### PR TITLE
Force the guard to false_exprt() whenever false is added to the conjunction

### DIFF
--- a/regression/cbmc/guard1/main.c
+++ b/regression/cbmc/guard1/main.c
@@ -1,0 +1,22 @@
+int main()
+{
+int i;
+int j;
+while(i) j = j + 1;
+}
+
+/*
+#include <assert.h>
+
+int main (void) {
+	int i;
+
+	while (1) {
+		i++;
+	}
+
+	assert(0);
+
+	return;
+}
+*/

--- a/regression/cbmc/guard1/test.desc
+++ b/regression/cbmc/guard1/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--depth 19
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--

--- a/src/util/guard.cpp
+++ b/src/util/guard.cpp
@@ -99,7 +99,7 @@ void guardt::add(const exprt &expr)
 
   if(is_false() || expr.is_true())
     return;
-  else if(is_true())
+  else if(is_true() || expr.is_false())
   {
     *this=expr;
 


### PR DESCRIPTION

Since r6259 guardt::is_false() is just exprt's is_false() instead of
a full loop testing each conjunct.