### PR TITLE
Minor cleanup of the ansi-c parser: consistent use of init

### DIFF
--- a/src/ansi-c/ansi_c_language.cpp
+++ b/src/ansi-c/ansi_c_language.cpp
@@ -11,7 +11,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <fstream>
 
 #include <util/expr_util.h>
-#include <util/replace_symbol.h>
 #include <util/config.h>
 #include <util/get_base_name.h>
 

--- a/src/ansi-c/cprover_library.cpp
+++ b/src/ansi-c/cprover_library.cpp
@@ -9,7 +9,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <sstream>
 
 #include <util/config.h>
-#include <util/replace_symbol.h>
 
 #include "cprover_library.h"
 #include "ansi_c_language.h"

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -1983,7 +1983,7 @@ type_name:
 initializer_opt:
         /* nothing */
         {
-          newstack($$);
+          init($$);
           stack($$).make_nil();
         }
         | '=' initializer


### PR DESCRIPTION
This is a duplicate of #5 after restoring all links to the SVN.