### PR TITLE
Enum linking

### DIFF
--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -25,7 +25,6 @@ Date: June 2006
 
 #include <ansi-c/ansi_c_language.h>
 
-#include <linking/linking_class.h>
 #include <linking/entry_point.h>
 
 #include <goto-programs/goto_convert.h>

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -598,8 +598,8 @@ void linkingt::duplicate_code_symbol(
 
       while(!conflicts.empty())
       {
-        const typet &t1=ns.follow(conflicts.front().first);
-        const typet &t2=ns.follow(conflicts.front().second);
+        const typet &t1=follow_tags_symbols(ns, conflicts.front().first);
+        const typet &t2=follow_tags_symbols(ns, conflicts.front().second);
 
         // void vs. non-void return type may be acceptable if the
         // return value is never used
@@ -626,7 +626,8 @@ void linkingt::duplicate_code_symbol(
                 old_symbol.value.is_nil()!=new_symbol.value.is_nil())
         {
           if(warn_msg.empty())
-            warn_msg="different pointer types in function";
+            warn_msg="pointer parameter types differ between "
+                     "declaration and definition";
           replace=new_symbol.value.is_not_nil();
         }
         // transparent union with (or entirely without) implementation is
@@ -812,7 +813,7 @@ void linkingt::duplicate_object_symbol(
       if(old_type.id()==ID_struct ||
          old_type.id()==ID_union ||
          old_type.id()==ID_array ||
-         old_type.id()==ID_c_enum_tag)
+         old_type.id()==ID_c_enum)
         detailed_conflict_report(
           old_symbol,
           new_symbol,

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -177,7 +177,7 @@ void linkingt::detailed_conflict_report_rec(
 {
   #ifdef DEBUG
   str << "<BEGIN DEPTH " << depth << ">";
-  debug();
+  debug_msg();
   #endif
 
   std::string msg;
@@ -380,7 +380,7 @@ void linkingt::detailed_conflict_report_rec(
 
   #ifdef DEBUG
   str << "<END DEPTH " << depth << ">";
-  debug();
+  debug_msg();
   #endif
 }
 
@@ -1113,8 +1113,8 @@ void linkingt::do_type_dependencies(id_sett &needs_to_be_renamed)
       {
         queue.push(*d_it);
         #ifdef DEBUG
-        str << "LINKING: needs to be renamed (dependency): " << s_it->first;
-        debug();
+        str << "LINKING: needs to be renamed (dependency): " << *d_it;
+        debug_msg();
         #endif
       }
   }
@@ -1147,7 +1147,7 @@ void linkingt::rename_symbols(const id_sett &needs_to_be_renamed)
     #ifdef DEBUG
     str << "LINKING: renaming " << *it << " to "
         << new_identifier;
-    debug();
+    debug_msg();
     #endif
 
     if(new_symbol.is_type)
@@ -1255,7 +1255,7 @@ void linkingt::typecheck()
       needs_to_be_renamed.insert(s_it->first);
       #ifdef DEBUG
       str << "LINKING: needs to be renamed: " << s_it->first;
-      debug();
+      debug_msg();
       #endif
     }
   }

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -1134,6 +1134,8 @@ Function: linkingt::rename_symbols
 
 void linkingt::rename_symbols(const id_sett &needs_to_be_renamed)
 {
+  namespacet src_ns(src_symbol_table);
+
   for(id_sett::const_iterator
       it=needs_to_be_renamed.begin();
       it!=needs_to_be_renamed.end();
@@ -1141,7 +1143,13 @@ void linkingt::rename_symbols(const id_sett &needs_to_be_renamed)
   {
     symbolt &new_symbol=src_symbol_table.symbols[*it];
 
-    irep_idt new_identifier=rename(*it);
+    irep_idt new_identifier;
+
+    if(new_symbol.is_type)
+      new_identifier=type_to_name(src_ns, *it, new_symbol.type);
+    else
+      new_identifier=rename(*it);
+
     new_symbol.name=new_identifier;
     
     #ifdef DEBUG

--- a/src/util/message_stream.h
+++ b/src/util/message_stream.h
@@ -86,6 +86,13 @@ public:
     sequence_number++;
   }
   
+  void debug_msg()
+  {
+    send_msg(9, str.str());
+    clear_err();
+    sequence_number++;
+  }
+
   std::ostringstream str;
   
   bool get_error_found() const


### PR DESCRIPTION
This series of patches improves the diagnostic output in case of linking problems for enum types, and also fixes the problem of inconsistent type renaming when linking 3 or more files.
This is a duplicate of #7 after restoring all links to the SVN.