### PR TITLE
Maintain ID_C_expr_simplified

### DIFF
--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -131,13 +131,13 @@ protected:
     statet &state,
     const bool write);
 
-  void dereference_rec(
+  bool dereference_rec(
     exprt &expr,
     statet &state,
     guardt &guard,
     const bool write);
 
-  void dereference_rec_address_of(
+  bool dereference_rec_address_of(
     exprt &expr,
     statet &state,
     guardt &guard);

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -148,7 +148,7 @@ public:
   enum levelt { L0=0, L1=1, L2=2 };
 
   // performs renaming _up to_ the given level
-  void rename(exprt &expr, const namespacet &ns, levelt level=L2);
+  bool rename(exprt &expr, const namespacet &ns, levelt level=L2);
   void rename(
     typet &type,
     const irep_idt &l1_identifier,
@@ -170,7 +170,7 @@ public:
   void get_original_name(exprt &expr) const;
   void get_original_name(typet &type) const;
 protected:
-  void rename_address(exprt &expr, const namespacet &ns, levelt level);
+  bool rename_address(exprt &expr, const namespacet &ns, levelt level);
 
   void set_ssa_indices(ssa_exprt &expr, const namespacet &ns, levelt level=L2);
   // only required for value_set.assign

--- a/src/util/irep_ids.def
+++ b/src/util/irep_ids.def
@@ -810,6 +810,7 @@ IREP_ID_ONE(cprover_string_to_upper_case_func)
 IREP_ID_ONE(cprover_string_trim_func)
 IREP_ID_ONE(cprover_string_value_of_func)
 IREP_ID_ONE(array_replace)
+IREP_ID_TWO(C_expr_simplified, #expr_simplified)
 
 #undef IREP_ID_ONE
 #undef IREP_ID_TWO

--- a/src/util/replace_expr.cpp
+++ b/src/util/replace_expr.cpp
@@ -22,6 +22,9 @@ bool replace_expr(const exprt &what, const exprt &by, exprt &dest)
   Forall_operands(it, dest)
     result=replace_expr(what, by, *it) && result;
 
+  if(!result)
+    dest.remove(ID_C_expr_simplified);
+
   return result;
 }
 
@@ -41,6 +44,9 @@ bool replace_expr(const replace_mapt &what, exprt &dest)
 
   Forall_operands(it, dest)
     result=replace_expr(what, *it) && result;
+
+  if(!result)
+    dest.remove(ID_C_expr_simplified);
 
   return result;
 }

--- a/src/util/replace_symbol.cpp
+++ b/src/util/replace_symbol.cpp
@@ -70,6 +70,9 @@ bool replace_symbolt::replace(exprt &dest) const
      !replace(static_cast<typet&>(dest.add(ID_C_va_arg_type))))
     result=false;
 
+  if(!result)
+    dest.remove(ID_C_expr_simplified);
+
   return result;
 }
 
@@ -161,6 +164,9 @@ bool replace_symbolt::replace(typet &dest) const
     if(!replace(array_type.size()))
       result=false;
   }
+
+  if(!result)
+    dest.remove(ID_C_expr_simplified);
 
   return result;
 }

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2334,20 +2334,22 @@ bool simplify_exprt::simplify_rec(exprt &expr)
   exprt tmp=expr;
   bool result=true;
 
+  if(!tmp.get_bool(ID_C_expr_simplified))
+  {
   result=simplify_node_preorder(tmp);
 
   if(!simplify_node(tmp))
     result=false;
 
-  #if 1
   replace_mapt::const_iterator it=local_replace_map.find(tmp);
   if(it!=local_replace_map.end())
   {
     tmp=it->second;
     result=false;
   }
-  #else
-  if(!local_replace_map.empty() &&
+  }
+  #if 0
+  else if(!local_replace_map.empty() &&
      !replace_expr(local_replace_map, tmp))
   {
     simplify_rec(tmp);
@@ -2357,6 +2359,7 @@ bool simplify_exprt::simplify_rec(exprt &expr)
 
   if(!result)
   {
+    tmp.set(ID_C_expr_simplified, true);
     expr.swap(tmp);
 
     #ifdef USE_CACHE


### PR DESCRIPTION
The aim is to avoid redundant invocations of the simplifier by storing is_simplified with each expression. This patch is the first part of this, then second half will be added once #25 is merged as there would be conflicting code changes.
