### PR TITLE
Evaluating object_size requires pointer_logic.objects fully populated

### DIFF
--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -899,6 +899,9 @@ Function: bv_pointerst::post_process
 
 void bv_pointerst::post_process()
 {
+  // post-processing arrays may yield further objects, do this first
+  SUB::post_process();
+
   for(postponed_listt::const_iterator
       it=postponed_list.begin();
       it!=postponed_list.end();
@@ -907,6 +910,4 @@ void bv_pointerst::post_process()
 
   // Clear the list to avoid re-doing in case of incremental usage.
   postponed_list.clear();
-  
-  SUB::post_process();
 }


### PR DESCRIPTION
Expressions used in the context of unbounded arrays may still be subject to object_size or other pointer-related operations. Thus they need to be seen before evaluating object_size. 