### PR TITLE
Allow specially named uninterpreted functions to introduce SMT-LIB di…

### DIFF
--- a/doc/html-manual/api.shtml
+++ b/doc/html-manual/api.shtml
@@ -199,6 +199,18 @@ the given value.
 Uninterpreted functions are documented <a href="modeling-nondet.shtml">here</a>.
 </p>
 
+<p class="justified">
+If the SMT2 back-end (<code>--smt2</code>) is enabled, then
+uninterpreted function named
+(<code>__CPROVER_uninterpreted_smt_escape</code>) will be handled
+differently.  The first argument, which must be a string literal,
+will be used as the function instead of it being uninterpreted.
+This allows arbitrary SMT-LIB expressions to be `escaped' and passed
+through CBMC.  Using other back-ends these will be treated as normal
+uninterpreted functions.
+</p>
+
+
 <h3>Predefined Types and Symbols</h3>
 
 <h4>__CPROVER_bitvector</h4>

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -155,6 +155,9 @@ protected:
   
   std::string convert_identifier(const irep_idt &identifier);
   
+  bool uf_is_escaped_smt(const exprt &function);
+  std::string convert_function_name(const function_application_exprt &fa);
+
   // introduces a let-expression for operands
   exprt convert_operands(const exprt &);
   


### PR DESCRIPTION
…rectly.

This is a potential code injection to the SMT solver but that shouldn't be a massive issue.  It's a bit of a hack but allows fast prototyping of solver features.
