### PR TITLE
Whitespace-only (!) cleanup - don't use tabs

### DIFF
--- a/src/ansi-c/library/math.c
+++ b/src/ansi-c/library/math.c
@@ -617,8 +617,8 @@ float sqrtf(float f)
   if ( f < 0.0f )
     return 0.0f/0.0f; // NaN
   else if (__CPROVER_isinff(f) ||   // +Inf only
-	   f == 0.0f          ||   // Includes -0
-	   __CPROVER_isnanf(f))
+           f == 0.0f          ||   // Includes -0
+           __CPROVER_isnanf(f))
     return f;
   else if (__CPROVER_isnormalf(f))
   {
@@ -702,8 +702,8 @@ double sqrt(double d)
   if ( d < 0.0 )
     return 0.0/0.0; // NaN
   else if (__CPROVER_isinfd(d) ||   // +Inf only
-	   d == 0.0            ||   // Includes -0
-	   __CPROVER_isnand(d))
+           d == 0.0            ||   // Includes -0
+           __CPROVER_isnand(d))
     return d;
   else if (__CPROVER_isnormald(d))
   {
@@ -771,8 +771,8 @@ long double sqrtl(long double d)
   if(d < 0.0l)
     return 0.0l/0.0l; // NaN
   else if (__CPROVER_isinfld(d) ||   // +Inf only
-	   d == 0.0l            ||   // Includes -0
-	   __CPROVER_isnanld(d))
+           d == 0.0l            ||   // Includes -0
+           __CPROVER_isnanld(d))
     return d;
   else if (__CPROVER_isnormalld(d))
   {

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -44,7 +44,7 @@ int make_identifier()
 
   // this hashes the identifier
   irep_idt base_name=yytext;
-  
+
   if(PARSER.cpp98)
   {
     stack(yyansi_clval).id(ID_symbol);
@@ -139,43 +139,43 @@ delimiter       [ \t\b\r]
 newline         [\n\f\v]|"\\\n"
 whitespace      {delimiter}+
 ws              {delimiter}*
-ucletter	[A-Z]
-lcletter	[a-z]
-letter		({ucletter}|{lcletter})
-digit		[0-9]
-bindigit	[01]
-octdigit	[0-7]
-hexdigit	[0-9a-fA-F]
-identifier	(({letter}|"_"|"$")({letter}|{digit}|"_"|"$")*)
-integer		{digit}+
-binary		{bindigit}+
+ucletter        [A-Z]
+lcletter        [a-z]
+letter          ({ucletter}|{lcletter})
+digit           [0-9]
+bindigit        [01]
+octdigit        [0-7]
+hexdigit        [0-9a-fA-F]
+identifier      (({letter}|"_"|"$")({letter}|{digit}|"_"|"$")*)
+integer         {digit}+
+binary          {bindigit}+
 msiw_suffix     ([iI]("8"|"16"|"32"|"64"|"128"))
 int_suffix      [uUlLiIjJ]*|[uU]?{msiw_suffix}
-bininteger	"0"[bB]{bindigit}+{int_suffix}
-decinteger	[1-9]({digit}|"'")*{int_suffix}
-octinteger	"0"({octdigit}|"'")*{int_suffix}
-hexinteger	"0"[xX]{hexdigit}({hexdigit}|"'")*{int_suffix}
+bininteger      "0"[bB]{bindigit}+{int_suffix}
+decinteger      [1-9]({digit}|"'")*{int_suffix}
+octinteger      "0"({octdigit}|"'")*{int_suffix}
+hexinteger      "0"[xX]{hexdigit}({hexdigit}|"'")*{int_suffix}
 integer_s       {decinteger}|{bininteger}|{octinteger}|{hexinteger}
-octchar		"\\"{octdigit}{1,3}
-hexchar		"\\x"{hexdigit}+
-exponent	[eE][+-]?{integer}
-fraction	{integer}
-float1		{integer}"."{fraction}?({exponent})?
-float2		"."{fraction}({exponent})?
-float3		{integer}{exponent}
+octchar         "\\"{octdigit}{1,3}
+hexchar         "\\x"{hexdigit}+
+exponent        [eE][+-]?{integer}
+fraction        {integer}
+float1          {integer}"."{fraction}?({exponent})?
+float2          "."{fraction}({exponent})?
+float3          {integer}{exponent}
 hexfloat1       "0"[xX]{hexdigit}+"."{hexdigit}+[pP][+-]?{integer}
 hexfloat2       "0"[xX]{hexdigit}+"."[pP][+-]?{integer}
 hexfloat3       "0"[xX]{hexdigit}+[pP][+-]?{integer}
 float_suffix    [fFlLiIjJ]*
 gcc_ext_float_suffix    [wWqQ]|[dD][fFdDlL]?
-float		{float1}|{float2}|{float3}|{hexfloat1}|{hexfloat2}|{hexfloat3}
+float           {float1}|{float2}|{float3}|{hexfloat1}|{hexfloat2}|{hexfloat3}
 float_s         {float}{float_suffix}|{integer}[fF]
-gcc_ext_float_s         {float}{gcc_ext_float_suffix}
-bitvector	{binary}[bB]
-bitvector_u	{binary}([uU][bB]|[bB][uU])
-cppstart	{ws}"#"{ws}
-cpplineno	{cppstart}"line"*{ws}{integer}{ws}.*{newline}
-cppdirective	{cppstart}.*
+gcc_ext_float_s {float}{gcc_ext_float_suffix}
+bitvector       {binary}[bB]
+bitvector_u     {binary}([uU][bB]|[bB][uU])
+cppstart        {ws}"#"{ws}
+cpplineno       {cppstart}"line"*{ws}{integer}{ws}.*{newline}
+cppdirective    {cppstart}.*
 
 escape_sequence [\\][^\n]
 c_char [^'\\\n]|{escape_sequence}
@@ -214,35 +214,35 @@ void ansi_c_scanner_init()
 %%
 
 <INITIAL>.|\n   { BEGIN(GRAMMAR);
-		  yyless(0);		/* start again with this character */
-		 }
+                  yyless(0); /* start again with this character */
+                }
 
 <GRAMMAR>"/*"   { BEGIN(COMMENT1); } /* begin C comment state */
 
 <COMMENT1>{
-   "*/"	        { BEGIN(GRAMMAR); } /* end comment state, back to GRAMMAR */
-   "/*"		{ yyansi_cerror("Probably nested comments"); }
-   <<EOF>>	{ yyansi_cerror("Unterminated comment"); return TOK_SCANNER_ERROR; }
-   [^*/\n]*	{ /* ignore every char except '*' and NL (performance!) */ }
-   .		{ } /* all single characters within comments are ignored */
-   \n		{ }
-	}
+   "*/"         { BEGIN(GRAMMAR); } /* end comment state, back to GRAMMAR */
+   "/*"         { yyansi_cerror("Probably nested comments"); }
+   <<EOF>>      { yyansi_cerror("Unterminated comment"); return TOK_SCANNER_ERROR; }
+   [^*/\n]*     { /* ignore every char except '*' and NL (performance!) */ }
+   .            { } /* all single characters within comments are ignored */
+   \n           { }
+}
 
 <STRING_LITERAL_COMMENT>{
-   "*/"	        { BEGIN(STRING_LITERAL); } /* end comment state, back to STRING_LITERAL */
-   "/*"		{ yyansi_cerror("Probably nested comments"); }
-   <<EOF>>	{ yyansi_cerror("Unterminated comment"); return TOK_SCANNER_ERROR; }
-   [^*/\n]*	{ /* ignore every char except '*' and NL (performance!) */ }
-   .		{ } /* all single characters within comments are ignored */
-   \n		{ }
-	}
+   "*/"         { BEGIN(STRING_LITERAL); } /* end comment state, back to STRING_LITERAL */
+   "/*"         { yyansi_cerror("Probably nested comments"); }
+   <<EOF>>      { yyansi_cerror("Unterminated comment"); return TOK_SCANNER_ERROR; }
+   [^*/\n]*     { /* ignore every char except '*' and NL (performance!) */ }
+   .            { } /* all single characters within comments are ignored */
+   \n           { }
+}
 
-<GRAMMAR>"//"	{ BEGIN(COMMENT2); }	/* begin C++ comment state */
+<GRAMMAR>"//"   { BEGIN(COMMENT2); } /* begin C++ comment state */
 
 <COMMENT2>{
-   \n		{ BEGIN(GRAMMAR); }	/* end comment state, back GRAMMAR */
-   .*		{ } /* all characters within comments are ignored */
-	}
+   \n           { BEGIN(GRAMMAR); } /* end comment state, back GRAMMAR */
+   .*           { } /* all characters within comments are ignored */
+}
 
 <GRAMMAR>{char_lit} {
                   newstack(yyansi_clval);
@@ -267,10 +267,10 @@ void ansi_c_scanner_init()
 <STRING_LITERAL>{cpplineno} {
                   preprocessor_line(yytext, PARSER);
                   PARSER.set_line_no(PARSER.get_line_no()-1);
-		 }
+                }
 <STRING_LITERAL>{cppdirective} { /* ignore */ }
 <STRING_LITERAL>"/*" { BEGIN(STRING_LITERAL_COMMENT); /* C comment, ignore */ }
-<STRING_LITERAL>"//".*\n	{ /* C++ comment, ignore */ }
+<STRING_LITERAL>"//".*\n { /* C++ comment, ignore */ }
 <STRING_LITERAL>. { // anything else: back to normal
                   source_locationt l=stack(yyansi_clval).source_location();
                   stack(yyansi_clval)=convert_string_literal(PARSER.string_literal);
@@ -280,140 +280,140 @@ void ansi_c_scanner_init()
                   return TOK_STRING;
                 }
 
-<GRAMMAR>{newline}	{ } /* skipped */
-<GRAMMAR>{whitespace}	{ } /* skipped */
+<GRAMMAR>{newline} { } /* skipped */
+<GRAMMAR>{whitespace} { } /* skipped */
 
-<GRAMMAR>{cpplineno}	{
+<GRAMMAR>{cpplineno} {
                   preprocessor_line(yytext, PARSER);
                   PARSER.set_line_no(PARSER.get_line_no()-1);
-		 }
+                }
 
 <GRAMMAR>{cppstart}"pragma"{ws}"pack"{ws}"("{ws}"push"{ws}")"{ws}{newline} {
-                   // Done by Visual Studio and gcc
-                   // http://msdn.microsoft.com/en-us/library/2e70t5y1%28v=vs.80%29.aspx
-                   // push, pop could also use identifiers
-                   if(PARSER.pragma_pack.empty())
-                     PARSER.pragma_pack.push_back(convert_integer_literal("0"));
-                   else
-                     PARSER.pragma_pack.push_back(PARSER.pragma_pack.back());
-		 }
+                  // Done by Visual Studio and gcc
+                  // http://msdn.microsoft.com/en-us/library/2e70t5y1%28v=vs.80%29.aspx
+                  // push, pop could also use identifiers
+                  if(PARSER.pragma_pack.empty())
+                    PARSER.pragma_pack.push_back(convert_integer_literal("0"));
+                  else
+                    PARSER.pragma_pack.push_back(PARSER.pragma_pack.back());
+                }
 
 <GRAMMAR>{cppstart}"pragma"{ws}"pack"{ws}"("{ws}"push"{ws}","{ws}{integer_s}{ws}")"{ws}{newline} {
-                   // Done by Visual Studio and gcc
-                   // http://msdn.microsoft.com/en-us/library/2e70t5y1%28v=vs.80%29.aspx
-                   // push, pop could also use identifiers
-                   std::string tmp(yytext);
-                   std::string::size_type p=tmp.find(',')+1;
-                   while(tmp[p]==' ' || tmp[p]=='\t') ++p;
-                   std::string value=std::string(tmp, p, tmp.find_last_not_of(") \t\n\r")+1-p);
-                   exprt n=convert_integer_literal(value);
-                   PARSER.pragma_pack.push_back(n);
-		 }
+                  // Done by Visual Studio and gcc
+                  // http://msdn.microsoft.com/en-us/library/2e70t5y1%28v=vs.80%29.aspx
+                  // push, pop could also use identifiers
+                  std::string tmp(yytext);
+                  std::string::size_type p=tmp.find(',')+1;
+                  while(tmp[p]==' ' || tmp[p]=='\t') ++p;
+                  std::string value=std::string(tmp, p, tmp.find_last_not_of(") \t\n\r")+1-p);
+                  exprt n=convert_integer_literal(value);
+                  PARSER.pragma_pack.push_back(n);
+                }
 
 <GRAMMAR>{cppstart}"pragma"{ws}"pack"{ws}"("{ws}{integer_s}{ws}")"{ws}{newline} {
-                   // Done by Visual Studio and gcc
-                   // http://msdn.microsoft.com/en-us/library/2e70t5y1%28v=vs.80%29.aspx
-                   std::string tmp(yytext);
-                   std::string::size_type p=tmp.find('(')+1;
-                   while(tmp[p]==' ' || tmp[p]=='\t') ++p;
-                   std::string value=std::string(tmp, p, tmp.find_last_not_of(") \t\n\r")+1-p);
-                   exprt n=convert_integer_literal(value);
-                   PARSER.pragma_pack.push_back(n);
-		 }
+                  // Done by Visual Studio and gcc
+                  // http://msdn.microsoft.com/en-us/library/2e70t5y1%28v=vs.80%29.aspx
+                  std::string tmp(yytext);
+                  std::string::size_type p=tmp.find('(')+1;
+                  while(tmp[p]==' ' || tmp[p]=='\t') ++p;
+                  std::string value=std::string(tmp, p, tmp.find_last_not_of(") \t\n\r")+1-p);
+                  exprt n=convert_integer_literal(value);
+                  PARSER.pragma_pack.push_back(n);
+                }
 
 <GRAMMAR>{cppstart}"pragma"{ws}"pack"{ws}"("{ws}"pop"{ws}")"{ws}{newline} {
-                   // Done by Visual Studio and gcc
-                   // http://msdn.microsoft.com/en-us/library/2e70t5y1%28v=vs.80%29.aspx
-                   // push, pop could also use identifiers
-                   if(!PARSER.pragma_pack.empty()) PARSER.pragma_pack.pop_back();
-		 }
+                  // Done by Visual Studio and gcc
+                  // http://msdn.microsoft.com/en-us/library/2e70t5y1%28v=vs.80%29.aspx
+                  // push, pop could also use identifiers
+                  if(!PARSER.pragma_pack.empty()) PARSER.pragma_pack.pop_back();
+                }
 
 <GRAMMAR>{cppstart}"pragma"{ws}"pack"{ws}"("{ws}")"{ws}{newline} {
-                   // Done by Visual Studio and gcc
-                   // http://msdn.microsoft.com/en-us/library/2e70t5y1%28v=vs.80%29.aspx
-                   // should be equivalent to pop-all
-                   PARSER.pragma_pack.clear();
-		 }
+                  // Done by Visual Studio and gcc
+                  // http://msdn.microsoft.com/en-us/library/2e70t5y1%28v=vs.80%29.aspx
+                  // should be equivalent to pop-all
+                  PARSER.pragma_pack.clear();
+                }
 
 <GRAMMAR>{cppstart}"pragma"{ws}.* {
-                   // silently ignore other pragmas
-		 }
+                  // silently ignore other pragmas
+                }
 
 <GRAMMAR>{cppstart}"ident"{ws}.* { /* ignore */ }
 <GRAMMAR>{cppstart}"define"{ws}.* { /* ignore */ }
 <GRAMMAR>{cppstart}"undef"{ws}.* { /* ignore */ }
 
-<GRAMMAR>{cppdirective}	{
-		  yyansi_cerror("Preprocessor directive found");
-		  return TOK_SCANNER_ERROR;
-		 }
+<GRAMMAR>{cppdirective} {
+                  yyansi_cerror("Preprocessor directive found");
+                  return TOK_SCANNER_ERROR;
+                }
 
 %{
 /*** keywords ***/
 %}
 
 <GRAMMAR,GCC_ATTRIBUTE3>{
-"auto"		{ loc(); return TOK_AUTO; }
-"_Bool"		{ if(PARSER.cpp98)
+"auto"          { loc(); return TOK_AUTO; }
+"_Bool"         { if(PARSER.cpp98)
                     return make_identifier();
                   else
                   { loc(); return TOK_BOOL; }
                 }
-"break"		{ loc(); return TOK_BREAK; }
-"case"		{ loc(); return TOK_CASE; }
-"char"		{ loc(); return TOK_CHAR; }
-"_Complex"	{ loc(); return TOK_COMPLEX; }
-"const"		{ loc(); return TOK_CONST; }
-"continue"	{ loc(); return TOK_CONTINUE; }
-"default"	{ loc(); return TOK_DEFAULT; }
-"do"		{ loc(); return TOK_DO; }
-"double"	{ loc(); return TOK_DOUBLE; }
-"else"		{ loc(); return TOK_ELSE; }
-"enum"		{ loc(); PARSER.tag_following=true; return TOK_ENUM; }
-"extern"	{ loc(); return TOK_EXTERN; }
-"float"		{ loc(); return TOK_FLOAT; }
-"for"		{ loc(); return TOK_FOR; }
-"goto"		{ loc(); return TOK_GOTO; }
-"if"		{ loc(); return TOK_IF; }
-"inline"	{ loc(); return TOK_INLINE; }
-"int"		{ loc(); return TOK_INT; }
-"long"		{ loc(); return TOK_LONG; }
-"register"	{ loc(); return TOK_REGISTER; }
+"break"         { loc(); return TOK_BREAK; }
+"case"          { loc(); return TOK_CASE; }
+"char"          { loc(); return TOK_CHAR; }
+"_Complex"      { loc(); return TOK_COMPLEX; }
+"const"         { loc(); return TOK_CONST; }
+"continue"      { loc(); return TOK_CONTINUE; }
+"default"       { loc(); return TOK_DEFAULT; }
+"do"            { loc(); return TOK_DO; }
+"double"        { loc(); return TOK_DOUBLE; }
+"else"          { loc(); return TOK_ELSE; }
+"enum"          { loc(); PARSER.tag_following=true; return TOK_ENUM; }
+"extern"        { loc(); return TOK_EXTERN; }
+"float"         { loc(); return TOK_FLOAT; }
+"for"           { loc(); return TOK_FOR; }
+"goto"          { loc(); return TOK_GOTO; }
+"if"            { loc(); return TOK_IF; }
+"inline"        { loc(); return TOK_INLINE; }
+"int"           { loc(); return TOK_INT; }
+"long"          { loc(); return TOK_LONG; }
+"register"      { loc(); return TOK_REGISTER; }
 "restrict"      { loc(); return TOK_RESTRICT; }
-"return"	{ loc(); return TOK_RETURN; }
-"short" 	{ loc(); return TOK_SHORT; }
-"signed"	{ loc(); return TOK_SIGNED; }
-"sizeof"	{ loc(); return TOK_SIZEOF; }
-"static"	{ loc(); return TOK_STATIC; }
-"struct"	{ loc(); PARSER.tag_following=true; return TOK_STRUCT; }
-"switch"	{ loc(); return TOK_SWITCH; }
-"typedef"	{ loc(); return TOK_TYPEDEF; }
-"union"		{ loc(); PARSER.tag_following=true; return TOK_UNION; }
-"unsigned"	{ loc(); return TOK_UNSIGNED; }
-"void"		{ loc(); return TOK_VOID; }
-"volatile"	{ loc(); return TOK_VOLATILE; }
-"while"		{ loc(); return TOK_WHILE; }
+"return"        { loc(); return TOK_RETURN; }
+"short"         { loc(); return TOK_SHORT; }
+"signed"        { loc(); return TOK_SIGNED; }
+"sizeof"        { loc(); return TOK_SIZEOF; }
+"static"        { loc(); return TOK_STATIC; }
+"struct"        { loc(); PARSER.tag_following=true; return TOK_STRUCT; }
+"switch"        { loc(); return TOK_SWITCH; }
+"typedef"       { loc(); return TOK_TYPEDEF; }
+"union"         { loc(); PARSER.tag_following=true; return TOK_UNION; }
+"unsigned"      { loc(); return TOK_UNSIGNED; }
+"void"          { loc(); return TOK_VOID; }
+"volatile"      { loc(); return TOK_VOLATILE; }
+"while"         { loc(); return TOK_WHILE; }
 
 "__auto_type"   { if(PARSER.mode==ansi_c_parsert::GCC && !PARSER.cpp98)
-                    { loc(); return TOK_GCC_AUTO_TYPE; }
+                  { loc(); return TOK_GCC_AUTO_TYPE; }
                   else
                     return make_identifier();
                 }
 
-"__float80"	{ if(PARSER.mode==ansi_c_parsert::GCC)
-                    { loc(); return TOK_GCC_FLOAT80; }
+"__float80"     { if(PARSER.mode==ansi_c_parsert::GCC)
+                  { loc(); return TOK_GCC_FLOAT80; }
                   else
                     return make_identifier();
                 }
 
-"__float128"	{ if(PARSER.mode==ansi_c_parsert::GCC)
-                    { loc(); return TOK_GCC_FLOAT128; }
+"__float128"    { if(PARSER.mode==ansi_c_parsert::GCC)
+                  { loc(); return TOK_GCC_FLOAT128; }
                   else
                     return make_identifier();
                 }
 
-"__int128"	{ if(PARSER.mode==ansi_c_parsert::GCC)
-                    { loc(); return TOK_GCC_INT128; }
+"__int128"      { if(PARSER.mode==ansi_c_parsert::GCC)
+                  { loc(); return TOK_GCC_INT128; }
                   else
                     return make_identifier();
                 }
@@ -467,7 +467,7 @@ void ansi_c_scanner_init()
                 }
 
 "__real__" |
-"__real"	{ if(PARSER.mode==ansi_c_parsert::GCC ||
+"__real"        { if(PARSER.mode==ansi_c_parsert::GCC ||
                      PARSER.mode==ansi_c_parsert::ARM)
                     { loc(); return TOK_REAL; }
                   else
@@ -475,7 +475,7 @@ void ansi_c_scanner_init()
                 }
 
 "__imag__" |
-"__imag"	{ if(PARSER.mode==ansi_c_parsert::GCC ||
+"__imag"        { if(PARSER.mode==ansi_c_parsert::GCC ||
                      PARSER.mode==ansi_c_parsert::ARM)
                     { loc(); return TOK_IMAG; }
                   else
@@ -608,11 +608,11 @@ void ansi_c_scanner_init()
                     return make_identifier();
                 }
 
-"__wchar_t"     { if(PARSER.mode==ansi_c_parsert::MSC)  
-                    { loc(); return TOK_WCHAR_T; }  
+"__wchar_t"     { if(PARSER.mode==ansi_c_parsert::MSC)
+                    { loc(); return TOK_WCHAR_T; }
                   else
                     return make_identifier();
-                }                                                                          
+                }
 
 %{
 /* C++ Keywords and Operators */
@@ -658,7 +658,7 @@ typeid              { return cpp98_keyword(TOK_TYPEID); }
 typename            { return cpp98_keyword(TOK_TYPENAME); }
 using               { return cpp98_keyword(TOK_USING); }
 virtual             { return cpp98_keyword(TOK_VIRTUAL); }
-wchar_t	            { // CodeWarrior doesn't have wchar_t built in,
+wchar_t             { // CodeWarrior doesn't have wchar_t built in,
                       // and MSC has a command-line option to turn it off
                       if(PARSER.mode==ansi_c_parsert::CW)
                         return make_identifier();
@@ -737,14 +737,14 @@ __decltype          { if(PARSER.cpp98 && PARSER.mode==ansi_c_parsert::GCC)
 "["{ws}"emitidl" |
 "["{ws}"module" |
 "["{ws}"export"  { if(PARSER.mode==ansi_c_parsert::MSC)
-	             BEGIN(MSC_ANNOTATION);
+                     BEGIN(MSC_ANNOTATION);
                    else
-	           {
-	             yyless(1); // puts all but [ back into stream
-	             loc();
-	             PARSER.tag_following=false;
-	             return yytext[0]; // returns the [
-	           }
+                   {
+                     yyless(1); // puts all but [ back into stream
+                     loc();
+                     PARSER.tag_following=false;
+                     return yytext[0]; // returns the [
+                   }
                  }
 
 "__char16_t"     { if(PARSER.mode==ansi_c_parsert::GCC)
@@ -1013,8 +1013,8 @@ __decltype          { if(PARSER.cpp98 && PARSER.mode==ansi_c_parsert::GCC)
                     return make_identifier();
                 }
 
-"__inline"	{ loc(); return TOK_INLINE; }
-"__inline__"	{ loc(); return TOK_INLINE; }
+"__inline"      { loc(); return TOK_INLINE; }
+"__inline__"    { loc(); return TOK_INLINE; }
 
 "__label__"     { if(PARSER.mode==ansi_c_parsert::GCC ||
                      PARSER.mode==ansi_c_parsert::ARM)
@@ -1144,10 +1144,10 @@ __decltype          { if(PARSER.cpp98 && PARSER.mode==ansi_c_parsert::GCC)
   /* This is a C11 keyword. It can be used as a type qualifier
      and as a type specifier, which introduces ambiguity into the grammar.
      We thus have two different tokens.
-     
+
      6.7.2.4 - 4: If the _Atomic keyword is immediately followed by a left
      parenthesis, it is interpreted as a type specifier (with a type name),
-     not as a type qualifier.  
+     not as a type qualifier.
    */
 
 "_Atomic"{ws}"(" { // put back all but _Atomic
@@ -1224,29 +1224,29 @@ __decltype          { if(PARSER.cpp98 && PARSER.mode==ansi_c_parsert::GCC)
   /* operators following */
 
 <GRAMMAR,GCC_ATTRIBUTE3>{
-"->"		{ loc(); return TOK_ARROW; }
-"++"		{ loc(); return TOK_INCR; }
-"--"		{ loc(); return TOK_DECR; }
-"<<"		{ loc(); return TOK_SHIFTLEFT; }
-">>"		{ loc(); return TOK_SHIFTRIGHT; }
-"<="		{ loc(); return TOK_LE; }
-">="		{ loc(); return TOK_GE; }
-"=="		{ loc(); return TOK_EQ; }
-"!="		{ loc(); return TOK_NE; }
-"&&"		{ loc(); return TOK_ANDAND; }
-"||"		{ loc(); return TOK_OROR; }
-"..."		{ loc(); return TOK_ELLIPSIS; }
+"->"            { loc(); return TOK_ARROW; }
+"++"            { loc(); return TOK_INCR; }
+"--"            { loc(); return TOK_DECR; }
+"<<"            { loc(); return TOK_SHIFTLEFT; }
+">>"            { loc(); return TOK_SHIFTRIGHT; }
+"<="            { loc(); return TOK_LE; }
+">="            { loc(); return TOK_GE; }
+"=="            { loc(); return TOK_EQ; }
+"!="            { loc(); return TOK_NE; }
+"&&"            { loc(); return TOK_ANDAND; }
+"||"            { loc(); return TOK_OROR; }
+"..."           { loc(); return TOK_ELLIPSIS; }
 
-"*="		{ loc(); return TOK_MULTASSIGN; }
-"/="		{ loc(); return TOK_DIVASSIGN; }
-"%="		{ loc(); return TOK_MODASSIGN; }
-"+="		{ loc(); return TOK_PLUSASSIGN; }
-"-="		{ loc(); return TOK_MINUSASSIGN; }
-"<<="		{ loc(); return TOK_SHLASSIGN; }
-">>="		{ loc(); return TOK_SHRASSIGN; }
-"&="		{ loc(); return TOK_ANDASSIGN; }
-"^="		{ loc(); return TOK_XORASSIGN; }
-"|="		{ loc(); return TOK_ORASSIGN; }
+"*="            { loc(); return TOK_MULTASSIGN; }
+"/="            { loc(); return TOK_DIVASSIGN; }
+"%="            { loc(); return TOK_MODASSIGN; }
+"+="            { loc(); return TOK_PLUSASSIGN; }
+"-="            { loc(); return TOK_MINUSASSIGN; }
+"<<="           { loc(); return TOK_SHLASSIGN; }
+">>="           { loc(); return TOK_SHRASSIGN; }
+"&="            { loc(); return TOK_ANDASSIGN; }
+"^="            { loc(); return TOK_XORASSIGN; }
+"|="            { loc(); return TOK_ORASSIGN; }
 
   /* digraphs */
 "<:"            { loc(); return '['; }
@@ -1257,7 +1257,7 @@ __decltype          { if(PARSER.cpp98 && PARSER.mode==ansi_c_parsert::GCC)
 
 <GRAMMAR>{
 
-{identifier}	{ return make_identifier(); }
+{identifier}    { return make_identifier(); }
 
 {integer_s}     { newstack(yyansi_clval);
                   stack(yyansi_clval)=convert_integer_literal(yytext);
@@ -1265,24 +1265,24 @@ __decltype          { if(PARSER.cpp98 && PARSER.mode==ansi_c_parsert::GCC)
                   return TOK_INTEGER;
                 }
 
-{gcc_ext_float_s}	{ if(PARSER.mode!=ansi_c_parsert::GCC)
+{gcc_ext_float_s} { if(PARSER.mode!=ansi_c_parsert::GCC)
                     {
-		                  yyansi_cerror("Preprocessor directive found");
-		                  return TOK_SCANNER_ERROR;
+                      yyansi_cerror("Preprocessor directive found");
+                      return TOK_SCANNER_ERROR;
                     }
-                  newstack(yyansi_clval); 
+                    newstack(yyansi_clval);
+                    stack(yyansi_clval)=convert_float_literal(yytext);
+                    PARSER.set_source_location(stack(yyansi_clval));
+                    return TOK_FLOATING;
+                  }
+
+{float_s}       { newstack(yyansi_clval);
                   stack(yyansi_clval)=convert_float_literal(yytext);
                   PARSER.set_source_location(stack(yyansi_clval));
-		  return TOK_FLOATING;
-		}
+                  return TOK_FLOATING;
+                }
 
-{float_s}	{ newstack(yyansi_clval); 
-                  stack(yyansi_clval)=convert_float_literal(yytext);
-                  PARSER.set_source_location(stack(yyansi_clval));
-		  return TOK_FLOATING;
-		}
-
-"{"             { 
+"{"             {
                   PARSER.tag_following=false;
                   if(PARSER.asm_block_following) { BEGIN(ASM_BLOCK); }
                   loc();
@@ -1296,7 +1296,7 @@ __decltype          { if(PARSER.cpp98 && PARSER.mode==ansi_c_parsert::GCC)
                 }
 
   /* This catches all one-character operators */
-.		{ loc(); PARSER.tag_following=false; return yytext[0]; }
+.               { loc(); PARSER.tag_following=false; return yytext[0]; }
 }
 
 <MSC_ANNOTATION>"]" { BEGIN(GRAMMAR); }
@@ -1419,7 +1419,7 @@ __decltype          { if(PARSER.cpp98 && PARSER.mode==ansi_c_parsert::GCC)
                 }
 {ws}            { /* ignore */ }
 {newline}       { /* ignore */ }
-{identifier}	{ return make_identifier(); }
+{identifier}    { return make_identifier(); }
 .               { loc(); return yytext[0]; }
 }
 
@@ -1442,7 +1442,7 @@ __decltype          { if(PARSER.cpp98 && PARSER.mode==ansi_c_parsert::GCC)
 .               { BEGIN(GRAMMAR); loc(); return yytext[0]; }
 }
 
-<<EOF>>		{ yyterminate(); /* done! */ }
+<<EOF>>         { yyterminate(); /* done! */ }
 
 %%
 

--- a/src/assembler/scanner.l
+++ b/src/assembler/scanner.l
@@ -23,23 +23,23 @@ newline         [\n\f\v]|"\\\n"
 whitespace      {delimiter}+
 ws              {delimiter}*
 ws_or_newline   ({delimiter}|{newline})*
-ucletter	[A-Z]
-lcletter	[a-z]
-letter		({ucletter}|{lcletter})
-digit		[0-9]
-bindigit	[01]
-octdigit	[0-7]
-hexdigit	[0-9a-fA-F]
-identifier	(({letter}|"_"|"$"|".")({letter}|{digit}|"_"|"$"|".")*)
-integer		{digit}+
-binary		{bindigit}+
-bininteger	"0"[bB]{bindigit}+{int_suffix}
-decinteger	[1-9]{digit}*{int_suffix}
-octinteger	"0"{octdigit}*{int_suffix}
-hexinteger	"0"[xX]{hexdigit}+{int_suffix}
+ucletter        [A-Z]
+lcletter        [a-z]
+letter          ({ucletter}|{lcletter})
+digit           [0-9]
+bindigit        [01]
+octdigit        [0-7]
+hexdigit        [0-9a-fA-F]
+identifier      (({letter}|"_"|"$"|".")({letter}|{digit}|"_"|"$"|".")*)
+integer         {digit}+
+binary          {bindigit}+
+bininteger      "0"[bB]{bindigit}+{int_suffix}
+decinteger      [1-9]{digit}*{int_suffix}
+octinteger      "0"{octdigit}*{int_suffix}
+hexinteger      "0"[xX]{hexdigit}+{int_suffix}
 integer_s       {decinteger}|{bininteger}|{octinteger}|{hexinteger}
-octchar		"\\"{octdigit}{1,3}
-hexchar		"\\x"{hexdigit}+
+octchar         "\\"{octdigit}{1,3}
+hexchar         "\\x"{hexdigit}+
 
 escape_sequence [\\][^\n]
 c_char [^'\\\n]|{escape_sequence}
@@ -62,46 +62,44 @@ void assemlber_scanner_init()
 %%
 
 <INITIAL>.|\n   { BEGIN(GRAMMAR);
-		  yyless(0);		/* start again with this character */
-		 }
+                  yyless(0); /* start again with this character */
+                }
 
-<GRAMMAR>"#"	{ PARSER.new_instruction(); BEGIN(LINE_COMMENT); } /* begin comment state */
+<GRAMMAR>"#"    { PARSER.new_instruction(); BEGIN(LINE_COMMENT); } /* begin comment state */
 
 <LINE_COMMENT>{
-   \n		{ BEGIN(GRAMMAR); }	/* end comment state, back GRAMMAR */
-   .*		{ } /* all characters within comments are ignored */
-	}
-
-<GRAMMAR>{newline}	{ PARSER.new_instruction(); }
-<GRAMMAR>";"		{ PARSER.new_instruction(); }
-<GRAMMAR>{whitespace}	{ } /* skipped */
-
-%{
-/*** keywords ***/
-%}
-
-<GRAMMAR>{
-".data"		{ }
+   \n           { BEGIN(GRAMMAR); } /* end comment state, back GRAMMAR */
+   .*           { } /* all characters within comments are ignored */
 }
 
-%{
-/*** rest ***/
-%}
+<GRAMMAR>{newline} { PARSER.new_instruction(); }
+<GRAMMAR>";"    { PARSER.new_instruction(); }
+<GRAMMAR>{whitespace} { } /* skipped */
+
+ /*** keywords ***/
 
 <GRAMMAR>{
-{ws}                { /* ignore */ }
-{identifier}        { irept identifier(ID_symbol);
-                      identifier.set(ID_identifier, yytext);
-                      PARSER.add_token(identifier); }
+".data"         { }
+}
+
+ /*** rest ***/
+
+<GRAMMAR>{
+{ws}            { /* ignore */ }
+{identifier}    { irept identifier(ID_symbol);
+                  identifier.set(ID_identifier, yytext);
+                  PARSER.add_token(identifier);
+                }
 
 ">>"            { PARSER.add_token(irept(ID_shr)); }
 "<<"            { PARSER.add_token(irept(ID_shl)); }
 .               { std::string s;
                   s+=yytext[0];
-                  PARSER.add_token(irept(s)); }
+                  PARSER.add_token(irept(s));
+                }
 }
 
-<<EOF>>		{ yyterminate(); /* done! */ }
+<<EOF>>         { yyterminate(); /* done! */ }
 
 %%
 

--- a/src/common
+++ b/src/common
@@ -100,7 +100,7 @@ else ifeq ($(BUILD_ENV_),Cygwin)
   CP_CXXFLAGS = -MMD -MP -std=c++11 -U__STRICT_ANSI__
   LINKFLAGS = -static -std=c++11
   LINKLIB = ar rcT $@ $^
-  LINKBIN = $(CXX) $(LINKFLAGS) -o $@ -Wl,--start-group $^ -Wl,--end-group $(LIBS) -static 
+  LINKBIN = $(CXX) $(LINKFLAGS) -o $@ -Wl,--start-group $^ -Wl,--end-group $(LIBS) -static
   LINKNATIVE = $(HOSTCXX) -std=c++11 -o $@ $^ -static
 ifeq ($(origin CC),default)
   #CC = gcc
@@ -127,7 +127,7 @@ else ifeq ($(BUILD_ENV_),MSVC)
   CFLAGS ?= /W3 /O2 /GF
   CXXFLAGS ?= /W3 /D_CRT_SECURE_NO_WARNINGS /O2 /GF
   CP_CFLAGS =
-  CP_CXXFLAGS = 
+  CP_CXXFLAGS =
   LINKLIB = lib /NOLOGO /OUT:$@ $^
   LINKBIN = $(CXX) $(LINKFLAGS) /Fe$@ $^ $(LIBS)
   LINKNATIVE = $(HOSTCXX) /Fe$@ $^
@@ -161,7 +161,7 @@ CP_CXXFLAGS += $(CXXFLAGS) $(INCLUDES)
 OBJ += $(patsubst %.cpp, %$(OBJEXT), $(filter %.cpp, $(SRC)))
 OBJ += $(patsubst %.cc, %$(OBJEXT), $(filter %.cc, $(SRC)))
 
-.SUFFIXES:	.cc .d .cpp
+.SUFFIXES: .cc .d .cpp
 
 %.o:%.cpp
 	$(CXX) -c $(CP_CXXFLAGS) -o $@ $<

--- a/src/json/parser.y
+++ b/src/json/parser.y
@@ -58,11 +58,11 @@ int yyjsonerror(const std::string &error)
 
 %}
 
-%token	TOK_STRING
-%token	TOK_NUMBER
-%token	TOK_TRUE
-%token	TOK_FALSE
-%token	TOK_NULL
+%token TOK_STRING
+%token TOK_NUMBER
+%token TOK_TRUE
+%token TOK_FALSE
+%token TOK_NULL
 
 %%
 

--- a/src/json/scanner.l
+++ b/src/json/scanner.l
@@ -20,27 +20,27 @@ static int isatty(int) { return 0; }
 #include "json_y.tab.h"
 %}
 
-string	\"\"|\"{chars}\"
-chars	{char}+
-char	[^\"]|\\\"
+string  \"\"|\"{chars}\"
+chars   {char}+
+char    [^\"]|\\\"
 
-number	{int}|{int}{frac}|{int}{exp}|{int}{frac}{exp}
-int	{digit}|{digit19}{digits}|-{digit}|-{digit19}{digits}
-frac	"."{digits}
-exp	e{digits}
-digits	{digit}+
+number  {int}|{int}{frac}|{int}{exp}|{int}{frac}{exp}
+int     {digit}|{digit19}{digits}|-{digit}|-{digit19}{digits}
+frac    "."{digits}
+exp     {e}{digits}
+digits  {digit}+
 digit   [0-9]
 digit19 [1-9]
-e	e|e\+|e-|E|E\+|E- 
+e       e|e\+|e-|E|E\+|E- 
 
 %%
 
-{string}	{ return TOK_STRING; }
-{number}	{ return TOK_NUMBER; }
-"true"		{ return TOK_TRUE; }
-"false"		{ return TOK_FALSE; }
-"null"		{ return TOK_NULL; }
+{string}        { return TOK_STRING; }
+{number}        { return TOK_NUMBER; }
+"true"          { return TOK_TRUE; }
+"false"         { return TOK_FALSE; }
+"null"          { return TOK_NULL; }
 
-[" "\r\n\t]	{ /* eat */ }
-.		{ return yytext[0]; }
+[" "\r\n\t]     { /* eat */ }
+.               { return yytext[0]; }
 

--- a/src/xmllang/parser.y
+++ b/src/xmllang/parser.y
@@ -48,7 +48,7 @@ misc_seq_opt
  ;
 
 misc
- : COMMENT			{ free($1); }
+ : COMMENT      { free($1); }
  | PI
  ;
 
@@ -58,24 +58,24 @@ PI
    attribute_seq_opt
    { xml_parser.stack.pop_back(); }
    ENDPI
- ;	
+ ;
 
 element
- : START			{ xml_parser.current().name=$1;
+ : START   { xml_parser.current().name=$1;
                                   free($1);
-				}
+           }
    attribute_seq_opt
    empty_or_content
  ;
 
 empty_or_content
- : SLASH CLOSE			{ }
- | CLOSE			{ }
-   content END name_opt CLOSE	{ free($5); }
+ : SLASH CLOSE  { }
+ | CLOSE  { }
+   content END name_opt CLOSE  { free($5); }
  ;
 
 content
- : content DATA			{ xml_parser.current().data+=xmlt::unescape($2); free($2); }
+ : content DATA  { xml_parser.current().data+=xmlt::unescape($2); free($2); }
  | content misc
  | content
    { xml_parser.new_level(); }
@@ -85,8 +85,8 @@ content
  ;
 
 name_opt
- : NAME				{ $$=$1; }
- | /*empty*/			{ $$=strdup(""); }
+ : NAME  { $$=$1; }
+ | /*empty*/  { $$=strdup(""); }
  ;
 
 attribute_seq_opt
@@ -95,7 +95,7 @@ attribute_seq_opt
  ;
 
 attribute
- : NAME EQ VALUE		{ xml_parser.current().set_attribute(
+ : NAME EQ VALUE  { xml_parser.current().set_attribute(
                                     xmlt::unescape($1), xmlt::unescape($3));
                                   free($1); free($3);}
  ;

--- a/src/xmllang/scanner.l
+++ b/src/xmllang/scanner.l
@@ -17,7 +17,7 @@ static int isatty(int) { return 0; }
 
 #define PARSER xml_parser
 
-//static int keep;			/* To store start condition */
+//static int keep;  /* To store start condition */
 
 static char *word(char *s)
 {
@@ -34,17 +34,17 @@ static char *word(char *s)
 %}
 
 
-nl		(\r\n|\r|\n)
-ws		[ \t\r\n]+
-open		{nl}?"<"
-close		">"{nl}?
-namestart	[A-Za-z\200-\377_]
-namechar	[A-Za-z\200-\377_0-9.:-]
-esc		"&#"[0-9]+";"|"&#x"[0-9a-fA-F]+";"|"&"[a-zA-Z]+";"
-name		{namestart}{namechar}*
-data		([^<\n&]|\n[^<&]|\n{esc}|{esc})+
-comment		{open}"!--"([^-]|"-"[^-])*"--"{close}
-string		\"([^"&]|{esc})*\"|\'([^'&]|{esc})*\'
+nl         (\r\n|\r|\n)
+ws         [ \t\r\n]+
+open       {nl}?"<"
+close      ">"{nl}?
+namestart  [A-Za-z\200-\377_]
+namechar   [A-Za-z\200-\377_0-9.:-]
+esc        "&#"[0-9]+";"|"&#x"[0-9a-fA-F]+";"|"&"[a-zA-Z]+";"
+name       {namestart}{namechar}*
+data       ([^<\n&]|\n[^<&]|\n{esc}|{esc})+
+comment    {open}"!--"([^-]|"-"[^-])*"--"{close}
+string     \"([^"&]|{esc})*\"|\'([^'&]|{esc})*\'
 
 /*
  * The CONTENT mode is used for the content of elements, i.e.,
@@ -59,28 +59,28 @@ string		\"([^"&]|{esc})*\"|\'([^'&]|{esc})*\'
 
 %%
 
-<INITIAL,PI>{ws}		{/* skip */}
-<INITIAL>"/"		{return SLASH;}
-<INITIAL,PI>"="		{return EQ;}
-<INITIAL>{close}	{BEGIN(CONTENT); return CLOSE;}
-<INITIAL,PI>{name}		{yyxmllval.s=strdup(yytext); return NAME;}
-<INITIAL,PI>{string}	{yyxmllval.s=strdup(yytext); return VALUE;}
-<INITIAL,PI>"?"{close}	{BEGIN(INITIAL); return ENDPI;}
+<INITIAL,PI>{ws}  {/* skip */}
+<INITIAL>"/"      {return SLASH;}
+<INITIAL,PI>"="   {return EQ;}
+<INITIAL>{close}  {BEGIN(CONTENT); return CLOSE;}
+<INITIAL,PI>{name}    {yyxmllval.s=strdup(yytext); return NAME;}
+<INITIAL,PI>{string}  {yyxmllval.s=strdup(yytext); return VALUE;}
+<INITIAL,PI>"?"{close}  {BEGIN(INITIAL); return ENDPI;}
 
-{open}{ws}?{name}	{BEGIN(INITIAL); yyxmllval.s=word(yytext); return START;}
-{open}{ws}?"/"		{BEGIN(INITIAL); return END;}
-{open}"?xml"		{BEGIN(INITIAL); return STARTXMLDECL;}
-{open}"?"		{BEGIN(PI); yyxmllval.s=word(yytext); return STARTPI;}
-{comment}		{yyxmllval.s=strdup(yytext); return COMMENT;}
+{open}{ws}?{name} {BEGIN(INITIAL); yyxmllval.s=word(yytext); return START;}
+{open}{ws}?"/"    {BEGIN(INITIAL); return END;}
+{open}"?xml"      {BEGIN(INITIAL); return STARTXMLDECL;}
+{open}"?"         {BEGIN(PI); yyxmllval.s=word(yytext); return STARTPI;}
+{comment}         {yyxmllval.s=strdup(yytext); return COMMENT;}
 
-<CONTENT>{data}		{yyxmllval.s=strdup(yytext); return DATA;}
+<CONTENT>{data}   {yyxmllval.s=strdup(yytext); return DATA;}
 
 <INITIAL>{open}"!"{ws}?"DOCTYPE"   {BEGIN(DTD); /* skip */}
-<DTD>.   {/* skip */}
+<DTD>.            {/* skip */}
 <DTD>\]{close}    {BEGIN(INITIAL); /* skip */}
 
-.			{ yyxmlerror("unexpected character"); }
-{nl}			{/* skip, must be an extra one at EOF */;}
+.                 { yyxmlerror("unexpected character"); }
+{nl}              {/* skip, must be an extra one at EOF */;}
 
 %%
 


### PR DESCRIPTION
This patch does not change any code, only replaces tabs by spaces and removes spaces at the end of a line.