### PR TITLE
Sequentialization of nested interrupts

### DIFF
--- a/regression/goto-instrument-isr/Makefile
+++ b/regression/goto-instrument-isr/Makefile
@@ -1,0 +1,31 @@
+
+default: tests.log
+
+test:
+	@if ! ../test.pl -c ../chain.sh ; then \
+		../failed-tests-printer.pl ; \
+		exit 1; \
+	fi
+
+tests.log:
+	@if ! ../test.pl -c ../chain.sh ; then \
+		../failed-tests-printer.pl ; \
+		exit 1; \
+	fi
+
+show:
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			vim -o "$$dir/*.c" "$$dir/*.out"; \
+		fi; \
+	done;
+
+clean:
+	@for dir in *; do \
+		rm -f tests.log; \
+		if [ -d "$$dir" ]; then \
+			cd "$$dir"; \
+			rm -f *.out *.gb; \
+			cd ..; \
+		fi \
+	done

--- a/regression/goto-instrument-isr/chain.sh
+++ b/regression/goto-instrument-isr/chain.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+src=../../../src
+goto_cc=$src/goto-cc/goto-cc
+goto_instrument=$src/goto-instrument/goto-instrument
+cbmc=$src/cbmc/cbmc
+
+name=${@:$#}
+name=${name%.c}
+
+args=${@:1:$#-1}
+
+$goto_cc -o $name.gb $name.c
+# $goto_instrument --show-goto-functions $name.gb
+$goto_instrument $args $name.gb ${name}-mod.gb
+if [ ! -e ${name}-mod.gb ] ; then
+  cp $name.gb ${name}-mod.gb
+elif echo "$args" | grep -q -- "--dump-c" ; then
+  mv ${name}-mod.gb ${name}-mod.c
+  $goto_cc ${name}-mod.c -o ${name}-mod.gb
+  rm ${name}-mod.c
+fi
+$goto_instrument --show-goto-functions ${name}-mod.gb
+$cbmc --unwind 2 ${name}-mod.gb
+

--- a/regression/goto-instrument-isr/isr-rr/main.c
+++ b/regression/goto-instrument-isr/isr-rr/main.c
@@ -1,0 +1,12 @@
+int global=0;
+
+void isrA()
+{
+  int a=global;
+  assert(0); // unreachable
+}
+
+int main()
+{
+  int x=global;
+}

--- a/regression/goto-instrument-isr/isr-rr/test.desc
+++ b/regression/goto-instrument-isr/isr-rr/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--isr isrA
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/goto-instrument-isr/isr-rw/main.c
+++ b/regression/goto-instrument-isr/isr-rw/main.c
@@ -1,0 +1,12 @@
+int global=0;
+
+void isrA()
+{
+  global=1;
+}
+
+int main()
+{
+  int x=global;
+  assert(x==0);
+}

--- a/regression/goto-instrument-isr/isr-rw/test.desc
+++ b/regression/goto-instrument-isr/isr-rw/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--isr isrA
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-instrument-isr/isr-wr/main.c
+++ b/regression/goto-instrument-isr/isr-wr/main.c
@@ -1,0 +1,12 @@
+int global=0;
+
+void isrA()
+{
+  int a=global;
+  assert(a==0);
+}
+
+int main()
+{
+  global=1;
+}

--- a/regression/goto-instrument-isr/isr-wr/test.desc
+++ b/regression/goto-instrument-isr/isr-wr/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--isr isrA
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-instrument-isr/isr-ww/main.c
+++ b/regression/goto-instrument-isr/isr-ww/main.c
@@ -1,0 +1,12 @@
+int global;
+
+void isrA()
+{
+  global=1;
+}
+
+int main()
+{
+  global=0;
+  assert(global==0);
+}

--- a/regression/goto-instrument-isr/isr-ww/test.desc
+++ b/regression/goto-instrument-isr/isr-ww/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--isr isrA
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-instrument-isr/nest-isr1/main.c
+++ b/regression/goto-instrument-isr/nest-isr1/main.c
@@ -1,0 +1,73 @@
+#include <stdbool.h>
+
+int global;
+const int num_irqs=2;
+const char* __CPROVER_isr_array[]={"isrA", "isrB"};
+int irq_enabled[]={0, 0};
+int count=2;
+
+int nondet_int();
+bool nondet_bool();
+
+void __CPROVER_enable_isr(int i)
+{
+  irq_enabled[i]=1;
+}
+
+void __CPROVER_disable_isr(int i)
+{
+  irq_enabled[i]=0;
+}
+
+void f()
+{
+  int j=count;
+  int irq;
+
+  for(int i=0; i<j; i++)
+  {
+    // non-deterministically generate candidate irq
+    irq = nondet_int();
+    __CPROVER_assume(irq>=0 && irq<num_irqs);
+
+    // if irq is enabled, contingently generate the interrupt
+    if(count!=0 && irq_enabled[irq] && nondet_bool())
+    {
+      count--;
+
+      // invoke the ISR, preempting the calling program
+      switch(irq)
+      {
+        case 0: isrA(); break;
+        case 1: isrB(); break;
+        default: ;
+      }
+    }
+  }
+}
+
+void isrA()
+{
+  __CPROVER_disable_isr(0);
+  __CPROVER_enable_isr(1);
+
+  global=0;
+
+  __CPROVER_enable_isr(0);
+}
+
+void isrB()
+{
+  __CPROVER_disable_isr(1);
+
+  global=1;
+  assert(global==1); // safe
+
+  __CPROVER_enable_isr(1);
+}
+
+int main()
+{
+  __CPROVER_enable_isr(0);
+  f();
+}

--- a/regression/goto-instrument-isr/nest-isr1/test.desc
+++ b/regression/goto-instrument-isr/nest-isr1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--scheduling-function f
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/goto-instrument-isr/nest-isr2/main.c
+++ b/regression/goto-instrument-isr/nest-isr2/main.c
@@ -1,0 +1,73 @@
+#include <stdbool.h>
+
+int global;
+const int num_irqs=2;
+const char* __CPROVER_isr_array[]={"isrA", "isrB"};
+int irq_enabled[]={0, 0};
+int count=2;
+
+int nondet_int();
+bool nondet_bool();
+
+void __CPROVER_enable_isr(int i)
+{
+  irq_enabled[i]=1;
+}
+
+void __CPROVER_disable_isr(int i)
+{
+  irq_enabled[i]=0;
+}
+
+void f()
+{
+  int j=count;
+  int irq;
+
+  for(int i=0; i<j; i++)
+  {
+    // non-deterministically generate candidate irq
+    irq = nondet_int();
+    __CPROVER_assume(irq>=0 && irq<num_irqs);
+
+    // if irq is enabled, contingently generate the interrupt
+    if(count!=0 && irq_enabled[irq] && nondet_bool())
+    {
+      count--;
+
+      // invoke the ISR, preempting the calling program
+      switch(irq)
+      {
+        case 0: isrA(); break;
+        case 1: isrB(); break;
+        default: ;
+      }
+    }
+  }
+}
+
+void isrA()
+{
+  __CPROVER_disable_isr(0);
+
+  global=0;
+
+  __CPROVER_enable_isr(0);
+}
+
+void isrB()
+{
+  __CPROVER_disable_isr(1);
+  __CPROVER_enable_isr(0);
+
+  global=1;
+  assert(global==1); // fail
+
+  __CPROVER_enable_isr(1);
+}
+
+int main()
+{
+  __CPROVER_enable_isr(1);
+  f();
+}

--- a/regression/goto-instrument-isr/nest-isr2/test.desc
+++ b/regression/goto-instrument-isr/nest-isr2/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--scheduling-function f
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/src/goto-instrument/Makefile
+++ b/src/goto-instrument/Makefile
@@ -2,8 +2,8 @@ SRC = goto_instrument_parse_options.cpp rw_set.cpp \
       document_properties.cpp goto_instrument_languages.cpp \
       uninitialized.cpp full_slicer.cpp k_induction.cpp \
       object_id.cpp show_locations.cpp points_to.cpp \
-      alignment_checks.cpp race_check.cpp \
-      nondet_volatile.cpp interrupt.cpp function.cpp branch.cpp \
+      alignment_checks.cpp race_check.cpp nondet_volatile.cpp \
+      interrupt.cpp interrupt_util.cpp function.cpp branch.cpp \
       mmio.cpp stack_depth.cpp nondet_static.cpp \
       concurrency.cpp dump_c.cpp dot.cpp havoc_loops.cpp \
       call_sequences.cpp unwind.cpp function_modifies.cpp \

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1298,7 +1298,8 @@ void goto_instrument_parse_optionst::instrument_goto_program()
     // Scheduling function
     if(cmdline.isset("scheduling-function"))
     {
-      status() << "Instrumenting scheduling function for nested interrupts" << eom;
+      status() << "Instrumenting scheduling function for nested interrupts"
+               << eom;
       nested_interrupts(
         value_set_analysis,
         symbol_table,

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1162,6 +1162,7 @@ void goto_instrument_parse_optionst::instrument_goto_program()
      cmdline.isset("race-check") ||
      cmdline.isset("mm") ||
      cmdline.isset("isr") ||
+     cmdline.isset("scheduling-function") ||
      cmdline.isset("concurrency"))
   {
     do_indirect_call_and_rtti_removal();
@@ -1292,6 +1293,17 @@ void goto_instrument_parse_optionst::instrument_goto_program()
         symbol_table,
         goto_functions,
         cmdline.get_value("isr"));
+    }
+
+    // Scheduling function
+    if(cmdline.isset("scheduling-function"))
+    {
+      status() << "Instrumenting scheduling function for nested interrupts" << eom;
+      nested_interrupts(
+        value_set_analysis,
+        symbol_table,
+        goto_functions,
+        cmdline.get_value("scheduling-function"));
     }
 
     // Memory-mapped I/O

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -42,6 +42,7 @@ Author: Daniel Kroening, kroening@kroening.com
   "(call-graph)" \
   "(no-po-rendering)(render-cluster-file)(render-cluster-function)" \
   "(nondet-volatile)(isr):" \
+  "(nondet-volatile)(scheduling-function):" \
   "(stack-depth):(nondet-static)" \
   "(function-enter):(function-exit):(branch):" \
   OPT_SHOW_GOTO_FUNCTIONS \

--- a/src/goto-instrument/interrupt.cpp
+++ b/src/goto-instrument/interrupt.cpp
@@ -217,15 +217,12 @@ void nested_interrupts(
     bool race_on_read=false;
     bool race_on_write=false;
 
-    for(isr_rw_set_mapt::const_iterator
-        it=isr_rw_set_map.begin();
-        it!=isr_rw_set_map.end();
-        ++it)
+    for(const auto &it : isr_rw_set_map)
     {
-      if(it->first==function_id)
+      if(it.first==function_id)
         continue;
 
-      const rw_set_function_rect &isr_rw_set=it->second;
+      const rw_set_function_rect &isr_rw_set=it.second;
 
       if(!race_on_read && potential_race_on_read(rw_set, isr_rw_set))
         race_on_read=true;
@@ -279,16 +276,14 @@ void nested_interrupts(
 
   // figure out which objects are read/written by the ISR
   isr_rw_set_mapt isr_rw_set_map;
-  for(isr_mapt::const_iterator
-      isr_it=isr_map.begin();
-      isr_it!=isr_map.end();
-      ++isr_it)
+
+  for(const auto &isr_it : isr_map)
   {
     recursion_sett recursion_set;
     rw_set_function_rect isr_rw_set(
-      value_sets, ns, goto_functions, isr_it->second, recursion_set);
+      value_sets, ns, goto_functions, isr_it.second, recursion_set);
     isr_rw_set_map.insert(
-      std::pair<irep_idt, rw_set_function_rect>(isr_it->second, isr_rw_set));
+      std::pair<irep_idt, rw_set_function_rect>(isr_it.second, isr_rw_set));
   }
 
   // now instrument

--- a/src/goto-instrument/interrupt.cpp
+++ b/src/goto-instrument/interrupt.cpp
@@ -203,7 +203,6 @@ void nested_interrupts(
 
   Forall_goto_program_instructions(i_it, goto_program)
   {
-
 #ifdef LOCAL_MAY
     local_may_aliast local_may(goto_function);
 #endif
@@ -229,7 +228,7 @@ void nested_interrupts(
       if(!race_on_write && potential_race_on_write(rw_set, isr_rw_set))
         race_on_write=true;
 
-      if (race_on_write)
+      if(race_on_write)
         break;
     }
 
@@ -267,7 +266,8 @@ void nested_interrupts(
   isr_mapt isr_map;
   build_isr_map(ns, isr_map);
 
-  if(isr_map.size()<=0) {
+  if(isr_map.size()<=0)
+  {
     #ifdef DEBUG
     std::cout << "No interrupt handlers found" << std::endl;
     #endif

--- a/src/goto-instrument/interrupt.cpp
+++ b/src/goto-instrument/interrupt.cpp
@@ -233,10 +233,12 @@ void nested_interrupts(
     }
 
     if(race_on_read || race_on_write)
-      insert_function_before_instruction(goto_program, i_it, scheduling_function);
+      insert_function_before_instruction(
+        goto_program, i_it, scheduling_function);
 
     if(race_on_write)
-      insert_function_after_instruction(goto_program, i_it, scheduling_function);
+      insert_function_after_instruction(
+        goto_program, i_it, scheduling_function);
   }
 }
 

--- a/src/goto-instrument/interrupt.cpp
+++ b/src/goto-instrument/interrupt.cpp
@@ -195,6 +195,7 @@ void nested_interrupts(
   const goto_functionst::goto_functiont& goto_function,
 #endif
   goto_programt &goto_program,
+  const irep_idt &function_id,
   const symbol_exprt &scheduling_function,
   const isr_rw_set_mapt &isr_rw_set_map)
 {
@@ -221,6 +222,9 @@ void nested_interrupts(
         it!=isr_rw_set_map.end();
         ++it)
     {
+      if(it->first==function_id)
+        continue;
+
       const rw_set_function_rect &isr_rw_set=it->second;
 
       if(!race_on_read && potential_race_on_read(rw_set, isr_rw_set))
@@ -298,7 +302,7 @@ void nested_interrupts(
 #ifdef LOCAL_MAY
         f_it->second,
 #endif
-        f_it->second.body, sched_f, isr_rw_set_map);
+        f_it->second.body, f_it->first, sched_f, isr_rw_set_map);
 
   goto_functions.update();
 }

--- a/src/goto-instrument/interrupt.cpp
+++ b/src/goto-instrument/interrupt.cpp
@@ -291,7 +291,9 @@ void nested_interrupts(
   Forall_goto_functions(f_it, goto_functions)
     if(f_it->first!=CPROVER_PREFIX "initialize" &&
        f_it->first!=goto_functionst::entry_point() &&
-       f_it->first!=sched_f.get_identifier())
+       f_it->first!=sched_f.get_identifier() &&
+       f_it->first!=CPROVER_ENABLE_ISR &&
+       f_it->first!=CPROVER_DISABLE_ISR)
       nested_interrupts(
         value_sets, symbol_table,
 #ifdef LOCAL_MAY

--- a/src/goto-instrument/interrupt.h
+++ b/src/goto-instrument/interrupt.h
@@ -2,9 +2,9 @@
 
 Module: Interrupt Instrumentation for Goto Programs
 
-Author: Daniel Kroening
+Author: Daniel Kroening, Lihao Liang
 
-Date: September 2011
+Date: June 2016
 
 \*******************************************************************/
 
@@ -21,5 +21,11 @@ void interrupt(
   const class symbol_tablet &symbol_table,
   goto_functionst &goto_functions,
   const irep_idt &interrupt_handler);
+
+void nested_interrupts(
+  value_setst &value_sets,
+  const class symbol_tablet &symbol_table,
+  goto_functionst &goto_functions,
+  const irep_idt &scheduling_function);
 
 #endif // CPROVER_GOTO_INSTRUMENT_INTERRUPT_H

--- a/src/goto-instrument/interrupt_util.cpp
+++ b/src/goto-instrument/interrupt_util.cpp
@@ -206,7 +206,8 @@ void build_isr_map(const namespacet &ns, isr_mapt &isr_map)
 
   forall_operands(thread_it, thread_array_expr)
   {
-    const irep_idt &thread_name=to_string_constant(thread_it->op0().op0()).get_value();
+    const irep_idt &thread_name=
+      to_string_constant(thread_it->op0().op0()).get_value();
     isr_map[i]=thread_name;
     i++;
   }

--- a/src/goto-instrument/interrupt_util.cpp
+++ b/src/goto-instrument/interrupt_util.cpp
@@ -34,13 +34,14 @@ symbol_exprt get_isr(
     // look it up
     symbol_tablet::symbolst::const_iterator s_it=
       symbol_table.symbols.find(m_it->second);
-    
-    if(s_it==symbol_table.symbols.end()) continue;
-  
+
+    if(s_it==symbol_table.symbols.end())
+      continue;
+
     if(s_it->second.type.id()==ID_code)
       matches.push_back(s_it->second.symbol_expr());
   }
-  
+
   if(matches.empty())
     throw "interrupt handler `"+id2string(interrupt_handler)+"' not found";
 
@@ -48,7 +49,7 @@ symbol_exprt get_isr(
     throw "interrupt handler `"+id2string(interrupt_handler)+"' is ambiguous";
 
   symbol_exprt isr=matches.front();
-  
+
   if(!to_code_type(isr.type()).parameters().empty())
     throw "interrupt handler `"+id2string(interrupt_handler)+
           "' must not have parameters";
@@ -78,7 +79,7 @@ bool potential_race_on_read(
     if(isr_rw_set.has_w_entry(e_it->first))
       return true;
   }
-  
+
   return false;
 }
 
@@ -107,7 +108,7 @@ bool potential_race_on_write(
     if(isr_rw_set.has_w_entry(e_it->first))
       return true;
   }
-  
+
   return false;
 }
 
@@ -134,11 +135,11 @@ void insert_function_before_instruction(
 
   const source_locationt &source_location=
     original_instruction.source_location;
-  
+
   code_function_callt function_call;
   function_call.add_source_location()=source_location;
   function_call.function()=function;
-  
+
   goto_programt::targett t_call=i_it;
   goto_programt::targett t_orig=goto_program.insert_after(t_call);
 
@@ -147,7 +148,7 @@ void insert_function_before_instruction(
   t_call->function=original_instruction.function;
 
   t_orig->swap(original_instruction);
-  
+
   i_it=t_orig; // the for loop already counts us up
 }
 
@@ -170,20 +171,20 @@ void insert_function_after_instruction(
 {
   goto_programt::targett t_orig=i_it;
   t_orig++;
-  
+
   goto_programt::targett t_call=goto_program.insert_after(i_it);
-  
+
   const source_locationt &source_location=i_it->source_location;
-  
+
   code_function_callt function_call;
   function_call.add_source_location()=source_location;
   function_call.function()=function;
-  
+
   t_call->make_function_call(function_call);
   t_call->source_location=source_location;
   t_call->function=i_it->function;
 
-  i_it=t_call; // the for loop already counts us up      
+  i_it=t_call; // the for loop already counts us up
 }
 
 /*******************************************************************\

--- a/src/goto-instrument/interrupt_util.cpp
+++ b/src/goto-instrument/interrupt_util.cpp
@@ -199,7 +199,7 @@ Function: build_isr_map
 
 void build_isr_map(const namespacet &ns, isr_mapt &isr_map)
 {
-  const symbolt &threads=ns.lookup(CPROVER_ISR_ARRAY_ID);
+  const symbolt &threads=ns.lookup(CPROVER_ISR_ARRAY);
   const array_exprt &thread_array_expr=to_array_expr(threads.value);
   unsigned int i=0;
 

--- a/src/goto-instrument/interrupt_util.cpp
+++ b/src/goto-instrument/interrupt_util.cpp
@@ -1,0 +1,212 @@
+/*******************************************************************\
+
+Module: Interrupt Instrumentation
+
+Author: Daniel Kroening, Lihao Liang
+
+Date: June 2016
+
+\*******************************************************************/
+
+#include <ansi-c/string_constant.h>
+#include "interrupt_util.h"
+
+/*******************************************************************\
+
+Function: get_isr
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+symbol_exprt get_isr(
+  const symbol_tablet &symbol_table,
+  const irep_idt &interrupt_handler)
+{
+  std::list<symbol_exprt> matches;
+
+  forall_symbol_base_map(m_it, symbol_table.symbol_base_map, interrupt_handler)
+  {
+    // look it up
+    symbol_tablet::symbolst::const_iterator s_it=
+      symbol_table.symbols.find(m_it->second);
+    
+    if(s_it==symbol_table.symbols.end()) continue;
+  
+    if(s_it->second.type.id()==ID_code)
+      matches.push_back(s_it->second.symbol_expr());
+  }
+  
+  if(matches.empty())
+    throw "interrupt handler `"+id2string(interrupt_handler)+"' not found";
+
+  if(matches.size()>=2)
+    throw "interrupt handler `"+id2string(interrupt_handler)+"' is ambiguous";
+
+  symbol_exprt isr=matches.front();
+  
+  if(!to_code_type(isr.type()).parameters().empty())
+    throw "interrupt handler `"+id2string(interrupt_handler)+
+          "' must not have parameters";
+
+  return isr;
+}
+
+/*******************************************************************\
+
+Function: poential_race_on_read
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+bool potential_race_on_read(
+  const rw_set_baset &code_rw_set,
+  const rw_set_baset &isr_rw_set)
+{
+  // R/W race?
+  forall_rw_set_r_entries(e_it, code_rw_set)
+  {
+    if(isr_rw_set.has_w_entry(e_it->first))
+      return true;
+  }
+  
+  return false;
+}
+
+/*******************************************************************\
+
+Function: poential_race_on_write
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+bool potential_race_on_write(
+  const rw_set_baset &code_rw_set,
+  const rw_set_baset &isr_rw_set)
+{
+  // W/R or W/W?
+  forall_rw_set_w_entries(e_it, code_rw_set)
+  {
+    if(isr_rw_set.has_r_entry(e_it->first))
+      return true;
+
+    if(isr_rw_set.has_w_entry(e_it->first))
+      return true;
+  }
+  
+  return false;
+}
+
+/*******************************************************************\
+
+Function: insert_function_before_instruction
+
+  Inputs:
+
+ Outputs:
+
+ Purpose: insert function call before instruction
+
+\*******************************************************************/
+
+void insert_function_before_instruction(
+  goto_programt &goto_program,
+  goto_programt::targett &i_it,
+  const symbol_exprt &function)
+{
+  goto_programt::instructiont &instruction=*i_it;
+  goto_programt::instructiont original_instruction;
+  original_instruction.swap(instruction);
+
+  const source_locationt &source_location=
+    original_instruction.source_location;
+  
+  code_function_callt function_call;
+  function_call.add_source_location()=source_location;
+  function_call.function()=function;
+  
+  goto_programt::targett t_call=i_it;
+  goto_programt::targett t_orig=goto_program.insert_after(t_call);
+
+  t_call->make_function_call(function_call);
+  t_call->source_location=source_location;
+  t_call->function=original_instruction.function;
+
+  t_orig->swap(original_instruction);
+  
+  i_it=t_orig; // the for loop already counts us up
+}
+
+/*******************************************************************\
+
+Function: insert_function_after_instruction
+
+  Inputs:
+
+ Outputs:
+
+ Purpose: insert function call after instruction
+
+\*******************************************************************/
+
+void insert_function_after_instruction(
+  goto_programt &goto_program,
+  goto_programt::targett &i_it,
+  const symbol_exprt &function)
+{
+  goto_programt::targett t_orig=i_it;
+  t_orig++;
+  
+  goto_programt::targett t_call=goto_program.insert_after(i_it);
+  
+  const source_locationt &source_location=i_it->source_location;
+  
+  code_function_callt function_call;
+  function_call.add_source_location()=source_location;
+  function_call.function()=function;
+  
+  t_call->make_function_call(function_call);
+  t_call->source_location=source_location;
+  t_call->function=i_it->function;
+
+  i_it=t_call; // the for loop already counts us up      
+}
+
+/*******************************************************************\
+
+Function: build_isr_map
+
+  Inputs:
+
+ Outputs:
+
+ Purpose: retrieve a list of interrupt handlers from source code
+\*******************************************************************/
+
+void build_isr_map(const namespacet &ns, isr_mapt &isr_map)
+{
+  const symbolt &threads=ns.lookup(CPROVER_ISR_ARRAY_ID);
+  const array_exprt &thread_array_expr=to_array_expr(threads.value);
+  unsigned int i=0;
+
+  forall_operands(thread_it, thread_array_expr)
+  {
+    const irep_idt &thread_name=to_string_constant(thread_it->op0().op0()).get_value();
+    isr_map[i]=thread_name;
+    i++;
+  }
+}

--- a/src/goto-instrument/interrupt_util.h
+++ b/src/goto-instrument/interrupt_util.h
@@ -14,7 +14,7 @@ Date: June 2016
 #include <unordered_map>
 #include "rw_set.h"
 
-#define CPROVER_ISR_ARRAY_ID "__CPROVER_ISR_ARRAY"
+#define CPROVER_ISR_ARRAY "__CPROVER_isr_array"
 #define CPROVER_ENABLE_ISR  "__CPROVER_enable_isr"
 #define CPROVER_DISABLE_ISR "__CPROVER_disable_isr"
 

--- a/src/goto-instrument/interrupt_util.h
+++ b/src/goto-instrument/interrupt_util.h
@@ -11,12 +11,13 @@ Date: June 2016
 #ifndef CPROVER_INTERRUPT_UTIL_H
 #define CPROVER_INTERRUPT_UTIL_H
 
+#include <unordered_map>
 #include "rw_set.h"
 
 #define CPROVER_ISR_ARRAY_ID "__CPROVER_ISR_ARRAY"
 
-typedef hash_map_cont<unsigned int, irep_idt> isr_mapt;
-typedef hash_map_cont<irep_idt, rw_set_function_rect, irep_id_hash> 
+typedef std::unordered_map<unsigned int, irep_idt> isr_mapt;
+typedef std::unordered_map<irep_idt, rw_set_function_rect, irep_id_hash>
   isr_rw_set_mapt;
 
 symbol_exprt get_isr(

--- a/src/goto-instrument/interrupt_util.h
+++ b/src/goto-instrument/interrupt_util.h
@@ -15,6 +15,8 @@ Date: June 2016
 #include "rw_set.h"
 
 #define CPROVER_ISR_ARRAY_ID "__CPROVER_ISR_ARRAY"
+#define CPROVER_ENABLE_ISR  "__CPROVER_enable_isr"
+#define CPROVER_DISABLE_ISR "__CPROVER_disable_isr"
 
 typedef std::unordered_map<unsigned int, irep_idt> isr_mapt;
 typedef std::unordered_map<irep_idt, rw_set_function_rect, irep_id_hash>

--- a/src/goto-instrument/interrupt_util.h
+++ b/src/goto-instrument/interrupt_util.h
@@ -8,8 +8,8 @@ Date: June 2016
 
 \*******************************************************************/
 
-#ifndef CPROVER_INTERRUPT_UTIL_H
-#define CPROVER_INTERRUPT_UTIL_H
+#ifndef CPROVER_GOTO_INSTRUMENT_INTERRUPT_UTIL_H
+#define CPROVER_GOTO_INSTRUMENT_INTERRUPT_UTIL_H
 
 #include <unordered_map>
 #include "rw_set.h"
@@ -48,4 +48,4 @@ void build_isr_map(
   const namespacet &ns, 
   isr_mapt &isr_map);
 
-#endif
+#endif // CPROVER_GOTO_INSTRUMENT_INTERRUPT_UTIL_H

--- a/src/goto-instrument/interrupt_util.h
+++ b/src/goto-instrument/interrupt_util.h
@@ -1,0 +1,48 @@
+/*******************************************************************\
+
+Module: Interrupt Instrumentation 
+
+Author: Daniel Kroening, Lihao Liang
+
+Date: June 2016
+
+\*******************************************************************/
+
+#ifndef CPROVER_INTERRUPT_UTIL_H
+#define CPROVER_INTERRUPT_UTIL_H
+
+#include "rw_set.h"
+
+#define CPROVER_ISR_ARRAY_ID "__CPROVER_ISR_ARRAY"
+
+typedef hash_map_cont<unsigned int, irep_idt> isr_mapt;
+typedef hash_map_cont<irep_idt, rw_set_function_rect, irep_id_hash> 
+  isr_rw_set_mapt;
+
+symbol_exprt get_isr(
+  const symbol_tablet &symbol_table,
+  const irep_idt &interrupt_handler);
+
+bool potential_race_on_read(
+  const rw_set_baset &code_rw_set,
+  const rw_set_baset &isr_rw_set);
+
+ bool potential_race_on_write(
+  const rw_set_baset &code_rw_set,
+  const rw_set_baset &isr_rw_set);
+ 
+void insert_function_before_instruction(
+  goto_programt &goto_program,
+  goto_programt::targett &i_it,
+  const symbol_exprt &function);
+
+void insert_function_after_instruction(
+  goto_programt &goto_program,
+  goto_programt::targett &i_it,
+  const symbol_exprt &function);
+
+void build_isr_map(
+  const namespacet &ns, 
+  isr_mapt &isr_map);
+
+#endif

--- a/src/goto-instrument/interrupt_util.h
+++ b/src/goto-instrument/interrupt_util.h
@@ -30,10 +30,10 @@ bool potential_race_on_read(
   const rw_set_baset &code_rw_set,
   const rw_set_baset &isr_rw_set);
 
- bool potential_race_on_write(
+bool potential_race_on_write(
   const rw_set_baset &code_rw_set,
   const rw_set_baset &isr_rw_set);
- 
+
 void insert_function_before_instruction(
   goto_programt &goto_program,
   goto_programt::targett &i_it,
@@ -45,7 +45,7 @@ void insert_function_after_instruction(
   const symbol_exprt &function);
 
 void build_isr_map(
-  const namespacet &ns, 
+  const namespacet &ns,
   isr_mapt &isr_map);
 
 #endif // CPROVER_GOTO_INSTRUMENT_INTERRUPT_UTIL_H

--- a/src/goto-instrument/rw_set.cpp
+++ b/src/goto-instrument/rw_set.cpp
@@ -189,7 +189,7 @@ void _rw_set_loct::read_write_rec(
       if(it->id()==ID_unknown)
       {
         /* as an under-approximation */
-        //std::cout << "Sorry, LOCAL_MAY too imprecise. Omitting some variables."
+        // std::cout << "Sorry, LOCAL_MAY too imprecise. Omitting some variables."
         //  << std::endl;
         irep_idt object=ID_unknown;
 
@@ -219,7 +219,6 @@ void _rw_set_loct::read_write_rec(
   else if(expr.id()==ID_address_of)
   {
     assert(expr.operands().size()==1);
-
   }
   else if(expr.id()==ID_if)
   {
@@ -290,7 +289,7 @@ void rw_set_functiont::compute_rec(const exprt &function)
     compute_rec(to_if_expr(function).true_case());
     compute_rec(to_if_expr(function).false_case());
   }
-} 
+}
 
 /*******************************************************************\
 

--- a/src/goto-instrument/rw_set.cpp
+++ b/src/goto-instrument/rw_set.cpp
@@ -268,8 +268,10 @@ void rw_set_functiont::compute_rec(const exprt &function)
 #ifdef LOCAL_MAY
       local_may_aliast local_may(f_it->second);
 #if 0
-      for(goto_functionst::function_mapt::const_iterator g_it=goto_functions.function_map.begin();
-        g_it!=goto_functions.function_map.end(); ++g_it)
+      for(goto_functionst::function_mapt::const_iterator
+          g_it=goto_functions.function_map.begin();
+          g_it!=goto_functions.function_map.end();
+          ++g_it)
         local_may(g_it->second);
 #endif
 #endif
@@ -342,10 +344,10 @@ void rw_set_loc_rect::compute_rec(recursion_sett &recursion_set)
       }
       else if(function.id()==ID_if)
       {
-        *this+=rw_set_function_rect(
-          value_sets, ns, goto_functions, to_if_expr(function).true_case(), recursion_set);
-        *this+=rw_set_function_rect(
-          value_sets, ns, goto_functions, to_if_expr(function).false_case(), recursion_set);
+        *this+=rw_set_function_rect(value_sets, ns, goto_functions,
+          to_if_expr(function).true_case(), recursion_set);
+        *this+=rw_set_function_rect(value_sets, ns, goto_functions,
+          to_if_expr(function).false_case(), recursion_set);
       }
     }
   }

--- a/src/goto-instrument/rw_set.h
+++ b/src/goto-instrument/rw_set.h
@@ -351,7 +351,8 @@ protected:
   recursion_sett &recursion_set;
 
   void compute_func_rec(const exprt &function, recursion_sett &recursion_set);
-  void compute_func_rec(const irep_idt &function, recursion_sett &recursion_set);
+  void compute_func_rec(const irep_idt &function,
+    recursion_sett &recursion_set);
 };
 
 #endif // CPROVER_GOTO_INSTRUMENT_RW_SET_H

--- a/src/goto-instrument/rw_set.h
+++ b/src/goto-instrument/rw_set.h
@@ -136,7 +136,7 @@ protected:
   const goto_programt::const_targett target;
 
 #ifdef LOCAL_MAY
-  local_may_aliast& local_may;
+  local_may_aliast &local_may;
 #endif
 
   inline void read(const exprt &expr)
@@ -179,7 +179,7 @@ public:
 #ifdef LOCAL_MAY
       , may
 #endif
-   )
+    )
   {
     compute();
   }
@@ -251,7 +251,8 @@ protected:
   bool dereferencing;
   std::vector<entryt> dereferenced;
 
-  void track_deref(const entryt& entry, bool read) {
+  void track_deref(const entryt& entry, bool read)
+  {
     if(dereferencing && dereferenced.size()==0)
     {
       dereferenced.insert(dereferenced.begin(), entry);
@@ -263,11 +264,13 @@ protected:
         dereferenced.front().object));
   }
 
-  void set_track_deref() {
+  void set_track_deref()
+  {
     dereferencing=true;
   }
 
-  void reset_track_deref() {
+  void reset_track_deref()
+  {
     dereferencing=false;
     dereferenced.clear();
   }

--- a/src/goto-instrument/rw_set.h
+++ b/src/goto-instrument/rw_set.h
@@ -34,7 +34,7 @@ Date: June 2016
 class rw_set_baset
 {
 public:
-  rw_set_baset(const namespacet &_ns)
+  explicit rw_set_baset(const namespacet &_ns)
     :ns(_ns)
   {
   }

--- a/src/goto-instrument/rw_set.h
+++ b/src/goto-instrument/rw_set.h
@@ -14,6 +14,7 @@ Date: June 2016
 #include <iosfwd>
 #include <vector>
 #include <set>
+#include <unordered_set>
 
 #include <util/guard.h>
 #include <util/std_code.h>
@@ -272,7 +273,7 @@ protected:
   }
 };
 
-typedef hash_set_cont<irep_idt, irep_id_hash> recursion_sett;
+typedef std::unordered_set<irep_idt, irep_id_hash> recursion_sett;
 
 // another producer of read/write sets
 // this time look inside the body of function calls

--- a/src/goto-instrument/rw_set.h
+++ b/src/goto-instrument/rw_set.h
@@ -2,9 +2,9 @@
 
 Module: Race Detection for Threaded Goto Programs
 
-Author: Daniel Kroening
+Author: Daniel Kroening, Lihao Liang
 
-Date: February 2006
+Date: June 2016
 
 \*******************************************************************/
 
@@ -26,6 +26,7 @@ Date: February 2006
 #ifdef LOCAL_MAY
 #include <analyses/local_may_alias.h>
 #endif
+
 
 // a container for read/write sets
 
@@ -269,6 +270,84 @@ protected:
     dereferencing=false;
     dereferenced.clear();
   }
+};
+
+typedef hash_set_cont<irep_idt, irep_id_hash> recursion_sett;
+
+// another producer of read/write sets
+// this time look inside the body of function calls
+
+class rw_set_loc_rect:public rw_set_loct
+{
+public:
+  rw_set_loc_rect(
+    const namespacet &_ns,
+    value_setst &_value_sets,
+    goto_programt::const_targett _target,
+#ifdef LOCAL_MAY
+    local_may_aliast &may,
+#endif
+    const goto_functionst &_goto_functions,
+    recursion_sett &_recursion_set):
+    rw_set_loct(_ns, _value_sets, _target
+#ifdef LOCAL_MAY
+     , may
+#endif
+    ),
+    goto_functions(_goto_functions),
+    recursion_set(_recursion_set)
+  {
+    compute_rec(recursion_set);
+  }
+
+protected:
+  const goto_functionst &goto_functions;
+  recursion_sett &recursion_set;
+
+  void compute_rec(recursion_sett &recursion_set);
+};
+
+// another producer of entire functions
+// this time look inside the body of function calls
+
+class rw_set_function_rect:public rw_set_baset
+{
+public:
+  rw_set_function_rect(
+    value_setst &_value_sets,
+    const namespacet &_ns,
+    const goto_functionst &_goto_functions,
+    const irep_idt &function,
+    recursion_sett &_recursion_set):
+    rw_set_baset(_ns),
+    value_sets(_value_sets),
+    goto_functions(_goto_functions),
+    recursion_set(_recursion_set)
+  {
+    compute_func_rec(function, recursion_set);
+  }
+
+  rw_set_function_rect(
+    value_setst &_value_sets,
+    const namespacet &_ns,
+    const goto_functionst &_goto_functions,
+    const exprt &function,
+    recursion_sett &_recursion_set):
+    rw_set_baset(_ns),
+    value_sets(_value_sets),
+    goto_functions(_goto_functions),
+    recursion_set(_recursion_set)
+  {
+    compute_func_rec(function, recursion_set);
+  }
+
+protected:
+  value_setst &value_sets;
+  const goto_functionst &goto_functions;
+  recursion_sett &recursion_set;
+
+  void compute_func_rec(const exprt &function, recursion_sett &recursion_set);
+  void compute_func_rec(const irep_idt &function, recursion_sett &recursion_set);
 };
 
 #endif // CPROVER_GOTO_INSTRUMENT_RW_SET_H


### PR DESCRIPTION
This series of patches adds support for sequentialization of nested interrupts to goto-instrument.

Usage: goto-instrument --scheduling-function f input.gb output.gb

Note: source code requires
1. a scheduling function that invokes ISRs;
2. a char\* array named __CPROVER_isr_array to store function names of ISRs, e.g. 
const char\* __CPROVER_isr_array[] = {"isrA", "isrB"};

3. functions __CPROVER_enable_isr(i) and __CPROVER_disable_isr(i) to enable and disable interrupt i, respectively. 

See 66815da for code examples.
