### PR TITLE
Extended GCC attributes parsing and processing

### DIFF
--- a/regression/ansi-c/gcc_attributes5/main.c
+++ b/regression/ansi-c/gcc_attributes5/main.c
@@ -21,6 +21,14 @@ STATIC_ASSERT(__alignof(var7)==8);
 
 void (__attribute__((aligned)) *****f1)(void);
 void (__attribute__((aligned)) f2)(void);
+
+int __attribute__((cdecl,regparm(0))) *foo1(int x);
+int __attribute__((cdecl,regparm(0))) *(foo2)(int x);
+int (__attribute__((cdecl,regparm(0))) *foo3)(int x);
+int (* __attribute__((cdecl,regparm(0))) foo4)(int x);
+typedef int (__attribute__((cdecl,regparm(0))) foo5)(int x);
+typedef int (__attribute__((cdecl,regparm(0))) *foo6)(int x);
+typedef int* (__attribute__((cdecl,regparm(0))) *foo7)(int x);
                 
 #endif
 

--- a/regression/ansi-c/gcc_attributes5/test.desc
+++ b/regression/ansi-c/gcc_attributes5/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/gcc_attributes6/test.desc
+++ b/regression/ansi-c/gcc_attributes6/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/gcc_attributes9/main.c
+++ b/regression/ansi-c/gcc_attributes9/main.c
@@ -1,0 +1,20 @@
+#ifdef __GNUC__
+
+int foo();
+char foo __attribute__((section("other")));
+long more_foo __attribute__((section("other2"))) asm("foo");
+
+const char* __attribute__((section("s"))) bar1();
+const char* __attribute__((section("s"),weak)) bar2();
+const char* __attribute__((section("s"))) __attribute__((weak)) bar();
+
+#endif
+
+int main()
+{
+#ifdef __GNUC__
+  static int __attribute__((section(".data.unlikely"))) __warned;
+  __warned=1;
+  return __warned;
+#endif
+}

--- a/regression/ansi-c/gcc_attributes9/test.desc
+++ b/regression/ansi-c/gcc_attributes9/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/src/ansi-c/ansi_c_convert_type.cpp
+++ b/src/ansi-c/ansi_c_convert_type.cpp
@@ -116,9 +116,6 @@ void ansi_c_convert_typet::read_rec(const typet &type)
   {
     gcc_attribute_mode=type;
   }
-  else if(type.id()==ID_gcc_attribute)
-  {
-  }
   else if(type.id()==ID_msc_based)
   {
     const exprt &as_expr=static_cast<const exprt &>(static_cast<const irept &>(type));

--- a/src/ansi-c/ansi_c_convert_type.cpp
+++ b/src/ansi-c/ansi_c_convert_type.cpp
@@ -78,6 +78,12 @@ void ansi_c_convert_typet::read_rec(const typet &type)
   {
     c_storage_spec.asm_label=type.subtype().get(ID_value);
   }
+  else if(type.id()==ID_section &&
+          type.has_subtype() &&
+          type.subtype().id()==ID_string_constant)
+  {
+    c_storage_spec.section=type.subtype().get(ID_value);
+  }
   else if(type.id()==ID_const)
     c_qualifiers.is_constant=true;
   else if(type.id()==ID_restrict)

--- a/src/ansi-c/c_storage_spec.cpp
+++ b/src/ansi-c/c_storage_spec.cpp
@@ -67,4 +67,10 @@ void c_storage_spect::read(const typet &type)
   {
     asm_label=type.subtype().get(ID_value);
   }
+  else if(type.id()==ID_section &&
+          type.has_subtype() &&
+          type.subtype().id()==ID_string_constant)
+  {
+    section=type.subtype().get(ID_value);
+  }
 }

--- a/src/ansi-c/c_storage_spec.h
+++ b/src/ansi-c/c_storage_spec.h
@@ -36,6 +36,7 @@ public:
     is_weak=false;
     alias.clear();
     asm_label.clear();
+    section.clear();
   }
   
   bool is_typedef, is_extern, is_static, is_register,
@@ -46,6 +47,7 @@ public:
 
   // GCC asm labels __asm__("foo") - these change the symbol name
   irep_idt asm_label;
+  irep_idt section;
   
   friend bool operator == (
     const c_storage_spect &a,
@@ -59,7 +61,8 @@ public:
            a.is_inline==b.is_inline &&
            a.is_weak==b.is_weak &&
            a.alias==b.alias &&
-           a.asm_label==b.asm_label;
+           a.asm_label==b.asm_label &&
+           a.section==b.section;
   }
 
   friend bool operator != (
@@ -82,6 +85,7 @@ public:
     a.is_weak         |=b.is_weak;
     if(!b.alias.empty()) a.alias=b.alias;
     if(!b.asm_label.empty()) a.asm_label=b.asm_label;
+    if(!b.section.empty()) a.section=b.section;
     
     return a;
   }

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -855,7 +855,19 @@ void c_typecheck_baset::typecheck_declaration(
         symbol.is_macro=true;
       }
 
-      apply_asm_label(full_spec.asm_label, symbol);
+      if(full_spec.section.empty())
+        apply_asm_label(full_spec.asm_label, symbol);
+      else
+      {
+        std::string asm_name;
+        asm_name=id2string(full_spec.section)+"$$";
+        if(!full_spec.asm_label.empty())
+          asm_name+=id2string(full_spec.asm_label);
+        else
+          asm_name+=id2string(symbol.name);
+
+        apply_asm_label(asm_name, symbol);
+      }
       irep_idt identifier=symbol.name;
 
       typecheck_symbol(symbol);

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -71,8 +71,8 @@ void c_typecheck_baset::move_symbol(symbolt &symbol, symbolt *&new_symbol)
   if(symbol_table.move(symbol, new_symbol))
   {
     err_location(symbol.location);
-    str << "failed to move symbol `" << symbol.name
-        << "' into symbol table";
+    error() << "failed to move symbol `" << symbol.name
+            << "' into symbol table" << eom;
     throw 0;
   }
 }
@@ -118,7 +118,7 @@ void c_typecheck_baset::typecheck_symbol(symbolt &symbol)
   else if(!is_function && symbol.value.id()==ID_code)
   {
     err_location(symbol.value);
-    str << "only functions can have a function body";
+    error() << "only functions can have a function body" << eom;
     throw 0;
   }
   
@@ -162,8 +162,8 @@ void c_typecheck_baset::typecheck_symbol(symbolt &symbol)
     if(old_it->second.is_type!=symbol.is_type)
     {
       err_location(symbol.location);
-      str << "redeclaration of `" << symbol.display_name()
-          << "' as a different kind of symbol";
+      error() << "redeclaration of `" << symbol.display_name()
+              << "' as a different kind of symbol" << eom;
       throw 0;
     }
 
@@ -275,9 +275,9 @@ void c_typecheck_baset::typecheck_redefinition_type(
     else
     {
       err_location(new_symbol.location);
-      str << "error: conflicting definition of type symbol `"
-          << new_symbol.display_name()
-          << "'";
+      error() << "error: conflicting definition of type symbol `"
+              << new_symbol.display_name()
+              << "'" << eom;
       throw 0;
     }
   }
@@ -296,9 +296,9 @@ void c_typecheck_baset::typecheck_redefinition_type(
       {
         // arg! new tag type
         err_location(new_symbol.location);
-        str << "error: conflicting definition of tag symbol `"
-            << new_symbol.display_name()
-            << "'";
+        error() << "error: conflicting definition of tag symbol `"
+                << new_symbol.display_name()
+                << "'" << eom;
         throw 0;
       }
     }
@@ -322,10 +322,10 @@ void c_typecheck_baset::typecheck_redefinition_type(
       if(follow(new_symbol.type)!=follow(old_symbol.type))
       {
         err_location(new_symbol.location);
-        str << "error: type symbol `" << new_symbol.display_name()
-            << "' defined twice:" << "\n";
-        str << "Original: " << to_string(old_symbol.type) << "\n";
-        str << "     New: " << to_string(new_symbol.type);
+        error() << "error: type symbol `"
+                << new_symbol.display_name() << "' defined twice:\n"
+                << "Original: " << to_string(old_symbol.type) << "\n"
+                << "     New: " << to_string(new_symbol.type) << eom;
         throw 0;
       }
     }
@@ -375,7 +375,8 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
     if(final_new.id()==ID_code)
     {
       err_location(new_symbol.location);
-      str << "function type not allowed for K&R function parameter";
+      error() << "function type not allowed for K&R function parameter"
+              << eom;
       throw 0;
     }
     
@@ -393,10 +394,11 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
     if(final_old.id()!=ID_code)
     {
       err_location(new_symbol.location);
-      str << "error: function symbol `" << new_symbol.display_name()
-          << "' redefined with a different type:" << "\n";
-      str << "Original: " << to_string(old_symbol.type) << "\n";
-      str << "     New: " << to_string(new_symbol.type);
+      error() << "error: function symbol `"
+              << new_symbol.display_name()
+              << "' redefined with a different type:\n"
+              << "Original: " << to_string(old_symbol.type) << "\n"
+              << "     New: " << to_string(new_symbol.type) << eom;
       throw 0;
     }
 
@@ -449,8 +451,8 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
         else
         {
           err_location(new_symbol.location);
-          str << "function body `" << new_symbol.display_name()
-              << "' defined twice";
+          error() << "function body `" << new_symbol.display_name()
+                  << "' defined twice" << eom;
           throw 0;
         }
       }
@@ -504,8 +506,9 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
         if(s_it==symbol_table.symbols.end())
         {
           err_location(old_symbol.location);
-          str << "typecheck_redefinition_non_type: "
-                 "failed to find symbol `" << identifier << "'";
+          error() << "typecheck_redefinition_non_type: "
+                  << "failed to find symbol `" << identifier << "'"
+                  << eom;
           throw 0;
         }
                   
@@ -547,10 +550,10 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
     else
     {
       err_location(new_symbol.location);
-      str << "error: symbol `" << new_symbol.display_name()
-          << "' redefined with a different type:" << "\n";
-      str << "Original: " << to_string(old_symbol.type) << "\n";
-      str << "     New: " << to_string(new_symbol.type);
+      error() << "error: symbol `" << new_symbol.display_name()
+              << "' redefined with a different type:\n"
+              << "Original: " << to_string(old_symbol.type) << "\n"
+              << "     New: " << to_string(new_symbol.type) << eom;
       throw 0;
     }
   }
@@ -587,8 +590,8 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
         else
         {
           err_location(new_symbol.value);
-          str << "symbol `" << new_symbol.display_name()
-              << "' already has an initial value";
+          error() << "symbol `" << new_symbol.display_name()
+                  << "' already has an initial value" << eom;
           warning_msg();
         }
       }
@@ -687,8 +690,8 @@ void c_typecheck_baset::typecheck_function_body(symbolt &symbol)
     if(labels_defined.find(it->first)==labels_defined.end())
     {
       err_location(it->second);
-      str << "branching label `" << it->first
-          << "' is not defined in function";
+      error() << "branching label `" << it->first
+              << "' is not defined in function" << eom;
       throw 0;
     }
   }
@@ -736,9 +739,9 @@ void c_typecheck_baset::apply_asm_label(
       }
       else
       {
-        str << "replacing asm renaming "
-            << asm_label_map[orig_name] << " by "
-            << asm_label;
+        error() << "replacing asm renaming "
+                << asm_label_map[orig_name] << " by "
+                << asm_label << eom;
         throw 0;
       }
     }
@@ -849,7 +852,12 @@ void c_typecheck_baset::typecheck_declaration(
       if(!full_spec.alias.empty())
       {
         if(symbol.value.is_not_nil())
-          throw "alias attribute cannot be used with a body";
+        {
+          err_location(symbol.location);
+          error() << "alias attribute cannot be used with a body"
+                  << eom;
+          throw 0;
+        }
 
         // alias function need not have been declared yet, thus
         // can't lookup

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -736,7 +736,9 @@ void c_typecheck_baset::apply_asm_label(
       }
       else
       {
-        str << "error: conflicting asm renaming";
+        str << "replacing asm renaming "
+            << asm_label_map[orig_name] << " by "
+            << asm_label;
         throw 0;
       }
     }
@@ -869,6 +871,7 @@ void c_typecheck_baset::typecheck_declaration(
         apply_asm_label(asm_name, symbol);
       }
       irep_idt identifier=symbol.name;
+      d_it->set_name(identifier);
 
       typecheck_symbol(symbol);
 

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -10,6 +10,9 @@
  * ftp://ftp.sra.co.jp/.a/pub/cmd/c++grammar2.0.tar.gz)
  */
 
+#ifdef ANSI_C_DEBUG
+#define YYDEBUG 1
+#endif
 #define PARSER ansi_c_parser
 
 #include "ansi_c_parser.h"

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -2881,6 +2881,32 @@ function_head:
 declarator:
           identifier_declarator
         | typedef_declarator
+        | paren_attribute_declarator
+        ;
+
+paren_attribute_declarator:
+          '(' gcc_type_attribute_list identifier_declarator ')'
+        {
+          stack_type($1)=typet(ID_abstract);
+          $2=merge($2, $1); // dest=$2
+          make_subtype($3, $2); // dest=$3
+          $$=$3;
+        }
+        | '(' gcc_type_attribute_list identifier_declarator ')' postfixing_abstract_declarator
+        {
+          stack_type($1)=typet(ID_abstract);
+          $2=merge($2, $1); // dest=$2
+          make_subtype($3, $2); // dest=$3
+          /* note: this is (a pointer to) a function ($5) */
+          /* or an array ($5) with name ($3) */
+          $$=$3;
+          make_subtype($$, $5);
+        }
+        | '*' paren_attribute_declarator
+        {
+          $$=$2;
+          do_pointer($1, $2);
+        }
         ;
 
 typedef_declarator:

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -136,6 +136,7 @@ extern char *yyansi_ctext;
 %token TOK_GCC_ATTRIBUTE_GNU_INLINE "__gnu_inline__"
 %token TOK_GCC_ATTRIBUTE_WEAK "weak"
 %token TOK_GCC_ATTRIBUTE_ALIAS "alias"
+%token TOK_GCC_ATTRIBUTE_SECTION "section"
 %token TOK_GCC_ATTRIBUTE_NORETURN "noreturn"
 %token TOK_GCC_ATTRIBUTE_CONSTRUCTOR "constructor"
 %token TOK_GCC_ATTRIBUTE_DESTRUCTOR "destructor"
@@ -1516,6 +1517,8 @@ gcc_type_attribute:
         { $$=$1; set($$, ID_weak); }
         | TOK_GCC_ATTRIBUTE_ALIAS '(' TOK_STRING ')'
         { $$=$1; set($$, ID_alias); mto($$, $3); }
+        | TOK_GCC_ATTRIBUTE_SECTION '(' TOK_STRING ')'
+        { $$=$1; set($$, ID_section); mto($$, $3); }
         | TOK_GCC_ATTRIBUTE_NORETURN
         { $$=$1; set($$, ID_noreturn); }
         | TOK_GCC_ATTRIBUTE_CONSTRUCTOR

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -1476,27 +1476,6 @@ aggregate_key:
         | TOK_UNION
         { $$=$1; set($$, ID_union); }
         ;
-        
-gcc_attribute_expression_list:
-          assignment_expression
-        {
-          init($$, ID_expression_list);
-          mto($$, $1);
-        }
-        | gcc_attribute_expression_list ',' assignment_expression
-        {
-          $$=$1;
-          mto($$, $3);
-        }
-        ;
-
-gcc_attribute_expression_list_opt:
-          /* empty */
-        {
-          init($$, ID_expression_list);
-        }
-        | gcc_attribute_expression_list
-        ;
 
 gcc_type_attribute:
           TOK_GCC_ATTRIBUTE_PACKED
@@ -1531,23 +1510,6 @@ gcc_attribute:
           /* empty */
         {
           init($$);
-        }
-        | TOK_CONST
-        {
-          $$=$1;
-          stack($$).id(ID_gcc_attribute);
-          stack($$).set(ID_identifier, ID_const);
-        }
-        | identifier
-        {
-          $$=$1;
-          stack($$).id(ID_gcc_attribute);
-        }
-        | identifier '(' gcc_attribute_expression_list_opt ')'
-        {
-          $$=$1;
-          stack($$).id(ID_gcc_attribute);
-          stack($$).operands().swap(stack($3).operands());
         }
         | gcc_type_attribute
         ;

--- a/src/ansi-c/parser_static.inc
+++ b/src/ansi-c/parser_static.inc
@@ -193,6 +193,7 @@ static void make_subtype(typet &dest, typet &src)
          src.id()==ID_pointer ||
          src.id()==ID_code ||
          src.id()==ID_merged_type ||
+         src.id()==ID_abstract ||
          src.id()==ID_c_bit_field);
 
   typet *p=&dest;

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -35,6 +35,9 @@ static int isatty(int) { return 0; }
 
 #include "ansi_c_parser.h"
 #include "ansi_c_y.tab.h"
+#ifdef ANSI_C_DEBUG
+extern int yyansi_cdebug;
+#endif
 
 #define loc() \
   { newstack(yyansi_clval); PARSER.set_source_location(stack(yyansi_clval)); }
@@ -208,6 +211,9 @@ string_lit      ("L"|"u"|"U"|"u8")?["]{s_char}*["]
 %{
 void ansi_c_scanner_init()
 {
+#ifdef ANSI_C_DEBUG
+  yyansi_cdebug=1;
+#endif
   YY_FLUSH_BUFFER;
   BEGIN(0);
 }

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -816,14 +816,14 @@ __decltype          { if(PARSER.cpp98 && PARSER.mode==ansi_c_parsert::GCC)
                      PARSER.mode==ansi_c_parsert::CW ||
                      PARSER.mode==ansi_c_parsert::ARM)
                   {
-                    #if 1
                     if(PARSER.cpp98)
                       BEGIN(IGNORE_PARENS);
                     else
+                    {
                       BEGIN(GCC_ATTRIBUTE1);
-                    #else
-                    loc(); return TOK_GCC_ATTRIBUTE;
-                    #endif
+                      loc();
+                      return TOK_GCC_ATTRIBUTE;
+                    }
                   }
                   else
                     return make_identifier();
@@ -1362,7 +1362,7 @@ __decltype          { if(PARSER.cpp98 && PARSER.mode==ansi_c_parsert::GCC)
                 }
 {ws}            { /* ignore */ }
 {newline}       { /* ignore */ }
-"("             { BEGIN(GCC_ATTRIBUTE1a); }
+"("             { BEGIN(GCC_ATTRIBUTE1a); return yytext[0]; }
 .               { BEGIN(GRAMMAR); loc(); return yytext[0]; }
 }
 
@@ -1371,7 +1371,7 @@ __decltype          { if(PARSER.cpp98 && PARSER.mode==ansi_c_parsert::GCC)
                   preprocessor_line(yytext, PARSER);
                   PARSER.set_line_no(PARSER.get_line_no()-1);
                 }
-"("             { BEGIN(GCC_ATTRIBUTE2); PARSER.parenthesis_counter=0; }
+"("             { BEGIN(GCC_ATTRIBUTE2); PARSER.parenthesis_counter=0; return yytext[0]; }
 {ws}            { /* ignore */ }
 {newline}       { /* ignore */ }
 .               { BEGIN(GRAMMAR); loc(); return yytext[0]; }
@@ -1414,7 +1414,7 @@ __decltype          { if(PARSER.cpp98 && PARSER.mode==ansi_c_parsert::GCC)
 {ws}                { /* ignore */ }
 {newline}           { /* ignore */ }
 {identifier}        { BEGIN(GCC_ATTRIBUTE4); }
-")"                 { BEGIN(GCC_ATTRIBUTE5); }
+")"                 { BEGIN(GCC_ATTRIBUTE5); return yytext[0]; }
 .                   { /* ignore */ }
 }
 
@@ -1428,7 +1428,7 @@ __decltype          { if(PARSER.cpp98 && PARSER.mode==ansi_c_parsert::GCC)
                   {
                     BEGIN(GCC_ATTRIBUTE5);
                     loc();
-                    return TOK_GCC_ATTRIBUTE_END;
+                    return yytext[0];
                   }
                   else
                   {
@@ -1441,7 +1441,7 @@ __decltype          { if(PARSER.cpp98 && PARSER.mode==ansi_c_parsert::GCC)
                   {
                     BEGIN(GCC_ATTRIBUTE2);
                     loc();
-                    return TOK_GCC_ATTRIBUTE_END;
+                    return yytext[0];
                   }
                   else
                   {
@@ -1463,12 +1463,21 @@ __decltype          { if(PARSER.cpp98 && PARSER.mode==ansi_c_parsert::GCC)
 <GCC_ATTRIBUTE4>{ // an attribute we just ignore
 "("             { PARSER.parenthesis_counter++; }
 ")"             { if(PARSER.parenthesis_counter==0)
+                  {
                     BEGIN(GCC_ATTRIBUTE5);
+                    loc();
+                    return yytext[0];
+                  }
                   else
                     PARSER.parenthesis_counter--;
                 }
 ","             { if(PARSER.parenthesis_counter==0)
-                    BEGIN(GCC_ATTRIBUTE2); }
+                  {
+                    BEGIN(GCC_ATTRIBUTE2);
+                    loc();
+                    return yytext[0];
+                  }
+                }
 .               { /* Throw away */ }
 }
 
@@ -1477,7 +1486,7 @@ __decltype          { if(PARSER.cpp98 && PARSER.mode==ansi_c_parsert::GCC)
                   preprocessor_line(yytext, PARSER);
                   PARSER.set_line_no(PARSER.get_line_no()-1);
                 }
-")"             { BEGIN(GRAMMAR); }
+")"             { BEGIN(GRAMMAR); loc(); return yytext[0]; }
 {ws}            { /* Throw away */ }
 {newline}       { /* Throw away */ }
 .               { BEGIN(GRAMMAR); loc(); return yytext[0]; }

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -1402,6 +1402,9 @@ __decltype          { if(PARSER.cpp98 && PARSER.mode==ansi_c_parsert::GCC)
 "alias" |
 "__alias__"          { BEGIN(GCC_ATTRIBUTE3); loc(); return TOK_GCC_ATTRIBUTE_ALIAS; }
 
+"section" |
+"__section__"       { BEGIN(GCC_ATTRIBUTE3); loc(); return TOK_GCC_ATTRIBUTE_SECTION; }
+
 "noreturn" |
 "__noreturn__"      { BEGIN(GCC_ATTRIBUTE3); loc(); return TOK_GCC_ATTRIBUTE_NORETURN; }
 

--- a/src/util/irep_ids.txt
+++ b/src/util/irep_ids.txt
@@ -725,3 +725,4 @@ C_spec_ensures #spec_ensures
 virtual_function
 C_element_type #element_type
 working_directory
+section

--- a/src/util/irep_ids.txt
+++ b/src/util/irep_ids.txt
@@ -529,7 +529,6 @@ explicit
 storage_spec
 member_spec
 msc_declspec
-gcc_attribute
 packed
 C_packed #packed
 transparent_union


### PR DESCRIPTION
Includes support for __attribute__((section("foo"))) and fixes existing regression tests that were marked KNOWNBUG. Built on top of #50, hence half of the patch series is redundant.