### PR TITLE
change java bool type representation

### DIFF
--- a/src/java_bytecode/java_types.cpp
+++ b/src/java_bytecode/java_types.cpp
@@ -164,7 +164,7 @@ Function: java_boolean_type
 
 typet java_boolean_type()
 {
-  return c_bool_typet(8);
+  return signedbv_typet(32);
 }
 
 /*******************************************************************\


### PR DESCRIPTION
The JVM does not fully support a Boolean type. Instead, it uses an
32-bit integral type with value 0 for false and 1 for true (cf. 2.3.4 of
the JVM Spec). In particular, the bytecodes iconst_0 and iconst_1 are
used for false and true.