### PR TITLE
Output source location with all type checking errors

### DIFF
--- a/src/ansi-c/c_typecheck_argc_argv.cpp
+++ b/src/ansi-c/c_typecheck_argc_argv.cpp
@@ -35,7 +35,8 @@ void c_typecheck_baset::add_argc_argv(const symbolt &main_symbol)
      parameters.size()!=3)
   {
     err_location(main_symbol.location);
-    throw "main expected to have no or two or three parameters";
+    str << "main expected to have no or two or three parameters";
+    throw 0;
   }
 
   symbolt *argc_new_symbol;

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -71,8 +71,9 @@ void c_typecheck_baset::move_symbol(symbolt &symbol, symbolt *&new_symbol)
   if(symbol_table.move(symbol, new_symbol))
   {
     err_location(symbol.location);
-    throw "failed to move symbol `"+id2string(symbol.name)+
-          "' into symbol table";
+    str << "failed to move symbol `" << symbol.name
+        << "' into symbol table";
+    throw 0;
   }
 }
 
@@ -117,7 +118,8 @@ void c_typecheck_baset::typecheck_symbol(symbolt &symbol)
   else if(!is_function && symbol.value.id()==ID_code)
   {
     err_location(symbol.value);
-    throw "only functions can have a function body";
+    str << "only functions can have a function body";
+    throw 0;
   }
   
   // set the pretty name
@@ -371,7 +373,8 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
     if(final_new.id()==ID_code)
     {
       err_location(new_symbol.location);
-      throw "function type not allowed for K&R function parameter";
+      str << "function type not allowed for K&R function parameter";
+      throw 0;
     }
     
     // fix up old symbol -- we now got the type
@@ -446,7 +449,6 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
           err_location(new_symbol.location);
           str << "function body `" << new_symbol.display_name()
               << "' defined twice";
-          error_msg();
           throw 0;
         }
       }

--- a/src/ansi-c/c_typecheck_code.cpp
+++ b/src/ansi-c/c_typecheck_code.cpp
@@ -44,7 +44,11 @@ Function: c_typecheck_baset::typecheck_code
 void c_typecheck_baset::typecheck_code(codet &code)
 {
   if(code.id()!=ID_code)
-    throw "expected code, got "+code.pretty();
+  {
+    err_location(code);
+    str << "expected code, got " << code.pretty();
+    throw 0;
+  }
 
   code.type()=code_typet();
 
@@ -205,7 +209,11 @@ Function: c_typecheck_baset::typecheck_assign
 void c_typecheck_baset::typecheck_assign(codet &code)
 {
   if(code.operands().size()!=2)
-    throw "assignment statement expected to have two operands";
+  {
+    err_location(code);
+    str << "assignment statement expected to have two operands";
+    throw 0;
+  }
 
   typecheck_expr(code.op0());
   typecheck_expr(code.op1());
@@ -280,7 +288,8 @@ void c_typecheck_baset::typecheck_break(codet &code)
   if(!break_is_allowed)
   {
     err_location(code);
-    throw "break not allowed here";
+    str << "break not allowed here";
+    throw 0;
   }
 }
 
@@ -301,7 +310,8 @@ void c_typecheck_baset::typecheck_continue(codet &code)
   if(!continue_is_allowed)
   {
     err_location(code);
-    throw "continue not allowed here";
+    str << "continue not allowed here";
+    throw 0;
   }
 }
 
@@ -323,14 +333,16 @@ void c_typecheck_baset::typecheck_decl(codet &code)
   if(code.operands().size()!=1)
   {
     err_location(code);
-    throw "decl expected to have 1 operand";
+    str << "decl expected to have 1 operand";
+    throw 0;
   }
 
   // op0 must be declaration
   if(code.op0().id()!=ID_declaration)
   {
     err_location(code);
-    throw "decl statement expected to have declaration as operand";
+    str << "decl statement expected to have declaration as operand";
+    throw 0;
   }
 
   ansi_c_declarationt declaration;
@@ -381,7 +393,8 @@ void c_typecheck_baset::typecheck_decl(codet &code)
        !is_complete_type(symbol.type))
     {
       err_location(symbol.location);
-      throw "incomplete type not permitted here";
+      str << "incomplete type not permitted here";
+      throw 0;
     }
   
     // see if it's a typedef
@@ -489,7 +502,11 @@ Function: c_typecheck_baset::typecheck_expression
 void c_typecheck_baset::typecheck_expression(codet &code)
 {
   if(code.operands().size()!=1)
-    throw "expression statement expected to have one operand";
+  {
+    err_location(code);
+    str << "expression statement expected to have one operand";
+    throw 0;
+  }
 
   exprt &op=code.op0();
   typecheck_expr(op);
@@ -510,7 +527,11 @@ Function: c_typecheck_baset::typecheck_for
 void c_typecheck_baset::typecheck_for(codet &code)
 {
   if(code.operands().size()!=4)
-    throw "for expected to have four operands";
+  {
+    err_location(code);
+    str << "for expected to have four operands";
+    throw 0;
+  }
     
   // the "for" statement has an implicit block around it,
   // since code.op0() may contain declarations
@@ -627,7 +648,8 @@ void c_typecheck_baset::typecheck_switch_case(code_switch_caset &code)
   if(code.operands().size()!=2)
   {
     err_location(code);
-    throw "switch_case expected to have two operands";
+    str << "switch_case expected to have two operands";
+    throw 0;
   }
 
   typecheck_code(code.code());
@@ -637,7 +659,8 @@ void c_typecheck_baset::typecheck_switch_case(code_switch_caset &code)
     if(!case_is_allowed)
     {
       err_location(code);
-      throw "did not expect default label here";
+      str << "did not expect default label here";
+      throw 0;
     }
   }
   else
@@ -645,7 +668,8 @@ void c_typecheck_baset::typecheck_switch_case(code_switch_caset &code)
     if(!case_is_allowed)
     {
       err_location(code);
-      throw "did not expect `case' here";
+      str << "did not expect `case' here";
+      throw 0;
     }
   
     exprt &case_expr=code.case_op();
@@ -671,7 +695,8 @@ void c_typecheck_baset::typecheck_gcc_switch_case_range(codet &code)
   if(code.operands().size()!=3)
   {
     err_location(code);
-    throw "gcc_switch_case_range expected to have three operands";
+    str << "gcc_switch_case_range expected to have three operands";
+    throw 0;
   }
 
   typecheck_code(to_code(code.op2()));
@@ -679,7 +704,8 @@ void c_typecheck_baset::typecheck_gcc_switch_case_range(codet &code)
   if(!case_is_allowed)
   {
     err_location(code);
-    throw "did not expect `case' here";
+    str << "did not expect `case' here";
+    throw 0;
   }
 
   typecheck_expr(code.op0());
@@ -741,7 +767,8 @@ void c_typecheck_baset::typecheck_gcc_computed_goto(codet &code)
   if(code.operands().size()!=1)
   {
     err_location(code);
-    throw "computed-goto expected to have one operand";
+    str << "computed-goto expected to have one operand";
+    throw 0;
   }
 
   exprt &dest=code.op0();
@@ -749,7 +776,8 @@ void c_typecheck_baset::typecheck_gcc_computed_goto(codet &code)
   if(dest.id()!=ID_dereference)
   {
     err_location(dest);
-    throw "computed-goto expected to have dereferencing operand";
+    str << "computed-goto expected to have dereferencing operand";
+    throw 0;
   }
   
   assert(dest.operands().size()==1);
@@ -773,7 +801,11 @@ Function: c_typecheck_baset::typecheck_ifthenelse
 void c_typecheck_baset::typecheck_ifthenelse(code_ifthenelset &code)
 {
   if(code.operands().size()!=3)
-    throw "ifthenelse expected to have three operands";
+  {
+    err_location(code);
+    str << "ifthenelse expected to have three operands";
+    throw 0;
+  }
 
   exprt &cond=code.cond();
 
@@ -831,7 +863,11 @@ Function: c_typecheck_baset::typecheck_start_thread
 void c_typecheck_baset::typecheck_start_thread(codet &code)
 {
   if(code.operands().size()!=1)
-    throw "start_thread expected to have one operand";
+  {
+    err_location(code);
+    str << "start_thread expected to have one operand";
+    throw 0;
+  }
 
   typecheck_code(to_code(code.op0()));
 }
@@ -876,7 +912,8 @@ void c_typecheck_baset::typecheck_return(codet &code)
   else
   {
     err_location(code);
-    throw "return expected to have 0 or 1 operands";
+    str << "return expected to have 0 or 1 operands";
+    throw 0;
   }
 }
 
@@ -895,7 +932,11 @@ Function: c_typecheck_baset::typecheck_switch
 void c_typecheck_baset::typecheck_switch(code_switcht &code)
 {
   if(code.operands().size()!=2)
-    throw "switch expects two operands";
+  {
+    err_location(code);
+    str << "switch expects two operands";
+    throw 0;
+  }
 
   typecheck_expr(code.value());
 
@@ -934,7 +975,11 @@ Function: c_typecheck_baset::typecheck_while
 void c_typecheck_baset::typecheck_while(code_whilet &code)
 {
   if(code.operands().size()!=2)
-    throw "while expected to have two operands";
+  {
+    err_location(code);
+    str << "while expected to have two operands";
+    throw 0;
+  }
 
   typecheck_expr(code.cond());
   implicit_typecast_bool(code.cond());
@@ -977,7 +1022,11 @@ Function: c_typecheck_baset::typecheck_dowhile
 void c_typecheck_baset::typecheck_dowhile(code_dowhilet &code)
 {
   if(code.operands().size()!=2)
-    throw "do while expected to have two operands";
+  {
+    err_location(code);
+    str << "do while expected to have two operands";
+    throw 0;
+  }
 
   typecheck_expr(code.cond());
   implicit_typecast_bool(code.cond());

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -289,7 +289,8 @@ void c_typecheck_baset::typecheck_expr_main(exprt &expr)
     if(expr.op0().get(ID_statement)!=ID_decl)
     {
       err_location(expr);
-      throw "expected declaration as operand of quantifier";
+      str << "expected declaration as operand of quantifier";
+      throw 0;
     }
 
     // replace declaration by symbol expression
@@ -320,8 +321,9 @@ void c_typecheck_baset::typecheck_expr_main(exprt &expr)
       if(!is_number(op_type))
       {
         err_location(expr.op0());
-        throw "real/imag expect numerical operand, "
-              "but got `"+to_string(op_type)+"'";
+        str << "real/imag expect numerical operand, "
+            << "but got `" << to_string(op_type) << "'";
+        throw 0;
       }
 
       // we could compile away, I suppose      
@@ -349,7 +351,8 @@ void c_typecheck_baset::typecheck_expr_main(exprt &expr)
     if(expr.operands().size()!=1)
     {
       err_location(expr);
-      throw "_Generic expects one operand";
+      str << "_Generic expects one operand";
+      throw 0;
     }
 
     // This is one of the few places where it's detectable
@@ -547,7 +550,8 @@ void c_typecheck_baset::typecheck_expr_builtin_offsetof(exprt &expr)
   if(!expr.operands().empty())
   {
     err_location(expr);
-    throw "builtin_offsetof expects no operands";
+    str << "builtin_offsetof expects no operands";
+    throw 0;
   }
 
   typet &type=static_cast<typet &>(expr.add(ID_type_arg));
@@ -567,8 +571,9 @@ void c_typecheck_baset::typecheck_expr_builtin_offsetof(exprt &expr)
       if(type.id()!=ID_union && type.id()!=ID_struct)
       {
         err_location(expr);
-        throw "offsetof of member expects struct/union type, "
-              "but got `"+to_string(type)+"'";
+        str << "offsetof of member expects struct/union type, "
+            << "but got `" << to_string(type) << "'";
+        throw 0;
       }
       
       bool found=false;
@@ -656,8 +661,9 @@ void c_typecheck_baset::typecheck_expr_builtin_offsetof(exprt &expr)
           if(!found2)
           {
             err_location(expr);    
-            throw "offset-of of member failed to find component `"+
-                  id2string(component_name)+"' in `"+to_string(type)+"'";
+            str << "offset-of of member failed to find component `"
+                << component_name << "' in `" << to_string(type) << "'";
+            throw 0;
           }
         }
       }
@@ -669,7 +675,8 @@ void c_typecheck_baset::typecheck_expr_builtin_offsetof(exprt &expr)
       if(type.id()!=ID_array)
       {
         err_location(expr);
-        throw "offsetof of index expects array type";
+        str << "offsetof of index expects array type";
+        throw 0;
       }
 
       exprt index=m_it->op0();
@@ -733,7 +740,8 @@ void c_typecheck_baset::typecheck_expr_operands(exprt &expr)
     if(declaration.declarators().size()!=1)
     {
       err_location(expr);
-      throw "expected one declarator exactly";
+      str << "expected one declarator exactly";
+      throw 0;
     }
 
     irep_idt identifier=
@@ -757,7 +765,8 @@ void c_typecheck_baset::typecheck_expr_operands(exprt &expr)
        !is_complete_type(symbol.type) || symbol.type.id()==ID_code)
     {
       err_location(expr);
-      throw "unexpected quantified symbol";
+      str << "unexpected quantified symbol";
+      throw 0;
     }
     
     code_declt decl;
@@ -1567,7 +1576,6 @@ void c_typecheck_baset::typecheck_expr_ptrmember(exprt &expr)
   {
     err_location(expr);
     str << "ptrmember operator expects one operand";
-    error_msg();
     throw 0;
   }
 
@@ -1615,7 +1623,6 @@ void c_typecheck_baset::typecheck_expr_member(exprt &expr)
   {
     err_location(expr);
     str << "member operator expects one operand";
-    error_msg();
     throw 0;
   }
 
@@ -1827,7 +1834,6 @@ void c_typecheck_baset::typecheck_side_effect_gcc_conditional_expression(
   {
     err_location(expr);
     str << "gcc conditional_expr expects two operands";
-    error_msg();
     throw 0;
   }
 
@@ -1865,7 +1871,6 @@ void c_typecheck_baset::typecheck_expr_address_of(exprt &expr)
   {
     err_location(expr);
     str << "unary operator & expects one operand";
-    error_msg();
     throw 0;
   }
 
@@ -1875,7 +1880,6 @@ void c_typecheck_baset::typecheck_expr_address_of(exprt &expr)
   {
     err_location(expr);
     str << "cannot take address of a bit field";
-    error_msg();
     throw 0;
   }
   
@@ -2133,7 +2137,8 @@ void c_typecheck_baset::typecheck_side_effect_function_call(
   if(expr.operands().size()!=2)
   {
     err_location(expr);
-    throw "function_call side effect expects two operands";
+    str << "function_call side effect expects two operands";
+    throw 0;
   }
 
   exprt &f_op=expr.function();
@@ -2215,7 +2220,8 @@ void c_typecheck_baset::typecheck_side_effect_function_call(
   if(f_op.type().id()!=ID_code)
   {
     err_location(f_op);
-    throw "expected code as argument";
+    str << "expected code as argument";
+    throw 0;
   }
 
   const code_typet &code_type=to_code_type(f_op.type());
@@ -2259,7 +2265,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=2)
     {
       err_location(f_op);
-      throw "same_object expects two operands";
+      str << "same_object expects two operands";
+      throw 0;
     }
 
     exprt same_object_expr=same_object(expr.arguments()[0], expr.arguments()[1]);
@@ -2272,7 +2279,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=2)
     {
       err_location(f_op);
-      throw "get_must expects two operands";
+      str << "get_must expects two operands";
+      throw 0;
     }
 
     typecheck_function_call_arguments(expr);
@@ -2288,7 +2296,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=2)
     {
       err_location(f_op);
-      throw "get_may expects two operands";
+      str << "get_may expects two operands";
+      throw 0;
     }
 
     typecheck_function_call_arguments(expr);
@@ -2304,7 +2313,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=1)
     {
       err_location(f_op);
-      throw "invalid_pointer expects one operand";
+      str << "invalid_pointer expects one operand";
+      throw 0;
     }
 
     predicate_exprt same_object_expr(ID_invalid_pointer);
@@ -2318,7 +2328,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=1)
     {
       err_location(f_op);
-      throw "buffer_size expects one operand";
+      str << "buffer_size expects one operand";
+      throw 0;
     }
 
     exprt buffer_size_expr("buffer_size", size_type());
@@ -2332,7 +2343,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=1)
     {
       err_location(f_op);
-      throw "is_zero_string expects one operand";
+      str << "is_zero_string expects one operand";
+      throw 0;
     }
 
     predicate_exprt is_zero_string_expr("is_zero_string");
@@ -2347,7 +2359,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=1)
     {
       err_location(f_op);
-      throw "zero_string_length expects one operand";
+      str << "zero_string_length expects one operand";
+      throw 0;
     }
 
     exprt zero_string_length_expr("zero_string_length", size_type());
@@ -2360,7 +2373,11 @@ exprt c_typecheck_baset::do_special_functions(
   else if(identifier==CPROVER_PREFIX "DYNAMIC_OBJECT")
   {
     if(expr.arguments().size()!=1)
-      throw "dynamic_object expects one argument";
+    {
+      err_location(f_op);
+      str << "dynamic_object expects one argument";
+      throw 0;
+    }
 
     exprt dynamic_object_expr=exprt(ID_dynamic_object, expr.type());
     dynamic_object_expr.operands()=expr.arguments();
@@ -2371,7 +2388,11 @@ exprt c_typecheck_baset::do_special_functions(
   else if(identifier==CPROVER_PREFIX "POINTER_OFFSET")
   {
     if(expr.arguments().size()!=1)
-      throw "pointer_offset expects one argument";
+    {
+      err_location(f_op);
+      str << "pointer_offset expects one argument";
+      throw 0;
+    }
 
     exprt pointer_offset_expr=exprt(ID_pointer_offset, expr.type());
     pointer_offset_expr.operands()=expr.arguments();
@@ -2382,7 +2403,11 @@ exprt c_typecheck_baset::do_special_functions(
   else if(identifier==CPROVER_PREFIX "POINTER_OBJECT")
   {
     if(expr.arguments().size()!=1)
-      throw "pointer_object expects one argument";
+    {
+      err_location(f_op);
+      str << "pointer_object expects one argument";
+      throw 0;
+    }
 
     exprt pointer_object_expr=exprt(ID_pointer_object, expr.type());
     pointer_object_expr.operands()=expr.arguments();
@@ -2398,7 +2423,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=1)
     {
       err_location(f_op);
-      throw "isnan expects one operand";
+      str << "isnan expects one operand";
+      throw 0;
     }
 
     exprt isnan_expr(ID_isnan, bool_typet());
@@ -2414,7 +2440,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=1)
     {
       err_location(f_op);
-      throw "isfinite expects one operand";
+      str << "isfinite expects one operand";
+      throw 0;
     }
 
     exprt isfinite_expr(ID_isfinite, bool_typet());
@@ -2459,7 +2486,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=1)
     {
       err_location(f_op);
-      throw "abs-functions expect one operand";
+      str << "abs-functions expect one operand";
+      throw 0;
     }
 
     exprt abs_expr(ID_abs, expr.type());
@@ -2473,7 +2501,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=1)
     {
       err_location(f_op);
-      throw "malloc expects one operand";
+      str << "malloc expects one operand";
+      throw 0;
     }
 
     exprt malloc_expr=side_effect_exprt(ID_malloc);
@@ -2491,7 +2520,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=1)
     {
       err_location(f_op);
-      throw "isinf expects one operand";
+      str << "isinf expects one operand";
+      throw 0;
     }
 
     exprt isinf_expr(ID_isinf, bool_typet());
@@ -2507,7 +2537,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=1)
     {
       err_location(f_op);
-      throw "isnormal expects one operand";
+      str << "isnormal expects one operand";
+      throw 0;
     }
 
     exprt isnormal_expr(ID_isnormal, bool_typet());
@@ -2526,7 +2557,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=1)
     {
       err_location(f_op);
-      throw "sign expects one operand";
+      str << "sign expects one operand";
+      throw 0;
     }
 
     exprt sign_expr(ID_sign, bool_typet());
@@ -2545,7 +2577,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=1)
     {
       err_location(f_op);
-      throw id2string(identifier)+" expects one operand";
+      str << id2string(identifier)+" expects one operand";
+      throw 0;
     }
 
     exprt popcount_expr(ID_popcount, expr.type());
@@ -2559,7 +2592,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=2)
     {
       err_location(f_op);
-      throw "equal expects two operands";
+      str << "equal expects two operands";
+      throw 0;
     }
     
     equal_exprt equality_expr;
@@ -2570,7 +2604,8 @@ exprt c_typecheck_baset::do_special_functions(
                      equality_expr.rhs().type(), *this))
     {
       err_location(f_op);
-      throw "equal expects two operands of same type";
+      str << "equal expects two operands of same type";
+      throw 0;
     }
 
     return equality_expr;
@@ -2586,7 +2621,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=2)
     {
       err_location(f_op);
-      throw "__builtin_expect expects two arguments";
+      str << "__builtin_expect expects two arguments";
+      throw 0;
     }
 
     return typecast_exprt(expr.arguments()[0], expr.type());
@@ -2600,7 +2636,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=2)
     {
       err_location(f_op);
-      throw "__builtin_object_size expects two arguments";
+      str << "__builtin_object_size expects two arguments";
+      throw 0;
     }
 
     make_constant(expr.arguments()[1]);
@@ -2641,7 +2678,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=3)
     {
       err_location(f_op);
-      throw "__builtin_choose_expr expects three arguments";
+      str << "__builtin_choose_expr expects three arguments";
+      throw 0;
     }
     
     expr.arguments()[0].make_typecast(bool_typet());
@@ -2659,7 +2697,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=1)
     {
       err_location(f_op);
-      throw "__builtin_constant_p expects one argument";
+      str << "__builtin_constant_p expects one argument";
+      throw 0;
     }
 
     // try to produce constant
@@ -2695,7 +2734,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=1)
     {
       err_location(f_op);
-      throw "__builtin_classify_type expects one argument";
+      str << "__builtin_classify_type expects one argument";
+      throw 0;
     }
     
     exprt object=expr.arguments()[0];
@@ -2730,7 +2770,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()!=2)
     {
       err_location(f_op);
-      throw "float_debug expects two operands";
+      str << "float_debug expects two operands";
+      throw 0;
     }
 
     const irep_idt &id=
@@ -2766,7 +2807,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(expr.arguments().size()<1)
     {
       err_location(f_op);
-      throw "__sync_* primitives take as least one argument";
+      str << "__sync_* primitives take as least one argument";
+      throw 0;
     }
     
     exprt &ptr_arg=expr.arguments().front();
@@ -2774,7 +2816,8 @@ exprt c_typecheck_baset::do_special_functions(
     if(ptr_arg.type().id()!=ID_pointer)
     {
       err_location(f_op);
-      throw "__sync_* primitives take pointer as first argument";
+      str << "__sync_* primitives take pointer as first argument";
+      throw 0;
     }
     
     expr.type()=expr.arguments().front().type().subtype();
@@ -2825,7 +2868,8 @@ void c_typecheck_baset::typecheck_function_call_arguments(
     if(parameter_types.size()>arguments.size())
     {
       err_location(expr);
-      throw "not enough function arguments";
+      str << "not enough function arguments";
+      throw 0;
     }
   }
   else if(parameter_types.size()!=arguments.size())
@@ -3231,7 +3275,8 @@ void c_typecheck_baset::typecheck_arithmetic_pointer(const exprt &expr)
   if(subtype.id()==ID_incomplete_struct)
   {
     err_location(expr);
-    throw "pointer arithmetic with unknown object size";
+    str << "pointer arithmetic with unknown object size";
+    throw 0;
   }
 }
 
@@ -3621,7 +3666,8 @@ void c_typecheck_baset::make_constant_index(exprt &expr)
      expr.id()!=ID_infinity)
   {
     err_location(expr.find_source_location());
-    throw "conversion to integer constant failed";
+    str << "conversion to integer constant failed";
+    throw 0;
   }
 }
 

--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -52,7 +52,8 @@ void c_typecheck_baset::do_initializer(
     if(result.id()!=ID_array)
     {
       err_location(result);
-      throw "invalid array initializer";
+      str << "invalid array initializer " << to_string(result);
+      throw 0;
     }
   }
     
@@ -113,13 +114,16 @@ exprt c_typecheck_baset::do_initializer_rec(
       if(to_integer(to_array_type(full_type).size(), array_size))
       {
         err_location(value);
-        throw "array size needs to be constant";
+        str << "array size needs to be constant, got "
+            << to_string(to_array_type(full_type).size());
+        throw 0;
       }
       
       if(array_size<0)
       {
         err_location(value);
-        throw "array size must not be negative";
+        str << "array size must not be negative";
+        throw 0;
       }
 
       if(mp_integer(tmp.operands().size())>array_size)
@@ -163,13 +167,16 @@ exprt c_typecheck_baset::do_initializer_rec(
       if(to_integer(to_array_type(full_type).size(), array_size))
       {
         err_location(value);
-        throw "array size needs to be constant";
+        str << "array size needs to be constant, got "
+            << to_string(to_array_type(full_type).size());
+        throw 0;
       }
       
       if(array_size<0)
       {
         err_location(value);
-        throw "array size must not be negative";
+        str << "array size must not be negative";
+        throw 0;
       }
 
       if(mp_integer(tmp2.operands().size())>array_size)
@@ -704,7 +711,8 @@ designatort c_typecheck_baset::make_designator(
       if(d_op.id()!=ID_index)
       {
         err_location(d_op);
-        throw "expected array index designator";
+        str << "expected array index designator";
+        throw 0;
       }
 
       assert(d_op.operands().size()==1);
@@ -716,7 +724,8 @@ designatort c_typecheck_baset::make_designator(
       if(to_integer(tmp_index, index))
       {
         err_location(d_op.op0());
-        throw "expected constant array index designator";
+        str << "expected constant array index designator";
+        throw 0;
       }
 
       if(to_array_type(full_type).size().is_nil())
@@ -724,7 +733,8 @@ designatort c_typecheck_baset::make_designator(
       else if(to_integer(to_array_type(full_type).size(), size))
       {
         err_location(d_op.op0());
-        throw "expected constant array size";
+        str << "expected constant array size";
+        throw 0;
       }
       
       entry.index=integer2long(index);
@@ -739,7 +749,8 @@ designatort c_typecheck_baset::make_designator(
       if(d_op.id()!=ID_member)
       {
         err_location(d_op);
-        throw "expected member designator";
+        str << "expected member designator";
+        throw 0;
       }
 
       const irep_idt &component_name=d_op.get(ID_component_name);


### PR DESCRIPTION
Also cleanup: remove error_msg() calls that are only sometimes present;
exception handler will take care of outputting the error message.