### PR TITLE
Proper C++ includes

### DIFF
--- a/src/analyses/invariant_set.h
+++ b/src/analyses/invariant_set.h
@@ -9,11 +9,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_CEGAR_INVARIANT_SET_H
 #define CPROVER_CEGAR_INVARIANT_SET_H
 
-/*
-#include <ref_expr_set.h>
-
-*/
-
 #include <util/std_code.h>
 #include <util/numbering.h>
 #include <util/union_find.h>

--- a/src/big-int/bigint-test.cc
+++ b/src/big-int/bigint-test.cc
@@ -6,9 +6,9 @@
 #include "allocainc.h"
 
 #include <new>
-#include <errno.h>
-#include <stdio.h>
-#include <string.h>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
 
 
 // =====================================================================

--- a/src/big-int/bigint.cc
+++ b/src/big-int/bigint.cc
@@ -8,12 +8,12 @@
 #include "bigint.hh"
 #include "allocainc.h"
 
-#include <ctype.h>
-#include <limits.h>
-#include <string.h>
+#include <cctype>
+#include <climits>
+#include <cstring>
 
 // How to report errors.
-#include <stdio.h>
+#include <cstdio>
 #define error(x) fprintf (stderr, "%s\n", x)
 
 

--- a/src/json/json_parser.cpp
+++ b/src/json/json_parser.cpp
@@ -6,9 +6,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-#include <stdlib.h>
-#include <string.h>
-
 #include <fstream>
 
 #include "json_parser.h"

--- a/src/util/lispexpr.h
+++ b/src/util/lispexpr.h
@@ -12,7 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_LISPEXPR_H
 
 #if defined(_WIN32) && !defined(__MINGW32__)
-#include <string.h>
+#include <cstring>
 #define strcasecmp _strcmpi
 #else
 #include <strings.h>

--- a/src/util/pipe_stream.cpp
+++ b/src/util/pipe_stream.cpp
@@ -20,7 +20,7 @@ Author:
 #include <sys/wait.h>
 #include <signal.h>
 #include <unistd.h>
-#include <string.h>
+#include <cstring>
 #endif
 
 #define READ_BUFFER_SIZE 1024

--- a/src/util/string_container.cpp
+++ b/src/util/string_container.cpp
@@ -6,7 +6,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-#include <string.h>
+#include <cstring>
 
 #include "string_container.h"
 

--- a/src/xmllang/parser.y
+++ b/src/xmllang/parser.y
@@ -1,5 +1,5 @@
 %{
-#include <string.h>
+#include <cstring>
 
 #include "xml_parser.h"
 

--- a/src/xmllang/scanner.l
+++ b/src/xmllang/scanner.l
@@ -8,9 +8,9 @@
 static int isatty(int) { return 0; }
 #endif
 
-#include <ctype.h>
-#include <string.h>
-#include <stdlib.h>
+#include <cctype>
+#include <cstring>
+#include <cstdlib>
 
 #include "xml_parser.h"
 #include "xml_y.tab.h"

--- a/src/xmllang/xml_parser.cpp
+++ b/src/xmllang/xml_parser.cpp
@@ -6,9 +6,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-#include <stdlib.h>
-#include <string.h>
-
+#include <cstdlib>
+#include <cstring>
 #include <fstream>
 
 #include "xml_parser.h"


### PR DESCRIPTION
Use C++ headers instead of C-style ones wherever possible. (Some of them could likely be removed entirely.)