### PR TITLE
Successfully producing a formula with --outfile should not yield non-zero exit

### DIFF
--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -598,7 +598,7 @@ safety_checkert::resultt bmct::stop_on_fail(
   default:
     if(options.get_bool_option("dimacs") ||
        options.get_option("outfile")!="")
-      return ERROR;
+      return SAFE;
       
     error() << "decision procedure failed" << eom;
 


### PR DESCRIPTION
If there's a design decision that SAFE/exit 0 should only ever be returned when safety is proven, and --outfile thus correctly has a non-zero exit code, then the regression test Malloc22 must be fixed instead.