### PR TITLE
Array initialization with a non-array is expected to fail

### DIFF
--- a/regression/ansi-c/Struct_Initialization1/test.desc
+++ b/regression/ansi-c/Struct_Initialization1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/Struct_Initialization2/main.c
+++ b/regression/ansi-c/Struct_Initialization2/main.c
@@ -4,6 +4,7 @@
 struct A {
   int x;
   int y;
+  int arr[];
 };
 
 struct _classinfo {
@@ -12,8 +13,8 @@ struct _classinfo {
   int *interfaces[];
 };
 
-struct _classinfo nullclass1 = { 42, 1, 2, 3, 4 };
-struct _classinfo nullclass2 = { 42, { 1, 2 }, { 3, 4 } };
+struct _classinfo nullclass1 = { 42, 1, 2, 0, 3, 4 };
+struct _classinfo nullclass2 = { 42, { 1, 2, 0 }, { 3, 4 } };
 
 STATIC_ASSERT(sizeof(nullclass1)==sizeof(struct _classinfo));
 STATIC_ASSERT(sizeof(nullclass2)==sizeof(struct _classinfo));

--- a/regression/ansi-c/Struct_Initialization2/test.desc
+++ b/regression/ansi-c/Struct_Initialization2/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+
+^EXIT=(64|1)$
+^SIGNAL=0$
+^CONVERSION ERROR$
+--
+^warning: ignoring
+--
+variable-length arrays in the middle of a struct are not permitted

--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -89,10 +89,11 @@ protected:
     const typet &type,
     bool force_constant);
 
-  virtual void do_designated_initializer(
+  virtual exprt::operandst::const_iterator do_designated_initializer(
     exprt &result,
     designatort &designator,
-    const exprt &value,
+    const exprt &initializer_list,
+    exprt::operandst::const_iterator init_it,
     bool force_constant);
 
   designatort make_designator(const typet &type, const exprt &src);

--- a/src/ansi-c/designator.h
+++ b/src/ansi-c/designator.h
@@ -24,9 +24,11 @@ public:
   {
     size_t index;
     size_t size;
+    bool vla_permitted;
     typet type, subtype;
 
-    entryt():index(0), size(0)
+    explicit entryt(const typet &type):
+      index(0), size(0), vla_permitted(false), type(type)
     {
     }
   };


### PR DESCRIPTION
In the past, this failed an internal assertion; nowadays a proper error is
reported to the user. clang -Werror says:

```
Struct_Initialization1/main.c:9:38: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
struct _classinfo nullclass1 = { 42, 0, 0 };
                                     ^~~~
                                     {   }
1 error generated.
```
