### PR TITLE
pragma pack(n) still permits more dense alignment than n

### DIFF
--- a/regression/ansi-c/pragma_pack3/main.c
+++ b/regression/ansi-c/pragma_pack3/main.c
@@ -13,6 +13,29 @@ struct S
 
 STATIC_ASSERT(sizeof(struct S)==sizeof(int)+2);
 
+// "The alignment of a member will be on a boundary that is either a multiple of
+// n or a multiple of the size of the member, whichever is smaller."
+#pragma pack(4)
+
+struct S2
+{
+  short s1;
+  short s2;
+  int i;
+};
+
+STATIC_ASSERT(sizeof(struct S2)==sizeof(short)+sizeof(short)+sizeof(int));
+
+struct S3
+{
+  short s1;
+  short s2;
+  short s3;
+  int i;
+};
+
+STATIC_ASSERT(sizeof(struct S3)==sizeof(short)+sizeof(short)+sizeof(int)+4);
+
 int main()
 {
   return 0;

--- a/src/ansi-c/ansi_c_convert_type.cpp
+++ b/src/ansi-c/ansi_c_convert_type.cpp
@@ -33,14 +33,6 @@ void ansi_c_convert_typet::read(const typet &type)
   clear();
   source_location=type.source_location();
   read_rec(type);
-
-  if(!aligned &&
-     type.find(ID_C_alignment).is_not_nil())
-  {
-    aligned=true;
-
-    alignment=static_cast<const exprt &>(type.find(ID_C_alignment));
-  }
 }
 
 /*******************************************************************\

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -1605,7 +1605,19 @@ member_declaring_list:
         {
           if(!PARSER.pragma_pack.empty() &&
              !PARSER.pragma_pack.back().is_zero())
-            stack($2).set(ID_C_alignment, PARSER.pragma_pack.back());
+          {
+            // communicate #pragma pack(n) alignment constraints by
+            // by both setting packing AND alignment; see padding.cpp
+            // for more details
+            init($$);
+            set($$, ID_packed);
+            $2=merge($2, $$);
+
+            init($$);
+            set($$, ID_aligned);
+            stack($$).set(ID_size, PARSER.pragma_pack.back());
+            $2=merge($2, $$);
+          }
 
           $2=merge($2, $1);
 


### PR DESCRIPTION
Quoting the documentation: "The alignment of a member will be on a
boundary that is either a multiple of n or a multiple of the size of the
member, whichever is smaller."