### PR TITLE
GCC mode of goto-cc uses GCC's exit code, proper cleanup of files

### DIFF
--- a/regression/ansi-c/struct6/test.desc
+++ b/regression/ansi-c/struct6/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 
-^EXIT=64$
+^EXIT=\(64\|1\)$
 ^SIGNAL=0$
 ^file main.c line 2: incomplete type not permitted here$
 ^CONVERSION ERROR$

--- a/regression/cpp/Address_of_Method2/test.desc
+++ b/regression/cpp/Address_of_Method2/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.cpp
 
-^EXIT=64$
+^EXIT=\(64\|1\)$
 ^SIGNAL=0$
 ^CONVERSION ERROR$
 --

--- a/regression/cpp/Address_of_Method3/test.desc
+++ b/regression/cpp/Address_of_Method3/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.cpp
 
-^EXIT=64$
+^EXIT=\(64\|1\)$
 ^SIGNAL=0$
 ^CONVERSION ERROR$
 --

--- a/regression/cpp/Constant2/test.desc
+++ b/regression/cpp/Constant2/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.cpp
 
-^EXIT=64$
+^EXIT=\(64\|1\)$
 ^SIGNAL=0$
 ^CONVERSION ERROR$
 --

--- a/regression/cpp/Constant3/test.desc
+++ b/regression/cpp/Constant3/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.cpp
 
-^EXIT=64$
+^EXIT=\(64\|1\)$
 ^SIGNAL=0$
 ^CONVERSION ERROR$
 --

--- a/regression/cpp/Pointer_Conversion1/test.desc
+++ b/regression/cpp/Pointer_Conversion1/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.cpp
 
-^EXIT=64$
+^EXIT=\(64\|1\)$
 ^SIGNAL=0$
 ^CONVERSION ERROR$
 --

--- a/regression/cpp/Resolver12/test.desc
+++ b/regression/cpp/Resolver12/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.cpp
 
-^EXIT=64$
+^EXIT=\(64\|1\)$
 ^SIGNAL=0$
 ^CONVERSION ERROR$
 --

--- a/regression/cpp/Resolver4/test.desc
+++ b/regression/cpp/Resolver4/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.cpp
 
-^EXIT=64$
+^EXIT=\(64\|1\)$
 ^SIGNAL=0$
 ^CONVERSION ERROR$
 --

--- a/regression/cpp/union3/test.desc
+++ b/regression/cpp/union3/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.cpp
 
-^EXIT=64$
+^EXIT=\(64\|1\)$
 ^SIGNAL=0$
 ^CONVERSION ERROR$
 --

--- a/regression/cpp/union4/test.desc
+++ b/regression/cpp/union4/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.cpp
 
-^EXIT=64$
+^EXIT=\(64\|1\)$
 ^SIGNAL=0$
 ^CONVERSION ERROR$
 --

--- a/regression/cpp/union5/test.desc
+++ b/regression/cpp/union5/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.cpp
 
-^EXIT=64$
+^EXIT=\(64\|1\)$
 ^SIGNAL=0$
 ^CONVERSION ERROR$
 --

--- a/src/goto-cc/armcc_mode.cpp
+++ b/src/goto-cc/armcc_mode.cpp
@@ -6,6 +6,14 @@ Author: CM Wintersteiger, 2006
 
 \*******************************************************************/
 
+#ifdef _WIN32
+#define EX_OK 0
+#define EX_USAGE 64
+#define EX_SOFTWARE 70
+#else
+#include <sysexits.h>
+#endif
+
 #include <iostream>
 
 #include <util/string2int.h>
@@ -28,12 +36,12 @@ Function: armcc_modet::doit
 
 \*******************************************************************/
 
-bool armcc_modet::doit()
+int armcc_modet::doit()
 {
   if(cmdline.isset('?') || cmdline.isset("help"))
   {
     help();
-    return false;
+    return EX_OK;
   }
 
   unsigned int verbosity=1;
@@ -184,7 +192,7 @@ bool armcc_modet::doit()
   }
 
   // Parse input program, convert to goto program, write output
-  return compiler.doit();
+  return compiler.doit() ? EX_USAGE : EX_OK;
 }
 
 /*******************************************************************\

--- a/src/goto-cc/armcc_mode.h
+++ b/src/goto-cc/armcc_mode.h
@@ -17,7 +17,7 @@ Date: June 2006
 class armcc_modet:public goto_cc_modet
 {
 public:
-  virtual bool doit();
+  virtual int doit();
   virtual void help_mode();
 
   explicit armcc_modet(armcc_cmdlinet &_armcc_cmdline):

--- a/src/goto-cc/cw_mode.cpp
+++ b/src/goto-cc/cw_mode.cpp
@@ -6,6 +6,14 @@ Author: CM Wintersteiger, 2006
 
 \*******************************************************************/
 
+#ifdef _WIN32
+#define EX_OK 0
+#define EX_USAGE 64
+#define EX_SOFTWARE 70
+#else
+#include <sysexits.h>
+#endif
+
 #include <iostream>
 
 #include <util/string2int.h>
@@ -28,12 +36,12 @@ Function: cw_modet::doit
 
 \*******************************************************************/
 
-bool cw_modet::doit()
+int cw_modet::doit()
 {
   if(cmdline.isset('?') || cmdline.isset("help"))
   {
     help();
-    return false;
+    return EX_OK;
   }
 
   unsigned int verbosity=1;
@@ -173,7 +181,7 @@ bool cw_modet::doit()
   }
 
   // Parse input program, convert to goto program, write output
-  return compiler.doit();
+  return compiler.doit() ? EX_USAGE : EX_OK;
 }
 
 /*******************************************************************\

--- a/src/goto-cc/cw_mode.h
+++ b/src/goto-cc/cw_mode.h
@@ -17,7 +17,7 @@ Date: June 2006
 class cw_modet:public goto_cc_modet
 {
 public:
-  virtual bool doit();
+  virtual int doit();
   virtual void help_mode();
 
   explicit cw_modet(gcc_cmdlinet &_gcc_cmdline):

--- a/src/goto-cc/gcc_mode.cpp
+++ b/src/goto-cc/gcc_mode.cpp
@@ -6,8 +6,15 @@ Author: CM Wintersteiger, 2006
 
 \*******************************************************************/
 
+#ifdef _WIN32
+#define EX_OK 0
+#define EX_USAGE 64
+#define EX_SOFTWARE 70
+#else
+#include <sysexits.h>
+#endif
+
 #include <cstdio>
-#include <cstdlib> // exit()
 #include <iostream>
 
 #include <util/string2int.h>
@@ -62,7 +69,7 @@ Function: gcc_modet::doit
 
 \*******************************************************************/
 
-bool gcc_modet::doit()
+int gcc_modet::doit()
 {
   act_as_ld=
     base_name=="ld" ||
@@ -72,7 +79,7 @@ bool gcc_modet::doit()
      cmdline.isset("help"))
   {
     help();
-    return false;
+    return EX_OK;
   }
 
   unsigned int verbosity=1;
@@ -101,13 +108,13 @@ bool gcc_modet::doit()
       "Architecture: " << config.this_architecture() << '\n' <<
       "OS: " << config.this_operating_system() << '\n';
 
-    return false; // Exit!
+    return EX_OK; // Exit!
   }
 
   if(cmdline.isset("dumpversion"))
   {
     std::cout << "3.4.4" << std::endl;
-    return false;
+    return EX_OK;
   }
 
   if(cmdline.isset("Wall"))
@@ -147,11 +154,7 @@ bool gcc_modet::doit()
           cmdline.isset('S') ||
           cmdline.isset('E') ||
           !cmdline.have_infile_arg())
-  {
-    int result;
-    result=run_gcc();
-    exit(result);
-  }
+    return run_gcc(); // exit!
   
   // get configuration
   config.set(cmdline);
@@ -353,7 +356,7 @@ bool gcc_modet::doit()
           if(exit_code!=0)
           {
             error() << "preprocessing has failed" << eom;
-            return true;
+            return exit_code;
           }
           
           compiler.add_input_file(dest);
@@ -383,25 +386,18 @@ bool gcc_modet::doit()
 
   if(compiler.source_files.empty() &&
      compiler.object_files.empty())
-  {
-    temp_dir.clear();
-    int result;
-    result=run_gcc();
-    exit(result);
-  }
+    return run_gcc(); // exit!
 
   // do all the rest
-  bool result=compiler.doit();
+  if(compiler.doit())
+    return 1; // GCC exit code for all kinds of errors
 
   // We can generate hybrid ELF and Mach-O binaries
   // containing both executable machine code and the goto-binary.
-  if(!result && produce_hybrid_binary)
-  {
-    if(gcc_hybrid_binary())
-      result=true;
-  }
+  if(produce_hybrid_binary)
+    return gcc_hybrid_binary();
   
-  return result;
+  return EX_OK;
 }
 
 /*******************************************************************\
@@ -566,7 +562,7 @@ int gcc_modet::gcc_hybrid_binary()
         have_files=true;
 
     if(!have_files)
-      return 0;
+      return EX_OK;
   }
 
   std::list<std::string> output_files;
@@ -600,7 +596,8 @@ int gcc_modet::gcc_hybrid_binary()
 
   if(output_files.empty() ||
      (output_files.size()==1 &&
-      output_files.front()=="/dev/null")) return 0;
+      output_files.front()=="/dev/null"))
+    return EX_OK;
 
   if(act_as_ld)
     debug() << "Running ld to generate hybrid binary" << eom;
@@ -723,7 +720,7 @@ int gcc_modet::gcc_hybrid_binary()
     #endif
   }
   
-  return result!=0;
+  return result;
 }
 
 /*******************************************************************\

--- a/src/goto-cc/gcc_mode.h
+++ b/src/goto-cc/gcc_mode.h
@@ -17,7 +17,7 @@ Date: June 2006
 class gcc_modet:public goto_cc_modet
 {
 public:
-  virtual bool doit();
+  virtual int doit();
   virtual void help_mode();
 
   explicit gcc_modet(goto_cc_cmdlinet &_cmdline):

--- a/src/goto-cc/goto_cc_mode.cpp
+++ b/src/goto-cc/goto_cc_mode.cpp
@@ -108,10 +108,7 @@ int goto_cc_modet::main(int argc, const char **argv)
 
   try
   {
-    if(doit())
-      return EX_USAGE; // error
-    else
-      return EX_OK;
+    return doit();
   }
 
   catch(const char *e)

--- a/src/goto-cc/goto_cc_mode.h
+++ b/src/goto-cc/goto_cc_mode.h
@@ -21,7 +21,7 @@ public:
   std::string base_name;
 
   virtual int main(int argc, const char **argv);
-  virtual bool doit()=0;
+  virtual int doit()=0;
   virtual void help_mode()=0;
   virtual void help();
   virtual void usage_error();

--- a/src/goto-cc/ld_mode.cpp
+++ b/src/goto-cc/ld_mode.cpp
@@ -6,6 +6,14 @@ Author: Daniel Kroening, 2013
 
 \*******************************************************************/
 
+#ifdef _WIN32
+#define EX_OK 0
+#define EX_USAGE 64
+#define EX_SOFTWARE 70
+#else
+#include <sysexits.h>
+#endif
+
 #include <iostream>
 
 #include <util/string2int.h>
@@ -28,12 +36,12 @@ Function: ld_modet::doit
 
 \*******************************************************************/
 
-bool ld_modet::doit()
+int ld_modet::doit()
 {
   if(cmdline.isset("help"))
   {
     help();
-    return false;
+    return EX_OK;
   }
 
   unsigned int verbosity=1;
@@ -54,7 +62,7 @@ bool ld_modet::doit()
   {
     std::cout << "GNU ld version 2.16.91 20050610 (goto-cc " CBMC_VERSION ")\n";
     std::cout << "Copyright (C) 2006-2014 Daniel Kroening, Christoph Wintersteiger\n";
-    return false; // Exit!
+    return EX_OK; // Exit!
   }
 
   if(cmdline.isset("verbosity"))
@@ -112,7 +120,8 @@ bool ld_modet::doit()
   }
     
   // do all the rest
-  bool result=compiler.doit();
+  if(compiler.doit())
+    return 1; // ld uses exit code 1 for all sorts of errors
 
   #if 0
   if(produce_hybrid_binary)
@@ -122,7 +131,7 @@ bool ld_modet::doit()
   }
   #endif
   
-  return result;
+  return EX_OK;
 }
 
 /*******************************************************************\

--- a/src/goto-cc/ld_mode.h
+++ b/src/goto-cc/ld_mode.h
@@ -17,7 +17,7 @@ Date: June 2006
 class ld_modet:public goto_cc_modet
 {
 public:
-  virtual bool doit();
+  virtual int doit();
   virtual void help_mode();
 
   explicit ld_modet(ld_cmdlinet &_ld_cmdline):

--- a/src/goto-cc/ms_cl_mode.cpp
+++ b/src/goto-cc/ms_cl_mode.cpp
@@ -6,6 +6,14 @@ Author: CM Wintersteiger, 2006
 
 \*******************************************************************/
 
+#ifdef _WIN32
+#define EX_OK 0
+#define EX_USAGE 64
+#define EX_SOFTWARE 70
+#else
+#include <sysexits.h>
+#endif
+
 #include <iostream>
 
 #include <util/string2int.h>
@@ -39,13 +47,13 @@ static bool is_directory(const std::string &s)
   return last_char=='\\' || last_char=='/';
 }
 
-bool ms_cl_modet::doit()
+int ms_cl_modet::doit()
 {
   if(cmdline.isset('?') || 
      cmdline.isset("help"))
   {
     help();
-    return false;
+    return EX_OK;
   }
 
   unsigned int verbosity=1;
@@ -165,7 +173,7 @@ bool ms_cl_modet::doit()
   }
 
   // Parse input program, convert to goto program, write output
-  return compiler.doit();
+  return compiler.doit() ? EX_USAGE : EX_OK;
 }
 
 /*******************************************************************\

--- a/src/goto-cc/ms_cl_mode.h
+++ b/src/goto-cc/ms_cl_mode.h
@@ -17,7 +17,7 @@ Date: June 2006
 class ms_cl_modet:public goto_cc_modet
 {
 public:
-  virtual bool doit();
+  virtual int doit();
   virtual void help_mode();
 
   explicit ms_cl_modet(ms_cl_cmdlinet &_ms_cl_cmdline):


### PR DESCRIPTION
This change enables proper cleanup via destructors instead of premature calls to
exit().

ARM/CW/CL modes continue to exit with EX_USAGE in case of errors, which might
not actually match the behaviour of armcc/Codewarrior/cl.