### PR TITLE
Fix switch values that need an implicit upcast to find a struct member

### DIFF
--- a/src/java_bytecode/java_bytecode_typecheck_code.cpp
+++ b/src/java_bytecode/java_bytecode_typecheck_code.cpp
@@ -54,6 +54,11 @@ void java_bytecode_typecheckt::typecheck_code(codet &code)
     if(code_ifthenelse.else_case().is_not_nil())
       typecheck_code(code_ifthenelse.else_case());
   }
+  else if(statement==ID_switch)
+  {
+    code_switcht &code_switch = to_code_switch(code);
+    typecheck_expr(code_switch.value());
+  }
   else if(statement==ID_return)
   {
     if(code.operands().size()==1)


### PR DESCRIPTION
Upcasts might happen in the immediate argument to a switch statement (e.g. switch(((A*)x)->y) needing to become switch(x->superclass.y)). The Java bytecode typechecker already looked at some contexts for possible implicit casts like this; this adds switch arguments to the list. Fixes #154.