### PR TITLE
The unwinder of goto-instrument is finally enabled 

### DIFF
--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -181,12 +181,10 @@ int goto_instrument_parse_optionst::doit()
 
 
           unwind(goto_program, l_it->first, loop_exit, k);
-          goto_programt::instructiont assume(ASSUME);
-          assume.guard=loop_guard;
+          // add the assumption that the loop guard is violated
           goto_programt::targett t=goto_function.body.insert_before(loop_exit);
-          *t=assume;
-          //goto_functions.update();
-          //goto_functions.compute_loop_numbers();
+          t->make_assumption(loop_guard);
+
         }
       }
 

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -152,8 +152,8 @@ int goto_instrument_parse_optionst::doit()
 
       int k = stoi(cmdline.get_value("unwind"));
 
-//#define UNWIND_DEFAULT
-#define UNWIND_TYPE2
+#define UNWIND_DEFAULT
+//#define UNWIND_TYPE2
 
 #ifdef UNWIND_DEFAULT
       // here we simply unwind all loops in the goto program

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -84,7 +84,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "skip_loops.h"
 #include "code_contracts.h"
 #include "unwind.h"
-#include "loop_utils.h"
+
 
 
 /*******************************************************************\
@@ -152,121 +152,9 @@ int goto_instrument_parse_optionst::doit()
 
       int k = stoi(cmdline.get_value("unwind"));
 
-#define UNWIND_DEFAULT
-//#define UNWIND_TYPE2
+      goto_unwind(goto_functions, k);
+      //goto_unwind_type2(goto_functions, k);
 
-#ifdef UNWIND_DEFAULT
-      // here we simply unwind all loops in the goto program
-      // each loop body is repeated k times, then an assumption is added
-      Forall_goto_functions(it, goto_functions)
-      {
-        goto_functionst::goto_functiont &goto_function=it->second;
-        if(!goto_function.body_available())
-        {
-          continue;
-        }
-        goto_programt &goto_program=goto_function.body;
-
-        // the unwinding continues until there is no loop in the function
-        while(true)
-        {
-          natural_loops_mutablet natural_loops(goto_program);
-          // if there is no loop anymore in the current function,
-          // then go to the next function for unwinding
-          if(natural_loops.loop_map.size()==0)
-          {
-            break;
-          }
-          typedef const natural_loops_mutablet::natural_loopt loopt;
-          for(natural_loops_mutablet::loop_mapt::const_iterator
-              l_it=natural_loops.loop_map.begin();
-              l_it!=natural_loops.loop_map.end();
-              l_it++)
-          {
-            // save a copy of the loop guard
-            const exprt loop_guard=l_it->first->guard;
-            //if(loop_guard.is_true())
-            //{
-            //  status() << "WARNING on the loop of the form \"while(true){...}\" inside the function \"" <<  l_it->first->function << "\"!!!" << eom;
-            //}
-
-            const loopt &loop=l_it->second;
-            assert(!loop.empty());
-            goto_programt::targett loop_exit=get_loop_exit(loop);
-
-            unwind(goto_program, l_it->first, loop_exit, k);
-            // add the assumption that the loop guard is violated
-            goto_programt::targett t=goto_function.body.insert_before(loop_exit);
-            t->make_assumption(loop_guard);
-
-          }
-    	}
-      }
-#endif
-
-#ifdef UNWIND_TYPE2
-
-      // another chance is that we repeat the loop body "k" times,
-      // after which we continue with the loop
-      std::vector<std::pair<goto_programt::targett, goto_programt::targett> > loop_points;
-
-      Forall_goto_functions(it, goto_functions)
-      {
-        goto_functionst::goto_functiont &goto_function=it->second;
-        if(!goto_function.body_available())
-        {
-          continue;
-        }
-        goto_programt &goto_program=goto_function.body;
-
-        while(true)
-        {
-          natural_loops_mutablet natural_loops(goto_program);
-          if(natural_loops.loop_map.size()==0)
-            break;
-          typedef const natural_loops_mutablet::natural_loopt loopt;
-          for(natural_loops_mutablet::loop_mapt::const_iterator
-                l_it=natural_loops.loop_map.begin();
-        	    l_it!=natural_loops.loop_map.end();
-        	    l_it++)
-          {
-        	// save a copy of the loop guard
-        	const exprt loop_guard=l_it->first->guard;
-
-        	const loopt &loop=l_it->second;
-        	assert(!loop.empty());
-        	goto_programt::targett loop_exit=get_loop_exit(loop);
-        	goto_programt::targett loop_head=l_it->first;
-
-        	//unwind(goto_program, l_it->first, loop_exit, k);
-        	std::vector<goto_programt::targett> exit_points;
-        	unwind(goto_program, loop_head, loop_exit, k, exit_points);
-
-        	goto_programt::targett t=goto_program.insert_before(loop_exit);
-
-        	t->make_goto();
-
-        	// to avoid the infinite while loop, we delay the specification of t's target;
-        	// be careful that there is a temporary inconsistent status as the goto statement
-        	// t does not have a target
-        	if(k>1)
-        	  loop_points.push_back(make_pair(t, exit_points[k-2]));
-        	else
-        	  loop_points.push_back(make_pair(t, loop_head));
-          }
-
-        }
-
-      }
-      // it is time to add the complete loop at the end of each unwinding operation
-      for(std::vector<std::pair<goto_programt::targett, goto_programt::targett> >::iterator
-            jt=loop_points.begin(); jt!=loop_points.end(); ++jt)
-      {
-        jt->first->targets.push_back(jt->second);
-      }
-#endif
-
-      //remove_skip(goto_functions);
       goto_functions.update();
       goto_functions.compute_loop_numbers();
     }

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -149,10 +149,15 @@ int goto_instrument_parse_optionst::doit()
 
     if(cmdline.isset("unwind"))
     {
-      // here we simply unwind all loops in the goto program
-      // each loop body is repeated k times, then an assumption is added
+
       int k = stoi(cmdline.get_value("unwind"));
 
+//#define UNWIND_DEFAULT
+#define UNWIND_TYPE2
+
+#ifdef UNWIND_DEFAULT
+      // here we simply unwind all loops in the goto program
+      // each loop body is repeated k times, then an assumption is added
       Forall_goto_functions(it, goto_functions)
       {
         goto_functionst::goto_functiont &goto_function=it->second;
@@ -180,6 +185,10 @@ int goto_instrument_parse_optionst::doit()
           {
             // save a copy of the loop guard
             const exprt loop_guard=l_it->first->guard;
+            //if(loop_guard.is_true())
+            //{
+            //  status() << "WARNING on the loop of the form \"while(true){...}\" inside the function \"" <<  l_it->first->function << "\"!!!" << eom;
+            //}
 
             const loopt &loop=l_it->second;
             assert(!loop.empty());
@@ -193,6 +202,69 @@ int goto_instrument_parse_optionst::doit()
           }
     	}
       }
+#endif
+
+#ifdef UNWIND_TYPE2
+
+      // another chance is that we repeat the loop body "k" times,
+      // after which we continue with the loop
+      std::vector<std::pair<goto_programt::targett, goto_programt::targett> > loop_points;
+
+      Forall_goto_functions(it, goto_functions)
+      {
+        goto_functionst::goto_functiont &goto_function=it->second;
+        if(!goto_function.body_available())
+        {
+          continue;
+        }
+        goto_programt &goto_program=goto_function.body;
+
+        while(true)
+        {
+          natural_loops_mutablet natural_loops(goto_program);
+          if(natural_loops.loop_map.size()==0)
+            break;
+          typedef const natural_loops_mutablet::natural_loopt loopt;
+          for(natural_loops_mutablet::loop_mapt::const_iterator
+                l_it=natural_loops.loop_map.begin();
+        	    l_it!=natural_loops.loop_map.end();
+        	    l_it++)
+          {
+        	// save a copy of the loop guard
+        	const exprt loop_guard=l_it->first->guard;
+
+        	const loopt &loop=l_it->second;
+        	assert(!loop.empty());
+        	goto_programt::targett loop_exit=get_loop_exit(loop);
+        	goto_programt::targett loop_head=l_it->first;
+
+        	//unwind(goto_program, l_it->first, loop_exit, k);
+        	std::vector<goto_programt::targett> exit_points;
+        	unwind(goto_program, loop_head, loop_exit, k, exit_points);
+
+        	goto_programt::targett t=goto_program.insert_before(loop_exit);
+
+        	t->make_goto();
+
+        	// to avoid the infinite while loop, we delay the specification of t's target;
+        	// be careful that there is a temporary inconsistent status as the goto statement
+        	// t does not have a target
+        	if(k>1)
+        	  loop_points.push_back(make_pair(t, exit_points[k-2]));
+        	else
+        	  loop_points.push_back(make_pair(t, loop_head));
+          }
+
+        }
+
+      }
+      // it is time to add the complete loop at the end of each unwinding operation
+      for(std::vector<std::pair<goto_programt::targett, goto_programt::targett> >::iterator
+            jt=loop_points.begin(); jt!=loop_points.end(); ++jt)
+      {
+        jt->first->targets.push_back(jt->second);
+      }
+#endif
 
       //remove_skip(goto_functions);
       goto_functions.update();

--- a/src/goto-instrument/unwind.cpp
+++ b/src/goto-instrument/unwind.cpp
@@ -7,14 +7,16 @@ Author: Daniel Kroening, kroening@kroening.com
 \*******************************************************************/
 
 #include <util/std_expr.h>
-
+#include <goto-programs/goto_functions.h>
 #include "unwind.h"
+#include "loop_utils.h"
+
 
 /*******************************************************************\
 
 Function: unwind
 
-  Inputs:
+ Inputs:
 
  Outputs:
 
@@ -36,7 +38,7 @@ void unwind(
 
 Function: unwind
 
-  Inputs:
+ Inputs:
 
  Outputs:
 
@@ -169,4 +171,139 @@ void unwind(
 
   // update it all
   goto_program.update();
+}
+
+/*******************************************************************\
+
+Function: goto_unwind
+
+ Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void goto_unwind(
+  goto_functionst &goto_functions,
+  const unsigned k)
+{
+  // here we simply unwind all loops in the goto program
+  // each loop body is repeated k times, then an assumption is added
+  Forall_goto_functions(it, goto_functions)
+  {
+    goto_functionst::goto_functiont &goto_function=it->second;
+	if(!goto_function.body_available())
+	{
+	  continue;
+	}
+	goto_programt &goto_program=goto_function.body;
+
+	// the unwinding continues until there is no loop in the function
+	while(true)
+	{
+	  natural_loops_mutablet natural_loops(goto_program);
+	  // if there is no loop anymore in the current function,
+	  // then go to the next function for unwinding
+	  if(natural_loops.loop_map.size()==0)
+	  {
+	    break;
+	  }
+	  typedef const natural_loops_mutablet::natural_loopt loopt;
+	  for(natural_loops_mutablet::loop_mapt::const_iterator
+	        l_it=natural_loops.loop_map.begin();
+	        l_it!=natural_loops.loop_map.end();
+	        l_it++)
+	  {
+	     // save a copy of the loop guard
+	     const exprt loop_guard=l_it->first->guard;
+
+	     const loopt &loop=l_it->second;
+	     assert(!loop.empty());
+	     goto_programt::targett loop_exit=get_loop_exit(loop);
+
+	     unwind(goto_program, l_it->first, loop_exit, k);
+	     // add the assumption that the loop guard is violated
+	     goto_programt::targett t=goto_function.body.insert_before(loop_exit);
+	     t->make_assumption(loop_guard);
+	  }
+	}
+  }
+}
+
+/*******************************************************************\
+
+Function: goto_unwind_type2
+
+ Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void goto_unwind_type2(
+  goto_functionst &goto_functions,
+  const unsigned k)
+{
+    // another chance is that we repeat the loop body "k" times,
+    // after which we continue with the loop
+    std::vector<std::pair<goto_programt::targett, goto_programt::targett> > loop_points;
+
+    Forall_goto_functions(it, goto_functions)
+    {
+      goto_functionst::goto_functiont &goto_function=it->second;
+      if(!goto_function.body_available())
+      {
+        continue;
+      }
+      goto_programt &goto_program=goto_function.body;
+
+      while(true)
+      {
+        natural_loops_mutablet natural_loops(goto_program);
+        if(natural_loops.loop_map.size()==0)
+          break;
+        typedef const natural_loops_mutablet::natural_loopt loopt;
+        for(natural_loops_mutablet::loop_mapt::const_iterator
+              l_it=natural_loops.loop_map.begin();
+      	    l_it!=natural_loops.loop_map.end();
+      	    l_it++)
+        {
+      	// save a copy of the loop guard
+      	const exprt loop_guard=l_it->first->guard;
+
+      	const loopt &loop=l_it->second;
+      	assert(!loop.empty());
+      	goto_programt::targett loop_exit=get_loop_exit(loop);
+      	goto_programt::targett loop_head=l_it->first;
+
+      	//unwind(goto_program, l_it->first, loop_exit, k);
+      	std::vector<goto_programt::targett> exit_points;
+      	unwind(goto_program, loop_head, loop_exit, k, exit_points);
+
+      	goto_programt::targett t=goto_program.insert_before(loop_exit);
+
+      	t->make_goto();
+
+      	// to avoid the infinite while loop, we delay the specification of t's target;
+      	// be careful that there is a temporary inconsistent status as the goto statement
+      	// t does not have a target
+      	if(k>1)
+      	  loop_points.push_back(make_pair(t, exit_points[k-2]));
+      	else
+      	  loop_points.push_back(make_pair(t, loop_head));
+        }
+
+      }
+
+    }
+    // it is time to add the complete loop at the end of each unwinding operation
+    for(std::vector<std::pair<goto_programt::targett, goto_programt::targett> >::iterator
+          jt=loop_points.begin(); jt!=loop_points.end(); ++jt)
+    {
+      jt->first->targets.push_back(jt->second);
+    }
 }

--- a/src/goto-instrument/unwind.cpp
+++ b/src/goto-instrument/unwind.cpp
@@ -16,7 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 Function: unwind
 
- Inputs:
+  Inputs:
 
  Outputs:
 
@@ -38,7 +38,7 @@ void unwind(
 
 Function: unwind
 
- Inputs:
+  Inputs:
 
  Outputs:
 
@@ -177,7 +177,7 @@ void unwind(
 
 Function: goto_unwind
 
- Inputs:
+  Inputs:
 
  Outputs:
 
@@ -236,7 +236,7 @@ void goto_unwind(
 
 Function: goto_unwind_type2
 
- Inputs:
+  Inputs:
 
  Outputs:
 

--- a/src/goto-instrument/unwind.h
+++ b/src/goto-instrument/unwind.h
@@ -24,4 +24,12 @@ void unwind(
   const unsigned k,
   std::vector<goto_programt::targett> &iteration_points);
 
+void goto_unwind(
+  goto_functionst &goto_functions,
+  const unsigned k);
+
+void goto_unwind_type2(
+  goto_functionst &goto_functions,
+  const unsigned k);
+
 #endif


### PR DESCRIPTION
Note that previously the piece of codes for```--unwind``` in```goto-instrument``` was in fact disabled. This patch on one hand triggers the unwinding operation in ```goto-instrument```, on the other hand it makes implementation of  the unwinder of ```goto-instrument``` more completed. 

After unwinding the loop body for the specified number of times, there are now two choices. By default, the unwinder will insert an assume statement; instead, the type2 unwinder will choose to continue the loop.
