### PR TITLE
dump-c: do not output dead instructions

### DIFF
--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -1398,7 +1398,8 @@ goto_programt::const_targett goto_program2codet::convert_goto_break_continue(
   if(target->get_target()==next)
   {
     dest.copy_to_operands(code_skipt());
-    return target;
+    // skip over all dead instructions
+    return --next;
   }
 
   goto_programt::const_targett loop_end=loop_last_stack.back().first;


### PR DESCRIPTION
When the instruction causing dead code is skipped, the dead instructions must
not be generated either as demonstrated by #170.

Fixes #170.