### PR TITLE
Allow clean cast from derived to base type

### DIFF
--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -280,6 +280,13 @@ bool value_set_dereferencet::dereference_type_compare(
          to_struct_type(ot_base)))
       return true; // ok, dt is a prefix of ot
   }
+
+  if(ot_base.id()==ID_struct)
+  {
+    const auto& otcomp = to_struct_type(ot_base).components();
+    if(otcomp.size()!=0 && dereference_type_compare(otcomp[0].type(),dereference_type))
+      return true; // dt is a prefix (specifically the first field) of ot
+  }
   
   // we are generous about code pointers
   if(dereference_type.id()==ID_code &&


### PR DESCRIPTION
The pointer-analysis subpass already allows structural subtyping in the form of casting from a struct to a prefix of the same struct. This allows a `struct { int x; }*` to `int*`, for example, along the same lines.

This prevents accesses via a base class from manifesting as bytewise-reinterpret (`byte_extract`) opcodes in the counterexample trace, which simplifies the Java test-case generation considerably, as it is no longer necessary to implement reinterpretation in the interpreter. I'm passing it through master as it may have an unforseen impact on other languages.