### PR TITLE
Fix local var frame

### DIFF
--- a/src/java_bytecode/bytecode_info.h
+++ b/src/java_bytecode/bytecode_info.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 // http://en.wikipedia.org/wiki/Java_bytecode_instruction_listings
 
 // The 'result_type' is one of the following:
@@ -40,7 +42,7 @@ struct bytecode_infot
 
 extern struct bytecode_infot const bytecode_info[];
 
-typedef unsigned char u1;
-typedef unsigned short u2;
-typedef unsigned int u4;
-typedef unsigned long long u8;
+typedef uint8_t  u1;
+typedef uint16_t u2;
+typedef uint32_t u4;
+typedef uint64_t u8;

--- a/src/java_bytecode/bytecode_info.h
+++ b/src/java_bytecode/bytecode_info.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // http://en.wikipedia.org/wiki/Java_bytecode_instruction_listings
 
 // The 'result_type' is one of the following:
@@ -38,3 +40,7 @@ struct bytecode_infot
 
 extern struct bytecode_infot const bytecode_info[];
 
+typedef unsigned char u1;
+typedef unsigned short u2;
+typedef unsigned int u4;
+typedef unsigned long long u8;

--- a/src/java_bytecode/java_bytecode_convert_class.cpp
+++ b/src/java_bytecode/java_bytecode_convert_class.cpp
@@ -116,8 +116,6 @@ void java_bytecode_convert_classt::convert(const classt &c)
     throw 0;
   }
 
-  std::cout << "-----------\nclass: " << c.name << std::endl;
-  
   // now do fields
   for(const auto & it : c.fields)
     convert(*class_symbol, it);

--- a/src/java_bytecode/java_bytecode_convert_class.cpp
+++ b/src/java_bytecode/java_bytecode_convert_class.cpp
@@ -116,6 +116,8 @@ void java_bytecode_convert_classt::convert(const classt &c)
     throw 0;
   }
 
+  std::cout << "-----------\nclass: " << c.name << std::endl;
+  
   // now do fields
   for(const auto & it : c.fields)
     convert(*class_symbol, it);

--- a/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -112,7 +112,12 @@ protected:
     else if(var_list_length == 1)
       return var_list[0];
     else
-      throw ("local variable " + std::to_string(number_int) + " not found");
+      {
+        // return reference to unnamed local variable
+        variablet var;
+        variablet &v = var;
+        return v;
+      }
   }
 
   // JVM local variables

--- a/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -114,9 +114,8 @@ protected:
     else
       {
         // return reference to unnamed local variable
-        variablet var;
-        variablet &v = var;
-        return v;
+        var_list.resize(1);
+        return var_list[0];
       }
   }
 

--- a/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -25,6 +25,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "bytecode_info.h"
 #include "java_types.h"
 
+#include <limits>
+
 namespace {
 class patternt
 {
@@ -107,13 +109,22 @@ protected:
             if (address + (size_t) inst_size >= start_pc && address < start_pc + length)
               return var;
           }
-        throw ("end of list reached, address " + std::to_string(address) + " not found");
+        // add unnamed local variable to end of list at this index
+        // with scope from 0 to INT_MAX
+        // as it is at the end of the vector, it will only be taken into account
+        // if no other variable is valid
+        size_t list_length = var_list.size();
+        var_list.resize(list_length + 1);
+        var_list[list_length].start_pc = 0;
+        var_list[list_length].length = std::numeric_limits<size_t>::max();
+        return var_list[list_length];
       }
     else if(var_list_length == 1)
       return var_list[0];
     else
       {
         // return reference to unnamed local variable
+        // if no local variable is defined for this index
         var_list.resize(1);
         return var_list[0];
       }

--- a/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -122,9 +122,7 @@ protected:
     
     std::size_t number_int=safe_string2size_t(id2string(number));
     typet t=java_type_from_char(type_char);
-
     variablest &var_list = variables[number_int];
-    size_t var_list_length = var_list.size();
 
     // search variable in list for correct frame / address if necessary
     variablet &var = find_variable_for_slot(number_int, address, var_list, inst_size);
@@ -291,14 +289,6 @@ void java_bytecode_convert_methodt::convert(
 
   variables.clear();
 
-  // set up variables array
-  for(std::size_t i=0, param_index=0;
-      i < parameters.size(); ++i)
-  {
-    variables[param_index].resize(1);
-    param_index+=get_variable_slots(parameters[i]);
-  }
-
   // Do the parameters and locals in the variable table, which is available when
   // compiled with -g or for methods with many local variables in the latter
   // case, different variables can have the same index, depending on the
@@ -318,6 +308,14 @@ void java_bytecode_convert_methodt::convert(
     variables[v.index][number_index_entries].symbol_expr = result;
     variables[v.index][number_index_entries].start_pc = v.start_pc;
     variables[v.index][number_index_entries].length = v.length;
+  }
+
+  // set up variables array
+  for(std::size_t i=0, param_index=0;
+      i < parameters.size(); ++i)
+  {
+    variables[param_index].resize(1);
+    param_index+=get_variable_slots(parameters[i]);
   }
 
   // assign names to parameters

--- a/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -104,7 +104,7 @@ protected:
           {
             size_t start_pc = var.start_pc;
             size_t length = var.length;
-            if (address + (size_t) inst_size >= start_pc && address <= start_pc + length)
+            if (address + (size_t) inst_size >= start_pc && address < start_pc + length)
               return var;
           }
         throw ("end of list reached, address " + std::to_string(address) + " not found");

--- a/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -312,11 +312,23 @@ void java_bytecode_convert_methodt::convert(
 
   variables.clear();
 
-  // Do the parameters and locals in the variable table,
-  // which is available when compiled with -g
-  // or with methods with many local variables
-  // in the latter case, different variables can have
-  // the same index, depending on the context!
+  // set up variables array
+  for(std::size_t i=0, param_index=0;
+      i < parameters.size(); ++i)
+  {
+    std::cout << "parameter " << std::to_string(param_index) << " " << parameters[i] << std::endl;
+    variables[param_index].resize(1);
+    param_index+=get_variable_slots(parameters[i]);
+  }
+
+  // Do the parameters and locals in the variable table, which is available when
+  // compiled with -g or for methods with many local variables in the latter
+  // case, different variables can have the same index, depending on the
+  // context.
+  //
+  // to calculate which variable to use, one uses the address of the instruction
+  // that uses the variable, the size of the instruction and the start_pc /
+  // length values in the local variable table
   for(const auto & v : m.local_variable_table)
   {
     typet t=java_type_from_string(v.signature);
@@ -328,14 +340,6 @@ void java_bytecode_convert_methodt::convert(
     variables[v.index][number_index_entries].symbol_expr = result;
     variables[v.index][number_index_entries].start_pc = v.start_pc;
     variables[v.index][number_index_entries].length = v.length;
-  }
-  
-  // set up variables array
-  for(std::size_t i=0, param_index=0;
-      i < parameters.size(); ++i)
-  {
-    variables[param_index];
-    param_index+=get_variable_slots(parameters[i]);
   }
 
   // assign names to parameters

--- a/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -105,26 +105,16 @@ protected:
             size_t start_pc = var.start_pc;
             size_t length = var.length;
             if (address + (size_t) inst_size >= start_pc && address <= start_pc + length)
-              {
-                std::cout << "found for address " << std::to_string(address)
-                          << " starting at " << std::to_string(start_pc)
-                          << " length: " << std::to_string(length)
-                          << var.symbol_expr << std::endl;
-                return var;
-              }
+              return var;
           }
-        std::cout << "end of list reached, address " << std::to_string(address) << std::endl;
-        return var_list[0];
+        throw ("end of list reached, address " + std::to_string(address) + " not found");
       }
     else if(var_list_length == 1)
       return var_list[0];
     else
-      {
-        std::cout << "no local variable exists!" << std::endl;
-        return var_list[0];
-      }
+      throw ("local variable " + std::to_string(number_int) + " not found");
   }
-  
+
   // JVM local variables
   const exprt variable(const exprt &arg, char type_char, size_t address, instruction_sizet inst_size)
   {
@@ -133,21 +123,12 @@ protected:
     std::size_t number_int=safe_string2size_t(id2string(number));
     typet t=java_type_from_char(type_char);
 
-    std::cout << "getting the variable list for number " << std::to_string(number_int) << std::endl;
     variablest &var_list = variables[number_int];
-
     size_t var_list_length = var_list.size();
-    if(var_list_length == 1)
-      std::cout << "only single variable" << std::endl;
-    else if (var_list_length > 1)
-      std::cout << "multiple variables (" << std::to_string(var_list_length) << ") with this index" << std::endl;
-    else
-      std::cout << "no variable with this index" << std::endl;
 
     // search variable in list for correct frame / address if necessary
     variablet &var = find_variable_for_slot(number_int, address, var_list, inst_size);
 
-    std::cout << "look at number " << std::to_string(number_int) << std::endl;    
     if(var.symbol_expr.get_identifier().empty())
     {
       // an un-named local variable
@@ -286,8 +267,6 @@ void java_bytecode_convert_methodt::convert(
 {
   //const class_typet &class_type=to_class_type(class_symbol.type);
 
-  std::cout << "--------\n" << m.name << std::endl;
-
   typet member_type=java_type_from_string(m.signature);
 
   assert(member_type.id()==ID_code);
@@ -316,7 +295,6 @@ void java_bytecode_convert_methodt::convert(
   for(std::size_t i=0, param_index=0;
       i < parameters.size(); ++i)
   {
-    std::cout << "parameter " << std::to_string(param_index) << " " << parameters[i] << std::endl;
     variables[param_index].resize(1);
     param_index+=get_variable_slots(parameters[i]);
   }

--- a/src/java_bytecode/java_bytecode_parse_tree.h
+++ b/src/java_bytecode/java_bytecode_parse_tree.h
@@ -98,6 +98,8 @@ public:
       irep_idt name;
       std::string signature;
       std::size_t index;
+      std::size_t start_pc;
+      std::size_t length;
     };
 
     typedef std::vector<local_variablet> local_variable_tablet;

--- a/src/java_bytecode/java_bytecode_parse_tree.h
+++ b/src/java_bytecode/java_bytecode_parse_tree.h
@@ -17,6 +17,11 @@ Author: Daniel Kroening, kroening@kroening.com
 class java_bytecode_parse_treet
 {
 public:
+  typedef unsigned char u1;
+  typedef unsigned short u2;
+  typedef unsigned int u4;
+  typedef unsigned long long u8;
+
   class annotationt
   {
   public:
@@ -94,9 +99,41 @@ public:
       std::string signature;
       std::size_t index;
     };
-    
+
     typedef std::vector<local_variablet> local_variable_tablet;
     local_variable_tablet local_variable_table;
+
+    class verification_type_infot
+    {
+    public:
+      enum verification_type_info_type { TOP, INTEGER, FLOAT, LONG, DOUBLE,
+                                         ITEM_NULL, UNINITIALIZED_THIS,
+                                         OBJECT, UNINITIALIZED};
+      verification_type_info_type type;
+      u1 tag;
+      u2 cpool_index;
+      u2 offset;
+    };
+
+    class stack_map_table_entryt
+    {
+    public:
+      enum stack_frame_type { SAME, SAME_LOCALS_ONE_STACK, SAME_LOCALS_ONE_STACK_EXTENDED,
+                              CHOP, SAME_EXTENDED, APPEND, FULL};
+      stack_frame_type type;
+      size_t offset_delta;
+      size_t chops;
+      size_t appends;
+
+      typedef std::vector<verification_type_infot> local_verification_type_infot;
+      typedef std::vector<verification_type_infot> stack_verification_type_infot;
+
+      local_verification_type_infot locals;
+      stack_verification_type_infot stack;
+    };
+
+    typedef std::vector<stack_map_table_entryt> stack_map_tablet;
+    stack_map_tablet stack_map_table;
 
     virtual void output(std::ostream &out) const;
     

--- a/src/java_bytecode/java_bytecode_parse_tree.h
+++ b/src/java_bytecode/java_bytecode_parse_tree.h
@@ -14,14 +14,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/std_code.h>
 #include <util/std_types.h>
 
+#include "bytecode_info.h"
+
 class java_bytecode_parse_treet
 {
 public:
-  typedef unsigned char u1;
-  typedef unsigned short u2;
-  typedef unsigned int u4;
-  typedef unsigned long long u8;
-
   class annotationt
   {
   public:

--- a/src/java_bytecode/java_bytecode_parser.cpp
+++ b/src/java_bytecode/java_bytecode_parser.cpp
@@ -26,6 +26,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #define DEBUG
 #ifdef DEBUG
 #include <iostream>
+#include <string>
 #endif
 
 class java_bytecode_parsert:public parsert
@@ -1096,10 +1097,9 @@ void java_bytecode_parsert::rcode_attribute(methodt &method)
   }
   else if(attribute_name=="StackMapTable")
   {
-    std::cout << "reading StackMapTable" << std::endl;
-    u2 attribute_name_index=read_u2();
-    u4 attribute_length=read_u4();
     u2 stack_map_entries=read_u2();
+
+    std::cout << "reading StackMapTable; length: " << std::to_string(stack_map_entries) << std::endl;
 
     method.stack_map_table.resize(stack_map_entries);
 
@@ -1107,14 +1107,18 @@ void java_bytecode_parsert::rcode_attribute(methodt &method)
     {
       u1 frame_type=read_u1();
 
+      std::cout << "frame type " << std::to_string(frame_type) << std::endl;
+
       if(0 <= frame_type && frame_type <= 63)
         {
+          std::cout << "FRAME: SAME" << std::endl;
           method.stack_map_table[i].type = methodt::stack_map_table_entryt::SAME;
           method.stack_map_table[i].locals.resize(0);
           method.stack_map_table[i].stack.resize(0);
         }
       else if(64 <= frame_type && frame_type <= 127)
         {
+          std::cout << "FRAME: SAME_LOCALS_ONE_STACK" << std::endl;
           method.stack_map_table[i].type = methodt::stack_map_table_entryt::SAME_LOCALS_ONE_STACK;
           method.stack_map_table[i].locals.resize(0);
           method.stack_map_table[i].stack.resize(1);
@@ -1124,18 +1128,21 @@ void java_bytecode_parsert::rcode_attribute(methodt &method)
         }
       else if(frame_type == 247)
         {
+          std::cout << "FRAME: SAME_LOCALS_ONE_STACK_EXTENDED" << std::endl;
           method.stack_map_table[i].type = methodt::stack_map_table_entryt::SAME_LOCALS_ONE_STACK_EXTENDED;
           method.stack_map_table[i].locals.resize(0);
           method.stack_map_table[i].stack.resize(1);
         }
       else if(248 <= frame_type && frame_type <= 250)
         {
+          std::cout << "FRAME: CHOP" << std::endl;
           method.stack_map_table[i].type = methodt::stack_map_table_entryt::CHOP;
           method.stack_map_table[i].locals.resize(0);
           method.stack_map_table[i].stack.resize(0);
         }
       else if(frame_type == 251)
         {
+          std::cout << "FRAME: SAME_EXTENDED" << std::endl;
           method.stack_map_table[i].type = methodt::stack_map_table_entryt::SAME_EXTENDED;
           u2 offset=read_u2();
           method.stack_map_table[i].locals.resize(0);
@@ -1143,12 +1150,14 @@ void java_bytecode_parsert::rcode_attribute(methodt &method)
         }
       else if(252 <= frame_type && frame_type <= 254)
         {
+          std::cout << "FRAME: APPEND" << std::endl;
           method.stack_map_table[i].type = methodt::stack_map_table_entryt::APPEND;
           method.stack_map_table[i].locals.resize(0);
           method.stack_map_table[i].stack.resize(0);
         }
       else if(frame_type == 255)
         {
+          std::cout << "FRAME: SAME_EXTENDED" << std::endl;
           method.stack_map_table[i].type = methodt::stack_map_table_entryt::SAME_EXTENDED;
           method.stack_map_table[i].locals.resize(0);
           method.stack_map_table[i].stack.resize(0);
@@ -1165,19 +1174,33 @@ void java_bytecode_parsert::read_verification_type_info(methodt::verification_ty
 {
   u1 tag = read_u1();
   if(tag == 0)
-    v.type=methodt::verification_type_infot::TOP;
+    {
+      v.type=methodt::verification_type_infot::TOP;
+    }
   else if(tag == 1)
-    v.type=methodt::verification_type_infot::INTEGER;
+    {
+      v.type=methodt::verification_type_infot::INTEGER;
+    }
   else if(tag == 2)
-    v.type=methodt::verification_type_infot::FLOAT;
+    {
+      v.type=methodt::verification_type_infot::FLOAT;
+    }
   else if(tag == 3)
-    v.type=methodt::verification_type_infot::LONG;
+    {
+      v.type=methodt::verification_type_infot::LONG;
+    }
   else if(tag == 4)
-    v.type=methodt::verification_type_infot::DOUBLE;
+    {
+      v.type=methodt::verification_type_infot::DOUBLE;
+    }
   else if(tag == 5)
-    v.type=methodt::verification_type_infot::ITEM_NULL;
+    {
+      v.type=methodt::verification_type_infot::ITEM_NULL;
+    }
   else if(tag == 6)
-    v.type=methodt::verification_type_infot::UNINITIALIZED_THIS;
+    {
+      v.type=methodt::verification_type_infot::UNINITIALIZED_THIS;
+    }
   else if(tag == 7)
     {
       v.type=methodt::verification_type_infot::OBJECT;

--- a/src/java_bytecode/java_bytecode_parser.cpp
+++ b/src/java_bytecode/java_bytecode_parser.cpp
@@ -23,10 +23,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "java_types.h"
 #include "bytecode_info.h"
 
-#define DEBUG
 #ifdef DEBUG
 #include <iostream>
-#include <string>
 #endif
 
 class java_bytecode_parsert:public parsert
@@ -1101,26 +1099,19 @@ void java_bytecode_parsert::rcode_attribute(methodt &method)
   {
     u2 stack_map_entries=read_u2();
 
-    std::cout << "reading StackMapTable; length: " << std::to_string(stack_map_entries) << std::endl;
-
     method.stack_map_table.resize(stack_map_entries);
 
     for(size_t i=0; i<stack_map_entries; i++)
     {
       u1 frame_type=read_u1();
-
-      std::cout << std::to_string(i) << " th frame is of type " << std::to_string(frame_type) << std::endl;
-
       if(0 <= frame_type && frame_type <= 63)
         {
-          std::cout << "FRAME: SAME" << std::endl;
           method.stack_map_table[i].type = methodt::stack_map_table_entryt::SAME;
           method.stack_map_table[i].locals.resize(0);
           method.stack_map_table[i].stack.resize(0);
         }
       else if(64 <= frame_type && frame_type <= 127)
         {
-          std::cout << "FRAME: SAME_LOCALS_ONE_STACK" << std::endl;
           method.stack_map_table[i].type = methodt::stack_map_table_entryt::SAME_LOCALS_ONE_STACK;
           method.stack_map_table[i].locals.resize(0);
           method.stack_map_table[i].stack.resize(1);
@@ -1130,7 +1121,6 @@ void java_bytecode_parsert::rcode_attribute(methodt &method)
         }
       else if(frame_type == 247)
         {
-          std::cout << "FRAME: SAME_LOCALS_ONE_STACK_EXTENDED" << std::endl;
           method.stack_map_table[i].type = methodt::stack_map_table_entryt::SAME_LOCALS_ONE_STACK_EXTENDED;
           method.stack_map_table[i].locals.resize(0);
           method.stack_map_table[i].stack.resize(1);
@@ -1142,7 +1132,6 @@ void java_bytecode_parsert::rcode_attribute(methodt &method)
         }
       else if(248 <= frame_type && frame_type <= 250)
         {
-          std::cout << "FRAME: CHOP" << std::endl;
           method.stack_map_table[i].type = methodt::stack_map_table_entryt::CHOP;
           method.stack_map_table[i].locals.resize(0);
           method.stack_map_table[i].stack.resize(0);
@@ -1151,7 +1140,6 @@ void java_bytecode_parsert::rcode_attribute(methodt &method)
         }
       else if(frame_type == 251)
         {
-          std::cout << "FRAME: SAME_EXTENDED" << std::endl;
           method.stack_map_table[i].type = methodt::stack_map_table_entryt::SAME_EXTENDED;
           u2 offset=read_u2();
           method.stack_map_table[i].locals.resize(0);
@@ -1162,7 +1150,6 @@ void java_bytecode_parsert::rcode_attribute(methodt &method)
       else if(252 <= frame_type && frame_type <= 254)
         {
           size_t new_locals = (size_t) (frame_type - 251);
-          std::cout << "FRAME: APPEND" << std::endl;
           method.stack_map_table[i].type = methodt::stack_map_table_entryt::APPEND;
           method.stack_map_table[i].locals.resize(new_locals);
           method.stack_map_table[i].stack.resize(0);
@@ -1177,7 +1164,6 @@ void java_bytecode_parsert::rcode_attribute(methodt &method)
         }
       else if(frame_type == 255)
         {
-          std::cout << "FRAME: FULL" << std::endl;
           method.stack_map_table[i].type = methodt::stack_map_table_entryt::FULL;
 
           u2 offset_delta = read_u2();
@@ -1250,7 +1236,7 @@ void java_bytecode_parsert::read_verification_type_info(methodt::verification_ty
     }
   else
     throw "ERROR: unknown verification type info encountered";
-}  
+}
 
 /*******************************************************************\
 

--- a/src/java_bytecode/java_bytecode_parser.cpp
+++ b/src/java_bytecode/java_bytecode_parser.cpp
@@ -1125,9 +1125,9 @@ void java_bytecode_parsert::rcode_attribute(methodt &method)
           method.stack_map_table[i].locals.resize(0);
           method.stack_map_table[i].stack.resize(1);
           methodt::verification_type_infot verification_type_info;
+          u2 offset_delta = read_u2();
           read_verification_type_info(verification_type_info);
           method.stack_map_table[i].stack[0] = verification_type_info;
-          u2 offset_delta = read_u2();
           method.stack_map_table[i].offset_delta = offset_delta;
         }
       else if(248 <= frame_type && frame_type <= 250)
@@ -1141,7 +1141,6 @@ void java_bytecode_parsert::rcode_attribute(methodt &method)
       else if(frame_type == 251)
         {
           method.stack_map_table[i].type = methodt::stack_map_table_entryt::SAME_EXTENDED;
-          UNUSED u2 offset=read_u2();
           method.stack_map_table[i].locals.resize(0);
           method.stack_map_table[i].stack.resize(0);
           u2 offset_delta = read_u2();
@@ -1165,8 +1164,8 @@ void java_bytecode_parsert::rcode_attribute(methodt &method)
       else if(frame_type == 255)
         {
           method.stack_map_table[i].type = methodt::stack_map_table_entryt::FULL;
-
-          UNUSED u2 offset_delta = read_u2();
+          u2 offset_delta = read_u2();
+          method.stack_map_table[i].offset_delta = offset_delta;
           u2 number_locals = read_u2();
           method.stack_map_table[i].locals.resize(number_locals);
           for (size_t k = 0; k < (size_t) number_locals; k++)
@@ -1175,7 +1174,6 @@ void java_bytecode_parsert::rcode_attribute(methodt &method)
               methodt::verification_type_infot &v = method.stack_map_table[i].locals.back();
               read_verification_type_info(v);
             }
-
           u2 number_stack_items = read_u2();
           method.stack_map_table[i].stack.resize(number_stack_items);
           for (size_t k = 0; k < (size_t) number_stack_items; k++)

--- a/src/java_bytecode/java_bytecode_parser.cpp
+++ b/src/java_bytecode/java_bytecode_parser.cpp
@@ -1141,7 +1141,7 @@ void java_bytecode_parsert::rcode_attribute(methodt &method)
       else if(frame_type == 251)
         {
           method.stack_map_table[i].type = methodt::stack_map_table_entryt::SAME_EXTENDED;
-          u2 offset=read_u2();
+          UNUSED u2 offset=read_u2();
           method.stack_map_table[i].locals.resize(0);
           method.stack_map_table[i].stack.resize(0);
           u2 offset_delta = read_u2();
@@ -1166,7 +1166,7 @@ void java_bytecode_parsert::rcode_attribute(methodt &method)
         {
           method.stack_map_table[i].type = methodt::stack_map_table_entryt::FULL;
 
-          u2 offset_delta = read_u2();
+          UNUSED u2 offset_delta = read_u2();
           u2 number_locals = read_u2();
           method.stack_map_table[i].locals.resize(number_locals);
           for (size_t k = 0; k < (size_t) number_locals; k++)

--- a/src/java_bytecode/java_bytecode_parser.cpp
+++ b/src/java_bytecode/java_bytecode_parser.cpp
@@ -1084,8 +1084,8 @@ void java_bytecode_parsert::rcode_attribute(methodt &method)
 
     for(unsigned i=0; i<local_variable_table_length; i++)
     {
-      UNUSED u2 start_pc=read_u2();
-      UNUSED u2 length=read_u2();
+      u2 start_pc=read_u2();
+      u2 length=read_u2();
       u2 name_index=read_u2();
       u2 descriptor_index=read_u2();
       u2 index=read_u2();
@@ -1093,6 +1093,8 @@ void java_bytecode_parsert::rcode_attribute(methodt &method)
       method.local_variable_table[i].index=index;
       method.local_variable_table[i].name=pool_entry(name_index).s;
       method.local_variable_table[i].signature=id2string(pool_entry(descriptor_index).s);
+      method.local_variable_table[i].start_pc=start_pc;
+      method.local_variable_table[i].length=length;
     }
   }
   else if(attribute_name=="StackMapTable")

--- a/src/java_bytecode/java_bytecode_parser.cpp
+++ b/src/java_bytecode/java_bytecode_parser.cpp
@@ -49,11 +49,6 @@ public:
   
   java_bytecode_parse_treet parse_tree;
 
-  typedef unsigned char u1;
-  typedef unsigned short u2;
-  typedef unsigned int u4;
-  typedef unsigned long long u8;
-  
   struct pool_entryt
   {
     u1 tag;
@@ -193,6 +188,16 @@ protected:
 #define CONSTANT_MethodHandle        15
 #define CONSTANT_MethodType          16
 #define CONSTANT_InvokeDynamic       18
+
+#define VTYPE_INFO_TOP         0
+#define VTYPE_INFO_INTEGER     1
+#define VTYPE_INFO_FLOAT       2
+#define VTYPE_INFO_LONG        3
+#define VTYPE_INFO_DOUBLE      4
+#define VTYPE_INFO_ITEM_NULL   5
+#define VTYPE_INFO_UNINIT_THIS 6
+#define VTYPE_INFO_OBJECT      7
+#define VTYPE_INFO_UNINIT      8
 
 /*******************************************************************\
 
@@ -1105,84 +1110,84 @@ void java_bytecode_parsert::rcode_attribute(methodt &method)
     {
       u1 frame_type=read_u1();
       if(0 <= frame_type && frame_type <= 63)
-        {
-          method.stack_map_table[i].type = methodt::stack_map_table_entryt::SAME;
-          method.stack_map_table[i].locals.resize(0);
-          method.stack_map_table[i].stack.resize(0);
-        }
+      {
+        method.stack_map_table[i].type = methodt::stack_map_table_entryt::SAME;
+        method.stack_map_table[i].locals.resize(0);
+        method.stack_map_table[i].stack.resize(0);
+      }
       else if(64 <= frame_type && frame_type <= 127)
-        {
-          method.stack_map_table[i].type = methodt::stack_map_table_entryt::SAME_LOCALS_ONE_STACK;
-          method.stack_map_table[i].locals.resize(0);
-          method.stack_map_table[i].stack.resize(1);
-          methodt::verification_type_infot verification_type_info;
-          read_verification_type_info(verification_type_info);
-          method.stack_map_table[i].stack[0] = verification_type_info;
-        }
+      {
+        method.stack_map_table[i].type = methodt::stack_map_table_entryt::SAME_LOCALS_ONE_STACK;
+        method.stack_map_table[i].locals.resize(0);
+        method.stack_map_table[i].stack.resize(1);
+        methodt::verification_type_infot verification_type_info;
+        read_verification_type_info(verification_type_info);
+        method.stack_map_table[i].stack[0] = verification_type_info;
+      }
       else if(frame_type == 247)
-        {
-          method.stack_map_table[i].type = methodt::stack_map_table_entryt::SAME_LOCALS_ONE_STACK_EXTENDED;
-          method.stack_map_table[i].locals.resize(0);
-          method.stack_map_table[i].stack.resize(1);
-          methodt::verification_type_infot verification_type_info;
-          u2 offset_delta = read_u2();
-          read_verification_type_info(verification_type_info);
-          method.stack_map_table[i].stack[0] = verification_type_info;
-          method.stack_map_table[i].offset_delta = offset_delta;
-        }
+      {
+        method.stack_map_table[i].type = methodt::stack_map_table_entryt::SAME_LOCALS_ONE_STACK_EXTENDED;
+        method.stack_map_table[i].locals.resize(0);
+        method.stack_map_table[i].stack.resize(1);
+        methodt::verification_type_infot verification_type_info;
+        u2 offset_delta = read_u2();
+        read_verification_type_info(verification_type_info);
+        method.stack_map_table[i].stack[0] = verification_type_info;
+        method.stack_map_table[i].offset_delta = offset_delta;
+      }
       else if(248 <= frame_type && frame_type <= 250)
-        {
-          method.stack_map_table[i].type = methodt::stack_map_table_entryt::CHOP;
-          method.stack_map_table[i].locals.resize(0);
-          method.stack_map_table[i].stack.resize(0);
-          u2 offset_delta = read_u2();
-          method.stack_map_table[i].offset_delta = offset_delta;
-        }
+      {
+        method.stack_map_table[i].type = methodt::stack_map_table_entryt::CHOP;
+        method.stack_map_table[i].locals.resize(0);
+        method.stack_map_table[i].stack.resize(0);
+        u2 offset_delta = read_u2();
+        method.stack_map_table[i].offset_delta = offset_delta;
+      }
       else if(frame_type == 251)
-        {
-          method.stack_map_table[i].type = methodt::stack_map_table_entryt::SAME_EXTENDED;
-          method.stack_map_table[i].locals.resize(0);
-          method.stack_map_table[i].stack.resize(0);
-          u2 offset_delta = read_u2();
-          method.stack_map_table[i].offset_delta = offset_delta;
-        }
+      {
+        method.stack_map_table[i].type = methodt::stack_map_table_entryt::SAME_EXTENDED;
+        method.stack_map_table[i].locals.resize(0);
+        method.stack_map_table[i].stack.resize(0);
+        u2 offset_delta = read_u2();
+        method.stack_map_table[i].offset_delta = offset_delta;
+      }
       else if(252 <= frame_type && frame_type <= 254)
+      {
+        size_t new_locals = (size_t) (frame_type - 251);
+        method.stack_map_table[i].type = methodt::stack_map_table_entryt::APPEND;
+        method.stack_map_table[i].locals.resize(new_locals);
+        method.stack_map_table[i].stack.resize(0);
+        u2 offset_delta = read_u2();
+        method.stack_map_table[i].offset_delta = offset_delta;
+        for(size_t k = 0; k < new_locals; k++)
         {
-          size_t new_locals = (size_t) (frame_type - 251);
-          method.stack_map_table[i].type = methodt::stack_map_table_entryt::APPEND;
-          method.stack_map_table[i].locals.resize(new_locals);
-          method.stack_map_table[i].stack.resize(0);
-          u2 offset_delta = read_u2();
-          method.stack_map_table[i].offset_delta = offset_delta;
-          for(size_t k = 0; k < new_locals; k++)
-            {
-              method.stack_map_table[i].locals.push_back(methodt::verification_type_infot());
-              methodt::verification_type_infot &v = method.stack_map_table[i].locals.back();
-              read_verification_type_info(v);
-            }
+          method.stack_map_table[i].locals.push_back(methodt::verification_type_infot());
+          methodt::verification_type_infot &v = method.stack_map_table[i].locals.back();
+          read_verification_type_info(v);
         }
+      }
       else if(frame_type == 255)
+      {
+        method.stack_map_table[i].type = methodt::stack_map_table_entryt::FULL;
+        u2 offset_delta = read_u2();
+        method.stack_map_table[i].offset_delta = offset_delta;
+        u2 number_locals = read_u2();
+        method.stack_map_table[i].locals.resize(number_locals);
+        for (size_t k = 0; k < (size_t) number_locals; k++)
         {
-          method.stack_map_table[i].type = methodt::stack_map_table_entryt::FULL;
-          u2 offset_delta = read_u2();
-          method.stack_map_table[i].offset_delta = offset_delta;
-          u2 number_locals = read_u2();
-          method.stack_map_table[i].locals.resize(number_locals);
-          for (size_t k = 0; k < (size_t) number_locals; k++)
-            {
-              method.stack_map_table[i].locals.push_back(methodt::verification_type_infot());
-              methodt::verification_type_infot &v = method.stack_map_table[i].locals.back();
-              read_verification_type_info(v);
-            }
-          u2 number_stack_items = read_u2();
-          method.stack_map_table[i].stack.resize(number_stack_items);
-          for (size_t k = 0; k < (size_t) number_stack_items; k++)
-            {
-              method.stack_map_table[i].stack.push_back(methodt::verification_type_infot());
-              methodt::verification_type_infot &v = method.stack_map_table[i].stack.back();
-              read_verification_type_info(v);
-            }
+          method.stack_map_table[i].locals.push_back(methodt::verification_type_infot());
+          methodt::verification_type_infot &v = method.stack_map_table[i].locals.back();
+          read_verification_type_info(v);
         }
+        u2 number_stack_items = read_u2();
+        method.stack_map_table[i].stack.resize(number_stack_items);
+        for (size_t k = 0; k < (size_t) number_stack_items; k++)
+        {
+          method.stack_map_table[i].stack.push_back(methodt::verification_type_infot());
+          methodt::verification_type_infot &v = method.stack_map_table[i].stack.back();
+          read_verification_type_info(v);
+        }
+      }
       else
         throw "ERROR: unknown stack frame type encountered";
     }
@@ -1194,46 +1199,40 @@ void java_bytecode_parsert::rcode_attribute(methodt &method)
 void java_bytecode_parsert::read_verification_type_info(methodt::verification_type_infot& v)
 {
   u1 tag = read_u1();
-  if(tag == 0)
-    {
-      v.type=methodt::verification_type_infot::TOP;
-    }
-  else if(tag == 1)
-    {
-      v.type=methodt::verification_type_infot::INTEGER;
-    }
-  else if(tag == 2)
-    {
-      v.type=methodt::verification_type_infot::FLOAT;
-    }
-  else if(tag == 3)
-    {
-      v.type=methodt::verification_type_infot::LONG;
-    }
-  else if(tag == 4)
-    {
-      v.type=methodt::verification_type_infot::DOUBLE;
-    }
-  else if(tag == 5)
-    {
-      v.type=methodt::verification_type_infot::ITEM_NULL;
-    }
-  else if(tag == 6)
-    {
-      v.type=methodt::verification_type_infot::UNINITIALIZED_THIS;
-    }
-  else if(tag == 7)
-    {
-      v.type=methodt::verification_type_infot::OBJECT;
-      v.cpool_index=read_u2();
-    }
-  else if(tag == 8)
-    {
-      v.type=methodt::verification_type_infot::UNINITIALIZED;
-      v.offset=read_u2();
-    }
-  else
+  switch(tag)
+  {
+  case VTYPE_INFO_TOP:
+    v.type=methodt::verification_type_infot::TOP;
+    break;
+  case VTYPE_INFO_INTEGER:
+    v.type=methodt::verification_type_infot::INTEGER;
+    break;
+  case VTYPE_INFO_FLOAT:
+    v.type=methodt::verification_type_infot::FLOAT;
+    break;
+  case VTYPE_INFO_LONG:
+    v.type=methodt::verification_type_infot::LONG;
+    break;
+  case VTYPE_INFO_DOUBLE:
+    v.type=methodt::verification_type_infot::DOUBLE;
+    break;
+  case VTYPE_INFO_ITEM_NULL:
+    v.type=methodt::verification_type_infot::ITEM_NULL;
+    break;
+  case VTYPE_INFO_UNINIT_THIS:
+    v.type=methodt::verification_type_infot::UNINITIALIZED_THIS;
+    break;
+  case VTYPE_INFO_OBJECT:
+    v.type=methodt::verification_type_infot::OBJECT;
+    v.cpool_index=read_u2();
+    break;
+  case VTYPE_INFO_UNINIT:
+    v.type=methodt::verification_type_infot::UNINITIALIZED;
+    v.offset=read_u2();
+    break;
+  default:
     throw "ERROR: unknown verification type info encountered";
+  }
 }
 
 /*******************************************************************\


### PR DESCRIPTION
This corrects local variable usage which depends on local frames. If present, the LocalVarTable contains information about the local variable scope. This scope is defined for a variable with index `n` via `start_pc` and `length`.

Instead of `variablet`, the `expanding_vector` `variables` now contains a `std::vector<variablet>` for each index. For an instruction at address `a`, the corresponding variable is searched as the valid variable for the frame `start_pc <= a + length(instruction) < start_pc + length`.

resolve #177 