### PR TITLE
skip monitorenter / monitorexit

### DIFF
--- a/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1349,6 +1349,13 @@ codet java_bytecode_convert_methodt::convert_instructions(
       results[0]=
         binary_predicate_exprt(op[0], "java_instanceof", arg0);
     }
+    else if(statement=="monitorenter")
+      warning() << "critical section with lock object is ignored ("
+                << i_it->source_location << ")" << eom;
+    else if(statement=="monitorexit")
+      // just skip, is always preceeded with "monitorenter"
+    {
+    }
     else
     {
       c=codet(statement);


### PR DESCRIPTION
Thread synchronization is currently not supported in Java. Emit warning
upon entering a critical section which is marked by `monitorenter`,
simply skip `monitorexit`.

temporary fix for #153