### PR TITLE
add classes of local var table to class_ref

### DIFF
--- a/src/java_bytecode/java_bytecode_parser.cpp
+++ b/src/java_bytecode/java_bytecode_parser.cpp
@@ -359,6 +359,11 @@ void java_bytecode_parsert::get_class_refs()
   {
     typet t=java_type_from_string(m.signature);
     get_class_refs_rec(t);
+    for(const auto & var : m.local_variable_table)
+    {
+      typet var_type=java_type_from_string(var.signature);
+      get_class_refs_rec(var_type);
+    }
   } 
 }
 


### PR DESCRIPTION
This supports loading class refs that only appear in the local variable
table. Not doing so result in some cases in an error of type `failed to
find type symbol`.

resolve #187