### PR TITLE
Added a case study into the CPROVER manual on test case generation

### DIFF
--- a/doc/html-manual/cover.shtml
+++ b/doc/html-manual/cover.shtml
@@ -1,0 +1,164 @@
+<!--#include virtual="header.inc" -->
+
+<link rel="stylesheet" href="highlight/styles/default.css">
+<script src="highlight/highlight.pack.js"></script>
+<script>hljs.initHighlightingOnLoad();</script>
+
+<p><a href="./">CPROVER Manual TOC</a></p>
+
+<h2>Automatic Test Case Generation by CPROVER</h2>
+
+<h3>A Small Tutorial with A Case Study</h3>
+
+<!--<h4>Verilog vs. ANSI-C</h4>-->
+
+<p class="justified">
+We assume that CBMC is installed on your system. If not so, follow
+<a href="installation-cbmc.shtml">these instructions</a>.</p>
+
+<!--<p class="justified">
+The following Verilog module implements a 4-bit counter
+(<a href="counter.v">counter.v</a>):
+-->
+</p>
+
+
+<p class="justified">
+CBMC can be used to automatically generate test cases following certain 
+<a href="https://en.wikipedia.org/wiki/Code_coverage">code coverage</a> criterion. 
+Common coverage criteria include  branch coverage, condition coverage and 
+the <a href="https://en.wikipedia.org/wiki/Modified_condition/decision_coverage">Modified Condition/ Decision Coverage (MC/DC)</a>.
+For example, MC/DC is used in several avionics software development guidances to ensure adequate testing 
+of safety critical softwares.
+Briefly speaking, in order to ensure MC/DC, for every conditional statement containing boolean decisions,
+each boolean variable should be evaluated one time 
+to "true" and one time to "false", which affects the decision's outcome.
+</p>
+
+<p class="justified">
+In the following, we are going to demonstrate how to utilize the code coverage functionality in CBMC,
+through a case study. Even though it is simple, the following program (namely <a href="pid.c">pid.c</a>)
+is excerpted from a real-time embedded benchmark <a href="https://www.irit.fr/recherches/ARCHI/MARCH/rubrique.php3?id_rubrique=97">PapaBench</a>,
+which is an application for autopilot/fly-by-wire and is developed to be embedded on different Unmanned Aerial Vehicles (UAV). It is adjusted
+for the demonstration purpose.
+</p>
+
+<pre><code class="c numbered">01:  // CONSTANTS:
+02:  #define MAX_CLIMB_SUM_ERR 150
+03:  #define MAX_CLIMB 1
+04:
+05:  #define CLOCK 16
+06:  #define MAX_PPRZ (CLOCK*600)
+07:  
+08:  #define CLIMB_LEVEL_GAZ 0.31
+09:  #define CLIMB_GAZ_OF_CLIMB 0.2
+10:  #define CLIMB_PITCH_OF_VZ_PGAIN 0.05
+11:  #define CLIMB_PGAIN -0.03
+12:  #define CLIMB_IGAIN 0.1
+13:  
+14:  const float pitch_of_vz_pgain=CLIMB_PITCH_OF_VZ_PGAIN;
+15:  const float climb_pgain=CLIMB_PGAIN;
+16:  const float climb_igain=CLIMB_IGAIN;
+17:  const float nav_pitch=0;
+18:  
+19:  // OUTPUTS:
+20:  float desired_gaz;
+21:  float desired_pitch;
+22:  float climb_sum_err;
+23:  
+24:  /** Computes desired_gaz and desired_pitch */
+25:  void climb_pid_run (float desired_climb,  float estimator_z_dot, float old_climb_sum_err) {
+26:    /** Range of inputs */ 
+27:    __CPROVER_assume(desired_climb>=-MAX_CLIMB && desired_climb<=MAX_CLIMB);
+28:    __CPROVER_assume(estimator_z_dot>=-MAX_CLIMB && estimator_z_dot<=MAX_CLIMB);
+29:    __CPROVER_assume(old_climb_sum_err>=-MAX_CLIMB_SUM_ERR && old_climb_sum_err<=MAX_CLIMB_SUM_ERR);
+30:  
+31:    float err=estimator_z_dot-desired_climb;
+32:
+33:    float fgaz=climb_pgain*(err+climb_igain*old_climb_sum_err)+CLIMB_LEVEL_GAZ+CLIMB_GAZ_OF_CLIMB*desired_climb;
+34:  
+35:    float pprz=fgaz*MAX_PPRZ;
+36:    desired_gaz=((pprz>=0 && pprz<=MAX_PPRZ) ? pprz : (pprz>MAX_PPRZ ? MAX_PPRZ : 0));
+37:                      
+38:    /** pitch offset for climb */
+39:    float pitch_of_vz=(desired_climb>0) ? desired_climb*pitch_of_vz_pgain : 0;
+40:    desired_pitch=nav_pitch+pitch_of_vz;
+41:  
+42:    climb_sum_err=err+old_climb_sum_err;
+43:    if (climb_sum_err>MAX_CLIMB_SUM_ERR) climb_sum_err=MAX_CLIMB_SUM_ERR;
+44:    if (climb_sum_err<-MAX_CLIMB_SUM_ERR) climb_sum_err=-MAX_CLIMB_SUM_ERR;
+45:  
+46:  }
+</code></pre>
+
+<p class="justified">
+The function <code>climb_pid_run</code> is part of the whole PID control procedure. Its input arguments
+<code>desired_climb</code> and <code>estimator_z_dot</code> represent respectively the desired and 
+estimated speed in meters per second in the vertical direction; <code>old_climb_sum_err</code> is 
+the current accumulated error between <code>desired_climb</code> and <code>estimator_z_dot</code>.
+Given inputs, the function then computes the <code>desired_gaz</code> and <code>desired_pitch</code>
+parameters, and update the accumulated <code>climb_sum_err</code>.
+</p>
+
+<p class="justified">
+There are 4 conditional statements in the function: line 36, line 39, and line 43 and line 44.
+Suppose that the interest is to achieve a code coverage over the program according to MC/DC criterion.
+This can be done through CBMC by calling 
+</p>
+
+<pre>
+<code> cbmc pid.c --cover mcdc --function climb_pid_run
+</code></pre>
+
+<p class="justified">
+The <code>--cover mcdc</code> option chooses the coverage criterion, and <code>--function climb_pid_run</code>
+specifies the function to be analyzed.
+</p>
+
+<p class="justified">
+The printed outputs will display the configurations of conditions that have been covered by CBMC.
+At first, for each conditional statement, the configuration for its decision to be <em>true</em>/<em>false</em>
+will be covered.
+
+On the other hand, to fullfil the requirement of MC/DC, more configurations need to be taken into account.
+For example, at line 36, there is
+</p>
+<pre>
+<code> pprz>=0 && pprz<=MAX_PPRZ
+</code></pre>
+To respect with MC/DC on such a decision (either <em>true</em> or <em>false</em>), three 
+configurations for its conditions (boolean expressions) are finally covered and reported by CBMC.
+We show them here, and the labels are added for the purpose of convenient explanation in this tutorial.
+<pre>
+<code>C1: !(pprz >= (float)0) && pprz <= (float)(16 * 600)
+C2: pprz >= (float)0 && !(pprz <= (float)(16 * 600))
+C3: pprz >= (float)0 && pprz <= (float)(16 * 600)
+</code></pre>
+
+<p class="justified">
+In the end of the run of CBMC, test cases are automatically reported and formatted.
+We put the test suite generated for the case study in below, with labels for convenience.
+</p>
+<pre><code>Test suite:
+T1: desired_climb=6.250003e-2f, estimator_z_dot=1.000000f, old_climb_sum_err=8.988036e+0f
+T2: desired_climb=0.000000f, estimator_z_dot=6.134232e-38f, old_climb_sum_err=-6.232042e-37f
+T3: desired_climb=6.750841e-20f, estimator_z_dot=-6.011939e-1f, old_climb_sum_err=1.156406e+2f
+T4: desired_climb=-9.999999e-1f, estimator_z_dot=1.000000f, old_climb_sum_err=150.000000f
+T5: desired_climb=9.999999e-1f, estimator_z_dot=-1.000000f, old_climb_sum_err=-150.000000f
+</code></pre>
+<p class="justified">
+Corresponding to conditions covered for the MC/DC requirement, T1 and T2 are both tests that make C3 to be <em>true</em>, 
+T3 and T4 are eligible to cover C1, and T5 is for C2.
+Similarly, conditional statements at line 39, 43 and 44 can be analyzed.
+As we can see, CBMC greatly releases the burden of manually generating test cases.
+</p>
+
+<p class="justified">
+More detailed information can be outputted together with these test cases (e.g., in xml format)
+by specifying options like <code>--trace</code> and <code>--xml-ui</code> when running CBMC.
+Finally, besides <code>--cover mcdc</code>, other coverage criteria like <code>branch</code>, <code>decision</code>,
+<code>path</code> etc. are also available when calling CBMC.
+</p>
+
+
+

--- a/doc/html-manual/pid.c
+++ b/doc/html-manual/pid.c
@@ -1,0 +1,47 @@
+// CONSTANTS:
+#define MAX_CLIMB_SUM_ERR 150
+#define MAX_CLIMB 1
+
+#define CLOCK 16
+#define MAX_PPRZ (CLOCK*600)
+
+#define CLIMB_LEVEL_GAZ 0.31
+#define CLIMB_GAZ_OF_CLIMB 0.2
+#define CLIMB_PITCH_OF_VZ_PGAIN 0.05
+#define CLIMB_PGAIN -0.03
+#define CLIMB_IGAIN 0.1
+
+const float pitch_of_vz_pgain=CLIMB_PITCH_OF_VZ_PGAIN;
+const float climb_pgain=CLIMB_PGAIN;
+const float climb_igain=CLIMB_IGAIN;
+const float nav_pitch=0;
+
+// OUTPUTS:
+float desired_gaz;
+float desired_pitch;
+float climb_sum_err;
+
+/** Computes desired_gaz and desired_pitch */
+void climb_pid_run (float desired_climb,  float estimator_z_dot, float old_climb_sum_err) {
+  /** Range of inputs */ 
+  __CPROVER_assume(desired_climb>=-MAX_CLIMB && desired_climb<=MAX_CLIMB);
+  __CPROVER_assume(estimator_z_dot>=-MAX_CLIMB && estimator_z_dot<=MAX_CLIMB);
+  __CPROVER_assume(old_climb_sum_err>=-MAX_CLIMB_SUM_ERR && old_climb_sum_err<=MAX_CLIMB_SUM_ERR);
+
+  float err=estimator_z_dot-desired_climb;
+
+  float fgaz=climb_pgain*(err+climb_igain*old_climb_sum_err)+CLIMB_LEVEL_GAZ+CLIMB_GAZ_OF_CLIMB*desired_climb;
+
+  float pprz=fgaz*MAX_PPRZ;
+  desired_gaz=((pprz>=0 && pprz<=MAX_PPRZ) ? pprz : (pprz>MAX_PPRZ ? MAX_PPRZ : 0));
+  
+  /** pitch offset for climb */
+  float pitch_of_vz=(desired_climb>0) ? desired_climb*pitch_of_vz_pgain : 0;
+  desired_pitch=nav_pitch+pitch_of_vz;
+
+  climb_sum_err=err+old_climb_sum_err;
+  if (climb_sum_err>MAX_CLIMB_SUM_ERR) climb_sum_err=MAX_CLIMB_SUM_ERR;
+  if (climb_sum_err<-MAX_CLIMB_SUM_ERR) climb_sum_err=-MAX_CLIMB_SUM_ERR;
+
+}
+


### PR DESCRIPTION
Updated the CPROVER manual, by adding a case study on test case generation following code coverage. In particular, the ``--cover mcdc`` option of  CBMC is investigated.