### PR TITLE
direct support for ID_c_bool in exprt

### DIFF
--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -245,9 +245,18 @@ Function: exprt::is_true
 
 bool exprt::is_true() const
 {
-  return is_constant() &&
-         type().id()==ID_bool &&
-         get(ID_value)!=ID_false;
+  if(is_constant())
+  {
+    if(type().id()==ID_bool)
+      return get(ID_value)!=ID_false;
+    else if(type().id()==ID_c_bool)
+    {
+      mp_integer i;
+      to_integer(*this,i);
+      return i!=mp_zero;
+    }
+  }
+  return false;
 }
 
 /*******************************************************************\
@@ -264,9 +273,14 @@ Function: exprt::is_false
 
 bool exprt::is_false() const
 {
-  return is_constant() &&
-         type().id()==ID_bool &&
-         get(ID_value)==ID_false;
+  if(is_constant())
+  {
+    if(type().id()==ID_bool)
+      return get(ID_value)==ID_false;
+    else if(type().id()==ID_c_bool)
+      return !is_true();
+  }
+  return false;
 }
 
 /*******************************************************************\

--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -253,7 +253,7 @@ bool exprt::is_true() const
     {
       mp_integer i;
       to_integer(*this,i);
-      return i!=mp_zero;
+      return i!=mp_integer(0);
     }
   }
   return false;

--- a/src/util/mp_arith.h
+++ b/src/util/mp_arith.h
@@ -27,6 +27,5 @@ const mp_integer binary2integer(const std::string &, bool is_signed);
 mp_integer::ullong_t integer2ulong(const mp_integer &);
 std::size_t integer2size_t(const mp_integer &);
 unsigned integer2unsigned(const mp_integer &);
-const mp_integer mp_zero=string2integer("0");
 
 #endif

--- a/src/util/mp_arith.h
+++ b/src/util/mp_arith.h
@@ -27,5 +27,6 @@ const mp_integer binary2integer(const std::string &, bool is_signed);
 mp_integer::ullong_t integer2ulong(const mp_integer &);
 std::size_t integer2size_t(const mp_integer &);
 unsigned integer2unsigned(const mp_integer &);
+const mp_integer mp_zero=string2integer("0");
 
 #endif


### PR DESCRIPTION
The `is_true()` / `is_false()` functions in `exprt` currently support
only the `ID_bool` type. In Java, Boolean values are represented as
`ID_c_bool` due to the internal JVM usage of integers. Adding this
support here seems easier than having special treatment in
`java_bytecode`.
