### PR TITLE
Check static array bounds even when the underlying object is dynamic.`

### DIFF
--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1185,13 +1185,11 @@ void goto_checkt::bounds_check(
 
     add_guarded_claim(
       precond,
-      name+" upper bound",
+      name+" dynamic object upper bound",
       "array bounds",
       expr.find_source_location(),
       expr,
       guard);
-
-    return;
   }
 
   const exprt &size=array_type.id()==ID_array ?


### PR DESCRIPTION
See writeup in https://github.com/diffblue/cbmc/issues/239

Untested except against the test case given in that issue.
