### PR TITLE
Symex: synthesise clean references to subfields and/or array indices when addressing subexpressions

### DIFF
--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -514,6 +514,8 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
     const typet &object_type=ns.follow(object.type());
     const exprt &root_object=o.root_object();
     const typet &root_object_type=ns.follow(root_object.type());
+
+    exprt root_object_subexpression=root_object;
     
     if(dereference_type_compare(object_type, dereference_type) && 
        o.offset().is_zero())
@@ -572,6 +574,13 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
 
       if(ns.follow(result.value.type())!=ns.follow(dereference_type))
         result.value.make_typecast(dereference_type);
+    }
+    else if(get_subexpression_at_offset(root_object_subexpression, o.offset(),
+					dereference_type, ns))
+    {
+      // Successfully found a member, array index, or combination thereof
+      // that matches the desired type and offset:
+      result.value=root_object_subexpression;
     }
     else
     {

--- a/src/util/pointer_offset_size.cpp
+++ b/src/util/pointer_offset_size.cpp
@@ -21,6 +21,39 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "pointer_offset_size.h"
 
+member_offset_iterator::member_offset_iterator(const struct_typet _type,
+                                               const namespacet _ns) :
+  type(_type),
+  ns(_ns),
+  bit_field_bits(0),
+  current({0,0})
+{
+}
+
+member_offset_iterator& member_offset_iterator::operator++()
+{
+  if(current.second!=-1) // Already failed?
+  {
+    const auto& comp=type.components()[current.first];
+    if(comp.type().id()==ID_c_bit_field)
+    {
+      // take the extra bytes needed
+      std::size_t w=to_c_bit_field_type(comp.type()).get_width();
+      for(; w>bit_field_bits; ++current.second, bit_field_bits+=8);
+      bit_field_bits-=w;
+    }
+    else
+    {
+      const typet &subtype=comp.type();
+      mp_integer sub_size=pointer_offset_size(subtype, ns);
+      if(sub_size==-1) current.second=-1; // give up
+      else current.second+=sub_size;
+    }
+  }
+  ++current.first;
+  return *this;
+}
+
 /*******************************************************************\
 
 Function: member_offset
@@ -39,35 +72,18 @@ mp_integer member_offset(
   const namespacet &ns)
 {
   const struct_typet::componentst &components=type.components();
-  
-  mp_integer result=0;
-  std::size_t bit_field_bits=0;
+  member_offset_iterator offsets(type,ns);
   
   for(struct_typet::componentst::const_iterator
       it=components.begin();
-      it!=components.end();
-      it++)
+      it!=components.end() && offsets->second!=-1;
+      ++it, ++offsets)
   {
     if(it->get_name()==member)
       break;
-
-    if(it->type().id()==ID_c_bit_field)
-    {
-      // take the extra bytes needed
-      std::size_t w=to_c_bit_field_type(it->type()).get_width();
-      for(; w>bit_field_bits; ++result, bit_field_bits+=8);
-      bit_field_bits-=w;
-    }
-    else
-    {
-      const typet &subtype=it->type();
-      mp_integer sub_size=pointer_offset_size(subtype, ns);
-      if(sub_size==-1) return -1; // give up
-      result+=sub_size;
-    }
   }
 
-  return result;
+  return offsets->second;
 }
 
 /*******************************************************************\

--- a/src/util/pointer_offset_size.cpp
+++ b/src/util/pointer_offset_size.cpp
@@ -21,8 +21,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "pointer_offset_size.h"
 
-member_offset_iterator::member_offset_iterator(const struct_typet _type,
-                                               const namespacet _ns) :
+member_offset_iterator::member_offset_iterator(const struct_typet& _type,
+                                               const namespacet& _ns) :
   type(_type),
   ns(_ns),
   bit_field_bits(0),

--- a/src/util/pointer_offset_size.cpp
+++ b/src/util/pointer_offset_size.cpp
@@ -23,10 +23,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 member_offset_iterator::member_offset_iterator(const struct_typet& _type,
                                                const namespacet& _ns) :
+  current({0,0}),
   type(_type),
   ns(_ns),
-  bit_field_bits(0),
-  current({0,0})
+  bit_field_bits(0)
 {
 }
 
@@ -636,13 +636,14 @@ exprt build_sizeof_expr(
 bool get_subexpression_at_offset(
   exprt& result,
   mp_integer offset,
-  const typet& target_type,
+  const typet& target_type_raw,
   const namespacet& ns)
 {
-  if(offset==0 && result.type()==target_type)
-    return true;
+  const typet& source_type=ns.follow(result.type());
+  const typet& target_type=ns.follow(target_type_raw);
 
-  const typet& source_type=result.type();
+  if(offset==0 && source_type==target_type)
+    return true;
   
   if(source_type.id()==ID_struct)
   {

--- a/src/util/pointer_offset_size.h
+++ b/src/util/pointer_offset_size.h
@@ -21,6 +21,20 @@ class constant_exprt;
 
 // these return -1 on failure
 
+class member_offset_iterator {
+  typedef std::pair<size_t,mp_integer> refst;
+  refst current;
+  const struct_typet &type;
+  const namespacet &ns;
+  size_t bit_field_bits;
+ public:
+  member_offset_iterator(const struct_typet _type,
+                         const namespacet _ns);
+  member_offset_iterator& operator++();
+  const refst& operator*() const { return current; }
+  const refst* operator->() const { return &current; }
+};
+
 mp_integer member_offset(
   const struct_typet &type,
   const irep_idt &member,

--- a/src/util/pointer_offset_size.h
+++ b/src/util/pointer_offset_size.h
@@ -28,8 +28,8 @@ class member_offset_iterator {
   const namespacet &ns;
   size_t bit_field_bits;
  public:
-  member_offset_iterator(const struct_typet _type,
-                         const namespacet _ns);
+  member_offset_iterator(const struct_typet& _type,
+                         const namespacet& _ns);
   member_offset_iterator& operator++();
   const refst& operator*() const { return current; }
   const refst* operator->() const { return &current; }

--- a/src/util/pointer_offset_size.h
+++ b/src/util/pointer_offset_size.h
@@ -71,4 +71,16 @@ exprt build_sizeof_expr(
   const constant_exprt &expr,
   const namespacet &ns);
 
+bool get_subexpression_at_offset(
+  exprt& result,
+  mp_integer offset,
+  const typet& target_type,
+  const namespacet& ns);
+
+bool get_subexpression_at_offset(
+  exprt& result,
+  const exprt& offset,
+  const typet& target_type,
+  const namespacet& ns);
+
 #endif


### PR DESCRIPTION
See issue #235 for details.