### PR TITLE
Ensure globally unique location numbers after reading binary

### DIFF
--- a/src/goto-programs/read_bin_goto_object.cpp
+++ b/src/goto-programs/read_bin_goto_object.cpp
@@ -160,6 +160,8 @@ bool read_bin_goto_object_v3(
     if(hidden) f.make_hidden();
   }
   
+  functions.compute_location_numbers();
+
   return false;
 }
 


### PR DESCRIPTION
Location numbers are not stored in v3 goto binaries. Reading from
binaries up to now only invoked update() on a per-function level. The
additional goto_functionst::compute_location_numbers() ensures globally
unique location numbers. Fixes #313.