### PR TITLE
Repeat the from pull request #288 for other domains.

### DIFF
--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1803,6 +1803,10 @@ void value_sett::apply_code(
   else if(statement==ID_fence)
   {
   }
+  else if(statement==ID_input || statement==ID_output)
+  {
+	  // doesn't do anything
+  }
   else
   {
     //std::cerr << code.pretty() << std::endl;

--- a/src/pointer-analysis/value_set_fivr.cpp
+++ b/src/pointer-analysis/value_set_fivr.cpp
@@ -1882,6 +1882,11 @@ void value_set_fivrt::apply_code(
       assign(lhs, code.op0(), ns);
     }
   }
+  else if(statement==ID_input || statement==ID_output)
+  {
+	  // doesn't do anything
+  }
+
   else
     throw
       code.pretty()+"\n"+

--- a/src/pointer-analysis/value_set_fivrns.cpp
+++ b/src/pointer-analysis/value_set_fivrns.cpp
@@ -1517,6 +1517,10 @@ void value_set_fivrnst::apply_code(
       assign(lhs, code.op0(), ns);
     }
   }
+  else if(statement==ID_input || statement==ID_output)
+  {
+	  // doesn't do anything
+  }
   else
   {
     throw


### PR DESCRIPTION
https://github.com/diffblue/cbmc/issues/281

was fixed by:

https://github.com/diffblue/cbmc/pull/288

this copies the fix to other pointer analysis domains.  Without this, some of the functionality of goto-instrument is broken.
