### PR TITLE
Fix libzip-download make rule

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -96,10 +96,10 @@ libzip-download:
 	# The below wants SSL
 	#@lwp-download http://www.nih.at/libzip/libzip-1.1.2.tar.gz
 	@lwp-download http://http.debian.net/debian/pool/main/libz/libzip/libzip_1.1.2.orig.tar.gz
-	@tar xfz libzip-1.1.2.tar.gz
+	@tar xfz libzip_1.1.2.orig.tar.gz
 	@rm -Rf ../libzip
 	@mv libzip-1.1.2 ../libzip
-	@rm libzip-1.1.2.tar.gz
+	@rm libzip_1.1.2.orig.tar.gz
 
 libzip-build:
 	@echo "Building zlib"


### PR DESCRIPTION
https://github.com/diffblue/cbmc/commit/6b21f364f215a4bf9b5884b727943486d50f7827 changed the name of the archive that is downloaded, but did not adapt subsequent steps. This PR fixes that.