### PR TITLE
Fix typos in struct_bytewise (__mk68k__ -> __m68k__)

### DIFF
--- a/regression/cbmc-with-incr/Struct_Bytewise1/struct_bytewise.c
+++ b/regression/cbmc-with-incr/Struct_Bytewise1/struct_bytewise.c
@@ -3,7 +3,7 @@
 
 #if !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
 
-#if defined(__avr32__) || defined(__hppa__)    || defined(__mk68k__) || \
+#if defined(__avr32__) || defined(__hppa__)    || defined(__m68k__) || \
     defined(__mips__)  || defined(__powerpc__) || defined(__s390__) || \
     defined(__s390x__) || defined(__sparc__)
 

--- a/regression/cbmc/Struct_Bytewise1/struct_bytewise.c
+++ b/regression/cbmc/Struct_Bytewise1/struct_bytewise.c
@@ -3,7 +3,7 @@
 
 #if !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
 
-#if defined(__avr32__) || defined(__hppa__)    || defined(__mk68k__) || \
+#if defined(__avr32__) || defined(__hppa__)    || defined(__m68k__) || \
     defined(__mips__)  || defined(__powerpc__) || defined(__s390__) || \
     defined(__s390x__) || defined(__sparc__)
 


### PR DESCRIPTION
Hi!

This patch fixes two typos which I stumbled over being one of Debian's m68k porters.

The code checks for m68k by looking whether `__mk68k__` is defined. However, the proper definition to look for is `__m68k__`:

`(sid-m68k-sbuild)root@ikarus:/# echo | gcc -E -dM - |grep mk68`
`(sid-m68k-sbuild)root@ikarus:/# echo | gcc -E -dM - |grep m68k`
`#define __m68k__ 1`
`(sid-m68k-sbuild)root@ikarus:/#`

This was tested with gcc-6.2.1 on Debian/m68k.

Thanks,
Adrian