### PR TITLE
Disable cprover memory for java

### DIFF
--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/time_stopping.h>
 #include <util/message.h>
 #include <util/json.h>
+#include <util/cprover_prefix.h>
 
 #include <langapi/mode.h>
 #include <langapi/languages.h>
@@ -427,6 +428,12 @@ safety_checkert::resultt bmct::run(
 
   symex.set_message_handler(get_message_handler());
   symex.options=options;
+
+  {
+    const symbolt *init_symbol;
+    if(!ns.lookup(CPROVER_PREFIX "initialize", init_symbol))
+      symex.mode=init_symbol->mode;
+  }  
 
   status() << "Starting Bounded Model Checking" << eom;
 

--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -432,7 +432,7 @@ safety_checkert::resultt bmct::run(
   {
     const symbolt *init_symbol;
     if(!ns.lookup(CPROVER_PREFIX "initialize", init_symbol))
-      symex.mode=init_symbol->mode;
+      symex.language_mode=init_symbol->mode;
   }  
 
   status() << "Starting Bounded Model Checking" << eom;

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -49,6 +49,7 @@ public:
     remaining_vccs(0),
     constant_propagation(true),
     new_symbol_table(_new_symbol_table),
+    mode(),
     ns(_ns),
     target(_target),
     atomic_section_counter(0),
@@ -94,6 +95,8 @@ public:
 
   optionst options;
   symbol_tablet &new_symbol_table;
+
+  irep_idt mode;
 
 protected:
   const namespacet &ns;

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -49,7 +49,7 @@ public:
     remaining_vccs(0),
     constant_propagation(true),
     new_symbol_table(_new_symbol_table),
-    mode(),
+    language_mode(),
     ns(_ns),
     target(_target),
     atomic_section_counter(0),
@@ -96,7 +96,9 @@ public:
   optionst options;
   symbol_tablet &new_symbol_table;
 
-  irep_idt mode;
+  /// language_mode: ID_java, ID_C or another language identifier
+  /// if we know the source language in use, irep_idt() otherwise.
+  irep_idt language_mode;
 
 protected:
   const namespacet &ns;

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -295,8 +295,9 @@ void goto_symext::dereference_rec(
       ns,
       new_symbol_table,
       options,
-      symex_dereference_state);
-
+      symex_dereference_state,
+      mode);      
+    
     // std::cout << "**** " << from_expr(ns, "", tmp1) << std::endl;
     exprt tmp2=dereference.dereference(
       tmp1, guard, write?value_set_dereferencet::WRITE:value_set_dereferencet::READ);

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -296,7 +296,7 @@ void goto_symext::dereference_rec(
       new_symbol_table,
       options,
       symex_dereference_state,
-      mode);      
+      language_mode);
     
     // std::cout << "**** " << from_expr(ns, "", tmp1) << std::endl;
     exprt tmp2=dereference.dereference(

--- a/src/pointer-analysis/goto_program_dereference.h
+++ b/src/pointer-analysis/goto_program_dereference.h
@@ -19,6 +19,10 @@ Author: Daniel Kroening, kroening@kroening.com
 class goto_program_dereferencet:protected dereference_callbackt
 {
 public:
+  // Note: this currently doesn't specify a source language
+  // for the final argument to value_set_dereferencet.
+  // This means that language-inappropriate values such as
+  // (struct A*)some_integer_value in Java, may be returned.
   goto_program_dereferencet(
     const namespacet &_ns,
     symbol_tablet &_new_symbol_table,
@@ -27,7 +31,7 @@ public:
     options(_options),
     ns(_ns),
     value_sets(_value_sets),
-    dereference(_ns, _new_symbol_table, _options, *this) { }
+    dereference(_ns, _new_symbol_table, _options, *this, ID_nil) { }
 
   void dereference_program(
     goto_programt &goto_program,

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -460,7 +460,7 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
       return result;
     }
     
-    const symbolt &memory_symbol=ns.lookup(CPROVER_PREFIX "memory");    
+    const symbolt &memory_symbol=ns.lookup(CPROVER_PREFIX "memory");
     exprt symbol_expr=symbol_exprt(memory_symbol.name, memory_symbol.type);
 
     exprt pointer_offset=unary_exprt(

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -454,7 +454,13 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
     // This is stuff like *((char *)5).
     // This is turned into an access to __CPROVER_memory[...].
 
-    const symbolt &memory_symbol=ns.lookup(CPROVER_PREFIX "memory");
+    if(language_mode==ID_java)
+    {
+      result.value=nil_exprt();
+      return result;
+    }
+    
+    const symbolt &memory_symbol=ns.lookup(CPROVER_PREFIX "memory");    
     exprt symbol_expr=symbol_exprt(memory_symbol.name, memory_symbol.type);
 
     exprt pointer_offset=unary_exprt(

--- a/src/pointer-analysis/value_set_dereference.h
+++ b/src/pointer-analysis/value_set_dereference.h
@@ -39,11 +39,13 @@ public:
     const namespacet &_ns,
     symbol_tablet &_new_symbol_table,
     const optionst &_options,
-    dereference_callbackt &_dereference_callback):
+    dereference_callbackt &_dereference_callback,
+    const irep_idt _language_mode = irep_idt()):
     ns(_ns),
     new_symbol_table(_new_symbol_table),
     options(_options),
-    dereference_callback(_dereference_callback)
+    dereference_callback(_dereference_callback),
+    language_mode(_language_mode)
   { }
 
   virtual ~value_set_dereferencet() { }
@@ -80,6 +82,7 @@ private:
   symbol_tablet &new_symbol_table;
   const optionst &options;
   dereference_callbackt &dereference_callback;
+  const irep_idt language_mode;
   static unsigned invalid_counter;
 
   bool dereference_type_compare(

--- a/src/pointer-analysis/value_set_dereference.h
+++ b/src/pointer-analysis/value_set_dereference.h
@@ -40,7 +40,7 @@ public:
     symbol_tablet &_new_symbol_table,
     const optionst &_options,
     dereference_callbackt &_dereference_callback,
-    const irep_idt _language_mode=irep_idt()):
+    const irep_idt _language_mode):
     ns(_ns),
     new_symbol_table(_new_symbol_table),
     options(_options),

--- a/src/pointer-analysis/value_set_dereference.h
+++ b/src/pointer-analysis/value_set_dereference.h
@@ -40,7 +40,7 @@ public:
     symbol_tablet &_new_symbol_table,
     const optionst &_options,
     dereference_callbackt &_dereference_callback,
-    const irep_idt _language_mode = irep_idt()):
+    const irep_idt _language_mode=irep_idt()):
     ns(_ns),
     new_symbol_table(_new_symbol_table),
     options(_options),
@@ -82,6 +82,8 @@ private:
   symbol_tablet &new_symbol_table;
   const optionst &options;
   dereference_callbackt &dereference_callback;
+  /// language_mode: ID_java, ID_C or another language identifier
+  /// if we know the source language in use, irep_idt() otherwise.
   const irep_idt language_mode;
   static unsigned invalid_counter;
 


### PR DESCRIPTION
#197 and diffblue/verification-engine-utils#173 showed that in some circumstances, goto-symex's value-set analysis can reach the conclusion that an integer may be cast to a pointer, and so generate a reference to the __CPROVER_memory symbol. This is invalid in Java however, since the symbol is not defined and of course Java cannot express dereferencing a non-pointer type.

The attached patch disables generation of __CPROVER_memory references when a Java-typed entry point is found. I couldn't provide a test case against master at this time however because the examples in both of the above bugs now succeed against master, presumably because value-set analysis has been improved and is harder to confuse into introducing a pointer-to-int cast.