### PR TITLE
Cause a regeneration of the _start method if a --function is provided

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,6 +74,21 @@ test_script:
     sed -i "13i mv $NAME.exe $NAME.gb" goto-instrument-typedef/chain.sh || true
     cat goto-instrument-typedef/chain.sh || true
 
+    sed -i "s/goto-cc\/goto-cc/goto-cc\/goto-cl/" goto-cc-cbmc/chain.sh || true
+    sed -i "11s/.*/$GC $NAME.c/" goto-cc-cbmc/chain.sh || true
+    sed -i "12i mv $NAME.exe $NAME.gb" goto-cc-cbmc/chain.sh || true
+    cat goto-cc-cbmc/chain.sh || true
+
+    sed -i "s/goto-cc\/goto-cc/goto-cc\/goto-cl/" goto-cc-goto-analyzer/chain.sh || true
+    sed -i "11s/.*/$gc $name.c/" goto-cc-goto-analyzer/chain.sh || true
+    sed -i "12i mv $name.exe $name.gb" goto-cc-goto-analyzer/chain.sh || true
+    cat goto-cc-goto-analyzer/chain.sh || true
+
+    sed -i "s/goto-cc\/goto-cc/goto-cc\/goto-cl/" goto-cc-symex/chain.sh || true
+    sed -i "11s/.*/$gc $name.c/" goto-cc-symex/chain.sh || true
+    sed -i "12i mv $name.exe $name.gb" goto-cc-symex/chain.sh || true
+    cat goto-cc-symex/chain.sh || true
+
     rem HACK disable failing tests
     rmdir /s /q ansi-c\arch_flags_mcpu_bad
     rmdir /s /q ansi-c\arch_flags_mcpu_good

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -6,6 +6,8 @@ DIRS = ansi-c \
        cpp \
        goto-analyzer \
        goto-cc-cbmc \
+       goto-cc-goto-analyzer \
+       goto-cc-goto-symex \
        goto-diff \
        goto-gcc \
        goto-instrument \

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -5,6 +5,7 @@ DIRS = ansi-c \
        cbmc-java-inheritance \
        cpp \
        goto-analyzer \
+       goto-cc-cbmc \
        goto-diff \
        goto-gcc \
        goto-instrument \

--- a/regression/cbmc/pointer-function-parameters-2/test.desc
+++ b/regression/cbmc/pointer-function-parameters-2/test.desc
@@ -4,9 +4,9 @@ main.c
 ^\*\* 7 of 7 covered \(100.0%\)$
 ^\*\* Used 4 iterations$
 ^Test suite:$
-^a=\(\(signed int \*\*\)NULL\), tmp\$1=[^,]*, tmp\$2=[^,]*$
-^a=&tmp\$1!0, tmp\$1=\(\(signed int \*\)NULL\), tmp\$2=[^,]*$
-^a=&tmp\$1!0, tmp\$1=&tmp\$2!0, tmp\$2=([012356789][0-9]*|4[0-9]+)$
-^a=&tmp\$1!0, tmp\$1=&tmp\$2!0, tmp\$2=4$
+^a=\(\(signed int \*\*\)NULL\), tmp\$\d+=[^,]*, tmp\$\d+=[^,]*$
+^a=&tmp\$\d+!0, tmp\$\d+=\(\(signed int \*\)NULL\), tmp\$\d+=[^,]*$
+^a=&tmp\$\d+!0, tmp\$\d+=&tmp\$\d+!0, tmp\$\d+=([012356789][0-9]*|4[0-9]+)$
+^a=&tmp\$\d+!0, tmp\$\d+=&tmp\$\d+!0, tmp\$\d+=4$
 --
 ^warning: ignoring

--- a/regression/cbmc/pointer-function-parameters/test.desc
+++ b/regression/cbmc/pointer-function-parameters/test.desc
@@ -4,8 +4,8 @@ main.c
 ^\*\* 5 of 5 covered \(100\.0%\)$
 ^\*\* Used 3 iterations$
 ^Test suite:$
-^a=\(\(signed int \*\)NULL\), tmp\$1=[^,]*$
-^a=&tmp\$1!0, tmp\$1=4$
-^a=&tmp\$1!0, tmp\$1=([012356789][0-9]*|4[0-9]+)$
+^a=\(\(signed int \*\)NULL\), tmp\$\d+=[^,]*$
+^a=&tmp\$\d+!0, tmp\$\d+=4$
+^a=&tmp\$\d+!0, tmp\$\d+=([012356789][0-9]*|4[0-9]+)$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/regenerate-entry-function/main.c
+++ b/regression/goto-analyzer/regenerate-entry-function/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+int fun(int x)
+{
+	int i;
+	if(i>=20)
+    assert(i>=10);
+}
+
+int main(int argc, char** argv)
+{
+  int i;
+
+  if(i>=5)
+    assert(i>=10);
+}

--- a/regression/goto-analyzer/regenerate-entry-function/test.desc
+++ b/regression/goto-analyzer/regenerate-entry-function/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--function fun --show-goto-functions
+^\s*fun\(x\);$
+^EXIT=6$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/goto-cc-cbmc/Makefile
+++ b/regression/goto-cc-cbmc/Makefile
@@ -1,0 +1,30 @@
+default: tests.log
+
+test:
+	@if ! ../test.pl -c ../chain.sh ; then \
+		../failed-tests-printer.pl ; \
+		exit 1; \
+	fi
+
+tests.log:
+	@if ! ../test.pl -c ../chain.sh ; then \
+		../failed-tests-printer.pl ; \
+		exit 1; \
+	fi
+
+show:
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			vim -o "$$dir/*.c" "$$dir/*.out"; \
+		fi; \
+	done;
+
+clean:
+	@for dir in *; do \
+		$(RM) tests.log; \
+		if [ -d "$$dir" ]; then \
+			cd "$$dir"; \
+			$(RM) *.out *.gb; \
+			cd ..; \
+		fi \
+	done

--- a/regression/goto-cc-cbmc/chain.sh
+++ b/regression/goto-cc-cbmc/chain.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+SRC=../../../src
+
+GC=$SRC/goto-cc/goto-cc
+CBMC=$SRC/cbmc/cbmc
+
+OPTS=$1
+NAME=${2%.c}
+
+$GC $NAME.c -o $NAME.gb
+$CBMC $NAME.gb $OPTS

--- a/regression/goto-cc-cbmc/regenerate-entry-function/main.c
+++ b/regression/goto-cc-cbmc/regenerate-entry-function/main.c
@@ -1,0 +1,23 @@
+int fun(int x)
+{
+	if(x > 0)
+	{
+		return x * x;
+	}
+	else
+	{
+		return x;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	if(argc>4)
+	{
+		return 0;
+	}
+	else
+	{
+		return 1;
+	}
+}

--- a/regression/goto-cc-cbmc/regenerate-entry-function/test.desc
+++ b/regression/goto-cc-cbmc/regenerate-entry-function/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+"--function fun --cover branch"
+
+^EXIT=0$
+^SIGNAL=0$
+^x=
+--
+^warning: ignoring

--- a/regression/goto-cc-cbmc/regenerate-entry-function/test.desc
+++ b/regression/goto-cc-cbmc/regenerate-entry-function/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 "--function fun --cover branch"
-
 ^EXIT=0$
 ^SIGNAL=0$
 ^x=

--- a/regression/goto-cc-goto-analyzer/Makefile
+++ b/regression/goto-cc-goto-analyzer/Makefile
@@ -1,0 +1,32 @@
+
+default: tests.log
+
+test:
+	@if ! ../test.pl -c ../chain.sh ; then \
+		../failed-tests-printer.pl ; \
+		exit 1; \
+	fi
+
+tests.log:
+	pwd
+	@if ! ../test.pl -c ../chain.sh ; then \
+		../failed-tests-printer.pl ; \
+		exit 1; \
+	fi
+
+show:
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			vim -o "$$dir/*.c" "$$dir/*.out"; \
+		fi; \
+	done;
+
+clean:
+	@for dir in *; do \
+		rm -f tests.log; \
+		if [ -d "$$dir" ]; then \
+			cd "$$dir"; \
+			rm -f *.out *.gb; \
+			cd ..; \
+		fi \
+	done

--- a/regression/goto-cc-goto-analyzer/chain.sh
+++ b/regression/goto-cc-goto-analyzer/chain.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+src=../../../src
+
+gc=$src/goto-cc/goto-cc
+goto_analyzer=$src/goto-analyzer/goto-analyzer
+
+options=$1
+name=${2%.c}
+
+$gc $name.c -o $name.gb
+$goto_analyzer $name.gb $options

--- a/regression/goto-cc-goto-analyzer/regenerate-entry-function/main.c
+++ b/regression/goto-cc-goto-analyzer/regenerate-entry-function/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+int fun(int x)
+{
+	int i;
+	if(i>=20)
+    assert(i>=10);
+}
+
+int main(int argc, char** argv)
+{
+  int i;
+
+  if(i>=5)
+    assert(i>=10);
+}

--- a/regression/goto-cc-goto-analyzer/regenerate-entry-function/test.desc
+++ b/regression/goto-cc-goto-analyzer/regenerate-entry-function/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+"--function fun --show-goto-functions"
+^\s*fun\(x\);$
+^EXIT=6$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/goto-cc-symex/Makefile
+++ b/regression/goto-cc-symex/Makefile
@@ -1,0 +1,32 @@
+
+default: tests.log
+
+test:
+	@if ! ../test.pl -c ../chain.sh ; then \
+		../failed-tests-printer.pl ; \
+		exit 1; \
+	fi
+
+tests.log:
+	pwd
+	@if ! ../test.pl -c ../chain.sh ; then \
+		../failed-tests-printer.pl ; \
+		exit 1; \
+	fi
+
+show:
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			vim -o "$$dir/*.c" "$$dir/*.out"; \
+		fi; \
+	done;
+
+clean:
+	@for dir in *; do \
+		rm -f tests.log; \
+		if [ -d "$$dir" ]; then \
+			cd "$$dir"; \
+			rm -f *.out *.gb; \
+			cd ..; \
+		fi \
+	done

--- a/regression/goto-cc-symex/chain.sh
+++ b/regression/goto-cc-symex/chain.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+src=../../../src
+
+gc=$src/goto-cc/goto-cc
+symex=$src/symex/symex
+
+options=$1
+name=${2%.c}
+
+$gc $name.c -o $name.gb
+$symex $name.gb $options

--- a/regression/goto-cc-symex/regenerate-entry-function/main.c
+++ b/regression/goto-cc-symex/regenerate-entry-function/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+int fun(int x)
+{
+	int i;
+	if(i>=20)
+    assert(i>=10);
+}
+
+int main(int argc, char** argv)
+{
+  int i;
+
+  if(i>=5)
+    assert(i>=10);
+}

--- a/regression/goto-cc-symex/regenerate-entry-function/test.desc
+++ b/regression/goto-cc-symex/regenerate-entry-function/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+"--function fun --show-goto-functions"
+^\s*return.=fun\(x\);$
+^EXIT=6$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/symex/regenerate-entry-function/main.c
+++ b/regression/symex/regenerate-entry-function/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+int fun(int x)
+{
+	int i;
+	if(i>=20)
+    assert(i>=10);
+}
+
+int main(int argc, char** argv)
+{
+  int i;
+
+  if(i>=5)
+    assert(i>=10);
+}

--- a/regression/symex/regenerate-entry-function/test.desc
+++ b/regression/symex/regenerate-entry-function/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--function fun --show-goto-functions
+fun\(x\);$
+^EXIT=6$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/symex/show-trace1/test.desc
+++ b/regression/symex/show-trace1/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.c
 --trace
 ^EXIT=10$
@@ -9,3 +9,5 @@ main.c
 ^  k=6 .*$
 --
 ^warning: ignoring
+--
+diffblue/cbmc#1361

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -121,7 +121,6 @@ void record_function_outputs(
 
 bool ansi_c_entry_point(
   symbol_tablet &symbol_table,
-  const std::string &standard_main,
   message_handlert &message_handler)
 {
   // check if entry point is already there
@@ -168,7 +167,7 @@ bool ansi_c_entry_point(
     main_symbol=matches.front();
   }
   else
-    main_symbol=standard_main;
+    main_symbol=ID_main;
 
   // look it up
   symbol_tablet::symbolst::const_iterator s_it=

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -18,6 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/config.h>
 #include <util/cprover_prefix.h>
 #include <util/prefix.h>
+#include <util/symbol.h>
 
 #include <util/c_types.h>
 #include <ansi-c/string_constant.h>
@@ -190,6 +191,22 @@ bool ansi_c_entry_point(
   if(static_lifetime_init(symbol_table, symbol.location, message_handler))
     return true;
 
+  return generate_ansi_c_start_function(symbol, symbol_table, message_handler);
+}
+
+
+/// Generate a _start function for a specific function
+/// \param entry_function_symbol: The symbol for the function that should be
+///   used as the entry point
+/// \param symbol_table: The symbol table for the program. The new _start
+///   function symbol will be added to this table
+/// \return Returns false if the _start method was generated correctly
+bool generate_ansi_c_start_function(
+  const symbolt &symbol,
+  symbol_tablet &symbol_table,
+  message_handlert &message_handler)
+{
+  PRECONDITION(!symbol.value.is_nil());
   code_blockt init_code;
 
   // build call to initialization function
@@ -237,7 +254,7 @@ bool ansi_c_entry_point(
   const code_typet::parameterst &parameters=
     to_code_type(symbol.type).parameters();
 
-  if(symbol.name==standard_main)
+  if(symbol.name==ID_main)
   {
     if(parameters.empty())
     {

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -195,10 +195,11 @@ bool ansi_c_entry_point(
 
 
 /// Generate a _start function for a specific function
-/// \param entry_function_symbol: The symbol for the function that should be
+/// \param symbol: The symbol for the function that should be
 ///   used as the entry point
 /// \param symbol_table: The symbol table for the program. The new _start
 ///   function symbol will be added to this table
+/// \param message_handler: The message handler
 /// \return Returns false if the _start method was generated correctly
 bool generate_ansi_c_start_function(
   const symbolt &symbol,

--- a/src/ansi-c/ansi_c_entry_point.h
+++ b/src/ansi-c/ansi_c_entry_point.h
@@ -15,7 +15,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 bool ansi_c_entry_point(
   symbol_tablet &symbol_table,
-  const std::string &standard_main,
   message_handlert &message_handler);
 
 bool generate_ansi_c_start_function(

--- a/src/ansi-c/ansi_c_entry_point.h
+++ b/src/ansi-c/ansi_c_entry_point.h
@@ -18,4 +18,9 @@ bool ansi_c_entry_point(
   const std::string &standard_main,
   message_handlert &message_handler);
 
+bool generate_ansi_c_start_function(
+  const symbolt &symbol,
+  symbol_tablet &symbol_table,
+  message_handlert &message_handler);
+
 #endif // CPROVER_ANSI_C_ANSI_C_ENTRY_POINT_H

--- a/src/ansi-c/ansi_c_language.cpp
+++ b/src/ansi-c/ansi_c_language.cpp
@@ -143,8 +143,7 @@ bool ansi_c_languaget::typecheck(
 bool ansi_c_languaget::final(symbol_tablet &symbol_table)
 {
   generate_opaque_method_stubs(symbol_table);
-
-  if(ansi_c_entry_point(symbol_table, "main", get_message_handler()))
+  if(ansi_c_entry_point(symbol_table, get_message_handler()))
     return true;
 
   return false;

--- a/src/ansi-c/ansi_c_language.cpp
+++ b/src/ansi-c/ansi_c_language.cpp
@@ -36,6 +36,22 @@ void ansi_c_languaget::modules_provided(std::set<std::string> &modules)
   modules.insert(get_base_name(parse_path, true));
 }
 
+/// Generate a _start function for a specific function
+/// \param entry_function_symbol: The symbol for the function that should be
+///   used as the entry point
+/// \param symbol_table: The symbol table for the program. The new _start
+///   function symbol will be added to this table
+/// \return Returns false if the _start method was generated correctly
+bool ansi_c_languaget::generate_start_function(
+  const symbolt &entry_function_symbol,
+  symbol_tablet &symbol_table)
+{
+  return generate_ansi_c_start_function(
+    entry_function_symbol,
+    symbol_table,
+    *message_handler);
+}
+
 /// ANSI-C preprocessing
 bool ansi_c_languaget::preprocess(
   std::istream &instream,

--- a/src/ansi-c/ansi_c_language.cpp
+++ b/src/ansi-c/ansi_c_language.cpp
@@ -43,11 +43,11 @@ void ansi_c_languaget::modules_provided(std::set<std::string> &modules)
 ///   function symbol will be added to this table
 /// \return Returns false if the _start method was generated correctly
 bool ansi_c_languaget::generate_start_function(
-  const symbolt &entry_function_symbol,
+  const irep_idt &entry_function_symbol_id,
   symbol_tablet &symbol_table)
 {
   return generate_ansi_c_start_function(
-    entry_function_symbol,
+    symbol_table.symbols.at(entry_function_symbol_id),
     symbol_table,
     *message_handler);
 }

--- a/src/ansi-c/ansi_c_language.cpp
+++ b/src/ansi-c/ansi_c_language.cpp
@@ -37,7 +37,7 @@ void ansi_c_languaget::modules_provided(std::set<std::string> &modules)
 }
 
 /// Generate a _start function for a specific function
-/// \param entry_function_symbol: The symbol for the function that should be
+/// \param entry_function_symbol_id: The symbol for the function that should be
 ///   used as the entry point
 /// \param symbol_table: The symbol table for the program. The new _start
 ///   function symbol will be added to this table

--- a/src/ansi-c/ansi_c_language.h
+++ b/src/ansi-c/ansi_c_language.h
@@ -73,6 +73,10 @@ public:
 
   void modules_provided(std::set<std::string> &modules) override;
 
+  virtual bool generate_start_function(
+    const class symbolt &entry_function_symbol,
+    class symbol_tablet &symbol_table) override;
+
 protected:
   ansi_c_parse_treet parse_tree;
   std::string parse_path;

--- a/src/ansi-c/ansi_c_language.h
+++ b/src/ansi-c/ansi_c_language.h
@@ -74,7 +74,7 @@ public:
   void modules_provided(std::set<std::string> &modules) override;
 
   virtual bool generate_start_function(
-    const class symbolt &entry_function_symbol,
+    const irep_idt &entry_function_symbol_id,
     class symbol_tablet &symbol_table) override;
 
 protected:

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -51,6 +51,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/show_properties.h>
 #include <goto-programs/string_abstraction.h>
 #include <goto-programs/string_instrumentation.h>
+#include <goto-programs/rebuild_goto_start_function.h>
 
 #include <goto-symex/rewrite_union.h>
 #include <goto-symex/adjust_float_expressions.h>
@@ -631,22 +632,14 @@ int cbmc_parse_optionst::get_goto_program(
     if(cmdline.isset("function"))
     {
       const std::string &function_id=cmdline.get_value("function");
-      const auto &desired_entry_function=
-        symbol_table.symbols.find(function_id);
+      rebuild_goto_start_functiont start_function_rebuilder(
+        get_message_handler(),
+        goto_model.symbol_table,
+        goto_model.goto_functions);
 
-      if(desired_entry_function!=symbol_table.symbols.end())
+      if(start_function_rebuilder(function_id))
       {
-        languaget *language=get_language_from_mode(
-          desired_entry_function->second.mode);
-        language->regenerate_start_function(
-          desired_entry_function->second,
-          symbol_table,
-          goto_functions);
-      }
-      else
-      {
-        error() << "main symbol `" << function_id;
-        error() << "' not found" << messaget::eom;
+        return 6;
       }
     }
 

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -630,14 +630,24 @@ int cbmc_parse_optionst::get_goto_program(
 
     if(cmdline.isset("function"))
     {
-      const symbolt &desired_entry_function=
-        symbol_table.lookup(cmdline.get_value("function"));
-      languaget *language=get_language_from_mode(desired_entry_function.mode);
+      const std::string &function_id=cmdline.get_value("function");
+      const auto &desired_entry_function=
+        symbol_table.symbols.find(function_id);
 
-      language->regenerate_start_function(
-        desired_entry_function,
-        symbol_table,
-        goto_functions);
+      if(desired_entry_function!=symbol_table.symbols.end())
+      {
+        languaget *language=get_language_from_mode(
+          desired_entry_function->second.mode);
+        language->regenerate_start_function(
+          desired_entry_function->second,
+          symbol_table,
+          goto_functions);
+      }
+      else
+      {
+        error() << "main symbol `" << function_id;
+        error() << "' not found" << messaget::eom;
+      }
     }
 
     if(cmdline.isset("show-symbol-table"))

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -624,6 +624,8 @@ int cbmc_parse_optionst::get_goto_program(
   try
   {
     if(initialize_goto_model(goto_model, cmdline, get_message_handler()))
+    // Remove all binaries from the command line as they
+    // are already compiled
       return 6;
 
     if(cmdline.isset("function"))

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -626,6 +626,18 @@ int cbmc_parse_optionst::get_goto_program(
     if(initialize_goto_model(goto_model, cmdline, get_message_handler()))
       return 6;
 
+    if(cmdline.isset("function"))
+    {
+      const symbolt &desired_entry_function=
+        symbol_table.lookup(cmdline.get_value("function"));
+      languaget *language=get_language_from_mode(desired_entry_function.mode);
+
+      language->regenerate_start_function(
+        desired_entry_function,
+        symbol_table,
+        goto_functions);
+    }
+
     if(cmdline.isset("show-symbol-table"))
     {
       show_symbol_table(goto_model, ui_message_handler.get_ui());

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -1009,7 +1009,7 @@ void cbmc_parse_optionst::help()
     " --round-to-plus-inf          rounding towards plus infinity\n"
     " --round-to-minus-inf         rounding towards minus infinity\n"
     " --round-to-zero              rounding towards zero\n"
-    " --function name              set main function name\n"
+    HELP_FUNCTIONS
     "\n"
     "Program representations:\n"
     " --show-parse-tree            show parse tree\n"

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/ui_message.h>
 #include <util/parse_options.h>
+#include <goto-programs/rebuild_goto_start_function.h>
 
 #include <analyses/goto_check.h>
 
@@ -26,7 +27,8 @@ class goto_functionst;
 class optionst;
 
 #define CBMC_OPTIONS \
-  "(program-only)(function):(preprocess)(slice-by-trace):" \
+  "(program-only)(preprocess)(slice-by-trace):" \
+  OPT_FUNCTIONS \
   "(no-simplify)(unwind):(unwindset):(slice-formula)(full-slice)" \
   "(debug-level):(no-propagation)(no-simplify-if)" \
   "(document-subgoals)(outfile):(test-preprocessor)" \

--- a/src/cpp/cpp_language.cpp
+++ b/src/cpp/cpp_language.cpp
@@ -53,6 +53,22 @@ void cpp_languaget::modules_provided(std::set<std::string> &modules)
   modules.insert(get_base_name(parse_path, true));
 }
 
+/// Generate a _start function for a specific function
+/// \param entry_function_symbol: The symbol for the function that should be
+///   used as the entry point
+/// \param symbol_table: The symbol table for the program. The new _start
+///   function symbol will be added to this table
+/// \return Returns false if the _start method was generated correctly
+bool cpp_languaget::generate_start_function(
+  const symbolt &entry_function_symbol,
+  symbol_tablet &symbol_table)
+{
+  return generate_ansi_c_start_function(
+    entry_function_symbol,
+    symbol_table,
+    *message_handler);
+}
+
 /// ANSI-C preprocessing
 bool cpp_languaget::preprocess(
   std::istream &instream,

--- a/src/cpp/cpp_language.cpp
+++ b/src/cpp/cpp_language.cpp
@@ -152,7 +152,7 @@ bool cpp_languaget::typecheck(
 
 bool cpp_languaget::final(symbol_tablet &symbol_table)
 {
-  if(ansi_c_entry_point(symbol_table, "main", get_message_handler()))
+  if(ansi_c_entry_point(symbol_table, get_message_handler()))
     return true;
 
   return false;

--- a/src/cpp/cpp_language.cpp
+++ b/src/cpp/cpp_language.cpp
@@ -54,7 +54,7 @@ void cpp_languaget::modules_provided(std::set<std::string> &modules)
 }
 
 /// Generate a _start function for a specific function
-/// \param entry_function_symbol: The symbol for the function that should be
+/// \param entry_function_symbol_id: The symbol for the function that should be
 ///   used as the entry point
 /// \param symbol_table: The symbol table for the program. The new _start
 ///   function symbol will be added to this table

--- a/src/cpp/cpp_language.cpp
+++ b/src/cpp/cpp_language.cpp
@@ -60,11 +60,11 @@ void cpp_languaget::modules_provided(std::set<std::string> &modules)
 ///   function symbol will be added to this table
 /// \return Returns false if the _start method was generated correctly
 bool cpp_languaget::generate_start_function(
-  const symbolt &entry_function_symbol,
+  const irep_idt &entry_function_symbol_id,
   symbol_tablet &symbol_table)
 {
   return generate_ansi_c_start_function(
-    entry_function_symbol,
+    symbol_table.lookup(entry_function_symbol_id),
     symbol_table,
     *message_handler);
 }

--- a/src/cpp/cpp_language.h
+++ b/src/cpp/cpp_language.h
@@ -85,6 +85,10 @@ public:
 
   void modules_provided(std::set<std::string> &modules) override;
 
+  virtual bool generate_start_function(
+    const class symbolt &entry_function_symbol,
+    class symbol_tablet &symbol_table) override;
+
 protected:
   cpp_parse_treet cpp_parse_tree;
   std::string parse_path;

--- a/src/cpp/cpp_language.h
+++ b/src/cpp/cpp_language.h
@@ -86,7 +86,7 @@ public:
   void modules_provided(std::set<std::string> &modules) override;
 
   virtual bool generate_start_function(
-    const class symbolt &entry_function_symbol,
+    const irep_idt &entry_function_symbol_id,
     class symbol_tablet &symbol_table) override;
 
 protected:

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -494,6 +494,7 @@ void goto_analyzer_parse_optionst::help()
     " --classpath dir/jar          set the classpath\n"
     " --main-class class-name      set the name of the main class\n"
     JAVA_BYTECODE_LANGUAGE_OPTIONS_HELP
+    HELP_FUNCTIONS
     "\n"
     "Program representations:\n"
     " --show-parse-tree            show parse tree\n"

--- a/src/goto-analyzer/goto_analyzer_parse_options.h
+++ b/src/goto-analyzer/goto_analyzer_parse_options.h
@@ -17,6 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <goto-programs/goto_model.h>
 #include <goto-programs/show_goto_functions.h>
+#include <goto-programs/rebuild_goto_start_function.h>
 
 #include <analyses/goto_check.h>
 
@@ -27,7 +28,7 @@ class goto_functionst;
 class optionst;
 
 #define GOTO_ANALYSER_OPTIONS \
-  "(function):" \
+  OPT_FUNCTIONS \
   "D:I:(std89)(std99)(std11)" \
   "(classpath):(cp):(main-class):" \
   "(16)(32)(64)(LP64)(ILP64)(LLP64)(ILP32)(LP32)" \

--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -368,7 +368,7 @@ bool compilet::link()
     symbol_table.remove(goto_functionst::entry_point());
     compiled_functions.function_map.erase(goto_functionst::entry_point());
 
-    if(ansi_c_entry_point(symbol_table, "main", get_message_handler()))
+    if(ansi_c_entry_point(symbol_table, get_message_handler()))
       return true;
 
     // entry_point may (should) add some more functions.

--- a/src/goto-programs/Makefile
+++ b/src/goto-programs/Makefile
@@ -36,6 +36,7 @@ SRC = basic_blocks.cpp \
       property_checker.cpp \
       read_bin_goto_object.cpp \
       read_goto_binary.cpp \
+      rebuild_goto_start_function.cpp \
       remove_asm.cpp \
       remove_complex.cpp \
       remove_const_function_pointers.cpp \

--- a/src/goto-programs/initialize_goto_model.cpp
+++ b/src/goto-programs/initialize_goto_model.cpp
@@ -21,6 +21,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <langapi/mode.h>
 #include <langapi/language_ui.h>
 
+#include <goto-programs/rebuild_goto_start_function.h>
+
 #include "goto_convert_functions.h"
 #include "read_goto_binary.h"
 
@@ -129,6 +131,20 @@ bool initialize_goto_model(
 
       if(read_object_and_link(file, goto_model, message_handler))
         return true;
+    }
+
+    if(cmdline.isset("function"))
+    {
+      const std::string &function_id=cmdline.get_value("function");
+      rebuild_goto_start_functiont start_function_rebuilder(
+        msg.get_message_handler(),
+        goto_model.symbol_table,
+        goto_model.goto_functions);
+
+      if(start_function_rebuilder(function_id))
+      {
+        return 6;
+      }
     }
 
     msg.status() << "Generating GOTO Program" << messaget::eom;

--- a/src/goto-programs/rebuild_goto_start_function.cpp
+++ b/src/goto-programs/rebuild_goto_start_function.cpp
@@ -69,7 +69,7 @@ bool rebuild_goto_start_functiont::operator()(
       symbol_table);
 
   // Remove the function from the goto_functions so it is copied back in
-  // from the symbol table
+  // from the symbol table during goto_convert
   if(!return_code)
   {
     const auto &start_function=

--- a/src/goto-programs/rebuild_goto_start_function.cpp
+++ b/src/goto-programs/rebuild_goto_start_function.cpp
@@ -1,0 +1,84 @@
+/*******************************************************************\
+ Module: Goto Programs
+ Author: Thomas Kiley, thomas@diffblue.com
+\*******************************************************************/
+
+/// \file
+/// Goto Programs Author: Thomas Kiley, thomas@diffblue.com
+
+#include "rebuild_goto_start_function.h"
+
+#include <goto-programs/goto_functions.h>
+#include <util/language.h>
+#include <util/symbol.h>
+#include <util/symbol_table.h>
+#include <langapi/mode.h>
+#include <memory>
+
+/// To rebuild the _start funciton in the event the program was compiled into
+/// GOTO with a different entry function selected.
+/// \param _message_handler: The message handler to report any messages with
+/// \param symbol_table: The symbol table of the program (to replace the _start
+///   functions symbo)
+/// \param goto_functions: The goto functions of the program (to replace the
+///   body of the _start function).
+rebuild_goto_start_functiont::rebuild_goto_start_functiont(
+  message_handlert &_message_handler,
+  symbol_tablet &symbol_table,
+  goto_functionst &goto_functions):
+  messaget(_message_handler),
+  symbol_table(symbol_table),
+  goto_functions(goto_functions)
+{
+}
+
+/// To rebuild the _start function in the event the program was compiled into
+/// GOTO with a different entry function selected. It works by discarding the
+/// _start symbol and GOTO function and calling on the relevant languaget to
+/// generate the _start function again.
+/// \param entry_function: The name of the entry function that should be
+/// called from _start
+/// \return Returns true if either the symbol is not found, or something went
+///   wrong with generating the start_function. False otherwise.
+bool rebuild_goto_start_functiont::operator()(
+  const irep_idt &entry_function)
+{
+  const auto &desired_entry_function=
+    symbol_table.symbols.find(entry_function);
+
+  // Check the specified entry function is a function in the symbol table
+  if(desired_entry_function==symbol_table.symbols.end())
+  {
+    error() << "main symbol `" << entry_function
+            << "' not found" << eom;
+    return true;
+  }
+
+  // Remove the existing _start function so we can create a new one
+  symbol_table.remove(goto_functionst::entry_point());
+
+  auto language=
+    std::unique_ptr<languaget>(
+      get_language_from_mode(
+        desired_entry_function->second.mode));
+  assert(language);
+
+  bool return_code=
+    language->generate_start_function(
+      desired_entry_function->second,
+      symbol_table);
+
+  // Remove the function from the goto_functions so it is copied back in
+  // from the symbol table
+  if(!return_code)
+  {
+    const auto &start_function=
+      goto_functions.function_map.find(goto_functionst::entry_point());
+    if(start_function!=goto_functions.function_map.end())
+    {
+      goto_functions.function_map.erase(start_function);
+    }
+  }
+
+  return return_code;
+}

--- a/src/goto-programs/rebuild_goto_start_function.h
+++ b/src/goto-programs/rebuild_goto_start_function.h
@@ -14,6 +14,12 @@
 class symbol_tablet;
 class goto_functionst;
 
+#define OPT_FUNCTIONS \
+  "(function):"
+
+#define HELP_FUNCTIONS \
+  " --function name              set main function name\n"
+
 class rebuild_goto_start_functiont: public messaget
 {
 public:

--- a/src/goto-programs/rebuild_goto_start_function.h
+++ b/src/goto-programs/rebuild_goto_start_function.h
@@ -1,0 +1,32 @@
+/*******************************************************************\
+ Module: Goto Programs
+ Author: Thomas Kiley, thomas@diffblue.com
+\*******************************************************************/
+
+/// \file
+/// Goto Programs Author: Thomas Kiley, thomas@diffblue.com
+
+#ifndef CPROVER_GOTO_PROGRAMS_REBUILD_GOTO_START_FUNCTION_H
+#define CPROVER_GOTO_PROGRAMS_REBUILD_GOTO_START_FUNCTION_H
+
+#include <util/message.h>
+
+class symbol_tablet;
+class goto_functionst;
+
+class rebuild_goto_start_functiont: public messaget
+{
+public:
+  rebuild_goto_start_functiont(
+    message_handlert &_message_handler,
+    symbol_tablet &symbol_table,
+    goto_functionst &goto_functions);
+
+  bool operator()(const irep_idt &entry_function);
+
+private:
+  symbol_tablet &symbol_table;
+  goto_functionst &goto_functions;
+};
+
+#endif // CPROVER_GOTO_PROGRAMS_REBUILD_GOTO_START_FUNCTION_H

--- a/src/goto-programs/rebuild_goto_start_function.h
+++ b/src/goto-programs/rebuild_goto_start_function.h
@@ -31,6 +31,10 @@ public:
   bool operator()(const irep_idt &entry_function);
 
 private:
+  irep_idt get_entry_point_mode() const;
+
+  void remove_existing_entry_point();
+
   symbol_tablet &symbol_table;
   goto_functionst &goto_functions;
 };

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -113,11 +113,15 @@ void java_bytecode_languaget::modules_provided(std::set<std::string> &modules)
 ///   function symbol will be added to this table
 /// \return Returns false if the _start method was generated correctly
 bool java_bytecode_languaget::generate_start_function(
-  const symbolt &entry_function_symbol,
+  const irep_idt &entry_function_symbol_id,
   symbol_tablet &symbol_table)
 {
+  const auto res=
+    get_main_symbol(
+      symbol_table, entry_function_symbol_id, get_message_handler());
+
   return generate_java_start_function(
-    entry_function_symbol,
+    res.main_function,
     symbol_table,
     get_message_handler(),
     assume_inputs_non_null,

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -106,6 +106,26 @@ void java_bytecode_languaget::modules_provided(std::set<std::string> &modules)
   // modules.insert(translation_unit(parse_path));
 }
 
+/// Generate a _start function for a specific function.
+/// \param entry_function_symbol: The symbol for the function that should be
+///   used as the entry point
+/// \param symbol_table: The symbol table for the program. The new _start
+///   function symbol will be added to this table
+/// \return Returns false if the _start method was generated correctly
+bool java_bytecode_languaget::generate_start_function(
+  const symbolt &entry_function_symbol,
+  symbol_tablet &symbol_table)
+{
+  return generate_java_start_function(
+    entry_function_symbol,
+    symbol_table,
+    get_message_handler(),
+    assume_inputs_non_null,
+    max_nondet_array_length,
+    max_nondet_tree_depth,
+    *pointer_type_selector);
+}
+
 /// ANSI-C preprocessing
 bool java_bytecode_languaget::preprocess(
   std::istream &instream,

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -107,7 +107,7 @@ void java_bytecode_languaget::modules_provided(std::set<std::string> &modules)
 }
 
 /// Generate a _start function for a specific function.
-/// \param entry_function_symbol: The symbol for the function that should be
+/// \param entry_function_symbol_id: The symbol for the function that should be
 ///   used as the entry point
 /// \param symbol_table: The symbol table for the program. The new _start
 ///   function symbol will be added to this table

--- a/src/java_bytecode/java_bytecode_language.h
+++ b/src/java_bytecode/java_bytecode_language.h
@@ -137,6 +137,10 @@ public:
   virtual void convert_lazy_method(
     const irep_idt &id, symbol_tablet &) override;
 
+  virtual bool generate_start_function(
+    const class symbolt &entry_function_symbol,
+    class symbol_tablet &symbol_table) override;
+
 protected:
   bool do_ci_lazy_method_conversion(symbol_tablet &, lazy_methodst &);
   const select_pointer_typet &get_pointer_type_selector() const;

--- a/src/java_bytecode/java_bytecode_language.h
+++ b/src/java_bytecode/java_bytecode_language.h
@@ -138,7 +138,7 @@ public:
     const irep_idt &id, symbol_tablet &) override;
 
   virtual bool generate_start_function(
-    const class symbolt &entry_function_symbol,
+    const irep_idt &entry_function_symbol_id,
     class symbol_tablet &symbol_table) override;
 
 protected:

--- a/src/java_bytecode/java_entry_point.cpp
+++ b/src/java_bytecode/java_entry_point.cpp
@@ -520,12 +520,19 @@ bool java_entry_point(
     pointer_type_selector);
 }
 
-/// Generate a _start function for a specific function
-/// \param entry_function_symbol: The symbol for the function that should be
-///   used as the entry point
-/// \param symbol_table: The symbol table for the program. The new _start
-///   function symbol will be added to this table
-/// \return Returns false if the _start method was generated correctly
+/// Generate a _start function for a specific function. See
+/// java_entry_point for more details.
+/// \param symbol: The symbol representing the function to call
+/// \param symbol_table: Global symbol table
+/// \param message_handler: Where to write output to
+/// \param assume_init_pointers_not_null: When creating pointers, assume they
+///   always take a non-null value.
+/// \param max_nondet_array_length: The length of the arrays to create when
+///   filling them
+/// \param max_nondet_tree_depth: defines the maximum depth of the object tree
+///   (see java_entry_points documentation for details)
+/// \param pointer_type_selector: Logic for substituting types of pointers
+/// \returns true if error occurred on entry point search, false otherwise
 bool generate_java_start_function(
   const symbolt &symbol,
   symbol_tablet &symbol_table,

--- a/src/java_bytecode/java_entry_point.cpp
+++ b/src/java_bytecode/java_entry_point.cpp
@@ -510,6 +510,32 @@ bool java_entry_point(
     max_nondet_tree_depth,
     pointer_type_selector);
 
+  return generate_java_start_function(
+    symbol,
+    symbol_table,
+    message_handler,
+    assume_init_pointers_not_null,
+    max_nondet_array_length,
+    max_nondet_tree_depth,
+    pointer_type_selector);
+}
+
+/// Generate a _start function for a specific function
+/// \param entry_function_symbol: The symbol for the function that should be
+///   used as the entry point
+/// \param symbol_table: The symbol table for the program. The new _start
+///   function symbol will be added to this table
+/// \return Returns false if the _start method was generated correctly
+bool generate_java_start_function(
+  const symbolt &symbol,
+  symbol_tablet &symbol_table,
+  message_handlert &message_handler,
+  bool assume_init_pointers_not_null,
+  size_t max_nondet_array_length,
+  size_t max_nondet_tree_depth,
+  const select_pointer_typet &pointer_type_selector)
+{
+  messaget message(message_handler);
   code_blockt init_code;
 
   // build call to initialization function

--- a/src/java_bytecode/java_entry_point.h
+++ b/src/java_bytecode/java_entry_point.h
@@ -40,4 +40,13 @@ main_function_resultt get_main_symbol(
   message_handlert &,
   bool allow_no_body=false);
 
+bool generate_java_start_function(
+  const symbolt &symbol,
+  class symbol_tablet &symbol_table,
+  class message_handlert &message_handler,
+  bool assume_init_pointers_not_null,
+  size_t max_nondet_array_length,
+  size_t max_nondet_tree_depth,
+  const select_pointer_typet &pointer_type_selector);
+
 #endif // CPROVER_JAVA_BYTECODE_JAVA_ENTRY_POINT_H

--- a/src/jsil/jsil_language.cpp
+++ b/src/jsil/jsil_language.cpp
@@ -41,6 +41,22 @@ bool jsil_languaget::interfaces(symbol_tablet &symbol_table)
   return false;
 }
 
+/// Generate a _start function for a specific function
+/// \param entry_function_symbol: The symbol for the function that should be
+///   used as the entry point
+/// \param symbol_table: The symbol table for the program. The new _start
+///   function symbol will be added to this table
+/// \return Returns false if the _start method was generated correctly
+bool jsil_languaget::generate_start_function(
+  const symbolt &entry_function_symbol,
+  symbol_tablet &symbol_table)
+{
+  // TODO(tkiley): This should be implemented if this language
+  // is used.
+  UNREACHABLE;
+  return true;
+}
+
 bool jsil_languaget::preprocess(
   std::istream &instream,
   const std::string &path,

--- a/src/jsil/jsil_language.cpp
+++ b/src/jsil/jsil_language.cpp
@@ -42,7 +42,7 @@ bool jsil_languaget::interfaces(symbol_tablet &symbol_table)
 }
 
 /// Generate a _start function for a specific function
-/// \param entry_function_symbol: The symbol for the function that should be
+/// \param entry_function_symbol_id: The symbol for the function that should be
 ///   used as the entry point
 /// \param symbol_table: The symbol table for the program. The new _start
 ///   function symbol will be added to this table

--- a/src/jsil/jsil_language.cpp
+++ b/src/jsil/jsil_language.cpp
@@ -48,7 +48,7 @@ bool jsil_languaget::interfaces(symbol_tablet &symbol_table)
 ///   function symbol will be added to this table
 /// \return Returns false if the _start method was generated correctly
 bool jsil_languaget::generate_start_function(
-  const symbolt &entry_function_symbol,
+  const irep_idt &entry_function_symbol_id,
   symbol_tablet &symbol_table)
 {
   // TODO(tkiley): This should be implemented if this language

--- a/src/jsil/jsil_language.h
+++ b/src/jsil/jsil_language.h
@@ -69,6 +69,10 @@ public:
   virtual void modules_provided(std::set<std::string> &modules);
   virtual bool interfaces(symbol_tablet &symbol_table);
 
+  virtual bool generate_start_function(
+    const class symbolt &entry_function_symbol,
+    class symbol_tablet &symbol_table) override;
+
 protected:
   jsil_parse_treet parse_tree;
   std::string parse_path;

--- a/src/jsil/jsil_language.h
+++ b/src/jsil/jsil_language.h
@@ -25,19 +25,19 @@ public:
   virtual bool preprocess(
     std::istream &instream,
     const std::string &path,
-    std::ostream &outstream);
+    std::ostream &outstream) override;
 
   virtual bool parse(
     std::istream &instream,
-    const std::string &path);
+    const std::string &path) override;
 
   virtual bool typecheck(
     symbol_tablet &context,
-    const std::string &module);
+    const std::string &module) override;
 
-  virtual bool final(symbol_tablet &context);
+  virtual bool final(symbol_tablet &context) override;
 
-  virtual void show_parse(std::ostream &out);
+  virtual void show_parse(std::ostream &out) override;
 
   virtual ~jsil_languaget();
   jsil_languaget() { }
@@ -45,29 +45,29 @@ public:
   virtual bool from_expr(
     const exprt &expr,
     std::string &code,
-    const namespacet &ns);
+    const namespacet &ns) override;
 
   virtual bool from_type(
     const typet &type,
     std::string &code,
-    const namespacet &ns);
+    const namespacet &ns) override;
 
   virtual bool to_expr(
     const std::string &code,
     const std::string &module,
     exprt &expr,
-    const namespacet &ns);
+    const namespacet &ns) override;
 
-  virtual std::unique_ptr<languaget> new_language()
+  virtual std::unique_ptr<languaget> new_language() override
   { return util_make_unique<jsil_languaget>(); }
 
-  virtual std::string id() const { return "jsil"; }
-  virtual std::string description() const
+  virtual std::string id() const override { return "jsil"; }
+  virtual std::string description() const override
   { return "Javascript Intermediate Language"; }
-  virtual std::set<std::string> extensions() const;
+  virtual std::set<std::string> extensions() const override;
 
-  virtual void modules_provided(std::set<std::string> &modules);
-  virtual bool interfaces(symbol_tablet &symbol_table);
+  virtual void modules_provided(std::set<std::string> &modules) override;
+  virtual bool interfaces(symbol_tablet &symbol_table) override;
 
   virtual bool generate_start_function(
     const class symbolt &entry_function_symbol,

--- a/src/jsil/jsil_language.h
+++ b/src/jsil/jsil_language.h
@@ -70,7 +70,7 @@ public:
   virtual bool interfaces(symbol_tablet &symbol_table) override;
 
   virtual bool generate_start_function(
-    const class symbolt &entry_function_symbol,
+    const irep_idt &entry_function_symbol_id,
     class symbol_tablet &symbol_table) override;
 
 protected:

--- a/src/symex/symex_parse_options.cpp
+++ b/src/symex/symex_parse_options.cpp
@@ -587,7 +587,7 @@ void symex_parse_optionst::help()
     " --round-to-plus-inf          IEEE floating point rounding mode\n"
     " --round-to-minus-inf         IEEE floating point rounding mode\n"
     " --round-to-zero              IEEE floating point rounding mode\n"
-    " --function name              set main function name\n"
+    HELP_FUNCTIONS
     "\n"
     "Java Bytecode frontend options:\n"
     JAVA_BYTECODE_LANGUAGE_OPTIONS_HELP

--- a/src/symex/symex_parse_options.h
+++ b/src/symex/symex_parse_options.h
@@ -17,6 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <goto-programs/goto_model.h>
 #include <goto-programs/show_goto_functions.h>
+#include <goto-programs/rebuild_goto_start_function.h>
 
 #include <analyses/goto_check.h>
 
@@ -28,7 +29,7 @@ class goto_functionst;
 class optionst;
 
 #define SYMEX_OPTIONS \
-  "(function):" \
+  OPT_FUNCTIONS \
   "D:I:" \
   "(depth):(context-bound):(branch-bound):(unwind):(max-search-time):" \
   OPT_GOTO_CHECK \

--- a/src/util/language.cpp
+++ b/src/util/language.cpp
@@ -12,13 +12,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "language.h"
 
 #include "expr.h"
-#include <util/config.h>
 #include <util/symbol.h>
 #include <util/symbol_table.h>
 #include <util/prefix.h>
 #include <util/cprover_prefix.h>
 #include <util/std_types.h>
-#include <goto-programs/goto_functions.h>
 
 bool languaget::final(symbol_tablet &symbol_table)
 {
@@ -210,37 +208,3 @@ bool languaget::generate_start_function(
   return true;
 }
 
-/// To replace an existing _start function with a new one that calls a specified
-/// function
-/// \param required_entry_function: a code symbol inside the symbol table which
-///   is the function that should be used as the entry point.
-/// \param symbol_table: the symbol table for the program. The _start symbol
-///   will be replaced with a new start function
-/// \param goto_functions: the functions for the goto program. The _start
-///   function will be erased from this
-/// \return Returns false if the new start function is created successfully,
-///   true otherwise.
-bool languaget::regenerate_start_function(
-  const symbolt &entry_function_symbol,
-  symbol_tablet &symbol_table,
-  goto_functionst &goto_functions)
-{
-  // Remove the existing _start function so we can create a new one
-  symbol_table.remove(goto_functionst::entry_point());
-
-  bool return_code=generate_start_function(entry_function_symbol, symbol_table);
-
-  // Remove the function from the goto_functions so is copied back in
-  // from the symbol table
-  if(!return_code)
-  {
-    const auto &start_function=
-      goto_functions.function_map.find(goto_functionst::entry_point());
-    if(start_function!=goto_functions.function_map.end())
-    {
-      goto_functions.function_map.erase(start_function);
-    }
-  }
-
-  return return_code;
-}

--- a/src/util/language.cpp
+++ b/src/util/language.cpp
@@ -191,20 +191,3 @@ void languaget::generate_opaque_parameter_symbols(
     symbol_table.add(param_symbol);
   }
 }
-
-/// Generate a entry function for a specific function. Should be overriden in
-/// derived languagets
-/// \param entry_function_symbol: The symbol for the function that should be
-///   used as the entry point
-/// \param symbol_table: The symbol table for the program. The new _start
-///   function symbol will be added to this table
-/// \return Returns false if the entry method was generated correctly
-bool languaget::generate_start_function(
-  const symbolt &entry_function_symbol,
-  symbol_tablet &symbol_table)
-{
-  // Implement in derived languagets
-  assert(0);
-  return true;
-}
-

--- a/src/util/language.cpp
+++ b/src/util/language.cpp
@@ -194,6 +194,22 @@ void languaget::generate_opaque_parameter_symbols(
   }
 }
 
+/// Generate a entry function for a specific function. Should be overriden in
+/// derived languagets
+/// \param entry_function_symbol: The symbol for the function that should be
+///   used as the entry point
+/// \param symbol_table: The symbol table for the program. The new _start
+///   function symbol will be added to this table
+/// \return Returns false if the entry method was generated correctly
+bool languaget::generate_start_function(
+  const symbolt &entry_function_symbol,
+  symbol_tablet &symbol_table)
+{
+  // Implement in derived languagets
+  assert(0);
+  return true;
+}
+
 /// To replace an existing _start function with a new one that calls a specified
 /// function
 /// \param required_entry_function: a code symbol inside the symbol table which
@@ -205,18 +221,14 @@ void languaget::generate_opaque_parameter_symbols(
 /// \return Returns false if the new start function is created successfully,
 ///   true otherwise.
 bool languaget::regenerate_start_function(
-  const symbolt &required_entry_function,
+  const symbolt &entry_function_symbol,
   symbol_tablet &symbol_table,
   goto_functionst &goto_functions)
 {
   // Remove the existing _start function so we can create a new one
   symbol_table.remove(goto_functionst::entry_point());
-  config.main=required_entry_function.name.c_str();
 
-  // TODO(tkiley): calling final is not really correct (in fact for example,
-  // opaque function stubs get generated here). Instead the final method should
-  // call this to generate the function in the first place.
-  bool return_code=final(symbol_table);
+  bool return_code=generate_start_function(entry_function_symbol, symbol_table);
 
   // Remove the function from the goto_functions so is copied back in
   // from the symbol table

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -119,8 +119,12 @@ public:
 
   void set_should_generate_opaque_method_stubs(bool should_generate_stubs);
 
+  virtual bool generate_start_function(
+    const class symbolt &entry_function_symbol,
+    class symbol_tablet &symbol_table);
+
   bool regenerate_start_function(
-    const class symbolt &required_entry_function,
+    const class symbolt &entry_function_symbol,
     symbol_tablet &symbol_table,
     class goto_functionst &goto_functions);
 

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -119,6 +119,11 @@ public:
 
   void set_should_generate_opaque_method_stubs(bool should_generate_stubs);
 
+  bool regenerate_start_function(
+    const class symbolt &required_entry_function,
+    symbol_tablet &symbol_table,
+    class goto_functionst &goto_functions);
+
   // constructor / destructor
 
   languaget() { }

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -123,11 +123,6 @@ public:
     const class symbolt &entry_function_symbol,
     class symbol_tablet &symbol_table);
 
-  bool regenerate_start_function(
-    const class symbolt &entry_function_symbol,
-    symbol_tablet &symbol_table,
-    class goto_functionst &goto_functions);
-
   // constructor / destructor
 
   languaget() { }

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -121,7 +121,7 @@ public:
 
   virtual bool generate_start_function(
     const class symbolt &entry_function_symbol,
-    class symbol_tablet &symbol_table);
+    class symbol_tablet &symbol_table)=0;
 
   // constructor / destructor
 

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -120,7 +120,7 @@ public:
   void set_should_generate_opaque_method_stubs(bool should_generate_stubs);
 
   virtual bool generate_start_function(
-    const class symbolt &entry_function_symbol,
+    const irep_idt &entry_function_symbol_id,
     class symbol_tablet &symbol_table)=0;
 
   // constructor / destructor


### PR DESCRIPTION
Issue: #175 

If the user provides a --function argument, tell the `languaget` to regenerate the _start function to call this function. Previously if the program had been precompiled (using goto-cc), the start function that
was used in the original generation would be used again meaning the --function argument was ignored.

This PR is dependent on #343 
Real diff: https://github.com/diffblue/cbmc/pull/338/files/cf755ef77320e996be587bde46416f6fd1e17f39..1443d3b2ebee5950b0d422b076943574bad1cef9