### PR TITLE
Turn off float constant folding in simplifier

### DIFF
--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -402,6 +402,7 @@ bool simplify_exprt::simplify_plus(exprt &expr)
 
   if(ns.follow(expr.type()).id()==ID_floatbv)
   {
+#if 0
     // we only merge neighboring constants!
     Forall_expr(it, operands)
     {
@@ -419,6 +420,7 @@ bool simplify_exprt::simplify_plus(exprt &expr)
         }
       }
     }
+#endif
   }
   else
   {


### PR DESCRIPTION
Float constant folding does not correctly consider the rounding mode.