### PR TITLE
Allowed test.desc to pass flags to the grep command

### DIFF
--- a/regression/test.pl
+++ b/regression/test.pl
@@ -194,7 +194,7 @@ follows the format specified below. Any line starting with // will be ignored.
 
 where
   <level>                is one of CORE, THOROUGH, FUTURE or KNOWNBUG
-  <main source>          is a file with extension .c/.i/.cpp/.ii/.xml/.class/.jar
+  <main source>          is a file with extension .c/.i/.gb/.cpp/.ii/.xml/.class/.jar
   <options>              additional options to be passed to CMD
   <grep_options>         additional flags to be passed to grep when checking required
                          patterns (this is optional, if the line stats with a `-'

--- a/regression/test.pl
+++ b/regression/test.pl
@@ -185,6 +185,7 @@ follows the format specified below. Any line starting with // will be ignored.
 <level>
 <main source>
 <options>
+<grep_options>
 <required patterns>
 --
 <disallowed patterns>
@@ -195,6 +196,10 @@ where
   <level>                is one of CORE, THOROUGH, FUTURE or KNOWNBUG
   <main source>          is a file with extension .c/.i/.cpp/.ii/.xml/.class/.jar
   <options>              additional options to be passed to CMD
+  <grep_options>         additional flags to be passed to grep when checking required
+                         patterns (this is optional, if the line stats with a `-'
+                         it will be used as grep options. Otherwise, it will be
+                         considered part of the required patterns)
   <required patterns>    one or more lines of regualar expressions that must occur in the output
   <disallowed patterns>  one or more lines of expressions that must not occur in output
   <comment text>         free form text

--- a/regression/test.pl
+++ b/regression/test.pl
@@ -59,7 +59,19 @@ sub load($) {
 
 sub test($$$$$) {
   my ($name, $test, $t_level, $cmd, $ign) = @_;
-  my ($level, $input, $options, @results) = load("$test");
+  my ($level, $input, $options, $grep_options, @results) = load("$test");
+
+  # If the 4th line starts with a '-' we use that line as options to pass to
+  # grep when matching all lines in this test
+  if($grep_options =~ /^-/) {
+    print "\nActivating perl flags: $grep_options\n";
+  }
+  else {
+    # No grep options so stick this back into the results array
+    unshift @results, $grep_options;
+    $grep_options = "";
+  }
+
   $options =~ s/$ign//g if(defined($ign));
 
   my $output = $input;
@@ -107,7 +119,7 @@ sub test($$$$$) {
           my $r;
           $result =~ s/\\/\\\\/g;
           $result =~ s/([^\\])\$/$1\\r\\\\?\$/;
-          system("bash", "-c", "grep \$'$result' \"$name/$output\" >/dev/null");
+          system("bash", "-c", "grep $grep_options \$'$result' \"$name/$output\" >/dev/null");
           $r = ($included ? $? != 0 : $? == 0);
           if($r) {
             print LOG "$result [FAILED]\n";


### PR DESCRIPTION
If the fourth line starts with a `-` we pass that line as flags to the grep command when checking the lines in this test. This allows for tests to pass flags such as: `-Pzo` to [check multiple consecutive lines](http://stackoverflow.com/questions/3717772/regex-grep-for-multi-line-search-needed/7167115#7167115).

I needed multi-line checking as I want to verify that, when outputting a symbol table, a specific variable has a specific type and a different variable has a different type. Therefore checking the existence of these lines is not sufficient to verify the outcome. 

I have run all the old tests in CBMC to check there aren't any that will inadvertently activate this feature. I will try across all directories to check, however, there may be a cleaner way that will preserve backwards compatibility. 

In general, I would be tempted to try and find an existing regression test runner and write a script to convert existing tests to a new format. This probably won't be the only missing feature from this script, and it would be good to have some documentation that can be pointed to. 