### PR TITLE
Extracted functions from the convert/convert_type methods in expr2c

### DIFF
--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -359,29 +359,7 @@ std::string expr2ct::convert_rec(
   }
   else if(src.id()==ID_struct)
   {
-    const struct_typet &struct_type=to_struct_type(src);
-
-    std::string dest=q+"struct";
-
-    const irep_idt &tag=struct_type.get_tag();
-    if(tag!="") dest+=" "+id2string(tag);
-    dest+=" {";
-
-    for(struct_typet::componentst::const_iterator
-        it=struct_type.components().begin();
-        it!=struct_type.components().end();
-        it++)
-    {
-      dest+=' ';
-      dest+=convert_rec(it->type(), c_qualifierst(), id2string(it->get_name()));
-      dest+=';';
-    }
-
-    dest+=" }";
-
-    dest+=d;
-
-    return dest;
+    return convert_struct_type(src, q, d);
   }
   else if(src.id()==ID_incomplete_struct)
   {
@@ -704,6 +682,97 @@ std::string expr2ct::convert_rec(
 
     return dest;
   }
+}
+
+/*******************************************************************\
+
+Function: expr2ct::convert_struct_type
+
+  Inputs:
+          src - the struct type being converted
+          qualifiers - any qualifiers on the type
+          declarator - the declarator on the type
+
+ Outputs: Returns a type declaration for a struct, containing the
+          body of the struct and in that body the padding parameters.
+
+ Purpose: To generate C-like string for defining the given struct
+
+\*******************************************************************/
+std::string expr2ct::convert_struct_type(
+  const typet &src,
+  const std::string &qualifiers_str,
+  const std::string &declarator_str)
+{
+  return convert_struct_type(src, qualifiers_str, declarator_str, true, true);
+}
+
+/*******************************************************************\
+
+Function: expr2ct::convert_struct_type
+
+  Inputs:
+          src - the struct type being converted
+          qualifiers - any qualifiers on the type
+          declarator - the declarator on the type
+          inc_struct_body - when generating the code, should we include
+                            a complete definition of the struct
+          inc_padding_parameters - should the padding parameters be included
+                                   Note this only makes sense if inc_struct_body
+
+ Outputs: Returns a type declaration for a struct, optionally containing the
+          body of the struct (and in that body, optionally the padding
+          parameters).
+
+ Purpose: To generate C-like string for declaring (or defining) the given struct
+
+\*******************************************************************/
+std::string expr2ct::convert_struct_type(
+  const typet &src,
+  const std::string &qualifiers,
+  const std::string &declarator,
+  bool inc_struct_body,
+  bool inc_padding_parameters)
+{
+  // Either we are including the body (in which case it makes sense to include
+  // or exclude the parameters) or there is no body so therefore we definitely
+  // shouldn't be including the parameters
+  assert(inc_struct_body || !inc_padding_parameters);
+
+  const struct_typet &struct_type=to_struct_type(src);
+
+  std::string dest=qualifiers+"struct";
+
+  const irep_idt &tag=struct_type.get_tag();
+  if(tag!="")
+    dest+=" "+id2string(tag);
+
+  if(inc_struct_body)
+  {
+    dest+=" {";
+
+    for(struct_typet::componentst::const_iterator
+        it=struct_type.components().begin();
+        it!=struct_type.components().end();
+        it++)
+    {
+      // Skip padding parameters unless we including them
+      if(it->get_is_padding() && !inc_padding_parameters)
+      {
+        continue;
+      }
+
+      dest+= ' ';
+      dest+=convert_rec(it->type(), c_qualifierst(), id2string(it->get_name()));
+      dest+= ';';
+    }
+
+    dest+=" }";
+  }
+
+  dest+=declarator;
+
+  return dest;
 }
 
 /*******************************************************************\

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -2338,6 +2338,31 @@ std::string expr2ct::convert_struct(
   const exprt &src,
   unsigned &precedence)
 {
+  return convert_struct(src, precedence, true);
+}
+
+/*******************************************************************\
+
+Function: expr2ct::convert_struct
+
+  Inputs:
+    src - The struct declaration expression
+    precedence
+    include_padding_members - Should the generated C code
+                              include the padding members added
+                              to structs for GOTOs benifit
+
+ Outputs: A string representation of the struct expression
+
+ Purpose: To generate a C-like string representing a struct. Can optionally
+          include the padding parameters.
+
+\*******************************************************************/
+std::string expr2ct::convert_struct(
+  const exprt &src,
+  unsigned &precedence,
+  bool include_padding_members)
+{
   const typet full_type=ns.follow(src.type());
 
   if(full_type.id()!=ID_struct)
@@ -2367,6 +2392,12 @@ std::string expr2ct::convert_struct(
   {
     if(o_it->type().id()==ID_code)
       continue;
+
+    if(c_it->get_is_padding() && !include_padding_members)
+    {
+      ++o_it;
+      continue;
+    }
 
     if(first)
       first=false;

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -2216,11 +2216,7 @@ std::string expr2ct::convert_constant(
   }
   else if(type.id()==ID_bool)
   {
-    // C doesn't really have these
-    if(src.is_true())
-      dest="TRUE";
-    else
-      dest="FALSE";
+    dest = convert_constant_bool(src.is_true());
   }
   else if(type.id()==ID_unsignedbv ||
           type.id()==ID_signedbv ||
@@ -2236,11 +2232,7 @@ std::string expr2ct::convert_constant(
 
     if(type.id()==ID_c_bool)
     {
-      // C doesn't really have these
-      if(int_value!=0)
-        dest="TRUE";
-      else
-        dest="FALSE";
+      dest = convert_constant_bool(int_value != 0);
     }
     else if(type==char_type() && type!=signed_int_type() && type!=unsigned_int_type())
     {
@@ -2389,6 +2381,28 @@ std::string expr2ct::convert_constant(
     return convert_norep(src, precedence);
 
   return dest;
+}
+
+/*******************************************************************\
+
+Function: expr2ct::convert_constant_bool
+
+  Inputs:
+          boolean_value - The value of the constant bool expression
+
+ Outputs: Returns a C-like representation of the boolean value,
+          e.g. TRUE or FALSE.
+
+ Purpose: To get the C-like representation of a given boolean value.
+
+\*******************************************************************/
+std::string expr2ct::convert_constant_bool(bool boolean_value)
+{
+  // C doesn't really have these
+  if(boolean_value)
+    return "TRUE";
+  else
+    return "FALSE";
 }
 
 /*******************************************************************\

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -495,18 +495,7 @@ std::string expr2ct::convert_rec(
   }
   else if(src.id()==ID_array)
   {
-    // The [...] gets attached to the declarator.
-    std::string array_suffix;
-
-    if(to_array_type(src).size().is_nil())
-      array_suffix="[]";
-    else
-      array_suffix="["+convert(to_array_type(src).size())+"]";
-
-    // This won't really parse without declarator.
-    // Note that qualifiers are passed down.
-    return convert_rec(
-      src.subtype(), qualifiers, declarator+array_suffix);
+    return convert_array_type(src, qualifiers, declarator);
   }
   else if(src.id()==ID_incomplete_array)
   {
@@ -773,6 +762,68 @@ std::string expr2ct::convert_struct_type(
   dest+=declarator;
 
   return dest;
+}
+
+/*******************************************************************\
+
+Function: expr2ct::convert_array_type
+
+  Inputs:
+          src - The array type to convert
+          qualifier
+          declarator_str
+
+ Outputs: A C-like type declaration of an array
+
+ Purpose: To generate a C-like type declaration of an array. Includes
+          the size of the array in the []
+
+\*******************************************************************/
+
+std::string expr2ct::convert_array_type(
+  const typet &src,
+  const c_qualifierst &qualifiers,
+  const std::string &declarator_str)
+{
+  return convert_array_type(src, qualifiers, declarator_str, true);
+}
+
+/*******************************************************************\
+
+Function: expr2ct::convert_array_type
+
+  Inputs:
+          src - The array type to convert
+          qualifier
+          declarator_str
+          inc_size_if_possible - Should the generated string include
+                                 the size of the array (if it is known).
+
+ Outputs: A C-like type declaration of an array
+
+ Purpose: To generate a C-like type declaration of an array. Optionally
+          can include or exclude the size of the array in the []
+
+\*******************************************************************/
+
+std::string expr2ct::convert_array_type(
+  const typet &src,
+  const c_qualifierst &qualifiers,
+  const std::string &declarator_str,
+  bool inc_size_if_possible)
+{
+  // The [...] gets attached to the declarator.
+  std::string array_suffix;
+
+  if(to_array_type(src).size().is_nil() || !inc_size_if_possible)
+    array_suffix="[]";
+  else
+    array_suffix="["+convert(to_array_type(src).size())+"]";
+
+  // This won't really parse without declarator.
+  // Note that qualifiers are passed down.
+  return convert_rec(
+    src.subtype(), qualifiers, declarator_str+array_suffix);
 }
 
 /*******************************************************************\

--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -209,6 +209,11 @@ protected:
   std::string convert_designated_initializer(const exprt &src, unsigned &precedence);
   std::string convert_concatenation(const exprt &src, unsigned &precedence);
   std::string convert_sizeof(const exprt &src, unsigned &precedence);
+
+  std::string convert_struct(
+    const exprt &src,
+    unsigned &precedence,
+    bool include_padding_members);
 };
 
 #endif // CPROVER_ANSI_C_EXPR2C_CLASS_H

--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -48,7 +48,7 @@ protected:
     const std::string &qualifer_str,
     const std::string &declarator_str,
     bool inc_struct_body,
-    bool inc_padding_parameters);
+    bool inc_padding_components);
 
   virtual std::string convert_array_type(
     const typet &src,
@@ -237,7 +237,7 @@ protected:
   std::string convert_struct(
     const exprt &src,
     unsigned &precedence,
-    bool include_padding_members);
+    bool include_padding_components);
 };
 
 #endif // CPROVER_ANSI_C_EXPR2C_CLASS_H

--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -209,6 +209,7 @@ protected:
   std::string convert_object_descriptor(const exprt &src, unsigned &precedence);
   std::string convert_literal(const exprt &src, unsigned &precedence);
   virtual std::string convert_constant(const constant_exprt &src, unsigned &precedence);
+  virtual std::string convert_constant_bool(bool boolean_value);
 
   std::string convert_norep(const exprt &src, unsigned &precedence);
 

--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -38,6 +38,18 @@ protected:
     const c_qualifierst &qualifiers,
     const std::string &declarator);
 
+  virtual std::string convert_struct_type(
+    const typet &src,
+    const std::string &qualifiers_str,
+    const std::string &declarator_str);
+
+  std::string convert_struct_type(
+    const typet &src,
+    const std::string &qualifer_str,
+    const std::string &declarator_str,
+    bool inc_struct_body,
+    bool inc_padding_parameters);
+
   static std::string indent_str(unsigned indent);
 
   std::unordered_map<irep_idt,

--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -50,6 +50,17 @@ protected:
     bool inc_struct_body,
     bool inc_padding_parameters);
 
+  virtual std::string convert_array_type(
+    const typet &src,
+    const c_qualifierst &qualifiers,
+    const std::string &declarator_str);
+
+  std::string convert_array_type(
+    const typet &src,
+    const c_qualifierst &qualifiers,
+    const std::string &declarator_str,
+    bool inc_size_if_possible);
+
   static std::string indent_str(unsigned indent);
 
   std::unordered_map<irep_idt,


### PR DESCRIPTION
In preparation for a class which provides a more accurate C generation, moved a bunch of the conversion functions into there own functions that can be overriden. 