### PR TITLE
Added a regression to demonstrate const structs

### DIFF
--- a/regression/goto-instrument/const-struct1/main.c
+++ b/regression/goto-instrument/const-struct1/main.c
@@ -1,0 +1,13 @@
+
+struct struct_tag_name
+{
+	int x;
+	float y;
+};
+
+int main()
+{
+  const struct struct_tag_name my_struct_var = {.x =  1, .y = 3.15};
+  const double z = 4;
+  return 0;
+}

--- a/regression/goto-instrument/const-struct1/test.desc
+++ b/regression/goto-instrument/const-struct1/test.desc
@@ -1,0 +1,9 @@
+KNWONBUG
+main.c
+"--show-symbol-table"
+^Type\.*: struct struct_tag_name$
+^Type\.*: const double$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring


### PR DESCRIPTION
Const structs are not storing their const-ness inside the symbol table. This regression test exhibits this behaviour. Marked as KNOWNBUG (is issue #355)