### PR TITLE
Store the typedef identifier in the symbol_type (cleaned up)

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -5,6 +5,7 @@ DIRS = ansi-c \
        cbmc-java \
        goto-analyzer \
        goto-instrument \
+       goto-instrument-typedef \
        test-script \
        # Empty last line
 

--- a/regression/ansi-c/gcc_types_compatible_p1/main.c
+++ b/regression/ansi-c/gcc_types_compatible_p1/main.c
@@ -7,6 +7,14 @@ double d;
 typedef enum T1 { hot, dog, poo, bear } dingos;
 typedef enum T2 { janette, laura, amanda } cranberry;
 
+typedef enum AnonEnum { jim, bob, fred } names;
+
+typedef dingos altdingos;
+typedef dingos diffdingos;
+
+typedef names altnames;
+typedef names diffnames;
+
 typedef float same1;
 typedef float same2;
 
@@ -52,6 +60,9 @@ STATIC_ASSERT(__builtin_types_compatible_p(typeof (dingos), unsigned)); // ha!
 STATIC_ASSERT(__builtin_types_compatible_p(typeof (hot), typeof (laura)));
 STATIC_ASSERT(__builtin_types_compatible_p(int[5], int[]));
 STATIC_ASSERT(__builtin_types_compatible_p(same1, same2));
+STATIC_ASSERT(__builtin_types_compatible_p(dingos, altdingos));
+STATIC_ASSERT(__builtin_types_compatible_p(diffdingos, altdingos));
+STATIC_ASSERT(__builtin_types_compatible_p(diffnames, altnames));
 STATIC_ASSERT(__builtin_types_compatible_p(typeof (hot) *, int *));
 STATIC_ASSERT(__builtin_types_compatible_p(typeof (hot), typeof (janette)));
 STATIC_ASSERT(__builtin_types_compatible_p(__int128, signed __int128));
@@ -84,7 +95,6 @@ STATIC_ASSERT(!__builtin_types_compatible_p(__float128, long double));
 STATIC_ASSERT(!__builtin_types_compatible_p(__float128, double));
 STATIC_ASSERT(!__builtin_types_compatible_p(__int128, unsigned __int128));
 #endif
-
 #endif
 
 int main(void)

--- a/regression/ansi-c/gcc_types_compatible_p4/main.c
+++ b/regression/ansi-c/gcc_types_compatible_p4/main.c
@@ -1,0 +1,27 @@
+#define STATIC_ASSERT(condition) \
+  int some_array[(condition) ? 1 : -1];
+
+typedef struct struct_tag
+{
+  int x;
+  float y;
+} struct_typedef;
+
+typedef struct struct_tag alt_typedef;
+typedef struct_typedef another_typedef;
+
+#ifdef __GNUC__
+
+
+STATIC_ASSERT(__builtin_types_compatible_p(struct struct_tag, struct_typedef));
+STATIC_ASSERT(__builtin_types_compatible_p(struct struct_tag, alt_typedef));
+STATIC_ASSERT(__builtin_types_compatible_p(struct struct_tag, another_typedef));
+STATIC_ASSERT(__builtin_types_compatible_p(struct_typedef, alt_typedef));
+STATIC_ASSERT(__builtin_types_compatible_p(struct_typedef, another_typedef));
+STATIC_ASSERT(__builtin_types_compatible_p(alt_typedef, another_typedef));
+
+#endif
+
+int main(void)
+{
+}

--- a/regression/ansi-c/gcc_types_compatible_p4/test.desc
+++ b/regression/ansi-c/gcc_types_compatible_p4/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/regression/cbmc/typedef-anon-struct1/main.c
+++ b/regression/cbmc/typedef-anon-struct1/main.c
@@ -1,0 +1,11 @@
+
+typedef struct
+{
+  int x;
+  float y;
+} MYSTRUCT;
+
+void fun()
+{
+  MYSTRUCT mystruct_var = {.x = 3, .y = 2.1f};
+}

--- a/regression/cbmc/typedef-anon-struct1/test.desc
+++ b/regression/cbmc/typedef-anon-struct1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: mystruct_var\nMode\.+: C\nType\.+: MYSTRUCT
+--
+warning: ignoring

--- a/regression/cbmc/typedef-anon-struct2/main.c
+++ b/regression/cbmc/typedef-anon-struct2/main.c
@@ -1,0 +1,11 @@
+
+typedef struct
+{
+  int x;
+  float y;
+} MYSTRUCT;
+
+void fun()
+{
+  MYSTRUCT mystruct_var  = {.x = 10, .y = 3.1f}, another_mystruct_var = {.x = 3, .y = 2.1f};
+}

--- a/regression/cbmc/typedef-anon-struct2/test.desc
+++ b/regression/cbmc/typedef-anon-struct2/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: mystruct_var\nMode\.+: C\nType\.+: MYSTRUCT
+Base name\.+: another_mystruct_var\nMode\.+: C\nType\.+: MYSTRUCT
+--
+warning: ignoring

--- a/regression/cbmc/typedef-anon-union1/main.c
+++ b/regression/cbmc/typedef-anon-union1/main.c
@@ -1,0 +1,11 @@
+
+typedef union
+{
+  int x;
+  float y;
+} MYUNION;
+
+void fun()
+{
+  MYUNION myunion_var = {.y = 2.1f};
+}

--- a/regression/cbmc/typedef-anon-union1/test.desc
+++ b/regression/cbmc/typedef-anon-union1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: myunion_var\nMode\.+: C\nType\.+: MYUNION
+--
+warning: ignoring

--- a/regression/cbmc/typedef-anon-union2/main.c
+++ b/regression/cbmc/typedef-anon-union2/main.c
@@ -1,0 +1,11 @@
+
+typedef union
+{
+  int x;
+  float y;
+} MYUNION;
+
+void fun()
+{
+  MYUNION myunion_var = {.y = 2.1f}, another_myunion_var = {.y = 2.1f};
+}

--- a/regression/cbmc/typedef-anon-union2/test.desc
+++ b/regression/cbmc/typedef-anon-union2/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: myunion_var\nMode\.+: C\nType\.+: MYUNION
+Base name\.+: another_myunion_var\nMode\.+: C\nType\.+: MYUNION
+--
+warning: ignoring

--- a/regression/cbmc/typedef-const-struct1/main.c
+++ b/regression/cbmc/typedef-const-struct1/main.c
@@ -1,0 +1,12 @@
+
+typedef struct tag_struct_name
+{
+  int x;
+  float y;
+} MYSTRUCT;
+
+void fun()
+{
+  const struct tag_struct_name tag_struct_var = {.x = 1, .y = 3.14f};
+  const MYSTRUCT mystruct_var = {.x = 3, .y = 2.1f};
+}

--- a/regression/cbmc/typedef-const-struct1/test.desc
+++ b/regression/cbmc/typedef-const-struct1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: tag_struct_var\nMode\.+: C\nType\.+: const struct tag_struct_name
+Base name\.+: mystruct_var\nMode\.+: C\nType\.+: const MYSTRUCT
+--
+warning: ignoring

--- a/regression/cbmc/typedef-const-type1/main.c
+++ b/regression/cbmc/typedef-const-type1/main.c
@@ -1,0 +1,8 @@
+
+typedef int MYINT;
+
+void fun()
+{
+  const int int_var = 3;
+  const MYINT myint_var = 5;
+}

--- a/regression/cbmc/typedef-const-type1/test.desc
+++ b/regression/cbmc/typedef-const-type1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: int_var\nMode\.+: C\nType\.+: const signed int
+Base name\.+: myint_var\nMode\.+: C\nType\.+: const MYINT
+--
+warning: ignoring

--- a/regression/cbmc/typedef-const-union1/main.c
+++ b/regression/cbmc/typedef-const-union1/main.c
@@ -1,0 +1,12 @@
+
+typedef union tag_union_name
+{
+  int x;
+  float y;
+} MYUNION;
+
+void fun()
+{
+  const union tag_union_name tag_union_var = {1};
+  const MYUNION myunion_var = {.y = 2.1f};
+}

--- a/regression/cbmc/typedef-const-union1/test.desc
+++ b/regression/cbmc/typedef-const-union1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: tag_union_var\nMode\.+: C\nType\.+: const union tag_union_name
+Base name\.+: myunion_var\nMode\.+: C\nType\.+: const MYUNION
+--
+warning: ignoring

--- a/regression/cbmc/typedef-param-anon-struct1/main.c
+++ b/regression/cbmc/typedef-param-anon-struct1/main.c
@@ -1,0 +1,11 @@
+
+typedef struct
+{
+  int x;
+  float y;
+} MYSTRUCT;
+
+void fun(MYSTRUCT mystruct_param)
+{
+
+}

--- a/regression/cbmc/typedef-param-anon-struct1/test.desc
+++ b/regression/cbmc/typedef-param-anon-struct1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: mystruct_param\nMode\.+: C\nType\.+: MYSTRUCT
+--
+warning: ignoring

--- a/regression/cbmc/typedef-param-anon-union1/main.c
+++ b/regression/cbmc/typedef-param-anon-union1/main.c
@@ -1,0 +1,10 @@
+
+typedef union
+{
+  int x;
+  float y;
+} MYUNION;
+
+void fun(MYUNION myunion_param)
+{
+}

--- a/regression/cbmc/typedef-param-anon-union1/test.desc
+++ b/regression/cbmc/typedef-param-anon-union1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: myunion_param\nMode\.+: C\nType\.+: MYUNION
+--
+warning: ignoring

--- a/regression/cbmc/typedef-param-struct1/main.c
+++ b/regression/cbmc/typedef-param-struct1/main.c
@@ -1,0 +1,10 @@
+
+typedef struct tag_struct_name
+{
+  int x;
+  float y;
+} MYSTRUCT;
+
+void fun(struct tag_struct_name tag_struct_param, MYSTRUCT mystruct_param)
+{
+}

--- a/regression/cbmc/typedef-param-struct1/test.desc
+++ b/regression/cbmc/typedef-param-struct1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: tag_struct_param\nMode\.+: C\nType\.+: struct tag_struct_name
+Base name\.+: mystruct_param\nMode\.+: C\nType\.+: MYSTRUCT
+--
+warning: ignoring

--- a/regression/cbmc/typedef-param-type1/main.c
+++ b/regression/cbmc/typedef-param-type1/main.c
@@ -1,0 +1,7 @@
+
+typedef int MYINT;
+
+void fun(int int_param, MYINT myint_param)
+{
+
+}

--- a/regression/cbmc/typedef-param-type1/test.desc
+++ b/regression/cbmc/typedef-param-type1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: int_param\nMode\.+: C\nType\.+: signed int
+Base name\.+: myint_param\nMode\.+: C\nType\.+: MYINT
+--
+warning: ignoring

--- a/regression/cbmc/typedef-param-type2/main.c
+++ b/regression/cbmc/typedef-param-type2/main.c
@@ -1,0 +1,8 @@
+
+typedef int MYINT;
+typedef int ALTINT;
+
+void fun(int int_param, MYINT myint_param, ALTINT altint_param)
+{
+
+}

--- a/regression/cbmc/typedef-param-type2/test.desc
+++ b/regression/cbmc/typedef-param-type2/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: int_param\nMode\.+: C\nType\.+: signed int
+Base name\.+: myint_param\nMode\.+: C\nType\.+: MYINT
+Base name\.+: altint_param\nMode\.+: C\nType\.+: ALTINT
+--
+warning: ignoring

--- a/regression/cbmc/typedef-param-type3/main.c
+++ b/regression/cbmc/typedef-param-type3/main.c
@@ -1,0 +1,7 @@
+
+typedef int MYINT;
+typedef MYINT CHAINEDINT;
+
+void fun(int int_param, MYINT myint_param, CHAINEDINT chainedint_param)
+{
+}

--- a/regression/cbmc/typedef-param-type3/test.desc
+++ b/regression/cbmc/typedef-param-type3/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: int_param\nMode\.+: C\nType\.+: signed int
+Base name\.+: myint_param\nMode\.+: C\nType\.+: MYINT
+Base name\.+: chainedint_param\nMode\.+: C\nType\.+: CHAINEDINT
+--
+warning: ignoring

--- a/regression/cbmc/typedef-param-union1/main.c
+++ b/regression/cbmc/typedef-param-union1/main.c
@@ -1,0 +1,10 @@
+
+typedef union tag_union_name
+{
+  int x;
+  float y;
+} MYUNION;
+
+void fun(union tag_union_name tag_union_param, MYUNION myunion_param)
+{
+}

--- a/regression/cbmc/typedef-param-union1/test.desc
+++ b/regression/cbmc/typedef-param-union1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: tag_union_param\nMode\.+: C\nType\.+: union tag_union_name
+Base name\.+: myunion_param\nMode\.+: C\nType\.+: MYUNION
+--
+warning: ignoring

--- a/regression/cbmc/typedef-return-anon-struct1/main.c
+++ b/regression/cbmc/typedef-return-anon-struct1/main.c
@@ -1,0 +1,12 @@
+
+typedef struct
+{
+  int x;
+  float y;
+} MYSTRUCT;
+
+MYSTRUCT fun()
+{
+  MYSTRUCT return_variable = {.x = 1, .y = 3.14f};
+  return return_variable;
+}

--- a/regression/cbmc/typedef-return-anon-struct1/test.desc
+++ b/regression/cbmc/typedef-return-anon-struct1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: return\nMode\.+: C\nType\.+: MYSTRUCT
+Base name\.+: fun\nMode\.+: C\nType\.+: MYSTRUCT \(\)
+--
+warning: ignoring

--- a/regression/cbmc/typedef-return-anon-union1/main.c
+++ b/regression/cbmc/typedef-return-anon-union1/main.c
@@ -1,0 +1,15 @@
+
+typedef union
+{
+  int x;
+  float y;
+} MYUNION;
+
+
+MYUNION fun()
+{
+  MYUNION return_variable = {1};
+  return return_variable;
+}
+
+

--- a/regression/cbmc/typedef-return-anon-union1/test.desc
+++ b/regression/cbmc/typedef-return-anon-union1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: fun\nMode\.+: C\nType\.+: MYUNION \(\)
+--
+warning: ignoring

--- a/regression/cbmc/typedef-return-struct1/main.c
+++ b/regression/cbmc/typedef-return-struct1/main.c
@@ -1,0 +1,20 @@
+
+typedef struct tag_struct_name
+{
+  int x;
+  float y;
+} MYSTRUCT;
+
+struct tag_struct_name fun()
+{
+  struct tag_struct_name return_variable = { .x = 1, .y = 3.14f};
+  return return_variable;
+}
+
+MYSTRUCT fun2()
+{
+  MYSTRUCT return_variable = { .x = 1, .y = 3.14f};
+  return return_variable;
+}
+
+

--- a/regression/cbmc/typedef-return-struct1/test.desc
+++ b/regression/cbmc/typedef-return-struct1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: fun\nMode\.+: C\nType\.+: struct tag_struct_name \(\)
+Base name\.+: fun2\nMode\.+: C\nType\.+: MYSTRUCT \(\)
+--
+warning: ignoring

--- a/regression/cbmc/typedef-return-type1/main.c
+++ b/regression/cbmc/typedef-return-type1/main.c
@@ -1,0 +1,12 @@
+
+typedef int MYINT;
+
+int fun()
+{
+  return 4;
+}
+
+MYINT fun2()
+{
+  return 5;
+}

--- a/regression/cbmc/typedef-return-type1/test.desc
+++ b/regression/cbmc/typedef-return-type1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: fun\nMode\.+: C\nType\.+: signed int \(\)
+Base name\.+: fun2\nMode\.+: C\nType\.+: MYINT \(\)
+--
+warning: ignoring

--- a/regression/cbmc/typedef-return-type2/main.c
+++ b/regression/cbmc/typedef-return-type2/main.c
@@ -1,0 +1,13 @@
+
+typedef int MYINT;
+typedef int ALTINT;
+
+MYINT fun()
+{
+
+}
+
+ALTINT fun2()
+{
+
+}

--- a/regression/cbmc/typedef-return-type2/test.desc
+++ b/regression/cbmc/typedef-return-type2/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: fun\nMode\.+: C\nType\.+: MYINT \(\)
+Base name\.+: fun2\nMode\.+: C\nType\.+: ALTINT \(\)
+--
+warning: ignoring

--- a/regression/cbmc/typedef-return-type3/main.c
+++ b/regression/cbmc/typedef-return-type3/main.c
@@ -1,0 +1,12 @@
+
+typedef int MYINT;
+typedef MYINT CHAINEDINT;
+
+MYINT fun()
+{
+}
+
+CHAINEDINT fun2()
+{
+
+}

--- a/regression/cbmc/typedef-return-type3/test.desc
+++ b/regression/cbmc/typedef-return-type3/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+Base name\.+: fun\nMode\.+: C\nType\.+: MYINT \(\)
+Base name\.+: fun2\nMode\.+: C\nType\.+: CHAINEDINT \(\)
+--
+warning: ignoring

--- a/regression/cbmc/typedef-return-union1/main.c
+++ b/regression/cbmc/typedef-return-union1/main.c
@@ -1,0 +1,20 @@
+
+typedef union tag_union_name
+{
+  int x;
+  float y;
+} MYUNION;
+
+union tag_union_name fun()
+{
+  union tag_union_name return_variable = {1};
+  return return_variable;
+}
+
+MYUNION fun2()
+{
+  MYUNION return_variable = {1};
+  return return_variable;
+}
+
+

--- a/regression/cbmc/typedef-return-union1/test.desc
+++ b/regression/cbmc/typedef-return-union1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: fun\nMode\.+: C\nType\.+: union tag_union_name \(\)
+Base name\.+: fun2\nMode\.+: C\nType\.+: MYUNION \(\)
+--
+warning: ignoring

--- a/regression/cbmc/typedef-struct1/main.c
+++ b/regression/cbmc/typedef-struct1/main.c
@@ -1,0 +1,12 @@
+
+typedef struct tag_struct_name
+{
+  int x;
+  float y;
+} MYSTRUCT;
+
+void fun()
+{
+  struct tag_struct_name tag_struct_var = {.x = 1, .y = 3.14f};
+  MYSTRUCT mystruct_var = {.x = 3, .y = 2.1f};
+}

--- a/regression/cbmc/typedef-struct1/test.desc
+++ b/regression/cbmc/typedef-struct1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: tag_struct_var\nMode\.+: C\nType\.+: struct tag_struct_name
+Base name\.+: mystruct_var\nMode\.+: C\nType\.+: MYSTRUCT
+--
+warning: ignoring

--- a/regression/cbmc/typedef-struct2/main.c
+++ b/regression/cbmc/typedef-struct2/main.c
@@ -1,0 +1,12 @@
+
+typedef struct tag_struct_name
+{
+  int x;
+  float y;
+} MYSTRUCT;
+
+void fun()
+{
+  struct tag_struct_name tag_struct_var = {.x = 1, .y = 3.14f};
+  MYSTRUCT mystruct_var = {.x = 3, .y = 2.1f};
+}

--- a/regression/cbmc/typedef-struct2/test.desc
+++ b/regression/cbmc/typedef-struct2/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: tag_struct_var\nMode\.+: C\nType\.+: struct tag_struct_name
+Base name\.+: mystruct_var\nMode\.+: C\nType\.+: MYSTRUCT
+--
+warning: ignoring

--- a/regression/cbmc/typedef-type1/main.c
+++ b/regression/cbmc/typedef-type1/main.c
@@ -1,0 +1,8 @@
+
+typedef int MYINT;
+
+void fun()
+{
+  int int_var = 3;
+  MYINT myint_var = 5;
+}

--- a/regression/cbmc/typedef-type1/test.desc
+++ b/regression/cbmc/typedef-type1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: int_var\nMode\.+: C\nType\.+: signed int
+Base name\.+: myint_var\nMode\.+: C\nType\.+: MYINT
+--
+warning: ignoring

--- a/regression/cbmc/typedef-type2/main.c
+++ b/regression/cbmc/typedef-type2/main.c
@@ -1,0 +1,10 @@
+
+typedef int MYINT;
+typedef int ALTINT;
+
+void fun()
+{
+  int int_var = 3;
+  MYINT myint_var = 5;
+  ALTINT altint_var = 7;
+}

--- a/regression/cbmc/typedef-type2/test.desc
+++ b/regression/cbmc/typedef-type2/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: int_var\nMode\.+: C\nType\.+: signed int
+Base name\.+: myint_var\nMode\.+: C\nType\.+: MYINT
+Base name\.+: altint_var\nMode\.+: C\nType\.+: ALTINT
+--
+warning: ignoring

--- a/regression/cbmc/typedef-type3/main.c
+++ b/regression/cbmc/typedef-type3/main.c
@@ -1,0 +1,10 @@
+
+typedef int MYINT;
+typedef MYINT CHAINEDINT;
+
+void fun()
+{
+  int int_var = 3;
+  MYINT myint_var = 5;
+  CHAINEDINT chainedint_var = 5;
+}

--- a/regression/cbmc/typedef-type3/test.desc
+++ b/regression/cbmc/typedef-type3/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: int_var\nMode\.+: C\nType\.+: signed int
+Base name\.+: myint_var\nMode\.+: C\nType\.+: MYINT
+Base name\.+: chainedint_var\nMode\.+: C\nType\.+: CHAINEDINT
+--
+warning: ignoring

--- a/regression/cbmc/typedef-type4/main.c
+++ b/regression/cbmc/typedef-type4/main.c
@@ -1,0 +1,8 @@
+
+typedef int MYINT;
+
+void fun()
+{
+  int int_var = 3;
+  MYINT myint_var = 5, another_myint_var = 10;
+}

--- a/regression/cbmc/typedef-type4/test.desc
+++ b/regression/cbmc/typedef-type4/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: int_var\nMode\.+: C\nType\.+: signed int
+Base name\.+: myint_var\nMode\.+: C\nType\.+: MYINT
+Base name\.+: another_myint_var\nMode\.+: C\nType\.+: MYINT
+--
+warning: ignoring

--- a/regression/cbmc/typedef-union1/main.c
+++ b/regression/cbmc/typedef-union1/main.c
@@ -1,0 +1,12 @@
+
+typedef union tag_union_name
+{
+  int x;
+  float y;
+} MYUNION;
+
+void fun()
+{
+  union tag_union_name tag_union_var = {1};
+  MYUNION myunion_var = {.y = 2.1f};
+}

--- a/regression/cbmc/typedef-union1/test.desc
+++ b/regression/cbmc/typedef-union1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: tag_union_var\nMode\.+: C\nType\.+: union tag_union_name
+Base name\.+: myunion_var\nMode\.+: C\nType\.+: MYUNION
+--
+warning: ignoring

--- a/regression/cbmc/typedef-union2/main.c
+++ b/regression/cbmc/typedef-union2/main.c
@@ -1,0 +1,12 @@
+
+typedef union tag_union_name
+{
+  int x;
+  float y;
+} MYUNION;
+
+void fun()
+{
+  union tag_union_name tag_union_var = {1}, another_tag_union_var = {1};
+  MYUNION myunion_var = {.y = 2.1f}, another_myunion_var = {.y = 3.1f};
+}

--- a/regression/cbmc/typedef-union2/test.desc
+++ b/regression/cbmc/typedef-union2/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--show-symbol-table --function fun
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: tag_union_var\nMode\.+: C\nType\.+: union tag_union_name
+Base name\.+: another_tag_union_var\nMode\.+: C\nType\.+: union tag_union_name
+Base name\.+: myunion_var\nMode\.+: C\nType\.+: MYUNION
+Base name\.+: another_myunion_var\nMode\.+: C\nType\.+: MYUNION
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/Makefile
+++ b/regression/goto-instrument-typedef/Makefile
@@ -1,0 +1,31 @@
+
+default: tests.log
+
+test:
+	@if ! ../test.pl -c ../chain.sh ; then \
+		../failed-tests-printer.pl ; \
+		exit 1; \
+	fi
+
+tests.log:
+	@if ! ../test.pl -c ../chain.sh ; then \
+		../failed-tests-printer.pl ; \
+		exit 1; \
+	fi
+
+show:
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			vim -o "$$dir/*.c" "$$dir/*.out"; \
+		fi; \
+	done;
+
+clean:
+	@for dir in *; do \
+		rm -f tests.log; \
+		if [ -d "$$dir" ]; then \
+			cd "$$dir"; \
+			rm -f *.out *.gb; \
+			cd ..; \
+		fi \
+	done

--- a/regression/goto-instrument-typedef/chain.sh
+++ b/regression/goto-instrument-typedef/chain.sh
@@ -8,6 +8,7 @@ GI=$SRC/goto-instrument/goto-instrument
 OPTS=$1
 NAME=${2%.c}
 
+rm $NAME.gb
 $GC $NAME.c --function fun -o $NAME.gb
 echo $GI $OPTS $NAME.gb
 $GI $OPTS $NAME.gb

--- a/regression/goto-instrument-typedef/chain.sh
+++ b/regression/goto-instrument-typedef/chain.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+SRC=../../../src
+
+GC=$SRC/goto-cc/goto-cc
+GI=$SRC/goto-instrument/goto-instrument
+
+OPTS=$1
+NAME=${2%.c}
+
+$GC $NAME.c --function fun -o $NAME.gb
+echo $GI $OPTS $NAME.gb
+$GI $OPTS $NAME.gb

--- a/regression/goto-instrument-typedef/typedef-anon-struct1/main.c
+++ b/regression/goto-instrument-typedef/typedef-anon-struct1/main.c
@@ -1,0 +1,11 @@
+
+typedef struct
+{
+  int x;
+  float y;
+} MYSTRUCT;
+
+void fun()
+{
+  MYSTRUCT mystruct_var = {.x = 3, .y = 2.1f};
+}

--- a/regression/goto-instrument-typedef/typedef-anon-struct1/test.desc
+++ b/regression/goto-instrument-typedef/typedef-anon-struct1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: mystruct_var\nMode\.+: C\nType\.+: MYSTRUCT
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-anon-struct2/main.c
+++ b/regression/goto-instrument-typedef/typedef-anon-struct2/main.c
@@ -1,0 +1,11 @@
+
+typedef struct
+{
+  int x;
+  float y;
+} MYSTRUCT;
+
+void fun()
+{
+  MYSTRUCT mystruct_var  = {.x = 10, .y = 3.1f}, another_mystruct_var = {.x = 3, .y = 2.1f};
+}

--- a/regression/goto-instrument-typedef/typedef-anon-struct2/test.desc
+++ b/regression/goto-instrument-typedef/typedef-anon-struct2/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: mystruct_var\nMode\.+: C\nType\.+: MYSTRUCT
+Base name\.+: another_mystruct_var\nMode\.+: C\nType\.+: MYSTRUCT
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-anon-union1/main.c
+++ b/regression/goto-instrument-typedef/typedef-anon-union1/main.c
@@ -1,0 +1,11 @@
+
+typedef union
+{
+  int x;
+  float y;
+} MYUNION;
+
+void fun()
+{
+  MYUNION myunion_var = {.y = 2.1f};
+}

--- a/regression/goto-instrument-typedef/typedef-anon-union1/test.desc
+++ b/regression/goto-instrument-typedef/typedef-anon-union1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: myunion_var\nMode\.+: C\nType\.+: MYUNION
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-anon-union2/main.c
+++ b/regression/goto-instrument-typedef/typedef-anon-union2/main.c
@@ -1,0 +1,11 @@
+
+typedef union
+{
+  int x;
+  float y;
+} MYUNION;
+
+void fun()
+{
+  MYUNION myunion_var = {.y = 2.1f}, another_myunion_var = {.y = 2.1f};
+}

--- a/regression/goto-instrument-typedef/typedef-anon-union2/test.desc
+++ b/regression/goto-instrument-typedef/typedef-anon-union2/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: myunion_var\nMode\.+: C\nType\.+: MYUNION
+Base name\.+: another_myunion_var\nMode\.+: C\nType\.+: MYUNION
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-const-struct1/main.c
+++ b/regression/goto-instrument-typedef/typedef-const-struct1/main.c
@@ -1,0 +1,12 @@
+
+typedef struct tag_struct_name
+{
+  int x;
+  float y;
+} MYSTRUCT;
+
+void fun()
+{
+  const struct tag_struct_name tag_struct_var = {.x = 1, .y = 3.14f};
+  const MYSTRUCT mystruct_var = {.x = 3, .y = 2.1f};
+}

--- a/regression/goto-instrument-typedef/typedef-const-struct1/test.desc
+++ b/regression/goto-instrument-typedef/typedef-const-struct1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: tag_struct_var\nMode\.+: C\nType\.+: const struct tag_struct_name
+Base name\.+: mystruct_var\nMode\.+: C\nType\.+: const MYSTRUCT
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-const-type1/main.c
+++ b/regression/goto-instrument-typedef/typedef-const-type1/main.c
@@ -1,0 +1,8 @@
+
+typedef int MYINT;
+
+void fun()
+{
+  const int int_var = 3;
+  const MYINT myint_var = 5;
+}

--- a/regression/goto-instrument-typedef/typedef-const-type1/test.desc
+++ b/regression/goto-instrument-typedef/typedef-const-type1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: int_var\nMode\.+: C\nType\.+: const signed int
+Base name\.+: myint_var\nMode\.+: C\nType\.+: const MYINT
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-const-union1/main.c
+++ b/regression/goto-instrument-typedef/typedef-const-union1/main.c
@@ -1,0 +1,12 @@
+
+typedef union tag_union_name
+{
+  int x;
+  float y;
+} MYUNION;
+
+void fun()
+{
+  const union tag_union_name tag_union_var = {1};
+  const MYUNION myunion_var = {.y = 2.1f};
+}

--- a/regression/goto-instrument-typedef/typedef-const-union1/test.desc
+++ b/regression/goto-instrument-typedef/typedef-const-union1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: tag_union_var\nMode\.+: C\nType\.+: const union tag_union_name
+Base name\.+: myunion_var\nMode\.+: C\nType\.+: const MYUNION
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-param-anon-struct1/main.c
+++ b/regression/goto-instrument-typedef/typedef-param-anon-struct1/main.c
@@ -1,0 +1,11 @@
+
+typedef struct
+{
+  int x;
+  float y;
+} MYSTRUCT;
+
+void fun(MYSTRUCT mystruct_param)
+{
+
+}

--- a/regression/goto-instrument-typedef/typedef-param-anon-struct1/test.desc
+++ b/regression/goto-instrument-typedef/typedef-param-anon-struct1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: mystruct_param\nMode\.+: C\nType\.+: MYSTRUCT
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-param-anon-union1/main.c
+++ b/regression/goto-instrument-typedef/typedef-param-anon-union1/main.c
@@ -1,0 +1,10 @@
+
+typedef union
+{
+  int x;
+  float y;
+} MYUNION;
+
+void fun(MYUNION myunion_param)
+{
+}

--- a/regression/goto-instrument-typedef/typedef-param-anon-union1/test.desc
+++ b/regression/goto-instrument-typedef/typedef-param-anon-union1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: myunion_param\nMode\.+: C\nType\.+: MYUNION
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-param-struct1/main.c
+++ b/regression/goto-instrument-typedef/typedef-param-struct1/main.c
@@ -1,0 +1,10 @@
+
+typedef struct tag_struct_name
+{
+  int x;
+  float y;
+} MYSTRUCT;
+
+void fun(struct tag_struct_name tag_struct_param, MYSTRUCT mystruct_param)
+{
+}

--- a/regression/goto-instrument-typedef/typedef-param-struct1/test.desc
+++ b/regression/goto-instrument-typedef/typedef-param-struct1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: tag_struct_param\nMode\.+: C\nType\.+: struct tag_struct_name
+Base name\.+: mystruct_param\nMode\.+: C\nType\.+: MYSTRUCT
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-param-type1/main.c
+++ b/regression/goto-instrument-typedef/typedef-param-type1/main.c
@@ -1,0 +1,7 @@
+
+typedef int MYINT;
+
+void fun(int int_param, MYINT myint_param)
+{
+
+}

--- a/regression/goto-instrument-typedef/typedef-param-type1/test.desc
+++ b/regression/goto-instrument-typedef/typedef-param-type1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: int_param\nMode\.+: C\nType\.+: signed int
+Base name\.+: myint_param\nMode\.+: C\nType\.+: MYINT
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-param-type2/main.c
+++ b/regression/goto-instrument-typedef/typedef-param-type2/main.c
@@ -1,0 +1,8 @@
+
+typedef int MYINT;
+typedef int ALTINT;
+
+void fun(int int_param, MYINT myint_param, ALTINT altint_param)
+{
+
+}

--- a/regression/goto-instrument-typedef/typedef-param-type2/test.desc
+++ b/regression/goto-instrument-typedef/typedef-param-type2/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: int_param\nMode\.+: C\nType\.+: signed int
+Base name\.+: myint_param\nMode\.+: C\nType\.+: MYINT
+Base name\.+: altint_param\nMode\.+: C\nType\.+: ALTINT
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-param-type3/main.c
+++ b/regression/goto-instrument-typedef/typedef-param-type3/main.c
@@ -1,0 +1,7 @@
+
+typedef int MYINT;
+typedef MYINT CHAINEDINT;
+
+void fun(int int_param, MYINT myint_param, CHAINEDINT chainedint_param)
+{
+}

--- a/regression/goto-instrument-typedef/typedef-param-type3/test.desc
+++ b/regression/goto-instrument-typedef/typedef-param-type3/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: int_param\nMode\.+: C\nType\.+: signed int
+Base name\.+: myint_param\nMode\.+: C\nType\.+: MYINT
+Base name\.+: chainedint_param\nMode\.+: C\nType\.+: CHAINEDINT
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-param-union1/main.c
+++ b/regression/goto-instrument-typedef/typedef-param-union1/main.c
@@ -1,0 +1,10 @@
+
+typedef union tag_union_name
+{
+  int x;
+  float y;
+} MYUNION;
+
+void fun(union tag_union_name tag_union_param, MYUNION myunion_param)
+{
+}

--- a/regression/goto-instrument-typedef/typedef-param-union1/test.desc
+++ b/regression/goto-instrument-typedef/typedef-param-union1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: tag_union_param\nMode\.+: C\nType\.+: union tag_union_name
+Base name\.+: myunion_param\nMode\.+: C\nType\.+: MYUNION
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-return-anon-struct1/main.c
+++ b/regression/goto-instrument-typedef/typedef-return-anon-struct1/main.c
@@ -1,0 +1,12 @@
+
+typedef struct
+{
+  int x;
+  float y;
+} MYSTRUCT;
+
+MYSTRUCT fun()
+{
+  MYSTRUCT return_variable = {.x = 1, .y = 3.14f};
+  return return_variable;
+}

--- a/regression/goto-instrument-typedef/typedef-return-anon-struct1/test.desc
+++ b/regression/goto-instrument-typedef/typedef-return-anon-struct1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: return\nMode\.+: C\nType\.+: MYSTRUCT
+Base name\.+: fun\nMode\.+: C\nType\.+: MYSTRUCT \(\)
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-return-anon-union1/main.c
+++ b/regression/goto-instrument-typedef/typedef-return-anon-union1/main.c
@@ -1,0 +1,15 @@
+
+typedef union
+{
+  int x;
+  float y;
+} MYUNION;
+
+
+MYUNION fun()
+{
+  MYUNION return_variable = {1};
+  return return_variable;
+}
+
+

--- a/regression/goto-instrument-typedef/typedef-return-anon-union1/test.desc
+++ b/regression/goto-instrument-typedef/typedef-return-anon-union1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: fun\nMode\.+: C\nType\.+: MYUNION \(\)
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-return-struct1/main.c
+++ b/regression/goto-instrument-typedef/typedef-return-struct1/main.c
@@ -1,0 +1,20 @@
+
+typedef struct tag_struct_name
+{
+  int x;
+  float y;
+} MYSTRUCT;
+
+struct tag_struct_name fun()
+{
+  struct tag_struct_name return_variable = { .x = 1, .y = 3.14f};
+  return return_variable;
+}
+
+MYSTRUCT fun2()
+{
+  MYSTRUCT return_variable = { .x = 1, .y = 3.14f};
+  return return_variable;
+}
+
+

--- a/regression/goto-instrument-typedef/typedef-return-struct1/test.desc
+++ b/regression/goto-instrument-typedef/typedef-return-struct1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: fun\nMode\.+: C\nType\.+: struct tag_struct_name \(\)
+Base name\.+: fun2\nMode\.+: C\nType\.+: MYSTRUCT \(\)
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-return-type1/main.c
+++ b/regression/goto-instrument-typedef/typedef-return-type1/main.c
@@ -1,0 +1,12 @@
+
+typedef int MYINT;
+
+int fun()
+{
+  return 4;
+}
+
+MYINT fun2()
+{
+  return 5;
+}

--- a/regression/goto-instrument-typedef/typedef-return-type1/test.desc
+++ b/regression/goto-instrument-typedef/typedef-return-type1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: fun\nMode\.+: C\nType\.+: signed int \(\)
+Base name\.+: fun2\nMode\.+: C\nType\.+: MYINT \(\)
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-return-type2/main.c
+++ b/regression/goto-instrument-typedef/typedef-return-type2/main.c
@@ -1,0 +1,13 @@
+
+typedef int MYINT;
+typedef int ALTINT;
+
+MYINT fun()
+{
+
+}
+
+ALTINT fun2()
+{
+
+}

--- a/regression/goto-instrument-typedef/typedef-return-type2/test.desc
+++ b/regression/goto-instrument-typedef/typedef-return-type2/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: fun\nMode\.+: C\nType\.+: MYINT \(\)
+Base name\.+: fun2\nMode\.+: C\nType\.+: ALTINT \(\)
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-return-type3/main.c
+++ b/regression/goto-instrument-typedef/typedef-return-type3/main.c
@@ -1,0 +1,12 @@
+
+typedef int MYINT;
+typedef MYINT CHAINEDINT;
+
+MYINT fun()
+{
+}
+
+CHAINEDINT fun2()
+{
+
+}

--- a/regression/goto-instrument-typedef/typedef-return-type3/test.desc
+++ b/regression/goto-instrument-typedef/typedef-return-type3/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+Base name\.+: fun\nMode\.+: C\nType\.+: MYINT \(\)
+Base name\.+: fun2\nMode\.+: C\nType\.+: CHAINEDINT \(\)
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-return-union1/main.c
+++ b/regression/goto-instrument-typedef/typedef-return-union1/main.c
@@ -1,0 +1,20 @@
+
+typedef union tag_union_name
+{
+  int x;
+  float y;
+} MYUNION;
+
+union tag_union_name fun()
+{
+  union tag_union_name return_variable = {1};
+  return return_variable;
+}
+
+MYUNION fun2()
+{
+  MYUNION return_variable = {1};
+  return return_variable;
+}
+
+

--- a/regression/goto-instrument-typedef/typedef-return-union1/test.desc
+++ b/regression/goto-instrument-typedef/typedef-return-union1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: fun\nMode\.+: C\nType\.+: union tag_union_name \(\)
+Base name\.+: fun2\nMode\.+: C\nType\.+: MYUNION \(\)
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-struct1/main.c
+++ b/regression/goto-instrument-typedef/typedef-struct1/main.c
@@ -1,0 +1,12 @@
+
+typedef struct tag_struct_name
+{
+  int x;
+  float y;
+} MYSTRUCT;
+
+void fun()
+{
+  struct tag_struct_name tag_struct_var = {.x = 1, .y = 3.14f};
+  MYSTRUCT mystruct_var = {.x = 3, .y = 2.1f};
+}

--- a/regression/goto-instrument-typedef/typedef-struct1/test.desc
+++ b/regression/goto-instrument-typedef/typedef-struct1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: tag_struct_var\nMode\.+: C\nType\.+: struct tag_struct_name
+Base name\.+: mystruct_var\nMode\.+: C\nType\.+: MYSTRUCT
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-struct2/main.c
+++ b/regression/goto-instrument-typedef/typedef-struct2/main.c
@@ -1,0 +1,12 @@
+
+typedef struct tag_struct_name
+{
+  int x;
+  float y;
+} MYSTRUCT;
+
+void fun()
+{
+  struct tag_struct_name tag_struct_var = {.x = 1, .y = 3.14f};
+  MYSTRUCT mystruct_var = {.x = 3, .y = 2.1f};
+}

--- a/regression/goto-instrument-typedef/typedef-struct2/test.desc
+++ b/regression/goto-instrument-typedef/typedef-struct2/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: tag_struct_var\nMode\.+: C\nType\.+: struct tag_struct_name
+Base name\.+: mystruct_var\nMode\.+: C\nType\.+: MYSTRUCT
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-type1/main.c
+++ b/regression/goto-instrument-typedef/typedef-type1/main.c
@@ -1,0 +1,8 @@
+
+typedef int MYINT;
+
+void fun()
+{
+  int int_var = 3;
+  MYINT myint_var = 5;
+}

--- a/regression/goto-instrument-typedef/typedef-type1/test.desc
+++ b/regression/goto-instrument-typedef/typedef-type1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: int_var\nMode\.+: C\nType\.+: signed int
+Base name\.+: myint_var\nMode\.+: C\nType\.+: MYINT
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-type2/main.c
+++ b/regression/goto-instrument-typedef/typedef-type2/main.c
@@ -1,0 +1,10 @@
+
+typedef int MYINT;
+typedef int ALTINT;
+
+void fun()
+{
+  int int_var = 3;
+  MYINT myint_var = 5;
+  ALTINT altint_var = 7;
+}

--- a/regression/goto-instrument-typedef/typedef-type2/test.desc
+++ b/regression/goto-instrument-typedef/typedef-type2/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: int_var\nMode\.+: C\nType\.+: signed int
+Base name\.+: myint_var\nMode\.+: C\nType\.+: MYINT
+Base name\.+: altint_var\nMode\.+: C\nType\.+: ALTINT
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-type3/main.c
+++ b/regression/goto-instrument-typedef/typedef-type3/main.c
@@ -1,0 +1,10 @@
+
+typedef int MYINT;
+typedef MYINT CHAINEDINT;
+
+void fun()
+{
+  int int_var = 3;
+  MYINT myint_var = 5;
+  CHAINEDINT chainedint_var = 5;
+}

--- a/regression/goto-instrument-typedef/typedef-type3/test.desc
+++ b/regression/goto-instrument-typedef/typedef-type3/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: int_var\nMode\.+: C\nType\.+: signed int
+Base name\.+: myint_var\nMode\.+: C\nType\.+: MYINT
+Base name\.+: chainedint_var\nMode\.+: C\nType\.+: CHAINEDINT
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-type4/main.c
+++ b/regression/goto-instrument-typedef/typedef-type4/main.c
@@ -1,0 +1,8 @@
+
+typedef int MYINT;
+
+void fun()
+{
+  int int_var = 3;
+  MYINT myint_var = 5, another_myint_var = 10;
+}

--- a/regression/goto-instrument-typedef/typedef-type4/test.desc
+++ b/regression/goto-instrument-typedef/typedef-type4/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: int_var\nMode\.+: C\nType\.+: signed int
+Base name\.+: myint_var\nMode\.+: C\nType\.+: MYINT
+Base name\.+: another_myint_var\nMode\.+: C\nType\.+: MYINT
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-union1/main.c
+++ b/regression/goto-instrument-typedef/typedef-union1/main.c
@@ -1,0 +1,12 @@
+
+typedef union tag_union_name
+{
+  int x;
+  float y;
+} MYUNION;
+
+void fun()
+{
+  union tag_union_name tag_union_var = {1};
+  MYUNION myunion_var = {.y = 2.1f};
+}

--- a/regression/goto-instrument-typedef/typedef-union1/test.desc
+++ b/regression/goto-instrument-typedef/typedef-union1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: tag_union_var\nMode\.+: C\nType\.+: union tag_union_name
+Base name\.+: myunion_var\nMode\.+: C\nType\.+: MYUNION
+--
+warning: ignoring

--- a/regression/goto-instrument-typedef/typedef-union2/main.c
+++ b/regression/goto-instrument-typedef/typedef-union2/main.c
@@ -1,0 +1,12 @@
+
+typedef union tag_union_name
+{
+  int x;
+  float y;
+} MYUNION;
+
+void fun()
+{
+  union tag_union_name tag_union_var = {1}, another_tag_union_var = {1};
+  MYUNION myunion_var = {.y = 2.1f}, another_myunion_var = {.y = 3.1f};
+}

--- a/regression/goto-instrument-typedef/typedef-union2/test.desc
+++ b/regression/goto-instrument-typedef/typedef-union2/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+"--show-symbol-table"
+// Enable multi-line checking
+activate-multi-line-match
+EXIT=0
+SIGNAL=0
+Base name\.+: tag_union_var\nMode\.+: C\nType\.+: union tag_union_name
+Base name\.+: another_tag_union_var\nMode\.+: C\nType\.+: union tag_union_name
+Base name\.+: myunion_var\nMode\.+: C\nType\.+: MYUNION
+Base name\.+: another_myunion_var\nMode\.+: C\nType\.+: MYUNION
+--
+warning: ignoring

--- a/src/ansi-c/ansi_c_declaration.cpp
+++ b/src/ansi-c/ansi_c_declaration.cpp
@@ -146,6 +146,10 @@ typet ansi_c_declarationt::full_type(
 
   *p=type();
 
+  // retain typedef for dump-c
+  if(get_is_typedef())
+    result.set(ID_typedef,declarator.get_name());
+
   return result;
 }
 

--- a/src/ansi-c/ansi_c_declaration.cpp
+++ b/src/ansi-c/ansi_c_declaration.cpp
@@ -148,7 +148,7 @@ typet ansi_c_declarationt::full_type(
 
   // retain typedef for dump-c
   if(get_is_typedef())
-    result.set(ID_typedef,declarator.get_name());
+    result.set(ID_C_typedef,declarator.get_name());
 
   return result;
 }

--- a/src/ansi-c/ansi_c_declaration.cpp
+++ b/src/ansi-c/ansi_c_declaration.cpp
@@ -148,7 +148,7 @@ typet ansi_c_declarationt::full_type(
 
   // retain typedef for dump-c
   if(get_is_typedef())
-    result.set(ID_C_typedef,declarator.get_name());
+    result.set(ID_C_typedef, declarator.get_name());
 
   return result;
 }

--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -262,10 +262,6 @@ protected:
   asm_label_mapt asm_label_map;
 
   void apply_asm_label(const irep_idt &asm_label, symbolt &symbol);
-
-private:
-  static bool are_types_equal_ignoring_typedef(
-    const typet type1, const typet &type2);
 };
 
 #endif // CPROVER_ANSI_C_C_TYPECHECK_BASE_H

--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -262,6 +262,10 @@ protected:
   asm_label_mapt asm_label_map;
 
   void apply_asm_label(const irep_idt &asm_label, symbolt &symbol);
+
+private:
+  static bool are_types_equal_ignoring_typedef(
+    const typet type1, const typet &type2);
 };
 
 #endif // CPROVER_ANSI_C_C_TYPECHECK_BASE_H

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -140,8 +140,6 @@ bool c_typecheck_baset::gcc_types_compatible_p(
   if(type1.id()==ID_c_enum)
   {
     if(type2.id()==ID_c_enum) // both are enums
-      // We don't need to remove the typedef flag here since as it is an enum
-      // we have already followed the enum tag to get to the underlying enum
       return type1==type2; // compares the tag
     else if(type2==type1.subtype())
       return true;
@@ -186,51 +184,18 @@ bool c_typecheck_baset::gcc_types_compatible_p(
   }
   else
   {
-    if(are_types_equal_ignoring_typedef(type1, type2))
+    if(type1==type2)
     {
       // Need to distinguish e.g. long int from int or
       // long long int from long int.
       // The rules appear to match those of C++.
-      // Isn't this explictly handled by checking type1==type2 (since
-      // operator== recursively checks all sub types).
+
       if(type1.get(ID_C_c_type)==type2.get(ID_C_c_type))
         return true;
     }
   }
 
   return false;
-}
-
-/*******************************************************************\
-
-Function: c_typecheck_baset::are_types_equal_ignoring_typedef
-
-  Inputs:
-   type1 - the first type to compare
-   type2 - the second type to compare
-
- Outputs: True if the types are equal
-
- Purpose: To check whether two types are equal, ignoring if they have a
-          different typedef tag. We do this by explictly removing the
-          ID_C_typedef from the type before comparing. Then we just use
-          operator== to compare the resultant types.
-
-\*******************************************************************/
-bool c_typecheck_baset::are_types_equal_ignoring_typedef(
-  const typet type1, const typet &type2)
-{
-  typet non_typedefd_type1=type1;
-  typet non_typedefd_type2=type2;
-  if(type1.get(ID_C_typedef)!=ID_nil)
-  {
-    non_typedefd_type1.remove(ID_C_typedef);
-  }
-  if(type2.get(ID_C_typedef)!=ID_nil)
-  {
-    non_typedefd_type2.remove(ID_C_typedef);
-  }
-  return non_typedefd_type1==non_typedefd_type2;
 }
 
 /*******************************************************************\

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -52,6 +52,7 @@ void c_typecheck_baset::typecheck_type(typet &type)
     c_qualifiers+=c_qualifierst(type.subtype());
     bool packed=type.get_bool(ID_C_packed);
     exprt alignment=static_cast<const exprt &>(type.find(ID_C_alignment));
+    irept _typedef=type.find(ID_typedef);
 
     type.swap(type.subtype());
 
@@ -60,6 +61,8 @@ void c_typecheck_baset::typecheck_type(typet &type)
       type.set(ID_C_packed, true);
     if(alignment.is_not_nil())
       type.add(ID_C_alignment, alignment);
+    if(_typedef.is_not_nil())
+      type.add(ID_typedef, _typedef);
 
     return; // done
   }

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -52,7 +52,7 @@ void c_typecheck_baset::typecheck_type(typet &type)
     c_qualifiers+=c_qualifierst(type.subtype());
     bool packed=type.get_bool(ID_C_packed);
     exprt alignment=static_cast<const exprt &>(type.find(ID_C_alignment));
-    irept _typedef=type.find(ID_typedef);
+    irept _typedef=type.find(ID_C_typedef);
 
     type.swap(type.subtype());
 
@@ -62,7 +62,7 @@ void c_typecheck_baset::typecheck_type(typet &type)
     if(alignment.is_not_nil())
       type.add(ID_C_alignment, alignment);
     if(_typedef.is_not_nil())
-      type.add(ID_typedef, _typedef);
+      type.add(ID_C_typedef, _typedef);
 
     return; // done
   }

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -232,9 +232,9 @@ std::string expr2ct::convert_rec(
   std::string d=
     declarator==""?declarator:" "+declarator;
 
-  if(src.find(ID_typedef).is_not_nil())
+  if(src.find(ID_C_typedef).is_not_nil())
   {
-    return q+id2string(src.get(ID_typedef))+d;
+    return q+id2string(src.get(ID_C_typedef))+d;
   }
 
   if(src.id()==ID_bool)

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -232,6 +232,11 @@ std::string expr2ct::convert_rec(
   std::string d=
     declarator==""?declarator:" "+declarator;
 
+  if(src.find(ID_typedef).is_not_nil())
+  {
+    return q+id2string(src.get(ID_typedef))+d;
+  }
+
   if(src.id()==ID_bool)
   {
     return q+"_Bool"+d;

--- a/src/util/irep_ids.txt
+++ b/src/util/irep_ids.txt
@@ -251,7 +251,7 @@ concatenation
 infinity
 return_type
 typedef
-C_typedef
+C_typedef #typedef
 extern
 static
 auto

--- a/src/util/irep_ids.txt
+++ b/src/util/irep_ids.txt
@@ -251,6 +251,7 @@ concatenation
 infinity
 return_type
 typedef
+C_typedef
 extern
 static
 auto


### PR DESCRIPTION
Issue: https://github.com/diffblue/verification-engine-utils/issues/315

_This is an improved, tested and tidied version of this PR: https://github.com/diffblue/cbmc/pull/345, there is some useful discussion there._

The basic idea is to store the typedef in the type of each expression. Then when we convert a type, if it has an active typedef, we prefer that over the actual type. 

~This PR is dependent on: #353 for the tests to work as it uses the multi-line extension.~

~Real diff: https://github.com/diffblue/cbmc/pull/358/files/4437682559813e9efb9349416aaa764b8036b4a4..7d0a79335ae0d40f609a37a443b13ea6f1723082~