### PR TITLE
Fix a bug in the bitwise encoding of float to int casting.

### DIFF
--- a/regression/cbmc/Float-to-int1/main.c
+++ b/regression/cbmc/Float-to-int1/main.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+
+double nondet_double();
+
+int main(void)
+{
+  double d = nondet_double();
+
+  __CPROVER_assume(d < 0x1.0p+63 && d > 0x1.0p+53);
+
+  long long int i = d;
+  double d1 = i;
+
+  assert(d1 != 0x0);
+
+  return 0;
+}
+

--- a/regression/cbmc/Float-to-int1/test.desc
+++ b/regression/cbmc/Float-to-int1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--floatbv
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc/Float-to-int2/main.c
+++ b/regression/cbmc/Float-to-int2/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+int nondet_int();
+double nondet_double();
+
+int main(void)
+{
+  int i = nondet_int();
+  double di = (double)i;
+  int j = (int)di;
+
+  assert(i == j);
+
+  return 0;
+}
+

--- a/regression/cbmc/Float-to-int2/test.desc
+++ b/regression/cbmc/Float-to-int2/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--floatbv
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc/Float-to-int3/main.c
+++ b/regression/cbmc/Float-to-int3/main.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+#include <stdint.h>
+
+int64_t nondet_int64_t();
+double nondet_double();
+
+int main(void)
+{
+  int64_t i = nondet_int64_t();
+
+  __CPROVER_assume((i & (int64_t)0x7FF) == (int64_t)0);
+  
+  double di = (double)i;
+  int64_t j = (int64_t)di;
+
+  assert(i == j);
+
+  return 0;
+}
+

--- a/regression/cbmc/Float-to-int3/test.desc
+++ b/regression/cbmc/Float-to-int3/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--floatbv
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring


### PR DESCRIPTION
This affects cases when a floating-point number is cast to an integer
which is longer than the significand of the float and the exponent is
greater than the length of the significand.  This includes
float -> (u)int32_t and double -> (u)int64_t.  These were incorrectly
converted to 0.