### PR TITLE
Generalise dominators template

### DIFF
--- a/src/analyses/cfg_dominators.h
+++ b/src/analyses/cfg_dominators.h
@@ -126,13 +126,13 @@ void cfg_dominators_templatet<P, T, post_dom>::fixedpoint(P &program)
 {
   std::list<T> worklist;
 
-  if(program.instructions.empty())
+  if(cfg.nodes_empty(program))
     return;
 
   if(post_dom)
-    entry_node = --program.instructions.end();
+    entry_node=cfg.get_last_node(program);
   else
-    entry_node = program.instructions.begin();
+    entry_node=cfg.get_first_node(program);
   typename cfgt::nodet &n=cfg[cfg.entry_map[entry_node]];
   n.dominators.insert(entry_node);
 
@@ -228,17 +228,18 @@ void cfg_dominators_templatet<P, T, post_dom>::output(std::ostream &out) const
       it=cfg.entry_map.begin();
       it!=cfg.entry_map.end(); ++it)
   {
-    unsigned n=it->first->location_number;
+    T n=it->first;
 
     if(post_dom)
       out << n << " post-dominated by ";
     else
       out << n << " dominated by ";
-    for(typename target_sett::const_iterator d_it=it->second.dominators.begin();
-        d_it!=it->second.dominators.end();)
+    const auto& doms=cfg[it->second].dominators;
+    for(typename target_sett::const_iterator d_it=doms.begin();
+        d_it!=doms.end();)
     {
-      out << (*d_it)->location_number;
-      if (++d_it!=it->second.dominators.end())
+      out << *d_it;
+      if(++d_it!=doms.end())
         out << ", ";
     }
     out << "\n";

--- a/src/goto-programs/cfg.h
+++ b/src/goto-programs/cfg.h
@@ -131,6 +131,10 @@ public:
     compute_edges(goto_functions, goto_program);
   }
 
+  I get_first_node(P &program) const { return program.instructions.begin(); }
+  I get_last_node(P &program) const { return --program.instructions.end(); }
+  bool nodes_empty(P &program) const { return program.instructions.empty(); }
+
 };
 
 /*******************************************************************\


### PR DESCRIPTION
This previously assumed some internal specifics of goto_programt. This generalises it to allow the CFG graph to specify how to retrieve the start and end nodes or detect an empty program, and moves the details particular to goto_programt into its particular specialisation.

This allows us to use the generic dominators implementation on other control-flow graph representations.