### PR TITLE
utf8 to utf16 conversion and utf16 to ascii

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
           packages:
             - libwww-perl
             - clang-3.7
+            - libc++-dev
       before_install:
         - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/clang-3.7 90
       env: COMPILER="clang++-3.7 -stdlib=libc++"
@@ -34,7 +35,7 @@ matrix:
       env: COMPILER=g++
     - os: osx
       compiler: clang
-      env: COMPILER="clang++ -stdlib=libc++"
+      env: COMPILER=clang++
     - env: NAME="CPP-LINT"
       script: scripts/run_lint.sh master HEAD
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,17 +28,16 @@ matrix:
             - clang-3.7
       before_install:
         - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/clang-3.7 90
-      env: COMPILER=clang++-3.7
+      env: COMPILER="clang++-3.7 -stdlib=libc++"
     - os: osx
       compiler: gcc
       env: COMPILER=g++
     - os: osx
       compiler: clang
-      env: COMPILER=clang++
+      env: COMPILER="clang++ -stdlib=libc++"
     - env: NAME="CPP-LINT"
       script: scripts/run_lint.sh master HEAD
 
 script:
   - make -C src minisat2-download
-  - make -C src CXX=$COMPILER CXXFLAGS="-Wall -O2 -g -Werror -Wno-deprecated-register -pedantic -Wno-sign-compare" -j2 && make -C regression test
-  - make -C src CXX=$COMPILER CXXFLAGS="-Wall -O2 -g -Werror -Wno-deprecated-register -pedantic -Wno-sign-compare" -j2 aa-symex.dir cegis.dir clobber.dir memory-models.dir musketeer.dir
+  - make -C src CXX="$COMPILER" CXXFLAGS="-Wall -O2 -g -Werror -Wno-deprecated-register -pedantic -Wno-sign-compare" -j2 && make -C regression test

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
             - libwww-perl
             - clang-3.7
             - libc++-dev
+	    - libstdc++-5-dev
       before_install:
         - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/clang-3.7 90
       env: COMPILER="clang++-3.7 -stdlib=libstdc++"
@@ -42,3 +43,4 @@ matrix:
 script:
   - make -C src minisat2-download
   - make -C src CXX="$COMPILER" CXXFLAGS="-Wall -O2 -g -Werror -Wno-deprecated-register -pedantic -Wno-sign-compare" -j2 && make -C regression test
+  - make -C src CXX="$COMPILER" CXXFLAGS="-Wall -O2 -g -Werror -Wno-deprecated-register -pedantic -Wno-sign-compare" -j2 aa-symex.dir cegis.dir clobber.dir memory-models.dir musketeer.dir

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
             - libc++-dev
       before_install:
         - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/clang-3.7 90
-      env: COMPILER="clang++-3.7 -stdlib=libc++"
+      env: COMPILER="clang++-3.7 -stdlib=libstdc++"
     - os: osx
       compiler: gcc
       env: COMPILER=g++

--- a/src/util/unicode.cpp
+++ b/src/util/unicode.cpp
@@ -7,6 +7,8 @@ Author: Daniel Kroening, kroening@kroening.com
 \*******************************************************************/
 
 #include <cstring>
+#include <locale>
+#include <codecvt>
 
 #include "unicode.h"
 
@@ -252,4 +254,42 @@ const char **narrow_argv(int argc, const wchar_t **argv_wide)
     argv_narrow[i]=strdup(narrow(argv_wide[i]).c_str());
 
   return argv_narrow;
+}
+
+std::wstring utf8_to_utf16_big_endian(const std::string& in)
+{
+  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t> > converter;
+  return converter.from_bytes(in);
+}
+
+std::wstring utf8_to_utf16_little_endian(const std::string& in)
+{
+  const std::codecvt_mode mode=std::codecvt_mode::little_endian;
+
+  // default largest value codecvt_utf8_utf16 reads without error is 0x10ffff
+  // see: http://en.cppreference.com/w/cpp/locale/codecvt_utf8_utf16
+  const unsigned long maxcode=0x10ffff;
+
+  typedef std::codecvt_utf8_utf16<wchar_t, maxcode, mode> codecvt_utf8_utf16t;
+  std::wstring_convert<codecvt_utf8_utf16t> converter;
+  return converter.from_bytes(in);
+}
+
+std::string utf16_little_endian_to_ascii(const std::wstring& in)
+{
+  std::string result;
+  std::locale loc;
+  for(const auto c : in)
+  {
+    if(c<=255 && isprint(c, loc))
+      result+=(unsigned char)c;
+    else
+    {
+      result+="\\u";
+      char hex[5];
+      snprintf(hex, sizeof(hex), "%04x", (wchar_t)c);
+      result+=hex;
+    }
+  }
+  return result;
 }

--- a/src/util/unicode.h
+++ b/src/util/unicode.h
@@ -22,6 +22,10 @@ std::wstring widen(const std::string &s);
 std::string utf32_to_utf8(const std::basic_string<unsigned int> &s);
 std::string utf16_to_utf8(const std::basic_string<unsigned short int> &s);
 
+std::wstring utf8_to_utf16_big_endian(const std::string&);
+std::wstring utf8_to_utf16_little_endian(const std::string&);
+std::string utf16_little_endian_to_ascii(const std::wstring& in);
+
 const char **narrow_argv(int argc, const wchar_t **argv_wide);
 
 #endif // CPROVER_UTIL_UNICODE_H


### PR DESCRIPTION
Adds functions to `util/unicode.cpp` to convert from utf8 strings to utf16, both for little and big endian encodings and a function to pretty print utf16 characters in ascii.
These conversions are useful for the string refinement because utf16 is used by java.
Note that codecvt does not come automatically with old version of gcc, so I saw compilation problems with gcc-4.8 (Ubuntu 16.04), but none with gcc-6.