### PR TITLE
Don't call `java_array_type('\0')`. Fixes #383

### DIFF
--- a/src/java_bytecode/java_bytecode_convert_class.cpp
+++ b/src/java_bytecode/java_bytecode_convert_class.cpp
@@ -250,7 +250,7 @@ Function: java_bytecode_convert_classt::add_array_types
 
 void java_bytecode_convert_classt::add_array_types()
 {
-  const char letters[]="ijsbcfdza";
+  const std::string letters="ijsbcfdza";
 
   for(const char l : letters)
   {


### PR DESCRIPTION
Trivial fix. See https://github.com/diffblue/cbmc/issues/383 for details.