### PR TITLE
Don't convert native methods

### DIFF
--- a/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -413,7 +413,9 @@ void java_bytecode_convert_methodt::convert(
   method_has_this=code_type.has_this();
 
   tmp_vars.clear();
-  method_symbol.value=convert_instructions(m.instructions, code_type);
+
+  if((!m.is_abstract) && (!m.is_native))
+    method_symbol.value=convert_instructions(m.instructions, code_type);
 
   // do we have the method symbol already?
   const auto s_it=symbol_table.symbols.find(method.get_name());


### PR DESCRIPTION
This commit leaves them with a nil value, to differentiate them from a method that actually has an empty body (i.e. `{}`) It has no immediate impact, but will make forthcoming changes easier as we can assume that every non-nil method has at least one instruction.

Abstract methods are treated similarly (this mirrors a change already in place in the `test_gen` branch, which again seeks to differentiate an empty body from an undefined method)