### PR TITLE
Fixed ambiguity in mem_fun.

### DIFF
--- a/src/cegis/cegis-util/program_helper.cpp
+++ b/src/cegis/cegis-util/program_helper.cpp
@@ -348,8 +348,8 @@ goto_programt::targett insert_after_preserving_source_location(
 goto_programt::targett insert_before_preserving_source_location(
     goto_programt &body, goto_programt::targett pos)
 {
-  const auto op=std::bind1st(std::mem_fun(&goto_programt::insert_before),
-      &body);
+  typedef goto_programt::targett(goto_programt::*ftype)(goto_programt::targett);
+  const auto op=std::bind1st(std::mem_fun(static_cast<ftype>(&goto_programt::insert_before)), &body);
   return insert_preserving_source_location(pos, op);
 }
 


### PR DESCRIPTION
Goto_programt received an additional insert_before in a recent commit. This
made this reference to it ambiguous. Fixed using a static_cast.