### PR TITLE
Stub Java 8 lambdas

### DIFF
--- a/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -19,6 +19,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/arith_tools.h>
 #include <util/ieee_float.h>
 #include <util/expr_util.h>
+#include <linking/zero_initializer.h>
 
 #include "java_bytecode_convert_method.h"
 #include "bytecode_info.h"
@@ -701,7 +702,12 @@ codet java_bytecode_convert_methodt::convert_instructions(
       if(return_type.id()!=ID_empty)
       {
         results.resize(1);
-        results[0]=nil_exprt();
+        results[0]=
+          zero_initializer(
+            return_type,
+            i_it->source_location,
+            namespacet(symbol_table),
+            get_message_handler());
       }
     }
     else if(statement=="invokeinterface" ||


### PR DESCRIPTION
Java 8 lambdas are implemented using the `invokedynamic` instruction. Handling them correctly requires runtime code generation, or static analysis to achieve the same result; in the meantime this patch at least returns something of the right type, so subsequent conversion stages don't choke on an unexpected `nil_exprt`.