### PR TITLE
Fix data-flow1 test

### DIFF
--- a/regression/goto-instrument/data-flow1/test.desc
+++ b/regression/goto-instrument/data-flow1/test.desc
@@ -3,6 +3,6 @@ main.c
 "--show-dependence-graph"
 ^EXIT=0$
 ^SIGNAL=0$
-Data dependencies: .*33.*
+Data dependencies: *[0-9]\+,[0-9]\+,[0-9]\+
 --
 ^warning: ignoring


### PR DESCRIPTION
This checked for a hardcoded location number, but that varied from build to build due to nondeterministic ordering of functions in the GOTO binary file. Instead just check for the right number of dependencies.