### PR TITLE
Fixed a bug in all caps functions without function bodies

### DIFF
--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -3152,9 +3152,9 @@ def CheckForFunctionCommentHeaders(filename, raw_lines, error):
             body_found = False
             break
 
-      # body found, i.e. not a declaration
-      if body_found:
-        CheckForFunctionCommentHeader(filename, raw_lines, linenum, function_name, error)
+          # body found, i.e. not a declaration
+          if body_found:
+            CheckForFunctionCommentHeader(filename, raw_lines, linenum, function_name, error)
     linenum += 1
 
 def CheckForFunctionCommentHeader(filename, raw_lines, linenum, function_name, error):


### PR DESCRIPTION
There is an exception to the function body rule that was being incorrectly applied in, for example [line 236 for java_bytecode_convert_method.cpp](https://github.com/diffblue/cbmc/blob/master/src/java_bytecode/java_bytecode_convert_method.cpp#L236). The problem was incorrect indentation causing the code to be run even when the function shoudn't have been checked.