### PR TITLE
Corrected regex for member operator functions

### DIFF
--- a/regression/cpp-linter/function-comment-header6/main.cpp
+++ b/regression/cpp-linter/function-comment-header6/main.cpp
@@ -22,3 +22,54 @@ static void operator()()
 {
   do_something();
 }
+
+
+/*******************************************************************\
+Function: ssa_analyzert::operator()
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void ssa_analyzert::operator()(
+  int x,
+  float y)
+{
+  do_something();
+}
+
+/*******************************************************************\
+Function: class_namet::rename_l1
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void class_namet::rename_l1()
+{
+  do_something();
+}
+
+/*******************************************************************\
+Function: class_namet::operator++
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+int class_namet::operator++()
+{
+  add_something();
+}

--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -3125,7 +3125,7 @@ def CheckForFunctionCommentHeaders(filename, raw_lines, error):
     # Look for declaration function_name( but allowing for *, & being attached to the function name
     # but not being considered part of it
     regexp = r'\w(\w|::|\s|\*|\&)* (\*|\&)?(?P<fnc_name>(\w(\w|::)*))\('#
-    operator_regexp = r'\w(\w|::|\s|\*|\&)* (\*|\&)?(?P<fnc_name>(|operator\(.*\)|operator.*))\('
+    operator_regexp = r'\w(\w|::|\s|\*|\&)* (\*|\&)?(?P<fnc_name>(\w(\w|::)*::)?(operator\(.*\)|operator.*))\('
     operator_match = Match(operator_regexp, line)
     match_result = Match(regexp, line)
     function_name = ""


### PR DESCRIPTION
Issue: https://github.com/diffblue/cbmc-testgen/issues/62 [private]

The regex for finding operator functions didn't work if the function belonged to a class as it wasn't matching the :: correctly. Extended the regression test to cover this. 