### PR TITLE
Adding check for throw formatting

### DIFF
--- a/CODING_STANDARD
+++ b/CODING_STANDARD
@@ -122,6 +122,8 @@ C++ features:
 - We allow to use 3rd-party libraries directly. 
   No wrapper matching the coding rules is required. 
   Allowed libraries are: STL. 
+- When throwing, omit the brackets, i.e. `throw "error"`.
+- Error messages should start with a lower case letter.
 - Use the auto keyword if and only if one of the following
   - The type is explictly repeated on the RHS (e.g. a constructor call)
   - Adding the type will increase confusion (e.g. iterators, function pointers)

--- a/regression/cpp-linter/throw/main.cpp
+++ b/regression/cpp-linter/throw/main.cpp
@@ -1,0 +1,30 @@
+/*******************************************************************\
+
+Module: Lint Examples
+
+Author: Thomas Kiley, thomas@diffblue.com
+
+\*******************************************************************/
+
+/*******************************************************************\
+
+Function: fun
+
+ Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+static void fun()
+{
+  throw "a valid error";
+
+  throw("too bracketed");
+  throw ("too bracketed");
+
+  throw "Too capitalised";
+  throw("Too bracketed and capitalised");
+}

--- a/regression/cpp-linter/throw/test.desc
+++ b/regression/cpp-linter/throw/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.cpp
+
+main\.cpp:25:  Do not include brackets when throwing an error  \[readability/throw\] \[4\]
+main\.cpp:26:  Extra space before ( in function call  \[whitespace/parens\] \[4\]
+main\.cpp:26:  Do not include brackets when throwing an error  \[readability/throw\] \[4\]
+main\.cpp:28:  First character of throw error message should be lower case  \[readability/throw\] \[4\]
+main\.cpp:29:  Do not include brackets when throwing an error  \[readability/throw\] \[4\]
+main\.cpp:29:  First character of throw error message should be lower case  \[readability/throw\] \[4\]
+^Total errors found: 6$
+^SIGNAL=0$
+--

--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -223,6 +223,7 @@ _ERROR_CATEGORIES = [
     'readability/nul',
     'readability/strings',
     'readability/todo',
+    'readability/throw',
     'readability/utf8',
     'readability/function_comment'
     'runtime/arrays',
@@ -5160,6 +5161,20 @@ def CheckLanguage(filename, clean_lines, linenum, file_extension,
           'Do not use unnamed namespaces in header files.  See '
           'https://google-styleguide.googlecode.com/svn/trunk/cppguide.xml#Namespaces'
           ' for more information.')
+
+
+
+  # Check that throw statements don't include the optional bracket
+  # We use raw lines as we want to check the contents of the string too
+  # We require the error message starts with a lower case character
+  raw_line = clean_lines.raw_lines[linenum]
+  if(Match(r'^\s*throw', raw_line)):
+    if(Match(r'^\s*throw\s*\(', raw_line)):
+      error(filename, linenum, 'readability/throw', 4,
+          'Do not include brackets when throwing an error')
+    if(Match(r'\s*throw\s*\(?"[A-Z]', raw_line)):
+      error(filename, linenum, 'readability/throw', 4,
+          'First character of throw error message should be lower case')
 
 
 def CheckGlobalStatic(filename, clean_lines, linenum, error):


### PR DESCRIPTION
Throw statements should not have the bracket and the first character of the error message should be lower case. Added a check to the linter to verify this. Added regression tests to check this.

Also updated the coding standard to make these rules explicit. 