### PR TITLE
Generalise dominators template

### DIFF
--- a/src/goto-programs/cfg.h
+++ b/src/goto-programs/cfg.h
@@ -131,6 +131,9 @@ public:
     compute_edges(goto_functions, goto_program);
   }
 
+  I get_first_node(P &program) const { return program.instructions.begin(); }
+  I get_last_node(P &program) const { return --program.instructions.end(); }
+  bool nodes_empty(P &program) const { return program.instructions.empty(); }
 };
 
 /*******************************************************************\


### PR DESCRIPTION
This previously assumed some internal specifics of goto_programt. This generalises it to allow the CFG graph to specify how to retrieve the start and end nodes or detect an empty program, and moves the details particular to goto_programt into its particular specialisation.

This allows us to use the generic dominators implementation on other control-flow graph representations.

This replaces #367 to address existing review comments and also bring the PR under my control since I'll be the one fixing any forthcoming review comments.