### PR TITLE
Fix for lint failing when no linting errors

### DIFF
--- a/scripts/run_lint.sh
+++ b/scripts/run_lint.sh
@@ -12,6 +12,13 @@ then
     exit 1
 fi
 
+if ! [[ -e scripts/cpplint.py ]]
+then
+  echo "Lint script could not be found in the scripts directory"
+  echo "Ensure cpplint.py is inside the scripts directory then run again"
+  exit 1
+fi
+
 git_start=$1
 git_end=$2
 

--- a/scripts/run_lint.sh
+++ b/scripts/run_lint.sh
@@ -74,7 +74,7 @@ for file in $diff_files; do
   # Run the linting script and filter by the filter we've build
   # of all the modified lines
   # The errors from the linter go to STDERR so must be redirected to STDOUT
-  result=`python scripts/cpplint.py $file 2>&1 | grep -E "$lint_grep_filter"`
+  result=`python scripts/cpplint.py $file 2>&1 | { grep -E "$lint_grep_filter" || true; }`
 
   # Providing some errors were relevant we print them out
   if [ "$result" ]


### PR DESCRIPTION
Previously, as we had set -e enabled, the final grep (filtering relevant errors) would fail if there were no errors to find. This failure was causing the script to exit with an error code (causing the CI to think
the lint had failed). Now we ignore whether the grep fails or not.

Also added a error for if the script is missing. 