### PR TITLE
Run lint script handling deleted files

### DIFF
--- a/scripts/run_lint.sh
+++ b/scripts/run_lint.sh
@@ -44,6 +44,12 @@ IFS=$'\n'
 are_errors=0
 
 for file in $diff_files; do
+  # If the file has been deleted we don't want to run the linter on it
+  if ! [[ -e $file ]]
+  then
+    continue
+  fi
+
   # We build another grep filter the output of the linting script
   lint_grep_filter="^("
 


### PR DESCRIPTION
Previously we would try and run git blame on a deleted file (since would still show up in the diff) which would cause an error. Now we just skip over such files.