### PR TITLE
Ignore any files generated by the regression script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ regression/cbmc/tests.log
 src/big-int/test-bigint
 src/big-int/test-bigint.exe
 
+# regression/coverage file
+/regression/coverage_**
+
 # files stored by editors
 *~
 


### PR DESCRIPTION
If you run the coverage script introduced in #391 it generates a folder containing the results. This adds these generated files to the git ignore. 

The only reason why this might be a bad thing to ignore is if at some point we want a CI to run this script and make the results viewable somewhere. However, in this case I suspect it needs to not be in a randomly generated folder name but instead somewhere specific. 