### PR TITLE
Mark the two failing bugs in regressions/goto-analyzer as KNOWNBUG

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -1,4 +1,4 @@
-DIRS = ansi-c cbmc cpp goto-instrument goto-instrument-unwind
+DIRS = ansi-c cbmc cpp goto-instrument goto-instrument-unwind goto-analyzer
 
 test:
 	$(foreach var,$(DIRS), $(MAKE) -C $(var) test || exit 1;)

--- a/regression/goto-analyzer/intervals2/test.desc
+++ b/regression/goto-analyzer/intervals2/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 intervals2.c
 --intervals
 ^EXIT=0$

--- a/regression/goto-analyzer/intervals4/test.desc
+++ b/regression/goto-analyzer/intervals4/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 intervals4.c
 --intervals
 ^EXIT=0$


### PR DESCRIPTION
The two tests that fail appear to be real bugs as the conditions appear to be sufficient to conclude the assertion. I also added this folder to the regressions that get run since excluding these two the remainder
pass.

I shall create an issue for this, but if someone with more knowledge could confirm that my assessment that a) this should work and b) my suggested issue is correct that would be useful. 

I have also added this folder to the regressions that get run by the CI. 

**Proposed Issue**
The intervals analysis of goto-analyze doesn't work for intervals2 and intervals4. Both of these use && in an assertion that should be knowable. 