### PR TITLE
Support a config.local file

### DIFF
--- a/src/config.inc
+++ b/src/config.inc
@@ -1,3 +1,5 @@
+CONFIGDIR := $(dir $(lastword $(MAKEFILE_LIST)))
+
 # Build platform (use one of AUTO, Unix, OSX_Universal, MSVC, Cygwin, MinGW)
 BUILD_ENV = AUTO
 
@@ -24,3 +26,5 @@ LIBZIPINC = ../../libzip/lib
 # Signing identity for MacOS Gatekeeper
 
 OSX_IDENTITY="Developer ID Application: Daniel Kroening"
+
+-include $(CONFIGDIR)/config.local


### PR DESCRIPTION
This makes it easier to customise local config without catching git's attention.