### PR TITLE
Add emacs config

### DIFF
--- a/src/.dir-locals.el
+++ b/src/.dir-locals.el
@@ -1,0 +1,4 @@
+((c-mode . ((indent-tabs-mode .  nil)))
+ (c++-mode . ((indent-tabs-mode . nil)))
+ (nil . ((c-file-style . "linux")
+	 (c-basic-offset . 2))))


### PR DESCRIPTION
This sets Linux-style C indenting (cf. GNU-style default; AFAIK editorconfig cannot say this)
and sets indent to 2-spaces no-tabs in case you don't have the editorconfig plugin installed