### PR TITLE
Remove explicit "python" as cpplint.py is executable

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -40,7 +40,7 @@ do
   stagedFiles="$stagedFiles $tmpStaging/$file"
 done
 
-output=$(cd $gitRoot; python scripts/cpplint.py $stagedFiles 2>&1)
+output=$(cd $gitRoot; scripts/cpplint.py $stagedFiles 2>&1)
 retval=$?
 
 if [ $retval -ne 0 ]

--- a/scripts/run_lint.sh
+++ b/scripts/run_lint.sh
@@ -89,7 +89,7 @@ for file in $diff_files; do
   # Run the linting script and filter by the filter we've build
   # of all the modified lines
   # The errors from the linter go to STDERR so must be redirected to STDOUT
-  result=`python $script_folder/cpplint.py $file 2>&1 | { grep -E "$lint_grep_filter" || true; }`
+  result=`$script_folder/cpplint.py $file 2>&1 | { grep -E "$lint_grep_filter" || true; }`
 
   # Providing some errors were relevant we print them out
   if [ "$result" ]


### PR DESCRIPTION
Follow-up to #433 as suggested by @peterschrammel.