### PR TITLE
Fixed use of inline

### DIFF
--- a/src/util/json.h
+++ b/src/util/json.h
@@ -24,53 +24,53 @@ public:
                  J_TRUE, J_FALSE, J_NULL } kindt;
   kindt kind;
 
-  inline bool is_string() const
+  bool is_string() const
   {
     return kind==J_STRING;
   }
 
-  inline bool is_number() const
+  bool is_number() const
   {
     return kind==J_NUMBER;
   }
 
-  inline bool is_object() const
+  bool is_object() const
   {
     return kind==J_OBJECT;
   }
 
-  inline bool is_array() const
+  bool is_array() const
   {
     return kind==J_ARRAY;
   }
 
-  inline bool is_true() const
+  bool is_true() const
   {
     return kind==J_TRUE;
   }
 
-  inline bool is_false() const
+  bool is_false() const
   {
     return kind==J_FALSE;
   }
 
-  inline bool is_null() const
+  bool is_null() const
   {
     return kind==J_NULL;
   }
 
-  inline jsont():kind(J_NULL)
+  jsont():kind(J_NULL)
   {
   }
 
-  inline void output(std::ostream &out) const
+  void output(std::ostream &out) const
   {
     output_rec(out, 0);
   }
 
   void swap(jsont &other);
 
-  inline static jsont json_boolean(bool value)
+  static jsont json_boolean(bool value)
   {
     return jsont(value?J_TRUE:J_FALSE);
   }
@@ -83,11 +83,11 @@ public:
     array.clear();
   }
 
-  inline json_arrayt &make_array();
-  inline json_objectt &make_object();
+  json_arrayt &make_array();
+  json_objectt &make_object();
 
   // this presumes that this is an object
-  inline const jsont &operator[](const std::string &key) const
+  const jsont &operator[](const std::string &key) const
   {
     objectt::const_iterator it=object.find(key);
     if(it==object.end())
@@ -102,11 +102,11 @@ protected:
 
   static const jsont null_json_object;
 
-  inline explicit jsont(kindt _kind):kind(_kind)
+  explicit jsont(kindt _kind):kind(_kind)
   {
   }
 
-  inline jsont(kindt _kind, const std::string &_value):kind(_kind), value(_value)
+  jsont(kindt _kind, const std::string &_value):kind(_kind), value(_value)
   {
   }
 
@@ -134,7 +134,7 @@ public:
   {
   }
 
-  inline void resize(std::size_t size)
+  void resize(std::size_t size)
   {
     array.resize(size);
   }
@@ -144,13 +144,13 @@ public:
     return array.size();
   }
 
-  inline jsont &push_back(const jsont &json)
+  jsont &push_back(const jsont &json)
   {
     array.push_back(json);
     return static_cast<jsont &>(array.back());
   }
 
-  inline jsont &push_back()
+  jsont &push_back()
   {
     array.push_back(jsont());
     return static_cast<jsont &>(array.back());
@@ -182,12 +182,12 @@ public:
   {
   }
 
-  inline jsont &operator[](const std::string &key)
+  jsont &operator[](const std::string &key)
   {
     return object[key];
   }
 
-  inline const jsont &operator[](const std::string &key) const
+  const jsont &operator[](const std::string &key) const
   {
     objectt::const_iterator it=object.find(key);
     if(it==object.end())
@@ -215,13 +215,13 @@ public:
   json_nullt():jsont(J_NULL) { }
 };
 
-json_arrayt &jsont::make_array()
+inline json_arrayt &jsont::make_array()
 {
   kind=J_ARRAY;
   return static_cast<json_arrayt &>(*this);
 }
 
-json_objectt &jsont::make_object()
+inline json_objectt &jsont::make_object()
 {
   kind=J_OBJECT;
   return static_cast<json_objectt &>(*this);


### PR DESCRIPTION
While working on JSON reading I discovered incorrect usage of the inline keyword.
See http://en.cppreference.com/w/cpp/language/inline for why this is the case, especially the second paragraph:
A function defined entirely inside a class/struct/union definition, whether it's a member function or a non-member friend function, is implicitly an inline function.