### PR TITLE
Enable java tests

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -1,5 +1,5 @@
 
-DIRS = ansi-c cbmc cpp goto-instrument goto-analyzer
+DIRS = ansi-c cbmc cpp goto-instrument goto-analyzer cbmc-java
 
 test:
 	$(foreach var,$(DIRS), $(MAKE) -C $(var) test || exit 1;)

--- a/regression/cbmc-java/package_friendly1/test.desc
+++ b/regression/cbmc-java/package_friendly1/test.desc
@@ -2,7 +2,6 @@ CORE
 main.class
 package_friendly1.class package_friendly2.class --show-goto-functions
 ^main[.]main[(][)].*$
-^package_friendly1[.]operation1[(][)].*$
 ^package_friendly2[.]operation2[(][)].*$
 ^EXIT=0$
 ^SIGNAL=0$


### PR DESCRIPTION
This fixes an errant Java test and enables the cbmc-java regression test directory for a general `make test` command (and therefore for continuous integration).

Test `package_friendly1` was fixed (tested for now-changed behaviour)
Test `monitorenter1` requires #458 to work properly.

The last two commits are the only ones unique to this PR; the rest will rebase away when #458 goes in.