### PR TITLE
fixup! Consistently resize instead of just reserving in codet classes

### DIFF
--- a/src/analyses/flow_insensitive_analysis.cpp
+++ b/src/analyses/flow_insensitive_analysis.cpp
@@ -341,14 +341,13 @@ bool flow_insensitive_analysis_baset::do_function_call(
 
     goto_programt temp;
 
+    exprt rhs=side_effect_expr_nondett(code.lhs().type());
+
     goto_programt::targett r=temp.add_instruction();
     r->make_return();
-    r->code=code_returnt();
+    r->code=code_returnt(rhs);
     r->function=f_it->first;
     r->location_number=0;
-
-    exprt rhs=side_effect_expr_nondett(code.lhs().type());
-    r->code.move_to_operands(rhs);
 
     goto_programt::targett t=temp.add_instruction(END_FUNCTION);
     t->code.set(ID_identifier, code.function());

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -692,10 +692,7 @@ void cpp_typecheckt::typecheck_compound_declarator(
               namespacet(symbol_table).lookup(args[i].get(ID_C_identifier)).symbol_expr());
           }
 
-          code_returnt code_return;
-          code_return.return_value() = expr_call;
-
-          func_symb.value = code_return;
+          func_symb.value=code_returnt(expr_call);
         }
         else
         {

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -556,7 +556,7 @@ goto_programt::const_targett goto_program2codet::convert_return(
     goto_programt::const_targett upper_bound,
     codet &dest)
 {
-  code_returnt ret=to_code_return(target->code);
+  const code_returnt &ret=to_code_return(target->code);
 
   // add return instruction unless original code was missing a return
   if(!ret.has_return_value() ||

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1622,7 +1622,7 @@ void goto_convertt::convert_return(
 
     // remove void-typed return value
     if(!result_is_used)
-      new_code.operands().resize(0);
+      new_code.return_value().make_nil();
   }
 
   if(targets.has_return_value)

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -186,13 +186,12 @@ void goto_convert_functionst::add_return(
 
   #endif
 
+  side_effect_expr_nondett rhs(f.type.return_type());
+
   goto_programt::targett t=f.body.add_instruction();
   t->make_return();
-  t->code=code_returnt();
+  t->code=code_returnt(rhs);
   t->source_location=source_location;
-
-  side_effect_expr_nondett rhs(f.type.return_type());
-  t->code.move_to_operands(rhs);
 }
 
 /*******************************************************************\

--- a/src/goto-programs/goto_convert_new_switch_case.cpp
+++ b/src/goto-programs/goto_convert_new_switch_case.cpp
@@ -1508,7 +1508,7 @@ void goto_convertt::convert_return(
 
     // remove void-typed return value
     if(!result_is_used)
-      new_code.operands().resize(0);
+      new_code.return_value().make_nil();
   }
 
   if(targets.has_return_value)


### PR DESCRIPTION
The previous patch would make std_code consistent, but had failed to adjust uses of `code_returnt`.