### PR TITLE
Make JAR/zip support optional in regression tests

### DIFF
--- a/regression/cbmc-java/jar-file1/test.desc
+++ b/regression/cbmc-java/jar-file1/test.desc
@@ -1,8 +1,8 @@
 CORE
 some_jar.jar
 
-^EXIT=0$
+^EXIT=\(0\|6\)$
 ^SIGNAL=0$
-^VERIFICATION SUCCESSFUL$
+^\(VERIFICATION SUCCESSFUL\|No support for reading JAR files\)$
 --
 ^warning: ignoring

--- a/regression/cbmc-java/jar-file2/test.desc
+++ b/regression/cbmc-java/jar-file2/test.desc
@@ -1,8 +1,8 @@
 CORE
 jar-file2.jar
 --main-class some_class
-^EXIT=10$
+^EXIT=\(10\|6\)$
 ^SIGNAL=0$
-^VERIFICATION FAILED$
+^\(VERIFICATION FAILED\|No support for reading JAR files\)$
 --
 ^warning: ignoring


### PR DESCRIPTION
With cbmc-java regression tests enabled by default, the absence of optional JAR/zip file support should not cause regression tests to fail.