### PR TITLE
Factor class identifier extraction out of remove virtuals

### DIFF
--- a/src/goto-programs/Makefile
+++ b/src/goto-programs/Makefile
@@ -17,7 +17,7 @@ SRC = goto_convert.cpp goto_convert_function_call.cpp \
       goto_trace.cpp xml_goto_trace.cpp vcd_goto_trace.cpp \
       graphml_witness.cpp remove_virtual_functions.cpp \
       class_hierarchy.cpp show_goto_functions.cpp get_goto_model.cpp \
-      slice_global_inits.cpp goto_inline_class.cpp
+      slice_global_inits.cpp goto_inline_class.cpp class_identifier.cpp
 
 INCLUDES= -I ..
 

--- a/src/goto-programs/class_identifier.cpp
+++ b/src/goto-programs/class_identifier.cpp
@@ -1,0 +1,88 @@
+/*******************************************************************\
+
+Module: Extract class identifier
+
+Author: Chris Smowton, chris.smowton@diffblue.com
+
+\*******************************************************************/
+
+#include "class_identifier.h"
+
+#include <util/std_expr.h>
+
+/*******************************************************************\
+
+Function: build_class_identifier
+
+  Inputs: Struct expression
+
+ Outputs: Member expression giving the clsid field of the input,
+          or its parent, grandparent, etc.
+
+ Purpose:
+
+\*******************************************************************/
+
+static exprt build_class_identifier(
+  const exprt &src,
+  const namespacet &ns)
+{
+  // the class identifier is in the root class
+  exprt e=src;
+
+  while(1)
+  {
+    const typet &type=ns.follow(e.type());
+    assert(type.id()==ID_struct);
+
+    const struct_typet &struct_type=to_struct_type(type);
+    const struct_typet::componentst &components=struct_type.components();
+    assert(!components.empty());
+
+    member_exprt member_expr(
+      e,
+      components.front().get_name(),
+      components.front().type());
+
+    if(components.front().get_name()=="@class_identifier")
+    {
+      // found it
+      return member_expr;
+    }
+    else
+    {
+      e=member_expr;
+    }
+  }
+}
+
+/*******************************************************************\
+
+Function: get_class_identifier_field
+
+  Inputs: Pointer expression of any pointer type, including void*,
+          and a recommended access type if the pointer is void-typed.
+
+ Outputs: Member expression to access a class identifier, as above.
+
+ Purpose:
+
+\*******************************************************************/
+
+exprt get_class_identifier_field(
+  exprt this_expr,
+  const symbol_typet &suggested_type,
+  const namespacet &ns)
+{
+  // Get a pointer from which we can extract a clsid.
+  // If it's already a pointer to an object of some sort, just use it;
+  // if it's void* then use the suggested type.
+
+  assert(this_expr.type().id()==ID_pointer &&
+         "Non-pointer this-arg in remove-virtuals?");
+  const auto& points_to=this_expr.type().subtype();
+  if(points_to==empty_typet())
+    this_expr=typecast_exprt(this_expr, pointer_typet(suggested_type));
+  exprt deref=dereference_exprt(this_expr, this_expr.type().subtype());
+  return build_class_identifier(deref, ns);
+}

--- a/src/goto-programs/class_identifier.h
+++ b/src/goto-programs/class_identifier.h
@@ -9,12 +9,12 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 #ifndef CPROVER_GOTO_PROGRAMS_CLASS_IDENTIFIER_H
 #define CPROVER_GOTO_PROGRAMS_CLASS_IDENTIFIER_H
 
-#include <util/expr.h>
-#include <util/std_types.h>
-#include <util/namespace.h>
+class exprt;
+class namespacet;
+class symbol_typet;
 
 exprt get_class_identifier_field(
-  exprt this_expr,
+  const exprt &this_expr,
   const symbol_typet &suggested_type,
   const namespacet &ns);
 

--- a/src/goto-programs/class_identifier.h
+++ b/src/goto-programs/class_identifier.h
@@ -1,0 +1,21 @@
+/*******************************************************************\
+
+Module: Extract class identifier
+
+Author: Chris Smowton, chris.smowton@diffblue.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_GOTO_PROGRAMS_CLASS_IDENTIFIER_H
+#define CPROVER_GOTO_PROGRAMS_CLASS_IDENTIFIER_H
+
+#include <util/expr.h>
+#include <util/std_types.h>
+#include <util/namespace.h>
+
+exprt get_class_identifier_field(
+  exprt this_expr,
+  const symbol_typet &suggested_type,
+  const namespacet &ns);
+
+#endif

--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -139,9 +139,9 @@ void remove_virtual_functionst::remove_virtual_function(
   goto_programt new_code_gotos;
 
   exprt this_expr=code.arguments()[0];
-  // If necessary, cast to the last candidate function to get the object's clsid.
-  // By the structure of get_functions, this is the parent of all other classes
-  // under consideration.
+  // If necessary, cast to the last candidate function to
+  // get the object's clsid. By the structure of get_functions,
+  // this is the parent of all other classes under consideration.
   symbol_typet suggested_type(functions.back().class_id);
   exprt c_id2=get_class_identifier_field(this_expr, suggested_type, ns);
 
@@ -196,8 +196,10 @@ void remove_virtual_functionst::remove_virtual_function(
     const irep_idt comment=it->source_location.get_comment();
     it->source_location=target->source_location;
     it->function=target->function;
-    if(!property_class.empty()) it->source_location.set_property_class(property_class);
-    if(!comment.empty()) it->source_location.set_comment(comment);
+    if(!property_class.empty())
+      it->source_location.set_property_class(property_class);
+    if(!comment.empty())
+      it->source_location.set_comment(comment);
   }
 
   goto_programt::targett next_target=target;
@@ -302,7 +304,8 @@ void remove_virtual_functionst::get_functions(
     const class_hierarchyt::idst &parents=
       class_hierarchy.class_map[c].parents;
 
-    if(parents.empty()) break;
+    if(parents.empty())
+      break;
     c=parents.front();
   }
 
@@ -380,7 +383,6 @@ bool remove_virtual_functionst::remove_virtual_functions(
 
   if(did_something)
   {
-    //remove_skip(goto_program);
     goto_program.update();
   }
 


### PR DESCRIPTION
Part 2 of the remove virtual functions improvements (ready for merge now). This will be useful for other passes that inspect an object's dynamic clsid, such as the forthcoming lower-instanceof pass.