### PR TITLE
CPPlint on travis will not produce error return code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
       compiler: clang
       env: COMPILER=clang++
     - env: NAME="CPP-LINT"
-      script: scripts/run_lint.sh master HEAD
+      script: scripts/run_lint.sh master HEAD || true
 
 script:
   - make -C src minisat2-download


### PR DESCRIPTION
We now have a separate Jenkins job for PRs that reports the erros. The rationale is that github status for a build is only "fail/pass" for travis and so it was not easily visible whether a fail was due to linter or actuall build problems.