### PR TITLE
Keep track of qualifiers for structs and unions

### DIFF
--- a/regression/goto-instrument/const-struct1/test.desc
+++ b/regression/goto-instrument/const-struct1/test.desc
@@ -1,7 +1,7 @@
-KNOWNBUG
+CORE
 main.c
 --show-symbol-table
-^Type\.*: struct struct_tag_name$
+^Type\.*: const struct struct_tag_name$
 ^Type\.*: const double$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-instrument/const-struct2/main.c
+++ b/regression/goto-instrument/const-struct2/main.c
@@ -1,0 +1,10 @@
+
+int main()
+{
+  const struct struct_tag_name {
+  int x;
+  float y;
+  } my_struct_var = {.x =  1, .y = 3.15};
+  const double z = 4;
+  return 0;
+}

--- a/regression/goto-instrument/const-struct2/test.desc
+++ b/regression/goto-instrument/const-struct2/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--show-symbol-table
+^Type\.*: const struct struct_tag_name$
+^Type\.*: const double$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/goto-instrument/const-struct3/main.c
+++ b/regression/goto-instrument/const-struct3/main.c
@@ -1,0 +1,13 @@
+
+struct struct_tag_name
+{
+	int x;
+	float y;
+};
+
+int main()
+{
+  const struct struct_tag_name my_struct_var = {.x =  1, .y = 3.15};
+  const double z = 4;
+  return 0;
+}

--- a/regression/goto-instrument/const-struct3/test.desc
+++ b/regression/goto-instrument/const-struct3/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--dump-c
+^\s*const struct struct_tag_name my_struct_var
+^\s*const double z
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/goto-instrument/const-union1/main.c
+++ b/regression/goto-instrument/const-union1/main.c
@@ -1,0 +1,13 @@
+
+union union_tag_name
+{
+	int x;
+	float y;
+};
+
+int main()
+{
+  const union union_tag_name my_union_var = {.y = 3.15};
+  const double z = 4;
+  return 0;
+}

--- a/regression/goto-instrument/const-union1/test.desc
+++ b/regression/goto-instrument/const-union1/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--show-symbol-table
+^Type\.*: const union union_tag_name$
+^Type\.*: const double$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/goto-instrument/volatile-struct1/main.c
+++ b/regression/goto-instrument/volatile-struct1/main.c
@@ -1,0 +1,13 @@
+
+struct struct_tag_name
+{
+	int x;
+	float y;
+};
+
+int main()
+{
+  volatile struct struct_tag_name my_struct_var = {.x =  1, .y = 3.15};
+  const double z = 4;
+  return 0;
+}

--- a/regression/goto-instrument/volatile-struct1/test.desc
+++ b/regression/goto-instrument/volatile-struct1/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--show-symbol-table
+^Type\.*: volatile struct struct_tag_name$
+^Type\.*: const double$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -820,7 +820,9 @@ void c_typecheck_baset::typecheck_compound_type(struct_union_typet &type)
   symbol_type.add_source_location()=type.source_location();
   symbol_type.set_identifier(identifier);
 
+  c_qualifierst original_qualifiers(type);
   type.swap(symbol_type);
+  original_qualifiers.write(type);
 }
 
 /*******************************************************************\


### PR DESCRIPTION
Issue: #355, https://github.com/diffblue/cbmc-toyota/issues/21 [private]

When dealing withs structs (and unions) we replace the type with a symbol for that type (that may or may not be new). However, if a struct is declared, we still need to track any qualifiers (e.g. a variable that
is introduced as a const struct).

Changed the test demonstrating this to core and extended the testing to cover other related situations. 