### PR TITLE
Make string literal tables global

### DIFF
--- a/src/java_bytecode/java_bytecode_typecheck.cpp
+++ b/src/java_bytecode/java_bytecode_typecheck.cpp
@@ -184,3 +184,9 @@ bool java_bytecode_typecheck(
   // fail for now
   return true;
 }
+
+// Static members of java_bytecode_typecheckt:
+std::map<irep_idt, irep_idt>
+  java_bytecode_typecheckt::string_literal_to_symbol_name;
+std::map<irep_idt, size_t>
+  java_bytecode_typecheckt::escaped_string_literal_count;

--- a/src/java_bytecode/java_bytecode_typecheck.h
+++ b/src/java_bytecode/java_bytecode_typecheck.h
@@ -64,8 +64,8 @@ protected:
   virtual std::string to_string(const typet &type);
 
   std::set<irep_idt> already_typechecked;
-  std::map<irep_idt, irep_idt> string_literal_to_symbol_name;
-  std::map<irep_idt, size_t> escaped_string_literal_count;
+  static std::map<irep_idt, irep_idt> string_literal_to_symbol_name;
+  static std::map<irep_idt, size_t> escaped_string_literal_count;
 };
 
 #endif // CPROVER_JAVA_BYTECODE_JAVA_BYTECODE_TYPECHECK_H


### PR DESCRIPTION
The string literal uniqueing tables only work if they can see every string in the program, and if multiple .class files are specified on the command-line, multiple java_bytecode_typecheckt instances are created. Literal symbol creation would then fail if the two classes used matching literals. Note this does not apply to classes loaded on demand or from a JAR file, which *do* share a typecheckt instance with their parent.

This averts the immediate problem, but subsequent changes worth considering:
1. Give languaget a pointer back to some new class (say `java_language_globalt`) that houses state global to all Java frontend instances, and which cleans up after all Java frontends have gone away.
2. Since the Java frontend's demand-loads classes, *sharing* an instance of `java_languaget` in this case, consider allowing frontends to share a single `languaget` between multiple `language_filet` instances and thus sharing in the multiple-command-line-arguments case too.