### PR TITLE
get_language options to language API

### DIFF
--- a/src/java_bytecode/java_bytecode_language.h
+++ b/src/java_bytecode/java_bytecode_language.h
@@ -19,7 +19,7 @@ Author: Daniel Kroening, kroening@kroening.com
 class java_bytecode_languaget:public languaget
 {
 public:
-  virtual void get_language_options(const cmdlinet &);
+  virtual void get_language_options(const cmdlinet &) override;
 
   virtual bool preprocess(
     std::istream &instream,

--- a/src/langapi/language_ui.cpp
+++ b/src/langapi/language_ui.cpp
@@ -121,6 +121,7 @@ bool language_uit::parse(const std::string &filename)
 
   languaget &language=*lf.language;
   language.set_message_handler(get_message_handler());
+  language.get_language_options(_cmdline);
 
   status() << "Parsing " << filename << eom;
 

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -19,10 +19,14 @@ class symbol_tablet;
 class exprt;
 class namespacet;
 class typet;
+class cmdlinet;
 
 class languaget:public messaget
 {
 public:
+  // Parse language-specific options
+  virtual void get_language_options(const cmdlinet &) {}
+
   // parse file
 
   virtual bool preprocess(


### PR DESCRIPTION
Adds call to `get_language_options` to the language API. Prevents an
uninitialized bool error in the Java front-end.