### PR TITLE
Do not add named vars to used_local_names

### DIFF
--- a/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -170,8 +170,6 @@ const exprt java_bytecode_convert_methodt::variable(
   else
   {
     exprt result=var.symbol_expr;
-    if(!var.is_parameter)
-      used_local_names.insert(to_symbol_expr(result));
     if(do_cast==CAST_AS_NEEDED && t!=result.type())
       result=typecast_exprt(result, t);
     return result;


### PR DESCRIPTION
Commit 67f40196a0f206b0eabbef7081f33afa7f2fca1b accidentally reverted `java_bytecode_convert_methodt::variable` to an earlier version. This restores the version as of (https://github.com/smowton/cbmc/blob/find_scopes_for_anonymous_variables/src/java_bytecode/java_bytecode_convert_method.cpp).

Fixes failure of test cbmc-java/inferlexicalscope1