### PR TITLE
read ACC_ABSTRACT attribute in Java class files

### DIFF
--- a/src/java_bytecode/java_bytecode_parse_tree.cpp
+++ b/src/java_bytecode/java_bytecode_parse_tree.cpp
@@ -34,8 +34,8 @@ void java_bytecode_parse_treet::classt::swap(
 {
   other.name.swap(name);
   other.extends.swap(extends);
-  other.is_enum=is_enum;
-  other.enum_elements=enum_elements;
+  std::swap(other.is_enum, is_enum);
+  std::swap(other.enum_elements, enum_elements);
   std::swap(other.is_abstract, is_abstract);
   other.implements.swap(implements);
   other.fields.swap(fields);

--- a/src/java_bytecode/java_bytecode_parse_tree.h
+++ b/src/java_bytecode/java_bytecode_parse_tree.h
@@ -166,8 +166,8 @@ public:
   {
   public:
     irep_idt name, extends;
-    bool is_abstract;
-    bool is_enum;
+    bool is_abstract=false;
+    bool is_enum=false;
     size_t enum_elements=0;
 
     typedef std::list<irep_idt> implementst;

--- a/src/java_bytecode/java_bytecode_parser.cpp
+++ b/src/java_bytecode/java_bytecode_parser.cpp
@@ -300,6 +300,7 @@ void java_bytecode_parsert::rClassFile()
   u2 this_class=read_u2();
   u2 super_class=read_u2();
 
+  parsed_class.is_abstract=(access_flags&ACC_ABSTRACT)!=0;
   parsed_class.is_enum=(access_flags&ACC_ENUM)!=0;
   parsed_class.name=
     constant(this_class).type().get(ID_C_base_name);


### PR DESCRIPTION
This adds the initialization of the `is_abstract` and `is_enum` Boolean values
to the Java class file parser. It also adds setting the value of `is_abstract`
which wasn't done before and could lead to undefined behaviour as an unitialized
bool was read in `std::swap(other.is_abstract, is_abstract)`.