### PR TITLE
initialize Boolean values in c_typecheck_baset

### DIFF
--- a/src/ansi-c/ansi_c_typecheck.cpp
+++ b/src/ansi-c/ansi_c_typecheck.cpp
@@ -22,6 +22,7 @@ Function: ansi_c_typecheckt::typecheck
 
 void ansi_c_typecheckt::typecheck()
 {
+  start_typecheck_code();
   for(ansi_c_parse_treet::itemst::iterator
       it=parse_tree.items.begin();
       it!=parse_tree.items.end();

--- a/src/ansi-c/c_typecheck_code.cpp
+++ b/src/ansi-c/c_typecheck_code.cpp
@@ -14,7 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 /*******************************************************************\
 
-Function: c_typecheck_baset::init
+Function: c_typecheck_baset::start_typecheck_code
 
   Inputs:
 


### PR DESCRIPTION
c_typecheck_baset contains the method `start_typecheck_code()` which is not
called for `ansi_c`, only for `cpp`. This method initializes three Boolean
values:
```
  bool break_is_allowed;
  bool continue_is_allowed;
  bool case_is_allowed;
```
This patch adds a call to `start_typecheck_code()` to `ansi_c`, too.

The error was observed in `ansi_c/for_scope1`.