### PR TITLE
specify initial values for Boolean in struct optiont

### DIFF
--- a/src/util/cmdline.h
+++ b/src/util/cmdline.h
@@ -39,10 +39,19 @@ public:
 protected:
   struct optiont
   {
-    bool isset, hasval, islong;
+    bool isset;
+    bool hasval;
+    bool islong;
     char optchar;
     std::string optstring;
     std::list<std::string> values;
+  public:
+    optiont():
+      isset(false),
+      hasval(false),
+      islong(false),
+      optchar(0)
+      {}
   };
 
   std::vector<optiont> options;


### PR DESCRIPTION
Gave read of uninitilized Boolean value. Just a cleanup, no effect apart from
observation via UB check.