### PR TITLE
Add implied fields to classes

### DIFF
--- a/src/java_bytecode/java_bytecode_typecheck_expr.cpp
+++ b/src/java_bytecode/java_bytecode_typecheck_expr.cpp
@@ -254,10 +254,14 @@ void java_bytecode_typecheckt::typecheck_expr_member(member_exprt &expr)
     {
       // member doesn't exist. In this case struct_type should be an opaque
       // stub, and we'll add the member to it.
-      components
+      symbolt &symbol_table_type=
+        symbol_table.lookup("java::"+id2string(struct_type.get_tag()));
+      auto &add_to_components=
+        to_struct_type(symbol_table_type.type).components();
+      add_to_components
         .push_back(struct_typet::componentt(component_name, expr.type()));
-      components.back().set_base_name(component_name);
-      components.back().set_pretty_name(component_name);
+      add_to_components.back().set_base_name(component_name);
+      add_to_components.back().set_pretty_name(component_name);
       return;
     }
 


### PR DESCRIPTION
When dealing with opaque (unelaborated) classes, this infers
that a particular class or superclass must have a particular
field when the source program assumes their presence (i.e.
when there is an ((A*)a)->x reference and we don't yet know that
a field named 'x' exists). This feeds into opaque stub generation,
which can use the inferred type descriptor to create appropriate
object initialisers in stub functions.