### PR TITLE
Restore string literal symbol name escaping

### DIFF
--- a/src/java_bytecode/java_bytecode_typecheck_expr.cpp
+++ b/src/java_bytecode/java_bytecode_typecheck_expr.cpp
@@ -128,8 +128,8 @@ void java_bytecode_typecheckt::typecheck_expr_java_string_literal(exprt &expr)
   escape_non_alnum(escaped);
   identifier_str << "java::java.lang.String.Literal." << escaped;
   // Avoid naming clashes by virtue of escaping:
-  size_t unique_num=escaped_string_literal_count[identifier_str.str()];
-  unique_num++;
+  // NOTE this increments the count stored in the map.
+  size_t unique_num=++(escaped_string_literal_count[identifier_str.str()]);
   if(unique_num!=1)
     identifier_str << unique_num;
 


### PR DESCRIPTION
c1a34930effd3c9886ab20055787fe75d44d6d3f accidentally disabled use of the escaped_string_literal_count map. This restores the original behaviour and adds a comment to dissuade repeating the same mistake.

Problem was introduced in https://github.com/diffblue/cbmc/pull/425