### PR TITLE
Fix cfg dominator top

### DIFF
--- a/src/analyses/cfg_dominators.h
+++ b/src/analyses/cfg_dominators.h
@@ -35,7 +35,6 @@ public:
 
   void operator()(P &program);
 
-  target_sett top;
   T entry_node;
 
   void output(std::ostream &) const;
@@ -101,10 +100,6 @@ template <class P, class T, bool post_dom>
 void cfg_dominators_templatet<P, T, post_dom>::initialise(P &program)
 {
   cfg(program);
-
-  // initialise top element
-  for(const auto &node : cfg.entry_map)
-    top.insert(cfg[node.second].PC);
 }
 
 /*******************************************************************\


### PR DESCRIPTION
There are a couple of linting failures but these are due to a slightly over-zealous standard IMHO.

@danpoe This is one of the features I added at Toyota and we need for the next release.