### PR TITLE
make ~solvert virtual

### DIFF
--- a/src/cbmc/cbmc_solvers.cpp
+++ b/src/cbmc/cbmc_solvers.cpp
@@ -123,7 +123,7 @@ public:
     assert(_prop!=NULL);
   }
 
-  ~cbmc_solver_with_propt()
+  virtual ~cbmc_solver_with_propt()
   {
     delete prop;
   }
@@ -157,8 +157,6 @@ public:
   ~cbmc_solver_with_aigpropt()
   {
     // delete prop before the AIG
-    delete prop;
-    prop=NULL;
     delete aig;
   }
 
@@ -189,8 +187,6 @@ public:
   ~cbmc_solver_with_filet()
   {
     // delete the prop before the file
-    delete prop_conv_ptr;
-    prop_conv_ptr=NULL;
     delete out;
   }
 

--- a/src/cbmc/cbmc_solvers.h
+++ b/src/cbmc/cbmc_solvers.h
@@ -57,7 +57,7 @@ public:
       prop_conv_ptr = _prop_conv;
     }
 
-    ~solvert()
+    virtual ~solvert()
     {
       assert(prop_conv_ptr!=NULL);
       delete prop_conv_ptr;


### PR DESCRIPTION
There was a memory leak, as the `unique_ptr<solvert>` points to a
specialized sub-class, but its destructor was not virtual. Therefore
only the `solvert` destructor was called, not the destructor of the
"real" solver, causing a direct leak and indirect leaks in solver
memory.