### PR TITLE
utf8 to utf16 conversion and utf16 to ascii

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
           packages:
             - libwww-perl
             - clang-3.7
+            - libstdc++-5-dev
             - libubsan0
       before_install:
         - mkdir bin ; ln -s /usr/bin/clang-3.7 bin/gcc

--- a/src/util/unicode.cpp
+++ b/src/util/unicode.cpp
@@ -263,11 +263,35 @@ const char **narrow_argv(int argc, const wchar_t **argv_wide)
   return argv_narrow;
 }
 
+/*******************************************************************\
+
+Function: utf8_to_utf16_big_endian
+
+  Inputs: String in UTF-8 format
+
+ Outputs: String in UTF-16BE format
+
+ Purpose: Note this requires g++-5 libstdc++ / libc++ / MSVC2010+
+
+\*******************************************************************/
+
 std::wstring utf8_to_utf16_big_endian(const std::string& in)
 {
   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t> > converter;
   return converter.from_bytes(in);
 }
+
+/*******************************************************************\
+
+Function: utf8_to_utf16_little_endian
+
+  Inputs: String in UTF-8 format
+
+ Outputs: String in UTF-16LE format
+
+ Purpose: Note this requires g++-5 libstdc++ / libc++ / MSVC2010+
+
+\*******************************************************************/
 
 std::wstring utf8_to_utf16_little_endian(const std::string& in)
 {
@@ -281,6 +305,19 @@ std::wstring utf8_to_utf16_little_endian(const std::string& in)
   std::wstring_convert<codecvt_utf8_utf16t> converter;
   return converter.from_bytes(in);
 }
+
+/*******************************************************************\
+
+Function: utf16_little_endian_to_ascii
+
+  Inputs: String in UTF-16LE format
+
+ Outputs: String in US-ASCII format, with \uxxxx escapes for other
+          characters
+
+ Purpose:
+
+\*******************************************************************/
 
 std::string utf16_little_endian_to_ascii(const std::wstring& in)
 {

--- a/src/util/unicode.cpp
+++ b/src/util/unicode.cpp
@@ -9,6 +9,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <cstring>
 #include <locale>
 #include <codecvt>
+#include <iomanip>
+#include <sstream>
 
 #include "unicode.h"
 
@@ -282,19 +284,20 @@ std::wstring utf8_to_utf16_little_endian(const std::string& in)
 
 std::string utf16_little_endian_to_ascii(const std::wstring& in)
 {
-  std::string result;
+  std::ostringstream result;
   std::locale loc;
   for(const auto c : in)
   {
     if(c<=255 && isprint(c, loc))
-      result+=(unsigned char)c;
+      result << (unsigned char)c;
     else
     {
-      result+="\\u";
-      char hex[5];
-      snprintf(hex, sizeof(hex), "%04x", (wchar_t)c);
-      result+=hex;
+      result << "\\u"
+             << std::hex
+             << std::setw(4)
+             << std::setfill('0')
+             << (unsigned int)c;
     }
   }
-  return result;
+  return result.str();
 }

--- a/src/util/unicode.cpp
+++ b/src/util/unicode.cpp
@@ -7,6 +7,8 @@ Author: Daniel Kroening, kroening@kroening.com
 \*******************************************************************/
 
 #include <cstring>
+#include <locale>
+#include <codecvt>
 
 #include "unicode.h"
 
@@ -257,4 +259,42 @@ const char **narrow_argv(int argc, const wchar_t **argv_wide)
     argv_narrow[i]=strdup(narrow(argv_wide[i]).c_str());
 
   return argv_narrow;
+}
+
+std::wstring utf8_to_utf16_big_endian(const std::string& in)
+{
+  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t> > converter;
+  return converter.from_bytes(in);
+}
+
+std::wstring utf8_to_utf16_little_endian(const std::string& in)
+{
+  const std::codecvt_mode mode=std::codecvt_mode::little_endian;
+
+  // default largest value codecvt_utf8_utf16 reads without error is 0x10ffff
+  // see: http://en.cppreference.com/w/cpp/locale/codecvt_utf8_utf16
+  const unsigned long maxcode=0x10ffff;
+
+  typedef std::codecvt_utf8_utf16<wchar_t, maxcode, mode> codecvt_utf8_utf16t;
+  std::wstring_convert<codecvt_utf8_utf16t> converter;
+  return converter.from_bytes(in);
+}
+
+std::string utf16_little_endian_to_ascii(const std::wstring& in)
+{
+  std::string result;
+  std::locale loc;
+  for(const auto c : in)
+  {
+    if(c<=255 && isprint(c, loc))
+      result+=(unsigned char)c;
+    else
+    {
+      result+="\\u";
+      char hex[5];
+      snprintf(hex, sizeof(hex), "%04x", (wchar_t)c);
+      result+=hex;
+    }
+  }
+  return result;
 }

--- a/src/util/unicode.h
+++ b/src/util/unicode.h
@@ -22,9 +22,9 @@ std::wstring widen(const std::string &s);
 std::string utf32_to_utf8(const std::basic_string<unsigned int> &s);
 std::string utf16_to_utf8(const std::basic_string<unsigned short int> &s);
 
-std::wstring utf8_to_utf16_big_endian(const std::string&);
-std::wstring utf8_to_utf16_little_endian(const std::string&);
-std::string utf16_little_endian_to_ascii(const std::wstring& in);
+std::wstring utf8_to_utf16_big_endian(const std::string &);
+std::wstring utf8_to_utf16_little_endian(const std::string &);
+std::string utf16_little_endian_to_ascii(const std::wstring &in);
 
 const char **narrow_argv(int argc, const wchar_t **argv_wide);
 

--- a/src/util/unicode.h
+++ b/src/util/unicode.h
@@ -22,6 +22,10 @@ std::wstring widen(const std::string &s);
 std::string utf32_to_utf8(const std::basic_string<unsigned int> &s);
 std::string utf16_to_utf8(const std::basic_string<unsigned short int> &s);
 
+std::wstring utf8_to_utf16_big_endian(const std::string&);
+std::wstring utf8_to_utf16_little_endian(const std::string&);
+std::string utf16_little_endian_to_ascii(const std::wstring& in);
+
 const char **narrow_argv(int argc, const wchar_t **argv_wide);
 
 #endif // CPROVER_UTIL_UNICODE_H


### PR DESCRIPTION
_(Description by @forejtv:)_ This is successor of https://github.com/diffblue/cbmc/pull/372 after @smowton took the PR over. For convenience, this is the original PR description, see that PR for some discussion and context:

Adds functions to `util/unicode.cpp` to convert from utf8 strings to utf16, both for little and big endian encodings and a function to pretty print utf16 characters in ascii.
These conversions are useful for the string refinement because utf16 is used by java.
Note that codecvt does not come automatically with old version of gcc, so I saw compilation problems with gcc-4.8 (Ubuntu 16.04), but none with gcc-6.