### PR TITLE
Switch to stateless Java string escaping

### DIFF
--- a/src/java_bytecode/java_bytecode_typecheck.cpp
+++ b/src/java_bytecode/java_bytecode_typecheck.cpp
@@ -184,9 +184,3 @@ bool java_bytecode_typecheck(
   // fail for now
   return true;
 }
-
-// Static members of java_bytecode_typecheckt:
-std::map<irep_idt, irep_idt>
-  java_bytecode_typecheckt::string_literal_to_symbol_name;
-std::map<irep_idt, size_t>
-  java_bytecode_typecheckt::escaped_string_literal_count;

--- a/src/java_bytecode/java_bytecode_typecheck.h
+++ b/src/java_bytecode/java_bytecode_typecheck.h
@@ -64,8 +64,6 @@ protected:
   virtual std::string to_string(const typet &type);
 
   std::set<irep_idt> already_typechecked;
-  static std::map<irep_idt, irep_idt> string_literal_to_symbol_name;
-  static std::map<irep_idt, size_t> escaped_string_literal_count;
 };
 
 #endif // CPROVER_JAVA_BYTECODE_JAVA_BYTECODE_TYPECHECK_H


### PR DESCRIPTION
Before we squashed identifier-illegal characters and used a map to work around the ensuing identifier clashes (e.g. Hello? and Hello! both squash to Hello_ so now one must be renamed).

This switches to an encoding scheme: _ -> __, other unprintable character -> _xx where xx is a hex byte.