### PR TITLE
cpplint sed format improvements

### DIFF
--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -552,6 +552,7 @@ _SED_FIXUPS = {
   "Missing space before {": r's/\([^ ]\){/\1 {/',
   "Tab found, replace by spaces": r's/\t/  /',
   "Line ends in whitespace.  Consider deleting these extra spaces.": r's/\s*$//',
+  "You don't need a ; after a }": r's/};/}/',
   # "Statement after an if should be on a new line": r's/^\(\s*\)if *\(([^()]*)\) *\(.*\)$/\1if\2\n\1  \3/', # Single layer of nested bracets
   # "Statement after an if should be on a new line": r's/^\(\s*\)if *\((\([^()]\|([^()]*)\)*)\) *\(.*\)$/\1if\2\n\1  \4/', # Max 2 layers of nested bracets; messes up line numbers for other errors.
   # "Redundant blank line at the end of a code block should be deleted.": "d", # messes up line numbers for other errors.

--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -553,7 +553,7 @@ _SED_FIXUPS = {
   "Tab found, replace by spaces": r's/\t/  /g',
   "Line ends in whitespace.  Consider deleting these extra spaces.": r's/\s*$//',
   "You don't need a ; after a }": r's/};/}/',
-  "Missing space after ,": r's/,\([^ ]\)/, \1/',
+  "Missing space after ,": r's/,\([^ ]\)/, \1/g',
   # "Statement after an if should be on a new line": r's/^\(\s*\)if *\(([^()]*)\) *\(.*\)$/\1if\2\n\1  \3/', # Single layer of nested bracets
   # "Statement after an if should be on a new line": r's/^\(\s*\)if *\((\([^()]\|([^()]*)\)*)\) *\(.*\)$/\1if\2\n\1  \4/', # Max 2 layers of nested bracets; messes up line numbers for other errors.
   # "Redundant blank line at the end of a code block should be deleted.": "d", # messes up line numbers for other errors.

--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -553,6 +553,7 @@ _SED_FIXUPS = {
   "Tab found, replace by spaces": r's/\t/  /',
   "Line ends in whitespace.  Consider deleting these extra spaces.": r's/\s*$//',
   "You don't need a ; after a }": r's/};/}/',
+  "Missing space after ,": r's/,\([^ ]\)/, \1/',
   # "Statement after an if should be on a new line": r's/^\(\s*\)if *\(([^()]*)\) *\(.*\)$/\1if\2\n\1  \3/', # Single layer of nested bracets
   # "Statement after an if should be on a new line": r's/^\(\s*\)if *\((\([^()]\|([^()]*)\)*)\) *\(.*\)$/\1if\2\n\1  \4/', # Max 2 layers of nested bracets; messes up line numbers for other errors.
   # "Redundant blank line at the end of a code block should be deleted.": "d", # messes up line numbers for other errors.

--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -550,7 +550,7 @@ _SED_FIXUPS = {
   "Remove space before ( in switch (": "s/switch (/switch(/",
   "Should have a space between // and comment": 's/\/\//\/\/ /',
   "Missing space before {": r's/\([^ ]\){/\1 {/',
-  "Tab found, replace by spaces": r's/\t/  /',
+  "Tab found, replace by spaces": r's/\t/  /g',
   "Line ends in whitespace.  Consider deleting these extra spaces.": r's/\s*$//',
   "You don't need a ; after a }": r's/};/}/',
   "Missing space after ,": r's/,\([^ ]\)/, \1/',

--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -552,7 +552,9 @@ _SED_FIXUPS = {
   "Missing space before {": r's/\([^ ]\){/\1 {/',
   "Tab found, replace by spaces": r's/\t/  /',
   "Line ends in whitespace.  Consider deleting these extra spaces.": r's/\s*$//',
-  #"Redundant blank line at the end of a code block should be deleted.": "d", # messes up line numbers for other errors.
+  # "Statement after an if should be on a new line": r's/^\(\s*\)if *\(([^()]*)\) *\(.*\)$/\1if\2\n\1  \3/', # Single layer of nested bracets
+  # "Statement after an if should be on a new line": r's/^\(\s*\)if *\((\([^()]\|([^()]*)\)*)\) *\(.*\)$/\1if\2\n\1  \4/', # Max 2 layers of nested bracets; messes up line numbers for other errors.
+  # "Redundant blank line at the end of a code block should be deleted.": "d", # messes up line numbers for other errors.
 }
 
 _regexp_compile_cache = {}


### PR DESCRIPTION
Fix 3 more error types.

Add some commented out fixes for changes that affect line numbers. These break other fixes later in the same file - to use them, fixes will need to be applied in reverse order.