### PR TITLE
String refine java bytecode

### DIFF
--- a/src/java_bytecode/java_bytecode_convert_class.h
+++ b/src/java_bytecode/java_bytecode_convert_class.h
@@ -22,6 +22,7 @@ bool java_bytecode_convert_class(
   bool disable_runtime_checks,
   size_t max_array_length,
   lazy_methodst &,
-  lazy_methods_modet);
+  lazy_methods_modet,
+  bool string_refinement_enabled);
 
 #endif // CPROVER_JAVA_BYTECODE_JAVA_BYTECODE_CONVERT_CLASS_H

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -43,6 +43,7 @@ void java_bytecode_languaget::get_language_options(const cmdlinet &cmd)
 {
   disable_runtime_checks=cmd.isset("disable-runtime-check");
   assume_inputs_non_null=cmd.isset("java-assume-inputs-non-null");
+  string_refinement_enabled=cmd.isset("string-refine");
   if(cmd.isset("java-max-input-array-length"))
     max_nondet_array_length=
       std::stoi(cmd.get_value("java-max-input-array-length"));
@@ -494,7 +495,8 @@ bool java_bytecode_languaget::typecheck(
          disable_runtime_checks,
          max_user_array_length,
          lazy_methods,
-         lazy_methods_mode))
+         lazy_methods_mode,
+         string_refinement_enabled))
       return true;
   }
 
@@ -509,7 +511,7 @@ bool java_bytecode_languaget::typecheck(
 
   // now typecheck all
   if(java_bytecode_typecheck(
-       symbol_table, get_message_handler()))
+       symbol_table, get_message_handler(), string_refinement_enabled))
     return true;
 
   return false;

--- a/src/java_bytecode/java_bytecode_language.h
+++ b/src/java_bytecode/java_bytecode_language.h
@@ -104,6 +104,7 @@ protected:
   size_t max_user_array_length;     // max size for user code created arrays
   lazy_methodst lazy_methods;
   lazy_methods_modet lazy_methods_mode;
+  bool string_refinement_enabled;
 };
 
 languaget *new_java_bytecode_language();

--- a/src/java_bytecode/java_bytecode_typecheck.cpp
+++ b/src/java_bytecode/java_bytecode_typecheck.cpp
@@ -126,10 +126,11 @@ Function: java_bytecode_typecheck
 
 bool java_bytecode_typecheck(
   symbol_tablet &symbol_table,
-  message_handlert &message_handler)
+  message_handlert &message_handler,
+  bool string_refinement_enabled)
 {
   java_bytecode_typecheckt java_bytecode_typecheck(
-    symbol_table, message_handler);
+    symbol_table, message_handler, string_refinement_enabled);
   return java_bytecode_typecheck.typecheck_main();
 }
 

--- a/src/java_bytecode/java_bytecode_typecheck.h
+++ b/src/java_bytecode/java_bytecode_typecheck.h
@@ -21,7 +21,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 bool java_bytecode_typecheck(
   symbol_tablet &symbol_table,
-  message_handlert &message_handler);
+  message_handlert &message_handler,
+  bool string_refinement_enabled);
 
 bool java_bytecode_typecheck(
   exprt &expr,
@@ -33,10 +34,12 @@ class java_bytecode_typecheckt:public typecheckt
 public:
   java_bytecode_typecheckt(
     symbol_tablet &_symbol_table,
-    message_handlert &_message_handler):
+    message_handlert &_message_handler,
+    bool _string_refinement_enabled):
     typecheckt(_message_handler),
     symbol_table(_symbol_table),
-    ns(symbol_table)
+    ns(symbol_table),
+    string_refinement_enabled(_string_refinement_enabled)
   {
   }
 
@@ -48,6 +51,7 @@ public:
 protected:
   symbol_tablet &symbol_table;
   const namespacet ns;
+  bool string_refinement_enabled;
 
   void typecheck_type_symbol(symbolt &);
   void typecheck_non_type_symbol(symbolt &);

--- a/src/java_bytecode/java_bytecode_typecheck_expr.cpp
+++ b/src/java_bytecode/java_bytecode_typecheck_expr.cpp
@@ -117,7 +117,19 @@ static std::string escape_non_alnum(const std::string &toescape)
   return escaped.str();
 }
 
-static array_exprt utf16_to_array(const std::wstring& in)
+/*******************************************************************\
+
+Function: utf16_to_array
+
+  Inputs: `in`: wide string to convert
+
+ Outputs: Returns a Java char array containing the same wchars.
+
+ Purpose: Convert UCS-2 or UTF-16 to an array expression.
+
+\*******************************************************************/
+
+static array_exprt utf16_to_array(const std::wstring &in)
 {
   const auto jchar=java_char_type();
   array_exprt ret(array_typet(jchar, infinity_exprt(java_int_type())));
@@ -168,15 +180,18 @@ void java_bytecode_typecheckt::typecheck_expr_java_string_literal(exprt &expr)
   // Regardless of string refinement setting, at least initialize
   // the literal with @clsid = String and @lock = false:
   symbol_typet jlo_symbol("java::java.lang.Object");
-  const auto& jlo_struct=to_struct_type(ns.follow(jlo_symbol));
+  const auto &jlo_struct=to_struct_type(ns.follow(jlo_symbol));
   struct_exprt jlo_init(jlo_symbol);
-  const auto& jls_struct=to_struct_type(ns.follow(string_type));
+  const auto &jls_struct=to_struct_type(ns.follow(string_type));
 
   jlo_init.copy_to_operands(
-    constant_exprt("java::java.lang.String",
-                   jlo_struct.components()[0].type()));
+    constant_exprt(
+      "java::java.lang.String",
+      jlo_struct.components()[0].type()));
   jlo_init.copy_to_operands(
-    from_integer(0, jlo_struct.components()[1].type()));
+    from_integer(
+      0,
+      jlo_struct.components()[1].type()));
 
   // If string refinement *is* around, populate the actual
   // contents as well:
@@ -185,7 +200,7 @@ void java_bytecode_typecheckt::typecheck_expr_java_string_literal(exprt &expr)
     struct_exprt literal_init(new_symbol.type);
     literal_init.move_to_operands(jlo_init);
 
-    // Initialise the string with a constant utf-16 array:
+    // Initialize the string with a constant utf-16 array:
     symbolt array_symbol;
     array_symbol.name=escaped_symbol_name+"_constarray";
     array_symbol.type=array_typet(
@@ -203,7 +218,7 @@ void java_bytecode_typecheckt::typecheck_expr_java_string_literal(exprt &expr)
     array_symbol.value=literal_array;
 
     if(symbol_table.add(array_symbol))
-      throw "failed to add constarray symbol to symtab";
+      throw "failed to add constarray symbol to symbol table";
 
     literal_init.copy_to_operands(
       from_integer(literal_array.operands().size(),


### PR DESCRIPTION
When string-refinement is enabled, we define what java.lang.String objects are supposed to contains, and we affect this kind of objects for string literals.

Replaces #491. Depends on #541.