### PR TITLE
Fix lint filter against deleted files. Fixes #563

### DIFF
--- a/scripts/filter_lint_by_diff.py
+++ b/scripts/filter_lint_by_diff.py
@@ -15,6 +15,9 @@ with open(sys.argv[1], "r") as f:
   diff = unidiff.PatchSet(f)
   for diff_file in diff:
     filename = diff_file.target_file
+    # Skip files deleted in the tip (b side of the diff):
+    if filename == "/dev/null":
+      continue
     assert filename.startswith("b/")
     filename = os.path.join(repository_root, filename[2:])
     added_lines.add((filename, 0))


### PR DESCRIPTION
git-diff when a file has been removed diffs against /dev/null instead of the usual pattern `b/some/path/to/file.cpp`. This change avoids asserting a "b/" prefix in that case.