### PR TITLE
Allow the symbol table traverser to only output symbols that correspond to functions.

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -1,5 +1,8 @@
 
-DIRS = ansi-c cbmc cpp goto-instrument goto-analyzer cbmc-java
+DIRS = ansi-c cbmc cpp goto-instrument goto-analyzer cbmc-java \
+       goto-cc-goto-analyzer \
+       goto-cc-symex \
+       # Empty last line
 
 test:
 	$(foreach var,$(DIRS), $(MAKE) -C $(var) test || exit 1;)

--- a/regression/goto-analyzer/regenerate-entry-function/main.c
+++ b/regression/goto-analyzer/regenerate-entry-function/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+int fun(int x)
+{
+	int i;
+	if(i>=20)
+    assert(i>=10);
+}
+
+int main(int argc, char** argv)
+{
+  int i;
+
+  if(i>=5)
+    assert(i>=10);
+}

--- a/regression/goto-analyzer/regenerate-entry-function/test.desc
+++ b/regression/goto-analyzer/regenerate-entry-function/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--function fun --show-goto-functions
+
+^\s*fun(x);$
+^EXIT=6$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/goto-cbmc/cbmc-analyze1/main.c
+++ b/regression/goto-cbmc/cbmc-analyze1/main.c
@@ -1,0 +1,23 @@
+int fun(int x)
+{
+	if(x > 0)
+	{
+		return x * x;
+	}
+	else
+	{
+		return x;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	if(argc>4)
+	{
+		return 0;
+	}
+	else
+	{
+		return 1;
+	}
+}

--- a/regression/goto-cbmc/cbmc-analyze1/test.desc
+++ b/regression/goto-cbmc/cbmc-analyze1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+"--function fun --cover branch"
+
+^EXIT=0$
+^SIGNAL=0$
+^x=0$
+^x=2$
+--
+^warning: ignoring

--- a/regression/goto-cbmc/cbmc-reachable1/main.c
+++ b/regression/goto-cbmc/cbmc-reachable1/main.c
@@ -1,0 +1,23 @@
+int fun(int x)
+{
+	if(x > 0)
+	{
+		return x * x;
+	}
+	else
+	{
+		return x;
+	}
+}
+
+int main(int argc, char** argv)
+{
+	if(argc>4)
+	{
+		return 0;
+	}
+	else
+	{
+		return 1;
+	}
+}

--- a/regression/goto-cbmc/cbmc-reachable1/test.desc
+++ b/regression/goto-cbmc/cbmc-reachable1/test.desc
@@ -1,0 +1,20 @@
+CORE
+main.c
+"--function fun --cover branch --show-reachable-properties"
+
+^EXIT=0$
+^SIGNAL=0$
+^Property fun\.coverage\.1:$
+^  file main\.c line 3 function fun$
+^  function fun entry point$
+^  FALSE$
+^Property fun\.coverage\.2:$
+^  file main\.c line 3 function fun$
+^  function fun block 1 branch false$
+^  !(x > 0)$
+^Property fun\.coverage\.3:$
+^  file main\.c line 3 function fun$
+^  function fun block 1 branch true$
+^  !(!(x > 0))$
+--
+^warning: ignoring

--- a/regression/goto-cbmc/chain.sh
+++ b/regression/goto-cbmc/chain.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+SRC=../../../src
+
+GC=$SRC/goto-cc/goto-cc
+CBMC=$SRC/cbmc/cbmc
+
+OPTS=$1
+NAME=${2%.c}
+
+$GC $NAME.c -o $NAME.gb
+$CBMC $NAME.gb $OPTS

--- a/regression/goto-cc-goto-analyzer/Makefile
+++ b/regression/goto-cc-goto-analyzer/Makefile
@@ -1,0 +1,32 @@
+
+default: tests.log
+
+test:
+	@if ! ../test.pl -c ../chain.sh ; then \
+		../failed-tests-printer.pl ; \
+		exit 1; \
+	fi
+
+tests.log:
+	pwd
+	@if ! ../test.pl -c ../chain.sh ; then \
+		../failed-tests-printer.pl ; \
+		exit 1; \
+	fi
+
+show:
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			vim -o "$$dir/*.c" "$$dir/*.out"; \
+		fi; \
+	done;
+
+clean:
+	@for dir in *; do \
+		rm -f tests.log; \
+		if [ -d "$$dir" ]; then \
+			cd "$$dir"; \
+			rm -f *.out *.gb; \
+			cd ..; \
+		fi \
+	done

--- a/regression/goto-cc-goto-analyzer/chain.sh
+++ b/regression/goto-cc-goto-analyzer/chain.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+src=../../../src
+
+gc=$src/goto-cc/goto-cc
+goto_analyzer=$src/goto-analyzer/goto-analyzer
+
+options=$1
+name=${2%.c}
+
+$gc $name.c -o $name.gb
+$goto_analyzer $name.gb $options

--- a/regression/goto-cc-goto-analyzer/regenerate-entry-function/main.c
+++ b/regression/goto-cc-goto-analyzer/regenerate-entry-function/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+int fun(int x)
+{
+	int i;
+	if(i>=20)
+    assert(i>=10);
+}
+
+int main(int argc, char** argv)
+{
+  int i;
+
+  if(i>=5)
+    assert(i>=10);
+}

--- a/regression/goto-cc-goto-analyzer/regenerate-entry-function/test.desc
+++ b/regression/goto-cc-goto-analyzer/regenerate-entry-function/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+"--function fun --show-goto-functions"
+
+^\s*fun(x);$
+^EXIT=6$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/goto-cc-symex/Makefile
+++ b/regression/goto-cc-symex/Makefile
@@ -1,0 +1,32 @@
+
+default: tests.log
+
+test:
+	@if ! ../test.pl -c ../chain.sh ; then \
+		../failed-tests-printer.pl ; \
+		exit 1; \
+	fi
+
+tests.log:
+	pwd
+	@if ! ../test.pl -c ../chain.sh ; then \
+		../failed-tests-printer.pl ; \
+		exit 1; \
+	fi
+
+show:
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			vim -o "$$dir/*.c" "$$dir/*.out"; \
+		fi; \
+	done;
+
+clean:
+	@for dir in *; do \
+		rm -f tests.log; \
+		if [ -d "$$dir" ]; then \
+			cd "$$dir"; \
+			rm -f *.out *.gb; \
+			cd ..; \
+		fi \
+	done

--- a/regression/goto-cc-symex/chain.sh
+++ b/regression/goto-cc-symex/chain.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+src=../../../src
+
+gc=$src/goto-cc/goto-cc
+symex=$src/symex/symex
+
+options=$1
+name=${2%.c}
+
+$gc $name.c -o $name.gb
+$symex $name.gb $options

--- a/regression/goto-cc-symex/regenerate-entry-function/main.c
+++ b/regression/goto-cc-symex/regenerate-entry-function/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+int fun(int x)
+{
+	int i;
+	if(i>=20)
+    assert(i>=10);
+}
+
+int main(int argc, char** argv)
+{
+  int i;
+
+  if(i>=5)
+    assert(i>=10);
+}

--- a/regression/goto-cc-symex/regenerate-entry-function/test.desc
+++ b/regression/goto-cc-symex/regenerate-entry-function/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+"--function fun --show-goto-functions"
+
+^\s*return.=fun(x);$
+^EXIT=6$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/symex/regenerate-entry-function/main.c
+++ b/regression/symex/regenerate-entry-function/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+int fun(int x)
+{
+	int i;
+	if(i>=20)
+    assert(i>=10);
+}
+
+int main(int argc, char** argv)
+{
+  int i;
+
+  if(i>=5)
+    assert(i>=10);
+}

--- a/regression/symex/regenerate-entry-function/test.desc
+++ b/regression/symex/regenerate-entry-function/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--function fun --show-goto-functions
+
+^\s*return.=fun(x);$
+^EXIT=6$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/config.h>
 #include <util/cprover_prefix.h>
 #include <util/prefix.h>
+#include <util/symbol.h>
 
 #include <ansi-c/c_types.h>
 #include <ansi-c/string_constant.h>
@@ -259,6 +260,32 @@ bool ansi_c_entry_point(
   if(static_lifetime_init(symbol_table, symbol.location, message_handler))
     return true;
 
+  return generate_ansi_c_start_function(symbol, symbol_table, message_handler);
+}
+
+
+/*******************************************************************\
+
+Function: generate_ansi_c_start_function
+
+  Inputs:
+          entry_function_symbol - The symbol for the function that should
+                                  be used as the entry point
+          symbol_table - The symbol table for the program. The new _start
+                         function symbol will be added to this table
+
+ Outputs: Returns false if the _start method was generated correctly
+
+ Purpose: Generate a _start function for a specific function
+
+\*******************************************************************/
+
+bool generate_ansi_c_start_function(
+  const symbolt &symbol,
+  symbol_tablet &symbol_table,
+  message_handlert &message_handler)
+{
+  assert(!symbol.value.is_nil());
   code_blockt init_code;
 
   // build call to initialization function
@@ -306,7 +333,7 @@ bool ansi_c_entry_point(
   const code_typet::parameterst &parameters=
     to_code_type(symbol.type).parameters();
 
-  if(symbol.name==standard_main)
+  if(symbol.name==ID_main)
   {
     if(parameters.empty())
     {

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -190,7 +190,6 @@ Function: ansi_c_entry_point
 
 bool ansi_c_entry_point(
   symbol_tablet &symbol_table,
-  const std::string &standard_main,
   message_handlert &message_handler)
 {
   // check if entry point is already there
@@ -237,7 +236,7 @@ bool ansi_c_entry_point(
     main_symbol=matches.front();
   }
   else
-    main_symbol=standard_main;
+    main_symbol=ID_main;
 
   // look it up
   symbol_tablet::symbolst::const_iterator s_it=

--- a/src/ansi-c/ansi_c_entry_point.h
+++ b/src/ansi-c/ansi_c_entry_point.h
@@ -17,4 +17,9 @@ bool ansi_c_entry_point(
   const std::string &standard_main,
   message_handlert &message_handler);
 
+bool generate_ansi_c_start_function(
+  const symbolt &symbol,
+  symbol_tablet &symbol_table,
+  message_handlert &message_handler);
+
 #endif // CPROVER_ANSI_C_ANSI_C_ENTRY_POINT_H

--- a/src/ansi-c/ansi_c_entry_point.h
+++ b/src/ansi-c/ansi_c_entry_point.h
@@ -14,7 +14,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 bool ansi_c_entry_point(
   symbol_tablet &symbol_table,
-  const std::string &standard_main,
   message_handlert &message_handler);
 
 bool generate_ansi_c_start_function(

--- a/src/ansi-c/ansi_c_language.cpp
+++ b/src/ansi-c/ansi_c_language.cpp
@@ -61,6 +61,32 @@ void ansi_c_languaget::modules_provided(std::set<std::string> &modules)
 
 /*******************************************************************\
 
+Function: ansi_c_languaget::generate_start_function
+
+  Inputs:
+          entry_function_symbol - The symbol for the function that should
+                                  be used as the entry point
+          symbol_table - The symbol table for the program. The new _start
+                         function symbol will be added to this table
+
+ Outputs: Returns false if the _start method was generated correctly
+
+ Purpose: Generate a _start function for a specific function
+
+\*******************************************************************/
+
+bool ansi_c_languaget::generate_start_function(
+  const symbolt &entry_function_symbol,
+  symbol_tablet &symbol_table)
+{
+  return generate_ansi_c_start_function(
+    entry_function_symbol,
+    symbol_table,
+    *message_handler);
+}
+
+/*******************************************************************\
+
 Function: ansi_c_languaget::preprocess
 
   Inputs:

--- a/src/ansi-c/ansi_c_language.cpp
+++ b/src/ansi-c/ansi_c_language.cpp
@@ -222,7 +222,7 @@ Function: ansi_c_languaget::final
 
 bool ansi_c_languaget::final(symbol_tablet &symbol_table)
 {
-  if(ansi_c_entry_point(symbol_table, "main", get_message_handler()))
+  if(ansi_c_entry_point(symbol_table, get_message_handler()))
     return true;
 
   return false;

--- a/src/ansi-c/ansi_c_language.h
+++ b/src/ansi-c/ansi_c_language.h
@@ -72,6 +72,10 @@ public:
 
   void modules_provided(std::set<std::string> &modules) override;
 
+  virtual bool generate_start_function(
+    const class symbolt &entry_function_symbol,
+    class symbol_tablet &symbol_table) override;
+
 protected:
   ansi_c_parse_treet parse_tree;
   std::string parse_path;

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -674,6 +674,8 @@ int cbmc_parse_optionst::get_goto_program(
     cmdlinet::argst binaries;
     binaries.reserve(cmdline.args.size());
 
+    // Remove all binaries from the command line as they
+    // are already compiled
     for(cmdlinet::argst::iterator
         it=cmdline.args.begin();
         it!=cmdline.args.end();

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -38,6 +38,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/link_to_library.h>
 #include <goto-programs/remove_skip.h>
 #include <goto-programs/show_goto_functions.h>
+#include <goto-programs/rebuild_goto_start_function.h>
 
 #include <goto-symex/rewrite_union.h>
 #include <goto-symex/adjust_float_expressions.h>
@@ -724,22 +725,14 @@ int cbmc_parse_optionst::get_goto_program(
     if(cmdline.isset("function"))
     {
       const std::string &function_id=cmdline.get_value("function");
-      const auto &desired_entry_function=
-        symbol_table.symbols.find(function_id);
+      rebuild_goto_start_functiont start_function_rebuilder(
+        get_message_handler(),
+        symbol_table,
+        goto_functions);
 
-      if(desired_entry_function!=symbol_table.symbols.end())
+      if(start_function_rebuilder(function_id))
       {
-        languaget *language=get_language_from_mode(
-          desired_entry_function->second.mode);
-        language->regenerate_start_function(
-          desired_entry_function->second,
-          symbol_table,
-          goto_functions);
-      }
-      else
-      {
-        error() << "main symbol `" << function_id;
-        error() << "' not found" << messaget::eom;
+        return 6;
       }
     }
 

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -39,6 +39,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/remove_skip.h>
 #include <goto-programs/show_goto_functions.h>
 #include <goto-programs/rebuild_goto_start_function.h>
+#include <goto-programs/show_file_functions.h>
 
 #include <goto-symex/rewrite_union.h>
 #include <goto-symex/adjust_float_expressions.h>
@@ -434,6 +435,9 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
     options.set_option("stop-on-fail", true);
     options.set_option("trace", true);
   }
+  if(cmdline.isset("show-file-functions"))
+    options.set_option("show-file-functions", true);
+
 }
 
 /*******************************************************************\
@@ -742,6 +746,12 @@ int cbmc_parse_optionst::get_goto_program(
     if(cmdline.isset("show-symbol-table"))
     {
       show_symbol_table();
+      return 0;
+    }
+
+    if(cmdline.isset("show-file-functions"))
+    {
+      show_file_functions(std::cout, symbol_table);
       return 0;
     }
 
@@ -1144,6 +1154,7 @@ void cbmc_parse_optionst::help()
     "Program representations:\n"
     " --show-parse-tree            show parse tree\n"
     " --show-symbol-table          show symbol table\n"
+    HELP_SHOW_FILE_FUNCTIONS
     HELP_SHOW_GOTO_FUNCTIONS
     "\n"
     "Program instrumentation options:\n"

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -719,6 +719,18 @@ int cbmc_parse_optionst::get_goto_program(
       }
     }
 
+    if(cmdline.isset("function"))
+    {
+      const symbolt &desired_entry_function=
+        symbol_table.lookup(cmdline.get_value("function"));
+      languaget *language=get_language_from_mode(desired_entry_function.mode);
+
+      language->regenerate_start_function(
+        desired_entry_function,
+        symbol_table,
+        goto_functions);
+    }
+
     if(!binaries.empty())
       config.set_from_symbol_table(symbol_table);
 

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -723,14 +723,24 @@ int cbmc_parse_optionst::get_goto_program(
 
     if(cmdline.isset("function"))
     {
-      const symbolt &desired_entry_function=
-        symbol_table.lookup(cmdline.get_value("function"));
-      languaget *language=get_language_from_mode(desired_entry_function.mode);
+      const std::string &function_id=cmdline.get_value("function");
+      const auto &desired_entry_function=
+        symbol_table.symbols.find(function_id);
 
-      language->regenerate_start_function(
-        desired_entry_function,
-        symbol_table,
-        goto_functions);
+      if(desired_entry_function!=symbol_table.symbols.end())
+      {
+        languaget *language=get_language_from_mode(
+          desired_entry_function->second.mode);
+        language->regenerate_start_function(
+          desired_entry_function->second,
+          symbol_table,
+          goto_functions);
+      }
+      else
+      {
+        error() << "main symbol `" << function_id;
+        error() << "' not found" << messaget::eom;
+      }
     }
 
     if(!binaries.empty())

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -1139,7 +1139,7 @@ void cbmc_parse_optionst::help()
     " --round-to-plus-inf          rounding towards plus infinity\n"
     " --round-to-minus-inf         rounding towards minus infinity\n"
     " --round-to-zero              rounding towards zero\n"
-    " --function name              set main function name\n"
+    HELP_FUNCTIONS
     "\n"
     "Program representations:\n"
     " --show-parse-tree            show parse tree\n"

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -43,6 +43,7 @@ class optionst;
   "(little-endian)(big-endian)" \
   "(show-goto-functions)(show-loops)" \
   "(show-symbol-table)(show-parse-tree)(show-vcc)" \
+  OPT_SHOW_FILE_FUNCTIONS \
   "(show-claims)(claim):(show-properties)(show-reachable-properties)" \
   "(property):(stop-on-fail)(trace)" \
   "(error-label):(verbosity):(no-library)" \

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/ui_message.h>
 #include <util/parse_options.h>
+#include <goto-programs/rebuild_goto_start_function.h>
 
 #include <langapi/language_ui.h>
 
@@ -23,7 +24,8 @@ class goto_functionst;
 class optionst;
 
 #define CBMC_OPTIONS \
-  "(program-only)(function):(preprocess)(slice-by-trace):" \
+  "(program-only)(preprocess)(slice-by-trace):" \
+  OPT_FUNCTIONS \
   "(no-simplify)(unwind):(unwindset):(slice-formula)(full-slice)" \
   "(debug-level):(no-propagation)(no-simplify-if)" \
   "(document-subgoals)(outfile):(test-preprocessor)" \

--- a/src/cpp/cpp_language.cpp
+++ b/src/cpp/cpp_language.cpp
@@ -227,7 +227,7 @@ Function: cpp_languaget::final
 
 bool cpp_languaget::final(symbol_tablet &symbol_table)
 {
-  if(ansi_c_entry_point(symbol_table, "main", get_message_handler()))
+  if(ansi_c_entry_point(symbol_table, get_message_handler()))
     return true;
 
   return false;

--- a/src/cpp/cpp_language.cpp
+++ b/src/cpp/cpp_language.cpp
@@ -75,6 +75,32 @@ void cpp_languaget::modules_provided(std::set<std::string> &modules)
 
 /*******************************************************************\
 
+Function: cpp_languaget::generate_start_function
+
+  Inputs:
+          entry_function_symbol - The symbol for the function that should
+                                  be used as the entry point
+          symbol_table - The symbol table for the program. The new _start
+                         function symbol will be added to this table
+
+ Outputs: Returns false if the _start method was generated correctly
+
+ Purpose: Generate a _start function for a specific function
+
+\*******************************************************************/
+
+bool cpp_languaget::generate_start_function(
+  const symbolt &entry_function_symbol,
+  symbol_tablet &symbol_table)
+{
+  return generate_ansi_c_start_function(
+    entry_function_symbol,
+    symbol_table,
+    *message_handler);
+}
+
+/*******************************************************************\
+
 Function: cpp_languaget::preprocess
 
   Inputs:

--- a/src/cpp/cpp_language.h
+++ b/src/cpp/cpp_language.h
@@ -82,6 +82,10 @@ public:
 
   void modules_provided(std::set<std::string> &modules) override;
 
+  virtual bool generate_start_function(
+    const class symbolt &entry_function_symbol,
+    class symbol_tablet &symbol_table) override;
+
 protected:
   cpp_parse_treet cpp_parse_tree;
   std::string parse_path;

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -515,6 +515,7 @@ void goto_analyzer_parse_optionst::help()
     "Java Bytecode frontend options:\n"
     " --classpath dir/jar          set the classpath\n"
     " --main-class class-name      set the name of the main class\n"
+    HELP_FUNCTIONS
     "\n"
     "Program representations:\n"
     " --show-parse-tree            show parse tree\n"

--- a/src/goto-analyzer/goto_analyzer_parse_options.h
+++ b/src/goto-analyzer/goto_analyzer_parse_options.h
@@ -16,13 +16,14 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <goto-programs/get_goto_model.h>
 #include <goto-programs/show_goto_functions.h>
+#include <goto-programs/rebuild_goto_start_function.h>
 
 class bmct;
 class goto_functionst;
 class optionst;
 
 #define GOTO_ANALYSER_OPTIONS \
-  "(function):" \
+  OPT_FUNCTIONS \
   "D:I:(std89)(std99)(std11)" \
   "(classpath):(cp):(main-class):" \
   "(16)(32)(64)(LP64)(ILP64)(LLP64)(ILP32)(LP32)" \

--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -407,7 +407,7 @@ bool compilet::link()
     symbol_table.remove(goto_functionst::entry_point());
     compiled_functions.function_map.erase(goto_functionst::entry_point());
 
-    if(ansi_c_entry_point(symbol_table, "main", ui_message_handler))
+    if(ansi_c_entry_point(symbol_table, ui_message_handler))
       return true;
 
     // entry_point may (should) add some more functions.

--- a/src/goto-programs/Makefile
+++ b/src/goto-programs/Makefile
@@ -18,7 +18,9 @@ SRC = goto_convert.cpp goto_convert_function_call.cpp \
       graphml_witness.cpp remove_virtual_functions.cpp \
       class_hierarchy.cpp show_goto_functions.cpp get_goto_model.cpp \
       slice_global_inits.cpp goto_inline_class.cpp class_identifier.cpp \
-      remove_static_init_loops.cpp remove_instanceof.cpp
+      remove_static_init_loops.cpp remove_instanceof.cpp \
+      rebuild_goto_start_function.cpp \
+      # Empty last line
 
 INCLUDES= -I ..
 

--- a/src/goto-programs/Makefile
+++ b/src/goto-programs/Makefile
@@ -20,6 +20,7 @@ SRC = goto_convert.cpp goto_convert_function_call.cpp \
       slice_global_inits.cpp goto_inline_class.cpp class_identifier.cpp \
       remove_static_init_loops.cpp remove_instanceof.cpp \
       rebuild_goto_start_function.cpp \
+      show_file_functions.cpp \
       # Empty last line
 
 INCLUDES= -I ..

--- a/src/goto-programs/get_goto_model.cpp
+++ b/src/goto-programs/get_goto_model.cpp
@@ -13,6 +13,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/config.h>
 #include <util/unicode.h>
 
+#include <goto-programs/rebuild_goto_start_function.h>
+
 #include <langapi/mode.h>
 #include <langapi/language_ui.h>
 
@@ -32,7 +34,8 @@ Function: get_goto_modelt::operator()
 
 \*******************************************************************/
 
-bool get_goto_modelt::operator()(const std::vector<std::string> &files)
+bool get_goto_modelt::operator()(
+  const std::vector<std::string> &files)
 {
   if(files.empty())
   {
@@ -128,6 +131,20 @@ bool get_goto_modelt::operator()(const std::vector<std::string> &files)
 
       if(read_object_and_link(file, *this, get_message_handler()))
         return true;
+    }
+
+    if(config.main!="")
+    {
+      const std::string &function_id=config.main;
+      rebuild_goto_start_functiont start_function_rebuilder(
+        get_message_handler(),
+        symbol_table,
+        goto_functions);
+
+      if(start_function_rebuilder(function_id))
+      {
+        return true;
+      }
     }
 
     if(!binaries.empty())

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -76,6 +76,9 @@ void goto_convert_functionst::goto_convert()
 
   forall_symbols(it, symbol_table.symbols)
   {
+    // For each code symbol that:
+    // isn't a macro or type(?? - can a code symbol also be a type?)
+    // is one of the supported languages (either C, C++, Java or JSIL)
     if(!it->second.is_type &&
        !it->second.is_macro &&
        it->second.type.id()==ID_code &&

--- a/src/goto-programs/rebuild_goto_start_function.cpp
+++ b/src/goto-programs/rebuild_goto_start_function.cpp
@@ -7,6 +7,7 @@
 #include <util/language.h>
 #include <util/symbol.h>
 #include <langapi/mode.h>
+#include <memory>
 
 /*******************************************************************\
 

--- a/src/goto-programs/rebuild_goto_start_function.cpp
+++ b/src/goto-programs/rebuild_goto_start_function.cpp
@@ -1,0 +1,97 @@
+/*******************************************************************\
+ Module: Goto Programs
+ Author: Thomas Kiley, thomas@diffblue.com
+\*******************************************************************/
+
+#include "rebuild_goto_start_function.h"
+#include <util/language.h>
+#include <util/symbol.h>
+#include <langapi/mode.h>
+
+/*******************************************************************\
+
+Function: rebuild_goto_start_functiont::rebuild_goto_start_functiont
+
+  Inputs:
+          _message_handler - The message handler to report any messages with
+          symbol_table - The symbol table of the program (to replace the
+                         _start functions symbo)
+          goto_functions - The goto functions of the program (to replace the
+                           body of the _start function).
+
+ Outputs:
+
+ Purpose: To rebuild the _start funciton in the event the program was
+          compiled into GOTO with a different entry function selected.
+
+\*******************************************************************/
+
+rebuild_goto_start_functiont::rebuild_goto_start_functiont(
+  message_handlert &_message_handler,
+  symbol_tablet &symbol_table,
+  goto_functionst &goto_functions):
+  messaget(_message_handler),
+  symbol_table(symbol_table),
+  goto_functions(goto_functions)
+{
+}
+
+/*******************************************************************\
+
+Function: rebuild_goto_start_functiont::operator()
+
+  Inputs:
+          entry_function - The name of the entry function that should be
+                           called from _start
+
+ Outputs: Returns true if either the symbol is not found, or something went
+          wrong with generating the start_function. False otherwise.
+
+ Purpose: To rebuild the _start function in the event the program was
+          compiled into GOTO with a different entry function selected.
+          It works by discarding the _start symbol and GOTO function
+          and calling on the relevant languaget to generate the _start
+          function again.
+
+\*******************************************************************/
+
+bool rebuild_goto_start_functiont::operator()(const irep_idt &entry_function)
+{
+  const auto &desired_entry_function=
+    symbol_table.symbols.find(entry_function);
+
+  // Check the specified entry function is a function in the symbol table
+  if(desired_entry_function==symbol_table.symbols.end())
+  {
+    error() << "main symbol `" << entry_function
+            << "' not found" << eom;
+    return true;
+  }
+
+  // Remove the existing _start function so we can create a new one
+  symbol_table.remove(ID__start);
+
+  auto language=
+    std::unique_ptr<languaget>(
+      get_language_from_mode(
+        desired_entry_function->second.mode));
+  assert(language);
+
+  bool return_code=
+    language->generate_start_function(
+      desired_entry_function->second,
+      symbol_table);
+
+  // Remove the function from the goto_functions so is copied back in
+  // from the symbol table
+  if(!return_code)
+  {
+    const auto &start_function=goto_functions.function_map.find(ID__start);
+    if(start_function!=goto_functions.function_map.end())
+    {
+      goto_functions.function_map.erase(start_function);
+    }
+  }
+
+  return return_code;
+}

--- a/src/goto-programs/rebuild_goto_start_function.cpp
+++ b/src/goto-programs/rebuild_goto_start_function.cpp
@@ -84,7 +84,7 @@ bool rebuild_goto_start_functiont::operator()(const irep_idt &entry_function)
       symbol_table);
 
   // Remove the function from the goto_functions so is copied back in
-  // from the symbol table
+  // from the symbol table during goto_convert
   if(!return_code)
   {
     const auto &start_function=goto_functions.function_map.find(ID__start);

--- a/src/goto-programs/rebuild_goto_start_function.h
+++ b/src/goto-programs/rebuild_goto_start_function.h
@@ -1,0 +1,28 @@
+/*******************************************************************\
+ Module: Goto Programs
+ Author: Thomas Kiley, thomas@diffblue.com
+\*******************************************************************/
+
+#ifndef CPROVER_GOTO_PROGRAMS_REBUILD_GOTO_START_FUNCTION_H
+#define CPROVER_GOTO_PROGRAMS_REBUILD_GOTO_START_FUNCTION_H
+
+#include <util/message.h>
+#include <util/symbol_table.h>
+#include <goto-programs/goto_functions.h>
+
+class rebuild_goto_start_functiont: public messaget
+{
+public:
+  rebuild_goto_start_functiont(
+    message_handlert &_message_handler,
+    symbol_tablet &symbol_table,
+    goto_functionst &goto_functions);
+
+  bool operator()(const irep_idt &entry_function);
+
+private:
+  symbol_tablet &symbol_table;
+  goto_functionst &goto_functions;
+};
+
+#endif // CPROVER_GOTO_PROGRAMS_REBUILD_GOTO_START_FUNCTION_H

--- a/src/goto-programs/rebuild_goto_start_function.h
+++ b/src/goto-programs/rebuild_goto_start_function.h
@@ -10,6 +10,12 @@
 #include <util/symbol_table.h>
 #include <goto-programs/goto_functions.h>
 
+#define OPT_FUNCTIONS \
+  "(function):"
+
+#define HELP_FUNCTIONS \
+  " --function name              set main function name\n"
+
 class rebuild_goto_start_functiont: public messaget
 {
 public:

--- a/src/goto-programs/show_file_functions.cpp
+++ b/src/goto-programs/show_file_functions.cpp
@@ -1,0 +1,59 @@
+/*******************************************************************\
+
+Module: Show the functions present in the file
+
+Author: Fotis Koutoulakis
+
+\*******************************************************************/
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <set>
+
+#include <util/namespace.h>
+#include <util/language.h>
+#include <util/std_types.h>
+#include <util/symbol_table.h>
+
+#include "show_file_functions.h"
+
+/*******************************************************************\
+
+Function: show_file_functions
+
+  Inputs:
+
+ Outputs:
+
+ Purpose: Filter symbol table information so that only symbols that 
+          correspond to functions are output.
+
+\*******************************************************************/
+
+void show_file_functions(std::ostream &out, const symbol_tablet &symbol_table)
+{
+  // in order to sort the symbols alphabetically
+  std::set<std::string> symbols;
+
+  for(const auto &symbol_entry : symbol_table.symbols)
+    symbols.insert(id2string(symbol_entry.first));
+  
+  const namespacet ns(symbol_table);
+
+  for(const std::string &id : symbols)
+  {    
+    const symbolt &symbol=ns.lookup(id);
+
+    if (!(symbol.type.id() == ID_code))
+      continue;
+
+    if (!(symbol.is_file_local))
+      continue;
+
+    out << "Function: " << symbol.name << '\n';
+    out << '\n' << std::flush;
+  }
+}
+
+  

--- a/src/goto-programs/show_file_functions.h
+++ b/src/goto-programs/show_file_functions.h
@@ -1,0 +1,17 @@
+/*******************************************************************\
+
+Module: Show the functions present in the file
+
+Author: Fotis Koutoulakis
+
+\*******************************************************************/
+
+#pragma once
+
+#define OPT_SHOW_FILE_FUNCTIONS \
+  "(show-file-functions)"
+
+#define HELP_SHOW_FILE_FUNCTIONS \
+  " --show-file-functions             show only symbols that correspond to functions."
+
+void show_file_functions(std::ostream &, const symbol_tablet &);

--- a/src/goto-programs/show_symbol_table.cpp
+++ b/src/goto-programs/show_symbol_table.cpp
@@ -10,6 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <memory>
 
 #include <util/language.h>
+#include <util/std_types.h>
 #include <langapi/mode.h>
 
 #include "goto_model.h"
@@ -52,8 +53,8 @@ void show_symbol_table_plain(
   // we want to sort alphabetically
   std::set<std::string> symbols;
 
-  forall_symbols(it, goto_model.symbol_table.symbols)
-    symbols.insert(id2string(it->first));
+  for(const auto &symbol_entry : goto_model.symbol_table.symbols)
+    symbols.insert(id2string(symbol_entry.first));
 
   const namespacet ns(goto_model.symbol_table);
 
@@ -86,6 +87,7 @@ void show_symbol_table_plain(
     out << "Base name...: " << symbol.base_name << '\n';
     out << "Mode........: " << symbol.mode << '\n';
     out << "Type........: " << type_str << '\n';
+    out << "Is Function.: " << (symbol.type.id() == ID_code) ? "TRUE" : "FALSE" << '\n';
     out << "Value.......: " << value_str << '\n';
     out << "Flags.......:";
 

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -104,7 +104,9 @@ bool java_bytecode_languaget::generate_start_function(
   return generate_java_start_function(
     entry_function_symbol,
     symbol_table,
-    get_message_handler());
+    get_message_handler(),
+    assume_inputs_non_null,
+    max_nondet_array_length);
 }
 
 /*******************************************************************\

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -83,6 +83,32 @@ void java_bytecode_languaget::modules_provided(std::set<std::string> &modules)
 
 /*******************************************************************\
 
+Function: generate_start_function
+
+  Inputs:
+          entry_function_symbol - The symbol for the function that should
+                                  be used as the entry point
+          symbol_table - The symbol table for the program. The new _start
+                         function symbol will be added to this table
+
+ Outputs: Returns false if the _start method was generated correctly
+
+ Purpose: Generate a _start function for a specific function.
+
+\*******************************************************************/
+
+bool java_bytecode_languaget::generate_start_function(
+  const symbolt &entry_function_symbol,
+  symbol_tablet &symbol_table)
+{
+  return generate_java_start_function(
+    entry_function_symbol,
+    symbol_table,
+    get_message_handler());
+}
+
+/*******************************************************************\
+
 Function: java_bytecode_languaget::preprocess
 
   Inputs:

--- a/src/java_bytecode/java_bytecode_language.h
+++ b/src/java_bytecode/java_bytecode_language.h
@@ -70,6 +70,10 @@ public:
 
   void modules_provided(std::set<std::string> &modules) override;
 
+  virtual bool generate_start_function(
+    const class symbolt &entry_function_symbol,
+    class symbol_tablet &symbol_table) override;
+
 protected:
   irep_idt main_class;
   java_class_loadert java_class_loader;

--- a/src/java_bytecode/java_entry_point.cpp
+++ b/src/java_bytecode/java_entry_point.cpp
@@ -543,6 +543,31 @@ bool java_entry_point(
        max_nondet_array_length))
     return true;
 
+  return generate_java_start_function(symbol, symbol_table, message_handler);
+}
+
+/*******************************************************************\
+
+Function: generate_start_function
+
+  Inputs:
+          entry_function_symbol - The symbol for the function that should
+                                  be used as the entry point
+          symbol_table - The symbol table for the program. The new _start
+                         function symbol will be added to this table
+
+ Outputs: Returns false if the _start method was generated correctly
+
+ Purpose: Generate a _start function for a specific function
+
+\*******************************************************************/
+
+bool generate_java_start_function(
+  const symbolt &symbol,
+  symbol_tablet &symbol_table,
+  message_handlert &message_handler)
+{
+  messaget message(message_handler);
   code_blockt init_code;
 
   // build call to initialization function

--- a/src/java_bytecode/java_entry_point.cpp
+++ b/src/java_bytecode/java_entry_point.cpp
@@ -543,7 +543,12 @@ bool java_entry_point(
        max_nondet_array_length))
     return true;
 
-  return generate_java_start_function(symbol, symbol_table, message_handler);
+  return generate_java_start_function(
+    symbol,
+    symbol_table,
+    message_handler,
+    assume_init_pointers_not_null,
+    max_nondet_array_length);
 }
 
 /*******************************************************************\
@@ -565,7 +570,9 @@ Function: generate_start_function
 bool generate_java_start_function(
   const symbolt &symbol,
   symbol_tablet &symbol_table,
-  message_handlert &message_handler)
+  message_handlert &message_handler,
+  bool assume_init_pointers_not_null,
+  size_t max_nondet_array_length)
 {
   messaget message(message_handler);
   code_blockt init_code;

--- a/src/java_bytecode/java_entry_point.h
+++ b/src/java_bytecode/java_entry_point.h
@@ -30,4 +30,9 @@ main_function_resultt get_main_symbol(
   const irep_idt &main_class,
   message_handlert &);
 
+bool generate_java_start_function(
+  const symbolt &symbol,
+  class symbol_tablet &symbol_table,
+  class message_handlert &message_handler);
+
 #endif // CPROVER_JAVA_BYTECODE_JAVA_ENTRY_POINT_H

--- a/src/java_bytecode/java_entry_point.h
+++ b/src/java_bytecode/java_entry_point.h
@@ -33,6 +33,8 @@ main_function_resultt get_main_symbol(
 bool generate_java_start_function(
   const symbolt &symbol,
   class symbol_tablet &symbol_table,
-  class message_handlert &message_handler);
+  class message_handlert &message_handler,
+  bool assume_init_pointers_not_null,
+  size_t max_nondet_array_length);
 
 #endif // CPROVER_JAVA_BYTECODE_JAVA_ENTRY_POINT_H

--- a/src/jsil/jsil_language.cpp
+++ b/src/jsil/jsil_language.cpp
@@ -75,6 +75,32 @@ bool jsil_languaget::interfaces(symbol_tablet &symbol_table)
 
 /*******************************************************************\
 
+Function: jsil_languaget::generate_start_function
+
+  Inputs:
+          entry_function_symbol - The symbol for the function that should
+                                  be used as the entry point
+          symbol_table - The symbol table for the program. The new _start
+                         function symbol will be added to this table
+
+ Outputs: Returns false if the _start method was generated correctly
+
+ Purpose: Generate a _start function for a specific function
+
+\*******************************************************************/
+
+bool jsil_languaget::generate_start_function(
+  const symbolt &entry_function_symbol,
+  symbol_tablet &symbol_table)
+{
+  // TODO(tkiley): This should be implemented if this language
+  // is used.
+  assert(0);
+  return true;
+}
+
+/*******************************************************************\
+
 Function: jsil_languaget::preprocess
 
   Inputs:

--- a/src/jsil/jsil_language.h
+++ b/src/jsil/jsil_language.h
@@ -64,6 +64,10 @@ public:
   virtual void modules_provided(std::set<std::string> &modules);
   virtual bool interfaces(symbol_tablet &symbol_table);
 
+  virtual bool generate_start_function(
+    const class symbolt &entry_function_symbol,
+    class symbol_tablet &symbol_table) override;
+
 protected:
   jsil_parse_treet parse_tree;
   std::string parse_path;

--- a/src/jsil/jsil_language.h
+++ b/src/jsil/jsil_language.h
@@ -19,20 +19,20 @@ public:
   virtual bool preprocess(
     std::istream &instream,
     const std::string &path,
-    std::ostream &outstream);
+    std::ostream &outstream) override;
 
   virtual bool parse(
     std::istream &instream,
-    const std::string &path);
+    const std::string &path) override;
 
   virtual bool typecheck(
     symbol_tablet &context,
-    const std::string &module);
+    const std::string &module) override;
 
   virtual bool final(
-    symbol_tablet &context);
+    symbol_tablet &context) override;
 
-  virtual void show_parse(std::ostream &out);
+  virtual void show_parse(std::ostream &out) override;
 
   virtual ~jsil_languaget();
   jsil_languaget() { }
@@ -40,29 +40,29 @@ public:
   virtual bool from_expr(
     const exprt &expr,
     std::string &code,
-    const namespacet &ns);
+    const namespacet &ns) override;
 
   virtual bool from_type(
     const typet &type,
     std::string &code,
-    const namespacet &ns);
+    const namespacet &ns) override;
 
   virtual bool to_expr(
     const std::string &code,
     const std::string &module,
     exprt &expr,
-    const namespacet &ns);
+    const namespacet &ns) override;
 
-  virtual languaget *new_language()
+  virtual languaget *new_language() override
   { return new jsil_languaget; }
 
-  virtual std::string id() const { return "jsil"; }
-  virtual std::string description() const
+  virtual std::string id() const override { return "jsil"; }
+  virtual std::string description() const override
   { return "Javascript Intermediate Language"; }
-  virtual std::set<std::string> extensions() const;
+  virtual std::set<std::string> extensions() const override;
 
-  virtual void modules_provided(std::set<std::string> &modules);
-  virtual bool interfaces(symbol_tablet &symbol_table);
+  virtual void modules_provided(std::set<std::string> &modules) override;
+  virtual bool interfaces(symbol_tablet &symbol_table) override;
 
   virtual bool generate_start_function(
     const class symbolt &entry_function_symbol,

--- a/src/langapi/language_ui.cpp
+++ b/src/langapi/language_ui.cpp
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <util/language.h>
 #include <util/cmdline.h>
 #include <util/unicode.h>
+#include <util/std_types.h>
 
 #include "language_ui.h"
 #include "mode.h"
@@ -262,9 +263,9 @@ void language_uit::show_symbol_table_plain(
   // we want to sort alphabetically
   std::set<std::string> symbols;
 
-  forall_symbols(it, symbol_table.symbols)
-    symbols.insert(id2string(it->first));
-
+  for(const auto &symbol_entry : symbol_table.symbols)
+    symbols.insert(id2string(symbol_entry.first));
+  
   const namespacet ns(symbol_table);
 
   for(const std::string &id : symbols)
@@ -296,12 +297,20 @@ void language_uit::show_symbol_table_plain(
       continue;
     }
 
-    out << "Symbol......: " << symbol.name << '\n' << std::flush;
-    out << "Pretty name.: " << symbol.pretty_name << '\n';
+    if (!(symbol.type.id() == ID_code))
+      continue;
+
+    if (!(symbol.is_file_local))
+      continue;
+
+    out << "Symbol......: " << symbol.name << "\n\n" << std::flush;
+    continue;
+    out << "Pretty name.: " << symbol.pretty_name << "\n\n";
     out << "Module......: " << symbol.module << '\n';
     out << "Base name...: " << symbol.base_name << '\n';
     out << "Mode........: " << symbol.mode << '\n';
     out << "Type........: " << type_str << '\n';
+    out << "Is Function.: " << (symbol.type.id() == ID_code ? "True" : "False") << '\n';
     out << "Value.......: " << value_str << '\n';
     out << "Flags.......:";
 

--- a/src/symex/symex_parse_options.cpp
+++ b/src/symex/symex_parse_options.cpp
@@ -697,7 +697,7 @@ void symex_parse_optionst::help()
     " --round-to-plus-inf          IEEE floating point rounding mode\n"
     " --round-to-minus-inf         IEEE floating point rounding mode\n"
     " --round-to-zero              IEEE floating point rounding mode\n"
-    " --function name              set main function name\n"
+    HELP_FUNCTIONS
     "\n"
     "Program instrumentation options:\n"
     HELP_GOTO_CHECK

--- a/src/symex/symex_parse_options.h
+++ b/src/symex/symex_parse_options.h
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <goto-programs/get_goto_model.h>
 #include <goto-programs/show_goto_functions.h>
+#include <goto-programs/rebuild_goto_start_function.h>
 
 #include <langapi/language_ui.h>
 
@@ -25,7 +26,7 @@ class goto_functionst;
 class optionst;
 
 #define SYMEX_OPTIONS \
-  "(function):" \
+  OPT_FUNCTIONS \
   "D:I:" \
   "(depth):(context-bound):(branch-bound):(unwind):" \
   OPT_GOTO_CHECK \

--- a/src/util/language.cpp
+++ b/src/util/language.cpp
@@ -132,6 +132,31 @@ bool languaget::type_to_name(
 
 /*******************************************************************\
 
+Function: generate_start_function
+
+  Inputs:
+          entry_function_symbol - The symbol for the function that should
+                                  be used as the entry point
+          symbol_table - The symbol table for the program. The new _start
+                         function symbol will be added to this table
+
+ Outputs: Returns false if the _start method was generated correctly
+
+ Purpose: Generate a _start function for a specific function. Should
+          be overriden in derived languagets
+
+\*******************************************************************/
+bool languaget::generate_start_function(
+  const symbolt &entry_function_symbol,
+  symbol_tablet &symbol_table)
+{
+  // Implement in derived languagets
+  assert(0);
+  return true;
+}
+
+/*******************************************************************\
+
 Function: languaget::regenerate_start_function
 
   Inputs:
@@ -153,18 +178,14 @@ Function: languaget::regenerate_start_function
 
 \*******************************************************************/
 bool languaget::regenerate_start_function(
-  const symbolt &required_entry_function,
+  const symbolt &entry_function_symbol,
   symbol_tablet &symbol_table,
   goto_functionst &goto_functions)
 {
   // Remove the existing _start function so we can create a new one
   symbol_table.remove(ID__start);
-  config.main=required_entry_function.name.c_str();
 
-  // TODO(tkiley): calling final is not really correct (in fact for example,
-  // opaque function stubs get generated here). Instead the final method should
-  // call this to generate the function in the first place.
-  bool return_code=final(symbol_table);
+  bool return_code=generate_start_function(entry_function_symbol, symbol_table);
 
   // Remove the function from the goto_functions so is copied back in
   // from the symbol table

--- a/src/util/language.cpp
+++ b/src/util/language.cpp
@@ -8,6 +8,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "language.h"
 #include "expr.h"
+#include <util/config.h>
+#include <util/symbol.h>
+#include <util/symbol_table.h>
+#include <goto-programs/goto_functions.h>
 
 /*******************************************************************\
 
@@ -124,4 +128,54 @@ bool languaget::type_to_name(
   // util/
   name=type.pretty();
   return false;
+}
+
+/*******************************************************************\
+
+Function: languaget::regenerate_start_function
+
+  Inputs:
+          required_entry_function - a code symbol inside the symbol
+                                    table which is the function that
+                                    should be used as the entry point.
+
+          symbol_table - the symbol table for the program. The _start
+                         symbol will be replaced with a new start function
+
+          goto_functions - the functions for the goto program. The _start
+                           function will be erased from this
+
+ Outputs: Returns false if the new start function is created successfully,
+          true otherwise.
+
+ Purpose: To replace an existing _start function with a new one that
+          calls a specified function
+
+\*******************************************************************/
+bool languaget::regenerate_start_function(
+  const symbolt &required_entry_function,
+  symbol_tablet &symbol_table,
+  goto_functionst &goto_functions)
+{
+  // Remove the existing _start function so we can create a new one
+  symbol_table.remove(ID__start);
+  config.main=required_entry_function.name.c_str();
+
+  // TODO(tkiley): calling final is not really correct (in fact for example,
+  // opaque function stubs get generated here). Instead the final method should
+  // call this to generate the function in the first place.
+  bool return_code=final(symbol_table);
+
+  // Remove the function from the goto_functions so is copied back in
+  // from the symbol table
+  if(!return_code)
+  {
+    const auto &start_function=goto_functions.function_map.find(ID__start);
+    if(start_function!=goto_functions.function_map.end())
+    {
+      goto_functions.function_map.erase(start_function);
+    }
+  }
+
+  return return_code;
 }

--- a/src/util/language.cpp
+++ b/src/util/language.cpp
@@ -125,28 +125,3 @@ bool languaget::type_to_name(
   name=type.pretty();
   return false;
 }
-
-/*******************************************************************\
-
-Function: generate_start_function
-
-  Inputs:
-          entry_function_symbol - The symbol for the function that should
-                                  be used as the entry point
-          symbol_table - The symbol table for the program. The new _start
-                         function symbol will be added to this table
-
- Outputs: Returns false if the _start method was generated correctly
-
- Purpose: Generate a _start function for a specific function. Should
-          be overriden in derived languagets
-
-\*******************************************************************/
-bool languaget::generate_start_function(
-  const symbolt &entry_function_symbol,
-  symbol_tablet &symbol_table)
-{
-  // Implement in derived languagets
-  assert(0);
-  return true;
-}

--- a/src/util/language.cpp
+++ b/src/util/language.cpp
@@ -8,10 +8,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "language.h"
 #include "expr.h"
-#include <util/config.h>
-#include <util/symbol.h>
-#include <util/symbol_table.h>
-#include <goto-programs/goto_functions.h>
 
 /*******************************************************************\
 
@@ -153,50 +149,4 @@ bool languaget::generate_start_function(
   // Implement in derived languagets
   assert(0);
   return true;
-}
-
-/*******************************************************************\
-
-Function: languaget::regenerate_start_function
-
-  Inputs:
-          required_entry_function - a code symbol inside the symbol
-                                    table which is the function that
-                                    should be used as the entry point.
-
-          symbol_table - the symbol table for the program. The _start
-                         symbol will be replaced with a new start function
-
-          goto_functions - the functions for the goto program. The _start
-                           function will be erased from this
-
- Outputs: Returns false if the new start function is created successfully,
-          true otherwise.
-
- Purpose: To replace an existing _start function with a new one that
-          calls a specified function
-
-\*******************************************************************/
-bool languaget::regenerate_start_function(
-  const symbolt &entry_function_symbol,
-  symbol_tablet &symbol_table,
-  goto_functionst &goto_functions)
-{
-  // Remove the existing _start function so we can create a new one
-  symbol_table.remove(ID__start);
-
-  bool return_code=generate_start_function(entry_function_symbol, symbol_table);
-
-  // Remove the function from the goto_functions so is copied back in
-  // from the symbol table
-  if(!return_code)
-  {
-    const auto &start_function=goto_functions.function_map.find(ID__start);
-    if(start_function!=goto_functions.function_map.end())
-    {
-      goto_functions.function_map.erase(start_function);
-    }
-  }
-
-  return return_code;
 }

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -105,11 +105,6 @@ public:
     const class symbolt &entry_function_symbol,
     class symbol_tablet &symbol_table);
 
-  bool regenerate_start_function(
-    const class symbolt &entry_function_symbol,
-    symbol_tablet &symbol_table,
-    class goto_functionst &goto_functions);
-
   // constructor / destructor
 
   languaget() { }

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -103,7 +103,7 @@ public:
 
   virtual bool generate_start_function(
     const class symbolt &entry_function_symbol,
-    class symbol_tablet &symbol_table);
+    class symbol_tablet &symbol_table)=0;
 
   // constructor / destructor
 

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -101,6 +101,11 @@ public:
 
   virtual languaget *new_language()=0;
 
+  bool regenerate_start_function(
+    const class symbolt &required_entry_function,
+    symbol_tablet &symbol_table,
+    class goto_functionst &goto_functions);
+
   // constructor / destructor
 
   languaget() { }

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -101,8 +101,12 @@ public:
 
   virtual languaget *new_language()=0;
 
+  virtual bool generate_start_function(
+    const class symbolt &entry_function_symbol,
+    class symbol_tablet &symbol_table);
+
   bool regenerate_start_function(
-    const class symbolt &required_entry_function,
+    const class symbolt &entry_function_symbol,
     symbol_tablet &symbol_table,
     class goto_functionst &goto_functions);
 


### PR DESCRIPTION
NOTE: This pull request depends on #338.

Some information on what I'm trying to do here. In order to generate tests for minisat, one of the first things to do is to find a list of the functions that are in minisat's files, so that they can be fed into cbmc. Up until this point, cmbc didn't have a way to output only the functions present in a file (at least not one that I know off). So I wrote a command line flag, and a backing implementation to do just that.

Some thoughts:

- So, the current implementation is just a function, and we have been talking with Thomas on whether this should be a method in a class really, but since I don't know what's preferable, I would like some guidance on that.
- On the same matter, perhaps it would make more sense for it to be somehow included in the class that is responsible for the symbol table?
- The code works, but I need some guidance on how to make it much better than it currently is.
- Please, provide me with tons of feedback.

Real diff:
https://github.com/diffblue/cbmc/pull/573/files/add15dd9852f47efbe71256e31f6ec965131dde4..b96c49a46d579bfa554547ac213ed71ad2b65a8c
