### PR TITLE
Remove aa-symex from DIRS variable in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 DIRS = ansi-c big-int cbmc cpp goto-cc goto-instrument goto-programs \
        goto-symex langapi pointer-analysis solvers util linking xmllang \
-       assembler analyses java_bytecode aa-path-symex path-symex musketeer \
-       json cegis goto-analyzer jsil symex goto-diff aa-symex clobber \
+       assembler analyses java_bytecode path-symex musketeer \
+       json cegis goto-analyzer jsil symex goto-diff clobber \
        memory-models
 
 all: cbmc.dir goto-cc.dir goto-instrument.dir symex.dir goto-analyzer.dir goto-diff.dir


### PR DESCRIPTION
Without this patch, calling "make clean" fails, because make
tries to call "make clean" in the aa-symex directory as well.
By removing aa-symex from the DIRS variable, this problem is fixed.

Fixes: cleanup aa-path-symex and aa-symex

Solves issue:
https://github.com/diffblue/cbmc/issues/576