### PR TITLE
SSS: Call get_language_options from get_goto_model

### DIFF
--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -215,7 +215,7 @@ int goto_analyzer_parse_optionst::doit()
 
   goto_model.set_message_handler(get_message_handler());
 
-  if(goto_model(cmdline.args))
+  if(goto_model(cmdline))
     return 6;
 
   if(process_goto_program(options))

--- a/src/goto-programs/get_goto_model.cpp
+++ b/src/goto-programs/get_goto_model.cpp
@@ -32,8 +32,9 @@ Function: get_goto_modelt::operator()
 
 \*******************************************************************/
 
-bool get_goto_modelt::operator()(const std::vector<std::string> &files)
+bool get_goto_modelt::operator()(const cmdlinet &_cmdline)
 {
+  const std::vector<std::string> &files=_cmdline.args;
   if(files.empty())
   {
     error() << "Please provide a program" << eom;
@@ -92,6 +93,7 @@ bool get_goto_modelt::operator()(const std::vector<std::string> &files)
 
         languaget &language=*lf.language;
         language.set_message_handler(get_message_handler());
+        language.get_language_options(_cmdline);
 
         status() << "Parsing " << filename << eom;
 

--- a/src/goto-programs/get_goto_model.h
+++ b/src/goto-programs/get_goto_model.h
@@ -10,6 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_GOTO_PROGRAMS_GET_GOTO_MODEL_H
 
 #include <util/message.h>
+#include <util/cmdline.h>
 
 #include "goto_model.h"
 
@@ -17,7 +18,7 @@ class get_goto_modelt:public goto_modelt, public messaget
 {
 public:
   get_goto_modelt() : generate_start_function(true) {}
-  bool operator()(const std::vector<std::string> &);
+  bool operator()(const cmdlinet &);
   bool generate_start_function;
 };
 

--- a/src/symex/symex_parse_options.cpp
+++ b/src/symex/symex_parse_options.cpp
@@ -177,7 +177,7 @@ int symex_parse_optionst::doit()
 
   goto_model.set_message_handler(get_message_handler());
 
-  if(goto_model(cmdline.args))
+  if(goto_model(cmdline))
     return 6;
 
   if(process_goto_program(options))


### PR DESCRIPTION
We already have get-language-options in CBMC to configure the Java frontend specifically. Other driver programs that use get-goto-model should call it too.

This belongs upstream too, will create a PR against master for this as well.