### PR TITLE
SSS: Add get-underlying-object utility

### DIFF
--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -236,3 +236,8 @@ if_exprt lift_if(const exprt &src, std::size_t operand_number)
 
   return result;
 }
+
+const exprt &get_underlying_object(const exprt &in)
+{
+  return in.id()!=ID_member ? in : get_underlying_object(in.op0());
+}

--- a/src/util/expr_util.h
+++ b/src/util/expr_util.h
@@ -51,4 +51,6 @@ bool has_subexpr(const exprt &, const irep_idt &);
 /*! lift up an if_exprt one level */
 if_exprt lift_if(const exprt &, std::size_t operand_number);
 
+const exprt &get_underlying_object(const exprt &possible_member);
+
 #endif // CPROVER_UTIL_EXPR_UTIL_H


### PR DESCRIPTION
This looks through member expressions.