### PR TITLE
SSS: Java checkcast: fix stack when check disabled

### DIFF
--- a/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -980,10 +980,11 @@ codet java_bytecode_convert_methodt::convert_instructions(
         c=code_assertt(check);
         c.add_source_location().set_comment("Dynamic cast check");
         c.add_source_location().set_property_class("bad-dynamic-cast");
-        results[0]=op[0];
       }
       else
         c=code_skipt();
+
+      results[0]=op[0];
     }
     else if(statement=="invokedynamic")
     {


### PR DESCRIPTION
The checkcast instruction should always return the pointer it checked, even when we're not generating an assert in the case that it failed.

Will make an upstream version of this since it's a fix.