### PR TITLE
SSS: Call graph utilities

### DIFF
--- a/src/analyses/call_graph.cpp
+++ b/src/analyses/call_graph.cpp
@@ -279,3 +279,42 @@ bool  exists_direct_or_indirect_call(
   std::unordered_set<irep_idt,dstring_hash>  ignored;
   return exists_direct_or_indirect_call(call_graph,caller,callee,ignored);
 }
+
+void compute_inverted_call_graph(
+    call_grapht const&  original_call_graph,
+    call_grapht&  output_inverted_call_graph
+    )
+{
+  assert(output_inverted_call_graph.graph.empty());
+  for (auto const&  elem : original_call_graph.graph)
+    output_inverted_call_graph.add(elem.second,elem.first);
+}
+
+void find_leaves_bellow_function(
+    call_grapht const&  call_graph,
+    irep_idt const&  function,
+    std::unordered_set<irep_idt,dstring_hash>&  to_avoid,
+    std::unordered_set<irep_idt,dstring_hash>&  output
+    )
+{
+  if (to_avoid.count(function) != 0UL)
+    return;
+  to_avoid.insert(function);
+  call_grapht::call_edges_ranget const  range =
+      call_graph.out_edges(function);
+  if (range.first == range.second)
+    output.insert(function);
+  else
+    for (auto  it = range.first; it != range.second; ++it)
+      find_leaves_bellow_function(call_graph,it->second,to_avoid,output);
+}
+
+void find_leaves_bellow_function(
+    call_grapht const&  call_graph,
+    irep_idt const&  function,
+    std::unordered_set<irep_idt,dstring_hash>&  output
+    )
+{
+  std::unordered_set<irep_idt,dstring_hash>  to_avoid;
+  find_leaves_bellow_function(call_graph,function,to_avoid,output);
+}

--- a/src/analyses/call_graph.cpp
+++ b/src/analyses/call_graph.cpp
@@ -230,3 +230,52 @@ void get_inverted_topological_order(
       processed,
       output);
 }
+
+bool  exists_direct_call(
+    call_grapht const&  call_graph,
+    irep_idt const&  caller,
+    irep_idt const&  callee
+    )
+{
+  call_grapht::call_edges_ranget const  range =
+      call_graph.out_edges(caller);
+  for (auto  it = range.first; it != range.second; ++it)
+    if (callee == it->second)
+      return true;
+  return false;
+}
+
+bool  exists_direct_or_indirect_call(
+    call_grapht const&  call_graph,
+    irep_idt const&  caller,
+    irep_idt const&  callee,
+    std::unordered_set<irep_idt,dstring_hash>&  ignored_functions
+    )
+{
+  if (ignored_functions.count(caller) != 0UL)
+    return false;
+  ignored_functions.insert(caller);
+  if (exists_direct_call(call_graph,caller,callee))
+    return ignored_functions.count(callee) == 0UL;
+  call_grapht::call_edges_ranget const  range =
+      call_graph.out_edges(caller);
+  for (auto  it = range.first; it != range.second; ++it)
+    if (exists_direct_or_indirect_call(
+          call_graph,
+          it->second,
+          callee,
+          ignored_functions
+          ))
+      return true;
+  return false;
+}
+
+bool  exists_direct_or_indirect_call(
+    call_grapht const&  call_graph,
+    irep_idt const&  caller,
+    irep_idt const&  callee
+    )
+{
+  std::unordered_set<irep_idt,dstring_hash>  ignored;
+  return exists_direct_or_indirect_call(call_graph,caller,callee,ignored);
+}

--- a/src/analyses/call_graph.cpp
+++ b/src/analyses/call_graph.cpp
@@ -216,3 +216,17 @@ void  inverted_partial_topological_order(
           );
   output.push_back(start_function);
 }
+
+void get_inverted_topological_order(
+  call_grapht const& call_graph,
+  goto_functionst const& functions,
+  std::vector<irep_idt>& output)
+{
+  std::unordered_set<irep_idt,dstring_hash>  processed;
+  for (auto const&  elem : functions.function_map)
+    inverted_partial_topological_order(
+      call_graph,
+      elem.first,
+      processed,
+      output);
+}

--- a/src/analyses/call_graph.cpp
+++ b/src/analyses/call_graph.cpp
@@ -123,12 +123,11 @@ void call_grapht::output_dot(std::ostream &out) const
 
 
 void call_grapht::output_dot(
-    goto_functionst const&  functions,
-    std::ostream &out
-    ) const
+  goto_functionst const &functions,
+  std::ostream &out) const
 {
   out << "digraph call_graph {\n";
-  for (auto const&  elem : functions.function_map)
+  for(auto const &elem : functions.function_map)
     out << "  \"" << elem.first << "\";\n";
   for(grapht::const_iterator it=graph.begin();
       it!=graph.end();
@@ -189,31 +188,29 @@ void call_grapht::output_xml(std::ostream &out) const
 
 
 call_grapht::call_edges_ranget
-call_grapht::out_edges(irep_idt const&  caller) const
+call_grapht::out_edges(irep_idt const &caller) const
 {
   return graph.equal_range(caller);
 }
 
 
 void  inverted_partial_topological_order(
-    call_grapht const&  call_graph,
-    irep_idt const&  start_function,
-    std::unordered_set<irep_idt,dstring_hash>&  processed_functions,
-    std::vector<irep_idt>&  output
-    )
+  call_grapht const &call_graph,
+  irep_idt const &start_function,
+  std::unordered_set<irep_idt, dstring_hash> &processed_functions,
+  std::vector<irep_idt> &output)
 {
-  if (processed_functions.count(start_function) != 0ULL)
+  if(processed_functions.count(start_function) != 0ULL)
     return;
   processed_functions.insert(start_function);
   call_grapht::call_edges_ranget const  range =
-      call_graph.out_edges(start_function);
-  for (auto  it = range.first; it != range.second; ++it)
+    call_graph.out_edges(start_function);
+  for(auto  it = range.first; it != range.second; ++it)
     inverted_partial_topological_order(
-          call_graph,
-          it->second,
-          processed_functions,
-          output
-          );
+      call_graph,
+      it->second,
+      processed_functions,
+      output);
   output.push_back(start_function);
 }
 
@@ -222,8 +219,8 @@ void get_inverted_topological_order(
   goto_functionst const& functions,
   std::vector<irep_idt>& output)
 {
-  std::unordered_set<irep_idt,dstring_hash>  processed;
-  for (auto const&  elem : functions.function_map)
+  std::unordered_set<irep_idt, dstring_hash>  processed;
+  for(auto const &elem : functions.function_map)
     inverted_partial_topological_order(
       call_graph,
       elem.first,
@@ -231,90 +228,85 @@ void get_inverted_topological_order(
       output);
 }
 
-bool  exists_direct_call(
-    call_grapht const&  call_graph,
-    irep_idt const&  caller,
-    irep_idt const&  callee
-    )
+bool exists_direct_call(
+  call_grapht const &call_graph,
+  irep_idt const &caller,
+  irep_idt const &callee)
 {
   call_grapht::call_edges_ranget const  range =
-      call_graph.out_edges(caller);
-  for (auto  it = range.first; it != range.second; ++it)
-    if (callee == it->second)
+    call_graph.out_edges(caller);
+  for(auto  it = range.first; it != range.second; ++it)
+    if(callee == it->second)
       return true;
   return false;
 }
 
-bool  exists_direct_or_indirect_call(
-    call_grapht const&  call_graph,
-    irep_idt const&  caller,
-    irep_idt const&  callee,
-    std::unordered_set<irep_idt,dstring_hash>&  ignored_functions
-    )
+bool exists_direct_or_indirect_call(
+  call_grapht const &call_graph,
+  irep_idt const &caller,
+  irep_idt const &callee,
+  std::unordered_set<irep_idt, dstring_hash> &ignored_functions)
 {
-  if (ignored_functions.count(caller) != 0UL)
+  if(ignored_functions.count(caller) != 0UL)
     return false;
   ignored_functions.insert(caller);
-  if (exists_direct_call(call_graph,caller,callee))
+  if(exists_direct_call(call_graph, caller, callee))
     return ignored_functions.count(callee) == 0UL;
   call_grapht::call_edges_ranget const  range =
-      call_graph.out_edges(caller);
-  for (auto  it = range.first; it != range.second; ++it)
-    if (exists_direct_or_indirect_call(
+    call_graph.out_edges(caller);
+  for(auto  it = range.first; it != range.second; ++it)
+    if(exists_direct_or_indirect_call(
           call_graph,
           it->second,
           callee,
-          ignored_functions
-          ))
+          ignored_functions))
       return true;
   return false;
 }
 
-bool  exists_direct_or_indirect_call(
-    call_grapht const&  call_graph,
-    irep_idt const&  caller,
-    irep_idt const&  callee
-    )
+bool exists_direct_or_indirect_call(
+  call_grapht const &call_graph,
+  irep_idt const &caller,
+  irep_idt const &callee)
 {
-  std::unordered_set<irep_idt,dstring_hash>  ignored;
-  return exists_direct_or_indirect_call(call_graph,caller,callee,ignored);
+  std::unordered_set<irep_idt, dstring_hash>  ignored;
+  return exists_direct_or_indirect_call(call_graph, caller, callee, ignored);
 }
 
 void compute_inverted_call_graph(
-    call_grapht const&  original_call_graph,
-    call_grapht&  output_inverted_call_graph
-    )
+  call_grapht const &original_call_graph,
+  call_grapht &output_inverted_call_graph)
 {
   assert(output_inverted_call_graph.graph.empty());
-  for (auto const&  elem : original_call_graph.graph)
-    output_inverted_call_graph.add(elem.second,elem.first);
+  for(auto const &elem : original_call_graph.graph)
+    output_inverted_call_graph.add(elem.second, elem.first);
 }
 
 void find_leaves_bellow_function(
-    call_grapht const&  call_graph,
-    irep_idt const&  function,
-    std::unordered_set<irep_idt,dstring_hash>&  to_avoid,
-    std::unordered_set<irep_idt,dstring_hash>&  output
-    )
+  call_grapht const &call_graph,
+  irep_idt const &function,
+  std::unordered_set<irep_idt, dstring_hash> &to_avoid,
+  std::unordered_set<irep_idt, dstring_hash> &output)
 {
-  if (to_avoid.count(function) != 0UL)
+  if(to_avoid.count(function) != 0UL)
     return;
   to_avoid.insert(function);
   call_grapht::call_edges_ranget const  range =
-      call_graph.out_edges(function);
-  if (range.first == range.second)
+    call_graph.out_edges(function);
+  if(range.first == range.second)
     output.insert(function);
   else
-    for (auto  it = range.first; it != range.second; ++it)
-      find_leaves_bellow_function(call_graph,it->second,to_avoid,output);
+  {
+    for(auto  it = range.first; it != range.second; ++it)
+      find_leaves_bellow_function(call_graph, it->second, to_avoid, output);
+  }
 }
 
-void find_leaves_bellow_function(
-    call_grapht const&  call_graph,
-    irep_idt const&  function,
-    std::unordered_set<irep_idt,dstring_hash>&  output
-    )
+void find_leaves_below_function(
+  call_grapht const &call_graph,
+  irep_idt const &function,
+  std::unordered_set<irep_idt, dstring_hash> &output)
 {
-  std::unordered_set<irep_idt,dstring_hash>  to_avoid;
-  find_leaves_bellow_function(call_graph,function,to_avoid,output);
+  std::unordered_set<irep_idt, dstring_hash> to_avoid;
+  find_leaves_bellow_function(call_graph, function, to_avoid, output);
 }

--- a/src/analyses/call_graph.cpp
+++ b/src/analyses/call_graph.cpp
@@ -123,11 +123,11 @@ void call_grapht::output_dot(std::ostream &out) const
 
 
 void call_grapht::output_dot(
-  goto_functionst const &functions,
+  const goto_functionst &functions,
   std::ostream &out) const
 {
   out << "digraph call_graph {\n";
-  for(auto const &elem : functions.function_map)
+  for(const auto &elem : functions.function_map)
     out << "  \"" << elem.first << "\";\n";
   for(grapht::const_iterator it=graph.begin();
       it!=graph.end();
@@ -186,26 +186,52 @@ void call_grapht::output_xml(std::ostream &out) const
   }
 }
 
+/*******************************************************************\
+
+Function: call_grapht::out_edges
+
+  Inputs: `caller`: node to search for
+
+ Outputs: Returns list of edges whose first component is `caller`.
+
+ Purpose:
+
+\*******************************************************************/
 
 call_grapht::call_edges_ranget
-call_grapht::out_edges(irep_idt const &caller) const
+call_grapht::out_edges(const irep_idt &caller) const
 {
   return graph.equal_range(caller);
 }
 
+/*******************************************************************\
 
-void  inverted_partial_topological_order(
-  call_grapht const &call_graph,
-  irep_idt const &start_function,
+Function: inverted_partial_topological_order
+
+  Inputs: `call_graph`: Call graph
+          `start_function`: start node, must occur in call graph
+          `processed_functions`: set of functions already seen
+
+ Outputs: `output`: inverted topological sort of the graph reachable
+            from start node (i.e. leaves first, root last)
+          `processed_functions`: set of functions already seen
+
+ Purpose: Get reverse-top-sorted subgraph
+
+\*******************************************************************/
+
+void inverted_partial_topological_order(
+  const call_grapht &call_graph,
+  const irep_idt &start_function,
   std::unordered_set<irep_idt, dstring_hash> &processed_functions,
   std::vector<irep_idt> &output)
 {
-  if(processed_functions.count(start_function) != 0ULL)
+  if(processed_functions.count(start_function)!=0ULL)
     return;
   processed_functions.insert(start_function);
-  call_grapht::call_edges_ranget const  range =
+  const call_grapht::call_edges_ranget range =
     call_graph.out_edges(start_function);
-  for(auto  it = range.first; it != range.second; ++it)
+  for(auto it=range.first; it!=range.second; ++it)
     inverted_partial_topological_order(
       call_graph,
       it->second,
@@ -214,13 +240,29 @@ void  inverted_partial_topological_order(
   output.push_back(start_function);
 }
 
+/*******************************************************************\
+
+Function: get_inverted_topological_order
+
+  Inputs: `call_graph`: Call graph
+          `functions`: map containing all functions of interest;
+            only function names are used to index into call graph;
+            function bodies are ignored.
+
+ Outputs: `output`: inverted topological sort of the graph reachable
+            from start node (i.e. leaves first, root last)
+
+ Purpose: Get reverse-top-sorted call graph
+
+\*******************************************************************/
+
 void get_inverted_topological_order(
-  call_grapht const& call_graph,
-  goto_functionst const& functions,
+  const call_grapht& call_graph,
+  const goto_functionst& functions,
   std::vector<irep_idt>& output)
 {
-  std::unordered_set<irep_idt, dstring_hash>  processed;
-  for(auto const &elem : functions.function_map)
+  std::unordered_set<irep_idt, dstring_hash> processed;
+  for(const auto &elem : functions.function_map)
     inverted_partial_topological_order(
       call_graph,
       elem.first,
@@ -228,85 +270,176 @@ void get_inverted_topological_order(
       output);
 }
 
+/*******************************************************************\
+
+Function: exists_direct_call
+
+  Inputs: `call_graph`: Call graph
+          `caller`: Caller
+          `callee`: Potential callee
+
+ Outputs: Returns true if call graph says caller calls callee.
+
+ Purpose: See output
+
+\*******************************************************************/
+
+
 bool exists_direct_call(
-  call_grapht const &call_graph,
-  irep_idt const &caller,
-  irep_idt const &callee)
+  const call_grapht &call_graph,
+  const irep_idt &caller,
+  const irep_idt &callee)
 {
-  call_grapht::call_edges_ranget const  range =
+  const call_grapht::call_edges_ranget range =
     call_graph.out_edges(caller);
-  for(auto  it = range.first; it != range.second; ++it)
-    if(callee == it->second)
+  for(auto it=range.first; it!=range.second; ++it)
+    if(callee==it->second)
       return true;
   return false;
 }
 
+/*******************************************************************\
+
+Function: exists_direct_or_indirect_call
+
+  Inputs: `call_graph`: Call graph
+          `caller`: Caller
+          `callee`: Potential callee
+          `ignored_functions`: Functions to exclude from call graph
+            for the purposes of finding a path
+
+ Outputs: Returns true if call graph says caller can reach callee
+          via any intermediate sequence of callees not occurring
+          in ignored_functions
+
+ Purpose: See output
+
+\*******************************************************************/
+
 bool exists_direct_or_indirect_call(
-  call_grapht const &call_graph,
-  irep_idt const &caller,
-  irep_idt const &callee,
+  const call_grapht &call_graph,
+  const irep_idt &caller,
+  const irep_idt &callee,
   std::unordered_set<irep_idt, dstring_hash> &ignored_functions)
 {
-  if(ignored_functions.count(caller) != 0UL)
+  if(ignored_functions.count(caller)!=0UL)
     return false;
   ignored_functions.insert(caller);
   if(exists_direct_call(call_graph, caller, callee))
-    return ignored_functions.count(callee) == 0UL;
-  call_grapht::call_edges_ranget const  range =
+    return ignored_functions.count(callee)==0UL;
+  const call_grapht::call_edges_ranget range=
     call_graph.out_edges(caller);
-  for(auto  it = range.first; it != range.second; ++it)
+  for(auto it=range.first; it!=range.second; ++it)
     if(exists_direct_or_indirect_call(
-          call_graph,
-          it->second,
-          callee,
-          ignored_functions))
+         call_graph,
+         it->second,
+         callee,
+         ignored_functions))
       return true;
   return false;
 }
 
+/*******************************************************************\
+
+Function: exists_direct_or_indirect_call
+
+  Inputs: `call_graph`: Call graph
+          `caller`: Caller
+          `callee`: Potential callee
+
+ Outputs: Returns true if call graph says caller can reach callee
+          via any intermediate sequence of callees
+
+ Purpose: See output
+
+\*******************************************************************/
+
 bool exists_direct_or_indirect_call(
-  call_grapht const &call_graph,
-  irep_idt const &caller,
-  irep_idt const &callee)
+  const call_grapht &call_graph,
+  const irep_idt &caller,
+  const irep_idt &callee)
 {
   std::unordered_set<irep_idt, dstring_hash>  ignored;
   return exists_direct_or_indirect_call(call_graph, caller, callee, ignored);
 }
 
+/*******************************************************************\
+
+Function: computed_inverted_call_graph
+
+  Inputs: `original_call_graph`: call graph
+
+ Outputs: `output_inverted_call_graph`: input call graph with caller->
+   callee edges reversed.
+
+ Purpose: See output
+
+\*******************************************************************/
+
 void compute_inverted_call_graph(
-  call_grapht const &original_call_graph,
+  const call_grapht &original_call_graph,
   call_grapht &output_inverted_call_graph)
 {
   assert(output_inverted_call_graph.graph.empty());
-  for(auto const &elem : original_call_graph.graph)
+  for(const auto &elem : original_call_graph.graph)
     output_inverted_call_graph.add(elem.second, elem.first);
 }
 
-void find_leaves_bellow_function(
-  call_grapht const &call_graph,
-  irep_idt const &function,
+/*******************************************************************\
+
+Function: find_leaves_below_function
+
+  Inputs: `call_graph`: call graph
+          `function`: start node
+          `to_avoid`: functions already visited
+
+ Outputs: `output`: set of leaves reachable from 'function'
+          `to_avoid`: functions already visited (with 'function'
+            added)
+
+ Purpose: See output
+
+\*******************************************************************/
+
+
+void find_leaves_below_function(
+  const call_grapht &call_graph,
+  const irep_idt &function,
   std::unordered_set<irep_idt, dstring_hash> &to_avoid,
   std::unordered_set<irep_idt, dstring_hash> &output)
 {
-  if(to_avoid.count(function) != 0UL)
+  if(to_avoid.count(function)!=0UL)
     return;
   to_avoid.insert(function);
-  call_grapht::call_edges_ranget const  range =
+  const call_grapht::call_edges_ranget range =
     call_graph.out_edges(function);
-  if(range.first == range.second)
+  if(range.first==range.second)
     output.insert(function);
   else
   {
-    for(auto  it = range.first; it != range.second; ++it)
-      find_leaves_bellow_function(call_graph, it->second, to_avoid, output);
+    for(auto it=range.first; it!=range.second; ++it)
+      find_leaves_below_function(call_graph, it->second, to_avoid, output);
   }
 }
 
+/*******************************************************************\
+
+Function: find_leaves_below_function
+
+  Inputs: `call_graph`: call graph
+          `function`: start node
+
+ Outputs: `output`: set of leaves reachable from 'function'
+
+ Purpose: See output
+
+\*******************************************************************/
+
 void find_leaves_below_function(
-  call_grapht const &call_graph,
-  irep_idt const &function,
+  const call_grapht &call_graph,
+  const irep_idt &function,
   std::unordered_set<irep_idt, dstring_hash> &output)
 {
   std::unordered_set<irep_idt, dstring_hash> to_avoid;
-  find_leaves_bellow_function(call_graph, function, to_avoid, output);
+  find_leaves_below_function(call_graph, function, to_avoid, output);
 }

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -51,13 +51,14 @@ public:
    * function. So, an iterator to any such element is actually an iterator to
    * an edge of the call graph.
    */
-  typedef grapht::const_iterator  call_edge_iteratort;
+  typedef grapht::const_iterator call_edge_iteratort;
 
   /**
    * Since a call graph is implemented as a multimap, we use ranges
    * of call graph edges to represent out-edges from a node (a function)
    */
-  typedef std::pair<call_edge_iteratort,call_edge_iteratort>  call_edges_ranget;
+  typedef
+    std::pair<call_edge_iteratort, call_edge_iteratort> call_edges_ranget;
 
   /**
    * It returns a range of edges represented by a pair of iterators. The
@@ -105,12 +106,12 @@ Typical usage:
  // Let's assume there is 'goto_modelt GM' and 'call_grapht CG'
  std::vector<irep_idt>  result; // Here we will store the topological order.
  {
-   std::unordered_set<irep_idt,dstring_hash>  processed;
+   std::unordered_set<irep_idt, dstring_hash>  processed;
    for (auto const&  elem : GM.goto_functions.function_map)
-     partial_topological_order(CG,elem.first,processed,result);
+     partial_topological_order(CG, elem.first, processed, result);
    // Now we reverse the result to get the classic (partial)
    // topological order instead of the inverted one.
-   std::reverse(result.begin(),result.end());
+   std::reverse(result.begin(), result.end());
  }
  std::cout << "A (partial) topological order of my call graph is: ";
  for (irep_idt const&  fn_name : result)
@@ -118,11 +119,10 @@ Typical usage:
 
 \*******************************************************************/
 void  inverted_partial_topological_order(
-    call_grapht const&  call_graph,
-    irep_idt const&  start_function,
-    std::unordered_set<irep_idt,dstring_hash>&  processed_functions,
-    std::vector<irep_idt>&  output
-    );
+  call_grapht const &call_graph,
+  irep_idt const &start_function,
+  std::unordered_set<irep_idt, dstring_hash> &processed_functions,
+  std::vector<irep_idt> &output);
 
 void get_inverted_topological_order(
   call_grapht const& call_graph,
@@ -130,40 +130,34 @@ void get_inverted_topological_order(
   std::vector<irep_idt>& output);
 
 bool  exists_direct_call(
-    call_grapht const&  call_graph,
-    irep_idt const&  caller,
-    irep_idt const&  callee
-    );
+  call_grapht const &call_graph,
+  irep_idt const &caller,
+  irep_idt const &callee);
 
 bool  exists_direct_or_indirect_call(
-    call_grapht const&  call_graph,
-    irep_idt const&  caller,
-    irep_idt const&  callee,
-    std::unordered_set<irep_idt,dstring_hash>&  ignored_functions
-    );
+  call_grapht const &call_graph,
+  irep_idt const &caller,
+  irep_idt const &callee,
+  std::unordered_set<irep_idt, dstring_hash> &ignored_functions);
 
 bool  exists_direct_or_indirect_call(
-    call_grapht const&  call_graph,
-    irep_idt const&  caller,
-    irep_idt const&  callee
-    );
+  call_grapht const &call_graph,
+  irep_idt const &caller,
+  irep_idt const &callee);
 
 void compute_inverted_call_graph(
-    call_grapht const&  original_call_graph,
-    call_grapht&  output_inverted_call_graph
-    );
+  call_grapht const &original_call_graph,
+  call_grapht &output_inverted_call_graph);
 
-void find_leaves_bellow_function(
-    call_grapht const&  call_graph,
-    irep_idt const&  function,
-    std::unordered_set<irep_idt,dstring_hash>&  to_avoid,
-    std::unordered_set<irep_idt,dstring_hash>&  output
-    );
+void find_leaves_below_function(
+  call_grapht const &call_graph,
+  irep_idt const &function,
+  std::unordered_set<irep_idt, dstring_hash> &to_avoid,
+  std::unordered_set<irep_idt, dstring_hash> &output);
 
-void find_leaves_bellow_function(
-    call_grapht const&  call_graph,
-    irep_idt const&  function,
-    std::unordered_set<irep_idt,dstring_hash>&  output
-    );
+void find_leaves_below_function(
+  call_grapht const &call_graph,
+  irep_idt const &function,
+  std::unordered_set<irep_idt, dstring_hash> &output);
 
 #endif // CPROVER_ANALYSES_CALL_GRAPH_H

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -119,4 +119,24 @@ void get_inverted_topological_order(
   goto_functionst const& functions,
   std::vector<irep_idt>& output);
 
+bool  exists_direct_call(
+    call_grapht const&  call_graph,
+    irep_idt const&  caller,
+    irep_idt const&  callee
+    );
+
+bool  exists_direct_or_indirect_call(
+    call_grapht const&  call_graph,
+    irep_idt const&  caller,
+    irep_idt const&  callee,
+    std::unordered_set<irep_idt,dstring_hash>&  ignored_functions
+    );
+
+bool  exists_direct_or_indirect_call(
+    call_grapht const&  call_graph,
+    irep_idt const&  caller,
+    irep_idt const&  callee
+    );
+
+
 #endif // CPROVER_ANALYSES_CALL_GRAPH_H

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -75,38 +75,48 @@ public:
   call_edges_ranget  out_edges(irep_idt const&  caller) const;
 };
 
-/**
- * For DAG call graphs it computes an inverted topological order of all
- * functions in the call graph. Otherwise, it computes only a partial
- * inverted topological order (all loops are broken at some (randomly)
- * chosen edge to get a DAG). The topolocical order is stored in the
- * 'output' vector.
- *
- * Since the algorithm is implemented using DFS, those 'breaks' are
- * implemented naturally by a set of processed (vidited) functions.
- *
- * The function actually performs only one DFS from a passed 'start_function'.
- * So, to get whole inverted (partial) topological order of all functions in
- * the call graph, this function has to be called for all functions in the
- * program.
- *
- * NOTE: The order is 'inverted'. It means that
- *
- * Typical usage:
- *  // Let's assume there is 'goto_modelt GM' and 'call_grapht CG'
- *  std::vector<irep_idt>  result; // Here we will store the topological order.
- *  {
- *    std::unordered_set<irep_idt,dstring_hash>  processed;
- *    for (auto const&  elem : GM.goto_functions.function_map)
- *      partial_topological_order(CG,elem.first,processed,result);
- *    // Now we reverse the result to get the classic (partial)
- *    // topological order instead of the inverted one.
- *    std::reverse(result.begin(),result.end());
- *  }
- *  std::cout << "A (partial) topological order of my call graph is: ";
- *  for (irep_idt const&  fn_name : result)
- *    std::cout << fn_name << ", ";
- */
+/*******************************************************************\
+
+Function: inverted_partial_topological_order
+
+  Inputs: See purpose
+
+ Outputs: See purpose
+
+ Purpose:
+
+For DAG call graphs it computes an inverted topological order of all
+functions in the call graph. Otherwise, it computes only a partial
+inverted topological order (all loops are broken at some (randomly)
+chosen edge to get a DAG). The topolocical order is stored in the
+'output' vector.
+
+Since the algorithm is implemented using DFS, those 'breaks' are
+implemented naturally by a set of processed (vidited) functions.
+
+The function actually performs only one DFS from a passed 'start_function'.
+So, to get whole inverted (partial) topological order of all functions in
+the call graph, this function has to be called for all functions in the
+program.
+
+NOTE: The order is 'inverted'. It means that
+
+Typical usage:
+ // Let's assume there is 'goto_modelt GM' and 'call_grapht CG'
+ std::vector<irep_idt>  result; // Here we will store the topological order.
+ {
+   std::unordered_set<irep_idt,dstring_hash>  processed;
+   for (auto const&  elem : GM.goto_functions.function_map)
+     partial_topological_order(CG,elem.first,processed,result);
+   // Now we reverse the result to get the classic (partial)
+   // topological order instead of the inverted one.
+   std::reverse(result.begin(),result.end());
+ }
+ std::cout << "A (partial) topological order of my call graph is: ";
+ for (irep_idt const&  fn_name : result)
+   std::cout << fn_name << ", ";
+
+\*******************************************************************/
 void  inverted_partial_topological_order(
     call_grapht const&  call_graph,
     irep_idt const&  start_function,

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -138,5 +138,22 @@ bool  exists_direct_or_indirect_call(
     irep_idt const&  callee
     );
 
+void compute_inverted_call_graph(
+    call_grapht const&  original_call_graph,
+    call_grapht&  output_inverted_call_graph
+    );
+
+void find_leaves_bellow_function(
+    call_grapht const&  call_graph,
+    irep_idt const&  function,
+    std::unordered_set<irep_idt,dstring_hash>&  to_avoid,
+    std::unordered_set<irep_idt,dstring_hash>&  output
+    );
+
+void find_leaves_bellow_function(
+    call_grapht const&  call_graph,
+    irep_idt const&  function,
+    std::unordered_set<irep_idt,dstring_hash>&  output
+    );
 
 #endif // CPROVER_ANALYSES_CALL_GRAPH_H

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -30,7 +30,7 @@ public:
    * store funtions (nodes). It only stores edges (from caller to callee).
    * So, the resulting graph would not show not-called functions.
    */
-  void output_dot(goto_functionst const&  functions, std::ostream &out) const;
+  void output_dot(const goto_functionst &functions, std::ostream &out) const;
 
   void output(std::ostream &out) const;
   void output_xml(std::ostream &out) const;
@@ -66,14 +66,14 @@ public:
    * iterator the end of the range (that edge does NOT belong to the range).
    *
    * Usage:
-   *  irep_idt const  caller_name = "foo";
-   *  call_grapht::call_edges_ranget const  range =
+   *  const irep_idt caller_name = "foo";
+   *  const call_grapht::call_edges_ranget range =
    *      my_call_graph.out_edges(caller_name);
    *  std::cout << "Callees of " << caller_name << " are: ";
-   *  for (auto  it = range.first; it != range.second; ++it)
+   *  for (auto it = range.first; it != range.second; ++it)
    *    std::cout << it->second << ", ";
    */
-  call_edges_ranget  out_edges(irep_idt const&  caller) const;
+  call_edges_ranget out_edges(const irep_idt &caller) const;
 };
 
 /*******************************************************************\
@@ -107,57 +107,57 @@ Typical usage:
  std::vector<irep_idt>  result; // Here we will store the topological order.
  {
    std::unordered_set<irep_idt, dstring_hash>  processed;
-   for (auto const&  elem : GM.goto_functions.function_map)
+   for (const auto &elem : GM.goto_functions.function_map)
      partial_topological_order(CG, elem.first, processed, result);
    // Now we reverse the result to get the classic (partial)
    // topological order instead of the inverted one.
    std::reverse(result.begin(), result.end());
  }
  std::cout << "A (partial) topological order of my call graph is: ";
- for (irep_idt const&  fn_name : result)
+ for (const irep_idt &fn_name : result)
    std::cout << fn_name << ", ";
 
 \*******************************************************************/
-void  inverted_partial_topological_order(
-  call_grapht const &call_graph,
-  irep_idt const &start_function,
+void inverted_partial_topological_order(
+  const call_grapht &call_graph,
+  const irep_idt &start_function,
   std::unordered_set<irep_idt, dstring_hash> &processed_functions,
   std::vector<irep_idt> &output);
 
 void get_inverted_topological_order(
-  call_grapht const& call_graph,
-  goto_functionst const& functions,
-  std::vector<irep_idt>& output);
+  const call_grapht &call_graph,
+  const goto_functionst &functions,
+  std::vector<irep_idt> &output);
 
-bool  exists_direct_call(
-  call_grapht const &call_graph,
-  irep_idt const &caller,
-  irep_idt const &callee);
+bool exists_direct_call(
+  const call_grapht &call_graph,
+  const irep_idt &caller,
+  const irep_idt &callee);
 
-bool  exists_direct_or_indirect_call(
-  call_grapht const &call_graph,
-  irep_idt const &caller,
-  irep_idt const &callee,
+bool exists_direct_or_indirect_call(
+  const call_grapht &call_graph,
+  const irep_idt &caller,
+  const irep_idt &callee,
   std::unordered_set<irep_idt, dstring_hash> &ignored_functions);
 
-bool  exists_direct_or_indirect_call(
-  call_grapht const &call_graph,
-  irep_idt const &caller,
-  irep_idt const &callee);
+bool exists_direct_or_indirect_call(
+  const call_grapht &call_graph,
+  const irep_idt &caller,
+  const irep_idt &callee);
 
 void compute_inverted_call_graph(
-  call_grapht const &original_call_graph,
+  const call_grapht &original_call_graph,
   call_grapht &output_inverted_call_graph);
 
 void find_leaves_below_function(
-  call_grapht const &call_graph,
-  irep_idt const &function,
+  const call_grapht &call_graph,
+  const irep_idt &function,
   std::unordered_set<irep_idt, dstring_hash> &to_avoid,
   std::unordered_set<irep_idt, dstring_hash> &output);
 
 void find_leaves_below_function(
-  call_grapht const &call_graph,
-  irep_idt const &function,
+  const call_grapht &call_graph,
+  const irep_idt &function,
   std::unordered_set<irep_idt, dstring_hash> &output);
 
 #endif // CPROVER_ANALYSES_CALL_GRAPH_H

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -114,5 +114,9 @@ void  inverted_partial_topological_order(
     std::vector<irep_idt>&  output
     );
 
+void get_inverted_topological_order(
+  call_grapht const& call_graph,
+  goto_functionst const& functions,
+  std::vector<irep_idt>& output);
 
 #endif // CPROVER_ANALYSES_CALL_GRAPH_H

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -11,6 +11,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <iosfwd>
 #include <map>
+#include <vector>
+#include <unordered_set>
 
 #include <goto-programs/goto_functions.h>
 
@@ -21,6 +23,15 @@ public:
   explicit call_grapht(const goto_functionst &);
 
   void output_dot(std::ostream &out) const;
+
+  /**
+   * It writes this into the passed stream in the Graphviz's DOT format.
+   * The method accepts also functions, because the callgraph does not
+   * store funtions (nodes). It only stores edges (from caller to callee).
+   * So, the resulting graph would not show not-called functions.
+   */
+  void output_dot(goto_functionst const&  functions, std::ostream &out) const;
+
   void output(std::ostream &out) const;
   void output_xml(std::ostream &out) const;
 
@@ -32,6 +43,76 @@ public:
 protected:
   void add(const irep_idt &function,
            const goto_programt &body);
+
+public:
+  /**
+   * Each element of the call graph is a pair where the first element is a
+   * name of a caller function and the second element is the name of a called
+   * function. So, an iterator to any such element is actually an iterator to
+   * an edge of the call graph.
+   */
+  typedef grapht::const_iterator  call_edge_iteratort;
+
+  /**
+   * Since a call graph is implemented as a multimap, we use ranges
+   * of call graph edges to represent out-edges from a node (a function)
+   */
+  typedef std::pair<call_edge_iteratort,call_edge_iteratort>  call_edges_ranget;
+
+  /**
+   * It returns a range of edges represented by a pair of iterators. The
+   * first iterator refers to the first edge in the range and the second
+   * iterator the end of the range (that edge does NOT belong to the range).
+   *
+   * Usage:
+   *  irep_idt const  caller_name = "foo";
+   *  call_grapht::call_edges_ranget const  range =
+   *      my_call_graph.out_edges(caller_name);
+   *  std::cout << "Callees of " << caller_name << " are: ";
+   *  for (auto  it = range.first; it != range.second; ++it)
+   *    std::cout << it->second << ", ";
+   */
+  call_edges_ranget  out_edges(irep_idt const&  caller) const;
 };
+
+/**
+ * For DAG call graphs it computes an inverted topological order of all
+ * functions in the call graph. Otherwise, it computes only a partial
+ * inverted topological order (all loops are broken at some (randomly)
+ * chosen edge to get a DAG). The topolocical order is stored in the
+ * 'output' vector.
+ *
+ * Since the algorithm is implemented using DFS, those 'breaks' are
+ * implemented naturally by a set of processed (vidited) functions.
+ *
+ * The function actually performs only one DFS from a passed 'start_function'.
+ * So, to get whole inverted (partial) topological order of all functions in
+ * the call graph, this function has to be called for all functions in the
+ * program.
+ *
+ * NOTE: The order is 'inverted'. It means that
+ *
+ * Typical usage:
+ *  // Let's assume there is 'goto_modelt GM' and 'call_grapht CG'
+ *  std::vector<irep_idt>  result; // Here we will store the topological order.
+ *  {
+ *    std::unordered_set<irep_idt,dstring_hash>  processed;
+ *    for (auto const&  elem : GM.goto_functions.function_map)
+ *      partial_topological_order(CG,elem.first,processed,result);
+ *    // Now we reverse the result to get the classic (partial)
+ *    // topological order instead of the inverted one.
+ *    std::reverse(result.begin(),result.end());
+ *  }
+ *  std::cout << "A (partial) topological order of my call graph is: ";
+ *  for (irep_idt const&  fn_name : result)
+ *    std::cout << fn_name << ", ";
+ */
+void  inverted_partial_topological_order(
+    call_grapht const&  call_graph,
+    irep_idt const&  start_function,
+    std::unordered_set<irep_idt,dstring_hash>&  processed_functions,
+    std::vector<irep_idt>&  output
+    );
+
 
 #endif // CPROVER_ANALYSES_CALL_GRAPH_H


### PR DESCRIPTION
These extend `call_grapht` with some basic is-(transitive)-child and topological sorting functions.