### PR TITLE
SSS: static analysis tweaks

### DIFF
--- a/src/analyses/static_analysis.cpp
+++ b/src/analyses/static_analysis.cpp
@@ -518,19 +518,21 @@ void static_analysis_baset::do_function_call_rec(
     }
     return;
   }
-  
+
   if(function.id()==ID_symbol)
   {
     const irep_idt &identifier=function.get(ID_identifier);
 
-    if(recursion_set.find(identifier)!=recursion_set.end())
+    if(ignore_recursion)
     {
-      // recursion detected!
-      return;
+      if(recursion_set.find(identifier)!=recursion_set.end())
+      {
+        // recursion detected!
+        return;
+      }
+      else
+        recursion_set.insert(identifier);
     }
-    else
-      recursion_set.insert(identifier);
-
     goto_functionst::function_mapt::const_iterator it=
       goto_functions.function_map.find(identifier);
 
@@ -544,7 +546,8 @@ void static_analysis_baset::do_function_call_rec(
       arguments,
       new_state);
 
-    recursion_set.erase(identifier);
+    if(ignore_recursion)
+      recursion_set.erase(identifier);
   }
   else if(function.id()==ID_if)
   {

--- a/src/analyses/static_analysis.cpp
+++ b/src/analyses/static_analysis.cpp
@@ -422,8 +422,12 @@ void static_analysis_baset::do_function_call(
 {
   const goto_functionst::goto_functiont &goto_function=f_it->second;
 
-  if(!goto_function.body_available())
-    return; // do nothing
+  if((!goto_function.body_available()) || !should_enter_function(f_it->first))
+  {
+    // Per default do nothing, but a subclass might transform across the stubbed callsite.
+    transform_function_stub(f_it->first,new_state,l_call,l_return);
+    return;
+  }
 
   assert(!goto_function.body.instructions.empty());
 

--- a/src/analyses/static_analysis.cpp
+++ b/src/analyses/static_analysis.cpp
@@ -172,7 +172,7 @@ void static_analysis_baset::output(
 
     get_state(i_it).output(ns, out);
     out << "\n";
-    #if 0
+    #if 1
     goto_program.output_instruction(ns, identifier, out, i_it);
     out << "\n";
     #endif
@@ -425,8 +425,9 @@ void static_analysis_baset::do_function_call(
 
   if((!goto_function.body_available()) || !should_enter_function(f_it->first))
   {
-    // Per default do nothing, but a subclass might transform across the stubbed callsite.
-    transform_function_stub(f_it->first,new_state,l_call,l_return);
+    // Per default do nothing,
+    // but a subclass might transform across the stubbed callsite.
+    transform_function_stub(f_it->first, new_state, l_call, l_return);
     return;
   }
 
@@ -515,7 +516,13 @@ void static_analysis_baset::do_function_call_rec(
     {
       auto fid=function.get(ID_identifier);
       if(!should_enter_function(fid))
-        transform_function_stub(function.get(ID_identifier),new_state,l_call,l_return);
+      {
+        transform_function_stub(
+          function.get(ID_identifier),
+          new_state,
+          l_call,
+          l_return);
+      }
     }
     return;
   }

--- a/src/analyses/static_analysis.cpp
+++ b/src/analyses/static_analysis.cpp
@@ -509,8 +509,16 @@ void static_analysis_baset::do_function_call_rec(
 {
   // see if we have the functions at all
   if(goto_functions.function_map.empty())
+  {
+    if(function.id()==ID_symbol)
+    {
+      auto fid=function.get(ID_identifier);
+      if(!should_enter_function(fid))
+        transform_function_stub(function.get(ID_identifier),new_state,l_call,l_return);
+    }
     return;
-
+  }
+  
   if(function.id()==ID_symbol)
   {
     const irep_idt &identifier=function.get(ID_identifier);

--- a/src/analyses/static_analysis.cpp
+++ b/src/analyses/static_analysis.cpp
@@ -323,6 +323,7 @@ bool static_analysis_baset::fixedpoint(
 
   while(!working_set.empty())
   {
+    ++nsteps;
     locationt l=get_next(working_set);
 
     if(visit(l, working_set, goto_program, goto_functions))

--- a/src/analyses/static_analysis.h
+++ b/src/analyses/static_analysis.h
@@ -95,6 +95,7 @@ public:
   typedef goto_programt::const_targett locationt;
 
   explicit static_analysis_baset(const namespacet &_ns):
+    nsteps(0),
     ns(_ns),
     initialized(false)
   {
@@ -165,6 +166,8 @@ public:
   // get lhs that return value is assigned to
   // for an edge that returns from a function
   static exprt get_return_lhs(locationt to);
+
+  size_t nsteps;
 
 protected:
   const namespacet &ns;

--- a/src/analyses/static_analysis.h
+++ b/src/analyses/static_analysis.h
@@ -244,6 +244,9 @@ protected:
     const exprt::operandst &arguments,
     statet &new_state);
 
+  virtual bool should_enter_function(const irep_idt&) { return true; }
+  virtual void transform_function_stub(const irep_idt&, statet& state, locationt l_call, locationt l_return) {}
+
   // abstract methods
 
   virtual void generate_state(locationt l)=0;

--- a/src/analyses/static_analysis.h
+++ b/src/analyses/static_analysis.h
@@ -248,8 +248,13 @@ protected:
     const exprt::operandst &arguments,
     statet &new_state);
 
-  virtual bool should_enter_function(const irep_idt&) { return true; }
-  virtual void transform_function_stub(const irep_idt&, statet& state, locationt l_call, locationt l_return) {}
+  virtual bool should_enter_function(const irep_idt &) { return true; }
+  virtual void transform_function_stub(
+    const irep_idt &,
+    statet &state,
+    locationt l_call,
+    locationt l_return)
+  {}
 
   // abstract methods
 
@@ -267,7 +272,6 @@ protected:
 
   bool ignore_recursion;
   virtual bool get_ignore_recursion() { return true; }
-  
 };
 
 // T is expected to be derived from domain_baset

--- a/src/analyses/static_analysis.h
+++ b/src/analyses/static_analysis.h
@@ -98,6 +98,7 @@ public:
     ns(_ns),
     initialized(false)
   {
+    ignore_recursion=get_ignore_recursion();
   }
 
   virtual void initialize(
@@ -260,6 +261,10 @@ protected:
     locationt l,
     const exprt &expr,
     std::list<exprt> &dest)=0;
+
+  bool ignore_recursion;
+  virtual bool get_ignore_recursion() { return true; }
+  
 };
 
 // T is expected to be derived from domain_baset


### PR DESCRIPTION
Static analysis is marked obsolete upstream, but also still the basis for value-set analysis. This adds some basic hooks for a subclass to: (a) provide behaviour at a function stub, (b) get an ordinary callback even on recursive calls, (c) count transform operations. It also enables printing instructions in domain dumps, which matches the replacement `ai.h`'s behaviour.