### PR TITLE
SSS: Add irep IDs

### DIFF
--- a/src/util/irep_ids.txt
+++ b/src/util/irep_ids.txt
@@ -801,3 +801,4 @@ cprover_string_to_lower_case_func
 cprover_string_to_upper_case_func
 cprover_string_trim_func
 cprover_string_value_of_func
+external_value_set external-value-set


### PR DESCRIPTION
Until we figure out an alternative mechanism, it's only really practical for irep IDs to be added in the support branch.