### PR TITLE
SSS: Keep identical structs

### DIFF
--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -261,7 +261,8 @@ bool simplify_exprt::simplify_typecast(exprt &expr)
   }
 
   // eliminate redundant typecasts
-  if(base_type_eq(expr.type(), expr.op0().type(), ns))
+  if((!keep_identical_structs) &&
+     base_type_eq(expr.type(), expr.op0().type(), ns))
   {
     exprt tmp;
     tmp.swap(expr.op0());

--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -38,6 +38,7 @@ class simplify_exprt
 public:
   explicit simplify_exprt(const namespacet &_ns):
     do_simplify_if(true),
+    keep_identical_structs(false),
     ns(_ns)
 #ifdef DEBUG_ON_DEMAND
     , debug_on(false)
@@ -54,6 +55,7 @@ public:
   }
 
   bool do_simplify_if;
+  bool keep_identical_structs;
 
   // These below all return 'true' if the simplification wasn't applicable.
   // If false is returned, the expression has changed.


### PR DESCRIPTION
Normally it will eliminate casts from one struct type to another
if they have like members, but this leads to type errors in
languages like Java where they cannot be used interchangeably
unless they also have a subtype relationship.