### PR TITLE
SSS: Windows build fix

### DIFF
--- a/src/add_shlwapi.inc
+++ b/src/add_shlwapi.inc
@@ -1,0 +1,4 @@
+
+ifeq ($(BUILD_ENV),MSVC)
+  LIBS=shlwapi.lib
+endif

--- a/src/config.inc
+++ b/src/config.inc
@@ -16,6 +16,11 @@ ifeq ($(shell uname),Linux)
   LIBS=-lboost_filesystem -lboost_system
 endif
 
+# On Windows this Makefile is subject to sed s/BUILD_ENV.*/BUILD_ENV = MSVC,
+# so we can't directly test BUILD_ENV here.
+SELF_DIR = $(dir $(lastword $(MAKEFILE_LIST)))
+include $(SELF_DIR)add_shlwapi.inc
+
 # If GLPK is available; this is used by goto-instrument and musketeer.
 #LIB_GLPK = -lglpk
 


### PR DESCRIPTION
This should link shlwapi.dll, fixing the AppVeyor failure currently happening on the SSS branch.