### PR TITLE
remove `<regex>` from unapproved headers in cpplint

### DIFF
--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -6264,7 +6264,6 @@ def FlagCxx11Features(filename, clean_lines, linenum, error):
                                       'thread',
                                       'chrono',
                                       'ratio',
-                                      'regex',
                                       'system_error',
                                      ):
     error(filename, linenum, 'build/c++11', 5,


### PR DESCRIPTION
The reason for `<regex>` being discouraged seems to be a preference for an
external library within Google:

https://github.com/google/styleguide/issues/194