### PR TITLE
Add simple pretty-printer extension mechanism

### DIFF
--- a/src/ansi-c/ansi_c_language.cpp
+++ b/src/ansi-c/ansi_c_language.cpp
@@ -21,6 +21,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "ansi_c_typecheck.h"
 #include "ansi_c_parser.h"
 #include "expr2c.h"
+#include "expr2c_class.h"
 #include "c_preprocess.h"
 #include "ansi_c_internal_additions.h"
 #include "type2name.h"
@@ -281,6 +282,24 @@ bool ansi_c_languaget::from_type(
 {
   code=type2c(type, ns);
   return false;
+}
+
+/*******************************************************************\
+
+Function: ansi_c_languaget::get_pretty_printer
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+std::unique_ptr<pretty_printert>
+ansi_c_languaget::get_pretty_printer(const namespacet &ns)
+{
+  return std::unique_ptr<pretty_printert>(new expr2ct(ns));
 }
 
 /*******************************************************************\

--- a/src/ansi-c/ansi_c_language.h
+++ b/src/ansi-c/ansi_c_language.h
@@ -53,6 +53,9 @@ public:
     std::string &code,
     const namespacet &ns) override;
 
+  std::unique_ptr<pretty_printert>
+    get_pretty_printer(const namespacet &) override;
+
   bool type_to_name(
     const typet &type,
     std::string &name,

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -204,6 +204,7 @@ Function: expr2ct::convert
 
 std::string expr2ct::convert(const typet &src)
 {
+  assert(next_pretty_printer && "Next pretty-printer should be set");
   return convert_rec(src, c_qualifierst(), "");
 }
 
@@ -679,14 +680,7 @@ std::string expr2ct::convert_rec(
     return q+"__attribute__(("+id2string(src.id())+")) void"+d;
   }
 
-  {
-    lispexprt lisp;
-    irep2lisp(src, lisp);
-    std::string dest="irep(\""+MetaString(lisp.expr2string())+"\")";
-    dest+=d;
-
-    return dest;
-  }
+  return next_pretty_printer->convert(src);
 }
 
 /*******************************************************************\
@@ -5009,7 +5003,7 @@ std::string expr2ct::convert(
     return convert(src.type());
 
   // no C language expression for internal representation
-  return convert_norep(src, precedence);
+  return next_pretty_printer->convert(src);
 }
 
 /*******************************************************************\
@@ -5046,7 +5040,9 @@ std::string expr2c(const exprt &expr, const namespacet &ns)
 {
   std::string code;
   expr2ct expr2c(ns);
+  norep_pretty_printert norep;
   expr2c.get_shorthands(expr);
+  expr2c.set_next_pretty_printer(&norep);
   return expr2c.convert(expr);
 }
 
@@ -5065,6 +5061,8 @@ Function: type2c
 std::string type2c(const typet &type, const namespacet &ns)
 {
   expr2ct expr2c(ns);
+  norep_pretty_printert norep;
+  expr2c.set_next_pretty_printer(&norep);
   // expr2c.get_shorthands(expr);
   return expr2c.convert(type);
 }

--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -16,17 +16,19 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/std_code.h>
 #include <util/std_expr.h>
 
+#include <langapi/pretty_printer.h>
+
 class c_qualifierst;
 class namespacet;
 
-class expr2ct
+class expr2ct:public pretty_printert
 {
 public:
   explicit expr2ct(const namespacet &_ns):ns(_ns), sizeof_nesting(0) { }
   virtual ~expr2ct() { }
 
-  virtual std::string convert(const typet &src);
-  virtual std::string convert(const exprt &src);
+  std::string convert(const typet &src) override;
+  std::string convert(const exprt &src) override;
 
   void get_shorthands(const exprt &expr);
 

--- a/src/cpp/cpp_language.cpp
+++ b/src/cpp/cpp_language.cpp
@@ -22,6 +22,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include "cpp_internal_additions.h"
 #include "cpp_language.h"
 #include "expr2cpp.h"
+#include "expr2cpp_class.h"
 #include "cpp_parser.h"
 #include "cpp_typecheck.h"
 #include "cpp_type2name.h"
@@ -358,6 +359,24 @@ bool cpp_languaget::from_type(
 {
   code=type2cpp(type, ns);
   return false;
+}
+
+/*******************************************************************\
+
+Function: cpp_languaget::get_pretty_printer
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+std::unique_ptr<pretty_printert>
+cpp_languaget::get_pretty_printer(const namespacet &ns)
+{
+  return std::unique_ptr<pretty_printert>(new expr2cppt(ns));
 }
 
 /*******************************************************************\

--- a/src/cpp/cpp_language.h
+++ b/src/cpp/cpp_language.h
@@ -62,6 +62,9 @@ public:
     std::string &code,
     const namespacet &ns) override;
 
+  std::unique_ptr<pretty_printert>
+    get_pretty_printer(const namespacet &) override;
+
   bool type_to_name(
     const typet &type,
     std::string &name,

--- a/src/cpp/expr2cpp.cpp
+++ b/src/cpp/expr2cpp.cpp
@@ -17,44 +17,9 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include <ansi-c/c_misc.h>
 #include <ansi-c/c_qualifiers.h>
-#include <ansi-c/expr2c_class.h>
 
 #include "expr2cpp.h"
-
-class expr2cppt:public expr2ct
-{
-public:
-  explicit expr2cppt(const namespacet &_ns):expr2ct(_ns) { }
-
-  std::string convert(const exprt &src) override
-  {
-    return expr2ct::convert(src);
-  }
-
-  std::string convert(const typet &src) override
-  {
-    return expr2ct::convert(src);
-  }
-
-protected:
-  std::string convert(const exprt &src, unsigned &precedence) override;
-  std::string convert_cpp_this(const exprt &src, unsigned precedence);
-  std::string convert_cpp_new(const exprt &src, unsigned precedence);
-  std::string convert_extractbit(const exprt &src, unsigned precedence);
-  std::string convert_extractbits(const exprt &src, unsigned precedence);
-  std::string convert_code_cpp_delete(const exprt &src, unsigned precedence);
-  std::string convert_struct(const exprt &src, unsigned &precedence) override;
-  std::string convert_code(const codet &src, unsigned indent) override;
-  // NOLINTNEXTLINE(whitespace/line_length)
-  std::string convert_constant(const constant_exprt &src, unsigned &precedence) override;
-
-  std::string convert_rec(
-    const typet &src,
-    const c_qualifierst &qualifiers,
-    const std::string &declarator) override;
-
-  typedef std::unordered_set<std::string, string_hash> id_sett;
-};
+#include "expr2cpp_class.h"
 
 /*******************************************************************\
 
@@ -647,6 +612,8 @@ std::string expr2cpp(const exprt &expr, const namespacet &ns)
 {
   expr2cppt expr2cpp(ns);
   expr2cpp.get_shorthands(expr);
+  norep_pretty_printert norep;
+  expr2cpp.set_next_pretty_printer(&norep);
   return expr2cpp.convert(expr);
 }
 
@@ -665,5 +632,7 @@ Function: type2cpp
 std::string type2cpp(const typet &type, const namespacet &ns)
 {
   expr2cppt expr2cpp(ns);
+  norep_pretty_printert norep;
+  expr2cpp.set_next_pretty_printer(&norep);
   return expr2cpp.convert(type);
 }

--- a/src/cpp/expr2cpp_class.h
+++ b/src/cpp/expr2cpp_class.h
@@ -1,0 +1,49 @@
+/*******************************************************************\
+
+Module:
+
+Author: Daniel Kroening, kroening@cs.cmu.edu
+
+\*******************************************************************/
+
+#ifndef CPROVER_CPP_EXPR2CPP_CLASS_H
+#define CPROVER_CPP_EXPR2CPP_CLASS_H
+
+#include <ansi-c/expr2c_class.h>
+
+class expr2cppt:public expr2ct
+{
+public:
+  explicit expr2cppt(const namespacet &_ns):expr2ct(_ns) { }
+
+  std::string convert(const exprt &src) override
+  {
+    return expr2ct::convert(src);
+  }
+
+  std::string convert(const typet &src) override
+  {
+    return expr2ct::convert(src);
+  }
+
+protected:
+  std::string convert(const exprt &src, unsigned &precedence) override;
+  std::string convert_cpp_this(const exprt &src, unsigned precedence);
+  std::string convert_cpp_new(const exprt &src, unsigned precedence);
+  std::string convert_extractbit(const exprt &src, unsigned precedence);
+  std::string convert_extractbits(const exprt &src, unsigned precedence);
+  std::string convert_code_cpp_delete(const exprt &src, unsigned precedence);
+  std::string convert_struct(const exprt &src, unsigned &precedence) override;
+  std::string convert_code(const codet &src, unsigned indent) override;
+  // NOLINTNEXTLINE(whitespace/line_length)
+  std::string convert_constant(const constant_exprt &src, unsigned &precedence) override;
+
+  std::string convert_rec(
+    const typet &src,
+    const c_qualifierst &qualifiers,
+    const std::string &declarator) override;
+
+  typedef std::unordered_set<std::string, string_hash> id_sett;
+};
+
+#endif

--- a/src/java_bytecode/expr2java.cpp
+++ b/src/java_bytecode/expr2java.cpp
@@ -565,6 +565,8 @@ std::string expr2java(const exprt &expr, const namespacet &ns)
 {
   expr2javat expr2java(ns);
   expr2java.get_shorthands(expr);
+  norep_pretty_printert norep;
+  expr2java.set_next_pretty_printer(&norep);
   return expr2java.convert(expr);
 }
 
@@ -583,5 +585,7 @@ Function: type2java
 std::string type2java(const typet &type, const namespacet &ns)
 {
   expr2javat expr2java(ns);
+  norep_pretty_printert norep;
+  expr2java.set_next_pretty_printer(&norep);
   return expr2java.convert(type);
 }

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -850,6 +850,24 @@ bool java_bytecode_languaget::from_type(
 
 /*******************************************************************\
 
+Function: java_bytecode_languaget::get_pretty_printer
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+std::unique_ptr<pretty_printert>
+java_bytecode_languaget::get_pretty_printer(const namespacet &ns)
+{
+  return std::unique_ptr<pretty_printert>(new expr2javat(ns));
+}
+
+/*******************************************************************\
+
 Function: java_bytecode_languaget::to_expr
 
   Inputs:

--- a/src/java_bytecode/java_bytecode_language.h
+++ b/src/java_bytecode/java_bytecode_language.h
@@ -70,6 +70,9 @@ public:
     std::string &code,
     const namespacet &ns) override;
 
+  std::unique_ptr<pretty_printert>
+    get_pretty_printer(const namespacet &) override;
+
   bool to_expr(
     const std::string &code,
     const std::string &module,

--- a/src/jsil/expr2jsil.cpp
+++ b/src/jsil/expr2jsil.cpp
@@ -9,24 +9,7 @@ Author: Michael Tautschnig, tautschn@amazon.com
 #include <ansi-c/expr2c_class.h>
 
 #include "expr2jsil.h"
-
-class expr2jsilt:public expr2ct
-{
-public:
-  explicit expr2jsilt(const namespacet &_ns):expr2ct(_ns) { }
-
-  virtual std::string convert(const exprt &src)
-  {
-    return expr2ct::convert(src);
-  }
-
-  virtual std::string convert(const typet &src)
-  {
-    return expr2ct::convert(src);
-  }
-
-protected:
-};
+#include "expr2jsil_class.h"
 
 /*******************************************************************\
 
@@ -44,6 +27,8 @@ std::string expr2jsil(const exprt &expr, const namespacet &ns)
 {
   expr2jsilt expr2jsil(ns);
   expr2jsil.get_shorthands(expr);
+  norep_pretty_printert norep;
+  expr2jsil.set_next_pretty_printer(&norep);
   return expr2jsil.convert(expr);
 }
 
@@ -62,5 +47,7 @@ Function: type2jsil
 std::string type2jsil(const typet &type, const namespacet &ns)
 {
   expr2jsilt expr2jsil(ns);
+  norep_pretty_printert norep;
+  expr2jsil.set_next_pretty_printer(&norep);
   return expr2jsil.convert(type);
 }

--- a/src/jsil/expr2jsil_class.h
+++ b/src/jsil/expr2jsil_class.h
@@ -1,0 +1,33 @@
+
+/*******************************************************************\
+
+Module: Jsil Language
+
+Author: Michael Tautschnig, tautschn@amazon.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_JSIL_EXPR2JSIL_CLASS_H
+#define CPROVER_JSIL_EXPR2JSIL_CLASS_H
+
+#include <ansi-c/expr2c_class.h>
+
+class expr2jsilt:public expr2ct
+{
+public:
+  explicit expr2jsilt(const namespacet &_ns):expr2ct(_ns) { }
+
+  virtual std::string convert(const exprt &src)
+  {
+    return expr2ct::convert(src);
+  }
+
+  virtual std::string convert(const typet &src)
+  {
+    return expr2ct::convert(src);
+  }
+
+protected:
+};
+
+#endif

--- a/src/jsil/jsil_language.cpp
+++ b/src/jsil/jsil_language.cpp
@@ -10,6 +10,7 @@ Author: Michael Tautschnig, tautschn@amazon.com
 #include <util/get_base_name.h>
 
 #include "expr2jsil.h"
+#include "expr2jsil_class.h"
 #include "jsil_convert.h"
 #include "jsil_entry_point.h"
 #include "jsil_internal_additions.h"
@@ -254,6 +255,24 @@ bool jsil_languaget::from_type(
 {
   code=type2jsil(type, ns);
   return false;
+}
+
+/*******************************************************************\
+
+Function: jsil_languaget::get_pretty_printer
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+std::unique_ptr<pretty_printert>
+jsil_languaget::get_pretty_printer(const namespacet &ns)
+{
+  return std::unique_ptr<pretty_printert>(new expr2jsilt(ns));
 }
 
 /*******************************************************************\

--- a/src/jsil/jsil_language.h
+++ b/src/jsil/jsil_language.h
@@ -48,6 +48,9 @@ public:
     std::string &code,
     const namespacet &ns);
 
+  std::unique_ptr<pretty_printert>
+    get_pretty_printer(const namespacet &);
+
   virtual bool to_expr(
     const std::string &code,
     const std::string &module,

--- a/src/langapi/language_util.cpp
+++ b/src/langapi/language_util.cpp
@@ -51,10 +51,72 @@ static languaget* get_language(
 
 std::vector<pretty_printer_factoryt> registered_pretty_printers;
 
+/*******************************************************************\
+
+Function: register_global_pretty_printer
+
+  Inputs: `new_printer`: factory method returning
+             `unique_ptr<pretty_printert>`
+
+ Outputs:
+
+ Purpose: This registers a custom pretty-printer for use printing
+          expressions with `from_expr` and `from_type` also defined
+          in language_util.h. The function given should allocate
+          an instance of the printer and return a unique_ptr that
+          disposes of it appropriately (so if allocated with `new`,
+          ordinary `std::unique_ptr` will do the trick).
+          `from_expr` and `from_type` will always build a stack of
+          printer classes of the form:
+          L -> C1 -> C2 ... Cn -> X
+
+          L is the language frontend pretty-printer associated
+          with an expression, C1 ... Cn are instances of the registered
+          custom printers in order of registration, and X is the fallback
+          irep-to-lisp printer `norep_pretty_printert`. The -> arrows
+          represent `next_pretty_printer` fields used to defer printing
+          of expressions a particular printer can't handle; all printers
+          in the stack also get `top_pretty_printer` set to point at L,
+          which they should use when printing subexpressions to give
+          the whole stack a chance to provide a representation.
+
+          Note at present language custom printers such as `expr2javat`
+          are subclasses of `expr2ct` rather than using this deferral
+          mechanism; thus even when a Java expression is being printed
+          there is still only one L in the stack, rather than
+          expr2javat -> expr2ct -> C1 ... Cn -> X
+          as one might expect. The language printers (in particular
+          expr2ct) always assume they are at the top of the stack
+          (so top_pretty_printer == this), and will need adapting if
+          we want to e.g. place a custom printer *above* expr2ct
+          in the future.
+
+\*******************************************************************/
+
 void register_global_pretty_printer(pretty_printer_factoryt new_printer)
 {
   registered_pretty_printers.push_back(new_printer);
 }
+
+/*******************************************************************\
+
+Function: get_pretty_printer_stack
+
+  Inputs: `ns`: namespace
+          `language_printer`: pointer to instance of a pretty-printer
+             that should be placed at the head of the printer stack.
+
+ Outputs:
+
+ Purpose: (See `register_global_pretty_printer` above for context)
+          Takes a reference to language-specific pretty-printer L,
+          instantiates custom printers C1 .. Cn if any have been
+          registered, creates the fallback norep pretty-printer X,
+          and sets their next_ and top_pretty_printer pointers.
+          A vector of unique pointers is returned whose back member
+          is the head of the stack (L, in the notation used above).
+
+\*******************************************************************/
 
 static std::vector<std::unique_ptr<pretty_printert>> get_pretty_printer_stack(
   const namespacet &ns,
@@ -84,11 +146,17 @@ static std::vector<std::unique_ptr<pretty_printert>> get_pretty_printer_stack(
 
 Function: from_expr
 
-  Inputs:
+  Inputs: `ns`: global namespace
+          `identifier`: symbol-table identifier associated with `expr`
+            or the empty string if none
+          `expr`: expression to print
 
- Outputs:
+ Outputs: Returns pretty-printed string equivalent of `expr`.
 
- Purpose:
+ Purpose: Pretty-prints an expression. If custom pretty-printers have
+          been registered they will be instantiated and may take part
+          in printing `expr`; see `register_global_pretty_printer` for
+          details.
 
 \*******************************************************************/
 
@@ -106,11 +174,17 @@ std::string from_expr(
 
 Function: from_type
 
-  Inputs:
+  Inputs: `ns`: global namespace
+          `identifier`: symbol-table identifier associated with `type`
+            or the empty string if none
+          `type`: type to print
 
- Outputs:
+ Outputs: Returns pretty-printed string equivalent of `type`.
 
- Purpose:
+ Purpose: Pretty-prints an type. If custom pretty-printers have
+          been registered they will be instantiated and may take part
+          in printing `type`; see `register_global_pretty_printer` for
+          details.
 
 \*******************************************************************/
 

--- a/src/langapi/language_util.h
+++ b/src/langapi/language_util.h
@@ -9,7 +9,11 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #ifndef CPROVER_LANGAPI_LANGUAGE_UTIL_H
 #define CPROVER_LANGAPI_LANGUAGE_UTIL_H
 
+#include <memory>
+#include <functional>
+
 #include <util/irep.h>
+#include <langapi/pretty_printer.h>
 
 class exprt;
 class namespacet;
@@ -28,6 +32,11 @@ std::string from_type(
   const typet &type);
 
 std::string from_type(const typet &type);
+
+typedef std::function<std::unique_ptr<pretty_printert>(const namespacet &)>
+  pretty_printer_factoryt;
+
+void register_global_pretty_printer(pretty_printer_factoryt);
 
 exprt to_expr(
   const namespacet &ns,

--- a/src/langapi/pretty_printer.h
+++ b/src/langapi/pretty_printer.h
@@ -1,8 +1,8 @@
 /*******************************************************************\
 
-Module:
+Module: Generic expression / type pretty-printer
 
-Author: Daniel Kroening, kroening@cs.cmu.edu
+Author: Chris Smowton, chris.smowton@diffblue.com
 
 \*******************************************************************/
 
@@ -18,6 +18,16 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include <cassert>
 
+/*
+ * Interface to an expression and/or type pretty-printer.
+ * The convert(...) routines should pretty-print the expressions
+ * they know how to deal with, and defer to next_pretty_printer
+ * for those they can't handle, and top_pretty_printer for
+ * subexpressions (whether it understands them or not).
+ * Per default they always defer.
+ * See `util/language_util.h` and particularly
+ * `register_global_pretty_printer` for detail on how these are used.
+ */
 class pretty_printert
 {
  public:

--- a/src/langapi/pretty_printer.h
+++ b/src/langapi/pretty_printer.h
@@ -1,0 +1,76 @@
+/*******************************************************************\
+
+Module:
+
+Author: Daniel Kroening, kroening@cs.cmu.edu
+
+\*******************************************************************/
+
+#ifndef CPROVER_LANGAPI_PRETTY_PRINTER_H
+#define CPROVER_LANGAPI_PRETTY_PRINTER_H
+
+#include <util/lispirep.h>
+#include <util/lispexpr.h>
+#include <util/expr.h>
+#include <util/type.h>
+// Borrow MetaString, a simple string-escaping routine
+#include <ansi-c/c_misc.h>
+
+#include <cassert>
+
+class pretty_printert
+{
+ public:
+  pretty_printert():
+  next_pretty_printer(nullptr),
+  top_pretty_printer(nullptr)
+  {}
+
+  virtual ~pretty_printert() {}
+
+  virtual std::string convert(const typet &src)
+  {
+    assert(next_pretty_printer);
+    return next_pretty_printer->convert(src);
+  }
+  virtual std::string convert(const exprt &src)
+  {
+    assert(next_pretty_printer);
+    return next_pretty_printer->convert(src);
+  }
+
+  void set_next_pretty_printer(
+    pretty_printert *next)
+  {
+    next_pretty_printer=next;
+  }
+  void set_top_pretty_printer(
+    pretty_printert *top)
+  {
+    top_pretty_printer=top;
+  }
+
+ protected:
+  pretty_printert *next_pretty_printer;
+  pretty_printert *top_pretty_printer;
+};
+
+class norep_pretty_printert:public pretty_printert
+{
+ public:
+  std::string convert(const typet &src) override
+  {
+    lispexprt lisp;
+    irep2lisp(src, lisp);
+    return "irep(\""+MetaString(lisp.expr2string())+"\")";
+  }
+
+  std::string convert(const exprt &src) override
+  {
+    lispexprt lisp;
+    irep2lisp(src, lisp);
+    return "irep(\""+MetaString(lisp.expr2string())+"\")";
+  }
+};
+
+#endif

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -12,6 +12,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <set>
 #include <iosfwd>
 #include <string>
+#include <memory>
+
+#include <langapi/pretty_printer.h>
 
 #include "message.h"
 
@@ -87,7 +90,6 @@ public:
   virtual void show_parse(std::ostream &out)=0;
 
   // conversion of expressions
-
   virtual bool from_expr(
     const exprt &expr,
     std::string &code,
@@ -97,6 +99,9 @@ public:
     const typet &type,
     std::string &code,
     const namespacet &ns);
+
+  virtual std::unique_ptr<pretty_printert>
+    get_pretty_printer(const namespacet &)=0;
 
   virtual bool type_to_name(
     const typet &type,


### PR DESCRIPTION
Despite its name, expr2c is the de facto global default pretty-printer.
This allows an extension module to register a handler for expr types
that expr2c cannot do by itself.