### PR TITLE
Call get_value_set via a base-class reference

### DIFF
--- a/src/pointer-analysis/value_set_analysis.h
+++ b/src/pointer-analysis/value_set_analysis.h
@@ -103,7 +103,10 @@ public:
     const exprt &expr,
     value_setst::valuest &dest)
   {
-    (*this)[l].value_set.get_value_set(expr, dest, baset::ns);
+    ((const value_sett&)(*this)[l].value_set).get_value_set(
+      expr,
+      dest,
+      baset::ns);
   }
 };
 


### PR DESCRIPTION
The non-virtual call is hidden by a like-named virtual; calling
via a base-class reference like this avoids the need for all
subclasses to explicitly forward the method.