### PR TITLE
Extension of the call-graph and call-graph-based algorithms

### DIFF
--- a/src/analyses/call_graph.cpp
+++ b/src/analyses/call_graph.cpp
@@ -77,6 +77,18 @@ void call_grapht::add(
   }
 }
 
+/*******************************************************************\
+
+Function: call_grapht::swap
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
 void call_grapht::swap(call_grapht &other)
 {
   std::swap(graph, other.graph);
@@ -104,17 +116,33 @@ void call_grapht::add(
   graph.insert(std::pair<irep_idt, irep_idt>(caller, callee));
 }
 
-void call_grapht::add(const irep_idt &caller, const irep_idt &callee,
+/*******************************************************************\
+
+Function: call_grapht::add
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void call_grapht::add(
+  const irep_idt &caller,
+  const irep_idt &callee,
   const map_from_edges_to_call_locationst::mapped_type &call_sites)
 {
   bool exists=false;
   const call_grapht::call_edges_ranget range=out_edges(caller);
   for(auto it=range.first; it!=range.second; ++it)
+  {
     if(it->second==callee)
     {
       exists=true;
       break;
     }
+  }
   if(!exists)
     add(caller, callee);
   std::copy(
@@ -464,6 +492,18 @@ void find_leaves_below_function(
   find_leaves_below_function(call_graph, function, to_avoid, output);
 }
 
+/*******************************************************************\
+
+Function: find_direct_or_indirect_callees_of_function
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
 void find_direct_or_indirect_callees_of_function(
   const call_grapht &call_graph,
   const irep_idt &function,
@@ -473,6 +513,18 @@ void find_direct_or_indirect_callees_of_function(
   find_leaves_below_function(call_graph, function, output, leaves);
   output.insert(leaves.cbegin(), leaves.cend());
 }
+
+/*******************************************************************\
+
+Function: find_nearest_common_callees
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
 
 void find_nearest_common_callees(
   const call_grapht &call_graph,

--- a/src/analyses/call_graph.cpp
+++ b/src/analyses/call_graph.cpp
@@ -79,7 +79,7 @@ void call_grapht::add(
 
 void call_grapht::swap(call_grapht &other)
 {
-  std::swap(graph,other.graph);
+  std::swap(graph, other.graph);
   std::swap(map_from_edges_to_call_locations,
             other.map_from_edges_to_call_locations);
 }
@@ -109,17 +109,17 @@ void call_grapht::add(const irep_idt &caller, const irep_idt &callee,
 {
   bool exists=false;
   const call_grapht::call_edges_ranget range=out_edges(caller);
-  for (auto it=range.first; it!=range.second; ++it)
+  for(auto it=range.first; it!=range.second; ++it)
     if(it->second==callee)
     {
       exists=true;
       break;
     }
   if(!exists)
-    add(caller,callee);
+    add(caller, callee);
   std::copy(
-    call_sites.cbegin(),call_sites.cend(),
-    std::back_inserter(map_from_edges_to_call_locations[{caller,callee}]));
+    call_sites.cbegin(), call_sites.cend(),
+    std::back_inserter(map_from_edges_to_call_locations[{caller, callee}]));
 }
 
 
@@ -146,9 +146,9 @@ void call_grapht::output_dot(std::ostream &out) const
         << " [label=\"{";
     bool first=true;
     for(const auto instr_it :
-        get_map_from_edges_to_call_locations().at({edge.first,edge.second}))
+        get_map_from_edges_to_call_locations().at({edge.first, edge.second}))
     {
-      if (!first)
+      if(!first)
         out << ",";
       out << instr_it->location_number;
       first=false;
@@ -400,7 +400,7 @@ void compute_inverted_call_graph(
   assert(output_inverted_call_graph.graph.empty());
   for(const auto &elem : original_call_graph.graph)
     output_inverted_call_graph.add(
-      elem.second,elem.first,
+      elem.second, elem.first,
       original_call_graph.get_map_from_edges_to_call_locations().at(
         {elem.first, elem.second}));
 }
@@ -467,11 +467,11 @@ void find_leaves_below_function(
 void find_direct_or_indirect_callees_of_function(
   const call_grapht &call_graph,
   const irep_idt &function,
-  std::unordered_set<irep_idt,dstring_hash> &output)
+  std::unordered_set<irep_idt, dstring_hash> &output)
 {
-  std::unordered_set<irep_idt,dstring_hash> leaves;
-  find_leaves_below_function(call_graph,function,output,leaves);
-  output.insert(leaves.cbegin(),leaves.cend());
+  std::unordered_set<irep_idt, dstring_hash> leaves;
+  find_leaves_below_function(call_graph, function, output, leaves);
+  output.insert(leaves.cbegin(), leaves.cend());
 }
 
 void find_nearest_common_callees(
@@ -487,7 +487,7 @@ void find_nearest_common_callees(
     return;
   }
 
-  std::map<irep_idt,std::size_t> counting;
+  std::map<irep_idt, std::size_t> counting;
   for(const auto &elem : call_graph.graph)
   {
     counting[elem.first]=0U;
@@ -495,8 +495,8 @@ void find_nearest_common_callees(
   }
   for(const auto &fn : functions)
   {
-    std::unordered_set<irep_idt,dstring_hash> callees;
-    find_direct_or_indirect_callees_of_function(call_graph,fn,callees);
+    std::unordered_set<irep_idt, dstring_hash> callees;
+    find_direct_or_indirect_callees_of_function(call_graph, fn, callees);
     assert(callees.count(fn)==1U);
     for(const auto &callee : callees)
       ++counting[callee];

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -174,7 +174,7 @@ void find_leaves_below_function(
 void find_direct_or_indirect_callees_of_function(
   const call_grapht &call_graph,
   const irep_idt &function,
-  std::unordered_set<irep_idt,dstring_hash> &output);
+  std::unordered_set<irep_idt, dstring_hash> &output);
 
 void find_nearest_common_callees(
   const call_grapht &call_graph,
@@ -190,7 +190,7 @@ get_call_sites(
   irep_idt const&  caller,
   irep_idt const&  callee)
 {
-  return call_graph.get_map_from_edges_to_call_locations().at({caller,callee});
+  return call_graph.get_map_from_edges_to_call_locations().at({caller, callee});
 }
 
 #endif // CPROVER_ANALYSES_CALL_GRAPH_H

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -186,9 +186,9 @@ void find_nearest_common_callees(
  */
 inline const std::vector<goto_programt::instructionst::const_iterator> &
 get_call_sites(
-  call_grapht const&  call_graph,
-  irep_idt const&  caller,
-  irep_idt const&  callee)
+  const call_grapht &call_graph,
+  const irep_idt &caller,
+  const irep_idt &callee)
 {
   return call_graph.get_map_from_edges_to_call_locations().at({caller, callee});
 }


### PR DESCRIPTION
There are 3 updates:

1) Added mapping from edges of the call-graph to particular instructions in the caller GOTO programs, where the calls are performed.

2) Added new functions find_direct_or_indirect_callees_of_function and find_nearest_common_callees.

3) Clean up output_dot.
