### PR TITLE
Fixed crash on non-ascii diff

### DIFF
--- a/scripts/filter_lint_by_diff.py
+++ b/scripts/filter_lint_by_diff.py
@@ -11,20 +11,19 @@ if len(sys.argv) != 3:
 added_lines = set()
 repository_root = sys.argv[2]
 
-with open(sys.argv[1], "r") as f:
-  diff = unidiff.PatchSet(f)
-  for diff_file in diff:
-    filename = diff_file.target_file
-    # Skip files deleted in the tip (b side of the diff):
-    if filename == "/dev/null":
-      continue
-    assert filename.startswith("b/")
-    filename = os.path.join(repository_root, filename[2:])
-    added_lines.add((filename, 0))
-    for diff_hunk in diff_file:
-      for diff_line in diff_hunk:
-        if diff_line.line_type == "+":
-          added_lines.add((filename, diff_line.target_line_no))
+diff = unidiff.PatchSet.from_filename(sys.argv[1])
+for diff_file in diff:
+  filename = diff_file.target_file
+  # Skip files deleted in the tip (b side of the diff):
+  if filename == "/dev/null":
+    continue
+  assert filename.startswith("b/")
+  filename = os.path.join(repository_root, filename[2:])
+  added_lines.add((filename, 0))
+  for diff_hunk in diff_file:
+    for diff_line in diff_hunk:
+      if diff_line.line_type == "+":
+        added_lines.add((filename, diff_line.target_line_no))
 
 for l in sys.stdin:
   bits = l.split(":")


### PR DESCRIPTION
Sometimes the diff file would contain a unicode character. Since we were opening the file, this meant that unidiff was reading the file in the wrong format. By letting unidiff handle reading the file we slightly simplify the code and fix this problem.