### PR TITLE
Remove DEBUG ifdefs which broke the debug build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,8 @@ matrix:
 
 script:
   - if [ -L bin/gcc ] ; then export PATH=$PWD/bin:$PATH ; fi ;
+    COMMAND="make -C src CXX=$COMPILER CXXFLAGS=\"-Wall -O0 -ggdb3 -Werror -Wno-deprecated-register -pedantic -Wno-sign-compare -DDEBUG\" -j2" &&
+    eval ${PRE_COMMAND} ${COMMAND} &&
     COMMAND="make -C src minisat2-download" &&
     eval ${PRE_COMMAND} ${COMMAND} &&
     COMMAND="make -C src CXX=$COMPILER CXXFLAGS=\"-Wall -O2 -g -Werror -Wno-deprecated-register -pedantic -Wno-sign-compare\" -j2" &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,8 +68,6 @@ matrix:
 
 script:
   - if [ -L bin/gcc ] ; then export PATH=$PWD/bin:$PATH ; fi ;
-    COMMAND="make -C src CXX=$COMPILER CXXFLAGS=\"-Wall -O0 -ggdb3 -Werror -Wno-deprecated-register -pedantic -Wno-sign-compare -DDEBUG\" -j2" &&
-    eval ${PRE_COMMAND} ${COMMAND} &&
     COMMAND="make -C src minisat2-download" &&
     eval ${PRE_COMMAND} ${COMMAND} &&
     COMMAND="make -C src CXX=$COMPILER CXXFLAGS=\"-Wall -O2 -g -Werror -Wno-deprecated-register -pedantic -Wno-sign-compare\" -j2" &&
@@ -77,4 +75,8 @@ script:
     COMMAND="env UBSAN_OPTIONS=print_stacktrace=1 make -C regression test" &&
     eval ${PRE_COMMAND} ${COMMAND} &&
     COMMAND="make -C src CXX=$COMPILER CXXFLAGS=$FLAGS -j2 cegis.dir clobber.dir memory-models.dir musketeer.dir" &&
+    eval ${PRE_COMMAND} ${COMMAND} &&
+    COMMAND="make -C src clean" &&
+    eval ${PRE_COMMAND} ${COMMAND} &&
+    COMMAND="make -C src CXX=$COMPILER CXXFLAGS=\"-Wall -O0 -ggdb3 -Werror -Wno-deprecated-register -pedantic -Wno-sign-compare -DDEBUG\" -j2" &&
     eval ${PRE_COMMAND} ${COMMAND}

--- a/src/analyses/cfg_dominators.h
+++ b/src/analyses/cfg_dominators.h
@@ -224,6 +224,13 @@ void dominators_pretty_print_node(const T &node, std::ostream &out)
   out << node;
 }
 
+inline void dominators_pretty_print_node(
+  const goto_programt::targett& target,
+  std::ostream& out)
+{
+  out << target->code.pretty();
+}
+
 /*******************************************************************\
 
 Function: cfg_dominators_templatet::output
@@ -241,7 +248,7 @@ void cfg_dominators_templatet<P, T, post_dom>::output(std::ostream &out) const
 {
   for(const auto &node : cfg.entry_map)
   {
-    T n=node.first;
+    auto n=node.first;
 
     dominators_pretty_print_node(n, out);
     if(post_dom)

--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -6,8 +6,6 @@ Author: Peter Schrammel
 
 \*******************************************************************/
 
-// #define DEBUG
-
 #ifdef DEBUG
 #include <iostream>
 #endif

--- a/src/analyses/natural_loops.cpp
+++ b/src/analyses/natural_loops.cpp
@@ -10,8 +10,6 @@ Author: Georg Weissenbacher, georg@weissenbacher.name
 
 #include "natural_loops.h"
 
-// #define DEBUG
-
 /*******************************************************************\
 
 Function: show_natural_loops

--- a/src/analyses/natural_loops.h
+++ b/src/analyses/natural_loops.h
@@ -90,6 +90,10 @@ void natural_loops_templatet<P, T>::compute(P &program)
 {
   cfg_dominators(program);
 
+#ifdef DEBUG
+  cfg_dominators.output(std::cout);
+#endif
+
   // find back-edges m->n
   for(T m_it=program.instructions.begin();
       m_it!=program.instructions.end();

--- a/src/analyses/natural_loops.h
+++ b/src/analyses/natural_loops.h
@@ -81,8 +81,6 @@ Function: natural_loops_templatet::compute
 
 \*******************************************************************/
 
-// #define DEBUG
-
 #ifdef DEBUG
 #include <iostream>
 #endif
@@ -91,10 +89,6 @@ template<class P, class T>
 void natural_loops_templatet<P, T>::compute(P &program)
 {
   cfg_dominators(program);
-
-#ifdef DEBUG
-  cfg_dominators.output(std::cout);
-#endif
 
   // find back-edges m->n
   for(T m_it=program.instructions.begin();

--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -687,7 +687,7 @@ void bmct::setup_unwind()
 
   for(auto &val : unwindset_loops)
   {
-    unsigned thread_nr;
+    unsigned thread_nr=0;
     bool thread_nr_set=false;
 
     if(!val.empty() &&

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -637,6 +637,12 @@ bool Parser::rDefinition(cpp_itemt &item)
 {
   int t=lex.LookAhead(0);
 
+  #ifdef DEBUG
+  indenter _i;
+  std::cout << std::string(__indent, ' ') << "Parser::rDefinition 1 " << t
+            << '\n';
+  #endif
+
   if(t==';')
     return rNullDeclaration(item.make_declaration());
   else if(t==TOK_TYPEDEF)
@@ -1229,6 +1235,12 @@ bool Parser::rTemplateDecl(cpp_declarationt &decl)
   switch(kind)
   {
   case tdk_decl:
+    #ifdef DEBUG
+    std::cout << std::string(__indent, ' ') << "BODY: "
+              << body.pretty() << '\n';
+    std::cout << std::string(__indent, ' ') << "TEMPLATE_TYPE: "
+              << template_type.pretty() << '\n';
+    #endif
     body.add(ID_template_type).swap(template_type);
     body.set(ID_is_template, true);
     decl.swap(body);
@@ -1895,6 +1907,11 @@ bool Parser::rIntegralDeclaration(
 
     if(lex.LookAhead(0)==';')
     {
+      #ifdef DEBUG
+      std::cout << std::string(__indent, ' ')
+                << "Parser::rIntegralDeclaration 8 "
+                << declaration.pretty() << '\n';
+      #endif
       lex.get_token(tk);
       return true;
     }
@@ -5098,6 +5115,10 @@ bool Parser::rClassBody(exprt &body)
       // body=Ptree::List(ob, nil, new Leaf(tk));
       return true;        // error recovery
     }
+    #ifdef DEBUG
+    std::cout << std::string(__indent, ' ') << "Parser::rClassBody "
+              << member.pretty() << '\n';
+    #endif
 
     members.move_to_operands(
       static_cast<exprt &>(static_cast<irept &>(member)));
@@ -7558,7 +7579,7 @@ bool Parser::rPrimaryExpr(exprt &exp)
   #ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 0 "
-            << lex.LookAhead(0) << " " << lex.current_token().text <<"\n";
+            << lex.LookAhead(0) << ' ' << lex.current_token().text << '\n';
   #endif
 
   switch(lex.LookAhead(0))
@@ -9219,6 +9240,10 @@ bool Parser::rExprStatement(codet &statement)
 
     if(rDeclarationStatement(statement))
     {
+      #ifdef DEBUG
+      std::cout << std::string(__indent, ' ') << "rDe "
+                << statement.pretty() << '\n';
+      #endif
       return true;
     }
     else

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -21,8 +21,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include "cpp_member_spec.h"
 #include "cpp_enum_type.h"
 
-// #define DEBUG
-
 #ifdef DEBUG
 #include <iostream>
 
@@ -639,12 +637,6 @@ bool Parser::rDefinition(cpp_itemt &item)
 {
   int t=lex.LookAhead(0);
 
-  #ifdef DEBUG
-  indenter _i;
-  std::cout << std::string(__indent, ' ') << "Parser::rDefinition 1 " << t
-            << "\n";
-  #endif
-
   if(t==';')
     return rNullDeclaration(item.make_declaration());
   else if(t==TOK_TYPEDEF)
@@ -1237,12 +1229,6 @@ bool Parser::rTemplateDecl(cpp_declarationt &decl)
   switch(kind)
   {
   case tdk_decl:
-    #ifdef DEBUG
-    std::cout << std::string(__indent, ' ') << "BODY: " << body << std::endl;
-    std::cout << std::string(__indent, ' ') << "TEMPLATE_TYPE: "
-              << template_type << std::endl;
-    #endif
-
     body.add(ID_template_type).swap(template_type);
     body.set(ID_is_template, true);
     decl.swap(body);
@@ -1909,12 +1895,6 @@ bool Parser::rIntegralDeclaration(
 
     if(lex.LookAhead(0)==';')
     {
-      #ifdef DEBUG
-      std::cout << std::string(__indent, ' ')
-                << "Parser::rIntegralDeclaration 8 "
-                << declaration << "\n";
-      #endif
-
       lex.get_token(tk);
       return true;
     }
@@ -5118,11 +5098,6 @@ bool Parser::rClassBody(exprt &body)
       // body=Ptree::List(ob, nil, new Leaf(tk));
       return true;        // error recovery
     }
-
-    #ifdef DEBUG
-    std::cout << std::string(__indent, ' ') << "Parser::rClassBody " << member
-              << std::endl;
-    #endif
 
     members.move_to_operands(
       static_cast<exprt &>(static_cast<irept &>(member)));
@@ -9244,10 +9219,6 @@ bool Parser::rExprStatement(codet &statement)
 
     if(rDeclarationStatement(statement))
     {
-      #ifdef DEBUG
-      std::cout << std::string(__indent, ' ') << "rDe: " << statement
-                << std::endl;
-      #endif
       return true;
     }
     else

--- a/src/goto-instrument/accelerate/accelerate.cpp
+++ b/src/goto-instrument/accelerate/accelerate.cpp
@@ -27,8 +27,6 @@ Author: Matt Lewis
 #include "overflow_instrumenter.h"
 #include "util.h"
 
-#define DEBUG
-
 goto_programt::targett acceleratet::find_back_jump(
   goto_programt::targett loop_header)
 {

--- a/src/goto-instrument/accelerate/acceleration_utils.cpp
+++ b/src/goto-instrument/accelerate/acceleration_utils.cpp
@@ -42,8 +42,6 @@ Author: Matt Lewis
 #include "cone_of_influence.h"
 #include "overflow_instrumenter.h"
 
-#define DEBUG
-
 void acceleration_utilst::gather_rvalues(
   const exprt &expr,
   expr_sett &rvalues)

--- a/src/goto-instrument/accelerate/all_paths_enumerator.cpp
+++ b/src/goto-instrument/accelerate/all_paths_enumerator.cpp
@@ -10,8 +10,6 @@ Author: Matt Lewis
 
 #include "all_paths_enumerator.h"
 
-// #define DEBUG
-
 bool all_paths_enumeratort::next(patht &path)
 {
   if(last_path.empty())

--- a/src/goto-instrument/accelerate/cone_of_influence.cpp
+++ b/src/goto-instrument/accelerate/cone_of_influence.cpp
@@ -12,8 +12,6 @@ Author: Matt Lewis
 
 #include "cone_of_influence.h"
 
-// #define DEBUG
-
 void cone_of_influencet::cone_of_influence(
   const expr_sett &targets,
   expr_sett &cone)

--- a/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
+++ b/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
@@ -43,9 +43,6 @@ Author: Matt Lewis
 #include "cone_of_influence.h"
 #include "overflow_instrumenter.h"
 
-#define DEBUG
-
-
 bool disjunctive_polynomial_accelerationt::accelerate(
   path_acceleratort &accelerator)
 {

--- a/src/goto-instrument/accelerate/enumerating_loop_acceleration.cpp
+++ b/src/goto-instrument/accelerate/enumerating_loop_acceleration.cpp
@@ -10,8 +10,6 @@ Author: Matt Lewis
 
 #include "enumerating_loop_acceleration.h"
 
-// #define DEBUG
-
 bool enumerating_loop_accelerationt::accelerate(
   path_acceleratort &accelerator)
 {

--- a/src/goto-instrument/accelerate/overflow_instrumenter.cpp
+++ b/src/goto-instrument/accelerate/overflow_instrumenter.cpp
@@ -18,8 +18,6 @@ Author: Matt Lewis
 #include "overflow_instrumenter.h"
 #include "util.h"
 
-// #define DEBUG
-
 /*
  * This code is copied wholesale from analyses/goto_check.cpp.
  */

--- a/src/goto-instrument/accelerate/polynomial_accelerator.cpp
+++ b/src/goto-instrument/accelerate/polynomial_accelerator.cpp
@@ -39,9 +39,6 @@ Author: Matt Lewis
 #include "cone_of_influence.h"
 #include "overflow_instrumenter.h"
 
-#define DEBUG
-
-
 bool polynomial_acceleratort::accelerate(
   patht &loop,
   path_acceleratort &accelerator)

--- a/src/goto-instrument/accelerate/sat_path_enumerator.cpp
+++ b/src/goto-instrument/accelerate/sat_path_enumerator.cpp
@@ -42,8 +42,6 @@ Author: Matt Lewis
 #include "util.h"
 #include "overflow_instrumenter.h"
 
-#define DEBUG
-
 bool sat_path_enumeratort::next(patht &path)
 {
   scratch_programt program(symbol_table);

--- a/src/goto-instrument/accelerate/scratch_program.cpp
+++ b/src/goto-instrument/accelerate/scratch_program.cpp
@@ -28,6 +28,11 @@ bool scratch_programt::check_sat(bool do_slice)
   remove_skip(*this);
   update();
 
+#ifdef DEBUG
+  std::cout << "Checking following program for satness:\n";
+  output(ns, "scratch", std::cout);
+#endif
+
   symex.constant_propagation=constant_propagation;
   goto_symex_statet::propagationt::valuest constants;
 
@@ -42,12 +47,16 @@ bool scratch_programt::check_sat(bool do_slice)
   {
     // Symex sliced away all our assertions.
 #ifdef DEBUG
-    std::cout << "Trivially unsat" << std::endl;
+    std::cout << "Trivially unsat\n";
 #endif
     return false;
   }
 
   equation.convert(*checker);
+
+#ifdef DEBUG
+  std::cout << "Finished symex, invoking decision procedure.\n";
+#endif
 
   return (checker->dec_solve()==decision_proceduret::D_SATISFIABLE);
 }

--- a/src/goto-instrument/accelerate/scratch_program.cpp
+++ b/src/goto-instrument/accelerate/scratch_program.cpp
@@ -15,8 +15,6 @@ Author: Matt Lewis
 
 #include "scratch_program.h"
 
-// #define DEBUG
-
 #ifdef DEBUG
 #include <iostream>
 #endif
@@ -29,11 +27,6 @@ bool scratch_programt::check_sat(bool do_slice)
 
   remove_skip(*this);
   update();
-
-#ifdef DEBUG
-  std::cout << "Checking following program for satness:" << endl;
-  output(ns, "scratch", cout);
-#endif
 
   symex.constant_propagation=constant_propagation;
   goto_symex_statet::propagationt::valuest constants;
@@ -55,10 +48,6 @@ bool scratch_programt::check_sat(bool do_slice)
   }
 
   equation.convert(*checker);
-
-#ifdef DEBUG
-  cout << "Finished symex, invoking decision procedure." << endl;
-#endif
 
   return (checker->dec_solve()==decision_proceduret::D_SATISFIABLE);
 }

--- a/src/goto-instrument/accelerate/trace_automaton.cpp
+++ b/src/goto-instrument/accelerate/trace_automaton.cpp
@@ -75,6 +75,11 @@ void trace_automatont::add_path(patht &path)
   {
     goto_programt::targett l=step.loc;
 
+#ifdef DEBUG
+    std::cout << ", " << l->location_number << ':'
+              << l->source_location.as_string();
+#endif
+
     if(in_alphabet(l))
     {
 #ifdef DEBUG
@@ -103,6 +108,13 @@ void trace_automatont::add_path(patht &path)
  */
 void trace_automatont::determinise()
 {
+#ifdef DEBUG
+  std::cout << "Determinising automaton with " << nta.num_states
+            << " states and " << nta.accept_states.size()
+            << " accept states and " << nta.count_transitions()
+            << " transitions\n";
+#endif
+
   dstates.clear();
   unmarked_dstates.clear();
   dta.clear();
@@ -110,6 +122,10 @@ void trace_automatont::determinise()
   state_sett init_states;
   init_states.insert(nta.init_state);
   epsilon_closure(init_states);
+
+#ifdef DEBUG
+  std::cout << "There are " << init_states.size() << " init states\n";
+#endif
 
   dta.init_state=add_dstate(init_states);
 
@@ -371,7 +387,7 @@ void automatont::reverse(goto_programt::targett epsilon)
 
   std::cout << "Reversing automaton, old init=" << init_state
             << ", new init=" << new_init << ", old accept="
-            << *(accept_states.begin()) << "/" << accept_states.size()
+            << *(accept_states.begin()) << '/' << accept_states.size()
             << " new accept=" << init_state << std::endl;
 
   accept_states.clear();
@@ -455,7 +471,7 @@ void automatont::output(std::ostream &str)
   str << "Accept states: ";
 
   for(const auto &state : accept_states)
-    str << state << " ";
+    str << state << ' ';
 
   str << std::endl;
 

--- a/src/goto-instrument/accelerate/trace_automaton.cpp
+++ b/src/goto-instrument/accelerate/trace_automaton.cpp
@@ -12,8 +12,6 @@ Author: Matt Lewis
 #include "trace_automaton.h"
 #include "path.h"
 
-// #define DEBUG
-
 void trace_automatont::build()
 {
 #ifdef DEBUG
@@ -76,9 +74,6 @@ void trace_automatont::add_path(patht &path)
   for(const auto &step : path)
   {
     goto_programt::targett l=step.loc;
-#ifdef DEBUG
-      std::cout << ", " << l->location_number << ":" << l->location;
-#endif
 
     if(in_alphabet(l))
     {
@@ -108,13 +103,6 @@ void trace_automatont::add_path(patht &path)
  */
 void trace_automatont::determinise()
 {
-#ifdef DEBUG
-  std::cout << "Determinising automaton with " << nta.num_states
-            << " states and " << nta.accept_states.size()
-            << " accept states and " << nta.count_transitions()
-            << " transitions" << endl;
-#endif
-
   dstates.clear();
   unmarked_dstates.clear();
   dta.clear();
@@ -122,10 +110,6 @@ void trace_automatont::determinise()
   state_sett init_states;
   init_states.insert(nta.init_state);
   epsilon_closure(init_states);
-
-#ifdef DEBUG
-  std::cout << "There are " << init_states.size() << " init states" << endl;
-#endif
 
   dta.init_state=add_dstate(init_states);
 

--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -6,8 +6,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-// #define DEBUG
-
 #ifdef DEBUG
 #include <iostream>
 #endif

--- a/src/java_bytecode/java_local_variable_table.cpp
+++ b/src/java_bytecode/java_local_variable_table.cpp
@@ -546,14 +546,6 @@ static void merge_variable_table_entries(
   merge_into.var.start_pc=found_dominator;
   merge_into.var.length=last_pc-found_dominator;
 
-#ifdef DEBUG
-  debug_out << "Merged " << merge_vars.size() << " variables named "
-            << merge_into.var.name << "; new live range "
-            << merge_into.var.start_pc << "-"
-            << merge_into.var.start_pc + merge_into.var.length
-            << messaget::eom;
-#endif
-
   // Nuke the now-subsumed var-table entries:
   for(auto &v : merge_vars)
     if(v!=&merge_into)

--- a/src/java_bytecode/java_local_variable_table.cpp
+++ b/src/java_bytecode/java_local_variable_table.cpp
@@ -352,7 +352,7 @@ static void populate_predecessor_map(
             // handling is presently vague (any subroutine is assumed to
             // be able to return to any callsite)
             msg.warning() << "Local variable table: ignoring flow from "
-                          << "out of range for " << it->var.name << " "
+                          << "out of range for " << it->var.name << ' '
                           << pred << " -> " << amapit->first
                           << messaget::eom;
             continue;
@@ -375,7 +375,7 @@ static void populate_predecessor_map(
             // assumed to be able to return to any callsite)
             msg.warning() << "Local variable table: ignoring flow from "
                           << "clashing variable for "
-                          << it->var.name << " " << pred << " -> "
+                          << it->var.name << ' ' << pred << " -> "
                           << amapit->first << messaget::eom;
             continue;
           }
@@ -545,6 +545,13 @@ static void merge_variable_table_entries(
   // Apply the changes:
   merge_into.var.start_pc=found_dominator;
   merge_into.var.length=last_pc-found_dominator;
+
+#ifdef DEBUG
+  debug_out << "Merged " << merge_vars.size() << " variables named "
+            << merge_into.var.name << "; new live range "
+            << merge_into.var.start_pc << '-'
+            << merge_into.var.start_pc + merge_into.var.length << '\n';
+#endif
 
   // Nuke the now-subsumed var-table entries:
   for(auto &v : merge_vars)

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -936,11 +936,6 @@ bool linkingt::adjust_object_type_rec(
   else if(t1.id()!=t2.id())
   {
     // type classes do not match and can't be fixed
-    #ifdef DEBUG
-    str << "LINKING: cannot join " << t1.id() << " vs. " << t2.id();
-    debug_msg();
-    #endif
-
     return true;
   }
 
@@ -1041,11 +1036,6 @@ bool linkingt::adjust_object_type(
   const symbolt &new_symbol,
   bool &set_to_new)
 {
-  #ifdef DEBUG
-  str << "LINKING: trying to adjust types of " << old_symbol.name;
-  debug_msg();
-  #endif
-
   const typet &old_type=follow_tags_symbols(ns, old_symbol.type);
   const typet &new_type=follow_tags_symbols(ns, new_symbol.type);
 

--- a/src/path-symex/path_symex.cpp
+++ b/src/path-symex/path_symex.cpp
@@ -22,8 +22,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "path_symex.h"
 #include "path_symex_class.h"
 
-// #define DEBUG
-
 #ifdef DEBUG
 #include <iostream>
 #endif

--- a/src/path-symex/path_symex_state.cpp
+++ b/src/path-symex/path_symex_state.cpp
@@ -18,8 +18,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "path_symex_state.h"
 
-// #define DEBUG
-
 #ifdef DEBUG
 #include <iostream>
 #include <langapi/language_util.h>

--- a/src/path-symex/path_symex_state_read.cpp
+++ b/src/path-symex/path_symex_state_read.cpp
@@ -13,8 +13,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "path_symex_state.h"
 
-// #define DEBUG
-
 #ifdef DEBUG
 #include <iostream>
 #include <langapi/language_util.h>

--- a/src/path-symex/var_map.cpp
+++ b/src/path-symex/var_map.cpp
@@ -14,8 +14,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "var_map.h"
 
-// #define DEBUG
-
 /*******************************************************************\
 
 Function: var_mapt::var_infot::operator()

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -6,8 +6,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-// #define DEBUG
-
 #ifdef DEBUG
 #include <iostream>
 #include <langapi/language_util.h>

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -6,8 +6,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-// #define DEBUG
-
 #ifdef DEBUG
 #include <iostream>
 #endif

--- a/src/solvers/flattening/arrays.cpp
+++ b/src/solvers/flattening/arrays.cpp
@@ -6,8 +6,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-// #define DEBUG
-
 #include <cassert>
 #include <iostream>
 

--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -27,8 +27,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "../floatbv/float_utils.h"
 
-// #define DEBUG
-
 /*******************************************************************\
 
 Function: boolbvt::literal
@@ -144,9 +142,6 @@ const bvt &boolbvt::convert_bv(const exprt &expr)
     bv_cache.insert(std::make_pair(expr, bvt()));
   if(!cache_result.second)
   {
-    #ifdef DEBUG
-    std::cout << "Cache hit on " << expr << "\n";
-    #endif
     return cache_result.first->second;
   }
 
@@ -205,10 +200,6 @@ Function: boolbvt::convert_bitvector
 
 bvt boolbvt::convert_bitvector(const exprt &expr)
 {
-  #ifdef DEBUG
-  std::cout << "BV: " << expr.pretty() << std::endl;
-  #endif
-
   if(expr.type().id()==ID_bool)
   {
     bvt bv;

--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -17,8 +17,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "boolbv.h"
 #include "boolbv_type.h"
 
-// #define DEBUG
-
 /*******************************************************************\
 
 Function: boolbvt::get

--- a/src/solvers/flattening/boolbv_map.cpp
+++ b/src/solvers/flattening/boolbv_map.cpp
@@ -13,8 +13,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "boolbv_map.h"
 #include "boolbv_width.h"
 
-// #define DEBUG
-
 #ifdef DEBUG
 #include <iostream>
 #endif

--- a/src/solvers/flattening/equality.cpp
+++ b/src/solvers/flattening/equality.cpp
@@ -6,8 +6,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-// #define DEBUG
-
 #ifdef DEBUG
 #include <iostream>
 #endif
@@ -109,11 +107,6 @@ literalt equalityt::equality2(const exprt &e1, const exprt &e2)
     else
       l=result->second;
   }
-
-  #ifdef DEBUG
-  std::cout << "EQUALITY " << l << "<=>"
-            << e1 << "=" << e2 << std::endl;
-  #endif
 
   return l;
 }

--- a/src/solvers/flattening/functions.cpp
+++ b/src/solvers/flattening/functions.cpp
@@ -6,8 +6,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-// #define DEBUG
-
 #include <cassert>
 
 #include <util/std_types.h>

--- a/src/solvers/prop/prop_conv.cpp
+++ b/src/solvers/prop/prop_conv.cpp
@@ -18,8 +18,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "prop_conv.h"
 #include "literal_expr.h"
 
-// #define DEBUG
-
 /*******************************************************************\
 
 Function: prop_convt::is_in_conflict

--- a/src/solvers/sat/satcheck_limmat.cpp
+++ b/src/solvers/sat/satcheck_limmat.cpp
@@ -16,8 +16,6 @@ extern "C"
 #include "limmat.h"
 }
 
-// #define DEBUG
-
 /*******************************************************************\
 
 Function: satcheck_limmatt::satcheck_limmatt

--- a/src/solvers/sat/satcheck_zchaff.cpp
+++ b/src/solvers/sat/satcheck_zchaff.cpp
@@ -13,8 +13,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <zchaff_solver.h>
 
-// #define DEBUG
-
 /*******************************************************************\
 
 Function: satcheck_zchaff_baset::satcheck_zchaff_baset

--- a/src/util/union_find.h
+++ b/src/util/union_find.h
@@ -157,7 +157,8 @@ public:
   // are 'a' and 'b' in the same set?
   bool same_set(const T &a, const T &b) const
   {
-    typename subt::number_type na, nb;
+    typedef typename subt::number_type subt_number_typet;
+    subt_number_typet na=subt_number_typet(), nb=subt_number_typet();
     bool have_na=!subt::get_number(a, na),
          have_nb=!subt::get_number(b, nb);
 


### PR DESCRIPTION
With this commit applied, the build succeeds when invoked by `make CXXFLAGS=-DDEBUG`. This is achieved by deleting anything within a `#ifdef DEBUG` block which caused build errors. Several files also contained `// #define DEBUG` lines, which have been removed.