### PR TITLE
Missing forward declaration

### DIFF
--- a/src/goto-programs/show_symbol_table.h
+++ b/src/goto-programs/show_symbol_table.h
@@ -11,6 +11,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/ui_message.h>
 
+class goto_modelt;
+
 void show_symbol_table(
   const goto_modelt &,
   ui_message_handlert::uit ui);


### PR DESCRIPTION
This caused this to not compile if included before whatever brings in goto_modelt.