### PR TITLE
Correct pretty-printing of code_returnt

### DIFF
--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -3337,7 +3337,7 @@ std::string expr2ct::convert_code_return(
   std::string dest=indent_str(indent);
   dest+="return";
 
-  if(src.operands().size()==1)
+  if(to_code_return(src).has_return_value())
     dest+=" "+convert(src.op0());
 
   dest+=';';


### PR DESCRIPTION
Thought I'd made a mistake when I got `return irep("nil")` in the symbol table output-- turns out the C pretty-printer just never got updated when `code_returnt` started using a nil irep to represent return-without-value. This cleans it up.