### PR TITLE
Added serialization of irept and dstringt

### DIFF
--- a/src/config.inc
+++ b/src/config.inc
@@ -9,7 +9,7 @@ BUILD_ENV = AUTO
 
 # Select optimisation or debug info
 #CXXFLAGS += -O2 -DNDEBUG
-#CXXFLAGS += -O0 -g
+CXXFLAGS += -O0 -g
 
 ifeq ($(shell uname),Linux)
   CXXFLAGS += -DUSE_BOOST

--- a/src/util/dstring.cpp
+++ b/src/util/dstring.cpp
@@ -7,3 +7,33 @@ Author: Daniel Kroening, kroening@kroening.com
 \*******************************************************************/
 
 #include "dstring.h"
+#include "serializer.h"
+
+
+/*******************************************************************\
+
+  Function: dstring::serialize
+
+  Inputs:
+    serializer: The serializer to read from/write to
+
+  Outputs:
+
+  Purpose:
+    Serializes this instance to/from the given serializer.
+
+\*******************************************************************/
+void dstringt::serialize(serializert &serializer)
+{
+  if(serializer.is_for_reading())
+  {
+    std::string str;
+    serializer.serialize("dstring", str);
+    no=string_container[str];
+  }
+  else
+  {
+    std::string str=as_string();
+    serializer.serialize("dstring", str);
+  }
+}

--- a/src/util/dstring.h
+++ b/src/util/dstring.h
@@ -13,6 +13,9 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "string_container.h"
 
+class serializert;
+
+
 class dstringt
 {
 public:
@@ -122,6 +125,8 @@ public:
   {
     return out << as_string();
   }
+
+  void serialize(serializert &serializer);
 
   // non-standard
 

--- a/src/util/file_util.cpp
+++ b/src/util/file_util.cpp
@@ -371,3 +371,31 @@ std::string fileutl_get_relative_path(
   std::string const result = fileutl_join_path_parts(split1);
   return result;
 }
+
+/*******************************************************************\
+
+  Function: make_valid_filename
+
+  Inputs:
+    file_name: The file name to sanitize.
+
+  Outputs:
+
+  Purpose:
+    Replaces invalid characters in a file name using a hard-coded list of
+    replacements.
+    This is not designed to operate on path names and will replace folder
+    seperator characters.
+
+\*******************************************************************/
+std::string make_valid_filename(std::string file_name)
+{
+  std::replace(file_name.begin(), file_name.end(), '#', '_');
+  std::replace(file_name.begin(), file_name.end(), '$', '_');
+  std::replace(file_name.begin(), file_name.end(), ':', '.');
+  std::replace(file_name.begin(), file_name.end(), '/', '.');
+  std::replace(file_name.begin(), file_name.end(), '\\', '.');
+  std::replace(file_name.begin(), file_name.end(), '<', '[');
+  std::replace(file_name.begin(), file_name.end(), '>', ']');
+  return file_name;
+}

--- a/src/util/file_util.h
+++ b/src/util/file_util.h
@@ -62,4 +62,6 @@ std::string fileutl_get_relative_path(
   std::string const &pathname,
   std::string const &directory);
 
+std::string make_valid_filename(std::string filename);
+
 #endif // CPROVER_UTIL_FILE_UTIL_H

--- a/src/util/irep.cpp
+++ b/src/util/irep.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "string2int.h"
 #include "irep.h"
 #include "string_hash.h"
+#include "serializer.h"
 #include "irep_hash.h"
 
 #ifdef SUB_IS_LIST
@@ -1002,4 +1003,25 @@ std::string irept::pretty(unsigned indent, unsigned max_indent) const
   }
 
   return result;
+}
+
+/*******************************************************************\
+
+  Function: irept::serialize
+
+  Inputs:
+    serializer: The serializer to read from/write to
+
+  Outputs:
+
+  Purpose:
+    Serializes this instance to/from the given serializer.
+
+\*******************************************************************/
+void irept::serialize(serializert &serializer)
+{
+  serializer.serialize("id", write().data);
+  serializer.serialize("subs", get_sub());
+  serializer.serialize("named_subs", get_named_sub());
+  serializer.serialize("comments", get_comments());
 }

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -45,6 +45,9 @@ typedef std::string irep_namet;
 typedef string_hash irep_id_hash;
 #endif
 
+class serializert;
+
+
 inline const std::string &id2string(const irep_idt &d)
 {
   #ifdef USE_DSTRING
@@ -256,6 +259,8 @@ public:
   bool full_eq(const irept &other) const;
 
   std::string pretty(unsigned indent=0, unsigned max_indent=0) const;
+
+  void serialize(serializert &serializer);
 
 protected:
   static bool is_comment(const irep_namet &name)

--- a/src/util/serializer.h
+++ b/src/util/serializer.h
@@ -17,6 +17,7 @@ Purpose: Generic serialization of object hierarchies.
 #include <vector>
 #include <set>
 #include <map>
+#include <cassert>
 #ifdef USE_BOOST
 #include <boost/bimap.hpp>
 #endif
@@ -162,9 +163,7 @@ public:
     traitst * result=dynamic_cast<traitst *>(traits);
     if(result!=nullptr)
       return *result;
-    if(parent==nullptr)
-      throw std::logic_error(
-        "Traits of required type not found on this serializer");
+    assert(parent!=nullptr);  // In release build allow undefined behaviour
     return parent->get_traits<traitst>();
   }
 
@@ -188,9 +187,7 @@ public:
   \*******************************************************************/
   void set_traits(serializer_traitst &serializer_traits)
   {
-    if(traits!=nullptr)
-      throw std::logic_error(
-        "Tried to set traits twice on the same serializert");
+    assert(traits==nullptr);
     traits=&serializer_traits;
   }
 

--- a/src/util/serializer.h
+++ b/src/util/serializer.h
@@ -1,0 +1,845 @@
+/*******************************************************************\
+
+Module: Serializer
+
+Author: Nathan.Phillips@diffblue.com
+
+Purpose: Generic serialization of object hierarchies.
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_SERIALIZER_H
+#define CPROVER_UTIL_SERIALIZER_H
+
+#include <utility>
+#include <string>
+#include <functional>
+#include <vector>
+#include <set>
+#include <map>
+#ifdef USE_BOOST
+#include <boost/bimap.hpp>
+#endif
+
+
+/*******************************************************************\
+
+Class: serializer_traitst
+
+Purpose:
+  A base class for classes that define traits that can be attached to a
+  serializer.
+  This is used to augment the behaviour of a family of serializers, typically
+  by passing data that is required for serializing a particular type of object
+  through to a sub-object serialization routine.
+
+\*******************************************************************/
+class serializer_traitst
+{
+public:
+  // The virtual destructor ensures sub-classes are disposed correctly.
+  virtual ~serializer_traitst()=default;
+};
+
+
+/*******************************************************************\
+
+Class: serializert
+
+Purpose:
+  A base class for all serializers.
+  This is used to implement serialization by being passed to the serialize
+  method of classes to be serialized.
+  Defines pure virtual methods for serializing basic types.
+  Implements methods for serializing collection types.
+
+\*******************************************************************/
+class serializert
+{
+private:
+  // The serializer for a containing object, if any
+  serializert *parent;
+  // Whether this serializer is used for reading rather than writing
+  bool is_read;
+  // Traits attached to this serializer
+  serializer_traitst *traits;
+
+protected:
+  /*******************************************************************\
+
+  Function: serializert::serializert
+
+  Inputs:
+    parent: The serializer for the containing object.
+    is_read: Whether this serializer is used for reading rather than writing.
+
+  Outputs:
+
+  Purpose:
+    Creates a serializert for a sub-object of a larger serialization.
+    This is only called internally by sub-class implementations.
+
+  \*******************************************************************/
+  serializert(serializert *parent, bool is_read)
+    : parent(parent), is_read(is_read), traits(nullptr)
+  {
+  }
+
+  /*******************************************************************\
+
+  Function: serializert::serializert
+
+  Inputs:
+    is_read: Whether this serializer is used for reading rather than writing.
+
+  Outputs:
+
+  Purpose:
+    Creates a serializert.
+    This will be exposed externally by sub-class implementations but is not
+    itself public.
+
+  \*******************************************************************/
+  explicit serializert(bool is_read)
+    : parent(nullptr), is_read(is_read), traits(nullptr)
+  {
+  }
+
+  // The virtual destructor ensures sub-classes are disposed correctly.
+  virtual ~serializert()=default;
+
+public:
+  /*******************************************************************\
+
+  Function: serializert::is_for_reading
+
+  Inputs:
+
+  Outputs:
+    Whether this serializer is used for reading rather than writing.
+
+  Purpose:
+    Gets whether this serializer is used for reading rather than writing.
+
+  \*******************************************************************/
+  bool is_for_reading() { return is_read; }
+
+  /*******************************************************************\
+
+  Function: serializert::get_traits
+
+  Template parameters:
+    traitst:
+      The type of traits to return. Must be derived from serializer_traitst
+
+  Inputs:
+
+  Outputs:
+    A reference to traits attached to this serializer or one of its parents of
+    type traitst.
+
+  Exceptions:
+    std::logic_error:
+      If there were no traits of type traitst attached to this serializer or
+      one of its parents
+
+  Purpose:
+    Gets traits attached to this serializer of a specific type.
+
+  \*******************************************************************/
+  template<typename traitst>
+  traitst &get_traits() const
+  {
+    traitst * result=dynamic_cast<traitst *>(traits);
+    if(result!=nullptr)
+      return *result;
+    if(parent==nullptr)
+      throw std::logic_error(
+        "Traits of required type not found on this serializer");
+    return parent->get_traits<traitst>();
+  }
+
+  /*******************************************************************\
+
+  Function: serializert::set_traits
+
+  Inputs:
+    traits:
+      Traits to attach to this serializer
+
+  Outputs:
+
+  Exceptions:
+    std::logic_error:
+      If there were already traits attached to this serializer
+
+  Purpose:
+    Sets traits attached to this serializer.
+
+  \*******************************************************************/
+  void set_traits(serializer_traitst &serializer_traits)
+  {
+    if(traits!=nullptr)
+      throw std::logic_error(
+        "Tried to set traits twice on the same serializert");
+    traits=&serializer_traits;
+  }
+
+public:
+  /*******************************************************************\
+
+  Function: serializert::serialize
+
+  Inputs:
+    name: The name of the field to serialize.
+    field: The field to serialize.
+
+  Outputs:
+
+  Purpose:
+    Serializes a field.
+
+  \*******************************************************************/
+  virtual void serialize(const char *name, bool &field)=0;
+
+  /*******************************************************************\
+
+  Function: serializert::serialize
+
+  Inputs:
+    name: The name of the field to serialize.
+    field: The field to serialize.
+
+  Outputs:
+
+  Purpose:
+    Serializes a field.
+
+  \*******************************************************************/
+  virtual void serialize(const char *name, char &field)=0;
+
+  /*******************************************************************\
+
+  Function: serializert::serialize
+
+  Inputs:
+    name: The name of the field to serialize.
+    field: The field to serialize.
+
+  Outputs:
+
+  Purpose:
+    Serializes a field.
+
+  \*******************************************************************/
+  virtual void serialize(const char *name, std::string &field)=0;
+
+  /*******************************************************************\
+
+  Function: serializert::serialize
+
+  Inputs:
+    name: The name of the field to serialize.
+    field: The field to serialize.
+
+  Outputs:
+
+  Purpose:
+    Serializes a field.
+
+  \*******************************************************************/
+  virtual void serialize(const char *name, int &field)=0;
+
+  /*******************************************************************\
+
+  Function: serializert::serialize
+
+  Inputs:
+    name: The name of the field to serialize.
+    field: The field to serialize.
+
+  Outputs:
+
+  Purpose:
+    Serializes a field.
+
+  \*******************************************************************/
+  virtual void serialize(const char *name, unsigned int &field)=0;
+
+  /*******************************************************************\
+
+  Function: serializert::serialize
+
+  Inputs:
+    name: The name of the field to serialize.
+    field: The field to serialize.
+
+  Outputs:
+
+  Purpose:
+    Serializes a field.
+
+  \*******************************************************************/
+  virtual void serialize(const char *name, unsigned long long &field)=0;
+
+  /*******************************************************************\
+
+  Function: serializert::serialize
+
+  Inputs:
+    name: The name of the field to serialize.
+    field: The field to serialize.
+
+  Outputs:
+
+  Purpose:
+    Serializes a field.
+
+  \*******************************************************************/
+  virtual void serialize(const char *name, float &field)=0;
+
+  // Serializing objects that implement a serialize method
+protected:
+  // This is a non-templated function so that it can be virtual
+  // It therefore can't take an object of the type to be serialized
+  // Instead it takes a function that writes to such an object
+  virtual void serialize_object(
+    const char *name,
+    std::function<void(serializert &serializer)> serialize)=0;
+
+public:
+  /*******************************************************************\
+
+  Function: serializert::serialize
+
+  Template parameters:
+    T:
+      The type of the field to serialize. Must implement a serialize method.
+
+  Inputs:
+    name: The name of the field to serialize.
+    field: The field to serialize.
+
+  Outputs:
+
+  Purpose:
+    Serializes a field.
+
+  \*******************************************************************/
+  template<typename T>
+  void serialize(const char *name, T &field)
+  {
+    serialize_object(
+      name,
+      [&field] (serializert &serializer)
+      {
+        field.serialize(serializer);
+      });
+  }
+
+  /*******************************************************************\
+
+  Function: serializert::serialize
+
+  Template parameters:
+    T:
+      The type of the field to serialize. Must be serializable.
+
+  Inputs:
+    name: The name of the field to serialize.
+    field: An rvalue reference to the field to serialize.
+
+  Outputs:
+
+  Purpose:
+    Serializes a field.
+    Since the field is an rvalue reference this override is useful for writing
+      temporary objects or reading into temporary objects that store their
+      values in a non-temporary.
+
+  \*******************************************************************/
+  template<typename T>
+  void serialize(const char *name, T &&field)
+  {
+    serialize(name, static_cast<T &>(field));
+  }
+
+  /*******************************************************************\
+
+  Function: serializert::read_object
+
+  Template parameters:
+    T:
+      The type of the field to read.
+      Must implement a serialize method and have a default constructor.
+
+  Inputs:
+
+  Outputs:
+    An object of the type T read from the serializer.
+
+  Purpose:
+    Serializes a field.
+
+  \*******************************************************************/
+  template<typename T>
+  T read_object()
+  {
+    T result;
+    result.serialize(*this);
+    return result;
+  }
+
+  /*******************************************************************\
+
+  Function: serializert::read_object
+
+  Template parameters:
+    T:
+      The type of the field to read.
+      Must be serializable and have a default constructor.
+
+  Inputs:
+    name: The name of the field to serialize.
+
+  Outputs:
+    An object of the type T read from the field serializer.
+
+  Purpose:
+    Serializes a field.
+
+  \*******************************************************************/
+  template<typename T>
+  T read_object(const char *name)
+  {
+    T result;
+    serialize(name, result);
+    return result;
+  }
+
+  // Serializing pairs of serializable values
+private:
+  /*******************************************************************\
+
+  Class serializable_pairt
+
+  Template parameters:
+    pairt:
+      The type of the underlying pair to serialize.
+      Must have member types first_type and second_type that are serializable.
+
+  Purpose:
+    Wraps a pair in a serializable object that removes const from the
+    component members. Obviously this should not be used to read into a const
+    value but is useful for writing const values such as are found in the
+    value_type of maps.
+
+  \*******************************************************************/
+  template<typename pairt>
+  class serializable_pairt
+  {
+  private:
+    pairt &value;
+
+  public:
+    // This allows conversion from pairt
+    // NOLINTNEXTLINE(runtime/explicit)
+    serializable_pairt(pairt &value)
+      : value(value)
+    {
+    }
+
+    // This is an implicit conversion back to pairt
+    operator pairt &() const { return value; }
+
+    void serialize(serializert &serializer)
+    {
+      serializer.serialize(
+        "first",
+        const_cast<typename std::remove_const<
+          typename pairt::first_type>::type &>(value.first));
+      serializer.serialize(
+        "second",
+        const_cast<typename std::remove_const<
+          typename pairt::second_type>::type &>(value.second));
+    }
+  };
+
+public:
+  /*******************************************************************\
+
+  Function: serializert::serialize
+
+  Template parameters:
+    firstt: The type of the first element of the pair. Must be serializable.
+    secondt: The type of the second element of the pair. Must be serializable.
+
+  Inputs:
+    name: The name of the field to serialize.
+    field: The field to serialize.
+
+  Outputs:
+
+  Purpose:
+    Serializes a field of type std::pair<firstt, secondt>.
+
+  \*******************************************************************/
+  template<typename firstt, typename secondt>
+  void serialize(const char *name, std::pair<firstt, secondt> &field)
+  {
+    serialize(name, serializable_pairt<std::pair<firstt, secondt>>(field));
+  }
+
+public:
+  // A helper class for writing vectors
+  class collection_writert
+  {
+  public:
+    virtual bool is_end() const=0;
+    virtual void write(serializert &serializer)=0;
+  };
+
+  virtual void read_array(
+    const char *name,
+    std::function<void(serializert &serializer)> read_elt)=0;
+  virtual void write_array(
+    const char *name, collection_writert &collection_writer)=0;
+
+public:
+  // A helper class for writing vectors of objects that implement a serialize
+  //  method
+  template<typename collectiont>
+  class serializable_obj_collection_writert:public collection_writert
+  {
+  public:
+    typedef typename collectiont::iterator iteratort;
+    typedef typename collectiont::reference referencet;
+
+  private:
+    iteratort it;
+    iteratort end_it;
+
+  public:
+    explicit serializable_obj_collection_writert(collectiont &collection)
+      : it(collection.begin()), end_it(collection.end())
+    {
+    }
+
+    serializable_obj_collection_writert(iteratort it, iteratort end_it)
+      : it(it), end_it(end_it)
+    {
+    }
+
+    bool is_end() const { return it==end_it; }
+
+    void write(serializert &serializer)
+    {
+      it->serialize(serializer);
+      ++it;
+    }
+  };
+
+public:
+  /*******************************************************************\
+
+  Function: serializert::serialize_objects
+
+  Template parameters:
+    eltt:
+      The type of elements of the vector.
+      Must implement a serialize method and have a default constructor.
+
+  Inputs:
+    name: The name of the field to serialize.
+    field: The field to serialize.
+
+  Outputs:
+
+  Purpose:
+    Serializes a field of type std::vector<eltt>.
+    One can just use serialize instead of serialize_objects, but then each
+      object will be wrapped in another object with a single member
+
+  \*******************************************************************/
+  template<typename eltt>
+  void serialize_objects(const char *name, std::vector<eltt> &field)
+  {
+    if(is_read)
+    {
+      read_array(
+        name,
+        [&field] (serializert &serializer)
+        {
+          field.emplace_back();
+          field.back().serialize(serializer);
+        });
+    }
+    else
+    {
+      serializable_obj_collection_writert<std::vector<eltt>> writer(field);
+      write_array(name, writer);
+    }
+  }
+
+protected:
+  // A helper class for writing vectors of serializable objects (wrapped in a
+  //  value field)
+  template<typename collectiont>
+  class serializable_collection_writert:public collection_writert
+  {
+  public:
+    typedef typename collectiont::iterator iteratort;
+    typedef typename collectiont::reference referencet;
+
+  private:
+    iteratort it;
+    iteratort end_it;
+
+  public:
+    explicit serializable_collection_writert(collectiont &collection)
+      : it(collection.begin()), end_it(collection.end())
+    {
+    }
+
+    serializable_collection_writert(iteratort it, iteratort end_it)
+      : it(it), end_it(end_it)
+    {
+    }
+
+    bool is_end() const { return it==end_it; }
+
+    void write(serializert &serializer)
+    {
+      serializer.serialize("value", *it);
+      ++it;
+    }
+  };
+
+public:
+  /*******************************************************************\
+
+  Function: serializert::serialize
+
+  Template parameters:
+    eltt:
+      The type of elements of the vector.
+      Must be serializable and have a default constructor.
+
+  Inputs:
+    name: The name of the field to serialize.
+    field: The field to serialize.
+
+  Outputs:
+
+  Purpose:
+    Serializes a field of type std::vector<eltt>.
+
+  \*******************************************************************/
+  template<typename eltt>
+  void serialize(const char *name, std::vector<eltt> &field)
+  {
+    if(is_read)
+    {
+      read_array(
+        name,
+        [&field] (serializert &serializer)
+      {
+        field.emplace_back();
+        serializer.serialize("value", field.back());
+      });
+    }
+    else
+    {
+      serializable_collection_writert<std::vector<eltt>> writer(field);
+      write_array(name, writer);
+    }
+  }
+
+public:
+  /*******************************************************************\
+
+  Function: serializert::serialize_set
+
+  Template parameters:
+    sett:
+      The type of set to be serialized.
+      Must have a member type value_type that is serializable and can be
+        inserted into the set.
+
+  Inputs:
+    name: The name of the field to serialize.
+    field: The field to serialize.
+    create_elt: A function that returns new set elements.
+
+  Outputs:
+
+  Purpose:
+    Serializes a set field.
+
+  \*******************************************************************/
+  template<typename sett>
+  void serialize_set(
+    const char *name,
+    sett &field,
+    const std::function<typename sett::value_type()> &create_elt)
+  {
+    if(is_read)
+    {
+      read_array(
+        name,
+        [&field, &create_elt](serializert &serializer)
+      {
+        typename sett::value_type elt=create_elt();
+        serializer.serialize("value", elt);
+        field.insert(elt);
+      });
+    }
+    else
+    {
+      serializable_collection_writert<sett> writer(field);
+      write_array(name, writer);
+    }
+  }
+
+private:
+  /*******************************************************************\
+
+  Function: serializert::serialize_set
+
+  Template parameters:
+    sett:
+      The type of set to be serialized.
+      Must have a member type value_type that is serializable, has a default
+        constructor and can be inserted into the set.
+
+  Inputs:
+    name: The name of the field to serialize.
+    field: The field to serialize.
+
+  Outputs:
+
+  Purpose:
+    Helper function to serialize a set field.
+
+  \*******************************************************************/
+  template<typename sett>
+  void serialize_set(const char *name, sett &field)
+  {
+    serialize_set(name, field, [] () { return typename sett::value_type(); });
+  }
+
+public:
+  /*******************************************************************\
+
+  Function: serializert::serialize
+
+  Template parameters:
+    eltt:
+      The type of elements of the set.
+      Must be serializable and have a default constructor.
+
+  Inputs:
+    name: The name of the field to serialize.
+    field: The field to serialize.
+
+  Outputs:
+
+  Purpose:
+    Serializes a field of type std::set<eltt>.
+
+  \*******************************************************************/
+  template<typename eltt>
+  void serialize(const char *name, std::set<eltt> &field)
+  {
+    serialize_set(name, field);
+  }
+
+  // Serializing maps of serializable values
+private:
+  // This helper function can serialize any type of map (mapt) that has member
+  //  types key_type, mapped_type, value_type and reference, an insert method
+  //  that takes std::pair<mapt::key_type, mapt::mapped_type> and can be
+  //  enumerated to get elements of type mapt::reference from which a
+  //  serializable_pairt<mapt::value_type> can be created.
+  template<typename mapt>
+  void serialize_map(const char *name, mapt &field)
+  {
+    if(is_read)
+    {
+      read_array(
+        name,
+        [&field](serializert &serializer)
+      {
+        typedef std::pair<typename mapt::key_type, typename mapt::mapped_type>
+          pairt;
+        pairt key_value_pair;
+        serializable_pairt<pairt> wrapper(key_value_pair);
+        wrapper.serialize(serializer);
+        field.insert(key_value_pair);
+      });
+    }
+    else
+    {
+      typedef serializable_pairt<typename mapt::value_type> wrappert;
+      std::vector<wrappert> wrapper_vector;
+      for(typename mapt::reference elt : field)
+        wrapper_vector.emplace_back(elt);
+      serializable_obj_collection_writert<std::vector<wrappert>>
+        writer(wrapper_vector);
+      write_array(name, writer);
+    }
+  }
+
+public:
+  /*******************************************************************\
+
+  Function: serializert::serialize
+
+  Template parameters:
+    keyt: The type of keys of the map. Must be serializable.
+    valuet: The type of values of the map. Must be serializable.
+
+  Inputs:
+    name: The name of the field to serialize.
+    field: The field to serialize.
+
+  Outputs:
+
+  Purpose:
+    Serializes a field of type std::map<keyt, valuet>.
+
+  \*******************************************************************/
+  template<typename keyt, typename valuet>
+  void serialize(const char *name, std::map<keyt, valuet> &field)
+  {
+    serialize_map(name, field);
+  }
+
+#ifdef USE_BOOST
+  /*******************************************************************\
+
+  Function: serializert::serialize
+
+  Template parameters:
+    keyt: The type of keys of the map. Must be serializable.
+    valuet: The type of values of the map. Must be serializable.
+
+  Inputs:
+    name: The name of the field to serialize.
+    field: The field to serialize.
+
+  Outputs:
+
+  Purpose:
+    Serializes a field of type boost::bimap<keyt, valuet>.
+
+  \*******************************************************************/
+  template<typename keyt, typename valuet>
+  void serialize(const char *name, boost::bimap<keyt, valuet> &field)
+  {
+    serialize_map(name, field.left);
+  }
+#endif
+};
+
+#endif

--- a/src/util/serializer.h
+++ b/src/util/serializer.h
@@ -56,6 +56,9 @@ Purpose:
 \*******************************************************************/
 class serializert
 {
+  /////////////////////////////////////////////////////////////////////////////
+  // Section: Data used in this class
+
 private:
   // The serializer for a containing object, if any
   serializert *parent;
@@ -63,6 +66,9 @@ private:
   bool is_read;
   // Traits attached to this serializer
   serializer_traitst *traits;
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Section: Constructors/destructors
 
 protected:
   /*******************************************************************\
@@ -107,6 +113,9 @@ protected:
 
   // The virtual destructor ensures sub-classes are disposed correctly.
   virtual ~serializert()=default;
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Section: Accessors
 
 public:
   /*******************************************************************\
@@ -184,6 +193,9 @@ public:
         "Tried to set traits twice on the same serializert");
     traits=&serializer_traits;
   }
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Section: Serialization of basic data types
 
 public:
   /*******************************************************************\
@@ -298,7 +310,9 @@ public:
   \*******************************************************************/
   virtual void serialize(const char *name, float &field)=0;
 
-  // Serializing objects that implement a serialize method
+  /////////////////////////////////////////////////////////////////////////////
+  // Section: Serializing objects that implement a serialize method
+
 protected:
   // This is a non-templated function so that it can be virtual
   // It therefore can't take an object of the type to be serialized
@@ -335,33 +349,6 @@ public:
       {
         field.serialize(serializer);
       });
-  }
-
-  /*******************************************************************\
-
-  Function: serializert::serialize
-
-  Template parameters:
-    T:
-      The type of the field to serialize. Must be serializable.
-
-  Inputs:
-    name: The name of the field to serialize.
-    field: An rvalue reference to the field to serialize.
-
-  Outputs:
-
-  Purpose:
-    Serializes a field.
-    Since the field is an rvalue reference this override is useful for writing
-      temporary objects or reading into temporary objects that store their
-      values in a non-temporary.
-
-  \*******************************************************************/
-  template<typename T>
-  void serialize(const char *name, T &&field)
-  {
-    serialize(name, static_cast<T &>(field));
   }
 
   /*******************************************************************\
@@ -417,7 +404,40 @@ public:
     return result;
   }
 
-  // Serializing pairs of serializable values
+  /////////////////////////////////////////////////////////////////////////////
+  // Section: Serializing rvalue references
+
+public:
+  /*******************************************************************\
+
+  Function: serializert::serialize
+
+  Template parameters:
+    T:
+      The type of the field to serialize. Must be serializable.
+
+  Inputs:
+    name: The name of the field to serialize.
+    field: An rvalue reference to the field to serialize.
+
+  Outputs:
+
+  Purpose:
+    Serializes a field.
+    Since the field is an rvalue reference this override is useful for writing
+      temporary objects or reading into temporary objects that store their
+      values in a non-temporary.
+
+  \*******************************************************************/
+  template<typename T>
+  void serialize(const char *name, T &&field)
+  {
+    serialize(name, static_cast<T &>(field));
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Section: Serializing pairs of serializable values
+
 private:
   /*******************************************************************\
 
@@ -490,8 +510,11 @@ public:
     serialize(name, serializable_pairt<std::pair<firstt, secondt>>(field));
   }
 
+  /////////////////////////////////////////////////////////////////////////////
+  // Section: Serializing vectors
+
 public:
-  // A helper class for writing vectors
+  // A helper base class for writing vectors
   class collection_writert
   {
   public:
@@ -499,11 +522,17 @@ public:
     virtual void write(serializert &serializer)=0;
   };
 
+  // Virtual function that must be implemented to support reading vectors
   virtual void read_array(
     const char *name,
     std::function<void(serializert &serializer)> read_elt)=0;
+
+  // Virtual function that must be implemented to support writing vectors
   virtual void write_array(
     const char *name, collection_writert &collection_writer)=0;
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Section: Serializing vectors of objects that implement a serialize method
 
 public:
   // A helper class for writing vectors of objects that implement a serialize
@@ -581,6 +610,9 @@ public:
     }
   }
 
+  /////////////////////////////////////////////////////////////////////////////
+  // Section: Serializing vectors of serializable values
+
 protected:
   // A helper class for writing vectors of serializable objects (wrapped in a
   //  value field)
@@ -654,6 +686,9 @@ public:
       write_array(name, writer);
     }
   }
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Section: Serializing sets of serializable values
 
 public:
   /*******************************************************************\
@@ -754,7 +789,9 @@ public:
     serialize_set(name, field);
   }
 
-  // Serializing maps of serializable values
+  /////////////////////////////////////////////////////////////////////////////
+  // Section: Serializing maps of serializable values
+
 private:
   // This helper function can serialize any type of map (mapt) that has member
   //  types key_type, mapped_type, value_type and reference, an insert method


### PR DESCRIPTION
This adds a generic serialization framework that is used by summary virtualization in the security scanner.
It allows for targets including storage as JSON or using a database server.
It uses a non-virtual serialize method (through the use of templates) that avoids adding size to the objects to be serialized.
A trade-off was the choice to use single function serialization (rather than separate load/save functions). This minimises the impact on classes to be serialized but does sometimes cause issues as const objects can't naively be serialized out.
make_valid_filename has been added. This is for use in JSON serialization. While this serialization implementation is not included in the CBMC repository, this repository seems the right place for that function.
The serialization of irept in particular is based on a previous save to JSON function used by the security scanner and does not necessarily do a full serialization. If this is to be used in other contexts then summary virtualization, it could easily be extended (preferably by someone who understands the internals of irept better).