### PR TITLE
Prevent the user to run the full-slice option for multi-threaded C code

### DIFF
--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -905,7 +905,15 @@ bool cbmc_parse_optionst::process_goto_program(
     if(cmdline.isset("full-slice"))
     {
       status() << "Performing a full slice" << eom;
-      full_slicer(goto_functions, ns);
+      try
+      {
+        full_slicer(goto_functions, ns);
+      }
+      catch(const char *error_msg)
+      {
+        error() << error_msg << eom;
+        return 1;
+      }
     }
 
     // checks don't know about adjusted float expressions

--- a/src/goto-instrument/full_slicer.cpp
+++ b/src/goto-instrument/full_slicer.cpp
@@ -413,6 +413,9 @@ void full_slicert::operator()(
   Forall_goto_functions(f_it, goto_functions)
     if(f_it->second.body_available())
     {
+      if(f_it->first=="pthread_create")
+        throw "--full-slice does not support C/Pthreads yet";
+
       Forall_goto_program_instructions(i_it, f_it->second.body)
       {
         const cfgt::entryt &e=cfg.entry_map[i_it];


### PR DESCRIPTION
Currently, the full slicer does not support multi-threaded C programs.
Thus, we throw an exception if the full-slice option has been activated
to slice multi-threaded programs based on C/POSIX.