### PR TITLE
Fix concurrent traces generated via --trace

### DIFF
--- a/regression/cbmc-concurrency/trace1/main.c
+++ b/regression/cbmc-concurrency/trace1/main.c
@@ -1,0 +1,28 @@
+// #include <pthread.h>
+#include <assert.h>
+
+volatile unsigned x = 0, y = 0;
+volatile unsigned r1 = 0, r2 = 0;
+
+void* thr1(void* arg) {
+  x = 1;
+  r1 = y + 1;
+  return 0;
+}
+
+void* thr2(void* arg) {
+  y = 1;
+  r2 = x + 1;
+  return 0;
+}
+
+int main(){
+  // pthread_t t1, t2;
+  // pthread_create(&t1, NULL, thr1, NULL);
+  // pthread_create(&t2, NULL, thr2, NULL);
+__CPROVER_ASYNC_1: thr1(0);
+__CPROVER_ASYNC_2: thr2(0);
+  assert(r1 != 1 || r2 != 1);
+  return 0;
+}
+

--- a/regression/cbmc-concurrency/trace1/test.desc
+++ b/regression/cbmc-concurrency/trace1/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--mm tso --trace
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+^[[:space:]]*r2=1u \(.*\)$
+--
+^warning: ignoring


### PR DESCRIPTION
Traces had been cut off at the failing assertion without considering steps
performed in threads with a higher thread id. The behaviour of --stop-on-fail
was correct in this regard. The trace trimming must only be performed after
re-ordering of steps according to their time stamps.