### PR TITLE
Enabled test cases in goto-instrument after fixes in the full-slice

### DIFF
--- a/regression/goto-instrument/slice01/test.desc
+++ b/regression/goto-instrument/slice01/test.desc
@@ -1,6 +1,6 @@
-KNOWNBUG
+CORE
 main.c
---unwind 2 --full-slice
+--unwind 2 --full-slice --add-library
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/goto-instrument/slice13/main.c
+++ b/regression/goto-instrument/slice13/main.c
@@ -17,7 +17,9 @@ void test (int mode, double d, float result) {
 
 int main (void)
 {
+#ifdef __GNUC__
   // Nearer to 0x1.fffffep+127 than to 0x1.000000p+128
   test(FE_UPWARD, 0x1.fffffe0000001p+127, +INFINITY);
+#endif
   return 1;
 }

--- a/regression/goto-instrument/slice13/test.desc
+++ b/regression/goto-instrument/slice13/test.desc
@@ -1,8 +1,6 @@
-KNOWNBUG
+CORE
 main.c
---floatbv --full-slice
+--full-slice --add-library
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
---
-^warning: ignoring

--- a/regression/goto-instrument/slice16/test.desc
+++ b/regression/goto-instrument/slice16/test.desc
@@ -1,8 +1,6 @@
-KNOWNBUG
+CORE
 main.c
 --full-slice --unwind 2
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
---
-^warning: ignoring


### PR DESCRIPTION
Enabled test cases slice01, slice13, and slice16 in the goto-instrument regression
suite after fixes related to commits 27227cc and 211cb90.