### PR TITLE
added function call to working queue in the full-slicer

### DIFF
--- a/regression/goto-instrument/slice18/main.c
+++ b/regression/goto-instrument/slice18/main.c
@@ -1,3 +1,5 @@
+#include<assert.h>
+
 void exit(int status);
 
 int main() {

--- a/regression/goto-instrument/slice18/test.desc
+++ b/regression/goto-instrument/slice18/test.desc
@@ -1,8 +1,6 @@
-KNOWNBUG
+CORE
 main.c
 --full-slice
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
---
-^warning: ignoring

--- a/src/goto-instrument/full_slicer.cpp
+++ b/src/goto-instrument/full_slicer.cpp
@@ -402,6 +402,8 @@ void full_slicert::operator()(
       const exprt &s=to_code_dead(e_it->first->code).symbol();
       decl_dead[to_symbol_expr(s).get_identifier()].push(e_it->second);
     }
+    else if(e_it->first->is_function_call())
+      add_to_queue(queue, e_it->second, e_it->first);
   }
 
   // compute program dependence graph (and post-dominators)


### PR DESCRIPTION
After building the CFG data structure, function calls must be added to the working queue in the full-slicer for not slicing incorrectly programs that contain only function prototypes.