### PR TITLE
Replace boost dependency with simple mkdir -p implementation

### DIFF
--- a/src/config.inc
+++ b/src/config.inc
@@ -13,7 +13,6 @@ BUILD_ENV = AUTO
 
 ifeq ($(shell uname),Linux)
   CXXFLAGS += -DUSE_BOOST
-  LIBS=-lboost_filesystem -lboost_system
 endif
 
 # On Windows this Makefile is subject to sed s/BUILD_ENV.*/BUILD_ENV = MSVC,


### PR DESCRIPTION
This eliminates our one Boost runtime dependency, meaning we can now build by packaging header dependencies only.