### PR TITLE
Apply DRY in symbol_table::lookup

### DIFF
--- a/src/util/symbol_table.cpp
+++ b/src/util/symbol_table.cpp
@@ -151,12 +151,7 @@ Function: symbol_tablet::lookup
 
 const symbolt &symbol_tablet::lookup(const irep_idt &identifier) const
 {
-  symbolst::const_iterator it=symbols.find(identifier);
-
-  if(it==symbols.end())
-    throw "symbol "+id2string(identifier)+" not found";
-
-  return it->second;
+  return lookup(*this, identifier);
 }
 
 /*******************************************************************\
@@ -173,12 +168,7 @@ Function: symbol_tablet::lookup
 
 symbolt &symbol_tablet::lookup(const irep_idt &identifier)
 {
-  symbolst::iterator it=symbols.find(identifier);
-
-  if(it==symbols.end())
-    throw "symbol "+id2string(identifier)+" not found";
-
-  return it->second;
+  return lookup(*this, identifier);
 }
 
 /*******************************************************************\

--- a/src/util/symbol_table.h
+++ b/src/util/symbol_table.h
@@ -90,6 +90,20 @@ public:
 
   symbolt &lookup(const irep_idt &identifier);
   const symbolt &lookup(const irep_idt &identifier) const;
+
+private:
+  template <typename T>
+  static auto lookup(T &t, const irep_idt &id) -> decltype(t.lookup(id))
+  {
+    auto it=t.symbols.find(id);
+
+    if(it==t.symbols.end())
+    {
+      throw "symbol "+id2string(id)+" not found";
+    }
+
+    return it->second;
+  }
 };
 
 std::ostream &operator << (


### PR DESCRIPTION
For const and non-const getters with non-trivial behaviour, they should delegate to a common method which contains the logic, and is templated to deduce appropriate constness.