### PR TITLE
Added tests that demonstrate the issue with static inline c functions.

### DIFF
--- a/regression/ansi-c/static_inline1/main.c
+++ b/regression/ansi-c/static_inline1/main.c
@@ -1,0 +1,11 @@
+inline static int fun(int a)
+{
+    return a+1;
+}
+
+int main(int argc, char *argv[])
+{
+    fun(5);
+    return 0;
+}
+

--- a/regression/ansi-c/static_inline1/test.desc
+++ b/regression/ansi-c/static_inline1/test.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+
+--
+^warning: ignoring

--- a/regression/ansi-c/static_inline2/main.c
+++ b/regression/ansi-c/static_inline2/main.c
@@ -1,0 +1,4 @@
+inline static int fun(int a)
+{
+    return a+1;
+}

--- a/regression/ansi-c/static_inline2/test.desc
+++ b/regression/ansi-c/static_inline2/test.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+main.c
+--function fun
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+
+--
+^warning: ignoring


### PR DESCRIPTION
There is a problem with `cbmc` with how it handles `static inline` qualified functions. If we include a main function, and run `cbmc` without the `--function` parameter, so that it defaults to main, it converts the program without any issues. 

On the other hand, if we pass it a file without a main method in it, and call it with `--function fun`, then it will result in a `CONVERSION ERROR`.

This pull request contains tests to demonstrate that.