### PR TITLE
Rename _start to __CPROVER_start

### DIFF
--- a/regression/cbmc/graphml_witness1/test.desc
+++ b/regression/cbmc/graphml_witness1/test.desc
@@ -46,29 +46,29 @@ main.c
   <graph edgedefault="directed">
     <data key="sourcecodelang">C</data>
     <node id="sink"/>
-    <node id="33.22">
+    <node id="[0-9\.]*">
       <data key="entry">true</data>
     </node>
     <edge source="33.22" target="4.29">
       <data key="originfile">main.c</data>
       <data key="startline">21</data>
     </edge>
-    <node id="4.29"/>
-    <edge source="4.29" target="29.31">
+    <node id="[0-9\.]*"/>
+    <edge source="[0-9\.]*" target="[0-9\.]*">
       <data key="originfile">main.c</data>
       <data key="startline">29</data>
       <data key="assumption.scope">main</data>
     </edge>
-    <node id="29.31"/>
-    <edge source="29.31" target="5.33">
+    <node id="[0-9\.]*"/>
+    <edge source="[0-9\.]*" target="[0-9\.]*">
       <data key="originfile">main.c</data>
       <data key="startline">15</data>
       <data key="assumption.scope">remove_one</data>
     </edge>
-    <node id="5.33">
+    <node id="[0-9\.]*">
       <data key="violation">true</data>
     </node>
-    <edge source="5.33" target="sink">
+    <edge source="[0-9\.]*" target="sink">
       <data key="originfile">main.c</data>
       <data key="startline">31</data>
     </edge>

--- a/regression/cbmc/graphml_witness1/test.desc
+++ b/regression/cbmc/graphml_witness1/test.desc
@@ -49,7 +49,7 @@ main.c
     <node id="[0-9\.]*">
       <data key="entry">true</data>
     </node>
-    <edge source="33.22" target="4.29">
+    <edge source="[0-9\.]*" target="[0-9\.]*">
       <data key="originfile">main.c</data>
       <data key="startline">21</data>
     </edge>

--- a/src/cbmc/symex_coverage.cpp
+++ b/src/cbmc/symex_coverage.cpp
@@ -276,7 +276,7 @@ void symex_coveraget::compute_overall_coverage(
   forall_goto_functions(gf_it, goto_functions)
   {
     if(!gf_it->second.body_available() ||
-       gf_it->first==ID__start ||
+       gf_it->first==goto_functions.entry_point() ||
        gf_it->first==CPROVER_PREFIX "initialize")
       continue;
 

--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -1391,7 +1391,7 @@ void instrument_cover_goals(
 {
   Forall_goto_functions(f_it, goto_functions)
   {
-    if(f_it->first==ID__start ||
+    if(f_it->first==goto_functions.entry_point() ||
        f_it->first=="__CPROVER_initialize")
       continue;
 

--- a/src/goto-programs/goto_functions_template.h
+++ b/src/goto-programs/goto_functions_template.h
@@ -16,6 +16,7 @@ Date: June 2003
 
 #include <util/std_types.h>
 #include <util/symbol.h>
+#include <util/cprover_prefix.h>
 
 template <class bodyT>
 class goto_function_templatet
@@ -123,7 +124,7 @@ public:
   static inline irep_idt entry_point()
   {
     // do not confuse with C's "int main()"
-    return ID__start;
+    return CPROVER_PREFIX "_start";
   }
 
   void swap(goto_functions_templatet &other)

--- a/src/goto-programs/show_goto_functions_json.cpp
+++ b/src/goto-programs/show_goto_functions_json.cpp
@@ -67,7 +67,7 @@ json_objectt show_goto_functions_jsont::convert(
     json_function["isBodyAvailable"]=
       jsont::json_boolean(function.body_available());
     bool is_internal=(has_prefix(id2string(function_name), CPROVER_PREFIX) ||
-                      function_name==ID__start);
+                      function_name==goto_functions.entry_point());
     json_function["isInternal"]=jsont::json_boolean(is_internal);
 
     if(function.body_available())

--- a/src/goto-programs/show_goto_functions_xml.cpp
+++ b/src/goto-programs/show_goto_functions_xml.cpp
@@ -80,7 +80,7 @@ xmlt show_goto_functions_xmlt::convert(
     xml_function.set_attribute_bool(
       "is_body_available", function.body_available());
     bool is_internal=(has_prefix(id2string(function_name), CPROVER_PREFIX) ||
-                      function_name==ID__start);
+                      function_name==goto_functions.entry_point());
     xml_function.set_attribute_bool("is_internal", is_internal);
 
     if(function.body_available())

--- a/src/util/irep_ids.txt
+++ b/src/util/irep_ids.txt
@@ -681,7 +681,6 @@ read
 write
 native
 final
-_start
 compound_literal
 custom_bv
 custom_unsignedbv


### PR DESCRIPTION
While identifiers starting with _ (or __ ?) are reserved according to the C standard,
people nevertheless use them. Using __CPROVER_start will make collisions less
likely.

Includes cleanup so that, outside cegis, there is exactly one point where this
name is spelled out.