### PR TITLE
Switch to using Boost header-only tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ libzip/
 zlib/
 minisat*/
 glucose-syrup/
+boost-include/
 
 # flex/bison generated files
 src/ansi-c/ansi_c_lex.yy.cpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,6 @@ matrix:
             - libwww-perl
             - g++-5
             - libubsan0
-            - libboost-system-dev
-            - libboost-filesystem-dev
       before_install:
         - mkdir bin ; ln -s /usr/bin/gcc-5 bin/gcc
       # env: COMPILER=g++-5 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover -fno-omit-frame-pointer"
@@ -60,8 +58,6 @@ matrix:
             - clang-3.7
             - libstdc++-5-dev
             - libubsan0
-            - libboost-system-dev
-            - libboost-filesystem-dev
       before_install:
         - mkdir bin ; ln -s /usr/bin/clang-3.7 bin/gcc
       # env: COMPILER=clang++-3.7 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined,integer -fno-omit-frame-pointer"
@@ -74,7 +70,9 @@ script:
   - if [ -L bin/gcc ] ; then export PATH=$PWD/bin:$PATH ; fi ;
     COMMAND="make -C src minisat2-download" &&
     eval ${PRE_COMMAND} ${COMMAND} &&
-    COMMAND="make -C src CXX=$COMPILER CXXFLAGS=\"-Wall -O2 -g -Werror -Wno-deprecated-register -pedantic -Wno-sign-compare\" -j2" &&
+    COMMAND="make -C src boost-download" &&
+    eval ${PRE_COMMAND} ${COMMAND} &&
+    COMMAND="make -C src CXX=$COMPILER CXXFLAGS=\"-Wall -O2 -g -Werror -Wno-deprecated-register -pedantic -Wno-sign-compare -DUSE_BOOST\" -j2" &&
     eval ${PRE_COMMAND} ${COMMAND} &&
     COMMAND="env UBSAN_OPTIONS=print_stacktrace=1 make -C regression test" &&
     eval ${PRE_COMMAND} ${COMMAND} &&

--- a/src/Makefile
+++ b/src/Makefile
@@ -84,4 +84,13 @@ glucose-download:
 	@(cd ../glucose-syrup; patch -p1 < ../scripts/glucose-syrup-patch)
 	@rm glucose-syrup.tgz
 
+boost-download:
+	@echo "Downloading boost headers"
+	@lwp-download "http://storage.googleapis.com/diffblue-mirror/boost/boost_1.63_headers.tar.bz2?GoogleAccessId=diffbluemaster@diffblue-cr.iam.gserviceaccount.com&Expires=1542631994&Signature=X2GwPSm1dR8IPGP0D5JoyDmOnL%2Br4F7AI7NUA7SbmOAowMC0JS7Q5A6%2BkQziUzQa88zpddr5gSRbDOLqdoGzwLrYgPNtURS5dJ7l1q6xfJWSS%2FYf8be%2FSbdfLVN8qcXKCsfDe05Hqf%2Bz2cksqjQ1H6L0syj43rftbW4%2F7tp355%2BkinCeE466ulJeyru3CK%2F3RGX2Ul6ZQV6lNxkit1m6QM5BRtLbUQ1GOW0GCK9fWH2fry2n7kRVBCM3oz8fX62kLdKYlaXCf%2BvvXs9hOOmcQurL%2Fa4DCJYoClX%2BpznqXVmjUY%2FI3pD4HlRKbCeiPnoC6de2i1uxFNSVTBpG3w%2BtfA%3D%3D"
+	@tar xfj boost_1.63_headers.tar.bz2
+	@rm -Rf ../boost-include
+	@mkdir ../boost-include
+	@mv boost ../boost-include/boost
+	@rm boost_1.63_headers.tar.bz2
+
 .PHONY: minisat2-download glucose-download

--- a/src/common
+++ b/src/common
@@ -1,3 +1,6 @@
+MAKEFILES_WITHOUT_DEPS = $(filter-out %.d, $(MAKEFILE_LIST))
+THIS_DIR = $(abspath $(dir $(lastword $(MAKEFILES_WITHOUT_DEPS))))
+
 # Build platform
 # (use one of AUTO, Unix, OSX, OSX_Universal, MSVC, Cygwin, MinGW)
 
@@ -155,6 +158,8 @@ first_target: all
 
 HOSTCXX ?= $(CXX)
 
+BOOST_DIR = $(abspath $(THIS_DIR)/../boost-include)
+INCLUDES += -I$(BOOST_DIR)
 CP_CFLAGS += $(CFLAGS) $(INCLUDES)
 CP_CXXFLAGS += $(CXXFLAGS) $(INCLUDES)
 
@@ -207,4 +212,3 @@ D_FILES1 = $(SRC:.c=.d)
 D_FILES = $(D_FILES1:.cpp=.d)
 
 -include $(D_FILES)
-


### PR DESCRIPTION
This should level the Boost environment across platforms.