### PR TITLE
Test to demonstate assert bug on alpine

### DIFF
--- a/regression/cbmc/simple_assert/main.c
+++ b/regression/cbmc/simple_assert/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+
+int main(int argc, char* argv[])
+{
+  int x = 5;
+  assert(x==5);
+
+  return 0;
+}

--- a/regression/cbmc/simple_assert/test.desc
+++ b/regression/cbmc/simple_assert/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--cover location
+
+^EXIT=0$
+^SIGNAL=0$
+^\[main\.coverage\.1\] .* function main block 1: SATISFIED$
+^\[main\.coverage\.2\] .* function main block 2: SATISFIED$
+^\[main\.coverage\.3\] .* function main block 3: SATISFIED$
+^\[main\.coverage\.4\] .* function main block 4: SATISFIED$
+4 of 4 covered \(100.0%\)$
+--
+^warning: ignoring
+^CONVERSION ERROR$


### PR DESCRIPTION
The user added assert in this test does not get coverage under alpine linux.

I can make this a KNOWNBUG but I thought it would be useful for it to run on CI so everyone can see the problem. The problem seems to be to do with how the assert is handled (possibly caused by musl having a different assert.h when compared to glibc).

**GOTO on Ubuntu Linux**

```
main /* main */
        // 0 file regression/goto-analyzer/sensitivity-test-constants-int/../sensitivity-test-common-files/int_sensitivity_tests.c line 7 function main
        signed int x;
        // 1 file regression/goto-analyzer/sensitivity-test-constants-int/../sensitivity-test-common-files/int_sensitivity_tests.c line 7 function main
        x = 0;
        // 2 file regression/goto-analyzer/sensitivity-test-constants-int/../sensitivity-test-common-files/int_sensitivity_tests.c line 8 function main
        ASSERT x == 0 // assertion x==0
        // 3 file regression/goto-analyzer/sensitivity-test-constants-int/../sensitivity-test-common-files/int_sensitivity_tests.c line 8 function main
        IF !(x == 0) THEN GOTO 1
        // 4 file regression/goto-analyzer/sensitivity-test-constants-int/../sensitivity-test-common-files/int_sensitivity_tests.c line 8 function main
        (void)0;
        // 5 no location
     1: SKIP
        // 6 file regression/goto-analyzer/sensitivity-test-constants-int/../sensitivity-test-common-files/int_sensitivity_tests.c line 9 function main
        main#return_value = 0;
        // 7 file regression/goto-analyzer/sensitivity-test-constants-int/../sensitivity-test-common-files/int_sensitivity_tests.c line 9 function main
        dead x;
        // 8 file regression/goto-analyzer/sensitivity-test-constants-int/../sensitivity-test-common-files/int_sensitivity_tests.c line 9 function main
        GOTO 2
        // 9 file regression/goto-analyzer/sensitivity-test-constants-int/../sensitivity-test-common-files/int_sensitivity_tests.c line 10 function main
     2: END_FUNCTION
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

**GOTO on Alpine Linux**

```
main /* main */
        // 0 file /cbmc/regression/goto-analyzer/sensitivity-test-constants-int/../sensitivity-test-common-files/int_sensitivity_tests.c line 7 function main
        signed int x;
        // 1 file /cbmc/regression/goto-analyzer/sensitivity-test-constants-int/../sensitivity-test-common-files/int_sensitivity_tests.c line 7 function main
        x = 0;
        // 2 file /cbmc/regression/goto-analyzer/sensitivity-test-constants-int/../sensitivity-test-common-files/int_sensitivity_tests.c line 8 function main
        IF !(x == 0) THEN GOTO 1
        // 3 no location
        TRUE;
        // 4 no location
        GOTO 4
        // 5 file /cbmc/regression/goto-analyzer/sensitivity-test-constants-int/../sensitivity-test-common-files/int_sensitivity_tests.c line 8 function main
     1: ASSERT FALSE // assertion x==0
        // 6 no location
        IF !(0 != 0) THEN GOTO 2
        // 7 no location
        TRUE;
        // 8 no location
        GOTO 3
        // 9 no location
     2: FALSE;
        // 10 no location
     3: SKIP
        // 11 no location
     4: SKIP
        // 12 file /cbmc/regression/goto-analyzer/sensitivity-test-constants-int/../sensitivity-test-common-files/int_sensitivity_tests.c line 9 function main
        main#return_value = 0;
        // 13 file /cbmc/regression/goto-analyzer/sensitivity-test-constants-int/../sensitivity-test-common-files/int_sensitivity_tests.c line 9 function main
        dead x;
        // 14 file /cbmc/regression/goto-analyzer/sensitivity-test-constants-int/../sensitivity-test-common-files/int_sensitivity_tests.c line 9 function main
        GOTO 5
        // 15 file /cbmc/regression/goto-analyzer/sensitivity-test-constants-int/../sensitivity-test-common-files/int_sensitivity_tests.c line 10 function main
     5: END_FUNCTION
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```