### PR TITLE
Use versioned container of Alpine Linux.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ matrix:
       services:
         - docker
       before_install:
-        - docker pull diffblue/cbmc-builder:alpine
+        - docker pull diffblue/cbmc-builder:alpine-0.0.1
       env:
-        - PRE_COMMAND="docker run -v ${TRAVIS_BUILD_DIR}:/cbmc -v ${HOME}/.ccache:/root/.ccache diffblue/cbmc-builder:alpine"
+        - PRE_COMMAND="docker run -v ${TRAVIS_BUILD_DIR}:/cbmc -v ${HOME}/.ccache:/root/.ccache diffblue/cbmc-builder:alpine-0.0.1"
         - COMPILER="ccache g++"
 
     # OS X using g++


### PR DESCRIPTION
After standardisation and release of [diffblue/cbmc-builder](https://github.com/diffblue/cbmc-builder), we should use versioned number of container so change to new version will be under control (currently we always fetch `latest`).