### PR TITLE
Fixes to pointer handling in goto_rw [depends-on: #2646]

### DIFF
--- a/regression/goto-instrument/slice19/test.desc
+++ b/regression/goto-instrument/slice19/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --full-slice
 ^EXIT=0$

--- a/regression/goto-instrument/slice24/main.c
+++ b/regression/goto-instrument/slice24/main.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+#include <stdlib.h>
+
+static void f(int* x) { *x = 5; }
+static void g(int *x) { assert(*x == 5); }
+
+int main(int argc, char** argv) {
+
+  int *x = (int*)malloc(sizeof(int));
+  f(x);
+  g(x);
+
+  return 0;
+}

--- a/regression/goto-instrument/slice24/test.desc
+++ b/regression/goto-instrument/slice24/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--full-slice --add-library
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -127,8 +127,6 @@ void rw_range_sett::get_objects_dereference(
 {
   const exprt &pointer=deref.pointer();
   get_objects_rec(get_modet::READ, pointer);
-  if(mode!=get_modet::READ)
-    get_objects_rec(mode, pointer);
 }
 
 void rw_range_sett::get_objects_byte_extract(
@@ -413,14 +411,13 @@ void rw_range_sett::get_objects_typecast(
 
 void rw_range_sett::get_objects_address_of(const exprt &object)
 {
-  if(object.id()==ID_string_constant ||
+  if(object.id()==ID_symbol ||
+     object.id()==ID_string_constant ||
      object.id()==ID_label ||
      object.id()==ID_array ||
      object.id()=="NULL-object")
     // constant, nothing to do
     return;
-  else if(object.id()==ID_symbol)
-    get_objects_rec(get_modet::READ, object);
   else if(object.id()==ID_dereference)
     get_objects_rec(get_modet::READ, object);
   else if(object.id()==ID_index)
@@ -562,11 +559,6 @@ void rw_range_sett::get_objects_rec(
           expr.id()==ID_string_constant)
   {
     // dereferencing may yield some weird ones, ignore these
-  }
-  else if(mode==get_modet::LHS_W)
-  {
-    forall_operands(it, expr)
-      get_objects_rec(mode, *it);
   }
   else
     throw "rw_range_sett: assignment to `"+expr.id_string()+"' not handled";

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -127,6 +127,11 @@ void rw_range_sett::get_objects_dereference(
 {
   const exprt &pointer=deref.pointer();
   get_objects_rec(get_modet::READ, pointer);
+
+  // we don't have points-to information, dereferencing will yield some
+  // in-memory object
+  const symbolt &memory_symbol = ns.lookup(CPROVER_PREFIX "memory");
+  get_objects_rec(mode, memory_symbol.symbol_expr(), -1, size);
 }
 
 void rw_range_sett::get_objects_byte_extract(
@@ -612,6 +617,13 @@ void rw_range_set_value_sett::get_objects_dereference(
   if(object.is_not_nil() &&
      !value_set_dereferencet::has_dereference(object))
     get_objects_rec(mode, object, range_start, new_size);
+  else
+  {
+    // we don't have sufficient points-to information, dereferencing will yield
+    // some in-memory object
+    const symbolt &memory_symbol = ns.lookup(CPROVER_PREFIX "memory");
+    get_objects_rec(mode, memory_symbol.symbol_expr(), -1, size);
+  }
 }
 
 void guarded_range_domaint::output(


### PR DESCRIPTION
1. This reverts commit 55d129761bd06033af036e1585cdf411782509d2. Pointers require dereferencing, and taking an address of an object does not induce any reads on the object.
2. goto_rw tries to be over-approximating in its set of read/written objects, but had previously failed to do so in case of pointers. With the new fallback to `__CPROVER_memory` this ought to be resolved (albeit in a very coarse manner).