### PR TITLE
Temporarily disable the goto-analyzer regression tests.

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -3,7 +3,6 @@ DIRS = ansi-c \
        cbmc \
        cpp \
        cbmc-java \
-       goto-analyzer \
        goto-instrument \
        test-script \
        # Empty last line


### PR DESCRIPTION
Cherry picking 23d6aade2af1a1689e5ce5e3527fc5b3ec6c79ae from the goto-analyzer
branch introduced tests that require changes to the command-line arguments
of goto-analyzer in preceeding patches.  Without these the tests will fail,
causing test failures on master.