### PR TITLE
Add range-erase to goto_program_template

### DIFF
--- a/src/goto-programs/goto_program_template.h
+++ b/src/goto-programs/goto_program_template.h
@@ -275,6 +275,12 @@ public:
   //! The list of instructions in the goto program
   instructionst instructions;
 
+  //! A range-erase which should maintain goto program invariants
+  targett erase(const_targett first, const_targett last)
+  {
+    return instructions.erase(first, last);
+  }
+
   // Convert a const_targett to a targett - use with care and avoid
   // whenever possible
   targett const_cast_target(const_targett t)


### PR DESCRIPTION
As per #691.

Once the goto-programs class has a method to check whether its variants have been maintained, this method should probably check and fix-up the goto program if necessary after the erase.