### PR TITLE
Remove blank lines from regression test specs

### DIFF
--- a/regression/acceleration/array_unsafe1/test.desc
+++ b/regression/acceleration/array_unsafe1/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --no-unwinding-assertions
-
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/acceleration/array_unsafe2/test.desc
+++ b/regression/acceleration/array_unsafe2/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --no-unwinding-assertions
-
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/acceleration/array_unsafe3/test.desc
+++ b/regression/acceleration/array_unsafe3/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --no-unwinding-assertions
-
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/acceleration/array_unsafe4/test.desc
+++ b/regression/acceleration/array_unsafe4/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --no-unwinding-assertions
-
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/acceleration/const_unsafe1/test.desc
+++ b/regression/acceleration/const_unsafe1/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --no-unwinding-assertions
-
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/acceleration/diamond_unsafe1/test.desc
+++ b/regression/acceleration/diamond_unsafe1/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --no-unwinding-assertions
-
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/acceleration/diamond_unsafe2/test.desc
+++ b/regression/acceleration/diamond_unsafe2/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --no-unwinding-assertions
-
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/acceleration/functions_unsafe1/test.desc
+++ b/regression/acceleration/functions_unsafe1/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --no-unwinding-assertions
-
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/acceleration/multivar_unsafe1/test.desc
+++ b/regression/acceleration/multivar_unsafe1/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --no-unwinding-assertions
-
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/acceleration/nested_unsafe1/test.desc
+++ b/regression/acceleration/nested_unsafe1/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --no-unwinding-assertions
-
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/acceleration/overflow_unsafe1/test.desc
+++ b/regression/acceleration/overflow_unsafe1/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --no-unwinding-assertions
-
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/acceleration/phases_unsafe1/test.desc
+++ b/regression/acceleration/phases_unsafe1/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --no-unwinding-assertions
-
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/acceleration/simple_unsafe1/test.desc
+++ b/regression/acceleration/simple_unsafe1/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --no-unwinding-assertions
-
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/acceleration/simple_unsafe2/test.desc
+++ b/regression/acceleration/simple_unsafe2/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --no-unwinding-assertions
-
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/acceleration/simple_unsafe3/test.desc
+++ b/regression/acceleration/simple_unsafe3/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --no-unwinding-assertions
-
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/acceleration/simple_unsafe4/test.desc
+++ b/regression/acceleration/simple_unsafe4/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --no-unwinding-assertions
-
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/ansi-c/static_inline1/test.desc
+++ b/regression/ansi-c/static_inline1/test.desc
@@ -4,6 +4,5 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
-
 --
 ^warning: ignoring

--- a/regression/ansi-c/static_inline2/test.desc
+++ b/regression/ansi-c/static_inline2/test.desc
@@ -4,6 +4,5 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
-
 --
 ^warning: ignoring

--- a/regression/cbmc-incr-oneloop/unwind-forever1/test.desc
+++ b/regression/cbmc-incr-oneloop/unwind-forever1/test.desc
@@ -3,6 +3,5 @@ main.c
  --incremental-check main.0
 ^EXIT=142$
 ^SIGNAL=0$
-
 --
 ^warning: ignoring

--- a/regression/cbmc-incr-oneloop/unwind-forever2/test.desc
+++ b/regression/cbmc-incr-oneloop/unwind-forever2/test.desc
@@ -3,6 +3,5 @@ main.c
 --incremental-check main.0
 ^EXIT=142$
 ^SIGNAL=0$
-
 --
 ^warning: ignoring

--- a/regression/cbmc-java/tableswitch2/test.desc
+++ b/regression/cbmc-java/tableswitch2/test.desc
@@ -1,7 +1,6 @@
 CORE
 table_switch_neg_offset.class
 --function table_switch_neg_offset.f
-
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cpp-linter/function-comment-header1/test.desc
+++ b/regression/cpp-linter/function-comment-header1/test.desc
@@ -3,6 +3,5 @@ main.cpp
 
 ^main\.cpp:26:  Could not find function header comment for foo  \[readability/function_comment\] \[4\]
 ^Total errors found: 1$
-
 ^SIGNAL=0$
 --

--- a/regression/cpp-linter/struct-inline-decl/test.desc
+++ b/regression/cpp-linter/struct-inline-decl/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.cpp
 
-
 ^Total errors found: 0$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/approx-array-variable-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-array-variable-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp_tbl\[\(signed long int\)i\] == f2 THEN GOTO [0-9]$
 ^\s*IF fp_tbl\[\(signed long int\)i\] == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/approx-const-fp-array-variable-cast-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-cast-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/approx-const-fp-array-variable-const-fp-with-null/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-const-fp-with-null/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/approx-const-fp-array-variable-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/approx-const-fp-array-variable-const-pointer-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-const-pointer-const-struct-non-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/approx-const-fp-array-variable-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-const-struct-non-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/approx-const-fp-array-variable-invalid-cast-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-invalid-cast-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == \(const void_fp\)f2 THEN GOTO [0-9]$
 ^\s*IF fp == \(const void_fp\)f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-array-const-pointer-const-fp-const-lost/test.desc
+++ b/regression/goto-analyzer/no-match-const-array-const-pointer-const-fp-const-lost/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF \*fp == f1 THEN GOTO [0-9]$
 ^\s*IF \*fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-array-literal-const-fp-run-time/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-array-literal-const-fp-run-time/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-array-literal-non-const-fp-run-time/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-array-literal-non-const-fp-run-time/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-array-literal-non-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-array-literal-non-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp2 == f1 THEN GOTO [0-9]$
 ^\s*IF fp2 == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-array-non-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-array-non-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp2 == f1 THEN GOTO [0-9]$
 ^\s*IF fp2 == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-binary-op-const-lost/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-binary-op-const-lost/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-const-array-index-lost/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-array-index-lost/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF \*fp == f1 THEN GOTO [0-9]$
 ^\s*IF \*fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-const-array-lost/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-array-lost/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF \*fp == f1 THEN GOTO [0-9]$
 ^\s*IF \*fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-const-cast/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-cast/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-const-lost/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-lost/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-const-pointer-const-struct-const-fp-null/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-pointer-const-struct-const-fp-null/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*ASSERT FALSE // invalid function pointer$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/no-match-const-fp-const-pointer-non-const-struct-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-pointer-non-const-struct-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-dereference-const-pointer-null/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-dereference-const-pointer-null/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*ASSERT FALSE // invalid function pointer$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/no-match-const-fp-dereference-non-const-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-dereference-non-const-pointer-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF final_fp == f1 THEN GOTO [0-9]$
 ^\s*IF final_fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-dynamic-array-non-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-dynamic-array-non-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-non-const-pointer-non-const-struct-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-non-const-pointer-non-const-struct-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-non-const-struct-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-non-const-struct-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-non-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-non-const-struct-non-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-null/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-null/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*ASSERT FALSE // invalid function pointer$
 --

--- a/regression/goto-analyzer/no-match-const-fp-ternerary-op-const-lost/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-ternerary-op-const-lost/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-pointer-const-struct-const-fp-const-cast/test.desc
+++ b/regression/goto-analyzer/no-match-const-pointer-const-struct-const-fp-const-cast/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF container_pointer->fp == f1 THEN GOTO [0-9]$
 ^\s*IF container_pointer->fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-pointer-non-const-struct-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-pointer-non-const-struct-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF pts->go == f1 THEN GOTO [0-9]$
 ^\s*IF pts->go == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-struct-non-const-fp-null/test.desc
+++ b/regression/goto-analyzer/no-match-const-struct-non-const-fp-null/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*ASSERT FALSE // invalid function pointer$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/no-match-dereference-const-pointer-const-array-literal-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-dereference-const-pointer-const-array-literal-pointer-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF \*container_ptr->fp_tbl\[\(signed long int\)1\] == f1 THEN GOTO [0-9]$
 ^\s*IF \*container_ptr->fp_tbl\[\(signed long int\)1\] == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-dereference-non-const-struct-const-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-dereference-non-const-struct-const-pointer-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF \*container_container\.container == f1 THEN GOTO [0-9]$
 ^\s*IF \*container_container\.container == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-dereference-non-const-struct-non-const-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-dereference-non-const-struct-non-const-pointer-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF \*container_container\.container == f1 THEN GOTO [0-9]$
 ^\s*IF \*container_container\.container == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-non-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-non-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-parameter-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-parameter-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-parameter-fp/test.desc
+++ b/regression/goto-analyzer/no-match-parameter-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-pointer-const-struct-array-literal-non-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-pointer-const-struct-array-literal-non-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*IF container_ptr->fp_tbl\[\(signed long int\)1\] == f1 THEN GOTO [0-9]$
 ^\s*IF container_ptr->fp_tbl\[\(signed long int\)1\] == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/precise-const-fp-array-literal-const-fp-run-time/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-array-literal-const-fp-run-time/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 --

--- a/regression/goto-analyzer/precise-const-fp-array-literal-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-array-literal-const-struct-non-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-fp-array-variable-const-pointer-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-array-variable-const-pointer-const-struct-non-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*f2\(\);
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-fp-const-struct-const-array-literal-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-const-struct-const-array-literal-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-fp-const-struct-non-const-array-literal-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-const-struct-non-const-array-literal-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-fp-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-const-struct-non-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*f2\(\);
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-fp-dereference-const-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-dereference-const-pointer-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*f2\(\);
 --

--- a/regression/goto-analyzer/precise-const-pointer-const-struct-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-pointer-const-struct-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*f2\(\);$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-struct-non-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*f2\(\);
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-derefence-const-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-derefence-const-pointer-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-derefence/test.desc
+++ b/regression/goto-analyzer/precise-derefence/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*f2\(\);
 --

--- a/regression/goto-analyzer/precise-dereference-address-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-dereference-address-pointer-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-dereference-const-struct-const-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-dereference-const-struct-const-pointer-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-dereference-const-struct-const-pointer-const-struct-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-dereference-const-struct-const-pointer-const-struct-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-dereference-const-struct-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-dereference-const-struct-pointer-const-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --show-goto-functions --verbosity 10 --pointer-check
-
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^SIGNAL=0$

--- a/regression/goto-instrument/approx-array-variable-const-fp-only-remove-const/test.desc
+++ b/regression/goto-instrument/approx-array-variable-const-fp-only-remove-const/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --verbosity 10 --pointer-check --remove-const-function-pointers
-
 ^\s*IF fp_tbl\[\(signed long int\)i\] == f2 THEN GOTO [0-9]$
 ^\s*IF fp_tbl\[\(signed long int\)i\] == f3 THEN GOTO [0-9]$
 ^\s*IF fp_tbl\[\(signed long int\)i\] == f4 THEN GOTO [0-9]$

--- a/regression/goto-instrument/approx-array-variable-const-fp-remove-all-fp/test.desc
+++ b/regression/goto-instrument/approx-array-variable-const-fp-remove-all-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --verbosity 10 --pointer-check --remove-function-pointers
-
 ^\s*IF fp_tbl\[\(signed long int\)i\] == f2 THEN GOTO [0-9]$
 ^\s*IF fp_tbl\[\(signed long int\)i\] == f3 THEN GOTO [0-9]$
 ^\s*IF fp_tbl\[\(signed long int\)i\] == f4 THEN GOTO [0-9]$

--- a/regression/goto-instrument/no-match-non-const-fp-only-remove-const/test.desc
+++ b/regression/goto-instrument/no-match-non-const-fp-only-remove-const/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --verbosity 10 --pointer-check --remove-const-function-pointers
-
 ^\s*fp\(\);$
 ^SIGNAL=0$
 --

--- a/regression/goto-instrument/no-match-non-const-fp-remove-all-fp/test.desc
+++ b/regression/goto-instrument/no-match-non-const-fp-remove-all-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --verbosity 10 --pointer-check --remove-function-pointers
-
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-instrument/precise-const-fp-only-remove-const/test.desc
+++ b/regression/goto-instrument/precise-const-fp-only-remove-const/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --verbosity 10 --pointer-check --remove-const-function-pointers
-
 ^\s*f2\(\);
 --
 ^warning: ignoring

--- a/regression/goto-instrument/precise-const-fp-remove-all-fp/test.desc
+++ b/regression/goto-instrument/precise-const-fp-remove-all-fp/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --verbosity 10 --pointer-check --remove-function-pointers
-
 ^\s*f2\(\);
 --
 ^warning: ignoring


### PR DESCRIPTION
Matching blank lines fails on Windows/AppVeyor. Also, there should not be any
requirement for our output to contain blank lines.