### PR TITLE
Initialise array clsid fields

### DIFF
--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -802,14 +802,21 @@ void goto_convertt::do_java_new_array(
   t_n->code=code_assignt(lhs, malloc_expr);
   t_n->source_location=location;
 
-  // multi-dimensional?
-
   assert(ns.follow(object_type).id()==ID_struct);
   const struct_typet &struct_type=to_struct_type(ns.follow(object_type));
   assert(struct_type.components().size()==3);
 
-  // if it's an array, we need to set the length field
+  // Init base class:
   dereference_exprt deref(lhs, object_type);
+  exprt zero_object=
+    zero_initializer(object_type, location, ns, get_message_handler());
+  set_class_identifier(
+    to_struct_expr(zero_object), ns, to_symbol_type(object_type));
+  goto_programt::targett t_i=dest.add_instruction(ASSIGN);
+  t_i->code=code_assignt(deref, zero_object);
+  t_i->source_location=location;
+
+  // if it's an array, we need to set the length field
   member_exprt length(
     deref,
     struct_type.components()[1].get_name(),
@@ -841,6 +848,8 @@ void goto_convertt::do_java_new_array(
   goto_programt::targett t_d=dest.add_instruction(OTHER);
   t_d->code=array_set;
   t_d->source_location=location;
+
+  // multi-dimensional?
 
   if(rhs.operands().size()>=2)
   {

--- a/src/java_bytecode/java_bytecode_convert_class.cpp
+++ b/src/java_bytecode/java_bytecode_convert_class.cpp
@@ -335,13 +335,19 @@ void java_bytecode_convert_classt::add_array_types()
     struct_type.components().reserve(3);
     struct_typet::componentt
       comp0("@java.lang.Object", symbol_typet("java::java.lang.Object"));
+    comp0.set_pretty_name("@java.lang.Object");
+    comp0.set_base_name("@java.lang.Object");
     struct_type.components().push_back(comp0);
 
     struct_typet::componentt comp1("length", java_int_type());
+    comp1.set_pretty_name("length");
+    comp1.set_base_name("length");
     struct_type.components().push_back(comp1);
 
     struct_typet::componentt
       comp2("data", pointer_typet(java_type_from_char(l)));
+    comp2.set_pretty_name("data");
+    comp2.set_base_name("data");
     struct_type.components().push_back(comp2);
 
     symbolt symbol;


### PR DESCRIPTION
Not doing this prevented any cast-to-array-type from succeeding, which is common e.g. in return from java.lang.Object.clone.