### PR TITLE
Run static initializers for enumeration types before all others

### DIFF
--- a/src/java_bytecode/java_bytecode_convert_class.cpp
+++ b/src/java_bytecode/java_bytecode_convert_class.cpp
@@ -107,9 +107,12 @@ void java_bytecode_convert_classt::convert(const classt &c)
   class_type.set_tag(c.name);
   class_type.set(ID_base_name, c.name);
   if(c.is_enum)
+  {
     class_type.set(
       ID_java_enum_static_unwind,
       std::to_string(c.enum_elements+1));
+    class_type.set(ID_enumeration, true);
+  }
 
   if(!c.extends.empty())
   {


### PR DESCRIPTION
Really we should be running them in topographical order (or invoking
them at exactly the time the JVM spec says they will be, even better)
but this is much less effort and works around the common case that
enumeration types are assumed to be initialized by other static init
code, which treats them like global constants.