### PR TITLE
Adding build icon for AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status][build_img]][travis]
+[![Build Status][travis_img]][travis] [![Build Status][appveyor_img]][appveyor]
 
 [CProver Wiki](http://www.cprover.org/wiki)
 
@@ -19,5 +19,7 @@ License
 =======
 4-clause BSD license, see `LICENSE` file.
 
-[build_img]: https://travis-ci.org/diffblue/cbmc.svg?branch=master
 [travis]: https://travis-ci.org/diffblue/cbmc
+[travis_img]: https://travis-ci.org/diffblue/cbmc.svg?branch=master
+[appveyor]: https://ci.appveyor.com/project/diffblue/cbmc/
+[appveyor_img]: https://ci.appveyor.com/api/projects/status/github/diffblue/cbmc?svg=true&branch=master


### PR DESCRIPTION
Added the icon for AppVeyor so we don't miss it when it fails. 

See the README here: https://github.com/thk123/cbmc/tree/feature/appveyor-badge