### PR TITLE
Coverage (branch mode): add missing is-current-function test

### DIFF
--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -1411,7 +1411,7 @@ void instrument_cover_goals(
         t->source_location.set_function(i_it->function);
       }
 
-      if(i_it->is_goto() && !i_it->guard.is_true())
+      if(i_it->is_goto() && !i_it->guard.is_true() && cover_curr_function)
       {
         std::string b=std::to_string(basic_blocks[i_it]);
         std::string true_comment=


### PR DESCRIPTION
With `--cover-function-only`, all coverage tests should be conditional on
the function containing the target matching `--function`; however this particular
case got missed out.