### PR TITLE
Use small intrusive pointer in irep

### DIFF
--- a/src/util/cow.h
+++ b/src/util/cow.h
@@ -1,0 +1,86 @@
+#pragma once
+
+template <typename T> class cow final {
+public:
+  cow() = default;
+
+  template <typename... Ts>
+  explicit cow(Ts &&... ts) : t_(new T(std::forward<Ts>(ts)...)) {
+    t_->increment_use_count();
+  }
+
+  cow(const cow &rhs) {
+    if (!rhs.t_->is_unshareable()) {
+      t_ = rhs.t_;
+      t_->increment_use_count();
+    } else {
+      t_ = new T(*t_);
+    }
+  }
+
+  cow &operator=(const cow &rhs) {
+    auto copy(rhs);
+    swap(copy);
+    return *this;
+  }
+
+  cow(cow &&rhs) { swap(rhs); }
+
+  cow &operator=(cow &&rhs) {
+    swap(rhs);
+    return *this;
+  }
+
+  ~cow() {
+    if (t_->is_unshareable()) {
+      delete t_;
+    } else {
+      t_->decrement_use_count();
+      if (t_->get_use_count() == 0) {
+        delete t_;
+      }
+    }
+  }
+
+  void swap(cow &rhs) {
+    using std::swap;
+    swap(t_, rhs.t_);
+  }
+
+  const T &operator*() const { return *t_; }
+
+  T &write(bool mark_unshareable) {
+    if (!t_->is_unshareable() && t_->get_use_count() != 1) {
+
+    } else {
+
+    }
+  }
+
+private:
+  T *t_ = nullptr;
+};
+
+class cow_base {
+public:
+  cow_base() = default;
+  cow_base(const cow_base &) {}
+  cow_base &operator=(const cow_base &) {}
+  cow_base(cow_base &&) {}
+  cow_base &operator=(cow_base &&) {}
+
+  void increment_use_count() { use_count_ += 1; }
+  void decrement_use_count() { use_count_ -= 1; }
+  std::size_t get_use_count() const { return use_count_; }
+
+  void set_unshareable(bool u) { use_count_ = u ? unshareable : 1; }
+  bool is_unshareable() { return use_count_ == unshareable; }
+
+protected:
+  ~cow_base() = default;
+
+private:
+  static const std::size_t unshareable =
+      std::numeric_limits<std::size_t>::max();
+  std::size_t use_count_ = 0;
+};

--- a/src/util/irep.cpp
+++ b/src/util/irep.cpp
@@ -22,16 +22,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <iostream>
 #endif
 
-#ifdef SHARING
-small_shared_ptrt<irept::dt>& irept::get_empty_dt()
-{
-  // Putting this in a function makes sure that it exists the first time that
-  // the function is called, which solves undefined-order-of-static-init issues.
-  static small_shared_ptrt<dt> empty=make_small_shared_ptr<dt>();
-  return empty;
-}
-#endif
-
 /*******************************************************************\
 
 Function: named_subt_lower_bound

--- a/src/util/irep.cpp
+++ b/src/util/irep.cpp
@@ -22,10 +22,14 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <iostream>
 #endif
 
-irept nil_rep_storage;
-
 #ifdef SHARING
-irept::dt irept::empty_d;
+small_shared_ptrt<irept::dt>& irept::get_empty_dt()
+{
+  // Putting this in a function makes sure that it exists the first time that
+  // the function is called, which solves undefined-order-of-static-init issues.
+  static small_shared_ptrt<dt> empty=make_small_shared_ptr<dt>();
+  return empty;
+}
 #endif
 
 /*******************************************************************\
@@ -75,177 +79,13 @@ Function: get_nil_irep
 
 const irept &get_nil_irep()
 {
+  static irept nil_rep_storage;
   if(nil_rep_storage.id().empty()) // initialized?
+  {
     nil_rep_storage.id(ID_nil);
+  }
   return nil_rep_storage;
 }
-
-/*******************************************************************\
-
-Function: irept::detach
-
-  Inputs:
-
- Outputs:
-
- Purpose:
-
-\*******************************************************************/
-
-#ifdef SHARING
-void irept::detach()
-{
-  #ifdef IREP_DEBUG
-  std::cout << "DETACH1: " << data << std::endl;
-  #endif
-
-  if(data==&empty_d)
-  {
-    data=new dt;
-
-    #ifdef IREP_DEBUG
-    std::cout << "ALLOCATED " << data << std::endl;
-    #endif
-  }
-  else if(data->ref_count>1)
-  {
-    dt *old_data(data);
-    data=new dt(*old_data);
-
-    #ifdef IREP_DEBUG
-    std::cout << "ALLOCATED " << data << std::endl;
-    #endif
-
-    data->ref_count=1;
-    remove_ref(old_data);
-  }
-
-  assert(data->ref_count==1);
-
-  #ifdef IREP_DEBUG
-  std::cout << "DETACH2: " << data << std::endl;
-  #endif
-}
-#endif
-
-/*******************************************************************\
-
-Function: irept::remove_ref
-
-  Inputs:
-
- Outputs:
-
- Purpose:
-
-\*******************************************************************/
-
-#ifdef SHARING
-void irept::remove_ref(dt *old_data)
-{
-  if(old_data==&empty_d)
-    return;
-
-  #if 0
-  nonrecursive_destructor(old_data);
-  #else
-
-  assert(old_data->ref_count!=0);
-
-  #ifdef IREP_DEBUG
-  std::cout << "R: " << old_data << " " << old_data->ref_count << std::endl;
-  #endif
-
-  old_data->ref_count--;
-  if(old_data->ref_count==0)
-  {
-    #ifdef IREP_DEBUG
-    std::cout << "D: " << pretty() << std::endl;
-    std::cout << "DELETING " << old_data->data
-              << " " << old_data << std::endl;
-    old_data->clear();
-    std::cout << "DEALLOCATING " << old_data << "\n";
-    #endif
-
-    // may cause recursive call
-    delete old_data;
-
-    #ifdef IREP_DEBUG
-    std::cout << "DONE\n";
-    #endif
-  }
-  #endif
-}
-#endif
-
-/*******************************************************************\
-
-Function: irept::nonrecursive_destructor
-
-  Inputs:
-
- Outputs:
-
- Purpose: Does the same as remove_ref, but
-          using an explicit stack instead of recursion.
-
-\*******************************************************************/
-
-#ifdef SHARING
-void irept::nonrecursive_destructor(dt *old_data)
-{
-  std::vector<dt *> stack(1, old_data);
-
-  while(!stack.empty())
-  {
-    dt *d=stack.back();
-    stack.erase(--stack.end());
-    if(d==&empty_d)
-      continue;
-
-    assert(d->ref_count!=0);
-    d->ref_count--;
-
-    if(d->ref_count==0)
-    {
-      stack.reserve(stack.size()+
-                    d->named_sub.size()+
-                    d->comments.size()+
-                    d->sub.size());
-
-      for(named_subt::iterator
-          it=d->named_sub.begin();
-          it!=d->named_sub.end();
-          it++)
-      {
-        stack.push_back(it->second.data);
-        it->second.data=&empty_d;
-      }
-
-      for(named_subt::iterator
-          it=d->comments.begin();
-          it!=d->comments.end();
-          it++)
-      {
-        stack.push_back(it->second.data);
-        it->second.data=&empty_d;
-      }
-
-      for(subt::iterator
-          it=d->sub.begin();
-          it!=d->sub.end();
-          it++)
-      {
-        stack.push_back(it->data);
-        it->data=&empty_d;
-      }
-
-      // now delete, won't do recursion
-      delete d;
-    }
-  }
-}
-#endif
 
 /*******************************************************************\
 
@@ -261,9 +101,6 @@ Function: irept::move_to_named_sub
 
 void irept::move_to_named_sub(const irep_namet &name, irept &irep)
 {
-  #ifdef SHARING
-  detach();
-  #endif
   add(name).swap(irep);
   irep.clear();
 }
@@ -282,9 +119,6 @@ Function: irept::move_to_sub
 
 void irept::move_to_sub(irept &irep)
 {
-  #ifdef SHARING
-  detach();
-  #endif
   get_sub().push_back(get_nil_irep());
   get_sub().back().swap(irep);
 }

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -18,8 +18,11 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #define SHARING
 // #define HASH_CODE
-#define USE_MOVE
 // #define SUB_IS_LIST
+
+#ifdef SHARING
+#include "small_shared_ptr.h"
+#endif
 
 #ifdef SUB_IS_LIST
 #include <list>
@@ -102,85 +105,12 @@ public:
   bool is_nil() const { return id()==ID_nil; }
   bool is_not_nil() const { return id()!=ID_nil; }
 
-  explicit irept(const irep_idt &_id):data(&empty_d)
+  irept()=default;
+
+  explicit irept(const irep_idt &_id)
   {
     id(_id);
   }
-
-  #ifdef SHARING
-  // constructor for blank irep
-  irept():data(&empty_d)
-  {
-  }
-
-  // copy constructor
-  irept(const irept &irep):data(irep.data)
-  {
-    if(data!=&empty_d)
-    {
-      assert(data->ref_count!=0);
-      data->ref_count++;
-      #ifdef IREP_DEBUG
-      std::cout << "COPY " << data << " " << data->ref_count << std::endl;
-      #endif
-    }
-  }
-
-  #ifdef USE_MOVE
-  // Copy from rvalue reference.
-  // Note that this does avoid a branch compared to the
-  // standard copy constructor above.
-  irept(irept &&irep):data(irep.data)
-  {
-    #ifdef IREP_DEBUG
-    std::cout << "COPY MOVE\n";
-    #endif
-    irep.data=&empty_d;
-  }
-  #endif
-
-  irept &operator=(const irept &irep)
-  {
-    #ifdef IREP_DEBUG
-    std::cout << "ASSIGN\n";
-    #endif
-
-    // Ordering is very important here!
-    // Consider self-assignment, which may destroy 'irep'
-    dt *irep_data=irep.data;
-    if(irep_data!=&empty_d)
-      irep_data->ref_count++;
-
-    remove_ref(data); // this may kill 'irep'
-    data=irep_data;
-
-    return *this;
-  }
-
-  #ifdef USE_MOVE
-  // Note that the move assignment operator does avoid
-  // three branches compared to standard operator above.
-  irept &operator=(irept &&irep)
-  {
-    #ifdef IREP_DEBUG
-    std::cout << "ASSIGN MOVE\n";
-    #endif
-    // we simply swap two pointers
-    std::swap(data, irep.data);
-    return *this;
-  }
-  #endif
-
-  ~irept()
-  {
-    remove_ref(data);
-  }
-
-  #else
-  irept()
-  {
-  }
-  #endif
 
   const irep_idt &id() const
   { return read().data; }
@@ -256,106 +186,69 @@ protected:
   static bool is_comment(const irep_namet &name)
   { return !name.empty() && name[0]=='#'; }
 
-public:
+private:
   class dt
+  #ifdef SHARING
+    :public small_pointeet
+  #endif
   {
-  private:
-    friend class irept;
-
-    #ifdef SHARING
-    unsigned ref_count;
-    #endif
-
+  public:
     irep_idt data;
-
     named_subt named_sub;
     named_subt comments;
     subt sub;
 
     #ifdef HASH_CODE
-    mutable std::size_t hash_code;
+    mutable std::size_t hash_code=0;
     #endif
 
     void clear()
     {
       data.clear();
-      sub.clear();
       named_sub.clear();
       comments.clear();
+      sub.clear();
       #ifdef HASH_CODE
       hash_code=0;
       #endif
     }
-
-    void swap(dt &d)
-    {
-      d.data.swap(data);
-      d.sub.swap(sub);
-      d.named_sub.swap(named_sub);
-      d.comments.swap(comments);
-      #ifdef HASH_CODE
-      std::swap(d.hash_code, hash_code);
-      #endif
-    }
-
-    #ifdef SHARING
-    dt():ref_count(1)
-      #ifdef HASH_CODE
-         , hash_code(0)
-      #endif
-    {
-    }
-    #else
-    dt()
-      #ifdef HASH_CODE
-      :hash_code(0)
-      #endif
-    {
-    }
-    #endif
   };
 
-protected:
-  #ifdef SHARING
-  dt *data;
-  static dt empty_d;
-
-  static void remove_ref(dt *old_data);
-  static void nonrecursive_destructor(dt *old_data);
-  void detach();
+#ifdef SHARING
+  static small_shared_ptrt<dt> &get_empty_dt();
+  small_shared_ptrt<dt> data=get_empty_dt();
+#else
+  dt data;
+#endif
 
 public:
   const dt &read() const
   {
+    #ifdef SHARING
+    assert(data);
     return *data;
+    #else
+    return data;
+    #endif
   }
 
+private:
   dt &write()
   {
-    detach();
+    #ifdef SHARING
+    assert(data);
+    if(data.use_count()!=1)
+    {
+      data=make_small_shared_ptr<dt>(*data);
+    }
     #ifdef HASH_CODE
     data->hash_code=0;
     #endif
     return *data;
-  }
-
-  #else
-  dt data;
-
-public:
-  const dt &read() const
-  {
+    #else
     return data;
-  }
-
-  dt &write()
-  {
-    #ifdef HASH_CODE
-    data.hash_code=0;
     #endif
-    return data;
   }
-  #endif
 };
 
 // NOLINTNEXTLINE(readability/identifiers)

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -215,8 +215,7 @@ private:
   };
 
 #ifdef SHARING
-  static small_shared_ptrt<dt> &get_empty_dt();
-  small_shared_ptrt<dt> data=get_empty_dt();
+  small_shared_ptrt<dt> data=make_small_shared_ptr<dt>();
 #else
   dt data;
 #endif

--- a/src/util/merge_irep.h
+++ b/src/util/merge_irep.h
@@ -20,16 +20,16 @@ public:
   {
     // We assume that both are in the same container,
     // which isn't checked.
-    return data==other.data;
+    return &read()==&other.read();
   }
 
   bool operator<(const merged_irept &other) const
   {
     // again, assumes that both are in the same container
-    return ((std::size_t)data)<((std::size_t)other.data);
+    return &read()<&other.read();
   }
 
-  std::size_t hash() const { return (std::size_t)data; }
+  std::size_t hash() const { return reinterpret_cast<std::size_t>(&read()); }
 
   // copy constructor: will only copy from other merged_irepts
   merged_irept(const merged_irept &_src):irept(_src)

--- a/src/util/small_shared_ptr.h
+++ b/src/util/small_shared_ptr.h
@@ -1,0 +1,208 @@
+/*******************************************************************\
+
+Module: Small intrusive shared pointers
+
+Author: Reuben Thomas, reuben.thomas@diffblue.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_SMALL_SHARED_PTR_H
+#define CPROVER_UTIL_SMALL_SHARED_PTR_H
+
+#include <iosfwd>  // ostream
+#include <utility> // swap
+
+// TODO We should liberally scatter `constexpr`s and `noexcept`s on platforms
+// that support them.
+
+// This class is really similar to boost's intrusive_pointer, but can be a bit
+// simpler seeing as we're only using it one place...
+
+template <typename T>
+class small_shared_ptrt final
+{
+public:
+  small_shared_ptrt()=default;
+
+  explicit small_shared_ptrt(T *t):t_(t)
+  {
+    if(t_)
+    {
+      pointee_increment_use_count(*t_);
+    }
+  }
+
+  small_shared_ptrt(const small_shared_ptrt &rhs):t_(rhs.t_)
+  {
+    if(t_)
+    {
+      pointee_increment_use_count(*t_);
+    }
+  }
+
+  small_shared_ptrt &operator=(const small_shared_ptrt &rhs)
+  {
+    auto copy(rhs);
+    swap(copy);
+    return *this;
+  }
+
+  small_shared_ptrt(small_shared_ptrt &&rhs)
+  {
+    swap(rhs);
+  }
+
+  small_shared_ptrt &operator=(small_shared_ptrt &&rhs)
+  {
+    swap(rhs);
+    return *this;
+  }
+
+  ~small_shared_ptrt()
+  {
+    if(!t_)
+    {
+      return;
+    }
+    pointee_decrement_use_count(*t_);
+    if(pointee_use_count(*t_)==0)
+    {
+      delete t_;
+    }
+  }
+
+  void swap(small_shared_ptrt &rhs)
+  {
+    std::swap(t_, rhs.t_);
+  }
+
+  T *get() const
+  {
+    return t_;
+  }
+
+  T &operator*() const
+  {
+    return *t_;
+  }
+
+  T *operator->() const
+  {
+    return t_;
+  }
+
+  unsigned use_count() const
+  {
+    return t_?pointee_use_count(*t_):0;
+  }
+
+  explicit operator bool() const
+  {
+    return t_!=nullptr;
+  }
+
+private:
+  T *t_=nullptr;
+};
+
+template <typename T>
+std::ostream &operator<<(std::ostream &os, const small_shared_ptrt<T> &ptr)
+{
+  return os << ptr.get();
+}
+
+template <typename T, typename... Ts>
+small_shared_ptrt<T> make_small_shared_ptr(Ts &&... ts)
+{
+  return small_shared_ptrt<T>(new T(std::forward<Ts>(ts)...));
+}
+
+template <typename T, typename U>
+bool operator==(
+  const small_shared_ptrt<T> &lhs,
+  const small_shared_ptrt<U> &rhs)
+{
+  return lhs.get()==rhs.get();
+}
+
+template <typename T, typename U>
+bool operator!=(
+  const small_shared_ptrt<T> &lhs,
+  const small_shared_ptrt<U> &rhs)
+{
+  return lhs.get()!=rhs.get();
+}
+
+template <typename T, typename U>
+bool operator<(
+  const small_shared_ptrt<T> &lhs,
+  const small_shared_ptrt<U> &rhs)
+{
+  return lhs.get()<rhs.get();
+}
+
+template <typename T, typename U>
+bool operator>(
+  const small_shared_ptrt<T> &lhs,
+  const small_shared_ptrt<U> &rhs)
+{
+  return lhs.get()>rhs.get();
+}
+
+template <typename T, typename U>
+bool operator<=(
+  const small_shared_ptrt<T> &lhs,
+  const small_shared_ptrt<U> &rhs)
+{
+  return lhs.get()<=rhs.get();
+}
+
+template <typename T, typename U>
+bool operator>=(
+  const small_shared_ptrt<T> &lhs,
+  const small_shared_ptrt<U> &rhs)
+{
+  return lhs.get()>=rhs.get();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class small_pointeet
+{
+public:
+  small_pointeet()=default;
+
+  // These can't be `= default` because we need the use_count_ to be unaffected
+  small_pointeet(const small_pointeet &rhs) {}
+  small_pointeet &operator=(const small_pointeet &rhs) { return *this; }
+  small_pointeet(small_pointeet &&rhs) {}
+  small_pointeet &operator=(small_pointeet &&rhs) { return *this; }
+
+  void increment_use_count() { use_count_+=1; }
+  void decrement_use_count() { use_count_-=1; }
+  unsigned use_count() const { return use_count_; }
+
+protected:
+  // Enables public inheritance but disables polymorphic usage
+  ~small_pointeet()=default;
+
+private:
+  unsigned use_count_=0;
+};
+
+inline void pointee_increment_use_count(small_pointeet &p)
+{
+  p.increment_use_count();
+}
+
+inline void pointee_decrement_use_count(small_pointeet &p)
+{
+  p.decrement_use_count();
+}
+
+inline unsigned pointee_use_count(const small_pointeet &p)
+{
+  return p.use_count();
+}
+
+#endif


### PR DESCRIPTION
Follows up #685. Rather than using `std::shared_ptr` which uses more memory than is strictly necessary (an extra pointer to the control block in the shared_ptr itself, plus the control block memory) we use a custom `small_shared_ptr` which is based on boost's `intrusive_ptr`.

This approach uses exactly the same amount of memory as was used previously, but separating the resource management into a separate class makes the logic a bit clearer, and greatly simplifies the copy- and move-assignment operators. It also means we don't need to explicitly redeclare custom move/copy constructors/assignment-ops in `irep.h`.