### PR TITLE
Restore array skip-initialize flag

### DIFF
--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -837,17 +837,20 @@ void goto_convertt::do_java_new_array(
   t_p->source_location=location;
 
   // zero-initialize the data
-  exprt zero_element=
-    zero_initializer(
-      data.type().subtype(),
-      location,
-      ns,
-      get_message_handler());
-  codet array_set(ID_array_set);
-  array_set.copy_to_operands(data, zero_element);
-  goto_programt::targett t_d=dest.add_instruction(OTHER);
-  t_d->code=array_set;
-  t_d->source_location=location;
+  if(!rhs.get_bool(ID_skip_initialize))
+  {
+    exprt zero_element=
+      zero_initializer(
+        data.type().subtype(),
+        location,
+        ns,
+        get_message_handler());
+    codet array_set(ID_array_set);
+    array_set.copy_to_operands(data, zero_element);
+    goto_programt::targett t_d=dest.add_instruction(OTHER);
+    t_d->code=array_set;
+    t_d->source_location=location;
+  }
 
   // multi-dimensional?
 


### PR DESCRIPTION
(This is low-priority-- just a cleanup / minor optimisation that had gone astray, which I noticed while preparing https://github.com/diffblue/cbmc/pull/788)

This allows a java-new-array instruction to indicate that the array will be completely initialized immediately afterwards, and therefore the zero-init instruction can be omitted. The nondet object factory currently uses this to note that it will non-det initialize the whole array.