### PR TITLE
Set function member for class identifier assignment

### DIFF
--- a/src/goto-programs/remove_instanceof.cpp
+++ b/src/goto-programs/remove_instanceof.cpp
@@ -140,6 +140,7 @@ void remove_instanceoft::lower_instanceof(
     newinst->make_assignment();
     newinst->code=code_assignt(newsym.symbol_expr(), object_clsid);
     newinst->source_location=this_inst->source_location;
+    newinst->function=this_inst->function;
 
     // Insert the check instruction after the existing one.
     // This will briefly be ill-formed (use before def of


### PR DESCRIPTION
This sets the function member for the class identifier assignment when removing instanceof.

fixes diffblue/test-gen#193. 