### PR TITLE
Always convert assertions to assumptions in coverage mode

### DIFF
--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -954,46 +954,12 @@ bool cbmc_parse_optionst::process_goto_program(
     // instrument cover goals
     if(cmdline.isset("cover"))
     {
-      std::list<std::string> criteria_strings=
-        cmdline.get_values("cover");
-
-      std::set<coverage_criteriont> criteria;
-
-      for(const auto &criterion_string : criteria_strings)
-      {
-        coverage_criteriont c;
-
-        if(criterion_string=="assertion" || criterion_string=="assertions")
-          c=coverage_criteriont::ASSERTION;
-        else if(criterion_string=="path" || criterion_string=="paths")
-          c=coverage_criteriont::PATH;
-        else if(criterion_string=="branch" || criterion_string=="branches")
-          c=coverage_criteriont::BRANCH;
-        else if(criterion_string=="location" || criterion_string=="locations")
-          c=coverage_criteriont::LOCATION;
-        else if(criterion_string=="decision" || criterion_string=="decisions")
-          c=coverage_criteriont::DECISION;
-        else if(criterion_string=="condition" || criterion_string=="conditions")
-          c=coverage_criteriont::CONDITION;
-        else if(criterion_string=="mcdc")
-          c=coverage_criteriont::MCDC;
-        else if(criterion_string=="cover")
-          c=coverage_criteriont::COVER;
-        else
-        {
-          error() << "unknown coverage criterion" << eom;
-          return true;
-        }
-
-        criteria.insert(c);
-      }
-
-      status() << "Instrumenting coverage goals" << eom;
-
-      for(const auto &criterion : criteria)
-        instrument_cover_goals(symbol_table, goto_functions, criterion);
-
-      goto_functions.update();
+      if(instrument_cover_goals(
+           cmdline,
+           symbol_table,
+           goto_functions,
+           get_message_handler()))
+        return true;
     }
 
     // remove skips

--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -12,6 +12,7 @@ Date: May 2016
 #include <iterator>
 
 #include <util/prefix.h>
+#include <util/message.h>
 
 #include "cover.h"
 
@@ -1397,4 +1398,65 @@ void instrument_cover_goals(
 
     instrument_cover_goals(symbol_table, f_it->second.body, criterion);
   }
+}
+
+/*******************************************************************\
+
+Function: instrument_cover_goals
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+bool instrument_cover_goals(
+  const cmdlinet &cmdline,
+  const symbol_tablet &symbol_table,
+  goto_functionst &goto_functions,
+  message_handlert &msgh)
+{
+  messaget msg;
+  msg.set_message_handler(msgh);
+  std::list<std::string> criteria_strings=cmdline.get_values("cover");
+  std::set<coverage_criteriont> criteria;
+
+  for(const auto &criterion_string : criteria_strings)
+  {
+    coverage_criteriont c;
+
+    if(criterion_string=="assertion" || criterion_string=="assertions")
+      c=coverage_criteriont::ASSERTION;
+    else if(criterion_string=="path" || criterion_string=="paths")
+      c=coverage_criteriont::PATH;
+    else if(criterion_string=="branch" || criterion_string=="branches")
+      c=coverage_criteriont::BRANCH;
+    else if(criterion_string=="location" || criterion_string=="locations")
+      c=coverage_criteriont::LOCATION;
+    else if(criterion_string=="decision" || criterion_string=="decisions")
+      c=coverage_criteriont::DECISION;
+    else if(criterion_string=="condition" || criterion_string=="conditions")
+      c=coverage_criteriont::CONDITION;
+    else if(criterion_string=="mcdc")
+      c=coverage_criteriont::MCDC;
+    else if(criterion_string=="cover")
+      c=coverage_criteriont::COVER;
+    else
+    {
+      msg.error() << "unknown coverage criterion" << messaget::eom;
+      return true;
+    }
+
+    criteria.insert(c);
+  }
+
+  msg.status() << "Instrumenting coverage goals" << messaget::eom;
+
+  for(const auto &criterion : criteria)
+    instrument_cover_goals(symbol_table, goto_functions, criterion);
+
+  goto_functions.update();
+  return false;
 }

--- a/src/goto-instrument/cover.h
+++ b/src/goto-instrument/cover.h
@@ -12,6 +12,7 @@ Date: May 2016
 #define CPROVER_GOTO_INSTRUMENT_COVER_H
 
 #include <goto-programs/goto_model.h>
+#include <util/cmdline.h>
 
 enum class coverage_criteriont
 {
@@ -27,5 +28,11 @@ void instrument_cover_goals(
   const symbol_tablet &symbol_table,
   goto_functionst &goto_functions,
   coverage_criteriont);
+
+bool instrument_cover_goals(
+  const cmdlinet &cmdline,
+  const symbol_tablet &symbol_table,
+  goto_functionst &goto_functions,
+  message_handlert &msgh);
 
 #endif // CPROVER_GOTO_INSTRUMENT_COVER_H


### PR DESCRIPTION
I've seen one too many apparent bug attributable to using `--cover` without `--assertions-as-assumptions`. Time to simply make `cover` imply `assertions-as-assumptions`. This PR also moves the coverage option into `goto-instrument/cover.cpp`, which places it better for driver programs that use CBMC to amend and re-use instead of duplicating this code.

Rationale for pushing this upstream: `cover` without `assertions-as-assumptions` is simply incorrect-- code in the wake of an assertion should assume that the assertion passed, and alleged coverage that assumes we magically passed over the assertion while violating its condition is spurious. Open CBMC should either include a coverage mode that works, or not include one at all.