### PR TITLE
Fix translation of safety checker status to exit codes

### DIFF
--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -1045,17 +1045,28 @@ int cbmc_parse_optionst::do_bmc(
 {
   bmc.set_ui(get_ui());
 
+  int result=6;
+
   // do actual BMC
-  bool result=(bmc.run(goto_functions)==safety_checkert::SAFE);
+  switch(bmc.run(goto_functions))
+  {
+    case safety_checkert::SAFE:
+      result=0;
+      break;
+    case safety_checkert::UNSAFE:
+      result=10;
+      break;
+    case safety_checkert::ERROR:
+      result=6;
+      break;
+  }
 
   // let's log some more statistics
   debug() << "Memory consumption:" << messaget::endl;
   memory_info(debug());
   debug() << eom;
 
-  // We return '0' if the property holds,
-  // and '10' if it is violated.
-  return result?0:10;
+  return result;
 }
 
 /*******************************************************************\


### PR DESCRIPTION
The bmc_cover returns true on error which is translated
into safety_checkert::ERROR in bmc.cpp, which was then
incorrectly translated into exit code 10 instead of 6.

Fixes diffblue/test-gen#201.