### PR TITLE
Do not treat integer literals 0u, 0l as base-8

### DIFF
--- a/regression/cbmc/unsigned1/main.c
+++ b/regression/cbmc/unsigned1/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  unsigned x;
+  x=0u;
+  return 0;
+}

--- a/regression/cbmc/unsigned1/test.desc
+++ b/regression/cbmc/unsigned1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--show-goto-functions
+^EXIT=0$
+^SIGNAL=0$
+--
+00u
+^warning: ignoring

--- a/src/ansi-c/literals/convert_integer_literal.cpp
+++ b/src/ansi-c/literals/convert_integer_literal.cpp
@@ -75,7 +75,7 @@ exprt convert_integer_literal(const std::string &src)
     std::string without_prefix(src, 2, std::string::npos);
     value=string2integer(without_prefix, 2);
   }
-  else if(src.size()>=2 && src[0]=='0')
+  else if(src.size()>=2 && src[0]=='0' && isdigit(src[1]))
   {
     // octal
     base=8;


### PR DESCRIPTION
Only literals with a digit following the initial 0 should be understood as
base-8.