### PR TITLE
Fix issue #158 (missing test cases)

### DIFF
--- a/src/solvers/refinement/string_refinement.h
+++ b/src/solvers/refinement/string_refinement.h
@@ -90,6 +90,11 @@ private:
   // by the solver
   replace_mapt current_model;
 
+  // Length of char arrays found during concretization
+  std::map<exprt, exprt> found_length;
+  // Content of char arrays found during concretization
+  std::map<exprt, array_exprt> found_content;
+
   void add_equivalence(const irep_idt & lhs, const exprt & rhs);
 
   void display_index_set();
@@ -142,9 +147,6 @@ private:
   void concretize_string(const exprt &expr);
   void concretize_results();
   void concretize_lengths();
-
-  // Length of char arrays found during concretization
-  std::map<exprt, exprt> found_length;
 
   exprt get_array(const exprt &arr, const exprt &size) const;
   exprt get_array(const exprt &arr) const;


### PR DESCRIPTION
This rewrites part of the concretization process of strings. We now re-use the last concretized value, which avoids extra calls to the solver and also avoids over-constraining the model with lemmas, which resulted in missing test cases.

The related issue is here : https://github.com/diffblue/test-gen/issues/158