### PR TITLE
Fix issue cbmc/test-gen#201

### DIFF
--- a/src/solvers/refinement/string_refinement.cpp
+++ b/src/solvers/refinement/string_refinement.cpp
@@ -475,8 +475,8 @@ void string_refinementt::set_to(const exprt &expr, bool value)
 
     // Preprocessing to remove function applications.
     const exprt &lhs=eq_expr.lhs();
-    debug() << "(sr::set_to) " << from_expr(lhs)
-            << " = " << from_expr(eq_expr.rhs()) << eom;
+    debug() << "(sr::set_to) " << from_expr(ns, "", lhs)
+            << " = " << from_expr(ns, "", eq_expr.rhs()) << eom;
 
     // TODO: See if this happens at all.
     if(lhs.id()!=ID_symbol)
@@ -545,7 +545,7 @@ decision_proceduret::resultt string_refinementt::dec_solve()
   for(std::pair<exprt, bool> &pair : non_string_axioms)
   {
     replace_expr(symbol_resolve, pair.first);
-    debug() << "super::set_to " << from_expr(pair.first) << eom;
+    debug() << "super::set_to " << from_expr(ns, "", pair.first) << eom;
     supert::set_to(pair.first, pair.second);
   }
 


### PR DESCRIPTION
Adding namespace to arguments of from_expr in debug

Not finding a symbol in from_expr can cause some exception to be thrown.
This was happening while outputing debug information in some examples
when --refine-strings was activated.