### PR TITLE
Fix memory leak in ansi-c frontend Fixes: #569

### DIFF
--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -54,7 +54,7 @@ void c_typecheck_baset::typecheck_type(typet &type)
     exprt alignment=static_cast<const exprt &>(type.find(ID_C_alignment));
     irept _typedef=type.find(ID_C_typedef);
 
-    type.swap(type.subtype());
+    type=type.subtype();
 
     c_qualifiers.write(type);
     if(packed)


### PR DESCRIPTION
If you swap an irep with an irep that it contains, it creates a circular reference which lives until the program quits. Unfortunately, we were doing that in the ansi-c front end, causing the leaks described in #569.