### PR TITLE
Fix iterator-invalidation bug in ansi-c/padding.cpp

### DIFF
--- a/src/ansi-c/padding.cpp
+++ b/src/ansi-c/padding.cpp
@@ -203,7 +203,7 @@ void add_padding(struct_typet &type, const namespacet &ns)
       it!=components.end();
       it++)
   {
-    const typet &it_type=it->type();
+    const typet it_type=it->type();
     mp_integer a=1;
 
     const bool packed=it_type.get_bool(ID_C_packed) ||


### PR DESCRIPTION
The insert on line 262 invalidates the iterators of the vector which is
being iterated, which may cause the reference on line 206 to dangle.
This in turn leads to undefined behaviour on line 269 when the reference
is passed to a function.

The fix is to take a copy instead of a reference on line 206.