### PR TITLE
Correcting addition of symbol to symbol map

### DIFF
--- a/src/solvers/refinement/string_refinement.cpp
+++ b/src/solvers/refinement/string_refinement.cpp
@@ -187,7 +187,8 @@ void string_refinementt::add_symbol_to_symbol_map(
   symbol_resolve[lhs]=new_rhs;
   reverse_symbol_resolve[new_rhs].push_back(lhs);
 
-  std::list<exprt> symbols_to_update_with_new_rhs(reverse_symbol_resolve[rhs]);
+  const std::list<exprt> &symbols_to_update_with_new_rhs(
+    reverse_symbol_resolve[lhs]);
   for(exprt item : symbols_to_update_with_new_rhs)
   {
     symbol_resolve[item]=new_rhs;


### PR DESCRIPTION
There was a mistake that could cause looping over symbols in the map that don't actually need to be modified and could greatly slow down the analysis.