### PR TITLE
Add assert to local_bitvector_analysis.cpp

### DIFF
--- a/src/analyses/local_bitvector_analysis.cpp
+++ b/src/analyses/local_bitvector_analysis.cpp
@@ -400,6 +400,7 @@ void local_bitvector_analysist::build(const goto_functiont &goto_function)
 
     for(const auto &succ : node.successors)
     {
+      assert(succ<loc_infos.size());
       if(loc_infos[succ].merge(loc_info_dest))
         work_queue.push(succ);
     }


### PR DESCRIPTION
When running the [linked program](https://github.com/diffblue/cbmc/files/928455/id.000118.sig.04.src.000006.op.arith8.pos.5884.val.-3.zip)
 (thanks @mgudemann for the test case) with cbmc under address-sanitizer, we get the following error:

```
Reading GOTO program from file
Reading: /home/reuben/Downloads/more crashes/crashes/id:000118,sig:04,src:000006,op:arith8,pos:5884,val:-3
Generating GOTO Program
Adding CPROVER library (x86_64)
Removal of function pointers and virtual functions
Partial Inlining
Generic Property Instrumentation
=================================================================
==6360==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x603000009b70 at pc 0x000001004d5d bp 0x7ffceb271700 sp 0x7ffceb2716f8
READ of size 8 at 0x603000009b70 thread T0
    #0 0x1004d5c in std::vector<local_bitvector_analysist::flagst, std::allocator<local_bitvector_analysist::flagst> >::size() const /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/stl_vector.h:655:40
    #1 0x100113c in local_bitvector_analysist::loc_infot::merge(local_bitvector_analysist::loc_infot const&) /home/reuben/development/cbmc/src/analyses/local_bitvector_analysis.cpp:70:36
    #2 0x10042e4 in local_bitvector_analysist::build(goto_function_templatet<goto_programt> const&) /home/reuben/development/cbmc/src/analyses/local_bitvector_analysis.cpp:403:10
    #3 0xff7e93 in local_bitvector_analysist::local_bitvector_analysist(goto_function_templatet<goto_programt> const&) /home/reuben/development/cbmc/src/analyses/./local_bitvector_analysis.h:39:5
    #4 0xff40e8 in goto_checkt::goto_check(goto_function_templatet<goto_programt>&, dstringt const&) /home/reuben/development/cbmc/src/analyses/goto_check.cpp:1593:29
    #5 0xff74db in goto_check(namespacet const&, optionst const&, goto_functionst&) /home/reuben/development/cbmc/src/analyses/goto_check.cpp:1883:5
    #6 0x81415b in cbmc_parse_optionst::process_goto_program(optionst const&, goto_functionst&) /home/reuben/development/cbmc/src/cbmc/cbmc_parse_options.cpp:907:5
    #7 0x813455 in cbmc_parse_optionst::get_goto_program(optionst const&, bmct&, goto_functionst&) /home/reuben/development/cbmc/src/cbmc/cbmc_parse_options.cpp:737:8
    #8 0x810928 in cbmc_parse_optionst::doit() /home/reuben/development/cbmc/src/cbmc/cbmc_parse_options.cpp:534:5
    #9 0x127792c in parse_options_baset::main() /home/reuben/development/cbmc/src/util/parse_options.cpp:104:10
    #10 0x808240 in main /home/reuben/development/cbmc/src/cbmc/cbmc_main.cpp:53:11
    #11 0x7f66e2da782f in __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:291
    #12 0x4248c8 in _start (/home/reuben/development/cbmc/src/cbmc/cbmc+0x4248c8)

0x603000009b70 is located 8 bytes to the right of 24-byte region [0x603000009b50,0x603000009b68)
allocated by thread T0 here:
    #0 0x4f5fc0 in operator new(unsigned long) (/home/reuben/development/cbmc/src/cbmc/cbmc+0x4f5fc0)
    #1 0x100fd79 in __gnu_cxx::new_allocator<local_bitvector_analysist::loc_infot>::allocate(unsigned long, void const*) /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/ext/new_allocator.h:104:27
    #2 0xff7e93 in local_bitvector_analysist::local_bitvector_analysist(goto_function_templatet<goto_programt> const&) /home/reuben/development/cbmc/src/analyses/./local_bitvector_analysis.h:39:5
    #3 0xff74db in goto_check(namespacet const&, optionst const&, goto_functionst&) /home/reuben/development/cbmc/src/analyses/goto_check.cpp:1883:5
    #4 0x81415b in cbmc_parse_optionst::process_goto_program(optionst const&, goto_functionst&) /home/reuben/development/cbmc/src/cbmc/cbmc_parse_options.cpp:907:5
    #5 0x813455 in cbmc_parse_optionst::get_goto_program(optionst const&, bmct&, goto_functionst&) /home/reuben/development/cbmc/src/cbmc/cbmc_parse_options.cpp:737:8
    #6 0x810928 in cbmc_parse_optionst::doit() /home/reuben/development/cbmc/src/cbmc/cbmc_parse_options.cpp:534:5
    #7 0x127792c in parse_options_baset::main() /home/reuben/development/cbmc/src/util/parse_options.cpp:104:10
    #8 0x7f66e2da782f in __libc_start_main /build/glibc-9tT8Do/glibc-2.23/csu/../csu/libc-start.c:291

SUMMARY: AddressSanitizer: heap-buffer-overflow /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/stl_vector.h:655:40 in std::vector<local_bitvector_analysist::flagst, std::allocator<local_bitvector_analysist::flagst> >::size() const
Shadow bytes around the buggy address:
  0x0c067fff9310: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c067fff9320: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c067fff9330: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c067fff9340: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c067fff9350: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x0c067fff9360: fa fa fa fa fa fa fa fa fa fa 00 00 00 fa[fa]fa
  0x0c067fff9370: 00 00 00 00 fa fa fd fd fd fa fa fa fd fd fd fa
  0x0c067fff9380: fa fa fd fd fd fa fa fa fd fd fd fa fa fa fd fd
  0x0c067fff9390: fd fa fa fa fd fd fd fa fa fa fd fd fd fa fa fa
  0x0c067fff93a0: fd fd fd fa fa fa fd fd fd fa fa fa fd fd fd fa
  0x0c067fff93b0: fa fa fd fd fd fa fa fa fd fd fd fa fa fa fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==6360==ABORTING
```

After applying this patch, we instead trigger the new assertion:

```
Reading GOTO program from file
Reading: /home/reuben/Downloads/more crashes/crashes/id:000118,sig:04,src:000006,op:arith8,pos:5884,val:-3
Generating GOTO Program
Adding CPROVER library (x86_64)
Removal of function pointers and virtual functions
Partial Inlining
Generic Property Instrumentation
cbmc: local_bitvector_analysis.cpp:403: void local_bitvector_analysist::build(const goto_functiont &): Assertion `succ<loc_infos.size()' failed.
```

Though I think it's probably a good idea to add this assert to avoid memory corrpution, there may be a better fix that avoids triggering this assertion altogether. Could @tautschnig or @kroening advise?