### PR TITLE
Fix issue #241 - Conversion from int

### DIFF
--- a/regression/strings-smoke-tests/java_append_char/test.desc
+++ b/regression/strings-smoke-tests/java_append_char/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_append_char.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_append_int/test.desc
+++ b/regression/strings-smoke-tests/java_append_int/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_append_int.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_append_object/test.desc
+++ b/regression/strings-smoke-tests/java_append_object/test.desc
@@ -5,3 +5,4 @@ test_append_object.class
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
 --
+Issue: diffblue/test-gen#82

--- a/regression/strings-smoke-tests/java_append_string/test.desc
+++ b/regression/strings-smoke-tests/java_append_string/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_append_string.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_case/test.desc
+++ b/regression/strings-smoke-tests/java_case/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_case.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_char_array/test.desc
+++ b/regression/strings-smoke-tests/java_char_array/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_char_array.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_char_array_init/test.desc
+++ b/regression/strings-smoke-tests/java_char_array_init/test.desc
@@ -5,3 +5,4 @@ test_init.class
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
 --
+cbmc/test-gen#259

--- a/regression/strings-smoke-tests/java_char_at/test.desc
+++ b/regression/strings-smoke-tests/java_char_at/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_char_at.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_code_point/test.desc
+++ b/regression/strings-smoke-tests/java_code_point/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_code_point.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_compare/test.desc
+++ b/regression/strings-smoke-tests/java_compare/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_compare.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_concat/test.desc
+++ b/regression/strings-smoke-tests/java_concat/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_concat.class
 --refine-strings
 ^EXIT=10$

--- a/regression/strings-smoke-tests/java_contains/test.desc
+++ b/regression/strings-smoke-tests/java_contains/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+KNOWNBUG
 test_contains.class
 --refine-strings
 ^EXIT=10$
@@ -6,3 +6,4 @@ test_contains.class
 ^\[.*assertion.1\].* line 8.* SUCCESS$
 ^\[.*assertion.2\].* line 9.* FAILURE$
 --
+Issue: diffblue/test-gen#201

--- a/regression/strings-smoke-tests/java_delete/test.desc
+++ b/regression/strings-smoke-tests/java_delete/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_delete.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_delete_char_at/test.desc
+++ b/regression/strings-smoke-tests/java_delete_char_at/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_delete_char_at.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_empty/test.desc
+++ b/regression/strings-smoke-tests/java_empty/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_empty.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_endswith/test.desc
+++ b/regression/strings-smoke-tests/java_endswith/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_endswith.class
 --refine-strings
 ^EXIT=10$

--- a/regression/strings-smoke-tests/java_equal/test.desc
+++ b/regression/strings-smoke-tests/java_equal/test.desc
@@ -1,6 +1,6 @@
-FUTURE
+CORE
 test_equal.class
---refine-strings
+--refine-strings --string-max-length 100 --string-max-length 100
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 8.* FAILURE$

--- a/regression/strings-smoke-tests/java_float/test.desc
+++ b/regression/strings-smoke-tests/java_float/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_float.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_hash_code/test.desc
+++ b/regression/strings-smoke-tests/java_hash_code/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_hash_code.class
 --refine-strings
 ^EXIT=10$

--- a/regression/strings-smoke-tests/java_index_of/test.desc
+++ b/regression/strings-smoke-tests/java_index_of/test.desc
@@ -1,7 +1,8 @@
-FUTURE
+KNOWNBUG
 test_index_of.class
 --refine-strings
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
 --
+Issue: cbmc/test-gen#77

--- a/regression/strings-smoke-tests/java_index_of_char/test.desc
+++ b/regression/strings-smoke-tests/java_index_of_char/test.desc
@@ -1,7 +1,8 @@
-FUTURE
+CORE
 test_index_of_char.class
 --refine-strings
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
 --
+Issue: cbmc/test-gen#77

--- a/regression/strings-smoke-tests/java_insert_char/test.desc
+++ b/regression/strings-smoke-tests/java_insert_char/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_insert_char.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_insert_char_array/test.desc
+++ b/regression/strings-smoke-tests/java_insert_char_array/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_insert_char_array.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_insert_int/test.desc
+++ b/regression/strings-smoke-tests/java_insert_int/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_insert_int.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_insert_multiple/test.desc
+++ b/regression/strings-smoke-tests/java_insert_multiple/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_insert_multiple.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_insert_string/test.desc
+++ b/regression/strings-smoke-tests/java_insert_string/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_insert_string.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_int_to_string/test.desc
+++ b/regression/strings-smoke-tests/java_int_to_string/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_int.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_intern/test.desc
+++ b/regression/strings-smoke-tests/java_intern/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_intern.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_last_index_of/test.desc
+++ b/regression/strings-smoke-tests/java_last_index_of/test.desc
@@ -1,7 +1,8 @@
-FUTURE
+KNOWNBUG
 test_last_index_of.class
 --refine-strings
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
 --
+Issue: diffblue/test-gen#77

--- a/regression/strings-smoke-tests/java_last_index_of_char/test.desc
+++ b/regression/strings-smoke-tests/java_last_index_of_char/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_last_index_of_char.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_length/test.desc
+++ b/regression/strings-smoke-tests/java_length/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_length.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_parseint/test.desc
+++ b/regression/strings-smoke-tests/java_parseint/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_parseint.class
 --refine-strings
 ^EXIT=10$

--- a/regression/strings-smoke-tests/java_replace/test.desc
+++ b/regression/strings-smoke-tests/java_replace/test.desc
@@ -1,7 +1,8 @@
 FUTURE
 test_replace.class
---refine-strings
+--refine-strings --string-max-length 100
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
 --
+diffblue/test-gen#256

--- a/regression/strings-smoke-tests/java_replace_char/test.desc
+++ b/regression/strings-smoke-tests/java_replace_char/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_replace_char.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_set_char_at/test.desc
+++ b/regression/strings-smoke-tests/java_set_char_at/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_set_char_at.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_set_length/test.desc
+++ b/regression/strings-smoke-tests/java_set_length/test.desc
@@ -1,6 +1,6 @@
-FUTURE
+CORE
 test_set_length.class
---refine-strings
+--refine-strings --string-max-length 100
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 8.* SUCCESS$

--- a/regression/strings-smoke-tests/java_starts_with/test.desc
+++ b/regression/strings-smoke-tests/java_starts_with/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_starts_with.class
 --refine-strings
 ^EXIT=10$

--- a/regression/strings-smoke-tests/java_string_builder_length/test.desc
+++ b/regression/strings-smoke-tests/java_string_builder_length/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_sb_length.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_subsequence/test.desc
+++ b/regression/strings-smoke-tests/java_subsequence/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_subsequence.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_substring/test.desc
+++ b/regression/strings-smoke-tests/java_substring/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_substring.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings-smoke-tests/java_trim/test.desc
+++ b/regression/strings-smoke-tests/java_trim/test.desc
@@ -1,6 +1,6 @@
-FUTURE
+CORE
 test_trim.class
---refine-strings
+--refine-strings --string-max-length 100
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 6.* SUCCESS$

--- a/src/solvers/refinement/string_constraint_generator_valueof.cpp
+++ b/src/solvers/refinement/string_constraint_generator_valueof.cpp
@@ -267,23 +267,6 @@ string_exprt string_constraint_generatort::add_axioms_from_bool(
 
 /*******************************************************************\
 
-Function: smallest_by_digit
-
-  Inputs: number of digit
-
- Outputs: an integer with the right number of digit
-
- Purpose: gives the smallest integer with the specified number of digits
-
-\*******************************************************************/
-
-static mp_integer smallest_by_digit(int nb)
-{
-  return power(10, nb-1);
-}
-
-/*******************************************************************\
-
 Function: string_constraint_generatort::add_axioms_from_int
 
   Inputs: a signed integer expression, and a maximal size for the string
@@ -313,102 +296,90 @@ string_exprt string_constraint_generatort::add_axioms_from_int(
   exprt max=from_integer(max_size, index_type);
 
   // We add axioms:
-  // a1 : 0 <|res|<=max_size
-  // a2 : (res[0]='-')||('0'<=res[0]<='9')
+  // a1 : i < 0 => 1 <|res|<=max_size && res[0]='-'
+  // a2 : i >= 0 => 0 <|res|<=max_size-1 && '0'<=res[0]<='9'
+  // a3 : |res|>1 && '0'<=res[0]<='9' => res[0]!='0'
+  // a4 : |res|>1 && res[0]='-' => res[1]!='0'
 
-  and_exprt a1(res.axiom_for_is_strictly_longer_than(zero),
-               res.axiom_for_is_shorter_than(max));
+  binary_relation_exprt is_negative(i, ID_lt, zero);
+  and_exprt correct_length1(
+    res.axiom_for_is_strictly_longer_than(1),
+    res.axiom_for_is_shorter_than(max));
+  equal_exprt starts_with_minus(res[0], minus_char);
+  implies_exprt a1(is_negative, and_exprt(correct_length1, starts_with_minus));
   axioms.push_back(a1);
 
-  exprt chr=res[0];
-  equal_exprt starts_with_minus(chr, minus_char);
+  not_exprt is_positive(is_negative);
   and_exprt starts_with_digit(
-    binary_relation_exprt(chr, ID_ge, zero_char),
-    binary_relation_exprt(chr, ID_le, nine_char));
-  or_exprt a2(starts_with_digit, starts_with_minus);
+    binary_relation_exprt(res[0], ID_ge, zero_char),
+    binary_relation_exprt(res[0], ID_le, nine_char));
+  and_exprt correct_length2(
+    res.axiom_for_is_strictly_longer_than(0),
+    res.axiom_for_is_strictly_shorter_than(max));
+  implies_exprt a2(is_positive, and_exprt(correct_length2, starts_with_digit));
   axioms.push_back(a2);
 
-  // These are constraints to detect number that requiere the maximum number
-  // of digits
-  exprt smallest_with_max_digits=
-    from_integer(smallest_by_digit(max_size-1), type);
-  binary_relation_exprt big_negative(
-    i, ID_le, unary_minus_exprt(smallest_with_max_digits));
-  binary_relation_exprt big_positive(i, ID_ge, smallest_with_max_digits);
-  or_exprt requieres_max_digits(big_negative, big_positive);
+  implies_exprt a3(
+    and_exprt(res.axiom_for_is_strictly_longer_than(1), starts_with_digit),
+    not_exprt(equal_exprt(res[0], zero_char)));
+  axioms.push_back(a3);
+
+  implies_exprt a4(
+    and_exprt(res.axiom_for_is_strictly_longer_than(1), starts_with_minus),
+    not_exprt(equal_exprt(res[1], zero_char)));
+  axioms.push_back(a4);
+
+  assert(max_size<std::numeric_limits<size_t>::max());
 
   for(size_t size=1; size<=max_size; size++)
   {
     // For each possible size, we add axioms:
-    // all_numbers: forall 1<=i<=size. '0'<=res[i]<='9'
-    // a3 : |res|=size&&'0'<=res[0]<='9' =>
-    //      i=sum+str[0]-'0' &&all_numbers
-    // a4 : |res|=size&&res[0]='-' => i=-sum
-    // a5 : size>1 => |res|=size&&'0'<=res[0]<='9' => res[0]!='0'
-    // a6 : size>1 => |res|=size&&res[0]'-' => res[1]!='0'
-    // a7 : size==max_size => i>1000000000
-    exprt sum=from_integer(0, type);
-    exprt all_numbers=true_exprt();
-    chr=res[0];
-    exprt first_value=typecast_exprt(minus_exprt(chr, zero_char), type);
+    // a5 : forall 1 <= j < size. '0' <= res[j] <= '9' && sum == 10 * (sum/10)
+    // a6 : |res| == size && '0' <= res[0] <= '9' => i == sum
+    // a7 : |res| == size && res[0] == '-' => i == -sum
+
+    exprt::operandst digit_constraints;
+    exprt sum=if_exprt(
+      starts_with_digit,
+      typecast_exprt(minus_exprt(res[0], zero_char), type),
+      from_integer(0, type));
 
     for(size_t j=1; j<size; j++)
     {
-      chr=res[j];
-      sum=plus_exprt(
-        mult_exprt(sum, ten),
-        typecast_exprt(minus_exprt(chr, zero_char), type));
-      first_value=mult_exprt(first_value, ten);
+      mult_exprt ten_sum(sum, ten);
+      // sum = 10 * sum + (res[j] - '0')
+      exprt new_sum=plus_exprt(
+        ten_sum, typecast_exprt(minus_exprt(res[j], zero_char), type));
       and_exprt is_number(
-        binary_relation_exprt(chr, ID_ge, zero_char),
-        binary_relation_exprt(chr, ID_le, nine_char));
-      all_numbers=and_exprt(all_numbers, is_number);
+        binary_relation_exprt(res[j], ID_ge, zero_char),
+        binary_relation_exprt(res[j], ID_le, nine_char));
+      digit_constraints.push_back(is_number);
+
+      if(j>=max_size-1)
+      {
+        // check for overflows if the size is big
+        and_exprt no_overflow(
+          equal_exprt(sum, div_exprt(ten_sum, ten)),
+          binary_relation_exprt(new_sum, ID_ge, ten_sum));
+        digit_constraints.push_back(no_overflow);
+      }
+      sum=new_sum;
     }
 
-    axioms.push_back(all_numbers);
+    exprt a5=conjunction(digit_constraints);
+    axioms.push_back(a5);
 
     equal_exprt premise=res.axiom_for_has_length(size);
-    equal_exprt constr3(i, plus_exprt(sum, first_value));
-    implies_exprt a3(and_exprt(premise, starts_with_digit), constr3);
-    axioms.push_back(a3);
+    implies_exprt a6(
+      and_exprt(premise, starts_with_digit), equal_exprt(i, sum));
+    axioms.push_back(a6);
 
-    implies_exprt a4(
+    implies_exprt a7(
       and_exprt(premise, starts_with_minus),
       equal_exprt(i, unary_minus_exprt(sum)));
-    axioms.push_back(a4);
-
-    // disallow 0s at the beginning
-    if(size>1)
-    {
-      equal_exprt r0_zero(res[zero], zero_char);
-      implies_exprt a5(
-        and_exprt(premise, starts_with_digit),
-        not_exprt(r0_zero));
-      axioms.push_back(a5);
-
-      exprt one=from_integer(1, index_type);
-      equal_exprt r1_zero(res[one], zero_char);
-      implies_exprt a6(
-        and_exprt(premise, starts_with_minus),
-        not_exprt(r1_zero));
-      axioms.push_back(a6);
-    }
-
-    // when the size is close to the maximum, either the number is very big
-    // or it is negative
-    if(size==max_size-1)
-    {
-      implies_exprt a7(premise, or_exprt(requieres_max_digits,
-                                         starts_with_minus));
-      axioms.push_back(a7);
-    }
-    // when we reach the maximal size the number is very big in the negative
-    if(size==max_size)
-    {
-      implies_exprt a7(premise, and_exprt(starts_with_minus, big_negative));
-      axioms.push_back(a7);
-    }
+    axioms.push_back(a7);
   }
+
   return res;
 }
 


### PR DESCRIPTION
Correct the constraints for conversion from int.

This fixes issue diffblue/test-gen#241.

The first two constraints that were previously added in
add_axioms_from_int were not enough to ensure correctness.
They are replaced here by:
 *  a1 : i < 0 => 1 <|res|<=max_size && res[0]='-'
 *  a2 : i >= 0 => 0 <|res|<=max_size-1 && '0'<=res[0]<='9'

Clarifications in add_axioms_from_int
We make the code clearer and add overflow checks.

For the fix to be fully effective, PR #819 must also be merged, but there is no code dependency.