### PR TITLE
add visibility information for fields and methods

### DIFF
--- a/src/java_bytecode/java_bytecode_convert_class.cpp
+++ b/src/java_bytecode/java_bytecode_convert_class.cpp
@@ -294,6 +294,8 @@ void java_bytecode_convert_classt::convert(
       component.set_access(ID_protected);
     else if(f.is_public)
       component.set_access(ID_public);
+    else
+      component.set_access(ID_default);
   }
 }
 

--- a/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -232,6 +232,14 @@ void java_bytecode_convert_method_lazy(
   method_symbol.mode=ID_java;
   method_symbol.location=m.source_location;
   method_symbol.location.set_function(method_identifier);
+  if(m.is_public)
+    member_type.set(ID_access, ID_public);
+  else if(m.is_protected)
+    member_type.set(ID_access, ID_protected);
+  else if(m.is_private)
+    member_type.set(ID_access, ID_private);
+  else
+    member_type.set(ID_access, ID_default);
 
   if(method_symbol.base_name=="<init>")
   {

--- a/src/java_bytecode/java_bytecode_parser.cpp
+++ b/src/java_bytecode/java_bytecode_parser.cpp
@@ -709,6 +709,13 @@ void java_bytecode_parsert::rfields(classt &parsed_class)
     field.is_final=(access_flags&ACC_FINAL)!=0;
     field.is_enum=(access_flags&ACC_ENUM)!=0;
     field.signature=id2string(pool_entry(descriptor_index).s);
+    field.is_public=(access_flags&ACC_PUBLIC)!=0;
+    field.is_protected=(access_flags&ACC_PROTECTED)!=0;
+    field.is_private=(access_flags&ACC_PRIVATE)!=0;
+    size_t flags=(field.is_public?1:0)+
+      (field.is_protected?1:0)+
+      (field.is_private?1:0);
+    assert(flags<=1);
 
     for(std::size_t j=0; j<attributes_count; j++)
       rfield_attribute(field);
@@ -1561,6 +1568,10 @@ void java_bytecode_parsert::rmethod(classt &parsed_class)
   method.base_name=pool_entry(name_index).s;
   method.signature=id2string(pool_entry(descriptor_index).s);
 
+  size_t flags=(method.is_public?1:0)+
+    (method.is_protected?1:0)+
+    (method.is_private?1:0);
+  assert(flags<=1);
   u2 attributes_count=read_u2();
 
   for(std::size_t j=0; j<attributes_count; j++)


### PR DESCRIPTION
`membert` has Booleans `is_public`, `is_private` and `is_protected`. This was used, but not set in `fieldt` and set but not used in `methodt`.
This also adds `ID_default` when no other flag is set, in Java this allows visibility in the package, but not subclasses outside the package (cf. https://docs.oracle.com/javase/tutorial/java/javaOO/accesscontrol.html)