### PR TITLE
Improve style in goto_program_template.h

### DIFF
--- a/src/analyses/ai.cpp
+++ b/src/analyses/ai.cpp
@@ -412,11 +412,7 @@ bool ai_baset::visit(
 
   statet &current=get_state(l);
 
-  goto_programt::const_targetst successors;
-
-  goto_program.get_successors(l, successors);
-
-  for(const auto &to_l : successors)
+  for(const auto &to_l : goto_program.get_successors(l))
   {
     if(to_l==goto_program.instructions.end())
       continue;

--- a/src/analyses/flow_insensitive_analysis.cpp
+++ b/src/analyses/flow_insensitive_analysis.cpp
@@ -256,16 +256,13 @@ bool flow_insensitive_analysis_baset::visit(
     l->location_number << std::endl;
   #endif
 
-  goto_programt::const_targetst successors;
-  goto_program.get_successors(l, successors);
-
   seen_locations.insert(l);
   if(statistics.find(l)==statistics.end())
     statistics[l]=1;
   else
     statistics[l]++;
 
-  for(const auto &to_l : successors)
+  for(const auto &to_l : goto_program.get_successors(l))
   {
     if(to_l==goto_program.instructions.end())
       continue;

--- a/src/analyses/static_analysis.cpp
+++ b/src/analyses/static_analysis.cpp
@@ -356,11 +356,7 @@ bool static_analysis_baset::visit(
 
   current.seen=true;
 
-  goto_programt::const_targetst successors;
-
-  goto_program.get_successors(l, successors);
-
-  for(const auto &to_l : successors)
+  for(const auto &to_l : goto_program.get_successors(l))
   {
     if(to_l==goto_program.instructions.end())
       continue;

--- a/src/cegis/cegis-util/program_helper.cpp
+++ b/src/cegis/cegis-util/program_helper.cpp
@@ -350,18 +350,23 @@ goto_programt::targett insert_preserving_source_location(
 goto_programt::targett insert_after_preserving_source_location(
     goto_programt &body, goto_programt::targett pos)
 {
-  const auto op=std::bind1st(std::mem_fun(&goto_programt::insert_after), &body);
-  return insert_preserving_source_location(pos, op);
+  return insert_preserving_source_location(
+    pos,
+    [&](goto_programt::const_targett target)
+    {
+      return body.insert_after(target);
+    });
 }
 
 goto_programt::targett insert_before_preserving_source_location(
     goto_programt &body, goto_programt::targett pos)
 {
-  typedef goto_programt::targett (goto_programt::*ftype)(
-      goto_programt::targett);
-  const auto op=std::bind1st(
-      std::mem_fun(static_cast<ftype>(&goto_programt::insert_before)), &body);
-  return insert_preserving_source_location(pos, op);
+  return insert_preserving_source_location(
+    pos,
+    [&](goto_programt::const_targett target)
+    {
+      return body.insert_before(target);
+    });
 }
 
 void assign_in_cprover_init(goto_functionst &gf, symbolt &symbol,

--- a/src/goto-instrument/accelerate/all_paths_enumerator.cpp
+++ b/src/goto-instrument/accelerate/all_paths_enumerator.cpp
@@ -69,8 +69,7 @@ int all_paths_enumeratort::backtrack(patht &path)
   path.pop_back();
 
   path_nodet &parent=path.back();
-  goto_programt::targetst succs;
-  goto_program.get_successors(parent.loc, succs);
+  const auto succs=goto_program.get_successors(parent.loc);
 
   unsigned int ret=0;
 
@@ -119,12 +118,9 @@ void all_paths_enumeratort::extend_path(
   int succ)
 {
   goto_programt::targett next;
-  goto_programt::targetst succs;
   exprt guard=true_exprt();
 
-  goto_program.get_successors(t, succs);
-
-  for(const auto &s : succs)
+  for(const auto &s : goto_program.get_successors(t))
   {
     if(succ==0)
     {

--- a/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
+++ b/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
@@ -757,23 +757,19 @@ void disjunctive_polynomial_accelerationt::find_distinguishing_points()
       it!=loop.end();
       ++it)
   {
-    goto_programt::targetst succs;
-
-    goto_program.get_successors(*it, succs);
+    const auto succs=goto_program.get_successors(*it);
 
     if(succs.size() > 1)
     {
       // This location has multiple successors -- each successor is a
       // distinguishing point.
-      for(goto_programt::targetst::iterator jt=succs.begin();
-          jt!=succs.end();
-          ++jt)
+      for(const auto &jt : succs)
       {
         symbolt distinguisher_sym =
           utils.fresh_symbol("polynomial::distinguisher", bool_typet());
         symbol_exprt distinguisher=distinguisher_sym.symbol_expr();
 
-        distinguishing_points[*jt]=distinguisher;
+        distinguishing_points[jt]=distinguisher;
         distinguishers.push_back(distinguisher);
       }
     }
@@ -788,9 +784,8 @@ void disjunctive_polynomial_accelerationt::build_path(
   do
   {
     goto_programt::targett next;
-    goto_programt::targetst succs;
 
-    goto_program.get_successors(t, succs);
+    const auto succs=goto_program.get_successors(t);
 
     // We should have a looping path, so we should never hit a location
     // with no successors.

--- a/src/goto-instrument/accelerate/sat_path_enumerator.cpp
+++ b/src/goto-instrument/accelerate/sat_path_enumerator.cpp
@@ -109,9 +109,7 @@ void sat_path_enumeratort::find_distinguishing_points()
       it!=loop.end();
       ++it)
   {
-    goto_programt::targetst succs;
-
-    goto_program.get_successors(*it, succs);
+    const auto succs=goto_program.get_successors(*it);
 
     if(succs.size()>1)
     {
@@ -139,9 +137,7 @@ void sat_path_enumeratort::build_path(
   do
   {
     goto_programt::targett next;
-    goto_programt::targetst succs;
-
-    goto_program.get_successors(t, succs);
+    const auto succs=goto_program.get_successors(t);
 
     // We should have a looping path, so we should never hit a location
     // with no successors.

--- a/src/goto-instrument/accelerate/trace_automaton.cpp
+++ b/src/goto-instrument/accelerate/trace_automaton.cpp
@@ -38,10 +38,7 @@ void trace_automatont::build_alphabet(goto_programt &program)
 {
   Forall_goto_program_instructions(it, program)
   {
-    goto_programt::targetst succs;
-
-    program.get_successors(it, succs);
-
+    const auto succs=program.get_successors(it);
     if(succs.size()>1)
     {
       alphabet.insert(succs.begin(), succs.end());

--- a/src/goto-instrument/call_sequences.cpp
+++ b/src/goto-instrument/call_sequences.cpp
@@ -62,14 +62,11 @@ void show_call_sequences(
       continue; // abort search
     }
 
-    // get successors
-    goto_programt::const_targetst s;
-    goto_program.get_successors(t, s);
-
-    // add to stack
-    for(goto_programt::const_targetst::const_iterator
-        it=s.begin(); it!=s.end(); it++)
-      stack.push(*it);
+    // get successors and add to stack
+    for(const auto &it : goto_program.get_successors(t))
+    {
+      stack.push(it);
+    }
   }
 }
 

--- a/src/goto-instrument/dot.cpp
+++ b/src/goto-instrument/dot.cpp
@@ -217,8 +217,7 @@ void dott::write_dot_subgraph(
         write_edge(out, *it, **frit, flabel);
 
       seen.insert(it);
-      goto_programt::const_targetst temp;
-      goto_program.get_successors(it, temp);
+      const auto temp=goto_program.get_successors(it);
       worklist.insert(worklist.end(), temp.begin(), temp.end());
     }
   }

--- a/src/goto-instrument/wmm/goto2graph.cpp
+++ b/src/goto-instrument/wmm/goto2graph.cpp
@@ -1541,7 +1541,7 @@ bool instrumentert::is_cfg_spurious(const event_grapht::critical_cyclet &cyc)
   map.insert(p);
 
   goto_functionst this_interleaving;
-  this_interleaving.function_map=map;
+  this_interleaving.function_map=std::move(map);
   optionst no_option;
   null_message_handlert no_message;
 

--- a/src/goto-programs/remove_unreachable.cpp
+++ b/src/goto-programs/remove_unreachable.cpp
@@ -39,10 +39,8 @@ void remove_unreachable(goto_programt &goto_program)
        t!=goto_program.instructions.end())
     {
       reachable.insert(t);
-      goto_programt::targetst successors;
-      goto_program.get_successors(t, successors);
 
-      for(const auto &succ : successors)
+      for(const auto &succ : goto_program.get_successors(t))
         working.push(succ);
     }
   }


### PR DESCRIPTION
The biggest change is to `goto_program_templatet::get_successors`, which now returns a list of targets instead of modifying a list which was passed-by-reference. With move semantics, there should be no performance penalty. It also cleans up call sites of this method, which no longer need to have a preceding list declaration.

This change was made because there were two version of `get_successors`, one `const` and one not, with slightly different implementations. By templating the method on the `Target` type, we can reduce duplication, and avoid bugs where const- and non-const-methods have different behaviours.

Also replaced a few iterator increments/decrements with `std::next` and `std::prev`, and made some const-correctness fixes.