### PR TITLE
Remove 'erase' in replace_java_nondet.cpp, fixes #850

### DIFF
--- a/src/goto-programs/convert_nondet.cpp
+++ b/src/goto-programs/convert_nondet.cpp
@@ -132,7 +132,7 @@ static void convert_nondet(
 {
   for(auto instruction_iterator=goto_program.instructions.begin(),
         end=goto_program.instructions.end();
-        instruction_iterator!=end;)
+      instruction_iterator!=end;)
   {
     instruction_iterator=insert_nondet_init_code(
       goto_program,

--- a/src/goto-programs/replace_java_nondet.cpp
+++ b/src/goto-programs/replace_java_nondet.cpp
@@ -9,6 +9,7 @@ Author: Reuben Thomas, reuben.thomas@diffblue.com
 #include "goto-programs/replace_java_nondet.h"
 #include "goto-programs/goto_convert.h"
 #include "goto-programs/goto_model.h"
+#include "goto-programs/remove_skip.h"
 
 #include "util/irep_ids.h"
 
@@ -320,5 +321,8 @@ void replace_java_nondet(goto_functionst &goto_functions)
   {
     replace_java_nondet(goto_program.second.body);
   }
+
   goto_functions.compute_location_numbers();
+
+  remove_skip(goto_functions);
 }


### PR DESCRIPTION
This patch implements a fix for #850. I haven't added a regression test, because such a test would require that `org.cprover.jar` had already been built and placed in a known location.

Erasing a range of instructions from a goto program can cause memory bugs when `goto_program::update` is called. Specifically, if any of the remaining nodes in the program have elements of `targets` which point into the erased range, then the program may attempt an invalid read during the `update` call.

To avoid this, I thought of two options:
- check through the goto-program for instructions with `target`s that point into the removed range, and remove those `target`s, or
- just replace the existing instructions with no-ops.

Although I think the first solution is better, I can't think of a good way of doing it with acceptable complexity, so this patch implements the second option.