### PR TITLE
Testgen support for functions that return arrays.

### DIFF
--- a/regression/goto-instrument/array_01/main.c
+++ b/regression/goto-instrument/array_01/main.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+
+int **fun(void) {
+  int **Array = malloc(2 * sizeof(int *));
+
+  Array[0] = malloc(sizeof(int));
+  *Array[0] = 32;
+  Array[1] = malloc(sizeof(int));
+  *Array[1] = 64;
+
+  return Array;
+}
+
+int main(int argc, char *argv[])
+{
+  int **array;
+  array = fun();
+  return 0;
+}

--- a/regression/goto-instrument/array_01/test.desc
+++ b/regression/goto-instrument/array_01/test.desc
@@ -1,0 +1,18 @@
+CORE
+main.c
+--dump-c 
+^        signed int \*\*Array;$
+^        void \*return_value_malloc\$1;$
+^        return_value_malloc\$1=malloc\(\(signed int\)\(2ul \* sizeof\(signed int \*\)
+^        Array = \(signed int \*\*\)return_value_malloc\$1;$
+^        void \*return_value_malloc\$2;$
+^        return_value_malloc\$2=malloc\(\(signed int\)sizeof\(signed int\)
+^        Array\[0l\] = \(signed int \*\)return_value_malloc\$2;$
+^        \*Array\[0l\] \= 32;$
+^        void \*return_value_malloc\$3;$
+^        return_value_malloc\$3=malloc\(\(signed int\)sizeof\(signed int\)
+^        Array\[1l\] = \(signed int \*\)return_value_malloc\$3;$
+^        \*Array\[1l\] = 64;$
+^        return Array;$
+^SIGNAL=0$
+--

--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -61,6 +61,12 @@ protected:
     const std::string &declarator_str,
     bool inc_size_if_possible);
 
+  virtual std::string convert_pointer_type(
+    const typet &src,
+    const c_qualifierst &qualifiers,
+    const std::string &declarator,
+    bool toggle);
+
   static std::string indent_str(unsigned indent);
 
   std::unordered_map<irep_idt,


### PR DESCRIPTION
This PR introduces changes into cbmc designed to allow us to express code for C arrays under test, without which right now the behaviour we notice is completely bugged, producing code that is not syntactically valid C in the tests we generate.