### PR TITLE
Add CBMC package build file for Arch Linux

### DIFF
--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Vlastimil Zeman <vlastimil.zeman@diffblue.com>
+
+pkgname=cbmc
+pkgver=5.7
+pkgrel=1
+pkgdesc="Bounded Model Checker for C and C++ programs"
+arch=("x86_64")
+url="https://github.com/diffblue/cbmc"
+license=("BSD-4-Clause")
+depends=("gcc-libs>=6.3")
+makedepends=("gcc>=6.3"
+             "make>=4.2"
+             "patch>=2.7"
+             "perl-libwww>=6.24"
+             "bison>=3.0"
+             "flex>=2.6")
+source=("https://github.com/diffblue/cbmc/archive/$pkgname-$pkgver.tar.gz")
+sha256sums=("4f98cdce609532d3fc2587299ee4a6544f63aff5cf42e89d2baaa3d3562edf3e")
+
+
+build() {
+        make -C "$pkgname-$pkgname-$pkgver/src" minisat2-download
+        make -C "$pkgname-$pkgname-$pkgver/src" -j$(getconf _NPROCESSORS_ONLN)
+}
+
+
+check() {
+        make -C "$pkgname-$pkgname-$pkgver/regression" test
+}
+
+
+package() {
+        mkdir -p "$pkgdir/usr/bin/"
+        for binary in $pkgname goto-analyzer goto-cc goto-diff goto-instrument
+        do
+                cp "$pkgname-$pkgname-$pkgver/src/$binary/$binary" "$pkgdir/usr/bin/"
+                chmod 755 "$pkgdir/usr/bin/$binary"
+                chown root:root "$pkgdir/usr/bin/$binary"
+        done
+}

--- a/pkg/arch/README.md
+++ b/pkg/arch/README.md
@@ -1,0 +1,17 @@
+# Arch Linux Package
+
+Update packages and install build dependencies
+
+```bash
+sudo pacman -Sy archlinux-keyring && sudo pacman -Syyu
+sudo pacman -S gcc bison flex make patch perl-libwww fakeroot
+```
+
+Create folder for package and copy [PKGBUILD](PKGBUILD) file there.
+
+Build package by running `makepkg` in that folder. That will compile *CBMC* and
+run all tests. To install package run
+
+```bash
+sudo pacman -U cbmc-5.7-1-x86_64.pkg.tar.xz`
+```


### PR DESCRIPTION
Arch Linux use `PKGBUILD` file to create package. One can use `PKGBUILD` file from this commit (see README.md)
This was requested by @kroening and moved/updated here at the request of @peterschrammel.