### PR TITLE
Fix return of temporary ref in ssa_exprt

### DIFF
--- a/src/util/ssa_expr.h
+++ b/src/util/ssa_expr.h
@@ -42,7 +42,7 @@ public:
     return static_cast<const exprt &>(find(ID_expression));
   }
 
-  const irep_idt &get_object_name() const
+  irep_idt get_object_name() const
   {
     object_descriptor_exprt ode;
     ode.object()=get_original_expr();


### PR DESCRIPTION
This patch fixes an issue where `ssa_exprt::get_object_name` returns a const reference to an object with stack-bound lifetime.