### PR TITLE
Document $, !, @ and # in symbol names

### DIFF
--- a/src/util/fresh_symbol.cpp
+++ b/src/util/fresh_symbol.cpp
@@ -41,6 +41,7 @@ symbolt &get_fresh_aux_symbol(
 
   do
   {
+    // Distinguish local variables with the same name
     new_symbol.base_name=
       basename_prefix+
       "$"+

--- a/src/util/ssa_expr.cpp
+++ b/src/util/ssa_expr.cpp
@@ -61,18 +61,23 @@ static void build_ssa_identifier_rec(
 
     if(!l0.empty())
     {
+      // Distinguish different threads of execution
       os << '!' << l0;
       l1_object_os << '!' << l0;
     }
 
     if(!l1.empty())
     {
+      // Distinguish different calls to the same function (~stack frame)
       os << '@' << l1;
       l1_object_os << '@' << l1;
     }
 
     if(!l2.empty())
+    {
+      // Distinguish SSA steps for the same variable
       os << '#' << l2;
+    }
   }
   else
     assert(false);


### PR DESCRIPTION
Document what symbol name suffices beginning with $, !, @ and # mean,
at the points in the code where they are created.