### PR TITLE
Adding java_type field in json for bit vector values

### DIFF
--- a/src/goto-programs/json_goto_trace.cpp
+++ b/src/goto-programs/json_goto_trace.cpp
@@ -146,8 +146,13 @@ void convert(
         json_output["outputID"]=json_stringt(id2string(step.io_id));
 
         // Recovering the mode from the function
-        symbolt function_name=ns.lookup(source_location.get_function());
-        irep_idt mode=function_name.mode;
+        irep_idt mode;
+        const symbolt *function_name;
+        if(ns.lookup(source_location.get_function(), function_name))
+          // Failed to find symbol
+          mode=ID_unknown;
+        else
+          mode=function_name->mode;
         json_arrayt &json_values=json_output["values"].make_array();
 
         for(const auto &arg : step.io_args)

--- a/src/goto-programs/json_goto_trace.cpp
+++ b/src/goto-programs/json_goto_trace.cpp
@@ -100,9 +100,6 @@ void convert(
           full_lhs_value_string=from_expr(ns, identifier, it.full_lhs_value);
 #endif
 
-        if(step.full_lhs_value.is_not_nil())
-          full_lhs_value = json(step.full_lhs_value, ns);
-
         const symbolt *symbol;
         irep_idt base_name, display_name;
 
@@ -114,6 +111,13 @@ void convert(
             type_string=from_type(ns, identifier, symbol->type);
 
           json_assignment["mode"]=json_stringt(id2string(symbol->mode));
+          if(step.full_lhs_value.is_not_nil())
+            full_lhs_value=json(step.full_lhs_value, ns, symbol->mode);
+        }
+        else
+        {
+          if(step.full_lhs_value.is_not_nil())
+            full_lhs_value=json(step.full_lhs_value, ns);
         }
 
         json_assignment["value"]=full_lhs_value;
@@ -141,6 +145,9 @@ void convert(
         json_output["thread"]=json_numbert(std::to_string(step.thread_nr));
         json_output["outputID"]=json_stringt(id2string(step.io_id));
 
+        // Recovering the mode from the function
+        symbolt function_name=ns.lookup(source_location.get_function());
+        irep_idt mode=function_name.mode;
         json_arrayt &json_values=json_output["values"].make_array();
 
         for(const auto &arg : step.io_args)
@@ -148,7 +155,7 @@ void convert(
           if(arg.is_nil())
             json_values.push_back(json_stringt(""));
           else
-            json_values.push_back(json(arg, ns));
+            json_values.push_back(json(arg, ns, mode));
         }
 
         if(!json_location.is_null())

--- a/src/goto-programs/json_goto_trace.cpp
+++ b/src/goto-programs/json_goto_trace.cpp
@@ -92,13 +92,8 @@ void convert(
         std::string value_string, binary_string, type_string, full_lhs_string;
         json_objectt full_lhs_value;
 
-        if(step.full_lhs.is_not_nil())
-          full_lhs_string=from_expr(ns, identifier, step.full_lhs);
-
-#if 0
-        if(it.full_lhs_value.is_not_nil())
-          full_lhs_value_string=from_expr(ns, identifier, it.full_lhs_value);
-#endif
+        assert(step.full_lhs.is_not_nil());
+        full_lhs_string=from_expr(ns, identifier, step.full_lhs);
 
         const symbolt *symbol;
         irep_idt base_name, display_name;
@@ -111,13 +106,13 @@ void convert(
             type_string=from_type(ns, identifier, symbol->type);
 
           json_assignment["mode"]=json_stringt(id2string(symbol->mode));
-          if(step.full_lhs_value.is_not_nil())
-            full_lhs_value=json(step.full_lhs_value, ns, symbol->mode);
+          assert(step.full_lhs_value.is_not_nil());
+          full_lhs_value=json(step.full_lhs_value, ns, symbol->mode);
         }
         else
         {
-          if(step.full_lhs_value.is_not_nil())
-            full_lhs_value=json(step.full_lhs_value, ns);
+          assert(step.full_lhs_value.is_not_nil());
+          full_lhs_value=json(step.full_lhs_value, ns);
         }
 
         json_assignment["value"]=full_lhs_value;

--- a/src/util/json_expr.cpp
+++ b/src/util/json_expr.cpp
@@ -287,6 +287,8 @@ json_objectt json(
       std::string type_string;
       if(!lang->from_type(underlying_type, type_string, ns))
         result["type"]=json_stringt(type_string);
+      else
+        assert(false && "unknown type");
 
       mp_integer i;
       if(!to_integer(expr, i))

--- a/src/util/json_expr.cpp
+++ b/src/util/json_expr.cpp
@@ -15,6 +15,8 @@ Author: Peter Schrammel
 #include "std_expr.h"
 #include "config.h"
 #include "identifier.h"
+#include "language.h"
+#include <langapi/mode.h>
 
 #include "json_expr.h"
 
@@ -272,37 +274,19 @@ json_objectt json(
         type.id()==ID_c_bit_field?type.subtype():
         type;
 
-      bool is_signed=underlying_type.id()==ID_signedbv;
+      languaget *lang;
+      if(mode==ID_unknown)
+        lang=get_default_language();
+      else
+      {
+        lang=get_language_from_mode(mode);
+        if(!lang)
+          lang=get_default_language();
+      }
 
-      if(mode==ID_C)
-      {
-        std::string sig=is_signed?"":"unsigned ";
-        if(width==config.ansi_c.char_width)
-          result["type"]=json_stringt(sig+"char");
-        else if(width==config.ansi_c.int_width)
-          result["type"]=json_stringt(sig+"int");
-        else if(width==config.ansi_c.short_int_width)
-          result["type"]=json_stringt(sig+"short int");
-        else if(width==config.ansi_c.long_int_width)
-          result["type"]=json_stringt(sig+"long int");
-        else if(width==config.ansi_c.long_long_int_width)
-          result["type"]=json_stringt(sig+"long long int");
-        else
-          assert(false && "unknown C type");
-      }
-      else if(mode==ID_java)
-      {
-        if(width==8 && is_signed)
-          result["type"]=json_stringt("byte");
-        else if(width==16 && is_signed)
-          result["type"]=json_stringt("short");
-        else if(width==16 && !is_signed)
-          result["type"]=json_stringt("char");
-        else if(width==32 && is_signed)
-          result["type"]=json_stringt("int");
-        else if(width==64 && is_signed)
-          result["type"]=json_stringt("long");
-      }
+      std::string type_string;
+      if(!lang->from_type(underlying_type, type_string, ns))
+        result["type"]=json_stringt(type_string);
 
       mp_integer i;
       if(!to_integer(expr, i))

--- a/src/util/json_expr.cpp
+++ b/src/util/json_expr.cpp
@@ -293,6 +293,8 @@ json_objectt json(
       mp_integer i;
       if(!to_integer(expr, i))
         result["data"]=json_stringt(integer2string(i));
+      else
+        assert(false && "could not convert data to integer");
     }
     else if(type.id()==ID_c_enum)
     {
@@ -304,6 +306,8 @@ json_objectt json(
       mp_integer i;
       if(!to_integer(expr, i))
         result["data"]=json_stringt(integer2string(i));
+      else
+        assert(false && "could not convert data to integer");
     }
     else if(type.id()==ID_c_enum_tag)
     {

--- a/src/util/json_expr.h
+++ b/src/util/json_expr.h
@@ -10,6 +10,7 @@ Author: Peter Schrammel
 #define CPROVER_UTIL_JSON_EXPR_H
 
 #include "json.h"
+#include "irep.h"
 
 class source_locationt;
 class typet;
@@ -18,11 +19,13 @@ class namespacet;
 
 json_objectt json(
   const exprt &,
-  const namespacet &);
+  const namespacet &,
+  const irep_idt &mode=ID_unknown);
 
 json_objectt json(
   const typet &,
-  const namespacet &);
+  const namespacet &,
+  const irep_idt &mode=ID_unknown);
 
 json_objectt json(const source_locationt &);
 


### PR DESCRIPTION
The c_type field is confusing if the original program is in Java since the types do not match.
This adds a `java_type` field in the json output which clarifies what the type should be for Java.
This is in response to the issue raised here: diffblue/test-gen#294