### PR TITLE
Replace std::endl with \n

### DIFF
--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -235,6 +235,7 @@ _ERROR_CATEGORIES = [
     'readability/function_comment'
     'runtime/arrays',
     'runtime/casting',
+    'runtime/endl',
     'runtime/explicit',
     'runtime/int',
     'runtime/init',
@@ -6198,6 +6199,12 @@ def CheckNamespaceOrUsing(filename, clean_lines, linenum, error):
     error(filename, linenum, 'readability/namespace', 4,
           'Do not use using')
 
+def CheckForEndl(filename, clean_lines, linenum, error):
+  """Check that the line does not contain std::endl."""
+  line = clean_lines.elided[linenum]
+  if Match(r'[^a-zA-Z0-9_]*std::endl[^a-zA-Z0-9_]*', line):
+    error(filename, linenum, 'runtime/endl', 4, 'Do not use std::endl')
+
 def ProcessLine(filename, file_extension, clean_lines, line,
                 include_state, function_state, nesting_state, error,
                 extra_check_functions=[]):
@@ -6239,6 +6246,7 @@ def ProcessLine(filename, file_extension, clean_lines, line,
   CheckMakePairUsesDeduction(filename, clean_lines, line, error)
   CheckRedundantVirtual(filename, clean_lines, line, error)
   CheckNamespaceOrUsing(filename, clean_lines, line, error)
+  CheckForEndl(filename, clean_lines, line, error)
   for check_fn in extra_check_functions:
     check_fn(filename, clean_lines, line, error)
 

--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -93,7 +93,7 @@ void constant_propagator_domaint::assign_rec(
 
 #ifdef DEBUG
   std::cout << "assign: " << from_expr(ns, "", lhs)
-            << " := " << from_type(ns, "", rhs_type) << std::endl;
+            << " := " << from_type(ns, "", rhs_type) << '\n';
 #endif
 
   if(lhs.id()==ID_symbol && rhs.id()==ID_if)

--- a/src/analyses/dependence_graph.cpp
+++ b/src/analyses/dependence_graph.cpp
@@ -326,7 +326,7 @@ void dep_graph_domaint::output(
         out << ",";
       out << (*it)->location_number;
     }
-    out << std::endl;
+    out << '\n';
   }
 
   if(!data_deps.empty())
@@ -341,7 +341,7 @@ void dep_graph_domaint::output(
         out << ",";
       out << (*it)->location_number;
     }
-    out << std::endl;
+    out << '\n';
   }
 }
 

--- a/src/analyses/dirty.cpp
+++ b/src/analyses/dirty.cpp
@@ -115,5 +115,5 @@ Function: dirtyt::output
 void dirtyt::output(std::ostream &out) const
 {
   for(const auto &d : dirty)
-    out << d << std::endl;
+    out << d << '\n';
 }

--- a/src/analyses/flow_insensitive_analysis.cpp
+++ b/src/analyses/flow_insensitive_analysis.cpp
@@ -133,10 +133,7 @@ void flow_insensitive_analysis_baset::output(
 {
   forall_goto_functions(f_it, goto_functions)
   {
-    out << "////" << std::endl;
-    out << "//// Function: " << f_it->first << std::endl;
-    out << "////" << std::endl;
-    out << std::endl;
+    out << "////\n" << "//// Function: " << f_it->first << "\n////\n\n";
 
     output(f_it->second.body, f_it->first, out);
   }
@@ -253,7 +250,7 @@ bool flow_insensitive_analysis_baset::visit(
 
   #if 0
   std::cout << "Visiting: " << l->function << " " <<
-    l->location_number << std::endl;
+    l->location_number << '\n';
   #endif
 
   seen_locations.insert(l);
@@ -294,14 +291,14 @@ bool flow_insensitive_analysis_baset::visit(
   }
 
 //  if (id2string(l->function).find("debug")!=std::string::npos)
-//    std::cout << l->function << std::endl; //=="messages::debug")
+//    std::cout << l->function << '\n'; //=="messages::debug")
 
 //  {
 //    static unsigned state_cntr=0;
 //    std::string s("pastate"); s += std::to_string(state_cntr);
 //    std::ofstream f(s.c_str());
 //    goto_program.output_instruction(ns, "", f, l);
-//    f << std::endl;
+//    f << '\n';
 //    get_state().output(ns, f);
 //    f.close();
 //    state_cntr++;

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -107,22 +107,22 @@ Function: rw_range_sett::output
 
 void rw_range_sett::output(std::ostream &out) const
 {
-  out << "READ:" << std::endl;
+  out << "READ:\n";
   forall_rw_range_set_r_objects(it, *this)
   {
     out << "  " << it->first;
     it->second->output(ns, out);
-    out << std::endl;
+    out << '\n';
   }
 
-  out << std::endl;
+  out << '\n';
 
-  out << "WRITE:" << std::endl;
+  out << "WRITE:\n";
   forall_rw_range_set_w_objects(it, *this)
   {
     out << "  " << it->first;
     it->second->output(ns, out);
-    out << std::endl;
+    out << '\n';
   }
 }
 

--- a/src/analyses/invariant_set.cpp
+++ b/src/analyses/invariant_set.cpp
@@ -36,7 +36,7 @@ Function: inv_object_storet::output
 void inv_object_storet::output(std::ostream &out) const
 {
   for(unsigned i=0; i<entries.size(); i++)
-    out << "STORE " << i << ": " << to_string(i, "") << std::endl;
+    out << "STORE " << i << ": " << to_string(i, "") << '\n';
 }
 
 /*******************************************************************\
@@ -488,7 +488,7 @@ void invariant_sett::output(
 {
   if(is_false)
   {
-    out << "FALSE" << std::endl;
+    out << "FALSE\n";
     return;
   }
 
@@ -510,28 +510,28 @@ void invariant_sett::output(
           out << to_string(j, identifier);
         }
 
-      out << std::endl;
+      out << '\n';
     }
 
   for(const auto &bounds : bounds_map)
   {
     out << to_string(bounds.first, identifier)
         << " in " << bounds.second
-        << std::endl;
+        << '\n';
   }
 
   for(const auto &le : le_set)
   {
     out << to_string(le.first, identifier)
         << " <= " << to_string(le.second, identifier)
-        << std::endl;
+        << '\n';
   }
 
   for(const auto &ne : ne_set)
   {
     out << to_string(ne.first, identifier)
         << " != " << to_string(ne.second, identifier)
-        << std::endl;
+        << '\n';
   }
 }
 
@@ -604,7 +604,7 @@ void invariant_sett::strengthen_rec(const exprt &expr)
     throw "non-Boolean argument to strengthen()";
 
   #if 0
-  std::cout << "S: " << from_expr(*ns, "", expr) << std::endl;
+  std::cout << "S: " << from_expr(*ns, "", expr) << '\n';
   #endif
 
   if(is_false)
@@ -836,7 +836,7 @@ tvt invariant_sett::implies_rec(const exprt &expr) const
     throw "implies: non-Boolean expression";
 
   #if 0
-  std::cout << "I: " << from_expr(*ns, "", expr) << std::endl;
+  std::cout << "I: " << from_expr(*ns, "", expr) << '\n';
   #endif
 
   if(is_false) // can't get any stronger
@@ -1508,7 +1508,7 @@ void invariant_sett::apply_code(const codet &code)
   }
   else
   {
-    std::cerr << code.pretty() << std::endl;
+    std::cerr << code.pretty() << '\n';
     throw "invariant_sett: unexpected statement: "+id2string(statement);
   }
 }

--- a/src/analyses/natural_loops.cpp
+++ b/src/analyses/natural_loops.cpp
@@ -26,12 +26,12 @@ void show_natural_loops(const goto_functionst &goto_functions)
 {
   forall_goto_functions(it, goto_functions)
   {
-    std::cout << "*** " << it->first << std::endl;
+    std::cout << "*** " << it->first << '\n';
 
     natural_loopst natural_loops;
     natural_loops(it->second.body);
     natural_loops.output(std::cout);
 
-    std::cout << std::endl;
+    std::cout << '\n';
   }
 }

--- a/src/analyses/reaching_definitions.cpp
+++ b/src/analyses/reaching_definitions.cpp
@@ -650,7 +650,7 @@ Function: rd_range_domaint::output
 
 void rd_range_domaint::output(std::ostream &out) const
 {
-  out << "Reaching definitions:" << std::endl;
+  out << "Reaching definitions:\n";
 
   if(has_values.is_known())
   {
@@ -681,7 +681,7 @@ void rd_range_domaint::output(std::ostream &out) const
         out << "@" << itl->first->location_number;
       }
 
-    out << "]" << std::endl;
+    out << "]\n";
 
     clear_cache(identifier);
   }

--- a/src/ansi-c/file_converter.cpp
+++ b/src/ansi-c/file_converter.cpp
@@ -37,6 +37,6 @@ int main()
         std::cout << ch;
     }
 
-    std::cout << "\\n\"" << std::endl;
+    std::cout << "\\n\"\n";
   }
 }

--- a/src/ansi-c/library/converter.cpp
+++ b/src/ansi-c/library/converter.cpp
@@ -57,7 +57,7 @@ int main()
           std::cout << ch;
       }
 
-      std::cout << "\\n\"" << std::endl;
+      std::cout << "\\n\"\n";
     }
   }
 

--- a/src/ansi-c/parser_static.inc
+++ b/src/ansi-c/parser_static.inc
@@ -100,8 +100,8 @@ Function: merge_types
 static void merge_types(irept &dest, irept &src)
 {
   #if 0
-  std::cout << "D: " << dest.pretty() << std::endl;
-  std::cout << "S: " << src.pretty() << std::endl;
+  std::cout << "D: " << dest.pretty() << '\n';
+  std::cout << "S: " << src.pretty() << '\n';
   #endif
 
   if(src.is_nil())
@@ -183,8 +183,8 @@ static void make_subtype(typet &dest, typet &src)
   // find spot in 'dest' where to insert 'src'
 
   #if 0
-  std::cout << "D: " << dest.pretty() << std::endl;
-  std::cout << "S: " << src.pretty() << std::endl;
+  std::cout << "D: " << dest.pretty() << '\n';
+  std::cout << "S: " << src.pretty() << '\n';
   #endif
 
   assert(src.id()==ID_array ||

--- a/src/cbmc/cbmc_main.cpp
+++ b/src/cbmc/cbmc_main.cpp
@@ -53,9 +53,9 @@ int main(int argc, const char **argv)
   int res=parse_options.main();
 
   #ifdef IREP_HASH_STATS
-  std::cout << "IREP_HASH_CNT=" << irep_hash_cnt << std::endl;
-  std::cout << "IREP_CMP_CNT=" << irep_cmp_cnt << std::endl;
-  std::cout << "IREP_CMP_NE_CNT=" << irep_cmp_ne_cnt << std::endl;
+  std::cout << "IREP_HASH_CNT=" << irep_hash_cnt << '\n';
+  std::cout << "IREP_CMP_CNT=" << irep_cmp_cnt << '\n';
+  std::cout << "IREP_CMP_NE_CNT=" << irep_cmp_ne_cnt << '\n';
   #endif
 
   return res;

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -458,7 +458,7 @@ int cbmc_parse_optionst::doit()
 {
   if(cmdline.isset("version"))
   {
-    std::cout << CBMC_VERSION << std::endl;
+    std::cout << CBMC_VERSION << '\n';
     return 0; // should contemplate EX_OK from sysexits.h
   }
 

--- a/src/cbmc/symex_coverage.cpp
+++ b/src/cbmc/symex_coverage.cpp
@@ -279,9 +279,9 @@ void goto_program_coverage_recordt::compute_coverage_lines(
     {
       if(!(c_entry->second.size()==1 || is_branch))
       {
-        std::cerr << it->location_number << std::endl;
+        std::cerr << it->location_number << '\n';
         for(const auto &cov : c_entry->second)
-          std::cerr << cov.second.succ->location_number << std::endl;
+          std::cerr << cov.second.succ->location_number << '\n';
       }
       assert(c_entry->second.size()==1 || is_branch);
 

--- a/src/clobber/clobber_parse_options.cpp
+++ b/src/clobber/clobber_parse_options.cpp
@@ -147,7 +147,7 @@ int clobber_parse_optionst::doit()
 {
   if(cmdline.isset("version"))
   {
-    std::cout << CBMC_VERSION << std::endl;
+    std::cout << CBMC_VERSION << '\n';
     return 0;
   }
 
@@ -532,7 +532,7 @@ void clobber_parse_optionst::report_success()
       xmlt xml("cprover-status");
       xml.data="SUCCESS";
       std::cout << xml;
-      std::cout << std::endl;
+      std::cout << '\n';
     }
     break;
 
@@ -561,7 +561,7 @@ void clobber_parse_optionst::show_counterexample(
   switch(get_ui())
   {
   case ui_message_handlert::uit::PLAIN:
-    std::cout << std::endl << "Counterexample:" << std::endl;
+    std::cout << "\nCounterexample:\n";
     show_goto_trace(std::cout, ns, error_trace);
     break;
 
@@ -569,7 +569,7 @@ void clobber_parse_optionst::show_counterexample(
     {
       xmlt xml;
       convert(ns, error_trace, xml);
-      std::cout << xml << std::endl;
+      std::cout << xml << '\n';
     }
     break;
 
@@ -604,7 +604,7 @@ void clobber_parse_optionst::report_failure()
       xmlt xml("cprover-status");
       xml.data="FAILURE";
       std::cout << xml;
-      std::cout << std::endl;
+      std::cout << '\n';
     }
     break;
 

--- a/src/cpp/cpp_convert_type.cpp
+++ b/src/cpp/cpp_convert_type.cpp
@@ -66,7 +66,7 @@ void cpp_convert_typet::read(const typet &type)
   other.clear();
 
   #if 0
-  std::cout << "cpp_convert_typet::read: " << type.pretty() << std::endl;
+  std::cout << "cpp_convert_typet::read: " << type.pretty() << '\n';
   #endif
 
   read_rec(type);
@@ -88,7 +88,7 @@ void cpp_convert_typet::read_rec(const typet &type)
 {
   #if 0
   std::cout << "cpp_convert_typet::read_rec: "
-            << type.pretty() << std::endl;
+            << type.pretty() << '\n';
   #endif
 
   if(type.id()==ID_merged_type)

--- a/src/cpp/cpp_id.cpp
+++ b/src/cpp/cpp_id.cpp
@@ -59,7 +59,7 @@ void cpp_idt::print(std::ostream &out, unsigned indent) const
         it++)
       it->second.print(out, indent+2);
 
-    out << std::endl;
+    out << '\n';
   }
 }
 
@@ -78,22 +78,22 @@ Function: cpp_idt::print_fields
 void cpp_idt::print_fields(std::ostream &out, unsigned indent) const
 {
   for(unsigned i=0; i<indent; i++) out << ' ';
-  out << "**identifier=" << identifier << std::endl;
+  out << "**identifier=" << identifier << '\n';
 
   for(unsigned i=0; i<indent; i++) out << ' ';
-  out << "  prefix=" << prefix << std::endl;
+  out << "  prefix=" << prefix << '\n';
 
   for(unsigned i=0; i<indent; i++) out << ' ';
-  out << "  suffix=" << suffix << std::endl;
+  out << "  suffix=" << suffix << '\n';
 
   for(unsigned i=0; i<indent; i++) out << ' ';
-  out << "  base_name=" << base_name << std::endl;
+  out << "  base_name=" << base_name << '\n';
 
   for(unsigned i=0; i<indent; i++) out << ' ';
-  out << "  method=" << is_method << std::endl;
+  out << "  method=" << is_method << '\n';
 
   for(unsigned i=0; i<indent; i++) out << ' ';
-  out << "  class_identifier=" << class_identifier << std::endl;
+  out << "  class_identifier=" << class_identifier << '\n';
 
   for(scope_listt::const_iterator
       it=secondary_scopes.begin();
@@ -101,7 +101,7 @@ void cpp_idt::print_fields(std::ostream &out, unsigned indent) const
       it++)
   {
     for(unsigned i=0; i<indent; i++) out << ' ';
-    out << "  secondary_scope=" << (*it)->identifier << std::endl;
+    out << "  secondary_scope=" << (*it)->identifier << '\n';
   }
 
   for(scope_listt::const_iterator
@@ -110,7 +110,7 @@ void cpp_idt::print_fields(std::ostream &out, unsigned indent) const
       it++)
   {
     for(unsigned i=0; i<indent; i++) out << ' ';
-    out << "  using_scope=" << (*it)->identifier << std::endl;
+    out << "  using_scope=" << (*it)->identifier << '\n';
   }
 
   for(unsigned i=0; i<indent; i++) out << ' ';
@@ -123,10 +123,10 @@ void cpp_idt::print_fields(std::ostream &out, unsigned indent) const
     out << " member";
   if(is_static_member)
     out << " static_member";
-  out << std::endl;
+  out << '\n';
 
   for(unsigned i=0; i<indent; i++) out << ' ';
-  out << "  id_class=" << id_class << std::endl;
+  out << "  id_class=" << id_class << '\n';
 }
 
 /*******************************************************************\

--- a/src/cpp/cpp_instantiate_template.cpp
+++ b/src/cpp/cpp_instantiate_template.cpp
@@ -121,7 +121,7 @@ void cpp_typecheckt::show_instantiation_stack(std::ostream &out)
         out << to_string(*a_it);
     }
 
-    out << "> at " << s_it->source_location << std::endl;
+    out << "> at " << s_it->source_location << '\n';
   }
 }
 
@@ -286,8 +286,8 @@ const symbolt &cpp_typecheckt::instantiate_template(
   instantiation_stack.back().full_template_args=full_template_args;
 
   #if 0
-  std::cout << "L: " << source_location << std::endl;
-  std::cout << "I: " << template_symbol.name << std::endl;
+  std::cout << "L: " << source_location << '\n';
+  std::cout << "I: " << template_symbol.name << '\n';
   #endif
 
   cpp_save_scopet cpp_saved_scope(cpp_scopes);
@@ -310,7 +310,7 @@ const symbolt &cpp_typecheckt::instantiate_template(
     else
       std::cout << to_string(*it);
   }
-  std::cout << ">" << std::endl;
+  std::cout << ">\n";
   #endif
 
   // do we have arguments?
@@ -429,7 +429,7 @@ const symbolt &cpp_typecheckt::instantiate_template(
   }
 
   #if 0
-  std::cout << "MAP:" << std::endl;
+  std::cout << "MAP:\n";
   template_map.print(std::cout);
   #endif
 

--- a/src/cpp/cpp_language.cpp
+++ b/src/cpp/cpp_language.cpp
@@ -252,7 +252,7 @@ void cpp_languaget::show_parse(
       item.get_linkage_spec();
 
     out << "LINKAGE " << linkage_spec.linkage().get("value")
-        << ":" << std::endl;
+        << ":\n";
 
     for(cpp_linkage_spect::itemst::const_iterator
         it=linkage_spec.items().begin();
@@ -260,7 +260,7 @@ void cpp_languaget::show_parse(
         it++)
       show_parse(out, *it);
 
-    out << std::endl;
+    out << '\n';
   }
   else if(item.is_namespace_spec())
   {
@@ -268,7 +268,7 @@ void cpp_languaget::show_parse(
       item.get_namespace_spec();
 
     out << "NAMESPACE " << namespace_spec.get_namespace()
-        << ":" << std::endl;
+        << ":\n";
 
     for(cpp_namespace_spect::itemst::const_iterator
         it=namespace_spec.items().begin();
@@ -276,7 +276,7 @@ void cpp_languaget::show_parse(
         it++)
       show_parse(out, *it);
 
-    out << std::endl;
+    out << '\n';
   }
   else if(item.is_using())
   {
@@ -285,15 +285,15 @@ void cpp_languaget::show_parse(
     out << "USING ";
     if(cpp_using.get_namespace())
       out << "NAMESPACE ";
-    out << cpp_using.name().pretty() << std::endl;
-    out << std::endl;
+    out << cpp_using.name().pretty() << '\n';
+    out << '\n';
   }
   else if(item.is_declaration())
   {
     item.get_declaration().output(out);
   }
   else
-    out << "UNKNOWN: " << item.pretty() << std::endl;
+    out << "UNKNOWN: " << item.pretty() << '\n';
 }
 
 /*******************************************************************\

--- a/src/cpp/cpp_name.cpp
+++ b/src/cpp/cpp_name.cpp
@@ -77,7 +77,7 @@ void cpp_namet::convert(
     else if(id==ID_template_args)
     {
       std::stringstream ss;
-      ss << location() << std::endl;
+      ss << location() << '\n';
       ss << "no template arguments allowed here";
       throw ss.str();
     }

--- a/src/cpp/cpp_scope.cpp
+++ b/src/cpp/cpp_scope.cpp
@@ -131,11 +131,11 @@ void cpp_scopet::lookup(
   // are looking for templates!
 
   #if 0
-  std::cout << "B: " << base_name <<  std::endl;
-  std::cout << "K: " << kind << std::endl;
-  std::cout << "I: " << id_class << std::endl;
+  std::cout << "B: " << base_name << '\n';
+  std::cout << "K: " << kind << '\n';
+  std::cout << "I: " << id_class << '\n';
   std::cout << "THIS: " << this->base_name << " " << this->id_class
-            << " " << this->identifier << std::endl;
+            << " " << this->identifier << '\n';
   #endif
 
   cpp_id_mapt::iterator

--- a/src/cpp/cpp_token_buffer.cpp
+++ b/src/cpp/cpp_token_buffer.cpp
@@ -147,12 +147,12 @@ void cpp_token_buffert::read_token()
     tokens.back().filename=ansi_c_parser.get_file();
   }
 
-  // std::cout << "TOKEN: " << kind << " " << tokens.back().text << std::endl;
+  // std::cout << "TOKEN: " << kind << " " << tokens.back().text << '\n';
 
   tokens.back().kind=kind;
 
-  // std::cout << "II: " << token_vector.back()->kind << std::endl;
-  // std::cout << "I2: " << token_vector.size() << std::endl;
+  // std::cout << "II: " << token_vector.back()->kind << '\n';
+  // std::cout << "I2: " << token_vector.size() << '\n';
 }
 
 /*******************************************************************\

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -1674,8 +1674,7 @@ bool cpp_typecheckt::get_component(
           error().source_location=source_location;
           str << "error: member `" << component_name
               << "' is not accessible (" << component.get(ID_access) << ")";
-          str << std::endl
-              << "struct name: " << final_type.get(ID_name);
+          str << "\nstruct name: " << final_type.get(ID_name);
           throw 0;
           #endif
         }

--- a/src/cpp/cpp_typecheck_constructor.cpp
+++ b/src/cpp/cpp_typecheck_constructor.cpp
@@ -553,7 +553,7 @@ void cpp_typecheckt::default_assignop_value(
       if(size_expr.id()==ID_infinity)
       {
         // error().source_location=object);
-        // err << "cannot copy array of infinite size" << std::endl;
+        // err << "cannot copy array of infinite size\n";
         // throw 0;
         continue;
       }

--- a/src/cpp/cpp_typecheck_conversions.cpp
+++ b/src/cpp/cpp_typecheck_conversions.cpp
@@ -1743,8 +1743,8 @@ void cpp_typecheckt::implicit_typecast(exprt &expr, const typet &type)
             << to_string(e.type()) << "' to `"
             << to_string(type) << "'" << eom;
     #if 0
-    str << "\n " << follow(e.type()).pretty() << std::endl;
-    str << "\n " << type.pretty() << std::endl;
+    str << "\n " << follow(e.type()).pretty() << '\n';
+    str << "\n " << type.pretty() << '\n';
     #endif
     throw 0;
   }

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -89,22 +89,22 @@ void cpp_typecheckt::typecheck_expr_main(exprt &expr)
   else if(expr.is_nil())
   {
     #if 0
-    std::cerr << "cpp_typecheckt::typecheck_expr_main got nil" << std::endl;
+    std::cerr << "cpp_typecheckt::typecheck_expr_main got nil\n";
     #endif
     abort();
   }
   else if(expr.id()==ID_code)
   {
     #if 0
-    std::cerr << "cpp_typecheckt::typecheck_expr_main got code" << std::endl;
+    std::cerr << "cpp_typecheckt::typecheck_expr_main got code\n";
     #endif
     abort();
   }
   else if(expr.id()==ID_symbol)
   {
     #if 0
-    std::cout << "E: " << expr.pretty() << std::endl;
-    std::cerr << "cpp_typecheckt::typecheck_expr_main got symbol" << std::endl;
+    std::cout << "E: " << expr.pretty() << '\n';
+    std::cerr << "cpp_typecheckt::typecheck_expr_main got symbol\n";
     abort();
     #endif
   }
@@ -1266,7 +1266,7 @@ void cpp_typecheckt::typecheck_expr_typecast(exprt &expr)
 {
   // should not be called
   #if 0
-  std::cout << "E: " << expr.pretty() << std::endl;
+  std::cout << "E: " << expr.pretty() << '\n';
   assert(0);
   #endif
 }

--- a/src/cpp/cpp_typecheck_fargs.cpp
+++ b/src/cpp/cpp_typecheck_fargs.cpp
@@ -129,7 +129,7 @@ bool cpp_typecheck_fargst::match(
     #if 0
     // unclear, todo
     if(is_reference(operand.type()))
-      std::cout << "O: " << operand.pretty() << std::endl;
+      std::cout << "O: " << operand.pretty() << '\n';
 
     assert(!is_reference(operand.type()));
     #endif
@@ -148,7 +148,7 @@ bool cpp_typecheck_fargst::match(
     #if 0
     std::cout << "C: " << cpp_typecheck.to_string(operand.type())
               << " -> " << cpp_typecheck.to_string(parameter.type())
-              << std::endl;
+              << '\n';
     #endif
 
     // can we do the standard conversion sequence?
@@ -158,13 +158,13 @@ bool cpp_typecheck_fargst::match(
       // ok
       distance+=rank;
       #if 0
-      std::cout << "OK " << rank << std::endl;
+      std::cout << "OK " << rank << '\n';
       #endif
     }
     else
     {
       #if 0
-      std::cout << "NOT OK" << std::endl;
+      std::cout << "NOT OK\n";
       #endif
       return false; // no conversion possible
     }

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -348,7 +348,7 @@ exprt cpp_typecheck_resolvet::convert_identifier(
       std::cout << "I: " << identifier.class_identifier
                 << " "
                 << cpp_typecheck.cpp_scopes.current_scope().
-                    this_class_identifier << std::endl;
+                    this_class_identifier << '\n';
       #endif
 
       const exprt &this_expr=
@@ -1070,9 +1070,9 @@ cpp_scopet &cpp_typecheck_resolvet::resolve_scope(
 
         // std::cout << "S: "
         //           << cpp_typecheck.cpp_scopes.current_scope().identifier
-        //           << std::endl;
+        //           << '\n';
         // cpp_typecheck.cpp_scopes.current_scope().print(std::cout);
-        // std::cout << "X: " << id_set.size() <<std::endl;
+        // std::cout << "X: " << id_set.size() << '\n';
 
         symbol_typet instance=
           disambiguate_template_classes(final_base_name, id_set, template_args);
@@ -1353,10 +1353,10 @@ symbol_typet cpp_typecheck_resolvet::disambiguate_template_classes(
       m_it++)
   {
     std::cout << "M: " << m_it->cost
-              << " " << m_it->id << std::endl;
+              << " " << m_it->id << '\n';
   }
 
-  std::cout << std::endl;
+  std::cout << '\n';
   #endif
 
   const matcht &match=*matches.begin();
@@ -1564,7 +1564,7 @@ void cpp_typecheck_resolvet::show_identifiers(
       }
     }
 
-    out << std::endl;
+    out << '\n';
   }
 }
 
@@ -1823,16 +1823,16 @@ exprt cpp_typecheck_resolvet::resolve(
       #if 0
       exprt e1=*new_identifiers.begin();
       exprt e2=*(++new_identifiers.begin());
-      cpp_typecheck.str << "e1==e2: " << (e1==e2) << std::endl;
+      cpp_typecheck.str << "e1==e2: " << (e1==e2) << '\n';
       cpp_typecheck.str << "e1.type==e2.type: " << (e1.type()==e2.type())
-                        << std::endl;
+                        << '\n';
       cpp_typecheck.str << "e1.id()==e2.id(): " << (e1.id()==e2.id())
-                        << std::endl;
+                        << '\n';
       cpp_typecheck.str << "e1.iden==e2.iden: "
                         << (e1.get(ID_identifier)==e2.get(ID_identifier))
-                        << std::endl;
-      cpp_typecheck.str << "e1.iden:: " << e1.get(ID_identifier) << std::endl;
-      cpp_typecheck.str << "e2.iden:: " << e2.get(ID_identifier) << std::endl;
+                        << '\n';
+      cpp_typecheck.str << "e1.iden:: " << e1.get(ID_identifier) << '\n';
+      cpp_typecheck.str << "e2.iden:: " << e2.get(ID_identifier) << '\n';
       #endif
     }
 
@@ -2022,8 +2022,8 @@ void cpp_typecheck_resolvet::guess_template_args(
   // TT<C>
 
   #if 0
-  std::cout << "TT: " << template_type.pretty() << std::endl;
-  std::cout << "DT: " << desired_type.pretty() << std::endl;
+  std::cout << "TT: " << template_type.pretty() << '\n';
+  std::cout << "DT: " << desired_type.pretty() << '\n';
   #endif
 
   if(template_type.id()==ID_cpp_name)
@@ -2075,7 +2075,7 @@ void cpp_typecheck_resolvet::guess_template_args(
               t.remove(ID_C_volatile);
               #if 0
               std::cout << "ASSIGN " << id.identifier << " := "
-                        << cpp_typecheck.to_string(desired_type) << std::endl;
+                        << cpp_typecheck.to_string(desired_type) << '\n';
               #endif
             }
           }
@@ -2571,12 +2571,12 @@ void cpp_typecheck_resolvet::filter_for_named_scopes(
       #if 0
       cpp_typecheck.template_map.print(std::cout);
       std::cout << "S: " << cpp_typecheck.cpp_scopes.current_scope().identifier
-                << std::endl;
+                << '\n';
       std::cout << "P: "
                 << cpp_typecheck.cpp_scopes.current_scope().get_parent()
-                << std::endl;
-      std::cout << "I: " << id.identifier << std::endl;
-      std::cout << "E: " << e.pretty() << std::endl;
+                << '\n';
+      std::cout << "I: " << id.identifier << '\n';
+      std::cout << "E: " << e.pretty() << '\n';
       #endif
 
       if(e.id()!=ID_type)

--- a/src/cpp/cpp_typecheck_template.cpp
+++ b/src/cpp/cpp_typecheck_template.cpp
@@ -163,7 +163,7 @@ void cpp_typecheckt::typecheck_class_template(
       std::cout << "*****\n";
       std::cout << *cpp_scopes.id_map[symbol_name];
       std::cout << "*****\n";
-      std::cout << "II: " << symbol_name << std::endl;
+      std::cout << "II: " << symbol_name << '\n';
       #endif
 
       // We also replace the template scope (the old one could be deleted).
@@ -413,7 +413,7 @@ void cpp_typecheckt::typecheck_class_template_member(
   }
   else if((*(id_set.begin()))->id_class!=cpp_idt::id_classt::TEMPLATE)
   {
-    // std::cerr << *(*id_set.begin()) << std::endl;
+    // std::cerr << *(*id_set.begin()) << '\n';
     error().source_location=cpp_name.source_location();
     error() << "class template `"
             << cpp_name.get_sub().front().get(ID_identifier)

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -37,7 +37,7 @@ struct indenter // NOLINT(readability/identifiers)
   cpp_tokent _tk; \
   lex.LookAhead(0, _tk); \
   std::cout << std::string(__indent, ' ') << "Text [" << _tk.line_no << "]: " \
-    << _tk.text << std::endl; \
+    << _tk.text << '\n'; \
 }
 #endif
 
@@ -1687,7 +1687,7 @@ bool Parser::rDeclaration(cpp_declarationt &declaration)
   #ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rDeclaration 0.1  token: "
-            << lex.LookAhead(0) << std::endl;
+            << lex.LookAhead(0) << '\n';
   #endif
 
   if(!optAttribute(declaration))
@@ -5193,7 +5193,7 @@ bool Parser::rClassMember(cpp_itemt &member)
   #ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rClassMember 0 " << t
-            << std::endl;
+            << '\n';
   #endif // DEBUG
 
   if(t==TOK_PUBLIC || t==TOK_PROTECTED || t==TOK_PRIVATE)
@@ -7903,7 +7903,7 @@ bool Parser::rVarNameCore(exprt &name)
     #ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rVarNameCore 1.1 "
               << lex.LookAhead(0)
-              << std::endl;
+              << '\n';
     #endif
 
     switch(lex.LookAhead(0))

--- a/src/cpp/template_map.cpp
+++ b/src/cpp/template_map.cpp
@@ -202,12 +202,12 @@ void template_mapt::print(std::ostream &out) const
   for(type_mapt::const_iterator it=type_map.begin();
       it!=type_map.end();
       it++)
-    out << it->first << " = " << it->second.pretty() << std::endl;
+    out << it->first << " = " << it->second.pretty() << '\n';
 
   for(expr_mapt::const_iterator it=expr_map.begin();
       it!=expr_map.end();
       it++)
-    out << it->first << " = " << it->second.pretty() << std::endl;
+    out << it->first << " = " << it->second.pretty() << '\n';
 }
 
 /*******************************************************************\

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -193,7 +193,7 @@ int goto_analyzer_parse_optionst::doit()
 {
   if(cmdline.isset("version"))
   {
-    std::cout << CBMC_VERSION << std::endl;
+    std::cout << CBMC_VERSION << '\n';
     return 0;
   }
 

--- a/src/goto-analyzer/unreachable_instructions.cpp
+++ b/src/goto-analyzer/unreachable_instructions.cpp
@@ -218,7 +218,7 @@ void unreachable_instructions(
   }
 
   if(json && !json_result.array.empty())
-    os << json_result << std::endl;
+    os << json_result << '\n';
 }
 
 /*******************************************************************\
@@ -325,7 +325,7 @@ static void list_functions(
   }
 
   if(json && !json_result.array.empty())
-    os << json_result << std::endl;
+    os << json_result << '\n';
 }
 
 /*******************************************************************\

--- a/src/goto-cc/armcc_cmdline.cpp
+++ b/src/goto-cc/armcc_cmdline.cpp
@@ -316,7 +316,7 @@ bool armcc_cmdlinet::parse(int argc, const char **argv)
     else
     { // unrecognized option
       std::cout << "Warning: uninterpreted armcc option '"
-                << argv[i] << "'" << std::endl;
+                << argv[i] << "'\n";
     }
   }
 

--- a/src/goto-cc/armcc_mode.cpp
+++ b/src/goto-cc/armcc_mode.cpp
@@ -152,7 +152,7 @@ int armcc_modet::doit()
         it!=config.ansi_c.defines.end();
         it++)
     {
-      std::cout << "  " << (*it) << std::endl;
+      std::cout << "  " << (*it) << '\n';
     }
 
     std::cout << "Undefines:\n";
@@ -160,7 +160,7 @@ int armcc_modet::doit()
         it!=config.ansi_c.undefines.end();
         it++)
     {
-      std::cout << "  " << (*it) << std::endl;
+      std::cout << "  " << (*it) << '\n';
     }
 
     std::cout << "Preprocessor Options:\n";
@@ -168,7 +168,7 @@ int armcc_modet::doit()
         it!=config.ansi_c.preprocessor_options.end();
         it++)
     {
-      std::cout << "  " << (*it) << std::endl;
+      std::cout << "  " << (*it) << '\n';
     }
 
     std::cout << "Include Paths:\n";
@@ -176,7 +176,7 @@ int armcc_modet::doit()
         it!=config.ansi_c.include_paths.end();
         it++)
     {
-      std::cout << "  " << (*it) << std::endl;
+      std::cout << "  " << (*it) << '\n';
     }
 
     std::cout << "Library Paths:\n";
@@ -184,13 +184,13 @@ int armcc_modet::doit()
         it!=compiler.library_paths.end();
         it++)
     {
-      std::cout << "  " << (*it) << std::endl;
+      std::cout << "  " << (*it) << '\n';
     }
 
     std::cout << "Output file (object): "
-              << compiler.output_file_object << std::endl;
+              << compiler.output_file_object << '\n';
     std::cout << "Output file (executable): "
-              << compiler.output_file_executable << std::endl;
+              << compiler.output_file_executable << '\n';
   }
 
   // Parse input program, convert to goto program, write output

--- a/src/goto-cc/as86_cmdline.cpp
+++ b/src/goto-cc/as86_cmdline.cpp
@@ -150,7 +150,7 @@ bool as86_cmdlinet::parse(int argc, const char **argv)
     {
       // unrecognized option
       std::cerr << "Warning: uninterpreted as86 option '" << argv_i
-                << "'" << std::endl;
+                << "'\n";
     }
   }
 

--- a/src/goto-cc/as_cmdline.cpp
+++ b/src/goto-cc/as_cmdline.cpp
@@ -206,7 +206,7 @@ bool as_cmdlinet::parse(int argc, const char **argv)
     {
       // unrecognized option
       std::cerr << "Warning: uninterpreted as option '" << argv_i
-                << "'" << std::endl;
+                << "'\n";
     }
   }
 

--- a/src/goto-cc/as_mode.cpp
+++ b/src/goto-cc/as_mode.cpp
@@ -313,7 +313,7 @@ int as_modet::run_as()
   std::cout << "RUN:";
   for(std::size_t i=0; i<new_argv.size(); i++)
     std::cout << " " << new_argv[i];
-  std::cout << std::endl;
+  std::cout << '\n';
   #endif
 
   return run(new_argv[0], new_argv, cmdline.stdin_file, "");

--- a/src/goto-cc/bcc_cmdline.cpp
+++ b/src/goto-cc/bcc_cmdline.cpp
@@ -162,7 +162,7 @@ bool bcc_cmdlinet::parse(int argc, const char **argv)
     {
       // unrecognized option
       std::cerr << "Warning: uninterpreted bcc option '" << argv_i
-                << "'" << std::endl;
+                << "'\n";
     }
   }
 

--- a/src/goto-cc/cw_mode.cpp
+++ b/src/goto-cc/cw_mode.cpp
@@ -141,7 +141,7 @@ int cw_modet::doit()
         it!=config.ansi_c.defines.end();
         it++)
     {
-      std::cout << "  " << (*it) << std::endl;
+      std::cout << "  " << (*it) << '\n';
     }
 
     std::cout << "Undefines:\n";
@@ -149,7 +149,7 @@ int cw_modet::doit()
         it!=config.ansi_c.undefines.end();
         it++)
     {
-      std::cout << "  " << (*it) << std::endl;
+      std::cout << "  " << (*it) << '\n';
     }
 
     std::cout << "Preprocessor Options:\n";
@@ -157,7 +157,7 @@ int cw_modet::doit()
         it!=config.ansi_c.preprocessor_options.end();
         it++)
     {
-      std::cout << "  " << (*it) << std::endl;
+      std::cout << "  " << (*it) << '\n';
     }
 
     std::cout << "Include Paths:\n";
@@ -165,7 +165,7 @@ int cw_modet::doit()
         it!=config.ansi_c.include_paths.end();
         it++)
     {
-      std::cout << "  " << (*it) << std::endl;
+      std::cout << "  " << (*it) << '\n';
     }
 
     std::cout << "Library Paths:\n";
@@ -173,13 +173,13 @@ int cw_modet::doit()
         it!=compiler.library_paths.end();
         it++)
     {
-      std::cout << "  " << (*it) << std::endl;
+      std::cout << "  " << (*it) << '\n';
     }
 
     std::cout << "Output file (object): "
-              << compiler.output_file_object << std::endl;
+              << compiler.output_file_object << '\n';
     std::cout << "Output file (executable): "
-              << compiler.output_file_executable << std::endl;
+              << compiler.output_file_executable << '\n';
   }
 
   // Parse input program, convert to goto program, write output

--- a/src/goto-cc/gcc_cmdline.cpp
+++ b/src/goto-cc/gcc_cmdline.cpp
@@ -431,7 +431,7 @@ bool gcc_cmdlinet::parse_arguments(
       {
         // unrecognized option
         std::cerr << "Warning: uninterpreted gcc option '" << argv_i
-                  << "'" << std::endl;
+                  << "'\n";
       }
     }
   }

--- a/src/goto-cc/gcc_mode.cpp
+++ b/src/goto-cc/gcc_mode.cpp
@@ -214,7 +214,7 @@ int gcc_modet::doit()
 
   if(cmdline.isset("dumpversion"))
   {
-    std::cout << "3.4.4" << std::endl;
+    std::cout << "3.4.4\n";
     return EX_OK;
   }
 
@@ -609,7 +609,7 @@ int gcc_modet::preprocess(
   std::cout << "RUN:";
   for(std::size_t i=0; i<new_argv.size(); i++)
     std::cout << " " << new_argv[i];
-  std::cout << std::endl;
+  std::cout << '\n';
   #endif
 
   return run(new_argv[0], new_argv, cmdline.stdin_file, stdout_file);
@@ -644,7 +644,7 @@ int gcc_modet::run_gcc()
   std::cout << "RUN:";
   for(std::size_t i=0; i<new_argv.size(); i++)
     std::cout << " " << new_argv[i];
-  std::cout << std::endl;
+  std::cout << '\n';
   #endif
 
   return run(new_argv[0], new_argv, cmdline.stdin_file, "");

--- a/src/goto-cc/goto_cc_main.cpp
+++ b/src/goto-cc/goto_cc_main.cpp
@@ -71,7 +71,7 @@ int main(int argc, const char **argv)
 
   if(argv==NULL || argc<1)
   {
-    std::cerr << "failed to determine base name" << std::endl;
+    std::cerr << "failed to determine base name\n";
     return 1;
   }
 

--- a/src/goto-cc/ld_cmdline.cpp
+++ b/src/goto-cc/ld_cmdline.cpp
@@ -285,7 +285,7 @@ bool ld_cmdlinet::parse(int argc, const char **argv)
         }
         else
         {
-          std::cerr << "Warning: missing argument for " << argv_i << std::endl;
+          std::cerr << "Warning: missing argument for " << argv_i << '\n';
           set(os, ""); // end of command line
         }
       }
@@ -339,7 +339,7 @@ bool ld_cmdlinet::parse(int argc, const char **argv)
         }
         else
         {
-          std::cerr << "Warning: missing argument for " << argv_i << std::endl;
+          std::cerr << "Warning: missing argument for " << argv_i << '\n';
           set(os, ""); // end of command line
         }
       }
@@ -365,7 +365,7 @@ bool ld_cmdlinet::parse(int argc, const char **argv)
     {
       // unrecognized option
       std::cerr << "Warning: uninterpreted ld option '" << argv_i
-                << "'" << std::endl;
+                << "'\n";
     }
   }
 

--- a/src/goto-cc/ms_cl_cmdline.cpp
+++ b/src/goto-cc/ms_cl_cmdline.cpp
@@ -224,7 +224,7 @@ void ms_cl_cmdlinet::process_response_file(const std::string &file)
   if(!infile)
   {
     std::cerr << "failed to open response file `"
-              << file << "'" << std::endl;
+              << file << "'\n";
     return;
   }
 
@@ -352,7 +352,7 @@ void ms_cl_cmdlinet::process_non_cl_option(
 
   // unrecognized option
   std::cout << "Warning: uninterpreted non-CL option `"
-            << s << "'" << std::endl;
+            << s << "'\n";
 }
 
 /*******************************************************************\
@@ -576,5 +576,5 @@ void ms_cl_cmdlinet::process_cl_option(const std::string &s)
 
   // unrecognized option
   std::cout << "Warning: uninterpreted CL option `"
-            << s << "'" << std::endl;
+            << s << "'\n";
 }

--- a/src/goto-cc/ms_cl_mode.cpp
+++ b/src/goto-cc/ms_cl_mode.cpp
@@ -134,7 +134,7 @@ int ms_cl_modet::doit()
         it!=config.ansi_c.defines.end();
         it++)
     {
-      std::cout << "  " << (*it) << std::endl;
+      std::cout << "  " << (*it) << '\n';
     }
 
     std::cout << "Undefines:\n";
@@ -142,7 +142,7 @@ int ms_cl_modet::doit()
         it!=config.ansi_c.undefines.end();
         it++)
     {
-      std::cout << "  " << (*it) << std::endl;
+      std::cout << "  " << (*it) << '\n';
     }
 
     std::cout << "Preprocessor Options:\n";
@@ -150,7 +150,7 @@ int ms_cl_modet::doit()
         it!=config.ansi_c.preprocessor_options.end();
         it++)
     {
-      std::cout << "  " << (*it) << std::endl;
+      std::cout << "  " << (*it) << '\n';
     }
 
     std::cout << "Include Paths:\n";
@@ -158,7 +158,7 @@ int ms_cl_modet::doit()
         it!=config.ansi_c.include_paths.end();
         it++)
     {
-      std::cout << "  " << (*it) << std::endl;
+      std::cout << "  " << (*it) << '\n';
     }
 
     std::cout << "Library Paths:\n";
@@ -166,13 +166,13 @@ int ms_cl_modet::doit()
         it!=compiler.library_paths.end();
         it++)
     {
-      std::cout << "  " << (*it) << std::endl;
+      std::cout << "  " << (*it) << '\n';
     }
 
     std::cout << "Output file (object): "
-              << compiler.output_file_object << std::endl;
+              << compiler.output_file_object << '\n';
     std::cout << "Output file (executable): "
-              << compiler.output_file_executable << std::endl;
+              << compiler.output_file_executable << '\n';
   }
 
   // Parse input program, convert to goto program, write output

--- a/src/goto-cc/xml_binaries/read_goto_object.cpp
+++ b/src/goto-cc/xml_binaries/read_goto_object.cpp
@@ -96,7 +96,7 @@ bool read_goto_object(
         {
           symbolt symbol;
           symbolconverter.convert(*sym_it, symbol);
-          // std::cout << "Adding Symbol: " << symbol.name << std::endl;
+          // std::cout << "Adding Symbol: " << symbol.name << '\n';
           if(!symbol.is_type &&
              symbol.type.id()=="code")
           {
@@ -117,7 +117,7 @@ bool read_goto_object(
             fun_it++)
         {
           std::string fname = fun_it->get_attribute("name");
-          // std::cout << "Adding function body: " << fname << std::endl;
+          // std::cout << "Adding function body: " << fname << '\n';
           goto_functionst::goto_functiont &f = functions.function_map[fname];
           gfconverter.convert(*fun_it, f);
         }

--- a/src/goto-cc/xml_binaries/xml_goto_program.cpp
+++ b/src/goto-cc/xml_binaries/xml_goto_program.cpp
@@ -32,7 +32,7 @@ void convert(const goto_programt &goto_program,
              xmlt &xml)
 {
   std::stringstream tmp;
-  // std::cout << "TNO: " << goto_program.target_numbers.size() << std::endl;
+  // std::cout << "TNO: " << goto_program.target_numbers.size() << '\n';
 
   for(const auto &inst : goto_program.instructions)
   {
@@ -58,7 +58,7 @@ void convert(const goto_programt &goto_program,
 
     if(inst.target_number!=0)
     {
-      // std::cout << "Targetlabel found!" << std::endl;
+      // std::cout << "Targetlabel found!\n";
       tmp.str("");
       tmp << inst.target_number;
       ins.set_attribute("targetlabel", tmp.str());
@@ -289,8 +289,8 @@ void convert(const xmlt &xml, goto_programt &goto_program)
     }
     else
     {
-      std::cout << "Unknown instruction type encountered (" << it->name << ")";
-      std::cout << std::endl;
+      std::cout << "Unknown instruction type encountered (" << it->name
+                << ")\n";
       return;
     }
 
@@ -316,7 +316,7 @@ void convert(const xmlt &xml, goto_programt &goto_program)
           }
           else
           {
-            std::cout << "Unknown node in labels section." << std::endl;
+            std::cout << "Unknown node in labels section.\n";
             return;
           }
         }
@@ -374,12 +374,12 @@ void convert(const xmlt &xml, goto_programt &goto_program)
             else
             {
               std::cout << "Warning: instruction not found when "
-              "resolving target links." << std::endl;
+              "resolving target links.\n";
             }
           }
           else
           {
-            std::cout << "Unknown node in targets section." << std::endl;
+            std::cout << "Unknown node in targets section.\n";
             return;
           }
         }
@@ -391,7 +391,7 @@ void convert(const xmlt &xml, goto_programt &goto_program)
   // resolve links
   goto_program.update();
 
-  // std::cout << "TNI: " << goto_program.target_numbers.size() << std::endl;
+  // std::cout << "TNI: " << goto_program.target_numbers.size() << '\n';
 }
 
 /*******************************************************************\

--- a/src/goto-cc/xml_binaries/xml_goto_program_hashing.cpp
+++ b/src/goto-cc/xml_binaries/xml_goto_program_hashing.cpp
@@ -33,7 +33,7 @@ void xml_goto_program_convertt::convert(
   xmlt &xml)
 {
   std::stringstream tmp;
-  // std::cout << "TNO: " << goto_program.target_numbers.size() << std::endl;
+  // std::cout << "TNO: " << goto_program.target_numbers.size() << '\n';
 
   for(const auto &inst : goto_program.instructions)
   {
@@ -59,7 +59,7 @@ void xml_goto_program_convertt::convert(
 
     if(inst.target_number!=0)
     {
-      // std::cout << "Targetlabel found!" << std::endl;
+      // std::cout << "Targetlabel found!\n";
       tmp.str("");
       tmp << inst.target_number;
       ins.set_attribute("targetlabel", tmp.str());
@@ -285,8 +285,7 @@ void xml_goto_program_convertt::convert(
     else
     {
       std::cout << "Unknown instruction type encountered ("
-                << element.name << ")";
-      std::cout << std::endl;
+                << element.name << ")\n";
       return;
     }
 
@@ -313,7 +312,7 @@ void xml_goto_program_convertt::convert(
           }
           else
           {
-            std::cout << "Unknown node in labels section." << std::endl;
+            std::cout << "Unknown node in labels section.\n";
             return;
           }
         }
@@ -373,12 +372,12 @@ void xml_goto_program_convertt::convert(
             else
             {
               std::cout << "Warning: instruction not found when "
-              "resolving target links." << std::endl;
+              "resolving target links.\n";
             }
           }
           else
           {
-            std::cout << "Unknown node in targets section." << std::endl;
+            std::cout << "Unknown node in targets section.\n";
             return;
           }
         }
@@ -390,7 +389,7 @@ void xml_goto_program_convertt::convert(
   // resolve links
   goto_program.update();
 
-  // std::cout << "TNI: " << goto_program.target_numbers.size() << std::endl;
+  // std::cout << "TNI: " << goto_program.target_numbers.size() << '\n';
 }
 
 /*******************************************************************\

--- a/src/goto-cc/xml_binaries/xml_irep_hashing.cpp
+++ b/src/goto-cc/xml_binaries/xml_irep_hashing.cpp
@@ -106,8 +106,7 @@ void xml_irep_convertt::convert(
     else
     {
       // Should not happen
-      std::cout << "Unknown sub found (" << it->name << "); malformed xml?";
-      std::cout << std::endl;
+      std::cout << "Unknown sub found (" << it->name << "); malformed xml?\n";
     }
   }
 }
@@ -213,7 +212,7 @@ void xml_irep_convertt::resolve_references(const irept &cur)
     if(itr==ireps_container.id_container.end())
     {
       std::cout << "Warning: can't resolve irep reference (sub "
-                << cur.get("REF") << ")" << std::endl;
+                << cur.get("REF") << ")\n";
     }
     else
     {

--- a/src/goto-diff/change_impact.cpp
+++ b/src/goto-diff/change_impact.cpp
@@ -867,7 +867,7 @@ void change_impactt::output_instruction(char prefix,
     const irep_idt &line=target->source_location.get_line();
     if(!file.empty() && !line.empty())
       std::cout << prefix << " " << id2string(file)
-                << " " << id2string(line) << std::endl;
+                << " " << id2string(line) << '\n';
   }
   else
   {

--- a/src/goto-diff/goto_diff_main.cpp
+++ b/src/goto-diff/goto_diff_main.cpp
@@ -45,9 +45,9 @@ int main(int argc, const char **argv)
   int res=parse_options.main();
 
   #ifdef IREP_HASH_STATS
-  std::cout << "IREP_HASH_CNT=" << irep_hash_cnt << std::endl;
-  std::cout << "IREP_CMP_CNT=" << irep_cmp_cnt << std::endl;
-  std::cout << "IREP_CMP_NE_CNT=" << irep_cmp_ne_cnt << std::endl;
+  std::cout << "IREP_HASH_CNT=" << irep_hash_cnt << '\n';
+  std::cout << "IREP_CMP_CNT=" << irep_cmp_cnt << '\n';
+  std::cout << "IREP_CMP_NE_CNT=" << irep_cmp_ne_cnt << '\n';
   #endif
 
   return res;

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -296,7 +296,7 @@ int goto_diff_parse_optionst::doit()
 {
   if(cmdline.isset("version"))
   {
-    std::cout << CBMC_VERSION << std::endl;
+    std::cout << CBMC_VERSION << '\n';
     return 0;
   }
 

--- a/src/goto-diff/unified_diff.cpp
+++ b/src/goto-diff/unified_diff.cpp
@@ -306,8 +306,8 @@ void unified_difft::lcss(
   }
 
   #if 0
-  std::cerr << "old_count=" << old_count << std::endl;
-  std::cerr << "new_count=" << new_count << std::endl;
+  std::cerr << "old_count=" << old_count << '\n';
+  std::cerr << "new_count=" << new_count << '\n';
   for(i=0; i<=old_count; ++i)
   {
     for(j=0; j<=new_count; ++j)
@@ -317,7 +317,7 @@ void unified_difft::lcss(
         std::cerr << " ";
       std::cerr << lcss_matrix[i][j];
     }
-    std::cerr << std::endl;
+    std::cerr << '\n';
   }
   #endif
 

--- a/src/goto-instrument/accelerate/accelerate.cpp
+++ b/src/goto-instrument/accelerate/accelerate.cpp
@@ -95,7 +95,7 @@ int acceleratet::accelerate_loop(goto_programt::targett &loop_header)
   {
     // For now, only accelerate innermost loops.
 #ifdef DEBUG
-    std::cout << "Not accelerating an outer loop" << std::endl;
+    std::cout << "Not accelerating an outer loop\n";
 #endif
     return 0;
   }
@@ -130,8 +130,7 @@ int acceleratet::accelerate_loop(goto_programt::targett &loop_header)
     {
       // We have some underapproximated variables -- just punt for now.
 #ifdef DEBUG
-      std::cout << "Not inserting accelerator because of underapproximation"
-                << std::endl;
+      std::cout << "Not inserting accelerator because of underapproximation\n";
 #endif
 
       continue;
@@ -141,12 +140,12 @@ int acceleratet::accelerate_loop(goto_programt::targett &loop_header)
     num_accelerated++;
 
 #ifdef DEBUG
-    std::cout << "Accelerated path:" << std::endl;
+    std::cout << "Accelerated path:\n";
     output_path(accelerator.path, program, ns, std::cout);
 
     std::cout << "Accelerator has "
               << accelerator.pure_accelerator.instructions.size()
-              << " instructions" << std::endl;
+              << " instructions\n";
 #endif
   }
 
@@ -159,8 +158,8 @@ int acceleratet::accelerate_loop(goto_programt::targett &loop_header)
   loop.insert(new_inst);
 
 
-  std::cout << "Overflow loc is " << overflow_loc->location_number << std::endl;
-  std::cout << "Back jump is " << back_jump->location_number << std::endl;
+  std::cout << "Overflow loc is " << overflow_loc->location_number << '\n';
+  std::cout << "Back jump is " << back_jump->location_number << '\n';
 
   for(std::list<path_acceleratort>::iterator it=accelerators.begin();
       it!=accelerators.end();
@@ -291,7 +290,7 @@ void acceleratet::restrict_traces()
     {
 #ifdef DEBUG
       namespacet ns(symbol_table);
-      std::cout << "Restricting path:" << std::endl;
+      std::cout << "Restricting path:\n";
       output_path(it->subsumed, program, ns, std::cout);
 #endif
 
@@ -307,13 +306,13 @@ void acceleratet::restrict_traces()
 
 #ifdef DEBUG
       namespacet ns(symbol_table);
-      std::cout << "Restricting path:" << std::endl;
+      std::cout << "Restricting path:\n";
       output_path(double_accelerator, program, ns, std::cout);
 #endif
     automaton.add_path(double_accelerator);
   }
 
-  std::cout << "Building trace automaton..." << std::endl;
+  std::cout << "Building trace automaton...\n";
 
   automaton.build();
   insert_automaton(automaton);
@@ -342,7 +341,7 @@ void acceleratet::set_dirty_vars(path_acceleratort &accelerator)
 
 #ifdef DEBUG
     std::cout << "Setting dirty flag " << expr2c(dirty_var, ns)
-      << " for " << expr2c(*it, ns) << std::endl;
+      << " for " << expr2c(*it, ns) << '\n';
 #endif
 
     accelerator.pure_accelerator.add_instruction(ASSIGN)->code =
@@ -434,7 +433,7 @@ bool acceleratet::is_underapproximate(path_acceleratort &accelerator)
     }
 
 #ifdef DEBUG
-    std::cout << "Underapproximate variable: " << expr2c(*it, ns) << std::endl;
+    std::cout << "Underapproximate variable: " << expr2c(*it, ns) << '\n';
 #endif
     return true;
   }
@@ -497,7 +496,7 @@ void acceleratet::insert_automaton(trace_automatont &automaton)
     << "Inserting trace automaton with "
     << automaton.num_states() << " states, "
     << accept_states.size() << " accepting states and "
-    << transitions.size() << " transitions" << std::endl;
+    << transitions.size() << " transitions\n";
 
   // Declare the variables we'll use to encode the state machine.
   goto_programt::targett t=program.instructions.begin();
@@ -633,13 +632,13 @@ int acceleratet::accelerate_loops()
 
   if(num_accelerated > 0)
   {
-    std::cout << "Engaging crush mode..." << std::endl;
+    std::cout << "Engaging crush mode...\n";
 
     restrict_traces();
     // add_dirty_checks();
     program.update();
 
-    std::cout << "Crush mode engaged." << std::endl;
+    std::cout << "Crush mode engaged.\n";
   }
 
   return num_accelerated;
@@ -653,7 +652,7 @@ void accelerate_functions(
 {
   Forall_goto_functions(it, functions)
   {
-    std::cout << "Accelerating function " << it->first << std::endl;
+    std::cout << "Accelerating function " << it->first << '\n';
     acceleratet accelerate(it->second.body, functions, symbol_table, use_z3);
 
     int num_accelerated=accelerate.accelerate_loops();
@@ -661,7 +660,7 @@ void accelerate_functions(
     if(num_accelerated > 0)
     {
       std::cout << "Added " << num_accelerated
-                << " accelerator(s)" << std::endl;
+                << " accelerator(s)\n";
     }
   }
 }

--- a/src/goto-instrument/accelerate/acceleration_utils.cpp
+++ b/src/goto-instrument/accelerate/acceleration_utils.cpp
@@ -158,7 +158,7 @@ bool acceleration_utilst::check_inductive(
   }
 
 #ifdef DEBUG
-  std::cout << "Checking following program for inductiveness:" << std::endl;
+  std::cout << "Checking following program for inductiveness:\n";
   program.output(ns, "", std::cout);
 #endif
 
@@ -168,7 +168,7 @@ bool acceleration_utilst::check_inductive(
     {
       // We found a counterexample to inductiveness... :-(
   #ifdef DEBUG
-      std::cout << "Not inductive!" << std::endl;
+      std::cout << "Not inductive!\n";
   #endif
     return false;
     }
@@ -179,12 +179,12 @@ bool acceleration_utilst::check_inductive(
   }
   catch(std::string s)
   {
-    std::cout << "Error in inductiveness SAT check: " << s << std::endl;
+    std::cout << "Error in inductiveness SAT check: " << s << '\n';
     return false;
   }
   catch (const  char *s)
   {
-    std::cout << "Error in inductiveness SAT check: " << s << std::endl;
+    std::cout << "Error in inductiveness SAT check: " << s << '\n';
     return false;
   }
 }
@@ -439,7 +439,7 @@ bool acceleration_utilst::do_assumptions(
   simplify(guard, ns);
 
 #ifdef DEBUG
-  std::cout << "Checking following program for monotonicity:" << std::endl;
+  std::cout << "Checking following program for monotonicity:\n";
   program.output(ns, "", std::cout);
 #endif
 
@@ -448,7 +448,7 @@ bool acceleration_utilst::do_assumptions(
     if(program.check_sat())
     {
   #ifdef DEBUG
-      std::cout << "Path is not monotone" << std::endl;
+      std::cout << "Path is not monotone\n";
   #endif
 
       return false;
@@ -456,17 +456,17 @@ bool acceleration_utilst::do_assumptions(
   }
   catch(std::string s)
   {
-    std::cout << "Error in monotonicity SAT check: " << s << std::endl;
+    std::cout << "Error in monotonicity SAT check: " << s << '\n';
      return false;
   }
   catch(const char *s)
   {
-    std::cout << "Error in monotonicity SAT check: " << s << std::endl;
+    std::cout << "Error in monotonicity SAT check: " << s << '\n';
      return false;
   }
 
 #ifdef DEBUG
-  std::cout << "Path is monotone" << std::endl;
+  std::cout << "Path is monotone\n";
 #endif
 
   return true;
@@ -489,7 +489,7 @@ void acceleration_utilst::ensure_no_overflows(scratch_programt &program)
 
 #ifdef DEBUG
   time_t now=time(0);
-  std::cout << "Adding overflow checks at " << now << "..." << std::endl;
+  std::cout << "Adding overflow checks at " << now << "...\n";
 #endif
 
   instrumenter.add_overflow_checks();
@@ -502,7 +502,7 @@ void acceleration_utilst::ensure_no_overflows(scratch_programt &program)
 
 #ifdef DEBUG
   now=time(0);
-  std::cout << "Done at " << now << "." << std::endl;
+  std::cout << "Done at " << now << ".\n";
 #endif
 }
 
@@ -557,7 +557,7 @@ bool acceleration_utilst::do_arrays(
   scratch_programt &program)
 {
 #ifdef DEBUG
-  std::cout << "Doing arrays..." << std::endl;
+  std::cout << "Doing arrays...\n";
 #endif
 
   expr_sett arrays_written;
@@ -567,7 +567,7 @@ bool acceleration_utilst::do_arrays(
 
 #ifdef DEBUG
   std::cout << "Found " << array_assignments.size()
-            << " array assignments" << std::endl;
+            << " array assignments\n";
 #endif
 
   if(array_assignments.size()==0)
@@ -585,7 +585,7 @@ bool acceleration_utilst::do_arrays(
     // We weren't able to model some array assignment.  That means we need to
     // bail out altogether :-(
 #ifdef DEBUG
-    std::cout << "Couldn't model an array assignment :-(" << std::endl;
+    std::cout << "Couldn't model an array assignment :-(\n";
 #endif
     return false;
   }
@@ -661,8 +661,7 @@ bool acceleration_utilst::do_arrays(
            (index.coeff(loop_counter)!=1 && index.coeff(loop_counter)!=-1))
         {
 #ifdef DEBUG
-          std::cout << expr2c(index.to_expr(), ns) << " is nonlinear"
-                    << std::endl;
+          std::cout << expr2c(index.to_expr(), ns) << " is nonlinear\n";
 #endif
           nonlinear_index=true;
         }
@@ -814,7 +813,7 @@ bool acceleration_utilst::array_assignments2polys(
       // Couldn't convert the index -- bail out.
 #ifdef DEBUG
       std::cout << "Couldn't convert index: "
-                << expr2c(index_expr.index(), ns) << std::endl;
+                << expr2c(index_expr.index(), ns) << '\n';
 #endif
       return false;
     }
@@ -822,7 +821,7 @@ bool acceleration_utilst::array_assignments2polys(
 #ifdef DEBUG
     std::cout << "Converted index to: "
               << expr2c(poly_assignment.index.to_expr(), ns)
-              << std::endl;
+              << '\n';
 #endif
 
     if(it->second.id()==ID_nondet)
@@ -834,7 +833,7 @@ bool acceleration_utilst::array_assignments2polys(
       // Couldn't conver the RHS -- bail out.
 #ifdef DEBUG
       std::cout << "Couldn't convert RHS: " << expr2c(it->second, ns)
-                << std::endl;
+                << '\n';
 #endif
       return false;
     }
@@ -843,7 +842,7 @@ bool acceleration_utilst::array_assignments2polys(
 #ifdef DEBUG
       std::cout << "Converted RHS to: "
                 << expr2c(poly_assignment.value.to_expr(), ns)
-                << std::endl;
+                << '\n';
 #endif
 
       array_polynomials.push_back(poly_assignment);
@@ -868,7 +867,7 @@ bool acceleration_utilst::expr2poly(
   }
 
 #ifdef DEBUG
-  std::cout << "expr2poly(" << expr2c(subbed_expr, ns) << ")" << std::endl;
+  std::cout << "expr2poly(" << expr2c(subbed_expr, ns) << ")\n";
 #endif
 
   try
@@ -941,7 +940,7 @@ bool acceleration_utilst::do_nonrecursive(
       {
         // Not handling pointer dereferences yet...
 #ifdef DEBUG
-        std::cout << "Bailing out on write-through-pointer" << std::endl;
+        std::cout << "Bailing out on write-through-pointer\n";
 #endif
         return false;
       }
@@ -957,7 +956,7 @@ bool acceleration_utilst::do_nonrecursive(
           // out now.
 #ifdef DEBUG
           std::cout << "Bailing out on array written to twice in loop: " <<
-            expr2c(lhs.op0(), ns) << std::endl;
+            expr2c(lhs.op0(), ns) << '\n';
 #endif
           return false;
         }
@@ -980,8 +979,7 @@ bool acceleration_utilst::do_nonrecursive(
     if(arrays_read.find(*it)!=arrays_read.end())
     {
 #ifdef DEBUG
-      std::cout << "Bailing out on array read and written on same path"
-                << std::endl;
+      std::cout << "Bailing out on array read and written on same path\n";
 #endif
       return false;
     }
@@ -998,7 +996,7 @@ bool acceleration_utilst::do_nonrecursive(
 
 #ifdef DEBUG
       std::cout << "Fitted nonrecursive: " << expr2c(*it, ns) << "=" <<
-        expr2c(val, ns) << std::endl;
+        expr2c(val, ns) << '\n';
 #endif
     }
   }
@@ -1014,7 +1012,7 @@ bool acceleration_utilst::do_nonrecursive(
     {
 #ifdef DEBUG
       std::cout << "Failed to assign a nonrecursive array: " <<
-        expr2c(lhs, ns) << "=" << expr2c(rhs, ns) << std::endl;
+        expr2c(lhs, ns) << "=" << expr2c(rhs, ns) << '\n';
 #endif
       return false;
     }
@@ -1031,14 +1029,14 @@ bool acceleration_utilst::assign_array(
 {
 #ifdef DEBUG
   std::cout << "Modelling array assignment " << expr2c(lhs, ns) << "=" <<
-    expr2c(rhs, ns) << std::endl;
+    expr2c(rhs, ns) << '\n';
 #endif
 
   if(lhs.id()==ID_dereference)
   {
     // Don't handle writes through pointers for now...
 #ifdef DEBUG
-    std::cout << "Bailing out on write-through-pointer" << std::endl;
+    std::cout << "Bailing out on write-through-pointer\n";
 #endif
     return false;
   }
@@ -1088,7 +1086,7 @@ bool acceleration_utilst::assign_array(
   // Now let's ensure that the array did not change at the indices we
   // didn't touch.
 #ifdef DEBUG
-  std::cout << "Trying to polynomialize " << expr2c(idx, ns) << std::endl;
+  std::cout << "Trying to polynomialize " << expr2c(idx, ns) << '\n';
 #endif
 
   polynomialt poly;
@@ -1108,7 +1106,7 @@ bool acceleration_utilst::assign_array(
   {
     // idx is probably nonlinear... bail out.
 #ifdef DEBUG
-    std::cout << "Failed to polynomialize" << std::endl;
+    std::cout << "Failed to polynomialize\n";
 #endif
     return false;
   }
@@ -1123,7 +1121,7 @@ bool acceleration_utilst::assign_array(
     // alternation, and that's too expensive.  Bail out.
 #ifdef DEBUG
     std::cout << "Bailing out on nonlinear index: "
-              << expr2c(idx, ns) << std::endl;
+              << expr2c(idx, ns) << '\n';
 #endif
     return false;
   }
@@ -1153,7 +1151,7 @@ bool acceleration_utilst::assign_array(
     // happen to much so just bail out.
 #ifdef DEBUG
     std::cout << "Bailing out on write to constant array index: " <<
-      expr2c(idx, ns) << std::endl;
+      expr2c(idx, ns) << '\n';
 #endif
     return false;
   }

--- a/src/goto-instrument/accelerate/all_paths_enumerator.cpp
+++ b/src/goto-instrument/accelerate/all_paths_enumerator.cpp
@@ -36,7 +36,7 @@ bool all_paths_enumeratort::next(patht &path)
   do
   {
 #ifdef DEBUG
-    std::cout << "Enumerating next path..." << std::endl;
+    std::cout << "Enumerating next path...\n";
 #endif
 
     int decision=backtrack(last_path);
@@ -86,7 +86,7 @@ int all_paths_enumeratort::backtrack(patht &path)
     // We can take the next branch here...
 
 #ifdef DEBUG
-    std::cout << "Backtracked to a path of size " << path.size() << std::endl;
+    std::cout << "Backtracked to a path of size " << path.size() << '\n';
 #endif
 
     return ret+1;

--- a/src/goto-instrument/accelerate/cone_of_influence.cpp
+++ b/src/goto-instrument/accelerate/cone_of_influence.cpp
@@ -44,17 +44,17 @@ void cone_of_influencet::cone_of_influence(
     cone_map[rit->location_number]=next;
 
 #ifdef DEBUG
-    std::cout << "Previous cone: " << std::endl;
+    std::cout << "Previous cone: \n";
 
     for(const auto &expr : curr)
       std::cout << expr2c(expr, ns) << " ";
 
-    std::cout << std::endl << "Current cone: " << std::endl;
+    std::cout << "\nCurrent cone: \n";
 
     for(const auto &expr : next)
       std::cout << expr2c(expr, ns) << " ";
 
-    std::cout << std::endl;
+    std::cout << '\n';
 #endif
   }
 

--- a/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
+++ b/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
@@ -52,7 +52,7 @@ bool disjunctive_polynomial_accelerationt::accelerate(
   accelerator.clear();
 
 #ifdef DEBUG
-  std::cout << "Polynomial accelerating program:" << std::endl;
+  std::cout << "Polynomial accelerating program:\n";
 
   for(goto_programt::instructionst::iterator
       it=goto_program.instructions.begin();
@@ -65,13 +65,13 @@ bool disjunctive_polynomial_accelerationt::accelerate(
     }
   }
 
-  std::cout << "Modified:" << std::endl;
+  std::cout << "Modified:\n";
 
   for(expr_sett::iterator it=modified.begin();
       it!=modified.end();
       ++it)
   {
-    std::cout << expr2c(*it, ns) << std::endl;
+    std::cout << expr2c(*it, ns) << '\n';
   }
 #endif
 
@@ -121,7 +121,7 @@ bool disjunctive_polynomial_accelerationt::accelerate(
       {
 #ifdef DEBUG
         std::cout << "Fitted a polynomial for " << expr2c(target, ns)
-                  << std::endl;
+                  << '\n';
 #endif
         polynomials[target]=poly;
         accelerator.changed_vars.insert(target);
@@ -158,7 +158,7 @@ bool disjunctive_polynomial_accelerationt::accelerate(
       ++it)
   {
 #ifdef DEBUG
-    std::cout << "Trying to accelerate " << expr2c(*it, ns) << std::endl;
+    std::cout << "Trying to accelerate " << expr2c(*it, ns) << '\n';
 #endif
 
     if(it->type().id()==ID_bool)
@@ -166,7 +166,7 @@ bool disjunctive_polynomial_accelerationt::accelerate(
       // Hack: don't try to accelerate booleans.
       accelerator.dirty_vars.insert(*it);
 #ifdef DEBUG
-      std::cout << "Ignoring boolean" << std::endl;
+      std::cout << "Ignoring boolean\n";
 #endif
       continue;
     }
@@ -175,7 +175,7 @@ bool disjunctive_polynomial_accelerationt::accelerate(
        it->id()==ID_dereference)
     {
 #ifdef DEBUG
-      std::cout << "Ignoring array reference" << std::endl;
+      std::cout << "Ignoring array reference\n";
 #endif
       continue;
     }
@@ -184,7 +184,7 @@ bool disjunctive_polynomial_accelerationt::accelerate(
     {
       // We've accelerated variable this already.
 #ifdef DEBUG
-      std::cout << "We've accelerated it already" << std::endl;
+      std::cout << "We've accelerated it already\n";
 #endif
       continue;
     }
@@ -195,7 +195,7 @@ bool disjunctive_polynomial_accelerationt::accelerate(
     if(depends_on_array(*it, array_rhs))
     {
 #ifdef DEBUG
-      std::cout << "Ignoring because it depends on an array" << std::endl;
+      std::cout << "Ignoring because it depends on an array\n";
 #endif
       continue;
     }
@@ -218,7 +218,7 @@ bool disjunctive_polynomial_accelerationt::accelerate(
     }
 
 #ifdef DEBUG
-    std::cout << "Failed to accelerate " << expr2c(*it, ns) << std::endl;
+    std::cout << "Failed to accelerate " << expr2c(*it, ns) << '\n';
 #endif
 
     // We weren't able to accelerate this target...
@@ -247,7 +247,7 @@ bool disjunctive_polynomial_accelerationt::accelerate(
   catch(std::string s)
   {
     // Couldn't do WP.
-    std::cout << "Assumptions error: " << s << std::endl;
+    std::cout << "Assumptions error: " << s << '\n';
     return false;
   }
 
@@ -377,7 +377,7 @@ bool disjunctive_polynomial_accelerationt::find_path(patht &path)
     if(program.check_sat())
     {
 #ifdef DEBUG
-      std::cout << "Found a path" << std::endl;
+      std::cout << "Found a path\n";
 #endif
       build_path(program, path);
       record_path(program);
@@ -387,11 +387,11 @@ bool disjunctive_polynomial_accelerationt::find_path(patht &path)
   }
   catch(std::string s)
   {
-    std::cout << "Error in fitting polynomial SAT check: " << s << std::endl;
+    std::cout << "Error in fitting polynomial SAT check: " << s << '\n';
   }
   catch(const char *s)
   {
-    std::cout << "Error in fitting polynomial SAT check: " << s << std::endl;
+    std::cout << "Error in fitting polynomial SAT check: " << s << '\n';
   }
 
   return false;
@@ -413,13 +413,13 @@ bool disjunctive_polynomial_accelerationt::fit_polynomial(
 
 #ifdef DEBUG
   std::cout << "Fitting a polynomial for " << expr2c(var, ns)
-            << ", which depends on:" << std::endl;
+            << ", which depends on:\n";
 
   for(expr_sett::iterator it=influence.begin();
       it!=influence.end();
       ++it)
   {
-    std::cout << expr2c(*it, ns) << std::endl;
+    std::cout << expr2c(*it, ns) << '\n';
   }
 #endif
 
@@ -623,7 +623,7 @@ bool disjunctive_polynomial_accelerationt::fit_polynomial(
     if(program.check_sat())
     {
 #ifdef DEBUG
-      std::cout << "Found a polynomial" << std::endl;
+      std::cout << "Found a polynomial\n";
 #endif
 
       utils.extract_polynomial(program, coefficients, polynomial);
@@ -635,11 +635,11 @@ bool disjunctive_polynomial_accelerationt::fit_polynomial(
   }
   catch(std::string s)
   {
-    std::cout << "Error in fitting polynomial SAT check: " << s << std::endl;
+    std::cout << "Error in fitting polynomial SAT check: " << s << '\n';
   }
   catch(const char *s)
   {
-    std::cout << "Error in fitting polynomial SAT check: " << s << std::endl;
+    std::cout << "Error in fitting polynomial SAT check: " << s << '\n';
   }
 
   return false;

--- a/src/goto-instrument/accelerate/enumerating_loop_acceleration.cpp
+++ b/src/goto-instrument/accelerate/enumerating_loop_acceleration.cpp
@@ -22,7 +22,7 @@ bool enumerating_loop_accelerationt::accelerate(
   while(path_enumerator->next(path) && enumerated++!=path_limit)
   {
 #ifdef DEBUG
-    std::cout << "Found a path..." << std::endl;
+    std::cout << "Found a path...\n";
     namespacet ns(symbol_table);
 
     for(patht::iterator it = path.begin();
@@ -37,7 +37,7 @@ bool enumerating_loop_accelerationt::accelerate(
     {
       // We accelerated this path successfully -- return it.
 #ifdef DEBUG
-      std::cout << "Accelerated it" << std::endl;
+      std::cout << "Accelerated it\n";
 #endif
 
       accelerator.path.swap(path);
@@ -49,7 +49,7 @@ bool enumerating_loop_accelerationt::accelerate(
 
   // No more paths, or we hit the enumeration limit.
 #ifdef DEBUG
-  std::cout << "No more paths to accelerate!" << std::endl;
+  std::cout << "No more paths to accelerate!\n";
 #endif
 
   return false;

--- a/src/goto-instrument/accelerate/polynomial_accelerator.cpp
+++ b/src/goto-instrument/accelerate/polynomial_accelerator.cpp
@@ -61,7 +61,7 @@ bool polynomial_acceleratort::accelerate(
   utils.find_modified(body, targets);
 
 #ifdef DEBUG
-  std::cout << "Polynomial accelerating program:" << std::endl;
+  std::cout << "Polynomial accelerating program:\n";
 
   for(goto_programt::instructionst::iterator it=body.begin();
       it!=body.end();
@@ -70,13 +70,13 @@ bool polynomial_acceleratort::accelerate(
     program.output_instruction(ns, "scratch", std::cout, it);
   }
 
-  std::cout << "Modified:" << std::endl;
+  std::cout << "Modified:\n";
 
   for(expr_sett::iterator it=targets.begin();
       it!=targets.end();
       ++it)
   {
-    std::cout << expr2c(*it, ns) << std::endl;
+    std::cout << expr2c(*it, ns) << '\n';
   }
 #endif
 
@@ -118,7 +118,7 @@ bool polynomial_acceleratort::accelerate(
     {
 #ifdef DEBUG
       std::cout << "Found nonrecursive expression: "
-                << expr2c(target, ns) << std::endl;
+                << expr2c(target, ns) << '\n';
 #endif
 
       nonrecursive.insert(target);
@@ -147,7 +147,7 @@ bool polynomial_acceleratort::accelerate(
     {
 #ifdef DEBUG
       std::cout << "Failed to fit a polynomial for "
-                << expr2c(target, ns) << std::endl;
+                << expr2c(target, ns) << '\n';
 #endif
       accelerator.dirty_vars.insert(*it);
     }
@@ -180,7 +180,7 @@ bool polynomial_acceleratort::accelerate(
   catch (std::string s)
   {
     // Couldn't do WP.
-    std::cout << "Assumptions error: " << s << std::endl;
+    std::cout << "Assumptions error: " << s << '\n';
     return false;
   }
 
@@ -256,7 +256,7 @@ bool polynomial_acceleratort::accelerate(
     // We couldn't model some of the array assignments with polynomials...
     // Unfortunately that means we just have to bail out.
 #ifdef DEBUG
-    std::cout << "Failed to accelerate a nonrecursive expression" << std::endl;
+    std::cout << "Failed to accelerate a nonrecursive expression\n";
 #endif
     return false;
   }
@@ -291,13 +291,13 @@ bool polynomial_acceleratort::fit_polynomial_sliced(
 
 #ifdef DEBUG
   std::cout << "Fitting a polynomial for " << expr2c(var, ns)
-            << ", which depends on:" << std::endl;
+            << ", which depends on:\n";
 
   for(expr_sett::iterator it=influence.begin();
       it!=influence.end();
       ++it)
   {
-    std::cout << expr2c(*it, ns) << std::endl;
+    std::cout << expr2c(*it, ns) << '\n';
   }
 #endif
 
@@ -374,7 +374,7 @@ bool polynomial_acceleratort::fit_polynomial_sliced(
 
 #ifdef DEBUG
   std::cout << "Fitting polynomial over " << values.size()
-            << " variables" << std::endl;
+            << " variables\n";
 #endif
 
   for(int n=0; n<=2; n++)
@@ -403,7 +403,7 @@ bool polynomial_acceleratort::fit_polynomial_sliced(
   assert_for_values(program, values, coefficients, 2, body, var, overflow);
 
 #ifdef DEBUG
-  std::cout << "Fitting polynomial with program:" << std::endl;
+  std::cout << "Fitting polynomial with program:\n";
   program.output(ns, "", std::cout);
 #endif
 
@@ -424,11 +424,11 @@ bool polynomial_acceleratort::fit_polynomial_sliced(
   }
   catch(std::string s)
   {
-    std::cout << "Error in fitting polynomial SAT check: " << s << std::endl;
+    std::cout << "Error in fitting polynomial SAT check: " << s << '\n';
   }
   catch(const char *s)
   {
-    std::cout << "Error in fitting polynomial SAT check: " << s << std::endl;
+    std::cout << "Error in fitting polynomial SAT check: " << s << '\n';
   }
 
   return false;
@@ -465,7 +465,7 @@ bool polynomial_acceleratort::fit_const(
     {
 #ifdef DEBUG
       std::cout << "Fitting constant, eval'd to: "
-                << expr2c(program.eval(target), ns) << std::endl;
+                << expr2c(program.eval(target), ns) << '\n';
 #endif
       constant_exprt val=to_constant_expr(program.eval(target));
       mp_integer mp=binary2integer(val.get_value().c_str(), true);
@@ -484,11 +484,11 @@ bool polynomial_acceleratort::fit_const(
   }
   catch(std::string s)
   {
-    std::cout << "Error in fitting polynomial SAT check: " << s << std::endl;
+    std::cout << "Error in fitting polynomial SAT check: " << s << '\n';
   }
   catch(const char *s)
   {
-    std::cout << "Error in fitting polynomial SAT check: " << s << std::endl;
+    std::cout << "Error in fitting polynomial SAT check: " << s << '\n';
   }
 
   return false;
@@ -514,7 +514,7 @@ void polynomial_acceleratort::assert_for_values(
     if(this_type.id()==ID_pointer)
     {
 #ifdef DEBUG
-      std::cout << "Overriding pointer type" << std::endl;
+      std::cout << "Overriding pointer type\n";
 #endif
       this_type=unsignedbv_typet(config.ansi_c.pointer_width);
     }
@@ -696,7 +696,7 @@ bool polynomial_acceleratort::check_inductive(
   }
 
 #ifdef DEBUG
-  std::cout << "Checking following program for inductiveness:" << std::endl;
+  std::cout << "Checking following program for inductiveness:\n";
   program.output(ns, "", std::cout);
 #endif
 
@@ -706,7 +706,7 @@ bool polynomial_acceleratort::check_inductive(
     {
       // We found a counterexample to inductiveness... :-(
   #ifdef DEBUG
-      std::cout << "Not inductive!" << std::endl;
+      std::cout << "Not inductive!\n";
   #endif
     return false;
     }
@@ -717,12 +717,12 @@ bool polynomial_acceleratort::check_inductive(
   }
   catch(std::string s)
   {
-    std::cout << "Error in inductiveness SAT check: " << s << std::endl;
+    std::cout << "Error in inductiveness SAT check: " << s << '\n';
     return false;
   }
   catch(const  char *s)
   {
-    std::cout << "Error in inductiveness SAT check: " << s << std::endl;
+    std::cout << "Error in inductiveness SAT check: " << s << '\n';
     return false;
   }
 }

--- a/src/goto-instrument/accelerate/sat_path_enumerator.cpp
+++ b/src/goto-instrument/accelerate/sat_path_enumerator.cpp
@@ -83,7 +83,7 @@ bool sat_path_enumeratort::next(patht &path)
     if(program.check_sat())
     {
 #ifdef DEBUG
-      std::cout << "Found a path" << std::endl;
+      std::cout << "Found a path\n";
 #endif
       build_path(program, path);
       record_path(program);
@@ -93,11 +93,11 @@ bool sat_path_enumeratort::next(patht &path)
   }
   catch(std::string s)
   {
-    std::cout << "Error in fitting polynomial SAT check: " << s << std::endl;
+    std::cout << "Error in fitting polynomial SAT check: " << s << '\n';
   }
   catch(const char *s)
   {
-    std::cout << "Error in fitting polynomial SAT check: " << s << std::endl;
+    std::cout << "Error in fitting polynomial SAT check: " << s << '\n';
   }
 
   return false;

--- a/src/goto-instrument/accelerate/trace_automaton.cpp
+++ b/src/goto-instrument/accelerate/trace_automaton.cpp
@@ -15,7 +15,7 @@ Author: Matt Lewis
 void trace_automatont::build()
 {
 #ifdef DEBUG
-  std::cout << "NTA:" << std::endl;
+  std::cout << "NTA:\n";
   nta.output(std::cout);
 #endif
 
@@ -23,7 +23,7 @@ void trace_automatont::build()
   // minimise();
 
 #ifdef DEBUG
-  std::cout << "DTA:" << std::endl;
+  std::cout << "DTA:\n";
   dta.output(std::cout);
 #endif
 }
@@ -90,9 +90,9 @@ void trace_automatont::add_path(patht &path)
   }
 
 #ifdef DEBUG
-  std::cout << std::endl;
+  std::cout << '\n';
 
-  std::cout << "Final state: " << state << std::endl;
+  std::cout << "Final state: " << state << '\n';
 #endif
 
   nta.set_accepting(state);
@@ -163,7 +163,7 @@ void trace_automatont::determinise()
 #ifdef DEBUG
   std::cout << "Produced DTA with " << dta.num_states << " states and "
             << dta.accept_states.size() << " accept states and "
-            << dta.count_transitions() << " transitions" << std::endl;
+            << dta.count_transitions() << " transitions\n";
 #endif
 }
 
@@ -242,7 +242,7 @@ statet trace_automatont::add_dstate(state_sett &s)
 #ifdef DEBUG
       std::cout << "NTA state " << *it
                 << " is accepting, so accepting DTA state "
-                << state_num << std::endl;
+                << state_num << '\n';
 #endif
 
       dta.set_accepting(state_num);
@@ -385,7 +385,7 @@ void automatont::reverse(goto_programt::targett epsilon)
   std::cout << "Reversing automaton, old init=" << init_state
             << ", new init=" << new_init << ", old accept="
             << *(accept_states.begin()) << '/' << accept_states.size()
-            << " new accept=" << init_state << std::endl;
+            << " new accept=" << init_state << '\n';
 
   accept_states.clear();
   set_accepting(init_state);
@@ -463,14 +463,14 @@ void trace_automatont::minimise()
 
 void automatont::output(std::ostream &str)
 {
-  str << "Init: " << init_state << std::endl;
+  str << "Init: " << init_state << '\n';
 
   str << "Accept states: ";
 
   for(const auto &state : accept_states)
     str << state << ' ';
 
-  str << std::endl;
+  str << '\n';
 
   for(unsigned int i=0; i < transitions.size(); ++i)
   {
@@ -479,7 +479,7 @@ void automatont::output(std::ostream &str)
       goto_programt::targett l=trans.first;
       statet j=trans.second;
 
-      str << i << " -- " << l->location_number << " --> " << j << std::endl;
+      str << i << " -- " << l->location_number << " --> " << j << '\n';
     }
   }
 }

--- a/src/goto-instrument/accelerate/util.cpp
+++ b/src/goto-instrument/accelerate/util.cpp
@@ -115,6 +115,6 @@ typet join_types(const typet &t1, const typet &t2)
 
   std::cerr << "Tried to join types: "
             << t1.pretty() << " and " << t2.pretty()
-            << std::endl;
+            << '\n';
   assert(!"Couldn't join types");
 }

--- a/src/goto-instrument/alignment_checks.cpp
+++ b/src/goto-instrument/alignment_checks.cpp
@@ -78,16 +78,14 @@ void print_struct_alignment_problems(
               first_time_seen_in_struct=false;
               first_time_seen_from=false;
 
-              out << std::endl
-                  << "WARNING: "
+              out << "\nWARNING: "
                   << "declaration of structure "
                   << str.find_type(ID_tag).pretty()
-                  << " at " << it->second.location << std::endl;
+                  << " at " << it->second.location << '\n';
             }
 
             out << "members " << it_mem->get_pretty_name() << " and "
-                << it_next->get_pretty_name() << " might interfere"
-                << std::endl;
+                << it_next->get_pretty_name() << " might interfere\n";
           }
         }
       }
@@ -103,10 +101,10 @@ void print_struct_alignment_problems(
 
       if(2*integer2long(size)<=config.ansi_c.memory_operand_size)
       {
-        out << std::endl << "WARNING: "
+        out << "\nWARNING: "
             << "declaration of an array at "
-            << it->second.location << std::endl
-            << "might be concurrently accessed" << std::endl;
+            << it->second.location <<
+            << "\nmight be concurrently accessed\n";
       }
       #endif
     }

--- a/src/goto-instrument/call_sequences.cpp
+++ b/src/goto-instrument/call_sequences.cpp
@@ -34,7 +34,7 @@ void show_call_sequences(
   const goto_programt &goto_program,
   const goto_programt::const_targett start)
 {
-  std::cout << "# From " << function << std::endl;
+  std::cout << "# From " << function << '\n';
 
   std::stack<goto_programt::const_targett> stack;
   std::set<goto_programt::const_targett> seen;
@@ -57,7 +57,7 @@ void show_call_sequences(
       {
         // print pair function, function2
         std::cout << function << " -> "
-                  << to_symbol_expr(function2).get_identifier() << std::endl;
+                  << to_symbol_expr(function2).get_identifier() << '\n';
       }
       continue; // abort search
     }
@@ -88,7 +88,7 @@ void show_call_sequences(
 {
   // this is quadratic
 
-  std::cout << "# " << function << std::endl;
+  std::cout << "# " << function << '\n';
 
   show_call_sequences(
     function,
@@ -115,7 +115,7 @@ void show_call_sequences(
       next);
   }
 
-  std::cout << std::endl;
+  std::cout << '\n';
 }
 
 /*******************************************************************\

--- a/src/goto-instrument/document_properties.cpp
+++ b/src/goto-instrument/document_properties.cpp
@@ -376,53 +376,53 @@ void document_propertiest::doit()
           << escape_latex(source_location.get_string("file"), false)
           << " function "
           << escape_latex(source_location.get_string("function"), false)
-          << "}" << std::endl;
+          << "}\n";
 
-      out << std::endl;
+      out << '\n';
 
       for(std::set<irep_idt>::const_iterator
           s_it=it->second.comment_set.begin();
           s_it!=it->second.comment_set.end();
           s_it++)
         out << "\\claim{" << escape_latex(id2string(*s_it), false)
-            << "}" << std::endl;
+            << "}\n";
 
-      out << std::endl;
+      out << '\n';
 
       out << "\\begin{alltt}\\claimcode\n"
           << code
           << "\\end{alltt}\n";
 
-      out << std::endl;
-      out << std::endl;
+      out << '\n';
+      out << '\n';
       break;
 
     case HTML:
-      out << "<div class=\"claim\">" << std::endl
+      out << "<div class=\"claim\">\n"
           << "<div class=\"location\">File "
           << escape_html(source_location.get_string("file"))
           << " function "
           << escape_html(source_location.get_string("function"))
-          << "</div>" << std::endl;
+          << "</div>\n";
 
-      out << std::endl;
+      out << '\n';
 
       for(std::set<irep_idt>::const_iterator
           s_it=it->second.comment_set.begin();
           s_it!=it->second.comment_set.end();
           s_it++)
-        out << "<div class=\"description\">" << std::endl
-            << escape_html(id2string(*s_it)) << std::endl
-            << "</div>" << std::endl;
+        out << "<div class=\"description\">\n"
+            << escape_html(id2string(*s_it)) << '\n'
+            << "</div>\n";
 
-      out << std::endl;
+      out << '\n';
 
       out << "<div class=\"code\">\n"
           << code
-          << "</div> <!-- code -->" << std::endl;
+          << "</div> <!-- code -->\n";
 
-      out << "</div> <!-- claim -->" << std::endl;
-      out << std::endl;
+      out << "</div> <!-- claim -->\n";
+      out << '\n';
       break;
     }
   }

--- a/src/goto-instrument/dot.cpp
+++ b/src/goto-instrument/dot.cpp
@@ -84,8 +84,8 @@ void dott::write_dot_subgraph(
   clusters.back().set("name", name);
   clusters.back().set("nr", subgraphscount);
 
-  out << "subgraph \"cluster_" << name << "\" {" << std::endl;
-  out << "label=\"" << name << "\";" << std::endl;
+  out << "subgraph \"cluster_" << name << "\" {\n";
+  out << "label=\"" << name << "\";\n";
 
   const goto_programt::instructionst &instructions =
     goto_program.instructions;
@@ -93,7 +93,7 @@ void dott::write_dot_subgraph(
   if(instructions.empty())
   {
     out << "Node_" << subgraphscount << "_0 " <<
-      "[shape=Mrecord,fontsize=22,label=\"?\"];" << std::endl;
+      "[shape=Mrecord,fontsize=22,label=\"?\"];\n";
   }
   else
   {
@@ -191,7 +191,7 @@ void dott::write_dot_subgraph(
         out <<"Mrecord";
       out << ",fontsize=22,label=\"";
       out << tmp.str();
-      out << "\"];" << std::endl;
+      out << "\"];\n";
 
       std::set<goto_programt::const_targett> tres;
       std::set<goto_programt::const_targett> fres;
@@ -222,7 +222,7 @@ void dott::write_dot_subgraph(
     }
   }
 
-  out << "}" << std::endl;
+  out << "}\n";
   subgraphscount++;
 }
 
@@ -253,25 +253,24 @@ void dott::do_dot_function_calls(
       out << expr.op0().id() <<
         " -> " "Node_" << cit->get("nr") << "_0" <<
         " [lhead=\"cluster_" << expr.op1().get(ID_identifier) << "\"," <<
-        "color=blue];" << std::endl;
+        "color=blue];\n";
     }
     else
     {
       out << "subgraph \"cluster_" << expr.op1().get(ID_identifier) <<
-        "\" {" << std::endl;
-      out << "rank=sink;"<<std::endl;
-      out << "label=\"" << expr.op1().get(ID_identifier) << "\";" << std::endl;
+        "\" {\n";
+      out << "rank=sink;\n";
+      out << "label=\"" << expr.op1().get(ID_identifier) << "\";\n";
       out << "Node_" << subgraphscount << "_0 " <<
-        "[shape=Mrecord,fontsize=22,label=\"?\"];"
-          << std::endl;
-      out << "}" << std::endl;
+        "[shape=Mrecord,fontsize=22,label=\"?\"];\n";
+      out << "}\n";
       clusters.push_back(exprt("cluster"));
       clusters.back().set("name", expr.op1().get(ID_identifier));
       clusters.back().set("nr", subgraphscount);
       out << expr.op0().id() <<
         " -> " "Node_" << subgraphscount << "_0" <<
         " [lhead=\"cluster_" << expr.op1().get("identifier") << "\"," <<
-        "color=blue];" << std::endl;
+        "color=blue];\n";
       subgraphscount++;
     }
   }
@@ -291,8 +290,8 @@ Function: dott::output
 
 void dott::output(std::ostream &out)
 {
-  out << "digraph G {" << std::endl;
-  out << DOTGRAPHSETTINGS << std::endl;
+  out << "digraph G {\n";
+  out << DOTGRAPHSETTINGS << '\n';
 
   std::list<exprt> clusters;
 
@@ -302,7 +301,7 @@ void dott::output(std::ostream &out)
 
   do_dot_function_calls(out);
 
-  out << "}" << std::endl;
+  out << "}\n";
 }
 
 /*******************************************************************\
@@ -406,7 +405,7 @@ void dott::write_edge(
         out << ",color=red";
       out << "]";
     }
-  out << ";" << std::endl;
+  out << ";\n";
 }
 
 /*******************************************************************\

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -188,8 +188,8 @@ void dump_ct::operator()(std::ostream &os)
         type_id==ID_incomplete_union ||
         type_id==ID_c_enum))
     {
-      os << "// " << symbol.name << std::endl;
-      os << "// " << symbol.location << std::endl;
+      os << "// " << symbol.name << '\n';
+      os << "// " << symbol.location << '\n';
 
       if(type_id==ID_c_enum)
         convert_compound_enum(symbol.type, os);
@@ -255,42 +255,39 @@ void dump_ct::operator()(std::ostream &os)
       it=system_headers.begin();
       it!=system_headers.end();
       ++it)
-    os << "#include <" << *it << ">" << std::endl;
+    os << "#include <" << *it << ">\n";
   if(!system_headers.empty())
-    os << std::endl;
+    os << '\n';
 
   if(global_var_stream.str().find("NULL")!=std::string::npos ||
      func_body_stream.str().find("NULL")!=std::string::npos)
   {
-    os << "#ifndef NULL" << std::endl
-       << "#define NULL ((void*)0)" << std::endl
-       << "#endif" << std::endl;
-    os << std::endl;
+    os << "#ifndef NULL\n"
+       << "#define NULL ((void*)0)\n"
+       << "#endif\n\n";
   }
   if(func_body_stream.str().find("FENCE")!=std::string::npos)
   {
-    os << "#ifndef FENCE" << std::endl
-       << "#define FENCE(x) ((void)0)" << std::endl
-       << "#endif" << std::endl;
-    os << std::endl;
+    os << "#ifndef FENCE\n"
+       << "#define FENCE(x) ((void)0)\n"
+       << "#endif\n\n";
   }
   if(func_body_stream.str().find("IEEE_FLOAT_")!=std::string::npos)
   {
-    os << "#ifndef IEEE_FLOAT_EQUAL" << std::endl
-       << "#define IEEE_FLOAT_EQUAL(x,y) ((x)==(y))" << std::endl
-       << "#endif" << std::endl;
-    os << "#ifndef IEEE_FLOAT_NOTEQUAL" << std::endl
-       << "#define IEEE_FLOAT_NOTEQUAL(x,y) ((x)!=(y))" << std::endl
-       << "#endif" << std::endl;
-    os << std::endl;
+    os << "#ifndef IEEE_FLOAT_EQUAL\n"
+       << "#define IEEE_FLOAT_EQUAL(x,y) ((x)==(y))\n"
+       << "#endif\n"
+       << "#ifndef IEEE_FLOAT_NOTEQUAL\n"
+       << "#define IEEE_FLOAT_NOTEQUAL(x,y) ((x)!=(y))\n"
+       << "#endif\n\n";
   }
 
   if(!func_decl_stream.str().empty())
-    os << func_decl_stream.str() << std::endl;
+    os << func_decl_stream.str() << '\n';
   if(!compound_body_stream.str().empty())
-    os << compound_body_stream.str() << std::endl;
+    os << compound_body_stream.str() << '\n';
   if(!global_var_stream.str().empty())
-    os << global_var_stream.str() << std::endl;
+    os << global_var_stream.str() << '\n';
   os << func_body_stream.str();
 }
 
@@ -471,7 +468,7 @@ void dump_ct::convert_compound(
 
     irep_idt comp_name=comp.get_name();
 
-    struct_body << indent(1) << "// " << comp_name << std::endl;
+    struct_body << indent(1) << "// " << comp_name << '\n';
     struct_body << indent(1);
 
     // component names such as "main" would collide with other objects in the
@@ -518,7 +515,7 @@ void dump_ct::convert_compound(
     else
       assert(false);
 
-    struct_body << ";" << std::endl;
+    struct_body << ";\n";
   }
 
   os << type_to_string(unresolved);
@@ -527,8 +524,8 @@ void dump_ct::convert_compound(
     assert(language->id()=="cpp");
     os << ": " << base_decls.str();
   }
-  os << std::endl;
-  os << "{" << std::endl;
+  os << '\n';
+  os << "{\n";
   os << struct_body.str();
 
   /*
@@ -548,9 +545,7 @@ void dump_ct::convert_compound(
     os << " __attribute__ ((__transparent_union__))";
   if(type.get_bool(ID_C_packed))
     os << " __attribute__ ((__packed__))";
-  os << ";";
-  os << std::endl;
-  os << std::endl;
+  os << ";\n";
 }
 
 /*******************************************************************\
@@ -946,9 +941,9 @@ void dump_ct::convert_global_variable(
   if((func.empty() || symbol.is_extern) &&
      (symbol.value.is_nil() || !syms.empty()))
   {
-    os << "// " << symbol.name << std::endl;
-    os << "// " << symbol.location << std::endl;
-    os << expr_to_string(d) << std::endl;
+    os << "// " << symbol.name << '\n';
+    os << "// " << symbol.location << '\n';
+    os << expr_to_string(d) << '\n';
   }
 
   if(!symbol.value.is_nil())
@@ -978,13 +973,13 @@ void dump_ct::convert_global_variable(
     local_static_decls[symbol.name]=d;
   else if(!symbol.value.is_nil())
   {
-    os << "// " << symbol.name << std::endl;
-    os << "// " << symbol.location << std::endl;
+    os << "// " << symbol.name << '\n';
+    os << "// " << symbol.location << '\n';
 
     std::list<irep_idt> empty_static, empty_types;
     cleanup_decl(d, empty_static, empty_types);
     assert(empty_static.empty());
-    os << expr_to_string(d) << std::endl;
+    os << expr_to_string(d) << '\n';
   }
 }
 
@@ -1050,11 +1045,11 @@ void dump_ct::convert_function_declaration(
     converted_enum.swap(converted_e_bak);
     converted_compound.swap(converted_c_bak);
 
-    os_body << "// " << symbol.name << std::endl;
-    os_body << "// " << symbol.location << std::endl;
-    os_body << make_decl(symbol.name, symbol.type) << std::endl;
+    os_body << "// " << symbol.name << '\n';
+    os_body << "// " << symbol.location << '\n';
+    os_body << make_decl(symbol.name, symbol.type) << '\n';
     os_body << expr_to_string(b);
-    os_body << std::endl << std::endl;
+    os_body << "\n\n";
 
     declared_enum_constants.swap(enum_constants_bak);
   }
@@ -1062,9 +1057,9 @@ void dump_ct::convert_function_declaration(
   if(symbol.name!=goto_functionst::entry_point() &&
      symbol.name!=ID_main)
   {
-    os_decl << "// " << symbol.name << std::endl;
-    os_decl << "// " << symbol.location << std::endl;
-    os_decl << make_decl(symbol.name, symbol.type) << ";" << std::endl;
+    os_decl << "// " << symbol.name << '\n';
+    os_decl << "// " << symbol.location << '\n';
+    os_decl << make_decl(symbol.name, symbol.type) << ";\n";
   }
 }
 

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -133,7 +133,7 @@ int goto_instrument_parse_optionst::doit()
 {
   if(cmdline.isset("version"))
   {
-    std::cout << CBMC_VERSION << std::endl;
+    std::cout << CBMC_VERSION << '\n';
     return 0;
   }
 
@@ -244,7 +244,7 @@ int goto_instrument_parse_optionst::doit()
           }
           else
           {
-            std::cout << result << std::endl;
+            std::cout << result << '\n';
           }
         }
       }
@@ -258,10 +258,9 @@ int goto_instrument_parse_optionst::doit()
 
       forall_goto_functions(f_it, goto_functions)
       {
-        std::cout << "////" << std::endl;
-        std::cout << "//// Function: " << f_it->first << std::endl;
-        std::cout << "////" << std::endl;
-        std::cout << std::endl;
+        std::cout << "////\n";
+        std::cout << "//// Function: " << f_it->first << '\n';
+        std::cout << "////\n\n";
 
         const goto_programt &goto_program=f_it->second.body;
 
@@ -269,8 +268,7 @@ int goto_instrument_parse_optionst::doit()
         {
           goto_program.output_instruction(ns, "", std::cout, i_it);
           std::cout << "Is threaded: " << (is_threaded(i_it)?"True":"False")
-                    << std::endl;
-          std::cout << std::endl;
+                    << "\n\n";
         }
       }
     }
@@ -324,11 +322,11 @@ int goto_instrument_parse_optionst::doit()
       forall_goto_functions(it, goto_functions)
       {
         local_bitvector_analysist local_bitvector_analysis(it->second);
-        std::cout << ">>>>" << std::endl;
-        std::cout << ">>>> " << it->first << std::endl;
-        std::cout << ">>>>" << std::endl;
+        std::cout << ">>>>\n";
+        std::cout << ">>>> " << it->first << '\n';
+        std::cout << ">>>>\n";
         local_bitvector_analysis.output(std::cout, it->second, ns);
-        std::cout << std::endl;
+        std::cout << '\n';
       }
 
       return 0;
@@ -512,10 +510,9 @@ int goto_instrument_parse_optionst::doit()
       {
         if(f_it->second.body_available())
         {
-          std::cout << "////" << std::endl;
-          std::cout << "//// Function: " << f_it->first << std::endl;
-          std::cout << "////" << std::endl;
-          std::cout << std::endl;
+          std::cout << "////\n";
+          std::cout << "//// Function: " << f_it->first << '\n';
+          std::cout << "////\n\n";
           rd_analysis.output(ns, f_it->second.body, std::cout);
         }
       }
@@ -535,10 +532,9 @@ int goto_instrument_parse_optionst::doit()
       {
         if(f_it->second.body_available())
         {
-          std::cout << "////" << std::endl;
-          std::cout << "//// Function: " << f_it->first << std::endl;
-          std::cout << "////" << std::endl;
-          std::cout << std::endl;
+          std::cout << "////\n";
+          std::cout << "//// Function: " << f_it->first << '\n';
+          std::cout << "////\n\n";
           dependence_graph.output(ns, f_it->second.body, std::cout);
         }
       }
@@ -1167,7 +1163,7 @@ void goto_instrument_parse_optionst::instrument_goto_program()
       }
       else
       {
-        std::cout << result << std::endl;
+        std::cout << result << '\n';
       }
     }
 

--- a/src/goto-instrument/points_to.cpp
+++ b/src/goto-instrument/points_to.cpp
@@ -71,7 +71,7 @@ void points_tot::output(std::ostream &out) const
       out << " " << *o_it;
     }
 
-    out << std::endl;
+    out << '\n';
   }
 }
 

--- a/src/goto-instrument/rw_set.cpp
+++ b/src/goto-instrument/rw_set.cpp
@@ -32,24 +32,24 @@ Function: rw_set_baset::output
 
 void rw_set_baset::output(std::ostream &out) const
 {
-  out << "READ:" << std::endl;
+  out << "READ:\n";
   for(entriest::const_iterator it=r_entries.begin();
       it!=r_entries.end();
       it++)
   {
     out << it->second.object << " if "
-        << from_expr(ns, "", it->second.guard) << std::endl;
+        << from_expr(ns, "", it->second.guard) << '\n';
   }
 
-  out << std::endl;
+  out << '\n';
 
-  out << "WRITE:" << std::endl;
+  out << "WRITE:\n";
   for(entriest::const_iterator it=w_entries.begin();
       it!=w_entries.end();
       it++)
   {
     out << it->second.object << " if "
-        << from_expr(ns, "", it->second.guard) << std::endl;
+        << from_expr(ns, "", it->second.guard) << '\n';
   }
 }
 
@@ -190,7 +190,7 @@ void _rw_set_loct::read_write_rec(
       {
         /* as an under-approximation */
         // std::cout << "Sorry, LOCAL_MAY too imprecise. "
-        //           << Omitting some variables." << std::endl;
+        //           << Omitting some variables.\n";
         irep_idt object=ID_unknown;
 
         entryt &entry=r_entries[object];

--- a/src/goto-instrument/show_locations.cpp
+++ b/src/goto-instrument/show_locations.cpp
@@ -55,14 +55,14 @@ void show_locations(
         l.new_element("function").data=
           id2string(source_location.get_function());
 
-        std::cout << xml << std::endl;
+        std::cout << xml << '\n';
       }
       break;
 
     case ui_message_handlert::uit::PLAIN:
       std::cout << function_id << " "
                 << it->location_number << " "
-                << it->source_location << std::endl;
+                << it->source_location << '\n';
       break;
 
     default:

--- a/src/goto-instrument/undefined_functions.cpp
+++ b/src/goto-instrument/undefined_functions.cpp
@@ -34,7 +34,7 @@ void list_undefined_functions(
   forall_goto_functions(it, goto_functions)
     if(!ns.lookup(it->first).is_macro &&
        !it->second.body_available())
-      os << it->first << std::endl;
+      os << it->first << '\n';
 }
 
 /*******************************************************************\

--- a/src/goto-instrument/uninitialized.cpp
+++ b/src/goto-instrument/uninitialized.cpp
@@ -270,10 +270,9 @@ void show_uninitialized(
   {
     if(f_it->second.body_available())
     {
-      out << "////" << std::endl;
-      out << "//// Function: " << f_it->first << std::endl;
-      out << "////" << std::endl;
-      out << std::endl;
+      out << "////\n";
+      out << "//// Function: " << f_it->first << '\n';
+      out << "////\n\n";
       uninitialized_analysist uninitialized_analysis;
       uninitialized_analysis(f_it->second.body, ns);
       uninitialized_analysis.output(ns, f_it->second.body, out);

--- a/src/goto-instrument/unwind.cpp
+++ b/src/goto-instrument/unwind.cpp
@@ -458,7 +458,7 @@ void goto_unwindt::operator()(
       continue;
 
 #ifdef DEBUG
-    std::cout << "Function: " << it->first << std::endl;
+    std::cout << "Function: " << it->first << '\n';
 #endif
 
     goto_programt &goto_program=goto_function.body;

--- a/src/goto-instrument/wmm/event_graph.cpp
+++ b/src/goto-instrument/wmm/event_graph.cpp
@@ -39,15 +39,15 @@ void event_grapht::print_rec_graph(std::ofstream &file, event_idt node_id,
 {
   const abstract_eventt &node=operator[](node_id);
   file << node_id << "[label=\"" << node << ", " << node.source_location <<
-    "\"];" << std::endl;
+    "\"];\n";
   visited.insert(node_id);
 
   for(wmm_grapht::edgest::const_iterator
     it=po_out(node_id).begin();
     it!=po_out(node_id).end(); ++it)
   {
-    file << node_id << "->" << it->first << "[]" << std::endl;
-    file << "{rank=same; " << node_id << "; " << it->first << "}" << std::endl;
+    file << node_id << "->" << it->first << "[]\n";
+    file << "{rank=same; " << node_id << "; " << it->first << "}\n";
     if(visited.find(it->first)==visited.end())
       print_rec_graph(file, it->first, visited);
   }
@@ -56,7 +56,7 @@ void event_grapht::print_rec_graph(std::ofstream &file, event_idt node_id,
     it=com_out(node_id).begin();
     it!=com_out(node_id).end(); ++it)
   {
-    file << node_id << "->" << it->first << "[style=\"dotted\"]" << std::endl;
+    file << node_id << "->" << it->first << "[style=\"dotted\"]\n";
     if(visited.find(it->first)==visited.end())
       print_rec_graph(file, it->first, visited);
   }
@@ -81,10 +81,10 @@ void event_grapht::print_graph()
   event_idt root=po_order.front();
   std::ofstream file;
   file.open("graph.dot");
-  file << "digraph G {" << std::endl;
-  file << "rankdir=LR;" << std::endl;
+  file << "digraph G {\n";
+  file << "rankdir=LR;\n";
   print_rec_graph(file, root, visited);
-  file << "}" << std::endl;
+  file << "}\n";
 }
 
 /*******************************************************************\
@@ -103,7 +103,7 @@ Function: event_grapht::copy_segment
 void event_grapht::explore_copy_segment(std::set<event_idt> &explored,
   event_idt begin, event_idt end) const
 {
-  // std::cout << "explores " << begin << " against " << end << std::endl;
+  // std::cout << "explores " << begin << " against " << end << '\n';
   if(explored.find(begin)!=explored.end())
     return;
 
@@ -149,7 +149,7 @@ event_idt event_grapht::copy_segment(event_idt begin, event_idt end)
 
 //  for(std::set<event_idt>::const_iterator it=covered.begin();
 //      it!=covered.end(); ++it)
-//    std::cout << "covered: " << *it << std::endl;
+//    std::cout << "covered: " << *it << '\n';
 
   std::map<event_idt, event_idt> orig2copy;
 
@@ -1768,12 +1768,11 @@ void event_grapht::critical_cyclet::print_dot(
     const abstract_eventt &ev=egraph[*it];
 
     /* id of the cycle in comments */
-    str << "/* " << id << " */" << std::endl;
+    str << "/* " << id << " */\n";
 
     /* vertex */
     str << ev.id << "[label=\"\\\\lb {" << ev.id << "}" << ev.get_operation();
-    str << "{" << ev.variable << "} {} @thread" << ev.thread << "\"];";
-    str << std::endl;
+    str << "{" << ev.variable << "} {} @thread" << ev.thread << "\"];\n";
   }
 
   /* print edges */
@@ -1783,7 +1782,7 @@ void event_grapht::critical_cyclet::print_dot(
     const abstract_eventt &cur=egraph[*cur_it];
 
     /* id of the cycle in comments */
-    str << "/* " << id << " */" << std::endl;
+    str << "/* " << id << " */\n";
 
     /* edge */
     if(prev_it!=end())
@@ -1845,7 +1844,7 @@ void event_grapht::critical_cyclet::print_dot(
       else
         str << cur.id << "[label=\"?";
 
-      str << "\",color=" << print_colour(colour) << "];" <<std::endl;
+      str << "\",color=" << print_colour(colour) << "];\n";
     }
 
     prev_it=cur_it;
@@ -1855,7 +1854,7 @@ void event_grapht::critical_cyclet::print_dot(
   const abstract_eventt &last=egraph[back()];
 
   /* id of the cycle in comments */
-  str << "/* " << id << " */" << std::endl;
+  str << "/* " << id << " */\n";
 
   /* edge */
   str << last.id << "->";
@@ -1911,5 +1910,5 @@ void event_grapht::critical_cyclet::print_dot(
   else
     str << first.id << "[label=\"?";
 
-  str << "\", color=" << print_colour(colour) << "];" <<std::endl;
+  str << "\", color=" << print_colour(colour) << "];\n";
 }

--- a/src/goto-instrument/wmm/goto2graph.cpp
+++ b/src/goto-instrument/wmm/goto2graph.cpp
@@ -1657,10 +1657,10 @@ void inline instrumentert::print_outputs_local(
     message.debug() << it->print_unsafes() << messaget::eom;
 #endif
     it->print_dot(dot, colour++, model);
-    ref << it->print_name(model, hide_internals) << std::endl;
-    output << it->print_output() << std::endl;
+    ref << it->print_name(model, hide_internals) << '\n';
+    output << it->print_output() << '\n';
     all << it->print_all(model, map_id2var, map_var2id, hide_internals)
-      << std::endl;
+      << '\n';
 
     /* emphasises instrumented events */
     for(std::list<event_idt>::const_iterator it_e=it->begin();
@@ -1682,7 +1682,7 @@ void inline instrumentert::print_outputs_local(
       {
         dot << ev.id << "[label=\"\\\\lb {" << ev.id << "}";
         dot << ev.get_operation() << "{" << ev.variable << "} {} @thread";
-        dot << ev.thread << "\",color=red,shape=box];" << std::endl;
+        dot << ev.thread << "\",color=red,shape=box];\n";
       }
     }
   }
@@ -1698,7 +1698,7 @@ void inline instrumentert::print_outputs_local(
         for(std::set<event_idt>::iterator it=same_po[i].begin();
           it!=same_po[i].end(); it++)
           dot << egraph[*it].id << ";";
-        dot << "};" << std::endl;
+        dot << "};\n";
       }
   }
 
@@ -1709,15 +1709,14 @@ void inline instrumentert::print_outputs_local(
       same_file.begin();
       it!=same_file.end(); it++)
     {
-      dot << "subgraph cluster_" << irep_id_hash()(it->first) << "{"
-          << std::endl;
-      dot << "  label=\"" << it->first << "\";" << std::endl;
+      dot << "subgraph cluster_" << irep_id_hash()(it->first) << "{\n";
+      dot << "  label=\"" << it->first << "\";\n";
       for(std::set<event_idt>::const_iterator ev_it=it->second.begin();
         ev_it!=it->second.end(); ev_it++)
       {
-        dot << "  " << egraph[*ev_it].id << ";" << std::endl;
+        dot << "  " << egraph[*ev_it].id << ";\n";
       }
-      dot << "};" << std::endl;
+      dot << "};\n";
     }
   }
 
@@ -1728,11 +1727,11 @@ void inline instrumentert::print_outputs_local(
       m_it!=map_id2var.end();
       ++m_it)
   {
-    table << std::endl << "| " << m_it->first << " : " << m_it->second;
+    table << "\n| " << m_it->first << " : " << m_it->second;
   }
-  table << std::endl;
+  table << '\n';
   table << std::string(80, '-');
-  table << std::endl;
+  table << '\n';
 }
 
 void instrumentert::print_outputs(memory_modelt model, bool hide_internals)
@@ -1749,8 +1748,8 @@ void instrumentert::print_outputs(memory_modelt model, bool hide_internals)
   all.open("all.txt");
   table.open("table.txt");
 
-  dot << "digraph G {" << std::endl;
-  dot << "nodesep=1; ranksep=1;" << std::endl;
+  dot << "digraph G {\n";
+  dot << "nodesep=1; ranksep=1;\n";
 
   /* prints cycles in the different outputs */
   if(!set_of_cycles.empty())
@@ -1764,21 +1763,21 @@ void instrumentert::print_outputs(memory_modelt model, bool hide_internals)
       std::string name="scc_" + std::to_string(i) + ".dot";
       local_dot.open(name.c_str());
 
-      local_dot << "digraph G {" << std::endl;
-      local_dot << "nodesep=1; ranksep=1;" << std::endl;
+      local_dot << "digraph G {\n";
+      local_dot << "nodesep=1; ranksep=1;\n";
       print_outputs_local(set_of_cycles_per_SCC[i], local_dot, ref, output, all,
         table, model, hide_internals);
-      local_dot << "}" << std::endl;
+      local_dot << "}\n";
       local_dot.close();
 
       dot << i << "[label=\"SCC " << i << "\",link=\"" << "scc_" << i;
-      dot << ".svg\"]" << std::endl;
+      dot << ".svg\"]\n";
     }
   }
   else
     message.debug() << "no cycles to output" << messaget::eom;
 
-  dot << "}" << std::endl;
+  dot << "}\n";
 
   dot.close();
   ref.close();

--- a/src/goto-instrument/wmm/pair_collection.cpp
+++ b/src/goto-instrument/wmm/pair_collection.cpp
@@ -16,7 +16,7 @@ Date: 2013
 #include "event_graph.h"
 
 #define OUTPUT(s, fence, file, line, id, type)  \
-  s<<fence<<"|"<<file<<"|"<<line<<"|"<<id<<"|"<<type<<std::endl
+  s<<fence<<"|"<<file<<"|"<<line<<"|"<<id<<"|"<<type<<'\n'
 
 /*******************************************************************\
 

--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -608,7 +608,7 @@ void goto_inlinet::expand_function_call(
   assert(!transitive || inline_map.empty());
 
 #ifdef DEBUG
-  std::cout << "Expanding call:" << std::endl;
+  std::cout << "Expanding call:\n";
   dest.output_instruction(ns, "", std::cout, target);
 #endif
 

--- a/src/goto-programs/goto_program_irep.cpp
+++ b/src/goto-programs/goto_program_irep.cpp
@@ -179,7 +179,7 @@ void convert(const irept &irep, goto_programt &program)
       if(fit==program.instructions.end())
       {
         std::cout << "Warning: could not resolve target link "
-                  << "during irep->goto_program translation." << std::endl;
+                  << "during irep->goto_program translation.\n";
         throw 0;
       }
     }

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -72,20 +72,18 @@ Function: interpretert::show_state
 
 void interpretert::show_state()
 {
-  std::cout << std::endl;
-  std::cout << "----------------------------------------------------"
-            << std::endl;
+  std::cout << "\n----------------------------------------------------\n";
 
   if(PC==function->second.body.instructions.end())
   {
     std::cout << "End of function `"
-              << function->first << "'" << std::endl;
+              << function->first << "'\n";
   }
   else
     function->second.body.output_instruction(
       ns, function->first, std::cout, PC);
 
-  std::cout << std::endl;
+  std::cout << '\n';
 }
 
 /*******************************************************************\
@@ -318,7 +316,7 @@ void interpretert::execute_assign()
     if(size!=rhs.size())
       std::cout << "!! failed to obtain rhs ("
                 << rhs.size() << " vs. "
-                << size << ")" << std::endl;
+                << size << ")\n";
     else
       assign(address, rhs);
   }
@@ -346,7 +344,7 @@ void interpretert::assign(
     {
       memory_cellt &cell=memory[integer2unsigned(address)];
       std::cout << "** assigning " << cell.identifier
-                << "[" << cell.offset << "]:=" << rhs[i] << std::endl;
+                << "[" << cell.offset << "]:=" << rhs[i] << '\n';
       cell.value=rhs[i];
     }
   }

--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -423,7 +423,7 @@ void interpretert::evaluate(
 
   std::cout << "!! failed to evaluate expression: "
             << from_expr(ns, function->first, expr)
-            << std::endl;
+            << '\n';
 }
 
 /*******************************************************************\
@@ -507,7 +507,7 @@ mp_integer interpretert::evaluate_address(const exprt &expr) const
 
   std::cout << "!! failed to evaluate address: "
             << from_expr(ns, function->first, expr)
-            << std::endl;
+            << '\n';
 
   return 0;
 }

--- a/src/goto-programs/read_goto_binary.cpp
+++ b/src/goto-programs/read_goto_binary.cpp
@@ -368,8 +368,8 @@ static bool link_functions(
       #if 0
       if(!base_type_eq(symbol.type, ns.lookup(id).type, ns))
       {
-        std::cerr << symbol << std::endl;
-        std::cerr << ns.lookup(id) << std::endl;
+        std::cerr << symbol << '\n';
+        std::cerr << ns.lookup(id) << '\n';
       }
       assert(base_type_eq(symbol.type, ns.lookup(id).type, ns));
       #endif

--- a/src/goto-programs/remove_asm.cpp
+++ b/src/goto-programs/remove_asm.cpp
@@ -143,7 +143,7 @@ void remove_asmt::process_instruction(
     const irep_idt &i_str=
       to_string_constant(code.op0()).get_value();
 
-    // std::cout << "DOING " << i_str << std::endl;
+    // std::cout << "DOING " << i_str << '\n';
 
     std::istringstream str(id2string(i_str));
     assembler_parser.clear();
@@ -163,7 +163,7 @@ void remove_asmt::process_instruction(
       std::cout << "A ********************\n";
       for(const auto &ins : instruction)
       {
-        std::cout << "XX: " << ins.pretty() << std::endl;
+        std::cout << "XX: " << ins.pretty() << '\n';
       }
 
       std::cout << "B ********************\n";

--- a/src/goto-programs/remove_exceptions.cpp
+++ b/src/goto-programs/remove_exceptions.cpp
@@ -438,7 +438,7 @@ void remove_exceptionst::instrument_exceptions(
         else
         {
 #ifdef DEBUG
-          std::cout << "Remove exceptions: empty stack" << std::endl;
+          std::cout << "Remove exceptions: empty stack\n";
 #endif
         }
       }

--- a/src/goto-programs/show_properties.cpp
+++ b/src/goto-programs/show_properties.cpp
@@ -67,7 +67,7 @@ void show_properties(
         xml_property.new_element("expression").data=
           from_expr(ns, identifier, ins.guard);
 
-        std::cout << xml_property << std::endl;
+        std::cout << xml_property << '\n';
       }
       break;
 
@@ -76,14 +76,14 @@ void show_properties(
       break;
 
     case ui_message_handlert::uit::PLAIN:
-      std::cout << "Property " << property_id << ":" << std::endl;
+      std::cout << "Property " << property_id << ":\n";
 
-      std::cout << "  " << ins.source_location << std::endl
-                << "  " << description << std::endl
+      std::cout << "  " << ins.source_location << '\n'
+                << "  " << description << '\n'
                 << "  " << from_expr(ns, identifier, ins.guard)
-                        << std::endl;
+                        << '\n';
 
-      std::cout << std::endl;
+      std::cout << '\n';
       break;
 
     default:

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -98,7 +98,7 @@ void goto_symex_statet::level0t::operator()(
 
   if(ns.lookup(obj_identifier, s))
   {
-    std::cerr << "level0: failed to find " << obj_identifier << std::endl;
+    std::cerr << "level0: failed to find " << obj_identifier << '\n';
     abort();
   }
 
@@ -375,7 +375,7 @@ static void assert_l1_renaming(const exprt &expr)
   #if 1
   if(check_renaming_l1(expr))
   {
-    std::cerr << expr.pretty() << std::endl;
+    std::cerr << expr.pretty() << '\n';
     assert(false);
   }
   #else
@@ -388,7 +388,7 @@ static void assert_l2_renaming(const exprt &expr)
   #if 1
   if(check_renaming(expr))
   {
-    std::cerr << expr.pretty() << std::endl;
+    std::cerr << expr.pretty() << '\n';
     assert(false);
   }
   #else
@@ -455,9 +455,9 @@ void goto_symex_statet::assignment(
   }
 
   #if 0
-  std::cout << "Assigning " << l1_identifier << std::endl;
+  std::cout << "Assigning " << l1_identifier << '\n';
   value_set.output(ns, std::cout);
-  std::cout << "**********************" << std::endl;
+  std::cout << "**********************\n";
   #endif
 }
 

--- a/src/goto-symex/slice_by_trace.cpp
+++ b/src/goto-symex/slice_by_trace.cpp
@@ -37,7 +37,7 @@ void symex_slice_by_tracet::slice_by_trace(
   std::string trace_files,
   symex_target_equationt &equation)
 {
-  std::cout << "Slicing by trace..." << std::endl;
+  std::cout << "Slicing by trace...\n";
 
   merge_identifier="goto_symex::\\merge";
   merge_symbol=symbol_exprt(typet(ID_bool));
@@ -124,7 +124,7 @@ void symex_slice_by_tracet::slice_by_trace(
 
   assign_merges(equation); // Now add the merge variable assignments to eqn
 
-  std::cout << "Finished slicing by trace..." << std::endl;
+  std::cout << "Finished slicing by trace...\n";
 }
 
 /*******************************************************************\
@@ -141,7 +141,7 @@ Function: read_trace
 
 void symex_slice_by_tracet::read_trace(std::string filename)
 {
-  std::cout << "Reading trace from file " << filename << std::endl;
+  std::cout << "Reading trace from file " << filename << '\n';
   std::ifstream file(filename);
   if(file.fail())
     throw "failed to read from trace file";
@@ -210,7 +210,7 @@ bool symex_slice_by_tracet::parse_alphabet(std::string read_line)
     std::cout << "Alphabet: ";
     if(!alphabet_parity)
       std::cout << "!";
-    std::cout << read_line << std::endl;
+    std::cout << read_line << '\n';
     alphabet.insert(read_line);
   }
   return false;
@@ -235,7 +235,7 @@ void symex_slice_by_tracet::parse_events(std::string read_line)
   bool parity=strstr(read_line.c_str(), "!")==NULL;
   bool universe=strstr(read_line.c_str(), "?")!=NULL;
   bool has_values=strstr(read_line.c_str(), " ")!=NULL;
-  std::cout << "Trace: " << read_line << std::endl;
+  std::cout << "Trace: " << read_line << '\n';
   std::vector<irep_idt> value_v;
   if(has_values)
   {
@@ -314,12 +314,12 @@ void symex_slice_by_tracet::compute_ts_back(
       exprt guard=i->guard;
 
 #if 0
-      std::cout << "EVENT:  " << event << std::endl;
-      std::cout << "GUARD:  " << from_expr(ns, "", guard) << std::endl;
+      std::cout << "EVENT:  " << event << '\n';
+      std::cout << "GUARD:  " << from_expr(ns, "", guard) << '\n';
       for(size_t j=0; j < t.size(); j++)
       {
         std::cout << "t[" << j << "]=" << from_expr(ns, "", t[j]) <<
-          std::endl;
+          '\n';
       }
 #endif
 
@@ -489,7 +489,7 @@ void symex_slice_by_tracet::slice_SSA_steps(
     if(!guard.is_true())
       potential_SSA_steps++;
     // it->output(ns,std::cout);
-    // std::cout << "-----------------" << std::endl;
+    // std::cout << "-----------------\n";
 
     if((guard.id()==ID_symbol) || (guard.id() == ID_not))
     {
@@ -529,7 +529,7 @@ void symex_slice_by_tracet::slice_SSA_steps(
       }
       else if(guard.id()==ID_or)
       {
-        std::cout << "Guarded by an OR." << std::endl;
+        std::cout << "Guarded by an OR.\n";
       }
     }
 
@@ -568,12 +568,12 @@ void symex_slice_by_tracet::slice_SSA_steps(
 
   std::cout << "Trace slicing effectively removed "
             << (sliced_SSA_steps + sliced_conds) << " out of "
-            << equation.SSA_steps.size() << " SSA_steps." << std::endl;
+            << equation.SSA_steps.size() << " SSA_steps.\n";
   std::cout << "  ("
                 << ((sliced_SSA_steps + sliced_conds) - trace_loc_sliced)
             << " out of "
             << (equation.SSA_steps.size()-trace_SSA_steps-location_SSA_steps)
-            << " non-trace, non-location SSA_steps)" << std::endl;
+            << " non-trace, non-location SSA_steps)\n";
 }
 
 /*******************************************************************\

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -297,7 +297,7 @@ void goto_symext::dereference_rec(
       symex_dereference_state,
       language_mode);
 
-    // std::cout << "**** " << from_expr(ns, "", tmp1) << std::endl;
+    // std::cout << "**** " << from_expr(ns, "", tmp1) << '\n';
     exprt tmp2=
       dereference.dereference(
         tmp1,
@@ -305,7 +305,7 @@ void goto_symext::dereference_rec(
         write?
           value_set_dereferencet::modet::WRITE:
           value_set_dereferencet::modet::READ);
-    // std::cout << "**** " << from_expr(ns, "", tmp2) << std::endl;
+    // std::cout << "**** " << from_expr(ns, "", tmp2) << '\n';
 
     expr.swap(tmp2);
 

--- a/src/goto-symex/symex_dereference_state.cpp
+++ b/src/goto-symex/symex_dereference_state.cpp
@@ -123,7 +123,7 @@ void symex_dereference_statet::get_value_set(
   #endif
 
   #if 0
-  std::cout << "E: " << from_expr(goto_symex.ns, "", expr) << std::endl;
+  std::cout << "E: " << from_expr(goto_symex.ns, "", expr) << '\n';
   #endif
 
   #if 0
@@ -131,7 +131,7 @@ void symex_dereference_statet::get_value_set(
   for(value_setst::valuest::const_iterator it=value_set.begin();
       it!=value_set.end();
       it++)
-    std::cout << from_expr(goto_symex.ns, "", *it) << std::endl;
+    std::cout << from_expr(goto_symex.ns, "", *it) << '\n';
   std::cout << "**************************\n";
   #endif
 }

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -181,7 +181,7 @@ void goto_symext::operator()(
        state.source.thread_nr+1<state.threads.size())
     {
       unsigned t=state.source.thread_nr+1;
-      // std::cout << "********* Now executing thread " << t << std::endl;
+      // std::cout << "********* Now executing thread " << t << '\n';
       state.switch_to_thread(t);
     }
   }

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -974,27 +974,27 @@ void symex_target_equationt::SSA_stept::output(
     out << "Thread " << source.thread_nr;
 
     if(source.pc->source_location.is_not_nil())
-      out << " " << source.pc->source_location << std::endl;
+      out << " " << source.pc->source_location << '\n';
     else
-      out << std::endl;
+      out << '\n';
   }
 
   switch(type)
   {
   case goto_trace_stept::typet::ASSERT:
-    out << "ASSERT " << from_expr(ns, "", cond_expr) << std::endl; break;
+    out << "ASSERT " << from_expr(ns, "", cond_expr) << '\n'; break;
   case goto_trace_stept::typet::ASSUME:
-    out << "ASSUME " << from_expr(ns, "", cond_expr) << std::endl; break;
+    out << "ASSUME " << from_expr(ns, "", cond_expr) << '\n'; break;
   case goto_trace_stept::typet::LOCATION:
-    out << "LOCATION" << std::endl; break;
+    out << "LOCATION" << '\n'; break;
   case goto_trace_stept::typet::INPUT:
-    out << "INPUT" << std::endl; break;
+    out << "INPUT" << '\n'; break;
   case goto_trace_stept::typet::OUTPUT:
-    out << "OUTPUT" << std::endl; break;
+    out << "OUTPUT" << '\n'; break;
 
   case goto_trace_stept::typet::DECL:
-    out << "DECL" << std::endl;
-    out << from_expr(ns, "", ssa_lhs) << std::endl;
+    out << "DECL" << '\n';
+    out << from_expr(ns, "", ssa_lhs) << '\n';
     break;
 
   case goto_trace_stept::typet::ASSIGNMENT:
@@ -1018,45 +1018,45 @@ void symex_target_equationt::SSA_stept::output(
       }
     }
 
-    out << ")" << std::endl;
+    out << ")\n";
     break;
 
   case goto_trace_stept::typet::DEAD:
-    out << "DEAD" << std::endl; break;
+    out << "DEAD\n"; break;
   case goto_trace_stept::typet::FUNCTION_CALL:
-    out << "FUNCTION_CALL" << std::endl; break;
+    out << "FUNCTION_CALL\n"; break;
   case goto_trace_stept::typet::FUNCTION_RETURN:
-    out << "FUNCTION_RETURN" << std::endl; break;
+    out << "FUNCTION_RETURN\n"; break;
   case goto_trace_stept::typet::CONSTRAINT:
-    out << "CONSTRAINT" << std::endl; break;
+    out << "CONSTRAINT\n"; break;
   case goto_trace_stept::typet::SHARED_READ:
-    out << "SHARED READ" << std::endl; break;
+    out << "SHARED READ\n"; break;
   case goto_trace_stept::typet::SHARED_WRITE:
-    out << "SHARED WRITE" << std::endl; break;
+    out << "SHARED WRITE\n"; break;
   case goto_trace_stept::typet::ATOMIC_BEGIN:
-    out << "ATOMIC_BEGIN" << std::endl; break;
+    out << "ATOMIC_BEGIN\n"; break;
   case goto_trace_stept::typet::ATOMIC_END:
-    out << "AUTOMIC_END" << std::endl; break;
+    out << "AUTOMIC_END\n"; break;
   case goto_trace_stept::typet::SPAWN:
-    out << "SPAWN" << std::endl; break;
+    out << "SPAWN\n"; break;
   case goto_trace_stept::typet::MEMORY_BARRIER:
-    out << "MEMORY_BARRIER" << std::endl; break;
+    out << "MEMORY_BARRIER\n"; break;
   case goto_trace_stept::typet::GOTO:
-    out << "IF " << from_expr(ns, "", cond_expr) << " GOTO" << std::endl; break;
+    out << "IF " << from_expr(ns, "", cond_expr) << " GOTO\n"; break;
 
   default: assert(false);
   }
 
   if(is_assert() || is_assume() || is_assignment() || is_constraint())
-    out << from_expr(ns, "", cond_expr) << std::endl;
+    out << from_expr(ns, "", cond_expr) << '\n';
 
   if(is_assert() || is_constraint())
-    out << comment << std::endl;
+    out << comment << '\n';
 
   if(is_shared_read() || is_shared_write())
-    out << from_expr(ns, "", ssa_lhs) << std::endl;
+    out << from_expr(ns, "", ssa_lhs) << '\n';
 
-  out << "Guard: " << from_expr(ns, "", guard) << std::endl;
+  out << "Guard: " << from_expr(ns, "", guard) << '\n';
 }
 
 /*******************************************************************\

--- a/src/langapi/language_ui.cpp
+++ b/src/langapi/language_ui.cpp
@@ -128,7 +128,7 @@ bool language_uit::parse(const std::string &filename)
   if(language.parse(infile, filename))
   {
     if(get_ui()==ui_message_handlert::uit::PLAIN)
-      std::cerr << "PARSING ERROR" << std::endl;
+      std::cerr << "PARSING ERROR\n";
 
     return true;
   }
@@ -253,7 +253,7 @@ void language_uit::show_symbol_table_plain(
   bool brief)
 {
   if(!brief)
-    out << '\n' << "Symbols:" << '\n' << std::endl;
+    out << "\nSymbols:\n\n";
 
   // we want to sort alphabetically
   std::set<std::string> symbols;
@@ -289,7 +289,7 @@ void language_uit::show_symbol_table_plain(
 
     if(brief)
     {
-      out << symbol.name << " " << type_str << std::endl;
+      out << symbol.name << " " << type_str << '\n';
       continue;
     }
 

--- a/src/memory-models/mmcc_parse_options.cpp
+++ b/src/memory-models/mmcc_parse_options.cpp
@@ -50,7 +50,7 @@ int mmcc_parse_optionst::doit()
 {
   if(cmdline.isset("version"))
   {
-    std::cout << CBMC_VERSION << std::endl;
+    std::cout << CBMC_VERSION << '\n';
     return 0;
   }
 

--- a/src/musketeer/fence_inserter.cpp
+++ b/src/musketeer/fence_inserter.cpp
@@ -931,7 +931,7 @@ void fence_insertert::print_to_file()
 
     s << to_string(it->second) << "|" << first.source_location.get_file()
       << "|" << first.source_location.get_line() << "|"
-      << first.source_location.get_column() << std::endl;
+      << first.source_location.get_column() << '\n';
     non_redundant_display.insert(s.str());
   }
 
@@ -972,7 +972,7 @@ void fence_insertert::print_to_file_2()
     s << to_string(it->second) << "|" << first.source_location.get_file()
     << "|" << first.source_location.get_line() << "|"
     << second.source_location.get_file()
-    << "|" << second.source_location.get_line() << std::endl;
+    << "|" << second.source_location.get_line() << '\n';
     non_redundant_display.insert(s.str());
   }
 
@@ -1018,7 +1018,7 @@ void fence_insertert::print_to_file_3()
       << second.source_location.get_file() << "|"
       << second.source_location.get_function() << "|"
       << second.source_location.get_line()
-      << "|" << second.variable << std::endl;
+      << "|" << second.variable << '\n';
     non_redundant_display.insert(s.str());
     }
     catch(std::string s)
@@ -1074,7 +1074,7 @@ void fence_insertert::print_to_file_4()
         << second.source_location.get_function() << "|"
         << second.source_location.get_line()
         << "|" << second.variable << "|"
-        << get_type(second.variable).get("#c_type") << std::endl;
+        << get_type(second.variable).get("#c_type") << '\n';
       non_redundant_display.insert(s.str());
     }
     catch (std::string s)

--- a/src/musketeer/fence_shared.cpp
+++ b/src/musketeer/fence_shared.cpp
@@ -30,7 +30,7 @@ Author: Vincent Nimal
 #endif
 
 #define OUTPUT(s, fence, file, line, id, type)  \
-  s<<fence<<"|"<<file<<"|"<<line<<"|"<<id<<"|"<<type<<std::endl
+  s<<fence<<"|"<<file<<"|"<<line<<"|"<<id<<"|"<<type<<'\n'
 
 class simple_insertiont
 {
@@ -198,7 +198,7 @@ bool fence_volatilet::is_volatile(const typet &src) const
     return true;
 
 //  std::cout << "type: " << src << " has sub: "
-//  << src.subtypes().empty() /*src.has_subtypes()*/ <<  std::endl;
+//  << src.subtypes().empty() /*src.has_subtypes()*/ <<  '\n';
   if(src.id()==ID_symbol)
   {
     symbol_tablet::symbolst::const_iterator s_it=
@@ -222,7 +222,7 @@ bool fence_volatilet::is_volatile(const typet &src) const
       it!=src.subtypes().end();
       ++it)
     {
-      // std::cout << *it << std::endl;
+      // std::cout << *it << '\n';
       vol|=is_volatile(*it);
       if(vol)
         break;
@@ -247,7 +247,7 @@ Function:
 
 void fence_volatilet::compute()
 {
-  std::cout << "--------" << std::endl;
+  std::cout << "--------\n";
 
   forall_goto_functions(f_it, goto_functions)
   {
@@ -332,7 +332,7 @@ Function:
 
 void fence_all_sharedt::compute()
 {
-  std::cout << "--------" << std::endl;
+  std::cout << "--------\n";
 
   forall_goto_functions(f_it, goto_functions)
   {

--- a/src/musketeer/musketeer_parse_options.cpp
+++ b/src/musketeer/musketeer_parse_options.cpp
@@ -88,7 +88,7 @@ int goto_fence_inserter_parse_optionst::doit()
 {
   if(cmdline.isset("version"))
   {
-    std::cout << MUSKETEER_VERSION << std::endl;
+    std::cout << MUSKETEER_VERSION << '\n';
     return 0;
   }
 

--- a/src/path-symex/path_symex.cpp
+++ b/src/path-symex/path_symex.cpp
@@ -421,8 +421,8 @@ void path_symext::assign_rec(
   // const typet &ssa_lhs_type=state.var_map.ns.follow(ssa_lhs.type());
 
   #ifdef DEBUG
-  std::cout << "assign_rec: " << ssa_lhs.pretty() << std::endl;
-  // std::cout << "ssa_lhs_type: " << ssa_lhs_type.id() << std::endl;
+  std::cout << "assign_rec: " << ssa_lhs.pretty() << '\n';
+  // std::cout << "ssa_lhs_type: " << ssa_lhs_type.id() << '\n';
   #endif
 
   if(ssa_lhs.id()==ID_symbol)
@@ -435,8 +435,8 @@ void path_symext::assign_rec(
 
     #ifdef DEBUG
     const irep_idt &ssa_identifier=symbol_expr.get_identifier();
-    std::cout << "SSA symbol identifier: " << ssa_identifier << std::endl;
-    std::cout << "full identifier: " << full_identifier << std::endl;
+    std::cout << "SSA symbol identifier: " << ssa_identifier << '\n';
+    std::cout << "full identifier: " << full_identifier << '\n';
     #endif
 
     var_mapt::var_infot &var_info=state.var_map[full_identifier];
@@ -447,7 +447,7 @@ void path_symext::assign_rec(
     symbol_exprt new_lhs=var_info.ssa_symbol();
 
     #ifdef DEBUG
-    std::cout << "new_lhs: " << new_lhs.get_identifier() << std::endl;
+    std::cout << "new_lhs: " << new_lhs.get_identifier() << '\n';
     #endif
 
     // record new state of lhs
@@ -469,8 +469,8 @@ void path_symext::assign_rec(
       if(!base_type_eq(ssa_rhs.type(), new_lhs.type(), state.var_map.ns))
       {
         #ifdef DEBUG
-        std::cout << "ssa_rhs: " << ssa_rhs.pretty() << std::endl;
-        std::cout << "new_lhs: " << new_lhs.pretty() << std::endl;
+        std::cout << "ssa_rhs: " << ssa_rhs.pretty() << '\n';
+        std::cout << "new_lhs: " << new_lhs.pretty() << '\n';
         #endif
         throw "assign_rec got different types";
       }
@@ -493,7 +493,7 @@ void path_symext::assign_rec(
   else if(ssa_lhs.id()==ID_member)
   {
     #ifdef DEBUG
-    std::cout << "assign_rec ID_member" << std::endl;
+    std::cout << "assign_rec ID_member\n";
     #endif
 
     const member_exprt &ssa_lhs_member_expr=to_member_expr(ssa_lhs);
@@ -532,7 +532,7 @@ void path_symext::assign_rec(
   else if(ssa_lhs.id()==ID_index)
   {
     #ifdef DEBUG
-    std::cout << "assign_rec ID_index" << std::endl;
+    std::cout << "assign_rec ID_index\n";
     #endif
 
     throw "unexpected array index on lhs";
@@ -540,7 +540,7 @@ void path_symext::assign_rec(
   else if(ssa_lhs.id()==ID_dereference)
   {
     #ifdef DEBUG
-    std::cout << "assign_rec ID_dereference" << std::endl;
+    std::cout << "assign_rec ID_dereference\n";
     #endif
 
     throw "unexpected dereference on lhs";
@@ -548,7 +548,7 @@ void path_symext::assign_rec(
   else if(ssa_lhs.id()==ID_if)
   {
     #ifdef DEBUG
-    std::cout << "assign_rec ID_if" << std::endl;
+    std::cout << "assign_rec ID_if\n";
     #endif
 
     const if_exprt &lhs_if_expr=to_if_expr(ssa_lhs);
@@ -568,7 +568,7 @@ void path_symext::assign_rec(
           ssa_lhs.id()==ID_byte_extract_big_endian)
   {
     #ifdef DEBUG
-    std::cout << "assign_rec ID_byte_extract" << std::endl;
+    std::cout << "assign_rec ID_byte_extract\n";
     #endif
 
     const byte_extract_exprt &byte_extract_expr=
@@ -698,7 +698,7 @@ void path_symext::function_call_rec(
   std::list<path_symex_statet> &further_states)
 {
   #ifdef DEBUG
-  std::cout << "function_call_rec: " << function.pretty() << std::endl;
+  std::cout << "function_call_rec: " << function.pretty() << '\n';
   #endif
 
   if(function.id()==ID_symbol)
@@ -1073,7 +1073,7 @@ void path_symext::operator()(
   std::cout << "path_symext::operator(): "
             << state.pc() << " "
             << instruction.type
-            << std::endl;
+            << '\n';
   #endif
 
   switch(instruction.type)

--- a/src/path-symex/path_symex_state.cpp
+++ b/src/path-symex/path_symex_state.cpp
@@ -82,14 +82,14 @@ Function: path_symex_statet::output
 
 void path_symex_statet::output(const threadt &thread, std::ostream &out) const
 {
-  out << "  PC: " << thread.pc << std::endl;
+  out << "  PC: " << thread.pc << '\n';
   out << "  Call stack:";
   for(call_stackt::const_iterator
       it=thread.call_stack.begin();
       it!=thread.call_stack.end();
       it++)
-    out << " " << it->return_location << std::endl;
-  out << std::endl;
+    out << " " << it->return_location << '\n';
+  out << '\n';
 }
 
 /*******************************************************************\
@@ -108,9 +108,9 @@ void path_symex_statet::output(std::ostream &out) const
 {
   for(unsigned t=0; t<threads.size(); t++)
   {
-    out << "*** Thread " << t << std::endl;
+    out << "*** Thread " << t << '\n';
     output(threads[t], out);
-    out << std::endl;
+    out << '\n';
   }
 }
 

--- a/src/path-symex/path_symex_state_read.cpp
+++ b/src/path-symex/path_symex_state_read.cpp
@@ -33,7 +33,7 @@ Function: path_symex_statet::read
 exprt path_symex_statet::read(const exprt &src, bool propagate)
 {
   #ifdef DEBUG
-  // std::cout << "path_symex_statet::read " << src.pretty() << std::endl;
+  // std::cout << "path_symex_statet::read " << src.pretty() << '\n';
   #endif
 
   // This has three phases!
@@ -49,7 +49,7 @@ exprt path_symex_statet::read(const exprt &src, bool propagate)
   exprt tmp5=simplify_expr(tmp4, var_map.ns);
 
   #ifdef DEBUG
-  // std::cout << " ==> " << tmp.pretty() << std::endl;
+  // std::cout << " ==> " << tmp.pretty() << '\n';
   #endif
 
   return tmp5;
@@ -71,7 +71,7 @@ exprt path_symex_statet::expand_structs_and_arrays(const exprt &src)
 {
   #ifdef DEBUG
   std::cout << "expand_structs_and_arrays: "
-            << from_expr(var_map.ns, "", src) << std::endl;
+            << from_expr(var_map.ns, "", src) << '\n';
   #endif
 
   const typet &src_type=var_map.ns.follow(src.type());
@@ -262,7 +262,7 @@ exprt path_symex_statet::instantiate_rec(
 {
   #ifdef DEBUG
   std::cout << "instantiate_rec: "
-            << from_expr(var_map.ns, "", src) << std::endl;
+            << from_expr(var_map.ns, "", src) << '\n';
   #endif
 
   // check whether this is a symbol(.member|[index])*
@@ -451,7 +451,7 @@ exprt path_symex_statet::read_symbol_member_index(
 
   #ifdef DEBUG
   std::cout << "read_symbol_member_index_rec " << identifier
-            << " var_info " << var_info.full_identifier << std::endl;
+            << " var_info " << var_info.full_identifier << '\n';
   #endif
 
   // warning: reference is not stable
@@ -627,7 +627,7 @@ exprt path_symex_statet::instantiate_rec_address(
   bool propagate)
 {
   #ifdef DEBUG
-  std::cout << "instantiate_rec_address: " << src.id() << std::endl;
+  std::cout << "instantiate_rec_address: " << src.id() << '\n';
   #endif
 
   if(src.id()==ID_symbol)
@@ -687,7 +687,7 @@ exprt path_symex_statet::instantiate_rec_address(
   {
     // this shouldn't really happen
     #ifdef DEBUG
-    std::cout << "SRC: " << src.pretty() << std::endl;
+    std::cout << "SRC: " << src.pretty() << '\n';
     #endif
     throw "address of unexpected `"+src.id_string()+"'";
   }

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -44,7 +44,7 @@ exprt dereferencet::operator()(const exprt &pointer)
   const typet &type=pointer.type().subtype();
 
   #ifdef DEBUG
-  std::cout << "DEREF: " << from_expr(ns, "", pointer) << std::endl;
+  std::cout << "DEREF: " << from_expr(ns, "", pointer) << '\n';
   #endif
 
   return dereference_rec(

--- a/src/pointer-analysis/show_value_sets.cpp
+++ b/src/pointer-analysis/show_value_sets.cpp
@@ -36,7 +36,7 @@ void show_value_sets(
     {
       xmlt xml;
       convert(goto_functions, value_set_analysis, xml);
-      std::cout << xml << std::endl;
+      std::cout << xml << '\n';
     }
     break;
 
@@ -73,7 +73,7 @@ void show_value_sets(
     {
       xmlt xml;
       convert(goto_program, value_set_analysis, xml);
-      std::cout << xml << std::endl;
+      std::cout << xml << '\n';
     }
     break;
 

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -224,7 +224,7 @@ void value_sett::output(
       }
     }
 
-    out << " } " << std::endl;
+    out << " } \n";
   }
 }
 
@@ -432,7 +432,7 @@ void value_sett::get_value_set(
   #if 0
   for(value_setst::valuest::const_iterator it=dest.begin();
       it!=dest.end(); it++)
-    std::cout << "GET_VALUE_SET: " << from_expr(ns, "", *it) << std::endl;
+    std::cout << "GET_VALUE_SET: " << from_expr(ns, "", *it) << '\n';
   #endif
 }
 
@@ -482,7 +482,7 @@ void value_sett::get_value_set_rec(
 {
   #if 0
   std::cout << "GET_VALUE_SET_REC EXPR: " << from_expr(ns, "", expr) << "\n";
-  std::cout << "GET_VALUE_SET_REC SUFFIX: " << suffix << std::endl;
+  std::cout << "GET_VALUE_SET_REC SUFFIX: " << suffix << '\n';
   #endif
 
   const typet &expr_type=ns.follow(expr.type());
@@ -985,7 +985,7 @@ void value_sett::get_value_set_rec(
   else
   {
     #if 0
-    std::cout << "WARNING: not doing " << expr.id() << std::endl;
+    std::cout << "WARNING: not doing " << expr.id() << '\n';
     #endif
   }
 
@@ -1079,7 +1079,7 @@ void value_sett::get_reference_set_rec(
 {
   #if 0
   std::cout << "GET_REFERENCE_SET_REC EXPR: " << from_expr(ns, "", expr)
-            << std::endl;
+            << '\n';
   #endif
 
   if(expr.id()==ID_symbol ||
@@ -1105,7 +1105,7 @@ void value_sett::get_reference_set_rec(
     #if 0
     for(expr_sett::const_iterator it=value_set.begin();
         it!=value_set.end(); it++)
-      std::cout << "VALUE_SET: " << from_expr(ns, "", *it) << std::endl;
+      std::cout << "VALUE_SET: " << from_expr(ns, "", *it) << '\n';
     #endif
 
     return;
@@ -1250,8 +1250,8 @@ void value_sett::assign(
   bool add_to_sets)
 {
   #if 0
-  std::cout << "ASSIGN LHS: " << from_expr(ns, "", lhs) << std::endl;
-  std::cout << "ASSIGN RHS: " << from_expr(ns, "", rhs) << std::endl;
+  std::cout << "ASSIGN LHS: " << from_expr(ns, "", lhs) << '\n';
+  std::cout << "ASSIGN RHS: " << from_expr(ns, "", rhs) << '\n';
   output(ns, std::cout);
   #endif
 
@@ -1475,16 +1475,16 @@ void value_sett::assign_rec(
   bool add_to_sets)
 {
   #if 0
-  std::cout << "ASSIGN_REC LHS: " << from_expr(ns, "", lhs) << std::endl;
-  std::cout << "ASSIGN_REC LHS ID: " << lhs.id() << std::endl;
-  std::cout << "ASSIGN_REC SUFFIX: " << suffix << std::endl;
+  std::cout << "ASSIGN_REC LHS: " << from_expr(ns, "", lhs) << '\n';
+  std::cout << "ASSIGN_REC LHS ID: " << lhs.id() << '\n';
+  std::cout << "ASSIGN_REC SUFFIX: " << suffix << '\n';
 
   for(object_map_dt::const_iterator it=values_rhs.read().begin();
       it!=values_rhs.read().end();
       it++)
     std::cout << "ASSIGN_REC RHS: " <<
-      from_expr(ns, "", object_numbering[it->first]) << std::endl;
-  std::cout << std::endl;
+      from_expr(ns, "", object_numbering[it->first]) << '\n';
+  std::cout << '\n';
   #endif
 
   if(lhs.id()==ID_symbol)
@@ -1821,7 +1821,7 @@ void value_sett::apply_code(
   }
   else
   {
-    // std::cerr << code.pretty() << std::endl;
+    // std::cerr << code.pretty() << '\n';
     throw "value_sett: unexpected statement: "+id2string(statement);
   }
 }

--- a/src/pointer-analysis/value_set_analysis_fivr.h
+++ b/src/pointer-analysis/value_set_analysis_fivr.h
@@ -47,11 +47,11 @@ public:
   {
     forall_goto_program_instructions(it, goto_program)
     {
-      out << "**** " << it->source_location << std::endl;
+      out << "**** " << it->source_location << '\n';
       output(it, out);
-      out << std::endl;
+      out << '\n';
       goto_program.output_instruction(ns, "", out, it);
-      out << std::endl;
+      out << '\n';
     }
   }
 

--- a/src/pointer-analysis/value_set_analysis_fivrns.h
+++ b/src/pointer-analysis/value_set_analysis_fivrns.h
@@ -49,11 +49,11 @@ public:
   {
     forall_goto_program_instructions(it, goto_program)
     {
-      out << "**** " << it->source_location << std::endl;
+      out << "**** " << it->source_location << '\n';
       output(it, out);
-      out << std::endl;
+      out << '\n';
       goto_program.output_instruction(ns, "", out, it);
-      out << std::endl;
+      out << '\n';
     }
   }
 

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -122,7 +122,7 @@ exprt value_set_dereferencet::dereference(
   const typet &type=pointer.type().subtype();
 
   #if 0
-  std::cout << "DEREF: " << from_expr(ns, "", pointer) << std::endl;
+  std::cout << "DEREF: " << from_expr(ns, "", pointer) << '\n';
   #endif
 
   // collect objects the pointer may point to
@@ -135,7 +135,7 @@ exprt value_set_dereferencet::dereference(
       it=points_to_set.begin();
       it!=points_to_set.end();
       it++)
-    std::cout << "P: " << from_expr(ns, "", *it) << std::endl;
+    std::cout << "P: " << from_expr(ns, "", *it) << '\n';
   #endif
 
   // get the values of these
@@ -151,7 +151,7 @@ exprt value_set_dereferencet::dereference(
 
     #if 0
     std::cout << "V: " << from_expr(ns, "", value.pointer_guard) << " --> ";
-    std::cout << from_expr(ns, "", value.value) << std::endl;
+    std::cout << from_expr(ns, "", value.value) << '\n';
     #endif
 
     values.push_back(value);
@@ -235,8 +235,7 @@ exprt value_set_dereferencet::dereference(
   }
 
   #if 0
-  std::cout << "R: " << from_expr(ns, "", value) << std::endl
-            << std::endl;
+  std::cout << "R: " << from_expr(ns, "", value) << "\n\n";
   #endif
 
   return value;
@@ -353,7 +352,7 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
   const exprt &object=o.object();
 
   #if 0
-  std::cout << "O: " << from_expr(ns, "", root_object) << std::endl;
+  std::cout << "O: " << from_expr(ns, "", root_object) << '\n';
   #endif
 
   valuet result;

--- a/src/pointer-analysis/value_set_domain_fi.cpp
+++ b/src/pointer-analysis/value_set_domain_fi.cpp
@@ -35,7 +35,7 @@ bool value_set_domain_fit::transform(
 
 //  std::cout << "transforming: " <<
 //      from_l->function << " " << from_l->location_number << " to " <<
-//      to_l->function << " " << to_l->location_number << std::endl;
+//      to_l->function << " " << to_l->location_number << '\n';
 
   switch(from_l->type)
   {

--- a/src/pointer-analysis/value_set_domain_fivr.cpp
+++ b/src/pointer-analysis/value_set_domain_fivr.cpp
@@ -34,7 +34,7 @@ bool value_set_domain_fivrt::transform(
   #if 0
   std::cout << "Transforming: " <<
     from_l->function << " " << from_l->location_number << " to " <<
-    to_l->function << " " << to_l->location_number << std::endl;
+    to_l->function << " " << to_l->location_number << '\n';
   #endif
 
   switch(from_l->type)

--- a/src/pointer-analysis/value_set_domain_fivrns.cpp
+++ b/src/pointer-analysis/value_set_domain_fivrns.cpp
@@ -34,7 +34,7 @@ bool value_set_domain_fivrnst::transform(
   #if 0
   std::cout << "Transforming: " <<
     from_l->function << " " << from_l->location_number << " to " <<
-    to_l->function << " " << to_l->location_number << std::endl;
+    to_l->function << " " << to_l->location_number << '\n';
   #endif
 
   switch(from_l->type)

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -161,14 +161,14 @@ void value_set_fit::flatten(
   object_mapt &dest) const
 {
   #if 0
-  std::cout << "FLATTEN: " << e.identifier << e.suffix << std::endl;
+  std::cout << "FLATTEN: " << e.identifier << e.suffix << '\n';
   #endif
 
   flatten_seent seen;
   flatten_rec(e, dest, seen);
 
   #if 0
-  std::cout << "FLATTEN: Done." << std::endl;
+  std::cout << "FLATTEN: Done.\n";
   #endif
 }
 
@@ -190,7 +190,7 @@ void value_set_fit::flatten_rec(
   flatten_seent &seen) const
 {
   #if 0
-  std::cout << "FLATTEN_REC: " << e.identifier << e.suffix << std::endl;
+  std::cout << "FLATTEN_REC: " << e.identifier << e.suffix << '\n';
   #endif
 
   std::string identifier = id2string(e.identifier);
@@ -433,7 +433,7 @@ void value_set_fit::get_value_set(
 
   #if 0
   for(expr_sett::const_iterator it=value_set.begin(); it!=value_set.end(); it++)
-    std::cout << "GET_VALUE_SET: " << from_expr(ns, "", *it) << std::endl;
+    std::cout << "GET_VALUE_SET: " << from_expr(ns, "", *it) << '\n';
   #endif
 }
 
@@ -483,9 +483,9 @@ void value_set_fit::get_value_set_rec(
 {
   #if 0
   std::cout << "GET_VALUE_SET_REC EXPR: " << from_expr(ns, "", expr)
-            << std::endl;
-  std::cout << "GET_VALUE_SET_REC SUFFIX: " << suffix << std::endl;
-  std::cout << std::endl;
+            << '\n';
+  std::cout << "GET_VALUE_SET_REC SUFFIX: " << suffix << '\n';
+  std::cout << '\n';
   #endif
 
   if(expr.type().id()=="#REF#")
@@ -924,7 +924,7 @@ void value_set_fit::get_reference_set_sharing_rec(
 {
   #if 0
   std::cout << "GET_REFERENCE_SET_REC EXPR: " << from_expr(ns, "", expr)
-            << std::endl;
+            << '\n';
   #endif
 
   if(expr.type().id()=="#REF#")
@@ -999,7 +999,7 @@ void value_set_fit::get_reference_set_sharing_rec(
     for(expr_sett::const_iterator it=value_set.begin();
         it!=value_set.end();
         it++)
-      std::cout << "VALUE_SET: " << from_expr(ns, "", *it) << std::endl;
+      std::cout << "VALUE_SET: " << from_expr(ns, "", *it) << '\n';
     #endif
 
     return;
@@ -1133,8 +1133,8 @@ void value_set_fit::assign(
   const namespacet &ns)
 {
   #if 0
-  std::cout << "ASSIGN LHS: " << from_expr(ns, "", lhs) << std::endl;
-  std::cout << "ASSIGN RHS: " << from_expr(ns, "", rhs) << std::endl;
+  std::cout << "ASSIGN LHS: " << from_expr(ns, "", lhs) << '\n';
+  std::cout << "ASSIGN RHS: " << from_expr(ns, "", rhs) << '\n';
   #endif
 
   if(rhs.id()==ID_if)
@@ -1399,12 +1399,12 @@ void value_set_fit::assign_rec(
   assign_recursion_sett &recursion_set)
 {
   #if 0
-  std::cout << "ASSIGN_REC LHS: " << from_expr(ns, "", lhs) << std::endl;
-  std::cout << "ASSIGN_REC SUFFIX: " << suffix << std::endl;
+  std::cout << "ASSIGN_REC LHS: " << from_expr(ns, "", lhs) << '\n';
+  std::cout << "ASSIGN_REC SUFFIX: " << suffix << '\n';
 
   for(object_map_dt::const_iterator it=values_rhs.read().begin();
       it!=values_rhs.read().end(); it++)
-    std::cout << "ASSIGN_REC RHS: " << to_expr(it) << std::endl;
+    std::cout << "ASSIGN_REC RHS: " << to_expr(it) << '\n';
   #endif
 
   if(lhs.type().id()=="#REF#")

--- a/src/pointer-analysis/value_set_fivr.cpp
+++ b/src/pointer-analysis/value_set_fivr.cpp
@@ -182,7 +182,7 @@ void value_set_fivrt::output(
       if(vr != object_map.read().validity_ranges.end())
       {
         if(vr->second.empty())
-          std::cout << "        Empty validity record" << std::endl;
+          std::cout << "        Empty validity record\n";
         else
         {
           for(object_map_dt::vrange_listt::const_iterator vit =
@@ -196,13 +196,13 @@ void value_set_fivrt::output(
                 from_target_index>=vit->from &&
                 from_target_index<=vit->to)
               out << " (*)";
-            out << std::endl;
+            out << '\n';
           }
         }
       }
       else
       {
-        out << "        No validity information" << std::endl;
+        out << "        No validity information\n";
       }
       #endif
 
@@ -238,14 +238,14 @@ void value_set_fivrt::flatten(
         object_mapt &dest) const
 {
   #if 0
-  std::cout << "FLATTEN: " << e.identifier << e.suffix << std::endl;
+  std::cout << "FLATTEN: " << e.identifier << e.suffix << '\n';
   #endif
 
   flatten_seent seen;
   flatten_rec(e, dest, seen, from_function, from_target_index);
 
   #if 0
-  std::cout << "FLATTEN: Done." << std::endl;
+  std::cout << "FLATTEN: Done.\n";
   #endif
 }
 
@@ -269,7 +269,7 @@ void value_set_fivrt::flatten_rec(
         unsigned at_index) const
 {
   #if 0
-  std::cout << "FLATTEN_REC: " << e.identifier << e.suffix << std::endl;
+  std::cout << "FLATTEN_REC: " << e.identifier << e.suffix << '\n';
   #endif
 
   std::string identifier=id2string(e.identifier);
@@ -560,7 +560,7 @@ void value_set_fivrt::get_value_set(
   for(std::list<exprt>::const_iterator it=value_set.begin();
       it!=value_set.end();
       it++)
-    std::cout << "GET_VALUE_SET: " << from_expr(ns, "", *it) << std::endl;
+    std::cout << "GET_VALUE_SET: " << from_expr(ns, "", *it) << '\n';
   #endif
 }
 
@@ -609,9 +609,9 @@ void value_set_fivrt::get_value_set_rec(
   gvs_recursion_sett &recursion_set) const
 {
   #if 0
-  std::cout << "GET_VALUE_SET_REC EXPR: " << expr << std::endl;
-  std::cout << "GET_VALUE_SET_REC SUFFIX: " << suffix << std::endl;
-  std::cout << std::endl;
+  std::cout << "GET_VALUE_SET_REC EXPR: " << expr << '\n';
+  std::cout << "GET_VALUE_SET_REC SUFFIX: " << suffix << '\n';
+  std::cout << '\n';
   #endif
 
   if(expr.type().id()=="#REF#")
@@ -1050,7 +1050,7 @@ void value_set_fivrt::get_reference_set_sharing_rec(
 {
   #if 0
   std::cout << "GET_REFERENCE_SET_REC EXPR: " << from_expr(ns, "", expr)
-            << std::endl;
+            << '\n';
   #endif
 
   if(expr.type().id()=="#REF#")
@@ -1125,7 +1125,7 @@ void value_set_fivrt::get_reference_set_sharing_rec(
     for(expr_sett::const_iterator it=value_set.begin();
         it!=value_set.end();
         it++)
-      std::cout << "VALUE_SET: " << from_expr(ns, "", *it) << std::endl;
+      std::cout << "VALUE_SET: " << from_expr(ns, "", *it) << '\n';
     #endif
 
     return;
@@ -1262,9 +1262,9 @@ void value_set_fivrt::assign(
   bool add_to_sets)
 {
   #if 0
-  std::cout << "ASSIGN LHS: " << lhs << std::endl;
-  std::cout << "ASSIGN LTYPE: " << ns.follow(lhs.type()) << std::endl;
-  std::cout << "ASSIGN RHS: " << from_expr(ns, "", rhs) << std::endl;
+  std::cout << "ASSIGN LHS: " << lhs << '\n';
+  std::cout << "ASSIGN LTYPE: " << ns.follow(lhs.type()) << '\n';
+  std::cout << "ASSIGN RHS: " << from_expr(ns, "", rhs) << '\n';
   #endif
 
   if(rhs.id()==ID_if)
@@ -1373,7 +1373,7 @@ void value_set_fivrt::assign(
       if(rhs.id()==ID_array_of)
       {
         assert(rhs.operands().size()==1);
-//        std::cout << "AOF: " << rhs.op0() << std::endl;
+//        std::cout << "AOF: " << rhs.op0() << '\n';
         assign(lhs_index, rhs.op0(), ns, add_to_sets);
       }
       else if(rhs.id()==ID_array ||
@@ -1528,12 +1528,12 @@ void value_set_fivrt::assign_rec(
   bool add_to_sets)
 {
   #if 0
-  std::cout << "ASSIGN_REC LHS: " << lhs << std::endl;
-  std::cout << "ASSIGN_REC SUFFIX: " << suffix << std::endl;
+  std::cout << "ASSIGN_REC LHS: " << lhs << '\n';
+  std::cout << "ASSIGN_REC SUFFIX: " << suffix << '\n';
 
   for(object_map_dt::const_iterator it=values_rhs.read().begin();
       it!=values_rhs.read().end(); it++)
-    std::cout << "ASSIGN_REC RHS: " << to_expr(it) << std::endl;
+    std::cout << "ASSIGN_REC RHS: " << to_expr(it) << '\n';
   #endif
 
   if(lhs.type().id()=="#REF#")
@@ -1733,7 +1733,7 @@ void value_set_fivrt::do_function_call(
                                  "argument$"+std::to_string(i);
     add_var(identifier, "");
     exprt dummy_lhs=symbol_exprt(identifier, arguments[i].type());
-//    std::cout << arguments[i] << std::endl;
+//    std::cout << arguments[i] << '\n';
 
     assign(dummy_lhs, arguments[i], ns, true);
 
@@ -1925,7 +1925,7 @@ bool value_set_fivrt::insert_to(
   object_map_dt &map=dest.write();
   if(map.find(n)==map.end())
   {
-//    std::cout << "NEW(" << n << "): " << object_numbering[n] << std::endl;
+//    std::cout << "NEW(" << n << "): " << object_numbering[n] << '\n';
     // new
     map[n]=object;
     map.set_valid_at(n, to_function, to_target_index);
@@ -1933,7 +1933,7 @@ bool value_set_fivrt::insert_to(
   }
   else
   {
-//    std::cout << "UPD " << n << std::endl;
+//    std::cout << "UPD " << n << '\n';
     objectt &old=map[n];
 
     bool res=map.set_valid_at(n, to_function, to_target_index);
@@ -1978,7 +1978,7 @@ bool value_set_fivrt::insert_from(
   object_map_dt &map=dest.write();
   if(map.find(n)==map.end())
   {
-//    std::cout << "NEW(" << n << "): " << object_numbering[n] << std::endl;
+//    std::cout << "NEW(" << n << "): " << object_numbering[n] << '\n';
     // new
     map[n]=object;
     map.set_valid_at(n, from_function, from_target_index);
@@ -1986,7 +1986,7 @@ bool value_set_fivrt::insert_from(
   }
   else
   {
-//    std::cout << "UPD " << n << std::endl;
+//    std::cout << "UPD " << n << '\n';
     objectt &old=map[n];
 
     bool res=map.set_valid_at(n, from_function, from_target_index);
@@ -2138,7 +2138,7 @@ bool value_set_fivrt::object_map_dt::is_valid_at(
 {
   #if 0
     std::cout << "IS_VALID_AT: " << inx << ", " << f << ", line " << line <<
-      std::endl;
+      '\n';
   #endif
 
   validity_rangest::const_iterator vrs=validity_ranges.find(inx);
@@ -2240,7 +2240,7 @@ bool value_set_fivrt::handover(void)
 
     if(t_it==temporary_values.end())
     {
-//      std::cout << "OLD VALUES FOR: " << ident << std::endl;
+//      std::cout << "OLD VALUES FOR: " << ident << '\n';
       Forall_valid_objects(o_it, state_map.write())
       {
         if(state_map.write().set_valid_at(o_it->first,
@@ -2250,7 +2250,7 @@ bool value_set_fivrt::handover(void)
     }
     else
     {
-//      std::cout << "NEW VALUES FOR: " << ident << std::endl;
+//      std::cout << "NEW VALUES FOR: " << ident << '\n';
       if(make_union(state_map, t_it->second.object_map))
         changed=true;
     }

--- a/src/pointer-analysis/value_set_fivrns.cpp
+++ b/src/pointer-analysis/value_set_fivrns.cpp
@@ -182,7 +182,7 @@ void value_set_fivrnst::output_entry(
     if(vr != object_map.read().validity_ranges.end())
     {
       if(vr->second.empty())
-        std::cout << "        Empty validity record" << std::endl;
+        std::cout << "        Empty validity record\n";
       else
       {
         for(object_map_dt::vrange_listt::const_iterator vit =
@@ -196,13 +196,13 @@ void value_set_fivrnst::output_entry(
               from_target_index>=vit->from &&
               from_target_index<=vit->to)
             out << " (*)";
-          out << std::endl;
+          out << '\n';
         }
       }
     }
     else
     {
-      out << "        No validity information" << std::endl;
+      out << "        No validity information\n";
     }
     #endif
 
@@ -358,7 +358,7 @@ void value_set_fivrnst::get_value_set(
   #if 0
   for(std::list<exprt>::const_iterator it=value_set.begin();
       it!=value_set.end(); it++)
-    std::cout << "GET_VALUE_SET: " << from_expr(ns, "", *it) << std::endl;
+    std::cout << "GET_VALUE_SET: " << from_expr(ns, "", *it) << '\n';
   #endif
 }
 
@@ -405,9 +405,9 @@ void value_set_fivrnst::get_value_set_rec(
   const namespacet &ns) const
 {
   #if 0
-  std::cout << "GET_VALUE_SET_REC EXPR: " << expr << std::endl;
-  std::cout << "GET_VALUE_SET_REC SUFFIX: " << suffix << std::endl;
-  std::cout << std::endl;
+  std::cout << "GET_VALUE_SET_REC EXPR: " << expr << '\n';
+  std::cout << "GET_VALUE_SET_REC SUFFIX: " << suffix << '\n';
+  std::cout << '\n';
   #endif
 
   if(expr.id()==ID_unknown || expr.id()==ID_invalid)
@@ -763,7 +763,7 @@ void value_set_fivrnst::get_reference_set_rec(
 {
   #if 0
   std::cout << "GET_REFERENCE_SET_REC EXPR: " << from_expr(ns, "", expr)
-            << std::endl;
+            << '\n';
   #endif
 
   if(expr.id()==ID_symbol ||
@@ -788,7 +788,7 @@ void value_set_fivrnst::get_reference_set_rec(
     #if 0
     for(expr_sett::const_iterator it=value_set.begin();
         it!=value_set.end(); it++)
-      std::cout << "VALUE_SET: " << from_expr(ns, "", *it) << std::endl;
+      std::cout << "VALUE_SET: " << from_expr(ns, "", *it) << '\n';
     #endif
 
     return;
@@ -925,9 +925,9 @@ void value_set_fivrnst::assign(
   bool add_to_sets)
 {
   #if 0
-  std::cout << "ASSIGN LHS: " << lhs << std::endl;
-  std::cout << "ASSIGN LTYPE: " << ns.follow(lhs.type()) << std::endl;
-  std::cout << "ASSIGN RHS: " << from_expr(ns, "", rhs) << std::endl;
+  std::cout << "ASSIGN LHS: " << lhs << '\n';
+  std::cout << "ASSIGN LTYPE: " << ns.follow(lhs.type()) << '\n';
+  std::cout << "ASSIGN RHS: " << from_expr(ns, "", rhs) << '\n';
   #endif
 
   if(rhs.id()==ID_if)
@@ -1036,7 +1036,7 @@ void value_set_fivrnst::assign(
       if(rhs.id()==ID_array_of)
       {
         assert(rhs.operands().size()==1);
-//        std::cout << "AOF: " << rhs.op0() << std::endl;
+//        std::cout << "AOF: " << rhs.op0() << '\n';
         assign(lhs_index, rhs.op0(), ns, add_to_sets);
       }
       else if(rhs.id()==ID_array ||
@@ -1186,12 +1186,12 @@ void value_set_fivrnst::assign_rec(
   bool add_to_sets)
 {
   #if 0
-  std::cout << "ASSIGN_REC LHS: " << lhs << std::endl;
-  std::cout << "ASSIGN_REC SUFFIX: " << suffix << std::endl;
+  std::cout << "ASSIGN_REC LHS: " << lhs << '\n';
+  std::cout << "ASSIGN_REC SUFFIX: " << suffix << '\n';
 
   for(object_map_dt::const_iterator it=values_rhs.read().begin();
       it!=values_rhs.read().end(); it++)
-    std::cout << "ASSIGN_REC RHS: " << to_expr(it) << std::endl;
+    std::cout << "ASSIGN_REC RHS: " << to_expr(it) << '\n';
   #endif
 
   if(lhs.id()==ID_symbol)
@@ -1360,7 +1360,7 @@ void value_set_fivrnst::do_function_call(
                                  "argument$"+std::to_string(i);
     add_var(identifier, "");
     exprt dummy_lhs=symbol_exprt(identifier, arguments[i].type());
-//    std::cout << arguments[i] << std::endl;
+//    std::cout << arguments[i] << '\n';
 
     assign(dummy_lhs, arguments[i], ns, true);
 
@@ -1557,7 +1557,7 @@ bool value_set_fivrnst::insert_to(
   object_map_dt &map = dest.write();
   if(map.find(n)==map.end())
   {
-//    std::cout << "NEW(" << n << "): " << object_numbering[n] << std::endl;
+//    std::cout << "NEW(" << n << "): " << object_numbering[n] << '\n';
     // new
     map[n]=object;
     map.set_valid_at(n, to_function, to_target_index);
@@ -1565,7 +1565,7 @@ bool value_set_fivrnst::insert_to(
   }
   else
   {
-//    std::cout << "UPD " << n << std::endl;
+//    std::cout << "UPD " << n << '\n';
     objectt &old=map[n];
 
     bool res = map.set_valid_at(n, to_function, to_target_index);
@@ -1610,7 +1610,7 @@ bool value_set_fivrnst::insert_from(
   object_map_dt &map = dest.write();
   if(map.find(n)==map.end())
   {
-//    std::cout << "NEW(" << n << "): " << object_numbering[n] << std::endl;
+//    std::cout << "NEW(" << n << "): " << object_numbering[n] << '\n';
     // new
     map[n]=object;
     map.set_valid_at(n, from_function, from_target_index);
@@ -1618,7 +1618,7 @@ bool value_set_fivrnst::insert_from(
   }
   else
   {
-//    std::cout << "UPD " << n << std::endl;
+//    std::cout << "UPD " << n << '\n';
     objectt &old=map[n];
 
     bool res = map.set_valid_at(n, from_function, from_target_index);
@@ -1745,7 +1745,7 @@ bool value_set_fivrnst::object_map_dt::is_valid_at(
 {
   #if 0
     std::cout << "IS_VALID_AT: " << inx << ", " << f << ", line " << line <<
-      std::endl;
+      '\n';
   #endif
 
   validity_rangest::const_iterator vrs = validity_ranges.find(inx);
@@ -1797,10 +1797,10 @@ bool value_set_fivrnst::handover(void)
 
     if(t_it==temporary_values.end())
     {
-//      std::cout << "OLD VALUES FOR: " << ident << std::endl;
+//      std::cout << "OLD VALUES FOR: " << ident << '\n';
       Forall_valid_objects(o_it, state_map.write())
       {
-//        std::cout << "STILL VALID: " << to_expr(o_it) << std::endl;
+//        std::cout << "STILL VALID: " << to_expr(o_it) << '\n';
         if(state_map.write().set_valid_at(o_it->first,
                                           to_function, to_target_index))
           changed = true;
@@ -1808,7 +1808,7 @@ bool value_set_fivrnst::handover(void)
     }
     else
     {
-//      std::cout << "NEW VALUES FOR: " << ident << std::endl;
+//      std::cout << "NEW VALUES FOR: " << ident << '\n';
       if(make_union(state_map, t_it->second.object_map))
         changed = true;
     }

--- a/src/solvers/cvc/cvc_conv.cpp
+++ b/src/solvers/cvc/cvc_conv.cpp
@@ -895,7 +895,7 @@ literalt cvc_convt::convert(const exprt &expr)
   convert_literal(l);
   out << " <=> (";
   convert_expr(expr);
-  out << ");" << std::endl << std::endl;
+  out << ");\n\n";
 
   return l;
 }
@@ -1467,7 +1467,7 @@ void cvc_convt::set_to(const exprt &expr, bool value)
     return;
   }
 
-  out << "%% set_to " << (value?"true":"false") << std::endl;
+  out << "%% set_to " << (value?"true":"false") << '\n';
 
   if(expr.id()==ID_equal && value)
   {
@@ -1497,7 +1497,7 @@ void cvc_convt::set_to(const exprt &expr, bool value)
           out << " = ";
           convert_expr(expr.op1());
 
-          out << ";" << std::endl << std::endl;
+          out << ";\n\n";
           return;
         }
       }
@@ -1516,7 +1516,7 @@ void cvc_convt::set_to(const exprt &expr, bool value)
   if(!value)
     out << ")";
 
-  out << ";" << std::endl << std::endl;
+  out << ";\n\n";
 }
 
 /*******************************************************************\
@@ -1554,7 +1554,7 @@ void cvc_convt::find_symbols(const exprt &expr)
       convert_identifier(id2string(identifier));
       out << ": ";
       convert_type(expr.type());
-      out << ";" << std::endl;
+      out << ";\n";
     }
   }
   else if(expr.id()==ID_nondet_symbol)
@@ -1573,7 +1573,7 @@ void cvc_convt::find_symbols(const exprt &expr)
       convert_identifier(id2string(identifier));
       out << ": ";
       convert_type(expr.type());
-      out << ";" << std::endl;
+      out << ";\n";
     }
   }
 }

--- a/src/solvers/cvc/cvc_dec.cpp
+++ b/src/solvers/cvc/cvc_dec.cpp
@@ -87,8 +87,8 @@ Function: cvc_dect::dec_solve
 
 decision_proceduret::resultt cvc_dect::dec_solve()
 {
-  out << "QUERY FALSE;" << std::endl;
-  out << "COUNTERMODEL;" << std::endl;
+  out << "QUERY FALSE;\n";
+  out << "COUNTERMODEL;\n";
 
   temp_out.close();
 
@@ -150,8 +150,7 @@ void cvc_dect::read_assert(std::istream &in, std::string &line)
     std::string value=std::string(line, pos, pos2-pos);
 
     #if 0
-    std::cout << ">" << identifier << "< = >" << value << "<";
-    std::cout << std::endl;
+    std::cout << ">" << identifier << "< = >" << value << "<\n";
     #endif
   }
   else

--- a/src/solvers/cvc/cvc_prop.cpp
+++ b/src/solvers/cvc/cvc_prop.cpp
@@ -59,10 +59,10 @@ Function: cvc_propt::land
 
 void cvc_propt::land(literalt a, literalt b, literalt o)
 {
-  out << "%% land" << std::endl;
+  out << "%% land\n";
   out << "ASSERT (" << cvc_literal(a) << " AND "
       << cvc_literal(b) << ") <=> " << cvc_literal(o)
-      << ";" << std::endl << std::endl;
+      << ";\n\n";
 }
 
 /*******************************************************************\
@@ -79,10 +79,10 @@ Function: cvc_propt::lor
 
 void cvc_propt::lor(literalt a, literalt b, literalt o)
 {
-  out << "%% lor" << std::endl;
+  out << "%% lor\n";
   out << "ASSERT (" << cvc_literal(a) << " OR "
       << cvc_literal(b) << ") <=> " << cvc_literal(o)
-      << ";" << std::endl << std::endl;
+      << ";\n\n";
 }
 
 /*******************************************************************\
@@ -99,10 +99,10 @@ Function: cvc_propt::lxor
 
 void cvc_propt::lxor(literalt a, literalt b, literalt o)
 {
-  out << "%% lxor" << std::endl;
+  out << "%% lxor\n";
   out << "ASSERT (" << cvc_literal(a) << " XOR "
       << cvc_literal(b) << ") <=> " << cvc_literal(o)
-      << ";" << std::endl << std::endl;
+      << ";\n\n";
 }
 
 /*******************************************************************\
@@ -119,10 +119,10 @@ Function: cvc_propt::lnand
 
 void cvc_propt::lnand(literalt a, literalt b, literalt o)
 {
-  out << "%% lnand" << std::endl;
+  out << "%% lnand\n";
   out << "ASSERT (NOT (" << cvc_literal(a) << " AND "
       << cvc_literal(b) << ")) <=> " << cvc_literal(o)
-      << ";" << std::endl << std::endl;
+      << ";\n\n";
 }
 
 /*******************************************************************\
@@ -139,10 +139,10 @@ Function: cvc_propt::lnor
 
 void cvc_propt::lnor(literalt a, literalt b, literalt o)
 {
-  out << "%% lnor" << std::endl;
+  out << "%% lnor\n";
   out << "ASSERT (NOT (" << cvc_literal(a) << " OR "
       << cvc_literal(b) << ")) <=> " << cvc_literal(o)
-      << ";" << std::endl << std::endl;
+      << ";\n\n";
 }
 
 /*******************************************************************\
@@ -159,10 +159,10 @@ Function: cvc_propt::lequal
 
 void cvc_propt::lequal(literalt a, literalt b, literalt o)
 {
-  out << "%% lequal" << std::endl;
+  out << "%% lequal\n";
   out << "ASSERT (" << cvc_literal(a) << " <=> "
       << cvc_literal(b) << ") <=> " << cvc_literal(o)
-      << ";" << std::endl << std::endl;
+      << ";\n\n";
 }
 
 /*******************************************************************\
@@ -179,10 +179,10 @@ Function: cvc_propt::limplies
 
 void cvc_propt::limplies(literalt a, literalt b, literalt o)
 {
-  out << "%% limplies" << std::endl;
+  out << "%% limplies\n";
   out << "ASSERT (" << cvc_literal(a) << " => "
       << cvc_literal(b) << ") <=> " << cvc_literal(o)
-      << ";" << std::endl << std::endl;
+      << ";\n\n";
 }
 
 /*******************************************************************\
@@ -199,7 +199,7 @@ Function: cvc_propt::land
 
 literalt cvc_propt::land(const bvt &bv)
 {
-  out << "%% land" << std::endl;
+  out << "%% land\n";
 
   literalt literal=def_cvc_literal();
 
@@ -210,7 +210,7 @@ literalt cvc_propt::land(const bvt &bv)
     out << cvc_literal(*it);
   }
 
-  out << ";" << std::endl << std::endl;
+  out << ";\n\n";
 
   return literal;
 }
@@ -229,7 +229,7 @@ Function: cvc_propt::lor
 
 literalt cvc_propt::lor(const bvt &bv)
 {
-  out << "%% lor" << std::endl;
+  out << "%% lor\n";
 
   literalt literal=def_cvc_literal();
 
@@ -240,7 +240,7 @@ literalt cvc_propt::lor(const bvt &bv)
     out << cvc_literal(*it);
   }
 
-  out << ";" << std::endl << std::endl;
+  out << ";\n\n";
 
   return literal;
 }
@@ -299,12 +299,11 @@ literalt cvc_propt::land(literalt a, literalt b)
   if(a==b)
     return a;
 
-  out << "%% land" << std::endl;
+  out << "%% land\n";
 
   literalt o=def_cvc_literal();
 
-  out << cvc_literal(a) << " AND " << cvc_literal(b) << ";"
-      << std::endl << std::endl;
+  out << cvc_literal(a) << " AND " << cvc_literal(b) << ";\n\n";
 
   return o;
 }
@@ -334,12 +333,11 @@ literalt cvc_propt::lor(literalt a, literalt b)
   if(a==b)
     return a;
 
-  out << "%% lor" << std::endl;
+  out << "%% lor\n";
 
   literalt o=def_cvc_literal();
 
-  out << cvc_literal(a) << " OR " << cvc_literal(b) << ";"
-      << std::endl << std::endl;
+  out << cvc_literal(a) << " OR " << cvc_literal(b) << ";\n\n";
 
   return o;
 }
@@ -367,12 +365,11 @@ literalt cvc_propt::lxor(literalt a, literalt b)
   if(b==const_literal(true))
     return !a;
 
-  out << "%% lxor" << std::endl;
+  out << "%% lxor\n";
 
   literalt o=def_cvc_literal();
 
-  out << cvc_literal(a) << " XOR " << cvc_literal(b) << ";"
-      << std::endl << std::endl;
+  out << cvc_literal(a) << " XOR " << cvc_literal(b) << ";\n\n";
 
   return o;
 }
@@ -466,14 +463,13 @@ literalt cvc_propt::lselect(literalt a, literalt b, literalt c)
   if(b==c)
     return b;
 
-  out << "%% lselect" << std::endl;
+  out << "%% lselect\n";
 
   literalt o=def_cvc_literal();
 
   out << "IF " << cvc_literal(a) << " THEN "
       << cvc_literal(b) << " ELSE "
-      << cvc_literal(c) << " ENDIF;"
-      << std::endl << std::endl;
+      << cvc_literal(c) << " ENDIF;\n\n";
 
   return o;
 }
@@ -492,7 +488,7 @@ Function: cvc_propt::new_variable
 
 literalt cvc_propt::new_variable()
 {
-  out << "l" << _no_variables << ": BOOLEAN;" << std::endl;
+  out << "l" << _no_variables << ": BOOLEAN;\n";
   literalt l;
   l.set(_no_variables, false);
   _no_variables++;
@@ -555,7 +551,7 @@ void cvc_propt::lcnf(const bvt &bv)
 
   assert(!new_bv.empty());
 
-  out << "%% lcnf" << std::endl;
+  out << "%% lcnf\n";
   out << "ASSERT ";
 
   for(bvt::const_iterator it=new_bv.begin(); it!=new_bv.end(); it++)
@@ -565,7 +561,7 @@ void cvc_propt::lcnf(const bvt &bv)
     out << cvc_literal(*it);
   }
 
-  out << ";" << std::endl << std::endl;
+  out << ";\n\n";
 }
 
 /*******************************************************************\
@@ -607,6 +603,6 @@ Function: cvc_propt::prop_solve
 
 propt::resultt cvc_propt::prop_solve()
 {
-  out << "QUERY FALSE;" << std::endl;
+  out << "QUERY FALSE;\n";
   return P_ERROR;
 }

--- a/src/solvers/dplib/dplib_conv.cpp
+++ b/src/solvers/dplib/dplib_conv.cpp
@@ -248,7 +248,7 @@ Function: dplib_convt::convert_rest
 
 literalt dplib_convt::convert_rest(const exprt &expr)
 {
-  // dplib_prop.out << "%% E: " << expr << std::endl;
+  // dplib_prop.out << "%% E: " << expr << '\n';
 
   literalt l=prop.new_variable();
 
@@ -262,7 +262,7 @@ literalt dplib_convt::convert_rest(const exprt &expr)
     convert_dplib_expr(expr.op0());
     dplib_prop.out << ((expr.id()==ID_equal)?"=":"/=");
     convert_dplib_expr(expr.op1());
-    dplib_prop.out << ");" << std::endl;
+    dplib_prop.out << ");\n";
   }
 
   return l;
@@ -1129,7 +1129,7 @@ void dplib_convt::set_to(const exprt &expr, bool value)
   if(value && expr.is_true())
     return;
 
-  dplib_prop.out << "// set_to " << (value?"true":"false") << std::endl;
+  dplib_prop.out << "// set_to " << (value?"true":"false") << '\n';
 
   if(expr.id()==ID_equal && value)
   {
@@ -1159,7 +1159,7 @@ void dplib_convt::set_to(const exprt &expr, bool value)
           dplib_prop.out << " = ";
           convert_dplib_expr(expr.op1());
 
-          dplib_prop.out << ";" << std::endl << std::endl;
+          dplib_prop.out << ";\n\n";
           return;
         }
       }
@@ -1178,7 +1178,7 @@ void dplib_convt::set_to(const exprt &expr, bool value)
   if(!value)
     dplib_prop.out << ")";
 
-  dplib_prop.out << ";" << std::endl << std::endl;
+  dplib_prop.out << ";\n\n";
 }
 
 /*******************************************************************\
@@ -1216,7 +1216,7 @@ void dplib_convt::find_symbols(const exprt &expr)
       convert_identifier(id2string(identifier));
       dplib_prop.out << ": ";
       convert_dplib_type(expr.type());
-      dplib_prop.out << ";" << std::endl;
+      dplib_prop.out << ";\n";
     }
   }
   else if(expr.id()==ID_nondet_symbol)
@@ -1235,7 +1235,7 @@ void dplib_convt::find_symbols(const exprt &expr)
       convert_identifier(id2string(identifier));
       dplib_prop.out << ": ";
       convert_dplib_type(expr.type());
-      dplib_prop.out << ";" << std::endl;
+      dplib_prop.out << ";\n";
     }
   }
 }

--- a/src/solvers/dplib/dplib_dec.cpp
+++ b/src/solvers/dplib/dplib_dec.cpp
@@ -86,8 +86,8 @@ Function: dplib_dect::dec_solve
 
 decision_proceduret::resultt dplib_dect::dec_solve()
 {
-  dplib_prop.out << "QUERY FALSE;" << std::endl;
-  dplib_prop.out << "COUNTERMODEL;" << std::endl;
+  dplib_prop.out << "QUERY FALSE;\n";
+  dplib_prop.out << "COUNTERMODEL;\n";
 
   post_process();
 
@@ -151,8 +151,7 @@ void dplib_dect::read_assert(std::istream &in, std::string &line)
     std::string value=std::string(line, pos, pos2-pos);
 
     #if 0
-    std::cout << ">" << identifier << "< = >" << value << "<";
-    std::cout << std::endl;
+    std::cout << ">" << identifier << "< = >" << value << "<\n";
     #endif
   }
   else

--- a/src/solvers/dplib/dplib_prop.cpp
+++ b/src/solvers/dplib/dplib_prop.cpp
@@ -45,10 +45,10 @@ Function: dplib_propt::land
 
 void dplib_propt::land(literalt a, literalt b, literalt o)
 {
-  out << "// land" << std::endl;
+  out << "// land\n";
   out << "AXIOM (" << dplib_literal(a) << " & "
       << dplib_literal(b) << ") <=> " << dplib_literal(o)
-      << ";" << std::endl << std::endl;
+      << ";\n\n";
 }
 
 /*******************************************************************\
@@ -65,10 +65,10 @@ Function: dplib_propt::lor
 
 void dplib_propt::lor(literalt a, literalt b, literalt o)
 {
-  out << "// lor" << std::endl;
+  out << "// lor\n";
   out << "AXIOM (" << dplib_literal(a) << " | "
       << dplib_literal(b) << ") <=> " << dplib_literal(o)
-      << ";" << std::endl << std::endl;
+      << ";\n\n";
 }
 
 /*******************************************************************\
@@ -85,10 +85,10 @@ Function: dplib_propt::lxor
 
 void dplib_propt::lxor(literalt a, literalt b, literalt o)
 {
-  out << "// lxor" << std::endl;
+  out << "// lxor\n";
   out << "AXIOM (" << dplib_literal(a) << " <=> "
       << dplib_literal(b) << ") <=> !" << dplib_literal(o)
-      << ";" << std::endl << std::endl;
+      << ";\n\n";
 }
 
 /*******************************************************************\
@@ -105,10 +105,10 @@ Function: dplib_propt::lnand
 
 void dplib_propt::lnand(literalt a, literalt b, literalt o)
 {
-  out << "// lnand" << std::endl;
+  out << "// lnand\n";
   out << "AXIOM (" << dplib_literal(a) << " & "
       << dplib_literal(b) << ") <=> !" << dplib_literal(o)
-      << ";" << std::endl << std::endl;
+      << ";\n\n";
 }
 
 /*******************************************************************\
@@ -125,10 +125,10 @@ Function: dplib_propt::lnor
 
 void dplib_propt::lnor(literalt a, literalt b, literalt o)
 {
-  out << "// lnor" << std::endl;
+  out << "// lnor\n";
   out << "AXIOM (" << dplib_literal(a) << " | "
       << dplib_literal(b) << ") <=> !" << dplib_literal(o)
-      << ";" << std::endl << std::endl;
+      << ";\n\n";
 }
 
 /*******************************************************************\
@@ -145,10 +145,10 @@ Function: dplib_propt::lequal
 
 void dplib_propt::lequal(literalt a, literalt b, literalt o)
 {
-  out << "// lequal" << std::endl;
+  out << "// lequal\n";
   out << "AXIOM (" << dplib_literal(a) << " <=> "
       << dplib_literal(b) << ") <=> " << dplib_literal(o)
-      << ";" << std::endl << std::endl;
+      << ";\n\n";
 }
 
 /*******************************************************************\
@@ -165,10 +165,10 @@ Function: dplib_propt::limplies
 
 void dplib_propt::limplies(literalt a, literalt b, literalt o)
 {
-  out << "// limplies" << std::endl;
+  out << "// limplies\n";
   out << "AXIOM (" << dplib_literal(a) << " => "
       << dplib_literal(b) << ") <=> " << dplib_literal(o)
-      << ";" << std::endl << std::endl;
+      << ";\n\n";
 }
 
 /*******************************************************************\
@@ -185,7 +185,7 @@ Function: dplib_propt::land
 
 literalt dplib_propt::land(const bvt &bv)
 {
-  out << "// land" << std::endl;
+  out << "// land\n";
 
   literalt literal=def_dplib_literal();
 
@@ -196,7 +196,7 @@ literalt dplib_propt::land(const bvt &bv)
     out << dplib_literal(*it);
   }
 
-  out << std::endl << std::endl;
+  out << "\n\n";
 
   return literal;
 }
@@ -215,7 +215,7 @@ Function: dplib_propt::lor
 
 literalt dplib_propt::lor(const bvt &bv)
 {
-  out << "// lor" << std::endl;
+  out << "// lor\n";
 
   literalt literal=def_dplib_literal();
 
@@ -226,7 +226,7 @@ literalt dplib_propt::lor(const bvt &bv)
     out << dplib_literal(*it);
   }
 
-  out << std::endl << std::endl;
+  out << "\n\n";
 
   return literal;
 }
@@ -287,7 +287,7 @@ literalt dplib_propt::land(literalt a, literalt b)
 
   literalt o=def_dplib_literal();
   out << dplib_literal(a) << " & " << dplib_literal(b)
-      << ";" << std::endl << std::endl;
+      << ";\n\n";
 
   return o;
 }
@@ -319,7 +319,7 @@ literalt dplib_propt::lor(literalt a, literalt b)
 
   literalt o=def_dplib_literal();
   out << dplib_literal(a) << " | " << dplib_literal(b)
-      << ";" << std::endl << std::endl;
+      << ";\n\n";
 
   return o;
 }
@@ -349,7 +349,7 @@ literalt dplib_propt::lxor(literalt a, literalt b)
 
   literalt o=def_dplib_literal();
   out << "!(" << dplib_literal(a) << " <-> " << dplib_literal(b)
-      << ");" << std::endl << std::endl;
+      << ");\n\n";
 
   return o;
 }
@@ -443,14 +443,13 @@ literalt dplib_propt::lselect(literalt a, literalt b, literalt c)
   if(b==c)
     return b;
 
-  out << "// lselect" << std::endl;
+  out << "// lselect\n";
 
   literalt o=def_dplib_literal();
 
   out << "IF " << dplib_literal(a) << " THEN "
       << dplib_literal(b) << " ELSE "
-      << dplib_literal(c) << " ENDIF;"
-      << std::endl << std::endl;
+      << dplib_literal(c) << " ENDIF;\n\n";
 
   return o;
 }
@@ -470,7 +469,7 @@ Function: dplib_propt::new_variable
 literalt dplib_propt::new_variable()
 {
   _no_variables++;
-  out << "l" << _no_variables << ": boolean;" << std::endl;
+  out << "l" << _no_variables << ": boolean;\n";
   literalt l;
   l.set(_no_variables, false);
   return l;
@@ -532,7 +531,7 @@ void dplib_propt::lcnf(const bvt &bv)
 
   assert(!new_bv.empty());
 
-  out << "// lcnf" << std::endl;
+  out << "// lcnf\n";
   out << "AXIOM ";
 
   for(bvt::const_iterator it=new_bv.begin(); it!=new_bv.end(); it++)
@@ -542,7 +541,7 @@ void dplib_propt::lcnf(const bvt &bv)
     out << dplib_literal(*it);
   }
 
-  out << ";" << std::endl << std::endl;
+  out << ";\n\n";
 }
 
 /*******************************************************************\
@@ -585,7 +584,7 @@ Function: dplib_propt::finish
 void dplib_propt::finish()
 {
   // we want satisfiability
-  out << "THEOREM false;" << std::endl;
+  out << "THEOREM false;\n";
 }
 
 /*******************************************************************\

--- a/src/solvers/flattening/arrays.cpp
+++ b/src/solvers/flattening/arrays.cpp
@@ -84,7 +84,7 @@ literalt arrayst::record_array_equality(
   // check types
   if(!base_type_eq(op0.type(), op1.type(), ns))
   {
-    std::cout << equality.pretty() << std::endl;
+    std::cout << equality.pretty() << '\n';
     throw "record_array_equality got equality without matching types";
   }
 
@@ -174,7 +174,7 @@ void arrayst::collect_arrays(const exprt &a)
     // check types
     if(!base_type_eq(array_type, a.op0().type(), ns))
     {
-      std::cout << a.pretty() << std::endl;
+      std::cout << a.pretty() << '\n';
       throw "collect_arrays got 'with' without matching types";
     }
 
@@ -196,7 +196,7 @@ void arrayst::collect_arrays(const exprt &a)
     // check types
     if(!base_type_eq(array_type, a.op0().type(), ns))
     {
-      std::cout << a.pretty() << std::endl;
+      std::cout << a.pretty() << '\n';
       throw "collect_arrays got 'update' without matching types";
     }
 
@@ -220,14 +220,14 @@ void arrayst::collect_arrays(const exprt &a)
     // check types
     if(!base_type_eq(array_type, a.op1().type(), ns))
     {
-      std::cout << a.pretty() << std::endl;
+      std::cout << a.pretty() << '\n';
       throw "collect_arrays got if without matching types";
     }
 
     // check types
     if(!base_type_eq(array_type, a.op2().type(), ns))
     {
-      std::cout << a.pretty() << std::endl;
+      std::cout << a.pretty() << '\n';
       throw "collect_arrays got if without matching types";
     }
 
@@ -390,7 +390,7 @@ void arrayst::add_array_Ackermann_constraints()
   // this is quadratic!
 
 #if 0
-  std::cout << "arrays.size(): " << arrays.size() << std::endl;
+  std::cout << "arrays.size(): " << arrays.size() << '\n';
 #endif
 
   // iterate over arrays
@@ -399,7 +399,7 @@ void arrayst::add_array_Ackermann_constraints()
     const index_sett &index_set=index_map[arrays.find_number(i)];
 
 #if 0
-    std::cout << "index_set.size(): " << index_set.size() << std::endl;
+    std::cout << "index_set.size(): " << index_set.size() << '\n';
 #endif
 
     // iterate over indices, 2x!
@@ -516,8 +516,8 @@ void arrayst::update_index_map(bool update_all)
                 << arrays.find_number(i1->first) << " = "
                 << from_expr(ns, "", arrays[arrays.find_number(i1->first)])
                 << "): "
-                << from_expr(ns, "", *i2) << std::endl;
-  std::cout << "-----" << std::endl;
+                << from_expr(ns, "", *i2) << '\n';
+  std::cout << "-----\n";
 #endif
 }
 
@@ -678,7 +678,7 @@ void arrayst::add_array_constraints_with(
 
     if(index_expr.type()!=value.type())
     {
-      std::cout << expr.pretty() << std::endl;
+      std::cout << expr.pretty() << '\n';
       assert(false);
     }
 
@@ -774,7 +774,7 @@ void arrayst::add_array_constraints_update(
 
     if(index_expr.type()!=value.type())
     {
-      std::cout << expr.pretty() << std::endl;
+      std::cout << expr.pretty() << '\n';
       assert(false);
     }
 

--- a/src/solvers/flattening/boolbv_add_sub.cpp
+++ b/src/solvers/flattening/boolbv_add_sub.cpp
@@ -53,7 +53,7 @@ bvt boolbvt::convert_add_sub(const exprt &expr)
 
   if(op0.type()!=type)
   {
-    std::cerr << expr.pretty() << std::endl;
+    std::cerr << expr.pretty() << '\n';
     throw "add/sub with mixed types";
   }
 
@@ -83,7 +83,7 @@ bvt boolbvt::convert_add_sub(const exprt &expr)
   {
     if(it->type()!=type)
     {
-      std::cerr << expr.pretty() << std::endl;
+      std::cerr << expr.pretty() << '\n';
       throw "add/sub with mixed types";
     }
 

--- a/src/solvers/flattening/boolbv_case.cpp
+++ b/src/solvers/flattening/boolbv_case.cpp
@@ -64,10 +64,9 @@ bvt boolbvt::convert_case(const exprt &expr)
       if(compare_bv.size()!=op.size())
       {
         std::cerr << "compare operand: " << compare_bv.size()
-                  << std::endl
-                  << "operand: " << op.size() << std::endl
+                  << "\noperand: " << op.size() << '\n'
                   << it->pretty()
-                  << std::endl;
+                  << '\n';
 
         throw "size of compare operand does not match";
       }
@@ -84,10 +83,9 @@ bvt boolbvt::convert_case(const exprt &expr)
       if(bv.size()!=op.size())
       {
         std::cerr << "result size: " << bv.size()
-                  << std::endl
-                  << "operand: " << op.size() << std::endl
+                  << "\noperand: " << op.size() << '\n'
                   << it->pretty()
-                  << std::endl;
+                  << '\n';
 
         throw "size of value operand does not match";
       }

--- a/src/solvers/flattening/boolbv_cond.cpp
+++ b/src/solvers/flattening/boolbv_cond.cpp
@@ -66,10 +66,9 @@ bvt boolbvt::convert_cond(const exprt &expr)
         if(bv.size()!=op.size())
         {
           std::cerr << "result size: " << bv.size()
-                    << std::endl
-                    << "operand: " << op.size() << std::endl
+                    << "\noperand: " << op.size() << '\n'
                     << it->pretty()
-                    << std::endl;
+                    << '\n';
 
           throw "size of value operand does not match";
         }

--- a/src/solvers/flattening/boolbv_equality.cpp
+++ b/src/solvers/flattening/boolbv_equality.cpp
@@ -32,8 +32,8 @@ literalt boolbvt::convert_equality(const equal_exprt &expr)
 {
   if(!base_type_eq(expr.lhs().type(), expr.rhs().type(), ns))
   {
-    std::cout << "######### lhs: " << expr.lhs().pretty() << std::endl;
-    std::cout << "######### rhs: " << expr.rhs().pretty() << std::endl;
+    std::cout << "######### lhs: " << expr.lhs().pretty() << '\n';
+    std::cout << "######### rhs: " << expr.rhs().pretty() << '\n';
     throw "equality without matching types";
   }
 
@@ -56,10 +56,10 @@ literalt boolbvt::convert_equality(const equal_exprt &expr)
 
   if(bv0.size()!=bv1.size())
   {
-    std::cerr << "lhs: " << expr.lhs().pretty() << std::endl;
-    std::cerr << "lhs size: " << bv0.size() << std::endl;
-    std::cerr << "rhs: " << expr.rhs().pretty() << std::endl;
-    std::cerr << "rhs size: " << bv1.size() << std::endl;
+    std::cerr << "lhs: " << expr.lhs().pretty() << '\n';
+    std::cerr << "lhs size: " << bv0.size() << '\n';
+    std::cerr << "rhs: " << expr.rhs().pretty() << '\n';
+    std::cerr << "rhs size: " << bv1.size() << '\n';
     throw "unexpected size mismatch on equality";
   }
 
@@ -93,8 +93,8 @@ literalt boolbvt::convert_verilog_case_equality(
 
   if(!base_type_eq(expr.lhs().type(), expr.rhs().type(), ns))
   {
-    std::cout << "######### lhs: " << expr.lhs().pretty() << std::endl;
-    std::cout << "######### rhs: " << expr.rhs().pretty() << std::endl;
+    std::cout << "######### lhs: " << expr.lhs().pretty() << '\n';
+    std::cout << "######### rhs: " << expr.rhs().pretty() << '\n';
     throw "verilog_case_equality without matching types";
   }
 
@@ -103,10 +103,10 @@ literalt boolbvt::convert_verilog_case_equality(
 
   if(bv0.size()!=bv1.size())
   {
-    std::cerr << "lhs: " << expr.lhs().pretty() << std::endl;
-    std::cerr << "lhs size: " << bv0.size() << std::endl;
-    std::cerr << "rhs: " << expr.rhs().pretty() << std::endl;
-    std::cerr << "rhs size: " << bv1.size() << std::endl;
+    std::cerr << "lhs: " << expr.lhs().pretty() << '\n';
+    std::cerr << "lhs size: " << bv0.size() << '\n';
+    std::cerr << "rhs: " << expr.rhs().pretty() << '\n';
+    std::cerr << "rhs size: " << bv1.size() << '\n';
     throw "unexpected size mismatch on verilog_case_equality";
   }
 

--- a/src/solvers/flattening/boolbv_floatbv_op.cpp
+++ b/src/solvers/flattening/boolbv_floatbv_op.cpp
@@ -115,7 +115,7 @@ bvt boolbvt::convert_floatbv_op(const exprt &expr)
 
   if(op0.type()!=type || op1.type()!=type)
   {
-    std::cerr << expr.pretty() << std::endl;
+    std::cerr << expr.pretty() << '\n';
     throw "float op with mixed types";
   }
 

--- a/src/solvers/flattening/boolbv_map.cpp
+++ b/src/solvers/flattening/boolbv_map.cpp
@@ -160,7 +160,7 @@ void boolbv_mapt::get_literals(
 
     #ifdef DEBUG
     std::cout << "NEW: " << identifier << ":" << bit
-              << "=" << l << std::endl;
+              << "=" << l << '\n';
     #endif
   }
 }

--- a/src/solvers/prop/prop_conv.cpp
+++ b/src/solvers/prop/prop_conv.cpp
@@ -293,7 +293,7 @@ literalt prop_conv_solvert::convert(const exprt &expr)
     prop.set_frozen(literal);
 
   #if 0
-  std::cout << literal << "=" << expr << std::endl;
+  std::cout << literal << "=" << expr << '\n';
   #endif
 
   return literal;

--- a/src/solvers/qbf/qbf_bdd_core.cpp
+++ b/src/solvers/qbf/qbf_bdd_core.cpp
@@ -220,7 +220,7 @@ propt::resultt qbf_bdd_coret::prop_solve()
     {
       #if 0
       std::cout << "BDD E: " << var << ", " <<
-        matrix->nodeCount() << " nodes" << std::endl;
+        matrix->nodeCount() << " nodes\n";
       #endif
 
       BDD *model=new BDD();
@@ -236,7 +236,7 @@ propt::resultt qbf_bdd_coret::prop_solve()
     {
       #if 0
       std::cout << "BDD A: " << var << ", " <<
-        matrix->nodeCount() << " nodes" << std::endl;
+        matrix->nodeCount() << " nodes\n";
       #endif
 
       *matrix=matrix->UnivAbstract(*bdd_variable_map[var]);
@@ -510,7 +510,7 @@ const exprt qbf_bdd_certificatet::f_get(literalt l)
     if(it!=function_cache.end())
     {
       #if 0
-      std::cout << "CACHE HIT for " << l.dimacs() << std::endl;
+      std::cout << "CACHE HIT for " << l.dimacs() << '\n';
       #endif
 
       if(l.sign())
@@ -525,7 +525,7 @@ const exprt qbf_bdd_certificatet::f_get(literalt l)
     BDD &model=*model_bdds[l.var_no()];
 
     #if 0
-    std::cout << "Model " << l.var_no() << std::endl;
+    std::cout << "Model " << l.var_no() << '\n';
     model.PrintMinterm();
     #endif
 
@@ -547,7 +547,7 @@ const exprt qbf_bdd_certificatet::f_get(literalt l)
       std::cout << "CUBE: ";
       for(signed i=0; i<bdd_manager->ReadSize(); i++)
         std::cout << cube[i];
-      std::cout << std::endl;
+      std::cout << '\n';
       #endif
 
       for(signed i=0; i<bdd_manager->ReadSize(); i++)

--- a/src/solvers/qbf/qbf_squolem_core.cpp
+++ b/src/solvers/qbf/qbf_squolem_core.cpp
@@ -403,7 +403,7 @@ const exprt qbf_squolem_coret::f_get(literalt l)
   if(it!=function_cache.end())
   {
     #if 0
-    std::cout << "CACHE HIT for " << l.dimacs() << std::endl;
+    std::cout << "CACHE HIT for " << l.dimacs() << '\n';
     #endif
 
     if(l.sign())
@@ -478,7 +478,7 @@ const exprt qbf_squolem_coret::f_get_cnf(WitnessStack *wsp)
     }
 
     #if 0
-    std::cout << "CLAUSE: " << clause << std::endl;
+    std::cout << "CLAUSE: " << clause << '\n';
     #endif
 
     operands.push_back(clause);
@@ -534,7 +534,7 @@ const exprt qbf_squolem_coret::f_get_dnf(WitnessStack *wsp)
     }
 
     #if 0
-    std::cout << "CUBE: " << cube << std::endl;
+    std::cout << "CUBE: " << cube << '\n';
     #endif
 
     operands.push_back(cube);

--- a/src/solvers/qbf/qdimacs_cnf.cpp
+++ b/src/solvers/qbf/qdimacs_cnf.cpp
@@ -74,7 +74,7 @@ void qdimacs_cnft::write_prefix(std::ostream &out) const
       assert(false);
     }
 
-    out << " " << quantifier.var_no << " 0" << std::endl;
+    out << " " << quantifier.var_no << " 0\n";
   }
 
   // variables that are not quantified
@@ -82,7 +82,7 @@ void qdimacs_cnft::write_prefix(std::ostream &out) const
 
   for(std::size_t i=1; i<no_variables(); i++)
     if(!quantified[i])
-      out << "e " << i << " 0" << std::endl;
+      out << "e " << i << " 0\n";
 }
 
 /*******************************************************************\

--- a/src/solvers/qbf/qdimacs_core.cpp
+++ b/src/solvers/qbf/qdimacs_core.cpp
@@ -75,7 +75,7 @@ void qdimacs_coret::simplify_extractbits(exprt &expr) const
               value_string[value.to_ulong()]='1';
 
               #if 0
-              std::cout << "[" << value << "]=1" << std::endl;
+              std::cout << "[" << value << "]=1\n";
               #endif
 
               continue;
@@ -100,7 +100,7 @@ void qdimacs_coret::simplify_extractbits(exprt &expr) const
         new_operands.push_back(equality_exprt(it->first, new_value));
 
         #if 0
-        std::cout << "FINAL: " << value_string << std::endl;
+        std::cout << "FINAL: " << value_string << '\n';
         #endif
 
         expr.operands()=new_operands;

--- a/src/solvers/refinement/bv_refinement_loop.cpp
+++ b/src/solvers/refinement/bv_refinement_loop.cpp
@@ -239,7 +239,7 @@ void bv_refinementt::set_to(const exprt &expr, bool value)
   if(expr.id()=="=" && expr.operands().size()==2)
     forall_operands(it, expr.op1())
       std::cout << " " << it->id() << "@" << it->type().id();
-  std::cout << std::endl;
+  std::cout << '\n';
   #else
   SUB::set_to(expr, value);
   #endif

--- a/src/solvers/sat/cnf.cpp
+++ b/src/solvers/sat/cnf.cpp
@@ -647,7 +647,7 @@ bool cnft::process_clause(const bvt &bv, bvt &dest)
 
     if(l.var_no()>=_no_variables)
       std::cout << "l.var_no()=" << l.var_no()
-                << " _no_variables=" << _no_variables << std::endl;
+                << " _no_variables=" << _no_variables << '\n';
 
     assert(l.var_no()<_no_variables);
   }

--- a/src/solvers/sat/read_dimacs_cnf.cpp
+++ b/src/solvers/sat/read_dimacs_cnf.cpp
@@ -45,11 +45,11 @@ void read_dimacs_cnf(std::istream &in, cnft &dest)
         break;
 
       #ifdef VERBOSE
-      std::cout << "begin line " << line << std::endl;
+      std::cout << "begin line " << line << '\n';
       #endif
       size_t pos = line.find_first_of(DELIMITERS, 0);
       #ifdef VERBOSE
-      std::cout << "pos " << pos << std::endl;
+      std::cout << "pos " << pos << '\n';
       #endif
       size_t pos_char = line.find_first_of(CHAR_DELIMITERS, 0);
 
@@ -59,13 +59,13 @@ void read_dimacs_cnf(std::istream &in, cnft &dest)
         line.erase(0, pos+1);
         #ifdef VERBOSE
         std::cout << "i am here\n";
-        std::cout << decision << std::endl;
-        std::cout << "line" << line << std::endl;
+        std::cout << decision << '\n';
+        std::cout << "line" << line << '\n';
         #endif
         if(!decision.compare(std::string("c")))
         {
           #ifdef VERBOSE
-          std::cout << "c " << std::endl;
+          std::cout << "c \n";
           #endif
           break;
         }
@@ -73,7 +73,7 @@ void read_dimacs_cnf(std::istream &in, cnft &dest)
         if(!decision.compare(std::string("p")))
         {
           #ifdef VERBOSE
-          std::cout << "p " << std::endl;
+          std::cout << "p \n";
           #endif
           break;
         }
@@ -82,13 +82,13 @@ void read_dimacs_cnf(std::istream &in, cnft &dest)
         {
           int parsed_lit = unsafe_string2int(decision);
           #ifdef VERBOSE
-          std::cout << "parsed_lit " << parsed_lit << " " << std::endl;
+          std::cout << "parsed_lit " << parsed_lit << " \n";
           #endif
           if(parsed_lit == 0)
           {
             bvt no_dup=cnft::eliminate_duplicates(new_bv);
             #ifdef VERBOSE
-            std::cout << "calling lcnf " << new_bv.size() << std::endl;
+            std::cout << "calling lcnf " << new_bv.size() << '\n';
             #endif
             dest.lcnf(no_dup);
             new_bv.clear();
@@ -101,7 +101,7 @@ void read_dimacs_cnf(std::istream &in, cnft &dest)
             bool sign = (parsed_lit > 0) ? false : true;
             l.set(var, sign);
             #ifdef VERBOSE
-            std::cout << "setting l to " << l.get() << std::endl;
+            std::cout << "setting l to " << l.get() << '\n';
             #endif
             new_bv.push_back(l);
             if(dest.no_variables() <= var)

--- a/src/solvers/sat/satcheck_zchaff.cpp
+++ b/src/solvers/sat/satcheck_zchaff.cpp
@@ -206,7 +206,7 @@ propt::resultt satcheck_zchaff_baset::prop_solve()
   if(result==SATISFIABLE)
   {
     for(unsigned i=2; i<(_no_variables*2); i+=2)
-      cout << "DEBUG L" << i << ":" << get(i) << endl;
+      cout << "DEBUG L" << i << ":" << get(i) << '\n';
   }
   #endif
 

--- a/src/symex/symex_parse_options.cpp
+++ b/src/symex/symex_parse_options.cpp
@@ -161,7 +161,7 @@ int symex_parse_optionst::doit()
 {
   if(cmdline.isset("version"))
   {
-    std::cout << CBMC_VERSION << std::endl;
+    std::cout << CBMC_VERSION << '\n';
     return 0;
   }
 
@@ -568,7 +568,7 @@ void symex_parse_optionst::report_success()
       xmlt xml("cprover-status");
       xml.data="SUCCESS";
       std::cout << xml;
-      std::cout << std::endl;
+      std::cout << '\n';
     }
     break;
 
@@ -640,7 +640,7 @@ void symex_parse_optionst::report_failure()
       xmlt xml("cprover-status");
       xml.data="FAILURE";
       std::cout << xml;
-      std::cout << std::endl;
+      std::cout << '\n';
     }
     break;
 

--- a/src/util/base_type.cpp
+++ b/src/util/base_type.cpp
@@ -142,8 +142,8 @@ bool base_type_eqt::base_type_eq_rec(
     return true;
 
   #if 0
-  std::cout << "T1: " << type1.pretty() << std::endl;
-  std::cout << "T2: " << type2.pretty() << std::endl;
+  std::cout << "T1: " << type1.pretty() << '\n';
+  std::cout << "T2: " << type2.pretty() << '\n';
   #endif
 
   // loop avoidance

--- a/src/util/cmdline.cpp
+++ b/src/util/cmdline.cpp
@@ -291,7 +291,7 @@ bool cmdlinet::parse(int argc, const char **argv, const char *optstring)
 
     if(optstring[0]==':')
     {
-      std::cerr << "cmdlinet::parse: Invalid option string" << std::endl;
+      std::cerr << "cmdlinet::parse: Invalid option string\n";
       abort();
     }
 

--- a/src/util/guard.cpp
+++ b/src/util/guard.cpp
@@ -275,7 +275,7 @@ Function: operator <<
 std::ostream &operator << (std::ostream &out, const guardt &g)
 {
   forall_expr_list(it, g.guard_list)
-    out << "*** " << it->pretty() << std::endl;
+    out << "*** " << it->pretty() << '\n';
   return out;
 }
 

--- a/src/util/irep.cpp
+++ b/src/util/irep.cpp
@@ -96,7 +96,7 @@ Function: irept::detach
 void irept::detach()
 {
   #ifdef IREP_DEBUG
-  std::cout << "DETACH1: " << data << std::endl;
+  std::cout << "DETACH1: " << data << '\n';
   #endif
 
   if(data==&empty_d)
@@ -104,7 +104,7 @@ void irept::detach()
     data=new dt;
 
     #ifdef IREP_DEBUG
-    std::cout << "ALLOCATED " << data << std::endl;
+    std::cout << "ALLOCATED " << data << '\n';
     #endif
   }
   else if(data->ref_count>1)
@@ -113,7 +113,7 @@ void irept::detach()
     data=new dt(*old_data);
 
     #ifdef IREP_DEBUG
-    std::cout << "ALLOCATED " << data << std::endl;
+    std::cout << "ALLOCATED " << data << '\n';
     #endif
 
     data->ref_count=1;
@@ -123,7 +123,7 @@ void irept::detach()
   assert(data->ref_count==1);
 
   #ifdef IREP_DEBUG
-  std::cout << "DETACH2: " << data << std::endl;
+  std::cout << "DETACH2: " << data << '\n';
   #endif
 }
 #endif
@@ -153,16 +153,16 @@ void irept::remove_ref(dt *old_data)
   assert(old_data->ref_count!=0);
 
   #ifdef IREP_DEBUG
-  std::cout << "R: " << old_data << " " << old_data->ref_count << std::endl;
+  std::cout << "R: " << old_data << " " << old_data->ref_count << '\n';
   #endif
 
   old_data->ref_count--;
   if(old_data->ref_count==0)
   {
     #ifdef IREP_DEBUG
-    std::cout << "D: " << pretty() << std::endl;
+    std::cout << "D: " << pretty() << '\n';
     std::cout << "DELETING " << old_data->data
-              << " " << old_data << std::endl;
+              << " " << old_data << '\n';
     old_data->clear();
     std::cout << "DEALLOCATING " << old_data << "\n";
     #endif

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -121,7 +121,7 @@ public:
       assert(data->ref_count!=0);
       data->ref_count++;
       #ifdef IREP_DEBUG
-      std::cout << "COPY " << data << " " << data->ref_count << std::endl;
+      std::cout << "COPY " << data << " " << data->ref_count << '\n';
       #endif
     }
   }

--- a/src/util/irep_serialization.cpp
+++ b/src/util/irep_serialization.cpp
@@ -127,7 +127,7 @@ void irep_serializationt::read_irep(
 
   if(in.get()!=0)
   {
-    std::cerr << "irep not terminated" << std::endl;
+    std::cerr << "irep not terminated\n";
     throw 0;
   }
 }

--- a/src/util/pipe_stream.cpp
+++ b/src/util/pipe_stream.cpp
@@ -472,13 +472,13 @@ int main(int argc, char** argv)
   if(process.run() < 0)
     return -1;
 
-  process << "xxx\n" << std::endl;
+  process << "xxx\n\n";
 
   char token;
   for(int i=0; i<3; ++i)
   {
     process >> token;
-    std::cout << "Answer: " << token << std::endl;
+    std::cout << "Answer: " << token << '\n';
   }
 
   return process.wait();

--- a/src/util/reference_counting.h
+++ b/src/util/reference_counting.h
@@ -33,7 +33,7 @@ public:
       assert(d->ref_count!=0);
       d->ref_count++;
       #ifdef REFERENCE_COUNTING_DEBUG
-      std::cout << "COPY " << d << " " << d->ref_count << std::endl;
+      std::cout << "COPY " << d << " " << d->ref_count << '\n';
       #endif
     }
   }
@@ -121,14 +121,14 @@ void reference_counting<T>::remove_ref(dt *old_d)
   assert(old_d->ref_count!=0);
 
   #ifdef REFERENCE_COUNTING_DEBUG
-  std::cout << "R: " << old_d << " " << old_d->ref_count << std::endl;
+  std::cout << "R: " << old_d << " " << old_d->ref_count << '\n';
   #endif
 
   old_d->ref_count--;
   if(old_d->ref_count==0)
   {
     #ifdef REFERENCE_COUNTING_DEBUG
-    std::cout << "DELETING " << old_d << std::endl;
+    std::cout << "DELETING " << old_d << '\n';
     old_d->clear();
     std::cout << "DEALLOCATING " << old_d << "\n";
     #endif
@@ -145,7 +145,7 @@ template<class T>
 void reference_counting<T>::detatch()
 {
   #ifdef REFERENCE_COUNTING_DEBUG
-  std::cout << "DETATCH1: " << d << std::endl;
+  std::cout << "DETATCH1: " << d << '\n';
   #endif
 
   if(d==NULL)
@@ -153,7 +153,7 @@ void reference_counting<T>::detatch()
     d=new dt;
 
     #ifdef REFERENCE_COUNTING_DEBUG
-    std::cout << "ALLOCATED " << d << std::endl;
+    std::cout << "ALLOCATED " << d << '\n';
     #endif
   }
   else if(d->ref_count>1)
@@ -162,7 +162,7 @@ void reference_counting<T>::detatch()
     d=new dt(*old_d);
 
     #ifdef REFERENCE_COUNTING_DEBUG
-    std::cout << "ALLOCATED " << d << std::endl;
+    std::cout << "ALLOCATED " << d << '\n';
     #endif
 
     d->ref_count=1;
@@ -172,7 +172,7 @@ void reference_counting<T>::detatch()
   assert(d->ref_count==1);
 
   #ifdef REFERENCE_COUNTING_DEBUG
-  std::cout << "DETATCH2: " << d << std::endl;
+  std::cout << "DETATCH2: " << d << '\n'
   #endif
 }
 

--- a/src/util/ui_message.cpp
+++ b/src/util/ui_message.cpp
@@ -282,7 +282,7 @@ void ui_message_handlert::xml_ui_msg(
   result.set_attribute("type", type);
 
   std::cout << result;
-  std::cout << std::endl;
+  std::cout << '\n';
 }
 
 /*******************************************************************\


### PR DESCRIPTION
`endl` forces flushing of the current stream, which is generally not necessary. By avoiding `endl`, our software becomes faster and more concise, and specifies the required behaviour more accurately. Also, our coding guideline specifies that we should prefer '\n' to `endl`.