### PR TITLE
Deleted copy/added explicit move constructor.

### DIFF
--- a/src/util/tempfile.h
+++ b/src/util/tempfile.h
@@ -32,7 +32,10 @@ public:
   // Using the copy constructor would delete the file twice.
   temporary_filet(const temporary_filet &)=delete;
 
-  temporary_filet(temporary_filet &&)=default;
+  temporary_filet(temporary_filet &&other) :
+      name(std::move(other.name))
+  {
+  }
 
   // get the name
   std::string operator()() const

--- a/src/util/tempfile.h
+++ b/src/util/tempfile.h
@@ -29,6 +29,11 @@ public:
   {
   }
 
+  // Using the copy constructor would delete the file twice.
+  temporary_filet(const temporary_filet &)=delete;
+
+  temporary_filet(temporary_filet &&)=default;
+
   // get the name
   std::string operator()() const
   {


### PR DESCRIPTION
Implicit copy constructor leads to double deletion of files. Added explicit move
constructor to allow returning temp_filet.