### PR TITLE
Don't generate coverage goals for basic blocks containing exclusively our (exception) instrumentation

### DIFF
--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -54,6 +54,33 @@ public:
 #else
         it->is_goto() || it->is_function_call();
 #endif
+      // does the basic block contain user code or just our instrumentation?
+      goto_programt::instructionst::const_iterator it_inner=it;
+      if(it_inner!=_goto_program.instructions.end())
+        it_inner++;
+      bool instrumentation=true;
+      while(!it_inner->is_target() &&
+            !it_inner->is_goto() &&
+            !it_inner->is_function_call() &&
+            it_inner!=_goto_program.instructions.end())
+      {
+        if(it_inner->source_location.get(ID_instrumentation).empty() ||
+           !it_inner->source_location.get_bool(ID_instrumentation))
+        {
+          instrumentation=false;
+          break;
+        }
+        it_inner++;
+      }
+      // also check the last instruction from the basic block
+      if(instrumentation &&
+         it_inner!=_goto_program.instructions.end())
+        instrumentation=
+          !it_inner->source_location.get("instrumentation").empty() &&
+          it_inner->source_location.get_bool("instrumentation");
+
+      // we are only interested in basic blocks containing user code
+      next_is_target&=!instrumentation;
     }
 
     // create list of covered lines as CSV string and set as property of source

--- a/src/goto-programs/remove_exceptions.cpp
+++ b/src/goto-programs/remove_exceptions.cpp
@@ -127,6 +127,7 @@ void remove_exceptionst::add_exceptional_returns(
     t_null->make_assignment();
     t_null->source_location=
       goto_program.instructions.begin()->source_location;
+    t_null->source_location.set(ID_instrumentation, true);
     t_null->code=code_assignt(
       lhs_expr_null,
       rhs_expr_null);
@@ -171,6 +172,7 @@ void remove_exceptionst::instrument_exception_handler(
     goto_programt::targett t_null=goto_program.insert_after(instr_it);
     t_null->make_assignment();
     t_null->source_location=instr_it->source_location;
+    t_null->source_location.set(ID_instrumentation, true);
     t_null->code=code_assignt(
       lhs_expr_null,
       rhs_expr_null);
@@ -259,6 +261,7 @@ void remove_exceptionst::instrument_throw(
     goto_programt::targett t_end=goto_program.insert_after(instr_it);
     t_end->make_goto(exceptional_output);
     t_end->source_location=instr_it->source_location;
+    t_end->source_location.set(ID_instrumentation, true);
     t_end->function=instr_it->function;
   }
 
@@ -299,6 +302,7 @@ void remove_exceptionst::instrument_throw(
     t_dead->make_dead();
     t_dead->code=code_deadt(local);
     t_dead->source_location=instr_it->source_location;
+    t_dead->source_location.set(ID_instrumentation, true);
     t_dead->function=instr_it->function;
   }
 
@@ -365,6 +369,7 @@ void remove_exceptionst::instrument_function_call(
       goto_programt::targett t_end=goto_program.insert_after(instr_it);
       t_end->make_goto(exceptional_output);
       t_end->source_location=instr_it->source_location;
+      t_end->source_location.set(ID_instrumentation, true);
       t_end->function=instr_it->function;
     }
 
@@ -396,6 +401,7 @@ void remove_exceptionst::instrument_function_call(
       t_dead->make_dead();
       t_dead->code=code_deadt(local);
       t_dead->source_location=instr_it->source_location;
+      t_dead->source_location.set(ID_instrumentation, true);
       t_dead->function=instr_it->function;
     }
 

--- a/src/util/irep_ids.def
+++ b/src/util/irep_ids.def
@@ -808,6 +808,7 @@ IREP_ID_ONE(cprover_string_value_of_func)
 IREP_ID_ONE(skip_initialize)
 IREP_ID_ONE(basic_block_covered_lines)
 IREP_ID_ONE(is_nondet_nullable)
+IREP_ID_ONE(instrumentation)
 
 #undef IREP_ID_ONE
 #undef IREP_ID_TWO


### PR DESCRIPTION
This is meant to fix diffblue/test-gen#319