### PR TITLE
Moved vector_hasht implementation into cpp file

### DIFF
--- a/src/util/irep_hash_container.cpp
+++ b/src/util/irep_hash_container.cpp
@@ -8,6 +8,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "irep_hash_container.h"
 #include "irep.h"
+#include "irep_hash.h"
 
 /*******************************************************************\
 
@@ -37,6 +38,27 @@ size_t irep_hash_container_baset::number(const irept &irep)
   ptr_hash[&irep.read()]=id;
 
   return id;
+}
+
+/*******************************************************************\
+
+Function: irep_hash_container_baset::vector_hasht::operator()
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+size_t irep_hash_container_baset::vector_hasht::operator()(
+  const packedt &p) const
+{
+  size_t result=p.size(); // seed
+  for(auto elem : p)
+    result=hash_combine(result, elem);
+  return result;
 }
 
 /*******************************************************************\

--- a/src/util/irep_hash_container.h
+++ b/src/util/irep_hash_container.h
@@ -12,7 +12,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <cstdlib>  // for size_t
 #include <vector>
 
-#include "irep_hash.h"
 #include "numbering.h"
 
 class irept;
@@ -55,13 +54,7 @@ protected:
 
   struct vector_hasht
   {
-    size_t operator()(const packedt &p) const
-    {
-      size_t result=p.size(); // seed
-      for(auto elem : p)
-        result=hash_combine(result, elem);
-      return result;
-    }
+    size_t operator()(const packedt &p) const;
   };
 
   typedef hash_numbering<packedt, vector_hasht> numberingt;


### PR DESCRIPTION
This breaks the need to have irep_hash.h included in the irep hash container header file, which then propagates it elsewhere. This is important as irep_hash.h defines a macro that clashes with Boost.