### PR TITLE
Avoid unlink call on empty string

### DIFF
--- a/src/util/tempfile.cpp
+++ b/src/util/tempfile.cpp
@@ -164,5 +164,6 @@ Function: temporary_filet::~temporary_filet
 
 temporary_filet::~temporary_filet()
 {
-  if(!name.empty()) unlink(name.c_str());
+  if(!name.empty())
+    unlink(name.c_str());
 }

--- a/src/util/tempfile.cpp
+++ b/src/util/tempfile.cpp
@@ -164,5 +164,5 @@ Function: temporary_filet::~temporary_filet
 
 temporary_filet::~temporary_filet()
 {
-  unlink(name.c_str());
+  if(!name.empty()) unlink(name.c_str());
 }

--- a/src/util/tempfile.h
+++ b/src/util/tempfile.h
@@ -32,9 +32,9 @@ public:
   // Using the copy constructor would delete the file twice.
   temporary_filet(const temporary_filet &)=delete;
 
-  temporary_filet(temporary_filet &&other) :
-      name(std::move(other.name))
+  temporary_filet(temporary_filet &&other)
   {
+    name.swap(other.name);
   }
 
   // get the name


### PR DESCRIPTION
Replaced move constructor by "swap" on default-constructed, empty
string. This because the std::string move constructor does not guarantee
that the moved string is actually erased. Also added test so we don't
unnecessarily call "unlink" on an empty string, even though this has no
effect.