### PR TITLE
Cleanup/initialise goto model

### DIFF
--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -214,9 +214,7 @@ int goto_analyzer_parse_optionst::doit()
 
   register_languages();
 
-  goto_model.set_message_handler(get_message_handler());
-
-  if(goto_model(cmdline))
+  if(initialize_goto_model(goto_model, cmdline, get_message_handler()))
     return 6;
 
   if(process_goto_program(options))

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <java_bytecode/java_bytecode_language.h>
 #include <jsil/jsil_language.h>
 
+#include <goto-programs/initialize_goto_model.h>
 #include <goto-programs/set_properties.h>
 #include <goto-programs/remove_function_pointers.h>
 #include <goto-programs/remove_virtual_functions.h>

--- a/src/goto-analyzer/goto_analyzer_parse_options.h
+++ b/src/goto-analyzer/goto_analyzer_parse_options.h
@@ -14,7 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <langapi/language_ui.h>
 
-#include <goto-programs/get_goto_model.h>
+#include <goto-programs/goto_model.h>
 #include <goto-programs/show_goto_functions.h>
 
 #include <analyses/goto_check.h>

--- a/src/goto-analyzer/goto_analyzer_parse_options.h
+++ b/src/goto-analyzer/goto_analyzer_parse_options.h
@@ -56,7 +56,7 @@ public:
 
 protected:
   ui_message_handlert ui_message_handler;
-  get_goto_modelt goto_model;
+  goto_modelt goto_model;
 
   virtual void register_languages();
 

--- a/src/goto-programs/Makefile
+++ b/src/goto-programs/Makefile
@@ -6,7 +6,7 @@ SRC = basic_blocks.cpp \
       destructor.cpp \
       elf_reader.cpp \
       format_strings.cpp \
-      get_goto_model.cpp \
+      initialize_goto_model.cpp \
       goto_asm.cpp \
       goto_clean_expr.cpp \
       goto_convert.cpp \

--- a/src/goto-programs/get_goto_model.h
+++ b/src/goto-programs/get_goto_model.h
@@ -1,6 +1,6 @@
 /*******************************************************************\
 
-Module: Obtain a Goto Program
+Module: Initialize a Goto Program
 
 Author: Daniel Kroening, kroening@kroening.com
 
@@ -14,10 +14,9 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_model.h"
 
-class get_goto_modelt:public goto_modelt, public messaget
-{
-public:
-  bool operator()(const cmdlinet &);
-};
+bool initialize_goto_model(
+  goto_modelt &goto_model,
+  const cmdlinet &cmdline,
+  message_handlert &message_handler);
 
 #endif // CPROVER_GOTO_PROGRAMS_GET_GOTO_MODEL_H

--- a/src/goto-programs/initialize_goto_model.cpp
+++ b/src/goto-programs/initialize_goto_model.cpp
@@ -18,7 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_convert_functions.h"
 #include "read_goto_binary.h"
-#include "get_goto_model.h"
+#include "initialize_goto_model.h"
 
 /*******************************************************************\
 

--- a/src/goto-programs/initialize_goto_model.h
+++ b/src/goto-programs/initialize_goto_model.h
@@ -6,8 +6,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-#ifndef CPROVER_GOTO_PROGRAMS_GET_GOTO_MODEL_H
-#define CPROVER_GOTO_PROGRAMS_GET_GOTO_MODEL_H
+#ifndef CPROVER_GOTO_PROGRAMS_INITIALIZE_GOTO_MODEL_H
+#define CPROVER_GOTO_PROGRAMS_INITIALIZE_GOTO_MODEL_H
 
 #include <util/message.h>
 #include <util/cmdline.h>
@@ -19,4 +19,4 @@ bool initialize_goto_model(
   const cmdlinet &cmdline,
   message_handlert &message_handler);
 
-#endif // CPROVER_GOTO_PROGRAMS_GET_GOTO_MODEL_H
+#endif // CPROVER_GOTO_PROGRAMS_INITIALIZE_GOTO_MODEL_H

--- a/src/symex/symex_parse_options.cpp
+++ b/src/symex/symex_parse_options.cpp
@@ -21,6 +21,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <cpp/cpp_language.h>
 #include <java_bytecode/java_bytecode_language.h>
 
+#include <goto-programs/initialize_goto_model.h>
 #include <goto-programs/goto_convert_functions.h>
 #include <goto-programs/show_properties.h>
 #include <goto-programs/set_properties.h>

--- a/src/symex/symex_parse_options.cpp
+++ b/src/symex/symex_parse_options.cpp
@@ -177,9 +177,7 @@ int symex_parse_optionst::doit()
 
   eval_verbosity();
 
-  goto_model.set_message_handler(get_message_handler());
-
-  if(goto_model(cmdline))
+  if(initialize_goto_model(goto_model, cmdline, get_message_handler()))
     return 6;
 
   if(process_goto_program(options))

--- a/src/symex/symex_parse_options.h
+++ b/src/symex/symex_parse_options.h
@@ -59,7 +59,7 @@ public:
 
 protected:
   ui_message_handlert ui_message_handler;
-  get_goto_modelt goto_model;
+  goto_modelt goto_model;
 
   void get_command_line_options(optionst &options);
   bool process_goto_program(const optionst &options);

--- a/src/symex/symex_parse_options.h
+++ b/src/symex/symex_parse_options.h
@@ -12,7 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/ui_message.h>
 #include <util/parse_options.h>
 
-#include <goto-programs/get_goto_model.h>
+#include <goto-programs/goto_model.h>
 #include <goto-programs/show_goto_functions.h>
 
 #include <langapi/language_ui.h>


### PR DESCRIPTION
This initialisation does not need to be done by a derived class - it does not use any private members - and doing so prevents creating other derived classes
Lazy function loading will require classes derived from goto_modelt