### PR TITLE
Fix SHARING behaviour

### DIFF
--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -102,7 +102,10 @@ public:
   bool is_nil() const { return id()==ID_nil; }
   bool is_not_nil() const { return id()!=ID_nil; }
 
-  explicit irept(const irep_idt &_id):data(&empty_d)
+  explicit irept(const irep_idt &_id)
+#ifdef SHARING
+    :data(&empty_d)
+#endif
   {
     id(_id);
   }

--- a/src/util/merge_irep.h
+++ b/src/util/merge_irep.h
@@ -20,16 +20,19 @@ public:
   {
     // We assume that both are in the same container,
     // which isn't checked.
-    return data==other.data;
+    return &read()==&other.read();
   }
 
   bool operator<(const merged_irept &other) const
   {
     // again, assumes that both are in the same container
-    return ((std::size_t)data)<((std::size_t)other.data);
+    return &read()<&other.read();
   }
 
-  std::size_t hash() const { return (std::size_t)data; }
+  std::size_t hash() const
+  {
+    return reinterpret_cast<std::size_t>(&read());
+  }
 
   // copy constructor: will only copy from other merged_irepts
   merged_irept(const merged_irept &_src):irept(_src)


### PR DESCRIPTION
This PR fixes up the behaviour of `SHARING` so that it can be disabled if necessary. I think the way that `SHARING` is currently used could be improved - see for details. #907