### PR TITLE
Add message for unknown cbmc option

### DIFF
--- a/regression/cbmc/bad_option/main.c
+++ b/regression/cbmc/bad_option/main.c
@@ -1,0 +1,3 @@
+int main() {
+  return 0;
+}

--- a/regression/cbmc/bad_option/test.desc
+++ b/regression/cbmc/bad_option/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+-foo
+^EXIT=(64|1)$
+^SIGNAL=0$
+Unknown option: -foo
+--

--- a/regression/cbmc/bad_option/test_multiple.desc
+++ b/regression/cbmc/bad_option/test_multiple.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--trace --foo --refine-strings
+^EXIT=(64|1)$
+^SIGNAL=0$
+Unknown option: --foo
+--

--- a/src/util/cmdline.cpp
+++ b/src/util/cmdline.cpp
@@ -185,7 +185,10 @@ bool cmdlinet::parse(int argc, const char **argv, const char *optstring)
       }
 
       if(optnr<0)
+      {
+        unknown_arg=argv[i];
         return true;
+      }
       options[optnr].isset=true;
       if(options[optnr].hasval)
       {

--- a/src/util/cmdline.h
+++ b/src/util/cmdline.h
@@ -33,6 +33,7 @@ public:
 
   typedef std::vector<std::string> argst;
   argst args;
+  std::string unknown_arg;
 
   cmdlinet();
   virtual ~cmdlinet();

--- a/src/util/parse_options.cpp
+++ b/src/util/parse_options.cpp
@@ -37,11 +37,20 @@ void parse_options_baset::usage_error()
   help();
 }
 
+/// Print an error message mentioning the option that was not recognized when
+/// parsing the command line.
+void parse_options_baset::unknown_option_msg()
+{
+  if(!cmdline.unknown_arg.empty())
+    std::cerr << "Unknown option: " << cmdline.unknown_arg << "\n";
+}
+
 int parse_options_baset::main()
 {
   if(parse_result)
   {
     usage_error();
+    unknown_option_msg();
     return EX_USAGE;
   }
 

--- a/src/util/parse_options.h
+++ b/src/util/parse_options.h
@@ -31,6 +31,7 @@ public:
   virtual ~parse_options_baset() { }
 
 private:
+  void unknown_option_msg();
   bool parse_result;
 };
 


### PR DESCRIPTION
During command line parsing, if an unknown option is read, store it and output an error message at `parse_options_baset::main`.

This adds a message when the command line parser finds an unknown option. Ideally, this should be done using the `messaget` framework, but `parse_options_baset` does not inherit from it. All messages produced in this context are directly sent to the standard (as for the help string) or the error outputs.

This should also be applied to cbmc/master.