### PR TITLE
Do not hardcode char/bytes having 8 bits

### DIFF
--- a/src/cprover/cprover_parse_options.cpp
+++ b/src/cprover/cprover_parse_options.cpp
@@ -308,11 +308,9 @@ void cprover_parse_optionst::help()
 {
   std::cout << '\n';
 
-  std::cout
-    << u8"* * CPROVER " << CBMC_VERSION << " (" << (sizeof(void *) * 8)
-    << "-bit)"
-    << " * *\n"
-    << "* *                       Copyright 2022                       * *\n";
+  std::cout << '\n'
+            << banner_string("CPROVER", CBMC_VERSION) << '\n'
+            << align_center_with_border("Copyright 2022") << '\n';
 
   // clang-format off
   std::cout << help_formatter(

--- a/src/goto-instrument/contracts/memory_predicates.cpp
+++ b/src/goto-instrument/contracts/memory_predicates.cpp
@@ -137,7 +137,7 @@ void is_fresh_baset::update_ensures(goto_programt &ensures)
 
 array_typet is_fresh_baset::get_memmap_type()
 {
-  return array_typet(c_bool_typet(8), infinity_exprt(size_type()));
+  return array_typet(unsigned_char_type(), infinity_exprt(size_type()));
 }
 
 void is_fresh_baset::add_memory_map_decl(goto_programt &program)
@@ -149,7 +149,8 @@ void is_fresh_baset::add_memory_map_decl(goto_programt &program)
     goto_programt::make_decl(memmap_symbol.symbol_expr(), source_location));
   program.add(goto_programt::make_assignment(
     memmap_symbol.symbol_expr(),
-    array_of_exprt(from_integer(0, c_bool_typet(8)), get_memmap_type()),
+    array_of_exprt(
+      from_integer(0, get_memmap_type().element_type()), get_memmap_type()),
     source_location));
 }
 

--- a/src/goto-instrument/stack_depth.cpp
+++ b/src/goto-instrument/stack_depth.cpp
@@ -15,6 +15,7 @@ Date: November 2011
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/c_types.h>
 
 #include <goto-programs/goto_convert_functions.h>
 #include <goto-programs/goto_model.h>
@@ -26,7 +27,7 @@ static symbol_exprt add_stack_depth_symbol(
   message_handlert &message_handler)
 {
   const irep_idt identifier="$stack_depth";
-  unsignedbv_typet type(sizeof(std::size_t)*8);
+  typet type = size_type();
 
   symbolt new_symbol;
   new_symbol.name=identifier;

--- a/src/goto-instrument/synthesizer/expr_enumerator.cpp
+++ b/src/goto-instrument/synthesizer/expr_enumerator.cpp
@@ -8,6 +8,8 @@ Author: Qinheping Hu
 #include <util/format_expr.h>
 #include <util/simplify_expr.h>
 
+#include <climits>
+
 expr_sett leaf_enumeratort::enumerate(const std::size_t size) const
 {
   // Size of leaf expressions must be 1.
@@ -185,7 +187,7 @@ get_partitions_long(const std::size_t n, const std::size_t k)
 /// Compute all positions of ones in the bit vector `v` (1-indexed).
 std::vector<std::size_t> get_ones_pos(std::size_t v)
 {
-  const std::size_t length = sizeof(std::size_t) * 8;
+  const std::size_t length = sizeof(std::size_t) * CHAR_BIT;
   std::vector<std::size_t> result;
 
   // Start from the lowest bit at position `length`
@@ -236,7 +238,7 @@ std::list<partitiont> non_leaf_enumeratort::get_partitions(
     return {};
 
   // Number of bits at all.
-  const std::size_t length = sizeof(std::size_t) * 8;
+  const std::size_t length = sizeof(std::size_t) * CHAR_BIT;
 
   // This bithack-based implementation works only for `n` no larger than
   // `length`. Use the vector-based implementation `n` is too large.

--- a/src/goto-programs/goto_trace.cpp
+++ b/src/goto-programs/goto_trace.cpp
@@ -13,11 +13,10 @@ Author: Daniel Kroening
 
 #include "goto_trace.h"
 
-#include <ostream>
-
 #include <util/arith_tools.h>
 #include <util/byte_operators.h>
 #include <util/c_types.h>
+#include <util/config.h>
 #include <util/format_expr.h>
 #include <util/merge_irep.h>
 #include <util/range.h>
@@ -27,6 +26,8 @@ Author: Daniel Kroening
 #include <langapi/language_util.h>
 
 #include "printf_formatter.h"
+
+#include <ostream>
 
 static optionalt<symbol_exprt> get_object_rec(const exprt &src)
 {
@@ -195,7 +196,7 @@ static std::string numeric_representation(
   for(const auto c : result)
   {
     oss << c;
-    if(++i % 8 == 0 && result.size() != i)
+    if(++i % config.ansi_c.char_width == 0 && result.size() != i)
       oss << ' ';
   }
   if(options.base_prefix)

--- a/src/util/simplify_expr_struct.cpp
+++ b/src/util/simplify_expr_struct.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "arith_tools.h"
 #include "byte_operators.h"
 #include "c_types.h"
+#include "config.h"
 #include "invariant.h"
 #include "namespace.h"
 #include "pointer_offset_size.h"
@@ -185,7 +186,7 @@ simplify_exprt::simplify_member(const member_exprt &expr)
 
     if(target_size.has_value())
     {
-      mp_integer target_bits = target_size.value() * 8;
+      mp_integer target_bits = target_size.value() * config.ansi_c.char_width;
       const auto bits = expr2bits(op, true, ns);
 
       if(bits.has_value() &&


### PR DESCRIPTION
The C standard does not guarantee that char is exactly 8 bits, and there are DSPs (such Texas Instruments C55x) that do not have 8-bit-bytes. Use the configuration value instead.