### PR TITLE
Stop inheriting from std containers

### DIFF
--- a/src/analyses/goto_rw.h
+++ b/src/analyses/goto_rw.h
@@ -44,6 +44,14 @@ void goto_rw(const goto_functionst &goto_functions,
 class range_domain_baset
 {
 public:
+  range_domain_baset()=default;
+
+  range_domain_baset(const range_domain_baset &rhs)=delete;
+  range_domain_baset &operator=(const range_domain_baset &rhs)=delete;
+
+  range_domain_baset(range_domain_baset &&rhs)=delete;
+  range_domain_baset &operator=(range_domain_baset &&rhs)=delete;
+
   virtual ~range_domain_baset();
 
   virtual void output(const namespacet &ns, std::ostream &out) const=0;
@@ -61,12 +69,29 @@ inline range_spect to_range_spect(const mp_integer &size)
 }
 
 // each element x represents a range of bits [x.first, x.second.first)
-class range_domaint:
-  public range_domain_baset,
-  public std::list<std::pair<range_spect, range_spect> >
+class range_domaint:public range_domain_baset
 {
+  typedef std::list<std::pair<range_spect, range_spect>> sub_typet;
+  sub_typet data;
+
 public:
-  virtual void output(const namespacet &ns, std::ostream &out) const;
+  void output(const namespacet &ns, std::ostream &out) const override;
+
+  // NOLINTNEXTLINE(readability/identifiers)
+  typedef sub_typet::iterator iterator;
+  // NOLINTNEXTLINE(readability/identifiers)
+  typedef sub_typet::const_iterator const_iterator;
+
+  iterator begin() { return data.begin(); }
+  const_iterator begin() const { return data.begin(); }
+  const_iterator cbegin() const { return data.begin(); }
+
+  iterator end() { return data.end(); }
+  const_iterator end() const { return data.end(); }
+  const_iterator cend() const { return data.end(); }
+
+  template <typename T>
+  void push_back(T &&v) { data.push_back(std::forward<T>(v)); }
 };
 
 class array_exprt;
@@ -257,12 +282,29 @@ protected:
     const range_spect &size);
 };
 
-class guarded_range_domaint:
-  public range_domain_baset,
-  public std::multimap<range_spect, std::pair<range_spect, exprt> >
+class guarded_range_domaint:public range_domain_baset
 {
+  typedef std::multimap<range_spect, std::pair<range_spect, exprt>> sub_typet;
+  sub_typet data;
+
 public:
-  virtual void output(const namespacet &ns, std::ostream &out) const;
+  virtual void output(const namespacet &ns, std::ostream &out) const override;
+
+  // NOLINTNEXTLINE(readability/identifiers)
+  typedef sub_typet::iterator iterator;
+  // NOLINTNEXTLINE(readability/identifiers)
+  typedef sub_typet::const_iterator const_iterator;
+
+  iterator begin() { return data.begin(); }
+  const_iterator begin() const { return data.begin(); }
+  const_iterator cbegin() const { return data.begin(); }
+
+  iterator end() { return data.end(); }
+  const_iterator end() const { return data.end(); }
+  const_iterator cend() const { return data.end(); }
+
+  template<typename T>
+  iterator insert(T &&v) { return data.insert(std::forward<T>(v)); }
 };
 
 class rw_guarded_range_set_value_sett:public rw_range_set_value_sett

--- a/src/analyses/local_bitvector_analysis.h
+++ b/src/analyses/local_bitvector_analysis.h
@@ -186,27 +186,20 @@ protected:
   // This is a vector, so it's fast.
   typedef expanding_vectort<flagst> points_tot;
 
-  // the information tracked per program location
-  class loc_infot
-  {
-  public:
-    points_tot points_to;
+  static bool merge(points_tot &a, points_tot &b);
 
-    bool merge(const loc_infot &src);
-  };
-
-  typedef std::vector<loc_infot> loc_infost;
+  typedef std::vector<points_tot> loc_infost;
   loc_infost loc_infos;
 
   void assign_lhs(
     const exprt &lhs,
     const exprt &rhs,
-    const loc_infot &loc_info_src,
-    loc_infot &loc_info_dest);
+    points_tot &loc_info_src,
+    points_tot &loc_info_dest);
 
   flagst get_rec(
     const exprt &rhs,
-    const loc_infot &loc_info_src);
+    points_tot &loc_info_src);
 
   bool is_tracked(const irep_idt &identifier);
 };

--- a/src/goto-instrument/wmm/cycle_collection.cpp
+++ b/src/goto-instrument/wmm/cycle_collection.cpp
@@ -25,7 +25,7 @@ void event_grapht::graph_explorert::filter_thin_air(
   {
     std::set<critical_cyclet>::const_iterator next=it;
     ++next;
-    critical_cyclet::const_iterator e_it=it->begin();
+    auto e_it=it->begin();
     /* is there an event in the cycle not in thin-air events? */
     for(; e_it!=it->end(); ++e_it)
       if(thin_air_events.find(*e_it)==thin_air_events.end())

--- a/src/goto-instrument/wmm/data_dp.cpp
+++ b/src/goto-instrument/wmm/data_dp.cpp
@@ -24,13 +24,13 @@ void data_dpt::dp_analysis(
   const datat &write,
   bool local_write)
 {
-  const_iterator it;
+  data_typet::const_iterator it;
 
-  for(it=begin(); it!=end(); ++it)
+  for(it=data.cbegin(); it!=data.cend(); ++it)
   {
     if(local_read && it->id==read.id)
     {
-      insert(
+      data.insert(
         datat(
           write.id,
           (local_write?source_locationt():write.loc),
@@ -40,7 +40,7 @@ void data_dpt::dp_analysis(
 
     if(local_write && it->id==write.id)
     {
-      insert(
+      data.insert(
         datat(
           read.id,
           (local_read?source_locationt():read.loc),
@@ -49,12 +49,12 @@ void data_dpt::dp_analysis(
     }
   }
 
-  if(it==end())
+  if(it==data.cend())
   {
     ++class_nb;
-    insert(
+    data.insert(
       datat(read.id, (local_read?source_locationt():read.loc), class_nb));
-    insert(
+    data.insert(
       datat(write.id, (local_write?source_locationt():write.loc), class_nb));
   }
 }
@@ -71,11 +71,11 @@ void data_dpt::dp_analysis(
 /// search in N^2
 bool data_dpt::dp(const abstract_eventt &e1, const abstract_eventt &e2) const
 {
-  for(const_iterator it1=begin(); it1!=end(); ++it1)
+  for(auto it1=data.cbegin(); it1!=data.cend(); ++it1)
   {
-    const_iterator it2=it1;
+    auto it2=it1;
     ++it2;
-    if(it2==end())
+    if(it2==data.cend())
       break;
 
     if(e1.local)
@@ -89,7 +89,7 @@ bool data_dpt::dp(const abstract_eventt &e1, const abstract_eventt &e2) const
         continue;
     }
 
-    for(; it2!=end(); ++it2)
+    for(; it2!=data.cend(); ++it2)
     {
       if(e2.local)
       {
@@ -116,42 +116,42 @@ bool data_dpt::dp(const abstract_eventt &e1, const abstract_eventt &e2) const
 /// merge in N^3
 void data_dpt::dp_merge()
 {
-  if(size()<2)
+  if(data.size()<2)
     return;
 
-  unsigned initial_size=size();
+  unsigned initial_size=data.size();
 
   unsigned from=0;
   unsigned to=0;
 
   /* look for similar elements */
-  for(const_iterator it1=begin(); it1!=end(); ++it1)
+  for(auto it1=data.cbegin(); it1!=data.cend(); ++it1)
   {
-    const_iterator it2=it1;
+    auto it2=it1;
     ++it2;
     /* all ok -- ends */
-    if(it2==end())
+    if(it2==data.cend())
       return;
 
-    for(; it2!=end(); ++it2)
+    for(; it2!=data.cend(); ++it2)
     {
       if(it1 == it2)
       {
         from=it2->eq_class;
         to=it1->eq_class;
-        erase(it2);
+        data.erase(it2);
         break;
       }
     }
   }
 
   /* merge */
-  for(iterator it3=begin(); it3!=end(); ++it3)
+  for(auto it3=data.begin(); it3!=data.end(); ++it3)
     if(it3->eq_class==from)
       it3->eq_class=to;
 
   /* strictly monotonous => converges */
-  assert(initial_size>size());
+  assert(initial_size>data.size());
 
   /* repeat until classes are disjunct */
   dp_merge();
@@ -160,10 +160,10 @@ void data_dpt::dp_merge()
 void data_dpt::print(messaget &message)
 {
 #ifdef DEBUG
-  const_iterator it;
+  data_typet::const_iterator it;
   std::map<unsigned, std::set<source_locationt> > classed;
 
-  for(it=begin(); it!=end(); ++it)
+  for(it=data.cbegin(); it!=data.cend(); ++it)
   {
     if(classed.find(it->eq_class)==classed.end())
     {

--- a/src/goto-instrument/wmm/data_dp.cpp
+++ b/src/goto-instrument/wmm/data_dp.cpp
@@ -13,6 +13,7 @@ Date: 2012
 
 #include "data_dp.h"
 
+#include <util/invariant.h>
 #include <util/message.h>
 
 #include "abstract_event.h"
@@ -151,7 +152,7 @@ void data_dpt::dp_merge()
       it3->eq_class=to;
 
   /* strictly monotonous => converges */
-  assert(initial_size>data.size());
+  INVARIANT(initial_size>data.size(), "strictly monotonous => converges");
 
   /* repeat until classes are disjunct */
   dp_merge();

--- a/src/goto-instrument/wmm/data_dp.h
+++ b/src/goto-instrument/wmm/data_dp.h
@@ -48,11 +48,13 @@ struct datat
   }
 };
 
-class data_dpt:public std::set<datat>
+class data_dpt final
 {
-public:
+  typedef std::set<datat> data_typet;
+  data_typet data;
   unsigned class_nb;
 
+public:
   /* add this dependency in the structure */
   void dp_analysis(const abstract_eventt &read, const abstract_eventt &write);
   void dp_analysis(

--- a/src/goto-instrument/wmm/event_graph.cpp
+++ b/src/goto-instrument/wmm/event_graph.cpp
@@ -1427,7 +1427,7 @@ std::string event_grapht::critical_cyclet::print_name(
 
   if(first_done)
   {
-    critical_cyclet::size_type n_events=extra_fence_count;
+    auto n_events=extra_fence_count;
     for(std::string::const_iterator it=name.begin();
         it!=name.end();
         ++it)

--- a/src/goto-instrument/wmm/event_graph.h
+++ b/src/goto-instrument/wmm/event_graph.h
@@ -35,9 +35,11 @@ class event_grapht
 {
 public:
   /* critical cycle */
-  class critical_cyclet:public std::list<event_idt>
+  class critical_cyclet final
   {
-  protected:
+    typedef std::list<event_idt> data_typet;
+    data_typet data;
+
     event_grapht &egraph;
 
     bool is_not_uniproc() const;
@@ -50,15 +52,47 @@ public:
     std::string print_name(const critical_cyclet &redyced,
       memory_modelt model) const;
 
-    bool check_AC(const_iterator s_it, const abstract_eventt &first,
+    bool check_AC(
+      data_typet::const_iterator s_it,
+      const abstract_eventt &first,
       const abstract_eventt &second) const;
-    bool check_BC(const_iterator it, const abstract_eventt &first,
+    bool check_BC(
+      data_typet::const_iterator it,
+      const abstract_eventt &first,
       const abstract_eventt &second) const;
 
   public:
     unsigned id;
-
     bool has_user_defined_fence;
+
+    // NOLINTNEXTLINE(readability/identifiers)
+    typedef data_typet::iterator iterator;
+    // NOLINTNEXTLINE(readability/identifiers)
+    typedef data_typet::const_iterator const_iterator;
+    // NOLINTNEXTLINE(readability/identifiers)
+    typedef data_typet::value_type value_type;
+
+    iterator begin() { return data.begin(); }
+    const_iterator begin() const { return data.begin(); }
+    const_iterator cbegin() const { return data.cbegin(); }
+
+    iterator end() { return data.end(); }
+    const_iterator end() const { return data.end(); }
+    const_iterator cend() const { return data.cend(); }
+
+    template <typename T>
+    void push_front(T &&t) { data.push_front(std::forward<T>(t)); }
+
+    template <typename T>
+    void push_back(T &&t) { data.push_back(std::forward<T>(t)); }
+
+    value_type &front() { return data.front(); }
+    const value_type &front() const { return data.front(); }
+
+    value_type &back() { return data.back(); }
+    const value_type &back() const { return data.back(); }
+
+    size_t size() const { return data.size(); }
 
     critical_cyclet(event_grapht &_egraph, unsigned _id)
       :egraph(_egraph), id(_id), has_user_defined_fence(false)
@@ -67,23 +101,26 @@ public:
 
     void operator()(const critical_cyclet &cyc)
     {
-      clear();
-      for(const_iterator it=cyc.begin(); it!=cyc.end(); it++)
-        push_back(*it);
+      data.clear();
+      for(
+        auto it=cyc.data.cbegin();
+        it!=cyc.data.cend();
+        ++it)
+        data.push_back(*it);
       has_user_defined_fence=cyc.has_user_defined_fence;
     }
 
     bool is_cycle()
     {
       /* size check */
-      if(size()<4)
+      if(data.size()<4)
         return false;
 
       /* po order check */
-      const_iterator it=begin();
-      const_iterator n_it=it;
+      auto it=data.cbegin();
+      auto n_it=it;
       ++n_it;
-      for(; it!=end() && n_it!=end(); ++it, ++n_it)
+      for(; it!=data.cend() && n_it!=data.cend(); ++it, ++n_it)
       {
         if(egraph[*it].thread==egraph[*n_it].thread
           && !egraph.are_po_ordered(*it, *n_it))
@@ -177,7 +214,7 @@ public:
       {
         critical_cyclet reduced(egraph, id);
         this->hide_internals(reduced);
-        assert(!reduced.empty());
+        assert(!reduced.data.empty());
         return print_name(reduced, model);
       }
       else
@@ -196,7 +233,7 @@ public:
 
     bool operator<(const critical_cyclet &other) const
     {
-      return ( ((std::list<event_idt>) *this) < (std::list<event_idt>)other);
+      return data<other.data;
     }
   };
 

--- a/src/goto-instrument/wmm/event_graph.h
+++ b/src/goto-instrument/wmm/event_graph.h
@@ -102,10 +102,9 @@ public:
     void operator()(const critical_cyclet &cyc)
     {
       data.clear();
-      for(
-        auto it=cyc.data.cbegin();
-        it!=cyc.data.cend();
-        ++it)
+      for(auto it=cyc.data.cbegin();
+          it!=cyc.data.cend();
+          ++it)
         data.push_back(*it);
       has_user_defined_fence=cyc.has_user_defined_fence;
     }

--- a/src/goto-instrument/wmm/event_graph.h
+++ b/src/goto-instrument/wmm/event_graph.h
@@ -20,6 +20,7 @@ Date: 2012
 #include <iosfwd>
 
 #include <util/graph.h>
+#include <util/invariant.h>
 
 #include "abstract_event.h"
 #include "data_dp.h"
@@ -213,7 +214,7 @@ public:
       {
         critical_cyclet reduced(egraph, id);
         this->hide_internals(reduced);
-        assert(!reduced.data.empty());
+        INVARIANT(!reduced.data.empty(), "reduced must not be empty");
         return print_name(reduced, model);
       }
       else

--- a/src/goto-programs/cfg.h
+++ b/src/goto-programs/cfg.h
@@ -64,10 +64,29 @@ class cfg_baset:public grapht< cfg_base_nodet<T, I> >
 public:
   typedef std::size_t entryt;
 
-  struct entry_mapt:
-    public std::map<goto_programt::const_targett, entryt>
+  class entry_mapt final
   {
+    typedef std::map<goto_programt::const_targett, entryt> data_typet;
+    data_typet data;
+
+  public:
     grapht< cfg_base_nodet<T, I> > &container;
+
+    // NOLINTNEXTLINE(readability/identifiers)
+    typedef data_typet::iterator iterator;
+    // NOLINTNEXTLINE(readability/identifiers)
+    typedef data_typet::const_iterator const_iterator;
+
+    template <typename U>
+    const_iterator find(U &&u) const { return data.find(std::forward<U>(u)); }
+
+    iterator begin() { return data.begin(); }
+    const_iterator begin() const { return data.begin(); }
+    const_iterator cbegin() const { return data.cbegin(); }
+
+    iterator end() { return data.end(); }
+    const_iterator end() const { return data.end(); }
+    const_iterator cend() const { return data.cend(); }
 
     explicit entry_mapt(grapht< cfg_base_nodet<T, I> > &_container):
       container(_container)
@@ -76,7 +95,7 @@ public:
 
     entryt &operator[](const goto_programt::const_targett &t)
     {
-      std::pair<iterator, bool> e=insert(std::make_pair(t, 0));
+      auto e=data.insert(std::make_pair(t, 0));
 
       if(e.second)
         e.first->second=container.add_node();

--- a/src/goto-programs/format_strings.h
+++ b/src/goto-programs/format_strings.h
@@ -84,9 +84,7 @@ public:
   irep_idt value; // for text and pattern matching
 };
 
-class format_token_listt:public std::list<format_tokent>
-{
-};
+typedef std::list<format_tokent> format_token_listt;
 
 format_token_listt parse_format_string(const std::string &);
 

--- a/src/musketeer/ilp.h
+++ b/src/musketeer/ilp.h
@@ -22,26 +22,15 @@ Author: Vincent Nimal
 class ilpt
 {
 protected:
-  template <class T>
-  class my_vectort: public std::vector<T>
-  {
-  public:
-    T *to_array()
-    {
-      /* NOTE: not valid if T==bool */
-      return &(*this)[0];
-    }
-  };
-
   glp_iocp parm;
   unsigned matrix_size;
 
 public:
   glp_prob *lp;
 
-  my_vectort<int> imat;
-  my_vectort<int> jmat;
-  my_vectort<double> vmat;
+  std::vector<int> imat;
+  std::vector<int> jmat;
+  std::vector<double> vmat;
 
   ilpt()
   {
@@ -69,8 +58,8 @@ public:
 
   void solve()
   {
-    glp_load_matrix(lp, matrix_size, imat.to_array(),
-      jmat.to_array(), vmat.to_array());
+    glp_load_matrix(lp, matrix_size, imat.data(),
+      jmat.data(), vmat.data());
     glp_intopt(lp, &parm);
   }
 };

--- a/src/musketeer/propagate_const_function_pointers.cpp
+++ b/src/musketeer/propagate_const_function_pointers.cpp
@@ -114,12 +114,25 @@ protected:
     unsigned stack_scope);
 
   /* to keep track of the constant function pointers passed as arguments */
-  class arg_stackt: public std::set<irep_idt>
+  class arg_stackt final
   {
-  protected:
+    typedef std::set<irep_idt> data_typet;
+    data_typet data;
     const_function_pointer_propagationt &cfpp;
 
   public:
+    // NOLINTNEXTLINE(readability/identifiers)
+    typedef data_typet::iterator iterator;
+    // NOLINTNEXTLINE(readability/identifiers)
+    typedef data_typet::const_iterator const_iterator;
+    // NOLINTNEXTLINE(readability/identifiers)
+    typedef data_typet::value_type value_type;
+
+    std::pair<iterator, bool> insert(const value_type &t)
+    {
+      return data.insert(t);
+    }
+
     explicit arg_stackt(const_function_pointer_propagationt &_cfpp):
       cfpp(_cfpp)
     {}
@@ -415,7 +428,7 @@ void const_function_pointer_propagationt::arg_stackt::add_args(
 void const_function_pointer_propagationt::arg_stackt::remove_args()
 {
   /* remove the parameter names */
-  for(const_iterator arg_it=begin(); arg_it!=end(); ++arg_it)
+  for(const_iterator arg_it=data.begin(); arg_it!=data.end(); ++arg_it)
   {
     cfpp.remove(*arg_it);
     cfpp.message.debug() << "SET: remove " << *arg_it << messaget::eom;

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -33,7 +33,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "add_failed_symbols.h"
 
-const value_sett::object_map_dt value_sett::object_map_dt::blank;
+const value_sett::object_map_dt value_sett::object_map_dt::blank{};
 object_numberingt value_sett::object_numbering;
 
 bool value_sett::field_sensitive(
@@ -74,7 +74,7 @@ bool value_sett::insert(
   unsigned n,
   const objectt &object) const
 {
-  object_map_dt::const_iterator entry=dest.read().find(n);
+  auto entry=dest.read().find(n);
 
   if(entry==dest.read().end())
   {
@@ -184,9 +184,9 @@ void value_sett::output(
   }
 }
 
-exprt value_sett::to_expr(object_map_dt::const_iterator it) const
+exprt value_sett::to_expr(const object_map_dt::value_type &it) const
 {
-  const exprt &object=object_numbering[it->first];
+  const exprt &object=object_numbering[it.first];
 
   if(object.id()==ID_invalid ||
      object.id()==ID_unknown)
@@ -196,8 +196,8 @@ exprt value_sett::to_expr(object_map_dt::const_iterator it) const
 
   od.object()=object;
 
-  if(it->second.offset_is_set)
-    od.offset()=from_integer(it->second.offset, index_type());
+  if(it.second.offset_is_set)
+    od.offset()=from_integer(it.second.offset, index_type());
 
   od.type()=od.object().type();
 
@@ -251,7 +251,7 @@ bool value_sett::make_union(object_mapt &dest, const object_mapt &src) const
       it!=src.read().end();
       it++)
   {
-    if(insert(dest, it))
+    if(insert(dest, *it))
       result=true;
   }
 
@@ -323,7 +323,7 @@ void value_sett::get_value_set(
       it=object_map.read().begin();
       it!=object_map.read().end();
       it++)
-    dest.push_back(to_expr(it));
+    dest.push_back(to_expr(*it));
 
   #if 0
   for(value_setst::valuest::const_iterator it=dest.begin();
@@ -918,7 +918,7 @@ void value_sett::get_reference_set(
       it=object_map.read().begin();
       it!=object_map.read().end();
       it++)
-    dest.push_back(to_expr(it));
+    dest.push_back(to_expr(*it));
 }
 
 void value_sett::get_reference_set_rec(
@@ -1267,7 +1267,7 @@ void value_sett::do_free(
           to_dynamic_object_expr(object);
 
         if(to_mark.count(dynamic_object.get_instance())==0)
-          set(new_object_map, o_it);
+          set(new_object_map, *o_it);
         else
         {
           // adjust
@@ -1279,7 +1279,7 @@ void value_sett::do_free(
         }
       }
       else
-        set(new_object_map, o_it);
+        set(new_object_map, *o_it);
     }
 
     if(changed)

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -58,25 +58,57 @@ public:
     { return offset_is_set && offset.is_zero(); }
   };
 
-  class object_map_dt:public std::map<unsigned, objectt>
+  class object_map_dt
   {
+    typedef std::map<unsigned, objectt> data_typet;
+    data_typet data;
+
   public:
-    object_map_dt() {}
+    // NOLINTNEXTLINE(readability/identifiers)
+    typedef data_typet::iterator iterator;
+    // NOLINTNEXTLINE(readability/identifiers)
+    typedef data_typet::const_iterator const_iterator;
+    // NOLINTNEXTLINE(readability/identifiers)
+    typedef data_typet::value_type value_type;
+
+    iterator begin() { return data.begin(); }
+    const_iterator begin() const { return data.begin(); }
+    const_iterator cbegin() const { return data.cbegin(); }
+
+    iterator end() { return data.end(); }
+    const_iterator end() const { return data.end(); }
+    const_iterator cend() const { return data.cend(); }
+
+    size_t size() const { return data.size(); }
+
+    objectt &operator[](unsigned i) { return data[i]; }
+
+    template <typename It>
+    void insert(It b, It e) { data.insert(b, e); }
+
+    template <typename T>
+    const_iterator find(T &&t) const { return data.find(std::forward<T>(t)); }
+
     static const object_map_dt blank;
+
+    object_map_dt()=default;
+
+  protected:
+    ~object_map_dt()=default;
   };
 
-  exprt to_expr(object_map_dt::const_iterator it) const;
+  exprt to_expr(const object_map_dt::value_type &it) const;
 
   typedef reference_counting<object_map_dt> object_mapt;
 
-  void set(object_mapt &dest, object_map_dt::const_iterator it) const
+  void set(object_mapt &dest, const object_map_dt::value_type &it) const
   {
-    dest.write()[it->first]=it->second;
+    dest.write()[it.first]=it.second;
   }
 
-  bool insert(object_mapt &dest, object_map_dt::const_iterator it) const
+  bool insert(object_mapt &dest, const object_map_dt::value_type &it) const
   {
-    return insert(dest, it->first, it->second);
+    return insert(dest, it.first, it.second);
   }
 
   bool insert(object_mapt &dest, const exprt &src) const

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -80,6 +80,7 @@ public:
     const_iterator cend() const { return data.cend(); }
 
     size_t size() const { return data.size(); }
+    bool empty() const { return data.empty(); }
 
     objectt &operator[](unsigned i) { return data[i]; }
 

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -25,7 +25,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <langapi/language_util.h>
 #include <util/c_types.h>
 
-const value_set_fit::object_map_dt value_set_fit::object_map_dt::blank;
+const value_set_fit::object_map_dt value_set_fit::object_map_dt::blank{};
+
 object_numberingt value_set_fit::object_numbering;
 hash_numbering<irep_idt, irep_id_hash> value_set_fit::function_numbering;
 
@@ -206,11 +207,11 @@ void value_set_fit::flatten_rec(
         }
 
         forall_objects(oit, temp.read())
-          insert(dest, oit);
+          insert(dest, *oit);
       }
     }
     else
-      insert(dest, it);
+      insert(dest, *it);
   }
 
   if(generalize_index) // this means we had recursive symbols in there
@@ -222,9 +223,9 @@ void value_set_fit::flatten_rec(
   seen.erase(identifier + e.suffix);
 }
 
-exprt value_set_fit::to_expr(object_map_dt::const_iterator it) const
+exprt value_set_fit::to_expr(const object_map_dt::value_type &it) const
 {
-  const exprt &object=object_numbering[it->first];
+  const exprt &object=object_numbering[it.first];
 
   if(object.id()==ID_invalid ||
      object.id()==ID_unknown)
@@ -234,8 +235,8 @@ exprt value_set_fit::to_expr(object_map_dt::const_iterator it) const
 
   od.object()=object;
 
-  if(it->second.offset_is_set)
-    od.offset()=from_integer(it->second.offset, index_type());
+  if(it.second.offset_is_set)
+    od.offset()=from_integer(it.second.offset, index_type());
 
   od.type()=od.object().type();
 
@@ -287,7 +288,7 @@ bool value_set_fit::make_union(object_mapt &dest, const object_mapt &src) const
 
   forall_objects(it, src.read())
   {
-    if(insert(dest, it))
+    if(insert(dest, *it))
       result=true;
   }
 
@@ -340,7 +341,7 @@ void value_set_fit::get_value_set(
   }
 
   forall_objects(fit, flat_map.read())
-    value_set.push_back(to_expr(fit));
+    value_set.push_back(to_expr(*fit));
 
   #if 0
   // Sanity check!
@@ -744,11 +745,11 @@ void value_set_fit::get_reference_set(
         }
 
         forall_objects(it, omt.read())
-          dest.insert(to_expr(it));
+          dest.insert(to_expr(*it));
       }
     }
     else
-      dest.insert(to_expr(it));
+      dest.insert(to_expr(*it));
   }
 }
 
@@ -761,7 +762,7 @@ void value_set_fit::get_reference_set_sharing(
   get_reference_set_sharing(expr, object_map, ns);
 
   forall_objects(it, object_map.read())
-    dest.insert(to_expr(it));
+    dest.insert(to_expr(*it));
 }
 
 void value_set_fit::get_reference_set_sharing_rec(
@@ -833,13 +834,13 @@ void value_set_fit::get_reference_set_sharing_rec(
           }
 
           forall_objects(it2, t2.read())
-            insert(dest, it2);
+            insert(dest, *it2);
         }
         else
           insert(dest, exprt(ID_unknown, obj.type().subtype()));
       }
       else
-        insert(dest, it);
+        insert(dest, *it);
     }
 
     #if 0
@@ -1182,7 +1183,7 @@ void value_set_fit::do_free(
           to_dynamic_object_expr(object);
 
         if(to_mark.count(dynamic_object.get_instance())==0)
-          set(new_object_map, o_it);
+          set(new_object_map, *o_it);
         else
         {
           // adjust
@@ -1194,7 +1195,7 @@ void value_set_fit::do_free(
         }
       }
       else
-        set(new_object_map, o_it);
+        set(new_object_map, *o_it);
     }
 
     if(changed)

--- a/src/pointer-analysis/value_set_fi.h
+++ b/src/pointer-analysis/value_set_fi.h
@@ -71,25 +71,55 @@ public:
     { return offset_is_set && offset.is_zero(); }
   };
 
-  class object_map_dt:public std::map<unsigned, objectt>
+  class object_map_dt
   {
+    typedef std::map<unsigned, objectt> data_typet;
+    data_typet data;
+
   public:
-    object_map_dt() {}
+    // NOLINTNEXTLINE(readability/identifiers)
+    typedef data_typet::iterator iterator;
+    // NOLINTNEXTLINE(readability/identifiers)
+    typedef data_typet::const_iterator const_iterator;
+    // NOLINTNEXTLINE(readability/identifiers)
+    typedef data_typet::value_type value_type;
+
+    iterator begin() { return data.begin(); }
+    const_iterator begin() const { return data.begin(); }
+    const_iterator cbegin() const { return data.cbegin(); }
+
+    iterator end() { return data.end(); }
+    const_iterator end() const { return data.end(); }
+    const_iterator cend() const { return data.cend(); }
+
+    size_t size() const { return data.size(); }
+
+    objectt &operator[](unsigned i) { return data[i]; }
+
+    template <typename It>
+    void insert(It b, It e) { data.insert(b, e); }
+
+    template <typename T>
+    const_iterator find(T &&t) const { return data.find(std::forward<T>(t)); }
+
     static const object_map_dt blank;
+
+  protected:
+    ~object_map_dt()=default;
   };
 
-  exprt to_expr(object_map_dt::const_iterator it) const;
+  exprt to_expr(const object_map_dt::value_type &it) const;
 
   typedef reference_counting<object_map_dt> object_mapt;
 
-  void set(object_mapt &dest, object_map_dt::const_iterator it) const
+  void set(object_mapt &dest, const object_map_dt::value_type &it) const
   {
-    dest.write()[it->first]=it->second;
+    dest.write()[it.first]=it.second;
   }
 
-  bool insert(object_mapt &dest, object_map_dt::const_iterator it) const
+  bool insert(object_mapt &dest, const object_map_dt::value_type &it) const
   {
-    return insert(dest, it->first, it->second);
+    return insert(dest, it.first, it.second);
   }
 
   bool insert(object_mapt &dest, const exprt &src) const

--- a/src/util/expanding_vector.h
+++ b/src/util/expanding_vector.h
@@ -13,31 +13,40 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <vector>
 
 template<typename T>
-class expanding_vectort:public std::vector<T>
+class expanding_vectort
 {
+  typedef std::vector<T> data_typet;
+  data_typet data;
+
 public:
+  // NOLINTNEXTLINE(readability/identifiers)
+  typedef typename data_typet::size_type size_type;
+  // NOLINTNEXTLINE(readability/identifiers)
+  typedef typename data_typet::iterator iterator;
+  // NOLINTNEXTLINE(readability/identifiers)
+  typedef typename data_typet::const_iterator const_iterator;
+
   T &operator[] (typename std::vector<T>::size_type n)
   {
-    check_index(n);
-    return subt::operator[](n);
+    if(n>=data.size())
+      data.resize(n+1);
+    return data[n];
   }
 
-  const T &operator[] (typename std::vector<T>::size_type n) const
-  {
-    // hack-ish const cast
-    const_cast<expanding_vectort*>(this)->check_index(n);
-    return subt::operator[](n);
-  }
+  void clear() { data.clear(); }
 
-protected:
-  typedef std::vector<T> subt;
+  iterator begin() { return data.begin(); }
+  const_iterator begin() const { return data.begin(); }
+  const_iterator cbegin() const { return data.cbegin(); }
 
-  // make the vector large enough to contain 'n'
-  void check_index(typename std::vector<T>::size_type n)
-  {
-    if(n>=subt::size())
-      subt::resize(n+1);
-  }
+  iterator end() { return data.end(); }
+  const_iterator end() const { return data.end(); }
+  const_iterator cend() const { return data.cend(); }
+
+  size_type size() const { return data.size(); }
+
+  void push_back(const T &t) { data.push_back(t); }
+  void push_back(T &&t) { data.push_back(std::move(t)); }
 };
 
 #endif // CPROVER_UTIL_EXPANDING_VECTOR_H

--- a/src/util/numbering.h
+++ b/src/util/numbering.h
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <unordered_map>
 #include <vector>
 
+#include <util/invariant.h>
 
 template <typename T>
 // NOLINTNEXTLINE(readability/identifiers)
@@ -48,7 +49,7 @@ public:
     if(result.second) // inserted?
     {
       data.push_back(a);
-      assert(data.size()==numbers.size());
+      INVARIANT(data.size()==numbers.size(), "vector sizes must match");
     }
 
     return (result.first)->second;

--- a/src/util/numbering.h
+++ b/src/util/numbering.h
@@ -18,11 +18,25 @@ Author: Daniel Kroening, kroening@kroening.com
 
 template <typename T>
 // NOLINTNEXTLINE(readability/identifiers)
-class numbering:public std::vector<T>
+class numbering final
 {
 public:
   // NOLINTNEXTLINE(readability/identifiers)
   typedef std::size_t number_type;
+
+private:
+  typedef std::vector<T> data_typet;
+  data_typet data;
+  typedef std::map<T, number_type> numberst;
+  numberst numbers;
+
+public:
+  // NOLINTNEXTLINE(readability/identifiers)
+  typedef typename data_typet::size_type size_type;
+  // NOLINTNEXTLINE(readability/identifiers)
+  typedef typename data_typet::iterator iterator;
+  // NOLINTNEXTLINE(readability/identifiers)
+  typedef typename data_typet::const_iterator const_iterator;
 
   number_type number(const T &a)
   {
@@ -33,8 +47,8 @@ public:
 
     if(result.second) // inserted?
     {
-      this->push_back(a);
-      assert(this->size()==numbers.size());
+      data.push_back(a);
+      assert(data.size()==numbers.size());
     }
 
     return (result.first)->second;
@@ -58,24 +72,45 @@ public:
 
   void clear()
   {
-    subt::clear();
+    data.clear();
     numbers.clear();
   }
 
-protected:
-  typedef std::vector<T> subt;
+  size_t size() const { return data.size(); }
 
-  typedef std::map<T, number_type> numberst;
-  numberst numbers;
+  T &operator[](size_type t) { return data[t]; }
+  const T &operator[](size_type t) const { return data[t]; }
+
+  iterator begin() { return data.begin(); }
+  const_iterator begin() const { return data.begin(); }
+  const_iterator cbegin() const { return data.cbegin(); }
+
+  iterator end() { return data.end(); }
+  const_iterator end() const { return data.end(); }
+  const_iterator cend() const { return data.cend(); }
 };
 
 template <typename T, class hash_fkt>
 // NOLINTNEXTLINE(readability/identifiers)
-class hash_numbering:public std::vector<T>
+class hash_numbering final
 {
 public:
   // NOLINTNEXTLINE(readability/identifiers)
   typedef unsigned int number_type;
+
+private:
+  typedef std::vector<T> data_typet;
+  data_typet data;
+  typedef std::unordered_map<T, number_type, hash_fkt> numberst;
+  numberst numbers;
+
+public:
+  // NOLINTNEXTLINE(readability/identifiers)
+  typedef typename data_typet::size_type size_type;
+  // NOLINTNEXTLINE(readability/identifiers)
+  typedef typename data_typet::iterator iterator;
+  // NOLINTNEXTLINE(readability/identifiers)
+  typedef typename data_typet::const_iterator const_iterator;
 
   number_type number(const T &a)
   {
@@ -106,15 +141,25 @@ public:
 
   void clear()
   {
-    subt::clear();
+    data.clear();
     numbers.clear();
   }
 
-protected:
-  typedef std::vector<T> subt;
+  template <typename U>
+  void push_back(U &&u) { data.push_back(std::forward<U>(u)); }
 
-  typedef std::unordered_map<T, number_type, hash_fkt> numberst;
-  numberst numbers;
+  T &operator[](size_type t) { return data[t]; }
+  const T &operator[](size_type t) const { return data[t]; }
+
+  size_type size() const { return data.size(); }
+
+  iterator begin() { return data.begin(); }
+  const_iterator begin() const { return data.begin(); }
+  const_iterator cbegin() const { return data.cbegin(); }
+
+  iterator end() { return data.end(); }
+  const_iterator end() const { return data.end(); }
+  const_iterator cend() const { return data.cend(); }
 };
 
 #endif // CPROVER_UTIL_NUMBERING_H

--- a/src/util/union_find.h
+++ b/src/util/union_find.h
@@ -130,11 +130,21 @@ public:
 
 template <typename T>
 // NOLINTNEXTLINE(readability/identifiers)
-class union_find:public numbering<T>
+class union_find final
 {
+  typedef numbering<T> numbering_typet;
+  numbering_typet numbers;
+
+  // NOLINTNEXTLINE(readability/identifiers)
+  typedef typename numbering_typet::number_type number_type;
+
 public:
   // NOLINTNEXTLINE(readability/identifiers)
-  typedef typename numbering<T>::size_type size_type;
+  typedef typename numbering_typet::size_type size_type;
+  // NOLINTNEXTLINE(readability/identifiers)
+  typedef typename numbering_typet::iterator iterator;
+  // NOLINTNEXTLINE(readability/identifiers)
+  typedef typename numbering_typet::const_iterator const_iterator;
 
   // true == already in same set
   bool make_union(const T &a, const T &b)
@@ -149,7 +159,7 @@ public:
   bool make_union(typename numbering<T>::const_iterator it_a,
                   typename numbering<T>::const_iterator it_b)
   {
-    size_type na=it_a-numbering<T>::begin(), nb=it_b-numbering<T>::begin();
+    size_type na=it_a-numbers.begin(), nb=it_b-numbers.begin();
     bool is_union=find_number(na)==find_number(nb);
     uuf.make_union(na, nb);
     return is_union;
@@ -158,10 +168,9 @@ public:
   // are 'a' and 'b' in the same set?
   bool same_set(const T &a, const T &b) const
   {
-    typedef typename subt::number_type subt_number_typet;
-    subt_number_typet na=subt_number_typet(), nb=subt_number_typet();
-    bool have_na=!subt::get_number(a, na),
-         have_nb=!subt::get_number(b, nb);
+    number_type na, nb;
+    bool have_na=!numbers.get_number(a, na),
+         have_nb=!numbers.get_number(b, nb);
 
     if(have_na && have_nb)
       return uuf.same_set(na, nb);
@@ -175,22 +184,22 @@ public:
   bool same_set(typename numbering<T>::const_iterator it_a,
                 typename numbering<T>::const_iterator it_b) const
   {
-    return uuf.same_set(it_a-numbering<T>::begin(), it_b-numbering<T>::begin());
+    return uuf.same_set(it_a-numbers.begin(), it_b-numbers.begin());
   }
 
   const T &find(typename numbering<T>::const_iterator it) const
   {
-    return numbering<T>::operator[](find_number(it-numbering<T>::begin()));
+    return numbers[find_number(it-numbers.begin())];
   }
 
   const T &find(const T &a)
   {
-    return numbering<T>::operator[](find_number(number(a)));
+    return numbers[find_number(number(a))];
   }
 
   size_type find_number(typename numbering<T>::const_iterator it) const
   {
-    return find_number(it-numbering<T>::begin());
+    return find_number(it-numbers.begin());
   }
 
   size_type find_number(size_type a) const
@@ -210,9 +219,8 @@ public:
 
   bool is_root(const T &a) const
   {
-    typename subt::number_type na;
-
-    if(subt::get_number(a, na))
+    number_type na;
+    if(numbers.get_number(a, na))
       return true; // not found, it's a root
     else
       return uuf.is_root(na);
@@ -220,36 +228,54 @@ public:
 
   bool is_root(typename numbering<T>::const_iterator it) const
   {
-    return uuf.is_root(it-numbering<T>::begin());
+    return uuf.is_root(it-numbers.begin());
   }
 
   size_type number(const T &a)
   {
-    size_type n=subt::number(a);
+    size_type n=numbers.number(a);
 
     if(n>=uuf.size())
-      uuf.resize(this->size());
+      uuf.resize(numbers.size());
 
-    assert(uuf.size()==this->size());
+    assert(uuf.size()==numbers.size());
 
     return n;
   }
 
   void clear()
   {
-    subt::clear();
+    numbers.clear();
     uuf.clear();
   }
 
   void isolate(typename numbering<T>::const_iterator it)
   {
-    uuf.isolate(it-numbering<T>::begin());
+    uuf.isolate(it-numbers.begin());
   }
 
   void isolate(const T &a)
   {
     uuf.isolate(number(a));
   }
+
+  bool get_number(const T &a, number_type &n) const
+  {
+    return numbers.get_number(a, n);
+  }
+
+  size_t size() const { return numbers.size(); }
+
+  T &operator[](size_type t) { return numbers[t]; }
+  const T &operator[](size_type t) const { return numbers[t]; }
+
+  iterator begin() { return numbers.begin(); }
+  const_iterator begin() const { return numbers.begin(); }
+  const_iterator cbegin() const { return numbers.cbegin(); }
+
+  iterator end() { return numbers.end(); }
+  const_iterator end() const { return numbers.end(); }
+  const_iterator cend() const { return numbers.cend(); }
 
 protected:
   unsigned_union_find uuf;

--- a/src/util/union_find.h
+++ b/src/util/union_find.h
@@ -238,7 +238,7 @@ public:
     if(n>=uuf.size())
       uuf.resize(numbers.size());
 
-    assert(uuf.size()==numbers.size());
+    INVARIANT(uuf.size()==numbers.size(), "container sizes must match");
 
     return n;
   }


### PR DESCRIPTION
The std containers aren't designed to be inherited-from. This patch aims to replace inheritance from std containers with composition. It also removes util/error.h because it seems that this file isn't included anywhere. Let me know if that should be done in a different PR.