### PR TITLE
Strongly typed enums

### DIFF
--- a/src/analyses/custom_bitvector_analysis.cpp
+++ b/src/analyses/custom_bitvector_analysis.cpp
@@ -32,19 +32,19 @@ void custom_bitvector_domaint::set_bit(
 {
   switch(mode)
   {
-  case SET_MUST:
+  case modet::SET_MUST:
     set_bit(must_bits[identifier], bit_nr);
     break;
 
-  case CLEAR_MUST:
+  case modet::CLEAR_MUST:
     clear_bit(must_bits[identifier], bit_nr);
     break;
 
-  case SET_MAY:
+  case modet::SET_MAY:
     set_bit(may_bits[identifier], bit_nr);
     break;
 
-  case CLEAR_MAY:
+  case modet::CLEAR_MAY:
     clear_bit(may_bits[identifier], bit_nr);
     break;
   }
@@ -408,13 +408,13 @@ void custom_bitvector_domaint::transform(
             modet mode;
 
             if(identifier=="__CPROVER_set_must")
-              mode=SET_MUST;
+              mode=modet::SET_MUST;
             else if(identifier=="__CPROVER_clear_must")
-              mode=CLEAR_MUST;
+              mode=modet::CLEAR_MUST;
             else if(identifier=="__CPROVER_set_may")
-              mode=SET_MAY;
+              mode=modet::SET_MAY;
             else if(identifier=="__CPROVER_clear_may")
-              mode=CLEAR_MAY;
+              mode=modet::CLEAR_MAY;
             else
               assert(false);
 
@@ -423,7 +423,7 @@ void custom_bitvector_domaint::transform(
             if(lhs.is_constant() &&
                to_constant_expr(lhs).get_value()==ID_NULL) // NULL means all
             {
-              if(mode==CLEAR_MAY)
+              if(mode==modet::CLEAR_MAY)
               {
                 for(auto &bit : may_bits)
                   clear_bit(bit.second, bit_nr);
@@ -431,7 +431,7 @@ void custom_bitvector_domaint::transform(
                 // erase blank ones
                 erase_blank_vectors(may_bits);
               }
-              else if(mode==CLEAR_MUST)
+              else if(mode==modet::CLEAR_MUST)
               {
                 for(auto &bit : must_bits)
                   clear_bit(bit.second, bit_nr);
@@ -475,13 +475,13 @@ void custom_bitvector_domaint::transform(
         modet mode;
 
         if(statement=="set_must")
-          mode=SET_MUST;
+          mode=modet::SET_MUST;
         else if(statement=="clear_must")
-          mode=CLEAR_MUST;
+          mode=modet::CLEAR_MUST;
         else if(statement=="set_may")
-          mode=SET_MAY;
+          mode=modet::SET_MAY;
         else if(statement=="clear_may")
-          mode=CLEAR_MAY;
+          mode=modet::CLEAR_MAY;
         else
           assert(false);
 
@@ -490,7 +490,7 @@ void custom_bitvector_domaint::transform(
         if(lhs.is_constant() &&
            to_constant_expr(lhs).get_value()==ID_NULL) // NULL means all
         {
-          if(mode==CLEAR_MAY)
+          if(mode==modet::CLEAR_MAY)
           {
             for(bitst::iterator b_it=may_bits.begin();
                 b_it!=may_bits.end();
@@ -500,7 +500,7 @@ void custom_bitvector_domaint::transform(
             // erase blank ones
             erase_blank_vectors(may_bits);
           }
-          else if(mode==CLEAR_MUST)
+          else if(mode==modet::CLEAR_MUST)
           {
             for(bitst::iterator b_it=must_bits.begin();
                 b_it!=must_bits.end();

--- a/src/analyses/custom_bitvector_analysis.h
+++ b/src/analyses/custom_bitvector_analysis.h
@@ -102,7 +102,7 @@ public:
     custom_bitvector_analysist &) const;
 
 private:
-  typedef enum { SET_MUST, CLEAR_MUST, SET_MAY, CLEAR_MAY } modet;
+  enum class modet { SET_MUST, CLEAR_MUST, SET_MAY, CLEAR_MAY };
 
   void set_bit(const exprt &, unsigned bit_nr, modet);
   void set_bit(const irep_idt &, unsigned bit_nr, modet);

--- a/src/analyses/dependence_graph.cpp
+++ b/src/analyses/dependence_graph.cpp
@@ -141,7 +141,7 @@ void dep_graph_domaint::control_dependencies(
 
   // add edges to the graph
   for(const auto &c_dep : control_deps)
-    dep_graph.add_dep(dep_edget::CTRL, c_dep, to);
+    dep_graph.add_dep(dep_edget::kindt::CTRL, c_dep, to);
 }
 
 /*******************************************************************\
@@ -234,7 +234,7 @@ void dep_graph_domaint::data_dependencies(
     // *it might be handled in a future call call to visit only,
     // depending on the sequence of successors; make sure it exists
     dep_graph.get_state(d_dep);
-    dep_graph.add_dep(dep_edget::DATA, d_dep, to);
+    dep_graph.add_dep(dep_edget::kindt::DATA, d_dep, to);
   }
 }
 

--- a/src/analyses/dependence_graph.h
+++ b/src/analyses/dependence_graph.h
@@ -24,27 +24,21 @@ class dependence_grapht;
 class dep_edget
 {
 public:
-  typedef enum
-  {
-    NONE,
-    CTRL,
-    DATA,
-    BOTH
-  } kindt;
+  enum class kindt { NONE, CTRL, DATA, BOTH };
 
   void add(kindt _kind)
   {
     switch(kind)
     {
-      case NONE:
+      case kindt::NONE:
         kind=_kind;
         break;
-      case DATA:
-      case CTRL:
+      case kindt::DATA:
+      case kindt::CTRL:
         if(kind!=_kind)
-          kind=BOTH;
+          kind=kindt::BOTH;
         break;
-      case BOTH:
+      case kindt::BOTH:
         break;
     }
   }

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -179,7 +179,7 @@ void rw_range_sett::get_objects_if(
     get_objects_rec(mode, if_expr.true_case(), range_start, size);
   else
   {
-    get_objects_rec(READ, if_expr.cond());
+    get_objects_rec(get_modet::READ, if_expr.cond());
 
     get_objects_rec(mode, if_expr.false_case(), range_start, size);
     get_objects_rec(mode, if_expr.true_case(), range_start, size);
@@ -205,8 +205,8 @@ void rw_range_sett::get_objects_dereference(
   const range_spect &size)
 {
   const exprt &pointer=deref.pointer();
-  get_objects_rec(READ, pointer);
-  if(mode!=READ)
+  get_objects_rec(get_modet::READ, pointer);
+  if(mode!=get_modet::READ)
     get_objects_rec(mode, pointer);
 }
 
@@ -395,7 +395,7 @@ void rw_range_sett::get_objects_index(
   mp_integer index;
   if(to_integer(simp_index, index))
   {
-    get_objects_rec(READ, expr.index());
+    get_objects_rec(get_modet::READ, expr.index());
     index=-1;
   }
 
@@ -593,42 +593,42 @@ void rw_range_sett::get_objects_address_of(const exprt &object)
     // constant, nothing to do
     return;
   else if(object.id()==ID_symbol)
-    get_objects_rec(READ, object);
+    get_objects_rec(get_modet::READ, object);
   else if(object.id()==ID_dereference)
-    get_objects_rec(READ, object);
+    get_objects_rec(get_modet::READ, object);
   else if(object.id()==ID_index)
   {
     const index_exprt &index=to_index_expr(object);
 
-    get_objects_rec(READ, address_of_exprt(index.array()));
-    get_objects_rec(READ, index.index());
+    get_objects_rec(get_modet::READ, address_of_exprt(index.array()));
+    get_objects_rec(get_modet::READ, index.index());
   }
   else if(object.id()==ID_member)
   {
     const member_exprt &member=to_member_expr(object);
 
-    get_objects_rec(READ, address_of_exprt(member.struct_op()));
+    get_objects_rec(get_modet::READ, address_of_exprt(member.struct_op()));
   }
   else if(object.id()==ID_if)
   {
     const if_exprt &if_expr=to_if_expr(object);
 
-    get_objects_rec(READ, if_expr.cond());
-    get_objects_rec(READ, address_of_exprt(if_expr.true_case()));
-    get_objects_rec(READ, address_of_exprt(if_expr.false_case()));
+    get_objects_rec(get_modet::READ, if_expr.cond());
+    get_objects_rec(get_modet::READ, address_of_exprt(if_expr.true_case()));
+    get_objects_rec(get_modet::READ, address_of_exprt(if_expr.false_case()));
   }
   else if(object.id()==ID_byte_extract_little_endian ||
           object.id()==ID_byte_extract_big_endian)
   {
     const byte_extract_exprt &be=to_byte_extract_expr(object);
 
-    get_objects_rec(READ, address_of_exprt(be.op()));
+    get_objects_rec(get_modet::READ, address_of_exprt(be.op()));
   }
   else if(object.id()==ID_typecast)
   {
     const typecast_exprt &tc=to_typecast_expr(object);
 
-    get_objects_rec(READ, address_of_exprt(tc.op()));
+    get_objects_rec(get_modet::READ, address_of_exprt(tc.op()));
   }
   else
     throw "rw_range_sett: address_of `"+object.id_string()+"' not handled";
@@ -652,7 +652,7 @@ void rw_range_sett::add(
   const range_spect &range_start,
   const range_spect &range_end)
 {
-  objectst::iterator entry=(mode==LHS_W ? w_range_set : r_range_set).
+  objectst::iterator entry=(mode==get_modet::LHS_W ? w_range_set : r_range_set).
     insert(
       std::pair<const irep_idt&, range_domain_baset*>(identifier, 0)).first;
 
@@ -742,9 +742,9 @@ void rw_range_sett::get_objects_rec(
     else
       add(mode, identifier, 0, -1);
   }
-  else if(mode==READ && expr.id()==ID_address_of)
+  else if(mode==get_modet::READ && expr.id()==ID_address_of)
     get_objects_address_of(to_address_of_expr(expr).object());
-  else if(mode==READ)
+  else if(mode==get_modet::READ)
   {
     // possibly affects the full object size, even if range_start/size
     // are only a subset of the bytes (e.g., when using the result of
@@ -757,7 +757,7 @@ void rw_range_sett::get_objects_rec(
   {
     // dereferencing may yield some weird ones, ignore these
   }
-  else if(mode==LHS_W)
+  else if(mode==get_modet::LHS_W)
   {
     forall_operands(it, expr)
       get_objects_rec(mode, *it);
@@ -803,7 +803,7 @@ void rw_range_sett::get_objects_rec(const typet &type)
   if(type.id()==ID_array)
   {
     get_objects_rec(type.subtype());
-    get_objects_rec(READ, to_array_type(type).size());
+    get_objects_rec(get_modet::READ, to_array_type(type).size());
   }
 }
 
@@ -904,7 +904,7 @@ void rw_guarded_range_set_value_sett::get_objects_if(
     get_objects_rec(mode, if_expr.true_case(), range_start, size);
   else
   {
-    get_objects_rec(READ, if_expr.cond());
+    get_objects_rec(get_modet::READ, if_expr.cond());
 
     guardt guard_bak1(guard), guard_bak2(guard);
 
@@ -936,7 +936,7 @@ void rw_guarded_range_set_value_sett::add(
   const range_spect &range_start,
   const range_spect &range_end)
 {
-  objectst::iterator entry=(mode==LHS_W ? w_range_set : r_range_set).
+  objectst::iterator entry=(mode==get_modet::LHS_W ? w_range_set : r_range_set).
     insert(
       std::pair<const irep_idt&, range_domain_baset*>(identifier, 0)).first;
 
@@ -964,8 +964,8 @@ void goto_rw(goto_programt::const_targett target,
              const code_assignt &assign,
              rw_range_sett &rw_set)
 {
-  rw_set.get_objects_rec(target, rw_range_sett::LHS_W, assign.lhs());
-  rw_set.get_objects_rec(target, rw_range_sett::READ, assign.rhs());
+  rw_set.get_objects_rec(target, rw_range_sett::get_modet::LHS_W, assign.lhs());
+  rw_set.get_objects_rec(target, rw_range_sett::get_modet::READ, assign.rhs());
 }
 
 /*******************************************************************\
@@ -987,16 +987,16 @@ void goto_rw(goto_programt::const_targett target,
   if(function_call.lhs().is_not_nil())
     rw_set.get_objects_rec(
       target,
-      rw_range_sett::LHS_W,
+      rw_range_sett::get_modet::LHS_W,
       function_call.lhs());
 
   rw_set.get_objects_rec(
     target,
-    rw_range_sett::READ,
+    rw_range_sett::get_modet::READ,
     function_call.function());
 
   forall_expr(it, function_call.arguments())
-    rw_set.get_objects_rec(target, rw_range_sett::READ, *it);
+    rw_set.get_objects_rec(target, rw_range_sett::get_modet::READ, *it);
 }
 
 /*******************************************************************\
@@ -1025,7 +1025,7 @@ void goto_rw(goto_programt::const_targett target,
   case ASSERT:
     rw_set.get_objects_rec(
       target,
-      rw_range_sett::READ,
+      rw_range_sett::get_modet::READ,
       target->guard);
     break;
 
@@ -1036,7 +1036,7 @@ void goto_rw(goto_programt::const_targett target,
       if(code_return.has_return_value())
         rw_set.get_objects_rec(
           target,
-          rw_range_sett::READ,
+          rw_range_sett::get_modet::READ,
           code_return.return_value());
     }
     break;
@@ -1046,7 +1046,7 @@ void goto_rw(goto_programt::const_targett target,
     if(target->code.get(ID_statement)==ID_printf)
     {
       forall_expr(it, target->code.operands())
-        rw_set.get_objects_rec(target, rw_range_sett::READ, *it);
+        rw_set.get_objects_rec(target, rw_range_sett::get_modet::READ, *it);
     }
     break;
 
@@ -1069,7 +1069,7 @@ void goto_rw(goto_programt::const_targett target,
   case DEAD:
     rw_set.get_objects_rec(
       target,
-      rw_range_sett::LHS_W,
+      rw_range_sett::get_modet::LHS_W,
       to_code_dead(target->code).symbol());
     break;
 
@@ -1078,7 +1078,7 @@ void goto_rw(goto_programt::const_targett target,
       to_code_decl(target->code).symbol().type());
     rw_set.get_objects_rec(
       target,
-      rw_range_sett::LHS_W,
+      rw_range_sett::get_modet::LHS_W,
       to_code_decl(target->code).symbol());
     break;
 

--- a/src/analyses/goto_rw.h
+++ b/src/analyses/goto_rw.h
@@ -111,7 +111,7 @@ public:
     return *static_cast<range_domaint*>(it->second);
   }
 
-  typedef enum { LHS_W, READ } get_modet;
+  enum class get_modet { LHS_W, READ };
 
   virtual void get_objects_rec(
     goto_programt::const_targett _target,

--- a/src/analyses/local_bitvector_analysis.h
+++ b/src/analyses/local_bitvector_analysis.h
@@ -61,7 +61,7 @@ public:
     }
 
     // the bits for the "bitvector analysis"
-    typedef enum
+    enum bitst
     {
       B_unknown=1<<0,
       B_uninitialized=1<<1,
@@ -71,7 +71,7 @@ public:
       B_null=1<<5,
       B_static_lifetime=1<<6,
       B_integer_address=1<<7
-    } bitst;
+    };
 
     explicit flagst(const bitst _bits):bits(_bits)
     {

--- a/src/ansi-c/ansi_c_parser.cpp
+++ b/src/ansi-c/ansi_c_parser.cpp
@@ -59,15 +59,15 @@ ansi_c_id_classt ansi_c_parsert::lookup(
   {
     ansi_c_identifiert &i=
       current_scope().name_map[scope_name];
-    i.id_class=ANSI_C_TAG;
+    i.id_class=ansi_c_id_classt::ANSI_C_TAG;
     i.prefixed_name=current_scope().prefix+id2string(scope_name);
     i.base_name=base_name;
     identifier=i.prefixed_name;
-    return ANSI_C_TAG;
+    return ansi_c_id_classt::ANSI_C_TAG;
   }
 
   identifier=base_name;
-  return ANSI_C_UNKNOWN;
+  return ansi_c_id_classt::ANSI_C_UNKNOWN;
 }
 
 /*******************************************************************\
@@ -94,7 +94,7 @@ void ansi_c_parsert::add_tag_with_body(irept &tag)
     // re-defined in a deeper scope
     ansi_c_identifiert &identifier=
       current_scope().name_map[scope_name];
-    identifier.id_class=ANSI_C_TAG;
+    identifier.id_class=ansi_c_id_classt::ANSI_C_TAG;
     identifier.prefixed_name=prefixed_name;
     tag.set(ID_identifier, prefixed_name);
   }
@@ -180,8 +180,9 @@ void ansi_c_parsert::add_declarator(
     if(is_extern)
       force_root_scope=true;
 
-    ansi_c_id_classt id_class=
-      is_typedef?ANSI_C_TYPEDEF:ANSI_C_SYMBOL;
+    ansi_c_id_classt id_class=is_typedef?
+      ansi_c_id_classt::ANSI_C_TYPEDEF:
+      ansi_c_id_classt::ANSI_C_SYMBOL;
 
     scopet &scope=
       force_root_scope?root_scope():current_scope();
@@ -216,19 +217,19 @@ Function: ansi_c_parsert::get_class
 ansi_c_id_classt ansi_c_parsert::get_class(const typet &type)
 {
   if(type.id()==ID_typedef)
-    return ANSI_C_TYPEDEF;
+    return ansi_c_id_classt::ANSI_C_TYPEDEF;
   else if(type.id()==ID_struct ||
           type.id()==ID_union ||
           type.id()==ID_c_enum)
-    return ANSI_C_TAG;
+    return ansi_c_id_classt::ANSI_C_TAG;
   else if(type.id()==ID_merged_type)
   {
     forall_subtypes(it, type)
-      if(get_class(*it)==ANSI_C_TYPEDEF)
-        return ANSI_C_TYPEDEF;
+      if(get_class(*it)==ansi_c_id_classt::ANSI_C_TYPEDEF)
+        return ansi_c_id_classt::ANSI_C_TYPEDEF;
   }
   else if(type.has_subtype())
     return get_class(type.subtype());
 
-  return ANSI_C_SYMBOL;
+  return ansi_c_id_classt::ANSI_C_SYMBOL;
 }

--- a/src/ansi-c/ansi_c_parser.h
+++ b/src/ansi-c/ansi_c_parser.h
@@ -98,7 +98,7 @@ public:
     return scopes.back();
   }
 
-  typedef enum { TAG, MEMBER, PARAMETER, OTHER } decl_typet;
+  enum class decl_typet { TAG, MEMBER, PARAMETER, OTHER };
 
   // convert a declarator and then add it to existing an declaration
   void add_declarator(exprt &declaration, irept &declarator);

--- a/src/ansi-c/ansi_c_scope.cpp
+++ b/src/ansi-c/ansi_c_scope.cpp
@@ -29,7 +29,7 @@ void ansi_c_scopet::print(std::ostream &out) const
   for(const auto &name : name_map)
   {
     out << "  ID: " << name.first
-        << " CLASS: " << name.second.id_class
+        << " CLASS: " << static_cast<int>(name.second.id_class)
         << "\n";
   }
 }

--- a/src/ansi-c/ansi_c_scope.h
+++ b/src/ansi-c/ansi_c_scope.h
@@ -11,8 +11,16 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/irep.h>
 
-typedef enum { ANSI_C_UNKNOWN, ANSI_C_SYMBOL, ANSI_C_TYPEDEF,
-               ANSI_C_TAG, ANSI_C_LOCAL_LABEL } ansi_c_id_classt;
+enum class ansi_c_id_classt
+{
+  ANSI_C_UNKNOWN,
+  ANSI_C_SYMBOL,
+  ANSI_C_TYPEDEF,
+  ANSI_C_TAG,
+  ANSI_C_LOCAL_LABEL
+};
+
+std::ostream &operator<<(std::ostream &os, ansi_c_id_classt c);
 
 class ansi_c_identifiert
 {
@@ -20,7 +28,7 @@ public:
   ansi_c_id_classt id_class;
   irep_idt base_name, prefixed_name;
 
-  ansi_c_identifiert():id_class(ANSI_C_UNKNOWN)
+  ansi_c_identifiert():id_class(ansi_c_id_classt::ANSI_C_UNKNOWN)
   {
   }
 };

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -265,7 +265,8 @@ identifier:
           irep_idt value=stack($2).get(ID_value);
           stack($$).set(ID_C_base_name, value);
           stack($$).set(ID_identifier, value);
-          stack($$).set(ID_C_id_class, ANSI_C_SYMBOL);
+          stack($$).set(
+            ID_C_id_class, static_cast<int>(ansi_c_id_classt::ANSI_C_SYMBOL));
         }
         ;
 
@@ -2387,7 +2388,7 @@ gcc_local_label_statement:
             irep_idt base_name=it->get(ID_identifier);
             irep_idt id="label-"+id2string(base_name);
             ansi_c_parsert::identifiert &i=PARSER.current_scope().name_map[id];
-            i.id_class=ANSI_C_LOCAL_LABEL;
+            i.id_class=ansi_c_id_classt::ANSI_C_LOCAL_LABEL;
             i.prefixed_name=PARSER.current_scope().prefix+id2string(id);
             i.base_name=base_name;
           }

--- a/src/ansi-c/parser_static.inc
+++ b/src/ansi-c/parser_static.inc
@@ -364,7 +364,7 @@ static void create_function_scope(const YYSTYPE d)
           irep_idt base_name=param_decl.declarator().get_base_name();
           ansi_c_identifiert &identifier=
             PARSER.current_scope().name_map[base_name];
-          identifier.id_class=ANSI_C_SYMBOL;
+          identifier.id_class=ansi_c_id_classt::ANSI_C_SYMBOL;
           identifier.base_name=base_name;
           identifier.prefixed_name=param_decl.declarator().get_name();
         }

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -96,9 +96,9 @@ int make_identifier()
     stack(yyansi_clval).id(ID_symbol);
     stack(yyansi_clval).set(ID_C_base_name, base_name);
     stack(yyansi_clval).set(ID_identifier, identifier);
-    stack(yyansi_clval).set(ID_C_id_class, result);
+    stack(yyansi_clval).set(ID_C_id_class, static_cast<int>(result));
 
-    if(result==ANSI_C_TYPEDEF)
+    if(result==ansi_c_id_classt::ANSI_C_TYPEDEF)
       return TOK_TYPEDEFNAME;
     else
       return TOK_IDENTIFIER;

--- a/src/cbmc/all_properties.cpp
+++ b/src/cbmc/all_properties.cpp
@@ -166,7 +166,7 @@ safety_checkert::resultt bmc_all_propertiest::operator()()
   report(cover_goals);
 
   if(error)
-    return safety_checkert::ERROR;
+    return safety_checkert::resultt::ERROR;
 
   bool safe=(cover_goals.number_covered()==0);
 
@@ -175,7 +175,7 @@ safety_checkert::resultt bmc_all_propertiest::operator()()
   else
     bmc.report_failure(); // legacy, might go away
 
-  return safe?safety_checkert::SAFE:safety_checkert::UNSAFE;
+  return safe?safety_checkert::resultt::SAFE:safety_checkert::resultt::UNSAFE;
 }
 
 /*******************************************************************\

--- a/src/cbmc/all_properties.cpp
+++ b/src/cbmc/all_properties.cpp
@@ -140,7 +140,7 @@ safety_checkert::resultt bmc_all_propertiest::operator()()
 
   decision_proceduret::resultt result=cover_goals();
 
-  if(result==decision_proceduret::D_ERROR)
+  if(result==decision_proceduret::resultt::D_ERROR)
   {
     error=true;
     for(auto &g : goal_map)

--- a/src/cbmc/all_properties.cpp
+++ b/src/cbmc/all_properties.cpp
@@ -194,7 +194,7 @@ void bmc_all_propertiest::report(const cover_goalst &cover_goals)
 {
   switch(bmc.ui)
   {
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     {
       status() << "\n** Results:" << eom;
 
@@ -222,7 +222,7 @@ void bmc_all_propertiest::report(const cover_goalst &cover_goals)
     }
     break;
 
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
     {
       for(const auto &g : goal_map)
       {
@@ -238,7 +238,7 @@ void bmc_all_propertiest::report(const cover_goalst &cover_goals)
       break;
     }
 
-    case ui_message_handlert::JSON_UI:
+    case ui_message_handlert::uit::JSON_UI:
     {
       json_objectt json_result;
       json_arrayt &result_array=json_result["result"].make_array();

--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -77,12 +77,12 @@ void bmct::error_trace()
 
   switch(ui)
   {
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     std::cout << "\n" << "Counterexample:" << "\n";
     show_goto_trace(std::cout, ns, goto_trace);
     break;
 
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
     {
       xmlt xml;
       convert(ns, goto_trace, xml);
@@ -90,7 +90,7 @@ void bmct::error_trace()
     }
     break;
 
-  case ui_message_handlert::JSON_UI:
+  case ui_message_handlert::uit::JSON_UI:
     {
       json_objectt json_result;
       json_arrayt &result_array=json_result["results"].make_array();
@@ -235,10 +235,10 @@ void bmct::report_success()
 
   switch(ui)
   {
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     break;
 
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
     {
       xmlt xml("cprover-status");
       xml.data="SUCCESS";
@@ -247,7 +247,7 @@ void bmct::report_success()
     }
     break;
 
-  case ui_message_handlert::JSON_UI:
+  case ui_message_handlert::uit::JSON_UI:
     {
       json_objectt json_result;
       json_result["cProverStatus"]=json_stringt("success");
@@ -275,10 +275,10 @@ void bmct::report_failure()
 
   switch(ui)
   {
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     break;
 
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
     {
       xmlt xml("cprover-status");
       xml.data="FAILURE";
@@ -287,7 +287,7 @@ void bmct::report_failure()
     }
     break;
 
-  case ui_message_handlert::JSON_UI:
+  case ui_message_handlert::uit::JSON_UI:
     {
       json_objectt json_result;
       json_result["cProverStatus"]=json_stringt("failure");

--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -637,12 +637,12 @@ safety_checkert::resultt bmct::stop_on_fail(
 {
   switch(run_decision_procedure(prop_conv))
   {
-  case decision_proceduret::D_UNSATISFIABLE:
+  case decision_proceduret::resultt::D_UNSATISFIABLE:
     report_success();
     output_graphml(resultt::SAFE, goto_functions);
     return resultt::SAFE;
 
-  case decision_proceduret::D_SATISFIABLE:
+  case decision_proceduret::resultt::D_SATISFIABLE:
     if(options.get_bool_option("trace"))
     {
       if(options.get_bool_option("beautify"))

--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -130,9 +130,9 @@ void bmct::output_graphml(
     return;
 
   graphml_witnesst graphml_witness(ns);
-  if(result==UNSAFE)
+  if(result==resultt::UNSAFE)
     graphml_witness(safety_checkert::error_trace);
-  else if(result==SAFE)
+  else if(result==resultt::SAFE)
     graphml_witness(equation);
   else
     return;
@@ -426,7 +426,7 @@ safety_checkert::resultt bmct::run(
   {
     error() << "Invalid memory model " << mm
             << " -- use one of sc, tso, pso" << eom;
-    return safety_checkert::ERROR;
+    return safety_checkert::resultt::ERROR;
   }
 
   symex.set_message_handler(get_message_handler());
@@ -464,7 +464,7 @@ safety_checkert::resultt bmct::run(
     message.error().source_location=symex.last_source_location;
     message.error() << error_str << messaget::eom;
 
-    return safety_checkert::ERROR;
+    return safety_checkert::resultt::ERROR;
   }
 
   catch(const char *error_str)
@@ -473,13 +473,13 @@ safety_checkert::resultt bmct::run(
     message.error().source_location=symex.last_source_location;
     message.error() << error_str << messaget::eom;
 
-    return safety_checkert::ERROR;
+    return safety_checkert::resultt::ERROR;
   }
 
   catch(std::bad_alloc)
   {
     error() << "Out of memory" << eom;
-    return safety_checkert::ERROR;
+    return safety_checkert::resultt::ERROR;
   }
 
   statistics() << "size of program expression: "
@@ -534,13 +534,13 @@ safety_checkert::resultt bmct::run(
        symex.output_coverage_report(goto_functions, cov_out))
     {
       error() << "Failed to write symex coverage report" << eom;
-      return safety_checkert::ERROR;
+      return safety_checkert::resultt::ERROR;
     }
 
     if(options.get_bool_option("show-vcc"))
     {
       show_vcc();
-      return safety_checkert::SAFE; // to indicate non-error
+      return safety_checkert::resultt::SAFE; // to indicate non-error
     }
 
     if(!options.get_list_option("cover").empty())
@@ -548,7 +548,7 @@ safety_checkert::resultt bmct::run(
       const optionst::value_listt criteria=
         options.get_list_option("cover");
       return cover(goto_functions, criteria)?
-        safety_checkert::ERROR:safety_checkert::SAFE;
+        safety_checkert::resultt::ERROR:safety_checkert::resultt::SAFE;
     }
 
     if(options.get_option("localize-faults")!="")
@@ -563,14 +563,14 @@ safety_checkert::resultt bmct::run(
        symex.remaining_vccs==0)
     {
       report_success();
-      output_graphml(SAFE, goto_functions);
-      return safety_checkert::SAFE;
+      output_graphml(resultt::SAFE, goto_functions);
+      return safety_checkert::resultt::SAFE;
     }
 
     if(options.get_bool_option("program-only"))
     {
       show_program();
-      return safety_checkert::SAFE;
+      return safety_checkert::resultt::SAFE;
     }
 
     return decide(goto_functions, prop_conv);
@@ -579,19 +579,19 @@ safety_checkert::resultt bmct::run(
   catch(std::string &error_str)
   {
     error() << error_str << eom;
-    return safety_checkert::ERROR;
+    return safety_checkert::resultt::ERROR;
   }
 
   catch(const char *error_str)
   {
     error() << error_str << eom;
-    return safety_checkert::ERROR;
+    return safety_checkert::resultt::ERROR;
   }
 
   catch(std::bad_alloc)
   {
     error() << "Out of memory" << eom;
-    return safety_checkert::ERROR;
+    return safety_checkert::resultt::ERROR;
   }
 }
 
@@ -639,8 +639,8 @@ safety_checkert::resultt bmct::stop_on_fail(
   {
   case decision_proceduret::D_UNSATISFIABLE:
     report_success();
-    output_graphml(SAFE, goto_functions);
-    return SAFE;
+    output_graphml(resultt::SAFE, goto_functions);
+    return resultt::SAFE;
 
   case decision_proceduret::D_SATISFIABLE:
     if(options.get_bool_option("trace"))
@@ -650,20 +650,20 @@ safety_checkert::resultt bmct::stop_on_fail(
           dynamic_cast<bv_cbmct &>(prop_conv), equation, ns);
 
       error_trace();
-      output_graphml(UNSAFE, goto_functions);
+      output_graphml(resultt::UNSAFE, goto_functions);
     }
 
     report_failure();
-    return UNSAFE;
+    return resultt::UNSAFE;
 
   default:
     if(options.get_bool_option("dimacs") ||
        options.get_option("outfile")!="")
-      return SAFE;
+      return resultt::SAFE;
 
     error() << "decision procedure failed" << eom;
 
-    return ERROR;
+    return resultt::ERROR;
   }
 }
 

--- a/src/cbmc/bmc.h
+++ b/src/cbmc/bmc.h
@@ -40,7 +40,7 @@ public:
     equation(ns),
     symex(ns, new_symbol_table, equation),
     prop_conv(_prop_conv),
-    ui(ui_message_handlert::PLAIN)
+    ui(ui_message_handlert::uit::PLAIN)
   {
     symex.constant_propagation=options.get_bool_option("propagation");
     symex.record_coverage=

--- a/src/cbmc/bmc_cover.cpp
+++ b/src/cbmc/bmc_cover.cpp
@@ -309,7 +309,7 @@ bool bmc_covert::operator()()
 
   switch(bmc.ui)
   {
-    case ui_message_handlert::PLAIN:
+    case ui_message_handlert::uit::PLAIN:
     {
       status() << "\n** coverage results:" << eom;
 
@@ -334,7 +334,7 @@ bool bmc_covert::operator()()
       break;
     }
 
-    case ui_message_handlert::XML_UI:
+    case ui_message_handlert::uit::XML_UI:
     {
       for(const auto &goal_pair : goal_map)
       {
@@ -386,7 +386,7 @@ bool bmc_covert::operator()()
       break;
     }
 
-    case ui_message_handlert::JSON_UI:
+    case ui_message_handlert::uit::JSON_UI:
     {
       json_objectt json_result;
       json_arrayt &goals_array=json_result["goals"].make_array();
@@ -452,7 +452,7 @@ bool bmc_covert::operator()()
                << (cover_goals.iterations()==1?"":"s")
                << eom;
 
-  if(bmc.ui==ui_message_handlert::PLAIN)
+  if(bmc.ui==ui_message_handlert::uit::PLAIN)
   {
     std::cout << "Test suite:" << '\n';
 

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -1010,13 +1010,13 @@ int cbmc_parse_optionst::do_bmc(
   // do actual BMC
   switch(bmc.run(goto_functions))
   {
-    case safety_checkert::SAFE:
+    case safety_checkert::resultt::SAFE:
       result=0;
       break;
-    case safety_checkert::UNSAFE:
+    case safety_checkert::resultt::UNSAFE:
       result=10;
       break;
-    case safety_checkert::ERROR:
+    case safety_checkert::resultt::ERROR:
       result=6;
       break;
   }

--- a/src/cbmc/cbmc_solvers.cpp
+++ b/src/cbmc/cbmc_solvers.cpp
@@ -80,24 +80,24 @@ smt2_dect::solvert cbmc_solverst::get_smt2_solver_type() const
 {
   assert(options.get_bool_option("smt2"));
 
-  smt2_dect::solvert s=smt2_dect::GENERIC;
+  smt2_dect::solvert s=smt2_dect::solvert::GENERIC;
 
   if(options.get_bool_option("boolector"))
-    s=smt2_dect::BOOLECTOR;
+    s=smt2_dect::solvert::BOOLECTOR;
   else if(options.get_bool_option("mathsat"))
-    s=smt2_dect::MATHSAT;
+    s=smt2_dect::solvert::MATHSAT;
   else if(options.get_bool_option("cvc3"))
-    s=smt2_dect::CVC3;
+    s=smt2_dect::solvert::CVC3;
   else if(options.get_bool_option("cvc4"))
-    s=smt2_dect::CVC4;
+    s=smt2_dect::solvert::CVC4;
   else if(options.get_bool_option("opensmt"))
-    s=smt2_dect::OPENSMT;
+    s=smt2_dect::solvert::OPENSMT;
   else if(options.get_bool_option("yices"))
-    s=smt2_dect::YICES;
+    s=smt2_dect::solvert::YICES;
   else if(options.get_bool_option("z3"))
-    s=smt2_dect::Z3;
+    s=smt2_dect::solvert::Z3;
   else if(options.get_bool_option("generic"))
-    s=smt2_dect::GENERIC;
+    s=smt2_dect::solvert::GENERIC;
 
   return s;
 }
@@ -312,7 +312,7 @@ cbmc_solverst::solvert* cbmc_solverst::get_smt2(smt2_dect::solvert solver)
 
   if(filename=="")
   {
-    if(solver==smt2_dect::GENERIC)
+    if(solver==smt2_dect::solvert::GENERIC)
     {
       error() << "please use --outfile" << eom;
       throw 0;

--- a/src/cbmc/cbmc_solvers.cpp
+++ b/src/cbmc/cbmc_solvers.cpp
@@ -134,9 +134,9 @@ cbmc_solverst::solvert* cbmc_solverst::get_default()
   bv_cbmct *bv_cbmc=new bv_cbmct(ns, solver->prop());
 
   if(options.get_option("arrays-uf")=="never")
-    bv_cbmc->unbounded_array=bv_cbmct::U_NONE;
+    bv_cbmc->unbounded_array=bv_cbmct::unbounded_arrayt::U_NONE;
   else if(options.get_option("arrays-uf")=="always")
-    bv_cbmc->unbounded_array=bv_cbmct::U_ALL;
+    bv_cbmc->unbounded_array=bv_cbmct::unbounded_arrayt::U_ALL;
 
   solver->set_prop_conv(bv_cbmc);
 

--- a/src/cbmc/cbmc_solvers.cpp
+++ b/src/cbmc/cbmc_solvers.cpp
@@ -42,24 +42,24 @@ smt1_dect::solvert cbmc_solverst::get_smt1_solver_type() const
 {
   assert(options.get_bool_option("smt1"));
 
-  smt1_dect::solvert s=smt1_dect::GENERIC;
+  smt1_dect::solvert s=smt1_dect::solvert::GENERIC;
 
   if(options.get_bool_option("boolector"))
-    s=smt1_dect::BOOLECTOR;
+    s=smt1_dect::solvert::BOOLECTOR;
   else if(options.get_bool_option("mathsat"))
-    s=smt1_dect::MATHSAT;
+    s=smt1_dect::solvert::MATHSAT;
   else if(options.get_bool_option("cvc3"))
-    s=smt1_dect::CVC3;
+    s=smt1_dect::solvert::CVC3;
   else if(options.get_bool_option("cvc4"))
-    s=smt1_dect::CVC4;
+    s=smt1_dect::solvert::CVC4;
   else if(options.get_bool_option("opensmt"))
-    s=smt1_dect::OPENSMT;
+    s=smt1_dect::solvert::OPENSMT;
   else if(options.get_bool_option("yices"))
-    s=smt1_dect::YICES;
+    s=smt1_dect::solvert::YICES;
   else if(options.get_bool_option("z3"))
-    s=smt1_dect::Z3;
+    s=smt1_dect::solvert::Z3;
   else if(options.get_bool_option("generic"))
-    s=smt1_dect::GENERIC;
+    s=smt1_dect::solvert::GENERIC;
 
   return s;
 }
@@ -232,7 +232,7 @@ cbmc_solverst::solvert* cbmc_solverst::get_smt1(smt1_dect::solvert solver)
 
   if(filename=="")
   {
-    if(solver==smt1_dect::GENERIC)
+    if(solver==smt1_dect::solvert::GENERIC)
     {
       error() << "please use --outfile" << eom;
       throw 0;

--- a/src/cbmc/counterexample_beautification.cpp
+++ b/src/cbmc/counterexample_beautification.cpp
@@ -40,7 +40,7 @@ void counterexample_beautificationt::get_minimization_list(
       it!=equation.SSA_steps.end(); it++)
   {
     if(it->is_assignment() &&
-       it->assignment_type==symex_targett::STATE)
+       it->assignment_type==symex_targett::assignment_typet::STATE)
     {
       if(!prop_conv.l_get(it->guard_literal).is_false())
       {
@@ -136,7 +136,7 @@ void counterexample_beautificationt::operator()(
         it!=equation.SSA_steps.end(); it++)
     {
       if(it->is_assignment() &&
-         it->assignment_type!=symex_targett::HIDDEN)
+         it->assignment_type!=symex_targett::assignment_typet::HIDDEN)
       {
         if(!it->guard_literal.is_constant())
           guard_count[it->guard_literal]++;

--- a/src/cbmc/fault_localization.cpp
+++ b/src/cbmc/fault_localization.cpp
@@ -139,7 +139,7 @@ bool fault_localizationt::check(const lpointst &lpoints,
 
   bmc.prop_conv.set_assumptions(assumptions);
 
-  if(bmc.prop_conv()==decision_proceduret::D_SATISFIABLE)
+  if(bmc.prop_conv()==decision_proceduret::resultt::D_SATISFIABLE)
     return false;
 
   return true;
@@ -362,11 +362,11 @@ safety_checkert::resultt fault_localizationt::stop_on_fail()
 {
   switch(run_decision_procedure(bmc.prop_conv))
   {
-  case decision_proceduret::D_UNSATISFIABLE:
+  case decision_proceduret::resultt::D_UNSATISFIABLE:
     bmc.report_success();
     return safety_checkert::resultt::SAFE;
 
-  case decision_proceduret::D_SATISFIABLE:
+  case decision_proceduret::resultt::D_SATISFIABLE:
     if(options.get_bool_option("trace"))
     {
       if(options.get_bool_option("beautify"))

--- a/src/cbmc/fault_localization.cpp
+++ b/src/cbmc/fault_localization.cpp
@@ -64,7 +64,7 @@ void fault_localizationt::collect_guards(lpointst &lpoints)
       it!=bmc.equation.SSA_steps.end(); it++)
   {
     if(it->is_assignment() &&
-       it->assignment_type==symex_targett::STATE &&
+       it->assignment_type==symex_targett::assignment_typet::STATE &&
        !it->ignore)
     {
       if(!it->guard_literal.is_constant())

--- a/src/cbmc/fault_localization.cpp
+++ b/src/cbmc/fault_localization.cpp
@@ -453,7 +453,7 @@ void fault_localizationt::report(
 
   switch(bmc.ui)
   {
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     if(cover_goals.number_covered()>0)
     {
       status() << "\n** Most likely fault location:" << eom;
@@ -465,9 +465,9 @@ void fault_localizationt::report(
       }
     }
     break;
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
     break;
-  case ui_message_handlert::JSON_UI:
+  case ui_message_handlert::uit::JSON_UI:
     break;
   }
 }

--- a/src/cbmc/fault_localization.cpp
+++ b/src/cbmc/fault_localization.cpp
@@ -364,7 +364,7 @@ safety_checkert::resultt fault_localizationt::stop_on_fail()
   {
   case decision_proceduret::D_UNSATISFIABLE:
     bmc.report_success();
-    return safety_checkert::SAFE;
+    return safety_checkert::resultt::SAFE;
 
   case decision_proceduret::D_SATISFIABLE:
     if(options.get_bool_option("trace"))
@@ -382,12 +382,12 @@ safety_checkert::resultt fault_localizationt::stop_on_fail()
     report(ID_nil);
 
     bmc.report_failure();
-    return safety_checkert::UNSAFE;
+    return safety_checkert::resultt::UNSAFE;
 
   default:
     error() << "decision procedure failed" << eom;
 
-    return safety_checkert::ERROR;
+    return safety_checkert::resultt::ERROR;
   }
 }
 

--- a/src/cbmc/show_vcc.cpp
+++ b/src/cbmc/show_vcc.cpp
@@ -190,15 +190,15 @@ void bmct::show_vcc()
 
   switch(ui)
   {
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
     error() << "XML UI not supported" << eom;
     return;
 
-  case ui_message_handlert::JSON_UI:
+  case ui_message_handlert::uit::JSON_UI:
     show_vcc_json(out);
     break;
 
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     show_vcc_plain(out);
     break;
   }

--- a/src/clobber/clobber_parse_options.cpp
+++ b/src/clobber/clobber_parse_options.cpp
@@ -524,10 +524,10 @@ void clobber_parse_optionst::report_success()
 
   switch(get_ui())
   {
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     break;
 
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
     {
       xmlt xml("cprover-status");
       xml.data="SUCCESS";
@@ -560,12 +560,12 @@ void clobber_parse_optionst::show_counterexample(
 
   switch(get_ui())
   {
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     std::cout << std::endl << "Counterexample:" << std::endl;
     show_goto_trace(std::cout, ns, error_trace);
     break;
 
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
     {
       xmlt xml;
       convert(ns, error_trace, xml);
@@ -596,10 +596,10 @@ void clobber_parse_optionst::report_failure()
 
   switch(get_ui())
   {
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     break;
 
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
     {
       xmlt xml("cprover-status");
       xml.data="FAILURE";

--- a/src/cpp/cpp_declarator_converter.cpp
+++ b/src/cpp/cpp_declarator_converter.cpp
@@ -160,7 +160,7 @@ symbolt &cpp_declarator_convertert::convert(
       exprt symbol_expr=
         cpp_typecheck.resolve(
           name,
-          cpp_typecheck_resolvet::TYPE,
+          cpp_typecheck_resolvet::wantt::TYPE,
           cpp_typecheck_fargst());
 
       if(symbol_expr.id()!=ID_type ||

--- a/src/cpp/cpp_declarator_converter.cpp
+++ b/src/cpp/cpp_declarator_converter.cpp
@@ -100,7 +100,7 @@ symbolt &cpp_declarator_convertert::convert(
   get_final_identifier();
 
   // first see if it is a member
-  if(scope->id_class==cpp_idt::CLASS && !is_friend)
+  if(scope->id_class==cpp_idt::id_classt::CLASS && !is_friend)
   {
     // it's a member! it must be declared already
 
@@ -238,13 +238,13 @@ symbolt &cpp_declarator_convertert::convert(
       cpp_scopet::id_sett id_set;
 
       scope->lookup_identifier(
-        symbol.name, cpp_idt::TEMPLATE_PARAMETER, id_set);
+        symbol.name, cpp_idt::id_classt::TEMPLATE_PARAMETER, id_set);
 
       if(id_set.empty())
       {
         cpp_idt &identifier=
           cpp_typecheck.cpp_scopes.put_into_scope(symbol, *scope);
-        identifier.id_class=cpp_idt::TEMPLATE_PARAMETER;
+        identifier.id_class=cpp_idt::id_classt::TEMPLATE_PARAMETER;
       }
     }
 
@@ -618,13 +618,13 @@ symbolt &cpp_declarator_convertert::convert_new_symbol(
     cpp_typecheck.cpp_scopes.put_into_scope(*new_symbol, *scope, is_friend);
 
   if(is_template)
-    identifier.id_class=cpp_idt::TEMPLATE;
+    identifier.id_class=cpp_idt::id_classt::TEMPLATE;
   else if(is_template_parameter)
-    identifier.id_class=cpp_idt::TEMPLATE_PARAMETER;
+    identifier.id_class=cpp_idt::id_classt::TEMPLATE_PARAMETER;
   else if(is_typedef)
-    identifier.id_class=cpp_idt::TYPEDEF;
+    identifier.id_class=cpp_idt::id_classt::TYPEDEF;
   else
-    identifier.id_class=cpp_idt::SYMBOL;
+    identifier.id_class=cpp_idt::id_classt::SYMBOL;
 
   // do the value
   if(!new_symbol->is_type)

--- a/src/cpp/cpp_id.cpp
+++ b/src/cpp/cpp_id.cpp
@@ -29,7 +29,7 @@ cpp_idt::cpp_idt():
   is_static_member(false),
   is_scope(false),
   is_constructor(false),
-  id_class(UNKNOWN),
+  id_class(id_classt::UNKNOWN),
   this_expr(static_cast<const exprt &>(get_nil_irep())),
   compound_counter(0),
   parent(NULL)
@@ -163,20 +163,16 @@ std::ostream &operator<<(std::ostream &out, const cpp_idt::id_classt &id_class)
 {
   switch(id_class)
   {
-    case cpp_idt::UNKNOWN:            out << "UNKNOWN"; break;
-    case cpp_idt::SYMBOL:             out << "SYMBOL"; break;
-    case cpp_idt::TYPEDEF:            out << "TYPEDEF"; break;
-    case cpp_idt::CLASS:              out << "CLASS"; break;
-    case cpp_idt::TEMPLATE:           out << "TEMPLATE"; break;
-    case cpp_idt::TEMPLATE_PARAMETER: out << "TEMPLATE_PARAMETER"; break;
-    case cpp_idt::ROOT_SCOPE:         out << "ROOT_SCOPE"; break;
-    case cpp_idt::BLOCK_SCOPE:        out << "BLOCK_SCOPE"; break;
-    case cpp_idt::TEMPLATE_SCOPE:     out << "TEMPLATE_SCOPE"; break;
-    case cpp_idt::NAMESPACE:          out << "NAMESPACE"; break;
-
-    default:
-      out << "(OTHER)";
+  case cpp_idt::id_classt::UNKNOWN:           return out<<"UNKNOWN";
+  case cpp_idt::id_classt::SYMBOL:            return out<<"SYMBOL";
+  case cpp_idt::id_classt::TYPEDEF:           return out<<"TYPEDEF";
+  case cpp_idt::id_classt::CLASS:             return out<<"CLASS";
+  case cpp_idt::id_classt::TEMPLATE:          return out<<"TEMPLATE";
+  case cpp_idt::id_classt::TEMPLATE_PARAMETER:return out<<"TEMPLATE_PARAMETER";
+  case cpp_idt::id_classt::ROOT_SCOPE:        return out<<"ROOT_SCOPE";
+  case cpp_idt::id_classt::BLOCK_SCOPE:       return out<<"BLOCK_SCOPE";
+  case cpp_idt::id_classt::TEMPLATE_SCOPE:    return out<<"TEMPLATE_SCOPE";
+  case cpp_idt::id_classt::NAMESPACE:         return out<<"NAMESPACE";
+  default: return out << "(OTHER)";
   }
-
-  return out;
 }

--- a/src/cpp/cpp_id.h
+++ b/src/cpp/cpp_id.h
@@ -26,12 +26,20 @@ class cpp_idt
 public:
   cpp_idt();
 
-  typedef enum
+  enum class id_classt
   {
-    UNKNOWN, SYMBOL, TYPEDEF, CLASS, ENUM, TEMPLATE,
-    TEMPLATE_PARAMETER, NAMESPACE, BLOCK_SCOPE,
-    TEMPLATE_SCOPE, ROOT_SCOPE
-  } id_classt;
+    UNKNOWN,
+    SYMBOL,
+    TYPEDEF,
+    CLASS,
+    ENUM,
+    TEMPLATE,
+    TEMPLATE_PARAMETER,
+    NAMESPACE,
+    BLOCK_SCOPE,
+    TEMPLATE_SCOPE,
+    ROOT_SCOPE,
+  };
 
   bool is_member, is_method, is_static_member,
        is_scope, is_constructor;
@@ -40,22 +48,22 @@ public:
 
   bool is_class() const
   {
-    return id_class==CLASS;
+    return id_class==id_classt::CLASS;
   }
 
   bool is_enum() const
   {
-    return id_class==ENUM;
+    return id_class==id_classt::ENUM;
   }
 
   bool is_namespace() const
   {
-    return id_class==NAMESPACE;
+    return id_class==id_classt::NAMESPACE;
   }
 
   bool is_typedef() const
   {
-    return id_class==TYPEDEF;
+    return id_class==id_classt::TYPEDEF;
   }
 
   irep_idt identifier, base_name;

--- a/src/cpp/cpp_instantiate_template.cpp
+++ b/src/cpp/cpp_instantiate_template.cpp
@@ -201,13 +201,13 @@ const symbolt &cpp_typecheckt::class_template_symbol(
   // put into template scope
   cpp_idt &id=cpp_scopes.put_into_scope(*s_ptr, *template_scope);
 
-  id.id_class=cpp_idt::CLASS;
+  id.id_class=cpp_idt::id_classt::CLASS;
   id.is_scope=true;
   id.prefix=template_scope->prefix+
             id2string(s_ptr->base_name)+
             id2string(suffix)+"::";
   id.class_identifier=s_ptr->name;
-  id.id_class=cpp_idt::CLASS;
+  id.id_class=cpp_idt::id_classt::CLASS;
 
   return *s_ptr;
 }
@@ -390,13 +390,13 @@ const symbolt &cpp_typecheckt::instantiate_template(
       // It has already been instantianted!
       const cpp_idt &cpp_id = **id_set.begin();
 
-      assert(cpp_id.id_class == cpp_idt::CLASS ||
-             cpp_id.id_class == cpp_idt::SYMBOL);
+      assert(cpp_id.id_class == cpp_idt::id_classt::CLASS ||
+             cpp_id.id_class == cpp_idt::id_classt::SYMBOL);
 
       const symbolt &symb=lookup(cpp_id.identifier);
 
       // continue if the type is incomplete only
-      if(cpp_id.id_class==cpp_idt::CLASS &&
+      if(cpp_id.id_class==cpp_idt::id_classt::CLASS &&
          symb.type.id()==ID_struct)
         return symb;
       else if(symb.value.is_not_nil())
@@ -410,7 +410,7 @@ const symbolt &cpp_typecheckt::instantiate_template(
     // set up a scope as subscope of the template scope
     cpp_scopet &sub_scope=
       cpp_scopes.current_scope().new_scope(subscope_name);
-    sub_scope.id_class=cpp_idt::TEMPLATE_SCOPE;
+    sub_scope.id_class=cpp_idt::id_classt::TEMPLATE_SCOPE;
     sub_scope.prefix=template_scope->get_parent().prefix;
     sub_scope.suffix=suffix;
     sub_scope.add_using_scope(template_scope->get_parent());

--- a/src/cpp/cpp_scope.cpp
+++ b/src/cpp/cpp_scope.cpp
@@ -175,7 +175,7 @@ void cpp_scopet::lookup(
   }
 
   if(!id_set.empty() &&
-     id_class!=TEMPLATE) return; // done, upwards scopes are hidden
+     id_class!=id_classt::TEMPLATE) return; // done, upwards scopes are hidden
 
   // secondary scopes
   for(scope_listt::iterator
@@ -194,7 +194,7 @@ void cpp_scopet::lookup(
     return; // done
 
   if(!id_set.empty() &&
-     id_class!=TEMPLATE) return; // done, upwards scopes are hidden
+     id_class!=id_classt::TEMPLATE) return; // done, upwards scopes are hidden
 
   // ask parent, recursive call
   if(!is_root_scope())

--- a/src/cpp/cpp_scope.h
+++ b/src/cpp/cpp_scope.h
@@ -69,18 +69,18 @@ public:
 
   bool is_root_scope() const
   {
-    return id_class==ROOT_SCOPE;
+    return id_class==id_classt::ROOT_SCOPE;
   }
 
   bool is_global_scope() const
   {
-    return id_class==ROOT_SCOPE ||
-           id_class==NAMESPACE;
+    return id_class==id_classt::ROOT_SCOPE ||
+           id_class==id_classt::NAMESPACE;
   }
 
   bool is_template_scope() const
   {
-    return id_class==TEMPLATE_SCOPE;
+    return id_class==id_classt::TEMPLATE_SCOPE;
   }
 
   cpp_scopet &get_parent() const
@@ -118,7 +118,7 @@ class cpp_root_scopet:public cpp_scopet
 public:
   cpp_root_scopet()
   {
-    id_class=ROOT_SCOPE;
+    id_class=id_classt::ROOT_SCOPE;
     identifier="::";
   }
 };

--- a/src/cpp/cpp_scopes.cpp
+++ b/src/cpp/cpp_scopes.cpp
@@ -26,7 +26,7 @@ Function: cpp_scopest::new_block_scope
 cpp_scopet &cpp_scopest::new_block_scope()
 {
   unsigned prefix=++current_scope().compound_counter;
-  return new_scope(std::to_string(prefix), cpp_idt::BLOCK_SCOPE);
+  return new_scope(std::to_string(prefix), cpp_idt::id_classt::BLOCK_SCOPE);
 }
 
 /*******************************************************************\
@@ -57,7 +57,7 @@ cpp_idt &cpp_scopest::put_into_scope(
     {
       irep_idt block_base_name(std::string("$block:")+symbol.base_name.c_str());
       cpp_idt &id = scope.insert(block_base_name);
-      id.id_class=cpp_idt::BLOCK_SCOPE;
+      id.id_class=cpp_idt::id_classt::BLOCK_SCOPE;
       id.identifier=symbol.name;
       id.is_scope=true;
       id.prefix = id2string(scope.prefix) + id2string(symbol.base_name) + "::";
@@ -74,7 +74,7 @@ cpp_idt &cpp_scopest::put_into_scope(
 
     cpp_idt &id=current_scope().insert(symbol.base_name);
     id.identifier=symbol.name;
-    id.id_class = cpp_idt::SYMBOL;
+    id.id_class = cpp_idt::id_classt::SYMBOL;
     if(id_map.find(symbol.name)==id_map.end())
       id_map[symbol.name]=&id;
     return id;
@@ -83,7 +83,7 @@ cpp_idt &cpp_scopest::put_into_scope(
   {
     cpp_idt &id=scope.insert(symbol.base_name);
     id.identifier=symbol.name;
-    id.id_class = cpp_idt::SYMBOL;
+    id.id_class = cpp_idt::id_classt::SYMBOL;
     if(id_map.find(symbol.name)==id_map.end())
       id_map[symbol.name]=&id;
     return id;

--- a/src/cpp/cpp_scopes.h
+++ b/src/cpp/cpp_scopes.h
@@ -46,7 +46,7 @@ public:
 
   cpp_scopet &new_namespace(const irep_idt &new_scope_name)
   {
-    return new_scope(new_scope_name, cpp_idt::NAMESPACE);
+    return new_scope(new_scope_name, cpp_idt::id_classt::NAMESPACE);
   }
 
   cpp_scopet &new_block_scope();

--- a/src/cpp/cpp_typecheck_bases.cpp
+++ b/src/cpp/cpp_typecheck_bases.cpp
@@ -40,7 +40,7 @@ void cpp_typecheckt::typecheck_compound_bases(struct_typet &type)
     exprt base_symbol_expr=
       resolve(
         name,
-        cpp_typecheck_resolvet::TYPE,
+        cpp_typecheck_resolvet::wantt::TYPE,
         cpp_typecheck_fargst());
 
     if(base_symbol_expr.id()!=ID_type)

--- a/src/cpp/cpp_typecheck_code.cpp
+++ b/src/cpp/cpp_typecheck_code.cpp
@@ -256,7 +256,7 @@ void cpp_typecheckt::typecheck_member_initializer(codet &code)
   // Plus, this should happen in class scope, not the scope of
   // the constructor because of the constructor arguments.
   exprt symbol_expr=
-    resolve(member, cpp_typecheck_resolvet::VAR, fargs);
+    resolve(member, cpp_typecheck_resolvet::wantt::VAR, fargs);
 
   if(symbol_expr.type().id()==ID_code)
   {
@@ -340,7 +340,7 @@ void cpp_typecheckt::typecheck_member_initializer(codet &code)
         cpp_save_scopet cpp_saved_scope(cpp_scopes);
         cpp_scopes.go_to(
           *(cpp_scopes.id_map[cpp_scopes.current_scope().class_identifier]));
-        symbol_expr=resolve(member, cpp_typecheck_resolvet::VAR, fargs);
+        symbol_expr=resolve(member, cpp_typecheck_resolvet::wantt::VAR, fargs);
       }
 
       if(symbol_expr.id() == ID_dereference &&

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -269,13 +269,13 @@ void cpp_typecheckt::typecheck_compound_type(
     // put into dest_scope
     cpp_idt &id=cpp_scopes.put_into_scope(*new_symbol, *dest_scope);
 
-    id.id_class=cpp_idt::CLASS;
+    id.id_class=cpp_idt::id_classt::CLASS;
     id.is_scope=true;
     id.prefix=cpp_scopes.current_scope().prefix+
               id2string(new_symbol->base_name)+
               cpp_scopes.current_scope().suffix+"::";
     id.class_identifier=new_symbol->name;
-    id.id_class=cpp_idt::CLASS;
+    id.id_class=cpp_idt::id_classt::CLASS;
 
     if(has_body)
       typecheck_compound_body(*new_symbol);
@@ -856,7 +856,9 @@ void cpp_typecheckt::put_compound_into_scope(
   {
     // put the symbol into scope
     cpp_idt &id=cpp_scopes.current_scope().insert(base_name);
-    id.id_class=compound.get_bool("is_type")?cpp_idt::TYPEDEF:cpp_idt::SYMBOL;
+    id.id_class=compound.get_bool("is_type")?
+      cpp_idt::id_classt::TYPEDEF:
+      cpp_idt::id_classt::SYMBOL;
     id.identifier=name;
     id.class_identifier=cpp_scopes.current_scope().identifier;
     id.is_member=true;
@@ -870,7 +872,7 @@ void cpp_typecheckt::put_compound_into_scope(
       cpp_scopes.current_scope().insert(
         irep_idt(std::string("$block:") + base_name.c_str()));
 
-    id_block.id_class=cpp_idt::BLOCK_SCOPE;
+    id_block.id_class=cpp_idt::id_classt::BLOCK_SCOPE;
     id_block.identifier=name;
     id_block.class_identifier=cpp_scopes.current_scope().identifier;
     id_block.is_method=true;
@@ -905,7 +907,9 @@ void cpp_typecheckt::put_compound_into_scope(
 
     // put into the scope
     cpp_idt &id=cpp_scopes.current_scope().insert(base_name);
-    id.id_class=compound.get_bool(ID_is_type)?cpp_idt::TYPEDEF:cpp_idt::SYMBOL;
+    id.id_class=compound.get_bool(ID_is_type)?
+      cpp_idt::id_classt::TYPEDEF:
+      cpp_idt::id_classt::SYMBOL;
     id.identifier=name;
     id.class_identifier=cpp_scopes.current_scope().identifier;
     id.is_member=true;
@@ -1545,7 +1549,7 @@ void cpp_typecheckt::add_anonymous_members_to_scope(
       }
 
       cpp_idt &id=cpp_scopes.current_scope().insert(base_name);
-      id.id_class=cpp_idt::SYMBOL;
+      id.id_class=cpp_idt::id_classt::SYMBOL;
       id.identifier=comp.get_name();
       id.class_identifier=struct_union_symbol.name;
       id.is_member=true;

--- a/src/cpp/cpp_typecheck_declaration.cpp
+++ b/src/cpp/cpp_typecheck_declaration.cpp
@@ -118,7 +118,7 @@ void cpp_typecheckt::convert_anonymous_union(
     }
 
     cpp_idt &id=cpp_scopes.current_scope().insert(base_name);
-    id.id_class = cpp_idt::SYMBOL;
+    id.id_class = cpp_idt::id_classt::SYMBOL;
     id.identifier=it->get(ID_name);
     id.class_identifier=union_symbol.name;
     id.is_member=true;

--- a/src/cpp/cpp_typecheck_enum_type.cpp
+++ b/src/cpp/cpp_typecheck_enum_type.cpp
@@ -83,7 +83,7 @@ void cpp_typecheckt::typecheck_enum_body(symbolt &enum_symbol)
     cpp_idt &scope_identifier=
       cpp_scopes.put_into_scope(*new_symbol);
 
-    scope_identifier.id_class=cpp_idt::SYMBOL;
+    scope_identifier.id_class=cpp_idt::id_classt::SYMBOL;
 
     ++i;
   }
@@ -212,7 +212,7 @@ void cpp_typecheckt::typecheck_enum_type(typet &type)
     cpp_idt &scope_identifier=
       cpp_scopes.put_into_scope(*new_symbol, dest_scope);
 
-    scope_identifier.id_class=cpp_idt::CLASS;
+    scope_identifier.id_class=cpp_idt::id_classt::CLASS;
 
     typecheck_enum_body(*new_symbol);
   }

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -379,7 +379,7 @@ void cpp_typecheckt::typecheck_expr_sizeof(exprt &expr)
 
       exprt symbol_expr=resolve(
         to_cpp_name(static_cast<const irept &>(type)),
-        cpp_typecheck_resolvet::BOTH,
+        cpp_typecheck_resolvet::wantt::BOTH,
         fargs);
 
       if(symbol_expr.id()!=ID_type)
@@ -398,7 +398,7 @@ void cpp_typecheckt::typecheck_expr_sizeof(exprt &expr)
 
         exprt symbol_expr=resolve(
           to_cpp_name(static_cast<const irept &>(type.subtype())),
-          cpp_typecheck_resolvet::BOTH,
+          cpp_typecheck_resolvet::wantt::BOTH,
           fargs);
 
         if(symbol_expr.id()!=ID_type)
@@ -725,7 +725,7 @@ bool cpp_typecheckt::operator_is_overloaded(exprt &expr)
 
         // should really be a qualified search
         exprt resolve_result=resolve(
-          cpp_name, cpp_typecheck_resolvet::VAR, fargs, false);
+          cpp_name, cpp_typecheck_resolvet::wantt::VAR, fargs, false);
 
         if(resolve_result.is_not_nil())
         {
@@ -767,7 +767,7 @@ bool cpp_typecheckt::operator_is_overloaded(exprt &expr)
         fargs.in_use=true;
 
         exprt resolve_result=resolve(
-             cpp_name, cpp_typecheck_resolvet::VAR, fargs, false);
+             cpp_name, cpp_typecheck_resolvet::wantt::VAR, fargs, false);
 
         if(resolve_result.is_not_nil())
         {
@@ -1063,7 +1063,7 @@ void cpp_typecheckt::typecheck_expr_explicit_typecast(exprt &expr)
 
       exprt symbol_expr=resolve(
         to_cpp_name(static_cast<const irept &>(expr.type())),
-        cpp_typecheck_resolvet::TYPE,
+        cpp_typecheck_resolvet::wantt::TYPE,
         fargs,
         false); // fail silently
 
@@ -1356,7 +1356,7 @@ void cpp_typecheckt::typecheck_expr_member(
 
     exprt symbol_expr=resolve(
                         component_cpp_name,
-                        cpp_typecheck_resolvet::VAR,
+                        cpp_typecheck_resolvet::wantt::VAR,
                         new_fargs);
 
     if(symbol_expr.id()==ID_dereference)
@@ -2097,7 +2097,7 @@ void cpp_typecheckt::typecheck_expr_cpp_name(
   exprt symbol_expr=
     resolve(
       to_cpp_name(expr),
-      cpp_typecheck_resolvet::VAR,
+      cpp_typecheck_resolvet::wantt::VAR,
       fargs);
 
   // we want VAR
@@ -3141,7 +3141,7 @@ void cpp_typecheckt::explicit_typecast_ambiguity(exprt &expr)
     exprt resolve_result=
       resolve(
         to_cpp_name(expr.type()),
-        cpp_typecheck_resolvet::BOTH,
+        cpp_typecheck_resolvet::wantt::BOTH,
         cpp_typecheck_fargst());
 
     if(resolve_result.id()!=ID_type)

--- a/src/cpp/cpp_typecheck_initializer.cpp
+++ b/src/cpp/cpp_typecheck_initializer.cpp
@@ -110,7 +110,7 @@ void cpp_typecheckt::convert_initializer(symbolt &symbol)
 
       exprt resolved_expr=resolve(
         to_cpp_name(static_cast<irept &>(symbol.value.op0())),
-        cpp_typecheck_resolvet::BOTH, fargs);
+        cpp_typecheck_resolvet::wantt::BOTH, fargs);
 
       assert(symbol.type.subtype() == resolved_expr.type());
 

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -303,7 +303,7 @@ exprt cpp_typecheck_resolvet::convert_identifier(
   const wantt want,
   const cpp_typecheck_fargst &fargs)
 {
-  if(identifier.id_class==cpp_scopet::TEMPLATE_PARAMETER)
+  if(identifier.id_class==cpp_scopet::id_classt::TEMPLATE_PARAMETER)
     return convert_template_parameter(identifier);
 
   exprt e;
@@ -329,11 +329,11 @@ exprt cpp_typecheck_resolvet::convert_identifier(
     const typet &type=component.type();
     assert(type.is_not_nil());
 
-    if(identifier.id_class==cpp_scopet::TYPEDEF)
+    if(identifier.id_class==cpp_scopet::id_classt::TYPEDEF)
     {
       e=type_exprt(type);
     }
-    else if(identifier.id_class==cpp_scopet::SYMBOL)
+    else if(identifier.id_class==cpp_scopet::id_classt::SYMBOL)
     {
       // A non-static, non-type member.
       // There has to be an object.
@@ -1065,7 +1065,7 @@ cpp_scopet &cpp_typecheck_resolvet::resolve_scope(
         cpp_typecheck.cpp_scopes.current_scope().lookup(
           final_base_name,
           recursive?cpp_scopet::RECURSIVE:cpp_scopet::QUALIFIED,
-          cpp_idt::TEMPLATE,
+          cpp_idt::id_classt::TEMPLATE,
           id_set);
 
         // std::cout << "S: "
@@ -1630,7 +1630,7 @@ exprt cpp_typecheck_resolvet::resolve(
       base_name, lookup_kind, id_set);
   else
     cpp_typecheck.cpp_scopes.current_scope().lookup(
-      base_name, lookup_kind, cpp_idt::TEMPLATE, id_set);
+      base_name, lookup_kind, cpp_idt::id_classt::TEMPLATE, id_set);
 
   // Argument-dependent name lookup
   #if 0
@@ -1958,7 +1958,7 @@ void cpp_typecheck_resolvet::guess_template_args(
       {
         const cpp_idt &id=**it;
         // template parameter?
-        if(id.id_class==cpp_idt::TEMPLATE_PARAMETER)
+        if(id.id_class==cpp_idt::id_classt::TEMPLATE_PARAMETER)
         {
           // see if unassigned
           exprt &e=cpp_typecheck.template_map.expr_map[id.identifier];
@@ -2062,7 +2062,7 @@ void cpp_typecheck_resolvet::guess_template_args(
           const cpp_idt &id=**it;
 
           // template argument?
-          if(id.id_class==cpp_idt::TEMPLATE_PARAMETER)
+          if(id.id_class==cpp_idt::id_classt::TEMPLATE_PARAMETER)
           {
             // see if unassigned
             typet &t=cpp_typecheck.template_map.type_map[id.identifier];
@@ -2545,7 +2545,7 @@ void cpp_typecheck_resolvet::filter_for_named_scopes(
           break;
       }
     }
-    else if(id.id_class==cpp_scopet::TEMPLATE)
+    else if(id.id_class==cpp_scopet::id_classt::TEMPLATE)
     {
       // std::cout << "X3\n";
       #if 0
@@ -2561,7 +2561,7 @@ void cpp_typecheck_resolvet::filter_for_named_scopes(
       }
       #endif
     }
-    else if(id.id_class==cpp_scopet::TEMPLATE_PARAMETER)
+    else if(id.id_class==cpp_scopet::id_classt::TEMPLATE_PARAMETER)
     {
       // std::cout << "X4\n";
       // a template parameter may evaluate to be a scope: it could

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -494,15 +494,15 @@ void cpp_typecheck_resolvet::filter(
 
     switch(want)
     {
-    case TYPE:
+    case wantt::TYPE:
       match=(it->id()==ID_type);
       break;
 
-    case VAR:
+    case wantt::VAR:
       match=(it->id()!=ID_type);
       break;
 
-    case BOTH:
+    case wantt::BOTH:
       match=true;
       break;
 
@@ -1695,7 +1695,7 @@ exprt cpp_typecheck_resolvet::resolve(
         have_methods=true;
     }
 
-    if(want==BOTH && have_classes && have_methods)
+    if(want==wantt::BOTH && have_classes && have_methods)
     {
       if(!fail_with_exception)
         return nil_exprt();
@@ -1708,7 +1708,7 @@ exprt cpp_typecheck_resolvet::resolve(
       throw 0;
     }
 
-    if(want==TYPE || have_classes)
+    if(want==wantt::TYPE || have_classes)
     {
       typet instance=
         disambiguate_template_classes(base_name, id_set, template_args);
@@ -1731,7 +1731,7 @@ exprt cpp_typecheck_resolvet::resolve(
   }
 
   // change types into constructors if we want a constructor
-  if(want==VAR)
+  if(want==wantt::VAR)
     make_constructors(identifiers);
 
   filter(identifiers, want);
@@ -1877,7 +1877,7 @@ exprt cpp_typecheck_resolvet::resolve(
 
   switch(want)
   {
-  case VAR:
+  case wantt::VAR:
     if(result.id()==ID_type && !cpp_typecheck.cpp_is_pod(result.type()))
     {
       if(!fail_with_exception)
@@ -1894,7 +1894,7 @@ exprt cpp_typecheck_resolvet::resolve(
     }
     break;
 
-  case TYPE:
+  case wantt::TYPE:
     if(result.id()!=ID_type)
     {
       if(!fail_with_exception)

--- a/src/cpp/cpp_typecheck_resolve.h
+++ b/src/cpp/cpp_typecheck_resolve.h
@@ -19,7 +19,7 @@ public:
   cpp_typecheck_resolvet(
     class cpp_typecheckt &_cpp_typecheck);
 
-  typedef enum { VAR, TYPE, BOTH } wantt;
+  enum class wantt { VAR, TYPE, BOTH };
 
   exprt resolve(
     const cpp_namet &cpp_name,

--- a/src/cpp/cpp_typecheck_template.cpp
+++ b/src/cpp/cpp_typecheck_template.cpp
@@ -180,7 +180,8 @@ void cpp_typecheckt::typecheck_class_template(
         previous_declaration.template_type());
     }
 
-    assert(cpp_scopes.id_map[symbol_name]->id_class == cpp_idt::TEMPLATE_SCOPE);
+    assert(cpp_scopes.id_map[symbol_name]->id_class ==
+           cpp_idt::id_classt::TEMPLATE_SCOPE);
     return;
   }
 
@@ -212,13 +213,14 @@ void cpp_typecheckt::typecheck_class_template(
 
   // put into current scope
   cpp_idt &id=cpp_scopes.put_into_scope(*new_symbol);
-  id.id_class=cpp_idt::TEMPLATE;
+  id.id_class=cpp_idt::id_classt::TEMPLATE;
   id.prefix=cpp_scopes.current_scope().prefix+
             id2string(new_symbol->base_name);
 
   // link the template symbol with the template scope
   cpp_scopes.id_map[symbol_name]=&template_scope;
-  assert(cpp_scopes.id_map[symbol_name]->id_class==cpp_idt::TEMPLATE_SCOPE);
+  assert(cpp_scopes.id_map[symbol_name]->id_class ==
+         cpp_idt::id_classt::TEMPLATE_SCOPE);
 }
 
 /*******************************************************************\
@@ -326,12 +328,12 @@ void cpp_typecheckt::typecheck_function_template(
 
   // put into scope
   cpp_idt &id=cpp_scopes.put_into_scope(*new_symbol);
-  id.id_class=cpp_idt::TEMPLATE;
+  id.id_class=cpp_idt::id_classt::TEMPLATE;
   id.prefix=cpp_scopes.current_scope().prefix+
             id2string(new_symbol->base_name);
 
   // link the template symbol with the template scope
-  assert(template_scope.id_class==cpp_idt::TEMPLATE_SCOPE);
+  assert(template_scope.id_class==cpp_idt::id_classt::TEMPLATE_SCOPE);
   cpp_scopes.id_map[symbol_name] = &template_scope;
 }
 
@@ -389,7 +391,7 @@ void cpp_typecheckt::typecheck_class_template_member(
   cpp_scopes.current_scope().lookup(
     cpp_name.get_sub().front().get(ID_identifier),
     cpp_scopet::SCOPE_ONLY, // look only in current scope
-    cpp_scopet::TEMPLATE,   // must be template
+    cpp_scopet::id_classt::TEMPLATE,   // must be template
     id_set);
 
   if(id_set.empty())
@@ -409,7 +411,7 @@ void cpp_typecheckt::typecheck_class_template_member(
             << "' is ambiguous" << eom;
     throw 0;
   }
-  else if((*(id_set.begin()))->id_class!=cpp_idt::TEMPLATE)
+  else if((*(id_set.begin()))->id_class!=cpp_idt::id_classt::TEMPLATE)
   {
     // std::cerr << *(*id_set.begin()) << std::endl;
     error().source_location=cpp_name.source_location();
@@ -616,7 +618,7 @@ void cpp_typecheckt::convert_class_template_specialization(
 
   cpp_scopest::id_sett id_set;
   cpp_scopes.current_scope().lookup(
-    base_name, cpp_scopet::SCOPE_ONLY, cpp_idt::TEMPLATE, id_set);
+    base_name, cpp_scopet::SCOPE_ONLY, cpp_idt::id_classt::TEMPLATE, id_set);
 
   // remove any specializations
   for(cpp_scopest::id_sett::iterator
@@ -833,7 +835,7 @@ cpp_scopet &cpp_typecheckt::typecheck_template_parameters(
       cpp_scopes.current_scope().prefix+id_suffix);
 
   template_scope.prefix=template_scope.get_parent().prefix+id_suffix;
-  template_scope.id_class=cpp_idt::TEMPLATE_SCOPE;
+  template_scope.id_class=cpp_idt::id_classt::TEMPLATE_SCOPE;
 
   cpp_scopes.go_to(template_scope);
 
@@ -887,7 +889,7 @@ cpp_scopet &cpp_typecheckt::typecheck_template_parameters(
     // add to scope
     cpp_idt &id=scope.insert(base_name);
     id.identifier=identifier;
-    id.id_class=cpp_idt::TEMPLATE_PARAMETER;
+    id.id_class=cpp_idt::id_classt::TEMPLATE_PARAMETER;
 
     // is it a type or not?
     if(declaration.get_bool(ID_is_type))

--- a/src/cpp/cpp_typecheck_type.cpp
+++ b/src/cpp/cpp_typecheck_type.cpp
@@ -59,7 +59,7 @@ void cpp_typecheckt::typecheck_type(typet &type)
 
     exprt symbol_expr=resolve(
       cpp_name,
-      cpp_typecheck_resolvet::TYPE,
+      cpp_typecheck_resolvet::wantt::TYPE,
       cpp_typecheck_fargst());
 
     if(symbol_expr.id()!=ID_type)
@@ -209,7 +209,7 @@ void cpp_typecheckt::typecheck_type(typet &type)
 
         exprt symbol_expr=resolve(
           to_cpp_name(static_cast<const irept &>(tmp_type)),
-          cpp_typecheck_resolvet::BOTH,
+          cpp_typecheck_resolvet::wantt::BOTH,
           fargs);
 
         type=symbol_expr.type();

--- a/src/cpp/cpp_typecheck_using.cpp
+++ b/src/cpp/cpp_typecheck_using.cpp
@@ -63,7 +63,7 @@ void cpp_typecheckt::convert(cpp_usingt &cpp_using)
   {
     if(using_directive)
     {
-      if((*it)->id_class==cpp_idt::NAMESPACE)
+      if((*it)->id_class==cpp_idt::id_classt::NAMESPACE)
         cpp_scopes.current_scope().add_using_scope(
           static_cast<cpp_scopet &>(**it));
       else
@@ -74,8 +74,8 @@ void cpp_typecheckt::convert(cpp_usingt &cpp_using)
     else // declaration
     {
       // we copy all 'normal' identifiers into the current scope
-      if((*it)->id_class!=cpp_idt::TEMPLATE_PARAMETER &&
-         (*it)->id_class!=cpp_idt::NAMESPACE)
+      if((*it)->id_class!=cpp_idt::id_classt::TEMPLATE_PARAMETER &&
+         (*it)->id_class!=cpp_idt::id_classt::NAMESPACE)
         cpp_scopes.current_scope().insert(**it);
     }
   }

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -44,63 +44,90 @@ struct indenter // NOLINT(readability/identifiers)
 class new_scopet
 {
 public:
-  new_scopet():kind(NONE), anon_count(0), parent(NULL)
+  new_scopet():kind(kindt::NONE), anon_count(0), parent(NULL)
   {
   }
 
-  typedef enum { NONE,
-                 TEMPLATE, MEMBER, FUNCTION, VARIABLE,
-                 TYPEDEF, TAG,
-                 NAMESPACE, CLASS_TEMPLATE, MEMBER_TEMPLATE,
-                 FUNCTION_TEMPLATE, BLOCK,
-                 NON_TYPE_TEMPLATE_PARAMETER,
-                 TYPE_TEMPLATE_PARAMETER,
-                 TEMPLATE_TEMPLATE_PARAMETER } kindt;
+  enum class kindt
+  {
+    NONE,
+    TEMPLATE,
+    MEMBER,
+    FUNCTION,
+    VARIABLE,
+    TYPEDEF,
+    TAG,
+    NAMESPACE,
+    CLASS_TEMPLATE,
+    MEMBER_TEMPLATE,
+    FUNCTION_TEMPLATE,
+    BLOCK,
+    NON_TYPE_TEMPLATE_PARAMETER,
+    TYPE_TEMPLATE_PARAMETER,
+    TEMPLATE_TEMPLATE_PARAMETER
+  };
+
   kindt kind;
   irep_idt id;
 
   bool is_type() const
   {
-    return kind==TYPEDEF ||
-           kind==TYPE_TEMPLATE_PARAMETER ||
-           kind==TAG ||
-           kind==CLASS_TEMPLATE;
+    return kind==kindt::TYPEDEF ||
+           kind==kindt::TYPE_TEMPLATE_PARAMETER ||
+           kind==kindt::TAG ||
+           kind==kindt::CLASS_TEMPLATE;
   }
 
   bool is_template() const
   {
-    return kind==FUNCTION_TEMPLATE ||
-           kind==CLASS_TEMPLATE ||
-           kind==MEMBER_TEMPLATE;
+    return kind==kindt::FUNCTION_TEMPLATE ||
+           kind==kindt::CLASS_TEMPLATE ||
+           kind==kindt::MEMBER_TEMPLATE;
   }
 
   bool is_named_scope() const
   {
-    return kind==NAMESPACE ||
-           kind==TAG ||
-           kind==TYPE_TEMPLATE_PARAMETER;
+    return kind==kindt::NAMESPACE ||
+           kind==kindt::TAG ||
+           kind==kindt::TYPE_TEMPLATE_PARAMETER;
   }
 
   static const char *kind2string(kindt kind)
   {
     switch(kind)
     {
-    case NONE: return "?";
-    case TEMPLATE: return "TEMPLATE";
-    case MEMBER: return "MEMBER";
-    case FUNCTION: return "FUNCTION";
-    case VARIABLE: return "VARIABLE";
-    case TYPEDEF: return "TYPEDEF";
-    case TAG: return "TAG";
-    case NAMESPACE: return "NAMESPACE";
-    case CLASS_TEMPLATE: return "CLASS_TEMPLATE";
-    case MEMBER_TEMPLATE: return "MEMBER_TEMPLATE";
-    case FUNCTION_TEMPLATE: return "FUNCTION_TEMPLATE";
-    case BLOCK: return "BLOCK";
-    case NON_TYPE_TEMPLATE_PARAMETER: return "NON_TYPE_TEMPLATE_PARAMETER";
-    case TYPE_TEMPLATE_PARAMETER: return "TYPE_TEMPLATE_PARAMETER";
-    case TEMPLATE_TEMPLATE_PARAMETER: return "TEMPLATE_TEMPLATE_PARAMETER";
-    default: return "";
+    case kindt::NONE:
+      return "?";
+    case kindt::TEMPLATE:
+      return "TEMPLATE";
+    case kindt::MEMBER:
+      return "MEMBER";
+    case kindt::FUNCTION:
+      return "FUNCTION";
+    case kindt::VARIABLE:
+      return "VARIABLE";
+    case kindt::TYPEDEF:
+      return "TYPEDEF";
+    case kindt::TAG:
+      return "TAG";
+    case kindt::NAMESPACE:
+      return "NAMESPACE";
+    case kindt::CLASS_TEMPLATE:
+      return "CLASS_TEMPLATE";
+    case kindt::MEMBER_TEMPLATE:
+      return "MEMBER_TEMPLATE";
+    case kindt::FUNCTION_TEMPLATE:
+      return "FUNCTION_TEMPLATE";
+    case kindt::BLOCK:
+      return "BLOCK";
+    case kindt::NON_TYPE_TEMPLATE_PARAMETER:
+      return "NON_TYPE_TEMPLATE_PARAMETER";
+    case kindt::TYPE_TEMPLATE_PARAMETER:
+      return "TYPE_TEMPLATE_PARAMETER";
+    case kindt::TEMPLATE_TEMPLATE_PARAMETER:
+      return "TEMPLATE_TEMPLATE_PARAMETER";
+    default:
+      return "";
     }
   }
 
@@ -184,7 +211,7 @@ public:
     lex(_cpp_parser.token_buffer),
     parser(_cpp_parser)
   {
-    root_scope.kind=new_scopet::NAMESPACE;
+    root_scope.kind=new_scopet::kindt::NAMESPACE;
     current_scope=&root_scope;
   }
 
@@ -1214,7 +1241,7 @@ bool Parser::rTemplateDecl(cpp_declarationt &decl)
 {
   TemplateDeclKind kind=tdk_unknown;
 
-  make_sub_scope("#template", new_scopet::TEMPLATE);
+  make_sub_scope("#template", new_scopet::kindt::TEMPLATE);
   current_scope->id_map.clear();
 
   typet template_type;
@@ -1446,7 +1473,7 @@ bool Parser::rTempArgDeclaration(cpp_declarationt &declaration)
       cpp_name.get_sub().push_back(name);
       declarator.name().swap(cpp_name);
 
-      add_id(declarator.name(), new_scopet::TYPE_TEMPLATE_PARAMETER);
+      add_id(declarator.name(), new_scopet::kindt::TYPE_TEMPLATE_PARAMETER);
 
       if(has_ellipsis)
       {
@@ -1551,7 +1578,7 @@ bool Parser::rTempArgDeclaration(cpp_declarationt &declaration)
               << "Parser::rTempArgDeclaration 4\n";
     #endif
 
-    add_id(declarator.name(), new_scopet::NON_TYPE_TEMPLATE_PARAMETER);
+    add_id(declarator.name(), new_scopet::kindt::NON_TYPE_TEMPLATE_PARAMETER);
 
     if(has_ellipsis)
     {
@@ -4968,7 +4995,7 @@ bool Parser::rClassSpec(typet &spec)
   #endif
 
   save_scopet saved_scope(current_scope);
-  make_sub_scope(spec.find(ID_tag), new_scopet::TAG);
+  make_sub_scope(spec.find(ID_tag), new_scopet::kindt::TAG);
 
   exprt body;
 

--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -580,7 +580,7 @@ bool compilet::parse(const std::string &file_name)
 
     if(language.parse(infile, file_name))
     {
-      if(get_ui()==ui_message_handlert::PLAIN)
+      if(get_ui()==ui_message_handlert::uit::PLAIN)
         error() << "PARSING ERROR" << eom;
       return true;
     }
@@ -634,7 +634,7 @@ bool compilet::parse_stdin()
   {
     if(language.parse(std::cin, ""))
     {
-      if(get_ui()==ui_message_handlert::PLAIN)
+      if(get_ui()==ui_message_handlert::uit::PLAIN)
         error() << "PARSING ERROR" << eom;
       return true;
     }

--- a/src/goto-diff/change_impact.cpp
+++ b/src/goto-diff/change_impact.cpp
@@ -518,8 +518,8 @@ void change_impactt::propogate_dep_forward(
     if((change_impact[src->function][src] &data_flag)
         || (change_impact[src->function][src] &ctrl_flag))
       continue;
-    if(it->second.get() == dep_edget::DATA
-        || it->second.get() == dep_edget::BOTH)
+    if(it->second.get() == dep_edget::kindt::DATA
+        || it->second.get() == dep_edget::kindt::BOTH)
       change_impact[src->function][src] |= data_flag;
     else
       change_impact[src->function][src] |= ctrl_flag;
@@ -559,8 +559,8 @@ void change_impactt::propogate_dep_back(
     {
       continue;
     }
-    if(it->second.get() == dep_edget::DATA
-        || it->second.get() == dep_edget::BOTH)
+    if(it->second.get() == dep_edget::kindt::DATA
+        || it->second.get() == dep_edget::kindt::BOTH)
       change_impact[src->function][src] |= data_flag;
     else
       change_impact[src->function][src] |= ctrl_flag;

--- a/src/goto-diff/change_impact.cpp
+++ b/src/goto-diff/change_impact.cpp
@@ -260,7 +260,7 @@ protected:
   dependence_grapht old_dep_graph;
   dependence_grapht new_dep_graph;
 
-  typedef enum
+  enum mod_flagt
   {
     SAME=0,
     NEW=1<<0,
@@ -269,7 +269,7 @@ protected:
     DEL_DATA_DEP=1<<3,
     NEW_CTRL_DEP=1<<4,
     DEL_CTRL_DEP=1<<5
-  } mod_flagt;
+  };
 
   typedef std::map<goto_programt::const_targett, unsigned>
     goto_program_change_impactt;
@@ -445,13 +445,15 @@ void change_impactt::change_impact(
           const dependence_grapht::nodet &d_node=
             old_dep_graph[old_dep_graph[o_it].get_node_id()];
 
-          if(impact_mode==BACKWARD || impact_mode==BOTH)
+          if(impact_mode==impact_modet::BACKWARD ||
+             impact_mode==impact_modet::BOTH)
             propogate_dep_back(
               d_node,
               old_dep_graph,
               old_change_impact,
               true);
-          if(impact_mode==FORWARD || impact_mode==BOTH)
+          if(impact_mode==impact_modet::FORWARD ||
+             impact_mode==impact_modet::BOTH)
             propogate_dep_forward(
               d_node,
               old_dep_graph,
@@ -468,13 +470,15 @@ void change_impactt::change_impact(
           const dependence_grapht::nodet &d_node=
             new_dep_graph[new_dep_graph[n_it].get_node_id()];
 
-          if(impact_mode==BACKWARD || impact_mode==BOTH)
+          if(impact_mode==impact_modet::BACKWARD ||
+             impact_mode==impact_modet::BOTH)
             propogate_dep_back(
               d_node,
               new_dep_graph,
               new_change_impact,
               false);
-          if(impact_mode==FORWARD || impact_mode==BOTH)
+          if(impact_mode==impact_modet::FORWARD ||
+             impact_mode==impact_modet::BOTH)
             propogate_dep_forward(
               d_node,
               new_dep_graph,

--- a/src/goto-diff/change_impact.h
+++ b/src/goto-diff/change_impact.h
@@ -12,7 +12,7 @@ Date: April 2016
 #define CPROVER_GOTO_DIFF_CHANGE_IMPACT_H
 
 class goto_modelt;
-typedef enum {FORWARD, BACKWARD, BOTH} impact_modet;
+enum class impact_modet { FORWARD, BACKWARD, BOTH };
 
 void change_impact(
   const goto_modelt &model_old,

--- a/src/goto-diff/goto_diff.h
+++ b/src/goto-diff/goto_diff.h
@@ -28,7 +28,7 @@ public:
     messaget(_message_handler),
     goto_model1(_goto_model1),
     goto_model2(_goto_model2),
-    ui(ui_message_handlert::PLAIN),
+    ui(ui_message_handlert::uit::PLAIN),
     total_functions_count(0)
      {}
 

--- a/src/goto-diff/goto_diff_base.cpp
+++ b/src/goto-diff/goto_diff_base.cpp
@@ -26,7 +26,7 @@ std::ostream &goto_difft::output_functions(std::ostream &out) const
 {
   switch(ui)
   {
-    case ui_message_handlert::PLAIN:
+    case ui_message_handlert::uit::PLAIN:
     {
       out << "total number of functions: " << total_functions_count << "\n";
       out << "new functions: \n";
@@ -63,7 +63,7 @@ std::ostream &goto_difft::output_functions(std::ostream &out) const
       }
       break;
     }
-    case ui_message_handlert::JSON_UI:
+    case ui_message_handlert::uit::JSON_UI:
     {
       json_objectt json_result;
       json_result["totalNumberOfFunctions"]=
@@ -77,7 +77,7 @@ std::ostream &goto_difft::output_functions(std::ostream &out) const
       out << ",\n" << json_result;
       break;
     }
-    case ui_message_handlert::XML_UI:
+    case ui_message_handlert::uit::XML_UI:
     {
       out << "not supported yet";
     }

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -350,8 +350,10 @@ int goto_diff_parse_optionst::doit()
 
     impact_modet impact_mode=
       cmdline.isset("forward-impact") ?
-      FORWARD :
-      (cmdline.isset("backward-impact") ? BACKWARD : BOTH);
+      impact_modet::FORWARD :
+      (cmdline.isset("backward-impact") ?
+         impact_modet::BACKWARD :
+         impact_modet::BOTH);
     change_impact(
       goto_model1,
       goto_model2,

--- a/src/goto-instrument/accelerate/scratch_program.cpp
+++ b/src/goto-instrument/accelerate/scratch_program.cpp
@@ -58,7 +58,7 @@ bool scratch_programt::check_sat(bool do_slice)
   std::cout << "Finished symex, invoking decision procedure.\n";
 #endif
 
-  return (checker->dec_solve()==decision_proceduret::D_SATISFIABLE);
+  return (checker->dec_solve()==decision_proceduret::resultt::D_SATISFIABLE);
 }
 
 exprt scratch_programt::eval(const exprt &e)

--- a/src/goto-instrument/accelerate/scratch_program.h
+++ b/src/goto-instrument/accelerate/scratch_program.h
@@ -37,7 +37,7 @@ public:
     symex(ns, symbol_table, equation),
     satcheck(new satcheckt),
     satchecker(ns, *satcheck),
-    z3(ns, "accelerate", "", "", smt2_dect::Z3),
+    z3(ns, "accelerate", "", "", smt2_dect::solvert::Z3),
     checker(&z3) // checker(&satchecker)
   {
   }

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -200,19 +200,20 @@ int goto_instrument_parse_optionst::doit()
           throw "more than one of --unwinding-assertions,--partial-loops,"
                 "--continue-as-loops selected";
 
-        goto_unwindt::unwind_strategyt unwind_strategy=goto_unwindt::ASSUME;
+        goto_unwindt::unwind_strategyt unwind_strategy=
+          goto_unwindt::unwind_strategyt::ASSUME;
 
         if(unwinding_assertions)
         {
-          unwind_strategy=goto_unwindt::ASSERT;
+          unwind_strategy=goto_unwindt::unwind_strategyt::ASSERT;
         }
         else if(partial_loops)
         {
-          unwind_strategy=goto_unwindt::PARTIAL;
+          unwind_strategy=goto_unwindt::unwind_strategyt::PARTIAL;
         }
         else if(continue_as_loops)
         {
-          unwind_strategy=goto_unwindt::CONTINUE;
+          unwind_strategy=goto_unwindt::unwind_strategyt::CONTINUE;
         }
 
         goto_unwindt goto_unwind;

--- a/src/goto-instrument/k_induction.cpp
+++ b/src/goto-instrument/k_induction.cpp
@@ -79,7 +79,7 @@ void k_inductiont::process_loop(
     // now unwind k times
     goto_unwindt goto_unwind;
     goto_unwind.unwind(goto_function.body, loop_head, loop_exit, k,
-                       goto_unwindt::PARTIAL);
+                       goto_unwindt::unwind_strategyt::PARTIAL);
 
     // assume the loop condition has become false
     goto_programt::instructiont assume(ASSUME);
@@ -103,8 +103,13 @@ void k_inductiont::process_loop(
     std::vector<goto_programt::targett> iteration_points;
 
     goto_unwindt goto_unwind;
-    goto_unwind.unwind(goto_function.body, loop_head, loop_exit, k+1,
-                       goto_unwindt::PARTIAL, iteration_points);
+    goto_unwind.unwind(
+      goto_function.body,
+      loop_head,
+      loop_exit,
+      k+1,
+      goto_unwindt::unwind_strategyt::PARTIAL,
+      iteration_points);
 
     // we can remove everything up to the first assertion
     for(goto_programt::targett t=loop_head; t!=loop_exit; t++)

--- a/src/goto-instrument/object_id.cpp
+++ b/src/goto-instrument/object_id.cpp
@@ -20,7 +20,7 @@ Function: get_objects_rec
 
 \*******************************************************************/
 
-typedef enum { LHS_R, LHS_W, READ } get_modet;
+enum class get_modet { LHS_R, LHS_W, READ };
 
 void get_objects_rec(
   get_modet mode,
@@ -30,18 +30,18 @@ void get_objects_rec(
 {
   if(expr.id()==ID_symbol)
   {
-    if(mode==LHS_W || mode==READ)
+    if(mode==get_modet::LHS_W || mode==get_modet::READ)
       dest.insert(object_idt(to_symbol_expr(expr)));
   }
   else if(expr.id()==ID_index)
   {
     const index_exprt &index_expr=to_index_expr(expr);
 
-    if(mode==LHS_R || mode==READ)
-      get_objects_rec(READ, index_expr.index(), dest, "");
+    if(mode==get_modet::LHS_R || mode==get_modet::READ)
+      get_objects_rec(get_modet::READ, index_expr.index(), dest, "");
 
-    if(mode==LHS_R)
-      get_objects_rec(READ, index_expr.array(), dest, "[]"+suffix);
+    if(mode==get_modet::LHS_R)
+      get_objects_rec(get_modet::READ, index_expr.array(), dest, "[]"+suffix);
     else
       get_objects_rec(mode, index_expr.array(), dest, "[]"+suffix);
   }
@@ -49,8 +49,8 @@ void get_objects_rec(
   {
     const if_exprt &if_expr=to_if_expr(expr);
 
-    if(mode==LHS_R || mode==READ)
-      get_objects_rec(READ, if_expr.cond(), dest, "");
+    if(mode==get_modet::LHS_R || mode==get_modet::READ)
+      get_objects_rec(get_modet::READ, if_expr.cond(), dest, "");
 
     get_objects_rec(mode, if_expr.true_case(), dest, suffix);
     get_objects_rec(mode, if_expr.false_case(), dest, suffix);
@@ -67,14 +67,14 @@ void get_objects_rec(
     const dereference_exprt &dereference_expr=
       to_dereference_expr(expr);
 
-    if(mode==LHS_R || mode==READ)
-      get_objects_rec(READ, dereference_expr.pointer(), dest, "");
+    if(mode==get_modet::LHS_R || mode==get_modet::READ)
+      get_objects_rec(get_modet::READ, dereference_expr.pointer(), dest, "");
   }
   else
   {
-    if(mode==LHS_R || mode==READ)
+    if(mode==get_modet::LHS_R || mode==get_modet::READ)
       forall_operands(it, expr)
-        get_objects_rec(READ, *it, dest, "");
+        get_objects_rec(get_modet::READ, *it, dest, "");
   }
 }
 
@@ -92,7 +92,7 @@ Function: get_objects
 
 void get_objects(const exprt &expr, object_id_sett &dest)
 {
-  get_objects_rec(READ, expr, dest, "");
+  get_objects_rec(get_modet::READ, expr, dest, "");
 }
 
 /*******************************************************************\
@@ -109,8 +109,8 @@ Function: get_objects_r
 
 void get_objects_r(const code_assignt &assign, object_id_sett &dest)
 {
-  get_objects_rec(LHS_R, assign.lhs(), dest, "");
-  get_objects_rec(READ, assign.rhs(), dest, "");
+  get_objects_rec(get_modet::LHS_R, assign.lhs(), dest, "");
+  get_objects_rec(get_modet::READ, assign.rhs(), dest, "");
 }
 
 /*******************************************************************\
@@ -127,7 +127,7 @@ Function: get_objects_w
 
 void get_objects_w(const code_assignt &assign, object_id_sett &dest)
 {
-  get_objects_rec(LHS_W, assign.lhs(), dest, "");
+  get_objects_rec(get_modet::LHS_W, assign.lhs(), dest, "");
 }
 
 /*******************************************************************\
@@ -144,7 +144,7 @@ Function: get_objects_w_lhs
 
 void get_objects_w(const exprt &lhs, object_id_sett &dest)
 {
-  get_objects_rec(LHS_W, lhs, dest, "");
+  get_objects_rec(get_modet::LHS_W, lhs, dest, "");
 }
 
 /*******************************************************************\
@@ -161,5 +161,5 @@ Function: get_objects_r_lhs
 
 void get_objects_r_lhs(const exprt &lhs, object_id_sett &dest)
 {
-  get_objects_rec(LHS_R, lhs, dest, "");
+  get_objects_rec(get_modet::LHS_R, lhs, dest, "");
 }

--- a/src/goto-instrument/show_locations.cpp
+++ b/src/goto-instrument/show_locations.cpp
@@ -41,7 +41,7 @@ void show_locations(
 
     switch(ui)
     {
-    case ui_message_handlert::XML_UI:
+    case ui_message_handlert::uit::XML_UI:
       {
         xmlt xml("program_location");
         xml.new_element("function").data=id2string(function_id);
@@ -59,7 +59,7 @@ void show_locations(
       }
       break;
 
-    case ui_message_handlert::PLAIN:
+    case ui_message_handlert::uit::PLAIN:
       std::cout << function_id << " "
                 << it->location_number << " "
                 << it->source_location << std::endl;

--- a/src/goto-instrument/unwind.cpp
+++ b/src/goto-instrument/unwind.cpp
@@ -180,7 +180,7 @@ void goto_unwindt::unwind(
   // rest program after unwound part
   goto_programt rest_program;
 
-  if(unwind_strategy==PARTIAL)
+  if(unwind_strategy==unwind_strategyt::PARTIAL)
   {
     goto_programt::targett t=rest_program.add_instruction();
     unwind_log.insert(t, loop_head->location_number);
@@ -190,7 +190,7 @@ void goto_unwindt::unwind(
     t->function=loop_head->function;
     t->location_number=loop_head->location_number;
   }
-  else if(unwind_strategy==CONTINUE)
+  else if(unwind_strategy==unwind_strategyt::CONTINUE)
   {
     copy_segment(loop_head, loop_exit, rest_program);
   }
@@ -216,9 +216,9 @@ void goto_unwindt::unwind(
 
     goto_programt::targett new_t=rest_program.add_instruction();
 
-    if(unwind_strategy==ASSERT)
+    if(unwind_strategy==unwind_strategyt::ASSERT)
       new_t->make_assertion(exit_cond);
-    else if(unwind_strategy==ASSUME)
+    else if(unwind_strategy==unwind_strategyt::ASSUME)
       new_t->make_assumption(exit_cond);
     else
       assert(false);

--- a/src/goto-instrument/unwind.h
+++ b/src/goto-instrument/unwind.h
@@ -22,7 +22,7 @@ void parse_unwindset(const std::string &us, unwind_sett &unwind_set);
 class goto_unwindt
 {
 public:
-  typedef enum { CONTINUE, PARTIAL, ASSERT, ASSUME } unwind_strategyt;
+  enum class unwind_strategyt { CONTINUE, PARTIAL, ASSERT, ASSUME };
 
   // unwind loop
 
@@ -47,14 +47,14 @@ public:
     goto_programt &goto_program,
     const unwind_sett &unwind_set,
     const int k=-1, // -1: no global bound
-    const unwind_strategyt unwind_strategy=PARTIAL);
+    const unwind_strategyt unwind_strategy=unwind_strategyt::PARTIAL);
 
   // unwind all functions
 
   void operator()(
     goto_functionst &goto_functions,
     const unsigned k, // global bound
-    const unwind_strategyt unwind_strategy=PARTIAL)
+    const unwind_strategyt unwind_strategy=unwind_strategyt::PARTIAL)
   {
     const unwind_sett unwind_set;
     operator()(goto_functions, unwind_set, k, unwind_strategy);
@@ -64,7 +64,7 @@ public:
     goto_functionst &goto_functions,
     const unwind_sett &unwind_set,
     const int k=-1, // -1: no global bound
-    const unwind_strategyt unwind_strategy=PARTIAL);
+    const unwind_strategyt unwind_strategy=unwind_strategyt::PARTIAL);
 
   // unwind log
 

--- a/src/goto-instrument/wmm/abstract_event.cpp
+++ b/src/goto-instrument/wmm/abstract_event.cpp
@@ -27,9 +27,9 @@ bool abstract_eventt::unsafe_pair_lwfence_param(const abstract_eventt &next,
   bool lwsync_met) const
 {
   /* pairs with fences are not properly pairs */
-  if(operation==Fence || next.operation==Fence
-    || operation==Lwfence || next.operation==Lwfence
-    || operation==ASMfence || next.operation==ASMfence)
+  if(operation==operationt::Fence || next.operation==operationt::Fence
+    || operation==operationt::Lwfence || next.operation==operationt::Lwfence
+    || operation==operationt::ASMfence || next.operation==operationt::ASMfence)
     return false;
 
   /* pairs of shared variables */
@@ -39,40 +39,64 @@ bool abstract_eventt::unsafe_pair_lwfence_param(const abstract_eventt &next,
   switch(model)
   {
   case TSO:
-    return (thread==next.thread && operation==Write && next.operation==Read);
+    return (thread==next.thread &&
+            operation==operationt::Write &&
+            next.operation==operationt::Read);
 
   case PSO:
-    return (thread==next.thread && operation==Write
+    return (thread==next.thread && operation==operationt::Write
       /* lwsyncWW -> mfenceWW */
-      && !(operation==Write && next.operation==Write && lwsync_met));
+      && !(operation==operationt::Write &&
+           next.operation==operationt::Write &&
+           lwsync_met));
 
   case RMO:
     return
       thread==next.thread &&
       /* lwsyncWW -> mfenceWW */
-      !(operation==Write && next.operation==Write && lwsync_met) &&
+      !(operation==operationt::Write &&
+        next.operation==operationt::Write &&
+        lwsync_met) &&
       /* lwsyncRW -> mfenceRW */
-      !(operation==Read && next.operation==Write && lwsync_met) &&
+      !(operation==operationt::Read &&
+        next.operation==operationt::Write &&
+        lwsync_met) &&
       /* lwsyncRR -> mfenceRR */
-      !(operation==Read && next.operation==Read && lwsync_met) &&
+      !(operation==operationt::Read &&
+        next.operation==operationt::Read &&
+        lwsync_met) &&
       /* if posWW, wsi maintained by the processor */
-      !(variable==next.variable && operation==Write && next.operation==Write) &&
+      !(variable==next.variable &&
+        operation==operationt::Write &&
+        next.operation==operationt::Write) &&
       /* if posRW, fri maintained by the processor */
-      !(variable==next.variable && operation==Read && next.operation==Write);
+      !(variable==next.variable &&
+        operation==operationt::Read &&
+        next.operation==operationt::Write);
 
   case Power:
     return ((thread==next.thread
       /* lwsyncWW -> mfenceWW */
-      && !(operation==Write && next.operation==Write && lwsync_met)
+      && !(operation==operationt::Write &&
+           next.operation==operationt::Write &&
+           lwsync_met)
       /* lwsyncRW -> mfenceRW */
-      && !(operation==Read && next.operation==Write && lwsync_met)
+      && !(operation==operationt::Read &&
+           next.operation==operationt::Write &&
+           lwsync_met)
       /* lwsyncRR -> mfenceRR */
-      && !(operation==Read && next.operation==Read && lwsync_met)
+      && !(operation==operationt::Read &&
+           next.operation==operationt::Read &&
+           lwsync_met)
       /* if posWW, wsi maintained by the processor */
-      && (variable!=next.variable || operation!=Write || next.operation!=Write))
+      && (variable!=next.variable ||
+          operation!=operationt::Write ||
+          next.operation!=operationt::Write))
       /* rfe */
-      || (thread!=next.thread && operation==Write && next.operation==Read
-        && variable==next.variable));
+      || (thread!=next.thread &&
+          operation==operationt::Write &&
+          next.operation==operationt::Read &&
+          variable==next.variable));
 
   case Unknown:
     {
@@ -100,9 +124,12 @@ bool abstract_eventt::unsafe_pair_asm(const abstract_eventt &next,
   unsigned char met) const
 {
   /* pairs with fences are not properly pairs */
-  if(operation==Fence || next.operation==Fence
-    || operation==Lwfence || next.operation==Lwfence
-    || operation==ASMfence || next.operation==ASMfence)
+  if(operation==operationt::Fence ||
+     next.operation==operationt::Fence ||
+     operation==operationt::Lwfence ||
+     next.operation==operationt::Lwfence ||
+     operation==operationt::ASMfence ||
+     next.operation==operationt::ASMfence)
     return false;
 
   /* pairs of shared variables */
@@ -112,31 +139,38 @@ bool abstract_eventt::unsafe_pair_asm(const abstract_eventt &next,
   switch(model)
   {
   case TSO:
-    return (thread==next.thread && operation==Write && next.operation==Read
-      && (met&1)==0);
+    return (thread==next.thread &&
+            operation==operationt::Write &&
+            next.operation==operationt::Read &&
+            (met&1)==0);
   case PSO:
-    return (thread==next.thread && operation==Write
-      && (met&3)==0);
+    return (thread==next.thread &&
+            operation==operationt::Write &&
+            (met&3)==0);
   case RMO:
     return
       thread==next.thread &&
       (met&15)==0 &&
       /* if posWW, wsi maintained by the processor */
-      !(variable==next.variable && operation==Write && next.operation==Write) &&
+      !(variable==next.variable &&
+        operation==operationt::Write &&
+          next.operation==operationt::Write) &&
       /* if posRW, fri maintained by the processor */
-      !(variable==next.variable && operation==Read && next.operation==Write);
+      !(variable==next.variable &&
+        operation==operationt::Read &&
+        next.operation==operationt::Write);
   case Power:
     return
       (thread==next.thread &&
        (met&15)==0 &&
        /* if posWW, wsi maintained by the processor */
        (variable!=next.variable ||
-        operation!=Write ||
-        next.operation!=Write)) ||
+        operation!=operationt::Write ||
+        next.operation!=operationt::Write)) ||
       /* rfe */
       (thread!=next.thread &&
-       operation==Write &&
-       next.operation==Read &&
+       operation==operationt::Write &&
+       next.operation==operationt::Read &&
        variable==next.variable);
 
   case Unknown:

--- a/src/goto-instrument/wmm/abstract_event.h
+++ b/src/goto-instrument/wmm/abstract_event.h
@@ -28,7 +28,7 @@ protected:
 
 public:
   /* for now, both fence functions and asm fences accepted */
-  typedef enum {Write, Read, Fence, Lwfence, ASMfence} operationt;
+  enum class operationt { Write, Read, Fence, Lwfence, ASMfence };
 
   operationt operation;
   unsigned thread;
@@ -111,7 +111,9 @@ public:
 
   bool is_fence() const
   {
-    return operation==Fence || operation==Lwfence || operation==ASMfence;
+    return operation==operationt::Fence ||
+           operation==operationt::Lwfence ||
+           operation==operationt::ASMfence;
   }
 
   /* checks the safety of the pair locally (i.e., w/o taking fences
@@ -138,11 +140,11 @@ public:
   {
     switch(operation)
     {
-      case Write: return "W";
-      case Read: return "R";
-      case Fence: return "F";
-      case Lwfence: return "f";
-      case ASMfence: return "asm:";
+      case operationt::Write: return "W";
+      case operationt::Read: return "R";
+      case operationt::Fence: return "F";
+      case operationt::Lwfence: return "f";
+      case operationt::ASMfence: return "asm:";
     }
     assert(false);
     return "?";
@@ -152,16 +154,18 @@ public:
     const abstract_eventt &second) const
   {
     return
-      (WRfence && first.operation==Write && second.operation==Read) ||
+      (WRfence &&
+       first.operation==operationt::Write &&
+       second.operation==operationt::Read) ||
       ((WWfence || WWcumul) &&
-       first.operation==Write &&
-       second.operation==Write) ||
+       first.operation==operationt::Write &&
+       second.operation==operationt::Write) ||
       ((RWfence || RWcumul) &&
-       first.operation==Read &&
-       second.operation==Write) ||
+       first.operation==operationt::Read &&
+       second.operation==operationt::Write) ||
       ((RRfence || RRcumul) &&
-       first.operation==Read &&
-       second.operation==Read);
+       first.operation==operationt::Read &&
+       second.operation==operationt::Read);
   }
 
   bool is_direct() const { return WWfence || WRfence || RRfence || RWfence; }

--- a/src/goto-instrument/wmm/cycle_collection.cpp
+++ b/src/goto-instrument/wmm/cycle_collection.cpp
@@ -263,7 +263,7 @@ bool event_grapht::graph_explorert::backtrack(
   if(!this_vertex.local)
   {
     /* only the lwsyncWR can be interpreted as poWR (i.e., skip of the fence) */
-    if(lwfence_met && this_vertex.operation!=abstract_eventt::Read)
+    if(lwfence_met && this_vertex.operation!=abstract_eventt::operationt::Read)
       return false; // {no_comm=true;get_com_only=false;}//return false;
 
     bool has_to_be_unsafe_updated=false;
@@ -274,9 +274,9 @@ bool event_grapht::graph_explorert::backtrack(
        id2string(this_vertex.variable).find("[]")==std::string::npos)
     {
       /* no more than 4 events per thread */
-      if(this_vertex.operation!=abstract_eventt::Fence &&
-         this_vertex.operation!=abstract_eventt::Lwfence &&
-         this_vertex.operation!=abstract_eventt::ASMfence)
+      if(this_vertex.operation!=abstract_eventt::operationt::Fence &&
+         this_vertex.operation!=abstract_eventt::operationt::Lwfence &&
+         this_vertex.operation!=abstract_eventt::operationt::ASMfence)
       {
         if(events_per_thread[this_vertex.thread]==4)
           return false;
@@ -295,13 +295,16 @@ bool event_grapht::graph_explorert::backtrack(
         point_stack.pop();
         const event_idt preprevious=point_stack.top();
         point_stack.push(previous);
-        if(!egraph[preprevious].unsafe_pair(this_vertex, model)
-          && !(this_vertex.operation==abstract_eventt::Fence
-            || egraph[preprevious].operation==abstract_eventt::Fence
-            || this_vertex.operation==abstract_eventt::Lwfence
-            || egraph[preprevious].operation==abstract_eventt::Lwfence
-            || this_vertex.operation==abstract_eventt::ASMfence
-            || egraph[preprevious].operation==abstract_eventt::ASMfence))
+        if(!egraph[preprevious].unsafe_pair(this_vertex, model) &&
+           !(this_vertex.operation==abstract_eventt::operationt::Fence ||
+             egraph[preprevious].operation==
+               abstract_eventt::operationt::Fence ||
+             this_vertex.operation==abstract_eventt::operationt::Lwfence ||
+             egraph[preprevious].operation==
+               abstract_eventt::operationt::Lwfence ||
+             this_vertex.operation==abstract_eventt::operationt::ASMfence ||
+             egraph[preprevious].operation==
+               abstract_eventt::operationt::ASMfence))
           return false;
       }
     }
@@ -316,14 +319,15 @@ bool event_grapht::graph_explorert::backtrack(
        not taken into account) */
     if(!point_stack.empty() &&
        egraph.are_po_ordered(point_stack.top(), vertex) &&
-       this_vertex.operation!=abstract_eventt::Fence &&
-       this_vertex.operation!=abstract_eventt::Lwfence &&
-       this_vertex.operation!=abstract_eventt::ASMfence &&
+       this_vertex.operation!=abstract_eventt::operationt::Fence &&
+       this_vertex.operation!=abstract_eventt::operationt::Lwfence &&
+       this_vertex.operation!=abstract_eventt::operationt::ASMfence &&
        this_vertex.variable==egraph[point_stack.top()].variable)
     {
       if(same_var_pair ||
-         (this_vertex.operation==abstract_eventt::Read &&
-          egraph[point_stack.top()].operation==abstract_eventt::Read))
+         (this_vertex.operation==abstract_eventt::operationt::Read &&
+          egraph[point_stack.top()].operation==
+            abstract_eventt::operationt::Read))
       {
         events_per_thread[this_vertex.thread]--;
         return false; // {no_comm=true;get_com_only=false;} //return false;
@@ -339,18 +343,18 @@ bool event_grapht::graph_explorert::backtrack(
     /* constraint 1.b */
     if(!point_stack.empty() &&
        egraph.are_po_ordered(point_stack.top(), vertex) &&
-       this_vertex.operation!=abstract_eventt::Fence &&
-       this_vertex.operation!=abstract_eventt::Lwfence &&
-       this_vertex.operation!=abstract_eventt::ASMfence &&
+       this_vertex.operation!=abstract_eventt::operationt::Fence &&
+       this_vertex.operation!=abstract_eventt::operationt::Lwfence &&
+       this_vertex.operation!=abstract_eventt::operationt::ASMfence &&
        this_vertex.variable!=egraph[point_stack.top()].variable)
     {
       same_var_pair_updated=false;
     }
 
     /* constraint 2: per variable, either W W, R W, W R, or R W R */
-    if(this_vertex.operation!=abstract_eventt::Fence &&
-       this_vertex.operation!=abstract_eventt::Lwfence &&
-       this_vertex.operation!=abstract_eventt::ASMfence)
+    if(this_vertex.operation!=abstract_eventt::operationt::Fence &&
+       this_vertex.operation!=abstract_eventt::operationt::Lwfence &&
+       this_vertex.operation!=abstract_eventt::operationt::ASMfence)
     {
       const unsigned char nb_writes=writes_per_variable[this_vertex.variable];
       const unsigned char nb_reads=reads_per_variable[this_vertex.variable];
@@ -360,7 +364,7 @@ bool event_grapht::graph_explorert::backtrack(
         events_per_thread[this_vertex.thread]--;
         return false; // {no_comm=true;get_com_only=false;} //return false;
       }
-      else if(this_vertex.operation==abstract_eventt::Write)
+      else if(this_vertex.operation==abstract_eventt::operationt::Write)
       {
         if(nb_writes==2)
         {
@@ -370,7 +374,7 @@ bool event_grapht::graph_explorert::backtrack(
         else
           writes_per_variable[this_vertex.variable]++;
       }
-      else if(this_vertex.operation==abstract_eventt::Read)
+      else if(this_vertex.operation==abstract_eventt::operationt::Read)
       {
         if(nb_reads==2)
         {
@@ -522,11 +526,11 @@ bool event_grapht::graph_explorert::backtrack(
     point_stack.pop();
 
     /* removes variable access */
-    if(this_vertex.operation!=abstract_eventt::Fence &&
-       this_vertex.operation!=abstract_eventt::Lwfence &&
-       this_vertex.operation!=abstract_eventt::ASMfence)
+    if(this_vertex.operation!=abstract_eventt::operationt::Fence &&
+       this_vertex.operation!=abstract_eventt::operationt::Lwfence &&
+       this_vertex.operation!=abstract_eventt::operationt::ASMfence)
     {
-      if(this_vertex.operation==abstract_eventt::Write)
+      if(this_vertex.operation==abstract_eventt::operationt::Write)
         writes_per_variable[this_vertex.variable]--;
       else
         reads_per_variable[this_vertex.variable]--;
@@ -544,12 +548,14 @@ bool event_grapht::graph_explorert::backtrack(
        (po_trans > 1 || po_trans==0) &&
        !point_stack.empty() &&
        egraph.are_po_ordered(point_stack.top(), vertex) &&
-       this_vertex.operation!=abstract_eventt::Fence &&
-       (this_vertex.operation!=abstract_eventt::Lwfence ||
-        egraph[point_stack.top()].operation==abstract_eventt::Write) &&
-       (this_vertex.operation!=abstract_eventt::ASMfence ||
+       this_vertex.operation!=abstract_eventt::operationt::Fence &&
+       (this_vertex.operation!=abstract_eventt::operationt::Lwfence ||
+        egraph[point_stack.top()].operation==
+          abstract_eventt::operationt::Write) &&
+       (this_vertex.operation!=abstract_eventt::operationt::ASMfence ||
         !this_vertex.WRfence ||
-        egraph[point_stack.top()].operation==abstract_eventt::Write))
+        egraph[point_stack.top()].operation==
+          abstract_eventt::operationt::Write))
     {
       skip_tracked.insert(vertex);
 
@@ -590,11 +596,13 @@ bool event_grapht::graph_explorert::backtrack(
       /* skip lwfence by po-transition only if we consider a WR */
       // TO CHECK
       const bool is_lwfence=
-        (this_vertex.operation==abstract_eventt::Lwfence &&
-         egraph[point_stack.top()].operation==abstract_eventt::Write) ||
-        (this_vertex.operation==abstract_eventt::ASMfence &&
+        (this_vertex.operation==abstract_eventt::operationt::Lwfence &&
+         egraph[point_stack.top()].operation==
+           abstract_eventt::operationt::Write) ||
+        (this_vertex.operation==abstract_eventt::operationt::ASMfence &&
          (!this_vertex.WRfence &&
-          egraph[point_stack.top()].operation==abstract_eventt::Write));
+          egraph[point_stack.top()].operation==
+            abstract_eventt::operationt::Write));
 
       for(wmm_grapht::edgest::const_iterator w_it=
           egraph.po_out(vertex).begin();

--- a/src/goto-instrument/wmm/event_graph.cpp
+++ b/src/goto-instrument/wmm/event_graph.cpp
@@ -237,7 +237,7 @@ bool event_grapht::critical_cyclet::check_AC(
   for(; AC_it!=end(); ++AC_it)
   {
     const abstract_eventt &AC_evt=egraph[*AC_it];
-    if(AC_evt.operation==abstract_eventt::Fence)
+    if(AC_evt.operation==abstract_eventt::operationt::Fence)
     {
       AC=true;
       break;
@@ -254,7 +254,7 @@ bool event_grapht::critical_cyclet::check_AC(
     for(AC_it=begin(); ; ++AC_it)
     {
       const abstract_eventt &AC_evt=egraph[*AC_it];
-      if(AC_evt.operation==abstract_eventt::Fence)
+      if(AC_evt.operation==abstract_eventt::operationt::Fence)
       {
         AC=true;
         break;
@@ -300,7 +300,7 @@ bool event_grapht::critical_cyclet::check_BC(
   for(; BC_it!=begin(); --BC_it)
   {
     const abstract_eventt &BC_evt=egraph[*BC_it];
-    if(BC_evt.operation==abstract_eventt::Fence)
+    if(BC_evt.operation==abstract_eventt::operationt::Fence)
     {
       BC=true;
       break;
@@ -319,7 +319,7 @@ bool event_grapht::critical_cyclet::check_BC(
     for(; ; --BC_it)
     {
       const abstract_eventt &BC_evt=egraph[*BC_it];
-      if(BC_evt.operation==abstract_eventt::Fence)
+      if(BC_evt.operation==abstract_eventt::operationt::Fence)
       {
         BC=true;
         break;
@@ -372,20 +372,21 @@ bool event_grapht::critical_cyclet::is_unsafe(memory_modelt model, bool fast)
     const abstract_eventt &next_evt=egraph[*next];
 
     /* strong fence -- this pair is safe */
-    if(it_evt.operation==abstract_eventt::Fence)
+    if(it_evt.operation==abstract_eventt::operationt::Fence)
       continue;
 
-    if(next_evt.operation==abstract_eventt::Fence)
+    if(next_evt.operation==abstract_eventt::operationt::Fence)
       continue;
 
     /* first element is a weak fence */
-    if(it_evt.operation==abstract_eventt::Lwfence)
+    if(it_evt.operation==abstract_eventt::operationt::Lwfence)
       continue;
 
     /* selects the next event which is not a weak fence */
     const_iterator s_it=next;
 
-    for( ; s_it!=end() && egraph[*s_it].operation==abstract_eventt::Lwfence;
+    for(; s_it!=end() &&
+          egraph[*s_it].operation==abstract_eventt::operationt::Lwfence;
         ++s_it)
     {
     }
@@ -395,7 +396,7 @@ bool event_grapht::critical_cyclet::is_unsafe(memory_modelt model, bool fast)
 
     const abstract_eventt &s_evt=egraph[*s_it];
 
-    if(s_evt.operation==abstract_eventt::Fence)
+    if(s_evt.operation==abstract_eventt::operationt::Fence)
       continue;
 
     /* if the whole cycle has been explored */
@@ -509,18 +510,19 @@ bool event_grapht::critical_cyclet::is_unsafe(memory_modelt model, bool fast)
   }
 
   /* strong fence -- this pair is safe */
-  if(egraph[back()].operation==abstract_eventt::Fence
-    || egraph[front()].operation==abstract_eventt::Fence)
+  if(egraph[back()].operation==abstract_eventt::operationt::Fence
+    || egraph[front()].operation==abstract_eventt::operationt::Fence)
     return unsafe_met;
 
   /* first element is a weak fence */
-  if(egraph[back()].operation==abstract_eventt::Lwfence)
+  if(egraph[back()].operation==abstract_eventt::operationt::Lwfence)
     return unsafe_met;
 
   /* selects the next event which is not a weak fence */
   const_iterator s_it;
   for(s_it=begin();
-      s_it!=end() && egraph[*s_it].operation==abstract_eventt::Lwfence;
+      s_it!=end() &&
+      egraph[*s_it].operation==abstract_eventt::operationt::Lwfence;
       s_it++)
   {
   }
@@ -529,7 +531,7 @@ bool event_grapht::critical_cyclet::is_unsafe(memory_modelt model, bool fast)
   if(s_it==end())
     return unsafe_met;
 
-  if(egraph[*s_it].operation==abstract_eventt::Fence)
+  if(egraph[*s_it].operation==abstract_eventt::operationt::Fence)
     return unsafe_met;
 
   const abstract_eventt &first=egraph[back()];
@@ -663,10 +665,10 @@ bool event_grapht::critical_cyclet::is_unsafe_asm(
     fences_met=0;
 
     /* fence -- this pair is safe */
-    if(egraph[*it].operation==abstract_eventt::ASMfence)
+    if(egraph[*it].operation==abstract_eventt::operationt::ASMfence)
       continue;
 
-    if(egraph[*(++it)].operation==abstract_eventt::ASMfence)
+    if(egraph[*(++it)].operation==abstract_eventt::operationt::ASMfence)
     {
       --it;
       continue;
@@ -679,14 +681,15 @@ bool event_grapht::critical_cyclet::is_unsafe_asm(
     --it;
 
     for(;
-      s_it!=end() && egraph[*s_it].operation==abstract_eventt::ASMfence;
+      s_it!=end() &&
+      egraph[*s_it].operation==abstract_eventt::operationt::ASMfence;
       s_it++)
       fences_met |= egraph[*s_it].fence_value();
 
     if(s_it==end())
       continue;
 
-    if(egraph[*s_it].operation==abstract_eventt::ASMfence)
+    if(egraph[*s_it].operation==abstract_eventt::operationt::ASMfence)
       continue;
 
     /* if the whole cycle has been explored */
@@ -714,7 +717,7 @@ bool event_grapht::critical_cyclet::is_unsafe_asm(
       for(;
         AC_it!=end() && egraph[*AC_it].thread==second.thread;
         AC_it++)
-        if(egraph[*AC_it].operation==abstract_eventt::ASMfence
+        if(egraph[*AC_it].operation==abstract_eventt::operationt::ASMfence
           && egraph[*AC_it].is_cumul()
           && egraph[*AC_it].is_corresponding_fence(egraph[*it], egraph[*s_it]))
         {
@@ -730,7 +733,7 @@ bool event_grapht::critical_cyclet::is_unsafe_asm(
         for(AC_it=begin();
             !(egraph[*AC_it]==first) && egraph[*AC_it].thread==second.thread;
             AC_it++)
-          if(egraph[*AC_it].operation==abstract_eventt::ASMfence &&
+          if(egraph[*AC_it].operation==abstract_eventt::operationt::ASMfence &&
              egraph[*AC_it].is_cumul() &&
              egraph[*AC_it].is_corresponding_fence(egraph[*it], egraph[*s_it]))
           {
@@ -758,7 +761,7 @@ bool event_grapht::critical_cyclet::is_unsafe_asm(
           BC_it!=begin() && egraph[*BC_it].thread==first.thread;
           BC_it--)
       {
-        if(egraph[*BC_it].operation==abstract_eventt::ASMfence &&
+        if(egraph[*BC_it].operation==abstract_eventt::operationt::ASMfence &&
            egraph[*BC_it].is_cumul() &&
            egraph[*BC_it].is_corresponding_fence(egraph[*it], egraph[*s_it]))
         {
@@ -775,7 +778,7 @@ bool event_grapht::critical_cyclet::is_unsafe_asm(
         for(BC_it=end();
             !(egraph[*BC_it]==second) && egraph[*BC_it].thread==first.thread;
             BC_it--)
-          if(egraph[*BC_it].operation==abstract_eventt::ASMfence &&
+          if(egraph[*BC_it].operation==abstract_eventt::operationt::ASMfence &&
              egraph[*BC_it].is_cumul() &&
              egraph[*BC_it].is_corresponding_fence(egraph[*it], egraph[*s_it]))
           {
@@ -827,8 +830,8 @@ bool event_grapht::critical_cyclet::is_unsafe_asm(
   }
 
   /* strong fence -- this pair is safe */
-  if(egraph[back()].operation==abstract_eventt::ASMfence
-    || egraph[front()].operation==abstract_eventt::ASMfence)
+  if(egraph[back()].operation==abstract_eventt::operationt::ASMfence
+    || egraph[front()].operation==abstract_eventt::operationt::ASMfence)
     return unsafe_met;
 
   fences_met=0;
@@ -836,14 +839,16 @@ bool event_grapht::critical_cyclet::is_unsafe_asm(
   /* selects the next event which is not a weak fence */
   const_iterator s_it;
   for(s_it=begin();
-    s_it!=end() && egraph[*s_it].operation==abstract_eventt::ASMfence; s_it++)
+    s_it!=end() &&
+    egraph[*s_it].operation==abstract_eventt::operationt::ASMfence;
+    s_it++)
     fences_met |= egraph[*s_it].fence_value();
 
   /* if the whole cycle has been explored */
   if(s_it==end())
     return unsafe_met;
 
-  if(egraph[*s_it].operation==abstract_eventt::ASMfence)
+  if(egraph[*s_it].operation==abstract_eventt::operationt::ASMfence)
     return unsafe_met;
 
   const abstract_eventt &first=egraph[back()];
@@ -867,7 +872,7 @@ bool event_grapht::critical_cyclet::is_unsafe_asm(
     for(;
       AC_it!=end() && egraph[*AC_it].thread==second.thread;
       AC_it++)
-      if(egraph[*AC_it].operation==abstract_eventt::ASMfence
+      if(egraph[*AC_it].operation==abstract_eventt::operationt::ASMfence
         && egraph[*AC_it].is_cumul()
         && egraph[*AC_it].is_corresponding_fence(first, second))
       {
@@ -883,7 +888,7 @@ bool event_grapht::critical_cyclet::is_unsafe_asm(
       for(AC_it=begin();
           !(egraph[*AC_it]==first) && egraph[*AC_it].thread==second.thread;
           AC_it++)
-        if(egraph[*AC_it].operation==abstract_eventt::ASMfence &&
+        if(egraph[*AC_it].operation==abstract_eventt::operationt::ASMfence &&
            egraph[*AC_it].is_cumul() &&
            egraph[*AC_it].is_corresponding_fence(first, second))
         {
@@ -902,7 +907,7 @@ bool event_grapht::critical_cyclet::is_unsafe_asm(
     for(;
       BC_it!=begin() && egraph[*BC_it].thread==first.thread;
       BC_it--)
-      if(egraph[*BC_it].operation==abstract_eventt::ASMfence
+      if(egraph[*BC_it].operation==abstract_eventt::operationt::ASMfence
         && egraph[*BC_it].is_cumul()
         && egraph[*BC_it].is_corresponding_fence(first, second))
       {
@@ -920,7 +925,7 @@ bool event_grapht::critical_cyclet::is_unsafe_asm(
       for(;
         !(egraph[*BC_it]==second) && egraph[*BC_it].thread==first.thread;
         BC_it--)
-        if(egraph[*BC_it].operation==abstract_eventt::ASMfence
+        if(egraph[*BC_it].operation==abstract_eventt::operationt::ASMfence
           && egraph[*BC_it].is_cumul()
           && egraph[*BC_it].is_corresponding_fence(first, second))
         {
@@ -985,9 +990,9 @@ bool event_grapht::critical_cyclet::is_not_uniproc() const
   for(; it!=end(); ++it)
   {
     const abstract_eventt &it_evt=egraph[*it];
-    if(it_evt.operation!=abstract_eventt::Fence
-      && it_evt.operation!=abstract_eventt::Lwfence
-      && it_evt.operation!=abstract_eventt::ASMfence)
+    if(it_evt.operation!=abstract_eventt::operationt::Fence
+      && it_evt.operation!=abstract_eventt::operationt::Lwfence
+      && it_evt.operation!=abstract_eventt::operationt::ASMfence)
       break;
   }
 
@@ -1006,9 +1011,9 @@ bool event_grapht::critical_cyclet::is_not_uniproc() const
   {
     const abstract_eventt &it_evt=egraph[*it];
     if(it_evt.variable!=var
-      && it_evt.operation!=abstract_eventt::Fence
-      && it_evt.operation!=abstract_eventt::Lwfence
-      && it_evt.operation!=abstract_eventt::ASMfence)
+      && it_evt.operation!=abstract_eventt::operationt::Fence
+      && it_evt.operation!=abstract_eventt::operationt::Lwfence
+      && it_evt.operation!=abstract_eventt::operationt::ASMfence)
       break;
   }
 
@@ -1035,9 +1040,9 @@ bool event_grapht::critical_cyclet::is_not_weak_uniproc() const
   for(; it!=end(); it++)
   {
     const abstract_eventt &it_evt=egraph[*it];
-    if(it_evt.operation!=abstract_eventt::Fence
-      && it_evt.operation!=abstract_eventt::Lwfence
-      && it_evt.operation!=abstract_eventt::ASMfence)
+    if(it_evt.operation!=abstract_eventt::operationt::Fence
+      && it_evt.operation!=abstract_eventt::operationt::Lwfence
+      && it_evt.operation!=abstract_eventt::operationt::ASMfence)
       break;
   }
 
@@ -1053,11 +1058,11 @@ bool event_grapht::critical_cyclet::is_not_weak_uniproc() const
     const abstract_eventt &it_evt=egraph[*it];
     if(
       !(it_evt.variable==var
-        &&(it==begin() || it_evt.operation!=abstract_eventt::Read
-          || egraph[*prev].operation!=abstract_eventt::Read))
-      && it_evt.operation!=abstract_eventt::Fence
-      && it_evt.operation!=abstract_eventt::Lwfence
-      && it_evt.operation!=abstract_eventt::ASMfence)
+        &&(it==begin() || it_evt.operation!=abstract_eventt::operationt::Read
+          || egraph[*prev].operation!=abstract_eventt::operationt::Read))
+      && it_evt.operation!=abstract_eventt::operationt::Fence
+      && it_evt.operation!=abstract_eventt::operationt::Lwfence
+      && it_evt.operation!=abstract_eventt::operationt::ASMfence)
       break;
   }
 
@@ -1094,8 +1099,8 @@ bool event_grapht::critical_cyclet::is_not_thin_air() const
     const abstract_eventt &next=egraph[*n_it];
 
     /* rf */
-    if(current.operation==abstract_eventt::Write &&
-      next.operation==abstract_eventt::Read)
+    if(current.operation==abstract_eventt::operationt::Write &&
+      next.operation==abstract_eventt::operationt::Read)
       continue;
 
     /* data dependencies */
@@ -1111,8 +1116,8 @@ bool event_grapht::critical_cyclet::is_not_thin_air() const
   const abstract_eventt &next=egraph[front()];
 
   /* rf */
-  if(current.operation==abstract_eventt::Write &&
-    next.operation==abstract_eventt::Read)
+  if(current.operation==abstract_eventt::operationt::Write &&
+    next.operation==abstract_eventt::operationt::Read)
      return false;
 
   /* data dependencies */
@@ -1167,24 +1172,24 @@ std::string event_grapht::critical_cyclet::print_unsafes() const
     const abstract_eventt &last=egraph[it->first];
 
     if(last.variable==first.variable
-      && last.operation==abstract_eventt::Write
-      && first.operation==abstract_eventt::Read)
+      && last.operation==abstract_eventt::operationt::Write
+      && first.operation==abstract_eventt::operationt::Read)
     {
       name += " Rf";
       name += (last.thread==first.thread?"i":"e");
     }
 
     else if(last.variable==first.variable &&
-            last.operation==abstract_eventt::Read &&
-            first.operation==abstract_eventt::Write &&
+            last.operation==abstract_eventt::operationt::Read &&
+            first.operation==abstract_eventt::operationt::Write &&
             (last.thread!=first.thread || it->first > it->second))
     {
       name += " Fr";
       name += (last.thread==first.thread?"i":"e");
     }
     else if(last.variable==first.variable &&
-            last.operation==abstract_eventt::Write &&
-            first.operation==abstract_eventt::Write &&
+            last.operation==abstract_eventt::operationt::Write &&
+            first.operation==abstract_eventt::operationt::Write &&
             (last.thread!=first.thread || it->first > it->second))
     {
       /* we prefer to write Po rather than Wsi */
@@ -1192,7 +1197,7 @@ std::string event_grapht::critical_cyclet::print_unsafes() const
       name += (last.thread==first.thread?"i":"e");
     }
     else if(last.thread==first.thread &&
-            last.operation!=abstract_eventt::Fence)
+            last.operation!=abstract_eventt::operationt::Fence)
     {
       name += " Po";
       name += (last.variable==first.variable?"s":"d") + last.get_operation()
@@ -1453,15 +1458,15 @@ std::string event_grapht::critical_cyclet::print_name(
     {
       const abstract_eventt &prev=egraph[*prev_it];
 
-      if(prev.operation==abstract_eventt::Fence ||
-         prev.operation==abstract_eventt::Lwfence ||
-         prev.operation==abstract_eventt::ASMfence)
+      if(prev.operation==abstract_eventt::operationt::Fence ||
+         prev.operation==abstract_eventt::operationt::Lwfence ||
+         prev.operation==abstract_eventt::operationt::ASMfence)
       {
         ++extra_fence_count;
         // nothing to do
       }
 
-      else if(cur.operation==abstract_eventt::Fence)
+      else if(cur.operation==abstract_eventt::operationt::Fence)
       {
         const_iterator n_it=cur_it;
         bool wraparound=false;
@@ -1477,9 +1482,9 @@ std::string event_grapht::critical_cyclet::print_name(
             n_it=reduced.begin();
           }
           const abstract_eventt &cand=egraph[*n_it];
-          if(cand.operation!=abstract_eventt::Fence &&
-             cand.operation!=abstract_eventt::Lwfence &&
-             cand.operation!=abstract_eventt::ASMfence)
+          if(cand.operation!=abstract_eventt::operationt::Fence &&
+             cand.operation!=abstract_eventt::operationt::Lwfence &&
+             cand.operation!=abstract_eventt::operationt::ASMfence)
             break;
           if(!wraparound)
             ++cur_it;
@@ -1487,14 +1492,14 @@ std::string event_grapht::critical_cyclet::print_name(
             ++extra_fence_count;
         }
         const abstract_eventt &succ=egraph[*n_it];
-        assert(succ.operation==abstract_eventt::Read ||
-               succ.operation==abstract_eventt::Write);
+        assert(succ.operation==abstract_eventt::operationt::Read ||
+               succ.operation==abstract_eventt::operationt::Write);
         name += (model==Power?" Sync":" MFence");
         name += (prev.variable==succ.variable?"s":"d")
           + prev.get_operation() + succ.get_operation();
       }
 
-      else if(cur.operation==abstract_eventt::Lwfence)
+      else if(cur.operation==abstract_eventt::operationt::Lwfence)
       {
         std::string cand_name=" LwSync";
         const_iterator n_it=cur_it;
@@ -1511,12 +1516,12 @@ std::string event_grapht::critical_cyclet::print_name(
             n_it=reduced.begin();
           }
           const abstract_eventt &cand=egraph[*n_it];
-          if(cand.operation!=abstract_eventt::Fence &&
-             cand.operation!=abstract_eventt::Lwfence &&
-             cand.operation!=abstract_eventt::ASMfence)
+          if(cand.operation!=abstract_eventt::operationt::Fence &&
+             cand.operation!=abstract_eventt::operationt::Lwfence &&
+             cand.operation!=abstract_eventt::operationt::ASMfence)
             break;
-          else if(cand.operation==abstract_eventt::Fence ||
-                  (cand.operation==abstract_eventt::ASMfence &&
+          else if(cand.operation==abstract_eventt::operationt::Fence ||
+                  (cand.operation==abstract_eventt::operationt::ASMfence &&
                    cand.fence_value()&1))
             cand_name=(model==Power?" Sync":" MFence");
           if(!wraparound)
@@ -1525,14 +1530,14 @@ std::string event_grapht::critical_cyclet::print_name(
             ++extra_fence_count;
         }
         const abstract_eventt &succ=egraph[*n_it];
-        assert(succ.operation==abstract_eventt::Read ||
-               succ.operation==abstract_eventt::Write);
+        assert(succ.operation==abstract_eventt::operationt::Read ||
+               succ.operation==abstract_eventt::operationt::Write);
         name += cand_name;
         name += (prev.variable==succ.variable?"s":"d")
           + prev.get_operation() + succ.get_operation();
       }
 
-      else if(cur.operation==abstract_eventt::ASMfence)
+      else if(cur.operation==abstract_eventt::operationt::ASMfence)
       {
         std::string cand_name;
         if(cur.fence_value()&1)
@@ -1553,12 +1558,12 @@ std::string event_grapht::critical_cyclet::print_name(
             n_it=reduced.begin();
           }
           const abstract_eventt &cand=egraph[*n_it];
-          if(cand.operation!=abstract_eventt::Fence &&
-             cand.operation!=abstract_eventt::Lwfence &&
-             cand.operation!=abstract_eventt::ASMfence)
+          if(cand.operation!=abstract_eventt::operationt::Fence &&
+             cand.operation!=abstract_eventt::operationt::Lwfence &&
+             cand.operation!=abstract_eventt::operationt::ASMfence)
             break;
-          else if(cand.operation==abstract_eventt::Fence ||
-                  (cand.operation==abstract_eventt::ASMfence &&
+          else if(cand.operation==abstract_eventt::operationt::Fence ||
+                  (cand.operation==abstract_eventt::operationt::ASMfence &&
                    cand.fence_value()&1))
             cand_name=(model==Power?" Sync":" MFence");
           if(!wraparound)
@@ -1567,24 +1572,24 @@ std::string event_grapht::critical_cyclet::print_name(
             ++extra_fence_count;
         }
         const abstract_eventt &succ=egraph[*n_it];
-        assert(succ.operation==abstract_eventt::Read ||
-               succ.operation==abstract_eventt::Write);
+        assert(succ.operation==abstract_eventt::operationt::Read ||
+               succ.operation==abstract_eventt::operationt::Write);
         name += cand_name;
         name += (prev.variable==succ.variable?"s":"d")
           + prev.get_operation() + succ.get_operation();
       }
 
       else if(prev.variable==cur.variable
-        && prev.operation==abstract_eventt::Write
-        && cur.operation==abstract_eventt::Read)
+        && prev.operation==abstract_eventt::operationt::Write
+        && cur.operation==abstract_eventt::operationt::Read)
       {
         name += " Rf";
         name += (prev.thread==cur.thread?"i":"e");
       }
 
       else if(prev.variable==cur.variable
-        && prev.operation==abstract_eventt::Read
-        && cur.operation==abstract_eventt::Write
+        && prev.operation==abstract_eventt::operationt::Read
+        && cur.operation==abstract_eventt::operationt::Write
         && (prev.thread!=cur.thread || *prev_it > *cur_it))
       {
         name += " Fr";
@@ -1592,8 +1597,8 @@ std::string event_grapht::critical_cyclet::print_name(
       }
 
       else if(prev.variable==cur.variable &&
-              prev.operation==abstract_eventt::Write &&
-              cur.operation==abstract_eventt::Write &&
+              prev.operation==abstract_eventt::operationt::Write &&
+              cur.operation==abstract_eventt::operationt::Write &&
               (prev.thread!=cur.thread || *prev_it > *cur_it))
       {
         /* we prefer to write Po rather than Wsi */
@@ -1602,13 +1607,13 @@ std::string event_grapht::critical_cyclet::print_name(
       }
 
       else if(prev.thread==cur.thread
-        && prev.operation!=abstract_eventt::Fence
-        && prev.operation!=abstract_eventt::Lwfence
-        && prev.operation!=abstract_eventt::ASMfence)
+        && prev.operation!=abstract_eventt::operationt::Fence
+        && prev.operation!=abstract_eventt::operationt::Lwfence
+        && prev.operation!=abstract_eventt::operationt::ASMfence)
       {
         const data_dpt &dep=egraph.map_data_dp[cur.thread];
 
-        if(prev.operation==abstract_eventt::Read &&
+        if(prev.operation==abstract_eventt::operationt::Read &&
            dep.dp(prev, cur))
         {
           name += " DpData";
@@ -1646,13 +1651,13 @@ std::string event_grapht::critical_cyclet::print_name(
   const abstract_eventt &first=egraph[reduced.front()];
   const abstract_eventt &last=egraph[reduced.back()];
 
-  assert(last.operation!=abstract_eventt::Fence &&
-         last.operation!=abstract_eventt::Lwfence &&
-         last.operation!=abstract_eventt::ASMfence);
+  assert(last.operation!=abstract_eventt::operationt::Fence &&
+         last.operation!=abstract_eventt::operationt::Lwfence &&
+         last.operation!=abstract_eventt::operationt::ASMfence);
 
-  if(first.operation==abstract_eventt::Fence ||
-     first.operation==abstract_eventt::Lwfence ||
-     first.operation==abstract_eventt::ASMfence)
+  if(first.operation==abstract_eventt::operationt::Fence ||
+     first.operation==abstract_eventt::operationt::Lwfence ||
+     first.operation==abstract_eventt::operationt::ASMfence)
   {
     std::string cand_name=" LwSync";
     const_iterator it=reduced.begin();
@@ -1660,35 +1665,35 @@ std::string event_grapht::critical_cyclet::print_name(
     {
       const abstract_eventt &cand=egraph[*it];
 
-      if(cand.operation!=abstract_eventt::Fence &&
-         cand.operation!=abstract_eventt::Lwfence &&
-         cand.operation!=abstract_eventt::ASMfence)
+      if(cand.operation!=abstract_eventt::operationt::Fence &&
+         cand.operation!=abstract_eventt::operationt::Lwfence &&
+         cand.operation!=abstract_eventt::operationt::ASMfence)
         break;
-      else if(cand.operation==abstract_eventt::Fence ||
-              (cand.operation==abstract_eventt::ASMfence &&
+      else if(cand.operation==abstract_eventt::operationt::Fence ||
+              (cand.operation==abstract_eventt::operationt::ASMfence &&
                cand.fence_value()&1))
         cand_name=(model==Power?" Sync":" MFence");
     }
     assert(it!=reduced.begin() && it!=reduced.end());
     const abstract_eventt &succ=egraph[*it];
-    assert(succ.operation==abstract_eventt::Read ||
-           succ.operation==abstract_eventt::Write);
+    assert(succ.operation==abstract_eventt::operationt::Read ||
+           succ.operation==abstract_eventt::operationt::Write);
     name += cand_name;
     name += (last.variable==succ.variable?"s":"d")
       + last.get_operation() + succ.get_operation();
   }
 
   else if(last.variable==first.variable
-    && last.operation==abstract_eventt::Write
-    && first.operation==abstract_eventt::Read)
+    && last.operation==abstract_eventt::operationt::Write
+    && first.operation==abstract_eventt::operationt::Read)
   {
     name += " Rf";
     name += (last.thread==first.thread?"i":"e");
   }
 
   else if(last.variable==first.variable
-    && last.operation==abstract_eventt::Read
-    && first.operation==abstract_eventt::Write
+    && last.operation==abstract_eventt::operationt::Read
+    && first.operation==abstract_eventt::operationt::Write
     && (last.thread!=first.thread || reduced.back() > reduced.front()))
   {
     name += " Fr";
@@ -1696,8 +1701,8 @@ std::string event_grapht::critical_cyclet::print_name(
   }
 
   else if(last.variable==first.variable &&
-          last.operation==abstract_eventt::Write &&
-          first.operation==abstract_eventt::Write &&
+          last.operation==abstract_eventt::operationt::Write &&
+          first.operation==abstract_eventt::operationt::Write &&
           (last.thread!=first.thread || reduced.back() > reduced.front()))
   {
     /* we prefer to write Po rather than Wsi */
@@ -1709,7 +1714,7 @@ std::string event_grapht::critical_cyclet::print_name(
   {
     const data_dpt &dep=egraph.map_data_dp[last.thread];
 
-    if(last.operation==abstract_eventt::Read &&
+    if(last.operation==abstract_eventt::operationt::Read &&
        dep.dp(last, first))
     {
       name += " DpData";
@@ -1786,7 +1791,7 @@ void event_grapht::critical_cyclet::print_dot(
       const abstract_eventt &prev=egraph[*prev_it];
 
       str << prev.id << "->";
-      if(cur.operation==abstract_eventt::Fence)
+      if(cur.operation==abstract_eventt::operationt::Fence)
       {
         const_iterator n_it=cur_it;
         ++n_it;
@@ -1797,7 +1802,7 @@ void event_grapht::critical_cyclet::print_dot(
         str << (prev.variable==cur.variable?"s":"d");
         str << prev.get_operation() << succ.get_operation();
       }
-      else if(cur.operation==abstract_eventt::Lwfence)
+      else if(cur.operation==abstract_eventt::operationt::Lwfence)
       {
         const_iterator n_it=cur_it;
         ++n_it;
@@ -1808,22 +1813,22 @@ void event_grapht::critical_cyclet::print_dot(
         str  <<prev.get_operation() << succ.get_operation();
       }
       else if(prev.variable==cur.variable
-        && prev.operation==abstract_eventt::Write
-        && cur.operation==abstract_eventt::Read)
+        && prev.operation==abstract_eventt::operationt::Write
+        && cur.operation==abstract_eventt::operationt::Read)
       {
         str << cur.id << "[label=\"";
         str << "Rf" << (prev.thread==cur.thread?"i":"e");
       }
       else if(prev.variable==cur.variable
-        && prev.operation==abstract_eventt::Read
-        && cur.operation==abstract_eventt::Write)
+        && prev.operation==abstract_eventt::operationt::Read
+        && cur.operation==abstract_eventt::operationt::Write)
       {
         str << cur.id << "[label=\"";
         str << "Fr" << (prev.thread==cur.thread?"i":"e");
       }
       else if(prev.variable==cur.variable &&
-              prev.operation==abstract_eventt::Write &&
-              cur.operation==abstract_eventt::Write &&
+              prev.operation==abstract_eventt::operationt::Write &&
+              cur.operation==abstract_eventt::operationt::Write &&
               prev.thread!=cur.thread)
       {
         /* we prefer to write Po rather than Wsi */
@@ -1831,7 +1836,7 @@ void event_grapht::critical_cyclet::print_dot(
         str << "Ws" << (prev.thread==cur.thread?"i":"e");
       }
       else if(prev.thread==cur.thread &&
-              prev.operation!=abstract_eventt::Fence)
+              prev.operation!=abstract_eventt::operationt::Fence)
       {
         str << cur.id << "[label=\"";
         str << "Po" << (prev.variable==cur.variable?"s":"d")
@@ -1854,7 +1859,7 @@ void event_grapht::critical_cyclet::print_dot(
 
   /* edge */
   str << last.id << "->";
-  if(first.operation==abstract_eventt::Fence)
+  if(first.operation==abstract_eventt::operationt::Fence)
   {
     const_iterator next=begin();
     ++next;
@@ -1864,7 +1869,7 @@ void event_grapht::critical_cyclet::print_dot(
     str << (last.variable==first.variable?"s":"d");
     str << last.get_operation() << succ.get_operation();
   }
-  else if(first.operation==abstract_eventt::Lwfence)
+  else if(first.operation==abstract_eventt::operationt::Lwfence)
   {
     const_iterator next=begin();
     ++next;
@@ -1874,22 +1879,22 @@ void event_grapht::critical_cyclet::print_dot(
     str << last.get_operation() << succ.get_operation();
   }
   else if(last.variable==first.variable &&
-          last.operation==abstract_eventt::Write &&
-          first.operation==abstract_eventt::Read)
+          last.operation==abstract_eventt::operationt::Write &&
+          first.operation==abstract_eventt::operationt::Read)
   {
     str << first.id << "[label=\"";
     str << "Rf" << (last.thread==first.thread?"i":"e");
   }
   else if(last.variable==first.variable &&
-          last.operation==abstract_eventt::Read &&
-          first.operation==abstract_eventt::Write)
+          last.operation==abstract_eventt::operationt::Read &&
+          first.operation==abstract_eventt::operationt::Write)
   {
     str << first.id << "[label=\"";
     str << "Fr" << (last.thread==first.thread?"i":"e");
   }
   else if(last.variable==first.variable &&
-          last.operation==abstract_eventt::Write &&
-          first.operation==abstract_eventt::Write &&
+          last.operation==abstract_eventt::operationt::Write &&
+          first.operation==abstract_eventt::operationt::Write &&
           last.thread!=first.thread)
   {
     /* we prefer to write Po rather than Wsi */
@@ -1897,7 +1902,7 @@ void event_grapht::critical_cyclet::print_dot(
     str << "Ws" << (last.thread==first.thread?"i":"e");
   }
   else if(last.thread==first.thread &&
-          last.operation!=abstract_eventt::Fence)
+          last.operation!=abstract_eventt::operationt::Fence)
   {
     str << first.id << "[label=\"";
     str << "Po" << (last.variable==first.variable?"s":"d");

--- a/src/goto-instrument/wmm/goto2graph.cpp
+++ b/src/goto-instrument/wmm/goto2graph.cpp
@@ -886,7 +886,7 @@ void instrumentert::cfg_visitort::visit_cfg_lwfence(
   goto_programt::instructionst::iterator i_it)
 {
   const goto_programt::instructiont &instruction=*i_it;
-  const abstract_eventt new_fence_event(abstract_eventt::Lwfence,
+  const abstract_eventt new_fence_event(abstract_eventt::operationt::Lwfence,
     thread, "f", instrumenter.unique_id++, instruction.source_location, false);
   const event_idt new_fence_node=egraph.add_node();
   egraph[new_fence_node](new_fence_event);
@@ -937,7 +937,7 @@ void instrumentert::cfg_visitort::visit_cfg_asm_fence(
   bool WWcumul=instruction.code.get_bool(ID_WWcumul);
   bool RRcumul=instruction.code.get_bool(ID_RRcumul);
   bool RWcumul=instruction.code.get_bool(ID_RWcumul);
-  const abstract_eventt new_fence_event(abstract_eventt::ASMfence,
+  const abstract_eventt new_fence_event(abstract_eventt::operationt::ASMfence,
     thread, "asm", instrumenter.unique_id++, instruction.source_location,
     false, WRfence, WWfence, RRfence, RWfence, WWcumul, RWcumul, RRcumul);
   const event_idt new_fence_node=egraph.add_node();
@@ -1026,7 +1026,7 @@ void instrumentert::cfg_visitort::visit_cfg_assign(
     assert(read_expr);
 #endif
 
-    const abstract_eventt new_read_event(abstract_eventt::Read,
+    const abstract_eventt new_read_event(abstract_eventt::operationt::Read,
       thread, id2string(read), instrumenter.unique_id++,
       instruction.source_location, local(read));
 
@@ -1124,7 +1124,7 @@ void instrumentert::cfg_visitort::visit_cfg_assign(
     // assert(write_expr);
 
     /* creates Write */
-    const abstract_eventt new_write_event(abstract_eventt::Write,
+    const abstract_eventt new_write_event(abstract_eventt::operationt::Write,
       thread, id2string(write), instrumenter.unique_id++,
       instruction.source_location, local(write));
 
@@ -1311,7 +1311,7 @@ void instrumentert::cfg_visitort::visit_cfg_fence(
   goto_programt::instructionst::iterator i_it)
 {
   const goto_programt::instructiont &instruction=*i_it;
-  const abstract_eventt new_fence_event(abstract_eventt::Fence,
+  const abstract_eventt new_fence_event(abstract_eventt::operationt::Fence,
     thread, "F", instrumenter.unique_id++, instruction.source_location, false);
   const event_idt new_fence_node=egraph.add_node();
   egraph[new_fence_node](new_fence_event);

--- a/src/goto-instrument/wmm/instrumenter_strategies.cpp
+++ b/src/goto-instrument/wmm/instrumenter_strategies.cpp
@@ -249,9 +249,9 @@ unsigned inline instrumentert::cost(
   /* cost(poW*)=1
      cost(poRW)=cost(rfe)=2
      cost(poRR)=3 */
-  if(egraph[e.first].operation==abstract_eventt::Write)
+  if(egraph[e.first].operation==abstract_eventt::operationt::Write)
     return 1;
-  else if(egraph[e.second].operation==abstract_eventt::Write
+  else if(egraph[e.second].operation==abstract_eventt::operationt::Write
     || !e.is_po)
     return 2;
   else

--- a/src/goto-instrument/wmm/pair_collection.cpp
+++ b/src/goto-instrument/wmm/pair_collection.cpp
@@ -59,7 +59,7 @@ void event_grapht::graph_pensieve_explorert::collect_pairs(namespacet &ns)
         /* directly outputs */
         OUTPUT(res, "fence", first_event.source_location.get_file(),
           first_event.source_location.get_line(), first_event.variable,
-            first_event.operation);
+            static_cast<int>(first_event.operation));
       }
       catch(std::string s)
       {

--- a/src/goto-instrument/wmm/wmm.h
+++ b/src/goto-instrument/wmm/wmm.h
@@ -11,16 +11,16 @@ Date: 2012
 #ifndef CPROVER_GOTO_INSTRUMENT_WMM_WMM_H
 #define CPROVER_GOTO_INSTRUMENT_WMM_WMM_H
 
-typedef enum
+enum memory_modelt
 {
   Unknown=-1,
   TSO=0,
   PSO=1,
   RMO=2,
   Power=3
-} memory_modelt;
+};
 
-typedef enum
+enum instrumentation_strategyt
 {
   all=0,
   min_interference=1,
@@ -28,13 +28,13 @@ typedef enum
   write_first=3,
   my_events=4,
   one_event_per_cycle=5
-} instrumentation_strategyt;
+};
 
-typedef enum
+enum loop_strategyt
 {
   arrays_only=0,
   all_loops=1,
   no_loop=2
-} loop_strategyt;
+};
 
 #endif // CPROVER_GOTO_INSTRUMENT_WMM_WMM_H

--- a/src/goto-programs/elf_reader.h
+++ b/src/goto-programs/elf_reader.h
@@ -99,7 +99,7 @@ class elf_readert
 public:
   explicit elf_readert(std::istream &_in);
 
-  typedef enum { ELF32=1, ELF64=2 } elf_classt;
+  enum elf_classt { ELF32=1, ELF64=2 };
   elf_classt elf_class;
 
   // the ELF header

--- a/src/goto-programs/format_strings.cpp
+++ b/src/goto-programs/format_strings.cpp
@@ -36,11 +36,16 @@ void parse_flags(
   {
     switch(*it)
     {
-      case '#': curtok.flags.push_back(format_tokent::ALTERNATE); break;
-      case '0': curtok.flags.push_back(format_tokent::ZERO_PAD); break;
-      case '-': curtok.flags.push_back(format_tokent::LEFT_ADJUST); break;
-      case ' ': curtok.flags.push_back(format_tokent::SIGNED_SPACE); break;
-      case '+': curtok.flags.push_back(format_tokent::SIGN); break;
+      case '#':
+        curtok.flags.push_back(format_tokent::flag_typet::ALTERNATE); break;
+      case '0':
+        curtok.flags.push_back(format_tokent::flag_typet::ZERO_PAD); break;
+      case '-':
+        curtok.flags.push_back(format_tokent::flag_typet::LEFT_ADJUST); break;
+      case ' ':
+        curtok.flags.push_back(format_tokent::flag_typet::SIGNED_SPACE); break;
+      case '+':
+        curtok.flags.push_back(format_tokent::flag_typet::SIGN); break;
       default: throw 0;
     }
     it++;
@@ -65,7 +70,7 @@ void parse_field_width(
 {
   if(*it=='*')
   {
-    curtok.flags.push_back(format_tokent::ASTERISK);
+    curtok.flags.push_back(format_tokent::flag_typet::ASTERISK);
     it++;
   }
 
@@ -96,7 +101,7 @@ void parse_precision(
 
     if(*it=='*')
     {
-      curtok.flags.push_back(format_tokent::ASTERISK);
+      curtok.flags.push_back(format_tokent::flag_typet::ASTERISK);
       it++;
     }
     else
@@ -129,29 +134,29 @@ void parse_length_modifier(
     it++;
     if(*it=='h')
       it++;
-    curtok.length_modifier = format_tokent::LEN_h;
+    curtok.length_modifier = format_tokent::length_modifierst::LEN_h;
   }
   else if(*it=='l')
   {
     it++;
     if(*it=='l')
       it++;
-    curtok.length_modifier = format_tokent::LEN_l;
+    curtok.length_modifier = format_tokent::length_modifierst::LEN_l;
   }
   else if(*it=='L')
   {
     it++;
-    curtok.length_modifier = format_tokent::LEN_L;
+    curtok.length_modifier = format_tokent::length_modifierst::LEN_L;
   }
   else if(*it=='j')
   {
     it++;
-    curtok.length_modifier = format_tokent::LEN_j;
+    curtok.length_modifier = format_tokent::length_modifierst::LEN_j;
   }
   else if(*it=='t')
   {
     it++;
-    curtok.length_modifier = format_tokent::LEN_L;
+    curtok.length_modifier = format_tokent::length_modifierst::LEN_L;
   }
 }
 
@@ -176,34 +181,37 @@ void parse_conversion_specifier(
   {
     case 'd':
     case 'i':
-      curtok.type=format_tokent::INT;
-      curtok.representation=format_tokent::SIGNED_DEC;
+      curtok.type=format_tokent::token_typet::INT;
+      curtok.representation=format_tokent::representationt::SIGNED_DEC;
       break;
     case 'o':
-      curtok.type=format_tokent::INT;
-      curtok.representation=format_tokent::UNSIGNED_OCT;
+      curtok.type=format_tokent::token_typet::INT;
+      curtok.representation=format_tokent::representationt::UNSIGNED_OCT;
       break;
     case 'u':
-      curtok.type=format_tokent::INT;
-      curtok.representation=format_tokent::UNSIGNED_DEC;
+      curtok.type=format_tokent::token_typet::INT;
+      curtok.representation=format_tokent::representationt::UNSIGNED_DEC;
       break;
     case 'x':
     case 'X':
-      curtok.type=format_tokent::INT;
-      curtok.representation=format_tokent::UNSIGNED_HEX;
+      curtok.type=format_tokent::token_typet::INT;
+      curtok.representation=format_tokent::representationt::UNSIGNED_HEX;
       break;
     case 'e':
-    case 'E': curtok.type=format_tokent::FLOAT; break;
+    case 'E': curtok.type=format_tokent::token_typet::FLOAT; break;
     case 'f':
-    case 'F': curtok.type=format_tokent::FLOAT; break;
+    case 'F': curtok.type=format_tokent::token_typet::FLOAT; break;
     case 'g':
-    case 'G': curtok.type=format_tokent::FLOAT; break;
+    case 'G': curtok.type=format_tokent::token_typet::FLOAT; break;
     case 'a':
-    case 'A': curtok.type=format_tokent::FLOAT; break;
-    case 'c': curtok.type=format_tokent::CHAR; break;
-    case 's': curtok.type=format_tokent::STRING; break;
-    case 'p': curtok.type=format_tokent::POINTER; break;
-    case '%': curtok.type=format_tokent::TEXT; curtok.value="%"; break;
+    case 'A': curtok.type=format_tokent::token_typet::FLOAT; break;
+    case 'c': curtok.type=format_tokent::token_typet::CHAR; break;
+    case 's': curtok.type=format_tokent::token_typet::STRING; break;
+    case 'p': curtok.type=format_tokent::token_typet::POINTER; break;
+    case '%':
+      curtok.type=format_tokent::token_typet::TEXT;
+      curtok.value="%";
+      break;
     case '[': // pattern matching in, e.g., fscanf.
     {
       std::string tmp;
@@ -264,8 +272,8 @@ format_token_listt parse_format_string(const std::string &arg_string)
     else
     {
       if(token_list.empty() ||
-         token_list.back().type!=format_tokent::TEXT)
-        token_list.push_back(format_tokent(format_tokent::TEXT));
+         token_list.back().type!=format_tokent::token_typet::TEXT)
+        token_list.push_back(format_tokent(format_tokent::token_typet::TEXT));
 
       std::string tmp;
       for( ; it!=arg_string.end() && *it!='%'; it++)
@@ -295,62 +303,63 @@ typet get_type(const format_tokent &token)
 {
   switch(token.type)
   {
-  case format_tokent::INT:
+  case format_tokent::token_typet::INT:
     switch(token.length_modifier)
     {
-    case format_tokent::LEN_h:
-      if(token.representation==format_tokent::SIGNED_DEC)
+    case format_tokent::length_modifierst::LEN_h:
+      if(token.representation==format_tokent::representationt::SIGNED_DEC)
         return signed_char_type();
       else
         return unsigned_char_type();
 
-    case format_tokent::LEN_hh:
-      if(token.representation==format_tokent::SIGNED_DEC)
+    case format_tokent::length_modifierst::LEN_hh:
+      if(token.representation==format_tokent::representationt::SIGNED_DEC)
         return signed_short_int_type();
       else
         return unsigned_short_int_type();
 
-    case format_tokent::LEN_l:
-      if(token.representation==format_tokent::SIGNED_DEC)
+    case format_tokent::length_modifierst::LEN_l:
+      if(token.representation==format_tokent::representationt::SIGNED_DEC)
         return signed_long_int_type();
       else
         return unsigned_long_int_type();
 
-    case format_tokent::LEN_ll:
-      if(token.representation==format_tokent::SIGNED_DEC)
+    case format_tokent::length_modifierst::LEN_ll:
+      if(token.representation==format_tokent::representationt::SIGNED_DEC)
         return signed_long_long_int_type();
       else
         return unsigned_long_long_int_type();
 
     default:
-      if(token.representation==format_tokent::SIGNED_DEC)
+      if(token.representation==format_tokent::representationt::SIGNED_DEC)
         return signed_int_type();
       else
         return unsigned_int_type();
     }
 
-  case format_tokent::FLOAT:
+  case format_tokent::token_typet::FLOAT:
     switch(token.length_modifier)
     {
-    case format_tokent::LEN_l: return double_type();
-    case format_tokent::LEN_L: return long_double_type();
+    case format_tokent::length_modifierst::LEN_l: return double_type();
+    case format_tokent::length_modifierst::LEN_L: return long_double_type();
     default: return float_type();
     }
 
-  case format_tokent::CHAR:
+  case format_tokent::token_typet::CHAR:
     switch(token.length_modifier)
     {
-    case format_tokent::LEN_l: return wchar_t_type();
+    case format_tokent::length_modifierst::LEN_l: return wchar_t_type();
     default: return char_type();
     }
 
-  case format_tokent::POINTER:
+  case format_tokent::token_typet::POINTER:
     return pointer_type(void_type());
 
-  case format_tokent::STRING:
+  case format_tokent::token_typet::STRING:
     switch(token.length_modifier)
     {
-    case format_tokent::LEN_l: return array_typet(wchar_t_type(), nil_exprt());
+    case format_tokent::length_modifierst::LEN_l:
+      return array_typet(wchar_t_type(), nil_exprt());
     default: return array_typet(char_type(), nil_exprt());
     }
 

--- a/src/goto-programs/format_strings.h
+++ b/src/goto-programs/format_strings.h
@@ -18,39 +18,57 @@ Author: CM Wintersteiger
 class format_tokent
 {
 public:
-  typedef enum { UNKNOWN,
-                 TEXT,
-                 INT, // d, i, o, u, x
-                 FLOAT, // a, e, f, g
-                 CHAR, // c
-                 STRING, // s
-                 POINTER // p
-               } token_typet;
-
-  typedef enum { ALTERNATE, ZERO_PAD, LEFT_ADJUST,
-                 SIGNED_SPACE, SIGN, ASTERISK } flag_typet;
-
-  typedef enum
+  enum class token_typet
   {
-    LEN_undef, LEN_h, LEN_hh, LEN_l, LEN_ll,
-    LEN_L, LEN_j, LEN_t
-  } length_modifierst;
+    UNKNOWN,
+    TEXT,
+    INT, // d, i, o, u, x
+    FLOAT, // a, e, f, g
+    CHAR, // c
+    STRING, // s
+    POINTER // p
+  };
 
-  typedef enum
+  enum class flag_typet
   {
-    SIGNED_undef, SIGNED_DEC, UNSIGNED_DEC,
-    UNSIGNED_OCT, UNSIGNED_HEX
-  } representationt;
+    ALTERNATE,
+    ZERO_PAD,
+    LEFT_ADJUST,
+    SIGNED_SPACE,
+    SIGN,
+    ASTERISK
+  };
+
+  enum class length_modifierst
+  {
+    LEN_undef,
+    LEN_h,
+    LEN_hh,
+    LEN_l,
+    LEN_ll,
+    LEN_L,
+    LEN_j,
+    LEN_t
+  };
+
+  enum class representationt
+  {
+    SIGNED_undef,
+    SIGNED_DEC,
+    UNSIGNED_DEC,
+    UNSIGNED_OCT,
+    UNSIGNED_HEX
+  };
 
   explicit format_tokent(token_typet _type)
     : type(_type),
-      length_modifier(LEN_undef),
-      representation(SIGNED_undef)
+      length_modifier(length_modifierst::LEN_undef),
+      representation(representationt::SIGNED_undef)
     { }
   format_tokent():
-    type(UNKNOWN),
-    length_modifier(LEN_undef),
-    representation(SIGNED_undef)
+    type(token_typet::UNKNOWN),
+    length_modifier(length_modifierst::LEN_undef),
+    representation(representationt::SIGNED_undef)
     { }
 
 

--- a/src/goto-programs/goto_program_template.h
+++ b/src/goto-programs/goto_program_template.h
@@ -23,7 +23,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/source_location.h>
 #include <util/std_expr.h>
 
-typedef enum
+enum goto_program_instruction_typet
 {
   NO_INSTRUCTION_TYPE=0,
   GOTO=1,           // branch, possibly guarded
@@ -44,7 +44,7 @@ typedef enum
   FUNCTION_CALL=16, // call a function
   THROW=17,         // throw an exception
   CATCH=18          // catch an exception
-} goto_program_instruction_typet;
+};
 
 std::ostream &operator<<(std::ostream &, goto_program_instruction_typet);
 

--- a/src/goto-programs/goto_trace.cpp
+++ b/src/goto-programs/goto_trace.cpp
@@ -59,24 +59,25 @@ void goto_trace_stept::output(
 
   switch(type)
   {
-  case goto_trace_stept::ASSERT: out << "ASSERT"; break;
-  case goto_trace_stept::ASSUME: out << "ASSUME"; break;
-  case goto_trace_stept::LOCATION: out << "LOCATION"; break;
-  case goto_trace_stept::ASSIGNMENT: out << "ASSIGNMENT"; break;
-  case goto_trace_stept::GOTO: out << "GOTO"; break;
-  case goto_trace_stept::DECL: out << "DECL"; break;
-  case goto_trace_stept::OUTPUT: out << "OUTPUT"; break;
-  case goto_trace_stept::INPUT: out << "INPUT"; break;
-  case goto_trace_stept::ATOMIC_BEGIN: out << "ATOMC_BEGIN"; break;
-  case goto_trace_stept::ATOMIC_END: out << "ATOMIC_END"; break;
-  case goto_trace_stept::SHARED_READ: out << "SHARED_READ"; break;
-  case goto_trace_stept::SHARED_WRITE: out << "SHARED WRITE"; break;
-  case goto_trace_stept::FUNCTION_CALL: out << "FUNCTION CALL"; break;
-  case goto_trace_stept::FUNCTION_RETURN: out << "FUNCTION RETURN"; break;
+  case goto_trace_stept::typet::ASSERT: out << "ASSERT"; break;
+  case goto_trace_stept::typet::ASSUME: out << "ASSUME"; break;
+  case goto_trace_stept::typet::LOCATION: out << "LOCATION"; break;
+  case goto_trace_stept::typet::ASSIGNMENT: out << "ASSIGNMENT"; break;
+  case goto_trace_stept::typet::GOTO: out << "GOTO"; break;
+  case goto_trace_stept::typet::DECL: out << "DECL"; break;
+  case goto_trace_stept::typet::OUTPUT: out << "OUTPUT"; break;
+  case goto_trace_stept::typet::INPUT: out << "INPUT"; break;
+  case goto_trace_stept::typet::ATOMIC_BEGIN: out << "ATOMC_BEGIN"; break;
+  case goto_trace_stept::typet::ATOMIC_END: out << "ATOMIC_END"; break;
+  case goto_trace_stept::typet::SHARED_READ: out << "SHARED_READ"; break;
+  case goto_trace_stept::typet::SHARED_WRITE: out << "SHARED WRITE"; break;
+  case goto_trace_stept::typet::FUNCTION_CALL: out << "FUNCTION CALL"; break;
+  case goto_trace_stept::typet::FUNCTION_RETURN:
+    out << "FUNCTION RETURN"; break;
   default: assert(false);
   }
 
-  if(type==ASSERT || type==ASSUME || type==GOTO)
+  if(type==typet::ASSERT || type==typet::ASSUME || type==typet::GOTO)
     out << " (" << cond_value << ")";
 
   if(hidden)
@@ -332,7 +333,7 @@ void show_goto_trace(
 
     switch(step.type)
     {
-    case goto_trace_stept::ASSERT:
+    case goto_trace_stept::typet::ASSERT:
       if(!step.cond_value)
       {
         out << "\n";
@@ -348,7 +349,7 @@ void show_goto_trace(
       }
       break;
 
-    case goto_trace_stept::ASSUME:
+    case goto_trace_stept::typet::ASSUME:
       if(!step.cond_value)
       {
         out << "\n";
@@ -363,13 +364,13 @@ void show_goto_trace(
       }
       break;
 
-    case goto_trace_stept::LOCATION:
+    case goto_trace_stept::typet::LOCATION:
       break;
 
-    case goto_trace_stept::GOTO:
+    case goto_trace_stept::typet::GOTO:
       break;
 
-    case goto_trace_stept::ASSIGNMENT:
+    case goto_trace_stept::typet::ASSIGNMENT:
       if(step.pc->is_assign() ||
          step.pc->is_return() || // returns have a lhs!
          step.pc->is_function_call() ||
@@ -392,7 +393,7 @@ void show_goto_trace(
       }
       break;
 
-    case goto_trace_stept::DECL:
+    case goto_trace_stept::typet::DECL:
       if(prev_step_nr!=step.step_nr || first_step)
       {
         first_step=false;
@@ -403,7 +404,7 @@ void show_goto_trace(
       trace_value(out, ns, step.lhs_object, step.full_lhs, step.full_lhs_value);
       break;
 
-    case goto_trace_stept::OUTPUT:
+    case goto_trace_stept::typet::OUTPUT:
       if(step.formatted)
       {
         printf_formattert printf_formatter(ns);
@@ -433,7 +434,7 @@ void show_goto_trace(
       }
       break;
 
-    case goto_trace_stept::INPUT:
+    case goto_trace_stept::typet::INPUT:
       show_state_header(out, step, step.pc->source_location, step.step_nr);
       out << "  INPUT " << step.io_id << ":";
 
@@ -453,21 +454,21 @@ void show_goto_trace(
       out << "\n";
       break;
 
-    case goto_trace_stept::FUNCTION_CALL:
-    case goto_trace_stept::FUNCTION_RETURN:
-    case goto_trace_stept::SPAWN:
-    case goto_trace_stept::MEMORY_BARRIER:
-    case goto_trace_stept::ATOMIC_BEGIN:
-    case goto_trace_stept::ATOMIC_END:
-    case goto_trace_stept::DEAD:
+    case goto_trace_stept::typet::FUNCTION_CALL:
+    case goto_trace_stept::typet::FUNCTION_RETURN:
+    case goto_trace_stept::typet::SPAWN:
+    case goto_trace_stept::typet::MEMORY_BARRIER:
+    case goto_trace_stept::typet::ATOMIC_BEGIN:
+    case goto_trace_stept::typet::ATOMIC_END:
+    case goto_trace_stept::typet::DEAD:
       break;
 
-    case goto_trace_stept::CONSTRAINT:
+    case goto_trace_stept::typet::CONSTRAINT:
       assert(false);
       break;
 
-    case goto_trace_stept::SHARED_READ:
-    case goto_trace_stept::SHARED_WRITE:
+    case goto_trace_stept::typet::SHARED_READ:
+    case goto_trace_stept::typet::SHARED_WRITE:
       assert(false);
       break;
 

--- a/src/goto-programs/goto_trace.h
+++ b/src/goto-programs/goto_trace.h
@@ -33,38 +33,55 @@ class goto_trace_stept
 public:
   unsigned step_nr;
 
-  bool is_assignment() const      { return type==ASSIGNMENT; }
-  bool is_assume() const          { return type==ASSUME; }
-  bool is_assert() const          { return type==ASSERT; }
-  bool is_goto() const            { return type==GOTO; }
-  bool is_constraint() const      { return type==CONSTRAINT; }
-  bool is_function_call() const   { return type==FUNCTION_CALL; }
-  bool is_function_return() const { return type==FUNCTION_RETURN; }
-  bool is_location() const        { return type==LOCATION; }
-  bool is_output() const          { return type==OUTPUT; }
-  bool is_input() const           { return type==INPUT; }
-  bool is_decl() const            { return type==DECL; }
-  bool is_dead() const            { return type==DEAD; }
-  bool is_shared_read() const     { return type==SHARED_READ; }
-  bool is_shared_write() const    { return type==SHARED_WRITE; }
-  bool is_spawn() const           { return type==SPAWN; }
-  bool is_memory_barrier() const  { return type==MEMORY_BARRIER; }
-  bool is_atomic_begin() const    { return type==ATOMIC_BEGIN; }
-  bool is_atomic_end() const      { return type==ATOMIC_END; }
+  bool is_assignment() const      { return type==typet::ASSIGNMENT; }
+  bool is_assume() const          { return type==typet::ASSUME; }
+  bool is_assert() const          { return type==typet::ASSERT; }
+  bool is_goto() const            { return type==typet::GOTO; }
+  bool is_constraint() const      { return type==typet::CONSTRAINT; }
+  bool is_function_call() const   { return type==typet::FUNCTION_CALL; }
+  bool is_function_return() const { return type==typet::FUNCTION_RETURN; }
+  bool is_location() const        { return type==typet::LOCATION; }
+  bool is_output() const          { return type==typet::OUTPUT; }
+  bool is_input() const           { return type==typet::INPUT; }
+  bool is_decl() const            { return type==typet::DECL; }
+  bool is_dead() const            { return type==typet::DEAD; }
+  bool is_shared_read() const     { return type==typet::SHARED_READ; }
+  bool is_shared_write() const    { return type==typet::SHARED_WRITE; }
+  bool is_spawn() const           { return type==typet::SPAWN; }
+  bool is_memory_barrier() const  { return type==typet::MEMORY_BARRIER; }
+  bool is_atomic_begin() const    { return type==typet::ATOMIC_BEGIN; }
+  bool is_atomic_end() const      { return type==typet::ATOMIC_END; }
 
-  typedef enum { NONE, ASSIGNMENT, ASSUME, ASSERT, GOTO,
-                 LOCATION, INPUT, OUTPUT, DECL, DEAD,
-                 FUNCTION_CALL, FUNCTION_RETURN,
-                 CONSTRAINT,
-                 SHARED_READ, SHARED_WRITE,
-                 SPAWN, MEMORY_BARRIER, ATOMIC_BEGIN, ATOMIC_END } typet;
+  enum class typet
+  {
+    NONE,
+    ASSIGNMENT,
+    ASSUME,
+    ASSERT,
+    GOTO,
+    LOCATION,
+    INPUT,
+    OUTPUT,
+    DECL,
+    DEAD,
+    FUNCTION_CALL,
+    FUNCTION_RETURN,
+    CONSTRAINT,
+    SHARED_READ,
+    SHARED_WRITE,
+    SPAWN,
+    MEMORY_BARRIER,
+    ATOMIC_BEGIN,
+    ATOMIC_END
+  };
+
   typet type;
 
   // we may choose to hide a step
   bool hidden;
 
   // we categorize
-  typedef enum { STATE, ACTUAL_PARAMETER } assignment_typet;
+  enum class assignment_typet { STATE, ACTUAL_PARAMETER };
   assignment_typet assignment_type;
 
   goto_programt::const_targett pc;
@@ -105,9 +122,9 @@ public:
 
   goto_trace_stept():
     step_nr(0),
-    type(NONE),
+    type(typet::NONE),
     hidden(false),
-    assignment_type(STATE),
+    assignment_type(assignment_typet::STATE),
     thread_nr(0),
     cond_value(false),
     formatted(false)

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -245,7 +245,7 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
     goto_tracet::stepst::const_iterator next=it;
     ++next;
     if(next!=goto_trace.steps.end() &&
-       next->type==goto_trace_stept::ASSIGNMENT &&
+       next->type==goto_trace_stept::typet::ASSIGNMENT &&
        it->full_lhs==next->full_lhs &&
        it->pc->source_location==next->pc->source_location)
     {
@@ -265,7 +265,7 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
     graphml[node].line=source_location.get_line();
     graphml[node].thread_nr=it->thread_nr;
     graphml[node].is_violation=
-      it->type==goto_trace_stept::ASSERT && !it->cond_value;
+      it->type==goto_trace_stept::typet::ASSERT && !it->cond_value;
     graphml[node].has_invariant=false;
 
     step_to_node[it->step_nr]=node;
@@ -299,9 +299,9 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
 
     switch(it->type)
     {
-    case goto_trace_stept::ASSIGNMENT:
-    case goto_trace_stept::ASSERT:
-    case goto_trace_stept::GOTO:
+    case goto_trace_stept::typet::ASSIGNMENT:
+    case goto_trace_stept::typet::ASSERT:
+    case goto_trace_stept::typet::GOTO:
       {
         xmlt edge("edge");
         edge.set_attribute("source", graphml[from].node_name);
@@ -317,7 +317,7 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
           data_l.data=id2string(graphml[from].line);
         }
 
-        if(it->type==goto_trace_stept::ASSIGNMENT &&
+        if(it->type==goto_trace_stept::typet::ASSIGNMENT &&
            it->lhs_object_value.is_not_nil() &&
            it->full_lhs.is_not_nil())
         {
@@ -337,7 +337,7 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
             val_s.data=id2string(it->pc->source_location.get_function());
           }
         }
-        else if(it->type==goto_trace_stept::GOTO &&
+        else if(it->type==goto_trace_stept::typet::GOTO &&
                 it->pc->is_goto())
         {
           xmlt &val=edge.new_element("data");
@@ -374,22 +374,22 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
       }
       break;
 
-    case goto_trace_stept::DECL:
-    case goto_trace_stept::FUNCTION_CALL:
-    case goto_trace_stept::FUNCTION_RETURN:
-    case goto_trace_stept::LOCATION:
-    case goto_trace_stept::ASSUME:
-    case goto_trace_stept::INPUT:
-    case goto_trace_stept::OUTPUT:
-    case goto_trace_stept::SHARED_READ:
-    case goto_trace_stept::SHARED_WRITE:
-    case goto_trace_stept::SPAWN:
-    case goto_trace_stept::MEMORY_BARRIER:
-    case goto_trace_stept::ATOMIC_BEGIN:
-    case goto_trace_stept::ATOMIC_END:
-    case goto_trace_stept::DEAD:
-    case goto_trace_stept::CONSTRAINT:
-    case goto_trace_stept::NONE:
+    case goto_trace_stept::typet::DECL:
+    case goto_trace_stept::typet::FUNCTION_CALL:
+    case goto_trace_stept::typet::FUNCTION_RETURN:
+    case goto_trace_stept::typet::LOCATION:
+    case goto_trace_stept::typet::ASSUME:
+    case goto_trace_stept::typet::INPUT:
+    case goto_trace_stept::typet::OUTPUT:
+    case goto_trace_stept::typet::SHARED_READ:
+    case goto_trace_stept::typet::SHARED_WRITE:
+    case goto_trace_stept::typet::SPAWN:
+    case goto_trace_stept::typet::MEMORY_BARRIER:
+    case goto_trace_stept::typet::ATOMIC_BEGIN:
+    case goto_trace_stept::typet::ATOMIC_END:
+    case goto_trace_stept::typet::DEAD:
+    case goto_trace_stept::typet::CONSTRAINT:
+    case goto_trace_stept::typet::NONE:
       // ignore
       break;
     }
@@ -500,9 +500,9 @@ void graphml_witnesst::operator()(const symex_target_equationt &equation)
 
     switch(it->type)
     {
-    case goto_trace_stept::ASSIGNMENT:
-    case goto_trace_stept::ASSERT:
-    case goto_trace_stept::GOTO:
+    case goto_trace_stept::typet::ASSIGNMENT:
+    case goto_trace_stept::typet::ASSERT:
+    case goto_trace_stept::typet::GOTO:
       {
         xmlt edge("edge");
         edge.set_attribute("source", graphml[from].node_name);
@@ -546,22 +546,22 @@ void graphml_witnesst::operator()(const symex_target_equationt &equation)
       }
       break;
 
-    case goto_trace_stept::DECL:
-    case goto_trace_stept::FUNCTION_CALL:
-    case goto_trace_stept::FUNCTION_RETURN:
-    case goto_trace_stept::LOCATION:
-    case goto_trace_stept::ASSUME:
-    case goto_trace_stept::INPUT:
-    case goto_trace_stept::OUTPUT:
-    case goto_trace_stept::SHARED_READ:
-    case goto_trace_stept::SHARED_WRITE:
-    case goto_trace_stept::SPAWN:
-    case goto_trace_stept::MEMORY_BARRIER:
-    case goto_trace_stept::ATOMIC_BEGIN:
-    case goto_trace_stept::ATOMIC_END:
-    case goto_trace_stept::DEAD:
-    case goto_trace_stept::CONSTRAINT:
-    case goto_trace_stept::NONE:
+    case goto_trace_stept::typet::DECL:
+    case goto_trace_stept::typet::FUNCTION_CALL:
+    case goto_trace_stept::typet::FUNCTION_RETURN:
+    case goto_trace_stept::typet::LOCATION:
+    case goto_trace_stept::typet::ASSUME:
+    case goto_trace_stept::typet::INPUT:
+    case goto_trace_stept::typet::OUTPUT:
+    case goto_trace_stept::typet::SHARED_READ:
+    case goto_trace_stept::typet::SHARED_WRITE:
+    case goto_trace_stept::typet::SPAWN:
+    case goto_trace_stept::typet::MEMORY_BARRIER:
+    case goto_trace_stept::typet::ATOMIC_BEGIN:
+    case goto_trace_stept::typet::ATOMIC_END:
+    case goto_trace_stept::typet::DEAD:
+    case goto_trace_stept::typet::CONSTRAINT:
+    case goto_trace_stept::typet::NONE:
       // ignore
       break;
     }

--- a/src/goto-programs/json_goto_trace.cpp
+++ b/src/goto-programs/json_goto_trace.cpp
@@ -50,7 +50,7 @@ void convert(
 
     switch(step.type)
     {
-    case goto_trace_stept::ASSERT:
+    case goto_trace_stept::typet::ASSERT:
       if(!step.cond_value)
       {
         irep_idt property_id;
@@ -77,8 +77,8 @@ void convert(
       }
       break;
 
-    case goto_trace_stept::ASSIGNMENT:
-    case goto_trace_stept::DECL:
+    case goto_trace_stept::typet::ASSIGNMENT:
+    case goto_trace_stept::typet::DECL:
       {
         irep_idt identifier=step.lhs_object.get_identifier();
         json_objectt &json_assignment=dest_array.push_back().make_object();
@@ -121,12 +121,15 @@ void convert(
         json_assignment["thread"]=json_numbert(std::to_string(step.thread_nr));
 
         json_assignment["assignmentType"]=
-          json_stringt(step.assignment_type==goto_trace_stept::ACTUAL_PARAMETER?
-                       "actual-parameter":"variable");
+          json_stringt(
+            step.assignment_type==
+              goto_trace_stept::assignment_typet::ACTUAL_PARAMETER?
+            "actual-parameter":
+            "variable");
       }
       break;
 
-    case goto_trace_stept::OUTPUT:
+    case goto_trace_stept::typet::OUTPUT:
       {
         json_objectt &json_output=dest_array.push_back().make_object();
 
@@ -150,7 +153,7 @@ void convert(
       }
       break;
 
-    case goto_trace_stept::INPUT:
+    case goto_trace_stept::typet::INPUT:
       {
         json_objectt &json_input=dest_array.push_back().make_object();
 
@@ -174,11 +177,11 @@ void convert(
       }
       break;
 
-    case goto_trace_stept::FUNCTION_CALL:
-    case goto_trace_stept::FUNCTION_RETURN:
+    case goto_trace_stept::typet::FUNCTION_CALL:
+    case goto_trace_stept::typet::FUNCTION_RETURN:
       {
         std::string tag=
-          (step.type==goto_trace_stept::FUNCTION_CALL)?
+          (step.type==goto_trace_stept::typet::FUNCTION_CALL)?
             "function-call":"function-return";
         json_objectt &json_call_return=dest_array.push_back().make_object();
 

--- a/src/goto-programs/loop_ids.cpp
+++ b/src/goto-programs/loop_ids.cpp
@@ -52,7 +52,7 @@ void show_loop_ids(
 {
   switch(ui)
   {
-    case ui_message_handlert::PLAIN:
+    case ui_message_handlert::uit::PLAIN:
     {
       forall_goto_program_instructions(it, goto_program)
       {
@@ -69,7 +69,7 @@ void show_loop_ids(
       }
       break;
     }
-    case ui_message_handlert::XML_UI:
+    case ui_message_handlert::uit::XML_UI:
     {
       forall_goto_program_instructions(it, goto_program)
       {
@@ -87,7 +87,7 @@ void show_loop_ids(
       }
       break;
     }
-    case ui_message_handlert::JSON_UI:
+    case ui_message_handlert::uit::JSON_UI:
       assert(false); // use function below
   }
 }
@@ -97,7 +97,7 @@ void show_loop_ids_json(
   const goto_programt &goto_program,
   json_arrayt &loops)
 {
-  assert(ui==ui_message_handlert::JSON_UI); // use function above
+  assert(ui==ui_message_handlert::uit::JSON_UI); // use function above
 
   forall_goto_program_instructions(it, goto_program)
   {
@@ -131,12 +131,12 @@ void show_loop_ids(
 {
   switch(ui)
   {
-    case ui_message_handlert::PLAIN:
-    case ui_message_handlert::XML_UI:
+    case ui_message_handlert::uit::PLAIN:
+    case ui_message_handlert::uit::XML_UI:
       forall_goto_functions(it, goto_functions)
         show_loop_ids(ui, it->second.body);
       break;
-    case ui_message_handlert::JSON_UI:
+    case ui_message_handlert::uit::JSON_UI:
       json_objectt json_result;
       json_arrayt &loops=json_result["loops"].make_array();
 

--- a/src/goto-programs/property_checker.cpp
+++ b/src/goto-programs/property_checker.cpp
@@ -24,10 +24,10 @@ std::string property_checkert::as_string(resultt result)
 {
   switch(result)
   {
-  case property_checkert::PASS: return "OK";
-  case property_checkert::FAIL: return "FAILURE";
-  case property_checkert::ERROR: return "ERROR";
-  case property_checkert::UNKNOWN: return "UNKNOWN";
+  case property_checkert::resultt::PASS: return "OK";
+  case property_checkert::resultt::FAIL: return "FAILURE";
+  case property_checkert::resultt::ERROR: return "ERROR";
+  case property_checkert::resultt::UNKNOWN: return "UNKNOWN";
   }
 
   return "";
@@ -82,7 +82,7 @@ void property_checkert::initialize_property_map(
         irep_idt property_id=source_location.get_property_id();
 
         property_statust &property_status=property_map[property_id];
-        property_status.result=UNKNOWN;
+        property_status.result=resultt::UNKNOWN;
         property_status.location=i_it;
       }
     }

--- a/src/goto-programs/property_checker.h
+++ b/src/goto-programs/property_checker.h
@@ -26,7 +26,7 @@ public:
   explicit property_checkert(
     message_handlert &_message_handler);
 
-  typedef enum { PASS, FAIL, ERROR, UNKNOWN } resultt;
+  enum class resultt { PASS, FAIL, ERROR, UNKNOWN };
 
   static std::string as_string(resultt);
 

--- a/src/goto-programs/safety_checker.h
+++ b/src/goto-programs/safety_checker.h
@@ -26,7 +26,7 @@ public:
     const namespacet &_ns,
     message_handlert &_message_handler);
 
-  typedef enum { SAFE, UNSAFE, ERROR } resultt;
+  enum class resultt { SAFE, UNSAFE, ERROR };
 
   // check whether all assertions in goto_functions are safe
   // if UNSAFE, then a trace is returned

--- a/src/goto-programs/show_goto_functions.cpp
+++ b/src/goto-programs/show_goto_functions.cpp
@@ -42,21 +42,21 @@ void show_goto_functions(
 {
   switch(ui)
   {
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
   {
     show_goto_functions_xmlt xml_show_functions(ns);
     xml_show_functions(goto_functions, std::cout);
   }
   break;
 
-  case ui_message_handlert::JSON_UI:
+  case ui_message_handlert::uit::JSON_UI:
   {
     show_goto_functions_jsont json_show_functions(ns);
     json_show_functions(goto_functions, std::cout);
   }
   break;
 
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     goto_functions.output(ns, std::cout);
     break;
   }

--- a/src/goto-programs/show_properties.cpp
+++ b/src/goto-programs/show_properties.cpp
@@ -53,7 +53,7 @@ void show_properties(
 
     switch(ui)
     {
-    case ui_message_handlert::XML_UI:
+    case ui_message_handlert::uit::XML_UI:
       {
         // use me instead
         xmlt xml_property("property");
@@ -71,11 +71,11 @@ void show_properties(
       }
       break;
 
-    case ui_message_handlert::JSON_UI:
+    case ui_message_handlert::uit::JSON_UI:
       assert(false);
       break;
 
-    case ui_message_handlert::PLAIN:
+    case ui_message_handlert::uit::PLAIN:
       std::cout << "Property " << property_id << ":" << std::endl;
 
       std::cout << "  " << ins.source_location << std::endl
@@ -185,7 +185,7 @@ void show_properties(
   ui_message_handlert::uit ui,
   const goto_functionst &goto_functions)
 {
-  if(ui == ui_message_handlert::JSON_UI)
+  if(ui == ui_message_handlert::uit::JSON_UI)
     show_properties_json(ns, goto_functions);
   else
     for(const auto &fct : goto_functions.function_map)
@@ -210,7 +210,7 @@ void show_properties(
   ui_message_handlert::uit ui)
 {
   const namespacet ns(goto_model.symbol_table);
-  if(ui == ui_message_handlert::JSON_UI)
+  if(ui == ui_message_handlert::uit::JSON_UI)
     show_properties_json(ns, goto_model.goto_functions);
   else
     show_properties(ns, ui, goto_model.goto_functions);

--- a/src/goto-programs/show_symbol_table.cpp
+++ b/src/goto-programs/show_symbol_table.cpp
@@ -148,11 +148,11 @@ void show_symbol_table(
 {
   switch(ui)
   {
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     show_symbol_table_plain(goto_model, std::cout);
     break;
 
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
     show_symbol_table_xml_ui();
     break;
 

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -153,15 +153,15 @@ string_abstractiont::string_abstractiont(
 
   s.components()[0].set_name("is_zero");
   s.components()[0].set_pretty_name("is_zero");
-  s.components()[0].type()=build_type(IS_ZERO);
+  s.components()[0].type()=build_type(whatt::IS_ZERO);
 
   s.components()[1].set_name("length");
   s.components()[1].set_pretty_name("length");
-  s.components()[1].type()=build_type(LENGTH);
+  s.components()[1].type()=build_type(whatt::LENGTH);
 
   s.components()[2].set_name("size");
   s.components()[2].set_pretty_name("size");
-  s.components()[2].type()=build_type(SIZE);
+  s.components()[2].type()=build_type(whatt::SIZE);
 
   string_struct=s;
 }
@@ -184,9 +184,9 @@ typet string_abstractiont::build_type(whatt what)
 
   switch(what)
   {
-  case IS_ZERO: type=bool_typet(); break;
-  case LENGTH:  type=size_type(); break;
-  case SIZE:    type=size_type(); break;
+  case whatt::IS_ZERO: type=bool_typet(); break;
+  case whatt::LENGTH:  type=size_type(); break;
+  case whatt::SIZE:    type=size_type(); break;
   }
 
   return type;
@@ -598,11 +598,11 @@ symbol_exprt string_abstractiont::add_dummy_symbol_and_value(
   {
     new_symbol.value=struct_exprt(string_struct);
     new_symbol.value.operands().resize(3);
-    new_symbol.value.op0()=build_unknown(IS_ZERO, false);
-    new_symbol.value.op1()=build_unknown(LENGTH, false);
+    new_symbol.value.op0()=build_unknown(whatt::IS_ZERO, false);
+    new_symbol.value.op1()=build_unknown(whatt::LENGTH, false);
     new_symbol.value.op2()=to_array_type(source_type).size().id()==ID_infinity?
-      build_unknown(SIZE, false):to_array_type(source_type).size();
-    make_type(new_symbol.value.op2(), build_type(SIZE));
+      build_unknown(whatt::SIZE, false):to_array_type(source_type).size();
+    make_type(new_symbol.value.op2(), build_type(whatt::SIZE));
   }
   else
     new_symbol.value=
@@ -832,19 +832,19 @@ void string_abstractiont::replace_string_macros(
   if(expr.id()=="is_zero_string")
   {
     assert(expr.operands().size()==1);
-    exprt tmp=build(expr.op0(), IS_ZERO, lhs, source_location);
+    exprt tmp=build(expr.op0(), whatt::IS_ZERO, lhs, source_location);
     expr.swap(tmp);
   }
   else if(expr.id()=="zero_string_length")
   {
     assert(expr.operands().size()==1);
-    exprt tmp=build(expr.op0(), LENGTH, lhs, source_location);
+    exprt tmp=build(expr.op0(), whatt::LENGTH, lhs, source_location);
     expr.swap(tmp);
   }
   else if(expr.id()=="buffer_size")
   {
     assert(expr.operands().size()==1);
-    exprt tmp=build(expr.op0(), SIZE, false, source_location);
+    exprt tmp=build(expr.op0(), whatt::SIZE, false, source_location);
     expr.swap(tmp);
   }
   else
@@ -888,7 +888,7 @@ exprt string_abstractiont::build(
 
   exprt result=member(str_struct, what);
 
-  if(what==LENGTH || what==SIZE)
+  if(what==whatt::LENGTH || what==whatt::SIZE)
   {
     // adjust for offset
     exprt pointer_offset(ID_pointer_offset, size_type());
@@ -1227,12 +1227,12 @@ exprt string_abstractiont::build_unknown(whatt what, bool write)
 
   switch(what)
   {
-  case IS_ZERO:
+  case whatt::IS_ZERO:
     result=false_exprt();
     break;
 
-  case LENGTH:
-  case SIZE:
+  case whatt::LENGTH:
+  case whatt::SIZE:
     result=side_effect_expr_nondett(type);
     break;
   }
@@ -1401,8 +1401,8 @@ bool string_abstractiont::build_symbol_constant(
       value.operands().resize(3);
 
       value.op0()=true_exprt();
-      value.op1()=from_integer(zero_length, build_type(LENGTH));
-      value.op2()=from_integer(buf_size, build_type(SIZE));
+      value.op1()=from_integer(zero_length, build_type(whatt::LENGTH));
+      value.op2()=from_integer(buf_size, build_type(whatt::SIZE));
 
       // initialization
       goto_programt::targett assignment1=initialization.add_instruction();
@@ -1535,7 +1535,7 @@ goto_programt::targett string_abstractiont::abstract_char_assign(
     exprt new_lhs;
     if(!build_wrap(i_lhs.array(), new_lhs, true))
     {
-      exprt i2=member(new_lhs, LENGTH);
+      exprt i2=member(new_lhs, whatt::LENGTH);
       assert(i2.is_not_nil());
 
       exprt new_length=i_lhs.index();
@@ -1553,10 +1553,10 @@ goto_programt::targett string_abstractiont::abstract_char_assign(
     exprt new_lhs;
     if(!build_wrap(ptr.pointer, new_lhs, true))
     {
-      const exprt i2=member(new_lhs, LENGTH);
+      const exprt i2=member(new_lhs, whatt::LENGTH);
       assert(i2.is_not_nil());
 
-      make_type(ptr.offset, build_type(LENGTH));
+      make_type(ptr.offset, build_type(whatt::LENGTH));
       return
         char_assign(
           dest,
@@ -1564,7 +1564,7 @@ goto_programt::targett string_abstractiont::abstract_char_assign(
           new_lhs,
           i2,
           ptr.offset.is_nil()?
-            from_integer(0, build_type(LENGTH)):
+            from_integer(0, build_type(whatt::LENGTH)):
             ptr.offset);
     }
   }
@@ -1593,7 +1593,7 @@ goto_programt::targett string_abstractiont::char_assign(
 {
   goto_programt tmp;
 
-  const exprt i1=member(new_lhs, IS_ZERO);
+  const exprt i1=member(new_lhs, whatt::IS_ZERO);
   assert(i1.is_not_nil());
 
   goto_programt::targett assignment1=tmp.add_instruction();
@@ -1753,8 +1753,8 @@ goto_programt::targett string_abstractiont::value_assignments_string_struct(
   {
     goto_programt::targett assignment=tmp.add_instruction(ASSIGN);
     assignment->code=code_assignt(
-        member(lhs, IS_ZERO),
-        member(rhs, IS_ZERO));
+        member(lhs, whatt::IS_ZERO),
+        member(rhs, whatt::IS_ZERO));
     assignment->code.add_source_location()=target->source_location;
     assignment->function=target->function;
     assignment->source_location=target->source_location;
@@ -1763,8 +1763,8 @@ goto_programt::targett string_abstractiont::value_assignments_string_struct(
   {
     goto_programt::targett assignment=tmp.add_instruction(ASSIGN);
     assignment->code=code_assignt(
-        member(lhs, LENGTH),
-        member(rhs, LENGTH));
+        member(lhs, whatt::LENGTH),
+        member(rhs, whatt::LENGTH));
     assignment->code.add_source_location()=target->source_location;
     assignment->function=target->function;
     assignment->source_location=target->source_location;
@@ -1773,8 +1773,8 @@ goto_programt::targett string_abstractiont::value_assignments_string_struct(
   {
     goto_programt::targett assignment=tmp.add_instruction(ASSIGN);
     assignment->code=code_assignt(
-        member(lhs, SIZE),
-        member(rhs, SIZE));
+        member(lhs, whatt::SIZE),
+        member(rhs, whatt::SIZE));
     assignment->code.add_source_location()=target->source_location;
     assignment->function=target->function;
     assignment->source_location=target->source_location;
@@ -1813,9 +1813,9 @@ exprt string_abstractiont::member(const exprt &a, whatt what)
 
   switch(what)
   {
-  case IS_ZERO: result.set_component_name("is_zero"); break;
-  case SIZE: result.set_component_name("size"); break;
-  case LENGTH: result.set_component_name("length"); break;
+  case whatt::IS_ZERO: result.set_component_name("is_zero"); break;
+  case whatt::SIZE: result.set_component_name("size"); break;
+  case whatt::LENGTH: result.set_component_name("length"); break;
   }
 
   return result;

--- a/src/goto-programs/string_abstraction.h
+++ b/src/goto-programs/string_abstraction.h
@@ -108,7 +108,7 @@ protected:
     goto_programt::targett target,
     const exprt &lhs, const exprt &rhs);
 
-  typedef enum { IS_ZERO, LENGTH, SIZE } whatt;
+  enum class whatt { IS_ZERO, LENGTH, SIZE };
 
   static typet build_type(whatt what);
   exprt build(

--- a/src/goto-programs/string_instrumentation.cpp
+++ b/src/goto-programs/string_instrumentation.cpp
@@ -562,7 +562,7 @@ void string_instrumentationt::do_format_string_read(
 
     for(const auto &token : token_list)
     {
-      if(token.type==format_tokent::STRING)
+      if(token.type==format_tokent::token_typet::STRING)
       {
         const exprt &arg=arguments[argument_start_inx+args];
         const typet &arg_type=ns.follow(arg.type());
@@ -591,10 +591,13 @@ void string_instrumentationt::do_format_string_read(
         }
       }
 
-      if(token.type!=format_tokent::TEXT &&
-         token.type!=format_tokent::UNKNOWN) args++;
+      if(token.type!=format_tokent::token_typet::TEXT &&
+         token.type!=format_tokent::token_typet::UNKNOWN) args++;
 
-      if(find(token.flags.begin(), token.flags.end(), format_tokent::ASTERISK)!=
+      if(find(
+           token.flags.begin(),
+           token.flags.end(),
+           format_tokent::flag_typet::ASTERISK)!=
          token.flags.end())
         args++; // just eat the additional argument
     }
@@ -674,13 +677,16 @@ void string_instrumentationt::do_format_string_write(
 
     for(const auto &token : token_list)
     {
-      if(find(token.flags.begin(), token.flags.end(), format_tokent::ASTERISK)!=
+      if(find(
+           token.flags.begin(),
+           token.flags.end(),
+           format_tokent::flag_typet::ASTERISK)!=
          token.flags.end())
         continue; // asterisk means `ignore this'
 
       switch(token.type)
       {
-        case format_tokent::STRING:
+        case format_tokent::token_typet::STRING:
         {
           const exprt &argument=arguments[argument_start_inx+args];
           const typet &arg_type=ns.follow(argument.type());
@@ -729,8 +735,8 @@ void string_instrumentationt::do_format_string_write(
           args++;
           break;
         }
-        case format_tokent::TEXT:
-        case format_tokent::UNKNOWN:
+        case format_tokent::token_typet::TEXT:
+        case format_tokent::token_typet::UNKNOWN:
         {
           // nothing
           break;

--- a/src/goto-programs/vcd_goto_trace.cpp
+++ b/src/goto-programs/vcd_goto_trace.cpp
@@ -149,7 +149,7 @@ void output_vcd(
   {
     switch(step.type)
     {
-    case goto_trace_stept::ASSIGNMENT:
+    case goto_trace_stept::typet::ASSIGNMENT:
       {
         irep_idt identifier=step.lhs_object.get_identifier();
         const typet &type=step.lhs_object.type();

--- a/src/goto-programs/wp.cpp
+++ b/src/goto-programs/wp.cpp
@@ -101,7 +101,7 @@ Function: aliasing
 
 \*******************************************************************/
 
-typedef enum { A_MAY, A_MUST, A_MUSTNOT } aliasingt;
+enum class aliasingt { A_MAY, A_MUST, A_MUSTNOT };
 
 aliasingt aliasing(
   const exprt &e1, const exprt &e2,
@@ -122,20 +122,20 @@ aliasingt aliasing(
 
   // fairly radical. Ignores struct prefixes and the like.
   if(!base_type_eq(e1.type(), e2.type(), ns))
-    return A_MUSTNOT;
+    return aliasingt::A_MUSTNOT;
 
   // syntactically the same?
   if(e1==e2)
-    return A_MUST;
+    return aliasingt::A_MUST;
 
   // the trivial case first
   if(e1.id()==ID_symbol && e2.id()==ID_symbol)
   {
     if(to_symbol_expr(e1).get_identifier()==
        to_symbol_expr(e2).get_identifier())
-      return A_MUST;
+      return aliasingt::A_MUST;
     else
-      return A_MUSTNOT;
+      return aliasingt::A_MUSTNOT;
   }
 
   // an array or struct will never alias with a variable,
@@ -143,16 +143,16 @@ aliasingt aliasing(
 
   if(e1.id()==ID_index || e1.id()==ID_struct)
     if(e2.id()!=ID_dereference && e1.id()!=e2.id())
-      return A_MUSTNOT;
+      return aliasingt::A_MUSTNOT;
 
   if(e2.id()==ID_index || e2.id()==ID_struct)
     if(e2.id()!=ID_dereference && e1.id()!=e2.id())
-      return A_MUSTNOT;
+      return aliasingt::A_MUSTNOT;
 
   // we give up, and say it may
   // (could do much more here)
 
-  return A_MAY;
+  return aliasingt::A_MAY;
 }
 
 /*******************************************************************\
@@ -187,11 +187,11 @@ void substitute_rec(
     // could these be possible the same?
     switch(aliasing(dest, what, ns))
     {
-    case A_MUST:
+    case aliasingt::A_MUST:
       dest=by; // they are always the same
       break;
 
-    case A_MAY:
+    case aliasingt::A_MAY:
       {
         // consider possible aliasing between 'what' and 'dest'
         exprt what_address=address_of_exprt(what);
@@ -210,7 +210,7 @@ void substitute_rec(
         return;
       }
 
-    case A_MUSTNOT:
+    case aliasingt::A_MUSTNOT:
       // nothing to do
       break;
     }

--- a/src/goto-programs/xml_goto_trace.cpp
+++ b/src/goto-programs/xml_goto_trace.cpp
@@ -49,7 +49,7 @@ void convert(
 
     switch(step.type)
     {
-    case goto_trace_stept::ASSERT:
+    case goto_trace_stept::typet::ASSERT:
       if(!step.cond_value)
       {
         irep_idt property_id;
@@ -76,8 +76,8 @@ void convert(
       }
       break;
 
-    case goto_trace_stept::ASSIGNMENT:
-    case goto_trace_stept::DECL:
+    case goto_trace_stept::typet::ASSIGNMENT:
+    case goto_trace_stept::typet::DECL:
       {
         irep_idt identifier=step.lhs_object.get_identifier();
         xmlt &xml_assignment=dest.new_element("assignment");
@@ -128,7 +128,8 @@ void convert(
         xml_assignment.set_attribute("step_nr", std::to_string(step.step_nr));
 
         xml_assignment.set_attribute("assignment_type",
-          step.assignment_type==goto_trace_stept::ACTUAL_PARAMETER?
+          step.assignment_type==
+            goto_trace_stept::assignment_typet::ACTUAL_PARAMETER?
           "actual_parameter":"state");
 
         if(step.lhs_object_value.is_not_nil())
@@ -137,7 +138,7 @@ void convert(
       }
       break;
 
-    case goto_trace_stept::OUTPUT:
+    case goto_trace_stept::typet::OUTPUT:
       {
         printf_formattert printf_formatter(ns);
         printf_formatter(id2string(step.format_string), step.io_args);
@@ -162,7 +163,7 @@ void convert(
       }
       break;
 
-    case goto_trace_stept::INPUT:
+    case goto_trace_stept::typet::INPUT:
       {
         xmlt &xml_input=dest.new_element("input");
         xml_input.new_element("input_id").data=id2string(step.io_id);
@@ -183,11 +184,11 @@ void convert(
       }
       break;
 
-    case goto_trace_stept::FUNCTION_CALL:
-    case goto_trace_stept::FUNCTION_RETURN:
+    case goto_trace_stept::typet::FUNCTION_CALL:
+    case goto_trace_stept::typet::FUNCTION_RETURN:
       {
         std::string tag=
-          (step.type==goto_trace_stept::FUNCTION_CALL)?
+          (step.type==goto_trace_stept::typet::FUNCTION_CALL)?
           "function_call":"function_return";
         xmlt &xml_call_return=dest.new_element(tag);
 

--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -220,8 +220,10 @@ void build_goto_trace(
 
     // drop PHI and GUARD assignments altogether
     if(it->is_assignment() &&
-       (SSA_step.assignment_type==symex_target_equationt::PHI ||
-        SSA_step.assignment_type==symex_target_equationt::GUARD))
+       (SSA_step.assignment_type==
+          symex_target_equationt::assignment_typet::PHI ||
+        SSA_step.assignment_type==
+          symex_target_equationt::assignment_typet::GUARD))
       continue;
 
     goto_tracet::stepst &steps=time_map[current_time];
@@ -247,8 +249,10 @@ void build_goto_trace(
 
     goto_trace_step.assignment_type=
       (it->is_assignment()&&
-       (SSA_step.assignment_type==symex_targett::VISIBLE_ACTUAL_PARAMETER ||
-        SSA_step.assignment_type==symex_targett::HIDDEN_ACTUAL_PARAMETER))?
+       (SSA_step.assignment_type==
+          symex_targett::assignment_typet::VISIBLE_ACTUAL_PARAMETER ||
+        SSA_step.assignment_type==
+          symex_targett::assignment_typet::HIDDEN_ACTUAL_PARAMETER))?
       goto_trace_stept::assignment_typet::ACTUAL_PARAMETER:
       goto_trace_stept::assignment_typet::STATE;
 

--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -249,8 +249,8 @@ void build_goto_trace(
       (it->is_assignment()&&
        (SSA_step.assignment_type==symex_targett::VISIBLE_ACTUAL_PARAMETER ||
         SSA_step.assignment_type==symex_targett::HIDDEN_ACTUAL_PARAMETER))?
-      goto_trace_stept::ACTUAL_PARAMETER:
-      goto_trace_stept::STATE;
+      goto_trace_stept::assignment_typet::ACTUAL_PARAMETER:
+      goto_trace_stept::assignment_typet::STATE;
 
     if(SSA_step.original_full_lhs.is_not_nil())
       goto_trace_step.full_lhs=

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -759,7 +759,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
       ssa_l1.get_original_expr(),
       tmp,
       source,
-      symex_targett::PHI);
+      symex_targett::assignment_typet::PHI);
 
     set_ssa_indices(ssa_l1, ns, L2);
     expr=ssa_l1;

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -142,7 +142,7 @@ public:
     }
   } propagation;
 
-  typedef enum { L0=0, L1=1, L2=2 } levelt;
+  enum levelt { L0=0, L1=1, L2=2 };
 
   // performs renaming _up to_ the given level
   void rename(exprt &expr, const namespacet &ns, levelt level=L2);

--- a/src/goto-symex/partial_order_concurrency.cpp
+++ b/src/goto-symex/partial_order_concurrency.cpp
@@ -96,7 +96,7 @@ void partial_order_concurrencyt::add_init_writes(
       // no SSA L2 index, thus nondet value
       SSA_step.ssa_lhs=e_it->ssa_lhs;
       SSA_step.ssa_lhs.remove_level_2();
-      SSA_step.type=goto_trace_stept::SHARED_WRITE;
+      SSA_step.type=goto_trace_stept::typet::SHARED_WRITE;
       SSA_step.atomic_section_id=0;
       SSA_step.source=e_it->source;
     }

--- a/src/goto-symex/partial_order_concurrency.h
+++ b/src/goto-symex/partial_order_concurrency.h
@@ -24,13 +24,13 @@ public:
   typedef eventst::const_iterator event_it;
 
   // the name of a clock variable for a shared read/write
-  typedef enum
+  enum axiomt
   {
     AX_SC_PER_LOCATION=1,
     AX_NO_THINAIR=2,
     AX_OBSERVATION=4,
     AX_PROPAGATION=8
-  } axiomt;
+  };
 
   static irep_idt rw_clock_id(
     event_it e,
@@ -191,14 +191,14 @@ class partial_order_concurrencyt
 {
 public:
   // the is-acyclic checks
-  typedef enum
+  enum acyclict
   {
     AC_UNIPROC=0,
     AC_THINAIR=1,
     AC_GHB=2,
     AC_PPC_WS_FENCE=3,
     AC_N_AXIOMS=4
-  } acyclict;
+  };
 
   typedef abstract_eventt evtt;
   typedef std::map<evtt const*, std::map<evtt const*, exprt> > adj_matrixt;

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -113,50 +113,50 @@ void symex_slicet::slice(symex_target_equationt::SSA_stept &SSA_step)
 
   switch(SSA_step.type)
   {
-  case goto_trace_stept::ASSERT:
+  case goto_trace_stept::typet::ASSERT:
     get_symbols(SSA_step.cond_expr);
     break;
 
-  case goto_trace_stept::ASSUME:
+  case goto_trace_stept::typet::ASSUME:
     get_symbols(SSA_step.cond_expr);
     break;
 
-  case goto_trace_stept::GOTO:
+  case goto_trace_stept::typet::GOTO:
     get_symbols(SSA_step.cond_expr);
     break;
 
-  case goto_trace_stept::LOCATION:
+  case goto_trace_stept::typet::LOCATION:
     // ignore
     break;
 
-  case goto_trace_stept::ASSIGNMENT:
+  case goto_trace_stept::typet::ASSIGNMENT:
     slice_assignment(SSA_step);
     break;
 
-  case goto_trace_stept::DECL:
+  case goto_trace_stept::typet::DECL:
     slice_decl(SSA_step);
     break;
 
-  case goto_trace_stept::OUTPUT:
-  case goto_trace_stept::INPUT:
+  case goto_trace_stept::typet::OUTPUT:
+  case goto_trace_stept::typet::INPUT:
     break;
 
-  case goto_trace_stept::DEAD:
+  case goto_trace_stept::typet::DEAD:
     // ignore for now
     break;
 
-  case goto_trace_stept::CONSTRAINT:
-  case goto_trace_stept::SHARED_READ:
-  case goto_trace_stept::SHARED_WRITE:
-  case goto_trace_stept::ATOMIC_BEGIN:
-  case goto_trace_stept::ATOMIC_END:
-  case goto_trace_stept::SPAWN:
-  case goto_trace_stept::MEMORY_BARRIER:
+  case goto_trace_stept::typet::CONSTRAINT:
+  case goto_trace_stept::typet::SHARED_READ:
+  case goto_trace_stept::typet::SHARED_WRITE:
+  case goto_trace_stept::typet::ATOMIC_BEGIN:
+  case goto_trace_stept::typet::ATOMIC_END:
+  case goto_trace_stept::typet::SPAWN:
+  case goto_trace_stept::typet::MEMORY_BARRIER:
     // ignore for now
     break;
 
-  case goto_trace_stept::FUNCTION_CALL:
-  case goto_trace_stept::FUNCTION_RETURN:
+  case goto_trace_stept::typet::FUNCTION_CALL:
+  case goto_trace_stept::typet::FUNCTION_RETURN:
     // ignore for now
     break;
 
@@ -248,39 +248,39 @@ void symex_slicet::collect_open_variables(
 
     switch(SSA_step.type)
     {
-    case goto_trace_stept::ASSERT:
+    case goto_trace_stept::typet::ASSERT:
       get_symbols(SSA_step.cond_expr);
       break;
 
-    case goto_trace_stept::ASSUME:
+    case goto_trace_stept::typet::ASSUME:
       get_symbols(SSA_step.cond_expr);
       break;
 
-    case goto_trace_stept::LOCATION:
+    case goto_trace_stept::typet::LOCATION:
       // ignore
       break;
 
-    case goto_trace_stept::ASSIGNMENT:
+    case goto_trace_stept::typet::ASSIGNMENT:
       get_symbols(SSA_step.ssa_rhs);
       lhs.insert(SSA_step.ssa_lhs.get_identifier());
       break;
 
-    case goto_trace_stept::OUTPUT:
-    case goto_trace_stept::INPUT:
-    case goto_trace_stept::DEAD:
-    case goto_trace_stept::NONE:
+    case goto_trace_stept::typet::OUTPUT:
+    case goto_trace_stept::typet::INPUT:
+    case goto_trace_stept::typet::DEAD:
+    case goto_trace_stept::typet::NONE:
       break;
 
-    case goto_trace_stept::DECL:
-    case goto_trace_stept::FUNCTION_CALL:
-    case goto_trace_stept::FUNCTION_RETURN:
-    case goto_trace_stept::CONSTRAINT:
-    case goto_trace_stept::SHARED_READ:
-    case goto_trace_stept::SHARED_WRITE:
-    case goto_trace_stept::ATOMIC_BEGIN:
-    case goto_trace_stept::ATOMIC_END:
-    case goto_trace_stept::SPAWN:
-    case goto_trace_stept::MEMORY_BARRIER:
+    case goto_trace_stept::typet::DECL:
+    case goto_trace_stept::typet::FUNCTION_CALL:
+    case goto_trace_stept::typet::FUNCTION_RETURN:
+    case goto_trace_stept::typet::CONSTRAINT:
+    case goto_trace_stept::typet::SHARED_READ:
+    case goto_trace_stept::typet::SHARED_WRITE:
+    case goto_trace_stept::typet::ATOMIC_BEGIN:
+    case goto_trace_stept::typet::ATOMIC_END:
+    case goto_trace_stept::typet::SPAWN:
+    case goto_trace_stept::typet::MEMORY_BARRIER:
       // ignore for now
       break;
 

--- a/src/goto-symex/slice_by_trace.cpp
+++ b/src/goto-symex/slice_by_trace.cpp
@@ -630,7 +630,7 @@ void symex_slice_by_tracet::assign_merges(
     SSA_step.guard=t_guard.as_expr();
     SSA_step.ssa_lhs=merge_sym;
     SSA_step.ssa_rhs.swap(merge_copy);
-    SSA_step.assignment_type=symex_targett::HIDDEN;
+    SSA_step.assignment_type=symex_targett::assignment_typet::HIDDEN;
 
     SSA_step.cond_expr=equal_exprt(SSA_step.ssa_lhs, SSA_step.ssa_rhs);
     SSA_step.type=goto_trace_stept::typet::ASSIGNMENT;

--- a/src/goto-symex/slice_by_trace.cpp
+++ b/src/goto-symex/slice_by_trace.cpp
@@ -119,7 +119,7 @@ void symex_slice_by_tracet::slice_by_trace(
   SSA_step.guard=t_guard.as_expr();
   SSA_step.ssa_lhs.make_nil();
   SSA_step.cond_expr.swap(trace_condition);
-  SSA_step.type=goto_trace_stept::ASSUME;
+  SSA_step.type=goto_trace_stept::typet::ASSUME;
   SSA_step.source=empty_source;
 
   assign_merges(equation); // Now add the merge variable assignments to eqn
@@ -633,7 +633,7 @@ void symex_slice_by_tracet::assign_merges(
     SSA_step.assignment_type=symex_targett::HIDDEN;
 
     SSA_step.cond_expr=equal_exprt(SSA_step.ssa_lhs, SSA_step.ssa_rhs);
-    SSA_step.type=goto_trace_stept::ASSIGNMENT;
+    SSA_step.type=goto_trace_stept::typet::ASSIGNMENT;
     SSA_step.source=empty_source;
   }
 }

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -93,21 +93,21 @@ void goto_symext::symex_assign(
   }
   else
   {
-    assignment_typet assignment_type=symex_targett::STATE;
+    assignment_typet assignment_type=symex_targett::assignment_typet::STATE;
 
     // Let's hide return value assignments.
     if(lhs.id()==ID_symbol &&
        id2string(to_symbol_expr(lhs).get_identifier()).find(
                   "#return_value!")!=std::string::npos)
-      assignment_type=symex_targett::HIDDEN;
+      assignment_type=symex_targett::assignment_typet::HIDDEN;
 
     // We hide if we are in a hidden function.
     if(state.top().hidden_function)
-      assignment_type=symex_targett::HIDDEN;
+      assignment_type=symex_targett::assignment_typet::HIDDEN;
 
     // We hide if we are executing a hidden instruction.
     if(state.source.pc->source_location.get_hide())
-      assignment_type=symex_targett::HIDDEN;
+      assignment_type=symex_targett::assignment_typet::HIDDEN;
 
     guardt guard; // NOT the state guard!
     symex_assign_rec(state, lhs, nil_exprt(), rhs, guard, assignment_type);
@@ -303,7 +303,7 @@ void goto_symext::symex_assign_symbol(
   // do the assignment
   const symbolt &symbol=ns.lookup(ssa_lhs.get_original_expr());
   if(symbol.is_auxiliary)
-    assignment_type=symex_targett::HIDDEN;
+    assignment_type=symex_targett::assignment_typet::HIDDEN;
 
   target.assignment(
     tmp_guard.as_expr(),

--- a/src/goto-symex/symex_decl.cpp
+++ b/src/goto-symex/symex_decl.cpp
@@ -120,7 +120,9 @@ void goto_symext::symex_decl(statet &state, const symbol_exprt &expr)
     state.guard.as_expr(),
     ssa,
     state.source,
-    hidden?symex_targett::HIDDEN:symex_targett::STATE);
+    hidden?
+      symex_targett::assignment_typet::HIDDEN:
+      symex_targett::assignment_typet::STATE);
 
   assert(state.dirty);
   if((*state.dirty)(ssa.get_object_name()) &&

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -302,7 +302,9 @@ void goto_symext::dereference_rec(
       dereference.dereference(
         tmp1,
         guard,
-        write?value_set_dereferencet::WRITE:value_set_dereferencet::READ);
+        write?
+          value_set_dereferencet::modet::WRITE:
+          value_set_dereferencet::modet::READ);
     // std::cout << "**** " << from_expr(ns, "", tmp2) << std::endl;
 
     expr.swap(tmp2);

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -184,7 +184,7 @@ void goto_symext::symex_goto(statet &state)
         new_lhs, new_lhs, guard_symbol_expr,
         new_rhs,
         original_source,
-        symex_targett::GUARD);
+        symex_targett::assignment_typet::GUARD);
 
       guard_expr=guard_symbol_expr;
       guard_expr.make_not();
@@ -437,7 +437,7 @@ void goto_symext::phi_function(
       new_lhs, new_lhs, new_lhs.get_original_expr(),
       rhs,
       dest_state.source,
-      symex_targett::PHI);
+      symex_targett::assignment_typet::PHI);
   }
 }
 

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -94,7 +94,12 @@ void goto_symext::symex_start_thread(statet &state)
     const bool record_events=state.record_events;
     state.record_events=false;
     symex_assign_symbol(
-      state, lhs, nil_exprt(), rhs, guard, symex_targett::HIDDEN);
+      state,
+      lhs,
+      nil_exprt(),
+      rhs,
+      guard,
+      symex_targett::assignment_typet::HIDDEN);
     state.record_events=record_events;
   }
 
@@ -122,6 +127,11 @@ void goto_symext::symex_start_thread(statet &state)
 
     guardt guard;
     symex_assign_symbol(
-      state, lhs, nil_exprt(), rhs, guard, symex_targett::HIDDEN);
+      state,
+      lhs,
+      nil_exprt(),
+      rhs,
+      guard,
+      symex_targett::assignment_typet::HIDDEN);
   }
 }

--- a/src/goto-symex/symex_target.h
+++ b/src/goto-symex/symex_target.h
@@ -51,10 +51,10 @@ public:
     }
   };
 
-  typedef enum
+  enum class assignment_typet
   {
     STATE, HIDDEN, VISIBLE_ACTUAL_PARAMETER, HIDDEN_ACTUAL_PARAMETER, PHI, GUARD
-  } assignment_typet;
+  };
 
   // read event
   virtual void shared_read(

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -74,7 +74,7 @@ void symex_target_equationt::shared_read(
 
   SSA_step.guard=guard;
   SSA_step.ssa_lhs=ssa_object;
-  SSA_step.type=goto_trace_stept::SHARED_READ;
+  SSA_step.type=goto_trace_stept::typet::SHARED_READ;
   SSA_step.atomic_section_id=atomic_section_id;
   SSA_step.source=source;
 
@@ -104,7 +104,7 @@ void symex_target_equationt::shared_write(
 
   SSA_step.guard=guard;
   SSA_step.ssa_lhs=ssa_object;
-  SSA_step.type=goto_trace_stept::SHARED_WRITE;
+  SSA_step.type=goto_trace_stept::typet::SHARED_WRITE;
   SSA_step.atomic_section_id=atomic_section_id;
   SSA_step.source=source;
 
@@ -130,7 +130,7 @@ void symex_target_equationt::spawn(
   SSA_steps.push_back(SSA_stept());
   SSA_stept &SSA_step=SSA_steps.back();
   SSA_step.guard=guard;
-  SSA_step.type=goto_trace_stept::SPAWN;
+  SSA_step.type=goto_trace_stept::typet::SPAWN;
   SSA_step.source=source;
 
   merge_ireps(SSA_step);
@@ -155,7 +155,7 @@ void symex_target_equationt::memory_barrier(
   SSA_steps.push_back(SSA_stept());
   SSA_stept &SSA_step=SSA_steps.back();
   SSA_step.guard=guard;
-  SSA_step.type=goto_trace_stept::MEMORY_BARRIER;
+  SSA_step.type=goto_trace_stept::typet::MEMORY_BARRIER;
   SSA_step.source=source;
 
   merge_ireps(SSA_step);
@@ -181,7 +181,7 @@ void symex_target_equationt::atomic_begin(
   SSA_steps.push_back(SSA_stept());
   SSA_stept &SSA_step=SSA_steps.back();
   SSA_step.guard=guard;
-  SSA_step.type=goto_trace_stept::ATOMIC_BEGIN;
+  SSA_step.type=goto_trace_stept::typet::ATOMIC_BEGIN;
   SSA_step.atomic_section_id=atomic_section_id;
   SSA_step.source=source;
 
@@ -208,7 +208,7 @@ void symex_target_equationt::atomic_end(
   SSA_steps.push_back(SSA_stept());
   SSA_stept &SSA_step=SSA_steps.back();
   SSA_step.guard=guard;
-  SSA_step.type=goto_trace_stept::ATOMIC_END;
+  SSA_step.type=goto_trace_stept::typet::ATOMIC_END;
   SSA_step.atomic_section_id=atomic_section_id;
   SSA_step.source=source;
 
@@ -249,7 +249,7 @@ void symex_target_equationt::assignment(
   SSA_step.assignment_type=assignment_type;
 
   SSA_step.cond_expr=equal_exprt(SSA_step.ssa_lhs, SSA_step.ssa_rhs);
-  SSA_step.type=goto_trace_stept::ASSIGNMENT;
+  SSA_step.type=goto_trace_stept::typet::ASSIGNMENT;
   SSA_step.hidden=(assignment_type!=STATE &&
                    assignment_type!=VISIBLE_ACTUAL_PARAMETER);
   SSA_step.source=source;
@@ -284,7 +284,7 @@ void symex_target_equationt::decl(
   SSA_step.ssa_lhs=ssa_lhs;
   SSA_step.ssa_full_lhs=ssa_lhs;
   SSA_step.original_full_lhs=ssa_lhs.get_original_expr();
-  SSA_step.type=goto_trace_stept::DECL;
+  SSA_step.type=goto_trace_stept::typet::DECL;
   SSA_step.source=source;
   SSA_step.hidden=(assignment_type!=STATE);
 
@@ -335,7 +335,7 @@ void symex_target_equationt::location(
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
-  SSA_step.type=goto_trace_stept::LOCATION;
+  SSA_step.type=goto_trace_stept::typet::LOCATION;
   SSA_step.source=source;
 
   merge_ireps(SSA_step);
@@ -362,7 +362,7 @@ void symex_target_equationt::function_call(
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
-  SSA_step.type=goto_trace_stept::FUNCTION_CALL;
+  SSA_step.type=goto_trace_stept::typet::FUNCTION_CALL;
   SSA_step.source=source;
   SSA_step.identifier=identifier;
 
@@ -390,7 +390,7 @@ void symex_target_equationt::function_return(
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
-  SSA_step.type=goto_trace_stept::FUNCTION_RETURN;
+  SSA_step.type=goto_trace_stept::typet::FUNCTION_RETURN;
   SSA_step.source=source;
   SSA_step.identifier=identifier;
 
@@ -419,7 +419,7 @@ void symex_target_equationt::output(
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
-  SSA_step.type=goto_trace_stept::OUTPUT;
+  SSA_step.type=goto_trace_stept::typet::OUTPUT;
   SSA_step.source=source;
   SSA_step.io_args=args;
   SSA_step.io_id=output_id;
@@ -450,7 +450,7 @@ void symex_target_equationt::output_fmt(
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
-  SSA_step.type=goto_trace_stept::OUTPUT;
+  SSA_step.type=goto_trace_stept::typet::OUTPUT;
   SSA_step.source=source;
   SSA_step.io_args=args;
   SSA_step.io_id=output_id;
@@ -482,7 +482,7 @@ void symex_target_equationt::input(
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
-  SSA_step.type=goto_trace_stept::INPUT;
+  SSA_step.type=goto_trace_stept::typet::INPUT;
   SSA_step.source=source;
   SSA_step.io_args=args;
   SSA_step.io_id=input_id;
@@ -512,7 +512,7 @@ void symex_target_equationt::assumption(
 
   SSA_step.guard=guard;
   SSA_step.cond_expr=cond;
-  SSA_step.type=goto_trace_stept::ASSUME;
+  SSA_step.type=goto_trace_stept::typet::ASSUME;
   SSA_step.source=source;
 
   merge_ireps(SSA_step);
@@ -541,7 +541,7 @@ void symex_target_equationt::assertion(
 
   SSA_step.guard=guard;
   SSA_step.cond_expr=cond;
-  SSA_step.type=goto_trace_stept::ASSERT;
+  SSA_step.type=goto_trace_stept::typet::ASSERT;
   SSA_step.source=source;
   SSA_step.comment=msg;
 
@@ -570,7 +570,7 @@ void symex_target_equationt::goto_instruction(
 
   SSA_step.guard=guard;
   SSA_step.cond_expr=cond;
-  SSA_step.type=goto_trace_stept::GOTO;
+  SSA_step.type=goto_trace_stept::typet::GOTO;
   SSA_step.source=source;
 
   merge_ireps(SSA_step);
@@ -599,7 +599,7 @@ void symex_target_equationt::constraint(
 
   SSA_step.guard=true_exprt();
   SSA_step.cond_expr=cond;
-  SSA_step.type=goto_trace_stept::CONSTRAINT;
+  SSA_step.type=goto_trace_stept::typet::CONSTRAINT;
   SSA_step.source=source;
   SSA_step.comment=msg;
 
@@ -981,23 +981,23 @@ void symex_target_equationt::SSA_stept::output(
 
   switch(type)
   {
-  case goto_trace_stept::ASSERT:
+  case goto_trace_stept::typet::ASSERT:
     out << "ASSERT " << from_expr(ns, "", cond_expr) << std::endl; break;
-  case goto_trace_stept::ASSUME:
+  case goto_trace_stept::typet::ASSUME:
     out << "ASSUME " << from_expr(ns, "", cond_expr) << std::endl; break;
-  case goto_trace_stept::LOCATION:
+  case goto_trace_stept::typet::LOCATION:
     out << "LOCATION" << std::endl; break;
-  case goto_trace_stept::INPUT:
+  case goto_trace_stept::typet::INPUT:
     out << "INPUT" << std::endl; break;
-  case goto_trace_stept::OUTPUT:
+  case goto_trace_stept::typet::OUTPUT:
     out << "OUTPUT" << std::endl; break;
 
-  case goto_trace_stept::DECL:
+  case goto_trace_stept::typet::DECL:
     out << "DECL" << std::endl;
     out << from_expr(ns, "", ssa_lhs) << std::endl;
     break;
 
-  case goto_trace_stept::ASSIGNMENT:
+  case goto_trace_stept::typet::ASSIGNMENT:
     out << "ASSIGNMENT (";
     switch(assignment_type)
     {
@@ -1015,27 +1015,27 @@ void symex_target_equationt::SSA_stept::output(
     out << ")" << std::endl;
     break;
 
-  case goto_trace_stept::DEAD:
+  case goto_trace_stept::typet::DEAD:
     out << "DEAD" << std::endl; break;
-  case goto_trace_stept::FUNCTION_CALL:
+  case goto_trace_stept::typet::FUNCTION_CALL:
     out << "FUNCTION_CALL" << std::endl; break;
-  case goto_trace_stept::FUNCTION_RETURN:
+  case goto_trace_stept::typet::FUNCTION_RETURN:
     out << "FUNCTION_RETURN" << std::endl; break;
-  case goto_trace_stept::CONSTRAINT:
+  case goto_trace_stept::typet::CONSTRAINT:
     out << "CONSTRAINT" << std::endl; break;
-  case goto_trace_stept::SHARED_READ:
+  case goto_trace_stept::typet::SHARED_READ:
     out << "SHARED READ" << std::endl; break;
-  case goto_trace_stept::SHARED_WRITE:
+  case goto_trace_stept::typet::SHARED_WRITE:
     out << "SHARED WRITE" << std::endl; break;
-  case goto_trace_stept::ATOMIC_BEGIN:
+  case goto_trace_stept::typet::ATOMIC_BEGIN:
     out << "ATOMIC_BEGIN" << std::endl; break;
-  case goto_trace_stept::ATOMIC_END:
+  case goto_trace_stept::typet::ATOMIC_END:
     out << "AUTOMIC_END" << std::endl; break;
-  case goto_trace_stept::SPAWN:
+  case goto_trace_stept::typet::SPAWN:
     out << "SPAWN" << std::endl; break;
-  case goto_trace_stept::MEMORY_BARRIER:
+  case goto_trace_stept::typet::MEMORY_BARRIER:
     out << "MEMORY_BARRIER" << std::endl; break;
-  case goto_trace_stept::GOTO:
+  case goto_trace_stept::typet::GOTO:
     out << "IF " << from_expr(ns, "", cond_expr) << " GOTO" << std::endl; break;
 
   default: assert(false);

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -250,8 +250,8 @@ void symex_target_equationt::assignment(
 
   SSA_step.cond_expr=equal_exprt(SSA_step.ssa_lhs, SSA_step.ssa_rhs);
   SSA_step.type=goto_trace_stept::typet::ASSIGNMENT;
-  SSA_step.hidden=(assignment_type!=STATE &&
-                   assignment_type!=VISIBLE_ACTUAL_PARAMETER);
+  SSA_step.hidden=(assignment_type!=assignment_typet::STATE &&
+                   assignment_type!=assignment_typet::VISIBLE_ACTUAL_PARAMETER);
   SSA_step.source=source;
 
   merge_ireps(SSA_step);
@@ -286,7 +286,7 @@ void symex_target_equationt::decl(
   SSA_step.original_full_lhs=ssa_lhs.get_original_expr();
   SSA_step.type=goto_trace_stept::typet::DECL;
   SSA_step.source=source;
-  SSA_step.hidden=(assignment_type!=STATE);
+  SSA_step.hidden=(assignment_type!=assignment_typet::STATE);
 
   // the condition is trivially true, and only
   // there so we see the symbols
@@ -1001,12 +1001,18 @@ void symex_target_equationt::SSA_stept::output(
     out << "ASSIGNMENT (";
     switch(assignment_type)
     {
-    case HIDDEN: out << "HIDDEN"; break;
-    case STATE: out << "STATE"; break;
-    case VISIBLE_ACTUAL_PARAMETER: out << "VISIBLE_ACTUAL_PARAMETER"; break;
-    case HIDDEN_ACTUAL_PARAMETER: out << "HIDDEN_ACTUAL_PARAMETER"; break;
-    case PHI: out << "PHI"; break;
-    case GUARD: out << "GUARD"; break;
+    case assignment_typet::HIDDEN:
+      out << "HIDDEN"; break;
+    case assignment_typet::STATE:
+      out << "STATE"; break;
+    case assignment_typet::VISIBLE_ACTUAL_PARAMETER:
+      out << "VISIBLE_ACTUAL_PARAMETER"; break;
+    case assignment_typet::HIDDEN_ACTUAL_PARAMETER:
+      out << "HIDDEN_ACTUAL_PARAMETER"; break;
+    case assignment_typet::PHI:
+      out << "PHI"; break;
+    case assignment_typet::GUARD:
+      out << "GUARD"; break;
     default:
       {
       }

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -170,31 +170,38 @@ public:
     sourcet source;
     goto_trace_stept::typet type;
 
-    bool is_assert() const          { return type==goto_trace_stept::ASSERT; }
-    bool is_assume() const          { return type==goto_trace_stept::ASSUME; }
     // NOLINTNEXTLINE(whitespace/line_length)
-    bool is_assignment() const      { return type==goto_trace_stept::ASSIGNMENT; }
-    bool is_goto() const            { return type==goto_trace_stept::GOTO; }
+    bool is_assert() const          { return type==goto_trace_stept::typet::ASSERT; }
     // NOLINTNEXTLINE(whitespace/line_length)
-    bool is_constraint() const      { return type==goto_trace_stept::CONSTRAINT; }
-    bool is_location() const        { return type==goto_trace_stept::LOCATION; }
-    bool is_output() const          { return type==goto_trace_stept::OUTPUT; }
-    bool is_decl() const            { return type==goto_trace_stept::DECL; }
+    bool is_assume() const          { return type==goto_trace_stept::typet::ASSUME; }
     // NOLINTNEXTLINE(whitespace/line_length)
-    bool is_function_call() const   { return type==goto_trace_stept::FUNCTION_CALL; }
+    bool is_assignment() const      { return type==goto_trace_stept::typet::ASSIGNMENT; }
     // NOLINTNEXTLINE(whitespace/line_length)
-    bool is_function_return() const { return type==goto_trace_stept::FUNCTION_RETURN; }
+    bool is_goto() const            { return type==goto_trace_stept::typet::GOTO; }
     // NOLINTNEXTLINE(whitespace/line_length)
-    bool is_shared_read() const     { return type==goto_trace_stept::SHARED_READ; }
+    bool is_constraint() const      { return type==goto_trace_stept::typet::CONSTRAINT; }
     // NOLINTNEXTLINE(whitespace/line_length)
-    bool is_shared_write() const    { return type==goto_trace_stept::SHARED_WRITE; }
-    bool is_spawn() const           { return type==goto_trace_stept::SPAWN; }
+    bool is_location() const        { return type==goto_trace_stept::typet::LOCATION; }
     // NOLINTNEXTLINE(whitespace/line_length)
-    bool is_memory_barrier() const  { return type==goto_trace_stept::MEMORY_BARRIER; }
+    bool is_output() const          { return type==goto_trace_stept::typet::OUTPUT; }
     // NOLINTNEXTLINE(whitespace/line_length)
-    bool is_atomic_begin() const    { return type==goto_trace_stept::ATOMIC_BEGIN; }
+    bool is_decl() const            { return type==goto_trace_stept::typet::DECL; }
     // NOLINTNEXTLINE(whitespace/line_length)
-    bool is_atomic_end() const      { return type==goto_trace_stept::ATOMIC_END; }
+    bool is_function_call() const   { return type==goto_trace_stept::typet::FUNCTION_CALL; }
+    // NOLINTNEXTLINE(whitespace/line_length)
+    bool is_function_return() const { return type==goto_trace_stept::typet::FUNCTION_RETURN; }
+    // NOLINTNEXTLINE(whitespace/line_length)
+    bool is_shared_read() const     { return type==goto_trace_stept::typet::SHARED_READ; }
+    // NOLINTNEXTLINE(whitespace/line_length)
+    bool is_shared_write() const    { return type==goto_trace_stept::typet::SHARED_WRITE; }
+    // NOLINTNEXTLINE(whitespace/line_length)
+    bool is_spawn() const           { return type==goto_trace_stept::typet::SPAWN; }
+    // NOLINTNEXTLINE(whitespace/line_length)
+    bool is_memory_barrier() const  { return type==goto_trace_stept::typet::MEMORY_BARRIER; }
+    // NOLINTNEXTLINE(whitespace/line_length)
+    bool is_atomic_begin() const    { return type==goto_trace_stept::typet::ATOMIC_BEGIN; }
+    // NOLINTNEXTLINE(whitespace/line_length)
+    bool is_atomic_end() const      { return type==goto_trace_stept::typet::ATOMIC_END; }
 
     // we may choose to hide
     bool hidden;
@@ -229,7 +236,7 @@ public:
     bool ignore;
 
     SSA_stept():
-      type(goto_trace_stept::NONE),
+      type(goto_trace_stept::typet::NONE),
       hidden(false),
       guard(static_cast<const exprt &>(get_nil_irep())),
       guard_literal(const_literal(false)),

--- a/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -93,11 +93,11 @@ public:
   std::set<symbol_exprt> used_local_names;
   bool method_has_this;
 
-  typedef enum instruction_sizet
+  enum instruction_sizet
   {
     INST_INDEX=2,
     INST_INDEX_CONST=3
-  } instruction_sizet;
+  };
 
   codet get_array_bounds_check(
     const exprt &arraystruct,

--- a/src/langapi/language_ui.cpp
+++ b/src/langapi/language_ui.cpp
@@ -127,7 +127,7 @@ bool language_uit::parse(const std::string &filename)
 
   if(language.parse(infile, filename))
   {
-    if(get_ui()==ui_message_handlert::PLAIN)
+    if(get_ui()==ui_message_handlert::uit::PLAIN)
       std::cerr << "PARSING ERROR" << std::endl;
 
     return true;
@@ -206,11 +206,11 @@ void language_uit::show_symbol_table(bool brief)
 {
   switch(get_ui())
   {
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     show_symbol_table_plain(std::cout, brief);
     break;
 
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
     show_symbol_table_xml_ui(brief);
     break;
 

--- a/src/musketeer/cycles_visitor.cpp
+++ b/src/musketeer/cycles_visitor.cpp
@@ -275,8 +275,9 @@ void cycles_visitort::powr_constraint(
   for(std::set<edget>::iterator e_i=C_j.unsafe_pairs.begin();
     e_i!=C_j.unsafe_pairs.end(); ++e_i)
   {
-    if(e_i->is_po && (graph[e_i->first].operation==abstract_eventt::Write
-        && graph[e_i->second].operation==abstract_eventt::Read))
+    if(e_i->is_po &&
+       (graph[e_i->first].operation==abstract_eventt::operationt::Write &&
+        graph[e_i->second].operation==abstract_eventt::operationt::Read))
     {
       if( edges.insert(fence_inserter.add_edge(*e_i)).second )
         ++fence_inserter.constraints_number;
@@ -306,8 +307,9 @@ void cycles_visitort::poww_constraint(
   for(std::set<edget>::iterator e_i=C_j.unsafe_pairs.begin();
     e_i!=C_j.unsafe_pairs.end(); ++e_i)
   {
-    if(e_i->is_po && (graph[e_i->first].operation==abstract_eventt::Write
-        && graph[e_i->second].operation==abstract_eventt::Write))
+    if(e_i->is_po &&
+       (graph[e_i->first].operation==abstract_eventt::operationt::Write &&
+        graph[e_i->second].operation==abstract_eventt::operationt::Write))
     {
       if( edges.insert(fence_inserter.add_edge(*e_i)).second )
         ++fence_inserter.constraints_number;
@@ -337,8 +339,9 @@ void cycles_visitort::porw_constraint(
   for(std::set<edget>::iterator e_i=C_j.unsafe_pairs.begin();
     e_i!=C_j.unsafe_pairs.end(); ++e_i)
   {
-    if(e_i->is_po && (graph[e_i->first].operation==abstract_eventt::Read
-        && graph[e_i->second].operation==abstract_eventt::Write))
+    if(e_i->is_po &&
+       (graph[e_i->first].operation==abstract_eventt::operationt::Read &&
+        graph[e_i->second].operation==abstract_eventt::operationt::Write))
     {
       if( edges.insert(fence_inserter.add_edge(*e_i)).second )
         ++fence_inserter.constraints_number;
@@ -368,8 +371,9 @@ void cycles_visitort::porr_constraint(
   for(std::set<edget>::iterator e_i=C_j.unsafe_pairs.begin();
     e_i!=C_j.unsafe_pairs.end(); ++e_i)
   {
-    if(e_i->is_po && (graph[e_i->first].operation==abstract_eventt::Read
-        && graph[e_i->second].operation==abstract_eventt::Read))
+    if(e_i->is_po &&
+       (graph[e_i->first].operation==abstract_eventt::operationt::Read &&
+        graph[e_i->second].operation==abstract_eventt::operationt::Read))
     {
       if( edges.insert(fence_inserter.add_edge(*e_i)).second )
         ++fence_inserter.constraints_number;
@@ -400,8 +404,8 @@ void cycles_visitort::com_constraint(
     it!=C_j.unsafe_pairs.end();
     ++it)
   {
-    if(egraph[it->first].operation==abstract_eventt::Write
-      && egraph[it->second].operation==abstract_eventt::Read
+    if(egraph[it->first].operation==abstract_eventt::operationt::Write
+      && egraph[it->second].operation==abstract_eventt::operationt::Read
       && egraph[it->first].thread!=egraph[it->second].thread)
       if( edges.insert(fence_inserter.add_invisible_edge(*it)).second )
         ++fence_inserter.constraints_number;

--- a/src/musketeer/fence_inserter.h
+++ b/src/musketeer/fence_inserter.h
@@ -100,7 +100,7 @@ protected:
   void preprocess();
   void solve();
 
-  typedef enum {Fence=0, Dp=1, Lwfence=2, Branching=3, Ctlfence=4} fence_typet;
+  enum fence_typet { Fence=0, Dp=1, Lwfence=2, Branching=3, Ctlfence=4 };
   virtual unsigned fence_cost(fence_typet e) const;
 
   std::string to_string(fence_typet f) const;

--- a/src/musketeer/graph_visitor.cpp
+++ b/src/musketeer/graph_visitor.cpp
@@ -173,8 +173,8 @@ void const_graph_visitort::graph_explore_BC(
       const abstract_eventt &e1=egraph[*it];
       const abstract_eventt &e2=egraph[*next_it];
       if(!porw ||
-         (e1.operation==abstract_eventt::Read &&
-          e2.operation==abstract_eventt::Write))
+         (e1.operation==abstract_eventt::operationt::Read &&
+          e2.operation==abstract_eventt::operationt::Write))
         edges.insert(fence_inserter.add_edge(edget(*it, *next_it)));
     }
     assert(it!=old_path.end());
@@ -239,8 +239,8 @@ void const_graph_visitort::const_graph_explore_BC(
     {
       const abstract_eventt &e1=egraph[*it];
       const abstract_eventt &e2=egraph[*next_it];
-      if((e1.operation==abstract_eventt::Read
-        && e2.operation==abstract_eventt::Write))
+      if((e1.operation==abstract_eventt::operationt::Read &&
+          e2.operation==abstract_eventt::operationt::Write))
         fence_inserter.add_edge(edget(*it, *next_it));
     }
     // NEW
@@ -312,8 +312,8 @@ void const_graph_visitort::graph_explore_AC(
       const abstract_eventt &e1=egraph[*next_it];
       const abstract_eventt &e2=egraph[*it];
       if(!porw ||
-         (e1.operation==abstract_eventt::Read &&
-          e2.operation==abstract_eventt::Write))
+         (e1.operation==abstract_eventt::operationt::Read &&
+          e2.operation==abstract_eventt::operationt::Write))
         edges.insert(fence_inserter.add_edge(edget(*next_it, *it)));
     }
     assert(it!=old_path.end());
@@ -379,8 +379,8 @@ void const_graph_visitort::const_graph_explore_AC(
     {
       const abstract_eventt &e1=egraph[*next_it];
       const abstract_eventt &e2=egraph[*it];
-      if(e1.operation==abstract_eventt::Read &&
-         e2.operation==abstract_eventt::Write)
+      if(e1.operation==abstract_eventt::operationt::Read &&
+         e2.operation==abstract_eventt::operationt::Write)
         fence_inserter.add_edge(edget(*next_it, *it));
     }
     // NEW
@@ -478,9 +478,13 @@ void const_graph_visitort::CT(
   assert(test_first.operation!=test_second.operation);
 
   const event_idt first=
-    (test_first.operation==abstract_eventt::Write?edge.first:edge.second);
+    (test_first.operation==abstract_eventt::operationt::Write?
+     edge.first:
+     edge.second);
   const event_idt second=
-    (test_second.operation==abstract_eventt::Read?edge.second:edge.first);
+    (test_second.operation==abstract_eventt::operationt::Read?
+     edge.second:
+     edge.first);
 
   /* TODO: AC + restricts to C_1 U ... U C_n */
   visited_nodes.clear();
@@ -539,9 +543,13 @@ void const_graph_visitort::CT_not_powr(
   assert(test_first.operation!=test_second.operation);
 
   const event_idt first=
-    (test_first.operation==abstract_eventt::Write?edge.first:edge.second);
+    (test_first.operation==abstract_eventt::operationt::Write?
+     edge.first:
+     edge.second);
   const event_idt second=
-    (test_second.operation==abstract_eventt::Read?edge.second:edge.first);
+    (test_second.operation==abstract_eventt::operationt::Read?
+     edge.second:
+     edge.first);
 
   /* TODO: AC + restricts to C_1 U ... U C_n */
   visited_nodes.clear();

--- a/src/musketeer/infer_mode.h
+++ b/src/musketeer/infer_mode.h
@@ -9,11 +9,11 @@
 #ifndef CPROVER_MUSKETEER_INFER_MODE_H
 #define CPROVER_MUSKETEER_INFER_MODE_H
 
-typedef enum
+enum infer_modet
 {
   INFER=0,
   USER_DEF=1,
   USER_ASSERT=2
-} infer_modet;
+};
 
 #endif // CPROVER_MUSKETEER_INFER_MODE_H

--- a/src/path-symex/build_goto_trace.cpp
+++ b/src/path-symex/build_goto_trace.cpp
@@ -49,48 +49,48 @@ void build_goto_trace(
     switch(instruction.type)
     {
     case ASSIGN:
-      trace_step.type=goto_trace_stept::ASSIGNMENT;
+      trace_step.type=goto_trace_stept::typet::ASSIGNMENT;
       trace_step.full_lhs=step.full_lhs;
       trace_step.full_lhs_value=decision_procedure.get(step.ssa_lhs);
       break;
 
     case DECL:
-      trace_step.type=goto_trace_stept::DECL;
+      trace_step.type=goto_trace_stept::typet::DECL;
       trace_step.full_lhs=step.full_lhs;
       trace_step.lhs_object=ssa_exprt(step.full_lhs);
       trace_step.full_lhs_value=decision_procedure.get(step.ssa_lhs);
       break;
 
     case DEAD:
-      trace_step.type=goto_trace_stept::DEAD;
+      trace_step.type=goto_trace_stept::typet::DEAD;
       break;
 
     case ASSUME:
-      trace_step.type=goto_trace_stept::ASSUME;
+      trace_step.type=goto_trace_stept::typet::ASSUME;
       break;
 
     case FUNCTION_CALL:
-      trace_step.type=goto_trace_stept::FUNCTION_CALL;
+      trace_step.type=goto_trace_stept::typet::FUNCTION_CALL;
       break;
 
     case END_FUNCTION:
-      trace_step.type=goto_trace_stept::FUNCTION_RETURN;
+      trace_step.type=goto_trace_stept::typet::FUNCTION_RETURN;
       break;
 
     case START_THREAD:
-      trace_step.type=goto_trace_stept::SPAWN;
+      trace_step.type=goto_trace_stept::typet::SPAWN;
       break;
 
     case ATOMIC_BEGIN:
-      trace_step.type=goto_trace_stept::ATOMIC_BEGIN;
+      trace_step.type=goto_trace_stept::typet::ATOMIC_BEGIN;
       break;
 
     case ATOMIC_END:
-      trace_step.type=goto_trace_stept::ATOMIC_END;
+      trace_step.type=goto_trace_stept::typet::ATOMIC_END;
       break;
 
     default:
-      trace_step.type=goto_trace_stept::LOCATION;
+      trace_step.type=goto_trace_stept::typet::LOCATION;
     }
 
     goto_trace.add_step(trace_step);
@@ -108,7 +108,7 @@ void build_goto_trace(
     trace_step.pc=state.get_instruction();
     trace_step.thread_nr=state.get_current_thread();
     trace_step.step_nr=step_nr;
-    trace_step.type=goto_trace_stept::ASSERT;
+    trace_step.type=goto_trace_stept::typet::ASSERT;
 
     const irep_idt &comment=
       instruction.source_location.get_comment();

--- a/src/path-symex/path_symex_state.cpp
+++ b/src/path-symex/path_symex_state.cpp
@@ -194,11 +194,12 @@ bool path_symex_statet::is_feasible(
   // check whether SAT
   switch(decision_procedure())
   {
-  case decision_proceduret::D_SATISFIABLE: return true;
+  case decision_proceduret::resultt::D_SATISFIABLE: return true;
 
-  case decision_proceduret::D_UNSATISFIABLE: return false;
+  case decision_proceduret::resultt::D_UNSATISFIABLE: return false;
 
-  case decision_proceduret::D_ERROR: throw "error from decision procedure";
+  case decision_proceduret::resultt::D_ERROR:
+    throw "error from decision procedure";
   }
 
   return true; // not really reachable
@@ -240,10 +241,10 @@ bool path_symex_statet::check_assertion(
   // check whether SAT
   switch(decision_procedure.dec_solve())
   {
-  case decision_proceduret::D_SATISFIABLE:
+  case decision_proceduret::resultt::D_SATISFIABLE:
     return false; // error
 
-  case decision_proceduret::D_UNSATISFIABLE:
+  case decision_proceduret::resultt::D_UNSATISFIABLE:
     return true; // no error
 
   default:

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -162,7 +162,7 @@ void goto_program_dereferencet::dereference_rec(
               op.pretty();
 
       if(dereference.has_dereference(op))
-        dereference_rec(op, guard, value_set_dereferencet::READ);
+        dereference_rec(op, guard, value_set_dereferencet::modet::READ);
 
       if(expr.id()==ID_or)
       {
@@ -191,7 +191,7 @@ void goto_program_dereferencet::dereference_rec(
       throw msg;
     }
 
-    dereference_rec(expr.op0(), guard, value_set_dereferencet::READ);
+    dereference_rec(expr.op0(), guard, value_set_dereferencet::modet::READ);
 
     bool o1=dereference.has_dereference(expr.op1());
     bool o2=dereference.has_dereference(expr.op2());
@@ -402,15 +402,17 @@ void goto_program_dereferencet::dereference_instruction(
   #endif
   goto_programt::instructiont &i=*target;
 
-  dereference_expr(i.guard, checks_only, value_set_dereferencet::READ);
+  dereference_expr(i.guard, checks_only, value_set_dereferencet::modet::READ);
 
   if(i.is_assign())
   {
     if(i.code.operands().size()!=2)
       throw "assignment expects two operands";
 
-    dereference_expr(i.code.op0(), checks_only, value_set_dereferencet::WRITE);
-    dereference_expr(i.code.op1(), checks_only, value_set_dereferencet::READ);
+    dereference_expr(
+      i.code.op0(), checks_only, value_set_dereferencet::modet::WRITE);
+    dereference_expr(
+      i.code.op1(), checks_only, value_set_dereferencet::modet::READ);
   }
   else if(i.is_function_call())
   {
@@ -418,17 +420,21 @@ void goto_program_dereferencet::dereference_instruction(
 
     if(function_call.lhs().is_not_nil())
       dereference_expr(
-        function_call.lhs(), checks_only, value_set_dereferencet::WRITE);
+        function_call.lhs(),
+        checks_only,
+        value_set_dereferencet::modet::WRITE);
 
     dereference_expr(
-      function_call.function(), checks_only, value_set_dereferencet::READ);
+      function_call.function(),
+      checks_only,
+      value_set_dereferencet::modet::READ);
     dereference_expr(
-      function_call.op2(), checks_only, value_set_dereferencet::READ);
+      function_call.op2(), checks_only, value_set_dereferencet::modet::READ);
   }
   else if(i.is_return())
   {
     Forall_operands(it, i.code)
-      dereference_expr(*it, checks_only, value_set_dereferencet::READ);
+      dereference_expr(*it, checks_only, value_set_dereferencet::modet::READ);
   }
   else if(i.is_other())
   {
@@ -439,12 +445,14 @@ void goto_program_dereferencet::dereference_instruction(
       if(i.code.operands().size()!=1)
         throw "expression expects one operand";
 
-      dereference_expr(i.code.op0(), checks_only, value_set_dereferencet::READ);
+      dereference_expr(
+        i.code.op0(), checks_only, value_set_dereferencet::modet::READ);
     }
     else if(statement==ID_printf)
     {
       Forall_operands(it, i.code)
-        dereference_expr(*it, checks_only, value_set_dereferencet::READ);
+        dereference_expr(
+          *it, checks_only, value_set_dereferencet::modet::READ);
     }
   }
 }
@@ -470,7 +478,7 @@ void goto_program_dereferencet::dereference_expression(
   valid_local_variables=&target->local_variables;
   #endif
 
-  dereference_expr(expr, false, value_set_dereferencet::READ);
+  dereference_expr(expr, false, value_set_dereferencet::modet::READ);
 }
 
 /*******************************************************************\

--- a/src/pointer-analysis/show_value_sets.cpp
+++ b/src/pointer-analysis/show_value_sets.cpp
@@ -32,7 +32,7 @@ void show_value_sets(
 {
   switch(ui)
   {
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
     {
       xmlt xml;
       convert(goto_functions, value_set_analysis, xml);
@@ -40,7 +40,7 @@ void show_value_sets(
     }
     break;
 
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     value_set_analysis.output(goto_functions, std::cout);
     break;
 
@@ -69,7 +69,7 @@ void show_value_sets(
 {
   switch(ui)
   {
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
     {
       xmlt xml;
       convert(goto_program, value_set_analysis, xml);
@@ -77,7 +77,7 @@ void show_value_sets(
     }
     break;
 
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     value_set_analysis.output(goto_program, std::cout);
     break;
 

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -660,7 +660,7 @@ void value_set_dereferencet::valid_check(
   {
     // always valid, but can't write
 
-    if(mode==WRITE)
+    if(mode==modet::WRITE)
     {
       dereference_callback.dereference_failure(
         "pointer dereference",

--- a/src/pointer-analysis/value_set_dereference.h
+++ b/src/pointer-analysis/value_set_dereference.h
@@ -48,7 +48,7 @@ public:
 
   virtual ~value_set_dereferencet() { }
 
-  typedef enum { READ, WRITE } modet;
+  enum class modet { READ, WRITE };
 
   /*!
    * The method 'dereference' dereferences the

--- a/src/solvers/cvc/cvc_dec.cpp
+++ b/src/solvers/cvc/cvc_dec.cpp
@@ -209,13 +209,13 @@ decision_proceduret::resultt cvc_dect::read_cvcl_result()
           read_assert(in, line);
       }
 
-      return D_SATISFIABLE;
+      return resultt::D_SATISFIABLE;
     }
     else if(has_prefix(line, "Valid."))
-      return D_UNSATISFIABLE;
+      return resultt::D_UNSATISFIABLE;
   }
 
   error() << "Unexpected result from CVC-Lite" << eom;
 
-  return D_ERROR;
+  return resultt::D_ERROR;
 }

--- a/src/solvers/flattening/arrays.cpp
+++ b/src/solvers/flattening/arrays.cpp
@@ -441,7 +441,7 @@ void arrayst::add_array_Ackermann_constraints()
             equal_exprt values_equal(index_expr1, index_expr2);
 
             // add constraint
-            lazy_constraintt lazy(ARRAY_ACKERMANN,
+            lazy_constraintt lazy(lazy_typet::ARRAY_ACKERMANN,
               or_exprt(literal_exprt(!indices_equal_lit), values_equal));
             add_array_constraint(lazy, true); // added lazily
 
@@ -634,7 +634,7 @@ void arrayst::add_array_constraints(
       assert(index_expr1.type()==index_expr2.type());
 
       // add constraint
-      lazy_constraintt lazy(ARRAY_TYPECAST,
+      lazy_constraintt lazy(lazy_typet::ARRAY_TYPECAST,
         equal_exprt(index_expr1, index_expr2));
       add_array_constraint(lazy, false); // added immediately
     }
@@ -682,7 +682,8 @@ void arrayst::add_array_constraints_with(
       assert(false);
     }
 
-     lazy_constraintt lazy(ARRAY_WITH, equal_exprt(index_expr, value));
+    lazy_constraintt lazy(
+       lazy_typet::ARRAY_WITH, equal_exprt(index_expr, value));
      add_array_constraint(lazy, false); // added immediately
   }
 
@@ -722,7 +723,7 @@ void arrayst::add_array_constraints_with(
         equal_exprt equality_expr(index_expr1, index_expr2);
 
         // add constraint
-        lazy_constraintt lazy(ARRAY_WITH, or_exprt(equality_expr,
+        lazy_constraintt lazy(lazy_typet::ARRAY_WITH, or_exprt(equality_expr,
                                 literal_exprt(guard_lit)));
         add_array_constraint(lazy, false); // added immediately
 
@@ -862,7 +863,8 @@ void arrayst::add_array_constraints_array_of(
     assert(base_type_eq(index_expr.type(), expr.op0().type(), ns));
 
     // add constraint
-    lazy_constraintt lazy(ARRAY_OF, equal_exprt(index_expr, expr.op0()));
+    lazy_constraintt lazy(
+      lazy_typet::ARRAY_OF, equal_exprt(index_expr, expr.op0()));
     add_array_constraint(lazy, false); // added immediately
   }
 }
@@ -910,7 +912,7 @@ void arrayst::add_array_constraints_if(
     assert(index_expr1.type()==index_expr2.type());
 
     // add implication
-    lazy_constraintt lazy(ARRAY_IF,
+    lazy_constraintt lazy(lazy_typet::ARRAY_IF,
                             or_exprt(literal_exprt(!cond_lit),
                               equal_exprt(index_expr1, index_expr2)));
     add_array_constraint(lazy, false); // added immediately
@@ -939,8 +941,10 @@ void arrayst::add_array_constraints_if(
     assert(index_expr1.type()==index_expr2.type());
 
     // add implication
-    lazy_constraintt lazy(ARRAY_IF, or_exprt(literal_exprt(cond_lit),
-                          equal_exprt(index_expr1, index_expr2)));
+    lazy_constraintt lazy(
+      lazy_typet::ARRAY_IF,
+      or_exprt(literal_exprt(cond_lit),
+      equal_exprt(index_expr1, index_expr2)));
     add_array_constraint(lazy, false); // added immediately
 
 #if 0 // old code for adding, not significantly faster

--- a/src/solvers/flattening/arrays.h
+++ b/src/solvers/flattening/arrays.h
@@ -68,14 +68,15 @@ protected:
   index_mapt index_map;
 
   // adds array constraints lazily
-  typedef enum lazy_type
+  enum class lazy_typet
   {
     ARRAY_ACKERMANN,
     ARRAY_WITH,
     ARRAY_IF,
     ARRAY_OF,
     ARRAY_TYPECAST
-  } lazy_typet;
+  };
+
   struct lazy_constraintt
   {
     lazy_typet type;

--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -845,7 +845,7 @@ bool boolbvt::is_unbounded_array(const typet &type) const
   if(type.id()!=ID_array)
     return false;
 
-  if(unbounded_array==U_ALL)
+  if(unbounded_array==unbounded_arrayt::U_ALL)
     return true;
 
   const exprt &size=to_array_type(type).size();
@@ -854,7 +854,7 @@ bool boolbvt::is_unbounded_array(const typet &type) const
   if(to_integer(size, s))
     return true;
 
-  if(unbounded_array==U_AUTO)
+  if(unbounded_array==unbounded_arrayt::U_AUTO)
     if(s>1000) // magic number!
       return true;
 

--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -34,7 +34,7 @@ public:
     const namespacet &_ns,
     propt &_prop):
     arrayst(_ns, _prop),
-    unbounded_array(U_NONE),
+    unbounded_array(unbounded_arrayt::U_NONE),
     boolbv_width(_ns),
     bv_utils(_prop),
     functions(*this),
@@ -71,7 +71,7 @@ public:
 
   using arrayst::literal;
 
-  typedef enum { U_NONE, U_ALL, U_AUTO } unbounded_arrayt;
+  enum class unbounded_arrayt { U_NONE, U_ALL, U_AUTO };
   unbounded_arrayt unbounded_array;
 
   mp_integer get_value(const bvt &bv)

--- a/src/solvers/flattening/boolbv_abs.cpp
+++ b/src/solvers/flattening/boolbv_abs.cpp
@@ -46,13 +46,13 @@ bvt boolbvt::convert_abs(const exprt &expr)
 
   bvtypet bvtype=get_bvtype(expr.type());
 
-  if(bvtype==IS_FIXED ||
-     bvtype==IS_SIGNED ||
-     bvtype==IS_UNSIGNED)
+  if(bvtype==bvtypet::IS_FIXED ||
+     bvtype==bvtypet::IS_SIGNED ||
+     bvtype==bvtypet::IS_UNSIGNED)
   {
     return bv_utils.absolute_value(op_bv);
   }
-  else if(bvtype==IS_FLOAT)
+  else if(bvtype==bvtypet::IS_FLOAT)
   {
     float_utilst float_utils(prop, to_floatbv_type(expr.type()));
     return float_utils.abs(op_bv);

--- a/src/solvers/flattening/boolbv_add_sub.cpp
+++ b/src/solvers/flattening/boolbv_add_sub.cpp
@@ -74,8 +74,8 @@ bvt boolbvt::convert_add_sub(const exprt &expr)
 
   bv_utilst::representationt rep=
     (arithmetic_type.id()==ID_signedbv ||
-     arithmetic_type.id()==ID_fixedbv)?bv_utilst::SIGNED:
-                                       bv_utilst::UNSIGNED;
+     arithmetic_type.id()==ID_fixedbv)?bv_utilst::representationt::SIGNED:
+                                       bv_utilst::representationt::UNSIGNED;
 
   for(exprt::operandst::const_iterator
       it=operands.begin()+1;

--- a/src/solvers/flattening/boolbv_bv_rel.cpp
+++ b/src/solvers/flattening/boolbv_bv_rel.cpp
@@ -44,7 +44,7 @@ literalt boolbvt::convert_bv_rel(const exprt &expr)
     if(bv0.size()==bv1.size() && !bv0.empty() &&
        bvtype0==bvtype1)
     {
-      if(bvtype0==IS_FLOAT)
+      if(bvtype0==bvtypet::IS_FLOAT)
       {
         float_utilst float_utils(prop, to_floatbv_type(op0.type()));
 
@@ -61,15 +61,16 @@ literalt boolbvt::convert_bv_rel(const exprt &expr)
       }
       else if((op0.type().id()==ID_range &&
                op1.type()==op0.type()) ||
-               bvtype0==IS_SIGNED ||
-               bvtype0==IS_UNSIGNED ||
-               bvtype0==IS_FIXED)
+               bvtype0==bvtypet::IS_SIGNED ||
+               bvtype0==bvtypet::IS_UNSIGNED ||
+               bvtype0==bvtypet::IS_FIXED)
       {
         literalt literal;
 
         bv_utilst::representationt rep=
-          ((bvtype0==IS_SIGNED) || (bvtype0==IS_FIXED))?bv_utilst::SIGNED:
-                                                        bv_utilst::UNSIGNED;
+          ((bvtype0==bvtypet::IS_SIGNED) || (bvtype0==bvtypet::IS_FIXED))?
+             bv_utilst::SIGNED:
+             bv_utilst::UNSIGNED;
 
         #if 1
 
@@ -95,8 +96,8 @@ literalt boolbvt::convert_bv_rel(const exprt &expr)
         return literal;
         #endif
       }
-      else if((bvtype0==IS_VERILOG_SIGNED ||
-               bvtype0==IS_VERILOG_UNSIGNED) &&
+      else if((bvtype0==bvtypet::IS_VERILOG_SIGNED ||
+               bvtype0==bvtypet::IS_VERILOG_UNSIGNED) &&
               op0.type()==op1.type())
       {
         // extract number bits

--- a/src/solvers/flattening/boolbv_bv_rel.cpp
+++ b/src/solvers/flattening/boolbv_bv_rel.cpp
@@ -69,8 +69,8 @@ literalt boolbvt::convert_bv_rel(const exprt &expr)
 
         bv_utilst::representationt rep=
           ((bvtype0==bvtypet::IS_SIGNED) || (bvtype0==bvtypet::IS_FIXED))?
-             bv_utilst::SIGNED:
-             bv_utilst::UNSIGNED;
+             bv_utilst::representationt::SIGNED:
+             bv_utilst::representationt::UNSIGNED;
 
         #if 1
 
@@ -112,7 +112,7 @@ literalt boolbvt::convert_bv_rel(const exprt &expr)
         for(std::size_t i=0; i<extract1.size(); i++)
           extract1[i]=bv1[i*2];
 
-        bv_utilst::representationt rep=bv_utilst::UNSIGNED;
+        bv_utilst::representationt rep=bv_utilst::representationt::UNSIGNED;
 
         // now compare
         return bv_utils.rel(extract0, expr.id(), extract1, rep);

--- a/src/solvers/flattening/boolbv_bv_rel.cpp
+++ b/src/solvers/flattening/boolbv_bv_rel.cpp
@@ -49,13 +49,13 @@ literalt boolbvt::convert_bv_rel(const exprt &expr)
         float_utilst float_utils(prop, to_floatbv_type(op0.type()));
 
         if(rel==ID_le)
-          return float_utils.relation(bv0, float_utilst::LE, bv1);
+          return float_utils.relation(bv0, float_utilst::relt::LE, bv1);
         else if(rel==ID_lt)
-          return float_utils.relation(bv0, float_utilst::LT, bv1);
+          return float_utils.relation(bv0, float_utilst::relt::LT, bv1);
         else if(rel==ID_ge)
-          return float_utils.relation(bv0, float_utilst::GE, bv1);
+          return float_utils.relation(bv0, float_utilst::relt::GE, bv1);
         else if(rel==ID_gt)
-          return float_utils.relation(bv0, float_utilst::GT, bv1);
+          return float_utils.relation(bv0, float_utilst::relt::GT, bv1);
         else
           return SUB::convert_rest(expr);
       }

--- a/src/solvers/flattening/boolbv_div.cpp
+++ b/src/solvers/flattening/boolbv_div.cpp
@@ -59,7 +59,7 @@ bvt boolbvt::convert_div(const div_exprt &expr)
     op0.insert(op0.begin(), zeros.begin(), zeros.end());
     op1=bv_utils.sign_extension(op1, op1.size()+fraction_bits);
 
-    bv_utils.divider(op0, op1, res, rem, bv_utilst::SIGNED);
+    bv_utils.divider(op0, op1, res, rem, bv_utilst::representationt::SIGNED);
 
     // cut it down again
     res.resize(width);
@@ -67,8 +67,8 @@ bvt boolbvt::convert_div(const div_exprt &expr)
   else
   {
     bv_utilst::representationt rep=
-      expr.type().id()==ID_signedbv?bv_utilst::SIGNED:
-                                   bv_utilst::UNSIGNED;
+      expr.type().id()==ID_signedbv?bv_utilst::representationt::SIGNED:
+                                    bv_utilst::representationt::UNSIGNED;
 
     bv_utils.divider(op0, op1, res, rem, rep);
   }

--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -119,7 +119,7 @@ exprt boolbvt::bv_get_rec(
 
   bvtypet bvtype=get_bvtype(type);
 
-  if(bvtype==IS_UNKNOWN)
+  if(bvtype==bvtypet::IS_UNKNOWN)
   {
     if(type.id()==ID_array)
     {
@@ -265,7 +265,7 @@ exprt boolbvt::bv_get_rec(
 
   switch(bvtype)
   {
-  case IS_UNKNOWN:
+  case bvtypet::IS_UNKNOWN:
     if(type.id()==ID_string)
     {
       mp_integer int_value=binary2integer(value, false);
@@ -279,7 +279,7 @@ exprt boolbvt::bv_get_rec(
     }
     break;
 
-  case IS_RANGE:
+  case bvtypet::IS_RANGE:
     {
       mp_integer int_value=binary2integer(value, false);
       mp_integer from=string2integer(type.get_string(ID_from));
@@ -291,7 +291,7 @@ exprt boolbvt::bv_get_rec(
     break;
 
   default:
-  case IS_C_ENUM:
+  case bvtypet::IS_C_ENUM:
     constant_exprt value_expr(type);
     value_expr.set_value(value);
     return value_expr;

--- a/src/solvers/flattening/boolbv_ieee_float_rel.cpp
+++ b/src/solvers/flattening/boolbv_ieee_float_rel.cpp
@@ -47,9 +47,9 @@ literalt boolbvt::convert_ieee_float_rel(const exprt &expr)
       float_utilst float_utils(prop, to_floatbv_type(op0.type()));
 
       if(rel==ID_ieee_float_equal)
-        return float_utils.relation(bv0, float_utilst::EQ, bv1);
+        return float_utils.relation(bv0, float_utilst::relt::EQ, bv1);
       else if(rel==ID_ieee_float_notequal)
-        return !float_utils.relation(bv0, float_utilst::EQ, bv1);
+        return !float_utils.relation(bv0, float_utilst::relt::EQ, bv1);
       else
         return SUB::convert_rest(expr);
     }

--- a/src/solvers/flattening/boolbv_ieee_float_rel.cpp
+++ b/src/solvers/flattening/boolbv_ieee_float_rel.cpp
@@ -42,7 +42,7 @@ literalt boolbvt::convert_ieee_float_rel(const exprt &expr)
     const bvt &bv1=convert_bv(op1);
 
     if(bv0.size()==bv1.size() && !bv0.empty() &&
-       bvtype0==IS_FLOAT && bvtype1==IS_FLOAT)
+       bvtype0==bvtypet::IS_FLOAT && bvtype1==bvtypet::IS_FLOAT)
     {
       float_utilst float_utils(prop, to_floatbv_type(op0.type()));
 

--- a/src/solvers/flattening/boolbv_map.h
+++ b/src/solvers/flattening/boolbv_map.h
@@ -42,7 +42,7 @@ public:
   class map_entryt
   {
   public:
-    map_entryt():width(0), bvtype(IS_UNKNOWN)
+    map_entryt():width(0), bvtype(bvtypet::IS_UNKNOWN)
     {
     }
 

--- a/src/solvers/flattening/boolbv_mod.cpp
+++ b/src/solvers/flattening/boolbv_mod.cpp
@@ -43,8 +43,8 @@ bvt boolbvt::convert_mod(const mod_exprt &expr)
     throw "mod got mixed-type operands";
 
   bv_utilst::representationt rep=
-    expr.type().id()==ID_signedbv?bv_utilst::SIGNED:
-                                  bv_utilst::UNSIGNED;
+    expr.type().id()==ID_signedbv?bv_utilst::representationt::SIGNED:
+                                  bv_utilst::representationt::UNSIGNED;
 
   const bvt &op0=convert_bv(expr.op0());
   const bvt &op1=convert_bv(expr.op1());

--- a/src/solvers/flattening/boolbv_mult.cpp
+++ b/src/solvers/flattening/boolbv_mult.cpp
@@ -84,8 +84,8 @@ bvt boolbvt::convert_mult(const exprt &expr)
       throw "multiplication with mixed types";
 
     bv_utilst::representationt rep=
-      expr.type().id()==ID_signedbv?bv_utilst::SIGNED:
-                                    bv_utilst::UNSIGNED;
+      expr.type().id()==ID_signedbv?bv_utilst::representationt::SIGNED:
+                                    bv_utilst::representationt::UNSIGNED;
 
     bv=convert_bv(op0);
 

--- a/src/solvers/flattening/boolbv_overflow.cpp
+++ b/src/solvers/flattening/boolbv_overflow.cpp
@@ -42,8 +42,8 @@ literalt boolbvt::convert_overflow(const exprt &expr)
       return SUB::convert_rest(expr);
 
     bv_utilst::representationt rep=
-      expr.op0().type().id()==ID_signedbv?bv_utilst::SIGNED:
-                                          bv_utilst::UNSIGNED;
+      expr.op0().type().id()==ID_signedbv?bv_utilst::representationt::SIGNED:
+                                          bv_utilst::representationt::UNSIGNED;
 
     return expr.id()==ID_overflow_minus?
       bv_utils.overflow_sub(bv0, bv1, rep):
@@ -65,8 +65,8 @@ literalt boolbvt::convert_overflow(const exprt &expr)
       throw "operand size mismatch on overflow-*";
 
     bv_utilst::representationt rep=
-      operands[0].type().id()==ID_signedbv?bv_utilst::SIGNED:
-                                           bv_utilst::UNSIGNED;
+      operands[0].type().id()==ID_signedbv?bv_utilst::representationt::SIGNED:
+                                           bv_utilst::representationt::UNSIGNED;
 
     if(operands[0].type()!=operands[1].type())
       throw "operand type mismatch on overflow-*";
@@ -81,7 +81,7 @@ literalt boolbvt::convert_overflow(const exprt &expr)
 
     bvt result=bv_utils.multiplier(bv0, bv1, rep);
 
-    if(rep==bv_utilst::UNSIGNED)
+    if(rep==bv_utilst::representationt::UNSIGNED)
     {
       bvt bv_overflow;
       bv_overflow.reserve(old_size);

--- a/src/solvers/flattening/boolbv_power.cpp
+++ b/src/solvers/flattening/boolbv_power.cpp
@@ -40,7 +40,7 @@ bvt boolbvt::convert_power(const binary_exprt &expr)
       bv_utils.equal(op0, bv_utils.build_constant(2, op0.size()));
 
     bvt one=bv_utils.build_constant(1, width);
-    bvt shift=bv_utils.shift(one, bv_utilst::LEFT, op1);
+    bvt shift=bv_utils.shift(one, bv_utilst::shiftt::LEFT, op1);
 
     bvt nondet=prop.new_variables(width);
 

--- a/src/solvers/flattening/boolbv_shift.cpp
+++ b/src/solvers/flattening/boolbv_shift.cpp
@@ -53,11 +53,11 @@ bvt boolbvt::convert_shift(const binary_exprt &expr)
   bv_utilst::shiftt shift;
 
   if(expr.id()==ID_shl)
-    shift=bv_utilst::LEFT;
+    shift=bv_utilst::shiftt::LEFT;
   else if(expr.id()==ID_ashr)
-    shift=bv_utilst::ARIGHT;
+    shift=bv_utilst::shiftt::ARIGHT;
   else if(expr.id()==ID_lshr)
-    shift=bv_utilst::LRIGHT;
+    shift=bv_utilst::shiftt::LRIGHT;
   else
     throw "unexpected shift operator";
 

--- a/src/solvers/flattening/boolbv_type.cpp
+++ b/src/solvers/flattening/boolbv_type.cpp
@@ -23,29 +23,29 @@ Function: get_bvtype
 bvtypet get_bvtype(const typet &type)
 {
   if(type.id()==ID_signedbv)
-    return IS_SIGNED;
+    return bvtypet::IS_SIGNED;
   else if(type.id()==ID_unsignedbv)
-    return IS_UNSIGNED;
+    return bvtypet::IS_UNSIGNED;
   else if(type.id()==ID_c_bool)
-    return IS_C_BOOL;
+    return bvtypet::IS_C_BOOL;
   else if(type.id()==ID_c_enum ||
           type.id()==ID_c_enum_tag ||
           type.id()==ID_incomplete_c_enum)
-    return IS_C_ENUM;
+    return bvtypet::IS_C_ENUM;
   else if(type.id()==ID_floatbv)
-    return IS_FLOAT;
+    return bvtypet::IS_FLOAT;
   else if(type.id()==ID_fixedbv)
-    return IS_FIXED;
+    return bvtypet::IS_FIXED;
   else if(type.id()==ID_bv)
-    return IS_BV;
+    return bvtypet::IS_BV;
   else if(type.id()==ID_verilog_signedbv)
-    return IS_VERILOG_SIGNED;
+    return bvtypet::IS_VERILOG_SIGNED;
   else if(type.id()==ID_verilog_unsignedbv)
-    return IS_VERILOG_UNSIGNED;
+    return bvtypet::IS_VERILOG_UNSIGNED;
   else if(type.id()==ID_range)
-    return IS_RANGE;
+    return bvtypet::IS_RANGE;
   else if(type.id()==ID_c_bit_field)
-    return IS_C_BIT_FIELD;
+    return bvtypet::IS_C_BIT_FIELD;
 
-  return IS_UNKNOWN;
+  return bvtypet::IS_UNKNOWN;
 }

--- a/src/solvers/flattening/boolbv_type.h
+++ b/src/solvers/flattening/boolbv_type.h
@@ -12,12 +12,12 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/type.h>
 
 // new stuff
-typedef enum
+enum class bvtypet
 {
   IS_BV, IS_SIGNED, IS_UNSIGNED, IS_FLOAT, IS_FIXED, IS_C_BOOL,
   IS_VERILOG_SIGNED, IS_VERILOG_UNSIGNED, IS_RANGE, IS_UNKNOWN,
   IS_C_ENUM, IS_C_BIT_FIELD
-} bvtypet;
+};
 
 bvtypet get_bvtype(const typet &type);
 

--- a/src/solvers/flattening/boolbv_typecast.cpp
+++ b/src/solvers/flattening/boolbv_typecast.cpp
@@ -62,7 +62,7 @@ bool boolbvt::type_conversion(
   bvtypet dest_bvtype=get_bvtype(dest_type);
   bvtypet src_bvtype=get_bvtype(src_type);
 
-  if(src_bvtype==IS_C_BIT_FIELD)
+  if(src_bvtype==bvtypet::IS_C_BIT_FIELD)
     return
       type_conversion(
         c_bit_field_replacement_type(to_c_bit_field_type(src_type), ns),
@@ -70,7 +70,7 @@ bool boolbvt::type_conversion(
         dest_type,
         dest);
 
-  if(dest_bvtype==IS_C_BIT_FIELD)
+  if(dest_bvtype==bvtypet::IS_C_BIT_FIELD)
     return
       type_conversion(
         src_type,
@@ -144,10 +144,10 @@ bool boolbvt::type_conversion(
 
   switch(dest_bvtype)
   {
-  case IS_RANGE:
-    if(src_bvtype==IS_UNSIGNED ||
-       src_bvtype==IS_SIGNED ||
-       src_bvtype==IS_C_BOOL)
+  case bvtypet::IS_RANGE:
+    if(src_bvtype==bvtypet::IS_UNSIGNED ||
+       src_bvtype==bvtypet::IS_SIGNED ||
+       src_bvtype==bvtypet::IS_C_BOOL)
     {
       mp_integer dest_from=to_range_type(dest_type).get_from();
 
@@ -161,7 +161,7 @@ bool boolbvt::type_conversion(
         return false;
       }
     }
-    else if(src_bvtype==IS_RANGE) // range to range
+    else if(src_bvtype==bvtypet::IS_RANGE) // range to range
     {
       mp_integer src_from=to_range_type(src_type).get_from();
       mp_integer dest_from=to_range_type(dest_type).get_from();
@@ -186,30 +186,30 @@ bool boolbvt::type_conversion(
     }
     break;
 
-  case IS_FLOAT: // to float
+  case bvtypet::IS_FLOAT: // to float
     {
       float_utilst float_utils(prop);
 
       switch(src_bvtype)
       {
-      case IS_FLOAT: // float to float
+      case bvtypet::IS_FLOAT: // float to float
         // we don't have a rounding mode here,
         // which is why we refuse.
         break;
 
-      case IS_SIGNED: // signed to float
-      case IS_C_ENUM:
+      case bvtypet::IS_SIGNED: // signed to float
+      case bvtypet::IS_C_ENUM:
         float_utils.spec=ieee_float_spect(to_floatbv_type(dest_type));
         dest=float_utils.from_signed_integer(src);
         return false;
 
-      case IS_UNSIGNED: // unsigned to float
-      case IS_C_BOOL: // _Bool to float
+      case bvtypet::IS_UNSIGNED: // unsigned to float
+      case bvtypet::IS_C_BOOL: // _Bool to float
         float_utils.spec=ieee_float_spect(to_floatbv_type(dest_type));
         dest=float_utils.from_unsigned_integer(src);
         return false;
 
-      case IS_BV:
+      case bvtypet::IS_BV:
         assert(src_width==dest_width);
         dest=src;
         return false;
@@ -236,8 +236,8 @@ bool boolbvt::type_conversion(
     }
     break;
 
-  case IS_FIXED:
-    if(src_bvtype==IS_FIXED)
+  case bvtypet::IS_FIXED:
+    if(src_bvtype==bvtypet::IS_FIXED)
     {
       // fixed to fixed
 
@@ -278,16 +278,16 @@ bool boolbvt::type_conversion(
 
       return false;
     }
-    else if(src_bvtype==IS_BV)
+    else if(src_bvtype==bvtypet::IS_BV)
     {
       assert(src_width==dest_width);
       dest=src;
       return false;
     }
-    else if(src_bvtype==IS_UNSIGNED ||
-            src_bvtype==IS_SIGNED ||
-            src_bvtype==IS_C_BOOL ||
-            src_bvtype==IS_C_ENUM)
+    else if(src_bvtype==bvtypet::IS_UNSIGNED ||
+            src_bvtype==bvtypet::IS_SIGNED ||
+            src_bvtype==bvtypet::IS_C_BOOL ||
+            src_bvtype==bvtypet::IS_C_ENUM)
     {
       // integer to fixed
 
@@ -305,7 +305,7 @@ bool boolbvt::type_conversion(
           l=src[i];
         else
         {
-          if(src_bvtype==IS_SIGNED || src_bvtype==IS_C_ENUM)
+          if(src_bvtype==bvtypet::IS_SIGNED || src_bvtype==bvtypet::IS_C_ENUM)
             l=src[src_width-1]; // sign extension
           else
             l=const_literal(false); // zero extension
@@ -336,17 +336,17 @@ bool boolbvt::type_conversion(
     }
     break;
 
-  case IS_UNSIGNED:
-  case IS_SIGNED:
-  case IS_C_ENUM:
+  case bvtypet::IS_UNSIGNED:
+  case bvtypet::IS_SIGNED:
+  case bvtypet::IS_C_ENUM:
     switch(src_bvtype)
     {
-    case IS_FLOAT: // float to integer
+    case bvtypet::IS_FLOAT: // float to integer
       // we don't have a rounding mode here,
       // which is why we refuse.
       break;
 
-    case IS_FIXED: // fixed to integer
+    case bvtypet::IS_FIXED: // fixed to integer
       {
         std::size_t op_fraction_bits=
           to_fixedbv_type(src_type).get_fraction_bits();
@@ -357,7 +357,7 @@ bool boolbvt::type_conversion(
             dest.push_back(src[i+op_fraction_bits]);
           else
           {
-            if(dest_bvtype==IS_SIGNED)
+            if(dest_bvtype==bvtypet::IS_SIGNED)
               dest.push_back(src[src_width-1]); // sign extension
             else
               dest.push_back(const_literal(false)); // zero extension
@@ -377,17 +377,17 @@ bool boolbvt::type_conversion(
         return false;
       }
 
-    case IS_UNSIGNED: // integer to integer
-    case IS_SIGNED:
-    case IS_C_ENUM:
-    case IS_C_BOOL:
+    case bvtypet::IS_UNSIGNED: // integer to integer
+    case bvtypet::IS_SIGNED:
+    case bvtypet::IS_C_ENUM:
+    case bvtypet::IS_C_BOOL:
       {
         // We do sign extension for any source type
         // that is signed, independently of the
         // destination type.
         // E.g., ((short)(ulong)(short)-1)==-1
         bool sign_extension=
-          src_bvtype==IS_SIGNED || src_bvtype==IS_C_ENUM;
+          src_bvtype==bvtypet::IS_SIGNED || src_bvtype==bvtypet::IS_C_ENUM;
 
         for(std::size_t i=0; i<dest_width; i++)
         {
@@ -401,8 +401,8 @@ bool boolbvt::type_conversion(
 
         return false;
       }
-
-    case IS_VERILOG_UNSIGNED: // verilog_unsignedbv to signed/unsigned/enum
+    // verilog_unsignedbv to signed/unsigned/enum
+    case bvtypet::IS_VERILOG_UNSIGNED:
       {
         for(std::size_t i=0; i<dest_width; i++)
         {
@@ -418,7 +418,7 @@ bool boolbvt::type_conversion(
       }
       break;
 
-    case IS_VERILOG_SIGNED: // verilog_signedbv to signed/unsigned/enum
+    case bvtypet::IS_VERILOG_SIGNED: // verilog_signedbv to signed/unsigned/enum
       {
         for(std::size_t i=0; i<dest_width; i++)
         {
@@ -454,9 +454,9 @@ bool boolbvt::type_conversion(
     }
     break;
 
-  case IS_VERILOG_UNSIGNED:
-    if(src_bvtype==IS_UNSIGNED ||
-       src_bvtype==IS_C_BOOL ||
+  case bvtypet::IS_VERILOG_UNSIGNED:
+    if(src_bvtype==bvtypet::IS_UNSIGNED ||
+       src_bvtype==bvtypet::IS_C_BOOL ||
        src_type.id()==ID_bool)
     {
       for(std::size_t i=0, j=0; i<dest_width; i+=2, j++)
@@ -471,7 +471,7 @@ bool boolbvt::type_conversion(
 
       return false;
     }
-    else if(src_bvtype==IS_SIGNED)
+    else if(src_bvtype==bvtypet::IS_SIGNED)
     {
       for(std::size_t i=0, j=0; i<dest_width; i+=2, j++)
       {
@@ -485,7 +485,7 @@ bool boolbvt::type_conversion(
 
       return false;
     }
-    else if(src_bvtype==IS_VERILOG_UNSIGNED)
+    else if(src_bvtype==bvtypet::IS_VERILOG_UNSIGNED)
     {
       // verilog_unsignedbv to verilog_unsignedbv
       dest=src;
@@ -505,20 +505,20 @@ bool boolbvt::type_conversion(
     }
     break;
 
-  case IS_BV:
+  case bvtypet::IS_BV:
     assert(src_width==dest_width);
     dest=src;
     return false;
 
-  case IS_C_BOOL:
+  case bvtypet::IS_C_BOOL:
     dest.resize(dest_width, const_literal(false));
 
-    if(src_bvtype==IS_FLOAT)
+    if(src_bvtype==bvtypet::IS_FLOAT)
     {
       float_utilst float_utils(prop, to_floatbv_type(src_type));
       dest[0]=!float_utils.is_zero(src);
     }
-    else if(src_bvtype==IS_C_BOOL)
+    else if(src_bvtype==bvtypet::IS_C_BOOL)
       dest[0]=src[0];
     else
       dest[0]=!bv_utils.is_zero(src);

--- a/src/solvers/flattening/boolbv_unary_minus.cpp
+++ b/src/solvers/flattening/boolbv_unary_minus.cpp
@@ -52,7 +52,7 @@ bvt boolbvt::convert_unary_minus(const unary_exprt &expr)
   if(op_width==0 || op_width!=width)
     return conversion_failed(expr);
 
-  if(bvtype==IS_UNKNOWN &&
+  if(bvtype==bvtypet::IS_UNKNOWN &&
      (type.id()==ID_vector || type.id()==ID_complex))
   {
     const typet &subtype=ns.follow(type.subtype());
@@ -98,21 +98,21 @@ bvt boolbvt::convert_unary_minus(const unary_exprt &expr)
 
     return bv;
   }
-  else if(bvtype==IS_FIXED && op_bvtype==IS_FIXED)
+  else if(bvtype==bvtypet::IS_FIXED && op_bvtype==bvtypet::IS_FIXED)
   {
     if(no_overflow)
       return bv_utils.negate_no_overflow(op_bv);
     else
       return bv_utils.negate(op_bv);
   }
-  else if(bvtype==IS_FLOAT && op_bvtype==IS_FLOAT)
+  else if(bvtype==bvtypet::IS_FLOAT && op_bvtype==bvtypet::IS_FLOAT)
   {
     assert(!no_overflow);
     float_utilst float_utils(prop, to_floatbv_type(expr.type()));
     return float_utils.negate(op_bv);
   }
-  else if((op_bvtype==IS_SIGNED || op_bvtype==IS_UNSIGNED) &&
-          (bvtype==IS_SIGNED || bvtype==IS_UNSIGNED))
+  else if((op_bvtype==bvtypet::IS_SIGNED || op_bvtype==bvtypet::IS_UNSIGNED) &&
+          (bvtype==bvtypet::IS_SIGNED || bvtype==bvtypet::IS_UNSIGNED))
   {
     if(no_overflow)
       prop.l_set_to(bv_utils.overflow_negate(op_bv), false);

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -92,7 +92,8 @@ literalt bv_pointerst::convert_rest(const exprt &expr)
       const bvt &bv0=convert_bv(operands[0]);
       const bvt &bv1=convert_bv(operands[1]);
 
-      return bv_utils.rel(bv0, expr.id(), bv1, bv_utilst::UNSIGNED);
+      return bv_utils.rel(
+        bv0, expr.id(), bv1, bv_utilst::representationt::UNSIGNED);
     }
   }
 
@@ -399,8 +400,8 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
       }
 
       bv_utilst::representationt rep=
-        it->type().id()==ID_signedbv?bv_utilst::SIGNED:
-                                     bv_utilst::UNSIGNED;
+        it->type().id()==ID_signedbv?bv_utilst::representationt::SIGNED:
+                                     bv_utilst::representationt::UNSIGNED;
 
       bvt op=convert_bv(*it);
 
@@ -521,7 +522,8 @@ bvt bv_pointerst::convert_bitvector(const exprt &expr)
     {
       bvt element_size_bv=
         bv_utils.build_constant(element_size, bv.size());
-      bv=bv_utils.divider(bv, element_size_bv, bv_utilst::SIGNED);
+      bv=bv_utils.divider(
+        bv, element_size_bv, bv_utilst::representationt::SIGNED);
     }
 
     return bv;
@@ -738,8 +740,8 @@ void bv_pointerst::offset_arithmetic(
   bvt bv_index=convert_bv(index);
 
   bv_utilst::representationt rep=
-    index.type().id()==ID_signedbv?bv_utilst::SIGNED:
-                                   bv_utilst::UNSIGNED;
+    index.type().id()==ID_signedbv?bv_utilst::representationt::SIGNED:
+                                   bv_utilst::representationt::UNSIGNED;
 
   bv_index=bv_utils.extension(bv_index, offset_bits, rep);
 

--- a/src/solvers/flattening/bv_utils.cpp
+++ b/src/solvers/flattening/bv_utils.cpp
@@ -225,7 +225,7 @@ bvt bv_utilst::extension(
   assert(old_size!=0);
 
   literalt extend_with=
-    (rep==SIGNED && !bv.empty())?bv[old_size-1]:
+    (rep==representationt::SIGNED && !bv.empty())?bv[old_size-1]:
     const_literal(false);
 
   for(std::size_t i=old_size; i<new_size; i++)
@@ -565,7 +565,7 @@ Function: bv_utilst::overflow_add
 literalt bv_utilst::overflow_add(
   const bvt &op0, const bvt &op1, representationt rep)
 {
-  if(rep==SIGNED)
+  if(rep==representationt::SIGNED)
   {
     // An overflow occurs if the signs of the two operands are the same
     // and the sign of the sum is the opposite.
@@ -577,7 +577,7 @@ literalt bv_utilst::overflow_add(
     return
       prop.land(sign_the_same, prop.lxor(result[result.size()-1], old_sign));
   }
-  else if(rep==UNSIGNED)
+  else if(rep==representationt::UNSIGNED)
   {
     // overflow is simply carry-out
     return carry_out(op0, op1, const_literal(false));
@@ -601,7 +601,7 @@ Function: bv_utilst::overflow_sub
 literalt bv_utilst::overflow_sub(
   const bvt &op0, const bvt &op1, representationt rep)
 {
-  if(rep==SIGNED)
+  if(rep==representationt::SIGNED)
   {
     // We special-case x-INT_MIN, which is >=0 if
     // x is negative, always representable, and
@@ -612,9 +612,9 @@ literalt bv_utilst::overflow_sub(
     return
       prop.lselect(op1_is_int_min,
         !op0_is_negative,
-        overflow_add(op0, negate(op1), SIGNED));
+        overflow_add(op0, negate(op1), representationt::SIGNED));
   }
-  else if(rep==UNSIGNED)
+  else if(rep==representationt::UNSIGNED)
   {
     // overflow is simply _negated_ carry-out
     return !carry_out(op0, inverted(op1), const_literal(true));
@@ -643,7 +643,7 @@ void bv_utilst::adder_no_overflow(
 {
   const bvt tmp_op=subtract?inverted(op):op;
 
-  if(rep==SIGNED)
+  if(rep==representationt::SIGNED)
   {
     // an overflow occurs if the signs of the two operands are the same
     // and the sign of the sum is the opposite
@@ -659,7 +659,7 @@ void bv_utilst::adder_no_overflow(
     prop.l_set_to_false(
       prop.land(sign_the_same, prop.lxor(sum[sum.size()-1], old_sign)));
   }
-  else if(rep==UNSIGNED)
+  else if(rep==representationt::UNSIGNED)
   {
     literalt carry_out;
     adder(sum, tmp_op, const_literal(subtract), carry_out);
@@ -746,15 +746,15 @@ bvt bv_utilst::shift(const bvt &src, const shiftt s, std::size_t dist)
 
     switch(s)
     {
-    case LEFT:
+    case shiftt::LEFT:
       l=(dist<=i?src[i-dist]:const_literal(false));
       break;
 
-    case ARIGHT:
+    case shiftt::ARIGHT:
       l=(i+dist<src.size()?src[i+dist]:src[src.size()-1]); // sign bit
       break;
 
-    case LRIGHT:
+    case shiftt::LRIGHT:
       l=(i+dist<src.size()?src[i+dist]:const_literal(false));
       break;
 
@@ -1233,8 +1233,8 @@ bvt bv_utilst::multiplier(
 {
   switch(rep)
   {
-  case SIGNED: return signed_multiplier(op0, op1);
-  case UNSIGNED: return unsigned_multiplier(op0, op1);
+  case representationt::SIGNED: return signed_multiplier(op0, op1);
+  case representationt::UNSIGNED: return unsigned_multiplier(op0, op1);
   default: assert(false);
   }
 }
@@ -1258,8 +1258,10 @@ bvt bv_utilst::multiplier_no_overflow(
 {
   switch(rep)
   {
-  case SIGNED: return signed_multiplier_no_overflow(op0, op1);
-  case UNSIGNED: return unsigned_multiplier_no_overflow(op0, op1);
+  case representationt::SIGNED:
+    return signed_multiplier_no_overflow(op0, op1);
+  case representationt::UNSIGNED:
+    return unsigned_multiplier_no_overflow(op0, op1);
   default: assert(false);
   }
 }
@@ -1334,8 +1336,10 @@ void bv_utilst::divider(
 
   switch(rep)
   {
-  case SIGNED: signed_divider(op0, op1, result, remainer); break;
-  case UNSIGNED: unsigned_divider(op0, op1, result, remainer); break;
+  case representationt::SIGNED:
+    signed_divider(op0, op1, result, remainer); break;
+  case representationt::UNSIGNED:
+    unsigned_divider(op0, op1, result, remainer); break;
   default: assert(false);
   }
 }
@@ -1427,12 +1431,14 @@ void bv_utilst::unsigned_divider(
   // op1!=0 => rem < op1
 
   prop.l_set_to_true(
-    prop.limplies(is_not_zero, lt_or_le(false, rem, op1, UNSIGNED)));
+    prop.limplies(
+      is_not_zero, lt_or_le(false, rem, op1, representationt::UNSIGNED)));
 
   // op1!=0 => res <= op0
 
   prop.l_set_to_true(
-    prop.limplies(is_not_zero, lt_or_le(true, res, op0, UNSIGNED)));
+    prop.limplies(
+      is_not_zero, lt_or_le(true, res, op0, representationt::UNSIGNED)));
 }
 
 
@@ -1753,9 +1759,9 @@ literalt bv_utilst::lt_or_le(
 
     literalt result;
 
-    if(rep==SIGNED)
+    if(rep==representationt::SIGNED)
       result=prop.lxor(prop.lequal(top0, top1), carry);
-    else if(rep==UNSIGNED)
+    else if(rep==representationt::UNSIGNED)
       result=!carry;
     else
       assert(false);
@@ -1807,7 +1813,7 @@ literalt bv_utilst::signed_less_than(
   const bvt &bv0,
   const bvt &bv1)
 {
-  return lt_or_le(false, bv0, bv1, SIGNED);
+  return lt_or_le(false, bv0, bv1, representationt::SIGNED);
 }
 
 /*******************************************************************\

--- a/src/solvers/flattening/bv_utils.h
+++ b/src/solvers/flattening/bv_utils.h
@@ -27,7 +27,7 @@ class bv_utilst
 public:
   explicit bv_utilst(propt &_prop):prop(_prop) { }
 
-  typedef enum { SIGNED, UNSIGNED } representationt;
+  enum class representationt { SIGNED, UNSIGNED };
 
   bvt build_constant(const mp_integer &i, std::size_t width);
 
@@ -67,7 +67,7 @@ public:
   literalt overflow_sub(const bvt &op0, const bvt &op1, representationt rep);
   literalt carry_out(const bvt &op0, const bvt &op1, literalt carry_in);
 
-  typedef enum { LEFT, LRIGHT, ARIGHT } shiftt;
+  enum class shiftt { LEFT, LRIGHT, ARIGHT };
   bvt shift(const bvt &op, const shiftt shift, std::size_t distance);
   bvt shift(const bvt &op, const shiftt shift, const bvt &distance);
 
@@ -173,12 +173,12 @@ public:
 
   bvt sign_extension(const bvt &bv, std::size_t new_size)
   {
-    return extension(bv, new_size, SIGNED);
+    return extension(bv, new_size, representationt::SIGNED);
   }
 
   bvt zero_extension(const bvt &bv, std::size_t new_size)
   {
-    return extension(bv, new_size, UNSIGNED);
+    return extension(bv, new_size, representationt::UNSIGNED);
   }
 
   bvt zeros(std::size_t new_size) const

--- a/src/solvers/floatbv/float_bv.cpp
+++ b/src/solvers/floatbv/float_bv.cpp
@@ -94,13 +94,13 @@ exprt float_bvt::convert(const exprt &expr)
   else if(expr.id()==ID_isnormal)
     return isnormal(expr.op0(), get_spec(expr.op0()));
   else if(expr.id()==ID_lt)
-    return relation(expr.op0(), LT, expr.op1(), get_spec(expr.op0()));
+    return relation(expr.op0(), relt::LT, expr.op1(), get_spec(expr.op0()));
   else if(expr.id()==ID_gt)
-    return relation(expr.op0(), GT, expr.op1(), get_spec(expr.op0()));
+    return relation(expr.op0(), relt::GT, expr.op1(), get_spec(expr.op0()));
   else if(expr.id()==ID_le)
-    return relation(expr.op0(), LE, expr.op1(), get_spec(expr.op0()));
+    return relation(expr.op0(), relt::LE, expr.op1(), get_spec(expr.op0()));
   else if(expr.id()==ID_ge)
-    return relation(expr.op0(), GE, expr.op1(), get_spec(expr.op0()));
+    return relation(expr.op0(), relt::GE, expr.op1(), get_spec(expr.op0()));
   else if(expr.id()==ID_sign)
     return sign_bit(expr.op0());
 
@@ -1034,12 +1034,12 @@ exprt float_bvt::relation(
   const exprt &src2,
   const ieee_float_spect &spec)
 {
-  if(rel==GT)
-    return relation(src2, LT, src1, spec); // swapped
-  else if(rel==GE)
-    return relation(src2, LE, src1, spec); // swapped
+  if(rel==relt::GT)
+    return relation(src2, relt::LT, src1, spec); // swapped
+  else if(rel==relt::GE)
+    return relation(src2, relt::LE, src1, spec); // swapped
 
-  assert(rel==EQ || rel==LT || rel==LE);
+  assert(rel==relt::EQ || rel==relt::LT || rel==relt::LE);
 
   // special cases: -0 and 0 are equal
   exprt is_zero1=is_zero(src1, spec);
@@ -1051,7 +1051,7 @@ exprt float_bvt::relation(
   exprt isnan2=isnan(src2, spec);
   exprt nan=or_exprt(isnan1, isnan2);
 
-  if(rel==LT || rel==LE)
+  if(rel==relt::LT || rel==relt::LE)
   {
     exprt bitwise_equal=equal_exprt(src1, src2);
 
@@ -1081,7 +1081,7 @@ exprt float_bvt::relation(
         sign_bit(src1),
         less_than2);
 
-    if(rel==LT)
+    if(rel==relt::LT)
     {
       exprt and_bv(ID_and, bool_typet());
       and_bv.copy_to_operands(less_than3);
@@ -1092,7 +1092,7 @@ exprt float_bvt::relation(
 
       return and_bv;
     }
-    else if(rel==LE)
+    else if(rel==relt::LE)
     {
       exprt or_bv(ID_or, bool_typet());
       or_bv.copy_to_operands(less_than3);
@@ -1104,7 +1104,7 @@ exprt float_bvt::relation(
     else
       assert(false);
   }
-  else if(rel==EQ)
+  else if(rel==relt::EQ)
   {
     exprt bitwise_equal=equal_exprt(src1, src2);
 

--- a/src/solvers/floatbv/float_bv.h
+++ b/src/solvers/floatbv/float_bv.h
@@ -93,7 +93,7 @@ public:
     const ieee_float_spect &dest_spec);
 
   // relations
-  typedef enum { LT, LE, EQ, GT, GE } relt;
+  enum class relt { LT, LE, EQ, GT, GE };
   exprt relation(
     const exprt &,
     relt rel,

--- a/src/solvers/floatbv/float_utils.cpp
+++ b/src/solvers/floatbv/float_utils.cpp
@@ -177,7 +177,8 @@ bvt float_utilst::to_integer(
     bvt offset=bv_utils.build_constant(fraction.size()-1,
                                        unpacked.exponent.size());
     bvt distance=bv_utils.sub(offset, unpacked.exponent);
-    bvt shift_result=bv_utils.shift(fraction, bv_utilst::LRIGHT, distance);
+    bvt shift_result=bv_utils.shift(
+      fraction, bv_utilst::shiftt::LRIGHT, distance);
 
     // if the exponent is negative, we have zero anyways
     bvt result=shift_result;
@@ -1153,7 +1154,7 @@ void float_utilst::normalization_shift(bvt &fraction, bvt &exponent)
     // If so, shift the zeros out left by 'distance'.
     // Otherwise, leave as is.
     const bvt shifted=
-      bv_utils.shift(fraction, bv_utilst::LEFT, distance);
+      bv_utils.shift(fraction, bv_utilst::shiftt::LEFT, distance);
 
     fraction=
       bv_utils.select(prefix_is_zero, shifted, fraction);
@@ -1769,7 +1770,7 @@ bvt float_utilst::sticky_right_shift(
   {
     if(dist[stage]!=const_literal(false))
     {
-      bvt tmp=bv_utils.shift(result, bv_utilst::LRIGHT, d);
+      bvt tmp=bv_utils.shift(result, bv_utilst::shiftt::LRIGHT, d);
 
       bvt lost_bits;
 

--- a/src/solvers/floatbv/float_utils.cpp
+++ b/src/solvers/floatbv/float_utils.cpp
@@ -789,12 +789,12 @@ literalt float_utilst::relation(
   relt rel,
   const bvt &src2)
 {
-  if(rel==GT)
-    return relation(src2, LT, src1); // swapped
-  else if(rel==GE)
-    return relation(src2, LE, src1); // swapped
+  if(rel==relt::GT)
+    return relation(src2, relt::LT, src1); // swapped
+  else if(rel==relt::GE)
+    return relation(src2, relt::LE, src1); // swapped
 
-  assert(rel==EQ || rel==LT || rel==LE);
+  assert(rel==relt::EQ || rel==relt::LT || rel==relt::LE);
 
   // special cases: -0 and 0 are equal
   literalt is_zero1=is_zero(src1);
@@ -806,7 +806,7 @@ literalt float_utilst::relation(
   literalt is_NaN2=is_NaN(src2);
   literalt NaN=prop.lor(is_NaN1, is_NaN2);
 
-  if(rel==LT || rel==LE)
+  if(rel==relt::LT || rel==relt::LE)
   {
     literalt bitwise_equal=bv_utils.equal(src1, src2);
 
@@ -829,7 +829,7 @@ literalt float_utilst::relation(
         sign_bit(src1),
         less_than2);
 
-    if(rel==LT)
+    if(rel==relt::LT)
     {
       bvt and_bv;
       and_bv.push_back(less_than3);
@@ -839,7 +839,7 @@ literalt float_utilst::relation(
 
       return prop.land(and_bv);
     }
-    else if(rel==LE)
+    else if(rel==relt::LE)
     {
       bvt or_bv;
       or_bv.push_back(less_than3);
@@ -851,7 +851,7 @@ literalt float_utilst::relation(
     else
       assert(false);
   }
-  else if(rel==EQ)
+  else if(rel==relt::EQ)
   {
     literalt bitwise_equal=bv_utils.equal(src1, src2);
 

--- a/src/solvers/floatbv/float_utils.h
+++ b/src/solvers/floatbv/float_utils.h
@@ -132,7 +132,7 @@ public:
   bvt conversion(const bvt &src, const ieee_float_spect &dest_spec);
 
   // relations
-  typedef enum { LT, LE, EQ, GT, GE } relt;
+  enum class relt { LT, LE, EQ, GT, GE };
   literalt relation(const bvt &src1, relt rel, const bvt &src2);
 
   // constants

--- a/src/solvers/prop/aig_prop.h
+++ b/src/solvers/prop/aig_prop.h
@@ -57,7 +57,7 @@ public:
   { assert(0); return tvt::unknown(); }
 
   resultt prop_solve() override
-  { assert(0); return P_ERROR; }
+  { assert(0); return resultt::P_ERROR; }
 
 protected:
   aigt &dest;

--- a/src/solvers/prop/cover_goals.cpp
+++ b/src/solvers/prop/cover_goals.cpp
@@ -142,10 +142,10 @@ decision_proceduret::resultt cover_goalst::operator()()
 
     switch(dec_result)
     {
-    case decision_proceduret::D_UNSATISFIABLE: // DONE
+    case decision_proceduret::resultt::D_UNSATISFIABLE: // DONE
       return dec_result;
 
-    case decision_proceduret::D_SATISFIABLE:
+    case decision_proceduret::resultt::D_SATISFIABLE:
       // mark the goals we got, and notify observers
       mark();
       break;
@@ -155,8 +155,8 @@ decision_proceduret::resultt cover_goalst::operator()()
       return dec_result;
     }
   }
-  while(dec_result==decision_proceduret::D_SATISFIABLE &&
+  while(dec_result==decision_proceduret::resultt::D_SATISFIABLE &&
         number_covered()<size());
 
-  return decision_proceduret::D_SATISFIABLE;
+  return decision_proceduret::resultt::D_SATISFIABLE;
 }

--- a/src/solvers/prop/minimize.cpp
+++ b/src/solvers/prop/minimize.cpp
@@ -155,7 +155,7 @@ void prop_minimizet::operator()()
       literalt c=constraint();
 
       if(c.is_false())
-        dec_result=decision_proceduret::D_UNSATISFIABLE;
+        dec_result=decision_proceduret::resultt::D_UNSATISFIABLE;
       else
       {
         _iterations++;
@@ -167,11 +167,11 @@ void prop_minimizet::operator()()
 
         switch(dec_result)
         {
-        case decision_proceduret::D_UNSATISFIABLE:
+        case decision_proceduret::resultt::D_UNSATISFIABLE:
           last_was_SAT=false;
           break;
 
-        case decision_proceduret::D_SATISFIABLE:
+        case decision_proceduret::resultt::D_SATISFIABLE:
           last_was_SAT=true;
           fix_objectives(); // fix the ones we got
           break;
@@ -183,7 +183,7 @@ void prop_minimizet::operator()()
         }
       }
     }
-    while(dec_result!=decision_proceduret::D_UNSATISFIABLE);
+    while(dec_result!=decision_proceduret::resultt::D_UNSATISFIABLE);
   }
 
   if(!last_was_SAT)

--- a/src/solvers/prop/prop.h
+++ b/src/solvers/prop/prop.h
@@ -90,7 +90,7 @@ public:
 
   // solving
   virtual const std::string solver_text()=0;
-  typedef enum { P_SATISFIABLE, P_UNSATISFIABLE, P_ERROR } resultt;
+  enum class resultt { P_SATISFIABLE, P_UNSATISFIABLE, P_ERROR };
   virtual resultt prop_solve()=0;
 
   // satisfying assignment, from prop_assignmentt

--- a/src/solvers/prop/prop_conv.cpp
+++ b/src/solvers/prop/prop_conv.cpp
@@ -673,12 +673,12 @@ decision_proceduret::resultt prop_conv_solvert::dec_solve()
 
   switch(result)
   {
-    case propt::P_SATISFIABLE: return D_SATISFIABLE;
-    case propt::P_UNSATISFIABLE: return D_UNSATISFIABLE;
-    default: return D_ERROR;
+    case propt::P_SATISFIABLE: return resultt::D_SATISFIABLE;
+    case propt::P_UNSATISFIABLE: return resultt::D_UNSATISFIABLE;
+    default: return resultt::D_ERROR;
   }
 
-  return D_ERROR;
+  return resultt::D_ERROR;
 }
 
 /*******************************************************************\

--- a/src/solvers/prop/prop_conv.cpp
+++ b/src/solvers/prop/prop_conv.cpp
@@ -673,8 +673,8 @@ decision_proceduret::resultt prop_conv_solvert::dec_solve()
 
   switch(result)
   {
-    case propt::P_SATISFIABLE: return resultt::D_SATISFIABLE;
-    case propt::P_UNSATISFIABLE: return resultt::D_UNSATISFIABLE;
+    case propt::resultt::P_SATISFIABLE: return resultt::D_SATISFIABLE;
+    case propt::resultt::P_UNSATISFIABLE: return resultt::D_UNSATISFIABLE;
     default: return resultt::D_ERROR;
   }
 

--- a/src/solvers/prop/prop_conv_store.cpp
+++ b/src/solvers/prop/prop_conv_store.cpp
@@ -25,7 +25,7 @@ Function: prop_conv_storet::set_to
 void prop_conv_storet::set_to(const exprt &expr, bool value)
 {
   constraintt &constraint=constraints.add_constraint();
-  constraint.type=constraintt::SET_TO;
+  constraint.type=constraintt::typet::SET_TO;
   constraint.expr=expr;
   constraint.value=value;
 }
@@ -45,7 +45,7 @@ Function: prop_conv_storet::convert_rest
 literalt prop_conv_storet::convert(const exprt &expr)
 {
   constraintt &constraint=constraints.add_constraint();
-  constraint.type=constraintt::CONVERT;
+  constraint.type=constraintt::typet::CONVERT;
   constraint.expr=expr;
   #if 0
   constraint.literal=prop.new_variable();
@@ -111,11 +111,11 @@ void prop_conv_storet::constraintt::replay(prop_convt &dest) const
 {
   switch(type)
   {
-  case SET_TO:
+  case typet::SET_TO:
     dest.set_to(expr, value);
     break;
 
-  case CONVERT:
+  case typet::CONVERT:
     // dest.prop.set_equal(dest.convert_rest(expr), literal);
     break;
 
@@ -140,12 +140,12 @@ void prop_conv_storet::constraintt::print(std::ostream &out) const
 {
   switch(type)
   {
-  case SET_TO:
+  case typet::SET_TO:
     out << "SET_TO " << (value?"TRUE":"FALSE") << ": ";
     out << expr.pretty() << "\n";
     break;
 
-  case CONVERT:
+  case typet::CONVERT:
     out << "CONVERT(" << literal.dimacs() << "): ";
     out << expr.pretty() << "\n";
     break;

--- a/src/solvers/prop/prop_conv_store.h
+++ b/src/solvers/prop/prop_conv_store.h
@@ -20,7 +20,7 @@ public:
 
   struct constraintt
   {
-    typedef enum { NONE, CONVERT, SET_TO } typet;
+    enum class typet { NONE, CONVERT, SET_TO };
     typet type;
 
     exprt expr;

--- a/src/solvers/qbf/qbf_quantor.cpp
+++ b/src/solvers/qbf/qbf_quantor.cpp
@@ -148,20 +148,20 @@ propt::resultt qbf_quantort::prop_solve()
     if(!result_found)
     {
       messaget::error() << "Quantor failed: unknown result" << eom;
-      return P_ERROR;
+      return resultt::P_ERROR;
     }
   }
 
   if(result)
   {
     messaget::status() << "Quantor: TRUE" << eom;
-    return P_SATISFIABLE;
+    return resultt::P_SATISFIABLE;
   }
   else
   {
     messaget::status() << "Quantor: FALSE" << eom;
-    return P_UNSATISFIABLE;
+    return resultt::P_UNSATISFIABLE;
   }
 
-  return P_ERROR;
+  return resultt::P_ERROR;
 }

--- a/src/solvers/qbf/qbf_qube.cpp
+++ b/src/solvers/qbf/qbf_qube.cpp
@@ -97,7 +97,7 @@ propt::resultt qbf_qubet::prop_solve()
 {
   // sKizzo crashes on empty instances
   if(no_clauses()==0)
-    return P_SATISFIABLE;
+    return resultt::P_SATISFIABLE;
 
   {
     messaget::status() <<
@@ -156,20 +156,20 @@ propt::resultt qbf_qubet::prop_solve()
     if(!result_found)
     {
       messaget::error() << "QuBE failed: unknown result" << eom;
-      return P_ERROR;
+      return resultt::P_ERROR;
     }
   }
 
   if(result)
   {
     messaget::status() << "QuBE: TRUE" << eom;
-    return P_SATISFIABLE;
+    return resultt::P_SATISFIABLE;
   }
   else
   {
     messaget::status() << "QuBE: FALSE" << eom;
-    return P_UNSATISFIABLE;
+    return resultt::P_UNSATISFIABLE;
   }
 
-  return P_ERROR;
+  return resultt::P_ERROR;
 }

--- a/src/solvers/qbf/qbf_qube_core.cpp
+++ b/src/solvers/qbf/qbf_qube_core.cpp
@@ -80,7 +80,7 @@ Function: qbf_qube_coret::prop_solve
 propt::resultt qbf_qube_coret::prop_solve()
 {
   if(no_clauses()==0)
-    return P_SATISFIABLE;
+    return resultt::P_SATISFIABLE;
 
   {
     messaget::status() << "QuBE: "
@@ -146,7 +146,7 @@ propt::resultt qbf_qube_coret::prop_solve()
     if(!result_found)
     {
       messaget::error() << "QuBE failed: unknown result" << eom;
-      return P_ERROR;
+      return resultt::P_ERROR;
     }
   }
 
@@ -156,12 +156,12 @@ propt::resultt qbf_qube_coret::prop_solve()
   if(result)
   {
     messaget::status() << "QuBE: TRUE" << eom;
-    return P_SATISFIABLE;
+    return resultt::P_SATISFIABLE;
   }
   else
   {
     messaget::status() << "QuBE: FALSE" << eom;
-    return P_UNSATISFIABLE;
+    return resultt::P_UNSATISFIABLE;
   }
 }
 

--- a/src/solvers/qbf/qbf_skizzo.cpp
+++ b/src/solvers/qbf/qbf_skizzo.cpp
@@ -97,7 +97,7 @@ propt::resultt qbf_skizzot::prop_solve()
 {
   // sKizzo crashes on empty instances
   if(no_clauses()==0)
-    return P_SATISFIABLE;
+    return resultt::P_SATISFIABLE;
 
   {
     messaget::status() <<
@@ -156,20 +156,20 @@ propt::resultt qbf_skizzot::prop_solve()
     if(!result_found)
     {
       messaget::error() << "Skizzo failed: unknown result" << eom;
-      return P_ERROR;
+      return resultt::P_ERROR;
     }
   }
 
   if(result)
   {
     messaget::status() << "Skizzo: TRUE" << eom;
-    return P_SATISFIABLE;
+    return resultt::P_SATISFIABLE;
   }
   else
   {
     messaget::status() << "Skizzo: FALSE" << eom;
-    return P_UNSATISFIABLE;
+    return resultt::P_UNSATISFIABLE;
   }
 
-  return P_ERROR;
+  return resultt::P_ERROR;
 }

--- a/src/solvers/qbf/qdimacs_cnf.cpp
+++ b/src/solvers/qbf/qdimacs_cnf.cpp
@@ -62,11 +62,11 @@ void qdimacs_cnft::write_prefix(std::ostream &out) const
 
     switch(quantifier.type)
     {
-    case quantifiert::UNIVERSAL:
+    case quantifiert::typet::UNIVERSAL:
       out << "a";
       break;
 
-    case quantifiert::EXISTENTIAL:
+    case quantifiert::typet::EXISTENTIAL:
       out << "e";
       break;
 

--- a/src/solvers/qbf/qdimacs_cnf.h
+++ b/src/solvers/qbf/qdimacs_cnf.h
@@ -32,11 +32,11 @@ public:
   class quantifiert
   {
   public:
-    typedef enum { NONE, EXISTENTIAL, UNIVERSAL } typet;
+    enum class typet { NONE, EXISTENTIAL, UNIVERSAL };
     typet type;
     unsigned var_no;
 
-    quantifiert():type(NONE), var_no(0)
+    quantifiert():type(typet::NONE), var_no(0)
     {
     }
 
@@ -51,7 +51,7 @@ public:
 
     size_t hash() const
     {
-      return var_no^(type<<24);
+      return var_no^(static_cast<int>(type)<<24);
     }
   };
 
@@ -71,12 +71,12 @@ public:
 
   void add_existential_quantifier(const literalt l)
   {
-    add_quantifier(quantifiert(quantifiert::EXISTENTIAL, l));
+    add_quantifier(quantifiert(quantifiert::typet::EXISTENTIAL, l));
   }
 
   void add_universal_quantifier(const literalt l)
   {
-    add_quantifier(quantifiert(quantifiert::UNIVERSAL, l));
+    add_quantifier(quantifiert(quantifiert::typet::UNIVERSAL, l));
   }
 
   bool is_quantified(const literalt l) const;

--- a/src/solvers/qbf/qdimacs_core.h
+++ b/src/solvers/qbf/qdimacs_core.h
@@ -21,7 +21,7 @@ public:
   virtual tvt l_get(literalt a) const=0;
   virtual bool is_in_core(literalt l) const=0;
 
-  typedef enum { M_TRUE, M_FALSE, M_DONTCARE, M_COMPLEX } modeltypet;
+  enum modeltypet { M_TRUE, M_FALSE, M_DONTCARE, M_COMPLEX };
   virtual modeltypet m_get(literalt a) const=0;
 
   typedef std::pair<exprt, unsigned> symbol_mapt;

--- a/src/solvers/refinement/bv_refinement_loop.cpp
+++ b/src/solvers/refinement/bv_refinement_loop.cpp
@@ -161,8 +161,8 @@ decision_proceduret::resultt bv_refinementt::prop_solve()
 
   switch(result)
   {
-    case propt::P_SATISFIABLE: return resultt::D_SATISFIABLE;
-    case propt::P_UNSATISFIABLE: return resultt::D_UNSATISFIABLE;
+    case propt::resultt::P_SATISFIABLE: return resultt::D_SATISFIABLE;
+    case propt::resultt::P_UNSATISFIABLE: return resultt::D_UNSATISFIABLE;
     default: return resultt::D_ERROR;
   }
 }

--- a/src/solvers/refinement/bv_refinement_loop.cpp
+++ b/src/solvers/refinement/bv_refinement_loop.cpp
@@ -92,27 +92,27 @@ decision_proceduret::resultt bv_refinementt::dec_solve()
 
     switch(prop_solve())
     {
-    case D_SATISFIABLE:
+    case resultt::D_SATISFIABLE:
       check_SAT();
       if(!progress)
       {
         status() << "BV-Refinement: got SAT, and it simulates => SAT" << eom;
         status() << "Total iterations: " << iteration << eom;
-        return D_SATISFIABLE;
+        return resultt::D_SATISFIABLE;
       }
       else
         status() << "BV-Refinement: got SAT, and it is spurious, refining"
                  << eom;
       break;
 
-    case D_UNSATISFIABLE:
+    case resultt::D_UNSATISFIABLE:
       check_UNSAT();
       if(!progress)
       {
         status() << "BV-Refinement: got UNSAT, and the proof passes => UNSAT"
                  << eom;
         status() << "Total iterations: " << iteration << eom;
-        return D_UNSATISFIABLE;
+        return resultt::D_UNSATISFIABLE;
       }
       else
         status() << "BV-Refinement: got UNSAT, and the proof fails, refining"
@@ -120,7 +120,7 @@ decision_proceduret::resultt bv_refinementt::dec_solve()
       break;
 
     default:
-      return D_ERROR;
+      return resultt::D_ERROR;
     }
   }
 }
@@ -161,9 +161,9 @@ decision_proceduret::resultt bv_refinementt::prop_solve()
 
   switch(result)
   {
-    case propt::P_SATISFIABLE: return D_SATISFIABLE;
-    case propt::P_UNSATISFIABLE: return D_UNSATISFIABLE;
-    default: return D_ERROR;
+    case propt::P_SATISFIABLE: return resultt::D_SATISFIABLE;
+    case propt::P_UNSATISFIABLE: return resultt::D_UNSATISFIABLE;
+    default: return resultt::D_ERROR;
   }
 }
 

--- a/src/solvers/refinement/bv_refinement_loop.cpp
+++ b/src/solvers/refinement/bv_refinement_loop.cpp
@@ -83,7 +83,7 @@ decision_proceduret::resultt bv_refinementt::dec_solve()
     status() << "BV-Refinement: iteration " << iteration << eom;
 
     // output the very same information in a structured fashion
-    if(ui==ui_message_handlert::XML_UI)
+    if(ui==ui_message_handlert::uit::XML_UI)
     {
       xmlt xml("refinement-iteration");
       xml.data=std::to_string(iteration);

--- a/src/solvers/refinement/refine_arithmetic.cpp
+++ b/src/solvers/refinement/refine_arithmetic.cpp
@@ -413,21 +413,24 @@ void bv_refinementt::check_SAT(approximationt &a)
         r=bv_utils.multiplier(
           a.op0_bv, a.op1_bv,
           a.expr.type().id()==ID_signedbv?
-            bv_utilst::SIGNED:bv_utilst::UNSIGNED);
+            bv_utilst::representationt::SIGNED:
+            bv_utilst::representationt::UNSIGNED);
       }
       else if(a.expr.id()==ID_div)
       {
         r=bv_utils.divider(
           a.op0_bv, a.op1_bv,
           a.expr.type().id()==ID_signedbv?
-            bv_utilst::SIGNED:bv_utilst::UNSIGNED);
+            bv_utilst::representationt::SIGNED:
+            bv_utilst::representationt::UNSIGNED);
       }
       else if(a.expr.id()==ID_mod)
       {
         r=bv_utils.remainder(
           a.op0_bv, a.op1_bv,
           a.expr.type().id()==ID_signedbv?
-            bv_utilst::SIGNED:bv_utilst::UNSIGNED);
+            bv_utilst::representationt::SIGNED:
+            bv_utilst::representationt::UNSIGNED);
       }
       else
         assert(0);

--- a/src/solvers/refinement/refine_arrays.cpp
+++ b/src/solvers/refinement/refine_arrays.cpp
@@ -67,7 +67,7 @@ void bv_refinementt::arrays_overapproximated()
   {
     satcheck_no_simplifiert sat_check;
     bv_pointerst solver(ns, sat_check);
-    solver.unbounded_array=bv_pointerst::U_ALL;
+    solver.unbounded_array=bv_pointerst::unbounded_arrayt::U_ALL;
 
     exprt current=(*it).lazy;
 

--- a/src/solvers/refinement/refine_arrays.cpp
+++ b/src/solvers/refinement/refine_arrays.cpp
@@ -101,12 +101,12 @@ void bv_refinementt::arrays_overapproximated()
     exprt simplified=get(current);
     solver << simplified;
 
-    switch(sat_check.prop_solve())
+    switch(static_cast<decision_proceduret::resultt>(sat_check.prop_solve()))
     {
-    case decision_proceduret::D_SATISFIABLE:
+    case decision_proceduret::resultt::D_SATISFIABLE:
       ++it;
       break;
-    case decision_proceduret::D_UNSATISFIABLE:
+    case decision_proceduret::resultt::D_UNSATISFIABLE:
       prop.l_set_to_true(convert(current));
       nb_active++;
       lazy_array_constraints.erase(it++);

--- a/src/solvers/sat/cnf.h
+++ b/src/solvers/sat/cnf.h
@@ -63,7 +63,7 @@ protected:
 class cnf_solvert:public cnft
 {
 public:
-  cnf_solvert():status(INIT), clause_counter(0)
+  cnf_solvert():status(statust::INIT), clause_counter(0)
   {
   }
 
@@ -73,7 +73,7 @@ public:
   }
 
 protected:
-  typedef enum { INIT, SAT, UNSAT, ERROR } statust;
+  enum class statust { INIT, SAT, UNSAT, ERROR };
   statust status;
   size_t clause_counter;
 };

--- a/src/solvers/sat/cnf_clause_list.h
+++ b/src/solvers/sat/cnf_clause_list.h
@@ -33,7 +33,7 @@ public:
     return tvt::unknown();
   }
 
-  virtual resultt prop_solve() { return P_ERROR; }
+  virtual resultt prop_solve() { return resultt::P_ERROR; }
 
   virtual size_t no_clauses() const { return clauses.size(); }
 

--- a/src/solvers/sat/dimacs_cnf.h
+++ b/src/solvers/sat/dimacs_cnf.h
@@ -50,7 +50,7 @@ public:
 
   virtual resultt prop_solve()
   {
-    return P_ERROR;
+    return resultt::P_ERROR;
   }
 
   virtual tvt l_get(literalt) const

--- a/src/solvers/sat/pbs_dimacs_cnf.cpp
+++ b/src/solvers/sat/pbs_dimacs_cnf.cpp
@@ -247,9 +247,9 @@ propt::resultt pbs_dimacs_cnft::prop_solve()
   }
 
   if(result)
-    return P_SATISFIABLE;
+    return resultt::P_SATISFIABLE;
   else
-    return P_UNSATISFIABLE;
+    return resultt::P_UNSATISFIABLE;
 }
 
 /*******************************************************************\

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -252,7 +252,7 @@ propt::resultt satcheck_minisat2_baset<T>::prop_solve()
             "SAT checker: instance is SATISFIABLE" << eom;
           assert(solver->model.size()!=0);
           status=statust::SAT;
-          return P_SATISFIABLE;
+          return resultt::P_SATISFIABLE;
         }
         else
         {
@@ -263,14 +263,14 @@ propt::resultt satcheck_minisat2_baset<T>::prop_solve()
     }
 
     status=statust::UNSAT;
-    return P_UNSATISFIABLE;
+    return resultt::P_UNSATISFIABLE;
   }
   catch(Minisat::OutOfMemoryException)
   {
     messaget::error() <<
       "SAT checker ran out of memory" << eom;
     status=statust::ERROR;
-    return P_ERROR;
+    return resultt::P_ERROR;
   }
 }
 

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -210,7 +210,7 @@ Function: satcheck_minisat2_baset::prop_solve
 template<typename T>
 propt::resultt satcheck_minisat2_baset<T>::prop_solve()
 {
-  assert(status!=ERROR);
+  assert(status!=statust::ERROR);
 
   {
     messaget::status() <<
@@ -251,7 +251,7 @@ propt::resultt satcheck_minisat2_baset<T>::prop_solve()
           messaget::status() <<
             "SAT checker: instance is SATISFIABLE" << eom;
           assert(solver->model.size()!=0);
-          status=SAT;
+          status=statust::SAT;
           return P_SATISFIABLE;
         }
         else
@@ -262,14 +262,14 @@ propt::resultt satcheck_minisat2_baset<T>::prop_solve()
       }
     }
 
-    status=UNSAT;
+    status=statust::UNSAT;
     return P_UNSATISFIABLE;
   }
   catch(Minisat::OutOfMemoryException)
   {
     messaget::error() <<
       "SAT checker ran out of memory" << eom;
-    status=ERROR;
+    status=statust::ERROR;
     return P_ERROR;
   }
 }

--- a/src/solvers/sat/satcheck_zchaff.h
+++ b/src/solvers/sat/satcheck_zchaff.h
@@ -37,7 +37,7 @@ public:
 protected:
   CSolver *solver;
 
-  typedef enum { INIT, SAT, UNSAT, ERROR } statust;
+  enum statust { INIT, SAT, UNSAT, ERROR };
   statust status;
 };
 

--- a/src/solvers/smt1/smt1_conv.cpp
+++ b/src/solvers/smt1/smt1_conv.cpp
@@ -88,7 +88,7 @@ decision_proceduret::resultt smt1_convt::dec_solve()
 {
   write_footer();
   out.flush();
-  return decision_proceduret::D_ERROR;
+  return decision_proceduret::resultt::D_ERROR;
 }
 
 /*******************************************************************\

--- a/src/solvers/smt1/smt1_conv.h
+++ b/src/solvers/smt1/smt1_conv.h
@@ -28,8 +28,17 @@ class member_exprt;
 class smt1_convt:public prop_convt
 {
 public:
-  typedef enum
-  { GENERIC, BOOLECTOR, CVC3, CVC4, MATHSAT, OPENSMT, YICES, Z3 } solvert;
+  enum class solvert
+  {
+    GENERIC,
+    BOOLECTOR,
+    CVC3,
+    CVC4,
+    MATHSAT,
+    OPENSMT,
+    YICES,
+    Z3
+  };
 
   smt1_convt(
     const namespacet &_ns,

--- a/src/solvers/smt1/smt1_dec.cpp
+++ b/src/solvers/smt1/smt1_dec.cpp
@@ -41,14 +41,14 @@ Function: smt1_dect::decision_procedure_text
 std::string smt1_dect::decision_procedure_text() const
 {
   return "SMT1 "+logic+" using "+
-    (solver==GENERIC?"Generic":
-     solver==BOOLECTOR?"Boolector":
-     solver==CVC3?"CVC3":
-     solver==CVC4?"CVC3":
-     solver==MATHSAT?"MathSAT":
-     solver==OPENSMT?"OpenSMT":
-     solver==YICES?"Yices":
-     solver==Z3?"Z3":
+    (solver==solvert::GENERIC?"Generic":
+     solver==solvert::BOOLECTOR?"Boolector":
+     solver==solvert::CVC3?"CVC3":
+     solver==solvert::CVC4?"CVC3":
+     solver==solvert::MATHSAT?"MathSAT":
+     solver==solvert::OPENSMT?"OpenSMT":
+     solver==solvert::YICES?"Yices":
+     solver==solvert::Z3?"Z3":
      "(unknown)");
 }
 
@@ -125,7 +125,7 @@ decision_proceduret::resultt smt1_dect::dec_solve()
 
   switch(solver)
   {
-  case BOOLECTOR:
+  case solvert::BOOLECTOR:
     // -rwl0 disables rewriting, which makes things slower,
     // but in return values for arrays appear
     // command = "boolector -rwl0 --smt "
@@ -136,34 +136,34 @@ decision_proceduret::resultt smt1_dect::dec_solve()
             + temp_result_filename;
     break;
 
-  case CVC3:
+  case solvert::CVC3:
     command = "cvc3 +model -lang smtlib -output-lang smtlib "
             + temp_out_filename
             + " > "
             + temp_result_filename;
     break;
 
-  case CVC4:
+  case solvert::CVC4:
     command = "cvc4 -L smt1 "
             + temp_out_filename
             + " > "
             + temp_result_filename;
     break;
 
-  case MATHSAT:
+  case solvert::MATHSAT:
     command = "mathsat -model -input=smt"
               " < "+temp_out_filename
             + " > "+temp_result_filename;
     break;
 
-  case OPENSMT:
+  case solvert::OPENSMT:
     command = "opensmt "
             + temp_out_filename
             + " > "
             + temp_result_filename;
     break;
 
-  case YICES:
+  case solvert::YICES:
     //    command = "yices -smt -e "   // Calling convention for older versions
     command = "yices-smt --full-model "  //  Calling for 2.2.1
             + temp_out_filename
@@ -171,7 +171,7 @@ decision_proceduret::resultt smt1_dect::dec_solve()
             + temp_result_filename;
     break;
 
-  case Z3:
+  case solvert::Z3:
     command = "z3 -smt "
             + temp_out_filename
             + " > "
@@ -197,29 +197,29 @@ decision_proceduret::resultt smt1_dect::dec_solve()
 
   switch(solver)
   {
-  case BOOLECTOR:
+  case solvert::BOOLECTOR:
     return read_result_boolector(in);
 
-  case CVC3:
+  case solvert::CVC3:
     return read_result_cvc3(in);
 
-  case CVC4:
+  case solvert::CVC4:
     error() << "no support for CVC4 with SMT1, use SMT2 instead" << eom;
     return decision_proceduret::resultt::D_ERROR;
 
-  case MATHSAT:
+  case solvert::MATHSAT:
     return read_result_mathsat(in);
 
-  case OPENSMT:
+  case solvert::OPENSMT:
     return read_result_opensmt(in);
 
-  case YICES:
+  case solvert::YICES:
     return read_result_yices(in);
 
-  case Z3:
+  case solvert::Z3:
     return read_result_z3(in);
 
-  case GENERIC:
+  case solvert::GENERIC:
   default:
     error() << "Generic solver can't solve" << eom;
     return decision_proceduret::resultt::D_ERROR;

--- a/src/solvers/smt1/smt1_dec.cpp
+++ b/src/solvers/smt1/smt1_dec.cpp
@@ -190,7 +190,7 @@ decision_proceduret::resultt smt1_dect::dec_solve()
   if(res<0)
   {
     error() << "error running SMT1 solver" << eom;
-    return decision_proceduret::D_ERROR;
+    return decision_proceduret::resultt::D_ERROR;
   }
 
   std::ifstream in(temp_result_filename.c_str());
@@ -205,7 +205,7 @@ decision_proceduret::resultt smt1_dect::dec_solve()
 
   case CVC4:
     error() << "no support for CVC4 with SMT1, use SMT2 instead" << eom;
-    return decision_proceduret::D_ERROR;
+    return decision_proceduret::resultt::D_ERROR;
 
   case MATHSAT:
     return read_result_mathsat(in);
@@ -222,7 +222,7 @@ decision_proceduret::resultt smt1_dect::dec_solve()
   case GENERIC:
   default:
     error() << "Generic solver can't solve" << eom;
-    return decision_proceduret::D_ERROR;
+    return decision_proceduret::resultt::D_ERROR;
   }
 }
 
@@ -311,14 +311,14 @@ decision_proceduret::resultt smt1_dect::read_result_boolector(std::istream &in)
       boolean_assignment[v]=(value=="1");
     }
 
-    return D_SATISFIABLE;
+    return resultt::D_SATISFIABLE;
   }
   else if(line=="unsat")
-    return D_UNSATISFIABLE;
+    return resultt::D_UNSATISFIABLE;
   else
     error() << "Unexpected result from SMT-Solver: " << line << eom;
 
-  return D_ERROR;
+  return resultt::D_ERROR;
 }
 
 /*******************************************************************\
@@ -335,7 +335,7 @@ Function: smt1_dect::read_result_opensmt
 
 decision_proceduret::resultt smt1_dect::read_result_opensmt(std::istream &in)
 {
-  return D_ERROR;
+  return resultt::D_ERROR;
 }
 
 /*******************************************************************\
@@ -359,15 +359,15 @@ decision_proceduret::resultt smt1_dect::read_result_yices(std::istream &in)
     if(line=="sat")
     {
       // fixme: read values
-      return D_SATISFIABLE;
+      return resultt::D_SATISFIABLE;
     }
     else if(line=="unsat")
-      return D_UNSATISFIABLE;
+      return resultt::D_UNSATISFIABLE;
   }
 
   error() << "Unexpected result from SMT-Solver" << eom;
 
-  return D_ERROR;
+  return resultt::D_ERROR;
 }
 
 /*******************************************************************\
@@ -414,7 +414,7 @@ Function: smt1_dect::read_result_mathsat
 decision_proceduret::resultt smt1_dect::read_result_mathsat(std::istream &in)
 {
   std::string line;
-  decision_proceduret::resultt res = D_ERROR;
+  decision_proceduret::resultt res = resultt::D_ERROR;
 
   boolean_assignment.clear();
   boolean_assignment.resize(no_boolean_variables, false);
@@ -425,9 +425,9 @@ decision_proceduret::resultt smt1_dect::read_result_mathsat(std::istream &in)
   while(std::getline(in, line))
   {
     if(line=="sat")
-      res=D_SATISFIABLE;
+      res=resultt::D_SATISFIABLE;
     else if(line=="unsat")
-      res=D_UNSATISFIABLE;
+      res=resultt::D_UNSATISFIABLE;
     else if(line.size()>=1 && line[0]=='(')
     {
       // (iff B0 true)
@@ -496,7 +496,7 @@ Function: smt1_dect::read_result_z3
 decision_proceduret::resultt smt1_dect::read_result_z3(std::istream &in)
 {
   std::string line;
-  decision_proceduret::resultt res = D_ERROR;
+  decision_proceduret::resultt res = resultt::D_ERROR;
 
   boolean_assignment.clear();
   boolean_assignment.resize(no_boolean_variables, false);
@@ -507,9 +507,9 @@ decision_proceduret::resultt smt1_dect::read_result_z3(std::istream &in)
   while(std::getline(in, line))
   {
     if(line=="sat")
-      res = D_SATISFIABLE;
+      res = resultt::D_SATISFIABLE;
     else if(line=="unsat")
-      res = D_UNSATISFIABLE;
+      res = resultt::D_UNSATISFIABLE;
     else
     {
       std::size_t pos=line.find(" -> ");
@@ -692,7 +692,7 @@ Function: smt1_dect::read_result_cvc3
 decision_proceduret::resultt smt1_dect::read_result_cvc3(std::istream &in)
 {
   std::string line;
-  decision_proceduret::resultt res = D_ERROR;
+  decision_proceduret::resultt res = resultt::D_ERROR;
 
   boolean_assignment.clear();
   boolean_assignment.resize(no_boolean_variables, false);
@@ -703,9 +703,9 @@ decision_proceduret::resultt smt1_dect::read_result_cvc3(std::istream &in)
   while(std::getline(in, line))
   {
     if(line=="sat")
-      res = D_SATISFIABLE;
+      res = resultt::D_SATISFIABLE;
     else if(line=="unsat")
-      res = D_UNSATISFIABLE;
+      res = resultt::D_UNSATISFIABLE;
     else if(line.find("Current scope level")!=std::string::npos ||
             line.find("Variable Assignment")!=std::string::npos)
     {

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -106,14 +106,14 @@ void smt2_convt::write_header()
 
   switch(solver)
   {
-  case GENERIC: break;
-  case BOOLECTOR: out << "; Generated for Boolector\n"; break;
-  case CVC3: out << "; Generated for CVC 3\n"; break;
-  case CVC4: out << "; Generated for CVC 4\n"; break;
-  case MATHSAT: out << "; Generated for MathSAT\n"; break;
-  case OPENSMT: out << "; Generated for OPENSMT\n"; break;
-  case YICES: out << "; Generated for Yices\n"; break;
-  case Z3: out << "; Generated for Z3\n"; break;
+  case solvert::GENERIC: break;
+  case solvert::BOOLECTOR: out << "; Generated for Boolector\n"; break;
+  case solvert::CVC3: out << "; Generated for CVC 3\n"; break;
+  case solvert::CVC4: out << "; Generated for CVC 4\n"; break;
+  case solvert::MATHSAT: out << "; Generated for MathSAT\n"; break;
+  case solvert::OPENSMT: out << "; Generated for OPENSMT\n"; break;
+  case solvert::YICES: out << "; Generated for Yices\n"; break;
+  case solvert::Z3: out << "; Generated for Z3\n"; break;
   }
 
   out << "(set-info :source \"" << notes << "\")" << "\n";
@@ -163,7 +163,7 @@ void smt2_convt::write_footer(std::ostream &out)
   out << "(check-sat)" << "\n";
   out << "\n";
 
-  if(solver!=BOOLECTOR)
+  if(solver!=solvert::BOOLECTOR)
   {
     for(const auto &id : smt2_identifiers)
       out << "(get-value (|" << id << "|))" << "\n";
@@ -739,9 +739,9 @@ void smt2_convt::convert_byte_extract(const byte_extract_exprt &expr)
 {
   // we just run the flattener
   exprt flattened_expr=flatten_byte_extract(expr, ns);
-  unflatten(BEGIN, expr.type());
+  unflatten(wheret::BEGIN, expr.type());
   convert_expr(flattened_expr);
-  unflatten(END, expr.type());
+  unflatten(wheret::END, expr.type());
 }
 
 /*******************************************************************\
@@ -854,9 +854,9 @@ void smt2_convt::convert_byte_update(const byte_update_exprt &expr)
   exprt ext_value=typecast_exprt(expr.value(), one_mask.type());
   exprt or_expr=bitor_exprt(and_expr, shl_exprt(ext_value, distance));
 
-  unflatten(BEGIN, expr.type());
+  unflatten(wheret::BEGIN, expr.type());
   flatten2bv(or_expr);
-  unflatten(END, expr.type());
+  unflatten(wheret::END, expr.type());
   #endif
 }
 
@@ -1972,7 +1972,7 @@ void smt2_convt::convert_expr(const exprt &expr)
   else if(expr.id()==ID_forall ||
           expr.id()==ID_exists)
   {
-    if(solver==MATHSAT)
+    if(solver==solvert::MATHSAT)
       // NOLINTNEXTLINE(readability/throw)
       throw "MathSAT does not support quantifiers";
 
@@ -4111,7 +4111,7 @@ void smt2_convt::convert_index(const index_exprt &expr)
       std::size_t array_width=boolbv_width(array_type);
       assert(array_width!=0);
 
-      unflatten(BEGIN, array_type.subtype());
+      unflatten(wheret::BEGIN, array_type.subtype());
 
       std::size_t sub_width=boolbv_width(array_type.subtype());
       std::size_t index_width=boolbv_width(expr.index().type());
@@ -4139,7 +4139,7 @@ void smt2_convt::convert_index(const index_exprt &expr)
 
       out << ")))"; // mult, bvlshr, extract
 
-      unflatten(END, array_type.subtype());
+      unflatten(wheret::END, array_type.subtype());
     }
   }
   else if(array_op_type.id()==ID_vector)
@@ -4238,7 +4238,7 @@ void smt2_convt::convert_member(const member_exprt &expr)
     if(width==0)
       INVALIDEXPR("failed to get union member width");
 
-    unflatten(BEGIN, expr.type());
+    unflatten(wheret::BEGIN, expr.type());
 
     out << "((_ extract "
            << (width-1)
@@ -4246,7 +4246,7 @@ void smt2_convt::convert_member(const member_exprt &expr)
     convert_expr(struct_op);
     out << ")";
 
-    unflatten(END, expr.type());
+    unflatten(wheret::END, expr.type());
   }
   else
     UNEXPECTEDCASE(
@@ -4383,7 +4383,7 @@ void smt2_convt::unflatten(
 
   if(type.id()==ID_bool)
   {
-    if(where==BEGIN)
+    if(where==wheret::BEGIN)
       out << "(= "; // produces a bool
     else
       out << " #b1)";
@@ -4406,7 +4406,7 @@ void smt2_convt::unflatten(
       if(to_integer(vector_type.size(), size))
         INVALIDEXPR("failed to convert vector size to constant");
 
-      if(where==BEGIN)
+      if(where==wheret::BEGIN)
         out << "(let ((?ufop" << nesting << " ";
       else
       {
@@ -4419,10 +4419,10 @@ void smt2_convt::unflatten(
         for(mp_integer i=0; i!=size; ++i, offset+=subtype_width)
         {
           out << " ";
-          unflatten(BEGIN, vector_type.subtype(), nesting+1);
+          unflatten(wheret::BEGIN, vector_type.subtype(), nesting+1);
           out << "((_ extract " << offset+subtype_width-1 << " "
               << offset << ") ?ufop" << nesting << ")";
-          unflatten(END, vector_type.subtype(), nesting+1);
+          unflatten(wheret::END, vector_type.subtype(), nesting+1);
         }
 
         out << "))"; // mk-, let
@@ -4438,7 +4438,7 @@ void smt2_convt::unflatten(
     if(use_datatypes)
     {
       // extract members
-      if(where==BEGIN)
+      if(where==wheret::BEGIN)
         out << "(let ((?ufop" << nesting << " ";
       else
       {
@@ -4467,10 +4467,10 @@ void smt2_convt::unflatten(
           std::size_t member_width=boolbv_width(it->type());
 
           out << " ";
-          unflatten(BEGIN, it->type(), nesting+1);
+          unflatten(wheret::BEGIN, it->type(), nesting+1);
           out << "((_ extract " << offset+member_width-1 << " "
               << offset << ") ?ufop" << nesting << ")";
-          unflatten(END, it->type(), nesting+1);
+          unflatten(wheret::END, it->type(), nesting+1);
           offset+=member_width;
         }
 

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -241,7 +241,7 @@ decision_proceduret::resultt smt2_convt::dec_solve()
 {
   write_footer(out);
   out.flush();
-  return decision_proceduret::D_ERROR;
+  return decision_proceduret::resultt::D_ERROR;
 }
 
 /*******************************************************************\

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -27,7 +27,7 @@ class member_exprt;
 class smt2_convt:public prop_convt
 {
 public:
-  typedef enum
+  enum class solvert
   {
     GENERIC,
     BOOLECTOR,
@@ -37,7 +37,7 @@ public:
     OPENSMT,
     YICES,
     Z3
-  } solvert;
+  };
 
   smt2_convt(
     const namespacet &_ns,
@@ -66,28 +66,28 @@ public:
 
     switch(solver)
     {
-    case GENERIC:
+    case solvert::GENERIC:
       break;
 
-    case BOOLECTOR:
+    case solvert::BOOLECTOR:
       break;
 
-    case CVC3:
+    case solvert::CVC3:
       break;
 
-    case CVC4:
+    case solvert::CVC4:
       break;
 
-    case MATHSAT:
+    case solvert::MATHSAT:
       break;
 
-    case OPENSMT:
+    case solvert::OPENSMT:
       break;
 
-    case YICES:
+    case solvert::YICES:
       break;
 
-    case Z3:
+    case solvert::Z3:
       use_array_of_bool=true;
       emit_set_logic=false;
       use_datatypes=true;
@@ -249,7 +249,7 @@ protected:
   // e.g., booleans, vectors, structs, arrays but also
   // floats when using the FPA theory.
   // unflatten() does the opposite.
-  typedef enum { BEGIN, END } wheret;
+  enum class wheret { BEGIN, END };
   void flatten2bv(const exprt &);
   void unflatten(wheret, const typet &, unsigned nesting=0);
 

--- a/src/solvers/smt2/smt2_dec.cpp
+++ b/src/solvers/smt2/smt2_dec.cpp
@@ -208,7 +208,7 @@ decision_proceduret::resultt smt2_dect::dec_solve()
   if(res<0)
   {
     error() << "error running SMT2 solver" << eom;
-    return decision_proceduret::D_ERROR;
+    return decision_proceduret::resultt::D_ERROR;
   }
 
   std::ifstream in(smt2_temp_file.temp_result_filename.c_str());
@@ -231,7 +231,7 @@ Function: smt2_dect::read_result
 decision_proceduret::resultt smt2_dect::read_result(std::istream &in)
 {
   std::string line;
-  decision_proceduret::resultt res=D_ERROR;
+  decision_proceduret::resultt res=resultt::D_ERROR;
 
   boolean_assignment.clear();
   boolean_assignment.resize(no_boolean_variables, false);
@@ -244,9 +244,9 @@ decision_proceduret::resultt smt2_dect::read_result(std::istream &in)
     irept parsed=smt2irep(in);
 
     if(parsed.id()=="sat")
-      res=D_SATISFIABLE;
+      res=resultt::D_SATISFIABLE;
     else if(parsed.id()=="unsat")
-      res=D_UNSATISFIABLE;
+      res=resultt::D_UNSATISFIABLE;
     else if(parsed.id()=="" &&
             parsed.get_sub().size()==1 &&
             parsed.get_sub().front().get_sub().size()==2)
@@ -266,11 +266,11 @@ decision_proceduret::resultt smt2_dect::read_result(std::istream &in)
     {
       // We ignore errors after UNSAT because get-value after check-sat
       // returns unsat will give an error.
-      if(res!=D_UNSATISFIABLE)
+      if(res!=resultt::D_UNSATISFIABLE)
       {
         error() << "SMT2 solver returned error message:\n"
                 << "\t\"" << parsed.get_sub()[1].id() <<"\"" << eom;
-        return decision_proceduret::D_ERROR;
+        return decision_proceduret::resultt::D_ERROR;
       }
     }
   }

--- a/src/solvers/smt2/smt2_dec.cpp
+++ b/src/solvers/smt2/smt2_dec.cpp
@@ -43,14 +43,14 @@ std::string smt2_dect::decision_procedure_text() const
   return "SMT2 "+logic+
     (use_FPA_theory?" (with FPA)":"")+
     " using "+
-    (solver==GENERIC?"Generic":
-     solver==BOOLECTOR?"Boolector":
-     solver==CVC3?"CVC3":
-     solver==CVC4?"CVC4":
-     solver==MATHSAT?"MathSAT":
-     solver==OPENSMT?"OpenSMT":
-     solver==YICES?"Yices":
-     solver==Z3?"Z3":
+    (solver==solvert::GENERIC?"Generic":
+     solver==solvert::BOOLECTOR?"Boolector":
+     solver==solvert::CVC3?"CVC3":
+     solver==solvert::CVC4?"CVC4":
+     solver==solvert::MATHSAT?"MathSAT":
+     solver==solvert::OPENSMT?"OpenSMT":
+     solver==solvert::YICES?"Yices":
+     solver==solvert::Z3?"Z3":
      "(unknown)");
 }
 
@@ -129,21 +129,21 @@ decision_proceduret::resultt smt2_dect::dec_solve()
 
   switch(solver)
   {
-  case BOOLECTOR:
+  case solvert::BOOLECTOR:
     command = "boolector --smt2 "
             + smt2_temp_file.temp_out_filename
             + " -m > "
             + smt2_temp_file.temp_result_filename;
     break;
 
-  case CVC3:
+  case solvert::CVC3:
     command = "cvc3 +model -lang smtlib -output-lang smtlib "
             + smt2_temp_file.temp_out_filename
             + " > "
             + smt2_temp_file.temp_result_filename;
     break;
 
-  case CVC4:
+  case solvert::CVC4:
     // The flags --bitblast=eager --bv-div-zero-const help but only
     // work for pure bit-vector formulas.
     command = "cvc4 -L smt2 "
@@ -152,7 +152,7 @@ decision_proceduret::resultt smt2_dect::dec_solve()
             + smt2_temp_file.temp_result_filename;
     break;
 
-  case MATHSAT:
+  case solvert::MATHSAT:
     // The options below were recommended by Alberto Griggio
     // on 10 July 2013
     command = "mathsat -input=smt2"
@@ -173,7 +173,7 @@ decision_proceduret::resultt smt2_dect::dec_solve()
             + " > "+smt2_temp_file.temp_result_filename;
     break;
 
-  case OPENSMT:
+  case solvert::OPENSMT:
     command = "opensmt "
             + smt2_temp_file.temp_out_filename
             + " > "
@@ -181,7 +181,7 @@ decision_proceduret::resultt smt2_dect::dec_solve()
     break;
 
 
-  case YICES:
+  case solvert::YICES:
     //    command = "yices -smt -e "   // Calling convention for older versions
     command = "yices-smt2 "  //  Calling for 2.2.1
             + smt2_temp_file.temp_out_filename
@@ -189,7 +189,7 @@ decision_proceduret::resultt smt2_dect::dec_solve()
             + smt2_temp_file.temp_result_filename;
     break;
 
-  case Z3:
+  case solvert::Z3:
     command = "z3 -smt2 "
             + smt2_temp_file.temp_out_filename
             + " > "

--- a/src/symex/path_search.cpp
+++ b/src/symex/path_search.cpp
@@ -156,7 +156,7 @@ path_searcht::resultt path_searcht::operator()(
 
   report_statistics();
 
-  return number_of_failed_properties==0?SAFE:UNSAFE;
+  return number_of_failed_properties==0?resultt::SAFE:resultt::UNSAFE;
 }
 
 /*******************************************************************\

--- a/src/symex/symex_cover.cpp
+++ b/src/symex/symex_cover.cpp
@@ -76,7 +76,7 @@ void symex_parse_optionst::report_cover(
 
   switch(get_ui())
   {
-    case ui_message_handlert::PLAIN:
+    case ui_message_handlert::uit::PLAIN:
     {
       status() << "\n** coverage results:" << eom;
 
@@ -101,7 +101,7 @@ void symex_parse_optionst::report_cover(
       break;
     }
 
-    case ui_message_handlert::XML_UI:
+    case ui_message_handlert::uit::XML_UI:
     {
       for(const auto &prop_pair : property_map)
       {
@@ -148,7 +148,7 @@ void symex_parse_optionst::report_cover(
 
       break;
     }
-    case ui_message_handlert::JSON_UI:
+    case ui_message_handlert::uit::JSON_UI:
     {
       json_objectt json_result;
       json_arrayt &result_array=json_result["results"].make_array();
@@ -208,7 +208,7 @@ void symex_parse_optionst::report_cover(
            << "%)"
            << eom;
 
-  if(get_ui()==ui_message_handlert::PLAIN)
+  if(get_ui()==ui_message_handlert::uit::PLAIN)
   {
     std::set<std::string> tests;
 

--- a/src/symex/symex_parse_options.cpp
+++ b/src/symex/symex_parse_options.cpp
@@ -479,7 +479,7 @@ Function: symex_parse_optionst::report_properties
 void symex_parse_optionst::report_properties(
   const path_searcht::property_mapt &property_map)
 {
-  if(get_ui()==ui_message_handlert::PLAIN)
+  if(get_ui()==ui_message_handlert::uit::PLAIN)
     status() << "\n** Results:" << eom;
 
   for(path_searcht::property_mapt::const_iterator
@@ -487,7 +487,7 @@ void symex_parse_optionst::report_properties(
       it!=property_map.end();
       it++)
   {
-    if(get_ui()==ui_message_handlert::XML_UI)
+    if(get_ui()==ui_message_handlert::uit::XML_UI)
     {
       xmlt xml_result("result");
       xml_result.set_attribute("claim", id2string(it->first));
@@ -561,10 +561,10 @@ void symex_parse_optionst::report_success()
 
   switch(get_ui())
   {
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     break;
 
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
     {
       xmlt xml("cprover-status");
       xml.data="SUCCESS";
@@ -597,12 +597,12 @@ void symex_parse_optionst::show_counterexample(
 
   switch(get_ui())
   {
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     std::cout << '\n' << "Counterexample:" << '\n';
     show_goto_trace(std::cout, ns, error_trace);
     break;
 
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
     {
       xmlt xml;
       convert(ns, error_trace, xml);
@@ -633,10 +633,10 @@ void symex_parse_optionst::report_failure()
 
   switch(get_ui())
   {
-  case ui_message_handlert::PLAIN:
+  case ui_message_handlert::uit::PLAIN:
     break;
 
-  case ui_message_handlert::XML_UI:
+  case ui_message_handlert::uit::XML_UI:
     {
       xmlt xml("cprover-status");
       xml.data="FAILURE";

--- a/src/symex/symex_parse_options.cpp
+++ b/src/symex/symex_parse_options.cpp
@@ -261,12 +261,12 @@ int symex_parse_optionst::doit()
       // do actual symex, for assertion checking
       switch(path_search(goto_model.goto_functions))
       {
-      case safety_checkert::SAFE:
+      case safety_checkert::resultt::SAFE:
         report_properties(path_search.property_map);
         report_success();
         return 0;
 
-      case safety_checkert::UNSAFE:
+      case safety_checkert::resultt::UNSAFE:
         report_properties(path_search.property_map);
         report_failure();
         return 10;

--- a/src/util/decision_procedure.h
+++ b/src/util/decision_procedure.h
@@ -39,7 +39,7 @@ public:
   { set_to(expr, false); }
 
   // solve the problem
-  typedef enum { D_SATISFIABLE, D_UNSATISFIABLE, D_ERROR } resultt;
+  enum class resultt { D_SATISFIABLE, D_UNSATISFIABLE, D_ERROR };
 
   // will eventually be protected, use below call operator
   virtual resultt dec_solve()=0;

--- a/src/util/find_symbols.cpp
+++ b/src/util/find_symbols.cpp
@@ -11,7 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "find_symbols.h"
 
-typedef enum { F_TYPE, F_TYPE_NON_PTR, F_EXPR, F_BOTH } kindt;
+enum class kindt { F_TYPE, F_TYPE_NON_PTR, F_EXPR, F_BOTH };
 
 /*******************************************************************\
 
@@ -181,7 +181,7 @@ void find_symbols(kindt kind, const exprt &src, find_symbols_sett &dest)
 
   find_symbols(kind, src.type(), dest);
 
-  if(kind==F_BOTH || kind==F_EXPR)
+  if(kind==kindt::F_BOTH || kind==kindt::F_EXPR)
     if(src.id()==ID_symbol ||
        src.id()==ID_next_symbol)
       dest.insert(src.get(ID_identifier));
@@ -211,7 +211,7 @@ Function: find_symbols
 
 void find_symbols(kindt kind, const typet &src, find_symbols_sett &dest)
 {
-  if(kind!=F_TYPE_NON_PTR ||
+  if(kind!=kindt::F_TYPE_NON_PTR ||
      src.id()!=ID_pointer)
   {
     if(src.has_subtype())
@@ -287,7 +287,7 @@ Function: find_type_symbols
 
 void find_type_symbols(const exprt &src, find_symbols_sett &dest)
 {
-  find_symbols(F_TYPE, src, dest);
+  find_symbols(kindt::F_TYPE, src, dest);
 }
 
 /*******************************************************************\
@@ -304,7 +304,7 @@ Function: find_type_symbols
 
 void find_type_symbols(const typet &src, find_symbols_sett &dest)
 {
-  find_symbols(F_TYPE, src, dest);
+  find_symbols(kindt::F_TYPE, src, dest);
 }
 
 /*******************************************************************\
@@ -323,7 +323,7 @@ void find_non_pointer_type_symbols(
   const exprt &src,
   find_symbols_sett &dest)
 {
-  find_symbols(F_TYPE_NON_PTR, src, dest);
+  find_symbols(kindt::F_TYPE_NON_PTR, src, dest);
 }
 
 /*******************************************************************\
@@ -342,7 +342,7 @@ void find_non_pointer_type_symbols(
   const typet &src,
   find_symbols_sett &dest)
 {
-  find_symbols(F_TYPE_NON_PTR, src, dest);
+  find_symbols(kindt::F_TYPE_NON_PTR, src, dest);
 }
 
 /*******************************************************************\
@@ -359,7 +359,7 @@ Function: find_type_and_expr_symbols
 
 void find_type_and_expr_symbols(const exprt &src, find_symbols_sett &dest)
 {
-  find_symbols(F_BOTH, src, dest);
+  find_symbols(kindt::F_BOTH, src, dest);
 }
 
 /*******************************************************************\
@@ -376,5 +376,5 @@ Function: find_type_and_expr_symbols
 
 void find_type_and_expr_symbols(const typet &src, find_symbols_sett &dest)
 {
-  find_symbols(F_BOTH, src, dest);
+  find_symbols(kindt::F_BOTH, src, dest);
 }

--- a/src/util/format_spec.h
+++ b/src/util/format_spec.h
@@ -23,14 +23,14 @@ public:
   // eE: SCIENTIFIC
   // gG: AUTOMATIC
 
-  typedef enum { DECIMAL, SCIENTIFIC, AUTOMATIC } stylet;
+  enum class stylet { DECIMAL, SCIENTIFIC, AUTOMATIC };
   stylet style;
 
   format_spect():
     min_width(0),
     precision(6),
     zero_padding(false),
-    style(AUTOMATIC)
+    style(stylet::AUTOMATIC)
   {
   }
 
@@ -44,12 +44,12 @@ public:
 
   static format_spect scientific()
   {
-    return format_spect(SCIENTIFIC);
+    return format_spect(stylet::SCIENTIFIC);
   }
 
   static format_spect automatic()
   {
-    return format_spect(AUTOMATIC);
+    return format_spect(stylet::AUTOMATIC);
   }
 };
 

--- a/src/util/ieee_float.cpp
+++ b/src/util/ieee_float.cpp
@@ -151,15 +151,15 @@ std::string ieee_floatt::format(const format_spect &format_spec) const
 
   switch(format_spec.style)
   {
-  case format_spect::DECIMAL:
+  case format_spect::stylet::DECIMAL:
     result+=to_string_decimal(format_spec.precision);
     break;
 
-  case format_spect::SCIENTIFIC:
+  case format_spect::stylet::SCIENTIFIC:
     result+=to_string_scientific(format_spec.precision);
     break;
 
-  case format_spect::AUTOMATIC:
+  case format_spect::stylet::AUTOMATIC:
     {
       // "Style e is used if the exponent from its conversion
       //  is less than -4 or greater than or equal to the precision."

--- a/src/util/ieee_float.h
+++ b/src/util/ieee_float.h
@@ -110,12 +110,12 @@ public:
   // ROUND_TO_EVEN is also known as "round to nearest, ties to even", and
   // is the IEEE default.
   // The numbering below is what x86 uses in the control word.
-  typedef enum
+  enum rounding_modet
   {
     ROUND_TO_EVEN=0, ROUND_TO_MINUS_INF=1,
     ROUND_TO_PLUS_INF=2,  ROUND_TO_ZERO=3,
     UNKNOWN, NONDETERMINISTIC
-  } rounding_modet;
+  };
 
   rounding_modet rounding_mode;
 

--- a/src/util/json.cpp
+++ b/src/util/json.cpp
@@ -10,7 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "json.h"
 
-const jsont jsont::null_json_object(jsont::J_NULL);
+const jsont jsont::null_json_object(jsont::kindt::J_NULL);
 
 /*******************************************************************\
 
@@ -78,17 +78,17 @@ void jsont::output_rec(std::ostream &out, unsigned indent) const
 {
   switch(kind)
   {
-  case J_STRING:
+  case kindt::J_STRING:
     out << '"';
     escape_string(value, out);
     out << '"';
     break;
 
-  case J_NUMBER:
+  case kindt::J_NUMBER:
     out << value;
     break;
 
-  case J_OBJECT:
+  case kindt::J_OBJECT:
     out << '{';
     for(objectt::const_iterator o_it=object.begin();
         o_it!=object.end();
@@ -115,7 +115,7 @@ void jsont::output_rec(std::ostream &out, unsigned indent) const
     out << '}';
     break;
 
-  case J_ARRAY:
+  case kindt::J_ARRAY:
     out << '[';
 
     if(array.empty())
@@ -149,11 +149,11 @@ void jsont::output_rec(std::ostream &out, unsigned indent) const
     out << ']';
     break;
 
-  case J_TRUE: out << "true"; break;
+  case kindt::J_TRUE: out << "true"; break;
 
-  case J_FALSE: out << "false"; break;
+  case kindt::J_FALSE: out << "false"; break;
 
-  case J_NULL: out << "null"; break;
+  case kindt::J_NULL: out << "null"; break;
   }
 }
 

--- a/src/util/json.h
+++ b/src/util/json.h
@@ -20,46 +20,55 @@ class json_arrayt;
 class jsont
 {
 public:
-  typedef enum { J_STRING, J_NUMBER, J_OBJECT, J_ARRAY,
-                 J_TRUE, J_FALSE, J_NULL } kindt;
+  enum class kindt
+  {
+    J_STRING,
+    J_NUMBER,
+    J_OBJECT,
+    J_ARRAY,
+    J_TRUE,
+    J_FALSE,
+    J_NULL
+  };
+
   kindt kind;
 
   bool is_string() const
   {
-    return kind==J_STRING;
+    return kind==kindt::J_STRING;
   }
 
   bool is_number() const
   {
-    return kind==J_NUMBER;
+    return kind==kindt::J_NUMBER;
   }
 
   bool is_object() const
   {
-    return kind==J_OBJECT;
+    return kind==kindt::J_OBJECT;
   }
 
   bool is_array() const
   {
-    return kind==J_ARRAY;
+    return kind==kindt::J_ARRAY;
   }
 
   bool is_true() const
   {
-    return kind==J_TRUE;
+    return kind==kindt::J_TRUE;
   }
 
   bool is_false() const
   {
-    return kind==J_FALSE;
+    return kind==kindt::J_FALSE;
   }
 
   bool is_null() const
   {
-    return kind==J_NULL;
+    return kind==kindt::J_NULL;
   }
 
-  jsont():kind(J_NULL)
+  jsont():kind(kindt::J_NULL)
   {
   }
 
@@ -72,13 +81,13 @@ public:
 
   static jsont json_boolean(bool value)
   {
-    return jsont(value?J_TRUE:J_FALSE);
+    return jsont(value?kindt::J_TRUE:kindt::J_FALSE);
   }
 
   void clear()
   {
     value.clear();
-    kind=J_NULL;
+    kind=kindt::J_NULL;
     object.clear();
     array.clear();
   }
@@ -130,7 +139,7 @@ inline std::ostream &operator<<(std::ostream &out, const jsont &src)
 class json_arrayt:public jsont
 {
 public:
-  json_arrayt():jsont(J_ARRAY)
+  json_arrayt():jsont(kindt::J_ARRAY)
   {
   }
 
@@ -161,7 +170,7 @@ class json_stringt:public jsont
 {
 public:
   explicit json_stringt(const std::string &_value):
-    jsont(J_STRING, _value)
+    jsont(kindt::J_STRING, _value)
   {
   }
 };
@@ -170,7 +179,7 @@ class json_numbert:public jsont
 {
 public:
   explicit json_numbert(const std::string &_value):
-    jsont(J_NUMBER, _value)
+    jsont(kindt::J_NUMBER, _value)
   {
   }
 };
@@ -178,7 +187,7 @@ public:
 class json_objectt:public jsont
 {
 public:
-  json_objectt():jsont(J_OBJECT)
+  json_objectt():jsont(kindt::J_OBJECT)
   {
   }
 
@@ -200,30 +209,30 @@ public:
 class json_truet:public jsont
 {
 public:
-  json_truet():jsont(J_TRUE) { }
+  json_truet():jsont(kindt::J_TRUE) { }
 };
 
 class json_falset:public jsont
 {
 public:
-  json_falset():jsont(J_FALSE) { }
+  json_falset():jsont(kindt::J_FALSE) { }
 };
 
 class json_nullt:public jsont
 {
 public:
-  json_nullt():jsont(J_NULL) { }
+  json_nullt():jsont(kindt::J_NULL) { }
 };
 
 inline json_arrayt &jsont::make_array()
 {
-  kind=J_ARRAY;
+  kind=kindt::J_ARRAY;
   return static_cast<json_arrayt &>(*this);
 }
 
 inline json_objectt &jsont::make_object()
 {
-  kind=J_OBJECT;
+  kind=kindt::J_OBJECT;
   return static_cast<json_objectt &>(*this);
 }
 

--- a/src/util/ui_message.cpp
+++ b/src/util/ui_message.cpp
@@ -33,10 +33,10 @@ ui_message_handlert::ui_message_handlert(
 {
   switch(__ui)
   {
-  case PLAIN:
+  case uit::PLAIN:
     break;
 
-  case XML_UI:
+  case uit::XML_UI:
     std::cout << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" << "\n";
     std::cout << "<cprover>" << "\n";
 
@@ -49,7 +49,7 @@ ui_message_handlert::ui_message_handlert(
     }
     break;
 
-  case JSON_UI:
+  case uit::JSON_UI:
     {
       std::cout << "[\n";
       json_objectt json_program;
@@ -76,9 +76,9 @@ ui_message_handlert::ui_message_handlert(
   const class cmdlinet &cmdline,
   const std::string &program):
   ui_message_handlert(
-    cmdline.isset("xml-ui")?XML_UI:
-    cmdline.isset("json-ui")?JSON_UI:
-    PLAIN,
+    cmdline.isset("xml-ui")?uit::XML_UI:
+    cmdline.isset("json-ui")?uit::JSON_UI:
+    uit::PLAIN,
     program)
 {
 }
@@ -99,15 +99,15 @@ ui_message_handlert::~ui_message_handlert()
 {
   switch(get_ui())
   {
-  case XML_UI:
+  case uit::XML_UI:
     std::cout << "</cprover>" << "\n";
     break;
 
-  case JSON_UI:
+  case uit::JSON_UI:
     std::cout << "\n]\n";
     break;
 
-  case PLAIN:
+  case uit::PLAIN:
     break;
   }
 }
@@ -154,15 +154,15 @@ void ui_message_handlert::print(
   {
     switch(get_ui())
     {
-    case PLAIN:
+    case uit::PLAIN:
     {
       console_message_handlert console_message_handler;
       console_message_handler.print(level, message);
     }
     break;
 
-    case XML_UI:
-    case JSON_UI:
+    case uit::XML_UI:
+    case uit::JSON_UI:
     {
       source_locationt location;
       location.make_nil();
@@ -195,13 +195,13 @@ void ui_message_handlert::print(
   {
     switch(get_ui())
     {
-    case PLAIN:
+    case uit::PLAIN:
       message_handlert::print(
         level, message, sequence_number, location);
       break;
 
-    case XML_UI:
-    case JSON_UI:
+    case uit::XML_UI:
+    case uit::JSON_UI:
     {
       std::string tmp_message(message);
 
@@ -240,14 +240,14 @@ void ui_message_handlert::ui_msg(
 {
   switch(get_ui())
   {
-  case PLAIN:
+  case uit::PLAIN:
     break;
 
-  case XML_UI:
+  case uit::XML_UI:
     xml_ui_msg(type, msg1, msg2, location);
     break;
 
-  case JSON_UI:
+  case uit::JSON_UI:
     json_ui_msg(type, msg1, msg2, location);
     break;
   }

--- a/src/util/ui_message.h
+++ b/src/util/ui_message.h
@@ -14,7 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 class ui_message_handlert:public message_handlert
 {
 public:
-  typedef enum { PLAIN, XML_UI, JSON_UI } uit;
+  enum class uit { PLAIN, XML_UI, JSON_UI };
 
   ui_message_handlert(uit, const std::string &program);
   ui_message_handlert(const class cmdlinet &, const std::string &program);


### PR DESCRIPTION
Strongly typed enums allow us to benefit from stronger type-checking and reduced namespace pollution.

The conversion method was essentially:
- Does the enum specify the integer values of its members? If so:
  - The implicit integer conversion is probably important, so just use `enum <name> {};` syntax, else
  - The integer value of the enum probably doesn't matter too much, so use `enum class <name> {};`

Of course, `enum class` still has an underlying integral representation, but you have to `static_cast` to get at it. I'd prefer to use `enum class` everywhere, but it would have made this PR gigantic, so that might be something for a follow-up PR.