### PR TITLE
Improved the error message if an invalid argument is given to unwind

### DIFF
--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -167,7 +167,17 @@ int goto_instrument_parse_optionst::doit()
         int k=-1;
 
         if(unwind)
-          k=std::stoi(cmdline.get_value("unwind"));
+        {
+          try
+          {
+            k=std::stoi(cmdline.get_value("unwind"));
+          }
+          catch (std::invalid_argument)
+          {
+            throw "unwind parameter requires an integer unwind bound";
+          }
+        }
+
 
         unwind_sett unwind_set;
 


### PR DESCRIPTION
Some CBMC arguments that modify the GOTO program take as an argument the name of the result. For unwind it takes an integer number for how many times to unwind. This transforms the exception that is thrown when a user misunderstands this into something readable.