### PR TITLE
Add brackets to resolve ambiguity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,7 +152,7 @@ script:
   - if [ -e bin/gcc ] ; then export PATH=$PWD/bin:$PATH ; fi ;
     COMMAND="env UBSAN_OPTIONS=print_stacktrace=1 make -C regression test" &&
     eval ${PRE_COMMAND} ${COMMAND}
-  - COMMAND="make -C unit CXX=\"$COMPILER\" CXXFLAGS=\"$FLAGS $EXTRA_CXXFLAGS\" -j2" &&
+  - COMMAND="make -C unit CXX=\"$COMPILER\" CXXFLAGS=\"-Wall -Werror -pedantic -O2 -g $EXTRA_CXXFLAGS\" -j2" &&
     eval ${PRE_COMMAND} ${COMMAND}
   - COMMAND="make -C unit test" && eval ${PRE_COMMAND} ${COMMAND}
 

--- a/unit/miniBDD.cpp
+++ b/unit/miniBDD.cpp
@@ -18,7 +18,7 @@ void test1()
   mini_bddt x=mgr.Var("x");
   mini_bddt y=mgr.Var("y");
   mini_bddt z=mgr.Var("z");
-  mini_bddt f=(x&y&z)|(!x&!y&z);
+  mini_bddt f=(x&y&z)|((!x)&(!y)&z);
   y.clear();
   x.clear();
   z.clear();


### PR DESCRIPTION
There is an ambiguity in this expression caused by a mix of bit-wise (operator&) and logical (operator!) operators in mini_bdd.
Personally I would change the bit-wise operators to logical operators in mini_bdd but some concern was raised that people may then wrongly expect them to short-circuit, as the Boolean logical operators do. (Overridden logical operators do not short-circuit, as stated here under *Restrictions*: http://en.cppreference.com/w/cpp/language/operators.)
The other option would be to change the operator! to operator~, but in my opinion this would be moving in the wrong direction and reduce code-clarity.