### PR TITLE
Added tests that demonstrate problems in function pointer removal

### DIFF
--- a/regression/goto-analyzer/approx-const-fp-array-variable-struct-const-fp-with-zero/main.c
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-struct-const-fp-with-zero/main.c
@@ -1,0 +1,42 @@
+#include <stdio.h>
+
+void f1 (void) { printf("%i\n", 1); }
+void f2 (void) { printf("%i\n", 2); }
+void f3 (void) { printf("%i\n", 3); }
+void f4 (void) { printf("%i\n", 4); }
+void f5 (void) { printf("%i\n", 5); }
+void f6 (void) { printf("%i\n", 6); }
+void f7 (void) { printf("%i\n", 7); }
+void f8 (void) { printf("%i\n", 8); }
+void f9 (void) { printf("%i\n", 9); }
+
+typedef void(*void_fp)(void);
+
+struct action
+{
+  int x;
+  void_fp fun;
+};
+
+// Array with an empty final element
+const struct action fp_tbl[5] = {{1, f2}, {2, f3} ,{3, f4},};
+
+// There is a basic check that excludes all functions that aren't used anywhere
+// This ensures that check can't work in this example
+const void_fp fp_all[] = {f1, f2 ,f3, f4, f5 ,f6, f7, f8, f9};
+
+void func(int i)
+{
+  const void_fp fp = fp_tbl[i].fun;
+  fp();
+}
+
+int main()
+{
+  for(int i=0;i<3;i++)
+  {
+    func(i);
+  }
+
+  return 0;
+}

--- a/regression/goto-analyzer/approx-const-fp-array-variable-struct-const-fp-with-zero/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-struct-const-fp-with-zero/test.desc
@@ -1,0 +1,18 @@
+KNOWNBUG
+main.c
+--show-goto-functions --verbosity 10 --pointer-check
+^Removing function pointers and virtual functions$
+^\s*IF fp == f2 THEN GOTO [0-9]$
+^\s*IF fp == f3 THEN GOTO [0-9]$
+^\s*IF fp == f4 THEN GOTO [0-9]$
+^\s*ASSERT FALSE // invalid function pointer$
+^SIGNAL=0$
+--
+^warning: ignoring
+
+^\s*IF fp == f1 THEN GOTO [0-9]$
+^\s*IF fp == f1 THEN GOTO [0-9]$
+^\s*IF fp == f1 THEN GOTO [0-9]$
+^\s*IF fp == f1 THEN GOTO [0-9]$
+^\s*IF fp == f1 THEN GOTO [0-9]$
+^\s*IF fp == f1 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/precise-const-fp-supurious-const-loss/main.c
+++ b/regression/goto-analyzer/precise-const-fp-supurious-const-loss/main.c
@@ -1,0 +1,34 @@
+#include <stdio.h>
+
+void f1 (void) { printf("%i\n", 1); }
+void f2 (void) { printf("%i\n", 2); }
+void f3 (void) { printf("%i\n", 3); }
+void f4 (void) { printf("%i\n", 4); }
+void f5 (void) { printf("%i\n", 5); }
+void f6 (void) { printf("%i\n", 6); }
+void f7 (void) { printf("%i\n", 7); }
+void f8 (void) { printf("%i\n", 8); }
+void f9 (void) { printf("%i\n", 9); }
+
+typedef void(*void_fp)(void);
+
+// There is a basic check that excludes all functions that aren't used anywhere
+// This ensures that check can't work in this example
+const void_fp fp_all[] = {f1, f2 ,f3, f4, f5 ,f6, f7, f8, f9};
+
+const int const_number=4;
+
+void func()
+{
+  // Here we 'lose' const-ness except it is a copy so we shouldn't care
+  int non_const_number=const_number;
+  const void_fp fp = f2;
+  fp();
+}
+
+int main()
+{
+  func();
+
+  return 0;
+}

--- a/regression/goto-analyzer/precise-const-fp-supurious-const-loss/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-supurious-const-loss/test.desc
@@ -1,0 +1,18 @@
+KNOWNBUG
+main.c
+--show-goto-functions --verbosity 10 --pointer-check
+^Removing function pointers and virtual functions$
+^\s*f2\(\);
+--
+^warning: ignoring
+^\s*\d+:\s*f1\(\);
+^\s*\d+:\s*f3\(\);
+^\s*\d+:\s*f4\(\);
+^\s*\d+:\s*f5\(\);
+^\s*\d+:\s*f6\(\);
+^\s*\d+:\s*f7\(\);
+^\s*\d+:\s*f8\(\);
+^\s*\d+:\s*f9\(\);
+--
+Though this example program appears to lose const-ness, since it is a primitive
+it is a copy so it is irrelevant.


### PR DESCRIPTION
Added two test cases that currently don't work correctly when removing function pointers. 

**Irrelevant loss of const**

If a const primitive is assigned to a non-const primitive, this is classified as a loss of const-ness which causes the FP removal to fall back to worst case behaviour. However, this is a copy so irrelevant and should be ignored. 

**Array of structs with null pointer**

We correctly deal with an array containing FPs including a null pointer, but do not deal with it if the pointer is inside a struct. The behaviour should be consistent. 