### PR TITLE
Remove unneeded code

### DIFF
--- a/src/cpp/expr2cpp.cpp
+++ b/src/cpp/expr2cpp.cpp
@@ -26,16 +26,6 @@ class expr2cppt:public expr2ct
 public:
   explicit expr2cppt(const namespacet &_ns):expr2ct(_ns) { }
 
-  std::string convert(const exprt &src) override
-  {
-    return expr2ct::convert(src);
-  }
-
-  std::string convert(const typet &src) override
-  {
-    return expr2ct::convert(src);
-  }
-
 protected:
   std::string convert_with_precedence(
     const exprt &src, unsigned &precedence) override;

--- a/src/jsil/expr2jsil.cpp
+++ b/src/jsil/expr2jsil.cpp
@@ -15,16 +15,6 @@ class expr2jsilt:public expr2ct
 public:
   explicit expr2jsilt(const namespacet &_ns):expr2ct(_ns) { }
 
-  virtual std::string convert(const exprt &src)
-  {
-    return expr2ct::convert(src);
-  }
-
-  virtual std::string convert(const typet &src)
-  {
-    return expr2ct::convert(src);
-  }
-
 protected:
 };
 


### PR DESCRIPTION
Now that PR #916 has been merged, we don't need to manually forward
convert(const exprt) and convert(const typet) calls to the base class.