### PR TITLE
Fix a mistake in convert_is_java_identifier_start

### DIFF
--- a/src/java_bytecode/character_refine_preprocess.cpp
+++ b/src/java_bytecode/character_refine_preprocess.cpp
@@ -1059,7 +1059,7 @@ codet character_refine_preprocesst::convert_is_java_identifier_start_char(
     conversion_inputt &target)
 {
   return convert_char_function(
-    &character_refine_preprocesst::expr_of_is_unicode_identifier_part, target);
+    &character_refine_preprocesst::expr_of_is_unicode_identifier_start, target);
 }
 
 /*******************************************************************\


### PR DESCRIPTION
The wrong function was previously called: `expr_of_is_unicode_identifer_part` instead of `expr_of_is_unicode_indentifier_start`.
This is related to diffblue/test-gen#118