### PR TITLE
Do not configure bmct/prop_convt before reading goto programs

### DIFF
--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -503,27 +503,6 @@ int cbmc_parse_optionst::doit()
 
   goto_functionst goto_functions;
 
-  // get solver
-  cbmc_solverst cbmc_solvers(options, symbol_table, ui_message_handler);
-  cbmc_solvers.set_ui(get_ui());
-
-  std::unique_ptr<cbmc_solverst::solvert> cbmc_solver;
-
-  try
-  {
-    cbmc_solver=cbmc_solvers.get_solver();
-  }
-
-  catch(const char *error_msg)
-  {
-    error() << error_msg << eom;
-    return 1; // should contemplate EX_SOFTWARE from sysexits.h
-  }
-
-  prop_convt &prop_conv=cbmc_solver->prop_conv();
-
-  bmct bmc(options, symbol_table, ui_message_handler, prop_conv);
-
   expr_listt bmc_constraints;
 
   int get_goto_program_ret=
@@ -551,7 +530,7 @@ int cbmc_parse_optionst::doit()
     remove_static_init_loops(symbol_table, goto_functions, options);
 
   // do actual BMC
-  return do_bmc(bmc, goto_functions);
+  return do_bmc(options, goto_functions);
 }
 
 /*******************************************************************\
@@ -1002,9 +981,29 @@ Function: cbmc_parse_optionst::do_bmc
 \*******************************************************************/
 
 int cbmc_parse_optionst::do_bmc(
-  bmct &bmc,
+  const optionst &options,
   const goto_functionst &goto_functions)
 {
+  // get solver
+  cbmc_solverst cbmc_solvers(options, symbol_table, ui_message_handler);
+  cbmc_solvers.set_ui(get_ui());
+
+  std::unique_ptr<cbmc_solverst::solvert> cbmc_solver;
+
+  try
+  {
+    cbmc_solver=cbmc_solvers.get_solver();
+  }
+
+  catch(const char *error_msg)
+  {
+    error() << error_msg << eom;
+    throw 0;
+  }
+
+  prop_convt &prop_conv=cbmc_solver->prop_conv();
+
+  bmct bmc(options, symbol_table, ui_message_handler, prop_conv);
   bmc.set_ui(get_ui());
 
   int result=6;

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -82,7 +82,9 @@ protected:
   virtual void register_languages();
 
   virtual void get_command_line_options(optionst &options);
-  virtual int do_bmc(bmct &bmc, const goto_functionst &goto_functions);
+  virtual int do_bmc(
+    const optionst &options,
+    const goto_functionst &goto_functions);
 
   virtual int get_goto_program(
     const optionst &options,

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -267,6 +267,9 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
   if(!is_ptr(expr.type()))
     throw "convert_pointer_type got non-pointer type";
 
+  // make sure the config hasn't been changed
+  assert(bits==config.ansi_c.pointer_width);
+
   if(expr.id()==ID_symbol)
   {
     const irep_idt &identifier=to_symbol_expr(expr).get_identifier();


### PR DESCRIPTION
get_goto_program may affect configt, in particular the ansi_c.pointer_width.
Thus prop_convt may be configured with the wrong pointer width in bv_pointerst.

It is not clear from the code base what get_modules is meant to do.