### PR TITLE
Adding accessors for the access properties

### DIFF
--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -866,6 +866,16 @@ public:
     set(ID_C_inlined, value);
   }
 
+  const irep_idt &get_access() const
+  {
+    return get(ID_access);
+  }
+
+  void set_access(const irep_idt &access)
+  {
+    return set(ID_access, access);
+  }
+
   // this produces the list of parameter identifiers
   std::vector<irep_idt> parameter_identifiers() const
   {


### PR DESCRIPTION
To avoid usage of `get` directly, introducing accessors  for the access properties of functions.  Required as part of diffblue/test-gen#393