### PR TITLE
Reset unwinding counters when leaving a loop at the loop head

### DIFF
--- a/regression/cbmc/unwind_counters1/main.c
+++ b/regression/cbmc/unwind_counters1/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  for(int i=0; i<2; ++i)
+    for(int j=0; j<10; ++j);
+  return 0;
+}

--- a/regression/cbmc/unwind_counters1/test.desc
+++ b/regression/cbmc/unwind_counters1/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--unwind 11 --unwinding-assertions
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--

--- a/regression/cbmc/unwind_counters2/main.c
+++ b/regression/cbmc/unwind_counters2/main.c
@@ -1,0 +1,8 @@
+int main()
+{
+  l2: goto l1;
+  l1: int x=5;
+  goto l2;
+
+  return 0;
+}

--- a/regression/cbmc/unwind_counters2/test.desc
+++ b/regression/cbmc/unwind_counters2/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--unwind 3 --unwinding-assertions
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--

--- a/regression/cbmc/unwind_counters3/main.c
+++ b/regression/cbmc/unwind_counters3/main.c
@@ -1,0 +1,9 @@
+int main()
+{
+  int i=0;
+  l2: if(i==1) int y=0;
+  l1: int x=5;
+  goto l2;
+
+  return 0;
+}

--- a/regression/cbmc/unwind_counters3/test.desc
+++ b/regression/cbmc/unwind_counters3/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--unwind 3 --unwinding-assertions
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -155,6 +155,16 @@ protected:
   irep_idt guard_identifier;
 
   // symex
+  virtual void symex_transition(
+    statet &state,
+    goto_programt::const_targett to,
+    bool is_backwards_goto=false);
+  virtual void symex_transition(statet &state)
+  {
+    goto_programt::const_targett next=state.source.pc;
+    ++next;
+    symex_transition(state, next);
+  }
 
   virtual void symex_goto(statet &state);
   virtual void symex_start_thread(statet &state);

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -254,7 +254,7 @@ void goto_symext::symex_function_call_code(
       state.guard.add(false_exprt());
     }
 
-    state.source.pc++;
+    symex_transition(state);
     return;
   }
 
@@ -276,7 +276,7 @@ void goto_symext::symex_function_call_code(
       symex_assign_rec(state, code);
     }
 
-    state.source.pc++;
+    symex_transition(state);
     return;
   }
 
@@ -314,7 +314,7 @@ void goto_symext::symex_function_call_code(
   frame.loop_iterations[identifier].count++;
 
   state.source.is_set=true;
-  state.source.pc=goto_function.body.instructions.begin();
+  symex_transition(state, goto_function.body.instructions.begin());
 }
 
 /// pop one call frame
@@ -326,7 +326,7 @@ void goto_symext::pop_frame(statet &state)
     statet::framet &frame=state.top();
 
     // restore program counter
-    state.source.pc=frame.calling_location.pc;
+    symex_transition(state, frame.calling_location.pc);
 
     // restore L1 renaming
     state.level1.restore_from(frame.old_level1);

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -105,18 +105,6 @@ void goto_symext::symex_goto(statet &state)
       return; // nothing else to do
     }
   }
-  else if(new_guard.is_true() && !old_guard.is_true())
-  {
-    // we may have left a loop (i.e., the forward goto is beyond
-    // the end of the loop) as the loop condition has become false
-    // via constant propagation and simplification (the original
-    // condition "old_guard" was not trivially true, but "new_guard"
-    // is) -- reset all candidate loop counters
-    for(const auto &i_e : instruction.incoming_edges)
-      if(i_e->is_goto() && i_e->is_backwards_goto() &&
-         goto_target->location_number>i_e->location_number)
-        frame.loop_iterations[goto_programt::loop_id(i_e)].count=0;
-  }
 
   goto_programt::const_targett new_state_pc, state_pc;
   symex_targett::sourcet original_source=state.source;

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -105,6 +105,18 @@ void goto_symext::symex_goto(statet &state)
       return; // nothing else to do
     }
   }
+  else if(new_guard.is_true() && !old_guard.is_true())
+  {
+    // we may have left a loop (i.e., the forward goto is beyond
+    // the end of the loop) as the loop condition has become false
+    // via constant propagation and simplification (the original
+    // condition "old_guard" was not trivially true, but "new_guard"
+    // is) -- reset all candidate loop counters
+    for(const auto &i_e : instruction.incoming_edges)
+      if(i_e->is_goto() && i_e->is_backwards_goto() &&
+         goto_target->location_number>i_e->location_number)
+        frame.loop_iterations[goto_programt::loop_id(i_e)].count=0;
+  }
 
   goto_programt::const_targett new_state_pc, state_pc;
   symex_targett::sourcet original_source=state.source;


### PR DESCRIPTION
Constant propagation and simplification may determine that a loop cannot be
unrolled further. This is determined at the loop head, which is a forward goto
in case of for or while (but not do-while) loops. Before this patch, forward
gotos would never cause loop counters to be reset. In nested loops, the inner
loop(s) would thus have their unwinding counts added to previous (complete) loop
executions.