### PR TITLE
Improve constructor and copy of strings

### DIFF
--- a/src/java_bytecode/java_string_library_preprocess.h
+++ b/src/java_bytecode/java_string_library_preprocess.h
@@ -136,6 +136,16 @@ private:
     const source_locationt &loc,
     symbol_tablet &symbol_table);
 
+  codet make_copy_string_code(
+    const code_typet &type,
+    const source_locationt &loc,
+    symbol_tablet &symbol_table);
+
+  codet make_copy_constructor_code(
+    const code_typet &type,
+    const source_locationt &loc,
+    symbol_tablet &symbol_table);
+
   // Auxiliary functions
   codet code_for_scientific_notation(
     const exprt &arg,
@@ -250,6 +260,12 @@ private:
     const source_locationt &loc,
     symbol_tablet &symbol_table,
     code_blockt &code);
+
+  codet code_assign_components_to_java_string(
+    const exprt &lhs,
+    const exprt &rhs_array,
+    const exprt &rhs_length,
+    symbol_tablet &symbol_table);
 
   codet code_assign_string_expr_to_java_string(
     const exprt &lhs, const string_exprt &rhs, symbol_tablet &symbol_table);


### PR DESCRIPTION
We now assign strings in one step instead of field by field.
This makes constant propagation work better in later step of the analysis.

This is necessary for the implementation of String.replace().

Part of diffblue/cbmc#256.
Partly replaces #984.