### PR TITLE
Write traces to status() not cout

### DIFF
--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -78,15 +78,16 @@ void bmct::error_trace()
   switch(ui)
   {
   case ui_message_handlert::uit::PLAIN:
-    std::cout << "\n" << "Counterexample:" << "\n";
-    show_goto_trace(std::cout, ns, goto_trace);
+    status() << "Counterexample:" << eom;
+    show_goto_trace(status(), ns, goto_trace);
+    status() << eom;
     break;
 
   case ui_message_handlert::uit::XML_UI:
     {
       xmlt xml;
       convert(ns, goto_trace, xml);
-      std::cout << xml << "\n";
+      status() << xml << eom;
     }
     break;
 
@@ -103,7 +104,7 @@ void bmct::error_trace()
       result["status"]=json_stringt("failed");
       jsont &json_trace=result["trace"];
       convert(ns, goto_trace, json_trace);
-      std::cout << ",\n" << json_result;
+      status() << ",\n" << json_result << eom;
     }
     break;
   }


### PR DESCRIPTION
Traces can't be caught with a messaget; this fixes that so they are printed like everything else.