### PR TITLE
Stop attempting to convert previously-converted doc headers

### DIFF
--- a/scripts/reformat_docs.py
+++ b/scripts/reformat_docs.py
@@ -206,9 +206,7 @@ def replace_block(
     if header_formatter.is_block_valid(block):
         converted = header_formatter.convert(header_from_block(block))
         if header_formatter.needs_new_header(file_contents) and converted:
-            return '%s%s' % (
-                    block_contents.group(0),
-                    header_formatter.convert(header_from_block(block)) + '\n')
+            return block_contents.group(0) + converted + '\n'
         return block_contents.group(0)
 
     if class_formatter.is_block_valid(block):


### PR DESCRIPTION
Updates the documentation conversion script so that it doesn't try to convert file headers which have already been converted. This should mean that, after the initial run, subsequent runs of the `do_doc_convert` script do not make any changes to the codebase, which should make rebases from pre-Doxygen code much easier.