### PR TITLE
Do not remove calls to functions without a body during inlining

### DIFF
--- a/regression/goto-instrument/inline_16/main.c
+++ b/regression/goto-instrument/inline_16/main.c
@@ -1,0 +1,9 @@
+void func1();
+
+int main()
+{
+  int ret;
+
+  func1();
+  ret = func2();
+}

--- a/regression/goto-instrument/inline_16/test.desc
+++ b/regression/goto-instrument/inline_16/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--inline
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+func1\(\)
+ret.*=.*func2\(\)
+no body for function.*func1
+no body for function.*func2
+--
+^warning: ignoring

--- a/regression/goto-instrument/inline_17/main.c
+++ b/regression/goto-instrument/inline_17/main.c
@@ -1,0 +1,9 @@
+void func1()
+{
+  func2();
+}
+
+int main()
+{
+  func1();
+}

--- a/regression/goto-instrument/inline_17/test.desc
+++ b/regression/goto-instrument/inline_17/test.desc
@@ -1,13 +1,10 @@
 CORE
 main.c
---inline --remove-calls-no-body
+--function-inline func1
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
-^\s*x;$
-^\s*c;$
-^\s*a;$
-no body.*[`]f
+func1\(\)
+func2\(\)
 --
-f\(\)
 ^warning: ignoring

--- a/regression/goto-instrument/remove-calls-no-body1/main.c
+++ b/regression/goto-instrument/remove-calls-no-body1/main.c
@@ -1,0 +1,19 @@
+void func1();
+
+void func3()
+{
+}
+
+void func4()
+{
+  func1();
+  func2();
+}
+
+void main()
+{
+  func1();
+  func2();
+  func3();
+  func4();
+}

--- a/regression/goto-instrument/remove-calls-no-body1/test.desc
+++ b/regression/goto-instrument/remove-calls-no-body1/test.desc
@@ -1,13 +1,12 @@
 CORE
 main.c
---inline --remove-calls-no-body
+--remove-calls-no-body
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
-^\s*x;$
-^\s*c;$
-^\s*a;$
-no body.*[`]f
+func3\(\)
+func4\(\)
 --
-f\(\)
+func1\(\)
+func2\(\)
 ^warning: ignoring

--- a/regression/goto-instrument/remove-calls-no-body2/main.c
+++ b/regression/goto-instrument/remove-calls-no-body2/main.c
@@ -1,0 +1,21 @@
+int func1(int arg1, int arg2);
+
+void func3()
+{
+}
+
+void func4()
+{
+  func1(567, 285);
+  func2();
+}
+
+void main()
+{
+  int ret1;
+
+  ret1 = func1(567, 285);
+  func2();
+  func3();
+  func4();
+}

--- a/regression/goto-instrument/remove-calls-no-body2/test.desc
+++ b/regression/goto-instrument/remove-calls-no-body2/test.desc
@@ -1,0 +1,15 @@
+CORE
+main.c
+--remove-calls-no-body
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+func3\(\)
+func4\(\)
+567;
+285;
+ret1.*=.*NONDET
+--
+func1\(.*\)
+func2\(.*\)
+^warning: ignoring

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -992,7 +992,7 @@ void goto_instrument_parse_optionst::instrument_goto_program()
   // now do full inlining, if requested
   if(cmdline.isset("inline"))
   {
-    do_indirect_call_and_rtti_removal();
+    do_indirect_call_and_rtti_removal(/*force=*/true);
 
     if(cmdline.isset("show-custom-bitvector-analysis") ||
        cmdline.isset("custom-bitvector-analysis"))
@@ -1003,7 +1003,7 @@ void goto_instrument_parse_optionst::instrument_goto_program()
     }
 
     status() << "Performing full inlining" << eom;
-    goto_inline(goto_model, get_message_handler());
+    goto_inline(goto_model, get_message_handler(), true);
   }
 
   if(cmdline.isset("show-custom-bitvector-analysis") ||
@@ -1111,27 +1111,12 @@ void goto_instrument_parse_optionst::instrument_goto_program()
   if(cmdline.isset("partial-inline"))
   {
     do_indirect_call_and_rtti_removal();
-    do_partial_inlining();
 
-    goto_model.goto_functions.update();
-    goto_model.goto_functions.compute_loop_numbers();
-  }
+    status() << "Partial inlining" << eom;
+    goto_partial_inline(goto_functions, ns, ui_message_handler, 0, true);
 
-  // now do full inlining, if requested
-  if(cmdline.isset("inline"))
-  {
-    do_indirect_call_and_rtti_removal(/*force=*/true);
-
-    if(cmdline.isset("show-custom-bitvector-analysis") ||
-       cmdline.isset("custom-bitvector-analysis"))
-    {
-      do_remove_returns();
-      thread_exit_instrumentation(goto_model);
-      mutex_init_instrumentation(goto_model);
-    }
-
-    status() << "Performing full inlining" << eom;
-    goto_inline(goto_model, get_message_handler(), true);
+    goto_functions.update();
+    goto_functions.compute_loop_numbers();
   }
 
   if(cmdline.isset("constant-propagator"))

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -19,6 +19,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/goto_functions.h>
 #include <goto-programs/show_goto_functions.h>
 #include <goto-programs/show_properties.h>
+#include <goto-programs/remove_calls_no_body.h>
 #include <goto-programs/remove_const_function_pointers.h>
 
 #include <analyses/goto_check.h>
@@ -84,7 +85,8 @@ Author: Daniel Kroening, kroening@kroening.com
   "(show-threaded)(list-calls-args)(print-path-lengths)" \
   "(undefined-function-is-assume-false)" \
   "(remove-function-body):"\
-  "(splice-call):"
+  "(splice-call):" \
+  OPT_REMOVE_CALLS_NO_BODY
 // clang-format on
 
 class goto_instrument_parse_optionst:

--- a/src/goto-programs/Makefile
+++ b/src/goto-programs/Makefile
@@ -40,6 +40,7 @@ SRC = basic_blocks.cpp \
       read_goto_binary.cpp \
       rebuild_goto_start_function.cpp \
       remove_asm.cpp \
+      remove_calls_no_body.cpp \
       remove_complex.cpp \
       remove_const_function_pointers.cpp \
       remove_exceptions.cpp \

--- a/src/goto-programs/goto_inline.cpp
+++ b/src/goto-programs/goto_inline.cpp
@@ -79,7 +79,7 @@ void goto_inline(
 
     Forall_goto_program_instructions(i_it, goto_program)
     {
-      if(!goto_inlinet::is_call(i_it))
+      if(!i_it->is_function_call())
         continue;
 
       call_list.push_back(goto_inlinet::callt(i_it, false));

--- a/src/goto-programs/goto_inline.cpp
+++ b/src/goto-programs/goto_inline.cpp
@@ -79,7 +79,7 @@ void goto_inline(
 
     Forall_goto_program_instructions(i_it, goto_program)
     {
-      if(!i_it->is_function_call())
+      if(!goto_inlinet::is_call(i_it))
         continue;
 
       call_list.push_back(goto_inlinet::callt(i_it, false));

--- a/src/goto-programs/goto_inline_class.h
+++ b/src/goto-programs/goto_inline_class.h
@@ -6,7 +6,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-
 #ifndef CPROVER_GOTO_PROGRAMS_GOTO_INLINE_CLASS_H
 #define CPROVER_GOTO_PROGRAMS_GOTO_INLINE_CLASS_H
 

--- a/src/goto-programs/goto_inline_class.h
+++ b/src/goto-programs/goto_inline_class.h
@@ -6,6 +6,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
+
 #ifndef CPROVER_GOTO_PROGRAMS_GOTO_INLINE_CLASS_H
 #define CPROVER_GOTO_PROGRAMS_GOTO_INLINE_CLASS_H
 
@@ -168,13 +169,6 @@ protected:
     goto_programt &dest,
     goto_programt::targett target,
     const exprt &lhs,
-    const symbol_exprt &function,
-    const exprt::operandst &arguments);
-
-  void insert_function_nobody(
-    goto_programt &dest,
-    const exprt &lhs,
-    goto_programt::targett target,
     const symbol_exprt &function,
     const exprt::operandst &arguments);
 

--- a/src/goto-programs/remove_calls_no_body.cpp
+++ b/src/goto-programs/remove_calls_no_body.cpp
@@ -1,0 +1,129 @@
+/*******************************************************************\
+
+Module: Remove calls to functions without a body
+
+Author: Daniel Poetzl
+
+\*******************************************************************/
+
+/// \file
+/// Remove calls to functions without a body
+
+#include <util/invariant.h>
+#include "remove_calls_no_body.h"
+
+/// Remove a single call
+/// \param goto_program: goto program to modify
+/// \param target: iterator pointing to the call
+/// \param lhs: lhs of the call to which the return value is assigned
+/// \param arguments: arguments of the call
+void remove_calls_no_bodyt::remove_call_no_body(
+  goto_programt &goto_program,
+  goto_programt::targett target,
+  const exprt &lhs,
+  const exprt::operandst &arguments)
+{
+  PRECONDITION(target->is_function_call());
+  PRECONDITION(!goto_program.empty());
+
+  goto_programt tmp;
+
+  // evaluate function arguments -- they might have
+  // pointer dereferencing or the like
+  for(const exprt &argument : arguments)
+  {
+    goto_programt::targett t = tmp.add_instruction();
+    t->make_other(code_expressiont(argument));
+    t->source_location = target->source_location;
+    t->function = target->function;
+  }
+
+  // return value
+  if(lhs.is_not_nil())
+  {
+    side_effect_expr_nondett rhs(lhs.type());
+    rhs.add_source_location() = target->source_location;
+
+    code_assignt code(lhs, rhs);
+    code.add_source_location() = target->source_location;
+
+    goto_programt::targett t = tmp.add_instruction(ASSIGN);
+    t->source_location = target->source_location;
+    t->function = target->function;
+    t->code.swap(code);
+  }
+
+  // kill call
+  target->type = LOCATION;
+  target->code.clear();
+  target++;
+
+  goto_program.destructive_insert(target, tmp);
+}
+
+/// Check if instruction is a call to an opaque function through an ordinary
+/// (non-function pointer) call.
+/// \param target: iterator pointing to the instruction to check
+/// \param goto_functions: all goto function to look up call target
+bool remove_calls_no_bodyt::is_opaque_function_call(
+  const goto_programt::const_targett target,
+  const goto_functionst &goto_functions)
+{
+  if(!target->is_function_call())
+    return false;
+
+  const code_function_callt &cfc = to_code_function_call(target->code);
+  const exprt &f = cfc.function();
+
+  if(f.id() != ID_symbol)
+    return false;
+
+  const symbol_exprt &se = to_symbol_expr(f);
+  const irep_idt id = se.get_identifier();
+
+  goto_functionst::function_mapt::const_iterator f_it =
+    goto_functions.function_map.find(id);
+
+  if(f_it != goto_functions.function_map.end())
+  {
+    return !f_it->second.body_available();
+  }
+
+  return false;
+}
+
+/// Remove calls to functions without a body and replace them with evaluations
+/// of the arguments of the call and a nondet assignment to the variable taking
+/// the return value.
+/// \param goto_program: goto program to operate on
+/// \param goto_functions: all goto functions; for looking up functions which
+///   the goto program may call
+void remove_calls_no_bodyt::
+operator()(goto_programt &goto_program, const goto_functionst &goto_functions)
+{
+  for(goto_programt::targett it = goto_program.instructions.begin();
+      it != goto_program.instructions.end();) // no it++
+  {
+    if(is_opaque_function_call(it, goto_functions))
+    {
+      const code_function_callt &cfc = to_code_function_call(it->code);
+      remove_call_no_body(goto_program, it, cfc.lhs(), cfc.arguments());
+    }
+    else
+    {
+      it++;
+    }
+  }
+}
+
+/// Remove calls to functions without a body and replace them with evaluations
+/// of the arguments of the call and a nondet assignment to the variable taking
+/// the return value.
+/// \param goto_functions: goto functions to operate on
+void remove_calls_no_bodyt::operator()(goto_functionst &goto_functions)
+{
+  Forall_goto_functions(f_it, goto_functions)
+  {
+    (*this)(f_it->second.body, goto_functions);
+  }
+}

--- a/src/goto-programs/remove_calls_no_body.h
+++ b/src/goto-programs/remove_calls_no_body.h
@@ -1,0 +1,43 @@
+/*******************************************************************\
+
+Module: Remove calls to functions without a body
+
+Author: Daniel Poetzl
+
+\*******************************************************************/
+
+/// \file
+/// Remove calls to functions without a body
+
+#ifndef CPROVER_GOTO_PROGRAMS_REMOVE_CALLS_NO_BODY_H
+#define CPROVER_GOTO_PROGRAMS_REMOVE_CALLS_NO_BODY_H
+
+#include "goto_functions.h"
+
+class remove_calls_no_bodyt
+{
+protected:
+  bool is_opaque_function_call(
+    const goto_programt::const_targett target,
+    const goto_functionst &goto_functions);
+
+  void remove_call_no_body(
+    goto_programt &dest,
+    goto_programt::targett target,
+    const exprt &lhs,
+    const exprt::operandst &arguments);
+
+public:
+  void operator()(
+    goto_programt &goto_program,
+    const goto_functionst &goto_functions);
+
+  void operator()(goto_functionst &goto_functions);
+};
+
+#define OPT_REMOVE_CALLS_NO_BODY "(remove-calls-no-body)"
+
+#define HELP_REMOVE_CALLS_NO_BODY                                              \
+  " --remove-calls-no-body       remove calls to functions without a body\n"
+
+#endif // CPROVER_GOTO_PROGRAMS_REMOVE_CALLS_NO_BODY_H


### PR DESCRIPTION
When using ``--inline`` or ``--function-inline`` in goto-instrument, calls to functions without a body are now kept (partial inlining already keeps them).

Additionally there's now a separate analysis pass ``--remove-calls-nobody`` which removes calls to functions without a body and replaces them by a nondet assignment to the return variable and evaluations of the call arguments.