### PR TITLE
Allow anonymous namespaces

### DIFF
--- a/regression/cpp-linter/namespace/main.cpp
+++ b/regression/cpp-linter/namespace/main.cpp
@@ -1,0 +1,34 @@
+// Author: Pascal Kesseli, pascal.kesseli@diffblue.com
+
+namespace asdf {}
+
+namespace
+asdf
+{}
+
+namespace
+asdf
+  {}
+
+  namespace
+
+
+asdf
+{}
+
+namespace xyz = my::nested::namespaces;
+
+
+
+namespace {}
+
+namespace
+{ }
+
+namespace
+{
+}
+
+    namespace
+{
+}

--- a/regression/cpp-linter/namespace/test.desc
+++ b/regression/cpp-linter/namespace/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.cpp
+
+main\.cpp:3:  Do not use namespaces  \[readability/namespace\] \[4\]
+main\.cpp:5:  Do not use namespaces  \[readability/namespace\] \[4\]
+main\.cpp:9:  Do not use namespaces  \[readability/namespace\] \[4\]
+main\.cpp:13:  Do not use namespaces  \[readability/namespace\] \[4\]
+main\.cpp:19:  Do not use namespaces  \[readability/namespace\] \[4\]
+^EXIT=1$
+^SIGNAL=0$
+--

--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -6216,9 +6216,22 @@ def CheckItemIndentationInNamespace(filename, raw_lines_no_comments, linenum,
 
 def CheckNamespaceOrUsing(filename, clean_lines, linenum, error):
   line = clean_lines.elided[linenum]
-  if Match(r'^namespace(\s|$)', line):
-    error(filename, linenum, 'readability/namespace', 4,
-          'Do not use namespaces')
+  if Match(r'^\s*namespace(\s+.*)?$', line):
+    num_lines=len(clean_lines.elided)
+    current_linenum=linenum
+    while current_linenum<num_lines:
+      current_line=clean_lines.elided[current_linenum]
+      if current_linenum==linenum:
+        is_named=Match(r'^\s*namespace\s+[^\s{]+.*$', current_line)
+      else:
+        is_named=Match(r'^\s*[^\s{]+.*$', current_line)
+      if is_named:
+        error(filename, linenum, 'readability/namespace', 4,
+              'Do not use namespaces')
+        break
+      if '{' in current_line:
+        break
+      current_linenum+=1
   if Match(r'^using\s', line):
     error(filename, linenum, 'readability/namespace', 4,
           'Do not use using')


### PR DESCRIPTION
Only give warnings for namespaces with actual names, in accordance with
https://github.com/diffblue/cbmc/commit/ad4137535398efcca8f3defa291d85c2baa9faa3.
This enables the use of anonymous namespaces without warnings.