### PR TITLE
Change two errors to warnings

### DIFF
--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -894,8 +894,7 @@ typet interpretert::concretize_type(const typet &type)
     }
     else
     {
-      error() << "Failed to concretize variable array"
-              << eom;
+      warning() << "Failed to concretize variable array" << eom;
     }
   }
   return type;

--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -1054,7 +1054,7 @@ void interpretert::evaluate(
   {
     if(expr.type().id()==ID_signedbv)
     {
-      error() << "Infinite size arrays not supported" << eom;
+      warning() << "Infinite size arrays not supported" << eom;
       return;
     }
   }


### PR DESCRIPTION
"Infinite size arrays not supported" and "Failed to concretize variable
array" are now warnings rather than errors.