### PR TITLE
Fix removal of first component

### DIFF
--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -1967,7 +1967,9 @@ def GetHeaderGuardCPPVariable(filename):
 
   fileinfo = FileInfo(filename)
   file_path_from_root = fileinfo.RepositoryName()
-  file_path_from_root = 'CPROVER_' + file_path_from_root[4:]
+  # Remove first path component
+  offset=len(file_path_from_root.split(os.path.sep)[0])+1
+  file_path_from_root = 'CPROVER_' + file_path_from_root[offset:]
   if _root:
     suffix = os.sep
     # On Windows using directory separator will leave us with


### PR DESCRIPTION
Removal of first component for header guard suggestion is hard-coded to
remove 4 characters ("src/").  This doesn't work with all directory
names ("unit/").