### PR TITLE
Fix bad return type of char pointer func

### DIFF
--- a/src/solvers/refinement/string_constraint_generator_main.cpp
+++ b/src/solvers/refinement/string_constraint_generator_main.cpp
@@ -684,7 +684,12 @@ exprt string_constraint_generatort::add_axioms_for_char_pointer(
 {
   exprt char_pointer=args(fun, 1)[0];
   if(char_pointer.id()==ID_index)
-    return char_pointer.op0();
+    return typecast_exprt(char_pointer.op0(), fun.type());
+  // TODO: It seems reasonable that the result of the function application
+  //       should match the return type of the function. However it is not
+  //       clear whether this typecast is properly handled in the string
+  //       refinement. We need regression tests that use that function.
+
   // TODO: we do not know what to do in the other cases
   assert(false);
   return exprt();


### PR DESCRIPTION
We cast the return type of ID_cprover_string_array_of_char_pointer_func so that it matches its expected return type.

This addresses: diffblue/platform#975