### PR TITLE
Constant-propagate non-const ? const : const expressions and simplify

### DIFF
--- a/regression/cbmc/address_space_size_limit1/test.desc
+++ b/regression/cbmc/address_space_size_limit1/test.desc
@@ -1,7 +1,10 @@
-CORE thorough-paths broken-smt-backend
+FUTURE thorough-paths broken-smt-backend
 test.c
 --no-simplify --unwind 300 --object-bits 8
 too many addressed objects
 ^EXIT=6$
 ^SIGNAL=0$
 --
+Propagating if expressions without support by the simplifier makes this test
+very expensive. Propagation of if expressions should likely be made conditional
+on simplification being enabled.

--- a/src/goto-symex/goto_symex_is_constant.h
+++ b/src/goto-symex/goto_symex_is_constant.h
@@ -12,8 +12,8 @@ Author: Michael Tautschig, tautschn@amazon.com
 #ifndef CPROVER_GOTO_SYMEX_GOTO_SYMEX_IS_CONSTANT_H
 #define CPROVER_GOTO_SYMEX_GOTO_SYMEX_IS_CONSTANT_H
 
-#include <util/expr.h>
 #include <util/expr_util.h>
+#include <util/std_expr.h>
 
 class goto_symex_is_constantt : public is_constantt
 {
@@ -46,6 +46,13 @@ protected:
       return true;
       */
       return false;
+    }
+    else if(auto if_expr = expr_try_dynamic_cast<if_exprt>(expr))
+    {
+      // consider ?: constant if both branches are constants, irrespective of
+      // the condition
+      return is_constant(if_expr->true_case()) &&
+             is_constant(if_expr->false_case());
     }
 
     return is_constantt::is_constant(expr);

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -461,6 +461,18 @@ simplify_exprt::resultt<> simplify_exprt::simplify_plus(const plus_exprt &expr)
       return changed(simplify_plus(result));
     }
 
+    for(std::size_t op_if = 0; op_if < expr.operands().size(); ++op_if)
+    {
+      if(expr.operands()[op_if].id() == ID_if)
+      {
+        if_exprt if_expr = lift_if(expr, op_if);
+        if_expr.true_case() = simplify_plus(to_plus_expr(if_expr.true_case()));
+        if_expr.false_case() =
+          simplify_plus(to_plus_expr(if_expr.false_case()));
+        return changed(simplify_if(if_expr));
+      }
+    }
+
     // count the constants
     size_t count=0;
     forall_operands(it, expr)


### PR DESCRIPTION
This enables bounded unwinding of loops where the loop counter is modified in
branches within the loop body. Furthermore lift ?: out of more expressions
(plus, typecast, index) to enable further simplification and propagation.

Marking as do-not-merge until performance benchmarking is in place.