### PR TITLE
tvt's || operator is not marked as const

### DIFF
--- a/src/util/threeval.h
+++ b/src/util/threeval.h
@@ -74,7 +74,7 @@ public:
     return unknown();
   }
 
-  tvt operator||(const tvt other)
+  tvt operator||(const tvt other) const
   {
     if(is_true() || other.is_true())
       return tvt(true);


### PR DESCRIPTION
Despite it being safe to mark it as such.  All other similar methods being marked as const.  This commit marks the method as const.