### PR TITLE
Improve goto-gcc/-as compatibility with GCC

### DIFF
--- a/src/goto-cc/as_cmdline.cpp
+++ b/src/goto-cc/as_cmdline.cpp
@@ -42,6 +42,7 @@ const char *as_options_without_argument[]=
   "-K",
   "-L",
   "--keep-locals",
+  "-Qy",
   "-R",
   "--reduce-memory-overheads",
   "--statistics",

--- a/src/goto-cc/as_mode.cpp
+++ b/src/goto-cc/as_mode.cpp
@@ -173,11 +173,11 @@ int as_modet::doit()
       continue;
 
     // extract the preprocessed source from the file
-    std::ifstream is(arg_it->arg);
+    std::string infile=arg_it->arg=="-"?cmdline.stdin_file:arg_it->arg;
+    std::ifstream is(infile);
     if(!is.is_open())
     {
-      error() << "Failed to open input source " << arg_it->arg
-        << eom;
+      error() << "Failed to open input source " << infile << eom;
       return 1;
     }
 
@@ -205,7 +205,7 @@ int as_modet::doit()
 
         ++outputs;
         std::string new_name=
-          get_base_name(arg_it->arg, true)+"_"+
+          get_base_name(infile, true)+"_"+
           std::to_string(outputs)+".i";
         dest=temp_dir(new_name);
 

--- a/src/goto-cc/gcc_mode.cpp
+++ b/src/goto-cc/gcc_mode.cpp
@@ -803,7 +803,7 @@ int gcc_modet::gcc_hybrid_binary()
   if(output_files.empty() ||
      (output_files.size()==1 &&
       output_files.front()=="/dev/null"))
-    return EX_OK;
+    return run_gcc();
 
   debug() << "Running " << native_tool_name
           << " to generate hybrid binary" << eom;

--- a/src/goto-cc/gcc_mode.cpp
+++ b/src/goto-cc/gcc_mode.cpp
@@ -265,10 +265,10 @@ int gcc_modet::doit()
     base_name=="bcc" ||
     base_name.find("goto-bcc")!=std::string::npos;
 
-  if((cmdline.isset('v') || cmdline.isset("version")) &&
-     cmdline.have_infile_arg()) // let the native tool print the version
+  if((cmdline.isset('v') && cmdline.have_infile_arg()) ||
+     (cmdline.isset("version") && !produce_hybrid_binary))
   {
-    // This a) prints the version and b) increases verbosity.
+    // "-v" a) prints the version and b) increases verbosity.
     // Compilation continues, don't exit!
 
     if(act_as_ld)
@@ -282,6 +282,9 @@ int gcc_modet::doit()
 
   if(cmdline.isset("version"))
   {
+    if(produce_hybrid_binary)
+      return run_gcc();
+
     std::cout << '\n' <<
       "Copyright (C) 2006-2014 Daniel Kroening, Christoph Wintersteiger\n" <<
       "CBMC version: " CBMC_VERSION << '\n' <<
@@ -293,6 +296,9 @@ int gcc_modet::doit()
 
   if(cmdline.isset("dumpversion"))
   {
+    if(produce_hybrid_binary)
+      return run_gcc();
+
     std::cout << "3.4.4\n";
     return EX_OK;
   }


### PR DESCRIPTION
Make sure exit codes and version output match GCC's when operating in goto-gcc mode. In goto-as mode, handle input from stdin.