### PR TITLE
Call `get_language_options` on `--show-parse-tree`

### DIFF
--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -602,6 +602,7 @@ int cbmc_parse_optionst::get_goto_program(
       }
 
       languaget *language=get_language_from_filename(filename);
+      language->get_language_options(cmdline);
 
       if(language==NULL)
       {
@@ -751,6 +752,7 @@ void cbmc_parse_optionst::preprocessing()
     }
 
     languaget *ptr=get_language_from_filename(filename);
+    ptr->get_language_options(cmdline);
 
     if(ptr==NULL)
     {

--- a/src/clobber/clobber_parse_options.cpp
+++ b/src/clobber/clobber_parse_options.cpp
@@ -248,6 +248,7 @@ bool clobber_parse_optionst::get_goto_program(
       }
 
       languaget *language=get_language_from_filename(filename);
+      language->get_language_options(cmdline);
 
       if(language==NULL)
       {

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/config.h>
 #include <util/cmdline.h>
 #include <util/string2int.h>
+#include <util/invariant.h>
 #include <json/json_parser.h>
 
 #include <goto-programs/class_hierarchy.h>
@@ -79,6 +80,8 @@ void java_bytecode_languaget::get_language_options(const cmdlinet &cmd)
   }
   else
     java_cp_include_files=".*";
+
+  language_options_initialized=true;
 }
 
 std::set<std::string> java_bytecode_languaget::extensions() const
@@ -105,6 +108,7 @@ bool java_bytecode_languaget::parse(
   std::istream &instream,
   const std::string &path)
 {
+  PRECONDITION(language_options_initialized);
   java_class_loader.set_message_handler(get_message_handler());
   java_class_loader.set_java_cp_include_files(java_cp_include_files);
 

--- a/src/java_bytecode/java_class_loader_limit.cpp
+++ b/src/java_bytecode/java_class_loader_limit.cpp
@@ -19,7 +19,7 @@ void java_class_loader_limitt::setup_class_load_limit(
   std::string &java_cp_include_files)
 {
   if(java_cp_include_files.empty())
-    throw "class regexp cannot be empty";
+    throw "class regexp cannot be empty, `get_language_options` not called?";
 
   // '@' signals file reading with list of class files to load
   regex_match=java_cp_include_files[0]!='@';

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -137,6 +137,7 @@ protected:
   static irep_idt get_stub_return_symbol_name(const irep_idt &function_id);
 
   bool generate_opaque_stubs;
+  bool language_options_initialized=false;
 
 private:
   bool is_symbol_opaque_function(const symbolt &symbol);


### PR DESCRIPTION
`--show-parse-tree` did not call `get_language_options`, therefore required parameters were not set in the Java front-end, for example the class file loader regexp.