### PR TITLE
Added KNOWNBUG regression test for `--string-printable`

### DIFF
--- a/regression/strings-smoke-tests/java_contains/test_contains.java
+++ b/regression/strings-smoke-tests/java_contains/test_contains.java
@@ -9,7 +9,9 @@ public class test_contains
       assert(!s.contains(t));
 
       String z = new String(x);
-      if (z.length() > 3) assert(t.contains(z));
-      else assert(z.contains(u));
+      if (z.length() > 3)
+        assert(t.contains(z));
+      else
+        assert(z.contains(u));
    }
 }

--- a/regression/strings-smoke-tests/java_contains/test_string_printable.desc
+++ b/regression/strings-smoke-tests/java_contains/test_string_printable.desc
@@ -1,0 +1,14 @@
+KNOWNBUG
+test_string_printable.class
+--refine-strings --string-printable
+^EXIT=10$
+^SIGNAL=0$
+^\[.*assertion.1\].* line 8.* SUCCESS$
+^\[.*assertion.2\].* line 9.* SUCCESS$
+^\[.*assertion.3\].* line 12.* FAILURE$
+^\[.*assertion.4\].* line 13.* FAILURE$
+^VERIFICATION FAILED$
+--
+--
+This should create a huge formula and run out of memory.
+Issue: https://github.com/diffblue/test-gen/issues/745


### PR DESCRIPTION
The test causes CBMC to keep using memory until it crashes. Additionally, by using `--verbosity 10`, it can be seen that currently the `--string-printable` option does NOT enforce that nondet strings only contain printable (ASCII) characters.

This relates to diffblue/test-gen/issues/563, and this test will be used to investigate diffblue/test-gen/issues/745.