### PR TITLE
Adapt perl script to handle multiple .desc files

### DIFF
--- a/regression/failed-tests-printer.pl
+++ b/regression/failed-tests-printer.pl
@@ -6,21 +6,25 @@ open LOG,"<tests.log" or die "Failed to open tests.log\n";
 
 my $printed_this_test = 1;
 my $current_test = "";
+my $output_file = "";
+my $descriptor_file = "";
 
 while (<LOG>) {
   chomp;
   if (/^Test '(.+)'/) {
     $current_test = $1;
     $printed_this_test = 0;
+  } elsif (/Descriptor:\s+([^\s]+)/) {
+    $descriptor_file = $1;
+  } elsif (/Output:\s+([^\s]+)/) {
+    $output_file = $1;
   } elsif (/\[FAILED\]\s*$/) {
     if(0 == $printed_this_test) {
       $printed_this_test = 1;
       print "\n\n";
       print "Failed test: $current_test\n";
-      my $outf = `sed -n '2p' $current_test/test.desc`;
-      $outf =~ s/\..*$/.out/;
-      system("cat $current_test/$outf");
-      print "\n\nFailed test.desc lines:\n";
+      system("cat $current_test/$output_file");
+      print "\n\nFailed $descriptor_file lines:\n";
     }
     print "$_\n";
   }

--- a/regression/test.pl
+++ b/regression/test.pl
@@ -71,7 +71,9 @@ sub test($$$$$) {
 
   $options =~ s/$ign//g if(defined($ign));
 
-  my $output = $input;
+  my $descriptor = $test;
+  $descriptor =~ s/^.*\///;
+  my $output = $descriptor;
   $output =~ s/\.[^.]*$/.out/;
 
   if($output eq $input) {
@@ -82,6 +84,7 @@ sub test($$$$$) {
   print LOG "Test '$name'\n";
   print LOG "  Level: $level\n";
   print LOG "  Input: $input\n";
+  print LOG "  Descriptor: $descriptor\n";
   print LOG "  Output: $output\n";
   print LOG "  Options: $options\n";
   print LOG "  Results:\n";


### PR DESCRIPTION
Solves the following issue: https://github.com/diffblue/test-gen/issues/680

Changes test.pl to name output *.out files after *.desc instead
of *.class files. Also updates failed-test-printer.pl to work with
those new *.out files.