### PR TITLE
Enable working string regression tests

### DIFF
--- a/regression/strings/StaticCharMethods01/test.desc
+++ b/regression/strings/StaticCharMethods01/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 StaticCharMethods01.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings/StaticCharMethods02/test.desc
+++ b/regression/strings/StaticCharMethods02/test.desc
@@ -1,8 +1,9 @@
-FUTURE
+CORE
 StaticCharMethods02.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
+^\[.*assertion\.1\] .* line 6 .* FAILURE$
 --
 ^warning: ignoring

--- a/regression/strings/StaticCharMethods03/test.desc
+++ b/regression/strings/StaticCharMethods03/test.desc
@@ -1,8 +1,9 @@
-FUTURE
+CORE
 StaticCharMethods03.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 6 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/StaticCharMethods04/test.desc
+++ b/regression/strings/StaticCharMethods04/test.desc
@@ -1,8 +1,9 @@
-FUTURE
+CORE
 StaticCharMethods04.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
+^\[.*assertion\.1\] .* line 6 .* FAILURE$
 --
 ^warning: ignoring

--- a/regression/strings/StaticCharMethods05/test.desc
+++ b/regression/strings/StaticCharMethods05/test.desc
@@ -1,8 +1,11 @@
-FUTURE
+CORE
 StaticCharMethods05.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
+^\[pointer_dereference\.2\] reference is null in \*this->data: FAILURE$
+^\[.*assertion\.1\] .* line 12 .* FAILURE$
+^\[.*assertion\.2\] .* line 22 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/StringCompare01/test.desc
+++ b/regression/strings/StringCompare01/test.desc
@@ -6,3 +6,5 @@ StringCompare01.class
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
+--
+Fails because string.regionMatches is not implemented

--- a/regression/strings/StringCompare02/test.desc
+++ b/regression/strings/StringCompare02/test.desc
@@ -1,8 +1,9 @@
-FUTURE
+CORE
 StringCompare02.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 12 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/StringCompare03/test.desc
+++ b/regression/strings/StringCompare03/test.desc
@@ -1,8 +1,9 @@
-FUTURE
+CORE
 StringCompare03.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 12 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/StringCompare04/test.desc
+++ b/regression/strings/StringCompare04/test.desc
@@ -1,8 +1,9 @@
-FUTURE
+CORE
 StringCompare04.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
+^\[.*assertion\.1\] .* line 7 .* FAILURE$
 --
 ^warning: ignoring

--- a/regression/strings/StringCompare05/test.desc
+++ b/regression/strings/StringCompare05/test.desc
@@ -1,8 +1,9 @@
-FUTURE
+CORE
 StringCompare05.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
+^\[.*assertion\.1\] .* line 9 .* FAILURE$
 --
 ^warning: ignoring

--- a/regression/strings/StringConcatenation01/test.desc
+++ b/regression/strings/StringConcatenation01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 StringConcatenation01.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings/StringConcatenation02/test.desc
+++ b/regression/strings/StringConcatenation02/test.desc
@@ -1,8 +1,9 @@
-KNOWNBUG
+CORE
 StringConcatenation02.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
+^\[.*assertion\.1\] .* line 7 .* FAILURE$
 --
 ^warning: ignoring

--- a/regression/strings/StringConcatenation03/test.desc
+++ b/regression/strings/StringConcatenation03/test.desc
@@ -1,8 +1,9 @@
-FUTURE
+CORE
 StringConcatenation03.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
+^\[.*assertion\.1\] .* line 11 .* FAILURE$
 --
 ^warning: ignoring

--- a/regression/strings/StringConcatenation04/test.desc
+++ b/regression/strings/StringConcatenation04/test.desc
@@ -1,8 +1,9 @@
-FUTURE
+CORE
 StringConcatenation04.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 8 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/StringIndexMethods01/test.desc
+++ b/regression/strings/StringIndexMethods01/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+THOROUGH
 StringIndexMethods01.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings/StringIndexMethods02/test.desc
+++ b/regression/strings/StringIndexMethods02/test.desc
@@ -1,8 +1,9 @@
-FUTURE
+CORE
 StringIndexMethods02.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 6 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/StringIndexMethods03/test.desc
+++ b/regression/strings/StringIndexMethods03/test.desc
@@ -1,8 +1,9 @@
-FUTURE
+CORE
 StringIndexMethods03.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 6 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/StringIndexMethods04/test.desc
+++ b/regression/strings/StringIndexMethods04/test.desc
@@ -1,8 +1,9 @@
-FUTURE
+CORE
 StringIndexMethods04.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 6 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/StringIndexMethods05/test.desc
+++ b/regression/strings/StringIndexMethods05/test.desc
@@ -3,6 +3,7 @@ StringIndexMethods05.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 6 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/StringMiscellaneous02/test.desc
+++ b/regression/strings/StringMiscellaneous02/test.desc
@@ -1,8 +1,9 @@
-FUTURE
+CORE
 StringMiscellaneous02.class
 --refine-strings --unwind 30
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 6 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/StringMiscellaneous03/test.desc
+++ b/regression/strings/StringMiscellaneous03/test.desc
@@ -1,8 +1,9 @@
-FUTURE
+CORE
 StringMiscellaneous03.class
 --refine-strings --unwind 30
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 11 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/StringMiscellaneous04/test.desc
+++ b/regression/strings/StringMiscellaneous04/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 StringMiscellaneous04.class
 --refine-strings --unwind 30
 ^EXIT=0$

--- a/regression/strings/StringStartEnd01/test.desc
+++ b/regression/strings/StringStartEnd01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+THOROUGH
 StringStartEnd01.class
 --refine-strings --unwind 30
 ^EXIT=0$

--- a/regression/strings/StringStartEnd02/test.desc
+++ b/regression/strings/StringStartEnd02/test.desc
@@ -1,8 +1,9 @@
-KNOWNBUG
+CORE
 StringStartEnd02.class
 --refine-strings --unwind 30
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 13 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/StringStartEnd03/test.desc
+++ b/regression/strings/StringStartEnd03/test.desc
@@ -1,8 +1,9 @@
-KNOWNBUG
+THOROUGH
 StringStartEnd03.class
 --refine-strings --unwind 15
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 13 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/StringValueOf02/test.desc
+++ b/regression/strings/StringValueOf02/test.desc
@@ -1,8 +1,9 @@
-FUTURE
+CORE
 StringValueOf02.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 7 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/StringValueOf03/test.desc
+++ b/regression/strings/StringValueOf03/test.desc
@@ -1,8 +1,9 @@
-FUTURE
+CORE
 StringValueOf03.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 7 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/StringValueOf04/test.desc
+++ b/regression/strings/StringValueOf04/test.desc
@@ -1,8 +1,9 @@
-KNOWNBUG
+CORE
 StringValueOf04.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 7 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/StringValueOf05/test.desc
+++ b/regression/strings/StringValueOf05/test.desc
@@ -1,8 +1,9 @@
-KNOWNBUG
+CORE
 StringValueOf05.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 7 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/StringValueOf06/test.desc
+++ b/regression/strings/StringValueOf06/test.desc
@@ -1,8 +1,9 @@
-KNOWNBUG
+CORE
 StringValueOf06.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 7 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/StringValueOf07/test.desc
+++ b/regression/strings/StringValueOf07/test.desc
@@ -1,8 +1,9 @@
-KNOWNBUG
+CORE
 StringValueOf07.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 8 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/StringValueOf08/test.desc
+++ b/regression/strings/StringValueOf08/test.desc
@@ -1,8 +1,9 @@
-FUTURE
+CORE
 StringValueOf08.class
 --refine-strings --string-max-length 100
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 7 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/StringValueOf09/test.desc
+++ b/regression/strings/StringValueOf09/test.desc
@@ -1,8 +1,9 @@
-FUTURE
+THOROUGH
 StringValueOf09.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 7 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/SubString01/test.desc
+++ b/regression/strings/SubString01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 SubString01.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings/SubString02/test.desc
+++ b/regression/strings/SubString02/test.desc
@@ -1,8 +1,9 @@
-KNOWNBUG
+CORE
 SubString02.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 7 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/SubString03/test.desc
+++ b/regression/strings/SubString03/test.desc
@@ -1,8 +1,9 @@
-KNOWNBUG
+CORE
 SubString03.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
+^\[.*assertion\.1\] .* line 7 .* FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/strings/bug-test-gen-095/test.desc
+++ b/regression/strings/bug-test-gen-095/test.desc
@@ -3,6 +3,6 @@ test.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-[.*assertion\.1] .* line 8 .* FAILURE
+\[.*assertion\.1\] .* line 8 .* FAILURE
 ^VERIFICATION FAILED$
 --

--- a/regression/strings/bug-test-gen-119-2/test.desc
+++ b/regression/strings/bug-test-gen-119-2/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 StringValueOfLong.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings/bug-test-gen-119/test.desc
+++ b/regression/strings/bug-test-gen-119/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 StringValueOfBool.class
 --refine-strings
 ^EXIT=0$

--- a/regression/strings/java_append_char/test.desc
+++ b/regression/strings/java_append_char/test.desc
@@ -1,7 +1,8 @@
-FUTURE
+CORE
 test_append_char.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 15.* FAILURE$
+^VERIFICATION FAILED$
+^\[.*assertion\.1\].* line 15.* FAILURE$
 --

--- a/regression/strings/java_append_int/test.desc
+++ b/regression/strings/java_append_int/test.desc
@@ -1,7 +1,9 @@
-FUTURE
+KNOWNBUG
 test_append_int.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 9.* FAILURE$
+^\[.*assertion\.1\].* line 9.* FAILURE$
 --
+--
+Requires private library, should be moved to test-gen suite

--- a/regression/strings/java_append_object/test.desc
+++ b/regression/strings/java_append_object/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+KNOWNBUG
 test_append_object.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 15.* FAILURE$
+^\[.*assertion\.1\].* line 15.* FAILURE$
 --

--- a/regression/strings/java_case/test.desc
+++ b/regression/strings/java_case/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+CORE
 test_case.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 8.* FAILURE$
+^\[.*assertion\.1\].* line 8.* FAILURE$
 --

--- a/regression/strings/java_char_array/test.desc
+++ b/regression/strings/java_char_array/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+CORE
 test_char_array.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 9.* FAILURE$
+^\[.*assertion\.1\].* line 9.* FAILURE$
 --

--- a/regression/strings/java_char_array_init/test.desc
+++ b/regression/strings/java_char_array_init/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_init.class
 --refine-strings
 ^EXIT=10$

--- a/regression/strings/java_char_at/test.desc
+++ b/regression/strings/java_char_at/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+CORE
 test_char_at.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 5.* FAILURE$
+^\[.*assertion\.1\].* line 5.* FAILURE$
 --

--- a/regression/strings/java_code_point/test.desc
+++ b/regression/strings/java_code_point/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+CORE
 test_code_point.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 8.* FAILURE$
+^\[.*assertion\.1\].* line 8.* FAILURE$
 --

--- a/regression/strings/java_compare/test.desc
+++ b/regression/strings/java_compare/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+CORE
 test_compare.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 7.* FAILURE$
+^\[.*assertion\.1\].* line 7.* FAILURE$
 --

--- a/regression/strings/java_concat/test.desc
+++ b/regression/strings/java_concat/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 test_concat.class
 --refine-strings
 ^EXIT=10$

--- a/regression/strings/java_contains/test.desc
+++ b/regression/strings/java_contains/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+CORE
 test_contains.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 7.* FAILURE$
+^\[.*assertion\.1\].* line 7.* FAILURE$
 --

--- a/regression/strings/java_delete/test.desc
+++ b/regression/strings/java_delete/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+CORE
 test_delete.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 8.* FAILURE$
+^\[.*assertion\.1\].* line 8.* FAILURE$
 --

--- a/regression/strings/java_delete_char_at/test.desc
+++ b/regression/strings/java_delete_char_at/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+CORE
 test_delete_char_at.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 9.* FAILURE$
+^\[.*assertion\.1\].* line 9.* FAILURE$
 --

--- a/regression/strings/java_easychair/test.desc
+++ b/regression/strings/java_easychair/test.desc
@@ -3,5 +3,5 @@ easychair.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 30.* FAILURE$
+^\[.*assertion\.1\].* line 30.* FAILURE$
 --

--- a/regression/strings/java_empty/test.desc
+++ b/regression/strings/java_empty/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+CORE
 test_empty.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 6.* FAILURE$
+^\[.*assertion\.1\].* line 6.* FAILURE$
 --

--- a/regression/strings/java_endswith/test.desc
+++ b/regression/strings/java_endswith/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+CORE
 test_endswith.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 7.* FAILURE$
+^\[.*assertion\.1\].* line 7.* FAILURE$
 --

--- a/regression/strings/java_equal/test.desc
+++ b/regression/strings/java_equal/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+CORE
 test_equal.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 8.* FAILURE$
+^\[.*assertion\.1\].* line 8.* FAILURE$
 --

--- a/regression/strings/java_float/test.desc
+++ b/regression/strings/java_float/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+THOROUGH
 test_float.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 15.* FAILURE$
+^\[.*assertion\.1\].* line 15.* FAILURE$
 --

--- a/regression/strings/java_hash_code/test.desc
+++ b/regression/strings/java_hash_code/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+CORE
 test_hash_code.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 7.* FAILURE$
+^\[.*assertion\.1\].* line 7.* FAILURE$
 --

--- a/regression/strings/java_index_of/test.desc
+++ b/regression/strings/java_index_of/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+CORE
 test_index_of.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 8.* FAILURE$
+^\[.*assertion\.1\].* line 8.* FAILURE$
 --

--- a/regression/strings/java_index_of_char/test.desc
+++ b/regression/strings/java_index_of_char/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+CORE
 test_index_of_char.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 8.* FAILURE$
+^\[.*assertion\.1\].* line 8.* FAILURE$
 --

--- a/regression/strings/java_insert_char/test.desc
+++ b/regression/strings/java_insert_char/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+CORE
 test_insert_char.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 8.* FAILURE$
+^\[.*assertion\.1\].* line 8.* FAILURE$
 --

--- a/regression/strings/java_insert_char_array/test.desc
+++ b/regression/strings/java_insert_char_array/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+CORE
 test_insert_char_array.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 12.* FAILURE$
+^\[.*assertion\.1\].* line 12.* FAILURE$
 --

--- a/regression/strings/java_insert_int/test.desc
+++ b/regression/strings/java_insert_int/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+CORE
 test_insert_int.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 8.* FAILURE$
+^\[.*assertion\.1\].* line 8.* FAILURE$
 --

--- a/regression/strings/java_insert_multiple/test.desc
+++ b/regression/strings/java_insert_multiple/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+CORE
 test_insert_multiple.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 9.* FAILURE$
+^\[.*assertion\.1\].* line 9.* FAILURE$
 --

--- a/regression/strings/java_insert_string/test.desc
+++ b/regression/strings/java_insert_string/test.desc
@@ -1,7 +1,7 @@
-FUTURE
+CORE
 test_insert_string.class
 --refine-strings
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*assertion.1\].* line 8.* FAILURE$
+^\[.*assertion\.1\].* line 8.* FAILURE$
 --


### PR DESCRIPTION
Solution for the following ticket: https://github.com/diffblue/test-gen/issues/727

Updates test descriptors for working tests in the regression/strings directory.

Based off of this PR: https://github.com/diffblue/cbmc/pull/1114