### PR TITLE
Documentation for goto_program_templatet and cfg_baset

### DIFF
--- a/src/goto-programs/cfg.h
+++ b/src/goto-programs/cfg.h
@@ -31,6 +31,31 @@ struct cfg_base_nodet:public graph_nodet<empty_edget>, public T
   I PC;
 };
 
+/// A multi-procedural control flow graph (CFG) whose nodes store references to
+/// instructions in a GOTO program.
+///
+/// An instance of cfg_baset<T> is a directed graph whose nodes inherit from a
+/// user-provided type T and store a pointer to an instruction of some
+/// goto program in the field `PC`. The field `PC` of every node points to the
+/// original GOTO instruction that gave rise to the node, and the field
+/// cfg_baset::entry_map maps every GOTO instruction to some CFG node.
+///
+/// The CFG is constructed on the operator() from either one goto_programt or
+/// multiple goto_programt objects (stored in a goto_functionst).  The edges of
+/// the CFG are created on the method compute_edges(), and notably include:
+///
+/// - Edges from location A to B if both A and B belong to the same
+///   goto_programt and A can flow into B.
+/// - An edge from each FUNCTION_CALL instruction and the first instruction of
+///   the called function, when that function body is available and its body is
+///   non-empty.
+/// - For each FUNCTION_CALL instruction found, an edge between the exit point
+///   of the called function and the instruction immediately after the
+///   FUNCTION_CALL, when the function body is available and its body is
+///   non-empty.
+///
+///   Note that cfg_baset is the base class of many other subclasses and the
+///   specific edges constructed by operator() can be different in those.
 template<class T,
          typename P=const goto_programt,
          typename I=goto_programt::const_targett>

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -33,9 +33,13 @@ std::ostream &goto_programt::output_instruction(
   return output_instruction(ns, identifier, out, *it);
 }
 
-/// Writes to out a two line string representation of the specific instruction.
-/// It is of the format: // {location} file {source file} line {line in source
-/// file} {representation of the instruction}
+/// Writes to \p out a two/three line string representation of a given
+/// \p instruction. The output is of the format:
+/// ```
+///   // {location} file {source file} line {line in source file}
+///   // Labels: {list-of-labels}
+///   {representation of the instruction}
+/// ```
 /// \param ns: the namespace to resolve the expressions in
 /// \param identifier: the identifier used to find a symbol to identify the
 ///   source language

--- a/src/goto-programs/goto_program_template.h
+++ b/src/goto-programs/goto_program_template.h
@@ -24,6 +24,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/source_location.h>
 #include <util/std_expr.h>
 
+/// The type of an instruction in a GOTO program.
 enum goto_program_instruction_typet
 {
   NO_INSTRUCTION_TYPE=0,
@@ -49,14 +50,26 @@ enum goto_program_instruction_typet
 
 std::ostream &operator<<(std::ostream &, goto_program_instruction_typet);
 
-/*! \brief A generic container class for a control flow graph
-           for one function, in the form of a goto-program
-*/
+/// A generic container class for the GOTO intermediate representation of one
+/// function.
+///
+/// A function is represented by a std::list of instructions. Execution starts
+/// in the first instruction of the list. Then, the execution of the i-th
+/// instruction is followed by the execution of the (i+1)-th instruction unless
+/// instruction i jumps to some other instruction in the list. See the internal
+/// class instructiont for additional details
+///
+/// Although it is straightforward to compute the control flow graph (CFG) of a
+/// function from the list of instructions and the goto target locations in
+/// instructions, the GOTO intermediate representation is _not_ regarded as the
+/// CFG of a function. See instead the class cfg_baset, which is based on grapht
+/// and allows for easier implementation of generic graph algorithms (e.g.,
+/// dominator analysis).
 template <class codeT, class guardT>
 class goto_program_templatet
 {
 public:
-  // Copying is deleted as this class contains pointers that cannot be copied
+  /// Copying is deleted as this class contains pointers that cannot be copied
   goto_program_templatet(const goto_program_templatet &)=delete;
   goto_program_templatet &operator=(const goto_program_templatet &)=delete;
 
@@ -77,60 +90,127 @@ public:
     return *this;
   }
 
-  /*! \brief Container for an instruction of the goto-program
-  */
+  /// This class represents an instruction in the GOTO intermediate
+  /// representation.  Three fields are key:
+  ///
+  /// - type:  an enum value describing the action performed by this instruction
+  /// - guard: an (arbitrarily complex) expression (usually an \ref exprt) of
+  ///          Boolean type
+  /// - code:  a code statement (usually a \ref codet)
+  ///
+  /// The meaning of an instruction node depends on the `type` field. Different
+  /// kinds of instructions make use of the fields `guard` and `code` for
+  /// different purposes.  We list below, using a mixture of pseudo code and
+  /// plain English, the meaning of different kinds of instructions.
+  /// We use `guard`, `code`, and `targets` to mean the value of the
+  /// respective fields in this class:
+  ///
+  /// - GOTO:
+  ///     if `guard` then goto `targets`
+  /// - RETURN:
+  ///     Set the value returned by `code` (which shall be either nil or an
+  ///     instance of code_returnt) and then jump to the end of the function.
+  /// - DECL:
+  ///     Introduces a symbol denoted by the field `code` (an instance of
+  ///     code_declt), the life-time of which is bounded by a corresponding DEAD
+  ///     instruction.
+  /// - FUNCTION_CALL:
+  ///     Invoke the function denoted by field `code` (an instance of
+  ///     code_function_callt).
+  /// - ASSIGN:
+  ///     Update the left-hand side of `code` (an instance of code_assignt) to
+  ///     the value of the right-hand side.
+  /// - OTHER:
+  ///     Execute the `code` (an instance of codet of kind ID_fence, ID_printf,
+  ///     ID_array_copy, ID_array_set, ID_input, ID_output, ...).
+  /// - ASSUME:
+  ///     Wait for `guard` to evaluate to true.
+  /// - ASSERT:
+  ///     Using ASSERT instructions is the one and only way to express
+  ///     properties to be verified. Execution paths abort if `guard` evaluates
+  ///     to false.
+  /// - SKIP, LOCATION:
+  ///     No-op.
+  /// - ATOMIC_BEGIN, ATOMIC_END:
+  ///     When a thread executes ATOMIC_BEGIN, no thread other will be able to
+  ///     execute any instruction until the same thread executes ATOMIC_END.
+  /// - END_FUNCTION:
+  ///     Can only occur as the last instruction of the list.
+  /// - START_THREAD:
+  ///     Create a new thread and run the code of this function starting from
+  ///     targets[0]. Quite often the instruction pointed by targets[0] will be
+  ///     just a FUNCTION_CALL, followed by an END_THREAD.
+  /// - END_THREAD:
+  ///     Terminate the calling thread.
+  /// - THROW:
+  ///     throw `exception1`, ..., `exceptionN`
+  ///     where the list of exceptions is extracted from the `code` field
+  /// - CATCH, when code.find(ID_exception_list) is non-empty:
+  ///     Establishes that from here to the next occurrence of CATCH with an
+  ///     empty list (see below) if
+  ///     - `exception1` is thrown, then goto `target1`,
+  ///     - ...
+  ///     - `exceptionN` is thrown, then goto `targetN`.
+  ///     The list of exceptions is obtained from the `code` field and the list
+  ///     of targets from the `targets` field.
+  /// - CATCH, when empty code.find(ID_exception_list) is empty:
+  ///     clears all the catch clauses established as per the above in this
+  ///     function?
   class instructiont
   {
   public:
     codeT code;
 
-    //! function this belongs to
+    /// The function this instruction belongs to
     irep_idt function;
 
-    //! the location of the instruction in the source file
+    /// The location of the instruction in the source file
     source_locationt source_location;
 
-    //! what kind of instruction?
+    /// What kind of instruction?
     goto_program_instruction_typet type;
 
-    //! guard for gotos, assume, assert
+    /// Guard for gotos, assume, assert
     guardT guard;
 
     // The below will eventually become a single target only.
-    //! the target for gotos and for start_thread nodes
+    /// The target for gotos and for start_thread nodes
     typedef typename std::list<instructiont>::iterator targett;
     typedef typename std::list<instructiont>::const_iterator const_targett;
     typedef std::list<targett> targetst;
     typedef std::list<const_targett> const_targetst;
 
+    /// The list of successor instructions
     targetst targets;
 
-    // for the usual case of a single target
+    /// Returns the first (and only) successor for the usual case of a single
+    /// target
     targett get_target() const
     {
       assert(targets.size()==1);
       return targets.front();
     }
 
-    // for the usual case of a single target
+    /// Sets the first (and only) successor for the usual case of a single
+    /// target
     void set_target(targett t)
     {
       targets.clear();
       targets.push_back(t);
     }
 
-    //! goto target labels
+    /// Goto target labels
     typedef std::list<irep_idt> labelst;
     labelst labels;
 
     // will go away
     std::set<targett> incoming_edges;
 
-    //! is this node a branch target?
+    /// Is this node a branch target?
     bool is_target() const
     { return target_number!=nil_target; }
 
-    //! clear the node
+    /// Clear the node
     void clear(goto_program_instruction_typet _type)
     {
       type=_type;
@@ -205,7 +285,7 @@ public:
     {
     }
 
-    //! swap two instructions
+    /// Swap two instructions
     void swap(instructiont &instruction)
     {
       using std::swap;
@@ -217,30 +297,30 @@ public:
       swap(instruction.function, function);
     }
 
-    //! Uniquely identify an invalid target or location
     #if (defined _MSC_VER && _MSC_VER <= 1800)
     // Visual Studio <= 2013 does not support constexpr, making
     // numeric_limits::max() unviable for a static const member
     static const unsigned nil_target=
       static_cast<unsigned>(-1);
     #else
+    /// Uniquely identify an invalid target or location
     static const unsigned nil_target=
       std::numeric_limits<unsigned>::max();
     #endif
 
-    //! A globally unique number to identify a program location.
-    //! It's guaranteed to be ordered in program order within
-    //! one goto_program.
+    /// A globally unique number to identify a program location.
+    /// It's guaranteed to be ordered in program order within
+    /// one goto_program.
     unsigned location_number;
 
-    //! Number unique per function to identify loops
+    /// Number unique per function to identify loops
     unsigned loop_number;
 
-    //! A number to identify branch targets.
-    //! This is \ref nil_target if it's not a target.
+    /// A number to identify branch targets.
+    /// This is \ref nil_target if it's not a target.
     unsigned target_number;
 
-    //! Returns true if the instruction is a backwards branch.
+    /// Returns true if the instruction is a backwards branch.
     bool is_backwards_goto() const
     {
       if(!is_goto())
@@ -268,17 +348,17 @@ public:
   typedef typename std::list<targett> targetst;
   typedef typename std::list<const_targett> const_targetst;
 
-  //! The list of instructions in the goto program
+  /// The list of instructions in the goto program
   instructionst instructions;
 
-  // Convert a const_targett to a targett - use with care and avoid
-  // whenever possible
+  /// Convert a const_targett to a targett - use with care and avoid
+  /// whenever possible
   targett const_cast_target(const_targett t)
   {
     return instructions.erase(t, t);
   }
 
-  // Dummy for templates with possible const contexts
+  /// Dummy for templates with possible const contexts
   const_targett const_cast_target(const_targett t) const
   {
     return t;
@@ -306,7 +386,7 @@ public:
 
   void compute_incoming_edges();
 
-  //! Insertion that preserves jumps to "target".
+  /// Insertion that preserves jumps to "target".
   void insert_before_swap(targett target)
   {
     assert(target!=instructions.end());
@@ -314,16 +394,16 @@ public:
     instructions.insert(next, instructiont())->swap(*target);
   }
 
-  //! Insertion that preserves jumps to "target".
-  //! The instruction is destroyed.
+  /// Insertion that preserves jumps to "target".
+  /// The instruction is destroyed.
   void insert_before_swap(targett target, instructiont &instruction)
   {
     insert_before_swap(target);
     target->swap(instruction);
   }
 
-  //! Insertion that preserves jumps to "target".
-  //! The program p is destroyed.
+  /// Insertion that preserves jumps to "target".
+  /// The program p is destroyed.
   void insert_before_swap(
     targett target,
     goto_program_templatet<codeT, guardT> &p)
@@ -337,21 +417,21 @@ public:
     instructions.splice(next, p.instructions);
   }
 
-  //! Insertion before the given target
-  //! \return newly inserted location
+  /// Insertion before the given target
+  /// \return newly inserted location
   targett insert_before(const_targett target)
   {
     return instructions.insert(target, instructiont());
   }
 
-  //! Insertion after the given target
-  //! \return newly inserted location
+  /// Insertion after the given target
+  /// \return newly inserted location
   targett insert_after(const_targett target)
   {
     return instructions.insert(std::next(target), instructiont());
   }
 
-  //! Appends the given program, which is destroyed
+  /// Appends the given program, which is destroyed
   void destructive_append(goto_program_templatet<codeT, guardT> &p)
   {
     instructions.splice(instructions.end(),
@@ -359,8 +439,8 @@ public:
     // BUG: The iterators to p-instructions are invalidated!
   }
 
-  //! Inserts the given program at the given location.
-  //! The program is destroyed.
+  /// Inserts the given program at the given location.
+  /// The program is destroyed.
   void destructive_insert(
     const_targett target,
     goto_program_templatet<codeT, guardT> &p)
@@ -369,78 +449,78 @@ public:
     // BUG: The iterators to p-instructions are invalidated!
   }
 
-  //! Adds an instruction at the end.
-  //! \return The newly added instruction.
+  /// Adds an instruction at the end.
+  /// \return The newly added instruction.
   targett add_instruction()
   {
     instructions.push_back(instructiont());
     return --instructions.end();
   }
 
-  //! Adds an instruction of given type at the end.
-  //! \return The newly added instruction.
+  /// Adds an instruction of given type at the end.
+  /// \return The newly added instruction.
   targett add_instruction(goto_program_instruction_typet type)
   {
     instructions.push_back(instructiont(type));
     return --instructions.end();
   }
 
-  //! Output goto program to given stream
+  /// Output goto program to given stream
   std::ostream &output(
     const namespacet &ns,
     const irep_idt &identifier,
     std::ostream &out) const;
 
-  //! Output goto-program to given stream
+  /// Output goto-program to given stream
   std::ostream &output(std::ostream &out) const
   {
     return output(namespacet(symbol_tablet()), "", out);
   }
 
-  //! Output a single instruction
+  /// Output a single instruction
   virtual std::ostream &output_instruction(
     const namespacet &ns,
     const irep_idt &identifier,
     std::ostream &out,
     typename instructionst::const_iterator it) const=0;
 
-  //! Compute the target numbers
+  /// Compute the target numbers
   void compute_target_numbers();
 
-  //! Compute location numbers
+  /// Compute location numbers
   void compute_location_numbers(unsigned &nr)
   {
     for(auto &i : instructions)
       i.location_number=nr++;
   }
 
-  //! Compute location numbers
+  /// Compute location numbers
   void compute_location_numbers()
   {
     unsigned nr=0;
     compute_location_numbers(nr);
   }
 
-  //! Compute loop numbers
+  /// Compute loop numbers
   void compute_loop_numbers();
 
-  //! Update all indices
+  /// Update all indices
   void update();
 
-  //! Human-readable loop name
+  /// Human-readable loop name
   static irep_idt loop_id(const_targett target)
   {
     return id2string(target->function)+"."+
            std::to_string(target->loop_number);
   }
 
-  //! Is the program empty?
+  /// Is the program empty?
   bool empty() const
   {
     return instructions.empty();
   }
 
-  //! Constructor
+  /// Constructor
   goto_program_templatet()
   {
   }
@@ -449,13 +529,13 @@ public:
   {
   }
 
-  //! Swap the goto program
+  /// Swap the goto program
   void swap(goto_program_templatet<codeT, guardT> &program)
   {
     program.instructions.swap(instructions);
   }
 
-  //! Clear the goto program
+  /// Clear the goto program
   void clear()
   {
     instructions.clear();
@@ -469,10 +549,10 @@ public:
     return end_function;
   }
 
-  //! Copy a full goto program, preserving targets
+  /// Copy a full goto program, preserving targets
   void copy_from(const goto_program_templatet<codeT, guardT> &src);
 
-  //! Does the goto program have an assertion?
+  /// Does the goto program have an assertion?
   bool has_assertion() const;
 };
 

--- a/src/util/graph.h
+++ b/src/util/graph.h
@@ -27,6 +27,8 @@ class empty_edget
 {
 };
 
+/// This class represents a node in a directed graph.
+/// See \ref grapht for more information.
 template<class E=empty_edget>
 class graph_nodet
 {
@@ -59,7 +61,7 @@ public:
   }
 };
 
-// a node type with an extra bit
+/// A node type with an extra bit
 template<class E>
 class visited_nodet:public graph_nodet<E>
 {
@@ -74,8 +76,7 @@ public:
   }
 };
 
-// compute intersection of two edge sets,
-// in linear time
+/// Compute intersection of two edge sets, in linear time
 template<class E>
 void intersection(
   const typename graph_nodet<E>::edgest &a,
@@ -101,7 +102,32 @@ void intersection(
   }
 }
 
-// a generic graph class with a parametric node type
+/// A generic directed graph with a parametric node type.
+///
+/// The nodes of the graph are stored in the only field of the class, a
+/// std::vector named `nodes`. Nodes are instances of class graph_nodet<E> or a
+/// subclass of it. Graph edges contain a payload object of parametric type E
+/// (which has to be default-constructible).  By default E is instantiated with
+/// an empty class (empty_edget).
+///
+/// Each node is identified by its offset inside the `nodes` vector. The
+/// incoming and outgoing edges of a node are stored as std::maps in the fields
+/// `in` and `out` of the graph_nodet<E>. These maps associate a node identifier
+/// (the offset) to the edge payload (of type E).
+///
+/// In fact, observe that two instances of E are stored per edge of the graph.
+/// For instance, assume that we want to create a graph with two nodes, A and B,
+/// and one edge from A to B, labelled by object e. We achieve this by inserting
+/// the pair (offsetof(B),e) in the map `A.out` and the pair (offsetof(A),e) in
+/// the map `B.in`.
+///
+/// Nodes are inserted in the graph using grapht::add_node(), which returns the
+/// identifier (offset) of the inserted node. Edges between nodes are created
+/// by grapht::add_edge(a,b), where `a` and `b` are the identifiers of nodes.
+/// Method `add_edges` adds a default-constructed payload object of type E.
+/// Adding a payload objet `e` to an edge seems to be only possibly by manually
+/// inserting `e` in the std::maps `in` and `out` of the two nodes associated to
+/// the edge.
 template<class N=graph_nodet<empty_edget> >
 class grapht
 {


### PR DESCRIPTION
This started as an effort to understand how _exactly_ `instructiont` is used in the context of https://github.com/diffblue/test-gen/issues/690, but the issue got deprioritized and I'm now trying to merge this only.

This PR only adds documentation, no functional change.

The following classes have been documented:

- grapht
- cfg_baset
- goto_program_templatet
- goto_program_templatet::instructiont