### PR TITLE
Added in parameter to correct call to gen_nondet_init

### DIFF
--- a/src/goto-programs/convert_nondet.cpp
+++ b/src/goto-programs/convert_nondet.cpp
@@ -85,9 +85,10 @@ static goto_programt::targett insert_nondet_init_code(
     symbol_table,
     source_loc,
     true,
+    true,
     !nullable,
     max_nondet_array_length,
-    NO_UPDATE_IN_PLACE);
+    update_in_placet::NO_UPDATE_IN_PLACE);
 
   // Convert this code into goto instructions
   goto_programt new_instructions;

--- a/src/java_bytecode/java_object_factory.h
+++ b/src/java_bytecode/java_object_factory.h
@@ -23,7 +23,7 @@ exprt object_factory(
   size_t max_nondet_array_length,
   const source_locationt &);
 
-enum update_in_placet
+enum class update_in_placet
 {
   NO_UPDATE_IN_PLACE,
   MAY_UPDATE_IN_PLACE,
@@ -39,7 +39,7 @@ void gen_nondet_init(
   bool create_dyn_objs,
   bool assume_non_null,
   size_t max_nondet_array_length,
-  update_in_placet update_in_place=NO_UPDATE_IN_PLACE);
+  update_in_placet update_in_place);
 
 exprt allocate_dynamic_object(
   const exprt &target_expr,


### PR DESCRIPTION
Previously, since the `update_in_place parameter` is optional and there is one too few parameters, the `NO_UPDATE_IN_PLACE` was being interpreted as the `max_nondet_array_length` (i.e. of 0) and the `max_nondet_array_length` was being used as the assume_not_null (presumably true) and `!nullable`
was being used as `create_dyn_objects`.

I took a guess it should be `true` - but this should be verified! 

I removed the default parameter as it wasn't even being used anywhere, except erroneously. 

test-gen PR: diffblue/test-gen#766