### PR TITLE
extended the existing-coverage option to support bytecode_index

### DIFF
--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -132,24 +132,33 @@ bool coverage_goalst::get_coverage_goals(
     return true;
   }
 
-  for(const auto &goal : json.array)
+  // traverse the given JSON file
+  for(const auto &goals_in_json : json.array)
   {
-    // get the file of each existing goal
-    irep_idt file=goal["file"].value;
-    source_location.set_file(file);
-
-    // get the function of each existing goal
-    irep_idt function=goal["function"].value;
-    source_location.set_function(function);
-
-    // get the lines array
-    if(goal["lines"].is_array())
+    // get the set of goals
+    if(goals_in_json["goals"].is_array())
     {
-      for(const auto &line_json : goal["lines"].array)
+      // store the source location for each existing goal
+      for(const auto &each_goal : goals_in_json["goals"].array)
       {
-        // get the line of each existing goal
-        irep_idt line=line_json["number"].value;
+        // get and set the bytecode_index
+        irep_idt bytecode_index=
+          each_goal["sourceLocation"]["bytecode_index"].value;
+        source_location.set_java_bytecode_index(bytecode_index);
+
+        // get and set the file
+        irep_idt file=each_goal["sourceLocation"]["file"].value;
+        source_location.set_file(file);
+
+        // get and set the function
+        irep_idt function=each_goal["sourceLocation"]["function"].value;
+        source_location.set_function(function);
+
+        // get and set the line
+        irep_idt line=each_goal["sourceLocation"]["line"].value;
         source_location.set_line(line);
+
+        // store the existing goal
         goals.add_goal(source_location);
       }
     }

--- a/src/goto-instrument/cover.h
+++ b/src/goto-instrument/cover.h
@@ -25,10 +25,11 @@ public:
     message_handlert &message_handler,
     coverage_goalst &goals);
   void add_goal(source_locationt goal);
-  bool is_existing_goal(source_locationt source_loc) const;
+  bool is_existing_goal(source_locationt source_loc);
+  void check_uncovered_goals(messaget msg);
 
 private:
-  std::vector<source_locationt> existing_goals;
+  std::map<source_locationt, bool> existing_goals;
 };
 
 enum class coverage_criteriont
@@ -56,7 +57,7 @@ void instrument_cover_goals(
   const symbol_tablet &symbol_table,
   goto_functionst &goto_functions,
   coverage_criteriont,
-  const coverage_goalst &goals,
+  coverage_goalst &goals,
   bool function_only=false,
   bool ignore_trivial=false);
 
@@ -64,7 +65,7 @@ void instrument_cover_goals(
   const symbol_tablet &symbol_table,
   goto_programt &goto_program,
   coverage_criteriont,
-  const coverage_goalst &goals,
+  coverage_goalst &goals,
   bool function_only=false,
   bool ignore_trivial=false);
 

--- a/src/goto-instrument/cover.h
+++ b/src/goto-instrument/cover.h
@@ -23,10 +23,11 @@ public:
   static bool get_coverage_goals(
     const std::string &coverage,
     message_handlert &message_handler,
-    coverage_goalst &goals);
+    coverage_goalst &goals,
+    const irep_idt &mode);
   void add_goal(source_locationt goal);
   bool is_existing_goal(source_locationt source_loc);
-  void check_uncovered_goals(messaget msg);
+  void check_uncovered_goals(messaget &msg);
 
 private:
   std::map<source_locationt, bool> existing_goals;


### PR DESCRIPTION
Extended the existing-coverage option to support bytecode_index, 
given the current JSON format to specify goals for C and Java programs.
This PR https://github.com/diffblue/test-gen/pull/760 contains the regression 
tests for C and Java programs to check the existing-coverage option