### PR TITLE
Fix interpreter allocation sizing

### DIFF
--- a/src/goto-programs/interpreter_class.h
+++ b/src/goto-programs/interpreter_class.h
@@ -145,7 +145,7 @@ protected:
       return 0;
     std::size_t ret=0;
     std::size_t alloc_size=base_address_to_alloc_size(address);
-    while(memory_iter!=memory.end() && ret<alloc_size)
+    while(memory_iter!=memory.end() && memory_iter->first<(address+alloc_size))
     {
       ++ret;
       ++memory_iter;


### PR DESCRIPTION
This could previously overestimate object sizes, potentially by including
all other objects in the address space in the size estimate. That could
lead to overly long variable-length arrays, with performance cost though
most likely no correctness problems in Java, since all arrays have an
explicit length.
