### PR TITLE
Support out-of-bounds checks on arrays of dynamic size

### DIFF
--- a/regression/cbmc/dynamic_size1/main.c
+++ b/regression/cbmc/dynamic_size1/main.c
@@ -1,0 +1,14 @@
+#include <stdlib.h>
+
+int main()
+{
+  unsigned x;
+
+  int *A=malloc(x*sizeof(int));
+
+  char *p=&A[1];
+
+  char c=*p;
+
+  return c;
+}

--- a/regression/cbmc/dynamic_size1/test.desc
+++ b/regression/cbmc/dynamic_size1/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--pointer-check
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+^unknown or invalid type size:


### PR DESCRIPTION
Previously the code would rely on type sizes being constant when building a
subtraction; this is unnecessary as the expression is sent to the solver for
evaluation anyway.

~The code should be adjusted once #1063 is merged, thus marking do-not-merge for now.~