### PR TITLE
[depends: #1063] Use nullptr to represent null pointers (targets master)

### DIFF
--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -37,7 +37,7 @@ public:
     const namespacet &_ns,
     const optionst &_options):
     ns(_ns),
-    local_bitvector_analysis(0)
+    local_bitvector_analysis(nullptr)
   {
     enable_bounds_check=_options.get_bool_option("bounds-check");
     enable_pointer_check=_options.get_bool_option("pointer-check");

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -463,9 +463,9 @@ void rw_range_sett::add(
 {
   objectst::iterator entry=(mode==get_modet::LHS_W ? w_range_set : r_range_set).
     insert(
-      std::pair<const irep_idt&, range_domain_baset*>(identifier, 0)).first;
+      std::pair<const irep_idt&, range_domain_baset*>(identifier, nullptr)).first;
 
-  if(entry->second==0)
+  if(entry->second==nullptr)
     entry->second=new range_domaint();
 
   static_cast<range_domaint*>(entry->second)->push_back(
@@ -663,9 +663,9 @@ void rw_guarded_range_set_value_sett::add(
 {
   objectst::iterator entry=(mode==get_modet::LHS_W ? w_range_set : r_range_set).
     insert(
-      std::pair<const irep_idt&, range_domain_baset*>(identifier, 0)).first;
+      std::pair<const irep_idt&, range_domain_baset*>(identifier, nullptr)).first;
 
-  if(entry->second==0)
+  if(entry->second==nullptr)
     entry->second=new guarded_range_domaint();
 
   static_cast<guarded_range_domaint*>(entry->second)->insert(

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -463,7 +463,8 @@ void rw_range_sett::add(
 {
   objectst::iterator entry=(mode==get_modet::LHS_W ? w_range_set : r_range_set).
     insert(
-      std::pair<const irep_idt&, range_domain_baset*>(identifier, nullptr)).first;
+      std::pair<const irep_idt&, range_domain_baset*>(
+        identifier, nullptr)).first;
 
   if(entry->second==nullptr)
     entry->second=new range_domaint();
@@ -663,7 +664,8 @@ void rw_guarded_range_set_value_sett::add(
 {
   objectst::iterator entry=(mode==get_modet::LHS_W ? w_range_set : r_range_set).
     insert(
-      std::pair<const irep_idt&, range_domain_baset*>(identifier, nullptr)).first;
+      std::pair<const irep_idt&, range_domain_baset*>(
+        identifier, nullptr)).first;
 
   if(entry->second==nullptr)
     entry->second=new guarded_range_domaint();

--- a/src/analyses/goto_rw.h
+++ b/src/analyses/goto_rw.h
@@ -108,7 +108,7 @@ public:
 
   const range_domaint &get_ranges(objectst::const_iterator it) const
   {
-    assert(dynamic_cast<range_domaint*>(it->second)!=nullptr);
+    PRECONDITION(dynamic_cast<range_domaint*>(it->second)!=nullptr);
     return *static_cast<range_domaint*>(it->second);
   }
 
@@ -277,7 +277,7 @@ public:
 
   const guarded_range_domaint &get_ranges(objectst::const_iterator it) const
   {
-    assert(dynamic_cast<guarded_range_domaint*>(it->second)!=nullptr);
+    PRECONDITION(dynamic_cast<guarded_range_domaint*>(it->second)!=nullptr);
     return *static_cast<guarded_range_domaint*>(it->second);
   }
 

--- a/src/analyses/goto_rw.h
+++ b/src/analyses/goto_rw.h
@@ -108,7 +108,7 @@ public:
 
   const range_domaint &get_ranges(objectst::const_iterator it) const
   {
-    assert(dynamic_cast<range_domaint*>(it->second)!=0);
+    assert(dynamic_cast<range_domaint*>(it->second)!=nullptr);
     return *static_cast<range_domaint*>(it->second);
   }
 
@@ -277,7 +277,7 @@ public:
 
   const guarded_range_domaint &get_ranges(objectst::const_iterator it) const
   {
-    assert(dynamic_cast<guarded_range_domaint*>(it->second)!=0);
+    assert(dynamic_cast<guarded_range_domaint*>(it->second)!=nullptr);
     return *static_cast<guarded_range_domaint*>(it->second);
   }
 

--- a/src/analyses/invariant_set.cpp
+++ b/src/analyses/invariant_set.cpp
@@ -144,7 +144,7 @@ bool invariant_sett::get_object(
   const exprt &expr,
   unsigned &n) const
 {
-  assert(object_store!=nullptr);
+  PRECONDITION(object_store!=nullptr);
   return object_store->get(expr, n);
 }
 
@@ -315,7 +315,8 @@ void invariant_sett::output(
     return;
   }
 
-  assert(object_store!=nullptr);
+  INVARIANT(
+    object_store!=nullptr, nullptr_exceptiont("Object store is null"));
 
   for(unsigned i=0; i<eq_set.size(); i++)
     if(eq_set.is_root(i) &&
@@ -899,7 +900,7 @@ std::string invariant_sett::to_string(
   unsigned a,
   const irep_idt &identifier) const
 {
-  assert(object_store!=nullptr);
+  PRECONDITION(object_store!=nullptr);
   return object_store->to_string(a, identifier);
 }
 

--- a/src/analyses/invariant_set.cpp
+++ b/src/analyses/invariant_set.cpp
@@ -144,7 +144,7 @@ bool invariant_sett::get_object(
   const exprt &expr,
   unsigned &n) const
 {
-  assert(object_store!=NULL);
+  assert(object_store!=nullptr);
   return object_store->get(expr, n);
 }
 
@@ -315,7 +315,7 @@ void invariant_sett::output(
     return;
   }
 
-  assert(object_store!=NULL);
+  assert(object_store!=nullptr);
 
   for(unsigned i=0; i<eq_set.size(); i++)
     if(eq_set.is_root(i) &&
@@ -899,7 +899,7 @@ std::string invariant_sett::to_string(
   unsigned a,
   const irep_idt &identifier) const
 {
-  assert(object_store!=NULL);
+  assert(object_store!=nullptr);
   return object_store->to_string(a, identifier);
 }
 

--- a/src/analyses/invariant_set.h
+++ b/src/analyses/invariant_set.h
@@ -98,9 +98,9 @@ public:
   invariant_sett():
     threaded(false),
     is_false(false),
-    value_sets(NULL),
-    object_store(NULL),
-    ns(NULL)
+    value_sets(nullptr),
+    object_store(nullptr),
+    ns(nullptr)
   {
   }
 

--- a/src/analyses/invariant_set.h
+++ b/src/analyses/invariant_set.h
@@ -22,6 +22,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "interval_template.h"
 
+#define nullptr_exceptiont(str) str
+
 class inv_object_storet
 {
 public:

--- a/src/analyses/local_may_alias.h
+++ b/src/analyses/local_may_alias.h
@@ -109,7 +109,7 @@ public:
 
   local_may_aliast &operator()(const irep_idt &fkt)
   {
-    assert(goto_functions!=nullptr);
+    PRECONDITION(goto_functions!=nullptr);
     fkt_mapt::iterator f_it=fkt_map.find(fkt);
     if(f_it!=fkt_map.end())
       return *f_it->second;

--- a/src/analyses/local_may_alias.h
+++ b/src/analyses/local_may_alias.h
@@ -94,7 +94,7 @@ protected:
 class local_may_alias_factoryt
 {
 public:
-  local_may_alias_factoryt():goto_functions(NULL)
+  local_may_alias_factoryt():goto_functions(nullptr)
   {
   }
 
@@ -109,7 +109,7 @@ public:
 
   local_may_aliast &operator()(const irep_idt &fkt)
   {
-    assert(goto_functions!=NULL);
+    assert(goto_functions!=nullptr);
     fkt_mapt::iterator f_it=fkt_map.find(fkt);
     if(f_it!=fkt_map.end())
       return *f_it->second;

--- a/src/analyses/reaching_definitions.cpp
+++ b/src/analyses/reaching_definitions.cpp
@@ -51,7 +51,9 @@ void rd_range_domaint::transform(
 {
   reaching_definitions_analysist *rd=
     dynamic_cast<reaching_definitions_analysist*>(&ai);
-  assert(rd!=nullptr);
+  INVARIANT(
+    rd!=nullptr,
+    bad_cast_exceptiont("ai has type reaching_definitions_analysist"));
 
   assert(bv_container);
 
@@ -298,7 +300,9 @@ void rd_range_domaint::transform_assign(
     const symbolt *symbol_ptr;
     if(ns.lookup(identifier, symbol_ptr))
       continue;
-    assert(symbol_ptr!=nullptr);
+    INVARIANT(
+      symbol_ptr!=nullptr,
+      nullptr_exceptiont("Symbol is in symbol table"));
 
     const range_domaint &ranges=rw_set.get_ranges(it);
 

--- a/src/analyses/reaching_definitions.cpp
+++ b/src/analyses/reaching_definitions.cpp
@@ -51,7 +51,7 @@ void rd_range_domaint::transform(
 {
   reaching_definitions_analysist *rd=
     dynamic_cast<reaching_definitions_analysist*>(&ai);
-  assert(rd!=0);
+  assert(rd!=nullptr);
 
   assert(bv_container);
 
@@ -298,7 +298,7 @@ void rd_range_domaint::transform_assign(
     const symbolt *symbol_ptr;
     if(ns.lookup(identifier, symbol_ptr))
       continue;
-    assert(symbol_ptr!=0);
+    assert(symbol_ptr!=nullptr);
 
     const range_domaint &ranges=rw_set.get_ranges(it);
 

--- a/src/analyses/reaching_definitions.h
+++ b/src/analyses/reaching_definitions.h
@@ -26,6 +26,9 @@ class is_threadedt;
 class dirtyt;
 class reaching_definitions_analysist;
 
+#define bad_cast_exceptiont(str) str
+#define nullptr_exceptiont(str) str
+
 // requirement: V has a member "identifier" of type irep_idt
 template<typename V>
 class sparse_bitvector_analysist
@@ -259,7 +262,9 @@ public:
     statet &s=concurrency_aware_ait<rd_range_domaint>::get_state(l);
 
     rd_range_domaint *rd_state=dynamic_cast<rd_range_domaint*>(&s);
-    assert(rd_state!=nullptr);
+    INVARIANT(
+      rd_state!=nullptr,
+      bad_cast_exceptiont("rd_state has type rd_range_domaint"));
 
     rd_state->set_bitvector_container(*this);
 

--- a/src/analyses/reaching_definitions.h
+++ b/src/analyses/reaching_definitions.h
@@ -102,7 +102,7 @@ public:
   rd_range_domaint():
     ai_domain_baset(),
     has_values(false),
-    bv_container(0)
+    bv_container(nullptr)
   {
   }
 
@@ -243,9 +243,9 @@ public:
   explicit reaching_definitions_analysist(const namespacet &_ns):
     concurrency_aware_ait<rd_range_domaint>(),
     ns(_ns),
-    value_sets(0),
-    is_threaded(0),
-    is_dirty(0)
+    value_sets(nullptr),
+    is_threaded(nullptr),
+    is_dirty(nullptr)
   {
   }
 
@@ -259,7 +259,7 @@ public:
     statet &s=concurrency_aware_ait<rd_range_domaint>::get_state(l);
 
     rd_range_domaint *rd_state=dynamic_cast<rd_range_domaint*>(&s);
-    assert(rd_state!=0);
+    assert(rd_state!=nullptr);
 
     rd_state->set_bitvector_container(*this);
 

--- a/src/ansi-c/c_preprocess.cpp
+++ b/src/ansi-c/c_preprocess.cpp
@@ -344,7 +344,7 @@ bool c_preprocess(
 static bool is_dot_i_file(const std::string &path)
 {
   const char *ext=strrchr(path.c_str(), '.');
-  if(ext==NULL)
+  if(ext==nullptr)
     return false;
   if(std::string(ext)==".i" ||
      std::string(ext)==".ii")
@@ -889,7 +889,7 @@ bool c_preprocess_gcc_clang(
 
   FILE *stream=popen(command.c_str(), "r");
 
-  if(stream!=NULL)
+  if(stream!=nullptr)
   {
     int ch;
     while((ch=fgetc(stream))!=EOF)
@@ -1011,7 +1011,7 @@ bool c_preprocess_arm(
 
   FILE *stream=popen(command.c_str(), "r");
 
-  if(stream!=NULL)
+  if(stream!=nullptr)
   {
     int ch;
     while((ch=fgetc(stream))!=EOF)

--- a/src/ansi-c/cprover_library.cpp
+++ b/src/ansi-c/cprover_library.cpp
@@ -38,7 +38,7 @@ std::string get_cprover_library_text(
   std::size_t count=0;
 
   for(cprover_library_entryt *e=cprover_library;
-      e->function!=NULL;
+      e->function!=nullptr;
       e++)
   {
     irep_idt id=e->function;

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -2664,7 +2664,7 @@ std::string expr2ct::convert_code_decl(
 
   std::string dest=indent_str(indent);
 
-  const symbolt *symbol=0;
+  const symbolt *symbol=nullptr;
   if(!ns.lookup(to_symbol_expr(src.op0()).get_identifier(), symbol))
   {
     if(symbol->is_file_local &&

--- a/src/big-int/bigint-test.cc
+++ b/src/big-int/bigint-test.cc
@@ -161,7 +161,7 @@ static void
 run_clisp_tests (char const *fn)
 {
   FILE *f = fopen (fn, "rt");
-  if (f == 0)
+  if (f == nullptr)
     {
       fprintf (stderr, "Error opening %s: %s.\n", fn, strerror (errno));
       return;

--- a/src/big-int/bigint.cc
+++ b/src/big-int/bigint.cc
@@ -266,7 +266,7 @@ digit_div (onedig_t *r, const onedig_t *y, unsigned yl, onedig_t *q, unsigned ql
 	  --qh;
 	  add_back (r, y, yl);
 	}
-      if (q != 0)
+      if (q != nullptr)
 	q[i] = qh;
     }
 }
@@ -580,7 +580,7 @@ char *
 BigInt::as_string (char *p, unsigned l, onedig_t b) const
 {
   if (l < 2)
-    return 0;				// Not enough room for number.
+    return nullptr;				// Not enough room for number.
   p[--l] = '\0';
   // Check for zero. Would otherwise print as empty string.
   unsigned len = length;
@@ -598,7 +598,7 @@ BigInt::as_string (char *p, unsigned l, onedig_t b) const
   do
     {
       if (l == 0)
-	return 0;
+	return nullptr;
       onedig_t r = digit_div (dig, len, b);
       p[--l] = r < 10 ? r + '0' : 'A' + r - 10;
       if (dig[len-1] == 0)
@@ -608,7 +608,7 @@ BigInt::as_string (char *p, unsigned l, onedig_t b) const
   // Maybe attach sign.
   if (!positive){
     if (l == 0)
-      return 0;
+      return nullptr;
     else
       p[--l] = '-';
   }
@@ -1268,7 +1268,7 @@ BigInt::operator%= (BigInt const &y)
 	}
       if (a[al-1] >= b[bl-1])
 	a[al++] = 0;
-      digit_div (a, b, bl, 0, al - bl);
+      digit_div (a, b, bl, nullptr, al - bl);
       length = bl;
       adjust();
       if (scale != 1)

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -590,7 +590,7 @@ int cbmc_parse_optionst::get_goto_program(
 
       languaget *language=get_language_from_filename(filename);
 
-      if(language==NULL)
+      if(language==nullptr)
       {
         error() << "failed to figure out type of file `"
                 <<  filename << "'" << eom;
@@ -739,7 +739,7 @@ void cbmc_parse_optionst::preprocessing()
 
     languaget *ptr=get_language_from_filename(filename);
 
-    if(ptr==NULL)
+    if(ptr==nullptr)
     {
       error() << "failed to figure out type of file" << eom;
       return;

--- a/src/clobber/clobber_parse_options.cpp
+++ b/src/clobber/clobber_parse_options.cpp
@@ -250,7 +250,7 @@ bool clobber_parse_optionst::get_goto_program(
 
       languaget *language=get_language_from_filename(filename);
 
-      if(language==NULL)
+      if(language==nullptr)
       {
         error() << "failed to figure out type of file `" <<  filename << "'"
                 << eom;

--- a/src/cpp/cpp_id.cpp
+++ b/src/cpp/cpp_id.cpp
@@ -24,7 +24,7 @@ cpp_idt::cpp_idt():
   id_class(id_classt::UNKNOWN),
   this_expr(static_cast<const exprt &>(get_nil_irep())),
   compound_counter(0),
-  parent(NULL)
+  parent(nullptr)
 {
 }
 

--- a/src/cpp/cpp_id.h
+++ b/src/cpp/cpp_id.h
@@ -20,6 +20,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <iosfwd>
 
 #include <util/expr.h>
+#include <util/invariant.h>
 #include <util/std_types.h>
 
 class cpp_scopet;
@@ -81,7 +82,7 @@ public:
 
   cpp_idt &get_parent() const
   {
-    assert(parent!=nullptr);
+    PRECONDITION(parent!=nullptr);
     return *parent;
   }
 

--- a/src/cpp/cpp_id.h
+++ b/src/cpp/cpp_id.h
@@ -81,7 +81,7 @@ public:
 
   cpp_idt &get_parent() const
   {
-    assert(parent!=NULL);
+    assert(parent!=nullptr);
     return *parent;
   }
 

--- a/src/cpp/cpp_instantiate_template.cpp
+++ b/src/cpp/cpp_instantiate_template.cpp
@@ -130,7 +130,8 @@ const symbolt &cpp_typecheckt::class_template_symbol(
   cpp_scopet *template_scope=
     static_cast<cpp_scopet *>(cpp_scopes.id_map[template_symbol.name]);
 
-  assert(template_scope!=nullptr);
+  INVARIANT(
+    template_scope!=nullptr, nullptr_exceptiont("template_scope is null"));
 
   irep_idt identifier=
     id2string(template_scope->prefix)+
@@ -284,7 +285,8 @@ const symbolt &cpp_typecheckt::instantiate_template(
     throw 0;
   }
 
-  assert(template_scope!=nullptr);
+  INVARIANT(
+    template_scope!=nullptr, nullptr_exceptiont("template_scope is null"));
 
   // produce new declaration
   cpp_declarationt new_decl=to_cpp_declaration(template_symbol.type);

--- a/src/cpp/cpp_instantiate_template.cpp
+++ b/src/cpp/cpp_instantiate_template.cpp
@@ -130,7 +130,7 @@ const symbolt &cpp_typecheckt::class_template_symbol(
   cpp_scopet *template_scope=
     static_cast<cpp_scopet *>(cpp_scopes.id_map[template_symbol.name]);
 
-  assert(template_scope!=NULL);
+  assert(template_scope!=nullptr);
 
   irep_idt identifier=
     id2string(template_scope->prefix)+
@@ -276,7 +276,7 @@ const symbolt &cpp_typecheckt::instantiate_template(
   cpp_scopet *template_scope=
     static_cast<cpp_scopet *>(cpp_scopes.id_map[template_symbol.name]);
 
-  if(template_scope==NULL)
+  if(template_scope==nullptr)
   {
     error().source_location=source_location;
     error() << "identifier: " << template_symbol.name << '\n'
@@ -284,7 +284,7 @@ const symbolt &cpp_typecheckt::instantiate_template(
     throw 0;
   }
 
-  assert(template_scope!=NULL);
+  assert(template_scope!=nullptr);
 
   // produce new declaration
   cpp_declarationt new_decl=to_cpp_declaration(template_symbol.type);

--- a/src/cpp/cpp_language.cpp
+++ b/src/cpp/cpp_language.cpp
@@ -65,7 +65,7 @@ bool cpp_languaget::preprocess(
   // check extension
 
   const char *ext=strrchr(path.c_str(), '.');
-  if(ext!=NULL && std::string(ext)==".ipp")
+  if(ext!=nullptr && std::string(ext)==".ipp")
   {
     std::ifstream infile(path);
 

--- a/src/cpp/cpp_typecheck.h
+++ b/src/cpp/cpp_typecheck.h
@@ -30,6 +30,8 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include "cpp_template_type.h"
 #include "cpp_util.h"
 
+#define nullptr_exceptiont(str) str
+
 bool cpp_typecheck(
   cpp_parse_treet &cpp_parse_tree,
   symbol_tablet &symbol_table,

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -109,7 +109,7 @@ void cpp_typecheckt::typecheck_compound_type(
   // get the tag name
   bool has_tag=type.find(ID_tag).is_not_nil();
   irep_idt base_name;
-  cpp_scopet *dest_scope=NULL;
+  cpp_scopet *dest_scope=nullptr;
   bool has_body=type.find(ID_body).is_not_nil();
   bool tag_only_declaration=type.get_bool(ID_C_tag_only_declaration);
 

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -471,7 +471,7 @@ struct operator_entryt
   { ID_notequal, "!=" },
   { ID_dereference, "*" },
   { ID_ptrmember, "->" },
-  { irep_idt(), NULL }
+  { irep_idt(), nullptr }
 };
 
 bool cpp_typecheckt::operator_is_overloaded(exprt &expr)

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -1117,7 +1117,7 @@ symbol_typet cpp_typecheck_resolvet::disambiguate_template_classes(
       static_cast<cpp_scopet *>(
         cpp_typecheck.cpp_scopes.id_map[id]);
 
-    if(template_scope==NULL)
+    if(template_scope==nullptr)
     {
       cpp_typecheck.error().source_location=source_location;
       cpp_typecheck.error() << "template identifier: " << id << '\n'
@@ -1959,7 +1959,7 @@ exprt cpp_typecheck_resolvet::guess_function_template_args(
     static_cast<cpp_scopet *>(
       cpp_typecheck.cpp_scopes.id_map[template_identifier]);
 
-  if(template_scope==NULL)
+  if(template_scope==nullptr)
   {
     cpp_typecheck.error().source_location=source_location;
     cpp_typecheck.error() << "template identifier: "

--- a/src/cpp/cpp_typecheck_template.cpp
+++ b/src/cpp/cpp_typecheck_template.cpp
@@ -910,7 +910,7 @@ cpp_template_args_tct cpp_typecheckt::typecheck_template_args(
       // these need to be typechecked in the scope of the template,
       // not in the current scope!
       cpp_idt *template_scope=cpp_scopes.id_map[template_symbol.name];
-      assert(template_scope!=NULL);
+      assert(template_scope!=nullptr);
       cpp_scopes.go_to(*template_scope);
     }
 
@@ -960,7 +960,7 @@ cpp_template_args_tct cpp_typecheckt::typecheck_template_args(
       {
         cpp_save_scopet cpp_saved_scope(cpp_scopes);
         cpp_idt *template_scope=cpp_scopes.id_map[template_symbol.name];
-        assert(template_scope!=NULL);
+        assert(template_scope!=nullptr);
         cpp_scopes.go_to(*template_scope);
         typecheck_type(type);
       }

--- a/src/cpp/cpp_typecheck_template.cpp
+++ b/src/cpp/cpp_typecheck_template.cpp
@@ -910,7 +910,8 @@ cpp_template_args_tct cpp_typecheckt::typecheck_template_args(
       // these need to be typechecked in the scope of the template,
       // not in the current scope!
       cpp_idt *template_scope=cpp_scopes.id_map[template_symbol.name];
-      assert(template_scope!=nullptr);
+      INVARIANT(
+        template_scope!=nullptr, nullptr_exceptiont("template_scope is null"));
       cpp_scopes.go_to(*template_scope);
     }
 
@@ -960,7 +961,9 @@ cpp_template_args_tct cpp_typecheckt::typecheck_template_args(
       {
         cpp_save_scopet cpp_saved_scope(cpp_scopes);
         cpp_idt *template_scope=cpp_scopes.id_map[template_symbol.name];
-        assert(template_scope!=nullptr);
+        INVARIANT(
+          template_scope!=nullptr,
+          nullptr_exceptiont("template_scope is null"));
         cpp_scopes.go_to(*template_scope);
         typecheck_type(type);
       }

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -48,7 +48,7 @@ struct indenter // NOLINT(readability/identifiers)
 class new_scopet
 {
 public:
-  new_scopet():kind(kindt::NONE), anon_count(0), parent(NULL)
+  new_scopet():kind(kindt::NONE), anon_count(0), parent(nullptr)
   {
   }
 
@@ -155,7 +155,7 @@ public:
 
   std::string full_name() const
   {
-    return (parent==NULL?"":(parent->full_name()+"::"))+
+    return (parent==nullptr?"":(parent->full_name()+"::"))+
            id2string(id);
   }
 

--- a/src/goto-cc/armcc_cmdline.cpp
+++ b/src/goto-cc/armcc_cmdline.cpp
@@ -192,7 +192,7 @@ static const char *options_no_arg[]=
   "--translate_gcc",
   "--translate_gld",
   "-W",
-  NULL
+  nullptr
 };
 
 static const char *options_with_prefix[]=
@@ -242,7 +242,7 @@ static const char *options_with_prefix[]=
   "--configure_cpp_headers=",
   "--configure_extra_includes=",
   "--configure_extra_libraries=",
-  NULL
+  nullptr
 };
 
 static const char *options_with_arg[]=
@@ -262,7 +262,7 @@ static const char *options_with_arg[]=
   "-o",
   "--cpu",
   "--apcs",
-  NULL
+  nullptr
 };
 
 bool armcc_cmdlinet::parse(int argc, const char **argv)

--- a/src/goto-cc/as86_cmdline.cpp
+++ b/src/goto-cc/as86_cmdline.cpp
@@ -23,7 +23,7 @@ const char *goto_as86_options_with_argument[]=
   "--function",
   "--native-assembler",
   "--print-rejected-preprocessed-source",
-  NULL
+  nullptr
 };
 
 const char *as86_options_without_argument[]=
@@ -40,7 +40,7 @@ const char *as86_options_without_argument[]=
   "-u-", // both -u and -u- seem to be accepted
   "-v",
   "-w-",
-  NULL
+  nullptr
 };
 
 const char *as86_options_with_argument[]=
@@ -52,7 +52,7 @@ const char *as86_options_with_argument[]=
   "-b",
   "-s",
   "-t",
-  NULL
+  nullptr
 };
 
 bool as86_cmdlinet::parse(int argc, const char **argv)
@@ -75,7 +75,7 @@ bool as86_cmdlinet::parse(int argc, const char **argv)
 
     // separated only, and also allow concatenation with "="
     for(const char **o=goto_as86_options_with_argument;
-        *o!=NULL && !found;
+        *o!=nullptr && !found;
         ++o)
     {
       std::string os(*o);
@@ -113,7 +113,7 @@ bool as86_cmdlinet::parse(int argc, const char **argv)
     }
 
     for(const char **o=as86_options_with_argument;
-        *o!=NULL && !found;
+        *o!=nullptr && !found;
         ++o)
     {
       std::string os(*o);

--- a/src/goto-cc/as_cmdline.cpp
+++ b/src/goto-cc/as_cmdline.cpp
@@ -23,7 +23,7 @@ const char *goto_as_options_with_argument[]=
   "--function",
   "--native-assembler",
   "--print-rejected-preprocessed-source",
-  NULL
+  nullptr
 };
 
 const char *as_options_without_argument[]=
@@ -59,7 +59,7 @@ const char *as_options_without_argument[]=
   "--32", // i386
   "--64", // i386
   "-n", // i386
-  NULL
+  nullptr
 };
 
 const char *as_options_with_argument[]=
@@ -74,7 +74,7 @@ const char *as_options_with_argument[]=
   "-o",
   "-march", // i386
   "-mtune", // i386
-  NULL
+  nullptr
 };
 
 bool as_cmdlinet::parse(int argc, const char **argv)
@@ -104,7 +104,7 @@ bool as_cmdlinet::parse(int argc, const char **argv)
 
     // separated only, and also allow concatenation with "="
     for(const char **o=goto_as_options_with_argument;
-        *o!=NULL && !found;
+        *o!=nullptr && !found;
         ++o)
     {
       std::string os(*o);
@@ -170,7 +170,7 @@ bool as_cmdlinet::parse(int argc, const char **argv)
     }
 
     for(const char **o=as_options_with_argument;
-        *o!=NULL && !found;
+        *o!=nullptr && !found;
         ++o)
     {
       std::string os(*o);

--- a/src/goto-cc/bcc_cmdline.cpp
+++ b/src/goto-cc/bcc_cmdline.cpp
@@ -24,7 +24,7 @@ const char *goto_bcc_options_with_argument[]=
   "--native-compiler",
   "--native-linker",
   "--print-rejected-preprocessed-source",
-  NULL
+  nullptr
 };
 
 const char *bcc_options_without_argument[]=
@@ -46,7 +46,7 @@ const char *bcc_options_without_argument[]=
   "-x",
   "-W",
   "-ansi",
-  NULL
+  nullptr
 };
 
 const char *bcc_options_with_argument[]=
@@ -64,7 +64,7 @@ const char *bcc_options_with_argument[]=
   "-T",
   "-Q",
   "-t",
-  NULL
+  nullptr
 };
 
 bool bcc_cmdlinet::parse(int argc, const char **argv)
@@ -87,7 +87,7 @@ bool bcc_cmdlinet::parse(int argc, const char **argv)
 
     // separated only, and also allow concatenation with "="
     for(const char **o=goto_bcc_options_with_argument;
-        *o!=NULL && !found;
+        *o!=nullptr && !found;
         ++o)
     {
       std::string os(*o);
@@ -125,7 +125,7 @@ bool bcc_cmdlinet::parse(int argc, const char **argv)
     }
 
     for(const char **o=bcc_options_with_argument;
-        *o!=NULL && !found;
+        *o!=nullptr && !found;
         ++o)
     {
       std::string os(*o);

--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -232,7 +232,7 @@ bool compilet::add_input_file(const std::string &file_name)
 
     stream=popen(cmd.str().c_str(), "r");
 
-    if(stream!=NULL)
+    if(stream!=nullptr)
     {
       std::string line;
       int ch; // fgetc returns an int, not char
@@ -472,7 +472,7 @@ bool compilet::parse(const std::string &file_name)
   else
     languagep=get_language_from_filename(file_name);
 
-  if(languagep==NULL)
+  if(languagep==nullptr)
   {
     error() << "failed to figure out type of file `" << file_name << "'" << eom;
     return true;

--- a/src/goto-cc/gcc_cmdline.cpp
+++ b/src/goto-cc/gcc_cmdline.cpp
@@ -29,7 +29,7 @@ const char *goto_cc_options_with_separated_argument[]=
   "--native-compiler",
   "--native-linker",
   "--print-rejected-preprocessed-source",
-  NULL
+  nullptr
 };
 
 // non-gcc options
@@ -52,7 +52,7 @@ const char *goto_cc_options_without_argument[]=
   "--no-arch",
   "--partial-inlining",
   "-?",
-  NULL
+  nullptr
 };
 
 // separated or concatenated
@@ -75,7 +75,7 @@ const char *gcc_options_with_argument[]=
   "-U",
   "-u", // goes to linker
   "-T", // goes to linker
-  NULL
+  nullptr
 };
 
 const char *gcc_options_with_separated_argument[]=
@@ -107,7 +107,7 @@ const char *gcc_options_with_separated_argument[]=
   "-current_version", // on the Mac
   "-compatibility_version",  // on the Mac
   "-z",
-  NULL
+  nullptr
 };
 
 const char *gcc_options_with_concatenated_argument[]=
@@ -115,7 +115,7 @@ const char *gcc_options_with_concatenated_argument[]=
   "-d",
   "-g",
   "-A",
-  NULL
+  nullptr
 };
 
 const char *gcc_options_without_argument[]=
@@ -209,7 +209,7 @@ const char *gcc_options_without_argument[]=
   "-EB",
   "-EL",
   "-fast", // Apple only
-  NULL
+  nullptr
 };
 
 bool gcc_cmdlinet::parse(int argc, const char **argv)
@@ -282,7 +282,7 @@ bool gcc_cmdlinet::parse_arguments(
 
       // separated only, and also allow concatenation with "="
       for(const char **o=goto_cc_options_with_separated_argument;
-          *o!=NULL && !found;
+          *o!=nullptr && !found;
           ++o)
       {
         if(argv_i==*o) // separated
@@ -354,7 +354,7 @@ bool gcc_cmdlinet::parse_arguments(
 
       // separated only, and also allow concatenation with "="
       for(const char **o=gcc_options_with_separated_argument;
-          *o!=NULL && !found;
+          *o!=nullptr && !found;
           ++o)
       {
         if(argv_i==*o) // separated
@@ -380,7 +380,7 @@ bool gcc_cmdlinet::parse_arguments(
 
       // concatenated _or_ separated, e.g., -I
       for(const char **o=gcc_options_with_argument;
-          *o!=NULL && !found;
+          *o!=nullptr && !found;
           ++o)
       {
         if(argv_i==*o) // separated
@@ -405,7 +405,7 @@ bool gcc_cmdlinet::parse_arguments(
 
       // concatenated only
       for(const char **o=gcc_options_with_concatenated_argument;
-          *o!=NULL && !found;
+          *o!=nullptr && !found;
           ++o)
       {
         if(has_prefix(argv_i, *o)) // concatenated

--- a/src/goto-cc/goto_cc_cmdline.cpp
+++ b/src/goto-cc/goto_cc_cmdline.cpp
@@ -29,7 +29,7 @@ goto_cc_cmdlinet::~goto_cc_cmdlinet()
 
 bool goto_cc_cmdlinet::in_list(const char *option, const char **list)
 {
-  for(std::size_t i=0; list[i]!=NULL; i++)
+  for(std::size_t i=0; list[i]!=nullptr; i++)
   {
     if(strcmp(option, list[i])==0)
       return true;
@@ -43,7 +43,7 @@ bool goto_cc_cmdlinet::prefix_in_list(
   const char **list,
   std::string &prefix)
 {
-  for(std::size_t i=0; list[i]!=NULL; i++)
+  for(std::size_t i=0; list[i]!=nullptr; i++)
   {
     if(strncmp(option, list[i], strlen(list[i]))==0)
     {

--- a/src/goto-cc/goto_cc_main.cpp
+++ b/src/goto-cc/goto_cc_main.cpp
@@ -48,7 +48,7 @@ int main(int argc, const char **argv)
   const char **argv=narrow_argv(argc, argv_wide);
   #endif
 
-  if(argv==NULL || argc<1)
+  if(argv==nullptr || argc<1)
   {
     std::cerr << "failed to determine base name\n";
     return 1;

--- a/src/goto-cc/ld_cmdline.cpp
+++ b/src/goto-cc/ld_cmdline.cpp
@@ -24,7 +24,7 @@ const char *goto_ld_options_with_argument[]=
   "--verbosity",
   "--native-compiler",
   "--native-linker",
-  NULL
+  nullptr
 };
 
 const char *ld_options_with_argument[]=
@@ -99,7 +99,7 @@ const char *ld_options_with_argument[]=
   "--ios_version_min", // Apple only
   "--macosx_version_min", // Apple only
   "--install_name", // Apple only
-  NULL
+  nullptr
 };
 
 const char *ld_options_without_argument[]=
@@ -233,7 +233,7 @@ const char *ld_options_without_argument[]=
   "--dylib", // Apple only
   "--dylinker", // Apple only
   "--bundle", // Apple only
-  NULL
+  nullptr
 };
 
 bool ld_cmdlinet::parse(int argc, const char **argv)
@@ -262,7 +262,7 @@ bool ld_cmdlinet::parse(int argc, const char **argv)
     bool found=false;
 
     for(const char **o=goto_ld_options_with_argument;
-        *o!=NULL && !found;
+        *o!=nullptr && !found;
         ++o)
     {
       std::string os(*o);
@@ -299,7 +299,7 @@ bool ld_cmdlinet::parse(int argc, const char **argv)
 
     // also store in cmdlinet
 
-    for(const char **o=ld_options_without_argument; *o!=NULL && !found; o++)
+    for(const char **o=ld_options_without_argument; *o!=nullptr && !found; o++)
     {
       std::string os(*o);
       // ld accepts all long options also as short option
@@ -316,7 +316,7 @@ bool ld_cmdlinet::parse(int argc, const char **argv)
     // 2) concatenated with '=' for long options
     // 3) separate
 
-    for(const char **o=ld_options_with_argument; *o!=NULL && !found; o++)
+    for(const char **o=ld_options_with_argument; *o!=nullptr && !found; o++)
     {
       std::string os(*o);
 

--- a/src/goto-cc/ms_cl_cmdline.cpp
+++ b/src/goto-cc/ms_cl_cmdline.cpp
@@ -44,7 +44,7 @@ const char *non_ms_cl_options[]=
   "--partial-inlining",
   "--verbosity",
   "--function",
-  NULL
+  nullptr
 };
 
 bool ms_cl_cmdlinet::parse(const std::vector<std::string> &options)
@@ -110,7 +110,7 @@ void ms_cl_cmdlinet::parse_env()
 
   const char *CL_env=getenv("CL");
 
-  if(CL_env!=NULL)
+  if(CL_env!=nullptr)
     process_response_file_line(CL_env);
 
   #endif
@@ -275,7 +275,7 @@ void ms_cl_cmdlinet::process_non_cl_option(
 {
   set(s);
 
-  for(unsigned j=0; non_ms_cl_options[j]!=NULL; j++)
+  for(unsigned j=0; non_ms_cl_options[j]!=nullptr; j++)
     if(s==non_ms_cl_options[j])
       return;
 
@@ -288,7 +288,7 @@ void ms_cl_cmdlinet::process_non_cl_option(
 const char *ms_cl_flags[]=
 {
   "c", // compile only
-  NULL
+  nullptr
 };
 
 const char *ms_cl_prefixes[]=
@@ -406,7 +406,7 @@ const char *ms_cl_prefixes[]=
   "MT", //  link with LIBCMT.LIB
   "MDd", //  link with MSVCRTD.LIB debug lib
   "MTd", //  link with LIBCMTD.LIB debug lib
-  NULL
+  nullptr
 };
 
 void ms_cl_cmdlinet::process_cl_option(const std::string &s)
@@ -420,7 +420,7 @@ void ms_cl_cmdlinet::process_cl_option(const std::string &s)
     return;
   }
 
-  for(std::size_t j=0; ms_cl_flags[j]!=NULL; j++)
+  for(std::size_t j=0; ms_cl_flags[j]!=nullptr; j++)
   {
     if(std::string(s, 1, std::string::npos)==ms_cl_flags[j])
     {
@@ -453,7 +453,7 @@ void ms_cl_cmdlinet::process_cl_option(const std::string &s)
     }
   }
 
-  for(std::size_t j=0; ms_cl_prefixes[j]!=NULL; j++)
+  for(std::size_t j=0; ms_cl_prefixes[j]!=nullptr; j++)
   {
     std::string ms_cl_prefix=ms_cl_prefixes[j];
 

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -1309,7 +1309,7 @@ static bool find_block_position_rec(
   if(!root.has_operands())
     return false;
 
-  code_blockt *our_dest=0;
+  code_blockt *our_dest=nullptr;
 
   exprt::operandst &operands=root.operands();
   exprt::operandst::iterator first_found=operands.end();
@@ -1400,14 +1400,14 @@ void dump_ct::insert_local_static_decls(
     std::list<irep_idt> redundant;
     cleanup_decl(d, redundant, type_decls);
 
-    code_blockt *dest_ptr=0;
+    code_blockt *dest_ptr=nullptr;
     exprt::operandst::iterator before=b.operands().end();
 
     // some use of static variables might be optimised out if it is
     // within an if(false) { ... } block
     if(find_block_position_rec(*it, b, dest_ptr, before))
     {
-      CHECK_RETURN(dest_ptr!=0);
+      CHECK_RETURN(dest_ptr!=nullptr);
       dest_ptr->operands().insert(before, d);
     }
   }
@@ -1437,14 +1437,14 @@ void dump_ct::insert_local_type_decls(
     // another hack to ensure symbols inside types are seen
     skip.type()=type;
 
-    code_blockt *dest_ptr=0;
+    code_blockt *dest_ptr=nullptr;
     exprt::operandst::iterator before=b.operands().end();
 
     // we might not find it in case a transparent union type cast
     // has been removed by cleanup operations
     if(find_block_position_rec(*it, b, dest_ptr, before))
     {
-      CHECK_RETURN(dest_ptr!=0);
+      CHECK_RETURN(dest_ptr!=nullptr);
       dest_ptr->operands().insert(before, skip);
     }
   }

--- a/src/goto-instrument/model_argc_argv.cpp
+++ b/src/goto-instrument/model_argc_argv.cpp
@@ -38,7 +38,7 @@ bool model_argc_argv(
   messaget message(message_handler);
   const namespacet ns(symbol_table);
 
-  const symbolt *init_symbol=0;
+  const symbolt *init_symbol=nullptr;
   if(ns.lookup(CPROVER_PREFIX "initialize", init_symbol))
   {
     message.error() << "Linking not done, missing "

--- a/src/goto-instrument/wmm/cycle_collection.cpp
+++ b/src/goto-instrument/wmm/cycle_collection.cpp
@@ -56,7 +56,7 @@ void event_grapht::graph_explorert::collect_cycles(
   for(std::size_t i=0; i<egraph.size(); i++)
     mark[i]=false;
 
-  std::list<event_idt>* order=0;
+  std::list<event_idt>* order=nullptr;
   /* on Power, rfe pairs are also potentially unsafe */
   switch(model)
   {

--- a/src/goto-instrument/wmm/goto2graph.cpp
+++ b/src/goto-instrument/wmm/goto2graph.cpp
@@ -1198,7 +1198,7 @@ bool instrumentert::is_cfg_spurious(const event_grapht::critical_cyclet &cyc)
     const source_locationt &current_location=current_event.source_location;
 
     /* select relevant thread (po) -- or function contained in this thread */
-    goto_programt *current_po=0;
+    goto_programt *current_po=nullptr;
     bool thread_found=false;
 
     Forall_goto_functions(f_it, goto_functions)

--- a/src/goto-programs/initialize_goto_model.cpp
+++ b/src/goto-programs/initialize_goto_model.cpp
@@ -81,7 +81,7 @@ bool initialize_goto_model(
         lf.filename=filename;
         lf.language=get_language_from_filename(filename);
 
-        if(lf.language==NULL)
+        if(lf.language==nullptr)
         {
           source_locationt location;
           location.set_file(filename);

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -70,7 +70,7 @@ void interpretert::command()
 {
   #define BUFSIZE 100
   char command[BUFSIZE];
-  if(fgets(command, BUFSIZE-1, stdin)==NULL)
+  if(fgets(command, BUFSIZE-1, stdin)==nullptr)
   {
     done=true;
     return;

--- a/src/goto-programs/show_symbol_table.cpp
+++ b/src/goto-programs/show_symbol_table.cpp
@@ -48,7 +48,7 @@ void show_symbol_table_plain(
     else
     {
       ptr=get_language_from_mode(symbol.mode);
-      if(ptr==NULL)
+      if(ptr==nullptr)
         throw "symbol "+id2string(symbol.name)+" has unknown mode";
     }
 

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -22,10 +22,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 goto_symex_statet::goto_symex_statet():
   depth(0),
-  symex_target(NULL),
+  symex_target(nullptr),
   atomic_section_id(0),
   record_events(true),
-  dirty(0)
+  dirty(nullptr)
 {
   threads.resize(1);
   new_frame();
@@ -541,7 +541,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
     return false;
 
   // is it a shared object?
-  assert(dirty!=0);
+  assert(dirty!=nullptr);
   const irep_idt &obj_identifier=expr.get_object_name();
   if(obj_identifier=="goto_symex::\\guard" ||
      (!ns.lookup(obj_identifier).is_shared() &&
@@ -666,7 +666,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
   expr=ssa_l1;
 
   // and record that
-  assert(symex_target!=NULL);
+  assert(symex_target!=nullptr);
   symex_target->shared_read(
     guard.as_expr(),
     expr,
@@ -685,7 +685,7 @@ bool goto_symex_statet::l2_thread_write_encoding(
     return false;
 
   // is it a shared object?
-  assert(dirty!=0);
+  assert(dirty!=nullptr);
   const irep_idt &obj_identifier=expr.get_object_name();
   if(obj_identifier=="goto_symex::\\guard" ||
      (!ns.lookup(obj_identifier).is_shared() &&

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -541,7 +541,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
     return false;
 
   // is it a shared object?
-  assert(dirty!=nullptr);
+  INVARIANT(dirty!=nullptr, nullptr_exceptiont("dirty is null"));
   const irep_idt &obj_identifier=expr.get_object_name();
   if(obj_identifier=="goto_symex::\\guard" ||
      (!ns.lookup(obj_identifier).is_shared() &&
@@ -666,7 +666,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
   expr=ssa_l1;
 
   // and record that
-  assert(symex_target!=nullptr);
+  INVARIANT(symex_target!=nullptr, nullptr_exceptiont("symex_target is null"));
   symex_target->shared_read(
     guard.as_expr(),
     expr,
@@ -685,7 +685,7 @@ bool goto_symex_statet::l2_thread_write_encoding(
     return false;
 
   // is it a shared object?
-  assert(dirty!=nullptr);
+  INVARIANT(dirty!=nullptr, nullptr_exceptiont("dirty is null"));
   const irep_idt &obj_identifier=expr.get_object_name();
   if(obj_identifier=="goto_symex::\\guard" ||
      (!ns.lookup(obj_identifier).is_shared() &&

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -26,6 +26,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 class dirtyt;
 
+#define nullptr_exceptiont(str) str
+
 // central data structure: state
 class goto_symex_statet
 {

--- a/src/goto-symex/slice_by_trace.cpp
+++ b/src/goto-symex/slice_by_trace.cpp
@@ -187,9 +187,9 @@ void symex_slice_by_tracet::parse_events(std::string read_line)
 {
   if(read_line=="")
     return;
-  bool parity=strstr(read_line.c_str(), "!")==NULL;
-  bool universe=strstr(read_line.c_str(), "?")!=NULL;
-  bool has_values=strstr(read_line.c_str(), " ")!=NULL;
+  bool parity=strstr(read_line.c_str(), "!")==nullptr;
+  bool universe=strstr(read_line.c_str(), "?")!=nullptr;
+  bool has_values=strstr(read_line.c_str(), " ")!=nullptr;
   std::cout << "Trace: " << read_line << '\n';
   std::vector<irep_idt> value_v;
   if(has_values)

--- a/src/goto-symex/symex_dereference_state.cpp
+++ b/src/goto-symex/symex_dereference_state.cpp
@@ -43,7 +43,7 @@ bool symex_dereference_statet::has_failed_symbol(
         !ns.lookup(failed_symbol, symbol))
     {
       symbolt sym=*symbol;
-      symbolt *sym_ptr=0;
+      symbolt *sym_ptr=nullptr;
       symbol_exprt sym_expr=sym.symbol_expr();
       state.rename(sym_expr, ns, goto_symex_statet::L1);
       sym.name=to_ssa_expr(sym_expr).get_identifier();
@@ -64,7 +64,7 @@ bool symex_dereference_statet::has_failed_symbol(
         !ns.lookup(failed_symbol, symbol))
     {
       symbolt sym=*symbol;
-      symbolt *sym_ptr=0;
+      symbolt *sym_ptr=nullptr;
       symbol_exprt sym_expr=sym.symbol_expr();
       state.rename(sym_expr, ns, goto_symex_statet::L1);
       sym.name=to_ssa_expr(sym_expr).get_identifier();

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -139,7 +139,7 @@ void goto_symext::parameter_assignments(
   {
     // These are va_arg arguments; their types may differ from call to call
     unsigned va_count=0;
-    const symbolt *va_sym=0;
+    const symbolt *va_sym=nullptr;
     while(!ns.lookup(
         id2string(function_identifier)+"::va_arg"+std::to_string(va_count),
         va_sym))

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -158,7 +158,7 @@ void goto_symext::operator()(
   }
 
   delete state.dirty;
-  state.dirty=0;
+  state.dirty=nullptr;
 }
 
 /// symex starting from given program

--- a/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -405,7 +405,7 @@ void java_bytecode_convert_methodt::convert(
 const bytecode_infot &java_bytecode_convert_methodt::get_bytecode_info(
   const irep_idt &statement)
 {
-  for(const bytecode_infot *p=bytecode_info; p->mnemonic!=0; p++)
+  for(const bytecode_infot *p=bytecode_info; p->mnemonic!=nullptr; p++)
     if(statement==p->mnemonic)
       return *p;
 

--- a/src/java_bytecode/java_bytecode_parser.cpp
+++ b/src/java_bytecode/java_bytecode_parser.cpp
@@ -99,7 +99,7 @@ protected:
   {
     // pre-hash the mnemonics, so we do this only once
     bytecodes.resize(256);
-    for(const bytecode_infot *p=bytecode_info; p->mnemonic!=0; p++)
+    for(const bytecode_infot *p=bytecode_info; p->mnemonic!=nullptr; p++)
     {
       assert(p->opcode<bytecodes.size());
       bytecodes[p->opcode].mnemonic=p->mnemonic;

--- a/src/java_bytecode/java_local_variable_table.cpp
+++ b/src/java_bytecode/java_local_variable_table.cpp
@@ -288,7 +288,7 @@ static void populate_predecessor_map(
         auto pred_var=
           (pred<live_variable_at_address.size() ?
            live_variable_at_address[pred] :
-           0);
+           nullptr);
         if(pred_var==&*it)
         {
           // Flow from within same live range?

--- a/src/langapi/language_ui.cpp
+++ b/src/langapi/language_ui.cpp
@@ -68,7 +68,7 @@ bool language_uit::parse(const std::string &filename)
   lf.filename=filename;
   lf.language=get_language_from_filename(filename);
 
-  if(lf.language==NULL)
+  if(lf.language==nullptr)
   {
     source_locationt location;
     location.set_file(filename);
@@ -172,7 +172,7 @@ void language_uit::show_symbol_table_plain(
     else
     {
       ptr=get_language_from_mode(symbol.mode);
-      if(ptr==NULL)
+      if(ptr==nullptr)
         throw "symbol "+id2string(symbol.name)+" has unknown mode";
     }
 

--- a/src/langapi/language_util.cpp
+++ b/src/langapi/language_util.cpp
@@ -30,7 +30,7 @@ static languaget* get_language(
 
   languaget *ptr=get_language_from_mode(symbol->mode);
 
-  if(ptr==NULL)
+  if(ptr==nullptr)
     throw "symbol `"+id2string(symbol->name)+
       "' has unknown mode '"+id2string(symbol->mode)+"'";
 

--- a/src/langapi/mode.cpp
+++ b/src/langapi/mode.cpp
@@ -45,7 +45,7 @@ languaget *get_language_from_mode(const irep_idt &mode)
     if(mode==it->mode)
       return it->factory();
 
-  return NULL;
+  return nullptr;
 }
 
 languaget *get_language_from_filename(const std::string &filename)
@@ -53,13 +53,13 @@ languaget *get_language_from_filename(const std::string &filename)
   std::size_t ext_pos=filename.rfind('.');
 
   if(ext_pos==std::string::npos)
-    return NULL;
+    return nullptr;
 
   std::string extension=
     std::string(filename, ext_pos+1, std::string::npos);
 
   if(extension=="")
-    return NULL;
+    return nullptr;
 
   for(languagest::const_iterator
       l_it=languages.begin();
@@ -79,7 +79,7 @@ languaget *get_language_from_filename(const std::string &filename)
     #endif
   }
 
-  return NULL;
+  return nullptr;
 }
 
 languaget *get_default_language()

--- a/src/miniz/miniz.cpp
+++ b/src/miniz/miniz.cpp
@@ -197,7 +197,7 @@ int mz_deflateInit2(mz_streamp pStream, int level, int method, int window_bits, 
 
     pStream->data_type = 0;
     pStream->adler = MZ_ADLER32_INIT;
-    pStream->msg = NULL;
+    pStream->msg = nullptr;
     pStream->reserved = 0;
     pStream->total_in = 0;
     pStream->total_out = 0;
@@ -212,7 +212,7 @@ int mz_deflateInit2(mz_streamp pStream, int level, int method, int window_bits, 
 
     pStream->state = (struct mz_internal_state *)pComp;
 
-    if(tdefl_init(pComp, NULL, NULL, comp_flags) != TDEFL_STATUS_OKAY)
+    if(tdefl_init(pComp, nullptr, nullptr, comp_flags) != TDEFL_STATUS_OKAY)
     {
         mz_deflateEnd(pStream);
         return MZ_PARAM_ERROR;
@@ -226,7 +226,7 @@ int mz_deflateReset(mz_streamp pStream)
     if((!pStream) || (!pStream->state) || (!pStream->zalloc) || (!pStream->zfree))
         return MZ_STREAM_ERROR;
     pStream->total_in = pStream->total_out = 0;
-    tdefl_init((tdefl_compressor *)pStream->state, NULL, NULL, ((tdefl_compressor *)pStream->state)->m_flags);
+    tdefl_init((tdefl_compressor *)pStream->state, nullptr, nullptr, ((tdefl_compressor *)pStream->state)->m_flags);
     return MZ_OK;
 }
 
@@ -295,7 +295,7 @@ int mz_deflateEnd(mz_streamp pStream)
     if(pStream->state)
     {
         pStream->zfree(pStream->opaque, pStream->state);
-        pStream->state = NULL;
+        pStream->state = nullptr;
     }
     return MZ_OK;
 }
@@ -344,7 +344,7 @@ int mz_compress(unsigned char *pDest, mz_ulong *pDest_len, const unsigned char *
 
 mz_ulong mz_compressBound(mz_ulong source_len)
 {
-    return mz_deflateBound(NULL, source_len);
+    return mz_deflateBound(nullptr, source_len);
 }
 
 typedef struct
@@ -366,7 +366,7 @@ int mz_inflateInit2(mz_streamp pStream, int window_bits)
 
     pStream->data_type = 0;
     pStream->adler = 0;
-    pStream->msg = NULL;
+    pStream->msg = nullptr;
     pStream->total_in = 0;
     pStream->total_out = 0;
     pStream->reserved = 0;
@@ -516,7 +516,7 @@ int mz_inflateEnd(mz_streamp pStream)
     if(pStream->state)
     {
         pStream->zfree(pStream->opaque, pStream->state);
-        pStream->state = NULL;
+        pStream->state = nullptr;
     }
     return MZ_OK;
 }
@@ -566,7 +566,7 @@ const char *mz_error(int err)
     for(i = 0; i < sizeof(s_error_descs) / sizeof(s_error_descs[0]); ++i)
         if(s_error_descs[i].m_err == err)
             return s_error_descs[i].m_pDesc;
-    return NULL;
+    return nullptr;
 }
 
 #endif /*MINIZ_NO_ZLIB_APIS */
@@ -1210,7 +1210,7 @@ static int tdefl_flush_block(tdefl_compressor *d, int flush)
     mz_uint8 *pSaved_output_buf;
     mz_bool comp_block_succeeded = MZ_FALSE;
     int n, use_raw_block = ((d->m_flags & TDEFL_FORCE_ALL_RAW_BLOCKS) != 0) && (d->m_lookahead_pos - d->m_lz_code_buf_dict_pos) <= d->m_dict_size;
-    mz_uint8 *pOutput_buf_start = ((d->m_pPut_buf_func == NULL) && ((*d->m_pOut_buf_size - d->m_out_buf_ofs) >= TDEFL_OUT_BUF_SIZE)) ? ((mz_uint8 *)d->m_pOut_buf + d->m_out_buf_ofs) : d->m_output_buf;
+    mz_uint8 *pOutput_buf_start = ((d->m_pPut_buf_func == nullptr) && ((*d->m_pOut_buf_size - d->m_out_buf_ofs) >= TDEFL_OUT_BUF_SIZE)) ? ((mz_uint8 *)d->m_pOut_buf + d->m_out_buf_ofs) : d->m_output_buf;
 
     d->m_pOutput_buf = pOutput_buf_start;
     d->m_pOutput_buf_end = d->m_pOutput_buf + TDEFL_OUT_BUF_SIZE - 16;
@@ -1839,7 +1839,7 @@ tdefl_status tdefl_compress(tdefl_compressor *d, const void *pIn_buf, size_t *pI
     d->m_out_buf_ofs = 0;
     d->m_flush = flush;
 
-    if(((d->m_pPut_buf_func != NULL) == ((pOut_buf != NULL) || (pOut_buf_size != NULL))) || (d->m_prev_return_status != TDEFL_STATUS_OKAY) ||
+    if(((d->m_pPut_buf_func != nullptr) == ((pOut_buf != nullptr) || (pOut_buf_size != nullptr))) || (d->m_prev_return_status != TDEFL_STATUS_OKAY) ||
         (d->m_wants_to_finish && (flush != TDEFL_FINISH)) || (pIn_buf_size && *pIn_buf_size && !pIn_buf) || (pOut_buf_size && *pOut_buf_size && !pOut_buf))
     {
         if(pIn_buf_size)
@@ -1890,7 +1890,7 @@ tdefl_status tdefl_compress(tdefl_compressor *d, const void *pIn_buf, size_t *pI
 tdefl_status tdefl_compress_buffer(tdefl_compressor *d, const void *pIn_buf, size_t in_buf_size, tdefl_flush flush)
 {
     MZ_ASSERT(d->m_pPut_buf_func);
-    return tdefl_compress(d, pIn_buf, &in_buf_size, NULL, NULL, flush);
+    return tdefl_compress(d, pIn_buf, &in_buf_size, nullptr, nullptr, flush);
 }
 
 tdefl_status tdefl_init(tdefl_compressor *d, tdefl_put_buf_func_ptr pPut_buf_func, void *pPut_buf_user, int flags)
@@ -1913,12 +1913,12 @@ tdefl_status tdefl_init(tdefl_compressor *d, tdefl_put_buf_func_ptr pPut_buf_fun
     d->m_prev_return_status = TDEFL_STATUS_OKAY;
     d->m_saved_match_dist = d->m_saved_match_len = d->m_saved_lit = 0;
     d->m_adler32 = 1;
-    d->m_pIn_buf = NULL;
-    d->m_pOut_buf = NULL;
-    d->m_pIn_buf_size = NULL;
-    d->m_pOut_buf_size = NULL;
+    d->m_pIn_buf = nullptr;
+    d->m_pOut_buf = nullptr;
+    d->m_pIn_buf_size = nullptr;
+    d->m_pOut_buf_size = nullptr;
     d->m_flush = TDEFL_NO_FLUSH;
-    d->m_pSrc = NULL;
+    d->m_pSrc = nullptr;
     d->m_src_buf_left = 0;
     d->m_out_buf_ofs = 0;
     memset(&d->m_huff_count[0][0], 0, sizeof(d->m_huff_count[0][0]) * TDEFL_MAX_HUFF_SYMBOLS_0);
@@ -1993,7 +1993,7 @@ void *tdefl_compress_mem_to_heap(const void *pSrc_buf, size_t src_buf_len, size_
         *pOut_len = 0;
     out_buf.m_expandable = MZ_TRUE;
     if(!tdefl_compress_mem_to_output(pSrc_buf, src_buf_len, tdefl_output_buffer_putter, &out_buf, flags))
-        return NULL;
+        return nullptr;
     *pOut_len = out_buf.m_size;
     return out_buf.m_pBuf;
 }
@@ -2054,14 +2054,14 @@ void *tdefl_write_image_to_png_file_in_memory_ex(const void *pImage, int w, int 
     mz_uint32 c;
     *pLen_out = 0;
     if(!pComp)
-        return NULL;
+        return nullptr;
     MZ_CLEAR_OBJ(out_buf);
     out_buf.m_expandable = MZ_TRUE;
     out_buf.m_capacity = 57 + MZ_MAX(64, (1 + bpl) * h);
-    if(NULL == (out_buf.m_pBuf = (mz_uint8 *)MZ_MALLOC(out_buf.m_capacity)))
+    if(nullptr == (out_buf.m_pBuf = (mz_uint8 *)MZ_MALLOC(out_buf.m_capacity)))
     {
         MZ_FREE(pComp);
-        return NULL;
+        return nullptr;
     }
     /* write dummy header */
     for(z = 41; z; --z)
@@ -2073,11 +2073,11 @@ void *tdefl_write_image_to_png_file_in_memory_ex(const void *pImage, int w, int 
         tdefl_compress_buffer(pComp, &z, 1, TDEFL_NO_FLUSH);
         tdefl_compress_buffer(pComp, (mz_uint8 *)pImage + (flip ? (h - 1 - y) : y) * bpl, bpl, TDEFL_NO_FLUSH);
     }
-    if(tdefl_compress_buffer(pComp, NULL, 0, TDEFL_FINISH) != TDEFL_STATUS_DONE)
+    if(tdefl_compress_buffer(pComp, nullptr, 0, TDEFL_FINISH) != TDEFL_STATUS_DONE)
     {
         MZ_FREE(pComp);
         MZ_FREE(out_buf.m_pBuf);
-        return NULL;
+        return nullptr;
     }
     /* write real header */
     *pLen_out = out_buf.m_size - 41;
@@ -2097,7 +2097,7 @@ void *tdefl_write_image_to_png_file_in_memory_ex(const void *pImage, int w, int 
         *pLen_out = 0;
         MZ_FREE(pComp);
         MZ_FREE(out_buf.m_pBuf);
-        return NULL;
+        return nullptr;
     }
     c = (mz_uint32)mz_crc32(MZ_CRC32_INIT, out_buf.m_pBuf + 41 - 4, *pLen_out + 4);
     for(i = 0; i < 4; ++i, c <<= 8)
@@ -2778,20 +2778,20 @@ common_exit:
 void *tinfl_decompress_mem_to_heap(const void *pSrc_buf, size_t src_buf_len, size_t *pOut_len, int flags)
 {
     tinfl_decompressor decomp;
-    void *pBuf = NULL, *pNew_buf;
+    void *pBuf = nullptr, *pNew_buf;
     size_t src_buf_ofs = 0, out_buf_capacity = 0;
     *pOut_len = 0;
     tinfl_init(&decomp);
     for(;;)
     {
         size_t src_buf_size = src_buf_len - src_buf_ofs, dst_buf_size = out_buf_capacity - *pOut_len, new_out_buf_capacity;
-        tinfl_status status = tinfl_decompress(&decomp, (const mz_uint8 *)pSrc_buf + src_buf_ofs, &src_buf_size, (mz_uint8 *)pBuf, pBuf ? (mz_uint8 *)pBuf + *pOut_len : NULL, &dst_buf_size,
+        tinfl_status status = tinfl_decompress(&decomp, (const mz_uint8 *)pSrc_buf + src_buf_ofs, &src_buf_size, (mz_uint8 *)pBuf, pBuf ? (mz_uint8 *)pBuf + *pOut_len : nullptr, &dst_buf_size,
                                                (flags & ~TINFL_FLAG_HAS_MORE_INPUT) | TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF);
         if((status < 0) || (status == TINFL_STATUS_NEEDS_MORE_INPUT))
         {
             MZ_FREE(pBuf);
             *pOut_len = 0;
-            return NULL;
+            return nullptr;
         }
         src_buf_ofs += src_buf_size;
         *pOut_len += dst_buf_size;
@@ -2805,7 +2805,7 @@ void *tinfl_decompress_mem_to_heap(const void *pSrc_buf, size_t src_buf_len, siz
         {
             MZ_FREE(pBuf);
             *pOut_len = 0;
-            return NULL;
+            return nullptr;
         }
         pBuf = pNew_buf;
         out_buf_capacity = new_out_buf_capacity;
@@ -3175,7 +3175,7 @@ static mz_bool mz_zip_array_ensure_capacity(mz_zip_archive *pZip, mz_zip_array *
         while(new_capacity < min_new_capacity)
             new_capacity *= 2;
     }
-    if(NULL == (pNew_p = pZip->m_pRealloc(pZip->m_pAlloc_opaque, pArray->m_p, pArray->m_element_size, new_capacity)))
+    if(nullptr == (pNew_p = pZip->m_pRealloc(pZip->m_pAlloc_opaque, pArray->m_p, pArray->m_element_size, new_capacity)))
         return MZ_FALSE;
     pArray->m_p = pNew_p;
     pArray->m_capacity = new_capacity;
@@ -3304,7 +3304,7 @@ static mz_bool mz_zip_reader_init_internal(mz_zip_archive *pZip, mz_uint flags)
     pZip->m_total_files = 0;
     pZip->m_last_error = MZ_ZIP_NO_ERROR;
 
-    if(NULL == (pZip->m_pState = (mz_zip_internal_state *)pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, sizeof(mz_zip_internal_state))))
+    if(nullptr == (pZip->m_pState = (mz_zip_internal_state *)pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, sizeof(mz_zip_internal_state))))
         return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
 
     memset(pZip->m_pState, 0, sizeof(mz_zip_internal_state));
@@ -3692,7 +3692,7 @@ static mz_bool mz_zip_reader_end_internal(mz_zip_archive *pZip, mz_bool set_last
     if(pZip->m_pState)
     {
         mz_zip_internal_state *pState = pZip->m_pState;
-        pZip->m_pState = NULL;
+        pZip->m_pState = nullptr;
 
         mz_zip_array_clear(pZip, &pState->m_central_dir);
         mz_zip_array_clear(pZip, &pState->m_central_dir_offsets);
@@ -3710,7 +3710,7 @@ static mz_bool mz_zip_reader_end_internal(mz_zip_archive *pZip, mz_bool set_last
                     status = MZ_FALSE;
                 }
             }
-            pState->m_pFile = NULL;
+            pState->m_pFile = nullptr;
         }
 #endif /* #ifndef MINIZ_NO_STDIO */
 
@@ -3899,7 +3899,7 @@ mz_bool mz_zip_reader_init_cfile(mz_zip_archive *pZip, MZ_FILE *pFile, mz_uint64
 static MZ_FORCEINLINE const mz_uint8 *mz_zip_get_cdh(mz_zip_archive *pZip, mz_uint file_index)
 {
     if((!pZip) || (!pZip->m_pState) || (file_index >= pZip->m_total_files))
-        return NULL;
+        return nullptr;
     return &MZ_ZIP_ARRAY_ELEMENT(&pZip->m_pState->m_central_dir, mz_uint8, MZ_ZIP_ARRAY_ELEMENT(&pZip->m_pState->m_central_dir_offsets, mz_uint32, file_index));
 }
 
@@ -4333,7 +4333,7 @@ mz_bool mz_zip_reader_extract_to_mem_no_alloc(mz_zip_archive *pZip, mz_uint file
         if(((sizeof(size_t) == sizeof(mz_uint32))) && (read_buf_size > 0x7FFFFFFF))
             return mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
 
-        if(NULL == (pRead_buf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, (size_t)read_buf_size)))
+        if(nullptr == (pRead_buf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, (size_t)read_buf_size)))
             return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
 
         read_buf_avail = 0;
@@ -4390,19 +4390,19 @@ mz_bool mz_zip_reader_extract_to_mem_no_alloc(mz_zip_archive *pZip, mz_uint file
 mz_bool mz_zip_reader_extract_file_to_mem_no_alloc(mz_zip_archive *pZip, const char *pFilename, void *pBuf, size_t buf_size, mz_uint flags, void *pUser_read_buf, size_t user_read_buf_size)
 {
     mz_uint32 file_index;
-    if(!mz_zip_reader_locate_file_v2(pZip, pFilename, NULL, flags, &file_index))
+    if(!mz_zip_reader_locate_file_v2(pZip, pFilename, nullptr, flags, &file_index))
         return MZ_FALSE;
     return mz_zip_reader_extract_to_mem_no_alloc(pZip, file_index, pBuf, buf_size, flags, pUser_read_buf, user_read_buf_size);
 }
 
 mz_bool mz_zip_reader_extract_to_mem(mz_zip_archive *pZip, mz_uint file_index, void *pBuf, size_t buf_size, mz_uint flags)
 {
-    return mz_zip_reader_extract_to_mem_no_alloc(pZip, file_index, pBuf, buf_size, flags, NULL, 0);
+    return mz_zip_reader_extract_to_mem_no_alloc(pZip, file_index, pBuf, buf_size, flags, nullptr, 0);
 }
 
 mz_bool mz_zip_reader_extract_file_to_mem(mz_zip_archive *pZip, const char *pFilename, void *pBuf, size_t buf_size, mz_uint flags)
 {
-    return mz_zip_reader_extract_file_to_mem_no_alloc(pZip, pFilename, pBuf, buf_size, flags, NULL, 0);
+    return mz_zip_reader_extract_file_to_mem_no_alloc(pZip, pFilename, pBuf, buf_size, flags, nullptr, 0);
 }
 
 void *mz_zip_reader_extract_to_heap(mz_zip_archive *pZip, mz_uint file_index, size_t *pSize, mz_uint flags)
@@ -4417,7 +4417,7 @@ void *mz_zip_reader_extract_to_heap(mz_zip_archive *pZip, mz_uint file_index, si
     if(!p)
     {
         mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
-        return NULL;
+        return nullptr;
     }
 
     comp_size = MZ_READ_LE32(p + MZ_ZIP_CDH_COMPRESSED_SIZE_OFS);
@@ -4427,19 +4427,19 @@ void *mz_zip_reader_extract_to_heap(mz_zip_archive *pZip, mz_uint file_index, si
     if(((sizeof(size_t) == sizeof(mz_uint32))) && (alloc_size > 0x7FFFFFFF))
     {
         mz_zip_set_error(pZip, MZ_ZIP_INTERNAL_ERROR);
-        return NULL;
+        return nullptr;
     }
 
-    if(NULL == (pBuf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, (size_t)alloc_size)))
+    if(nullptr == (pBuf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, (size_t)alloc_size)))
     {
         mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
-        return NULL;
+        return nullptr;
     }
 
     if(!mz_zip_reader_extract_to_mem(pZip, file_index, pBuf, (size_t)alloc_size, flags))
     {
         pZip->m_pFree(pZip->m_pAlloc_opaque, pBuf);
-        return NULL;
+        return nullptr;
     }
 
     if(pSize)
@@ -4450,7 +4450,7 @@ void *mz_zip_reader_extract_to_heap(mz_zip_archive *pZip, mz_uint file_index, si
 void *mz_zip_reader_extract_file_to_heap(mz_zip_archive *pZip, const char *pFilename, size_t *pSize, mz_uint flags)
 {
     mz_uint32 file_index;
-    if(!mz_zip_reader_locate_file_v2(pZip, pFilename, NULL, flags, &file_index))
+    if(!mz_zip_reader_locate_file_v2(pZip, pFilename, nullptr, flags, &file_index))
     {
         if(pSize)
             *pSize = 0;
@@ -4465,8 +4465,8 @@ mz_bool mz_zip_reader_extract_to_callback(mz_zip_archive *pZip, mz_uint file_ind
     mz_uint file_crc32 = MZ_CRC32_INIT;
     mz_uint64 read_buf_size, read_buf_ofs = 0, read_buf_avail, comp_remaining, out_buf_ofs = 0, cur_file_ofs;
     mz_zip_archive_file_stat file_stat;
-    void *pRead_buf = NULL;
-    void *pWrite_buf = NULL;
+    void *pRead_buf = nullptr;
+    void *pWrite_buf = nullptr;
     mz_uint32 local_header_u32[(MZ_ZIP_LOCAL_DIR_HEADER_SIZE + sizeof(mz_uint32) - 1) / sizeof(mz_uint32)];
     mz_uint8 *pLocal_header = (mz_uint8 *)local_header_u32;
 
@@ -4510,7 +4510,7 @@ mz_bool mz_zip_reader_extract_to_callback(mz_zip_archive *pZip, mz_uint file_ind
     else
     {
         read_buf_size = MZ_MIN(file_stat.m_comp_size, (mz_uint64)MZ_ZIP_MAX_IO_BUF_SIZE);
-        if(NULL == (pRead_buf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, (size_t)read_buf_size)))
+        if(nullptr == (pRead_buf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, (size_t)read_buf_size)))
             return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
 
         read_buf_avail = 0;
@@ -4578,7 +4578,7 @@ mz_bool mz_zip_reader_extract_to_callback(mz_zip_archive *pZip, mz_uint file_ind
         tinfl_decompressor inflator;
         tinfl_init(&inflator);
 
-        if(NULL == (pWrite_buf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, TINFL_LZ_DICT_SIZE)))
+        if(nullptr == (pWrite_buf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, TINFL_LZ_DICT_SIZE)))
         {
             mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
             status = TINFL_STATUS_FAILED;
@@ -4660,7 +4660,7 @@ mz_bool mz_zip_reader_extract_to_callback(mz_zip_archive *pZip, mz_uint file_ind
 mz_bool mz_zip_reader_extract_file_to_callback(mz_zip_archive *pZip, const char *pFilename, mz_file_write_func pCallback, void *pOpaque, mz_uint flags)
 {
     mz_uint32 file_index;
-    if(!mz_zip_reader_locate_file_v2(pZip, pFilename, NULL, flags, &file_index))
+    if(!mz_zip_reader_locate_file_v2(pZip, pFilename, nullptr, flags, &file_index))
         return MZ_FALSE;
 
     return mz_zip_reader_extract_to_callback(pZip, file_index, pCallback, pOpaque, flags);
@@ -4711,7 +4711,7 @@ mz_bool mz_zip_reader_extract_to_file(mz_zip_archive *pZip, mz_uint file_index, 
 mz_bool mz_zip_reader_extract_file_to_file(mz_zip_archive *pZip, const char *pArchive_filename, const char *pDst_filename, mz_uint flags)
 {
     mz_uint32 file_index;
-    if(!mz_zip_reader_locate_file_v2(pZip, pArchive_filename, NULL, flags, &file_index))
+    if(!mz_zip_reader_locate_file_v2(pZip, pArchive_filename, nullptr, flags, &file_index))
         return MZ_FALSE;
 
     return mz_zip_reader_extract_to_file(pZip, file_index, pDst_filename, flags);
@@ -4733,7 +4733,7 @@ mz_bool mz_zip_reader_extract_to_cfile(mz_zip_archive *pZip, mz_uint file_index,
 mz_bool mz_zip_reader_extract_file_to_cfile(mz_zip_archive *pZip, const char *pArchive_filename, MZ_FILE *pFile, mz_uint flags)
 {
     mz_uint32 file_index;
-    if(!mz_zip_reader_locate_file_v2(pZip, pArchive_filename, NULL, flags, &file_index))
+    if(!mz_zip_reader_locate_file_v2(pZip, pArchive_filename, nullptr, flags, &file_index))
         return MZ_FALSE;
 
     return mz_zip_reader_extract_to_cfile(pZip, file_index, pFile, flags);
@@ -4989,7 +4989,7 @@ mz_bool mz_zip_validate_archive(mz_zip_archive *pZip, mz_uint flags)
             if(!mz_zip_reader_file_stat(pZip, i, &stat))
                 return MZ_FALSE;
 
-            if(!mz_zip_reader_locate_file_v2(pZip, stat.m_filename, NULL, 0, &found_index))
+            if(!mz_zip_reader_locate_file_v2(pZip, stat.m_filename, nullptr, 0, &found_index))
                 return MZ_FALSE;
 
             /* This check can fail if there are duplicate filenames in the archive (which we don't check for when writing - that's up to the user) */
@@ -5138,7 +5138,7 @@ static size_t mz_zip_heap_write_func(void *pOpaque, mz_uint64 file_ofs, const vo
         while(new_capacity < new_size)
             new_capacity *= 2;
 
-        if(NULL == (pNew_block = pZip->m_pRealloc(pZip->m_pAlloc_opaque, pState->m_pMem, 1, new_capacity)))
+        if(nullptr == (pNew_block = pZip->m_pRealloc(pZip->m_pAlloc_opaque, pState->m_pMem, 1, new_capacity)))
         {
             mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
             return 0;
@@ -5165,7 +5165,7 @@ static mz_bool mz_zip_writer_end_internal(mz_zip_archive *pZip, mz_bool set_last
     }
 
     pState = pZip->m_pState;
-    pZip->m_pState = NULL;
+    pZip->m_pState = nullptr;
     mz_zip_array_clear(pZip, &pState->m_central_dir);
     mz_zip_array_clear(pZip, &pState->m_central_dir_offsets);
     mz_zip_array_clear(pZip, &pState->m_sorted_central_dir_offsets);
@@ -5183,14 +5183,14 @@ static mz_bool mz_zip_writer_end_internal(mz_zip_archive *pZip, mz_bool set_last
             }
         }
 
-        pState->m_pFile = NULL;
+        pState->m_pFile = nullptr;
     }
 #endif /* #ifndef MINIZ_NO_STDIO */
 
     if((pZip->m_pWrite == mz_zip_heap_write_func) && (pState->m_pMem))
     {
         pZip->m_pFree(pZip->m_pAlloc_opaque, pState->m_pMem);
-        pState->m_pMem = NULL;
+        pState->m_pMem = nullptr;
     }
 
     pZip->m_pFree(pZip->m_pAlloc_opaque, pState);
@@ -5229,7 +5229,7 @@ mz_bool mz_zip_writer_init_v2(mz_zip_archive *pZip, mz_uint64 existing_size, mz_
     pZip->m_central_directory_file_ofs = 0;
     pZip->m_total_files = 0;
 
-    if(NULL == (pZip->m_pState = (mz_zip_internal_state *)pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, sizeof(mz_zip_internal_state))))
+    if(nullptr == (pZip->m_pState = (mz_zip_internal_state *)pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, sizeof(mz_zip_internal_state))))
         return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
 
     memset(pZip->m_pState, 0, sizeof(mz_zip_internal_state));
@@ -5268,7 +5268,7 @@ mz_bool mz_zip_writer_init_heap_v2(mz_zip_archive *pZip, size_t size_to_reserve_
 
     if(0 != (initial_allocation_size = MZ_MAX(initial_allocation_size, size_to_reserve_at_beginning)))
     {
-        if(NULL == (pZip->m_pState->m_pMem = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, initial_allocation_size)))
+        if(nullptr == (pZip->m_pState->m_pMem = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, initial_allocation_size)))
         {
             mz_zip_writer_end_internal(pZip, MZ_FALSE);
             return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
@@ -5320,7 +5320,7 @@ mz_bool mz_zip_writer_init_file_v2(mz_zip_archive *pZip, const char *pFilename, 
     if(!mz_zip_writer_init_v2(pZip, size_to_reserve_at_beginning, flags))
         return MZ_FALSE;
 
-    if(NULL == (pFile = MZ_FOPEN(pFilename, (flags & MZ_ZIP_FLAG_WRITE_ALLOW_READING) ? "w+b" : "wb")))
+    if(nullptr == (pFile = MZ_FOPEN(pFilename, (flags & MZ_ZIP_FLAG_WRITE_ALLOW_READING) ? "w+b" : "wb")))
     {
         mz_zip_writer_end(pZip);
         return mz_zip_set_error(pZip, MZ_ZIP_FILE_OPEN_FAILED);
@@ -5418,7 +5418,7 @@ mz_bool mz_zip_writer_init_from_reader_v2(mz_zip_archive *pZip, const char *pFil
                 return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
 
             /* Archive is being read from stdio and was originally opened only for reading. Try to reopen as writable. */
-            if(NULL == (pState->m_pFile = MZ_FREOPEN(pFilename, "r+b", pState->m_pFile)))
+            if(nullptr == (pState->m_pFile = MZ_FREOPEN(pFilename, "r+b", pState->m_pFile)))
             {
                 /* The mz_zip_archive is now in a bogus state because pState->m_pFile is NULL, so just close it. */
                 mz_zip_reader_end_internal(pZip, MZ_FALSE);
@@ -5465,7 +5465,7 @@ mz_bool mz_zip_writer_init_from_reader(mz_zip_archive *pZip, const char *pFilena
 /* TODO: pArchive_name is a terrible name here! */
 mz_bool mz_zip_writer_add_mem(mz_zip_archive *pZip, const char *pArchive_name, const void *pBuf, size_t buf_size, mz_uint level_and_flags)
 {
-    return mz_zip_writer_add_mem_ex(pZip, pArchive_name, pBuf, buf_size, NULL, 0, level_and_flags, 0, 0);
+    return mz_zip_writer_add_mem_ex(pZip, pArchive_name, pBuf, buf_size, nullptr, 0, level_and_flags, 0, 0);
 }
 
 typedef struct
@@ -5652,7 +5652,7 @@ static mz_bool mz_zip_writer_write_zeros(mz_zip_archive *pZip, mz_uint64 cur_fil
 mz_bool mz_zip_writer_add_mem_ex(mz_zip_archive *pZip, const char *pArchive_name, const void *pBuf, size_t buf_size, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags,
                                  mz_uint64 uncomp_size, mz_uint32 uncomp_crc32)
 {
-    return mz_zip_writer_add_mem_ex_v2(pZip, pArchive_name, pBuf, buf_size, pComment, comment_size, level_and_flags, uncomp_size, uncomp_crc32, NULL, NULL, 0, NULL, 0);
+    return mz_zip_writer_add_mem_ex_v2(pZip, pArchive_name, pBuf, buf_size, pComment, comment_size, level_and_flags, uncomp_size, uncomp_crc32, nullptr, nullptr, 0, nullptr, 0);
 }
 
 mz_bool mz_zip_writer_add_mem_ex_v2(mz_zip_archive *pZip, const char *pArchive_name, const void *pBuf, size_t buf_size, const void *pComment, mz_uint16 comment_size,
@@ -5664,10 +5664,10 @@ mz_bool mz_zip_writer_add_mem_ex_v2(mz_zip_archive *pZip, const char *pArchive_n
     mz_uint64 local_dir_header_ofs = pZip->m_archive_size, cur_archive_file_ofs = pZip->m_archive_size, comp_size = 0;
     size_t archive_name_size;
     mz_uint8 local_dir_header[MZ_ZIP_LOCAL_DIR_HEADER_SIZE];
-    tdefl_compressor *pComp = NULL;
+    tdefl_compressor *pComp = nullptr;
     mz_bool store_data_uncompressed;
     mz_zip_internal_state *pState;
-    mz_uint8 *pExtra_data = NULL;
+    mz_uint8 *pExtra_data = nullptr;
     mz_uint32 extra_size = 0;
     mz_uint8 extra_data[MZ_ZIP64_MAX_CENTRAL_EXTRA_FIELD_SIZE];
     mz_uint16 bit_flags = 0;
@@ -5713,7 +5713,7 @@ mz_bool mz_zip_writer_add_mem_ex_v2(mz_zip_archive *pZip, const char *pArchive_n
     if(!mz_zip_writer_validate_archive_name(pArchive_name))
         return mz_zip_set_error(pZip, MZ_ZIP_INVALID_FILENAME);
 
-    if(last_modified != NULL)
+    if(last_modified != nullptr)
     {
         mz_zip_time_t_to_dos_time(*last_modified, &dos_time, &dos_date);
     }
@@ -5764,7 +5764,7 @@ mz_bool mz_zip_writer_add_mem_ex_v2(mz_zip_archive *pZip, const char *pArchive_n
 
     if((!store_data_uncompressed) && (buf_size))
     {
-        if(NULL == (pComp = (tdefl_compressor *)pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, sizeof(tdefl_compressor))))
+        if(nullptr == (pComp = (tdefl_compressor *)pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, sizeof(tdefl_compressor))))
             return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
     }
 
@@ -5793,8 +5793,8 @@ mz_bool mz_zip_writer_add_mem_ex_v2(mz_zip_archive *pZip, const char *pArchive_n
         if(uncomp_size >= MZ_UINT32_MAX || local_dir_header_ofs >= MZ_UINT32_MAX)
         {
             pExtra_data = extra_data;
-            extra_size = mz_zip_writer_create_zip64_extra_data(extra_data, (uncomp_size >= MZ_UINT32_MAX) ? &uncomp_size : NULL,
-                                                               (uncomp_size >= MZ_UINT32_MAX) ? &comp_size : NULL, (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : NULL);
+            extra_size = mz_zip_writer_create_zip64_extra_data(extra_data, (uncomp_size >= MZ_UINT32_MAX) ? &uncomp_size : nullptr,
+                                                               (uncomp_size >= MZ_UINT32_MAX) ? &comp_size : nullptr, (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : nullptr);
         }
 
         if(!mz_zip_writer_create_local_dir_header(pZip, local_dir_header, (mz_uint16)archive_name_size, extra_size + user_extra_data_len, 0, 0, 0, method, bit_flags, dos_time, dos_date))
@@ -5812,7 +5812,7 @@ mz_bool mz_zip_writer_add_mem_ex_v2(mz_zip_archive *pZip, const char *pArchive_n
         }
         cur_archive_file_ofs += archive_name_size;
 
-        if(pExtra_data != NULL)
+        if(pExtra_data != nullptr)
         {
             if(pZip->m_pWrite(pZip->m_pIO_opaque, cur_archive_file_ofs, extra_data, extra_size) != extra_size)
                 return mz_zip_set_error(pZip, MZ_ZIP_FILE_WRITE_FAILED);
@@ -5890,7 +5890,7 @@ mz_bool mz_zip_writer_add_mem_ex_v2(mz_zip_archive *pZip, const char *pArchive_n
     }
 
     pZip->m_pFree(pZip->m_pAlloc_opaque, pComp);
-    pComp = NULL;
+    pComp = nullptr;
 
     if(uncomp_size)
     {
@@ -5901,7 +5901,7 @@ mz_bool mz_zip_writer_add_mem_ex_v2(mz_zip_archive *pZip, const char *pArchive_n
 
         MZ_WRITE_LE32(local_dir_footer + 0, MZ_ZIP_DATA_DESCRIPTOR_ID);
         MZ_WRITE_LE32(local_dir_footer + 4, uncomp_crc32);
-        if(pExtra_data == NULL)
+        if(pExtra_data == nullptr)
         {
             if((comp_size > MZ_UINT32_MAX) || (cur_archive_file_ofs > MZ_UINT32_MAX))
                 return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
@@ -5922,10 +5922,10 @@ mz_bool mz_zip_writer_add_mem_ex_v2(mz_zip_archive *pZip, const char *pArchive_n
         cur_archive_file_ofs += local_dir_footer_size;
     }
 
-    if(pExtra_data != NULL)
+    if(pExtra_data != nullptr)
     {
-        extra_size = mz_zip_writer_create_zip64_extra_data(extra_data, (uncomp_size >= MZ_UINT32_MAX) ? &uncomp_size : NULL,
-                                                           (uncomp_size >= MZ_UINT32_MAX) ? &comp_size : NULL, (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : NULL);
+        extra_size = mz_zip_writer_create_zip64_extra_data(extra_data, (uncomp_size >= MZ_UINT32_MAX) ? &uncomp_size : nullptr,
+                                                           (uncomp_size >= MZ_UINT32_MAX) ? &comp_size : nullptr, (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : nullptr);
     }
 
     if(!mz_zip_writer_add_to_central_dir(pZip, pArchive_name, (mz_uint16)archive_name_size, pExtra_data, extra_size, pComment,
@@ -5949,7 +5949,7 @@ mz_bool mz_zip_writer_add_cfile(mz_zip_archive *pZip, const char *pArchive_name,
     mz_uint64 local_dir_header_ofs, cur_archive_file_ofs = pZip->m_archive_size, uncomp_size = size_to_add, comp_size = 0;
     size_t archive_name_size;
     mz_uint8 local_dir_header[MZ_ZIP_LOCAL_DIR_HEADER_SIZE];
-    mz_uint8 *pExtra_data = NULL;
+    mz_uint8 *pExtra_data = nullptr;
     mz_uint32 extra_size = 0;
     mz_uint8 extra_data[MZ_ZIP64_MAX_CENTRAL_EXTRA_FIELD_SIZE];
     mz_zip_internal_state *pState;
@@ -6049,8 +6049,8 @@ mz_bool mz_zip_writer_add_cfile(mz_zip_archive *pZip, const char *pArchive_name,
         if(uncomp_size >= MZ_UINT32_MAX || local_dir_header_ofs >= MZ_UINT32_MAX)
         {
             pExtra_data = extra_data;
-            extra_size = mz_zip_writer_create_zip64_extra_data(extra_data, (uncomp_size >= MZ_UINT32_MAX) ? &uncomp_size : NULL,
-                                                               (uncomp_size >= MZ_UINT32_MAX) ? &comp_size : NULL, (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : NULL);
+            extra_size = mz_zip_writer_create_zip64_extra_data(extra_data, (uncomp_size >= MZ_UINT32_MAX) ? &uncomp_size : nullptr,
+                                                               (uncomp_size >= MZ_UINT32_MAX) ? &comp_size : nullptr, (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : nullptr);
         }
 
         if(!mz_zip_writer_create_local_dir_header(pZip, local_dir_header, (mz_uint16)archive_name_size, extra_size + user_extra_data_len, 0, 0, 0, method, gen_flags, dos_time, dos_date))
@@ -6195,7 +6195,7 @@ mz_bool mz_zip_writer_add_cfile(mz_zip_archive *pZip, const char *pArchive_name,
 
     MZ_WRITE_LE32(local_dir_footer + 0, MZ_ZIP_DATA_DESCRIPTOR_ID);
     MZ_WRITE_LE32(local_dir_footer + 4, uncomp_crc32);
-    if(pExtra_data == NULL)
+    if(pExtra_data == nullptr)
     {
         if(comp_size > MZ_UINT32_MAX)
             return mz_zip_set_error(pZip, MZ_ZIP_ARCHIVE_TOO_LARGE);
@@ -6215,10 +6215,10 @@ mz_bool mz_zip_writer_add_cfile(mz_zip_archive *pZip, const char *pArchive_name,
 
     cur_archive_file_ofs += local_dir_footer_size;
 
-    if(pExtra_data != NULL)
+    if(pExtra_data != nullptr)
     {
-        extra_size = mz_zip_writer_create_zip64_extra_data(extra_data, (uncomp_size >= MZ_UINT32_MAX) ? &uncomp_size : NULL,
-                                                           (uncomp_size >= MZ_UINT32_MAX) ? &comp_size : NULL, (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : NULL);
+        extra_size = mz_zip_writer_create_zip64_extra_data(extra_data, (uncomp_size >= MZ_UINT32_MAX) ? &uncomp_size : nullptr,
+                                                           (uncomp_size >= MZ_UINT32_MAX) ? &comp_size : nullptr, (local_dir_header_ofs >= MZ_UINT32_MAX) ? &local_dir_header_ofs : nullptr);
     }
 
     if(!mz_zip_writer_add_to_central_dir(pZip, pArchive_name, (mz_uint16)archive_name_size, pExtra_data, extra_size, pComment, comment_size,
@@ -6234,10 +6234,10 @@ mz_bool mz_zip_writer_add_cfile(mz_zip_archive *pZip, const char *pArchive_name,
 
 mz_bool mz_zip_writer_add_file(mz_zip_archive *pZip, const char *pArchive_name, const char *pSrc_filename, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags)
 {
-    MZ_FILE *pSrc_file = NULL;
+    MZ_FILE *pSrc_file = nullptr;
     mz_uint64 uncomp_size = 0;
     MZ_TIME_T file_modified_time;
-    MZ_TIME_T *pFile_time = NULL;
+    MZ_TIME_T *pFile_time = nullptr;
 
     memset(&file_modified_time, 0, sizeof(file_modified_time));
 
@@ -6255,7 +6255,7 @@ mz_bool mz_zip_writer_add_file(mz_zip_archive *pZip, const char *pArchive_name, 
     uncomp_size = MZ_FTELL64(pSrc_file);
     MZ_FSEEK64(pSrc_file, 0, SEEK_SET);
 
-    mz_bool status = mz_zip_writer_add_cfile(pZip, pArchive_name, pSrc_file, uncomp_size, pFile_time, pComment, comment_size, level_and_flags, NULL, 0, NULL, 0);
+    mz_bool status = mz_zip_writer_add_cfile(pZip, pArchive_name, pSrc_file, uncomp_size, pFile_time, pComment, comment_size, level_and_flags, nullptr, 0, nullptr, 0);
 
     MZ_FCLOSE(pSrc_file);
 
@@ -6372,7 +6372,7 @@ mz_bool mz_zip_writer_add_from_zip_reader(mz_zip_archive *pZip, mz_zip_archive *
         return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
 
     /* Get pointer to the source central dir header and crack it */
-    if(NULL == (pSrc_central_header = mz_zip_get_cdh(pSource_zip, src_file_index)))
+    if(nullptr == (pSrc_central_header = mz_zip_get_cdh(pSource_zip, src_file_index)))
         return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
 
     if(MZ_READ_LE32(pSrc_central_header + MZ_ZIP_CDH_SIG_OFS) != MZ_ZIP_CENTRAL_DIR_HEADER_SIG)
@@ -6401,7 +6401,7 @@ mz_bool mz_zip_writer_add_from_zip_reader(mz_zip_archive *pZip, mz_zip_archive *
             return mz_zip_set_error(pZip, MZ_ZIP_TOO_MANY_FILES);
     }
 
-    if(!mz_zip_file_stat_internal(pSource_zip, src_file_index, pSrc_central_header, &src_file_stat, NULL))
+    if(!mz_zip_file_stat_internal(pSource_zip, src_file_index, pSrc_central_header, &src_file_stat, nullptr))
         return MZ_FALSE;
 
     cur_src_file_ofs = src_file_stat.m_local_header_ofs;
@@ -6516,7 +6516,7 @@ mz_bool mz_zip_writer_add_from_zip_reader(mz_zip_archive *pZip, mz_zip_archive *
     cur_dst_file_ofs += MZ_ZIP_LOCAL_DIR_HEADER_SIZE;
 
     /* Copy over the source archive bytes to the dest archive, also ensure we have enough buf space to handle optional data descriptor */
-    if(NULL == (pBuf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, (size_t)MZ_MAX(32U, MZ_MIN((mz_uint64)MZ_ZIP_MAX_IO_BUF_SIZE, src_archive_bytes_remaining)))))
+    if(nullptr == (pBuf = pZip->m_pAlloc(pZip->m_pAlloc_opaque, 1, (size_t)MZ_MAX(32U, MZ_MIN((mz_uint64)MZ_ZIP_MAX_IO_BUF_SIZE, src_archive_bytes_remaining)))))
         return mz_zip_set_error(pZip, MZ_ZIP_ALLOC_FAILED);
 
     while(src_archive_bytes_remaining)
@@ -6624,7 +6624,7 @@ mz_bool mz_zip_writer_add_from_zip_reader(mz_zip_archive *pZip, mz_zip_archive *
         MZ_WRITE_LE32(new_central_header + MZ_ZIP_CDH_DECOMPRESSED_SIZE_OFS, MZ_UINT32_MAX);
         MZ_WRITE_LE32(new_central_header + MZ_ZIP_CDH_LOCAL_HEADER_OFS, MZ_UINT32_MAX);
 
-        if(!mz_zip_writer_update_zip64_extension_block(&new_ext_block, pZip, pSrc_ext, src_ext_len, &src_file_stat.m_comp_size, &src_file_stat.m_uncomp_size, &local_dir_header_ofs, NULL))
+        if(!mz_zip_writer_update_zip64_extension_block(&new_ext_block, pZip, pSrc_ext, src_ext_len, &src_file_stat.m_comp_size, &src_file_stat.m_uncomp_size, &local_dir_header_ofs, nullptr))
         {
             mz_zip_array_clear(pZip, &new_ext_block);
             return MZ_FALSE;
@@ -6796,7 +6796,7 @@ mz_bool mz_zip_writer_finalize_heap_archive(mz_zip_archive *pZip, void **ppBuf, 
     if((!ppBuf) || (!pSize))
         return mz_zip_set_error(pZip, MZ_ZIP_INVALID_PARAMETER);
 
-    *ppBuf = NULL;
+    *ppBuf = nullptr;
     *pSize = 0;
 
     if((!pZip) || (!pZip->m_pState))
@@ -6810,7 +6810,7 @@ mz_bool mz_zip_writer_finalize_heap_archive(mz_zip_archive *pZip, void **ppBuf, 
 
     *ppBuf = pZip->m_pState->m_pMem;
     *pSize = pZip->m_pState->m_mem_size;
-    pZip->m_pState->m_pMem = NULL;
+    pZip->m_pState->m_pMem = nullptr;
     pZip->m_pState->m_mem_size = pZip->m_pState->m_mem_capacity = 0;
 
     return MZ_TRUE;
@@ -6824,7 +6824,7 @@ mz_bool mz_zip_writer_end(mz_zip_archive *pZip)
 #ifndef MINIZ_NO_STDIO
 mz_bool mz_zip_add_mem_to_archive_file_in_place(const char *pZip_filename, const char *pArchive_name, const void *pBuf, size_t buf_size, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags)
 {
-    return mz_zip_add_mem_to_archive_file_in_place_v2(pZip_filename, pArchive_name, pBuf, buf_size, pComment, comment_size, level_and_flags, NULL);
+    return mz_zip_add_mem_to_archive_file_in_place_v2(pZip_filename, pArchive_name, pBuf, buf_size, pComment, comment_size, level_and_flags, nullptr);
 }
 
 mz_bool mz_zip_add_mem_to_archive_file_in_place_v2(const char *pZip_filename, const char *pArchive_name, const void *pBuf, size_t buf_size, const void *pComment, mz_uint16 comment_size, mz_uint level_and_flags, mz_zip_error *pErr)
@@ -6924,7 +6924,7 @@ void *mz_zip_extract_archive_file_to_heap_v2(const char *pZip_filename, const ch
 {
     mz_uint32 file_index;
     mz_zip_archive zip_archive;
-    void *p = NULL;
+    void *p = nullptr;
 
     if(pSize)
         *pSize = 0;
@@ -6934,7 +6934,7 @@ void *mz_zip_extract_archive_file_to_heap_v2(const char *pZip_filename, const ch
         if(pErr)
             *pErr = MZ_ZIP_INVALID_PARAMETER;
 
-        return NULL;
+        return nullptr;
     }
 
     mz_zip_zero_struct(&zip_archive);
@@ -6943,7 +6943,7 @@ void *mz_zip_extract_archive_file_to_heap_v2(const char *pZip_filename, const ch
         if(pErr)
             *pErr = zip_archive.m_last_error;
 
-        return NULL;
+        return nullptr;
     }
 
     if(mz_zip_reader_locate_file_v2(&zip_archive, pArchive_name, pComment, flags, &file_index))
@@ -6951,7 +6951,7 @@ void *mz_zip_extract_archive_file_to_heap_v2(const char *pZip_filename, const ch
         p = mz_zip_reader_extract_to_heap(&zip_archive, file_index, pSize, flags);
     }
 
-    mz_zip_reader_end_internal(&zip_archive, p != NULL);
+    mz_zip_reader_end_internal(&zip_archive, p != nullptr);
 
     if(pErr)
         *pErr = zip_archive.m_last_error;
@@ -6961,7 +6961,7 @@ void *mz_zip_extract_archive_file_to_heap_v2(const char *pZip_filename, const ch
 
 void *mz_zip_extract_archive_file_to_heap(const char *pZip_filename, const char *pArchive_name, size_t *pSize, mz_uint flags)
 {
-    return mz_zip_extract_archive_file_to_heap_v2(pZip_filename, pArchive_name, NULL, pSize, flags, NULL);
+    return mz_zip_extract_archive_file_to_heap_v2(pZip_filename, pArchive_name, nullptr, pSize, flags, nullptr);
 }
 
 #endif /* #ifndef MINIZ_NO_STDIO */
@@ -7133,7 +7133,7 @@ mz_uint64 mz_zip_get_archive_file_start_offset(mz_zip_archive *pZip)
 MZ_FILE *mz_zip_get_cfile(mz_zip_archive *pZip)
 {
     if((!pZip) || (!pZip->m_pState))
-        return 0;
+        return nullptr;
     return pZip->m_pState->m_pFile;
 }
 
@@ -7168,7 +7168,7 @@ mz_uint mz_zip_reader_get_filename(mz_zip_archive *pZip, mz_uint file_index, cha
 
 mz_bool mz_zip_reader_file_stat(mz_zip_archive *pZip, mz_uint file_index, mz_zip_archive_file_stat *pStat)
 {
-    return mz_zip_file_stat_internal(pZip, file_index, mz_zip_get_cdh(pZip, file_index), pStat, NULL);
+    return mz_zip_file_stat_internal(pZip, file_index, mz_zip_get_cdh(pZip, file_index), pStat, nullptr);
 }
 
 mz_bool mz_zip_end(mz_zip_archive *pZip)

--- a/src/path-symex/path_symex_history.h
+++ b/src/path-symex/path_symex_history.h
@@ -21,6 +21,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 class path_symex_stept;
 
+#define nullptr_exceptiont(str) str
+
 // This is a reference to a path_symex_stept,
 // and is really cheap to copy. These references are stable,
 // even though the underlying vector is not.
@@ -46,7 +48,7 @@ public:
 
   path_symex_historyt &get_history() const
   {
-    assert(history!=nullptr);
+    INVARIANT(history!=nullptr, nullptr_exceptiont("history is null"));
     return *history;
   }
 
@@ -154,7 +156,7 @@ public:
 
 inline void path_symex_step_reft::generate_successor()
 {
-  assert(history!=nullptr);
+  INVARIANT(history!=nullptr, nullptr_exceptiont("history is null"));
   path_symex_step_reft old=*this;
   index=history->step_container.size();
   history->step_container.push_back(path_symex_stept());
@@ -169,7 +171,7 @@ inline path_symex_step_reft &path_symex_step_reft::operator--()
 
 inline path_symex_stept &path_symex_step_reft::get() const
 {
-  assert(history!=nullptr);
+  INVARIANT(history!=nullptr, nullptr_exceptiont("history is null"));
   assert(!is_nil());
   return history->step_container[index];
 }

--- a/src/path-symex/path_symex_history.h
+++ b/src/path-symex/path_symex_history.h
@@ -35,7 +35,7 @@ public:
   }
 
   path_symex_step_reft():
-    index(std::numeric_limits<std::size_t>::max()), history(0)
+    index(std::numeric_limits<std::size_t>::max()), history(nullptr)
   {
   }
 
@@ -46,7 +46,7 @@ public:
 
   path_symex_historyt &get_history() const
   {
-    assert(history!=0);
+    assert(history!=nullptr);
     return *history;
   }
 
@@ -154,7 +154,7 @@ public:
 
 inline void path_symex_step_reft::generate_successor()
 {
-  assert(history!=0);
+  assert(history!=nullptr);
   path_symex_step_reft old=*this;
   index=history->step_container.size();
   history->step_container.push_back(path_symex_stept());
@@ -169,7 +169,7 @@ inline path_symex_step_reft &path_symex_step_reft::operator--()
 
 inline path_symex_stept &path_symex_step_reft::get() const
 {
-  assert(history!=0);
+  assert(history!=nullptr);
   assert(!is_nil());
   return history->step_container[index];
 }

--- a/src/path-symex/path_symex_state.h
+++ b/src/path-symex/path_symex_state.h
@@ -16,6 +16,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "var_map.h"
 #include "path_symex_history.h"
 
+#define nullptr_exceptiont(str) str
+
 struct path_symex_statet
 {
 public:

--- a/src/path-symex/path_symex_state_read.cpp
+++ b/src/path-symex/path_symex_state_read.cpp
@@ -430,7 +430,7 @@ bool path_symex_statet::is_symbol_member_index(const exprt &src) const
   // the loop avoids recursion
   while(true)
   {
-    const exprt *next=0;
+    const exprt *next=nullptr;
 
     if(current->id()==ID_symbol)
     {
@@ -465,7 +465,7 @@ bool path_symex_statet::is_symbol_member_index(const exprt &src) const
       return false;
 
     // next round
-    assert(next!=0);
+    assert(next!=nullptr);
     current=next;
   }
 }

--- a/src/path-symex/path_symex_state_read.cpp
+++ b/src/path-symex/path_symex_state_read.cpp
@@ -465,7 +465,7 @@ bool path_symex_statet::is_symbol_member_index(const exprt &src) const
       return false;
 
     // next round
-    assert(next!=nullptr);
+    INVARIANT(next!=nullptr, nullptr_exceptiont("next is null"));
     current=next;
   }
 }

--- a/src/path-symex/var_map.cpp
+++ b/src/path-symex/var_map.cpp
@@ -84,7 +84,7 @@ void var_mapt::init(var_infot &var_info)
     }
     else
     {
-      const symbolt *symbol=0;
+      const symbolt *symbol=nullptr;
       if(ns.lookup(var_info.symbol, symbol))
         throw "var_mapt::init identifier \""
           +id2string(var_info.full_identifier)

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -550,18 +550,18 @@ void value_set_fit::get_value_set_rec(
     if(expr.type().id()==ID_pointer)
     {
       // find the pointer operand
-      const exprt *ptr_operand=NULL;
+      const exprt *ptr_operand=nullptr;
 
       forall_operands(it, expr)
         if(it->type().id()==ID_pointer)
         {
-          if(ptr_operand==NULL)
+          if(ptr_operand==nullptr)
             ptr_operand=&(*it);
           else
             throw "more than one pointer operand in pointer arithmetic";
         }
 
-      if(ptr_operand==NULL)
+      if(ptr_operand==nullptr)
         throw "pointer type sum expected to have pointer operand";
 
       object_mapt pointer_expr_set;

--- a/src/pointer-analysis/value_set_fivr.cpp
+++ b/src/pointer-analysis/value_set_fivr.cpp
@@ -668,18 +668,18 @@ void value_set_fivrt::get_value_set_rec(
     if(expr.type().id()==ID_pointer)
     {
       // find the pointer operand
-      const exprt *ptr_operand=NULL;
+      const exprt *ptr_operand=nullptr;
 
       forall_operands(it, expr)
         if(it->type().id()==ID_pointer)
         {
-          if(ptr_operand==NULL)
+          if(ptr_operand==nullptr)
             ptr_operand=&(*it);
           else
             throw "more than one pointer operand in pointer arithmetic";
         }
 
-      if(ptr_operand==NULL)
+      if(ptr_operand==nullptr)
         throw "pointer type sum expected to have pointer operand";
 
       object_mapt pointer_expr_set;

--- a/src/pointer-analysis/value_set_fivrns.cpp
+++ b/src/pointer-analysis/value_set_fivrns.cpp
@@ -454,18 +454,18 @@ void value_set_fivrnst::get_value_set_rec(
     if(expr.type().id()==ID_pointer)
     {
       // find the pointer operand
-      const exprt *ptr_operand=NULL;
+      const exprt *ptr_operand=nullptr;
 
       forall_operands(it, expr)
         if(it->type().id()==ID_pointer)
         {
-          if(ptr_operand==NULL)
+          if(ptr_operand==nullptr)
             ptr_operand=&(*it);
           else
             throw "more than one pointer operand in pointer arithmetic";
         }
 
-      if(ptr_operand==NULL)
+      if(ptr_operand==nullptr)
         throw "pointer type sum expected to have pointer operand";
 
       object_mapt pointer_expr_set;

--- a/src/solvers/miniBDD/miniBDD.h
+++ b/src/solvers/miniBDD/miniBDD.h
@@ -55,7 +55,7 @@ public:
   unsigned node_number() const;
   void clear();
 
-  bool is_initialized() const { return node!=0; }
+  bool is_initialized() const { return node!=nullptr; }
 
   // internal
   explicit mini_bddt(class mini_bdd_nodet *_node);

--- a/src/solvers/miniBDD/miniBDD.inc
+++ b/src/solvers/miniBDD/miniBDD.inc
@@ -2,7 +2,7 @@
 
 // inline functions
 
-inline mini_bddt::mini_bddt():node(0)
+inline mini_bddt::mini_bddt():node(nullptr)
 {
 }
 
@@ -82,7 +82,7 @@ inline void mini_bddt::clear()
   if(is_initialized())
   {
     node->remove_reference();
-    node=NULL;
+    node=nullptr;
   }
 }
 

--- a/src/solvers/sat/pbs_dimacs_cnf.cpp
+++ b/src/solvers/sat/pbs_dimacs_cnf.cpp
@@ -125,7 +125,7 @@ bool pbs_dimacs_cnft::pbs_solve()
     {
       std::getline(file, line);
       if(strstr(line.c_str(),
-                "Variable Assignments Satisfying CNF Formula:")!=NULL)
+                "Variable Assignments Satisfying CNF Formula:")!=nullptr)
         {
           // print ("Reading assignments...\n");
           // std::cout << "No literals: " << no_variables() << "\n";
@@ -143,12 +143,12 @@ bool pbs_dimacs_cnft::pbs_solve()
           // std::cout << "\n";
           // print ("Finished reading assignments.\n");
         }
-      else if(strstr(line.c_str(), "SAT... SUM")!=NULL)
+      else if(strstr(line.c_str(), "SAT... SUM")!=nullptr)
         {
           // print (line);
           sscanf(line.c_str(), "%*s %*s %*s %d", &opt_sum);
         }
-      else if(strstr(line.c_str(), "SAT - All implied")!=NULL)
+      else if(strstr(line.c_str(), "SAT - All implied")!=nullptr)
         {
           // print (line);
           sscanf(
@@ -156,15 +156,15 @@ bool pbs_dimacs_cnft::pbs_solve()
             "%*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %d",
             &opt_sum);
         }
-      else if(strstr(line.c_str(), "SAT... Solution")!=NULL)
+      else if(strstr(line.c_str(), "SAT... Solution")!=nullptr)
         {
           // print(line);
           sscanf(line.c_str(), "%*s %*s %*s %d", &opt_sum);
         }
-      else if(strstr(line.c_str(), "Optimal Soln")!=NULL)
+      else if(strstr(line.c_str(), "Optimal Soln")!=nullptr)
         {
           // print(line);
-          if(strstr(line.c_str(), "time out")!=NULL)
+          if(strstr(line.c_str(), "time out")!=nullptr)
             {
               status() << "WARNING:  TIMED OUT.  SOLUTION MAY BE INCORRECT."
                        << eom;

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -739,7 +739,7 @@ bool configt::set(const cmdlinet &cmdline)
   ansi_c.arch="none";
   ansi_c.lib=configt::ansi_ct::libt::LIB_NONE;
   // NOLINTNEXTLINE(readability/casting)
-  ansi_c.NULL_is_zero=reinterpret_cast<size_t>((void*)0)==0;
+  ansi_c.NULL_is_zero=reinterpret_cast<size_t>(nullptr)==0;
 
   // Default is ROUND_TO_EVEN, justified by C99:
   // 1 At program startup the floating-point environment is initialized as
@@ -773,7 +773,7 @@ bool configt::set(const cmdlinet &cmdline)
   {
     // environment variable set?
     const char *CLASSPATH=getenv("CLASSPATH");
-    if(CLASSPATH!=NULL)
+    if(CLASSPATH!=nullptr)
       set_classpath(CLASSPATH);
     else
       set_classpath("."); // default

--- a/src/util/file_util.cpp
+++ b/src/util/file_util.cpp
@@ -51,7 +51,7 @@ std::string get_current_working_directory()
 
   errno=0;
 
-  while(buf && getcwd(buf, bsize-1)==NULL && errno==ERANGE)
+  while(buf && getcwd(buf, bsize-1)==nullptr && errno==ERANGE)
   {
     bsize*=2;
     buf=reinterpret_cast<char*>(realloc(buf, sizeof(char)*bsize));
@@ -98,10 +98,10 @@ void delete_directory(const std::string &path)
   delete_directory_utf16(utf8_to_utf16_little_endian(path));
 #else
   DIR *dir=opendir(path.c_str());
-  if(dir!=NULL)
+  if(dir!=nullptr)
   {
     struct dirent *ent;
-    while((ent=readdir(dir))!=NULL)
+    while((ent=readdir(dir))!=nullptr)
     {
       // Needed for Alpine Linux
       if(strcmp(ent->d_name, ".")==0 || strcmp(ent->d_name, "..")==0)

--- a/src/util/invariant.cpp
+++ b/src/util/invariant.cpp
@@ -57,7 +57,7 @@ static bool output_demangled_name(
 
     int demangle_success=1;
     char *demangled=
-      abi::__cxa_demangle(mangled.c_str(), NULL, 0, &demangle_success);
+      abi::__cxa_demangle(mangled.c_str(), nullptr, nullptr, &demangle_success);
 
     if(demangle_success==0)
     {

--- a/src/util/irep_ids.cpp
+++ b/src/util/irep_ids.cpp
@@ -22,7 +22,7 @@ const char *irep_ids_table[]=
 
 #include "irep_ids.def"
 
-  NULL,
+  nullptr,
 };
 
 #ifdef USE_DSTRING
@@ -47,7 +47,7 @@ void initialize_string_container()
 {
   // this is called by the constructor of string_containert
 
-  for(unsigned i=0; irep_ids_table[i]!=NULL; i++)
+  for(unsigned i=0; irep_ids_table[i]!=nullptr; i++)
   {
     unsigned x;
     x=string_container[irep_ids_table[i]];

--- a/src/util/language_file.cpp
+++ b/src/util/language_file.cpp
@@ -14,14 +14,14 @@ Author: Daniel Kroening, kroening@kroening.com
 
 language_filet::language_filet(const language_filet &rhs):
   modules(rhs.modules),
-  language(rhs.language==NULL?NULL:rhs.language->new_language()),
+  language(rhs.language==nullptr?nullptr:rhs.language->new_language()),
   filename(rhs.filename)
 {
 }
 
 language_filet::~language_filet()
 {
-  if(language!=NULL)
+  if(language!=nullptr)
     delete language;
 }
 

--- a/src/util/language_file.h
+++ b/src/util/language_file.h
@@ -49,7 +49,7 @@ public:
 
   language_filet(const language_filet &rhs);
 
-  language_filet():language(NULL)
+  language_filet():language(nullptr)
   {
   }
 

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -133,7 +133,7 @@ public:
   // constructors, destructor
 
   messaget():
-    message_handler(NULL),
+    message_handler(nullptr),
     mstream(M_DEBUG, *this)
   {
   }

--- a/src/util/namespace.cpp
+++ b/src/util/namespace.cpp
@@ -127,10 +127,10 @@ unsigned namespacet::get_max(const std::string &prefix) const
 {
   unsigned m=0;
 
-  if(symbol_table1!=NULL)
+  if(symbol_table1!=nullptr)
     m=std::max(m, ::get_max(prefix, symbol_table1->symbols));
 
-  if(symbol_table2!=NULL)
+  if(symbol_table2!=nullptr)
     m=std::max(m, ::get_max(prefix, symbol_table2->symbols));
 
   return m;
@@ -142,7 +142,7 @@ bool namespacet::lookup(
 {
   symbol_tablet::symbolst::const_iterator it;
 
-  if(symbol_table1!=NULL)
+  if(symbol_table1!=nullptr)
   {
     it=symbol_table1->symbols.find(name);
 
@@ -153,7 +153,7 @@ bool namespacet::lookup(
     }
   }
 
-  if(symbol_table2!=NULL)
+  if(symbol_table2!=nullptr)
   {
     it=symbol_table2->symbols.find(name);
 

--- a/src/util/namespace.h
+++ b/src/util/namespace.h
@@ -64,7 +64,7 @@ class namespacet:public namespace_baset
 public:
   // constructors
   explicit namespacet(const symbol_tablet &_symbol_table)
-  { symbol_table1=&_symbol_table; symbol_table2=NULL; }
+  { symbol_table1=&_symbol_table; symbol_table2=nullptr; }
 
   namespacet(
     const symbol_tablet &_symbol_table1,
@@ -101,12 +101,12 @@ class multi_namespacet:public namespacet
 {
 public:
   // constructors
-  multi_namespacet():namespacet(NULL, NULL)
+  multi_namespacet():namespacet(nullptr, nullptr)
   {
   }
 
   explicit multi_namespacet(
-    const symbol_tablet &symbol_table):namespacet(NULL, NULL)
+    const symbol_tablet &symbol_table):namespacet(nullptr, nullptr)
   {
     add(symbol_table);
   }

--- a/src/util/parser.h
+++ b/src/util/parser.h
@@ -39,7 +39,7 @@ public:
     last_line.clear();
   }
 
-  parsert():in(NULL) { clear(); }
+  parsert():in(nullptr) { clear(); }
   virtual ~parsert() { }
 
   // The following are for the benefit of the scanner

--- a/src/util/pipe_stream.cpp
+++ b/src/util/pipe_stream.cpp
@@ -159,12 +159,12 @@ int pipe_streamt::run()
         a_it++, i++)
        _argv[i]=strdup(a_it->c_str());
 
-    _argv[args.size()+1]=NULL;
+    _argv[args.size()+1]=nullptr;
 
     int result=execvp(executable.c_str(), _argv);
 
     if(result==-1)
-      perror(0);
+      perror(nullptr);
 
     return result;
   }
@@ -289,7 +289,7 @@ std::streamsize filedescriptor_streambuft::xsputn(
 /// read a character from the piped process
 std::streambuf::int_type filedescriptor_streambuft::underflow()
 {
-  if(gptr()==0)
+  if(gptr()==nullptr)
     return traits_type::eof();
 
   if(gptr()<egptr())
@@ -339,7 +339,7 @@ std::streamsize filedescriptor_streambuft::xsgetn(
 /// determine number of available characters in stream
 std::streamsize filedescriptor_streambuft::showmanyc()
 {
-  if(gptr()==0)
+  if(gptr()==nullptr)
     return 0;
 
   if(gptr()<egptr())

--- a/src/util/ref_expr_set.h
+++ b/src/util/ref_expr_set.h
@@ -35,7 +35,7 @@ public:
 
   bool empty() const
   {
-    if(d==NULL)
+    if(d==nullptr)
       return true;
     return d->expr_set.empty();
   }
@@ -52,13 +52,13 @@ public:
 
   bool make_union(const ref_expr_sett &s2)
   {
-    if(s2.d==NULL)
+    if(s2.d==nullptr)
       return false;
 
     if(s2.d==d)
       return false;
 
-    if(d==NULL)
+    if(d==nullptr)
     {
       copy_from(s2);
       return true;

--- a/src/util/reference_counting.h
+++ b/src/util/reference_counting.h
@@ -19,7 +19,7 @@ template<typename T>
 class reference_counting
 {
 public:
-  reference_counting():d(NULL)
+  reference_counting():d(nullptr)
   {
   }
 
@@ -31,7 +31,7 @@ public:
   // copy constructor
   reference_counting(const reference_counting &other):d(other.d)
   {
-    if(d!=NULL)
+    if(d!=nullptr)
     {
       assert(d->ref_count!=0);
       d->ref_count++;
@@ -50,7 +50,7 @@ public:
   ~reference_counting()
   {
     remove_ref(d);
-    d=NULL;
+    d=nullptr;
   }
 
   void swap(reference_counting &other)
@@ -61,12 +61,12 @@ public:
   void clear()
   {
     remove_ref(d);
-    d=NULL;
+    d=nullptr;
   }
 
   const T &read() const
   {
-    if(d==NULL)
+    if(d==nullptr)
       return T::blank;
     return *d;
   }
@@ -104,7 +104,7 @@ protected:
 
     remove_ref(d);
     d=other.d;
-    if(d!=NULL)
+    if(d!=nullptr)
       d->ref_count++;
   }
 
@@ -118,7 +118,7 @@ public:
 template<class T>
 void reference_counting<T>::remove_ref(dt *old_d)
 {
-  if(old_d==NULL)
+  if(old_d==nullptr)
     return;
 
   assert(old_d->ref_count!=0);
@@ -151,7 +151,7 @@ void reference_counting<T>::detatch()
   std::cout << "DETATCH1: " << d << '\n';
   #endif
 
-  if(d==NULL)
+  if(d==nullptr)
   {
     d=new dt;
 

--- a/src/util/run.cpp
+++ b/src/util/run.cpp
@@ -117,13 +117,13 @@ int run(
     {
       // resume signals
       remove_signal_catcher();
-      sigprocmask(SIG_SETMASK, &old_mask, NULL);
+      sigprocmask(SIG_SETMASK, &old_mask, nullptr);
 
       char **_argv=new char * [argv.size()+1];
       for(std::size_t i=0; i<argv.size(); i++)
         _argv[i]=strdup(argv[i].c_str());
 
-      _argv[argv.size()]=NULL;
+      _argv[argv.size()]=nullptr;
 
       if(stdin_fd!=STDIN_FILENO)
         dup2(stdin_fd, STDIN_FILENO);
@@ -137,7 +137,7 @@ int run(
     else /* fork() returns new pid to the parent process */
     {
       // resume signals
-      sigprocmask(SIG_SETMASK, &old_mask, NULL);
+      sigprocmask(SIG_SETMASK, &old_mask, nullptr);
 
       int status;     /* parent process: child's exit status */
 
@@ -166,7 +166,7 @@ int run(
   else /* fork returns -1 on failure */
   {
     // resume signals
-    sigprocmask(SIG_SETMASK, &old_mask, NULL);
+    sigprocmask(SIG_SETMASK, &old_mask, nullptr);
 
     if(stdin_fd!=STDIN_FILENO)
       close(stdin_fd);

--- a/src/util/signal_catcher.cpp
+++ b/src/util/signal_catcher.cpp
@@ -41,7 +41,7 @@ void install_signal_catcher()
   sigfillset(&(act.sa_mask));
 
   // install signal handler
-  sigaction(SIGTERM, &act, NULL);
+  sigaction(SIGTERM, &act, nullptr);
   #endif
 }
 
@@ -57,7 +57,7 @@ void remove_signal_catcher()
   act.sa_flags=0;
   sigfillset(&(act.sa_mask));
 
-  sigaction(SIGTERM, &act, NULL);
+  sigaction(SIGTERM, &act, nullptr);
   #endif
 }
 

--- a/src/util/tempdir.cpp
+++ b/src/util/tempdir.cpp
@@ -58,7 +58,7 @@ std::string get_temporary_directory(const std::string &name_template)
   #else
     std::string prefixed_name_template="/tmp/";
     const char *TMPDIR_env=getenv("TMPDIR");
-    if(TMPDIR_env!=0)
+    if(TMPDIR_env!=nullptr)
       prefixed_name_template=TMPDIR_env;
     if(*prefixed_name_template.rbegin()!='/')
       prefixed_name_template+='/';

--- a/src/util/tempfile.cpp
+++ b/src/util/tempfile.cpp
@@ -107,7 +107,7 @@ std::string get_temporary_file(
   #else
   std::string dir="/tmp/";
   const char *TMPDIR_env=getenv("TMPDIR");
-  if(TMPDIR_env!=0)
+  if(TMPDIR_env!=nullptr)
     dir=TMPDIR_env;
   if(*dir.rbegin()!='/')
     dir+='/';

--- a/src/util/unicode.cpp
+++ b/src/util/unicode.cpp
@@ -154,12 +154,12 @@ std::string utf32_to_utf8(const std::basic_string<unsigned int> &s)
 
 const char **narrow_argv(int argc, const wchar_t **argv_wide)
 {
-  if(argv_wide==NULL)
-    return NULL;
+  if(argv_wide==nullptr)
+    return nullptr;
 
   // the following never gets deleted
   const char **argv_narrow=new const char *[argc+1];
-  argv_narrow[argc]=0;
+  argv_narrow[argc]=nullptr;
 
   for(int i=0; i<argc; i++)
     argv_narrow[i]=strdup(narrow(argv_wide[i]).c_str());


### PR DESCRIPTION
This PR was created using clang-tidy's auto-fix mode. To run clang-tidy, I had to generate a compile database, which required a CMake build. I wonder whether it would be worth creating another PR to add CMake support to CBMC master, but *alongside* the existing makefile build. We could add a single configuration to Travis that builds using CMake instead, to ensure that both builds are kept up-to-date.