### PR TITLE
Add an access specification to stub methods

### DIFF
--- a/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1400,6 +1400,9 @@ codet java_bytecode_convert_methodt::convert_instructions(
           id2string(arg0.get(ID_C_class)).substr(6)+"."+
           id2string(symbol.base_name)+"()";
         symbol.type=arg0.type();
+        // ensure there is some access specification
+        if(symbol.type.get(ID_access).empty())
+          symbol.type.set(ID_access, ID_default);
         symbol.value.make_nil();
         symbol.mode=ID_java;
         assign_parameter_names(
@@ -2722,9 +2725,8 @@ const bool java_bytecode_convert_methodt::is_method_inherited(
         return true;
       // methods with the default access modifier are only
       // accessible within the same package.
-      else if(access==ID_default &&
-              java_class_to_package(id2string(parent))==classpackage)
-        return true;
+      else if(access==ID_default)
+        return java_class_to_package(id2string(parent))==classpackage;
       else if(access==ID_private)
         continue;
       else


### PR DESCRIPTION
In absence of an ID_access setting, is_method_inherited (currently only in test-gen-support) will fail.

I'm not sure whether picking `ID_public` is correct as I've done.

While debugging this, the handling of `ID_default` in the code snippet below also looks suspicious -- what about the case where `java_class_to_package(id2string(parent))!=classpackage`?

````c++
const bool java_bytecode_convert_methodt::is_method_inherited(
  const irep_idt &classname, const irep_idt &methodid) const
{
  [...]
    {
      const auto &access=symbol->type.get(ID_access);
      if(access==ID_public || access==ID_protected)
        return true;
      // methods with the default access modifier are only
      // accessible within the same package.
      else if(access==ID_default &&
              java_class_to_package(id2string(parent))==classpackage)
        return true;
      else if(access==ID_private)
        continue;
      else
        INVARIANT(false, "Unexpected access modifier.");
````