### PR TITLE
Escape square brackets in java_length test descriptor

### DIFF
--- a/regression/strings-smoke-tests/java_length/test.desc
+++ b/regression/strings-smoke-tests/java_length/test.desc
@@ -4,6 +4,6 @@ test_length.class
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
-[.*assertion.1] .* line 7 .*: SUCCESS
-[.*assertion.2] .* line 8 .*: FAILURE
+\[.*assertion\.1\] .* line 7 .*: SUCCESS
+\[.*assertion\.2\] .* line 8 .*: FAILURE
 --


### PR DESCRIPTION
Solves this issue: https://github.com/diffblue/test-gen/issues/738