### PR TITLE
test.pl - go through all child directories [master edition]

### DIFF
--- a/regression/test.pl
+++ b/regression/test.pl
@@ -184,7 +184,7 @@ sub dirs() {
   my @list;
 
   opendir CWD, ".";
-  @list = grep { !/^\./ && -d "$_" && !/CVS/ && -s "$_/test.desc" } readdir CWD;
+  @list = grep { !/^\./ && -d "$_" && !/CVS/ } readdir CWD;
   closedir CWD;
 
   @list = sort @list;


### PR DESCRIPTION
Fixes the following issue: https://github.com/diffblue/test-gen/issues/862#event-1187579258

Fixes a bug where test.pl would ignore directories that contain
valid tests (*.desc and *.java combo) and only test those directories
that contained a file with exact name "test.desc".