### PR TITLE
Add skipped regression tests for #1202

### DIFF
--- a/regression/strings-smoke-tests/java_format/test_warning.desc
+++ b/regression/strings-smoke-tests/java_format/test_warning.desc
@@ -1,0 +1,12 @@
+KNOWNBUG
+test.class
+--refine-strings --string-max-length 20 --verbosity 9
+^EXIT=10$
+^SIGNAL=0$
+^\[.*assertion.1\].* line 6.* SUCCESS$
+^\[.*assertion.2\].* line 7.* FAILURE$
+--
+^ignoring
+--
+Some type inconsistencies exist when adding equations to the solver.
+Issue: diffblue/test-gen#1202

--- a/regression/strings-smoke-tests/java_format2/test_warning.desc
+++ b/regression/strings-smoke-tests/java_format2/test_warning.desc
@@ -1,0 +1,13 @@
+KNOWNBUG
+test.class
+--refine-strings --string-max-length 20 --verbosity 9
+^EXIT=10$
+^SIGNAL=0$
+^\[.*assertion.1\].* line 6.* SUCCESS$
+^\[.*assertion.2\].* line 7.* FAILURE$
+--
+^warning
+--
+Some type inconsistencies exist when adding equations to the solver.
+Issue: diffblue/test-gen#1202
+

--- a/regression/strings-smoke-tests/java_format3/test_warning.desc
+++ b/regression/strings-smoke-tests/java_format3/test_warning.desc
@@ -1,0 +1,13 @@
+KNOWNBUG
+test.class
+--refine-strings --string-max-length 20 --verbosity 9
+^EXIT=10$
+^SIGNAL=0$
+^\[.*assertion.1\].* line 7.* SUCCESS$
+^\[.*assertion.2\].* line 9.* FAILURE$
+--
+^warning
+--
+Some type inconsistencies exist when adding equations to the solver.
+Issue: diffblue/test-gen#1202
+


### PR DESCRIPTION
Elicits the type inconsistency warnings generated by the `String.format` tests.