### PR TITLE
Fix linter and doxygen checks on travis

### DIFF
--- a/scripts/travis_doxygen.sh
+++ b/scripts/travis_doxygen.sh
@@ -8,5 +8,9 @@ pip install --user unidiff
 if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   $script_folder/run_diff.sh DOXYGEN HEAD~1 # Check for errors introduced in last commit
 else
-  $script_folder/run_diff.sh DOXYGEN $TRAVIS_BRANCH # Check for errors compared to merge target
+  TMP_HEAD=$(git rev-parse HEAD)
+  git config remote.origin.fetch +refs/heads/$TRAVIS_BRANCH:refs/remotes/origin/$TRAVIS_BRANCH
+  git fetch --unshallow
+  git checkout $TMP_HEAD
+  $script_folder/run_diff.sh DOXYGEN origin/$TRAVIS_BRANCH # Check for errors compared to merge target
 fi

--- a/scripts/travis_lint.sh
+++ b/scripts/travis_lint.sh
@@ -8,5 +8,9 @@ pip install --user unidiff
 if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   $script_folder/run_diff.sh CPPLINT HEAD~1 # Check for errors introduced in last commit
 else
-  $script_folder/run_diff.sh CPPLINT $TRAVIS_BRANCH # Check for errors compared to merge target
+  TMP_HEAD=$(git rev-parse HEAD)
+  git config remote.origin.fetch +refs/heads/$TRAVIS_BRANCH:refs/remotes/origin/$TRAVIS_BRANCH
+  git fetch --unshallow
+  git checkout $TMP_HEAD
+  $script_folder/run_diff.sh CPPLINT origin/$TRAVIS_BRANCH # Check for errors compared to merge target
 fi


### PR DESCRIPTION
Travis' shallow clones always use the master branch instead of the PR's target branch which causes the target branch to be unavailable for comparisons. This PR has a workaround.

The  fix is not necessary for master, but should be applied to master as well to facilitate merging.