### PR TITLE
Make string_container static init more resilient

### DIFF
--- a/src/util/dstring.h
+++ b/src/util/dstring.h
@@ -46,13 +46,13 @@ public:
 
   // this one is not safe for static objects
   // NOLINTNEXTLINE(runtime/explicit)
-  dstringt(const char *s):no(string_container[s])
+  dstringt(const char *s):no(get_string_container()[s])
   {
   }
 
   // this one is not safe for static objects
   // NOLINTNEXTLINE(runtime/explicit)
-  dstringt(const std::string &s):no(string_container[s])
+  dstringt(const std::string &s):no(get_string_container()[s])
   {
   }
 
@@ -152,12 +152,12 @@ private:
 
   // the reference returned is guaranteed to be stable
   const std::string &as_string() const
-  { return string_container.get_string(no); }
+  { return get_string_container().get_string(no); }
 };
 
 // the reference returned is guaranteed to be stable
 inline const std::string &as_string(const dstringt &s)
-{ return string_container.get_string(s.get_no()); }
+{ return get_string_container().get_string(s.get_no()); }
 
 // NOLINTNEXTLINE(readability/identifiers)
 struct dstring_hash

--- a/src/util/irep_ids.cpp
+++ b/src/util/irep_ids.cpp
@@ -43,14 +43,15 @@ const char *irep_ids_table[]=
 
 #include "irep_ids.def" // NOLINT(build/include)
 
-void initialize_string_container()
+string_containert::string_containert()
 {
-  // this is called by the constructor of string_containert
+  // pre-allocate empty string -- this gets index 0
+  get("");
 
+  // allocate strings
   for(unsigned i=0; irep_ids_table[i]!=nullptr; i++)
   {
-    unsigned x;
-    x=string_container[irep_ids_table[i]];
+    unsigned x=operator[](irep_ids_table[i]);
     INVARIANT(x==i, "i-th element is inserted at position i"); // sanity check
   }
 }

--- a/src/util/string_container.cpp
+++ b/src/util/string_container.cpp
@@ -13,8 +13,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <cstring>
 
-string_containert string_container;
-
 string_ptrt::string_ptrt(const char *_s):s(_s), len(strlen(_s))
 {
 }
@@ -25,17 +23,6 @@ bool string_ptrt::operator==(const string_ptrt &other) const
     return false;
 
   return len==0 || memcmp(s, other.s, len)==0;
-}
-
-void initialize_string_container();
-
-string_containert::string_containert()
-{
-  // pre-allocate empty string -- this gets index 0
-  get("");
-
-  // allocate strings
-  initialize_string_container();
 }
 
 string_containert::~string_containert()
@@ -86,4 +73,11 @@ unsigned string_containert::get(const std::string &s)
   string_vector.push_back(&string_list.back());
 
   return r;
+}
+
+/// Get a reference to the global string container.
+string_containert &get_string_container()
+{
+  static string_containert ret;
+  return ret;
 }

--- a/src/util/string_container.h
+++ b/src/util/string_container.h
@@ -89,7 +89,6 @@ protected:
   string_vectort string_vector;
 };
 
-// an ugly global object
-extern string_containert string_container;
+string_containert &get_string_container();
 
 #endif // CPROVER_UTIL_STRING_CONTAINER_H


### PR DESCRIPTION
Re-targets #1213 to test-gen-support. This patch improves the correctness of the program and will have minimal effects on performance, therefore I suggest we merge it into TGS, and upstream can conduct a detailed performance appraisal if they feel it is necessary there.