### PR TITLE
Escape backslash in generated tests [Hotfix]

### DIFF
--- a/src/util/unicode.cpp
+++ b/src/util/unicode.cpp
@@ -298,10 +298,16 @@ std::string utf16_little_endian_to_java(const std::wstring &in)
       result << "\\n";
     else if(ch=='\r')
       result << "\\r";
+    else if(ch=='\f')
+      result << "\\f";
+    else if(ch=='\b')
+      result << "\\b";
+    else if(ch=='\t')
+      result << "\\t";
     else if(ch<=255 && isprint(ch, loc))
     {
       const auto uch=static_cast<unsigned char>(ch);
-      if(uch=='"')
+      if(uch=='"' || uch=='\\')
         result << '\\';
       result << uch;
     }


### PR DESCRIPTION
Test-gen PR: https://github.com/diffblue/test-gen/pull/914
Somewhat related to this issue: https://github.com/diffblue/test-gen/issues/194