### PR TITLE
Public opaque methods + documentation

### DIFF
--- a/src/java_bytecode/jar_file.h
+++ b/src/java_bytecode/jar_file.h
@@ -23,6 +23,12 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "java_class_loader_limit.h"
 
+/// An in-memory representation of a JAR file, consisting of a handler to a zip
+/// file (field \ref zip) and a map from file names inside the zip file to the
+/// index they occupy in the root directory (field \ref filtered_jar).
+///
+/// Both fields are initialize by a call to open(). Method get_entry() reads a
+/// file from the zip and returns it.
 class jar_filet:public messaget
 {
 public:
@@ -30,25 +36,49 @@ public:
 
   ~jar_filet();
 
-  void open(java_class_loader_limitt &, const std::string &);
+  /// Initializes \ref zip to store the JAR file pointed by \p filepath and
+  /// loads the map \ref filtered_jar with the .class names allowed by \p limit.
+  void open(java_class_loader_limitt &limit, const std::string &filepath);
 
-  // Test for error; 'true' means we are good.
+  /// Test for error; 'true' means we are good.
   explicit operator bool() const { return mz_ok; }
 
-  // map internal index to real index in jar central directory
+  /// Reads the \ref zip field and returns a string storing the data contained
+  /// in file \p name.
+  std::string get_entry(const irep_idt &name);
+
+  /// Maps the names of the files stored in the JAR file to the index they
+  /// occupy (starting from 0) in the JAR central directory.  Populated by
+  /// method open() above.
   typedef std::map<irep_idt, size_t> filtered_jart;
   filtered_jart filtered_jar;
-
-  std::string get_entry(const irep_idt &);
 
   typedef std::map<std::string, std::string> manifestt;
   manifestt get_manifest();
 
 protected:
+
+  /// A handle representing the zip file
   mz_zip_archive zip;
+
+  /// True iff the \ref zip field has been correctly initialized with a JAR file
   bool mz_ok;
 };
 
+/// A pool of jar_filet objects, indexed by the filesystem path name used to
+/// load that jar_filet.
+///
+/// The state of the class is maintained by the field \ref file_map, a std::map
+/// associating the path of a .jar file with its in-memory representation.
+/// A call to
+///
+/// ```
+///   operator()(limit, path)
+/// ```
+///
+/// will either return a previously loaded jar_filet, if it is found in the map,
+/// or will load that file (using jar_filet::open) and return a newly created
+/// jar_filet.
 class jar_poolt:public messaget
 {
 public:

--- a/src/java_bytecode/jar_file.h
+++ b/src/java_bytecode/jar_file.h
@@ -57,7 +57,6 @@ public:
   manifestt get_manifest();
 
 protected:
-
   /// A handle representing the zip file
   mz_zip_archive zip;
 

--- a/src/java_bytecode/jar_file.h
+++ b/src/java_bytecode/jar_file.h
@@ -99,9 +99,9 @@ public:
   }
 
 protected:
+  /// A map from filesystem paths to jar_filet objects
   typedef std::map<std::string, jar_filet> file_mapt;
   file_mapt file_map;
-  std::string java_cp_include_files;
 };
 
 #endif // CPROVER_JAVA_BYTECODE_JAR_FILE_H

--- a/src/java_bytecode/java_bytecode_convert_class.cpp
+++ b/src/java_bytecode/java_bytecode_convert_class.cpp
@@ -237,6 +237,8 @@ void java_bytecode_convert_classt::convert(
   }
 }
 
+/// Register in the symbol table new symbols for the objects
+/// java::array[X] where X is byte, float, int, char...
 void java_bytecode_convert_classt::add_array_types()
 {
   const std::string letters="ijsbcfdza";

--- a/src/java_bytecode/java_bytecode_convert_class.cpp
+++ b/src/java_bytecode/java_bytecode_convert_class.cpp
@@ -48,7 +48,8 @@ public:
 
   void operator()(const java_bytecode_parse_treet &parse_tree)
   {
-    add_array_types();
+    // add array types to the symbol table
+    add_array_types(symbol_table);
 
     bool loading_success=parse_tree.loading_successful;
     if(loading_success)
@@ -74,12 +75,21 @@ protected:
   lazy_methods_modet lazy_methods_mode;
   java_string_library_preprocesst &string_preprocess;
 
+  /// This field will be initialized to false, and set to true when
+  /// add_array_types() is executed. It serves as a sentinel to make sure that
+  /// the code using this class calls add_array_types() at least once.
+  static bool add_array_types_executed;
+
   // conversion
   void convert(const classt &c);
   void convert(symbolt &class_symbol, const fieldt &f);
 
-  void add_array_types();
+  // see definition below for more info
+  static void add_array_types(symbol_tablet &symbol_table);
 };
+
+// initialization of static field
+bool java_bytecode_convert_classt::add_array_types_executed=false;
 
 void java_bytecode_convert_classt::convert(const classt &c)
 {
@@ -242,10 +252,16 @@ void java_bytecode_convert_classt::convert(
   }
 }
 
-/// Register in the symbol table new symbols for the objects
+/// Register in the \p symbol_table new symbols for the objects
 /// java::array[X] where X is byte, float, int, char...
-void java_bytecode_convert_classt::add_array_types()
+void java_bytecode_convert_classt::add_array_types(symbol_tablet &symbol_table)
 {
+  // this method only adds stuff to the symbol table, no need to execute it more
+  // than once
+  if(add_array_types_executed)
+    return;
+  add_array_types_executed=true;
+
   const std::string letters="ijsbcfdza";
 
   for(const char l : letters)

--- a/src/java_bytecode/java_bytecode_convert_class.cpp
+++ b/src/java_bytecode/java_bytecode_convert_class.cpp
@@ -144,6 +144,7 @@ void java_bytecode_convert_classt::convert(const classt &c)
   symbolt *class_symbol;
 
   // add before we do members
+  debug() << "Adding symbol: class '" << c.name << "'" << eom;
   if(symbol_table.move(new_symbol, class_symbol))
   {
     error() << "failed to add class symbol " << new_symbol.name << eom;
@@ -152,7 +153,10 @@ void java_bytecode_convert_classt::convert(const classt &c)
 
   // now do fields
   for(const auto &field : c.fields)
+  {
+    debug() << "Adding symbol:  field '" << field.name << "'" << eom;
     convert(*class_symbol, field);
+  }
 
   // now do methods
   for(const auto &method : c.methods)
@@ -163,6 +167,7 @@ void java_bytecode_convert_classt::convert(const classt &c)
       ":"+method.signature;
     // Always run the lazy pre-stage, as it symbol-table
     // registers the function.
+    debug() << "Adding symbol:  method '" << method_identifier << "'" << eom;
     java_bytecode_convert_method_lazy(
       *class_symbol,
       method_identifier,

--- a/src/java_bytecode/java_bytecode_convert_class.h
+++ b/src/java_bytecode/java_bytecode_convert_class.h
@@ -18,6 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "java_bytecode_parse_tree.h"
 #include "java_bytecode_language.h"
 
+/// See class \ref java_bytecode_convert_classt
 bool java_bytecode_convert_class(
   const java_bytecode_parse_treet &parse_tree,
   symbol_tablet &symbol_table,

--- a/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1419,8 +1419,18 @@ codet java_bytecode_convert_methodt::convert_instructions(
       // inherit a definition from a super-class, we create a new symbol and
       // insert it in the symbol table. The name and type of the method are
       // derived from the information we have in the call.
-      // The access attribute is arbitrarily fixed to ID_public, as we have no
-      // way to know.
+      // We fix the access attribute to ID_public, because of the following
+      // reasons:
+      // - We don't know the orignal access attribute and since the .class file
+      //   unavailable, we have no way to know.
+      // - Whatever it was, we assume that the bytecode we are translating
+      //   compiles correctly, so such a method has to be accessible from this
+      //   method.
+      // - We will never generate code that calls that method unless we
+      //   translate bytecode that calls that method. As a result we will never
+      //   generate code that may wrongly assume that such a method is
+      //   accessible if we assume that its access attribute is "more
+      //   accessible" than it actually is.
       irep_idt id=arg0.get(ID_identifier);
       if(symbol_table.symbols.find(id)==symbol_table.symbols.end() &&
          !(is_virtual && is_method_inherited(arg0.get(ID_C_class), arg0.get(ID_component_name))))
@@ -1432,6 +1442,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
           id2string(arg0.get(ID_C_class)).substr(6)+"."+
           id2string(symbol.base_name)+"()";
         symbol.type=arg0.type();
+        symbol.type.set(ID_access, ID_public);
         symbol.value.make_nil();
         symbol.mode=ID_java;
         assign_parameter_names(

--- a/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -67,11 +67,15 @@ protected:
   const char *p;
 };
 
-/// See above
-/// \par parameters: `ftype`: Function type whose parameters should be named
-/// `name_prefix`: Prefix for parameter names, typically the parent function's
-///   name.
-/// `symbol_table`: Global symbol table
+/// Iterates through the parameters of the function type \p ftype, finds a new
+/// new name for each parameter and renames them in `ftype.parameters()` as
+/// well as in the \p symbol_table.
+/// \param[in,out] ftype:
+///   Function type whose parameters should be named.
+/// \param name_prefix:
+///   Prefix for parameter names, typically the parent function's name.
+/// \param[in,out] symbol_table:
+///   Global symbol table.
 /// \return Assigns parameter names (side-effects on `ftype`) to function stub
 ///   parameters, which are initially nameless as method conversion hasn't
 ///   happened. Also creates symbols in `symbol_table`.
@@ -1409,8 +1413,12 @@ codet java_bytecode_convert_methodt::convert_instructions(
 
       assert(arg0.id()==ID_virtual_function);
 
-      // if we don't have a definition for the called symbol, and we won't
-      // inherit a definition from a super-class, create a stub.
+      // If we don't have a definition for the called symbol, and we won't
+      // inherit a definition from a super-class, we create a new symbol and
+      // insert it in the symbol table. The name and type of the method are
+      // derived from the information we have in the call.
+      // The access attribute is arbitrarily fixed to ID_public, as we have no
+      // way to know.
       irep_idt id=arg0.get(ID_identifier);
       if(symbol_table.symbols.find(id)==symbol_table.symbols.end() &&
          !(is_virtual && is_method_inherited(arg0.get(ID_C_class), arg0.get(ID_component_name))))
@@ -2729,12 +2737,19 @@ void java_bytecode_convert_method(
   java_bytecode_convert_method(class_symbol, method);
 }
 
+/// Returns true iff method \p methodid from class \p classname is
+/// a method inherited from a class (and not an interface!) from which
+/// \p classname inherits, either directly or indirectly.
 bool java_bytecode_convert_methodt::is_method_inherited(
   const irep_idt &classname, const irep_idt &methodid) const
 {
   resolve_concrete_function_callt call_resolver(symbol_table);
   const resolve_concrete_function_callt ::concrete_function_callt &
     resolved_call=call_resolver(classname, methodid);
+
+  // resolved_call is a pair (class-name, method-name) found by walking the
+  // chain of class inheritance (not interfaces!) and stopping on the first
+  // class that contains a method of equal name and type to `methodid`
 
   if(resolved_call.is_valid())
   {
@@ -2746,6 +2761,8 @@ bool java_bytecode_convert_methodt::is_method_inherited(
     const auto &access=function_symbol.type.get(ID_access);
     if(access==ID_public || access==ID_protected)
     {
+      // since the method is public, it is a public method of `classname`, it is
+      // inherited
       return true;
     }
 
@@ -2762,10 +2779,12 @@ bool java_bytecode_convert_methodt::is_method_inherited(
 
     if(access==ID_private)
     {
-      // This is somewhat contentious: previously this code would keep walking
-      // up the parent if it found a private function. But this isn't what Java
-      // appears to do. If a private method is found then that becomes the
-      // virtual signuate and blocks access to the parent class
+      // We return false because the method found by the call_resolver above
+      // proves that `methodid` cannot be inherited (assuming that the original
+      // Java code compiles). This is because, as we walk the inheritance chain
+      // for `classname` from Object to `classname`, a method can only become
+      // "more accessible". So, if the last occurrence is private, all others
+      // before must be private as well, and none is inherited in `classname`.
       return false;
     }
 

--- a/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -707,7 +707,8 @@ code_blockt &java_bytecode_convert_methodt::get_or_create_block_for_pcrange(
     {
       if(p<(*findstart) || p>=findlim_block_start_address)
       {
-        debug() << "Warning: refusing to create lexical block spanning "
+        debug() << "Generating codet:  "
+                << "warning: refusing to create lexical block spanning "
                 << (*findstart) << "-" << findlim_block_start_address
                 << " due to incoming edge " << p << " -> "
                 << checkit->first << eom;
@@ -729,7 +730,8 @@ code_blockt &java_bytecode_convert_methodt::get_or_create_block_for_pcrange(
   code_blockt &newblock=to_code_block(newlabel.code());
   auto nblocks=std::distance(findstart, findlim);
   assert(nblocks>=2);
-  debug() << "Combining " << std::distance(findstart, findlim)
+  debug() << "Generating codet:  combining "
+          << std::distance(findstart, findlim)
           << " blocks for addresses " << (*findstart) << "-"
           << findlim_block_start_address << eom;
 
@@ -1437,6 +1439,9 @@ codet java_bytecode_convert_methodt::convert_instructions(
           symbol.name,
           symbol_table);
 
+        debug()
+          << "Generating codet:  new opaque symbol: method '"
+          << symbol.name << "'" << eom;
         symbol_table.add(symbol);
       }
 

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -180,7 +180,8 @@ bool java_bytecode_languaget::typecheck(
   if(string_refinement_enabled)
     string_preprocess.initialize_conversion_table();
 
-  // first convert all
+  // first generate a new struct symbol for each class and a new function symbol
+  // for every method
   for(java_class_loadert::class_mapt::const_iterator
       c_it=java_class_loader.class_map.begin();
       c_it!=java_class_loader.class_map.end();

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -189,8 +189,6 @@ bool java_bytecode_languaget::typecheck(
     if(c_it->second.parsed_class.name.empty())
       continue;
 
-    debug() << "Generating class/member symbols: " << c_it->first << eom;
-
     if(java_bytecode_convert_class(
          c_it->second,
          symbol_table,

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -132,23 +132,25 @@ bool java_bytecode_languaget::parse(
   }
   else if(has_suffix(path, ".jar"))
   {
+    // build an object to potentially limit which classes are loaded
     java_class_loader_limitt class_loader_limit(
       get_message_handler(),
       java_cp_include_files);
     if(config.java.main_class.empty())
     {
-      // Does it have a main class set in the manifest?
+      // load the .jar file and retrieve its manifest
       jar_filet::manifestt manifest=
         java_class_loader.jar_pool(class_loader_limit, path).get_manifest();
       std::string manifest_main_class=manifest["Main-Class"];
 
+      // if the manifest declares a Main-Class line, we got a main class
       if(manifest_main_class!="")
         main_class=manifest_main_class;
     }
     else
       main_class=config.java.main_class;
 
-    // Do we have one now?
+    // do we have one now?
     if(main_class.empty())
     {
       status() << "JAR file without entry point: loading class files" << eom;

--- a/src/java_bytecode/java_class_loader.cpp
+++ b/src/java_bytecode/java_class_loader.cpp
@@ -188,6 +188,8 @@ void java_class_loadert::read_jar_file(
   if(jar_map.find(file)!=jar_map.end())
     return;
 
+  // read the .jar file, store it in memory and return a jar_filet representing
+  // it
   jar_filet &jar_file=jar_pool(class_loader_limit, id2string(file));
 
   if(!jar_file)
@@ -198,8 +200,9 @@ void java_class_loadert::read_jar_file(
 
   debug() << "adding JAR file `" << file << "'" << eom;
 
+  // create a new entry in the map and initialize using the list of file names
+  // that were retained in the jar_filet by the class_loader_limit filter
   auto &jm=jar_map[file];
-
   for(auto &jar_entry : jar_file.filtered_jar)
   {
     std::string file_name=id2string(jar_entry.first);

--- a/src/java_bytecode/java_class_loader.h
+++ b/src/java_bytecode/java_class_loader.h
@@ -27,10 +27,6 @@ public:
 
   void set_java_cp_include_files(std::string &);
 
-  // maps class names to the parse trees
-  typedef std::map<irep_idt, java_bytecode_parse_treet> class_mapt;
-  class_mapt class_map;
-
   static std::string file_to_class_name(const std::string &);
   static std::string class_name_to_file(const irep_idt &);
 
@@ -41,8 +37,30 @@ public:
 
   void load_entire_jar(java_class_loader_limitt &, const std::string &f);
 
+  void read_jar_file(java_class_loader_limitt &, const irep_idt &);
+
+  /// Given a \p class_name (e.g. "java.lang.Thread") try to load the
+  /// corresponding .class file by first scanning all .jar files whose
+  /// pathname is stored in \ref jar_files, and if that doesn't work, then scan
+  /// the actual filesystem using `config.java.classpath` as class path. Uses
+  /// \p limit to limit the class files that it might (directly or indirectly)
+  /// load and returns a default-constructed parse tree when unable to find the
+  /// .class file.
+  java_bytecode_parse_treet &get_parse_tree(
+    java_class_loader_limitt &limit, const irep_idt &class_name);
+
+  /// Maps class names to the bytecode parse trees.
+  typedef std::map<irep_idt, java_bytecode_parse_treet> class_mapt;
+  class_mapt class_map;
+
+  /// Maps .jar filesystem paths to jar_filet objects (stored inside).
+  /// Responsible for loading new jar files when they are first referenced.
   jar_poolt jar_pool;
 
+  /// An object of this class represents the information of _a single JAR file_
+  /// that is relevant for a class loader: a map associating logical class names
+  /// with with handles (struct entryt) that describe one .class file inside the
+  /// JAR. Currently the handle only contains the name of the .class file.
   class jar_map_entryt
   {
   public:
@@ -51,22 +69,26 @@ public:
       std::string class_file_name;
     };
 
-    // class name to index map
+    /// Maps class names to jar file entries.
     typedef std::map<irep_idt, entryt> entriest;
     entriest entries;
   };
 
-  // maps jar files to maps of class names
+  /// Maps .jar filesystem paths to .class file descriptors (see
+  /// jar_map_entryt).
   typedef std::map<irep_idt, jar_map_entryt> jar_mapt;
   jar_mapt jar_map;
 
-  void read_jar_file(java_class_loader_limitt &, const irep_idt &);
-
-  // get a parse tree for given class
-  java_bytecode_parse_treet &get_parse_tree(
-    java_class_loader_limitt &, const irep_idt &);
-
+  /// List of filesystem paths to .jar files that will be used, in the given
+  /// order, to find and load a class, provided its name (see \ref
+  /// get_parse_tree).
   std::list<std::string> jar_files;
+
+  /// Either a regular expression matching files that will be allowed to be
+  /// loaded or a string of the form `@PATH` where PATH is the file path of a
+  /// json file storing an explicit list of files allowed to be loaded. See
+  /// java_class_loader_limitt::setup_class_load_limit() for further
+  /// information.
   std::string java_cp_include_files;
 };
 

--- a/src/util/namespace.h
+++ b/src/util/namespace.h
@@ -52,8 +52,19 @@ public:
   const typet &follow_tag(const struct_tag_typet &src) const;
   const typet &follow_tag(const c_enum_tag_typet &src) const;
 
-  // these do the actual lookup
+  /// Returns the maximum integer n such that there is a symbol (in some of the
+  /// symbol tables) whose name is of the form "AB" where A is \p prefix and B
+  /// is n.  Symbols where B is not a number count as if B was equal to 0.
+  /// The intended use case is finding the next available symbol name for a
+  /// sequence of auto-generated symbols.
   virtual unsigned get_max(const std::string &prefix) const=0;
+
+  /// Searches for a symbol named \p name. Iff found, set \p symbol to point to
+  /// the symbol and return false; else \p symbol is unmodified and `true` is
+  /// returned. With multiple symbol tables, `symbol_table1` is searched first
+  /// and then symbol_table2.
+  /// \return False iff the requested symbol is found in at least one of the
+  /// tables.
   virtual bool lookup(const irep_idt &name, const symbolt *&symbol) const=0;
 };
 
@@ -84,8 +95,11 @@ public:
 
   using namespace_baset::lookup;
 
-  // these do the actual lookup
+  /// See namespace_baset::lookup(). Note that \ref namespacet has two symbol
+  /// tables.
   virtual bool lookup(const irep_idt &name, const symbolt *&symbol) const;
+
+  /// See documentation for namespace_baset::get_max().
   virtual unsigned get_max(const std::string &prefix) const;
 
   const symbol_tablet &get_symbol_table() const


### PR DESCRIPTION
Fixes https://github.com/diffblue/test-gen/issues/771

The fix for the issue is only the last commit. All other commits essentially improve documentation or debugging output. I advise to review one commit at a time.

During the conversion of bytecode to `codet`, when we discover a call to a
      method for which we don't have neither a symbol nor a body, we create a new
      symbol in the symbol table. Previously we didn't associate a visibility to its
      type. We now associated a public visibility. Not associating a visibility will
      cause an INVARIANT failure in `is_method_inherited()`.

