### PR TITLE
Load substituted pointers lazily 

### DIFF
--- a/src/java_bytecode/ci_lazy_methods.h
+++ b/src/java_bytecode/ci_lazy_methods.h
@@ -22,6 +22,7 @@
 #include <java_bytecode/java_bytecode_parse_tree.h>
 #include <java_bytecode/java_class_loader.h>
 #include <java_bytecode/ci_lazy_methods_needed.h>
+#include <java_bytecode/select_pointer_type.h>
 
 class java_string_library_preprocesst;
 
@@ -47,6 +48,7 @@ public:
     const std::vector<irep_idt> &main_jar_classes,
     const std::vector<irep_idt> &lazy_methods_extra_entry_points,
     java_class_loadert &java_class_loader,
+    const select_pointer_typet &pointer_type_selector,
     message_handlert &message_handler);
 
   // not const since messaget
@@ -62,6 +64,11 @@ private:
 
   void initialize_needed_classes(
     const std::vector<irep_idt> &entry_points,
+    const namespacet &ns,
+    ci_lazy_methods_neededt &lazy_methods);
+
+  void initialize_all_needed_classes_from_pointer(
+    const pointer_typet &pointer_type,
     const namespacet &ns,
     ci_lazy_methods_neededt &lazy_methods);
 
@@ -104,6 +111,7 @@ private:
   std::vector<irep_idt> main_jar_classes;
   std::vector<irep_idt> lazy_methods_extra_entry_points;
   java_class_loadert &java_class_loader;
+  const select_pointer_typet &pointer_type_selector;
 };
 
 #endif // CPROVER_JAVA_BYTECODE_GATHER_METHODS_LAZILY_H

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -276,6 +276,7 @@ bool java_bytecode_languaget::do_ci_lazy_method_conversion(
     main_jar_classes,
     lazy_methods_extra_entry_points,
     java_class_loader,
+    get_pointer_type_selector(),
     get_message_handler());
 
   return method_gather(symbol_table, lazy_methods, method_converter);

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -281,6 +281,13 @@ bool java_bytecode_languaget::do_ci_lazy_method_conversion(
   return method_gather(symbol_table, lazy_methods, method_converter);
 }
 
+const select_pointer_typet &
+  java_bytecode_languaget::get_pointer_type_selector() const
+{
+  PRECONDITION(pointer_type_selector.get()!=nullptr);
+  return *pointer_type_selector;
+}
+
 /// Provide feedback to `language_filest` so that when asked for a lazy method,
 /// it can delegate to this instance of java_bytecode_languaget.
 /// \return Populates `methods` with the complete list of lazy methods that are
@@ -364,7 +371,6 @@ bool java_bytecode_languaget::final(symbol_tablet &symbol_table)
     return res.error_found;
 
   // generate the test harness in __CPROVER__start and a call the entry point
-  select_pointer_typet pointer_type_selector;
   return
     java_entry_point(
       symbol_table,
@@ -373,7 +379,7 @@ bool java_bytecode_languaget::final(symbol_tablet &symbol_table)
       assume_inputs_non_null,
       max_nondet_array_length,
       max_nondet_tree_depth,
-      pointer_type_selector);
+      get_pointer_type_selector());
 }
 
 void java_bytecode_languaget::show_parse(std::ostream &out)

--- a/src/java_bytecode/java_bytecode_language.h
+++ b/src/java_bytecode/java_bytecode_language.h
@@ -10,11 +10,15 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_JAVA_BYTECODE_JAVA_BYTECODE_LANGUAGE_H
 #define CPROVER_JAVA_BYTECODE_JAVA_BYTECODE_LANGUAGE_H
 
+#include <memory>
+
 #include <util/language.h>
 #include <util/cmdline.h>
 
 #include "java_class_loader.h"
 #include "java_string_library_preprocess.h"
+
+#include <java_bytecode/select_pointer_type.h>
 
 #define JAVA_BYTECODE_LANGUAGE_OPTIONS /*NOLINT*/ \
   "(java-assume-inputs-non-null)"                 \
@@ -87,11 +91,19 @@ public:
   void show_parse(std::ostream &out) override;
 
   virtual ~java_bytecode_languaget();
+  java_bytecode_languaget(
+    std::unique_ptr<select_pointer_typet> pointer_type_selector):
+      max_nondet_array_length(MAX_NONDET_ARRAY_LENGTH_DEFAULT),
+      max_nondet_tree_depth(MAX_NONDET_TREE_DEPTH),
+      max_user_array_length(0),
+      pointer_type_selector(std::move(pointer_type_selector))
+  {}
+
   java_bytecode_languaget():
-    max_nondet_array_length(MAX_NONDET_ARRAY_LENGTH_DEFAULT),
-    max_nondet_tree_depth(MAX_NONDET_TREE_DEPTH),
-    max_user_array_length(0)
-    {}
+    java_bytecode_languaget(
+      std::unique_ptr<select_pointer_typet>(new select_pointer_typet()))
+  {}
+
 
   bool from_expr(
     const exprt &expr,
@@ -123,6 +135,7 @@ public:
 
 protected:
   bool do_ci_lazy_method_conversion(symbol_tablet &, lazy_methodst &);
+  const select_pointer_typet &get_pointer_type_selector() const;
 
   irep_idt main_class;
   std::vector<irep_idt> main_jar_classes;
@@ -138,6 +151,9 @@ protected:
   bool throw_runtime_exceptions;
   java_string_library_preprocesst string_preprocess;
   std::string java_cp_include_files;
+
+private:
+  const std::unique_ptr<const select_pointer_typet> pointer_type_selector;
 };
 
 languaget *new_java_bytecode_language();

--- a/src/java_bytecode/java_object_factory.cpp
+++ b/src/java_bytecode/java_object_factory.cpp
@@ -546,7 +546,7 @@ void java_object_factoryt::gen_nondet_pointer_init(
   PRECONDITION(expr.type().id()==ID_pointer);
 
   const pointer_typet &replacement_pointer_type=
-    pointer_type_selector.convert_pointer_type(pointer_type);
+    pointer_type_selector.convert_pointer_type(pointer_type, ns);
 
   // If we are changing the pointer, we generate code for creating a pointer
   // to the substituted type instead

--- a/src/java_bytecode/select_pointer_type.cpp
+++ b/src/java_bytecode/select_pointer_type.cpp
@@ -19,7 +19,7 @@
 /// \param pointer_type: The pointer type replace
 /// \return A pointer type where the subtype may have been modified
 pointer_typet select_pointer_typet::convert_pointer_type(
-  const pointer_typet &pointer_type) const
+  const pointer_typet &pointer_type, const namespacet &ns) const
 {
   return  pointer_type;
 }

--- a/src/java_bytecode/select_pointer_type.h
+++ b/src/java_bytecode/select_pointer_type.h
@@ -21,7 +21,7 @@ class select_pointer_typet
 public:
   virtual ~select_pointer_typet()=default;
   virtual pointer_typet convert_pointer_type(
-    const pointer_typet &pointer_type) const;
+    const pointer_typet &pointer_type, const namespacet &ns) const;
 };
 
 #endif // CPROVER_JAVA_BYTECODE_SELECT_POINTER_TYPE_H


### PR DESCRIPTION
When considering the types passed around, we perform a dry run on the pointer substitution to see if there are other types we should be loading for that specific pointer type. This involved some refactoring to ensure the same `pointer_type_selector` is used both at the actual substitution and in loading. 

The tests in test-gen are updated to use `--lazy-methods` flag to ensure this fix works. 