### PR TITLE
Improvement in check_axioms method of the string solver

### DIFF
--- a/regression/strings-smoke-tests/java_append_char/test.desc
+++ b/regression/strings-smoke-tests/java_append_char/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_append_char.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/strings-smoke-tests/java_case/test.desc
+++ b/regression/strings-smoke-tests/java_case/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_case.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* file test_case.java line 10 .* SUCCESS$

--- a/regression/strings-smoke-tests/java_insert_char/test.desc
+++ b/regression/strings-smoke-tests/java_insert_char/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_insert_char.class
---refine-strings
+--refine-strings  --string-max-length 1000
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/strings-smoke-tests/java_insert_char_array/test.desc
+++ b/regression/strings-smoke-tests/java_insert_char_array/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_insert_char_array.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/strings-smoke-tests/java_insert_int/test.desc
+++ b/regression/strings-smoke-tests/java_insert_int/test.desc
@@ -1,6 +1,6 @@
 FUTURE
 test_insert_int.class
---refine-strings
+--refine-strings  --string-max-length 1000
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/strings-smoke-tests/java_insert_multiple/test.desc
+++ b/regression/strings-smoke-tests/java_insert_multiple/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_insert_multiple.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/strings-smoke-tests/java_insert_string/test.desc
+++ b/regression/strings-smoke-tests/java_insert_string/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_insert_string.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/strings-smoke-tests/java_int_to_string/test3.desc
+++ b/regression/strings-smoke-tests/java_int_to_string/test3.desc
@@ -1,6 +1,6 @@
 CORE
 Test3.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/regression/strings-smoke-tests/java_int_to_string/test5.desc
+++ b/regression/strings-smoke-tests/java_int_to_string/test5.desc
@@ -1,6 +1,6 @@
 CORE
 Test5.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/regression/strings-smoke-tests/java_int_to_string_with_radix/test_binary1.desc
+++ b/regression/strings-smoke-tests/java_int_to_string_with_radix/test_binary1.desc
@@ -1,6 +1,6 @@
 CORE
 Test_binary1.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/regression/strings-smoke-tests/java_int_to_string_with_radix/test_binary2.desc
+++ b/regression/strings-smoke-tests/java_int_to_string_with_radix/test_binary2.desc
@@ -1,6 +1,6 @@
 CORE
 Test_binary2.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/regression/strings-smoke-tests/java_int_to_string_with_radix/test_hex1.desc
+++ b/regression/strings-smoke-tests/java_int_to_string_with_radix/test_hex1.desc
@@ -1,6 +1,6 @@
 CORE
 Test_hex1.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/regression/strings-smoke-tests/java_int_to_string_with_radix/test_hex2.desc
+++ b/regression/strings-smoke-tests/java_int_to_string_with_radix/test_hex2.desc
@@ -1,6 +1,6 @@
 CORE
 Test_hex2.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/regression/strings-smoke-tests/java_int_to_string_with_radix/test_hex3.desc
+++ b/regression/strings-smoke-tests/java_int_to_string_with_radix/test_hex3.desc
@@ -1,6 +1,6 @@
 CORE
 Test_hex3.class
---refine-strings
+--refine-strings --string-max-length 100
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/regression/strings-smoke-tests/java_int_to_string_with_radix/test_octal2.desc
+++ b/regression/strings-smoke-tests/java_int_to_string_with_radix/test_octal2.desc
@@ -1,6 +1,6 @@
 CORE
 Test_octal2.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/regression/strings-smoke-tests/java_int_to_string_with_radix/test_octal3.desc
+++ b/regression/strings-smoke-tests/java_int_to_string_with_radix/test_octal3.desc
@@ -1,6 +1,6 @@
 CORE
 Test_octal3.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/regression/strings-smoke-tests/java_long_to_string_with_radix/test_hex1.desc
+++ b/regression/strings-smoke-tests/java_long_to_string_with_radix/test_hex1.desc
@@ -1,6 +1,6 @@
 CORE
 Test_hex1.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/regression/strings-smoke-tests/java_long_to_string_with_radix/test_hex3.desc
+++ b/regression/strings-smoke-tests/java_long_to_string_with_radix/test_hex3.desc
@@ -1,6 +1,6 @@
 CORE
 Test_hex3.class
---refine-strings
+--refine-strings --string-max-length 100
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/regression/strings-smoke-tests/java_long_to_string_with_radix/test_octal1.desc
+++ b/regression/strings-smoke-tests/java_long_to_string_with_radix/test_octal1.desc
@@ -1,6 +1,6 @@
 CORE
 Test_octal1.class
---refine-strings
+--refine-strings --string-max-length 100
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/regression/strings-smoke-tests/java_long_to_string_with_radix/test_octal2.desc
+++ b/regression/strings-smoke-tests/java_long_to_string_with_radix/test_octal2.desc
@@ -1,6 +1,6 @@
 CORE
 Test_octal2.class
---refine-strings
+--refine-strings --string-max-length 100
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/regression/strings-smoke-tests/java_long_to_string_with_radix/test_octal3.desc
+++ b/regression/strings-smoke-tests/java_long_to_string_with_radix/test_octal3.desc
@@ -1,6 +1,6 @@
 CORE
 Test_octal3.class
---refine-strings
+--refine-strings --string-max-length 100
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/regression/strings-smoke-tests/java_value_of_float/test.desc
+++ b/regression/strings-smoke-tests/java_value_of_float/test.desc
@@ -1,6 +1,6 @@
 CORE
 test.class
---refine-strings --function test.check
+--refine-strings --function test.check --string-max-length 100
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* file test.java line 7 .* SUCCESS$

--- a/regression/strings-smoke-tests/java_value_of_float_2/test.desc
+++ b/regression/strings-smoke-tests/java_value_of_float_2/test.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 test.class
---refine-strings --function test.check
+--refine-strings --function test.check --string-max-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* file test.java line 6 .* SUCCESS$

--- a/regression/strings-smoke-tests/java_value_of_long/test.desc
+++ b/regression/strings-smoke-tests/java_value_of_long/test.desc
@@ -1,6 +1,6 @@
 CORE
 test.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* file test.java line 9 .* SUCCESS$

--- a/regression/strings/StringStartEnd02/test.desc
+++ b/regression/strings/StringStartEnd02/test.desc
@@ -1,6 +1,6 @@
 CORE
 StringStartEnd02.class
---refine-strings --unwind 30
+--refine-strings --unwind 30 --string-max-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion\.1\] .* line 13 .* FAILURE$

--- a/regression/strings/java_append_char/test.desc
+++ b/regression/strings/java_append_char/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_append_char.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/strings/java_case/test.desc
+++ b/regression/strings/java_case/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_case.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion\.1\].* line 8.* FAILURE$

--- a/regression/strings/java_char_array_init/test.desc
+++ b/regression/strings/java_char_array_init/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_init.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 14.* FAILURE$

--- a/regression/strings/java_insert_char/test.desc
+++ b/regression/strings/java_insert_char/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_insert_char.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion\.1\].* line 8.* FAILURE$

--- a/regression/strings/java_insert_char_array/test.desc
+++ b/regression/strings/java_insert_char_array/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_insert_char_array.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion\.1\].* line 12.* FAILURE$

--- a/regression/strings/java_insert_int/test.desc
+++ b/regression/strings/java_insert_int/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_insert_int.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion\.1\].* line 8.* FAILURE$

--- a/regression/strings/java_insert_string/test.desc
+++ b/regression/strings/java_insert_string/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_insert_string.class
---refine-strings
+--refine-strings --string-max-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion\.1\].* line 8.* FAILURE$

--- a/src/solvers/refinement/string_refinement.cpp
+++ b/src/solvers/refinement/string_refinement.cpp
@@ -1140,21 +1140,25 @@ bool string_refinementt::check_axioms()
 
     exprt negaxiom=negation_of_constraint(axiom_in_model);
 
-    debug() << "  - axiom:\n"
-            << "     " << from_expr(ns, "", axiom) << eom;
-    debug() << "  - axiom_in_model:\n"
-            << "     " << from_expr(ns, "", axiom_in_model) << eom;
-    debug() << "  - negated_axiom:\n"
-            << "     " << from_expr(ns, "", negaxiom) << eom;
+    debug() << "  "<< i << ".\n"
+            << "    - axiom:\n"
+            << "       " << from_expr(ns, "", axiom) << eom;
+    debug() << "    - axiom_in_model:\n"
+            << "       " << from_expr(ns, "", axiom_in_model) << eom;
+    debug() << "    - negated_axiom:\n"
+            << "       " << from_expr(ns, "", negaxiom) << eom;
 
-    substitute_array_access(negaxiom, true);
+    exprt with_concretized_arrays=concretize_arrays_in_expression(
+      negaxiom, generator.max_string_length);
+    debug() << "    - negated_axiom_with_concretized_array_access:\n"
+            << "       " << from_expr(ns, "", with_concretized_arrays) << eom;
 
-    debug() << "  - negated_axiom_without_array_access:\n"
-            << "     " << from_expr(ns, "", negaxiom) << eom;
-
+    substitute_array_access(with_concretized_arrays);
+    debug() << "    - negated_axiom_without_array_access:\n"
+            << "       " << from_expr(ns, "", with_concretized_arrays) << eom;
     exprt witness;
 
-    bool is_sat=is_axiom_sat(negaxiom, univ_var, witness);
+    bool is_sat=is_axiom_sat(with_concretized_arrays, univ_var, witness);
 
     if(is_sat)
     {

--- a/src/solvers/refinement/string_refinement.cpp
+++ b/src/solvers/refinement/string_refinement.cpp
@@ -848,6 +848,7 @@ exprt string_refinementt::substitute_array_with_expr(
     exprt else_expr=substitute_array_with_expr(with_expr.old(), index);
     const typet &type=then_expr.type();
     CHECK_RETURN(else_expr.type()==type);
+    CHECK_RETURN(index.type()==with_expr.where().type());
     return if_exprt(
       equal_exprt(index, with_expr.where()), then_expr, else_expr, type);
   }

--- a/src/solvers/refinement/string_refinement.cpp
+++ b/src/solvers/refinement/string_refinement.cpp
@@ -1088,17 +1088,14 @@ static exprt negation_of_constraint(const string_constraintt &axiom)
 /// \return a Boolean
 bool string_refinementt::check_axioms()
 {
-  debug() << "string_refinementt::check_axioms: ==============="
-          << "===========================================" << eom;
-  debug() << "string_refinementt::check_axioms: build the"
-          << " interpretation from the model of the prop_solver" << eom;
+  debug() << "string_refinementt::check_axioms:" << eom;
   debug_model();
 
   // Maps from indexes of violated universal axiom to a witness of violation
   std::map<size_t, exprt> violated;
 
-  debug() << "there are " << universal_axioms.size()
-          << " universal axioms" << eom;
+  debug() << "string_refinement::check_axioms: " << universal_axioms.size()
+          << " universal axioms:" << eom;
   for(size_t i=0; i<universal_axioms.size(); i++)
   {
     const string_constraintt &axiom=universal_axioms[i];
@@ -1112,20 +1109,32 @@ bool string_refinementt::check_axioms()
       univ_var, get(bound_inf), get(bound_sup), get(prem), get(body));
 
     exprt negaxiom=negation_of_constraint(axiom_in_model);
-    debug() << "(string_refinementt::check_axioms) Adding negated constraint: "
-            << from_expr(ns, "", negaxiom) << eom;
-    substitute_array_access(negaxiom);
+
+    debug() << "  - axiom:\n"
+            << "     " << from_expr(ns, "", axiom) << eom;
+    debug() << "  - axiom_in_model:\n"
+            << "     " << from_expr(ns, "", axiom_in_model) << eom;
+    debug() << "  - negated_axiom:\n"
+            << "     " << from_expr(ns, "", negaxiom) << eom;
+
+    substitute_array_access(negaxiom, true);
+
+    debug() << "  - negated_axiom_without_array_access:\n"
+            << "     " << from_expr(ns, "", negaxiom) << eom;
+
     exprt witness;
 
     bool is_sat=is_axiom_sat(negaxiom, univ_var, witness);
 
     if(is_sat)
     {
-      debug() << "string constraint can be violated for "
+      debug() << "  - violated_for: "
               << univ_var.get_identifier()
               << " = " << from_expr(ns, "", witness) << eom;
       violated[i]=witness;
     }
+    else
+      debug() << "  - correct" << eom;
   }
 
   // Maps from indexes of violated not_contains axiom to a witness of violation

--- a/src/solvers/refinement/string_refinement.cpp
+++ b/src/solvers/refinement/string_refinement.cpp
@@ -928,8 +928,7 @@ void string_refinementt::substitute_array_access(exprt &expr) const
 
     if(index_expr.array().id()==ID_with)
     {
-      expr=substitute_array_with_expr(
-        index_expr.array(), index_expr.index());
+      expr=substitute_array_with_expr(index_expr.array(), index_expr.index());
       return;
     }
 

--- a/src/solvers/refinement/string_refinement.cpp
+++ b/src/solvers/refinement/string_refinement.cpp
@@ -289,6 +289,26 @@ bool string_refinementt::add_axioms_for_string_assigns(
   return true;
 }
 
+/// Convert exprt to a specific type. Throw bad_cast if conversion
+/// cannot be performed
+/// Generic case doesn't exist, specialize for different types accordingly
+/// TODO: this should go to util
+template<typename T>
+T expr_cast(const exprt&);
+
+template<>
+std::size_t expr_cast<std::size_t>(const exprt& val_expr)
+{
+  mp_integer val_mb;
+  if(to_integer(val_expr, val_mb))
+    throw std::bad_cast();
+  if(!val_mb.is_long())
+    throw std::bad_cast();
+  if(val_mb<0)
+    throw std::bad_cast();
+  return val_mb.to_long();
+}
+
 /// If the expression is of type string, then adds constants to the index set to
 /// force the solver to pick concrete values for each character, and fill the
 /// maps `found_length` and `found_content`.

--- a/src/solvers/refinement/string_refinement.h
+++ b/src/solvers/refinement/string_refinement.h
@@ -146,11 +146,6 @@ private:
   bool is_valid_string_constraint(const string_constraintt &expr);
 
   exprt simplify_sum(const exprt &f) const;
-  template <typename T1, typename T2>
-  void pad_vector(
-    std::vector<T1> &result,
-    std::set<T2> &initialized,
-    T1 last_concretized) const;
 
   void concretize_string(const exprt &expr);
   void concretize_results();
@@ -164,39 +159,36 @@ private:
 
 exprt substitute_array_lists(exprt expr, size_t string_max_length);
 
-/// Utility function for concretization of strings. Copies concretized values to
-/// the left to initialize the unconcretized indices of concrete_array.
-/// \param concrete_array: the vector to populate
-/// \param initialized: the vector containing the indices of the concretized
-///   values
-/// \param last_concretized: initial value of the last concretized index
-template <typename T1, typename T2>
-void string_refinementt::pad_vector(
-  std::vector<T1> &concrete_array,
-  std::set<T2> &initialized,
-  T1 last_concretized) const
+exprt concretize_arrays_in_expression(
+  exprt expr, std::size_t string_max_length);
+
+/// Convert index-value map to a vector of values. If a value for an
+/// index is not defined, set it to the value referenced by the next higher
+/// index. The length of the resulting vector is the key of the map's
+/// last element + 1
+/// \param index_value: map containing values of specific vector cells
+/// \return Vector containing values as described in the map
+template <typename T>
+std::vector<T> fill_in_map_as_vector(
+  const std::map<std::size_t, T> &index_value)
 {
-  // Pad the concretized values to the left to assign the uninitialized
-  // values of result. The indices greater than concretize_limit are
-  // already assigned to last_concretized.
-  for(auto j=initialized.rbegin(); j!=initialized.rend();)
+  std::vector<T> result;
+  if(!index_value.empty())
   {
-    size_t i=*j;
-    // The leftmost index to pad is the value + 1 of the next element in
-    // 'initialized'. Since we cannot use the binary '+' operator on set
-    // iterators, we must increment the iterator here instead of in the
-    // for loop.
-    j++;
-    size_t leftmost_index_to_pad=(j!=initialized.rend()?*(j)+1:0);
-    // pad until we reach the next initialized index (right to left)
-    while(i>leftmost_index_to_pad)
-      concrete_array[(i--)-1]=last_concretized;
-    INVARIANT(
-      i==leftmost_index_to_pad,
-      string_refinement_invariantt("Loop decrements i until it is not greater "
-        " than leftmost_index_to_pad"));
-    if(i>0)
-      last_concretized=concrete_array[i-1];
+    result.resize(index_value.rbegin()->first+1);
+    for(auto it=index_value.rbegin(); it!=index_value.rend(); ++it)
+    {
+      const std::size_t index=it->first;
+      const T value=it->second;
+      const auto next=std::next(it);
+      const std::size_t leftmost_index_to_pad=
+        next!=index_value.rend()
+        ? next->first+1
+        : 0;
+      for(std::size_t j=leftmost_index_to_pad; j<=index; j++)
+        result[j]=value;
+    }
   }
+  return result;
 }
 #endif

--- a/src/util/expr_iterator.h
+++ b/src/util/expr_iterator.h
@@ -55,7 +55,6 @@ inline bool operator==(
   const depth_iterator_expr_statet &right)
 { return left.it==right.it && left.expr.get()==right.expr.get(); }
 
-
 /// Depth first search iterator base - iterates over supplied expression
 /// and all its operands recursively.
 /// Base class using CRTP
@@ -97,11 +96,19 @@ public:
     return this->downcast();
   }
 
+  depth_iterator_t &next_sibling_or_parent()
+  {
+    PRECONDITION(!m_stack.empty());
+    m_stack.back().it=m_stack.back().end;
+    ++(*this);
+    return this->downcast();
+  }
+
   /// Post-increment operator
   /// Expensive copy. Avoid if possible
   depth_iterator_t operator++(int)
   {
-    depth_iterator_t tmp(*this);
+    depth_iterator_t tmp(this->downcast());
     this->operator++();
     return tmp;
   }

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -24,6 +24,7 @@ SRC += unit_tests.cpp \
        solvers/refinement/string_constraint_generator_valueof/is_digit_with_radix.cpp \
        solvers/refinement/string_constraint_instantiation/instantiate_not_contains.cpp \
        solvers/refinement/string_refinement/substitute_array_list.cpp \
+       solvers/refinement/string_refinement/concretize_array.cpp \
        catch_example.cpp \
        # Empty last line
 

--- a/unit/solvers/refinement/string_refinement/concretize_array.cpp
+++ b/unit/solvers/refinement/string_refinement/concretize_array.cpp
@@ -1,0 +1,56 @@
+/*******************************************************************\
+
+ Module: Unit tests for concretize_array_expression in
+   solvers/refinement/string_refinement.cpp
+
+ Author: DiffBlue Limited. All rights reserved.
+
+\*******************************************************************/
+
+#include <catch.hpp>
+
+#include <util/arith_tools.h>
+#include <util/std_types.h>
+#include <util/std_expr.h>
+#include <solvers/refinement/string_refinement.h>
+
+SCENARIO("concretize_array_expression",
+  "[core][solvers][refinement][string_refinement]")
+{
+  const typet char_type=unsignedbv_typet(16);
+  const typet int_type=signedbv_typet(32);
+  const exprt index1=from_integer(1, int_type);
+  const exprt charx=from_integer('x', char_type);
+  const exprt index4=from_integer(4, int_type);
+  const exprt chary=from_integer('y', char_type);
+  const exprt index100=from_integer(100, int_type);
+  const exprt char0=from_integer('0', char_type);
+  const exprt index2=from_integer(2, int_type);
+  array_typet array_type(char_type, infinity_exprt(int_type));
+
+  // input_expr is
+  // `'0' + (ARRAY_OF(0) WITH [1:=x] WITH [4:=y] WITH [100:=z])[2]`
+  const plus_exprt input_expr(
+    from_integer('0', char_type),
+    index_exprt(
+      with_exprt(
+        with_exprt(
+          with_exprt(
+            array_of_exprt(from_integer(0, char_type), array_type),
+            index1,
+            charx),
+          index4,
+          chary),
+        index100,
+        from_integer('z', char_type)),
+      index2));
+
+  // String max length is 50, so index 100 should get ignored.
+  const exprt concrete=concretize_arrays_in_expression(input_expr, 50);
+
+  // The expected result is `'0' + { 'x', 'x', 'y', 'y', 'y' }`
+  array_exprt array(array_type);
+  array.operands()={charx, charx, chary, chary, chary};
+  const plus_exprt expected(char0, index_exprt(array, index2));
+  REQUIRE(concrete==expected);
+}

--- a/unit/util/expr_iterator.cpp
+++ b/unit/util/expr_iterator.cpp
@@ -133,3 +133,26 @@ TEST_CASE("Iterate over a 3-level tree, mutate - set all types to ID_symbol")
     REQUIRE(expr.get().id()==ID_symbol);
   }
 }
+
+TEST_CASE("next_sibling_or_parent, next sibling")
+{
+  std::vector<exprt> input(4);
+  input[1].operands()={ input[3] };
+  input[2].id(ID_int);
+  input[0].operands()={ input[1], input[2] };
+  auto it=input[0].depth_begin();
+  it++;
+  it.next_sibling_or_parent();
+  REQUIRE(*it==input[2]);
+}
+
+TEST_CASE("next_sibling_or_parent, next parent ")
+{
+  std::vector<exprt> input(3);
+  input[1].operands()={ input[2] };
+  input[0].operands()={ input[1] };
+  auto it=input[0].depth_begin();
+  it++;
+  it.next_sibling_or_parent();
+  REQUIRE(it==input[0].depth_end());
+}


### PR DESCRIPTION
This improves the method `check_axioms` of the string solver by padding the result gotten from the solver in a similar way to what is used in the `concretize` method.
In practice this means that the solver can find more quickly strings that are correct solutions once concretized.