### PR TITLE
Avoid zombie and print diagnostic output if run/execve fails

### DIFF
--- a/regression/goto-gcc/run_diagnostic/main.i
+++ b/regression/goto-gcc/run_diagnostic/main.i
@@ -1,0 +1,4 @@
+int main()
+{
+  return 0;
+}

--- a/regression/goto-gcc/run_diagnostic/test.desc
+++ b/regression/goto-gcc/run_diagnostic/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.i
+--native-compiler /no/such/tool
+^EXIT=1$
+^SIGNAL=0$
+^execvp /no/such/tool failed: No such file or directory$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/regression/goto-gcc/run_diagnostic/test.desc
+++ b/regression/goto-gcc/run_diagnostic/test.desc
@@ -5,5 +5,6 @@ main.i
 ^SIGNAL=0$
 ^execvp /no/such/tool failed: No such file or directory$
 --
+^Remove failed
 ^warning: ignoring
 ^CONVERSION ERROR$

--- a/src/util/run.cpp
+++ b/src/util/run.cpp
@@ -133,7 +133,7 @@ int run(
 
       /* usually no return */
       perror(std::string("execvp "+what+" failed").c_str());
-      return 1;
+      exit(1);
     }
     else /* fork() returns new pid to the parent process */
     {

--- a/src/util/run.cpp
+++ b/src/util/run.cpp
@@ -127,9 +127,12 @@ int run(
         dup2(stdin_fd, STDIN_FILENO);
       if(stdout_fd!=STDOUT_FILENO)
         dup2(stdout_fd, STDOUT_FILENO);
+
+      errno=0;
       execvp(what.c_str(), _argv.data());
 
       /* usually no return */
+      perror(std::string("execvp "+what+" failed").c_str());
       return 1;
     }
     else /* fork() returns new pid to the parent process */


### PR DESCRIPTION
This helped debugging why goto-gcc failed in a semi-broken set up.