### PR TITLE
[develop->master] Add non-const target comparator

### DIFF
--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -76,10 +76,17 @@ public:
       it!=(program).instructions.end(); it++)
 
 inline bool operator<(
-  const goto_programt::const_targett i1,
-  const goto_programt::const_targett i2)
+  const goto_programt::const_targett &i1,
+  const goto_programt::const_targett &i2)
 {
   return order_const_target<codet, exprt>(i1, i2);
+}
+
+inline bool operator<(
+  const goto_programt::targett &i1,
+  const goto_programt::targett &i2)
+{
+  return &(*i1)<&(*i2);
 }
 
 // NOLINTNEXTLINE(readability/identifiers)


### PR DESCRIPTION
I tried building with `CXXFLAGS=-D_GLIBCXX_DEBUG` and got a compile error, because the compiler couldn't convert between const and non-const "safe"-iterators in one place. Adding an explicit comparator for non-const iterators solves the problem.