### PR TITLE
Refactor, fix and document jar_filet class

### DIFF
--- a/src/java_bytecode/Makefile
+++ b/src/java_bytecode/Makefile
@@ -25,6 +25,7 @@ SRC = bytecode_info.cpp \
       java_string_library_preprocess.cpp \
       java_types.cpp \
       java_utils.cpp \
+      mz_zip_archive.cpp \
       select_pointer_type.cpp \
       # Empty last line
 

--- a/src/java_bytecode/jar_file.h
+++ b/src/java_bytecode/jar_file.h
@@ -1,110 +1,48 @@
 /*******************************************************************\
 
-Module: JAR File Reading
+Module: Jar file reader
 
-Author: Daniel Kroening, kroening@kroening.com
+Author: Diffblue Ltd
 
 \*******************************************************************/
-
-/// \file
-/// JAR File Reading
 
 #ifndef CPROVER_JAVA_BYTECODE_JAR_FILE_H
 #define CPROVER_JAVA_BYTECODE_JAR_FILE_H
 
-#define _LARGEFILE64_SOURCE 1
-#include "miniz/miniz.h"
-
+#include <unordered_map>
+#include <memory>
 #include <string>
 #include <vector>
-#include <map>
-#include <regex>
-#include <util/message.h>
+#include "mz_zip_archive.h"
 
-#include "java_class_loader_limit.h"
+class java_class_loader_limitt;
 
-/// An in-memory representation of a JAR file, consisting of a handler to a zip
-/// file (field \ref zip) and a map from file names inside the zip file to the
-/// index they occupy in the root directory (field \ref filtered_jar).
-///
-/// Both fields are initialize by a call to open(). Method get_entry() reads a
-/// file from the zip and returns it.
-class jar_filet:public messaget
+/// Class representing a .jar archive
+class jar_filet final
 {
 public:
-  jar_filet():
-    mz_ok(false)
-    // `zip` will be initialized by open()
-  {
-  }
-
-  ~jar_filet();
-
-  /// Initializes \ref zip to store the JAR file pointed by \p filepath and
-  /// loads the map \ref filtered_jar with the .class names allowed by \p limit.
-  void open(java_class_loader_limitt &limit, const std::string &filepath);
-
-  /// Test for error; 'true' means we are good.
-  explicit operator bool() const { return mz_ok; }
-
-  /// Reads the \ref zip field and returns a string storing the data contained
-  /// in file \p name.
-  std::string get_entry(const irep_idt &name);
-
-  /// Maps the names of the files stored in the JAR file to the index they
-  /// occupy (starting from 0) in the JAR central directory.  Populated by
-  /// method open() above.
-  typedef std::map<irep_idt, size_t> filtered_jart;
-  filtered_jart filtered_jar;
-
-  typedef std::map<std::string, std::string> manifestt;
-  manifestt get_manifest();
-
-protected:
-  /// A handle representing the zip file
-  mz_zip_archive zip;
-
-  /// True iff the \ref zip field has been correctly initialized with a JAR file
-  bool mz_ok;
-};
-
-/// A pool of jar_filet objects, indexed by the filesystem path name used to
-/// load that jar_filet.
-///
-/// The state of the class is maintained by the field \ref file_map, a std::map
-/// associating the path of a .jar file with its in-memory representation.
-/// A call to
-///
-/// ```
-///   operator()(limit, path)
-/// ```
-///
-/// will either return a previously loaded jar_filet, if it is found in the map,
-/// or will load that file (using jar_filet::open) and return a newly created
-/// jar_filet.
-class jar_poolt:public messaget
-{
-public:
-  jar_filet &operator()(
-    java_class_loader_limitt &class_loader_limit,
-    const std::string &file_name)
-  {
-    file_mapt::iterator it=file_map.find(file_name);
-    if(it==file_map.end())
-    {
-      jar_filet &jar_file=file_map[file_name];
-      jar_file.set_message_handler(get_message_handler());
-      jar_file.open(class_loader_limit, file_name);
-      return jar_file;
-    }
-    else
-      return file_map[file_name];
-  }
-
-protected:
-  /// A map from filesystem paths to jar_filet objects
-  typedef std::map<std::string, jar_filet> file_mapt;
-  file_mapt file_map;
+  /// Open java file for reading
+  /// \param limit Object limiting number of loaded .class files
+  /// \param filename Name of the file
+  /// \throw Throws std::runtime_error if file cannot be opened
+  jar_filet(java_class_loader_limitt &limit, const std::string &filename);
+  jar_filet(const jar_filet &)=delete;
+  jar_filet &operator=(const jar_filet &)=delete;
+  jar_filet(jar_filet &&);
+  jar_filet &operator=(jar_filet &&);
+  ~jar_filet()=default;
+  /// Get contents of a file in the jar archive.
+  /// Terminates the program if file doesn't exist
+  /// \param filename Name of the file in the archive
+  std::string get_entry(const std::string &filename);
+  /// Get contents of the Manifest file in the jar archive
+  std::unordered_map<std::string, std::string> get_manifest();
+  /// Get list of filenames in the archive
+  std::vector<std::string> filenames() const;
+private:
+  mz_zip_archivet m_zip_archive;
+  /// Map of filename to the file index in the zip archive
+  std::unordered_map<std::string, size_t> m_name_to_index;
 };
 
 #endif // CPROVER_JAVA_BYTECODE_JAR_FILE_H

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -138,8 +138,7 @@ bool java_bytecode_languaget::parse(
       java_cp_include_files);
     if(config.java.main_class.empty())
     {
-      // load the .jar file and retrieve its manifest
-      jar_filet::manifestt manifest=
+      auto manifest=
         java_class_loader.jar_pool(class_loader_limit, path).get_manifest();
       std::string manifest_main_class=manifest["Main-Class"];
 

--- a/src/java_bytecode/java_class_loader.cpp
+++ b/src/java_bytecode/java_class_loader.cpp
@@ -68,7 +68,6 @@ void java_class_loadert::set_java_cp_include_files(
   std::string &_java_cp_include_files)
 {
   java_cp_include_files=_java_cp_include_files;
-  jar_pool.set_message_handler(get_message_handler());
 }
 
 java_bytecode_parse_treet &java_class_loadert::get_parse_tree(
@@ -188,28 +187,27 @@ void java_class_loadert::read_jar_file(
   if(jar_map.find(file)!=jar_map.end())
     return;
 
-  // read the .jar file, store it in memory and return a jar_filet representing
-  // it
-  jar_filet &jar_file=jar_pool(class_loader_limit, id2string(file));
-
-  if(!jar_file)
+  std::vector<std::string> filenames;
+  try
+  {
+    filenames=this->jar_pool(class_loader_limit, id2string(file)).filenames();
+  }
+  catch(const std::runtime_error &)
   {
     error() << "failed to open JAR file `" << file << "'" << eom;
     return;
   }
-
   debug() << "adding JAR file `" << file << "'" << eom;
 
   // create a new entry in the map and initialize using the list of file names
   // that were retained in the jar_filet by the class_loader_limit filter
   auto &jm=jar_map[file];
-  for(auto &jar_entry : jar_file.filtered_jar)
+  for(auto &file_name : filenames)
   {
-    std::string file_name=id2string(jar_entry.first);
-
     // does it end on .class?
     if(has_suffix(file_name, ".class"))
     {
+      status() << "read class file " << file_name << " from " << file << eom;
       irep_idt class_name=file_to_class_name(file_name);
 
       // record
@@ -264,4 +262,19 @@ std::string java_class_loadert::class_name_to_file(const irep_idt &class_name)
   result+=".class";
 
   return result;
+}
+
+jar_filet &java_class_loadert::jar_pool(
+  java_class_loader_limitt &class_loader_limit,
+  const std::string &file_name)
+{
+  const auto it=m_archives.find(file_name);
+  if(it==m_archives.end())
+  {
+    // VS: Can't construct in place
+    auto file=jar_filet(class_loader_limit, file_name);
+    return m_archives.emplace(file_name, std::move(file)).first->second;
+  }
+  else
+    return it->second;
 }

--- a/src/java_bytecode/java_class_loader.h
+++ b/src/java_bytecode/java_class_loader.h
@@ -53,9 +53,11 @@ public:
   typedef std::map<irep_idt, java_bytecode_parse_treet> class_mapt;
   class_mapt class_map;
 
-  /// Maps .jar filesystem paths to jar_filet objects (stored inside).
-  /// Responsible for loading new jar files when they are first referenced.
-  jar_poolt jar_pool;
+  /// Load jar archive(from cache if already loaded)
+  /// \param limit
+  /// \param filename name of the file
+  jar_filet &jar_pool(java_class_loader_limitt &limit,
+                      const std::string &filename);
 
   /// An object of this class represents the information of _a single JAR file_
   /// that is relevant for a class loader: a map associating logical class names
@@ -90,6 +92,8 @@ public:
   /// java_class_loader_limitt::setup_class_load_limit() for further
   /// information.
   std::string java_cp_include_files;
+private:
+  std::map<std::string, jar_filet> m_archives;
 };
 
 #endif // CPROVER_JAVA_BYTECODE_JAVA_CLASS_LOADER_H

--- a/src/java_bytecode/mz_zip_archive.cpp
+++ b/src/java_bytecode/mz_zip_archive.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************\
+
+Module: mz_zip library wrapper
+
+Author: Diffblue Ltd
+
+\*******************************************************************/
+
+#include "mz_zip_archive.h"
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <algorithm>
+#define _LARGEFILE64_SOURCE 1
+#include <miniz/miniz.h>
+
+// Original struct is an anonymous struct with a typedef, This is
+// required to remove internals from the header file
+class mz_zip_archive_statet final:public mz_zip_archive
+{
+public:
+  explicit mz_zip_archive_statet(const std::string &filename):
+    mz_zip_archive({ })
+  {
+    if(MZ_TRUE!=mz_zip_reader_init_file(this, filename.data(), 0))
+      throw std::runtime_error("MZT: Could not load a file: "+filename);
+  }
+  mz_zip_archive_statet(const mz_zip_archive_statet &)=delete;
+  mz_zip_archive_statet(mz_zip_archive_statet &&)=delete;
+  mz_zip_archive_statet &operator=(const mz_zip_archive_statet &)=delete;
+  mz_zip_archive_statet &operator=(mz_zip_archive_statet &&)=delete;
+  ~mz_zip_archive_statet()
+  {
+    mz_zip_reader_end(this);
+  }
+};
+
+static_assert(sizeof(mz_uint)<=sizeof(size_t),
+              "size_t cannot store mz_zip file ids, choose a larger type");
+
+mz_zip_archivet::mz_zip_archivet(const std::string &filename):
+  m_state(new mz_zip_archive_statet(filename)) { }
+
+// VS Compatibility
+mz_zip_archivet::mz_zip_archivet(mz_zip_archivet &&other):
+  m_state(std::move(other.m_state)) { }
+
+// Has to be defined here because header is incomplete
+mz_zip_archivet::~mz_zip_archivet()=default;
+
+// VS Compatibility
+mz_zip_archivet &mz_zip_archivet::operator=(mz_zip_archivet &&other)
+{
+  m_state=std::move(other.m_state);
+  return *this;
+}
+
+size_t mz_zip_archivet::get_num_files()
+{
+  return mz_zip_reader_get_num_files(m_state.get());
+}
+
+std::string mz_zip_archivet::get_filename(const size_t index)
+{
+  const auto id=static_cast<mz_uint>(index);
+  std::vector<char> buffer;
+  buffer.resize(mz_zip_reader_get_filename(m_state.get(), id, nullptr, 0));
+  mz_zip_reader_get_filename(m_state.get(), id, buffer.data(), buffer.size());
+  // Buffer may contain junk returned after \0
+  const auto null_char_it=std::find(buffer.cbegin(), buffer.cend(), '\0');
+  return { buffer.cbegin(), null_char_it };
+}
+
+std::string mz_zip_archivet::extract(const size_t index)
+{
+  const auto id=static_cast<mz_uint>(index);
+  mz_zip_archive_file_stat file_stat={ };
+  const mz_bool stat_ok=mz_zip_reader_file_stat(m_state.get(), id, &file_stat);
+  if(stat_ok==MZ_TRUE)
+  {
+    std::vector<char> buffer(file_stat.m_uncomp_size);
+    const mz_bool read_ok=mz_zip_reader_extract_to_mem(
+      m_state.get(), id, buffer.data(), buffer.size(), 0);
+    if(read_ok==MZ_TRUE)
+      return { buffer.cbegin(), buffer.cend() };
+  }
+  throw std::runtime_error("Could not extract the file");
+}
+

--- a/src/java_bytecode/mz_zip_archive.h
+++ b/src/java_bytecode/mz_zip_archive.h
@@ -1,0 +1,51 @@
+/*******************************************************************\
+
+Module: mz_zip library wrapper
+
+Author: Diffblue Ltd
+
+\*******************************************************************/
+
+#ifndef CPROVER_JAVA_BYTECODE_MZ_ZIP_ARCHIVE_H
+#define CPROVER_JAVA_BYTECODE_MZ_ZIP_ARCHIVE_H
+
+#include <string>
+#include <memory>
+
+/// State of the mz_zip_archive object
+class mz_zip_archive_statet;
+
+/// Thin object-oriented wrapper around the MZ Zip library
+/// Zip file reader and extractor. Not thread safe. Move only.
+class mz_zip_archivet final
+{
+public:
+  /// Open a zip archive
+  /// \param filename Path of the zip archive
+  /// \throw Throws std::runtime_error if file cannot be opened
+  explicit mz_zip_archivet(const std::string &filename);
+  mz_zip_archivet(const mz_zip_archivet &)=delete;
+  mz_zip_archivet &operator=(const mz_zip_archivet &)=delete;
+  /// Move constructor. Doesn't throw. Leaves other object invalidated.
+  mz_zip_archivet(mz_zip_archivet &&other);
+  /// Move assignment. Doesn't throw. Replaces this object's state
+  /// with other object's state. Invalidates other object.
+  mz_zip_archivet &operator=(mz_zip_archivet &&other);
+  ~mz_zip_archivet();
+
+  /// Get number of files in the archive
+  size_t get_num_files();
+  /// Get file name of nth file in the archive
+  /// \param index id of the file in the archive
+  /// \return Name of the file in the archive
+  std::string get_filename(size_t index);
+  /// Get contents of nth file in the archive
+  /// \param index id of the file in the archive
+  /// \throw Throws std::runtime_error if file cannot be extracted
+  /// \return Contents of the file in the archive
+  std::string extract(size_t index);
+private:
+  std::unique_ptr<mz_zip_archive_statet> m_state;
+};
+
+#endif // CPROVER_JAVA_BYTECODE_MZ_ZIP_ARCHIVE_H


### PR DESCRIPTION

Architecturally:
 - Separates a discrete thin wrapper around `mz_zip_archive` C library
 - Preserves the original interface of `jar_filet` excluding object construction
 - Drops dependence on `messaget`, `irept` and `dstringt` and removes C header slightly lowering build time
 - Inlines  `jar_poolt` and debug messages into `java_class_loadert`
 - Protects the class against accidental inheritance

Fixes sleeping bugs:
 - Potential memory leak by using bare `new`
 - Copying `jar_poolt` or `jar_filet` (which contained state of the C library) would leave the program in an invalid state
 - Proper white space trimming of the values of the manifest file

Documents `jar_filet` and the `mz_zip_archivet` wrapper.