### PR TITLE
Removing unreachable and unused code in string constraint generation

### DIFF
--- a/src/solvers/refinement/string_constraint_generator.h
+++ b/src/solvers/refinement/string_constraint_generator.h
@@ -73,8 +73,6 @@ public:
   symbol_exprt fresh_boolean(const irep_idt &prefix);
   string_exprt fresh_string(const refined_string_typet &type);
   string_exprt get_string_expr(const exprt &expr);
-  string_exprt convert_java_string_to_string_exprt(
-    const exprt &underlying);
   plus_exprt plus_exprt_with_overflow_check(const exprt &op1, const exprt &op2);
 
   // Maps unresolved symbols to the string_exprt that was created for them
@@ -198,8 +196,6 @@ private:
   string_exprt add_axioms_for_insert_double(
     const function_application_exprt &f);
   string_exprt add_axioms_for_insert_float(const function_application_exprt &f);
-  string_exprt add_axioms_for_insert_char_array(
-    const function_application_exprt &f);
   string_exprt add_axioms_from_literal(const function_application_exprt &f);
   string_exprt add_axioms_from_int(const function_application_exprt &f);
   string_exprt add_axioms_from_int(
@@ -222,12 +218,6 @@ private:
   string_exprt add_axioms_from_char(const function_application_exprt &f);
   string_exprt add_axioms_from_char(
     const exprt &i, const refined_string_typet &ref_type);
-  string_exprt add_axioms_from_char_array(const function_application_exprt &f);
-  string_exprt add_axioms_from_char_array(
-    const exprt &length,
-    const exprt &data,
-    const exprt &offset,
-    const exprt &count);
   exprt add_axioms_for_index_of(
     const string_exprt &str,
     const exprt &c,
@@ -296,13 +286,8 @@ private:
     const string_exprt &expr);
   string_exprt add_axioms_for_trim(const function_application_exprt &expr);
 
-  // Add axioms corresponding to the String.valueOf([CII) function
-  // TODO: not working correctly at the moment
-  string_exprt add_axioms_for_value_of(const function_application_exprt &f);
-
   string_exprt add_axioms_for_code_point(
     const exprt &code_point, const refined_string_typet &ref_type);
-  string_exprt add_axioms_for_java_char_array(const exprt &char_array);
   exprt add_axioms_for_char_pointer(const function_application_exprt &fun);
   string_exprt add_axioms_for_if(const if_exprt &expr);
   exprt add_axioms_for_char_literal(const function_application_exprt &f);

--- a/src/solvers/refinement/string_constraint_generator_insert.cpp
+++ b/src/solvers/refinement/string_constraint_generator_insert.cpp
@@ -139,38 +139,3 @@ string_exprt string_constraint_generatort::add_axioms_for_insert_float(
   string_exprt s2=add_axioms_for_string_of_float(args(f, 3)[2], ref_type);
   return add_axioms_for_insert(s1, s2, args(f, 3)[1]);
 }
-
-/// add axioms corresponding to the StringBuilder.insert:(I[CII) and
-/// StringBuilder.insert:(I[C) java functions
-/// \par parameters: function application with 4 arguments plus two optional
-///   arguments:
-/// a string, an offset index, a length, data array, an offset and a
-/// count
-/// \return a new string expression
-string_exprt string_constraint_generatort::add_axioms_for_insert_char_array(
-  const function_application_exprt &f)
-{
-  exprt offset;
-  exprt count;
-  if(f.arguments().size()==6)
-  {
-    offset=f.arguments()[4];
-    count=f.arguments()[5];
-  }
-  else
-  {
-    INVARIANT(
-      f.arguments().size()==4,
-      string_refinement_invariantt("f must have 4 or 6 arguments and the case "
-        "of 6 arguments is already handled"));
-    count=f.arguments()[2];
-    offset=from_integer(0, count.type());
-  }
-
-  string_exprt str=get_string_expr(f.arguments()[0]);
-  const exprt &length=f.arguments()[2];
-  const exprt &data=f.arguments()[3];
-  string_exprt arr=add_axioms_from_char_array(
-    length, data, offset, count);
-  return add_axioms_for_insert(str, arr, f.arguments()[1]);
-}

--- a/src/solvers/refinement/string_constraint_generator_valueof.cpp
+++ b/src/solvers/refinement/string_constraint_generator_valueof.cpp
@@ -27,7 +27,7 @@ string_exprt string_constraint_generatort::add_axioms_from_int(
 {
   const refined_string_typet &ref_type=to_refined_string_type(expr.type());
   PRECONDITION(expr.arguments().size()>=1);
-  if (expr.arguments().size()==1)
+  if(expr.arguments().size()==1)
   {
     return add_axioms_from_int(expr.arguments()[0], ref_type);
   }
@@ -48,7 +48,7 @@ string_exprt string_constraint_generatort::add_axioms_from_long(
 {
   const refined_string_typet &ref_type=to_refined_string_type(expr.type());
   PRECONDITION(expr.arguments().size()>=1);
-  if (expr.arguments().size()==1)
+  if(expr.arguments().size()==1)
   {
     return add_axioms_from_int(expr.arguments()[0], ref_type);
   }
@@ -377,46 +377,6 @@ string_exprt string_constraint_generatort::add_axioms_from_char(
   return res;
 }
 
-/// Add axioms corresponding to the String.valueOf([C) and String.valueOf([CII)
-/// functions.
-/// \param f: function application with one or three arguments
-/// \return a new string expression
-string_exprt string_constraint_generatort::add_axioms_for_value_of(
-  const function_application_exprt &f)
-{
-  const function_application_exprt::argumentst &args=f.arguments();
-  if(args.size()==3)
-  {
-    const refined_string_typet &ref_type=to_refined_string_type(f.type());
-    string_exprt res=fresh_string(ref_type);
-    exprt char_array=args[0];
-    exprt offset=args[1];
-    exprt count=args[2];
-
-    // We add axioms:
-    // a1 : |res| = count
-    // a2 : forall idx<count, str[idx+offset]=res[idx]
-
-    string_exprt str=add_axioms_for_java_char_array(char_array);
-    axioms.push_back(res.axiom_for_has_length(count));
-
-    symbol_exprt idx=fresh_univ_index(
-      "QA_index_value_of", ref_type.get_index_type());
-    equal_exprt eq(str[plus_exprt(idx, offset)], res[idx]);
-    string_constraintt a2(idx, count, eq);
-    axioms.push_back(a2);
-    return res;
-  }
-  else
-  {
-    INVARIANT(
-      args.size()==1,
-      string_refinement_invariantt("f can only have 1 or 3 arguments and the "
-        "case of 3 has been handled"));
-    return add_axioms_for_java_char_array(args[0]);
-  }
-}
-
 /// Add axioms making the return value true if the given string is a correct
 /// number in the given radix
 /// \param str: string expression
@@ -428,8 +388,6 @@ void string_constraint_generatort::add_axioms_for_correct_number_format(
   const refined_string_typet &ref_type=to_refined_string_type(str.type());
   const typet &char_type=ref_type.get_char_type();
   const typet &index_type=ref_type.get_index_type();
-  exprt zero_char=constant_char('0', char_type);
-  exprt nine_char=constant_char('9', char_type);
   exprt minus_char=constant_char('-', char_type);
   exprt plus_char=constant_char('+', char_type);
 
@@ -665,7 +623,8 @@ exprt is_digit_with_radix_lower_case(
         binary_relation_exprt(chr, ID_le, nine_char)),
         and_exprt(
           binary_relation_exprt(chr, ID_ge, a_char),
-          binary_relation_exprt(chr, ID_lt, plus_exprt(a_char, radix_minus_ten))));
+          binary_relation_exprt(
+            chr, ID_lt, plus_exprt(a_char, radix_minus_ten))));
 
     return if_exprt(
       binary_relation_exprt(radix_char_type, ID_le, ten_char_type),


### PR DESCRIPTION
This should not affect the behaviour of CBMC as it only removes functions that were never called, and some style changes to make the linter happy.