### PR TITLE
C++ front end fixes [blocks: #2554]

### DIFF
--- a/regression/cbmc-cpp/CMakeLists.txt
+++ b/regression/cbmc-cpp/CMakeLists.txt
@@ -4,6 +4,6 @@ add_test_pl_tests(
 )
 else()
 add_test_pl_tests(
-    "$<TARGET_FILE:cbmc>"
+    "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation"
 )
 endif()

--- a/regression/cbmc-cpp/Makefile
+++ b/regression/cbmc-cpp/Makefile
@@ -10,10 +10,10 @@ else
 endif
 
 test:
-	@../test.pl -e -p -c ../../../src/cbmc/cbmc $(gcc_only)
+	@../test.pl -e -p -c "../../../src/cbmc/cbmc --validate-goto-model --validate-ssa-equation" $(gcc_only)
 
 tests.log: ../test.pl
-	@../test.pl -e -p -c ../../../src/cbmc/cbmc $(gcc_only)
+	@../test.pl -e -p -c "../../../src/cbmc/cbmc --validate-goto-model --validate-ssa-equation" $(gcc_only)
 
 show:
 	@for dir in *; do \

--- a/regression/goto-cc-cbmc/chain.sh
+++ b/regression/goto-cc-cbmc/chain.sh
@@ -6,13 +6,14 @@ is_windows=$3
 
 options=${*:4:$#-4}
 name=${*:$#}
-name=${name%.c}
+base_name=${name%.c}
+base_name=${base_name%.cpp}
 
 if [[ "${is_windows}" == "true" ]]; then
-  "${goto_cc}" "${name}.c"
-  mv "${name}.exe" "${name}.gb"
+  "${goto_cc}" "${name}"
+  mv "${base_name}.exe" "${base_name}.gb"
 else
-  "${goto_cc}" "${name}.c" -o "${name}.gb"
+  "${goto_cc}" "${name}" -o "${base_name}.gb"
 fi
 
-"${cbmc}" "${name}.gb" ${options}
+"${cbmc}" "${base_name}.gb" ${options}

--- a/regression/goto-cc-cbmc/cpp/main.cpp
+++ b/regression/goto-cc-cbmc/cpp/main.cpp
@@ -1,0 +1,4 @@
+int main()
+{
+  return 0;
+}

--- a/regression/goto-cc-cbmc/cpp/test.desc
+++ b/regression/goto-cc-cbmc/cpp/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.cpp
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/systemc/CMakeLists.txt
+++ b/regression/systemc/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_test_pl_tests(
-    "$<TARGET_FILE:cbmc>"
+    "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation"
 )

--- a/regression/systemc/Makefile
+++ b/regression/systemc/Makefile
@@ -1,10 +1,10 @@
 default: tests.log
 
 test:
-	@../test.pl -e -p -c ../../../src/cbmc/cbmc
+	@../test.pl -e -p -c "../../../src/cbmc/cbmc --validate-goto-model --validate-ssa-equation"
 
 tests.log: ../test.pl
-	@../test.pl -e -p -c ../../../src/cbmc/cbmc
+	@../test.pl -e -p -c "../../../src/cbmc/cbmc --validate-goto-model --validate-ssa-equation"
 
 show:
 	@for dir in *; do \

--- a/src/cpp/cpp_declarator_converter.cpp
+++ b/src/cpp/cpp_declarator_converter.cpp
@@ -460,11 +460,6 @@ symbolt &cpp_declarator_convertert::convert_new_symbol(
   symbol.is_macro=is_typedef && !is_template_parameter;
   symbol.pretty_name=pretty_name;
 
-  // Constant? These are propagated.
-  if(symbol.type.get_bool(ID_C_constant) &&
-     symbol.value.is_not_nil())
-    symbol.is_macro=true;
-
   if(is_code && !symbol.is_type)
   {
     // it is a function

--- a/src/cpp/cpp_declarator_converter.cpp
+++ b/src/cpp/cpp_declarator_converter.cpp
@@ -302,7 +302,8 @@ void cpp_declarator_convertert::combine_types(
         if(symbol.value.is_nil())
         {
           symbol_parameter.set_base_name(decl_parameter.get_base_name());
-          symbol_parameter.set_identifier(decl_parameter.get_identifier());
+          // set an empty identifier when no body is available
+          symbol_parameter.set_identifier(irep_idt());
           symbol_parameter.add_source_location()=
             decl_parameter.source_location();
         }
@@ -470,6 +471,13 @@ symbolt &cpp_declarator_convertert::convert_new_symbol(
 
     if(member_spec.is_inline())
       to_code_type(symbol.type).set_inlined(true);
+
+    if(symbol.value.is_nil())
+    {
+      // we don't need the identifiers
+      for(auto &parameter : to_code_type(symbol.type).parameters())
+        parameter.set_identifier(irep_idt());
+    }
   }
   else
   {

--- a/src/cpp/cpp_instantiate_template.cpp
+++ b/src/cpp/cpp_instantiate_template.cpp
@@ -54,6 +54,16 @@ std::string cpp_typecheckt::template_suffix(
     else // expression
     {
       exprt e=expr;
+
+      if(e.id() == ID_symbol)
+      {
+        const symbol_exprt &s = to_symbol_expr(e);
+        const symbolt &symbol = lookup(s.get_identifier());
+
+        if(cpp_is_pod(symbol.type) && symbol.type.get_bool(ID_C_constant))
+          e = symbol.value;
+      }
+
       make_constant(e);
 
       // this must be a constant, which includes true/false

--- a/src/cpp/cpp_language.cpp
+++ b/src/cpp/cpp_language.cpp
@@ -20,6 +20,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <util/get_base_name.h>
 
 #include <linking/linking.h>
+#include <linking/remove_internal_symbols.h>
 
 #include <ansi-c/ansi_c_entry_point.h>
 #include <ansi-c/c_preprocess.h>
@@ -131,6 +132,8 @@ bool cpp_languaget::typecheck(
   if(cpp_typecheck(
       cpp_parse_tree, new_symbol_table, module, get_message_handler()))
     return true;
+
+  remove_internal_symbols(new_symbol_table, get_message_handler(), false);
 
   return linking(symbol_table, new_symbol_table, get_message_handler());
 }

--- a/src/cpp/cpp_typecheck_enum_type.cpp
+++ b/src/cpp/cpp_typecheck_enum_type.cpp
@@ -63,6 +63,8 @@ void cpp_typecheckt::typecheck_enum_body(symbolt &enum_symbol)
     symbol.type=enum_tag_type;
     symbol.is_type=false;
     symbol.is_macro=true;
+    symbol.is_file_local = true;
+    symbol.is_thread_local = true;
 
     symbolt *new_symbol;
     if(symbol_table.move(symbol, new_symbol))

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -22,6 +22,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <util/c_types.h>
 #include <util/mathematical_types.h>
 #include <util/prefix.h>
+#include <util/simplify_expr.h>
 #include <util/std_expr.h>
 #include <util/std_types.h>
 #include <util/string_constant.h>
@@ -1046,6 +1047,26 @@ struct_tag_typet cpp_typecheck_resolvet::disambiguate_template_classes(
         source_location,
         primary_template_symbol,
         full_template_args);
+
+    for(auto &arg : full_template_args_tc.arguments())
+    {
+      if(arg.id() == ID_type)
+        continue;
+      if(arg.id() == ID_symbol)
+      {
+        const symbol_exprt &s = to_symbol_expr(arg);
+        const symbolt &symbol = cpp_typecheck.lookup(s.get_identifier());
+
+        if(
+          cpp_typecheck.cpp_is_pod(symbol.type) &&
+          symbol.type.get_bool(ID_C_constant))
+        {
+          arg = symbol.value;
+        }
+      }
+      simplify(arg, cpp_typecheck);
+    }
+
     // go back to where we used to be
   }
 

--- a/src/linking/remove_internal_symbols.cpp
+++ b/src/linking/remove_internal_symbols.cpp
@@ -95,6 +95,12 @@ void remove_internal_symbols(
   special.insert(CPROVER_PREFIX "deallocated");
   special.insert(CPROVER_PREFIX "dead_object");
   special.insert(CPROVER_PREFIX "rounding_mode");
+  special.insert("__new");
+  special.insert("__new_array");
+  special.insert("__placement_new");
+  special.insert("__placement_new_array");
+  special.insert("__delete");
+  special.insert("__delete_array");
 
   for(symbol_tablet::symbolst::const_iterator
       it=symbol_table.symbols.begin();
@@ -139,8 +145,9 @@ void remove_internal_symbols(
     {
       // body? not local (i.e., "static")?
       if(
-        has_body && (!is_file_local || (config.main.has_value() &&
-                                        symbol.name == config.main.value())))
+        has_body &&
+        (!is_file_local ||
+         (config.main.has_value() && symbol.base_name == config.main.value())))
       {
         get_symbols(ns, symbol, exported);
       }

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -915,6 +915,8 @@ bool configt::set(const cmdlinet &cmdline)
       ansi_c.preprocessor=ansi_ct::preprocessort::GCC;
       ansi_c.mode=ansi_ct::flavourt::VISUAL_STUDIO;
       #endif
+
+      cpp.cpp_standard = cppt::cpp_standardt::CPP14;
     }
   }
   else if(os=="macos")

--- a/src/util/symbol.cpp
+++ b/src/util/symbol.cpp
@@ -142,7 +142,9 @@ bool symbolt::is_well_formed() const
   // Exception: Java symbols' base names do not have type signatures
   // (for example, they can have name "someclass.method:(II)V" and base name
   // "method")
-  if(!has_suffix(id2string(name), id2string(base_name)) && mode != ID_java)
+  if(
+    !has_suffix(id2string(name), id2string(base_name)) && mode != ID_java &&
+    mode != ID_cpp)
   {
     bool criterion_must_hold = true;
 


### PR DESCRIPTION
This is a series of fixes mainly compiled by @peterschrammel plus some additional work of mine.

This includes the following commits to be reviewed:
- [x] ~e92421da24 Do not use assert without prior declaration~
- [ ] ~be13461761 Fix syntax errors in C++ regression tests~
- [x] ~c9094dd044 Fix broken comment frame~
- [x] ~12a71d181c Do not check friend declarations in wrong scope (moved to #2318)~
- [x] ~6ffc37c27d Do not add method body on declaration (will be handled on use)~
- [x] ~4576f14629 Line break~
- [ ] ~6dc9b9babc Fix delayed method body conversion for templates~
- [x] ~1db4a0459c Initial set of mini-system-c tests~
- [ ] ~c9f33342b8 Clean up unused template instantiation symbols~
- [ ] ~dc7b8c882e Fix disambiguation~
- [x] ~ba0df47444 C++ front-end: store typedef names (moved to #4551)~
- [x] ~43c0aa62f3 C++ front-end: parse GCC attributes~
- [ ] ~cafaac5947 Permit asm post-declarator mixed in any order with other qualifiers~
- [ ] ~6c6618b1f6 Permit GCC attributes after struct/class in class declaration~
- [ ] ~da7822bf7b Mark already-typechecked types as such~
- [x] ~f9e723e3c2 Typecheck initializer lists~
- [ ] ~d1bf14aad2 C++ front-end: Use C factory for compiler builtins~
- [x] ~5c14d094f8 Do not lose method qualifiers~
- [x] ~a67c62b99d Whitespace cleanup, comment type fixed~
- [x] ~f165ca9b9e Fix operator parsing~
- [x] ~d351125d4c Failing regression test from #661~
- [x] ~d3c2f9d2a8 Failing regression test from #933~
- [x] ~9fdefe8593 Enable compilation with DEBUG defined. Some of the code inside #ifdef DEBUG ... #ENDIF had become stale (moved to #4475)~
- [ ] ~edc0cd8774 Swap order of subtypes in construction of merged_type nodes, so that the main type is at the end. Handle and record GCC function attribute noreturn.~
- [x] ~f89a086304 Style improvements (moved to #4475)~
- [x] ~7cac0cecfc Prevent regression failures of cpp tests on windows.~
- [x] ~81a5569c73 Do not lint .h files in regression/~
- [x] ~a6e83f6b8f Don't abbreviate variable names (moved to #4552)~
- [x] 7aaaa8258d Mark parameters (and their symbols) as such (seems unnecessary)
- [ ] 63f0ef87c1 Do not mark arbitrary constants as macros
- [ ] d425cd7613 Declarator -> symbol conversion to match C implementation
- [ ] 5467da39fa C++: Remove internal symbols (macros in particular) before linking
- [x] ~44cb7c9892 decltype(bit field type) is the underlying subtype~
- [ ] ~c0a4278b84 Move is_template_scope to parent as it holds the id_class member~
- [ ] ~ab0812c47f Factor out set-up of sub_scope for template instantiation~
- [ ] ~87fddb8c3d Properly set up scope prefix instead of hacking it away~
- [x] ~0c686a8ffb Remove duplicate save_scope~
- [x] ~b3329e83f2 Remove redundant invariants~