### PR TITLE
fix verbosity in goto-gcc

### DIFF
--- a/regression/goto-gcc/verbosity1/main.c
+++ b/regression/goto-gcc/verbosity1/main.c
@@ -1,0 +1,4 @@
+int main()
+{
+  return 0;
+}

--- a/regression/goto-gcc/verbosity1/test.desc
+++ b/regression/goto-gcc/verbosity1/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--version
+^EXIT=0$
+^SIGNAL=0$
+--
+^RUN: .* --version
+^warning: ignoring
+^CONVERSION ERROR$

--- a/regression/goto-gcc/verbosity2/main.c
+++ b/regression/goto-gcc/verbosity2/main.c
@@ -1,0 +1,4 @@
+int main()
+{
+  return 0;
+}

--- a/regression/goto-gcc/verbosity2/test.desc
+++ b/regression/goto-gcc/verbosity2/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--version --verbosity 10
+^EXIT=0$
+^SIGNAL=0$
+^RUN: .* --version
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/src/goto-cc/gcc_mode.cpp
+++ b/src/goto-cc/gcc_mode.cpp
@@ -333,6 +333,14 @@ int gcc_modet::doit()
 
   unsigned int verbosity=1;
 
+  if(cmdline.isset("Wall") || cmdline.isset("Wextra"))
+    verbosity=2;
+
+  if(cmdline.isset("verbosity"))
+    verbosity=unsafe_string2unsigned(cmdline.get_value("verbosity"));
+
+  gcc_message_handler.set_verbosity(verbosity);
+
   bool act_as_bcc=
     base_name=="bcc" ||
     base_name.find("goto-bcc")!=std::string::npos;
@@ -380,14 +388,6 @@ int gcc_modet::doit()
     std::cout << "3.4.4\n";
     return EX_OK;
   }
-
-  if(cmdline.isset("Wall") || cmdline.isset("Wextra"))
-    verbosity=2;
-
-  if(cmdline.isset("verbosity"))
-    verbosity=unsafe_string2unsigned(cmdline.get_value("verbosity"));
-
-  gcc_message_handler.set_verbosity(verbosity);
 
   if(act_as_ld)
   {


### PR DESCRIPTION
Verbosity needs to be set before doing any output.
There are unfortunately scripts that do not tolerate the added ASM comments.