### PR TITLE
output the working directory for source locations in XML and json

### DIFF
--- a/src/util/file_util.cpp
+++ b/src/util/file_util.cpp
@@ -13,7 +13,10 @@ Date: January 2012
 
 #include "file_util.h"
 
+#include "invariant.h"
+
 #include <cerrno>
+#include <cstring>
 
 #if defined(__linux__) || \
     defined(__FreeBSD_kernel__) || \
@@ -36,29 +39,26 @@ Date: January 2012
 #define chdir _chdir
 #define popen _popen
 #define pclose _pclose
-#else
-#include <cstring>
 #endif
 
 /// \return current working directory
 std::string get_current_working_directory()
 {
-  unsigned bsize=50;
-
-  char *buf=reinterpret_cast<char*>(malloc(sizeof(char)*bsize));
-  if(!buf)
-    abort();
-
+  #ifndef _WIN32
   errno=0;
+  char *wd=realpath(".", nullptr);
+  INVARIANT(
+    wd!=nullptr && errno==0,
+    std::string("realpath failed: ")+strerror(errno));
 
-  while(buf && getcwd(buf, bsize-1)==nullptr && errno==ERANGE)
-  {
-    bsize*=2;
-    buf=reinterpret_cast<char*>(realloc(buf, sizeof(char)*bsize));
-  }
-
-  std::string working_directory=buf;
-  free(buf);
+  std::string working_directory=wd;
+  free(wd);
+  #else
+  char buffer[4096];
+  DWORD retval=GetCurrentDirectory(4096, buffer);
+  CHECK_RETURN(retval>0);
+  std::string working_directory(buffer);
+  #endif
 
   return working_directory;
 }

--- a/src/util/json_expr.cpp
+++ b/src/util/json_expr.cpp
@@ -84,6 +84,10 @@ json_objectt json(const source_locationt &location)
 {
   json_objectt result;
 
+  if(!location.get_working_directory().empty())
+    result["workingDirectory"]=
+      json_stringt(id2string(location.get_working_directory()));
+
   if(!location.get_file().empty())
     result["file"]=json_stringt(id2string(location.get_file()));
 

--- a/src/util/xml_expr.cpp
+++ b/src/util/xml_expr.cpp
@@ -28,6 +28,10 @@ xmlt xml(const source_locationt &location)
 
   result.name="location";
 
+  if(!location.get_working_directory().empty())
+    result.set_attribute(
+      "working-directory", id2string(location.get_working_directory()));
+
   if(!location.get_file().empty())
     result.set_attribute("file", id2string(location.get_file()));
 


### PR DESCRIPTION
This outputs the working directory of source locations both in XML output and json output.

The naming conventions of the respective communities are used, i.e., it's working-directory in XML and workingDirectory in json.