### PR TITLE
Add source location to JSON output

### DIFF
--- a/src/memory-models/Makefile
+++ b/src/memory-models/Makefile
@@ -9,6 +9,7 @@ SRC = mm2cpp.cpp \
 OBJ += ../big-int/big-int$(LIBEXT) \
       ../ansi-c/ansi-c$(LIBEXT) \
       ../linking/linking$(LIBEXT) \
+      ../langapi/langapi$(LIBEXT) \
       ../util/util$(LIBEXT)
 
 INCLUDES= -I ..

--- a/src/util/ui_message.cpp
+++ b/src/util/ui_message.cpp
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "xml.h"
 #include "json.h"
 #include "xml_expr.h"
+#include "json_expr.h"
 #include "cout_message.h"
 #include "cmdline.h"
 
@@ -219,11 +220,9 @@ void ui_message_handlert::json_ui_msg(
 
   json_objectt result;
 
-  #if 0
   if(location.is_not_nil() &&
      !location.get_file().empty())
-    result.new_element(xml(location));
-  #endif
+    result["sourceLocation"] = json(location);
 
   result["messageType"] = json_stringt(type);
   result["messageText"] = json_stringt(msg1);


### PR DESCRIPTION
Without this commit, the JSON output will miss source locations of messages. Compare the following plaintext output from cbmc:
```
file My.java line 8 function java::My.doIt:()V: no identifier for function parameter
```
with the JSON output for the same input file and parameters
```
{
  "messageText": "no identifier for function parameter",
  "messageType": "ERROR"
}
```

---
With this commit, the JSON output will be something like
```
{
  "messageText": "no identifier for function parameter",
  "messageType": "ERROR"
  "sourceLocation": {
        "bytecodeIndex": "2"
        "file": "My.java",
        "function": "java::My.doIt:()V",
        "line": "8"
      }
}
```
This should make debugging of errors easier.

Jira issue for this is [TG-438] (Diffblue login required)