### PR TITLE
Lazy-load static symbols which are accessed through pointers

### DIFF
--- a/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -2110,6 +2110,15 @@ codet java_bytecode_convert_methodt::convert_instructions(
           lazy_methods->add_needed_class(
             to_symbol_type(arg0.type()).get_identifier());
         }
+        else if(arg0.type().id()==ID_pointer)
+        {
+          const auto &pointer_type=to_pointer_type(arg0.type());
+          if(pointer_type.subtype().id()==ID_symbol)
+          {
+            lazy_methods->add_needed_class(
+              to_symbol_type(pointer_type.subtype()).get_identifier());
+          }
+        }
         else if(is_assertions_disabled_field)
         {
           lazy_methods->add_needed_class(arg0.get_string(ID_class));


### PR DESCRIPTION
This patch fixes https://diffblue.atlassian.net/browse/TG-390.

Below is a java class, with the disassembly for the `doIt` method on that class.

```java
public class test {
  public enum Foo { BAR; }
  public Foo doIt() { return Foo.BAR; }
}
```

```
  public com.diffblue.regression.test$Foo doIt();
    Code:
       0: getstatic     #2                  // Field com/diffblue/regression/test$Foo.BAR:Lcom/diffblue/regression/test$Foo;
       3: areturn
```
Note that the argument to `getstatic` is a reference to a static object, rather than being a plain object.
This patch ensures that the class of the static object is loaded when lazy-methods are enabled.