### PR TITLE
Add support for running regression tests in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ regression/**/*.smt2
 # regression/coverage file
 /regression/coverage_**
 
+# stats from parallel run of regression tests
+/regression/regression.stats
+
 # files stored by editors
 *~
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
             - libwww-perl
             - g++-5
             - libubsan0
+            - parallel
       before_install:
         - mkdir bin ; ln -s /usr/bin/gcc-5 bin/gcc
       # env: COMPILER=g++-5 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover -fno-omit-frame-pointer"
@@ -62,7 +63,7 @@ jobs:
       before_install:
           #we create symlink to non-ccache gcc, to be used in tests
         - mkdir bin ; ln -s /usr/bin/gcc bin/gcc
-        - HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache
+        - HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache parallel
         - export PATH=/usr/local/opt/ccache/libexec:$PATH
       env: COMPILER="ccache g++"
 
@@ -73,7 +74,7 @@ jobs:
       compiler: clang
       cache: ccache
       before_install:
-        - HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache
+        - HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache parallel
         - export PATH=/usr/local/opt/ccache/libexec:$PATH
       env:
         - COMPILER="ccache clang++ -Qunused-arguments -fcolor-diagnostics"
@@ -93,6 +94,7 @@ jobs:
             - libwww-perl
             - g++-5
             - libubsan0
+            - parallel
       before_install:
         - mkdir bin ; ln -s /usr/bin/gcc-5 bin/gcc
       # env: COMPILER=g++-5 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover -fno-omit-frame-pointer"
@@ -117,6 +119,7 @@ jobs:
             - clang-3.7
             - libstdc++-5-dev
             - libubsan0
+            - parallel
       before_install:
         - mkdir bin ; ln -s /usr/bin/clang-3.7 bin/gcc
         - export CCACHE_CPP2=yes
@@ -141,6 +144,7 @@ jobs:
             - clang-3.7
             - libstdc++-5-dev
             - libubsan0
+            - parallel
       before_install:
         - mkdir bin ; ln -s /usr/bin/clang-3.7 bin/gcc
         - export CCACHE_CPP2=yes
@@ -165,7 +169,7 @@ install:
 
 script:
   - if [ -e bin/gcc ] ; then export PATH=$PWD/bin:$PATH ; fi ;
-    COMMAND="env UBSAN_OPTIONS=print_stacktrace=1 make -C regression test CXX=\"$COMPILER\" CXXFLAGS=\"-Wall -Werror -pedantic -O2 -g $EXTRA_CXXFLAGS\"" &&
+    COMMAND="env UBSAN_OPTIONS=print_stacktrace=1 make -C regression test-parallel CXX=\"$COMPILER\" CXXFLAGS=\"-Wall -Werror -pedantic -O2 -g $EXTRA_CXXFLAGS\"" &&
     eval ${PRE_COMMAND} ${COMMAND}
   - COMMAND="make -C unit CXX=\"$COMPILER\" CXXFLAGS=\"-Wall -Werror -pedantic -O2 -g $EXTRA_CXXFLAGS\" -j2" &&
     eval ${PRE_COMMAND} ${COMMAND}

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -13,9 +13,45 @@ DIRS = ansi-c \
        test-script \
        # Empty last line
 
+.DEFAULT_GOAL := test
+
+# How many cores are available
+# Windows not supported = 1
+# CI has an issue with reporting correct number
+# `getconf _NPROCESSORS_ONLN` works on Linux and OS X
+ifeq ($(OS),Windows_NT)
+	NJOB = 1
+else
+  ifdef CI
+  	NJOB = 2
+  else
+    NJOB = $(shell getconf _NPROCESSORS_ONLN)
+  endif
+endif
 
 test:
 	$(foreach var,$(DIRS), $(MAKE) -C $(var) test || exit 1;)
+
+###############################################################################
+# Run tests using GNU parallel 20170722 or above
+# `make -C regression test-parallel`
+#
+# Prereq:
+# - Install GNU parallel:
+#   - ubuntu
+#   	(wget -O - pi.dk/3 || curl pi.dk/3/ || \
+#     fetch -o - http://pi.dk/3) | bash
+#   - osx
+#			brew install parallel
+###############################################################################
+test-parallel:
+	parallel --halt now,fail=1 \
+		--jobs $(NJOB) \
+		--bar \
+		--joblog regression.stats \
+		$(MAKE) -C {} test \
+		::: $(DIRS)
+	cat regression.stats
 
 clean:
 	@for dir in *; do \


### PR DESCRIPTION
Speedup regression test execution in Travis

Example (regression only):
- serial execution - 650 s - https://travis-ci.org/zemanlx/cbmc/jobs/270010671
- parallel execution - 372 s - https://travis-ci.org/zemanlx/cbmc/jobs/270043819