### PR TITLE
Clarified INVARIANT message in get_message_handler

### DIFF
--- a/src/util/message.h
+++ b/src/util/message.h
@@ -137,7 +137,9 @@ public:
 
   message_handlert &get_message_handler()
   {
-    INVARIANT(message_handler!=nullptr, "message handler is set");
+    INVARIANT(
+      message_handler!=nullptr,
+      "message handler should be set before calling get_message_handler");
     return *message_handler;
   }
 


### PR DESCRIPTION
The output when this invariant was violated confused me. This version may help other people.