### PR TITLE
HAVE_BV_REFINEMENT and HAVE_JAVA_BYTECODE are no longer needed

### DIFF
--- a/src/clobber/Makefile
+++ b/src/clobber/Makefile
@@ -3,6 +3,7 @@ SRC = clobber_main.cpp \
       # Empty last line
 OBJ += ../ansi-c/ansi-c$(LIBEXT) \
        ../cpp/cpp$(LIBEXT) \
+       ../java_bytecode/java_bytecode$(LIBEXT) \
        ../linking/linking$(LIBEXT) \
        ../big-int/big-int$(LIBEXT) \
        ../goto-programs/goto-programs$(LIBEXT) \
@@ -29,16 +30,6 @@ include ../common
 CLEANFILES = clobber$(EXEEXT)
 
 all: clobber$(EXEEXT)
-
-ifneq ($(wildcard ../bv_refinement/Makefile),)
-  OBJ += ../bv_refinement/bv_refinement$(LIBEXT)
-  CP_CXXFLAGS += -DHAVE_BV_REFINEMENT
-endif
-
-ifneq ($(wildcard ../java_bytecode/Makefile),)
-  OBJ += ../java_bytecode/java_bytecode$(LIBEXT)
-  CP_CXXFLAGS += -DHAVE_JAVA_BYTECODE
-endif
 
 ifneq ($(wildcard ../specc/Makefile),)
   OBJ += ../specc/specc$(LIBEXT)

--- a/src/goto-diff/Makefile
+++ b/src/goto-diff/Makefile
@@ -9,6 +9,7 @@ SRC = change_impact.cpp \
 
 OBJ += ../ansi-c/ansi-c$(LIBEXT) \
       ../cpp/cpp$(LIBEXT) \
+      ../java_bytecode/java_bytecode$(LIBEXT) \
       ../linking/linking$(LIBEXT) \
       ../big-int/big-int$(LIBEXT) \
       ../goto-programs/goto-programs$(LIBEXT) \
@@ -32,11 +33,6 @@ include ../common
 CLEANFILES = goto-diff$(EXEEXT)
 
 all: goto-diff$(EXEEXT)
-
-ifneq ($(wildcard ../java_bytecode/Makefile),)
-  OBJ += ../java_bytecode/java_bytecode$(LIBEXT)
-  CP_CXXFLAGS += -DHAVE_JAVA_BYTECODE
-endif
 
 ifneq ($(wildcard ../specc/Makefile),)
   OBJ += ../specc/specc$(LIBEXT)

--- a/src/goto-diff/goto_diff_languages.cpp
+++ b/src/goto-diff/goto_diff_languages.cpp
@@ -20,9 +20,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <specc/specc_language.h>
 #endif
 
-#ifdef HAVE_JAVA_BYTECODE
 #include <java_bytecode/java_bytecode_language.h>
-#endif
 
 void goto_diff_languagest::register_languages()
 {
@@ -33,7 +31,5 @@ void goto_diff_languagest::register_languages()
   register_language(new_specc_language);
   #endif
 
-  #ifdef HAVE_JAVA_BYTECODE
   register_language(new_java_bytecode_language);
-  #endif
 }

--- a/src/goto-instrument/Makefile
+++ b/src/goto-instrument/Makefile
@@ -65,6 +65,7 @@ SRC = accelerate/accelerate.cpp \
 
 OBJ += ../ansi-c/ansi-c$(LIBEXT) \
       ../cpp/cpp$(LIBEXT) \
+      ../java_bytecode/java_bytecode$(LIBEXT) \
       ../linking/linking$(LIBEXT) \
       ../big-int/big-int$(LIBEXT) \
       ../goto-programs/goto-programs$(LIBEXT) \
@@ -89,11 +90,6 @@ include ../config.inc
 include ../common
 
 all: goto-instrument$(EXEEXT)
-
-ifneq ($(wildcard ../java_bytecode/Makefile),)
-  OBJ += ../java_bytecode/java_bytecode$(LIBEXT)
-  CP_CXXFLAGS += -DHAVE_JAVA_BYTECODE
-endif
 
 ifneq ($(LIB_GLPK),)
   LIBS += $(LIB_GLPK)

--- a/src/symex/Makefile
+++ b/src/symex/Makefile
@@ -6,6 +6,7 @@ SRC = path_search.cpp \
 
 OBJ += ../ansi-c/ansi-c$(LIBEXT) \
        ../cpp/cpp$(LIBEXT) \
+       ../java_bytecode/java_bytecode$(LIBEXT) \
        ../linking/linking$(LIBEXT) \
        ../big-int/big-int$(LIBEXT) \
        ../goto-programs/goto-programs$(LIBEXT) \
@@ -33,16 +34,6 @@ include ../common
 CLEANFILES = symex$(EXEEXT)
 
 all: symex$(EXEEXT)
-
-ifneq ($(wildcard ../bv_refinement/Makefile),)
-  OBJ += ../bv_refinement/bv_refinement$(LIBEXT)
-  CP_CXXFLAGS += -DHAVE_BV_REFINEMENT
-endif
-
-ifneq ($(wildcard ../java_bytecode/Makefile),)
-  OBJ += ../java_bytecode/java_bytecode$(LIBEXT)
-  CP_CXXFLAGS += -DHAVE_JAVA_BYTECODE
-endif
 
 ifneq ($(wildcard ../specc/Makefile),)
   OBJ += ../specc/specc$(LIBEXT)


### PR DESCRIPTION
These are both obsolete, as the corresponding features are no longer optional.