### PR TITLE
any_reft and light_unordered_mapt template classes

### DIFF
--- a/src/util/any_ref.h
+++ b/src/util/any_ref.h
@@ -78,7 +78,18 @@ private:
 };
 
 template<typename T>
+bool operator==(const T& left, const any_reft &right)
+{ return right==left; }
+
+template<typename T>
 bool operator!=(const any_reft &left, const T &right)
 { return !(left==right); }
 
+template<typename T>
+bool operator!=(const T &left, const any_reft &right)
+{ return !(right==left); }
+
+template<>
+inline bool any_reft::operator==<any_reft>(const any_reft &other) const
+{ return ptr_==other.ptr_ && type_==other.type_; }
 #endif // CPROVER_UTIL_ANY_REF_H

--- a/src/util/any_ref.h
+++ b/src/util/any_ref.h
@@ -1,0 +1,84 @@
+/*******************************************************************\
+
+Module: Any reference - type-safe wrapper around void*
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_ANY_REF_H
+#define CPROVER_UTIL_ANY_REF_H
+
+#include <type_traits>
+#include <typeinfo>
+
+/// Any reference
+/// Stores a reference to any type
+/// Call .as<T>() to get the reference back
+class any_reft final
+{
+public:
+  template<typename T>
+  explicit any_reft(T &val):
+    type_(&type_of<T>),
+    ptr_(const_cast<typename std::remove_const<T>::type *>(&val)) { }
+
+  template<typename T>
+  any_reft &operator=(T &val)
+  {
+    type_=&type_of<T>;
+    ptr_=const_cast<typename std::remove_const<T>::type *>(&val);
+    return *this;
+  }
+
+  template<typename T>
+  bool operator==(const T &val) const
+  {
+    return
+      (type_==&type_of<T> ||
+       type_==&type_of<typename std::remove_const<T>::type>) &&
+      *static_cast<T *>(ptr_)==val;
+  }
+
+  /// Convert to a reference of a specific type
+  /// Throw std::bad_cast if type doesn't match the type
+  template<typename T>
+  T &as()
+  {
+    if(type_==&type_of<T> ||
+       type_==&type_of<typename std::remove_const<T>::type>)
+      return *static_cast<T *>(ptr_);
+    throw std::bad_cast();
+  }
+
+  /// Convert to a reference of a specific type
+  /// Throw std::bad_cast if type doesn't match the type
+  template<typename T>
+  const T &as() const
+  {
+    if(type_==&type_of<T> ||
+       type_==&type_of<typename std::remove_const<T>::type>)
+      return *static_cast<T *>(ptr_);
+    throw std::bad_cast();
+  }
+
+private:
+  template<typename T>
+  static void type_of()
+  {
+#ifdef _WIN32
+    // Hack to prevent VS release builds from optimizing this function out
+    volatile int i=typeid(T).hash_code()+std::is_const<T>::value?1:0;
+    (void)i;
+#endif
+  }
+
+  void(*type_)();
+  void *ptr_;
+};
+
+template<typename T>
+bool operator!=(const any_reft &left, const T &right)
+{ return !(left==right); }
+
+#endif // CPROVER_UTIL_ANY_REF_H

--- a/src/util/overlay_map.h
+++ b/src/util/overlay_map.h
@@ -60,42 +60,23 @@ public:
   }
 
   /// Set value for a specified key
-  void set(const key_type &key, const value_type &value)
+  void set(const key_type &key, value_type value)
   {
     auto &map=*data_.back();
     auto it=map.find(key);
     if(it==map.end())
-      map.emplace_hint(it, key, value);
-    else
-      it->second=value;
-  }
-
-  /// Set value for a specified key
-  void set(const key_type &key, value_type &&value)
-  {
-    auto &map=*data_.back();
-    auto it=map.find(key);
-    if(it==map.end())
-      map.emplace_hint(it, key, std::move(value));
+      map.emplace(key, std::move(value));
     else
       it->second=std::move(value);
   }
 
   /// Get a value stored under specified key
   value_type &at(const key_type &key)
-  {
-    if(auto ptr=find<datat, value_type>(data_, key))
-      return *ptr;
-    throw std::out_of_range("Element not found");
-  }
+  { return p_at(data_, key); }
 
   /// Get a value stored under specified key
   const value_type &at(const key_type &key) const
-  {
-    if(const auto ptr=find<const datat, const value_type>(data_, key))
-      return *ptr;
-    throw std::out_of_range("Element not found");
-  }
+  { return p_at(data_, key); }
 
 private:
   /// Creates a map that inherits elements with the "other" map
@@ -106,18 +87,18 @@ private:
       std::make_shared<std::unordered_map<key_type, value_type>>());
   }
 
-  template<typename data_t, typename ret_t>
-  static ret_t *find(data_t &data, const key_type &key)
+  template<typename data_t>
+  static auto p_at(data_t &data, const key_type &key)
+    -> decltype((*data[0])[key])
   {
-    const auto end=data.rend();
-    for(auto it=data.rbegin(); it!=end; ++it)
+    for(auto it=data.rbegin(), end=data.rend(); it!=end; ++it)
     {
       auto &map=(**it);
       const auto pair_it=map.find(key);
       if(pair_it!=map.end())
-        return &pair_it->second;
+        return pair_it->second;
     }
-    return nullptr;
+    throw std::out_of_range("Element not found");
   }
 
   typedef

--- a/src/util/overlay_map.h
+++ b/src/util/overlay_map.h
@@ -1,0 +1,130 @@
+/*******************************************************************\
+
+Module: Memory-efficient unordered_map
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_OVERLAY_MAP_H
+#define CPROVER_UTIL_OVERLAY_MAP_H
+
+#include <memory>
+#include <vector>
+#include <unordered_map>
+
+/// "Cheap copy" unordered map
+/// Copy-constructor is disabled. Call .overlay() to create a new
+/// layer on top of an existing map.
+///
+/// Copied data is shared with previous instance to avoid copying of
+/// all elements stored inside the map. For example having a map with
+/// 1000 elements, passing its overlay into the function and modifying one
+/// element is an efficient operation.
+/// Modifying elements in a base map changes non-overlaid elements in
+/// the child map. Destroying base, doesn't destroy elements in an overlay.
+template<typename key_type, typename value_type>
+class overlay_unordered_mapt
+{
+public:
+  /// Default constructor - constructs empty map
+  overlay_unordered_mapt():
+    data_(1, std::make_shared<std::unordered_map<key_type, value_type>>())
+  { }
+
+  /// Move constructor - claim "other"'s map state. Empty "other" map
+  overlay_unordered_mapt(overlay_unordered_mapt &&other):
+    overlay_unordered_mapt()
+  { *this=std::move(other); }
+
+  /// Convert regular map into overlay map
+  explicit overlay_unordered_mapt(
+    std::unordered_map<key_type, value_type> &&other):
+    data_(
+      1,
+      std::make_shared<std::unordered_map<key_type, value_type>>(
+        std::move(other)))
+  { }
+
+  /// Copy assignment - Clear this map and inherit from "other" map
+  overlay_unordered_mapt &operator=(const overlay_unordered_mapt &other)=delete;
+
+  overlay_unordered_mapt overlay() const
+  { return overlay_unordered_mapt(*this); }
+
+  /// Move assignment - swap state with "other" map
+  overlay_unordered_mapt &operator=(overlay_unordered_mapt &&other)
+  {
+    std::swap(other.data_, data_);
+    return *this;
+  }
+
+  /// Set value for a specified key
+  void set(const key_type &key, const value_type &value)
+  {
+    auto &map=*data_.back();
+    auto it=map.find(key);
+    if(it==map.end())
+      map.emplace_hint(it, key, value);
+    else
+      it->second=value;
+  }
+
+  /// Set value for a specified key
+  void set(const key_type &key, value_type &&value)
+  {
+    auto &map=*data_.back();
+    auto it=map.find(key);
+    if(it==map.end())
+      map.emplace_hint(it, key, std::move(value));
+    else
+      it->second=std::move(value);
+  }
+
+  /// Get a value stored under specified key
+  value_type &at(const key_type &key)
+  {
+    if(auto ptr=find<datat, value_type>(data_, key))
+      return *ptr;
+    throw std::out_of_range("Element not found");
+  }
+
+  /// Get a value stored under specified key
+  const value_type &at(const key_type &key) const
+  {
+    if(const auto ptr=find<const datat, const value_type>(data_, key))
+      return *ptr;
+    throw std::out_of_range("Element not found");
+  }
+
+private:
+  /// Creates a map that inherits elements with the "other" map
+  overlay_unordered_mapt(const overlay_unordered_mapt &other):
+    data_(other.data_)
+  {
+    data_.emplace_back(
+      std::make_shared<std::unordered_map<key_type, value_type>>());
+  }
+
+  template<typename data_t, typename ret_t>
+  static ret_t *find(data_t &data, const key_type &key)
+  {
+    const auto end=data.rend();
+    for(auto it=data.rbegin(); it!=end; ++it)
+    {
+      auto &map=(**it);
+      const auto pair_it=map.find(key);
+      if(pair_it!=map.end())
+        return &pair_it->second;
+    }
+    return nullptr;
+  }
+
+  typedef
+    std::vector<
+      std::shared_ptr<
+        std::unordered_map<key_type, value_type>>> datat;
+  datat data_;
+};
+
+#endif // CPROVER_UTIL_OVERLAY_MAP_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -7,6 +7,7 @@ SRC = src/expr/require_expr.cpp \
       catch_example.cpp \
       util/expr_iterator.cpp \
       util/optional.cpp \
+      any_ref.cpp \
       analyses/call_graph.cpp \
       java_bytecode/java_bytecode_convert_class/convert_abstract_class.cpp \
       # Empty last line

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -8,6 +8,7 @@ SRC = src/expr/require_expr.cpp \
       util/expr_iterator.cpp \
       util/optional.cpp \
       any_ref.cpp \
+      overlay_map.cpp \
       analyses/call_graph.cpp \
       java_bytecode/java_bytecode_convert_class/convert_abstract_class.cpp \
       # Empty last line

--- a/unit/any_ref.cpp
+++ b/unit/any_ref.cpp
@@ -1,0 +1,73 @@
+/*******************************************************************\
+
+Module: Any reference - type-safe wrapper around void*
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include "catch.hpp"
+#include <util/any_ref.h>
+
+TEST_CASE("Create and compare int reference")
+{
+  int variable=5;
+  any_reft var_ref(variable);
+  REQUIRE(var_ref.as<int>()==5);
+
+  const int constant=5;
+  any_reft const_ref(constant);
+  REQUIRE(const_ref.as<const int>()==5);
+}
+
+TEST_CASE("Create and compare int non-assignable reference")
+{
+  int variable=5;
+  const any_reft var_ref(variable);
+  REQUIRE(var_ref.as<int>()==5);
+
+  const int constant=5;
+  const any_reft const_ref(constant);
+  REQUIRE(const_ref.as<const int>()==5);
+}
+
+TEST_CASE("Allow conversion to const reference when original was non-const")
+{
+  const int value=5;
+  any_reft ref(value);
+  REQUIRE(ref.as<const int>()==5);
+}
+
+TEST_CASE("Conversion to a bad type should yield an error")
+{
+  const int value=7;
+  any_reft ref(value);
+  REQUIRE_THROWS_AS(ref.as<const bool>(), std::bad_cast);
+}
+
+TEST_CASE("Conversion to non-const if original was const should throw an error")
+{
+  const int value=7;
+  any_reft ref(value);
+  REQUIRE_THROWS_AS(ref.as<int>(), std::bad_cast);
+}
+
+TEST_CASE("any_ref should be assignable")
+{
+  const int value=7;
+  any_reft ref(value);
+  bool boolean=false;
+  ref=boolean;
+  REQUIRE(ref.as<const bool>()==false);
+  ref.as<bool>()=true;
+  REQUIRE(boolean==true);
+}
+
+class childt:public std::true_type { };
+
+TEST_CASE("Conversion to base class is not allowed")
+{
+  childt child;
+  any_reft ref(child);
+  REQUIRE_THROWS_AS(ref.as<std::true_type>(), std::bad_cast);
+}

--- a/unit/overlay_map.cpp
+++ b/unit/overlay_map.cpp
@@ -1,0 +1,69 @@
+/*******************************************************************\
+
+Module: Unit tests for overlay_unordered_map
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include "catch.hpp"
+#include <string>
+#include <util/overlay_map.h>
+
+TEST_CASE("Create and get a value from a overlay unordered map")
+{
+  overlay_unordered_mapt<std::string, std::string> map;
+  map.set("foo", "bar");
+  REQUIRE(map.at("foo")=="bar");
+}
+
+TEST_CASE("Move a value into unordered map, const at")
+{
+  overlay_unordered_mapt<std::string, std::string> map;
+  std::string bar("bar");
+  map.set("foo", std::move(bar));
+  REQUIRE(map.at("foo")=="bar");
+}
+
+TEST_CASE(".at should throw out_of_range, if element doesn't exist")
+{
+  overlay_unordered_mapt<std::string, std::string> map;
+  map.set("irn", "bru");
+  REQUIRE_THROWS_AS(map.at("foo"), std::out_of_range);
+}
+
+TEST_CASE("Copy should have old elements")
+{
+  overlay_unordered_mapt<std::string, std::string> old;
+  old.set("foo", "bar");
+  auto copy=old.overlay();
+  REQUIRE(copy.at("foo")=="bar");
+}
+
+TEST_CASE("Copy should not modify old elements")
+{
+  overlay_unordered_mapt<std::string, std::string> old;
+  old.set("foo", "bar");
+  auto copy=old.overlay();
+  copy.set("foo", "something else");
+  REQUIRE(old.at("foo")=="bar");
+  REQUIRE(copy.at("foo")=="something else");
+}
+
+TEST_CASE("Changing old values should modify values in the copy")
+{
+  overlay_unordered_mapt<std::string, std::string> old;
+  old.set("foo", "bar");
+  auto copy=old.overlay();
+  old.set("foo", "something else");
+  REQUIRE(copy.at("foo")=="something else");
+}
+
+TEST_CASE("Construct from unordered_map")
+{
+  std::unordered_map<std::string, std::string> map;
+  map.emplace("foo", "bar");
+  overlay_unordered_mapt<std::string, std::string> overlay_map(std::move(map));
+  REQUIRE(overlay_map.at("foo")=="bar");
+  REQUIRE(map.empty());
+}


### PR DESCRIPTION
These are two classes that solve that issue: https://github.com/diffblue/cbmc/issues/1309

`any_ref` is a type-safe reference wrapper of any type.

`light_unordered_mapt` is a cheap-copy hashmap.

Example usage in attached unit tests.