### PR TITLE
Avoid integer truncation

### DIFF
--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "interpreter.h"
 
 #include <cctype>
+#include <cstdint>
 #include <cstdio>
 #include <iostream>
 #include <fstream>
@@ -965,7 +966,7 @@ bool interpretert::unbounded_size(const typet &type)
 /// get allocated 2^32 address space each (of a 2^64 sized space).
 /// \param type: a structured type
 /// \return Size of the given type
-size_t interpretert::get_size(const typet &type)
+uint64_t interpretert::get_size(const typet &type)
 {
   if(unbounded_size(type))
     return 2ULL << 32ULL;
@@ -992,7 +993,7 @@ size_t interpretert::get_size(const typet &type)
     const union_typet::componentst &components=
       to_union_type(type).components();
 
-    size_t max_size=0;
+    uint64_t max_size=0;
 
     for(const auto &comp : components)
     {

--- a/src/goto-programs/interpreter_class.h
+++ b/src/goto-programs/interpreter_class.h
@@ -103,13 +103,13 @@ protected:
 
   const goto_functionst &goto_functions;
 
-  typedef std::unordered_map<irep_idt, std::size_t, irep_id_hash> memory_mapt;
-  typedef std::map<std::size_t, irep_idt> inverse_memory_mapt;
+  typedef std::unordered_map<irep_idt, mp_integer, irep_id_hash> memory_mapt;
+  typedef std::map<mp_integer, irep_idt> inverse_memory_mapt;
   memory_mapt memory_map;
   inverse_memory_mapt inverse_memory_map;
 
   const inverse_memory_mapt::value_type &address_to_object_record(
-    std::size_t address) const
+    const mp_integer &address) const
   {
     auto lower_bound=inverse_memory_map.lower_bound(address);
     if(lower_bound->first!=address)
@@ -120,34 +120,34 @@ protected:
     return *lower_bound;
   }
 
-  irep_idt address_to_identifier(std::size_t address) const
+  irep_idt address_to_identifier(const mp_integer &address) const
   {
     return address_to_object_record(address).second;
   }
 
-  std::size_t address_to_offset(std::size_t address) const
+  mp_integer address_to_offset(const mp_integer &address) const
   {
     return address-(address_to_object_record(address).first);
   }
 
-  std::size_t base_address_to_alloc_size(std::size_t address) const
+  mp_integer base_address_to_alloc_size(const mp_integer &address) const
   {
     PRECONDITION(address_to_offset(address)==0);
     auto upper_bound=inverse_memory_map.upper_bound(address);
-    std::size_t next_alloc_address=
+    mp_integer next_alloc_address=
       upper_bound==inverse_memory_map.end() ?
       memory.size() :
       upper_bound->first;
     return next_alloc_address-address;
   }
 
-  std::size_t base_address_to_actual_size(std::size_t address) const
+  uint64_t base_address_to_actual_size(const mp_integer &address) const
   {
     auto memory_iter=memory.find(address);
     if(memory_iter==memory.end())
       return 0;
     std::size_t ret=0;
-    std::size_t alloc_size=base_address_to_alloc_size(address);
+    mp_integer alloc_size=base_address_to_alloc_size(address);
     while(memory_iter!=memory.end() && memory_iter->first<(address+alloc_size))
     {
       ++ret;
@@ -186,7 +186,7 @@ protected:
   //  properties need to be mutable to avoid making all calls nonconst
   mutable memoryt memory;
 
-  std::size_t stack_pointer;
+  mp_integer stack_pointer;
 
   void build_memory_map();
   void build_memory_map(const symbolt &symbol);
@@ -195,13 +195,13 @@ protected:
   bool unbounded_size(const typet &);
   uint64_t get_size(const typet &type);
 
-  irep_idt get_component_id(const irep_idt &object, unsigned offset);
+  irep_idt get_component_id(const irep_idt &object, mp_integer offset);
   typet get_type(const irep_idt &id) const;
   exprt get_value(
     const typet &type,
-    std::size_t offset=0,
+    uint64_t offset=0,
     bool use_non_det=false);
-  exprt get_value(const typet &type, mp_vectort &rhs, std::size_t offset=0);
+  exprt get_value(const typet &type, mp_vectort &rhs, uint64_t offset=0);
   exprt get_value(const irep_idt &id);
 
   void step();
@@ -240,7 +240,7 @@ protected:
     goto_functionst::function_mapt::const_iterator return_function;
     mp_integer return_value_address;
     memory_mapt local_map;
-    unsigned old_stack_pointer;
+    mp_integer old_stack_pointer;
   };
 
   typedef std::stack<stack_framet> call_stackt;

--- a/src/goto-programs/interpreter_class.h
+++ b/src/goto-programs/interpreter_class.h
@@ -141,12 +141,12 @@ protected:
     return next_alloc_address-address;
   }
 
-  uint64_t base_address_to_actual_size(const mp_integer &address) const
+  mp_integer base_address_to_actual_size(const mp_integer &address) const
   {
     auto memory_iter=memory.find(address);
     if(memory_iter==memory.end())
       return 0;
-    std::size_t ret=0;
+    mp_integer ret=0;
     mp_integer alloc_size=base_address_to_alloc_size(address);
     while(memory_iter!=memory.end() && memory_iter->first<(address+alloc_size))
     {
@@ -193,15 +193,16 @@ protected:
   mp_integer build_memory_map(const irep_idt &id, const typet &type);
   typet concretize_type(const typet &type);
   bool unbounded_size(const typet &);
-  uint64_t get_size(const typet &type);
+  mp_integer get_size(const typet &type);
 
   irep_idt get_component_id(const irep_idt &object, mp_integer offset);
   typet get_type(const irep_idt &id) const;
   exprt get_value(
     const typet &type,
-    uint64_t offset=0,
+    mp_integer offset=0,
     bool use_non_det=false);
-  exprt get_value(const typet &type, mp_vectort &rhs, uint64_t offset=0);
+  exprt get_value(
+    const typet &type, mp_vectort &rhs, mp_integer offset=0);
   exprt get_value(const irep_idt &id);
 
   void step();
@@ -217,7 +218,7 @@ protected:
 
   void allocate(
     const mp_integer &address,
-    size_t size);
+    mp_integer size);
 
   void assign(
     const mp_integer &address,

--- a/src/goto-programs/interpreter_class.h
+++ b/src/goto-programs/interpreter_class.h
@@ -193,7 +193,7 @@ protected:
   mp_integer build_memory_map(const irep_idt &id, const typet &type);
   typet concretize_type(const typet &type);
   bool unbounded_size(const typet &);
-  size_t get_size(const typet &type);
+  uint64_t get_size(const typet &type);
 
   irep_idt get_component_id(const irep_idt &object, unsigned offset);
   typet get_type(const irep_idt &id) const;

--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -51,12 +51,12 @@ void interpretert::read_unbounded(
   mp_vectort &dest) const
 {
   // copy memory region
-  std::size_t address_val=integer2size_t(address);
+  const auto address_val=address;
   const auto offset=address_to_offset(address_val);
-  const std::size_t alloc_size=
+  const auto alloc_size=
     base_address_to_actual_size(address_val-offset);
   const auto to_read=alloc_size-offset;
-  for(size_t i=0; i<to_read; i++)
+  for(std::remove_const<decltype(to_read)>::type i=0; i<to_read; ++i)
   {
     mp_integer value;
 
@@ -77,10 +77,10 @@ void interpretert::read_unbounded(
 /// reserves memory block of size at address
 void interpretert::allocate(
   const mp_integer &address,
-  size_t size)
+  mp_integer size)
 {
   // clear memory region
-  for(size_t i=0; i<size; i++)
+  for(decltype(size) i=0; i<size; ++i)
   {
     if((address+i)<memory.size())
     {
@@ -307,7 +307,7 @@ void interpretert::evaluate(
   {
     if(expr.type().id()==ID_struct)
     {
-      dest.reserve(get_size(expr.type()));
+      dest.reserve(integer2size_t(get_size(expr.type())));
       bool error=false;
 
       forall_operands(it, expr)
@@ -315,7 +315,7 @@ void interpretert::evaluate(
         if(it->type().id()==ID_code)
           continue;
 
-        size_t sub_size=get_size(it->type());
+        const auto sub_size=get_size(it->type());
         if(sub_size==0)
           continue;
 
@@ -324,8 +324,8 @@ void interpretert::evaluate(
 
         if(tmp.size()==sub_size)
         {
-          for(size_t i=0; i<sub_size; i++)
-            dest.push_back(tmp[i]);
+          for(std::remove_const<decltype(sub_size)>::type i=0; i<sub_size; ++i)
+            dest.push_back(tmp[integer2size_t(i)]);
         }
         else
           error=true;
@@ -380,7 +380,7 @@ void interpretert::evaluate(
     {
       irep_idt value=to_constant_expr(expr).get_value();
       const char *str=value.c_str();
-      size_t length=strlen(str)+1;
+      const auto length=strlen(str)+1;
       if(show)
         warning() << "string decoding not fully implemented "
                   << length << eom;
@@ -401,7 +401,7 @@ void interpretert::evaluate(
   else if(expr.id()==ID_struct)
   {
     if(!unbounded_size(expr.type()))
-      dest.reserve(get_size(expr.type()));
+      dest.reserve(integer2size_t(get_size(expr.type())));
     bool error=false;
 
     forall_operands(it, expr)
@@ -409,7 +409,7 @@ void interpretert::evaluate(
       if(it->type().id()==ID_code)
         continue;
 
-      size_t sub_size=get_size(it->type());
+      const auto sub_size=get_size(it->type());
       if(sub_size==0)
         continue;
 
@@ -852,7 +852,7 @@ void interpretert::evaluate(
       mp_integer address=result[0];
       if(address>0 && address<memory.size())
       {
-        std::size_t address_val=integer2size_t(address);
+        const auto address_val=address;
         auto obj_type=get_type(address_to_identifier(address_val));
 
         mp_integer offset=address_to_offset(address_val);
@@ -954,7 +954,7 @@ void interpretert::evaluate(
     {
       if(!unbounded_size(expr.type()))
       {
-        dest.resize(get_size(expr.type()));
+        dest.resize(integer2size_t(get_size(expr.type())));
         read(address, dest);
       }
       else
@@ -1020,8 +1020,8 @@ void interpretert::evaluate(
       evaluate(ty.size(), size);
     if(size.size()==1)
     {
-      std::size_t size_int=integer2size_t(size[0]);
-      for(std::size_t i=0; i<size_int; ++i)
+      const auto size_int=size[0];
+      for(std::remove_const<decltype(size_int)>::type i=0; i<size_int; ++i)
         evaluate(expr.op0(), dest);
       return;
     }
@@ -1040,13 +1040,13 @@ void interpretert::evaluate(
       // Ignore indices < 0, which the string solver sometimes produces
       if(where[0]<0)
         return;
-      std::size_t where_idx=integer2size_t(where[0]);
-      std::size_t subtype_size=get_size(subtype);
-      std::size_t need_size=(where_idx+1)*subtype_size;
+      const auto where_idx=where[0];
+      const auto subtype_size=get_size(subtype);
+      const auto need_size=(where_idx+1)*subtype_size;
       if(dest.size()<need_size)
-        dest.resize(need_size, 0);
+        dest.resize(integer2size_t(need_size), 0);
       for(std::size_t i=0; i<new_value.size(); ++i)
-        dest[(where_idx*subtype_size)+i]=new_value[i];
+        dest[integer2size_t((where_idx*subtype_size)+i)]=new_value[i];
       return;
     }
   }
@@ -1135,7 +1135,7 @@ mp_integer interpretert::evaluate_address(
     const irep_idt &component_name=
       to_member_expr(expr).get_component_name();
 
-    unsigned offset=0;
+    mp_integer offset=0;
 
     for(const auto &comp : struct_type.components())
     {

--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -52,10 +52,10 @@ void interpretert::read_unbounded(
 {
   // copy memory region
   std::size_t address_val=integer2size_t(address);
-  const std::size_t offset=address_to_offset(address_val);
+  const auto offset=address_to_offset(address_val);
   const std::size_t alloc_size=
     base_address_to_actual_size(address_val-offset);
-  const std::size_t to_read=alloc_size-offset;
+  const auto to_read=alloc_size-offset;
   for(size_t i=0; i<to_read; i++)
   {
     mp_integer value;

--- a/src/util/sparse_vector.h
+++ b/src/util/sparse_vector.h
@@ -13,6 +13,7 @@ Author: Romain Brenguier
 #define CPROVER_UTIL_SPARSE_VECTOR_H
 
 #include "invariant.h"
+#include "mp_arith.h"
 
 #include <cstdint>
 #include <map>
@@ -20,35 +21,36 @@ Author: Romain Brenguier
 template<class T> class sparse_vectort
 {
 protected:
-  typedef std::map<uint64_t, T> underlyingt;
+  typedef std::map<mp_integer, T> underlyingt;
+  typedef typename underlyingt::key_type key_type;
   underlyingt underlying;
-  uint64_t _size;
+  mp_integer _size;
 
 public:
   sparse_vectort() :
     _size(0) {}
 
-  const T &operator[](uint64_t idx) const
+  const T &operator[](const key_type &idx) const
   {
     INVARIANT(idx<_size, "index out of range");
     return underlying[idx];
   }
 
-  T &operator[](uint64_t idx)
+  T &operator[](const key_type &idx)
   {
     INVARIANT(idx<_size, "index out of range");
     return underlying[idx];
   }
 
-  uint64_t size() const
+  mp_integer size() const
   {
     return _size;
   }
 
-  void resize(uint64_t new_size)
+  void resize(mp_integer new_size)
   {
     INVARIANT(new_size>=_size, "sparse vector can't be shrunk (yet)");
-    _size=new_size;
+    _size=std::move(new_size);
   }
 
   typedef typename underlyingt::iterator iteratort;
@@ -60,7 +62,7 @@ public:
   iteratort end() { return underlying.end(); }
   const_iteratort end() const { return underlying.end(); }
 
-  const_iteratort find(uint64_t idx) { return underlying.find(idx); }
+  const_iteratort find(const mp_integer &idx) { return underlying.find(idx); }
 };
 
 #endif // CPROVER_UTIL_SPARSE_VECTOR_H


### PR DESCRIPTION
The build is broken on 32-bit platforms, which is important because we should support OS X universal binaries. This patch fixes the build errors by explicitly using 64-bit integers rather than depending on `size_t` to be 64 bits wide.