### PR TITLE
Big-int: Fix copy-assign, add move ops, enable implicit conversions

### DIFF
--- a/src/big-int/bigint.cc
+++ b/src/big-int/bigint.cc
@@ -464,6 +464,12 @@ BigInt::BigInt (BigInt const &y)
   memcpy (digit, y.digit, length * sizeof (onedig_t));
 }
 
+BigInt::BigInt (BigInt &&y)
+  : BigInt()
+{
+  swap(y);
+}
+
 BigInt::BigInt (char const *s, onedig_t b)
   : size (adjust_size (small)),
     length (0),
@@ -473,40 +479,18 @@ BigInt::BigInt (char const *s, onedig_t b)
   scan (s, b);
 }
 
-
-BigInt &
-BigInt::operator= (llong_t l)
-{
-  reallocate (small);
-  assign (l);
-  return *this;
-}
-
-BigInt &
-BigInt::operator= (ullong_t ul)
-{
-  reallocate (small);
-  assign (ul);
-  return *this;
-}
-
 BigInt &
 BigInt::operator= (BigInt const &y)
 {
-  if (&y != this)
-    {
-      reallocate (y.length);
-      length = y.length;
-      positive = y.positive;
-      memcpy (digit, y.digit, length * sizeof (onedig_t));
-    }
+  BigInt copy(y);
+  swap(copy);
   return *this;
 }
 
 BigInt &
-BigInt::operator= (char const *s)
+BigInt::operator= (BigInt &&y)
 {
-  scan (s);
+  swap(y);
   return *this;
 }
 


### PR DESCRIPTION
The big-int class has a bunch of problems that are addressed by this PR:
- Unsafe copy assign which may leave objects in an inconsistent state: #1340 
- No move operations
- No cheap `swap`
- Arithmetic operations and comparisons only allow implicit conversions on the RHS, whereas they would be expected on both the LHS *and* RHS