### PR TITLE
Do not overwrite non-zero return codes

### DIFF
--- a/regression/goto-gcc/expect_fail/main.c
+++ b/regression/goto-gcc/expect_fail/main.c
@@ -1,0 +1,6 @@
+int foo(); // this is not defined and should cause linker errors
+
+int main()
+{
+  return foo();
+}

--- a/regression/goto-gcc/expect_fail/test.desc
+++ b/regression/goto-gcc/expect_fail/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=1$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/src/goto-cc/as_mode.cpp
+++ b/src/goto-cc/as_mode.cpp
@@ -336,11 +336,12 @@ int as_modet::as_hybrid_binary()
     result=run(objcopy_argv[0], objcopy_argv, "", "");
   }
 
-  result=remove(saved.c_str());
-  if(result!=0)
+  int remove_result=remove(saved.c_str());
+  if(remove_result!=0)
   {
     error() << "Remove failed: " << std::strerror(errno) << eom;
-    return result;
+    if(result==0)
+      result=remove_result;
   }
 
   #elif defined(__APPLE__)
@@ -362,11 +363,12 @@ int as_modet::as_hybrid_binary()
     result=run(lipo_argv[0], lipo_argv, "", "");
   }
 
-  result=remove(saved.c_str());
-  if(result!=0)
+  int remove_result=remove(saved.c_str());
+  if(remove_result!=0)
   {
     error() << "Remove failed: " << std::strerror(errno) << eom;
-    return result;
+    if(result==0)
+      result=remove_result;
   }
 
   #else

--- a/src/goto-cc/gcc_mode.cpp
+++ b/src/goto-cc/gcc_mode.cpp
@@ -982,11 +982,12 @@ int gcc_modet::gcc_hybrid_binary(compilet &compiler)
       result=run(objcopy_argv[0], objcopy_argv, "", "");
     }
 
-    result=remove(saved.c_str());
-    if(result!=0)
+    int remove_result=remove(saved.c_str());
+    if(remove_result!=0)
     {
       error() << "Remove failed: " << std::strerror(errno) << eom;
-      return result;
+      if(result==0)
+        result=remove_result;
     }
 
     #elif defined(__APPLE__)
@@ -1008,11 +1009,12 @@ int gcc_modet::gcc_hybrid_binary(compilet &compiler)
       result=run(lipo_argv[0], lipo_argv, "", "");
     }
 
-    result=remove(saved.c_str());
-    if(result!=0)
+    int remove_result=remove(saved.c_str());
+    if(remove_result!=0)
     {
       error() << "Remove failed: " << std::strerror(errno) << eom;
-      return result;
+      if(result==0)
+        result=remove_result;
     }
 
     #else


### PR DESCRIPTION
Failure in calling the native compiler must not be masked by a later successful
call to "remove". Follow-up fix to 2655d9861.