### PR TITLE
Properly prepare goto model for (reachability) slice

### DIFF
--- a/regression/goto-instrument/slice_function_ptr1/main.c
+++ b/regression/goto-instrument/slice_function_ptr1/main.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+
+int foo()
+{
+  assert(0);
+  return 0;
+}
+
+int main(void)
+{
+  int (*p)()=&foo;
+  return p();
+}

--- a/regression/goto-instrument/slice_function_ptr1/test.desc
+++ b/regression/goto-instrument/slice_function_ptr1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--full-slice
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-instrument/slice_function_ptr2/main.c
+++ b/regression/goto-instrument/slice_function_ptr2/main.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+
+int foo()
+{
+  assert(0);
+  return 0;
+}
+
+int main(void)
+{
+  int (*p)()=&foo;
+  return p();
+}

--- a/regression/goto-instrument/slice_function_ptr2/test.desc
+++ b/regression/goto-instrument/slice_function_ptr2/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--reachability-slice
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1426,6 +1426,8 @@ void goto_instrument_parse_optionst::instrument_goto_program()
   // reachability slice?
   if(cmdline.isset("reachability-slice"))
   {
+    do_indirect_call_and_rtti_removal();
+
     status() << "Performing a reachability slice" << eom;
     if(cmdline.isset("property"))
       reachability_slicer(goto_functions, cmdline.get_values("property"));
@@ -1436,8 +1438,8 @@ void goto_instrument_parse_optionst::instrument_goto_program()
   // full slice?
   if(cmdline.isset("full-slice"))
   {
-    remove_returns(symbol_table, goto_functions);
     do_indirect_call_and_rtti_removal();
+    do_remove_returns();
 
     status() << "Performing a full slice" << eom;
     if(cmdline.isset("property"))


### PR DESCRIPTION
1. remove_returns must always be called after removing function pointers.
2. reachability_slice requires function pointer removal.