### PR TITLE
Map wrappers: forward more of the std::map interface

### DIFF
--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -70,6 +70,8 @@ public:
     typedef data_typet::const_iterator const_iterator;
     // NOLINTNEXTLINE(readability/identifiers)
     typedef data_typet::value_type value_type;
+    // NOLINTNEXTLINE(readability/identifiers)
+    typedef data_typet::key_type key_type;
 
     iterator begin() { return data.begin(); }
     const_iterator begin() const { return data.begin(); }
@@ -82,7 +84,12 @@ public:
     size_t size() const { return data.size(); }
     bool empty() const { return data.empty(); }
 
-    objectt &operator[](unsigned i) { return data[i]; }
+    void erase(key_type i) { data.erase(i); }
+    void erase(const_iterator it) { data.erase(it); }
+
+    objectt &operator[](key_type i) { return data[i]; }
+    objectt &at(key_type i) { return data.at(i); }
+    const objectt &at(key_type i) const { return data.at(i); }
 
     template <typename It>
     void insert(It b, It e) { data.insert(b, e); }

--- a/src/util/numbering.h
+++ b/src/util/numbering.h
@@ -152,6 +152,9 @@ public:
   T &operator[](size_type t) { return data[t]; }
   const T &operator[](size_type t) const { return data[t]; }
 
+  T &at(size_type t) { return data.at(t); }
+  const T &at(size_type t) const { return data.at(t); }
+
   size_type size() const { return data.size(); }
 
   iterator begin() { return data.begin(); }


### PR DESCRIPTION
This remains incomplete, forwarding as per users' needs rather than forwarding the entire std::map interface, hopefully splitting the difference between providing useful functionality and preserving the
possibility to switch out different types without undue difficulty.

The forwarded methods are used by security-analyser. What to do about out-of-tree users who presumably could have been using any of std::map / std::vector's interfaces remains an open question.