### PR TITLE
Disable Alpine in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,20 +39,6 @@ jobs:
       # env: COMPILER=g++-5 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover -fno-omit-frame-pointer"
       env: COMPILER="ccache g++-5"
 
-    # Alpine Linux with musl-libc using g++
-    - stage: Test different OS/CXX/Flags
-      os: linux
-      sudo: required
-      compiler: gcc
-      cache: ccache
-      services:
-        - docker
-      before_install:
-        - docker pull diffblue/cbmc-builder:alpine-0.0.3
-      env:
-        - PRE_COMMAND="docker run -v ${TRAVIS_BUILD_DIR}:/cbmc -v ${HOME}/.ccache:/root/.ccache diffblue/cbmc-builder:alpine-0.0.3"
-        - COMPILER="ccache g++"
-
     # OS X using g++
     - stage: Test different OS/CXX/Flags
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -142,22 +142,16 @@ jobs:
 
 install:
   - ccache --max-size=1G
-  - COMMAND="make -C src minisat2-download" &&
-    eval ${PRE_COMMAND} ${COMMAND}
-  - COMMAND="make -C src/ansi-c library_check" &&
-    eval ${PRE_COMMAND} ${COMMAND}
-  - COMMAND="make -C src CXX=\"$COMPILER\" CXXFLAGS=\"-Wall -Werror -pedantic -O2 -g $EXTRA_CXXFLAGS\" -j2" &&
-    eval ${PRE_COMMAND} ${COMMAND}
-  - COMMAND="make -C src CXX=\"$COMPILER\" CXXFLAGS=\"$FLAGS $EXTRA_CXXFLAGS\" -j2 clobber.dir memory-models.dir musketeer.dir" &&
-    eval ${PRE_COMMAND} ${COMMAND}
+  - make -C src minisat2-download
+  - make -C src/ansi-c library_check
+  - make -C src "CXX=${COMPILER}" "CXXFLAGS=-Wall -Werror -pedantic -O2 -g ${EXTRA_CXXFLAGS}" -j2
+  - make -C src "CXX=${COMPILER}" "CXXFLAGS=-Wall -Werror -pedantic -O2 -g ${EXTRA_CXXFLAGS}" -j2 clobber.dir memory-models.dir musketeer.dir
 
 script:
   - if [ -e bin/gcc ] ; then export PATH=$PWD/bin:$PATH ; fi ;
-    COMMAND="env UBSAN_OPTIONS=print_stacktrace=1 make -C regression test CXX=\"$COMPILER\" CXXFLAGS=\"-Wall -Werror -pedantic -O2 -g $EXTRA_CXXFLAGS\"" &&
-    eval ${PRE_COMMAND} ${COMMAND}
-  - COMMAND="make -C unit CXX=\"$COMPILER\" CXXFLAGS=\"-Wall -Werror -pedantic -O2 -g $EXTRA_CXXFLAGS\" -j2" &&
-    eval ${PRE_COMMAND} ${COMMAND}
-  - COMMAND="make -C unit test" && eval ${PRE_COMMAND} ${COMMAND}
+  - env UBSAN_OPTIONS=print_stacktrace=1 make -C regression test "CXX=${COMPILER}" "CXXFLAGS=-Wall -Werror -pedantic -O2 -g ${EXTRA_CXXFLAGS}"
+  - make -C unit "CXX=${COMPILER}" "CXXFLAGS=-Wall -Werror -pedantic -O2 -g ${EXTRA_CXXFLAGS}" -j2
+  - make -C unit test
 
 before_cache:
   - ccache -s


### PR DESCRIPTION
Alpine Linux builds are no longer required. We can reduce load on Travis by disabling this build. Suggest @zemanlx and @peterschrammel to review.