### PR TITLE
Display error in catch(...)

### DIFF
--- a/src/goto-analyzer/taint_analysis.cpp
+++ b/src/goto-analyzer/taint_analysis.cpp
@@ -400,6 +400,7 @@ bool taint_analysist::operator()(
   }
   catch(...)
   {
+    error() << "Caught unexpected error in taint_analysist::operator()" << eom;
     return true;
   }
 }


### PR DESCRIPTION
A catch(...) was hiding a problem we had - it would have been faster to debug if it had printed a message, this PR makes it do so.