### PR TITLE
Disable symex tests, which are broken on Appveyor

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -12,7 +12,6 @@ DIRS = ansi-c \
        invariants \
        strings \
        strings-smoke-tests \
-       symex \
        test-script \
        # Empty last line
 


### PR DESCRIPTION
These should be made to pass *before* enabling them.

Request review from @peterschrammel and @allredj 