### PR TITLE
Add initial value to languaget::generate_opaque_stubs

### DIFF
--- a/src/util/language.h
+++ b/src/util/language.h
@@ -137,7 +137,7 @@ protected:
 
   static irep_idt get_stub_return_symbol_name(const irep_idt &function_id);
 
-  bool generate_opaque_stubs;
+  bool generate_opaque_stubs=false;
   bool language_options_initialized=false;
 
 private:


### PR DESCRIPTION
The bool member languaget::generate_opaque_stubs does not receive an
initial value, and not all contexts using languaget call its setter.
Valgrind thus detects a jump based on an uninitialised value. Added
explicit initial value `false`.