### PR TITLE
Re-enable old function signatures for test-gen compat

### DIFF
--- a/src/analyses/call_graph.cpp
+++ b/src/analyses/call_graph.cpp
@@ -18,9 +18,14 @@ call_grapht::call_grapht()
 {
 }
 
-call_grapht::call_grapht(const goto_modelt &goto_model)
+call_grapht::call_grapht(const goto_modelt &goto_model):
+  call_grapht(goto_model.goto_functions)
 {
-  forall_goto_functions(f_it, goto_model.goto_functions)
+}
+
+call_grapht::call_grapht(const goto_functionst &goto_functions)
+{
+  forall_goto_functions(f_it, goto_functions)
   {
     const goto_programt &body=f_it->second.body;
     add(f_it->first, body);

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -22,6 +22,7 @@ class call_grapht
 public:
   call_grapht();
   explicit call_grapht(const goto_modelt &);
+  explicit call_grapht(const goto_functionst &);
 
   void output_dot(std::ostream &out) const;
   void output(std::ostream &out) const;

--- a/src/goto-instrument/nondet_static.h
+++ b/src/goto-instrument/nondet_static.h
@@ -16,6 +16,12 @@ Date: November 2011
 #define CPROVER_GOTO_INSTRUMENT_NONDET_STATIC_H
 
 class goto_modelt;
+class namespacet;
+class goto_functionst;
+
+void nondet_static(
+  const namespacet &ns,
+  goto_functionst &goto_functions);
 
 void nondet_static(goto_modelt &);
 

--- a/src/goto-programs/remove_static_init_loops.cpp
+++ b/src/goto-programs/remove_static_init_loops.cpp
@@ -109,6 +109,19 @@ void remove_static_init_loops(
   optionst &options,
   message_handlert &msg)
 {
-  remove_static_init_loopst remove_loops(goto_model.symbol_table);
-  remove_loops.unwind_enum_static(goto_model.goto_functions, options, msg);
+  remove_static_init_loops(
+    goto_model.symbol_table,
+    goto_model.goto_functions,
+    options,
+    msg);
+}
+
+void remove_static_init_loops(
+  const symbol_tablet &symbol_table,
+  const goto_functionst &goto_functions,
+  optionst &options,
+  message_handlert &msg)
+{
+  remove_static_init_loopst remove_loops(symbol_table);
+  remove_loops.unwind_enum_static(goto_functions, options, msg);
 }

--- a/src/goto-programs/remove_static_init_loops.h
+++ b/src/goto-programs/remove_static_init_loops.h
@@ -19,9 +19,17 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/symbol_table.h>
 
 class goto_modelt;
+class symbol_tablet;
+class goto_functionst;
 
 void remove_static_init_loops(
   const goto_modelt &,
+  optionst &,
+  message_handlert &);
+
+void remove_static_init_loops(
+  const symbol_tablet &symbol_table,
+  const goto_functionst &goto_functions,
   optionst &,
   message_handlert &);
 

--- a/src/goto-programs/show_goto_functions.h
+++ b/src/goto-programs/show_goto_functions.h
@@ -16,12 +16,18 @@ Author: Peter Schrammel
 
 class namespacet;
 class goto_modelt;
+class goto_functionst;
 
 #define OPT_SHOW_GOTO_FUNCTIONS \
   "(show-goto-functions)"
 
 #define HELP_SHOW_GOTO_FUNCTIONS \
   " --show-goto-functions        show goto program\n"
+
+void show_goto_functions(
+  const namespacet &ns,
+  ui_message_handlert::uit ui,
+  const goto_functionst &goto_functions);
 
 void show_goto_functions(
   const goto_modelt &,

--- a/src/goto-programs/show_properties.h
+++ b/src/goto-programs/show_properties.h
@@ -16,9 +16,16 @@ Author: Daniel Kroening, kroening@kroening.com
 
 class namespacet;
 class goto_modelt;
+class symbol_tablet;
+class goto_functionst;
 
 void show_properties(
   const goto_modelt &,
   ui_message_handlert::uit ui);
+
+void show_properties(
+  const namespacet &ns,
+  ui_message_handlert::uit ui,
+  const goto_functionst &goto_functions);
 
 #endif // CPROVER_GOTO_PROGRAMS_SHOW_PROPERTIES_H


### PR DESCRIPTION
CBMC needs some tweaks in order to re-enable test-gen compatibility. This is because in some cases we need to pass an unrelated symbol_table and goto_functions into another function. In these cases, we can't construct a fresh goto_model at the call site (goto_functions are only move-able, so the goto_functions wouldn't be usable in the outer scope after the call), which means it's essentially impossible to call such functions with a goto_model.

See diffblue/test-gen#1042 for an example of when this causes difficulties.

Suggest @allredj and @LAJW for review.