### PR TITLE
Corrected regression makefile

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -7,7 +7,7 @@ DIRS = ansi-c \
        goto-analyzer \
        goto-cc-cbmc \
        goto-cc-goto-analyzer \
-       goto-cc-goto-symex \
+       goto-cc-symex \
        goto-diff \
        goto-gcc \
        goto-instrument \

--- a/regression/goto-cc-symex/regenerate-entry-function/test.desc
+++ b/regression/goto-cc-symex/regenerate-entry-function/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 "--function fun --show-goto-functions"
-^\s*return.=fun\(x\);$
+fun\(x\);$
 ^EXIT=6$
 ^SIGNAL=0$
 --


### PR DESCRIPTION
The makefile update (introduced in #338) was pointing at the wrong directory, which somehow didn't cause a CI failure! This corrects that. In doing so realised that the test was slightly inaccurate, so resolved this issue as well.