### PR TITLE
return STL containers directly for some variants of compute_called_functions

### DIFF
--- a/src/goto-analyzer/unreachable_instructions.cpp
+++ b/src/goto-analyzer/unreachable_instructions.cpp
@@ -128,8 +128,8 @@ void unreachable_instructions(
 {
   json_arrayt json_result;
 
-  std::set<irep_idt> called;
-  compute_called_functions(goto_model, called);
+  std::set<irep_idt> called=
+    compute_called_functions(goto_model);
 
   const namespacet ns(goto_model.symbol_table);
 
@@ -191,8 +191,8 @@ static void list_functions(
 {
   json_arrayt json_result;
 
-  std::set<irep_idt> called;
-  compute_called_functions(goto_model, called);
+  std::set<irep_idt> called=
+    compute_called_functions(goto_model);
 
   const namespacet ns(goto_model.symbol_table);
 

--- a/src/goto-programs/compute_called_functions.cpp
+++ b/src/goto-programs/compute_called_functions.cpp
@@ -66,13 +66,22 @@ void compute_address_taken_functions(
     compute_address_taken_functions(it->second.body, address_taken);
 }
 
+/// get all functions whose address is taken
+std::set<irep_idt> compute_address_taken_functions(
+  const goto_functionst &goto_functions)
+{
+  std::set<irep_idt> address_taken;
+  compute_address_taken_functions(goto_functions, address_taken);
+  return address_taken;
+}
+
 /// computes the functions that are (potentially) called
-void compute_called_functions(
-  const goto_functionst &goto_functions,
-  std::set<irep_idt> &functions)
+std::set<irep_idt> compute_called_functions(
+  const goto_functionst &goto_functions)
 {
   std::set<irep_idt> working_queue;
   std::set<irep_idt> done;
+  std::set<irep_idt> functions;
 
   // start from entry point
   working_queue.insert(goto_functions.entry_point());
@@ -109,12 +118,13 @@ void compute_called_functions(
       }
     }
   }
+
+  return functions;
 }
 
 /// computes the functions that are (potentially) called
-void compute_called_functions(
-  const goto_modelt &goto_model,
-  std::set<irep_idt> &functions)
+std::set<irep_idt> compute_called_functions(
+  const goto_modelt &goto_model)
 {
-  compute_called_functions(goto_model.goto_functions, functions);
+  return compute_called_functions(goto_model.goto_functions);
 }

--- a/src/goto-programs/compute_called_functions.h
+++ b/src/goto-programs/compute_called_functions.h
@@ -17,24 +17,19 @@ Author: Daniel Kroening, kroening@kroening.com
 // compute the set of functions whose address is taken
 
 void compute_address_taken_functions(
-  const exprt &src,
-  std::set<irep_idt> &address_taken);
+  const exprt &,
+  std::set<irep_idt> &);
 
 void compute_address_taken_functions(
-  const goto_programt &goto_program,
-  std::set<irep_idt> &address_taken);
+  const goto_programt &,
+  std::set<irep_idt> &);
 
 void compute_address_taken_functions(
-  const goto_functionst &goto_functions,
-  std::set<irep_idt> &address_taken);
+  const goto_functionst &,
+  std::set<irep_idt> &);
 
 // computes the functions that are (potentially) called
-void compute_called_functions(
-  const goto_functionst &,
-  std::set<irep_idt> &functions);
-
-void compute_called_functions(
-  const goto_modelt &,
-  std::set<irep_idt> &functions);
+std::set<irep_idt> compute_called_functions(const goto_functionst &);
+std::set<irep_idt> compute_called_functions(const goto_modelt &);
 
 #endif // CPROVER_GOTO_PROGRAMS_COMPUTE_CALLED_FUNCTIONS_H

--- a/src/goto-programs/link_to_library.cpp
+++ b/src/goto-programs/link_to_library.cpp
@@ -45,8 +45,8 @@ void link_to_library(
 
   while(true)
   {
-    std::set<irep_idt> called_functions;
-    compute_called_functions(goto_functions, called_functions);
+    std::set<irep_idt> called_functions=
+      compute_called_functions(goto_functions);
 
     // eliminate those for which we already have a body
 


### PR DESCRIPTION
Since C++11, STL containers (and other classes with move semantics) can be returned at constant cost.

Please add similar instances to this PR.