### PR TITLE
Split the entry-point-generation phase into two parts

### DIFF
--- a/regression/goto-cc-cbmc/mixed-c-library-goto-main/lib.c
+++ b/regression/goto-cc-cbmc/mixed-c-library-goto-main/lib.c
@@ -1,0 +1,4 @@
+
+int getone() {
+  return 1;
+}

--- a/regression/goto-cc-cbmc/mixed-c-library-goto-main/main.c
+++ b/regression/goto-cc-cbmc/mixed-c-library-goto-main/main.c
@@ -1,0 +1,12 @@
+
+extern int getone();
+
+#include <assert.h>
+
+int main(int argc, char** argv) {
+  assert(getone()==1);
+}
+
+int altmain() {
+  assert(getone()==0);
+}

--- a/regression/goto-cc-cbmc/mixed-c-library-goto-main/with_function.desc
+++ b/regression/goto-cc-cbmc/mixed-c-library-goto-main/with_function.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+lib.c --function altmain
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-cc-cbmc/mixed-c-library-goto-main/without_function.desc
+++ b/regression/goto-cc-cbmc/mixed-c-library-goto-main/without_function.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+lib.c
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/goto-cc-cbmc/mixed-goto-library-c-main/lib.c
+++ b/regression/goto-cc-cbmc/mixed-goto-library-c-main/lib.c
@@ -1,0 +1,4 @@
+
+int getone() {
+  return 1;
+}

--- a/regression/goto-cc-cbmc/mixed-goto-library-c-main/main.c
+++ b/regression/goto-cc-cbmc/mixed-goto-library-c-main/main.c
@@ -1,0 +1,12 @@
+
+extern int getone();
+
+#include <assert.h>
+
+int main(int argc, char** argv) {
+  assert(getone()==1);
+}
+
+int altmain() {
+  assert(getone()==0);
+}

--- a/regression/goto-cc-cbmc/mixed-goto-library-c-main/with_function.desc
+++ b/regression/goto-cc-cbmc/mixed-goto-library-c-main/with_function.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+lib.c --function altmain
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-cc-cbmc/mixed-goto-library-c-main/without_function.desc
+++ b/regression/goto-cc-cbmc/mixed-goto-library-c-main/without_function.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+lib.c
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/ansi-c/ansi_c_language.cpp
+++ b/src/ansi-c/ansi_c_language.cpp
@@ -36,22 +36,6 @@ void ansi_c_languaget::modules_provided(std::set<std::string> &modules)
   modules.insert(get_base_name(parse_path, true));
 }
 
-/// Generate a _start function for a specific function
-/// \param entry_function_symbol_id: The symbol for the function that should be
-///   used as the entry point
-/// \param symbol_table: The symbol table for the program. The new _start
-///   function symbol will be added to this table
-/// \return Returns false if the _start method was generated correctly
-bool ansi_c_languaget::generate_start_function(
-  const irep_idt &entry_function_symbol_id,
-  symbol_tablet &symbol_table)
-{
-  return generate_ansi_c_start_function(
-    symbol_table.symbols.at(entry_function_symbol_id),
-    symbol_table,
-    *message_handler);
-}
-
 /// ANSI-C preprocessing
 bool ansi_c_languaget::preprocess(
   std::istream &instream,
@@ -140,13 +124,19 @@ bool ansi_c_languaget::typecheck(
   return false;
 }
 
-bool ansi_c_languaget::final(symbol_tablet &symbol_table)
+bool ansi_c_languaget::generate_support_functions(
+  symbol_tablet &symbol_table)
 {
+  // Note this can happen here because C doesn't currently
+  // support lazy loading at the symbol-table level, and therefore
+  // function bodies have already been populated and external stub
+  // symbols created during the typecheck() phase. If it gains lazy
+  // loading support then stubs will need to be created during
+  // function body parsing, or else generate-stubs moved to the
+  // final phase.
   generate_opaque_method_stubs(symbol_table);
-  if(ansi_c_entry_point(symbol_table, get_message_handler()))
-    return true;
-
-  return false;
+  // This creates __CPROVER_start and __CPROVER_initialize:
+  return ansi_c_entry_point(symbol_table, get_message_handler());
 }
 
 void ansi_c_languaget::show_parse(std::ostream &out)

--- a/src/ansi-c/ansi_c_language.h
+++ b/src/ansi-c/ansi_c_language.h
@@ -31,12 +31,12 @@ public:
     std::istream &instream,
     const std::string &path) override;
 
+  bool generate_support_functions(
+    symbol_tablet &symbol_table) override;
+
   bool typecheck(
     symbol_tablet &symbol_table,
     const std::string &module) override;
-
-  bool final(
-    symbol_tablet &symbol_table) override;
 
   void show_parse(std::ostream &out) override;
 
@@ -72,10 +72,6 @@ public:
   std::set<std::string> extensions() const override;
 
   void modules_provided(std::set<std::string> &modules) override;
-
-  virtual bool generate_start_function(
-    const irep_idt &entry_function_symbol_id,
-    class symbol_tablet &symbol_table) override;
 
 protected:
   ansi_c_parse_treet parse_tree;

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -52,7 +52,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/show_properties.h>
 #include <goto-programs/string_abstraction.h>
 #include <goto-programs/string_instrumentation.h>
-#include <goto-programs/rebuild_goto_start_function.h>
 
 #include <goto-symex/rewrite_union.h>
 #include <goto-symex/adjust_float_expressions.h>
@@ -629,21 +628,6 @@ int cbmc_parse_optionst::get_goto_program(
     // Remove all binaries from the command line as they
     // are already compiled
       return 6;
-
-    if(cmdline.isset("function"))
-    {
-      const std::string &function_id=cmdline.get_value("function");
-      rebuild_goto_start_functiont start_function_rebuilder(
-          get_message_handler(),
-          cmdline,
-          goto_model.symbol_table,
-          goto_model.goto_functions);
-
-      if(start_function_rebuilder(function_id))
-      {
-        return 6;
-      }
-    }
 
     if(cmdline.isset("show-symbol-table"))
     {

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -14,7 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/ui_message.h>
 #include <util/parse_options.h>
-#include <goto-programs/rebuild_goto_start_function.h>
+#include <util/language.h>
 
 #include <analyses/goto_check.h>
 

--- a/src/cpp/cpp_language.cpp
+++ b/src/cpp/cpp_language.cpp
@@ -53,22 +53,6 @@ void cpp_languaget::modules_provided(std::set<std::string> &modules)
   modules.insert(get_base_name(parse_path, true));
 }
 
-/// Generate a _start function for a specific function
-/// \param entry_function_symbol_id: The symbol for the function that should be
-///   used as the entry point
-/// \param symbol_table: The symbol table for the program. The new _start
-///   function symbol will be added to this table
-/// \return Returns false if the _start method was generated correctly
-bool cpp_languaget::generate_start_function(
-  const irep_idt &entry_function_symbol_id,
-  symbol_tablet &symbol_table)
-{
-  return generate_ansi_c_start_function(
-    symbol_table.lookup(entry_function_symbol_id),
-    symbol_table,
-    *message_handler);
-}
-
 /// ANSI-C preprocessing
 bool cpp_languaget::preprocess(
   std::istream &instream,
@@ -150,12 +134,10 @@ bool cpp_languaget::typecheck(
   return linking(symbol_table, new_symbol_table, get_message_handler());
 }
 
-bool cpp_languaget::final(symbol_tablet &symbol_table)
+bool cpp_languaget::generate_support_functions(
+  symbol_tablet &symbol_table)
 {
-  if(ansi_c_entry_point(symbol_table, get_message_handler()))
-    return true;
-
-  return false;
+  return ansi_c_entry_point(symbol_table, get_message_handler());
 }
 
 void cpp_languaget::show_parse(std::ostream &out)

--- a/src/cpp/cpp_language.h
+++ b/src/cpp/cpp_language.h
@@ -33,6 +33,9 @@ public:
     std::istream &instream,
     const std::string &path) override;
 
+  bool generate_support_functions(
+    symbol_tablet &symbol_table) override;
+
   bool typecheck(
     symbol_tablet &symbol_table,
     const std::string &module) override;
@@ -42,9 +45,6 @@ public:
     symbol_tablet &src,
     const std::string &module,
     class replace_symbolt &replace_symbol) const;
-
-  bool final(
-    symbol_tablet &symbol_table) override;
 
   void show_parse(std::ostream &out) override;
 
@@ -84,10 +84,6 @@ public:
   std::set<std::string> extensions() const override;
 
   void modules_provided(std::set<std::string> &modules) override;
-
-  virtual bool generate_start_function(
-    const irep_idt &entry_function_symbol_id,
-    class symbol_tablet &symbol_table) override;
 
 protected:
   cpp_parse_treet cpp_parse_tree;

--- a/src/goto-analyzer/goto_analyzer_parse_options.h
+++ b/src/goto-analyzer/goto_analyzer_parse_options.h
@@ -14,10 +14,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/ui_message.h>
 #include <util/parse_options.h>
+#include <util/language.h>
 
 #include <goto-programs/goto_model.h>
 #include <goto-programs/show_goto_functions.h>
-#include <goto-programs/rebuild_goto_start_function.h>
 
 #include <analyses/goto_check.h>
 

--- a/src/goto-programs/initialize_goto_model.cpp
+++ b/src/goto-programs/initialize_goto_model.cpp
@@ -53,12 +53,11 @@ bool initialize_goto_model(
         sources.push_back(file);
     }
 
+    language_filest language_files;
+    language_files.set_message_handler(message_handler);
+
     if(!sources.empty())
     {
-      language_filest language_files;
-
-      language_files.set_message_handler(message_handler);
-
       for(const auto &filename : sources)
       {
         #ifdef _MSC_VER
@@ -114,19 +113,6 @@ bool initialize_goto_model(
         msg.error() << "CONVERSION ERROR" << messaget::eom;
         return true;
       }
-
-      if(binaries.empty())
-      {
-        // Enable/disable stub generation for opaque methods
-        bool stubs_enabled=cmdline.isset("generate-opaque-stubs");
-        language_files.set_should_generate_opaque_method_stubs(stubs_enabled);
-
-        if(language_files.final(goto_model.symbol_table))
-        {
-          msg.error() << "CONVERSION ERROR" << messaget::eom;
-          return true;
-        }
-      }
     }
 
     for(const auto &file : binaries)
@@ -137,17 +123,49 @@ bool initialize_goto_model(
         return true;
     }
 
-    if(cmdline.isset("function"))
+    bool binaries_provided_start=
+      goto_model.symbol_table.has_symbol(goto_functionst::entry_point());
+
+    bool entry_point_generation_failed=false;
+
+    if(binaries_provided_start && cmdline.isset("function"))
     {
-      const std::string &function_id=cmdline.get_value("function");
-      rebuild_goto_start_functiont start_function_rebuilder(
+      // Rebuild the entry-point, using the language annotation of the
+      // existing __CPROVER_start function:
+      rebuild_goto_start_functiont rebuild_existing_start(
         msg.get_message_handler(),
         cmdline,
         goto_model.symbol_table,
         goto_model.goto_functions);
+      entry_point_generation_failed=rebuild_existing_start();
+    }
+    else if(!binaries_provided_start)
+    {
+      // Unsure of the rationale for only generating stubs when there are no
+      // GOTO binaries in play; simply mirroring old code in language_uit here.
+      if(binaries.empty())
+      {
+        // Enable/disable stub generation for opaque methods
+        bool stubs_enabled=cmdline.isset("generate-opaque-stubs");
+        language_files.set_should_generate_opaque_method_stubs(stubs_enabled);
+      }
 
-      if(start_function_rebuilder(function_id))
-        return true;
+      // Allow all language front-ends to try to provide the user-specified
+      // (--function) entry-point, or some language-specific default:
+      entry_point_generation_failed=
+        language_files.generate_support_functions(goto_model.symbol_table);
+    }
+
+    if(entry_point_generation_failed)
+    {
+      msg.error() << "SUPPORT FUNCTION GENERATION ERROR" << messaget::eom;
+      return true;
+    }
+
+    if(language_files.final(goto_model.symbol_table))
+    {
+      msg.error() << "FINAL STAGE CONVERSION ERROR" << messaget::eom;
+      return true;
     }
 
     msg.status() << "Generating GOTO Program" << messaget::eom;

--- a/src/goto-programs/rebuild_goto_start_function.cpp
+++ b/src/goto-programs/rebuild_goto_start_function.cpp
@@ -44,8 +44,7 @@ rebuild_goto_start_functiont::rebuild_goto_start_functiont(
 /// called from _start
 /// \return Returns true if either the symbol is not found, or something went
 ///   wrong with generating the start_function. False otherwise.
-bool rebuild_goto_start_functiont::operator()(
-  const irep_idt &entry_function)
+bool rebuild_goto_start_functiont::operator()()
 {
   const irep_idt &mode=get_entry_point_mode();
 
@@ -59,7 +58,7 @@ bool rebuild_goto_start_functiont::operator()(
   remove_existing_entry_point();
 
   bool return_code=
-    language->generate_start_function(entry_function, symbol_table);
+    language->generate_support_functions(symbol_table);
 
   // Remove the function from the goto_functions so it is copied back in
   // from the symbol table during goto_convert

--- a/src/goto-programs/rebuild_goto_start_function.h
+++ b/src/goto-programs/rebuild_goto_start_function.h
@@ -30,7 +30,7 @@ public:
     symbol_tablet &symbol_table,
     goto_functionst &goto_functions);
 
-  bool operator()(const irep_idt &entry_function);
+  bool operator()();
 
 private:
   irep_idt get_entry_point_mode() const;

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -109,30 +109,6 @@ void java_bytecode_languaget::modules_provided(std::set<std::string> &modules)
   // modules.insert(translation_unit(parse_path));
 }
 
-/// Generate a _start function for a specific function.
-/// \param entry_function_symbol_id: The symbol for the function that should be
-///   used as the entry point
-/// \param symbol_table: The symbol table for the program. The new _start
-///   function symbol will be added to this table
-/// \return Returns false if the _start method was generated correctly
-bool java_bytecode_languaget::generate_start_function(
-  const irep_idt &entry_function_symbol_id,
-  symbol_tablet &symbol_table)
-{
-  PRECONDITION(language_options_initialized);
-  const auto res=
-    get_main_symbol(
-      symbol_table, entry_function_symbol_id, get_message_handler());
-
-  return generate_java_start_function(
-    res.main_function,
-    symbol_table,
-    get_message_handler(),
-    assume_inputs_non_null,
-    object_factory_parameters,
-    *pointer_type_selector);
-}
-
 /// ANSI-C preprocessing
 bool java_bytecode_languaget::preprocess(
   std::istream &instream,
@@ -205,6 +181,8 @@ bool java_bytecode_languaget::typecheck(
 {
   PRECONDITION(language_options_initialized);
 
+  java_internal_additions(symbol_table);
+
   if(string_refinement_enabled)
     string_preprocess.initialize_conversion_table();
 
@@ -265,6 +243,27 @@ bool java_bytecode_languaget::typecheck(
     return true;
 
   return false;
+}
+
+bool java_bytecode_languaget::generate_support_functions(
+  symbol_tablet &symbol_table)
+{
+  PRECONDITION(language_options_initialized);
+
+  main_function_resultt res=
+    get_main_symbol(symbol_table, main_class, get_message_handler());
+  if(res.stop_convert)
+    return res.error_found;
+
+  // generate the test harness in __CPROVER__start and a call the entry point
+  return
+    java_entry_point(
+      symbol_table,
+      main_class,
+      get_message_handler(),
+      assume_inputs_non_null,
+      object_factory_parameters,
+      get_pointer_type_selector());
 }
 
 /// Uses a simple context-insensitive ('ci') analysis to determine which methods
@@ -391,25 +390,11 @@ void java_bytecode_languaget::replace_string_methods(
 bool java_bytecode_languaget::final(symbol_tablet &symbol_table)
 {
   PRECONDITION(language_options_initialized);
-  java_internal_additions(symbol_table);
 
   // replace code of String methods calls by code we generate
   replace_string_methods(symbol_table);
 
-  main_function_resultt res=
-    get_main_symbol(symbol_table, main_class, get_message_handler());
-  if(res.stop_convert)
-    return res.error_found;
-
-  // generate the test harness in __CPROVER__start and a call the entry point
-  return
-    java_entry_point(
-      symbol_table,
-      main_class,
-      get_message_handler(),
-      assume_inputs_non_null,
-      object_factory_parameters,
-      get_pointer_type_selector());
+  return false;
 }
 
 void java_bytecode_languaget::show_parse(std::ostream &out)

--- a/src/java_bytecode/java_bytecode_language.h
+++ b/src/java_bytecode/java_bytecode_language.h
@@ -98,6 +98,9 @@ public:
     std::istream &instream,
     const std::string &path) override;
 
+  bool generate_support_functions(
+    symbol_tablet &symbol_table) override;
+
   bool typecheck(
     symbol_tablet &context,
     const std::string &module) override;
@@ -153,10 +156,6 @@ public:
   virtual void lazy_methods_provided(std::set<irep_idt> &) const override;
   virtual void convert_lazy_method(
     const irep_idt &id, symbol_tablet &) override;
-
-  virtual bool generate_start_function(
-    const irep_idt &entry_function_symbol_id,
-    class symbol_tablet &symbol_table) override;
 
 protected:
   bool do_ci_lazy_method_conversion(symbol_tablet &, lazy_methodst &);

--- a/src/java_bytecode/java_entry_point.cpp
+++ b/src/java_bytecode/java_entry_point.cpp
@@ -13,6 +13,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <unordered_set>
 #include <iostream>
 
+#include <linking/static_lifetime_init.h>
+
 #include <util/arith_tools.h>
 #include <util/prefix.h>
 #include <util/std_types.h>
@@ -34,13 +36,15 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "java_types.h"
 #include "java_utils.h"
 
-#define INITIALIZE CPROVER_PREFIX "initialize"
-
 static void create_initialize(symbol_tablet &symbol_table)
 {
+  // If __CPROVER_initialize already exists, replace it. It may already exist
+  // if a GOTO binary provided it. This behaviour mirrors the ANSI-C frontend.
+  symbol_table.symbols.erase(INITIALIZE_FUNCTION);
+
   symbolt initialize;
-  initialize.name=INITIALIZE;
-  initialize.base_name=INITIALIZE;
+  initialize.name=INITIALIZE_FUNCTION;
+  initialize.base_name=INITIALIZE_FUNCTION;
   initialize.mode=ID_java;
 
   code_typet type;
@@ -59,8 +63,7 @@ static void create_initialize(symbol_tablet &symbol_table)
 
   initialize.value=init_code;
 
-  if(symbol_table.add(initialize))
-    throw "failed to add "+std::string(INITIALIZE);
+  symbol_table.add(initialize);
 }
 
 static bool should_init_symbol(const symbolt &sym)
@@ -93,7 +96,7 @@ void java_static_lifetime_init(
   const object_factory_parameterst &object_factory_parameters,
   const select_pointer_typet &pointer_type_selector)
 {
-  symbolt &initialize_symbol=symbol_table.lookup(INITIALIZE);
+  symbolt &initialize_symbol=symbol_table.lookup(INITIALIZE_FUNCTION);
   code_blockt &code_block=to_code_block(to_code(initialize_symbol.value));
 
   // We need to zero out all static variables, or nondet-initialize if they're
@@ -539,11 +542,11 @@ bool generate_java_start_function(
   // build call to initialization function
   {
     symbol_tablet::symbolst::iterator init_it=
-      symbol_table.symbols.find(INITIALIZE);
+      symbol_table.symbols.find(INITIALIZE_FUNCTION);
 
     if(init_it==symbol_table.symbols.end())
     {
-      message.error() << "failed to find " INITIALIZE " symbol"
+      message.error() << "failed to find " INITIALIZE_FUNCTION " symbol"
                       << messaget::eom;
       return true; // give up with error
     }

--- a/src/jsil/jsil_language.cpp
+++ b/src/jsil/jsil_language.cpp
@@ -41,22 +41,6 @@ bool jsil_languaget::interfaces(symbol_tablet &symbol_table)
   return false;
 }
 
-/// Generate a _start function for a specific function
-/// \param entry_function_symbol_id: The symbol for the function that should be
-///   used as the entry point
-/// \param symbol_table: The symbol table for the program. The new _start
-///   function symbol will be added to this table
-/// \return Returns false if the _start method was generated correctly
-bool jsil_languaget::generate_start_function(
-  const irep_idt &entry_function_symbol_id,
-  symbol_tablet &symbol_table)
-{
-  // TODO(tkiley): This should be implemented if this language
-  // is used.
-  UNREACHABLE;
-  return true;
-}
-
 bool jsil_languaget::preprocess(
   std::istream &instream,
   const std::string &path,
@@ -102,14 +86,12 @@ bool jsil_languaget::typecheck(
   return false;
 }
 
-bool jsil_languaget::final(symbol_tablet &symbol_table)
+bool jsil_languaget::generate_support_functions(
+  symbol_tablet &symbol_table)
 {
-  if(jsil_entry_point(
-      symbol_table,
-      get_message_handler()))
-    return true;
-
-  return false;
+  return jsil_entry_point(
+    symbol_table,
+    get_message_handler());
 }
 
 void jsil_languaget::show_parse(std::ostream &out)

--- a/src/jsil/jsil_language.h
+++ b/src/jsil/jsil_language.h
@@ -31,11 +31,12 @@ public:
     std::istream &instream,
     const std::string &path) override;
 
+  virtual bool generate_support_functions(
+    symbol_tablet &symbol_table) override;
+
   virtual bool typecheck(
     symbol_tablet &context,
     const std::string &module) override;
-
-  virtual bool final(symbol_tablet &context) override;
 
   virtual void show_parse(std::ostream &out) override;
 
@@ -68,10 +69,6 @@ public:
 
   virtual void modules_provided(std::set<std::string> &modules) override;
   virtual bool interfaces(symbol_tablet &symbol_table) override;
-
-  virtual bool generate_start_function(
-    const irep_idt &entry_function_symbol_id,
-    class symbol_tablet &symbol_table) override;
 
 protected:
   jsil_parse_treet parse_tree;

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -28,6 +28,12 @@ class namespacet;
 class typet;
 class cmdlinet;
 
+#define OPT_FUNCTIONS \
+  "(function):"
+
+#define HELP_FUNCTIONS \
+  " --function name              set main function name\n"
+
 class languaget:public messaget
 {
 public:
@@ -44,6 +50,17 @@ public:
   virtual bool parse(
     std::istream &instream,
     const std::string &path)=0;
+
+  /// Create language-specific support functions, such as __CPROVER_start,
+  /// __CPROVER_initialize and language-specific library functions.
+  /// This runs after the `typecheck` phase but before lazy function loading.
+  /// Anything that must wait until lazy function loading is done can be
+  /// deferred until `final`, which runs after lazy function loading is
+  /// complete. Functions introduced here are visible to lazy loading and
+  /// can influence its decisions (e.g. picking the types of input parameters
+  /// and globals), whereas anything introduced during `final` cannot.
+  virtual bool generate_support_functions(
+    symbol_tablet &symbol_table)=0;
 
   // add external dependencies of a given module to set
 
@@ -65,8 +82,8 @@ public:
   virtual void convert_lazy_method(const irep_idt &id, symbol_tablet &)
   { }
 
-  // final adjustments, e.g., initialization and call to main()
-
+  /// Final adjustments, e.g. initializing stub functions and globals that
+  /// were discovered during function loading
   virtual bool final(
     symbol_tablet &symbol_table);
 
@@ -118,10 +135,6 @@ public:
   virtual std::unique_ptr<languaget> new_language()=0;
 
   void set_should_generate_opaque_method_stubs(bool should_generate_stubs);
-
-  virtual bool generate_start_function(
-    const irep_idt &entry_function_symbol_id,
-    class symbol_tablet &symbol_table)=0;
 
   // constructor / destructor
 

--- a/src/util/language_file.cpp
+++ b/src/util/language_file.cpp
@@ -165,6 +165,22 @@ bool language_filest::typecheck(symbol_tablet &symbol_table)
   return false;
 }
 
+bool language_filest::generate_support_functions(
+  symbol_tablet &symbol_table)
+{
+  std::set<std::string> languages;
+
+  for(file_mapt::iterator it=file_map.begin();
+      it!=file_map.end(); it++)
+  {
+    if(languages.insert(it->second.language->id()).second)
+      if(it->second.language->generate_support_functions(symbol_table))
+        return true;
+  }
+
+  return false;
+}
+
 bool language_filest::final(
   symbol_tablet &symbol_table)
 {

--- a/src/util/language_file.h
+++ b/src/util/language_file.h
@@ -83,6 +83,8 @@ public:
 
   void show_parse(std::ostream &out);
 
+  bool generate_support_functions(symbol_tablet &symbol_table);
+
   bool typecheck(symbol_tablet &symbol_table);
 
   bool final(symbol_tablet &symbol_table);


### PR DESCRIPTION
The new generate_support_functions phase creates __CPROVER_start and __CPROVER_initialize and runs before lazy loading; the final phase will run *after* lazy loading, and is therefore used to patch up changes that require functions' bodies to have been loaded already.

In subsequent PRs, lazy loading will take advantage of this to read __CPROVER_start and use it to guide its work; CI-lazy-loading will use it to replace its current hackish logic to guess how globals and parameters will be initialised.