### PR TITLE
TG-634 (Rollback) Remove invariant causing failure in unit test generation involving CharSequences

### DIFF
--- a/src/java_bytecode/java_object_factory.cpp
+++ b/src/java_bytecode/java_object_factory.cpp
@@ -882,13 +882,6 @@ void java_object_factoryt::gen_nondet_struct_init(
               binary_relation_exprt(me, ID_le, max_length)));
           }
         }
-        else
-        {
-          INVARIANT(
-            class_identifier!="java.lang.CharSequence" &&
-              class_identifier!="java.lang.AbstractStringBuilder",
-            "Trying to initialize abstract class");
-        }
       }
     }
   }


### PR DESCRIPTION
This change was piggybacked on top of another PR without rerunning CI on ~test-gen~ Deeptest repository, accidentally breaking it.

@romainbrenguier @allredj Please, review ASAP, it's blocking all Deeptest changes.
