### PR TITLE
[TG-634] Logical expression building utility

### DIFF
--- a/src/solvers/refinement/axt.h
+++ b/src/solvers/refinement/axt.h
@@ -1,0 +1,88 @@
+/*******************************************************************\
+
+ Module: Expression Building Utility
+
+ Author: Diffblue Limited. All rights reserved.
+
+\*******************************************************************/
+#ifndef CPROVER_SOLVERS_REFINEMENT_AXT_H
+#define CPROVER_SOLVERS_REFINEMENT_AXT_H
+
+#include <util/expr.h>
+#include <util/string_expr.h>
+
+/// Thin wrapper for exprt class assigning different meaning to operators
+/// Performing logical expression on axt will not yield usual results
+/// (with exception of assignment operator), but rather new axt
+/// instances containing trees of logical expressions expressed as exprt
+/// hierarchies.
+class axt final
+{
+public:
+  axt(const exprt &expr) // NOLINT Use implicit conversions for best results
+    : expr(expr)
+  {
+  }
+  axt operator>(const axt &rhs) const
+  {
+    return axt(binary_relation_exprt(expr, ID_gt, rhs.expr));
+  }
+  axt operator<(const axt &rhs) const
+  {
+    return axt(binary_relation_exprt(expr, ID_lt, rhs.expr));
+  }
+  axt operator>=(const axt &rhs) const
+  {
+    return axt(binary_relation_exprt(expr, ID_ge, rhs.expr));
+  }
+  axt operator<=(const axt &rhs) const
+  {
+    return axt(binary_relation_exprt(expr, ID_le, rhs.expr));
+  }
+  axt operator==(const axt &rhs) const
+  {
+    return axt(equal_exprt(expr, rhs.expr));
+  }
+  axt operator!=(const axt &rhs) const
+  {
+    return axt(notequal_exprt(expr, rhs.expr));
+  }
+  // Implication
+  axt operator>>=(const axt &rhs) const
+  {
+    return axt(implies_exprt(expr, rhs.expr));
+  }
+  axt operator+(const axt &rhs) const
+  {
+    return axt(plus_exprt(expr, rhs.expr));
+  }
+  axt operator-(const axt &rhs) const
+  {
+    return axt(minus_exprt(expr, rhs.expr));
+  }
+  axt operator&&(const axt &rhs) const
+  {
+    return axt(and_exprt(expr, rhs.expr));
+  }
+  axt operator||(const axt &rhs) const
+  {
+    return axt(or_exprt(expr, rhs.expr));
+  }
+  axt operator[](const axt &index) const
+  {
+    return axt(to_string_expr(expr)[index.expr]);
+  }
+  axt operator!()
+  {
+    return axt(not_exprt(expr));
+  }
+  operator exprt() const
+  {
+    return expr;
+  }
+
+private:
+  exprt expr;
+};
+
+#endif // CPROVER_SOLVERS_REFINEMENT_AXT_H


### PR DESCRIPTION
This PR implements an `exprt` wrapper for constructing logical expression hierarchies using C++ operators.

Additionally, this PR contains small refactor on one of the most used string functions to show that it's working as intended.

For example, it lets following code:
```c++
exprt res_length=plus_exprt( 
  s1.length(), minus_exprt(end_index, start_index));
binary_relation_exprt prem(end_index, ID_gt, start_index); 
implies_exprt a1(prem, equal_exprt(res.length(), res_length));
```

be expressed this way:

```c++
exprt a1 = end_index > start_index >>=
           axt(s1.length()) + end_index - start_index == axt(res.length());

```


Part 2 of [String Refinement overhaul PR](https://github.com/diffblue/cbmc/pull/1399/commits)