### PR TITLE
Remove unused identifier

### DIFF
--- a/src/goto-diff/unified_diff.cpp
+++ b/src/goto-diff/unified_diff.cpp
@@ -384,15 +384,26 @@ void unified_difft::output(std::ostream &os) const
 
   for(const std::pair<irep_idt, differencest> &p : differences_map)
   {
-    goto_functionst::function_mapt::const_iterator f1=
-      old_goto_functions.function_map.find(p.first);
-    goto_functionst::function_mapt::const_iterator f2=
-      new_goto_functions.function_map.find(p.first);
+    const irep_idt &function=p.first;
+
+    goto_functionst::function_mapt::const_iterator old_fit=
+      old_goto_functions.function_map.find(function);
+    goto_functionst::function_mapt::const_iterator new_fit=
+      new_goto_functions.function_map.find(function);
+
+    const goto_programt &old_goto_program=
+      old_fit==old_goto_functions.function_map.end() ?
+      empty :
+      old_fit->second.body;
+    const goto_programt &new_goto_program=
+      new_fit==new_goto_functions.function_map.end() ?
+      empty :
+      new_fit->second.body;
 
     output_diff(
-      p.first,
-      f1==old_goto_functions.function_map.end()?empty:f1->second.body,
-      f2==new_goto_functions.function_map.end()?empty:f2->second.body,
+      function,
+      old_goto_program,
+      new_goto_program,
       p.second,
       os);
   }

--- a/src/goto-diff/unified_diff.cpp
+++ b/src/goto-diff/unified_diff.cpp
@@ -54,7 +54,6 @@ void unified_difft::get_diff(
     new_fit->second.body;
 
   get_diff(
-    function,
     old_goto_program,
     new_goto_program,
     entry->second,
@@ -62,7 +61,6 @@ void unified_difft::get_diff(
 }
 
 void unified_difft::get_diff(
-  const irep_idt &identifier,
   const goto_programt &old_goto_program,
   const goto_programt &new_goto_program,
   const differencest &differences,
@@ -109,7 +107,6 @@ void unified_difft::output_diff(
 {
   goto_program_difft diff;
   get_diff(
-    identifier,
     old_goto_program,
     new_goto_program,
     differences,

--- a/src/goto-diff/unified_diff.h
+++ b/src/goto-diff/unified_diff.h
@@ -76,7 +76,6 @@ protected:
     differencest &differences) const;
 
   void get_diff(
-    const irep_idt &identifier,
     const goto_programt &old_goto_program,
     const goto_programt &new_goto_program,
     const differencest &differences,


### PR DESCRIPTION
Remove unused function identifier parameter from unified_difft.getdiff() and changes to unified_difft.output() to improve readability by making it similar in style to two parameter version of unified_difft.getdiff()