### PR TITLE
Add a filtered show function to the symbol table

### DIFF
--- a/src/util/symbol_table.cpp
+++ b/src/util/symbol_table.cpp
@@ -107,10 +107,30 @@ bool symbol_tablet::remove(const irep_idt &name)
 /// \param out: The ostream to direct output to
 void symbol_tablet::show(std::ostream &out) const
 {
+  show(out, [](const symbolt &){ return true; });
+}
+
+/// Print the contents of the symbol table that meet the filters requirements.
+/// It can be used to for example only print out type symbols:
+/// ```
+/// show(std::cout, [](const symbolt &symbol) { return symbol.is_type; });
+/// ```
+/// \param out: The ostream to direct output to
+/// \param print_condition: A predicate that determines whether a given
+///   symbol should be printed.
+void symbol_tablet::show(
+  std::ostream &out,
+  std::function<bool (const symbolt &)> print_condition) const
+{
   out << "\n" << "Symbols:" << "\n";
 
-  forall_symbols(it, symbols)
-    out << it->second;
+  for(const auto &symbol : symbols)
+  {
+    if(print_condition(symbol.second))
+    {
+      out << symbol.second;
+    }
+  }
 }
 
 /// Find a symbol in the symbol table. Throws a string if no such symbol is

--- a/src/util/symbol_table.cpp
+++ b/src/util/symbol_table.cpp
@@ -119,8 +119,7 @@ void symbol_tablet::show(std::ostream &out) const
 /// \param print_condition: A predicate that determines whether a given
 ///   symbol should be printed.
 void symbol_tablet::show(
-  std::ostream &out,
-  std::function<bool (const symbolt &)> print_condition) const
+  std::ostream &out, std::function<bool(const symbolt&)> print_condition) const
 {
   out << "\n" << "Symbols:" << "\n";
 

--- a/src/util/symbol_table.cpp
+++ b/src/util/symbol_table.cpp
@@ -119,7 +119,8 @@ void symbol_tablet::show(std::ostream &out) const
 /// \param print_condition: A predicate that determines whether a given
 ///   symbol should be printed.
 void symbol_tablet::show(
-  std::ostream &out, std::function<bool(const symbolt&)> print_condition) const
+  std::ostream &out,
+  symbol_tablet::symbol_filter_functiont print_condition) const
 {
   out << "\n" << "Symbols:" << "\n";
 

--- a/src/util/symbol_table.h
+++ b/src/util/symbol_table.h
@@ -22,6 +22,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <iosfwd>
 #include <map>
 #include <unordered_map>
+#include <functional>
 
 #include "symbol.h"
 
@@ -76,6 +77,10 @@ public:
   bool remove(const irep_idt &name);
 
   void show(std::ostream &out) const;
+
+  void show(
+    std::ostream &out,
+    std::function<bool(const symbolt &symbol)> print_condition) const;
 
   void swap(symbol_tablet &other)
   {

--- a/src/util/symbol_table.h
+++ b/src/util/symbol_table.h
@@ -47,6 +47,7 @@ typedef std::multimap<irep_idt, irep_idt> symbol_module_mapt;
                                          it_end=(expr).upper_bound(module); \
       it!=it_end; ++it)
 
+
 /*! \brief The symbol table
     \ingroup gr_symbol_table
 */
@@ -78,9 +79,10 @@ public:
 
   void show(std::ostream &out) const;
 
+  using symbol_filter_functiont=std::function<bool(const symbolt &symbol)>;
   void show(
     std::ostream &out,
-    std::function<bool(const symbolt &symbol)> print_condition) const;
+    symbol_filter_functiont print_condition) const;
 
   void swap(symbol_tablet &other)
   {


### PR DESCRIPTION
Function allows specifying a predicate that determines whether a given symbol to be printed. This can be very useful when debugging large symbol tables.