### PR TITLE
Set opaque stub generation in initialize-goto-model

### DIFF
--- a/src/goto-programs/initialize_goto_model.cpp
+++ b/src/goto-programs/initialize_goto_model.cpp
@@ -117,6 +117,10 @@ bool initialize_goto_model(
 
       if(binaries.empty())
       {
+        // Enable/disable stub generation for opaque methods
+        bool stubs_enabled=cmdline.isset("generate-opaque-stubs");
+        language_files.set_should_generate_opaque_method_stubs(stubs_enabled);
+
         if(language_files.final(goto_model.symbol_table))
         {
           msg.error() << "CONVERSION ERROR" << messaget::eom;


### PR DESCRIPTION
This mirrors existing code in now-redundant language_uit. Required to port test-gen to use initialize-goto-model.