### PR TITLE
Object factory: initialise global symbols in place

### DIFF
--- a/src/java_bytecode/java_entry_point.cpp
+++ b/src/java_bytecode/java_entry_point.cpp
@@ -125,18 +125,17 @@ void java_static_lifetime_init(
           if(allow_null && is_non_null_library_global(nameid))
             allow_null=false;
         }
-        auto newsym=object_factory(
-          sym.type,
-          symname,
+        gen_nondet_init(
+          sym.symbol_expr(),
           code_block,
-          allow_null,
           symbol_table,
-          object_factory_parameters,
-          allocation_typet::GLOBAL,
           source_location,
-          pointer_type_selector);
-        code_assignt assignment(sym.symbol_expr(), newsym);
-        code_block.add(assignment);
+          false,
+          allocation_typet::GLOBAL,
+          allow_null,
+          object_factory_parameters,
+          pointer_type_selector,
+          update_in_placet::NO_UPDATE_IN_PLACE);
       }
       else if(sym.value.is_not_nil())
       {


### PR DESCRIPTION
This eliminates a misleading attribution of global symbols to __CPROVER_start, which could lead to their elimination by replace_entry_pointt. Specifically, before we would get something like:

```
Integer* __CPROVER__start::somepackage.someglobal = new Integer();
somepackage.someglobal = __CPROVER__start::somepackage.someglobal;
```

whereas now we simply initialize the global symbol in place, avoiding the problem with misattributing locals in __CPROVER_initialize to __CPROVER_start by not using locals at all.

This change is required to port test-gen to use initialize-goto-model, which calls regenerate-start-function, which in turn purges all __CPROVER__start functions as part of its work of replacing a (perhaps) pre-existing __CPROVER_start with a new one as directed by the `--function` command-line option.