### PR TITLE
Block coverage now reports all source code lines contributing to a ba…

### DIFF
--- a/regression/cbmc/block-coverage-report1/main.c
+++ b/regression/cbmc/block-coverage-report1/main.c
@@ -1,0 +1,10 @@
+int main() {
+
+  int x;
+
+  if (x<0)
+    return 0;
+  else
+    return 1;
+
+}

--- a/regression/cbmc/block-coverage-report1/test.desc
+++ b/regression/cbmc/block-coverage-report1/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--cover location
+block 1 \(lines main.c:main:3,5\): SATISFIED
+block 2 \(lines main.c:main:6\): SATISFIED
+block 3 \(lines main.c:main:6,10\): FAILED
+block 4 \(lines main.c:main:8\): SATISFIED
+block 5 \(lines main.c:main:10\): SATISFIED
+--

--- a/regression/cbmc/block-coverage-report2/main.c
+++ b/regression/cbmc/block-coverage-report2/main.c
@@ -1,0 +1,24 @@
+// This is supposed to be testing basic blocks with inlining,
+// but cbmc has now turned off inlining by default.
+
+inline int foo(int x) {
+  int y;
+  y = x+1;
+  return y;
+}
+
+main() {
+
+  int x;
+  x =10;
+  while (x) {
+    int y;
+    y = foo(x);
+    if (y < 5)
+      break;
+    x--;
+  }
+
+  return;
+
+}

--- a/regression/cbmc/block-coverage-report2/test.desc
+++ b/regression/cbmc/block-coverage-report2/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--cover location
+block 1 \(lines main.c:main:12,13\): SATISFIED
+block 2 \(lines main.c:main:14\): SATISFIED
+block 3 \(lines main.c:main:15,16\): SATISFIED
+block 4 \(lines main.c:main:16,17\): SATISFIED
+block 5 \(lines main.c:main:18\): SATISFIED
+block 6 \(lines main.c:main:14,19,20\): SATISFIED
+block 7 \(lines main.c:main:22,24\): SATISFIED
+block 1 \(lines main.c:foo:5,6,7,8\): SATISFIED
+--

--- a/regression/cbmc/block-coverage-report3/main.c
+++ b/regression/cbmc/block-coverage-report3/main.c
@@ -1,0 +1,6 @@
+void main() {
+  int x = 0;
+  while (x < 3) {
+    x++;
+  }
+}

--- a/regression/cbmc/block-coverage-report3/test.desc
+++ b/regression/cbmc/block-coverage-report3/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--cover location --unwind 1
+block 1 \(lines main.c:main:2\): SATISFIED
+block 2 \(lines main.c:main:3\): SATISFIED
+block 3 \(lines main.c:main:3,4\): SATISFIED
+block 4 \(lines main.c:main:6\): FAILED
+--

--- a/regression/cbmc/block-coverage-report4/main.c
+++ b/regression/cbmc/block-coverage-report4/main.c
@@ -1,0 +1,6 @@
+void main() {
+  int x = 0;
+  while (x < 3) {
+    x++;
+  }
+}

--- a/regression/cbmc/block-coverage-report4/test.desc
+++ b/regression/cbmc/block-coverage-report4/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--cover location --unwind 4
+block 1 \(lines main.c:main:2\): SATISFIED
+block 2 \(lines main.c:main:3\): SATISFIED
+block 3 \(lines main.c:main:3,4\): SATISFIED
+block 4 \(lines main.c:main:6\): SATISFIED
+--


### PR DESCRIPTION
Block coverage obtained with "cbmc --cover locations" now reports the file name and line number of every line of source code contributing to a basic block in the "description" field of the xml output.  (The lines contributing to a block can come from multiple files via function inlining and definitions in include files, so reporting line numbers alone is not sufficient.)