### PR TITLE
Allow expr_dynamic_cast to be used with std_code types

### DIFF
--- a/src/util/expr_cast.h
+++ b/src/util/expr_cast.h
@@ -84,7 +84,7 @@ expr_try_dynamic_cast(const exprt &base)
   return detail::expr_try_dynamic_cast<
     T,
     typename std::remove_reference<T>::type,
-    typename std::remove_const<typename std::remove_reference<T>::type>::type,
+    typename std::decay<T>::type,
     const exprt>(base);
 }
 
@@ -101,7 +101,7 @@ expr_try_dynamic_cast(exprt &base)
   return detail::expr_try_dynamic_cast<
     T,
     typename std::remove_reference<T>::type,
-    typename std::remove_const<typename std::remove_reference<T>::type>::type,
+    typename std::decay<T>::type,
     exprt>(base);
 }
 
@@ -155,7 +155,7 @@ T expr_dynamic_cast(const exprt &base)
 {
   return detail::expr_dynamic_cast<
     T,
-    typename std::remove_const<typename std::remove_reference<T>::type>::type,
+    typename std::decay<T>::type,
     const exprt>(base);
 }
 
@@ -171,7 +171,7 @@ T expr_dynamic_cast(exprt &base)
 {
   return detail::expr_dynamic_cast<
     T,
-    typename std::remove_const<typename std::remove_reference<T>::type>::type,
+    typename std::decay<T>::type,
     exprt>(base);
 }
 

--- a/src/util/expr_cast.h
+++ b/src/util/expr_cast.h
@@ -164,8 +164,8 @@ inline void validate_operands(
 {
   DATA_INVARIANT(
     allow_more
-      ? value.operands().size()==number
-      : value.operands().size()>=number,
+      ? value.operands().size()>=number
+      : value.operands().size()==number,
     message);
 }
 

--- a/src/util/expr_cast.h
+++ b/src/util/expr_cast.h
@@ -30,6 +30,10 @@ Author: Nathan Phillips <Nathan.Phillips@diffblue.com>
 /// \return true if \a base is of type \a T
 template<typename T> bool can_cast_expr(const exprt &base);
 
+/// Called after casting. Provides a point to assert on the structure of the
+/// expr. By default, this is a no-op, but you can provide an overload to
+/// validate particular types.
+inline void validate_expr(const exprt &) {}
 
 /// \brief Try to cast a constant reference to a generic exprt to a specific
 ///   derived class

--- a/src/util/expr_cast.h
+++ b/src/util/expr_cast.h
@@ -30,22 +30,24 @@ Author: Nathan Phillips <Nathan.Phillips@diffblue.com>
 /// \return true if \a base is of type \a T
 template<typename T> bool can_cast_expr(const exprt &base);
 
-/// Called after casting. Provides a point to assert on the structure of the
+/// Called after casting.  Provides a point to assert on the structure of the
 /// expr. By default, this is a no-op, but you can provide an overload to
-/// validate particular types.
+/// validate particular types.  Should always succeed unless the program has
+/// entered an invalid state.  We validate objects at cast time as that is when
+/// these checks have been used historically, but it would be reasonable to
+/// validate objects in this way at any time.
 inline void validate_expr(const exprt &) {}
 
 namespace detail // NOLINT
 {
 
-// We hide this in a namespace so that only functions that it only
-// participates in overload resolution when explicitly requested.
+// We hide these functions in a namespace so that only functions that they only
+// participate in overload resolution when explicitly requested.
 
 /// \brief Try to cast a reference to a generic exprt to a specific derived
 ///    class
 /// \tparam T The reference or const reference type to \a TUnderlying to cast
 ///    to
-/// \tparam TUnderlying An exprt-derived class type
 /// \tparam TExpr The original type to cast from, either exprt or const exprt
 /// \param base Reference to a generic \ref exprt
 /// \return Reference to object of type \a TUnderlying
@@ -54,8 +56,8 @@ template <typename T, typename TExpr>
 optionalt<std::reference_wrapper<typename std::remove_reference<T>::type>>
 expr_try_dynamic_cast(TExpr &base)
 {
-  typedef typename std::decay<T>::type TUnderlying;
-  typedef typename std::remove_reference<T>::type TConst;
+  typedef typename std::decay<T>::type TUnderlyingt;
+  typedef typename std::remove_reference<T>::type TConstt;
   static_assert(
     std::is_same<typename std::remove_const<TExpr>::type, exprt>::value,
     "Tried to expr_try_dynamic_cast from something that wasn't an exprt");
@@ -63,13 +65,30 @@ expr_try_dynamic_cast(TExpr &base)
     std::is_reference<T>::value,
     "Tried to convert exprt & to non-reference type");
   static_assert(
-    std::is_base_of<exprt, TUnderlying>::value,
+    std::is_base_of<exprt, TUnderlyingt>::value,
     "The template argument T must be derived from exprt.");
-  if(!can_cast_expr<TUnderlying>(base))
+  if(!can_cast_expr<TUnderlyingt>(base))
     return {};
-  T value=static_cast<T>(base);
-  validate_expr(value);
-  return std::reference_wrapper<TConst>(value);
+  T ret=static_cast<T>(base);
+  validate_expr(ret);
+  return std::reference_wrapper<TConstt>(ret);
+}
+
+/// \brief Try to cast a reference to a generic exprt to a specific derived
+///    class
+/// \tparam T The reference or const reference type to \a TUnderlying to cast
+///    to
+/// \tparam TExpr The original type to cast from, either exprt or const exprt
+/// \param base Reference to a generic \ref exprt
+/// \return Reference to object of type \a TUnderlying
+///   or valueless optional if \a base is not an instance of \a TUnderlying
+template <typename T, typename TExpr>
+optionalt<std::reference_wrapper<typename std::remove_reference<T>::type>>
+expr_try_checked_cast(TExpr &base)
+{
+  typedef typename std::decay<T>::type TUnderlyingt;
+  PRECONDITION(can_cast_expr<TUnderlyingt>(base));
+  return expr_try_checked_cast<T>(base);
 }
 
 } // namespace detail
@@ -100,25 +119,48 @@ expr_try_dynamic_cast(exprt &base)
   return detail::expr_try_dynamic_cast<T>(base);
 }
 
+/// \brief Try to cast a constant reference to a generic exprt to a specific
+///   derived class. Also assert that the expr invariants are not violated.
+/// \tparam T The exprt-derived class to cast to
+/// \param base Reference to a generic \ref exprt
+/// \return Reference to object of type \a T or valueless optional if \a base
+///   is not an instance of \a T
+template<typename T>
+optionalt<std::reference_wrapper<typename std::remove_reference<T>::type>>
+expr_try_checked_cast(const exprt &base)
+{
+  return detail::expr_try_checked_cast<T>(base);
+}
+
+/// \brief Try to cast a reference to a generic exprt to a specific derived
+///   class. Also assert that the expr invariants are not violated.
+/// \tparam T The exprt-derived class to cast to
+/// \param base Reference to a generic \ref exprt
+/// \return Reference to object of type \a T or valueless optional if \a base is
+///   not an instance of \a T
+template<typename T>
+optionalt<std::reference_wrapper<typename std::remove_reference<T>::type>>
+expr_try_checked_cast(exprt &base)
+{
+  return detail::expr_try_checked_cast<T>(base);
+}
+
 namespace detail // NOLINT
 {
 
-// We hide this in a namespace so that only functions that it only
-// participates in overload resolution when explicitly requested.
+// We hide these functions in a namespace so that only functions that they only
+// participate in overload resolution when explicitly requested.
 
-/// \brief Cast a reference to a generic exprt to a specific derived class
+/// \brief Cast a reference to a generic exprt to a specific derived class.
 /// \tparam T The reference or const reference type to \a TUnderlying to cast to
-/// \tparam TUnderlying An exprt-derived class type
 /// \tparam TExpr The original type to cast from, either exprt or const exprt
 /// \param base Reference to a generic \ref exprt
 /// \return Reference to object of type \a T
 /// \throw std::bad_cast If \a base is not an instance of \a TUnderlying
-/// \remark If CBMC assertions (PRECONDITION) are set to abort then this will
-///   abort rather than throw if \a base is not an instance of \a TUnderlying
 template<typename T, typename TExpr>
 T expr_dynamic_cast(TExpr &base)
 {
-  typedef typename std::decay<T>::type TUnderlying;
+  typedef typename std::decay<T>::type TUnderlyingt;
   static_assert(
     std::is_same<typename std::remove_const<TExpr>::type, exprt>::value,
     "Tried to expr_dynamic_cast from something that wasn't an exprt");
@@ -126,14 +168,30 @@ T expr_dynamic_cast(TExpr &base)
     std::is_reference<T>::value,
     "Tried to convert exprt & to non-reference type");
   static_assert(
-    std::is_base_of<exprt, TUnderlying>::value,
+    std::is_base_of<exprt, TUnderlyingt>::value,
     "The template argument T must be derived from exprt.");
-  PRECONDITION(can_cast_expr<TUnderlying>(base));
-  if(!can_cast_expr<TUnderlying>(base))
+  if(!can_cast_expr<TUnderlyingt>(base))
     throw std::bad_cast();
-  T value=static_cast<T>(base);
-  validate_expr(value);
-  return value;
+  T ret=static_cast<T>(base);
+  validate_expr(ret);
+  return ret;
+}
+
+/// \brief Cast a reference to a generic exprt to a specific derived class.
+///   Also assert that the expression has the expected type.
+/// \tparam T The reference or const reference type to \a TUnderlying to cast to
+/// \tparam TExpr The original type to cast from, either exprt or const exprt
+/// \param base Reference to a generic \ref exprt
+/// \return Reference to object of type \a T
+/// \throw std::bad_cast If \a base is not an instance of \a TUnderlying
+/// \remark If CBMC assertions (PRECONDITION) are set to abort then this will
+///   abort rather than throw if \a base is not an instance of \a TUnderlying
+template<typename T, typename TExpr>
+T expr_checked_cast(TExpr &base)
+{
+  typedef typename std::decay<T>::type TUnderlyingt;
+  PRECONDITION(can_cast_expr<TUnderlyingt>(base));
+  return expr_dynamic_cast<T>(base);
 }
 
 } // namespace detail
@@ -163,6 +221,34 @@ template<typename T>
 T expr_dynamic_cast(exprt &base)
 {
   return detail::expr_dynamic_cast<T>(base);
+}
+
+/// \brief Cast a constant reference to a generic exprt to a specific derived
+///   class. Also assert that the exprt invariants are not violated.
+/// \tparam T The exprt-derived class to cast to
+/// \param base Reference to a generic \ref exprt
+/// \return Reference to object of type \a T
+/// \throw std::bad_cast If \a base is not an instance of \a T
+/// \remark If CBMC assertions (PRECONDITION) are set to abort then this will
+///   abort rather than throw if \a base is not an instance of \a T
+template<typename T>
+T expr_checked_cast(const exprt &base)
+{
+  return detail::expr_checked_cast<T>(base);
+}
+
+/// \brief Cast a reference to a generic exprt to a specific derived class.
+///   Also assert that the exprt invariants are not violated.
+/// \tparam T The exprt-derived class to cast to
+/// \param base Reference to a generic \ref exprt
+/// \return Reference to object of type \a T
+/// \throw std::bad_cast If \a base is not an instance of \a T
+/// \remark If CBMC assertions (PRECONDITION) are set to abort then this will
+///   abort rather than throw if \a base is not an instance of \a T
+template<typename T>
+T expr_checked_cast(exprt &base)
+{
+  return detail::expr_checked_cast<T>(base);
 }
 
 inline void validate_operands(

--- a/src/util/expr_cast.h
+++ b/src/util/expr_cast.h
@@ -35,39 +35,11 @@ template<typename T> bool can_cast_expr(const exprt &base);
 /// validate particular types.
 inline void validate_expr(const exprt &) {}
 
-/// \brief Try to cast a constant reference to a generic exprt to a specific
-///   derived class
-/// \tparam T The exprt-derived class to cast to
-/// \param base Reference to a generic \ref exprt
-/// \return Reference to object of type \a T or valueless optional if \a base
-///   is not an instance of \a T
-template<typename T>
-optionalt<std::reference_wrapper<typename std::remove_reference<T>::type>>
-expr_try_dynamic_cast(const exprt &base)
+namespace detail
 {
-  return expr_try_dynamic_cast<
-    T,
-    typename std::remove_reference<T>::type,
-    typename std::remove_const<typename std::remove_reference<T>::type>::type,
-    const exprt>(base);
-}
 
-/// \brief Try to cast a reference to a generic exprt to a specific derived
-///   class
-/// \tparam T The exprt-derived class to cast to
-/// \param base Reference to a generic \ref exprt
-/// \return Reference to object of type \a T or valueless optional if \a base is
-///   not an instance of \a T
-template<typename T>
-optionalt<std::reference_wrapper<typename std::remove_reference<T>::type>>
-expr_try_dynamic_cast(exprt &base)
-{
-  return expr_try_dynamic_cast<
-    T,
-    typename std::remove_reference<T>::type,
-    typename std::remove_const<typename std::remove_reference<T>::type>::type,
-    exprt>(base);
-}
+// We hide this in a namespace so that only functions that it only
+// participates in overload resolution when explicitly requested.
 
 /// \brief Try to cast a reference to a generic exprt to a specific derived
 ///    class
@@ -97,38 +69,47 @@ optionalt<std::reference_wrapper<TConst>> expr_try_dynamic_cast(TExpr &base)
   return optionalt<std::reference_wrapper<TConst>>(value);
 }
 
-/// \brief Cast a constant reference to a generic exprt to a specific derived
-///   class
+} // namespace detail
+
+/// \brief Try to cast a constant reference to a generic exprt to a specific
+///   derived class
 /// \tparam T The exprt-derived class to cast to
 /// \param base Reference to a generic \ref exprt
-/// \return Reference to object of type \a T
-/// \throw std::bad_cast If \a base is not an instance of \a T
-/// \remark If CBMC assertions (PRECONDITION) are set to abort then this will
-///   abort rather than throw if \a base is not an instance of \a T
+/// \return Reference to object of type \a T or valueless optional if \a base
+///   is not an instance of \a T
 template<typename T>
-T expr_dynamic_cast(const exprt &base)
+optionalt<std::reference_wrapper<typename std::remove_reference<T>::type>>
+expr_try_dynamic_cast(const exprt &base)
 {
-  return expr_dynamic_cast<
+  return detail::expr_try_dynamic_cast<
     T,
+    typename std::remove_reference<T>::type,
     typename std::remove_const<typename std::remove_reference<T>::type>::type,
     const exprt>(base);
 }
 
-/// \brief Cast a reference to a generic exprt to a specific derived class
+/// \brief Try to cast a reference to a generic exprt to a specific derived
+///   class
 /// \tparam T The exprt-derived class to cast to
 /// \param base Reference to a generic \ref exprt
-/// \return Reference to object of type \a T
-/// \throw std::bad_cast If \a base is not an instance of \a T
-/// \remark If CBMC assertions (PRECONDITION) are set to abort then this will
-///   abort rather than throw if \a base is not an instance of \a T
+/// \return Reference to object of type \a T or valueless optional if \a base is
+///   not an instance of \a T
 template<typename T>
-T expr_dynamic_cast(exprt &base)
+optionalt<std::reference_wrapper<typename std::remove_reference<T>::type>>
+expr_try_dynamic_cast(exprt &base)
 {
-  return expr_dynamic_cast<
+  return detail::expr_try_dynamic_cast<
     T,
+    typename std::remove_reference<T>::type,
     typename std::remove_const<typename std::remove_reference<T>::type>::type,
     exprt>(base);
 }
+
+namespace detail
+{
+
+// We hide this in a namespace so that only functions that it only
+// participates in overload resolution when explicitly requested.
 
 /// \brief Cast a reference to a generic exprt to a specific derived class
 /// \tparam T The reference or const reference type to \a TUnderlying to cast to
@@ -159,6 +140,40 @@ T expr_dynamic_cast(TExpr &base)
   return value;
 }
 
+} // namespace detail
+
+/// \brief Cast a constant reference to a generic exprt to a specific derived
+///   class
+/// \tparam T The exprt-derived class to cast to
+/// \param base Reference to a generic \ref exprt
+/// \return Reference to object of type \a T
+/// \throw std::bad_cast If \a base is not an instance of \a T
+/// \remark If CBMC assertions (PRECONDITION) are set to abort then this will
+///   abort rather than throw if \a base is not an instance of \a T
+template<typename T>
+T expr_dynamic_cast(const exprt &base)
+{
+  return detail::expr_dynamic_cast<
+    T,
+    typename std::remove_const<typename std::remove_reference<T>::type>::type,
+    const exprt>(base);
+}
+
+/// \brief Cast a reference to a generic exprt to a specific derived class
+/// \tparam T The exprt-derived class to cast to
+/// \param base Reference to a generic \ref exprt
+/// \return Reference to object of type \a T
+/// \throw std::bad_cast If \a base is not an instance of \a T
+/// \remark If CBMC assertions (PRECONDITION) are set to abort then this will
+///   abort rather than throw if \a base is not an instance of \a T
+template<typename T>
+T expr_dynamic_cast(exprt &base)
+{
+  return detail::expr_dynamic_cast<
+    T,
+    typename std::remove_const<typename std::remove_reference<T>::type>::type,
+    exprt>(base);
+}
 
 inline void validate_operands(
   const exprt &value,

--- a/src/util/expr_cast.h
+++ b/src/util/expr_cast.h
@@ -41,8 +41,8 @@ inline void validate_expr(const exprt &) {}
 namespace detail // NOLINT
 {
 
-// We hide these functions in a namespace so that only functions that they only
-// participate in overload resolution when explicitly requested.
+// We hide these functions in a namespace so that they only participate in
+// overload resolution when explicitly requested.
 
 /// \brief Try to cast a reference to a generic exprt to a specific derived
 ///    class
@@ -56,8 +56,7 @@ template <typename T, typename TExpr>
 optionalt<std::reference_wrapper<typename std::remove_reference<T>::type>>
 expr_try_dynamic_cast(TExpr &base)
 {
-  typedef typename std::decay<T>::type TUnderlyingt;
-  typedef typename std::remove_reference<T>::type TConstt;
+  typedef typename std::decay<T>::type decayt;
   static_assert(
     std::is_same<typename std::remove_const<TExpr>::type, exprt>::value,
     "Tried to expr_try_dynamic_cast from something that wasn't an exprt");
@@ -65,30 +64,13 @@ expr_try_dynamic_cast(TExpr &base)
     std::is_reference<T>::value,
     "Tried to convert exprt & to non-reference type");
   static_assert(
-    std::is_base_of<exprt, TUnderlyingt>::value,
+    std::is_base_of<exprt, decayt>::value,
     "The template argument T must be derived from exprt.");
-  if(!can_cast_expr<TUnderlyingt>(base))
+  if(!can_cast_expr<decayt>(base))
     return {};
   T ret=static_cast<T>(base);
   validate_expr(ret);
-  return std::reference_wrapper<TConstt>(ret);
-}
-
-/// \brief Try to cast a reference to a generic exprt to a specific derived
-///    class
-/// \tparam T The reference or const reference type to \a TUnderlying to cast
-///    to
-/// \tparam TExpr The original type to cast from, either exprt or const exprt
-/// \param base Reference to a generic \ref exprt
-/// \return Reference to object of type \a TUnderlying
-///   or valueless optional if \a base is not an instance of \a TUnderlying
-template <typename T, typename TExpr>
-optionalt<std::reference_wrapper<typename std::remove_reference<T>::type>>
-expr_try_checked_cast(TExpr &base)
-{
-  typedef typename std::decay<T>::type TUnderlyingt;
-  PRECONDITION(can_cast_expr<TUnderlyingt>(base));
-  return expr_try_checked_cast<T>(base);
+  return std::reference_wrapper<typename std::remove_reference<T>::type>(ret);
 }
 
 } // namespace detail
@@ -119,37 +101,11 @@ expr_try_dynamic_cast(exprt &base)
   return detail::expr_try_dynamic_cast<T>(base);
 }
 
-/// \brief Try to cast a constant reference to a generic exprt to a specific
-///   derived class. Also assert that the expr invariants are not violated.
-/// \tparam T The exprt-derived class to cast to
-/// \param base Reference to a generic \ref exprt
-/// \return Reference to object of type \a T or valueless optional if \a base
-///   is not an instance of \a T
-template<typename T>
-optionalt<std::reference_wrapper<typename std::remove_reference<T>::type>>
-expr_try_checked_cast(const exprt &base)
-{
-  return detail::expr_try_checked_cast<T>(base);
-}
-
-/// \brief Try to cast a reference to a generic exprt to a specific derived
-///   class. Also assert that the expr invariants are not violated.
-/// \tparam T The exprt-derived class to cast to
-/// \param base Reference to a generic \ref exprt
-/// \return Reference to object of type \a T or valueless optional if \a base is
-///   not an instance of \a T
-template<typename T>
-optionalt<std::reference_wrapper<typename std::remove_reference<T>::type>>
-expr_try_checked_cast(exprt &base)
-{
-  return detail::expr_try_checked_cast<T>(base);
-}
-
 namespace detail // NOLINT
 {
 
-// We hide these functions in a namespace so that only functions that they only
-// participate in overload resolution when explicitly requested.
+// We hide these functions in a namespace so that they only participate in
+// overload resolution when explicitly requested.
 
 /// \brief Cast a reference to a generic exprt to a specific derived class.
 /// \tparam T The reference or const reference type to \a TUnderlying to cast to
@@ -160,7 +116,7 @@ namespace detail // NOLINT
 template<typename T, typename TExpr>
 T expr_dynamic_cast(TExpr &base)
 {
-  typedef typename std::decay<T>::type TUnderlyingt;
+  typedef typename std::decay<T>::type decayt;
   static_assert(
     std::is_same<typename std::remove_const<TExpr>::type, exprt>::value,
     "Tried to expr_dynamic_cast from something that wasn't an exprt");
@@ -168,9 +124,9 @@ T expr_dynamic_cast(TExpr &base)
     std::is_reference<T>::value,
     "Tried to convert exprt & to non-reference type");
   static_assert(
-    std::is_base_of<exprt, TUnderlyingt>::value,
+    std::is_base_of<exprt, decayt>::value,
     "The template argument T must be derived from exprt.");
-  if(!can_cast_expr<TUnderlyingt>(base))
+  if(!can_cast_expr<decayt>(base))
     throw std::bad_cast();
   T ret=static_cast<T>(base);
   validate_expr(ret);
@@ -189,8 +145,7 @@ T expr_dynamic_cast(TExpr &base)
 template<typename T, typename TExpr>
 T expr_checked_cast(TExpr &base)
 {
-  typedef typename std::decay<T>::type TUnderlyingt;
-  PRECONDITION(can_cast_expr<TUnderlyingt>(base));
+  PRECONDITION(can_cast_expr<typename std::decay<T>::type>(base));
   return expr_dynamic_cast<T>(base);
 }
 


### PR DESCRIPTION
Provides some utility methods for the types in std_code.h, which allow them to be used with expr_dynamic_cast.

Suggest @NathanJPhillips and @smowton to review.