### PR TITLE
Test.pl: exit if a test is interrupted

### DIFF
--- a/regression/test.pl
+++ b/regression/test.pl
@@ -45,6 +45,11 @@ sub run($$$$$) {
   system "echo EXIT=$exit_value >>'$name/$output'";
   system "echo SIGNAL=$signal_num >>'$name/$output'";
 
+  if($signal_num == 2) {
+    print "\nProgram under test interrupted; stopping\n";
+    exit 1;
+  }
+
   return $failed;
 }
 


### PR DESCRIPTION
In the specific case where a test died to SIGINT, we probably ought to stop.
Contrast SIGTERM, SIGKILL and so on, where we will carry on.

This also makes ctest exit cleanly when SIGINT'd