### PR TITLE
TG-838 Documentation of the string solver

### DIFF
--- a/src/solvers/refinement/README.md
+++ b/src/solvers/refinement/README.md
@@ -1,0 +1,211 @@
+\page string-solver String solver
+
+\author Romain Brenguier
+
+\tableofcontents
+
+\section string_solver_interface String solver interface
+
+\subsection general_interface General interface
+
+The common interface for solvers in CProver is inherited from 
+`decision_proceduret` and is the common interface for all solvers.
+It is essentially composed of these three functions:
+
+  - `string_refinementt::set_to(const exprt &expr, bool value)`: 
+  \copybrief string_refinementt::set_to
+  - `string_refinementt::dec_solve()`: 
+  \copybrief string_refinementt::dec_solve
+  - `string_refinementt::get(const exprt &expr) const`: 
+  \copybrief string_refinementt::get
+  
+For each goal given to CProver:
+  - `set_to` is called on several equations, roughly one for each step of the 
+    symbolic execution that leads to that goal;
+  - `dec_solve` is called to determine whether the goal is reachable given these
+    equations;
+  - `get` is called by the interpreter to obtain concrete value to build a trace
+    leading to the goal;
+  - The same process can be repeated for further goals, in that case the 
+    constraints added by previous calls to `set_to` remain valid.
+
+\subsection specificity Specificity of the string solver
+
+The specificity of the solver is in what kind of expressions `set_to` accepts 
+and understands. `string_refinementt::set_to` accepts all constraints that are
+normally accepted by `bv_refinementt`.
+
+`string_refinementt::set_to` also understands constraints of the form:
+  * `char_pointer1 = b ? char_pointer2 : char_pointer3` where `char_pointer<i>` 
+    variables are of type pointer to characters and `b` is a Boolean
+    expression.
+  * `i = cprover_primitive(args)` where `i` is of signed bit vector type.
+    String primitives are listed in the next section.
+
+\note In the implementation, equations that are not of these forms are passed 
+  to an embedded `bv_refinementt` solver.
+
+\subsection string-representation String representation in the solver
+
+String primitives can have arguments which are pointers to characters.
+These pointers represent strings. 
+To each of these pointers the string solver associate a char array 
+which represents the content of the string.
+If the pointer is the address of an actual array in the program they should be 
+linked by using the primitive `cprover_string_associate_array_to_pointer`.
+The length of the array can also be linked to a variable of the program using
+ `cprover_string_associate_length_to_array`.
+
+\warning The solver assumes the memory pointed by the arguments is immutable
+which is not something that is true in general for C pointers for instance.
+Therefore for each transformation on a string, it is assumed the program 
+allocates a new string before calling a primitive.
+
+\section primitives String primitives
+
+\subsection basic-primitives Basic access:
+
+  * `cprover_string_associate_array_to_pointer` : Link with an array of
+    characters of the program.
+  * `cprover_string_associate_length_to_array` : Link the length of the array
+    with the given integer value.
+  * `cprover_string_char_at` :
+  \copybrief string_constraint_generatort::add_axioms_for_char_at(const function_application_exprt &f)
+  \link  string_constraint_generatort::add_axioms_for_char_at(const function_application_exprt &f) More... \endlink
+  * `cprover_string_length` : 
+  \copybrief string_constraint_generatort::add_axioms_for_length(const function_application_exprt &f)
+  \link string_constraint_generatort::add_axioms_for_length(const function_application_exprt &f) More... \endlink
+
+\subsection comparisons Comparisons:
+
+  * `cprover_string_compare_to` :
+   \copybrief string_constraint_generatort::add_axioms_for_compare_to(const function_application_exprt &f)
+   \link string_constraint_generatort::add_axioms_for_compare_to(const function_application_exprt &f) More... \endlink
+  * `cprover_string_contains` : 
+  \copybrief string_constraint_generatort::add_axioms_for_contains(const function_application_exprt &f)
+  \link string_constraint_generatort::add_axioms_for_contains(const function_application_exprt &f) More... \endlink
+  * `cprover_string_equals` : 
+  \copybrief string_constraint_generatort::add_axioms_for_equals(const function_application_exprt &f)
+  \link string_constraint_generatort::add_axioms_for_equals(const function_application_exprt &f) More... \endlink
+  * `cprover_string_equals_ignore_case` :
+  \copybrief string_constraint_generatort::add_axioms_for_equals_ignore_case(const function_application_exprt &f)
+  \link string_constraint_generatort::add_axioms_for_equals_ignore_case(const function_application_exprt &f) More... \endlink
+  * `cprover_string_hash_code` :
+  \copybrief string_constraint_generatort::add_axioms_for_hash_code
+  \link string_constraint_generatort::add_axioms_for_hash_code More... \endlink
+  * `cprover_string_is_prefix` :
+  \copybrief string_constraint_generatort::add_axioms_for_is_prefix
+  \link string_constraint_generatort::add_axioms_for_is_prefix More... \endlink
+  * `cprover_string_is_suffix` :
+  \copybrief string_constraint_generatort::add_axioms_for_is_suffix
+  \link string_constraint_generatort::add_axioms_for_is_suffix More... \endlink
+  * `cprover_string_index_of` : 
+  \copybrief string_constraint_generatort::add_axioms_for_index_of(const function_application_exprt &f)
+  \link string_constraint_generatort::add_axioms_for_index_of(const function_application_exprt &f) More... \endlink
+  * `cprover_string_last_index_of` :
+  \copybrief string_constraint_generatort::add_axioms_for_last_index_of(const function_application_exprt &f)
+  \link string_constraint_generatort::add_axioms_for_last_index_of(const function_application_exprt &f)  More... \endlink
+
+\subsection transformations Transformations:  
+
+  * `cprover_string_char_set` :
+    \copybrief string_constraint_generatort::add_axioms_for_char_set(const function_application_exprt &f)
+    \link string_constraint_generatort::add_axioms_for_char_set(const function_application_exprt &f) More... \endlink
+  * `cprover_string_concat` : 
+    \copybrief string_constraint_generatort::add_axioms_for_concat(const function_application_exprt &f)
+    \link string_constraint_generatort::add_axioms_for_concat(const function_application_exprt &f) More... \endlink
+  * `cprover_string_delete` :
+    \copybrief string_constraint_generatort::add_axioms_for_delete(const function_application_exprt &f)
+    \link string_constraint_generatort::add_axioms_for_delete(const function_application_exprt &f) More... \endlink
+  * `cprover_string_insert` : 
+    \copybrief string_constraint_generatort::add_axioms_for_insert(const function_application_exprt &f)
+    \link string_constraint_generatort::add_axioms_for_insert(const function_application_exprt &f) More... \endlink
+  * `cprover_string_replace` :
+    \copybrief string_constraint_generatort::add_axioms_for_replace(const function_application_exprt &f)
+    \link string_constraint_generatort::add_axioms_for_replace(const function_application_exprt &f) More... \endlink
+  * `cprover_string_set_length` :
+    \copybrief string_constraint_generatort::add_axioms_for_set_length(const function_application_exprt &f)
+    \link string_constraint_generatort::add_axioms_for_set_length(const function_application_exprt &f) More... \endlink
+  * `cprover_string_substring` : 
+    \copybrief string_constraint_generatort::add_axioms_for_substring(const function_application_exprt &f)
+    \link string_constraint_generatort::add_axioms_for_substring(const function_application_exprt &f) More... \endlink
+  * `cprover_string_to_lower_case` :
+    \copybrief string_constraint_generatort::add_axioms_for_to_lower_case(const function_application_exprt &f)
+    \link string_constraint_generatort::add_axioms_for_to_lower_case(const function_application_exprt &f) More... \endlink
+  * `cprover_string_to_upper_case` :
+    \copybrief string_constraint_generatort::add_axioms_for_to_upper_case(const function_application_exprt &f)
+    \link string_constraint_generatort::add_axioms_for_to_upper_case(const function_application_exprt &f) More... \endlink
+  * `cprover_string_trim` :
+    \copybrief string_constraint_generatort::add_axioms_for_trim(const function_application_exprt &f)
+    \link string_constraint_generatort::add_axioms_for_trim(const function_application_exprt &f) More... \endlink
+
+\subsection conversions Conversions:
+
+  * `cprover_string_format` :
+    \copybrief string_constraint_generatort::add_axioms_for_format(const function_application_exprt &f)
+    \link string_constraint_generatort::add_axioms_for_format(const function_application_exprt &f) More... \endlink
+  * `cprover_string_from_literal` :
+    \copybrief string_constraint_generatort::add_axioms_from_literal(const function_application_exprt &f)
+    \link string_constraint_generatort::add_axioms_from_literal(const function_application_exprt &f) More... \endlink
+  * `cprover_string_of_int` :
+    \copybrief string_constraint_generatort::add_axioms_from_int(const function_application_exprt &f)
+    \link string_constraint_generatort::add_axioms_from_int(const function_application_exprt &f) More... \endlink
+  * `cprover_string_of_float` :
+    \copybrief string_constraint_generatort::add_axioms_for_string_of_float(const function_application_exprt &f)
+    \link string_constraint_generatort::add_axioms_for_string_of_float(const function_application_exprt &f) More... \endlink
+  * `cprover_string_of_float_scientific_notation` :
+    \copybrief string_constraint_generatort::add_axioms_from_float_scientific_notation(const function_application_exprt &f)
+    \link string_constraint_generatort::add_axioms_from_float_scientific_notation(const function_application_exprt &f) More... \endlink
+  * `cprover_string_of_char` :
+    \copybrief string_constraint_generatort::add_axioms_from_char(const function_application_exprt &f)
+    \link string_constraint_generatort::add_axioms_from_char(const function_application_exprt &f) More... \endlink
+  * `cprover_string_parse_int` :
+    \copybrief string_constraint_generatort::add_axioms_for_parse_int(const function_application_exprt &f)
+    \link string_constraint_generatort::add_axioms_for_parse_int(const function_application_exprt &f) More... \endlink
+
+\subsection deprecated Deprecated primitives:
+
+  * `cprover_string_concat_code_point`, `cprover_string_code_point_at`,
+    `cprover_string_code_point_before`, `cprover_string_code_point_count`: 
+    Java specific, should be part of Java models.
+  * `cprover_string_offset_by_code_point`, `cprover_string_concat_char`, 
+    `cprover_string_concat_int`, `cprover_string_concat_long`, 
+    `cprover_string_concat_bool`, `cprover_string_concat_double`,
+    `cprover_string_concat_float`, `cprover_string_insert_int`, 
+    `cprover_string_insert_long`, `cprover_string_insert_bool`,
+    `cprover_string_insert_char`, `cprover_string_insert_double`,
+     `cprover_string_insert_float` : 
+    Should be done in two steps: conversion from primitive type and call
+    to the string primitive.
+  * `cprover_string_array_of_char_pointer`, `cprover_string_to_char_array` : 
+     Pointer to char array association
+     is now handled by `string_constraint_generatort`, there is no need for
+     explicit conversion.
+  * `cprover_string_intern` : Never tested.
+  * `cprover_string_is_empty` :
+    Should use `cprover_string_length(s) == 0` instead.
+  * `cprover_string_empty_string` : Can use literal of empty string instead.
+  * `cprover_string_of_long` : Should be the same as `cprover_string_of_int`.
+  * `cprover_string_delete_char_at` : A call to 
+    `cprover_string_delete_char_at(s, i)` would be the same thing as 
+    `cprover_string_delete(s, i, i+1)`.
+  * `cprover_string_of_bool` :
+    Language dependent, should be implemented in the models.
+  * `cprover_string_copy` : Same as `cprover_string_substring(s, 0)`.
+  * `cprover_string_of_int_hex` : Same as `cprover_string_of_int(s, 16)`.
+  * `cprover_string_of_double` : Same as `cprover_string_of_float`.
+ 
+\section algorithm Decision algorithm
+
+\copydetails string_refinementt::dec_solve
+
+\subsection instantiation Instantiation
+
+This is done by generate_instantiations(messaget::mstreamt &stream, const namespacet &ns, const string_constraint_generatort &generator, const index_set_pairt &index_set, const string_axiomst &axioms).
+\copydetails generate_instantiations(messaget::mstreamt &stream, const namespacet &ns, const string_constraint_generatort &generator, const index_set_pairt &index_set, const string_axiomst &axioms)
+ 
+\subsection axiom-check Axiom check
+
+\copydetails check_axioms(const string_axiomst &axioms, string_constraint_generatort &generator, const std::function<exprt(const exprt &)> &get, messaget::mstreamt &stream, const namespacet &ns, std::size_t max_string_length, bool use_counter_example, ui_message_handlert::uit ui, const union_find_replacet &symbol_resolve)
+\link check_axioms(const string_axiomst &axioms, string_constraint_generatort &generator, const std::function<exprt(const exprt &)> &get, messaget::mstreamt &stream, const namespacet &ns, std::size_t max_string_length, bool use_counter_example, ui_message_handlert::uit ui, const union_find_replacet &symbol_resolve) 
+  (See function documentation...) \endlink

--- a/src/solvers/refinement/string_constraint.h
+++ b/src/solvers/refinement/string_constraint.h
@@ -26,29 +26,32 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include <util/string_expr.h>
 #include <langapi/language_util.h>
 
-/*! \brief Universally quantified string constraint
-
-    This represents a universally quantified string constraint as laid out in
-    DOI: 10.1007/978-3-319-03077-7. The paper seems to specify a universal
-    constraint as follows.
-
-    A universal constraint is of the form \f$\forall n. L(n) \rightarrow
-    P(n, s_0,\ldots, s_k)\f$ where
-
-    1. \f$L(n)\f$ does not contain string indices [possibly not required, but
-       implied by examples]
-    2. \f$\forall n. L(n) \rightarrow P'\left(s_0[f_0(n)],\ldots, s_k[f_k(n)]
-       \right)\f$, i.e. when focusing on one specific string, all indices are
-       the same [stated in a roundabout manner]
-    3. Each \f$f\f$ is linear and therefore has an inverse [explicitly stated]
-    4. \f$L(n)\f$ and \f$P(n, s_0,\ldots, s_k)\f$ may contain other (free)
-       variables, but in \f$P\f$, \f$n\f$ can only occur as an argument to an
-       \f$f\f$ [explicitly stated, implied]
-
-    We extend this slightly by restricting n to be in a specific range, but this
-    is another implication which can be pushed in to \f$L(n)\f$.
-*/
-
+///  ### Universally quantified string constraint
+///
+///  This represents a universally quantified string constraint as laid out in
+///  DOI: 10.1007/978-3-319-03077-7. The paper seems to specify a universal
+///  constraint as follows.
+///
+///  A universal constraint is of the form
+///  \f$ \forall i.\ PI(i) \Rightarrow  PV(i)\f$
+///  where \f$PI\f$ and \f$PV\f$ satisfies the following conditions:
+///
+///    * The predicate `PI` , called the index guard, must follow the grammar
+///      * \f$iguard : iguard \land iguard \mid iguard \lor iguard \mid
+///        iterm \le iterm \mid  iterm = iterm \f$
+///      * \f$iterm : integer\_constant1 \times i + integer\_constant2 \f$
+///
+///    * The predicate `PV` is called the value constraint.
+///      The index variable `i` can only be used in array read expressions of
+///      the form `a[i]`.
+///      ie. `PV` is of the form \f$P'(s_0[f_0(i)],\ldots, s_k[f_k(i)]
+///      )\f$, moreover when focusing on one specific string, all indices are
+///      the same [stated in a roundabout manner].
+///      \f$L(n)\f$ and \f$P(n, s_0,\ldots, s_k)\f$ may contain other (free)
+///      variables, but in \f$P\f$, \f$n\f$ can only occur as an argument to an
+///      \f$f\f$ [explicitly stated, implied].
+///
+/// \todo The fact that we follow this grammar is not enforced at the moment.
 class string_constraintt: public exprt
 {
 public:
@@ -155,6 +158,7 @@ inline std::string from_expr(
     from_expr(ns, identifier, expr.body());
 }
 
+/// Constraints to encode non containement of strings.
 class string_not_contains_constraintt: public exprt
 {
 public:

--- a/src/solvers/refinement/string_constraint_generator.h
+++ b/src/solvers/refinement/string_constraint_generator.h
@@ -211,36 +211,27 @@ private:
     const array_string_exprt &str,
     const exprt &c,
     const exprt &from_index);
-
-  // Add axioms corresponding to the String.indexOf:(String;I) java function
   exprt add_axioms_for_index_of_string(
     const array_string_exprt &haystack,
     const array_string_exprt &needle,
     const exprt &from_index);
-
-  // Add axioms corresponding to the String.indexOf java functions
   exprt add_axioms_for_index_of(const function_application_exprt &f);
-
-  // Add axioms corresponding to the String.lastIndexOf:(String;I) java function
   exprt add_axioms_for_last_index_of_string(
     const array_string_exprt &haystack,
     const array_string_exprt &needle,
     const exprt &from_index);
-
-  // Add axioms corresponding to the String.lastIndexOf:(CI) java function
   exprt add_axioms_for_last_index_of(
     const array_string_exprt &str,
     const exprt &c,
     const exprt &from_index);
 
-  // Add axioms corresponding to the String.lastIndexOf java functions
   exprt add_axioms_for_last_index_of(const function_application_exprt &f);
 
-  // TODO: the specifications of these functions is only partial
-  // We currently only specify that the string for NaN is "NaN", for infinity
-  // and minus infinity the string are "Infinity" and "-Infinity respectively
-  // otherwise the string contains only characters in [0123456789.] and '-' at
-  // the start for negative number
+  /// \todo The specifications of these functions is only partial.
+  /// We currently only specify that the string for NaN is "NaN", for infinity
+  /// and minus infinity the string are "Infinity" and "-Infinity respectively
+  /// otherwise the string contains only characters in [0123456789.] and '-' at
+  /// the start for negative number
   exprt add_axioms_for_string_of_float(const function_application_exprt &f);
   exprt
   add_axioms_for_string_of_float(const array_string_exprt &res, const exprt &f);
@@ -254,16 +245,16 @@ private:
   exprt add_axioms_from_float_scientific_notation(
     const function_application_exprt &f);
 
-  // Add axioms corresponding to the String.valueOf(D) java function
-  // TODO: the specifications is only partial
+  /// Add axioms corresponding to the String.valueOf(D) java function
+  /// \todo The specifications is only partial.
   exprt add_axioms_from_double(const function_application_exprt &f);
 
   exprt add_axioms_for_replace(const function_application_exprt &f);
   exprt add_axioms_for_set_length(const function_application_exprt &f);
 
-  // TODO: the specification may not be correct for the case where the
-  // string is shorter than end. An actual java program should throw an
-  // exception in that case
+  /// \todo The specification may not be correct for the case where the
+  /// string is shorter than end. An actual java program should throw an
+  /// exception in that case.
   exprt add_axioms_for_substring(
     const array_string_exprt &res,
     const array_string_exprt &str,
@@ -282,16 +273,18 @@ private:
     const exprt &code_point);
   exprt add_axioms_for_char_literal(const function_application_exprt &f);
 
-  // Add axioms corresponding the String.codePointCount java function
-  // TODO: this function is underspecified, we do not compute the exact value
-  // but over approximate it.
+  /// Add axioms corresponding the String.codePointCount java function
+  /// \todo This function is underspecified, we do not compute the exact value
+  /// but over approximate it.
+  /// \deprecated This is Java specific and should be implemented in Java.
   exprt add_axioms_for_code_point_count(const function_application_exprt &f);
 
-  // Add axioms corresponding the String.offsetByCodePointCount java function
-  // TODO: this function is underspecified, it should return the index within
-  // this String that is offset from the given first argument by second argument
-  // code points and we approximate this by saying the result is
-  // between index + offset and index + 2 * offset
+  /// Add axioms corresponding the String.offsetByCodePointCount java function
+  /// \todo This function is underspecified, it should return the index within
+  /// this String that is offset from the given first argument by second
+  /// argument code points and we approximate this by saying the result is
+  /// between index + offset and index + 2 * offset.
+  /// \deprecated This is Java specific and should be implemented in Java.
   exprt add_axioms_for_offset_by_code_point(
     const function_application_exprt &f);
 
@@ -313,9 +306,10 @@ private:
   exprt add_axioms_for_parse_int(const function_application_exprt &f);
   exprt add_axioms_for_compare_to(const function_application_exprt &f);
 
-  // Add axioms corresponding to the String.intern java function
-  // TODO: this does not work at the moment because of the way we treat
-  // string pointers
+  /// Add axioms corresponding to the String.intern java function
+  /// \todo This does not work at the moment because of the way we treat
+  /// string pointers.
+  /// \deprecated Not tested.
   symbol_exprt add_axioms_for_intern(const function_application_exprt &f);
 
   exprt associate_array_to_pointer(const function_application_exprt &f);

--- a/src/solvers/refinement/string_constraint_generator_constants.cpp
+++ b/src/solvers/refinement/string_constraint_generator_constants.cpp
@@ -15,8 +15,8 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include <util/prefix.h>
 #include <util/unicode.h>
 
-/// add axioms saying the returned string expression should be equal to the
-/// string constant
+/// Add axioms ensuring that the provided string expression and constant are
+/// equal.
 /// \param res: array of characters for the result
 /// \param sval: a string constant
 /// \return integer expression equal to zero
@@ -29,8 +29,8 @@ exprt string_constraint_generatort::add_axioms_for_constant(
   std::string c_str=id2string(sval);
   std::wstring str;
 
-  // TODO: we should have a special treatment for java strings when the
-  // conversion function is available:
+/// \todo We should have a special treatment for java strings when the
+/// conversion function is available:
 #if 0
   if(mode==ID_java)
     str=utf8_to_utf16_little_endian(c_str);
@@ -52,7 +52,7 @@ exprt string_constraint_generatort::add_axioms_for_constant(
   return from_integer(0, get_return_code_type());
 }
 
-/// add axioms to say that the returned string expression is empty
+/// Add axioms to say that the returned string expression is empty
 /// \param f: function application with arguments integer `length` and character
 ///           pointer `ptr`.
 /// \return integer expression equal to zero
@@ -65,8 +65,11 @@ exprt string_constraint_generatort::add_axioms_for_empty_string(
   return from_integer(0, get_return_code_type());
 }
 
-/// add axioms to say that the returned string expression is equal to the string
-/// literal
+/// String corresponding to an internal cprover string
+///
+/// Add axioms ensuring that the returned string expression is equal to the
+/// string literal.
+/// \todo The name of the function should be changed to reflect what it does.
 /// \param f: function application with an argument which is a string literal
 /// that is a constant with a string value.
 /// \return string expression

--- a/src/solvers/refinement/string_constraint_generator_float.cpp
+++ b/src/solvers/refinement/string_constraint_generator_float.cpp
@@ -18,7 +18,7 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 
 /// Gets the unbiased exponent in a floating-point bit-vector
 ///
-/// TODO: factorize with float_bv.cpp float_utils.h
+/// \todo Refactor with float_bv.cpp float_utils.h
 /// \param src: a floating point expression
 /// \param spec: specification for floating points
 /// \return A new 32 bit integer expression representing the exponent.
@@ -147,6 +147,8 @@ exprt estimate_decimal_exponent(const exprt &f, const ieee_float_spect &spec)
   return round_expr_to_zero(adjust_for_neg);
 }
 
+/// String representation of a float value
+///
 /// Add axioms corresponding to the String.valueOf(F) java function
 /// \param f: function application with one float argument
 /// \return an integer expression
@@ -174,8 +176,8 @@ exprt string_constraint_generatort::add_axioms_from_double(
 /// This specification is correct for inputs that do not exceed 100000 and the
 /// function is unspecified for other values.
 ///
-/// \todo: this specification is not correct for negative numbers and
-/// double precision
+/// \todo This specification is not correct for negative numbers and
+/// double precision.
 /// \param res: string expression corresponding to the result
 /// \param f: expression representing a float
 /// \return an integer expression, different from zero if an error should be
@@ -306,7 +308,7 @@ exprt string_constraint_generatort::add_axioms_for_fractional_part(
 /// Then \f$n\f$ can be expressed by the equation:
 /// \f$log_10(n) = log_10(m) + log_10(2) * e - d\f$
 /// \f$n = f / 10^d = m * 2^e / 10^d = m * 2^e / 10^(floor(log_10(2) * e))\f$
-/// TODO: For now we only consider single precision.
+/// \todo For now we only consider single precision.
 /// \param res: string expression representing the float in scientific notation
 /// \param f: a float expression, which is positive
 /// \return a integer expression different from 0 to signal an exception
@@ -471,6 +473,8 @@ exprt string_constraint_generatort::add_axioms_from_float_scientific_notation(
   return add_axioms_for_concat(res, string_expr_with_E, exponent_string);
 }
 
+/// Representation of a float value in scientific notation
+///
 /// Add axioms corresponding to the scientific representation of floating point
 /// values
 /// \param f: a function application expression

--- a/src/solvers/refinement/string_constraint_generator_format.cpp
+++ b/src/solvers/refinement/string_constraint_generator_format.cpp
@@ -320,13 +320,13 @@ string_constraint_generatort::add_axioms_for_format_specifier(
     return res;
   }
   case format_specifiert::OCTAL_INTEGER:
-    // TODO: conversion of octal not implemented
+  /// \todo Conversion of octal is not implemented.
   case format_specifiert::GENERAL:
-    // TODO: general not implemented
+  /// \todo Conversion for format specifier general is not implemented.
   case format_specifiert::HEXADECIMAL_FLOAT:
-    // TODO: hexadecimal float not implemented
+  /// \todo Conversion of hexadecimal float is not implemented.
   case format_specifiert::DATE_TIME:
-    // TODO: DateTime not implemented
+    /// \todo Conversion of date-time is not implemented
     // For all these unimplemented cases we return a non-deterministic string
     message.warning() << "unimplemented format specifier: " << fs.conversion
                         << message.eom;
@@ -433,9 +433,10 @@ std::string utf16_constant_array_to_java(
   return utf16_little_endian_to_java(out);
 }
 
-/// Add axioms to specify the Java String.format function.
+/// Formatted string using a format string and list of arguments
 ///
-/// TODO: This is correct only if the first argument (ie the format string) is
+/// Add axioms to specify the Java String.format function.
+/// \todo This is correct only if the first argument (ie the format string) is
 /// constant or does not contain format specifiers.
 /// \param f: a function application
 /// \return A string expression representing the return value of the

--- a/src/solvers/refinement/string_constraint_generator_indexof.cpp
+++ b/src/solvers/refinement/string_constraint_generator_indexof.cpp
@@ -14,13 +14,26 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include <solvers/refinement/string_refinement_invariant.h>
 #include <solvers/refinement/string_constraint_generator.h>
 
-/// Add axioms stating that the returned value is the index within str of the
-/// first occurrence of c starting the search at from_index, or -1 if no such
-/// character occurs at or after position from_index.
-/// \param str: a string expression
-/// \param c: an expression representing a character
-/// \param from_index: an expression representing an index in the string
-/// \return a integer expression
+/// Add axioms stating that the returned value is the index within `haystack`
+/// (`str`) of the first occurrence of `needle` (`c`) starting the search at
+/// `from_index`, or is `-1` if no such character occurs at or after position
+/// `from_index`.
+/// \todo Make argument names match whose of add_axioms_for_index_of_string
+///
+/// These axioms are:
+///   1. \f$-1 \le {\tt index} < |{\tt haystack}| \f$
+///   2. \f$ \lnot contains \Leftrightarrow {\tt index} = -1 \f$
+///   3. \f$ contains \Rightarrow {\tt from\_index} \le {\tt index}
+///          \land {\tt haystack}[{\tt index}] = {\tt needle} \f$
+///   4. \f$ \forall i \in [{\tt from\_index}, {\tt index}).\ contains
+///          \Rightarrow {\tt haystack}[i] \ne {\tt needle} \f$
+///   5. \f$ \forall m, n \in [{\tt from\_index}, |{\tt haystack}|)
+///          .\ \lnot contains \Rightarrow {\tt haystack}[m] \ne {\tt needle}
+///      \f$
+/// \param str: an array of characters expression
+/// \param c: a character expression
+/// \param from_index: an integer expression
+/// \return integer expression `index`
 exprt string_constraint_generatort::add_axioms_for_index_of(
   const array_string_exprt &str,
   const exprt &c,
@@ -29,13 +42,6 @@ exprt string_constraint_generatort::add_axioms_for_index_of(
   const typet &index_type=str.length().type();
   symbol_exprt index=fresh_exist_index("index_of", index_type);
   symbol_exprt contains=fresh_boolean("contains_in_index_of");
-
-  // We add axioms:
-  // a1 : -1 <= index < |str|
-  // a2 : !contains <=> index=-1
-  // a3 : contains ==> from_index <= index && str[index] = c
-  // a4 : forall n, n:[from_index,index[. contains ==> str[n] != c
-  // a5 : forall m, n:[from_index,|str|[. !contains ==> str[m] != c
 
   exprt minus1=from_integer(-1, index_type);
   and_exprt a1(
@@ -70,14 +76,28 @@ exprt string_constraint_generatort::add_axioms_for_index_of(
   return index;
 }
 
-/// Add axioms stating that the returned value is the index within haystack of
-/// the first occurrence of needle starting the search at from_index, or -1 if
-/// needle does not occur at or after position from_index.
-/// \param haystack: a string expression
-/// \param needle: a string expression
-/// \param from_index: an expression representing an index in strings
-/// \return an integer expression representing the first index of needle in
-///   haystack after from_index, or -1 if there is none
+/// Add axioms stating that the returned value `index` is the index within
+/// `haystack` of the first occurrence of `needle` starting the search at
+/// `from_index`, or `-1` if needle does not occur at or after position
+/// `from_index`.
+///
+/// These axioms are:
+///   1. \f$ contains \Rightarrow {\tt from\_index} \le \tt{index}
+///          \le |{\tt haystack}|-|{\tt needle} | \f$
+///   2. \f$ \lnot contains \Leftrightarrow {\tt index} = -1 \f$
+///   3. \f$ \forall n \in [0,|{\tt needle}|).\ contains
+///          \Rightarrow {\tt haystack}[n + {\tt index}] = {\tt needle}[n] \f$
+///   4. \f$ \forall n \in [{\tt from\_index}, {\tt index}).\ contains
+///          \Rightarrow (\exists m \in [0,|{\tt needle}|).\ {\tt haystack}[m+n]
+///          \ne {\tt needle}[m]]) \f$
+///   5. \f$ \forall n \in [{\tt from\_index},|{\tt haystack}|-|{\tt needle}|]
+///          .\ \lnot contains \Rightarrow (\exists m \in [0,|{\tt needle}|)
+///          .\ {\tt haystack}[m+n] \ne {\tt needle}[m]) \f$
+/// \param haystack: an array of character expression
+/// \param needle: an array of character expression
+/// \param from_index: an integer expression
+/// \return integer expression `index` representing the first index of `needle`
+///   in `haystack`
 exprt string_constraint_generatort::add_axioms_for_index_of_string(
   const array_string_exprt &haystack,
   const array_string_exprt &needle,
@@ -86,16 +106,6 @@ exprt string_constraint_generatort::add_axioms_for_index_of_string(
   const typet &index_type=haystack.length().type();
   symbol_exprt offset=fresh_exist_index("index_of", index_type);
   symbol_exprt contains=fresh_boolean("contains_substring");
-
-  // We add axioms:
-  // a1 : contains ==> from_index <= offset <= |haystack|-|needle|
-  // a2 : !contains <=> offset=-1
-  // a3 : forall n:[0,|needle|[.
-  //        contains ==> haystack[n+offset]=needle[n]
-  // a4 : forall n:[from_index,offset[.
-  //        contains ==> (exists m:[0,|needle|[. haystack[m+n] != needle[m]])
-  // a5:  forall n:[from_index,|haystack|-|needle|].
-  //        !contains ==> (exists m:[0,|needle|[. haystack[m+n] != needle[m])
 
   implies_exprt a1(
     contains,
@@ -149,11 +159,30 @@ exprt string_constraint_generatort::add_axioms_for_index_of_string(
 /// the last occurrence of needle starting the search backward at from_index (ie
 /// the index is smaller or equal to from_index), or -1 if needle does not occur
 /// before from_index.
-/// \param haystack: a string expression
-/// \param needle: a string expression
-/// \param from_index: an expression representing an index in strings
-/// \return an integer expression representing the last index of needle in
-///   haystack before or at from_index, or -1 if there is none
+///
+/// These axioms are:
+///   1. \f$ contains \Rightarrow -1 \le {\tt index}
+///          \land {\tt index} \le {\tt from\_index}
+///          \land {\tt index} \le |{\tt haystack}| - |{\tt needle}| \f$
+///   2. \f$ \lnot contains \Leftrightarrow {\tt index}= -1 \f$
+///   3. \f$ \forall n \in [0, |{\tt needle}|).\ contains
+///          \Rightarrow {\tt haystack}[n+{\tt index}] = {\tt needle}[n] \f$
+///   4. \f$ \forall n \in [{\tt index}+1,
+///                         min({\tt from\_index},
+///                             |{\tt haystack}| - |{\tt needle}|)]
+///          .\ contains \Rightarrow
+///          (\exists m \in [0,|{\tt needle}|)
+///          .\ {\tt haystack}[m+n] \ne {\tt needle}[m]]) \f$
+///   5. \f$ \forall n \in
+///          [0, min({\tt from\_index}, |{\tt haystack}| - |{\tt needle}|)]
+///          .\ \lnot contains \Rightarrow
+///          (\exists m \in [0,|{\tt needle}|)
+///          .\ {\tt haystack}[m+n] \ne {\tt needle}[m]) \f$
+/// \param haystack: an array of characters expression
+/// \param needle: an array of characters expression
+/// \param from_index: integer expression
+/// \return integer expression `index` representing the last index of `needle`
+///         in `haystack` before or at `from_index`, or -1 if there is none
 exprt string_constraint_generatort::add_axioms_for_last_index_of_string(
   const array_string_exprt &haystack,
   const array_string_exprt &needle,
@@ -162,19 +191,6 @@ exprt string_constraint_generatort::add_axioms_for_last_index_of_string(
   const typet &index_type=haystack.length().type();
   symbol_exprt offset=fresh_exist_index("index_of", index_type);
   symbol_exprt contains=fresh_boolean("contains_substring");
-
-  // We add axioms:
-  // a1 : contains ==> -1 <= offset && offset <= from_index
-  //                   && offset <= |haystack| - |needle|
-  // a2 : !contains <=> offset = -1
-  // a3 : forall n:[0, |needle|[,
-  //        contains ==> haystack[n+offset] = needle[n]
-  // a4 : forall n:[offset+1, min(from_index, |haystack| - |needle|)].
-  //        contains ==>
-  //          (exists m:[0,|needle|[. haystack[m+n] != needle[m]])
-  // a5:  forall n:[0, min(from_index, |haystack| - |needle|)].
-  //        !contains ==>
-  //          (exists m:[0,|needle|[. haystack[m+n] != needle[m])
 
   implies_exprt a1(
     contains,
@@ -225,10 +241,23 @@ exprt string_constraint_generatort::add_axioms_for_last_index_of_string(
   return offset;
 }
 
-/// add axioms corresponding to the String.indexOf:(C), String.indexOf:(CI),
-/// String.indexOf:(String), and String.indexOf:(String,I) java functions
-/// \par parameters: function application with 2 or 3 arguments
-/// \return a integer expression
+/// Index of the first occurence of a target inside the string
+///
+/// If the target is a character:
+/// \copybrief add_axioms_for_index_of(const array_string_exprt&,const exprt&,const exprt&)
+/// \link
+/// add_axioms_for_index_of(const array_string_exprt&,const exprt&,const exprt&)
+/// (More...) \endlink
+///
+/// If the target is a refined_string:
+/// \copybrief string_constraint_generatort::add_axioms_for_index_of_string
+/// \link string_constraint_generatort::add_axioms_for_index_of_string (More...)
+/// \endlink
+/// \warning slow for string targets
+/// \param f: function application with arguments refined_string `haystack`,
+///           refined_string or character `needle`, and optional integer
+///           `from_index` with default value `0`
+/// \return integer expression
 exprt string_constraint_generatort::add_axioms_for_index_of(
   const function_application_exprt &f)
 {
@@ -258,14 +287,26 @@ exprt string_constraint_generatort::add_axioms_for_index_of(
   }
 }
 
-/// Add axioms stating that the returned value is the index within str of the
-/// last occurrence of c starting the search backward at from_index, or -1 if no
-/// such character occurs at or before position from_index.
-/// \param str: a string expression
-/// \param c: an expression representing a character
-/// \param from_index: an expression representing an index in the string
-/// \return an integer expression representing the last index of c in str before
-///   or at from_index, or -1 if there is none
+/// Add axioms stating that the returned value is the index within `haystack`
+/// (`str`) of the last occurrence of `needle` (`c`) starting the search
+/// backward at `from_index`, or `-1` if no such character occurs at or before
+/// position `from_index`.
+/// \todo Change argument names to match add_axioms_for_last_index_of_string
+///
+/// These axioms are :
+///   1. \f$ -1 \le {\tt index} \le {\tt from\_index} \f$
+///   2. \f$ {\tt index} = -1 \Leftrightarrow \lnot contains\f$
+///   3. \f$ contains \Rightarrow ({\tt index} \le {\tt from\_index} \land
+///          {\tt haystack}[i] = {\tt needle} )\f$
+///   4. \f$ \forall n \in [{\tt index} +1, {\tt from\_index}+1)
+///          .\ contains \Rightarrow {\tt haystack}[n] \ne {\tt needle} \f$
+///   5. \f$ \forall m \in [0, {\tt from\_index}+1)
+///          .\ \lnot contains \Rightarrow {\tt haystack}[m] \ne {\tt needle}\f$
+/// \param str: an array of characters expression
+/// \param c: a character expression
+/// \param from_index: an integer expression
+/// \return integer expression `index` representing the last index of `needle`
+///         in `haystack` before or at `from_index`, or `-1` if there is none
 exprt string_constraint_generatort::add_axioms_for_last_index_of(
   const array_string_exprt &str,
   const exprt &c,
@@ -274,13 +315,6 @@ exprt string_constraint_generatort::add_axioms_for_last_index_of(
   const typet &index_type = str.length().type();
   symbol_exprt index=fresh_exist_index("last_index_of", index_type);
   symbol_exprt contains=fresh_boolean("contains_in_last_index_of");
-
-  // We add axioms:
-  // a1 : -1 <= i <= from_index
-  // a2 : i = -1 <=> !contains
-  // a3 : contains ==> (i <= from_index && s[i] = c)
-  // a4 : forall n:[i+1, from_index+1[ && contains ==> s[n] != c
-  // a5 : forall m:[0, from_index+1[ && !contains ==> s[m] != c
 
   exprt index1=from_integer(1, index_type);
   exprt minus1=from_integer(-1, index_type);
@@ -320,11 +354,23 @@ exprt string_constraint_generatort::add_axioms_for_last_index_of(
   return index;
 }
 
-/// add axioms corresponding to the String.lastIndexOf:(C),
-/// String.lastIndexOf:(CI), String.lastIndexOf:(String), and
-/// String.lastIndexOf:(String,I) java functions
-/// \par parameters: function application with 2 or 3 arguments
-/// \return a integer expression
+/// Index of the last occurence of a target inside the string
+///
+/// If the target is a character:
+/// \copybrief add_axioms_for_last_index_of(const array_string_exprt&,const exprt&,const exprt&)
+/// \link
+/// add_axioms_for_last_index_of(const array_string_exprt&,const exprt&,const exprt&)
+///   (More...) \endlink
+///
+/// If the target is a refined_string:
+/// \copybrief string_constraint_generatort::add_axioms_for_last_index_of_string
+/// \link string_constraint_generatort::add_axioms_for_last_index_of_string
+///   (More...) \endlink
+/// \warning slow for string targets
+/// \param f: function application with arguments refined_string `haystack`,
+///           refined_string or character `needle`, and optional integer
+///           `from_index` with default value `|haystack|-1`
+/// \return an integer expression
 exprt string_constraint_generatort::add_axioms_for_last_index_of(
   const function_application_exprt &f)
 {

--- a/src/solvers/refinement/string_constraint_generator_indexof.cpp
+++ b/src/solvers/refinement/string_constraint_generator_indexof.cpp
@@ -244,6 +244,7 @@ exprt string_constraint_generatort::add_axioms_for_last_index_of_string(
 /// Index of the first occurence of a target inside the string
 ///
 /// If the target is a character:
+// NOLINTNEXTLINE
 /// \copybrief add_axioms_for_index_of(const array_string_exprt&,const exprt&,const exprt&)
 /// \link
 /// add_axioms_for_index_of(const array_string_exprt&,const exprt&,const exprt&)
@@ -357,9 +358,10 @@ exprt string_constraint_generatort::add_axioms_for_last_index_of(
 /// Index of the last occurence of a target inside the string
 ///
 /// If the target is a character:
+// NOLINTNEXTLINE
 /// \copybrief add_axioms_for_last_index_of(const array_string_exprt&,const exprt&,const exprt&)
-/// \link
-/// add_axioms_for_last_index_of(const array_string_exprt&,const exprt&,const exprt&)
+// NOLINTNEXTLINE
+/// \link add_axioms_for_last_index_of(const array_string_exprt&,const exprt&,const exprt&)
 ///   (More...) \endlink
 ///
 /// If the target is a refined_string:

--- a/src/solvers/refinement/string_constraint_generator_insert.cpp
+++ b/src/solvers/refinement/string_constraint_generator_insert.cpp
@@ -12,11 +12,16 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include <solvers/refinement/string_refinement_invariant.h>
 #include <solvers/refinement/string_constraint_generator.h>
 
-/// add axioms stating that the result correspond to the first string where we
-/// inserted the second one at position offset
-/// \par parameters: two string expression and an integer offset
-/// \return an expression whose value would be different from zero if there is
-///   an exception to signal
+/// Add axioms ensuring the result `res` corresponds to `s1` where we
+/// inserted `s2` at position `offset`.
+/// This is equivalent to
+/// `res=concat(substring(s1, 0, offset), concat(s2, substring(s1, offset)))`.
+/// \param res: array of characters expression
+/// \param s1: array of characters expression
+/// \param s2: array of characters expression
+/// \param offset: integer expression
+/// \return an expression expression which is different from zero if there is
+///         an exception to signal
 exprt string_constraint_generatort::add_axioms_for_insert(
   const array_string_exprt &res,
   const array_string_exprt &s1,
@@ -46,12 +51,23 @@ exprt string_constraint_generatort::add_axioms_for_insert(
     return_code1);
 }
 
-/// add axioms corresponding to the StringBuilder.insert(int, CharSequence) and
-/// StringBuilder.insert(int, CharSequence, int, int) java functions
-/// \param f: function application with arguments integer `|res|`, char pointer
-///           `&res[0]`, refined string `s1`, refined string `s2`,
-///           integer `offset`
-/// \return a new string expression
+/// Insertion of a string in another at a specific index
+///
+/// \copybrief string_constraint_generatort::add_axioms_for_insert(
+/// const array_string_exprt &, const array_string_exprt &,
+/// const array_string_exprt &, const exprt &)
+/// \link
+/// add_axioms_for_insert(const array_string_exprt&,const array_string_exprt&,const array_string_exprt&,const exprt&)
+///   (More...) \endlink
+///
+/// If `start` and `end` arguments are given then `substring(s2, start, end)`
+/// is considered instead of `s2`.
+/// \param f: function application with arguments integer `|res|`, character
+///           pointer `&res[0]`, refined_string `s1`, refined_string`s2`,
+///           integer `offset`, optional integer `start` and optional integer
+///           `end`
+/// \return an integer expression which is different from zero if there is
+///         an exception to signal
 exprt string_constraint_generatort::add_axioms_for_insert(
   const function_application_exprt &f)
 {
@@ -80,7 +96,9 @@ exprt string_constraint_generatort::add_axioms_for_insert(
     return add_axioms_for_insert(res, s1, s2, offset);
   }
 }
+
 /// add axioms corresponding to the StringBuilder.insert(I) java function
+/// \deprecated
 /// \param f: function application with three arguments: a string, an
 ///   integer offset, and an integer
 /// \return an expression
@@ -100,6 +118,7 @@ exprt string_constraint_generatort::add_axioms_for_insert_int(
 }
 
 /// add axioms corresponding to the StringBuilder.insert(Z) java function
+/// \deprecated should convert the value to string and call insert
 /// \param f: function application with three arguments: a string, an
 ///   integer offset, and a Boolean
 /// \return a new string expression
@@ -118,7 +137,8 @@ exprt string_constraint_generatort::add_axioms_for_insert_bool(
   return add_axioms_for_insert(res, s1, s2, offset);
 }
 
-/// add axioms corresponding to the StringBuilder.insert(C) java function
+/// Add axioms corresponding to the StringBuilder.insert(C) java function
+/// \todo This should be merged with add_axioms_for_insert.
 /// \param f: function application with three arguments: a string, an
 ///   integer offset, and a character
 /// \return an expression
@@ -138,6 +158,7 @@ exprt string_constraint_generatort::add_axioms_for_insert_char(
 }
 
 /// add axioms corresponding to the StringBuilder.insert(D) java function
+/// \deprecated should convert the value to string and call insert
 /// \param f: function application with three arguments: a string, an
 ///   integer offset, and a double
 /// \return a string expression
@@ -157,7 +178,8 @@ exprt string_constraint_generatort::add_axioms_for_insert_double(
   return add_axioms_for_insert(res, s1, s2, offset);
 }
 
-/// add axioms corresponding to the StringBuilder.insert(F) java function
+/// Add axioms corresponding to the StringBuilder.insert(F) java function
+/// \deprecated should convert the value to string and call insert
 /// \param f: function application with three arguments: a string, an
 ///   integer offset, and a float
 /// \return a new string expression

--- a/src/solvers/refinement/string_constraint_generator_insert.cpp
+++ b/src/solvers/refinement/string_constraint_generator_insert.cpp
@@ -56,8 +56,8 @@ exprt string_constraint_generatort::add_axioms_for_insert(
 /// \copybrief string_constraint_generatort::add_axioms_for_insert(
 /// const array_string_exprt &, const array_string_exprt &,
 /// const array_string_exprt &, const exprt &)
-/// \link
-/// add_axioms_for_insert(const array_string_exprt&,const array_string_exprt&,const array_string_exprt&,const exprt&)
+// NOLINTNEXTLINE
+/// \link add_axioms_for_insert(const array_string_exprt&,const array_string_exprt&,const array_string_exprt&,const exprt&)
 ///   (More...) \endlink
 ///
 /// If `start` and `end` arguments are given then `substring(s2, start, end)`

--- a/src/solvers/refinement/string_constraint_generator_main.cpp
+++ b/src/solvers/refinement/string_constraint_generator_main.cpp
@@ -222,7 +222,7 @@ string_constraint_generatort::associate_char_array_to_char_pointer(
     char_pointer.id() == ID_constant &&
     to_constant_expr(char_pointer).get_value() == ID_NULL)
   {
-    // TODO: is this useful?
+    /// \todo Check if the case char_array_null occurs.
     array_typet array_type(
       char_array_type.subtype(),
       from_integer(0, to_array_type(char_array_type).size().type()));
@@ -269,9 +269,9 @@ exprt string_constraint_generatort::associate_array_to_pointer(
     array_expr.length() = pair.first->second;
   }
 
-  // TODO should use a function for that
+  /// \todo We should use a function for inserting the correspondance
+  /// between array and pointers.
   arrays_of_pointers_.insert(std::make_pair(pointer_expr, array_expr));
-  // TODO should go inside function
   add_default_axioms(to_array_string_expr(array_expr));
   return from_integer(0, f.type());
 }
@@ -337,7 +337,7 @@ void string_constraint_generatort::add_default_axioms(
 }
 
 /// Adds creates a new array if it does not already exists
-/// TODO: This should be replaced by associate_char_array_to_char_pointer
+/// \todo This should be replaced by associate_char_array_to_char_pointer
 array_string_exprt string_constraint_generatort::char_array_of_pointer(
   const exprt &pointer,
   const exprt &length)
@@ -484,7 +484,8 @@ exprt string_constraint_generatort::add_axioms_for_function_application(
 
 /// add axioms to say that the returned string expression is equal to the
 /// argument of the function application
-/// \par parameters: function application with one argument, which is a string,
+/// \deprecated should use substring instead
+/// \param f: function application with one argument, which is a string,
 /// or three arguments: string, integer offset and count
 /// \return a new string expression
 exprt string_constraint_generatort::add_axioms_for_copy(
@@ -500,10 +501,11 @@ exprt string_constraint_generatort::add_axioms_for_copy(
   return add_axioms_for_substring(res, str, offset, plus_exprt(offset, count));
 }
 
-
-/// add axioms corresponding to the String.length java function
-/// \par parameters: function application with one string argument
-/// \return a string expression of index type
+/// Length of a string
+///
+/// Returns the length of the string argument of the given function application
+/// \param f: function application with argument string `str`
+/// \return expression `|str|`
 exprt string_constraint_generatort::add_axioms_for_length(
   const function_application_exprt &f)
 {
@@ -513,7 +515,7 @@ exprt string_constraint_generatort::add_axioms_for_length(
 }
 
 /// expression true exactly when the index is positive
-/// \par parameters: an index expression
+/// \param x: an index expression
 /// \return a Boolean expression
 exprt string_constraint_generatort::axiom_for_is_positive_index(const exprt &x)
 {
@@ -521,7 +523,7 @@ exprt string_constraint_generatort::axiom_for_is_positive_index(const exprt &x)
 }
 
 /// add axioms stating that the returned value is equal to the argument
-/// \par parameters: function application with one character argument
+/// \param f: function application with one character argument
 /// \return a new character expression
 exprt string_constraint_generatort::add_axioms_for_char_literal(
   const function_application_exprt &f)
@@ -551,11 +553,13 @@ exprt string_constraint_generatort::add_axioms_for_char_literal(
   }
 }
 
-/// add axioms stating that the character of the string at the given position is
-/// equal to the returned value
-/// \par parameters: function application with two arguments: a string and an
-///   integer
-/// \return a character expression
+/// Character at a given position
+///
+/// Add axioms stating that the character of the string at position given by
+/// second argument is equal to the returned value.
+/// This axiom is \f$ char = str[i] \f$.
+/// \param f: function application with arguments string `str` and integer `i`
+/// \return character expression `char`
 exprt string_constraint_generatort::add_axioms_for_char_at(
   const function_application_exprt &f)
 {

--- a/src/solvers/refinement/string_constraint_generator_testing.cpp
+++ b/src/solvers/refinement/string_constraint_generator_testing.cpp
@@ -70,6 +70,7 @@ exprt string_constraint_generatort::add_axioms_for_is_prefix(
 /// Add axioms ensuring the return value is true when the string starts with the
 /// given target.
 /// These axioms are detailed here:
+// NOLINTNEXTLINE
 /// string_constraint_generatort::add_axioms_for_is_prefix(const array_string_exprt &prefix, const array_string_exprt &str, const exprt &offset)
 /// \todo The primitive should be renamed to `starts_with`.
 /// \todo Get rid of the boolean flag.

--- a/src/solvers/refinement/string_constraint_generator_testing.cpp
+++ b/src/solvers/refinement/string_constraint_generator_testing.cpp
@@ -13,10 +13,21 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include <solvers/refinement/string_refinement_invariant.h>
 #include <solvers/refinement/string_constraint_generator.h>
 
-/// add axioms stating that the returned expression is true exactly when the
-/// first string is a prefix of the second one, starting at position offset
-/// \par parameters: a prefix string, a string and an integer offset
-/// \return a Boolean expression
+/// Add axioms stating that the returned expression is true exactly when the
+/// first string is a prefix of the second one, starting at position offset.
+///
+/// These axioms are:
+///   1. \f$ {\tt isprefix} \Rightarrow |str| \ge |{\tt prefix}|+offset \f$
+///   2. \f$ \forall 0 \le qvar<|{\tt prefix}|.\ {\tt isprefix}
+///          \Rightarrow s0[witness+{\tt offset}]=s2[witness] \f$
+///   3. \f$ !{\tt isprefix} \Rightarrow |{\tt str}|<|{\tt prefix}|+{\tt offset}
+///          \lor (0 \le witness<|{\tt prefix}|
+///        \land {\tt str}[witness+{\tt offset}] \ne {\tt prefix}[witness])\f$
+///
+/// \param prefix: an array of characters
+/// \param str: an array of characters
+/// \param offset: an integer
+/// \return Boolean expression `isprefix`
 exprt string_constraint_generatort::add_axioms_for_is_prefix(
   const array_string_exprt &prefix,
   const array_string_exprt &str,
@@ -24,13 +35,6 @@ exprt string_constraint_generatort::add_axioms_for_is_prefix(
 {
   symbol_exprt isprefix=fresh_boolean("isprefix");
   const typet &index_type=str.length().type();
-
-  // We add axioms:
-  // a1 : isprefix => |str| >= |prefix|+offset
-  // a2 : forall 0<=qvar<|prefix|. isprefix => s0[witness+offset]=s2[witness]
-  // a3 : !isprefix =>
-  //        |str|<|prefix|+offset ||
-  //        (0<=witness<|prefix| && str[witness+offset]!=prefix[witness])
 
   implies_exprt a1(
     isprefix,
@@ -61,12 +65,20 @@ exprt string_constraint_generatort::add_axioms_for_is_prefix(
   return isprefix;
 }
 
-/// add axioms corresponding to the String.isPrefix java function
-/// \par parameters: a function application with 2 or 3 arguments and a Boolean
-///   telling
-/// whether the prefix is the second argument (when swap_arguments is
-/// true) or the first argument
-/// \return a Boolean expression
+/// Test if the target is a prefix of the string
+///
+/// Add axioms ensuring the return value is true when the string starts with the
+/// given target.
+/// These axioms are detailed here:
+/// string_constraint_generatort::add_axioms_for_is_prefix(const array_string_exprt &prefix, const array_string_exprt &str, const exprt &offset)
+/// \todo The primitive should be renamed to `starts_with`.
+/// \todo Get rid of the boolean flag.
+/// \param f: a function application with arguments refined_string `s0`,
+///           refined string `s1` and optional integer argument `offset`
+///           whose default value is 0
+/// \param swap_arguments: a Boolean telling whether the prefix is the second
+///        argument or the first argument
+/// \return boolean expression `isprefix`
 exprt string_constraint_generatort::add_axioms_for_is_prefix(
   const function_application_exprt &f, bool swap_arguments)
 {
@@ -80,9 +92,10 @@ exprt string_constraint_generatort::add_axioms_for_is_prefix(
   return typecast_exprt(add_axioms_for_is_prefix(s0, s1, offset), f.type());
 }
 
-/// add axioms stating that the returned value is true exactly when the argument
-/// string is empty
-/// \par parameters: function application with a string argument
+/// Add axioms stating that the returned value is true exactly when the argument
+/// string is empty.
+/// \deprecated should use `string_length(s)==0` instead
+/// \param f: function application with a string argument
 /// \return a Boolean expression
 exprt string_constraint_generatort::add_axioms_for_is_empty(
   const function_application_exprt &f)
@@ -100,12 +113,26 @@ exprt string_constraint_generatort::add_axioms_for_is_empty(
   return typecast_exprt(is_empty, f.type());
 }
 
-/// add axioms corresponding to the String.isSuffix java function
-/// \par parameters: a function application with 2 or 3 arguments and a Boolean
-///   telling
-/// whether the suffix is the second argument (when swap_arguments is
-/// true) or the first argument
-/// \return a Boolean expression
+/// Test if the target is a suffix of the string
+///
+/// Add axioms ensuring the return value is true when the first string ends with
+/// the given target.
+/// These axioms are:
+///   1. \f$ \texttt{issuffix} \Rightarrow |s_0| \ge |s_1| \f$
+///   2. \f$ \forall i <|s_1|.\ {\tt issuffix}
+///          \Rightarrow s_1[i] = s_0[i + |s_0| - |s_1|]
+///      \f$
+///   3. \f$ \lnot {\tt issuffix} \Rightarrow
+///     (|s_1| > |s_0| \land {\tt witness}=-1)
+///     \lor (|s_1| > {witness} \ge 0
+///       \land s_1[{witness}] \ne s_0[{witness} + |s_0| - |s_1|] \f$
+///
+/// \todo The primitive should be renamed `ends_with`.
+/// \param f: a function application with arguments refined_string `s0`
+///           and refined_string  `s1`
+/// \param swap_arguments: boolean flag telling whether the suffix is the second
+///        argument or the first argument
+/// \return Boolean expression `issuffix`
 exprt string_constraint_generatort::add_axioms_for_is_suffix(
   const function_application_exprt &f, bool swap_arguments)
 {
@@ -118,15 +145,6 @@ exprt string_constraint_generatort::add_axioms_for_is_suffix(
   const array_string_exprt &s0 = get_string_expr(args[swap_arguments ? 1 : 0]);
   const array_string_exprt &s1 = get_string_expr(args[swap_arguments ? 0 : 1]);
   const typet &index_type=s0.length().type();
-
-  // We add axioms:
-  // a1 : issufix => s0.length >= s1.length
-  // a2 : forall witness<s1.length.
-  //     issufix => s1[witness]=s0[witness + s0.length-s1.length]
-  // a3 : !issuffix =>
-  //   (s1.length > s0.length && witness=-1)
-  //     || (s1.length > witness>=0
-  //       &&s1[witness]!=s0[witness + s0.length-s1.length]
 
   implies_exprt a1(issuffix, s1.axiom_for_length_ge(s0.length()));
   axioms.push_back(a1);
@@ -156,9 +174,24 @@ exprt string_constraint_generatort::add_axioms_for_is_suffix(
   return tc_issuffix;
 }
 
-/// add axioms corresponding to the String.contains java function
-/// \par parameters: function application with two string arguments
-/// \return a Boolean expression
+/// Test whether a string contains another
+///
+/// Add axioms ensuring the returned value is true when the first string
+/// contains the second.
+/// These axioms are:
+///   1. \f$ contains \Rightarrow |s_0| \ge |s_1| \f$
+///   2. \f$ contains \Rightarrow 0 \le startpos \le |s_0|-|s_1| \f$
+///   3. \f$ !contains \Rightarrow startpos = -1 \f$
+///   4. \f$ \forall qvar < |s_1|.\ contains
+///          \Rightarrow s_1[qvar] = s_0[startpos + qvar] \f$
+///   5. \f$ \forall startpos \le |s_0|-|s_1|.
+///          \ (!contains \land |s_0| \ge |s_1|)
+///          \Rightarrow \exists witness < |s_1|.
+///          \ s_1[witness] \ne s_0[startpos+witness] \f$
+/// \warning slow for target longer than one character
+/// \param f: function application with arguments refined_string `s0`
+///           refined_string `s1`
+/// \return Boolean expression `contains`
 exprt string_constraint_generatort::add_axioms_for_contains(
   const function_application_exprt &f)
 {
@@ -170,15 +203,6 @@ exprt string_constraint_generatort::add_axioms_for_contains(
   const symbol_exprt contains = fresh_boolean("contains");
   const symbol_exprt startpos =
     fresh_exist_index("startpos_contains", index_type);
-
-  // We add axioms:
-  // a1 : contains ==> |s0| >= |s1|
-  // a2 : contains ==> 0 <= startpos <= |s0|-|s1|
-  // a3 : !contains ==> startpos = -1
-  // a4 : forall qvar < |s1|. contains ==> s1[qvar] = s0[startpos + qvar]
-  // a5 : !contains ==> |s1| > |s0| ||
-  //      (forall startpos <= |s0| - |s1|.
-  //         exists witness < |s1|. s1[witness] != s0[witness + startpos])
 
   const implies_exprt a1(contains, s0.axiom_for_length_ge(s1.length()));
   axioms.push_back(a1);
@@ -201,9 +225,6 @@ exprt string_constraint_generatort::add_axioms_for_contains(
     qvar, s1.length(), contains, equal_exprt(s1[qvar], s0[qvar_shifted]));
   axioms.push_back(a4);
 
-  // We rewrite axiom a4 as:
-  // forall startpos <= |s0|-|s1|.  (!contains && |s0| >= |s1|)
-  //     ==> exists witness < |s1|. s1[witness] != s0[startpos+witness]
   string_not_contains_constraintt a5(
     from_integer(0, index_type),
     plus_exprt(from_integer(1, index_type), length_diff),

--- a/src/solvers/refinement/string_constraint_generator_transformation.cpp
+++ b/src/solvers/refinement/string_constraint_generator_transformation.cpp
@@ -76,6 +76,7 @@ exprt string_constraint_generatort::add_axioms_for_set_length(
 ///   const array_string_exprt &str,
 ///   const exprt &start,
 ///   const exprt &end)
+// NOLINTNEXTLINE
 /// \link string_constraint_generatort::add_axioms_for_substring(const array_string_exprt &res, const array_string_exprt &str, const exprt &start, const exprt &end)
 ///   (More...) \endlink
 /// \warning The specification may not be correct for the case where the string
@@ -367,8 +368,9 @@ exprt string_constraint_generatort::add_axioms_for_to_upper_case(
 
 /// Conversion of a string to upper case
 ///
-/// \copybrief string_constraint_generatort::add_axioms_for_to_upper_case(
-/// const array_string_exprt &res, const array_string_exprt &str)
+// NOLINTNEXTLINE
+/// \copybrief string_constraint_generatort::add_axioms_for_to_upper_case(const array_string_exprt&, const array_string_exprt&)
+// NOLINTNEXTLINE
 /// \link string_constraint_generatort::add_axioms_for_to_upper_case(const array_string_exprt &res, const array_string_exprt &str)
 ///   (More...) \endlink
 /// \param f: function application with arguments integer `|res|`, character
@@ -551,7 +553,9 @@ exprt string_constraint_generatort::add_axioms_for_delete(
 
 /// Remove a portion of a string
 ///
+// NOLINTNEXTLINE
 /// \copybrief string_constraint_generatort::add_axioms_for_delete(const array_string_exprt &res, const array_string_exprt &str, const exprt &start, const exprt &end)
+// NOLINTNEXTLINE
 /// \link string_constraint_generatort::add_axioms_for_delete(const array_string_exprt &res, const array_string_exprt &str, const exprt &start, const exprt &end)
 ///   (More...) \endlink
 /// \param f: function application with arguments integer `|res|`, character

--- a/src/solvers/refinement/string_constraint_generator_valueof.cpp
+++ b/src/solvers/refinement/string_constraint_generator_valueof.cpp
@@ -18,6 +18,8 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include <cmath>
 #include <solvers/floatbv/float_bv.h>
 
+/// Convert an integer to a string
+///
 /// Add axioms corresponding to the String.valueOf(I) java function.
 /// \param f: function application with one integer argument
 /// \return a new string expression
@@ -35,6 +37,7 @@ exprt string_constraint_generatort::add_axioms_from_int(
 }
 
 /// Add axioms corresponding to the String.valueOf(J) java function.
+/// \deprecated should use add_axioms_from_int instead
 /// \param f: function application with one long argument
 /// \return a new string expression
 exprt string_constraint_generatort::add_axioms_from_long(
@@ -51,6 +54,7 @@ exprt string_constraint_generatort::add_axioms_from_long(
 }
 
 /// Add axioms corresponding to the String.valueOf(Z) java function.
+/// \deprecated this is specific to Java
 /// \param f: function application with a Boolean argument
 /// \return a new string expression
 exprt string_constraint_generatort::add_axioms_from_bool(
@@ -64,6 +68,7 @@ exprt string_constraint_generatort::add_axioms_from_bool(
 
 /// Add axioms stating that the returned string equals "true" when the Boolean
 /// expression is true and "false" when it is false.
+/// \deprecated This is language dependent
 /// \param res: string expression for the result
 /// \param b: Boolean expression
 /// \return code 0 on success
@@ -191,6 +196,7 @@ exprt string_constraint_generatort::int_of_hex_char(const exprt &chr)
 
 /// Add axioms stating that the string `res` corresponds to the integer
 /// argument written in hexadecimal.
+/// \deprecated use add_axioms_from_int which takes a radix argument instead
 /// \param res: string expression for the result
 /// \param i: an integer argument
 /// \return code 0 on success
@@ -247,7 +253,7 @@ exprt string_constraint_generatort::add_axioms_from_int_hex(
   return from_integer(0, get_return_code_type());
 }
 
-/// add axioms corresponding to the Integer.toHexString(I) java function
+/// Add axioms corresponding to the Integer.toHexString(I) java function
 /// \param f: function application with an integer argument
 /// \return code 0 on success
 exprt string_constraint_generatort::add_axioms_from_int_hex(
@@ -259,8 +265,14 @@ exprt string_constraint_generatort::add_axioms_from_int_hex(
   return add_axioms_from_int_hex(res, f.arguments()[2]);
 }
 
-/// Add axioms corresponding to the String.valueOf(C) java function.
-/// \param f: function application one char argument
+/// Conversion from char to string
+///
+/// \copybrief  string_constraint_generatort::add_axioms_from_char(
+///   const array_string_exprt &res, const exprt &c)
+/// \link string_constraint_generatort::add_axioms_from_char(const array_string_exprt &res, const exprt &c)
+///    (More...) \endlink
+/// \param f: function application with arguments integer `|res|`, character
+///           pointer `&res[0]` and character `c`
 /// \return code 0 on success
 exprt string_constraint_generatort::add_axioms_from_char(
   const function_application_exprt &f)
@@ -271,10 +283,12 @@ exprt string_constraint_generatort::add_axioms_from_char(
   return add_axioms_from_char(res, f.arguments()[2]);
 }
 
-/// Add axioms stating that the returned string has length 1 and the character
-/// it contains corresponds to the input expression.
-/// \param res: string expression for the result
-/// \param c: one expression of type char
+/// Add axiom stating that string `res` has length 1 and the character
+/// it contains equals `c`.
+///
+/// This axiom is: \f$ |{\tt res}| = 1 \land {\tt res}[0] = {\tt c} \f$.
+/// \param res: array of characters expression
+/// \param c: character expression
 /// \return code 0 on success
 exprt string_constraint_generatort::add_axioms_from_char(
   const array_string_exprt &res,
@@ -462,10 +476,13 @@ void string_constraint_generatort::add_axioms_for_characters_in_integer_string(
   }
 }
 
-/// add axioms corresponding to the Integer.parseInt java function
-/// \param f: a function application with either one string expression or one
-///   string expression and an integer expression for the radix
-/// \return an integer expression
+/// Integer value represented by a string
+///
+/// Add axioms ensuring the value of the returned integer corresponds
+/// to the value represented by `str`
+/// \param f: a function application with arguments refined_string `str` and
+///          an optional integer for the radix
+/// \return integer expression equal to the value represented by `str`
 exprt string_constraint_generatort::add_axioms_for_parse_int(
   const function_application_exprt &f)
 {
@@ -476,8 +493,8 @@ exprt string_constraint_generatort::add_axioms_for_parse_int(
   const exprt radix=f.arguments().size()==1?
     static_cast<exprt>(from_integer(10, type)):
     static_cast<exprt>(typecast_exprt(f.arguments()[1], type));
-  /// Most of the time we can evaluate radix as an integer. The value 0 is used
-  /// to indicate when we can't tell what the radix is.
+  // Most of the time we can evaluate radix as an integer. The value 0 is used
+  // to indicate when we can't tell what the radix is.
   const unsigned long radix_ul=to_integer_or_default(radix, 0);
   PRECONDITION((radix_ul>=2 && radix_ul<=36) || radix_ul==0);
 
@@ -488,8 +505,9 @@ exprt string_constraint_generatort::add_axioms_for_parse_int(
 
   const std::size_t max_string_length=max_printed_string_length(type, radix_ul);
 
-  /// TODO: we should throw an exception when this does not hold:
-  /// Note that the only thing stopping us from taking longer strings with many
+  /// \todo We should throw an exception when constraints added in
+  /// add_axioms_for_correct_number_format do not hold.
+  /// \note the only thing stopping us from taking longer strings with many
   /// leading zeros is the axioms for correct number format
   add_axioms_for_correct_number_format(
     input_int,

--- a/src/solvers/refinement/string_constraint_generator_valueof.cpp
+++ b/src/solvers/refinement/string_constraint_generator_valueof.cpp
@@ -269,6 +269,7 @@ exprt string_constraint_generatort::add_axioms_from_int_hex(
 ///
 /// \copybrief  string_constraint_generatort::add_axioms_from_char(
 ///   const array_string_exprt &res, const exprt &c)
+// NOLINTNEXTLINE
 /// \link string_constraint_generatort::add_axioms_from_char(const array_string_exprt &res, const exprt &c)
 ///    (More...) \endlink
 /// \param f: function application with arguments integer `|res|`, character

--- a/src/solvers/refinement/string_refinement.cpp
+++ b/src/solvers/refinement/string_refinement.cpp
@@ -215,6 +215,7 @@ static void display_index_set(
 ///     the index set of `str` we find `y` such that `f(y)=val` and
 ///     add lemma `P(y)`.
 ///     (See
+// NOLINTNEXTLINE
 ///     `instantiate(messaget::mstreamt&,const string_constraintt&,const exprt &,const exprt&)`
 ///      for details)
 ///   * For formulas of the form
@@ -467,12 +468,15 @@ void output_equations(
 /// Pointer symbols which are set to be equal by constraints, are replaced by
 /// an single symbol in the solver. The `symbol_solvert` object used for this
 /// substitution is constructed by
+// NOLINTNEXTLINE
 /// `generate_symbol_resolution_from_equations(const std::vector<equal_exprt>&,const namespacet&,messaget::mstreamt&)`.
 /// All these symbols are then replaced using
+// NOLINTNEXTLINE
 /// `replace_symbols_in_equations(const union_find_replacet &, std::vector<equal_exprt> &)`.
 ///
 /// ## Conversion to first order formulas:
 /// Each string primitive is converted to a list of first order formulas by the
+// NOLINTNEXTLINE
 /// function `substitute_function_applications_in_equations(std::vector<equal_exprt>&,string_constraint_generatort&)`.
 /// These formulas should be unquantified or be either a `string_constraintt`
 /// or a `string_not_contains_constraintt`.


### PR DESCRIPTION
This is based on https://github.com/diffblue/cbmc/pull/1420 and documents the new version of the solver.
This adds a README.md file in `solvers/refinement` which produce a page `String solver` in `Modules` of the Doxygen manual of cprover.
 