### PR TITLE
Return pointer from expr_try_dynamic_cast

### DIFF
--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -55,7 +55,7 @@ inline bool can_cast_code_impl(const exprt &expr, const Tag &tag)
 {
   try
   {
-    return expr_dynamic_cast<const codet &>(expr).get_statement()==tag;
+    return expr_dynamic_cast<codet>(expr).get_statement()==tag;
   }
   catch(const std::bad_cast &)
   {
@@ -1246,8 +1246,7 @@ inline bool can_cast_side_effect_expr_impl(const exprt &expr, const Tag &tag)
 {
   try
   {
-    return
-      expr_dynamic_cast<const side_effect_exprt &>(expr).get_statement()==tag;
+    return expr_dynamic_cast<side_effect_exprt>(expr).get_statement()==tag;
   }
   catch(const std::bad_cast &)
   {

--- a/unit/util/expr_cast/expr_cast.cpp
+++ b/unit/util/expr_cast/expr_cast.cpp
@@ -23,12 +23,12 @@ SCENARIO("expr_dynamic_cast",
     THEN("Try-casting from exprt reference to symbol_exprt pointer "
          "returns a value")
     {
-      REQUIRE(expr_try_dynamic_cast<const symbol_exprt &>(expr).has_value());
+      REQUIRE(expr_try_dynamic_cast<symbol_exprt>(expr)!=nullptr);
     }
 
     THEN("Casting from exprt pointer to transt pointer doesn't return a value")
     {
-      REQUIRE(!expr_try_dynamic_cast<const transt &>(expr).has_value());
+      REQUIRE(expr_try_dynamic_cast<transt>(expr)==nullptr);
     }
   }
   GIVEN("A exprt reference to a symbolt")
@@ -38,13 +38,13 @@ SCENARIO("expr_dynamic_cast",
     THEN("Casting from exprt reference to symbol_exprt reference "
          "returns a value")
     {
-      REQUIRE(expr_try_dynamic_cast<symbol_exprt &>(expr).has_value());
+      REQUIRE(expr_try_dynamic_cast<symbol_exprt>(expr)!=nullptr);
     }
 
     THEN("Casting from exprt reference to transt reference "
          "doesn't return a value")
     {
-      REQUIRE(!expr_try_dynamic_cast<transt &>(expr).has_value());
+      REQUIRE(expr_try_dynamic_cast<transt>(expr)==nullptr);
     }
   }
   GIVEN("A const exprt reference to a symbolt")
@@ -54,7 +54,7 @@ SCENARIO("expr_dynamic_cast",
     THEN(
       "Casting from exprt reference to symbol_exprt reference should not throw")
     {
-      REQUIRE_NOTHROW(expr_dynamic_cast<const symbol_exprt &>(expr_ref));
+      REQUIRE_NOTHROW(expr_dynamic_cast<symbol_exprt>(expr_ref));
     }
 
     THEN("Casting from exprt reference to transt reference should throw")
@@ -62,7 +62,7 @@ SCENARIO("expr_dynamic_cast",
       // This no longer throws exceptions when our custom asserts are set to
       //  abort the program
       // REQUIRE_THROWS_AS(
-      //   expr_dynamic_cast<const transt &>(expr_ref),
+      //   expr_dynamic_cast<transt>(expr_ref),
       //   std::bad_cast);
     }
   }
@@ -73,7 +73,7 @@ SCENARIO("expr_dynamic_cast",
     THEN(
       "Casting from exprt reference to symbol_exprt reference should not throw")
     {
-      REQUIRE_NOTHROW(expr_dynamic_cast<symbol_exprt &>(expr_ref));
+      REQUIRE_NOTHROW(expr_dynamic_cast<symbol_exprt>(expr_ref));
     }
 
     THEN("Casting from exprt reference to transt reference should throw")
@@ -81,7 +81,7 @@ SCENARIO("expr_dynamic_cast",
       // This no longer throws exceptions when our custom asserts are set to
       //  abort the program
       // REQUIRE_THROWS_AS(
-      //   expr_dynamic_cast<transt &>(expr_ref),
+      //   expr_dynamic_cast<transt>(expr_ref),
       //   std::bad_cast);
     }
 
@@ -89,7 +89,7 @@ SCENARIO("expr_dynamic_cast",
       "Casting from non-const exprt reference to const symbol_exprt reference "
       "should be fine")
     {
-      REQUIRE_NOTHROW(expr_dynamic_cast<const symbol_exprt &>(expr_ref));
+      REQUIRE_NOTHROW(expr_dynamic_cast<symbol_exprt>(expr_ref));
     }
   }
 }


### PR DESCRIPTION
In a similar vein to the recent symbol-table change: `expr_try_dynamic_cast` now returns a pointer which is null on failure.

I've also simplified the casts a bit, so that you can just write `expr_try_dynamic_cast<code_declt>(arg)` and the return type will be deduced as a const pointer if `arg` is const, and a non-const pointer if `arg` is mutable. `expr_dynamic_cast` works the same way, but always returns a reference.

Because `expr_try_dynamic_cast` now has practically no overhead, we can implement `expr_dynamic_cast` in terms of it, so that a `bad_cast` is thrown if the pointer is null, otherwise the pointer is dereferenced.

As this is similar to the symtab change, I'd suggest @smowton and @LAJW for review.