### PR TITLE
Fix testing-utils Makefile dependency

### DIFF
--- a/unit/Makefile
+++ b/unit/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all cprover.dir test
+.PHONY: all cprover.dir testing-utils.dir test
 
 # Source files for test utilities
 SRC = unit_tests.cpp \
@@ -40,7 +40,7 @@ include ../src/common
 cprover.dir:
 	$(MAKE) $(MAKEARGS) -C ../src
 
-testing-utils/testing-utils$(LIBEXT):
+testing-utils.dir:
 	$(MAKE) $(MAKEARGS) -C testing-utils
 
 CPROVER_LIBS =../src/java_bytecode/java_bytecode$(LIBEXT) \
@@ -69,7 +69,7 @@ TESTS = unit_tests$(EXEEXT) \
 
 CLEANFILES = $(TESTS)
 
-all: cprover.dir
+all: cprover.dir testing-utils.dir
 	$(MAKE) $(MAKEARGS) $(TESTS)
 
 test: all


### PR DESCRIPTION
This previously led to it being built on first use, but not rebuilt on subsequent change.