### PR TITLE
Fix a few places where a null pointer may be dereferenced

### DIFF
--- a/src/goto-programs/remove_exceptions.cpp
+++ b/src/goto-programs/remove_exceptions.cpp
@@ -312,7 +312,7 @@ void remove_exceptionst::add_exception_dispatch_sequence(
 
   // find the symbol corresponding to the caught exceptions
   const symbolt &exc_symbol=
-    *symbol_table.lookup(id2string(function_id)+EXC_SUFFIX);
+    symbol_table.lookup_ref(id2string(function_id)+EXC_SUFFIX);
   symbol_exprt exc_thrown=exc_symbol.symbol_expr();
 
   // add GOTOs implementing the dynamic dispatch of the
@@ -387,7 +387,7 @@ void remove_exceptionst::instrument_throw(
 
   // find the symbol where the thrown exception should be stored:
   const symbolt &exc_symbol=
-    *symbol_table.lookup(id2string(func_it->first)+EXC_SUFFIX);
+    symbol_table.lookup_ref(id2string(func_it->first)+EXC_SUFFIX);
   symbol_exprt exc_thrown=exc_symbol.symbol_expr();
 
   // add the assignment with the appropriate cast

--- a/src/java_bytecode/java_bytecode_typecheck_expr.cpp
+++ b/src/java_bytecode/java_bytecode_typecheck_expr.cpp
@@ -290,8 +290,8 @@ void java_bytecode_typecheckt::typecheck_expr_member(member_exprt &expr)
     {
       // member doesn't exist. In this case struct_type should be an opaque
       // stub, and we'll add the member to it.
-      symbolt &symbol_table_type=
-        *symbol_table.get_writeable("java::"+id2string(struct_type.get_tag()));
+      symbolt &symbol_table_type=symbol_table.get_writeable_ref(
+        "java::"+id2string(struct_type.get_tag()));
       auto &add_to_components=
         to_struct_type(symbol_table_type.type).components();
       add_to_components


### PR DESCRIPTION
Found a few places where the symbol table is accessed in an unsafe way, possibly leading to null pointers being dereferenced.

@smowton and @LAJW to review again?