### PR TITLE
Simplify a broader range of java primitive types

### DIFF
--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -61,22 +61,87 @@ TEST_CASE("Simplify const pointer offset")
   REQUIRE(offset_value==1234);
 }
 
-TEST_CASE("Simplify Java boolean -> int -> boolean casts")
+namespace
+{
+
+void test_unnecessary_cast(const typet &type)
 {
   config.set_arch("none");
 
-  const exprt simplified=simplify_expr(
-    typecast_exprt(
+  WHEN("The casts can be removed, they are")
+  {
+    const exprt simplified=simplify_expr(
       typecast_exprt(
-        symbol_exprt(
-          "foo",
-          java_boolean_type()),
-        java_int_type()),
-      java_boolean_type()),
-    namespacet(symbol_tablet()));
+        typecast_exprt(symbol_exprt("foo", type), java_int_type()),
+        type),
+      namespacet(symbol_tablet()));
 
-  REQUIRE(simplified.id()==ID_symbol);
-  REQUIRE(simplified.type()==java_boolean_type());
-  const auto &symbol=to_symbol_expr(simplified);
-  REQUIRE(symbol.get_identifier()=="foo");
+    REQUIRE(simplified.id()==ID_symbol);
+    REQUIRE(simplified.type()==type);
+    const auto &symbol=to_symbol_expr(simplified);
+    REQUIRE(symbol.get_identifier()=="foo");
+  }
+
+  WHEN("Casts should remain, they are left untouched")
+  {
+    {
+      const exprt simplified=simplify_expr(
+        typecast_exprt(symbol_exprt("foo", type), java_int_type()),
+        namespacet(symbol_tablet()));
+
+      REQUIRE(simplified.id()==ID_typecast);
+      REQUIRE(simplified.type()==java_int_type());
+    }
+
+    {
+      const exprt simplified=simplify_expr(
+        typecast_exprt(symbol_exprt("foo", java_int_type()), type),
+        namespacet(symbol_tablet()));
+
+      REQUIRE(simplified.id()==ID_typecast);
+      REQUIRE(simplified.type()==type);
+    }
+  }
+
+  WHEN("Deeply nested casts are present, they are collapsed appropriately")
+  {
+    {
+      const exprt simplified=simplify_expr(
+        typecast_exprt(
+          typecast_exprt(
+            typecast_exprt(
+              typecast_exprt(
+                typecast_exprt(symbol_exprt("foo", type), java_int_type()),
+                type),
+              java_int_type()),
+            type),
+          java_int_type()),
+        namespacet(symbol_tablet()));
+
+      REQUIRE(
+        simplified==typecast_exprt(symbol_exprt("foo", type), java_int_type()));
+    }
+  }
+}
+
+} // namespace
+
+TEST_CASE("Simplify Java boolean -> int -> boolean casts")
+{
+  test_unnecessary_cast(java_boolean_type());
+}
+
+TEST_CASE("Simplify Java byte -> int -> byte casts")
+{
+  test_unnecessary_cast(java_byte_type());
+}
+
+TEST_CASE("Simplify Java char -> int -> char casts")
+{
+  test_unnecessary_cast(java_char_type());
+}
+
+TEST_CASE("Simplify Java short -> int -> short casts")
+{
+  test_unnecessary_cast(java_short_type());
 }


### PR DESCRIPTION
This is an extension to #1438, which removes circular casts through `byte`, `char`, and `short` in addition to `boolean`. This change has been made because, in working on diffblue/test-gen#1070, I discovered that primitive types shorter than int can create unnecessary circular type-casts in loaded `codet`s.

Suggest for @pkesseli and @thk123 to review.