### PR TITLE
Fail CMake build if make-generated files are found

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,13 +30,23 @@ endif(DOXYGEN_FOUND)
 
 #   Add a bison target named 'parser'.
 macro(generic_bison name)
+    set(bison_header "${name}_y.tab.h")
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${bison_header}")
+        message(FATAL_ERROR "Generated file ${bison_header} found in source tree. If you previously built with `make`, run `make clean` and try again")
+    endif()
+
+    set(bison_source "${name}_y.tab.cpp")
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${bison_source}")
+        message(FATAL_ERROR "Generated file ${bison_source} found in source tree. If you previously built with `make`, run `make clean` and try again")
+    endif()
+
     bison_target(
         parser
         "${CMAKE_CURRENT_SOURCE_DIR}/parser.y"
-        "${CMAKE_CURRENT_BINARY_DIR}/${name}_y.tab.cpp"
+        "${CMAKE_CURRENT_BINARY_DIR}/${bison_source}"
         COMPILE_FLAGS "-pyy${name}"
     )
-    set(renamed_parser_header "${CMAKE_CURRENT_BINARY_DIR}/${name}_y.tab.h")
+    set(renamed_parser_header "${CMAKE_CURRENT_BINARY_DIR}/${bison_header}")
     add_custom_command(OUTPUT "${renamed_parser_header}"
         COMMAND "${CMAKE_COMMAND}" -E copy "${BISON_parser_OUTPUT_HEADER}" "${renamed_parser_header}"
         MAIN_DEPENDENCY "${BISON_parser_OUTPUT_HEADER}"
@@ -47,6 +57,11 @@ endmacro(generic_bison)
 
 #   Add a flex target named 'scanner'
 macro(generic_flex name)
+    set(flex_source "${name}_lex.yy.cpp")
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${flex_source}")
+        message(FATAL_ERROR "Generated file ${flex_source} found in source tree. If you previously built with `make`, run `make clean` and try again")
+    endif()
+
     flex_target(
         scanner
         "${CMAKE_CURRENT_SOURCE_DIR}/scanner.l"


### PR DESCRIPTION
CMake currently emits a warning if it finds duplicate files in the source and build tree, but then generates a build with broken dependencies. If the generated files in the source tree are removed at this point, CMake doesn't know how to re-generate them, leading to confusing error messages.

This patch causes CMake to emit a fatal error at configure-time if generated files are found in the source tree. This way, CMake doesn't try to include files previously generated by the plain-make build in its own build.

Suggest for @peterschrammel and @LAJW to review.