### PR TITLE
Align options string with help function and options parser

### DIFF
--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -32,7 +32,7 @@ class optionst;
   "(no-simplify)(unwind):(unwindset):(slice-formula)(full-slice)" \
   "(debug-level):(no-propagation)(no-simplify-if)" \
   "(document-subgoals)(outfile):(test-preprocessor)" \
-  "D:I:(c89)(c99)(c11)(cpp89)(cpp99)(cpp11)" \
+  "D:I:(c89)(c99)(c11)(cpp98)(cpp03)(cpp11)" \
   "(object-bits):" \
   "(classpath):(cp):(main-class):" \
   "(depth):(partial-loops)(no-unwinding-assertions)(unwinding-assertions)" \


### PR DESCRIPTION
The help message and the code both expect the options for specifying C++ standard to be: --cpp98, --cpp03 --cpp11. The numbers in the options string are not aligned with this.