### PR TITLE
Add type visitors

### DIFF
--- a/src/util/type.cpp
+++ b/src/util/type.cpp
@@ -9,6 +9,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "type.h"
 
+#include <stack>
+
 void typet::copy_to_subtypes(const typet &type)
 {
   subtypes().push_back(type);
@@ -33,4 +35,34 @@ bool is_number(const typet &type)
          id==ID_signedbv ||
          id==ID_floatbv ||
          id==ID_fixedbv;
+}
+
+template <typename Visitee, typename Visitor>
+void visit_impl(Visitee &visitee, Visitor &visitor)
+{
+  std::stack<decltype(&visitee)> stack;
+  stack.push(&visitee);
+
+  while(!stack.empty())
+  {
+    auto &type = *stack.top();
+    stack.pop();
+
+    visitor(type);
+
+    for(auto &subtype : type.subtypes())
+    {
+      stack.push(&subtype);
+    }
+  }
+}
+
+void visit(typet &visitee, type_visitort &visitor)
+{
+  visit_impl(visitee, visitor);
+}
+
+void visit(const typet &visitee, const_type_visitort &visitor)
+{
+  visit_impl(visitee, visitor);
 }

--- a/src/util/type.h
+++ b/src/util/type.h
@@ -203,4 +203,21 @@ pre-defined types:
 bool is_number(const typet &type);
 // rational, real, integer, complex, unsignedbv, signedbv, floatbv
 
+class type_visitort
+{
+public:
+  virtual ~type_visitort() = default;
+  virtual void operator()(typet &type) = 0;
+};
+
+class const_type_visitort
+{
+public:
+  virtual ~const_type_visitort() = default;
+  virtual void operator()(const typet &type) = 0;
+};
+
+void visit(typet &type, type_visitort &visitor);
+void visit(const typet &type, const_type_visitort &visitor);
+
 #endif // CPROVER_UTIL_TYPE_H


### PR DESCRIPTION
We have visitors for `exprt`, but it would be useful to traverse types and subtypes in the same way.