### PR TITLE
Call graph enhancements

### DIFF
--- a/src/analyses/Makefile
+++ b/src/analyses/Makefile
@@ -1,5 +1,6 @@
 SRC = ai.cpp \
       call_graph.cpp \
+      call_graph_helpers.cpp \
       constant_propagator.cpp \
       custom_bitvector_analysis.cpp \
       dependence_graph.cpp \

--- a/src/analyses/call_graph.cpp
+++ b/src/analyses/call_graph.cpp
@@ -14,16 +14,19 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/std_expr.h>
 #include <util/xml.h>
 
-call_grapht::call_grapht()
+call_grapht::call_grapht(bool collect_callsites):
+  collect_callsites(collect_callsites)
 {
 }
 
-call_grapht::call_grapht(const goto_modelt &goto_model):
-  call_grapht(goto_model.goto_functions)
+call_grapht::call_grapht(const goto_modelt &goto_model, bool collect_callsites):
+  call_grapht(goto_model.goto_functions, collect_callsites)
 {
 }
 
-call_grapht::call_grapht(const goto_functionst &goto_functions)
+call_grapht::call_grapht(
+  const goto_functionst &goto_functions, bool collect_callsites):
+  collect_callsites(collect_callsites)
 {
   forall_goto_functions(f_it, goto_functions)
   {
@@ -42,7 +45,12 @@ void call_grapht::add(
     {
       const exprt &function_expr=to_code_function_call(i_it->code).function();
       if(function_expr.id()==ID_symbol)
-        add(function, to_symbol_expr(function_expr).get_identifier());
+      {
+        const irep_idt &callee=to_symbol_expr(function_expr).get_identifier();
+        add(function, callee);
+        if(collect_callsites)
+          callsites[{function, callee}].insert(i_it);
+      }
     }
   }
 }
@@ -52,6 +60,21 @@ void call_grapht::add(
   const irep_idt &callee)
 {
   graph.insert(std::pair<irep_idt, irep_idt>(caller, callee));
+}
+
+/// Add edge with optional callsite information
+/// \param caller: caller function
+/// \param callee: callee function
+/// \param callsite: call instruction responsible for this edge. Note this is
+///   only stored if `collect_callsites` was specified during construction.
+void call_grapht::add(
+  const irep_idt &caller,
+  const irep_idt &callee,
+  locationt callsite)
+{
+  add(caller, callee);
+  if(collect_callsites)
+    callsites[{caller, callee}].insert(callsite);
 }
 
 /// Returns an inverted copy of this call graph
@@ -64,6 +87,20 @@ call_grapht call_grapht::get_inverted() const
   return result;
 }
 
+std::string call_grapht::format_callsites(const edget &edge) const
+{
+  PRECONDITION(collect_callsites);
+  std::string ret="{";
+  for(const locationt &loc : callsites.at(edge))
+  {
+    if(ret.size()>1)
+      ret+=", ";
+    ret+=std::to_string(loc->location_number);
+  }
+  ret+='}';
+  return ret;
+}
+
 void call_grapht::output_dot(std::ostream &out) const
 {
   out << "digraph call_graph {\n";
@@ -72,8 +109,10 @@ void call_grapht::output_dot(std::ostream &out) const
   {
     out << "  \"" << edge.first << "\" -> "
         << "\"" << edge.second << "\" "
-        << " [arrowhead=\"vee\"];"
-        << "\n";
+        << " [arrowhead=\"vee\"";
+    if(collect_callsites)
+      out << " label=\"" << format_callsites(edge) << "\"";
+    out << "];\n";
   }
 
   out << "}\n";
@@ -84,11 +123,18 @@ void call_grapht::output(std::ostream &out) const
   for(const auto &edge : graph)
   {
     out << edge.first << " -> " << edge.second << "\n";
+    if(collect_callsites)
+      out << "  (callsites: " << format_callsites(edge) << ")\n";
   }
 }
 
 void call_grapht::output_xml(std::ostream &out) const
 {
+  // Note I don't implement callsite output here; I'll leave that
+  // to the first interested XML user.
+  if(collect_callsites)
+    out << "<!-- XML call-graph representation does not document callsites yet."
+      " If you need this, edit call_grapht::output_xml -->\n";
   for(const auto &edge : graph)
   {
     out << "<call_graph_edge caller=\"";

--- a/src/analyses/call_graph.cpp
+++ b/src/analyses/call_graph.cpp
@@ -35,9 +35,9 @@ call_grapht::call_grapht(
   }
 }
 
-void call_grapht::add(
-  const irep_idt &function,
-  const goto_programt &body)
+static void forall_callsites(
+  const goto_programt &body,
+  std::function<void(goto_programt::const_targett, const irep_idt &)> call_task)
 {
   forall_goto_program_instructions(i_it, body)
   {
@@ -47,14 +47,73 @@ void call_grapht::add(
       if(function_expr.id()==ID_symbol)
       {
         const irep_idt &callee=to_symbol_expr(function_expr).get_identifier();
-        add(function, callee);
-        if(collect_callsites)
-          callsites[{function, callee}].insert(i_it);
+        call_task(i_it, callee);
       }
     }
   }
 }
 
+/// Create call graph restricted to functions reachable from `root`
+/// \param functions: functions to search for callsites
+/// \param root: function to start exploring the graph
+/// \param collect_callsites: if true, then each added graph edge will have
+///   the calling instruction recorded in `callsites` map.
+call_grapht::call_grapht(
+  const goto_functionst &goto_functions,
+  const irep_idt &root,
+  bool collect_callsites)
+{
+  std::stack<irep_idt, std::vector<irep_idt>> pending_stack;
+  pending_stack.push(root);
+
+  while(!pending_stack.empty())
+  {
+    irep_idt function=pending_stack.top();
+    pending_stack.pop();
+    const goto_programt &goto_program=
+      goto_functions.function_map.at(function).body;
+
+    forall_callsites(
+      goto_program,
+      [&](goto_programt::const_targett i_it, const irep_idt &callee)
+      {
+        add(function, callee, i_it);
+        if(graph.find(callee)==graph.end())
+          pending_stack.push(callee);
+      }
+    ); // NOLINT
+  }
+}
+
+/// Create call graph restricted to functions reachable from `root`
+/// \param goto_model: model to search for callsites
+/// \param root: function to start exploring the graph
+/// \param collect_callsites: if true, then each added graph edge will have
+///   the calling instruction recorded in `callsites` map.
+call_grapht::call_grapht(
+  const goto_modelt &goto_model,
+  const irep_idt &root,
+  bool collect_callsites):
+  call_grapht(goto_model.goto_functions, root, collect_callsites)
+{
+}
+
+void call_grapht::add(
+  const irep_idt &function,
+  const goto_programt &body)
+{
+  forall_callsites(
+    body,
+    [&](goto_programt::const_targett i_it, const irep_idt &callee)
+    {
+      add(function, callee, i_it);
+    }
+  ); // NOLINT
+}
+
+/// Add edge
+/// \param caller: caller function
+/// \param callee: callee function
 void call_grapht::add(
   const irep_idt &caller,
   const irep_idt &callee)

--- a/src/analyses/call_graph.cpp
+++ b/src/analyses/call_graph.cpp
@@ -14,16 +14,27 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/std_expr.h>
 #include <util/xml.h>
 
+/// Create empty call graph
+/// \param collect_callsites: if true, then each added graph edge will have
+///   the calling instruction recorded in `callsites` map.
 call_grapht::call_grapht(bool collect_callsites):
   collect_callsites(collect_callsites)
 {
 }
 
+/// Create complete call graph
+/// \param goto_model: model to search for callsites
+/// \param collect_callsites: if true, then each added graph edge will have
+///   the calling instruction recorded in `callsites` map.
 call_grapht::call_grapht(const goto_modelt &goto_model, bool collect_callsites):
   call_grapht(goto_model.goto_functions, collect_callsites)
 {
 }
 
+/// Create complete call graph
+/// \param goto_functions: functions to search for callsites
+/// \param collect_callsites: if true, then each added graph edge will have
+///   the calling instruction recorded in `callsites` map.
 call_grapht::call_grapht(
   const goto_functionst &goto_functions, bool collect_callsites):
   collect_callsites(collect_callsites)
@@ -54,7 +65,7 @@ static void forall_callsites(
 }
 
 /// Create call graph restricted to functions reachable from `root`
-/// \param functions: functions to search for callsites
+/// \param goto_functions: functions to search for callsites
 /// \param root: function to start exploring the graph
 /// \param collect_callsites: if true, then each added graph edge will have
 ///   the calling instruction recorded in `callsites` map.
@@ -204,6 +215,10 @@ call_grapht::directed_grapht call_grapht::get_directed_graph() const
   return ret;
 }
 
+/// Prints callsites responsible for a graph edge as comma-separated
+/// location numbers, e.g. "{1, 2, 3}".
+/// \param edge: graph edge
+/// \return pretty representation of edge callsites
 std::string call_grapht::format_callsites(const edget &edge) const
 {
   PRECONDITION(collect_callsites);

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -20,23 +20,33 @@ Author: Daniel Kroening, kroening@kroening.com
 class call_grapht
 {
 public:
-  call_grapht();
-  explicit call_grapht(const goto_modelt &);
-  explicit call_grapht(const goto_functionst &);
+  explicit call_grapht(bool collect_callsites=false);
+  explicit call_grapht(const goto_modelt &, bool collect_callsites=false);
+  explicit call_grapht(const goto_functionst &, bool collect_callsites=false);
 
   void output_dot(std::ostream &out) const;
   void output(std::ostream &out) const;
   void output_xml(std::ostream &out) const;
 
   typedef std::multimap<irep_idt, irep_idt> grapht;
+  typedef std::pair<irep_idt, irep_idt> edget;
+  typedef goto_programt::const_targett locationt;
+  typedef std::set<locationt> locationst;
+  typedef std::map<edget, locationst> callsitest;
+
   grapht graph;
+  callsitest callsites;
 
   void add(const irep_idt &caller, const irep_idt &callee);
+  void add(const irep_idt &caller, const irep_idt &callee, locationt callsite);
   call_grapht get_inverted() const;
 
 protected:
   void add(const irep_idt &function,
            const goto_programt &body);
+private:
+  bool collect_callsites;
+  std::string format_callsites(const edget &edge) const;
 };
 
 #endif // CPROVER_ANALYSES_CALL_GRAPH_H

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <map>
 
 #include <goto-programs/goto_model.h>
+#include <util/graph.h>
 
 class call_grapht
 {
@@ -40,6 +41,44 @@ public:
   void add(const irep_idt &caller, const irep_idt &callee);
   void add(const irep_idt &caller, const irep_idt &callee, locationt callsite);
   call_grapht get_inverted() const;
+
+  struct edge_with_callsitest
+  {
+    locationst callsites;
+  };
+
+  struct function_nodet:public graph_nodet<edge_with_callsitest>
+  {
+    irep_idt function;
+  };
+
+  /// Directed graph representation of this call graph
+  class directed_grapht : public ::grapht<function_nodet>
+  {
+    friend class call_grapht;
+
+    /// Maps function names onto node indices
+    std::unordered_map<irep_idt, node_indext, irep_id_hash> nodes_by_name;
+
+  public:
+    /// Find the graph node by function name
+    /// \param function: function to find
+    /// \return none if function is not in this graph, or some index otherwise.
+    optionalt<node_indext> get_node_index(const irep_idt &function) const;
+
+    /// Type of the node name -> node index map.
+    typedef
+      std::unordered_map<irep_idt, node_indext, irep_id_hash> nodes_by_namet;
+
+    /// Get the node name -> node index map
+    /// \return node-by-name map
+    const nodes_by_namet &get_nodes_by_name() const
+    {
+      return nodes_by_name;
+    }
+  };
+
+  directed_grapht get_directed_graph() const;
 
 protected:
   void add(const irep_idt &function,

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -25,8 +25,28 @@ public:
   explicit call_grapht(const goto_modelt &, bool collect_callsites=false);
   explicit call_grapht(const goto_functionst &, bool collect_callsites=false);
 
-  // These two constructors build a call graph restricted to functions
+  // These two functions build a call graph restricted to functions
   // reachable from the given root.
+
+  static call_grapht create_from_root_function(
+    const goto_modelt &model,
+    const irep_idt &root,
+    bool collect_callsites)
+  {
+    return call_grapht(model, root, collect_callsites);
+  }
+
+  static call_grapht create_from_root_function(
+    const goto_functionst &functions,
+    const irep_idt &root,
+    bool collect_callsites)
+  {
+    return call_grapht(functions, root, collect_callsites);
+  }
+
+  // Constructors used to implement the above:
+
+private:
   call_grapht(
     const goto_modelt &model,
     const irep_idt &root,
@@ -35,6 +55,8 @@ public:
     const goto_functionst &functions,
     const irep_idt &root,
     bool collect_callsites);
+
+public:
 
   void output_dot(std::ostream &out) const;
   void output(std::ostream &out) const;

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -40,26 +40,50 @@ public:
   void output(std::ostream &out) const;
   void output_xml(std::ostream &out) const;
 
+  /// Type of the call graph. Note parallel edges (e.g. A having two callsites
+  /// both targeting B) result in multiple graph edges.
   typedef std::multimap<irep_idt, irep_idt> grapht;
+
+  /// Type of a call graph edge in `grapht`
   typedef std::pair<irep_idt, irep_idt> edget;
+
+  /// Type of a callsite stored in member `callsites`
   typedef goto_programt::const_targett locationt;
+
+  /// Type of a set of callsites
   typedef std::set<locationt> locationst;
+
+  /// Type mapping from call-graph edges onto the set of call instructions
+  /// that make that call.
   typedef std::map<edget, locationst> callsitest;
 
+  /// Call graph, including duplicate key-value pairs when there are parallel
+  /// edges (see `grapht` documentation). This representation is retained for
+  /// backward compatibility; use `get_directed_graph()` to get a generic
+  /// directed graph representation that provides more graph algorithms
+  /// (shortest path, SCCs and so on).
   grapht graph;
+
+  /// Map from call-graph edges to a set of callsites that make the given call.
   callsitest callsites;
 
   void add(const irep_idt &caller, const irep_idt &callee);
   void add(const irep_idt &caller, const irep_idt &callee, locationt callsite);
+
   call_grapht get_inverted() const;
 
+  /// Edge of the directed graph representation of this call graph
   struct edge_with_callsitest
   {
+    /// Callsites responsible for this graph edge. Will be empty if
+    /// `collect_callsites` was not set at `call_grapht` construction time.
     locationst callsites;
   };
 
-  struct function_nodet:public graph_nodet<edge_with_callsitest>
+  /// Node of the directed graph representation of this call graph
+  struct function_nodet : public graph_nodet<edge_with_callsitest>
   {
+    /// Function name
     irep_idt function;
   };
 

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -25,6 +25,17 @@ public:
   explicit call_grapht(const goto_modelt &, bool collect_callsites=false);
   explicit call_grapht(const goto_functionst &, bool collect_callsites=false);
 
+  // These two constructors build a call graph restricted to functions
+  // reachable from the given root.
+  call_grapht(
+    const goto_modelt &model,
+    const irep_idt &root,
+    bool collect_callsites);
+  call_grapht(
+    const goto_functionst &functions,
+    const irep_idt &root,
+    bool collect_callsites);
+
   void output_dot(std::ostream &out) const;
   void output(std::ostream &out) const;
   void output_xml(std::ostream &out) const;

--- a/src/analyses/call_graph_helpers.cpp
+++ b/src/analyses/call_graph_helpers.cpp
@@ -1,0 +1,72 @@
+/*******************************************************************\
+
+Module: Function Call Graph Helpers
+
+Author: Chris Smowton, chris.smowton@diffblue.com
+
+\*******************************************************************/
+
+/// \file
+/// Function Call Graph Helpers
+
+#include "call_graph_helpers.h"
+
+/// Get either callers or callees of a given function
+/// \param graph: call graph
+/// \param function: function to query
+/// \param forwards: if true, get callees; otherwise get callers.
+static std::set<irep_idt> get_neighbours(
+  const call_grapht::directed_grapht &graph,
+  const irep_idt &function,
+  bool forwards)
+{
+  std::set<irep_idt> result;
+  const auto &fnode = graph[*(graph.get_node_index(function))];
+  const auto &neighbours = forwards ? fnode.out : fnode.in;
+  for(const auto &succ_edge : neighbours)
+    result.insert(graph[succ_edge.first].function);
+  return result;
+}
+
+std::set<irep_idt> get_callees(
+  const call_grapht::directed_grapht &graph, const irep_idt &function)
+{
+  return get_neighbours(graph, function, true);
+}
+
+std::set<irep_idt> get_callers(
+  const call_grapht::directed_grapht &graph, const irep_idt &function)
+{
+  return get_neighbours(graph, function, false);
+}
+
+/// Get either reachable functions or functions that can reach a given function.
+/// In both cases the query function itself is included.
+/// \param graph: call graph
+/// \param function: function to query
+/// \param forwards: if true, get reachable functions; otherwise get functions
+///   that can reach the given function.
+static std::set<irep_idt> get_connected_functions(
+  const call_grapht::directed_grapht &graph,
+  const irep_idt &function,
+  bool forwards)
+{
+  std::vector<call_grapht::directed_grapht::node_indext> connected_nodes =
+    graph.get_reachable(*(graph.get_node_index(function)), forwards);
+  std::set<irep_idt> result;
+  for(const auto i : connected_nodes)
+    result.insert(graph[i].function);
+  return result;
+}
+
+std::set<irep_idt> get_reachable_functions(
+  const call_grapht::directed_grapht &graph, const irep_idt &function)
+{
+  return get_connected_functions(graph, function, true);
+}
+
+std::set<irep_idt> get_reaching_functions(
+  const call_grapht::directed_grapht &graph, const irep_idt &function)
+{
+  return get_connected_functions(graph, function, false);
+}

--- a/src/analyses/call_graph_helpers.h
+++ b/src/analyses/call_graph_helpers.h
@@ -1,0 +1,52 @@
+/*******************************************************************\
+
+Module: Function Call Graph Helpers
+
+Author: Chris Smowton, chris.smowton@diffblue.com
+
+\*******************************************************************/
+
+/// \file
+/// Function Call Graph Helpers
+
+#ifndef CPROVER_ANALYSES_CALL_GRAPH_HELPERS_H
+#define CPROVER_ANALYSES_CALL_GRAPH_HELPERS_H
+
+#include "call_graph.h"
+
+// These are convenience functions for working with the directed graph
+// representation of a call graph, obtained via
+// `call_grapht::get_directed_graph`. Usually function names must be mapped
+// to and from node indices, as in `graph.get_node_index("f")`, or
+// `graph[node_index].function`; these helpers include the translation for
+// convenience.
+
+/// Get functions directly callable from a given function
+/// \param graph: call graph
+/// \param function: function to query
+/// \return set of called functions
+std::set<irep_idt> get_callees(
+  const call_grapht::directed_grapht &graph, const irep_idt &function);
+
+/// Get functions that call a given function
+/// \param graph: call graph
+/// \param function: function to query
+/// \return set of caller functions
+std::set<irep_idt> get_callers(
+  const call_grapht::directed_grapht &graph, const irep_idt &function);
+
+/// Get functions reachable from a given function
+/// \param graph: call graph
+/// \param function: function to query
+/// \return set of reachable functions, including `function`
+std::set<irep_idt> get_reachable_functions(
+  const call_grapht::directed_grapht &graph, const irep_idt &function);
+
+/// Get functions that can reach a given function
+/// \param graph: call graph
+/// \param function: function to query
+/// \return set of functions that can reach the target, including `function`
+std::set<irep_idt> get_reaching_functions(
+  const call_grapht::directed_grapht &graph, const irep_idt &function);
+
+#endif

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -659,6 +659,22 @@ int goto_instrument_parse_optionst::doit()
       return CPROVER_EXIT_SUCCESS;
     }
 
+    if(cmdline.isset("reachable-call-graph"))
+    {
+      do_indirect_call_and_rtti_removal();
+      call_grapht call_graph =
+        call_grapht::create_from_root_function(
+          goto_model, goto_functionst::entry_point(), false);
+      if(cmdline.isset("xml"))
+        call_graph.output_xml(std::cout);
+      else if(cmdline.isset("dot"))
+        call_graph.output_dot(std::cout);
+      else
+        call_graph.output(std::cout);
+
+      return 0;
+    }
+
     if(cmdline.isset("dot"))
     {
       namespacet ns(goto_model.symbol_table);
@@ -1455,6 +1471,9 @@ void goto_instrument_parse_optionst::help()
     " --list-calls-args            list all function calls with their arguments\n"
     // NOLINTNEXTLINE(whitespace/line_length)
     " --print-path-lengths         print statistics about control-flow graph paths\n"
+    " --call-graph                 show graph of function calls\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    " --reachable-call-graph       show graph of function calls potentially reachable from main function\n"
     "\n"
     "Safety checks:\n"
     " --no-assertions              ignore user assertions\n"

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -43,7 +43,7 @@ Author: Daniel Kroening, kroening@kroening.com
   "(log):" \
   "(max-var):(max-po-trans):(ignore-arrays)" \
   "(cfg-kill)(no-dependencies)(force-loop-duplication)" \
-  "(call-graph)" \
+  "(call-graph)(reachable-call-graph)" \
   "(no-po-rendering)(render-cluster-file)(render-cluster-function)" \
   "(nondet-volatile)(isr):" \
   "(stack-depth):(nondet-static)" \

--- a/src/util/graph.h
+++ b/src/util/graph.h
@@ -246,6 +246,8 @@ public:
 
   void visit_reachable(node_indext src);
 
+  std::vector<node_indext> get_reachable(node_indext src, bool forwards) const;
+
   void make_chordal();
 
   // return value: number of connected subgraphs
@@ -447,26 +449,40 @@ void grapht<N>::shortest_path(
 template<class N>
 void grapht<N>::visit_reachable(node_indext src)
 {
-  // DFS
+  std::vector<node_indext> reachable = get_reachable(src, true);
+  for(const auto index : reachable)
+    nodes[index].visited = true;
+}
 
-  std::stack<node_indext> s;
+template<class N>
+std::vector<typename N::node_indext>
+grapht<N>::get_reachable(node_indext src, bool forwards) const
+{
+  std::vector<node_indext> result;
+  std::vector<bool> visited(size(), false);
+
+  std::stack<node_indext, std::vector<node_indext>> s;
   s.push(src);
 
   while(!s.empty())
   {
-    node_indext n=s.top();
+    node_indext n = s.top();
     s.pop();
 
-    nodet &node=nodes[n];
-    node.visited=true;
+    if(visited[n])
+      continue;
 
-    for(typename edgest::const_iterator
-        it=node.out.begin();
-        it!=node.out.end();
-        it++)
-      if(!nodes[it->first].visited)
-        s.push(it->first);
+    result.push_back(n);
+    visited[n] = true;
+
+    const auto &node = nodes[n];
+    const auto &succs = forwards ? node.out : node.in;
+    for(const auto succ : succs)
+      if(!visited[succ.first])
+        s.push(succ.first);
   }
+
+  return result;
 }
 
 template<class N>

--- a/unit/analyses/call_graph.cpp
+++ b/unit/analyses/call_graph.cpp
@@ -11,6 +11,7 @@ Author:
 #include <testing-utils/catch.hpp>
 
 #include <analyses/call_graph.h>
+#include <analyses/call_graph_helpers.h>
 
 #include <util/symbol_table.h>
 #include <util/std_code.h>
@@ -160,12 +161,24 @@ SCENARIO("call_graph",
       }
     }
 
+    WHEN("A call-graph is constructed rooted at B")
+    {
+      call_grapht call_graph_from_b =
+        call_grapht::create_from_root_function(goto_model, "B", false);
+      THEN("We expect only B -> C and B -> D in the resulting graph")
+      {
+        const auto &check_graph=call_graph_from_b.graph;
+        REQUIRE(check_graph.size()==2);
+        REQUIRE(multimap_key_matches(check_graph, "B", {"C", "D"}));
+      }
+    }
+
     WHEN("The call graph is exported as a grapht")
     {
-      call_grapht::directed_call_grapht exported=
+      call_grapht::directed_grapht exported=
         call_graph_from_goto_functions.get_directed_graph();
 
-      typedef call_grapht::directed_call_grapht::node_indext node_indext;
+      typedef call_grapht::directed_grapht::node_indext node_indext;
       std::map<irep_idt, node_indext> nodes_by_name;
       for(node_indext i=0; i<exported.size(); ++i)
         nodes_by_name[exported[i].function]=i;
@@ -179,15 +192,51 @@ SCENARIO("call_graph",
         REQUIRE(exported.has_edge(nodes_by_name["B"], nodes_by_name["C"]));
         REQUIRE(exported.has_edge(nodes_by_name["B"], nodes_by_name["D"]));
       }
+
+      THEN("We expect A to have successors {A, B}")
+      {
+        std::set<irep_idt> successors = get_callees(exported, "A");
+        REQUIRE(successors.size() == 2);
+        REQUIRE(successors.count("A"));
+        REQUIRE(successors.count("B"));
+      }
+
+      THEN("We expect C to have predecessors {B}")
+      {
+        std::set<irep_idt> predecessors = get_callers(exported, "C");
+        REQUIRE(predecessors.size() == 1);
+        REQUIRE(predecessors.count("B"));
+      }
+
+      THEN("We expect all of {A, B, C, D} to be reachable from A")
+      {
+        std::set<irep_idt> successors =
+          get_reachable_functions(exported, "A");
+        REQUIRE(successors.size() == 4);
+        REQUIRE(successors.count("A"));
+        REQUIRE(successors.count("B"));
+        REQUIRE(successors.count("C"));
+        REQUIRE(successors.count("D"));
+      }
+
+      THEN("We expect {D, B, A} to be able to reach D")
+      {
+        std::set<irep_idt> predecessors =
+          get_reaching_functions(exported, "D");
+        REQUIRE(predecessors.size() == 3);
+        REQUIRE(predecessors.count("A"));
+        REQUIRE(predecessors.count("B"));
+        REQUIRE(predecessors.count("D"));
+      }
     }
 
     WHEN("The call graph, with call sites, is exported as a grapht")
     {
       call_grapht call_graph_from_goto_functions(goto_model, true);
-      call_grapht::directed_call_grapht exported=
+      call_grapht::directed_grapht exported=
         call_graph_from_goto_functions.get_directed_graph();
 
-      typedef call_grapht::directed_call_grapht::node_indext node_indext;
+      typedef call_grapht::directed_grapht::node_indext node_indext;
       std::map<irep_idt, node_indext> nodes_by_name;
       for(node_indext i=0; i<exported.size(); ++i)
         nodes_by_name[exported[i].function]=i;


### PR DESCRIPTION
Two enhancements to the call graph, again both used in the security analyser but probably useful to others:

1. Optionally record callsites while building the graph, such that on seeing an A -> B edge in the callgraph it's easy to find out the calling instruction.
2. Support export to a `grapht`-derived data structure, such that standard graph algorithms can be used on the call graph.