### PR TITLE
[TG-925] Add command line options for setting up satcheck randomizer

### DIFF
--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -390,6 +390,13 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
   else
     options.set_option("sat-preprocessor", true);
 
+  if(cmdline.isset("random-seed"))
+    options.set_option("random-seed", cmdline.get_values("random-seed"));
+
+  if(cmdline.isset("random-var-freq"))
+    options.set_option(
+      "random-var-freq", cmdline.get_values("random-var-freq"));
+
   options.set_option(
     "pretty-names",
     !cmdline.isset("no-pretty-names"));
@@ -898,6 +905,7 @@ int cbmc_parse_optionst::do_bmc(bmct &bmc)
 /// display command line help
 void cbmc_parse_optionst::help()
 {
+  // clang-format off
   std::cout <<
     "\n"
     "* *   CBMC " CBMC_VERSION " - Copyright (C) 2001-2017 ";
@@ -1001,6 +1009,9 @@ void cbmc_parse_optionst::help()
     " --dimacs                     generate CNF in DIMACS format\n"
     " --beautify                   beautify the counterexample (greedy heuristic)\n" // NOLINT(*)
     " --localize-faults            localize faults (experimental)\n"
+    " --random-seed n              SAT checker random seed (unsigned integer)\n"
+    " --random-var-freq n          SAT checker random variable frequency\n"
+    "                              (floating point number between 0 and 1)\n"
     " --smt1                       use default SMT1 solver (obsolete)\n"
     " --smt2                       use default SMT2 solver (Z3)\n"
     " --boolector                  use Boolector\n"
@@ -1025,4 +1036,5 @@ void cbmc_parse_optionst::help()
     " --json-ui                    use JSON-formatted output\n"
     " --verbosity #                verbosity level\n"
     "\n";
+  // clang-format on
 }

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -24,6 +24,7 @@ class bmct;
 class goto_functionst;
 class optionst;
 
+// clang-format off
 #define CBMC_OPTIONS \
   "(program-only)(preprocess)(slice-by-trace):" \
   OPT_FUNCTIONS \
@@ -65,7 +66,10 @@ class optionst;
   "(round-to-nearest)(round-to-plus-inf)(round-to-minus-inf)(round-to-zero)" \
   "(graphml-witness):" \
   "(localize-faults)(localize-faults-method):" \
+  "(random-seed):" \
+  "(random-var-freq):" \
   "(fixedbv)(floatbv)(all-claims)(all-properties)" // legacy, and will eventually disappear // NOLINT(whitespace/line_length)
+// clang-format on
 
 class cbmc_parse_optionst:
   public parse_options_baset,

--- a/src/goto-instrument/accelerate/accelerate.cpp
+++ b/src/goto-instrument/accelerate/accelerate.cpp
@@ -116,10 +116,11 @@ int acceleratet::accelerate_loop(goto_programt::targett &loop_header)
     program,
     loop,
     loop_header,
-    accelerate_limit);
+    accelerate_limit,
+    options);
 #else
-  disjunctive_polynomial_accelerationt
-    acceleration(symbol_table, goto_functions, program, loop, loop_header);
+  disjunctive_polynomial_accelerationt acceleration(
+    symbol_table, goto_functions, program, loop, loop_header, options);
 #endif
 
   path_acceleratort accelerator;
@@ -333,7 +334,7 @@ void acceleratet::set_dirty_vars(path_acceleratort &accelerator)
 
     if(jt==dirty_vars_map.end())
     {
-      scratch_programt scratch(symbol_table, message_handler);
+      scratch_programt scratch(symbol_table, message_handler, options);
       symbolt new_sym=utils.fresh_symbol("accelerate::dirty", bool_typet());
       dirty_var=new_sym.symbol_expr();
       dirty_vars_map[*it]=dirty_var;
@@ -512,7 +513,7 @@ void acceleratet::insert_automaton(trace_automatont &automaton)
   // machine.
   for(const auto &sym : automaton.alphabet)
   {
-    scratch_programt state_machine(symbol_table, message_handler);
+    scratch_programt state_machine(symbol_table, message_handler, options);
     trace_automatont::sym_range_pairt p=transitions.equal_range(sym);
 
     build_state_machine(p.first, p.second, accept_states, state, next_state,
@@ -651,13 +652,13 @@ int acceleratet::accelerate_loops()
 void accelerate_functions(
   goto_modelt &goto_model,
   message_handlert &message_handler,
-  bool use_z3)
+  const optionst &options)
 {
   Forall_goto_functions(it, goto_model.goto_functions)
   {
     std::cout << "Accelerating function " << it->first << '\n';
     acceleratet accelerate(
-      it->second.body, goto_model, message_handler, use_z3);
+      it->second.body, goto_model, message_handler, options);
 
     int num_accelerated=accelerate.accelerate_loops();
 

--- a/src/goto-instrument/accelerate/accelerate.h
+++ b/src/goto-instrument/accelerate/accelerate.h
@@ -34,19 +34,20 @@ public:
     goto_programt &_program,
     goto_modelt &_goto_model,
     message_handlert &message_handler,
-    bool _use_z3)
+    const optionst &_options)
     : message_handler(message_handler),
       program(_program),
       goto_functions(_goto_model.goto_functions),
       symbol_table(_goto_model.symbol_table),
       ns(_goto_model.symbol_table),
-      utils(symbol_table, message_handler, goto_functions),
-      use_z3(_use_z3)
+      utils(symbol_table, message_handler, options, goto_functions),
+      options(options)
   {
     natural_loops(program);
   }
 
   int accelerate_loop(goto_programt::targett &loop_header);
+
   int accelerate_loops();
 
   bool accelerate_path(patht &path, path_acceleratort &accelerator);
@@ -124,12 +125,12 @@ protected:
 
   expr_mapt dirty_vars_map;
 
-  bool use_z3;
+  const optionst &options;
 };
 
 void accelerate_functions(
-  goto_modelt &,
+  goto_modelt &goto_model,
   message_handlert &message_handler,
-  bool use_z3);
+  const optionst &options);
 
 #endif // CPROVER_GOTO_INSTRUMENT_ACCELERATE_ACCELERATE_H

--- a/src/goto-instrument/accelerate/acceleration_utils.cpp
+++ b/src/goto-instrument/accelerate/acceleration_utils.cpp
@@ -112,7 +112,6 @@ void acceleration_utilst::find_modified(
   }
 }
 
-
 bool acceleration_utilst::check_inductive(
   std::map<exprt, polynomialt> polynomials,
   patht &path)
@@ -128,7 +127,7 @@ bool acceleration_utilst::check_inductive(
   // assert (target1==polynomial1);
   // assert (target2==polynomial2);
   // ...
-  scratch_programt program(symbol_table, message_handler);
+  scratch_programt program(symbol_table, message_handler, options);
   std::vector<exprt> polynomials_hold;
   substitutiont substitution;
 
@@ -386,7 +385,7 @@ bool acceleration_utilst::do_assumptions(
   // assert(!precondition);
 
   exprt condition=precondition(path);
-  scratch_programt program(symbol_table, message_handler);
+  scratch_programt program(symbol_table, message_handler, options);
 
   substitutiont substitution;
   stash_polynomials(program, polynomials, substitution, path);

--- a/src/goto-instrument/accelerate/acceleration_utils.h
+++ b/src/goto-instrument/accelerate/acceleration_utils.h
@@ -35,14 +35,17 @@ class acceleration_utilst
 {
 protected:
   message_handlert &message_handler;
+  const optionst &options;
 
 public:
   acceleration_utilst(
     symbol_tablet &_symbol_table,
     message_handlert &message_handler,
+    const optionst &_options,
     const goto_functionst &_goto_functions,
     exprt &_loop_counter)
     : message_handler(message_handler),
+      options(_options),
       symbol_table(_symbol_table),
       ns(symbol_table),
       goto_functions(_goto_functions),
@@ -53,8 +56,10 @@ public:
   acceleration_utilst(
     symbol_tablet &_symbol_table,
     message_handlert &message_handler,
+    const optionst &_options,
     const goto_functionst &_goto_functions)
     : message_handler(message_handler),
+      options(_options),
       symbol_table(_symbol_table),
       ns(symbol_table),
       goto_functions(_goto_functions),

--- a/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
+++ b/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
@@ -51,7 +51,7 @@ bool disjunctive_polynomial_accelerationt::accelerate(
   path_acceleratort &accelerator)
 {
   std::map<exprt, polynomialt> polynomials;
-  scratch_programt program(symbol_table, message_handler);
+  scratch_programt program(symbol_table, message_handler, options);
 
   accelerator.clear();
 
@@ -144,7 +144,7 @@ bool disjunctive_polynomial_accelerationt::accelerate(
   expr_sett dirty;
   utils.find_modified(accelerator.path, dirty);
   polynomial_acceleratort path_acceleration(
-    message_handler, symbol_table, goto_functions, loop_counter);
+    message_handler, options, symbol_table, goto_functions, loop_counter);
   goto_programt::instructionst assigns;
 
   for(patht::iterator it=accelerator.path.begin();
@@ -342,7 +342,7 @@ bool disjunctive_polynomial_accelerationt::accelerate(
 
 bool disjunctive_polynomial_accelerationt::find_path(patht &path)
 {
-  scratch_programt program(symbol_table, message_handler);
+  scratch_programt program(symbol_table, message_handler, options);
 
   program.append(fixed);
   program.append(fixed);
@@ -410,7 +410,7 @@ bool disjunctive_polynomial_accelerationt::fit_polynomial(
   std::vector<expr_listt> parameters;
   std::set<std::pair<expr_listt, exprt> > coefficients;
   expr_listt exprs;
-  scratch_programt program(symbol_table, message_handler);
+  scratch_programt program(symbol_table, message_handler, options);
   expr_sett influence;
 
   cone_of_influence(var, influence);
@@ -861,7 +861,7 @@ void disjunctive_polynomial_accelerationt::build_path(
  */
 void disjunctive_polynomial_accelerationt::build_fixed()
 {
-  scratch_programt scratch(symbol_table, message_handler);
+  scratch_programt scratch(symbol_table, message_handler, options);
   std::map<exprt, exprt> shadow_distinguishers;
 
   fixed.copy_from(goto_program);

--- a/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.h
+++ b/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.h
@@ -20,7 +20,7 @@ Author: Matt Lewis
 
 #include <goto-programs/goto_program.h>
 #include <goto-programs/goto_functions.h>
-
+#include <solvers/sat/satcheck.h>
 #include <analyses/natural_loops.h>
 
 #include "scratch_program.h"
@@ -36,19 +36,27 @@ class disjunctive_polynomial_accelerationt:public loop_accelerationt
 public:
   disjunctive_polynomial_accelerationt(
     message_handlert &message_handler,
+    const optionst &_options,
     symbol_tablet &_symbol_table,
     goto_functionst &_goto_functions,
     goto_programt &_goto_program,
     natural_loops_mutablet::natural_loopt &_loop,
-    goto_programt::targett _loop_header)
+    goto_programt::targett _loop_header,
+    const satcheck_infot &satcheck_info)
     : message_handler(message_handler),
+      options(_options),
       symbol_table(_symbol_table),
       ns(symbol_table),
       goto_functions(_goto_functions),
       goto_program(_goto_program),
       loop(_loop),
       loop_header(_loop_header),
-      utils(symbol_table, message_handler, goto_functions, loop_counter)
+      utils(
+        symbol_table,
+        message_handler,
+        _options,
+        goto_functions,
+        loop_counter)
   {
     loop_counter = nil_exprt();
     find_distinguishing_points();
@@ -67,6 +75,7 @@ public:
 
 protected:
   message_handlert &message_handler;
+  const optionst &options;
 
   void assert_for_values(
     scratch_programt &program,

--- a/src/goto-instrument/accelerate/enumerating_loop_acceleration.h
+++ b/src/goto-instrument/accelerate/enumerating_loop_acceleration.h
@@ -37,17 +37,23 @@ public:
     goto_programt &_goto_program,
     natural_loops_mutablet::natural_loopt &_loop,
     goto_programt::targett _loop_header,
-    int _path_limit)
+    int _path_limit,
+    const optionst &options)
     : symbol_table(_symbol_table),
       goto_functions(_goto_functions),
       goto_program(_goto_program),
       loop(_loop),
       loop_header(_loop_header),
-      polynomial_accelerator(message_handler, symbol_table, goto_functions),
+      polynomial_accelerator(
+        message_handler,
+        options,
+        symbol_table,
+        goto_functions),
       path_limit(_path_limit),
       path_enumerator(
         util_make_unique<sat_path_enumeratort>(
           message_handler,
+          options,
           symbol_table,
           goto_functions,
           goto_program,

--- a/src/goto-instrument/accelerate/polynomial_accelerator.cpp
+++ b/src/goto-instrument/accelerate/polynomial_accelerator.cpp
@@ -59,7 +59,7 @@ bool polynomial_acceleratort::accelerate(
 
   expr_sett targets;
   std::map<exprt, polynomialt> polynomials;
-  scratch_programt program(symbol_table, message_handler);
+  scratch_programt program(symbol_table, message_handler, options);
   goto_programt::instructionst assigns;
 
   utils.find_modified(body, targets);
@@ -288,7 +288,7 @@ bool polynomial_acceleratort::fit_polynomial_sliced(
   std::vector<expr_listt> parameters;
   std::set<std::pair<expr_listt, exprt> > coefficients;
   expr_listt exprs;
-  scratch_programt program(symbol_table, message_handler);
+  scratch_programt program(symbol_table, message_handler, options);
   exprt overflow_var =
     utils.fresh_symbol("polynomial::overflow", bool_typet()).symbol_expr();
   overflow_instrumentert overflow(program, overflow_var, symbol_table);
@@ -668,7 +668,7 @@ bool polynomial_acceleratort::check_inductive(
   // assert (target1==polynomial1);
   // assert (target2==polynomial2);
   // ...
-  scratch_programt program(symbol_table, message_handler);
+  scratch_programt program(symbol_table, message_handler, options);
   std::vector<exprt> polynomials_hold;
   substitutiont substitution;
 

--- a/src/goto-instrument/accelerate/polynomial_accelerator.h
+++ b/src/goto-instrument/accelerate/polynomial_accelerator.h
@@ -16,7 +16,7 @@ Author: Matt Lewis
 #include <set>
 
 #include <util/symbol_table.h>
-
+#include <solvers/sat/satcheck.h>
 #include <goto-programs/goto_program.h>
 #include <goto-programs/goto_functions.h>
 
@@ -39,12 +39,14 @@ public:
     const goto_functionst &_goto_functions,
     const exprt &_loop_counter = nil_exprt())
     : message_handler(message_handler),
+      options(options),
       symbol_table(const_cast<symbol_tablet &>(_symbol_table)),
       ns(symbol_table),
       goto_functions(_goto_functions),
       utils(
         symbol_table,
         message_handler,
+        options,
         goto_functions,
         loop_counter),
       loop_counter(_loop_counter)
@@ -60,6 +62,7 @@ public:
 
 protected:
   message_handlert &message_handler;
+  const optionst &options;
 
   bool fit_polynomial_sliced(
     goto_programt::instructionst &sliced_body,
@@ -149,6 +152,8 @@ protected:
   const goto_functionst &goto_functions;
   acceleration_utilst utils;
 
+private:
+  const satcheck_infot satcheck_info;
   exprt loop_counter;
 
   expr_sett nonrecursive;

--- a/src/goto-instrument/accelerate/polynomial_accelerator.h
+++ b/src/goto-instrument/accelerate/polynomial_accelerator.h
@@ -34,27 +34,19 @@ class polynomial_acceleratort:public path_accelerationt
 public:
   polynomial_acceleratort(
     message_handlert &message_handler,
-    const symbol_tablet &_symbol_table,
-    const goto_functionst &_goto_functions)
-    : message_handler(message_handler),
-      symbol_table(const_cast<symbol_tablet &>(_symbol_table)),
-      ns(symbol_table),
-      goto_functions(_goto_functions),
-      utils(symbol_table, message_handler, goto_functions, loop_counter)
-  {
-    loop_counter=nil_exprt();
-  }
-
-  polynomial_acceleratort(
-    message_handlert &message_handler,
+    const optionst &options,
     const symbol_tablet &_symbol_table,
     const goto_functionst &_goto_functions,
-    exprt &_loop_counter)
+    const exprt &_loop_counter = nil_exprt())
     : message_handler(message_handler),
       symbol_table(const_cast<symbol_tablet &>(_symbol_table)),
       ns(symbol_table),
       goto_functions(_goto_functions),
-      utils(symbol_table, message_handler, goto_functions, loop_counter),
+      utils(
+        symbol_table,
+        message_handler,
+        goto_functions,
+        loop_counter),
       loop_counter(_loop_counter)
   {
   }

--- a/src/goto-instrument/accelerate/sat_path_enumerator.cpp
+++ b/src/goto-instrument/accelerate/sat_path_enumerator.cpp
@@ -48,7 +48,7 @@ Author: Matt Lewis
 
 bool sat_path_enumeratort::next(patht &path)
 {
-  scratch_programt program(symbol_table, message_handler);
+  scratch_programt program(symbol_table, message_handler, options);
 
   program.append(fixed);
   program.append(fixed);
@@ -213,7 +213,7 @@ void sat_path_enumeratort::build_path(
  */
 void sat_path_enumeratort::build_fixed()
 {
-  scratch_programt scratch(symbol_table, message_handler);
+  scratch_programt scratch(symbol_table, message_handler, options);
   std::map<exprt, exprt> shadow_distinguishers;
 
   fixed.copy_from(goto_program);

--- a/src/goto-instrument/accelerate/sat_path_enumerator.h
+++ b/src/goto-instrument/accelerate/sat_path_enumerator.h
@@ -19,7 +19,6 @@ Author: Matt Lewis
 
 #include <goto-programs/goto_program.h>
 #include <goto-programs/goto_functions.h>
-
 #include <analyses/natural_loops.h>
 
 #include "path_enumerator.h"
@@ -36,19 +35,26 @@ class sat_path_enumeratort:public path_enumeratort
 public:
   sat_path_enumeratort(
     message_handlert &message_handler,
+    const optionst &_options,
     symbol_tablet &_symbol_table,
     goto_functionst &_goto_functions,
     goto_programt &_goto_program,
     natural_loops_mutablet::natural_loopt &_loop,
     goto_programt::targett _loop_header)
     : message_handler(message_handler),
+      options(_options),
       symbol_table(_symbol_table),
       ns(symbol_table),
       goto_functions(_goto_functions),
       goto_program(_goto_program),
       loop(_loop),
       loop_header(_loop_header),
-      utils(symbol_table, message_handler, goto_functions, loop_counter)
+      utils(
+        symbol_table,
+        message_handler,
+        options,
+        goto_functions,
+        loop_counter)
   {
     find_distinguishing_points();
     build_fixed();
@@ -58,6 +64,8 @@ public:
 
 protected:
   message_handlert &message_handler;
+  const optionst &options;
+
   void find_distinguishing_points();
 
   void build_path(scratch_programt &scratch_program, patht &path);

--- a/src/goto-instrument/accelerate/scratch_program.h
+++ b/src/goto-instrument/accelerate/scratch_program.h
@@ -35,7 +35,10 @@ Author: Matt Lewis
 class scratch_programt:public goto_programt
 {
 public:
-  scratch_programt(symbol_tablet &_symbol_table, message_handlert &mh)
+  scratch_programt(
+    symbol_tablet &_symbol_table,
+    message_handlert &mh,
+    const optionst &options)
     : constant_propagation(true),
       symbol_table(_symbol_table),
       ns(symbol_table),
@@ -44,8 +47,17 @@ public:
       satcheck(util_make_unique<satcheckt>()),
       satchecker(ns, *satcheck),
       z3(ns, "accelerate", "", "", smt2_dect::solvert::Z3),
-      checker(&z3) // checker(&satchecker)
+      checker(&z3)
   {
+    if(options.get_bool_option("z3"))
+      checker = &z3;
+    else
+    {
+      satcheck_infot satcheck_info = parse_satcheck_info(options);
+      satcheck->set_random_var_freq(satcheck_info.random_var_freq);
+      satcheck->set_random_seed(satcheck_info.random_seed);
+      checker = &satchecker;
+    }
   }
 
   void append(goto_programt::instructionst &instructions);

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -710,8 +710,15 @@ int goto_instrument_parse_optionst::doit()
       goto_inline(goto_model, get_message_handler());
 
       status() << "Accelerating" << eom;
-      accelerate_functions(
-        goto_model, get_message_handler(), cmdline.isset("z3"));
+      optionst options;
+      if(cmdline.isset("random-seed"))
+        options.set_option("random-seed", cmdline.get_value("random-seed"));
+      if(cmdline.isset("random-var-freq"))
+        options.set_option(
+          "random-var-freq", cmdline.get_value("random-var-freq"));
+      options.set_option("z3", cmdline.isset("z3"));
+
+      accelerate_functions(goto_model, get_message_handler(), options);
       remove_skip(goto_model);
       goto_model.goto_functions.update();
     }

--- a/src/solvers/flattening/bv_minimize.h
+++ b/src/solvers/flattening/bv_minimize.h
@@ -48,9 +48,11 @@ public:
     return "Bit vector minimizing SAT";
   }
 
-  explicit bv_minimizing_dect(const namespacet &_ns):
-    bv_pointerst(_ns, satcheck)
+  bv_minimizing_dect(const namespacet &_ns, const satcheck_infot &satcheck_info)
+    : bv_pointerst(_ns, satcheck)
   {
+    satcheck.set_random_var_freq(satcheck_info.random_var_freq);
+    satcheck.set_random_seed(satcheck_info.random_seed);
   }
 
   void minimize(const minimization_listt &objectives)

--- a/src/solvers/prop/prop.h
+++ b/src/solvers/prop/prop.h
@@ -116,6 +116,20 @@ public:
     warning() << "CPU limit ignored (not implemented)" << eom;
   }
 
+  /// Set random variable seed
+  /// (supported by solvers such as minisat2 and glucose)
+  virtual void set_random_seed(std::size_t value)
+  {
+    warning() << "random-seed not supported" << eom;
+  }
+
+  /// Set random variable frequency
+  /// (supported by solvers such as minisat2 and glucose)
+  virtual void set_random_var_freq(double value)
+  {
+    warning() << "random-var-freq not supported" << eom;
+  }
+
 protected:
   // to avoid a temporary for lcnf(...)
   bvt lcnf_bv;

--- a/src/solvers/refinement/bv_refinement.h
+++ b/src/solvers/refinement/bv_refinement.h
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/ui_message.h>
 
 #include <solvers/flattening/bv_pointers.h>
+#include <solvers/sat/satcheck.h>
 
 #define MAX_STATE 10000
 
@@ -30,6 +31,7 @@ private:
     bool refine_arrays=true;
     /// Enable arithmetic refinement
     bool refine_arithmetic=true;
+    satcheck_infot satcheck;
   };
 public:
   struct infot:public configt

--- a/src/solvers/refinement/refine_arrays.cpp
+++ b/src/solvers/refinement/refine_arrays.cpp
@@ -46,6 +46,8 @@ void bv_refinementt::arrays_overapproximated()
   while(it!=lazy_array_constraints.end())
   {
     satcheck_no_simplifiert sat_check;
+    sat_check.set_random_var_freq(config_.satcheck.random_var_freq);
+    sat_check.set_random_seed(config_.satcheck.random_seed);
     bv_pointerst solver(ns, sat_check);
     solver.unbounded_array=bv_pointerst::unbounded_arrayt::U_ALL;
 

--- a/src/solvers/refinement/string_refinement.cpp
+++ b/src/solvers/refinement/string_refinement.cpp
@@ -606,7 +606,7 @@ decision_proceduret::resultt string_refinementt::dec_solve()
   {
     bool satisfied;
     std::vector<exprt> counter_examples;
-    std::tie(satisfied, counter_examples)=check_axioms(
+    std::tie(satisfied, counter_examples) = check_axioms(
       axioms,
       generator,
       get,
@@ -654,7 +654,7 @@ decision_proceduret::resultt string_refinementt::dec_solve()
     {
       bool satisfied;
       std::vector<exprt> counter_examples;
-      std::tie(satisfied, counter_examples)=check_axioms(
+      std::tie(satisfied, counter_examples) = check_axioms(
         axioms,
         generator,
         get,

--- a/src/solvers/sat/satcheck.cpp
+++ b/src/solvers/sat/satcheck.cpp
@@ -8,6 +8,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 
 #include "satcheck.h"
+#include <util/string2int.h>
+#include <util/options.h>
 
 // Sanity check
 
@@ -22,3 +24,15 @@ Author: Daniel Kroening, kroening@kroening.com
 #error "I expected to have MiniSat 2"
 #endif
 #endif
+
+satcheck_infot parse_satcheck_info(const optionst &options)
+{
+  satcheck_infot satcheck_info;
+  if(!options.get_option("random-seed").empty())
+    satcheck_info.random_seed =
+      safe_string2size_t(options.get_option("random-seed"));
+  if(!options.get_option("random-var-freq").empty())
+    satcheck_info.random_var_freq =
+      std::stod(options.get_option("random-var-freq"));
+  return satcheck_info;
+}

--- a/src/solvers/sat/satcheck.h
+++ b/src/solvers/sat/satcheck.h
@@ -124,4 +124,13 @@ typedef satcheck_glucose_no_simplifiert satcheck_no_simplifiert;
 
 #endif
 
+class optionst;
+struct satcheck_infot final
+{
+  std::size_t random_seed = 91648253; // Default copied from minisat2/glucose
+  double random_var_freq = 0.0;
+};
+
+satcheck_infot parse_satcheck_info(const optionst &options);
+
 #endif // CPROVER_SOLVERS_SAT_SATCHECK_H

--- a/src/solvers/sat/satcheck_glucose.cpp
+++ b/src/solvers/sat/satcheck_glucose.cpp
@@ -221,6 +221,18 @@ void satcheck_glucose_baset<T>::set_assumptions(const bvt &bv)
     assert(!it->is_constant());
 }
 
+template <typename T>
+void satcheck_glucose_baset<T>::set_random_seed(std::size_t value)
+{
+  this->solver->random_seed = value;
+}
+
+template <typename T>
+void satcheck_glucose_baset<T>::set_random_var_freq(double value)
+{
+  this->solver->random_var_freq = value;
+}
+
 satcheck_glucose_no_simplifiert::satcheck_glucose_no_simplifiert():
   satcheck_glucose_baset<Glucose::Solver>(new Glucose::Solver)
 {

--- a/src/solvers/sat/satcheck_glucose.h
+++ b/src/solvers/sat/satcheck_glucose.h
@@ -46,6 +46,9 @@ public:
   virtual bool has_set_assumptions() const { return true; }
   virtual bool has_is_in_conflict() const { return true; }
 
+  void set_random_seed(std::size_t) override;
+  void set_random_var_freq(double) override;
+
 protected:
   T *solver;
 

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -20,6 +20,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/invariant.h>
 #include <util/threeval.h>
 #include <util/invariant.h>
+#include <util/options.h>
 
 #include <minisat/core/Solver.h>
 #include <minisat/simp/SimpSolver.h>
@@ -293,6 +294,18 @@ void satcheck_minisat2_baset<T>::set_assumptions(const bvt &bv)
       assumptions.clear();
       break;
     }
+}
+
+template <typename T>
+void satcheck_minisat2_baset<T>::set_random_seed(std::size_t value)
+{
+  this->solver->random_seed = value;
+}
+
+template <typename T>
+void satcheck_minisat2_baset<T>::set_random_var_freq(double value)
+{
+  this->solver->random_var_freq = value;
 }
 
 satcheck_minisat_no_simplifiert::satcheck_minisat_no_simplifiert():

--- a/src/solvers/sat/satcheck_minisat2.h
+++ b/src/solvers/sat/satcheck_minisat2.h
@@ -51,6 +51,9 @@ public:
     time_limit_seconds=lim;
   }
 
+  void set_random_seed(std::size_t) override;
+  void set_random_var_freq(double) override;
+
 protected:
   T *solver;
   uint32_t time_limit_seconds;

--- a/unit/solvers/refinement/string_constraint_instantiation/instantiate_not_contains.cpp
+++ b/unit/solvers/refinement/string_constraint_instantiation/instantiate_not_contains.cpp
@@ -142,7 +142,10 @@ std::string create_info(std::vector<exprt> &lemmas, const namespacet &ns)
 /// \return SAT solver result
 decision_proceduret::resultt check_sat(const exprt &expr, const namespacet &ns)
 {
+  satcheck_infot satcheck_info;
   satcheck_no_simplifiert sat_check;
+  sat_check.set_random_var_freq(satcheck_info.random_var_freq);
+  sat_check.set_random_seed(satcheck_info.random_seed);
   bv_refinementt::infot info;
   info.ns=&ns;
   info.prop=&sat_check;


### PR DESCRIPTION
New options:
```bash
--random-seed 13121110 # seed for randomizer - floating point number
--random-var-freq 0...1 # random generator frequency - floating point number
```
If unset defaults those values as defined in sat checker (works as before).

Also  simplifies the satcheck wrapper implementation.

Review tips: Each commit contains changes as described in the title. There's one massive commit, which forces parametrization of satcheck. I tried to make it as small as possible, given in how many places satcheck is used.

TODO: Prettier messages if arguments are not valid, ~floating point numbers, restrict random-var-freq to 0...1 in command line parser, lintage.~

Implements this ticket: https://diffblue.atlassian.net/browse/TG-925