### PR TITLE
Remove unnecessary includes in java-typecheck

### DIFF
--- a/src/java_bytecode/java_bytecode_typecheck_expr.cpp
+++ b/src/java_bytecode/java_bytecode_typecheck_expr.cpp
@@ -13,8 +13,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <iomanip>
 
-#include <util/std_expr.h>
-#include <util/prefix.h>
 #include <util/arith_tools.h>
 #include <util/unicode.h>
 


### PR DESCRIPTION
This is a fragment taken from #1420