### PR TITLE
Fix graphml output of concurrency witnesses

### DIFF
--- a/regression/cbmc-concurrency/graphml_witness1/main.c
+++ b/regression/cbmc-concurrency/graphml_witness1/main.c
@@ -1,0 +1,8 @@
+int global;
+
+int main()
+{
+  __CPROVER_ASYNC_1: global=1;
+  global=2;
+  assert(global==2); // to fail
+}

--- a/regression/cbmc-concurrency/graphml_witness1/test.desc
+++ b/regression/cbmc-concurrency/graphml_witness1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--graphml-witness -
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+</graphml>
+--
+^warning: ignoring

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -141,7 +141,7 @@ static bool filter_out(
   goto_tracet::stepst::const_iterator &it)
 {
   if(it->hidden &&
-     (!it->is_assignment() ||
+     (!it->pc->is_assign() ||
       to_code_assign(it->pc->code).rhs().id()!=ID_side_effect ||
       to_code_assign(it->pc->code).rhs().get(ID_statement)!=ID_nondet))
     return true;


### PR DESCRIPTION
The START_THREAD instruction may induce a number of assignments, which end up as
assignment in the symex_target_equation while the corresponding pc still points
to a START_THREAD instruction. Hence testing assignments must be done
consistently either within the symex_target_equation or within the goto program
level.