### PR TITLE
Correctly identify bitfield constants as CONSTANT values

### DIFF
--- a/regression/goto-analyzer/variable-sensitivity-bit-field-constants/main.c
+++ b/regression/goto-analyzer/variable-sensitivity-bit-field-constants/main.c
@@ -1,0 +1,14 @@
+struct bitfield_struct {
+  unsigned char byte;
+  unsigned char bitfield:1;
+};
+
+extern struct bitfield_struct bs;
+
+void main(void)
+{
+  bs.byte = 10;
+  bs.bitfield = 1;
+  __CPROVER_assert(bs.byte==10, "bs.byte==10");
+  __CPROVER_assert(bs.bitfield==1, "bs.bitfield==1");
+}

--- a/regression/goto-analyzer/variable-sensitivity-bit-field-constants/test.desc
+++ b/regression/goto-analyzer/variable-sensitivity-bit-field-constants/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--function main --variable --structs --verify
+^EXIT=0$
+^SIGNAL=0$
+\[main\.assertion\.1\] .* bs\.byte==10: Success
+\[main\.assertion\.2\] .* bs\.bitfield==1: Success
+--

--- a/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.cpp
@@ -127,7 +127,7 @@ abstract_object_pointert variable_sensitivity_object_factoryt::
     return initialize_abstract_object<abstract_objectt>(
       followed_type, top, bottom, e, environment, ns);
   default:
-    assert(false);
+    UNREACHABLE;
     return initialize_abstract_object<abstract_objectt>(
       followed_type, top, bottom, e, environment, ns);
   }

--- a/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.cpp
@@ -32,7 +32,8 @@ variable_sensitivity_object_factoryt::ABSTRACT_OBJECT_TYPET
 
   if(type.id()==ID_signedbv || type.id()==ID_unsignedbv ||
     type.id()==ID_floatbv || type.id()==ID_fixedbv ||
-    type.id()==ID_c_bool || type.id()==ID_bool || type.id()==ID_integer)
+    type.id()==ID_c_bool || type.id()==ID_bool ||
+    type.id()==ID_integer || type.id()==ID_c_bit_field)
   {
     abstract_object_type=CONSTANT;
   }


### PR DESCRIPTION
Previously constant bitfield values were identified as TWO_VALUE by
default, meaning they became TOP immediately. This change makes them
be correctly identified as constants and hence have their values tracked
appropriately.