### PR TITLE
Temporary fix for definition of __int64 by mingw compiler.

### DIFF
--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -862,7 +862,7 @@ bool configt::set(const cmdlinet &cmdline)
       #endif
 
       // MinGW has extra defines
-      ansi_c.defines.push_back("__int64=\"long long\"");
+      ansi_c.defines.push_back("__int64=long long");
     }
     else
     {


### PR DESCRIPTION
The existing code calls the shell quote function for defines, which in the case of 
`__int64="long long"` eventually results into preprocessed code like this: 
```
"long long" n;
```
Adding the define switch to additional options fixes the problem temporarily, but a proper fix requires enhancing the shell quote function. 