### PR TITLE
Disable colour in travis diff display

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,10 @@ jobs:
         # Now we can do the formatting pass
         clang-format --version
         git-clang-format-3.8 "${TRAVIS_BRANCH}"
-        git diff --color > formatted.diff
+        git diff > formatted.diff
         if [[ -s formatted.diff ]] ; then
-          echo 'Formatting error! Apply the following diff and resubmit:'
+          echo 'Formatting error! The following diff shows the required changes'
+          echo 'Use the raw log to get a version of the diff that preserves spacing'
           cat formatted.diff
           exit 1
         fi


### PR DESCRIPTION
The Travis output collapses consecutive spaces into a single space character, meaning that diff displays have incorrect indentation. However, the raw log retains the correct number of spaces. If we disable colours in the Travis diff, it should be possible to copy the diff from the raw log and to apply it directly as a patch.