### PR TITLE
Disable dowhile brace check by default

### DIFF
--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -220,20 +220,21 @@ _ERROR_CATEGORIES = [
     'readability/casting',
     'readability/check',
     'readability/constructors',
+    'readability/dowhile',
     'readability/fn_size',
+    'readability/function_comment'
+    'readability/identifier_spacing',
+    'readability/identifiers',
     'readability/inheritance',
     'readability/multiline_comment',
     'readability/multiline_string',
-    'readability/identifier_spacing',
-    'readability/identifiers',
     'readability/namespace',
     'readability/nolint',
     'readability/nul',
     'readability/strings',
-    'readability/todo',
     'readability/throw',
+    'readability/todo',
     'readability/utf8',
-    'readability/function_comment'
     'runtime/arrays',
     'runtime/casting',
     'runtime/endl',
@@ -282,7 +283,7 @@ _LEGACY_ERROR_CATEGORIES = [
 # flag. By default all errors are on, so only add here categories that should be
 # off by default (i.e., categories that must be enabled by the --filter= flags).
 # All entries here should start with a '-' or '+', as in the --filter= flag.
-_DEFAULT_FILTERS = ['-build/include_alpha']
+_DEFAULT_FILTERS = ['-build/include_alpha', '-readability/dowhile']
 
 # The default list of categories suppressed for C (not C++) files.
 _DEFAULT_C_SUPPRESSED_CATEGORIES = [
@@ -4197,7 +4198,7 @@ def CheckDoWhile(filename, clean_lines, linenum, error):
   if Search(r'}\s*while\s*\(', line):
     do_found, num = FindDoStart(clean_lines, linenum)
     if do_found:
-        error(filename, linenum, 'readability/braces', 4,
+        error(filename, linenum, 'readability/dowhile', 4,
             'while statement of do...while loop should be on a separate line to the closing brace')
 
 def CheckTrailingSemicolon(filename, clean_lines, linenum, error):


### PR DESCRIPTION
Quoting @thk123:
> I have found another discrepancy between linter and clang-format (though this I think is a clear cut case of we just update the rule from the linter:
> ```
> whitespace/blank_line] [3] src/java_bytecode/java_types.cpp:370: while statement of do...while loop should be on a separate line to the closing brace [readability/braces] [4] 
> ```
> C++ as formatted by clang-format
> ```
>    do
>    {
>      // some code...
>    } while(f_pos != std::string::npos);
> ```

This patch puts the check in a new category `readability/dowhile`, and then disables this category of checks by default. In this way, the linter should not complain about clang-format's treatment of dowhile loops.