### PR TITLE
Add _Float128 spelling for 128-bit float type

### DIFF
--- a/regression/ansi-c/gcc_types_compatible_p1/main.c
+++ b/regression/ansi-c/gcc_types_compatible_p1/main.c
@@ -67,6 +67,13 @@ STATIC_ASSERT(__builtin_types_compatible_p(typeof (hot) *, int *));
 STATIC_ASSERT(__builtin_types_compatible_p(typeof (hot), typeof (janette)));
 STATIC_ASSERT(__builtin_types_compatible_p(__int128, signed __int128));
 
+#ifndef __clang__
+// clang doesn't have these
+#if defined(__x86_64__) || defined(__i386__)
+STATIC_ASSERT(__builtin_types_compatible_p(__float128, _Float128));
+#endif
+#endif
+
 /* Incompatible types */
 
 STATIC_ASSERT(!__builtin_types_compatible_p(char, _Bool));

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -466,7 +466,8 @@ void ansi_c_scanner_init()
                     return make_identifier();
                 }
 
-"__float128"    { // clang doesn't have it
+"__float128" |
+"_Float128"     { // clang doesn't have it
                   if(PARSER.mode==configt::ansi_ct::flavourt::GCC)
                   { loc(); return TOK_GCC_FLOAT128; }
                   else


### PR DESCRIPTION
According to https://gcc.gnu.org/onlinedocs/gcc/Floating-Types.html,
"On i386, x86_64, PowerPC, and IA-64 other than HP-UX, __float128 is an alias for _Float128"
and we support __float128, so we should probably support the other type name too.

As of glibc commit https://github.com/bminor/glibc/commit/fcee5905d341fe975f7786e72c831ada1c8fa78b, and in particular at least in the version shipped in Ubuntu 17.10, there are public `_Float128` declarations, which cause `goto-cc` to fail with a syntax error when including `math.h` due to the undefined type name.

Note this PR is probably not good enough yet as I don't really understand Flex/Bison, and just did the smallest hack to check this was the problem. I suggest someone who knows more about the parser and/or who knows more about what we intend to do with float128 should take it from here.