### PR TITLE
Enable casting from derived types to other derived types

### DIFF
--- a/src/util/expr_cast.h
+++ b/src/util/expr_cast.h
@@ -74,7 +74,7 @@ auto expr_try_dynamic_cast(TExpr &base)
     typename detail::expr_try_dynamic_cast_return_typet<T, TExpr>::type
     returnt;
   static_assert(
-    std::is_same<typename std::decay<TExpr>::type, exprt>::value,
+    std::is_base_of<exprt, typename std::decay<TExpr>::type>::value,
     "Tried to expr_try_dynamic_cast from something that wasn't an exprt");
   static_assert(
     std::is_base_of<exprt, T>::value,


### PR DESCRIPTION
When working with `codet` I sometimes want to try casting from `codet` to `code_assignt` (for example), which the current `expr_cast` doesn't allow. This patch changes one of the static type checks so that it just ensures the type being cast has `exprt` as an ancestor, rather than forcing the argument to have exactly `exprt` type.