### PR TITLE
Ignore files and directories created by Eclipse and Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,13 @@ src/goto-analyzer/taint_driver_scripts/.idea/*
 /*.creator.user
 /*.files
 /*.includes
+# Eclipse
+src/.cproject
+src/.project
+src/.settings/*
+# Visual Studio
+Debug/*
+Release/*
 
 # compilation files
 *.lo


### PR DESCRIPTION
It bugs me every time I do "git status" to see the Eclipse and Visual Studio settings and compilation directories listed as "not tracked".