### PR TITLE
Convert sharing-node test to run under Catch

### DIFF
--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -10,7 +10,6 @@ list(REMOVE_ITEM sources
     # Used in executables
     ${CMAKE_CURRENT_SOURCE_DIR}/miniBDD.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/string_utils.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/sharing_node.cpp
 
     # Don't build
     ${CMAKE_CURRENT_SOURCE_DIR}/sharing_map.cpp
@@ -70,14 +69,3 @@ target_include_directories(string_utils
 target_link_libraries(string_utils solvers ansi-c)
 add_test(NAME string_utils COMMAND $<TARGET_FILE:string_utils>)
 set_tests_properties(string_utils PROPERTIES LABELS "CORE;CBMC")
-
-add_executable(sharing_node sharing_node.cpp)
-target_include_directories(sharing_node
-    PUBLIC
-    ${CBMC_BINARY_DIR}
-    ${CBMC_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}
-)
-target_link_libraries(sharing_node util)
-add_test(NAME sharing_node COMMAND $<TARGET_FILE:sharing_node>)
-set_tests_properties(sharing_node PROPERTIES LABELS "CORE;CBMC")

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -21,6 +21,7 @@ SRC += unit_tests.cpp \
        miniBDD_new.cpp \
        java_bytecode/java_string_library_preprocess/convert_exprt_to_string_exprt.cpp \
        java_bytecode/java_utils_test.cpp \
+       sharing_node.cpp \
        solvers/refinement/string_constraint_generator_valueof/calculate_max_string_length.cpp \
        solvers/refinement/string_constraint_generator_valueof/get_numeric_value_from_character.cpp \
        solvers/refinement/string_constraint_generator_valueof/is_digit_with_radix.cpp \
@@ -67,7 +68,6 @@ OBJ += $(CPROVER_LIBS) testing-utils/testing-utils$(LIBEXT)
 TESTS = unit_tests$(EXEEXT) \
         miniBDD$(EXEEXT) \
         string_utils$(EXEEXT) \
-        sharing_node$(EXEEXT) \
         # Empty last line
 
 CLEANFILES = $(TESTS)
@@ -88,7 +88,4 @@ miniBDD$(EXEEXT): miniBDD$(OBJEXT) $(CPROVER_LIBS)
 	$(LINKBIN)
 
 string_utils$(EXEEXT): string_utils$(OBJEXT) $(CPROVER_LIBS)
-	$(LINKBIN)
-
-sharing_node$(EXEEXT): sharing_node$(OBJEXT) $(CPROVER_LIBS)
 	$(LINKBIN)

--- a/unit/sharing_node.cpp
+++ b/unit/sharing_node.cpp
@@ -1,12 +1,15 @@
+// Copyright 2016-2017 DiffBlue Limited. All Rights Reserved.
+
+/// \file Tests for sharing-node utility
+
 #include <iostream>
 #include <cassert>
 
 #include <util/sharing_node.h>
+#include <testing-utils/catch.hpp>
 
 void sharing_node_test()
 {
-  std::cout << "Running sharing node test" << std::endl;
-
   typedef sharing_nodet<std::string, std::string> snt;
 
   // internal node test
@@ -16,36 +19,36 @@ void sharing_node_test()
 
     const snt *p2;
 
-    assert(sn1.is_empty());
+    REQUIRE(sn1.is_empty());
 
     sn1.add_child(0);
     sn1.add_child(1);
     sn1.add_child(2);
 
-    assert(!sn2.is_empty());
-    assert(sn2.is_internal());
-    assert(!sn2.is_container());
-    assert(!sn2.is_leaf());
+    REQUIRE(!sn2.is_empty());
+    REQUIRE(sn2.is_internal());
+    REQUIRE(!sn2.is_container());
+    REQUIRE(!sn2.is_leaf());
 
-    assert(sn2.get_sub().size()==3);
+    REQUIRE(sn2.get_sub().size()==3);
 
     p2=sn2.find_child(0);
-    assert(p2!=nullptr);
+    REQUIRE(p2!=nullptr);
 
     p2=sn1.find_child(0);
-    assert(p2!=nullptr);
+    REQUIRE(p2!=nullptr);
 
     p2=sn2.find_child(3);
-    assert(p2==nullptr);
+    REQUIRE(p2==nullptr);
 
     p2=sn1.find_child(3);
-    assert(p2==nullptr);
+    REQUIRE(p2==nullptr);
 
     sn1.remove_child(0);
-    assert(sn2.get_sub().size()==2);
+    REQUIRE(sn2.get_sub().size()==2);
 
     sn1.clear();
-    assert(sn2.is_empty());
+    REQUIRE(sn2.is_empty());
   }
 
   // container node test
@@ -61,18 +64,18 @@ void sharing_node_test()
     p1=sn1.add_child(2);
     p2=p1;
 
-    assert(p1->find_leaf("a")==nullptr);
-    assert(p2->find_leaf("a")==nullptr);
+    REQUIRE(p1->find_leaf("a")==nullptr);
+    REQUIRE(p2->find_leaf("a")==nullptr);
 
     p1->place_leaf("a", "b");
-    assert(p2->get_container().size()==1);
+    REQUIRE(p2->get_container().size()==1);
     p1->place_leaf("c", "d");
-    assert(p2->get_container().size()==2);
+    REQUIRE(p2->get_container().size()==2);
 
-    assert(p2->is_container());
+    REQUIRE(p2->is_container());
 
     p1->remove_leaf("a");
-    assert(p2->get_container().size()==1);
+    REQUIRE(p2->get_container().size()==1);
   }
 
   // copy test 1
@@ -81,16 +84,16 @@ void sharing_node_test()
     snt sn2;
 
     sn2=sn1;
-    assert(sn1.data.use_count()==3);
-    assert(sn2.data.use_count()==3);
+    REQUIRE(sn1.data.use_count()==3);
+    REQUIRE(sn2.data.use_count()==3);
 
     sn1.add_child(0);
-    assert(sn1.data.use_count()==1);
+    REQUIRE(sn1.data.use_count()==1);
     // the newly created node is empty as well
-    assert(sn2.data.use_count()==3);
+    REQUIRE(sn2.data.use_count()==3);
 
     sn2=sn1;
-    assert(sn2.data.use_count()==2);
+    REQUIRE(sn2.data.use_count()==2);
   }
 
   // copy test 2
@@ -110,20 +113,17 @@ void sharing_node_test()
     const snt &sn2c=sn2;
     sn2=sn1;
 
-    assert(sn1.is_internal());
-    assert(sn2.is_internal());
+    REQUIRE(sn1.is_internal());
+    REQUIRE(sn2.is_internal());
 
     sn1.remove_child(0);
-    assert(sn1c.get_sub().size()==1);
+    REQUIRE(sn1c.get_sub().size()==1);
 
-    assert(sn2c.get_sub().size()==2);
+    REQUIRE(sn2c.get_sub().size()==2);
   }
 }
 
-int main()
+TEST_CASE("Sharing node")
 {
-  sharing_node_test();  
-
-  return 0;
+  sharing_node_test();
 }
-


### PR DESCRIPTION
Per @andreast271 this is necessary for compile unit tests with -DNDEBUG

This generalises https://github.com/diffblue/cbmc/pull/1536 to convert the test to Catch style while we're moving away from `assert`