### PR TITLE
Replace unsigned with appropriate type

### DIFF
--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -71,7 +71,7 @@ value_sett::entryt &value_sett::get_entry(
 
 bool value_sett::insert(
   object_mapt &dest,
-  unsigned n,
+  object_numberingt::number_type n,
   const objectt &object) const
 {
   auto entry=dest.read().find(n);

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -60,7 +60,7 @@ public:
 
   class object_map_dt
   {
-    typedef std::map<unsigned, objectt> data_typet;
+    typedef std::map<object_numberingt::number_type, objectt> data_typet;
     data_typet data;
 
   public:
@@ -132,7 +132,10 @@ public:
     return insert(dest, object_numbering.number(src), objectt(offset));
   }
 
-  bool insert(object_mapt &dest, unsigned n, const objectt &object) const;
+  bool insert(
+    object_mapt &dest,
+    object_numberingt::number_type n,
+    const objectt &object) const;
 
   bool insert(object_mapt &dest, const exprt &expr, const objectt &object) const
   {


### PR DESCRIPTION
Replace unsigned with object_numberingt::number_type, which actually
resolves to size_t rather than unsigned.