### PR TITLE
Use INVARIANT rather than assert for sharing-node assertions

### DIFF
--- a/src/util/sharing_node.h
+++ b/src/util/sharing_node.h
@@ -19,7 +19,7 @@ Author: Daniel Poetzl
 
 #include "invariant.h"
 
-#define _sn_assert(b) assert(b)
+#define _sn_assert(b) INVARIANT(b, "Sharing-node internal invariant")
 //#define _sn_assert(b)
 
 template <class T>


### PR DESCRIPTION
This has the additional benefit that `_sn_assert` statements will no longer leave dangling unused variables, as reported by @andreast271 in #1536 
