### PR TITLE
Remove virtual functions: expose single-call entry-point

### DIFF
--- a/src/goto-programs/remove_virtual_functions.h
+++ b/src/goto-programs/remove_virtual_functions.h
@@ -25,4 +25,37 @@ void remove_virtual_functions(
   const symbol_tablet &symbol_table,
   goto_functionst &goto_functions);
 
+/// Specifies remove_virtual_function's behaviour when the actual supplied
+/// parameter does not match any of the possible callee types
+enum class virtual_dispatch_fallback_actiont
+{
+  /// When no callee type matches, call the last passed function, which
+  /// is expected to be some safe default:
+  CALL_LAST_FUNCTION,
+  /// When no callee type matches, ASSUME false, thus preventing any complete
+  /// trace from using this path.
+  ASSUME_FALSE
+};
+
+class dispatch_table_entryt
+{
+ public:
+  dispatch_table_entryt() = default;
+  explicit dispatch_table_entryt(const irep_idt &_class_id) :
+    class_id(_class_id)
+  {}
+
+  symbol_exprt symbol_expr;
+  irep_idt class_id;
+};
+
+typedef std::vector<dispatch_table_entryt> dispatch_table_entriest;
+
+void remove_virtual_function(
+  goto_modelt &goto_model,
+  goto_programt &goto_program,
+  goto_programt::targett instruction,
+  const dispatch_table_entriest &dispatch_table,
+  virtual_dispatch_fallback_actiont fallback_action);
+
 #endif // CPROVER_GOTO_PROGRAMS_REMOVE_VIRTUAL_FUNCTIONS_H


### PR DESCRIPTION
This enables passes that take a different approach to virtual function lowering to re-use its dispatch-table-construction logic. For example, in the security analyser we might pass something like:
`remove_virtual_function(some_vcall_instruction, { type A -> function A::f_specialization_1, type B -> function B::f_specialization_2 })`

Since we generate partial dispatch tables, having established some classes visible in the hierarchy are not feasible callees, we also support adding an `ASSUME FALSE` for the no-match case instead of always falling through to the least-derived callee as at present.

I'm aware this needs some tests adding; putting it up now for feedback in the meantime.