### PR TITLE
Expose `seen` field of the static analysis domain

### DIFF
--- a/src/analyses/static_analysis.h
+++ b/src/analyses/static_analysis.h
@@ -86,6 +86,9 @@ public:
   // this computes the join between "this" and "b"
   // return true if "this" has changed
 
+  bool has_been_seen() const { return seen; }
+  void set_seen() { seen=true; }
+
 protected:
   bool seen;
 


### PR DESCRIPTION
This enables use of the domain by an alternative driver routine--
in our case, an out-of-class reimplementation of `static_analysist::fixedpoint` that accounts for context-sensitivity.