### PR TITLE
Add map-container helper

### DIFF
--- a/src/util/map_fn.h
+++ b/src/util/map_fn.h
@@ -1,0 +1,26 @@
+/*******************************************************************\
+
+ Module: Map function onto container helper
+
+ Author: Diffblue Limited. All rights reserved.
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_MAP_FN_H
+#define CPROVER_UTIL_MAP_FN_H
+
+#include <iterator>
+
+template<typename Container, typename Callable>
+Container map_fn(const Callable &callable, const Container &input)
+{
+  Container result;
+  std::transform(
+    begin(input),
+    end(input),
+    std::inserter(result, end(result)),
+    callable);
+  return result;
+}
+
+#endif


### PR DESCRIPTION
A simple helper routine for applying a stereotypical case of `std::transform`. Example usage:

```
std::vector<int> numbers {1, 2, 3};
auto plusones = map_fn([](int x) { return x + 1; }, numbers);
```

By use of `inserter` this should work with quite a few STL containers: `set`, `map`, `vector` and their unordered cousins should all work.

The more general `map ( A container, A -> B ) -> B container` is trickier and I leave that to anyone willing to spend the time :)