### PR TITLE
Add some unit test helper functions, useful for Java generics unit tests

### DIFF
--- a/unit/testing-utils/require_type.cpp
+++ b/unit/testing-utils/require_type.cpp
@@ -59,6 +59,21 @@ code_typet require_type::require_code(const typet &type)
   return to_code_type(type);
 }
 
+/// Verify a given type is an code_typet, and that the code it represents
+/// accepts a given number of parameters
+/// \param type The type to check
+/// \param num_params check the the given code_typet expects this
+/// number of parameters
+/// \return The type cast to a code_typet
+code_typet require_type::require_code(
+  const typet &type,
+  const size_t num_params)
+{
+  code_typet code_type=require_code(type);
+  REQUIRE(code_type.parameters().size()==num_params);
+  return code_type;
+}
+
 /// Verify that a function has a parameter of a specific name.
 /// \param function_type: The type of the function
 /// \param param_name: The name of the parameter
@@ -77,4 +92,106 @@ code_typet::parametert require_type::require_parameter(
 
   REQUIRE(param != function_type.parameters().end());
   return *param;
+}
+
+/// Verify a given type is a java_generic_type, optionally checking
+/// that it's associated type variables match a given set of identifiers
+/// \param type The type to check
+/// \param type_variables An optional set of type variable identifiers which
+/// should be expected as the type parameters of the generic type.
+/// \return The given type, cast to a java_generic_typet
+const java_generic_typet &require_type::require_java_generic_type_variables(
+  const typet &type,
+  const optionalt<std::initializer_list<irep_idt>> &type_variables)
+{
+  REQUIRE(is_java_generic_type(type));
+  const java_generic_typet &generic_type=to_java_generic_type(type);
+  if(type_variables)
+  {
+    const java_generic_typet::generic_type_variablest &generic_type_vars=
+      generic_type.generic_type_variables();
+    REQUIRE(generic_type_vars.size()==type_variables.value().size());
+    REQUIRE(
+      std::equal(
+        type_variables->begin(),
+        type_variables->end(),
+        generic_type_vars.begin(),
+        [](const irep_idt &type_var_name, const java_generic_parametert &param)
+        {
+          REQUIRE(!is_java_generic_inst_parameter((param)));
+          return param.type_variable().get_identifier()==type_var_name;
+        }));
+  }
+
+  return generic_type;
+}
+
+/// Verify a given type is a java_generic_type, optionally checking
+/// that it's associated type variables match a given set of identifiers
+/// \param type The type to check
+/// \param type_variables An optional set of type variable identifiers which
+/// should be expected as the type parameters of the generic type.
+/// \return The given type, cast to a java_generic_typet
+const java_generic_typet
+&require_type::require_java_generic_type_instantiations(
+  const typet &type,
+  const optionalt<std::initializer_list<irep_idt>> &type_instantiations)
+{
+  REQUIRE(is_java_generic_type(type));
+  const java_generic_typet &generic_type=to_java_generic_type(type);
+  if(type_instantiations)
+  {
+    const java_generic_typet::generic_type_variablest &generic_type_vars=
+      generic_type.generic_type_variables();
+    REQUIRE(generic_type_vars.size()==type_instantiations.value().size());
+    REQUIRE(
+      std::equal(
+        type_instantiations->begin(),
+        type_instantiations->end(),
+        generic_type_vars.begin(),
+        [](const irep_idt &type_id, const java_generic_parametert &param)
+        {
+          REQUIRE(is_java_generic_inst_parameter((param)));
+          return param.subtype()==symbol_typet(type_id);
+        }));
+  }
+
+
+  return generic_type;
+}
+
+/// Verify a given type is a java_generic_parameter, optionally checking
+/// that it's associated type variables match a given set of identifiers
+/// \param type The type to check
+/// \param type_variables An optional set of type variable identifiers which
+/// should be expected as the type parameters of the generic type.
+/// \return The given type, cast to a java_generic_typet
+const java_generic_parametert
+&require_type::require_java_generic_parameter_variables(
+  const typet &type,
+  const optionalt<irep_idt> &type_variable)
+{
+  REQUIRE(is_java_generic_parameter(type));
+  const java_generic_parametert &generic_param=to_java_generic_parameter(type);
+  if(type_variable)
+  {
+    const java_generic_parametert::type_variablet &generic_type_var=
+      generic_param.type_variable();
+    REQUIRE(!is_java_generic_inst_parameter((generic_param)));
+    REQUIRE(generic_type_var.get_identifier()==type_variable.value());
+  }
+
+  return generic_param;
+}
+
+const typet &require_type::require_java_non_generic_type(
+  const typet &type,
+  const optionalt<irep_idt> &expect_type)
+{
+  REQUIRE(!is_java_generic_parameter(type));
+  REQUIRE(!is_java_generic_type(type));
+  REQUIRE(!is_java_generic_inst_parameter(type));
+  if(expect_type)
+    REQUIRE(type.subtype()==symbol_typet(expect_type.value()));
+  return type;
 }

--- a/unit/testing-utils/require_type.h
+++ b/unit/testing-utils/require_type.h
@@ -17,6 +17,8 @@
 
 #include <util/optional.h>
 #include <util/std_types.h>
+#include <java_bytecode/java_types.h>
+
 
 // NOLINTNEXTLINE(readability/namespace)
 namespace require_type
@@ -29,8 +31,29 @@ struct_typet::componentt require_component(
   const irep_idt &component_name);
 
 code_typet require_code(const typet &type);
+
 code_typet::parametert
 require_parameter(const code_typet &function_type, const irep_idt &param_name);
+
+code_typet require_code(
+  const typet &type,
+  const size_t num_params);
+
+const java_generic_typet &require_java_generic_type_variables(
+  const typet &type,
+  const optionalt<std::initializer_list<irep_idt>> &type_variables);
+
+const java_generic_typet &require_java_generic_type_instantiations(
+  const typet &type,
+  const optionalt<std::initializer_list<irep_idt>> &type_instantiations);
+
+const java_generic_parametert &require_java_generic_parameter_variables(
+  const typet &type,
+  const optionalt<irep_idt> &type_variables);
+
+const typet &require_java_non_generic_type(
+  const typet &type,
+  const optionalt<irep_idt> &expect_type);
 }
 
-#endif
+#endif // CPROVER_TESTING_UTILS_REQUIRE_TYPE_H

--- a/unit/testing-utils/require_type.h
+++ b/unit/testing-utils/require_type.h
@@ -39,21 +39,29 @@ code_typet require_code(
   const typet &type,
   const size_t num_params);
 
-const java_generic_typet &require_java_generic_type_variables(
-  const typet &type,
-  const optionalt<std::initializer_list<irep_idt>> &type_variables);
+// A mini DSL for describing an expected set of type parameters for a
+// java_generic_typet
+enum class type_parameter_kindt { Inst, Var };
+struct expected_type_parametert
+{
+  type_parameter_kindt kind;
+  irep_idt description;
+};
+typedef std::initializer_list<expected_type_parametert>
+  expected_type_parameterst;
 
-const java_generic_typet &require_java_generic_type_instantiations(
+java_generic_typet require_java_generic_type(
   const typet &type,
-  const optionalt<std::initializer_list<irep_idt>> &type_instantiations);
+  const optionalt<require_type::expected_type_parameterst> &type_expectations);
 
-const java_generic_parametert &require_java_generic_parameter_variables(
+
+java_generic_parametert require_java_generic_parameter(
   const typet &type,
-  const optionalt<irep_idt> &type_variables);
+  const optionalt<require_type::expected_type_parametert> &type_expectation);
 
 const typet &require_java_non_generic_type(
   const typet &type,
-  const optionalt<irep_idt> &expect_type);
+  const optionalt<symbol_typet> &expect_subtype);
 }
 
 #endif // CPROVER_TESTING_UTILS_REQUIRE_TYPE_H


### PR DESCRIPTION
These are helper functions that were originally part of https://github.com/diffblue/cbmc/pull/1460 but have been minimally changed to compile cleanly on latest develop branch. `require_code` has been slightly refactored in the light of a similiar `require_code` helper function having been added since PR1460 was created.