### PR TITLE
Tidied up get_main_symbol

### DIFF
--- a/src/java_bytecode/ci_lazy_methods.cpp
+++ b/src/java_bytecode/ci_lazy_methods.cpp
@@ -60,9 +60,9 @@ bool ci_lazy_methodst::operator()(
   std::vector<irep_idt> method_worklist1;
   std::vector<irep_idt> method_worklist2;
 
-  auto main_function=
+  main_function_resultt main_function =
     get_main_symbol(symbol_table, main_class, get_message_handler(), true);
-  if(main_function.stop_convert)
+  if(!main_function.is_success())
   {
     // Failed, mark all functions in the given main class(es)
     // reaclass_hierarchyable.

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -264,8 +264,8 @@ bool java_bytecode_languaget::generate_support_functions(
 
   main_function_resultt res=
     get_main_symbol(symbol_table, main_class, get_message_handler());
-  if(res.stop_convert)
-    return res.error_found;
+  if(!res.is_success())
+    return res.is_error();
 
   // generate the test harness in __CPROVER__start and a call the entry point
   return

--- a/src/java_bytecode/java_entry_point.h
+++ b/src/java_bytecode/java_entry_point.h
@@ -26,12 +26,38 @@ bool java_entry_point(
   const object_factory_parameterst &object_factory_parameters,
   const select_pointer_typet &pointer_type_selector);
 
-typedef struct
+struct main_function_resultt
 {
+  enum statust
+  {
+    Success,
+    Error,
+    NotFound
+  } status;
   symbolt main_function;
-  bool error_found;
-  bool stop_convert;
-} main_function_resultt;
+
+  // Implicit conversion doesn't lose information and allows return of status
+  // NOLINTNEXTLINE(runtime/explicit)
+  main_function_resultt(statust status) : status(status)
+  {
+  }
+
+  // Implicit conversion doesn't lose information and allows return of symbol
+  // NOLINTNEXTLINE(runtime/explicit)
+  main_function_resultt(const symbolt &main_function)
+    : status(Success), main_function(main_function)
+  {
+  }
+
+  bool is_success() const
+  {
+    return status == Success;
+  }
+  bool is_error() const
+  {
+    return status == Error;
+  }
+};
 
 /// Figures out the entry point of the code to verify
 main_function_resultt get_main_symbol(


### PR DESCRIPTION
Changed main_function_resultt
  Use an enum instead of a collection of bools
  Added implicit constructors to main_function_resultt to make code in get_main_symbol briefer
  Added is_success and is_error helpers
Tidied up code in get_main_symbol
Fixed wrong comment