### PR TITLE
Use unique ptr for (soon-to-be) polymorphic types

### DIFF
--- a/src/cbmc/all_properties.cpp
+++ b/src/cbmc/all_properties.cpp
@@ -35,7 +35,7 @@ void bmc_all_propertiest::goal_covered(const cover_goalst::goalt &)
     // check whether failed
     for(auto &c : g.second.instances)
     {
-      literalt cond=c->cond_literal;
+      literalt cond = (*c)->cond_literal;
 
       if(solver.l_get(cond).is_false())
       {
@@ -70,9 +70,8 @@ safety_checkert::resultt bmc_all_propertiest::operator()()
 
   // get the conditions for these goals from formula
   // collect all 'instances' of the properties
-  for(symex_target_equationt::SSA_stepst::iterator
-      it=bmc.equation.SSA_steps.begin();
-      it!=bmc.equation.SSA_steps.end();
+  for(auto it = make_dereference_iterator(bmc.equation.SSA_steps.begin());
+      it != bmc.equation.SSA_steps.end();
       it++)
   {
     if(it->is_assert())
@@ -92,7 +91,7 @@ safety_checkert::resultt bmc_all_propertiest::operator()()
       else
         continue;
 
-      goal_map[property_id].instances.push_back(it);
+      goal_map[property_id].instances.push_back(it.base());
     }
   }
 

--- a/src/cbmc/all_properties_class.h
+++ b/src/cbmc/all_properties_class.h
@@ -75,7 +75,7 @@ public:
     {
       std::vector<exprt> tmp;
       tmp.reserve(instances.size());
-      for(const auto &inst : instances)
+      for(const auto &inst : make_dereference_facade(instances))
         tmp.push_back(literal_exprt(inst->cond_literal));
       return conjunction(tmp);
     }

--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -220,7 +220,7 @@ void bmct::show_program()
 
   std::cout << "\n" << "Program constraints:" << "\n";
 
-  for(const auto &step : equation.SSA_steps)
+  for(const auto &step : make_dereference_facade(equation.SSA_steps))
   {
     std::cout << "// " << step.source.pc->location_number << " ";
     std::cout << step.source.pc->source_location.as_string() << "\n";

--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -73,7 +73,7 @@ void bmct::error_trace()
       json_objectt json;
       json_arrayt &result_array=json["results"].make_array();
       json_objectt &json_result=result_array.push_back().make_object();
-      const goto_trace_stept &step=goto_trace.steps.back();
+      const goto_trace_stept &step = *goto_trace.steps.back();
       json_result["property"]=
         json_stringt(id2string(step.pc->source_location.get_property_id()));
       json_result["description"]=

--- a/src/cbmc/bmc_cover.cpp
+++ b/src/cbmc/bmc_cover.cpp
@@ -208,7 +208,7 @@ bool bmc_covert::operator()()
     }
   }
 
-  for(auto &step : bmc.equation.SSA_steps)
+  for(auto &step : make_dereference_facade(bmc.equation.SSA_steps))
     step.cond_literal=literalt(0, 0);
 
   // Do conversion to next solver layer
@@ -217,8 +217,8 @@ bool bmc_covert::operator()()
 
   // get the conditions for these goals from formula
   // collect all 'instances' of the goals
-  for(auto it = bmc.equation.SSA_steps.begin();
-      it!=bmc.equation.SSA_steps.end();
+  for(auto it = make_dereference_iterator(bmc.equation.SSA_steps.begin());
+      it != bmc.equation.SSA_steps.end();
       it++)
   {
     if(it->is_assert())
@@ -229,7 +229,7 @@ bool bmc_covert::operator()()
           literal_exprt(it->guard_literal),
           literal_exprt(!it->cond_literal) });
       literalt l_c=solver.convert(c);
-      goal_map[id(it->source.pc)].add_instance(it, l_c);
+      goal_map[id(it->source.pc)].add_instance(it.base(), l_c);
     }
   }
 

--- a/src/cbmc/bmc_cover.cpp
+++ b/src/cbmc/bmc_cover.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/xml_expr.h>
 #include <util/json.h>
 #include <util/json_expr.h>
+#include <util/dereference_iterator.h>
 
 #include <solvers/prop/cover_goals.h>
 #include <solvers/prop/literal_expr.h>
@@ -115,7 +116,7 @@ public:
   {
     bool first=true;
     std::string test;
-    for(const auto &step : goto_trace.steps)
+    for(const auto &step : make_dereference_facade(goto_trace.steps))
     {
       if(step.is_input())
       {
@@ -174,13 +175,12 @@ void bmc_covert::satisfying_assignment()
   goto_tracet &goto_trace=test.goto_trace;
 
   // Now delete anything after first failed assumption
-  for(goto_tracet::stepst::iterator
-      s_it1=goto_trace.steps.begin();
-      s_it1!=goto_trace.steps.end();
+  for(auto s_it1 = make_dereference_iterator(goto_trace.steps.begin());
+      s_it1 != goto_trace.steps.end();
       s_it1++)
     if(s_it1->is_assume() && !s_it1->cond_value)
     {
-      goto_trace.steps.erase(++s_it1, goto_trace.steps.end());
+      goto_trace.steps.erase(++s_it1.base(), goto_trace.steps.end());
       break;
     }
 }
@@ -320,7 +320,7 @@ bool bmc_covert::operator()()
         {
           xmlt &xml_test=xml_result.new_element("inputs");
 
-          for(const auto &step : test.goto_trace.steps)
+          for(const auto &step : make_dereference_facade(test.goto_trace.steps))
           {
             if(step.is_input())
             {
@@ -376,7 +376,7 @@ bool bmc_covert::operator()()
         {
           json_arrayt &json_test=result["inputs"].make_array();
 
-          for(const auto &step : test.goto_trace.steps)
+          for(const auto &step : make_dereference_facade(test.goto_trace.steps))
           {
             if(step.is_input())
             {

--- a/src/cbmc/counterexample_beautification.cpp
+++ b/src/cbmc/counterexample_beautification.cpp
@@ -26,9 +26,9 @@ void counterexample_beautificationt::get_minimization_list(
 {
   // ignore the ones that are assigned under false guards
 
-  for(symex_target_equationt::SSA_stepst::const_iterator
-      it=equation.SSA_steps.begin();
-      it!=equation.SSA_steps.end(); it++)
+  for(auto it = make_dereference_iterator(equation.SSA_steps.begin());
+      it != equation.SSA_steps.end();
+      it++)
   {
     if(it->is_assignment() &&
        it->assignment_type==symex_targett::assignment_typet::STATE)
@@ -59,23 +59,23 @@ void counterexample_beautificationt::get_minimization_list(
   }
 }
 
-symex_target_equationt::SSA_stepst::const_iterator
+dereference_iteratort<symex_target_equationt::SSA_stepst::const_iterator>
 counterexample_beautificationt::get_failed_property(
   const prop_convt &prop_conv,
   const symex_target_equationt &equation)
 {
   // find failed property
 
-  for(symex_target_equationt::SSA_stepst::const_iterator
-      it=equation.SSA_steps.begin();
-      it!=equation.SSA_steps.end(); it++)
+  for(auto it = make_dereference_iterator(equation.SSA_steps.begin());
+      it != equation.SSA_steps.end();
+      it++)
     if(it->is_assert() &&
        prop_conv.l_get(it->guard_literal).is_true() &&
        prop_conv.l_get(it->cond_literal).is_false())
       return it;
 
   UNREACHABLE;
-  return equation.SSA_steps.end();
+  return make_dereference_iterator(equation.SSA_steps.end());
 }
 
 void counterexample_beautificationt::operator()(
@@ -98,9 +98,9 @@ void counterexample_beautificationt::operator()(
     typedef std::map<literalt, unsigned> guard_countt;
     guard_countt guard_count;
 
-    for(symex_target_equationt::SSA_stepst::const_iterator
-        it=equation.SSA_steps.begin();
-        it!=equation.SSA_steps.end(); it++)
+    for(auto it = make_dereference_iterator(equation.SSA_steps.begin());
+        it != equation.SSA_steps.end();
+        it++)
     {
       if(it->is_assignment() &&
          it->assignment_type!=symex_targett::assignment_typet::HIDDEN)

--- a/src/cbmc/counterexample_beautification.h
+++ b/src/cbmc/counterexample_beautification.h
@@ -42,12 +42,14 @@ protected:
     const exprt &expr,
     class prop_minimizet &prop_minimize);
 
-  symex_target_equationt::SSA_stepst::const_iterator get_failed_property(
+  dereference_iteratort<symex_target_equationt::SSA_stepst::const_iterator>
+  get_failed_property(
     const prop_convt &prop_conv,
     const symex_target_equationt &equation);
 
   // the failed property
-  symex_target_equationt::SSA_stepst::const_iterator failed;
+  dereference_iteratort<symex_target_equationt::SSA_stepst::const_iterator>
+    failed;
 };
 
 #endif // CPROVER_CBMC_COUNTEREXAMPLE_BEAUTIFICATION_H

--- a/src/cbmc/fault_localization.cpp
+++ b/src/cbmc/fault_localization.cpp
@@ -29,7 +29,7 @@ Author: Peter Schrammel
 
 void fault_localizationt::freeze_guards()
 {
-  for(const auto &step : bmc.equation.SSA_steps)
+  for(const auto &step : make_dereference_facade(bmc.equation.SSA_steps))
   {
     if(!step.guard_literal.is_constant())
       bmc.prop_conv.set_frozen(step.guard_literal);
@@ -41,9 +41,9 @@ void fault_localizationt::freeze_guards()
 
 void fault_localizationt::collect_guards(lpointst &lpoints)
 {
-  for(symex_target_equationt::SSA_stepst::const_iterator
-      it=bmc.equation.SSA_steps.begin();
-      it!=bmc.equation.SSA_steps.end(); it++)
+  for(auto it = make_dereference_iterator(bmc.equation.SSA_steps.begin());
+      it != bmc.equation.SSA_steps.end();
+      it++)
   {
     if(it->is_assignment() &&
        it->assignment_type==symex_targett::assignment_typet::STATE &&
@@ -62,19 +62,19 @@ void fault_localizationt::collect_guards(lpointst &lpoints)
   }
 }
 
-symex_target_equationt::SSA_stepst::const_iterator
+dereference_iteratort<symex_target_equationt::SSA_stepst::const_iterator>
 fault_localizationt::get_failed_property()
 {
-  for(symex_target_equationt::SSA_stepst::const_iterator
-      it=bmc.equation.SSA_steps.begin();
-      it!=bmc.equation.SSA_steps.end(); it++)
+  for(auto it = make_dereference_iterator(bmc.equation.SSA_steps.begin());
+      it != bmc.equation.SSA_steps.end();
+      it++)
     if(it->is_assert() &&
        bmc.prop_conv.l_get(it->guard_literal).is_true() &&
        bmc.prop_conv.l_get(it->cond_literal).is_false())
       return it;
 
   UNREACHABLE;
-  return bmc.equation.SSA_steps.end();
+  return make_dereference_iterator(bmc.equation.SSA_steps.end());
 }
 
 bool fault_localizationt::check(const lpointst &lpoints,
@@ -331,12 +331,12 @@ void fault_localizationt::goal_covered(
     // check whether failed
     for(auto &inst : goal_pair.second.instances)
     {
-      literalt cond=inst->cond_literal;
+      literalt cond = (*inst)->cond_literal;
 
       if(solver.l_get(cond).is_false())
       {
         goal_pair.second.status=goalt::statust::FAILURE;
-        symex_target_equationt::SSA_stepst::iterator next=inst;
+        auto next = inst;
         next++; // include the assertion
         build_goto_trace(
           bmc.equation, next, solver, bmc.ns, goal_pair.second.goto_trace);

--- a/src/cbmc/fault_localization.h
+++ b/src/cbmc/fault_localization.h
@@ -50,7 +50,8 @@ protected:
   const optionst &options;
 
   // the failed property
-  symex_target_equationt::SSA_stepst::const_iterator failed;
+  dereference_iteratort<symex_target_equationt::SSA_stepst::const_iterator>
+    failed;
 
   // the list of localization points up to the failed property
   struct lpointt
@@ -82,7 +83,8 @@ protected:
   // void localize_TBD(
   //  prop_convt &prop_conv);
 
-  symex_target_equationt::SSA_stepst::const_iterator get_failed_property();
+  dereference_iteratort<symex_target_equationt::SSA_stepst::const_iterator>
+  get_failed_property();
 
   decision_proceduret::resultt
     run_decision_procedure(prop_convt &prop_conv);

--- a/src/cbmc/show_vcc.cpp
+++ b/src/cbmc/show_vcc.cpp
@@ -26,9 +26,8 @@ void bmct::show_vcc_plain(std::ostream &out)
 
   bool has_threads=equation.has_threads();
 
-  for(symex_target_equationt::SSA_stepst::iterator
-      s_it=equation.SSA_steps.begin();
-      s_it!=equation.SSA_steps.end();
+  for(auto s_it = make_dereference_iterator(equation.SSA_steps.begin());
+      s_it != equation.SSA_steps.end();
       s_it++)
   {
     if(!s_it->is_assert())
@@ -40,12 +39,11 @@ void bmct::show_vcc_plain(std::ostream &out)
     if(s_it->comment!="")
       out << s_it->comment << "\n";
 
-    symex_target_equationt::SSA_stepst::const_iterator
-      p_it=equation.SSA_steps.begin();
+    auto p_it = make_dereference_iterator(equation.SSA_steps.begin());
 
     // we show everything in case there are threads
-    symex_target_equationt::SSA_stepst::const_iterator
-      last_it=has_threads?equation.SSA_steps.end():s_it;
+    auto last_it =
+      has_threads ? make_dereference_iterator(equation.SSA_steps.end()) : s_it;
 
     for(std::size_t count=1; p_it!=last_it; p_it++)
       if(p_it->is_assume() || p_it->is_assignment() || p_it->is_constraint())
@@ -84,9 +82,8 @@ void bmct::show_vcc_json(std::ostream &out)
 
   bool has_threads=equation.has_threads();
 
-  for(symex_target_equationt::SSA_stepst::iterator
-      s_it=equation.SSA_steps.begin();
-      s_it!=equation.SSA_steps.end();
+  for(auto s_it = make_dereference_iterator(equation.SSA_steps.begin());
+      s_it != equation.SSA_steps.end();
       s_it++)
   {
     if(!s_it->is_assert())
@@ -104,14 +101,14 @@ void bmct::show_vcc_json(std::ostream &out)
       object["comment"]=json_stringt(s);
 
     // we show everything in case there are threads
-    symex_target_equationt::SSA_stepst::const_iterator
-      last_it=has_threads?equation.SSA_steps.end():s_it;
+    auto last_it =
+      has_threads ? make_dereference_iterator(equation.SSA_steps.end()) : s_it;
 
     json_arrayt &json_constraints=object["constraints"].make_array();
 
-    for(symex_target_equationt::SSA_stepst::const_iterator p_it
-          =equation.SSA_steps.begin();
-        p_it!=last_it; p_it++)
+    for(auto p_it = make_dereference_iterator(equation.SSA_steps.begin());
+        p_it != last_it;
+        p_it++)
     {
       if((p_it->is_assume() ||
          p_it->is_assignment() ||

--- a/src/goto-programs/goto_trace.cpp
+++ b/src/goto-programs/goto_trace.cpp
@@ -18,6 +18,7 @@ Author: Daniel Kroening
 
 #include <util/arith_tools.h>
 #include <util/symbol.h>
+#include <util/dereference_iterator.h>
 
 #include <ansi-c/printf_formatter.h>
 #include <langapi/language_util.h>
@@ -26,7 +27,7 @@ void goto_tracet::output(
   const class namespacet &ns,
   std::ostream &out) const
 {
-  for(const auto &step : steps)
+  for(const auto &step : make_dereference_facade(steps))
     step.output(ns, out);
 }
 
@@ -249,7 +250,7 @@ void show_goto_trace(
   unsigned prev_step_nr=0;
   bool first_step=true;
 
-  for(const auto &step : goto_trace.steps)
+  for(const auto &step : make_dereference_facade(goto_trace.steps))
   {
     // hide the hidden ones
     if(step.hidden)

--- a/src/goto-programs/goto_trace.h
+++ b/src/goto-programs/goto_trace.h
@@ -151,7 +151,7 @@ public:
 class goto_tracet
 {
 public:
-  typedef std::list<goto_trace_stept> stepst;
+  typedef std::list<std::unique_ptr<goto_trace_stept>> stepst;
   stepst steps;
 
   irep_idt mode;
@@ -174,16 +174,17 @@ public:
     other.mode.swap(mode);
   }
 
-  void add_step(const goto_trace_stept &step)
+  void add_step(std::unique_ptr<goto_trace_stept> step)
   {
-    steps.push_back(step);
+    steps.push_back(std::move(step));
   }
 
   // retrieves the final step in the trace for manipulation
   // (used to fill a trace from code, hence non-const)
-  inline goto_trace_stept &get_last_step()
+  // We return a non-owning pointer to help ensure the object is not sliced
+  inline goto_trace_stept *get_last_step()
   {
-    return steps.back();
+    return steps.back().get();
   }
 
   // delete all steps after (not including) s

--- a/src/goto-programs/goto_trace.h
+++ b/src/goto-programs/goto_trace.h
@@ -151,6 +151,21 @@ public:
 class goto_tracet
 {
 public:
+  goto_tracet() = default;
+  goto_tracet(const goto_tracet &) = delete;
+  goto_tracet &operator=(const goto_tracet &) = delete;
+
+  goto_tracet(goto_tracet &&other)
+    : steps(std::move(other.steps)), mode(std::move(other.mode))
+  {
+  }
+
+  goto_tracet &operator=(goto_tracet &&other)
+  {
+    swap(other);
+    return *this;
+  }
+
   typedef std::list<std::unique_ptr<goto_trace_stept>> stepst;
   stepst steps;
 

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -17,6 +17,7 @@ Author: Daniel Kroening
 #include <util/arith_tools.h>
 #include <util/prefix.h>
 #include <util/ssa_expr.h>
+#include <util/dereference_iterator.h>
 
 void graphml_witnesst::remove_l0_l1(exprt &expr)
 {
@@ -137,8 +138,8 @@ std::string graphml_witnesst::convert_assign_rec(
 
 static bool filter_out(
   const goto_tracet &goto_trace,
-  const goto_tracet::stepst::const_iterator &prev_it,
-  goto_tracet::stepst::const_iterator &it)
+  const dereference_iteratort<goto_tracet::stepst::const_iterator> &prev_it,
+  dereference_iteratort<goto_tracet::stepst::const_iterator> &it)
 {
   if(it->hidden &&
      (!it->pc->is_assign() ||
@@ -184,10 +185,9 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
   // step numbers start at 1
   std::vector<std::size_t> step_to_node(goto_trace.steps.size()+1, 0);
 
-  goto_tracet::stepst::const_iterator prev_it=goto_trace.steps.end();
-  for(goto_tracet::stepst::const_iterator
-      it=goto_trace.steps.begin();
-      it!=goto_trace.steps.end();
+  auto prev_it = make_dereference_iterator(goto_trace.steps.end());
+  for(auto it = make_dereference_iterator(goto_trace.steps.begin());
+      it != goto_trace.steps.end();
       it++) // we cannot replace this by a ranged for
   {
     if(filter_out(goto_trace, prev_it, it))
@@ -198,7 +198,7 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
     }
 
     // skip declarations followed by an immediate assignment
-    goto_tracet::stepst::const_iterator next=it;
+    auto next = it;
     ++next;
     if(next!=goto_trace.steps.end() &&
        next->type==goto_trace_stept::typet::ASSIGNMENT &&
@@ -228,10 +228,8 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
   }
 
   // build edges
-  for(goto_tracet::stepst::const_iterator
-      it=goto_trace.steps.begin();
-      it!=goto_trace.steps.end();
-      ) // no ++it
+  for(auto it = make_dereference_iterator(goto_trace.steps.begin());
+      it != goto_trace.steps.end();) // no ++it
   {
     const std::size_t from=step_to_node[it->step_nr];
 
@@ -241,7 +239,7 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
       continue;
     }
 
-    goto_tracet::stepst::const_iterator next=it;
+    auto next = it;
     for(++next;
         next!=goto_trace.steps.end() &&
         (step_to_node[next->step_nr]==sink || it->pc==next->pc);

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -367,9 +367,8 @@ void graphml_witnesst::operator()(const symex_target_equationt &equation)
   std::vector<std::size_t> step_to_node(equation.SSA_steps.size()+1, 0);
 
   std::size_t step_nr=1;
-  for(symex_target_equationt::SSA_stepst::const_iterator
-      it=equation.SSA_steps.begin();
-      it!=equation.SSA_steps.end();
+  for(auto it = make_dereference_iterator(equation.SSA_steps.begin());
+      it != equation.SSA_steps.end();
       it++, step_nr++) // we cannot replace this by a ranged for
   {
     const source_locationt &source_location=it->source.pc->source_location;
@@ -387,7 +386,7 @@ void graphml_witnesst::operator()(const symex_target_equationt &equation)
     }
 
     // skip declarations followed by an immediate assignment
-    symex_target_equationt::SSA_stepst::const_iterator next=it;
+    auto next = it;
     ++next;
     if(next!=equation.SSA_steps.end() &&
        next->is_assignment() &&
@@ -414,10 +413,8 @@ void graphml_witnesst::operator()(const symex_target_equationt &equation)
 
   // build edges
   step_nr=1;
-  for(symex_target_equationt::SSA_stepst::const_iterator
-      it=equation.SSA_steps.begin();
-      it!=equation.SSA_steps.end();
-      ) // no ++it
+  for(auto it = make_dereference_iterator(equation.SSA_steps.begin());
+      it != equation.SSA_steps.end();) // no ++it
   {
     const std::size_t from=step_to_node[step_nr];
 
@@ -428,7 +425,7 @@ void graphml_witnesst::operator()(const symex_target_equationt &equation)
       continue;
     }
 
-    symex_target_equationt::SSA_stepst::const_iterator next=it;
+    auto next = it;
     std::size_t next_step_nr=step_nr;
     for(++next, ++next_step_nr;
         next!=equation.SSA_steps.end() &&

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -25,6 +25,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/fixedbv.h>
 #include <util/std_expr.h>
 #include <util/message.h>
+#include <util/make_unique.h>
+
 #include <json/json_parser.h>
 
 #include "interpreter_class.h"
@@ -247,8 +249,8 @@ void interpretert::step()
   next_pc=pc;
   next_pc++;
 
-  steps.add_step(goto_trace_stept());
-  goto_trace_stept &trace_step=steps.get_last_step();
+  steps.add_step(util_make_unique<goto_trace_stept>());
+  goto_trace_stept &trace_step = *steps.get_last_step();
   trace_step.thread_nr=thread_id;
   trace_step.pc=pc;
   switch(pc->type)
@@ -671,7 +673,7 @@ void interpretert::execute_assign()
               << eom;
     else
     {
-      goto_trace_stept &trace_step=steps.get_last_step();
+      goto_trace_stept &trace_step = *steps.get_last_step();
       assign(address, rhs);
       trace_step.full_lhs=code_assign.lhs();
 
@@ -764,7 +766,7 @@ void interpretert::execute_function_call()
 
   // Retrieve the empty last trace step struct we pushed for this step
   // of the interpreter run to fill it with the corresponding data
-  goto_trace_stept &trace_step=steps.get_last_step();
+  goto_trace_stept &trace_step = *steps.get_last_step();
 #if 0
   const memory_cellt &cell=memory[address];
 #endif

--- a/src/goto-programs/json_goto_trace.cpp
+++ b/src/goto-programs/json_goto_trace.cpp
@@ -18,6 +18,7 @@ Author: Daniel Kroening
 #include <util/config.h>
 #include <util/invariant.h>
 #include <util/simplify_expr.h>
+#include <util/dereference_iterator.h>
 
 #include <langapi/language_util.h>
 
@@ -35,7 +36,7 @@ void convert(
 
   source_locationt previous_source_location;
 
-  for(const auto &step : goto_trace.steps)
+  for(const auto &step : make_dereference_facade(goto_trace.steps))
   {
     const source_locationt &source_location=step.pc->source_location;
 

--- a/src/goto-programs/vcd_goto_trace.cpp
+++ b/src/goto-programs/vcd_goto_trace.cpp
@@ -20,6 +20,7 @@ Date: June 2011
 #include <util/arith_tools.h>
 #include <util/pointer_offset_size.h>
 #include <util/numbering.h>
+#include <util/dereference_iterator.h>
 
 std::string as_vcd_binary(
   const exprt &expr,
@@ -97,7 +98,7 @@ void output_vcd(
 
   numbering<irep_idt> n;
 
-  for(const auto &step : goto_trace.steps)
+  for(const auto &step : make_dereference_facade(goto_trace.steps))
   {
     if(step.is_assignment())
     {
@@ -124,7 +125,7 @@ void output_vcd(
 
   unsigned timestamp=0;
 
-  for(const auto &step : goto_trace.steps)
+  for(const auto &step : make_dereference_facade(goto_trace.steps))
   {
     switch(step.type)
     {

--- a/src/goto-programs/xml_goto_trace.cpp
+++ b/src/goto-programs/xml_goto_trace.cpp
@@ -17,6 +17,7 @@ Author: Daniel Kroening
 
 #include <util/xml_expr.h>
 #include <util/symbol.h>
+#include <util/dereference_iterator.h>
 
 #include <ansi-c/printf_formatter.h>
 #include <langapi/language_util.h>
@@ -30,7 +31,7 @@ void convert(
 
   source_locationt previous_source_location;
 
-  for(const auto &step : goto_trace.steps)
+  for(const auto &step : make_dereference_facade(goto_trace.steps))
   {
     const source_locationt &source_location=step.pc->source_location;
 

--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -190,9 +190,8 @@ void build_goto_trace(
   const goto_trace_stept *end_ptr=nullptr;
   bool end_step_seen=false;
 
-  for(symex_target_equationt::SSA_stepst::const_iterator
-      it=target.SSA_steps.begin();
-      it!=target.SSA_steps.end();
+  for(auto it = make_dereference_iterator(target.SSA_steps.begin());
+      it != target.SSA_steps.end();
       it++)
   {
     if(it==end_step)

--- a/src/goto-symex/memory_model_sc.cpp
+++ b/src/goto-symex/memory_model_sc.cpp
@@ -48,9 +48,8 @@ void memory_model_sct::build_per_thread_map(
 {
   // this orders the events within a thread
 
-  for(eventst::const_iterator
-      e_it=equation.SSA_steps.begin();
-      e_it!=equation.SSA_steps.end();
+  for(auto e_it = make_dereference_iterator(equation.SSA_steps.begin());
+      e_it != equation.SSA_steps.end();
       e_it++)
   {
     // concurrency-related?
@@ -71,9 +70,8 @@ void memory_model_sct::thread_spawn(
   // instruction of the new thread in program order
 
   unsigned next_thread_id=0;
-  for(eventst::const_iterator
-      e_it=equation.SSA_steps.begin();
-      e_it!=equation.SSA_steps.end();
+  for(auto e_it = make_dereference_iterator(equation.SSA_steps.begin());
+      e_it != equation.SSA_steps.end();
       e_it++)
   {
     if(e_it->is_spawn())
@@ -165,7 +163,7 @@ void memory_model_sct::program_order(
 
     // iterate over relevant events in the thread
 
-    event_it previous=equation.SSA_steps.end();
+    event_it previous = make_dereference_iterator(equation.SSA_steps.end());
 
     for(event_listt::const_iterator
         e_it=events.begin();

--- a/src/goto-symex/partial_order_concurrency.cpp
+++ b/src/goto-symex/partial_order_concurrency.cpp
@@ -15,6 +15,7 @@ Author: Michael Tautschnig, michael.tautschnig@cs.ox.ac.uk
 
 #include <util/arith_tools.h>
 #include <util/simplify_expr.h>
+#include <util/make_unique.h>
 
 partial_order_concurrencyt::partial_order_concurrencyt(
   const namespacet &_ns):ns(_ns)
@@ -33,9 +34,8 @@ void partial_order_concurrencyt::add_init_writes(
 
   symex_target_equationt::SSA_stepst init_steps;
 
-  for(eventst::const_iterator
-      e_it=equation.SSA_steps.begin();
-      e_it!=equation.SSA_steps.end();
+  for(auto e_it = make_dereference_iterator(equation.SSA_steps.begin());
+      e_it != equation.SSA_steps.end();
       e_it++)
   {
     if(e_it->is_spawn())
@@ -56,8 +56,9 @@ void partial_order_concurrencyt::add_init_writes(
        e_it->is_shared_read() ||
        !e_it->guard.is_true())
     {
-      init_steps.push_back(symex_target_equationt::SSA_stept());
-      symex_target_equationt::SSA_stept &SSA_step=init_steps.back();
+      init_steps.push_back(
+        util_make_unique<symex_target_equationt::SSA_stept>());
+      symex_target_equationt::SSA_stept &SSA_step = *init_steps.back();
 
       SSA_step.guard=true_exprt();
       // no SSA L2 index, thus nondet value
@@ -82,9 +83,8 @@ void partial_order_concurrencyt::build_event_lists(
   // a per-thread counter
   std::map<unsigned, unsigned> counter;
 
-  for(eventst::const_iterator
-      e_it=equation.SSA_steps.begin();
-      e_it!=equation.SSA_steps.end();
+  for(auto e_it = make_dereference_iterator(equation.SSA_steps.begin());
+      e_it != equation.SSA_steps.end();
       e_it++)
   {
     if(e_it->is_shared_read() ||

--- a/src/goto-symex/partial_order_concurrency.h
+++ b/src/goto-symex/partial_order_concurrency.h
@@ -13,6 +13,7 @@ Author: Michael Tautschnig, michael.tautschnig@cs.ox.ac.uk
 #define CPROVER_GOTO_SYMEX_PARTIAL_ORDER_CONCURRENCY_H
 
 #include <util/message.h>
+#include <util/dereference_iterator.h>
 
 #include "symex_target_equation.h"
 
@@ -24,7 +25,7 @@ public:
 
   typedef symex_target_equationt::SSA_stept eventt;
   typedef symex_target_equationt::SSA_stepst eventst;
-  typedef eventst::const_iterator event_it;
+  typedef dereference_iteratort<eventst::const_iterator> event_it;
 
   // the name of a clock variable for a shared read/write
   enum axiomt

--- a/src/goto-symex/postcondition.cpp
+++ b/src/goto-symex/postcondition.cpp
@@ -54,9 +54,8 @@ void postcondition(
   const goto_symex_statet &s,
   exprt &dest)
 {
-  for(symex_target_equationt::SSA_stepst::const_iterator
-      it=equation.SSA_steps.begin();
-      it!=equation.SSA_steps.end();
+  for(auto it = make_dereference_iterator(equation.SSA_steps.begin());
+      it != equation.SSA_steps.end();
       it++)
   {
     postconditiont postcondition(ns, value_set, *it, s);

--- a/src/goto-symex/precondition.cpp
+++ b/src/goto-symex/precondition.cpp
@@ -58,9 +58,8 @@ void precondition(
   const goto_symex_statet &s,
   exprt &dest)
 {
-  for(symex_target_equationt::SSA_stepst::const_reverse_iterator
-      it=equation.SSA_steps.rbegin();
-      it!=equation.SSA_steps.rend();
+  for(auto it = make_dereference_iterator(equation.SSA_steps.rbegin());
+      it != equation.SSA_steps.rend();
       it++)
   {
     preconditiont precondition(ns, value_sets, target, *it, s);

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "slice.h"
 
 #include <util/std_expr.h>
+#include <util/dereference_iterator.h>
 
 #include "symex_slice_class.h"
 
@@ -44,9 +45,8 @@ void symex_slicet::slice(
 
 void symex_slicet::slice(symex_target_equationt &equation)
 {
-  for(symex_target_equationt::SSA_stepst::reverse_iterator
-      it=equation.SSA_steps.rbegin();
-      it!=equation.SSA_steps.rend();
+  for(auto it = make_dereference_iterator(equation.SSA_steps.rbegin());
+      it != equation.SSA_steps.rend();
       it++)
     slice(*it);
 }
@@ -148,9 +148,8 @@ void symex_slicet::collect_open_variables(
 {
   symbol_sett lhs;
 
-  for(symex_target_equationt::SSA_stepst::const_iterator
-      it=equation.SSA_steps.begin();
-      it!=equation.SSA_steps.end();
+  for(auto it = make_dereference_iterator(equation.SSA_steps.begin());
+      it != equation.SSA_steps.end();
       it++)
   {
     const symex_target_equationt::SSA_stept &SSA_step=*it;
@@ -239,20 +238,17 @@ void slice(symex_target_equationt &equation,
 void simple_slice(symex_target_equationt &equation)
 {
   // just find the last assertion
-  symex_target_equationt::SSA_stepst::iterator
-    last_assertion=equation.SSA_steps.end();
+  auto last_assertion = make_dereference_iterator(equation.SSA_steps.end());
 
-  for(symex_target_equationt::SSA_stepst::iterator
-      it=equation.SSA_steps.begin();
-      it!=equation.SSA_steps.end();
+  for(auto it = make_dereference_iterator(equation.SSA_steps.begin());
+      it != equation.SSA_steps.end();
       it++)
     if(it->is_assert())
       last_assertion=it;
 
   // slice away anything after it
 
-  symex_target_equationt::SSA_stepst::iterator s_it=
-    last_assertion;
+  auto s_it = last_assertion;
 
   if(s_it!=equation.SSA_steps.end())
   {

--- a/src/goto-symex/slice_by_trace.cpp
+++ b/src/goto-symex/slice_by_trace.cpp
@@ -21,6 +21,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/arith_tools.h>
 #include <util/std_expr.h>
 #include <util/guard.h>
+#include <util/make_unique.h>
+#include <util/dereference_iterator.h>
 
 #include <langapi/language_util.h>
 
@@ -104,8 +106,9 @@ void symex_slice_by_tracet::slice_by_trace(
   guardt t_guard;
   t_guard.make_true();
   symex_targett::sourcet empty_source;
-  equation.SSA_steps.push_front(symex_target_equationt::SSA_stept());
-  symex_target_equationt::SSA_stept &SSA_step=equation.SSA_steps.front();
+  equation.SSA_steps.push_front(
+    util_make_unique<symex_target_equationt::SSA_stept>());
+  symex_target_equationt::SSA_stept &SSA_step = *equation.SSA_steps.front();
 
   SSA_step.guard=t_guard.as_expr();
   SSA_step.ssa_lhs.make_nil();
@@ -236,9 +239,8 @@ void symex_slice_by_tracet::compute_ts_back(
 {
   size_t merge_count=0;
 
-  for(symex_target_equationt::SSA_stepst::reverse_iterator
-      i=equation.SSA_steps.rbegin();
-      i!=equation.SSA_steps.rend();
+  for(auto i = make_dereference_iterator(equation.SSA_steps.rbegin());
+      i != equation.SSA_steps.rend();
       i++)
   {
     if(i->is_output() &&
@@ -391,9 +393,8 @@ void symex_slice_by_tracet::slice_SSA_steps(
   size_t location_SSA_steps=0;
   size_t trace_loc_sliced=0;
 
-  for(symex_target_equationt::SSA_stepst::iterator
-      it=equation.SSA_steps.begin();
-      it!=equation.SSA_steps.end();
+  for(auto it = make_dereference_iterator(equation.SSA_steps.begin());
+      it != equation.SSA_steps.end();
       it++)
   {
     if(it->is_output())
@@ -519,8 +520,9 @@ void symex_slice_by_tracet::assign_merges(
 
     exprt merge_copy(*i);
 
-    equation.SSA_steps.push_front(symex_target_equationt::SSA_stept());
-    symex_target_equationt::SSA_stept &SSA_step=equation.SSA_steps.front();
+    equation.SSA_steps.push_front(
+      util_make_unique<symex_target_equationt::SSA_stept>());
+    symex_target_equationt::SSA_stept &SSA_step = *equation.SSA_steps.front();
 
     SSA_step.guard=t_guard.as_expr();
     SSA_step.ssa_lhs=merge_sym;

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -38,8 +38,8 @@ void symex_target_equationt::shared_read(
   unsigned atomic_section_id,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
-  SSA_stept &SSA_step=SSA_steps.back();
+  SSA_steps.push_back(util_make_unique<SSA_stept>());
+  SSA_stept &SSA_step = *SSA_steps.back();
 
   SSA_step.guard=guard;
   SSA_step.ssa_lhs=ssa_object;
@@ -57,8 +57,8 @@ void symex_target_equationt::shared_write(
   unsigned atomic_section_id,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
-  SSA_stept &SSA_step=SSA_steps.back();
+  SSA_steps.push_back(util_make_unique<SSA_stept>());
+  SSA_stept &SSA_step = *SSA_steps.back();
 
   SSA_step.guard=guard;
   SSA_step.ssa_lhs=ssa_object;
@@ -74,8 +74,8 @@ void symex_target_equationt::spawn(
   const exprt &guard,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
-  SSA_stept &SSA_step=SSA_steps.back();
+  SSA_steps.push_back(util_make_unique<SSA_stept>());
+  SSA_stept &SSA_step = *SSA_steps.back();
   SSA_step.guard=guard;
   SSA_step.type=goto_trace_stept::typet::SPAWN;
   SSA_step.source=source;
@@ -87,8 +87,8 @@ void symex_target_equationt::memory_barrier(
   const exprt &guard,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
-  SSA_stept &SSA_step=SSA_steps.back();
+  SSA_steps.push_back(util_make_unique<SSA_stept>());
+  SSA_stept &SSA_step = *SSA_steps.back();
   SSA_step.guard=guard;
   SSA_step.type=goto_trace_stept::typet::MEMORY_BARRIER;
   SSA_step.source=source;
@@ -102,8 +102,8 @@ void symex_target_equationt::atomic_begin(
   unsigned atomic_section_id,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
-  SSA_stept &SSA_step=SSA_steps.back();
+  SSA_steps.push_back(util_make_unique<SSA_stept>());
+  SSA_stept &SSA_step = *SSA_steps.back();
   SSA_step.guard=guard;
   SSA_step.type=goto_trace_stept::typet::ATOMIC_BEGIN;
   SSA_step.atomic_section_id=atomic_section_id;
@@ -118,8 +118,8 @@ void symex_target_equationt::atomic_end(
   unsigned atomic_section_id,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
-  SSA_stept &SSA_step=SSA_steps.back();
+  SSA_steps.push_back(util_make_unique<SSA_stept>());
+  SSA_stept &SSA_step = *SSA_steps.back();
   SSA_step.guard=guard;
   SSA_step.type=goto_trace_stept::typet::ATOMIC_END;
   SSA_step.atomic_section_id=atomic_section_id;
@@ -140,8 +140,8 @@ void symex_target_equationt::assignment(
 {
   assert(ssa_lhs.is_not_nil());
 
-  SSA_steps.push_back(SSA_stept());
-  SSA_stept &SSA_step=SSA_steps.back();
+  SSA_steps.push_back(util_make_unique<SSA_stept>());
+  SSA_stept &SSA_step = *SSA_steps.back();
 
   SSA_step.guard=guard;
   SSA_step.ssa_lhs=ssa_lhs;
@@ -168,8 +168,8 @@ void symex_target_equationt::decl(
 {
   assert(ssa_lhs.is_not_nil());
 
-  SSA_steps.push_back(SSA_stept());
-  SSA_stept &SSA_step=SSA_steps.back();
+  SSA_steps.push_back(util_make_unique<SSA_stept>());
+  SSA_stept &SSA_step = *SSA_steps.back();
 
   SSA_step.guard=guard;
   SSA_step.ssa_lhs=ssa_lhs;
@@ -200,8 +200,8 @@ void symex_target_equationt::location(
   const exprt &guard,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
-  SSA_stept &SSA_step=SSA_steps.back();
+  SSA_steps.push_back(util_make_unique<SSA_stept>());
+  SSA_stept &SSA_step = *SSA_steps.back();
 
   SSA_step.guard=guard;
   SSA_step.type=goto_trace_stept::typet::LOCATION;
@@ -216,8 +216,8 @@ void symex_target_equationt::function_call(
   const irep_idt &identifier,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
-  SSA_stept &SSA_step=SSA_steps.back();
+  SSA_steps.push_back(util_make_unique<SSA_stept>());
+  SSA_stept &SSA_step = *SSA_steps.back();
 
   SSA_step.guard=guard;
   SSA_step.type=goto_trace_stept::typet::FUNCTION_CALL;
@@ -233,8 +233,8 @@ void symex_target_equationt::function_return(
   const irep_idt &identifier,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
-  SSA_stept &SSA_step=SSA_steps.back();
+  SSA_steps.push_back(util_make_unique<SSA_stept>());
+  SSA_stept &SSA_step = *SSA_steps.back();
 
   SSA_step.guard=guard;
   SSA_step.type=goto_trace_stept::typet::FUNCTION_RETURN;
@@ -251,8 +251,8 @@ void symex_target_equationt::output(
   const irep_idt &output_id,
   const std::list<exprt> &args)
 {
-  SSA_steps.push_back(SSA_stept());
-  SSA_stept &SSA_step=SSA_steps.back();
+  SSA_steps.push_back(util_make_unique<SSA_stept>());
+  SSA_stept &SSA_step = *SSA_steps.back();
 
   SSA_step.guard=guard;
   SSA_step.type=goto_trace_stept::typet::OUTPUT;
@@ -271,8 +271,8 @@ void symex_target_equationt::output_fmt(
   const irep_idt &fmt,
   const std::list<exprt> &args)
 {
-  SSA_steps.push_back(SSA_stept());
-  SSA_stept &SSA_step=SSA_steps.back();
+  SSA_steps.push_back(util_make_unique<SSA_stept>());
+  SSA_stept &SSA_step = *SSA_steps.back();
 
   SSA_step.guard=guard;
   SSA_step.type=goto_trace_stept::typet::OUTPUT;
@@ -292,8 +292,8 @@ void symex_target_equationt::input(
   const irep_idt &input_id,
   const std::list<exprt> &args)
 {
-  SSA_steps.push_back(SSA_stept());
-  SSA_stept &SSA_step=SSA_steps.back();
+  SSA_steps.push_back(util_make_unique<SSA_stept>());
+  SSA_stept &SSA_step = *SSA_steps.back();
 
   SSA_step.guard=guard;
   SSA_step.type=goto_trace_stept::typet::INPUT;
@@ -310,8 +310,8 @@ void symex_target_equationt::assumption(
   const exprt &cond,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
-  SSA_stept &SSA_step=SSA_steps.back();
+  SSA_steps.push_back(util_make_unique<SSA_stept>());
+  SSA_stept &SSA_step = *SSA_steps.back();
 
   SSA_step.guard=guard;
   SSA_step.cond_expr=cond;
@@ -328,8 +328,8 @@ void symex_target_equationt::assertion(
   const std::string &msg,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
-  SSA_stept &SSA_step=SSA_steps.back();
+  SSA_steps.push_back(util_make_unique<SSA_stept>());
+  SSA_stept &SSA_step = *SSA_steps.back();
 
   SSA_step.guard=guard;
   SSA_step.cond_expr=cond;
@@ -346,8 +346,8 @@ void symex_target_equationt::goto_instruction(
   const exprt &cond,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
-  SSA_stept &SSA_step=SSA_steps.back();
+  SSA_steps.push_back(util_make_unique<SSA_stept>());
+  SSA_stept &SSA_step = *SSA_steps.back();
 
   SSA_step.guard=guard;
   SSA_step.cond_expr=cond;
@@ -364,8 +364,8 @@ void symex_target_equationt::constraint(
   const sourcet &source)
 {
   // like assumption, but with global effect
-  SSA_steps.push_back(SSA_stept());
-  SSA_stept &SSA_step=SSA_steps.back();
+  SSA_steps.push_back(util_make_unique<SSA_stept>());
+  SSA_stept &SSA_step = *SSA_steps.back();
 
   SSA_step.guard=true_exprt();
   SSA_step.cond_expr=cond;
@@ -395,7 +395,7 @@ void symex_target_equationt::convert(
 void symex_target_equationt::convert_assignments(
   decision_proceduret &decision_procedure) const
 {
-  for(const auto &step : SSA_steps)
+  for(const auto &step : make_dereference_facade(SSA_steps))
   {
     if(step.is_assignment() && !step.ignore)
       decision_procedure.set_to_true(step.cond_expr);
@@ -407,7 +407,7 @@ void symex_target_equationt::convert_assignments(
 void symex_target_equationt::convert_decls(
   prop_convt &prop_conv) const
 {
-  for(const auto &step : SSA_steps)
+  for(const auto &step : make_dereference_facade(SSA_steps))
   {
     if(step.is_decl() && !step.ignore)
     {
@@ -423,7 +423,7 @@ void symex_target_equationt::convert_decls(
 void symex_target_equationt::convert_guards(
   prop_convt &prop_conv)
 {
-  for(auto &step : SSA_steps)
+  for(auto &step : make_dereference_facade(SSA_steps))
   {
     if(step.ignore)
       step.guard_literal=const_literal(false);
@@ -437,7 +437,7 @@ void symex_target_equationt::convert_guards(
 void symex_target_equationt::convert_assumptions(
   prop_convt &prop_conv)
 {
-  for(auto &step : SSA_steps)
+  for(auto &step : make_dereference_facade(SSA_steps))
   {
     if(step.is_assume())
     {
@@ -454,7 +454,7 @@ void symex_target_equationt::convert_assumptions(
 void symex_target_equationt::convert_goto_instructions(
   prop_convt &prop_conv)
 {
-  for(auto &step : SSA_steps)
+  for(auto &step : make_dereference_facade(SSA_steps))
   {
     if(step.is_goto())
     {
@@ -472,7 +472,7 @@ void symex_target_equationt::convert_goto_instructions(
 void symex_target_equationt::convert_constraints(
   decision_proceduret &decision_procedure) const
 {
-  for(const auto &step : SSA_steps)
+  for(const auto &step : make_dereference_facade(SSA_steps))
   {
     if(step.is_constraint())
     {
@@ -499,7 +499,7 @@ void symex_target_equationt::convert_assertions(
 
   if(number_of_assertions==1)
   {
-    for(auto &step : SSA_steps)
+    for(auto &step : make_dereference_facade(SSA_steps))
     {
       if(step.is_assert())
       {
@@ -521,7 +521,7 @@ void symex_target_equationt::convert_assertions(
 
   exprt assumption=true_exprt();
 
-  for(auto &step : SSA_steps)
+  for(auto &step : make_dereference_facade(SSA_steps))
   {
     if(step.is_assert())
     {
@@ -559,7 +559,7 @@ void symex_target_equationt::convert_io(
 {
   std::size_t io_count=0;
 
-  for(auto &step : SSA_steps)
+  for(auto &step : make_dereference_facade(SSA_steps))
     if(!step.ignore)
     {
       for(const auto &arg : step.io_args)
@@ -603,7 +603,7 @@ void symex_target_equationt::merge_ireps(SSA_stept &SSA_step)
 
 void symex_target_equationt::output(std::ostream &out) const
 {
-  for(const auto &step : SSA_steps)
+  for(const auto &step : make_dereference_facade(SSA_steps))
   {
     step.output(ns, out);
     out << "--------------\n";

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -35,6 +35,18 @@ public:
   explicit symex_target_equationt(const namespacet &_ns);
   virtual ~symex_target_equationt();
 
+  symex_target_equationt(const symex_target_equationt &) = delete;
+  symex_target_equationt &operator=(const symex_target_equationt &) = delete;
+
+  symex_target_equationt(symex_target_equationt &&other)
+    : SSA_steps(std::move(other.SSA_steps)),
+      ns(std::move(other.ns)),
+      merge_irep(std::move(other.merge_irep))
+  {
+  }
+
+  symex_target_equationt &operator=(symex_target_equationt &&other) = delete;
+
   // read event
   virtual void shared_read(
     const exprt &guard,

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <iosfwd>
 
 #include <util/merge_irep.h>
+#include <util/dereference_iterator.h>
 
 #include <goto-programs/goto_program.h>
 #include <goto-programs/goto_trace.h>
@@ -264,10 +265,8 @@ public:
   std::size_t count_assertions() const
   {
     std::size_t i=0;
-    for(SSA_stepst::const_iterator
-        it=SSA_steps.begin();
-        it!=SSA_steps.end(); it++)
-      if(it->is_assert())
+    for(const auto &it : make_dereference_facade(SSA_steps))
+      if(it.is_assert())
         i++;
     return i;
   }
@@ -275,15 +274,13 @@ public:
   std::size_t count_ignored_SSA_steps() const
   {
     std::size_t i=0;
-    for(SSA_stepst::const_iterator
-        it=SSA_steps.begin();
-        it!=SSA_steps.end(); it++)
-      if(it->ignore)
+    for(const auto &it : make_dereference_facade(SSA_steps))
+      if(it.ignore)
         i++;
     return i;
   }
 
-  typedef std::list<SSA_stept> SSA_stepst;
+  typedef std::list<std::unique_ptr<SSA_stept>> SSA_stepst;
   SSA_stepst SSA_steps;
 
   SSA_stepst::iterator get_SSA_step(std::size_t s)
@@ -306,10 +303,8 @@ public:
 
   bool has_threads() const
   {
-    for(SSA_stepst::const_iterator it=SSA_steps.begin();
-        it!=SSA_steps.end();
-        it++)
-      if(it->source.thread_nr!=0)
+    for(const auto &it : make_dereference_facade(SSA_steps))
+      if(it.source.thread_nr != 0)
         return true;
 
     return false;

--- a/src/util/dereference_iterator.h
+++ b/src/util/dereference_iterator.h
@@ -1,0 +1,67 @@
+/*******************************************************************\
+
+Module: Iterator utilities
+
+Author: @reuk
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_DEREFERENCE_ITERATOR_H
+#define CPROVER_UTIL_DEREFERENCE_ITERATOR_H
+
+#include "util/mapping_iterator.h"
+
+namespace detail // NOLINT
+{
+struct dereft final
+{
+  template <typename T>
+  decltype(*std::declval<T>()) operator()(T &t) const
+  {
+    return *t;
+  }
+};
+} // namespace detail
+
+template <typename It>
+using dereference_iteratort = mapping_iteratort<It, detail::dereft>; // NOLINT
+
+template <typename It>
+dereference_iteratort<It> make_dereference_iterator(It &&it)
+{
+  return dereference_iteratort<It>{std::forward<It>(it)};
+}
+
+template <typename T>
+class dereference_facadet final
+{
+public:
+  explicit dereference_facadet(T &t) : t_(t)
+  {
+  }
+
+  using iterator = dereference_iteratort<decltype(begin(std::declval<T>()))>;
+
+  iterator begin() const
+  {
+    using std::begin;
+    return iterator{begin(t_)};
+  }
+
+  iterator end() const
+  {
+    using std::end;
+    return iterator{end(t_)};
+  }
+
+private:
+  T &t_;
+};
+
+template <typename T>
+dereference_facadet<T> make_dereference_facade(T &t)
+{
+  return dereference_facadet<T>{t};
+}
+
+#endif

--- a/src/util/mapping_iterator.h
+++ b/src/util/mapping_iterator.h
@@ -1,0 +1,259 @@
+/*******************************************************************\
+
+Module: Iterator utilities
+
+Author: @reuk
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_MAPPING_ITERATOR_H
+#define CPROVER_UTIL_MAPPING_ITERATOR_H
+
+#include <iterator>
+#include <type_traits>
+
+/// Allows inline transformations on iterators.
+/// When the iterator is dereferenced, it is passed through a unary functor of
+/// some kind, and the returned value is the output of this functor.
+/// Useful for 'pipelining' operations on iterators, or for adapting ranges
+/// when passing them to methods in a way that doesn't require a new range to be
+/// allocated
+template <typename It, typename Mapper>
+class mapping_iteratort final
+{
+public:
+  using iterator_category =
+    typename std::iterator_traits<It>::iterator_category;
+
+  using value_type = decltype(std::declval<Mapper>()(*std::declval<It>()));
+  using difference_type = typename std::iterator_traits<It>::difference_type;
+  using reference = typename std::add_lvalue_reference<value_type>::type;
+  using pointer = typename std::add_pointer<reference>::type;
+
+  mapping_iteratort() = default;
+  explicit mapping_iteratort(It it) : it_(std::move(it))
+  {
+  }
+
+  explicit mapping_iteratort(It it, Mapper mapper)
+    : it_(std::move(it)), mapper_(std::move(mapper))
+  {
+  }
+
+  template <class U, class V>
+  mapping_iteratort(const mapping_iteratort<U, V> &other)
+    : it_(other.it_), mapper_(other.mapper_)
+  {
+  }
+
+  template <class U, class V>
+  void swap(mapping_iteratort<U, V> &other)
+  {
+    using std::swap;
+    swap(it_, other.it_);
+    swap(mapper_, other.mapper_);
+  }
+
+  template <class U, class V>
+  mapping_iteratort &operator=(mapping_iteratort<U, V> other)
+  {
+    swap(other);
+    return *this;
+  }
+
+  mapping_iteratort(const mapping_iteratort &other)
+    : it_(other.it_), mapper_(other.mapper_)
+  {
+  }
+
+  mapping_iteratort(mapping_iteratort &&other)
+    : it_(std::move(other.it_)), mapper_(std::move(other.mapper_))
+  {
+  }
+
+  mapping_iteratort &operator=(const mapping_iteratort &other)
+  {
+    auto copy = other;
+    swap(copy);
+    return *this;
+  }
+
+  mapping_iteratort &operator=(mapping_iteratort &&other)
+  {
+    swap(other);
+    return *this;
+  }
+
+  It base() const
+  {
+    return it_;
+  }
+
+  value_type operator*() const
+  {
+    return mapper_(*it_);
+  }
+
+  pointer operator->() const
+  {
+    return &mapper_(*it_);
+  }
+
+  value_type operator[](difference_type n) const
+  {
+    return mapper_(it_[n]);
+  }
+
+  mapping_iteratort &operator++()
+  {
+    ++it_;
+    return *this;
+  }
+  mapping_iteratort &operator--()
+  {
+    --it_;
+    return *this;
+  }
+
+  mapping_iteratort operator++(int)
+  {
+    return mapping_iteratort{it_++, mapper_};
+  }
+  mapping_iteratort operator--(int)
+  {
+    return mapping_iteratort{it_--, mapper_};
+  }
+
+  mapping_iteratort operator+(difference_type n) const
+  {
+    auto ret = *this;
+    return ret += n;
+  }
+  mapping_iteratort operator-(difference_type n) const
+  {
+    auto ret = *this;
+    return ret -= n;
+  }
+
+  mapping_iteratort &operator+=(difference_type n)
+  {
+    it_ += n;
+    return *this;
+  }
+
+  mapping_iteratort &operator-=(difference_type n)
+  {
+    it_ -= n;
+    return *this;
+  }
+
+private:
+  It it_;
+  Mapper mapper_;
+
+  template <typename U, typename V>
+  friend class mapping_iteratort;
+};
+
+template <class A, class B, class C, class D>
+bool operator==(
+  const mapping_iteratort<A, B> &lhs,
+  const mapping_iteratort<C, D> &rhs)
+{
+  return lhs.base() == rhs.base();
+}
+
+template <class A, class B, class C>
+bool operator==(const mapping_iteratort<A, B> &lhs, const C &rhs)
+{
+  return lhs.base() == rhs;
+}
+
+template <class A, class B, class C>
+bool operator==(const A &lhs, const mapping_iteratort<B, C> &rhs)
+{
+  return lhs == rhs.base();
+}
+
+template <class A, class B, class C, class D>
+bool operator!=(
+  const mapping_iteratort<A, B> &lhs,
+  const mapping_iteratort<C, D> &rhs)
+{
+  return lhs.base() != rhs.base();
+}
+
+template <class A, class B, class C>
+bool operator!=(const mapping_iteratort<A, B> &lhs, const C &rhs)
+{
+  return lhs.base() != rhs;
+}
+
+template <class A, class B, class C>
+bool operator!=(const A &lhs, const mapping_iteratort<B, C> &rhs)
+{
+  return lhs != rhs.base();
+}
+
+template <class A, class B, class C, class D>
+bool operator<(
+  const mapping_iteratort<A, B> &lhs,
+  const mapping_iteratort<C, D> &rhs)
+{
+  return lhs.base() < rhs.base();
+}
+
+template <class A, class B, class C, class D>
+bool operator<=(
+  const mapping_iteratort<A, B> &lhs,
+  const mapping_iteratort<C, D> &rhs)
+{
+  return lhs.base() <= rhs.base();
+}
+
+template <class A, class B, class C, class D>
+bool operator>(
+  const mapping_iteratort<A, B> &lhs,
+  const mapping_iteratort<C, D> &rhs)
+{
+  return lhs.base() > rhs.base();
+}
+
+template <class A, class B, class C, class D>
+bool operator>=(
+  const mapping_iteratort<A, B> &lhs,
+  const mapping_iteratort<C, D> &rhs)
+{
+  return lhs.base() >= rhs.base();
+}
+
+template <class U, class V>
+mapping_iteratort<U, V> operator+(
+  typename mapping_iteratort<U, V>::difference_type n,
+  const mapping_iteratort<U, V> &it)
+{
+  return it + n;
+}
+
+template <class U, class V>
+mapping_iteratort<U, V> operator-(
+  typename mapping_iteratort<U, V>::difference_type n,
+  const mapping_iteratort<U, V> &it)
+{
+  return it - n;
+}
+
+template <class U, class V>
+typename mapping_iteratort<U, V>::difference_type
+operator-(const mapping_iteratort<U, V> &a, const mapping_iteratort<U, V> &b)
+{
+  return a.base() - b.base();
+}
+
+template <class U, class V>
+mapping_iteratort<U, V> make_mapping_iterator(U &&it, V &&mapper)
+{
+  return mapping_iteratort<U, V>{std::forward<U>(it), std::forward<V>(mapper)};
+}
+
+#endif


### PR DESCRIPTION
Splits out the first part of #1570 into a bite-size and easily-digestible change. The idea, long-term, is to store the different kinds of goto instructions and SSA steps as discrete types. In order to do this, objects must be stored and accessed through a base class pointer. This is accomplished by changing collections of goto instructions and ssa steps to store unique_ptrs instead. The pointed-to types will become base classes in a future PR.