### PR TITLE
Constructed class to mimic the original class in all but name of symbol

### DIFF
--- a/src/java_bytecode/generate_java_generic_type.h
+++ b/src/java_bytecode/generate_java_generic_type.h
@@ -33,6 +33,14 @@ private:
     const java_generic_class_typet &replacement_type,
     const java_generic_typet &generic_reference) const;
 
+  java_class_typet construct_specialised_generic_type(
+    const java_generic_class_typet &generic_class_definition,
+    const irep_idt &new_tag,
+    const struct_typet::componentst &new_components) const;
+
+  type_symbolt build_symbol_from_specialised_class(
+    const java_class_typet &specialised_class) const;
+
   message_handlert &message_handler;
 };
 

--- a/unit/java_bytecode/generate_concrete_generic_type/generate_java_generic_type.cpp
+++ b/unit/java_bytecode/generate_concrete_generic_type/generate_java_generic_type.cpp
@@ -153,22 +153,22 @@ SCENARIO(
     REQUIRE(new_symbol_table.has_symbol(first_expected_symbol));
     auto first_symbol=new_symbol_table.lookup(first_expected_symbol);
     REQUIRE(first_symbol->type.id()==ID_struct);
-    auto first_symbol_type=
-      to_struct_type(first_symbol->type).components()[3].type();
-    REQUIRE(first_symbol_type.id()==ID_pointer);
-    REQUIRE(first_symbol_type.subtype().id()==ID_symbol);
-    REQUIRE(to_symbol_type(first_symbol_type.subtype()).get_identifier()==
-      "java::java.lang.Boolean");
+    const struct_union_typet::componentt &component =
+      require_type::require_component(
+        to_struct_type(first_symbol->type), "elem");
+    auto first_symbol_type=component.type();
+    require_type::require_pointer(
+      first_symbol_type, symbol_typet("java::java.lang.Boolean"));
 
     REQUIRE(new_symbol_table.has_symbol(second_expected_symbol));
     auto second_symbol=new_symbol_table.lookup(second_expected_symbol);
     REQUIRE(second_symbol->type.id()==ID_struct);
-    auto second_symbol_type=
-      to_struct_type(second_symbol->type).components()[3].type();
-    REQUIRE(second_symbol_type.id()==ID_pointer);
-    REQUIRE(second_symbol_type.subtype().id()==ID_symbol);
-    REQUIRE(to_symbol_type(second_symbol_type.subtype()).get_identifier()==
-            "java::java.lang.Integer");
+    const struct_union_typet::componentt &second_component =
+      require_type::require_component(
+        to_struct_type(second_symbol->type), "elem");
+    auto second_symbol_type=second_component.type();
+    require_type::require_pointer(
+      second_symbol_type, symbol_typet("java::java.lang.Integer"));
   }
 }
 


### PR DESCRIPTION
When the tag was wrong it causes issues in calling methods and meant the real time type information would not be handled correctly.

As the components on the new class have been moved, accessing the components by index no longer works. Instead access the components by name (and made use of other helper functions)