### PR TITLE
Remove useless cmdlinet::clear() call

### DIFF
--- a/src/util/cmdline.cpp
+++ b/src/util/cmdline.cpp
@@ -18,7 +18,6 @@ cmdlinet::cmdlinet()
 
 cmdlinet::~cmdlinet()
 {
-  clear();
 }
 
 void cmdlinet::clear()


### PR DESCRIPTION
Found this with `clang-tidy`

In `cmdlinet` this clears vectors that are about to die anyway, and because it is called in a destructor it cannot dispatch to a child class. By removing this call we can disabuse any extending child of the false expectation that their derived clear() method will in fact be called.

If there are any children in derived products relying on this behaviour it has never worked. The classes in the cbmc repo that extend `cmdlinet` don't override `clear()` AFAICT and so are not affected.

I found one more similar instance, the call to virtual `set_message_handler` in `language_uit`'s constructor (again it will never dispatch to anything other than `messaget::set_message_handler`), but that seems less likely to cause trouble.