### PR TITLE
Remove pointless typecasts

### DIFF
--- a/src/util/std_types.cpp
+++ b/src/util/std_types.cpp
@@ -146,17 +146,17 @@ mp_integer signedbv_typet::largest() const
 
 constant_exprt signedbv_typet::zero_expr() const
 {
-  return to_constant_expr(from_integer(0, *this));
+  return from_integer(0, *this);
 }
 
 constant_exprt signedbv_typet::smallest_expr() const
 {
-  return to_constant_expr(from_integer(smallest(), *this));
+  return from_integer(smallest(), *this);
 }
 
 constant_exprt signedbv_typet::largest_expr() const
 {
-  return to_constant_expr(from_integer(largest(), *this));
+  return from_integer(largest(), *this);
 }
 
 mp_integer unsignedbv_typet::smallest() const
@@ -171,15 +171,15 @@ mp_integer unsignedbv_typet::largest() const
 
 constant_exprt unsignedbv_typet::zero_expr() const
 {
-  return to_constant_expr(from_integer(0, *this));
+  return from_integer(0, *this);
 }
 
 constant_exprt unsignedbv_typet::smallest_expr() const
 {
-  return to_constant_expr(from_integer(smallest(), *this));
+  return from_integer(smallest(), *this);
 }
 
 constant_exprt unsignedbv_typet::largest_expr() const
 {
-  return to_constant_expr(from_integer(largest(), *this));
+  return from_integer(largest(), *this);
 }


### PR DESCRIPTION
`from_integer` already returns a `constant_exprt`.

I wrote a mini Clang pass to look for materialised temporaries being used with `to_*_expr` and similar casting functions, which recently caused a fun bug in test-gen due to something like
`const member_exprt &member = to_member_expr(returns_exprt_by_value());`

There were around 25 instances in the codebase altogether, but most have the pattern `floatbv_typet type=to_floatbv_type(long_double_type())` (example from `c_typecheck_expr.cpp`), which captures the temporary returned by `long_double_type()` just before it goes out of scope at the semicolon (not after `to_floatbv_type` returns as I had feared). The cases corrected by this PR were similarly just OK due to an immediate conversion back to a value type, but were also redundant casts so I figured I'd clean them up.

Long story short: lots of things that look like bugs, no actual bugs, thanks to the temporary lifespan rules being slightly more generous than one might guess.