### PR TITLE
Aggressive slicer

### DIFF
--- a/regression/goto-instrument/aggressive_slicer1/main.c
+++ b/regression/goto-instrument/aggressive_slicer1/main.c
@@ -1,0 +1,30 @@
+void D()
+{
+  __CPROVER_assert(0,"");
+}
+
+void C()
+{
+  int nondet;
+  if(nondet)
+  	D();
+}
+
+void B() 
+{
+  C();
+};
+
+int main()
+{
+  int nondet;
+
+  __CPROVER_assume(nondet!=3);
+  switch(nondet)
+  {
+    case 1: B(); break;
+    case 3: C(); break;
+    default: break;
+  }
+return 0;
+}

--- a/regression/goto-instrument/aggressive_slicer1/test.desc
+++ b/regression/goto-instrument/aggressive_slicer1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--aggressive-slice
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/goto-instrument/aggressive_slicer2/main.c
+++ b/regression/goto-instrument/aggressive_slicer2/main.c
@@ -1,0 +1,30 @@
+void D()
+{
+  __CPROVER_assert(0,"");
+}
+
+void C()
+{
+  int nondet;
+  if(nondet)
+  	D();
+}
+
+void B() 
+{
+  C();
+};
+
+int main()
+{
+  int nondet;
+
+  __CPROVER_assume(nondet!=3);
+  switch(nondet)
+  {
+    case 1: B(); break;
+    case 3: C(); break;
+    default: break;
+  }
+return 0;
+}

--- a/regression/goto-instrument/aggressive_slicer2/test.desc
+++ b/regression/goto-instrument/aggressive_slicer2/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--aggressive-slice --property D.assertion.1
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/goto-instrument/aggressive_slicer3/main.c
+++ b/regression/goto-instrument/aggressive_slicer3/main.c
@@ -1,0 +1,29 @@
+void D()
+{
+  __CPROVER_assert(0,"");
+}
+
+void C()
+{
+  int nondet;
+  if(nondet)
+  	D();
+}
+
+void B() 
+{
+  C();
+};
+
+int main()
+{
+  int nondet;
+
+  switch(nondet)
+  {
+    case 1: B(); break;
+    case 3: C(); break;
+    default: break;
+  }
+return 0;
+}

--- a/regression/goto-instrument/aggressive_slicer3/test.desc
+++ b/regression/goto-instrument/aggressive_slicer3/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--aggressive-slice
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-instrument/aggressive_slicer4/main.c
+++ b/regression/goto-instrument/aggressive_slicer4/main.c
@@ -1,0 +1,29 @@
+void D()
+{
+  __CPROVER_assert(0,"");
+}
+
+void C()
+{
+  int nondet;
+  if(nondet)
+  	D();
+}
+
+void B() 
+{
+  C();
+};
+
+int main()
+{
+  int nondet;
+  __CPROVER_assume(nondet!=3);
+  switch(nondet)
+  {
+    case 1: B(); break;
+    case 3: C(); break;
+    default: break;
+  }
+return 0;
+}

--- a/regression/goto-instrument/aggressive_slicer4/test.desc
+++ b/regression/goto-instrument/aggressive_slicer4/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--aggressive-slice --preserve-function B
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-instrument/aggressive_slicer5/main.c
+++ b/regression/goto-instrument/aggressive_slicer5/main.c
@@ -1,0 +1,29 @@
+void D()
+{
+  __CPROVER_assert(0,"");
+}
+
+void C()
+{
+  int nondet;
+  if(nondet)
+  	D();
+}
+
+void B() 
+{
+  C();
+};
+
+int main()
+{
+  int nondet;
+__CPROVER_assume(nondet!=3);
+  switch(nondet)
+  {
+    case 1: B(); break;
+    case 3: C(); break;
+    default: break;
+  }
+return 0;
+}

--- a/regression/goto-instrument/aggressive_slicer5/test.desc
+++ b/regression/goto-instrument/aggressive_slicer5/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--aggressive-slice --property D.assertion.1 --preserve-all-direct-paths
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-instrument/aggressive_slicer6/main.c
+++ b/regression/goto-instrument/aggressive_slicer6/main.c
@@ -1,0 +1,29 @@
+void D()
+{
+  __CPROVER_assert(0,"");
+}
+
+void C()
+{
+  int nondet;
+  if(nondet)
+  	D();
+}
+
+void B() 
+{
+  C();
+};
+
+int main()
+{
+  int nondet;
+  __CPROVER_assume(nondet!=3);
+  switch(nondet)
+  {
+    case 1: B(); break;
+    case 3: C(); break;
+    default: break;
+  }
+return 0;
+}

--- a/regression/goto-instrument/aggressive_slicer6/test.desc
+++ b/regression/goto-instrument/aggressive_slicer6/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--aggressive-slice --call-depth 1
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/src/analyses/Makefile
+++ b/src/analyses/Makefile
@@ -22,6 +22,7 @@ SRC = ai.cpp \
       locals.cpp \
       natural_loops.cpp \
       reaching_definitions.cpp \
+      reachable_call_graph.cpp \
       static_analysis.cpp \
       uncaught_exceptions_analysis.cpp \
       uninitialized_domain.cpp \

--- a/src/analyses/call_graph.cpp
+++ b/src/analyses/call_graph.cpp
@@ -18,9 +18,14 @@ call_grapht::call_grapht()
 {
 }
 
-call_grapht::call_grapht(const goto_modelt &goto_model)
+call_grapht::call_grapht(const goto_modelt &goto_model):
+  call_grapht(goto_model.goto_functions)
 {
-  forall_goto_functions(f_it, goto_model.goto_functions)
+}
+
+call_grapht::call_grapht(const goto_functionst &goto_functions)
+{
+  forall_goto_functions(f_it, goto_functions)
   {
     const goto_programt &body=f_it->second.body;
     add(f_it->first, body);

--- a/src/analyses/call_graph.cpp
+++ b/src/analyses/call_graph.cpp
@@ -107,8 +107,8 @@ call_grapht call_grapht::get_inverted() const
   return result;
 }
 
-std::list<irep_idt>call_grapht::shortest_function_path
-(irep_idt src, irep_idt dest)
+std::list<irep_idt> call_grapht::shortest_function_path(
+    irep_idt src, irep_idt dest)
 {
   std::list<irep_idt> result;
   node_indext src_idx, dest_idx;

--- a/src/analyses/call_graph.cpp
+++ b/src/analyses/call_graph.cpp
@@ -107,6 +107,26 @@ call_grapht call_grapht::get_inverted() const
   return result;
 }
 
+std::list<irep_idt>call_grapht::shortest_function_path
+(irep_idt src, irep_idt dest)
+{
+  std::list<irep_idt> result;
+  node_indext src_idx, dest_idx;
+  if(!get_node_index(src, src_idx))
+    throw "unable to find src function in call graph";
+  if(!get_node_index(dest, dest_idx))
+    throw "unable to find destination function in call graph";
+
+  patht path;
+  shortest_path(src_idx, dest_idx, path);
+  for(const auto &n : path)
+  {
+    result.push_back(nodes[n].function_name);
+  }
+  return result;
+}
+
+
 std::unordered_set<irep_idt, irep_id_hash>
 call_grapht::reachable_functions(irep_idt start_function)
 {

--- a/src/analyses/call_graph.cpp
+++ b/src/analyses/call_graph.cpp
@@ -7,7 +7,7 @@ Author: Daniel Kroening, kroening@kroening.com
 \*******************************************************************/
 
 /// \file
-/// Function Call Graphs
+/// Function Call Graph
 
 #include "call_graph.h"
 
@@ -18,14 +18,9 @@ call_grapht::call_grapht()
 {
 }
 
-call_grapht::call_grapht(const goto_modelt &goto_model):
-  call_grapht(goto_model.goto_functions)
+call_grapht::call_grapht(const goto_modelt &goto_model)
 {
-}
-
-call_grapht::call_grapht(const goto_functionst &goto_functions)
-{
-  forall_goto_functions(f_it, goto_functions)
+  forall_goto_functions(f_it, goto_model.goto_functions)
   {
     const goto_programt &body=f_it->second.body;
     add(f_it->first, body);
@@ -51,50 +46,91 @@ void call_grapht::add(
   const irep_idt &caller,
   const irep_idt &callee)
 {
-  graph.insert(std::pair<irep_idt, irep_idt>(caller, callee));
-}
-
-/// Returns an inverted copy of this call graph
-/// \return Inverted (callee -> caller) call graph
-call_grapht call_grapht::get_inverted() const
-{
-  call_grapht result;
-  for(const auto &caller_callee : graph)
-    result.add(caller_callee.second, caller_callee.first);
-  return result;
-}
-
-void call_grapht::output_dot(std::ostream &out) const
-{
-  out << "digraph call_graph {\n";
-
-  for(const auto &edge : graph)
+  std::size_t caller_idx = node_numbering.number(caller);
+  if(caller_idx >= nodes.size())
   {
-    out << "  \"" << edge.first << "\" -> "
-        << "\"" << edge.second << "\" "
-        << " [arrowhead=\"vee\"];"
-        << "\n";
+    node_indext node_index = add_node();
+    nodes[node_index].function_name = caller;
   }
 
-  out << "}\n";
+  std::size_t callee_idx = node_numbering.number(callee);
+  if(callee_idx >= nodes.size())
+  {
+    node_indext node_index = add_node();
+    nodes[node_index].function_name = callee;
+  }
+
+  add_edge(caller_idx, callee_idx);
 }
 
-void call_grapht::output(std::ostream &out) const
+
+void call_grapht::output_dot_node(std::ostream &out, node_indext n) const
 {
-  for(const auto &edge : graph)
+  const nodet &node = nodes.at(n);
+
+  for(const auto &edge : node.out)
   {
-    out << edge.first << " -> " << edge.second << "\n";
+    out << "  \"" << node.function_name << "\" -> " << "\""
+        << nodes[edge.first].function_name << "\" " << " [arrowhead=\"vee\"];"
+        << "\n";
+  }
+}
+
+void call_grapht::output_xml_node(std::ostream &out, node_indext n) const
+{
+  const nodet &node = nodes.at(n);
+
+  for(const auto &edge : node.out)
+  {
+    out << "<call_graph_edge caller=\"";
+    xmlt::escape_attribute(id2string(node.function_name), out);
+    out << "\" callee=\"";
+    xmlt::escape_attribute(id2string(nodes[edge.first].function_name), out);
+    out << "\">\n";
   }
 }
 
 void call_grapht::output_xml(std::ostream &out) const
 {
-  for(const auto &edge : graph)
+  for(node_indext n = 0; n < nodes.size(); n++)
+    output_xml_node(out, n);
+}
+
+call_grapht call_grapht::get_inverted() const
+{
+  call_grapht result;
+  for(const auto &n : nodes)
   {
-    out << "<call_graph_edge caller=\"";
-    xmlt::escape_attribute(id2string(edge.first), out);
-    out << "\" callee=\"";
-    xmlt::escape_attribute(id2string(edge.second), out);
-    out << "\">\n";
+    for(const auto &i : n.in)
+      result.add(n.function_name, nodes[i.first].function_name);
   }
+  return result;
+}
+
+std::unordered_set<irep_idt, irep_id_hash>
+call_grapht::reachable_functions(irep_idt start_function)
+{
+  std::unordered_set<irep_idt, irep_id_hash> result;
+  std::list<node_indext> worklist;
+  node_indext start_index;
+
+  if(get_node_index(start_function, start_index))
+    worklist.push_back(start_index);
+  else
+    throw "no start function found in call graph";
+
+  while(!worklist.empty())
+  {
+    const node_indext id = worklist.front();
+    worklist.pop_front();
+
+    result.insert(nodes[id].function_name);
+    for(const auto &o : nodes[id].out)
+    {
+      if(result.find(nodes[o.first].function_name) == result.end())
+        worklist.push_back(o.first);
+    }
+  }
+
+  return result;
 }

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -62,6 +62,15 @@ public:
   /// \return list of function names on the shortest path between src and dest
   std::list<irep_idt>shortest_function_path(irep_idt src, irep_idt dest);
 
+  /// \brief get the names of all functions reachable from a list of functions
+  /// within N function call steps.
+  /// \param function_list  list of functions to start from. Functions reachable within
+  /// N function call steps are appended to this list
+  /// \param steps  number of function call steps
+  void reachable_within_n_steps(std::size_t steps,
+      std::unordered_set<irep_idt, irep_id_hash> &function_list);
+
+
   /// get the index of the node that corresponds to a function name
   /// \param[in] function_name function_name passed by reference
   /// \param[out] n variable for the node index to be written to

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -23,9 +23,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/numbering.h>
 
 
-/// Function call graph inherits from grapht to allow forward and
+/// \brief Function call graph: each node represents a function
+/// in the GOTO model, a directed edge from A to B indicates
+/// that function A calls function B.
+/// Inherits from grapht to allow forward and
 /// backward traversal of the function call graph
-
 struct call_graph_nodet: public graph_nodet<empty_edget>
 {
   typedef graph_nodet<empty_edget>::edget edget;
@@ -43,11 +45,28 @@ public:
 
   void add(const irep_idt &caller, const irep_idt &callee);
   void output_xml(std::ostream &out) const;
+
+  /// \return the inverted call graph
   call_grapht get_inverted() const;
+
+  /// \brief get the names of all functions reachable from a start function
+  /// \param start  name of initial function
+  /// \return set of all names of the reachable functions
   std::unordered_set<irep_idt, irep_id_hash>
       reachable_functions(irep_idt start);
+
+  /// \brief Function returns the shortest path on the function call graph
+  /// between a source and a destination function
+  /// \param src  name of the starting function
+  /// \param dest name of the destination function
+  /// \return list of function names on the shortest path between src and dest
   std::list<irep_idt>shortest_function_path(irep_idt src, irep_idt dest);
 
+  /// get the index of the node that corresponds to a function name
+  /// \param[in] function_name function_name passed by reference
+  /// \param[out] n variable for the node index to be written to
+  /// \return true if a node with the given function name exists,
+  /// false if it does not exist
   bool get_node_index(const irep_idt& function_name, node_indext &n) const
   {
     for(node_indext idx = 0; idx < nodes.size(); idx++)
@@ -61,6 +80,9 @@ public:
     return false;
   }
 
+  /// \brief get a list of functions called by a function
+  /// \param function_name   the irep_idt of the function
+  /// \return an unordered set of all functions called by function_name
   std::unordered_set<irep_idt, irep_id_hash> get_successors(
       const irep_idt& function_name) const
   {

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -42,6 +42,7 @@ class call_grapht: public grapht<call_graph_nodet>
 public:
   call_grapht();
   explicit call_grapht(const goto_modelt &);
+  explicit call_grapht(const goto_functionst &);
 
   void add(const irep_idt &caller, const irep_idt &callee);
   void output_xml(std::ostream &out) const;

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -7,34 +7,77 @@ Author: Daniel Kroening, kroening@kroening.com
 \*******************************************************************/
 
 /// \file
-/// Function Call Graphs
+/// Function Call Graph
 
 #ifndef CPROVER_ANALYSES_CALL_GRAPH_H
 #define CPROVER_ANALYSES_CALL_GRAPH_H
 
 #include <iosfwd>
 #include <map>
+#include <unordered_set>
 
 #include <goto-programs/goto_model.h>
 
-class call_grapht
+#include <util/irep.h>
+#include <util/graph.h>
+#include <util/numbering.h>
+
+
+/// Function call graph inherits from grapht to allow forward and
+/// backward traversal of the function call graph
+
+struct call_graph_nodet: public graph_nodet<empty_edget>
+{
+  typedef graph_nodet<empty_edget>::edget edget;
+  typedef graph_nodet<empty_edget>::edgest edgest;
+
+  irep_idt function_name;
+  bool visited = false;
+};
+
+class call_grapht: public grapht<call_graph_nodet>
 {
 public:
   call_grapht();
   explicit call_grapht(const goto_modelt &);
-  explicit call_grapht(const goto_functionst &);
-
-  void output_dot(std::ostream &out) const;
-  void output(std::ostream &out) const;
-  void output_xml(std::ostream &out) const;
-
-  typedef std::multimap<irep_idt, irep_idt> grapht;
-  grapht graph;
 
   void add(const irep_idt &caller, const irep_idt &callee);
+  void output_xml(std::ostream &out) const;
   call_grapht get_inverted() const;
+  std::unordered_set<irep_idt, irep_id_hash>
+      reachable_functions(irep_idt start);
+
+  bool get_node_index(const irep_idt& function_name, node_indext &n) const
+  {
+    for(node_indext idx = 0; idx < nodes.size(); idx++)
+    {
+      if(nodes[idx].function_name == function_name)
+      {
+        n = idx;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  std::unordered_set<irep_idt, irep_id_hash> get_successors(
+      const irep_idt& function_name) const
+  {
+    std::unordered_set<irep_idt, irep_id_hash> result;
+    node_indext function_idx;
+    if(!get_node_index(function_name, function_idx))
+      return result;
+
+    for(const auto &o : nodes[function_idx].out)
+      result.insert(nodes[o.first].function_name);
+    return result;
+  }
+
 
 protected:
+  void output_dot_node(std::ostream &out, node_indext n) const override;
+  void output_xml_node(std::ostream &out, node_indext n) const;
+  numbering<irep_idt> node_numbering;
   void add(const irep_idt &function,
            const goto_programt &body);
 };

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -46,6 +46,7 @@ public:
   call_grapht get_inverted() const;
   std::unordered_set<irep_idt, irep_id_hash>
       reachable_functions(irep_idt start);
+  std::list<irep_idt>shortest_function_path(irep_idt src, irep_idt dest);
 
   bool get_node_index(const irep_idt& function_name, node_indext &n) const
   {

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -64,7 +64,8 @@ public:
 
   /// \brief get the names of all functions reachable from a list of functions
   /// within N function call steps.
-  /// \param function_list  list of functions to start from. Functions reachable within
+  /// \param function_list  list of functions to start from.
+  /// Functions reachable within
   /// N function call steps are appended to this list
   /// \param steps  number of function call steps
   void reachable_within_n_steps(std::size_t steps,

--- a/src/analyses/reachable_call_graph.cpp
+++ b/src/analyses/reachable_call_graph.cpp
@@ -17,6 +17,11 @@ reachable_call_grapht::reachable_call_grapht
   build(_goto_model.goto_functions);
 }
 
+void reachable_call_grapht::initialize(const goto_modelt & _goto_model)
+{
+  build(_goto_model.goto_functions);
+}
+
 void reachable_call_grapht::build(const goto_functionst & goto_functions)
 {
   irep_idt start_function_name = goto_functions.entry_point();

--- a/src/analyses/reachable_call_graph.cpp
+++ b/src/analyses/reachable_call_graph.cpp
@@ -8,12 +8,8 @@ Author:
 
 /// \file
 /// Reachable Call Graph
-/// Constructs a call graph only from the functions reachable from a given
-/// entry point, or the goto_functions.entry_point if none is given.
-
 #include "reachable_call_graph.h"
 #include <util/message.h>
-
 
 reachable_call_grapht::reachable_call_grapht
 (const goto_modelt & _goto_model)
@@ -70,7 +66,6 @@ void reachable_call_grapht::build(
     }
   }
 }
-
 
 std::unordered_set<irep_idt, irep_id_hash>
 reachable_call_grapht::backward_slice(irep_idt destination_function)

--- a/src/analyses/reachable_call_graph.cpp
+++ b/src/analyses/reachable_call_graph.cpp
@@ -1,0 +1,105 @@
+/*******************************************************************\
+
+Module: Reachable Call Graphs
+
+Author:
+
+\*******************************************************************/
+
+/// \file
+/// Reachable Call Graph
+/// Constructs a call graph only from the functions reachable from a given
+/// entry point, or the goto_functions.entry_point if none is given.
+
+#include "reachable_call_graph.h"
+#include <util/message.h>
+
+
+reachable_call_grapht::reachable_call_grapht
+(const goto_modelt & _goto_model)
+{
+  build(_goto_model.goto_functions);
+}
+
+void reachable_call_grapht::build(const goto_functionst & goto_functions)
+{
+  irep_idt start_function_name = goto_functions.entry_point();
+  build(goto_functions, start_function_name);
+}
+
+
+void reachable_call_grapht::build(
+    const goto_functionst & goto_functions,
+    irep_idt start_function_name)
+{
+  std::set<irep_idt> working_queue;
+  std::set<irep_idt> done;
+
+  // start from entry point
+  working_queue.insert(start_function_name);
+
+  while(!working_queue.empty())
+  {
+    irep_idt caller=*working_queue.begin();
+    working_queue.erase(working_queue.begin());
+
+    if(!done.insert(caller).second)
+      continue;
+
+    const goto_functionst::function_mapt::const_iterator f_it=
+      goto_functions.function_map.find(caller);
+
+    if(f_it==goto_functions.function_map.end())
+      continue;
+
+    const goto_programt &program=
+      f_it->second.body;
+
+    forall_goto_program_instructions(i_it, program)
+    {
+      if(i_it->is_function_call())
+      {
+        const exprt &function_expr=to_code_function_call(i_it->code).function();
+        if(function_expr.id()==ID_symbol)
+        {
+          irep_idt callee = to_symbol_expr(function_expr).get_identifier();
+          add(caller, callee);
+          working_queue.insert(callee);
+        }
+      }
+    }
+  }
+}
+
+
+std::unordered_set<irep_idt, irep_id_hash>
+reachable_call_grapht::backward_slice(irep_idt destination_function)
+{
+  std::unordered_set<irep_idt, irep_id_hash> result;
+  std::list<node_indext> worklist;
+  for(node_indext idx=0; idx<nodes.size(); idx++)
+  {
+    if(nodes[idx].function_name==destination_function)
+    {
+      worklist.push_back(idx);
+      break;
+    }
+  }
+  INVARIANT(!worklist.empty(), "destination function not found");
+
+  while(!worklist.empty())
+  {
+    const node_indext id = worklist.front();
+    worklist.pop_front();
+
+    result.insert(nodes[id].function_name);
+    for(const auto o : nodes[id].in)
+    {
+      if(result.find(nodes[o.first].function_name)==result.end())
+          worklist.push_back(o.first);
+    }
+  }
+
+return result;
+}
+

--- a/src/analyses/reachable_call_graph.h
+++ b/src/analyses/reachable_call_graph.h
@@ -20,6 +20,7 @@ class reachable_call_grapht: public call_grapht
 {
 public:
   explicit reachable_call_grapht(const goto_modelt &);
+  reachable_call_grapht() = default;
 
   /// \brief performs a backwards slice on a reachable call graph
   /// and returns an unordered set of all functions between the initial
@@ -28,6 +29,10 @@ public:
   /// \return unordered set of function names
   std::unordered_set<irep_idt, irep_id_hash>
   backward_slice(irep_idt destination_function);
+  /// \brief used to initialise reachable_call_graph if we have used the
+  /// empty constructor. Necessary for aggressive slicer, to avoid constructing
+  /// reachable call graph unless we need it.
+  void initialize(const goto_modelt &);
 protected:
   void build(const goto_functionst &);
   void build(const goto_functionst &, irep_idt start_function);

--- a/src/analyses/reachable_call_graph.h
+++ b/src/analyses/reachable_call_graph.h
@@ -8,6 +8,8 @@ Author:
 
 /// \file
 /// Reachable Call Graphs
+/// Constructs a call graph only from the functions reachable from a given
+/// entry point, or the goto_functions.entry_point if none is given.
 
 #ifndef CPROVER_ANALYSES_REACHABLE_CALL_GRAPH_H
 #define CPROVER_ANALYSES_REACHABLE_CALL_GRAPH_H
@@ -19,13 +21,11 @@ class reachable_call_grapht: public call_grapht
 public:
   explicit reachable_call_grapht(const goto_modelt &);
 
-  /// \brief Generates list of functions reachable from initial state and
-  /// that may reach a given destination function
-  ///
-  /// This is done by inverting the reachable call graph and performing bfs on
-  /// the inverted call graph.
-  /// \param destination function
-  /// \return unorderded set of function names as irep_idts
+  /// \brief performs a backwards slice on a reachable call graph
+  /// and returns an unordered set of all functions between the initial
+  /// function and the destination function, i.e., a cone of influence
+  /// \param destination_function   name of destination function
+  /// \return unordered set of function names
   std::unordered_set<irep_idt, irep_id_hash>
   backward_slice(irep_idt destination_function);
 protected:

--- a/src/analyses/reachable_call_graph.h
+++ b/src/analyses/reachable_call_graph.h
@@ -1,0 +1,36 @@
+/*******************************************************************\
+
+Module: Reachable Call Graphs
+
+Author:
+
+\*******************************************************************/
+
+/// \file
+/// Reachable Call Graphs
+
+#ifndef CPROVER_ANALYSES_REACHABLE_CALL_GRAPH_H
+#define CPROVER_ANALYSES_REACHABLE_CALL_GRAPH_H
+
+#include "call_graph.h"
+
+class reachable_call_grapht: public call_grapht
+{
+public:
+  explicit reachable_call_grapht(const goto_modelt &);
+
+  /// \brief Generates list of functions reachable from initial state and
+  /// that may reach a given destination function
+  ///
+  /// This is done by inverting the reachable call graph and performing bfs on
+  /// the inverted call graph.
+  /// \param destination function
+  /// \return unorderded set of function names as irep_idts
+  std::unordered_set<irep_idt, irep_id_hash>
+  backward_slice(irep_idt destination_function);
+protected:
+  void build(const goto_functionst &);
+  void build(const goto_functionst &, irep_idt start_function);
+};
+
+#endif /* SRC_ANALYSES_REACHABLE_CALL_GRAPH_H_ */

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1420,6 +1420,32 @@ void goto_instrument_parse_optionst::instrument_goto_program()
       throw 0;
   }
 
+  // aggressive slicer
+  if(cmdline.isset("aggressive-slice"))
+  {
+    do_indirect_call_and_rtti_removal();
+
+    status() << "Performing an aggressive slice" << eom;
+    aggressive_slicert aggressive_slicer(goto_model, get_message_handler());
+
+    if(cmdline.isset("call-depth"))
+      aggressive_slicer.call_depth = safe_string2unsigned(
+          cmdline.get_value("call-depth"));
+
+    if(cmdline.isset("preserve-function"))
+      aggressive_slicer.preserve_functions(
+          cmdline.get_values("preserve-function"));
+
+    if(cmdline.isset("property"))
+      aggressive_slicer.properties = cmdline.get_values("property");
+
+    if(cmdline.isset("preserve-functions-containing"))
+      aggressive_slicer.name_snippets = cmdline.get_values(
+          "preserve-functions-containing");
+
+    aggressive_slicer.doit();
+  }
+
   // recalculate numbers, etc.
   goto_model.goto_functions.update();
 }
@@ -1519,6 +1545,13 @@ void goto_instrument_parse_optionst::help()
     " --full-slice                 slice away instructions that don't affect assertions\n" // NOLINT(*)
     " --property id                slice with respect to specific property only\n" // NOLINT(*)
     " --slice-global-inits         slice away initializations of unused global variables\n" // NOLINT(*)
+    " --aggressive-slice           remove bodies of any functions not on the shortest path between\n" // NOLINT(*)
+    "                              the start function and the function containing the property(s)\n" // NOLINT(*)
+    " --call-depth <n>             used with aggressive-slice, preserves all functions within <n> function calls\n" // NOLINT(*)
+    "                              of the functions on the shortest path\n"
+    " --preserve-function <f>      force the aggressive slicer to preserve function <f>\n" // NOLINT(*)
+    " --preserve-function containing <f>\n"
+    "                              force the aggressive slicer to preserve all functions with names containing <f>\n" // NOLINT(*)
     "\n"
     "Further transformations:\n"
     " --constant-propagator        propagate constants and simplify expressions\n" // NOLINT(*)

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1442,6 +1442,18 @@ void goto_instrument_parse_optionst::instrument_goto_program()
     status() << "Performing an aggressive slice" << eom;
     aggressive_slicert aggressive_slicer(goto_model, get_message_handler());
 
+    if(cmdline.isset("preserve-all-direct-paths"))
+    {
+      if(!cmdline.isset("property"))
+      {
+        error() << "Property must be specified"
+                << " with the sound aggressive slicer"
+                << eom;
+        throw 0;
+      }
+      aggressive_slicer.preserve_all_direct_paths=true;
+    }
+
     if(cmdline.isset("call-depth"))
       aggressive_slicer.call_depth = safe_string2unsigned(
           cmdline.get_value("call-depth"));
@@ -1572,6 +1584,8 @@ void goto_instrument_parse_optionst::help()
     " --preserve-function <f>      force the aggressive slicer to preserve function <f>\n" // NOLINT(*)
     " --preserve-function containing <f>\n"
     "                              force the aggressive slicer to preserve all functions with names containing <f>\n" // NOLINT(*)
+    " --preserve-all-direct-paths  force the aggressive slicer to preserve all functions on direct paths to the property\n" // NOLINT(*)
+    "                              Must be used with a specified property\n"
     "\n"
     "Further transformations:\n"
     " --constant-propagator        propagate constants and simplify expressions\n" // NOLINT(*)

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -61,6 +61,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <analyses/dependence_graph.h>
 #include <analyses/constant_propagator.h>
 #include <analyses/is_threaded.h>
+#include <analyses/reachable_call_graph.h>
+
 
 #include <cbmc/version.h>
 
@@ -648,15 +650,23 @@ int goto_instrument_parse_optionst::doit()
     {
       do_indirect_call_and_rtti_removal();
       call_grapht call_graph(goto_model);
-
       if(cmdline.isset("xml"))
         call_graph.output_xml(std::cout);
-      else if(cmdline.isset("dot"))
-        call_graph.output_dot(std::cout);
       else
-        call_graph.output(std::cout);
+        call_graph.output_dot(std::cout);
 
       return CPROVER_EXIT_SUCCESS;
+    }
+
+    if(cmdline.isset("reachable-call-graph"))
+    {
+      do_indirect_call_and_rtti_removal();
+      reachable_call_grapht reach_graph(goto_model);
+      if(cmdline.isset("xml"))
+        reach_graph.output_xml(std::cout);
+      else
+        reach_graph.output_dot(std::cout);
+    return 0;
     }
 
     if(cmdline.isset("dot"))
@@ -1454,6 +1464,8 @@ void goto_instrument_parse_optionst::help()
     " --list-calls-args            list all function calls with their arguments\n"
     // NOLINTNEXTLINE(whitespace/line_length)
     " --print-path-lengths         print statistics about control-flow graph paths\n"
+    " --call-graph                 show graph of function calls\n"
+    " --reachable-call-graph       show graph of function calls potentially reachable from main function\n" // NOLINT(*)
     "\n"
     "Safety checks:\n"
     " --no-assertions              ignore user assertions\n"

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -85,6 +85,7 @@ Author: Daniel Kroening, kroening@kroening.com
   "(harness-generator):" \
   "(preserve-function):" \
   "(preserve-functions-containing):" \
+  "(preserve-all-direct-paths)" \
 
 class goto_instrument_parse_optionst:
   public parse_options_baset,

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -44,6 +44,7 @@ Author: Daniel Kroening, kroening@kroening.com
   "(max-var):(max-po-trans):(ignore-arrays)" \
   "(cfg-kill)(no-dependencies)(force-loop-duplication)" \
   "(call-graph)" \
+  "(reachable-call-graph)" \
   "(no-po-rendering)(render-cluster-file)(render-cluster-function)" \
   "(nondet-volatile)(isr):" \
   "(stack-depth):(nondet-static)" \

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -80,7 +80,11 @@ Author: Daniel Kroening, kroening@kroening.com
   "(undefined-function-is-assume-false)" \
   "(remove-function-body):"\
   "(splice-call):" \
-
+  "(aggressive-slice)" \
+  "(call-depth):" \
+  "(harness-generator):" \
+  "(preserve-function):" \
+  "(preserve-functions-containing):" \
 
 class goto_instrument_parse_optionst:
   public parse_options_baset,

--- a/src/goto-instrument/remove_function.cpp
+++ b/src/goto-instrument/remove_function.cpp
@@ -71,13 +71,25 @@ void aggressive_slicert::doit()
   if(!name_snippets.empty())
     find_functions_that_contain_name_snippet();
 
+  if(preserve_all_direct_paths)
+    reach_graph.initialize(goto_model);
+
   for(const auto &p : properties)
   {
     source_locationt property_loc = find_property(p, goto_model.goto_functions);
     irep_idt dest = property_loc.get_function();
-    for(const auto &func : call_graph.shortest_function_path(
-        start_function, dest))
-      functions_to_keep.insert(func);
+
+    if(preserve_all_direct_paths)
+    {
+      for(const auto & func : reach_graph.backward_slice(dest))
+        functions_to_keep.insert(func);
+    }
+    else
+    {
+      for(const auto &func : call_graph.shortest_function_path(start_function,
+          dest))
+        functions_to_keep.insert(func);
+    }
   }
 
   // Add functions within distance of shortest path functions

--- a/src/goto-instrument/remove_function.cpp
+++ b/src/goto-instrument/remove_function.cpp
@@ -12,10 +12,88 @@ Date: April 2017
 /// Remove function definition
 
 #include "remove_function.h"
+#include "function_modifies.h"
 
 #include <util/message.h>
 
 #include <goto-programs/goto_model.h>
+#include <goto-programs/show_properties.h>
+
+#include <string>
+
+
+void aggressive_slicert::get_property_list()
+{
+  for(const auto &fct : goto_model.goto_functions.function_map)
+  {
+    if(!fct.second.is_inlined())
+    {
+      for(const auto &ins : fct.second.body.instructions)
+        if(ins.is_assert())
+        {
+          for(const auto &func : call_graph.shortest_function_path(
+              start_function, ins.function))
+          {
+            functions_to_keep.insert(func);
+          }
+        }
+    }
+  }
+}
+
+
+void aggressive_slicert::find_functions_that_contain_name_snippet()
+{
+  for(const auto &name_snippet : name_snippets)
+  {
+    forall_goto_functions(f_it, goto_model.goto_functions)
+    {
+      if(id2string(f_it->first).find(name_snippet)!=std::string::npos)
+        functions_to_keep.insert(f_it->first);
+    }
+  }
+}
+
+
+void aggressive_slicert::doit()
+{
+  messaget message(message_handler);
+
+  functions_to_keep.insert(CPROVER_PREFIX "initialize");
+  functions_to_keep.insert(start_function);
+
+  // if no properties are specified, get list of all properties
+  if(properties.empty())
+    get_property_list();
+
+  // if a name snippet is given, get list of all functions containing
+  // name snippet
+  if(!name_snippets.empty())
+    find_functions_that_contain_name_snippet();
+
+  for(const auto &p : properties)
+  {
+    source_locationt property_loc = find_property(p, goto_model.goto_functions);
+    irep_idt dest = property_loc.get_function();
+    for(const auto &func : call_graph.shortest_function_path(
+        start_function, dest))
+      functions_to_keep.insert(func);
+  }
+
+  // Add functions within distance of shortest path functions
+  // to the list
+  if(call_depth != 0)
+    call_graph.reachable_within_n_steps(call_depth, functions_to_keep);
+
+  for(const auto &func : functions_to_keep)
+    message.status() << "Keeping: " << func << messaget::eom;
+
+  forall_goto_functions(f_it, goto_model.goto_functions)
+  {
+    if(functions_to_keep.find(f_it->first)==functions_to_keep.end())
+      remove_function(goto_model, f_it->first, message_handler);
+  }
+}
 
 /// Remove the body of function "identifier" such that an analysis will treat it
 /// as a side-effect free function with non-deterministic return value.

--- a/src/goto-instrument/remove_function.h
+++ b/src/goto-instrument/remove_function.h
@@ -21,6 +21,7 @@ Date: April 2017
 #include <util/irep.h>
 
 #include <analyses/call_graph.h>
+#include <analyses/reachable_call_graph.h>
 
 class goto_modelt;
 class message_handlert;
@@ -47,13 +48,15 @@ public:
   aggressive_slicert(
       goto_modelt & _goto_model,
       message_handlert &_msg) :
+      preserve_all_direct_paths(false),
+      call_depth(0),
+      start_function(_goto_model.goto_functions.entry_point()),
       goto_model(_goto_model),
       message_handler(_msg),
-      call_graph(_goto_model)
-  {
-    start_function = goto_model.goto_functions.entry_point();
-    call_depth=0;
-  }
+      call_graph(_goto_model),
+      reach_graph()
+      {
+      }
 
   ///  \brief Removes the body of all functions except those on the
   /// shortest path or functions
@@ -71,6 +74,11 @@ public:
       functions_to_keep.insert(f);
   };
 
+  /// \brief When set to true we preserve all functions on direct paths between
+  /// the start function
+  /// and any given properties. We do not allow this option to be used without
+  /// specifying a property, as that would effectively be doing a full-slice
+  bool preserve_all_direct_paths;
   std::list<std::string> properties;
   std::size_t call_depth;
   std::list<std::string> name_snippets;
@@ -81,6 +89,7 @@ private:
   message_handlert & message_handler;
   std::unordered_set<irep_idt, irep_id_hash> functions_to_keep;
   call_grapht call_graph;
+  reachable_call_grapht reach_graph;
 
   /// \brief Finds all functions whose name contains a name snippet
   /// and adds them to the std::unordered_set of irep_idts of functions

--- a/src/goto-instrument/remove_function.h
+++ b/src/goto-instrument/remove_function.h
@@ -16,8 +16,11 @@ Date: April 2017
 
 #include <list>
 #include <string>
+#include <unordered_set>
 
 #include <util/irep.h>
+
+#include <analyses/call_graph.h>
 
 class goto_modelt;
 class message_handlert;
@@ -31,5 +34,63 @@ void remove_functions(
   goto_modelt &,
   const std::list<std::string> &names,
   message_handlert &);
+
+/// \brief The aggressive slicer removes the body of all the functions except
+/// those on the shortest path, those within the call-depth of the
+/// shortest path, those given by name as command line argument,
+/// and those that contain a given irep_idt snippet
+/// If no properties are set by the user, we preserve all functions on
+/// the shortest paths to each property.
+class aggressive_slicert
+{
+public:
+  aggressive_slicert(
+      goto_modelt & _goto_model,
+      message_handlert &_msg) :
+      goto_model(_goto_model),
+      message_handler(_msg),
+      call_graph(_goto_model)
+  {
+    start_function = goto_model.goto_functions.entry_point();
+    call_depth=0;
+  }
+
+  ///  \brief Removes the body of all functions except those on the
+  /// shortest path or functions
+  /// that are reachable from functions on the shortest path within
+  /// N calls, where N is given by the parameter "distance"
+  void doit();
+
+  /// \brief Adds a list of functions to the set of functions for the aggressive
+  /// slicer to preserve
+  /// \param  function list a list of functions in form std::list<std::string>, as returned
+  /// by get_cmdline_option.
+  void preserve_functions(const std::list<std::string>& function_list)
+  {
+    for(const auto &f : function_list)
+      functions_to_keep.insert(f);
+  };
+
+  std::list<std::string> properties;
+  std::size_t call_depth;
+  std::list<std::string> name_snippets;
+
+private:
+  irep_idt start_function;
+  goto_modelt & goto_model;
+  message_handlert & message_handler;
+  std::unordered_set<irep_idt, irep_id_hash> functions_to_keep;
+  call_grapht call_graph;
+
+  /// \brief Finds all functions whose name contains a name snippet
+  /// and adds them to the std::unordered_set of irep_idts of functions
+  /// for the aggressive slicer to preserve
+  void find_functions_that_contain_name_snippet();
+
+  /// \brief Finds all properties in the goto_model and writes their
+  /// names to a list. This function is only called if no properties
+  /// are given by the user
+  void get_property_list();
+};
 
 #endif // CPROVER_GOTO_INSTRUMENT_REMOVE_FUNCTION_H

--- a/src/goto-instrument/remove_function.h
+++ b/src/goto-instrument/remove_function.h
@@ -66,8 +66,8 @@ public:
 
   /// \brief Adds a list of functions to the set of functions for the aggressive
   /// slicer to preserve
-  /// \param  function list a list of functions in form std::list<std::string>, as returned
-  /// by get_cmdline_option.
+  /// \param  function_list    a list of functions in form
+  /// std::list<std::string>, as returned by get_cmdline_option.
   void preserve_functions(const std::list<std::string>& function_list)
   {
     for(const auto &f : function_list)

--- a/src/goto-programs/show_properties.cpp
+++ b/src/goto-programs/show_properties.cpp
@@ -23,6 +23,30 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "goto_functions.h"
 #include "goto_model.h"
 
+
+source_locationt find_property(
+    const irep_idt &property,
+    const goto_functionst & goto_functions)
+{
+  for(const auto &fct : goto_functions.function_map)
+  {
+    const goto_programt &goto_program = fct.second.body;
+
+    for(const auto &ins : goto_program.instructions)
+    {
+      if(ins.is_assert())
+      {
+        if(ins.source_location.get_property_id() == property)
+        {
+          return ins.source_location;
+        }
+      }
+    }
+  }
+  throw "property not found";
+}
+
+
 void show_properties(
   const namespacet &ns,
   const irep_idt &identifier,

--- a/src/goto-programs/show_properties.h
+++ b/src/goto-programs/show_properties.h
@@ -28,4 +28,11 @@ void show_properties(
   ui_message_handlert::uit ui,
   const goto_functionst &goto_functions);
 
+/// \brief Returns a source_locationt that corresponds
+/// to the property given by an irep_idt.
+/// \param property irep_idt and goto_functions
+source_locationt find_property(
+    const irep_idt &property,
+    const goto_functionst &);
+
 #endif // CPROVER_GOTO_PROGRAMS_SHOW_PROPERTIES_H

--- a/src/goto-programs/slice_global_inits.cpp
+++ b/src/goto-programs/slice_global_inits.cpp
@@ -30,11 +30,8 @@ void slice_global_inits(goto_modelt &goto_model)
   // gather all functions reachable from the entry point
 
   call_grapht call_graph(goto_model);
-  const call_grapht::grapht &graph=call_graph.graph;
-  goto_functionst &goto_functions=goto_model.goto_functions;
 
-  std::list<irep_idt> worklist;
-  std::unordered_set<irep_idt, irep_id_hash> functions_reached;
+  goto_functionst &goto_functions=goto_model.goto_functions;
 
   const irep_idt entry_point=goto_functionst::entry_point();
 
@@ -44,26 +41,8 @@ void slice_global_inits(goto_modelt &goto_model)
   if(e_it==goto_functions.function_map.end())
     throw "entry point not found";
 
-  worklist.push_back(entry_point);
-
-  do
-  {
-    const irep_idt id=worklist.front();
-    worklist.pop_front();
-
-    functions_reached.insert(id);
-
-    const auto &p=graph.equal_range(id);
-
-    for(auto it=p.first; it!=p.second; it++)
-    {
-      const irep_idt callee=it->second;
-
-      if(functions_reached.find(callee)==functions_reached.end())
-        worklist.push_back(callee);
-    }
-  }
-  while(!worklist.empty());
+  std::unordered_set<irep_idt, irep_id_hash> functions_reached=
+      call_graph.reachable_functions(entry_point);
 
   const irep_idt initialize=CPROVER_PREFIX "initialize";
   functions_reached.erase(initialize);

--- a/src/util/graph.h
+++ b/src/util/graph.h
@@ -655,8 +655,12 @@ std::list<typename grapht<N>::node_indext> grapht<N>::topsort() const
 template<class N>
 void grapht<N>::output_dot(std::ostream &out) const
 {
+  out << "digraph call_graph {\n";
+
   for(node_indext n=0; n<nodes.size(); n++)
     output_dot_node(out, n);
+
+  out << "}\n";
 }
 
 template<class N>
@@ -668,7 +672,12 @@ void grapht<N>::output_dot_node(std::ostream &out, node_indext n) const
       it=node.out.begin();
       it!=node.out.end();
       it++)
-    out << n << " -> " << it->first << '\n';
+  {
+    out << "  \"" << n << "\" -> "
+        << "\"" << it->first << "\" "
+        << " [arrowhead=\"vee\"];"
+        << "\n";
+  }
 }
 
 #endif // CPROVER_UTIL_GRAPH_H

--- a/src/util/graph.h
+++ b/src/util/graph.h
@@ -263,7 +263,7 @@ public:
   std::list<node_indext> topsort() const;
 
   void output_dot(std::ostream &out) const;
-  void output_dot_node(std::ostream &out, node_indext n) const;
+  virtual void output_dot_node(std::ostream &out, node_indext n) const;
 
 protected:
   class tarjant

--- a/src/util/graph.h
+++ b/src/util/graph.h
@@ -666,15 +666,12 @@ void grapht<N>::output_dot(std::ostream &out) const
 template<class N>
 void grapht<N>::output_dot_node(std::ostream &out, node_indext n) const
 {
-  const nodet &node=nodes[n];
+  const nodet &node=nodes.at(n);
 
-  for(typename edgest::const_iterator
-      it=node.out.begin();
-      it!=node.out.end();
-      it++)
+  for(const auto &edge : node.out)
   {
     out << "  \"" << n << "\" -> "
-        << "\"" << it->first << "\" "
+        << "\"" << edge.first << "\" "
         << " [arrowhead=\"vee\"];"
         << "\n";
   }


### PR DESCRIPTION
This pull request is dependent on:
https://github.com/diffblue/cbmc/pull/1586
https://github.com/diffblue/cbmc/pull/1509

The aggressive slicer by default removes function bodies of any functions not on the shortest path on the call graph between the start function and the property. If no property is specified, it will preseve the shortest path for each property. It is parameterisable:

 --call-depth <n> "    preserves all functions within <n> function calls of the shorets path " --preserve-function <f>      forces the aggressive slicer to preserve function <f>
 --preserve-function containing <f>  force the aggressive slicer to preserve all functions with names containing <f>
 --preserve-all-direct-paths  force the aggressive slicer to preserve all functions on direct paths to the property. This option must be used with a specified property. 

The aggressive slicer is designed to be used in conjunction with:
https://github.com/diffblue/cbmc/pull/1585 - to over-approximate any function bodies we have removed
https://github.com/diffblue/cbmc/pull/1566 - to block functions we do not wish to be included in paths

The results are not sound, it may produce spurious traces, due to over-approximating the removed function bodies, and it may miss traces due to the removed function bodies writing to global variables, or if "preserve-all-direct-paths" is not used. However, it is designed for use with code bases that are far too big to otherwise use cbmc on.

The parameterisation is intended to be used as a means of providing engineer feedback. 