### PR TITLE
Don't mutate parameters in numbering class, remove duplication in numbering classes

### DIFF
--- a/src/analyses/custom_bitvector_analysis.cpp
+++ b/src/analyses/custom_bitvector_analysis.cpp
@@ -181,10 +181,10 @@ unsigned custom_bitvector_analysist::get_bit_nr(
   else if(string_expr.id()==ID_string_constant)
   {
     irep_idt value=string_expr.get(ID_value);
-    return bits(value);
+    return bits.number(value);
   }
   else
-    return bits("(unknown)");
+    return bits.number("(unknown)");
 }
 
 std::set<exprt> custom_bitvector_analysist::aliases(

--- a/src/analyses/invariant_set.cpp
+++ b/src/analyses/invariant_set.cpp
@@ -52,7 +52,12 @@ bool inv_object_storet::get(const exprt &expr, unsigned &n)
     return false;
   }
 
-  return map.get_number(s, n);
+  if(const auto number = map.get_number(s))
+  {
+    n = *number;
+    return false;
+  }
+  return true;
 }
 
 unsigned inv_object_storet::add(const exprt &expr)

--- a/src/solvers/flattening/boolbv_constant.cpp
+++ b/src/solvers/flattening/boolbv_constant.cpp
@@ -48,7 +48,7 @@ bvt boolbvt::convert_constant(const constant_exprt &expr)
   else if(expr_type.id()==ID_string)
   {
     // we use the numbering for strings
-    std::size_t number=string_numbering(expr.get_value());
+    std::size_t number = string_numbering.number(expr.get_value());
     return bv_utils.build_constant(number, bv.size());
   }
   else if(expr_type.id()==ID_range)

--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -330,13 +330,14 @@ exprt boolbvt::bv_get_unbounded_array(const exprt &expr) const
   valuest values;
 
   {
-    std::size_t number;
-
-    if(arrays.get_number(expr, number))
+    const auto opt_num = arrays.get_number(expr);
+    if(!opt_num)
+    {
       return nil_exprt();
+    }
 
     // get root
-    number=arrays.find_number(number);
+    const auto number = arrays.find_number(*opt_num);
 
     assert(number<index_map.size());
     index_mapt::const_iterator it=index_map.find(number);

--- a/src/util/numbering.h
+++ b/src/util/numbering.h
@@ -50,11 +50,6 @@ public:
     return (result.first)->second;
   }
 
-  number_type operator()(const T &a)
-  {
-    return number(a);
-  }
-
   optionalt<number_type> get_number(const T &a) const
   {
     const auto it = numbers_.find(a);

--- a/src/util/numbering.h
+++ b/src/util/numbering.h
@@ -6,7 +6,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-
 #ifndef CPROVER_UTIL_NUMBERING_H
 #define CPROVER_UTIL_NUMBERING_H
 
@@ -18,39 +17,38 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/invariant.h>
 #include <util/optional.h>
 
-template <typename T>
-// NOLINTNEXTLINE(readability/identifiers)
-class numbering final
+/// \tparam Map a map from a key type to some numeric type
+template <typename Map>
+class template_numberingt final
 {
 public:
-  using number_type = std::size_t; // NOLINT
+  using number_type = typename Map::mapped_type; // NOLINT
+  using key_type = typename Map::key_type;       // NOLINT
 
 private:
-  using data_typet = std::vector<T>; // NOLINT
+  using data_typet = std::vector<key_type>; // NOLINT
   data_typet data_;
-  using numberst = std::map<T, number_type>; // NOLINT
-  numberst numbers_;
+  Map numbers_;
 
 public:
   using size_type = typename data_typet::size_type;           // NOLINT
   using iterator = typename data_typet::iterator;             // NOLINT
   using const_iterator = typename data_typet::const_iterator; // NOLINT
 
-  number_type number(const T &a)
+  number_type number(const key_type &a)
   {
-    std::pair<typename numberst::const_iterator, bool> result = numbers_.insert(
-      std::pair<T, number_type>(a, number_type(numbers_.size())));
+    const auto result = numbers_.emplace(a, number_type(numbers_.size()));
 
     if(result.second) // inserted?
     {
-      data_.push_back(a);
+      data_.emplace_back(a);
       INVARIANT(data_.size() == numbers_.size(), "vector sizes must match");
     }
 
     return (result.first)->second;
   }
 
-  optionalt<number_type> get_number(const T &a) const
+  optionalt<number_type> get_number(const key_type &a) const
   {
     const auto it = numbers_.find(a);
     if(it == numbers_.end())
@@ -64,120 +62,6 @@ public:
   {
     data_.clear();
     numbers_.clear();
-  }
-
-  size_t size() const
-  {
-    return data_.size();
-  }
-
-  T &operator[](size_type t)
-  {
-    return data_[t];
-  }
-  const T &operator[](size_type t) const
-  {
-    return data_[t];
-  }
-
-  iterator begin()
-  {
-    return data_.begin();
-  }
-  const_iterator begin() const
-  {
-    return data_.begin();
-  }
-  const_iterator cbegin() const
-  {
-    return data_.cbegin();
-  }
-
-  iterator end()
-  {
-    return data_.end();
-  }
-  const_iterator end() const
-  {
-    return data_.end();
-  }
-  const_iterator cend() const
-  {
-    return data_.cend();
-  }
-};
-
-template <typename T, class hash_fkt>
-// NOLINTNEXTLINE(readability/identifiers)
-class hash_numbering final
-{
-public:
-  using number_type = unsigned int; // NOLINT
-
-private:
-  using data_typet = std::vector<T>; // NOLINT
-  data_typet data_;
-  using numberst = std::unordered_map<T, number_type, hash_fkt>; // NOLINT
-  numberst numbers_;
-
-public:
-  using size_type = typename data_typet::size_type;           // NOLINT
-  using iterator = typename data_typet::iterator;             // NOLINT
-  using const_iterator = typename data_typet::const_iterator; // NOLINT
-
-  number_type number(const T &a)
-  {
-    std::pair<typename numberst::const_iterator, bool> result = numbers_.insert(
-      std::pair<T, number_type>(a, number_type(numbers_.size())));
-
-    if(result.second) // inserted?
-    {
-      this->push_back(a);
-      assert(this->size() == numbers_.size());
-    }
-
-    return (result.first)->second;
-  }
-
-  optionalt<number_type> get_number(const T &a) const
-  {
-    const auto it = numbers_.find(a);
-
-    if(it == numbers_.end())
-    {
-      return {};
-    }
-    return it->second;
-  }
-
-  void clear()
-  {
-    data_.clear();
-    numbers_.clear();
-  }
-
-  template <typename U>
-  void push_back(U &&u)
-  {
-    data_.push_back(std::forward<U>(u));
-  }
-
-  T &operator[](size_type t)
-  {
-    return data_[t];
-  }
-  const T &operator[](size_type t) const
-  {
-    return data_[t];
-  }
-
-  T &at(size_type t)
-  {
-    return data_.at(t);
-  }
-  const T &at(size_type t) const
-  {
-    return data_.at(t);
   }
 
   size_type size() const
@@ -185,6 +69,15 @@ public:
     return data_.size();
   }
 
+  key_type &operator[](size_type t)
+  {
+    return data_[t];
+  }
+  const key_type &operator[](size_type t) const
+  {
+    return data_[t];
+  }
+
   iterator begin()
   {
     return data_.begin();
@@ -211,5 +104,12 @@ public:
     return data_.cend();
   }
 };
+
+template <typename Key>
+using numbering = template_numberingt<std::map<Key, std::size_t>>; // NOLINT
+
+template <typename Key, typename Hash>
+using hash_numbering = // NOLINT
+  template_numberingt<std::unordered_map<Key, std::size_t, Hash>>;
 
 #endif // CPROVER_UTIL_NUMBERING_H

--- a/src/util/numbering.h
+++ b/src/util/numbering.h
@@ -23,22 +23,18 @@ template <typename T>
 class numbering final
 {
 public:
-  // NOLINTNEXTLINE(readability/identifiers)
-  typedef std::size_t number_type;
+  using number_type = std::size_t; // NOLINT
 
 private:
-  typedef std::vector<T> data_typet;
+  using data_typet = std::vector<T>; // NOLINT
   data_typet data;
-  typedef std::map<T, number_type> numberst;
+  using numberst = std::map<T, number_type>; // NOLINT
   numberst numbers;
 
 public:
-  // NOLINTNEXTLINE(readability/identifiers)
-  typedef typename data_typet::size_type size_type;
-  // NOLINTNEXTLINE(readability/identifiers)
-  typedef typename data_typet::iterator iterator;
-  // NOLINTNEXTLINE(readability/identifiers)
-  typedef typename data_typet::const_iterator const_iterator;
+  using size_type = typename data_typet::size_type;           // NOLINT
+  using iterator = typename data_typet::iterator;             // NOLINT
+  using const_iterator = typename data_typet::const_iterator; // NOLINT
 
   number_type number(const T &a)
   {
@@ -96,22 +92,18 @@ template <typename T, class hash_fkt>
 class hash_numbering final
 {
 public:
-  // NOLINTNEXTLINE(readability/identifiers)
-  typedef unsigned int number_type;
+  using number_type = unsigned int; // NOLINT
 
 private:
-  typedef std::vector<T> data_typet;
+  using data_typet = std::vector<T>; // NOLINT
   data_typet data;
-  typedef std::unordered_map<T, number_type, hash_fkt> numberst;
+  using numberst = std::unordered_map<T, number_type, hash_fkt>; // NOLINT
   numberst numbers;
 
 public:
-  // NOLINTNEXTLINE(readability/identifiers)
-  typedef typename data_typet::size_type size_type;
-  // NOLINTNEXTLINE(readability/identifiers)
-  typedef typename data_typet::iterator iterator;
-  // NOLINTNEXTLINE(readability/identifiers)
-  typedef typename data_typet::const_iterator const_iterator;
+  using size_type = typename data_typet::size_type;           // NOLINT
+  using iterator = typename data_typet::iterator;             // NOLINT
+  using const_iterator = typename data_typet::const_iterator; // NOLINT
 
   number_type number(const T &a)
   {

--- a/src/util/numbering.h
+++ b/src/util/numbering.h
@@ -27,9 +27,9 @@ public:
 
 private:
   using data_typet = std::vector<T>; // NOLINT
-  data_typet data;
+  data_typet data_;
   using numberst = std::map<T, number_type>; // NOLINT
-  numberst numbers;
+  numberst numbers_;
 
 public:
   using size_type = typename data_typet::size_type;           // NOLINT
@@ -38,15 +38,13 @@ public:
 
   number_type number(const T &a)
   {
-    std::pair<typename numberst::const_iterator, bool> result=
-      numbers.insert(
-      std::pair<T, number_type>
-      (a, number_type(numbers.size())));
+    std::pair<typename numberst::const_iterator, bool> result = numbers_.insert(
+      std::pair<T, number_type>(a, number_type(numbers_.size())));
 
     if(result.second) // inserted?
     {
-      data.push_back(a);
-      INVARIANT(data.size()==numbers.size(), "vector sizes must match");
+      data_.push_back(a);
+      INVARIANT(data_.size() == numbers_.size(), "vector sizes must match");
     }
 
     return (result.first)->second;
@@ -59,8 +57,8 @@ public:
 
   optionalt<number_type> get_number(const T &a) const
   {
-    const auto it = numbers.find(a);
-    if(it == numbers.end())
+    const auto it = numbers_.find(a);
+    if(it == numbers_.end())
     {
       return {};
     }
@@ -69,22 +67,49 @@ public:
 
   void clear()
   {
-    data.clear();
-    numbers.clear();
+    data_.clear();
+    numbers_.clear();
   }
 
-  size_t size() const { return data.size(); }
+  size_t size() const
+  {
+    return data_.size();
+  }
 
-  T &operator[](size_type t) { return data[t]; }
-  const T &operator[](size_type t) const { return data[t]; }
+  T &operator[](size_type t)
+  {
+    return data_[t];
+  }
+  const T &operator[](size_type t) const
+  {
+    return data_[t];
+  }
 
-  iterator begin() { return data.begin(); }
-  const_iterator begin() const { return data.begin(); }
-  const_iterator cbegin() const { return data.cbegin(); }
+  iterator begin()
+  {
+    return data_.begin();
+  }
+  const_iterator begin() const
+  {
+    return data_.begin();
+  }
+  const_iterator cbegin() const
+  {
+    return data_.cbegin();
+  }
 
-  iterator end() { return data.end(); }
-  const_iterator end() const { return data.end(); }
-  const_iterator cend() const { return data.cend(); }
+  iterator end()
+  {
+    return data_.end();
+  }
+  const_iterator end() const
+  {
+    return data_.end();
+  }
+  const_iterator cend() const
+  {
+    return data_.cend();
+  }
 };
 
 template <typename T, class hash_fkt>
@@ -96,9 +121,9 @@ public:
 
 private:
   using data_typet = std::vector<T>; // NOLINT
-  data_typet data;
+  data_typet data_;
   using numberst = std::unordered_map<T, number_type, hash_fkt>; // NOLINT
-  numberst numbers;
+  numberst numbers_;
 
 public:
   using size_type = typename data_typet::size_type;           // NOLINT
@@ -107,15 +132,13 @@ public:
 
   number_type number(const T &a)
   {
-    std::pair<typename numberst::const_iterator, bool> result=
-      numbers.insert(
-      std::pair<T, number_type>
-      (a, number_type(numbers.size())));
+    std::pair<typename numberst::const_iterator, bool> result = numbers_.insert(
+      std::pair<T, number_type>(a, number_type(numbers_.size())));
 
     if(result.second) // inserted?
     {
       this->push_back(a);
-      assert(this->size()==numbers.size());
+      assert(this->size() == numbers_.size());
     }
 
     return (result.first)->second;
@@ -123,9 +146,9 @@ public:
 
   optionalt<number_type> get_number(const T &a) const
   {
-    const auto it = numbers.find(a);
+    const auto it = numbers_.find(a);
 
-    if(it == numbers.end())
+    if(it == numbers_.end())
     {
       return {};
     }
@@ -134,28 +157,64 @@ public:
 
   void clear()
   {
-    data.clear();
-    numbers.clear();
+    data_.clear();
+    numbers_.clear();
   }
 
   template <typename U>
-  void push_back(U &&u) { data.push_back(std::forward<U>(u)); }
+  void push_back(U &&u)
+  {
+    data_.push_back(std::forward<U>(u));
+  }
 
-  T &operator[](size_type t) { return data[t]; }
-  const T &operator[](size_type t) const { return data[t]; }
+  T &operator[](size_type t)
+  {
+    return data_[t];
+  }
+  const T &operator[](size_type t) const
+  {
+    return data_[t];
+  }
 
-  T &at(size_type t) { return data.at(t); }
-  const T &at(size_type t) const { return data.at(t); }
+  T &at(size_type t)
+  {
+    return data_.at(t);
+  }
+  const T &at(size_type t) const
+  {
+    return data_.at(t);
+  }
 
-  size_type size() const { return data.size(); }
+  size_type size() const
+  {
+    return data_.size();
+  }
 
-  iterator begin() { return data.begin(); }
-  const_iterator begin() const { return data.begin(); }
-  const_iterator cbegin() const { return data.cbegin(); }
+  iterator begin()
+  {
+    return data_.begin();
+  }
+  const_iterator begin() const
+  {
+    return data_.begin();
+  }
+  const_iterator cbegin() const
+  {
+    return data_.cbegin();
+  }
 
-  iterator end() { return data.end(); }
-  const_iterator end() const { return data.end(); }
-  const_iterator cend() const { return data.cend(); }
+  iterator end()
+  {
+    return data_.end();
+  }
+  const_iterator end() const
+  {
+    return data_.end();
+  }
+  const_iterator cend() const
+  {
+    return data_.cend();
+  }
 };
 
 #endif // CPROVER_UTIL_NUMBERING_H

--- a/src/util/numbering.h
+++ b/src/util/numbering.h
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <vector>
 
 #include <util/invariant.h>
+#include <util/optional.h>
 
 template <typename T>
 // NOLINTNEXTLINE(readability/identifiers)
@@ -60,15 +61,14 @@ public:
     return number(a);
   }
 
-  bool get_number(const T &a, number_type &n) const
+  optionalt<number_type> get_number(const T &a) const
   {
-    typename numberst::const_iterator it=numbers.find(a);
-
-    if(it==numbers.end())
-      return true;
-
-    n=it->second;
-    return false;
+    const auto it = numbers.find(a);
+    if(it == numbers.end())
+    {
+      return {};
+    }
+    return it->second;
   }
 
   void clear()
@@ -129,15 +129,15 @@ public:
     return (result.first)->second;
   }
 
-  bool get_number(const T &a, number_type &n) const
+  optionalt<number_type> get_number(const T &a) const
   {
-    typename numberst::const_iterator it=numbers.find(a);
+    const auto it = numbers.find(a);
 
-    if(it==numbers.end())
-      return true;
-
-    n=it->second;
-    return false;
+    if(it == numbers.end())
+    {
+      return {};
+    }
+    return it->second;
   }
 
   void clear()

--- a/src/util/union_find.h
+++ b/src/util/union_find.h
@@ -168,16 +168,14 @@ public:
   // are 'a' and 'b' in the same set?
   bool same_set(const T &a, const T &b) const
   {
-    number_type na, nb;
-    bool have_na=!numbers.get_number(a, na),
-         have_nb=!numbers.get_number(b, nb);
+    const optionalt<number_type> na = numbers.get_number(a);
+    const optionalt<number_type> nb = numbers.get_number(a);
 
-    if(have_na && have_nb)
-      return uuf.same_set(na, nb);
-    else if(!have_na && !have_nb)
+    if(na && nb)
+      return uuf.same_set(*na, *nb);
+    if(!na && !nb)
       return a==b;
-    else
-      return false;
+    return false;
   }
 
   // are 'a' and 'b' in the same set?
@@ -259,9 +257,9 @@ public:
     uuf.isolate(number(a));
   }
 
-  bool get_number(const T &a, number_type &n) const
+  optionalt<number_type> get_number(const T &a) const
   {
-    return numbers.get_number(a, n);
+    return numbers.get_number(a);
   }
 
   size_t size() const { return numbers.size(); }


### PR DESCRIPTION
Small change to the interface of `numbering` that makes `get_number` return an optional, instead of mutating its parameter. Returning values, rather than mutating parameters, allows us to keep more variables const, and to avoid uninitialized variables.

Also remove code duplication between `numberingt` and `hash_numberingt` by introducing a common superclass.