### PR TITLE
Use existing UTF-16 conversion logic in Java test generation, which was previously missing escapes

### DIFF
--- a/src/java_bytecode/expr2java.cpp
+++ b/src/java_bytecode/expr2java.cpp
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <util/std_types.h>
 #include <util/std_expr.h>
 #include <util/symbol.h>
+#include <util/unicode.h>
 #include <util/arith_tools.h>
 #include <util/ieee_float.h>
 
@@ -191,20 +192,7 @@ std::string expr2javat::convert_constant(
     if(to_integer(src, int_value))
       UNREACHABLE;
 
-    dest+="(char)'";
-
-    if(int_value>=' ' && int_value<127)
-      dest+=static_cast<char>(int_value.to_long());
-    else
-    {
-      std::string hex=integer2string(int_value, 16);
-      while(hex.size()<4) hex='0'+hex;
-      dest+='\\';
-      dest+='u';
-      dest+=hex;
-    }
-
-    dest+='\'';
+    dest += "(char)'" + utf16_little_endian_to_java(int_value.to_long()) + '\'';
     return dest;
   }
   else if(src.type()==java_byte_type())

--- a/src/util/unicode.h
+++ b/src/util/unicode.h
@@ -26,6 +26,7 @@ std::string utf32_to_utf8(const std::basic_string<unsigned int> &s);
 
 std::wstring utf8_to_utf16_big_endian(const std::string &);
 std::wstring utf8_to_utf16_little_endian(const std::string &);
+std::string utf16_little_endian_to_java(const wchar_t ch);
 std::string utf16_little_endian_to_java(const std::wstring &in);
 
 std::vector<std::string> narrow_argv(int argc, const wchar_t **argv_wide);


### PR DESCRIPTION
newline and carriage return need to be printed as \n and \r in Java code, respectively (as opposed to \u000a and \u000d). ' and \ need to be escaped.

This fixes the bugs TG-561 and TG-1183.

Corresponding PR: https://github.com/diffblue/test-gen/pull/1195