### PR TITLE
[TG-1422] Remove evaluator precondition

### DIFF
--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -1196,8 +1196,6 @@ mp_integer interpretert::evaluate_address(
     if(expr.operands().size()!=1)
       throw "typecast expects one operand";
 
-    PRECONDITION(expr.type().id()==ID_pointer);
-
     return evaluate_address(expr.op0(), fail_quietly);
   }
   if(!fail_quietly)


### PR DESCRIPTION
This is related to the now closed #1595 . In summary, due to the inner workings of the generics concretisation code, we got some traces that caused the evaluator to fail with a precondition violation. 

After review of that PR, it was suggested that a better way to work around this would be to drop the precondition altogether, as it was too tight from the moment it had been introduced. This PR does just that.