### PR TITLE
Fix location of show-symbol-table

### DIFF
--- a/src/clobber/clobber_parse_options.cpp
+++ b/src/clobber/clobber_parse_options.cpp
@@ -126,6 +126,21 @@ int clobber_parse_optionst::doit()
   {
     goto_model=initialize_goto_model(cmdline, get_message_handler());
 
+
+    // show it?
+    if(cmdline.isset("show-loops"))
+    {
+      show_loop_ids(get_ui(), goto_model);
+      return 6;
+    }
+
+    // show it?
+    if(cmdline.isset("show-goto-functions"))
+    {
+      show_goto_functions(goto_model, get_ui());
+      return 6;
+    }
+
     label_properties(goto_model);
 
     if(cmdline.isset("show-properties"))
@@ -211,20 +226,6 @@ bool clobber_parse_optionst::process_goto_program(
 
     if(cmdline.isset("cover-assertions"))
       make_assertions_false(goto_model);
-
-    // show it?
-    if(cmdline.isset("show-loops"))
-    {
-      show_loop_ids(get_ui(), goto_model);
-      return true;
-    }
-
-    // show it?
-    if(cmdline.isset("show-goto-functions"))
-    {
-      show_goto_functions(goto_model, get_ui());
-      return true;
-    }
   }
 
   return false;

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -185,6 +185,20 @@ int goto_analyzer_parse_optionst::doit()
   if(process_goto_program(options))
     return 6;
 
+  // show it?
+  if(cmdline.isset("show-symbol-table"))
+  {
+    ::show_symbol_table(goto_model.symbol_table, get_ui());
+    return 6;
+  }
+
+  // show it?
+  if(cmdline.isset("show-goto-functions"))
+  {
+    show_goto_functions(goto_model, get_ui());
+    return 6;
+  }
+
   if(cmdline.isset("taint"))
   {
     std::string taint_file=cmdline.get_value("taint");
@@ -400,20 +414,6 @@ bool goto_analyzer_parse_optionst::process_goto_program(
 
     // add loop ids
     goto_model.goto_functions.compute_loop_numbers();
-
-    // show it?
-    if(cmdline.isset("show-goto-functions"))
-    {
-      show_goto_functions(goto_model, get_ui());
-      return true;
-    }
-
-    // show it?
-    if(cmdline.isset("show-symbol-table"))
-    {
-      ::show_symbol_table(goto_model, get_ui());
-      return true;
-    }
   }
 
   catch(const char *e)


### PR DESCRIPTION
These abilities don't belong in the module-level pass but in the main driver.
This is simply moving code and makes no functional difference.
The anomaly was found when implementing lazy loading, where the module-level pass is more strictly used as such.