### PR TITLE
Add headers needed to build under MSVC14 / Visual Studio 2015

### DIFF
--- a/src/java_bytecode/generate_java_generic_type.cpp
+++ b/src/java_bytecode/generate_java_generic_type.cpp
@@ -6,6 +6,9 @@
  Author: DiffBlue Limited. All rights reserved.
 
 \*******************************************************************/
+
+#include <iterator>
+
 #include "generate_java_generic_type.h"
 #include <util/namespace.h>
 #include <java_bytecode/java_types.h>

--- a/src/java_bytecode/java_types.cpp
+++ b/src/java_bytecode/java_types.cpp
@@ -7,6 +7,7 @@ Author: Daniel Kroening, kroening@kroening.com
 \*******************************************************************/
 
 #include <cctype>
+#include <iterator>
 
 #include <util/prefix.h>
 #include <util/std_types.h>


### PR DESCRIPTION
These were presumably included from other standard library includes on other target platforms.