### PR TITLE
Fix iterator comparison bug in expr_iterator

### DIFF
--- a/src/util/expr_iterator.h
+++ b/src/util/expr_iterator.h
@@ -53,7 +53,10 @@ struct depth_iterator_expr_statet final
 inline bool operator==(
   const depth_iterator_expr_statet &left,
   const depth_iterator_expr_statet &right)
-{ return left.it==right.it && left.expr.get()==right.expr.get(); }
+{
+  return distance(left.it, left.end) == distance(right.it, right.end) &&
+         left.expr.get() == right.expr.get();
+}
 
 /// Depth first search iterator base - iterates over supplied expression
 /// and all its operands recursively.


### PR DESCRIPTION
After calling `mutate()` on an `expr_iterator`, a new state struct is created, containing iterators over the operands of a new expr created by copy-on-write behaviour. When this struct is compared for equality with the current struct at the back of the stack, iterators from two different collections are compared, which is undefined behaviour.

This patch changes the equality comparison to check the size of the iterator range in each state struct, rather than comparing iterators directly. This way, there's no danger of comparing iterators from different collections.

This bug was found by enabling `-D_GLIBCXX_DEBUG`. I suggest that this debug mode is added to Travis.