### PR TITLE
Use stdlib debug mode in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,9 @@ jobs:
       before_install:
         - mkdir bin ; ln -s /usr/bin/gcc-5 bin/gcc
       # env: COMPILER=g++-5 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover -fno-omit-frame-pointer"
-      env: COMPILER="ccache g++-5"
+      env:
+        - COMPILER="ccache g++-5"
+        - EXTRA_CXXFLAGS="-D_GLIBCXX_DEBUG"
 
     # OS X using g++
     - stage: Test different OS/CXX/Flags


### PR DESCRIPTION
I've spent the morning finding bugs with iterator comparisons that were discovered using the debug mode of the g++ stdlib. It would be helpful to have this enabled in Travis, so that issues are discovered before buggy code is merged.