### PR TITLE
Fix problem with string data allocation TG-1612

### DIFF
--- a/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/src/java_bytecode/java_string_library_preprocess.cpp
@@ -1696,14 +1696,6 @@ codet java_string_library_preprocesst::make_init_from_array_code(
   /// \todo this assumes the array to be constant between all calls to
   /// string primitives, which may not be true in general.
   refined_string_exprt string_arg = to_string_expr(args[1]);
-  add_pointer_to_array_association(
-    string_arg.content(),
-    dereference_exprt(
-      string_arg.content(),
-      array_typet(java_char_type(), infinity_exprt(java_int_type()))),
-    symbol_table,
-    loc,
-    code);
 
   // The third argument is `count`, whereas the third argument of substring
   // is `end` which corresponds to `offset+count`

--- a/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/src/java_bytecode/java_string_library_preprocess.cpp
@@ -519,6 +519,7 @@ refined_string_exprt java_string_library_preprocesst::make_nondet_string_expr(
   symbol_table_baset &symbol_table,
   code_blockt &code)
 {
+  /// \todo refactor with initialize_nonddet_string_struct
   const refined_string_exprt str = decl_string_expr(loc, symbol_table, code);
 
   side_effect_expr_nondett nondet_length(str.length().type());

--- a/src/solvers/refinement/string_constraint_generator_main.cpp
+++ b/src/solvers/refinement/string_constraint_generator_main.cpp
@@ -270,7 +270,10 @@ exprt string_constraint_generatort::associate_array_to_pointer(
 
   /// \todo We should use a function for inserting the correspondance
   /// between array and pointers.
-  arrays_of_pointers_.insert(std::make_pair(pointer_expr, array_expr));
+  const auto it_bool =
+    arrays_of_pointers_.insert(std::make_pair(pointer_expr, array_expr));
+  INVARIANT(
+    it_bool.second, "should not associate two arrays to the same pointer");
   add_default_axioms(to_array_string_expr(array_expr));
   return from_integer(0, f.type());
 }

--- a/unit/java_bytecode/java_object_factory/gen_nondet_string_init.cpp
+++ b/unit/java_bytecode/java_object_factory/gen_nondet_string_init.cpp
@@ -70,18 +70,22 @@ SCENARIO(
           "tmp_object_factory = NONDET(int);",
           "__CPROVER_assume(tmp_object_factory >= 0);",
           "__CPROVER_assume(tmp_object_factory <= 20);",
+          "char (*string_data_pointer)[INFINITY()];",
+          "string_data_pointer = "
+            "ALLOCATE(char [INFINITY()], INFINITY(), false);",
           "char nondet_infinite_array[INFINITY()];",
           "nondet_infinite_array = NONDET(char [INFINITY()]);",
+          "*string_data_pointer = nondet_infinite_array;",
           "int return_array;",
           "return_array = cprover_associate_array_to_pointer_func"
-          "(nondet_infinite_array, nondet_infinite_array);",
+            "(*string_data_pointer, *string_data_pointer);",
           "int return_array;",
           "return_array = cprover_associate_length_to_array_func"
-          "(nondet_infinite_array, tmp_object_factory);",
+            "(*string_data_pointer, tmp_object_factory);",
           "arg = { .@java.lang.Object={ .@class_identifier"
-          "=\"java::java.lang.String\", .@lock=false },"
-          " .length=tmp_object_factory, "
-          ".data=nondet_infinite_array };"};
+            "=\"java::java.lang.String\", .@lock=false },"
+            " .length=tmp_object_factory, "
+            ".data=*string_data_pointer };"};
 
         for(std::size_t i = 0;
             i < code_string.size() && i < reference_code.size();


### PR DESCRIPTION
String data was allocated on a stack as an infinite array of characters. This could cause problems when this happens in a loop or a function call as several strings could have the same data pointer. We fix that by using dynamic allocation instead.
