### PR TITLE
[Don't merge] Add cron jobs for sanitizers and libc++ debug mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -241,6 +241,27 @@ jobs:
         - COMPILER="ccache g++"
       script: echo "This is coverity build. No need for tests."
 
+    - stage: Extended checks
+      env:
+        - NAME="sanitized build"
+      if: type = cron
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - libc++-dev
+      os: linux
+      compiler: clang
+      cache: ccache
+      install:
+        - ccache -z
+        - ccache --max-size=1G
+        - cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Sanitized -DCMAKE_CXX_COMPILER="clang++" -DCMAKE_CXX_FLAGS="-Wno-error=unused-command-line-argument -stdlib=libc++"
+        - cmake --build build -- -j4
+      script: (cd build; ctest -j2 -V -L CORE)
+
+
   allow_failures:
     - <<: *formatting-stage
     - <<: *linter-stage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.2)
 
+include(cmake/set_up_configs.cmake)
+
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")

--- a/cmake/set_up_configs.cmake
+++ b/cmake/set_up_configs.cmake
@@ -1,0 +1,10 @@
+if(NOT CONFIGURATIONS_HAVE_BEEN_SET_UP)
+    set(CONFIGURATIONS_HAVE_BEEN_SET_UP true)
+    set(build_types_string "Debug;Release;RelWithDebInfo;Sanitized;LibCPPDebug")
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY HELPSTRING "Choose the type of build")
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "${build_types_string}")
+    set(CMAKE_CONFIGURATION_TYPES "${build_types_string}" CACHE STRING "" FORCE)
+
+    set(CMAKE_CXX_FLAGS_SANITIZED "-fsanitize=address,undefined")
+    set(CMAKE_CXX_FLAGS_LIBCPPDEBUG "-D_LIBCPP_DEBUG=1 -D_GLIBCXX_DEBUG")
+endif()


### PR DESCRIPTION
This PR adds stages for address and undefined-behavior sanitizer, and for the libc++ debug mode. These stages should only run during a cron job.

Obviously don't merge this until we know that the stages work properly...

I think the input of @chrisr-diffblue, @owen-jones-diffblue, @zemanlx would be especially useful on this PR.