### PR TITLE
Fix to unified_difft::lcss to not error on iterator check

### DIFF
--- a/src/goto-diff/unified_diff.cpp
+++ b/src/goto-diff/unified_diff.cpp
@@ -266,7 +266,8 @@ unified_difft::differencest unified_difft::lcss(
     {
       differences.push_back(differencet::DELETED);
       --i;
-      --old_rit;
+      if(old_goto_program.instructions.begin()!=old_rit)
+        --old_rit;
     }
     else if(instructions_equal(*old_rit, *new_rit))
     {
@@ -286,7 +287,8 @@ unified_difft::differencest unified_difft::lcss(
     {
       differences.push_back(differencet::NEW);
       --j;
-      --new_rit;
+      if(new_goto_program.instructions.begin()!=new_rit)
+        --new_rit;
     }
   }
 


### PR DESCRIPTION
Change to 
```
static differencest unified_difft::lcss(
  const irep_idt &, const goto_programt &, const goto_programt &);
```
to not stop on error in debug iterator check