### PR TITLE
Java: fully use allocate

### DIFF
--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -539,31 +539,6 @@ void goto_convertt::do_cpp_new(
   dest.destructive_append(tmp_initializer);
 }
 
-void set_class_identifier(
-  struct_exprt &expr,
-  const namespacet &ns,
-  const symbol_typet &class_type)
-{
-  const struct_typet &struct_type=
-    to_struct_type(ns.follow(expr.type()));
-  const struct_typet::componentst &components=struct_type.components();
-
-  if(components.empty())
-    return;
-  assert(!expr.operands().empty());
-
-  if(components.front().get_name()=="@class_identifier")
-  {
-    assert(expr.op0().id()==ID_constant);
-    expr.op0()=constant_exprt(class_type.get_identifier(), string_typet());
-  }
-  else
-  {
-    assert(expr.op0().id()==ID_struct);
-    set_class_identifier(to_struct_expr(expr.op0()), ns, class_type);
-  }
-}
-
 void goto_convertt::do_java_new(
   const exprt &lhs,
   const side_effect_exprt &rhs,
@@ -594,8 +569,6 @@ void goto_convertt::do_java_new(
   dereference_exprt deref(lhs, object_type);
   exprt zero_object=
     zero_initializer(object_type, location, ns, get_message_handler());
-  set_class_identifier(
-    to_struct_expr(zero_object), ns, to_symbol_type(object_type));
   goto_programt::targett t_i=dest.add_instruction(ASSIGN);
   t_i->code=code_assignt(deref, zero_object);
   t_i->source_location=location;
@@ -641,8 +614,6 @@ void goto_convertt::do_java_new_array(
   dereference_exprt deref(lhs, object_type);
   exprt zero_object=
     zero_initializer(object_type, location, ns, get_message_handler());
-  set_class_identifier(
-    to_struct_expr(zero_object), ns, to_symbol_type(object_type));
   goto_programt::targett t_i=dest.add_instruction(ASSIGN);
   t_i->code=code_assignt(deref, zero_object);
   t_i->source_location=location;

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -557,21 +557,12 @@ void goto_convertt::do_java_new(
   // we produce a malloc side-effect, which stays
   side_effect_exprt malloc_expr(ID_allocate);
   malloc_expr.copy_to_operands(object_size);
-  // could use true and get rid of the code below
-  malloc_expr.copy_to_operands(false_exprt());
+  malloc_expr.copy_to_operands(true_exprt());
   malloc_expr.type()=rhs.type();
 
   goto_programt::targett t_n=dest.add_instruction(ASSIGN);
   t_n->code=code_assignt(lhs, malloc_expr);
   t_n->source_location=location;
-
-  // zero-initialize the object
-  dereference_exprt deref(lhs, object_type);
-  exprt zero_object=
-    zero_initializer(object_type, location, ns, get_message_handler());
-  goto_programt::targett t_i=dest.add_instruction(ASSIGN);
-  t_i->code=code_assignt(deref, zero_object);
-  t_i->source_location=location;
 }
 
 void goto_convertt::do_java_new_array(
@@ -595,8 +586,7 @@ void goto_convertt::do_java_new_array(
   // we produce a malloc side-effect, which stays
   side_effect_exprt malloc_expr(ID_allocate);
   malloc_expr.copy_to_operands(object_size);
-  // code use true and get rid of the code below
-  malloc_expr.copy_to_operands(false_exprt());
+  malloc_expr.copy_to_operands(true_exprt());
   malloc_expr.type()=rhs.type();
 
   goto_programt::targett t_n=dest.add_instruction(ASSIGN);
@@ -610,15 +600,8 @@ void goto_convertt::do_java_new_array(
   // introduce such dependencies. We do this simple check instead:
   PRECONDITION(struct_type.components().size()==3);
 
-  // Init base class:
+  // it's an array, we need to set the length field
   dereference_exprt deref(lhs, object_type);
-  exprt zero_object=
-    zero_initializer(object_type, location, ns, get_message_handler());
-  goto_programt::targett t_i=dest.add_instruction(ASSIGN);
-  t_i->code=code_assignt(deref, zero_object);
-  t_i->source_location=location;
-
-  // if it's an array, we need to set the length field
   member_exprt length(
     deref,
     struct_type.components()[1].get_name(),


### PR DESCRIPTION
This has the potential for performance improvements as it permits more constant propagation. Whether it actually does is not clear unless there is some established Java performance benchmark?

Also, these changes would compete with "Do lowering of java_new as a functions-level pass" of #1563, hence marking it "Do not merge". All input is very much solicited.