### PR TITLE
Adds an option to simplify repeatedly instead of just once

### DIFF
--- a/regression/goto-analyzer-simplify/fully-simplify-expression/main.c
+++ b/regression/goto-analyzer-simplify/fully-simplify-expression/main.c
@@ -1,0 +1,9 @@
+unsigned int nondet_uint();
+
+int main(void)
+{
+  unsigned int K = nondet_uint();
+  unsigned int x = 0u;
+  unsigned int result = K * x;
+  return 0;
+}

--- a/regression/goto-analyzer-simplify/fully-simplify-expression/test.desc
+++ b/regression/goto-analyzer-simplify/fully-simplify-expression/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+"--variable --simplify-full"
+
+result = 0u

--- a/src/analyses/variable-sensitivity/abstract_enviroment.cpp
+++ b/src/analyses/variable-sensitivity/abstract_enviroment.cpp
@@ -248,6 +248,22 @@ bool abstract_environmentt::assign(
 
   // Write the value for the root symbol back into the map
   assert(lhs_type==rhs_type);
+
+  // check if we can reduce the rhs to a constant
+  // if not, we should write top
+  // TODO: This throws away useful information,
+  //       but we don't have anything much better right
+  //       now; We can't guarantee that the value of the
+  //       expression won't change in the future, so carrying
+  //       the expression as if its value was constant will
+  //       lead to incorrect statements about the code
+  exprt final_value_constant = final_value->to_constant();
+  if(final_value_constant.is_nil()) {
+    final_value = abstract_object_factory(rhs_type, ns, true, false);
+  } else {
+    final_value = eval(final_value_constant, ns);
+  }
+
   // If LHS was directly the symbol
   if(s.id()==ID_symbol)
   {

--- a/src/analyses/variable-sensitivity/abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_object.cpp
@@ -175,10 +175,9 @@ abstract_object_pointert abstract_objectt::expression_transform(
 
     if(lhs_value.is_nil())
     {
-      // One of the values is not resolvable to a constant
-      // so we can't really do anything more with
-      // this expression and should just return top for the result
-      return environment.abstract_object_factory(expr.type(), ns, true, false);
+      // do not give up if a sub-expression is not a constant,
+      // because the whole expression may still be simplified in some cases
+      constant_replaced_expr.operands().push_back(op);
     }
     else
     {
@@ -189,7 +188,12 @@ abstract_object_pointert abstract_objectt::expression_transform(
   }
 
   exprt simplified=simplify_expr(constant_replaced_expr, ns);
-  return environment.abstract_object_factory(simplified.type(), simplified, ns);
+  if(simplified.is_constant()) {
+    return environment.abstract_object_factory(simplified.type(), simplified, ns);
+  } else {
+    // if our final expression isn't a constant, just return top
+    return environment.abstract_object_factory(expr.type(), ns, true, false);
+  }
 }
 
 /*******************************************************************\

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -201,6 +201,10 @@ void goto_analyzer_parse_optionst::get_command_line_options(optionst &options)
     "simplify-slicing",
     !(cmdline.isset("no-simplify-slicing")));
 
+  options.set_option(
+    "simplify-full",
+    cmdline.isset("simplify-full"));
+
   // Abstract interpreter choice
   options.set_option("flow-sensitive", false);
   options.set_option("concurrent", false);

--- a/src/goto-analyzer/goto_analyzer_parse_options.h
+++ b/src/goto-analyzer/goto_analyzer_parse_options.h
@@ -152,7 +152,8 @@ class optionst;
   "(unwindset)" \
   WRAP_ENTRY_POINT_IN_WHILE_TRUE \
   "(functions-ignore)" \
-  "(functions-full)"
+  "(functions-full)" \
+  "(simplify-full)"
 
 class goto_analyzer_parse_optionst:
   public parse_options_baset,


### PR DESCRIPTION
I did some tests to check if simplifying goto code twice would yield the same result (i.e. simplify once simplifies as much as we can). This turned out not to be the case.

This adds an option (--simplify-full) to simplify the goto code repeatedly until nothing changes anymore, which should address that issue.