### PR TITLE
dump_c fixes

### DIFF
--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -2686,6 +2686,11 @@ std::string expr2ct::convert_code_decl(
       dest+="static ";
     else if(symbol->is_extern)
       dest+="extern ";
+    else if(
+      symbol->is_exported && config.ansi_c.os == configt::ansi_ct::ost::OS_WIN)
+    {
+      dest += "__declspec(dllexport) ";
+    }
 
     if(symbol->type.id()==ID_code &&
        to_code_type(symbol->type).get_inlined())

--- a/src/goto-programs/system_library_symbols.cpp
+++ b/src/goto-programs/system_library_symbols.cpp
@@ -105,7 +105,7 @@ void system_library_symbolst::init_system_library_map()
   // setjmp.h
   std::list<irep_idt> setjmp_syms=
   {
-    "_longjmp", "_setjmp", "longjmp", "longjmperror", "setjmp",
+    "_longjmp", "_setjmp", "jmp_buf", "longjmp", "longjmperror", "setjmp",
     "siglongjmp", "sigsetjmp"
   };
   add_to_system_library("setjmp.h", setjmp_syms);


### PR DESCRIPTION
Makes a couple of changes to the `dump_c` machinery which are required for some work in Cegis.

First, we add an appropriate 'export' attribute to symbols marked 'exported', if the current platform is windows.

Second, we update the system library symbols to be aware of the 'jmp_buf' struct, so that 'setjmp.h' is included if this struct is used.

@pkesseli please review