### PR TITLE
type_dynamic_cast (extension of expr_cast)

### DIFF
--- a/src/solvers/flattening/boolbv_width.cpp
+++ b/src/solvers/flattening/boolbv_width.cpp
@@ -194,10 +194,7 @@ const boolbv_widtht::entryt &boolbv_widtht::get_entry(const typet &type) const
     // no width
   }
   else if(type_id==ID_pointer)
-  {
-    entry.total_width=to_pointer_type(type).get_width();
-    DATA_INVARIANT(entry.total_width!=0, "pointer must have width");
-  }
+    entry.total_width = type_checked_cast<pointer_typet>(type).get_width();
   else if(type_id==ID_symbol)
     entry=get_entry(ns.follow(type));
   else if(type_id==ID_struct_tag)

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -20,6 +20,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "expr.h"
 #include "mp_arith.h"
 #include "invariant.h"
+#include "expr_cast.h"
 
 class constant_exprt;
 
@@ -1428,6 +1429,18 @@ inline pointer_typet &to_pointer_type(typet &type)
   PRECONDITION(type.id()==ID_pointer);
   PRECONDITION(!type.get(ID_width).empty());
   return static_cast<pointer_typet &>(type);
+}
+
+template <>
+inline bool can_cast_type<pointer_typet>(const typet &type)
+{
+  return type.id() == ID_pointer;
+}
+
+inline void validate_type(const pointer_typet &type)
+{
+  DATA_INVARIANT(!type.get(ID_width).empty(), "pointer must have width");
+  DATA_INVARIANT(type.get_width() > 0, "pointer must have non-zero width");
 }
 
 /*! \brief The reference type

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -1417,8 +1417,9 @@ public:
 inline const pointer_typet &to_pointer_type(const typet &type)
 {
   PRECONDITION(type.id()==ID_pointer);
-  PRECONDITION(!type.get(ID_width).empty());
-  return static_cast<const pointer_typet &>(type);
+  const pointer_typet &ret = static_cast<const pointer_typet &>(type);
+  validate_type(ret);
+  return ret;
 }
 
 /*! \copydoc to_pointer_type(const typet &)
@@ -1427,8 +1428,9 @@ inline const pointer_typet &to_pointer_type(const typet &type)
 inline pointer_typet &to_pointer_type(typet &type)
 {
   PRECONDITION(type.id()==ID_pointer);
-  PRECONDITION(!type.get(ID_width).empty());
-  return static_cast<pointer_typet &>(type);
+  pointer_typet &ret = static_cast<pointer_typet &>(type);
+  validate_type(ret);
+  return ret;
 }
 
 template <>


### PR DESCRIPTION
This is similar to expr_cast (added by @NathanJPhillips), with some code duplication.
Allows to use type_dynamic_cast<> for typet objects in the same way we
use expr_dynamic_cast<> for exprt.
This PR adds an example use of this for pointer_typet.