### PR TITLE
Allows simplification of expressions containing non-const

### DIFF
--- a/regression/goto-analyzer-simplify/simplify-complex-expression/main.c
+++ b/regression/goto-analyzer-simplify/simplify-complex-expression/main.c
@@ -1,0 +1,11 @@
+int nondet_int(void);
+
+int main(void)
+{
+  int r = nondet_int();
+  r = r + 1;
+  if(r == 2) {
+    return 1;
+  }
+  return 0;
+}

--- a/regression/goto-analyzer-simplify/simplify-complex-expression/test.desc
+++ b/regression/goto-analyzer-simplify/simplify-complex-expression/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+"--variable"
+
+r == 2

--- a/regression/goto-analyzer-simplify/simplify-multiply-by-zero/main.c
+++ b/regression/goto-analyzer-simplify/simplify-multiply-by-zero/main.c
@@ -1,0 +1,8 @@
+int nondet_int(void);
+
+int main(void)
+{
+  int K = nondet_int();
+  int x = 0;
+  return K * x;
+}

--- a/regression/goto-analyzer-simplify/simplify-multiply-by-zero/test.desc
+++ b/regression/goto-analyzer-simplify/simplify-multiply-by-zero/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+"--variable"
+
+main#return_value = 0;

--- a/src/analyses/variable-sensitivity/abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_object.cpp
@@ -175,10 +175,9 @@ abstract_object_pointert abstract_objectt::expression_transform(
 
     if(lhs_value.is_nil())
     {
-      // One of the values is not resolvable to a constant
-      // so we can't really do anything more with
-      // this expression and should just return top for the result
-      return environment.abstract_object_factory(expr.type(), ns, true, false);
+      // do not give up if a sub-expression is not a constant,
+      // because the whole expression may still be simplified in some cases
+      constant_replaced_expr.operands().push_back(op);
     }
     else
     {
@@ -189,7 +188,12 @@ abstract_object_pointert abstract_objectt::expression_transform(
   }
 
   exprt simplified=simplify_expr(constant_replaced_expr, ns);
-  return environment.abstract_object_factory(simplified.type(), simplified, ns);
+  if(simplified.is_constant()) {
+    return environment.abstract_object_factory(simplified.type(), simplified, ns);
+  } else {
+    // if our final expression isn't a constant, just return top
+    return environment.abstract_object_factory(expr.type(), ns, true, false);
+  }
 }
 
 /*******************************************************************\

--- a/src/analyses/variable-sensitivity/abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_object.cpp
@@ -188,9 +188,13 @@ abstract_object_pointert abstract_objectt::expression_transform(
   }
 
   exprt simplified=simplify_expr(constant_replaced_expr, ns);
-  if(simplified.is_constant()) {
-    return environment.abstract_object_factory(simplified.type(), simplified, ns);
-  } else {
+  if(simplified.is_constant())
+  {
+    return environment.abstract_object_factory(
+            simplified.type(), simplified, ns);
+  }
+  else
+  {
     // if our final expression isn't a constant, just return top
     return environment.abstract_object_factory(expr.type(), ns, true, false);
   }


### PR DESCRIPTION
Previously, abstract_objectt::expression_transform returned top
whenever one of the subexpressions of an operator was non-const,
which didn't allow simplification in situations like

```
int x = 0;
int y = nondet_int();
int z = x * y;
```

The old behavior would've replaced `x * y` with `0 * y`,
with this change it will correctly simplify it to `0` instead.