### PR TITLE
Allows simplification of expressions containing non-const

### DIFF
--- a/regression/goto-analyzer-simplify/simplify-complex-expression/main.c
+++ b/regression/goto-analyzer-simplify/simplify-complex-expression/main.c
@@ -1,0 +1,11 @@
+int nondet_int(void);
+
+int main(void)
+{
+  int r = nondet_int();
+  r = r + 1;
+  if(r == 2) {
+    return 1;
+  }
+  return 0;
+}

--- a/regression/goto-analyzer-simplify/simplify-complex-expression/test.desc
+++ b/regression/goto-analyzer-simplify/simplify-complex-expression/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--variable
+r == 2
+^SIGNAL=0$
+^EXIT=6$
+--
+--
+
+Checks for a bug that occurred while changing the simplifier,
+where a variable would be replaced by the RHS of its last assignment,
+even if the value of that expression had changed since then;
+Most egregiously when the RHS contained the symbol on the LHS (thus leading
+to a recursive definition).

--- a/regression/goto-analyzer-simplify/simplify-multiply-by-zero/main.c
+++ b/regression/goto-analyzer-simplify/simplify-multiply-by-zero/main.c
@@ -1,0 +1,8 @@
+int nondet_int(void);
+
+int main(void)
+{
+  int K = nondet_int();
+  int x = 0;
+  return K * x;
+}

--- a/regression/goto-analyzer-simplify/simplify-multiply-by-zero/test.desc
+++ b/regression/goto-analyzer-simplify/simplify-multiply-by-zero/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+"--variable"
+^SIGNAL=0$
+^EXIT=6$
+main#return_value = 0;
+--
+--
+Tests that a multiplication
+of variable*variable can be simplified
+if one of the variables can be evaluated to 0.


### PR DESCRIPTION
Previously, abstract_objectt::expression_transform returned top
whenever one of the subexpressions of an operator was non-const,
which didn't allow simplification in situations like

```
int x = 0;
int y = nondet_int();
int z = x * y;
```

The old behavior would've replaced `x * y` with `0 * y`,
with this change it will correctly simplify it to `0` instead.