### PR TITLE
[TG-1888] Correct some classes visibility levels

### DIFF
--- a/src/java_bytecode/generate_java_generic_type.cpp
+++ b/src/java_bytecode/generate_java_generic_type.cpp
@@ -106,7 +106,7 @@ symbolt generate_java_generic_typet::operator()(
 
   const java_specialized_generic_class_typet new_java_class{
     generic_name,
-    class_definition.get_tag(),
+    class_definition,
     replacement_components,
     existing_generic_type.generic_type_arguments()};
 

--- a/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/src/java_bytecode/java_string_library_preprocess.cpp
@@ -192,7 +192,7 @@ typet string_length_type()
 void java_string_library_preprocesst::add_string_type(
   const irep_idt &class_name, symbol_tablet &symbol_table)
 {
-  class_typet string_type;
+  java_class_typet string_type;
   string_type.set_tag(class_name);
   string_type.components().resize(3);
   string_type.components()[0].set_name("@java.lang.Object");
@@ -204,6 +204,7 @@ void java_string_library_preprocesst::add_string_type(
   string_type.components()[2].set_name("data");
   string_type.components()[2].set_pretty_name("data");
   string_type.components()[2].type() = pointer_type(java_char_type());
+  string_type.set_access(ID_public);
   string_type.add_base(symbol_typet("java::java.lang.Object"));
   if(class_name!="java.lang.CharSequence")
   {

--- a/src/java_bytecode/java_types.h
+++ b/src/java_bytecode/java_types.h
@@ -456,12 +456,13 @@ public:
   /// parameters and name.
   /// \param generic_name: The new name for the class
   ///   (like Generic<java::Float>)
-  /// \param tag: The name for the original class (like java::Generic)
+  /// \param originating_class: The name for the original class (like
+  ///   java::Generic)
   /// \param new_components: The specialised components
   /// \return The newly constructed class.
   java_specialized_generic_class_typet(
     const irep_idt &generic_name,
-    const irep_idt &tag,
+    const java_class_typet &originating_class,
     const struct_typet::componentst &new_components,
     const generic_type_argumentst &specialised_parameters)
   {
@@ -469,7 +470,8 @@ public:
     set(ID_name, "java::" + id2string(generic_name));
     set(ID_base_name, id2string(generic_name));
     components() = new_components;
-    set_tag(tag);
+    set_tag(originating_class.get_tag());
+    set_access(originating_class.get_access());
 
     generic_type_arguments() = specialised_parameters;
   }


### PR DESCRIPTION
`java.lang.String` did not have a visibility level set. This has been changed to `ID_public`. 

Generic classes were not mimicking the class they were based on, this is now fixed.

This needs some rebasing before being merged. 