### PR TITLE
Add support for partial path merging with path exploration

### DIFF
--- a/src/ansi-c/ansi_c_internal_additions.cpp
+++ b/src/ansi-c/ansi_c_internal_additions.cpp
@@ -234,6 +234,9 @@ void ansi_c_internal_additions(std::string &code)
     "void __CPROVER_k_induction_hint(unsigned min, unsigned max, "
       "unsigned step, unsigned loop_free);\n"
 
+    // Switches on path exploration when doing `--paths partial`
+    "void __CPROVER_begin_path_explore();\n"
+
     // format string-related
     "int __CPROVER_scanf(const char *, ...);\n"
 

--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -620,7 +620,8 @@ int bmct::do_language_agnostic_bmc(
       result = bmc.run(goto_model.goto_functions);
     }
     INVARIANT(
-      opts.get_bool_option("paths") || worklist.empty(),
+      opts.get_bool_option("paths") || opts.get_bool_option("partial-merge") ||
+        worklist.empty(),
       "the worklist should be empty after doing full-program "
       "model checking, but the worklist contains " +
         std::to_string(worklist.size()) + " unexplored branches.");
@@ -698,7 +699,8 @@ void bmct::perform_symbolic_execution(const goto_functionst &goto_functions)
 {
   symex.symex_from_entry_point_of(goto_functions, symex_symbol_table);
   INVARIANT(
-    options.get_bool_option("paths") || branch_worklist.empty(),
+    options.get_bool_option("paths") ||
+      options.get_bool_option("partial-merge") || branch_worklist.empty(),
     "Branch points were saved even though we should have been "
     "executing the entire program and merging paths");
 }

--- a/src/cbmc/bmc.h
+++ b/src/cbmc/bmc.h
@@ -166,7 +166,8 @@ protected:
     symex.record_coverage =
       !options.get_option("symex-coverage-report").empty();
     INVARIANT(
-      options.get_bool_option("paths"),
+      options.get_bool_option("paths") ||
+        options.get_bool_option("partial-merge"),
       "Should only use saved equation & goto_state constructor "
       "when doing path exploration");
   }
@@ -297,15 +298,17 @@ private:
   "(no-unwinding-assertions)"                                                  \
   "(no-pretty-names)"                                                          \
   "(partial-loops)"                                                            \
-  "(paths)"                                                                    \
+  "(paths):"                                                                   \
   "(depth):"                                                                   \
   "(unwind):"                                                                  \
   "(unwindset):"                                                               \
-  "(graphml-witness):"                                                         \
-  "(unwindset):"
+  "(graphml-witness):"
 
 #define HELP_BMC                                                               \
-  " --paths                      explore paths one at a time\n"                \
+  " --paths [partial]            explore paths one at a time. If 'partial'\n"  \
+  "                              is given, do path exploration only after\n"   \
+  "                              seeing __CPROVER_begin_path_explore() in\n"   \
+  "                              the input program\n"                          \
   " --program-only               only show program expression\n"               \
   " --show-loops                 show the loops in the program\n"              \
   " --depth nr                   limit search depth\n"                         \

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -108,7 +108,12 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
   }
 
   if(cmdline.isset("paths"))
-    options.set_option("paths", true);
+  {
+    if(cmdline.get_value("paths") == "partial")
+      options.set_option("partial-merge", true);
+    else
+      options.set_option("paths", true);
+  }
 
   if(cmdline.isset("program-only"))
     options.set_option("program-only", true);

--- a/src/goto-instrument/accelerate/scratch_program.h
+++ b/src/goto-instrument/accelerate/scratch_program.h
@@ -37,8 +37,8 @@ class scratch_programt:public goto_programt
 public:
   scratch_programt(symbol_tablet &_symbol_table, message_handlert &mh)
     : constant_propagation(true),
+      symex_state(false),
       symbol_table(_symbol_table),
-      symex_symbol_table(),
       ns(symbol_table, symex_symbol_table),
       equation(),
       branch_worklist(),

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -21,8 +21,9 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <analyses/dirty.h>
 
-goto_symex_statet::goto_symex_statet()
+goto_symex_statet::goto_symex_statet(bool doing_partial_merging)
   : depth(0),
+    doing_partial_merging(doing_partial_merging),
     symex_target(nullptr),
     atomic_section_id(0),
     record_events(true),

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -32,7 +32,7 @@ Author: Daniel Kroening, kroening@kroening.com
 class goto_symex_statet final
 {
 public:
-  goto_symex_statet();
+  explicit goto_symex_statet(bool doing_partial_merging);
   ~goto_symex_statet();
 
   /// \brief Fake "copy constructor" that initializes the `symex_target` member
@@ -51,6 +51,9 @@ public:
 
   /// distance from entry
   unsigned depth;
+
+  const bool doing_partial_merging;
+  bool doing_path_exploration;
 
   guardt guard;
   symex_targett::sourcet source;
@@ -204,6 +207,8 @@ public:
   {
   public:
     unsigned depth;
+    const bool doing_partial_merging;
+    bool doing_path_exploration;
     level2t::current_namest level2_current_names;
     value_sett value_set;
     guardt guard;
@@ -213,6 +218,8 @@ public:
 
     explicit goto_statet(const goto_symex_statet &s):
       depth(s.depth),
+      doing_partial_merging(s.doing_partial_merging),
+      doing_path_exploration(s.doing_path_exploration),
       level2_current_names(s.level2.current_names),
       value_set(s.value_set),
       guard(s.guard),
@@ -243,6 +250,8 @@ public:
 
   explicit goto_symex_statet(const goto_statet &s)
     : depth(s.depth),
+      doing_partial_merging(s.doing_partial_merging),
+      doing_path_exploration(s.doing_path_exploration),
       guard(s.guard),
       source(s.source),
       propagation(s.propagation),

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -111,7 +111,7 @@ void goto_symext::symex_goto(statet &state)
     (simpl_state_guard.is_true() ||
      // or there is another block, but we're doing path exploration so
      // we're going to skip over it for now and return to it later.
-     options.get_bool_option("paths")))
+     state.doing_path_exploration))
   {
     DATA_INVARIANT(
       instruction.targets.size() > 0,
@@ -172,7 +172,7 @@ void goto_symext::symex_goto(statet &state)
     log.debug() << "Resuming from '" << state_pc->code.source_location() << "'"
                 << log.eom;
   }
-  else if(options.get_bool_option("paths"))
+  else if(state.doing_path_exploration)
   {
     // At this point, `state_pc` is the instruction we should execute
     // immediately, and `new_state_pc` is the instruction that we should execute

--- a/src/jbmc/jbmc_parse_options.cpp
+++ b/src/jbmc/jbmc_parse_options.cpp
@@ -99,6 +99,14 @@ void jbmc_parse_optionst::get_command_line_options(optionst &options)
     exit(1); // should contemplate EX_USAGE from sysexits.h
   }
 
+  if(cmdline.isset("paths"))
+  {
+    if(cmdline.get_value("paths") == "partial")
+      options.set_option("partial-merge", true);
+    else
+      options.set_option("paths", true);
+  }
+
   if(cmdline.isset("program-only"))
     options.set_option("program-only", true);
 


### PR DESCRIPTION
This PR depends on #1641; please review only the last commit in the PR (`Able to do partial merging with path exploration`).

This commit adds a new dummy function `__CPROVER_begin_path_explore()` and new flag `--partial-merge`. When both `--paths` and `--partial-merge` are passed to CBMC, goto-symex will perform path-merging until it encounters a call to `__CPROVER_begin_path_explore()`. From that point onward, it will do path exploration (saving untaken paths onto a workqueue and not merging paths).

This mode is useful where we don't want to resume execution from boring code early on in `main()`. The idea is that we should do path-merging along all initialization code, and then do path-exploration from that point onward.