### PR TITLE
Refactor tracking of last_written_location to remove it from abstract_objectt

### DIFF
--- a/src/analyses/Makefile
+++ b/src/analyses/Makefile
@@ -32,6 +32,7 @@ SRC = ai.cpp \
       variable-sensitivity/array_abstract_object.cpp \
       variable-sensitivity/constant_abstract_value.cpp \
       variable-sensitivity/constant_pointer_abstract_object.cpp \
+      variable-sensitivity/dependency_context_abstract_object.cpp \
       variable-sensitivity/pointer_abstract_object.cpp \
       variable-sensitivity/struct_abstract_object.cpp \
       variable-sensitivity/variable_sensitivity_domain.cpp \

--- a/src/analyses/variable-sensitivity/abstract_enviroment.cpp
+++ b/src/analyses/variable-sensitivity/abstract_enviroment.cpp
@@ -74,9 +74,8 @@ abstract_object_pointert abstract_environmentt::eval(
   }
   else if(simplified_id==ID_address_of)
   {
-    sharing_ptrt<pointer_abstract_objectt> pointer_object=
-      std::dynamic_pointer_cast<const pointer_abstract_objectt>(
-        abstract_object_factory(simplified_expr.type(), simplified_expr, ns));
+    abstract_object_pointert pointer_object=
+      abstract_object_factory(simplified_expr.type(), simplified_expr, ns);
 
     // Store the abstract object in the pointer
     return pointer_object;
@@ -239,9 +238,7 @@ bool abstract_environmentt::assign(
 
     if(final_value != map[symbol_expr])
     {
-      map[symbol_expr]=final_value
-          ->update_last_written_locations(
-              value->get_last_written_locations(), false);
+      map[symbol_expr]=final_value;
     }
   }
   return true;
@@ -634,10 +631,6 @@ void abstract_environmentt::output(
     out << entry.first.get_identifier()
         << " (" << ") -> ";
     entry.second->output(out, ai, ns);
-
-    out << " @ ";
-    entry.second->output_last_written_locations(
-        out, entry.second->get_last_written_locations());
     out << "\n";
   }
   out << "}\n";

--- a/src/analyses/variable-sensitivity/abstract_enviroment.cpp
+++ b/src/analyses/variable-sensitivity/abstract_enviroment.cpp
@@ -717,59 +717,8 @@ std::vector<symbol_exprt> abstract_environmentt::modified_symbols(
     const auto &second_entry = second.map.find(entry.first);
     if (second_entry != second.map.end())
     {
-      // for the last written write locations to match
-      // each location in one must be equal to precisely one location
-      // in the other
-      // Since a set can assume at most one match
-
-      const abstract_objectt::locationst &first_write_locations=
-        entry.second->get_last_written_locations();
-      const abstract_objectt::locationst &second_write_locations=
-        second_entry->second->get_last_written_locations();
-
-      class location_ordert
-      {
-      public:
-        bool operator()(
-          goto_programt::const_targett instruction,
-          goto_programt::const_targett other_instruction)
-        {
-          return instruction->location_number>
-            other_instruction->location_number;
-        }
-      };
-
-      typedef std::set<goto_programt::const_targett, location_ordert>
-        sorted_locationst;
-
-      sorted_locationst lhs_location;
-      for(const auto &entry:first_write_locations)
-      {
-        lhs_location.insert(entry);
-      }
-
-
-      sorted_locationst rhs_location;
-      for(const auto &entry:second_write_locations)
-      {
-        rhs_location.insert(entry);
-      }
-
-      abstract_objectt::locationst intersection;
-      std::set_intersection(
-        lhs_location.cbegin(),
-        lhs_location.cend(),
-        rhs_location.cbegin(),
-        rhs_location.cend(),
-        std::inserter(intersection, intersection.end()),
-        location_ordert());
-      bool all_matched=intersection.size()==first_write_locations.size() &&
-        intersection.size()==second_write_locations.size();
-
-      if (!all_matched)
-      {
+      if(second_entry->second->has_been_modified(entry.second))
         symbols_diff.push_back(entry.first);
-      }
     }
   }
 

--- a/src/analyses/variable-sensitivity/abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_object.cpp
@@ -396,33 +396,21 @@ bool abstract_objectt::should_use_base_merge(
   return is_top() || other->is_bottom() || other->is_top();
 }
 
-/*******************************************************************\
-
-Function: abstract_objectt::update_last_written_locations
-
-  Inputs:
-   Set of locations to be written.
-
- Outputs:
-   An abstract_object_pointer pointing to the cloned, updated object.
-
- Purpose: Creates a mutable clone of the current object, and updates
-          the last written location map with the provided location(s).
-
-          For immutable objects.
-
-\*******************************************************************/
-
-abstract_object_pointert abstract_objectt::update_last_written_locations(
-    const locationst &locations,
-    bool update_sub_elements) const
+/**
+ * Update the location context for an abstract object, potentially
+ * propogating the update to any children of this abstract object.
+ *
+ * \param locations the set of locations to be updated
+ * \param update_sub_elements if true, propogate the update operation to any
+ * children of this abstract object
+ *
+ * \return a clone of this abstract object with it's location context
+ * updated
+ */
+abstract_object_pointert abstract_objectt::update_location_context(
+  const locationst &locations,
+  const bool update_sub_elements) const
 {
-  if(update_sub_elements)
-  {
-    internal_abstract_object_pointert clone=mutable_clone();
-    clone->update_sub_elements(locations);
-    return clone;
-  }
   return shared_from_this();
 }
 

--- a/src/analyses/variable-sensitivity/abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_object.cpp
@@ -133,14 +133,14 @@ Function: abstract_objectt::abstract_object_merge
 abstract_object_pointert abstract_objectt::abstract_object_merge(
   const abstract_object_pointert other) const
 {
-  if(top)
+  if(is_top())
     return shared_from_this();
   if(other->bottom)
     return shared_from_this();
 
 
   internal_abstract_object_pointert merged=mutable_clone();
-  merged->top=true;
+  merged->make_top();
   merged->bottom=false;
   return merged;
 }

--- a/src/analyses/variable-sensitivity/abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_object.cpp
@@ -133,16 +133,32 @@ Function: abstract_objectt::abstract_object_merge
 abstract_object_pointert abstract_objectt::abstract_object_merge(
   const abstract_object_pointert other) const
 {
-  if(is_top())
-    return shared_from_this();
-  if(other->bottom)
-    return shared_from_this();
-
+  if(is_top() || other->bottom)
+    return this->abstract_object_merge_internal(other);
 
   internal_abstract_object_pointert merged=mutable_clone();
   merged->make_top();
   merged->bottom=false;
-  return merged;
+  return merged->abstract_object_merge_internal(other);
+}
+
+/**
+ * Helper function for abstract_objectt::abstract_object_merge to perform any
+ * additional actions after the base abstract_object_merge has completed it's
+ * actions but immediately prior to it returning. As such, this function gives
+ * the ability to perform additional work for a merge.
+ *
+ * This default implementation just returns itself.
+ *
+ * \param other the object to merge with this
+ *
+ * \return the result of the merge
+ */
+abstract_object_pointert abstract_objectt::abstract_object_merge_internal(
+  const abstract_object_pointert other) const
+{
+  // Default implementation
+  return shared_from_this();
 }
 
 /*******************************************************************\
@@ -357,15 +373,6 @@ abstract_object_pointert abstract_objectt::merge(
   // If no modifications, we will return the original pointer
   out_modifications=result!=op1;
 
-  locationst get_location_union = op1->get_location_union(
-      op2->get_last_written_locations());
-  // If the union is larger than the initial set, then update.
-  if(get_location_union.size() > op1->get_last_written_locations().size())
-  {
-    out_modifications=true;
-    result=result->update_last_written_locations(get_location_union, false);
-  }
-
   return result;
 }
 
@@ -410,55 +417,13 @@ abstract_object_pointert abstract_objectt::update_last_written_locations(
     const locationst &locations,
     bool update_sub_elements) const
 {
-  internal_abstract_object_pointert clone=mutable_clone();
-  clone->set_last_written_locations(locations);
   if(update_sub_elements)
+  {
+    internal_abstract_object_pointert clone=mutable_clone();
     clone->update_sub_elements(locations);
-  return clone;
-}
-
-/*******************************************************************\
-
-Function: abstract_objectt::get_location_union
-
-  Inputs:
-   Set of locations unioned
-
- Outputs:
-   The union of the two sets
-
- Purpose: Takes the location set of the current object, and unions it
-          with the provided set.
-
-\*******************************************************************/
-
-abstract_objectt::locationst abstract_objectt::get_location_union(const locationst &locations) const
-{
-  locationst existing_locations=get_last_written_locations();
-  existing_locations.insert(locations.begin(), locations.end());
-
-  return existing_locations;
-}
-
-/*******************************************************************\
-
-Function: abstract_objectt::set_last_written_locations
-
-  Inputs:
-   Set of locations to be written
-
- Outputs:
-   Void
-
- Purpose: Writes the provided set to the object.
-
-          For mutable objects.
-
-\*******************************************************************/
-
-void abstract_objectt::set_last_written_locations(const locationst &locations)
-{
-  last_written_locations=locations;
+    return clone;
+  }
+  return shared_from_this();
 }
 
 /*******************************************************************\
@@ -477,51 +442,8 @@ Function: abstract_objectt::get_last_written_locations
 
 abstract_objectt::locationst abstract_objectt::get_last_written_locations() const
 {
-  return last_written_locations;
+  return {};
 }
 
-/*******************************************************************\
 
-Function: abstract_objectt::output_last_written_location
-
-  Inputs:
-   object - the object to read information from
-   out - the stream to write to
-   ai - the abstract interpreter that contains this domain
-   ns - the current namespace
-
- Outputs: None
-
- Purpose: Print out all last written locations for a specified
-          object
-
-\*******************************************************************/
-
-void abstract_objectt::output_last_written_locations(
-  std::ostream &out,
-  const abstract_objectt::locationst &locations)
-{
-  out << "[";
-  bool comma=false;
-
-  std::set<unsigned> sorted_locations;
-  for(auto location: locations)
-  {
-    sorted_locations.insert(location->location_number);
-  }
-
-  for (auto location_number: sorted_locations)
-  {
-    if(!comma)
-    {
-      out << location_number;
-      comma=true;
-    }
-    else
-    {
-      out << ", " << location_number;
-    }
-  }
-  out << "]";
-}
 

--- a/src/analyses/variable-sensitivity/abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_object.cpp
@@ -426,24 +426,5 @@ abstract_object_pointert abstract_objectt::update_last_written_locations(
   return shared_from_this();
 }
 
-/*******************************************************************\
-
-Function: abstract_objectt::get_last_written_locations
-
-  Inputs:
-   None
-
- Outputs:
-   Set of locations for the provided object.
-
- Purpose: Getter for last_written_locations
-
-\*******************************************************************/
-
-abstract_objectt::locationst abstract_objectt::get_last_written_locations() const
-{
-  return {};
-}
-
 
 

--- a/src/analyses/variable-sensitivity/abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_object.cpp
@@ -192,6 +192,53 @@ abstract_object_pointert abstract_objectt::expression_transform(
   return environment.abstract_object_factory(simplified.type(), simplified, ns);
 }
 
+/**
+ * A helper function to evaluate an abstract object contained
+ * within a container object. More precise abstractions may override this
+ * to return more precise results.
+ *
+ * \param env the abstract environment
+ * \param specifier a modifier expression, such as an array index or field
+ * specifier used to indicate access to a specific component
+ * \param ns the current namespace
+ *
+ * \return the abstract_objectt representing the value of the read component.
+ */
+abstract_object_pointert abstract_objectt::read(
+  const abstract_environmentt &env,
+  const exprt &specifier,
+  const namespacet &ns) const
+{
+  return shared_from_this();
+}
+
+/**
+ * A helper function to evaluate writing to a component of an
+ * abstract object. More precise abstractions may override this to
+ * update what they are storing for a specific component.
+ *
+ * \param environment the abstract environment
+ * \param ns the current namespace
+ * \param stack the remaining stack of expressions on the LHS to evaluate
+ * \param specifier the expression uses to access a specific component
+ * \param value the value we are trying to write to the component
+ * \param merging_write if true, this and all future writes will be merged
+ * with the current value
+ *
+ * \return the abstract_objectt representing the result of writing
+ * to a specific component.
+ */
+abstract_object_pointert abstract_objectt::write(
+  abstract_environmentt &environment,
+  const namespacet &ns,
+  const std::stack<exprt> stack,
+  const exprt &specifier,
+  const abstract_object_pointert value,
+  bool merging_write) const
+{
+  return environment.abstract_object_factory(type(), ns, true);
+}
+
 /*******************************************************************\
 
 Function: abstract_objectt::is_top

--- a/src/analyses/variable-sensitivity/abstract_object.h
+++ b/src/analyses/variable-sensitivity/abstract_object.h
@@ -31,6 +31,7 @@
 #include <map>
 #include <iosfwd>
 #include <algorithm>
+#include <stack>
 
 #include <goto-programs/goto_program.h>
 #include <util/expr.h>
@@ -97,6 +98,19 @@ public:
     const namespacet &ns) const;
 
   virtual exprt to_constant() const;
+
+  virtual abstract_object_pointert read(
+    const abstract_environmentt &env,
+    const exprt &specifier,
+    const namespacet &ns) const;
+
+  virtual abstract_object_pointert write(
+    abstract_environmentt &environment,
+    const namespacet &ns,
+    const std::stack<exprt> stack,
+    const exprt &specifier,
+    const abstract_object_pointert value,
+    bool merging_write) const;
 
   virtual void output(
     std::ostream &out, const class ai_baset &ai, const namespacet &ns) const;

--- a/src/analyses/variable-sensitivity/abstract_object.h
+++ b/src/analyses/variable-sensitivity/abstract_object.h
@@ -144,9 +144,9 @@ public:
     abstract_object_pointert op2,
     bool &out_modifications);
 
-  virtual abstract_object_pointert update_last_written_locations(
-      const locationst &locations,
-      const bool update_sub_elements) const;
+  virtual abstract_object_pointert update_location_context(
+    const locationst &locations,
+    const bool update_sub_elements) const;
 
   // Const versions must perform copy-on-write
   abstract_object_pointert make_top() const
@@ -168,6 +168,32 @@ public:
     clone->clear_top();
     return clone;
   }
+
+  /**
+   * Pure virtual interface required of a client that can apply a copy-on-write
+   * operation to a given abstract_object_pointert.
+   */
+  struct abstract_object_visitort
+  {
+    virtual abstract_object_pointert visit(
+      const abstract_object_pointert element) const = 0;
+  };
+
+  /**
+   * Apply a visitor operation to all sub elements of this abstract_object.
+   * A sub element might be a member of a struct, or an element of an array,
+   * for instance, but this is entirely determined by the particular
+   * derived instance of abstract_objectt.
+   *
+   * \param visitor an instance of a visitor class that will be applied to
+   * all sub elements
+   * \return A new abstract_object if it's contents is modifed, or this if
+   * no modification is needed
+   */
+  virtual abstract_object_pointert visit_sub_elements(
+    const abstract_object_visitort &visitor) const
+  { return shared_from_this(); }
+
 
 private:
   // To enforce copy-on-write these are private and have read-only accessors
@@ -197,9 +223,6 @@ protected:
   {
     return internal_abstract_object_pointert(new abstract_objectt(*this));
   }
-
-  virtual void update_sub_elements(const locationst &locations)
-  {}
 
   abstract_object_pointert abstract_object_merge(
     const abstract_object_pointert other) const;

--- a/src/analyses/variable-sensitivity/abstract_object.h
+++ b/src/analyses/variable-sensitivity/abstract_object.h
@@ -137,11 +137,33 @@ public:
     std::ostream &out,
     const abstract_objectt::locationst &locations);
 
+  // Const versions must perform copy-on-write
+  abstract_object_pointert make_top() const
+  {
+    if(is_top())
+      return shared_from_this();
+
+    internal_abstract_object_pointert clone = mutable_clone();
+    clone->make_top();
+    return clone;
+  }
+
+  abstract_object_pointert clear_top() const
+  {
+    if(!is_top())
+      return shared_from_this();
+
+    internal_abstract_object_pointert clone = mutable_clone();
+    clone->clear_top();
+    return clone;
+  }
+
 private:
   // To enforce copy-on-write these are private and have read-only accessors
   typet t;
   bool bottom;
   locationst last_written_locations;
+  bool top;
 
   abstract_object_pointert abstract_object_merge(
     const abstract_object_pointert other) const;
@@ -164,10 +186,6 @@ protected:
   virtual void update_sub_elements(const locationst &locations)
   {}
 
-  bool top;
-
-  // The one exception is merge in descendant classes, which needs this
-  void make_top() { top=true; }
 
   bool should_use_base_merge(const abstract_object_pointert other) const;
 
@@ -179,6 +197,10 @@ protected:
     const std::map<keyt, abstract_object_pointert> &map1,
     const std::map<keyt, abstract_object_pointert> &map2,
     std::map<keyt, abstract_object_pointert> &out_map);
+
+  // The one exception is merge in descendant classes, which needs this
+  virtual void make_top() { top=true; }
+  virtual void clear_top() { top=false; }
 };
 
 template<typename keyt>

--- a/src/analyses/variable-sensitivity/abstract_object.h
+++ b/src/analyses/variable-sensitivity/abstract_object.h
@@ -123,6 +123,22 @@ public:
     return abstract_object_pointert(mutable_clone());
   }
 
+  /**
+   * Determine whether 'this' abstract_object has been modified in comparison
+   * to a previous 'before' state.
+   * \param before The abstract_object_pointert to use as a reference to
+   * compare against
+   * \return true if 'this' is considered to have been modified in comparison
+   * to 'before', false otherwise.
+   */
+  virtual bool has_been_modified(const abstract_object_pointert before) const
+    {
+      // Default implementation, with no other information to go on
+      // falls back to relying on copy-on-write and pointer inequality
+      // to indicate if an abstract_objectt has been modified
+      return this != before.get();
+    };
+
   static abstract_object_pointert merge(
     abstract_object_pointert op1,
     abstract_object_pointert op2,
@@ -131,7 +147,6 @@ public:
   virtual abstract_object_pointert update_last_written_locations(
       const locationst &locations,
       const bool update_sub_elements) const;
-  virtual locationst get_last_written_locations() const;
 
   // Const versions must perform copy-on-write
   abstract_object_pointert make_top() const

--- a/src/analyses/variable-sensitivity/array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/array_abstract_object.cpp
@@ -78,6 +78,55 @@ array_abstract_objectt::array_abstract_objectt(
   assert(e.type().id()==ID_array);
 }
 
+/**
+ * A helper function to evaluate an abstract object contained
+ * within a container object. More precise abstractions may override this
+ * to return more precise results.
+ *
+ * \param env the abstract environment
+ * \param specifier a modifier expression, such as an array index or field
+ * specifier used to indicate access to a specific component
+ * \param ns the current namespace
+ *
+ * \return the abstract_objectt representing the value of the read component.
+ */
+abstract_object_pointert array_abstract_objectt::read(
+  const abstract_environmentt &env,
+  const exprt &specifier,
+  const namespacet &ns) const
+{
+  return read_index(env, to_index_expr(specifier), ns);
+}
+
+/**
+ * A helper function to evaluate writing to a component of an
+ * abstract object. More precise abstractions may override this to
+ * update what they are storing for a specific component.
+ *
+ * \param environment the abstract environment
+ * \param ns the current namespace
+ * \param stack the remaining stack of expressions on the LHS to evaluate
+ * \param specifier the expression uses to access a specific component
+ * \param value the value we are trying to write to the component
+ * \param merging_write if true, this and all future writes will be merged
+ * with the current value
+ *
+ * \return the abstract_objectt representing the result of writing
+ * to a specific component.
+ */
+abstract_object_pointert array_abstract_objectt::write(
+  abstract_environmentt &environment,
+  const namespacet &ns,
+  const std::stack<exprt> stack,
+  const exprt &specifier,
+  const abstract_object_pointert value,
+  bool merging_write) const
+{
+  return write_index(
+    environment, ns, stack, to_index_expr(specifier), value, merging_write);
+}
+
+
 /*******************************************************************\
 
 Function: array_abstract_objectt::read_index

--- a/src/analyses/variable-sensitivity/array_abstract_object.h
+++ b/src/analyses/variable-sensitivity/array_abstract_object.h
@@ -26,21 +26,34 @@ public:
     const abstract_environmentt &environment,
     const namespacet &ns);
 
-  virtual abstract_object_pointert read_index(
+  virtual abstract_object_pointert read(
+    const abstract_environmentt &env,
+    const exprt &specifier,
+    const namespacet &ns) const override;
+
+  virtual abstract_object_pointert write(
+    abstract_environmentt &environment,
+    const namespacet &ns,
+    const std::stack<exprt> stack,
+    const exprt &specifier,
+    const abstract_object_pointert value,
+    bool merging_write) const override;
+
+protected:
+  CLONE
+
+  abstract_object_pointert read_index(
     const abstract_environmentt &env,
     const index_exprt &index,
     const namespacet &ns) const;
 
-  virtual sharing_ptrt<array_abstract_objectt> write_index(
+  sharing_ptrt<array_abstract_objectt> write_index(
     abstract_environmentt &environment,
     const namespacet &ns,
     const std::stack<exprt> stack,
     const index_exprt &index_expr,
     const abstract_object_pointert value,
     bool merging_write) const;
-
-protected:
-  CLONE
 };
 
 #endif // CPROVER_ANALYSES_VARIABLE_SENSITIVITY_ARRAY_ABSTRACT_OBJECT_H

--- a/src/analyses/variable-sensitivity/constant_array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/constant_array_abstract_object.cpp
@@ -205,6 +205,55 @@ void constant_array_abstract_objectt::output(
   }
 }
 
+/**
+ * A helper function to evaluate an abstract object contained
+ * within a container object. More precise abstractions may override this
+ * to return more precise results.
+ *
+ * \param env the abstract environment
+ * \param specifier a modifier expression, such as an array index or field
+ * specifier used to indicate access to a specific component
+ * \param ns the current namespace
+ *
+ * \return the abstract_objectt representing the value of the read component.
+ */
+abstract_object_pointert constant_array_abstract_objectt::read(
+  const abstract_environmentt &env,
+  const exprt &specifier,
+  const namespacet &ns) const
+{
+  return read_index(env, to_index_expr(specifier), ns);
+}
+
+/**
+ * A helper function to evaluate writing to a component of an
+ * abstract object. More precise abstractions may override this to
+ * update what they are storing for a specific component.
+ *
+ * \param environment the abstract environment
+ * \param ns the current namespace
+ * \param stack the remaining stack of expressions on the LHS to evaluate
+ * \param specifier the expression uses to access a specific component
+ * \param value the value we are trying to write to the component
+ * \param merging_write if true, this and all future writes will be merged
+ * with the current value
+ *
+ * \return the abstract_objectt representing the result of writing
+ * to a specific component.
+ */
+abstract_object_pointert constant_array_abstract_objectt::write(
+  abstract_environmentt &environment,
+  const namespacet &ns,
+  const std::stack<exprt> stack,
+  const exprt &specifier,
+  const abstract_object_pointert value,
+  bool merging_write) const
+{
+  return write_index(
+    environment, ns, stack, to_index_expr(specifier), value,
+    merging_write);
+}
+
 /*******************************************************************\
 
 Function: constant_array_abstract_objectt::read_index

--- a/src/analyses/variable-sensitivity/constant_array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/constant_array_abstract_object.cpp
@@ -193,12 +193,6 @@ void constant_array_abstract_objectt::output(
     {
       out << "[" << entry.first << "] = ";
       entry.second->output(out, ai, ns);
-
-      // Start outputting specific last_written_locations
-      out << " @ ";
-      output_last_written_locations(out,
-          entry.second->get_last_written_locations());
-
       out << "\n";
     }
     out << "}";

--- a/src/analyses/variable-sensitivity/constant_array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/constant_array_abstract_object.cpp
@@ -81,7 +81,7 @@ constant_array_abstract_objectt::constant_array_abstract_objectt(
       map[mp_integer(index)]=environment.eval(entry, ns);
       ++index;
     }
-    top=false;
+    clear_top();
   }
 }
 
@@ -354,7 +354,7 @@ sharing_ptrt<array_abstract_objectt>
       {
         if(is_top())
         {
-          copy->top=false;
+          copy->clear_top();
         }
 
         copy->map[index_value]=value;
@@ -390,7 +390,7 @@ sharing_ptrt<array_abstract_objectt>
 
         if(is_top())
         {
-          copy->top=false;
+          copy->clear_top();
         }
         copy->map[index_value]=environment.write(
           array_entry, value, stack, ns, merging_write);
@@ -407,7 +407,7 @@ sharing_ptrt<array_abstract_objectt>
               array_entry.second, value, stack, ns, true);
           if(is_top())
           {
-            copy->top=false;
+            copy->clear_top();
           }
         }
 

--- a/src/analyses/variable-sensitivity/constant_array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/constant_array_abstract_object.cpp
@@ -467,27 +467,29 @@ bool constant_array_abstract_objectt::eval_index(
   }
 }
 
-/*******************************************************************\
-
-Function: constant_array_abstract_objectt::update_sub_elements
-
-  Inputs:
-   locations - Locations to write
-
- Outputs: None
-
- Purpose: Updates write location for sub-elements.
-
-          For example, if a[2] = {5, 6}, this will update
-          the write location for objects 5 and 6 as well as a.
-
-\*******************************************************************/
-
-void constant_array_abstract_objectt::update_sub_elements(
-    const locationst &locations)
+/**
+ * Apply a visitor operation to all sub elements of this abstract_object.
+ * A sub element might be a member of a struct, or an element of an array,
+ * for instance, but this is entirely determined by the particular
+ * derived instance of abstract_objectt.
+ *
+ * \param visitor an instance of a visitor class that will be applied to
+ * all sub elements
+ * \return A new abstract_object if it's contents is modifed, or this if
+ * no modification is needed
+ */
+abstract_object_pointert
+constant_array_abstract_objectt::visit_sub_elements(
+  const abstract_object_visitort &visitor) const
 {
-  for(auto &item: map)
+  const auto &result=
+    std::dynamic_pointer_cast<constant_array_abstract_objectt>(
+      mutable_clone());
+
+  for(auto &item : result->map)
   {
-    item.second=item.second->update_last_written_locations(locations, true);
+    item.second=visitor.visit(item.second);
   }
+
+  return result;
 }

--- a/src/analyses/variable-sensitivity/constant_array_abstract_object.h
+++ b/src/analyses/variable-sensitivity/constant_array_abstract_object.h
@@ -48,6 +48,9 @@ public:
     const abstract_object_pointert value,
     bool merging_write) const override;
 
+  virtual abstract_object_pointert visit_sub_elements(
+    const abstract_object_visitort &visitor) const override;
+
 protected:
   CLONE
 
@@ -85,8 +88,6 @@ private:
 
   abstract_object_pointert constant_array_merge(
     const constant_array_pointert other) const;
-
-  virtual void update_sub_elements(const locationst &locations) override;
 };
 
 #endif // CPROVER_ANALYSES_VARIABLE_SENSITIVITY_CONSTANT_ARRAY_ABSTRACT_OBJECT_H

--- a/src/analyses/variable-sensitivity/constant_array_abstract_object.h
+++ b/src/analyses/variable-sensitivity/constant_array_abstract_object.h
@@ -35,21 +35,34 @@ public:
   void output(
     std::ostream &out, const ai_baset &ai, const namespacet &ns) const override;
 
-  virtual abstract_object_pointert read_index(
+  virtual abstract_object_pointert read(
     const abstract_environmentt &env,
-    const index_exprt &index,
+    const exprt &specifier,
     const namespacet &ns) const override;
 
-  virtual sharing_ptrt<array_abstract_objectt> write_index(
+  virtual abstract_object_pointert write(
     abstract_environmentt &environment,
     const namespacet &ns,
     const std::stack<exprt> stack,
-    const index_exprt &index_expr,
+    const exprt &specifier,
     const abstract_object_pointert value,
     bool merging_write) const override;
 
 protected:
   CLONE
+
+  abstract_object_pointert read_index(
+    const abstract_environmentt &env,
+    const index_exprt &index,
+    const namespacet &ns) const;
+
+  sharing_ptrt<array_abstract_objectt> write_index(
+    abstract_environmentt &environment,
+    const namespacet &ns,
+    const std::stack<exprt> stack,
+    const index_exprt &index_expr,
+    const abstract_object_pointert value,
+    bool merging_write) const;
 
   virtual abstract_object_pointert merge(
     abstract_object_pointert other) const override;

--- a/src/analyses/variable-sensitivity/constant_pointer_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/constant_pointer_abstract_object.cpp
@@ -96,7 +96,14 @@ constant_pointer_abstract_objectt::constant_pointer_abstract_objectt(
     value_stack(e, environment, ns)
 {
   assert(e.type().id()==ID_pointer);
-  top=value_stack.is_top_value();
+  if(value_stack.is_top_value())
+  {
+    make_top();
+  }
+  else
+  {
+    clear_top();
+  }
 }
 
 /*******************************************************************\

--- a/src/analyses/variable-sensitivity/dependency_context_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/dependency_context_abstract_object.cpp
@@ -1,0 +1,321 @@
+/*******************************************************************\
+
+ Module: analyses variable-sensitivity
+
+ Author: Chris Ryder, chris.ryder@diffblue.com
+
+\*******************************************************************/
+
+#include <util/std_types.h>
+#include <ostream>
+#include <analyses/variable-sensitivity/abstract_enviroment.h>
+#include "dependency_context_abstract_object.h"
+#include "full_struct_abstract_object.h"
+
+void dependency_context_abstract_objectt::set_child(
+  const abstract_object_pointert &child)
+{
+  child_abstract_object = child;
+}
+
+void dependency_context_abstract_objectt::make_top_internal()
+{
+  if(!child_abstract_object->is_top())
+    set_child(child_abstract_object->make_top());
+}
+
+void dependency_context_abstract_objectt::clear_top_internal()
+{
+  if(child_abstract_object->is_top())
+    set_child(child_abstract_object->clear_top());
+}
+
+/*******************************************************************\
+
+Function: dependency_context_abstract_objectt::update_last_written_locations
+
+  Inputs:
+   Set of locations to be written.
+
+ Outputs:
+   An abstract_object_pointer pointing to the cloned, updated object.
+
+ Purpose: Creates a mutable clone of the current object, and updates
+          the last written location map with the provided location(s).
+
+          For immutable objects.
+
+\*******************************************************************/
+abstract_object_pointert
+  dependency_context_abstract_objectt::update_last_written_locations(
+    const abstract_objectt::locationst &locations,
+    const bool update_sub_elements) const
+{
+  const auto &result=
+    std::dynamic_pointer_cast<dependency_context_abstract_objectt>(
+      mutable_clone());
+
+  result->set_child(child_abstract_object->update_last_written_locations(
+    locations, update_sub_elements));
+
+  result->set_last_written_locations(locations);
+  return result;
+}
+
+abstract_objectt::locationst
+  dependency_context_abstract_objectt::get_last_written_locations() const
+{
+  return last_written_locations;
+}
+
+/**
+ * A helper function to evaluate an abstract object contained
+ * within a container object. More precise abstractions may override this
+ * to return more precise results.
+ *
+ * \param env the abstract environment
+ * \param specifier a modifier expression, such as an array index or field
+ * specifier used to indicate access to a specific component
+ * \param ns the current namespace
+ *
+ * \return the abstract_objectt representing the value of the read component.
+ * For the dependency context, the operation is simply delegated to the
+ * child object
+ */
+abstract_object_pointert dependency_context_abstract_objectt::read(
+  const abstract_environmentt &env,
+  const exprt &specifier,
+  const namespacet &ns) const
+{
+  return child_abstract_object->read(env, specifier, ns);
+}
+
+/**
+ * A helper function to evaluate writing to a component of an
+ * abstract object. More precise abstractions may override this to
+ * update what they are storing for a specific component.
+ *
+ * \param environment the abstract environment
+ * \param ns the current namespace
+ * \param stack the remaining stack of expressions on the LHS to evaluate
+ * \param specifier the expression uses to access a specific component
+ * \param value the value we are trying to write to the component
+ * \param merging_write if true, this and all future writes will be merged
+ * with the current value
+ *
+ * \return the abstract_objectt representing the result of writing
+ * to a specific component.
+ */
+abstract_object_pointert dependency_context_abstract_objectt::write(
+  abstract_environmentt &environment,
+  const namespacet &ns,
+  const std::stack<exprt> stack,
+  const exprt &specifier,
+  const abstract_object_pointert value,
+  bool merging_write) const
+{
+  // But delegate the write to the child
+  abstract_object_pointert updated_child=
+    child_abstract_object->write(
+      environment, ns, stack, specifier, value, merging_write);
+
+  // Only perform an update if the write to the child has in fact changed it...
+  // FIXME: But do we still want to record the write???
+  if(updated_child == child_abstract_object)
+    return shared_from_this();
+
+  // Need to ensure the result of the write is still wrapped in a dependency
+  // context
+  const auto &result=
+    std::dynamic_pointer_cast<dependency_context_abstract_objectt>(
+      mutable_clone());
+
+  // Update the child and record the updated write locations
+  result->set_child(updated_child);
+  result->set_last_written_locations(value->get_last_written_locations());
+
+  return result;
+}
+
+/**
+ * Create a new abstract object that is the result of merging this abstract
+ * object with a given abstract_object
+ *
+ * \param other the abstract object to merge with
+ *
+ * \return the result of the merge, or 'this' if the merge would not change
+ * the current abstract object
+ */
+abstract_object_pointert dependency_context_abstract_objectt::merge(
+  abstract_object_pointert other) const
+{
+  auto cast_other=
+    std::dynamic_pointer_cast<const dependency_context_abstract_objectt>(other);
+
+  if(cast_other)
+  {
+    bool child_modified=false;
+
+    auto merged_child=
+      abstract_objectt::merge(
+        child_abstract_object, cast_other->child_abstract_object,
+        child_modified);
+
+    abstract_objectt::locationst location_union=get_location_union(
+      cast_other->get_last_written_locations());
+    // If the union is larger than the initial set, then update.
+    bool merge_locations =
+      location_union.size()>get_last_written_locations().size();
+
+    if(child_modified || merge_locations)
+    {
+      const auto &result=
+        std::dynamic_pointer_cast<dependency_context_abstract_objectt>(
+          mutable_clone());
+      if(child_modified)
+      {
+        result->set_child(merged_child);
+      }
+      if(merge_locations)
+      {
+        result->set_last_written_locations(location_union);
+      }
+
+      return result;
+    }
+
+    return shared_from_this();
+  }
+
+  return abstract_objectt::merge(other);
+}
+
+/**
+ * Helper function for abstract_objectt::abstract_object_merge to perform any
+ * additional actions after the base abstract_object_merge has completed it's
+ * actions but immediately prior to it returning. As such, this function gives
+ * the ability to perform additional work for a merge.
+ *
+ * For the dependency context, this additional work is the tracking of
+ * last_written_locations across the merge
+ *
+ * \param other the object to merge with this
+ *
+ * \return the result of the merge
+ */
+abstract_object_pointert
+  dependency_context_abstract_objectt::abstract_object_merge_internal(
+    const abstract_object_pointert other) const
+{
+  abstract_objectt::locationst location_union = get_location_union(
+      other->get_last_written_locations());
+
+  // If the union is larger than the initial set, then update.
+  if(location_union.size() > get_last_written_locations().size())
+  {
+    abstract_object_pointert result = mutable_clone();
+    return result->update_last_written_locations(location_union, false);
+  }
+  return shared_from_this();
+}
+
+/**
+ * Sets the last written locations for this context
+ *
+ * \param locations the locations to set
+ */
+void dependency_context_abstract_objectt::set_last_written_locations(
+  const abstract_objectt::locationst &locations)
+{
+  last_written_locations=locations;
+}
+
+/**
+ * Try to resolve an expression with the maximum level of precision
+ * available.
+ *
+ * \param expr the expression to evaluate and find the result of. This will
+ * be the symbol referred to be op0()
+ * \param environment the abstract environment in which to resolve 'expr'
+ * \param ns the current namespace
+ *
+ * \return the resolved expression
+ */
+abstract_object_pointert
+  dependency_context_abstract_objectt::expression_transform(
+    const exprt &expr,
+    const abstract_environmentt &environment,
+    const namespacet &ns) const
+{
+  return child_abstract_object->expression_transform(expr, environment, ns);
+}
+
+/**
+ * Output a representation of the value of this abstract object
+ *
+ * \param out the stream to write to
+ * \param ai the abstract interpreter that contains the abstract domain
+ * (that contains the object ... )
+ * \param ns the current namespace
+ */
+void dependency_context_abstract_objectt::output(
+  std::ostream &out, const ai_baset &ai, const namespacet &ns) const
+{
+  child_abstract_object->output(out, ai, ns);
+
+  // Output last written locations immediately following the child output
+  out << " @ ";
+  output_last_written_locations(out, last_written_locations);
+}
+
+/**
+ * Construct the union of the location set of the current object, and a
+ * the provided location set.
+ *
+ * \param locations the set of locations to be unioned with this context
+ *
+ * \return the union of this objects location set, and 'locations'
+ */
+abstract_objectt::locationst
+  dependency_context_abstract_objectt::get_location_union(
+    const locationst &locations) const
+{
+  locationst existing_locations=get_last_written_locations();
+  existing_locations.insert(locations.begin(), locations.end());
+
+  return existing_locations;
+}
+
+/**
+ * Internal helper function to format and output a given set of locations
+ *
+ * \param out the stream on which to output the locations
+ * \param locations the set of locations to output
+ */
+void dependency_context_abstract_objectt::output_last_written_locations(
+  std::ostream &out,
+  const abstract_objectt::locationst &locations)
+{
+  out << "[";
+  bool comma=false;
+
+  std::set<unsigned> sorted_locations;
+  for(auto location : locations)
+  {
+    sorted_locations.insert(location->location_number);
+  }
+
+  for(auto location_number : sorted_locations)
+  {
+    if(!comma)
+    {
+      out << location_number;
+      comma=true;
+    }
+    else
+    {
+      out << ", " << location_number;
+    }
+  }
+  out << "]";
+}

--- a/src/analyses/variable-sensitivity/dependency_context_abstract_object.h
+++ b/src/analyses/variable-sensitivity/dependency_context_abstract_object.h
@@ -1,0 +1,182 @@
+/*******************************************************************\
+
+ Module: analyses variable-sensitivity
+
+ Author: Chris Ryder, chris.ryder@diffblue.com
+
+\*******************************************************************/
+#ifndef CPROVER_ANALYSES_VARIABLE_SENSITIVITY_DEPENDENCY_CONTEXT_ABSTRACT_OBJECT_H
+#define CPROVER_ANALYSES_VARIABLE_SENSITIVITY_DEPENDENCY_CONTEXT_ABSTRACT_OBJECT_H
+
+#include <stack>
+#include <analyses/variable-sensitivity/abstract_object.h>
+#include <iostream>
+#include "array_abstract_object.h"
+
+/**
+ * General implementation of an abstract_objectt which tracks the
+ * last written locations for a given abstract_objectt.
+ * Instances of this class are constructed with an abstract_object_pointert,
+ * to which most operations are delegated, while at the same time this
+ * class handles the tracking of the 'last_written_location' information.
+ *
+ * Instances of this class are best constructed via the templated version
+ * of this, 'context_abstract_objectt<T>' which provides the same
+ * constructors as the standard 'abstract_objectt' class.
+ */
+class dependency_context_abstract_objectt: public abstract_objectt
+{
+public:
+  // These constructors mirror those in the base abstract_objectt, but with
+  // the addition of an extra argument which is the abstract_objectt to wrap.
+  explicit dependency_context_abstract_objectt(
+    const abstract_object_pointert child,
+    const typet &type):
+      abstract_objectt(type)
+  {
+    child_abstract_object = child;
+  }
+
+  dependency_context_abstract_objectt(
+    const abstract_object_pointert child,
+    const typet &type,
+    bool top,
+    bool bottom):
+      abstract_objectt(type, top, bottom)
+  {
+    child_abstract_object = child;
+  }
+
+  explicit dependency_context_abstract_objectt(
+    const abstract_object_pointert child,
+    const exprt &expr,
+    const abstract_environmentt &environment,
+    const namespacet &ns):
+      abstract_objectt(expr, environment, ns)
+  {
+    child_abstract_object = child;
+  }
+
+  virtual ~dependency_context_abstract_objectt() {}
+
+  // Standard abstract_objectt interface
+
+  virtual abstract_objectt::locationst get_last_written_locations()
+    const override;
+
+  virtual abstract_object_pointert update_last_written_locations(
+    const abstract_objectt::locationst &locations,
+    const bool update_sub_elements) const override;
+
+  locationst get_location_union(const locationst &locations) const;
+
+  virtual const typet &type() const
+  {
+    return child_abstract_object->type();
+  }
+
+  virtual bool is_top() const override
+  {
+    return child_abstract_object->is_top();
+  }
+
+  virtual bool is_bottom() const override
+  {
+    return child_abstract_object->is_bottom();
+  }
+
+  abstract_object_pointert expression_transform(
+    const exprt &expr,
+    const abstract_environmentt &environment,
+    const namespacet &ns) const;
+
+  virtual exprt to_constant() const override
+  {
+    return child_abstract_object->to_constant();
+  }
+
+  virtual void output(
+    std::ostream &out, const class ai_baset &ai, const namespacet &ns) const
+  override;
+
+
+protected:
+  CLONE
+
+  virtual abstract_object_pointert merge(
+    abstract_object_pointert other) const override;
+
+  virtual abstract_object_pointert read(
+    const abstract_environmentt &env,
+    const exprt &specifier,
+    const namespacet &ns) const override;
+
+  virtual abstract_object_pointert write(
+    abstract_environmentt &environment,
+    const namespacet &ns,
+    const std::stack<exprt> stack,
+    const exprt &specifier,
+    const abstract_object_pointert value,
+    bool merging_write) const override;
+
+  static void output_last_written_locations(
+    std::ostream &out,
+    const abstract_objectt::locationst &locations);
+
+private:
+  // To enforce copy-on-write these are private and have read-only accessors
+  abstract_objectt::locationst last_written_locations;
+  abstract_object_pointert child_abstract_object;
+
+  // These are internal hooks that allow sub-classes to perform additional
+  // actions when an abstract_object is set/unset to TOP
+  virtual void make_top_internal() override;
+  virtual void clear_top_internal() override;
+
+  virtual abstract_object_pointert abstract_object_merge_internal(
+    const abstract_object_pointert other) const override;
+
+  void set_last_written_locations(
+    const abstract_objectt::locationst &locations);
+
+  void set_child(
+    const abstract_object_pointert &child);
+
+};
+
+
+/**
+ * Templated extension of the abstract implementation, used as a wrapper around
+ * other abstract_objectt classes to enable the factory to instantiate the
+ * context information
+ */
+template <class AOT>
+class context_abstract_objectt: public dependency_context_abstract_objectt
+{
+public:
+  explicit context_abstract_objectt(const typet &type):
+    dependency_context_abstract_objectt(
+      abstract_object_pointert(new AOT(type)), type) {}
+
+  context_abstract_objectt(
+    const typet &type,
+    bool top,
+    bool bottom):
+      dependency_context_abstract_objectt(
+        abstract_object_pointert(new AOT(type, top, bottom)),
+          type,
+          top,
+          bottom) {}
+
+  explicit context_abstract_objectt(
+    const exprt &expr,
+    const abstract_environmentt &environment,
+    const namespacet &ns):
+      dependency_context_abstract_objectt(
+        abstract_object_pointert(new AOT(expr, environment, ns)),
+        expr,
+        environment,
+        ns) {}
+};
+// NOLINTNEXTLINE(whitespace/line_length)
+#endif // CPROVER_ANALYSES_VARIABLE_SENSITIVITY_DEPENDENCY_CONTEXT_ABSTRACT_OBJECT_H

--- a/src/analyses/variable-sensitivity/dependency_context_abstract_object.h
+++ b/src/analyses/variable-sensitivity/dependency_context_abstract_object.h
@@ -61,8 +61,8 @@ public:
 
   // Standard abstract_objectt interface
 
-  virtual abstract_objectt::locationst get_last_written_locations()
-    const override;
+  virtual bool has_been_modified(const abstract_object_pointert before) const
+    override;
 
   virtual abstract_object_pointert update_last_written_locations(
     const abstract_objectt::locationst &locations,
@@ -122,6 +122,8 @@ protected:
   static void output_last_written_locations(
     std::ostream &out,
     const abstract_objectt::locationst &locations);
+
+  virtual abstract_objectt::locationst get_last_written_locations() const;
 
 private:
   // To enforce copy-on-write these are private and have read-only accessors

--- a/src/analyses/variable-sensitivity/dependency_context_abstract_object.h
+++ b/src/analyses/variable-sensitivity/dependency_context_abstract_object.h
@@ -64,9 +64,27 @@ public:
   virtual bool has_been_modified(const abstract_object_pointert before) const
     override;
 
-  virtual abstract_object_pointert update_last_written_locations(
+  virtual abstract_object_pointert update_location_context(
     const abstract_objectt::locationst &locations,
     const bool update_sub_elements) const override;
+
+  // A visitor class to update the last_written_locations of any visited
+  // abstract_object with a given set of locations.
+  class location_update_visitort:
+    public abstract_objectt::abstract_object_visitort
+  {
+  public:
+    explicit location_update_visitort(const locationst &locations):
+      locations(locations) { }
+
+    abstract_object_pointert visit(const abstract_object_pointert element) const
+    {
+      return element->update_location_context(locations, true);
+    }
+
+  private:
+    const locationst &locations;
+  };
 
   locationst get_location_union(const locationst &locations) const;
 
@@ -143,7 +161,6 @@ private:
 
   void set_child(
     const abstract_object_pointert &child);
-
 };
 
 

--- a/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
@@ -185,8 +185,6 @@ sharing_ptrt<struct_abstract_objectt>
   internal_sharing_ptrt<full_struct_abstract_objectt> copy(
     new full_struct_abstract_objectt(*this));
 
-  copy->set_last_written_locations(value->get_last_written_locations());
-
   if(!stack.empty())
   {
     abstract_object_pointert starting_value;
@@ -283,12 +281,6 @@ void full_struct_abstract_objectt::output(
     }
     out << "." << entry.first << "=";
     entry.second->output(out, ai, ns);
-
-    // Start outputting specific last_written_locations
-    out << " @ ";
-    output_last_written_locations(out,
-        entry.second->get_last_written_locations());
-
   }
   out << "}";
 }

--- a/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
@@ -204,7 +204,7 @@ sharing_ptrt<struct_abstract_objectt>
 
     copy->map[c]=
       environment.write(starting_value, value, stack, ns, merging_write);
-    copy->top=false;
+    copy->clear_top();
     assert(copy->verify());
     return copy;
   }
@@ -244,7 +244,7 @@ sharing_ptrt<struct_abstract_objectt>
     else
     {
       copy->map[c]=value;
-      copy->top=false;
+      copy->clear_top();
       assert(!copy->is_bottom());
     }
 

--- a/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
@@ -386,27 +386,29 @@ abstract_object_pointert full_struct_abstract_objectt::merge_constant_structs(
   }
 }
 
-/*******************************************************************\
-
-Function: full_struct_abstract_objectt::update_sub_elements
-
-  Inputs:
-   locations - Locations to write
-
- Outputs: None
-
- Purpose: Updates write location for sub-elements.
-
-          For example, if a=b where a and b are structs, this will
-          update the write location for components too.
-
-\*******************************************************************/
-
-void full_struct_abstract_objectt::update_sub_elements(
-    const locationst &locations)
+/**
+ * Apply a visitor operation to all sub elements of this abstract_object.
+ * A sub element might be a member of a struct, or an element of an array,
+ * for instance, but this is entirely determined by the particular
+ * derived instance of abstract_objectt.
+ *
+ * \param visitor an instance of a visitor class that will be applied to
+ * all sub elements
+ * \return A new abstract_object if it's contents is modifed, or this if
+ * no modification is needed
+ */
+abstract_object_pointert
+  full_struct_abstract_objectt::visit_sub_elements(
+  const abstract_object_visitort &visitor) const
 {
-  for(auto &item: map)
+  const auto &result=
+    std::dynamic_pointer_cast<full_struct_abstract_objectt>(
+      mutable_clone());
+
+  for(auto &item : result->map)
   {
-    item.second=item.second->update_last_written_locations(locations, true);
+    item.second=visitor.visit(item.second);
   }
+
+  return result;
 }

--- a/src/analyses/variable-sensitivity/full_struct_abstract_object.h
+++ b/src/analyses/variable-sensitivity/full_struct_abstract_object.h
@@ -31,21 +31,6 @@ public:
     const abstract_environmentt &environment,
     const namespacet &ns);
 
-
-  // struct interface
-  virtual abstract_object_pointert read_component(
-    const abstract_environmentt &environment,
-    const member_exprt &member_expr,
-    const namespacet& ns) const override;
-
-  virtual sharing_ptrt<struct_abstract_objectt> write_component(
-    abstract_environmentt &environment,
-    const namespacet &ns,
-    const std::stack<exprt> &stack,
-    const member_exprt &member_expr,
-    const abstract_object_pointert value,
-    bool merging_write) const override;
-
   virtual void output(
     std::ostream &out,
     const class ai_baset &ai,
@@ -63,6 +48,20 @@ private:
 
 protected:
   CLONE
+
+  // struct interface
+  virtual abstract_object_pointert read_component(
+    const abstract_environmentt &environment,
+    const member_exprt &member_expr,
+    const namespacet& ns) const override;
+
+  virtual sharing_ptrt<struct_abstract_objectt> write_component(
+    abstract_environmentt &environment,
+    const namespacet &ns,
+    const std::stack<exprt> &stack,
+    const member_exprt &member_expr,
+    const abstract_object_pointert value,
+    bool merging_write) const override;
 
   bool verify() const;
   // Set the state of this to the merge result of op1 and op2 and

--- a/src/analyses/variable-sensitivity/full_struct_abstract_object.h
+++ b/src/analyses/variable-sensitivity/full_struct_abstract_object.h
@@ -36,6 +36,9 @@ public:
     const class ai_baset &ai,
     const class namespacet &ns) const override;
 
+  virtual abstract_object_pointert visit_sub_elements(
+    const abstract_object_visitort &visitor) const override;
+
 private:
   // no entry means component is top
   typedef std::map<irep_idt, abstract_object_pointert> struct_mapt;
@@ -60,8 +63,6 @@ protected:
     const member_exprt &member_expr,
     const abstract_object_pointert value,
     bool merging_write) const override;
-
-  virtual void update_sub_elements(const locationst &locations) override;
 
   bool verify() const;
   // Set the state of this to the merge result of op1 and op2 and

--- a/src/analyses/variable-sensitivity/full_struct_abstract_object.h
+++ b/src/analyses/variable-sensitivity/full_struct_abstract_object.h
@@ -41,8 +41,6 @@ private:
   typedef std::map<irep_idt, abstract_object_pointert> struct_mapt;
   struct_mapt map;
 
-  virtual void update_sub_elements(const locationst &locations) override;
-
   abstract_object_pointert merge_constant_structs(
     constant_struct_pointert other) const;
 
@@ -62,6 +60,8 @@ protected:
     const member_exprt &member_expr,
     const abstract_object_pointert value,
     bool merging_write) const override;
+
+  virtual void update_sub_elements(const locationst &locations) override;
 
   bool verify() const;
   // Set the state of this to the merge result of op1 and op2 and

--- a/src/analyses/variable-sensitivity/pointer_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/pointer_abstract_object.cpp
@@ -77,6 +77,53 @@ pointer_abstract_objectt::pointer_abstract_objectt(
   assert(e.type().id()==ID_pointer);
 }
 
+/**
+ * A helper function to evaluate an abstract object contained
+ * within a container object. More precise abstractions may override this
+ * to return more precise results.
+ *
+ * \param env the abstract environment
+ * \param specifier a modifier expression, such as an array index or field
+ * specifier used to indicate access to a specific component
+ * \param ns the current namespace
+ *
+ * \return the abstract_objectt representing the value of the read component.
+ */
+abstract_object_pointert pointer_abstract_objectt::read(
+  const abstract_environmentt &env,
+  const exprt &specifier,
+  const namespacet &ns) const
+{
+  return read_dereference(env, ns);
+}
+
+/**
+ * A helper function to evaluate writing to a component of an
+ * abstract object. More precise abstractions may override this to
+ * update what they are storing for a specific component.
+ *
+ * \param environment the abstract environment
+ * \param ns the current namespace
+ * \param stack the remaining stack of expressions on the LHS to evaluate
+ * \param specifier the expression uses to access a specific component
+ * \param value the value we are trying to write to the component
+ * \param merging_write if true, this and all future writes will be merged
+ * with the current value
+ *
+ * \return the abstract_objectt representing the result of writing
+ * to a specific component.
+ */
+abstract_object_pointert pointer_abstract_objectt::write(
+  abstract_environmentt &environment,
+  const namespacet &ns,
+  const std::stack<exprt> stack,
+  const exprt &specifier,
+  const abstract_object_pointert value,
+  bool merging_write) const
+{
+  return write_dereference(environment, ns, stack, value, merging_write);
+}
+
 /*******************************************************************\
 
 Function: pointer_abstract_objectt::read_dereference

--- a/src/analyses/variable-sensitivity/pointer_abstract_object.h
+++ b/src/analyses/variable-sensitivity/pointer_abstract_object.h
@@ -27,6 +27,22 @@ public:
     const abstract_environmentt &environment,
     const namespacet &ns);
 
+  virtual abstract_object_pointert read(
+    const abstract_environmentt &env,
+    const exprt &specifier,
+    const namespacet &ns) const override;
+
+  virtual abstract_object_pointert write(
+    abstract_environmentt &environment,
+    const namespacet &ns,
+    const std::stack<exprt> stack,
+    const exprt &specifier,
+    const abstract_object_pointert value,
+    bool merging_write) const override;
+
+protected:
+  CLONE
+
   // pointer interface
   virtual abstract_object_pointert read_dereference(
     const abstract_environmentt &env, const namespacet &ns) const;
@@ -37,9 +53,6 @@ public:
     const std::stack<exprt> stack,
     const abstract_object_pointert value,
     bool merging_write) const;
-
-protected:
-  CLONE
 };
 
 #endif // CPROVER_ANALYSES_VARIABLE_SENSITIVITY_POINTER_ABSTRACT_OBJECT_H

--- a/src/analyses/variable-sensitivity/struct_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/struct_abstract_object.cpp
@@ -78,6 +78,54 @@ struct_abstract_objectt::struct_abstract_objectt(
   assert(ns.follow(e.type()).id()==ID_struct);
 }
 
+/**
+ * A helper function to evaluate an abstract object contained
+ * within a container object. More precise abstractions may override this
+ * to return more precise results.
+ *
+ * \param env the abstract environment
+ * \param specifier a modifier expression, such as an array index or field
+ * specifier used to indicate access to a specific component
+ * \param ns the current namespace
+ *
+ * \return the abstract_objectt representing the value of the read component.
+ */
+abstract_object_pointert struct_abstract_objectt::read(
+  const abstract_environmentt &env,
+  const exprt &specifier,
+  const namespacet &ns) const
+{
+  return this->read_component(env, to_member_expr(specifier), ns);
+}
+
+/**
+ * A helper function to evaluate writing to a component of an
+ * abstract object. More precise abstractions may override this to
+ * update what they are storing for a specific component.
+ *
+ * \param environment the abstract environment
+ * \param ns the current namespace
+ * \param stack the remaining stack of expressions on the LHS to evaluate
+ * \param specifier the expression uses to access a specific component
+ * \param value the value we are trying to write to the component
+ * \param merging_write if true, this and all future writes will be merged
+ * with the current value
+ *
+ * \return the abstract_objectt representing the result of writing
+ * to a specific component.
+ */
+abstract_object_pointert struct_abstract_objectt::write(
+  abstract_environmentt &environment,
+  const namespacet &ns,
+  const std::stack<exprt> stack,
+  const exprt &specifier,
+  const abstract_object_pointert value,
+  bool merging_write) const
+{
+  return this->write_component(
+    environment, ns, stack, to_member_expr(specifier), value, merging_write);
+}
+
 /*******************************************************************\
 
 Function: struct_abstract_objectt::read_component

--- a/src/analyses/variable-sensitivity/struct_abstract_object.h
+++ b/src/analyses/variable-sensitivity/struct_abstract_object.h
@@ -25,6 +25,22 @@ public:
     const abstract_environmentt &environment,
     const namespacet &ns);
 
+  virtual abstract_object_pointert read(
+    const abstract_environmentt &env,
+    const exprt &specifier,
+    const namespacet &ns) const override;
+
+  virtual abstract_object_pointert write(
+    abstract_environmentt &environment,
+    const namespacet &ns,
+    const std::stack<exprt> stack,
+    const exprt &specifier,
+    const abstract_object_pointert value,
+    bool merging_write) const override;
+
+protected:
+  CLONE
+
   // struct interface
   virtual abstract_object_pointert read_component(
     const abstract_environmentt &environment,
@@ -38,9 +54,6 @@ public:
     const member_exprt &member_expr,
     const abstract_object_pointert value,
     bool merging_write) const;
-
-protected:
-  CLONE
 };
 
 #endif // CPROVER_ANALYSES_VARIABLE_SENSITIVITY_STRUCT_ABSTRACT_OBJECT_H

--- a/src/analyses/variable-sensitivity/union_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/union_abstract_object.cpp
@@ -77,6 +77,54 @@ union_abstract_objectt::union_abstract_objectt(
   assert(ns.follow(expr.type()).id()==ID_union);
 }
 
+/**
+ * A helper function to evaluate an abstract object contained
+ * within a container object. More precise abstractions may override this
+ * to return more precise results.
+ *
+ * \param env the abstract environment
+ * \param specifier a modifier expression, such as an array index or field
+ * specifier used to indicate access to a specific component
+ * \param ns the current namespace
+ *
+ * \return the abstract_objectt representing the value of the read component.
+ */
+abstract_object_pointert union_abstract_objectt::read(
+  const abstract_environmentt &env,
+  const exprt &specifier,
+  const namespacet &ns) const
+{
+  return read_component(env, to_member_expr(specifier), ns);
+}
+
+/**
+ * A helper function to evaluate writing to a component of an
+ * abstract object. More precise abstractions may override this to
+ * update what they are storing for a specific component.
+ *
+ * \param environment the abstract environment
+ * \param ns the current namespace
+ * \param stack the remaining stack of expressions on the LHS to evaluate
+ * \param specifier the expression uses to access a specific component
+ * \param value the value we are trying to write to the component
+ * \param merging_write if true, this and all future writes will be merged
+ * with the current value
+ *
+ * \return the abstract_objectt representing the result of writing
+ * to a specific component.
+ */
+abstract_object_pointert union_abstract_objectt::write(
+  abstract_environmentt &environment,
+  const namespacet &ns,
+  const std::stack<exprt> stack,
+  const exprt &specifier,
+  const abstract_object_pointert value,
+  bool merging_write) const
+{
+  return write_component(
+    environment, ns, stack, to_member_expr(specifier), value, merging_write);
+}
+
 /*******************************************************************\
 
 Function: union_abstract_objectt::read_component

--- a/src/analyses/variable-sensitivity/union_abstract_object.h
+++ b/src/analyses/variable-sensitivity/union_abstract_object.h
@@ -25,6 +25,22 @@ public:
       const abstract_environmentt &environment,
       const namespacet &ns);
 
+  virtual abstract_object_pointert read(
+    const abstract_environmentt &env,
+    const exprt &specifier,
+    const namespacet &ns) const override;
+
+  virtual abstract_object_pointert write(
+    abstract_environmentt &environment,
+    const namespacet &ns,
+    const std::stack<exprt> stack,
+    const exprt &specifier,
+    const abstract_object_pointert value,
+    bool merging_write) const override;
+
+protected:
+    CLONE
+
     // union interface
     virtual abstract_object_pointert read_component(
       const abstract_environmentt &environment,
@@ -38,10 +54,6 @@ public:
       const member_exprt &member_expr,
       const abstract_object_pointert value,
       bool merging_write) const;
-
-protected:
-    CLONE
 };
-
 #endif // CPROVER_ANALYSES_VARIABLE_SENSITIVITY_UNION_ABSTRACT_OBJECT_H
 

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
@@ -431,9 +431,8 @@ void variable_sensitivity_domaint::transform_function_call(
         {
           if(called_arg.type().id()==ID_pointer)
           {
-            sharing_ptrt<pointer_abstract_objectt> pointer_value=
-              std::dynamic_pointer_cast<const pointer_abstract_objectt>(
-                abstract_state.eval(called_arg, ns));
+            abstract_object_pointert pointer_value=
+              abstract_state.eval(called_arg, ns);
 
             assert(pointer_value);
 

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
@@ -438,10 +438,11 @@ void variable_sensitivity_domaint::transform_function_call(
             assert(pointer_value);
 
             // Write top to the pointer
-            pointer_value->write_dereference(
+            pointer_value->write(
               abstract_state,
               ns,
               std::stack<exprt>(),
+              nil_exprt(),
               abstract_state.abstract_object_factory(
                 called_arg.type().subtype(), ns, true), false);
           }

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
@@ -55,8 +55,8 @@ void variable_sensitivity_domaint::transform(
       const abstract_objectt::locationst write_location={ from };
       abstract_object_pointert top_object=
         abstract_state.abstract_object_factory(
-          to_code_decl(instruction.code).symbol().type(), ns, true)
-            ->update_last_written_locations(write_location, true);
+            to_code_decl(instruction.code).symbol().type(), ns, true)
+          ->update_location_context(write_location, true);
       abstract_state.assign(
           to_code_decl(instruction.code).symbol(), top_object, ns);
     }
@@ -81,8 +81,8 @@ void variable_sensitivity_domaint::transform(
       const code_assignt &inst = to_code_assign(instruction.code);
 
       const abstract_objectt::locationst write_location={ from };
-      abstract_object_pointert rhs = abstract_state.eval(inst.rhs(), ns)
-          ->update_last_written_locations(write_location, true);
+      abstract_object_pointert rhs =abstract_state.eval(inst.rhs(), ns)
+        ->update_location_context(write_location, true);
       abstract_state.assign(inst.lhs(), rhs, ns);
     }
     break;
@@ -481,7 +481,8 @@ void variable_sensitivity_domaint::transform_function_call(
 
         // Evaluate the expression that is being
         // passed into the function call (called_arg)
-        abstract_object_pointert param_val=abstract_state.eval(called_arg, ns)->update_last_written_locations({ from }, true);
+        abstract_object_pointert param_val=abstract_state.eval(called_arg, ns)
+          ->update_location_context({from}, true);
 
         // Assign the evaluated value to the symbol associated with the
         // parameter of the function

--- a/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.cpp
@@ -100,36 +100,46 @@ abstract_object_pointert variable_sensitivity_object_factoryt::
   switch(abstract_object_type)
   {
   case CONSTANT:
-    return initialize_abstract_object<constant_abstract_valuet>(
-      followed_type, top, bottom, e, environment, ns);
+    return initialize_abstract_object<
+      context_abstract_objectt<constant_abstract_valuet>>(
+        followed_type, top, bottom, e, environment, ns);
   case ARRAY_SENSITIVE:
-    return initialize_abstract_object<constant_array_abstract_objectt>(
-      followed_type, top, bottom, e, environment, ns);
+    return initialize_abstract_object<
+      context_abstract_objectt<constant_array_abstract_objectt>>(
+        followed_type, top, bottom, e, environment, ns);
   case ARRAY_INSENSITIVE:
-    return initialize_abstract_object<array_abstract_objectt>(
-      followed_type, top, bottom, e, environment, ns);
+    return initialize_abstract_object<
+      context_abstract_objectt<array_abstract_objectt>>(
+        followed_type, top, bottom, e, environment, ns);
   case POINTER_SENSITIVE:
-    return initialize_abstract_object<constant_pointer_abstract_objectt>(
-      followed_type, top, bottom, e, environment, ns);
+    return initialize_abstract_object<
+      context_abstract_objectt<constant_pointer_abstract_objectt>>(
+        followed_type, top, bottom, e, environment, ns);
   case POINTER_INSENSITIVE:
-    return initialize_abstract_object<pointer_abstract_objectt>(
-      followed_type, top, bottom, e, environment, ns);
+    return initialize_abstract_object<
+      context_abstract_objectt<pointer_abstract_objectt>>(
+        followed_type, top, bottom, e, environment, ns);
   case STRUCT_SENSITIVE:
-    return initialize_abstract_object<full_struct_abstract_objectt>(
-      followed_type, top, bottom, e, environment, ns);
+    return initialize_abstract_object<
+      context_abstract_objectt<full_struct_abstract_objectt>>(
+        followed_type, top, bottom, e, environment, ns);
   case STRUCT_INSENSITIVE:
-    return initialize_abstract_object<struct_abstract_objectt>(
-      followed_type, top, bottom, e, environment, ns);
+    return initialize_abstract_object<
+      context_abstract_objectt<struct_abstract_objectt>>(
+        followed_type, top, bottom, e, environment, ns);
   case UNION_INSENSITIVE:
-    return initialize_abstract_object<union_abstract_objectt>(
-      followed_type, top, bottom, e, environment, ns);
+    return initialize_abstract_object<
+      context_abstract_objectt<union_abstract_objectt>>(
+        followed_type, top, bottom, e, environment, ns);
   case TWO_VALUE:
-    return initialize_abstract_object<abstract_objectt>(
-      followed_type, top, bottom, e, environment, ns);
+    return initialize_abstract_object<
+      context_abstract_objectt<abstract_objectt>>(
+        followed_type, top, bottom, e, environment, ns);
   default:
     UNREACHABLE;
-    return initialize_abstract_object<abstract_objectt>(
-      followed_type, top, bottom, e, environment, ns);
+    return initialize_abstract_object<
+      context_abstract_objectt<abstract_objectt>>(
+        followed_type, top, bottom, e, environment, ns);
   }
 }
 

--- a/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.h
@@ -16,6 +16,7 @@
 #include <analyses/variable-sensitivity/constant_pointer_abstract_object.h>
 #include <analyses/variable-sensitivity/full_struct_abstract_object.h>
 #include <analyses/variable-sensitivity/union_abstract_object.h>
+#include <analyses/variable-sensitivity/dependency_context_abstract_object.h>
 #include <util/options.h>
 #include <util/namespace.h>
 

--- a/unit/analyses/variable-sensitivity/constant_array_abstract_object/merge.cpp
+++ b/unit/analyses/variable-sensitivity/constant_array_abstract_object/merge.cpp
@@ -59,7 +59,7 @@ public:
      constant_array_abstract_object_pointert array_object,
     const index_exprt &index) const
   {
-    return array_object->read_index(enviroment, index, ns)->to_constant();
+    return array_object->read(enviroment, index, ns)->to_constant();
   }
 
 private:

--- a/unit/analyses/variable-sensitivity/full_struct_abstract_object/merge.cpp
+++ b/unit/analyses/variable-sensitivity/full_struct_abstract_object/merge.cpp
@@ -41,7 +41,7 @@ public:
     full_struct_abstract_objectt::constant_struct_pointert struct_object,
     const member_exprt &component) const
   {
-    return struct_object->read_component(
+    return struct_object->read(
       enviroment, component, ns)->to_constant();
   }
 
@@ -59,8 +59,8 @@ public:
     for(const exprt &op : starting_value.operands())
     {
       const auto &component=struct_type.components()[comp_index];
-      std::shared_ptr<const struct_abstract_objectt> new_result=
-        result->write_component(
+      std::shared_ptr<const abstract_objectt> new_result=
+        result->write(
           enviroment,
           ns,
           std::stack<exprt>(),


### PR DESCRIPTION
Most of the code change is to remove `last_written_location` out of `abstract_objectt`, with a slight extension to the API to have generic read/write functions, which just wrap the existing `read_*` and `write_*` functions provided by some of the current `*_abstract_objectt` classes. There’s also a bit of a change in API so that setting an `abstract_objectt` to TOP now requires calling a `make_top` function (and likewise for clearing TOP, using a `clear_top` function). Other than that checking the logic in the merge functions in `dependency_context_abstract_object` classes, that would be good.