### PR TITLE
Fixes use of wrong identifier when pretty printing bitfield types

### DIFF
--- a/regression/goto-instrument/bitfield_naming/main.c
+++ b/regression/goto-instrument/bitfield_naming/main.c
@@ -1,0 +1,18 @@
+typedef struct {
+  unsigned char b11 : 1;
+  unsigned char b22 : 1;
+  unsigned char b34 : 2;
+  unsigned char b58 : 4;
+} bf_t;
+
+typedef union {
+  unsigned char val;
+  bf_t bf;
+} union_bf_t;
+
+int main(void)
+{
+  union_bf_t bf;
+  bf.bf.b11 = 1;
+  return 0;
+}

--- a/regression/goto-instrument/bitfield_naming/test.desc
+++ b/regression/goto-instrument/bitfield_naming/test.desc
@@ -1,0 +1,15 @@
+CORE
+main.c
+--show-goto-functions --json-ui
+^EXIT=0$
+^SIGNAL=0$
+BF1\{U8\}\$U8\$\'b11\'
+BF1\{U8\}\$U8\$\'b22\'
+BF2\{U8\}\$U8\$\'b34\'
+BF4\{U8\}\$U8\$\'b58\'
+--
+--
+
+Checks that type2name generates the right names for structs containing bitfields,
+in particular including the width of bitfield fields.
+

--- a/src/ansi-c/type2name.cpp
+++ b/src/ansi-c/type2name.cpp
@@ -230,7 +230,7 @@ static std::string type2name(
   else if(type.id()==ID_incomplete_c_enum)
     result +="EN?";
   else if(type.id()==ID_c_bit_field)
-    result+="BF"+type.get_string(ID_size);
+    result+="BF"+type.get_string(ID_width);
   else if(type.id()==ID_vector)
     result+="VEC"+type.get_string(ID_size);
   else


### PR DESCRIPTION
The width of a bitfield is indicated with `ID_width`. Old version of `type2name` was using `ID_size` instead, which (silently) threw away the information about the width of a bitfield in the pretty printed type.

As a side note, I'm not sure it's such a good idea for the get* type functions to fail silently.