### PR TITLE
Add extra tests for the non-det issue with constants.

### DIFF
--- a/regression/goto-instrument/no_nondet_const/main.c
+++ b/regression/goto-instrument/no_nondet_const/main.c
@@ -1,0 +1,8 @@
+int var;
+const int arr[] = {10, 20, 30};
+
+int main(void)
+{
+  var = arr[2];
+  return 0;
+}

--- a/regression/goto-instrument/no_nondet_const/test.desc
+++ b/regression/goto-instrument/no_nondet_const/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--nondet-static
+^EXIT=0$
+^SIGNAL=0$
+--
+arr = NONDET\(const signed int \[3ll\]\)
+--


### PR DESCRIPTION
This is extending #1632 with extra tests, this time added to `goto-instrument` to demonstrate that the fix has been applied.

Paging @martin-cs for a review.