### PR TITLE
Add code_typet::get_this

### DIFF
--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -181,10 +181,11 @@ void remove_virtual_functionst::remove_virtual_function(
         // Cast the `this` pointer to the correct type for the new callee:
         const auto &callee_type=
           to_code_type(ns.lookup(fun.symbol_expr.get_identifier()).type);
+        const code_typet::parametert *this_param = callee_type.get_this();
         INVARIANT(
-          callee_type.has_this(),
+          this_param != nullptr,
           "Virtual function callees must have a `this` argument");
-        typet need_type=callee_type.parameters()[0].type();
+        typet need_type=this_param->type();
         if(!type_eq(newcall.arguments()[0].type(), need_type, ns))
           newcall.arguments()[0].make_typecast(need_type);
       }

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -818,8 +818,16 @@ public:
 
   bool has_this() const
   {
+    return get_this() != nullptr;
+  }
+
+  const parametert *get_this() const
+  {
     const parameterst &p=parameters();
-    return !p.empty() && p.front().get_this();
+    if(!p.empty() && p.front().get_this())
+      return &p.front();
+    else
+      return nullptr;
   }
 
   bool is_KnR() const


### PR DESCRIPTION
This simple utility saves a double-lookup compared to has_this followed by parameters()[0].

More synchronisation of simple utilities present in the sec codebase but not in cbmc.