### PR TITLE
Fix usage of instruction source location

### DIFF
--- a/regression/goto-instrument/store_goto_locations_json/main.c
+++ b/regression/goto-instrument/store_goto_locations_json/main.c
@@ -1,0 +1,4 @@
+int main(void)
+{
+  return 0;
+}

--- a/regression/goto-instrument/store_goto_locations_json/test.desc
+++ b/regression/goto-instrument/store_goto_locations_json/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--show-goto-functions --json-ui --store-goto-locations
+^EXIT=0$
+^SIGNAL=0$
+\"originalGOTOLocation\": \"0\"
+--
+--
+
+Checks that generated JSON contains
+original goto locations, if any
+

--- a/src/goto-programs/show_goto_functions_json.cpp
+++ b/src/goto-programs/show_goto_functions_json.cpp
@@ -63,15 +63,16 @@ json_objectt show_goto_functions_jsont::convert(
         instruction_entry["instructionId"]=
           json_stringt(instruction.to_string());
 
-        if(instruction.code.source_location().is_not_nil())
+        if(instruction.source_location.is_not_nil())
         {
           instruction_entry["sourceLocation"]=
-            json(instruction.code.source_location());
+            json(instruction.source_location);
 
-          if(instruction.code.source_location().get_goto_location()!="")
+          if(!instruction.source_location.get_goto_location().empty())
           {
             instruction_entry["originalGOTOLocation"]=
-              json_stringt(id2string(instruction.code.source_location().get_goto_location()));
+              json_stringt(
+                id2string(instruction.source_location.get_goto_location()));
           }
         }
 


### PR DESCRIPTION
get_goto_location should be called on the source_locationt contained in
the instruction, rather than on the one in the code of the instruction,
as that is where they are stored in store_goto_locations.

With this change `goto-instrument --show-goto-code --json-ui` will output the originalGOTOLocation as it's supposed to.