### PR TITLE
Improve cprover_string_literal argument handling TG-1245

### DIFF
--- a/src/solvers/refinement/string_constraint_generator.h
+++ b/src/solvers/refinement/string_constraint_generator.h
@@ -164,7 +164,11 @@ private:
     const exprt &end_index);
   exprt add_axioms_for_concat(const function_application_exprt &f);
   exprt add_axioms_for_concat_code_point(const function_application_exprt &f);
-  exprt add_axioms_for_constant(const array_string_exprt &res, irep_idt sval);
+  exprt add_axioms_for_constant(
+    const array_string_exprt &res,
+    irep_idt sval,
+    const exprt &guard = true_exprt());
+
   exprt add_axioms_for_delete(
     const array_string_exprt &res,
     const array_string_exprt &str,

--- a/src/solvers/refinement/string_constraint_generator.h
+++ b/src/solvers/refinement/string_constraint_generator.h
@@ -199,6 +199,11 @@ private:
   exprt add_axioms_for_insert_char(const function_application_exprt &f);
   exprt add_axioms_for_insert_float(const function_application_exprt &f);
   exprt add_axioms_for_insert_double(const function_application_exprt &f);
+
+  exprt add_axioms_for_cprover_string(
+    const array_string_exprt &res,
+    const exprt &arg,
+    const exprt &guard);
   exprt add_axioms_from_literal(const function_application_exprt &f);
   exprt add_axioms_from_int(const function_application_exprt &f);
   exprt add_axioms_from_int(

--- a/src/solvers/refinement/string_constraint_generator_constants.cpp
+++ b/src/solvers/refinement/string_constraint_generator_constants.cpp
@@ -19,10 +19,12 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 /// equal.
 /// \param res: array of characters for the result
 /// \param sval: a string constant
+/// \param guard: condition under which the axiom should apply, true by default
 /// \return integer expression equal to zero
 exprt string_constraint_generatort::add_axioms_for_constant(
   const array_string_exprt &res,
-  irep_idt sval)
+  irep_idt sval,
+  const exprt &guard)
 {
   const typet &index_type = res.length().type();
   const typet &char_type = res.content().type().subtype();
@@ -43,12 +45,12 @@ exprt string_constraint_generatort::add_axioms_for_constant(
     const exprt idx = from_integer(i, index_type);
     const exprt c = from_integer(str[i], char_type);
     const equal_exprt lemma(res[idx], c);
-    axioms.push_back(lemma);
+    axioms.push_back(implies_exprt(guard, lemma));
   }
 
   const exprt s_length = from_integer(str.size(), index_type);
 
-  axioms.push_back(res.axiom_for_has_length(s_length));
+  axioms.push_back(implies_exprt(guard, equal_exprt(res.length(), s_length)));
   return from_integer(0, get_return_code_type());
 }
 

--- a/src/solvers/refinement/string_refinement.cpp
+++ b/src/solvers/refinement/string_refinement.cpp
@@ -345,33 +345,14 @@ bool has_subtype(
 }
 
 /// \param type: a type
-/// \param ns: namespace
 /// \return true if a subtype of `type` is an pointer of characters.
 ///         The meaning of "subtype" is in the algebraic datatype sense:
 ///         for example, the subtypes of a struct are the types of its
 ///         components, the subtype of a pointer is the type it points to,
 ///         etc...
-static bool has_char_pointer_subtype(const typet &type, const namespacet &ns)
+static bool has_char_pointer_subtype(const typet &type)
 {
-  if(is_char_pointer_type(type))
-    return true;
-
-  if(type.id() == ID_struct || type.id() == ID_union)
-  {
-    const struct_union_typet &struct_type = to_struct_union_type(type);
-    for(const auto &comp : struct_type.components())
-    {
-      if(has_char_pointer_subtype(comp.type(), ns))
-        return true;
-    }
-  }
-
-  for(const auto &t : type.subtypes())
-  {
-    if(has_char_pointer_subtype(t, ns))
-      return true;
-  }
-  return false;
+  return has_subtype(type, is_char_pointer_type);
 }
 
 /// \param type: a type
@@ -471,7 +452,7 @@ static union_find_replacet generate_symbol_resolution_from_equations(
       // function applications can be ignored because they will be replaced
       // in the convert_function_application step of dec_solve
     }
-    else if(has_char_pointer_subtype(lhs.type(), ns))
+    else if(has_char_pointer_subtype(lhs.type()))
     {
       if(rhs.type().id() == ID_struct)
       {

--- a/src/solvers/refinement/string_refinement.cpp
+++ b/src/solvers/refinement/string_refinement.cpp
@@ -531,9 +531,9 @@ void output_equations(
   const std::vector<equal_exprt> &equations,
   const namespacet &ns)
 {
-  for(const auto &eq : equations)
-    output << "  * " << from_expr(ns, "", eq.lhs())
-           << " == " << from_expr(ns, "", eq.rhs()) << std::endl;
+  for(std::size_t i = 0; i < equations.size(); ++i)
+    output << "  [" << i << "] " << from_expr(ns, "", equations[i].lhs())
+           << " == " << from_expr(ns, "", equations[i].rhs()) << std::endl;
 }
 
 /// Main decision procedure of the solver. Looks for a valuation of variables
@@ -620,6 +620,14 @@ decision_proceduret::resultt string_refinementt::dec_solve()
 
   const union_find_replacet string_id_symbol_resolve =
     string_identifiers_resolution_from_equations(equations, ns, debug());
+#ifdef DEBUG
+  debug() << "symbol resolve string:" << eom;
+  for(const auto &pair : string_id_symbol_resolve.to_vector())
+  {
+    debug() << from_expr(ns, "", pair.first) << " --> "
+            << from_expr(ns, "", pair.second) << eom;
+  }
+#endif
 
   debug() << "dec_solve: Replacing char pointer symbols" << eom;
   replace_symbols_in_equations(symbol_resolve, equations);

--- a/src/solvers/refinement/string_refinement.h
+++ b/src/solvers/refinement/string_refinement.h
@@ -116,4 +116,10 @@ bool has_subtype(
   const typet &type,
   const std::function<bool(const typet &)> &pred);
 
+// Declaration required for unit-test:
+union_find_replacet string_identifiers_resolution_from_equations(
+  std::vector<equal_exprt> &equations,
+  const namespacet &ns,
+  messaget::mstreamt &stream);
+
 #endif

--- a/src/solvers/refinement/string_refinement.h
+++ b/src/solvers/refinement/string_refinement.h
@@ -112,4 +112,8 @@ exprt concretize_arrays_in_expression(
 
 bool is_char_array_type(const typet &type, const namespacet &ns);
 
+bool has_subtype(
+  const typet &type,
+  const std::function<bool(const typet &)> &pred);
+
 #endif

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -31,6 +31,7 @@ SRC += unit_tests.cpp \
        solvers/refinement/string_constraint_generator_valueof/is_digit_with_radix.cpp \
        solvers/refinement/string_constraint_instantiation/instantiate_not_contains.cpp \
        solvers/refinement/string_refinement/concretize_array.cpp \
+       solvers/refinement/string_refinement/has_subtype.cpp \
        solvers/refinement/string_refinement/substitute_array_list.cpp \
        solvers/refinement/string_refinement/union_find_replace.cpp \
        util/expr_cast/expr_cast.cpp \

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -33,6 +33,7 @@ SRC += unit_tests.cpp \
        solvers/refinement/string_refinement/concretize_array.cpp \
        solvers/refinement/string_refinement/has_subtype.cpp \
        solvers/refinement/string_refinement/substitute_array_list.cpp \
+       solvers/refinement/string_refinement/string_symbol_resolution.cpp \
        solvers/refinement/string_refinement/union_find_replace.cpp \
        util/expr_cast/expr_cast.cpp \
        util/expr_iterator.cpp \

--- a/unit/solvers/refinement/string_refinement/has_subtype.cpp
+++ b/unit/solvers/refinement/string_refinement/has_subtype.cpp
@@ -1,0 +1,61 @@
+/*******************************************************************\
+
+ Module: Unit tests for has_subtype in
+   solvers/refinement/string_refinement.cpp
+
+ Author: DiffBlue Limited. All rights reserved.
+
+\*******************************************************************/
+
+#include <testing-utils/catch.hpp>
+
+#include <util/c_types.h>
+#include <solvers/refinement/string_refinement.h>
+#include <java_bytecode/java_types.h>
+
+// Curryfied version of type comparison.
+// Useful for the predicate argument of has_subtype
+static std::function<bool(const typet &)> is_type(const typet &t1)
+{
+  auto f = [&](const typet &t2) { return t1 == t2; };
+  return f;
+}
+
+SCENARIO("has_subtype", "[core][solvers][refinement][string_refinement]")
+{
+  const typet char_type = java_char_type();
+  const typet int_type = java_int_type();
+  const typet bool_type = java_boolean_type();
+
+  REQUIRE(has_subtype(char_type, is_type(char_type)));
+  REQUIRE_FALSE(has_subtype(char_type, is_type(int_type)));
+
+  GIVEN("a struct with char and int fields")
+  {
+    struct_typet struct_type;
+    struct_type.components().emplace_back("char_field", char_type);
+    struct_type.components().emplace_back("int_field", int_type);
+    THEN("char and int are subtypes")
+    {
+      REQUIRE(has_subtype(struct_type, is_type(char_type)));
+      REQUIRE(has_subtype(struct_type, is_type(int_type)));
+    }
+    THEN("bool is not a subtype")
+    {
+      REQUIRE_FALSE(has_subtype(struct_type, is_type(bool_type)));
+    }
+  }
+
+  GIVEN("a pointer to char")
+  {
+    pointer_typet ptr_type = pointer_type(char_type);
+    THEN("char is a subtype")
+    {
+      REQUIRE(has_subtype(ptr_type, is_type(char_type)));
+    }
+    THEN("int is not a subtype")
+    {
+      REQUIRE_FALSE(has_subtype(ptr_type, is_type(int_type)));
+    }
+  }
+}

--- a/unit/solvers/refinement/string_refinement/string_symbol_resolution.cpp
+++ b/unit/solvers/refinement/string_refinement/string_symbol_resolution.cpp
@@ -1,0 +1,101 @@
+/*******************************************************************\
+
+ Module: Unit tests for string_identifiers_resolution_from_equations in
+   solvers/refinement/string_refinement.cpp
+
+ Author: DiffBlue Limited. All rights reserved.
+
+\*******************************************************************/
+
+#include <testing-utils/catch.hpp>
+
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/std_expr.h>
+#include <solvers/refinement/string_refinement.h>
+#include <util/symbol_table.h>
+#include <langapi/mode.h>
+#include <java_bytecode/java_bytecode_language.h>
+#include <iostream>
+
+SCENARIO("string_identifiers_resolution_from_equations",
+"[core][solvers][refinement][string_refinement]")
+{
+  // For printing expression
+  register_language(new_java_bytecode_language);
+  symbol_tablet symbol_table;
+  namespacet ns(symbol_table);
+  messaget::mstreamt &stream = messaget().debug();
+
+  GIVEN("Some equations")
+  {
+    constant_exprt a("a", string_typet());
+    constant_exprt b("b", string_typet());
+    constant_exprt c("c", string_typet());
+    constant_exprt d("d", string_typet());
+    constant_exprt e("e", string_typet());
+    constant_exprt f("f", string_typet());
+
+    struct_typet struct_type;
+    struct_type.components().emplace_back("str1", string_typet());
+    struct_type.components().emplace_back("str2", string_typet());
+    struct_exprt struct_expr(struct_type);
+    struct_expr.operands().push_back(a);
+    struct_expr.operands().push_back(f);
+    symbol_exprt symbol_struct("sym_struct", struct_type);
+
+    std::vector<equal_exprt> equations;
+    equations.emplace_back(a, b);
+    equations.emplace_back(b, c);
+    equations.emplace_back(d, e);
+    equations.emplace_back(symbol_struct, struct_expr);
+
+    WHEN("There is no function call")
+    {
+      union_find_replacet symbol_resolve =
+        string_identifiers_resolution_from_equations(
+          equations, ns, stream);
+
+      THEN("The symbol resolution structure is empty")
+      {
+        REQUIRE(symbol_resolve.to_vector().empty());
+      }
+    }
+
+    WHEN("There is a function call")
+    {
+      symbol_exprt fun_sym("f", code_typet());
+      function_application_exprt fun(fun_sym, bool_typet());
+      fun.operands().push_back(c);
+      symbol_exprt bool_sym("bool_b", bool_typet());
+      equations.emplace_back(bool_sym, fun);
+      union_find_replacet symbol_resolve =
+        string_identifiers_resolution_from_equations(
+          equations, ns, stream);
+
+      THEN("Equations that depend on it should be added")
+      {
+        REQUIRE(symbol_resolve.find(b) == symbol_resolve.find(c));
+        REQUIRE(symbol_resolve.find(a) == symbol_resolve.find(b));
+
+        member_exprt sym_m1(symbol_struct, "str1", string_typet());
+        member_exprt sym_m2(symbol_struct, "str2", string_typet());
+
+        REQUIRE(symbol_resolve.find(sym_m1) == symbol_resolve.find(c));
+        REQUIRE(symbol_resolve.find(sym_m2) == symbol_resolve.find(f));
+      }
+
+      THEN("Equations that do not depend on it should not be added")
+      {
+        REQUIRE(symbol_resolve.find(d) != symbol_resolve.find(e));
+      }
+
+      THEN("No other equation is added")
+      {
+        REQUIRE(symbol_resolve.find(a) != symbol_resolve.find(d));
+        REQUIRE(symbol_resolve.find(a) != symbol_resolve.find(f));
+        REQUIRE(symbol_resolve.find(d) != symbol_resolve.find(f));
+      }
+    }
+  }
+}


### PR DESCRIPTION
cprover_string_literal was requiring a string constant as argument,
but we now deal with if expressions as well.
This also improve solver handling of expressions of type `string_typet` by recording the symbols in the symbol_resolve map.