### PR TITLE
Add `at` method to `template_numberingt`

### DIFF
--- a/src/util/numbering.h
+++ b/src/util/numbering.h
@@ -69,6 +69,11 @@ public:
     return data_.size();
   }
 
+  const key_type &at(size_type t) const
+  {
+    return data_.at(t);
+  }
+
   key_type &operator[](size_type t)
   {
     return data_[t];


### PR DESCRIPTION
Previously the only way of getting a value was with `operator[]`, which makes it too easy to get a non-const reference without meaning to.
This also removes an incompatibility with the previous version of numbering which was causing a diff between security analyser and CBMC.