### PR TITLE
Allow coverage instrumentation of JDK methods

### DIFF
--- a/src/goto-instrument/cover_filter.cpp
+++ b/src/goto-instrument/cover_filter.cpp
@@ -32,11 +32,8 @@ bool internal_functions_filtert::operator()(
   if(goto_function.is_hidden())
     return false;
 
-  // ignore Java built-ins
-  if(
-    has_prefix(id2string(identifier), "java::array[") ||
-    has_prefix(id2string(identifier), "java::org.cprover") ||
-    has_prefix(id2string(identifier), "java::java."))
+  // ignore Java built-ins (synthetic functions)
+  if(has_prefix(id2string(identifier), "java::array["))
     return false;
 
   // ignore if built-in library


### PR DESCRIPTION
The refactoring in https://github.com/diffblue/cbmc/pull/1419 unnecessarily extended java-built-ins to `java.* ` and `org.cprover.*`, making it impossible to use --cover on JDK methods.