### PR TITLE
Fix op1/op0 copy&paste typo

### DIFF
--- a/src/cpp/cpp_typecheck_constructor.cpp
+++ b/src/cpp/cpp_typecheck_constructor.cpp
@@ -48,7 +48,7 @@ static void copy_parent(
   code.operands().push_back(exprt("explicit-typecast"));
   exprt &op1=code.op1();
 
-  op0.type()=
+  op1.type() =
     pointer_type(cpp_namet(parent_base_name, source_location).as_type());
   op1.type().set(ID_C_reference, true);
   op1.type().subtype().set(ID_C_constant, true);


### PR DESCRIPTION
The typo was introduced in a9806c0432f7c4c9a708eed14428b187f8ed735a.

See #834 for a discussion.