### PR TITLE
Allow to remove instanceof when remove exceptions

### DIFF
--- a/src/goto-programs/remove_exceptions.cpp
+++ b/src/goto-programs/remove_exceptions.cpp
@@ -90,49 +90,53 @@ public:
   {
   }
 
-  void operator()(
-    goto_functionst &goto_functions);
+  void operator()(goto_functionst &goto_functions);
 
 protected:
   symbol_tablet &symbol_table;
   std::map<irep_idt, std::set<irep_idt>> &exceptions_map;
 
   void add_exceptional_returns(
-    const goto_functionst::function_mapt::iterator &);
+    const irep_idt &function_id,
+    goto_programt &goto_program);
 
   void instrument_exception_handler(
-    const goto_functionst::function_mapt::iterator &,
+    const irep_idt &function_id,
+    goto_programt &goto_program,
     const goto_programt::targett &);
 
   void add_exception_dispatch_sequence(
-    const goto_functionst::function_mapt::iterator &,
+    const irep_idt &function_id,
+    goto_programt &goto_program,
     const goto_programt::targett &instr_it,
     const stack_catcht &stack_catch,
     const std::vector<exprt> &locals);
 
   void instrument_throw(
-    const goto_functionst::function_mapt::iterator &,
+    const irep_idt &function_id,
+    goto_programt &goto_program,
     const goto_programt::targett &,
     const stack_catcht &,
     const std::vector<exprt> &);
 
   void instrument_function_call(
-    const goto_functionst::function_mapt::iterator &,
+    const irep_idt &function_id,
+    goto_programt &goto_program,
     const goto_programt::targett &,
     const stack_catcht &,
     const std::vector<exprt> &);
 
   void instrument_exceptions(
-    const goto_functionst::function_mapt::iterator &);
+    const irep_idt &function_id,
+    goto_programt &goto_program);
 };
 
 /// adds exceptional return variables for every function that may escape
 /// exceptions
 void remove_exceptionst::add_exceptional_returns(
-  const goto_functionst::function_mapt::iterator &func_it)
+  const irep_idt &function_id,
+  goto_programt &goto_program)
 {
-  const irep_idt &function_id=func_it->first;
-  goto_programt &goto_program=func_it->second.body;
 
   auto maybe_symbol=symbol_table.lookup(function_id);
   INVARIANT(maybe_symbol, "functions should be recorded in the symbol table");
@@ -236,17 +240,17 @@ void remove_exceptionst::add_exceptional_returns(
 /// Translates an exception landing-pad into instructions that copy the
 /// in-flight exception pointer to a nominated expression, then clear the
 /// in-flight exception (i.e. null the pointer), hence marking it caught.
-/// \param func_it: iterator pointing to the function containing this
-///   landingpad instruction
-/// \param instr_it [in, out]: iterator pointing to the landingpad instruction.
+/// \param function_id: name of the function containing this landingpad
+///   instruction
+/// \param goto_program: body of the function containing this landingpad
+///   instruction
+/// \param instr_it: iterator pointing to the landingpad instruction.
 ///   Will be overwritten.
 void remove_exceptionst::instrument_exception_handler(
-  const goto_functionst::function_mapt::iterator &func_it,
+  const irep_idt &function_id,
+  goto_programt &goto_program,
   const goto_programt::targett &instr_it)
 {
-  const irep_idt &function_id=func_it->first;
-  goto_programt &goto_program=func_it->second.body;
-
   PRECONDITION(instr_it->type==CATCH);
 
   // retrieve the exception variable
@@ -285,20 +289,19 @@ void remove_exceptionst::instrument_exception_handler(
 /// if (exception instanceof ExnA) then goto handlerA
 /// else if (exception instanceof ExnB) then goto handlerB
 /// else goto universal_handler or (dead locals; function exit)
-/// \param func_it: iterator pointing to function instr_it belongs to
+/// \param function_id: name of the function to which instr_it belongs
+/// \param goto_program: body of the function to which instr_it belongs
 /// \param instr_it: throw or call instruction that may be an
 ///   exception source
 /// \param stack_catch: exception handlers currently registered
 /// \param locals: local variables to kill on a function-exit edge
 void remove_exceptionst::add_exception_dispatch_sequence(
-  const goto_functionst::function_mapt::iterator &func_it,
+  const irep_idt &function_id,
+  goto_programt &goto_program,
   const goto_programt::targett &instr_it,
   const remove_exceptionst::stack_catcht &stack_catch,
   const std::vector<exprt> &locals)
 {
-  const irep_idt &function_id=func_it->first;
-  goto_programt &goto_program=func_it->second.body;
-
   // Unless we have a universal exception handler, jump to end of function
   // if not caught:
   goto_programt::targett default_target=goto_program.get_end_function();
@@ -360,10 +363,11 @@ void remove_exceptionst::add_exception_dispatch_sequence(
   }
 }
 
-/// instruments each throw with conditional GOTOS to the  corresponding
+/// instruments each throw with conditional GOTOS to the corresponding
 /// exception handlers
 void remove_exceptionst::instrument_throw(
-  const goto_functionst::function_mapt::iterator &func_it,
+  const irep_idt &function_id,
+  goto_programt &goto_program,
   const goto_programt::targett &instr_it,
   const remove_exceptionst::stack_catcht &stack_catch,
   const std::vector<exprt> &locals)
@@ -383,11 +387,11 @@ void remove_exceptionst::instrument_throw(
     return;
 
   add_exception_dispatch_sequence(
-    func_it, instr_it, stack_catch, locals);
+    function_id, goto_program, instr_it, stack_catch, locals);
 
   // find the symbol where the thrown exception should be stored:
-  const symbolt &exc_symbol=
-    symbol_table.lookup_ref(id2string(func_it->first)+EXC_SUFFIX);
+  const symbolt &exc_symbol =
+    symbol_table.lookup_ref(id2string(function_id) + EXC_SUFFIX);
   symbol_exprt exc_thrown=exc_symbol.symbol_expr();
 
   // add the assignment with the appropriate cast
@@ -401,15 +405,13 @@ void remove_exceptionst::instrument_throw(
 /// instruments each function call that may escape exceptions with conditional
 /// GOTOS to the corresponding exception handlers
 void remove_exceptionst::instrument_function_call(
-  const goto_functionst::function_mapt::iterator &func_it,
+  const irep_idt &function_id,
+  goto_programt &goto_program,
   const goto_programt::targett &instr_it,
   const stack_catcht &stack_catch,
   const std::vector<exprt> &locals)
 {
   PRECONDITION(instr_it->type==FUNCTION_CALL);
-
-  goto_programt &goto_program=func_it->second.body;
-  const irep_idt &function_id=func_it->first;
 
   // save the address of the next instruction
   goto_programt::targett next_it=instr_it;
@@ -430,7 +432,7 @@ void remove_exceptionst::instrument_function_call(
   if(callee_inflight_exception && local_inflight_exception)
   {
     add_exception_dispatch_sequence(
-      func_it, instr_it, stack_catch, locals);
+      function_id, goto_program, instr_it, stack_catch, locals);
 
     const symbol_exprt callee_inflight_exception_expr=
       callee_inflight_exception->symbol_expr();
@@ -463,12 +465,12 @@ void remove_exceptionst::instrument_function_call(
 /// handlers. Additionally, it re-computes the live-range of local variables in
 /// order to add DEAD instructions.
 void remove_exceptionst::instrument_exceptions(
-  const goto_functionst::function_mapt::iterator &func_it)
+  const irep_idt &function_id,
+  goto_programt &goto_program)
 {
   stack_catcht stack_catch; // stack of try-catch blocks
   std::vector<std::vector<exprt>> stack_locals; // stack of local vars
   std::vector<exprt> locals;
-  goto_programt &goto_program=func_it->second.body;
 
   if(goto_program.empty())
     return;
@@ -486,7 +488,7 @@ void remove_exceptionst::instrument_exceptions(
       // Is it an exception landing pad (start of a catch block)?
       if(statement==ID_exception_landingpad)
       {
-        instrument_exception_handler(func_it, instr_it);
+        instrument_exception_handler(function_id, goto_program, instr_it);
       }
       // Is it a catch handler pop?
       else if(statement==ID_pop_catch)
@@ -551,11 +553,13 @@ void remove_exceptionst::instrument_exceptions(
     }
     else if(instr_it->type==THROW)
     {
-      instrument_throw(func_it, instr_it, stack_catch, locals);
+      instrument_throw(
+        function_id, goto_program, instr_it, stack_catch, locals);
     }
     else if(instr_it->type==FUNCTION_CALL)
     {
-      instrument_function_call(func_it, instr_it, stack_catch, locals);
+      instrument_function_call(
+        function_id, goto_program, instr_it, stack_catch, locals);
     }
   }
 }
@@ -563,9 +567,9 @@ void remove_exceptionst::instrument_exceptions(
 void remove_exceptionst::operator()(goto_functionst &goto_functions)
 {
   Forall_goto_functions(it, goto_functions)
-    add_exceptional_returns(it);
+    add_exceptional_returns(it->first, it->second.body);
   Forall_goto_functions(it, goto_functions)
-    instrument_exceptions(it);
+    instrument_exceptions(it->first, it->second.body);
 }
 
 /// removes throws/CATCH-POP/CATCH-PUSH
@@ -583,7 +587,5 @@ void remove_exceptions(
 /// removes throws/CATCH-POP/CATCH-PUSH
 void remove_exceptions(goto_modelt &goto_model)
 {
-  remove_exceptions(
-    goto_model.symbol_table,
-    goto_model.goto_functions);
+  remove_exceptions(goto_model.symbol_table, goto_model.goto_functions);
 }

--- a/src/goto-programs/remove_exceptions.h
+++ b/src/goto-programs/remove_exceptions.h
@@ -21,7 +21,15 @@ Date:   December 2016
 // Removes 'throw x' and CATCH-PUSH/CATCH-POP
 // and adds the required instrumentation (GOTOs and assignments)
 
-void remove_exceptions(symbol_tablet &, goto_functionst &);
-void remove_exceptions(goto_modelt &);
+enum class remove_exceptions_typest
+{
+  REMOVE_ADDED_INSTANCEOF,
+  DONT_REMOVE_INSTANCEOF,
+};
+
+void remove_exceptions(
+  goto_modelt &goto_model,
+  remove_exceptions_typest type =
+    remove_exceptions_typest::DONT_REMOVE_INSTANCEOF);
 
 #endif

--- a/src/goto-programs/remove_instanceof.cpp
+++ b/src/goto-programs/remove_instanceof.cpp
@@ -28,15 +28,16 @@ public:
     class_hierarchy(symbol_table);
   }
 
-  // Lower instanceof for a single functions
+  // Lower instanceof for a single function
   bool lower_instanceof(goto_programt &);
+
+  // Lower instanceof for a single instruction
+  bool lower_instanceof(goto_programt &, goto_programt::targett);
 
 protected:
   symbol_tablet &symbol_table;
   namespacet ns;
   class_hierarchyt class_hierarchy;
-
-  bool lower_instanceof(goto_programt &, goto_programt::targett);
 
   std::size_t lower_instanceof(
     exprt &, goto_programt &, goto_programt::targett);
@@ -168,9 +169,24 @@ bool remove_instanceoft::lower_instanceof(goto_programt &goto_program)
 }
 
 
+/// Replace an instanceof in the expression or guard of the passed instruction
+/// of the given function body with an explicit class-identifier test.
+/// \remarks Extra auxiliary variables may be introduced into symbol_table.
+/// \param target: The instruction to work on.
+/// \param goto_program: The function body containing the instruction.
+/// \param symbol_table: The symbol table to add symbols to.
+void remove_instanceof(
+  goto_programt::targett target,
+  goto_programt &goto_program,
+  symbol_tablet &symbol_table)
+{
+  remove_instanceoft rem(symbol_table);
+  rem.lower_instanceof(goto_program, target);
+}
+
 /// Replace every instanceof in the passed function with an explicit
 /// class-identifier test.
-/// Extra auxiliary variables may be introduced into symbol_table.
+/// \remarks Extra auxiliary variables may be introduced into symbol_table.
 /// \param function: The function to work on.
 /// \param symbol_table: The symbol table to add symbols to.
 void remove_instanceof(
@@ -183,7 +199,7 @@ void remove_instanceof(
 
 /// Replace every instanceof in every function with an explicit
 /// class-identifier test.
-/// Extra auxiliary variables may be introduced into symbol_table.
+/// \remarks Extra auxiliary variables may be introduced into symbol_table.
 /// \param goto_functions: The functions to work on.
 /// \param symbol_table: The symbol table to add symbols to.
 void remove_instanceof(
@@ -198,6 +214,11 @@ void remove_instanceof(
     goto_functions.compute_location_numbers();
 }
 
+/// Replace every instanceof in every function with an explicit
+/// class-identifier test.
+/// \remarks Extra auxiliary variables may be introduced into symbol_table.
+/// \param goto_model: The functions to work on and the symbol table to add
+/// symbols to.
 void remove_instanceof(goto_modelt &goto_model)
 {
   remove_instanceof(goto_model.goto_functions, goto_model.symbol_table);

--- a/src/goto-programs/remove_instanceof.h
+++ b/src/goto-programs/remove_instanceof.h
@@ -17,6 +17,11 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 #include "goto_model.h"
 
 void remove_instanceof(
+  goto_programt::targett target,
+  goto_programt &goto_program,
+  symbol_tablet &symbol_table);
+
+void remove_instanceof(
   goto_functionst::goto_functiont &function,
   symbol_tablet &symbol_table);
 

--- a/src/jbmc/jbmc_parse_options.cpp
+++ b/src/jbmc/jbmc_parse_options.cpp
@@ -649,6 +649,8 @@ void jbmc_parse_optionst::process_goto_function(
     // Remove inline assembler; this needs to happen before
     // adding the library.
     remove_asm(function, symbol_table);
+    // Removal of RTTI inspection:
+    remove_instanceof(function, symbol_table);
   }
 
   catch(const char *e)
@@ -692,10 +694,9 @@ bool jbmc_parse_optionst::process_goto_functions(
       cmdline.isset("pointer-check"));
     // Java virtual functions -> explicit dispatch tables:
     remove_virtual_functions(goto_model);
-    // remove catch and throw (introduces instanceof)
-    remove_exceptions(goto_model);
-    // Similar removal of RTTI inspection:
-    remove_instanceof(goto_model);
+    // remove catch and throw (introduces instanceof but request it is removed)
+    remove_exceptions(
+      goto_model, remove_exceptions_typest::REMOVE_ADDED_INSTANCEOF);
 
     // instrument library preconditions
     instrument_preconditions(goto_model);


### PR DESCRIPTION
This removes the need to always run remove instanceof after remove exceptions and thus allows remove_instanceof to be moved to a function-pass
  