### PR TITLE
Run remove-virtual-functions on a per-function basis

### DIFF
--- a/src/goto-programs/goto_program_template.h
+++ b/src/goto-programs/goto_program_template.h
@@ -19,6 +19,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <sstream>
 #include <string>
 
+#include <util/invariant.h>
 #include <util/namespace.h>
 #include <util/symbol_table.h>
 #include <util/source_location.h>
@@ -512,7 +513,12 @@ public:
   void compute_location_numbers(unsigned &nr)
   {
     for(auto &i : instructions)
+    {
+      INVARIANT(
+        nr != std::numeric_limits<unsigned>::max(),
+        "Too many location numbers assigned");
       i.location_number=nr++;
+    }
   }
 
   /// Compute location numbers

--- a/src/goto-programs/lazy_goto_model.cpp
+++ b/src/goto-programs/lazy_goto_model.cpp
@@ -30,7 +30,8 @@ lazy_goto_modelt::lazy_goto_modelt(
       symbol_table,
       [this] (goto_functionst::goto_functiont &function) -> void
       {
-        this->post_process_function(function, symbol_table);
+        goto_model_functiont model_function(*goto_model, function);
+        this->post_process_function(model_function);
       },
       message_handler),
     post_process_function(std::move(post_process_function)),
@@ -49,7 +50,8 @@ lazy_goto_modelt::lazy_goto_modelt(lazy_goto_modelt &&other)
       symbol_table,
       [this] (goto_functionst::goto_functiont &function) -> void
       {
-        this->post_process_function(function, symbol_table);
+        goto_model_functiont model_function(*goto_model, function);
+        this->post_process_function(model_function);
       },
       other.message_handler),
     language_files(std::move(other.language_files)),

--- a/src/goto-programs/lazy_goto_model.h
+++ b/src/goto-programs/lazy_goto_model.h
@@ -15,14 +15,12 @@
 class cmdlinet;
 class optionst;
 
-
 /// Model that holds partially loaded map of functions
 class lazy_goto_modelt
 {
 public:
-  typedef std::function<void(
-    goto_functionst::goto_functiont &function,
-    symbol_tablet &symbol_table)> post_process_functiont;
+  typedef std::function<void(goto_model_functiont &function)>
+    post_process_functiont;
   typedef std::function<bool(goto_modelt &goto_model)> post_process_functionst;
 
   explicit lazy_goto_modelt(
@@ -53,11 +51,9 @@ public:
     message_handlert &message_handler)
   {
     return lazy_goto_modelt(
-      [&handler] (
-        goto_functionst::goto_functiont &function,
-        symbol_tablet &symbol_table) -> void
+      [&handler] (goto_model_functiont &function)
       {
-        handler.process_goto_function(function, symbol_table);
+        handler.process_goto_function(function);
       },
       [&handler, &options] (goto_modelt &goto_model) -> bool
       {

--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -24,8 +24,7 @@ class remove_virtual_functionst
 {
 public:
   remove_virtual_functionst(
-    const symbol_tablet &_symbol_table,
-    const goto_functionst &goto_functions);
+    const symbol_tablet &_symbol_table);
 
   void operator()(goto_functionst &goto_functions);
 
@@ -65,8 +64,7 @@ protected:
 };
 
 remove_virtual_functionst::remove_virtual_functionst(
-  const symbol_tablet &_symbol_table,
-  const goto_functionst &goto_functions):
+  const symbol_tablet &_symbol_table):
   ns(_symbol_table),
   symbol_table(_symbol_table)
 {
@@ -436,9 +434,7 @@ void remove_virtual_functions(
   const symbol_tablet &symbol_table,
   goto_functionst &goto_functions)
 {
-  remove_virtual_functionst
-    rvf(symbol_table, goto_functions);
-
+  remove_virtual_functionst rvf(symbol_table);
   rvf(goto_functions);
 }
 
@@ -448,6 +444,16 @@ void remove_virtual_functions(goto_modelt &goto_model)
     goto_model.symbol_table, goto_model.goto_functions);
 }
 
+void remove_virtual_functions(goto_model_functiont &function)
+{
+  remove_virtual_functionst rvf(function.get_symbol_table());
+  bool changed = rvf.remove_virtual_functions(
+    function.get_goto_function().body);
+  // Give fresh location numbers to `function`, in case it has grown:
+  if(changed)
+    function.compute_location_numbers();
+}
+
 void remove_virtual_function(
   goto_modelt &goto_model,
   goto_programt &goto_program,
@@ -455,8 +461,7 @@ void remove_virtual_function(
   const dispatch_table_entriest &dispatch_table,
   virtual_dispatch_fallback_actiont fallback_action)
 {
-  remove_virtual_functionst
-    rvf(goto_model.symbol_table, goto_model.goto_functions);
+  remove_virtual_functionst rvf(goto_model.symbol_table);
 
   rvf.remove_virtual_function(
     goto_program, instruction, dispatch_table, fallback_action);

--- a/src/goto-programs/remove_virtual_functions.h
+++ b/src/goto-programs/remove_virtual_functions.h
@@ -25,6 +25,12 @@ void remove_virtual_functions(
   const symbol_tablet &symbol_table,
   goto_functionst &goto_functions);
 
+/// Remove virtual functions from one function.
+/// May change the location numbers in `function`.
+/// \param function: function from which virtual functions should be converted
+///   to explicit dispatch tables.
+void remove_virtual_functions(goto_model_functiont &function);
+
 /// Specifies remove_virtual_function's behaviour when the actual supplied
 /// parameter does not match any of the possible callee types
 enum class virtual_dispatch_fallback_actiont

--- a/src/jbmc/jbmc_parse_options.cpp
+++ b/src/jbmc/jbmc_parse_options.cpp
@@ -637,15 +637,17 @@ int jbmc_parse_optionst::get_goto_program(
 }
 
 void jbmc_parse_optionst::process_goto_function(
-  goto_functionst::goto_functiont &function, symbol_tablet &symbol_table)
+  goto_model_functiont &function)
 {
+  symbol_tablet &symbol_table = function.get_symbol_table();
+  goto_functionst::goto_functiont &goto_function = function.get_goto_function();
   try
   {
     // Remove inline assembler; this needs to happen before
     // adding the library.
-    remove_asm(function, symbol_table);
+    remove_asm(goto_function, symbol_table);
     // Removal of RTTI inspection:
-    remove_instanceof(function, symbol_table);
+    remove_instanceof(goto_function, symbol_table);
   }
 
   catch(const char *e)

--- a/src/jbmc/jbmc_parse_options.cpp
+++ b/src/jbmc/jbmc_parse_options.cpp
@@ -648,6 +648,8 @@ void jbmc_parse_optionst::process_goto_function(
     remove_asm(goto_function, symbol_table);
     // Removal of RTTI inspection:
     remove_instanceof(goto_function, symbol_table);
+    // Java virtual functions -> explicit dispatch tables:
+    remove_virtual_functions(function);
   }
 
   catch(const char *e)
@@ -678,8 +680,6 @@ bool jbmc_parse_optionst::process_goto_functions(
     remove_java_new(goto_model, get_message_handler());
 
     status() << "Removal of virtual functions" << eom;
-    // Java virtual functions -> explicit dispatch tables:
-    remove_virtual_functions(goto_model);
     // remove catch and throw (introduces instanceof but request it is removed)
     remove_exceptions(
       goto_model, remove_exceptions_typest::REMOVE_ADDED_INSTANCEOF);

--- a/src/jbmc/jbmc_parse_options.h
+++ b/src/jbmc/jbmc_parse_options.h
@@ -81,8 +81,7 @@ public:
     const char **argv,
     const std::string &extra_options);
 
-  void process_goto_function(
-    goto_functionst::goto_functiont &function, symbol_tablet &symbol_table);
+  void process_goto_function(goto_model_functiont &function);
   bool process_goto_functions(goto_modelt &goto_model, const optionst &options);
 
 protected:

--- a/unit/testing-utils/load_java_class.cpp
+++ b/unit/testing-utils/load_java_class.cpp
@@ -62,7 +62,7 @@ symbol_tablet load_java_class(
   // Construct a lazy_goto_modelt
   null_message_handlert message_handler;
   lazy_goto_modelt lazy_goto_model(
-    [] (goto_functionst::goto_functiont &function, symbol_tablet &symbol_table)
+    [] (goto_model_functiont &function)
     { },
     [] (goto_modelt &goto_model)
     { return false; },


### PR DESCRIPTION
This introduces a mechanism to re-number a single GOTO program, since various parts of the CBMC codebase will assume the globally-unique-location-numbers invariant holds and it's safest to ensure it holds as much of the time as possible, then uses it to move remove-virtual-functions to run as each function is elaborated, rather than all in one go at the end.