### PR TITLE
Goto analyzer develop simplify address of member

### DIFF
--- a/regression/goto-analyzer/sensitivity-test-constants-pointer-to-two-value-struct/test.desc
+++ b/regression/goto-analyzer/sensitivity-test-constants-pointer-to-two-value-struct/test.desc
@@ -9,12 +9,12 @@ sensitivity_test_constants_pointer_to_two_value_struct.c
 ^\[main.assertion.4\] .* p->a==1: Unknown$
 ^\[main.assertion.5\] .* p->b==2.0: Unknown$
 ^\[main.assertion.6\] .* p->b==1.0: Unknown$
-\[main\.assertion\.7\] .* comp_p==&x\.a: Unknown$
+\[main\.assertion\.7\] .* comp_p==&x\.a: Success$
 \[main\.assertion\.8\] .* comp_p==&x\.b: Unknown$
 \[main\.assertion\.9\] .* \*comp_p==0: Unknown$
 \[main\.assertion\.10\] .* \*comp_p==1: Unknown$
 \[main\.assertion\.11\] .* compb_p==&x\.a: Unknown$
-\[main\.assertion\.12\] .* compb_p==&x\.b: Unknown$
+\[main\.assertion\.12\] .* compb_p==&x\.b: Success$
 \[main\.assertion\.13\] .* \*compb_p==2\.0: Unknown$
 \[main\.assertion\.14\] .* \*compb_p==1\.0: Unknown$
 \[main\.assertion\.15\] .* implicit_p==&x\.a: Unknown$


### PR DESCRIPTION
These allow simplification in cases like

```
struct S {
  int x;
};

union U {
  int x;
};

int main(void)
{
  struct S s;
  union U u;
  assert(&s.x == &s.x);
  assert(((struct S*)&s.x) == &s);
  assert(&u.x == &u.x);
  assert(((union U*)&u.x) == &u);
}
```