### PR TITLE
Remove exceptions pass: introduce per-function operation

### DIFF
--- a/src/goto-programs/remove_exceptions.h
+++ b/src/goto-programs/remove_exceptions.h
@@ -16,7 +16,7 @@ Date:   December 2016
 
 #include <goto-programs/goto_model.h>
 
-#define EXC_SUFFIX "#exception_value"
+#define INFLIGHT_EXCEPTION_VARIABLE_NAME "java::@inflight_exception"
 
 // Removes 'throw x' and CATCH-PUSH/CATCH-POP
 // and adds the required instrumentation (GOTOs and assignments)

--- a/src/goto-programs/remove_exceptions.h
+++ b/src/goto-programs/remove_exceptions.h
@@ -28,6 +28,12 @@ enum class remove_exceptions_typest
 };
 
 void remove_exceptions(
+  goto_programt &goto_program,
+  symbol_tablet &symbol_table,
+  remove_exceptions_typest type =
+    remove_exceptions_typest::DONT_REMOVE_INSTANCEOF);
+
+void remove_exceptions(
   goto_modelt &goto_model,
   remove_exceptions_typest type =
     remove_exceptions_typest::DONT_REMOVE_INSTANCEOF);

--- a/src/java_bytecode/java_bytecode_internal_additions.cpp
+++ b/src/java_bytecode/java_bytecode_internal_additions.cpp
@@ -11,6 +11,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/std_types.h>
 #include <util/cprover_prefix.h>
 #include <util/c_types.h>
+// For INFLIGHT_EXCEPTION_VARIABLE_NAME
+#include <goto-programs/remove_exceptions.h>
 
 void java_internal_additions(symbol_table_baset &dest)
 {
@@ -39,6 +41,18 @@ void java_internal_additions(symbol_table_baset &dest)
     symbol.is_lvalue=true;
     symbol.is_state_var=true;
     symbol.is_thread_local=true;
+    dest.add(symbol);
+  }
+
+  {
+    auxiliary_symbolt symbol;
+    symbol.base_name = "@inflight_exception";
+    symbol.name = INFLIGHT_EXCEPTION_VARIABLE_NAME;
+    symbol.mode = ID_java;
+    symbol.type = pointer_type(empty_typet());
+    symbol.value = null_pointer_exprt(to_pointer_type(symbol.type));
+    symbol.is_file_local = false;
+    symbol.is_static_lifetime = true;
     dest.add(symbol);
   }
 }


### PR DESCRIPTION
Depends on #1719; please only review the second commit.

This introduces a per-function entry point for remove-exceptions. Unlike the PR for remove-virtual-functions I don't actually use it yet because it does result in more unreachable code; I'll enable this only when lazy-loading v2 (symex-driven function loading) is enabled.

Therefore don't merge this yet since it isn't tested, but this PR provides an easy place to review the change in isolation.