### PR TITLE
expr2c now distinguishes binary and multi-ary expressions

### DIFF
--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -88,6 +88,10 @@ protected:
     const exprt &src, const std::string &symbol,
     unsigned precedence, bool full_parentheses);
 
+  std::string convert_multi_ary(
+    const exprt &src, const std::string &symbol,
+    unsigned precedence, bool full_parentheses);
+
   std::string convert_cond(
     const exprt &src, unsigned precedence);
 


### PR DESCRIPTION
multi-ary and proper binary expressions can now have different textual representations; among other benefits, this allows considering associativity properly.