### PR TITLE
Add constructors for having memory-loaded jar files

### DIFF
--- a/src/java_bytecode/jar_file.cpp
+++ b/src/java_bytecode/jar_file.cpp
@@ -12,10 +12,7 @@ Author: Diffblue Ltd
 #include <util/invariant.h>
 #include "java_class_loader_limit.h"
 
-jar_filet::jar_filet(
-  java_class_loader_limitt &limit,
-  const std::string &filename):
-  m_zip_archive(filename)
+void jar_filet::initialize_file_index(java_class_loader_limitt &limit)
 {
   const size_t file_count=m_zip_archive.get_num_files();
   for(size_t index=0; index<file_count; index++)
@@ -24,6 +21,29 @@ jar_filet::jar_filet(
     if(!has_suffix(filename, ".class") || limit.load_class_file(filename))
       m_name_to_index.emplace(filename, index);
   }
+}
+
+/// This constructor creates a jar_file object whose contents
+/// are extracted from a memory buffer (byte array) as opposed
+/// to a jar file.
+jar_filet::jar_filet(
+  java_class_loader_limitt &limit,
+  const std::string &filename):
+  m_zip_archive(filename)
+{
+  initialize_file_index(limit);
+}
+
+/// This constructor creates a jar_file object whose contents
+/// are extracted from a memory buffer (byte array) as opposed
+/// to a jar file.
+jar_filet::jar_filet(
+  java_class_loader_limitt &limit,
+  const void *pMem,
+  size_t size):
+  m_zip_archive(pMem, size)
+{
+  initialize_file_index(limit);
 }
 
 // VS: No default move constructors or assigns

--- a/src/java_bytecode/jar_file.h
+++ b/src/java_bytecode/jar_file.h
@@ -21,16 +21,29 @@ class java_class_loader_limitt;
 class jar_filet final
 {
 public:
-  /// Open java file for reading
+  /// Open java file for reading.
   /// \param limit Object limiting number of loaded .class files
   /// \param filename Name of the file
   /// \throw Throws std::runtime_error if file cannot be opened
   jar_filet(java_class_loader_limitt &limit, const std::string &filename);
+
+  /// Open a JAR file of size \p size loaded in memory at address \p pMem.
+  /// \param limit Object limiting number of loaded .class files
+  /// \param pMem memory buffer with the contents of the jar file
+  /// \param size size  of the memory buffer
+  /// \throw Throws std::runtime_error if file cannot be opened
+  jar_filet(java_class_loader_limitt &limit, const void *pMem, size_t size);
+
   jar_filet(const jar_filet &)=delete;
   jar_filet &operator=(const jar_filet &)=delete;
   jar_filet(jar_filet &&);
   jar_filet &operator=(jar_filet &&);
   ~jar_filet()=default;
+
+  /// Loads the fileindex (m_name_to_index) with a map of loaded files to
+  /// indices.
+  void initialize_file_index(java_class_loader_limitt &limit);
+
   /// Get contents of a file in the jar archive.
   /// Terminates the program if file doesn't exist
   /// \param filename Name of the file in the archive
@@ -41,7 +54,7 @@ public:
   std::vector<std::string> filenames() const;
 private:
   mz_zip_archivet m_zip_archive;
-  /// Map of filename to the file index in the zip archive
+  /// Map of filename to the file index in the zip archive.
   std::unordered_map<std::string, size_t> m_name_to_index;
 };
 

--- a/src/java_bytecode/jar_file.h
+++ b/src/java_bytecode/jar_file.h
@@ -40,10 +40,6 @@ public:
   jar_filet &operator=(jar_filet &&);
   ~jar_filet()=default;
 
-  /// Loads the fileindex (m_name_to_index) with a map of loaded files to
-  /// indices.
-  void initialize_file_index(java_class_loader_limitt &limit);
-
   /// Get contents of a file in the jar archive.
   /// Terminates the program if file doesn't exist
   /// \param filename Name of the file in the archive
@@ -53,6 +49,10 @@ public:
   /// Get list of filenames in the archive
   std::vector<std::string> filenames() const;
 private:
+  /// Loads the fileindex (m_name_to_index) with a map of loaded files to
+  /// indices.
+  void initialize_file_index(java_class_loader_limitt &limit);
+
   mz_zip_archivet m_zip_archive;
   /// Map of filename to the file index in the zip archive.
   std::unordered_map<std::string, size_t> m_name_to_index;

--- a/src/java_bytecode/mz_zip_archive.cpp
+++ b/src/java_bytecode/mz_zip_archive.cpp
@@ -25,6 +25,14 @@ public:
     if(MZ_TRUE!=mz_zip_reader_init_file(this, filename.data(), 0))
       throw std::runtime_error("MZT: Could not load a file: "+filename);
   }
+
+  explicit mz_zip_archive_statet(const void *pMem, size_t size):
+    mz_zip_archive({ })
+  {
+    if(MZ_TRUE!=mz_zip_reader_init_mem(this, pMem, size, 0))
+      throw std::runtime_error("MZT: Could not load data from memory");
+  }
+
   mz_zip_archive_statet(const mz_zip_archive_statet &)=delete;
   mz_zip_archive_statet(mz_zip_archive_statet &&)=delete;
   mz_zip_archive_statet &operator=(const mz_zip_archive_statet &)=delete;
@@ -40,6 +48,9 @@ static_assert(sizeof(mz_uint)<=sizeof(size_t),
 
 mz_zip_archivet::mz_zip_archivet(const std::string &filename):
   m_state(new mz_zip_archive_statet(filename)) { }
+
+mz_zip_archivet::mz_zip_archivet(const void *pMem, size_t size):
+  m_state(new mz_zip_archive_statet(pMem, size)) { }
 
 // VS Compatibility
 mz_zip_archivet::mz_zip_archivet(mz_zip_archivet &&other):

--- a/src/java_bytecode/mz_zip_archive.cpp
+++ b/src/java_bytecode/mz_zip_archive.cpp
@@ -26,7 +26,7 @@ public:
       throw std::runtime_error("MZT: Could not load a file: "+filename);
   }
 
-  explicit mz_zip_archive_statet(const void *pMem, size_t size):
+  mz_zip_archive_statet(const void *pMem, size_t size):
     mz_zip_archive({ })
   {
     if(MZ_TRUE!=mz_zip_reader_init_mem(this, pMem, size, 0))

--- a/src/java_bytecode/mz_zip_archive.h
+++ b/src/java_bytecode/mz_zip_archive.h
@@ -24,6 +24,13 @@ public:
   /// \param filename Path of the zip archive
   /// \throw Throws std::runtime_error if file cannot be opened
   explicit mz_zip_archivet(const std::string &filename);
+
+  /// Loads a zip buffer
+  /// \param pMem pointer to the memory buffer
+  /// \param size size of the buffer
+  /// \throw Throws std::runtime_error if file cannot be opened
+  explicit mz_zip_archivet(const void *pMem, size_t size);
+
   mz_zip_archivet(const mz_zip_archivet &)=delete;
   mz_zip_archivet &operator=(const mz_zip_archivet &)=delete;
   /// Move constructor. Doesn't throw. Leaves other object invalidated.

--- a/src/java_bytecode/mz_zip_archive.h
+++ b/src/java_bytecode/mz_zip_archive.h
@@ -29,7 +29,7 @@ public:
   /// \param pMem pointer to the memory buffer
   /// \param size size of the buffer
   /// \throw Throws std::runtime_error if file cannot be opened
-  explicit mz_zip_archivet(const void *pMem, size_t size);
+  mz_zip_archivet(const void *pMem, size_t size);
 
   mz_zip_archivet(const mz_zip_archivet &)=delete;
   mz_zip_archivet &operator=(const mz_zip_archivet &)=delete;


### PR DESCRIPTION
We aim at internalizing a portion of the model-library by turning the jar into an include file.
This will enable us to load the corresponding buffer (or any we need henceforth) in a similar fashion as we load from a jar file.