### PR TITLE
JBMC: run add-failed-symbols on a per-function basis

### DIFF
--- a/src/goto-programs/convert_nondet.cpp
+++ b/src/goto-programs/convert_nondet.cpp
@@ -32,7 +32,7 @@ Author: Reuben Thomas, reuben.thomas@diffblue.com
 static goto_programt::targett insert_nondet_init_code(
   goto_programt &goto_program,
   const goto_programt::targett &target,
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   message_handlert &message_handler,
   const object_factory_parameterst &object_factory_parameters)
 {
@@ -113,7 +113,7 @@ static goto_programt::targett insert_nondet_init_code(
 /// \param max_nondet_array_length: Maximum size of new nondet arrays.
 void convert_nondet(
   goto_programt &goto_program,
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   message_handlert &message_handler,
   const object_factory_parameterst &object_factory_parameters)
 {
@@ -146,7 +146,7 @@ void convert_nondet(
 
 void convert_nondet(
   goto_functionst &goto_functions,
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   message_handlert &message_handler,
   const object_factory_parameterst &object_factory_parameters)
 {

--- a/src/goto-programs/convert_nondet.h
+++ b/src/goto-programs/convert_nondet.h
@@ -15,7 +15,7 @@ Author: Reuben Thomas, reuben.thomas@diffblue.com
 #include <cstddef> // size_t
 
 class goto_functionst;
-class symbol_tablet;
+class symbol_table_baset;
 class goto_modelt;
 class goto_model_functiont;
 class message_handlert;
@@ -30,7 +30,7 @@ struct object_factory_parameterst;
 ///   objects.
 void convert_nondet(
   goto_functionst &,
-  symbol_tablet &,
+  symbol_table_baset &,
   message_handlert &,
   const object_factory_parameterst &object_factory_parameters);
 

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -2178,7 +2178,7 @@ const symbolt &goto_convertt::lookup(const irep_idt &identifier)
 
 void goto_convert(
   const codet &code,
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   goto_programt &dest,
   message_handlert &message_handler)
 {
@@ -2212,7 +2212,7 @@ void goto_convert(
 }
 
 void goto_convert(
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   goto_programt &dest,
   message_handlert &message_handler)
 {

--- a/src/goto-programs/goto_convert.h
+++ b/src/goto-programs/goto_convert.h
@@ -20,13 +20,13 @@ Author: Daniel Kroening, kroening@kroening.com
 // start from given code
 void goto_convert(
   const codet &code,
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   goto_programt &dest,
   message_handlert &message_handler);
 
 // start from "main"
 void goto_convert(
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   goto_programt &dest,
   message_handlert &message_handler);
 

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -29,7 +29,7 @@ public:
   void goto_convert(const codet &code, goto_programt &dest);
 
   goto_convertt(
-    symbol_tablet &_symbol_table,
+    symbol_table_baset &_symbol_table,
     message_handlert &_message_handler):
     messaget(_message_handler),
     symbol_table(_symbol_table),
@@ -44,7 +44,7 @@ public:
   }
 
 protected:
-  symbol_tablet &symbol_table;
+  symbol_table_baset &symbol_table;
   namespacet ns;
   unsigned temporary_counter;
   std::string tmp_symbol_prefix;

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -21,7 +21,7 @@ Date: June 2003
 #include "goto_inline.h"
 
 goto_convert_functionst::goto_convert_functionst(
-  symbol_tablet &_symbol_table,
+  symbol_table_baset &_symbol_table,
   message_handlert &_message_handler):
   goto_convertt(_symbol_table, _message_handler)
 {
@@ -234,7 +234,7 @@ void goto_convert(
 }
 
 void goto_convert(
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   goto_functionst &functions,
   message_handlert &message_handler)
 {
@@ -269,7 +269,7 @@ void goto_convert(
 
 void goto_convert(
   const irep_idt &identifier,
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   goto_functionst &functions,
   message_handlert &message_handler)
 {

--- a/src/goto-programs/goto_convert_functions.h
+++ b/src/goto-programs/goto_convert_functions.h
@@ -20,7 +20,7 @@ Date: June 2003
 
 // convert it all!
 void goto_convert(
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   goto_functionst &functions,
   message_handlert &);
 
@@ -32,7 +32,7 @@ void goto_convert(
 // just convert a specific function
 void goto_convert(
   const irep_idt &identifier,
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   goto_functionst &functions,
   message_handlert &);
 
@@ -45,7 +45,7 @@ public:
     goto_functionst::goto_functiont &result);
 
   goto_convert_functionst(
-    symbol_tablet &_symbol_table,
+    symbol_table_baset &_symbol_table,
     message_handlert &_message_handler);
 
   virtual ~goto_convert_functionst();

--- a/src/goto-programs/lazy_goto_model.cpp
+++ b/src/goto-programs/lazy_goto_model.cpp
@@ -28,9 +28,14 @@ lazy_goto_modelt::lazy_goto_modelt(
       goto_model->goto_functions.function_map,
       language_files,
       symbol_table,
-      [this] (goto_functionst::goto_functiont &function) -> void
+      [this] (
+        goto_functionst::goto_functiont &function,
+        journalling_symbol_tablet &journalling_symbol_table) -> void
       {
-        goto_model_functiont model_function(*goto_model, function);
+        goto_model_functiont model_function(
+          journalling_symbol_table,
+          goto_model->goto_functions,
+          function);
         this->post_process_function(model_function, *this);
       },
       message_handler),
@@ -48,9 +53,14 @@ lazy_goto_modelt::lazy_goto_modelt(lazy_goto_modelt &&other)
       goto_model->goto_functions.function_map,
       language_files,
       symbol_table,
-      [this] (goto_functionst::goto_functiont &function) -> void
+      [this] (
+        goto_functionst::goto_functiont &function,
+        journalling_symbol_tablet &journalling_symbol_table) -> void
       {
-        goto_model_functiont model_function(*goto_model, function);
+        goto_model_functiont model_function(
+          journalling_symbol_table,
+          goto_model->goto_functions,
+          function);
         this->post_process_function(model_function, *this);
       },
       other.message_handler),

--- a/src/goto-programs/remove_instanceof.cpp
+++ b/src/goto-programs/remove_instanceof.cpp
@@ -22,7 +22,7 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 class remove_instanceoft
 {
 public:
-  explicit remove_instanceoft(symbol_tablet &symbol_table)
+  explicit remove_instanceoft(symbol_table_baset &symbol_table)
   : symbol_table(symbol_table), ns(symbol_table)
   {
     class_hierarchy(symbol_table);
@@ -35,7 +35,7 @@ public:
   bool lower_instanceof(goto_programt &, goto_programt::targett);
 
 protected:
-  symbol_tablet &symbol_table;
+  symbol_table_baset &symbol_table;
   namespacet ns;
   class_hierarchyt class_hierarchy;
 
@@ -183,7 +183,7 @@ bool remove_instanceoft::lower_instanceof(goto_programt &goto_program)
 void remove_instanceof(
   goto_programt::targett target,
   goto_programt &goto_program,
-  symbol_tablet &symbol_table)
+  symbol_table_baset &symbol_table)
 {
   remove_instanceoft rem(symbol_table);
   rem.lower_instanceof(goto_program, target);
@@ -196,7 +196,7 @@ void remove_instanceof(
 /// \param symbol_table: The symbol table to add symbols to.
 void remove_instanceof(
   goto_functionst::goto_functiont &function,
-  symbol_tablet &symbol_table)
+  symbol_table_baset &symbol_table)
 {
   remove_instanceoft rem(symbol_table);
   rem.lower_instanceof(function.body);
@@ -209,7 +209,7 @@ void remove_instanceof(
 /// \param symbol_table: The symbol table to add symbols to.
 void remove_instanceof(
   goto_functionst &goto_functions,
-  symbol_tablet &symbol_table)
+  symbol_table_baset &symbol_table)
 {
   remove_instanceoft rem(symbol_table);
   bool changed=false;

--- a/src/goto-programs/remove_instanceof.h
+++ b/src/goto-programs/remove_instanceof.h
@@ -19,15 +19,15 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 void remove_instanceof(
   goto_programt::targett target,
   goto_programt &goto_program,
-  symbol_tablet &symbol_table);
+  symbol_table_baset &symbol_table);
 
 void remove_instanceof(
   goto_functionst::goto_functiont &function,
-  symbol_tablet &symbol_table);
+  symbol_table_baset &symbol_table);
 
 void remove_instanceof(
   goto_functionst &goto_functions,
-  symbol_tablet &symbol_table);
+  symbol_table_baset &symbol_table);
 
 void remove_instanceof(goto_modelt &model);
 

--- a/src/goto-programs/remove_returns.cpp
+++ b/src/goto-programs/remove_returns.cpp
@@ -19,7 +19,7 @@ Date:   September 2009
 class remove_returnst
 {
 public:
-  explicit remove_returnst(symbol_tablet &_symbol_table):
+  explicit remove_returnst(symbol_table_baset &_symbol_table):
     symbol_table(_symbol_table)
   {
   }
@@ -35,7 +35,7 @@ public:
     goto_functionst &goto_functions);
 
 protected:
-  symbol_tablet &symbol_table;
+  symbol_table_baset &symbol_table;
 
   void replace_returns(
     const irep_idt &function_id,
@@ -251,7 +251,7 @@ void remove_returnst::operator()(
 
 /// removes returns
 void remove_returns(
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   goto_functionst &goto_functions)
 {
   remove_returnst rr(symbol_table);
@@ -290,7 +290,7 @@ void remove_returns(goto_modelt &goto_model)
 /// \return the function's type with its `return_type()` restored to its
 ///   original value if a \#return_value variable exists, or nil otherwise
 code_typet original_return_type(
-  const symbol_tablet &symbol_table,
+  const symbol_table_baset &symbol_table,
   const irep_idt &function_id)
 {
   code_typet type;

--- a/src/goto-programs/remove_returns.h
+++ b/src/goto-programs/remove_returns.h
@@ -22,7 +22,7 @@ Date:   September 2009
 // unless the function returns void,
 // and a 'goto the_end_of_the_function'.
 
-void remove_returns(symbol_tablet &, goto_functionst &);
+void remove_returns(symbol_table_baset &, goto_functionst &);
 
 typedef std::function<bool(const irep_idt &)> function_is_stubt;
 
@@ -31,12 +31,12 @@ void remove_returns(goto_model_functiont &, function_is_stubt);
 void remove_returns(goto_modelt &);
 
 // reverse the above operations
-void restore_returns(symbol_tablet &, goto_functionst &);
+void restore_returns(symbol_table_baset &, goto_functionst &);
 
 void restore_returns(goto_modelt &);
 
 code_typet original_return_type(
-  const symbol_tablet &symbol_table,
+  const symbol_table_baset &symbol_table,
   const irep_idt &function_id);
 
 #endif // CPROVER_GOTO_PROGRAMS_REMOVE_RETURNS_H

--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -24,7 +24,7 @@ class remove_virtual_functionst
 {
 public:
   remove_virtual_functionst(
-    const symbol_tablet &_symbol_table);
+    const symbol_table_baset &_symbol_table);
 
   void operator()(goto_functionst &goto_functions);
 
@@ -38,7 +38,7 @@ public:
 
 protected:
   const namespacet ns;
-  const symbol_tablet &symbol_table;
+  const symbol_table_baset &symbol_table;
 
   class_hierarchyt class_hierarchy;
 
@@ -64,7 +64,7 @@ protected:
 };
 
 remove_virtual_functionst::remove_virtual_functionst(
-  const symbol_tablet &_symbol_table):
+  const symbol_table_baset &_symbol_table):
   ns(_symbol_table),
   symbol_table(_symbol_table)
 {
@@ -431,7 +431,7 @@ void remove_virtual_functionst::operator()(goto_functionst &functions)
 }
 
 void remove_virtual_functions(
-  const symbol_tablet &symbol_table,
+  const symbol_table_baset &symbol_table,
   goto_functionst &goto_functions)
 {
   remove_virtual_functionst rvf(symbol_table);

--- a/src/goto-programs/remove_virtual_functions.h
+++ b/src/goto-programs/remove_virtual_functions.h
@@ -22,7 +22,7 @@ void remove_virtual_functions(
   goto_modelt &goto_model);
 
 void remove_virtual_functions(
-  const symbol_tablet &symbol_table,
+  const symbol_table_baset &symbol_table,
   goto_functionst &goto_functions);
 
 /// Remove virtual functions from one function.

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -379,7 +379,7 @@ void java_bytecode_languaget::methods_provided(id_sett &methods) const
 /// \param symtab: global symbol table
 void java_bytecode_languaget::convert_lazy_method(
   const irep_idt &function_id,
-  symbol_tablet &symtab)
+  symbol_table_baset &symtab)
 {
   const symbolt &symbol = symtab.lookup_ref(function_id);
   if(symbol.value.is_not_nil())

--- a/src/java_bytecode/java_bytecode_language.h
+++ b/src/java_bytecode/java_bytecode_language.h
@@ -152,7 +152,7 @@ public:
   virtual void methods_provided(id_sett &methods) const override;
   virtual void convert_lazy_method(
     const irep_idt &function_id,
-    symbol_tablet &symbol_table) override;
+    symbol_table_baset &symbol_table) override;
 
 protected:
   void convert_single_method(

--- a/src/jbmc/jbmc_parse_options.cpp
+++ b/src/jbmc/jbmc_parse_options.cpp
@@ -646,14 +646,11 @@ void jbmc_parse_optionst::process_goto_function(
   const can_produce_functiont &available_functions,
   const optionst &options)
 {
-  symbol_tablet &symbol_table = function.get_symbol_table();
+  journalling_symbol_tablet &symbol_table = function.get_symbol_table();
   namespacet ns(symbol_table);
   goto_functionst::goto_functiont &goto_function = function.get_goto_function();
   try
   {
-    // Remove inline assembler; this needs to happen before
-    // adding the library.
-    remove_asm(goto_function, symbol_table);
     // Removal of RTTI inspection:
     remove_instanceof(goto_function, symbol_table);
     // Java virtual functions -> explicit dispatch tables:

--- a/src/pointer-analysis/add_failed_symbols.cpp
+++ b/src/pointer-analysis/add_failed_symbols.cpp
@@ -15,11 +15,19 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/namespace.h>
 #include <util/std_expr.h>
 
+/// Get the name of the special symbol used to denote an unknown referee pointed
+/// to by a given pointer-typed symbol.
+/// \param id: base symbol id
+/// \return id of the corresponding unknown-object ("failed") symbol.
 irep_idt failed_symbol_id(const irep_idt &id)
 {
   return id2string(id)+"$object";
 }
 
+/// Create a failed-dereference symbol for the given base symbol if it is
+/// pointer-typed; if not, do nothing.
+/// \param symbol: symbol to created a failed symbol for
+/// \param symbol_table: global symbol table
 void add_failed_symbol(symbolt &symbol, symbol_table_baset &symbol_table)
 {
   if(symbol.type.id()==ID_pointer)
@@ -43,6 +51,11 @@ void add_failed_symbol(symbolt &symbol, symbol_table_baset &symbol_table)
   }
 }
 
+/// Create a failed-dereference symbol for the given base symbol if it is
+/// pointer-typed, an lvalue, and doesn't already have one. If any of these
+/// conditions are not met, do nothing.
+/// \param symbol: symbol to created a failed symbol for
+/// \param symbol_table: global symbol table
 void add_failed_symbol_if_needed(
   const symbolt &symbol, symbol_table_baset &symbol_table)
 {
@@ -55,6 +68,9 @@ void add_failed_symbol_if_needed(
   add_failed_symbol(*symbol_table.get_writeable(symbol.name), symbol_table);
 }
 
+/// Create a failed-dereference symbol for all symbols in the given table that
+/// need one (i.e. pointer-typed lvalues).
+/// \param symbol_table: global symbol table
 void add_failed_symbols(symbol_table_baset &symbol_table)
 {
   // the symbol table iterators are not stable, and
@@ -68,6 +84,11 @@ void add_failed_symbols(symbol_table_baset &symbol_table)
     add_failed_symbol_if_needed(*symbol, symbol_table);
 }
 
+/// Get the failed-dereference symbol for the given symbol
+/// \param expr: symbol expression to get a failed symbol for
+/// \param ns: global namespace
+/// \return symbol expression for the failed-dereference symbol, or nil_exprt
+///   if none exists.
 exprt get_failed_symbol(
   const symbol_exprt &expr,
   const namespacet &ns)

--- a/src/pointer-analysis/add_failed_symbols.cpp
+++ b/src/pointer-analysis/add_failed_symbols.cpp
@@ -20,7 +20,7 @@ irep_idt failed_symbol_id(const irep_idt &id)
   return id2string(id)+"$object";
 }
 
-void add_failed_symbol(symbolt &symbol, symbol_tablet &symbol_table)
+void add_failed_symbol(symbolt &symbol, symbol_table_baset &symbol_table)
 {
   if(symbol.type.id()==ID_pointer)
   {
@@ -43,7 +43,8 @@ void add_failed_symbol(symbolt &symbol, symbol_tablet &symbol_table)
   }
 }
 
-void add_failed_symbol(const symbolt &symbol, symbol_tablet &symbol_table)
+void add_failed_symbol_if_needed(
+  const symbolt &symbol, symbol_table_baset &symbol_table)
 {
   if(!symbol.is_lvalue)
     return;
@@ -54,7 +55,7 @@ void add_failed_symbol(const symbolt &symbol, symbol_tablet &symbol_table)
   add_failed_symbol(*symbol_table.get_writeable(symbol.name), symbol_table);
 }
 
-void add_failed_symbols(symbol_tablet &symbol_table)
+void add_failed_symbols(symbol_table_baset &symbol_table)
 {
   // the symbol table iterators are not stable, and
   // we are adding new symbols, this
@@ -64,7 +65,7 @@ void add_failed_symbols(symbol_tablet &symbol_table)
     symbol_list.push_back(&(named_symbol.second));
 
   for(const symbolt *symbol : symbol_list)
-    add_failed_symbol(*symbol, symbol_table);
+    add_failed_symbol_if_needed(*symbol, symbol_table);
 }
 
 exprt get_failed_symbol(

--- a/src/pointer-analysis/add_failed_symbols.h
+++ b/src/pointer-analysis/add_failed_symbols.h
@@ -14,12 +14,16 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/irep.h>
 
-class symbol_tablet;
+class symbol_table_baset;
+class symbolt;
 class exprt;
 class namespacet;
 class symbol_exprt;
 
-void add_failed_symbols(symbol_tablet &symbol_table);
+void add_failed_symbols(symbol_table_baset &symbol_table);
+
+void add_failed_symbol_if_needed(
+  const symbolt &symbol, symbol_table_baset &symbol_table);
 
 irep_idt failed_symbol_id(const irep_idt &identifier);
 

--- a/src/util/journalling_symbol_table.h
+++ b/src/util/journalling_symbol_table.h
@@ -48,7 +48,7 @@ private:
   changesett removed;
 
 private:
-  explicit journalling_symbol_tablet(symbol_tablet &base_symbol_table)
+  explicit journalling_symbol_tablet(symbol_table_baset &base_symbol_table)
     : symbol_table_baset(
         base_symbol_table.symbols,
         base_symbol_table.symbol_base_map,
@@ -77,7 +77,7 @@ public:
     return base_symbol_table.get_symbol_table();
   }
 
-  static journalling_symbol_tablet wrap(symbol_tablet &base_symbol_table)
+  static journalling_symbol_tablet wrap(symbol_table_baset &base_symbol_table)
   {
     return journalling_symbol_tablet(base_symbol_table);
   }

--- a/src/util/journalling_symbol_table.h
+++ b/src/util/journalling_symbol_table.h
@@ -38,7 +38,7 @@ public:
   typedef std::unordered_set<irep_idt, irep_id_hash> changesett;
 
 private:
-  symbol_tablet &base_symbol_table;
+  symbol_table_baset &base_symbol_table;
   // Symbols originally in the table will never be marked inserted
   changesett inserted;
   // get_writeable marks an existing symbol updated
@@ -74,7 +74,7 @@ public:
 
   virtual const symbol_tablet &get_symbol_table() const override
   {
-    return base_symbol_table;
+    return base_symbol_table.get_symbol_table();
   }
 
   static journalling_symbol_tablet wrap(symbol_tablet &base_symbol_table)

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -83,7 +83,8 @@ public:
 
   // populate a lazy method
   virtual void
-  convert_lazy_method(const irep_idt &function_id, symbol_tablet &symbol_table)
+  convert_lazy_method(
+    const irep_idt &function_id, symbol_table_baset &symbol_table)
   { }
 
   /// Final adjustments, e.g. initializing stub functions and globals that

--- a/src/util/language_file.cpp
+++ b/src/util/language_file.cpp
@@ -37,7 +37,7 @@ void language_filet::get_modules()
 
 void language_filet::convert_lazy_method(
   const irep_idt &id,
-  symbol_tablet &symbol_table)
+  symbol_table_baset &symbol_table)
 {
   language->convert_lazy_method(id, symbol_table);
 }

--- a/src/util/language_file.h
+++ b/src/util/language_file.h
@@ -49,7 +49,7 @@ public:
 
   void convert_lazy_method(
     const irep_idt &id,
-    symbol_tablet &symbol_table);
+    symbol_table_baset &symbol_table);
 
   explicit language_filet(const std::string &filename);
   language_filet(const language_filet &rhs);
@@ -119,7 +119,7 @@ public:
   // for this to be legal.
   void convert_lazy_method(
     const irep_idt &id,
-    symbol_tablet &symbol_table)
+    symbol_table_baset &symbol_table)
   {
     PRECONDITION(symbol_table.has_symbol(id));
     lazy_method_mapt::iterator it=lazy_method_map.find(id);


### PR DESCRIPTION
This is a bit more difficult than other pass conversions: it requires collecting a journal of new symbols from the front-end and passing it into process-goto-function, such that we can identify the new symbols more cheaply than making a full pass over the table every function (with quadratic cost). This in turn causes around 100 lines worth of `symbol_tablet -> symbol_table_baset`, though it turned out all affected code was already using the symbol table's public interface rather than directly fiddling with its internal data structures.

This should result in all functions getting failed symbols (`$failed_object` symbols, used in pointer analysis), as add-failed-symbols gets invoked before function loading starts (catching globals that have been pre-created) and after each function is loaded.

This depends on #1740; please only review the final 3 commits (from "Journalling symbol table: enable nesting" onwards) here.