### PR TITLE
Coverage: support instrumenting one function at a time

### DIFF
--- a/src/goto-instrument/cover.h
+++ b/src/goto-instrument/cover.h
@@ -15,6 +15,8 @@ Date: May 2016
 #define CPROVER_GOTO_INSTRUMENT_COVER_H
 
 #include <goto-programs/goto_model.h>
+#include "cover_filter.h"
+#include "cover_instrument.h"
 
 class message_handlert;
 class cmdlinet;
@@ -32,6 +34,15 @@ enum class coverage_criteriont
   COVER // __CPROVER_cover(x) annotations
 };
 
+struct cover_configt
+{
+  bool keep_assertions;
+  bool traces_must_terminate;
+  function_filterst function_filters;
+  goal_filterst goal_filters;
+  cover_instrumenterst cover_instrumenters;
+};
+
 void instrument_cover_goals(
   const symbol_tablet &,
   goto_functionst &,
@@ -43,6 +54,14 @@ void instrument_cover_goals(
   goto_programt &,
   coverage_criteriont,
   message_handlert &message_handler);
+
+std::unique_ptr<cover_configt> get_cover_config(
+  const optionst &, const symbol_tablet &, message_handlert &);
+
+void instrument_cover_goals(
+  const cover_configt &,
+  goto_model_functiont &,
+  message_handlert &);
 
 void parse_cover_options(const cmdlinet &, optionst &);
 

--- a/src/goto-programs/goto_model.h
+++ b/src/goto-programs/goto_model.h
@@ -86,9 +86,11 @@ public:
   goto_model_functiont(
     journalling_symbol_tablet &symbol_table,
     goto_functionst &goto_functions,
+    const irep_idt &function_id,
     goto_functionst::goto_functiont &goto_function):
   symbol_table(symbol_table),
   goto_functions(goto_functions),
+  function_id(function_id),
   goto_function(goto_function)
   {
   }
@@ -117,9 +119,17 @@ public:
     return goto_function;
   }
 
+  /// Get function id
+  /// \return `goto_function`'s name (its key in `goto_functions`)
+  const irep_idt &get_function_id()
+  {
+    return function_id;
+  }
+
 private:
   journalling_symbol_tablet &symbol_table;
   goto_functionst &goto_functions;
+  irep_idt function_id;
   goto_functionst::goto_functiont &goto_function;
 };
 

--- a/src/goto-programs/lazy_goto_functions_map.h
+++ b/src/goto-programs/lazy_goto_functions_map.h
@@ -49,6 +49,7 @@ public:
 
   typedef
     std::function<void(
+      const irep_idt &name,
       goto_functionst::goto_functiont &function,
       journalling_symbol_tablet &function_symbols)>
     post_process_functiont;
@@ -128,7 +129,7 @@ private:
     if(processed_functions.count(name)==0)
     {
       // Run function-pass conversions
-      post_process_function(function, journalling_table);
+      post_process_function(name, function, journalling_table);
       // Assign procedure-local location numbers for now
       function.body.compute_location_numbers();
       processed_functions.insert(name);

--- a/src/goto-programs/lazy_goto_model.cpp
+++ b/src/goto-programs/lazy_goto_model.cpp
@@ -29,12 +29,14 @@ lazy_goto_modelt::lazy_goto_modelt(
       language_files,
       symbol_table,
       [this] (
+        const irep_idt &function_name,
         goto_functionst::goto_functiont &function,
         journalling_symbol_tablet &journalling_symbol_table) -> void
       {
         goto_model_functiont model_function(
           journalling_symbol_table,
           goto_model->goto_functions,
+          function_name,
           function);
         this->post_process_function(model_function, *this);
       },
@@ -54,12 +56,14 @@ lazy_goto_modelt::lazy_goto_modelt(lazy_goto_modelt &&other)
       language_files,
       symbol_table,
       [this] (
+        const irep_idt &function_name,
         goto_functionst::goto_functiont &function,
         journalling_symbol_tablet &journalling_symbol_table) -> void
       {
         goto_model_functiont model_function(
           journalling_symbol_table,
           goto_model->goto_functions,
+          function_name,
           function);
         this->post_process_function(model_function, *this);
       },


### PR DESCRIPTION
This factors the coverage driver to pull apart parsing configuration and generating a coverage driver structure from actually performing the coverage, and factors the whole-program version to use a single-function version that operates under the same rules. This sets us up for an easy transition to applying coverage instrumentation per-function in JBMC.

Note I don't actually use this in JBMC yet as it does not yet use remove-exceptions in per-function mode. This PR is for reviewing the coverage alterations; I will bring in remove-exceptions and coverage-instrumentation together with the upcoming symex-driven function loading PR.