### PR TITLE
Simplify comparison between address of member expressions

### DIFF
--- a/regression/goto-analyzer/sensitivity-test-constants-pointer-to-constants-struct/test.desc
+++ b/regression/goto-analyzer/sensitivity-test-constants-pointer-to-constants-struct/test.desc
@@ -3,12 +3,22 @@ sensitivity_test_constants_pointer_to_constants_struct.c
 --variable --pointers --structs --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] .* assertion \(\*p\).a==0: Success$
-^\[main.assertion.2\] .* assertion \(\*p\).a==1: Failure \(if reachable\)$
-^\[main.assertion.3\] .* assertion p->a==0: Success$
-^\[main.assertion.4\] .* assertion p->a==1: Failure \(if reachable\)$
-^\[main.assertion.5\] .* assertion p->b==2.0: Success$
-^\[main.assertion.6\] .* assertion p->b==1.0: Failure \(if reachable\)$
+^\[main\.assertion\.1\] .* \(\*p\).a==0: Success$
+^\[main\.assertion\.2\] .* \(\*p\).a==1: Failure \(if reachable\)$
+^\[main\.assertion\.3\] .* p->a==0: Success$
+^\[main\.assertion\.4\] .* p->a==1: Failure \(if reachable\)$
+^\[main\.assertion\.5\] .* p->b==2.0: Success$
+^\[main\.assertion\.6\] .* p->b==1.0: Failure \(if reachable\)$
+^\[main\.assertion\.7\] .* comp_p==&x.a: Success$
+^\[main\.assertion\.9\] .* \*comp_p==0: Success$
+^\[main\.assertion\.10\] .* \*comp_p==1: Failure \(if reachable\)$
+^\[main\.assertion\.12\] .* compb_p==&x.b: Success$
+^\[main\.assertion\.13\] .* \*compb_p==2.0: Success$
+^\[main\.assertion\.14\] .* \*compb_p==1.0: Failure \(if reachable\)$
+^\[main\.assertion\.17\] .* \*implicit_p==0: Unknown$
+^\[main\.assertion\.18\] .* \*implicit_p==1: Unknown$
+^\[main\.assertion\.19\] .* x.a==5: Unknown$
+^\[main\.assertion\.20\] .* x.a==1: Unknown$
 --
 ^warning: ignoring
 --

--- a/regression/goto-analyzer/sensitivity-test-constants-pointer-to-two-value-struct/test.desc
+++ b/regression/goto-analyzer/sensitivity-test-constants-pointer-to-two-value-struct/test.desc
@@ -3,11 +3,25 @@ sensitivity_test_constants_pointer_to_two_value_struct.c
 --variable --pointers --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] .* assertion \(\*p\).a==0: Unknown$
-^\[main.assertion.2\] .* assertion \(\*p\).a==1: Unknown$
-^\[main.assertion.3\] .* assertion p->a==0: Unknown$
-^\[main.assertion.4\] .* assertion p->a==1: Unknown$
-^\[main.assertion.5\] .* assertion p->b==2.0: Unknown$
-^\[main.assertion.6\] .* assertion p->b==1.0: Unknown$
+^\[main.assertion.1\] .* \(\*p\).a==0: Unknown$
+^\[main.assertion.2\] .* \(\*p\).a==1: Unknown$
+^\[main.assertion.3\] .* p->a==0: Unknown$
+^\[main.assertion.4\] .* p->a==1: Unknown$
+^\[main.assertion.5\] .* p->b==2.0: Unknown$
+^\[main.assertion.6\] .* p->b==1.0: Unknown$
+\[main\.assertion\.7\] .* comp_p==&x\.a: Success$
+\[main\.assertion\.8\] .* comp_p==&x\.b: Unknown$
+\[main\.assertion\.9\] .* \*comp_p==0: Unknown$
+\[main\.assertion\.10\] .* \*comp_p==1: Unknown$
+\[main\.assertion\.11\] .* compb_p==&x\.a: Unknown$
+\[main\.assertion\.12\] .* compb_p==&x\.b: Success$
+\[main\.assertion\.13\] .* \*compb_p==2\.0: Unknown$
+\[main\.assertion\.14\] .* \*compb_p==1\.0: Unknown$
+\[main\.assertion\.15\] .* implicit_p==&x\.a: Unknown$
+\[main\.assertion\.16\] .* implicit_p==&x: Unknown$
+\[main\.assertion\.17\] .* \*implicit_p==0: Unknown$
+\[main\.assertion\.18\] .* \*implicit_p==1: Unknown$
+\[main\.assertion\.19\] .* x\.a==5: Unknown$
+\[main\.assertion\.20\] .* x\.a==1: Unknown$
 --
 ^warning: ignoring

--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -122,7 +122,7 @@ public:
   bool simplify_address_of_arg(exprt &expr);
   bool simplify_inequality_constant(exprt &expr);
   bool simplify_inequality_not_constant(exprt &expr);
-  bool simplify_inequality_address_of(exprt &expr);
+  bool simplify_equality_or_inequality_address_of(exprt &expr);
   bool simplify_inequality_pointer_object(exprt &expr);
 
   // main recursion

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -1208,7 +1208,7 @@ bool simplify_exprt::simplify_inequality(exprt &expr)
       (tmp1.id()==ID_address_of ||
        (tmp1.id()==ID_typecast && tmp1.op0().id()==ID_address_of)) &&
       (expr.id()==ID_equal || expr.id()==ID_notequal))
-    return simplify_inequality_address_of(expr);
+    return simplify_equality_or_inequality_address_of(expr);
 
   if(tmp0.id()==ID_pointer_object &&
      tmp1.id()==ID_pointer_object &&

--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -145,3 +145,187 @@ TEST_CASE("Simplify Java short -> int -> short casts")
 {
   test_unnecessary_cast(java_short_type());
 }
+
+SCENARIO("Comparing pointers to struct and union members")
+{
+  config.set_arch("none");
+  symbol_tablet symbol_table;
+  namespacet ns(symbol_table);
+
+  signedbv_typet int_type(32);
+
+  // struct { int x; int y; } s;
+  struct_typet simple_struct;
+  simple_struct.components().emplace_back("x", int_type);
+  simple_struct.components().emplace_back("y", int_type);
+
+  symbol_exprt simple_struct_var("s", simple_struct);
+
+  // union { int x; int y; } u;
+  union_typet simple_union;
+  simple_union.components().emplace_back("x", int_type);
+  simple_union.components().emplace_back("y", int_type);
+
+  symbol_exprt simple_union_var("u", simple_union);
+
+  WHEN("Comparing pointers to the same member in a struct")
+  {
+    THEN("Equality should simplify to true")
+    {
+      // &s.x == &s.x
+      auto x_equals_x = equal_exprt(
+        address_of_exprt(member_exprt(simple_struct_var, "x", int_type)),
+        address_of_exprt(member_exprt(simple_struct_var, "x", int_type)));
+      REQUIRE(simplify_expr(x_equals_x, ns) == true_exprt());
+
+      // &s.y == &s.y
+      auto y_equals_y = equal_exprt(
+        address_of_exprt(member_exprt(simple_struct_var, "y", int_type)),
+        address_of_exprt(member_exprt(simple_struct_var, "y", int_type)));
+      REQUIRE(simplify_expr(y_equals_y, ns) == true_exprt());
+    }
+    THEN("Inequality should simplify to false")
+    {
+      // &s.x != &s.x
+      auto x_notequals_x = notequal_exprt(
+        address_of_exprt(member_exprt(simple_struct_var, "x", int_type)),
+        address_of_exprt(member_exprt(simple_struct_var, "x", int_type)));
+      REQUIRE(simplify_expr(x_notequals_x, ns) == false_exprt());
+
+      // &s.y != &s.y
+      auto y_notequals_y = notequal_exprt(
+        address_of_exprt(member_exprt(simple_struct_var, "y", int_type)),
+        address_of_exprt(member_exprt(simple_struct_var, "y", int_type)));
+      REQUIRE(simplify_expr(y_notequals_y, ns) == false_exprt());
+    }
+  }
+
+  WHEN("Comparing pointers to different members in a struct")
+  {
+    THEN("Equality should simplify to false")
+    {
+      // &s.x == &s.y
+      auto equals = equal_exprt(
+        address_of_exprt(member_exprt(simple_struct_var, "x", int_type)),
+        address_of_exprt(member_exprt(simple_struct_var, "y", int_type)));
+      REQUIRE(simplify_expr(equals, ns) == false_exprt());
+    }
+    THEN("Inequality should simplify to true")
+    {
+      // &s.x != &s.y
+      auto notequals = notequal_exprt(
+        address_of_exprt(member_exprt(simple_struct_var, "x", int_type)),
+        address_of_exprt(member_exprt(simple_struct_var, "y", int_type)));
+      REQUIRE(simplify_expr(notequals, ns) == true_exprt());
+    }
+  }
+
+  WHEN("Comparing pointer to struct with pointer to first member")
+  {
+    THEN("Equality should simplify to true")
+    {
+      // (int*)&s == &s.x
+      auto equals = equal_exprt(
+        typecast_exprt(
+          address_of_exprt(simple_struct_var), pointer_type(int_type)),
+        address_of_exprt(member_exprt(simple_struct_var, "x", int_type)));
+      REQUIRE(simplify_expr(equals, ns) == true_exprt());
+    }
+
+    THEN("Inequality should simplify to false")
+    {
+      // (int*)&s != &s.x
+      auto notequals = notequal_exprt(
+        typecast_exprt(
+          address_of_exprt(simple_struct_var), pointer_type(int_type)),
+        address_of_exprt(member_exprt(simple_struct_var, "x", int_type)));
+      REQUIRE(simplify_expr(notequals, ns) == false_exprt());
+    }
+  }
+
+  WHEN("Comparing pointer to struct with pointer to member other than first")
+  {
+    THEN("Equality should simplify to false")
+    {
+      // (int*)&s == &s.y
+      auto equals = equal_exprt(
+        typecast_exprt(
+          address_of_exprt(simple_struct_var), pointer_type(int_type)),
+        address_of_exprt(member_exprt(simple_struct_var, "y", int_type)));
+      REQUIRE(simplify_expr(equals, ns) == false_exprt());
+    }
+
+    THEN("Inequality should simplify to true")
+    {
+      // (int*)&s != &s.y
+      auto notequals = notequal_exprt(
+        typecast_exprt(
+          address_of_exprt(simple_struct_var), pointer_type(int_type)),
+        address_of_exprt(member_exprt(simple_struct_var, "y", int_type)));
+      REQUIRE(simplify_expr(notequals, ns) == true_exprt());
+    }
+  }
+
+  WHEN("Comparing a pointers to the same union member")
+  {
+    THEN("Equality should simplify to true")
+    {
+      // &u.x == &u.x
+      auto equals = equal_exprt(
+        address_of_exprt(member_exprt(simple_union_var, "x", int_type)),
+        address_of_exprt(member_exprt(simple_union_var, "x", int_type)));
+      REQUIRE(simplify_expr(equals, ns) == true_exprt());
+    }
+
+    THEN("Inequality should simplify to false")
+    {
+      // &u.x != &u.x
+      auto notequals = notequal_exprt(
+        address_of_exprt(member_exprt(simple_union_var, "x", int_type)),
+        address_of_exprt(member_exprt(simple_union_var, "x", int_type)));
+      REQUIRE(simplify_expr(notequals, ns) == false_exprt());
+    }
+  }
+
+  WHEN("Comparing pointers to different union members")
+  {
+    THEN("Equality should simplify to true")
+    {
+      // &u.x == &u.y
+      auto equals = equal_exprt(
+        address_of_exprt(member_exprt(simple_union_var, "x", int_type)),
+        address_of_exprt(member_exprt(simple_union_var, "y", int_type)));
+      REQUIRE(simplify_expr(equals, ns) == true_exprt());
+    }
+    THEN("Inequality should simplify to false")
+    {
+      // &u.x != &u.y
+      auto notequals = notequal_exprt(
+        address_of_exprt(member_exprt(simple_union_var, "x", int_type)),
+        address_of_exprt(member_exprt(simple_union_var, "y", int_type)));
+      REQUIRE(simplify_expr(notequals, ns) == false_exprt());
+    }
+  }
+
+  WHEN("Comparing a pointer to union with a pointer to union member")
+  {
+    THEN("Equality should simplify to true")
+    {
+      // (int*)&u == &u.x
+      auto equals = equal_exprt(
+        typecast_exprt(
+          address_of_exprt(simple_union_var), pointer_type(int_type)),
+        address_of_exprt(member_exprt(simple_union_var, "x", int_type)));
+      REQUIRE(simplify_expr(equals, ns) == true_exprt());
+    }
+    THEN("Inequality should simplify to false")
+    {
+      // (int*)&u != &u.x
+      auto notequals = notequal_exprt(
+        typecast_exprt(
+          address_of_exprt(simple_union_var), pointer_type(int_type)),
+        address_of_exprt(member_exprt(simple_union_var, "x", int_type)));
+      REQUIRE(simplify_expr(notequals, ns) == false_exprt());
+    }
+  }
+}


### PR DESCRIPTION
For a struct like `struct S { int x; };` and a `struct S s;`, this lets comparisons like `&s.x == &s.x` and `(int*)&s == &s.x` be simplified, also similar expressions work for unions now.

For the validity of this simplification see [C11 Draft Standard N1570](http://www.iso-9899.info/n1570.html), section 6.7.2.1, paragraphs 15 and 16.