### PR TITLE
Fix a problem with function pointers removal including the wrong functions as a target

### DIFF
--- a/regression/goto-instrument/remove-function-pointers1/main.c
+++ b/regression/goto-instrument/remove-function-pointers1/main.c
@@ -1,0 +1,24 @@
+int f1(void);
+int f2(void);
+int f3(void);
+int f4(void);
+
+int (* const fptbl1[][2])(void) = {
+  { f1, f2 },
+  { f3, f4 },
+};
+
+int g1(void);
+int g2(void);
+
+int (* const fptbl2[])(void) = {
+  g1, g2
+};
+
+int func(int id1, int id2)
+{
+  int t;
+  t = fptbl1[id1][id2]();
+  t = fptbl2[id1]();
+  return t;
+}

--- a/regression/goto-instrument/remove-function-pointers1/test.desc
+++ b/regression/goto-instrument/remove-function-pointers1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--remove-function-pointers --show-goto-functions
+IF fptbl1\[\(signed long int\)id1\]\[\(signed long int\)id2\] == f1
+IF fptbl1\[\(signed long int\)id1\]\[\(signed long int\)id2\] == f4
+IF fptbl1\[\(signed long int\)id1\]\[\(signed long int\)id2\] == f2
+IF fptbl1\[\(signed long int\)id1\]\[\(signed long int\)id2\] == f3
+--
+IF fptbl1\[\(signed long int\)id1\]\[\(signed long int\)id2\] == g1
+IF fptbl1\[\(signed long int\)id1\]\[\(signed long int\)id2\] == g2
+--


### PR DESCRIPTION
Hi.

One of the problems that had been reported to us was that `goto-instrument`, once directed to `--remove-function-pointers`, it would do that but the resulting simplification would include some erroneous functions. This happened because the simplification was applying some rules, including that the functions had the same type, when it calculated the targets. In the example included as the test, this meant that for code that included this:

```
int (* const fptbl1[][2])(void) = {
  { f1, f2 },
  { f3, f4 },
};

...

t = fptbl1[id1][id2]();

...
```

we were getting output such as:

```
        IF fptbl1[(signed long int)id1][(signed long int)id2] == g1 THEN GOTO 1
        // 3 file function_pointer.c line 21 function func
        IF fptbl1[(signed long int)id1][(signed long int)id2] == f4 THEN GOTO 2
        // 4 file function_pointer.c line 21 function func
        IF fptbl1[(signed long int)id1][(signed long int)id2] == f3 THEN GOTO 3
        // 5 file function_pointer.c line 21 function func
        IF fptbl1[(signed long int)id1][(signed long int)id2] == f2 THEN GOTO 4
        // 6 file function_pointer.c line 21 function func
        IF fptbl1[(signed long int)id1][(signed long int)id2] == g2 THEN GOTO 5
        // 7 file function_pointer.c line 21 function func
        IF fptbl1[(signed long int)id1][(signed long int)id2] == f1 THEN GOTO 6
```

which includes the functions `g1` and `g2`, which is obviously wrong, as they are not present in the array `fptbl1`.

I would happy to see people's thoughts on the general solution.