### PR TITLE
Decision procedure cleanup

### DIFF
--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -161,7 +161,7 @@ bmct::run_decision_procedure(prop_convt &prop_conv)
 
   status() << "Running " << prop_conv.decision_procedure_text() << eom;
 
-  decision_proceduret::resultt dec_result=prop_conv.dec_solve();
+  decision_proceduret::resultt dec_result=prop_conv();
   // output runtime
 
   {

--- a/src/cbmc/fault_localization.cpp
+++ b/src/cbmc/fault_localization.cpp
@@ -255,7 +255,7 @@ fault_localizationt::run_decision_procedure(prop_convt &prop_conv)
   status() << "Running " << prop_conv.decision_procedure_text()
                << eom;
 
-  decision_proceduret::resultt dec_result=prop_conv.dec_solve();
+  decision_proceduret::resultt dec_result=prop_conv();
   // output runtime
 
   {

--- a/src/goto-instrument/accelerate/scratch_program.cpp
+++ b/src/goto-instrument/accelerate/scratch_program.cpp
@@ -61,7 +61,7 @@ bool scratch_programt::check_sat(bool do_slice)
   std::cout << "Finished symex, invoking decision procedure.\n";
 #endif
 
-  return (checker->dec_solve()==decision_proceduret::resultt::D_SATISFIABLE);
+  return (*checker)()==decision_proceduret::resultt::D_SATISFIABLE;
 }
 
 exprt scratch_programt::eval(const exprt &e)

--- a/src/solvers/prop/aig_prop.cpp
+++ b/src/solvers/prop/aig_prop.cpp
@@ -155,7 +155,7 @@ propt::resultt aig_prop_solvert::prop_solve()
            << aig.nodes.size() << " nodes" << eom;
   convert_aig();
 
-  return solver.prop_solve();
+  return solver();
 }
 
 /// Compute the phase information needed for Plaisted-Greenbaum encoding

--- a/src/solvers/prop/cover_goals.cpp
+++ b/src/solvers/prop/cover_goals.cpp
@@ -86,7 +86,7 @@ decision_proceduret::resultt cover_goalst::operator()()
     _iterations++;
 
     constraint();
-    dec_result=prop_conv.dec_solve();
+    dec_result=prop_conv();
 
     switch(dec_result)
     {

--- a/src/solvers/prop/minimize.cpp
+++ b/src/solvers/prop/minimize.cpp
@@ -122,7 +122,7 @@ void prop_minimizet::operator()()
         bvt assumptions;
         assumptions.push_back(c);
         prop_conv.set_assumptions(assumptions);
-        dec_result=prop_conv.dec_solve();
+        dec_result=prop_conv();
 
         switch(dec_result)
         {
@@ -152,6 +152,6 @@ void prop_minimizet::operator()()
 
     bvt assumptions; // no assumptions
     prop_conv.set_assumptions(assumptions);
-    prop_conv.dec_solve();
+    prop_conv();
   }
 }

--- a/src/solvers/prop/prop.h
+++ b/src/solvers/prop/prop.h
@@ -92,9 +92,12 @@ public:
   bvt new_variables(std::size_t width);
 
   // solving
-  virtual const std::string solver_text()=0;
   enum class resultt { P_SATISFIABLE, P_UNSATISFIABLE, P_ERROR };
-  virtual resultt prop_solve()=0;
+  // this solves the instance
+  resultt operator()() { return prop_solve(); }
+  /// \deprecated
+  virtual resultt prop_solve()=0; // will eventually be protected
+  virtual const std::string solver_text()=0;
 
   // satisfying assignment, from prop_assignmentt
   virtual tvt l_get(literalt a) const=0;

--- a/src/solvers/prop/prop_conv.cpp
+++ b/src/solvers/prop/prop_conv.cpp
@@ -490,7 +490,7 @@ decision_proceduret::resultt prop_conv_solvert::dec_solve()
 
   statistics() << "Solving with " << prop.solver_text() << eom;
 
-  propt::resultt result=prop.prop_solve();
+  propt::resultt result=prop();
 
   switch(result)
   {

--- a/src/solvers/refinement/bv_refinement_loop.cpp
+++ b/src/solvers/refinement/bv_refinement_loop.cpp
@@ -101,7 +101,7 @@ decision_proceduret::resultt bv_refinementt::prop_solve()
   }
 
   prop.set_assumptions(assumptions);
-  propt::resultt result=prop.prop_solve();
+  propt::resultt result=prop();
   prop.set_assumptions(parent_assumptions);
 
   switch(result)

--- a/src/util/decision_procedure.cpp
+++ b/src/util/decision_procedure.cpp
@@ -11,10 +11,4 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "decision_procedure.h"
 
-#include <cassert>
 
-bool decision_proceduret::in_core(const exprt &expr)
-{
-  UNREACHABLE;
-  return true;
-}

--- a/src/util/decision_procedure.h
+++ b/src/util/decision_procedure.h
@@ -44,22 +44,20 @@ public:
   // solve the problem
   enum class resultt { D_SATISFIABLE, D_UNSATISFIABLE, D_ERROR };
 
-  // will eventually be protected, use below call operator
-  virtual resultt dec_solve()=0;
-
   resultt operator()()
   {
     return dec_solve();
   }
-
-  // old-style, will go away
-  virtual bool in_core(const exprt &expr);
 
   // return a textual description of the decision procedure
   virtual std::string decision_procedure_text() const=0;
 
 protected:
   const namespacet &ns;
+
+public: // this line will eventually be removed, and thus
+  /// \deprecated use the operator() above
+  virtual resultt dec_solve()=0;
 };
 
 inline decision_proceduret &operator<<(


### PR DESCRIPTION
removes an old, un-used API (in-core), and removes usage of a deprecated one (dec_solve)