### PR TITLE
Java: infer opaque type fields before method conversion

### DIFF
--- a/src/java_bytecode/java_bytecode_typecheck_expr.cpp
+++ b/src/java_bytecode/java_bytecode_typecheck_expr.cpp
@@ -307,21 +307,6 @@ void java_bytecode_typecheckt::typecheck_expr_member(member_exprt &expr)
     struct_typet::componentst &components=
       struct_type.components();
 
-    if(struct_type.get_bool(ID_incomplete_class))
-    {
-      // member doesn't exist. In this case struct_type should be an opaque
-      // stub, and we'll add the member to it.
-      symbolt &symbol_table_type=symbol_table.get_writeable_ref(
-        "java::"+id2string(struct_type.get_tag()));
-      auto &add_to_components=
-        to_struct_type(symbol_table_type.type).components();
-      add_to_components
-        .push_back(struct_typet::componentt(component_name, expr.type()));
-      add_to_components.back().set_base_name(component_name);
-      add_to_components.back().set_pretty_name(component_name);
-      return;
-    }
-
     if(components.empty())
       break;
 


### PR DESCRIPTION
Before, opaque types' fields were inferred after a method is converted to codet (for example,
if we converted a method that accessed field A.x and type A didn't have a field x yet,
we would add it at this stage). This was problematic when converting functions on demand, as
we might create instances of an opaque type but then realise upon converting a later method
that it ought to have had more fields than we realised.

This commit changes our strategy to infer the types earlier, before any methods are converted.
This may lead to unnecessary work, but the pass executes very quickly even if thousands of
classes are loaded, so I expect the penalty to be minimal compared to the advantage that the
layout of types is fixed and will not change under the feet of subsequent passes.