### PR TITLE
Java string solver: ensure base types are loaded

### DIFF
--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -147,6 +147,16 @@ bool java_bytecode_languaget::parse(
   java_class_loader.set_message_handler(get_message_handler());
   java_class_loader.set_java_cp_include_files(java_cp_include_files);
   java_class_loader.add_load_classes(java_load_classes);
+  if(string_refinement_enabled)
+  {
+    string_preprocess.initialize_known_type_table();
+
+    auto get_string_base_classes = [this](const irep_idt &id) { // NOLINT (*)
+      return string_preprocess.get_string_type_base_classes(id);
+    };
+
+    java_class_loader.set_extra_class_refs_function(get_string_base_classes);
+  }
 
   // look at extension
   if(has_suffix(path, ".class"))

--- a/src/java_bytecode/java_class_loader.cpp
+++ b/src/java_bytecode/java_class_loader.cpp
@@ -72,6 +72,16 @@ java_bytecode_parse_treet &java_class_loadert::operator()(
         it!=parse_tree.class_refs.end();
         it++)
       queue.push(*it);
+
+    // Add any extra dependencies provided by our caller:
+    if(get_extra_class_refs)
+    {
+      std::vector<irep_idt> extra_class_refs =
+        get_extra_class_refs(c);
+
+      for(const irep_idt &id : extra_class_refs)
+        queue.push(id);
+    }
   }
 
   return class_map[class_name];
@@ -81,6 +91,16 @@ void java_class_loadert::set_java_cp_include_files(
   std::string &_java_cp_include_files)
 {
   java_cp_include_files=_java_cp_include_files;
+}
+
+/// Sets a function that provides extra dependencies for a particular class.
+/// Currently used by the string preprocessor to note that even if we don't
+/// have a definition of core string types, it will nontheless give them
+/// certain known superclasses and interfaces, such as Serializable.
+void java_class_loadert::set_extra_class_refs_function(
+  java_class_loadert::get_extra_class_refs_functiont func)
+{
+  get_extra_class_refs = func;
 }
 
 /// Retrieves a class file from a jar and loads it into the tree

--- a/src/java_bytecode/java_class_loader.h
+++ b/src/java_bytecode/java_class_loader.h
@@ -34,6 +34,12 @@ public:
   void set_java_cp_include_files(std::string &);
   void add_load_classes(const std::vector<irep_idt> &);
 
+  /// A function that yields a list of extra dependencies based on a class name.
+  typedef std::function<std::vector<irep_idt>(const irep_idt &)>
+    get_extra_class_refs_functiont;
+
+  void set_extra_class_refs_function(get_extra_class_refs_functiont func);
+
   static std::string file_to_class_name(const std::string &);
   static std::string class_name_to_file(const irep_idt &);
 
@@ -133,6 +139,7 @@ public:
 private:
   std::map<std::string, jar_filet> m_archives;
   std::vector<irep_idt> java_load_classes;
+  get_extra_class_refs_functiont get_extra_class_refs;
 };
 
 #endif // CPROVER_JAVA_BYTECODE_JAVA_CLASS_LOADER_H

--- a/src/java_bytecode/java_string_library_preprocess.h
+++ b/src/java_bytecode/java_string_library_preprocess.h
@@ -43,6 +43,7 @@ public:
   {
   }
 
+  void initialize_known_type_table();
   void initialize_conversion_table();
   void initialize_refined_string_type();
 
@@ -56,6 +57,8 @@ public:
   {
     return character_preprocess.replace_character_call(call);
   }
+  std::vector<irep_idt> get_string_type_base_classes(
+    const irep_idt &class_name);
   void add_string_type(const irep_idt &class_name, symbol_tablet &symbol_table);
   bool is_known_string_type(irep_idt class_name);
 


### PR DESCRIPTION
This adds a mechanism to the Java frontend class loader for its caller to advise it of
extra class dependencies to load, and uses it from the String preprocessor to indicate
that since it will add base classes to String, StringBuilder etc, then the class loader
should create symbols for those bases.

This restores the invariant that holds when --string-refine is not passed, that if a class
references another as a base, then that other class has an entry in the symbol table
(although that entry may be incomplete).