### PR TITLE
 Java frontend: create synthetic static initialisers for stub globals

### DIFF
--- a/regression/cbmc-java/generic_class_bound1/test.desc
+++ b/regression/cbmc-java/generic_class_bound1/test.desc
@@ -7,5 +7,5 @@ Gn.class
 .*file Gn.java line 9 function java::Gn.foo1:\(LGn;\)V bytecode-index 1 block 1: FAILED
 .*file Gn.java line 10 function java::Gn.foo1:\(LGn;\)V bytecode-index 4 block 2: FAILED
 .*file Gn.java line 11 function java::Gn.foo1:\(LGn;\)V bytecode-index 5 block 3: FAILED
-.*file Gn.java line 13 function java::Gn.main:\(\[Ljava/lang/String;\)V bytecode-index 2 block 1: SATISFIED
+.*file Gn.java line 13 function java::Gn.main:\(\[Ljava/lang/String;\)V bytecode-index 2 block 2: SATISFIED
 --

--- a/src/java_bytecode/java_bytecode_convert_class.cpp
+++ b/src/java_bytecode/java_bytecode_convert_class.cpp
@@ -377,6 +377,10 @@ void java_bytecode_convert_classt::convert(
     new_symbol.name=id2string(class_symbol.name)+"."+id2string(f.name);
     new_symbol.base_name=f.name;
     new_symbol.type=field_type;
+    // Annotating the type with ID_C_class to provide a static field -> class
+    // link matches the method used by java_bytecode_convert_method::convert
+    // for methods.
+    new_symbol.type.set(ID_C_class, class_symbol.name);
     new_symbol.pretty_name=id2string(class_symbol.pretty_name)+
       "."+id2string(f.name);
     new_symbol.mode=ID_java;

--- a/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -906,34 +906,6 @@ static void gather_symbol_live_ranges(
   }
 }
 
-/// See above
-/// \par parameters: `se`: Symbol expression referring to a static field
-/// `basename`: The static field's basename
-/// \return Creates a symbol table entry for the static field if one doesn't
-///   exist already.
-void java_bytecode_convert_methodt::check_static_field_stub(
-  const symbol_exprt &symbol_expr,
-  const irep_idt &basename)
-{
-  const auto &id=symbol_expr.get_identifier();
-  if(symbol_table.symbols.find(id)==symbol_table.symbols.end())
-  {
-    // Create a stub, to be overwritten if/when the real class is loaded.
-    symbolt new_symbol;
-    new_symbol.is_static_lifetime=true;
-    new_symbol.is_lvalue=true;
-    new_symbol.is_state_var=true;
-    new_symbol.name=id;
-    new_symbol.base_name=basename;
-    new_symbol.type=symbol_expr.type();
-    new_symbol.pretty_name=new_symbol.name;
-    new_symbol.mode=ID_java;
-    new_symbol.is_type=false;
-    new_symbol.value.make_nil();
-    symbol_table.add(new_symbol);
-  }
-}
-
 /// Each static access to classname should be prefixed with a check for
 /// necessary static init; this returns a call implementing that check.
 /// \param classname: Class name
@@ -2026,8 +1998,9 @@ codet java_bytecode_convert_methodt::convert_instructions(
         field_name.find("$assertionsDisabled")!=std::string::npos;
       symbol_expr.set_identifier(arg0.get_string(ID_class)+"."+field_name);
 
-      // If external, create a symbol table entry for this static field:
-      check_static_field_stub(symbol_expr, field_name);
+      INVARIANT(
+        symbol_table.has_symbol(symbol_expr.get_identifier()),
+        "getstatic symbol should have been created before method conversion");
 
       if(needed_lazy_methods)
       {
@@ -2081,8 +2054,9 @@ codet java_bytecode_convert_methodt::convert_instructions(
       const auto &field_name=arg0.get_string(ID_component_name);
       symbol_expr.set_identifier(arg0.get_string(ID_class)+"."+field_name);
 
-      // If external, create a symbol table entry for this static field:
-      check_static_field_stub(symbol_expr, field_name);
+      INVARIANT(
+        symbol_table.has_symbol(symbol_expr.get_identifier()),
+        "putstatic symbol should have been created before method conversion");
 
       if(needed_lazy_methods && arg0.type().id() == ID_symbol)
       {

--- a/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -246,10 +246,6 @@ protected:
 
   const bytecode_infot &get_bytecode_info(const irep_idt &statement);
 
-  void check_static_field_stub(
-    const symbol_exprt &se,
-    const irep_idt &basename);
-
   bool class_needs_clinit(const irep_idt &classname);
   exprt get_or_create_clinit_wrapper(const irep_idt &classname);
   codet get_clinit_call(const irep_idt &classname);

--- a/src/java_bytecode/java_bytecode_language.h
+++ b/src/java_bytecode/java_bytecode_language.h
@@ -19,7 +19,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "ci_lazy_methods.h"
 #include "ci_lazy_methods_needed.h"
 #include "java_class_loader.h"
+#include "java_static_initializers.h"
 #include "java_string_library_preprocess.h"
+#include "object_factory_parameters.h"
+#include "synthetic_methods_map.h"
 
 #include <java_bytecode/select_pointer_type.h>
 
@@ -53,10 +56,6 @@ Author: Daniel Kroening, kroening@kroening.com
   "                                  the purpose of lazy method loading\n"                       /* NOLINT(*) */ \
   "                                  A '.*' wildcard is allowed to specify all class members\n"
 
-#define MAX_NONDET_ARRAY_LENGTH_DEFAULT 5
-#define MAX_NONDET_STRING_LENGTH std::numeric_limits<std::int32_t>::max()
-#define MAX_NONDET_TREE_DEPTH 5
-
 class symbolt;
 
 enum lazy_methods_modet
@@ -64,26 +63,6 @@ enum lazy_methods_modet
   LAZY_METHODS_MODE_EAGER,
   LAZY_METHODS_MODE_CONTEXT_INSENSITIVE,
   LAZY_METHODS_MODE_CONTEXT_SENSITIVE
-};
-
-struct object_factory_parameterst final
-{
-  /// Maximum value for the non-deterministically-chosen length of an array.
-  size_t max_nondet_array_length=MAX_NONDET_ARRAY_LENGTH_DEFAULT;
-
-  /// Maximum value for the non-deterministically-chosen length of a string.
-  size_t max_nondet_string_length=MAX_NONDET_STRING_LENGTH;
-
-  /// Maximum depth for object hierarchy on input.
-  /// Used to prevent object factory to loop infinitely during the
-  /// generation of code that allocates/initializes data structures of recursive
-  /// data types or unbounded depth. We bound the maximum number of times we
-  /// dereference a pointer using a 'depth counter'. We set a pointer to null if
-  /// such depth becomes >= than this maximum value.
-  size_t max_nondet_tree_depth=MAX_NONDET_TREE_DEPTH;
-
-  /// Force string content to be ASCII printable characters when set to true.
-  bool string_printable = false;
 };
 
 class java_bytecode_languaget:public languaget
@@ -192,6 +171,8 @@ protected:
 
 private:
   const std::unique_ptr<const select_pointer_typet> pointer_type_selector;
+  synthetic_methods_mapt synthetic_methods;
+  stub_global_initializer_factoryt stub_global_initializer_factory;
 };
 
 std::unique_ptr<languaget> new_java_bytecode_language();

--- a/src/java_bytecode/java_entry_point.cpp
+++ b/src/java_bytecode/java_entry_point.cpp
@@ -82,17 +82,6 @@ static bool should_init_symbol(const symbolt &sym)
   return is_java_string_literal_id(sym.name);
 }
 
-static bool is_non_null_library_global(const irep_idt &symbolid)
-{
-  static const std::unordered_set<irep_idt, irep_id_hash> non_null_globals=
-  {
-    "java::java.lang.System.out",
-    "java::java.lang.System.err",
-    "java::java.lang.System.in"
-  };
-  return non_null_globals.count(symbolid);
-}
-
 static void java_static_lifetime_init(
   symbol_table_baset &symbol_table,
   const source_locationt &source_location,
@@ -128,8 +117,6 @@ static void java_static_lifetime_init(
           if(has_suffix(namestr, suffix))
             allow_null=false;
           if(allow_null && is_java_string_literal_id(nameid))
-            allow_null=false;
-          if(allow_null && is_non_null_library_global(nameid))
             allow_null=false;
         }
         gen_nondet_init(

--- a/src/java_bytecode/java_static_initializers.h
+++ b/src/java_bytecode/java_static_initializers.h
@@ -9,16 +9,48 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 #ifndef CPROVER_JAVA_BYTECODE_JAVA_STATIC_INITIALIZERS_H
 #define CPROVER_JAVA_BYTECODE_JAVA_STATIC_INITIALIZERS_H
 
+#include <unordered_set>
+
 #include <util/symbol_table.h>
 #include <util/std_code.h>
+#include <java_bytecode/object_factory_parameters.h>
+#include <java_bytecode/select_pointer_type.h>
+#include <java_bytecode/synthetic_methods_map.h>
 
 irep_idt clinit_wrapper_name(const irep_idt &class_name);
 
 bool is_clinit_wrapper_function(const irep_idt &function_id);
 
-void create_static_initializer_wrappers(symbol_tablet &symbol_table);
+void create_static_initializer_wrappers(
+  symbol_tablet &symbol_table,
+  synthetic_methods_mapt &synthetic_methods);
 
 codet get_clinit_wrapper_body(
-  const irep_idt &function_id, const symbol_tablet &symbol_table);
+  const irep_idt &function_id, const symbol_table_baset &symbol_table);
+
+class stub_global_initializer_factoryt
+{
+  /// Maps class symbols onto the stub globals that belong to them
+  std::unordered_multimap<irep_idt, irep_idt, irep_id_hash>
+    stub_globals_by_class;
+
+public:
+  void create_stub_global_initializer_symbols(
+    symbol_tablet &symbol_table,
+    const std::unordered_set<irep_idt, irep_id_hash> &stub_globals_set,
+    synthetic_methods_mapt &synthetic_methods);
+
+  codet get_stub_initializer_body(
+    const irep_idt &function_id,
+    symbol_table_baset &symbol_table,
+    const object_factory_parameterst &object_factory_parameters,
+    const select_pointer_typet &pointer_type_selector);
+};
+
+void create_stub_global_initializers(
+  symbol_tablet &symbol_table,
+  const std::unordered_set<irep_idt, irep_id_hash> &stub_globals_set,
+  const object_factory_parameterst &object_factory_parameters,
+  const select_pointer_typet &pointer_type_selector);
 
 #endif

--- a/src/java_bytecode/object_factory_parameters.h
+++ b/src/java_bytecode/object_factory_parameters.h
@@ -1,0 +1,39 @@
+/*******************************************************************\
+
+Module:
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_JAVA_BYTECODE_OBJECT_FACTORY_PARAMETERS_H
+#define CPROVER_JAVA_BYTECODE_OBJECT_FACTORY_PARAMETERS_H
+
+#include <cstdint>
+#include <limits>
+
+#define MAX_NONDET_ARRAY_LENGTH_DEFAULT 5
+#define MAX_NONDET_STRING_LENGTH std::numeric_limits<std::int32_t>::max()
+#define MAX_NONDET_TREE_DEPTH 5
+
+struct object_factory_parameterst final
+{
+  /// Maximum value for the non-deterministically-chosen length of an array.
+  size_t max_nondet_array_length=MAX_NONDET_ARRAY_LENGTH_DEFAULT;
+
+  /// Maximum value for the non-deterministically-chosen length of a string.
+  size_t max_nondet_string_length=MAX_NONDET_STRING_LENGTH;
+
+  /// Maximum depth for object hierarchy on input.
+  /// Used to prevent object factory to loop infinitely during the
+  /// generation of code that allocates/initializes data structures of recursive
+  /// data types or unbounded depth. We bound the maximum number of times we
+  /// dereference a pointer using a 'depth counter'. We set a pointer to null if
+  /// such depth becomes >= than this maximum value.
+  size_t max_nondet_tree_depth=MAX_NONDET_TREE_DEPTH;
+
+  /// Force string content to be ASCII printable characters when set to true.
+  bool string_printable = false;
+};
+
+#endif

--- a/src/java_bytecode/synthetic_methods_map.h
+++ b/src/java_bytecode/synthetic_methods_map.h
@@ -1,0 +1,21 @@
+/*******************************************************************\
+
+Module: Java Static Initializers
+
+Author: Chris Smowton, chris.smowton@diffblue.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_JAVA_BYTECODE_SYNTHETIC_METHODS_MAP_H
+#define CPROVER_JAVA_BYTECODE_SYNTHETIC_METHODS_MAP_H
+
+enum class synthetic_method_typet
+{
+  STATIC_INITIALIZER_WRAPPER,
+  STUB_CLASS_STATIC_INITIALIZER
+};
+
+typedef std::unordered_map<irep_idt, synthetic_method_typet, irep_id_hash>
+  synthetic_methods_mapt;
+
+#endif


### PR DESCRIPTION
Previously the Java frontend discovered static field references during method conversion, and when it
found them it created global symbols with nondet values, causing an object tree to be created in
__CPROVER_initialize. This caused two problems:
  (1) they were created late, meaning when incrementally loading functions, __CPROVER_initialize may
      already have been created when a new stub static field is discovered, and
  (2) by creating potentially large trees of potential objects in __CPROVER_initialize, symex would be
      compelled to accrue a lot of possibly-unused state.

This change moves the object tree creation into a synthetic static initialiser, which both defers executing
the initialisation until their class is actually used, and also creates the static initialisers before
method conversion, such that its already_run variable is mentioned in __CPROVER_initialize when it is
created (the initialize function is now both smaller and "right first time").

One test is updated as the synthetic clinit changes the block numbering.

@NathanJPhillips may wish to review.