### PR TITLE
Fix Java core-models build script

### DIFF
--- a/src/java_bytecode/CMakeLists.txt
+++ b/src/java_bytecode/CMakeLists.txt
@@ -1,13 +1,18 @@
-get_filename_component(JAVA_CORE_MODELS_INC "library/java_core_models.inc" REALPATH BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-set_source_files_properties("library/java_core_models.inc" GENERATED)
-
-file(GLOB sources "*.cpp")
-file(GLOB_RECURSE headers "*.h")
+# include here the targets defined in library/
 add_subdirectory(library)
 
-add_library(java_bytecode ${sources} ${headers} )
-add_dependencies(java_bytecode core_models_files)
+# target 'java_bytecode' depends on all .cpp and .h files
+file(GLOB sources "*.cpp")
+file(GLOB_RECURSE headers "*.h")
+add_library(java_bytecode ${sources} ${headers})
 
+# define the include directories (passed to the compiler with -I) that those
+# targets wishing to depend on the target 'java_bytecode' may want to use
 generic_includes(java_bytecode)
 
+# target 'java-core-models-inc' is defined in library/
+add_dependencies(java_bytecode java-core-models-inc)
+
+# if you link java_bytecode.a in, then you also need to link other .a libraries
+# in
 target_link_libraries(java_bytecode util goto-programs miniz json)

--- a/src/java_bytecode/library/CMakeLists.txt
+++ b/src/java_bytecode/library/CMakeLists.txt
@@ -1,19 +1,24 @@
 find_package(Java REQUIRED)
 include(UseJava)
 set(CMAKE_JAVA_COMPILE_FLAGS -sourcepath "src" -d "classes" -XDignore.symbol.file)
-file(GLOB_RECURSE java_sources "*.java")
-set(JAR_NAME "core-models")
-add_jar(${JAR_NAME} ${java_sources})
-get_filename_component(CORE_MODELS_JAR "core-models.jar" REALPATH BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-get_filename_component(JAVA_CORE_MODELS_INC "java_core_models.inc" REALPATH BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-file(GLOB_RECURSE jars "*.jar")
+
+# create a target for the executable performing the .jar -> .inc conversion
 add_executable(java-converter converter.cpp)
 
-add_custom_target(core_models_files)
-add_dependencies(core_models_files ${JAR_NAME})
-add_custom_command(TARGET core_models_files
-                   PRE_BUILD
-                   COMMAND java-converter JAVA_CORE_MODELS core-models.jar > ${JAVA_CORE_MODELS_INC}
-                   )
+# create a target 'core-models.jar' that depends on all .java files in src/
+file(GLOB_RECURSE java_sources "src/*.java")
+add_jar("core-models" ${java_sources})
 
-set_source_files_properties("java_core_models.inc" GENERATED)
+# define a cmake variable with the full path of the .inc file
+set(JAVA_CORE_MODELS_INC "${CMAKE_CURRENT_BINARY_DIR}/java_core_models.inc")
+
+# define a rule telling cmake how to generate the file ${JAVA_CORE_MODELS_INC} from
+# the .jar file by running the java-converter; the output file depends on the
+# .jar file but also on the converter (!)
+add_custom_command(OUTPUT ${JAVA_CORE_MODELS_INC}
+    COMMAND java-converter "JAVA_CORE_MODELS" "core-models.jar" > ${JAVA_CORE_MODELS_INC}
+    DEPENDS "core-models.jar" java-converter)
+
+# create a target 'core-models-inc' that depends on the .inc file
+add_custom_target(java-core-models-inc
+    DEPENDS ${JAVA_CORE_MODELS_INC})


### PR DESCRIPTION
This fixes two problems with the core-models build script:

1. Use of add_library with target_source_files listing the same source
   led to including the *source* files along with every build target, hence
   multiple builds of the same file

2. Using add_custom_command to create a pre-build hook instead of a normal
   file-producing command meant java_class_loader.cpp and its dependencies were
   rebuilt on every build.