### PR TITLE
Use more efficient algorithm to calculate dominators

### DIFF
--- a/src/analyses/cfg_dominators.h
+++ b/src/analyses/cfg_dominators.h
@@ -16,17 +16,203 @@ Author: Georg Weissenbacher, georg@weissenbacher.name
 #include <list>
 #include <map>
 #include <iosfwd>
-#include <cassert>
+#include <algorithm>
+#include <stack>
+#include <tuple>
+#include <type_traits>
+#include <iterator>
+#include <memory>
+#include <limits>
 
 #include <goto-programs/goto_functions.h>
 #include <goto-programs/goto_program.h>
 #include <goto-programs/cfg.h>
 
+template <typename T, typename node_indext>
+struct dominators_datat
+{
+  explicit dominators_datat(std::size_t size)
+    : data(size), immediate_dominator(size)
+  {
+  }
+  dominators_datat(
+    std::vector<T> data,
+    std::vector<node_indext> immediate_dominator)
+    : data(data), immediate_dominator(immediate_dominator)
+  {
+  }
+  std::vector<T> data;
+  std::vector<node_indext> immediate_dominator;
+};
+
+/// An immutable set of dominators. Constant memory usage and creation time,
+/// but linear lookup time
+/// Immutability is necessary because the structure uses sharing
+template <typename T, typename node_indext>
+class dominatorst
+{
+public:
+  using datat = dominators_datat<T, node_indext>;
+  static const node_indext npos;
+
+private:
+  std::shared_ptr<datat> dominators_data;
+  node_indext node_index;
+  mutable std::size_t cached_distance;
+
+public:
+  /// Create an empty set
+  /// Note: Only unreachable nodes should be assigned
+  /// empty sets after the algorithm completes
+  dominatorst() : dominators_data(nullptr), node_index(npos), cached_distance(0)
+  {
+  }
+
+  /// Create the dominators set of node_index
+  dominatorst(std::shared_ptr<datat> dominators_data, node_indext node_index)
+    : dominators_data(dominators_data),
+      node_index(node_index),
+      cached_distance(npos)
+  {
+  }
+
+  dominatorst(const dominatorst &other)
+    : dominators_data(other.dominators_data),
+      node_index(other.node_index),
+      cached_distance(other.cached_distance)
+  {
+  }
+
+  dominatorst &operator=(const dominatorst &rhs)
+  {
+    dominators_data = rhs.dominators_data;
+    node_index = rhs.node_index;
+    cached_distance = rhs.cached_distance;
+    return *this;
+  }
+
+  class dominatorst_iteratort
+    : public std::iterator<std::forward_iterator_tag, T>
+  {
+  public:
+    using parentt = const datat *;
+    using elemt = const T;
+
+  private:
+    parentt data;
+    node_indext current_index;
+
+  public:
+    dominatorst_iteratort(parentt cfg_dominators, node_indext current_index)
+      : data(cfg_dominators), current_index(current_index)
+    {
+    }
+
+    dominatorst_iteratort &operator++()
+    {
+      INVARIANT(
+        current_index != npos, "Shouldn't try to increment end-iterator");
+      current_index = data->immediate_dominator[current_index];
+      return *this;
+    }
+
+    dominatorst_iteratort operator++(int)
+    {
+      INVARIANT(
+        current_index != npos, "Shouldn't try to post-increment end-iterator");
+      node_indext tmp = current_index;
+      ++(*this);
+      return dominatorst_iteratort(data, tmp);
+    }
+
+    const elemt *get() const
+    {
+      INVARIANT(
+        current_index != npos, "Shouldn't try to dereference end-iterator");
+      return &data->data[current_index];
+    }
+
+    const elemt &operator*() const
+    {
+      return *get();
+    }
+
+    const elemt *operator->() const
+    {
+      return get();
+    }
+
+    bool operator!=(const dominatorst_iteratort &other) const
+    {
+      INVARIANT(
+        data == other.data, "iterators from different sets are not comparable");
+      return current_index != other.current_index;
+    }
+
+    bool operator==(const dominatorst_iteratort &other) const
+    {
+      return !(*this != other);
+    }
+  };
+
+  using const_iterator = dominatorst_iteratort;
+
+  const_iterator begin() const
+  {
+    return const_iterator(dominators_data.get(), node_index);
+  }
+
+  const_iterator cbegin() const
+  {
+    return begin();
+  }
+
+  const_iterator end() const
+  {
+    return const_iterator(dominators_data.get(), npos);
+  }
+
+  const_iterator cend() const
+  {
+    return end();
+  }
+
+  /// Return an iterator node if node is in this dominators set, end() otherwise
+  /// Note: O(n), when making many queries against the same set it is probably
+  /// worth copying into a std::set
+
+  const_iterator find(const T &node) const
+  {
+    return std::find(begin(), end(), node);
+  }
+
+  /// The size of the set; Linear time on the first call,
+  /// constant after that
+  std::size_t size() const
+  {
+    if(cached_distance == npos)
+    {
+      cached_distance = std::distance(begin(), end());
+    }
+    return cached_distance;
+  }
+
+  bool empty() const
+  {
+    return begin() == end();
+  }
+};
+
+template <typename T, typename node_indext>
+const node_indext
+  dominatorst<T, node_indext>::npos = std::numeric_limits<node_indext>::max();
+
 template <class P, class T, bool post_dom>
 class cfg_dominators_templatet
 {
 public:
-  typedef std::set<T> target_sett;
+  using node_indext = graph_nodet<>::node_indext;
+  using target_sett = dominatorst<T, node_indext>;
 
   struct nodet
   {
@@ -44,12 +230,241 @@ public:
 
 protected:
   void initialise(P &program);
-  void fixedpoint(P &program);
+
+  struct fixedpointt
+  {
+    explicit fixedpointt(cfg_dominators_templatet &cfg_dominators)
+      : cfg_dominators(cfg_dominators),
+        dfs_counter(0),
+        parent(cfg_dominators.cfg.size() + 1),
+        ancestor(cfg_dominators.cfg.size() + 1),
+        child(cfg_dominators.cfg.size() + 1),
+        vertex(cfg_dominators.cfg.size() + 1),
+        dom(cfg_dominators.cfg.size() + 1),
+        label(cfg_dominators.cfg.size() + 1),
+        semi(cfg_dominators.cfg.size() + 1),
+        size(cfg_dominators.cfg.size() + 1),
+        bucket(cfg_dominators.cfg.size() + 1)
+    {
+    }
+
+    void fixedpoint(P &program);
+
+  private:
+    cfg_dominators_templatet &cfg_dominators;
+    node_indext dfs_counter;
+    std::vector<node_indext> parent, ancestor, child, vertex, dom;
+
+    std::vector<node_indext> label, semi, size;
+
+    std::vector<std::set<node_indext>> bucket;
+
+    T get_entry_node(P &program)
+    {
+      if(post_dom)
+      {
+        return cfg_dominators.cfg.get_last_node(program);
+      }
+      else
+      {
+        return cfg_dominators.cfg.get_first_node(program);
+      }
+    };
+
+    void dfs(node_indext root)
+    {
+      struct dfs_statet
+      {
+        node_indext parent;
+        node_indext current;
+      };
+      std::stack<dfs_statet> work;
+      work.push({0, root});
+      while(!work.empty())
+      {
+        auto state = work.top();
+        work.pop();
+        node_indext v = state.current;
+        if(semi[v] == 0)
+        {
+          parent[v] = state.parent;
+          semi[v] = ++dfs_counter;
+          vertex[dfs_counter] = label[v] = v;
+          ancestor[v] = child[v] = 0;
+          size[v] = 1;
+          for_each_successor(v, [&](node_indext w) { work.push({v, w}); });
+        }
+      }
+    }
+
+    void compress(node_indext v)
+    {
+      if(ancestor[ancestor[v]] != 0)
+      {
+        compress(ancestor[v]);
+        if(semi[label[ancestor[v]]] < semi[label[v]])
+        {
+          label[v] = label[ancestor[v]];
+        }
+        ancestor[v] = ancestor[ancestor[v]];
+      }
+    }
+
+    node_indext eval(node_indext v)
+    {
+      if(ancestor[v] == 0)
+      {
+        return label[v];
+      }
+      compress(v);
+      if(semi[label[ancestor[v]]] >= semi[label[v]])
+      {
+        return label[v];
+      }
+      return label[ancestor[v]];
+    }
+
+    void link(node_indext v, node_indext w)
+    {
+      node_indext s = w;
+      while(semi[label[w]] < semi[label[child[s]]])
+      {
+        if(size[s] + size[child[child[s]]] >= 2 * size[child[s]])
+        {
+          ancestor[child[s]] = s;
+          child[s] = child[child[s]];
+        }
+        else
+        {
+          size[child[s]] = size[s];
+          s = ancestor[s] = child[s];
+        }
+      }
+      label[s] = label[w];
+      size[v] = size[v] + size[w];
+      if(size[v] < 2 * size[w])
+      {
+        std::swap(s, child[v]);
+      }
+      while(s != 0)
+      {
+        ancestor[s] = v;
+        s = child[s];
+      }
+    }
+
+    void assign_dominators(node_indext root)
+    {
+      auto dominators_data = std::make_shared<typename target_sett::datat>(
+        cfg_dominators.cfg.size());
+      for(node_indext i = 0; i < cfg_dominators.cfg.size(); ++i)
+      {
+        dominators_data->immediate_dominator[i] = dom[i + 1] - 1;
+        dominators_data->data[i] = cfg_dominators.cfg[i].PC;
+      }
+      std::stack<node_indext> work;
+      work.push(root);
+      while(!work.empty())
+      {
+        node_indext v = work.top();
+        work.pop();
+        if(cfg_dominators.cfg[v - 1].dominators.empty())
+        {
+          cfg_dominators.cfg[v - 1].dominators =
+            target_sett(dominators_data, v - 1);
+          for_each_successor(v, [&](node_indext w) { work.push(w); });
+        }
+      }
+    }
+
+    template <typename Action>
+    void for_each_successor(node_indext node_index, Action action)
+    {
+      // the -1 / +1 adjusts indices from 1 based to 0 based and back
+      auto ix = node_index - 1;
+      for(auto const &next :
+          post_dom ? cfg_dominators.cfg.in(ix) : cfg_dominators.cfg.out(ix))
+      {
+        action(next.first + 1);
+      }
+    }
+
+    template <typename Action>
+    void for_each_predecessor(node_indext node_index, Action action)
+    {
+      auto ix = node_index - 1;
+      for(auto const &prev :
+          post_dom ? cfg_dominators.cfg.out(ix) : cfg_dominators.cfg.in(ix))
+      {
+        action(prev.first + 1);
+      }
+    }
+  };
 };
+
+template <class P, class T, bool post_dom>
+void cfg_dominators_templatet<P, T, post_dom>::fixedpointt::fixedpoint(
+  P &program)
+{
+  // Dominator Tree according to Lengauer and Tarjan
+  // "A fast algorithm for finding dominators in a flow graph"
+  // This is ununderstandable without reading the paper!
+  // assumption: Vertex indices >= 0 and < cfg.size()
+  if(cfg_dominators.cfg.nodes_empty(program))
+  {
+    return;
+  }
+  cfg_dominators.entry_node = get_entry_node(program);
+  node_indext root =
+    cfg_dominators.cfg.entry_map[cfg_dominators.entry_node] + 1;
+  dfs_counter = 0;
+  dfs(root);
+  for(node_indext i = dfs_counter; i >= 2; --i)
+  {
+    node_indext w = vertex[i];
+    // NOLINTNEXTLINE
+    for_each_predecessor(w, [&](node_indext v) {
+      node_indext u = eval(v);
+      // reachable nodes may have unreachable
+      // nodes as their parents
+      if(semi[u] != 0 && semi[u] < semi[w])
+      {
+        semi[w] = semi[u];
+      }
+    });
+    bucket[vertex[semi[w]]].insert(w);
+    link(parent[w], w);
+    auto &w_parent_bucket = bucket[parent[w]];
+    for(auto v_it = begin(w_parent_bucket); v_it != end(w_parent_bucket);)
+    {
+      node_indext v = *v_it;
+      v_it = w_parent_bucket.erase(v_it);
+      node_indext u = eval(v);
+      if(semi[u] < semi[v])
+      {
+        dom[v] = u;
+      }
+      else
+      {
+        dom[v] = parent[w];
+      }
+    }
+  }
+  for(node_indext i = 2; i <= dfs_counter; ++i)
+  {
+    node_indext w = vertex[i];
+    if(dom[w] != vertex[semi[w]])
+    {
+      dom[w] = dom[dom[w]];
+    }
+  }
+
+  assign_dominators(root);
+}
 
 /// Print the result of the dominator computation
 template <class P, class T, bool post_dom>
-std::ostream &operator << (
+std::ostream &operator<<(
   std::ostream &out,
   const cfg_dominators_templatet<P, T, post_dom> &cfg_dominators)
 {
@@ -62,7 +477,8 @@ template <class P, class T, bool post_dom>
 void cfg_dominators_templatet<P, T, post_dom>::operator()(P &program)
 {
   initialise(program);
-  fixedpoint(program);
+  fixedpointt fixedpoint(*this);
+  fixedpoint.fixedpoint(program);
 }
 
 /// Initialises the elements of the fixed point analysis
@@ -70,98 +486,6 @@ template <class P, class T, bool post_dom>
 void cfg_dominators_templatet<P, T, post_dom>::initialise(P &program)
 {
   cfg(program);
-}
-
-/// Computes the MOP for the dominator analysis
-template <class P, class T, bool post_dom>
-void cfg_dominators_templatet<P, T, post_dom>::fixedpoint(P &program)
-{
-  std::list<T> worklist;
-
-  if(cfg.nodes_empty(program))
-    return;
-
-  if(post_dom)
-    entry_node=cfg.get_last_node(program);
-  else
-    entry_node=cfg.get_first_node(program);
-  typename cfgt::nodet &n=cfg[cfg.entry_map[entry_node]];
-  n.dominators.insert(entry_node);
-
-  for(typename cfgt::edgest::const_iterator
-      s_it=(post_dom?n.in:n.out).begin();
-      s_it!=(post_dom?n.in:n.out).end();
-      ++s_it)
-    worklist.push_back(cfg[s_it->first].PC);
-
-  while(!worklist.empty())
-  {
-    // get node from worklist
-    T current=worklist.front();
-    worklist.pop_front();
-
-    bool changed=false;
-    typename cfgt::nodet &node=cfg[cfg.entry_map[current]];
-    if(node.dominators.empty())
-    {
-      for(const auto &edge : (post_dom ? node.out : node.in))
-        if(!cfg[edge.first].dominators.empty())
-        {
-          node.dominators=cfg[edge.first].dominators;
-          node.dominators.insert(current);
-          changed=true;
-        }
-    }
-
-    // compute intersection of predecessors
-    for(const auto &edge : (post_dom ? node.out : node.in))
-    {
-      const target_sett &other=cfg[edge.first].dominators;
-      if(other.empty())
-        continue;
-
-      typename target_sett::const_iterator n_it=node.dominators.begin();
-      typename target_sett::const_iterator o_it=other.begin();
-
-      // in-place intersection. not safe to use set_intersect
-      while(n_it!=node.dominators.end() && o_it!=other.end())
-      {
-        if(*n_it==current)
-          ++n_it;
-        else if(*n_it<*o_it)
-        {
-          changed=true;
-          node.dominators.erase(n_it++);
-        }
-        else if(*o_it<*n_it)
-          ++o_it;
-        else
-        {
-          ++n_it;
-          ++o_it;
-        }
-      }
-
-      while(n_it!=node.dominators.end())
-      {
-        if(*n_it==current)
-          ++n_it;
-        else
-        {
-          changed=true;
-          node.dominators.erase(n_it++);
-        }
-      }
-    }
-
-    if(changed) // fixed point for node reached?
-    {
-      for(const auto &edge : (post_dom ? node.in : node.out))
-      {
-        worklist.push_back(cfg[edge.first].PC);
-      }
-    }
-  }
 }
 
 /// Pretty-print a single node in the dominator tree. Supply a specialisation if
@@ -213,10 +537,10 @@ typedef cfg_dominators_templatet<
           const goto_programt, goto_programt::const_targett, true>
         cfg_post_dominatorst;
 
-template<>
+template <>
 inline void dominators_pretty_print_node(
-  const goto_programt::const_targett &node,
-  std::ostream &out)
+  const goto_programt::const_targett& node,
+  std::ostream& out)
 {
   out << node->location_number;
 }

--- a/src/analyses/cfg_dominators.h
+++ b/src/analyses/cfg_dominators.h
@@ -183,7 +183,19 @@ public:
 
   const_iterator find(const T &node) const
   {
-    return std::find(begin(), end(), node);
+    std::less<T> less;
+    // FIXME This works around a bug in other parts of the code
+    // in particular, dependence_graph.cpp,
+    // where iterators to different lists than those that are
+    // stored in this set are passed to find.
+    // The Debug libstdc++ will (correctly!) run into an assertion failure
+    // using std::find. std::less for some reason doesn't trigger this assertion
+    // failure, so we use this as an ugly workaround until that code is fixed.
+
+    // NOLINTNEXTLINE
+    return std::find_if(cbegin(), cend(), [&](const T &other_node) {
+      return !less(node, other_node) && !less(other_node, node);
+    });
   }
 
   /// The size of the set; Linear time on the first call,

--- a/src/analyses/cfg_dominators.h
+++ b/src/analyses/cfg_dominators.h
@@ -28,6 +28,9 @@ Author: Georg Weissenbacher, georg@weissenbacher.name
 #include <goto-programs/goto_program.h>
 #include <goto-programs/cfg.h>
 
+/// Dominator tree
+/// Node indices are 0-based here (unlike in the internal data structures of
+/// the algorithm).
 template <typename T, typename node_indext>
 struct dominators_datat
 {
@@ -41,13 +44,16 @@ struct dominators_datat
     : data(data), immediate_dominator(immediate_dominator)
   {
   }
+
+  /// Maps node to T
   std::vector<T> data;
+
+  /// Maps node to its immediate dominator
   std::vector<node_indext> immediate_dominator;
 };
 
-/// An immutable set of dominators. Constant memory usage and creation time,
-/// but linear lookup time
-/// Immutability is necessary because the structure uses sharing
+/// An immutable set of dominators. Constant memory usage and creation time.
+/// Immutability is necessary because the structure uses sharing.
 template <typename T, typename node_indext>
 class dominatorst
 {
@@ -62,8 +68,8 @@ private:
 
 public:
   /// Create an empty set
-  /// Note: Only unreachable nodes should be assigned
-  /// empty sets after the algorithm completes
+  /// Note: Only unreachable nodes should be assigned empty sets after the
+  /// algorithm completes
   dominatorst() : dominators_data(nullptr), node_index(npos), cached_distance(0)
   {
   }
@@ -180,17 +186,15 @@ public:
   /// Return an iterator node if node is in this dominators set, end() otherwise
   /// Note: O(n), when making many queries against the same set it is probably
   /// worth copying into a std::set
-
   const_iterator find(const T &node) const
   {
     std::less<T> less;
-    // FIXME This works around a bug in other parts of the code
-    // in particular, dependence_graph.cpp,
-    // where iterators to different lists than those that are
-    // stored in this set are passed to find.
-    // The Debug libstdc++ will (correctly!) run into an assertion failure
-    // using std::find. std::less for some reason doesn't trigger this assertion
-    // failure, so we use this as an ugly workaround until that code is fixed.
+    // FIXME This works around a bug in other parts of the code in particular,
+    // dependence_graph.cpp, where iterators to different lists than those that
+    // are stored in this set are passed to find. The Debug libstdc++ will
+    // (correctly!) run into an assertion failure using std::find. std::less for
+    // some reason doesn't trigger this assertion failure, so we use this as an
+    // ugly workaround until that code is fixed.
 
     // NOLINTNEXTLINE
     return std::find_if(cbegin(), cend(), [&](const T &other_node) {
@@ -198,8 +202,7 @@ public:
     });
   }
 
-  /// The size of the set; Linear time on the first call,
-  /// constant after that
+  /// The size of the set. Linear time on the first call, constant after that.
   std::size_t size() const
   {
     if(cached_distance == npos)
@@ -219,6 +222,7 @@ template <typename T, typename node_indext>
 const node_indext
   dominatorst<T, node_indext>::npos = std::numeric_limits<node_indext>::max();
 
+/// Dominators for each instruction in a goto program
 template <class P, class T, bool post_dom>
 class cfg_dominators_templatet
 {
@@ -248,15 +252,17 @@ protected:
     explicit fixedpointt(cfg_dominators_templatet &cfg_dominators)
       : cfg_dominators(cfg_dominators),
         dfs_counter(0),
+        // Data structures have size cfg.size() + 1 as node indices are 1-based
+        // to match the paper of Lengauer/Tarjan.
         parent(cfg_dominators.cfg.size() + 1),
-        ancestor(cfg_dominators.cfg.size() + 1),
-        child(cfg_dominators.cfg.size() + 1),
         vertex(cfg_dominators.cfg.size() + 1),
         dom(cfg_dominators.cfg.size() + 1),
-        label(cfg_dominators.cfg.size() + 1),
         semi(cfg_dominators.cfg.size() + 1),
+        bucket(cfg_dominators.cfg.size() + 1),
+        ancestor(cfg_dominators.cfg.size() + 1),
+        label(cfg_dominators.cfg.size() + 1),
         size(cfg_dominators.cfg.size() + 1),
-        bucket(cfg_dominators.cfg.size() + 1)
+        child(cfg_dominators.cfg.size() + 1)
     {
     }
 
@@ -265,11 +271,33 @@ protected:
   private:
     cfg_dominators_templatet &cfg_dominators;
     node_indext dfs_counter;
-    std::vector<node_indext> parent, ancestor, child, vertex, dom;
 
-    std::vector<node_indext> label, semi, size;
+    /// Maps node to its parent in the DFS-generated spanning tree
+    std::vector<node_indext> parent;
 
+    /// Maps number to node (according to the DFS numbering)
+    std::vector<node_indext> vertex;
+
+    /// Maps node to its immediate dominator
+    std::vector<node_indext> dom;
+
+    /// Maps node to its semi-dominator (as defined by Lengauer/Tarjan)
+    /// A semidominator of a node w is the minimum node v (according to the DFS
+    /// numbering) for which there is a path from v to w such that all nodes
+    /// occuring on that path (other than v, w) have a larger number than w
+    /// (according to the DFS numbering)
+    std::vector<node_indext> semi;
+
+    /// Maps node to the set of nodes of which it is the semi-dominator
     std::vector<std::set<node_indext>> bucket;
+
+    // Used by link() and eval(), which are used to create and query
+    // an auxiliary data structure which is a forest that is contained
+    // in the DFS spanning tree.
+    std::vector<node_indext> ancestor;
+    std::vector<node_indext> label;
+    std::vector<node_indext> size;
+    std::vector<node_indext> child;
 
     T get_entry_node(P &program)
     {
@@ -283,6 +311,9 @@ protected:
       }
     };
 
+    /// DFS numbering
+    /// Number nodes in the order in which they are reached during a DFS,
+    /// intialize data structures
     void dfs(node_indext root)
     {
       struct dfs_statet
@@ -299,16 +330,20 @@ protected:
         node_indext v = state.current;
         if(semi[v] == 0)
         {
+          // Initialize data structures
           parent[v] = state.parent;
           semi[v] = ++dfs_counter;
           vertex[dfs_counter] = label[v] = v;
           ancestor[v] = child[v] = 0;
           size[v] = 1;
+          // Explore children
           for_each_successor(v, [&](node_indext w) { work.push({v, w}); });
         }
       }
     }
 
+    /// Compress path from v to the root in the tree of the forest that contains
+    /// v, by directly attaching nodes to the root
     void compress(node_indext v)
     {
       if(ancestor[ancestor[v]] != 0)
@@ -322,6 +357,8 @@ protected:
       }
     }
 
+    /// Return node with minimum semidominator on the path from the root of the
+    /// tree in the forest containing v to v, and compress path
     node_indext eval(node_indext v)
     {
       if(ancestor[v] == 0)
@@ -336,6 +373,9 @@ protected:
       return label[ancestor[v]];
     }
 
+    /// Add an edge to the forest
+    /// \param v: source node of edge
+    /// \param w: target node of edge
     void link(node_indext v, node_indext w)
     {
       node_indext s = w;
@@ -365,8 +405,10 @@ protected:
       }
     }
 
+    /// Fill output data structures
     void assign_dominators(node_indext root)
     {
+      // Fill dominator tree output data structure
       auto dominators_data = std::make_shared<typename target_sett::datat>(
         cfg_dominators.cfg.size());
       for(node_indext i = 0; i < cfg_dominators.cfg.size(); ++i)
@@ -374,6 +416,8 @@ protected:
         dominators_data->immediate_dominator[i] = dom[i + 1] - 1;
         dominators_data->data[i] = cfg_dominators.cfg[i].PC;
       }
+
+      // Assign immediate dominator to nodes in the cfg
       std::stack<node_indext> work;
       work.push(root);
       while(!work.empty())
@@ -389,10 +433,11 @@ protected:
       }
     }
 
+    /// Perform action on each child node
     template <typename Action>
     void for_each_successor(node_indext node_index, Action action)
     {
-      // the -1 / +1 adjusts indices from 1 based to 0 based and back
+      // The -1 / +1 adjusts indices from 1 based to 0 based and back
       auto ix = node_index - 1;
       for(auto const &next :
           post_dom ? cfg_dominators.cfg.in(ix) : cfg_dominators.cfg.out(ix))
@@ -401,6 +446,7 @@ protected:
       }
     }
 
+    /// Perform action on each parent node
     template <typename Action>
     void for_each_predecessor(node_indext node_index, Action action)
     {
@@ -414,14 +460,17 @@ protected:
   };
 };
 
+/// Dominator tree computation
+/// Follows "A fast algorithm for finding dominators in a flow graph" of
+/// Lengauer and Tarjan. Node indices are 1-based as in the paper, with the
+/// first element (with index 0) of each data structure simply left empty.
 template <class P, class T, bool post_dom>
 void cfg_dominators_templatet<P, T, post_dom>::fixedpointt::fixedpoint(
   P &program)
 {
-  // Dominator Tree according to Lengauer and Tarjan
-  // "A fast algorithm for finding dominators in a flow graph"
-  // This is ununderstandable without reading the paper!
-  // assumption: Vertex indices >= 0 and < cfg.size()
+  // The nodes in the cfg data structure are represented by indices >= 0 and <
+  // cfg.size(), whereas the internal data structures of the algorithm use
+  // 1-based indices to represent nodes
   if(cfg_dominators.cfg.nodes_empty(program))
   {
     return;
@@ -429,23 +478,35 @@ void cfg_dominators_templatet<P, T, post_dom>::fixedpointt::fixedpoint(
   cfg_dominators.entry_node = get_entry_node(program);
   node_indext root =
     cfg_dominators.cfg.entry_map[cfg_dominators.entry_node] + 1;
+
+  // The computation is carried out in four steps as given in the paper.
+
+  // Step 1
+  // Number nodes in the order in which they are reached during DFS, and
+  // initialize data structures
   dfs_counter = 0;
   dfs(root);
+
   for(node_indext i = dfs_counter; i >= 2; --i)
   {
+    // Step 2
+    // Compute semidominators
     node_indext w = vertex[i];
     // NOLINTNEXTLINE
     for_each_predecessor(w, [&](node_indext v) {
       node_indext u = eval(v);
-      // reachable nodes may have unreachable
-      // nodes as their parents
+      // Reachable nodes may have unreachable nodes as their parents
       if(semi[u] != 0 && semi[u] < semi[w])
       {
         semi[w] = semi[u];
       }
     });
+
     bucket[vertex[semi[w]]].insert(w);
     link(parent[w], w);
+
+    // Step 3
+    // Implicitely define immediate dominator
     auto &w_parent_bucket = bucket[parent[w]];
     for(auto v_it = begin(w_parent_bucket); v_it != end(w_parent_bucket);)
     {
@@ -462,6 +523,9 @@ void cfg_dominators_templatet<P, T, post_dom>::fixedpointt::fixedpoint(
       }
     }
   }
+
+  // Step 4
+  // Compute immediate dominator
   for(node_indext i = 2; i <= dfs_counter; ++i)
   {
     node_indext w = vertex[i];
@@ -471,10 +535,14 @@ void cfg_dominators_templatet<P, T, post_dom>::fixedpointt::fixedpoint(
     }
   }
 
+  // Fill output data structures
   assign_dominators(root);
 }
 
 /// Print the result of the dominator computation
+/// \param out: output stream
+/// \param cfg_dominators: structure containing the result of the dominator
+///   computation
 template <class P, class T, bool post_dom>
 std::ostream &operator<<(
   std::ostream &out,
@@ -500,15 +568,20 @@ void cfg_dominators_templatet<P, T, post_dom>::initialise(P &program)
   cfg(program);
 }
 
-/// Pretty-print a single node in the dominator tree. Supply a specialisation if
-/// operator<< is not sufficient.
-/// \par parameters: `node` to print and stream `out` to pretty-print it to
+/// Pretty-print a single node. Supply a specialisation if operator<< is not
+/// sufficient.
+/// \param node: node to print
+/// \param out: output stream
 template <class T>
 void dominators_pretty_print_node(const T &node, std::ostream &out)
 {
   out << node;
 }
 
+/// Pretty-print a single node.
+/// \param target: node to print
+/// \param out: output stream
+template <>
 inline void dominators_pretty_print_node(
   const goto_programt::targett& target,
   std::ostream& out)
@@ -516,7 +589,9 @@ inline void dominators_pretty_print_node(
   out << target->code.pretty();
 }
 
+
 /// Print the result of the dominator computation
+/// \param out: output stream
 template <class P, class T, bool post_dom>
 void cfg_dominators_templatet<P, T, post_dom>::output(std::ostream &out) const
 {
@@ -549,6 +624,9 @@ typedef cfg_dominators_templatet<
           const goto_programt, goto_programt::const_targett, true>
         cfg_post_dominatorst;
 
+/// Pretty-print a single node.
+/// \param node: node to print
+/// \param out: output stream
 template <>
 inline void dominators_pretty_print_node(
   const goto_programt::const_targett& node,

--- a/unit/analyses/cfg_dominators.cpp
+++ b/unit/analyses/cfg_dominators.cpp
@@ -1,0 +1,61 @@
+/*******************************************************************\
+
+Author: DiffBlue Limited. All rights reserved.
+
+\*******************************************************************/
+
+#include <string>
+#include <cstddef>
+
+#include <testing-utils/catch.hpp>
+#include <analyses/cfg_dominators.h>
+#include <memory>
+
+// Graph:
+
+SCENARIO("Looking up dominators")
+{
+  // Graph:
+  //  int x = rand();
+  //  if (x<0) {
+  //    x = -x;
+  //  } else {
+  //    x = x - 1;
+  //    log(x);
+  //  }
+  //  return x;
+  using domt = dominatorst<std::string, std::size_t>;
+  auto dominators_data =
+    std::make_shared<dominators_datat<std::string, std::size_t>>(
+      std::vector<std::string>{"int x = rand();",
+                               "if (x < 0)",
+                               "x = -x;",
+                               "x = x - 1;",
+                               "log(x);",
+                               "return x;"},
+      std::vector<std::size_t>{domt::npos, 0, 1, 1, 3, 1});
+
+  WHEN("Looking at the dominators of the root")
+  {
+    THEN("They should only exactly the root")
+    {
+      domt root_doms(dominators_data, 0);
+      REQUIRE(root_doms.size() == 1);
+      REQUIRE(*root_doms.begin() == dominators_data->data[0]);
+    }
+  }
+
+  WHEN(
+    "Looking at the dominators of a node that should have multiple dominators")
+  {
+    THEN("They should actually have multiple dominators")
+    {
+      domt log_doms(dominators_data, 4);
+      REQUIRE(log_doms.size() == 4);
+      REQUIRE(log_doms.find(dominators_data->data[0]) != log_doms.end());
+      REQUIRE(log_doms.find(dominators_data->data[1]) != log_doms.end());
+      REQUIRE(log_doms.find(dominators_data->data[3]) != log_doms.end());
+      REQUIRE(log_doms.find(dominators_data->data[4]) != log_doms.end());
+    }
+  }
+}


### PR DESCRIPTION
Use Lengauer&Tarjan's algorithm to calculate the tree of
immediate dominators instead of the previous algorithm,
which gives us a significant performance improvement.

Also, instead of storing the dominators in a std::set we
now just store the immediate dominators and make lookups
in there instead. This is a significant performance improvement
as long as the dominators set are only iterated over or only
queried infrequently, as is currently the case, and also
saves a lot of memory in the case of large functions (previous
memory usage was quadratic with function size, now it is linear).

In cases where a lot of queries are made against the same set of dominators,
they can still be copied to a local std::set prior to that.