### PR TITLE
Adding the irep_ids file to frequently modified low risk files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -46,6 +46,8 @@ src/cpp/ @kroening @tautschnig @peterschrammel
 
 # These files change frequently and changes are low-risk
 
+src/util/irep_ids.def @diffblue/cbmc-developers
+
 unit/ @diffblue/cbmc-developers
 regression/ @diffblue/cbmc-developers
 


### PR DESCRIPTION
Adding a new string to this list is a relatively common operation that carries little risk.