### PR TITLE
Extended core models

### DIFF
--- a/regression/cbmc-java/json_trace2/test.desc
+++ b/regression/cbmc-java/json_trace2/test.desc
@@ -5,6 +5,6 @@ activate-multi-line-match
 EXIT=0
 SIGNAL=0
 "outputID": "return",\n *"sourceLocation": \{\n *"file": "Test\.java",\n *"function": "java::Test\.test:\(Ljava/lang/Object;\)Z",\n *"line": "3"\n *\},\n *"stepType": "output",\n *"thread": 0,\n *"values": \[\n *\{\n *"binary": "00000000",\n *"data": "false",\n *"name": "integer",\n *"type": "boolean",\n *"width": 8
-"inputID": "arg1a",\n *"internal": true,\n *"mode": "java",\n *"sourceLocation": \{\n *"file": "Test\.java",\n *"function": "java::Test\.test:\(Ljava/lang/Object;\)Z",\n *"line": "3"\n *\},\n *"stepType": "input",\n *"thread": 0,\n *"values": \[\n *\{\n *"data": "null",\n *"name": "pointer",\n *"type": "struct java\.lang\.Object \{ __CPROVER_string @class_identifier; boolean @lock; \} \*"
+"inputID": "arg1a",\n *"internal": true,\n *"mode": "java",\n *"sourceLocation": \{\n *"file": "Test\.java",\n *"function": "java::Test\.test:\(Ljava/lang/Object;\)Z",\n *"line": "3"\n *\},\n *"stepType": "input",\n *"thread": 0,\n *"values": \[\n *\{\n *"data": "null",\n *"name": "pointer",\n *"type": "struct java\.lang\.Object \{ __CPROVER_string @class_identifier;[^\n]*"
 --
 ^warning: ignoring

--- a/src/java_bytecode/java_object_factory.cpp
+++ b/src/java_bytecode/java_object_factory.cpp
@@ -587,7 +587,7 @@ codet initialize_nondet_string_struct(
   const symbol_typet jlo_symbol("java::java.lang.Object");
   const struct_typet &jlo_type = to_struct_type(ns.follow(jlo_symbol));
   struct_exprt jlo_init(jlo_symbol);
-  java_root_class_init(jlo_init, jlo_type, false, class_id);
+  java_root_class_init(jlo_init, jlo_type, loc, class_id, ns);
 
   struct_exprt struct_expr(obj.type());
   struct_expr.copy_to_operands(jlo_init);
@@ -1040,8 +1040,10 @@ void java_object_factoryt::gen_nondet_struct_init(
       code.add_source_location()=loc;
       assignments.copy_to_operands(code);
     }
-    else if(name=="@lock")
+    else if(struct_tag == "java.lang.Object")
     {
+      // We zero-initialize all fields in Object because they are
+      // not meant to be nondet.
       if(update_in_place==update_in_placet::MUST_UPDATE_IN_PLACE)
         continue;
       code_assignt code(me, from_integer(0, me.type()));

--- a/src/java_bytecode/java_root_class.cpp
+++ b/src/java_bytecode/java_root_class.cpp
@@ -10,6 +10,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/arith_tools.h>
 #include <util/symbol.h>
+#include <util/namespace.h>
+#include <linking/zero_initializer.h>
 
 #include "java_types.h"
 
@@ -29,18 +31,6 @@ void java_root_class(symbolt &class_symbol)
 {
   struct_typet &struct_type=to_struct_type(class_symbol.type);
   struct_typet::componentst &components=struct_type.components();
-
-  {
-    // for monitorenter/monitorexit
-    struct_typet::componentt component;
-    component.set_name("@lock");
-    component.set_pretty_name("@lock");
-    component.type()=java_boolean_type();
-
-    // add at the beginning
-    components.insert(components.begin(), component);
-  }
-
   {
     // the class identifier is used for stuff such as 'instanceof'
     struct_typet::componentt component;
@@ -56,23 +46,32 @@ void java_root_class(symbolt &class_symbol)
 /// Adds members for an object of the root class (usually java.lang.Object).
 /// \param jlo [out] : object to initialize
 /// \param root_type: type of the root class
-/// \param lock: lock field
+/// \param location: source location
 /// \param class_identifier: class identifier field, generally begins with
 ///        "java::" prefix.
+/// \param ns namespace
 void java_root_class_init(
   struct_exprt &jlo,
   const struct_typet &root_type,
-  const bool lock,
-  const irep_idt &class_identifier)
+  const source_locationt &location,
+  const irep_idt &class_identifier,
+  const namespacet &ns)
 {
-  jlo.operands().resize(root_type.components().size());
+  // We need to fill the object fields from an empty struct
+  jlo.operands().resize(0);
 
-  const std::size_t clsid_nb=root_type.component_number("@class_identifier");
-  const typet &clsid_type=root_type.components()[clsid_nb].type();
-  constant_exprt clsid(class_identifier, clsid_type);
-  jlo.operands()[clsid_nb]=clsid;
-
-  const std::size_t lock_nb=root_type.component_number("@lock");
-  const typet &lock_type=root_type.components()[lock_nb].type();
-  jlo.operands()[lock_nb]=from_integer(lock, lock_type);
+  // We initialize any fields added to the java.lang.object model.
+  // Non-basic data types will be filled with nil.
+  for(const auto &comp : root_type.components())
+  {
+    if(comp.get_name() == "@class_identifier")
+    {
+      constant_exprt clsid(class_identifier, comp.type());
+      jlo.copy_to_operands(clsid);
+    }
+    else
+    {
+      jlo.copy_to_operands(zero_initializer(comp.type(), location, ns));
+    }
+  }
 }

--- a/src/java_bytecode/java_root_class.h
+++ b/src/java_bytecode/java_root_class.h
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_JAVA_BYTECODE_JAVA_ROOT_CLASS_H
 
 #include <util/std_expr.h>
+#include <util/source_location.h>
 
 // adds expected members for a root class,
 // which is usually java.lang.Object
@@ -21,7 +22,8 @@ void java_root_class(
 void java_root_class_init(
   struct_exprt &jlo,
   const struct_typet &root_type,
-  bool lock,
-  const irep_idt &class_identifier);
+  const source_locationt &location,
+  const irep_idt &class_identifier,
+  const namespacet &ns);
 
 #endif // CPROVER_JAVA_BYTECODE_JAVA_ROOT_CLASS_H

--- a/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/src/java_bytecode/java_string_library_preprocess.cpp
@@ -23,6 +23,7 @@ Date:   April 2017
 #include <util/refined_string_type.h>
 #include <util/string_expr.h>
 #include <util/c_types.h>
+#include <util/namespace.h>
 
 #include "java_types.h"
 #include "java_object_factory.h"
@@ -830,12 +831,20 @@ codet java_string_library_preprocesst::code_assign_components_to_java_string(
   PRECONDITION(implements_java_char_sequence_pointer(lhs.type()));
   dereference_exprt deref=checked_dereference(lhs, lhs.type().subtype());
 
-  // A String has a field Object with @clsid = String and @lock = false:
+  // A String has a field Object with @clsid = String:
   const symbolt &jlo_symbol=*symbol_table.lookup("java::java.lang.Object");
   const struct_typet &jlo_struct=to_struct_type(jlo_symbol.type);
   struct_exprt jlo_init(jlo_struct);
+  jlo_init.copy_to_operands(
+    constant_exprt(
+      "java::java.lang.String", jlo_struct.components()[0].type()));
   irep_idt clsid = get_tag(lhs.type().subtype());
-  java_root_class_init(jlo_init, jlo_struct, false, clsid);
+  java_root_class_init(
+    jlo_init,
+    jlo_struct,
+    lhs.source_location(),
+    clsid,
+    namespacet(symbol_table));
 
   struct_exprt struct_rhs(deref.type());
   struct_rhs.copy_to_operands(jlo_init);

--- a/src/java_bytecode/java_string_literals.cpp
+++ b/src/java_bytecode/java_string_literals.cpp
@@ -95,12 +95,17 @@ symbol_exprt get_or_create_string_literal_symbol(
   namespacet ns(symbol_table);
 
   // Regardless of string refinement setting, at least initialize
-  // the literal with @clsid = String and @lock = false:
+  // the literal with @clsid = String:
   symbol_typet jlo_symbol("java::java.lang.Object");
   const auto &jlo_struct = to_struct_type(ns.follow(jlo_symbol));
   struct_exprt jlo_init(jlo_symbol);
   const auto &jls_struct = to_struct_type(ns.follow(string_type));
-  java_root_class_init(jlo_init, jlo_struct, false, "java::java.lang.String");
+  java_root_class_init(
+    jlo_init,
+    jlo_struct,
+    string_expr.source_location(),
+    "java::java.lang.String",
+    ns);
 
   // If string refinement *is* around, populate the actual
   // contents as well:

--- a/unit/java_bytecode/java_object_factory/gen_nondet_string_init.cpp
+++ b/unit/java_bytecode/java_object_factory/gen_nondet_string_init.cpp
@@ -83,7 +83,7 @@ SCENARIO(
           "return_array = cprover_associate_length_to_array_func"
             "(*string_data_pointer, tmp_object_factory);",
           "arg = { .@java.lang.Object={ .@class_identifier"
-            "=\"java::java.lang.String\", .@lock=false },"
+            "=\"java::java.lang.String\" },"
             " .length=tmp_object_factory, "
             ".data=*string_data_pointer };"};
 


### PR DESCRIPTION
This PR has 2 purposes:
1) to remove a dependency on the java_root_class structure and allow variable size Object models (that can be updated in the models library) with zero initialization.
2) To add a small core-models library (Object.java, Class.java, and some exception classes) to use as the default model set for JBMC (test-gen still uses the models library)