### PR TITLE
Select instruction with non-empty function in coverage block [TG-2341]

### DIFF
--- a/src/goto-instrument/cover_basic_blocks.cpp
+++ b/src/goto-instrument/cover_basic_blocks.cpp
@@ -63,6 +63,7 @@ cover_basic_blockst::cover_basic_blockst(const goto_programt &_goto_program)
 
     // set representative program location to instrument
     if(
+      !it->function.empty() &&
       !it->source_location.is_nil() &&
       !it->source_location.get_file().empty() &&
       !it->source_location.get_line().empty() &&


### PR DESCRIPTION
Otherwise coverage goals cannot be linked to functions in consumers of CBMC output.