### PR TITLE
Fixes the symbol_base_tablet iterator

### DIFF
--- a/src/util/symbol_table_base.h
+++ b/src/util/symbol_table_base.h
@@ -144,6 +144,11 @@ public:
     typedef symbolst::const_iterator::reference reference;           // NOLINT
     typedef symbolst::iterator::iterator_category iterator_category; // NOLINT
 
+    bool operator!=(const iteratort &other) const
+    {
+      return it != other.it;
+    }
+
     bool operator==(const iteratort &other) const
     {
       return it == other.it;

--- a/unit/util/symbol_table.cpp
+++ b/unit/util/symbol_table.cpp
@@ -5,6 +5,25 @@
 #include <testing-utils/catch.hpp>
 #include <util/journalling_symbol_table.h>
 
+TEST_CASE("Iterating through a symbol table", "[core][utils][symbol_tablet]")
+{
+  symbol_tablet symbol_table;
+
+  symbolt symbol;
+  irep_idt symbol_name = "Test";
+  symbol.name = symbol_name;
+
+  symbol_table.insert(symbol);
+
+  int counter = 0;
+  for(auto &entry : symbol_table)
+  {
+    ++counter;
+  }
+
+  REQUIRE(counter == 1);
+}
+
 SCENARIO("journalling_symbol_table_writer",
   "[core][utils][journalling_symbol_table_writer]")
 {


### PR DESCRIPTION
The iterator for `symbol_base_tablet ` had a missing operator overload which prevented the following from working

```
symbol_tablet symbol_table
for(auto entry : symbol_table)
{
...
}
```