### PR TITLE
[TG-2356] skip basic block instrumentation from virtual call removal

### DIFF
--- a/src/goto-instrument/Makefile
+++ b/src/goto-instrument/Makefile
@@ -94,12 +94,12 @@ INCLUDES= -I ..
 
 LIBS =
 
-CLEANFILES = goto-instrument$(EXEEXT)
+CLEANFILES = goto-instrument$(EXEEXT) goto-instrument$(LIBEXT)
 
 include ../config.inc
 include ../common
 
-all: goto-instrument$(EXEEXT)
+all: goto-instrument$(EXEEXT) goto-instrument$(LIBEXT)
 
 ifneq ($(LIB_GLPK),)
   LIBS += $(LIB_GLPK)
@@ -110,6 +110,9 @@ endif
 
 goto-instrument$(EXEEXT): $(OBJ)
 	$(LINKBIN)
+
+goto-instrument$(LIBEXT): $(OBJ)
+	$(LINKLIB)
 
 .PHONY: goto-instrument-mac-signed
 

--- a/src/goto-instrument/cover_filter.cpp
+++ b/src/goto-instrument/cover_filter.cpp
@@ -101,5 +101,8 @@ operator()(const source_locationt &source_location) const
   if(source_location.is_built_in())
     return false;
 
+  if(source_location.get_java_removed_virtual_call())
+    return false;
+
   return true;
 }

--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -276,6 +276,8 @@ void remove_virtual_functionst::remove_virtual_function(
     const irep_idt property_class=it->source_location.get_property_class();
     const irep_idt comment=it->source_location.get_comment();
     it->source_location=target->source_location;
+    // mark instruction as originating from a removed virtual function call
+    it->source_location.set_java_removed_virtual_call();
     it->function=target->function;
     if(!property_class.empty())
       it->source_location.set_property_class(property_class);

--- a/src/util/irep_ids.def
+++ b/src/util/irep_ids.def
@@ -840,6 +840,7 @@ IREP_ID_TWO(type_variables, #type_variables)
 IREP_ID_ONE(havoc_object)
 IREP_ID_TWO(overflow_shl, overflow-shl)
 IREP_ID_TWO(C_no_initialization_required, #no_initialization_required)
+IREP_ID_TWO(C_java_removed_virtual_call, #java_removed_virtual_call)
 
 #undef IREP_ID_ONE
 #undef IREP_ID_TWO

--- a/src/util/source_location.h
+++ b/src/util/source_location.h
@@ -151,6 +151,19 @@ public:
     return set(ID_basic_block_covered_lines, covered_lines);
   }
 
+  /// Add comment to source location as originating from removed virtual call
+  void set_java_removed_virtual_call()
+  {
+    set(ID_C_java_removed_virtual_call, true);
+  }
+
+  /// Get information about whether call originated from a removed virtual
+  /// function call
+  bool get_java_removed_virtual_call() const
+  {
+    return get_bool(ID_C_java_removed_virtual_call);
+  }
+
   void set_hide()
   {
     set(ID_hide, true);

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -36,7 +36,15 @@ target_include_directories(unit
     ${CBMC_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
-target_link_libraries(unit testing-utils ansi-c solvers java_bytecode)
+target_link_libraries(
+ unit
+ testing-utils
+ ansi-c
+ solvers
+ java_bytecode
+ goto-programs
+ goto-instrument-lib)
+
 add_test(
     NAME unit
     COMMAND $<TARGET_FILE:unit>

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -66,6 +66,7 @@ CPROVER_LIBS =../src/java_bytecode/java_bytecode$(LIBEXT) \
               ../src/util/util$(LIBEXT) \
               ../src/big-int/big-int$(LIBEXT) \
               ../src/goto-programs/goto-programs$(LIBEXT) \
+              ../src/goto-instrument/goto-instrument$(LIBEXT) \
               ../src/pointer-analysis/pointer-analysis$(LIBEXT) \
               ../src/langapi/langapi$(LIBEXT) \
               ../src/assembler/assembler$(LIBEXT) \


### PR DESCRIPTION
When a virtual function call is encountered in Java, we replace it by explicit calls to all possible implementing object types.

The coverage instrumentation does not allow for a single bytecode index (the virtual call) to be instrumented several times, which makes sense, as only a single such instrumentation can be placed at the bytecode.

In the current implementation, a coverage property was placed right after the first guarded GOTO, but not on succeeding ones, leading to the situation that coverage was reported differently, depending on the order implementing classes were found. This patch removes instrumentation of GOTO instructions generated via remove_virtual_functions altogether, the function call is considered to be completed and covered if the final target `t_final` is reached. This is the target for each concrete function call.