### PR TITLE
Remove string solver iteration limit

### DIFF
--- a/src/cbmc/cbmc_solvers.cpp
+++ b/src/cbmc/cbmc_solvers.cpp
@@ -174,7 +174,7 @@ std::unique_ptr<cbmc_solverst::solvert> cbmc_solverst::get_string_refinement()
   auto prop=util_make_unique<satcheck_no_simplifiert>();
   prop->set_message_handler(get_message_handler());
   info.prop=prop.get();
-  info.refinement_bound=MAX_NB_REFINEMENT;
+  info.refinement_bound=DEFAULT_MAX_NB_REFINEMENT;
   info.ui=ui;
   if(options.get_bool_option("string-max-length"))
     info.string_max_length=options.get_signed_int_option("string-max-length");

--- a/src/solvers/refinement/string_refinement.h
+++ b/src/solvers/refinement/string_refinement.h
@@ -28,7 +28,7 @@ Author: Alberto Griggio, alberto.griggio@gmail.com
 #include <solvers/refinement/string_constraint_generator.h>
 #include <solvers/refinement/string_refinement_invariant.h>
 
-#define MAX_NB_REFINEMENT 100
+#define DEFAULT_MAX_NB_REFINEMENT std::numeric_limits<size_t>::max()
 #define CHARACTER_FOR_UNKNOWN '?'
 
 struct index_set_pairt


### PR DESCRIPTION
This could prevent a solution from being reached whenever more than 100 iterations
were required to reach one, and since it returned error on failure its termination
could never yield any useful result. Therefore let's simply let the user or driver
program / platform choose when to give up rather than impose an arbitrary limit.

See also https://diffblue.atlassian.net/browse/TG-2338