### PR TITLE
Refactor substitute_array_access method of string solver [TG-2138]

### DIFF
--- a/src/solvers/refinement/string_refinement.cpp
+++ b/src/solvers/refinement/string_refinement.cpp
@@ -171,7 +171,7 @@ string_refinementt::string_refinementt(const infot &info, bool):
 string_refinementt::string_refinementt(const infot &info):
   string_refinementt(info, validate(info)) { }
 
-/// display the current index set, for debugging
+/// Write index set to the given stream, use for debugging
 static void display_index_set(
   messaget::mstreamt &stream,
   const namespacet &ns,
@@ -669,6 +669,7 @@ union_find_replacet string_identifiers_resolution_from_equations(
   return result;
 }
 
+/// Output a vector of equations to the given stream, used for debugging.
 void output_equations(
   std::ostream &output,
   const std::vector<equal_exprt> &equations,
@@ -1021,8 +1022,12 @@ void string_refinementt::add_lemma(
 
 /// Get a model of an array and put it in a certain form.
 /// If the model is incomplete or if it is too big, return no value.
-/// \par parameters: an expression representing an array and an expression
-/// representing an integer
+/// \param super_get: function returning the valuation of an expression
+///        in a model
+/// \param ns: namespace
+/// \param max_string_length: maximum length of strings to analyze
+/// \param stream: output stream for warning messages
+/// \param arr: expression of type array representing a string
 /// \return an optional array expression or array_of_exprt
 static optionalt<exprt> get_array(
   const std::function<exprt(const exprt &)> &super_get,
@@ -1104,7 +1109,7 @@ static optionalt<exprt> get_array(
 
 /// convert the content of a string to a more readable representation. This
 /// should only be used for debugging.
-/// \par parameters: a constant array expression and a integer expression
+/// \param arr: a constant array expression
 /// \return a string
 static std::string string_of_array(const array_exprt &arr)
 {

--- a/src/solvers/refinement/string_refinement.h
+++ b/src/solvers/refinement/string_refinement.h
@@ -43,6 +43,41 @@ struct string_axiomst
   std::vector<string_not_contains_constraintt> not_contains;
 };
 
+/// Represents arrays of the form `array_of(x) with {i:=a} with {j:=b} ...`
+/// by a default value `x` and a list of entries `(i,a)`, `(j,b)` etc.
+class sparse_arrayt
+{
+public:
+  /// Initialize a sparse array from an expression of the form
+  /// `array_of(x) with {i:=a} with {j:=b} ...`
+  /// This is the form in which array valuations coming from the underlying
+  /// solver are given.
+  explicit sparse_arrayt(const with_exprt &expr);
+
+  /// Creates an if_expr corresponding to the result of accessing the array
+  /// at the given index
+  virtual exprt to_if_expression(const exprt &index) const;
+
+protected:
+  exprt default_value;
+  std::vector<std::pair<std::size_t, exprt>> entries;
+};
+
+/// Represents arrays by the indexes up to which the value remains the same.
+/// For instance `{'a', 'a', 'a', 'b', 'b', 'c'}` would be represented by
+/// by ('a', 2) ; ('b', 4), ('c', 5).
+/// This is particularly useful when the array is constant on intervals.
+class interval_sparse_arrayt final : public sparse_arrayt
+{
+public:
+  /// An expression of the form `array_of(x) with {i:=a} with {j:=b}` is
+  /// converted to an array `arr` where for all index `k` smaller than `i`,
+  /// `arr[k]` is `a`, for all index between `i` (exclusive) and `j` it is `b`
+  /// and for the others it is `x`.
+  explicit interval_sparse_arrayt(const with_exprt &expr);
+  exprt to_if_expression(const exprt &index) const override;
+};
+
 class string_refinementt final: public bv_refinementt
 {
 private:

--- a/src/solvers/refinement/string_refinement.h
+++ b/src/solvers/refinement/string_refinement.h
@@ -116,4 +116,11 @@ union_find_replacet string_identifiers_resolution_from_equations(
   const namespacet &ns,
   messaget::mstreamt &stream);
 
+// Declaration required for unit-test:
+exprt substitute_array_access(
+  exprt expr,
+  const std::function<symbol_exprt(const irep_idt &, const typet &)>
+    &symbol_generator,
+  const bool left_propagate);
+
 #endif

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -36,6 +36,7 @@ SRC += unit_tests.cpp \
        solvers/refinement/string_refinement/has_subtype.cpp \
        solvers/refinement/string_refinement/substitute_array_list.cpp \
        solvers/refinement/string_refinement/string_symbol_resolution.cpp \
+       solvers/refinement/string_refinement/sparse_array.cpp \
        solvers/refinement/string_refinement/union_find_replace.cpp \
        util/expr_cast/expr_cast.cpp \
        util/expr_iterator.cpp \

--- a/unit/solvers/refinement/string_refinement/sparse_array.cpp
+++ b/unit/solvers/refinement/string_refinement/sparse_array.cpp
@@ -1,0 +1,88 @@
+/*******************************************************************\
+
+ Module: Unit tests for sparse arrays
+   solvers/refinement/string_refinement.cpp
+
+ Author: DiffBlue Limited. All rights reserved.
+
+\*******************************************************************/
+
+#include <testing-utils/catch.hpp>
+
+#include <util/arith_tools.h>
+#include <util/std_types.h>
+#include <util/std_expr.h>
+#include <util/symbol_table.h>
+#include <solvers/refinement/string_refinement.h>
+#include <iostream>
+
+SCENARIO("sparse_array", "[core][solvers][refinement][string_refinement]")
+{
+  GIVEN("`ARRAY_OF(0) WITH [4:=x] WITH [1:=y] WITH [100:=z]`")
+  {
+    const typet char_type = unsignedbv_typet(16);
+    const typet int_type = signedbv_typet(32);
+    const exprt index1 = from_integer(1, int_type);
+    const exprt charx = from_integer('x', char_type);
+    const exprt index4 = from_integer(4, int_type);
+    const exprt chary = from_integer('y', char_type);
+    const exprt index100 = from_integer(100, int_type);
+    const exprt char0 = from_integer('0', char_type);
+    const exprt index2 = from_integer(2, int_type);
+    const exprt charz = from_integer('z', char_type);
+    const array_typet array_type(char_type, infinity_exprt(int_type));
+
+    const with_exprt input_expr(
+      with_exprt(
+        with_exprt(
+          array_of_exprt(from_integer(0, char_type), array_type),
+          index4,
+          charx),
+        index1,
+        chary),
+      index100,
+      charz);
+
+    WHEN("It is converted to a sparse array")
+    {
+      const sparse_arrayt sparse_array(input_expr);
+      THEN("The resulting if expression is index=4?x:index=1?y:index=100?z:0")
+      {
+        const symbol_exprt index("index", int_type);
+        const if_exprt expected(
+          equal_exprt(index, index4),
+          charx,
+          if_exprt(
+            equal_exprt(index, index1),
+            chary,
+            if_exprt(
+              equal_exprt(index, index100),
+              charz,
+              from_integer(0, char_type))));
+        REQUIRE(sparse_array.to_if_expression(index) == expected);
+      }
+    }
+
+    WHEN("It is converted to an interval sparse array")
+    {
+      const interval_sparse_arrayt sparse_array(input_expr);
+
+      THEN(
+        "The resulting if expression is index<=1?x:index<=4?y:index<=100?z:0")
+      {
+        const symbol_exprt index("index", int_type);
+        const if_exprt expected(
+          binary_relation_exprt(index, ID_le, index1),
+          chary,
+          if_exprt(
+            binary_relation_exprt(index, ID_le, index4),
+            charx,
+            if_exprt(
+              binary_relation_exprt(index, ID_le, index100),
+              charz,
+              from_integer(0, char_type))));
+        REQUIRE(sparse_array.to_if_expression(index) == expected);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This refactoring makes the transformation clearer and more efficient.

It has been split into several methods which each deal with one type of expression.
A sparse_array_class has been added to make the way we interpret arrays obtained from the underlying solver more explicit.
Instead of the result of the underlying solver being transformed to a concrete array and then converted to an if_expression, it is now converted to a sparse array, which can avoid an unnecessarily inflating the resulting "if"-expression.  

The PR also adds a unit test for the sparse_array class.