### PR TITLE
Remove unused lambda capture

### DIFF
--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -434,7 +434,8 @@ void remove_virtual_functionst::get_functions(
   std::sort(
     functions.begin(),
     functions.end(),
-    [&root_function](const dispatch_table_entryt &a, dispatch_table_entryt &b) {
+    [](const dispatch_table_entryt &a, dispatch_table_entryt &b)
+    {
       if(
         has_prefix(
           id2string(a.symbol_expr.get_identifier()), "java::java.lang.Object"))


### PR DESCRIPTION
Could somebody please merge this urgently; it's breaking the build for users of Clang++ 5. Pinging @kroening and @tautschnig.