### PR TITLE
Removed unused parameter/private field

### DIFF
--- a/src/java_bytecode/java_bytecode_convert_class.cpp
+++ b/src/java_bytecode/java_bytecode_convert_class.cpp
@@ -37,13 +37,11 @@ public:
     message_handlert &_message_handler,
     size_t _max_array_length,
     method_bytecodet &method_bytecode,
-    lazy_methods_modet _lazy_methods_mode,
     java_string_library_preprocesst &_string_preprocess)
     : messaget(_message_handler),
       symbol_table(_symbol_table),
       max_array_length(_max_array_length),
       method_bytecode(method_bytecode),
-      lazy_methods_mode(_lazy_methods_mode),
       string_preprocess(_string_preprocess)
   {
   }
@@ -75,7 +73,6 @@ protected:
   symbol_tablet &symbol_table;
   const size_t max_array_length;
   method_bytecodet &method_bytecode;
-  lazy_methods_modet lazy_methods_mode;
   java_string_library_preprocesst &string_preprocess;
 
   // conversion
@@ -604,7 +601,6 @@ bool java_bytecode_convert_class(
   message_handlert &message_handler,
   size_t max_array_length,
   method_bytecodet &method_bytecode,
-  lazy_methods_modet lazy_methods_mode,
   java_string_library_preprocesst &string_preprocess)
 {
   java_bytecode_convert_classt java_bytecode_convert_class(
@@ -612,7 +608,6 @@ bool java_bytecode_convert_class(
     message_handler,
     max_array_length,
     method_bytecode,
-    lazy_methods_mode,
     string_preprocess);
 
   try

--- a/src/java_bytecode/java_bytecode_convert_class.h
+++ b/src/java_bytecode/java_bytecode_convert_class.h
@@ -25,7 +25,6 @@ bool java_bytecode_convert_class(
   message_handlert &message_handler,
   size_t max_array_length,
   method_bytecodet &,
-  lazy_methods_modet,
   java_string_library_preprocesst &string_preprocess);
 
 void mark_java_implicitly_generic_class_type(

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -488,9 +488,10 @@ bool java_bytecode_languaget::typecheck(
      get_message_handler(),
      max_user_array_length,
      method_bytecode,
-     lazy_methods_mode,
      string_preprocess))
-       return true;
+    {
+      return true;
+    }
   }
 
   // first generate a new struct symbol for each class and a new function symbol
@@ -510,9 +511,10 @@ bool java_bytecode_languaget::typecheck(
         get_message_handler(),
         max_user_array_length,
         method_bytecode,
-        lazy_methods_mode,
         string_preprocess))
+    {
       return true;
+    }
   }
 
   // find and mark all implicitly generic class types


### PR DESCRIPTION
The presence of unused private fields causes warnings in some compilers