### PR TITLE
Allow non-const depth_iteratort to be created from a const root

### DIFF
--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -526,6 +526,10 @@ const_depth_iteratort exprt::depth_cbegin() const
 { return const_depth_iteratort(*this); }
 const_depth_iteratort exprt::depth_cend() const
 { return const_depth_iteratort(); }
+depth_iteratort exprt::depth_begin(std::function<exprt &()> mutate_root) const
+{
+  return depth_iteratort(*this, std::move(mutate_root));
+}
 
 const_unique_depth_iteratort exprt::unique_depth_begin() const
 { return const_unique_depth_iteratort(*this); }

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #define OPERANDS_IN_GETSUB
 
+#include <functional>
 #include "type.h"
 
 #define forall_operands(it, expr) \
@@ -172,6 +173,7 @@ public:
   const_depth_iteratort depth_end() const;
   const_depth_iteratort depth_cbegin() const;
   const_depth_iteratort depth_cend() const;
+  depth_iteratort depth_begin(std::function<exprt &()> mutate_root) const;
   const_unique_depth_iteratort unique_depth_begin() const;
   const_unique_depth_iteratort unique_depth_end() const;
   const_unique_depth_iteratort unique_depth_cbegin() const;


### PR DESCRIPTION
This allows creation of a non-const depth_iteratort from a const root as long as a function is provided to get a non-const version of the root if/when mutate if finally called.
It is required for #1789.
This can be useful when you have an `exprt` and want to depth iterate its first operand. As part of that iteration you may or may not decide to mutate one of the children, depending on the state of those children. If you do not decide to mutate a child then you probably don't want to call the non-const version of `op0()` because that will break sharing, so you create the depth iterator with the const `exprt` returned from the const invocation of `op0()`, but if you decide during iteration that you do want to mutate a child then you can call the non-const version of `op0()` on the original `exprt` in order to get a non-const `exprt` that the iterator can copy-on-write update to change the child. At this point the iterator needs to be informed that it is now safe to write to the `exprt` it contains. This is achieved by providing a call-back function to the iterator. The provided unit test contains the code for this example.