### PR TITLE
Remove destination directory before trying to move to it in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ install:
     Move-Item win_bison.exe bin\bison.exe -force
     Move-Item win_flex.exe bin\flex.exe -force
     Move-Item FlexLexer.h include\FlexLexer.h -force
+    Remove-Item bin\data -Force -Recurse -ErrorAction SilentlyContinue
     Move-Item data bin\data -force
     bison -V
     flex -V


### PR DESCRIPTION
This should fix an annoying issue that popped up in AppVeyor where the move from data to bin\data failed because bin\data already existed.

This is assuming that the intention was to replace bin\data with the contents of data, rather than moving the contents of data to bin\data in addition to what might already be there; This would be a different change so can someone please confirm whether or not this is the intended effect?