### PR TITLE
Restore irept sharing

### DIFF
--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -21,64 +21,40 @@ Author: Daniel Kroening, kroening@kroening.com
 
 void exprt::move_to_operands(exprt &expr)
 {
-  operandst &op=operands();
-  op.push_back(static_cast<const exprt &>(get_nil_irep()));
-  op.back().swap(expr);
+  move_to_sub(expr);
 }
 
 void exprt::move_to_operands(exprt &e1, exprt &e2)
 {
-  operandst &op=operands();
-  #ifndef USE_LIST
-  op.reserve(op.size()+2);
-  #endif
-  op.push_back(static_cast<const exprt &>(get_nil_irep()));
-  op.back().swap(e1);
-  op.push_back(static_cast<const exprt &>(get_nil_irep()));
-  op.back().swap(e2);
+  reserve_operands(get_operands_size() + 2);
+  move_to_sub(e1);
+  move_to_sub(e2);
 }
 
 void exprt::move_to_operands(exprt &e1, exprt &e2, exprt &e3)
 {
-  operandst &op=operands();
-  #ifndef USE_LIST
-  op.reserve(op.size()+3);
-  #endif
-  op.push_back(static_cast<const exprt &>(get_nil_irep()));
-  op.back().swap(e1);
-  op.push_back(static_cast<const exprt &>(get_nil_irep()));
-  op.back().swap(e2);
-  op.push_back(static_cast<const exprt &>(get_nil_irep()));
-  op.back().swap(e3);
+  reserve_operands(get_operands_size() + 3);
+  move_to_sub(e1);
+  move_to_sub(e2);
+  move_to_sub(e3);
 }
 
-void exprt::copy_to_operands(const exprt &expr)
+void exprt::copy_to_operands(exprt expr)
 {
-  operands().push_back(expr);
+  // Move the copy created by passing the argument by value to the operands
+  move_to_operands(expr);
 }
 
-void exprt::copy_to_operands(const exprt &e1, const exprt &e2)
+void exprt::copy_to_operands(exprt e1, exprt e2)
 {
-  operandst &op=operands();
-  #ifndef USE_LIST
-  op.reserve(op.size()+2);
-  #endif
-  op.push_back(e1);
-  op.push_back(e2);
+  // Move the copies created by passing the arguments by value to the operands
+  move_to_operands(e1, e2);
 }
 
-void exprt::copy_to_operands(
-  const exprt &e1,
-  const exprt &e2,
-  const exprt &e3)
+void exprt::copy_to_operands(exprt e1, exprt e2, exprt e3)
 {
-  operandst &op=operands();
-  #ifndef USE_LIST
-  op.reserve(op.size()+3);
-  #endif
-  op.push_back(e1);
-  op.push_back(e2);
-  op.push_back(e3);
+  // Move the copies created by passing the arguments by value to the operands
+  move_to_operands(e1, e2, e3);
 }
 
 void exprt::make_typecast(const typet &_type)
@@ -105,7 +81,7 @@ void exprt::make_not()
 
   if(id()==ID_not && operands().size()==1)
   {
-    new_expr.swap(operands().front());
+    new_expr.swap(op0());
   }
   else
   {

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -93,17 +93,23 @@ public:
   const exprt &op3() const
   { return operands()[3]; }
 
+  operandst::size_type get_operands_size() const
+  {
+    return get_sub_size();
+  }
   void reserve_operands(operandst::size_type n)
-  { operands().reserve(n) ; }
+  {
+    reserve_sub(n);
+  }
 
   // destroys expr, e1, e2, e3
   void move_to_operands(exprt &expr);
   void move_to_operands(exprt &e1, exprt &e2);
   void move_to_operands(exprt &e1, exprt &e2, exprt &e3);
   // does not destroy expr, e1, e2, e3
-  void copy_to_operands(const exprt &expr);
-  void copy_to_operands(const exprt &e1, const exprt &e2);
-  void copy_to_operands(const exprt &e1, const exprt &e2, const exprt &e3);
+  void copy_to_operands(exprt expr);
+  void copy_to_operands(exprt e1, exprt e2);
+  void copy_to_operands(exprt e1, exprt e2, exprt e3);
 
   // the following are deprecated -- use constructors instead
   void make_typecast(const typet &_type);

--- a/unit/util/irep_sharing.cpp
+++ b/unit/util/irep_sharing.cpp
@@ -7,7 +7,7 @@
 
 #ifdef SHARING
 
-SCENARIO("irept_sharing_trade_offs", "[!mayfail][core][utils][irept]")
+SCENARIO("irept_sharing", "[core][utils][irept]")
 {
   GIVEN("An irept created with move_to_sub")
   {
@@ -21,35 +21,6 @@ SCENARIO("irept_sharing_trade_offs", "[!mayfail][core][utils][irept]")
       irept irep = test_irep;
       REQUIRE(&irep.read() == &test_irep.read());
     }
-    THEN("Changing subs in the original using a reference taken before "
-      "copying should not change them in the copy")
-    {
-      irept &sub = test_irep.get_sub()[0];
-      irept irep = test_irep;
-      sub.id(ID_0);
-      REQUIRE(test_irep.get_sub()[0].id() == ID_0);
-      REQUIRE(irep.get_sub()[0].id() == ID_1);
-    }
-    THEN("Holding a reference to a sub should not prevent sharing")
-    {
-      irept &sub = test_irep.get_sub()[0];
-      irept irep = test_irep;
-      REQUIRE(&irep.read() == &test_irep.read());
-      sub = irept(ID_0);
-      REQUIRE(irep.get_sub()[0].id() == test_irep.get_sub()[0].id());
-    }
-  }
-}
-
-SCENARIO("irept_sharing", "[core][utils][irept]")
-{
-  GIVEN("An irept created with move_to_sub")
-  {
-    irept test_irep(ID_1);
-    irept test_subirep(ID_1);
-    irept test_subsubirep(ID_1);
-    test_subirep.move_to_sub(test_subsubirep);
-    test_irep.move_to_sub(test_subirep);
     THEN("Copies of a copy should return object with the same address")
     {
       irept irep1 = test_irep;
@@ -68,6 +39,15 @@ SCENARIO("irept_sharing", "[core][utils][irept]")
       irep.get_sub()[0].id(ID_0);
       REQUIRE(test_irep.get_sub()[0].id() == ID_1);
       REQUIRE(irep.get_sub()[0].id() == ID_0);
+    }
+    THEN("Changing subs in the original using a reference taken before "
+      "copying should not change them in the copy")
+    {
+      irept &sub = test_irep.get_sub()[0];
+      irept irep = test_irep;
+      sub.id(ID_0);
+      REQUIRE(test_irep.get_sub()[0].id() == ID_0);
+      REQUIRE(irep.get_sub()[0].id() == ID_1);
     }
     THEN("Getting a reference to a sub in a copy should break sharing")
     {
@@ -104,7 +84,7 @@ SCENARIO("irept_sharing", "[core][utils][irept]")
 
 #include <util/expr.h>
 
-SCENARIO("exprt_sharing_trade_offs", "[!mayfail][core][utils][exprt]")
+SCENARIO("exprt_sharing", "[core][utils][exprt]")
 {
   GIVEN("An expression created with move_to_operands")
   {
@@ -118,35 +98,6 @@ SCENARIO("exprt_sharing_trade_offs", "[!mayfail][core][utils][exprt]")
       exprt expr = test_expr;
       REQUIRE(&expr.read() == &test_expr.read());
     }
-    THEN("Changing operands in the original using a reference taken before "
-      "copying should not change them in the copy")
-    {
-      exprt &operand = test_expr.op0();
-      exprt expr = test_expr;
-      operand.id(ID_0);
-      REQUIRE(test_expr.op0().id() == ID_0);
-      REQUIRE(expr.op0().id() == ID_1);
-    }
-    THEN("Holding a reference to an operand should not prevent sharing")
-    {
-      exprt &operand = test_expr.op0();
-      exprt expr = test_expr;
-      REQUIRE(&expr.read() == &test_expr.read());
-      operand = exprt(ID_0);
-      REQUIRE(expr.op0().id() == test_expr.op0().id());
-    }
-  }
-}
-
-SCENARIO("exprt_sharing", "[core][utils][exprt]")
-{
-  GIVEN("An expression created with move_to_operands")
-  {
-    exprt test_expr(ID_1);
-    exprt test_subexpr(ID_1);
-    exprt test_subsubexpr(ID_1);
-    test_subexpr.move_to_operands(test_subsubexpr);
-    test_expr.move_to_operands(test_subexpr);
     THEN("Copies of a copy should return object with the same address")
     {
       exprt expr1 = test_expr;
@@ -165,6 +116,15 @@ SCENARIO("exprt_sharing", "[core][utils][exprt]")
       expr.op0().id(ID_0);
       REQUIRE(test_expr.op0().id() == ID_1);
       REQUIRE(expr.op0().id() == ID_0);
+    }
+    THEN("Changing operands in the original using a reference taken before "
+      "copying should not change them in the copy")
+    {
+      exprt &operand = test_expr.op0();
+      exprt expr = test_expr;
+      operand.id(ID_0);
+      REQUIRE(test_expr.op0().id() == ID_0);
+      REQUIRE(expr.op0().id() == ID_1);
     }
     THEN("Getting a reference to an operand in a copy should break sharing")
     {


### PR DESCRIPTION
A PR by @reuk some time ago prevented sharing when references are held to sub-parts but didn't re-enable sharing in situations where it is actually safe to do so. This PR amends that.

This should improve performance, particularly in memory usage.