### PR TITLE
Introduce fieldref_exprt to represent a field reference

### DIFF
--- a/src/java_bytecode/java_bytecode_parse_tree.h
+++ b/src/java_bytecode/java_bytecode_parse_tree.h
@@ -232,7 +232,7 @@ public:
     const typet &type,
     const irep_idt &component_name,
     const irep_idt &class_name)
-    : exprt(ID_fieldref, type)
+    : exprt(ID_empty_string, type)
   {
     set(ID_class, class_name);
     set(ID_component_name, component_name);

--- a/src/java_bytecode/java_bytecode_parse_tree.h
+++ b/src/java_bytecode/java_bytecode_parse_tree.h
@@ -222,4 +222,21 @@ public:
   }
 };
 
+/// Represents the argument of an instruction that uses a CONSTANT_Fieldref
+/// This is used for example as an argument to a getstatic and putstatic
+/// instruction
+class fieldref_exprt : public exprt
+{
+public:
+  fieldref_exprt(
+    const typet &type,
+    const irep_idt &component_name,
+    const irep_idt &class_name)
+    : exprt(ID_fieldref, type)
+  {
+    set(ID_class, class_name);
+    set(ID_component_name, component_name);
+  }
+};
+
 #endif // CPROVER_JAVA_BYTECODE_JAVA_BYTECODE_PARSE_TREE_H

--- a/src/java_bytecode/java_bytecode_parser.cpp
+++ b/src/java_bytecode/java_bytecode_parser.cpp
@@ -537,9 +537,8 @@ void java_bytecode_parsert::rconstant_pool()
         symbol_typet class_symbol=
           java_classname(id2string(class_name_entry.s));
 
-        exprt fieldref("fieldref", type);
-        fieldref.set(ID_class, class_symbol.get_identifier());
-        fieldref.set(ID_component_name, name_entry.s);
+        fieldref_exprt fieldref(
+          type, name_entry.s, class_symbol.get_identifier());
 
         it->expr=fieldref;
       }

--- a/src/util/irep_ids.def
+++ b/src/util/irep_ids.def
@@ -840,7 +840,6 @@ IREP_ID_TWO(type_variables, #type_variables)
 IREP_ID_ONE(havoc_object)
 IREP_ID_TWO(overflow_shl, overflow-shl)
 IREP_ID_TWO(C_no_initialization_required, #no_initialization_required)
-IREP_ID_ONE(fieldref)
 
 #undef IREP_ID_ONE
 #undef IREP_ID_TWO

--- a/src/util/irep_ids.def
+++ b/src/util/irep_ids.def
@@ -840,6 +840,7 @@ IREP_ID_TWO(type_variables, #type_variables)
 IREP_ID_ONE(havoc_object)
 IREP_ID_TWO(overflow_shl, overflow-shl)
 IREP_ID_TWO(C_no_initialization_required, #no_initialization_required)
+IREP_ID_ONE(fieldref)
 
 #undef IREP_ID_ONE
 #undef IREP_ID_TWO


### PR DESCRIPTION
Refactoring for some forthcoming unit tests for lamdbas - pull out this naked exprt into a reasonable type and removed a magic string while we're at it. 