### PR TITLE
Add source location to code added by preprocessing

### DIFF
--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -108,6 +108,12 @@ public:
     copy_to_operands(code);
   }
 
+  void add(codet code, const source_locationt &loc)
+  {
+    code.add_source_location() = loc;
+    add(code);
+  }
+
   void append(const code_blockt &extra_block);
 
   // This is the closing '}' or 'END' at the end of a block


### PR DESCRIPTION
When the String preprocessing adds code to populate some functions, we
should associate a code location to these instructions.
Otherwise this could in particular lead to problem with coverage
instrumentation which would not know what instruction to instrument, and
may not instrument the function at all.