### PR TITLE
Reaching definitions with sharing

### DIFF
--- a/src/analyses/CMakeLists.txt
+++ b/src/analyses/CMakeLists.txt
@@ -1,4 +1,9 @@
 file(GLOB_RECURSE sources "*.cpp" "*.h")
+list(REMOVE_ITEM sources
+    ${CMAKE_CURRENT_SOURCE_DIR}/reaching_definitions.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/reaching_definitions_without_sharing.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/reaching_definitions_with_sharing.cpp
+)
 add_library(analyses ${sources})
 
 generic_includes(analyses)

--- a/src/analyses/Makefile
+++ b/src/analyses/Makefile
@@ -22,7 +22,6 @@ SRC = ai.cpp \
       local_may_alias.cpp \
       locals.cpp \
       natural_loops.cpp \
-      reaching_definitions.cpp \
       static_analysis.cpp \
       uncaught_exceptions_analysis.cpp \
       uninitialized_domain.cpp \

--- a/src/analyses/dependence_graph.cpp
+++ b/src/analyses/dependence_graph.cpp
@@ -153,8 +153,7 @@ void dep_graph_domaint::data_dependencies(
   data_deps.clear();
 
   // TODO use (future) reaching-definitions-dereferencing rw_set
-  value_setst &value_sets=
-    dep_graph.reaching_definitions().get_value_sets();
+  value_setst &value_sets = *dep_graph.reaching_definitions().value_sets;
   rw_range_set_value_sett rw_set(ns, value_sets);
   goto_rw(to, rw_set);
 

--- a/src/analyses/dependence_graph.h
+++ b/src/analyses/dependence_graph.h
@@ -20,7 +20,7 @@ Date: August 2013
 
 #include "ai.h"
 #include "cfg_dominators.h"
-#include "reaching_definitions.h"
+#include "reaching_definitions_without_sharing.h"
 
 class dependence_grapht;
 

--- a/src/analyses/reaching_definitions.cpp
+++ b/src/analyses/reaching_definitions.cpp
@@ -1,3 +1,13 @@
+/*******************************************************************\
+
+Module: Range-based reaching definitions analysis (following Field-
+        Sensitive Program Dependence Analysis, Litvak et al., FSE 2010)
+
+Author: Michael Tautschnig
+
+Date: February 2013
+
+\*******************************************************************/
 
 template <bool remove_locals>
 void rd_range_domain_baset<remove_locals>::transform(
@@ -6,7 +16,7 @@ void rd_range_domain_baset<remove_locals>::transform(
   ai_baset &ai,
   const namespacet &ns)
 {
-  assert(bv_container);
+  PRECONDITION(bv_container);
 
   // kill values
   if(from->is_dead())
@@ -106,7 +116,7 @@ void rd_range_domain_baset<remove_locals>::kill_inf(
   const irep_idt &identifier,
   const range_spect &range_start)
 {
-  assert(range_start>=0);
+  PRECONDITION(range_start >= 0);
 
 #if 0
   valuest::iterator entry=values.find(identifier);
@@ -142,7 +152,7 @@ void rd_range_domain_baset<remove_locals>::kill(
   const range_spect &range_start,
   const range_spect &range_end)
 {
-  assert(range_start>=0);
+  PRECONDITION(range_start >= 0);
   // -1 for objects of infinite/unknown size
   if(range_end == -1)
   {
@@ -150,7 +160,7 @@ void rd_range_domain_baset<remove_locals>::kill(
     return;
   }
 
-  assert(range_end > range_start);
+  PRECONDITION(range_end > range_start);
 
   values_innert &current_values = get_values_inner(identifier);
   values_innert new_values;

--- a/src/analyses/reaching_definitions.cpp
+++ b/src/analyses/reaching_definitions.cpp
@@ -1,73 +1,11 @@
-/*******************************************************************\
 
-Module: Range-based reaching definitions analysis (following Field-
-        Sensitive Program Dependence Analysis, Litvak et al., FSE 2010)
-
-Author: Michael Tautschnig
-
-Date: February 2013
-
-\*******************************************************************/
-
-/// \file
-/// Range-based reaching definitions analysis (following Field- Sensitive
-///   Program Dependence Analysis, Litvak et al., FSE 2010)
-
-#include "reaching_definitions.h"
-
-#include <memory>
-
-#include <util/pointer_offset_size.h>
-#include <util/prefix.h>
-#include <util/make_unique.h>
-
-#include <pointer-analysis/value_set_analysis_fi.h>
-
-#include "is_threaded.h"
-#include "dirty.h"
-
-reaching_definitions_analysist::reaching_definitions_analysist(
-  const namespacet &_ns):
-    concurrency_aware_ait<rd_range_domaint>(),
-    ns(_ns)
-{
-}
-
-reaching_definitions_analysist::~reaching_definitions_analysist()=default;
-
-void rd_range_domaint::populate_cache(const irep_idt &identifier) const
-{
-  assert(bv_container);
-
-  valuest::const_iterator v_entry=values.find(identifier);
-  if(v_entry==values.end() ||
-     v_entry->second.empty())
-    return;
-
-  ranges_at_loct &export_entry=export_cache[identifier];
-
-  for(const auto &id : v_entry->second)
-  {
-    const reaching_definitiont &v=bv_container->get(id);
-
-    export_entry[v.definition_at].insert(
-      std::make_pair(v.bit_begin, v.bit_end));
-  }
-}
-
-void rd_range_domaint::transform(
+template <bool remove_locals>
+void rd_range_domain_baset<remove_locals>::transform(
   locationt from,
   locationt to,
   ai_baset &ai,
   const namespacet &ns)
 {
-  reaching_definitions_analysist *rd=
-    dynamic_cast<reaching_definitions_analysist*>(&ai);
-  INVARIANT_STRUCTURED(
-    rd!=nullptr,
-    bad_cast_exceptiont,
-    "ai has type reaching_definitions_analysist");
-
   assert(bv_container);
 
   // kill values
@@ -75,19 +13,19 @@ void rd_range_domaint::transform(
     transform_dead(ns, from);
   // kill thread-local values
   else if(from->is_start_thread())
-    transform_start_thread(ns, *rd);
+    transform_start_thread(ns, ai);
   // do argument-to-parameter assignments
   else if(from->is_function_call())
-    transform_function_call(ns, from, to, *rd);
+    transform_function_call(ns, from, to, ai);
   // cleanup parameters
   else if(from->is_end_function())
-    transform_end_function(ns, from, to, *rd);
+    transform_end_function(ns, from, to, ai);
   // lhs assignments
   else if(from->is_assign())
-    transform_assign(ns, from, from, *rd);
+    transform_assign(ns, from, from, ai);
   // initial (non-deterministic) value
   else if(from->is_decl())
-    transform_assign(ns, from, from, *rd);
+    transform_assign(ns, from, from, ai);
 
 #if 0
   // handle return values
@@ -124,182 +62,16 @@ void rd_range_domaint::transform(
 #endif
 }
 
-void rd_range_domaint::transform_dead(
-  const namespacet &ns,
-  locationt from)
-{
-  const irep_idt &identifier=
-    to_symbol_expr(to_code_dead(from->code).symbol()).get_identifier();
-
-  valuest::iterator entry=values.find(identifier);
-
-  if(entry!=values.end())
-  {
-    values.erase(entry);
-    export_cache.erase(identifier);
-  }
-}
-
-void rd_range_domaint::transform_start_thread(
-  const namespacet &ns,
-  reaching_definitions_analysist &rd)
-{
-  for(valuest::iterator it=values.begin();
-      it!=values.end();
-      ) // no ++it
-  {
-    const irep_idt &identifier=it->first;
-
-    if(!ns.lookup(identifier).is_shared() &&
-       !rd.get_is_dirty()(identifier))
-    {
-      export_cache.erase(identifier);
-
-      valuest::iterator next=it;
-      ++next;
-      values.erase(it);
-      it=next;
-    }
-    else
-      ++it;
-  }
-}
-
-void rd_range_domaint::transform_function_call(
+template <bool remove_locals>
+void rd_range_domain_baset<remove_locals>::transform_assign(
   const namespacet &ns,
   locationt from,
   locationt to,
-  reaching_definitions_analysist &rd)
+  ai_baset &ai)
 {
-  const code_function_callt &code=to_code_function_call(from->code);
+  infot info = get_info(ai);
 
-  // only if there is an actual call, i.e., we have a body
-  if(from->function != to->function)
-  {
-    for(valuest::iterator it=values.begin();
-        it!=values.end();
-       ) // no ++it
-    {
-      const irep_idt &identifier=it->first;
-
-      // dereferencing may introduce extra symbols
-      const symbolt *sym;
-      if((ns.lookup(identifier, sym) ||
-          !sym->is_shared()) &&
-         !rd.get_is_dirty()(identifier))
-      {
-        export_cache.erase(identifier);
-
-        valuest::iterator next=it;
-        ++next;
-        values.erase(it);
-        it=next;
-      }
-      else
-        ++it;
-    }
-
-    const symbol_exprt &fn_symbol_expr=to_symbol_expr(code.function());
-    const code_typet &code_type=
-      to_code_type(ns.lookup(fn_symbol_expr.get_identifier()).type);
-
-    for(const auto &param : code_type.parameters())
-    {
-      const irep_idt &identifier=param.get_identifier();
-
-      if(identifier.empty())
-        continue;
-
-      range_spect size=
-        to_range_spect(pointer_offset_bits(param.type(), ns));
-      gen(from, identifier, 0, size);
-    }
-  }
-  else
-  {
-    // handle return values of undefined functions
-    const code_function_callt &code=to_code_function_call(from->code);
-
-    if(code.lhs().is_not_nil())
-      transform_assign(ns, from, from, rd);
-  }
-}
-
-void rd_range_domaint::transform_end_function(
-  const namespacet &ns,
-  locationt from,
-  locationt to,
-  reaching_definitions_analysist &rd)
-{
-  goto_programt::const_targett call=to;
-  --call;
-  const code_function_callt &code=to_code_function_call(call->code);
-
-  valuest new_values;
-  new_values.swap(values);
-  values=rd[call].values;
-
-  for(const auto &new_value : new_values)
-  {
-    const irep_idt &identifier=new_value.first;
-
-    if(!rd.get_is_threaded()(call) ||
-       (!ns.lookup(identifier).is_shared() &&
-        !rd.get_is_dirty()(identifier)))
-    {
-      for(const auto &id : new_value.second)
-      {
-        const reaching_definitiont &v=bv_container->get(id);
-        kill(v.identifier, v.bit_begin, v.bit_end);
-      }
-    }
-
-    for(const auto &id : new_value.second)
-    {
-      const reaching_definitiont &v=bv_container->get(id);
-      gen(v.definition_at, v.identifier, v.bit_begin, v.bit_end);
-    }
-  }
-
-  const code_typet &code_type=
-    to_code_type(ns.lookup(from->function).type);
-
-  for(const auto &param : code_type.parameters())
-  {
-    const irep_idt &identifier=param.get_identifier();
-
-    if(identifier.empty())
-      continue;
-
-    valuest::iterator entry=values.find(identifier);
-
-    if(entry!=values.end())
-    {
-      values.erase(entry);
-      export_cache.erase(identifier);
-    }
-  }
-
-  // handle return values
-  if(code.lhs().is_not_nil())
-  {
-#if 0
-    rd_range_domaint *rd_state=
-      dynamic_cast<rd_range_domaint*>(&(rd.get_state(call)));
-    assert(rd_state!=0);
-    rd_state->
-#endif
-      transform_assign(ns, from, call, rd);
-  }
-}
-
-void rd_range_domaint::transform_assign(
-  const namespacet &ns,
-  locationt from,
-  locationt to,
-  reaching_definitions_analysist &rd)
-{
-  rw_range_set_value_sett rw_set(ns, rd.get_value_sets());
+  rw_range_set_value_sett rw_set(ns, info.value_sets);
   goto_rw(to, rw_set);
   const bool is_must_alias=rw_set.get_w_set().size()==1;
 
@@ -317,10 +89,10 @@ void rd_range_domaint::transform_assign(
 
     const range_domaint &ranges=rw_set.get_ranges(it);
 
-    if(is_must_alias &&
-       (!rd.get_is_threaded()(from) ||
-        (!symbol_ptr->is_shared() &&
-         !rd.get_is_dirty()(identifier))))
+    if(
+      is_must_alias &&
+      (!info.is_threaded(from) ||
+       (!symbol_ptr->is_shared() && !info.is_dirty(identifier))))
       for(const auto &range : ranges)
         kill(identifier, range.first, range.second);
 
@@ -329,107 +101,8 @@ void rd_range_domaint::transform_assign(
   }
 }
 
-void rd_range_domaint::kill(
-  const irep_idt &identifier,
-  const range_spect &range_start,
-  const range_spect &range_end)
-{
-  assert(range_start>=0);
-  // -1 for objects of infinite/unknown size
-  if(range_end==-1)
-  {
-    kill_inf(identifier, range_start);
-    return;
-  }
-
-  assert(range_end>range_start);
-
-  valuest::iterator entry=values.find(identifier);
-  if(entry==values.end())
-    return;
-
-  bool clear_export_cache=false;
-  values_innert new_values;
-
-  for(values_innert::iterator
-      it=entry->second.begin();
-      it!=entry->second.end();
-     ) // no ++it
-  {
-    const reaching_definitiont &v=bv_container->get(*it);
-
-    if(v.bit_begin >= range_end)
-      ++it;
-    else if(v.bit_end!=-1 &&
-            v.bit_end <= range_start)
-      ++it;
-    else if(v.bit_begin >= range_start &&
-            v.bit_end!=-1 &&
-            v.bit_end <= range_end) // rs <= a < b <= re
-    {
-      clear_export_cache=true;
-
-      entry->second.erase(it++);
-    }
-    else if(v.bit_begin >= range_start) // rs <= a <= re < b
-    {
-      clear_export_cache=true;
-
-      reaching_definitiont v_new=v;
-      v_new.bit_begin=range_end;
-      new_values.insert(bv_container->add(v_new));
-
-      entry->second.erase(it++);
-    }
-    else if(v.bit_end==-1 ||
-            v.bit_end > range_end) // a <= rs < re < b
-    {
-      clear_export_cache=true;
-
-      reaching_definitiont v_new=v;
-      v_new.bit_end=range_start;
-
-      reaching_definitiont v_new2=v;
-      v_new2.bit_begin=range_end;
-
-      new_values.insert(bv_container->add(v_new));
-      new_values.insert(bv_container->add(v_new2));
-
-      entry->second.erase(it++);
-    }
-    else // a <= rs < b <= re
-    {
-      clear_export_cache=true;
-
-      reaching_definitiont v_new=v;
-      v_new.bit_end=range_start;
-      new_values.insert(bv_container->add(v_new));
-
-      entry->second.erase(it++);
-    }
-  }
-
-  if(clear_export_cache)
-    export_cache.erase(identifier);
-
-  values_innert::iterator it=entry->second.begin();
-  for(const auto &id : new_values)
-  {
-    while(it!=entry->second.end() && *it<id)
-      ++it;
-    if(it==entry->second.end() || id<*it)
-    {
-      entry->second.insert(it, id);
-    }
-    else if(it!=entry->second.end())
-    {
-      assert(*it==id);
-      ++it;
-    }
-  }
-}
-
-void rd_range_domaint::kill_inf(
+template <bool remove_locals>
+void rd_range_domain_baset<remove_locals>::kill_inf(
   const irep_idt &identifier,
   const range_spect &range_start)
 {
@@ -440,7 +113,7 @@ void rd_range_domaint::kill_inf(
   if(entry==values.end())
     return;
 
-  XXX export_cache_available=false;
+  bool export_cache_available=false;
 
   // makes the analysis underapproximating
   rangest &ranges=entry->second;
@@ -463,256 +136,9 @@ void rd_range_domaint::kill_inf(
 #endif
 }
 
-bool rd_range_domaint::gen(
-  locationt from,
-  const irep_idt &identifier,
-  const range_spect &range_start,
-  const range_spect &range_end)
-{
-  // objects of size 0 like union U { signed : 0; };
-  if(range_start==0 && range_end==0)
-    return false;
-
-  assert(range_start>=0);
-
-  // -1 for objects of infinite/unknown size
-  assert(range_end>range_start || range_end==-1);
-
-  reaching_definitiont v;
-  v.identifier=identifier;
-  v.definition_at=from;
-  v.bit_begin=range_start;
-  v.bit_end=range_end;
-
-  if(!values[identifier].insert(bv_container->add(v)).second)
-    return false;
-
-  export_cache.erase(identifier);
-
-#if 0
-  range_spect merged_range_end=range_end;
-
-  std::pair<valuest::iterator, bool> entry=
-    values.insert(std::make_pair(identifier, rangest()));
-  rangest &ranges=entry.first->second;
-
-  if(!entry.second)
-  {
-    for(rangest::iterator it=ranges.begin();
-        it!=ranges.end();
-        ) // no ++it
-    {
-      if(it->second.second!=from ||
-         (it->second.first!=-1 && it->second.first <= range_start) ||
-         (range_end!=-1 && it->first >= range_end))
-        ++it;
-      else if(it->first > range_start) // rs < a < b,re
-      {
-        if(range_end!=-1)
-          merged_range_end=std::max(range_end, it->second.first);
-        ranges.erase(it++);
-      }
-      else if(it->second.first==-1 ||
-              (range_end!=-1 &&
-               it->second.first >= range_end)) // a <= rs < re <= b
-      {
-        // nothing to do
-        return false;
-      }
-      else // a <= rs < b < re
-      {
-        it->second.first=range_end;
-        return true;
-      }
-    }
-  }
-
-  ranges.insert(std::make_pair(
-      range_start,
-      std::make_pair(merged_range_end, from)));
-#endif
-
-  return true;
-}
-
-void rd_range_domaint::output(std::ostream &out) const
-{
-  out << "Reaching definitions:\n";
-
-  if(has_values.is_known())
-  {
-    out << has_values.to_string() << '\n';
-    return;
-  }
-
-  for(const auto &value : values)
-  {
-    const irep_idt &identifier=value.first;
-
-    const ranges_at_loct &ranges=get(identifier);
-
-    out << "  " << identifier << "[";
-
-    for(ranges_at_loct::const_iterator itl=ranges.begin();
-        itl!=ranges.end();
-        ++itl)
-      for(rangest::const_iterator itr=itl->second.begin();
-          itr!=itl->second.end();
-          ++itr)
-      {
-        if(itr!=itl->second.begin() ||
-           itl!=ranges.begin())
-          out << ";";
-
-        out << itr->first << ":" << itr->second;
-        out << "@" << itl->first->location_number;
-      }
-
-    out << "]\n";
-
-    clear_cache(identifier);
-  }
-}
-
-/// \return returns true iff there is something new
-bool rd_range_domaint::merge_inner(
-  values_innert &dest,
-  const values_innert &other)
-{
-  bool more=false;
-
-#if 0
-  ranges_at_loct::iterator itr=it->second.begin();
-  for(const auto &o : ito->second)
-  {
-    while(itr!=it->second.end() && itr->first<o.first)
-      ++itr;
-    if(itr==it->second.end() || o.first<itr->first)
-    {
-      it->second.insert(o);
-      more=true;
-    }
-    else if(itr!=it->second.end())
-    {
-      assert(itr->first==o.first);
-
-      for(const auto &o_range : o.second)
-        more=gen(itr->second, o_range.first, o_range.second) ||
-          more;
-
-      ++itr;
-    }
-  }
-#else
-  values_innert::iterator itr=dest.begin();
-  for(const auto &id : other)
-  {
-    while(itr!=dest.end() && *itr<id)
-      ++itr;
-    if(itr==dest.end() || id<*itr)
-    {
-      dest.insert(itr, id);
-      more=true;
-    }
-    else if(itr!=dest.end())
-    {
-      assert(*itr==id);
-      ++itr;
-    }
-  }
-#endif
-
-  return more;
-}
-
-/// \return returns true iff there is something new
-bool rd_range_domaint::merge(
-  const rd_range_domaint &other,
-  locationt from,
-  locationt to)
-{
-  bool changed=has_values.is_false();
-  has_values=tvt::unknown();
-
-  valuest::iterator it=values.begin();
-  for(const auto &value : other.values)
-  {
-    while(it!=values.end() && it->first<value.first)
-      ++it;
-    if(it==values.end() || value.first<it->first)
-    {
-      values.insert(value);
-      changed=true;
-    }
-    else if(it!=values.end())
-    {
-      assert(it->first==value.first);
-
-      if(merge_inner(it->second, value.second))
-      {
-        changed=true;
-        export_cache.erase(it->first);
-      }
-
-      ++it;
-    }
-  }
-
-  return changed;
-}
-
-/// \return returns true iff there is something new
-bool rd_range_domaint::merge_shared(
-  const rd_range_domaint &other,
-  goto_programt::const_targett from,
-  goto_programt::const_targett to,
-  const namespacet &ns)
-{
-  // TODO: dirty vars
-#if 0
-  reaching_definitions_analysist *rd=
-    dynamic_cast<reaching_definitions_analysist*>(&ai);
-  assert(rd!=0);
-#endif
-
-  bool changed=has_values.is_false();
-  has_values=tvt::unknown();
-
-  valuest::iterator it=values.begin();
-  for(const auto &value : other.values)
-  {
-    const irep_idt &identifier=value.first;
-
-    if(!ns.lookup(identifier).is_shared()
-       /*&& !rd.get_is_dirty()(identifier)*/)
-      continue;
-
-    while(it!=values.end() && it->first<value.first)
-      ++it;
-    if(it==values.end() || value.first<it->first)
-    {
-      values.insert(value);
-      changed=true;
-    }
-    else if(it!=values.end())
-    {
-      assert(it->first==value.first);
-
-      if(merge_inner(it->second, value.second))
-      {
-        changed=true;
-        export_cache.erase(it->first);
-      }
-
-      ++it;
-    }
-  }
-
-  return changed;
-}
-
-const rd_range_domaint::ranges_at_loct &rd_range_domaint::get(
-  const irep_idt &identifier) const
+template <bool remove_locals>
+const typename rd_range_domain_baset<remove_locals>::ranges_at_loct &
+rd_range_domain_baset<remove_locals>::get(const irep_idt &identifier) const
 {
   populate_cache(identifier);
 
@@ -724,18 +150,4 @@ const rd_range_domaint::ranges_at_loct &rd_range_domaint::get(
     return empty;
   else
     return entry->second;
-}
-
-void reaching_definitions_analysist::initialize(
-  const goto_functionst &goto_functions)
-{
-  auto value_sets_=util_make_unique<value_set_analysis_fit>(ns);
-  (*value_sets_)(goto_functions);
-  value_sets=std::move(value_sets_);
-
-  is_threaded=util_make_unique<is_threadedt>(goto_functions);
-
-  is_dirty=util_make_unique<dirtyt>(goto_functions);
-
-  concurrency_aware_ait<rd_range_domaint>::initialize(goto_functions);
 }

--- a/src/analyses/reaching_definitions.cpp
+++ b/src/analyses/reaching_definitions.cpp
@@ -205,22 +205,6 @@ void rd_range_domain_baset<remove_locals>::kill(
 }
 
 template <bool remove_locals>
-const typename rd_range_domain_baset<remove_locals>::ranges_at_loct &
-rd_range_domain_baset<remove_locals>::get(const irep_idt &identifier) const
-{
-  populate_cache(identifier);
-
-  static ranges_at_loct empty;
-
-  export_cachet::const_iterator entry=export_cache.find(identifier);
-
-  if(entry==export_cache.end())
-    return empty;
-  else
-    return entry->second;
-}
-
-template <bool remove_locals>
 void rd_range_domain_baset<remove_locals>::output(
   const irep_idt &identifier,
   std::ostream &out) const

--- a/src/analyses/reaching_definitions.cpp
+++ b/src/analyses/reaching_definitions.cpp
@@ -151,3 +151,31 @@ rd_range_domain_baset<remove_locals>::get(const irep_idt &identifier) const
   else
     return entry->second;
 }
+
+template <bool remove_locals>
+void rd_range_domain_baset<remove_locals>::output(
+  const irep_idt &identifier,
+  std::ostream &out) const
+{
+  const ranges_at_loct &ranges = get(identifier);
+
+  out << "  " << identifier << "[";
+
+  for(typename ranges_at_loct::const_iterator itl = ranges.begin();
+      itl != ranges.end();
+      ++itl)
+    for(typename rangest::const_iterator itr = itl->second.begin();
+        itr != itl->second.end();
+        ++itr)
+    {
+      if(itr != itl->second.begin() || itl != ranges.begin())
+        out << ";";
+
+      out << itr->first << ":" << itr->second;
+      out << "@" << itl->first->location_number;
+    }
+
+  out << "]\n";
+
+  clear_cache(identifier);
+}

--- a/src/analyses/reaching_definitions.h
+++ b/src/analyses/reaching_definitions.h
@@ -105,6 +105,8 @@ inline bool operator<(
   return false;
 }
 
+namespace
+{
 struct infot
 {
   infot(value_setst &value_sets, is_threadedt &is_threaded, dirtyt &is_dirty)
@@ -116,6 +118,10 @@ struct infot
   is_threadedt &is_threaded;
   dirtyt &is_dirty;
 };
+
+typedef std::set<std::size_t> values_innert;
+std::set<std::size_t> values_inner_empty;
+}
 
 template <bool remove_locals>
 class rd_range_domain_baset : public ai_domain_baset
@@ -201,10 +207,10 @@ protected:
     locationt to,
     ai_baset &ai);
 
-  virtual void kill(
+  void kill(
     const irep_idt &identifier,
     const range_spect &range_start,
-    const range_spect &range_end) = 0;
+    const range_spect &range_end);
 
   void kill_inf(
     const irep_idt &identifier,
@@ -219,6 +225,8 @@ protected:
   virtual void output(std::ostream &out) const = 0;
 
   void output(const irep_idt &identifier, std::ostream &out) const;
+
+  virtual values_innert &get_values_inner(const irep_idt &identifier) = 0;
 };
 
 template <typename rd_range_domain>

--- a/src/analyses/reaching_definitions.h
+++ b/src/analyses/reaching_definitions.h
@@ -17,6 +17,7 @@ Date: February 2013
 #define CPROVER_ANALYSES_REACHING_DEFINITIONS_H
 
 #include <util/base_exceptions.h>
+#include <util/invariant.h>
 #include <util/make_unique.h>
 #include <util/pointer_offset_size.h>
 #include <util/prefix.h>
@@ -42,7 +43,7 @@ class sparse_bitvector_analysist
 public:
   const V &get(const std::size_t value_index) const
   {
-    assert(value_index<values.size());
+    PRECONDITION(value_index < values.size());
     return values[value_index]->first;
   }
 
@@ -98,9 +99,10 @@ inline bool operator<(
   if(b.bit_end<a.bit_end)
     return false;
 
-  // we do not expect comparison of unrelated definitions
-  // as this operator< is only used in sparse_bitvector_analysist
-  assert(a.identifier==b.identifier);
+  INVARIANT(
+    a.identifier == b.identifier,
+    "No comparison of unrelated definitions"
+    "as operator< is only used in sparse_bitvector_analysist");
 
   return false;
 }

--- a/src/analyses/reaching_definitions.h
+++ b/src/analyses/reaching_definitions.h
@@ -155,10 +155,10 @@ public:
   typedef std::multimap<range_spect, range_spect> rangest;
   typedef std::map<locationt, rangest> ranges_at_loct;
 
-  const ranges_at_loct &get(const irep_idt &identifier) const;
+  virtual const ranges_at_loct &get(const irep_idt &identifier) const = 0;
   void clear_cache(const irep_idt &identifier) const
   {
-    export_cache[identifier].clear();
+    export_cache.erase(identifier);
   }
 
 protected:
@@ -182,8 +182,6 @@ protected:
   mutable export_cachet export_cache;
 
   virtual infot get_info(ai_baset &ai) = 0;
-
-  virtual void populate_cache(const irep_idt &identifier) const = 0;
 
   virtual void transform_dead(const namespacet &ns, locationt from) = 0;
 

--- a/src/analyses/reaching_definitions.h
+++ b/src/analyses/reaching_definitions.h
@@ -128,22 +128,22 @@ public:
   void make_top() final override
   {
     values.clear();
-    if(bv_container)
-      bv_container->clear();
+    bv_container = nullptr;
     has_values=tvt(true);
   }
 
   void make_bottom() final override
   {
     values.clear();
-    if(bv_container)
-      bv_container->clear();
+    bv_container = nullptr;
     has_values=tvt(false);
   }
 
   void make_entry() final override
   {
-    make_top();
+    values.clear();
+    bv_container = nullptr;
+    has_values = tvt::unknown();
   }
 
   bool is_top() const override final

--- a/src/analyses/reaching_definitions.h
+++ b/src/analyses/reaching_definitions.h
@@ -217,6 +217,8 @@ protected:
     const range_spect &range_end) = 0;
 
   virtual void output(std::ostream &out) const = 0;
+
+  void output(const irep_idt &identifier, std::ostream &out) const;
 };
 
 template <typename rd_range_domain>

--- a/src/analyses/reaching_definitions_with_sharing.cpp
+++ b/src/analyses/reaching_definitions_with_sharing.cpp
@@ -1,0 +1,397 @@
+
+template <bool remove_locals>
+infot rd_range_domain_with_sharingt<remove_locals>::get_info(ai_baset &ai)
+{
+  reaching_definitions_with_sharing_analysist *rd =
+    dynamic_cast<reaching_definitions_with_sharing_analysist *>(&ai);
+  INVARIANT_STRUCTURED(
+    rd != nullptr,
+    bad_cast_exceptiont,
+    "ai has type reaching_definitions_with_sharing_analysist");
+
+  return infot(*rd->value_sets, *rd->is_threaded, *rd->is_dirty);
+}
+
+template <bool remove_locals>
+void rd_range_domain_with_sharingt<remove_locals>::populate_cache(
+  const irep_idt &identifier) const
+{
+  assert(bv_container);
+
+  auto &r = values.find(identifier);
+
+  if(!r.second)
+    return;
+
+  const values_innert &inner = r.first;
+
+  if(inner.empty())
+    return;
+
+  ranges_at_loct &export_entry = export_cache[identifier];
+
+  for(const auto &id : inner)
+  {
+    const reaching_definitiont &v = bv_container->get(id);
+
+    export_entry[v.definition_at].insert(
+      std::make_pair(v.bit_begin, v.bit_end));
+  }
+}
+
+template <bool remove_locals>
+void rd_range_domain_with_sharingt<remove_locals>::transform_dead(
+  const namespacet &ns,
+  locationt from)
+{
+  const irep_idt &identifier =
+    to_symbol_expr(to_code_dead(from->code).symbol()).get_identifier();
+
+  values.erase(identifier);
+}
+
+template <bool remove_locals>
+void rd_range_domain_with_sharingt<remove_locals>::transform_start_thread(
+  const namespacet &ns,
+  ai_baset &ai)
+{
+  throw "transform_start_thread() unimplemented";
+}
+
+template <bool remove_locals>
+void rd_range_domain_with_sharingt<remove_locals>::transform_function_call(
+  const namespacet &ns,
+  locationt from,
+  locationt to,
+  ai_baset &ai)
+{
+  infot info = get_info(ai);
+
+  const code_function_callt &code = to_code_function_call(from->code);
+
+  goto_programt::const_targett next = from;
+  ++next;
+
+  // only if there is an actual call, i.e., we have a body
+  if(next != to)
+  {
+    if(remove_locals)
+    {
+      typename valuest::viewt view;
+      values.get_view(view);
+
+      for(const auto &p : view)
+      {
+        const irep_idt &identifier = p.first;
+
+        const symbolt *sym;
+
+        if(
+          (ns.lookup(identifier, sym) || !sym->is_shared()) &&
+          !info.is_dirty(identifier))
+        {
+          values.erase(identifier);
+        }
+      }
+    }
+
+    const symbol_exprt &fn_symbol_expr = to_symbol_expr(code.function());
+    const code_typet &code_type =
+      to_code_type(ns.lookup(fn_symbol_expr.get_identifier()).type);
+
+    for(const auto &param : code_type.parameters())
+    {
+      const irep_idt &identifier = param.get_identifier();
+
+      if(identifier.empty())
+        continue;
+
+      range_spect size = to_range_spect(pointer_offset_bits(param.type(), ns));
+      gen(from, identifier, 0, size);
+    }
+  }
+  else
+  {
+    // handle return values of undefined functions
+    const code_function_callt &code = to_code_function_call(from->code);
+
+    if(code.lhs().is_not_nil())
+      transform_assign(ns, from, from, ai);
+  }
+}
+
+template <bool remove_locals>
+void rd_range_domain_with_sharingt<remove_locals>::transform_end_function(
+  const namespacet &ns,
+  locationt from,
+  locationt to,
+  ai_baset &ai)
+{
+  goto_programt::const_targett call = to;
+  --call;
+  const code_function_callt &code = to_code_function_call(call->code);
+
+  if(remove_locals)
+  {
+    reaching_definitions_with_sharing_analysist *p =
+      dynamic_cast<reaching_definitions_with_sharing_analysist *>(&ai);
+    INVARIANT_STRUCTURED(
+      p != nullptr,
+      bad_cast_exceptiont,
+      "ai has type reaching_definitions_with_sharing_analysist");
+    reaching_definitions_with_sharing_analysist &rd = *p;
+
+    valuest new_values;
+    new_values.swap(values);
+    values = rd[call].values;
+
+    typename valuest::viewt view;
+    new_values.get_view(view);
+
+    infot info = get_info(ai);
+
+    for(const auto &new_value : view)
+    {
+      const irep_idt &identifier = new_value.first;
+
+      if(
+        !info.is_threaded(call) ||
+        (!ns.lookup(identifier).is_shared() && !info.is_dirty(identifier)))
+      {
+        for(const auto &id : new_value.second)
+        {
+          const reaching_definitiont &v = bv_container->get(id);
+          kill(v.identifier, v.bit_begin, v.bit_end);
+        }
+      }
+
+      for(const auto &id : new_value.second)
+      {
+        const reaching_definitiont &v = bv_container->get(id);
+        gen(v.definition_at, v.identifier, v.bit_begin, v.bit_end);
+      }
+    }
+  }
+
+  const code_typet &code_type = to_code_type(ns.lookup(from->function).type);
+
+  for(const auto &param : code_type.parameters())
+  {
+    const irep_idt &identifier = param.get_identifier();
+
+    if(identifier.empty())
+      continue;
+
+    values.erase(identifier);
+  }
+
+  // handle return values
+  if(code.lhs().is_not_nil())
+  {
+    transform_assign(ns, from, call, ai);
+  }
+}
+
+template <bool remove_locals>
+void rd_range_domain_with_sharingt<remove_locals>::kill(
+  const irep_idt &identifier,
+  const range_spect &range_start,
+  const range_spect &range_end)
+{
+  assert(range_start >= 0);
+  // -1 for objects of infinite/unknown size
+  if(range_end == -1)
+  {
+    kill_inf(identifier, range_start);
+    return;
+  }
+
+  assert(range_end > range_start);
+
+  auto &r = values.find(identifier);
+  if(!r.second)
+    return;
+
+  values_innert &current_values = r.first;
+  values_innert new_values;
+
+  for(typename values_innert::iterator it = current_values.begin();
+      it != current_values.end();) // no ++it
+  {
+    const reaching_definitiont &v = bv_container->get(*it);
+
+    if(v.bit_begin >= range_end)
+      ++it;
+    else if(v.bit_end != -1 && v.bit_end <= range_start)
+      ++it;
+    else if(
+      v.bit_begin >= range_start && v.bit_end != -1 &&
+      v.bit_end <= range_end) // rs <= a < b <= re
+    {
+      current_values.erase(it++);
+    }
+    else if(v.bit_begin >= range_start) // rs <= a <= re < b
+    {
+      reaching_definitiont v_new = v;
+      v_new.bit_begin = range_end;
+      new_values.insert(bv_container->add(v_new));
+
+      current_values.erase(it++);
+    }
+    else if(v.bit_end == -1 || v.bit_end > range_end) // a <= rs < re < b
+    {
+      reaching_definitiont v_new = v;
+      v_new.bit_end = range_start;
+
+      reaching_definitiont v_new2 = v;
+      v_new2.bit_begin = range_end;
+
+      new_values.insert(bv_container->add(v_new));
+      new_values.insert(bv_container->add(v_new2));
+
+      current_values.erase(it++);
+    }
+    else // a <= rs < b <= re
+    {
+      reaching_definitiont v_new = v;
+      v_new.bit_end = range_start;
+      new_values.insert(bv_container->add(v_new));
+
+      current_values.erase(it++);
+    }
+  }
+
+  current_values.insert(new_values.begin(), new_values.end());
+}
+
+template <bool remove_locals>
+bool rd_range_domain_with_sharingt<remove_locals>::gen(
+  locationt from,
+  const irep_idt &identifier,
+  const range_spect &range_start,
+  const range_spect &range_end)
+{
+  // objects of size 0 like union U { signed : 0; };
+  if(range_start == 0 && range_end == 0)
+    return false;
+
+  assert(range_start >= 0);
+
+  // -1 for objects of infinite/unknown size
+  assert(range_end > range_start || range_end == -1);
+
+  reaching_definitiont v;
+  v.identifier = identifier;
+  v.definition_at = from;
+  v.bit_begin = range_start;
+  v.bit_end = range_end;
+
+  size_t id = bv_container->add(v);
+
+  const auto &r = values[identifier].insert(id);
+  if(!r.second)
+    return false;
+
+  return true;
+}
+
+template <bool remove_locals>
+void rd_range_domain_with_sharingt<remove_locals>::output(
+  std::ostream &out) const
+{
+  out << "Reaching definitions:" << std::endl;
+
+  if(has_values.is_known())
+  {
+    out << has_values.to_string() << '\n';
+    return;
+  }
+
+  typename valuest::viewt view;
+  values.get_view(view);
+
+  for(const auto &value : view)
+  {
+    const irep_idt &identifier = value.first;
+    output(identifier, out);
+  }
+}
+
+/// \return returns true iff there is something new
+template <bool remove_locals>
+bool rd_range_domain_with_sharingt<remove_locals>::merge(
+  const rd_range_domain_with_sharingt &other,
+  locationt from,
+  locationt to)
+{
+  bool changed = false;
+
+  if(other.has_values.is_false())
+  {
+    assert(other.values.empty());
+    return false;
+  }
+
+  if(has_values.is_false())
+  {
+    assert(values.empty());
+
+    values = other.values;
+
+    assert(!other.has_values.is_true());
+    has_values = other.has_values;
+
+    return true;
+  }
+
+  rd_range_domain_with_sharingt &o =
+    const_cast<rd_range_domain_with_sharingt &>(other);
+  values.swap(o.values);
+
+  typename valuest::delta_viewt delta_view;
+  o.values.get_delta_view(values, delta_view);
+
+  for(const auto &element : delta_view)
+  {
+    bool in_both = element.in_both;
+    const irep_idt &k = element.k;
+    const values_innert &inner_other = element.m; // in other
+    const values_innert &inner = element.other_m; // in this
+
+    if(!in_both)
+    {
+      values.insert(k, inner_other);
+      changed = true;
+    }
+    else
+    {
+      if(inner != inner_other)
+      {
+        auto &v = values.find(k);
+        assert(v.second);
+
+        values_innert &inner = v.first;
+
+        size_t n = inner.size();
+        inner.insert(inner_other.begin(), inner_other.end());
+        if(inner.size() != n)
+          changed = true;
+      }
+    }
+  }
+
+  return changed;
+}
+
+/// \return returns true iff there is something new
+template <bool remove_locals>
+bool rd_range_domain_with_sharingt<remove_locals>::merge_shared(
+  const rd_range_domain_with_sharingt &other,
+  locationt from,
+  locationt to,
+  const namespacet &ns)
+{
+  throw "merge_shared() unimplemented";
+
+  return true;
+}

--- a/src/analyses/reaching_definitions_with_sharing.cpp
+++ b/src/analyses/reaching_definitions_with_sharing.cpp
@@ -1,3 +1,13 @@
+/*******************************************************************\
+
+Module: Range-based reaching definitions analysis (following Field-
+        Sensitive Program Dependence Analysis, Litvak et al., FSE 2010)
+
+Author: Michael Tautschnig
+
+Date: February 2013
+
+\*******************************************************************/
 
 template <bool remove_locals>
 infot rd_range_domain_with_sharingt<remove_locals>::get_info(ai_baset &ai)
@@ -13,11 +23,11 @@ infot rd_range_domain_with_sharingt<remove_locals>::get_info(ai_baset &ai)
 }
 
 template <bool remove_locals>
-const typename rd_range_domain_baset<remove_locals>::ranges_at_loct &
+const typename rd_range_domain_with_sharingt<remove_locals>::ranges_at_loct &
 rd_range_domain_with_sharingt<remove_locals>::get(
   const irep_idt &identifier) const
 {
-  assert(bv_container);
+  PRECONDITION(bv_container);
 
   static ranges_at_loct empty;
 
@@ -211,10 +221,10 @@ bool rd_range_domain_with_sharingt<remove_locals>::gen(
   if(range_start == 0 && range_end == 0)
     return false;
 
-  assert(range_start >= 0);
+  PRECONDITION(range_start >= 0);
 
   // -1 for objects of infinite/unknown size
-  assert(range_end > range_start || range_end == -1);
+  PRECONDITION(range_end > range_start || range_end == -1);
 
   reaching_definitiont v;
   v.identifier = identifier;
@@ -273,19 +283,16 @@ bool rd_range_domain_with_sharingt<remove_locals>::merge(
 {
   bool changed = false;
 
-  if(other.has_values.is_false())
+  if(other.is_bottom())
   {
-    assert(other.values.empty());
     return false;
   }
 
-  if(has_values.is_false())
+  if(is_bottom())
   {
-    assert(values.empty());
-
     values = other.values;
 
-    assert(!other.has_values.is_true());
+    INVARIANT(!other.is_top(), "top unused");
     has_values = other.has_values;
 
     return true;
@@ -315,7 +322,7 @@ bool rd_range_domain_with_sharingt<remove_locals>::merge(
       if(inner != inner_other)
       {
         auto &v = values.find(k);
-        assert(v.second);
+        INVARIANT(v.second, "key exists as in_both is true");
 
         values_innert &inner = v.first;
 

--- a/src/analyses/reaching_definitions_with_sharing.cpp
+++ b/src/analyses/reaching_definitions_with_sharing.cpp
@@ -193,78 +193,6 @@ void rd_range_domain_with_sharingt<remove_locals>::transform_end_function(
 }
 
 template <bool remove_locals>
-void rd_range_domain_with_sharingt<remove_locals>::kill(
-  const irep_idt &identifier,
-  const range_spect &range_start,
-  const range_spect &range_end)
-{
-  assert(range_start >= 0);
-  // -1 for objects of infinite/unknown size
-  if(range_end == -1)
-  {
-    kill_inf(identifier, range_start);
-    return;
-  }
-
-  assert(range_end > range_start);
-
-  auto &r = values.find(identifier);
-  if(!r.second)
-    return;
-
-  values_innert &current_values = r.first;
-  values_innert new_values;
-
-  for(typename values_innert::iterator it = current_values.begin();
-      it != current_values.end();) // no ++it
-  {
-    const reaching_definitiont &v = bv_container->get(*it);
-
-    if(v.bit_begin >= range_end)
-      ++it;
-    else if(v.bit_end != -1 && v.bit_end <= range_start)
-      ++it;
-    else if(
-      v.bit_begin >= range_start && v.bit_end != -1 &&
-      v.bit_end <= range_end) // rs <= a < b <= re
-    {
-      current_values.erase(it++);
-    }
-    else if(v.bit_begin >= range_start) // rs <= a <= re < b
-    {
-      reaching_definitiont v_new = v;
-      v_new.bit_begin = range_end;
-      new_values.insert(bv_container->add(v_new));
-
-      current_values.erase(it++);
-    }
-    else if(v.bit_end == -1 || v.bit_end > range_end) // a <= rs < re < b
-    {
-      reaching_definitiont v_new = v;
-      v_new.bit_end = range_start;
-
-      reaching_definitiont v_new2 = v;
-      v_new2.bit_begin = range_end;
-
-      new_values.insert(bv_container->add(v_new));
-      new_values.insert(bv_container->add(v_new2));
-
-      current_values.erase(it++);
-    }
-    else // a <= rs < b <= re
-    {
-      reaching_definitiont v_new = v;
-      v_new.bit_end = range_start;
-      new_values.insert(bv_container->add(v_new));
-
-      current_values.erase(it++);
-    }
-  }
-
-  current_values.insert(new_values.begin(), new_values.end());
-}
-
-template <bool remove_locals>
 bool rd_range_domain_with_sharingt<remove_locals>::gen(
   locationt from,
   const irep_idt &identifier,
@@ -315,6 +243,17 @@ void rd_range_domain_with_sharingt<remove_locals>::output(
     const irep_idt &identifier = value.first;
     output(identifier, out);
   }
+}
+
+template <bool remove_locals>
+values_innert &rd_range_domain_with_sharingt<remove_locals>::get_values_inner(
+  const irep_idt &identifier)
+{
+  auto &r = values.find(identifier);
+  if(!r.second)
+    return values_inner_empty;
+
+  return r.first;
 }
 
 /// \return returns true iff there is something new

--- a/src/analyses/reaching_definitions_with_sharing.cpp
+++ b/src/analyses/reaching_definitions_with_sharing.cpp
@@ -13,30 +13,38 @@ infot rd_range_domain_with_sharingt<remove_locals>::get_info(ai_baset &ai)
 }
 
 template <bool remove_locals>
-void rd_range_domain_with_sharingt<remove_locals>::populate_cache(
+const typename rd_range_domain_baset<remove_locals>::ranges_at_loct &
+rd_range_domain_with_sharingt<remove_locals>::get(
   const irep_idt &identifier) const
 {
   assert(bv_container);
 
-  auto &r = values.find(identifier);
+  static ranges_at_loct empty;
 
+  // Return cached value
+  auto e_it = export_cache.find(identifier);
+  if(e_it != export_cache.end())
+    return e_it->second;
+
+  auto &r = values.find(identifier);
   if(!r.second)
-    return;
+    return empty;
 
   const values_innert &inner = r.first;
 
   if(inner.empty())
-    return;
+    return empty;
 
-  ranges_at_loct &export_entry = export_cache[identifier];
+  ranges_at_loct &entry = export_cache[identifier];
 
   for(const auto &id : inner)
   {
     const reaching_definitiont &v = bv_container->get(id);
 
-    export_entry[v.definition_at].insert(
-      std::make_pair(v.bit_begin, v.bit_end));
+    entry[v.definition_at].insert(std::make_pair(v.bit_begin, v.bit_end));
   }
+
+  return entry;
 }
 
 template <bool remove_locals>

--- a/src/analyses/reaching_definitions_with_sharing.h
+++ b/src/analyses/reaching_definitions_with_sharing.h
@@ -49,9 +49,9 @@ public:
   using typename rd_range_domain_baset<remove_locals>::ranges_at_loct;
   using typename rd_range_domain_baset<remove_locals>::rangest;
   using rd_range_domain_baset<remove_locals>::export_cache;
-  using typename rd_range_domain_baset<remove_locals>::values_innert;
 
   using rd_range_domain_baset<remove_locals>::transform_assign;
+  using rd_range_domain_baset<remove_locals>::kill;
   using rd_range_domain_baset<remove_locals>::kill_inf;
   using rd_range_domain_baset<remove_locals>::get;
   using rd_range_domain_baset<remove_locals>::clear_cache;
@@ -127,11 +127,6 @@ private:
     locationt to,
     ai_baset &ai);
 
-  void kill(
-    const irep_idt &identifier,
-    const range_spect &range_start,
-    const range_spect &range_end);
-
   bool gen(
     locationt from,
     const irep_idt &identifier,
@@ -139,6 +134,8 @@ private:
     const range_spect &range_end);
 
   void output(std::ostream &out) const;
+
+  values_innert &get_values_inner(const irep_idt &identifier);
 };
 
 typedef reaching_definitions_analysis_ait<rd_range_domain_with_sharingt<false>>

--- a/src/analyses/reaching_definitions_with_sharing.h
+++ b/src/analyses/reaching_definitions_with_sharing.h
@@ -103,13 +103,13 @@ public:
     locationt to,
     const namespacet &ns);
 
+  const ranges_at_loct &get(const irep_idt &identifier) const;
+
 private:
   typedef sharing_mapt<irep_idt, values_innert, irep_id_hash> valuest;
   valuest values;
 
   infot get_info(ai_baset &ai);
-
-  void populate_cache(const irep_idt &identifier) const;
 
   void transform_dead(const namespacet &ns, locationt from);
 

--- a/src/analyses/reaching_definitions_with_sharing.h
+++ b/src/analyses/reaching_definitions_with_sharing.h
@@ -103,39 +103,39 @@ public:
     locationt to,
     const namespacet &ns);
 
-  const ranges_at_loct &get(const irep_idt &identifier) const;
+  const ranges_at_loct &get(const irep_idt &identifier) const override;
 
 private:
   typedef sharing_mapt<irep_idt, values_innert, irep_id_hash> valuest;
   valuest values;
 
-  infot get_info(ai_baset &ai);
+  infot get_info(ai_baset &ai) override;
 
-  void transform_dead(const namespacet &ns, locationt from);
+  void transform_dead(const namespacet &ns, locationt from) override;
 
-  void transform_start_thread(const namespacet &ns, ai_baset &ai);
+  void transform_start_thread(const namespacet &ns, ai_baset &ai) override;
 
   void transform_function_call(
     const namespacet &ns,
     locationt from,
     locationt to,
-    ai_baset &ai);
+    ai_baset &ai) override;
 
   void transform_end_function(
     const namespacet &ns,
     locationt from,
     locationt to,
-    ai_baset &ai);
+    ai_baset &ai) override;
 
   bool gen(
     locationt from,
     const irep_idt &identifier,
     const range_spect &range_start,
-    const range_spect &range_end);
+    const range_spect &range_end) override;
 
-  void output(std::ostream &out) const;
+  void output(std::ostream &out) const override;
 
-  values_innert &get_values_inner(const irep_idt &identifier);
+  values_innert &get_values_inner(const irep_idt &identifier) override;
 };
 
 typedef reaching_definitions_analysis_ait<rd_range_domain_with_sharingt<false>>

--- a/src/analyses/reaching_definitions_with_sharing.h
+++ b/src/analyses/reaching_definitions_with_sharing.h
@@ -13,13 +13,14 @@ Date: February 2013
 /// Range-based reaching definitions analysis (following Field- Sensitive
 ///   Program Dependence Analysis, Litvak et al., FSE 2010)
 
-#ifndef CPROVER_ANALYSES_REACHING_DEFINITIONS_WITHOUT_SHARING_H
-#define CPROVER_ANALYSES_REACHING_DEFINITIONS_WITHOUT_SHARING_H
+#ifndef CPROVER_ANALYSES_REACHING_DEFINITIONS_WITH_SHARING_H
+#define CPROVER_ANALYSES_REACHING_DEFINITIONS_WITH_SHARING_H
 
 #include <util/base_exceptions.h>
 #include <util/make_unique.h>
 #include <util/pointer_offset_size.h>
 #include <util/prefix.h>
+#include <util/sharing_map.h>
 #include <util/threeval.h>
 
 #include <pointer-analysis/value_set_analysis_fi.h>
@@ -37,8 +38,8 @@ class value_setst;
 class is_threadedt;
 class dirtyt;
 
-template <bool remove_locals = true>
-class rd_range_domain_without_sharingt
+template <bool remove_locals = false>
+class rd_range_domain_with_sharingt
   : public rd_range_domain_baset<remove_locals>
 {
 public:
@@ -92,22 +93,18 @@ public:
 
   // returns true iff there is something new
   bool merge(
-    const rd_range_domain_without_sharingt &other,
+    const rd_range_domain_with_sharingt &other,
     locationt from,
     locationt to);
 
   bool merge_shared(
-    const rd_range_domain_without_sharingt &other,
+    const rd_range_domain_with_sharingt &other,
     locationt from,
     locationt to,
     const namespacet &ns);
 
 private:
-#ifdef USE_DSTRING
-  typedef std::map<irep_idt, values_innert> valuest;
-#else
-  typedef std::unordered_map<irep_idt, values_innert, irep_id_hash> valuest;
-#endif
+  typedef sharing_mapt<irep_idt, values_innert, irep_id_hash> valuest;
   valuest values;
 
   infot get_info(ai_baset &ai);
@@ -142,15 +139,11 @@ private:
     const range_spect &range_end);
 
   void output(std::ostream &out) const;
-
-  bool merge_inner(values_innert &dest, const values_innert &other);
 };
 
-typedef rd_range_domain_without_sharingt<true> rd_range_domaint;
+typedef reaching_definitions_analysis_ait<rd_range_domain_with_sharingt<false>>
+  reaching_definitions_with_sharing_analysist;
 
-typedef reaching_definitions_analysis_ait<rd_range_domaint>
-  reaching_definitions_analysist;
+#include "reaching_definitions_with_sharing.cpp"
 
-#include "reaching_definitions_without_sharing.cpp"
-
-#endif // CPROVER_ANALYSES_REACHING_DEFINITIONS_WITHOUT_SHARING_H
+#endif // CPROVER_ANALYSES_REACHING_DEFINITIONS_WITH_SHARING_H

--- a/src/analyses/reaching_definitions_without_sharing.cpp
+++ b/src/analyses/reaching_definitions_without_sharing.cpp
@@ -18,7 +18,7 @@ void rd_range_domain_without_sharingt<remove_locals>::populate_cache(
 {
   assert(bv_container);
 
-  valuest::const_iterator v_entry = values.find(identifier);
+  typename valuest::const_iterator v_entry = values.find(identifier);
   if(v_entry == values.end() || v_entry->second.empty())
     return;
 
@@ -41,7 +41,7 @@ void rd_range_domain_without_sharingt<remove_locals>::transform_dead(
   const irep_idt &identifier =
     to_symbol_expr(to_code_dead(from->code).symbol()).get_identifier();
 
-  valuest::iterator entry = values.find(identifier);
+  typename valuest::iterator entry = values.find(identifier);
 
   if(entry != values.end())
   {
@@ -57,7 +57,8 @@ void rd_range_domain_without_sharingt<remove_locals>::transform_start_thread(
 {
   infot info = get_info(ai);
 
-  for(valuest::iterator it = values.begin(); it != values.end();) // no ++it
+  for(typename valuest::iterator it = values.begin();
+      it != values.end();) // no ++it
   {
     const irep_idt &identifier = it->first;
 
@@ -65,7 +66,7 @@ void rd_range_domain_without_sharingt<remove_locals>::transform_start_thread(
     {
       export_cache.erase(identifier);
 
-      valuest::iterator next = it;
+      typename valuest::iterator next = it;
       ++next;
       values.erase(it);
       it = next;
@@ -89,7 +90,8 @@ void rd_range_domain_without_sharingt<remove_locals>::transform_function_call(
   // only if there is an actual call, i.e., we have a body
   if(from->function != to->function)
   {
-    for(valuest::iterator it = values.begin(); it != values.end();) // no ++it
+    for(typename valuest::iterator it = values.begin();
+        it != values.end();) // no ++it
     {
       const irep_idt &identifier = it->first;
 
@@ -101,7 +103,7 @@ void rd_range_domain_without_sharingt<remove_locals>::transform_function_call(
       {
         export_cache.erase(identifier);
 
-        valuest::iterator next = it;
+        typename valuest::iterator next = it;
         ++next;
         values.erase(it);
         it = next;
@@ -191,7 +193,7 @@ void rd_range_domain_without_sharingt<remove_locals>::transform_end_function(
     if(identifier.empty())
       continue;
 
-    valuest::iterator entry = values.find(identifier);
+    typename valuest::iterator entry = values.find(identifier);
 
     if(entry != values.end())
     {
@@ -229,14 +231,14 @@ void rd_range_domain_without_sharingt<remove_locals>::kill(
 
   assert(range_end > range_start);
 
-  valuest::iterator entry = values.find(identifier);
+  typename valuest::iterator entry = values.find(identifier);
   if(entry == values.end())
     return;
 
   bool clear_export_cache = false;
   values_innert new_values;
 
-  for(values_innert::iterator it = entry->second.begin();
+  for(typename values_innert::iterator it = entry->second.begin();
       it != entry->second.end();) // no ++it
   {
     const reaching_definitiont &v = bv_container->get(*it);
@@ -293,7 +295,7 @@ void rd_range_domain_without_sharingt<remove_locals>::kill(
   if(clear_export_cache)
     export_cache.erase(identifier);
 
-  values_innert::iterator it = entry->second.begin();
+  typename values_innert::iterator it = entry->second.begin();
   for(const auto &id : new_values)
   {
     while(it != entry->second.end() && *it < id)
@@ -398,28 +400,7 @@ void rd_range_domain_without_sharingt<remove_locals>::output(
   for(const auto &value : values)
   {
     const irep_idt &identifier = value.first;
-
-    const ranges_at_loct &ranges = get(identifier);
-
-    out << "  " << identifier << "[";
-
-    for(typename ranges_at_loct::const_iterator itl = ranges.begin();
-        itl != ranges.end();
-        ++itl)
-      for(typename rangest::const_iterator itr = itl->second.begin();
-          itr != itl->second.end();
-          ++itr)
-      {
-        if(itr != itl->second.begin() || itl != ranges.begin())
-          out << ";";
-
-        out << itr->first << ":" << itr->second;
-        out << "@" << itl->first->location_number;
-      }
-
-    out << "]\n";
-
-    clear_cache(identifier);
+    output(identifier, out);
   }
 }
 
@@ -454,7 +435,7 @@ bool rd_range_domain_without_sharingt<remove_locals>::merge_inner(
     }
   }
 #else
-  values_innert::iterator itr = dest.begin();
+  typename values_innert::iterator itr = dest.begin();
   for(const auto &id : other)
   {
     while(itr != dest.end() && *itr < id)
@@ -485,7 +466,7 @@ bool rd_range_domain_without_sharingt<remove_locals>::merge(
   bool changed = has_values.is_false();
   has_values = tvt::unknown();
 
-  valuest::iterator it = values.begin();
+  typename valuest::iterator it = values.begin();
   for(const auto &value : other.values)
   {
     while(it != values.end() && it->first < value.first)
@@ -530,7 +511,7 @@ bool rd_range_domain_without_sharingt<remove_locals>::merge_shared(
   bool changed = has_values.is_false();
   has_values = tvt::unknown();
 
-  valuest::iterator it = values.begin();
+  typename valuest::iterator it = values.begin();
   for(const auto &value : other.values)
   {
     const irep_idt &identifier = value.first;

--- a/src/analyses/reaching_definitions_without_sharing.cpp
+++ b/src/analyses/reaching_definitions_without_sharing.cpp
@@ -1,3 +1,13 @@
+/*******************************************************************\
+
+Module: Range-based reaching definitions analysis (following Field-
+        Sensitive Program Dependence Analysis, Litvak et al., FSE 2010)
+
+Author: Michael Tautschnig
+
+Date: February 2013
+
+\*******************************************************************/
 
 template <bool remove_locals>
 infot rd_range_domain_without_sharingt<remove_locals>::get_info(ai_baset &ai)
@@ -13,11 +23,11 @@ infot rd_range_domain_without_sharingt<remove_locals>::get_info(ai_baset &ai)
 }
 
 template <bool remove_locals>
-const typename rd_range_domain_baset<remove_locals>::ranges_at_loct &
+const typename rd_range_domain_without_sharingt<remove_locals>::ranges_at_loct &
 rd_range_domain_without_sharingt<remove_locals>::get(
   const irep_idt &identifier) const
 {
-  assert(bv_container);
+  PRECONDITION(bv_container);
 
   static ranges_at_loct empty;
 
@@ -230,10 +240,10 @@ bool rd_range_domain_without_sharingt<remove_locals>::gen(
   if(range_start == 0 && range_end == 0)
     return false;
 
-  assert(range_start >= 0);
+  PRECONDITION(range_start >= 0);
 
   // -1 for objects of infinite/unknown size
-  assert(range_end > range_start || range_end == -1);
+  PRECONDITION(range_end > range_start || range_end == -1);
 
   reaching_definitiont v;
   v.identifier = identifier;
@@ -364,7 +374,7 @@ bool rd_range_domain_without_sharingt<remove_locals>::merge_inner(
     }
     else if(itr != dest.end())
     {
-      assert(*itr == id);
+      INVARIANT(*itr == id, "!= handled by other cases");
       ++itr;
     }
   }
@@ -395,7 +405,7 @@ bool rd_range_domain_without_sharingt<remove_locals>::merge(
     }
     else if(it != values.end())
     {
-      assert(it->first == value.first);
+      INVARIANT(it->first == value.first, "!= handled by other cases");
 
       if(merge_inner(it->second, value.second))
       {
@@ -446,7 +456,7 @@ bool rd_range_domain_without_sharingt<remove_locals>::merge_shared(
     }
     else if(it != values.end())
     {
-      assert(it->first == value.first);
+      INVARIANT(it->first == value.first, "!= handled by other cases");
 
       if(merge_inner(it->second, value.second))
       {

--- a/src/analyses/reaching_definitions_without_sharing.cpp
+++ b/src/analyses/reaching_definitions_without_sharing.cpp
@@ -13,24 +13,34 @@ infot rd_range_domain_without_sharingt<remove_locals>::get_info(ai_baset &ai)
 }
 
 template <bool remove_locals>
-void rd_range_domain_without_sharingt<remove_locals>::populate_cache(
+const typename rd_range_domain_baset<remove_locals>::ranges_at_loct &
+rd_range_domain_without_sharingt<remove_locals>::get(
   const irep_idt &identifier) const
 {
   assert(bv_container);
 
-  typename valuest::const_iterator v_entry = values.find(identifier);
-  if(v_entry == values.end() || v_entry->second.empty())
-    return;
+  static ranges_at_loct empty;
 
-  ranges_at_loct &export_entry = export_cache[identifier];
+  // Return cached value
+  auto e_it = export_cache.find(identifier);
+  if(e_it != export_cache.end())
+    return e_it->second;
 
-  for(const auto &id : v_entry->second)
+  // Check if values available
+  auto v_it = values.find(identifier);
+  if(v_it == values.end() || v_it->second.empty())
+    return empty;
+
+  ranges_at_loct &entry = export_cache[identifier];
+
+  for(const auto &id : v_it->second)
   {
     const reaching_definitiont &v = bv_container->get(id);
 
-    export_entry[v.definition_at].insert(
-      std::make_pair(v.bit_begin, v.bit_end));
+    entry[v.definition_at].insert(std::make_pair(v.bit_begin, v.bit_end));
   }
+
+  return entry;
 }
 
 template <bool remove_locals>

--- a/src/analyses/reaching_definitions_without_sharing.cpp
+++ b/src/analyses/reaching_definitions_without_sharing.cpp
@@ -1,0 +1,565 @@
+
+template <bool remove_locals>
+infot rd_range_domain_without_sharingt<remove_locals>::get_info(ai_baset &ai)
+{
+  reaching_definitions_analysist *rd =
+    dynamic_cast<reaching_definitions_analysist *>(&ai);
+  INVARIANT_STRUCTURED(
+    rd != nullptr,
+    bad_cast_exceptiont,
+    "ai has type reaching_definitions_analysist");
+
+  return infot(*rd->value_sets, *rd->is_threaded, *rd->is_dirty);
+}
+
+template <bool remove_locals>
+void rd_range_domain_without_sharingt<remove_locals>::populate_cache(
+  const irep_idt &identifier) const
+{
+  assert(bv_container);
+
+  valuest::const_iterator v_entry = values.find(identifier);
+  if(v_entry == values.end() || v_entry->second.empty())
+    return;
+
+  ranges_at_loct &export_entry = export_cache[identifier];
+
+  for(const auto &id : v_entry->second)
+  {
+    const reaching_definitiont &v = bv_container->get(id);
+
+    export_entry[v.definition_at].insert(
+      std::make_pair(v.bit_begin, v.bit_end));
+  }
+}
+
+template <bool remove_locals>
+void rd_range_domain_without_sharingt<remove_locals>::transform_dead(
+  const namespacet &ns,
+  locationt from)
+{
+  const irep_idt &identifier =
+    to_symbol_expr(to_code_dead(from->code).symbol()).get_identifier();
+
+  valuest::iterator entry = values.find(identifier);
+
+  if(entry != values.end())
+  {
+    values.erase(entry);
+    export_cache.erase(identifier);
+  }
+}
+
+template <bool remove_locals>
+void rd_range_domain_without_sharingt<remove_locals>::transform_start_thread(
+  const namespacet &ns,
+  ai_baset &ai)
+{
+  infot info = get_info(ai);
+
+  for(valuest::iterator it = values.begin(); it != values.end();) // no ++it
+  {
+    const irep_idt &identifier = it->first;
+
+    if(!ns.lookup(identifier).is_shared() && !info.is_dirty(identifier))
+    {
+      export_cache.erase(identifier);
+
+      valuest::iterator next = it;
+      ++next;
+      values.erase(it);
+      it = next;
+    }
+    else
+      ++it;
+  }
+}
+
+template <bool remove_locals>
+void rd_range_domain_without_sharingt<remove_locals>::transform_function_call(
+  const namespacet &ns,
+  locationt from,
+  locationt to,
+  ai_baset &ai)
+{
+  infot info = get_info(ai);
+
+  const code_function_callt &code = to_code_function_call(from->code);
+
+  // only if there is an actual call, i.e., we have a body
+  if(from->function != to->function)
+  {
+    for(valuest::iterator it = values.begin(); it != values.end();) // no ++it
+    {
+      const irep_idt &identifier = it->first;
+
+      // dereferencing may introduce extra symbols
+      const symbolt *sym;
+      if(
+        (ns.lookup(identifier, sym) || !sym->is_shared()) &&
+        !info.is_dirty(identifier))
+      {
+        export_cache.erase(identifier);
+
+        valuest::iterator next = it;
+        ++next;
+        values.erase(it);
+        it = next;
+      }
+      else
+        ++it;
+    }
+
+    const symbol_exprt &fn_symbol_expr = to_symbol_expr(code.function());
+    const code_typet &code_type =
+      to_code_type(ns.lookup(fn_symbol_expr.get_identifier()).type);
+
+    for(const auto &param : code_type.parameters())
+    {
+      const irep_idt &identifier = param.get_identifier();
+
+      if(identifier.empty())
+        continue;
+
+      range_spect size = to_range_spect(pointer_offset_bits(param.type(), ns));
+      gen(from, identifier, 0, size);
+    }
+  }
+  else
+  {
+    // handle return values of undefined functions
+    const code_function_callt &code = to_code_function_call(from->code);
+
+    if(code.lhs().is_not_nil())
+      transform_assign(ns, from, from, ai);
+  }
+}
+
+template <bool remove_locals>
+void rd_range_domain_without_sharingt<remove_locals>::transform_end_function(
+  const namespacet &ns,
+  locationt from,
+  locationt to,
+  ai_baset &ai)
+{
+  goto_programt::const_targett call = to;
+  --call;
+  const code_function_callt &code = to_code_function_call(call->code);
+
+  reaching_definitions_analysist *p =
+    dynamic_cast<reaching_definitions_analysist *>(&ai);
+  INVARIANT_STRUCTURED(
+    p != nullptr,
+    bad_cast_exceptiont,
+    "ai has type reaching_definitions_analysist");
+  reaching_definitions_analysist &rd = *p;
+
+  valuest new_values;
+  new_values.swap(values);
+  values = rd[call].values;
+
+  infot info = get_info(ai);
+
+  for(const auto &new_value : new_values)
+  {
+    const irep_idt &identifier = new_value.first;
+
+    if(
+      !info.is_threaded(call) ||
+      (!ns.lookup(identifier).is_shared() && !info.is_dirty(identifier)))
+    {
+      for(const auto &id : new_value.second)
+      {
+        const reaching_definitiont &v = bv_container->get(id);
+        kill(v.identifier, v.bit_begin, v.bit_end);
+      }
+    }
+
+    for(const auto &id : new_value.second)
+    {
+      const reaching_definitiont &v = bv_container->get(id);
+      gen(v.definition_at, v.identifier, v.bit_begin, v.bit_end);
+    }
+  }
+
+  const code_typet &code_type = to_code_type(ns.lookup(from->function).type);
+
+  for(const auto &param : code_type.parameters())
+  {
+    const irep_idt &identifier = param.get_identifier();
+
+    if(identifier.empty())
+      continue;
+
+    valuest::iterator entry = values.find(identifier);
+
+    if(entry != values.end())
+    {
+      values.erase(entry);
+      export_cache.erase(identifier);
+    }
+  }
+
+  // handle return values
+  if(code.lhs().is_not_nil())
+  {
+#if 0
+    rd_range_domaint *rd_state=
+      dynamic_cast<rd_range_domaint*>(&(rd.get_state(call)));
+    assert(rd_state!=0);
+    rd_state->
+#endif
+    transform_assign(ns, from, call, ai);
+  }
+}
+
+template <bool remove_locals>
+void rd_range_domain_without_sharingt<remove_locals>::kill(
+  const irep_idt &identifier,
+  const range_spect &range_start,
+  const range_spect &range_end)
+{
+  assert(range_start >= 0);
+  // -1 for objects of infinite/unknown size
+  if(range_end == -1)
+  {
+    kill_inf(identifier, range_start);
+    return;
+  }
+
+  assert(range_end > range_start);
+
+  valuest::iterator entry = values.find(identifier);
+  if(entry == values.end())
+    return;
+
+  bool clear_export_cache = false;
+  values_innert new_values;
+
+  for(values_innert::iterator it = entry->second.begin();
+      it != entry->second.end();) // no ++it
+  {
+    const reaching_definitiont &v = bv_container->get(*it);
+
+    if(v.bit_begin >= range_end)
+      ++it;
+    else if(v.bit_end != -1 && v.bit_end <= range_start)
+      ++it;
+    else if(
+      v.bit_begin >= range_start && v.bit_end != -1 &&
+      v.bit_end <= range_end) // rs <= a < b <= re
+    {
+      clear_export_cache = true;
+
+      entry->second.erase(it++);
+    }
+    else if(v.bit_begin >= range_start) // rs <= a <= re < b
+    {
+      clear_export_cache = true;
+
+      reaching_definitiont v_new = v;
+      v_new.bit_begin = range_end;
+      new_values.insert(bv_container->add(v_new));
+
+      entry->second.erase(it++);
+    }
+    else if(v.bit_end == -1 || v.bit_end > range_end) // a <= rs < re < b
+    {
+      clear_export_cache = true;
+
+      reaching_definitiont v_new = v;
+      v_new.bit_end = range_start;
+
+      reaching_definitiont v_new2 = v;
+      v_new2.bit_begin = range_end;
+
+      new_values.insert(bv_container->add(v_new));
+      new_values.insert(bv_container->add(v_new2));
+
+      entry->second.erase(it++);
+    }
+    else // a <= rs < b <= re
+    {
+      clear_export_cache = true;
+
+      reaching_definitiont v_new = v;
+      v_new.bit_end = range_start;
+      new_values.insert(bv_container->add(v_new));
+
+      entry->second.erase(it++);
+    }
+  }
+
+  if(clear_export_cache)
+    export_cache.erase(identifier);
+
+  values_innert::iterator it = entry->second.begin();
+  for(const auto &id : new_values)
+  {
+    while(it != entry->second.end() && *it < id)
+      ++it;
+    if(it == entry->second.end() || id < *it)
+    {
+      entry->second.insert(it, id);
+    }
+    else if(it != entry->second.end())
+    {
+      assert(*it == id);
+      ++it;
+    }
+  }
+}
+
+template <bool remove_locals>
+bool rd_range_domain_without_sharingt<remove_locals>::gen(
+  locationt from,
+  const irep_idt &identifier,
+  const range_spect &range_start,
+  const range_spect &range_end)
+{
+  // objects of size 0 like union U { signed : 0; };
+  if(range_start == 0 && range_end == 0)
+    return false;
+
+  assert(range_start >= 0);
+
+  // -1 for objects of infinite/unknown size
+  assert(range_end > range_start || range_end == -1);
+
+  reaching_definitiont v;
+  v.identifier = identifier;
+  v.definition_at = from;
+  v.bit_begin = range_start;
+  v.bit_end = range_end;
+
+  if(!values[identifier].insert(bv_container->add(v)).second)
+    return false;
+
+  export_cache.erase(identifier);
+
+#if 0
+  range_spect merged_range_end=range_end;
+
+  std::pair<valuest::iterator, bool> entry=
+    values.insert(std::make_pair(identifier, rangest()));
+  rangest &ranges=entry.first->second;
+
+  if(!entry.second)
+  {
+    for(rangest::iterator it=ranges.begin();
+        it!=ranges.end();
+        ) // no ++it
+    {
+      if(it->second.second!=from ||
+         (it->second.first!=-1 && it->second.first <= range_start) ||
+         (range_end!=-1 && it->first >= range_end))
+        ++it;
+      else if(it->first > range_start) // rs < a < b,re
+      {
+        if(range_end!=-1)
+          merged_range_end=std::max(range_end, it->second.first);
+        ranges.erase(it++);
+      }
+      else if(it->second.first==-1 ||
+              (range_end!=-1 &&
+               it->second.first >= range_end)) // a <= rs < re <= b
+      {
+        // nothing to do
+        return false;
+      }
+      else // a <= rs < b < re
+      {
+        it->second.first=range_end;
+        return true;
+      }
+    }
+  }
+
+  ranges.insert(std::make_pair(
+      range_start,
+      std::make_pair(merged_range_end, from)));
+#endif
+
+  return true;
+}
+
+template <bool remove_locals>
+void rd_range_domain_without_sharingt<remove_locals>::output(
+  std::ostream &out) const
+{
+  out << "Reaching definitions:\n";
+
+  if(has_values.is_known())
+  {
+    out << has_values.to_string() << '\n';
+    return;
+  }
+
+  for(const auto &value : values)
+  {
+    const irep_idt &identifier = value.first;
+
+    const ranges_at_loct &ranges = get(identifier);
+
+    out << "  " << identifier << "[";
+
+    for(typename ranges_at_loct::const_iterator itl = ranges.begin();
+        itl != ranges.end();
+        ++itl)
+      for(typename rangest::const_iterator itr = itl->second.begin();
+          itr != itl->second.end();
+          ++itr)
+      {
+        if(itr != itl->second.begin() || itl != ranges.begin())
+          out << ";";
+
+        out << itr->first << ":" << itr->second;
+        out << "@" << itl->first->location_number;
+      }
+
+    out << "]\n";
+
+    clear_cache(identifier);
+  }
+}
+
+/// \return returns true iff there is something new
+template <bool remove_locals>
+bool rd_range_domain_without_sharingt<remove_locals>::merge_inner(
+  values_innert &dest,
+  const values_innert &other)
+{
+  bool more = false;
+
+#if 0
+  ranges_at_loct::iterator itr=it->second.begin();
+  for(const auto &o : ito->second)
+  {
+    while(itr!=it->second.end() && itr->first<o.first)
+      ++itr;
+    if(itr==it->second.end() || o.first<itr->first)
+    {
+      it->second.insert(o);
+      more=true;
+    }
+    else if(itr!=it->second.end())
+    {
+      assert(itr->first==o.first);
+
+      for(const auto &o_range : o.second)
+        more=gen(itr->second, o_range.first, o_range.second) ||
+          more;
+
+      ++itr;
+    }
+  }
+#else
+  values_innert::iterator itr = dest.begin();
+  for(const auto &id : other)
+  {
+    while(itr != dest.end() && *itr < id)
+      ++itr;
+    if(itr == dest.end() || id < *itr)
+    {
+      dest.insert(itr, id);
+      more = true;
+    }
+    else if(itr != dest.end())
+    {
+      assert(*itr == id);
+      ++itr;
+    }
+  }
+#endif
+
+  return more;
+}
+
+/// \return returns true iff there is something new
+template <bool remove_locals>
+bool rd_range_domain_without_sharingt<remove_locals>::merge(
+  const rd_range_domain_without_sharingt &other,
+  locationt from,
+  locationt to)
+{
+  bool changed = has_values.is_false();
+  has_values = tvt::unknown();
+
+  valuest::iterator it = values.begin();
+  for(const auto &value : other.values)
+  {
+    while(it != values.end() && it->first < value.first)
+      ++it;
+    if(it == values.end() || value.first < it->first)
+    {
+      values.insert(value);
+      changed = true;
+    }
+    else if(it != values.end())
+    {
+      assert(it->first == value.first);
+
+      if(merge_inner(it->second, value.second))
+      {
+        changed = true;
+        export_cache.erase(it->first);
+      }
+
+      ++it;
+    }
+  }
+
+  return changed;
+}
+
+/// \return returns true iff there is something new
+template <bool remove_locals>
+bool rd_range_domain_without_sharingt<remove_locals>::merge_shared(
+  const rd_range_domain_without_sharingt &other,
+  locationt from,
+  locationt to,
+  const namespacet &ns)
+{
+// TODO: dirty vars
+#if 0
+  reaching_definitions_analysist *rd=
+    dynamic_cast<reaching_definitions_analysist*>(&ai);
+  assert(rd!=0);
+#endif
+
+  bool changed = has_values.is_false();
+  has_values = tvt::unknown();
+
+  valuest::iterator it = values.begin();
+  for(const auto &value : other.values)
+  {
+    const irep_idt &identifier = value.first;
+
+    if(
+      !ns.lookup(identifier).is_shared()
+      /*&& !rd.get_is_dirty()(identifier)*/)
+      continue;
+
+    while(it != values.end() && it->first < value.first)
+      ++it;
+    if(it == values.end() || value.first < it->first)
+    {
+      values.insert(value);
+      changed = true;
+    }
+    else if(it != values.end())
+    {
+      assert(it->first == value.first);
+
+      if(merge_inner(it->second, value.second))
+      {
+        changed = true;
+        export_cache.erase(it->first);
+      }
+
+      ++it;
+    }
+  }
+
+  return changed;
+}

--- a/src/analyses/reaching_definitions_without_sharing.h
+++ b/src/analyses/reaching_definitions_without_sharing.h
@@ -1,0 +1,155 @@
+/*******************************************************************\
+
+Module: Range-based reaching definitions analysis (following Field-
+        Sensitive Program Dependence Analysis, Litvak et al., FSE 2010)
+
+Author: Michael Tautschnig
+
+Date: February 2013
+
+\*******************************************************************/
+
+/// \file
+/// Range-based reaching definitions analysis (following Field- Sensitive
+///   Program Dependence Analysis, Litvak et al., FSE 2010)
+
+#ifndef CPROVER_ANALYSES_REACHING_DEFINITIONS_WITHOUT_SHARING_H
+#define CPROVER_ANALYSES_REACHING_DEFINITIONS_WITHOUT_SHARING_H
+
+#include <util/base_exceptions.h>
+#include <util/make_unique.h>
+#include <util/pointer_offset_size.h>
+#include <util/prefix.h>
+#include <util/threeval.h>
+
+#include <pointer-analysis/value_set_analysis_fi.h>
+
+#include <analyses/ai.h>
+#include <analyses/dirty.h>
+#include <analyses/goto_rw.h>
+#include <analyses/is_threaded.h>
+
+#include <memory>
+
+#include "reaching_definitions.h"
+
+class value_setst;
+class is_threadedt;
+class dirtyt;
+
+template <bool remove_locals = true>
+class rd_range_domain_without_sharingt
+  : public rd_range_domain_baset<remove_locals>
+{
+public:
+  using typename rd_range_domain_baset<remove_locals>::locationt;
+  using rd_range_domain_baset<remove_locals>::has_values;
+  using rd_range_domain_baset<remove_locals>::bv_container;
+  using typename rd_range_domain_baset<remove_locals>::ranges_at_loct;
+  using typename rd_range_domain_baset<remove_locals>::rangest;
+  using rd_range_domain_baset<remove_locals>::export_cache;
+
+  using rd_range_domain_baset<remove_locals>::transform_assign;
+  using rd_range_domain_baset<remove_locals>::kill_inf;
+  using rd_range_domain_baset<remove_locals>::get;
+  using rd_range_domain_baset<remove_locals>::clear_cache;
+
+  void make_top() final override
+  {
+    values.clear();
+    has_values = tvt(true);
+  }
+
+  void make_bottom() final override
+  {
+    values.clear();
+    has_values = tvt(false);
+  }
+
+  void make_entry() final override
+  {
+    values.clear();
+    has_values = tvt::unknown();
+  }
+
+  bool is_top() const override final
+  {
+    DATA_INVARIANT(
+      !has_values.is_true() || values.empty(),
+      "If domain is top, the value map must be empty");
+    return has_values.is_true();
+  }
+
+  bool is_bottom() const override final
+  {
+    DATA_INVARIANT(
+      !has_values.is_false() || values.empty(),
+      "If domain is bottom, the value map must be empty");
+    return has_values.is_false();
+  }
+
+  // returns true iff there is something new
+  bool merge(
+    const rd_range_domain_without_sharingt &other,
+    locationt from,
+    locationt to);
+
+  bool merge_shared(
+    const rd_range_domain_without_sharingt &other,
+    locationt from,
+    locationt to,
+    const namespacet &ns);
+
+private:
+  typedef std::set<std::size_t> values_innert;
+#ifdef USE_DSTRING
+  typedef std::map<irep_idt, values_innert> valuest;
+#else
+  typedef std::unordered_map<irep_idt, values_innert, irep_id_hash> valuest;
+#endif
+  valuest values;
+
+  infot get_info(ai_baset &ai);
+
+  void populate_cache(const irep_idt &identifier) const;
+
+  void transform_dead(const namespacet &ns, locationt from);
+
+  void transform_start_thread(const namespacet &ns, ai_baset &ai);
+
+  void transform_function_call(
+    const namespacet &ns,
+    locationt from,
+    locationt to,
+    ai_baset &ai);
+
+  void transform_end_function(
+    const namespacet &ns,
+    locationt from,
+    locationt to,
+    ai_baset &ai);
+
+  void kill(
+    const irep_idt &identifier,
+    const range_spect &range_start,
+    const range_spect &range_end);
+
+  bool gen(
+    locationt from,
+    const irep_idt &identifier,
+    const range_spect &range_start,
+    const range_spect &range_end);
+
+  void output(std::ostream &out) const;
+
+  bool merge_inner(values_innert &dest, const values_innert &other);
+};
+
+typedef rd_range_domain_without_sharingt<> rd_range_domaint;
+
+typedef reaching_definitions_analysis_ait<rd_range_domaint>
+  reaching_definitions_analysist;
+
+#include "reaching_definitions_without_sharing.cpp"
+
+#endif // CPROVER_ANALYSES_REACHING_DEFINITIONS_WITHOUT_SHARING_H

--- a/src/analyses/reaching_definitions_without_sharing.h
+++ b/src/analyses/reaching_definitions_without_sharing.h
@@ -102,7 +102,7 @@ public:
     locationt to,
     const namespacet &ns);
 
-  const ranges_at_loct &get(const irep_idt &identifier) const;
+  const ranges_at_loct &get(const irep_idt &identifier) const override;
 
 private:
 #ifdef USE_DSTRING
@@ -112,33 +112,33 @@ private:
 #endif
   valuest values;
 
-  infot get_info(ai_baset &ai);
+  infot get_info(ai_baset &ai) override;
 
-  void transform_dead(const namespacet &ns, locationt from);
+  void transform_dead(const namespacet &ns, locationt from) override;
 
-  void transform_start_thread(const namespacet &ns, ai_baset &ai);
+  void transform_start_thread(const namespacet &ns, ai_baset &ai) override;
 
   void transform_function_call(
     const namespacet &ns,
     locationt from,
     locationt to,
-    ai_baset &ai);
+    ai_baset &ai) override;
 
   void transform_end_function(
     const namespacet &ns,
     locationt from,
     locationt to,
-    ai_baset &ai);
+    ai_baset &ai) override;
 
   bool gen(
     locationt from,
     const irep_idt &identifier,
     const range_spect &range_start,
-    const range_spect &range_end);
+    const range_spect &range_end) override;
 
-  void output(std::ostream &out) const;
+  void output(std::ostream &out) const override;
 
-  values_innert &get_values_inner(const irep_idt &identifier);
+  values_innert &get_values_inner(const irep_idt &identifier) override;
 
   bool merge_inner(values_innert &dest, const values_innert &other);
 };

--- a/src/analyses/reaching_definitions_without_sharing.h
+++ b/src/analyses/reaching_definitions_without_sharing.h
@@ -102,6 +102,8 @@ public:
     locationt to,
     const namespacet &ns);
 
+  const ranges_at_loct &get(const irep_idt &identifier) const;
+
 private:
 #ifdef USE_DSTRING
   typedef std::map<irep_idt, values_innert> valuest;
@@ -111,8 +113,6 @@ private:
   valuest values;
 
   infot get_info(ai_baset &ai);
-
-  void populate_cache(const irep_idt &identifier) const;
 
   void transform_dead(const namespacet &ns, locationt from);
 

--- a/src/analyses/reaching_definitions_without_sharing.h
+++ b/src/analyses/reaching_definitions_without_sharing.h
@@ -48,9 +48,9 @@ public:
   using typename rd_range_domain_baset<remove_locals>::ranges_at_loct;
   using typename rd_range_domain_baset<remove_locals>::rangest;
   using rd_range_domain_baset<remove_locals>::export_cache;
-  using typename rd_range_domain_baset<remove_locals>::values_innert;
 
   using rd_range_domain_baset<remove_locals>::transform_assign;
+  using rd_range_domain_baset<remove_locals>::kill;
   using rd_range_domain_baset<remove_locals>::kill_inf;
   using rd_range_domain_baset<remove_locals>::get;
   using rd_range_domain_baset<remove_locals>::clear_cache;
@@ -130,11 +130,6 @@ private:
     locationt to,
     ai_baset &ai);
 
-  void kill(
-    const irep_idt &identifier,
-    const range_spect &range_start,
-    const range_spect &range_end);
-
   bool gen(
     locationt from,
     const irep_idt &identifier,
@@ -142,6 +137,8 @@ private:
     const range_spect &range_end);
 
   void output(std::ostream &out) const;
+
+  values_innert &get_values_inner(const irep_idt &identifier);
 
   bool merge_inner(values_innert &dest, const values_innert &other);
 };

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -49,18 +49,19 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <pointer-analysis/add_failed_symbols.h>
 #include <pointer-analysis/show_value_sets.h>
 
-#include <analyses/natural_loops.h>
-#include <analyses/global_may_alias.h>
-#include <analyses/local_bitvector_analysis.h>
-#include <analyses/custom_bitvector_analysis.h>
-#include <analyses/escape_analysis.h>
 #include <analyses/call_graph.h>
+#include <analyses/constant_propagator.h>
+#include <analyses/custom_bitvector_analysis.h>
+#include <analyses/dependence_graph.h>
+#include <analyses/escape_analysis.h>
+#include <analyses/global_may_alias.h>
 #include <analyses/interval_analysis.h>
 #include <analyses/interval_domain.h>
-#include <analyses/reaching_definitions.h>
-#include <analyses/dependence_graph.h>
-#include <analyses/constant_propagator.h>
 #include <analyses/is_threaded.h>
+#include <analyses/local_bitvector_analysis.h>
+#include <analyses/natural_loops.h>
+#include <analyses/reaching_definitions_with_sharing.h>
+#include <analyses/reaching_definitions_without_sharing.h>
 
 #include <cbmc/version.h>
 
@@ -472,9 +473,19 @@ int goto_instrument_parse_optionst::doit()
       do_indirect_call_and_rtti_removal();
 
       const namespacet ns(goto_model.symbol_table);
-      reaching_definitions_analysist rd_analysis(ns);
-      rd_analysis(goto_model);
-      rd_analysis.output(goto_model, std::cout);
+
+      if(cmdline.isset("sharing"))
+      {
+        reaching_definitions_with_sharing_analysist rd_analysis(ns);
+        rd_analysis(goto_model);
+        rd_analysis.output(goto_model, std::cout);
+      }
+      else
+      {
+        reaching_definitions_analysist rd_analysis(ns);
+        rd_analysis(goto_model);
+        rd_analysis.output(goto_model, std::cout);
+      }
 
       return CPROVER_EXIT_SUCCESS;
     }
@@ -1505,6 +1516,9 @@ void goto_instrument_parse_optionst::help()
     " --class-hierarchy            show class hierarchy\n"
     // NOLINTNEXTLINE(whitespace/line_length)
     " --show-threaded              show instructions that may be executed by more than one thread\n"
+    " --show-reaching-definitions  show reaching definitions\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    " --sharing                    enable sharing, use with --show-reaching-definitions\n"
     "\n"
     "Safety checks:\n"
     " --no-assertions              ignore user assertions\n"

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -86,11 +86,11 @@ Author: Daniel Kroening, kroening@kroening.com
   "(horn)(skip-loops):(apply-code-contracts)(model-argc-argv):" \
   "(show-threaded)(list-calls-args)(print-path-lengths)" \
   "(undefined-function-is-assume-false)" \
-  "(remove-function-body):"\
+  "(remove-function-body):" \
   "(splice-call):" \
   OPT_REMOVE_CALLS_NO_BODY \
-  OPT_REPLACE_FUNCTION_BODY
-
+  OPT_REPLACE_FUNCTION_BODY \
+  "(sharing)"
 // clang-format on
 
 class goto_instrument_parse_optionst:

--- a/src/util/sharing_map.h
+++ b/src/util/sharing_map.h
@@ -450,7 +450,7 @@ SHARING_MAPT2(, size_type)::erase(
     return 0;
 
   node_type *del=nullptr;
-  unsigned del_bit;
+  unsigned del_bit = 0;
 
   size_t key=hash()(k);
   node_type *p=&map;
@@ -472,18 +472,15 @@ SHARING_MAPT2(, size_type)::erase(
 
   _sm_assert(p->is_container());
 
-  {
-    const containert &c=as_const(p)->get_container();
+  const containert &c = as_const(p)->get_container();
 
-    if(c.size()==1)
-    {
-      del->remove_child(del_bit);
-      num--;
-      return 1;
-    }
+  if(c.size() == 1)
+  {
+    del->remove_child(del_bit);
+    num--;
+    return 1;
   }
 
-  containert &c=p->get_container();
   _sm_assert(c.size()>1);
   p->remove_leaf(k);
   num--;
@@ -505,10 +502,8 @@ SHARING_MAPT2(, size_type)::erase_all(
   return cnt;
 }
 
-SHARING_MAPT2(, const_find_type)::insert(
-  const key_type &k,
-  const mapped_type &m,
-  const tvt &key_exists)
+SHARING_MAPT2(const, const_find_type)
+::insert(const key_type &k, const mapped_type &m, const tvt &key_exists)
 {
   _sn_assert(!key_exists.is_true());
 
@@ -528,16 +523,13 @@ SHARING_MAPT2(, const_find_type)::insert(
   return const_find_type(as_const(p)->get_value(), true);
 }
 
-SHARING_MAPT2(, const_find_type)::insert(
-  const value_type &p,
-  const tvt &key_exists)
+SHARING_MAPT2(const, const_find_type)
+::insert(const value_type &p, const tvt &key_exists)
 {
   return insert(p.first, p.second, key_exists);
 }
 
-SHARING_MAPT2(, find_type)::place(
-  const key_type &k,
-  const mapped_type &m)
+SHARING_MAPT2(const, find_type)::place(const key_type &k, const mapped_type &m)
 {
   node_type *c=get_container_node(k);
   _sm_assert(c!=nullptr);
@@ -553,15 +545,12 @@ SHARING_MAPT2(, find_type)::place(
   return find_type(p->get_value(), true);
 }
 
-SHARING_MAPT2(, find_type)::place(
-  const value_type &p)
+SHARING_MAPT2(const, find_type)::place(const value_type &p)
 {
   return place(p.first, p.second);
 }
 
-SHARING_MAPT2(, find_type)::find(
-  const key_type &k,
-  const tvt &key_exists)
+SHARING_MAPT2(const, find_type)::find(const key_type &k, const tvt &key_exists)
 {
   _sm_assert(!key_exists.is_false());
 
@@ -578,7 +567,7 @@ SHARING_MAPT2(, find_type)::find(
 
 }
 
-SHARING_MAPT2(, const_find_type)::find(const key_type &k) const
+SHARING_MAPT2(const, const_find_type)::find(const key_type &k) const
 {
   const node_type *p=get_leaf_node(k);
 


### PR DESCRIPTION
Adds a version of the reaching definitions analysis that uses the `sharing_mapt` to use sharing between abstract states.