### PR TITLE
Speedup Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -169,6 +169,7 @@ jobs:
     # cmake build using g++-5
     - stage: Test different OS/CXX/Flags
       os: linux
+      compiler: gcc
       cache: ccache
       env:
         - BUILD_SYSTEM=cmake
@@ -189,6 +190,7 @@ jobs:
 
     - stage: Test different OS/CXX/Flags
       os: osx
+      compiler: clang
       cache: ccache
       before_install:
         - HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache

--- a/.travis.yml
+++ b/.travis.yml
@@ -249,7 +249,7 @@ jobs:
 
 install:
   - ccache -z
-  - ccache --max-size=1G
+  - ccache --max-size=2G
   - make -C src minisat2-download
   - make -C src/ansi-c library_check
   - make -C src "CXX=${COMPILER}" "CXXFLAGS=-Wall -Werror -pedantic -O2 -g ${EXTRA_CXXFLAGS}" -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -252,8 +252,8 @@ install:
   - ccache --max-size=2G
   - make -C src minisat2-download
   - make -C src/ansi-c library_check
-  - make -C src "CXX=${COMPILER}" "CXXFLAGS=-Wall -Werror -pedantic -O2 -g ${EXTRA_CXXFLAGS}" -j2
-  - make -C src "CXX=${COMPILER}" "CXXFLAGS=-Wall -Werror -pedantic -O2 -g ${EXTRA_CXXFLAGS}" -j2 clobber.dir memory-models.dir
+  - make -C src "CXX=${COMPILER}" "CXXFLAGS=-Wall -Werror -pedantic -O2 -g ${EXTRA_CXXFLAGS}" -j3
+  - make -C src "CXX=${COMPILER}" "CXXFLAGS=-Wall -Werror -pedantic -O2 -g ${EXTRA_CXXFLAGS}" -j3 clobber.dir memory-models.dir
 
 script:
   - if [ -e bin/gcc ] ; then export PATH=$PWD/bin:$PATH ; fi ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
         - mkdir bin ; ln -s /usr/bin/gcc-5 bin/gcc
       # env: COMPILER=g++-5 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover -fno-omit-frame-pointer"
       env:
-        - COMPILER="ccache g++-5"
+        - COMPILER="ccache /usr/bin/g++-5"
         - EXTRA_CXXFLAGS="-D_GLIBCXX_DEBUG"
 
     # OS X using g++
@@ -76,10 +76,8 @@ jobs:
       compiler: gcc
       cache: ccache
       before_install:
-          #we create symlink to non-ccache gcc, to be used in tests
-        - mkdir bin ; ln -s /usr/bin/gcc bin/gcc
         - HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache
-        - export PATH=/usr/local/opt/ccache/libexec:$PATH
+        - export PATH=$PATH:/usr/local/opt/ccache/libexec
       env: COMPILER="ccache g++"
 
     # OS X using clang++
@@ -90,7 +88,7 @@ jobs:
       cache: ccache
       before_install:
         - HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache
-        - export PATH=/usr/local/opt/ccache/libexec:$PATH
+        - export PATH=$PATH:/usr/local/opt/ccache/libexec
       env:
         - COMPILER="ccache clang++ -Qunused-arguments -fcolor-diagnostics"
         - CCACHE_CPP2=yes
@@ -113,7 +111,7 @@ jobs:
         - mkdir bin ; ln -s /usr/bin/gcc-5 bin/gcc
       # env: COMPILER=g++-5 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover -fno-omit-frame-pointer"
       env:
-        - COMPILER="ccache g++-5"
+        - COMPILER="ccache /usr/bin/g++-5"
         - EXTRA_CXXFLAGS="-DDEBUG"
       script: echo "Not running any tests for a debug build."
 
@@ -138,7 +136,7 @@ jobs:
         - export CCACHE_CPP2=yes
       # env: COMPILER=clang++-3.7 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined,integer -fno-omit-frame-pointer"
       env:
-        - COMPILER="ccache clang++-3.7 -Qunused-arguments -fcolor-diagnostics"
+        - COMPILER="ccache /usr/bin/clang++-3.7 -Qunused-arguments -fcolor-diagnostics"
         - CCACHE_CPP2=yes
         - EXTRA_CXXFLAGS="-DNDEBUG"
 
@@ -163,7 +161,7 @@ jobs:
         - export CCACHE_CPP2=yes
       # env: COMPILER=clang++-3.7 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined,integer -fno-omit-frame-pointer"
       env:
-        - COMPILER="ccache clang++-3.7 -Qunused-arguments -fcolor-diagnostics"
+        - COMPILER="ccache /usr/bin/clang++-3.7 -Qunused-arguments -fcolor-diagnostics"
         - CCACHE_CPP2=yes
         - EXTRA_CXXFLAGS="-DDEBUG -DUSE_STD_STRING"
       script: echo "Not running any tests for a debug build."
@@ -180,10 +178,12 @@ jobs:
             - ubuntu-toolchain-r-test
           packages:
             - g++-5
+      before_install:
+        - mkdir bin ; ln -s /usr/bin/gcc-5 bin/gcc
       install:
         - ccache -z
         - ccache --max-size=1G
-        - cmake -H. -Bbuild '-DCMAKE_BUILD_TYPE=Release' '-DCMAKE_CXX_COMPILER=g++-5'
+        - cmake -H. -Bbuild '-DCMAKE_BUILD_TYPE=Release'  '-DCMAKE_CXX_COMPILER=/usr/bin/g++-5'
         - cmake --build build -- -j4
       script: (cd build; ctest -V -L CORE -j2)
 
@@ -192,7 +192,7 @@ jobs:
       cache: ccache
       before_install:
         - HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache
-        - export PATH=/usr/local/opt/ccache/libexec:$PATH
+        - export PATH=$PATH:/usr/local/opt/ccache/libexec
       env:
         - BUILD_SYSTEM=cmake
         - CCACHE_CPP2=yes


### PR DESCRIPTION
Prompted by @forejtv, who noticed that our Travis builds seem to be making very poor use of the ccache (i.e. way too many misses) I took a look at what was going on. This PR fixes up the .travis.yml so that we should now make proper use of the ccache. The two main parts of this are:

1) We were double-invoking ccache due to a subtle behaviour in how Travis sets up the environment on jobs when you specify the 'cache: ccache' property. Travis was adding the locations of the g++/clang++ wrappers around ccache to the *front* of the PATH environment. This meant that when our build commands invoked, say, 'ccache g++' - we were actually invoking ccache on itself, which I believe was leading to very bad cache thrashing. Rather than simply just using the wrappers, I've kept the current explicit invocation of ccache but with an absolute path to the appropriate compiler. I believe it is best to make this explicit so that the behaviour is clear.

2) For the debug builds (i.e. the builds we specify '-g' for) the object files are actually so much bigger than non-debug builds that we were hitting the 1GB limit we specify on the ccache, which was also causing cache thrashing. Local tests (macOS, gcc, make) of ccache performance when doing a make; make clean; make cycle showed that with a 1GB limit the cache hit ratio was 80%, but with a 2GB limit it was 99.84% (1 cache miss). Non-debug builds are still have plenty of headroom with a 1GB cache, so I've only bumped up the cache size for the debug builds.

I've also included 1 commit that probably has a minor improvement in performance - slightly increasing the build parallelism to be (number of cores + 1), and a final 'cleanup' commit to ensure all the jobs declare to travis what type of compiler they expect to use. This in theory gives jobs for new PR's a better chance of finding a suitable 'seed' cache, but in reality we don't make use of that functionality so this is basically a cleanup commit.

Final note - after this is merged, Travis runtime will likely then be dominated by time to run regression tests, but that should be investigated/tackled as different PR.