### PR TITLE
BMC reporting phase: use restricted goto-functions interface

### DIFF
--- a/src/cbmc/all_properties.cpp
+++ b/src/cbmc/all_properties.cpp
@@ -63,10 +63,15 @@ safety_checkert::resultt bmc_all_propertiest::operator()()
 
   // Collect _all_ goals in `goal_map'.
   // This maps property IDs to 'goalt'
-  forall_goto_functions(f_it, goto_functions)
-    forall_goto_program_instructions(i_it, f_it->second.body)
+  for(const irep_idt &function_id : function_provider.get_available_functions())
+  {
+    forall_goto_program_instructions(
+      i_it, function_provider.get_existing_goto_function(function_id).body)
+    {
       if(i_it->is_assert())
         goal_map[i_it->source_location.get_property_id()]=goalt(*i_it);
+    }
+  }
 
   // get the conditions for these goals from formula
   // collect all 'instances' of the properties
@@ -230,10 +235,10 @@ void bmc_all_propertiest::report(const cover_goalst &cover_goals)
 }
 
 safety_checkert::resultt bmct::all_properties(
-  const goto_functionst &goto_functions,
+  const goto_functions_providert &function_provider,
   prop_convt &solver)
 {
-  bmc_all_propertiest bmc_all_properties(goto_functions, solver, *this);
+  bmc_all_propertiest bmc_all_properties(function_provider, solver, *this);
   bmc_all_properties.set_message_handler(get_message_handler());
   return bmc_all_properties();
 }

--- a/src/cbmc/all_properties_class.h
+++ b/src/cbmc/all_properties_class.h
@@ -22,10 +22,10 @@ class bmc_all_propertiest:
 {
 public:
   bmc_all_propertiest(
-    const goto_functionst &_goto_functions,
+    const goto_functions_providert &function_provider,
     prop_convt &_solver,
     bmct &_bmc):
-    goto_functions(_goto_functions), solver(_solver), bmc(_bmc)
+    function_provider(function_provider), solver(_solver), bmc(_bmc)
   {
   }
 
@@ -85,7 +85,7 @@ public:
   goal_mapt goal_map;
 
 protected:
-  const goto_functionst &goto_functions;
+  const goto_functions_providert &function_provider;
   prop_convt &solver;
   bmct &bmc;
 

--- a/src/cbmc/bmc_cover.cpp
+++ b/src/cbmc/bmc_cover.cpp
@@ -36,9 +36,9 @@ class bmc_covert:
 {
 public:
   bmc_covert(
-    const goto_functionst &_goto_functions,
+    const goto_functions_providert &function_provider,
     bmct &_bmc):
-    goto_functions(_goto_functions), solver(_bmc.prop_conv), bmc(_bmc)
+    function_provider(function_provider), solver(_bmc.prop_conv), bmc(_bmc)
   {
   }
 
@@ -138,7 +138,7 @@ public:
   }
 
 protected:
-  const goto_functionst &goto_functions;
+  const goto_functions_providert &function_provider;
   prop_convt &solver;
   bmct &bmc;
 };
@@ -199,9 +199,10 @@ bool bmc_covert::operator()()
 
   // Collect _all_ goals in `goal_map'.
   // This maps property IDs to 'goalt'
-  forall_goto_functions(f_it, goto_functions)
+  for(const irep_idt &function_id : function_provider.get_available_functions())
   {
-    forall_goto_program_instructions(i_it, f_it->second.body)
+    forall_goto_program_instructions(
+      i_it, function_provider.get_existing_goto_function(function_id).body)
     {
       if(i_it->is_assert())
         goal_map[id(i_it)]=
@@ -429,10 +430,10 @@ bool bmc_covert::operator()()
 
 /// Try to cover all goals
 bool bmct::cover(
-  const goto_functionst &goto_functions,
+  const goto_functions_providert &goto_functions_provider,
   const optionst::value_listt &criteria)
 {
-  bmc_covert bmc_cover(goto_functions, *this);
+  bmc_covert bmc_cover(goto_functions_provider, *this);
   bmc_cover.set_message_handler(get_message_handler());
   return bmc_cover();
 }

--- a/src/cbmc/fault_localization.h
+++ b/src/cbmc/fault_localization.h
@@ -26,12 +26,11 @@ class fault_localizationt:
 {
 public:
   explicit fault_localizationt(
-    const goto_functionst &_goto_functions,
+    const goto_functions_providert &_goto_functions_provider,
     bmct &_bmc,
     const optionst &_options)
     :
-    bmc_all_propertiest(_goto_functions, _bmc.prop_conv, _bmc),
-    goto_functions(_goto_functions),
+    bmc_all_propertiest(_goto_functions_provider, _bmc.prop_conv, _bmc),
     bmc(_bmc),
     options(_options)
   {
@@ -45,7 +44,6 @@ public:
   virtual void goal_covered(const cover_goalst::goalt &);
 
 protected:
-  const goto_functionst &goto_functions;
   bmct &bmc;
   const optionst &options;
 

--- a/src/cbmc/symex_bmc.h
+++ b/src/cbmc/symex_bmc.h
@@ -92,10 +92,10 @@ public:
   }
 
   bool output_coverage_report(
-    const goto_functionst &goto_functions,
+    const goto_functions_providert &goto_functions_provider,
     const std::string &path) const
   {
-    return symex_coverage.generate_report(goto_functions, path);
+    return symex_coverage.generate_report(goto_functions_provider, path);
   }
 
   bool record_coverage;

--- a/src/cbmc/symex_coverage.h
+++ b/src/cbmc/symex_coverage.h
@@ -21,7 +21,7 @@ Date: March 2016
 #include <goto-programs/goto_program.h>
 
 class coverage_recordt;
-class goto_functionst;
+class goto_functions_providert;
 class namespacet;
 class xmlt;
 
@@ -44,7 +44,7 @@ public:
   }
 
   bool generate_report(
-    const goto_functionst &goto_functions,
+    const goto_functions_providert &goto_functions_provider,
     const std::string &path) const;
 
 protected:
@@ -73,15 +73,15 @@ protected:
   coveraget coverage;
 
   bool output_report(
-    const goto_functionst &goto_functions,
+    const goto_functions_providert &goto_functions_provider,
     std::ostream &os) const;
 
   void build_cobertura(
-    const goto_functionst &goto_functions,
+    const goto_functions_providert &goto_functions_provider,
     xmlt &xml_coverage) const;
 
   void compute_overall_coverage(
-    const goto_functionst &goto_functions,
+    const goto_functions_providert &goto_functions_provider,
     coverage_recordt &dest) const;
 
   friend class goto_program_coverage_recordt;

--- a/src/goto-programs/goto_functions_provider.h
+++ b/src/goto-programs/goto_functions_provider.h
@@ -1,0 +1,125 @@
+/*******************************************************************\
+
+Module: Reduced wrapper interface to get goto functions
+
+Author: Chris Smowton
+
+Date: February 2018
+
+\*******************************************************************/
+
+#ifndef CPROVER_GOTO_PROGRAMS_GOTO_FUNCTIONS_PROVIDER_H
+#define CPROVER_GOTO_PROGRAMS_GOTO_FUNCTIONS_PROVIDER_H
+
+#include <unordered_set>
+
+#include <goto-programs/goto_functions.h>
+#include <goto-programs/lazy_goto_model.h>
+
+/// GOTO functions reduced interface. Provides functions to get a GOTO function
+/// by symbol id, and a function to get the set of existing functions (those for
+/// which get_existing_goto_function will not throw).
+/// This permits producing goto functions on demand, without having to support
+/// the full interface of std::map that goto_functionst exposes across
+/// operations with side-effects.
+class goto_functions_providert
+{
+public:
+  /// Get a GOTO function by name, or throw if no such function exists. This is
+  /// guaranteed side-effect free.
+  /// \param id: function to get
+  /// \return function body
+  virtual const goto_functionst::goto_functiont &get_existing_goto_function(
+    const irep_idt &id) const = 0;
+
+  /// Get a GOTO function by name, or throw if no such function exists.
+  /// Unlike get_existing_goto_function, this may have side-effects on the
+  /// symbol table, so symbol table iterators are not safe across calls.
+  /// It may also add to the set returned by get_available_functions.
+  /// \param id: function to get
+  /// \return function body
+  virtual const goto_functionst::goto_functiont &get_goto_function(
+    const irep_idt &id) = 0;
+
+  /// Get the set of available functions, for which get_existing_goto_function
+  /// must not throw. get_goto_function may be able to supply functions not
+  /// listed here, but if so it will have side-effects on the available
+  /// functions set and symbol table, as their bodies are produced on demand.
+  virtual std::unordered_set<irep_idt, irep_id_hash> get_available_functions()
+    const = 0;
+};
+
+/// GOTO functions view backing onto a goto_functionst object. All functions are
+/// available, in the sense that they can be accessed without side-effects.
+class eager_goto_functions_providert : public goto_functions_providert
+{
+public:
+  explicit eager_goto_functions_providert(
+    const goto_functionst &goto_functions) :
+    goto_functions(goto_functions)
+  {
+  }
+
+  const goto_functionst::goto_functiont &get_existing_goto_function(
+    const irep_idt &id) const override
+  {
+    return goto_functions.function_map.at(id);
+  }
+
+  const goto_functionst::goto_functiont &get_goto_function(
+    const irep_idt &id) override
+  {
+    return get_existing_goto_function(id);
+  }
+
+  std::unordered_set<irep_idt, irep_id_hash> get_available_functions()
+    const override
+  {
+    std::unordered_set<irep_idt, irep_id_hash> result;
+    for(const auto &id_and_body : goto_functions.function_map)
+      result.insert(id_and_body.first);
+    return result;
+  }
+
+private:
+  const goto_functionst &goto_functions;
+};
+
+/// GOTO functions provider backing onto a lazy goto model.
+/// get_available_functions returns those that have already been converted,
+/// either using get_goto_function or otherwise, and therefore can be accessed
+/// again in a const context. get_goto_function may be able to convert other
+/// functions on demand, but side-effects on the symbol table will result in
+/// this case.
+class lazy_goto_functions_providert : public goto_functions_providert
+{
+public:
+  explicit lazy_goto_functions_providert(
+    lazy_goto_modelt &lazy_goto_model) :
+    lazy_goto_model(lazy_goto_model)
+  {
+  }
+
+  const goto_functionst::goto_functiont &get_existing_goto_function(
+    const irep_idt &id) const override
+  {
+    return lazy_goto_model.get_converted_goto_function(id);
+  }
+
+  const goto_functionst::goto_functiont &get_goto_function(
+    const irep_idt &id) override
+  {
+    return lazy_goto_model.get_goto_function(id);
+  }
+
+  std::unordered_set<irep_idt, irep_id_hash> get_available_functions()
+    const override
+  {
+    return lazy_goto_model.get_converted_functions();
+  }
+
+private:
+  lazy_goto_modelt &lazy_goto_model;
+};
+
+#endif

--- a/src/goto-programs/goto_functions_provider.h
+++ b/src/goto-programs/goto_functions_provider.h
@@ -47,6 +47,12 @@ public:
   /// functions set and symbol table, as their bodies are produced on demand.
   virtual std::unordered_set<irep_idt, irep_id_hash> get_available_functions()
     const = 0;
+
+  /// DEPRECATED accessor to get a raw goto_functionst. Only recommended for use
+  /// with code currently being ported to the new interface, as concurrent use
+  /// of get_goto_function may invalidate iterators or otherwise surprise users
+  /// by modifying the map underneath them.
+  virtual const goto_functionst &get_goto_functions_deprecated() const = 0;
 };
 
 /// GOTO functions view backing onto a goto_functionst object. All functions are
@@ -79,6 +85,11 @@ public:
     for(const auto &id_and_body : goto_functions.function_map)
       result.insert(id_and_body.first);
     return result;
+  }
+
+  const goto_functionst &get_goto_functions_deprecated() const override
+  {
+    return goto_functions;
   }
 
 private:
@@ -116,6 +127,11 @@ public:
     const override
   {
     return lazy_goto_model.get_converted_functions();
+  }
+
+  const goto_functionst &get_goto_functions_deprecated() const override
+  {
+    return lazy_goto_model.get_goto_functions_deprecated();
   }
 
 private:

--- a/src/goto-programs/lazy_goto_functions_map.h
+++ b/src/goto-programs/lazy_goto_functions_map.h
@@ -117,6 +117,25 @@ public:
     ensure_function_loaded_internal(name);
   }
 
+  std::unordered_set<irep_idt, irep_id_hash> get_converted_functions() const
+  {
+    std::unordered_set<irep_idt, irep_id_hash> result;
+    for(const auto &id_and_body : goto_functions)
+      result.insert(id_and_body.first);
+    return result;
+  }
+
+  /// Returns the GOTO function body for function with name 'id', or throws if
+  /// that function has not been converted or does not exist.
+  /// Contrast `at(const irep_idt &)`, which converts functions on demand.
+  /// \param id: function id to retrieve
+  /// \return function body if available, or throws otherwise
+  const goto_functionst::goto_functiont &get_converted_goto_function(
+    const irep_idt &id) const
+  {
+    return goto_functions.at(id);
+  }
+
 private:
   // This returns a non-const reference, but if you use this method from a
   // const method then you should not return such a reference without making it

--- a/src/goto-programs/lazy_goto_model.h
+++ b/src/goto-programs/lazy_goto_model.h
@@ -118,6 +118,15 @@ public:
     return goto_functions.get_converted_goto_function(id);
   }
 
+  /// Deprecated accessor to retrieve the internal goto_functionst.
+  /// Use with care; concurrent use of get_goto_function will have side-effects
+  /// on this map which may surprise users, including invalidating any iterators
+  /// they have stored.
+  const goto_functionst &get_goto_functions_deprecated() const
+  {
+    return goto_model->goto_functions;
+  }
+
 private:
   std::unique_ptr<goto_modelt> goto_model;
 

--- a/src/goto-programs/lazy_goto_model.h
+++ b/src/goto-programs/lazy_goto_model.h
@@ -76,6 +76,11 @@ public:
 
   void initialize(const cmdlinet &cmdline);
 
+  const goto_functionst::goto_functiont &get_goto_function(const irep_idt &id)
+  {
+    return goto_functions.at(id);
+  }
+
   /// Eagerly loads all functions from the symbol table.
   void load_all_functions() const;
 
@@ -101,6 +106,17 @@ public:
   }
 
   virtual bool can_produce_function(const irep_idt &id) const;
+
+  std::unordered_set<irep_idt, irep_id_hash> get_converted_functions() const
+  {
+    return goto_functions.get_converted_functions();
+  }
+
+  const goto_functionst::goto_functiont &get_converted_goto_function(
+    const irep_idt &id) const
+  {
+    return goto_functions.get_converted_goto_function(id);
+  }
 
 private:
   std::unique_ptr<goto_modelt> goto_model;

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -105,16 +105,6 @@ public:
     const goto_functionst &goto_functions,
     symbol_tablet &new_symbol_table);
 
-  /// Performs symbolic execution using a state and equation that have
-  /// already been used to symex part of the program. The state is not
-  /// re-initialized; instead, symbolic execution resumes from the program
-  /// counter of the saved state.
-  virtual void resume_symex_from_saved_state(
-    const goto_functionst &goto_functions,
-    const statet &saved_state,
-    symex_target_equationt *const saved_equation,
-    symbol_tablet &new_symbol_table);
-
   /// \brief symex entire program starting from entry point
   ///
   /// The state that goto_symext maintains has a large memory footprint.
@@ -123,6 +113,16 @@ public:
   /// around afterwards.
   virtual void symex_from_entry_point_of(
     const get_goto_functiont &get_goto_function,
+    symbol_tablet &new_symbol_table);
+
+  /// Performs symbolic execution using a state and equation that have
+  /// already been used to symex part of the program. The state is not
+  /// re-initialized; instead, symbolic execution resumes from the program
+  /// counter of the saved state.
+  virtual void resume_symex_from_saved_state(
+    const get_goto_functiont &get_goto_function,
+    const statet &saved_state,
+    symex_target_equationt *const saved_equation,
     symbol_tablet &new_symbol_table);
 
   //// \brief symex entire program starting from entry point

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -211,14 +211,11 @@ void goto_symext::symex_with_state(
 }
 
 void goto_symext::resume_symex_from_saved_state(
-  const goto_functionst &goto_functions,
+  const get_goto_functiont &get_goto_function,
   const statet &saved_state,
   symex_target_equationt *const saved_equation,
   symbol_tablet &new_symbol_table)
 {
-  const get_goto_functiont get_goto_function = get_function_from_goto_functions(
-      goto_functions);
-
   // saved_state contains a pointer to a symex_target_equationt that is
   // almost certainly stale. This is because equations are owned by bmcts,
   // and we construct a new bmct for every path that we execute. We're on a

--- a/src/jbmc/jbmc_parse_options.cpp
+++ b/src/jbmc/jbmc_parse_options.cpp
@@ -489,12 +489,12 @@ int jbmc_parse_optionst::doit()
   if(set_properties(goto_model))
     return 7; // should contemplate EX_USAGE from sysexits.h
 
-  std::function<void(bmct &, const goto_modelt &)> configure_bmc;
+  std::function<void(bmct &, const symbol_tablet &)> configure_bmc;
   if(options.get_bool_option("java-unwind-enum-static"))
   {
     configure_bmc = [](
-      bmct &bmc, const goto_modelt &goto_model) { // NOLINT (*)
-        bmc.add_loop_unwind_handler([&goto_model](
+      bmct &bmc, const symbol_tablet &symbol_table) { // NOLINT (*)
+        bmc.add_loop_unwind_handler([&symbol_table](
                                       const irep_idt &function_id,
                                       unsigned loop_number,
                                       unsigned unwind,
@@ -504,14 +504,14 @@ int jbmc_parse_optionst::doit()
             loop_number,
             unwind,
             max_unwind,
-            goto_model.symbol_table);
+            symbol_table);
         });
     };
   }
   else
   {
     configure_bmc = [](
-      bmct &bmc, const goto_modelt &goto_model) { // NOLINT (*)
+      bmct &bmc, const symbol_tablet &goto_model) { // NOLINT (*)
       // NOOP
     };
   }


### PR DESCRIPTION
The BMC reporting phase previously got a `const goto_functionst &`. This was problematic for introducing symex-driven lazy loading, as the lazy equivalent, `lazy_goto_modelst`, intentionally does not expose the full `goto_functionst` interface, as exposing iterators would be potentially dangerous if those iterators were invalidated during incremental function loading, and confusing to users, who would expect an object that behaves like `goto_functionst`, but in fact find that the function map was magically gaining entries each time symex was run (it can be entered multiple times due to the new `--paths` option).

To deal with this, I introduce `goto_functions_providert`, a small interface that exposes the only functionality needed by `bmct`: "get a function, perhaps converting it on demand" (used by symex), "get a function that is definitely *not* converted on demand" (used in reporting), and "get all converted function ids" (also used in reporting).

`bmct` is amended to use the new interface (retaining entry-points that take `goto_functionst` for backward-compatibility), and a few reporting passes switch to using it too. The version of `goto_functions_providert` that backs onto a `lazy_goto_modelt` is currently unused, but will be used in the next PR in this series.

EDIT: Had to add a function exposing `goto_functionst` after all, as converting test-gen to use the new interface is too much work (for example, it needs a reverse location-number -> instruction lookup). This being so, if reviewers prefer I can just get the goto_functionst out of lazy_goto_modelt (with an accompanying health warning that if you retrieve and store an iterator you're likely to get burned when the map changes under your feet). However on balance I still think it better to use the reduced interface where we can.