### PR TITLE
BMC: support lazy goto model

### DIFF
--- a/src/goto-programs/abstract_goto_model.h
+++ b/src/goto-programs/abstract_goto_model.h
@@ -1,0 +1,54 @@
+/*******************************************************************\
+
+Module: Abstract GOTO Model
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+/// \file
+/// Abstract interface to eager or lazy GOTO models
+
+#ifndef CPROVER_GOTO_PROGRAMS_ABSTRACT_GOTO_MODEL_H
+#define CPROVER_GOTO_PROGRAMS_ABSTRACT_GOTO_MODEL_H
+
+#include "goto_functions.h"
+#include <util/symbol_table.h>
+
+/// Abstract interface to eager or lazy GOTO models
+class abstract_goto_modelt
+{
+public:
+  virtual ~abstract_goto_modelt()
+  {
+  }
+
+  /// Determines if this model can produce a body for the given function
+  /// \param id: function ID to query
+  /// \return true if we can produce a function body, or false if we would leave
+  ///   it a bodyless stub.
+  virtual bool can_produce_function(const irep_idt &id) const = 0;
+
+  /// Get a GOTO function by name, or throw if no such function exists.
+  /// May have side-effects on the GOTO function map provided by
+  /// get_goto_functions, or the symbol table returned by get_symbol_table,
+  /// so iterators pointing into either may be invalidated.
+  /// \param id: function to get
+  /// \return function body
+  virtual const goto_functionst::goto_functiont &get_goto_function(
+    const irep_idt &id) = 0;
+
+  /// Accessor to get a raw goto_functionst. Concurrent use of get_goto_function
+  /// may invalidate iterators or otherwise surprise users by modifying the map
+  /// underneath them, so this should only be used to lend a reference to code
+  /// that cannot also call get_goto_function.
+  virtual const goto_functionst &get_goto_functions() const = 0;
+
+  /// Accessor to get the symbol table. Concurrent use of get_goto_function
+  /// may invalidate iterators or otherwise surprise users by modifying the map
+  /// underneath them, so this should only be used to lend a reference to code
+  /// that cannot also call get_goto_function.
+  virtual const symbol_tablet &get_symbol_table() const = 0;
+};
+
+#endif

--- a/src/goto-programs/lazy_goto_model.h
+++ b/src/goto-programs/lazy_goto_model.h
@@ -8,6 +8,7 @@
 
 #include <langapi/language_file.h>
 
+#include "abstract_goto_model.h"
 #include "goto_model.h"
 #include "lazy_goto_functions_map.h"
 #include "goto_convert_functions.h"
@@ -15,24 +16,12 @@
 class cmdlinet;
 class optionst;
 
-/// Interface for a provider of function definitions to report whether or not it
-/// can provide a definition (function body) for a given function ID.
-struct can_produce_functiont
-{
-  /// Determines if this function provider can produce a body for the given
-  /// function
-  /// \param id: function ID to query
-  /// \return true if we can produce a function body, or false if we would leave
-  ///   it a bodyless stub.
-  virtual bool can_produce_function(const irep_idt &id) const = 0;
-};
-
 /// Model that holds partially loaded map of functions
-class lazy_goto_modelt : public can_produce_functiont
+class lazy_goto_modelt : public abstract_goto_modelt
 {
 public:
   typedef std::function<
-    void(goto_model_functiont &function, const can_produce_functiont &)>
+    void(goto_model_functiont &function, const abstract_goto_modelt &)>
     post_process_functiont;
   typedef std::function<bool(goto_modelt &goto_model)> post_process_functionst;
 
@@ -65,8 +54,8 @@ public:
   {
     return lazy_goto_modelt(
       [&handler, &options]
-      (goto_model_functiont &fun, const can_produce_functiont &cpf) { // NOLINT(*)
-        handler.process_goto_function(fun, cpf, options);
+      (goto_model_functiont &fun, const abstract_goto_modelt &model) { // NOLINT(*)
+        handler.process_goto_function(fun, model, options);
       },
       [&handler, &options] (goto_modelt &goto_model) -> bool { // NOLINT(*)
         return handler.process_goto_functions(goto_model, options);
@@ -100,7 +89,29 @@ public:
     return std::move(model.goto_model);
   }
 
-  virtual bool can_produce_function(const irep_idt &id) const;
+  // Implement the abstract_goto_modelt interface:
+
+  /// Accessor to retrieve the internal goto_functionst.
+  /// Use with care; concurrent use of get_goto_function will have side-effects
+  /// on this map which may surprise users, including invalidating any iterators
+  /// they have stored.
+  const goto_functionst &get_goto_functions() const override
+  {
+    return goto_model->goto_functions;
+  }
+
+  const symbol_tablet &get_symbol_table() const override
+  {
+    return symbol_table;
+  }
+
+  bool can_produce_function(const irep_idt &id) const override;
+
+  const goto_functionst::goto_functiont &get_goto_function(const irep_idt &id)
+    override
+  {
+    return goto_functions.at(id);
+  }
 
 private:
   std::unique_ptr<goto_modelt> goto_model;

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -105,16 +105,6 @@ public:
     const goto_functionst &goto_functions,
     symbol_tablet &new_symbol_table);
 
-  /// Performs symbolic execution using a state and equation that have
-  /// already been used to symex part of the program. The state is not
-  /// re-initialized; instead, symbolic execution resumes from the program
-  /// counter of the saved state.
-  virtual void resume_symex_from_saved_state(
-    const goto_functionst &goto_functions,
-    const statet &saved_state,
-    symex_target_equationt *const saved_equation,
-    symbol_tablet &new_symbol_table);
-
   /// \brief symex entire program starting from entry point
   ///
   /// The state that goto_symext maintains has a large memory footprint.
@@ -123,6 +113,16 @@ public:
   /// around afterwards.
   virtual void symex_from_entry_point_of(
     const get_goto_functiont &get_goto_function,
+    symbol_tablet &new_symbol_table);
+
+  /// Performs symbolic execution using a state and equation that have
+  /// already been used to symex part of the program. The state is not
+  /// re-initialized; instead, symbolic execution resumes from the program
+  /// counter of the saved state.
+  virtual void resume_symex_from_saved_state(
+    const get_goto_functiont &get_goto_function,
+    const statet &saved_state,
+    symex_target_equationt *const saved_equation,
     symbol_tablet &new_symbol_table);
 
   //// \brief symex entire program starting from entry point

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -211,14 +211,11 @@ void goto_symext::symex_with_state(
 }
 
 void goto_symext::resume_symex_from_saved_state(
-  const goto_functionst &goto_functions,
+  const get_goto_functiont &get_goto_function,
   const statet &saved_state,
   symex_target_equationt *const saved_equation,
   symbol_tablet &new_symbol_table)
 {
-  const get_goto_functiont get_goto_function = get_function_from_goto_functions(
-      goto_functions);
-
   // saved_state contains a pointer to a symex_target_equationt that is
   // almost certainly stale. This is because equations are owned by bmcts,
   // and we construct a new bmct for every path that we execute. We're on a

--- a/src/jbmc/jbmc_parse_options.h
+++ b/src/jbmc/jbmc_parse_options.h
@@ -91,7 +91,7 @@ public:
 
   void process_goto_function(
     goto_model_functiont &function,
-    const can_produce_functiont &,
+    const abstract_goto_modelt &,
     const optionst &);
   bool process_goto_functions(goto_modelt &goto_model, const optionst &options);
 

--- a/unit/testing-utils/load_java_class.cpp
+++ b/unit/testing-utils/load_java_class.cpp
@@ -88,7 +88,7 @@ symbol_tablet load_java_class(
   // Construct a lazy_goto_modelt
   null_message_handlert message_handler;
   lazy_goto_modelt lazy_goto_model(
-    [] (goto_model_functiont &function, const can_produce_functiont &cpf) { }, // NOLINT (*)
+    [] (goto_model_functiont &function, const abstract_goto_modelt &model) { }, // NOLINT (*)
     [] (goto_modelt &goto_model) { return false; }, // NOLINT (*)
     message_handler);
 


### PR DESCRIPTION
This introduces `goto_functions_providert`, which an interface that gets function bodies by name (perhaps converting them on demand), then gives a const view of the function map created so far, intended for reporting. It enables us to hide from `bmct` whether we're using plain old `goto_functionst` or `lazy_goto_modelt`.

Alternative to https://github.com/diffblue/cbmc/pull/1904, which tried harder to avoid use of `goto_functionst`, with the risk that users would store references to it or iterators pointing into it which could be invalidated upon converting more methods and so adding to the function map. However, test-gen would have required a **lot** of code to be changed, so it was necessary to expose a `const goto_functionst &` in the end regardless.