### PR TITLE
Path exploration goodies

### DIFF
--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -598,6 +598,7 @@ void bmct::setup_unwind()
 /// \param callback_after_symex: optional callback to be run after symex.
 ///   See class member `bmct::driver_callback_after_symex` for details.
 int bmct::do_language_agnostic_bmc(
+  const path_strategy_choosert &path_strategy_chooser,
   const optionst &opts,
   abstract_goto_modelt &model,
   const ui_message_handlert::uit &ui,
@@ -609,8 +610,12 @@ int bmct::do_language_agnostic_bmc(
   safety_checkert::resultt tmp_result = safety_checkert::resultt::UNKNOWN;
   const symbol_tablet &symbol_table = model.get_symbol_table();
   message_handlert &mh = message.get_message_handler();
-  std::unique_ptr<path_storaget> worklist =
-    path_storaget::make(path_storaget::disciplinet::FIFO);
+  std::unique_ptr<path_storaget> worklist;
+  std::string strategy = opts.get_option("exploration-strategy");
+  INVARIANT(
+    path_strategy_chooser.is_valid_strategy(strategy),
+    "Front-end passed us invalid path strategy '" + strategy + "'");
+  worklist = path_strategy_chooser.get(strategy);
   try
   {
     {

--- a/src/cbmc/bmc.h
+++ b/src/cbmc/bmc.h
@@ -117,6 +117,7 @@ public:
   }
 
   static int do_language_agnostic_bmc(
+    const path_strategy_choosert &path_strategy_chooser,
     const optionst &opts,
     abstract_goto_modelt &goto_model,
     const ui_message_handlert::uit &ui,
@@ -294,7 +295,8 @@ private:
   "(no-unwinding-assertions)"                                                  \
   "(no-pretty-names)"                                                          \
   "(partial-loops)"                                                            \
-  "(paths)"                                                                    \
+  "(paths):"                                                                   \
+  "(show-symex-strategies)"                                                    \
   "(depth):"                                                                   \
   "(unwind):"                                                                  \
   "(unwindset):"                                                               \
@@ -302,7 +304,8 @@ private:
   "(unwindset):"
 
 #define HELP_BMC                                                               \
-  " --paths                      explore paths one at a time\n"                \
+  " --paths [strategy]           explore paths one at a time\n"                \
+  " --show-symex-strategies      list strategies for use with --paths\n"       \
   " --program-only               only show program expression\n"               \
   " --show-loops                 show the loops in the program\n"              \
   " --depth nr                   limit search depth\n"                         \

--- a/src/cbmc/bmc.h
+++ b/src/cbmc/bmc.h
@@ -23,6 +23,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/goto_trace.h>
 
 #include <goto-symex/symex_target_equation.h>
+#include <goto-symex/path_storage.h>
+
 #include <goto-programs/goto_model.h>
 #include <goto-programs/safety_checker.h>
 #include <goto-symex/memory_model.h>
@@ -49,32 +51,32 @@ public:
   ///   constructor is `false` (unset), an instance of this class will
   ///   symbolically execute the entire program, performing path merging
   ///   to build a formula corresponding to all executions of the program
-  ///   up to the unwinding limit. In this case, the `branch_worklist`
+  ///   up to the unwinding limit. In this case, the `path_storage`
   ///   member shall not be touched; this is enforced by the assertion in
   ///   this class' implementation of bmct::perform_symbolic_execution().
   ///
   /// - If the `--paths` flag is `true`, this `bmct` object will explore a
   ///   single path through the codebase without doing any path merging.
   ///   If some paths were not taken, the state at those branch points
-  ///   will be appended to `branch_worklist`. After the single path that
+  ///   will be appended to `path_storage`. After the single path that
   ///   this `bmct` object executed has been model-checked, you can resume
   ///   exploring further paths by popping an element from
-  ///   `branch_worklist` and using it to construct a path_explorert
+  ///   `path_storage` and using it to construct a path_explorert
   ///   object.
   bmct(
     const optionst &_options,
     const symbol_tablet &outer_symbol_table,
     message_handlert &_message_handler,
     prop_convt &_prop_conv,
-    goto_symext::branch_worklistt &_branch_worklist,
+    path_storaget &_path_storage,
     std::function<bool(void)> callback_after_symex)
     : safety_checkert(ns, _message_handler),
       options(_options),
       outer_symbol_table(outer_symbol_table),
       ns(outer_symbol_table, symex_symbol_table),
       equation(),
-      branch_worklist(_branch_worklist),
-      symex(_message_handler, outer_symbol_table, equation, branch_worklist),
+      path_storage(_path_storage),
+      symex(_message_handler, outer_symbol_table, equation, path_storage),
       prop_conv(_prop_conv),
       ui(ui_message_handlert::uit::PLAIN),
       driver_callback_after_symex(callback_after_symex)
@@ -128,7 +130,7 @@ protected:
   ///
   /// This constructor exists as a delegate for the path_explorert class.
   /// It differs from \ref bmct's public constructor in that it actually
-  /// does something with the branch_worklistt argument, and also takes a
+  /// does something with the path_storaget argument, and also takes a
   /// symex_target_equationt. See the documentation for path_explorert for
   /// details.
   bmct(
@@ -137,15 +139,15 @@ protected:
     message_handlert &_message_handler,
     prop_convt &_prop_conv,
     symex_target_equationt &_equation,
-    goto_symext::branch_worklistt &_branch_worklist,
+    path_storaget &_path_storage,
     std::function<bool(void)> callback_after_symex)
     : safety_checkert(ns, _message_handler),
       options(_options),
       outer_symbol_table(outer_symbol_table),
       ns(outer_symbol_table),
       equation(_equation),
-      branch_worklist(_branch_worklist),
-      symex(_message_handler, outer_symbol_table, equation, branch_worklist),
+      path_storage(_path_storage),
+      symex(_message_handler, outer_symbol_table, equation, path_storage),
       prop_conv(_prop_conv),
       ui(ui_message_handlert::uit::PLAIN),
       driver_callback_after_symex(callback_after_symex)
@@ -166,7 +168,7 @@ protected:
   symbol_tablet symex_symbol_table;
   namespacet ns;
   symex_target_equationt equation;
-  goto_symext::branch_worklistt &branch_worklist;
+  path_storaget &path_storage;
   symex_bmct symex;
   prop_convt &prop_conv;
   std::unique_ptr<memory_model_baset> memory_model;
@@ -257,7 +259,7 @@ public:
     prop_convt &_prop_conv,
     symex_target_equationt &saved_equation,
     const goto_symex_statet &saved_state,
-    goto_symext::branch_worklistt &branch_worklist,
+    path_storaget &path_storage,
     std::function<bool(void)> callback_after_symex)
     : bmct(
         _options,
@@ -265,7 +267,7 @@ public:
         _message_handler,
         _prop_conv,
         saved_equation,
-        branch_worklist,
+        path_storage,
         callback_after_symex),
       saved_state(saved_state)
   {

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -68,7 +68,8 @@ cbmc_parse_optionst::cbmc_parse_optionst(int argc, const char **argv):
   parse_options_baset(CBMC_OPTIONS, argc, argv),
   xml_interfacet(cmdline),
   messaget(ui_message_handler),
-  ui_message_handler(cmdline, "CBMC " CBMC_VERSION)
+  ui_message_handler(cmdline, "CBMC " CBMC_VERSION),
+  path_strategy_chooser()
 {
 }
 
@@ -79,7 +80,8 @@ cbmc_parse_optionst::cbmc_parse_optionst(int argc, const char **argv):
   parse_options_baset(CBMC_OPTIONS+extra_options, argc, argv),
   xml_interfacet(cmdline),
   messaget(ui_message_handler),
-  ui_message_handler(cmdline, "CBMC " CBMC_VERSION)
+  ui_message_handler(cmdline, "CBMC " CBMC_VERSION),
+  path_strategy_chooser()
 {
 }
 
@@ -146,8 +148,13 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
     exit(CPROVER_EXIT_USAGE_ERROR);
   }
 
-  if(cmdline.isset("paths"))
-    options.set_option("paths", true);
+  if(cmdline.isset("show-symex-strategies"))
+  {
+    std::cout << path_strategy_chooser.show_strategies();
+    exit(CPROVER_EXIT_SUCCESS);
+  }
+
+  path_strategy_chooser.set_path_strategy_options(cmdline, options, *this);
 
   if(cmdline.isset("program-only"))
     options.set_option("program-only", true);
@@ -531,7 +538,11 @@ int cbmc_parse_optionst::doit()
     return CPROVER_EXIT_SET_PROPERTIES_FAILED;
 
   return bmct::do_language_agnostic_bmc(
-    options, goto_model, ui_message_handler.get_ui(), *this);
+    path_strategy_chooser,
+    options,
+    goto_model,
+    ui_message_handler.get_ui(),
+    *this);
 }
 
 bool cbmc_parse_optionst::set_properties()

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -110,6 +110,7 @@ public:
 protected:
   goto_modelt goto_model;
   ui_message_handlert ui_message_handler;
+  const path_strategy_choosert path_strategy_chooser;
 
   void eval_verbosity();
   void register_languages();

--- a/src/cbmc/symex_bmc.cpp
+++ b/src/cbmc/symex_bmc.cpp
@@ -22,8 +22,8 @@ symex_bmct::symex_bmct(
   message_handlert &mh,
   const symbol_tablet &outer_symbol_table,
   symex_target_equationt &_target,
-  goto_symext::branch_worklistt &branch_worklist)
-  : goto_symext(mh, outer_symbol_table, _target, branch_worklist),
+  path_storaget &path_storage)
+  : goto_symext(mh, outer_symbol_table, _target, path_storage),
     record_coverage(false),
     max_unwind(0),
     max_unwind_is_set(false),

--- a/src/cbmc/symex_bmc.h
+++ b/src/cbmc/symex_bmc.h
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/message.h>
 #include <util/threeval.h>
 
+#include <goto-symex/path_storage.h>
 #include <goto-symex/goto_symex.h>
 
 #include "symex_coverage.h"
@@ -26,7 +27,7 @@ public:
     message_handlert &mh,
     const symbol_tablet &outer_symbol_table,
     symex_target_equationt &_target,
-    goto_symext::branch_worklistt &branch_worklist);
+    path_storaget &path_storage);
 
   // To show progress
   source_locationt last_source_location;

--- a/src/doxyfile
+++ b/src/doxyfile
@@ -281,7 +281,7 @@ OPTIMIZE_OUTPUT_VHDL   = NO
 # Note that for custom extensions you also need to set FILE_PATTERNS otherwise
 # the files are not read by doxygen.
 
-EXTENSION_MAPPING      =
+EXTENSION_MAPPING      = h=c++
 
 # If the MARKDOWN_SUPPORT tag is enabled then doxygen pre-processes all comments
 # according to the Markdown format, which allows for more readable

--- a/src/goto-instrument/accelerate/scratch_program.h
+++ b/src/goto-instrument/accelerate/scratch_program.h
@@ -23,6 +23,7 @@ Author: Matt Lewis
 #include <goto-programs/goto_functions.h>
 
 #include <goto-symex/goto_symex.h>
+#include <goto-symex/path_storage.h>
 #include <goto-symex/symex_target_equation.h>
 
 #include <solvers/smt2/smt2_dec.h>
@@ -41,8 +42,8 @@ public:
       symex_symbol_table(),
       ns(symbol_table, symex_symbol_table),
       equation(),
-      branch_worklist(),
-      symex(mh, symbol_table, equation, branch_worklist),
+      path_storage(),
+      symex(mh, symbol_table, equation, path_storage),
       satcheck(util_make_unique<satcheckt>()),
       satchecker(ns, *satcheck),
       z3(ns, "accelerate", "", "", smt2_dect::solvert::Z3),
@@ -78,7 +79,7 @@ protected:
   symbol_tablet symex_symbol_table;
   namespacet ns;
   symex_target_equationt equation;
-  goto_symext::branch_worklistt branch_worklist;
+  path_fifot path_storage;
   goto_symext symex;
 
   std::unique_ptr<propt> satcheck;

--- a/src/goto-symex/Makefile
+++ b/src/goto-symex/Makefile
@@ -8,6 +8,7 @@ SRC = adjust_float_expressions.cpp \
       memory_model_sc.cpp \
       memory_model_tso.cpp \
       partial_order_concurrency.cpp \
+      path_storage.cpp \
       postcondition.cpp \
       precondition.cpp \
       rewrite_union.cpp \

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -53,7 +53,8 @@ public:
     const symbol_tablet &outer_symbol_table,
     symex_target_equationt &_target,
     path_storaget &path_storage)
-    : total_vccs(0),
+    : should_pause_symex(false),
+      total_vccs(0),
       remaining_vccs(0),
       constant_propagation(true),
       language_mode(),
@@ -158,6 +159,15 @@ public:
     const get_goto_functiont &get_goto_function,
     goto_programt::const_targett first,
     goto_programt::const_targett limit);
+
+  /// \brief Have states been pushed onto the workqueue?
+  ///
+  /// If this flag is set at the end of a symbolic execution run, it means that
+  /// symex has been paused because we encountered a GOTO instruction while
+  /// doing path exploration, and thus pushed the successor states of the GOTO
+  /// onto path_storage. The symbolic execution caller should now choose which
+  /// successor state to continue executing, and resume symex from that state.
+  bool should_pause_symex;
 
 protected:
   /// Initialise the symbolic execution and the given state with <code>pc</code>

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -18,6 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/goto_functions.h>
 
 #include "goto_symex_state.h"
+#include "path_storage.h"
 #include "symex_target_equation.h"
 
 class byte_extract_exprt;
@@ -47,30 +48,11 @@ class goto_symext
 public:
   typedef goto_symex_statet statet;
 
-  /// \brief Information saved at a conditional goto to resume execution
-  struct branch_pointt
-  {
-    symex_target_equationt equation;
-    statet state;
-
-    explicit branch_pointt(const symex_target_equationt &e, const statet &s)
-      : equation(e), state(s, &equation)
-    {
-    }
-
-    explicit branch_pointt(const branch_pointt &other)
-      : equation(other.equation), state(other.state, &equation)
-    {
-    }
-  };
-
-  typedef std::list<branch_pointt> branch_worklistt;
-
   goto_symext(
     message_handlert &mh,
     const symbol_tablet &outer_symbol_table,
     symex_target_equationt &_target,
-    branch_worklistt &branch_worklist)
+    path_storaget &path_storage)
     : total_vccs(0),
       remaining_vccs(0),
       constant_propagation(true),
@@ -81,7 +63,7 @@ public:
       atomic_section_counter(0),
       log(mh),
       guard_identifier("goto_symex::\\guard"),
-      branch_worklist(branch_worklist)
+      path_storage(path_storage)
   {
     options.set_option("simplify", true);
     options.set_option("assertions", true);
@@ -462,7 +444,7 @@ protected:
   void replace_nondet(exprt &);
   void rewrite_quantifiers(exprt &, statet &);
 
-  branch_worklistt &branch_worklist;
+  path_storaget &path_storage;
 };
 
 #endif // CPROVER_GOTO_SYMEX_GOTO_SYMEX_H

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -372,7 +372,13 @@ public:
   incremental_dirtyt dirty;
 
   goto_programt::const_targett saved_target;
-  bool has_saved_target;
+
+  /// \brief This state is saved, with the PC pointing to the target of a GOTO
+  bool has_saved_jump_target;
+
+  /// \brief This state is saved, with the PC pointing to the next instruction
+  /// of a GOTO
+  bool has_saved_next_instruction;
   bool saved_target_is_backwards;
 
 private:

--- a/src/goto-symex/path_storage.cpp
+++ b/src/goto-symex/path_storage.cpp
@@ -19,17 +19,20 @@ path_storaget::make(path_storaget::disciplinet discipline)
   UNREACHABLE;
 }
 
-path_storaget::patht &path_fifot::peek()
+path_storaget::patht &path_fifot::private_peek()
 {
   return paths.front();
 }
 
-void path_fifot::push(const path_storaget::patht &bp)
+void path_fifot::push(
+  const path_storaget::patht &next_instruction,
+  const path_storaget::patht &jump_target)
 {
-  paths.push_back(bp);
+  paths.push_back(next_instruction);
+  paths.push_back(jump_target);
 }
 
-void path_fifot::pop()
+void path_fifot::private_pop()
 {
   paths.pop_front();
 }

--- a/src/goto-symex/path_storage.cpp
+++ b/src/goto-symex/path_storage.cpp
@@ -1,0 +1,40 @@
+/*******************************************************************\
+
+Module: Path Storage
+
+Author: Kareem Khazem <karkhaz@karkhaz.com>
+
+\*******************************************************************/
+
+#include "path_storage.h"
+
+std::unique_ptr<path_storaget>
+path_storaget::make(path_storaget::disciplinet discipline)
+{
+  switch(discipline)
+  {
+  case path_storaget::disciplinet::FIFO:
+    return std::unique_ptr<path_fifot>(new path_fifot());
+  }
+  UNREACHABLE;
+}
+
+path_storaget::patht &path_fifot::peek()
+{
+  return paths.front();
+}
+
+void path_fifot::push(const path_storaget::patht &bp)
+{
+  paths.push_back(bp);
+}
+
+void path_fifot::pop()
+{
+  paths.pop_front();
+}
+
+std::size_t path_fifot::size() const
+{
+  return paths.size();
+}

--- a/src/goto-symex/path_storage.cpp
+++ b/src/goto-symex/path_storage.cpp
@@ -13,6 +13,39 @@ Author: Kareem Khazem <karkhaz@karkhaz.com>
 #include <util/exit_codes.h>
 #include <util/make_unique.h>
 
+// _____________________________________________________________________________
+// path_lifot
+
+path_storaget::patht &path_lifot::private_peek()
+{
+  last_peeked = paths.end();
+  --last_peeked;
+  return paths.back();
+}
+
+void path_lifot::push(
+  const path_storaget::patht &next_instruction,
+  const path_storaget::patht &jump_target)
+{
+  paths.push_back(next_instruction);
+  paths.push_back(jump_target);
+}
+
+void path_lifot::private_pop()
+{
+  PRECONDITION(last_peeked != paths.end());
+  paths.erase(last_peeked);
+  last_peeked = paths.end();
+}
+
+std::size_t path_lifot::size() const
+{
+  return paths.size();
+}
+
+// _____________________________________________________________________________
+// path_fifot
+
 path_storaget::patht &path_fifot::private_peek()
 {
   return paths.front();
@@ -35,6 +68,9 @@ std::size_t path_fifot::size() const
 {
   return paths.size();
 }
+
+// _____________________________________________________________________________
+// path_strategy_choosert
 
 std::string path_strategy_choosert::show_strategies() const
 {
@@ -69,10 +105,19 @@ void path_strategy_choosert::set_path_strategy_options(
 
 path_strategy_choosert::path_strategy_choosert()
   : strategies(
-      {{"fifo",
+      {{"lifo",
+        {" lifo                         next instruction is pushed before\n"
+         "                              goto target; paths are popped in\n"
+         "                              last-in, first-out order. Explores\n"
+         "                              the program tree depth-first.\n",
+         []() { // NOLINT(whitespace/braces)
+           return util_make_unique<path_lifot>();
+         }}},
+       {"fifo",
         {" fifo                         next instruction is pushed before\n"
          "                              goto target; paths are popped in\n"
-         "                              first-in, first-out order\n",
+         "                              first-in, first-out order. Explores\n"
+         "                              the program tree breadth-first.\n",
          []() { // NOLINT(whitespace/braces)
            return util_make_unique<path_fifot>();
          }}}})

--- a/src/goto-symex/path_storage.h
+++ b/src/goto-symex/path_storage.h
@@ -1,0 +1,82 @@
+/// \file path_storage.h
+/// \brief Storage of symbolic execution paths to resume
+/// \author Kareem Khazem <karkhaz@karkhaz.com>
+
+#ifndef CPROVER_GOTO_SYMEX_PATH_STORAGE_H
+#define CPROVER_GOTO_SYMEX_PATH_STORAGE_H
+
+#include "goto_symex_state.h"
+#include "symex_target_equation.h"
+
+#include <memory>
+
+/// \brief Storage for symbolic execution paths to be resumed later
+///
+/// This data structure supports saving partially-executed symbolic
+/// execution \ref path_storaget::patht "paths" so that their execution can
+/// be halted and resumed later. The choice of which path should be
+/// resumed next is implemented by subtypes of this abstract class.
+class path_storaget
+{
+public:
+  /// \brief Derived types of path_storaget
+  enum class disciplinet
+  {
+    /// path_fifot
+    FIFO
+  };
+
+  /// \brief Information saved at a conditional goto to resume execution
+  struct patht
+  {
+    symex_target_equationt equation;
+    goto_symex_statet state;
+
+    explicit patht(const symex_target_equationt &e, const goto_symex_statet &s)
+      : equation(e), state(s, &equation)
+    {
+    }
+
+    explicit patht(const patht &other)
+      : equation(other.equation), state(other.state, &equation)
+    {
+    }
+  };
+
+  /// \brief Factory method for building a subtype of path_storaget
+  static std::unique_ptr<path_storaget> make(disciplinet discipline);
+  virtual ~path_storaget() = default;
+
+  /// \brief Reference to the next path to resume
+  virtual patht &peek() = 0;
+
+  /// \brief Add a path to resume to the storage
+  virtual void push(const patht &bp) = 0;
+
+  /// \brief Remove the next path to resume from the storage
+  virtual void pop() = 0;
+
+  /// \brief How many paths does this storage contain?
+  virtual std::size_t size() const = 0;
+
+  /// \brief Is this storage empty?
+  bool empty() const
+  {
+    return size() == 0;
+  };
+};
+
+/// \brief FIFO save queue: paths are resumed in the order that they were saved
+class path_fifot : public path_storaget
+{
+public:
+  patht &peek() override;
+  void push(const patht &bp) override;
+  void pop() override;
+  std::size_t size() const override;
+
+protected:
+  std::list<patht> paths;
+};
+
+#endif /* CPROVER_GOTO_SYMEX_PATH_STORAGE_H */

--- a/src/goto-symex/path_storage.h
+++ b/src/goto-symex/path_storage.h
@@ -84,6 +84,22 @@ private:
   virtual void private_pop() = 0;
 };
 
+/// \brief LIFO save queue: depth-first search, try to finish paths
+class path_lifot : public path_storaget
+{
+public:
+  void push(const patht &, const patht &) override;
+  std::size_t size() const override;
+
+protected:
+  std::list<path_storaget::patht>::iterator last_peeked;
+  std::list<patht> paths;
+
+private:
+  patht &private_peek() override;
+  void private_pop() override;
+};
+
 /// \brief FIFO save queue: paths are resumed in the order that they were saved
 class path_fifot : public path_storaget
 {
@@ -134,7 +150,7 @@ public:
 protected:
   std::string default_strategy() const
   {
-    return "fifo";
+    return "lifo";
   }
 
   /// Map from the name of a strategy (to be supplied on the command line), to

--- a/src/goto-symex/path_storage.h
+++ b/src/goto-symex/path_storage.h
@@ -8,6 +8,11 @@
 #include "goto_symex_state.h"
 #include "symex_target_equation.h"
 
+#include <util/options.h>
+#include <util/cmdline.h>
+#include <util/ui_message.h>
+#include <util/invariant.h>
+
 #include <memory>
 
 /// \brief Storage for symbolic execution paths to be resumed later
@@ -19,13 +24,6 @@
 class path_storaget
 {
 public:
-  /// \brief Derived types of path_storaget
-  enum class disciplinet
-  {
-    /// path_fifot
-    FIFO
-  };
-
   /// \brief Information saved at a conditional goto to resume execution
   struct patht
   {
@@ -43,8 +41,6 @@ public:
     }
   };
 
-  /// \brief Factory method for building a subtype of path_storaget
-  static std::unique_ptr<path_storaget> make(disciplinet discipline);
   virtual ~path_storaget() = default;
 
   /// \brief Reference to the next path to resume
@@ -101,6 +97,53 @@ protected:
 private:
   patht &private_peek() override;
   void private_pop() override;
+};
+
+/// \brief Factory and information for path_storaget
+class path_strategy_choosert
+{
+public:
+  path_strategy_choosert();
+
+  /// \brief suitable for displaying as a front-end help message
+  std::string show_strategies() const;
+
+  /// \brief is there a factory constructor for the named strategy?
+  bool is_valid_strategy(const std::string strategy) const
+  {
+    return strategies.find(strategy) != strategies.end();
+  }
+
+  /// \brief Factory for a path_storaget
+  ///
+  /// Ensure that path_strategy_choosert::is_valid_strategy() returns true for a
+  /// particular string before calling this function on that string.
+  std::unique_ptr<path_storaget> get(const std::string strategy) const
+  {
+    auto found = strategies.find(strategy);
+    INVARIANT(
+      found != strategies.end(), "Unknown strategy '" + strategy + "'.");
+    return found->second.second();
+  }
+
+  /// \brief add `paths` and `exploration-strategy` option, suitable to be
+  /// invoked from front-ends.
+  void
+  set_path_strategy_options(const cmdlinet &, optionst &, messaget &) const;
+
+protected:
+  std::string default_strategy() const
+  {
+    return "fifo";
+  }
+
+  /// Map from the name of a strategy (to be supplied on the command line), to
+  /// the help text for that strategy and a factory thunk returning a pointer to
+  /// a derived class of path_storaget that implements that strategy.
+  std::map<const std::string,
+           std::pair<const std::string,
+                     const std::function<std::unique_ptr<path_storaget>()>>>
+    strategies;
 };
 
 #endif /* CPROVER_GOTO_SYMEX_PATH_STORAGE_H */

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -169,7 +169,8 @@ void goto_symext::symex_goto(statet &state)
     goto_programt::const_targett tmp = new_state_pc;
     new_state_pc = state_pc;
     state_pc = tmp;
-    log.debug() << "Resuming from '" << state_pc->code.source_location() << "'"
+
+    log.debug() << "Resuming from '" << state_pc->source_location << "'"
                 << log.eom;
   }
   else if(options.get_bool_option("paths"))

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -181,14 +181,14 @@ void goto_symext::symex_goto(statet &state)
     // executing from, so that goto_symex::symex_goto() knows that we've already
     // explored the branch starting from `state_pc` when it is later called at
     // this branch.
-    branch_pointt branch_point(target, state);
+    path_storaget::patht branch_point(target, state);
     branch_point.state.saved_target = new_state_pc;
     branch_point.state.has_saved_target = true;
     // `forward` tells us where the branch we're _currently_ executing is
     // pointing to; this needs to be inverted for the branch that we're saving,
     // so let its truth value for `backwards` be the same as ours for `forward`.
     branch_point.state.saved_target_is_backwards = forward;
-    branch_worklist.push_back(branch_point);
+    path_storage.push(branch_point);
     log.debug() << "Saving '" << new_state_pc->source_location << "'"
                 << log.eom;
   }

--- a/src/jbmc/jbmc_parse_options.h
+++ b/src/jbmc/jbmc_parse_options.h
@@ -27,6 +27,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/show_properties.h>
 #include <goto-instrument/cover.h>
 
+#include <goto-symex/path_storage.h>
+
 #include <java_bytecode/java_bytecode_language.h>
 
 class bmct;
@@ -103,6 +105,7 @@ public:
 protected:
   ui_message_handlert ui_message_handler;
   std::unique_ptr<cover_configt> cover_config;
+  path_strategy_choosert path_strategy_chooser;
 
   void eval_verbosity();
   void get_command_line_options(optionst &);

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(
         java_bytecode
         goto-programs
         goto-instrument-lib
+        cbmc-lib
 )
 
 add_test(

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -30,6 +30,7 @@ SRC += unit_tests.cpp \
        java_bytecode/java_types/java_type_from_string.cpp \
        java_bytecode/java_utils_test.cpp \
        java_bytecode/inherited_static_fields/inherited_static_fields.cpp \
+       path_strategies.cpp \
        pointer-analysis/custom_value_set_analysis.cpp \
        sharing_node.cpp \
        solvers/refinement/string_constraint_generator_valueof/calculate_max_string_length.cpp \
@@ -71,6 +72,34 @@ cprover.dir:
 testing-utils.dir:
 	$(MAKE) $(MAKEARGS) -C testing-utils
 
+# We need to link bmc.o to the unit test, so here's everything it depends on...
+BMC_DEPS =../src/cbmc/all_properties$(OBJEXT) \
+          ../src/cbmc/bmc$(OBJEXT) \
+          ../src/cbmc/bmc_cover$(OBJEXT) \
+          ../src/cbmc/bv_cbmc$(OBJEXT) \
+          ../src/cbmc/cbmc_dimacs$(OBJEXT) \
+          ../src/cbmc/cbmc_languages$(OBJEXT) \
+          ../src/cbmc/cbmc_parse_options$(OBJEXT) \
+          ../src/cbmc/cbmc_solvers$(OBJEXT) \
+          ../src/cbmc/counterexample_beautification$(OBJEXT) \
+          ../src/cbmc/fault_localization$(OBJEXT) \
+          ../src/cbmc/show_vcc$(OBJEXT) \
+          ../src/cbmc/symex_bmc$(OBJEXT) \
+          ../src/cbmc/symex_coverage$(OBJEXT) \
+          ../src/cbmc/xml_interface$(OBJEXT) \
+          ../src/jsil/expr2jsil$(OBJEXT) \
+          ../src/jsil/jsil_convert$(OBJEXT) \
+          ../src/jsil/jsil_entry_point$(OBJEXT) \
+          ../src/jsil/jsil_internal_additions$(OBJEXT) \
+          ../src/jsil/jsil_language$(OBJEXT) \
+          ../src/jsil/jsil_lex.yy$(OBJEXT) \
+          ../src/jsil/jsil_parser$(OBJEXT) \
+          ../src/jsil/jsil_parse_tree$(OBJEXT) \
+          ../src/jsil/jsil_typecheck$(OBJEXT) \
+          ../src/jsil/jsil_types$(OBJEXT) \
+          ../src/jsil/jsil_y.tab$(OBJEXT) \
+          # Empty last line
+#
 CPROVER_LIBS =../src/java_bytecode/java_bytecode$(LIBEXT) \
               ../src/miniz/miniz$(OBJEXT) \
               ../src/ansi-c/ansi-c$(LIBEXT) \
@@ -86,6 +115,7 @@ CPROVER_LIBS =../src/java_bytecode/java_bytecode$(LIBEXT) \
               ../src/assembler/assembler$(LIBEXT) \
               ../src/analyses/analyses$(LIBEXT) \
               ../src/solvers/solvers$(LIBEXT) \
+              $(BMC_DEPS)
               # Empty last line
 
 OBJ += $(CPROVER_LIBS) testing-utils/testing-utils$(LIBEXT)

--- a/unit/path_strategies.h
+++ b/unit/path_strategies.h
@@ -1,0 +1,62 @@
+/// \file Test for path strategies set through `cbmc --paths ...`
+///
+/// \author Kareem Khazem
+
+#ifndef CPROVER_PATH_STRATEGIES_H
+#define CPROVER_PATH_STRATEGIES_H
+
+#include <goto-programs/goto_model.h>
+#include <goto-programs/safety_checker.h>
+
+#include <goto-symex/goto_symex_state.h>
+
+/// \brief Events that we expect to happen during path exploration
+///
+/// See the description in the .cpp file on how to use this class.
+struct symex_eventt
+{
+public:
+  enum class enumt
+  {
+    JUMP,
+    NEXT,
+    SUCCESS,
+    FAILURE
+  };
+  typedef std::pair<enumt, int> pairt;
+  typedef std::list<pairt> listt;
+
+  static pairt resume(enumt kind, int location)
+  {
+    return pairt(kind, location);
+  }
+
+  static pairt result(enumt kind)
+  {
+    return pairt(kind, -1);
+  }
+
+  static void
+  validate_result(listt &events, const safety_checkert::resultt result);
+
+  static void validate_resume(listt &events, const goto_symex_statet &state);
+};
+
+void _check_with_strategy(
+  const std::string &strategy,
+  const std::string &program,
+  const unsigned unwind_limit,
+  symex_eventt::listt &events);
+
+/// Call this one, not the underscore version
+void check_with_strategy(
+  const std::string &strategy,
+  const std::string &program,
+  symex_eventt::listt events,
+  const unsigned unwind_limit)
+{
+  WHEN("strategy is '" + strategy + "'")
+  _check_with_strategy(strategy, program, unwind_limit, events);
+}
+
+#endif // CPROVER_PATH_STRATEGIES_H


### PR DESCRIPTION
Most of this daunting pull request is tests, I promise. :innocent:

- Implement @martin-cs's suggestion that control of which path to continue executing be moved out of `goto_symex/symex_goto.cpp` entirely. My previous implementation always saved one path on the queue and continued executing the other, meaning that _every_ symex run ended at the end of a path. We now save _both_ paths and halt symbolic execution, returning control to the caller, who can choose which path to execute (either of the two paths that were just saved, or even any of the paths that were saved earlier). This implies that a symex run shouldn't always be followed by a safety check, since we may not have finished executing a path; thus, I added `safety_checkert::resultt::SUSPENDED` to indicate that symex was suspended half-way through and the resulting equation has not been safety-checked.

- The path workqueue now has a custom data type instead of being a `std::list`, with `push()`, `peek()`, and `pop()` methods. The data type is subclassable for implementing different strategies. `peek()` is intentionally not marked `const`, so that the data type can lazily search for the next path to return only when `peek()` is called rather than modifying its state every time `push()` is called; I anticipate that future strategies might be time-consuming.

- There's a data structure called `path_strategy_choosert` which is both a factory for path exploration strategies, and also holds their stringified names and help texts all in the same place, so that there's a uniform way of setting the path exploration strategy from all the frontends without duplication.

- Two strategies are implemented: FIFO and progressive FIFO. The paths that FIFO returns will always alternate between the next instruction of a goto, and the target of that same goto, followed by the next and target of another goto, etc. Progressive FIFO will always return the jump targets of all gotos that have been pushed, and only start returning next instructions when the jump targets have all been executed---the idea being to prefer making forward progress rather than dwelling inside loops.

- Tests for all of this, courtesy of the Department of Overengineered Solutions. In order to test the functional correctness of strategies, we not only need to test the verification result, but also the order in which paths are popped. This means multi-line regexes in the test suite, but even for short test cases these regexes are hundreds of bytes long---tedious to write and impossible to understand. I therefore wrote an interpreter for a human-friendly language representing the pushes and pops of a path queue. Test writers should write what paths they expect to see in what order in the comments section of a `test.in` file, from which a `test.desc` file gets generated by `scripts/make_descs.py`. For example, writing this `test.in` file:

```
CORE
main.c
--unwind 2
activate-multi-line-match
SIGNAL=0
EXIT=10
--
^warning: ignoring
--
This strategy differs from 'fifo' because the failed path is the second
one, not the last one.

Test that the following happens in order:
execute line 6
save next 7
save jump 9

// We skip the loop first with this strategy. This path is infeasible,
// since x is 1 so we must have entered the loop; so the solver is happy.
any lines
execute line 6
resume jump 9
execute line 9
any lines
path is successful

// We now enter the loop and execute it; we then save "entering the loop
// twice" and "bailing out after the first spin".
any lines
execute line 6
resume next 7
execute line 7
any lines
save next 7
save jump 9

// Since the just saved "bailing out after the first spin" is a jump,
// execute that path. That path makes the assertion fail, since we
// decremented x from 1 to 0.
any lines
execute line 6
resume jump 9
execute line 9
any lines
path is unsuccessful

// Finally, execute "entering the loop twice". This path is infeasible
// because we cannot actually have entered the loop twice if x was only
// 1 to begin with, so the solver is happy.
any lines
execute line 6
resume next 7
execute line 7
any lines
path is successful
end
```
generates this `test.desc:`
```
CORE
main.c
--unwind 2
activate-multi-line-match
SIGNAL=0
EXIT=10
BMC at file[^\n]+line 6 function \w+\nSaving next instruction 'file[^\n]+line 7 function \w+'\nSaving jump target 'file[^\n]+line 9 function \w+'(.|\n)+BMC at file[^\n]+line 6 function \w+\nResuming from jump target 'file[^\n]+line 9 function \w+'\nBMC at file[^\n]+line 9 function \w+(.|\n)+VERIFICATION SUCCESSFUL(.|\n)+BMC at file[^\n]+line 6 function \w+\nResuming from next instruction 'file[^\n]+line 7 function \w+'\nBMC at file[^\n]+line 7 function \w+(.|\n)+Saving next instruction 'file[^\n]+line 7 function \w+'\nSaving jump target 'file[^\n]+line 9 function \w+'(.|\n)+BMC at file[^\n]+line 6 function \w+\nResuming from jump target 'file[^\n]+line 9 function \w+'\nBMC at file[^\n]+line 9 function \w+(.|\n)+VERIFICATION FAILED(.|\n)+BMC at file[^\n]+line 6 function \w+\nResuming from next instruction 'file[^\n]+line 7 function \w+'\nBMC at file[^\n]+line 7 function \w+(.|\n)+VERIFICATION SUCCESSFUL\n[^.]
--
^warning: ignoring
--
This strategy differs from 'fifo' because the failed path is the second
one, not the last one.

WARNING: This test.desc file is automatically generated
from the test.in file in this directory. Do not modify
this file.
```