### PR TITLE
goto-analyzer (un)reachable-functions: build valid json output

### DIFF
--- a/regression/goto-analyzer/reachable-functions-basic-json/test.desc
+++ b/regression/goto-analyzer/reachable-functions-basic-json/test.desc
@@ -6,4 +6,5 @@ CORE
 "function": "obviously_dead",$
 "function": "not_obviously_dead",$
 --
+"last line":[[:space:]]*$
 ^warning: ignoring

--- a/regression/goto-analyzer/unreachable-functions-basic-json/test.desc
+++ b/regression/goto-analyzer/unreachable-functions-basic-json/test.desc
@@ -6,4 +6,5 @@ CORE
 "function": "not_called",
 "last line": 6
 --
+"last line":[[:space:]]*$
 ^warning: ignoring

--- a/src/goto-analyzer/unreachable_instructions.cpp
+++ b/src/goto-analyzer/unreachable_instructions.cpp
@@ -325,9 +325,21 @@ static void list_functions(
 
       goto_programt::const_targett end_function=
         goto_program.instructions.end();
-      --end_function;
-      assert(end_function->is_end_function());
-      last_location=end_function->source_location;
+
+      // find the last instruction with a line number
+      // TODO(tautschnig): #918 will eventually ensure that every instruction
+      // has such
+      do
+      {
+        --end_function;
+        last_location = end_function->source_location;
+      }
+      while(
+        end_function != goto_program.instructions.begin() &&
+        last_location.get_line().empty());
+
+      if(last_location.get_line().empty())
+        last_location = decl.location;
     }
     else
       // completely ignore functions without a body, both for


### PR DESCRIPTION
Some functions do not have a location attached to the END_FUNCTION instruction.
This should be fixed (as is discussed in PR#918), but until such a fix is in
place this workaround will ensure JSON output is valid by not exclusively
relying on the END_FUNCTION location.

The regression tests now explicitly test for absence of such invalid JSON.