### PR TITLE
Speed up resolution of virtual callsites in lazy loading v1

### DIFF
--- a/src/java_bytecode/ci_lazy_methods.cpp
+++ b/src/java_bytecode/ci_lazy_methods.cpp
@@ -170,14 +170,15 @@ bool ci_lazy_methodst::operator()(
             << " callsites)"
             << eom;
 
-    for(const auto &callsite : virtual_callsites)
+    std::unordered_set<exprt, irep_hash> unique_functions;
+    for(const code_function_callt *virtual_callsite : virtual_callsites)
+      unique_functions.insert(virtual_callsite->function());
+
+    for(const exprt &function : unique_functions)
     {
       // This will also create a stub if a virtual callsite has no targets.
       get_virtual_method_targets(
-        *callsite,
-        instantiated_classes,
-        method_worklist2,
-        symbol_table);
+        function, instantiated_classes, method_worklist2, symbol_table);
     }
   }
   while(any_new_methods);
@@ -403,8 +404,8 @@ void ci_lazy_methodst::gather_virtual_callsites(
 
 /// Find possible callees, excluding types that are not known to be
 /// instantiated.
-/// \param c: function call whose potential target functions should
-///   be determined.
+/// \param called_function: virtual function call whose concrete function calls
+///   should be determined.
 /// \param instantiated_classes: set of classes that can be instantiated. Any
 ///   potential callee not in this set will be ignored.
 /// \param symbol_table: global symbol table
@@ -412,12 +413,11 @@ void ci_lazy_methodst::gather_virtual_callsites(
 ///   taking `instantiated_classes` into account (virtual function overrides
 ///   defined on classes that are not 'needed' are ignored)
 void ci_lazy_methodst::get_virtual_method_targets(
-  const code_function_callt &c,
+  const exprt &called_function,
   const std::set<irep_idt> &instantiated_classes,
   std::vector<irep_idt> &callable_methods,
   symbol_tablet &symbol_table)
 {
-  const auto &called_function=c.function();
   PRECONDITION(called_function.id()==ID_virtual_function);
 
   const auto &call_class=called_function.get(ID_C_class);

--- a/src/java_bytecode/ci_lazy_methods.h
+++ b/src/java_bytecode/ci_lazy_methods.h
@@ -134,7 +134,7 @@ private:
     std::vector<const code_function_callt *> &result);
 
   void get_virtual_method_targets(
-    const code_function_callt &c,
+    const exprt &called_function,
     const std::set<irep_idt> &instantiated_classes,
     std::vector<irep_idt> &callable_methods,
     symbol_tablet &symbol_table);


### PR DESCRIPTION
We removed duplicates from the list of virtual callsites by using an
unordered set. This gave a large speed up on at least one use case.
There is scope for further optimisation.