### PR TITLE
Fix cmake build

### DIFF
--- a/src/goto-programs/CMakeLists.txt
+++ b/src/goto-programs/CMakeLists.txt
@@ -3,4 +3,5 @@ add_library(goto-programs ${sources})
 
 generic_includes(goto-programs)
 
-target_link_libraries(goto-programs util assembler langapi analyses ansi-c)
+target_link_libraries(
+        goto-programs util assembler langapi analyses ansi-c java_bytecode)


### PR DESCRIPTION
cmake is failing while linking because of some dependencies between
goto-programs and java_bytecode.
Ideally this dependency should be removed but in the mean time the best
thing to do is to add java_bytecode for the linking of goto-programs.