### PR TITLE
Unit tests for invokedynamic with static lambdas [TG-2811]

### DIFF
--- a/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -250,8 +250,6 @@ protected:
 
   const bytecode_infot &get_bytecode_info(const irep_idt &statement);
 
-  bool class_needs_clinit(const irep_idt &classname);
-  exprt get_or_create_clinit_wrapper(const irep_idt &classname);
   codet get_clinit_call(const irep_idt &classname);
 
   bool is_method_inherited(

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -21,6 +21,7 @@ SRC += unit_tests.cpp \
        goto-programs/class_hierarchy_graph.cpp \
        goto-programs/remove_virtual_functions_without_fallback.cpp \
        java_bytecode/java_bytecode_convert_class/convert_abstract_class.cpp \
+       java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp \
        java_bytecode/java_bytecode_parse_generics/parse_generic_class.cpp \
        java_bytecode/java_object_factory/gen_nondet_string_init.cpp \
        java_bytecode/java_bytecode_parse_lambdas/java_bytecode_parse_lambda_method_table.cpp \

--- a/unit/java_bytecode/ci_lazy_methods/lazy_load_lambdas.cpp
+++ b/unit/java_bytecode/ci_lazy_methods/lazy_load_lambdas.cpp
@@ -18,7 +18,8 @@ SCENARIO(
   {
     const symbol_tablet symbol_table = load_java_class_lazy(
       "LocalLambdas",
-      "./java_bytecode/java_bytecode_parse_lambdas/lambda_examples/",
+      "./java_bytecode/java_bytecode_parse_lambdas/lambda_examples/"
+      "openjdk_8_classes",
       "LocalLambdas.test");
 
     THEN("Then the lambdas should be loaded")
@@ -68,7 +69,8 @@ SCENARIO(
   {
     const symbol_tablet symbol_table = load_java_class_lazy(
       "MemberLambdas",
-      "./java_bytecode/java_bytecode_parse_lambdas/lambda_examples/",
+      "./java_bytecode/java_bytecode_parse_lambdas/lambda_examples/"
+      "openjdk_8_classes",
       "MemberLambdas.test");
 
     THEN("Then the lambdas should be loaded")
@@ -117,7 +119,8 @@ SCENARIO(
   {
     const symbol_tablet symbol_table = load_java_class_lazy(
       "StaticLambdas",
-      "./java_bytecode/java_bytecode_parse_lambdas/lambda_examples/",
+      "./java_bytecode/java_bytecode_parse_lambdas/lambda_examples/"
+      "openjdk_8_classes",
       "StaticLambdas.test");
 
     THEN("Then the lambdas should be loaded")
@@ -166,7 +169,8 @@ SCENARIO(
   {
     const symbol_tablet symbol_table = load_java_class_lazy(
       "OuterMemberLambdas$Inner",
-      "./java_bytecode/java_bytecode_parse_lambdas/lambda_examples/",
+      "./java_bytecode/java_bytecode_parse_lambdas/lambda_examples/"
+      "openjdk_8_classes",
       "OuterMemberLambdas$Inner.test");
 
     THEN("Then the lambdas should be loaded")
@@ -192,7 +196,8 @@ SCENARIO(
 {
   const symbol_tablet symbol_table = load_java_class_lazy(
     "ExternalLambdaAccessor",
-    "./java_bytecode/java_bytecode_parse_lambdas/lambda_examples/",
+    "./java_bytecode/java_bytecode_parse_lambdas/lambda_examples/"
+    "openjdk_8_classes",
     "ExternalLambdaAccessor.test");
 
   THEN("Then the lambdas should be loaded")

--- a/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -86,6 +86,23 @@ SCENARIO(
               lambda_implementor_type_symbol.type);
 
           REQUIRE(tmp_lambda_class_type.has_base("java::SimpleLambda"));
+
+          THEN("The function in the class should call the lambda method")
+          {
+            const irep_idt method_identifier =
+              id2string(tmp_class_identifier) + ".Execute:()V";
+            const symbolt &method_symbol =
+              require_symbol::require_symbol_exists(
+                symbol_table, method_identifier);
+
+            REQUIRE(method_symbol.is_function());
+
+            const std::vector<codet> &assignments =
+              require_goto_statements::get_all_statements(method_symbol.value);
+
+            require_goto_statements::require_function_call(
+              assignments, "java::LocalLambdas.lambda$test$0:()V");
+          }
         }
       }
     }

--- a/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -143,6 +143,23 @@ SCENARIO(
             "Object;LDummyGeneric;)V";
           validate_lamdba_assignement(symbol_table, instructions, test_data);
         }
+        THEN(
+          "The local variable should be assigned a non-null pointer to a "
+          "array parameter interface implementor")
+        {
+          lambda_assignment_test_datat test_data;
+
+          test_data.lambda_variable_id =
+            std::regex(function_prefix_regex_str + "::\\d+::arrayParamLambda$");
+
+          test_data.lambda_interface = "java::ArrayParameterLambda";
+          test_data.lambda_interface_method_descriptor =
+            ".Execute:([I[Ljava/lang/Object;[LDummyGeneric;)V";
+          test_data.lambda_function_id =
+            "java::LocalLambdas.lambda$test$2:"
+            "([I[Ljava/lang/Object;[LDummyGeneric;)V";
+          validate_lamdba_assignement(symbol_table, instructions, test_data);
+        }
       }
     }
   });

--- a/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -14,6 +14,81 @@
 #include <testing-utils/run_test_with_compilers.h>
 #include <testing-utils/require_symbol.h>
 
+struct lambda_assignment_test_datat
+{
+  irep_idt lambda_variable_id;
+  irep_idt lambda_interface;
+  std::string lambda_interface_method_descriptor;
+  irep_idt lambda_function_id;
+};
+
+void validate_lamdba_assignement(
+  const symbol_tablet &symbol_table,
+  const std::vector<codet> &instructions,
+  const lambda_assignment_test_datat &test_data)
+{
+  const auto lambda_assignment =
+    require_goto_statements::find_pointer_assignments(
+      test_data.lambda_variable_id, instructions);
+
+  REQUIRE(lambda_assignment.non_null_assignments.size() == 1);
+  REQUIRE_FALSE(lambda_assignment.null_assignment.has_value());
+
+  const typecast_exprt &rhs_value = require_expr::require_typecast(
+    lambda_assignment.non_null_assignments[0].rhs());
+
+  const symbol_exprt &rhs_symbol =
+    require_expr::require_symbol(rhs_value.op0());
+
+  const irep_idt &tmp_object_symbol = rhs_symbol.get_identifier();
+
+  const auto tmp_object_assignments =
+    require_goto_statements::find_pointer_assignments(
+      tmp_object_symbol, instructions);
+
+  REQUIRE(tmp_object_assignments.non_null_assignments.size() == 1);
+  REQUIRE_FALSE(tmp_object_assignments.null_assignment.has_value());
+
+  const side_effect_exprt &side_effect_expr =
+    require_expr::require_side_effect_expr(
+      tmp_object_assignments.non_null_assignments[0].rhs(), ID_java_new);
+
+  const pointer_typet &lambda_temp_type =
+    require_type::require_pointer(side_effect_expr.type(), {});
+
+  const symbol_typet &lambda_implementor_type =
+    require_type::require_symbol(lambda_temp_type.subtype());
+
+  const irep_idt &tmp_class_identifier =
+    lambda_implementor_type.get_identifier();
+
+  const symbolt &lambda_implementor_type_symbol =
+    require_symbol::require_symbol_exists(symbol_table, tmp_class_identifier);
+
+  REQUIRE(lambda_implementor_type_symbol.is_type);
+  const class_typet &tmp_lambda_class_type =
+    require_type::require_complete_class(lambda_implementor_type_symbol.type);
+
+  REQUIRE(tmp_lambda_class_type.has_base(test_data.lambda_interface));
+
+  THEN("The function in the class should call the lambda method")
+  {
+    const irep_idt method_identifier =
+      id2string(tmp_class_identifier) +
+      test_data.lambda_interface_method_descriptor;
+    const symbolt &method_symbol =
+      require_symbol::require_symbol_exists(symbol_table, method_identifier);
+
+    REQUIRE(method_symbol.is_function());
+
+    const std::vector<codet> &assignments =
+      require_goto_statements::get_all_statements(method_symbol.value);
+
+    require_goto_statements::require_function_call(
+      assignments, test_data.lambda_function_id);
+  }
+}
+
 SCENARIO(
   "Converting invokedynamic with a local lambda",
   "[core]"
@@ -36,73 +111,19 @@ SCENARIO(
           require_goto_statements::get_all_statements(
             symbol_table.lookup_ref("java::LocalLambdas.test:()V").value);
 
-        THEN("The local variable should be assigned a non-null pointer")
+        const std::string function_prefix = "java::LocalLambdas.test:()V";
+
+        THEN(
+          "The local variable should be assigned a temp object implementing "
+          "SimpleLambda")
         {
-          // TODO(tkiley): we don't want 11 here
-          // TODO(tkiley): This is the actual lambda which doesn't currently work
-          const auto lambda_assignment =
-            require_goto_statements::find_pointer_assignments(
-              "java::LocalLambdas.test:()V::11::simpleLambda", instructions);
+          lambda_assignment_test_datat test_data;
+          test_data.lambda_variable_id = function_prefix + "::11::simpleLambda";
 
-          REQUIRE(lambda_assignment.non_null_assignments.size() == 1);
-          REQUIRE_FALSE(lambda_assignment.null_assignment.has_value());
-
-          const typecast_exprt &rhs_value = require_expr::require_typecast(
-            lambda_assignment.non_null_assignments[0].rhs());
-
-          const symbol_exprt &rhs_symbol =
-            require_expr::require_symbol(rhs_value.op0());
-
-          const irep_idt &tmp_object_symbol = rhs_symbol.get_identifier();
-
-          const auto tmp_object_assignments =
-            require_goto_statements::find_pointer_assignments(
-              tmp_object_symbol, instructions);
-
-          REQUIRE(tmp_object_assignments.non_null_assignments.size() == 1);
-          REQUIRE_FALSE(tmp_object_assignments.null_assignment.has_value());
-
-          const side_effect_exprt &side_effect_expr =
-            require_expr::require_side_effect_expr(
-              tmp_object_assignments.non_null_assignments[0].rhs(),
-              ID_java_new);
-
-          const pointer_typet &lambda_temp_type =
-            require_type::require_pointer(side_effect_expr.type(), {});
-
-          const symbol_typet &lambda_implementor_type =
-            require_type::require_symbol(lambda_temp_type.subtype());
-
-          const irep_idt &tmp_class_identifier =
-            lambda_implementor_type.get_identifier();
-
-          const symbolt &lambda_implementor_type_symbol =
-            require_symbol::require_symbol_exists(
-              symbol_table, tmp_class_identifier);
-
-          REQUIRE(lambda_implementor_type_symbol.is_type);
-          const class_typet &tmp_lambda_class_type =
-            require_type::require_complete_class(
-              lambda_implementor_type_symbol.type);
-
-          REQUIRE(tmp_lambda_class_type.has_base("java::SimpleLambda"));
-
-          THEN("The function in the class should call the lambda method")
-          {
-            const irep_idt method_identifier =
-              id2string(tmp_class_identifier) + ".Execute:()V";
-            const symbolt &method_symbol =
-              require_symbol::require_symbol_exists(
-                symbol_table, method_identifier);
-
-            REQUIRE(method_symbol.is_function());
-
-            const std::vector<codet> &assignments =
-              require_goto_statements::get_all_statements(method_symbol.value);
-
-            require_goto_statements::require_function_call(
-              assignments, "java::LocalLambdas.lambda$test$0:()V");
-          }
+          test_data.lambda_interface = "java::SimpleLambda";
+          test_data.lambda_interface_method_descriptor = ".Execute:()V";
+          test_data.lambda_function_id = "java::LocalLambdas.pretendLambda:()V";
+          validate_lamdba_assignement(symbol_table, instructions, test_data);
         }
       }
     }

--- a/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -176,7 +176,7 @@ SCENARIO(
             symbol_table.lookup_ref("java::LocalLambdas.test:()V").value);
 
         const std::string function_prefix_regex_str =
-          "java::LocalLambdas\\.test:\\(\\)V";
+          R"(java::LocalLambdas\.test:\(\)V)";
 
         THEN(
           "The local variable should be assigned a temp object implementing "
@@ -192,7 +192,7 @@ SCENARIO(
             symbol_table,
             instructions,
             test_data,
-            std::regex(function_prefix_regex_str + "::\\d+::simpleLambda$"));
+            std::regex(function_prefix_regex_str + R"(::\d+::simpleLambda$)"));
         }
         THEN(
           "The local variable should be assigned a non-null pointer to a "
@@ -219,7 +219,7 @@ SCENARIO(
             symbol_table,
             instructions,
             test_data,
-            std::regex(function_prefix_regex_str + "::\\d+::paramLambda$"));
+            std::regex(function_prefix_regex_str + R"(::\d+::paramLambda$)"));
         }
         THEN(
           "The local variable should be assigned a non-null pointer to a "
@@ -247,7 +247,7 @@ SCENARIO(
             instructions,
             test_data,
             std::regex(
-              function_prefix_regex_str + "::\\d+::arrayParamLambda$"));
+              function_prefix_regex_str + R"(::\d+::arrayParamLambda$)"));
         }
         THEN(
           "The local variable should be assigned a temp object implementing "
@@ -264,7 +264,7 @@ SCENARIO(
             instructions,
             test_data,
             std::regex(
-              function_prefix_regex_str + "::\\d+::returnPrimitiveLambda"));
+              function_prefix_regex_str + R"(::\d+::returnPrimitiveLambda$)"));
         }
         THEN(
           "The local variable should be assigned a temp object implementing "
@@ -286,7 +286,7 @@ SCENARIO(
             instructions,
             test_data,
             std::regex(
-              function_prefix_regex_str + "::\\d+::returnReferenceLambda"));
+              function_prefix_regex_str + R"(::\d+::returnReferenceLambda$)"));
         }
         THEN(
           "The local variable should be assigned a temp object implementing "
@@ -307,7 +307,7 @@ SCENARIO(
             test_data,
             std::regex(
               function_prefix_regex_str +
-              "::\\d+::returningSpecalisedGenericLambda"));
+              R"(::\d+::returningSpecalisedGenericLambda$)"));
         }
         // TODO[TG-2482]: Tests for local lambdas that capture variables
       }

--- a/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -160,7 +160,7 @@ void validate_local_variable_lambda_assignment(
 SCENARIO(
   "Converting invokedynamic with a local lambda",
   "[core]"
-  "[lamdba][java_bytecode][java_bytecode_convert_method][!mayfail]")
+  "[lambdas][java_bytecode][java_bytecode_convert_method][!mayfail]")
 {
   // NOLINTNEXTLINE(whitespace/braces)
   run_test_with_compilers([](const std::string &compiler) {

--- a/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -23,7 +23,7 @@ struct lambda_assignment_test_datat
   irep_idt lambda_function_id;
 
   std::vector<exprt> expected_params;
-  bool should_return_value;
+  bool should_return_value = true;
 };
 
 /// Verifies for a given function that contains:
@@ -43,12 +43,12 @@ struct lambda_assignment_test_datat
 /// \param symbol_table: The loaded symbol table
 /// \param instructions: The instructions of the method that calls invokedynamic
 /// \param test_data: The parameters for the test
-void validate_lamdba_assignement(
+void validate_lambda_assignment(
   const symbol_tablet &symbol_table,
   const std::vector<codet> &instructions,
   const lambda_assignment_test_datat &test_data,
   const require_goto_statements::pointer_assignment_locationt
-    &lambda_assignment)
+  &lambda_assignment)
 {
   const typecast_exprt &rhs_value = require_expr::require_typecast(
     lambda_assignment.non_null_assignments[0].rhs());
@@ -188,7 +188,7 @@ void validate_local_variable_lambda_assignment(
   REQUIRE(lambda_assignment.non_null_assignments.size() == 1);
   REQUIRE_FALSE(lambda_assignment.null_assignment.has_value());
 
-  validate_lamdba_assignement(
+  validate_lambda_assignment(
     symbol_table, instructions, test_data, lambda_assignment);
 }
 
@@ -261,7 +261,7 @@ SCENARIO(
             std::regex(function_prefix_regex_str + R"(::\d+::paramLambda$)"));
         }
         THEN(
-          "The local variable should be assigned a non-null pointer to a "
+          "The local variable should be assigned a non-null pointer to an "
           "array parameter interface implementor")
         {
           lambda_assignment_test_datat test_data;
@@ -354,6 +354,8 @@ SCENARIO(
   });
 }
 
+/// Find the assignment to the lambda in the constructor
+/// and then call validate_lamdba_assignement for full validation.
 void validate_member_variable_lambda_assignment(
   const symbol_tablet &symbol_table,
   const std::vector<codet> &instructions,
@@ -367,7 +369,7 @@ void validate_member_variable_lambda_assignment(
   REQUIRE(lambda_assignment.non_null_assignments.size() == 1);
   REQUIRE_FALSE(lambda_assignment.null_assignment.has_value());
 
-  validate_lamdba_assignement(
+  validate_lambda_assignment(
     symbol_table, instructions, test_data, lambda_assignment);
 }
 
@@ -433,7 +435,7 @@ SCENARIO(
             symbol_table, instructions, test_data, "paramLambda");
         }
         THEN(
-          "The local variable should be assigned a non-null pointer to a "
+          "The local variable should be assigned a non-null pointer to an "
           "array parameter interface implementor")
         {
           lambda_assignment_test_datat test_data;
@@ -509,6 +511,8 @@ SCENARIO(
   });
 }
 
+/// Find the assignment to the lambda  in the <clinit> and then call
+/// validate_lamdba_assignement for full validation.
 void validate_static_member_variable_lambda_assignment(
   const symbol_tablet &symbol_table,
   const std::vector<codet> &instructions,
@@ -522,7 +526,7 @@ void validate_static_member_variable_lambda_assignment(
   REQUIRE(lambda_assignment.non_null_assignments.size() == 1);
   REQUIRE_FALSE(lambda_assignment.null_assignment.has_value());
 
-  validate_lamdba_assignement(
+  validate_lambda_assignment(
     symbol_table, instructions, test_data, lambda_assignment);
 }
 
@@ -592,7 +596,7 @@ SCENARIO(
             symbol_table, instructions, test_data, "paramLambda");
         }
         THEN(
-          "The local variable should be assigned a non-null pointer to a "
+          "The local variable should be assigned a non-null pointer to an "
           "array parameter interface implementor")
         {
           lambda_assignment_test_datat test_data;

--- a/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -105,7 +105,20 @@ void validate_lamdba_assignement(
     Catch::Matchers::Vector::ContainsElementMatcher<irep_idt>{
       tmp_class_identifier});
 
-  require_type::require_component(tmp_lambda_class_type, "@java.lang.Object");
+  const java_class_typet::componentt super_class_component =
+    require_type::require_component(tmp_lambda_class_type, "@java.lang.Object");
+
+  const symbol_typet &super_class_type = require_type::require_symbol(
+    super_class_component.type(), "java::java.lang.Object");
+
+  const symbolt &base_class_symbol = require_symbol::require_symbol_exists(
+    symbol_table, super_class_type.get_identifier());
+
+  REQUIRE(base_class_symbol.is_type);
+  const class_typet &super_class_type_struct =
+    require_type::require_incomplete_class(base_class_symbol.type);
+
+  require_type::require_component(super_class_type_struct, "@class_identifier");
   // TODO verify the components of the class have been set correctly
 
   THEN("The function in the class should call the lambda method")

--- a/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -125,6 +125,21 @@ SCENARIO(
           test_data.lambda_function_id = "java::LocalLambdas.pretendLambda:()V";
           validate_lamdba_assignement(symbol_table, instructions, test_data);
         }
+        THEN(
+          "The local variable should be assigned a non-null pointer to a "
+          "parameter interface implementor")
+        {
+          lambda_assignment_test_datat test_data;
+          test_data.lambda_variable_id = function_prefix + "::35::paramLambda";
+
+          test_data.lambda_interface = "java::ParameterLambda";
+          test_data.lambda_interface_method_descriptor =
+            ".Execute:(ILjava/lang/Object;LDummyGeneric;)V";
+          test_data.lambda_function_id =
+            "java::LocalLambdas.lambda$test$1:(ILjava/lang/"
+            "Object;LDummyGeneric;)V";
+          validate_lamdba_assignement(symbol_table, instructions, test_data);
+        }
       }
     }
   });

--- a/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -14,6 +14,7 @@
 #include <testing-utils/run_test_with_compilers.h>
 #include <testing-utils/require_symbol.h>
 #include <util/expr_iterator.h>
+#include <goto-programs/class_hierarchy.h>
 
 struct lambda_assignment_test_datat
 {
@@ -85,6 +86,24 @@ void validate_lamdba_assignement(
     require_type::require_complete_class(lambda_implementor_type_symbol.type);
 
   REQUIRE(tmp_lambda_class_type.has_base(test_data.lambda_interface));
+  REQUIRE(tmp_lambda_class_type.has_base("java::java.lang.Object"));
+
+  class_hierarchyt class_hierarchy;
+  class_hierarchy(symbol_table);
+
+  const auto &parents = class_hierarchy.get_parents_trans(tmp_class_identifier);
+  REQUIRE_THAT(
+    parents,
+    Catch::Matchers::Vector::ContainsElementMatcher<irep_idt>{
+      test_data.lambda_interface});
+
+  const auto &interface_children =
+    class_hierarchy.get_children_trans(test_data.lambda_interface);
+
+  REQUIRE_THAT(
+    interface_children,
+    Catch::Matchers::Vector::ContainsElementMatcher<irep_idt>{
+      tmp_class_identifier});
 
   THEN("The function in the class should call the lambda method")
   {

--- a/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -232,6 +232,48 @@ SCENARIO(
           test_data.should_return_value = true;
           validate_lamdba_assignement(symbol_table, instructions, test_data);
         }
+        THEN(
+          "The local variable should be assigned a temp object implementing "
+          "ReturningLambdaReference")
+        {
+          lambda_assignment_test_datat test_data;
+
+          test_data.lambda_variable_id = std::regex(
+            function_prefix_regex_str + "::\\d+::returnReferenceLambda");
+
+          test_data.lambda_interface = "java::ReturningLambdaReference";
+
+          test_data.lambda_interface_method_descriptor =
+            ".Execute:()Ljava/lang/Object;";
+
+          //"java::LocalLambdas.lambda$test$0:()V"
+          test_data.lambda_function_id =
+            "java::LocalLambdas.lambda$test$4:()Ljava/lang/Object;";
+          test_data.expected_params = {};
+          test_data.should_return_value = true;
+          validate_lamdba_assignement(symbol_table, instructions, test_data);
+        }
+        THEN(
+          "The local variable should be assigned a temp object implementing "
+          "ReturningLambdaSpecalisedGeneric")
+        {
+          lambda_assignment_test_datat test_data;
+
+          test_data.lambda_variable_id = std::regex(
+            function_prefix_regex_str +
+            "::\\d+::returningSpecalisedGenericLambda");
+
+          test_data.lambda_interface = "java::ReturningLambdaSpecalisedGeneric";
+
+          test_data.lambda_interface_method_descriptor =
+            ".Execute:()LDummyGeneric;";
+          test_data.lambda_function_id =
+            "java::LocalLambdas.lambda$test$5:()LDummyGeneric;";
+          test_data.expected_params = {};
+          test_data.should_return_value = true;
+          validate_lamdba_assignement(symbol_table, instructions, test_data);
+        }
+        // TODO[TG-2482]: Tests for local lambdas that capture variables
       }
     }
   });

--- a/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -1,0 +1,93 @@
+/*******************************************************************\
+
+ Module: Unit tests for converting invokedynamic instructions into codet
+
+ Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include <testing-utils/catch.hpp>
+#include <testing-utils/load_java_class.h>
+#include <testing-utils/require_goto_statements.h>
+#include <testing-utils/require_expr.h>
+#include <testing-utils/require_type.h>
+#include <testing-utils/run_test_with_compilers.h>
+#include <testing-utils/require_symbol.h>
+
+SCENARIO(
+  "Converting invokedynamic with a local lambda",
+  "[core]"
+  "[lamdba][java_bytecode][java_bytecode_convert_method][!mayfail]")
+{
+  // NOLINTNEXTLINE(whitespace/braces)
+  run_test_with_compilers([](const std::string &compiler) {
+    GIVEN(
+      "A class with a static lambda variables from " + compiler + " compiler.")
+    {
+      symbol_tablet symbol_table = load_java_class(
+        "LocalLambdas",
+        "./java_bytecode/java_bytecode_parser/lambda_examples/" + compiler +
+          "_classes/",
+        "LocalLambdas.test");
+
+      WHEN("Inspecting the assignments of the entry function")
+      {
+        const std::vector<codet> &instructions =
+          require_goto_statements::get_all_statements(
+            symbol_table.lookup_ref("java::LocalLambdas.test:()V").value);
+
+        THEN("The local variable should be assigned a non-null pointer")
+        {
+          // TODO(tkiley): we don't want 11 here
+          // TODO(tkiley): This is the actual lambda which doesn't currently work
+          const auto lambda_assignment =
+            require_goto_statements::find_pointer_assignments(
+              "java::LocalLambdas.test:()V::11::simpleLambda", instructions);
+
+          REQUIRE(lambda_assignment.non_null_assignments.size() == 1);
+          REQUIRE_FALSE(lambda_assignment.null_assignment.has_value());
+
+          const typecast_exprt &rhs_value = require_expr::require_typecast(
+            lambda_assignment.non_null_assignments[0].rhs());
+
+          const symbol_exprt &rhs_symbol =
+            require_expr::require_symbol(rhs_value.op0());
+
+          const irep_idt &tmp_object_symbol = rhs_symbol.get_identifier();
+
+          const auto tmp_object_assignments =
+            require_goto_statements::find_pointer_assignments(
+              tmp_object_symbol, instructions);
+
+          REQUIRE(tmp_object_assignments.non_null_assignments.size() == 1);
+          REQUIRE_FALSE(tmp_object_assignments.null_assignment.has_value());
+
+          const side_effect_exprt &side_effect_expr =
+            require_expr::require_side_effect_expr(
+              tmp_object_assignments.non_null_assignments[0].rhs(),
+              ID_java_new);
+
+          const pointer_typet &lambda_temp_type =
+            require_type::require_pointer(side_effect_expr.type(), {});
+
+          const symbol_typet &lambda_implementor_type =
+            require_type::require_symbol(lambda_temp_type.subtype());
+
+          const irep_idt &tmp_class_identifier =
+            lambda_implementor_type.get_identifier();
+
+          const symbolt &lambda_implementor_type_symbol =
+            require_symbol::require_symbol_exists(
+              symbol_table, tmp_class_identifier);
+
+          REQUIRE(lambda_implementor_type_symbol.is_type);
+          const class_typet &tmp_lambda_class_type =
+            require_type::require_complete_class(
+              lambda_implementor_type_symbol.type);
+
+          REQUIRE(tmp_lambda_class_type.has_base("java::SimpleLambda"));
+        }
+      }
+    }
+  });
+}

--- a/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -99,9 +99,13 @@ void validate_lamdba_assignement(
     const std::vector<codet> &assignments =
       require_goto_statements::get_all_statements(method_symbol.value);
 
-    code_function_callt function_call =
-      require_goto_statements::require_function_call(
+    std::vector<code_function_callt> function_calls =
+      require_goto_statements::find_function_calls(
         assignments, test_data.lambda_function_id);
+
+    INFO("Looking for function call of " << test_data.lambda_function_id);
+    REQUIRE(function_calls.size() == 1);
+    const code_function_callt &function_call = function_calls[0];
 
     std::string variable_prefix = id2string(method_identifier) + "::";
     // replace all symbol exprs with a prefixed symbol expr

--- a/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -369,6 +369,102 @@ SCENARIO(
           validate_member_variable_lambda_assignment(
             symbol_table, instructions, test_data, "simpleLambda");
         }
+        THEN(
+          "The local variable should be assigned a temp object implementing "
+          "ParameterLambda")
+        {
+          lambda_assignment_test_datat test_data;
+          test_data.lambda_interface = "java::ParameterLambda";
+          test_data.lambda_interface_method_descriptor =
+            ".Execute:(ILjava/lang/Object;LDummyGeneric;)V";
+          test_data.lambda_function_id =
+            "java::MemberLambdas.lambda$new$1:"
+            "(ILjava/lang/Object;LDummyGeneric;)V";
+
+          symbol_exprt integer_param{"primitive", java_int_type()};
+          symbol_exprt ref_param{"reference",
+                                 java_type_from_string("Ljava/lang/Object;")};
+          symbol_exprt generic_param{
+            "specalisedGeneric",
+            java_type_from_string("LDummyGeneric<Ljava/lang/Interger;>;")};
+          test_data.expected_params = {integer_param, ref_param, generic_param};
+
+          test_data.should_return_value = false;
+          validate_member_variable_lambda_assignment(
+            symbol_table, instructions, test_data, "paramLambda");
+        }
+        THEN(
+          "The local variable should be assigned a non-null pointer to a "
+          "array parameter interface implementor")
+        {
+          lambda_assignment_test_datat test_data;
+          test_data.lambda_interface = "java::ArrayParameterLambda";
+          test_data.lambda_interface_method_descriptor =
+            ".Execute:([I[Ljava/lang/Object;[LDummyGeneric;)V";
+          test_data.lambda_function_id =
+            "java::MemberLambdas.lambda$new$2:"
+            "([I[Ljava/lang/Object;[LDummyGeneric;)V";
+
+          symbol_exprt integer_param{"primitive", java_type_from_string("[I")};
+          symbol_exprt ref_param{"reference",
+                                 java_type_from_string("[Ljava/lang/Object;")};
+          symbol_exprt generic_param{
+            "specalisedGeneric",
+            java_type_from_string("[LDummyGeneric<Ljava/lang/Interger;>;")};
+          test_data.expected_params = {integer_param, ref_param, generic_param};
+          test_data.should_return_value = false;
+
+          validate_member_variable_lambda_assignment(
+            symbol_table, instructions, test_data, "arrayParamLambda");
+        }
+        THEN(
+          "The local variable should be assigned a temp object implementing "
+          "ReturningLambdaPrimitive")
+        {
+          lambda_assignment_test_datat test_data;
+          test_data.lambda_interface = "java::ReturningLambdaPrimitive";
+          test_data.lambda_interface_method_descriptor = ".Execute:()I";
+          test_data.lambda_function_id = "java::MemberLambdas.lambda$new$3:()I";
+          test_data.expected_params = {};
+          test_data.should_return_value = true;
+          validate_member_variable_lambda_assignment(
+            symbol_table, instructions, test_data, "returnPrimitiveLambda");
+        }
+        THEN(
+          "The local variable should be assigned a temp object implementing "
+          "ReturningLambdaReference")
+        {
+          lambda_assignment_test_datat test_data;
+          test_data.lambda_interface = "java::ReturningLambdaReference";
+          test_data.lambda_interface_method_descriptor =
+            ".Execute:()Ljava/lang/Object;";
+          test_data.lambda_function_id =
+            "java::MemberLambdas.lambda$new$4:()Ljava/lang/Object;";
+          test_data.expected_params = {};
+          test_data.should_return_value = true;
+          validate_member_variable_lambda_assignment(
+            symbol_table, instructions, test_data, "returnReferenceLambda");
+        }
+        THEN(
+          "The local variable should be assigned a temp object implementing "
+          "ReturningLambdaSpecalisedGeneric")
+        {
+          lambda_assignment_test_datat test_data;
+          test_data.lambda_interface = "java::ReturningLambdaSpecalisedGeneric";
+          test_data.lambda_interface_method_descriptor =
+            ".Execute:()LDummyGeneric;";
+          test_data.lambda_function_id =
+            "java::MemberLambdas.lambda$new$5:()LDummyGeneric;";
+          test_data.expected_params = {};
+          test_data.should_return_value = true;
+          validate_member_variable_lambda_assignment(
+            symbol_table,
+            instructions,
+            test_data,
+            "returningSpecalisedGenericLambda");
+        }
+
+        // TODO[TG-2486]: Tests for member lambdas that capture member variables
       }
     }
   });

--- a/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -26,6 +26,23 @@ struct lambda_assignment_test_datat
   bool should_return_value;
 };
 
+/// Verifies for a given function that contains:
+///  {lambda_variable_id} = invokedynamic method_handle_index
+/// code looks
+/// like:
+///  tmp_object_symbol = java_new(lambda_tmp_type)
+///  {lambda_variable_id} = (cast)tmp_object_symbol
+/// and the type lambda_tmp_type:
+///  implements {lambda_interface}
+///  has method {lambda_interface_method_descriptor}
+/// and the method body looks like
+///  function_call_exprt(
+///    should_return_value ? symbol_exprt : nil_exprt,
+///    {lambda_function_id},
+///    {expected_params})
+/// \param symbol_table: The loaded symbol table
+/// \param instructions: The instructions of the method that calls invokedynamic
+/// \param test_data: The parameters for the test
 void validate_lamdba_assignement(
   const symbol_tablet &symbol_table,
   const std::vector<codet> &instructions,

--- a/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -105,6 +105,9 @@ void validate_lamdba_assignement(
     Catch::Matchers::Vector::ContainsElementMatcher<irep_idt>{
       tmp_class_identifier});
 
+  require_type::require_component(tmp_lambda_class_type, "@java.lang.Object");
+  // TODO verify the components of the class have been set correctly
+
   THEN("The function in the class should call the lambda method")
   {
     const irep_idt method_identifier =

--- a/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -16,7 +16,7 @@
 
 struct lambda_assignment_test_datat
 {
-  irep_idt lambda_variable_id;
+  std::regex lambda_variable_id;
   irep_idt lambda_interface;
   std::string lambda_interface_method_descriptor;
   irep_idt lambda_function_id;
@@ -111,14 +111,16 @@ SCENARIO(
           require_goto_statements::get_all_statements(
             symbol_table.lookup_ref("java::LocalLambdas.test:()V").value);
 
-        const std::string function_prefix = "java::LocalLambdas.test:()V";
+        const std::string function_prefix_regex_str =
+          "java::LocalLambdas\\.test:\\(\\)V";
 
         THEN(
           "The local variable should be assigned a temp object implementing "
           "SimpleLambda")
         {
           lambda_assignment_test_datat test_data;
-          test_data.lambda_variable_id = function_prefix + "::11::simpleLambda";
+          test_data.lambda_variable_id =
+            std::regex(function_prefix_regex_str + "::\\d+::simpleLambda$");
 
           test_data.lambda_interface = "java::SimpleLambda";
           test_data.lambda_interface_method_descriptor = ".Execute:()V";
@@ -130,7 +132,8 @@ SCENARIO(
           "parameter interface implementor")
         {
           lambda_assignment_test_datat test_data;
-          test_data.lambda_variable_id = function_prefix + "::35::paramLambda";
+          test_data.lambda_variable_id =
+            std::regex(function_prefix_regex_str + "::\\d+::paramLambda$");
 
           test_data.lambda_interface = "java::ParameterLambda";
           test_data.lambda_interface_method_descriptor =

--- a/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -169,8 +169,8 @@ SCENARIO(
     {
       symbol_tablet symbol_table = load_java_class(
         "LocalLambdas",
-        "./java_bytecode/java_bytecode_parser/lambda_examples/" + compiler +
-          "_classes/",
+        "./java_bytecode/java_bytecode_parse_lambdas/lambda_examples/" +
+          compiler + "_classes/",
         "LocalLambdas.test");
 
       WHEN("Inspecting the assignments of the entry function")
@@ -348,8 +348,8 @@ SCENARIO(
     {
       symbol_tablet symbol_table = load_java_class(
         "MemberLambdas",
-        "./java_bytecode/java_bytecode_parser/lambda_examples/" + compiler +
-          "_classes/",
+        "./java_bytecode/java_bytecode_parse_lambdas/lambda_examples/" +
+          compiler + "_classes/",
         "MemberLambdas.<init>");
 
       WHEN("Inspecting the assignments of the entry function")
@@ -503,8 +503,8 @@ SCENARIO(
     {
       symbol_tablet symbol_table = load_java_class(
         "StaticLambdas",
-        "./java_bytecode/java_bytecode_parser/lambda_examples/" + compiler +
-          "_classes/",
+        "./java_bytecode/java_bytecode_parse_lambdas/lambda_examples/" +
+          compiler + "_classes/",
         "StaticLambdas.<clinit>");
 
       WHEN("Inspecting the assignments of the entry function")

--- a/unit/testing-utils/load_java_class.cpp
+++ b/unit/testing-utils/load_java_class.cpp
@@ -17,6 +17,7 @@
 #include <goto-programs/lazy_goto_model.h>
 
 #include <java_bytecode/java_bytecode_language.h>
+#include <util/file_util.h>
 
 /// Go through the process of loading, type-checking and finalising loading a
 /// specific class file to build the symbol table. The functions are converted
@@ -127,6 +128,12 @@ symbol_tablet load_java_class(
   REQUIRE(class_symbol.is_type);
   const typet &class_type=class_symbol.type;
   REQUIRE(class_type.id()==ID_struct);
+
+  // Log the working directory to help people identify the common error
+  // of wrong working directory (should be the `unit` directory when running
+  // the unit tests).
+  std::string path = get_current_working_directory();
+  INFO("Working directory: " << path);
 
   // if this fails it indicates the class was not loaded
   // Check your working directory and the class path is correctly configured

--- a/unit/testing-utils/require_expr.cpp
+++ b/unit/testing-utils/require_expr.cpp
@@ -16,6 +16,7 @@
 
 #include <testing-utils/catch.hpp>
 #include <util/arith_tools.h>
+#include <util/std_code.h>
 
 /// Verify a given exprt is an index_exprt with a a constant value equal to the
 /// expected value
@@ -69,8 +70,39 @@ member_exprt require_expr::require_member(
 symbol_exprt require_expr::require_symbol(
   const exprt &expr, const irep_idt &symbol_name)
 {
-  REQUIRE(expr.id()==ID_symbol);
-  const symbol_exprt &symbol_expr=to_symbol_expr(expr);
+  const symbol_exprt &symbol_expr = require_symbol(expr);
   REQUIRE(symbol_expr.get_identifier()==symbol_name);
   return symbol_expr;
+}
+
+/// Verify a given exprt is a symbol_exprt.
+/// \param expr: The expression.
+/// \return The expr cast to a symbol_exprt
+symbol_exprt require_expr::require_symbol(const exprt &expr)
+{
+  REQUIRE(expr.id() == ID_symbol);
+  return to_symbol_expr(expr);
+}
+
+/// Verify a given exprt is a typecast_expr.
+/// \param expr: The expression.
+/// \return The expr cast to a typecast_exprt
+typecast_exprt require_expr::require_typecast(const exprt &expr)
+{
+  REQUIRE(expr.id() == ID_typecast);
+  return to_typecast_expr(expr);
+}
+
+/// Verify a given exprt is a side_effect_exprt with appropriate statement.
+/// \param expr: The expression.
+/// \param symbol_name: The intended identifier of statement
+/// \return The expr cast to a side_effect_exprt
+side_effect_exprt require_expr::require_side_effect_expr(
+  const exprt &expr,
+  const irep_idt &side_effect_statement)
+{
+  REQUIRE(expr.id() == ID_side_effect);
+  const side_effect_exprt &side_effect_expr = to_side_effect_expr(expr);
+  REQUIRE(side_effect_expr.get_statement() == side_effect_statement);
+  return side_effect_expr;
 }

--- a/unit/testing-utils/require_expr.h
+++ b/unit/testing-utils/require_expr.h
@@ -16,6 +16,7 @@
 #define CPROVER_TESTING_UTILS_REQUIRE_EXPR_H
 
 #include <util/std_expr.h>
+#include <util/std_code.h>
 
 // NOLINTNEXTLINE(readability/namespace)
 namespace require_expr
@@ -28,6 +29,14 @@ namespace require_expr
 
   symbol_exprt require_symbol(
     const exprt &expr, const irep_idt &symbol_name);
+
+  symbol_exprt require_symbol(const exprt &expr);
+
+  typecast_exprt require_typecast(const exprt &expr);
+
+  side_effect_exprt require_side_effect_expr(
+    const exprt &expr,
+    const irep_idt &side_effect_statement);
 }
 
 #endif // CPROVER_TESTING_UTILS_REQUIRE_EXPR_H

--- a/unit/testing-utils/require_goto_statements.cpp
+++ b/unit/testing-utils/require_goto_statements.cpp
@@ -409,3 +409,39 @@ require_goto_statements::require_entry_point_argument_assignment(
       .get_identifier();
   return argument_tmp_name;
 }
+
+/// Verify that a collection of statements contains a function call to a
+///   function whose symbol identifier matches the provided identifier
+/// \param statements: The collection of statements to inspect
+/// \param function_call_identifier: The symbol identifier of the function
+///   that should have been called
+/// \return The first code_function_callt to the relevant function or throws a
+///   no_matching_function_callt if no call is found
+code_function_callt require_goto_statements::require_function_call(
+  const std::vector<codet> &statements,
+  const irep_idt &function_call_identifier)
+{
+  // TODO: Would appreciate some review comments on whether it makes the most sense:
+  // - return a vector of matching code_function_calls
+  // - return an optionalt with the first matching call
+  // - return a code_function_callt throwing an exception if none found
+  for(const codet &statement : statements)
+  {
+    if(statement.get_statement() == ID_function_call)
+    {
+      const code_function_callt &function_call =
+        to_code_function_call(statement);
+
+      if(function_call.function().id() == ID_symbol)
+      {
+        if(
+          to_symbol_expr(function_call.function()).get_identifier() ==
+          function_call_identifier)
+        {
+          return function_call;
+        }
+      }
+    }
+  }
+  throw no_matching_function_callt(function_call_identifier);
+}

--- a/unit/testing-utils/require_goto_statements.cpp
+++ b/unit/testing-utils/require_goto_statements.cpp
@@ -478,16 +478,12 @@ require_goto_statements::require_entry_point_argument_assignment(
 /// \param statements: The collection of statements to inspect
 /// \param function_call_identifier: The symbol identifier of the function
 ///   that should have been called
-/// \return The first code_function_callt to the relevant function or throws a
-///   no_matching_function_callt if no call is found
-code_function_callt require_goto_statements::require_function_call(
+/// \return All calls to the matching function inside the statements
+std::vector<code_function_callt> require_goto_statements::find_function_calls(
   const std::vector<codet> &statements,
   const irep_idt &function_call_identifier)
 {
-  // TODO: Would appreciate some review comments on whether it makes the most sense:
-  // - return a vector of matching code_function_calls
-  // - return an optionalt with the first matching call
-  // - return a code_function_callt throwing an exception if none found
+  std::vector<code_function_callt> function_calls;
   for(const codet &statement : statements)
   {
     if(statement.get_statement() == ID_function_call)
@@ -501,10 +497,10 @@ code_function_callt require_goto_statements::require_function_call(
           to_symbol_expr(function_call.function()).get_identifier() ==
           function_call_identifier)
         {
-          return function_call;
+          function_calls.push_back(function_call);
         }
       }
     }
   }
-  throw no_matching_function_callt(function_call_identifier);
+  return function_calls;
 }

--- a/unit/testing-utils/require_goto_statements.h
+++ b/unit/testing-utils/require_goto_statements.h
@@ -16,6 +16,8 @@
 #include <util/std_types.h>
 #include <goto-programs/goto_program.h>
 
+#include <regex>
+
 #ifndef CPROVER_TESTING_UTILS_REQUIRE_GOTO_STATEMENTS_H
 #define CPROVER_TESTING_UTILS_REQUIRE_GOTO_STATEMENTS_H
 
@@ -79,6 +81,10 @@ require_entry_point_statements(const symbol_tablet &symbol_table);
 
 pointer_assignment_locationt find_pointer_assignments(
   const irep_idt &pointer_name,
+  const std::vector<codet> &instructions);
+
+pointer_assignment_locationt find_pointer_assignments(
+  const std::regex &pointer_name_match,
   const std::vector<codet> &instructions);
 
 const code_declt &require_declaration_of_name(

--- a/unit/testing-utils/require_goto_statements.h
+++ b/unit/testing-utils/require_goto_statements.h
@@ -74,6 +74,10 @@ pointer_assignment_locationt find_struct_component_assignments(
   const optionalt<irep_idt> &superclass_name,
   const irep_idt &component_name);
 
+pointer_assignment_locationt find_this_component_assignment(
+  const std::vector<codet> &statements,
+  const irep_idt &component_name);
+
 std::vector<codet> get_all_statements(const exprt &function_value);
 
 const std::vector<codet>

--- a/unit/testing-utils/require_goto_statements.h
+++ b/unit/testing-utils/require_goto_statements.h
@@ -49,25 +49,6 @@ private:
   std::string _varname;
 };
 
-class no_matching_function_callt : public std::exception
-{
-public:
-  explicit no_matching_function_callt(const irep_idt &function_identifier)
-    : function_identifier(function_identifier)
-  {
-  }
-
-  virtual const char *what() const throw()
-  {
-    std::ostringstream stringStream;
-    stringStream << "Failed to find function call for: " << function_identifier;
-    return stringStream.str().c_str();
-  }
-
-private:
-  irep_idt function_identifier;
-};
-
 pointer_assignment_locationt find_struct_component_assignments(
   const std::vector<codet> &statements,
   const irep_idt &structure_name,
@@ -115,7 +96,7 @@ const irep_idt &require_entry_point_argument_assignment(
   const irep_idt &argument_name,
   const std::vector<codet> &entry_point_statements);
 
-code_function_callt require_function_call(
+std::vector<code_function_callt> find_function_calls(
   const std::vector<codet> &statements,
   const irep_idt &function_call_identifier);
 }

--- a/unit/testing-utils/require_goto_statements.h
+++ b/unit/testing-utils/require_goto_statements.h
@@ -47,6 +47,25 @@ private:
   std::string _varname;
 };
 
+class no_matching_function_callt : public std::exception
+{
+public:
+  explicit no_matching_function_callt(const irep_idt &function_identifier)
+    : function_identifier(function_identifier)
+  {
+  }
+
+  virtual const char *what() const throw()
+  {
+    std::ostringstream stringStream;
+    stringStream << "Failed to find function call for: " << function_identifier;
+    return stringStream.str().c_str();
+  }
+
+private:
+  irep_idt function_identifier;
+};
+
 pointer_assignment_locationt find_struct_component_assignments(
   const std::vector<codet> &statements,
   const irep_idt &structure_name,
@@ -85,6 +104,10 @@ const irep_idt &require_struct_array_component_assignment(
 const irep_idt &require_entry_point_argument_assignment(
   const irep_idt &argument_name,
   const std::vector<codet> &entry_point_statements);
+
+code_function_callt require_function_call(
+  const std::vector<codet> &statements,
+  const irep_idt &function_call_identifier);
 }
 
 #endif // CPROVER_TESTING_UTILS_REQUIRE_GOTO_STATEMENTS_H


### PR DESCRIPTION
Depends on: #1937 :white_check_mark: 

Introduces unit tests for how the `invokedynamic` instruction is translated into codet. They are not turned on, but their behaviour is moddelled on what the codet looks like for

```java
SimpleLambda simpleLambda = new SimpleLambda() {
  public void Execute() {
    callStaticMethod();
  }
};
```

Which is the intended format. I can if it would be helpful split out some of the utility changes from the test introduction, but the changes are all separated by commits and the order provides some motivation for the auxiliary changes. 