### PR TITLE
Make children of codet consistent

### DIFF
--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -466,7 +466,7 @@ public:
 
   const codet &then_case() const
   {
-    return static_cast<const codet &>(op1());
+    return to_code(op1());
   }
 
   bool has_else_case() const
@@ -476,7 +476,7 @@ public:
 
   const codet &else_case() const
   {
-    return static_cast<const codet &>(op2());
+    return to_code(op2());
   }
 
   codet &then_case()
@@ -969,7 +969,7 @@ public:
 
   const codet &code() const
   {
-    return static_cast<const codet &>(op0());
+    return to_code(op0());
   }
 };
 
@@ -1038,7 +1038,7 @@ public:
 
   const codet &code() const
   {
-    return static_cast<const codet &>(op1());
+    return to_code(op1());
   }
 };
 
@@ -1619,7 +1619,7 @@ public:
 
   const codet &try_code() const
   {
-    return static_cast<const codet &>(op0());
+    return to_code(op0());
   }
 
   code_declt &get_catch_decl(unsigned i)


### PR DESCRIPTION
Some children of codet have a codet as an operand and have helper
functions to get that operand (code_dowhilet, code_fort,
code_ifthenelset, code_labelt, code_switch_caset, code_switcht,
code_try_catcht, code_whilet). Many of them use a pattern where the
const version of the helper function was using to_code() instead of
just doing a static cast, which adds an assertion that the operand has
id ID_code. (The non-const versions of the accessors do not do this,
presumably so they can be used to set the operand for the first time.)
Some of them were not using this pattern (code_labelt, code_ifthenelset,
code_switch_caset, code_try_catcht). This PR changes them to use it.