### PR TITLE
Update CODING_STANDARD.md

### DIFF
--- a/CODING_STANDARD.md
+++ b/CODING_STANDARD.md
@@ -77,7 +77,7 @@ Formatting is enforced using clang-format. For more information about this, see
 - The priority of documentation is readability. Therefore, feel free to use
   Doxygen features, or to add whitespace for multi-paragraph comment blocks if
   necessary.
-- Do not use colon after `\param` name, e.g., `\param arg_name ...` is ok while `\param arg_name: ...` should be avoided 
+- When describing parameters of functions, you may use a colon after the parameter name but if you choose to do so, do not add a space between the name and the colon as this will show in the generated documentation. For example, both `\param arg_name ...` and `\param arg_name: ...` are fine but `\param arg_name : ...` should be avoided. 
 - A comment block should immediately precede the definition of the entity it
   documents, which will generally mean that it will live in the source file.
   This allows us to take advantage of the one definition rule. If each entity

--- a/CODING_STANDARD.md
+++ b/CODING_STANDARD.md
@@ -66,8 +66,8 @@ Formatting is enforced using clang-format. For more information about this, see
   /// This sentence, until the first dot followed by whitespace, becomes
   /// the brief description. More detailed text follows. Feel free to
   /// break this into paragraphs to aid readability.
-  /// \param arg_name: This parameter doesn't need much description
-  /// \param [out] long_arg_name: This parameter is mutated by the function.
+  /// \param arg_name This parameter doesn't need much description
+  /// \param [out] long_arg_name This parameter is mutated by the function.
   ///   Extra info about the parameter gets indented an extra two columns,
   ///   like this.
   /// \return The return value is literally the value returned by the
@@ -77,6 +77,7 @@ Formatting is enforced using clang-format. For more information about this, see
 - The priority of documentation is readability. Therefore, feel free to use
   Doxygen features, or to add whitespace for multi-paragraph comment blocks if
   necessary.
+- Do not use colon after `\param` name, e.g., `\param arg_name ...` is ok while `\param arg_name: ...` should be avoided 
 - A comment block should immediately precede the definition of the entity it
   documents, which will generally mean that it will live in the source file.
   This allows us to take advantage of the one definition rule. If each entity


### PR DESCRIPTION
In Doxygen comments, we do not have much consistency about whether or not to use a colon after a parameter name. This PR suggests to not use the colon as it looks a bit weird in the documentation and the doxygen manual does not use it:
https://www.stack.nl/~dimitri/doxygen/manual/docblocks.html
On the other hand the argument to use it would be that it's more readable in the code. A way to increase readability without the colon could be to align the parameter descriptions using indents.
Express your opinion.