### PR TITLE
Remove reuk as a code-owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -51,9 +51,6 @@ src/util/irep_ids.def @diffblue/cbmc-developers
 unit/ @diffblue/cbmc-developers
 regression/ @diffblue/cbmc-developers
 
-CMakeLists.txt @reuk @chrisr-diffblue
-cmake/ @reuk @chrisr-diffblue
-
 scripts/ @diffblue/devops @thk123 @forejtv @peterschrammel
 .travis.yml @diffblue/devops @thk123 @forejtv @peterschrammel
 appveyor.yml @diffblue/devops @thk123 @forejtv @peterschrammel


### PR DESCRIPTION
The special owner for cmake-related stuff had the unintended side-effect of *preventing*
other owners from approving cmake changes, so let's just leave the cmake stuff with default
ownership for now.