### PR TITLE
Fix errors emitted by C++2a compiler

### DIFF
--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -588,8 +588,6 @@ void cpp_typecheck_resolvet::make_constructors(
 {
   resolve_identifierst new_identifiers;
 
-  resolve_identifierst::iterator next;
-
   for(resolve_identifierst::iterator
       it=identifiers.begin();
       it!=identifiers.end();

--- a/src/goto-instrument/cover_basic_blocks.h
+++ b/src/goto-instrument/cover_basic_blocks.h
@@ -21,6 +21,7 @@ class message_handlert;
 class cover_blocks_baset
 {
 public:
+  virtual ~cover_blocks_baset() = default;
   /// \param t a goto instruction
   /// \return the block number of the block
   ///         the given goto instruction is part of

--- a/src/goto-instrument/cover_instrument.h
+++ b/src/goto-instrument/cover_instrument.h
@@ -25,6 +25,7 @@ class goal_filterst;
 class cover_instrumenter_baset
 {
 public:
+  virtual ~cover_instrumenter_baset() = default;
   cover_instrumenter_baset(
     const symbol_tablet &_symbol_table,
     const goal_filterst &_goal_filters,

--- a/src/java_bytecode/java_bytecode_parse_tree.h
+++ b/src/java_bytecode/java_bytecode_parse_tree.h
@@ -21,6 +21,7 @@ Author: Daniel Kroening, kroening@kroening.com
 class java_bytecode_parse_treet
 {
 public:
+  virtual ~java_bytecode_parse_treet() = default;
   class annotationt
   {
   public:
@@ -157,11 +158,14 @@ public:
       is_synchronized(false)
     {
     }
+
+    virtual ~methodt() = default;
   };
 
   class fieldt:public membert
   {
   public:
+    virtual ~fieldt() = default;
     virtual void output(std::ostream &out) const;
     bool is_enum;
   };

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -33,13 +33,13 @@ hash_numbering<irep_idt, irep_id_hash> value_set_fit::function_numbering;
 static const char *alloc_adapter_prefix="alloc_adaptor::";
 
 #define forall_objects(it, map) \
-  for(object_map_dt::const_iterator (it) = (map).begin(); \
-  (it)!=(map).end(); \
+  for(object_map_dt::const_iterator it = (map).begin(); \
+  it!=(map).end(); \
   (it)++)
 
 #define Forall_objects(it, map) \
-  for(object_map_dt::iterator (it) = (map).begin(); \
-  (it)!=(map).end(); \
+  for(object_map_dt::iterator it = (map).begin(); \
+  it!=(map).end(); \
   (it)++)
 
 void value_set_fit::output(

--- a/src/pointer-analysis/value_set_fivr.cpp
+++ b/src/pointer-analysis/value_set_fivr.cpp
@@ -33,24 +33,24 @@ hash_numbering<irep_idt, irep_id_hash> value_set_fivrt::function_numbering;
 static const char *alloc_adapter_prefix="alloc_adaptor::";
 
 #define forall_objects(it, map) \
-  for(object_map_dt::const_iterator (it)=(map).begin(); \
-  (it)!=(map).end(); \
+  for(object_map_dt::const_iterator it=(map).begin(); \
+  it!=(map).end(); \
   (it)++)
 
 #define forall_valid_objects(it, map) \
-  for(object_map_dt::const_iterator (it)=(map).begin(); \
-  (it)!=(map).end(); \
+  for(object_map_dt::const_iterator it=(map).begin(); \
+  it!=(map).end(); \
   (it)++) \
-    if((map).is_valid_at((it)->first, from_function, from_target_index))
+    if((map).is_valid_at(it->first, from_function, from_target_index))
 
 #define Forall_objects(it, map) \
-  for(object_map_dt::iterator (it)=(map).begin(); \
-  (it)!=(map).end(); \
+  for(object_map_dt::iterator it=(map).begin(); \
+  it!=(map).end(); \
   (it)++)
 
 #define Forall_valid_objects(it, map) \
-  for(object_map_dt::iterator (it)=(map).begin(); \
-      (it)!=(map).end(); \
+  for(object_map_dt::iterator it=(map).begin(); \
+      it!=(map).end(); \
       (it)++) \
     if((map).is_valid_at((it)->first, from_function, from_target_index)) /* NOLINT(*) */
 


### PR DESCRIPTION
This commit fixes #1972, in particular fixing these three classes of
error that occurred over various files in the codebase:
```
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/7.3.1/../../../../include/c++/7.3.1/ext/new_allocator.h:140:22: error: destructor called on non-final 'java_bytecode_parse_treet::methodt' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
        destroy(_Up* __p) { __p->~_Up(); }
                            ^

cbmc/src/pointer-analysis/value_set_fivr.cpp:857:9: error: parentheses were disambiguated as redundant parentheses around declaration of variable named 'it' [-Werror,-Wvexing-parse]
        forall_objects(it, omt.read())
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

cbmc/src/cpp/cpp_typecheck_resolve.cpp:591:34: error: unused variable 'next'
[-Werror,-Wunused-variable]
  resolve_identifierst::iterator next;
                                   ^
```
These warnings are emitted when building with Clang 6.0 with the default
flags. As of this commit, one warning remains, which can be suppressed
by building with the flag -Wno-c++2a-compat until we have a proper fix.