### PR TITLE
Activate tests for StringBuffer.append in loops

### DIFF
--- a/regression/jbmc-strings/StringConcat/test_buffer_nondet_loop.desc
+++ b/regression/jbmc-strings/StringConcat/test_buffer_nondet_loop.desc
@@ -1,6 +1,6 @@
-FUTURE
+CORE
 Test.class
---refine-strings --string-max-length 1000 --string-max-input-length 100 --function Test.bufferNonDetLoop --depth 10000 --unwind 5  --verbosity 10  --property "java::Test.bufferNonDetLoop:(ILjava/lang/String;)Ljava/lang/String;.assertion.1"
+--refine-strings --string-max-length 1000 --string-max-input-length 100 --function Test.bufferNonDetLoop --depth 10000 --unwind 5  --verbosity 10  --property 'java::Test.bufferNonDetLoop:(ILjava/lang/String;)Ljava/lang/String;.assertion.1'
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/jbmc-strings/StringConcat/test_buffer_nondet_loop2.desc
+++ b/regression/jbmc-strings/StringConcat/test_buffer_nondet_loop2.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 Test.class
 --refine-strings --string-max-length 1000 --string-max-input-length 100 --function Test.bufferNonDetLoop2 --depth 10000 --unwind 5  --verbosity 10
 ^EXIT=10$

--- a/regression/jbmc-strings/StringConcat/test_buffer_nondet_loop4.desc
+++ b/regression/jbmc-strings/StringConcat/test_buffer_nondet_loop4.desc
@@ -1,6 +1,6 @@
-FUTURE
+CORE
 Test.class
---refine-strings --string-max-length 1000 --string-max-input-length 100 --function Test.bufferNonDetLoop4 --depth 10000 --unwind 5  --verbosity 10 --property "java::Test.bufferNonDetLoop4:(IILjava/lang/String;)Ljava/lang/String;.assertion.1"
+--refine-strings --string-max-length 1000 --string-max-input-length 100 --function Test.bufferNonDetLoop4 --depth 10000 --unwind 5  --verbosity 10 --property 'java::Test.bufferNonDetLoop4:(IILjava/lang/String;)Ljava/lang/String;.assertion.1'
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/jbmc-strings/StringConcat/test_buffer_nondet_loop5.desc
+++ b/regression/jbmc-strings/StringConcat/test_buffer_nondet_loop5.desc
@@ -1,6 +1,6 @@
-FUTURE
+CORE
 Test.class
---refine-strings --string-max-length 1000 --string-max-input-length 100 --function Test.bufferNonDetLoop5 --depth 10000 --unwind 5  --verbosity 10
+--refine-strings --string-max-length 1000 --string-max-input-length 100 --function Test.bufferNonDetLoop5 --depth 10000 --unwind 3 --verbosity 10
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/jbmc-strings/StringConcat/test_string_nondet.desc
+++ b/regression/jbmc-strings/StringConcat/test_string_nondet.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 Test.class
 --refine-strings --string-max-length 1000 --string-max-input-length 100 --function Test.stringNonDet --depth 10000 --unwind 5 --verbosity 10
 ^EXIT=10$


### PR DESCRIPTION
We activate these tests which check that refinement is not needed when
strings are not tested. They should all run in a reasonnable time now,
the most difficult takes about 2 seconds.