### PR TITLE
[SV-COMP'18 1/19] Include missing header

### DIFF
--- a/src/memory-models/mm2cpp.cpp
+++ b/src/memory-models/mm2cpp.cpp
@@ -8,6 +8,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "mm2cpp.h"
 
+#include <map>
 #include <ostream>
 
 #include <util/std_code.h>


### PR DESCRIPTION
irep.h only provides map when SUB_IS_LIST is not set.