### PR TITLE
[SV-COMP'18 15/19] Cure of consequences of some concurrency bug related to pthread_join.

### DIFF
--- a/src/ansi-c/library/pthread_lib.c
+++ b/src/ansi-c/library/pthread_lib.c
@@ -327,7 +327,7 @@ inline int pthread_join(pthread_t thread, void **value_ptr)
   #endif
 
   if((unsigned long)thread>__CPROVER_next_thread_id) return ESRCH;
-  if((unsigned long)thread==__CPROVER_thread_id) return EDEADLK;
+//  if((unsigned long)thread==__CPROVER_thread_id) return EDEADLK;
   if(value_ptr!=0) (void)**(char**)value_ptr;
   __CPROVER_assume(__CPROVER_threads_exited[(unsigned long)thread]);
 


### PR DESCRIPTION
This is not proper bug-fix. It is a fake/hot-fix preventing the bug
occur on SV-COMP benchmarks. Hoevewer, the bug is still there. I failed
to locate it in reasonable time.