### PR TITLE
[SV-COMP'18 16/19] Bugfix[byte_extract]: handling negative offsets by unknown bits.

### DIFF
--- a/src/solvers/flattening/boolbv_byte_extract.cpp
+++ b/src/solvers/flattening/boolbv_byte_extract.cpp
@@ -98,16 +98,13 @@ bvt boolbvt::convert_byte_extract(const byte_extract_exprt &expr)
   mp_integer index;
   if(!to_integer(offset, index))
   {
-    if(index<0)
-      throw "byte_extract flatting with negative offset: "+expr.pretty();
-
     mp_integer offset=index*byte_width;
 
-    std::size_t offset_i=integer2unsigned(offset);
+    long offset_i=offset.to_long();
 
-    for(std::size_t i=0; i<width; i++)
+    for(long i=0; i<(long)width; i++)
       // out of bounds?
-      if(offset<0 || offset_i+i>=op_bv.size())
+      if(offset<0 || offset_i+i>=(long)op_bv.size())
         bv[i]=prop.new_variable();
       else
         bv[i]=op_bv[offset_i+i];


### PR DESCRIPTION
Do not merge: regression test needed.