### PR TITLE
[SV-COMP'18 18/19] Fixing issue 'implicit conversion not permitted' for alias variables.

### DIFF
--- a/src/ansi-c/c_typecast.h
+++ b/src/ansi-c/c_typecast.h
@@ -41,7 +41,7 @@ bool c_implicit_typecast_arithmetic(
 class c_typecastt
 {
 public:
-  explicit c_typecastt(const namespacet &_ns):ns(_ns)
+  explicit c_typecastt(const namespacet &_ns):ns(_ns), current_symbol(nullptr)
   {
   }
 
@@ -62,6 +62,9 @@ public:
 
   std::list<std::string> errors;
   std::list<std::string> warnings;
+
+  void set_current_symbol(const symbolt * const symbol) { current_symbol=symbol; }
+  const symbolt *get_current_symbol() const { return current_symbol; }
 
 protected:
   const namespacet &ns;
@@ -100,6 +103,9 @@ protected:
   void do_typecast(exprt &dest, const typet &type);
 
   c_typet minimum_promotion(const typet &type) const;
+
+private:
+  const symbolt *current_symbol;
 };
 
 #endif // CPROVER_ANSI_C_C_TYPECAST_H

--- a/src/ansi-c/c_typecheck_typecast.cpp
+++ b/src/ansi-c/c_typecheck_typecast.cpp
@@ -15,6 +15,7 @@ void c_typecheck_baset::implicit_typecast(
   const typet &dest_type)
 {
   c_typecastt c_typecast(*this);
+  c_typecast.set_current_symbol(&current_symbol);
 
   typet src_type=expr.type();
 


### PR DESCRIPTION
There are several SV-COMP benchmarks where is used and alias
variable with a global array variable. The alias varialbe is not
array ariable and it wants to alias with the array, i.e. with the
first element in the array. This commit prevents the type mismatch.

Do not merge: regression test required