### PR TITLE
smt2_solver.{o,d} should be removed by "make clean"

### DIFF
--- a/src/common
+++ b/src/common
@@ -24,6 +24,7 @@ ifeq ($(filter-out Unix MinGW OSX OSX_Universal FreeBSD,$(BUILD_ENV_)),)
   # Linux-ish
   LIBEXT = .a
   OBJEXT = .o
+  DEPEXT = .d
 ifeq ($(BUILD_ENV_),MinGW)
   EXEEXT = .exe
 else
@@ -96,6 +97,7 @@ else ifeq ($(BUILD_ENV_),Cygwin)
   # use these for Cygwin:
   LIBEXT = .a
   OBJEXT = .o
+  DEPEXT = .d
   EXEEXT = .exe
   CFLAGS ?= -Wall -O2
   CXXFLAGS ?= -Wall -O2
@@ -128,6 +130,7 @@ else ifeq ($(BUILD_ENV_),MSVC)
   # use these for Visual Studio:
   LIBEXT = .lib
   OBJEXT = .obj
+  DEPEXT = .dep
   EXEEXT = .exe
   CFLAGS ?= /W3 /O2 /GF
   CXXFLAGS ?= /W3 /D_CRT_SECURE_NO_WARNINGS /O2 /GF
@@ -208,7 +211,7 @@ CP_CXXFLAGS += $(CXXFLAGS) $(INCLUDES)
 OBJ += $(patsubst %.cpp, %$(OBJEXT), $(filter %.cpp, $(SRC)))
 OBJ += $(patsubst %.cc, %$(OBJEXT), $(filter %.cc, $(SRC)))
 
-.SUFFIXES: .cc .d .cpp
+.SUFFIXES: .cc $(DEPEXT) .cpp
 
 %.o:%.cpp
 	$(CXX) -c $(CP_CXXFLAGS) -o $@ $<
@@ -231,9 +234,9 @@ OBJ += $(patsubst %.cc, %$(OBJEXT), $(filter %.cc, $(SRC)))
 
 clean:
 	$(RM) $(patsubst %.cpp, %$(OBJEXT), $(filter %.cpp, $(SRC))) \
-		$(patsubst %.cpp, %.d, $(filter %.cpp, $(SRC))) \
+		$(patsubst %.cpp, %$(DEPEXT), $(filter %.cpp, $(SRC))) \
 		$(patsubst %.cc, %$(OBJEXT), $(filter %.cc, $(SRC))) \
-		$(patsubst %.cc, %.d, $(filter %.cc, $(SRC))) \
+		$(patsubst %.cc, %$(DEPEXT), $(filter %.cc, $(SRC))) \
 		$(CLEANFILES)
 
 .PHONY: first_target clean all
@@ -250,8 +253,8 @@ sources: Makefile
 # include .depend
 # endif
 
-D_FILES1 = $(SRC:.c=.d)
-D_FILES = $(D_FILES1:.cpp=.d)
+D_FILES1 = $(SRC:.c=$(DEPEXT))
+D_FILES = $(D_FILES1:.cpp=$(DEPEXT))
 
 -include $(D_FILES)
 

--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -218,7 +218,7 @@ INCLUDES += -I .. \
 	$(PRECOSAT_INCLUDE) $(PICOSAT_INCLUDE) $(LINGELING_INCLUDE)
 
 CLEANFILES = solvers$(LIBEXT) \
-  smt2_solver$(EXEEXT) smt2/smt2_solver$(OBJEXT) smt2/smt2_solver.d
+  smt2_solver$(EXEEXT) smt2/smt2_solver$(OBJEXT) smt2/smt2_solver$(DEPEXT)
 
 all: solvers$(LIBEXT) smt2_solver$(EXEEXT)
 
@@ -229,10 +229,6 @@ ifneq ($(CUDD),)
   CP_CXXFLAGS += -DHAVE_QBF_CORE
 endif
 endif
-
-# extra dependencies
-
--include $(SRC:.cpp=.d)
 
 SOLVER_LIB = $(CHAFF_LIB) $(BOOLEFORCE_LIB) $(MINISAT_LIB) \
         $(MINISAT2_LIB) $(SMVSAT_LIB) $(SQUOLEM2_LIB) $(CUDD_LIB) \

--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -217,7 +217,8 @@ INCLUDES += -I .. \
   $(SMVSAT_INCLUDE) $(SQUOLEM2_INC) $(CUDD_INCLUDE) $(GLUCOSE_INCLUDE) \
 	$(PRECOSAT_INCLUDE) $(PICOSAT_INCLUDE) $(LINGELING_INCLUDE)
 
-CLEANFILES = solvers$(LIBEXT) smt2_solver$(EXEEXT)
+CLEANFILES = solvers$(LIBEXT) \
+  smt2_solver$(EXEEXT) smt2/smt2_solver$(OBJEXT) smt2/smt2_solver.d
 
 all: solvers$(LIBEXT) smt2_solver$(EXEEXT)
 


### PR DESCRIPTION
The set of files to be removed is inferred from the SRC variable, which does not
include smt2_solver.cpp. Hence the generated files need to be listed explicitly.