### PR TITLE
C library: Re-use known declarations when parsing the built-in library

### DIFF
--- a/regression/cbmc/library1/main.c
+++ b/regression/cbmc/library1/main.c
@@ -1,0 +1,16 @@
+struct _IO_FILE;
+typedef struct _IO_FILE FILE;
+struct _IO_FILE
+{
+  char dummy;
+};
+
+extern FILE *fopen(char const *fname, char const *mode);
+
+int main()
+{
+  FILE *f;
+  f = fopen("some_file", "r");
+  __CPROVER_assert(f == 0, "");
+  return 0;
+}

--- a/regression/cbmc/library1/test.desc
+++ b/regression/cbmc/library1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+implicit function declaration
+syntax error

--- a/src/ansi-c/ansi_c_language.h
+++ b/src/ansi-c/ansi_c_language.h
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <memory>
 
 #include <util/make_unique.h>
+#include <util/symbol_table.h>
 
 #include <langapi/language.h>
 
@@ -29,6 +30,9 @@ public:
   bool parse(
     std::istream &instream,
     const std::string &path) override;
+
+  bool
+  parse(std::istream &instream, const std::string &path, const symbol_tablet &);
 
   bool generate_support_functions(
     symbol_tablet &symbol_table) override;
@@ -75,6 +79,7 @@ public:
 protected:
   ansi_c_parse_treet parse_tree;
   std::string parse_path;
+  symbol_tablet new_symbol_table;
 };
 
 std::unique_ptr<languaget> new_ansi_c_language();

--- a/src/ansi-c/ansi_c_parser.h
+++ b/src/ansi-c/ansi_c_parser.h
@@ -35,7 +35,8 @@ public:
     mode(modet::NONE),
     cpp98(false),
     cpp11(false),
-    for_has_scope(false)
+    for_has_scope(false),
+    symbol_table(nullptr)
   {
   }
 
@@ -59,6 +60,8 @@ public:
     // set up global scope
     scopes.clear();
     scopes.push_back(scopet());
+
+    symbol_table = nullptr;
   }
 
   // internal state of the scanner
@@ -139,6 +142,14 @@ public:
     lookup(base_name, identifier, false, true);
     return identifier;
   }
+
+  void set_symbol_table(const symbol_tablet &st)
+  {
+    symbol_table = &st;
+  }
+
+private:
+  const symbol_tablet *symbol_table;
 };
 
 extern ansi_c_parsert ansi_c_parser;

--- a/src/ansi-c/ansi_c_scope.h
+++ b/src/ansi-c/ansi_c_scope.h
@@ -29,9 +29,11 @@ class ansi_c_identifiert
 {
 public:
   ansi_c_id_classt id_class;
+  bool from_symbol_table;
   irep_idt base_name, prefixed_name;
 
-  ansi_c_identifiert():id_class(ansi_c_id_classt::ANSI_C_UNKNOWN)
+  ansi_c_identifiert()
+    : id_class(ansi_c_id_classt::ANSI_C_UNKNOWN), from_symbol_table(false)
   {
   }
 };

--- a/src/ansi-c/cprover_library.cpp
+++ b/src/ansi-c/cprover_library.cpp
@@ -14,6 +14,9 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "ansi_c_language.h"
 
+static void
+add_library(const std::string &src, symbol_tablet &, message_handlert &);
+
 struct cprover_library_entryt
 {
   const char *function;
@@ -78,7 +81,7 @@ void add_cprover_library(
   add_library(library_text, symbol_table, message_handler);
 }
 
-void add_library(
+static void add_library(
   const std::string &src,
   symbol_tablet &symbol_table,
   message_handlert &message_handler)
@@ -90,7 +93,7 @@ void add_library(
 
   ansi_c_languaget ansi_c_language;
   ansi_c_language.set_message_handler(message_handler);
-  ansi_c_language.parse(in, "");
+  ansi_c_language.parse(in, "", symbol_table);
 
   ansi_c_language.typecheck(symbol_table, "<built-in-library>");
 }

--- a/src/ansi-c/cprover_library.h
+++ b/src/ansi-c/cprover_library.h
@@ -19,11 +19,6 @@ std::string get_cprover_library_text(
   const std::set<irep_idt> &functions,
   const symbol_tablet &);
 
-void add_library(
-  const std::string &src,
-  symbol_tablet &,
-  message_handlert &);
-
 void add_cprover_library(
   const std::set<irep_idt> &functions,
   symbol_tablet &,

--- a/src/ansi-c/library/cprover.h
+++ b/src/ansi-c/library/cprover.h
@@ -38,6 +38,7 @@ void __CPROVER_cover(__CPROVER_bool condition);
 
 void __CPROVER_input(const char *id, ...);
 void __CPROVER_output(const char *id, ...);
+int __CPROVER_printf(const char *fmt, ...);
 
 // concurrency-related
 void __CPROVER_atomic_begin();

--- a/src/ansi-c/library/err.c
+++ b/src/ansi-c/library/err.c
@@ -1,14 +1,6 @@
 /* FUNCTION: err */
 
-#ifndef __CPROVER_ERR_H_INCLUDED
-#include <err.h>
-#define __CPROVER_ERR_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_STDLIB_H_INCLUDED
-#include <stdlib.h>
-#define __CPROVER_STDLIB_H_INCLUDED
-#endif
+void abort(void);
 
 void err(int eval, const char *fmt, ...)
 {
@@ -19,15 +11,7 @@ void err(int eval, const char *fmt, ...)
 
 /* FUNCTION: err */
 
-#ifndef __CPROVER_ERR_H_INCLUDED
-#include <err.h>
-#define __CPROVER_ERR_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_STDLIB_H_INCLUDED
-#include <stdlib.h>
-#define __CPROVER_STDLIB_H_INCLUDED
-#endif
+void abort(void);
 
 void errx(int eval, const char *fmt, ...)
 {
@@ -38,22 +22,12 @@ void errx(int eval, const char *fmt, ...)
 
 /* FUNCTION: warn */
 
-#ifndef __CPROVER_ERR_H_INCLUDED
-#include <err.h>
-#define __CPROVER_ERR_H_INCLUDED
-#endif
-
 void warn(const char *fmt, ...)
 {
   (void)*fmt;
 }
 
 /* FUNCTION: warnx */
-
-#ifndef __CPROVER_ERR_H_INCLUDED
-#include <err.h>
-#define __CPROVER_ERR_H_INCLUDED
-#endif
 
 void warnx(const char *fmt, ...)
 {

--- a/src/ansi-c/library/fcntl.c
+++ b/src/ansi-c/library/fcntl.c
@@ -1,10 +1,5 @@
 /* FUNCTION: fcntl */
 
-#ifndef __CPROVER_FCNTL_H_INCLUDED
-#include <fcntl.h>
-#define __CPROVER_FCNTL_H_INCLUDED
-#endif
-
 int __VERIFIER_nondet_int();
 
 int fcntl(int fd, int cmd, ...)

--- a/src/ansi-c/library/getopt.c
+++ b/src/ansi-c/library/getopt.c
@@ -1,15 +1,16 @@
+#ifdef LIBRARY_CHECK
+#include <getopt.h>
+#endif
+
 /* FUNCTION: getopt */
 
 extern char *optarg;
 extern int optind;
 
-#ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
-#endif
+__CPROVER_size_t strlen(const char *s);
 
 __CPROVER_bool __VERIFIER_nondet___CPROVER_bool();
-size_t __VERIFIER_nondet_size_t();
+__CPROVER_size_t __VERIFIER_nondet_size_t();
 
 inline int getopt(
   int argc, char * const argv[], const char *optstring)
@@ -23,7 +24,7 @@ inline int getopt(
   if(optind>=argc || argv[optind][0]!='-')
     return -1;
 
-  size_t result_index=__VERIFIER_nondet_size_t();
+  __CPROVER_size_t result_index = __VERIFIER_nondet_size_t();
   __CPROVER_assume(
     result_index<strlen(optstring) && optstring[result_index]!=':');
   #ifdef __CPROVER_STRING_ABSTRACTION
@@ -49,7 +50,7 @@ inline int getopt(
       ++optind;
     }
     else
-      optarg=NULL;
+      optarg = 0;
   }
 
   return result;
@@ -57,10 +58,7 @@ inline int getopt(
 
 /* FUNCTION: getopt_long */
 
-#ifndef __CPROVER_GETOPT_H_INCLUDED
-#include <getopt.h>
-#define __CPROVER_GETOPT_H_INCLUDED
-#endif
+int getopt(int argc, char *const argv[], const char *optstring);
 
 inline int getopt_long(
   int argc,

--- a/src/ansi-c/library/inet.c
+++ b/src/ansi-c/library/inet.c
@@ -1,11 +1,16 @@
+#ifndef _WIN32
+#ifdef LIBRARY_CHECK
+#include <arpa/inet.h>
+#undef htonl
+#undef htons
+#undef ntohl
+#undef ntohs
+#endif
+#endif
+
 /* FUNCTION: inet_addr */
 
 #ifndef _WIN32
-
-#ifndef __CPROVER_INET_H_INCLUDED
-#include <arpa/inet.h>
-#define __CPROVER_INET_H_INCLUDED
-#endif
 
 in_addr_t __VERIFIER_nondet_in_addr_t();
 
@@ -27,11 +32,6 @@ in_addr_t inet_addr(const char *cp)
 /* FUNCTION: inet_aton */
 
 #ifndef _WIN32
-
-#ifndef __CPROVER_INET_H_INCLUDED
-#include <arpa/inet.h>
-#define __CPROVER_INET_H_INCLUDED
-#endif
 
 int __VERIFIER_nondet_int();
 
@@ -55,11 +55,6 @@ int inet_aton(const char *cp, struct in_addr *pin)
 
 #ifndef _WIN32
 
-#ifndef __CPROVER_INET_H_INCLUDED
-#include <arpa/inet.h>
-#define __CPROVER_INET_H_INCLUDED
-#endif
-
 in_addr_t __VERIFIER_nondet_in_addr_t();
 
 in_addr_t inet_network(const char *cp)
@@ -79,16 +74,9 @@ in_addr_t inet_network(const char *cp)
 
 /* FUNCTION: htonl */
 
-#ifndef __CPROVER_STDINT_H_INCLUDED
-#include <stdint.h>
-#define __CPROVER_STDINT_H_INCLUDED
-#endif
+unsigned int __builtin_bswap32(unsigned int);
 
-#undef htonl
-
-uint32_t __builtin_bswap32(uint32_t);
-
-uint32_t htonl(uint32_t hostlong)
+unsigned int htonl(unsigned int hostlong)
 {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   return __builtin_bswap32(hostlong);
@@ -99,16 +87,9 @@ uint32_t htonl(uint32_t hostlong)
 
 /* FUNCTION: htons */
 
-#ifndef __CPROVER_STDINT_H_INCLUDED
-#include <stdint.h>
-#define __CPROVER_STDINT_H_INCLUDED
-#endif
+unsigned short __builtin_bswap16(unsigned short);
 
-#undef htons
-
-uint16_t __builtin_bswap16(uint16_t);
-
-uint16_t htons(uint16_t hostshort)
+unsigned short htons(unsigned short hostshort)
 {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   return __builtin_bswap16(hostshort);
@@ -120,16 +101,9 @@ uint16_t htons(uint16_t hostshort)
 
 /* FUNCTION: ntohl */
 
-#ifndef __CPROVER_STDINT_H_INCLUDED
-#include <stdint.h>
-#define __CPROVER_STDINT_H_INCLUDED
-#endif
+unsigned int __builtin_bswap32(unsigned int);
 
-#undef ntohl
-
-uint32_t __builtin_bswap32(uint32_t);
-
-uint32_t ntohl(uint32_t netlong)
+unsigned int ntohl(unsigned int netlong)
 {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   return __builtin_bswap32(netlong);
@@ -141,16 +115,9 @@ uint32_t ntohl(uint32_t netlong)
 
 /* FUNCTION: ntohs */
 
-#ifndef __CPROVER_STDINT_H_INCLUDED
-#include <stdint.h>
-#define __CPROVER_STDINT_H_INCLUDED
-#endif
+unsigned short __builtin_bswap16(unsigned short);
 
-#undef ntohs
-
-uint16_t __builtin_bswap16(uint16_t);
-
-uint16_t ntohs(uint16_t netshort)
+unsigned short ntohs(unsigned short netshort)
 {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   return __builtin_bswap16(netshort);

--- a/src/ansi-c/library/locale.c
+++ b/src/ansi-c/library/locale.c
@@ -1,10 +1,8 @@
+#ifdef LIBRARY_CHECK
+#include <locale.h>
+#endif
 
 /* FUNCTION: setlocale */
-
-#ifndef __CPROVER_LOCALE_H_INCLUDED
-#include <locale.h>
-#define __CPROVER_LOCALE_H_INCLUDED
-#endif
 
 inline char *setlocale(int category, const char *locale)
 {
@@ -23,11 +21,6 @@ inline char *setlocale(int category, const char *locale)
 }
 
 /* FUNCTION: localeconv */
-
-#ifndef __CPROVER_LOCALE_H_INCLUDED
-#include <locale.h>
-#define __CPROVER_LOCALE_H_INCLUDED
-#endif
 
 inline struct lconv *localeconv(void)
 {

--- a/src/ansi-c/library/math.c
+++ b/src/ansi-c/library/math.c
@@ -714,11 +714,6 @@ __CPROVER_hide:;
  *      square root (i.e. the real value of the square root rounded).
  */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
 #define __CPROVER_FENV_H_INCLUDED
@@ -801,11 +796,6 @@ float sqrtf(float f)
 
 /* The same caveats as sqrtf apply */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
 #define __CPROVER_FENV_H_INCLUDED
@@ -871,11 +861,6 @@ double sqrt(double d)
 /* FUNCTION: sqrtl */
 
 /* The same caveats as sqrtf apply */
-
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
@@ -962,34 +947,28 @@ long double sqrtl(long double d)
 
 /* FUNCTION: fmax */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
 // TODO : Should call a __CPROVER_function so that it can be converted to SMT-LIB
-double fmax(double f, double g) { return ((f >= g) || isnan(g)) ? f : g; }
+double fmax(double f, double g)
+{
+  return ((f >= g) || __CPROVER_isnand(g)) ? f : g;
+}
 
 /* FUNCTION : fmaxf */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
 // TODO : Should call a __CPROVER_function so that it can be converted to SMT-LIB
-float fmaxf(float f, float g) { return ((f >= g) || isnan(g)) ? f : g; }
+float fmaxf(float f, float g)
+{
+  return ((f >= g) || __CPROVER_isnanf(g)) ? f : g;
+}
 
 
 /* FUNCTION : fmaxl */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
 // TODO : Should call a __CPROVER_function so that it can be converted to SMT-LIB
-long double fmaxl(long double f, long double g) { return ((f >= g) || isnan(g)) ? f : g; }
+long double fmaxl(long double f, long double g)
+{
+  return ((f >= g) || __CPROVER_isnanld(g)) ? f : g;
+}
 
 
 /* ISO 9899:2011
@@ -1006,33 +985,27 @@ long double fmaxl(long double f, long double g) { return ((f >= g) || isnan(g)) 
 
 /* FUNCTION: fmin */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
- 
 // TODO : Should call a __CPROVER_function so that it can be converted to SMT-LIB
-double fmin(double f, double g) { return ((f <= g) || isnan(g)) ? f : g; }
+double fmin(double f, double g)
+{
+  return ((f <= g) || __CPROVER_isnand(g)) ? f : g;
+}
 
 /* FUNCTION: fminf */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
 // TODO : Should call a __CPROVER_function so that it can be converted to SMT-LIB 
-float fminf(float f, float g) { return ((f <= g) || isnan(g)) ? f : g; }
+float fminf(float f, float g)
+{
+  return ((f <= g) || __CPROVER_isnanf(g)) ? f : g;
+}
 
 /* FUNCTION: fminl */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
 // TODO : Should call a __CPROVER_function so that it can be converted to SMT-LIB 
-long double fminl(long double f, long double g) { return ((f <= g) || isnan(g)) ? f : g; }
+long double fminl(long double f, long double g)
+{
+  return ((f <= g) || __CPROVER_isnanld(g)) ? f : g;
+}
 
 
 /* ISO 9899:2011
@@ -1045,30 +1018,15 @@ long double fminl(long double f, long double g) { return ((f <= g) || isnan(g)) 
 
 /* FUNCTION: fdim */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
 double fdim(double f, double g) { return ((f > g) ? f - g : +0.0); }
 
 
 /* FUNCTION: fdimf */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
 float fdimf(float f, float g) { return ((f > g) ? f - g : +0.0f); }
 
 
 /* FUNCTION: fdiml */
-
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
 
 long double fdiml(long double f, long double g) { return ((f > g) ? f - g : +0.0); }
 
@@ -1077,15 +1035,8 @@ long double fdiml(long double f, long double g) { return ((f > g) ? f - g : +0.0
 /* FUNCTION: __sort_of_CPROVER_round_to_integral */
 // TODO : Should be a real __CPROVER function to convert to SMT-LIB
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_FENV_H_INCLUDED
-#include <fenv.h>
-#define __CPROVER_FENV_H_INCLUDED
-#endif
+int fegetround();
+int fesetround(int);
 
 double __sort_of_CPROVER_round_to_integral (int rounding_mode, double d)
 {
@@ -1116,15 +1067,8 @@ double __sort_of_CPROVER_round_to_integral (int rounding_mode, double d)
 /* FUNCTION: __sort_of_CPROVER_round_to_integralf */
 // TODO : Should be a real __CPROVER function to convert to SMT-LIB
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_FENV_H_INCLUDED
-#include <fenv.h>
-#define __CPROVER_FENV_H_INCLUDED
-#endif
+int fegetround();
+int fesetround(int);
 
 float __sort_of_CPROVER_round_to_integralf (int rounding_mode, float d)
 {
@@ -1156,15 +1100,8 @@ float __sort_of_CPROVER_round_to_integralf (int rounding_mode, float d)
 /* FUNCTION: __sort_of_CPROVER_round_to_integrall */
 // TODO : Should be a real __CPROVER function to convert to SMT-LIB
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_FENV_H_INCLUDED
-#include <fenv.h>
-#define __CPROVER_FENV_H_INCLUDED
-#endif
+int fegetround();
+int fesetround(int);
 
 long double __sort_of_CPROVER_round_to_integrall (int rounding_mode, long double d)
 {
@@ -1200,11 +1137,6 @@ long double __sort_of_CPROVER_round_to_integrall (int rounding_mode, long double
 
 /* FUNCTION: ceil */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
 #define __CPROVER_FENV_H_INCLUDED
@@ -1218,11 +1150,6 @@ double ceil(double x)
 }
 
 /* FUNCTION: ceilf */
-
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
@@ -1238,11 +1165,6 @@ float ceilf(float x)
 
 
 /* FUNCTION: ceill */
-
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
@@ -1264,11 +1186,6 @@ long double ceill(long double x)
 
 /* FUNCTION: floor */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
 #define __CPROVER_FENV_H_INCLUDED
@@ -1282,11 +1199,6 @@ double floor(double x)
 }
 
 /* FUNCTION: floorf */
-
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
@@ -1302,11 +1214,6 @@ float floorf(float x)
 
 
 /* FUNCTION: floorl */
-
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
@@ -1329,11 +1236,6 @@ long double floorl(long double x)
 
 /* FUNCTION: trunc */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
 #define __CPROVER_FENV_H_INCLUDED
@@ -1347,11 +1249,6 @@ double trunc(double x)
 }
 
 /* FUNCTION: truncf */
-
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
@@ -1367,11 +1264,6 @@ float truncf(float x)
 
 
 /* FUNCTION: truncl */
-
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
@@ -1393,11 +1285,6 @@ long double truncl(long double x)
  */
 
 /* FUNCTION: round */
-
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
@@ -1430,11 +1317,6 @@ double round(double x)
 
 /* FUNCTION: roundf */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
 #define __CPROVER_FENV_H_INCLUDED
@@ -1466,11 +1348,6 @@ float roundf(float x)
 
 
 /* FUNCTION: roundl */
-
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
@@ -1512,17 +1389,8 @@ long double roundl(long double x)
 
 /* FUNCTION: nearbyint */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_FENV_H_INCLUDED
-#include <fenv.h>
-#define __CPROVER_FENV_H_INCLUDED
-#endif
-
 double __sort_of_CPROVER_round_to_integral (int rounding_mode, double d);
+int fegetround();
 
 double nearbyint(double x)
 {
@@ -1531,17 +1399,8 @@ double nearbyint(double x)
 
 /* FUNCTION: nearbyintf */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_FENV_H_INCLUDED
-#include <fenv.h>
-#define __CPROVER_FENV_H_INCLUDED
-#endif
-
 float __sort_of_CPROVER_round_to_integralf (int rounding_mode, float d);
+int fegetround();
 
 float nearbyintf(float x)
 {
@@ -1551,17 +1410,8 @@ float nearbyintf(float x)
 
 /* FUNCTION: nearbyintl */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_FENV_H_INCLUDED
-#include <fenv.h>
-#define __CPROVER_FENV_H_INCLUDED
-#endif
-
 long double __sort_of_CPROVER_round_to_integrall (int rounding_mode, long double d);
+int fegetround();
 
 long double nearbyintl(long double x)
 {
@@ -1579,17 +1429,8 @@ long double nearbyintl(long double x)
 
 /* FUNCTION: rint */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_FENV_H_INCLUDED
-#include <fenv.h>
-#define __CPROVER_FENV_H_INCLUDED
-#endif
-
 double __sort_of_CPROVER_round_to_integral (int rounding_mode, double d);
+int fegetround();
 
 double rint(double x)
 {
@@ -1598,17 +1439,8 @@ double rint(double x)
 
 /* FUNCTION: rintf */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_FENV_H_INCLUDED
-#include <fenv.h>
-#define __CPROVER_FENV_H_INCLUDED
-#endif
-
 float __sort_of_CPROVER_round_to_integralf (int rounding_mode, float d);
+int fegetround();
 
 float rintf(float x)
 {
@@ -1617,17 +1449,8 @@ float rintf(float x)
 
 /* FUNCTION: rintl */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_FENV_H_INCLUDED
-#include <fenv.h>
-#define __CPROVER_FENV_H_INCLUDED
-#endif
-
 long double __sort_of_CPROVER_round_to_integrall (int rounding_mode, long double d);
+int fegetround();
 
 long double rintl(long double x)
 {
@@ -1647,17 +1470,8 @@ long double rintl(long double x)
 
 /* FUNCTION: lrint */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_FENV_H_INCLUDED
-#include <fenv.h>
-#define __CPROVER_FENV_H_INCLUDED
-#endif
-
 double __sort_of_CPROVER_round_to_integral (int rounding_mode, double d);
+int fegetround();
 
 long int lrint(double x)
 {
@@ -1669,17 +1483,8 @@ long int lrint(double x)
 
 /* FUNCTION: lrintf */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_FENV_H_INCLUDED
-#include <fenv.h>
-#define __CPROVER_FENV_H_INCLUDED
-#endif
-
 float __sort_of_CPROVER_round_to_integralf (int rounding_mode, float d);
+int fegetround();
 
 long int lrintf(float x)
 {
@@ -1692,17 +1497,8 @@ long int lrintf(float x)
 
 /* FUNCTION: lrintl */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_FENV_H_INCLUDED
-#include <fenv.h>
-#define __CPROVER_FENV_H_INCLUDED
-#endif
-
 long double __sort_of_CPROVER_round_to_integrall (int rounding_mode, long double d);
+int fegetround();
 
 long int lrintl(long double x)
 {
@@ -1715,17 +1511,8 @@ long int lrintl(long double x)
 
 /* FUNCTION: llrint */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_FENV_H_INCLUDED
-#include <fenv.h>
-#define __CPROVER_FENV_H_INCLUDED
-#endif
-
 double __sort_of_CPROVER_round_to_integral (int rounding_mode, double d);
+int fegetround();
 
 long long int llrint(double x)
 {
@@ -1737,17 +1524,8 @@ long long int llrint(double x)
 
 /* FUNCTION: llrintf */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_FENV_H_INCLUDED
-#include <fenv.h>
-#define __CPROVER_FENV_H_INCLUDED
-#endif
-
 float __sort_of_CPROVER_round_to_integralf (int rounding_mode, float d);
+int fegetround();
 
 long long int llrintf(float x)
 {
@@ -1760,17 +1538,8 @@ long long int llrintf(float x)
 
 /* FUNCTION: llrintl */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_FENV_H_INCLUDED
-#include <fenv.h>
-#define __CPROVER_FENV_H_INCLUDED
-#endif
-
 long double __sort_of_CPROVER_round_to_integrall (int rounding_mode, long double d);
+int fegetround();
 
 long long int llrintl(long double x)
 {
@@ -1791,11 +1560,6 @@ long long int llrintl(long double x)
  */
 
 /* FUNCTION: lround */
-
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
@@ -1829,11 +1593,6 @@ long int lround(double x)
 
 /* FUNCTION: lroundf */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
 #define __CPROVER_FENV_H_INCLUDED
@@ -1865,11 +1624,6 @@ long int lroundf(float x)
 
 
 /* FUNCTION: lroundl */
-
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
@@ -1903,11 +1657,6 @@ long int lroundl(long double x)
 
 /* FUNCTION: llround */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
 #define __CPROVER_FENV_H_INCLUDED
@@ -1938,11 +1687,6 @@ long long int llround(double x)
 }
 
 /* FUNCTION: llroundf */
-
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
@@ -1975,11 +1719,6 @@ long long int llroundf(float x)
 
 
 /* FUNCTION: llroundl */
-
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
@@ -2021,11 +1760,6 @@ long long int llroundl(long double x)
 
 /* FUNCTION: modf */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
 #define __CPROVER_FENV_H_INCLUDED
@@ -2040,11 +1774,6 @@ double modf(double x, double *iptr)
 }
 
 /* FUNCTION: modff */
-
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
@@ -2061,11 +1790,6 @@ float __sort_of_CPROVER_round_to_integralf (int rounding_mode, float d);
 
 
 /* FUNCTION: modfl */
-
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
@@ -2145,11 +1869,6 @@ long double __sort_of_CPROVER_remainderl (int rounding_mode, long double x, long
 
 /* FUNCTION: fmod */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
 #define __CPROVER_FENV_H_INCLUDED
@@ -2162,11 +1881,6 @@ double fmod(double x, double y) { return __sort_of_CPROVER_remainder(FE_TOWARDZE
 
 /* FUNCTION: fmodf */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
 #define __CPROVER_FENV_H_INCLUDED
@@ -2178,11 +1892,6 @@ float fmodf(float x, float y) { return __sort_of_CPROVER_remainderf(FE_TOWARDZER
 
 
 /* FUNCTION: fmodl */
-
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
@@ -2210,11 +1919,6 @@ long double fmodl(long double x, long double y) { return __sort_of_CPROVER_remai
 
 /* FUNCTION: remainder */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
 #define __CPROVER_FENV_H_INCLUDED
@@ -2227,11 +1931,6 @@ double remainder(double x, double y) { return __sort_of_CPROVER_remainder(FE_TON
 
 /* FUNCTION: remainderf */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
 #define __CPROVER_FENV_H_INCLUDED
@@ -2243,11 +1942,6 @@ float remainderf(float x, float y) { return __sort_of_CPROVER_remainderf(FE_TONE
 
 
 /* FUNCTION: remainderl */
-
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_FENV_H_INCLUDED
 #include <fenv.h>
@@ -2271,47 +1965,26 @@ long double remainderl(long double x, long double y) { return __sort_of_CPROVER_
 
 /* FUNCTION: copysign */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
-double fabs (double d);
-
 double copysign(double x, double y)
 {
-  double abs = fabs(x);
-  return (signbit(y)) ? -abs : abs;
+  double abs = __CPROVER_fabs(x);
+  return (__CPROVER_signd(y)) ? -abs : abs;
 }
 
 /* FUNCTION: copysignf */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
-float fabsf (float d);
-
 float copysignf(float x, float y)
 {
-  float abs = fabs(x);
-  return (signbit(y)) ? -abs : abs;
+  float abs = __CPROVER_fabs(x);
+  return (__CPROVER_signf(y)) ? -abs : abs;
 }
 
 /* FUNCTION: copysignl */
 
-#ifndef __CPROVER_MATH_H_INCLUDED
-#include <math.h>
-#define __CPROVER_MATH_H_INCLUDED
-#endif
-
-long double fabsl (long double d);
-
 long double copysignl(long double x, long double y)
 {
-  long double abs = fabsl(x);
-  return (signbit(y)) ? -abs : abs;
+  long double abs = __CPROVER_fabsl(x);
+  return (__CPROVER_signld(y)) ? -abs : abs;
 }
 
 

--- a/src/ansi-c/library/netdb.c
+++ b/src/ansi-c/library/netdb.c
@@ -1,6 +1,8 @@
-/* FUNCTION: gethostbyname */
-
+#ifdef LIBRARY_CHECK
 #include <netdb.h>
+#endif
+
+/* FUNCTION: gethostbyname */
 
 __CPROVER_bool __VERIFIER_nondet___CPROVER_bool();
 

--- a/src/ansi-c/library/pthread_lib.c
+++ b/src/ansi-c/library/pthread_lib.c
@@ -1,9 +1,8 @@
-/* FUNCTION: pthread_mutexattr_settype */
-
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
+#ifdef LIBRARY_CHECK
 #include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
 #endif
+
+/* FUNCTION: pthread_mutexattr_settype */
 
 int __VERIFIER_nondet_int();
 
@@ -25,11 +24,6 @@ inline int pthread_mutexattr_settype(pthread_mutexattr_t *attr, int type)
 
 /* FUNCTION: pthread_cancel */
 
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
-
 int __VERIFIER_nondet_int();
 
 inline int pthread_cancel(pthread_t thread)
@@ -47,11 +41,6 @@ inline int pthread_cancel(pthread_t thread)
 }
 
 /* FUNCTION: pthread_mutex_init */
-
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_mutex_t_defined
 #define __CPROVER_mutex_t_defined
@@ -92,11 +81,6 @@ inline int pthread_mutex_init(
 }
 
 /* FUNCTION: pthread_mutex_lock */
-
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_mutex_t_defined
 #define __CPROVER_mutex_t_defined
@@ -141,11 +125,6 @@ inline int pthread_mutex_lock(pthread_mutex_t *mutex)
 }
 
 /* FUNCTION: pthread_mutex_trylock */
-
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_mutex_t_defined
 #define __CPROVER_mutex_t_defined
@@ -193,11 +172,6 @@ inline int pthread_mutex_trylock(pthread_mutex_t *mutex)
 
 /* FUNCTION: pthread_mutex_unlock */
 
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
-
 #ifndef __CPROVER_mutex_t_defined
 #define __CPROVER_mutex_t_defined
 #if defined __CYGWIN__ || defined __MINGW32__ || defined _WIN32
@@ -241,11 +215,6 @@ inline int pthread_mutex_unlock(pthread_mutex_t *mutex)
 
 /* FUNCTION: pthread_mutex_destroy */
 
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
-
 #ifndef __CPROVER_mutex_t_defined
 #define __CPROVER_mutex_t_defined
 #if defined __CYGWIN__ || defined __MINGW32__ || defined _WIN32
@@ -285,11 +254,6 @@ inline int pthread_mutex_destroy(pthread_mutex_t *mutex)
 
 /* FUNCTION: pthread_exit */
 
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
-
 extern __CPROVER_bool __CPROVER_threads_exited[];
 extern __CPROVER_thread_local unsigned long __CPROVER_thread_id;
 
@@ -302,11 +266,6 @@ inline void pthread_exit(void *value_ptr)
 }
 
 /* FUNCTION: pthread_join */
-
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_ERRNO_H_INCLUDED
 #include <errno.h>
@@ -338,11 +297,6 @@ inline int pthread_join(pthread_t thread, void **value_ptr)
 
 // This is for Apple
 
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
-
 #ifndef __CPROVER_ERRNO_H_INCLUDED
 #include <errno.h>
 #define __CPROVER_ERRNO_H_INCLUDED
@@ -373,11 +327,6 @@ inline int _pthread_join(pthread_t thread, void **value_ptr)
 
 /* FUNCTION: pthread_rwlock_destroy */
 
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
-
 inline int pthread_rwlock_destroy(pthread_rwlock_t *lock)
 {
   __CPROVER_HIDE:;
@@ -393,11 +342,6 @@ inline int pthread_rwlock_destroy(pthread_rwlock_t *lock)
 }
 
 /* FUNCTION: pthread_rwlock_init */
-
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
 
 #ifdef __CPROVER_CUSTOM_BITVECTOR_ANALYSIS
 inline void pthread_rwlock_cleanup(void *p)
@@ -424,11 +368,6 @@ inline int pthread_rwlock_init(pthread_rwlock_t *lock,
 
 /* FUNCTION: pthread_rwlock_rdlock */
 
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
-
 inline int pthread_rwlock_rdlock(pthread_rwlock_t *lock)
 {
   __CPROVER_HIDE:;
@@ -443,11 +382,6 @@ inline int pthread_rwlock_rdlock(pthread_rwlock_t *lock)
 
 /* FUNCTION: pthread_rwlock_tryrdlock */
 
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
-
 inline int pthread_rwlock_tryrdlock(pthread_rwlock_t *lock)
 {
   __CPROVER_HIDE:;
@@ -459,11 +393,6 @@ inline int pthread_rwlock_tryrdlock(pthread_rwlock_t *lock)
 }
 
 /* FUNCTION: pthread_rwlock_trywrlock */
-
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
 
 inline int pthread_rwlock_trywrlock(pthread_rwlock_t *lock)
 {
@@ -477,11 +406,6 @@ inline int pthread_rwlock_trywrlock(pthread_rwlock_t *lock)
 
 /* FUNCTION: pthread_rwlock_unlock */
 
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
-
 inline int pthread_rwlock_unlock(pthread_rwlock_t *lock)
 {
   __CPROVER_HIDE:;
@@ -493,11 +417,6 @@ inline int pthread_rwlock_unlock(pthread_rwlock_t *lock)
 }
 
 /* FUNCTION: pthread_rwlock_wrlock */
-
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
 
 inline int pthread_rwlock_wrlock(pthread_rwlock_t *lock)
 {
@@ -512,11 +431,6 @@ inline int pthread_rwlock_wrlock(pthread_rwlock_t *lock)
 }
 
 /* FUNCTION: pthread_create */
-
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
 
 extern __CPROVER_bool __CPROVER_threads_exited[];
 extern __CPROVER_thread_local unsigned long __CPROVER_thread_id;
@@ -560,11 +474,6 @@ inline int pthread_create(
 
 /* FUNCTION: pthread_cond_init */
 
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
-
 inline int pthread_cond_init(
     pthread_cond_t *cond,
     const pthread_condattr_t *attr)
@@ -575,11 +484,6 @@ inline int pthread_cond_init(
 }
 
 /* FUNCTION: pthread_cond_signal */
-
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
 
 inline int pthread_cond_signal(
   pthread_cond_t *cond)
@@ -592,11 +496,6 @@ inline int pthread_cond_signal(
 
 /* FUNCTION: pthread_cond_broadcast */
 
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
-
 inline int pthread_cond_broadcast(
     pthread_cond_t *cond)
 { __CPROVER_HIDE:
@@ -607,11 +506,6 @@ inline int pthread_cond_broadcast(
 }
 
 /* FUNCTION: pthread_cond_wait */
-
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
 
 inline int pthread_cond_wait(
     pthread_cond_t *cond,
@@ -643,11 +537,6 @@ inline int pthread_cond_wait(
 
 /* FUNCTION: pthread_spin_lock */
 
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
-
 // no pthread_spinlock_t on the Mac
 #ifndef __APPLE__
 int pthread_spin_lock(pthread_spinlock_t *lock)
@@ -666,11 +555,6 @@ int pthread_spin_lock(pthread_spinlock_t *lock)
 
 /* FUNCTION: pthread_spin_unlock */
 
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
-
 // no pthread_spinlock_t on the Mac
 #ifndef __APPLE__
 int pthread_spin_unlock(pthread_spinlock_t *lock)
@@ -686,11 +570,6 @@ int pthread_spin_unlock(pthread_spinlock_t *lock)
 #endif
 
 /* FUNCTION: pthread_spin_trylock */
-
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
 
 #ifndef __CPROVER_ERRNO_H_INCLUDED
 #include <errno.h>
@@ -721,11 +600,6 @@ int pthread_spin_trylock(pthread_spinlock_t *lock)
 
 /* FUNCTION: pthread_barrier_init */
 
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
-
 int __VERIFIER_nondet_int();
 
 // no pthread_barrier_t on the Mac
@@ -751,11 +625,6 @@ inline int pthread_barrier_init(
 
 /* FUNCTION: pthread_barrier_destroy */
 
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
-
 int __VERIFIER_nondet_int();
 
 // no pthread_barrier_t on the Mac
@@ -780,11 +649,6 @@ inline int pthread_barrier_destroy(pthread_barrier_t *barrier)
 #endif
 
 /* FUNCTION: pthread_barrier_wait */
-
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
 
 int __VERIFIER_nondet_int();
 

--- a/src/ansi-c/library/semaphore.c
+++ b/src/ansi-c/library/semaphore.c
@@ -1,6 +1,8 @@
-/* FUNCTION: sem_init */
-
+#ifdef LIBRARY_CHECK
 #include <semaphore.h>
+#endif
+
+/* FUNCTION: sem_init */
 
 inline int sem_init(sem_t *sem, int pshared, unsigned int value)
 {
@@ -19,8 +21,6 @@ inline int sem_init(sem_t *sem, int pshared, unsigned int value)
 
 /* FUNCTION: sem_wait */
 
-#include <semaphore.h>
-
 inline int sem_wait(sem_t *sem)
 {
   __CPROVER_HIDE:;
@@ -37,8 +37,6 @@ inline int sem_wait(sem_t *sem)
 }
 
 /* FUNCTION: sem_timedwait */
-
-#include <semaphore.h>
 
 inline int sem_timedwait(sem_t *sem, const struct timespec *abstime)
 {
@@ -58,8 +56,6 @@ inline int sem_timedwait(sem_t *sem, const struct timespec *abstime)
 
 /* FUNCTION: sem_trywait */
 
-#include <semaphore.h>
-
 inline int sem_trywait(sem_t *sem)
 {
   __CPROVER_HIDE:;
@@ -77,8 +73,6 @@ inline int sem_trywait(sem_t *sem)
 
 /* FUNCTION: sem_post */
 
-#include <semaphore.h>
-
 inline int sem_post(sem_t *sem)
 {
   __CPROVER_HIDE:;
@@ -95,8 +89,6 @@ inline int sem_post(sem_t *sem)
 }
 
 /* FUNCTION: sem_post_multiple */
-
-#include <semaphore.h>
 
 inline int sem_post_multiple(sem_t *sem, int number)
 {
@@ -116,8 +108,6 @@ inline int sem_post_multiple(sem_t *sem, int number)
 
 /* FUNCTION: sem_getvalue */
 
-#include <semaphore.h>
-
 inline int sem_getvalue(sem_t *sem, int *sval)
 {
   __CPROVER_HIDE:;
@@ -135,8 +125,6 @@ inline int sem_getvalue(sem_t *sem, int *sval)
 }
 
 /* FUNCTION: sem_destroy */
-
-#include <semaphore.h>
 
 inline int sem_destroy(sem_t *sem)
 {

--- a/src/ansi-c/library/setjmp.c
+++ b/src/ansi-c/library/setjmp.c
@@ -1,10 +1,8 @@
+#ifdef LIBRARY_CHECK
+#include <setjmp.h>
+#endif
 
 /* FUNCTION: longjmp */
-
-#ifndef __CPROVER_SETJMP_H_INCLUDED
-#include <setjmp.h>
-#define __CPROVER_SETJMP_H_INCLUDED
-#endif
 
 inline void longjmp(jmp_buf env, int val)
 {
@@ -16,11 +14,6 @@ inline void longjmp(jmp_buf env, int val)
 
 /* FUNCTION: _longjmp */
 
-#ifndef __CPROVER_SETJMP_H_INCLUDED
-#include <setjmp.h>
-#define __CPROVER_SETJMP_H_INCLUDED
-#endif
-
 inline void _longjmp(jmp_buf env, int val)
 {
   // does not return
@@ -31,11 +24,6 @@ inline void _longjmp(jmp_buf env, int val)
 
 /* FUNCTION: siglongjmp */
 
-#ifndef __CPROVER_SETJMP_H_INCLUDED
-#include <setjmp.h>
-#define __CPROVER_SETJMP_H_INCLUDED
-#endif
-
 inline void siglongjmp(sigjmp_buf env, int val)
 {
   // does not return
@@ -45,11 +33,6 @@ inline void siglongjmp(sigjmp_buf env, int val)
 }
 
 /* FUNCTION: setjmp */
-
-#ifndef __CPROVER_SETJMP_H_INCLUDED
-#include <setjmp.h>
-#define __CPROVER_SETJMP_H_INCLUDED
-#endif
 
 int __VERIFIER_nondet_int();
 

--- a/src/ansi-c/library/signal.c
+++ b/src/ansi-c/library/signal.c
@@ -1,14 +1,8 @@
-/* FUNCTION: kill */
-
-#ifndef __CPROVER_SYS_TYPES_H_INCLUDED
+#ifdef LIBRARY_CHECK
 #include <sys/types.h>
-#define __CPROVER_SYS_TYPES_H_INCLUDED
 #endif
 
-#ifndef __CPROVER_SIGNAL_H_INCLUDED
-#include <signal.h>
-#define __CPROVER_SIGNAL_H_INCLUDED
-#endif
+/* FUNCTION: kill */
 
 __CPROVER_bool __VERIFIER_nondet___CPROVER_bool();
 

--- a/src/ansi-c/library/stdio.c
+++ b/src/ansi-c/library/stdio.c
@@ -1,10 +1,9 @@
+#ifdef LIBRARY_CHECK
+#include <stdio.h>
+#include <stdarg.h>
+#endif
 
 /* FUNCTION: putchar */
-
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
 
 __CPROVER_bool __VERIFIER_nondet___CPROVER_bool();
 
@@ -12,16 +11,11 @@ inline int putchar(int c)
 {
   __CPROVER_HIDE:;
   __CPROVER_bool error=__VERIFIER_nondet___CPROVER_bool();
-  printf("%c", c);
+  __CPROVER_printf("%c", c);
   return (error?-1:c);
 }
 
 /* FUNCTION: puts */
-
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
 
 __CPROVER_bool __VERIFIER_nondet___CPROVER_bool();
 int __VERIFIER_nondet_int();
@@ -31,22 +25,12 @@ inline int puts(const char *s)
   __CPROVER_HIDE:;
   __CPROVER_bool error=__VERIFIER_nondet___CPROVER_bool();
   int ret=__VERIFIER_nondet_int();
-  printf("%s\n", s);
+  __CPROVER_printf("%s\n", s);
   if(error) ret=-1; else __CPROVER_assume(ret>=0);
   return ret;
 }
 
 /* FUNCTION: fopen */
-
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_STDLIB_H_INCLUDED
-#include <stdlib.h>
-#define __CPROVER_STDLIB_H_INCLUDED
-#endif
 
 #ifdef __CPROVER_CUSTOM_BITVECTOR_ANALYSIS
 inline void fclose_cleanup(void *stream)
@@ -59,6 +43,7 @@ inline void fclose_cleanup(void *stream)
 #endif
 
 __CPROVER_bool __VERIFIER_nondet___CPROVER_bool();
+void *malloc(__CPROVER_size_t malloc_size);
 
 inline FILE *fopen(const char *filename, const char *mode)
 {
@@ -75,11 +60,11 @@ inline FILE *fopen(const char *filename, const char *mode)
   __CPROVER_bool fopen_error=__VERIFIER_nondet___CPROVER_bool();
 
   #if !defined(__linux__) || defined(__GLIBC__)
-  fopen_result=fopen_error?NULL:malloc(sizeof(FILE));
+  fopen_result = fopen_error ? 0 : malloc(sizeof(FILE));
   #else
   // libraries need to expose the definition of FILE; this is the
   // case for musl
-  fopen_result=fopen_error?NULL:malloc(sizeof(int));
+  fopen_result = fopen_error ? 0 : malloc(sizeof(int));
   #endif
 
   #ifdef __CPROVER_CUSTOM_BITVECTOR_ANALYSIS
@@ -91,11 +76,6 @@ inline FILE *fopen(const char *filename, const char *mode)
 }
 
 /* FUNCTION: freopen */
-
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
 
 inline FILE* freopen(const char *filename, const char *mode, FILE *f)
 {
@@ -113,17 +93,8 @@ inline FILE* freopen(const char *filename, const char *mode, FILE *f)
 
 /* FUNCTION: fclose */
 
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_STDLIB_H_INCLUDED
-#include <stdlib.h>
-#define __CPROVER_STDLIB_H_INCLUDED
-#endif
-
 int __VERIFIER_nondet_int();
+void free(void *ptr);
 
 inline int fclose(FILE *stream)
 {
@@ -141,15 +112,7 @@ inline int fclose(FILE *stream)
 
 /* FUNCTION: fdopen */
 
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_STDLIB_H_INCLUDED
-#include <stdlib.h>
-#define __CPROVER_STDLIB_H_INCLUDED
-#endif
+void *malloc(__CPROVER_size_t malloc_size);
 
 inline FILE *fdopen(int handle, const char *mode)
 {
@@ -179,17 +142,9 @@ inline FILE *fdopen(int handle, const char *mode)
 // header files rename fdopen to _fdopen and would thus yield
 // unbounded recursion.
 
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_STDLIB_H_INCLUDED
-#include <stdlib.h>
-#define __CPROVER_STDLIB_H_INCLUDED
-#endif
-
 #ifdef __APPLE__
+void *malloc(__CPROVER_size_t malloc_size);
+
 inline FILE *_fdopen(int handle, const char *mode)
 {
   __CPROVER_HIDE:;
@@ -207,11 +162,6 @@ inline FILE *_fdopen(int handle, const char *mode)
 #endif
 
 /* FUNCTION: fgets */
-
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
 
 __CPROVER_bool __VERIFIER_nondet___CPROVER_bool();
 int __VERIFIER_nondet_int();
@@ -262,22 +212,14 @@ char *fgets(char *str, int size, FILE *stream)
 
 /* FUNCTION: fread */
 
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
+__CPROVER_size_t __VERIFIER_nondet_size_t();
 
-size_t __VERIFIER_nondet_size_t();
-
-inline size_t fread(
-  void *ptr,
-  size_t size,
-  size_t nitems,
-  FILE *stream)
+inline __CPROVER_size_t
+fread(void *ptr, __CPROVER_size_t size, __CPROVER_size_t nitems, FILE *stream)
 {
   __CPROVER_HIDE:;
-  size_t nread=__VERIFIER_nondet_size_t();
-  size_t bytes=nread*size;
+  __CPROVER_size_t nread = __VERIFIER_nondet_size_t();
+  __CPROVER_size_t bytes = nread * size;
   __CPROVER_assume(nread<=nitems);
 
   #if !defined(__linux__) || defined(__GLIBC__)
@@ -291,7 +233,7 @@ inline size_t fread(
                    "fread file must be open");
   #endif
 
-  for(size_t i=0; i<bytes; i++)
+  for(__CPROVER_size_t i = 0; i < bytes; i++)
   {
     char nondet_char;
     ((char *)ptr)[i]=nondet_char;
@@ -301,11 +243,6 @@ inline size_t fread(
 }
 
 /* FUNCTION: feof */
-
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
 
 int __VERIFIER_nondet_int();
 
@@ -331,11 +268,6 @@ inline int feof(FILE *stream)
 
 /* FUNCTION: ferror */
 
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
-
 int __VERIFIER_nondet_int();
 
 inline int ferror(FILE *stream)
@@ -360,11 +292,6 @@ inline int ferror(FILE *stream)
 
 /* FUNCTION: fileno */
 
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
-
 int __VERIFIER_nondet_int();
 
 inline int fileno(FILE *stream)
@@ -388,11 +315,6 @@ inline int fileno(FILE *stream)
 }
 
 /* FUNCTION: fputs */
-
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
 
 int __VERIFIER_nondet_int();
 
@@ -422,11 +344,6 @@ inline int fputs(const char *s, FILE *stream)
 
 /* FUNCTION: fflush */
 
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
-
 int __VERIFIER_nondet_int();
 
 inline int fflush(FILE *stream)
@@ -446,11 +363,6 @@ inline int fflush(FILE *stream)
 }
 
 /* FUNCTION: fpurge */
-
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
 
 int __VERIFIER_nondet_int();
 
@@ -475,11 +387,6 @@ inline int fpurge(FILE *stream)
 }
 
 /* FUNCTION: fgetc */
-
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
 
 int __VERIFIER_nondet_int();
 
@@ -506,11 +413,6 @@ inline int fgetc(FILE *stream)
 }
 
 /* FUNCTION: getc */
-
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
 
 int __VERIFIER_nondet_int();
 
@@ -540,11 +442,6 @@ inline int getc(FILE *stream)
 
 /* FUNCTION: getchar */
 
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
-
 int __VERIFIER_nondet_int();
 
 inline int getchar()
@@ -558,11 +455,6 @@ inline int getchar()
 }
 
 /* FUNCTION: getw */
-
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
 
 int __VERIFIER_nondet_int();
 
@@ -590,11 +482,6 @@ inline int getw(FILE *stream)
 
 /* FUNCTION: fseek */
 
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
-
 int __VERIFIER_nondet_int();
 
 inline int fseek(FILE *stream, long offset, int whence)
@@ -620,11 +507,6 @@ inline int fseek(FILE *stream, long offset, int whence)
 
 /* FUNCTION: ftell */
 
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
-
 long __VERIFIER_nondet_long();
 
 inline long ftell(FILE *stream)
@@ -648,11 +530,6 @@ inline long ftell(FILE *stream)
 
 /* FUNCTION: rewind */
 
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
-
 void rewind(FILE *stream)
 {
   __CPROVER_HIDE:
@@ -671,17 +548,12 @@ void rewind(FILE *stream)
 
 /* FUNCTION: fwrite */
 
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
+__CPROVER_size_t __VERIFIER_nondet_size_t();
 
-size_t __VERIFIER_nondet_size_t();
-
-size_t fwrite(
+__CPROVER_size_t fwrite(
   const void *ptr,
-  size_t size,
-  size_t nitems,
+  __CPROVER_size_t size,
+  __CPROVER_size_t nitems,
   FILE *stream)
 {
   __CPROVER_HIDE:;
@@ -699,17 +571,12 @@ size_t fwrite(
                    "fwrite file must be open");
   #endif
 
-  size_t nwrite=__VERIFIER_nondet_size_t();
+  __CPROVER_size_t nwrite = __VERIFIER_nondet_size_t();
   __CPROVER_assume(nwrite<=nitems);
   return nwrite;
 }
 
 /* FUNCTION: perror */
-
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
 
 void perror(const char *s)
 {
@@ -721,7 +588,7 @@ void perror(const char *s)
     #endif
     // should go to stderr
     if(s[0]!=0)
-      printf("%s: ", s);
+      __CPROVER_printf("%s: ", s);
   }
 
   // TODO: print errno error
@@ -729,15 +596,7 @@ void perror(const char *s)
 
 /* FUNCTION: fscanf */
 
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_STDARG_H_INCLUDED
-#include <stdarg.h>
-#define __CPROVER_STDARG_H_INCLUDED
-#endif
+int vfscanf(FILE *restrict stream, const char *restrict format, va_list arg);
 
 inline int fscanf(FILE *restrict stream, const char *restrict format, ...)
 {
@@ -751,15 +610,7 @@ inline int fscanf(FILE *restrict stream, const char *restrict format, ...)
 
 /* FUNCTION: scanf */
 
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_STDARG_H_INCLUDED
-#include <stdarg.h>
-#define __CPROVER_STDARG_H_INCLUDED
-#endif
+int vfscanf(FILE *restrict stream, const char *restrict format, va_list arg);
 
 inline int scanf(const char *restrict format, ...)
 {
@@ -773,15 +624,7 @@ inline int scanf(const char *restrict format, ...)
 
 /* FUNCTION: sscanf */
 
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_STDARG_H_INCLUDED
-#include <stdarg.h>
-#define __CPROVER_STDARG_H_INCLUDED
-#endif
+int vsscanf(const char *restrict s, const char *restrict format, va_list arg);
 
 inline int sscanf(const char *restrict s, const char *restrict format, ...)
 {
@@ -794,16 +637,6 @@ inline int sscanf(const char *restrict s, const char *restrict format, ...)
 }
 
 /* FUNCTION: vfscanf */
-
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_STDARG_H_INCLUDED
-#include <stdarg.h>
-#define __CPROVER_STDARG_H_INCLUDED
-#endif
 
 int __VERIFIER_nondet_int();
 
@@ -829,15 +662,7 @@ inline int vfscanf(FILE *restrict stream, const char *restrict format, va_list a
 
 /* FUNCTION: vscanf */
 
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_STDARG_H_INCLUDED
-#include <stdarg.h>
-#define __CPROVER_STDARG_H_INCLUDED
-#endif
+int vfscanf(FILE *restrict stream, const char *restrict format, va_list arg);
 
 inline int vscanf(const char *restrict format, va_list arg)
 {
@@ -846,16 +671,6 @@ inline int vscanf(const char *restrict format, va_list arg)
 }
 
 /* FUNCTION: vsscanf */
-
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_STDARG_H_INCLUDED
-#include <stdarg.h>
-#define __CPROVER_STDARG_H_INCLUDED
-#endif
 
 int __VERIFIER_nondet_int();
 
@@ -871,15 +686,7 @@ inline int vsscanf(const char *restrict s, const char *restrict format, va_list 
 
 /* FUNCTION: fprintf */
 
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_STDARG_H_INCLUDED
-#include <stdarg.h>
-#define __CPROVER_STDARG_H_INCLUDED
-#endif
+int vfprintf(FILE *stream, const char *restrict format, va_list arg);
 
 inline int fprintf(FILE *stream, const char *restrict format, ...)
 {
@@ -892,16 +699,6 @@ inline int fprintf(FILE *stream, const char *restrict format, ...)
 }
 
 /* FUNCTION: vfprintf */
-
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_STDARG_H_INCLUDED
-#include <stdarg.h>
-#define __CPROVER_STDARG_H_INCLUDED
-#endif
 
 int __VERIFIER_nondet_int();
 
@@ -929,23 +726,9 @@ inline int vfprintf(FILE *stream, const char *restrict format, va_list arg)
 
 /* FUNCTION: vasprintf */
 
-#ifndef __CPROVER_STDIO_H_INCLUDED
-#include <stdio.h>
-#define __CPROVER_STDIO_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_STDARG_H_INCLUDED
-#include <stdarg.h>
-#define __CPROVER_STDARG_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_STDLIB_H_INCLUDED
-#include <stdlib.h>
-#define __CPROVER_STDLIB_H_INCLUDED
-#endif
-
 char __VERIFIER_nondet_char();
 int __VERIFIER_nondet_int();
+void *malloc(__CPROVER_size_t malloc_size);
 
 inline int vasprintf(char **ptr, const char *fmt, va_list ap)
 {

--- a/src/ansi-c/library/string.c
+++ b/src/ansi-c/library/string.c
@@ -47,7 +47,7 @@ __inline char *__builtin___strcat_chk(char *dst, const char *src, __CPROVER_size
   __CPROVER_assert(__CPROVER_buffer_size(dst)>new_size,
                    "strcat buffer overflow");
   __CPROVER_size_t old_size=__CPROVER_zero_string_length(dst);
-  //"  for(size_t i=0; i<__CPROVER_zero_string_length(src); i++)
+  //"  for(__CPROVER_size_t i=0; i<__CPROVER_zero_string_length(src); i++)
   //"    dst[old_size+i];
   dst[new_size]=0;
   __CPROVER_is_zero_string(dst)=1;
@@ -120,13 +120,6 @@ __inline char *__builtin___strncat_chk(
 
 /* FUNCTION: strcpy */
 
-#ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
-#endif
-
-#undef strcpy
-
 inline char *strcpy(char *dst, const char *src)
 {
   __CPROVER_HIDE:;
@@ -158,14 +151,7 @@ inline char *strcpy(char *dst, const char *src)
 
 /* FUNCTION: strncpy */
 
-#ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
-#endif
-
-#undef strncpy
-
-inline char *strncpy(char *dst, const char *src, size_t n)
+inline char *strncpy(char *dst, const char *src, __CPROVER_size_t n)
 {
   __CPROVER_HIDE:;
   #ifdef __CPROVER_STRING_ABSTRACTION
@@ -197,12 +183,11 @@ inline char *strncpy(char *dst, const char *src, size_t n)
 
 /* FUNCTION: __builtin___strncpy_chk */
 
-#ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
-#endif
-
-inline char *__builtin___strncpy_chk(char *dst, const char *src, size_t n, size_t object_size)
+inline char *__builtin___strncpy_chk(
+  char *dst,
+  const char *src,
+  __CPROVER_size_t n,
+  __CPROVER_size_t object_size)
 {
   __CPROVER_HIDE:;
   #ifdef __CPROVER_STRING_ABSTRACTION
@@ -237,13 +222,6 @@ inline char *__builtin___strncpy_chk(char *dst, const char *src, size_t n, size_
 
 /* FUNCTION: strcat */
 
-#ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
-#endif
-
-#undef strcat
-
 inline char *strcat(char *dst, const char *src)
 {
   __CPROVER_HIDE:;
@@ -257,7 +235,7 @@ inline char *strcat(char *dst, const char *src)
   __CPROVER_assert(__CPROVER_buffer_size(dst)>new_size,
                    "strcat buffer overflow");
   __CPROVER_size_t old_size=__CPROVER_zero_string_length(dst);
-  //"  for(size_t i=0; i<__CPROVER_zero_string_length(src); i++)
+  //"  for(__CPROVER_size_t i=0; i<__CPROVER_zero_string_length(src); i++)
   //"    dst[old_size+i];
   dst[new_size]=0;
   __CPROVER_is_zero_string(dst)=1;
@@ -283,14 +261,7 @@ inline char *strcat(char *dst, const char *src)
 
 /* FUNCTION: strncat */
 
-#ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
-#endif
-
-#undef strncat
-
-inline char *strncat(char *dst, const char *src, size_t n)
+inline char *strncat(char *dst, const char *src, __CPROVER_size_t n)
 {
   __CPROVER_HIDE:;
   #ifdef __CPROVER_STRING_ABSTRACTION
@@ -334,13 +305,6 @@ inline char *strncat(char *dst, const char *src, size_t n)
 
 /* FUNCTION: strcmp */
 
-#ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
-#endif
-
-#undef strcmp
-
 inline int strcmp(const char *s1, const char *s2)
 {
   __CPROVER_HIDE:;
@@ -379,13 +343,6 @@ inline int strcmp(const char *s1, const char *s2)
 }
 
 /* FUNCTION: strcasecmp */
-
-#ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
-#endif
-
-#undef strcasecmp
 
 inline int strcasecmp(const char *s1, const char *s2)
 {
@@ -429,14 +386,7 @@ inline int strcasecmp(const char *s1, const char *s2)
 
 /* FUNCTION: strncmp */
 
-#ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
-#endif
-
-#undef strncmp
-
-inline int strncmp(const char *s1, const char *s2, size_t n)
+inline int strncmp(const char *s1, const char *s2, __CPROVER_size_t n)
 {
   __CPROVER_HIDE:;
   #ifdef __CPROVER_STRING_ABSTRACTION
@@ -471,14 +421,7 @@ inline int strncmp(const char *s1, const char *s2, size_t n)
 
 /* FUNCTION: strncasecmp */
 
-#ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
-#endif
-
-#undef strncasecmp
-
-inline int strncasecmp(const char *s1, const char *s2, size_t n)
+inline int strncasecmp(const char *s1, const char *s2, __CPROVER_size_t n)
 {
   __CPROVER_HIDE:;
   #ifdef __CPROVER_STRING_ABSTRACTION
@@ -516,14 +459,7 @@ inline int strncasecmp(const char *s1, const char *s2, size_t n)
 
 /* FUNCTION: strlen */
 
-#ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
-#endif
-
-#undef strlen
-
-inline size_t strlen(const char *s)
+inline __CPROVER_size_t strlen(const char *s)
 {
   __CPROVER_HIDE:;
   #ifdef __CPROVER_STRING_ABSTRACTION
@@ -539,18 +475,8 @@ inline size_t strlen(const char *s)
 
 /* FUNCTION: strdup */
 
-#ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
-#endif
-
-#ifndef __CPROVER_STDLIB_H_INCLUDED
-#include <stdlib.h>
-#define __CPROVER_STDLIB_H_INCLUDED
-#endif
-
-#undef strdup
-#undef strcpy
+void *malloc(__CPROVER_size_t malloc_size);
+char *strcpy(char *dst, const char *src);
 
 inline char *strdup(const char *str)
 {
@@ -568,14 +494,7 @@ inline char *strdup(const char *str)
 
 /* FUNCTION: memcpy */
 
-#ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
-#endif
-
-#undef memcpy
-
-void *memcpy(void *dst, const void *src, size_t n)
+void *memcpy(void *dst, const void *src, __CPROVER_size_t n)
 {
   __CPROVER_HIDE:
   #ifdef __CPROVER_STRING_ABSTRACTION
@@ -583,7 +502,7 @@ void *memcpy(void *dst, const void *src, size_t n)
                          "memcpy buffer overflow");
   __CPROVER_precondition(__CPROVER_buffer_size(dst)>=n,
                          "memcpy buffer overflow");
-  //  for(size_t i=0; i<n ; i++) dst[i]=src[i];
+  //  for(__CPROVER_size_t i=0; i<n ; i++) dst[i]=src[i];
   if(__CPROVER_is_zero_string(src) &&
      n > __CPROVER_zero_string_length(src))
   {
@@ -625,7 +544,7 @@ void *__builtin___memcpy_chk(void *dst, const void *src, __CPROVER_size_t n, __C
                          "memcpy buffer overflow");
   __CPROVER_precondition(__CPROVER_buffer_size(dst)==s,
                          "builtin object size");
-  //  for(size_t i=0; i<n ; i++) dst[i]=src[i];
+  //  for(__CPROVER_size_t i=0; i<n ; i++) dst[i]=src[i];
   if(__CPROVER_is_zero_string(src) &&
      n > __CPROVER_zero_string_length(src))
   {
@@ -658,20 +577,13 @@ void *__builtin___memcpy_chk(void *dst, const void *src, __CPROVER_size_t n, __C
 
 /* FUNCTION: memset */
 
-#ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
-#endif
-
-#undef memset
-
-void *memset(void *s, int c, size_t n)
+void *memset(void *s, int c, __CPROVER_size_t n)
 {
   __CPROVER_HIDE:;
   #ifdef __CPROVER_STRING_ABSTRACTION
   __CPROVER_precondition(__CPROVER_buffer_size(s)>=n,
                          "memset buffer overflow");
-  //  for(size_t i=0; i<n ; i++) s[i]=c;
+  //  for(__CPROVER_size_t i=0; i<n ; i++) s[i]=c;
   if(__CPROVER_is_zero_string(s) &&
      n > __CPROVER_zero_string_length(s))
   {
@@ -708,7 +620,7 @@ void *__builtin_memset(void *s, int c, __CPROVER_size_t n)
   #ifdef __CPROVER_STRING_ABSTRACTION
   __CPROVER_precondition(__CPROVER_buffer_size(s)>=n,
                          "memset buffer overflow");
-  //  for(size_t i=0; i<n ; i++) s[i]=c;
+  //  for(__CPROVER_size_t i=0; i<n ; i++) s[i]=c;
   if(__CPROVER_is_zero_string(s) &&
      n > __CPROVER_zero_string_length(s))
   {
@@ -749,7 +661,7 @@ void *__builtin___memset_chk(void *s, int c, __CPROVER_size_t n, __CPROVER_size_
                          "memset buffer overflow");
   __CPROVER_precondition(__CPROVER_buffer_size(s)==size,
                          "builtin object size");
-  //  for(size_t i=0; i<n ; i++) s[i]=c;
+  //  for(__CPROVER_size_t i=0; i<n ; i++) s[i]=c;
   if(__CPROVER_is_zero_string(s) &&
      n > __CPROVER_zero_string_length(s))
   {
@@ -781,14 +693,7 @@ void *__builtin___memset_chk(void *s, int c, __CPROVER_size_t n, __CPROVER_size_
 
 /* FUNCTION: memmove */
 
-#ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
-#endif
-
-#undef memmove
-
-void *memmove(void *dest, const void *src, size_t n)
+void *memmove(void *dest, const void *src, __CPROVER_size_t n)
 {
   __CPROVER_HIDE:;
   #ifdef __CPROVER_STRING_ABSTRACTION
@@ -821,14 +726,11 @@ void *memmove(void *dest, const void *src, size_t n)
 
 /* FUNCTION: __builtin___memmove_chk */
 
-#ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
-#endif
-
-#undef memmove
-
-void *__builtin___memmove_chk(void *dest, const void *src, size_t n, __CPROVER_size_t size)
+void *__builtin___memmove_chk(
+  void *dest,
+  const void *src,
+  __CPROVER_size_t n,
+  __CPROVER_size_t size)
 {
   __CPROVER_HIDE:;
   #ifdef __CPROVER_STRING_ABSTRACTION
@@ -866,14 +768,7 @@ void *__builtin___memmove_chk(void *dest, const void *src, size_t n, __CPROVER_s
 
 /* FUNCTION: memcmp */
 
-#ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
-#endif
-
-#undef memcmp
-
-inline int memcmp(const void *s1, const void *s2, size_t n)
+inline int memcmp(const void *s1, const void *s2, __CPROVER_size_t n)
 {
   __CPROVER_HIDE:;
   int res=0;
@@ -895,13 +790,6 @@ inline int memcmp(const void *s1, const void *s2, size_t n)
 }
 
 /* FUNCTION: strchr */
-
-#ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
-#endif
-
-#undef strchr
 
 inline char *strchr(const char *src, int c)
 {
@@ -925,13 +813,6 @@ inline char *strchr(const char *src, int c)
 
 /* FUNCTION: strrchr */
 
-#ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
-#endif
-
-#undef strchr
-
 inline char *strrchr(const char *src, int c)
 {
   __CPROVER_HIDE:;
@@ -953,11 +834,6 @@ inline char *strrchr(const char *src, int c)
 }
 
 /* FUNCTION: strerror */
-
-#ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
-#endif
 
 char *strerror(int errnum)
 {

--- a/src/ansi-c/library/syslog.c
+++ b/src/ansi-c/library/syslog.c
@@ -1,10 +1,5 @@
 /* FUNCTION: openlog */
 
-#ifndef __CPROVER_SYSLOG_H_INCLUDED
-#include <syslog.h>
-#define __CPROVER_SYSLOG_H_INCLUDED
-#endif
-
 void openlog(const char *ident, int option, int facility)
 {
   (void)*ident;
@@ -14,21 +9,11 @@ void openlog(const char *ident, int option, int facility)
 
 /* FUNCTION: closelog */
 
-#ifndef __CPROVER_SYSLOG_H_INCLUDED
-#include <syslog.h>
-#define __CPROVER_SYSLOG_H_INCLUDED
-#endif
-
 void closelog(void)
 {
 }
 
 /* FUNCTION: syslog */
-
-#ifndef __CPROVER_SYSLOG_H_INCLUDED
-#include <syslog.h>
-#define __CPROVER_SYSLOG_H_INCLUDED
-#endif
 
 void syslog(int priority, const char *format, ...)
 {

--- a/src/ansi-c/library/threads.c
+++ b/src/ansi-c/library/threads.c
@@ -1,11 +1,10 @@
+#ifdef LIBRARY_CHECK
+#include <threads.h>
+#endif
+
 /* FUNCTION: thrd_create */
 
 // following http://en.cppreference.com/w/c/thread
-
-#ifndef __CPROVER_THREADS_H_INCLUDED
-#include <threads.h>
-#define __CPROVER_THREADS_H_INCLUDED
-#endif
 
 int thrd_create(thrd_t *thr, thrd_start_t func, void *arg)
 {
@@ -13,32 +12,17 @@ int thrd_create(thrd_t *thr, thrd_start_t func, void *arg)
 
 /* FUNCTION: thrd_equal */
 
-#ifndef __CPROVER_THREADS_H_INCLUDED
-#include <threads.h>
-#define __CPROVER_THREADS_H_INCLUDED
-#endif
-
 int thrd_equal( thrd_t lhs, thrd_t rhs )
 {
 }
 
 /* FUNCTION: thrd_current */
 
-#ifndef __CPROVER_THREADS_H_INCLUDED
-#include <threads.h>
-#define __CPROVER_THREADS_H_INCLUDED
-#endif
-
 thrd_t thrd_current()
 {
 }
 
 /* FUNCTION: thrd_sleep */
-
-#ifndef __CPROVER_THREADS_H_INCLUDED
-#include <threads.h>
-#define __CPROVER_THREADS_H_INCLUDED
-#endif
 
 int thrd_sleep(const struct timespec* time_point,
                struct timespec* remaining)
@@ -60,32 +44,17 @@ void thrd_exit(int res)
 
 /* FUNCTION: mtx_init */
 
-#ifndef __CPROVER_THREADS_H_INCLUDED
-#include <threads.h>
-#define __CPROVER_THREADS_H_INCLUDED
-#endif
-
 int mtx_init( mtx_t* mutex, int type )
 {
 }
 
 /* FUNCTION: mtx_lock */
 
-#ifndef __CPROVER_THREADS_H_INCLUDED
-#include <threads.h>
-#define __CPROVER_THREADS_H_INCLUDED
-#endif
-
 int mtx_lock(mtx_t* mutex)
 {
 }
 
 /* FUNCTION: mtx_timedlock */
-
-#ifndef __CPROVER_THREADS_H_INCLUDED
-#include <threads.h>
-#define __CPROVER_THREADS_H_INCLUDED
-#endif
 
 int mtx_timedlock(mtx_t *restrict mutex,
                   const struct timespec *restrict time_point)
@@ -95,21 +64,11 @@ int mtx_timedlock(mtx_t *restrict mutex,
 
 /* FUNCTION: mtx_trylock */
 
-#ifndef __CPROVER_THREADS_H_INCLUDED
-#include <threads.h>
-#define __CPROVER_THREADS_H_INCLUDED
-#endif
-
 int mtx_trylock(mtx_t *mutex)
 {
 }
 
 /* FUNCTION: mtx_unlock */
-
-#ifndef __CPROVER_THREADS_H_INCLUDED
-#include <threads.h>
-#define __CPROVER_THREADS_H_INCLUDED
-#endif
 
 int mtx_unlock(mtx_t *mutex)
 {
@@ -118,21 +77,11 @@ int mtx_unlock(mtx_t *mutex)
 
 /* FUNCTION: mtx_destroy */
 
-#ifndef __CPROVER_THREADS_H_INCLUDED
-#include <threads.h>
-#define __CPROVER_THREADS_H_INCLUDED
-#endif
-
 void mtx_destroy(mtx_t *mutex)
 {
 }
 
 /* FUNCTION: call_once */
-
-#ifndef __CPROVER_THREADS_H_INCLUDED
-#include <threads.h>
-#define __CPROVER_THREADS_H_INCLUDED
-#endif
 
 void call_once(once_flag* flag, void (*func)(void))
 {
@@ -140,21 +89,11 @@ void call_once(once_flag* flag, void (*func)(void))
 
 /* FUNCTION: cnd_init */
 
-#ifndef __CPROVER_THREADS_H_INCLUDED
-#include <threads.h>
-#define __CPROVER_THREADS_H_INCLUDED
-#endif
-
 int cnd_init(cnd_t* cond)
 {
 }
 
 /* FUNCTION: cnd_signal */
-
-#ifndef __CPROVER_THREADS_H_INCLUDED
-#include <threads.h>
-#define __CPROVER_THREADS_H_INCLUDED
-#endif
 
 int cnd_signal(cnd_t *cond)
 {
@@ -163,21 +102,11 @@ int cnd_signal(cnd_t *cond)
 
 /* FUNCTION: cnd_broadcast */
 
-#ifndef __CPROVER_THREADS_H_INCLUDED
-#include <threads.h>
-#define __CPROVER_THREADS_H_INCLUDED
-#endif
-
 int cnd_broadcast(cnd_t *cond)
 {
 }
 
 /* FUNCTION: cnd_wait */
-
-#ifndef __CPROVER_THREADS_H_INCLUDED
-#include <threads.h>
-#define __CPROVER_THREADS_H_INCLUDED
-#endif
 
 int cnd_wait(cnd_t* cond, mtx_t* mutex)
 {
@@ -185,22 +114,12 @@ int cnd_wait(cnd_t* cond, mtx_t* mutex)
 
 /* FUNCTION: cnd_timedwait */
 
-#ifndef __CPROVER_THREADS_H_INCLUDED
-#include <threads.h>
-#define __CPROVER_THREADS_H_INCLUDED
-#endif
-
 int cnd_timedwait(cnd_t* restrict cond, mtx_t* restrict mutex,
                   const struct timespec* restrict time_point)
 {
 }
 
 /* FUNCTION: cnd_destroy */
-
-#ifndef __CPROVER_THREADS_H_INCLUDED
-#include <threads.h>
-#define __CPROVER_THREADS_H_INCLUDED
-#endif
 
 void cnd_destroy(cnd_t* cond)
 {

--- a/src/ansi-c/library/time.c
+++ b/src/ansi-c/library/time.c
@@ -1,11 +1,8 @@
-/* FUNCTION: time */
-
-#ifndef __CPROVER_TIME_H_INCLUDED
+#ifdef LIBRARY_CHECK
 #include <time.h>
-#define __CPROVER_TIME_H_INCLUDED
 #endif
 
-#undef time
+/* FUNCTION: time */
 
 time_t __VERIFIER_nondet_time_t();
 
@@ -17,13 +14,6 @@ time_t time(time_t *tloc)
 }
 
 /* FUNCTION: gmtime */
-
-#ifndef __CPROVER_TIME_H_INCLUDED
-#include <time.h>
-#define __CPROVER_TIME_H_INCLUDED
-#endif
-
-#undef gmtime
 
 struct tm *gmtime(const time_t *clock)
 {
@@ -43,13 +33,6 @@ struct tm *gmtime(const time_t *clock)
 
 /* FUNCTION: gmtime_r */
 
-#ifndef __CPROVER_TIME_H_INCLUDED
-#include <time.h>
-#define __CPROVER_TIME_H_INCLUDED
-#endif
-
-#undef gmtime
-
 struct tm *gmtime_r(const time_t *clock, struct tm *result)
 {
   // need to set the fields to something meaningful
@@ -58,13 +41,6 @@ struct tm *gmtime_r(const time_t *clock, struct tm *result)
 }
 
 /* FUNCTION: localtime */
-
-#ifndef __CPROVER_TIME_H_INCLUDED
-#include <time.h>
-#define __CPROVER_TIME_H_INCLUDED
-#endif
-
-#undef localtime
 
 struct tm *localtime(const time_t *clock)
 {
@@ -84,13 +60,6 @@ struct tm *localtime(const time_t *clock)
 
 /* FUNCTION: localtime_r */
 
-#ifndef __CPROVER_TIME_H_INCLUDED
-#include <time.h>
-#define __CPROVER_TIME_H_INCLUDED
-#endif
-
-#undef localtime
-
 struct tm *localtime_r(const time_t *clock, struct tm *result)
 {
   // need to set the fields to something meaningful
@@ -99,13 +68,6 @@ struct tm *localtime_r(const time_t *clock, struct tm *result)
 }
 
 /* FUNCTION: mktime */
-
-#ifndef __CPROVER_TIME_H_INCLUDED
-#include <time.h>
-#define __CPROVER_TIME_H_INCLUDED
-#endif
-
-#undef mktime
 
 time_t __VERIFIER_nondet_time_t();
 
@@ -118,13 +80,6 @@ time_t mktime(struct tm *timeptr)
 
 /* FUNCTION: timegm */
 
-#ifndef __CPROVER_TIME_H_INCLUDED
-#include <time.h>
-#define __CPROVER_TIME_H_INCLUDED
-#endif
-
-#undef timegm
-
 time_t __VERIFIER_nondet_time_t();
 
 time_t timegm(struct tm *timeptr)
@@ -135,11 +90,6 @@ time_t timegm(struct tm *timeptr)
 }
 
 /* FUNCTION: asctime */
-
-#ifndef __CPROVER_TIME_H_INCLUDED
-#include <time.h>
-#define __CPROVER_TIME_H_INCLUDED
-#endif
 
 char *asctime(const struct tm *timeptr)
 {
@@ -156,11 +106,6 @@ char *asctime(const struct tm *timeptr)
 }
 
 /* FUNCTION: ctime */
-
-#ifndef __CPROVER_TIME_H_INCLUDED
-#include <time.h>
-#define __CPROVER_TIME_H_INCLUDED
-#endif
 
 char *ctime(const time_t *clock)
 {

--- a/src/ansi-c/library/unistd.c
+++ b/src/ansi-c/library/unistd.c
@@ -126,12 +126,8 @@ inline int _close(int fildes)
 #define ret_type int
 #define size_type unsigned
 #else
-#ifndef __CPROVER_SYS_TYPES_H_INCLUDED
-#include <sys/types.h>
-#define __CPROVER_SYS_TYPES_H_INCLUDED
-#endif
-#define ret_type ssize_t
-#define size_type size_t
+#define ret_type long int
+#define size_type __CPROVER_size_t
 #endif
 
 extern struct __CPROVER_pipet __CPROVER_pipes[];
@@ -175,12 +171,8 @@ ret_type write(int fildes, const void *buf, size_type nbyte)
 #define ret_type int
 #define size_type unsigned
 #else
-#ifndef __CPROVER_SYS_TYPES_H_INCLUDED
-#include <sys/types.h>
-#define __CPROVER_SYS_TYPES_H_INCLUDED
-#endif
-#define ret_type ssize_t
-#define size_type size_t
+#define ret_type long int
+#define size_type __CPROVER_size_t
 #endif
 
 ret_type write(int fildes, const void *buf, size_type nbyte);
@@ -200,12 +192,8 @@ inline ret_type _write(int fildes, const void *buf, size_type nbyte)
 #define ret_type int
 #define size_type unsigned
 #else
-#ifndef __CPROVER_SYS_TYPES_H_INCLUDED
-#include <sys/types.h>
-#define __CPROVER_SYS_TYPES_H_INCLUDED
-#endif
-#define ret_type ssize_t
-#define size_type size_t
+#define ret_type long int
+#define size_type __CPROVER_size_t
 #endif
 
 extern struct __CPROVER_pipet __CPROVER_pipes[];
@@ -279,12 +267,8 @@ ret_type read(int fildes, void *buf, size_type nbyte)
 #define ret_type int
 #define size_type unsigned
 #else
-#ifndef __CPROVER_SYS_TYPES_H_INCLUDED
-#include <sys/types.h>
-#define __CPROVER_SYS_TYPES_H_INCLUDED
-#endif
-#define ret_type ssize_t
-#define size_type size_t
+#define ret_type long int
+#define size_type __CPROVER_size_t
 #endif
 
 ret_type read(int fildes, void *buf, size_type nbyte);

--- a/src/ansi-c/library/windows.c
+++ b/src/ansi-c/library/windows.c
@@ -1,7 +1,12 @@
+#ifdef _WIN32
+#ifdef LIBRARY_CHECK
+#include <windows.h>
+#endif
+#endif
+
 /* FUNCTION: QueryPerformanceFrequency */
 
 #ifdef _WIN32
-#include <windows.h>
 
 BOOL QueryPerformanceFrequency(LARGE_INTEGER *lpFrequency)
 {
@@ -18,7 +23,6 @@ BOOL QueryPerformanceFrequency(LARGE_INTEGER *lpFrequency)
 /* FUNCTION: ExitThread */
 
 #ifdef _WIN32
-#include <windows.h>
 
 inline VOID ExitThread(DWORD dwExitCode)
 {
@@ -30,7 +34,6 @@ inline VOID ExitThread(DWORD dwExitCode)
 /* FUNCTION: CreateThread */
 
 #ifdef _WIN32
-#include <windows.h>
 
 inline HANDLE CreateThread(
   LPSECURITY_ATTRIBUTES lpThreadAttributes,


### PR DESCRIPTION
When doing cross-platform verification we should not rely on 1) system headers
    being present and 2) system headers matching the declarations that were used
    while compiling the program to be verified. Thus re-use the symbol table that
    has been generated from the input program when compiling functions of the
    built-in library.

This will address a number of SV-COMP benchmarks that CBMC currently fails on
    for they use augmented standard-library types.