### PR TITLE
minisat: use size_t to index clauses

### DIFF
--- a/scripts/minisat64.patch
+++ b/scripts/minisat64.patch
@@ -1,0 +1,1756 @@
+diff -urN minisat-2.2.1/minisat/core/Dimacs.h minisat-2.2.1.64/minisat/core/Dimacs.h
+--- minisat-2.2.1/minisat/core/Dimacs.h	2011-02-21 13:31:17.000000000 +0000
++++ minisat-2.2.1.64/minisat/core/Dimacs.h	2018-03-15 16:37:30.632513704 +0000
+@@ -49,7 +49,7 @@
+     vec<Lit> lits;
+     int vars    = 0;
+     int clauses = 0;
+-    int cnt     = 0;
++    size_t cnt  = 0;
+     for (;;){
+         skipWhitespace(in);
+         if (*in == EOF) break;
+diff -urN minisat-2.2.1/minisat/core/Main.cc minisat-2.2.1.64/minisat/core/Main.cc
+--- minisat-2.2.1/minisat/core/Main.cc	2011-02-21 13:31:17.000000000 +0000
++++ minisat-2.2.1.64/minisat/core/Main.cc	2018-03-15 16:37:30.632513704 +0000
+@@ -168,7 +168,7 @@
+         if (res != NULL){
+             if (ret == l_True){
+                 fprintf(res, "SAT\n");
+-                for (int i = 0; i < S.nVars(); i++)
++                for (size_t i = 0; i < S.nVars(); i++)
+                     if (S.model[i] != l_Undef)
+                         fprintf(res, "%s%s%d", (i==0)?"":" ", (S.model[i]==l_True)?"":"-", i+1);
+                 fprintf(res, " 0\n");
+diff -urN minisat-2.2.1/minisat/core/Solver.cc minisat-2.2.1.64/minisat/core/Solver.cc
+--- minisat-2.2.1/minisat/core/Solver.cc	2018-03-21 14:54:06.918130658 +0000
++++ minisat-2.2.1.64/minisat/core/Solver.cc	2018-03-21 14:29:52.266160146 +0000
+@@ -113,7 +113,7 @@
+ //
+ Var Solver::newVar(lbool upol, bool dvar)
+ {
+-    int v = nVars();
++    size_t v = nVars();
+     watches  .init(mkLit(v, false));
+     watches  .init(mkLit(v, true ));
+     assigns  .push(l_Undef);
+@@ -137,7 +137,7 @@
+ 
+     // Check if clause is satisfied and remove false/duplicate literals:
+     sort(ps);
+-    Lit p; int i, j;
++    Lit p; size_t i, j;
+     for (i = j = 0, p = lit_Undef; i < ps.size(); i++)
+         if (value(ps[i]) == l_True || ps[i] == ~p)
+             return true;
+@@ -197,7 +197,7 @@
+ 
+ 
+ bool Solver::satisfied(const Clause& c) const {
+-    for (int i = 0; i < c.size(); i++)
++    for (size_t i = 0; i < c.size(); i++)
+         if (value(c[i]) == l_True)
+             return true;
+     return false; }
+@@ -205,13 +205,13 @@
+ 
+ // Revert to the state at given level (keeping all assignment at 'level' but not beyond).
+ //
+-void Solver::cancelUntil(int level) {
++void Solver::cancelUntil(size_t level) {
+     if (decisionLevel() > level){
+-        for (int c = trail.size()-1; c >= trail_lim[level]; c--){
+-            Var      x  = var(trail[c]);
++        for (size_t c = trail.size(); c > trail_lim[level]; c--){
++            Var      x  = var(trail[c - 1]);
+             assigns [x] = l_Undef;
+-            if (phase_saving > 1 || ((phase_saving == 1) && c > trail_lim.last()))
+-                polarity[x] = sign(trail[c]);
++            if (phase_saving > 1 || ((phase_saving == 1) && c - 1 > trail_lim.last()))
++                polarity[x] = sign(trail[c - 1]);
+             insertVarOrder(x); }
+         qhead = trail_lim[level];
+         trail.shrink(trail.size() - trail_lim[level]);
+@@ -255,7 +255,7 @@
+ 
+ /*_________________________________________________________________________________________________
+ |
+-|  analyze : (confl : Clause*) (out_learnt : vec<Lit>&) (out_btlevel : int&)  ->  [void]
++|  analyze : (confl : Clause*) (out_learnt : vec<Lit>&) (out_btlevel : size_t&)  ->  [void]
+ |  
+ |  Description:
+ |    Analyze conflict and produce a reason clause.
+@@ -270,15 +270,15 @@
+ |        rest of literals. There may be others from the same level though.
+ |  
+ |________________________________________________________________________________________________@*/
+-void Solver::analyze(CRef confl, vec<Lit>& out_learnt, int& out_btlevel)
++void Solver::analyze(CRef confl, vec<Lit>& out_learnt, size_t& out_btlevel)
+ {
+-    int pathC = 0;
++    ssize_t pathC = 0;
+     Lit p     = lit_Undef;
+ 
+     // Generate conflict clause:
+     //
+     out_learnt.push();      // (leave room for the asserting literal)
+-    int index   = trail.size() - 1;
++    size_t index   = trail.size();
+ 
+     do{
+         assert(confl != CRef_Undef); // (otherwise should be UIP)
+@@ -287,7 +287,7 @@
+         if (c.learnt())
+             claBumpActivity(c);
+ 
+-        for (int j = (p == lit_Undef) ? 0 : 1; j < c.size(); j++){
++        for (size_t j = (p == lit_Undef) ? 0 : 1; j < c.size(); j++){
+             Lit q = c[j];
+ 
+             if (!seen[var(q)] && level(var(q)) > 0){
+@@ -301,8 +301,8 @@
+         }
+         
+         // Select next clause to look at:
+-        while (!seen[var(trail[index--])]);
+-        p     = trail[index+1];
++        while (!seen[var(trail[--index])]);
++        p     = trail[index];
+         confl = reason(var(p));
+         seen[var(p)] = 0;
+         pathC--;
+@@ -312,10 +312,10 @@
+ 
+     // Simplify conflict clause:
+     //
+-    int i, j;
++    size_t i, j;
+     out_learnt.copyTo(analyze_toclear);
+     if (ccmin_mode == 2){
+-        uint32_t abstract_level = 0;
++        AbsLevel abstract_level = 0;
+         for (i = 1; i < out_learnt.size(); i++)
+             abstract_level |= abstractLevel(var(out_learnt[i])); // (maintain an abstraction of levels involved in conflict)
+ 
+@@ -331,7 +331,7 @@
+                 out_learnt[j++] = out_learnt[i];
+             else{
+                 Clause& c = ca[reason(var(out_learnt[i]))];
+-                for (int k = 1; k < c.size(); k++)
++                for (size_t k = 1; k < c.size(); k++)
+                     if (!seen[var(c[k])] && level(var(c[k])) > 0){
+                         out_learnt[j++] = out_learnt[i];
+                         break; }
+@@ -349,9 +349,9 @@
+     if (out_learnt.size() == 1)
+         out_btlevel = 0;
+     else{
+-        int max_i = 1;
++        size_t max_i = 1;
+         // Find the first literal assigned at the next-highest level:
+-        for (int i = 2; i < out_learnt.size(); i++)
++        for (size_t i = 2; i < out_learnt.size(); i++)
+             if (level(var(out_learnt[i])) > level(var(out_learnt[max_i])))
+                 max_i = i;
+         // Swap-in this literal at index 1:
+@@ -361,21 +361,21 @@
+         out_btlevel       = level(var(p));
+     }
+ 
+-    for (int j = 0; j < analyze_toclear.size(); j++) seen[var(analyze_toclear[j])] = 0;    // ('seen[]' is now cleared)
++    for (size_t j = 0; j < analyze_toclear.size(); j++) seen[var(analyze_toclear[j])] = 0;    // ('seen[]' is now cleared)
+ }
+ 
+ 
+ // Check if 'p' can be removed. 'abstract_levels' is used to abort early if the algorithm is
+ // visiting literals at levels that cannot be removed later.
+-bool Solver::litRedundant(Lit p, uint32_t abstract_levels)
++bool Solver::litRedundant(Lit p, AbsLevel abstract_levels)
+ {
+     analyze_stack.clear(); analyze_stack.push(p);
+-    int top = analyze_toclear.size();
++    size_t top = analyze_toclear.size();
+     while (analyze_stack.size() > 0){
+         assert(reason(var(analyze_stack.last())) != CRef_Undef);
+         Clause& c = ca[reason(var(analyze_stack.last()))]; analyze_stack.pop();
+ 
+-        for (int i = 1; i < c.size(); i++){
++        for (size_t i = 1; i < c.size(); i++){
+             Lit p  = c[i];
+             if (!seen[var(p)] && level(var(p)) > 0){
+                 if (reason(var(p)) != CRef_Undef && (abstractLevel(var(p)) & abstract_levels) != 0){
+@@ -383,7 +383,7 @@
+                     analyze_stack.push(p);
+                     analyze_toclear.push(p);
+                 }else{
+-                    for (int j = top; j < analyze_toclear.size(); j++)
++                    for (size_t j = top; j < analyze_toclear.size(); j++)
+                         seen[var(analyze_toclear[j])] = 0;
+                     analyze_toclear.shrink(analyze_toclear.size() - top);
+                     return false;
+@@ -415,15 +415,15 @@
+ 
+     seen[var(p)] = 1;
+ 
+-    for (int i = trail.size()-1; i >= trail_lim[0]; i--){
+-        Var x = var(trail[i]);
++    for (size_t i = trail.size(); i > trail_lim[0]; i--){
++        Var x = var(trail[i - 1]);
+         if (seen[x]){
+             if (reason(x) == CRef_Undef){
+                 assert(level(x) > 0);
+-                out_conflict.push(~trail[i]);
++                out_conflict.push(~trail[i - 1]);
+             }else{
+                 Clause& c = ca[reason(x)];
+-                for (int j = 1; j < c.size(); j++)
++                for (size_t j = 1; j < c.size(); j++)
+                     if (level(var(c[j])) > 0)
+                         seen[var(c[j])] = 1;
+             }
+@@ -458,7 +458,7 @@
+ CRef Solver::propagate()
+ {
+     CRef    confl     = CRef_Undef;
+-    int     num_props = 0;
++    size_t  num_props = 0;
+     watches.cleanAll();
+ 
+     while (qhead < trail.size()){
+@@ -489,7 +489,7 @@
+                 *j++ = w; continue; }
+ 
+             // Look for new watch:
+-            for (int k = 2; k < c.size(); k++)
++            for (size_t k = 2; k < c.size(); k++)
+                 if (value(c[k]) != l_False){
+                     c[1] = c[k]; c[k] = false_lit;
+                     watches[~c[1]].push(w);
+@@ -533,7 +533,7 @@
+ };
+ void Solver::reduceDB()
+ {
+-    int     i, j;
++    size_t  i, j;
+     double  extra_lim = cla_inc / learnts.size();    // Remove any clause below this activity
+ 
+     sort(learnts, reduceDB_lt(ca));
+@@ -553,7 +553,7 @@
+ 
+ void Solver::removeSatisfied(vec<CRef>& cs)
+ {
+-    int i, j;
++    size_t i, j;
+     for (i = j = 0; i < cs.size(); i++){
+         Clause& c = ca[cs[i]];
+         if (satisfied(c))
+@@ -568,7 +568,7 @@
+ void Solver::rebuildOrderHeap()
+ {
+     vec<Var> vs;
+-    for (Var v = 0; v < nVars(); v++)
++    for (size_t v = 0; v < nVars(); v++)
+         if (decision[v] && value(v) == l_Undef)
+             vs.push(v);
+     order_heap.build(vs);
+@@ -609,7 +609,7 @@
+ 
+ /*_________________________________________________________________________________________________
+ |
+-|  search : (nof_conflicts : int) (params : const SearchParams&)  ->  [lbool]
++|  search : (nof_conflicts : ssize_t) (params : const SearchParams&)  ->  [lbool]
+ |  
+ |  Description:
+ |    Search for a model the specified number of conflicts. 
+@@ -620,11 +620,11 @@
+ |    all variables are decision variables, this means that the clause set is satisfiable. 'l_False'
+ |    if the clause set is unsatisfiable. 'l_Undef' if the bound on number of conflicts is reached.
+ |________________________________________________________________________________________________@*/
+-lbool Solver::search(int nof_conflicts)
++lbool Solver::search(ssize_t nof_conflicts)
+ {
+     assert(ok);
+-    int         backtrack_level;
+-    int         conflictC = 0;
++    size_t      backtrack_level;
++    size_t      conflictC = 0;
+     vec<Lit>    learnt_clause;
+     starts++;
+ 
+@@ -654,19 +654,19 @@
+ 
+             if (--learntsize_adjust_cnt == 0){
+                 learntsize_adjust_confl *= learntsize_adjust_inc;
+-                learntsize_adjust_cnt    = (int)learntsize_adjust_confl;
++                learntsize_adjust_cnt    = (size_t)learntsize_adjust_confl;
+                 max_learnts             *= learntsize_inc;
+ 
+                 if (verbosity >= 1)
+-                    printf("| %9d | %7d %8d %8d | %8d %8d %6.0f | %6.3f %% |\n", 
+-                           (int)conflicts, 
+-                           (int)dec_vars - (trail_lim.size() == 0 ? trail.size() : trail_lim[0]), nClauses(), (int)clauses_literals, 
+-                           (int)max_learnts, nLearnts(), (double)learnts_literals/nLearnts(), progressEstimate()*100);
++                    printf("| %9ld | %7ld %8ld %8ld | %8ld %8ld %6.0f | %6.3f %% |\n", 
++                           (size_t)conflicts, 
++                           (size_t)dec_vars - (trail_lim.size() == 0 ? trail.size() : trail_lim[0]), nClauses(), (size_t)clauses_literals, 
++                           (size_t)max_learnts, nLearnts(), (double)learnts_literals/nLearnts(), progressEstimate()*100);
+             }
+ 
+         }else{
+             // NO CONFLICT
+-            if ((nof_conflicts >= 0 && conflictC >= nof_conflicts) || !withinBudget()){
++            if ((nof_conflicts >= 0 && conflictC >= (size_t)nof_conflicts) || !withinBudget()){
+                 // Reached bound on number of conflicts:
+                 progress_estimate = progressEstimate();
+                 cancelUntil(0);
+@@ -676,7 +676,7 @@
+             if (decisionLevel() == 0 && !simplify())
+                 return l_False;
+ 
+-            if (learnts.size()-nAssigns() >= max_learnts)
++            if (learnts.size() >= max_learnts + nAssigns())
+                 // Reduce the set of learnt clauses:
+                 reduceDB();
+ 
+@@ -719,9 +719,9 @@
+     double  progress = 0;
+     double  F = 1.0 / nVars();
+ 
+-    for (int i = 0; i <= decisionLevel(); i++){
+-        int beg = i == 0 ? 0 : trail_lim[i - 1];
+-        int end = i == decisionLevel() ? trail.size() : trail_lim[i];
++    for (size_t i = 0; i <= decisionLevel(); i++){
++        size_t beg = i == 0 ? 0 : trail_lim[i - 1];
++        size_t end = i == decisionLevel() ? trail.size() : trail_lim[i];
+         progress += pow(F, i) * (end - beg);
+     }
+ 
+@@ -767,7 +767,7 @@
+ 
+     max_learnts               = nClauses() * learntsize_factor;
+     learntsize_adjust_confl   = learntsize_adjust_start_confl;
+-    learntsize_adjust_cnt     = (int)learntsize_adjust_confl;
++    learntsize_adjust_cnt     = (size_t)learntsize_adjust_confl;
+     lbool   status            = l_Undef;
+ 
+     if (verbosity >= 1){
+@@ -778,7 +778,7 @@
+     }
+ 
+     // Search:
+-    int curr_restarts = 0;
++    size_t curr_restarts = 0;
+     while (status == l_Undef){
+         double rest_base = luby_restart ? luby(restart_inc, curr_restarts) : pow(restart_inc, curr_restarts);
+         status = search(rest_base * restart_first);
+@@ -793,7 +793,7 @@
+     if (status == l_True){
+         // Extend & copy model:
+         model.growTo(nVars());
+-        for (int i = 0; i < nVars(); i++) model[i] = value(i);
++        for (size_t i = 0; i < nVars(); i++) model[i] = value(i);
+     }else if (status == l_False && conflict.size() == 0)
+         ok = false;
+ 
+@@ -808,7 +808,7 @@
+ 
+ static Var mapVar(Var x, vec<Var>& map, Var& max)
+ {
+-    if (map.size() <= x || map[x] == -1){
++    if (map.size() <= (size_t)x || map[x] == -1){
+         map.growTo(x+1, -1);
+         map[x] = max++;
+     }
+@@ -820,7 +820,7 @@
+ {
+     if (satisfied(c)) return;
+ 
+-    for (int i = 0; i < c.size(); i++)
++    for (size_t i = 0; i < c.size(); i++)
+         if (value(c[i]) != l_False)
+             fprintf(f, "%s%d ", sign(c[i]) ? "-" : "", mapVar(var(c[i]), map, max)+1);
+     fprintf(f, "0\n");
+@@ -848,15 +848,15 @@
+ 
+     // Cannot use removeClauses here because it is not safe
+     // to deallocate them at this point. Could be improved.
+-    int cnt = 0;
+-    for (int i = 0; i < clauses.size(); i++)
++    size_t cnt = 0;
++    for (size_t i = 0; i < clauses.size(); i++)
+         if (!satisfied(ca[clauses[i]]))
+             cnt++;
+         
+-    for (int i = 0; i < clauses.size(); i++)
++    for (size_t i = 0; i < clauses.size(); i++)
+         if (!satisfied(ca[clauses[i]])){
+             Clause& c = ca[clauses[i]];
+-            for (int j = 0; j < c.size(); j++)
++            for (size_t j = 0; j < c.size(); j++)
+                 if (value(c[j]) != l_False)
+                     mapVar(var(c[j]), map, max);
+         }
+@@ -864,18 +864,18 @@
+     // Assumptions are added as unit clauses:
+     cnt += assumps.size();
+ 
+-    fprintf(f, "p cnf %d %d\n", max, cnt);
++    fprintf(f, "p cnf %d %ld\n", max, cnt);
+ 
+-    for (int i = 0; i < assumps.size(); i++){
++    for (size_t i = 0; i < assumps.size(); i++){
+         assert(value(assumps[i]) != l_False);
+         fprintf(f, "%s%d 0\n", sign(assumps[i]) ? "-" : "", mapVar(var(assumps[i]), map, max)+1);
+     }
+ 
+-    for (int i = 0; i < clauses.size(); i++)
++    for (size_t i = 0; i < clauses.size(); i++)
+         toDimacs(f, ca[clauses[i]], map, max);
+ 
+     if (verbosity > 0)
+-        printf("Wrote %d clauses with %d variables.\n", cnt, max);
++        printf("Wrote %ld clauses with %d variables.\n", cnt, max);
+ }
+ 
+ 
+@@ -886,20 +886,20 @@
+ {
+     // All watchers:
+     //
+-    // for (int i = 0; i < watches.size(); i++)
++    // for (size_t i = 0; i < watches.size(); i++)
+     watches.cleanAll();
+-    for (int v = 0; v < nVars(); v++)
+-        for (int s = 0; s < 2; s++){
++    for (size_t v = 0; v < nVars(); v++)
++        for (size_t s = 0; s < 2; s++){
+             Lit p = mkLit(v, s);
+             // printf(" >>> RELOCING: %s%d\n", sign(p)?"-":"", var(p)+1);
+             vec<Watcher>& ws = watches[p];
+-            for (int j = 0; j < ws.size(); j++)
++            for (size_t j = 0; j < ws.size(); j++)
+                 ca.reloc(ws[j].cref, to);
+         }
+ 
+     // All reasons:
+     //
+-    for (int i = 0; i < trail.size(); i++){
++    for (size_t i = 0; i < trail.size(); i++){
+         Var v = var(trail[i]);
+ 
+         if (reason(v) != CRef_Undef && (ca[reason(v)].reloced() || locked(ca[reason(v)])))
+@@ -908,12 +908,12 @@
+ 
+     // All learnt:
+     //
+-    for (int i = 0; i < learnts.size(); i++)
++    for (size_t i = 0; i < learnts.size(); i++)
+         ca.reloc(learnts[i], to);
+ 
+     // All original:
+     //
+-    for (int i = 0; i < clauses.size(); i++)
++    for (size_t i = 0; i < clauses.size(); i++)
+         ca.reloc(clauses[i], to);
+ }
+ 
+@@ -926,7 +926,7 @@
+ 
+     relocAll(to);
+     if (verbosity >= 2)
+-        printf("|  Garbage collection:   %12d bytes => %12d bytes             |\n", 
++        printf("|  Garbage collection:   %12ld bytes => %12ld bytes             |\n", 
+                ca.size()*ClauseAllocator::Unit_Size, to.size()*ClauseAllocator::Unit_Size);
+     to.moveTo(ca);
+ }
+diff -urN minisat-2.2.1/minisat/core/Solver.h minisat-2.2.1.64/minisat/core/Solver.h
+--- minisat-2.2.1/minisat/core/Solver.h	2011-02-21 13:31:17.000000000 +0000
++++ minisat-2.2.1.64/minisat/core/Solver.h	2018-03-21 14:33:07.702156184 +0000
+@@ -85,11 +85,11 @@
+     lbool   value      (Lit p) const;       // The current value of a literal.
+     lbool   modelValue (Var x) const;       // The value of a variable in the last model. The last call to solve must have been satisfiable.
+     lbool   modelValue (Lit p) const;       // The value of a literal in the last model. The last call to solve must have been satisfiable.
+-    int     nAssigns   ()      const;       // The current number of assigned literals.
+-    int     nClauses   ()      const;       // The current number of original clauses.
+-    int     nLearnts   ()      const;       // The current number of learnt clauses.
+-    int     nVars      ()      const;       // The current number of variables.
+-    int     nFreeVars  ()      const;
++    size_t  nAssigns   ()      const;       // The current number of assigned literals.
++    size_t  nClauses   ()      const;       // The current number of original clauses.
++    size_t  nLearnts   ()      const;       // The current number of learnt clauses.
++    size_t  nVars      ()      const;       // The current number of variables.
++    size_t  nFreeVars  ()      const;
+ 
+     // Resource contraints:
+     //
+@@ -130,7 +130,7 @@
+     double    learntsize_factor;  // The intitial limit for learnt clauses is a factor of the original clauses.                (default 1 / 3)
+     double    learntsize_inc;     // The limit for learnt clauses is multiplied with this factor each restart.                 (default 1.1)
+ 
+-    int       learntsize_adjust_start_confl;
++    size_t    learntsize_adjust_start_confl;
+     double    learntsize_adjust_inc;
+ 
+     // Statistics: (read-only member variable)
+@@ -142,8 +142,8 @@
+ 
+     // Helper structures:
+     //
+-    struct VarData { CRef reason; int level; };
+-    static inline VarData mkVarData(CRef cr, int l){ VarData d = {cr, l}; return d; }
++    struct VarData { CRef reason; size_t level; };
++    static inline VarData mkVarData(CRef cr, size_t l){ VarData d = {cr, l}; return d; }
+ 
+     struct Watcher {
+         CRef cref;
+@@ -181,10 +181,10 @@
+     vec<lbool>          user_pol;         // The users preferred polarity of each variable.
+     vec<char>           decision;         // Declares if a variable is eligible for selection in the decision heuristic.
+     vec<Lit>            trail;            // Assignment stack; stores all assigments made in the order they were made.
+-    vec<int>            trail_lim;        // Separator indices for different decision levels in 'trail'.
++    vec<size_t>         trail_lim;        // Separator indices for different decision levels in 'trail'.
+     vec<VarData>        vardata;          // Stores reason and level for each variable.
+-    int                 qhead;            // Head of queue (as index into the trail -- no more explicit propagation queue in MiniSat).
+-    int                 simpDB_assigns;   // Number of top-level assignments since last execution of 'simplify()'.
++    size_t              qhead;            // Head of queue (as index into the trail -- no more explicit propagation queue in MiniSat).
++    size_t              simpDB_assigns;   // Number of top-level assignments since last execution of 'simplify()'.
+     int64_t             simpDB_props;     // Remaining number of propagations that must be made before next execution of 'simplify()'.
+     vec<Lit>            assumptions;      // Current set of assumptions provided to solve by the user.
+     Heap<VarOrderLt>    order_heap;       // A priority queue of variables ordered with respect to the variable activity.
+@@ -203,7 +203,7 @@
+ 
+     double              max_learnts;
+     double              learntsize_adjust_confl;
+-    int                 learntsize_adjust_cnt;
++    size_t              learntsize_adjust_cnt;
+ 
+     // Resource contraints:
+     //
+@@ -219,11 +219,12 @@
+     void     uncheckedEnqueue (Lit p, CRef from = CRef_Undef);                         // Enqueue a literal. Assumes value of literal is undefined.
+     bool     enqueue          (Lit p, CRef from = CRef_Undef);                         // Test if fact 'p' contradicts current state, enqueue otherwise.
+     CRef     propagate        ();                                                      // Perform unit propagation. Returns possibly conflicting clause.
+-    void     cancelUntil      (int level);                                             // Backtrack until a certain level.
+-    void     analyze          (CRef confl, vec<Lit>& out_learnt, int& out_btlevel);    // (bt = backtrack)
++    void     cancelUntil      (size_t level);                                             // Backtrack until a certain level.
++    void     analyze          (CRef confl, vec<Lit>& out_learnt, size_t& out_btlevel);    // (bt = backtrack)
+     void     analyzeFinal     (Lit p, vec<Lit>& out_conflict);                         // COULD THIS BE IMPLEMENTED BY THE ORDINARIY "analyze" BY SOME REASONABLE GENERALIZATION?
+-    bool     litRedundant     (Lit p, uint32_t abstract_levels);                       // (helper method for 'analyze()')
+-    lbool    search           (int nof_conflicts);                                     // Search for a given number of conflicts.
++    typedef Clause::AbsLevel AbsLevel;
++    bool     litRedundant     (Lit p, AbsLevel abstract_levels);                       // (helper method for 'analyze()')
++    lbool    search           (ssize_t nof_conflicts);                                 // Search for a given number of conflicts.
+     lbool    solve_           ();                                                      // Main solve method (assumptions given in 'assumptions').
+     void     reduceDB         ();                                                      // Reduce the set of learnt clauses.
+     void     removeSatisfied  (vec<CRef>& cs);                                         // Shrink 'cs' to contain only non-satisfied clauses.
+@@ -249,10 +250,10 @@
+ 
+     // Misc:
+     //
+-    int      decisionLevel    ()      const; // Gives the current decisionlevel.
+-    uint32_t abstractLevel    (Var x) const; // Used to represent an abstraction of sets of decision levels.
++    size_t   decisionLevel    ()      const; // Gives the current decisionlevel.
++    AbsLevel abstractLevel    (Var x) const; // Used to represent an abstraction of sets of decision levels.
+     CRef     reason           (Var x) const;
+-    int      level            (Var x) const;
++    size_t   level            (Var x) const;
+     double   progressEstimate ()      const; // DELETE THIS ?? IT'S NOT VERY USEFUL ...
+     bool     withinBudget     ()      const;
+ 
+@@ -276,7 +277,7 @@
+ // Implementation of inline methods:
+ 
+ inline CRef Solver::reason(Var x) const { return vardata[x].reason; }
+-inline int  Solver::level (Var x) const { return vardata[x].level; }
++inline size_t  Solver::level (Var x) const { return vardata[x].level; }
+ 
+ inline void Solver::insertVarOrder(Var x) {
+     if (!order_heap.inHeap(x) && decision[x]) order_heap.insert(x); }
+@@ -286,7 +287,7 @@
+ inline void Solver::varBumpActivity(Var v, double inc) {
+     if ( (activity[v] += inc) > 1e100 ) {
+         // Rescale:
+-        for (int i = 0; i < nVars(); i++)
++        for (size_t i = 0; i < nVars(); i++)
+             activity[i] *= 1e-100;
+         var_inc *= 1e-100; }
+ 
+@@ -298,7 +299,7 @@
+ inline void Solver::claBumpActivity (Clause& c) {
+         if ( (c.activity() += cla_inc) > 1e20 ) {
+             // Rescale:
+-            for (int i = 0; i < learnts.size(); i++)
++            for (size_t i = 0; i < learnts.size(); i++)
+                 ca[learnts[i]].activity() *= 1e-20;
+             cla_inc *= 1e-20; } }
+ 
+@@ -317,17 +318,17 @@
+ inline bool     Solver::locked          (const Clause& c) const { return value(c[0]) == l_True && reason(var(c[0])) != CRef_Undef && ca.lea(reason(var(c[0]))) == &c; }
+ inline void     Solver::newDecisionLevel()                      { trail_lim.push(trail.size()); }
+ 
+-inline int      Solver::decisionLevel ()      const   { return trail_lim.size(); }
+-inline uint32_t Solver::abstractLevel (Var x) const   { return 1 << (level(x) & 31); }
++inline size_t   Solver::decisionLevel ()      const   { return trail_lim.size(); }
++inline Solver::AbsLevel Solver::abstractLevel (Var x) const   { return 1 << (level(x) & (sizeof(AbsLevel)*8-1)); }
+ inline lbool    Solver::value         (Var x) const   { return assigns[x]; }
+ inline lbool    Solver::value         (Lit p) const   { return assigns[var(p)] ^ sign(p); }
+ inline lbool    Solver::modelValue    (Var x) const   { return model[x]; }
+ inline lbool    Solver::modelValue    (Lit p) const   { return model[var(p)] ^ sign(p); }
+-inline int      Solver::nAssigns      ()      const   { return trail.size(); }
+-inline int      Solver::nClauses      ()      const   { return clauses.size(); }
+-inline int      Solver::nLearnts      ()      const   { return learnts.size(); }
+-inline int      Solver::nVars         ()      const   { return vardata.size(); }
+-inline int      Solver::nFreeVars     ()      const   { return (int)dec_vars - (trail_lim.size() == 0 ? trail.size() : trail_lim[0]); }
++inline size_t   Solver::nAssigns      ()      const   { return trail.size(); }
++inline size_t   Solver::nClauses      ()      const   { return clauses.size(); }
++inline size_t   Solver::nLearnts      ()      const   { return learnts.size(); }
++inline size_t   Solver::nVars         ()      const   { return vardata.size(); }
++inline size_t   Solver::nFreeVars     ()      const   { return (size_t)dec_vars - (trail_lim.size() == 0 ? trail.size() : trail_lim[0]); }
+ inline void     Solver::setPolarity   (Var v, lbool b){ user_pol[v] = b; }
+ inline void     Solver::setDecisionVar(Var v, bool b) 
+ { 
+diff -urN minisat-2.2.1/minisat/core/SolverTypes.h minisat-2.2.1.64/minisat/core/SolverTypes.h
+--- minisat-2.2.1/minisat/core/SolverTypes.h	2018-03-21 14:54:06.918130658 +0000
++++ minisat-2.2.1.64/minisat/core/SolverTypes.h	2018-03-21 14:34:37.654154361 +0000
+@@ -129,7 +129,18 @@
+         unsigned size      : 27; }                        header;
+ #include <util/pragma_push.def>
+ #include <util/pragma_wzero_length_array.def>
+-    union { Lit lit; float act; uint32_t abs; CRef rel; } data[0];
++public:
++    typedef uint32_t AbsLevel;
++private:
++#if SIZE_MAX == UINT32_MAX
++    union { Lit lit; float act; AbsLevel abs; CRef rel; } data[0];
++#else
++    static_assert(sizeof(Lit) == sizeof(float), "float has the size of Lit");
++    static_assert(sizeof(Lit) == sizeof(AbsLevel), "AbsLevel has the size of Lit");
++    static_assert(sizeof(Lit) == sizeof(uint32_t), "Lit is uint32_t");
++    static_assert(2 * sizeof(Lit) == sizeof(CRef), "CRef is 2*Lit");
++    union { Lit lit; float act; AbsLevel abs; uint32_t rel; } data[0];
++#endif
+ #include <util/pragma_pop.def>
+ 
+     friend class ClauseAllocator;
+@@ -142,7 +153,7 @@
+         header.reloced   = 0;
+         header.size      = ps.size();
+ 
+-        for (int i = 0; i < ps.size(); i++) 
++        for (size_t i = 0; i < ps.size(); i++) 
+             data[i].lit = ps[i];
+ 
+         if (header.has_extra) {
+@@ -158,7 +169,7 @@
+         header           = from.header;
+         header.has_extra = use_extra;   // NOTE: the copied clause may lose the extra field.
+ 
+-        for (int i = 0; i < from.size(); i++)
++        for (size_t i = 0; i < from.size(); i++)
+             data[i].lit = from[i];
+ 
+         if (header.has_extra) {
+@@ -172,14 +183,14 @@
+ public:
+     void calcAbstraction() {
+         assert(header.has_extra);
+-        uint32_t abstraction = 0;
+-        for (int i = 0; i < size(); i++)
+-            abstraction |= 1 << (var(data[i].lit) & 31);
++        AbsLevel abstraction = 0;
++        for (size_t i = 0; i < size(); i++)
++            abstraction |= 1 << (var(data[i].lit) & (sizeof(AbsLevel)*8 - 1));
+         data[header.size].abs = abstraction;  }
+ 
+ 
+-    int          size        ()      const   { return header.size; }
+-    void         shrink      (int i)         { assert(i <= size()); if (header.has_extra) data[header.size-i] = data[header.size]; header.size -= i; }
++    size_t       size        ()      const   { return header.size; }
++    void         shrink      (size_t i)      { assert(i <= size()); if (header.has_extra) data[header.size-i] = data[header.size]; header.size -= i; }
+     void         pop         ()              { shrink(1); }
+     bool         learnt      ()      const   { return header.learnt; }
+     bool         has_extra   ()      const   { return header.has_extra; }
+@@ -188,17 +199,25 @@
+     const Lit&   last        ()      const   { return data[header.size-1].lit; }
+ 
+     bool         reloced     ()      const   { return header.reloced; }
++#if SIZE_MAX == UINT32_MAX
+     CRef         relocation  ()      const   { return data[0].rel; }
+     void         relocate    (CRef c)        { header.reloced = 1; data[0].rel = c; }
++#else
++#include <util/pragma_push.def>
++#include <util/pragma_wstrict_aliasing.def>
++    CRef         relocation  ()      const   { return *(CRef*)data; }
++    void         relocate    (CRef c)        { header.reloced = 1; *(CRef*)data = c; }
++#include <util/pragma_pop.def>
++#endif
+ 
+     // NOTE: somewhat unsafe to change the clause in-place! Must manually call 'calcAbstraction' afterwards for
+     //       subsumption operations to behave correctly.
+-    Lit&         operator [] (int i)         { return data[i].lit; }
+-    Lit          operator [] (int i) const   { return data[i].lit; }
++    Lit&         operator [] (size_t i)      { return data[i].lit; }
++    Lit          operator [] (size_t i) const{ return data[i].lit; }
+     operator const Lit* (void) const         { return (Lit*)data; }
+ 
+     float&       activity    ()              { assert(header.has_extra); return data[header.size].act; }
+-    uint32_t     abstraction () const        { assert(header.has_extra); return data[header.size].abs; }
++    AbsLevel     abstraction () const        { assert(header.has_extra); return data[header.size].abs; }
+ 
+     Lit          subsumes    (const Clause& other) const;
+     void         strengthen  (Lit p);
+@@ -213,15 +232,22 @@
+ {
+     RegionAllocator<uint32_t> ra;
+ 
+-    static uint32_t clauseWord32Size(int size, bool has_extra){
++#if SIZE_MAX == UINT32_MAX
++    static size_t clauseWord32Size(size_t size, bool has_extra){
+         return (sizeof(Clause) + (sizeof(Lit) * (size + (int)has_extra))) / sizeof(uint32_t); }
++#else
++    static size_t clauseWord32Size(size_t size, bool has_extra){
++        size_t s = size + (size_t)has_extra;
++        s = s < 2 ? 2 : s;
++        return (sizeof(Clause) + (sizeof(Lit) * s)) / sizeof(uint32_t); }
++#endif
+ 
+  public:
+     enum { Unit_Size = RegionAllocator<uint32_t>::Unit_Size };
+ 
+     bool extra_clause_field;
+ 
+-    ClauseAllocator(uint32_t start_cap) : ra(start_cap), extra_clause_field(false){}
++    ClauseAllocator(size_t start_cap) : ra(start_cap), extra_clause_field(false){}
+     ClauseAllocator() : extra_clause_field(false){}
+ 
+     void moveTo(ClauseAllocator& to){
+@@ -246,8 +272,8 @@
+         new (lea(cid)) Clause(from, use_extra);
+         return cid; }
+ 
+-    uint32_t size      () const      { return ra.size(); }
+-    uint32_t wasted    () const      { return ra.wasted(); }
++    size_t   size      () const      { return ra.size(); }
++    size_t   wasted    () const      { return ra.wasted(); }
+ 
+     // Deref, Load Effective Address (LEA), Inverse of LEA (AEL):
+     Clause&       operator[](CRef r)         { return (Clause&)ra[r]; }
+@@ -313,7 +339,7 @@
+ template<class Idx, class Vec, class Deleted>
+ void OccLists<Idx,Vec,Deleted>::cleanAll()
+ {
+-    for (int i = 0; i < dirties.size(); i++)
++    for (size_t i = 0; i < dirties.size(); i++)
+         // Dirties may contain duplicates so check here if a variable is already cleaned:
+         if (dirty[toInt(dirties[i])])
+             clean(dirties[i]);
+@@ -325,7 +351,7 @@
+ void OccLists<Idx,Vec,Deleted>::clean(const Idx& idx)
+ {
+     Vec& vec = occs[toInt(idx)];
+-    int  i, j;
++    size_t  i, j;
+     for (i = j = 0; i < vec.size(); i++)
+         if (!deleted(vec[i]))
+             vec[j++] = vec[i];
+@@ -350,7 +376,7 @@
+  public:
+     // Size-operations:
+     void     clear       ()                           { map.clear(); }
+-    int      size        ()                const      { return map.elems(); }
++    size_t   size        ()                const      { return map.elems(); }
+ 
+     
+     // Insert/Remove/Test mapping:
+@@ -364,8 +390,8 @@
+     T&       operator [] (CRef cr)            { return map[cr]; }
+ 
+     // Iteration (not transparent at all at the moment):
+-    int  bucket_count() const { return map.bucket_count(); }
+-    const vec<typename HashTable::Pair>& bucket(int i) const { return map.bucket(i); }
++    size_t  bucket_count() const { return map.bucket_count(); }
++    const vec<typename HashTable::Pair>& bucket(size_t i) const { return map.bucket(i); }
+ 
+     // Move contents to other map:
+     void moveTo(CMap& other){ map.moveTo(other.map); }
+diff -urN minisat-2.2.1/minisat/mtl/Alg.h minisat-2.2.1.64/minisat/mtl/Alg.h
+--- minisat-2.2.1/minisat/mtl/Alg.h	2011-02-21 13:31:17.000000000 +0000
++++ minisat-2.2.1.64/minisat/mtl/Alg.h	2018-03-15 16:37:30.632513704 +0000
+@@ -35,7 +35,7 @@
+ template<class V, class T>
+ static inline void remove(V& ts, const T& t)
+ {
+-    int j = 0;
++    size_t j = 0;
+     for (; j < ts.size() && ts[j] != t; j++);
+     assert(j < ts.size());
+     for (; j < ts.size()-1; j++) ts[j] = ts[j+1];
+@@ -46,7 +46,7 @@
+ template<class V, class T>
+ static inline bool find(V& ts, const T& t)
+ {
+-    int j = 0;
++    size_t j = 0;
+     for (; j < ts.size() && ts[j] != t; j++);
+     return j < ts.size();
+ }
+@@ -69,7 +69,7 @@
+ {
+     if (!append)
+         to.clear();
+-    for (int i = 0; i < from.size(); i++){
++    for (size_t i = 0; i < from.size(); i++){
+         to.push();
+         copy(from[i], to.last());
+     }
+diff -urN minisat-2.2.1/minisat/mtl/Alloc.h minisat-2.2.1.64/minisat/mtl/Alloc.h
+--- minisat-2.2.1/minisat/mtl/Alloc.h	2011-02-21 13:31:17.000000000 +0000
++++ minisat-2.2.1.64/minisat/mtl/Alloc.h	2018-03-15 16:37:30.636513704 +0000
+@@ -33,19 +33,19 @@
+ class RegionAllocator
+ {
+     T*        memory;
+-    uint32_t  sz;
+-    uint32_t  cap;
+-    uint32_t  wasted_;
++    size_t    sz;
++    size_t    cap;
++    size_t    wasted_;
+ 
+-    void capacity(uint32_t min_cap);
++    void capacity(size_t min_cap);
+ 
+  public:
+     // TODO: make this a class for better type-checking?
+-    typedef uint32_t Ref;
+-    enum { Ref_Undef = UINT32_MAX };
++    typedef size_t Ref;
++    enum { Ref_Undef = SIZE_MAX };
+     enum { Unit_Size = sizeof(T) };
+ 
+-    explicit RegionAllocator(uint32_t start_cap = 1024*1024) : memory(NULL), sz(0), cap(0), wasted_(0){ capacity(start_cap); }
++    explicit RegionAllocator(size_t start_cap = 1024*1024) : memory(NULL), sz(0), cap(0), wasted_(0){ capacity(start_cap); }
+     ~RegionAllocator()
+     {
+         if (memory != NULL)
+@@ -53,11 +53,11 @@
+     }
+ 
+ 
+-    uint32_t size      () const      { return sz; }
+-    uint32_t wasted    () const      { return wasted_; }
++    size_t   size      () const      { return sz; }
++    size_t   wasted    () const      { return wasted_; }
+ 
+-    Ref      alloc     (int size); 
+-    void     free      (int size)    { wasted_ += size; }
++    Ref      alloc     (size_t size); 
++    void     free      (size_t size)    { wasted_ += size; }
+ 
+     // Deref, Load Effective Address (LEA), Inverse of LEA (AEL):
+     T&       operator[](Ref r)       { assert(r < sz); return memory[r]; }
+@@ -83,17 +83,17 @@
+ };
+ 
+ template<class T>
+-void RegionAllocator<T>::capacity(uint32_t min_cap)
++void RegionAllocator<T>::capacity(size_t min_cap)
+ {
+     if (cap >= min_cap) return;
+ 
+-    uint32_t prev_cap = cap;
++    size_t prev_cap = cap;
+     while (cap < min_cap){
+         // NOTE: Multiply by a factor (13/8) without causing overflow, then add 2 and make the
+         // result even by clearing the least significant bit. The resulting sequence of capacities
+         // is carefully chosen to hit a maximum capacity that is close to the '2^32-1' limit when
+         // using 'uint32_t' as indices so that as much as possible of this space can be used.
+-        uint32_t delta = ((cap >> 1) + (cap >> 3) + 2) & ~1;
++        size_t delta = ((cap >> 1) + (cap >> 3) + 2) & ~((size_t)1);
+         cap += delta;
+ 
+         if (cap <= prev_cap)
+@@ -108,13 +108,13 @@
+ 
+ template<class T>
+ typename RegionAllocator<T>::Ref
+-RegionAllocator<T>::alloc(int size)
++RegionAllocator<T>::alloc(size_t size)
+ { 
+     // printf("ALLOC called (this = %p, size = %d)\n", this, size); fflush(stdout);
+     assert(size > 0);
+     capacity(sz + size);
+ 
+-    uint32_t prev_sz = sz;
++    size_t prev_sz = sz;
+     sz += size;
+     
+     // Handle overflow:
+diff -urN minisat-2.2.1/minisat/mtl/Heap.h minisat-2.2.1.64/minisat/mtl/Heap.h
+--- minisat-2.2.1/minisat/mtl/Heap.h	2011-02-21 13:31:17.000000000 +0000
++++ minisat-2.2.1.64/minisat/mtl/Heap.h	2018-03-21 14:35:42.310153050 +0000
+@@ -60,8 +60,8 @@
+     void percolateDown(int i)
+     {
+         int x = heap[i];
+-        while (left(i) < heap.size()){
+-            int child = right(i) < heap.size() && lt(heap[right(i)], heap[left(i)]) ? right(i) : left(i);
++        while ((size_t)left(i) < heap.size()){
++            int child = (size_t)right(i) < heap.size() && lt(heap[right(i)], heap[left(i)]) ? right(i) : left(i);
+             if (!lt(heap[child], x)) break;
+             heap[i]          = heap[child];
+             indices[heap[i]] = i;
+@@ -75,10 +75,10 @@
+   public:
+     Heap(const Comp& c) : lt(c) { }
+ 
+-    int  size      ()          const { return heap.size(); }
++    size_t  size   ()          const { return heap.size(); }
+     bool empty     ()          const { return heap.size() == 0; }
+-    bool inHeap    (int n)     const { return n < indices.size() && indices[n] >= 0; }
+-    int  operator[](int index) const { assert(index < heap.size()); return heap[index]; }
++    bool inHeap    (int n)     const { return (size_t)n < indices.size() && indices[n] >= 0; }
++    int  operator[](int index) const { assert((size_t)index < heap.size()); return heap[index]; }
+ 
+ 
+     void decrease  (int n) { assert(inHeap(n)); percolateUp  (indices[n]); }
+@@ -121,21 +121,21 @@
+ 
+     // Rebuild the heap from scratch, using the elements in 'ns':
+     void build(vec<int>& ns) {
+-        for (int i = 0; i < heap.size(); i++)
++        for (size_t i = 0; i < heap.size(); i++)
+             indices[heap[i]] = -1;
+         heap.clear();
+ 
+-        for (int i = 0; i < ns.size(); i++){
++        for (size_t i = 0; i < ns.size(); i++){
+             indices[ns[i]] = i;
+             heap.push(ns[i]); }
+ 
+-        for (int i = heap.size() / 2 - 1; i >= 0; i--)
+-            percolateDown(i);
++        for (size_t i = heap.size() / 2; i > 0; i--)
++            percolateDown(i - 1);
+     }
+ 
+     void clear(bool dealloc = false) 
+     { 
+-        for (int i = 0; i < heap.size(); i++)
++        for (size_t i = 0; i < heap.size(); i++)
+             indices[heap[i]] = -1;
+         heap.clear(dealloc); 
+     }
+diff -urN minisat-2.2.1/minisat/mtl/Map.h minisat-2.2.1.64/minisat/mtl/Map.h
+--- minisat-2.2.1/minisat/mtl/Map.h	2011-02-21 13:31:17.000000000 +0000
++++ minisat-2.2.1.64/minisat/mtl/Map.h	2018-03-15 16:37:30.636513704 +0000
+@@ -62,14 +62,14 @@
+     E          equals;
+ 
+     vec<Pair>* table;
+-    int        cap;
+-    int        size;
++    size_t     cap;
++    size_t     size;
+ 
+     // Don't allow copying (error prone):
+     Map<K,D,H,E>&  operator = (Map<K,D,H,E>& other);
+                    Map        (Map<K,D,H,E>& other);
+ 
+-    bool    checkCap(int new_size) const { return new_size > cap; }
++    bool    checkCap(size_t new_size) const { return new_size > cap; }
+ 
+     int32_t index  (const K& k) const { return hash(k) % cap; }
+     void   _insert (const K& k, const D& d) { 
+@@ -79,16 +79,16 @@
+     void    rehash () {
+         const vec<Pair>* old = table;
+ 
+-        int old_cap = cap;
+-        int newsize = primes[0];
+-        for (int i = 1; newsize <= cap && i < nprimes; i++)
++        size_t old_cap = cap;
++        size_t newsize = primes[0];
++        for (size_t i = 1; newsize <= cap && i < nprimes; i++)
+            newsize = primes[i];
+ 
+         table = new vec<Pair>[newsize];
+         cap   = newsize;
+ 
+-        for (int i = 0; i < old_cap; i++){
+-            for (int j = 0; j < old[i].size(); j++){
++        for (size_t i = 0; i < old_cap; i++){
++            for (size_t j = 0; j < old[i].size(); j++){
+                 _insert(old[i][j].key, old[i][j].data); }}
+ 
+         delete [] old;
+@@ -109,7 +109,7 @@
+         assert(size != 0);
+         const D*         res = NULL;
+         const vec<Pair>& ps  = table[index(k)];
+-        for (int i = 0; i < ps.size(); i++)
++        for (size_t i = 0; i < ps.size(); i++)
+             if (equals(ps[i].key, k))
+                 res = &ps[i].data;
+         assert(res != NULL);
+@@ -122,7 +122,7 @@
+         assert(size != 0);
+         D*         res = NULL;
+         vec<Pair>& ps  = table[index(k)];
+-        for (int i = 0; i < ps.size(); i++)
++        for (size_t i = 0; i < ps.size(); i++)
+             if (equals(ps[i].key, k))
+                 res = &ps[i].data;
+         assert(res != NULL);
+@@ -134,7 +134,7 @@
+     bool peek   (const K& k, D& d) const {
+         if (size == 0) return false;
+         const vec<Pair>& ps = table[index(k)];
+-        for (int i = 0; i < ps.size(); i++)
++        for (size_t i = 0; i < ps.size(); i++)
+             if (equals(ps[i].key, k)){
+                 d = ps[i].data;
+                 return true; } 
+@@ -144,7 +144,7 @@
+     bool has   (const K& k) const {
+         if (size == 0) return false;
+         const vec<Pair>& ps = table[index(k)];
+-        for (int i = 0; i < ps.size(); i++)
++        for (size_t i = 0; i < ps.size(); i++)
+             if (equals(ps[i].key, k))
+                 return true;
+         return false;
+@@ -154,7 +154,7 @@
+     void remove(const K& k) {
+         assert(table != NULL);
+         vec<Pair>& ps = table[index(k)];
+-        int j = 0;
++        size_t j = 0;
+         for (; j < ps.size() && !equals(ps[j].key, k); j++);
+         assert(j < ps.size());
+         ps[j] = ps.last();
+@@ -168,8 +168,8 @@
+         table = NULL;
+     }
+ 
+-    int  elems() const { return size; }
+-    int  bucket_count() const { return cap; }
++    size_t  elems() const { return size; }
++    size_t  bucket_count() const { return cap; }
+ 
+     // NOTE: the hash and equality objects are not moved by this method:
+     void moveTo(Map& other){
+@@ -184,7 +184,7 @@
+     }
+ 
+     // NOTE: given a bit more time, I could make a more C++-style iterator out of this:
+-    const vec<Pair>& bucket(int i) const { return table[i]; }
++    const vec<Pair>& bucket(size_t i) const { return table[i]; }
+ };
+ 
+ //=================================================================================================
+diff -urN minisat-2.2.1/minisat/mtl/Queue.h minisat-2.2.1.64/minisat/mtl/Queue.h
+--- minisat-2.2.1/minisat/mtl/Queue.h	2011-02-21 13:31:17.000000000 +0000
++++ minisat-2.2.1.64/minisat/mtl/Queue.h	2018-03-21 14:36:32.654152030 +0000
+@@ -30,8 +30,8 @@
+ template<class T>
+ class Queue {
+     vec<T>  buf;
+-    int     first;
+-    int     end;
++    size_t  first;
++    size_t  end;
+ 
+ public:
+     typedef T Key;
+@@ -39,10 +39,10 @@
+     Queue() : buf(1), first(0), end(0) {}
+ 
+     void clear (bool dealloc = false) { buf.clear(dealloc); buf.growTo(1); first = end = 0; }
+-    int  size  () const { return (end >= first) ? end - first : end - first + buf.size(); }
++    size_t size  () const { return (end >= first) ? end - first : end - first + buf.size(); }
+ 
+-    const T& operator [] (int index) const  { assert(index >= 0); assert(index < size()); return buf[(first + index) % buf.size()]; }
+-    T&       operator [] (int index)        { assert(index >= 0); assert(index < size()); return buf[(first + index) % buf.size()]; }
++    const T& operator [] (size_t index) const  { assert(index < size()); return buf[(first + index) % buf.size()]; }
++    T&       operator [] (size_t index)        { assert(index < size()); return buf[(first + index) % buf.size()]; }
+ 
+     T    peek  () const { assert(first != end); return buf[first]; }
+     void pop   () { assert(first != end); first++; if (first == buf.size()) first = 0; }
+@@ -52,9 +52,9 @@
+         if (first == end){  // Resize:
+             vec<T>  tmp((buf.size()*3 + 1) >> 1);
+             //**/printf("queue alloc: %d elems (%.1f MB)\n", tmp.size(), tmp.size() * sizeof(T) / 1000000.0);
+-            int     i = 0;
+-            for (int j = first; j < buf.size(); j++) tmp[i++] = buf[j];
+-            for (int j = 0    ; j < end       ; j++) tmp[i++] = buf[j];
++            size_t      i = 0;
++            for (size_t j = first; j < buf.size(); j++) tmp[i++] = buf[j];
++            for (size_t j = 0    ; j < end       ; j++) tmp[i++] = buf[j];
+             first = 0;
+             end   = buf.size();
+             tmp.moveTo(buf);
+diff -urN minisat-2.2.1/minisat/mtl/Sort.h minisat-2.2.1.64/minisat/mtl/Sort.h
+--- minisat-2.2.1/minisat/mtl/Sort.h	2011-02-21 13:31:17.000000000 +0000
++++ minisat-2.2.1.64/minisat/mtl/Sort.h	2018-03-21 14:19:21.418172934 +0000
+@@ -36,12 +36,12 @@
+ 
+ 
+ template <class T, class LessThan>
+-void selectionSort(T* array, int size, LessThan lt)
++void selectionSort(T* array, size_t size, LessThan lt)
+ {
+-    int     i, j, best_i;
++    size_t  i, j, best_i;
+     T       tmp;
+ 
+-    for (i = 0; i < size-1; i++){
++    for (i = 0; size > 0 && i < size-1; i++){
+         best_i = i;
+         for (j = i+1; j < size; j++){
+             if (lt(array[j], array[best_i]))
+@@ -50,11 +50,11 @@
+         tmp = array[i]; array[i] = array[best_i]; array[best_i] = tmp;
+     }
+ }
+-template <class T> static inline void selectionSort(T* array, int size) {
++template <class T> static inline void selectionSort(T* array, size_t size) {
+     selectionSort(array, size, LessThan_default<T>()); }
+ 
+ template <class T, class LessThan>
+-void sort(T* array, int size, LessThan lt)
++void sort(T* array, size_t size, LessThan lt)
+ {
+     if (size <= 15)
+         selectionSort(array, size, lt);
+@@ -62,8 +62,8 @@
+     else{
+         T           pivot = array[size / 2];
+         T           tmp;
+-        int         i = -1;
+-        int         j = size;
++        size_t      i = SIZE_MAX;
++        size_t      j = size;
+ 
+         for(;;){
+             do i++; while(lt(array[i], pivot));
+@@ -78,7 +78,7 @@
+         sort(&array[i], size-i, lt);
+     }
+ }
+-template <class T> static inline void sort(T* array, int size) {
++template <class T> static inline void sort(T* array, size_t size) {
+     sort(array, size, LessThan_default<T>()); }
+ 
+ 
+diff -urN minisat-2.2.1/minisat/mtl/Vec.h minisat-2.2.1.64/minisat/mtl/Vec.h
+--- minisat-2.2.1/minisat/mtl/Vec.h	2018-03-21 14:54:06.918130658 +0000
++++ minisat-2.2.1.64/minisat/mtl/Vec.h	2018-03-21 14:39:38.566148261 +0000
+@@ -37,36 +37,36 @@
+ template<class T>
+ class vec {
+     T*  data;
+-    int sz;
+-    int cap;
++    size_t sz;
++    size_t cap;
+ 
+     // Don't allow copying (error prone):
+     vec<T>&  operator = (vec<T>& other);
+              vec        (vec<T>& other);
+              
+     // Helpers for calculating next capacity:
+-    static inline int  imax   (int x, int y) { int mask = (y-x) >> (sizeof(int)*8-1); return (x&mask) + (y&(~mask)); }
++    static inline size_t imax   (size_t x, size_t y) { return x > y ? x : y; }
+     //static inline void nextCap(int& cap){ cap += ((cap >> 1) + 2) & ~1; }
+-    static inline void nextCap(int& cap){ cap += ((cap >> 1) + 2) & ~1; }
++    static inline void nextCap(size_t& cap){ cap += ((cap >> 1) + 2) & ~(size_t)1; }
+ 
+ public:
+     // Constructors:
+     vec()                       : data(NULL) , sz(0)   , cap(0)    { }
+-    explicit vec(int size)      : data(NULL) , sz(0)   , cap(0)    { growTo(size); }
+-    vec(int size, const T& pad) : data(NULL) , sz(0)   , cap(0)    { growTo(size, pad); }
++    explicit vec(size_t size)   : data(NULL) , sz(0)   , cap(0)    { growTo(size); }
++    vec(size_t size, const T& pad) : data(NULL) , sz(0), cap(0)    { growTo(size, pad); }
+    ~vec()                                                          { clear(true); }
+ 
+     // Pointer to first element:
+     operator T*       (void)           { return data; }
+ 
+     // Size operations:
+-    int      size     (void) const     { return sz; }
+-    void     shrink   (int nelems)     { assert(nelems <= sz); for (int i = 0; i < nelems; i++) sz--, data[sz].~T(); }
+-    void     shrink_  (int nelems)     { assert(nelems <= sz); sz -= nelems; }
+-    int      capacity (void) const     { return cap; }
+-    void     capacity (int min_cap);
+-    void     growTo   (int size);
+-    void     growTo   (int size, const T& pad);
++    size_t   size     (void) const     { return sz; }
++    void     shrink   (size_t nelems)  { assert(nelems <= sz); for (size_t i = 0; i < nelems; i++) sz--, data[sz].~T(); }
++    void     shrink_  (size_t nelems)  { assert(nelems <= sz); sz -= nelems; }
++    size_t   capacity (void) const     { return cap; }
++    void     capacity (size_t min_cap);
++    void     growTo   (size_t size);
++    void     growTo   (size_t size, const T& pad);
+     void     clear    (bool dealloc = false);
+ 
+     // Stack interface:
+@@ -83,20 +83,20 @@
+     T&       last  (void)              { return data[sz-1]; }
+ 
+     // Vector interface:
+-    const T& operator [] (int index) const { return data[index]; }
+-    T&       operator [] (int index)       { return data[index]; }
++    const T& operator [] (size_t index) const { return data[index]; }
++    T&       operator [] (size_t index)       { return data[index]; }
+ 
+     // Duplicatation (preferred instead):
+-    void copyTo(vec<T>& copy) const { copy.clear(); copy.growTo(sz); for (int i = 0; i < sz; i++) copy[i] = data[i]; }
++    void copyTo(vec<T>& copy) const { copy.clear(); copy.growTo(sz); for (size_t i = 0; i < sz; i++) copy[i] = data[i]; }
+     void moveTo(vec<T>& dest) { dest.clear(true); dest.data = data; dest.sz = sz; dest.cap = cap; data = NULL; sz = 0; cap = 0; }
+ };
+ 
+ 
+ template<class T>
+-void vec<T>::capacity(int min_cap) {
++void vec<T>::capacity(size_t min_cap) {
+     if (cap >= min_cap) return;
+-    int add = imax((min_cap - cap + 1) & ~1, ((cap >> 1) + 2) & ~1);   // NOTE: grow by approximately 3/2
+-    if (add > INT_MAX - cap)
++    size_t add = imax((min_cap - cap + 1) & ~(size_t)1, ((cap >> 1) + 2) & ~(size_t)1);   // NOTE: grow by approximately 3/2
++    if (add > SIZE_MAX - cap)
+       throw OutOfMemoryException();
+ 
+     data = (T*)xrealloc(data, (cap += add) * sizeof(T));
+@@ -104,25 +104,25 @@
+ 
+ 
+ template<class T>
+-void vec<T>::growTo(int size, const T& pad) {
++void vec<T>::growTo(size_t size, const T& pad) {
+     if (sz >= size) return;
+     capacity(size);
+-    for (int i = sz; i < size; i++) data[i] = pad;
++    for (size_t i = sz; i < size; i++) data[i] = pad;
+     sz = size; }
+ 
+ 
+ template<class T>
+-void vec<T>::growTo(int size) {
++void vec<T>::growTo(size_t size) {
+     if (sz >= size) return;
+     capacity(size);
+-    for (int i = sz; i < size; i++) new (&data[i]) T();
++    for (size_t i = sz; i < size; i++) new (&data[i]) T();
+     sz = size; }
+ 
+ 
+ template<class T>
+ void vec<T>::clear(bool dealloc) {
+     if (data != NULL){
+-        for (int i = 0; i < sz; i++) data[i].~T();
++        for (size_t i = 0; i < sz; i++) data[i].~T();
+         sz = 0;
+         if (dealloc) free(data), data = NULL, cap = 0; } }
+ 
+diff -urN minisat-2.2.1/minisat/simp/Main.cc minisat-2.2.1.64/minisat/simp/Main.cc
+--- minisat-2.2.1/minisat/simp/Main.cc	2011-02-21 13:31:17.000000000 +0000
++++ minisat-2.2.1.64/minisat/simp/Main.cc	2018-03-15 16:37:30.636513704 +0000
+@@ -187,7 +187,7 @@
+         if (res != NULL){
+             if (ret == l_True){
+                 fprintf(res, "SAT\n");
+-                for (int i = 0; i < S.nVars(); i++)
++                for (size_t i = 0; i < S.nVars(); i++)
+                     if (S.model[i] != l_Undef)
+                         fprintf(res, "%s%s%d", (i==0)?"":" ", (S.model[i]==l_True)?"":"-", i+1);
+                 fprintf(res, " 0\n");
+diff -urN minisat-2.2.1/minisat/simp/SimpSolver.cc minisat-2.2.1.64/minisat/simp/SimpSolver.cc
+--- minisat-2.2.1/minisat/simp/SimpSolver.cc	2018-03-21 14:54:06.918130658 +0000
++++ minisat-2.2.1.64/minisat/simp/SimpSolver.cc	2018-03-21 14:44:39.630142158 +0000
+@@ -99,7 +99,7 @@
+ 
+     if (do_simp){
+         // Assumptions must be temporarily frozen to run variable elimination:
+-        for (int i = 0; i < assumptions.size(); i++){
++        for (size_t i = 0; i < assumptions.size(); i++){
+             Var v = var(assumptions[i]);
+ 
+             // If an assumption has been eliminated, remember it.
+@@ -124,7 +124,7 @@
+ 
+     if (do_simp)
+         // Unfreeze the assumptions that were frozen:
+-        for (int i = 0; i < extra_frozen.size(); i++)
++        for (size_t i = 0; i < extra_frozen.size(); i++)
+             setFrozen(extra_frozen[i], false);
+ 
+     return result;
+@@ -133,11 +133,11 @@
+ bool SimpSolver::addClause_(vec<Lit>& ps)
+ {
+ #ifndef NDEBUG
+-    for (int i = 0; i < ps.size(); i++)
++    for (size_t i = 0; i < ps.size(); i++)
+         assert(!isEliminated(var(ps[i])));
+ #endif
+ 
+-    int nclauses = clauses.size();
++    size_t nclauses = clauses.size();
+ 
+     if (use_rcheck && implied(ps))
+         return true;
+@@ -156,7 +156,7 @@
+         // consequence of how backward subsumption is used to mimic
+         // forward subsumption.
+         subsumption_queue.insert(cr);
+-        for (int i = 0; i < c.size(); i++){
++        for (size_t i = 0; i < c.size(); i++){
+             occurs[var(c[i])].push(cr);
+             n_occ[toInt(c[i])]++;
+             touched[var(c[i])] = 1;
+@@ -175,7 +175,7 @@
+     const Clause& c = ca[cr];
+ 
+     if (use_simplification)
+-        for (int i = 0; i < c.size(); i++){
++        for (size_t i = 0; i < c.size(); i++){
+             n_occ[toInt(c[i])]--;
+             updateElimHeap(var(c[i]));
+             occurs.smudge(var(c[i]));
+@@ -221,9 +221,9 @@
+     const Clause& ps  =  ps_smallest ? _qs : _ps;
+     const Clause& qs  =  ps_smallest ? _ps : _qs;
+ 
+-    for (int i = 0; i < qs.size(); i++){
++    for (size_t i = 0; i < qs.size(); i++){
+         if (var(qs[i]) != v){
+-            for (int j = 0; j < ps.size(); j++)
++            for (size_t j = 0; j < ps.size(); j++)
+                 if (var(ps[j]) == var(qs[i]))
+                 {
+                     if (ps[j] == ~qs[i])
+@@ -236,7 +236,7 @@
+         next:;
+     }
+ 
+-    for (int i = 0; i < ps.size(); i++)
++    for (size_t i = 0; i < ps.size(); i++)
+         if (var(ps[i]) != v)
+             out_clause.push(ps[i]);
+ 
+@@ -245,7 +245,7 @@
+ 
+ 
+ // Returns FALSE if clause is always satisfied.
+-bool SimpSolver::merge(const Clause& _ps, const Clause& _qs, Var v, int& size)
++bool SimpSolver::merge(const Clause& _ps, const Clause& _qs, Var v, size_t& size)
+ {
+     merges++;
+ 
+@@ -257,9 +257,9 @@
+ 
+     size = ps.size()-1;
+ 
+-    for (int i = 0; i < qs.size(); i++){
++    for (size_t i = 0; i < qs.size(); i++){
+         if (var(__qs[i]) != v){
+-            for (int j = 0; j < ps.size(); j++)
++            for (size_t j = 0; j < ps.size(); j++)
+                 if (var(__ps[j]) == var(__qs[i]))
+                 {
+                     if (__ps[j] == ~__qs[i])
+@@ -280,7 +280,7 @@
+ {
+     if (n_touched == 0) return;
+ 
+-    int i,j;
++    size_t i,j;
+     for (i = j = 0; i < subsumption_queue.size(); i++)
+         if (ca[subsumption_queue[i]].mark() == 0)
+             ca[subsumption_queue[i]].mark(2);
+@@ -309,7 +309,7 @@
+     assert(decisionLevel() == 0);
+ 
+     trail_lim.push(trail.size());
+-    for (int i = 0; i < c.size(); i++)
++    for (size_t i = 0; i < c.size(); i++)
+         if (value(c[i]) == l_True){
+             cancelUntil(0);
+             return false;
+@@ -327,9 +327,9 @@
+ // Backward subsumption + backward subsumption resolution
+ bool SimpSolver::backwardSubsumptionCheck(bool verbose)
+ {
+-    int cnt = 0;
+-    int subsumed = 0;
+-    int deleted_literals = 0;
++    size_t cnt = 0;
++    size_t subsumed = 0;
++    size_t deleted_literals = 0;
+     assert(decisionLevel() == 0);
+ 
+     while (subsumption_queue.size() > 0 || bwdsub_assigns < trail.size()){
+@@ -353,13 +353,13 @@
+         if (c.mark()) continue;
+ 
+         if (verbose && verbosity >= 2 && cnt++ % 1000 == 0)
+-            printf("subsumption left: %10d (%10d subsumed, %10d deleted literals)\r", subsumption_queue.size(), subsumed, deleted_literals);
++            printf("subsumption left: %10ld (%10ld subsumed, %10ld deleted literals)\r", subsumption_queue.size(), subsumed, deleted_literals);
+ 
+         assert(c.size() > 1 || value(c[0]) == l_True);    // Unit-clauses should have been propagated before this point.
+ 
+         // Find best variable to scan:
+         Var best = var(c[0]);
+-        for (int i = 1; i < c.size(); i++)
++        for (size_t i = 1; i < c.size(); i++)
+             if (occurs[var(c[i])].size() < occurs[best].size())
+                 best = var(c[i]);
+ 
+@@ -367,10 +367,10 @@
+         vec<CRef>& _cs = occurs.lookup(best);
+         CRef*       cs = (CRef*)_cs;
+ 
+-        for (int j = 0; j < _cs.size(); j++)
++        for (size_t j = 0; j < _cs.size(); j++)
+             if (c.mark())
+                 break;
+-            else if (!ca[cs[j]].mark() &&  cs[j] != cr && (subsumption_lim == -1 || ca[cs[j]].size() < subsumption_lim)){
++            else if (!ca[cs[j]].mark() &&  cs[j] != cr && (subsumption_lim == -1 || ca[cs[j]].size() < (size_t)subsumption_lim)){
+                 Lit l = c.subsumes(ca[cs[j]]);
+ 
+                 if (l == lit_Undef)
+@@ -401,7 +401,7 @@
+ 
+     trail_lim.push(trail.size());
+     Lit l = lit_Undef;
+-    for (int i = 0; i < c.size(); i++)
++    for (size_t i = 0; i < c.size(); i++)
+         if (var(c[i]) != v && value(c[i]) != l_False)
+             uncheckedEnqueue(~c[i]);
+         else
+@@ -428,7 +428,7 @@
+     if (value(v) != l_Undef || cls.size() == 0)
+         return true;
+ 
+-    for (int i = 0; i < cls.size(); i++)
++    for (size_t i = 0; i < cls.size(); i++)
+         if (!asymm(v, cls[i]))
+             return false;
+ 
+@@ -445,17 +445,17 @@
+ 
+ static void mkElimClause(vec<uint32_t>& elimclauses, Var v, Clause& c)
+ {
+-    int first = elimclauses.size();
+-    int v_pos = -1;
++    size_t first = elimclauses.size();
++    size_t v_pos = SIZE_MAX;
+ 
+     // Copy clause to elimclauses-vector. Remember position where the
+     // variable 'v' occurs:
+-    for (int i = 0; i < c.size(); i++){
++    for (size_t i = 0; i < c.size(); i++){
+         elimclauses.push(toInt(c[i]));
+         if (var(c[i]) == v)
+             v_pos = i + first;
+     }
+-    assert(v_pos != -1);
++    assert(v_pos != SIZE_MAX);
+ 
+     // Swap the first literal with the 'v' literal, so that the literal
+     // containing 'v' will occur first in the clause:
+@@ -479,19 +479,19 @@
+     //
+     const vec<CRef>& cls = occurs.lookup(v);
+     vec<CRef>        pos, neg;
+-    for (int i = 0; i < cls.size(); i++)
++    for (size_t i = 0; i < cls.size(); i++)
+         (find(ca[cls[i]], mkLit(v)) ? pos : neg).push(cls[i]);
+ 
+     // Check wether the increase in number of clauses stays within the allowed ('grow'). Moreover, no
+     // clause must exceed the limit on the maximal clause size (if it is set):
+     //
+-    int cnt         = 0;
+-    int clause_size = 0;
++    size_t cnt         = 0;
++    size_t clause_size = 0;
+ 
+-    for (int i = 0; i < pos.size(); i++)
+-        for (int j = 0; j < neg.size(); j++)
++    for (size_t i = 0; i < pos.size(); i++)
++        for (size_t j = 0; j < neg.size(); j++)
+             if (merge(ca[pos[i]], ca[neg[j]], v, clause_size) && 
+-                (++cnt > cls.size() + grow || (clause_lim != -1 && clause_size > clause_lim)))
++                (++cnt > cls.size() + grow || (clause_lim != -1 && clause_size > (size_t)clause_lim)))
+                 return true;
+ 
+     // Delete and store old clauses:
+@@ -500,22 +500,22 @@
+     eliminated_vars++;
+ 
+     if (pos.size() > neg.size()){
+-        for (int i = 0; i < neg.size(); i++)
++        for (size_t i = 0; i < neg.size(); i++)
+             mkElimClause(elimclauses, v, ca[neg[i]]);
+         mkElimClause(elimclauses, mkLit(v));
+     }else{
+-        for (int i = 0; i < pos.size(); i++)
++        for (size_t i = 0; i < pos.size(); i++)
+             mkElimClause(elimclauses, v, ca[pos[i]]);
+         mkElimClause(elimclauses, ~mkLit(v));
+     }
+ 
+-    for (int i = 0; i < cls.size(); i++)
++    for (size_t i = 0; i < cls.size(); i++)
+         removeClause(cls[i]); 
+ 
+     // Produce clauses in cross product:
+     vec<Lit>& resolvent = add_tmp;
+-    for (int i = 0; i < pos.size(); i++)
+-        for (int j = 0; j < neg.size(); j++)
++    for (size_t i = 0; i < pos.size(); i++)
++        for (size_t j = 0; j < neg.size(); j++)
+             if (merge(ca[pos[i]], ca[neg[j]], v, resolvent) && !addClause_(resolvent))
+                 return false;
+ 
+@@ -543,11 +543,11 @@
+     const vec<CRef>& cls = occurs.lookup(v);
+     
+     vec<Lit>& subst_clause = add_tmp;
+-    for (int i = 0; i < cls.size(); i++){
++    for (size_t i = 0; i < cls.size(); i++){
+         Clause& c = ca[cls[i]];
+ 
+         subst_clause.clear();
+-        for (int j = 0; j < c.size(); j++){
++        for (size_t j = 0; j < c.size(); j++){
+             Lit p = c[j];
+             subst_clause.push(var(p) == v ? x ^ sign(p) : p);
+         }
+@@ -564,15 +564,15 @@
+ 
+ void SimpSolver::extendModel()
+ {
+-    int i, j;
++    size_t i, j;
+     Lit x;
+ 
+-    for (i = elimclauses.size()-1; i > 0; i -= j){
+-        for (j = elimclauses[i--]; j > 1; j--, i--)
+-            if (modelValue(toLit(elimclauses[i])) != l_False)
++    for (i = elimclauses.size(); i > 1; i -= j){
++        for (j = elimclauses[--i]; j > 1; j--, i--)
++            if (modelValue(toLit(elimclauses[i - 1])) != l_False)
+                 goto next;
+ 
+-        x = toLit(elimclauses[i]);
++        x = toLit(elimclauses[i - 1]);
+         model[var(x)] = lbool(!sign(x));
+     next:;
+     }
+@@ -605,7 +605,7 @@
+             goto cleanup; }
+ 
+         // printf("  ## (time = %6.2f s) ELIM: vars = %d\n", cpuTime(), elim_heap.size());
+-        for (int cnt = 0; !elim_heap.empty(); cnt++){
++        for (size_t cnt = 0; !elim_heap.empty(); cnt++){
+             Var elim = elim_heap.removeMin();
+             
+             if (asynch_interrupt) break;
+@@ -613,7 +613,7 @@
+             if (isEliminated(elim) || value(elim) != l_Undef) continue;
+ 
+             if (verbosity >= 2 && cnt % 100 == 0)
+-                printf("elimination left: %10d\r", elim_heap.size());
++                printf("elimination left: %10ld\r", elim_heap.size());
+ 
+             if (use_asymm){
+                 // Temporarily freeze variable. Otherwise, it would immediately end up on the queue again:
+@@ -667,7 +667,7 @@
+ void SimpSolver::cleanUpClauses()
+ {
+     occurs.cleanAll();
+-    int i,j;
++    size_t i,j;
+     for (i = j = 0; i < clauses.size(); i++)
+         if (ca[clauses[i]].mark() == 0)
+             clauses[j++] = clauses[i];
+@@ -685,15 +685,15 @@
+ 
+     // All occurs lists:
+     //
+-    for (int i = 0; i < nVars(); i++){
++    for (size_t i = 0; i < nVars(); i++){
+         vec<CRef>& cs = occurs[i];
+-        for (int j = 0; j < cs.size(); j++)
++        for (size_t j = 0; j < cs.size(); j++)
+             ca.reloc(cs[j], to);
+     }
+ 
+     // Subsumption queue:
+     //
+-    for (int i = 0; i < subsumption_queue.size(); i++)
++    for (size_t i = 0; i < subsumption_queue.size(); i++)
+         ca.reloc(subsumption_queue[i], to);
+ 
+     // Temporary clause:
+@@ -713,7 +713,7 @@
+     relocAll(to);
+     Solver::relocAll(to);
+     if (verbosity >= 2)
+-        printf("|  Garbage collection:   %12d bytes => %12d bytes             |\n", 
++        printf("|  Garbage collection:   %12ld bytes => %12ld bytes             |\n", 
+                ca.size()*ClauseAllocator::Unit_Size, to.size()*ClauseAllocator::Unit_Size);
+     to.moveTo(ca);
+ }
+diff -urN minisat-2.2.1/minisat/simp/SimpSolver.h minisat-2.2.1.64/minisat/simp/SimpSolver.h
+--- minisat-2.2.1/minisat/simp/SimpSolver.h	2011-02-21 13:31:17.000000000 +0000
++++ minisat-2.2.1.64/minisat/simp/SimpSolver.h	2018-03-21 14:44:52.618141895 +0000
+@@ -92,17 +92,17 @@
+ 
+     // Statistics:
+     //
+-    int     merges;
+-    int     asymm_lits;
+-    int     eliminated_vars;
++    size_t     merges;
++    size_t     asymm_lits;
++    size_t     eliminated_vars;
+ 
+  protected:
+ 
+     // Helper structures:
+     //
+     struct ElimLt {
+-        const vec<int>& n_occ;
+-        explicit ElimLt(const vec<int>& no) : n_occ(no) {}
++        const vec<size_t>& n_occ;
++        explicit ElimLt(const vec<size_t>& no) : n_occ(no) {}
+ 
+         // TODO: are 64-bit operations here noticably bad on 32-bit platforms? Could use a saturating
+         // 32-bit implementation instead then, but this will have to do for now.
+@@ -129,13 +129,13 @@
+     vec<char>           touched;
+     OccLists<Var, vec<CRef>, ClauseDeleted>
+                         occurs;
+-    vec<int>            n_occ;
++    vec<size_t>         n_occ;
+     Heap<ElimLt>        elim_heap;
+     Queue<CRef>         subsumption_queue;
+     vec<char>           frozen;
+     vec<char>           eliminated;
+-    int                 bwdsub_assigns;
+-    int                 n_touched;
++    size_t              bwdsub_assigns;
++    size_t              n_touched;
+ 
+     // Temporaries:
+     //
+@@ -149,7 +149,7 @@
+     void          updateElimHeap           (Var v);
+     void          gatherTouchedClauses     ();
+     bool          merge                    (const Clause& _ps, const Clause& _qs, Var v, vec<Lit>& out_clause);
+-    bool          merge                    (const Clause& _ps, const Clause& _qs, Var v, int& size);
++    bool          merge                    (const Clause& _ps, const Clause& _qs, Var v, size_t& size);
+     bool          backwardSubsumptionCheck (bool verbose = false);
+     bool          eliminateVar             (Var v);
+     void          extendModel              ();
+diff -urN minisat-2.2.1/minisat/utils/Options.cc minisat-2.2.1.64/minisat/utils/Options.cc
+--- minisat-2.2.1/minisat/utils/Options.cc	2011-02-21 13:31:17.000000000 +0000
++++ minisat-2.2.1.64/minisat/utils/Options.cc	2018-03-15 16:37:30.636513704 +0000
+@@ -36,7 +36,7 @@
+         } else {
+             bool parsed_ok = false;
+         
+-            for (int k = 0; !parsed_ok && k < Option::getOptionList().size(); k++){
++            for (size_t k = 0; !parsed_ok && k < Option::getOptionList().size(); k++){
+                 parsed_ok = Option::getOptionList()[k]->parse(argv[i]);
+ 
+                 // fprintf(stderr, "checking %d: %s against flag <%s> (%s)\n", i, argv[i], Option::getOptionList()[k]->name, parsed_ok ? "ok" : "skip");
+@@ -67,7 +67,7 @@
+     const char* prev_cat  = NULL;
+     const char* prev_type = NULL;
+ 
+-    for (int i = 0; i < Option::getOptionList().size(); i++){
++    for (size_t i = 0; i < Option::getOptionList().size(); i++){
+         const char* cat  = Option::getOptionList()[i]->category;
+         const char* type = Option::getOptionList()[i]->type_name;
+ 
+diff -urN minisat-2.2.1/minisat/utils/ParseUtils.h minisat-2.2.1.64/minisat/utils/ParseUtils.h
+--- minisat-2.2.1/minisat/utils/ParseUtils.h	2018-03-21 14:54:06.918130658 +0000
++++ minisat-2.2.1.64/minisat/utils/ParseUtils.h	2018-03-15 16:38:52.080512053 +0000
+@@ -37,8 +37,8 @@
+ class StreamBuffer {
+     //gzFile        in;
+     unsigned char buf[buffer_size];
+-    int           pos;
+-    int           size;
++    size_t        pos;
++    size_t        size;
+ 
+     void assureLookahead() {
+         if (pos >= size) {
+@@ -50,7 +50,7 @@
+ 
+     int  operator *  () const { return (pos >= size) ? EOF : buf[pos]; }
+     void operator ++ ()       { pos++; assureLookahead(); }
+-    int  position    () const { return pos; }
++    size_t  position () const { return pos; }
+ };
+ 
+ 
+@@ -97,7 +97,7 @@
+ // number of characters.
+ template<class B>
+ static bool match(B& in, const char* str) {
+-    int i;
++    size_t i;
+     for (i = 0; str[i] != '\0'; i++)
+         if (in[i] != str[i])
+             return false;
+diff -urN minisat-2.2.1/minisat/utils/System.cc minisat-2.2.1.64/minisat/utils/System.cc
+--- minisat-2.2.1/minisat/utils/System.cc	2011-02-21 13:31:17.000000000 +0000
++++ minisat-2.2.1.64/minisat/utils/System.cc	2018-03-15 16:37:30.636513704 +0000
+@@ -27,25 +27,25 @@
+ 
+ using namespace Minisat;
+ 
+-static inline int memReadStat(int field)
++static inline size_t memReadStat(int field)
+ {
+     char  name[256];
+     pid_t pid = getpid();
+-    int   value;
++    size_t   value;
+ 
+     sprintf(name, "/proc/%d/statm", pid);
+     FILE* in = fopen(name, "rb");
+     if (in == NULL) return 0;
+ 
+     for (; field >= 0; field--)
+-        if (fscanf(in, "%d", &value) != 1)
++        if (fscanf(in, "%ld", &value) != 1)
+             printf("ERROR! Failed to parse memory statistics from \"/proc\".\n"), exit(1);
+     fclose(in);
+     return value;
+ }
+ 
+ 
+-static inline int memReadPeak(void)
++static inline size_t memReadPeak(void)
+ {
+     char  name[256];
+     pid_t pid = getpid();
+@@ -55,8 +55,8 @@
+     if (in == NULL) return 0;
+ 
+     // Find the correct line, beginning with "VmPeak:":
+-    int peak_kb = 0;
+-    while (!feof(in) && fscanf(in, "VmPeak: %d kB", &peak_kb) != 1)
++    size_t peak_kb = 0;
++    while (!feof(in) && fscanf(in, "VmPeak: %ld kB", &peak_kb) != 1)
+         while (!feof(in) && fgetc(in) != '\n')
+             ;
+     fclose(in);

--- a/src/Makefile
+++ b/src/Makefile
@@ -94,6 +94,7 @@ minisat2-download:
 	@rm -Rf ../minisat-2.2.1
 	@mv minisat2-2.2.1 ../minisat-2.2.1
 	@(cd ../minisat-2.2.1; patch -p1 < ../scripts/minisat-2.2.1-patch)
+	@(cd ../minisat-2.2.1; patch -p1 < ../scripts/minisat64.patch)
 	@rm minisat2_2.2.1.orig.tar.gz
 
 glucose-download:

--- a/src/solvers/CMakeLists.txt
+++ b/src/solvers/CMakeLists.txt
@@ -63,6 +63,7 @@ if("${sat_impl}" STREQUAL "minisat2")
     download_project(PROJ minisat2
         URL http://ftp.debian.org/debian/pool/main/m/minisat2/minisat2_2.2.1.orig.tar.gz
         PATCH_COMMAND patch -p1 -i ${CBMC_SOURCE_DIR}/../scripts/minisat-2.2.1-patch
+        COMMAND patch -p1 -i ${CBMC_SOURCE_DIR}/../scripts/minisat64.patch
         COMMAND cmake -E copy ${CBMC_SOURCE_DIR}/../scripts/minisat2_CMakeLists.txt CMakeLists.txt
     )
 

--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -11,7 +11,7 @@ ifneq ($(MINISAT),)
   MINISAT_INCLUDE=-I $(MINISAT)
   MINISAT_LIB=$(MINISAT)/Solver$(OBJEXT) $(MINISAT)/Proof$(OBJEXT) $(MINISAT)/File$(OBJEXT)
   CP_CXXFLAGS += -DHAVE_MINISAT
-  CLEANFILES += $(MINISAT_LIB) $(patsubst %$(OBJEXT), %.d, $(MINISAT_LIB))
+  CLEANFILES += $(MINISAT_LIB) $(patsubst %$(OBJEXT), %$(DEPEXT), $(MINISAT_LIB))
 endif
 
 ifneq ($(MINISAT2),)
@@ -19,7 +19,7 @@ ifneq ($(MINISAT2),)
   MINISAT2_INCLUDE=-I $(MINISAT2)
   MINISAT2_LIB=$(MINISAT2)/minisat/simp/SimpSolver$(OBJEXT) $(MINISAT2)/minisat/core/Solver$(OBJEXT)
   CP_CXXFLAGS += -DHAVE_MINISAT2 -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-  CLEANFILES += $(MINISAT2_LIB) $(patsubst %$(OBJEXT), %.d, $(MINISAT2_LIB))
+  CLEANFILES += $(MINISAT2_LIB) $(patsubst %$(OBJEXT), %$(DEPEXT), $(MINISAT2_LIB))
 endif
 
 ifneq ($(IPASIR),)
@@ -35,7 +35,7 @@ ifneq ($(GLUCOSE),)
   GLUCOSE_INCLUDE=-I $(GLUCOSE)
   GLUCOSE_LIB=$(GLUCOSE)/simp/SimpSolver$(OBJEXT) $(GLUCOSE)/core/Solver$(OBJEXT)
   CP_CXXFLAGS += -DHAVE_GLUCOSE -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-  CLEANFILES += $(GLUCOSE_LIB) $(patsubst %$(OBJEXT), %.d, $(GLUCOSE_LIB))
+  CLEANFILES += $(GLUCOSE_LIB) $(patsubst %$(OBJEXT), %$(DEPEXT), $(GLUCOSE_LIB))
 endif
 
 ifneq ($(SQUOLEM2),)
@@ -214,6 +214,11 @@ endif
 SOLVER_LIB = $(CHAFF_LIB) $(BOOLEFORCE_LIB) $(MINISAT_LIB) \
         $(MINISAT2_LIB) $(SQUOLEM2_LIB) $(CUDD_LIB) \
         $(PICOSAT_LIB) $(LINGELING_LIB) $(GLUCOSE_LIB) $(CADICAL_LIB)
+
+SOLVER_OBJS = $(filter %$(OBJEXT), $(SOLVER_LIB))
+ifneq ($(SOLVER_OBJS),)
+-include $(SOLVER_OBJS:$(OBJEXT)=$(DEPEXT))
+endif
 
 ###############################################################################
 

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -319,7 +319,7 @@ bool satcheck_minisat2_baset<T>::is_in_conflict(literalt a) const
 {
   int v=a.var_no();
 
-  for(int i=0; i<solver->conflict.size(); i++)
+  for(std::size_t i=0; i<solver->conflict.size(); i++)
     if(var(solver->conflict[i])==v)
       return true;
 

--- a/src/util/pragma_wstrict_aliasing.def
+++ b/src/util/pragma_wstrict_aliasing.def
@@ -1,0 +1,6 @@
+#if defined __clang__
+  #pragma clang diagnostic ignored "-Wstrict-aliasing"
+#elif defined __GNUC__
+  #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#elif defined _MSC_VER
+#endif


### PR DESCRIPTION
This enables Minisat to use more than 16GB of memory for storing clauses.