### PR TITLE
Add deprecate macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
     #   Ensure NDEBUG is not set for release builds
     set(CMAKE_CXX_FLAGS_RELEASE "-O2")
     #   Enable lots of warnings
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wpedantic -Werror")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wpedantic -Werror -Wno-error=deprecated-declarations")
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     #   This would be the place to enable warnings for Windows builds, although
     #   config.inc doesn't seem to do that currently

--- a/src/config.inc
+++ b/src/config.inc
@@ -5,7 +5,7 @@ BUILD_ENV = AUTO
 ifeq ($(BUILD_ENV),MSVC)
   #CXXFLAGS += /Wall /WX
 else
-  CXXFLAGS += -Wall -pedantic -Werror
+  CXXFLAGS += -Wall -pedantic -Werror -Wno-error=deprecated-declarations
 endif
 
 # Select optimisation or debug info

--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -18,6 +18,7 @@ Date: May 2016
 #include <util/make_unique.h>
 #include <util/cmdline.h>
 #include <util/options.h>
+#include <util/deprecate.h>
 
 #include "cover_basic_blocks.h"
 
@@ -51,6 +52,10 @@ void instrument_cover_goals(
 /// \deprecated use instrument_cover_goals(goto_programt &goto_program,
 /// const cover_instrumenterst &instrumenters,
 /// message_handlert &message_handler, const irep_idt mode) instead
+DEPRECATED(
+  "use instrument_cover_goals(goto_programt &goto_program,"
+  "const cover_instrumenterst &instrumenters,"
+  "message_handlert &message_handler, const irep_idt mode) instead")
 void instrument_cover_goals(
   const symbol_tablet &symbol_table,
   goto_programt &goto_program,

--- a/src/solvers/refinement/string_constraint_generator.h
+++ b/src/solvers/refinement/string_constraint_generator.h
@@ -25,6 +25,7 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include <util/replace_expr.h>
 #include <util/refined_string_type.h>
 #include <util/constexpr.def>
+#include <util/deprecate.h>
 #include <solvers/refinement/string_constraint.h>
 
 /// Generation of fresh symbols of a given type
@@ -351,6 +352,7 @@ private:
   /// \todo This function is underspecified, we do not compute the exact value
   /// but over approximate it.
   /// \deprecated This is Java specific and should be implemented in Java.
+  DEPRECATED("This is Java specific and should be implemented in Java")
   exprt add_axioms_for_code_point_count(const function_application_exprt &f);
 
   /// Add axioms corresponding the String.offsetByCodePointCount java function

--- a/src/solvers/refinement/string_constraint_generator_comparison.cpp
+++ b/src/solvers/refinement/string_constraint_generator_comparison.cpp
@@ -12,6 +12,7 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 ///   equals, equalsIgnoreCase, compareTo, hashCode, intern
 
 #include <solvers/refinement/string_constraint_generator.h>
+#include <util/deprecate.h>
 
 /// Equality of the content of two strings
 ///
@@ -267,6 +268,7 @@ exprt string_constraint_generatort::add_axioms_for_compare_to(
 /// \deprecated never tested
 /// \param f: function application with one string argument
 /// \return a string expression
+DEPRECATED("never tested")
 symbol_exprt string_constraint_generatort::add_axioms_for_intern(
   const function_application_exprt &f)
 {

--- a/src/solvers/refinement/string_constraint_generator_insert.cpp
+++ b/src/solvers/refinement/string_constraint_generator_insert.cpp
@@ -11,6 +11,7 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 
 #include <solvers/refinement/string_refinement_invariant.h>
 #include <solvers/refinement/string_constraint_generator.h>
+#include <util/deprecate.h>
 
 /// Add axioms ensuring the result `res` corresponds to `s1` where we
 /// inserted `s2` at position `offset`.
@@ -126,10 +127,11 @@ exprt string_constraint_generatort::add_axioms_for_insert(
 }
 
 /// add axioms corresponding to the StringBuilder.insert(I) java function
-/// \deprecated
+/// \deprecated should convert the value to string and call insert
 /// \param f: function application with three arguments: a string, an
 ///   integer offset, and an integer
 /// \return an expression
+DEPRECATED("should convert the value to string and call insert")
 exprt string_constraint_generatort::add_axioms_for_insert_int(
   const function_application_exprt &f)
 {
@@ -150,6 +152,7 @@ exprt string_constraint_generatort::add_axioms_for_insert_int(
 /// \param f: function application with three arguments: a string, an
 ///   integer offset, and a Boolean
 /// \return a new string expression
+DEPRECATED("should convert the value to string and call insert")
 exprt string_constraint_generatort::add_axioms_for_insert_bool(
   const function_application_exprt &f)
 {
@@ -190,6 +193,7 @@ exprt string_constraint_generatort::add_axioms_for_insert_char(
 /// \param f: function application with three arguments: a string, an
 ///   integer offset, and a double
 /// \return a string expression
+DEPRECATED("should convert the value to string and call insert")
 exprt string_constraint_generatort::add_axioms_for_insert_double(
   const function_application_exprt &f)
 {
@@ -211,6 +215,7 @@ exprt string_constraint_generatort::add_axioms_for_insert_double(
 /// \param f: function application with three arguments: a string, an
 ///   integer offset, and a float
 /// \return a new string expression
+DEPRECATED("should convert the value to string and call insert")
 exprt string_constraint_generatort::add_axioms_for_insert_float(
   const function_application_exprt &f)
 {

--- a/src/solvers/refinement/string_constraint_generator_main.cpp
+++ b/src/solvers/refinement/string_constraint_generator_main.cpp
@@ -26,6 +26,7 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include <util/pointer_predicates.h>
 #include <util/ssa_expr.h>
 #include <util/string_constant.h>
+#include <util/deprecate.h>
 
 string_constraint_generatort::string_constraint_generatort(
   const string_constraint_generatort::infot &info,
@@ -581,6 +582,7 @@ exprt string_constraint_generatort::add_axioms_for_function_application(
 /// \param f: function application with one argument, which is a string,
 /// or three arguments: string, integer offset and count
 /// \return a new string expression
+DEPRECATED("should use substring instead")
 exprt string_constraint_generatort::add_axioms_for_copy(
   const function_application_exprt &f)
 {

--- a/src/solvers/refinement/string_constraint_generator_testing.cpp
+++ b/src/solvers/refinement/string_constraint_generator_testing.cpp
@@ -12,6 +12,7 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 
 #include <solvers/refinement/string_refinement_invariant.h>
 #include <solvers/refinement/string_constraint_generator.h>
+#include <util/deprecate.h>
 
 /// Add axioms stating that the returned expression is true exactly when the
 /// first string is a prefix of the second one, starting at position offset.
@@ -97,6 +98,7 @@ exprt string_constraint_generatort::add_axioms_for_is_prefix(
 /// \deprecated should use `string_length(s)==0` instead
 /// \param f: function application with a string argument
 /// \return a Boolean expression
+DEPRECATED("should use `string_length(s)==0` instead")
 exprt string_constraint_generatort::add_axioms_for_is_empty(
   const function_application_exprt &f)
 {

--- a/src/solvers/refinement/string_constraint_generator_valueof.cpp
+++ b/src/solvers/refinement/string_constraint_generator_valueof.cpp
@@ -14,6 +14,7 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include <solvers/refinement/string_refinement_invariant.h>
 #include <solvers/refinement/string_constraint_generator.h>
 #include <util/simplify_expr.h>
+#include <util/deprecate.h>
 
 #include <cmath>
 #include <solvers/floatbv/float_bv.h>
@@ -40,6 +41,7 @@ exprt string_constraint_generatort::add_axioms_from_int(
 /// \deprecated should use add_axioms_from_int instead
 /// \param f: function application with one long argument
 /// \return a new string expression
+DEPRECATED("should use add_axioms_from_int instead")
 exprt string_constraint_generatort::add_axioms_from_long(
   const function_application_exprt &f)
 {
@@ -54,9 +56,10 @@ exprt string_constraint_generatort::add_axioms_from_long(
 }
 
 /// Add axioms corresponding to the String.valueOf(Z) java function.
-/// \deprecated this is specific to Java
+/// \deprecated This is Java specific and should be implemented in Java instead
 /// \param f: function application with a Boolean argument
 /// \return a new string expression
+DEPRECATED("This is Java specific and should be implemented in Java instead")
 exprt string_constraint_generatort::add_axioms_from_bool(
   const function_application_exprt &f)
 {
@@ -68,10 +71,11 @@ exprt string_constraint_generatort::add_axioms_from_bool(
 
 /// Add axioms stating that the returned string equals "true" when the Boolean
 /// expression is true and "false" when it is false.
-/// \deprecated This is language dependent
+/// \deprecated This is Java specific and should be implemented in Java instead
 /// \param res: string expression for the result
 /// \param b: Boolean expression
 /// \return code 0 on success
+DEPRECATED("This is Java specific and should be implemented in Java instead")
 exprt string_constraint_generatort::add_axioms_from_bool(
   const array_string_exprt &res,
   const exprt &b)
@@ -200,6 +204,7 @@ exprt string_constraint_generatort::int_of_hex_char(const exprt &chr)
 /// \param res: string expression for the result
 /// \param i: an integer argument
 /// \return code 0 on success
+DEPRECATED("use add_axioms_from_int which takes a radix argument instead")
 exprt string_constraint_generatort::add_axioms_from_int_hex(
   const array_string_exprt &res,
   const exprt &i)

--- a/src/util/arith_tools.h
+++ b/src/util/arith_tools.h
@@ -14,6 +14,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "optional.h"
 #include "invariant.h"
 
+#include "deprecate.h"
+
 class exprt;
 class constant_exprt;
 class typet;
@@ -21,10 +23,12 @@ class typet;
 // this one will go away
 // returns 'true' on error
 /// \deprecated: use the constant_exprt version instead
+DEPRECATED("Use the constant_exprt version instead")
 bool to_integer(const exprt &expr, mp_integer &int_value);
 
 // returns 'true' on error
 /// \deprecated: use numeric_cast<mp_integer> instead
+DEPRECATED("Use numeric_cast<mp_integer> instead")
 bool to_integer(const constant_exprt &expr, mp_integer &int_value);
 
 // returns 'true' on error

--- a/src/util/deprecate.h
+++ b/src/util/deprecate.h
@@ -1,0 +1,26 @@
+/*******************************************************************\
+
+Module:
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_DEPRECATE_H
+#define CPROVER_UTIL_DEPRECATE_H
+
+#if __cplusplus >= 201402L
+// C++14
+#define DEPRECATED(msg) [[deprecated(msg)]]
+#elif defined(__GNUC__)
+// GCC and GCC compatible compilers
+#define DEPRECATED(msg) __attribute__((deprecated(msg)))
+#elif defined(_MSC_VER)
+// Visual Studio
+#define DEPRECATED(msg) __declspec(deprecated(msg))
+#else
+// Compiler we don't know how to handle or that doesn't have deprecation support
+#define DEPRECATED(msg)
+#endif
+
+#endif // CPROVER_UTIL_DEPRECATE_H

--- a/src/util/mp_arith.h
+++ b/src/util/mp_arith.h
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "big-int/bigint.hh"
 #include "optional.h"
+#include "deprecate.h"
 
 // NOLINTNEXTLINE(readability/identifiers)
 typedef BigInt mp_integer;
@@ -52,12 +53,15 @@ const std::string integer2binary(const mp_integer &, std::size_t width);
 const mp_integer binary2integer(const std::string &, bool is_signed);
 
 /// \deprecated use numeric_cast<unsigned long long> instead
+DEPRECATED("Use numeric_cast<unsigned long long> instead")
 mp_integer::ullong_t integer2ulong(const mp_integer &);
 
 /// \deprecated use numeric_cast<std::size_t> instead
+DEPRECATED("Use numeric_cast<std::size_t> instead")
 std::size_t integer2size_t(const mp_integer &);
 
 /// \deprecated use numeric_cast<unsigned> instead
+DEPRECATED("Use numeric_cast<unsigned> instead")
 unsigned integer2unsigned(const mp_integer &);
 
 const mp_integer mp_zero=string2integer("0");


### PR DESCRIPTION
We currently have some "deprecated" functions, but we don't emit any diagnostics when they are used.

This adds a DEPRECATED macro that uses compiler builtins (or, when available, the C++14 `[[deprecated]]` attribute) to mark functions as deprecated.

To facilitate a gradual replacement of deprecated functionality deprecation warnings are not treated as errors.