### PR TITLE
Disable deprecation warnings by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
     #   Ensure NDEBUG is not set for release builds
     set(CMAKE_CXX_FLAGS_RELEASE "-O2")
     #   Enable lots of warnings
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wpedantic -Werror -Wno-error=deprecated-declarations")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wpedantic -Werror -Wno-deprecated-declarations")
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     #   This would be the place to enable warnings for Windows builds, although
     #   config.inc doesn't seem to do that currently

--- a/src/config.inc
+++ b/src/config.inc
@@ -5,7 +5,7 @@ BUILD_ENV = AUTO
 ifeq ($(BUILD_ENV),MSVC)
   #CXXFLAGS += /Wall /WX
 else
-  CXXFLAGS += -Wall -pedantic -Werror -Wno-error=deprecated-declarations
+  CXXFLAGS += -Wall -pedantic -Werror -Wno-deprecated-declarations
 endif
 
 # Select optimisation or debug info

--- a/src/util/arith_tools.h
+++ b/src/util/arith_tools.h
@@ -23,12 +23,12 @@ class typet;
 // this one will go away
 // returns 'true' on error
 /// \deprecated: use the constant_exprt version instead
-//DEPRECATED("Use the constant_exprt version instead")
+DEPRECATED("Use the constant_exprt version instead")
 bool to_integer(const exprt &expr, mp_integer &int_value);
 
 // returns 'true' on error
 /// \deprecated: use numeric_cast<mp_integer> instead
-//DEPRECATED("Use numeric_cast<mp_integer> instead")
+DEPRECATED("Use numeric_cast<mp_integer> instead")
 bool to_integer(const constant_exprt &expr, mp_integer &int_value);
 
 // returns 'true' on error

--- a/src/util/mp_arith.h
+++ b/src/util/mp_arith.h
@@ -53,15 +53,15 @@ const std::string integer2binary(const mp_integer &, std::size_t width);
 const mp_integer binary2integer(const std::string &, bool is_signed);
 
 /// \deprecated use numeric_cast<unsigned long long> instead
-//DEPRECATED("Use numeric_cast<unsigned long long> instead")
+DEPRECATED("Use numeric_cast<unsigned long long> instead")
 mp_integer::ullong_t integer2ulong(const mp_integer &);
 
 /// \deprecated use numeric_cast<std::size_t> instead
-//DEPRECATED("Use numeric_cast<std::size_t> instead")
+DEPRECATED("Use numeric_cast<std::size_t> instead")
 std::size_t integer2size_t(const mp_integer &);
 
 /// \deprecated use numeric_cast<unsigned> instead
-//DEPRECATED("Use numeric_cast<unsigned> instead")
+DEPRECATED("Use numeric_cast<unsigned> instead")
 unsigned integer2unsigned(const mp_integer &);
 
 const mp_integer mp_zero=string2integer("0");


### PR DESCRIPTION
Disable deprecation warnings by default, to avoid masking other issues with them.

See discussion on https://github.com/diffblue/cbmc/pull/2037