### PR TITLE
Increase parallelism in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,28 @@ jobs:
         - EXTRA_CXXFLAGS="-D_GLIBCXX_DEBUG"
       script: echo "Tests are run in the next stage."
 
+    # cmake build using g++-5
+    - stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 build
+      os: linux
+      compiler: gcc
+      cache: ccache
+      env:
+        - BUILD_SYSTEM=cmake
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      before_install:
+        - mkdir bin ; ln -s /usr/bin/gcc-5 bin/gcc
+      install:
+        - ccache -z
+        - ccache --max-size=1G
+        - cmake -H. -Bbuild '-DCMAKE_BUILD_TYPE=Release'  '-DCMAKE_CXX_COMPILER=/usr/bin/g++-5'
+        - cmake --build build -- -j4
+      script: echo "Tests are run in the next stage."
+
     # Ubuntu Linux with glibc using g++-5
     - stage: Test different OS/CXX/Flags
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -155,7 +155,6 @@ jobs:
             - libstdc++-5-dev
             - libubsan0
       before_install:
-        - export CCACHE_CPP2=yes
       # env: COMPILER=clang++-3.7 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined,integer -fno-omit-frame-pointer"
       env:
         - COMPILER="ccache /usr/bin/clang++-3.7"
@@ -252,7 +251,6 @@ jobs:
             - libc6-dev-i386
       before_install:
         - mkdir bin ; ln -s /usr/bin/gcc-5 bin/gcc
-        - export CCACHE_CPP2=yes
       # env: COMPILER=clang++-3.7 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined,integer -fno-omit-frame-pointer"
       env:
         - COMPILER="ccache /usr/bin/clang++-3.7"
@@ -276,7 +274,6 @@ jobs:
             - libstdc++-5-dev
             - libubsan0
       before_install:
-        - export CCACHE_CPP2=yes
       # env: COMPILER=clang++-3.7 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined,integer -fno-omit-frame-pointer"
       env:
         - NAME="DEBUG"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jobs:
   include:
 
     - &formatting-stage
-      stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 test
+      stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 build
       env: NAME="clang-format"
       addons:
         apt:
@@ -32,20 +32,20 @@ jobs:
       before_cache:
 
     - &linter-stage
-      stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 test
+      stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 build
       env: NAME="CPP-LINT"
       install:
       script: scripts/travis_lint.sh
       before_cache:
 
     - &string-table-check
-      stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 test
+      stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 build
       env: NAME="string-table"
       install:
       script: scripts/string_table_check.sh
       before_cache:
 
-    - stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 test
+    - stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 build
       env:
         NAME: "DOXYGEN-CHECK"
         DOXYGEN_VERSION: "1.8.14"
@@ -87,7 +87,30 @@ jobs:
         - scripts/publish_doc.sh
 
     # Ubuntu Linux with glibc using g++-5
-    - stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 test
+    - stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 build
+      os: linux
+      sudo: false
+      compiler: gcc
+      cache: ccache
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - libwww-perl
+            - g++-5
+            - libubsan0
+            - parallel
+      before_install:
+        - mkdir bin ; ln -s /usr/bin/gcc-5 bin/gcc
+      # env: COMPILER=g++-5 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover -fno-omit-frame-pointer"
+      env:
+        - COMPILER="ccache /usr/bin/g++-5"
+        - EXTRA_CXXFLAGS="-D_GLIBCXX_DEBUG"
+      script: echo "Tests are run in the next stage."
+
+    # Ubuntu Linux with glibc using g++-5
+    - stage: Test different OS/CXX/Flags
       os: linux
       sudo: false
       compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -184,6 +184,7 @@ jobs:
         - mkdir bin ; ln -s /usr/bin/gcc-5 bin/gcc
       # env: COMPILER=g++-5 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover -fno-omit-frame-pointer"
       env:
+        - NAME="DEBUG"
         - COMPILER="ccache /usr/bin/g++-5"
         - EXTRA_CXXFLAGS="-DDEBUG"
       script: echo "Not running any tests for a debug build."
@@ -215,7 +216,7 @@ jobs:
         - EXTRA_CXXFLAGS="-Qunused-arguments -fcolor-diagnostics -DNDEBUG"
         - CCACHE_CPP2=yes
 
-    # Ubuntu Linux with glibc using clang++-3.7, debug mode, disable USE_DSTRING
+    # Ubuntu Linux with glibc using clang++-3.7, debug mode
     - stage: Test different OS/CXX/Flags
       os: linux
       sudo: false
@@ -237,8 +238,9 @@ jobs:
         - export CCACHE_CPP2=yes
       # env: COMPILER=clang++-3.7 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined,integer -fno-omit-frame-pointer"
       env:
+        - NAME="DEBUG"
         - COMPILER="ccache /usr/bin/clang++-3.7"
-        - EXTRA_CXXFLAGS="-Qunused-arguments -fcolor-diagnostics -DDEBUG -DUSE_STD_STRING"
+        - EXTRA_CXXFLAGS="-Qunused-arguments -fcolor-diagnostics -DDEBUG"
         - CCACHE_CPP2=yes
       script: echo "Not running any tests for a debug build."
 
@@ -282,6 +284,28 @@ jobs:
         - cmake --build build -- -j4
       script: (cd build; ctest -V -L CORE -j2)
 
+    # Ubuntu Linux with glibc using g++-5, disable USE_DSTRING
+    - stage: Test different OS/CXX/Flags
+      os: linux
+      sudo: false
+      compiler: gcc
+      cache: ccache
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - libwww-perl
+            - g++-5
+            - libubsan0
+            - parallel
+      before_install:
+        - mkdir bin ; ln -s /usr/bin/gcc-5 bin/gcc
+      # env: COMPILER=g++-5 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover -fno-omit-frame-pointer"
+      env:
+        - NAME="USE_STD_STRING"
+        - COMPILER="ccache /usr/bin/g++-5"
+        - EXTRA_CXXFLAGS="-D_GLIBCXX_DEBUG -DUSE_STD_STRING"
 
     # Run Coverity
     - stage: Test different OS/CXX/Flags

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jobs:
   include:
 
     - &formatting-stage
-      stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 build
+      stage: Linter + Doxygen + non-debug builds
       env: NAME="clang-format"
       addons:
         apt:
@@ -32,20 +32,20 @@ jobs:
       before_cache:
 
     - &linter-stage
-      stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 build
+      stage: Linter + Doxygen + non-debug builds
       env: NAME="CPP-LINT"
       install:
       script: scripts/travis_lint.sh
       before_cache:
 
     - &string-table-check
-      stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 build
+      stage: Linter + Doxygen + non-debug builds
       env: NAME="string-table"
       install:
       script: scripts/string_table_check.sh
       before_cache:
 
-    - stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 build
+    - stage: Linter + Doxygen + non-debug builds
       env:
         NAME: "DOXYGEN-CHECK"
         DOXYGEN_VERSION: "1.8.14"
@@ -87,7 +87,7 @@ jobs:
         - scripts/publish_doc.sh
 
     # Ubuntu Linux with glibc using g++-5
-    - stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 build
+    - stage: Linter + Doxygen + non-debug builds
       os: linux
       sudo: false
       compiler: gcc
@@ -110,7 +110,7 @@ jobs:
       script: echo "Tests are run in the next stage."
 
     # cmake build using g++-5
-    - stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 build
+    - stage: Linter + Doxygen + non-debug builds
       os: linux
       compiler: gcc
       cache: ccache
@@ -131,8 +131,48 @@ jobs:
         - cmake --build build -- -j4
       script: echo "Tests are run in the next stage."
 
+    # OS X using clang++
+    - stage: Linter + Doxygen + non-debug builds
+      os: osx
+      sudo: false
+      compiler: clang
+      cache: ccache
+      before_install:
+        - HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache parallel
+        - export PATH=$PATH:/usr/local/opt/ccache/libexec
+      env: COMPILER="ccache clang++"
+      script: echo "Tests are run in the next stage."
+
+    # Ubuntu Linux with glibc using clang++-3.7, no-debug mode
+    - stage: Linter + Doxygen + non-debug builds
+      os: linux
+      sudo: false
+      compiler: clang
+      cache: ccache
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+          packages:
+            - libwww-perl
+            - clang-3.7
+            - libstdc++-5-dev
+            - libubsan0
+            - parallel
+            - libc6-dev-i386
+      before_install:
+        - mkdir bin ; ln -s /usr/bin/gcc-5 bin/gcc
+        - export CCACHE_CPP2=yes
+      # env: COMPILER=clang++-3.7 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined,integer -fno-omit-frame-pointer"
+      env:
+        - COMPILER="ccache /usr/bin/clang++-3.7"
+        - EXTRA_CXXFLAGS="-Qunused-arguments -fcolor-diagnostics -DNDEBUG"
+        - CCACHE_CPP2=yes
+      script: echo "Tests are run in the next stage."
+
     # Ubuntu Linux with glibc using g++-5
-    - stage: Test different OS/CXX/Flags
+    - stage: Linter + Doxygen + non-debug builds
       os: linux
       sudo: false
       compiler: gcc
@@ -153,6 +193,24 @@ jobs:
       env:
         - COMPILER="ccache /usr/bin/g++-5"
         - EXTRA_CXXFLAGS="-D_GLIBCXX_DEBUG"
+      script: echo "Tests are run in the next stage."
+
+    - stage: Linter + Doxygen + non-debug builds
+      os: osx
+      compiler: clang
+      cache: ccache
+      before_install:
+        - HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache
+        - export PATH=$PATH:/usr/local/opt/ccache/libexec
+      env:
+        - BUILD_SYSTEM=cmake
+        - CCACHE_CPP2=yes
+      install:
+        - ccache -z
+        - ccache --max-size=1G
+        - cmake -H. -Bbuild '-DCMAKE_BUILD_TYPE=Release' '-DCMAKE_OSX_ARCHITECTURES=x86_64'
+        - cmake --build build -- -j4
+      script: echo "Tests are run in the next stage."
 
     # OS X using clang++
     - stage: Test different OS/CXX/Flags

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,9 +100,6 @@ jobs:
             - libwww-perl
             - g++-5
             - libubsan0
-            - parallel
-      before_install:
-        - mkdir bin ; ln -s /usr/bin/gcc-5 bin/gcc
       # env: COMPILER=g++-5 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover -fno-omit-frame-pointer"
       env:
         - COMPILER="ccache /usr/bin/g++-5"
@@ -122,8 +119,6 @@ jobs:
             - ubuntu-toolchain-r-test
           packages:
             - g++-5
-      before_install:
-        - mkdir bin ; ln -s /usr/bin/gcc-5 bin/gcc
       install:
         - ccache -z
         - ccache --max-size=1G
@@ -159,10 +154,7 @@ jobs:
             - clang-3.7
             - libstdc++-5-dev
             - libubsan0
-            - parallel
-            - libc6-dev-i386
       before_install:
-        - mkdir bin ; ln -s /usr/bin/gcc-5 bin/gcc
         - export CCACHE_CPP2=yes
       # env: COMPILER=clang++-3.7 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined,integer -fno-omit-frame-pointer"
       env:
@@ -185,10 +177,6 @@ jobs:
             - libwww-perl
             - g++-5
             - libubsan0
-            - parallel
-            - libc6-dev-i386
-      before_install:
-        - mkdir bin ; ln -s /usr/bin/gcc-5 bin/gcc
       # env: COMPILER=g++-5 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover -fno-omit-frame-pointer"
       env:
         - COMPILER="ccache /usr/bin/g++-5"
@@ -237,9 +225,6 @@ jobs:
             - libwww-perl
             - g++-5
             - libubsan0
-            - libc6-dev-i386
-      before_install:
-        - mkdir bin ; ln -s /usr/bin/gcc-5 bin/gcc
       # env: COMPILER=g++-5 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover -fno-omit-frame-pointer"
       env:
         - NAME="DEBUG"
@@ -290,9 +275,7 @@ jobs:
             - clang-3.7
             - libstdc++-5-dev
             - libubsan0
-            - libc6-dev-i386
       before_install:
-        - mkdir bin ; ln -s /usr/bin/gcc-5 bin/gcc
         - export CCACHE_CPP2=yes
       # env: COMPILER=clang++-3.7 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined,integer -fno-omit-frame-pointer"
       env:


### PR DESCRIPTION
~Rarely used configuration options (aka preprocessor defines) that are not
generally used in production settings can safely be tested at cron-defined
intervals only rather than upon every PR/change to a PR.~

~The remaining non-cron builds are: {GCC, Clang} x {Linux, OS X} +
CMake/GCC/Linux.~

The changes proposed here break up large build+test tasks into separate steps so that as much work as possible can be done in parallel, resulting in failures being reported as soon as possible.