### PR TITLE
[TG-2717] Generic inheritance with pointer replacement

### DIFF
--- a/src/java_bytecode/java_object_factory.cpp
+++ b/src/java_bytecode/java_object_factory.cpp
@@ -766,6 +766,13 @@ void java_object_factoryt::gen_nondet_pointer_init(
   // for java types, technical debt TG-2707
   if(!equal_java_types(replacement_pointer_type, pointer_type))
   {
+    // update generic_parameter_specialization_map for the new pointer
+    generic_parameter_specialization_map_keyst
+      generic_parameter_specialization_map_keys(
+        generic_parameter_specialization_map);
+    generic_parameter_specialization_map_keys.insert_pairs_for_pointer(
+      replacement_pointer_type, ns.follow(replacement_pointer_type.subtype()));
+
     const symbol_exprt real_pointer_symbol = gen_nondet_subtype_pointer_init(
       assignments, alloc_type, replacement_pointer_type, depth);
 

--- a/src/java_bytecode/java_types.h
+++ b/src/java_bytecode/java_types.h
@@ -604,6 +604,19 @@ public:
   {
     return (generic_typest &)(add(ID_generic_types).get_sub());
   }
+
+  /// Check if this symbol has the given generic type. If yes, return its index
+  /// in the vector of generic types.
+  /// \param type The type we are looking for.
+  /// \return The index of the type in the vector of generic types.
+  optionalt<size_t> generic_type_index(const reference_typet &type) const
+  {
+    const auto &type_pointer =
+      std::find(generic_types().begin(), generic_types().end(), type);
+    if(type_pointer != generic_types().end())
+      return type_pointer - generic_types().begin();
+    return {};
+  }
 };
 
 /// \param type: the type to check

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -407,6 +407,19 @@ public:
     return false;
   }
 
+  /// Return the base with the given name, if exists.
+  /// \param id The name of the base we are looking for.
+  /// \return The base if exists.
+  optionalt<baset> get_base(const irep_idt &id) const
+  {
+    for(const auto &b : bases())
+    {
+      if(to_symbol_type(b.type()).get_identifier() == id)
+        return b;
+    }
+    return {};
+  }
+
   bool is_abstract() const
   {
     return get_bool(ID_abstract);

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -396,17 +396,6 @@ public:
     bases().push_back(baset(base));
   }
 
-  bool has_base(const irep_idt &id) const
-  {
-    for(const auto &b : bases())
-    {
-      if(to_symbol_type(b.type()).get(ID_identifier)==id)
-        return true;
-    }
-
-    return false;
-  }
-
   /// Return the base with the given name, if exists.
   /// \param id The name of the base we are looking for.
   /// \return The base if exists.
@@ -418,6 +407,11 @@ public:
         return b;
     }
     return {};
+  }
+
+  bool has_base(const irep_idt &id) const
+  {
+    return get_base(id).has_value();
   }
 
   bool is_abstract() const


### PR DESCRIPTION
When initiliazing a pointer and it is replaced by a different pointer (due to inheritance) we make sure that the generic parameter specialization map is updated too. For example, if we see a pointer to `Interface<Integer>` and there exists a class `A<T> implements Interface<T>` then we will be replacing the pointer with a pointer to `A<Integer>`. This PR makes sure that the generic type `A::T` is mapped to `Integer`.

Since CBMC does not construct replacement pointers, this change has no effect in CBMC itself (hence no unit tests or regression tests). The change is utilized in test generator: https://github.com/diffblue/test-gen/pull/1695.