### PR TITLE
Get legalistic about use of virtual with override

### DIFF
--- a/CODING_STANDARD.md
+++ b/CODING_STANDARD.md
@@ -154,6 +154,7 @@ Formatting is enforced using clang-format. For more information about this, see
 - Make member functions `const` whenever possible
 - Do not hide base class functions
 - You are encouraged to use `override`
+- When using `override` also use `virtual`
 - Single argument constructors must be `explicit`
 - Avoid implicit conversions
 - Avoid `friend` declarations


### PR DESCRIPTION
I recently had a comment on a PR complaining that I used the redundant `virtual` on a method declaration that I marked `override`.
I replied that the redundant virtual is useful documentation as it allows developers to see whether a function is virtual in a single place without having to check the beginning and the end of the declaration.
Another reviewer pointed out that our linter was specifically adjusted to allow this format here: https://github.com/diffblue/cbmc/commit/a7c24fb631d7ca017f4fad00320b6270ddc4f4c8#diff-4abdbb2a75f622bb69ca7ae19beee7c6R5647.
An analysis of the code base for CBMC shows that we have 457 uses of `override`, of which 154 combine it with `virtual`. Deeptest has a similar proportion with 22 of 64 uses using the combined version.
My hope with this PR is that it will ignite a style war that will get nowhere and result in this PR being closed. This will then be the definitive point of reference for allowing people to do whatever they feel most comfortable with.