### PR TITLE
Refactor java_bytecode_convert_methodt::convert_instructions

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1929,17 +1929,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
     }
     else if(statement=="monitorenter")
     {
-      // becomes a function call
-      code_typet type;
-      type.return_type()=void_typet();
-      type.parameters().resize(1);
-      type.parameters()[0].type()=java_reference_type(void_typet());
-      code_function_callt call;
-      call.function()=symbol_exprt("java::monitorenter", type);
-      call.lhs().make_nil();
-      call.arguments().push_back(op[0]);
-      call.add_source_location()=i_it->source_location;
-      c=call;
+      c = convert_monitorenter(i_it->source_location, op);
     }
     else if(statement=="monitorexit")
     {
@@ -2308,6 +2298,22 @@ codet java_bytecode_convert_methodt::convert_instructions(
     code.move_to_operands(block);
 
   return code;
+}
+
+codet java_bytecode_convert_methodt::convert_monitorenter(
+  const source_locationt &location,
+  const exprt::operandst &op) const
+{
+  code_typet type;
+  type.return_type() = void_typet();
+  type.parameters().resize(1);
+  type.parameters()[0].type() = java_reference_type(void_typet());
+  code_function_callt call;
+  call.function() = symbol_exprt("java::monitorenter", type);
+  call.lhs().make_nil();
+  call.arguments().push_back(op[0]);
+  call.add_source_location() = location;
+  return call;
 }
 
 void java_bytecode_convert_methodt::convert_multianewarray(

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1068,10 +1068,9 @@ codet java_bytecode_convert_methodt::convert_instructions(
       if(i_it->statement=="jsr" ||
          i_it->statement=="jsr_w")
       {
-        assert(
-          next!=instructions.end() &&
-          "jsr without valid return address?");
         auto next = std::next(i_it);
+        DATA_INVARIANT(
+          next != instructions.end(), "jsr should have valid return address");
         targets.insert(next->address);
         jsr_ret_targets.push_back(next->address);
       }

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1614,28 +1614,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
     }
     else if(statement=="iinc")
     {
-      code_blockt block;
-      block.add_source_location()=i_it->source_location;
-      // search variable on stack
-      const exprt &locvar=variable(arg0, 'i', i_it->address, NO_CAST);
-      save_stack_entries(
-        "stack_iinc",
-        java_int_type(),
-        block,
-        bytecode_write_typet::VARIABLE,
-        to_symbol_expr(locvar).get_identifier());
-
-      code_assignt code_assign;
-      code_assign.lhs()=
-        variable(arg0, 'i', i_it->address, NO_CAST);
-      exprt arg1_int_type=arg1;
-      if(arg1.type()!=java_int_type())
-        arg1_int_type.make_typecast(java_int_type());
-      code_assign.rhs()=plus_exprt(
-        variable(arg0, 'i', i_it->address, CAST_AS_NEEDED),
-        arg1_int_type);
-      block.copy_to_operands(code_assign);
-      c=block;
+      c = convert_iinc(arg0, arg1, i_it->source_location, i_it->address);
     }
     else if(statement==patternt("?xor"))
     {
@@ -2541,6 +2520,34 @@ codet java_bytecode_convert_methodt::convert_instructions(
     code.move_to_operands(block);
 
   return code;
+}
+
+codet java_bytecode_convert_methodt::convert_iinc(
+  const exprt &arg0,
+  const exprt &arg1,
+  const source_locationt &location,
+  const unsigned address)
+{
+  code_blockt block;
+  block.add_source_location() = location;
+  // search variable on stack
+  const exprt &locvar = variable(arg0, 'i', address, NO_CAST);
+  save_stack_entries(
+    "stack_iinc",
+    java_int_type(),
+    block,
+    bytecode_write_typet::VARIABLE,
+    to_symbol_expr(locvar).get_identifier());
+
+  code_assignt code_assign;
+  code_assign.lhs() = variable(arg0, 'i', address, NO_CAST);
+  exprt arg1_int_type = arg1;
+  if(arg1.type() != java_int_type())
+    arg1_int_type.make_typecast(java_int_type());
+  code_assign.rhs() =
+    plus_exprt(variable(arg0, 'i', address, CAST_AS_NEEDED), arg1_int_type);
+  block.copy_to_operands(code_assign);
+  return block;
 }
 
 codet java_bytecode_convert_methodt::convert_ifnull(

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1933,17 +1933,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
     }
     else if(statement=="monitorexit")
     {
-      // becomes a function call
-      code_typet type;
-      type.return_type()=void_typet();
-      type.parameters().resize(1);
-      type.parameters()[0].type()=java_reference_type(void_typet());
-      code_function_callt call;
-      call.function()=symbol_exprt("java::monitorexit", type);
-      call.lhs().make_nil();
-      call.arguments().push_back(op[0]);
-      call.add_source_location()=i_it->source_location;
-      c=call;
+      c = convert_monitorexit(i_it->source_location, op);
     }
     else if(statement=="swap")
     {
@@ -2307,6 +2297,22 @@ codet &java_bytecode_convert_methodt::do_exception_handling(
     }
   }
   return c;
+}
+
+codet java_bytecode_convert_methodt::convert_monitorexit(
+  const source_locationt &location,
+  const exprt::operandst &op) const
+{
+  code_typet type;
+  type.return_type() = void_typet();
+  type.parameters().resize(1);
+  type.parameters()[0].type() = java_reference_type(void_typet());
+  code_function_callt call;
+  call.function() = symbol_exprt("java::monitorexit", type);
+  call.lhs().make_nil();
+  call.arguments().push_back(op[0]);
+  call.add_source_location() = location;
+  return call;
 }
 
 codet java_bytecode_convert_methodt::convert_monitorenter(

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1794,15 +1794,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
     else if(statement=="putfield")
     {
       PRECONDITION(op.size() == 2 && results.empty());
-      code_blockt block;
-      save_stack_entries(
-        "stack_field",
-        op[1].type(),
-        block,
-        bytecode_write_typet::FIELD,
-        arg0.get(ID_component_name));
-      block.copy_to_operands(code_assignt(to_member(op[0], arg0), op[1]));
-      c=block;
+      c = convert_putfield(arg0, op);
     }
     else if(statement=="putstatic")
     {
@@ -2433,8 +2425,23 @@ codet java_bytecode_convert_methodt::convert_instructions(
   return code;
 }
 
+codet java_bytecode_convert_methodt::convert_putfield(
+  const exprt &arg0,
+  const exprt::operandst &op)
+{
+  code_blockt block;
+  save_stack_entries(
+    "stack_field",
+    op[1].type(),
+    block,
+    bytecode_write_typet::FIELD,
+    arg0.get(ID_component_name));
+  block.copy_to_operands(code_assignt(to_member(op[0], arg0), op[1]));
+  return block;
+}
+
 void java_bytecode_convert_methodt::convert_getstatic(
-  exprt &arg0,
+  const exprt &arg0,
   const symbol_exprt &symbol_expr,
   const bool is_assertions_disabled_field,
   codet &c,

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1602,16 +1602,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
       mp_integer number;
       bool ret=to_integer(to_constant_expr(arg0), number);
       INVARIANT(!ret, "ifnonnull argument should be an integer");
-      code_ifthenelset code_branch;
-      const typecast_exprt lhs(op[0], java_reference_type(empty_typet()));
-      const exprt rhs(null_pointer_exprt(to_pointer_type(lhs.type())));
-      code_branch.cond()=binary_relation_exprt(lhs, ID_notequal, rhs);
-      code_branch.then_case()=code_gotot(label(integer2string(number)));
-      code_branch.then_case().add_source_location()=
-        address_map.at(integer2unsigned(number)).source->source_location;
-      code_branch.add_source_location()=i_it->source_location;
-
-      c=code_branch;
+      c = convert_ifnonull(address_map, op, number, i_it->source_location);
     }
     else if(statement==patternt("ifnull"))
     {
@@ -2559,6 +2550,23 @@ codet java_bytecode_convert_methodt::convert_instructions(
     code.move_to_operands(block);
 
   return code;
+}
+
+codet java_bytecode_convert_methodt::convert_ifnonull(
+  const java_bytecode_convert_methodt::address_mapt &address_map,
+  const exprt::operandst &op,
+  const mp_integer &number,
+  const source_locationt &location) const
+{
+  code_ifthenelset code_branch;
+  const typecast_exprt lhs(op[0], java_reference_type(empty_typet()));
+  const exprt rhs(null_pointer_exprt(to_pointer_type(lhs.type())));
+  code_branch.cond() = binary_relation_exprt(lhs, ID_notequal, rhs);
+  code_branch.then_case() = code_gotot(label(integer2string(number)));
+  code_branch.then_case().add_source_location() =
+    address_map.at(integer2unsigned(number)).source->source_location;
+  code_branch.add_source_location() = location;
+  return code_branch;
 }
 
 codet java_bytecode_convert_methodt::convert_if(

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1213,12 +1213,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
     else if(statement=="athrow")
     {
       PRECONDITION(op.size() == 1 && results.size() == 1);
-
-      side_effect_expr_throwt throw_expr;
-      throw_expr.add_source_location()=i_it->source_location;
-      throw_expr.copy_to_operands(op[0]);
-      c=code_expressiont(throw_expr);
-      results[0]=op[0];
+      convert_athrow(i_it->source_location, op, c, results);
     }
     else if(statement=="checkcast")
     {
@@ -2186,6 +2181,19 @@ codet java_bytecode_convert_methodt::convert_instructions(
     code.move_to_operands(block);
 
   return code;
+}
+
+void java_bytecode_convert_methodt::convert_athrow(
+  const source_locationt &location,
+  const exprt::operandst &op,
+  codet &c,
+  exprt::operandst &results) const
+{
+  side_effect_expr_throwt throw_expr;
+  throw_expr.add_source_location() = location;
+  throw_expr.copy_to_operands(op[0]);
+  c = code_expressiont(throw_expr);
+  results[0] = op[0];
 }
 
 codet &java_bytecode_convert_methodt::do_exception_handling(

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1590,25 +1590,11 @@ codet java_bytecode_convert_methodt::convert_instructions(
         irep_idt();
 
       INVARIANT(!id.empty(), "unexpected bytecode-if");
-
       PRECONDITION(op.size() == 1 && results.empty());
       mp_integer number;
       bool ret=to_integer(to_constant_expr(arg0), number);
       INVARIANT(!ret, "if?? argument should be an integer");
-
-      code_ifthenelset code_branch;
-      code_branch.cond()=
-        binary_relation_exprt(op[0], id, from_integer(0, op[0].type()));
-      code_branch.cond().add_source_location()=i_it->source_location;
-      code_branch.cond().add_source_location().set_function(method_id);
-      code_branch.then_case()=code_gotot(label(integer2string(number)));
-      code_branch.then_case().add_source_location()=
-        address_map.at(integer2unsigned(number)).source->source_location;
-      code_branch.then_case().add_source_location().set_function(method_id);
-      code_branch.add_source_location()=i_it->source_location;
-      code_branch.add_source_location().set_function(method_id);
-
-      c=code_branch;
+      c = convert_if(address_map, op, id, number, i_it->source_location);
     }
     else if(statement==patternt("ifnonnull"))
     {
@@ -2573,6 +2559,27 @@ codet java_bytecode_convert_methodt::convert_instructions(
     code.move_to_operands(block);
 
   return code;
+}
+
+codet java_bytecode_convert_methodt::convert_if(
+  const java_bytecode_convert_methodt::address_mapt &address_map,
+  const exprt::operandst &op,
+  const irep_idt &id,
+  const mp_integer &number,
+  const source_locationt &location) const
+{
+  code_ifthenelset code_branch;
+  code_branch.cond() =
+    binary_relation_exprt(op[0], id, from_integer(0, op[0].type()));
+  code_branch.cond().add_source_location() = location;
+  code_branch.cond().add_source_location().set_function(method_id);
+  code_branch.then_case() = code_gotot(label(integer2string(number)));
+  code_branch.then_case().add_source_location() =
+    address_map.at(integer2unsigned(number)).source->source_location;
+  code_branch.then_case().add_source_location().set_function(method_id);
+  code_branch.add_source_location() = location;
+  code_branch.add_source_location().set_function(method_id);
+  return code_branch;
 }
 
 codet java_bytecode_convert_methodt::convert_if_cmp(

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1091,17 +1091,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
       ret_instructions.push_back(i_it);
     }
   }
-
-  // Draw edges from every `ret` to every `jsr` successor. Could do better with
-  // flow analysis to distinguish multiple subroutines within the same function.
-  for(const auto retinst : ret_instructions)
-  {
-    auto &a_entry=address_map.at(retinst->address);
-    a_entry.successors.insert(
-      a_entry.successors.end(),
-      jsr_ret_targets.begin(),
-      jsr_ret_targets.end());
-  }
+  draw_edges_from_ret_to_jsr(address_map, jsr_ret_targets, ret_instructions);
 
   for(const auto &address : address_map)
   {
@@ -2717,6 +2707,22 @@ codet java_bytecode_convert_methodt::convert_instructions(
     code.move_to_operands(block);
 
   return code;
+}
+
+void java_bytecode_convert_methodt::draw_edges_from_ret_to_jsr(
+  java_bytecode_convert_methodt::address_mapt &address_map,
+  const std::vector<unsigned int> &jsr_ret_targets,
+  const std::vector<
+    std::vector<java_bytecode_parse_treet::instructiont>::const_iterator>
+    &ret_instructions) const
+{ // Draw edges from every `ret` to every `jsr` successor. Could do better with
+  // flow analysis to distinguish multiple subroutines within the same function.
+  for(const auto &retinst : ret_instructions)
+  {
+    auto &a_entry = address_map.at(retinst->address);
+    a_entry.successors.insert(
+      a_entry.successors.end(), jsr_ret_targets.begin(), jsr_ret_targets.end());
+  }
 }
 
 std::vector<unsigned> java_bytecode_convert_methodt::try_catch_handler(

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1504,14 +1504,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
     else if(statement=="dup2")
     {
       PRECONDITION(!stack.empty() && results.empty());
-
-      if(get_bytecode_type_width(stack.back().type())==32)
-        op=pop(2);
-      else
-        op=pop(1);
-
-      results.insert(results.end(), op.begin(), op.end());
-      results.insert(results.end(), op.begin(), op.end());
+      convert_dup2(op, results);
     }
     else if(statement=="dup2_x1")
     {
@@ -1971,6 +1964,19 @@ codet java_bytecode_convert_methodt::convert_instructions(
     code.move_to_operands(block);
 
   return code;
+}
+
+void java_bytecode_convert_methodt::convert_dup2(
+  exprt::operandst &op,
+  exprt::operandst &results)
+{
+  if(get_bytecode_type_width(stack.back().type()) == 32)
+    op = pop(2);
+  else
+    op = pop(1);
+
+  results.insert(results.end(), op.begin(), op.end());
+  results.insert(results.end(), op.begin(), op.end());
 }
 
 exprt::operandst &java_bytecode_convert_methodt::convert_const(

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1610,16 +1610,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
       mp_integer number;
       bool ret=to_integer(to_constant_expr(arg0), number);
       INVARIANT(!ret, "ifnull argument should be an integer");
-      code_ifthenelset code_branch;
-      const typecast_exprt lhs(op[0], java_reference_type(empty_typet()));
-      const exprt rhs(null_pointer_exprt(to_pointer_type(lhs.type())));
-      code_branch.cond()=binary_relation_exprt(lhs, ID_equal, rhs);
-      code_branch.then_case()=code_gotot(label(integer2string(number)));
-      code_branch.then_case().add_source_location()=
-        address_map.at(integer2unsigned(number)).source->source_location;
-      code_branch.add_source_location()=i_it->source_location;
-
-      c=code_branch;
+      c = convert_ifnull(address_map, op, number, i_it->source_location);
     }
     else if(statement=="iinc")
     {
@@ -2550,6 +2541,23 @@ codet java_bytecode_convert_methodt::convert_instructions(
     code.move_to_operands(block);
 
   return code;
+}
+
+codet java_bytecode_convert_methodt::convert_ifnull(
+  const java_bytecode_convert_methodt::address_mapt &address_map,
+  const exprt::operandst &op,
+  const mp_integer &number,
+  const source_locationt &location) const
+{
+  code_ifthenelset code_branch;
+  const typecast_exprt lhs(op[0], java_reference_type(empty_typet()));
+  const exprt rhs(null_pointer_exprt(to_pointer_type(lhs.type())));
+  code_branch.cond() = binary_relation_exprt(lhs, ID_equal, rhs);
+  code_branch.then_case() = code_gotot(label(integer2string(number)));
+  code_branch.then_case().add_source_location() =
+    address_map.at(integer2unsigned(number)).source->source_location;
+  code_branch.add_source_location() = location;
+  return code_branch;
 }
 
 codet java_bytecode_convert_methodt::convert_ifnonull(

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1509,14 +1509,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
     else if(statement=="dup2_x1")
     {
       PRECONDITION(!stack.empty() && results.empty());
-
-      if(get_bytecode_type_width(stack.back().type())==32)
-        op=pop(3);
-      else
-        op=pop(2);
-
-      results.insert(results.end(), op.begin()+1, op.end());
-      results.insert(results.end(), op.begin(), op.end());
+      convert_dup2_x1(op, results);
     }
     else if(statement=="dup2_x2")
     {
@@ -1976,6 +1969,19 @@ void java_bytecode_convert_methodt::convert_dup2(
     op = pop(1);
 
   results.insert(results.end(), op.begin(), op.end());
+  results.insert(results.end(), op.begin(), op.end());
+}
+
+void java_bytecode_convert_methodt::convert_dup2_x1(
+  exprt::operandst &op,
+  exprt::operandst &results)
+{
+  if(get_bytecode_type_width(stack.back().type()) == 32)
+    op = pop(3);
+  else
+    op = pop(2);
+
+  results.insert(results.end(), op.begin() + 1, op.end());
   results.insert(results.end(), op.begin(), op.end());
 }
 

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1644,21 +1644,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
     else if(statement==patternt("?ushr"))
     {
       PRECONDITION(op.size() == 2 && results.size() == 1);
-      const typet type=java_type_from_char(statement[0]);
-
-      const std::size_t width=type.get_size_t(ID_width);
-      typet target=unsignedbv_typet(width);
-
-      exprt lhs=op[0];
-      if(lhs.type()!=target)
-        lhs.make_typecast(target);
-      exprt rhs=op[1];
-      if(rhs.type()!=target)
-        rhs.make_typecast(target);
-
-      results[0]=lshr_exprt(lhs, rhs);
-      if(results[0].type()!=op[0].type())
-        results[0].make_typecast(op[0].type());
+      results = convert_ushr(statement, op, results);
     }
     else if(statement==patternt("?add"))
     {
@@ -2520,6 +2506,29 @@ codet java_bytecode_convert_methodt::convert_instructions(
     code.move_to_operands(block);
 
   return code;
+}
+
+exprt::operandst &java_bytecode_convert_methodt::convert_ushr(
+  const irep_idt &statement,
+  const exprt::operandst &op,
+  exprt::operandst &results) const
+{
+  const typet type = java_type_from_char(statement[0]);
+
+  const std::size_t width = type.get_size_t(ID_width);
+  typet target = unsignedbv_typet(width);
+
+  exprt lhs = op[0];
+  if(lhs.type() != target)
+    lhs.make_typecast(target);
+  exprt rhs = op[1];
+  if(rhs.type() != target)
+    rhs.make_typecast(target);
+
+  results[0] = lshr_exprt(lhs, rhs);
+  if(results[0].type() != op[0].type())
+    results[0].make_typecast(op[0].type());
+  return results;
 }
 
 codet java_bytecode_convert_methodt::convert_iinc(

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1221,14 +1221,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
       // on stack to given type fails.
       // The stack isn't modified.
       PRECONDITION(op.size() == 1 && results.size() == 1);
-      binary_predicate_exprt check(op[0], ID_java_instanceof, arg0);
-      code_assertt assert_class(check);
-      assert_class.add_source_location().set_comment("Dynamic cast check");
-      assert_class.add_source_location().set_property_class("bad-dynamic-cast");
-      // we add this assert such that we can recognise it
-      // during the instrumentation phase
-      c=std::move(assert_class);
-      results[0]=op[0];
+      convert_checkcast(arg0, op, c, results);
     }
     else if(statement=="invokedynamic")
     {
@@ -2181,6 +2174,22 @@ codet java_bytecode_convert_methodt::convert_instructions(
     code.move_to_operands(block);
 
   return code;
+}
+
+void java_bytecode_convert_methodt::convert_checkcast(
+  const exprt &arg0,
+  const exprt::operandst &op,
+  codet &c,
+  exprt::operandst &results) const
+{
+  binary_predicate_exprt check(op[0], ID_java_instanceof, arg0);
+  code_assertt assert_class(check);
+  assert_class.add_source_location().set_comment("Dynamic cast check");
+  assert_class.add_source_location().set_property_class("bad-dynamic-cast");
+  // we add this assert such that we can recognise it
+  // during the instrumentation phase
+  c = std::move(assert_class);
+  results[0] = op[0];
 }
 
 void java_bytecode_convert_methodt::convert_athrow(

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1749,7 +1749,6 @@ codet java_bytecode_convert_methodt::convert_instructions(
       else
         op=pop(1);
 
-      assert(!stack.empty());
       exprt::operandst op2;
 
       if(get_bytecode_type_width(stack.back().type())==32)

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1682,26 +1682,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
     else if(statement==patternt("?cmp"))
     {
       PRECONDITION(op.size() == 2 && results.size() == 1);
-
-      // The integer result on the stack is:
-      //  0 if op[0] equals op[1]
-      // -1 if op[0] is less than op[1]
-      //  1 if op[0] is greater than op[1]
-
-      const typet t=java_int_type();
-      exprt one=from_integer(1, t);
-      exprt minus_one=from_integer(-1, t);
-
-      if_exprt greater=if_exprt(
-        binary_relation_exprt(op[0], ID_gt, op[1]),
-        one,
-        minus_one);
-
-      results[0]=
-        if_exprt(
-          binary_relation_exprt(op[0], ID_equal, op[1]),
-          from_integer(0, t),
-          greater);
+      results = convert_cmp(op, results);
     }
     else if(statement==patternt("?cmp?"))
     {
@@ -2506,6 +2487,26 @@ codet java_bytecode_convert_methodt::convert_instructions(
     code.move_to_operands(block);
 
   return code;
+}
+
+exprt::operandst &java_bytecode_convert_methodt::convert_cmp(
+  const exprt::operandst &op,
+  exprt::operandst &results) const
+{ // The integer result on the stack is:
+  //  0 if op[0] equals op[1]
+  // -1 if op[0] is less than op[1]
+  //  1 if op[0] is greater than op[1]
+
+  const typet t = java_int_type();
+  exprt one = from_integer(1, t);
+  exprt minus_one = from_integer(-1, t);
+
+  if_exprt greater =
+    if_exprt(binary_relation_exprt(op[0], ID_gt, op[1]), one, minus_one);
+
+  results[0] = if_exprt(
+    binary_relation_exprt(op[0], ID_equal, op[1]), from_integer(0, t), greater);
+  return results;
 }
 
 exprt::operandst &java_bytecode_convert_methodt::convert_ushr(

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1622,16 +1622,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
     }
     else if(statement=="pop" || statement=="pop2")
     {
-      // these are skips
-      c=code_skipt();
-
-      // pop2 removes two single-word items from the stack (e.g. two
-      // integers, or an integer and an object reference) or one
-      // two-word item (i.e. a double or a long).
-      // http://cs.au.dk/~mis/dOvs/jvmspec/ref-pop2.html
-      if(statement=="pop2" &&
-         get_bytecode_type_width(op[0].type())==32)
-        pop(1);
+      c = convert_pop(statement, op);
     }
     else if(statement=="instanceof")
     {
@@ -1899,6 +1890,22 @@ codet java_bytecode_convert_methodt::convert_instructions(
     code.move_to_operands(block);
 
   return code;
+}
+
+codet java_bytecode_convert_methodt::convert_pop(
+  const irep_idt &statement,
+  const exprt::operandst &op)
+{
+  // these are skips
+  codet c = code_skipt();
+
+  // pop2 removes two single-word items from the stack (e.g. two
+  // integers, or an integer and an object reference) or one
+  // two-word item (i.e. a double or a long).
+  // http://cs.au.dk/~mis/dOvs/jvmspec/ref-pop2.html
+  if(statement == "pop2" && get_bytecode_type_width(op[0].type()) == 32)
+    pop(1);
+  return c;
 }
 
 codet java_bytecode_convert_methodt::convert_switch(

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -994,10 +994,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
   std::vector<unsigned> jsr_ret_targets;
   std::vector<instructionst::const_iterator> ret_instructions;
 
-  for(instructionst::const_iterator
-      i_it=instructions.begin();
-      i_it!=instructions.end();
-      i_it++)
+  for(auto i_it = instructions.begin(); i_it != instructions.end(); i_it++)
   {
     converted_instructiont ins=converted_instructiont(i_it, code_skipt());
     std::pair<address_mapt::iterator, bool> a_entry=
@@ -1071,10 +1068,10 @@ codet java_bytecode_convert_methodt::convert_instructions(
       if(i_it->statement=="jsr" ||
          i_it->statement=="jsr_w")
       {
-        instructionst::const_iterator next=i_it+1;
         assert(
           next!=instructions.end() &&
           "jsr without valid return address?");
+        auto next = std::next(i_it);
         targets.insert(next->address);
         jsr_ret_targets.push_back(next->address);
       }
@@ -1142,9 +1139,9 @@ codet java_bytecode_convert_methodt::convert_instructions(
 
   while(!working_set.empty())
   {
-    std::set<unsigned>::iterator cur=working_set.begin();
     address_mapt::iterator a_it=address_map.find(*cur);
     CHECK_RETURN(a_it != address_map.end());
+    auto cur = working_set.begin();
     unsigned cur_pc=*cur;
     working_set.erase(cur);
 

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1514,22 +1514,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
     else if(statement=="dup2_x2")
     {
       PRECONDITION(!stack.empty() && results.empty());
-
-      if(get_bytecode_type_width(stack.back().type())==32)
-        op=pop(2);
-      else
-        op=pop(1);
-
-      exprt::operandst op2;
-
-      if(get_bytecode_type_width(stack.back().type())==32)
-        op2=pop(2);
-      else
-        op2=pop(1);
-
-      results.insert(results.end(), op.begin(), op.end());
-      results.insert(results.end(), op2.begin(), op2.end());
-      results.insert(results.end(), op.begin(), op.end());
+      convert_dup2_x2(op, results);
     }
     else if(statement=="dconst")
     {
@@ -1982,6 +1967,27 @@ void java_bytecode_convert_methodt::convert_dup2_x1(
     op = pop(2);
 
   results.insert(results.end(), op.begin() + 1, op.end());
+  results.insert(results.end(), op.begin(), op.end());
+}
+
+void java_bytecode_convert_methodt::convert_dup2_x2(
+  exprt::operandst &op,
+  exprt::operandst &results)
+{
+  if(get_bytecode_type_width(stack.back().type()) == 32)
+    op = pop(2);
+  else
+    op = pop(1);
+
+  exprt::operandst op2;
+
+  if(get_bytecode_type_width(stack.back().type()) == 32)
+    op2 = pop(2);
+  else
+    op2 = pop(1);
+
+  results.insert(results.end(), op.begin(), op.end());
+  results.insert(results.end(), op2.begin(), op2.end());
   results.insert(results.end(), op.begin(), op.end());
 }
 

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1342,38 +1342,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
     else if(statement==patternt("?const"))
     {
       assert(results.size()==1);
-
-      const char type_char=statement[0];
-      const bool is_double('d'==type_char);
-      const bool is_float('f'==type_char);
-
-      if(is_double || is_float)
-      {
-        const ieee_float_spect spec(
-          is_float?ieee_float_spect::single_precision():
-          ieee_float_spect::double_precision());
-
-        ieee_floatt value(spec);
-        if(arg0.type().id()!=ID_floatbv)
-        {
-          mp_integer number;
-          bool ret=to_integer(to_constant_expr(arg0), number);
-          DATA_INVARIANT(!ret, "failed to convert constant");
-          value.from_integer(number);
-        }
-        else
-          value.from_expr(to_constant_expr(arg0));
-
-        results[0]=value.to_expr();
-      }
-      else
-      {
-        mp_integer value;
-        bool ret=to_integer(to_constant_expr(arg0), value);
-        DATA_INVARIANT(!ret, "failed to convert constant");
-        const typet type=java_type_from_char(statement[0]);
-        results[0]=from_integer(value, type);
-      }
+      results = convert_const(statement, arg0, results);
     }
     else if(statement==patternt("?ipush"))
     {
@@ -2002,6 +1971,45 @@ codet java_bytecode_convert_methodt::convert_instructions(
     code.move_to_operands(block);
 
   return code;
+}
+
+exprt::operandst &java_bytecode_convert_methodt::convert_const(
+  const irep_idt &statement,
+  const exprt &arg0,
+  exprt::operandst &results) const
+{
+  const char type_char = statement[0];
+  const bool is_double('d' == type_char);
+  const bool is_float('f' == type_char);
+
+  if(is_double || is_float)
+  {
+    const ieee_float_spect spec(
+      is_float ? ieee_float_spect::single_precision()
+               : ieee_float_spect::double_precision());
+
+    ieee_floatt value(spec);
+    if(arg0.type().id() != ID_floatbv)
+    {
+      mp_integer number;
+      bool ret = to_integer(to_constant_expr(arg0), number);
+      DATA_INVARIANT(!ret, "failed to convert constant");
+      value.from_integer(number);
+    }
+    else
+      value.from_expr(to_constant_expr(arg0));
+
+    results[0] = value.to_expr();
+  }
+  else
+  {
+    mp_integer value;
+    bool ret = to_integer(to_constant_expr(arg0), value);
+    DATA_INVARIANT(!ret, "failed to convert constant");
+    const typet type = java_type_from_char(statement[0]);
+    results[0] = from_integer(value, type);
+  }
+  return results;
 }
 
 void java_bytecode_convert_methodt::convert_invoke(

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -430,5 +430,11 @@ protected:
     const std::set<unsigned int> &working_set,
     unsigned int cur_pc,
     codet &c);
+
+  void convert_athrow(
+    const source_locationt &location,
+    const exprt::operandst &op,
+    codet &c,
+    exprt::operandst &results) const;
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -349,5 +349,17 @@ protected:
     const irep_idt &id,
     const mp_integer &number,
     const source_locationt &location) const;
+
+  codet convert_ifnonull(
+    const java_bytecode_convert_methodt::address_mapt &address_map,
+    const exprt::operandst &op,
+    const mp_integer &number,
+    const source_locationt &location) const;
+
+  codet convert_ifnull(
+    java_bytecode_convert_methodt::address_mapt &address_map,
+    const exprt::operandst &op,
+    const mp_integer &number,
+    const source_locationt &location);
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -457,6 +457,8 @@ protected:
     const exprt &arg0,
     exprt::operandst &results) const;
 
+  void convert_dup2_x1(exprt::operandst &op, exprt::operandst &results);
+
   void convert_dup2(exprt::operandst &op, exprt::operandst &results);
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -305,6 +305,12 @@ protected:
 
   exprt
   convert_aload(const irep_idt &statement, const exprt::operandst &op) const;
+
+  code_blockt convert_ret(
+    const std::vector<unsigned int> &jsr_ret_targets,
+    const exprt &arg0,
+    const source_locationt &location,
+    unsigned address);
 };
 
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -367,5 +367,10 @@ protected:
     const exprt &arg1,
     const source_locationt &location,
     unsigned address);
+
+  exprt::operandst &convert_ushr(
+    const irep_idt &statement,
+    const exprt::operandst &op,
+    exprt::operandst &results) const;
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -273,6 +273,10 @@ protected:
     const typet &,
     code_blockt &,
     exprt &);
-};
+
+  std::vector<unsigned int> try_catch_handler(
+    unsigned int address,
+    const java_bytecode_parse_treet::methodt::exception_tablet &exception_table)
+    const;
 
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -389,5 +389,11 @@ protected:
     exprt::operandst &results);
 
   codet convert_putfield(const exprt &arg0, const exprt::operandst &op);
+
+  codet convert_putstatic(
+    const source_locationt &location,
+    const exprt &arg0,
+    const exprt::operandst &op,
+    const symbol_exprt &symbol_expr);
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -409,5 +409,12 @@ protected:
     const exprt::operandst &op,
     codet &c,
     exprt::operandst &results);
+
+  void convert_multianewarray(
+    const source_locationt &location,
+    const exprt &arg0,
+    const exprt::operandst &op,
+    codet &c,
+    exprt::operandst &results);
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -375,5 +375,10 @@ protected:
 
   exprt::operandst &
   convert_cmp(const exprt::operandst &op, exprt::operandst &results) const;
+
+  exprt::operandst &convert_cmp2(
+    const irep_idt &statement,
+    const exprt::operandst &op,
+    exprt::operandst &results) const;
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -362,10 +362,10 @@ protected:
     const mp_integer &number,
     const source_locationt &location) const;
 
-  codet convert_ifnull(
-    java_bytecode_convert_methodt::address_mapt &address_map,
-    const exprt::operandst &op,
-    const mp_integer &number,
-    const source_locationt &location);
+  codet convert_iinc(
+    const exprt &arg0,
+    const exprt &arg1,
+    const source_locationt &location,
+    unsigned address);
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -372,5 +372,8 @@ protected:
     const irep_idt &statement,
     const exprt::operandst &op,
     exprt::operandst &results) const;
+
+  exprt::operandst &
+  convert_cmp(const exprt::operandst &op, exprt::operandst &results) const;
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -285,6 +285,11 @@ protected:
     const std::vector<
       std::vector<java_bytecode_parse_treet::instructiont>::const_iterator>
       &ret_instructions) const;
+
+  optionalt<exprt> convert_invoke_dynamic(
+    const java_class_typet::java_lambda_method_handlest &lambda_method_handles,
+    const source_locationt &location,
+    const exprt &arg0);
 };
 
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -444,5 +444,12 @@ protected:
     exprt::operandst &results) const;
 
   codet &replace_call_to_cprover_assume(source_locationt location, codet &c);
+
+  void convert_invoke(
+    source_locationt location,
+    const irep_idt &statement,
+    exprt &arg0,
+    codet &c,
+    exprt::operandst &results);
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -290,6 +290,21 @@ protected:
     const java_class_typet::java_lambda_method_handlest &lambda_method_handles,
     const source_locationt &location,
     const exprt &arg0);
+
+  codet convert_astore(
+    const irep_idt &statement,
+    const exprt::operandst &op,
+    const source_locationt &location);
+
+  codet convert_store(
+    const irep_idt &statement,
+    const exprt &arg0,
+    const exprt::operandst &op,
+    unsigned address,
+    const source_locationt &location);
+
+  exprt
+  convert_aload(const irep_idt &statement, const exprt::operandst &op) const;
 };
 
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -380,5 +380,12 @@ protected:
     const irep_idt &statement,
     const exprt::operandst &op,
     exprt::operandst &results) const;
+
+  void convert_getstatic(
+    const exprt &arg0,
+    const symbol_exprt &symbol_expr,
+    bool is_assertions_disabled_field,
+    codet &c,
+    exprt::operandst &results);
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -357,6 +357,12 @@ protected:
     const source_locationt &location) const;
 
   codet convert_ifnull(
+    const java_bytecode_convert_methodt::address_mapt &address_map,
+    const exprt::operandst &op,
+    const mp_integer &number,
+    const source_locationt &location) const;
+
+  codet convert_ifnull(
     java_bytecode_convert_methodt::address_mapt &address_map,
     const exprt::operandst &op,
     const mp_integer &number,

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -451,5 +451,10 @@ protected:
     exprt &arg0,
     codet &c,
     exprt::operandst &results);
+
+  exprt::operandst &convert_const(
+    const irep_idt &statement,
+    const exprt &arg0,
+    exprt::operandst &results) const;
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -421,6 +421,10 @@ protected:
     const source_locationt &location,
     const exprt::operandst &op) const;
 
+  codet convert_monitorexit(
+    const source_locationt &location,
+    const exprt::operandst &op) const;
+
   codet &do_exception_handling(
     const methodt &method,
     const std::set<unsigned int> &working_set,

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -110,7 +110,10 @@ public:
     size_t length;
     bool is_parameter;
     std::vector<holet> holes;
-    variablet() : symbol_expr(), start_pc(0), length(0), is_parameter(false) {}
+
+    variablet() : symbol_expr(), start_pc(0), length(0), is_parameter(false)
+    {
+    }
   };
 
 protected:
@@ -124,8 +127,8 @@ protected:
 
   enum instruction_sizet
   {
-    INST_INDEX=2,
-    INST_INDEX_CONST=3
+    INST_INDEX = 2,
+    INST_INDEX_CONST = 3
   };
 
   // return corresponding reference of variable
@@ -161,6 +164,7 @@ protected:
   exprt::operandst pop(std::size_t n);
 
   void pop_residue(std::size_t n);
+
   void push(const exprt::operandst &o);
 
   /// Returns true iff the slot index of the local variable of a method (coming
@@ -168,15 +172,17 @@ protected:
   /// `slots_for_parameters` is initialized upon call.
   bool is_parameter(const local_variablet &v)
   {
-    return v.index<slots_for_parameters;
+    return v.index < slots_for_parameters;
   }
 
   struct converted_instructiont
   {
     converted_instructiont(
       const instructionst::const_iterator &it,
-      const codet &_code):source(it), code(_code), done(false)
-      {}
+      const codet &_code)
+      : source(it), code(_code), done(false)
+    {
+    }
 
     instructionst::const_iterator source;
     std::list<unsigned> successors;
@@ -211,9 +217,19 @@ protected:
     bool leaf;
     std::vector<unsigned> branch_addresses;
     std::vector<block_tree_nodet> branch;
-    block_tree_nodet():leaf(false) {}
-    explicit block_tree_nodet(bool l):leaf(l) {}
-    static block_tree_nodet get_leaf() { return block_tree_nodet(true); }
+
+    block_tree_nodet() : leaf(false)
+    {
+    }
+
+    explicit block_tree_nodet(bool l) : leaf(l)
+    {
+    }
+
+    static block_tree_nodet get_leaf()
+    {
+      return block_tree_nodet(true);
+    }
   };
 
   static void replace_goto_target(
@@ -235,7 +251,7 @@ protected:
     unsigned address_limit,
     unsigned next_block_start_address,
     const address_mapt &amap,
-    bool allow_merge=true);
+    bool allow_merge = true);
 
   optionalt<symbolt> get_lambda_method_symbol(
     const java_class_typet::java_lambda_method_handlest &lambda_method_handles,
@@ -261,13 +277,21 @@ protected:
   irep_idt get_static_field(
     const irep_idt &class_identifier, const irep_idt &component_name) const;
 
-  enum class bytecode_write_typet { VARIABLE, ARRAY_REF, STATIC_FIELD, FIELD};
+  enum class bytecode_write_typet
+  {
+    VARIABLE,
+    ARRAY_REF,
+    STATIC_FIELD,
+    FIELD
+  };
+
   void save_stack_entries(
     const std::string &,
     const typet &,
     code_blockt &,
     const bytecode_write_typet,
     const irep_idt &);
+
   void create_stack_tmp_var(
     const std::string &,
     const typet &,
@@ -311,6 +335,12 @@ protected:
     const exprt &arg0,
     const source_locationt &location,
     unsigned address);
-};
+
+  codet convert_if_cmp(
+    const java_bytecode_convert_methodt::address_mapt &address_map,
+    const irep_idt &statement,
+    const exprt::operandst &op,
+    const mp_integer &number,
+    const source_locationt &location) const;
 
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -462,5 +462,11 @@ protected:
   void convert_dup2_x1(exprt::operandst &op, exprt::operandst &results);
 
   void convert_dup2(exprt::operandst &op, exprt::operandst &results);
+
+  codet convert_switch(
+    java_bytecode_convert_methodt::address_mapt &address_map,
+    const exprt::operandst &op,
+    const java_bytecode_parse_treet::instructiont::argst &args,
+    const source_locationt &location);
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -401,5 +401,13 @@ protected:
     const exprt &arg0,
     codet &c,
     exprt::operandst &results);
+
+  void convert_newarray(
+    const source_locationt &location,
+    const irep_idt &statement,
+    const exprt &arg0,
+    const exprt::operandst &op,
+    codet &c,
+    exprt::operandst &results);
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -416,5 +416,9 @@ protected:
     const exprt::operandst &op,
     codet &c,
     exprt::operandst &results);
+
+  codet convert_monitorenter(
+    const source_locationt &location,
+    const exprt::operandst &op) const;
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -468,5 +468,7 @@ protected:
     const exprt::operandst &op,
     const java_bytecode_parse_treet::instructiont::argst &args,
     const source_locationt &location);
+
+  codet convert_pop(const irep_idt &statement, const exprt::operandst &op);
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -279,4 +279,12 @@ protected:
     const java_bytecode_parse_treet::methodt::exception_tablet &exception_table)
     const;
 
+  void draw_edges_from_ret_to_jsr(
+    address_mapt &address_map,
+    const std::vector<unsigned int> &jsr_ret_targets,
+    const std::vector<
+      std::vector<java_bytecode_parse_treet::instructiont>::const_iterator>
+      &ret_instructions) const;
+};
+
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -324,7 +324,7 @@ protected:
     const irep_idt &statement,
     const exprt &arg0,
     const exprt::operandst &op,
-    unsigned address,
+    const unsigned address,
     const source_locationt &location);
 
   exprt
@@ -334,7 +334,7 @@ protected:
     const std::vector<unsigned int> &jsr_ret_targets,
     const exprt &arg0,
     const source_locationt &location,
-    unsigned address);
+    const unsigned address);
 
   codet convert_if_cmp(
     const java_bytecode_convert_methodt::address_mapt &address_map,
@@ -343,4 +343,11 @@ protected:
     const mp_integer &number,
     const source_locationt &location) const;
 
+  codet convert_if(
+    const java_bytecode_convert_methodt::address_mapt &address_map,
+    const exprt::operandst &op,
+    const irep_idt &id,
+    const mp_integer &number,
+    const source_locationt &location) const;
+};
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -436,5 +436,11 @@ protected:
     const exprt::operandst &op,
     codet &c,
     exprt::operandst &results) const;
+
+  void convert_checkcast(
+    const exprt &arg0,
+    const exprt::operandst &op,
+    codet &c,
+    exprt::operandst &results) const;
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -456,5 +456,7 @@ protected:
     const irep_idt &statement,
     const exprt &arg0,
     exprt::operandst &results) const;
+
+  void convert_dup2(exprt::operandst &op, exprt::operandst &results);
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -442,5 +442,7 @@ protected:
     const exprt::operandst &op,
     codet &c,
     exprt::operandst &results) const;
+
+  codet &replace_call_to_cprover_assume(source_locationt location, codet &c);
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -387,5 +387,7 @@ protected:
     bool is_assertions_disabled_field,
     codet &c,
     exprt::operandst &results);
+
+  codet convert_putfield(const exprt &arg0, const exprt::operandst &op);
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -395,5 +395,11 @@ protected:
     const exprt &arg0,
     const exprt::operandst &op,
     const symbol_exprt &symbol_expr);
+
+  void convert_new(
+    const source_locationt &location,
+    const exprt &arg0,
+    codet &c,
+    exprt::operandst &results);
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -457,6 +457,8 @@ protected:
     const exprt &arg0,
     exprt::operandst &results) const;
 
+  void convert_dup2_x2(exprt::operandst &op, exprt::operandst &results);
+
   void convert_dup2_x1(exprt::operandst &op, exprt::operandst &results);
 
   void convert_dup2(exprt::operandst &op, exprt::operandst &results);

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -420,5 +420,11 @@ protected:
   codet convert_monitorenter(
     const source_locationt &location,
     const exprt::operandst &op) const;
+
+  codet &do_exception_handling(
+    const methodt &method,
+    const std::set<unsigned int> &working_set,
+    unsigned int cur_pc,
+    codet &c);
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -152,7 +152,7 @@ protected:
   symbol_exprt tmp_variable(const std::string &prefix, const typet &type);
 
   // JVM program locations
-  irep_idt label(const irep_idt &address);
+  static irep_idt label(const irep_idt &address);
 
   // JVM Stack
   typedef std::vector<exprt> stackt;


### PR DESCRIPTION
The goal of this PR is to reduce the size of this huge method without changing its behaviour, mainly by extracting some bits into new methods. 