### PR TITLE
Reset namespace after symbolic execution

### DIFF
--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -208,6 +208,9 @@ void goto_symext::symex_with_state(
   // execution, so return the names generated through symbolic execution
   // through `new_symbol_table`.
   new_symbol_table = state.symbol_table;
+  // reset the namespace back to a sane state as state.symbol_table might go out
+  // of scope
+  ns = namespacet(outer_symbol_table);
 }
 
 void goto_symext::resume_symex_from_saved_state(


### PR DESCRIPTION
The state's symbol table may go out of scope, leaving the namespace with a
dangling pointer. This is a follow-up to e8eec2c8a8.

This fix is factored out from #1868, which has regression tests that fail without this fix. The reason other regression tests don't catch this is that the namespace isn't used afterwards. Pinging @karkhaz and @kroening for discussion.