### PR TITLE
Move all the various id_sett typedefs into irep.h

### DIFF
--- a/src/analyses/call_graph_helpers.cpp
+++ b/src/analyses/call_graph_helpers.cpp
@@ -15,12 +15,12 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 /// \param graph: call graph
 /// \param function: function to query
 /// \param forwards: if true, get callees; otherwise get callers.
-static std::set<irep_idt> get_neighbours(
+static id_sett get_neighbours(
   const call_grapht::directed_grapht &graph,
   const irep_idt &function,
   bool forwards)
 {
-  std::set<irep_idt> result;
+  id_sett result;
   const auto &fnode = graph[*(graph.get_node_index(function))];
   const auto &neighbours = forwards ? fnode.out : fnode.in;
   for(const auto &succ_edge : neighbours)
@@ -28,13 +28,13 @@ static std::set<irep_idt> get_neighbours(
   return result;
 }
 
-std::set<irep_idt> get_callees(
+id_sett get_callees(
   const call_grapht::directed_grapht &graph, const irep_idt &function)
 {
   return get_neighbours(graph, function, true);
 }
 
-std::set<irep_idt> get_callers(
+id_sett get_callers(
   const call_grapht::directed_grapht &graph, const irep_idt &function)
 {
   return get_neighbours(graph, function, false);
@@ -46,27 +46,29 @@ std::set<irep_idt> get_callers(
 /// \param function: function to query
 /// \param forwards: if true, get reachable functions; otherwise get functions
 ///   that can reach the given function.
-static std::set<irep_idt> get_connected_functions(
+static id_sett get_connected_functions(
   const call_grapht::directed_grapht &graph,
   const irep_idt &function,
   bool forwards)
 {
   std::vector<call_grapht::directed_grapht::node_indext> connected_nodes =
     graph.get_reachable(*(graph.get_node_index(function)), forwards);
-  std::set<irep_idt> result;
+  id_sett result;
   for(const auto i : connected_nodes)
     result.insert(graph[i].function);
   return result;
 }
 
-std::set<irep_idt> get_reachable_functions(
-  const call_grapht::directed_grapht &graph, const irep_idt &function)
+id_sett get_reachable_functions(
+  const call_grapht::directed_grapht &graph,
+  const irep_idt &function)
 {
   return get_connected_functions(graph, function, true);
 }
 
-std::set<irep_idt> get_reaching_functions(
-  const call_grapht::directed_grapht &graph, const irep_idt &function)
+id_sett get_reaching_functions(
+  const call_grapht::directed_grapht &graph,
+  const irep_idt &function)
 {
   return get_connected_functions(graph, function, false);
 }

--- a/src/analyses/call_graph_helpers.h
+++ b/src/analyses/call_graph_helpers.h
@@ -25,28 +25,32 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 /// \param graph: call graph
 /// \param function: function to query
 /// \return set of called functions
-std::set<irep_idt> get_callees(
-  const call_grapht::directed_grapht &graph, const irep_idt &function);
+id_sett get_callees(
+  const call_grapht::directed_grapht &graph,
+  const irep_idt &function);
 
 /// Get functions that call a given function
 /// \param graph: call graph
 /// \param function: function to query
 /// \return set of caller functions
-std::set<irep_idt> get_callers(
-  const call_grapht::directed_grapht &graph, const irep_idt &function);
+id_sett get_callers(
+  const call_grapht::directed_grapht &graph,
+  const irep_idt &function);
 
 /// Get functions reachable from a given function
 /// \param graph: call graph
 /// \param function: function to query
 /// \return set of reachable functions, including `function`
-std::set<irep_idt> get_reachable_functions(
-  const call_grapht::directed_grapht &graph, const irep_idt &function);
+id_sett get_reachable_functions(
+  const call_grapht::directed_grapht &graph,
+  const irep_idt &function);
 
 /// Get functions that can reach a given function
 /// \param graph: call graph
 /// \param function: function to query
 /// \return set of functions that can reach the target, including `function`
-std::set<irep_idt> get_reaching_functions(
-  const call_grapht::directed_grapht &graph, const irep_idt &function);
+id_sett get_reaching_functions(
+  const call_grapht::directed_grapht &graph,
+  const irep_idt &function);
 
 #endif

--- a/src/analyses/dirty.h
+++ b/src/analyses/dirty.h
@@ -34,7 +34,6 @@ private:
 
 public:
   bool initialized;
-  typedef std::unordered_set<irep_idt, irep_id_hash> id_sett;
   typedef goto_functionst::goto_functiont goto_functiont;
 
   /// \post dirtyt objects that are created through this constructor are not
@@ -72,7 +71,7 @@ public:
     return operator()(expr.get_identifier());
   }
 
-  const id_sett &get_dirty_ids() const
+  const unordered_id_sett &get_dirty_ids() const
   {
     die_if_uninitialized();
     return dirty;
@@ -97,7 +96,7 @@ protected:
   void build(const goto_functiont &goto_function);
 
   // variables whose address is taken
-  id_sett dirty;
+  unordered_id_sett dirty;
 
   void find_dirty(const exprt &expr);
   void find_dirty_address_of(const exprt &expr);

--- a/src/analyses/dirty.h
+++ b/src/analyses/dirty.h
@@ -130,7 +130,7 @@ public:
 
 private:
   dirtyt dirty;
-  std::unordered_set<irep_idt, irep_id_hash> dirty_processed_functions;
+  unordered_id_sett dirty_processed_functions;
 };
 
 #endif // CPROVER_ANALYSES_DIRTY_H

--- a/src/analyses/escape_analysis.cpp
+++ b/src/analyses/escape_analysis.cpp
@@ -42,7 +42,7 @@ irep_idt escape_domaint::get_function(const exprt &lhs)
 
 void escape_domaint::assign_lhs_cleanup(
   const exprt &lhs,
-  const std::set<irep_idt> &cleanup_functions)
+  const id_sett &cleanup_functions)
 {
   if(lhs.id()==ID_symbol)
   {
@@ -61,7 +61,7 @@ void escape_domaint::assign_lhs_cleanup(
 
 void escape_domaint::assign_lhs_aliases(
   const exprt &lhs,
-  const std::set<irep_idt> &alias_set)
+  const id_sett &alias_set)
 {
   if(lhs.id()==ID_symbol)
   {
@@ -82,7 +82,7 @@ void escape_domaint::assign_lhs_aliases(
 
 void escape_domaint::get_rhs_cleanup(
   const exprt &rhs,
-  std::set<irep_idt> &cleanup_functions)
+  id_sett &cleanup_functions)
 {
   if(rhs.id()==ID_symbol)
   {
@@ -110,9 +110,7 @@ void escape_domaint::get_rhs_cleanup(
   }
 }
 
-void escape_domaint::get_rhs_aliases(
-  const exprt &rhs,
-  std::set<irep_idt> &alias_set)
+void escape_domaint::get_rhs_aliases(const exprt &rhs, id_sett &alias_set)
 {
   if(rhs.id()==ID_symbol)
   {
@@ -144,7 +142,7 @@ void escape_domaint::get_rhs_aliases(
 
 void escape_domaint::get_rhs_aliases_address_of(
   const exprt &rhs,
-  std::set<irep_idt> &alias_set)
+  id_sett &alias_set)
 {
   if(rhs.id()==ID_symbol)
   {
@@ -182,11 +180,11 @@ void escape_domaint::transform(
     {
       const code_assignt &code_assign=to_code_assign(instruction.code);
 
-      std::set<irep_idt> cleanup_functions;
+      id_sett cleanup_functions;
       get_rhs_cleanup(code_assign.rhs(), cleanup_functions);
       assign_lhs_cleanup(code_assign.lhs(), cleanup_functions);
 
-      std::set<irep_idt> aliases;
+      id_sett aliases;
       get_rhs_aliases(code_assign.rhs(), aliases);
       assign_lhs_aliases(code_assign.lhs(), aliases);
     }
@@ -196,7 +194,7 @@ void escape_domaint::transform(
     {
       const code_declt &code_decl=to_code_decl(instruction.code);
       aliases.isolate(code_decl.get_identifier());
-      assign_lhs_cleanup(code_decl.symbol(), std::set<irep_idt>());
+      assign_lhs_cleanup(code_decl.symbol(), id_sett());
     }
     break;
 
@@ -204,7 +202,7 @@ void escape_domaint::transform(
     {
       const code_deadt &code_dead=to_code_dead(instruction.code);
       aliases.isolate(code_dead.get_identifier());
-      assign_lhs_cleanup(code_dead.symbol(), std::set<irep_idt>());
+      assign_lhs_cleanup(code_dead.symbol(), id_sett());
     }
     break;
 
@@ -229,7 +227,7 @@ void escape_domaint::transform(
             if(!cleanup_function.empty())
             {
               // may alias other stuff
-              std::set<irep_idt> lhs_set;
+              id_sett lhs_set;
               get_rhs_aliases(lhs, lhs_set);
 
               for(const auto &lhs : lhs_set)
@@ -309,8 +307,8 @@ bool escape_domaint::merge(
 
   for(const auto &cleanup : b.cleanup_map)
   {
-    const std::set<irep_idt> &b_cleanup=cleanup.second.cleanup_functions;
-    std::set<irep_idt> &a_cleanup=cleanup_map[cleanup.first].cleanup_functions;
+    const id_sett &b_cleanup = cleanup.second.cleanup_functions;
+    id_sett &a_cleanup = cleanup_map[cleanup.first].cleanup_functions;
     auto old_size=a_cleanup.size();
     a_cleanup.insert(b_cleanup.begin(), b_cleanup.end());
     if(a_cleanup.size()!=old_size)
@@ -355,9 +353,7 @@ bool escape_domaint::merge(
   return changed;
 }
 
-void escape_domaint::check_lhs(
-  const exprt &lhs,
-  std::set<irep_idt> &cleanup_functions)
+void escape_domaint::check_lhs(const exprt &lhs, id_sett &cleanup_functions)
 {
   if(lhs.id()==ID_symbol)
   {
@@ -394,7 +390,7 @@ void escape_analysist::insert_cleanup(
   goto_functionst::goto_functiont &goto_function,
   goto_programt::targett location,
   const exprt &lhs,
-  const std::set<irep_idt> &cleanup_functions,
+  const id_sett &cleanup_functions,
   bool is_object,
   const namespacet &ns)
 {
@@ -446,7 +442,7 @@ void escape_analysist::instrument(
         {
           const code_assignt &code_assign=to_code_assign(instruction.code);
 
-          std::set<irep_idt> cleanup_functions;
+          id_sett cleanup_functions;
           operator[](i_it).check_lhs(code_assign.lhs(), cleanup_functions);
           insert_cleanup(
             f_it->second,
@@ -462,7 +458,7 @@ void escape_analysist::instrument(
         {
           const code_deadt &code_dead=to_code_dead(instruction.code);
 
-          std::set<irep_idt> cleanup_functions1;
+          id_sett cleanup_functions1;
 
           escape_domaint &d=operator[](i_it);
 
@@ -477,7 +473,7 @@ void escape_analysist::instrument(
               m_it->second.cleanup_functions.end());
           }
 
-          std::set<irep_idt> cleanup_functions2;
+          id_sett cleanup_functions2;
 
           d.check_lhs(code_dead.symbol(), cleanup_functions2);
 

--- a/src/analyses/escape_analysis.h
+++ b/src/analyses/escape_analysis.h
@@ -82,7 +82,7 @@ public:
 
   struct cleanupt
   {
-    std::set<irep_idt> cleanup_functions;
+    id_sett cleanup_functions;
   };
 
   // We track a set of 'cleanup functions' for specific
@@ -93,13 +93,13 @@ public:
 
 private:
   tvt has_values;
-  void assign_lhs_cleanup(const exprt &, const std::set<irep_idt> &);
-  void get_rhs_cleanup(const exprt &, std::set<irep_idt> &);
-  void assign_lhs_aliases(const exprt &, const std::set<irep_idt> &);
-  void get_rhs_aliases(const exprt &, std::set<irep_idt> &);
-  void get_rhs_aliases_address_of(const exprt &, std::set<irep_idt> &);
+  void assign_lhs_cleanup(const exprt &, const id_sett &);
+  void get_rhs_cleanup(const exprt &, id_sett &);
+  void assign_lhs_aliases(const exprt &, const id_sett &);
+  void get_rhs_aliases(const exprt &, id_sett &);
+  void get_rhs_aliases_address_of(const exprt &, id_sett &);
   irep_idt get_function(const exprt &);
-  void check_lhs(const exprt &, std::set<irep_idt> &);
+  void check_lhs(const exprt &, id_sett &);
 
   friend class escape_analysist;
 
@@ -122,7 +122,7 @@ protected:
     goto_functionst::goto_functiont &,
     goto_programt::targett,
     const exprt &,
-    const std::set<irep_idt> &,
+    const id_sett &,
     bool is_object,
     const namespacet &);
 };

--- a/src/analyses/flow_insensitive_analysis.h
+++ b/src/analyses/flow_insensitive_analysis.h
@@ -187,10 +187,10 @@ protected:
     return l;
   }
 
-  typedef std::set<irep_idt> functions_donet;
+  typedef id_sett functions_donet;
   functions_donet functions_done;
 
-  typedef std::set<irep_idt> recursion_sett;
+  typedef id_sett recursion_sett;
   recursion_sett recursion_set;
 
   bool initialized;

--- a/src/analyses/global_may_alias.cpp
+++ b/src/analyses/global_may_alias.cpp
@@ -13,7 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 void global_may_alias_domaint::assign_lhs_aliases(
   const exprt &lhs,
-  const std::set<irep_idt> &alias_set)
+  const id_sett &alias_set)
 {
   if(lhs.id()==ID_symbol)
   {
@@ -30,7 +30,7 @@ void global_may_alias_domaint::assign_lhs_aliases(
 
 void global_may_alias_domaint::get_rhs_aliases(
   const exprt &rhs,
-  std::set<irep_idt> &alias_set)
+  id_sett &alias_set)
 {
   if(rhs.id()==ID_symbol)
   {
@@ -58,7 +58,7 @@ void global_may_alias_domaint::get_rhs_aliases(
 
 void global_may_alias_domaint::get_rhs_aliases_address_of(
   const exprt &rhs,
-  std::set<irep_idt> &alias_set)
+  id_sett &alias_set)
 {
   if(rhs.id()==ID_symbol)
   {
@@ -92,7 +92,7 @@ void global_may_alias_domaint::transform(
     {
       const code_assignt &code_assign=to_code_assign(instruction.code);
 
-      std::set<irep_idt> aliases;
+      id_sett aliases;
       get_rhs_aliases(code_assign.rhs(), aliases);
       assign_lhs_aliases(code_assign.lhs(), aliases);
     }

--- a/src/analyses/global_may_alias.h
+++ b/src/analyses/global_may_alias.h
@@ -79,9 +79,9 @@ public:
 private:
   tvt has_values;
 
-  void assign_lhs_aliases(const exprt &, const std::set<irep_idt> &);
-  void get_rhs_aliases(const exprt &, std::set<irep_idt> &);
-  void get_rhs_aliases_address_of(const exprt &, std::set<irep_idt> &);
+  void assign_lhs_aliases(const exprt &, const id_sett &);
+  void get_rhs_aliases(const exprt &, id_sett &);
+  void get_rhs_aliases_address_of(const exprt &, id_sett &);
 };
 
 class global_may_alias_analysist:public ait<global_may_alias_domaint>

--- a/src/analyses/invariant_propagation.cpp
+++ b/src/analyses/invariant_propagation.cpp
@@ -127,7 +127,7 @@ void invariant_propagationt::add_objects(
   forall_goto_functions(f_it, goto_functions)
   {
     // get the locals
-    std::set<irep_idt> locals;
+    id_sett locals;
     get_local_identifiers(f_it->second, locals);
 
     const goto_programt &goto_program=f_it->second.body;

--- a/src/analyses/static_analysis.h
+++ b/src/analyses/static_analysis.h
@@ -221,10 +221,10 @@ protected:
   // for concurrent fixedpoint
   virtual bool merge_shared(statet &a, const statet &b, locationt to)=0;
 
-  typedef std::set<irep_idt> functions_donet;
+  typedef id_sett functions_donet;
   functions_donet functions_done;
 
-  typedef std::set<irep_idt> recursion_sett;
+  typedef id_sett recursion_sett;
   recursion_sett recursion_set;
 
   void generate_states(

--- a/src/analyses/uncaught_exceptions_analysis.cpp
+++ b/src/analyses/uncaught_exceptions_analysis.cpp
@@ -42,8 +42,7 @@ void uncaught_exceptions_domaint::join(
   thrown.insert(element);
 }
 
-void uncaught_exceptions_domaint::join(
-  const std::set<irep_idt> &elements)
+void uncaught_exceptions_domaint::join(const id_sett &elements)
 {
   thrown.insert(elements.begin(), elements.end());
 }
@@ -89,9 +88,9 @@ void uncaught_exceptions_domaint::transform(
     {
       if(!instruction.targets.empty()) // push
       {
-        std::set<irep_idt> caught;
+        id_sett caught;
         stack_caught.push_back(caught);
-        std::set<irep_idt> &last_caught=stack_caught.back();
+        id_sett &last_caught = stack_caught.back();
         const irept::subt &exception_list=
           instruction.code.find(ID_exception_list).get_sub();
 
@@ -107,7 +106,7 @@ void uncaught_exceptions_domaint::transform(
       {
         if(!stack_caught.empty())
         {
-          const std::set<irep_idt> &caught=stack_caught.back();
+          const id_sett &caught = stack_caught.back();
           join(caught);
           // remove the caught exceptions
           for(const auto &exc_id : caught)
@@ -137,7 +136,7 @@ void uncaught_exceptions_domaint::transform(
 }
 
 /// Returns the value of the private member thrown
-const std::set<irep_idt> &uncaught_exceptions_domaint::get_elements() const
+const id_sett &uncaught_exceptions_domaint::get_elements() const
 {
   return thrown;
 }
@@ -173,7 +172,7 @@ void uncaught_exceptions_analysist::collect_uncaught_exceptions(
         domain.transform(instr_it, *this, ns);
       }
       // did our estimation for the current function improve?
-      const std::set<irep_idt> &elements=domain.get_elements();
+      const id_sett &elements = domain.get_elements();
       if(exceptions_map[current_function->first].size()<elements.size())
       {
         change=true;
@@ -227,7 +226,7 @@ void uncaught_exceptions_analysist::operator()(
 void uncaught_exceptions(
   const goto_functionst &goto_functions,
   const namespacet &ns,
-  std::map<irep_idt, std::set<irep_idt>> &exceptions_map)
+  std::map<irep_idt, id_sett> &exceptions_map)
 {
   uncaught_exceptions_analysist exceptions;
   exceptions(goto_functions, ns, exceptions_map);

--- a/src/analyses/uncaught_exceptions_analysis.h
+++ b/src/analyses/uncaught_exceptions_analysis.h
@@ -29,7 +29,7 @@ class uncaught_exceptions_domaint
                  const namespacet &);
 
   void join(const irep_idt &);
-  void join(const std::set<irep_idt> &);
+  void join(const id_sett &);
   void join(const std::vector<irep_idt> &);
 
   void make_top()
@@ -42,14 +42,14 @@ class uncaught_exceptions_domaint
 
   static exprt get_exception_symbol(const exprt &exor);
 
-  const std::set<irep_idt>  &get_elements() const;
+  const id_sett &get_elements() const;
 
   void operator()(const namespacet &ns);
 
- private:
-  typedef std::vector<std::set<irep_idt>> stack_caughtt;
+private:
+  typedef std::vector<id_sett> stack_caughtt;
   stack_caughtt stack_caught;
-  std::set<irep_idt> thrown;
+  id_sett thrown;
   class_hierarchyt class_hierarchy;
 };
 
@@ -58,7 +58,7 @@ class uncaught_exceptions_domaint
 class uncaught_exceptions_analysist
 {
 public:
-  typedef std::map<irep_idt, std::set<irep_idt>> exceptions_mapt;
+  typedef std::map<irep_idt, id_sett> exceptions_mapt;
 
   void collect_uncaught_exceptions(
     const goto_functionst &,
@@ -81,6 +81,6 @@ public:
 void uncaught_exceptions(
   const goto_functionst &,
   const namespacet &,
-  std::map<irep_idt, std::set<irep_idt>> &);
+  std::map<irep_idt, id_sett> &);
 
 #endif

--- a/src/analyses/uninitialized_domain.h
+++ b/src/analyses/uninitialized_domain.h
@@ -26,7 +26,7 @@ public:
   }
 
   // Locals that are declared but may not be initialized
-  typedef std::set<irep_idt> uninitializedt;
+  typedef id_sett uninitializedt;
   uninitializedt uninitialized;
 
   void

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -877,7 +877,7 @@ void c_typecheck_baset::typecheck_compound_body(
   // scan for duplicate members
 
   {
-    std::unordered_set<irep_idt, irep_id_hash> members;
+    unordered_id_sett members;
 
     for(struct_union_typet::componentst::iterator
         it=components.begin();

--- a/src/ansi-c/cprover_library.cpp
+++ b/src/ansi-c/cprover_library.cpp
@@ -23,7 +23,7 @@ struct cprover_library_entryt
 ; // NOLINT(whitespace/semicolon)
 
 std::string get_cprover_library_text(
-  const std::set<irep_idt> &functions,
+  const id_sett &functions,
   const symbol_tablet &symbol_table)
 {
   std::ostringstream library_text;
@@ -64,7 +64,7 @@ std::string get_cprover_library_text(
 }
 
 void add_cprover_library(
-  const std::set<irep_idt> &functions,
+  const id_sett &functions,
   symbol_tablet &symbol_table,
   message_handlert &message_handler)
 {

--- a/src/ansi-c/cprover_library.h
+++ b/src/ansi-c/cprover_library.h
@@ -16,7 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/message.h>
 
 std::string get_cprover_library_text(
-  const std::set<irep_idt> &functions,
+  const id_sett &functions,
   const symbol_tablet &);
 
 void add_library(
@@ -25,7 +25,7 @@ void add_library(
   message_handlert &);
 
 void add_cprover_library(
-  const std::set<irep_idt> &functions,
+  const id_sett &functions,
   symbol_tablet &,
   message_handlert &);
 

--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -64,9 +64,7 @@ protected:
 
   static std::string indent_str(unsigned indent);
 
-  std::unordered_map<irep_idt,
-                std::unordered_set<irep_idt, irep_id_hash>,
-                irep_id_hash> ns_collision;
+  std::unordered_map<irep_idt, unordered_id_sett, irep_id_hash> ns_collision;
   std::unordered_map<irep_idt, irep_idt, irep_id_hash> shorthands;
 
   unsigned sizeof_nesting;

--- a/src/cbmc/symex_bmc.h
+++ b/src/cbmc/symex_bmc.h
@@ -147,7 +147,7 @@ protected:
 
   virtual void no_body(const irep_idt &identifier);
 
-  std::unordered_set<irep_idt, irep_id_hash> body_warnings;
+  unordered_id_sett body_warnings;
 
   symex_coveraget symex_coverage;
 };

--- a/src/cpp/cpp_typecheck.h
+++ b/src/cpp/cpp_typecheck.h
@@ -304,12 +304,12 @@ protected:
   void clean_up();
 
   void add_base_components(
-        const struct_typet &from,
-        const irep_idt &access,
-        struct_typet &to,
-        std::set<irep_idt> &bases,
-        std::set<irep_idt> &vbases,
-        bool is_virtual);
+    const struct_typet &from,
+    const irep_idt &access,
+    struct_typet &to,
+    id_sett &bases,
+    id_sett &vbases,
+    bool is_virtual);
 
   bool cast_away_constness(const typet &t1,
                            const typet &t2) const;
@@ -552,8 +552,7 @@ public:
 
   virtual void implicit_typecast(exprt &expr, const typet &type);
 
-  void get_bases(const struct_typet &type,
-     std::set<irep_idt> &set_bases) const;
+  void get_bases(const struct_typet &type, id_sett &set_bases) const;
 
   void get_virtual_bases(const struct_typet &type,
      std::list<irep_idt> &vbases) const;

--- a/src/cpp/cpp_typecheck_bases.cpp
+++ b/src/cpp/cpp_typecheck_bases.cpp
@@ -15,8 +15,8 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 void cpp_typecheckt::typecheck_compound_bases(struct_typet &type)
 {
-  std::set<irep_idt> bases;
-  std::set<irep_idt> vbases;
+  id_sett bases;
+  id_sett vbases;
 
   irep_idt default_class_access=
     type.get_bool(ID_C_class)?ID_private:ID_public;
@@ -121,8 +121,8 @@ void cpp_typecheckt::add_base_components(
   const struct_typet &from,
   const irep_idt &access,
   struct_typet &to,
-  std::set<irep_idt> &bases,
-  std::set<irep_idt> &vbases,
+  id_sett &bases,
+  id_sett &vbases,
   bool is_virtual)
 {
   const irep_idt &from_name = from.get(ID_name);

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -454,7 +454,7 @@ void cpp_typecheckt::typecheck_compound_declarator(
       virtual_name="@dtor";
 
     // The method may be virtual implicitly.
-    std::set<irep_idt> virtual_bases;
+    id_sett virtual_bases;
 
     for(const auto &comp : components)
     {
@@ -1614,7 +1614,7 @@ bool cpp_typecheckt::check_component_access(
 
 void cpp_typecheckt::get_bases(
   const struct_typet &type,
-  std::set<irep_idt> &set_bases) const
+  id_sett &set_bases) const
 {
   const irept::subt &bases=type.find(ID_bases).get_sub();
 
@@ -1662,7 +1662,7 @@ bool cpp_typecheckt::subtype_typecast(
   if(from.get(ID_name)==to.get(ID_name))
     return true;
 
-  std::set<irep_idt> bases;
+  id_sett bases;
 
   get_bases(from, bases);
 

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -159,7 +159,7 @@ void cpp_typecheck_resolvet::remove_duplicates(
   resolve_identifierst old_identifiers;
   old_identifiers.swap(identifiers);
 
-  std::set<irep_idt> ids;
+  id_sett ids;
   std::set<exprt> other;
 
   for(resolve_identifierst::const_iterator
@@ -1016,7 +1016,7 @@ symbol_typet cpp_typecheck_resolvet::disambiguate_template_classes(
     throw 0;
   }
 
-  std::set<irep_idt> primary_templates;
+  id_sett primary_templates;
 
   for(cpp_scopest::id_sett::const_iterator
       it=id_set.begin();

--- a/src/goto-analyzer/taint_analysis.cpp
+++ b/src/goto-analyzer/taint_analysis.cpp
@@ -81,7 +81,7 @@ void taint_analysist::instrument(
           const irep_idt &identifier=
             to_symbol_expr(function).get_identifier();
 
-          std::set<irep_idt> identifiers;
+          id_sett identifiers;
 
           identifiers.insert(identifier);
 

--- a/src/goto-analyzer/unreachable_instructions.cpp
+++ b/src/goto-analyzer/unreachable_instructions.cpp
@@ -169,8 +169,7 @@ void unreachable_instructions(
 {
   json_arrayt json_result;
 
-  std::set<irep_idt> called=
-    compute_called_functions(goto_model);
+  id_sett called = compute_called_functions(goto_model);
 
   const namespacet ns(goto_model.symbol_table);
 
@@ -293,7 +292,7 @@ static void xml_output_function(
 
 static void list_functions(
   const goto_modelt &goto_model,
-  const std::set<irep_idt> called,
+  const id_sett called,
   const optionst &options,
   std::ostream &os,
   bool unreachable)
@@ -389,7 +388,7 @@ void unreachable_functions(
   else
     options.set_option("text", true);
 
-  std::set<irep_idt> called = compute_called_functions(goto_model);
+  id_sett called = compute_called_functions(goto_model);
 
   list_functions(goto_model, called, options, os, true);
 }
@@ -405,17 +404,17 @@ void reachable_functions(
   else
     options.set_option("text", true);
 
-  std::set<irep_idt> called = compute_called_functions(goto_model);
+  id_sett called = compute_called_functions(goto_model);
 
   list_functions(goto_model, called, options, os, false);
 }
 
 
-std::set<irep_idt> compute_called_functions_from_ai(
+id_sett compute_called_functions_from_ai(
   const goto_modelt &goto_model,
   const ai_baset &ai)
 {
-  std::set<irep_idt> called;
+  id_sett called;
 
   forall_goto_functions(f_it, goto_model.goto_functions)
   {
@@ -438,7 +437,7 @@ bool static_unreachable_functions(
   message_handlert &message_handler,
   std::ostream &out)
 {
-  std::set<irep_idt> called = compute_called_functions_from_ai(goto_model, ai);
+  id_sett called = compute_called_functions_from_ai(goto_model, ai);
 
   list_functions(goto_model, called, options, out, true);
 
@@ -452,7 +451,7 @@ bool static_reachable_functions(
   message_handlert &message_handler,
   std::ostream &out)
 {
-  std::set<irep_idt> called = compute_called_functions_from_ai(goto_model, ai);
+  id_sett called = compute_called_functions_from_ai(goto_model, ai);
 
   list_functions(goto_model, called, options, out, false);
 

--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -691,7 +691,7 @@ void compilet::convert_symbols(goto_functionst &dest)
   {
     before=symbol_table.symbols.size();
 
-    typedef std::set<irep_idt> symbols_sett;
+    typedef id_sett symbols_sett;
     symbols_sett symbols;
 
     for(const auto &named_symbol : symbol_table.symbols)

--- a/src/goto-diff/goto_diff.h
+++ b/src/goto-diff/goto_diff.h
@@ -51,12 +51,11 @@ protected:
   ui_message_handlert::uit ui;
 
   unsigned total_functions_count;
-  typedef std::set<irep_idt> irep_id_sett;
-  irep_id_sett new_functions, modified_functions, deleted_functions;
+  id_sett new_functions, modified_functions, deleted_functions;
 
   void output_function_group(
     const std::string &group_name,
-    const irep_id_sett &function_group,
+    const id_sett &function_group,
     const goto_modelt &goto_model) const;
   void output_function(
     const irep_idt &function_name,
@@ -64,7 +63,7 @@ protected:
 
   void convert_function_group_json(
     json_arrayt &result,
-    const irep_id_sett &function_group,
+    const id_sett &function_group,
     const goto_modelt &goto_model) const;
   void convert_function_json(
     json_objectt &result,

--- a/src/goto-diff/goto_diff_base.cpp
+++ b/src/goto-diff/goto_diff_base.cpp
@@ -64,7 +64,7 @@ void goto_difft::output_functions() const
 /// \param goto_model: the goto model
 void goto_difft::output_function_group(
   const std::string &group_name,
-  const irep_id_sett &function_group,
+  const id_sett &function_group,
   const goto_modelt &goto_model) const
 {
   result() << group_name << ":\n";
@@ -113,7 +113,7 @@ void goto_difft::output_function(
 /// \param goto_model: the goto model
 void goto_difft::convert_function_group_json(
   json_arrayt &result,
-  const irep_id_sett &function_group,
+  const id_sett &function_group,
   const goto_modelt &goto_model) const
 {
   for(const auto &function_name : function_group)

--- a/src/goto-instrument/code_contracts.cpp
+++ b/src/goto-instrument/code_contracts.cpp
@@ -45,8 +45,7 @@ protected:
 
   unsigned temporary_counter;
 
-  typedef std::unordered_set<irep_idt, irep_id_hash> id_sett;
-  id_sett summarized;
+  unordered_id_sett summarized;
 
   void code_contracts(goto_functionst::goto_functiont &goto_function);
 
@@ -389,8 +388,8 @@ void code_contractst::operator()()
     goto_functions.function_map.find(CPROVER_PREFIX "initialize");
   assert(i_it!=goto_functions.function_map.end());
 
-  for(id_sett::const_iterator it=summarized.begin();
-      it!=summarized.end();
+  for(unordered_id_sett::const_iterator it = summarized.begin();
+      it != summarized.end();
       ++it)
     add_contract_check(*it, i_it->second.body);
 

--- a/src/goto-instrument/count_eloc.cpp
+++ b/src/goto-instrument/count_eloc.cpp
@@ -21,7 +21,7 @@ Date: December 2012
 
 #include <goto-programs/cfg.h>
 
-typedef std::unordered_set<irep_idt, irep_id_hash> linest;
+typedef unordered_id_sett linest;
 typedef std::unordered_map<irep_idt, linest, irep_id_hash> filest;
 typedef std::unordered_map<irep_idt, filest, irep_id_hash> working_dirst;
 

--- a/src/goto-instrument/document_properties.cpp
+++ b/src/goto-instrument/document_properties.cpp
@@ -63,7 +63,7 @@ private:
 
   struct doc_claimt
   {
-    std::set<irep_idt> comment_set;
+    id_sett comment_set;
   };
 
   enum { HTML, LATEX } format;
@@ -314,9 +314,8 @@ void document_propertiest::doit()
 
       out << '\n';
 
-      for(std::set<irep_idt>::const_iterator
-          s_it=it->second.comment_set.begin();
-          s_it!=it->second.comment_set.end();
+      for(id_sett::const_iterator s_it = it->second.comment_set.begin();
+          s_it != it->second.comment_set.end();
           s_it++)
         out << "\\claim{" << escape_latex(id2string(*s_it), false)
             << "}\n";
@@ -341,9 +340,8 @@ void document_propertiest::doit()
 
       out << '\n';
 
-      for(std::set<irep_idt>::const_iterator
-          s_it=it->second.comment_set.begin();
-          s_it!=it->second.comment_set.end();
+      for(id_sett::const_iterator s_it = it->second.comment_set.begin();
+          s_it != it->second.comment_set.end();
           s_it++)
         out << "<div class=\"description\">\n"
             << escape_html(id2string(*s_it)) << '\n'

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -769,10 +769,9 @@ void dump_ct::dump_typedefs(std::ostream &os) const
   // output
   std::map<std::string, typedef_infot> to_insert;
 
-  typedef std::unordered_set<irep_idt, irep_id_hash> id_sett;
-  id_sett typedefs_done;
-  std::unordered_map<irep_idt, id_sett, irep_id_hash>
-    forward_deps, reverse_deps;
+  unordered_id_sett typedefs_done;
+  std::unordered_map<irep_idt, unordered_id_sett, irep_id_hash> forward_deps,
+    reverse_deps;
 
   for(const auto &td : typedef_map)
     if(!td.second.type_decl_str.empty())
@@ -805,8 +804,9 @@ void dump_ct::dump_typedefs(std::ostream &os) const
       continue;
 
     // reduce remaining dependencies
-    id_sett &r_deps=r_it->second;
-    for(id_sett::iterator it=r_deps.begin(); it!=r_deps.end(); ) // no ++it
+    unordered_id_sett &r_deps = r_it->second;
+    for(unordered_id_sett::iterator it = r_deps.begin();
+        it != r_deps.end();) // no ++it
     {
       auto f_it=forward_deps.find(*it);
       if(f_it==forward_deps.end()) // might be done already
@@ -816,7 +816,7 @@ void dump_ct::dump_typedefs(std::ostream &os) const
       }
 
       // update dependencies
-      id_sett &f_deps=f_it->second;
+      unordered_id_sett &f_deps = f_it->second;
       PRECONDITION(!f_deps.empty());
       PRECONDITION(f_deps.find(t.typedef_name)!=f_deps.end());
       f_deps.erase(t.typedef_name);

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -613,7 +613,7 @@ void dump_ct::cleanup_decl(
 
   tmp.add_instruction(END_FUNCTION);
 
-  std::unordered_set<irep_idt, irep_id_hash> typedef_names;
+  unordered_id_sett typedef_names;
   for(const auto &td : typedef_map)
     typedef_names.insert(td.first);
 
@@ -640,7 +640,7 @@ void dump_ct::cleanup_decl(
 ///   function declarations or struct definitions
 void dump_ct::collect_typedefs(const typet &type, bool early)
 {
-  std::unordered_set<irep_idt, irep_id_hash> deps;
+  unordered_id_sett deps;
   collect_typedefs_rec(type, early, deps);
 }
 
@@ -654,12 +654,12 @@ void dump_ct::collect_typedefs(const typet &type, bool early)
 void dump_ct::collect_typedefs_rec(
   const typet &type,
   bool early,
-  std::unordered_set<irep_idt, irep_id_hash> &dependencies)
+  unordered_id_sett &dependencies)
 {
   if(system_symbols.is_type_internal(type, system_headers))
     return;
 
-  std::unordered_set<irep_idt, irep_id_hash> local_deps;
+  unordered_id_sett local_deps;
 
   if(type.id()==ID_code)
   {
@@ -986,7 +986,7 @@ void dump_ct::convert_function_declaration(
     code_blockt b;
     std::list<irep_idt> type_decls, local_static;
 
-    std::unordered_set<irep_idt, irep_id_hash> typedef_names;
+    unordered_id_sett typedef_names;
     for(const auto &td : typedef_map)
       typedef_names.insert(td.first);
 

--- a/src/goto-instrument/dump_c_class.h
+++ b/src/goto-instrument/dump_c_class.h
@@ -52,7 +52,7 @@ protected:
   std::unique_ptr<languaget> language;
   const bool harness;
 
-  typedef std::unordered_set<irep_idt, irep_id_hash> convertedt;
+  typedef unordered_id_sett convertedt;
   convertedt converted_compound, converted_global, converted_enum;
 
   std::set<std::string> system_headers;
@@ -68,7 +68,7 @@ protected:
     irep_idt typedef_name;
     std::string type_decl_str;
     bool early;
-    std::unordered_set<irep_idt, irep_id_hash> dependencies;
+    unordered_id_sett dependencies;
 
     explicit typedef_infot(const irep_idt &name):
       typedef_name(name),
@@ -108,7 +108,7 @@ protected:
   void collect_typedefs_rec(
     const typet &type,
     bool early,
-    std::unordered_set<irep_idt, irep_id_hash> &dependencies);
+    unordered_id_sett &dependencies);
   void gather_global_typedefs();
   void dump_typedefs(std::ostream &os) const;
 

--- a/src/goto-instrument/goto_program2code.h
+++ b/src/goto-instrument/goto_program2code.h
@@ -20,7 +20,6 @@ Author: Daniel Kroening, kroening@kroening.com
 class goto_program2codet
 {
   typedef std::list<irep_idt> id_listt;
-  typedef std::unordered_set<irep_idt, irep_id_hash> id_sett;
   typedef std::map<goto_programt::const_targett, goto_programt::const_targett>
     loopt;
   typedef std::unordered_map<irep_idt, unsigned, irep_id_hash> dead_mapt;
@@ -47,23 +46,23 @@ class goto_program2codet
 
 public:
   goto_program2codet(
-      const irep_idt &identifier,
-      const goto_programt &_goto_program,
-      symbol_tablet &_symbol_table,
-      code_blockt &_dest,
-      id_listt &_local_static,
-      id_listt &_type_names,
-      const id_sett &_typedef_names,
-      std::set<std::string> &_system_headers):
-    func_name(identifier),
-    goto_program(_goto_program),
-    symbol_table(_symbol_table),
-    ns(_symbol_table),
-    toplevel_block(_dest),
-    local_static(_local_static),
-    type_names(_type_names),
-    typedef_names(_typedef_names),
-    system_headers(_system_headers)
+    const irep_idt &identifier,
+    const goto_programt &_goto_program,
+    symbol_tablet &_symbol_table,
+    code_blockt &_dest,
+    id_listt &_local_static,
+    id_listt &_type_names,
+    const unordered_id_sett &_typedef_names,
+    std::set<std::string> &_system_headers)
+    : func_name(identifier),
+      goto_program(_goto_program),
+      symbol_table(_symbol_table),
+      ns(_symbol_table),
+      toplevel_block(_dest),
+      local_static(_local_static),
+      type_names(_type_names),
+      typedef_names(_typedef_names),
+      system_headers(_system_headers)
   {
     assert(local_static.empty());
 
@@ -84,18 +83,18 @@ protected:
   code_blockt &toplevel_block;
   id_listt &local_static;
   id_listt &type_names;
-  const id_sett &typedef_names;
+  const unordered_id_sett &typedef_names;
   std::set<std::string> &system_headers;
   std::unordered_set<exprt, irep_hash> va_list_expr;
 
   natural_loopst loops;
   loopt loop_map;
-  id_sett labels_in_use;
+  unordered_id_sett labels_in_use;
   dead_mapt dead_map;
   loop_last_stackt loop_last_stack;
-  id_sett local_static_set;
-  id_sett type_names_set;
-  id_sett const_removed;
+  unordered_id_sett local_static_set;
+  unordered_id_sett type_names_set;
+  unordered_id_sett const_removed;
 
   void build_loop_map();
   void build_dead_map();

--- a/src/goto-instrument/rw_set.h
+++ b/src/goto-instrument/rw_set.h
@@ -236,7 +236,7 @@ public:
   std::map<const irep_idt, const irep_idt> dereferenced_from;
 
   /* is var a read or write */
-  std::set<irep_idt> set_reads;
+  id_sett set_reads;
 
 #ifdef LOCAL_MAY
   rw_set_with_trackt(

--- a/src/goto-instrument/thread_instrumentation.cpp
+++ b/src/goto-instrument/thread_instrumentation.cpp
@@ -57,7 +57,7 @@ void thread_exit_instrumentation(goto_programt &goto_program)
 void thread_exit_instrumentation(goto_modelt &goto_model)
 {
   // we'll look for START THREAD
-  std::set<irep_idt> thread_fkts;
+  id_sett thread_fkts;
 
   forall_goto_functions(f_it, goto_model.goto_functions)
   {

--- a/src/goto-instrument/uninitialized.cpp
+++ b/src/goto-instrument/uninitialized.cpp
@@ -37,7 +37,7 @@ protected:
 
   // The variables that need tracking,
   // i.e., are uninitialized and may be read?
-  std::set<irep_idt> tracking;
+  id_sett tracking;
 
   void get_tracking(goto_programt::const_targett i_it);
 };
@@ -52,8 +52,7 @@ void uninitializedt::get_tracking(goto_programt::const_targett i_it)
     if(object.id() == ID_symbol)
     {
       const irep_idt &identifier = to_symbol_expr(object).get_identifier();
-      const std::set<irep_idt> &uninitialized=
-        uninitialized_analysis[i_it].uninitialized;
+      const id_sett &uninitialized = uninitialized_analysis[i_it].uninitialized;
       if(uninitialized.find(identifier)!=uninitialized.end())
         tracking.insert(identifier);
     }
@@ -74,10 +73,7 @@ void uninitializedt::add_assertions(goto_programt &goto_program)
     get_tracking(i_it);
 
   // add tracking symbols to symbol table
-  for(std::set<irep_idt>::const_iterator
-      it=tracking.begin();
-      it!=tracking.end();
-      it++)
+  for(id_sett::const_iterator it = tracking.begin(); it != tracking.end(); it++)
   {
     const symbolt &symbol=ns.lookup(*it);
 
@@ -138,8 +134,7 @@ void uninitializedt::add_assertions(goto_programt &goto_program)
       // const code_function_callt &code_function_call=
       //  to_code_function_call(instruction.code);
 
-      const std::set<irep_idt> &uninitialized=
-        uninitialized_analysis[i_it].uninitialized;
+      const id_sett &uninitialized = uninitialized_analysis[i_it].uninitialized;
 
       // check tracking variables
       for(const auto &object : read)

--- a/src/goto-instrument/wmm/goto2graph.h
+++ b/src/goto-instrument/wmm/goto2graph.h
@@ -204,7 +204,7 @@ protected:
     std::set<event_idt> unknown_write_nodes;
 
     /* set of functions visited so far -- we don't handle recursive functions */
-    std::set<irep_idt> functions_met;
+    id_sett functions_met;
 
     cfg_visitort(namespacet &_ns, instrumentert &_instrumenter)
     :ns(_ns), instrumenter(_instrumenter), egraph(_instrumenter.egraph),
@@ -323,7 +323,7 @@ public:
      the cycles, and locations of all the variables on the critical cycles */
   /* TODO: those maps are here to interface easily with weak_mem.cpp,
      but a rewriting of weak_mem can eliminate them */
-  std::set<irep_idt> var_to_instr;
+  id_sett var_to_instr;
   std::multimap<irep_idt, source_locationt> id2loc;
   std::multimap<irep_idt, source_locationt> id2cycloc;
 

--- a/src/goto-instrument/wmm/shared_buffers.cpp
+++ b/src/goto-instrument/wmm/shared_buffers.cpp
@@ -1270,8 +1270,9 @@ void shared_bufferst::cfg_visitort::weak_memory(
       i_it++;
 
       // does it for all the previous statements
-      for(std::set<irep_idt>::iterator s_it=past_writes.begin();
-        s_it!=past_writes.end(); s_it++)
+      for(id_sett::iterator s_it = past_writes.begin();
+          s_it != past_writes.end();
+          s_it++)
       {
         shared_buffers.det_flush(
           goto_program, i_it, source_location, *s_it,

--- a/src/goto-instrument/wmm/shared_buffers.h
+++ b/src/goto-instrument/wmm/shared_buffers.h
@@ -78,7 +78,7 @@ public:
 
   /* instructions in violation cycles (to instrument): */
   // variables in the cycles
-  std::set<irep_idt> cycles;
+  id_sett cycles;
   // events instrumented: var->locations in the code
   std::multimap<irep_idt, source_locationt> cycles_loc;
   // events in cycles: var->locations (for read instrumentations)
@@ -202,7 +202,7 @@ public:
     unsigned max_thread;
 
     /* data propagated through the CFG */
-    std::set<irep_idt> past_writes;
+    id_sett past_writes;
 
   public:
     cfg_visitort(shared_bufferst &_shared, symbol_tablet &_symbol_table,
@@ -228,11 +228,11 @@ protected:
   unsigned nb_threads;
 
   // instrumentations (not to be instrumented again)
-  std::set<irep_idt> instrumentations;
+  id_sett instrumentations;
 
   // variables (non necessarily shared) affected by reads delay
 public:
-  std::set<irep_idt> affected_by_delay_set;
+  id_sett affected_by_delay_set;
 
 protected:
   // for fresh variables

--- a/src/goto-instrument/wmm/weak_memory.cpp
+++ b/src/goto-instrument/wmm/weak_memory.cpp
@@ -228,15 +228,15 @@ void weak_memory(
   shared_buffers.affected_by_delay(
     goto_model.symbol_table, value_sets, goto_model.goto_functions);
 
-  for(std::set<irep_idt>::iterator it=
-    shared_buffers.affected_by_delay_set.begin();
-    it!=shared_buffers.affected_by_delay_set.end();
-    it++)
+  for(id_sett::iterator it = shared_buffers.affected_by_delay_set.begin();
+      it != shared_buffers.affected_by_delay_set.end();
+      it++)
     message.debug()<<id2string(*it)<<messaget::eom;
 
   message.status()<<"I instrument:"<<messaget::eom;
-  for(std::set<irep_idt>::iterator it=shared_buffers.cycles.begin();
-    it!=shared_buffers.cycles.end(); it++)
+  for(id_sett::iterator it = shared_buffers.cycles.begin();
+      it != shared_buffers.cycles.end();
+      it++)
   {
     typedef std::multimap<irep_idt, source_locationt>::iterator m_itt;
     const std::pair<m_itt, m_itt> ran=

--- a/src/goto-programs/compute_called_functions.cpp
+++ b/src/goto-programs/compute_called_functions.cpp
@@ -14,9 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/std_expr.h>
 
 /// get all functions whose address is taken
-void compute_address_taken_functions(
-  const exprt &src,
-  std::set<irep_idt> &address_taken)
+void compute_address_taken_functions(const exprt &src, id_sett &address_taken)
 {
   forall_operands(it, src)
     compute_address_taken_functions(*it, address_taken);
@@ -33,9 +31,7 @@ void compute_address_taken_functions(
 }
 
 /// get all functions in the expression
-void compute_functions(
-  const exprt &src,
-  std::set<irep_idt> &address_taken)
+void compute_functions(const exprt &src, id_sett &address_taken)
 {
   forall_operands(it, src)
     compute_functions(*it, address_taken);
@@ -48,7 +44,7 @@ void compute_functions(
 /// get all functions whose address is taken
 void compute_address_taken_functions(
   const goto_programt &goto_program,
-  std::set<irep_idt> &address_taken)
+  id_sett &address_taken)
 {
   forall_goto_program_instructions(it, goto_program)
   {
@@ -60,28 +56,26 @@ void compute_address_taken_functions(
 /// get all functions whose address is taken
 void compute_address_taken_functions(
   const goto_functionst &goto_functions,
-  std::set<irep_idt> &address_taken)
+  id_sett &address_taken)
 {
   forall_goto_functions(it, goto_functions)
     compute_address_taken_functions(it->second.body, address_taken);
 }
 
 /// get all functions whose address is taken
-std::set<irep_idt> compute_address_taken_functions(
-  const goto_functionst &goto_functions)
+id_sett compute_address_taken_functions(const goto_functionst &goto_functions)
 {
-  std::set<irep_idt> address_taken;
+  id_sett address_taken;
   compute_address_taken_functions(goto_functions, address_taken);
   return address_taken;
 }
 
 /// computes the functions that are (potentially) called
-std::set<irep_idt> compute_called_functions(
-  const goto_functionst &goto_functions)
+id_sett compute_called_functions(const goto_functionst &goto_functions)
 {
-  std::set<irep_idt> working_queue;
-  std::set<irep_idt> done;
-  std::set<irep_idt> functions;
+  id_sett working_queue;
+  id_sett done;
+  id_sett functions;
 
   // start from entry point
   working_queue.insert(goto_functions.entry_point());
@@ -123,8 +117,7 @@ std::set<irep_idt> compute_called_functions(
 }
 
 /// computes the functions that are (potentially) called
-std::set<irep_idt> compute_called_functions(
-  const goto_modelt &goto_model)
+id_sett compute_called_functions(const goto_modelt &goto_model)
 {
   return compute_called_functions(goto_model.goto_functions);
 }

--- a/src/goto-programs/compute_called_functions.h
+++ b/src/goto-programs/compute_called_functions.h
@@ -16,20 +16,14 @@ Author: Daniel Kroening, kroening@kroening.com
 
 // compute the set of functions whose address is taken
 
-void compute_address_taken_functions(
-  const exprt &,
-  std::set<irep_idt> &);
+void compute_address_taken_functions(const exprt &, id_sett &);
 
-void compute_address_taken_functions(
-  const goto_programt &,
-  std::set<irep_idt> &);
+void compute_address_taken_functions(const goto_programt &, id_sett &);
 
-void compute_address_taken_functions(
-  const goto_functionst &,
-  std::set<irep_idt> &);
+void compute_address_taken_functions(const goto_functionst &, id_sett &);
 
 // computes the functions that are (potentially) called
-std::set<irep_idt> compute_called_functions(const goto_functionst &);
-std::set<irep_idt> compute_called_functions(const goto_modelt &);
+id_sett compute_called_functions(const goto_functionst &);
+id_sett compute_called_functions(const goto_modelt &);
 
 #endif // CPROVER_GOTO_PROGRAMS_COMPUTE_CALLED_FUNCTIONS_H

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1478,9 +1478,7 @@ void goto_convertt::convert_specc_notify(
   copy(code, OTHER, dest);
 }
 
-void goto_convertt::convert_specc_event(
-  const exprt &op,
-  std::set<irep_idt> &events)
+void goto_convertt::convert_specc_event(const exprt &op, id_sett &events)
 {
   if(op.id()==ID_or || op.id()==ID_and)
   {

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -228,8 +228,7 @@ protected:
   void convert_specc_notify(const codet &code, goto_programt &dest);
   void convert_specc_wait(const codet &code, goto_programt &dest);
   void convert_specc_par(const codet &code, goto_programt &dest);
-  void convert_specc_event(const exprt &op,
-                           std::set<irep_idt> &events);
+  void convert_specc_event(const exprt &op, id_sett &events);
   void convert_start_thread(const codet &code, goto_programt &dest);
   void convert_end_thread(const codet &code, goto_programt &dest);
   void convert_atomic_begin(const codet &code, goto_programt &dest);

--- a/src/goto-programs/goto_functions.cpp
+++ b/src/goto-programs/goto_functions.cpp
@@ -74,10 +74,7 @@ void goto_functionst::compute_loop_numbers()
   }
 }
 
-
-void get_local_identifiers(
-  const goto_functiont &goto_function,
-  std::set<irep_idt> &dest)
+void get_local_identifiers(const goto_functiont &goto_function, id_sett &dest)
 {
   goto_function.body.get_decl_identifiers(dest);
 

--- a/src/goto-programs/goto_functions.h
+++ b/src/goto-programs/goto_functions.h
@@ -213,8 +213,6 @@ public:
       it=(functions).function_map.begin(); \
       it!=(functions).function_map.end(); it++)
 
-void get_local_identifiers(
-  const goto_functiont &,
-  std::set<irep_idt> &dest);
+void get_local_identifiers(const goto_functiont &, id_sett &dest);
 
 #endif // CPROVER_GOTO_PROGRAMS_GOTO_FUNCTIONS_H

--- a/src/goto-programs/goto_inline_class.h
+++ b/src/goto-programs/goto_inline_class.h
@@ -193,13 +193,13 @@ protected:
   typedef goto_functionst::function_mapt cachet;
   cachet cache;
 
-  typedef std::unordered_set<irep_idt, irep_id_hash> finished_sett;
+  typedef unordered_id_sett finished_sett;
   finished_sett finished_set;
 
-  typedef std::unordered_set<irep_idt, irep_id_hash> recursion_sett;
+  typedef unordered_id_sett recursion_sett;
   recursion_sett recursion_set;
 
-  typedef std::unordered_set<irep_idt, irep_id_hash> no_body_sett;
+  typedef unordered_id_sett no_body_sett;
   no_body_sett no_body_set;
 };
 

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -608,7 +608,7 @@ public:
   /// Does the goto program have an assertion?
   bool has_assertion() const;
 
-  typedef std::set<irep_idt> decl_identifierst;
+  typedef id_sett decl_identifierst;
   /// get the variables in decl statements
   void get_decl_identifiers(decl_identifierst &decl_identifiers) const;
 };

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -808,7 +808,7 @@ void interpretert::execute_function_call()
     frame.return_value_address=return_value_address;
 
     // local variables
-    std::set<irep_idt> locals;
+    id_sett locals;
     get_local_identifiers(f_it->second, locals);
 
     for(const auto &id : locals)

--- a/src/goto-programs/lazy_goto_functions_map.h
+++ b/src/goto-programs/lazy_goto_functions_map.h
@@ -61,7 +61,7 @@ private:
   /// Names of functions that are already fully available in the programt state.
   /// \remarks These functions do not need processing before being returned
   /// whenever they are requested
-  mutable std::unordered_set<irep_idt, irep_id_hash> processed_functions;
+  mutable unordered_id_sett processed_functions;
 
   language_filest &language_files;
   symbol_tablet &symbol_table;

--- a/src/goto-programs/link_goto_model.cpp
+++ b/src/goto-programs/link_goto_model.cpp
@@ -47,7 +47,7 @@ static bool link_functions(
   const symbol_tablet &src_symbol_table,
   goto_functionst &src_functions,
   const rename_symbolt &rename_symbol,
-  const std::unordered_set<irep_idt, irep_id_hash> &weak_symbols,
+  const unordered_id_sett &weak_symbols,
   const replace_symbolt &object_type_updates)
 {
   namespacet ns(dest_symbol_table);

--- a/src/goto-programs/link_goto_model.cpp
+++ b/src/goto-programs/link_goto_model.cpp
@@ -158,8 +158,7 @@ void link_goto_model(
   goto_modelt &src,
   message_handlert &message_handler)
 {
-  typedef std::unordered_set<irep_idt, irep_id_hash> id_sett;
-  id_sett weak_symbols;
+  unordered_id_sett weak_symbols;
 
   for(const auto &symbol_pair : dest.symbol_table.symbols)
   {

--- a/src/goto-programs/link_to_library.cpp
+++ b/src/goto-programs/link_to_library.cpp
@@ -41,16 +41,15 @@ void link_to_library(
   message.status() << "Adding CPROVER library ("
                    << config.ansi_c.arch << ")" << messaget::eom;
 
-  std::set<irep_idt> added_functions;
+  id_sett added_functions;
 
   while(true)
   {
-    std::set<irep_idt> called_functions=
-      compute_called_functions(goto_functions);
+    id_sett called_functions = compute_called_functions(goto_functions);
 
     // eliminate those for which we already have a body
 
-    std::set<irep_idt> missing_functions;
+    id_sett missing_functions;
 
     for(const auto &id : called_functions)
     {

--- a/src/goto-programs/remove_exceptions.cpp
+++ b/src/goto-programs/remove_exceptions.cpp
@@ -569,7 +569,7 @@ void remove_exceptions(
   remove_exceptions_typest type)
 {
   const namespacet ns(symbol_table);
-  std::map<irep_idt, std::set<irep_idt>> exceptions_map;
+  std::map<irep_idt, id_sett> exceptions_map;
   uncaught_exceptions(goto_functions, ns, exceptions_map);
   remove_exceptionst::function_may_throwt function_may_throw =
     [&exceptions_map](const irep_idt &id) { // NOLINT(whitespace/braces)

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -61,7 +61,7 @@ protected:
     goto_programt &goto_program,
     goto_programt::targett target);
 
-  std::set<irep_idt> address_taken;
+  id_sett address_taken;
 
   typedef std::map<irep_idt, code_typet> type_mapt;
   type_mapt type_map;
@@ -80,8 +80,7 @@ protected:
     code_function_callt &function_call,
     goto_programt &dest);
 
-  void compute_address_taken_in_symbols(
-    std::set<irep_idt> &address_taken)
+  void compute_address_taken_in_symbols(id_sett &address_taken)
   {
     const symbol_tablet &symbol_table=ns.get_symbol_table();
 

--- a/src/goto-programs/remove_unused_functions.cpp
+++ b/src/goto-programs/remove_unused_functions.cpp
@@ -24,7 +24,7 @@ void remove_unused_functions(
   goto_functionst &functions,
   message_handlert &message_handler)
 {
-  std::set<irep_idt> used_functions;
+  id_sett used_functions;
   std::list<goto_functionst::function_mapt::iterator> unused_functions;
   find_used_functions(
     goto_functionst::entry_point(), functions, used_functions);
@@ -55,10 +55,9 @@ void remove_unused_functions(
 void find_used_functions(
   const irep_idt &start,
   goto_functionst &functions,
-  std::set<irep_idt> &seen)
+  id_sett &seen)
 {
-  std::pair<std::set<irep_idt>::const_iterator, bool> res =
-    seen.insert(start);
+  std::pair<id_sett::const_iterator, bool> res = seen.insert(start);
 
   if(!res.second)
     return;

--- a/src/goto-programs/remove_unused_functions.h
+++ b/src/goto-programs/remove_unused_functions.h
@@ -27,6 +27,6 @@ void remove_unused_functions(
 void find_used_functions(
   const irep_idt &current,
   goto_functionst &functions,
-  std::set<irep_idt> &seen);
+  id_sett &seen);
 
 #endif // CPROVER_GOTO_PROGRAMS_REMOVE_UNUSED_FUNCTIONS_H

--- a/src/goto-programs/set_properties.cpp
+++ b/src/goto-programs/set_properties.cpp
@@ -16,7 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 void set_properties(
   goto_programt &goto_program,
-  std::unordered_set<irep_idt, irep_id_hash> &property_set)
+  unordered_id_sett &property_set)
 {
   for(goto_programt::instructionst::iterator
       it=goto_program.instructions.begin();
@@ -28,8 +28,7 @@ void set_properties(
 
     irep_idt property_id=it->source_location.get_property_id();
 
-    std::unordered_set<irep_idt, irep_id_hash>::iterator
-      c_it=property_set.find(property_id);
+    unordered_id_sett::iterator c_it = property_set.find(property_id);
 
     if(c_it==property_set.end())
       it->type=SKIP;
@@ -102,7 +101,7 @@ void set_properties(
   goto_functionst &goto_functions,
   const std::list<std::string> &properties)
 {
-  std::unordered_set<irep_idt, irep_id_hash> property_set;
+  unordered_id_sett property_set;
 
   property_set.insert(properties.begin(), properties.end());
 

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -61,7 +61,7 @@ public:
   typedef std::map<irep_idt, irep_idt> original_identifierst;
 
   // we remember all L1 renamings
-  typedef std::set<irep_idt> l1_historyt;
+  typedef id_sett l1_historyt;
   l1_historyt l1_history;
 
   struct renaming_levelt
@@ -273,7 +273,7 @@ public:
 
     renaming_levelt::current_namest old_level1;
 
-    typedef std::set<irep_idt> local_objectst;
+    typedef id_sett local_objectst;
     local_objectst local_objects;
 
     framet():

--- a/src/goto-symex/partial_order_concurrency.cpp
+++ b/src/goto-symex/partial_order_concurrency.cpp
@@ -28,7 +28,7 @@ partial_order_concurrencyt::~partial_order_concurrencyt()
 void partial_order_concurrencyt::add_init_writes(
   symex_target_equationt &equation)
 {
-  std::unordered_set<irep_idt, irep_id_hash> init_done;
+  unordered_id_sett init_done;
   bool spawn_seen=false;
 
   symex_target_equationt::SSA_stepst init_steps;

--- a/src/goto-symex/postcondition.cpp
+++ b/src/goto-symex/postcondition.cpp
@@ -175,7 +175,7 @@ bool postconditiont::is_used(
 
     value_setst::valuest expr_set;
     value_set.get_value_set(expr.op0(), expr_set, ns);
-    std::unordered_set<irep_idt, irep_id_hash> symbols;
+    unordered_id_sett symbols;
 
     for(value_setst::valuest::const_iterator
         it=expr_set.begin();

--- a/src/goto-symex/precondition.cpp
+++ b/src/goto-symex/precondition.cpp
@@ -117,7 +117,7 @@ void preconditiont::compute_rec(exprt &dest)
 
     value_setst::valuest expr_set;
     value_sets.get_values(target, dest.op0(), expr_set);
-    std::unordered_set<irep_idt, irep_id_hash> symbols;
+    unordered_id_sett symbols;
 
     for(value_setst::valuest::const_iterator
         it=expr_set.begin();

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -29,7 +29,7 @@ void slice(
 
 // Collects "open" variables that are used but not assigned
 
-typedef std::unordered_set<irep_idt, irep_id_hash> symbol_sett;
+typedef unordered_id_sett symbol_sett;
 
 void collect_open_variables(
   const symex_target_equationt &equation,

--- a/src/goto-symex/slice_by_trace.cpp
+++ b/src/goto-symex/slice_by_trace.cpp
@@ -213,7 +213,7 @@ void symex_slice_by_tracet::parse_events(std::string read_line)
     parity=false;
   if(!parity)
     read_line=read_line.substr(1, read_line.size()-1);
-  std::set<irep_idt> eis;
+  id_sett eis;
   size_t vlength=read_line.length();
   for(size_t vidx=0; vidx < vlength; vidx++)
   {

--- a/src/goto-symex/slice_by_trace.h
+++ b/src/goto-symex/slice_by_trace.h
@@ -29,12 +29,12 @@ public:
 
  protected:
   const namespacet &ns;
-  typedef std::set<irep_idt> alphabett;
+  typedef id_sett alphabett;
   alphabett alphabet;
   bool alphabet_parity;
   std::string semantics;
 
-  typedef std::pair<std::set<irep_idt>, bool> event_sett;
+  typedef std::pair<id_sett, bool> event_sett;
   typedef std::vector<event_sett> event_tracet;
 
   event_tracet sigma;

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -376,15 +376,14 @@ void goto_symext::locality(
     state.threads[state.source.thread_nr].function_frame[function_identifier];
   frame_nr++;
 
-  std::set<irep_idt> local_identifiers;
+  id_sett local_identifiers;
 
   get_local_identifiers(goto_function, local_identifiers);
 
   statet::framet &frame=state.top();
 
-  for(std::set<irep_idt>::const_iterator
-      it=local_identifiers.begin();
-      it!=local_identifiers.end();
+  for(id_sett::const_iterator it = local_identifiers.begin();
+      it != local_identifiers.end();
       it++)
   {
     // get L0 name

--- a/src/java_bytecode/ci_lazy_methods.cpp
+++ b/src/java_bytecode/ci_lazy_methods.cpp
@@ -110,7 +110,7 @@ bool ci_lazy_methodst::operator()(
     extra_entry_points.begin(),
     extra_entry_points.end());
 
-  std::set<irep_idt> instantiated_classes;
+  id_sett instantiated_classes;
 
   {
     std::vector<irep_idt> initial_callable_methods;
@@ -128,7 +128,7 @@ bool ci_lazy_methodst::operator()(
       initial_callable_methods.end());
   }
 
-  std::set<irep_idt> methods_already_populated;
+  id_sett methods_already_populated;
   std::vector<const code_function_callt *> virtual_callsites;
 
   bool any_new_methods=false;
@@ -414,7 +414,7 @@ void ci_lazy_methodst::gather_virtual_callsites(
 ///   defined on classes that are not 'needed' are ignored)
 void ci_lazy_methodst::get_virtual_method_targets(
   const exprt &called_function,
-  const std::set<irep_idt> &instantiated_classes,
+  const id_sett &instantiated_classes,
   std::vector<irep_idt> &callable_methods,
   symbol_tablet &symbol_table)
 {
@@ -553,7 +553,7 @@ void ci_lazy_methodst::gather_field_types(
 ///   `call_basename` if found and `classname` is present in
 ///   `instantiated_classes`, or irep_idt() otherwise.
 irep_idt ci_lazy_methodst::get_virtual_method_target(
-  const std::set<irep_idt> &instantiated_classes,
+  const id_sett &instantiated_classes,
   const irep_idt &call_basename,
   const irep_idt &classname,
   const symbol_tablet &symbol_table)

--- a/src/java_bytecode/ci_lazy_methods.h
+++ b/src/java_bytecode/ci_lazy_methods.h
@@ -135,7 +135,7 @@ private:
 
   void get_virtual_method_targets(
     const exprt &called_function,
-    const std::set<irep_idt> &instantiated_classes,
+    const id_sett &instantiated_classes,
     std::vector<irep_idt> &callable_methods,
     symbol_tablet &symbol_table);
 
@@ -150,7 +150,7 @@ private:
     ci_lazy_methods_neededt &needed_lazy_methods);
 
   irep_idt get_virtual_method_target(
-    const std::set<irep_idt> &instantiated_classes,
+    const id_sett &instantiated_classes,
     const irep_idt &call_basename,
     const irep_idt &classname,
     const symbol_tablet &symbol_table);

--- a/src/java_bytecode/ci_lazy_methods_needed.h
+++ b/src/java_bytecode/ci_lazy_methods_needed.h
@@ -21,11 +21,11 @@ class ci_lazy_methods_neededt
 public:
   ci_lazy_methods_neededt(
     std::vector<irep_idt> &_callable_methods,
-    std::set<irep_idt> &_instantiated_classes,
-    symbol_tablet &_symbol_table):
-  callable_methods(_callable_methods),
-  instantiated_classes(_instantiated_classes),
-  symbol_table(_symbol_table)
+    id_sett &_instantiated_classes,
+    symbol_tablet &_symbol_table)
+    : callable_methods(_callable_methods),
+      instantiated_classes(_instantiated_classes),
+      symbol_table(_symbol_table)
   {}
 
   void add_needed_method(const irep_idt &);
@@ -42,7 +42,7 @@ private:
   // instantiated_classes on the other hand is a true set of every class
   // found so far, so we can use a membership test to avoid
   // repeatedly exploring a class hierarchy.
-  std::set<irep_idt> &instantiated_classes;
+  id_sett &instantiated_classes;
   symbol_tablet &symbol_table;
 };
 

--- a/src/java_bytecode/java_bytecode_convert_class.cpp
+++ b/src/java_bytecode/java_bytecode_convert_class.cpp
@@ -439,7 +439,7 @@ void java_bytecode_convert_classt::convert(
   }
 
   // Now do methods
-  std::set<irep_idt> overlay_methods;
+  id_sett overlay_methods;
   for(auto overlay_class : overlay_classes)
   {
     for(const methodt &method : overlay_class.get().methods)

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -819,7 +819,7 @@ const select_pointer_typet &
 /// \return Populates `methods` with the complete list of lazy methods that are
 ///   available to convert (those which are valid parameters for
 ///   `convert_lazy_method`)
-void java_bytecode_languaget::methods_provided(id_sett &methods) const
+void java_bytecode_languaget::methods_provided(unordered_id_sett &methods) const
 {
   // Add all string solver methods to map
   string_preprocess.get_all_function_names(methods);

--- a/src/java_bytecode/java_bytecode_language.h
+++ b/src/java_bytecode/java_bytecode_language.h
@@ -135,7 +135,7 @@ public:
   std::set<std::string> extensions() const override;
 
   void modules_provided(std::set<std::string> &modules) override;
-  virtual void methods_provided(id_sett &methods) const override;
+  virtual void methods_provided(unordered_id_sett &methods) const override;
   virtual void convert_lazy_method(
     const irep_idt &function_id,
     symbol_table_baset &symbol_table) override;

--- a/src/java_bytecode/java_bytecode_parse_tree.h
+++ b/src/java_bytecode/java_bytecode_parse_tree.h
@@ -274,7 +274,7 @@ public:
 
   void output(std::ostream &out) const;
 
-  typedef std::set<irep_idt> class_refst;
+  typedef id_sett class_refst;
   class_refst class_refs;
 
   bool loading_successful;

--- a/src/java_bytecode/java_bytecode_typecheck.h
+++ b/src/java_bytecode/java_bytecode_typecheck.h
@@ -75,7 +75,7 @@ protected:
   virtual std::string to_string(const exprt &expr);
   virtual std::string to_string(const typet &type);
 
-  std::set<irep_idt> already_typechecked;
+  id_sett already_typechecked;
 };
 
 #endif // CPROVER_JAVA_BYTECODE_JAVA_BYTECODE_TYPECHECK_H

--- a/src/java_bytecode/java_object_factory.cpp
+++ b/src/java_bytecode/java_object_factory.cpp
@@ -67,7 +67,7 @@ class java_object_factoryt
   /// non-det generator visits a type, the type is added to this set. We forbid
   /// the non-det initialization when we see the type for the second time in
   /// this set AND the tree depth becomes >= than the maximum value above.
-  std::unordered_set<irep_idt, irep_id_hash> recursion_set;
+  unordered_id_sett recursion_set;
 
   /// Every time the non-det generator visits a type and the type is generic
   /// (either a struct or a pointer), the following map is used to store and
@@ -465,7 +465,7 @@ void java_object_factoryt::gen_pointer_target_init(
 class recursion_set_entryt
 {
   /// Recursion set to modify
-  std::unordered_set<irep_idt, irep_id_hash> &recursion_set;
+  unordered_id_sett &recursion_set;
   /// Entry to erase on destruction, if non-empty
   irep_idt erase_entry;
 
@@ -473,8 +473,7 @@ public:
   /// Initialize a recursion-set entry owner operating on a given set.
   /// Initially it does not own any set entry.
   /// \param _recursion_set: set to operate on.
-  explicit recursion_set_entryt(
-    std::unordered_set<irep_idt, irep_id_hash> &_recursion_set)
+  explicit recursion_set_entryt(unordered_id_sett &_recursion_set)
     : recursion_set(_recursion_set)
   { }
 

--- a/src/java_bytecode/java_static_initializers.cpp
+++ b/src/java_bytecode/java_static_initializers.cpp
@@ -264,7 +264,7 @@ static itertype advance_to_next_key(itertype in, itertype end)
 ///   when it is required.
 void stub_global_initializer_factoryt::create_stub_global_initializer_symbols(
   symbol_tablet &symbol_table,
-  const std::unordered_set<irep_idt, irep_id_hash> &stub_globals_set,
+  const unordered_id_sett &stub_globals_set,
   synthetic_methods_mapt &synthetic_methods)
 {
   // Populate map from class id -> stub globals:

--- a/src/java_bytecode/java_static_initializers.h
+++ b/src/java_bytecode/java_static_initializers.h
@@ -38,7 +38,7 @@ class stub_global_initializer_factoryt
 public:
   void create_stub_global_initializer_symbols(
     symbol_tablet &symbol_table,
-    const std::unordered_set<irep_idt, irep_id_hash> &stub_globals_set,
+    const unordered_id_sett &stub_globals_set,
     synthetic_methods_mapt &synthetic_methods);
 
   codet get_stub_initializer_body(
@@ -50,7 +50,7 @@ public:
 
 void create_stub_global_initializers(
   symbol_tablet &symbol_table,
-  const std::unordered_set<irep_idt, irep_id_hash> &stub_globals_set,
+  const unordered_id_sett &stub_globals_set,
   const object_factory_parameterst &object_factory_parameters,
   const select_pointer_typet &pointer_type_selector);
 

--- a/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/src/java_bytecode/java_string_library_preprocess.cpp
@@ -1827,7 +1827,7 @@ void add_keys_to_container(const TMap &map, TContainer &container)
 }
 
 void java_string_library_preprocesst::get_all_function_names(
-  id_sett &methods) const
+  unordered_id_sett &methods) const
 {
   for(const id_mapt *map : id_maps)
     add_keys_to_container(*map, methods);

--- a/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/src/java_bytecode/java_string_library_preprocess.cpp
@@ -1893,11 +1893,14 @@ bool java_string_library_preprocesst::is_known_string_type(
 
 void java_string_library_preprocesst::initialize_known_type_table()
 {
-  string_types=
-    std::unordered_set<irep_idt, irep_id_hash>{"java.lang.String",
-                                               "java.lang.StringBuilder",
-                                               "java.lang.CharSequence",
-                                               "java.lang.StringBuffer"};
+  string_types =
+    unordered_id_sett
+    {
+      "java.lang.String",
+      "java.lang.StringBuilder",
+      "java.lang.CharSequence",
+      "java.lang.StringBuffer"
+    };
 }
 
 /// fill maps with correspondence from java method names to conversion functions

--- a/src/java_bytecode/java_string_library_preprocess.h
+++ b/src/java_bytecode/java_string_library_preprocess.h
@@ -31,8 +31,6 @@ Date:   March 2017
 // Arbitrary limit of 10 arguments for the number of arguments to String.format
 #define MAX_FORMAT_ARGS 10
 
-typedef std::unordered_set<irep_idt, irep_id_hash> id_sett;
-
 class java_string_library_preprocesst:public messaget
 {
 public:
@@ -48,7 +46,7 @@ public:
   void initialize_refined_string_type();
 
   bool implements_function(const irep_idt &function_id) const;
-  void get_all_function_names(id_sett &methods) const;
+  void get_all_function_names(unordered_id_sett &methods) const;
 
   exprt
   code_for_function(const symbolt &symbol, symbol_table_baset &symbol_table);

--- a/src/java_bytecode/java_string_library_preprocess.h
+++ b/src/java_bytecode/java_string_library_preprocess.h
@@ -141,7 +141,7 @@ private:
     };
 
   // A set tells us what java types should be considered as string objects
-  std::unordered_set<irep_idt, irep_id_hash> string_types;
+  unordered_id_sett string_types;
 
   codet make_equals_function_code(
     const code_typet &type,

--- a/src/java_bytecode/java_types.cpp
+++ b/src/java_bytecode/java_types.cpp
@@ -744,9 +744,7 @@ bool equal_java_types(const typet &type1, const typet &type2)
   return (type1 == type2 && arrays_with_same_element_type);
 }
 
-void get_dependencies_from_generic_parameters_rec(
-  const typet &t,
-  std::set<irep_idt> &refs)
+void get_dependencies_from_generic_parameters_rec(const typet &t, id_sett &refs)
 {
   // Java generic type that holds different types in its type arguments
   if(is_java_generic_type(t))
@@ -793,7 +791,7 @@ void get_dependencies_from_generic_parameters_rec(
 /// \param refs [out]: the set to insert the names of the found dependencies
 void get_dependencies_from_generic_parameters(
   const std::string &signature,
-  std::set<irep_idt> &refs)
+  id_sett &refs)
 {
   try
   {
@@ -827,9 +825,7 @@ void get_dependencies_from_generic_parameters(
 /// only appear as generic type argument, not as a field reference.
 /// \param t: the type to analyze
 /// \param refs [out]: the set to insert the names of the found dependencies
-void get_dependencies_from_generic_parameters(
-  const typet &t,
-  std::set<irep_idt> &refs)
+void get_dependencies_from_generic_parameters(const typet &t, id_sett &refs)
 {
   get_dependencies_from_generic_parameters_rec(t, refs);
 }

--- a/src/java_bytecode/java_types.h
+++ b/src/java_bytecode/java_types.h
@@ -564,12 +564,8 @@ inline const optionalt<size_t> java_generics_get_index_for_subtype(
   return std::distance(gen_types.cbegin(), iter);
 }
 
-void get_dependencies_from_generic_parameters(
-  const std::string &,
-  std::set<irep_idt> &);
-void get_dependencies_from_generic_parameters(
-  const typet &,
-  std::set<irep_idt> &);
+void get_dependencies_from_generic_parameters(const std::string &, id_sett &);
+void get_dependencies_from_generic_parameters(const typet &, id_sett &);
 
 /// Type for a generic symbol, extends symbol_typet with a
 /// vector of java generic types.

--- a/src/java_bytecode/java_utils.cpp
+++ b/src/java_bytecode/java_utils.cpp
@@ -127,7 +127,7 @@ irep_idt resolve_friendly_method_name(
   if(friendly_name.rfind(':')==std::string::npos)
   {
     std::string prefix=qualified_name+':';
-    std::set<irep_idt> matches;
+    id_sett matches;
 
     for(const auto &s : symbol_table.symbols)
       if(has_prefix(id2string(s.first), prefix) &&

--- a/src/java_bytecode/java_utils.cpp
+++ b/src/java_bytecode/java_utils.cpp
@@ -420,11 +420,11 @@ resolve_inherited_componentt::inherited_componentt get_inherited_component(
 /// \return true if this static field is known never to be null
 bool is_non_null_library_global(const irep_idt &symbolid)
 {
-  static const std::unordered_set<irep_idt, irep_id_hash> non_null_globals =
-  {
-    "java::java.lang.System.out",
-    "java::java.lang.System.err",
-    "java::java.lang.System.in"
-  };
+  static const unordered_id_sett non_null_globals =
+    {
+      "java::java.lang.System.out",
+      "java::java.lang.System.err",
+      "java::java.lang.System.in"
+    };
   return non_null_globals.count(symbolid);
 }

--- a/src/jsil/jsil_typecheck.h
+++ b/src/jsil/jsil_typecheck.h
@@ -94,7 +94,7 @@ protected:
   virtual std::string to_string(const exprt &expr);
   virtual std::string to_string(const typet &type);
 
-  std::unordered_set<irep_idt, irep_id_hash> already_typechecked;
+  unordered_id_sett already_typechecked;
 };
 
 #endif // CPROVER_JSIL_JSIL_TYPECHECK_H

--- a/src/langapi/language.h
+++ b/src/langapi/language.h
@@ -23,8 +23,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <goto-programs/system_library_symbols.h>
 
-typedef std::unordered_set<irep_idt, irep_id_hash> id_sett;
-
 class symbol_tablet;
 class symbol_table_baset;
 class exprt;
@@ -79,7 +77,7 @@ public:
 
   // add lazy functions provided to set
 
-  virtual void methods_provided(id_sett &methods) const
+  virtual void methods_provided(unordered_id_sett &methods) const
   { }
 
   // populate a lazy method

--- a/src/langapi/language_file.cpp
+++ b/src/langapi/language_file.cpp
@@ -144,7 +144,7 @@ bool language_filest::typecheck(symbol_tablet &symbol_table)
       // register lazy methods.
       // TODO: learn about modules and generalise this
       // to module-providing languages if required.
-      id_sett lazy_method_ids;
+      unordered_id_sett lazy_method_ids;
       file.second.language->methods_provided(lazy_method_ids);
       for(const auto &id : lazy_method_ids)
         lazy_method_map[id]=&file.second;

--- a/src/langapi/language_file.h
+++ b/src/langapi/language_file.h
@@ -83,7 +83,7 @@ public:
   {
     // Clear relevant entries from lazy_method_map
     language_filet *language_file = &file_map.at(filename);
-    id_sett files_methods;
+    unordered_id_sett files_methods;
     for(const std::pair<irep_idt, language_filet *> &method : lazy_method_map)
     {
       if(method.second == language_file)

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -1162,7 +1162,7 @@ bool linkingt::needs_renaming_type(
   return true; // different
 }
 
-void linkingt::do_type_dependencies(id_sett &needs_to_be_renamed)
+void linkingt::do_type_dependencies(unordered_id_sett &needs_to_be_renamed)
 {
   // Any type that uses a symbol that will be renamed also
   // needs to be renamed, and so on, until saturation.
@@ -1186,9 +1186,8 @@ void linkingt::do_type_dependencies(id_sett &needs_to_be_renamed)
 
   std::stack<irep_idt> queue;
 
-  for(id_sett::const_iterator
-      d_it=needs_to_be_renamed.begin();
-      d_it!=needs_to_be_renamed.end();
+  for(unordered_id_sett::const_iterator d_it = needs_to_be_renamed.begin();
+      d_it != needs_to_be_renamed.end();
       d_it++)
     queue.push(*d_it);
 
@@ -1197,11 +1196,9 @@ void linkingt::do_type_dependencies(id_sett &needs_to_be_renamed)
     irep_idt id=queue.top();
     queue.pop();
 
-    const id_sett &u=used_by[id];
+    const unordered_id_sett &u = used_by[id];
 
-    for(id_sett::const_iterator
-        d_it=u.begin();
-        d_it!=u.end();
+    for(unordered_id_sett::const_iterator d_it = u.begin(); d_it != u.end();
         d_it++)
       if(needs_to_be_renamed.insert(*d_it).second)
       {
@@ -1214,7 +1211,7 @@ void linkingt::do_type_dependencies(id_sett &needs_to_be_renamed)
   }
 }
 
-void linkingt::rename_symbols(const id_sett &needs_to_be_renamed)
+void linkingt::rename_symbols(const unordered_id_sett &needs_to_be_renamed)
 {
   namespacet src_ns(src_symbol_table);
 
@@ -1258,7 +1255,7 @@ void linkingt::copy_symbols()
   }
 
   // Move over all the non-colliding ones
-  id_sett collisions;
+  unordered_id_sett collisions;
 
   for(const auto &named_symbol : src_symbols)
   {
@@ -1313,7 +1310,7 @@ void linkingt::typecheck()
 
   // PHASE 1: identify symbols to be renamed
 
-  id_sett needs_to_be_renamed;
+  unordered_id_sett needs_to_be_renamed;
 
   for(const auto &symbol_pair : src_symbol_table.symbols)
   {

--- a/src/linking/linking_class.h
+++ b/src/linking/linking_class.h
@@ -38,8 +38,6 @@ public:
   replace_symbolt object_type_updates;
 
 protected:
-  typedef std::unordered_set<irep_idt, irep_id_hash> id_sett;
-
   bool needs_renaming_type(
     const symbolt &old_symbol,
     const symbolt &new_symbol);
@@ -58,9 +56,9 @@ protected:
       return needs_renaming_non_type(old_symbol, new_symbol);
   }
 
-  void do_type_dependencies(id_sett &);
+  void do_type_dependencies(unordered_id_sett &);
 
-  void rename_symbols(const id_sett &needs_to_be_renamed);
+  void rename_symbols(const unordered_id_sett &needs_to_be_renamed);
   void copy_symbols();
 
   void duplicate_non_type_symbol(
@@ -94,8 +92,8 @@ protected:
     const symbolt &old_symbol;
     const symbolt &new_symbol;
     bool set_to_new;
-    id_sett o_symbols;
-    id_sett n_symbols;
+    unordered_id_sett o_symbols;
+    unordered_id_sett n_symbols;
   };
 
   bool adjust_object_type_rec(
@@ -173,12 +171,13 @@ protected:
   namespacet ns;
 
   // X -> Y iff Y uses X for new symbol type IDs X and Y
-  typedef std::unordered_map<irep_idt, id_sett, irep_id_hash> used_byt;
+  typedef std::unordered_map<irep_idt, unordered_id_sett, irep_id_hash>
+    used_byt;
 
   irep_idt rename(irep_idt);
 
   // the new IDs created by renaming
-  id_sett renamed_ids;
+  unordered_id_sett renamed_ids;
 };
 
 #endif // CPROVER_LINKING_LINKING_CLASS_H

--- a/src/pointer-analysis/goto_program_dereference.h
+++ b/src/pointer-analysis/goto_program_dereference.h
@@ -87,7 +87,7 @@ protected:
     const value_set_dereferencet::modet mode);
 
 #if 0
-  const std::set<irep_idt> *valid_local_variables;
+  const id_sett *valid_local_variables;
 #endif
   source_locationt dereference_location;
   goto_programt::const_targett current_target;

--- a/src/pointer-analysis/value_set_analysis_fi.cpp
+++ b/src/pointer-analysis/value_set_analysis_fi.cpp
@@ -138,7 +138,7 @@ void value_set_analysis_fit::add_vars(
   forall_goto_functions(f_it, goto_functions)
   {
     // get the locals
-    std::set<irep_idt> locals;
+    id_sett locals;
     get_local_identifiers(f_it->second, locals);
 
     for(auto l : locals)

--- a/src/pointer-analysis/value_set_analysis_fivr.cpp
+++ b/src/pointer-analysis/value_set_analysis_fivr.cpp
@@ -128,7 +128,7 @@ void value_set_analysis_fivrt::add_vars(
   forall_goto_functions(f_it, goto_functions)
   {
     // get the locals
-    std::set<irep_idt> locals;
+    id_sett locals;
     get_local_identifiers(f_it->second, locals);
 
     for(auto l : locals)

--- a/src/pointer-analysis/value_set_analysis_fivrns.cpp
+++ b/src/pointer-analysis/value_set_analysis_fivrns.cpp
@@ -128,7 +128,7 @@ void value_set_analysis_fivrnst::add_vars(
   forall_goto_functions(f_it, goto_functions)
   {
     // get the locals
-    std::set<irep_idt> locals;
+    id_sett locals;
     get_local_identifiers(f_it->second, locals);
 
     for(auto l : locals)

--- a/src/solvers/cvc/cvc_conv.cpp
+++ b/src/solvers/cvc/cvc_conv.cpp
@@ -1157,7 +1157,7 @@ void cvc_convt::set_to(const exprt &expr, bool value)
 
       if(id.type.is_nil())
       {
-        std::unordered_set<irep_idt, irep_id_hash> s_set;
+        unordered_id_sett s_set;
 
         ::find_symbols(expr.op1(), s_set);
 

--- a/src/solvers/smt1/smt1_conv.cpp
+++ b/src/solvers/smt1/smt1_conv.cpp
@@ -3019,13 +3019,11 @@ void smt1_convt::from_bool_end(const typet &type, bool bool_as_bv)
 
 void smt1_convt::find_symbols(const typet &type)
 {
-  std::set<irep_idt> rec_stack;
+  id_sett rec_stack;
   find_symbols_rec(type, rec_stack);
 }
 
-void smt1_convt::find_symbols_rec(
-  const typet &type,
-  std::set<irep_idt> &recstack)
+void smt1_convt::find_symbols_rec(const typet &type, id_sett &recstack)
 {
   if(type.id()==ID_array)
   {

--- a/src/solvers/smt1/smt1_conv.h
+++ b/src/solvers/smt1/smt1_conv.h
@@ -118,10 +118,10 @@ protected:
   void convert_literal(const literalt l);
 
   // auxiliary methods
-  std::set<irep_idt> quantified_symbols;
+  id_sett quantified_symbols;
   void find_symbols(const exprt &expr);
   void find_symbols(const typet &type);
-  void find_symbols_rec(const typet &type, std::set<irep_idt> &recstack);
+  void find_symbols_rec(const typet &type, id_sett &recstack);
   void flatten_array(const exprt &op);
 
   // booleans vs. bit-vector[1]

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -4475,13 +4475,11 @@ void smt2_convt::convert_type(const typet &type)
 
 void smt2_convt::find_symbols(const typet &type)
 {
-  std::set<irep_idt> recstack;
+  id_sett recstack;
   find_symbols_rec(type, recstack);
 }
 
-void smt2_convt::find_symbols_rec(
-  const typet &type,
-  std::set<irep_idt> &recstack)
+void smt2_convt::find_symbols_rec(const typet &type, id_sett &recstack)
 {
   if(type.id()==ID_array)
   {

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -171,7 +171,7 @@ protected:
   // auxiliary methods
   void find_symbols(const exprt &expr);
   void find_symbols(const typet &type);
-  void find_symbols_rec(const typet &type, std::set<irep_idt> &recstack);
+  void find_symbols_rec(const typet &type, id_sett &recstack);
 
   // letification
   typedef std::pair<unsigned, symbol_exprt> let_count_idt;
@@ -225,7 +225,7 @@ protected:
   void convert_floatbv(const exprt &expr);
   std::string type2id(const typet &) const;
   std::string floatbv_suffix(const exprt &) const;
-  std::set<irep_idt> bvfp_set; // already converted
+  id_sett bvfp_set; // already converted
 
   class smt2_symbolt:public exprt
   {

--- a/src/solvers/smt2/smt2_solver.cpp
+++ b/src/solvers/smt2/smt2_solver.cpp
@@ -38,7 +38,7 @@ protected:
   void define_constants(const exprt &);
   void expand_function_applications(exprt &);
 
-  std::set<irep_idt> constants_done;
+  id_sett constants_done;
 };
 
 void smt2_solvert::define_constants(const exprt &expr)

--- a/src/util/base_type.cpp
+++ b/src/util/base_type.cpp
@@ -18,8 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "namespace.h"
 #include "symbol.h"
 
-void base_type_rec(
-  typet &type, const namespacet &ns, std::set<irep_idt> &symb)
+void base_type_rec(typet &type, const namespacet &ns, id_sett &symb)
 {
   if(type.id()==ID_symbol ||
      type.id()==ID_c_enum_tag ||
@@ -78,7 +77,7 @@ void base_type_rec(
 
 void base_type(typet &type, const namespacet &ns)
 {
-  std::set<irep_idt> symb;
+  id_sett symb;
   base_type_rec(type, ns, symb);
 }
 

--- a/src/util/find_macros.h
+++ b/src/util/find_macros.h
@@ -17,7 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 class exprt;
 class namespacet;
 
-typedef std::unordered_set<irep_idt, irep_id_hash> find_macros_sett;
+typedef unordered_id_sett find_macros_sett;
 
 void find_macros(
   const exprt &src,

--- a/src/util/find_symbols.h
+++ b/src/util/find_symbols.h
@@ -19,7 +19,7 @@ class exprt;
 class symbol_exprt;
 class typet;
 
-typedef std::unordered_set<irep_idt, irep_id_hash> find_symbols_sett;
+typedef unordered_id_sett find_symbols_sett;
 
 void find_symbols(
   const exprt &src,

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <string>
 #include <cassert>
 #include <iosfwd>
+#include <unordered_set>
 
 #include "irep_ids.h"
 
@@ -43,6 +44,8 @@ typedef std::string irep_namet;
 // NOLINTNEXTLINE(readability/identifiers)
 typedef string_hash irep_id_hash;
 #endif
+
+typedef std::unordered_set<irep_idt, irep_id_hash> unordered_id_sett;
 
 inline const std::string &id2string(const irep_idt &d)
 {

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <string>
 #include <cassert>
 #include <iosfwd>
+#include <set>
 #include <unordered_set>
 
 #include "irep_ids.h"
@@ -45,6 +46,7 @@ typedef std::string irep_namet;
 typedef string_hash irep_id_hash;
 #endif
 
+typedef std::set<irep_idt> id_sett;
 typedef std::unordered_set<irep_idt, irep_id_hash> unordered_id_sett;
 
 inline const std::string &id2string(const irep_idt &d)

--- a/src/util/journalling_symbol_table.h
+++ b/src/util/journalling_symbol_table.h
@@ -34,7 +34,7 @@
 class journalling_symbol_tablet : public symbol_table_baset
 {
 public:
-  typedef std::unordered_set<irep_idt, irep_id_hash> changesett;
+  typedef unordered_id_sett changesett;
 
 private:
   symbol_table_baset &base_symbol_table;

--- a/unit/analyses/call_graph.cpp
+++ b/unit/analyses/call_graph.cpp
@@ -34,10 +34,10 @@ static symbolt create_void_function_symbol(
 static bool multimap_key_matches(
   const std::multimap<irep_idt, irep_idt> &map,
   const irep_idt &key,
-  const std::set<irep_idt> &values)
+  const id_sett &values)
 {
   auto matching_values=map.equal_range(key);
-  std::set<irep_idt> matching_set;
+  id_sett matching_set;
   for(auto it=matching_values.first; it!=matching_values.second; ++it)
     matching_set.insert(it->second);
   return matching_set==values;
@@ -195,7 +195,7 @@ SCENARIO("call_graph",
 
       THEN("We expect A to have successors {A, B}")
       {
-        std::set<irep_idt> successors = get_callees(exported, "A");
+        id_sett successors = get_callees(exported, "A");
         REQUIRE(successors.size() == 2);
         REQUIRE(successors.count("A"));
         REQUIRE(successors.count("B"));
@@ -203,15 +203,14 @@ SCENARIO("call_graph",
 
       THEN("We expect C to have predecessors {B}")
       {
-        std::set<irep_idt> predecessors = get_callers(exported, "C");
+        id_sett predecessors = get_callers(exported, "C");
         REQUIRE(predecessors.size() == 1);
         REQUIRE(predecessors.count("B"));
       }
 
       THEN("We expect all of {A, B, C, D} to be reachable from A")
       {
-        std::set<irep_idt> successors =
-          get_reachable_functions(exported, "A");
+        id_sett successors = get_reachable_functions(exported, "A");
         REQUIRE(successors.size() == 4);
         REQUIRE(successors.count("A"));
         REQUIRE(successors.count("B"));
@@ -221,8 +220,7 @@ SCENARIO("call_graph",
 
       THEN("We expect {D, B, A} to be able to reach D")
       {
-        std::set<irep_idt> predecessors =
-          get_reaching_functions(exported, "D");
+        id_sett predecessors = get_reaching_functions(exported, "D");
         REQUIRE(predecessors.size() == 3);
         REQUIRE(predecessors.count("A"));
         REQUIRE(predecessors.count("B"));


### PR DESCRIPTION
Call them unordered_id_sett to reflect the fact that these are unordered sets
Add matching id_sett for signed sets of identifiers.