### PR TITLE
Floating point simplification for goto-analyzer constants domain

### DIFF
--- a/regression/goto-analyzer/constant_propagation_floating_point_div/main.c
+++ b/regression/goto-analyzer/constant_propagation_floating_point_div/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+
+#define ROUND_F(x) ((int)((x) + 0.5f))
+int eight = ROUND_F(100.0f / 12.0f);
+
+int main()
+{
+  assert(eight == 8);
+}

--- a/regression/goto-analyzer/constant_propagation_floating_point_div/test.desc
+++ b/regression/goto-analyzer/constant_propagation_floating_point_div/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--constants --verify
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] file main.c line 8 function main, assertion eight == 8: Success$
+--
+^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_nondet_rounding_mode/main.c
+++ b/regression/goto-analyzer/constant_propagation_nondet_rounding_mode/main.c
@@ -1,0 +1,27 @@
+#include <assert.h>
+#include <fenv.h>
+#include <stdio.h>
+
+int nondet_rounding_mode(void);
+
+int main(void)
+{
+  // slightly bigger than 0.1
+  float f = 1.0f / 10.0f;
+
+  // now we don't know what rounding mode we're in
+  __CPROVER_rounding_mode = nondet_rounding_mode();
+  // depending on rounding mode 1.0f/10.0f could
+  // be greater or smaller than 0.1
+
+  // definitely not smaller than -0.1
+  assert((1.0f / 10.0f) - f < -0.1f);
+  // might be smaller than 0
+  assert((1.0f / 10.0f) - f < 0.0f);
+  // definitely smaller or equal to 0
+  assert((1.0f / 10.0f) - f <= 0.0f);
+  // might be greater or equal to 0
+  assert((1.0f / 10.0f) - f >= 0.0f);
+  // definitely not greater than 0
+  assert((1.0f / 10.0f) - f > 0.0f);
+}

--- a/regression/goto-analyzer/constant_propagation_nondet_rounding_mode/test.desc
+++ b/regression/goto-analyzer/constant_propagation_nondet_rounding_mode/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--constants --verify
+^EXIT=0$
+^SIGNAL=0$
+\[main.assertion.1\] file main.c line 18 function main, assertion \(1.0f / 10.0f\) - f < -0.1f: Failure \(if reachable\)
+\[main.assertion.2\] file main.c line 20 function main, assertion \(1.0f / 10.0f\) - f < 0.0f: Unknown
+\[main.assertion.3\] file main.c line 22 function main, assertion \(1.0f / 10.0f\) - f <= 0.0f: Success
+\[main.assertion.4\] file main.c line 24 function main, assertion \(1.0f / 10.0f\) - f >= 0.0f: Unknown
+\[main.assertion.5\] file main.c line 26 function main, assertion \(1.0f / 10.0f\) - f > 0.0f: Failure \(if reachable\)
+
+--
+^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_rounding_mode/main.c
+++ b/regression/goto-analyzer/constant_propagation_rounding_mode/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+
+int main(void)
+{
+  __CPROVER_rounding_mode = 0;
+  float rounded_up = 1.0f / 10.0f;
+  __CPROVER_rounding_mode = 1;
+  float rounded_down = 1.0f / 10.0f;
+  assert(rounded_up - 0.1f >= 0);
+  assert(rounded_down - 0.1f < 0);
+  return 0;
+}

--- a/regression/goto-analyzer/constant_propagation_rounding_mode/test.desc
+++ b/regression/goto-analyzer/constant_propagation_rounding_mode/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--constants --verify
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] file main.c line 9 function main, assertion rounded_up - 0.1f >= 0: Success
+^\[main.assertion.2\] file main.c line 10 function main, assertion rounded_down - 0.1f < 0: Success
+--
+^warning: ignoring

--- a/src/analyses/constant_propagator.h
+++ b/src/analyses/constant_propagator.h
@@ -138,7 +138,7 @@ public:
 
   valuest values;
 
-  bool try_evaluate(exprt &expr, const namespacet &ns) const;
+  bool partial_evaluate(exprt &expr, const namespacet &ns) const;
 
 protected:
   void assign_rec(
@@ -149,6 +149,12 @@ protected:
   bool two_way_propagate_rec(
     const exprt &expr,
     const namespacet &ns);
+
+  bool partial_evaluate_with_all_rounding_modes(
+    exprt &expr,
+    const namespacet &ns) const;
+
+  bool replace_constants_and_simplify(exprt &expr, const namespacet &ns) const;
 };
 
 class constant_propagator_ait:public ait<constant_propagator_domaint>

--- a/src/analyses/constant_propagator.h
+++ b/src/analyses/constant_propagator.h
@@ -138,6 +138,8 @@ public:
 
   valuest values;
 
+  bool try_evaluate(exprt &expr, const namespacet &ns) const;
+
 protected:
   void assign_rec(
     valuest &values,

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -27,7 +27,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <ansi-c/c_preprocess.h>
 
 #include <goto-programs/adjust_float_expressions.h>
-#include <goto-programs/convert_nondet.h>
 #include <goto-programs/initialize_goto_model.h>
 #include <goto-programs/instrument_preconditions.h>
 #include <goto-programs/goto_convert_functions.h>

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -26,6 +26,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <ansi-c/c_preprocess.h>
 
+#include <goto-programs/adjust_float_expressions.h>
+#include <goto-programs/convert_nondet.h>
 #include <goto-programs/initialize_goto_model.h>
 #include <goto-programs/instrument_preconditions.h>
 #include <goto-programs/goto_convert_functions.h>
@@ -49,7 +51,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/string_instrumentation.h>
 
 #include <goto-symex/rewrite_union.h>
-#include <goto-symex/adjust_float_expressions.h>
 
 #include <goto-instrument/reachability_slicer.h>
 #include <goto-instrument/full_slicer.h>

--- a/src/clobber/Makefile
+++ b/src/clobber/Makefile
@@ -13,7 +13,6 @@ OBJ += ../ansi-c/ansi-c$(LIBEXT) \
        ../assembler/assembler$(LIBEXT) \
        ../solvers/solvers$(LIBEXT) \
        ../util/util$(LIBEXT) \
-       ../goto-symex/adjust_float_expressions$(OBJEXT) \
        ../goto-symex/rewrite_union$(OBJEXT) \
        ../pointer-analysis/dereference$(OBJEXT) \
        ../goto-instrument/dump_c$(OBJEXT) \

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -56,6 +56,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/exit_codes.h>
 
 #include <cbmc/version.h>
+#include <goto-programs/adjust_float_expressions.h>
 
 #include "taint_analysis.h"
 #include "unreachable_instructions.h"
@@ -477,6 +478,7 @@ int goto_analyzer_parse_optionst::doit()
 /// Depending on the command line mode, run one of the analysis tasks
 int goto_analyzer_parse_optionst::perform_analysis(const optionst &options)
 {
+  adjust_float_expressions(goto_model);
   if(options.get_bool_option("taint"))
   {
     std::string taint_file=cmdline.get_value("taint");

--- a/src/goto-diff/Makefile
+++ b/src/goto-diff/Makefile
@@ -25,7 +25,6 @@ OBJ += ../ansi-c/ansi-c$(LIBEXT) \
       ../goto-instrument/cover_instrument_mcdc$(OBJEXT) \
       ../goto-instrument/cover_instrument_other$(OBJEXT) \
       ../goto-instrument/cover_util$(OBJEXT) \
-      ../goto-symex/adjust_float_expressions$(OBJEXT) \
       ../goto-symex/rewrite_union$(OBJEXT) \
       ../analyses/analyses$(LIBEXT) \
       ../langapi/langapi$(LIBEXT) \

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -24,6 +24,7 @@ Author: Peter Schrammel
 
 #include <langapi/language.h>
 
+#include <goto-programs/adjust_float_expressions.h>
 #include <goto-programs/goto_convert_functions.h>
 #include <goto-programs/instrument_preconditions.h>
 #include <goto-programs/mm_io.h>
@@ -45,7 +46,6 @@ Author: Peter Schrammel
 #include <goto-programs/link_to_library.h>
 
 #include <goto-symex/rewrite_union.h>
-#include <goto-symex/adjust_float_expressions.h>
 
 #include <goto-instrument/cover.h>
 

--- a/src/goto-programs/Makefile
+++ b/src/goto-programs/Makefile
@@ -1,4 +1,5 @@
-SRC = basic_blocks.cpp \
+SRC = adjust_float_expressions.cpp \
+      basic_blocks.cpp \
       builtin_functions.cpp \
       class_hierarchy.cpp \
       class_identifier.cpp \

--- a/src/goto-programs/adjust_float_expressions.cpp
+++ b/src/goto-programs/adjust_float_expressions.cpp
@@ -18,7 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/ieee_float.h>
 #include <util/arith_tools.h>
 
-#include <goto-programs/goto_model.h>
+#include "goto_model.h"
 
 static bool have_to_adjust_float_expressions(
   const exprt &expr,

--- a/src/goto-programs/adjust_float_expressions.h
+++ b/src/goto-programs/adjust_float_expressions.h
@@ -9,8 +9,8 @@ Author: Daniel Kroening, kroening@kroening.com
 /// \file
 /// Symbolic Execution
 
-#ifndef CPROVER_GOTO_SYMEX_ADJUST_FLOAT_EXPRESSIONS_H
-#define CPROVER_GOTO_SYMEX_ADJUST_FLOAT_EXPRESSIONS_H
+#ifndef CPROVER_GOTO_PROGRAMS_ADJUST_FLOAT_EXPRESSIONS_H
+#define CPROVER_GOTO_PROGRAMS_ADJUST_FLOAT_EXPRESSIONS_H
 
 #include <goto-programs/goto_functions.h>
 
@@ -31,4 +31,4 @@ void adjust_float_expressions(
   const namespacet &ns);
 void adjust_float_expressions(goto_modelt &goto_model);
 
-#endif // CPROVER_GOTO_SYMEX_ADJUST_FLOAT_EXPRESSIONS_H
+#endif // CPROVER_GOTO_PROGRAMS_ADJUST_FLOAT_EXPRESSIONS_H

--- a/src/goto-symex/Makefile
+++ b/src/goto-symex/Makefile
@@ -1,5 +1,4 @@
-SRC = adjust_float_expressions.cpp \
-      auto_objects.cpp \
+SRC = auto_objects.cpp \
       build_goto_trace.cpp \
       goto_symex.cpp \
       goto_symex_state.cpp \

--- a/src/jbmc/jbmc_parse_options.cpp
+++ b/src/jbmc/jbmc_parse_options.cpp
@@ -26,6 +26,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <ansi-c/ansi_c_language.h>
 
+#include <goto-programs/adjust_float_expressions.h>
+#include <goto-programs/convert_nondet.h>
 #include <goto-programs/lazy_goto_model.h>
 #include <goto-programs/instrument_preconditions.h>
 #include <goto-programs/goto_convert_functions.h>
@@ -40,8 +42,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/show_goto_functions.h>
 #include <goto-programs/show_symbol_table.h>
 #include <goto-programs/show_properties.h>
-
-#include <goto-symex/adjust_float_expressions.h>
 
 #include <goto-instrument/full_slicer.h>
 #include <goto-instrument/reachability_slicer.h>

--- a/src/jbmc/jbmc_parse_options.cpp
+++ b/src/jbmc/jbmc_parse_options.cpp
@@ -27,7 +27,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <ansi-c/ansi_c_language.h>
 
 #include <goto-programs/adjust_float_expressions.h>
-#include <goto-programs/convert_nondet.h>
 #include <goto-programs/lazy_goto_model.h>
 #include <goto-programs/instrument_preconditions.h>
 #include <goto-programs/goto_convert_functions.h>

--- a/src/util/ieee_float.h
+++ b/src/util/ieee_float.h
@@ -14,9 +14,13 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "mp_arith.h"
 #include "format_spec.h"
+#include "irep.h"
+#include "cprover_prefix.h"
 
 class constant_exprt;
 class floatbv_typet;
+
+const char ID_cprover_rounding_mode_str[] = CPROVER_PREFIX "rounding_mode";
 
 class ieee_float_spect
 {


### PR DESCRIPTION
This

* moves adjust_float_expression from symex to goto-programs - it only depends on stuff from util and goto-programs, so this should be fine
* uses adjust_float_expression in the constant propagator domain
* The functions from fenv.h (fesetround etc) are not used in the regression tests because apparently they don't quite work in goto-analyzer at the moment (implementation doesn't seem to be visible?)