### PR TITLE
Specify default hash function of `dstringt` to STL.

### DIFF
--- a/src/util/dstring.h
+++ b/src/util/dstring.h
@@ -175,4 +175,18 @@ inline std::ostream &operator<<(std::ostream &out, const dstringt &a)
   return a.operator<<(out);
 }
 
+// NOLINTNEXTLINE [allow specialisation within 'std']
+namespace std
+{
+/// Default hash function of `dstringt` for use with STL containers.
+template <>
+struct hash<dstringt> // NOLINT(readability/identifiers)
+{
+  size_t operator()(const dstringt &dstring) const
+  {
+    return dstring.hash();
+  }
+};
+}
+
 #endif // CPROVER_UTIL_DSTRING_H


### PR DESCRIPTION
This provides a default hash function of `dstringt` to STL. Which means
that the hash function no longer needs to be specified when declaring
instances of STL containers where `dstringt` is used as the key.