### PR TITLE
Remove unnecessary uses of irep_id_hash

### DIFF
--- a/src/analyses/call_graph.cpp
+++ b/src/analyses/call_graph.cpp
@@ -165,7 +165,7 @@ class function_indicest
   call_grapht::directed_grapht &graph;
 
 public:
-  std::unordered_map<irep_idt, node_indext, irep_id_hash> function_indices;
+  std::unordered_map<irep_idt, node_indext> function_indices;
 
   explicit function_indicest(call_grapht::directed_grapht &graph):
     graph(graph)

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -115,7 +115,7 @@ public:
     friend class call_grapht;
 
     /// Maps function names onto node indices
-    std::unordered_map<irep_idt, node_indext, irep_id_hash> nodes_by_name;
+    std::unordered_map<irep_idt, node_indext> nodes_by_name;
 
   public:
     /// Find the graph node by function name
@@ -124,8 +124,7 @@ public:
     optionalt<node_indext> get_node_index(const irep_idt &function) const;
 
     /// Type of the node name -> node index map.
-    typedef
-      std::unordered_map<irep_idt, node_indext, irep_id_hash> nodes_by_namet;
+    typedef std::unordered_map<irep_idt, node_indext> nodes_by_namet;
 
     /// Get the node name -> node index map
     /// \return node-by-name map

--- a/src/analyses/dirty.h
+++ b/src/analyses/dirty.h
@@ -34,7 +34,6 @@ private:
 
 public:
   bool initialized;
-  typedef std::unordered_set<irep_idt, irep_id_hash> id_sett;
   typedef goto_functionst::goto_functiont goto_functiont;
 
   /// \post dirtyt objects that are created through this constructor are not
@@ -72,7 +71,7 @@ public:
     return operator()(expr.get_identifier());
   }
 
-  const id_sett &get_dirty_ids() const
+  const std::unordered_set<irep_idt> &get_dirty_ids() const
   {
     die_if_uninitialized();
     return dirty;
@@ -97,7 +96,7 @@ protected:
   void build(const goto_functiont &goto_function);
 
   // variables whose address is taken
-  id_sett dirty;
+  std::unordered_set<irep_idt> dirty;
 
   void find_dirty(const exprt &expr);
   void find_dirty_address_of(const exprt &expr);
@@ -131,7 +130,7 @@ public:
 
 private:
   dirtyt dirty;
-  std::unordered_set<irep_idt, irep_id_hash> dirty_processed_functions;
+  std::unordered_set<irep_idt> dirty_processed_functions;
 };
 
 #endif // CPROVER_ANALYSES_DIRTY_H

--- a/src/analyses/invariant_propagation.cpp
+++ b/src/analyses/invariant_propagation.cpp
@@ -40,8 +40,7 @@ void invariant_propagationt::add_objects(
   goto_program.get_decl_identifiers(locals);
 
   // cache the list for the locals to speed things up
-  typedef std::unordered_map<irep_idt, object_listt, irep_id_hash>
-    object_cachet;
+  typedef std::unordered_map<irep_idt, object_listt> object_cachet;
   object_cachet object_cache;
 
   forall_goto_program_instructions(i_it, goto_program)
@@ -133,8 +132,7 @@ void invariant_propagationt::add_objects(
     const goto_programt &goto_program=f_it->second.body;
 
     // cache the list for the locals to speed things up
-    typedef std::unordered_map<irep_idt, object_listt, irep_id_hash>
-      object_cachet;
+    typedef std::unordered_map<irep_idt, object_listt> object_cachet;
     object_cachet object_cache;
 
     forall_goto_program_instructions(i_it, goto_program)

--- a/src/analyses/reaching_definitions.h
+++ b/src/analyses/reaching_definitions.h
@@ -60,7 +60,7 @@ public:
 protected:
   typedef typename std::map<V, std::size_t> inner_mapt;
   std::vector<typename inner_mapt::const_iterator> values;
-  std::unordered_map<irep_idt, inner_mapt, irep_id_hash> value_map;
+  std::unordered_map<irep_idt, inner_mapt> value_map;
 };
 
 struct reaching_definitiont
@@ -191,15 +191,14 @@ private:
   #ifdef USE_DSTRING
   typedef std::map<irep_idt, values_innert> valuest;
   #else
-  typedef std::unordered_map<irep_idt, values_innert, irep_id_hash> valuest;
+  typedef std::unordered_map<irep_idt, values_innert> valuest;
   #endif
   valuest values;
 
   #ifdef USE_DSTRING
   typedef std::map<irep_idt, ranges_at_loct> export_cachet;
   #else
-  typedef std::unordered_map<irep_idt, ranges_at_loct, irep_id_hash>
-    export_cachet;
+  typedef std::unordered_map<irep_idt, ranges_at_loct> export_cachet;
   #endif
   mutable export_cachet export_cache;
 

--- a/src/ansi-c/ansi_c_scope.h
+++ b/src/ansi-c/ansi_c_scope.h
@@ -41,8 +41,7 @@ class ansi_c_scopet
 public:
   // This maps "scope names" (tag-X, label-X, X) to
   // ansi_c_identifiert.
-  typedef std::unordered_map<irep_idt, ansi_c_identifiert, irep_id_hash>
-    name_mapt;
+  typedef std::unordered_map<irep_idt, ansi_c_identifiert> name_mapt;
   name_mapt name_map;
 
   std::string prefix;

--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -69,7 +69,7 @@ protected:
   const irep_idt mode;
   symbolt current_symbol;
 
-  typedef std::unordered_map<irep_idt, typet, irep_id_hash> id_type_mapt;
+  typedef std::unordered_map<irep_idt, typet> id_type_mapt;
   id_type_mapt parameter_map;
 
   // overload to use language specific syntax
@@ -270,7 +270,7 @@ protected:
            src.id()==ID_real;
   }
 
-  typedef std::unordered_map<irep_idt, irep_idt, irep_id_hash> asm_label_mapt;
+  typedef std::unordered_map<irep_idt, irep_idt> asm_label_mapt;
   asm_label_mapt asm_label_map;
 
   void apply_asm_label(const irep_idt &asm_label, symbolt &symbol);

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -877,7 +877,7 @@ void c_typecheck_baset::typecheck_compound_body(
   // scan for duplicate members
 
   {
-    std::unordered_set<irep_idt, irep_id_hash> members;
+    std::unordered_set<irep_idt> members;
 
     for(struct_union_typet::componentst::iterator
         it=components.begin();

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -1688,8 +1688,8 @@ std::string expr2ct::convert_symbol(
     dest=src.op0().get_string(ID_identifier);
   else
   {
-    std::unordered_map<irep_idt, irep_idt, irep_id_hash>::const_iterator
-      entry=shorthands.find(id);
+    std::unordered_map<irep_idt, irep_idt>::const_iterator entry =
+      shorthands.find(id);
     // we might be called from conversion of a type
     if(entry==shorthands.end())
     {

--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -64,9 +64,8 @@ protected:
 
   static std::string indent_str(unsigned indent);
 
-  std::unordered_map<irep_idt,
-                std::unordered_set<irep_idt, irep_id_hash>,
-                irep_id_hash> ns_collision;
+  std::unordered_map<irep_idt, std::unordered_set<irep_idt>, irep_id_hash>
+    ns_collision;
   std::unordered_map<irep_idt, irep_idt, irep_id_hash> shorthands;
 
   unsigned sizeof_nesting;

--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -64,9 +64,8 @@ protected:
 
   static std::string indent_str(unsigned indent);
 
-  std::unordered_map<irep_idt, std::unordered_set<irep_idt>, irep_id_hash>
-    ns_collision;
-  std::unordered_map<irep_idt, irep_idt, irep_id_hash> shorthands;
+  std::unordered_map<irep_idt, std::unordered_set<irep_idt>> ns_collision;
+  std::unordered_map<irep_idt, irep_idt> shorthands;
 
   unsigned sizeof_nesting;
 

--- a/src/ansi-c/type2name.cpp
+++ b/src/ansi-c/type2name.cpp
@@ -19,8 +19,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <util/pointer_offset_size.h>
 #include <util/invariant.h>
 
-typedef std::unordered_map<irep_idt, std::pair<size_t, bool>, irep_id_hash>
-  symbol_numbert;
+typedef std::unordered_map<irep_idt, std::pair<size_t, bool>> symbol_numbert;
 
 static std::string type2name(
   const typet &type,

--- a/src/cbmc/symex_bmc.h
+++ b/src/cbmc/symex_bmc.h
@@ -147,7 +147,7 @@ protected:
 
   virtual void no_body(const irep_idt &identifier);
 
-  std::unordered_set<irep_idt, irep_id_hash> body_warnings;
+  std::unordered_set<irep_idt> body_warnings;
 
   symex_coveraget symex_coverage;
 };

--- a/src/cbmc/symex_bmc.h
+++ b/src/cbmc/symex_bmc.h
@@ -112,7 +112,7 @@ protected:
   unsigned max_unwind;
   bool max_unwind_is_set;
 
-  typedef std::unordered_map<irep_idt, unsigned, irep_id_hash> loop_limitst;
+  typedef std::unordered_map<irep_idt, unsigned> loop_limitst;
   loop_limitst loop_limits;
 
   typedef std::map<unsigned, loop_limitst> thread_loop_limitst;

--- a/src/cpp/cpp_scopes.h
+++ b/src/cpp/cpp_scopes.h
@@ -65,7 +65,7 @@ public:
   }
 
   // mapping from function/class/scope names to their cpp_idt
-  typedef std::unordered_map<irep_idt, cpp_idt *, irep_id_hash> id_mapt;
+  typedef std::unordered_map<irep_idt, cpp_idt *> id_mapt;
   id_mapt id_map;
 
   cpp_scopet *current_scope_ptr;

--- a/src/cpp/expr2cpp.cpp
+++ b/src/cpp/expr2cpp.cpp
@@ -43,8 +43,6 @@ protected:
     const typet &src,
     const qualifierst &qualifiers,
     const std::string &declarator) override;
-
-  typedef std::unordered_set<std::string, string_hash> id_sett;
 };
 
 std::string expr2cppt::convert_struct(

--- a/src/goto-diff/goto_diff.h
+++ b/src/goto-diff/goto_diff.h
@@ -51,12 +51,11 @@ protected:
   ui_message_handlert::uit ui;
 
   unsigned total_functions_count;
-  typedef std::set<irep_idt> irep_id_sett;
-  irep_id_sett new_functions, modified_functions, deleted_functions;
+  std::set<irep_idt> new_functions, modified_functions, deleted_functions;
 
   void output_function_group(
     const std::string &group_name,
-    const irep_id_sett &function_group,
+    const std::set<irep_idt> &function_group,
     const goto_modelt &goto_model) const;
   void output_function(
     const irep_idt &function_name,
@@ -64,7 +63,7 @@ protected:
 
   void convert_function_group_json(
     json_arrayt &result,
-    const irep_id_sett &function_group,
+    const std::set<irep_idt> &function_group,
     const goto_modelt &goto_model) const;
   void convert_function_json(
     json_objectt &result,

--- a/src/goto-diff/goto_diff_base.cpp
+++ b/src/goto-diff/goto_diff_base.cpp
@@ -64,7 +64,7 @@ void goto_difft::output_functions() const
 /// \param goto_model: the goto model
 void goto_difft::output_function_group(
   const std::string &group_name,
-  const irep_id_sett &function_group,
+  const std::set<irep_idt> &function_group,
   const goto_modelt &goto_model) const
 {
   result() << group_name << ":\n";
@@ -113,7 +113,7 @@ void goto_difft::output_function(
 /// \param goto_model: the goto model
 void goto_difft::convert_function_group_json(
   json_arrayt &result,
-  const irep_id_sett &function_group,
+  const std::set<irep_idt> &function_group,
   const goto_modelt &goto_model) const
 {
   for(const auto &function_name : function_group)

--- a/src/goto-instrument/code_contracts.cpp
+++ b/src/goto-instrument/code_contracts.cpp
@@ -388,10 +388,8 @@ void code_contractst::operator()()
     goto_functions.function_map.find(CPROVER_PREFIX "initialize");
   assert(i_it!=goto_functions.function_map.end());
 
-  for(std::unordered_set<irep_idt>::const_iterator it = summarized.begin();
-      it != summarized.end();
-      ++it)
-    add_contract_check(*it, i_it->second.body);
+  for(const auto &contract : summarized)
+    add_contract_check(contract, i_it->second.body);
 
   // remove skips
   remove_skip(i_it->second.body);

--- a/src/goto-instrument/code_contracts.cpp
+++ b/src/goto-instrument/code_contracts.cpp
@@ -45,8 +45,7 @@ protected:
 
   unsigned temporary_counter;
 
-  typedef std::unordered_set<irep_idt, irep_id_hash> id_sett;
-  id_sett summarized;
+  std::unordered_set<irep_idt> summarized;
 
   void code_contracts(goto_functionst::goto_functiont &goto_function);
 
@@ -389,8 +388,8 @@ void code_contractst::operator()()
     goto_functions.function_map.find(CPROVER_PREFIX "initialize");
   assert(i_it!=goto_functions.function_map.end());
 
-  for(id_sett::const_iterator it=summarized.begin();
-      it!=summarized.end();
+  for(std::unordered_set<irep_idt>::const_iterator it = summarized.begin();
+      it != summarized.end();
       ++it)
     add_contract_check(*it, i_it->second.body);
 

--- a/src/goto-instrument/count_eloc.cpp
+++ b/src/goto-instrument/count_eloc.cpp
@@ -22,8 +22,8 @@ Date: December 2012
 #include <goto-programs/cfg.h>
 
 typedef std::unordered_set<irep_idt> linest;
-typedef std::unordered_map<irep_idt, linest, irep_id_hash> filest;
-typedef std::unordered_map<irep_idt, filest, irep_id_hash> working_dirst;
+typedef std::unordered_map<irep_idt, linest> filest;
+typedef std::unordered_map<irep_idt, filest> working_dirst;
 
 static void collect_eloc(
   const goto_modelt &goto_model,

--- a/src/goto-instrument/count_eloc.cpp
+++ b/src/goto-instrument/count_eloc.cpp
@@ -21,7 +21,7 @@ Date: December 2012
 
 #include <goto-programs/cfg.h>
 
-typedef std::unordered_set<irep_idt, irep_id_hash> linest;
+typedef std::unordered_set<irep_idt> linest;
 typedef std::unordered_map<irep_idt, linest, irep_id_hash> filest;
 typedef std::unordered_map<irep_idt, filest, irep_id_hash> working_dirst;
 

--- a/src/goto-instrument/cover_basic_blocks.h
+++ b/src/goto-instrument/cover_basic_blocks.h
@@ -125,7 +125,7 @@ private:
   // map block number to its location
   std::vector<source_locationt> block_locations;
   // map java indexes to block indexes
-  std::unordered_map<irep_idt, std::size_t, irep_id_hash> index_to_block;
+  std::unordered_map<irep_idt, std::size_t> index_to_block;
 
 public:
   explicit cover_basic_blocks_javat(const goto_programt &_goto_program);

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -613,7 +613,7 @@ void dump_ct::cleanup_decl(
 
   tmp.add_instruction(END_FUNCTION);
 
-  std::unordered_set<irep_idt, irep_id_hash> typedef_names;
+  std::unordered_set<irep_idt> typedef_names;
   for(const auto &td : typedef_map)
     typedef_names.insert(td.first);
 
@@ -640,7 +640,7 @@ void dump_ct::cleanup_decl(
 ///   function declarations or struct definitions
 void dump_ct::collect_typedefs(const typet &type, bool early)
 {
-  std::unordered_set<irep_idt, irep_id_hash> deps;
+  std::unordered_set<irep_idt> deps;
   collect_typedefs_rec(type, early, deps);
 }
 
@@ -654,12 +654,12 @@ void dump_ct::collect_typedefs(const typet &type, bool early)
 void dump_ct::collect_typedefs_rec(
   const typet &type,
   bool early,
-  std::unordered_set<irep_idt, irep_id_hash> &dependencies)
+  std::unordered_set<irep_idt> &dependencies)
 {
   if(system_symbols.is_type_internal(type, system_headers))
     return;
 
-  std::unordered_set<irep_idt, irep_id_hash> local_deps;
+  std::unordered_set<irep_idt> local_deps;
 
   if(type.id()==ID_code)
   {
@@ -769,9 +769,8 @@ void dump_ct::dump_typedefs(std::ostream &os) const
   // output
   std::map<std::string, typedef_infot> to_insert;
 
-  typedef std::unordered_set<irep_idt, irep_id_hash> id_sett;
-  id_sett typedefs_done;
-  std::unordered_map<irep_idt, id_sett, irep_id_hash>
+  std::unordered_set<irep_idt> typedefs_done;
+  std::unordered_map<irep_idt, std::unordered_set<irep_idt>, irep_id_hash>
     forward_deps, reverse_deps;
 
   for(const auto &td : typedef_map)
@@ -805,8 +804,9 @@ void dump_ct::dump_typedefs(std::ostream &os) const
       continue;
 
     // reduce remaining dependencies
-    id_sett &r_deps=r_it->second;
-    for(id_sett::iterator it=r_deps.begin(); it!=r_deps.end(); ) // no ++it
+    std::unordered_set<irep_idt> &r_deps = r_it->second;
+    for(std::unordered_set<irep_idt>::iterator it = r_deps.begin();
+        it != r_deps.end();) // no ++it
     {
       auto f_it=forward_deps.find(*it);
       if(f_it==forward_deps.end()) // might be done already
@@ -816,7 +816,7 @@ void dump_ct::dump_typedefs(std::ostream &os) const
       }
 
       // update dependencies
-      id_sett &f_deps=f_it->second;
+      std::unordered_set<irep_idt> &f_deps = f_it->second;
       PRECONDITION(!f_deps.empty());
       PRECONDITION(f_deps.find(t.typedef_name)!=f_deps.end());
       f_deps.erase(t.typedef_name);
@@ -986,7 +986,7 @@ void dump_ct::convert_function_declaration(
     code_blockt b;
     std::list<irep_idt> type_decls, local_static;
 
-    std::unordered_set<irep_idt, irep_id_hash> typedef_names;
+    std::unordered_set<irep_idt> typedef_names;
     for(const auto &td : typedef_map)
       typedef_names.insert(td.first);
 

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -87,7 +87,7 @@ void dump_ct::operator()(std::ostream &os)
     copied_symbol_table.add(symbol_pair.second);
   }
 
-  typedef std::unordered_map<irep_idt, unsigned, irep_id_hash> unique_tagst;
+  typedef std::unordered_map<irep_idt, unsigned> unique_tagst;
   unique_tagst unique_tags;
 
   // add tags to anonymous union/struct/enum,
@@ -770,8 +770,8 @@ void dump_ct::dump_typedefs(std::ostream &os) const
   std::map<std::string, typedef_infot> to_insert;
 
   std::unordered_set<irep_idt> typedefs_done;
-  std::unordered_map<irep_idt, std::unordered_set<irep_idt>, irep_id_hash>
-    forward_deps, reverse_deps;
+  std::unordered_map<irep_idt, std::unordered_set<irep_idt>> forward_deps,
+    reverse_deps;
 
   for(const auto &td : typedef_map)
     if(!td.second.type_decl_str.empty())

--- a/src/goto-instrument/dump_c_class.h
+++ b/src/goto-instrument/dump_c_class.h
@@ -59,8 +59,7 @@ protected:
 
   system_library_symbolst system_symbols;
 
-  typedef std::unordered_map<irep_idt, irep_idt, irep_id_hash>
-    declared_enum_constants_mapt;
+  typedef std::unordered_map<irep_idt, irep_idt> declared_enum_constants_mapt;
   declared_enum_constants_mapt declared_enum_constants;
 
   struct typedef_infot
@@ -129,8 +128,7 @@ protected:
     const typet &type,
     std::ostream &os);
 
-  typedef std::unordered_map<irep_idt, code_declt, irep_id_hash>
-          local_static_declst;
+  typedef std::unordered_map<irep_idt, code_declt> local_static_declst;
 
   void convert_global_variable(
       const symbolt &symbol,

--- a/src/goto-instrument/dump_c_class.h
+++ b/src/goto-instrument/dump_c_class.h
@@ -52,7 +52,7 @@ protected:
   std::unique_ptr<languaget> language;
   const bool harness;
 
-  typedef std::unordered_set<irep_idt, irep_id_hash> convertedt;
+  typedef std::unordered_set<irep_idt> convertedt;
   convertedt converted_compound, converted_global, converted_enum;
 
   std::set<std::string> system_headers;
@@ -68,7 +68,7 @@ protected:
     irep_idt typedef_name;
     std::string type_decl_str;
     bool early;
-    std::unordered_set<irep_idt, irep_id_hash> dependencies;
+    std::unordered_set<irep_idt> dependencies;
 
     explicit typedef_infot(const irep_idt &name):
       typedef_name(name),
@@ -108,7 +108,7 @@ protected:
   void collect_typedefs_rec(
     const typet &type,
     bool early,
-    std::unordered_set<irep_idt, irep_id_hash> &dependencies);
+    std::unordered_set<irep_idt> &dependencies);
   void gather_global_typedefs();
   void dump_typedefs(std::ostream &os) const;
 

--- a/src/goto-instrument/full_slicer_class.h
+++ b/src/goto-instrument/full_slicer_class.h
@@ -62,7 +62,7 @@ protected:
   typedef std::vector<cfgt::entryt> dep_node_to_cfgt;
   typedef std::stack<cfgt::entryt> queuet;
   typedef std::list<cfgt::entryt> jumpst;
-  typedef std::unordered_map<irep_idt, queuet, irep_id_hash> decl_deadt;
+  typedef std::unordered_map<irep_idt, queuet> decl_deadt;
 
   void fixedpoint(
     goto_functionst &goto_functions,

--- a/src/goto-instrument/goto_program2code.h
+++ b/src/goto-instrument/goto_program2code.h
@@ -22,7 +22,7 @@ class goto_program2codet
   typedef std::list<irep_idt> id_listt;
   typedef std::map<goto_programt::const_targett, goto_programt::const_targett>
     loopt;
-  typedef std::unordered_map<irep_idt, unsigned, irep_id_hash> dead_mapt;
+  typedef std::unordered_map<irep_idt, unsigned> dead_mapt;
   typedef std::list<std::pair<goto_programt::const_targett, bool> >
     loop_last_stackt;
 

--- a/src/goto-instrument/goto_program2code.h
+++ b/src/goto-instrument/goto_program2code.h
@@ -20,7 +20,6 @@ Author: Daniel Kroening, kroening@kroening.com
 class goto_program2codet
 {
   typedef std::list<irep_idt> id_listt;
-  typedef std::unordered_set<irep_idt, irep_id_hash> id_sett;
   typedef std::map<goto_programt::const_targett, goto_programt::const_targett>
     loopt;
   typedef std::unordered_map<irep_idt, unsigned, irep_id_hash> dead_mapt;
@@ -47,23 +46,23 @@ class goto_program2codet
 
 public:
   goto_program2codet(
-      const irep_idt &identifier,
-      const goto_programt &_goto_program,
-      symbol_tablet &_symbol_table,
-      code_blockt &_dest,
-      id_listt &_local_static,
-      id_listt &_type_names,
-      const id_sett &_typedef_names,
-      std::set<std::string> &_system_headers):
-    func_name(identifier),
-    goto_program(_goto_program),
-    symbol_table(_symbol_table),
-    ns(_symbol_table),
-    toplevel_block(_dest),
-    local_static(_local_static),
-    type_names(_type_names),
-    typedef_names(_typedef_names),
-    system_headers(_system_headers)
+    const irep_idt &identifier,
+    const goto_programt &_goto_program,
+    symbol_tablet &_symbol_table,
+    code_blockt &_dest,
+    id_listt &_local_static,
+    id_listt &_type_names,
+    const std::unordered_set<irep_idt> &_typedef_names,
+    std::set<std::string> &_system_headers)
+    : func_name(identifier),
+      goto_program(_goto_program),
+      symbol_table(_symbol_table),
+      ns(_symbol_table),
+      toplevel_block(_dest),
+      local_static(_local_static),
+      type_names(_type_names),
+      typedef_names(_typedef_names),
+      system_headers(_system_headers)
   {
     assert(local_static.empty());
 
@@ -84,18 +83,18 @@ protected:
   code_blockt &toplevel_block;
   id_listt &local_static;
   id_listt &type_names;
-  const id_sett &typedef_names;
+  const std::unordered_set<irep_idt> &typedef_names;
   std::set<std::string> &system_headers;
   std::unordered_set<exprt, irep_hash> va_list_expr;
 
   natural_loopst loops;
   loopt loop_map;
-  id_sett labels_in_use;
+  std::unordered_set<irep_idt> labels_in_use;
   dead_mapt dead_map;
   loop_last_stackt loop_last_stack;
-  id_sett local_static_set;
-  id_sett type_names_set;
-  id_sett const_removed;
+  std::unordered_set<irep_idt> local_static_set;
+  std::unordered_set<irep_idt> type_names_set;
+  std::unordered_set<irep_idt> const_removed;
 
   void build_loop_map();
   void build_dead_map();

--- a/src/goto-instrument/rw_set.h
+++ b/src/goto-instrument/rw_set.h
@@ -53,7 +53,7 @@ public:
     }
   };
 
-  typedef std::unordered_map<irep_idt, entryt, irep_id_hash> entriest;
+  typedef std::unordered_map<irep_idt, entryt> entriest;
   entriest r_entries, w_entries;
 
   void swap(rw_set_baset &other)

--- a/src/goto-programs/class_hierarchy.h
+++ b/src/goto-programs/class_hierarchy.h
@@ -75,8 +75,7 @@ class class_hierarchy_grapht : public grapht<class_hierarchy_graph_nodet>
 {
 public:
   /// Maps class identifiers onto node indices
-  typedef std::unordered_map<irep_idt, node_indext, irep_id_hash>
-    nodes_by_namet;
+  typedef std::unordered_map<irep_idt, node_indext> nodes_by_namet;
 
   void populate(const symbol_tablet &);
 

--- a/src/goto-programs/goto_inline_class.h
+++ b/src/goto-programs/goto_inline_class.h
@@ -193,13 +193,13 @@ protected:
   typedef goto_functionst::function_mapt cachet;
   cachet cache;
 
-  typedef std::unordered_set<irep_idt, irep_id_hash> finished_sett;
+  typedef std::unordered_set<irep_idt> finished_sett;
   finished_sett finished_set;
 
-  typedef std::unordered_set<irep_idt, irep_id_hash> recursion_sett;
+  typedef std::unordered_set<irep_idt> recursion_sett;
   recursion_sett recursion_set;
 
-  typedef std::unordered_set<irep_idt, irep_id_hash> no_body_sett;
+  typedef std::unordered_set<irep_idt> no_body_sett;
   no_body_sett no_body_set;
 };
 

--- a/src/goto-programs/interpreter_class.h
+++ b/src/goto-programs/interpreter_class.h
@@ -104,7 +104,7 @@ protected:
 
   const goto_functionst &goto_functions;
 
-  typedef std::unordered_map<irep_idt, mp_integer, irep_id_hash> memory_mapt;
+  typedef std::unordered_map<irep_idt, mp_integer> memory_mapt;
   typedef std::map<mp_integer, irep_idt> inverse_memory_mapt;
   memory_mapt memory_map;
   inverse_memory_mapt inverse_memory_map;

--- a/src/goto-programs/lazy_goto_functions_map.h
+++ b/src/goto-programs/lazy_goto_functions_map.h
@@ -61,7 +61,7 @@ private:
   /// Names of functions that are already fully available in the programt state.
   /// \remarks These functions do not need processing before being returned
   /// whenever they are requested
-  mutable std::unordered_set<irep_idt, irep_id_hash> processed_functions;
+  mutable std::unordered_set<irep_idt> processed_functions;
 
   language_filest &language_files;
   symbol_tablet &symbol_table;

--- a/src/goto-programs/link_goto_model.cpp
+++ b/src/goto-programs/link_goto_model.cpp
@@ -47,7 +47,7 @@ static bool link_functions(
   const symbol_tablet &src_symbol_table,
   goto_functionst &src_functions,
   const rename_symbolt &rename_symbol,
-  const std::unordered_set<irep_idt, irep_id_hash> &weak_symbols,
+  const std::unordered_set<irep_idt> &weak_symbols,
   const replace_symbolt &object_type_updates)
 {
   namespacet ns(dest_symbol_table);
@@ -158,8 +158,7 @@ void link_goto_model(
   goto_modelt &src,
   message_handlert &message_handler)
 {
-  typedef std::unordered_set<irep_idt, irep_id_hash> id_sett;
-  id_sett weak_symbols;
+  std::unordered_set<irep_idt> weak_symbols;
 
   for(const auto &symbol_pair : dest.symbol_table.symbols)
   {

--- a/src/goto-programs/set_properties.cpp
+++ b/src/goto-programs/set_properties.cpp
@@ -16,7 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 void set_properties(
   goto_programt &goto_program,
-  std::unordered_set<irep_idt, irep_id_hash> &property_set)
+  std::unordered_set<irep_idt> &property_set)
 {
   for(goto_programt::instructionst::iterator
       it=goto_program.instructions.begin();
@@ -28,8 +28,8 @@ void set_properties(
 
     irep_idt property_id=it->source_location.get_property_id();
 
-    std::unordered_set<irep_idt, irep_id_hash>::iterator
-      c_it=property_set.find(property_id);
+    std::unordered_set<irep_idt>::iterator c_it =
+      property_set.find(property_id);
 
     if(c_it==property_set.end())
       it->type=SKIP;
@@ -102,7 +102,7 @@ void set_properties(
   goto_functionst &goto_functions,
   const std::list<std::string> &properties)
 {
-  std::unordered_set<irep_idt, irep_id_hash> property_set;
+  std::unordered_set<irep_idt> property_set;
 
   property_set.insert(properties.begin(), properties.end());
 

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -252,8 +252,7 @@ void string_abstractiont::abstract(goto_programt &dest)
 
 void string_abstractiont::declare_define_locals(goto_programt &dest)
 {
-  typedef std::unordered_map<irep_idt, goto_programt::targett, irep_id_hash>
-    available_declst;
+  typedef std::unordered_map<irep_idt, goto_programt::targett> available_declst;
   available_declst available_decls;
 
   Forall_goto_program_instructions(it, dest)

--- a/src/goto-programs/string_abstraction.h
+++ b/src/goto-programs/string_abstraction.h
@@ -134,7 +134,7 @@ protected:
   typet string_struct;
   goto_programt initialization;
 
-  typedef std::unordered_map<irep_idt, irep_idt, irep_id_hash> localst;
+  typedef std::unordered_map<irep_idt, irep_idt> localst;
   localst locals;
 
   void abstract(goto_programt &dest);

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -192,7 +192,7 @@ protected:
   void get_l1_name(exprt &expr) const;
 
   // this maps L1 names to (L2) types
-  typedef std::unordered_map<irep_idt, typet, irep_id_hash> l1_typest;
+  typedef std::unordered_map<irep_idt, typet> l1_typest;
   l1_typest l1_types;
 
 public:
@@ -298,8 +298,7 @@ public:
       unsigned count;
       bool is_recursion;
     };
-    typedef std::unordered_map<irep_idt, loop_infot, irep_id_hash>
-      loop_iterationst;
+    typedef std::unordered_map<irep_idt, loop_infot> loop_iterationst;
     loop_iterationst loop_iterations;
   };
 

--- a/src/goto-symex/partial_order_concurrency.cpp
+++ b/src/goto-symex/partial_order_concurrency.cpp
@@ -28,7 +28,7 @@ partial_order_concurrencyt::~partial_order_concurrencyt()
 void partial_order_concurrencyt::add_init_writes(
   symex_target_equationt &equation)
 {
-  std::unordered_set<irep_idt, irep_id_hash> init_done;
+  std::unordered_set<irep_idt> init_done;
   bool spawn_seen=false;
 
   symex_target_equationt::SSA_stepst init_steps;

--- a/src/goto-symex/postcondition.cpp
+++ b/src/goto-symex/postcondition.cpp
@@ -175,7 +175,7 @@ bool postconditiont::is_used(
 
     value_setst::valuest expr_set;
     value_set.get_value_set(expr.op0(), expr_set, ns);
-    std::unordered_set<irep_idt, irep_id_hash> symbols;
+    std::unordered_set<irep_idt> symbols;
 
     for(value_setst::valuest::const_iterator
         it=expr_set.begin();

--- a/src/goto-symex/precondition.cpp
+++ b/src/goto-symex/precondition.cpp
@@ -117,7 +117,7 @@ void preconditiont::compute_rec(exprt &dest)
 
     value_setst::valuest expr_set;
     value_sets.get_values(target, dest.op0(), expr_set);
-    std::unordered_set<irep_idt, irep_id_hash> symbols;
+    std::unordered_set<irep_idt> symbols;
 
     for(value_setst::valuest::const_iterator
         it=expr_set.begin();

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -29,7 +29,7 @@ void slice(
 
 // Collects "open" variables that are used but not assigned
 
-typedef std::unordered_set<irep_idt, irep_id_hash> symbol_sett;
+typedef std::unordered_set<irep_idt> symbol_sett;
 
 void collect_open_variables(
   const symex_target_equationt &equation,

--- a/src/java_bytecode/character_refine_preprocess.h
+++ b/src/java_bytecode/character_refine_preprocess.h
@@ -36,8 +36,7 @@ private:
   typedef const code_function_callt &conversion_inputt;
   typedef codet (*conversion_functiont)(conversion_inputt &target);
   // A table tells us what method to call for each java method signature
-  std::unordered_map<irep_idt, conversion_functiont, irep_id_hash>
-    conversion_table;
+  std::unordered_map<irep_idt, conversion_functiont> conversion_table;
 
   // Conversion functions
   static exprt expr_of_char_count(const exprt &chr, const typet &type);

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -819,7 +819,8 @@ const select_pointer_typet &
 /// \return Populates `methods` with the complete list of lazy methods that are
 ///   available to convert (those which are valid parameters for
 ///   `convert_lazy_method`)
-void java_bytecode_languaget::methods_provided(id_sett &methods) const
+void java_bytecode_languaget::methods_provided(
+  std::unordered_set<irep_idt> &methods) const
 {
   // Add all string solver methods to map
   string_preprocess.get_all_function_names(methods);

--- a/src/java_bytecode/java_bytecode_language.h
+++ b/src/java_bytecode/java_bytecode_language.h
@@ -135,7 +135,8 @@ public:
   std::set<std::string> extensions() const override;
 
   void modules_provided(std::set<std::string> &modules) override;
-  virtual void methods_provided(id_sett &methods) const override;
+  virtual void
+  methods_provided(std::unordered_set<irep_idt> &methods) const override;
   virtual void convert_lazy_method(
     const irep_idt &function_id,
     symbol_table_baset &symbol_table) override;

--- a/src/java_bytecode/java_object_factory.cpp
+++ b/src/java_bytecode/java_object_factory.cpp
@@ -52,7 +52,7 @@ class java_object_factoryt
   /// non-det generator visits a type, the type is added to this set. We forbid
   /// the non-det initialization when we see the type for the second time in
   /// this set AND the tree depth becomes >= than the maximum value above.
-  std::unordered_set<irep_idt, irep_id_hash> recursion_set;
+  std::unordered_set<irep_idt> recursion_set;
 
   /// Every time the non-det generator visits a type and the type is generic
   /// (either a struct or a pointer), the following map is used to store and
@@ -462,7 +462,7 @@ void java_object_factoryt::gen_pointer_target_init(
 class recursion_set_entryt
 {
   /// Recursion set to modify
-  std::unordered_set<irep_idt, irep_id_hash> &recursion_set;
+  std::unordered_set<irep_idt> &recursion_set;
   /// Entry to erase on destruction, if non-empty
   irep_idt erase_entry;
 
@@ -470,8 +470,7 @@ public:
   /// Initialize a recursion-set entry owner operating on a given set.
   /// Initially it does not own any set entry.
   /// \param _recursion_set: set to operate on.
-  explicit recursion_set_entryt(
-    std::unordered_set<irep_idt, irep_id_hash> &_recursion_set)
+  explicit recursion_set_entryt(std::unordered_set<irep_idt> &_recursion_set)
     : recursion_set(_recursion_set)
   { }
 

--- a/src/java_bytecode/java_static_initializers.cpp
+++ b/src/java_bytecode/java_static_initializers.cpp
@@ -267,7 +267,7 @@ static itertype advance_to_next_key(itertype in, itertype end)
 ///   when it is required.
 void stub_global_initializer_factoryt::create_stub_global_initializer_symbols(
   symbol_tablet &symbol_table,
-  const std::unordered_set<irep_idt, irep_id_hash> &stub_globals_set,
+  const std::unordered_set<irep_idt> &stub_globals_set,
   synthetic_methods_mapt &synthetic_methods)
 {
   // Populate map from class id -> stub globals:

--- a/src/java_bytecode/java_static_initializers.h
+++ b/src/java_bytecode/java_static_initializers.h
@@ -31,8 +31,7 @@ codet get_clinit_wrapper_body(
 class stub_global_initializer_factoryt
 {
   /// Maps class symbols onto the stub globals that belong to them
-  typedef std::unordered_multimap<irep_idt, irep_idt, irep_id_hash>
-    stub_globals_by_classt;
+  typedef std::unordered_multimap<irep_idt, irep_idt> stub_globals_by_classt;
   stub_globals_by_classt stub_globals_by_class;
 
 public:

--- a/src/java_bytecode/java_static_initializers.h
+++ b/src/java_bytecode/java_static_initializers.h
@@ -38,7 +38,7 @@ class stub_global_initializer_factoryt
 public:
   void create_stub_global_initializer_symbols(
     symbol_tablet &symbol_table,
-    const std::unordered_set<irep_idt, irep_id_hash> &stub_globals_set,
+    const std::unordered_set<irep_idt> &stub_globals_set,
     synthetic_methods_mapt &synthetic_methods);
 
   codet get_stub_initializer_body(
@@ -50,7 +50,7 @@ public:
 
 void create_stub_global_initializers(
   symbol_tablet &symbol_table,
-  const std::unordered_set<irep_idt, irep_id_hash> &stub_globals_set,
+  const std::unordered_set<irep_idt> &stub_globals_set,
   const object_factory_parameterst &object_factory_parameters,
   const select_pointer_typet &pointer_type_selector);
 

--- a/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/src/java_bytecode/java_string_library_preprocess.cpp
@@ -1853,7 +1853,7 @@ void add_keys_to_container(const TMap &map, TContainer &container)
 }
 
 void java_string_library_preprocesst::get_all_function_names(
-  id_sett &methods) const
+  std::unordered_set<irep_idt> &methods) const
 {
   for(const id_mapt *map : id_maps)
     add_keys_to_container(*map, methods);
@@ -1919,11 +1919,10 @@ bool java_string_library_preprocesst::is_known_string_type(
 
 void java_string_library_preprocesst::initialize_known_type_table()
 {
-  string_types=
-    std::unordered_set<irep_idt, irep_id_hash>{"java.lang.String",
-                                               "java.lang.StringBuilder",
-                                               "java.lang.CharSequence",
-                                               "java.lang.StringBuffer"};
+  string_types = std::unordered_set<irep_idt>{"java.lang.String",
+                                              "java.lang.StringBuilder",
+                                              "java.lang.CharSequence",
+                                              "java.lang.StringBuffer"};
 }
 
 /// fill maps with correspondence from java method names to conversion functions

--- a/src/java_bytecode/java_string_library_preprocess.h
+++ b/src/java_bytecode/java_string_library_preprocess.h
@@ -105,11 +105,10 @@ private:
     symbol_table_baset &)>
     conversion_functiont;
 
-  typedef std::unordered_map<irep_idt, irep_idt, irep_id_hash> id_mapt;
+  typedef std::unordered_map<irep_idt, irep_idt> id_mapt;
 
   // Table mapping each java method signature to the code generating function
-  std::unordered_map<irep_idt, conversion_functiont, irep_id_hash>
-    conversion_table;
+  std::unordered_map<irep_idt, conversion_functiont> conversion_table;
 
   // Some Java functions have an equivalent in the solver that we will
   // call with the same argument and will return the same result

--- a/src/java_bytecode/java_string_library_preprocess.h
+++ b/src/java_bytecode/java_string_library_preprocess.h
@@ -31,8 +31,6 @@ Date:   March 2017
 // Arbitrary limit of 10 arguments for the number of arguments to String.format
 #define MAX_FORMAT_ARGS 10
 
-typedef std::unordered_set<irep_idt, irep_id_hash> id_sett;
-
 class java_string_library_preprocesst:public messaget
 {
 public:
@@ -48,7 +46,7 @@ public:
   void initialize_refined_string_type();
 
   bool implements_function(const irep_idt &function_id) const;
-  void get_all_function_names(id_sett &methods) const;
+  void get_all_function_names(std::unordered_set<irep_idt> &methods) const;
 
   exprt
   code_for_function(const symbolt &symbol, symbol_table_baset &symbol_table);
@@ -146,7 +144,7 @@ private:
     };
 
   // A set tells us what java types should be considered as string objects
-  std::unordered_set<irep_idt, irep_id_hash> string_types;
+  std::unordered_set<irep_idt> string_types;
 
   codet make_equals_function_code(
     const code_typet &type,

--- a/src/java_bytecode/java_utils.cpp
+++ b/src/java_bytecode/java_utils.cpp
@@ -420,11 +420,9 @@ resolve_inherited_componentt::inherited_componentt get_inherited_component(
 /// \return true if this static field is known never to be null
 bool is_non_null_library_global(const irep_idt &symbolid)
 {
-  static const std::unordered_set<irep_idt, irep_id_hash> non_null_globals =
-  {
+  static const std::unordered_set<irep_idt> non_null_globals = {
     "java::java.lang.System.out",
     "java::java.lang.System.err",
-    "java::java.lang.System.in"
-  };
+    "java::java.lang.System.in"};
   return non_null_globals.count(symbolid);
 }

--- a/src/java_bytecode/select_pointer_type.h
+++ b/src/java_bytecode/select_pointer_type.h
@@ -16,7 +16,7 @@
 #include <stack>
 #include "java_types.h"
 
-typedef std::unordered_map<irep_idt, std::stack<reference_typet>, irep_id_hash>
+typedef std::unordered_map<irep_idt, std::stack<reference_typet>>
   generic_parameter_specialization_mapt;
 
 class namespacet;

--- a/src/java_bytecode/synthetic_methods_map.h
+++ b/src/java_bytecode/synthetic_methods_map.h
@@ -34,7 +34,7 @@ enum class synthetic_method_typet
 };
 
 /// Maps method names on to a synthetic method kind.
-typedef std::unordered_map<irep_idt, synthetic_method_typet, irep_id_hash>
+typedef std::unordered_map<irep_idt, synthetic_method_typet>
   synthetic_methods_mapt;
 
 #endif

--- a/src/jsil/jsil_typecheck.h
+++ b/src/jsil/jsil_typecheck.h
@@ -94,7 +94,7 @@ protected:
   virtual std::string to_string(const exprt &expr);
   virtual std::string to_string(const typet &type);
 
-  std::unordered_set<irep_idt, irep_id_hash> already_typechecked;
+  std::unordered_set<irep_idt> already_typechecked;
 };
 
 #endif // CPROVER_JSIL_JSIL_TYPECHECK_H

--- a/src/langapi/language.h
+++ b/src/langapi/language.h
@@ -23,8 +23,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <goto-programs/system_library_symbols.h>
 
-typedef std::unordered_set<irep_idt, irep_id_hash> id_sett;
-
 class symbol_tablet;
 class symbol_table_baset;
 class exprt;
@@ -79,7 +77,7 @@ public:
 
   // add lazy functions provided to set
 
-  virtual void methods_provided(id_sett &methods) const
+  virtual void methods_provided(std::unordered_set<irep_idt> &methods) const
   { }
 
   // populate a lazy method

--- a/src/langapi/language_file.cpp
+++ b/src/langapi/language_file.cpp
@@ -144,7 +144,7 @@ bool language_filest::typecheck(symbol_tablet &symbol_table)
       // register lazy methods.
       // TODO: learn about modules and generalise this
       // to module-providing languages if required.
-      id_sett lazy_method_ids;
+      std::unordered_set<irep_idt> lazy_method_ids;
       file.second.language->methods_provided(lazy_method_ids);
       for(const auto &id : lazy_method_ids)
         lazy_method_map[id]=&file.second;

--- a/src/langapi/language_file.h
+++ b/src/langapi/language_file.h
@@ -83,7 +83,7 @@ public:
   {
     // Clear relevant entries from lazy_method_map
     language_filet *language_file = &file_map.at(filename);
-    id_sett files_methods;
+    std::unordered_set<irep_idt> files_methods;
     for(const std::pair<irep_idt, language_filet *> &method : lazy_method_map)
     {
       if(method.second == language_file)

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -1185,25 +1185,20 @@ void linkingt::do_type_dependencies(
     }
   }
 
-  std::stack<irep_idt> queue;
-
-  for(std::unordered_set<irep_idt>::const_iterator d_it =
-        needs_to_be_renamed.begin();
-      d_it != needs_to_be_renamed.end();
-      d_it++)
-    queue.push(*d_it);
+  std::deque<irep_idt> queue(
+    needs_to_be_renamed.begin(), needs_to_be_renamed.end());
 
   while(!queue.empty())
   {
-    irep_idt id = queue.top();
-    queue.pop();
+    irep_idt id = queue.back();
+    queue.pop_back();
 
     const std::unordered_set<irep_idt> &u = used_by[id];
 
     for(const auto &dep : u)
       if(needs_to_be_renamed.insert(dep).second)
       {
-        queue.push(dep);
+        queue.push_back(dep);
         #ifdef DEBUG
         debug() << "LINKING: needs to be renamed (dependency): "
                 << dep << eom;

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -1162,7 +1162,8 @@ bool linkingt::needs_renaming_type(
   return true; // different
 }
 
-void linkingt::do_type_dependencies(id_sett &needs_to_be_renamed)
+void linkingt::do_type_dependencies(
+  std::unordered_set<irep_idt> &needs_to_be_renamed)
 {
   // Any type that uses a symbol that will be renamed also
   // needs to be renamed, and so on, until saturation.
@@ -1186,9 +1187,9 @@ void linkingt::do_type_dependencies(id_sett &needs_to_be_renamed)
 
   std::stack<irep_idt> queue;
 
-  for(id_sett::const_iterator
-      d_it=needs_to_be_renamed.begin();
-      d_it!=needs_to_be_renamed.end();
+  for(std::unordered_set<irep_idt>::const_iterator d_it =
+        needs_to_be_renamed.begin();
+      d_it != needs_to_be_renamed.end();
       d_it++)
     queue.push(*d_it);
 
@@ -1197,11 +1198,10 @@ void linkingt::do_type_dependencies(id_sett &needs_to_be_renamed)
     irep_idt id=queue.top();
     queue.pop();
 
-    const id_sett &u=used_by[id];
+    const std::unordered_set<irep_idt> &u = used_by[id];
 
-    for(id_sett::const_iterator
-        d_it=u.begin();
-        d_it!=u.end();
+    for(std::unordered_set<irep_idt>::const_iterator d_it = u.begin();
+        d_it != u.end();
         d_it++)
       if(needs_to_be_renamed.insert(*d_it).second)
       {
@@ -1214,7 +1214,8 @@ void linkingt::do_type_dependencies(id_sett &needs_to_be_renamed)
   }
 }
 
-void linkingt::rename_symbols(const id_sett &needs_to_be_renamed)
+void linkingt::rename_symbols(
+  const std::unordered_set<irep_idt> &needs_to_be_renamed)
 {
   namespacet src_ns(src_symbol_table);
 
@@ -1258,7 +1259,7 @@ void linkingt::copy_symbols()
   }
 
   // Move over all the non-colliding ones
-  id_sett collisions;
+  std::unordered_set<irep_idt> collisions;
 
   for(const auto &named_symbol : src_symbols)
   {
@@ -1313,7 +1314,7 @@ void linkingt::typecheck()
 
   // PHASE 1: identify symbols to be renamed
 
-  id_sett needs_to_be_renamed;
+  std::unordered_set<irep_idt> needs_to_be_renamed;
 
   for(const auto &symbol_pair : src_symbol_table.symbols)
   {

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -1195,20 +1195,18 @@ void linkingt::do_type_dependencies(
 
   while(!queue.empty())
   {
-    irep_idt id=queue.top();
+    irep_idt id = queue.top();
     queue.pop();
 
     const std::unordered_set<irep_idt> &u = used_by[id];
 
-    for(std::unordered_set<irep_idt>::const_iterator d_it = u.begin();
-        d_it != u.end();
-        d_it++)
-      if(needs_to_be_renamed.insert(*d_it).second)
+    for(const auto &dep : u)
+      if(needs_to_be_renamed.insert(dep).second)
       {
-        queue.push(*d_it);
+        queue.push(dep);
         #ifdef DEBUG
         debug() << "LINKING: needs to be renamed (dependency): "
-                << *d_it << eom;
+                << dep << eom;
         #endif
       }
   }

--- a/src/linking/linking_class.h
+++ b/src/linking/linking_class.h
@@ -38,8 +38,6 @@ public:
   replace_symbolt object_type_updates;
 
 protected:
-  typedef std::unordered_set<irep_idt, irep_id_hash> id_sett;
-
   bool needs_renaming_type(
     const symbolt &old_symbol,
     const symbolt &new_symbol);
@@ -58,9 +56,9 @@ protected:
       return needs_renaming_non_type(old_symbol, new_symbol);
   }
 
-  void do_type_dependencies(id_sett &);
+  void do_type_dependencies(std::unordered_set<irep_idt> &);
 
-  void rename_symbols(const id_sett &needs_to_be_renamed);
+  void rename_symbols(const std::unordered_set<irep_idt> &needs_to_be_renamed);
   void copy_symbols();
 
   void duplicate_non_type_symbol(
@@ -94,8 +92,8 @@ protected:
     const symbolt &old_symbol;
     const symbolt &new_symbol;
     bool set_to_new;
-    id_sett o_symbols;
-    id_sett n_symbols;
+    std::unordered_set<irep_idt> o_symbols;
+    std::unordered_set<irep_idt> n_symbols;
   };
 
   bool adjust_object_type_rec(
@@ -173,12 +171,15 @@ protected:
   namespacet ns;
 
   // X -> Y iff Y uses X for new symbol type IDs X and Y
-  typedef std::unordered_map<irep_idt, id_sett, irep_id_hash> used_byt;
+  typedef std::unordered_map<irep_idt,
+                             std::unordered_set<irep_idt>,
+                             irep_id_hash>
+    used_byt;
 
   irep_idt rename(irep_idt);
 
   // the new IDs created by renaming
-  id_sett renamed_ids;
+  std::unordered_set<irep_idt> renamed_ids;
 };
 
 #endif // CPROVER_LINKING_LINKING_CLASS_H

--- a/src/linking/linking_class.h
+++ b/src/linking/linking_class.h
@@ -171,10 +171,7 @@ protected:
   namespacet ns;
 
   // X -> Y iff Y uses X for new symbol type IDs X and Y
-  typedef std::unordered_map<irep_idt,
-                             std::unordered_set<irep_idt>,
-                             irep_id_hash>
-    used_byt;
+  typedef std::unordered_map<irep_idt, std::unordered_set<irep_idt>> used_byt;
 
   irep_idt rename(irep_idt);
 

--- a/src/pointer-analysis/value_set_analysis_fi.cpp
+++ b/src/pointer-analysis/value_set_analysis_fi.cpp
@@ -47,7 +47,7 @@ void value_set_analysis_fit::add_vars(
   goto_program.get_decl_identifiers(locals);
 
   // cache the list for the locals to speed things up
-  typedef std::unordered_map<irep_idt, entry_listt, irep_id_hash> entry_cachet;
+  typedef std::unordered_map<irep_idt, entry_listt> entry_cachet;
   entry_cachet entry_cache;
 
   value_set_fit &v=state.value_set;

--- a/src/pointer-analysis/value_set_analysis_fivr.cpp
+++ b/src/pointer-analysis/value_set_analysis_fivr.cpp
@@ -47,7 +47,7 @@ void value_set_analysis_fivrt::add_vars(
   goto_program.get_decl_identifiers(locals);
 
   // cache the list for the locals to speed things up
-  typedef std::unordered_map<irep_idt, entry_listt, irep_id_hash> entry_cachet;
+  typedef std::unordered_map<irep_idt, entry_listt> entry_cachet;
   entry_cachet entry_cache;
 
   value_set_fivrt &v=state.value_set;

--- a/src/pointer-analysis/value_set_analysis_fivrns.cpp
+++ b/src/pointer-analysis/value_set_analysis_fivrns.cpp
@@ -47,7 +47,7 @@ void value_set_analysis_fivrnst::add_vars(
   goto_program.get_decl_identifiers(locals);
 
   // cache the list for the locals to speed things up
-  typedef std::unordered_map<irep_idt, entry_listt, irep_id_hash> entry_cachet;
+  typedef std::unordered_map<irep_idt, entry_listt> entry_cachet;
   entry_cachet entry_cache;
 
   value_set_fivrnst &v=state.value_set;

--- a/src/pointer-analysis/value_set_fi.h
+++ b/src/pointer-analysis/value_set_fi.h
@@ -192,9 +192,9 @@ public:
   #ifdef USE_DSTRING
   typedef std::map<idt, entryt> valuest;
   typedef std::set<idt> flatten_seent;
-  typedef std::unordered_set<idt, irep_id_hash> gvs_recursion_sett;
-  typedef std::unordered_set<idt, irep_id_hash> recfind_recursion_sett;
-  typedef std::unordered_set<idt, irep_id_hash> assign_recursion_sett;
+  typedef std::unordered_set<idt> gvs_recursion_sett;
+  typedef std::unordered_set<idt> recfind_recursion_sett;
+  typedef std::unordered_set<idt> assign_recursion_sett;
   #else
   typedef std::unordered_map<idt, entryt, string_hash> valuest;
   typedef std::unordered_set<idt, string_hash> flatten_seent;

--- a/src/pointer-analysis/value_set_fivr.h
+++ b/src/pointer-analysis/value_set_fivr.h
@@ -221,10 +221,10 @@ public:
 
   #ifdef USE_DSTRING
   typedef std::map<idt, entryt> valuest;
-  typedef std::unordered_set<idt, irep_id_hash> flatten_seent;
-  typedef std::unordered_set<idt, irep_id_hash> gvs_recursion_sett;
-  typedef std::unordered_set<idt, irep_id_hash> recfind_recursion_sett;
-  typedef std::unordered_set<idt, irep_id_hash> assign_recursion_sett;
+  typedef std::unordered_set<idt> flatten_seent;
+  typedef std::unordered_set<idt> gvs_recursion_sett;
+  typedef std::unordered_set<idt> recfind_recursion_sett;
+  typedef std::unordered_set<idt> assign_recursion_sett;
   #else
   typedef std::unordered_map<idt, entryt, string_hash> valuest;
   typedef std::unordered_set<idt, string_hash> flatten_seent;

--- a/src/solvers/cvc/cvc_conv.cpp
+++ b/src/solvers/cvc/cvc_conv.cpp
@@ -1157,7 +1157,7 @@ void cvc_convt::set_to(const exprt &expr, bool value)
 
       if(id.type.is_nil())
       {
-        std::unordered_set<irep_idt, irep_id_hash> s_set;
+        std::unordered_set<irep_idt> s_set;
 
         ::find_symbols(expr.op1(), s_set);
 

--- a/src/solvers/cvc/cvc_conv.h
+++ b/src/solvers/cvc/cvc_conv.h
@@ -55,8 +55,7 @@ protected:
     }
   };
 
-  typedef std::unordered_map<irep_idt, identifiert, irep_id_hash>
-    identifier_mapt;
+  typedef std::unordered_map<irep_idt, identifiert> identifier_mapt;
 
   identifier_mapt identifier_map;
 

--- a/src/solvers/flattening/boolbv_map.h
+++ b/src/solvers/flattening/boolbv_map.h
@@ -55,7 +55,7 @@ public:
     std::string get_value(const propt &) const;
   };
 
-  typedef std::unordered_map<irep_idt, map_entryt, irep_id_hash> mappingt;
+  typedef std::unordered_map<irep_idt, map_entryt> mappingt;
   mappingt mapping;
 
   void show() const;

--- a/src/solvers/smt1/smt1_conv.h
+++ b/src/solvers/smt1/smt1_conv.h
@@ -167,8 +167,7 @@ protected:
       identifier.value=tmp;
   }
 
-  typedef std::unordered_map<irep_idt, identifiert, irep_id_hash>
-    identifier_mapt;
+  typedef std::unordered_map<irep_idt, identifiert> identifier_mapt;
 
   identifier_mapt identifier_map;
 

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -274,8 +274,7 @@ protected:
     }
   };
 
-  typedef std::unordered_map<irep_idt, identifiert, irep_id_hash>
-    identifier_mapt;
+  typedef std::unordered_map<irep_idt, identifiert> identifier_mapt;
 
   identifier_mapt identifier_map;
 

--- a/src/solvers/smt2/smt2_dec.cpp
+++ b/src/solvers/smt2/smt2_dec.cpp
@@ -177,7 +177,7 @@ decision_proceduret::resultt smt2_dect::read_result(std::istream &in)
   boolean_assignment.clear();
   boolean_assignment.resize(no_boolean_variables, false);
 
-  typedef std::unordered_map<irep_idt, irept, irep_id_hash> valuest;
+  typedef std::unordered_map<irep_idt, irept> valuest;
   valuest values;
 
   while(in)

--- a/src/util/find_macros.h
+++ b/src/util/find_macros.h
@@ -17,7 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 class exprt;
 class namespacet;
 
-typedef std::unordered_set<irep_idt, irep_id_hash> find_macros_sett;
+typedef std::unordered_set<irep_idt> find_macros_sett;
 
 void find_macros(
   const exprt &src,

--- a/src/util/find_symbols.h
+++ b/src/util/find_symbols.h
@@ -19,7 +19,7 @@ class exprt;
 class symbol_exprt;
 class typet;
 
-typedef std::unordered_set<irep_idt, irep_id_hash> find_symbols_sett;
+typedef std::unordered_set<irep_idt> find_symbols_sett;
 
 void find_symbols(
   const exprt &src,

--- a/src/util/journalling_symbol_table.h
+++ b/src/util/journalling_symbol_table.h
@@ -34,7 +34,7 @@
 class journalling_symbol_tablet : public symbol_table_baset
 {
 public:
-  typedef std::unordered_set<irep_idt, irep_id_hash> changesett;
+  typedef std::unordered_set<irep_idt> changesett;
 
 private:
   symbol_table_baset &base_symbol_table;

--- a/src/util/rename_symbol.h
+++ b/src/util/rename_symbol.h
@@ -25,8 +25,8 @@ class typet;
 class rename_symbolt
 {
 public:
-  typedef std::unordered_map<irep_idt, irep_idt, irep_id_hash> expr_mapt;
-  typedef std::unordered_map<irep_idt, irep_idt, irep_id_hash> type_mapt;
+  typedef std::unordered_map<irep_idt, irep_idt> expr_mapt;
+  typedef std::unordered_map<irep_idt, irep_idt> type_mapt;
 
   void insert_expr(const irep_idt &old_id,
                    const irep_idt &new_id)

--- a/src/util/replace_symbol.h
+++ b/src/util/replace_symbol.h
@@ -22,8 +22,8 @@ Author: Daniel Kroening, kroening@kroening.com
 class replace_symbolt
 {
 public:
-  typedef std::unordered_map<irep_idt, exprt, irep_id_hash> expr_mapt;
-  typedef std::unordered_map<irep_idt, typet, irep_id_hash> type_mapt;
+  typedef std::unordered_map<irep_idt, exprt> expr_mapt;
+  typedef std::unordered_map<irep_idt, typet> type_mapt;
 
   void insert(const irep_idt &identifier,
                      const exprt &expr)

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -930,8 +930,7 @@ public:
     return result;
   }
 
-  typedef
-    std::unordered_map<irep_idt, std::size_t, irep_id_hash> parameter_indicest;
+  typedef std::unordered_map<irep_idt, std::size_t> parameter_indicest;
 
   /// Get a map from parameter name to its index
   parameter_indicest parameter_indices() const

--- a/src/util/symbol_table_base.h
+++ b/src/util/symbol_table_base.h
@@ -25,7 +25,7 @@ class symbol_tablet;
 class symbol_table_baset
 {
 public:
-  typedef std::unordered_map<irep_idt, symbolt, irep_id_hash> symbolst;
+  typedef std::unordered_map<irep_idt, symbolt> symbolst;
 
 public:
   const symbolst &symbols;


### PR DESCRIPTION
#2082 means that we don't need to specify a hash function to `irep_idt`. This PR removes unnecessary uses of `irep_id_hash`. It also builds on #2075 and removes typedefs for `std::set<irep_idt>` and `std::unordered_set<irep_idt>` on the basis that they are now short enough to use directly.