### PR TITLE
Attribute main function arguments to __CPROVER_start

### DIFF
--- a/src/java_bytecode/java_entry_point.cpp
+++ b/src/java_bytecode/java_entry_point.cpp
@@ -203,7 +203,7 @@ exprt::operandst java_build_arguments(
       !assume_init_pointers_not_null && !is_main && !is_this;
 
     object_factory_parameterst parameters = object_factory_parameters;
-    parameters.function_id = function.name;
+    parameters.function_id = goto_functionst::entry_point();
 
     // generate code to allocate and non-deterministicaly initialize the
     // argument


### PR DESCRIPTION
These are created to serve as arguments to main() (or whatever --function was passed), but are
declared in __CPROVER_start, and so should be named after their declarer like all other locals.

This was causing a problem in the security repository, where we relied on local variable names
being prefixed by their declaring function name, and the easiest fix was to restore that convention.