### PR TITLE
Sort includes using clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -84,7 +84,7 @@ NamespaceIndentation: None
 PenaltyBreakString: 10000
 PointerAlignment: Right
 ReflowComments: 'false'
-SortIncludes: 'false'
+SortIncludes: 'true'
 SpaceAfterCStyleCast: 'false'
 SpaceBeforeAssignmentOperators: 'true'
 SpaceBeforeParens: Never


### PR DESCRIPTION
In current version of clang-format, this leaves groupings alone and just sorts within the group. This seems strictly better than not sorting them. Can anyone can spot a reason to keep this off (given that we currently suggest PRs should sort their includes). 