### PR TITLE
Make test independent of string table entry ordering

### DIFF
--- a/regression/cbmc-java/virtual7/test.desc
+++ b/regression/cbmc-java/virtual7/test.desc
@@ -3,6 +3,6 @@ test.class
 --show-goto-functions --function test.main
 ^EXIT=0$
 ^SIGNAL=0$
-IF.*"java::C".*THEN GOTO
-IF.*"java::D".*THEN GOTO
+IF.*"java::B".*THEN GOTO
+IF.*"java::E".*THEN GOTO
 IF.*"java::A".*THEN GOTO

--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -445,10 +445,15 @@ void remove_virtual_functionst::get_functions(
         has_prefix(
           id2string(b.symbol_expr.get_identifier()), "java::java.lang.Object"))
         return true;
-      else if(a.symbol_expr.get_identifier() == b.symbol_expr.get_identifier())
-        return a.class_id < b.class_id;
       else
-        return a.symbol_expr.get_identifier() < b.symbol_expr.get_identifier();
+      {
+        int cmp = a.symbol_expr.get_identifier().compare(
+          b.symbol_expr.get_identifier());
+        if(cmp == 0)
+          return a.class_id < b.class_id;
+        else
+          return cmp < 0;
+      }
     });
 }
 


### PR DESCRIPTION
The program generated by virtual-function removal depends on where 'B', 'C',
'D', 'E' appear in the string table as there are multiple semantically
equivalent resolutions of virtual functions. The test should pass either way.

This was highlighted by #2100 and is now a pre-dependency of that one.