### PR TITLE
Extension to interpreter class [TG-3271]

### DIFF
--- a/src/goto-programs/interpreter_class.h
+++ b/src/goto-programs/interpreter_class.h
@@ -85,6 +85,7 @@ public:
     irep_idt calling_function;
     function_assignmentst return_assignments;
     function_assignmentst param_assignments;
+    function_assignmentst exception_assignments;
   };
 
   // list_input_varst maps function identifiers onto a vector of [name = value]


### PR DESCRIPTION
Interpreter now captures an exceptions that were raised as part of the `function_assignments_contextt`. 

~Note: this class is not used anywhere in CBMC and should probably just be moved into the TG repo. Will make a PR to do that following on from this one so people can voice concerns there.~ Not true - missed one place: `interpretert::execute_function_call` - ah well