### PR TITLE
Symex: resolve class-identifier comparisons

### DIFF
--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -291,6 +291,8 @@ protected:
     symex_transition(state, next);
   }
 
+  bool try_resolve_classid_operations(exprt &guard);
+
   virtual void symex_goto(statet &);
   virtual void symex_start_thread(statet &);
   virtual void symex_atomic_begin(statet &);


### PR DESCRIPTION
Ideally we would resolve comparisons like `x.@class_identifier == "A"` using our existing constant
propagation framework. However, it only classifies a structured object as a constant if all its fields
are constant -- there is no scope for a part-constant object, in the way that @class_identifier is
initialised once and then cannot change subsequently.

Therefore, instead we enforce the invariant that @class_identifier must match the actual type of the
object `x`.

This significantly improves symex processing virtual function dispatch, as it can determine when certain
callees are unreachable, and so potentially vastly simplify the resulting formula.

This needs tests writing, but adding early for comment. I don't expect this to get in exactly as written, but some avenue to provide this sort of information is needed.