### PR TITLE
Sharing map refactoring to reduce memory consumption

### DIFF
--- a/unit/Makefile
+++ b/unit/Makefile
@@ -27,6 +27,7 @@ SRC += unit_tests.cpp \
        util/message.cpp \
        util/optional.cpp \
        util/sharing_node.cpp \
+       util/sharing_map.cpp \
        util/small_map.cpp \
        util/small_shared_two_way_ptr.cpp \
        util/string_utils/split_string.cpp \

--- a/unit/util/sharing_map.cpp
+++ b/unit/util/sharing_map.cpp
@@ -6,6 +6,12 @@ Author: Daniel Poetzl
 
 \*******************************************************************/
 
+#define SHARING_MAP_INTERNAL_CHECKS
+#define SHARING_NODE_INTERNAL_CHECKS
+
+#include <climits>
+#include <random>
+
 #include <testing-utils/catch.hpp>
 #include <util/sharing_map.h>
 
@@ -191,6 +197,10 @@ void sharing_map_copy_test()
 class some_keyt
 {
 public:
+  some_keyt() : s(0)
+  {
+  }
+
   some_keyt(size_t s) : s(s)
   {
   }
@@ -240,14 +250,43 @@ void sharing_map_view_test()
 {
   SECTION("View")
   {
+    typedef std::pair<dstringt, std::string> pt;
+
     smt sm;
+    smt::viewt view;
+    std::vector<pt> pairs;
+
+    auto sort_view = [&pairs, &view]() {
+      pairs.clear();
+      for(auto &p : view)
+      {
+        pairs.push_back({p.first, p.second});
+      }
+      std::sort(pairs.begin(), pairs.end());
+    };
 
     fill(sm);
 
-    smt::viewt view;
     sm.get_view(view);
 
     REQUIRE(view.size() == 3);
+
+    sort_view();
+
+    REQUIRE((pairs[0] == pt("i", "0")));
+    REQUIRE((pairs[1] == pt("j", "1")));
+    REQUIRE((pairs[2] == pt("k", "2")));
+
+    sm.insert("l", "3");
+
+    view.clear();
+    sm.get_view(view);
+
+    REQUIRE(view.size() == 4);
+
+    sort_view();
+
+    REQUIRE((pairs[3] == pt("l", "3")));
   }
 
   SECTION("Delta view (no sharing, same keys)")
@@ -326,6 +365,32 @@ void sharing_map_view_test()
   }
 }
 
+void sharing_map_memory_test()
+{
+  int n;
+
+  n = 1000;
+  //n = 5000000;
+
+  //sharing_mapt<int, int> m;
+  std::map<int, int> m;
+  //std::unordered_map<int, int> m;
+
+  std::random_device r;
+  std::default_random_engine e(r());
+  std::uniform_int_distribution<int> uniform_dist(0, INT_MAX);
+
+  for(int i = 0; i < n; i++)
+  {
+    int v;
+
+    //v = i;
+    v = uniform_dist(e);
+
+    m.insert(std::make_pair(v, v));
+  }
+}
+
 TEST_CASE("Sharing map interface")
 {
   sharing_map_interface_test();
@@ -344,4 +409,9 @@ TEST_CASE("Sharing map collisions")
 TEST_CASE("Sharing map views")
 {
   sharing_map_view_test();
+}
+
+TEST_CASE("Sharing map memory")
+{
+  sharing_map_memory_test();
 }

--- a/unit/util/sharing_map.cpp
+++ b/unit/util/sharing_map.cpp
@@ -365,32 +365,6 @@ void sharing_map_view_test()
   }
 }
 
-void sharing_map_memory_test()
-{
-  int n;
-
-  n = 1000;
-  //n = 5000000;
-
-  //sharing_mapt<int, int> m;
-  std::map<int, int> m;
-  //std::unordered_map<int, int> m;
-
-  std::random_device r;
-  std::default_random_engine e(r());
-  std::uniform_int_distribution<int> uniform_dist(0, INT_MAX);
-
-  for(int i = 0; i < n; i++)
-  {
-    int v;
-
-    //v = i;
-    v = uniform_dist(e);
-
-    m.insert(std::make_pair(v, v));
-  }
-}
-
 TEST_CASE("Sharing map interface")
 {
   sharing_map_interface_test();
@@ -409,9 +383,4 @@ TEST_CASE("Sharing map collisions")
 TEST_CASE("Sharing map views")
 {
   sharing_map_view_test();
-}
-
-TEST_CASE("Sharing map memory")
-{
-  sharing_map_memory_test();
 }


### PR DESCRIPTION
This changes the representation of nodes in `sharing_mapt` to reduce memory consumption.