### PR TITLE
Cleanup of unnecessary includes, plus other cleanups

### DIFF
--- a/src/analyses/goto_rw.h
+++ b/src/analyses/goto_rw.h
@@ -13,7 +13,7 @@ Date: April 2010
 #define CPROVER_ANALYSES_GOTO_RW_H
 
 #include <map>
-#include <ostream>
+#include <iosfwd>
 #include <limits>
 #include <memory> // unique_ptr
 

--- a/src/analyses/goto_rw.h
+++ b/src/analyses/goto_rw.h
@@ -12,9 +12,9 @@ Date: April 2010
 #ifndef CPROVER_ANALYSES_GOTO_RW_H
 #define CPROVER_ANALYSES_GOTO_RW_H
 
-#include <map>
 #include <iosfwd>
 #include <limits>
+#include <map>
 #include <memory> // unique_ptr
 
 #include <util/guard.h>

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -8,19 +8,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "ansi_c_entry_point.h"
 
-#include <cassert>
-#include <cstdlib>
-
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/config.h>
-#include <util/cprover_prefix.h>
-#include <util/namespace.h>
-#include <util/prefix.h>
-#include <util/std_code.h>
-#include <util/std_expr.h>
 #include <util/string_constant.h>
-#include <util/symbol.h>
 
 #include <goto-programs/goto_functions.h>
 

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -23,6 +23,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/symbol.h>
 
 #include <goto-programs/goto_functions.h>
+
 #include <linking/static_lifetime_init.h>
 
 #include "c_nondet_symbol_factory.h"
@@ -217,7 +218,7 @@ bool generate_ansi_c_start_function(
     if(init_it==symbol_table.symbols.end())
     {
       messaget message(message_handler);
-      message.error() << "failed to find " CPROVER_PREFIX "initialize symbol"
+      message.error() << "failed to find " INITIALIZE_FUNCTION " symbol"
                       << messaget::eom;
       return true;
     }

--- a/src/ansi-c/ansi_c_internal_additions.cpp
+++ b/src/ansi-c/ansi_c_internal_additions.cpp
@@ -10,6 +10,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/config.h>
 
+#include <linking/static_lifetime_init.h>
+
 const char gcc_builtin_headers_types[]=
 "# 1 \"gcc_builtin_headers_types.h\"\n"
 #include "gcc_builtin_headers_types.inc"
@@ -172,7 +174,7 @@ void ansi_c_internal_additions(std::string &code)
     "\n"
     // This function needs to be declared, or otherwise can't be called
     // by the entry-point construction.
-    "void __CPROVER_initialize(void);\n"
+    "void " INITIALIZE_FUNCTION "(void);\n"
     "\n";
 
   // GCC junk stuff, also for CLANG and ARM

--- a/src/ansi-c/c_nondet_symbol_factory.cpp
+++ b/src/ansi-c/c_nondet_symbol_factory.cpp
@@ -11,21 +11,13 @@ Author: Diffblue Ltd.
 
 #include "c_nondet_symbol_factory.h"
 
-#include <set>
-#include <sstream>
-
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/fresh_symbol.h>
 #include <util/namespace.h>
-#include <util/pointer_offset_size.h>
-#include <util/prefix.h>
-#include <util/std_code.h>
 #include <util/std_expr.h>
 #include <util/std_types.h>
 #include <util/string_constant.h>
-
-#include <linking/zero_initializer.h>
 
 #include <goto-programs/goto_functions.h>
 

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -14,17 +14,14 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <cassert>
 
 #include <util/arith_tools.h>
-#include <util/c_types.h>
-#include <util/config.h>
-#include <util/std_types.h>
-#include <util/prefix.h>
-#include <util/cprover_prefix.h>
-#include <util/simplify_expr.h>
 #include <util/base_type.h>
-#include <util/std_expr.h>
-#include <util/string_constant.h>
+#include <util/c_types.h>
+#include <util/cprover_prefix.h>
+#include <util/ieee_float.h>
 #include <util/pointer_offset_size.h>
 #include <util/pointer_predicates.h>
+#include <util/simplify_expr.h>
+#include <util/string_constant.h>
 
 #include "builtin_factory.h"
 #include "c_typecast.h"

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -13,19 +13,16 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <unordered_set>
 
+#include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/config.h>
-#include <util/invariant.h>
-#include <util/simplify_expr.h>
-#include <util/arith_tools.h>
-#include <util/std_types.h>
 #include <util/pointer_offset_size.h>
+#include <util/simplify_expr.h>
 
+#include "ansi_c_convert_type.h"
 #include "c_qualifiers.h"
-#include "ansi_c_declaration.h"
 #include "padding.h"
 #include "type2name.h"
-#include "ansi_c_convert_type.h"
 
 void c_typecheck_baset::typecheck_type(typet &type)
 {

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -13,23 +13,18 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <sstream>
 
 #include <map>
-#include <set>
 
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/config.h>
-#include <util/std_types.h>
-#include <util/std_code.h>
-#include <util/ieee_float.h>
-#include <util/fixedbv.h>
-#include <util/prefix.h>
-#include <util/lispirep.h>
-#include <util/lispexpr.h>
-#include <util/namespace.h>
-#include <util/symbol.h>
-#include <util/suffix.h>
 #include <util/find_symbols.h>
+#include <util/fixedbv.h>
+#include <util/lispexpr.h>
+#include <util/lispirep.h>
+#include <util/namespace.h>
 #include <util/pointer_offset_size.h>
+#include <util/suffix.h>
+#include <util/symbol.h>
 
 #include "c_misc.h"
 #include "c_qualifiers.h"

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -10,14 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <algorithm>
 #include <cassert>
-#include <cctype>
-#include <cstdio>
-
-#ifdef _WIN32
-#ifndef __MINGW32__
-#define snprintf sprintf_s
-#endif
-#endif
+#include <sstream>
 
 #include <map>
 #include <set>
@@ -2258,9 +2251,9 @@ std::string expr2ct::convert_array(
           dest+=static_cast<char>(ch);
         else
         {
-          char hexbuf[10];
-          snprintf(hexbuf, sizeof(hexbuf), "\\x%x", ch);
-          dest+=hexbuf;
+          std::ostringstream oss;
+          oss << "\\x" << std::hex << ch;
+          dest += oss.str();
           last_was_hex=true;
         }
       }

--- a/src/ansi-c/type2name.cpp
+++ b/src/ansi-c/type2name.cpp
@@ -11,13 +11,12 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "type2name.h"
 
-#include <util/std_types.h>
 #include <util/arith_tools.h>
-#include <util/namespace.h>
-#include <util/symbol.h>
-#include <util/symbol_table.h>
-#include <util/pointer_offset_size.h>
 #include <util/invariant.h>
+#include <util/namespace.h>
+#include <util/pointer_offset_size.h>
+#include <util/std_types.h>
+#include <util/symbol_table.h>
 
 typedef std::unordered_map<irep_idt, std::pair<size_t, bool>> symbol_numbert;
 

--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -42,6 +42,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-symex/memory_model_tso.h>
 #include <goto-symex/memory_model_pso.h>
 
+#include <linking/static_lifetime_init.h>
+
 #include "cbmc_solvers.h"
 #include "counterexample_beautification.h"
 #include "fault_localization.h"
@@ -338,7 +340,7 @@ void bmct::setup()
 
   {
     const symbolt *init_symbol;
-    if(!ns.lookup(CPROVER_PREFIX "initialize", init_symbol))
+    if(!ns.lookup(INITIALIZE_FUNCTION, init_symbol))
       symex.language_mode=init_symbol->mode;
   }
 

--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -12,35 +12,22 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "bmc.h"
 
 #include <chrono>
-#include <exception>
-#include <fstream>
 #include <iostream>
-#include <memory>
 
 #include <util/exit_codes.h>
 #include <util/string2int.h>
-#include <util/source_location.h>
 #include <util/string_utils.h>
-#include <util/memory_info.h>
-#include <util/message.h>
-#include <util/json.h>
-#include <util/json_stream.h>
-#include <util/cprover_prefix.h>
 
-#include <langapi/mode.h>
 #include <langapi/language_util.h>
 
-#include <goto-programs/goto_model.h>
-#include <goto-programs/xml_goto_trace.h>
-#include <goto-programs/json_goto_trace.h>
 #include <goto-programs/graphml_witness.h>
+#include <goto-programs/json_goto_trace.h>
+#include <goto-programs/xml_goto_trace.h>
 
 #include <goto-symex/build_goto_trace.h>
+#include <goto-symex/memory_model_pso.h>
 #include <goto-symex/slice.h>
 #include <goto-symex/slice_by_trace.h>
-#include <goto-symex/memory_model_sc.h>
-#include <goto-symex/memory_model_tso.h>
-#include <goto-symex/memory_model_pso.h>
 
 #include <linking/static_lifetime_init.h>
 

--- a/src/cbmc/symex_coverage.cpp
+++ b/src/cbmc/symex_coverage.cpp
@@ -13,16 +13,13 @@ Date: March 2016
 
 #include "symex_coverage.h"
 
-#include <ctime>
 #include <chrono>
-#include <iostream>
+#include <ctime>
 #include <fstream>
-#include <sstream>
+#include <iostream>
 
-#include <util/xml.h>
 #include <util/string2int.h>
-#include <util/cprover_prefix.h>
-#include <util/prefix.h>
+#include <util/xml.h>
 
 #include <langapi/language_util.h>
 

--- a/src/cbmc/symex_coverage.cpp
+++ b/src/cbmc/symex_coverage.cpp
@@ -29,6 +29,8 @@ Date: March 2016
 #include <goto-programs/goto_functions.h>
 #include <goto-programs/remove_returns.h>
 
+#include <linking/static_lifetime_init.h>
+
 class coverage_recordt
 {
 public:
@@ -313,7 +315,7 @@ void symex_coveraget::compute_overall_coverage(
   {
     if(!gf_it->second.body_available() ||
        gf_it->first==goto_functions.entry_point() ||
-       gf_it->first==CPROVER_PREFIX "initialize")
+       gf_it->first == INITIALIZE_FUNCTION)
       continue;
 
     goto_program_coverage_recordt func_cov(ns, gf_it, coverage);

--- a/src/cbmc/symex_coverage.h
+++ b/src/cbmc/symex_coverage.h
@@ -15,7 +15,7 @@ Date: March 2016
 #define CPROVER_CBMC_SYMEX_COVERAGE_H
 
 #include <string>
-#include <ostream>
+#include <iosfwd>
 #include <map>
 
 #include <goto-programs/goto_program.h>

--- a/src/cbmc/symex_coverage.h
+++ b/src/cbmc/symex_coverage.h
@@ -14,9 +14,9 @@ Date: March 2016
 #ifndef CPROVER_CBMC_SYMEX_COVERAGE_H
 #define CPROVER_CBMC_SYMEX_COVERAGE_H
 
-#include <string>
 #include <iosfwd>
 #include <map>
+#include <string>
 
 #include <goto-programs/goto_program.h>
 

--- a/src/cpp/cpp_exception_id.cpp
+++ b/src/cpp/cpp_exception_id.cpp
@@ -11,6 +11,8 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "cpp_exception_id.h"
 
+#include <util/invariant.h>
+
 /// turns a type into a list of relevant exception IDs
 void cpp_exception_list_rec(
   const typet &src,
@@ -91,6 +93,6 @@ irep_idt cpp_exception_id(
 {
   std::vector<irep_idt> ids;
   cpp_exception_list_rec(src, ns, "", ids);
-  assert(!ids.empty());
+  CHECK_RETURN(!ids.empty());
   return ids.front();
 }

--- a/src/cpp/cpp_internal_additions.cpp
+++ b/src/cpp/cpp_internal_additions.cpp
@@ -14,6 +14,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <ansi-c/ansi_c_internal_additions.h>
 
+#include <linking/static_lifetime_init.h>
+
 std::string c2cpp(const std::string &s)
 {
   std::string result;
@@ -75,7 +77,7 @@ void cpp_internal_additions(std::ostream &out)
 
   // CPROVER extensions
   out << "extern \"C\" const unsigned __CPROVER::constant_infinity_uint;\n";
-  out << "extern \"C\" void __CPROVER_initialize();" << '\n';
+  out << "extern \"C\" void " INITIALIZE_FUNCTION "();" << '\n';
   out << "extern \"C\" void __CPROVER::input(const char *id, ...);" << '\n';
   out << "extern \"C\" void __CPROVER::output(const char *id, ...);" << '\n';
   out << "extern \"C\" void __CPROVER::cover(bool condition);" << '\n';

--- a/src/cpp/cpp_name.h
+++ b/src/cpp/cpp_name.h
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #define CPROVER_CPP_CPP_NAME_H
 
 #include <util/expr.h>
+#include <util/invariant.h>
 
 class cpp_namet:public irept
 {
@@ -142,13 +143,13 @@ public:
 
 inline cpp_namet &to_cpp_name(irept &cpp_name)
 {
-  assert(cpp_name.id() == ID_cpp_name);
+  PRECONDITION(cpp_name.id() == ID_cpp_name);
   return static_cast<cpp_namet &>(cpp_name);
 }
 
 inline const cpp_namet &to_cpp_name(const irept &cpp_name)
 {
-  assert(cpp_name.id() == ID_cpp_name);
+  PRECONDITION(cpp_name.id() == ID_cpp_name);
   return static_cast<const cpp_namet &>(cpp_name);
 }
 

--- a/src/cpp/cpp_template_args.h
+++ b/src/cpp/cpp_template_args.h
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #define CPROVER_CPP_CPP_TEMPLATE_ARGS_H
 
 #include <util/expr.h>
+#include <util/invariant.h>
 
 // A data structures for template arguments, i.e.,
 // a sequence of types/expressions of the form <E1, T2, ...>.
@@ -47,14 +48,14 @@ class cpp_template_args_non_tct:public cpp_template_args_baset
 inline cpp_template_args_non_tct &to_cpp_template_args_non_tc(
   irept &irep)
 {
-  assert(irep.id()==ID_template_args);
+  PRECONDITION(irep.id() == ID_template_args);
   return static_cast<cpp_template_args_non_tct &>(irep);
 }
 
 inline const cpp_template_args_non_tct &to_cpp_template_args_non_tc(
   const irept &irep)
 {
-  assert(irep.id()==ID_template_args);
+  PRECONDITION(irep.id() == ID_template_args);
   return static_cast<const cpp_template_args_non_tct &>(irep);
 }
 
@@ -80,13 +81,13 @@ public:
 
 inline cpp_template_args_tct &to_cpp_template_args_tc(irept &irep)
 {
-  assert(irep.id()==ID_template_args);
+  PRECONDITION(irep.id() == ID_template_args);
   return static_cast<cpp_template_args_tct &>(irep);
 }
 
 inline const cpp_template_args_tct &to_cpp_template_args_tc(const irept &irep)
 {
-  assert(irep.id()==ID_template_args);
+  PRECONDITION(irep.id() == ID_template_args);
   return static_cast<const cpp_template_args_tct &>(irep);
 }
 

--- a/src/cpp/cpp_template_type.h
+++ b/src/cpp/cpp_template_type.h
@@ -10,6 +10,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #ifndef CPROVER_CPP_CPP_TEMPLATE_TYPE_H
 #define CPROVER_CPP_CPP_TEMPLATE_TYPE_H
 
+#include <util/invariant.h>
 #include <util/type.h>
 #include <util/expr.h>
 
@@ -37,13 +38,13 @@ public:
 
 inline template_typet &to_template_type(typet &type)
 {
-  assert(type.id()==ID_template);
+  PRECONDITION(type.id() == ID_template);
   return static_cast<template_typet &>(type);
 }
 
 inline const template_typet &to_template_type(const typet &type)
 {
-  assert(type.id()==ID_template);
+  PRECONDITION(type.id() == ID_template);
   return static_cast<const template_typet &>(type);
 }
 

--- a/src/cpp/cpp_template_type.h
+++ b/src/cpp/cpp_template_type.h
@@ -12,7 +12,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include <util/invariant.h>
 #include <util/type.h>
-#include <util/expr.h>
 
 #include "cpp_template_parameter.h"
 

--- a/src/cpp/cpp_token_buffer.h
+++ b/src/cpp/cpp_token_buffer.h
@@ -16,6 +16,8 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include <list>
 
+#include <util/invariant.h>
+
 class cpp_token_buffert
 {
 public:
@@ -45,7 +47,7 @@ public:
   // the token that is currently being read from the file
   cpp_tokent &current_token()
   {
-    assert(!tokens.empty());
+    PRECONDITION(!tokens.empty());
     return tokens.back();
   }
 

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -15,23 +15,18 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <iostream>
 #endif
 
-#include <util/pointer_offset_size.h>
-#include <util/std_types.h>
 #include <util/arith_tools.h>
-#include <util/std_expr.h>
-#include <util/config.h>
-#include <util/simplify_expr.h>
 #include <util/base_type.h>
-#include <util/invariant.h>
-
 #include <util/c_types.h>
+#include <util/config.h>
+#include <util/pointer_offset_size.h>
+
 #include <ansi-c/c_qualifiers.h>
 
 #include <linking/zero_initializer.h>
 
-#include "cpp_type2name.h"
-#include "cpp_convert_type.h"
 #include "cpp_exception_id.h"
+#include "cpp_type2name.h"
 #include "expr2cpp.h"
 
 bool cpp_typecheckt::find_parent(

--- a/src/cpp/cpp_typecheck_initializer.cpp
+++ b/src/cpp/cpp_typecheck_initializer.cpp
@@ -14,11 +14,8 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/pointer_offset_size.h>
-#include <util/std_expr.h>
 
 #include <linking/zero_initializer.h>
-
-#include "cpp_util.h"
 
 /// Initialize an object with a value
 void cpp_typecheckt::convert_initializer(symbolt &symbol)

--- a/src/cpp/template_map.cpp
+++ b/src/cpp/template_map.cpp
@@ -173,14 +173,15 @@ void template_mapt::build(
   }
 
   // these should have been typechecked before
-  assert(instance.size()==template_parameters.size());
+  DATA_INVARIANT(
+    instance.size() == template_parameters.size(),
+    "template instantiation expected to match declaration");
 
   for(cpp_template_args_tct::argumentst::const_iterator
       i_it=instance.begin();
       i_it!=instance.end();
       i_it++, t_it++)
   {
-    assert(t_it!=template_parameters.end());
     set(*t_it, *i_it);
   }
 }

--- a/src/goto-analyzer/static_show_domain.cpp
+++ b/src/goto-analyzer/static_show_domain.cpp
@@ -8,6 +8,8 @@ Author: Martin Brain, martin.brain@cs.ox.ac.uk
 
 #include "static_show_domain.h"
 
+#include <util/options.h>
+
 #include <analyses/dependence_graph.h>
 
 /// Runs the analyzer and then prints out the domain

--- a/src/goto-analyzer/static_show_domain.h
+++ b/src/goto-analyzer/static_show_domain.h
@@ -9,7 +9,7 @@ Author: Martin Brain, martin.brain@cs.ox.ac.uk
 #ifndef CPROVER_GOTO_ANALYZER_STATIC_SHOW_DOMAIN_H
 #define CPROVER_GOTO_ANALYZER_STATIC_SHOW_DOMAIN_H
 
-#include <ostream>
+#include <iosfwd>
 
 #include <util/message.h>
 #include <util/options.h>

--- a/src/goto-analyzer/static_show_domain.h
+++ b/src/goto-analyzer/static_show_domain.h
@@ -11,12 +11,10 @@ Author: Martin Brain, martin.brain@cs.ox.ac.uk
 
 #include <iosfwd>
 
-#include <util/message.h>
-#include <util/options.h>
-
-#include <goto-programs/goto_model.h>
-
-#include <analyses/ai.h>
+class ai_baset;
+class goto_modelt;
+class message_handlert;
+class optionst;
 
 bool static_show_domain(
   const goto_modelt &,

--- a/src/goto-analyzer/static_simplifier.cpp
+++ b/src/goto-analyzer/static_simplifier.cpp
@@ -6,17 +6,17 @@ Author: Martin Brain, martin.brain@cs.ox.ac.uk
 
 \*******************************************************************/
 
+#include "static_simplifier.h"
+
+#include <util/message.h>
+#include <util/options.h>
+
+#include <goto-programs/goto_model.h>
 #include <goto-programs/remove_skip.h>
 #include <goto-programs/remove_unreachable.h>
 #include <goto-programs/write_goto_binary.h>
 
-#include <util/xml.h>
-#include <util/xml_expr.h>
-#include <util/json.h>
-#include <util/json_expr.h>
-
-#include "static_simplifier.h"
-
+#include <analyses/ai.h>
 
 /// Simplifies the program using the information in the abstract domain.
 /// \param goto_model: the program analyzed

--- a/src/goto-analyzer/static_simplifier.h
+++ b/src/goto-analyzer/static_simplifier.h
@@ -9,7 +9,7 @@ Author: Martin Brain, martin.brain@cs.ox.ac.uk
 #ifndef CPROVER_GOTO_ANALYZER_STATIC_SIMPLIFIER_H
 #define CPROVER_GOTO_ANALYZER_STATIC_SIMPLIFIER_H
 
-#include <ostream>
+#include <iosfwd>
 
 #include <util/message.h>
 #include <util/options.h>

--- a/src/goto-analyzer/static_simplifier.h
+++ b/src/goto-analyzer/static_simplifier.h
@@ -11,12 +11,10 @@ Author: Martin Brain, martin.brain@cs.ox.ac.uk
 
 #include <iosfwd>
 
-#include <util/message.h>
-#include <util/options.h>
-
-#include <goto-programs/goto_model.h>
-
-#include <analyses/ai.h>
+class ai_baset;
+class goto_modelt;
+class message_handlert;
+class optionst;
 
 bool static_simplifier(
   goto_modelt &,

--- a/src/goto-analyzer/static_verifier.cpp
+++ b/src/goto-analyzer/static_verifier.cpp
@@ -8,11 +8,14 @@ Author: Martin Brain, martin.brain@cs.ox.ac.uk
 
 #include "static_verifier.h"
 
-#include <util/xml.h>
-#include <util/xml_expr.h>
-#include <util/json.h>
 #include <util/json_expr.h>
+#include <util/message.h>
+#include <util/namespace.h>
+#include <util/options.h>
 
+#include <goto-programs/goto_model.h>
+
+#include <analyses/ai.h>
 
 /// Runs the analyzer and then prints out the domain
 /// \param goto_model: the program analyzed

--- a/src/goto-analyzer/static_verifier.h
+++ b/src/goto-analyzer/static_verifier.h
@@ -9,7 +9,7 @@ Author: Martin Brain, martin.brain@cs.ox.ac.uk
 #ifndef CPROVER_GOTO_ANALYZER_STATIC_VERIFIER_H
 #define CPROVER_GOTO_ANALYZER_STATIC_VERIFIER_H
 
-#include <ostream>
+#include <iosfwd>
 
 #include <util/message.h>
 #include <util/options.h>

--- a/src/goto-analyzer/static_verifier.h
+++ b/src/goto-analyzer/static_verifier.h
@@ -11,12 +11,10 @@ Author: Martin Brain, martin.brain@cs.ox.ac.uk
 
 #include <iosfwd>
 
-#include <util/message.h>
-#include <util/options.h>
-
-#include <goto-programs/goto_model.h>
-
-#include <analyses/ai.h>
+class ai_baset;
+class goto_modelt;
+class message_handlert;
+class optionst;
 
 bool static_verifier(
   const goto_modelt &,

--- a/src/goto-analyzer/unreachable_instructions.cpp
+++ b/src/goto-analyzer/unreachable_instructions.cpp
@@ -13,17 +13,15 @@ Date: April 2016
 
 #include "unreachable_instructions.h"
 
-#include <sstream>
-
-#include <util/json.h>
-#include <util/json_expr.h>
 #include <util/file_util.h>
+#include <util/json_expr.h>
+#include <util/options.h>
 #include <util/xml.h>
 
-#include <analyses/cfg_dominators.h>
-
-#include <goto-programs/goto_model.h>
 #include <goto-programs/compute_called_functions.h>
+
+#include <analyses/ai.h>
+#include <analyses/cfg_dominators.h>
 
 typedef std::map<unsigned, goto_programt::const_targett> dead_mapt;
 

--- a/src/goto-analyzer/unreachable_instructions.h
+++ b/src/goto-analyzer/unreachable_instructions.h
@@ -14,14 +14,12 @@ Date: April 2016
 #ifndef CPROVER_GOTO_ANALYZER_UNREACHABLE_INSTRUCTIONS_H
 #define CPROVER_GOTO_ANALYZER_UNREACHABLE_INSTRUCTIONS_H
 
-#include <ostream>
+#include <iosfwd>
 
-#include <analyses/ai.h>
-
-#include <util/options.h>
-#include <util/message.h>
-
+class ai_baset;
 class goto_modelt;
+class message_handlert;
+class optionst;
 
 void unreachable_instructions(
   const goto_modelt &,

--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -41,6 +41,8 @@ Date: June 2006
 
 #include <langapi/mode.h>
 
+#include <linking/static_lifetime_init.h>
+
 #include <cbmc/version.h>
 
 #define DOTGRAPHSETTINGS  "color=black;" \
@@ -372,7 +374,7 @@ bool compilet::link()
     // new symbols may have been added to a previously linked file
     // make sure a new entry point is created that contains all
     // static initializers
-    compiled_functions.function_map.erase("__CPROVER_initialize");
+    compiled_functions.function_map.erase(INITIALIZE_FUNCTION);
 
     symbol_table.remove(goto_functionst::entry_point());
     compiled_functions.function_map.erase(goto_functionst::entry_point());

--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -15,27 +15,21 @@ Date: June 2006
 
 #include <cstring>
 #include <fstream>
-#include <sstream>
 #include <iostream>
-#include <cstdlib>
-#include <algorithm>
 
-#include <util/config.h>
-#include <util/tempdir.h>
-#include <util/base_type.h>
 #include <util/cmdline.h>
+#include <util/config.h>
 #include <util/file_util.h>
-#include <util/unicode.h>
-#include <util/irep_serialization.h>
-#include <util/suffix.h>
 #include <util/get_base_name.h>
+#include <util/suffix.h>
+#include <util/tempdir.h>
+#include <util/unicode.h>
 
 #include <ansi-c/ansi_c_language.h>
 #include <ansi-c/ansi_c_entry_point.h>
 
 #include <goto-programs/goto_convert.h>
 #include <goto-programs/goto_convert_functions.h>
-#include <goto-programs/goto_inline.h>
 #include <goto-programs/read_goto_binary.h>
 #include <goto-programs/write_goto_binary.h>
 

--- a/src/goto-cc/linker_script_merge.cpp
+++ b/src/goto-cc/linker_script_merge.cpp
@@ -24,6 +24,7 @@ Author: Kareem Khazem <karkhaz@karkhaz.com>, 2017
 #include <util/string2int.h>
 #include <util/tempfile.h>
 
+#include <linking/static_lifetime_init.h>
 #include <linking/zero_initializer.h>
 
 #include <goto-programs/read_goto_binary.h>
@@ -78,10 +79,10 @@ int linker_script_merget::add_linker_script_definitions()
 
   fail=1;
   linker_valuest linker_values;
-  const auto &pair=original_gf.function_map.find(CPROVER_PREFIX "initialize");
+  const auto &pair=original_gf.function_map.find(INITIALIZE_FUNCTION);
   if(pair==original_gf.function_map.end())
   {
-    error() << "No " << CPROVER_PREFIX "initialize found in goto_functions"
+    error() << "No " << INITIALIZE_FUNCTION << " found in goto_functions"
             << eom;
     return fail;
   }
@@ -93,7 +94,7 @@ int linker_script_merget::add_linker_script_definitions()
       linker_values);
   if(fail!=0)
   {
-    error() << "Could not add linkerscript defs to __CPROVER_initialize" << eom;
+    error() << "Could not add linkerscript defs to " INITIALIZE_FUNCTION << eom;
     return fail;
   }
 

--- a/src/goto-cc/linker_script_merge.cpp
+++ b/src/goto-cc/linker_script_merge.cpp
@@ -6,31 +6,24 @@ Author: Kareem Khazem <karkhaz@karkhaz.com>, 2017
 
 \*******************************************************************/
 
-#include <json/json_parser.h>
+#include "linker_script_merge.h"
 
 #include <algorithm>
-#include <cstdio>
-#include <iostream>
-#include <iterator>
 #include <fstream>
+#include <iterator>
 
 #include <util/arith_tools.h>
 #include <util/c_types.h>
-#include <util/expr.h>
-#include <util/get_base_name.h>
 #include <util/magic.h>
-#include <util/prefix.h>
 #include <util/run.h>
-#include <util/string2int.h>
 #include <util/tempfile.h>
+
+#include <json/json_parser.h>
 
 #include <linking/static_lifetime_init.h>
 #include <linking/zero_initializer.h>
 
 #include <goto-programs/read_goto_binary.h>
-
-#include "compile.h"
-#include "linker_script_merge.h"
 
 int linker_script_merget::add_linker_script_definitions()
 {

--- a/src/goto-diff/goto_diff.h
+++ b/src/goto-diff/goto_diff.h
@@ -12,13 +12,14 @@ Author: Peter Schrammel
 #ifndef CPROVER_GOTO_DIFF_GOTO_DIFF_H
 #define CPROVER_GOTO_DIFF_GOTO_DIFF_H
 
-#include <goto-programs/goto_model.h>
-
-#include <util/json.h>
 #include <util/ui_message.h>
 
-#include <ostream>
+#include <iosfwd>
+#include <set>
 
+class goto_modelt;
+class json_arrayt;
+class json_objectt;
 class optionst;
 
 class goto_difft:public messaget

--- a/src/goto-diff/goto_diff_base.cpp
+++ b/src/goto-diff/goto_diff_base.cpp
@@ -11,10 +11,11 @@ Author: Peter Schrammel
 
 #include "goto_diff.h"
 
-#include <goto-programs/show_properties.h>
-
 #include <util/json_expr.h>
 #include <util/options.h>
+
+#include <goto-programs/goto_model.h>
+#include <goto-programs/show_properties.h>
 
 /// Output diff result
 void goto_difft::output_functions() const

--- a/src/goto-diff/syntactic_diff.cpp
+++ b/src/goto-diff/syntactic_diff.cpp
@@ -11,6 +11,8 @@ Author: Peter Schrammel
 
 #include "syntactic_diff.h"
 
+#include <goto-programs/goto_model.h>
+
 bool syntactic_difft::operator()()
 {
   forall_goto_functions(it, goto_model1.goto_functions)

--- a/src/goto-instrument/alignment_checks.cpp
+++ b/src/goto-instrument/alignment_checks.cpp
@@ -11,9 +11,8 @@ Author:
 
 #include "alignment_checks.h"
 
-#include <util/pointer_offset_size.h>
 #include <util/config.h>
-#include <util/symbol_table.h>
+#include <util/pointer_offset_size.h>
 
 void print_struct_alignment_problems(
   const symbol_tablet &symbol_table,

--- a/src/goto-instrument/call_sequences.cpp
+++ b/src/goto-instrument/call_sequences.cpp
@@ -15,9 +15,7 @@ Date: April 2013
 
 #include <stack>
 #include <iostream>
-#include <unordered_set>
 
-#include <util/std_expr.h>
 #include <util/simplify_expr.h>
 
 #include <goto-programs/goto_model.h>

--- a/src/goto-instrument/call_sequences.cpp
+++ b/src/goto-instrument/call_sequences.cpp
@@ -24,6 +24,8 @@ Date: April 2013
 
 #include <langapi/language_util.h>
 
+#include <linking/static_lifetime_init.h>
+
 void show_call_sequences(
   const irep_idt &caller,
   const goto_programt &goto_program)
@@ -286,7 +288,7 @@ static void list_calls_and_arguments(
       continue;
 
     const irep_idt &identifier=to_symbol_expr(f).get_identifier();
-    if(identifier=="__CPROVER_initialize")
+    if(identifier == INITIALIZE_FUNCTION)
       continue;
 
     std::string name=from_expr(ns, identifier, f);

--- a/src/goto-instrument/code_contracts.cpp
+++ b/src/goto-instrument/code_contracts.cpp
@@ -21,6 +21,8 @@ Date: February 2016
 
 #include <analyses/local_may_alias.h>
 
+#include <linking/static_lifetime_init.h>
+
 #include "loop_utils.h"
 
 class code_contractst
@@ -385,7 +387,7 @@ void code_contractst::operator()()
     code_contracts(it->second);
 
   goto_functionst::function_mapt::iterator i_it=
-    goto_functions.function_map.find(CPROVER_PREFIX "initialize");
+    goto_functions.function_map.find(INITIALIZE_FUNCTION);
   assert(i_it!=goto_functions.function_map.end());
 
   for(const auto &contract : summarized)

--- a/src/goto-instrument/code_contracts.cpp
+++ b/src/goto-instrument/code_contracts.cpp
@@ -13,7 +13,6 @@ Date: February 2016
 
 #include "code_contracts.h"
 
-#include <util/cprover_prefix.h>
 #include <util/fresh_symbol.h>
 #include <util/replace_symbol.h>
 

--- a/src/goto-instrument/cover_filter.cpp
+++ b/src/goto-instrument/cover_filter.cpp
@@ -11,9 +11,7 @@ Author: Peter Schrammel
 
 #include "cover_filter.h"
 
-#include <json/json_parser.h>
-
-#include <util/message.h>
+#include <linking/static_lifetime_init.h>
 
 /// Filter out functions that are not considered provided by the user
 /// \param identifier: a function name
@@ -26,7 +24,7 @@ bool internal_functions_filtert::operator()(
   if(identifier == goto_functionst::entry_point())
     return false;
 
-  if(identifier == (CPROVER_PREFIX "initialize"))
+  if(identifier == INITIALIZE_FUNCTION)
     return false;
 
   if(goto_function.is_hidden())

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -11,16 +11,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "dump_c.h"
 
-#include <sstream>
-#include <cctype>
-
-#include <util/config.h>
-#include <util/invariant.h>
-#include <util/prefix.h>
-#include <util/suffix.h>
-#include <util/find_symbols.h>
 #include <util/base_type.h>
-#include <util/cprover_prefix.h>
+#include <util/config.h>
+#include <util/find_symbols.h>
+#include <util/invariant.h>
 #include <util/replace_symbol.h>
 
 #include <ansi-c/ansi_c_language.h>
@@ -28,8 +22,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <linking/static_lifetime_init.h>
 
-#include "goto_program2code.h"
 #include "dump_c_class.h"
+#include "goto_program2code.h"
 
 inline std::ostream &operator << (std::ostream &out, dump_ct &src)
 {

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -26,6 +26,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <ansi-c/ansi_c_language.h>
 #include <cpp/cpp_language.h>
 
+#include <linking/static_lifetime_init.h>
+
 #include "goto_program2code.h"
 #include "dump_c_class.h"
 
@@ -953,7 +955,7 @@ void dump_ct::cleanup_harness(code_blockt &b)
         symbol_exprt &s=to_symbol_expr(func);
         if(s.get_identifier()==ID_main)
           s.set_identifier(CPROVER_PREFIX+id2string(ID_main));
-        else if(s.get_identifier()==CPROVER_PREFIX "initialize")
+        else if(s.get_identifier() == INITIALIZE_FUNCTION)
           continue;
       }
     }

--- a/src/goto-instrument/interrupt.cpp
+++ b/src/goto-instrument/interrupt.cpp
@@ -13,15 +13,7 @@ Date: September 2011
 
 #include "interrupt.h"
 
-#include <util/cprover_prefix.h>
-#include <util/std_expr.h>
-#include <util/std_code.h>
-#include <util/prefix.h>
-#include <util/symbol_table.h>
-
-#include <goto-programs/goto_functions.h>
-
-#include "rw_set.h"
+#include <linking/static_lifetime_init.h>
 
 #ifdef LOCAL_MAY
 #include <analyses/local_may_alias.h>
@@ -203,7 +195,7 @@ void interrupt(
   // now instrument
 
   Forall_goto_functions(f_it, goto_model.goto_functions)
-    if(f_it->first!=CPROVER_PREFIX "initialize" &&
+    if(f_it->first != INITIALIZE_FUNCTION &&
        f_it->first!=goto_functionst::entry_point() &&
        f_it->first!=isr.get_identifier())
       interrupt(

--- a/src/goto-instrument/mmio.cpp
+++ b/src/goto-instrument/mmio.cpp
@@ -13,7 +13,7 @@ Date: September 2011
 
 #include "mmio.h"
 
-#include <util/cprover_prefix.h>
+#include <linking/static_lifetime_init.h>
 
 #include <goto-programs/goto_program.h>
 #include <goto-programs/goto_functions.h>
@@ -169,7 +169,7 @@ void mmio(
   // now instrument
 
   Forall_goto_functions(f_it, goto_model.goto_functions)
-    if(f_it->first!=CPROVER_PREFIX "initialize" &&
+    if(f_it->first != INITIALIZE_FUNCTION &&
        f_it->first!=goto_functionst::entry_point())
       mmio(value_sets, goto_model.symbol_table,
 #ifdef LOCAL_MAY

--- a/src/goto-instrument/mmio.cpp
+++ b/src/goto-instrument/mmio.cpp
@@ -15,18 +15,6 @@ Date: September 2011
 
 #include <linking/static_lifetime_init.h>
 
-#include <goto-programs/goto_program.h>
-#include <goto-programs/goto_functions.h>
-
-#if 0
-#include <util/std_expr.h>
-#include <util/guard.h>
-#include <util/prefix.h>
-
-#include <goto-programs/remove_skip.h>
-#endif
-
-#include "interrupt.h"
 #include "rw_set.h"
 
 #ifdef LOCAL_MAY

--- a/src/goto-instrument/nondet_static.cpp
+++ b/src/goto-instrument/nondet_static.cpp
@@ -14,13 +14,7 @@ Date: November 2011
 
 #include "nondet_static.h"
 
-#include <util/namespace.h>
-#include <util/std_expr.h>
-#include <util/cprover_prefix.h>
-#include <util/prefix.h>
-
 #include <goto-programs/goto_model.h>
-#include <goto-programs/goto_functions.h>
 
 #include <linking/static_lifetime_init.h>
 

--- a/src/goto-instrument/nondet_static.cpp
+++ b/src/goto-instrument/nondet_static.cpp
@@ -22,6 +22,8 @@ Date: November 2011
 #include <goto-programs/goto_model.h>
 #include <goto-programs/goto_functions.h>
 
+#include <linking/static_lifetime_init.h>
+
 void nondet_static(
   const namespacet &ns,
   goto_functionst &goto_functions,
@@ -75,7 +77,7 @@ void nondet_static(
   const namespacet &ns,
   goto_functionst &goto_functions)
 {
-  nondet_static(ns, goto_functions, CPROVER_PREFIX "initialize");
+  nondet_static(ns, goto_functions, INITIALIZE_FUNCTION);
 
   // update counters etc.
   goto_functions.update();

--- a/src/goto-instrument/object_id.h
+++ b/src/goto-instrument/object_id.h
@@ -12,8 +12,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_GOTO_INSTRUMENT_OBJECT_ID_H
 #define CPROVER_GOTO_INSTRUMENT_OBJECT_ID_H
 
-#include <set>
 #include <iosfwd>
+#include <set>
 
 #include <util/std_expr.h>
 #include <util/std_code.h>

--- a/src/goto-instrument/object_id.h
+++ b/src/goto-instrument/object_id.h
@@ -13,7 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_GOTO_INSTRUMENT_OBJECT_ID_H
 
 #include <set>
-#include <ostream>
+#include <iosfwd>
 
 #include <util/std_expr.h>
 #include <util/std_code.h>

--- a/src/goto-instrument/race_check.cpp
+++ b/src/goto-instrument/race_check.cpp
@@ -13,16 +13,6 @@ Date: February 2006
 
 #include "race_check.h"
 
-#include <util/std_expr.h>
-#include <util/guard.h>
-#include <util/symbol_table.h>
-#include <util/prefix.h>
-#include <util/cprover_prefix.h>
-
-#include <goto-programs/goto_program.h>
-#include <goto-programs/goto_functions.h>
-
-#include <pointer-analysis/value_sets.h>
 #include <goto-programs/remove_skip.h>
 
 #include <linking/static_lifetime_init.h>

--- a/src/goto-instrument/race_check.cpp
+++ b/src/goto-instrument/race_check.cpp
@@ -25,6 +25,8 @@ Date: February 2006
 #include <pointer-analysis/value_sets.h>
 #include <goto-programs/remove_skip.h>
 
+#include <linking/static_lifetime_init.h>
+
 #include "rw_set.h"
 
 #ifdef LOCAL_MAY
@@ -300,7 +302,7 @@ void race_check(
 
   Forall_goto_functions(f_it, goto_model.goto_functions)
     if(f_it->first!=goto_functionst::entry_point() &&
-       f_it->first!=CPROVER_PREFIX "initialize")
+       f_it->first != INITIALIZE_FUNCTION)
       race_check(
         value_sets,
         goto_model.symbol_table,

--- a/src/goto-instrument/rw_set.h
+++ b/src/goto-instrument/rw_set.h
@@ -19,16 +19,16 @@ Date: February 2006
 #include <set>
 
 #include <util/guard.h>
-#include <util/std_code.h>
-#include <util/namespace.h>
 #include <util/std_expr.h>
 
 #include <goto-programs/goto_model.h>
-#include <pointer-analysis/value_sets.h>
 
 #ifdef LOCAL_MAY
 #include <analyses/local_may_alias.h>
 #endif
+
+class namespacet;
+class value_setst;
 
 // a container for read/write sets
 

--- a/src/goto-instrument/stack_depth.cpp
+++ b/src/goto-instrument/stack_depth.cpp
@@ -22,6 +22,8 @@ Date: November 2011
 
 #include <goto-programs/goto_model.h>
 
+#include <linking/static_lifetime_init.h>
+
 symbol_exprt add_stack_depth_symbol(symbol_tablet &symbol_table)
 {
   const irep_idt identifier="$stack_depth";
@@ -94,17 +96,16 @@ void stack_depth(
 
   Forall_goto_functions(f_it, goto_model.goto_functions)
     if(f_it->second.body_available() &&
-        f_it->first!=CPROVER_PREFIX "initialize" &&
+        f_it->first != INITIALIZE_FUNCTION &&
         f_it->first!=goto_functionst::entry_point())
       stack_depth(f_it->second.body, sym, depth, depth_expr);
 
   // initialize depth to 0
-  goto_functionst::function_mapt::iterator
-    i_it=goto_model.goto_functions.function_map.find(
-      CPROVER_PREFIX "initialize");
+  goto_functionst::function_mapt::iterator i_it =
+    goto_model.goto_functions.function_map.find(INITIALIZE_FUNCTION);
   DATA_INVARIANT(
     i_it!=goto_model.goto_functions.function_map.end(),
-    "__CPROVER_initialize must exist");
+    INITIALIZE_FUNCTION " must exist");
 
   goto_programt &init=i_it->second.body;
   goto_programt::targett first=init.instructions.begin();

--- a/src/goto-instrument/stack_depth.cpp
+++ b/src/goto-instrument/stack_depth.cpp
@@ -13,12 +13,7 @@ Date: November 2011
 
 #include "stack_depth.h"
 
-#include <util/c_types.h>
-#include <util/symbol_table.h>
-#include <util/std_expr.h>
-#include <util/std_types.h>
 #include <util/arith_tools.h>
-#include <util/cprover_prefix.h>
 
 #include <goto-programs/goto_model.h>
 

--- a/src/goto-instrument/wmm/goto2graph.cpp
+++ b/src/goto-instrument/wmm/goto2graph.cpp
@@ -16,17 +16,8 @@ Date: 2012
 #include <vector>
 #include <string>
 #include <fstream>
-#include <limits>
 
-#ifndef _WIN32
-#include <cstdlib>
-#endif
-
-#include <util/prefix.h>
-#include <util/cprover_prefix.h>
 #include <util/options.h>
-#include <util/message.h>
-#include <util/std_expr.h>
 
 #include <linking/static_lifetime_init.h>
 

--- a/src/goto-instrument/wmm/goto2graph.cpp
+++ b/src/goto-instrument/wmm/goto2graph.cpp
@@ -28,6 +28,8 @@ Date: 2012
 #include <util/message.h>
 #include <util/std_expr.h>
 
+#include <linking/static_lifetime_init.h>
+
 #include "../rw_set.h"
 #include "fence.h"
 
@@ -168,7 +170,7 @@ void instrumentert::cfg_visitort::visit_cfg_function(
   instrumenter.message.debug() << "visit function "
                                << function << messaget::eom;
 
-  if(function==CPROVER_PREFIX "initialize")
+  if(function == INITIALIZE_FUNCTION)
   {
     return;
   }

--- a/src/goto-instrument/wmm/shared_buffers.cpp
+++ b/src/goto-instrument/wmm/shared_buffers.cpp
@@ -7,6 +7,9 @@ Author: Daniel Kroening, kroening@kroening.com
 \*******************************************************************/
 
 #include "shared_buffers.h"
+
+#include <linking/static_lifetime_init.h>
+
 #include "fence.h"
 #include "../rw_set.h"
 
@@ -1054,7 +1057,7 @@ void shared_bufferst::cfg_visitort::weak_memory(
 {
   shared_buffers.message.debug() << "visit function "<< function
                                  << messaget::eom;
-  if(function==CPROVER_PREFIX "initialize")
+  if(function == INITIALIZE_FUNCTION)
     return;
 
   namespacet ns(symbol_table);

--- a/src/goto-instrument/wmm/shared_buffers.cpp
+++ b/src/goto-instrument/wmm/shared_buffers.cpp
@@ -8,12 +8,12 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "shared_buffers.h"
 
+#include <util/c_types.h>
+
 #include <linking/static_lifetime_init.h>
 
-#include "fence.h"
 #include "../rw_set.h"
-
-#include <util/c_types.h>
+#include "fence.h"
 
 /// returns a unique id (for fresh variables)
 std::string shared_bufferst::unique(void)

--- a/src/goto-instrument/wmm/weak_memory.cpp
+++ b/src/goto-instrument/wmm/weak_memory.cpp
@@ -29,6 +29,8 @@ Date: September 2011
 
 #include <goto-programs/remove_skip.h>
 
+#include <linking/static_lifetime_init.h>
+
 #include "../rw_set.h"
 
 #include "shared_buffers.h"
@@ -135,7 +137,7 @@ void weak_memory(
 
   // all access to shared variables is pushed into assignments
   Forall_goto_functions(f_it, goto_model.goto_functions)
-    if(f_it->first!=CPROVER_PREFIX "initialize" &&
+    if(f_it->first != INITIALIZE_FUNCTION &&
       f_it->first!=goto_functionst::entry_point())
       introduce_temporaries(value_sets, goto_model.symbol_table, f_it->first,
         f_it->second.body,

--- a/src/goto-instrument/wmm/weak_memory.cpp
+++ b/src/goto-instrument/wmm/weak_memory.cpp
@@ -23,10 +23,6 @@ Date: September 2011
 
 #include <set>
 
-#include <util/cprover_prefix.h>
-#include <util/prefix.h>
-#include <util/message.h>
-
 #include <goto-programs/remove_skip.h>
 
 #include <linking/static_lifetime_init.h>

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -17,17 +17,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/c_types.h>
 #include <util/cprover_prefix.h>
 #include <util/pointer_offset_size.h>
-#include <util/pointer_predicates.h>
-#include <util/prefix.h>
 #include <util/rational.h>
 #include <util/rational_tools.h>
-#include <util/replace_expr.h>
-#include <util/simplify_expr.h>
-#include <util/source_location.h>
-#include <util/std_code.h>
-#include <util/std_expr.h>
-#include <util/string_constant.h>
-#include <util/symbol.h>
 
 #include <linking/zero_initializer.h>
 

--- a/src/goto-programs/class_hierarchy.h
+++ b/src/goto-programs/class_hierarchy.h
@@ -19,7 +19,9 @@ Date: April 2016
 #include <unordered_map>
 
 #include <util/graph.h>
-#include <util/namespace.h>
+#include <util/irep.h>
+
+class symbol_tablet;
 
 class class_hierarchyt
 {

--- a/src/goto-programs/generate_function_bodies.cpp
+++ b/src/goto-programs/generate_function_bodies.cpp
@@ -8,17 +8,10 @@ Author: Diffblue Ltd.
 
 #include "generate_function_bodies.h"
 
-#include <memory>
-#include <sstream>
-#include <utility>
-#include <functional>
-
+#include <util/arith_tools.h>
 #include <util/format_expr.h>
 #include <util/make_unique.h>
-#include <util/message.h>
 #include <util/string_utils.h>
-#include <util/pointer_offset_size.h>
-#include <util/arith_tools.h>
 
 void generate_function_bodiest::generate_function_body(
   goto_functiont &function,

--- a/src/goto-programs/goto_functions.h
+++ b/src/goto-programs/goto_functions.h
@@ -14,14 +14,12 @@ Date: June 2003
 #ifndef CPROVER_GOTO_PROGRAMS_GOTO_FUNCTIONS_H
 #define CPROVER_GOTO_PROGRAMS_GOTO_FUNCTIONS_H
 
-#include "goto_program.h"
+#include <iosfwd>
 
-#include <ostream>
-#include <cassert>
-
-#include <util/std_types.h>
-#include <util/symbol.h>
 #include <util/cprover_prefix.h>
+#include <util/std_types.h>
+
+#include "goto_program.h"
 
 class goto_functiont
 {

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -12,7 +12,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_GOTO_PROGRAMS_GOTO_PROGRAM_H
 #define CPROVER_GOTO_PROGRAMS_GOTO_PROGRAM_H
 
-#include <cassert>
 #include <iosfwd>
 #include <set>
 #include <limits>

--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -11,16 +11,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "interpreter_class.h"
 
-#include <iostream>
-#include <sstream>
-#include <cstring>
-
-#include <util/ieee_float.h>
-#include <util/invariant.h>
 #include <util/fixedbv.h>
-#include <util/std_expr.h>
-#include <util/string_container.h>
+#include <util/ieee_float.h>
 #include <util/pointer_offset_size.h>
+#include <util/string_container.h>
 
 #include <langapi/language_util.h>
 

--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -389,14 +389,11 @@ void interpretert::evaluate(
     }
     else if(expr.type().id()==ID_string)
     {
-      irep_idt value=to_constant_expr(expr).get_value();
-      const char *str=value.c_str();
-      std::size_t length=strlen(str)+1;
+      const std::string &value = id2string(to_constant_expr(expr).get_value());
       if(show)
         warning() << "string decoding not fully implemented "
-                  << length << eom;
-      mp_integer tmp = get_string_container()[id2string(value)];
-      dest.push_back(tmp);
+                  << value.size() + 1 << eom;
+      dest.push_back(get_string_container()[value]);
       return;
     }
     else

--- a/src/goto-programs/remove_asm.cpp
+++ b/src/goto-programs/remove_asm.cpp
@@ -14,13 +14,12 @@ Date:   December 2014
 
 #include "remove_asm.h"
 
-#include <sstream>
-
 #include <util/c_types.h>
-#include <util/std_expr.h>
 #include <util/string_constant.h>
 
 #include <assembler/assembler_parser.h>
+
+#include "goto_model.h"
 
 class remove_asmt
 {

--- a/src/goto-programs/remove_asm.h
+++ b/src/goto-programs/remove_asm.h
@@ -15,7 +15,10 @@ Date:   December 2014
 #ifndef CPROVER_GOTO_PROGRAMS_REMOVE_ASM_H
 #define CPROVER_GOTO_PROGRAMS_REMOVE_ASM_H
 
-#include <goto-programs/goto_model.h>
+#include <goto-programs/goto_functions.h>
+
+class goto_modelt;
+class symbol_tablet;
 
 void remove_asm(
   goto_functionst::goto_functiont &goto_function,

--- a/src/goto-programs/remove_calls_no_body.cpp
+++ b/src/goto-programs/remove_calls_no_body.cpp
@@ -9,8 +9,11 @@ Author: Daniel Poetzl
 /// \file
 /// Remove calls to functions without a body
 
-#include <util/invariant.h>
 #include "remove_calls_no_body.h"
+
+#include <util/invariant.h>
+
+#include "goto_functions.h"
 
 /// Remove a single call
 /// \param goto_program: goto program to modify

--- a/src/goto-programs/remove_calls_no_body.h
+++ b/src/goto-programs/remove_calls_no_body.h
@@ -12,7 +12,9 @@ Author: Daniel Poetzl
 #ifndef CPROVER_GOTO_PROGRAMS_REMOVE_CALLS_NO_BODY_H
 #define CPROVER_GOTO_PROGRAMS_REMOVE_CALLS_NO_BODY_H
 
-#include "goto_functions.h"
+#include "goto_program.h"
+
+class goto_functionst;
 
 class remove_calls_no_bodyt
 {

--- a/src/goto-programs/remove_complex.cpp
+++ b/src/goto-programs/remove_complex.cpp
@@ -14,6 +14,10 @@ Date:   September 2014
 #include "remove_complex.h"
 
 #include <util/arith_tools.h>
+#include <util/std_expr.h>
+#include <util/std_types.h>
+
+#include "goto_model.h"
 
 static exprt complex_member(const exprt &expr, irep_idt id)
 {

--- a/src/goto-programs/remove_complex.h
+++ b/src/goto-programs/remove_complex.h
@@ -14,7 +14,9 @@ Date:   September 2014
 #ifndef CPROVER_GOTO_PROGRAMS_REMOVE_COMPLEX_H
 #define CPROVER_GOTO_PROGRAMS_REMOVE_COMPLEX_H
 
-#include <goto-programs/goto_model.h>
+class goto_functionst;
+class goto_modelt;
+class symbol_tablet;
 
 void remove_complex(symbol_tablet &, goto_functionst &);
 

--- a/src/goto-programs/remove_const_function_pointers.cpp
+++ b/src/goto-programs/remove_const_function_pointers.cpp
@@ -11,9 +11,14 @@ Author: Thomas Kiley, thomas.kiley@diffblue.com
 
 #include "remove_const_function_pointers.h"
 
-#include <ansi-c/c_qualifiers.h>
-#include <util/simplify_expr.h>
 #include <util/arith_tools.h>
+#include <util/simplify_expr.h>
+#include <util/std_expr.h>
+#include <util/symbol_table.h>
+
+#include <ansi-c/c_qualifiers.h>
+
+#include "goto_functions.h"
 
 #define LOG(message, irep) \
   debug() << "Case " << __LINE__ << " : " << message << "\n" \

--- a/src/goto-programs/remove_const_function_pointers.h
+++ b/src/goto-programs/remove_const_function_pointers.h
@@ -12,13 +12,22 @@ Author: Thomas Kiley, thomas.kiley@diffblue.com
 #ifndef CPROVER_GOTO_PROGRAMS_REMOVE_CONST_FUNCTION_POINTERS_H
 #define CPROVER_GOTO_PROGRAMS_REMOVE_CONST_FUNCTION_POINTERS_H
 
+#include <list>
 #include <unordered_set>
 
-#include "goto_model.h"
-#include <util/message.h>
 #include <util/expr.h>
-#include <util/namespace.h>
+#include <util/message.h>
+#include <util/mp_arith.h>
 
+class address_of_exprt;
+class dereference_exprt;
+class index_exprt;
+class member_exprt;
+class namespacet;
+class struct_exprt;
+class symbol_exprt;
+class symbol_tablet;
+class typecast_exprt;
 
 class remove_const_function_pointerst:public messaget
 {

--- a/src/goto-programs/remove_function_pointers.h
+++ b/src/goto-programs/remove_function_pointers.h
@@ -14,8 +14,11 @@ Date: June 2003
 #ifndef CPROVER_GOTO_PROGRAMS_REMOVE_FUNCTION_POINTERS_H
 #define CPROVER_GOTO_PROGRAMS_REMOVE_FUNCTION_POINTERS_H
 
-#include "goto_model.h"
-#include <util/message.h>
+class goto_functionst;
+class goto_programt;
+class goto_modelt;
+class message_handlert;
+class symbol_tablet;
 
 // remove indirect function calls
 // and replace by case-split

--- a/src/goto-programs/remove_returns.cpp
+++ b/src/goto-programs/remove_returns.cpp
@@ -14,7 +14,8 @@ Date:   September 2009
 #include "remove_returns.h"
 
 #include <util/std_expr.h>
-#include <util/symbol_table.h>
+
+#include "goto_model.h"
 
 class remove_returnst
 {

--- a/src/goto-programs/remove_returns.h
+++ b/src/goto-programs/remove_returns.h
@@ -14,9 +14,16 @@ Date:   September 2009
 #ifndef CPROVER_GOTO_PROGRAMS_REMOVE_RETURNS_H
 #define CPROVER_GOTO_PROGRAMS_REMOVE_RETURNS_H
 
-#include <goto-programs/goto_model.h>
+#include <functional>
+
+#include <util/std_types.h>
 
 #define RETURN_VALUE_SUFFIX "#return_value"
+
+class goto_functionst;
+class goto_model_functiont;
+class goto_modelt;
+class symbol_table_baset;
 
 // Turns 'return x' into an assignment to fkt#return_value,
 // unless the function returns void,

--- a/src/goto-programs/remove_skip.h
+++ b/src/goto-programs/remove_skip.h
@@ -12,8 +12,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_GOTO_PROGRAMS_REMOVE_SKIP_H
 #define CPROVER_GOTO_PROGRAMS_REMOVE_SKIP_H
 
-#include "goto_functions.h"
+#include "goto_program.h"
 
+class goto_functionst;
 class goto_modelt;
 
 bool is_skip(const goto_programt &, goto_programt::const_targett);

--- a/src/goto-programs/remove_unreachable.cpp
+++ b/src/goto-programs/remove_unreachable.cpp
@@ -14,6 +14,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <set>
 #include <stack>
 
+#include "goto_functions.h"
+
 /// remove unreachable code
 void remove_unreachable(goto_programt &goto_program)
 {

--- a/src/goto-programs/remove_unreachable.h
+++ b/src/goto-programs/remove_unreachable.h
@@ -12,7 +12,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_GOTO_PROGRAMS_REMOVE_UNREACHABLE_H
 #define CPROVER_GOTO_PROGRAMS_REMOVE_UNREACHABLE_H
 
-#include "goto_functions.h"
+class goto_functionst;
+class goto_programt;
 
 void remove_unreachable(goto_programt &goto_program);
 void remove_unreachable(goto_functionst &goto_functions);

--- a/src/goto-programs/remove_unused_functions.cpp
+++ b/src/goto-programs/remove_unused_functions.cpp
@@ -13,6 +13,8 @@ Author: CM Wintersteiger
 
 #include <util/message.h>
 
+#include "goto_model.h"
+
 void remove_unused_functions(
   goto_modelt &goto_model,
   message_handlert &message_handler)

--- a/src/goto-programs/remove_unused_functions.h
+++ b/src/goto-programs/remove_unused_functions.h
@@ -12,9 +12,14 @@ Author: CM Wintersteiger
 #ifndef CPROVER_GOTO_PROGRAMS_REMOVE_UNUSED_FUNCTIONS_H
 #define CPROVER_GOTO_PROGRAMS_REMOVE_UNUSED_FUNCTIONS_H
 
-#include <util/message.h>
+#include <set>
 
-#include <goto-programs/goto_model.h>
+#include <util/irep.h>
+
+class goto_functionst;
+class goto_modelt;
+class message_handlert;
+class symbol_tablet;
 
 void remove_unused_functions(
   goto_functionst &,

--- a/src/goto-programs/remove_vector.cpp
+++ b/src/goto-programs/remove_vector.cpp
@@ -14,6 +14,10 @@ Date:   September 2014
 #include "remove_vector.h"
 
 #include <util/arith_tools.h>
+#include <util/std_expr.h>
+#include <util/std_types.h>
+
+#include "goto_model.h"
 
 static bool have_to_remove_vector(const typet &type);
 

--- a/src/goto-programs/remove_vector.h
+++ b/src/goto-programs/remove_vector.h
@@ -14,7 +14,9 @@ Date:   September 2014
 #ifndef CPROVER_GOTO_PROGRAMS_REMOVE_VECTOR_H
 #define CPROVER_GOTO_PROGRAMS_REMOVE_VECTOR_H
 
-#include <goto-programs/goto_model.h>
+class goto_functionst;
+class goto_modelt;
+class symbol_tablet;
 
 void remove_vector(symbol_tablet &, goto_functionst &);
 

--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -8,17 +8,15 @@ Author: Daniel Kroening, kroening@kroening.com
 
 /// \file
 /// Remove Virtual Function (Method) Calls
+#include "remove_virtual_functions.h"
+
 #include <algorithm>
 
-#include "remove_virtual_functions.h"
-#include "class_hierarchy.h"
-#include "class_identifier.h"
-
-#include <goto-programs/resolve_inherited_component.h>
-
-#include <util/c_types.h>
-#include <util/prefix.h>
 #include <util/type_eq.h>
+
+#include "class_identifier.h"
+#include "goto_model.h"
+#include "resolve_inherited_component.h"
 
 class remove_virtual_functionst
 {

--- a/src/goto-programs/remove_virtual_functions.h
+++ b/src/goto-programs/remove_virtual_functions.h
@@ -14,8 +14,15 @@ Date: April 2016
 #ifndef CPROVER_GOTO_PROGRAMS_REMOVE_VIRTUAL_FUNCTIONS_H
 #define CPROVER_GOTO_PROGRAMS_REMOVE_VIRTUAL_FUNCTIONS_H
 
-#include "goto_model.h"
+#include <util/std_expr.h>
+
 #include "class_hierarchy.h"
+#include "goto_program.h"
+
+class goto_functionst;
+class goto_model_functiont;
+class goto_modelt;
+class symbol_table_baset;
 
 // remove virtual function calls
 // and replace by case-split

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -11,8 +11,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "string_abstraction.h"
 
-#include <cstring>
+#include <algorithm>
 
+#include <util/arith_tools.h>
+#include <util/c_types.h>
 #include <util/pointer_predicates.h>
 #include <util/std_expr.h>
 #include <util/std_code.h>
@@ -759,7 +761,11 @@ bool string_abstractiont::build(const exprt &object, exprt &dest, bool write)
 
   if(object.id()==ID_string_constant)
   {
-    mp_integer str_len=strlen(object.get(ID_value).c_str());
+    const std::string &str_value = id2string(object.get(ID_value));
+    // make sure we handle the case of a string constant with string-terminating
+    // \0 in it
+    const std::size_t str_len =
+      std::min(str_value.size(), str_value.find('\0'));
     return build_symbol_constant(str_len, str_len+1, dest);
   }
 

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -16,13 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/pointer_predicates.h>
-#include <util/std_expr.h>
-#include <util/std_code.h>
-#include <util/message.h>
-#include <util/arith_tools.h>
 #include <util/type_eq.h>
-
-#include <util/c_types.h>
 
 #include "pointer_arithmetic.h"
 

--- a/src/goto-programs/vcd_goto_trace.cpp
+++ b/src/goto-programs/vcd_goto_trace.cpp
@@ -63,17 +63,7 @@ std::string as_vcd_binary(
 
   // build "xxx"
 
-  mp_integer width;
-
-  if(type.id()==ID_unsignedbv ||
-     type.id()==ID_signedbv ||
-     type.id()==ID_floatbv ||
-     type.id()==ID_fixedbv ||
-     type.id()==ID_pointer ||
-     type.id()==ID_bv)
-    width=string2integer(type.get_string(ID_width));
-  else
-    width=pointer_offset_size(type, ns)*8;
+  const mp_integer width = pointer_offset_bits(type, ns);
 
   if(width>=0)
     return std::string(integer2size_t(width), 'x');
@@ -106,12 +96,7 @@ void output_vcd(
 
       const auto number=n.number(identifier);
 
-      mp_integer width;
-
-      if(type.id()==ID_bool)
-        width=1;
-      else
-        width=pointer_offset_bits(type, ns);
+      const mp_integer width = pointer_offset_bits(type, ns);
 
       if(width>=1)
         out << "$var reg " << width << " V" << number << " "

--- a/src/goto-programs/vcd_goto_trace.cpp
+++ b/src/goto-programs/vcd_goto_trace.cpp
@@ -13,13 +13,11 @@ Date: June 2011
 
 #include "vcd_goto_trace.h"
 
-#include <ctime>
-#include <ostream>
 #include <cassert>
+#include <ctime>
 
-#include <util/arith_tools.h>
-#include <util/pointer_offset_size.h>
 #include <util/numbering.h>
+#include <util/pointer_offset_size.h>
 
 std::string as_vcd_binary(
   const exprt &expr,

--- a/src/goto-symex/equation_conversion_exceptions.h
+++ b/src/goto-symex/equation_conversion_exceptions.h
@@ -12,7 +12,7 @@ Author: Diffblue Ltd.
 #ifndef CPROVER_GOTO_SYMEX_EQUATION_CONVERSION_EXCEPTIONS_H
 #define CPROVER_GOTO_SYMEX_EQUATION_CONVERSION_EXCEPTIONS_H
 
-#include <ostream>
+#include <sstream>
 
 #include <util/format_expr.h>
 

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -14,13 +14,13 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/options.h>
 #include <util/message.h>
-#include <util/byte_operators.h>
 
 #include <goto-programs/goto_functions.h>
 
 #include "goto_symex_state.h"
 #include "symex_target_equation.h"
 
+class byte_extract_exprt;
 class typet;
 class code_typet;
 class symbol_tablet;

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -11,24 +11,14 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_symex.h"
 
-#include <util/expr_util.h>
-#include <util/message.h>
 #include <util/arith_tools.h>
-#include <util/cprover_prefix.h>
-#include <util/std_types.h>
-#include <util/pointer_offset_size.h>
-#include <util/symbol_table.h>
-#include <util/std_expr.h>
-#include <util/std_code.h>
-#include <util/simplify_expr.h>
-#include <util/prefix.h>
-#include <util/string2int.h>
-#include <util/invariant_utils.h>
 #include <util/c_types.h>
+#include <util/invariant_utils.h>
+#include <util/pointer_offset_size.h>
+#include <util/simplify_expr.h>
+#include <util/string2int.h>
 
 #include <linking/zero_initializer.h>
-
-#include "goto_symex_state.h"
 
 inline static typet c_sizeof_type_rec(const exprt &expr)
 {

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -12,11 +12,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "goto_symex.h"
 
 #include <util/arith_tools.h>
-#include <util/std_expr.h>
-#include <util/cprover_prefix.h>
 #include <util/base_type.h>
-#include <util/pointer_offset_size.h>
+#include <util/byte_operators.h>
 #include <util/c_types.h>
+#include <util/pointer_offset_size.h>
 
 /// Given an expression, find the root object and the offset into it.
 ///

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -11,16 +11,14 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_symex.h"
 
-#include <util/invariant.h>
-#include <util/pointer_offset_size.h>
 #include <util/arith_tools.h>
 #include <util/base_type.h>
 #include <util/byte_operators.h>
+#include <util/c_types.h>
+#include <util/invariant.h>
+#include <util/pointer_offset_size.h>
 
 #include <pointer-analysis/value_set_dereference.h>
-#include <pointer-analysis/rewrite_index.h>
-
-#include <util/c_types.h>
 
 #include "symex_dereference_state.h"
 

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -11,19 +11,11 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_symex.h"
 
-#include <sstream>
-
-#include <util/cprover_prefix.h>
-#include <util/invariant.h>
-#include <util/prefix.h>
 #include <util/arith_tools.h>
 #include <util/base_type.h>
-#include <util/std_expr.h>
-#include <util/symbol_table.h>
-
+#include <util/byte_operators.h>
 #include <util/c_types.h>
-
-#include <analyses/dirty.h>
+#include <util/invariant.h>
 
 bool goto_symext::get_unwind_recursion(
   const irep_idt &identifier,

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -12,14 +12,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "goto_symex.h"
 
 #include <util/arith_tools.h>
-#include <util/invariant.h>
-#include <util/rename.h>
 #include <util/base_type.h>
-#include <util/std_expr.h>
-#include <util/std_code.h>
 #include <util/byte_operators.h>
-#include <util/pointer_offset_size.h>
 #include <util/c_types.h>
+#include <util/pointer_offset_size.h>
 
 void goto_symext::havoc_rec(
   statet &state,

--- a/src/java_bytecode/java_entry_point.cpp
+++ b/src/java_bytecode/java_entry_point.cpp
@@ -29,7 +29,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/string_constant.h>
 #include <util/suffix.h>
 
-#include "remove_exceptions.h"
+#include <linking/static_lifetime_init.h>
+
 #include "java_object_factory.h"
 #include "java_types.h"
 #include "java_utils.h"

--- a/src/java_bytecode/java_entry_point.cpp
+++ b/src/java_bytecode/java_entry_point.cpp
@@ -8,31 +8,15 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "java_entry_point.h"
 
-#include <algorithm>
-#include <set>
-#include <unordered_set>
-#include <iostream>
-
-#include <linking/static_lifetime_init.h>
-
-#include <util/arith_tools.h>
-#include <util/c_types.h>
 #include <util/config.h>
-#include <util/cprover_prefix.h>
-#include <util/message.h>
-#include <util/namespace.h>
-#include <util/pointer_offset_size.h>
-#include <util/prefix.h>
-#include <util/std_code.h>
-#include <util/std_expr.h>
-#include <util/std_types.h>
 #include <util/string_constant.h>
 #include <util/suffix.h>
+
+#include <goto-programs/goto_functions.h>
 
 #include <linking/static_lifetime_init.h>
 
 #include "java_object_factory.h"
-#include "java_types.h"
 #include "java_utils.h"
 
 static void create_initialize(symbol_table_baset &symbol_table)

--- a/src/java_bytecode/java_object_factory.cpp
+++ b/src/java_bytecode/java_object_factory.cpp
@@ -8,32 +8,14 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "java_object_factory.h"
 
-#include <unordered_set>
-#include <sstream>
-
-#include <util/arith_tools.h>
 #include <util/fresh_symbol.h>
-#include <util/c_types.h>
-#include <util/std_code.h>
-#include <util/std_expr.h>
-#include <util/namespace.h>
 #include <util/nondet_bool.h>
-#include <util/nondet_ifthenelse.h>
 #include <util/pointer_offset_size.h>
-#include <util/prefix.h>
-#include <util/invariant.h>
-
-#include <linking/zero_initializer.h>
 
 #include <goto-programs/goto_functions.h>
 
-#include <java_bytecode/select_pointer_type.h>
-
-#include "java_types.h"
-#include "java_utils.h"
-#include "java_string_library_preprocess.h"
-#include "java_root_class.h"
 #include "generic_parameter_specialization_map_keys.h"
+#include "java_root_class.h"
 
 class java_object_factoryt
 {

--- a/src/jsil/jsil_entry_point.cpp
+++ b/src/jsil/jsil_entry_point.cpp
@@ -20,13 +20,13 @@ Author: Michael Tautschnig, tautschn@amazon.com
 
 #include <goto-programs/goto_functions.h>
 
-#define INITIALIZE CPROVER_PREFIX "initialize"
+#include <linking/static_lifetime_init.h>
 
 static void create_initialize(symbol_tablet &symbol_table)
 {
   symbolt initialize;
-  initialize.name=CPROVER_PREFIX "initialize";
-  initialize.base_name=CPROVER_PREFIX "initialize";
+  initialize.name = INITIALIZE_FUNCTION;
+  initialize.base_name = INITIALIZE_FUNCTION;
   initialize.mode="jsil";
 
   code_typet type;
@@ -46,7 +46,7 @@ static void create_initialize(symbol_tablet &symbol_table)
   initialize.value=init_code;
 
   if(symbol_table.add(initialize))
-    throw "failed to add " CPROVER_PREFIX "initialize";
+    throw "failed to add " INITIALIZE_FUNCTION;
 }
 
 bool jsil_entry_point(
@@ -130,10 +130,10 @@ bool jsil_entry_point(
 
   {
     symbol_tablet::symbolst::const_iterator init_it=
-      symbol_table.symbols.find(CPROVER_PREFIX "initialize");
+      symbol_table.symbols.find(INITIALIZE_FUNCTION);
 
     if(init_it==symbol_table.symbols.end())
-      throw "failed to find " CPROVER_PREFIX "initialize symbol";
+      throw "failed to find " INITIALIZE_FUNCTION " symbol";
 
     code_function_callt call_init;
     call_init.lhs().make_nil();

--- a/src/jsil/jsil_entry_point.cpp
+++ b/src/jsil/jsil_entry_point.cpp
@@ -13,10 +13,7 @@ Author: Michael Tautschnig, tautschn@amazon.com
 
 #include <util/arith_tools.h>
 #include <util/config.h>
-#include <util/symbol_table.h>
 #include <util/message.h>
-#include <util/std_types.h>
-#include <util/cprover_prefix.h>
 
 #include <goto-programs/goto_functions.h>
 

--- a/src/jsil/jsil_parse_tree.cpp
+++ b/src/jsil/jsil_parse_tree.cpp
@@ -11,6 +11,8 @@ Author: Michael Tautschnig, tautschn@amazon.com
 
 #include "jsil_parse_tree.h"
 
+#include <ostream>
+
 #include <util/symbol.h>
 
 #include "jsil_types.h"

--- a/src/jsil/jsil_parse_tree.h
+++ b/src/jsil/jsil_parse_tree.h
@@ -12,7 +12,7 @@ Author: Michael Tautschnig, tautschn@amazon.com
 #ifndef CPROVER_JSIL_JSIL_PARSE_TREE_H
 #define CPROVER_JSIL_JSIL_PARSE_TREE_H
 
-#include <ostream>
+#include <iosfwd>
 #include <list>
 
 #include <util/std_expr.h>

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -12,15 +12,13 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "linking.h"
 
 #include <cassert>
-#include <stack>
+#include <deque>
+#include <unordered_set>
 
-#include <util/find_symbols.h>
-#include <util/source_location.h>
 #include <util/base_type.h>
-#include <util/std_expr.h>
-#include <util/std_types.h>
-#include <util/simplify_expr.h>
+#include <util/find_symbols.h>
 #include <util/pointer_offset_size.h>
+#include <util/simplify_expr.h>
 
 #include <langapi/language_util.h>
 

--- a/src/linking/remove_internal_symbols.cpp
+++ b/src/linking/remove_internal_symbols.cpp
@@ -11,12 +11,11 @@ Author: Daniel Kroening
 
 #include "remove_internal_symbols.h"
 
-#include <util/symbol_table.h>
-#include <util/namespace.h>
-#include <util/find_symbols.h>
-#include <util/std_types.h>
-#include <util/cprover_prefix.h>
 #include <util/config.h>
+#include <util/find_symbols.h>
+#include <util/namespace.h>
+#include <util/std_types.h>
+#include <util/symbol_table.h>
 
 #include "static_lifetime_init.h"
 

--- a/src/linking/remove_internal_symbols.cpp
+++ b/src/linking/remove_internal_symbols.cpp
@@ -18,6 +18,8 @@ Author: Daniel Kroening
 #include <util/cprover_prefix.h>
 #include <util/config.h>
 
+#include "static_lifetime_init.h"
+
 void get_symbols_rec(
   const namespacet &ns,
   const symbolt &symbol,
@@ -84,7 +86,7 @@ void remove_internal_symbols(
   special.insert("envp'");
   special.insert("envp_size'");
   special.insert(CPROVER_PREFIX "memory");
-  special.insert(CPROVER_PREFIX "initialize");
+  special.insert(INITIALIZE_FUNCTION);
   special.insert(CPROVER_PREFIX "malloc_size");
   special.insert(CPROVER_PREFIX "deallocated");
   special.insert(CPROVER_PREFIX "dead_object");

--- a/src/linking/static_lifetime_init.h
+++ b/src/linking/static_lifetime_init.h
@@ -10,10 +10,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_LINKING_STATIC_LIFETIME_INIT_H
 #define CPROVER_LINKING_STATIC_LIFETIME_INIT_H
 
-#include <util/symbol_table.h>
-#include <util/message.h>
-#include <util/source_location.h>
 #include <util/cprover_prefix.h>
+
+class message_handlert;
+class source_locationt;
+class symbol_tablet;
 
 bool static_lifetime_init(
   symbol_tablet &symbol_table,

--- a/src/linking/zero_initializer.cpp
+++ b/src/linking/zero_initializer.cpp
@@ -11,16 +11,13 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "zero_initializer.h"
 
-#include <sstream>
-
-#include <util/namespace.h>
-#include <util/message.h>
 #include <util/arith_tools.h>
-#include <util/std_types.h>
-#include <util/std_expr.h>
-#include <util/pointer_offset_size.h>
-
 #include <util/c_types.h>
+#include <util/message.h>
+#include <util/namespace.h>
+#include <util/pointer_offset_size.h>
+#include <util/std_expr.h>
+
 #include <ansi-c/expr2c.h>
 
 class zero_initializert:public messaget

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -14,17 +14,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <cassert>
 #include <ostream>
 
-#include <util/symbol_table.h>
-#include <util/simplify_expr.h>
-#include <util/base_type.h>
-#include <util/std_expr.h>
-#include <util/prefix.h>
-#include <util/std_code.h>
 #include <util/arith_tools.h>
-#include <util/pointer_offset_size.h>
-#include <util/cprover_prefix.h>
-
+#include <util/base_type.h>
 #include <util/c_types.h>
+#include <util/pointer_offset_size.h>
+#include <util/simplify_expr.h>
 
 #include <langapi/language_util.h>
 

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -712,20 +712,6 @@ void value_set_dereferencet::bounds_check(
   }
 }
 
-inline static unsigned bv_width(
-  const typet &type,
-  const namespacet &ns)
-{
-  if(type.id()==ID_c_enum_tag)
-  {
-    const typet &t=ns.follow_tag(to_c_enum_tag_type(type));
-    assert(t.id()==ID_c_enum);
-    return bv_width(t.subtype(), ns);
-  }
-
-  return unsafe_string2unsigned(type.get_string(ID_width));
-}
-
 static bool is_a_bv_type(const typet &type)
 {
   return type.id()==ID_unsignedbv ||
@@ -752,7 +738,7 @@ bool value_set_dereferencet::memory_model(
   if(is_a_bv_type(from_type) &&
      is_a_bv_type(to_type))
   {
-    if(bv_width(from_type, ns)==bv_width(to_type, ns))
+    if(pointer_offset_bits(from_type, ns) == pointer_offset_bits(to_type, ns))
     {
       // avoid semantic conversion in case of
       // cast to float or fixed-point,
@@ -772,7 +758,7 @@ bool value_set_dereferencet::memory_model(
   if(from_type.id()==ID_pointer &&
      to_type.id()==ID_pointer)
   {
-    if(bv_width(from_type, ns)==bv_width(to_type, ns))
+    if(pointer_offset_bits(from_type, ns) == pointer_offset_bits(to_type, ns))
       return memory_model_conversion(value, to_type, guard, offset);
   }
 

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -16,34 +16,22 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/format_expr.h>
 #endif
 
-#include <cassert>
-#include <sstream>
-
-#include <util/format_type.h>
-#include <util/invariant.h>
-#include <util/string2int.h>
-#include <util/expr_util.h>
-#include <util/base_type.h>
 #include <util/arith_tools.h>
-#include <util/rename.h>
 #include <util/array_name.h>
+#include <util/base_type.h>
+#include <util/byte_operators.h>
+#include <util/c_types.h>
 #include <util/config.h>
-#include <util/std_expr.h>
 #include <util/cprover_prefix.h>
-#include <util/pointer_offset_size.h>
-#include <util/symbol_table.h>
+#include <util/format_type.h>
 #include <util/guard.h>
 #include <util/options.h>
+#include <util/pointer_offset_size.h>
 #include <util/pointer_predicates.h>
-#include <util/byte_operators.h>
+#include <util/rename.h>
 #include <util/ssa_expr.h>
-#include <util/c_types.h>
 
 #include <ansi-c/c_typecast.h>
-
-#include <pointer-analysis/value_set.h>
-
-#include "pointer_offset_sum.h"
 
 // global data, horrible
 unsigned int value_set_dereferencet::invalid_counter=0;

--- a/src/solvers/flattening/boolbv_update.cpp
+++ b/src/solvers/flattening/boolbv_update.cpp
@@ -8,13 +8,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "boolbv.h"
 
-#include <util/std_types.h>
-#include <util/std_expr.h>
 #include <util/arith_tools.h>
-#include <util/base_type.h>
-#include <util/pointer_offset_size.h>
-
-#include <util/c_types.h>
 
 bvt boolbvt::convert_update(const exprt &expr)
 {

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -8,14 +8,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "bv_pointers.h"
 
+#include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/config.h>
-#include <util/arith_tools.h>
-#include <util/invariant.h>
-#include <util/prefix.h>
-#include <util/std_expr.h>
 #include <util/pointer_offset_size.h>
-#include <util/threeval.h>
 
 literalt bv_pointerst::convert_rest(const exprt &expr)
 {

--- a/src/solvers/flattening/flatten_byte_operators.cpp
+++ b/src/solvers/flattening/flatten_byte_operators.cpp
@@ -6,19 +6,17 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-#include <util/c_types.h>
-#include <util/expr.h>
-#include <util/std_types.h>
-#include <util/std_expr.h>
+#include "flatten_byte_operators.h"
+
 #include <util/arith_tools.h>
-#include <util/pointer_offset_size.h>
 #include <util/byte_operators.h>
+#include <util/c_types.h>
 #include <util/namespace.h>
+#include <util/pointer_offset_size.h>
 #include <util/replace_symbol.h>
 #include <util/simplify_expr.h>
 
 #include "flatten_byte_extract_exceptions.h"
-#include "flatten_byte_operators.h"
 
 /// rewrite an object into its individual bytes
 /// \par parameters: src  object to unpack

--- a/src/solvers/flattening/pointer_logic.cpp
+++ b/src/solvers/flattening/pointer_logic.cpp
@@ -15,9 +15,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/arith_tools.h>
 #include <util/c_types.h>
-#include <util/std_expr.h>
-#include <util/prefix.h>
+#include <util/invariant.h>
 #include <util/pointer_offset_size.h>
+#include <util/prefix.h>
+#include <util/std_expr.h>
 
 bool pointer_logict::is_dynamic_object(const exprt &expr) const
 {

--- a/src/util/base_type.cpp
+++ b/src/util/base_type.cpp
@@ -11,11 +11,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "base_type.h"
 
-#include <cassert>
 #include <set>
 
-#include "std_types.h"
 #include "namespace.h"
+#include "std_types.h"
 #include "symbol.h"
 #include "union_find.h"
 

--- a/src/util/base_type.cpp
+++ b/src/util/base_type.cpp
@@ -17,6 +17,39 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "std_types.h"
 #include "namespace.h"
 #include "symbol.h"
+#include "union_find.h"
+
+class base_type_eqt
+{
+public:
+  explicit base_type_eqt(const namespacet &_ns):ns(_ns)
+  {
+  }
+
+  bool base_type_eq(const typet &type1, const typet &type2)
+  {
+    identifiers.clear();
+    return base_type_eq_rec(type1, type2);
+  }
+
+  bool base_type_eq(const exprt &expr1, const exprt &expr2)
+  {
+    identifiers.clear();
+    return base_type_eq_rec(expr1, expr2);
+  }
+
+  virtual ~base_type_eqt() { }
+
+protected:
+  const namespacet &ns;
+
+  virtual bool base_type_eq_rec(const typet &type1, const typet &type2);
+  virtual bool base_type_eq_rec(const exprt &expr1, const exprt &expr2);
+
+  // for loop avoidance
+  typedef union_find<irep_idt> identifierst;
+  identifierst identifiers;
+};
 
 void base_type_rec(
   typet &type, const namespacet &ns, std::set<irep_idt> &symb)

--- a/src/util/base_type.h
+++ b/src/util/base_type.h
@@ -12,9 +12,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_BASE_TYPE_H
 #define CPROVER_UTIL_BASE_TYPE_H
 
-#include "union_find.h"
-#include "irep.h"
-
 class exprt;
 class typet;
 class namespacet;
@@ -28,37 +25,5 @@ bool base_type_eq(
   const exprt &expr1,
   const exprt &expr2,
   const namespacet &ns);
-
-class base_type_eqt
-{
-public:
-  explicit base_type_eqt(const namespacet &_ns):ns(_ns)
-  {
-  }
-
-  bool base_type_eq(const typet &type1, const typet &type2)
-  {
-    identifiers.clear();
-    return base_type_eq_rec(type1, type2);
-  }
-
-  bool base_type_eq(const exprt &expr1, const exprt &expr2)
-  {
-    identifiers.clear();
-    return base_type_eq_rec(expr1, expr2);
-  }
-
-  virtual ~base_type_eqt() { }
-
-protected:
-  const namespacet &ns;
-
-  virtual bool base_type_eq_rec(const typet &type1, const typet &type2);
-  virtual bool base_type_eq_rec(const exprt &expr1, const exprt &expr2);
-
-  // for loop avoidance
-  typedef union_find<irep_idt> identifierst;
-  identifierst identifiers;
-};
 
 #endif // CPROVER_UTIL_BASE_TYPE_H

--- a/src/util/fresh_symbol.cpp
+++ b/src/util/fresh_symbol.cpp
@@ -13,6 +13,8 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 
 #include "namespace.h"
 #include "rename.h"
+#include "symbol.h"
+#include "symbol_table_base.h"
 
 /// Installs a fresh-named symbol with the requested name pattern
 /// \par parameters: `type`: type of new symbol

--- a/src/util/fresh_symbol.h
+++ b/src/util/fresh_symbol.h
@@ -14,10 +14,12 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 
 #include <string>
 
-#include <util/irep.h>
-#include <util/source_location.h>
-#include <util/symbol_table.h>
-#include <util/type.h>
+#include "irep.h"
+
+class source_locationt;
+class symbolt;
+class symbol_table_baset;
+class typet;
 
 symbolt &get_fresh_aux_symbol(
   const typet &type,

--- a/src/util/graph.h
+++ b/src/util/graph.h
@@ -12,15 +12,15 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_GRAPH_H
 #define CPROVER_UTIL_GRAPH_H
 
-#include <list>
-#include <stack>
-#include <map>
-#include <vector>
-#include <iosfwd>
-#include <cassert>
 #include <algorithm>
-#include <queue>
+#include <cassert>
 #include <functional>
+#include <iosfwd>
+#include <list>
+#include <map>
+#include <queue>
+#include <stack>
+#include <vector>
 
 #include "invariant.h"
 

--- a/src/util/graph.h
+++ b/src/util/graph.h
@@ -16,7 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <stack>
 #include <map>
 #include <vector>
-#include <ostream>
+#include <iosfwd>
 #include <cassert>
 #include <algorithm>
 #include <queue>

--- a/src/util/invariant_utils.h
+++ b/src/util/invariant_utils.h
@@ -10,8 +10,7 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 #define CPROVER_UTIL_INVARIANT_TYPES_H
 
 #include "invariant.h"
-
-#include <util/irep.h>
+#include "irep.h"
 
 #include <string>
 

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -12,8 +12,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <vector>
 #include <string>
-#include <cassert>
-#include <iosfwd>
 
 #include "irep_ids.h"
 

--- a/src/util/irep_hash_container.h
+++ b/src/util/irep_hash_container.h
@@ -12,7 +12,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_IREP_HASH_CONTAINER_H
 #define CPROVER_UTIL_IREP_HASH_CONTAINER_H
 
-#include <cstdlib>  // for size_t
 #include <vector>
 
 #include "numbering.h"
@@ -22,7 +21,7 @@ class irept;
 class irep_hash_container_baset
 {
 public:
-  size_t number(const irept &irep);
+  std::size_t number(const irept &irep);
 
   explicit irep_hash_container_baset(bool _full):full(_full)
   {
@@ -41,23 +40,23 @@ protected:
 
   struct pointer_hasht
   {
-    size_t operator()(const void *p) const
+    std::size_t operator()(const void *p) const
     {
-      return (size_t)p;
+      return (std::size_t)p;
     }
   };
 
-  typedef std::unordered_map<const void *, size_t, pointer_hasht>
+  typedef std::unordered_map<const void *, std::size_t, pointer_hasht>
     ptr_hasht;
   ptr_hasht ptr_hash;
 
   // this is the second level: content
 
-  typedef std::vector<size_t> packedt;
+  typedef std::vector<std::size_t> packedt;
 
   struct vector_hasht
   {
-    size_t operator()(const packedt &p) const;
+    std::size_t operator()(const packedt &p) const;
   };
 
   typedef hash_numbering<packedt, vector_hasht> numberingt;

--- a/src/util/json_irep.h
+++ b/src/util/json_irep.h
@@ -12,7 +12,7 @@ Author: Thomas Kiley, thomas.kiley@diffblue.com
 #ifndef CPROVER_UTIL_JSON_IREP_H
 #define CPROVER_UTIL_JSON_IREP_H
 
-#include <util/irep.h>
+#include "irep.h"
 
 class jsont;
 class json_objectt;

--- a/src/util/json_stream.h
+++ b/src/util/json_stream.h
@@ -9,8 +9,8 @@ Author: Peter Schrammel
 #ifndef CPROVER_UTIL_JSON_STREAM_H
 #define CPROVER_UTIL_JSON_STREAM_H
 
-#include <memory>
 #include <iosfwd>
+#include <memory>
 
 #include "json.h"
 #include "invariant.h"

--- a/src/util/json_stream.h
+++ b/src/util/json_stream.h
@@ -10,7 +10,7 @@ Author: Peter Schrammel
 #define CPROVER_UTIL_JSON_STREAM_H
 
 #include <memory>
-#include <ostream>
+#include <iosfwd>
 
 #include "json.h"
 #include "invariant.h"

--- a/src/util/nondet_bool.h
+++ b/src/util/nondet_bool.h
@@ -12,8 +12,8 @@ Author: Chris Smowton, chris@smowton.net
 #ifndef CPROVER_UTIL_NONDET_BOOL_H
 #define CPROVER_UTIL_NONDET_BOOL_H
 
-#include <util/std_types.h>
-#include <util/std_expr.h>
+#include "std_expr.h"
+#include "std_types.h"
 
 /// \par parameters: Desired type (C_bool or plain bool)
 /// \return nondet expr of that type

--- a/src/util/nondet_ifthenelse.h
+++ b/src/util/nondet_ifthenelse.h
@@ -12,7 +12,7 @@ Author: Chris Smowton, chris@smowton.net
 #ifndef CPROVER_UTIL_NONDET_IFTHENELSE_H
 #define CPROVER_UTIL_NONDET_IFTHENELSE_H
 
-#include <util/std_code.h>
+#include "std_code.h"
 
 class symbol_tablet;
 class source_locationt;

--- a/src/util/numbering.h
+++ b/src/util/numbering.h
@@ -9,13 +9,12 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_NUMBERING_H
 #define CPROVER_UTIL_NUMBERING_H
 
-#include <cassert>
 #include <map>
 #include <unordered_map>
 #include <vector>
 
-#include <util/invariant.h>
-#include <util/optional.h>
+#include "invariant.h"
+#include "optional.h"
 
 /// \tparam Map a map from a key type to some numeric type
 template <typename Map>

--- a/src/util/pointer_offset_size.cpp
+++ b/src/util/pointer_offset_size.cpp
@@ -11,17 +11,13 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "pointer_offset_size.h"
 
-#include "c_types.h"
-#include "expr.h"
-#include "invariant.h"
 #include "arith_tools.h"
-#include "std_types.h"
-#include "std_expr.h"
-#include "expr_util.h"
-#include "simplify_expr.h"
+#include "c_types.h"
+#include "invariant.h"
 #include "namespace.h"
-#include "symbol.h"
+#include "simplify_expr.h"
 #include "ssa_expr.h"
+#include "std_expr.h"
 
 member_offset_iterator::member_offset_iterator(
   const struct_typet &_type,

--- a/src/util/pointer_predicates.cpp
+++ b/src/util/pointer_predicates.cpp
@@ -11,14 +11,12 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "pointer_predicates.h"
 
+#include "arith_tools.h"
 #include "c_types.h"
 #include "cprover_prefix.h"
 #include "namespace.h"
-#include "std_expr.h"
-#include "expr_util.h"
-#include "arith_tools.h"
 #include "pointer_offset_size.h"
-#include "config.h"
+#include "std_expr.h"
 #include "symbol.h"
 
 exprt pointer_object(const exprt &p)

--- a/src/util/rational.h
+++ b/src/util/rational.h
@@ -10,9 +10,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_RATIONAL_H
 #define CPROVER_UTIL_RATIONAL_H
 
-#include <cassert>
-#include <vector>
-
 #include "mp_arith.h"
 
 class constant_exprt;

--- a/src/util/refined_string_type.cpp
+++ b/src/util/refined_string_type.cpp
@@ -18,6 +18,8 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 
 #include "refined_string_type.h"
 
+#include "std_expr.h"
+
 refined_string_typet::refined_string_typet(
   const typet &index_type, const typet &char_type)
 {

--- a/src/util/refined_string_type.h
+++ b/src/util/refined_string_type.h
@@ -19,11 +19,8 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #ifndef CPROVER_UTIL_REFINED_STRING_TYPE_H
 #define CPROVER_UTIL_REFINED_STRING_TYPE_H
 
-#include <util/std_types.h>
-#include <util/std_expr.h>
-#include <util/arith_tools.h>
-#include <util/cprover_prefix.h>
-#include <util/expr_util.h>
+#include "cprover_prefix.h"
+#include "std_types.h"
 
 // Internal type used for string refinement
 class refined_string_typet: public struct_typet

--- a/src/util/sharing_map.h
+++ b/src/util/sharing_map.h
@@ -15,17 +15,15 @@ Author: Daniel Poetzl
 #include <string>
 #include <stack>
 #include <vector>
-#include <map>
 #include <stdexcept>
 #include <functional>
 #include <memory>
 #include <iosfwd>
 #include <cassert>
 
-#include <util/string2int.h>
-#include <util/threeval.h>
-#include <util/irep.h>
-#include <util/sharing_node.h>
+#include "irep.h"
+#include "sharing_node.h"
+#include "threeval.h"
 
 #define _sm_assert(b) assert(b)
 //#define _sm_assert(b)

--- a/src/util/sharing_node.h
+++ b/src/util/sharing_node.h
@@ -15,7 +15,6 @@ Author: Daniel Poetzl
 #include <list>
 #include <map>
 #include <memory>
-#include <cassert>
 
 #include "invariant.h"
 

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -11,35 +11,29 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <cassert>
 #include <algorithm>
 
-#include "c_types.h"
-#include "rational.h"
-#include "simplify_expr_class.h"
-#include "mp_arith.h"
 #include "arith_tools.h"
-#include "replace_expr.h"
-#include "std_types.h"
-#include "expr_util.h"
-#include "std_expr.h"
-#include "fixedbv.h"
-#include "pointer_offset_size.h"
-#include "rational_tools.h"
-#include "config.h"
 #include "base_type.h"
-#include "type_eq.h"
-#include "namespace.h"
-#include "threeval.h"
-#include "pointer_predicates.h"
-#include "prefix.h"
 #include "byte_operators.h"
-#include "bv_arithmetic.h"
+#include "c_types.h"
+#include "config.h"
 #include "endianness_map.h"
+#include "expr_util.h"
+#include "fixedbv.h"
+#include "namespace.h"
+#include "pointer_offset_size.h"
+#include "rational.h"
+#include "rational_tools.h"
 #include "simplify_utils.h"
+#include "std_expr.h"
+#include "type_eq.h"
 
 // #define DEBUGX
 
 #ifdef DEBUGX
 #include <iostream>
 #endif
+
+#include "simplify_expr_class.h"
 
 // #define USE_CACHE
 

--- a/src/util/simplify_expr_array.cpp
+++ b/src/util/simplify_expr_array.cpp
@@ -8,14 +8,11 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "simplify_expr_class.h"
 
-#include <cassert>
-
-#include "expr.h"
-#include "namespace.h"
-#include "std_expr.h"
-#include "replace_expr.h"
 #include "arith_tools.h"
+#include "namespace.h"
 #include "pointer_offset_size.h"
+#include "replace_expr.h"
+#include "std_expr.h"
 
 bool simplify_exprt::simplify_index(exprt &expr)
 {

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -14,7 +14,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "base_type.h"
 #include "bv_arithmetic.h"
 #include "config.h"
-#include "expr.h"
 #include "expr_util.h"
 #include "fixedbv.h"
 #include "ieee_float.h"
@@ -24,7 +23,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "rational.h"
 #include "rational_tools.h"
 #include "std_expr.h"
-#include "string2int.h"
 
 bool simplify_exprt::simplify_bswap(bswap_exprt &expr)
 {

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -10,17 +10,15 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <cassert>
 
-#include "c_types.h"
-#include "expr.h"
-#include "namespace.h"
-#include "std_expr.h"
-#include "pointer_offset_size.h"
 #include "arith_tools.h"
+#include "c_types.h"
 #include "config.h"
 #include "expr_util.h"
-#include "threeval.h"
-#include "prefix.h"
+#include "namespace.h"
+#include "pointer_offset_size.h"
 #include "pointer_predicates.h"
+#include "std_expr.h"
+#include "threeval.h"
 
 static bool is_dereference_integer_object(
   const exprt &expr,

--- a/src/util/simplify_expr_struct.cpp
+++ b/src/util/simplify_expr_struct.cpp
@@ -8,15 +8,12 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "simplify_expr_class.h"
 
-#include <cassert>
-
-#include "byte_operators.h"
-#include "expr.h"
-#include "namespace.h"
-#include "std_expr.h"
-#include "pointer_offset_size.h"
 #include "arith_tools.h"
 #include "base_type.h"
+#include "byte_operators.h"
+#include "namespace.h"
+#include "pointer_offset_size.h"
+#include "std_expr.h"
 
 bool simplify_exprt::simplify_member(exprt &expr)
 {

--- a/src/util/ssa_expr.h
+++ b/src/util/ssa_expr.h
@@ -10,7 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_SSA_EXPR_H
 #define CPROVER_UTIL_SSA_EXPR_H
 
-#include <util/std_expr.h>
+#include "std_expr.h"
 
 /*! \brief Expression providing an SSA-renamed symbol of expressions
 */

--- a/src/util/std_expr.cpp
+++ b/src/util/std_expr.cpp
@@ -13,9 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "arith_tools.h"
 #include "byte_operators.h"
 #include "c_types.h"
-#include "namespace.h"
 #include "pointer_offset_size.h"
-#include "std_types.h"
 
 bool constant_exprt::value_is_zero_string() const
 {

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -12,9 +12,9 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #ifndef CPROVER_UTIL_STRING_EXPR_H
 #define CPROVER_UTIL_STRING_EXPR_H
 
-#include <util/std_expr.h>
-#include <util/arith_tools.h>
-#include <util/refined_string_type.h>
+#include "arith_tools.h"
+#include "refined_string_type.h"
+#include "std_expr.h"
 
 // Given an representation of strings as exprt that implements `length` and
 // `content` this provides additional useful methods.

--- a/src/util/string_utils.h
+++ b/src/util/string_utils.h
@@ -10,7 +10,7 @@ Author: Daniel Poetzl
 #ifndef CPROVER_UTIL_STRING_UTILS_H
 #define CPROVER_UTIL_STRING_UTILS_H
 
-#include <ostream>
+#include <iosfwd>
 #include <string>
 #include <vector>
 

--- a/src/util/symbol_table_base.h
+++ b/src/util/symbol_table_base.h
@@ -6,12 +6,8 @@
 #ifndef CPROVER_UTIL_SYMBOL_TABLE_BASE_H
 #define CPROVER_UTIL_SYMBOL_TABLE_BASE_H
 
-#include <functional>
-#include <iosfwd>
 #include <map>
 #include <unordered_map>
-
-#include <util/optional.h>
 
 #include "symbol.h"
 

--- a/src/util/typecheck.cpp
+++ b/src/util/typecheck.cpp
@@ -6,12 +6,13 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-
 #include "typecheck.h"
+
+#include "invariant.h"
 
 bool typecheckt::typecheck_main()
 {
-  assert(message_handler);
+  PRECONDITION(message_handler);
 
   const unsigned errors_before=
     message_handler->get_message_count(messaget::M_ERROR);

--- a/src/util/union_find_replace.h
+++ b/src/util/union_find_replace.h
@@ -9,7 +9,7 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #ifndef CPROVER_UTIL_UNION_FIND_REPLACE_H
 #define CPROVER_UTIL_UNION_FIND_REPLACE_H
 
-#include <util/replace_expr.h>
+#include "replace_expr.h"
 
 /// Similar interface to union-find for expressions, with a function for
 /// replacing sub-expressions by their result for find.

--- a/src/xmllang/graphml.h
+++ b/src/xmllang/graphml.h
@@ -12,8 +12,7 @@ Author: Michael Tautschnig, mt@eecs.qmul.ac.uk
 #ifndef CPROVER_XMLLANG_GRAPHML_H
 #define CPROVER_XMLLANG_GRAPHML_H
 
-#include <istream>
-#include <ostream>
+#include <iosfwd>
 #include <string>
 
 #include <util/irep.h>


### PR DESCRIPTION
This is just cleanup work to reduce the number of includes where those includes are actually not necessary. This reduces the number of dependencies and thus the number of translation units that need to be rebuilt upon changes.

In my testing, I have not observed noteworthy differences in build time for a complete re-build (which would have been another desirable side effect).