### PR TITLE
Value-set analysis: switch to using ai.h

### DIFF
--- a/regression/goto-instrument/value-set-analysis1/main.c
+++ b/regression/goto-instrument/value-set-analysis1/main.c
@@ -1,0 +1,22 @@
+int main(int argc, char** argv) {
+
+  int x;
+  int *y = &x;
+
+  g(y, argc);
+
+}
+
+void f() {
+
+  int z;
+  int *w = &z;
+
+}
+
+void g(int *param, int unknown) {
+
+  int z;
+  int *w = unknown == 5 ? &z : param;
+
+}

--- a/regression/goto-instrument/value-set-analysis1/test.desc
+++ b/regression/goto-instrument/value-set-analysis1/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--show-value-sets
+^EXIT=0$
+^SIGNAL=0$
+f::1::w = \{ <z, 0, signed int> \}
+g::1::w = \{ <x, 0, signed int>, <z, 0, signed int> \}
+--
+^warning: ignoring

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -269,9 +269,9 @@ int goto_instrument_parse_optionst::doit()
 
       status() << "Pointer Analysis" << eom;
       namespacet ns(goto_model.symbol_table);
-      value_set_analysist value_set_analysis(ns);
-      value_set_analysis(goto_model.goto_functions);
-      show_value_sets(get_ui(), goto_model, value_set_analysis);
+      value_set_analysist value_set_analysis;
+      value_set_analysis.analyze_all_functions(goto_model);
+      show_value_sets(get_ui(), goto_model, value_set_analysis, ns);
       return CPROVER_EXIT_SUCCESS;
     }
 
@@ -450,8 +450,8 @@ int goto_instrument_parse_optionst::doit()
       }
 
       status() << "Pointer Analysis" << eom;
-      value_set_analysist value_set_analysis(ns);
-      value_set_analysis(goto_model.goto_functions);
+      value_set_analysist value_set_analysis;
+      value_set_analysis.analyze_all_functions(goto_model);
 
       const symbolt &symbol=ns.lookup(ID_main);
       symbol_exprt main(symbol.name, symbol.type);
@@ -1195,8 +1195,8 @@ void goto_instrument_parse_optionst::instrument_goto_program()
     do_indirect_call_and_rtti_removal();
 
     status() << "Pointer Analysis" << eom;
-    value_set_analysist value_set_analysis(ns);
-    value_set_analysis(goto_model.goto_functions);
+    value_set_analysist value_set_analysis;
+    value_set_analysis.analyze_all_functions(goto_model);
 
     if(cmdline.isset("remove-pointers"))
     {

--- a/src/goto-symex/precondition.cpp
+++ b/src/goto-symex/precondition.cpp
@@ -116,7 +116,7 @@ void preconditiont::compute_rec(exprt &dest)
     // aliasing may happen here
 
     value_setst::valuest expr_set;
-    value_sets.get_values(target, dest.op0(), expr_set);
+    value_sets.get_values(target, dest.op0(), expr_set, ns);
     std::unordered_set<irep_idt> symbols;
 
     for(value_setst::valuest::const_iterator

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -232,7 +232,7 @@ void goto_program_dereferencet::get_value_set(
   const exprt &expr,
   value_setst::valuest &dest)
 {
-  value_sets.get_values(current_target, expr, dest);
+  value_sets.get_values(current_target, expr, dest, ns);
 }
 
 void goto_program_dereferencet::dereference_expr(

--- a/src/pointer-analysis/show_value_sets.cpp
+++ b/src/pointer-analysis/show_value_sets.cpp
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <goto-programs/goto_model.h>
 
+#include <util/namespace.h>
 #include <util/xml.h>
 
 #include <iostream>
@@ -21,7 +22,8 @@ Author: Daniel Kroening, kroening@kroening.com
 void show_value_sets(
   ui_message_handlert::uit ui,
   const goto_modelt &goto_model,
-  const value_set_analysist &value_set_analysis)
+  const value_set_analysist &value_set_analysis,
+  const namespacet &ns)
 {
   switch(ui)
   {
@@ -34,32 +36,7 @@ void show_value_sets(
     break;
 
   case ui_message_handlert::uit::PLAIN:
-    value_set_analysis.output(goto_model.goto_functions, std::cout);
-    break;
-
-  default:
-    {
-    }
-  }
-}
-
-void show_value_sets(
-  ui_message_handlert::uit ui,
-  const goto_programt &goto_program,
-  const value_set_analysist &value_set_analysis)
-{
-  switch(ui)
-  {
-  case ui_message_handlert::uit::XML_UI:
-    {
-      xmlt xml;
-      convert(goto_program, value_set_analysis, xml);
-      std::cout << xml << '\n';
-    }
-    break;
-
-  case ui_message_handlert::uit::PLAIN:
-    value_set_analysis.output(goto_program, std::cout);
+    value_set_analysis.output(ns, goto_model.goto_functions, std::cout);
     break;
 
   default:

--- a/src/pointer-analysis/show_value_sets.h
+++ b/src/pointer-analysis/show_value_sets.h
@@ -20,6 +20,7 @@ class goto_modelt;
 void show_value_sets(
   ui_message_handlert::uit,
   const goto_modelt &,
-  const value_set_analysist &);
+  const value_set_analysist &,
+  const namespacet &);
 
 #endif // CPROVER_POINTER_ANALYSIS_SHOW_VALUE_SETS_H

--- a/src/pointer-analysis/value_set_analysis.h
+++ b/src/pointer-analysis/value_set_analysis.h
@@ -67,7 +67,7 @@ public:
 
     forall_goto_functions(it, goto_model.goto_functions)
     {
-      if(it->second.body.instructions.empty())
+      if(!it->second.body_available())
         continue;
       const auto &start_state =
         static_cast<const domaint &>(

--- a/src/pointer-analysis/value_set_analysis_fi.h
+++ b/src/pointer-analysis/value_set_analysis_fi.h
@@ -61,7 +61,8 @@ public:
   virtual void get_values(
     locationt l,
     const exprt &expr,
-    std::list<exprt> &dest)
+    std::list<exprt> &dest,
+    const namespacet &ns)
   {
     state.value_set.from_function =
       state.value_set.function_numbering.number(l->function);

--- a/src/pointer-analysis/value_set_analysis_fivr.h
+++ b/src/pointer-analysis/value_set_analysis_fivr.h
@@ -81,7 +81,8 @@ public:
   virtual void get_values(
     locationt l,
     const exprt &expr,
-    std::list<exprt> &dest)
+    std::list<exprt> &dest,
+    const namespacet &ns)
   {
     state.value_set.from_function =
       state.value_set.function_numbering.number(l->function);

--- a/src/pointer-analysis/value_set_analysis_fivrns.h
+++ b/src/pointer-analysis/value_set_analysis_fivrns.h
@@ -83,7 +83,8 @@ public:
   virtual void get_values(
     locationt l,
     const exprt &expr,
-    std::list<exprt> &dest)
+    std::list<exprt> &dest,
+    const namespacet &ns)
   {
     state.value_set.from_function =
       state.value_set.function_numbering.number(l->function);

--- a/src/pointer-analysis/value_set_domain.h
+++ b/src/pointer-analysis/value_set_domain.h
@@ -12,51 +12,82 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_POINTER_ANALYSIS_VALUE_SET_DOMAIN_H
 #define CPROVER_POINTER_ANALYSIS_VALUE_SET_DOMAIN_H
 
-#define USE_DEPRECATED_STATIC_ANALYSIS_H
-#include <analyses/static_analysis.h>
-
 #include "value_set.h"
 
+#include <analyses/ai.h>
+
 template<class VST>
-class value_set_domain_templatet:public domain_baset
+class value_set_domain_templatet : public ai_domain_baset
 {
 public:
   VST value_set;
 
+  value_set_domain_templatet() : state_is_bottom(false)
+  {
+  }
+
   // overloading
 
-  bool merge(const value_set_domain_templatet<VST> &other, locationt to)
+  bool merge(
+    const value_set_domain_templatet<VST> &other, locationt from, locationt to)
   {
-    return value_set.make_union(other.value_set);
+    bool ret = state_is_bottom;
+    state_is_bottom = false;
+    ret |= value_set.make_union(other.value_set);
+    return ret;
   }
 
   virtual void output(
-    const namespacet &ns,
-    std::ostream &out) const
+    std::ostream &out,
+    const ai_baset &value_set_analysis,
+    const namespacet &ns) const override
   {
     value_set.output(ns, out);
   }
 
-  virtual void initialize(
-    const namespacet &ns,
-    locationt l)
+  virtual void make_top() override
   {
     value_set.clear();
-    value_set.location_number=l->location_number;
+    state_is_bottom = false;
+  }
+
+  virtual void make_bottom() override
+  {
+    value_set.clear();
+    state_is_bottom = true;
+  }
+
+  virtual void make_entry() override
+  {
+    make_top();
+  }
+
+  virtual bool is_bottom() const override
+  {
+    return value_set.values.empty() && state_is_bottom;
+  }
+
+  virtual bool is_top() const override
+  {
+    return value_set.values.empty() && !state_is_bottom;
   }
 
   virtual void transform(
-    const namespacet &ns,
     locationt from_l,
-    locationt to_l);
+    locationt to_l,
+    ai_baset &ai,
+    const namespacet &ns) override;
 
-  virtual void get_reference_set(
+  void get_reference_set(
     const namespacet &ns,
     const exprt &expr,
     value_setst::valuest &dest)
   {
     value_set.get_reference_set(expr, dest, ns);
   }
+
+private:
+  bool state_is_bottom;
 };
 
 typedef value_set_domain_templatet<value_sett> value_set_domaint;

--- a/src/pointer-analysis/value_set_domain_transform.inc
+++ b/src/pointer-analysis/value_set_domain_transform.inc
@@ -15,9 +15,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 template<class VST>
 void value_set_domain_templatet<VST>::transform(
-  const namespacet &ns,
   locationt from_l,
-  locationt to_l)
+  locationt to_l,
+  ai_baset &value_set_analysis,
+  const namespacet &ns)
 {
   switch(from_l->type)
   {
@@ -27,8 +28,9 @@ void value_set_domain_templatet<VST>::transform(
 
   case END_FUNCTION:
   {
-    value_set.do_end_function(
-      static_analysis_baset::get_return_lhs(to_l), ns);
+    exprt return_lhs =
+      to_code_function_call(std::prev(to_l)->code).lhs();
+    value_set.do_end_function(return_lhs, ns);
     break;
   }
 

--- a/src/pointer-analysis/value_sets.h
+++ b/src/pointer-analysis/value_sets.h
@@ -31,7 +31,8 @@ public:
   virtual void get_values(
     goto_programt::const_targett l,
     const exprt &expr,
-    valuest &dest)=0;
+    valuest &dest,
+    const namespacet &ns)=0;
 
   virtual ~value_setst()
   {

--- a/unit/pointer-analysis/custom_value_set_analysis.cpp
+++ b/unit/pointer-analysis/custom_value_set_analysis.cpp
@@ -199,13 +199,13 @@ SCENARIO("test_value_set_analysis",
     value_set_analysist::locationt test_function_end=
       std::prev(test_function.instructions.end());
 
-    value_set_analysist normal_analysis(ns);
-    normal_analysis(goto_model.goto_functions);
+    value_set_analysist normal_analysis;
+    normal_analysis.analyze_all_functions(goto_model);
     const auto &normal_function_end_vs=
       normal_analysis[test_function_end].value_set;
 
-    test_value_set_analysist test_analysis(ns);
-    test_analysis(goto_model.goto_functions);
+    test_value_set_analysist test_analysis;
+    test_analysis.analyze_all_functions(goto_model);
     const auto &test_function_end_vs=
       test_analysis[test_function_end].value_set;
 


### PR DESCRIPTION
We've got a few `static_analysist` improvements in security-analyser (reducing domain size etc), but I figured if we're going to upstream them we should do so against `ait` instead. Therefore this ports `value_set_analysist` to use the newer infrastructure.

This eliminates the last in-tree user of static_analysis.h/cpp, so it can go away soon.

Possible snags:
* `static_analysist` had a default "analyse every function" behaviour, whereas `ait` analyses starting from the entry point (doing nothing at all if the GOTO program doesn't have a `__CPROVER_start` function). I added `value_set_analysist::analyse_all_functions` to get the old behaviour. `operator()` will still produce `ait`-style results, but we might want to hide `operator()` if we think that'll be too surprising to users.
* `concurrent_fixedpoint` is not reachable via `analyse_all_functions`. I could refactor `ait` a bit to fix that; do we want this?
* Passes using `show_value_sets` need to provide a namespace to make up for its removal in `ait`, but this is easily done.
* There are *no* regression tests for goto-instrument / --show-value-sets, the only in-tree user. There is however `unit/pointer-analysis/custom_value_set_analysis.cpp`, which was intended to test `value_sett` customisation hooks, but also by coincidence tests normal value-set analysis a little. Therefore confidence that there are no unintended changes is quite low.