### PR TITLE
Improvements to goto-analyzer's constant propagator and simplifier [blocks: #2522]

### DIFF
--- a/regression/goto-analyzer/constant_propagation_03/test.desc
+++ b/regression/goto-analyzer/constant_propagation_03/test.desc
@@ -1,9 +1,9 @@
-FUTURE
+CORE
 main.c
 --constants --simplify out.gb
 ^EXIT=0$
 ^SIGNAL=0$
-^Simplified:  assert: 1, assume: 0, goto: 2, assigns: 6, function calls: 0$
+^Simplified:  assert: 1, assume: 0, goto: 1, assigns: 6, function calls: 0$
 ^Unmodified:  assert: 0, assume: 0, goto: 0, assigns: 11, function calls: 2$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_04/test.desc
+++ b/regression/goto-analyzer/constant_propagation_04/test.desc
@@ -1,9 +1,9 @@
-FUTURE
+CORE
 main.c
 --constants --simplify out.gb
 ^EXIT=0$
 ^SIGNAL=0$
-^Simplified:  assert: 1, assume: 0, goto: 2, assigns: 6, function calls: 0$
+^Simplified:  assert: 1, assume: 0, goto: 1, assigns: 6, function calls: 0$
 ^Unmodified:  assert: 0, assume: 0, goto: 0, assigns: 11, function calls: 2$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_05/test.desc
+++ b/regression/goto-analyzer/constant_propagation_05/test.desc
@@ -1,8 +1,8 @@
-FUTURE
+CORE
 main.c
 --constants --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] file main.c line 12 function main, assertion j != 3: FAILURE \(if reachable\)$
+^\[main.assertion.1\] line 11 assertion j != 3: FAILURE \(if reachable\)$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_07/test.desc
+++ b/regression/goto-analyzer/constant_propagation_07/test.desc
@@ -1,9 +1,9 @@
-FUTURE
+CORE
 main.c
 --constants --simplify out.gb
 ^EXIT=0$
 ^SIGNAL=0$
-^Simplified:  assert: 1, assume: 0, goto: 4, assigns: 10, function calls: 0$
-^Unmodified:  assert: 0, assume: 0, goto: 1, assigns: 10, function calls: 2$
+^Simplified:  assert: 1, assume: 0, goto: 3, assigns: 11, function calls: 0$
+^Unmodified:  assert: 0, assume: 0, goto: 1, assigns: 9, function calls: 2$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_09/test.desc
+++ b/regression/goto-analyzer/constant_propagation_09/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --constants --verify
 ^EXIT=0$

--- a/regression/goto-analyzer/constant_propagation_09/test.desc
+++ b/regression/goto-analyzer/constant_propagation_09/test.desc
@@ -1,9 +1,8 @@
-FUTURE
+KNOWNBUG
 main.c
---constants --simplify out.gb
+--constants --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^Simplified:  assert: 1, assume: 0, goto: 3, assigns: 4, function calls: 0$
-^Unmodified:  assert: 0, assume: 0, goto: 0, assigns: 11, function calls: 2$
+^\[main.assertion.1\] line 9 assertion a\[(\(signed( long)? long int\))?0\] == 0: FAILURE \(if reachable\)$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_10/test.desc
+++ b/regression/goto-analyzer/constant_propagation_10/test.desc
@@ -1,8 +1,8 @@
-FUTURE
+CORE
 main.c
 --constants --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] file main.c line 10 function main, assertion a\[(\(signed( long)? long int\))?0\] == 2: FAILURE$
+^\[main.assertion.1\] line 10 assertion a\[(\(signed( long)? long int\))?0\] == 2: FAILURE \(if reachable\)$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_11/test.desc
+++ b/regression/goto-analyzer/constant_propagation_11/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --constants --verify
 ^EXIT=0$

--- a/regression/goto-analyzer/constant_propagation_11/test.desc
+++ b/regression/goto-analyzer/constant_propagation_11/test.desc
@@ -1,9 +1,8 @@
-FUTURE
+KNOWNBUG
 main.c
---constants --simplify out.gb
+--constants --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^Simplified:  assert: 1, assume: 0, goto: 0, assigns: 0, function calls: 0$
-^Unmodified:  assert: 0, assume: 0, goto: 0, assigns: 0, function calls: 0$
+^\[main.assertion.1\] line 9 assertion a\[(\(signed( long)? long int\))?0\] == 1: SUCCESS$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_12/test.desc
+++ b/regression/goto-analyzer/constant_propagation_12/test.desc
@@ -1,9 +1,9 @@
-FUTURE
+CORE
 main.c
 --constants --simplify out.gb
 ^EXIT=0$
 ^SIGNAL=0$
-^Simplified:  assert: 1, assume: 0, goto: 1, assigns: 4, function calls: 0$
-^Unmodified:  assert: 0, assume: 0, goto: 2, assigns: 11, function calls: 2$
+^Simplified:  assert: 1, assume: 0, goto: 1, assigns: 5, function calls: 0$
+^Unmodified:  assert: 0, assume: 0, goto: 1, assigns: 10, function calls: 2$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_13/test.desc
+++ b/regression/goto-analyzer/constant_propagation_13/test.desc
@@ -1,8 +1,8 @@
-FUTURE
+CORE
 main.c
 --constants --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] file main.c line 9 function main, assertion y == 0: FAILURE \(if reachable\)$
+^\[main.assertion.1\] line 9 assertion y == 0: FAILURE \(if reachable\)$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_14/test.desc
+++ b/regression/goto-analyzer/constant_propagation_14/test.desc
@@ -1,9 +1,9 @@
-FUTURE
+KNOWNBUG
 main.c
 --constants --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] file main.c line 11 function main, assertion tmp_if_expr: SUCCESS$
-^\[main.assertion.2\] file main.c line 12 function main, assertion tmp_if_expr\$1: FAILURE$
+^\[main.assertion.1\] line 11 assertion tmp_if_expr: SUCCESS$
+^\[main.assertion.2\] line 12 assertion tmp_if_expr\$0: FAILURE \(if reachable\)$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_14/test.desc
+++ b/regression/goto-analyzer/constant_propagation_14/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --constants --verify
 ^EXIT=0$

--- a/regression/goto-analyzer/constant_propagation_15/test.desc
+++ b/regression/goto-analyzer/constant_propagation_15/test.desc
@@ -1,8 +1,8 @@
-FUTURE
+CORE
 main.c
 --constants --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] file main.c line 9 function main, assertion a\[(\(signed( long)? long int\))?0\] == 2: FAILURE$
+^\[main.assertion.1\] line 9 assertion a\[(\(signed( long)? long int\))?0\] == 2: FAILURE \(if reachable\)$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_18/main.c
+++ b/regression/goto-analyzer/constant_propagation_18/main.c
@@ -1,0 +1,8 @@
+#include <assert.h>
+
+int main()
+{
+  int i = 1;
+  int *p = &i;
+  assert(*p == 1);
+}

--- a/regression/goto-analyzer/constant_propagation_18/test.desc
+++ b/regression/goto-analyzer/constant_propagation_18/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--constants --verify
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] line 7 assertion \*p == 1: SUCCESS$
+--
+^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_19/main.c
+++ b/regression/goto-analyzer/constant_propagation_19/main.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+
+int main()
+{
+  int x;
+  int *p = &x;
+  *p = 42;
+  assert(x == 42);
+  return 0;
+}

--- a/regression/goto-analyzer/constant_propagation_19/test.desc
+++ b/regression/goto-analyzer/constant_propagation_19/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--constants --verify
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] line 8 assertion x == 42: SUCCESS$
+--
+^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_two_way_1/main.c
+++ b/regression/goto-analyzer/constant_propagation_two_way_1/main.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+
+int main()
+{
+  int x;
+  if(x == 0)
+  {
+    assert(!x);
+  }
+  return 0;
+}

--- a/regression/goto-analyzer/constant_propagation_two_way_1/test.desc
+++ b/regression/goto-analyzer/constant_propagation_two_way_1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--constants --verify
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] line 8 assertion !x: SUCCESS$
+--
+^warning: ignoring

--- a/regression/goto-analyzer/sensitivity-function-call-recursive/test.desc
+++ b/regression/goto-analyzer/sensitivity-function-call-recursive/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.c
 --variable --pointers --arrays --structs --verify
 ^EXIT=0$

--- a/regression/goto-analyzer/sensitivity-test-constants-pointer-to-constants-struct/test.desc
+++ b/regression/goto-analyzer/sensitivity-test-constants-pointer-to-constants-struct/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 sensitivity_test_constants_pointer_to_constants_struct.c
 --variable --pointers --structs --verify
 ^EXIT=0$

--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -232,19 +232,15 @@ void constant_propagator_domaint::transform(
 /// handles equalities and conjunctions containing equalities
 bool constant_propagator_domaint::two_way_propagate_rec(
   const exprt &expr,
-  const namespacet &,
+  const namespacet &ns,
   const constant_propagator_ait *cp)
 {
 #ifdef DEBUG
   std::cout << "two_way_propagate_rec: " << format(expr) << '\n';
-#else
-  (void)expr; // unused parameter
 #endif
 
   bool change=false;
 
-  // this seems to be buggy at present
-#if 0
   if(expr.id()==ID_and)
   {
     // need a fixed point here to get the most out of it
@@ -265,14 +261,11 @@ bool constant_propagator_domaint::two_way_propagate_rec(
 
     // two-way propagation
     valuest copy_values=values;
-    assign_rec(copy_values, lhs, rhs, ns);
+    assign_rec(copy_values, lhs, rhs, ns, cp);
     if(!values.is_constant(rhs) || values.is_constant(lhs))
-       assign_rec(values, rhs, lhs, ns);
+      assign_rec(values, rhs, lhs, ns, cp);
     change = values.meet(copy_values, ns);
   }
-#else
-  (void)cp;   // unused parameter
-#endif
 
 #ifdef DEBUG
   std::cout << "two_way_propagate_rec: " << change << '\n';

--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -38,12 +38,18 @@ void constant_propagator_domaint::assign_rec(
 {
   if(lhs.id() == ID_dereference)
   {
-    const bool have_dirty = (cp != nullptr);
+    exprt eval_lhs = lhs;
+    if(partial_evaluate(dest_values, eval_lhs, ns))
+    {
+      const bool have_dirty = (cp != nullptr);
 
-    if(have_dirty)
-      dest_values.set_dirty_to_top(cp->dirty, ns);
+      if(have_dirty)
+        dest_values.set_dirty_to_top(cp->dirty, ns);
+      else
+        dest_values.set_to_top();
+    }
     else
-      dest_values.set_to_top();
+      assign_rec(dest_values, eval_lhs, rhs, ns, cp);
   }
   else if(lhs.id() == ID_index)
   {

--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -47,7 +47,7 @@ void constant_propagator_domaint::assign_rec(
   exprt tmp=rhs;
   partial_evaluate(dest_values, tmp, ns);
 
-  if(tmp.is_constant())
+  if(dest_values.is_constant(tmp))
   {
     DATA_INVARIANT(
       base_type_eq(ns.lookup(s).type, tmp.type(), ns),

--- a/src/analyses/constant_propagator.h
+++ b/src/analyses/constant_propagator.h
@@ -124,8 +124,6 @@ public:
     void set_dirty_to_top(const dirtyt &dirty, const namespacet &ns);
 
     bool is_constant(const exprt &expr) const;
-    bool is_array_constant(const exprt &expr) const;
-    bool is_constant_address_of(const exprt &expr) const;
 
     bool is_empty() const
     {

--- a/src/analyses/constant_propagator.h
+++ b/src/analyses/constant_propagator.h
@@ -137,11 +137,14 @@ public:
 
   valuest values;
 
-  bool partial_evaluate(exprt &expr, const namespacet &ns) const;
+  static bool partial_evaluate(
+    const valuest &known_values,
+    exprt &expr,
+    const namespacet &ns);
 
 protected:
-  void assign_rec(
-    valuest &values,
+  static void assign_rec(
+    valuest &dest_values,
     const exprt &lhs,
     const exprt &rhs,
     const namespacet &ns,
@@ -152,11 +155,15 @@ protected:
     const namespacet &ns,
     const constant_propagator_ait *cp);
 
-  bool partial_evaluate_with_all_rounding_modes(
+  static bool partial_evaluate_with_all_rounding_modes(
+    const valuest &known_values,
     exprt &expr,
-    const namespacet &ns) const;
+    const namespacet &ns);
 
-  bool replace_constants_and_simplify(exprt &expr, const namespacet &ns) const;
+  static bool replace_constants_and_simplify(
+    const valuest &known_values,
+    exprt &expr,
+    const namespacet &ns);
 };
 
 class constant_propagator_ait:public ait<constant_propagator_domaint>

--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -270,6 +270,12 @@ bool is_constantt::is_constant_address_of(const exprt &expr) const
   {
     return is_constant_address_of(to_member_expr(expr).compound());
   }
+  else if(expr.id() == ID_dereference)
+  {
+    const dereference_exprt &deref = to_dereference_expr(expr);
+
+    return is_constant(deref.pointer());
+  }
   else if(expr.id() == ID_string_constant)
     return true;
 


### PR DESCRIPTION
Previously only `exprt::id() == ID_constant` was deemed "constant", but several other expressions (in particular: the address of an object) are also constants that can safely be propagated. The interpretation of what is (or isn't) constant now largely overlaps with what goto-symex considers a constant.

Dependencies:
- [x] #2197 
- [x] #2198 
- [x] #2199 
- [x] #2200
- [x] #2221