### PR TITLE
use optional for unknown pointer offset sizes

### DIFF
--- a/src/analyses/reaching_definitions.cpp
+++ b/src/analyses/reaching_definitions.cpp
@@ -210,9 +210,11 @@ void rd_range_domaint::transform_function_call(
       if(identifier.empty())
         continue;
 
-      range_spect size=
-        to_range_spect(pointer_offset_bits(param.type(), ns));
-      gen(from, identifier, 0, size);
+      auto param_bits = pointer_offset_bits(param.type(), ns);
+      if(param_bits.has_value())
+        gen(from, identifier, 0, to_range_spect(*param_bits));
+      else
+        gen(from, identifier, 0, -1);
     }
   }
   else

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -3617,9 +3617,9 @@ std::string expr2ct::convert_with_precedence(
   else if(src.id()==ID_bswap)
     return convert_function(
       src,
-      "__builtin_bswap"+
-      integer2string(pointer_offset_bits(src.op0().type(), ns)),
-      precedence=16);
+      "__builtin_bswap" +
+        integer2string(*pointer_offset_bits(src.op0().type(), ns)),
+      precedence = 16);
 
   else if(src.id()==ID_isnormal)
     return convert_function(src, "isnormal", precedence=16);

--- a/src/ansi-c/padding.cpp
+++ b/src/ansi-c/padding.cpp
@@ -70,7 +70,7 @@ mp_integer alignment(const typet &type, const namespacet &ns)
           type.id()==ID_c_bool ||
           type.id()==ID_pointer)
   {
-    result=pointer_offset_size(type, ns);
+    result = *pointer_offset_size(type, ns);
   }
   else if(type.id()==ID_c_enum)
     result=alignment(type.subtype(), ns);
@@ -229,9 +229,9 @@ static void add_padding_msvc(struct_typet &type, const namespacet &ns)
       else
       {
         // keep track of offset
-        const mp_integer size = pointer_offset_size(it->type(), ns);
-        if(size >= 1)
-          offset += size;
+        const auto size = pointer_offset_size(it->type(), ns);
+        if(size.has_value() && *size >= 1)
+          offset += *size;
       }
     }
   }
@@ -375,10 +375,10 @@ static void add_padding_gcc(struct_typet &type, const namespacet &ns)
       }
     }
 
-    mp_integer size=pointer_offset_size(it_type, ns);
+    auto size = pointer_offset_size(it_type, ns);
 
-    if(size!=-1)
-      offset+=size;
+    if(size.has_value())
+      offset += *size;
   }
 
   // any explicit alignment for the struct?
@@ -435,9 +435,9 @@ void add_padding(union_typet &type, const namespacet &ns)
   // check per component, and ignore those without fixed size
   for(const auto &c : type.components())
   {
-    mp_integer s=pointer_offset_bits(c.type(), ns);
-    if(s>0)
-      size_bits=std::max(size_bits, s);
+    auto s = pointer_offset_bits(c.type(), ns);
+    if(s.has_value())
+      size_bits = std::max(size_bits, *s);
   }
 
   // Is the union packed?

--- a/src/ansi-c/type2name.cpp
+++ b/src/ansi-c/type2name.cpp
@@ -86,9 +86,9 @@ static std::string pointer_offset_bits_as_string(
   const typet &type,
   const namespacet &ns)
 {
-  mp_integer bits = pointer_offset_bits(type, ns);
-  CHECK_RETURN(bits != -1);
-  return integer2string(bits);
+  auto bits = pointer_offset_bits(type, ns);
+  CHECK_RETURN(bits.has_value());
+  return integer2string(*bits);
 }
 
 static bool parent_is_sym_check=false;

--- a/src/goto-instrument/alignment_checks.cpp
+++ b/src/goto-instrument/alignment_checks.cpp
@@ -51,12 +51,12 @@ void print_struct_alignment_problems(
         {
           const typet &it_type = it_next->type();
           const namespacet ns(symbol_table);
-          mp_integer size = pointer_offset_size(it_type, ns);
+          auto size = pointer_offset_size(it_type, ns);
 
-          if(size < 0)
+          if(!size.has_value())
             throw "type of unknown size:\n" + it_type.pretty();
 
-          cumulated_length += size;
+          cumulated_length += *size;
           // [it_mem;it_next] cannot be covered by an instruction
           if(cumulated_length > config.ansi_c.memory_operand_size)
           {
@@ -92,13 +92,13 @@ void print_struct_alignment_problems(
       #if 0
       const namespacet ns(symbol_table);
       const array_typet array=to_array_type(symbol_pair.second.type);
-      const mp_integer size=
+      const auto size=
         pointer_offset_size(array.subtype(), ns);
 
-      if(size<0)
+      if(!size.has_value())
         throw "type of unknown size:\n"+it_type.pretty();
 
-      if(2*integer2long(size)<=config.ansi_c.memory_operand_size)
+      if(2*integer2long(*size)<=config.ansi_c.memory_operand_size)
       {
         out << "\nWARNING: "
             << "declaration of an array at "

--- a/src/goto-instrument/count_eloc.cpp
+++ b/src/goto-instrument/count_eloc.cpp
@@ -191,9 +191,9 @@ void print_global_state_size(const goto_modelt &goto_model)
       continue;
     }
 
-    const mp_integer bits = pointer_offset_bits(symbol.type, ns);
-    if(bits > 0)
-      total_size += bits;
+    const auto bits = pointer_offset_bits(symbol.type, ns);
+    if(bits.has_value() && bits.value() > 0)
+      total_size += bits.value();
   }
 
   std::cout << "Total size of global objects: " << total_size << " bits\n";

--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -161,18 +161,18 @@ bool interpretert::byte_offset_to_memory_offset(
 
     for(const auto &comp : st.components())
     {
-      const mp_integer comp_offset = member_offset(st, comp.get_name(), ns);
+      const auto comp_offset = member_offset(st, comp.get_name(), ns);
 
-      const mp_integer component_byte_size =
-        pointer_offset_size(comp.type(), ns);
-      if(component_byte_size<0)
+      const auto component_byte_size = pointer_offset_size(comp.type(), ns);
+
+      if(!comp_offset.has_value() && !component_byte_size.has_value())
         return true;
 
-      if(comp_offset + component_byte_size > offset)
+      if(*comp_offset + *component_byte_size > offset)
       {
         mp_integer subtype_result;
-        bool ret=byte_offset_to_memory_offset(
-          comp.type(), offset - comp_offset, subtype_result);
+        bool ret = byte_offset_to_memory_offset(
+          comp.type(), offset - *comp_offset, subtype_result);
         result=previous_member_offsets+subtype_result;
         return ret;
       }
@@ -190,25 +190,30 @@ bool interpretert::byte_offset_to_memory_offset(
   else if(source_type.id()==ID_array)
   {
     const auto &at=to_array_type(source_type);
+
     mp_vectort array_size_vec;
     evaluate(at.size(), array_size_vec);
+
     if(array_size_vec.size()!=1)
       return true;
+
     mp_integer array_size=array_size_vec[0];
-    mp_integer elem_size_bytes=pointer_offset_size(at.subtype(), ns);
-    if(elem_size_bytes<=0)
+    auto elem_size_bytes = pointer_offset_size(at.subtype(), ns);
+    if(!elem_size_bytes.has_value() || *elem_size_bytes == 0)
       return true;
+
     mp_integer elem_size_leaves;
     if(count_type_leaves(at.subtype(), elem_size_leaves))
       return true;
-    mp_integer this_idx=offset/elem_size_bytes;
+
+    mp_integer this_idx = offset / (*elem_size_bytes);
     if(this_idx>=array_size_vec[0])
       return true;
+
     mp_integer subtype_result;
-    bool ret=byte_offset_to_memory_offset(
-      at.subtype(),
-      offset%elem_size_bytes,
-      subtype_result);
+    bool ret = byte_offset_to_memory_offset(
+      at.subtype(), offset % (*elem_size_bytes), subtype_result);
+
     result=subtype_result+(elem_size_leaves*this_idx);
     return ret;
   }
@@ -246,7 +251,10 @@ bool interpretert::memory_offset_to_byte_offset(
         mp_integer subtype_result;
         bool ret=memory_offset_to_byte_offset(
           comp.type(), cell_offset, subtype_result);
-        result = member_offset(st, comp.get_name(), ns) + subtype_result;
+        const auto member_offset_result =
+          member_offset(st, comp.get_name(), ns);
+        CHECK_RETURN(member_offset_result.has_value());
+        result = member_offset_result.value() + subtype_result;
         return ret;
       }
       else
@@ -260,26 +268,31 @@ bool interpretert::memory_offset_to_byte_offset(
   else if(source_type.id()==ID_array)
   {
     const auto &at=to_array_type(source_type);
+
     mp_vectort array_size_vec;
     evaluate(at.size(), array_size_vec);
     if(array_size_vec.size()!=1)
       return true;
-    mp_integer elem_size=pointer_offset_size(at.subtype(), ns);
-    if(elem_size==-1)
+
+    auto elem_size = pointer_offset_size(at.subtype(), ns);
+    if(!elem_size.has_value())
       return true;
+
     mp_integer elem_count;
     if(count_type_leaves(at.subtype(), elem_count))
       return true;
+
     mp_integer this_idx=full_cell_offset/elem_count;
     if(this_idx>=array_size_vec[0])
       return true;
+
     mp_integer subtype_result;
     bool ret=
       memory_offset_to_byte_offset(
         at.subtype(),
         full_cell_offset%elem_count,
         subtype_result);
-    result=subtype_result+(elem_size*this_idx);
+    result = subtype_result + ((*elem_size) * this_idx);
     return ret;
   }
   else

--- a/src/goto-programs/vcd_goto_trace.cpp
+++ b/src/goto-programs/vcd_goto_trace.cpp
@@ -61,12 +61,12 @@ std::string as_vcd_binary(
 
   // build "xxx"
 
-  const mp_integer width = pointer_offset_bits(type, ns);
+  const auto width = pointer_offset_bits(type, ns);
 
-  if(width>=0)
-    return std::string(integer2size_t(width), 'x');
-
-  return "";
+  if(width.has_value())
+    return std::string(integer2size_t(*width), 'x');
+  else
+    return "";
 }
 
 void output_vcd(
@@ -97,11 +97,12 @@ void output_vcd(
 
         const auto number=n.number(identifier);
 
-        const mp_integer width = pointer_offset_bits(type, ns);
+        const auto width = pointer_offset_bits(type, ns);
 
-        if(width>=1)
-          out << "$var reg " << width << " V" << number << " "
-              << identifier << " $end" << "\n";
+        if(width.has_value() && (*width) >= 1)
+          out << "$var reg " << (*width) << " V" << number << " " << identifier
+              << " $end"
+              << "\n";
       }
     }
   }

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -272,7 +272,9 @@ void goto_symext::symex_assign_symbol(
     log.debug(),
     [this, &ssa_lhs](messaget::mstreamt &mstream) {
       mstream << "Assignment to " << ssa_lhs.get_identifier()
-              << " [" << pointer_offset_bits(ssa_lhs.type(), ns) << " bits]"
+              << " ["
+              << pointer_offset_bits(ssa_lhs.type(), ns).value_or(0)
+              << " bits]"
               << messaget::eom;
     });
 

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -77,10 +77,10 @@ void goto_symext::symex_allocate(
       if(tmp_type.is_not_nil())
       {
         // Did the size get multiplied?
-        mp_integer elem_size=pointer_offset_size(tmp_type, ns);
+        auto elem_size = pointer_offset_size(tmp_type, ns);
         mp_integer alloc_size;
 
-        if(elem_size<0)
+        if(!elem_size.has_value() || *elem_size==0)
         {
         }
         else if(to_integer(tmp_size, alloc_size) &&
@@ -102,13 +102,13 @@ void goto_symext::symex_allocate(
         }
         else
         {
-          if(alloc_size==elem_size)
+          if(alloc_size == *elem_size)
             object_type=tmp_type;
           else
           {
-            mp_integer elements=alloc_size/elem_size;
+            mp_integer elements = alloc_size / (*elem_size);
 
-            if(elements*elem_size==alloc_size)
+            if(elements * (*elem_size) == alloc_size)
               object_type=array_typet(
                 tmp_type, from_integer(elements, tmp_size.type()));
           }

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -196,8 +196,9 @@ exprt goto_symext::address_arithmetic(
     if(expr.id()==ID_symbol &&
        expr.get_bool(ID_C_SSA_symbol))
     {
-      offset=compute_pointer_offset(expr, ns);
-      PRECONDITION(offset >= 0);
+      auto offset_opt = compute_pointer_offset(expr, ns);
+      PRECONDITION(offset_opt.has_value());
+      offset = *offset_opt;
     }
 
     if(offset>0)

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -255,7 +255,7 @@ void goto_symext::symex_goto(statet &state)
         log.debug(),
         [this, &new_lhs](messaget::mstreamt &mstream) {
           mstream << "Assignment to " << new_lhs.get_identifier()
-                  << " [" << pointer_offset_bits(new_lhs.type(), ns) << " bits]"
+                  << " [" << pointer_offset_bits(new_lhs.type(), ns).value_or(0) << " bits]"
                   << messaget::eom;
         });
 
@@ -489,7 +489,7 @@ void goto_symext::phi_function(
       log.debug(),
       [this, &new_lhs](messaget::mstreamt &mstream) {
         mstream << "Assignment to " << new_lhs.get_identifier()
-                << " [" << pointer_offset_bits(new_lhs.type(), ns) << " bits]"
+                << " [" << pointer_offset_bits(new_lhs.type(), ns).value_or(0) << " bits]"
                 << messaget::eom;
       });
 

--- a/src/solvers/flattening/boolbv_byte_extract.cpp
+++ b/src/solvers/flattening/boolbv_byte_extract.cpp
@@ -76,11 +76,14 @@ bvt boolbvt::convert_byte_extract(const byte_extract_exprt &expr)
 
   // see if the byte number is constant and within bounds, else work from the
   // root object
-  const mp_integer op_bytes = pointer_offset_size(expr.op().type(), ns);
+  const auto op_bytes_opt = pointer_offset_size(expr.op().type(), ns);
   auto index = numeric_cast<mp_integer>(expr.offset());
+
   if(
-    (!index.has_value() || (*index < 0 || *index >= op_bytes)) &&
-    (expr.op().id() == ID_member || expr.op().id() == ID_index ||
+    (!index.has_value() || !op_bytes_opt.has_value() ||
+     *index < 0 || *index >= *op_bytes_opt) &&
+    (expr.op().id() == ID_member ||
+     expr.op().id() == ID_index ||
      expr.op().id() == ID_byte_extract_big_endian ||
      expr.op().id() == ID_byte_extract_little_endian))
   {

--- a/src/solvers/flattening/boolbv_index.cpp
+++ b/src/solvers/flattening/boolbv_index.cpp
@@ -335,11 +335,13 @@ bvt boolbvt::convert_index(
     o.build(array, ns);
     CHECK_RETURN(o.offset().id() != ID_unknown);
 
-    const mp_integer subtype_bytes =
+    const auto subtype_bytes_opt =
       pointer_offset_size(array_type.subtype(), ns);
+    CHECK_RETURN(subtype_bytes_opt.has_value());
+
     exprt new_offset = simplify_expr(
       plus_exprt(
-        o.offset(), from_integer(index * subtype_bytes, o.offset().type())),
+        o.offset(), from_integer(index * (*subtype_bytes_opt), o.offset().type())),
       ns);
 
     byte_extract_exprt be(

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -136,11 +136,10 @@ bool bv_pointerst::convert_address_of_rec(
       UNREACHABLE;
 
     // get size
-    mp_integer size=
-      pointer_offset_size(array_type.subtype(), ns);
-    DATA_INVARIANT(size>0, "array subtype expected to have non-zero size");
+    auto size = pointer_offset_size(array_type.subtype(), ns);
+    CHECK_RETURN(size.has_value() && *size > 0);
 
-    offset_arithmetic(bv, size, index);
+    offset_arithmetic(bv, *size, index);
     CHECK_RETURN(bv.size()==bits);
     return false;
   }
@@ -171,13 +170,12 @@ bool bv_pointerst::convert_address_of_rec(
 
     if(struct_op_type.id()==ID_struct)
     {
-      mp_integer offset=member_offset(
-        to_struct_type(struct_op_type),
-        member_expr.get_component_name(), ns);
-      DATA_INVARIANT(offset>=0, "member offset expected to be positive");
+      auto offset = member_offset(
+        to_struct_type(struct_op_type), member_expr.get_component_name(), ns);
+      CHECK_RETURN(offset.has_value());
 
       // add offset
-      offset_arithmetic(bv, offset);
+      offset_arithmetic(bv, *offset);
     }
     else
     {
@@ -344,8 +342,9 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
         }
         else
         {
-          size = pointer_offset_size(pointer_sub_type, ns);
-          CHECK_RETURN(size > 0);
+          auto size_opt = pointer_offset_size(pointer_sub_type, ns);
+          CHECK_RETURN(size_opt.has_value() && *size_opt > 0);
+          size = *size_opt;
         }
       }
     }
@@ -426,8 +425,9 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
     }
     else
     {
-      element_size = pointer_offset_size(pointer_sub_type, ns);
-      DATA_INVARIANT(element_size > 0, "object size expected to be positive");
+      auto element_size_opt = pointer_offset_size(pointer_sub_type, ns);
+      CHECK_RETURN(element_size_opt.has_value() && *element_size_opt > 0);
+      element_size = *element_size_opt;
     }
 
     offset_arithmetic(bv, element_size, neg_op1);
@@ -504,14 +504,14 @@ bvt bv_pointerst::convert_bitvector(const exprt &expr)
     }
     else
     {
-      element_size = pointer_offset_size(pointer_sub_type, ns);
-      DATA_INVARIANT(element_size > 0, "object size expected to be positive");
+      auto element_size_opt = pointer_offset_size(pointer_sub_type, ns);
+      CHECK_RETURN(element_size_opt.has_value() && *element_size_opt > 0);
+      element_size = *element_size_opt;
     }
 
-    if(element_size!=1)
+    if(element_size != 1)
     {
-      bvt element_size_bv=
-        bv_utils.build_constant(element_size, bv.size());
+      bvt element_size_bv = bv_utils.build_constant(element_size, bv.size());
       bv=bv_utils.divider(
         bv, element_size_bv, bv_utilst::representationt::SIGNED);
     }

--- a/src/solvers/flattening/flatten_byte_operators.cpp
+++ b/src/solvers/flattening/flatten_byte_operators.cpp
@@ -48,7 +48,9 @@ static exprt unpack_rec(
     const array_typet &array_type=to_array_type(type);
     const typet &subtype=array_type.subtype();
 
-    mp_integer element_width=pointer_offset_bits(subtype, ns);
+    auto element_width = pointer_offset_bits(subtype, ns);
+    CHECK_RETURN(element_width.has_value());
+
     // this probably doesn't really matter
     #if 0
     INVARIANT(
@@ -62,7 +64,7 @@ static exprt unpack_rec(
       irep_pretty_diagnosticst(type));
     #endif
 
-    if(!unpack_byte_array && element_width==8)
+    if(!unpack_byte_array && *element_width == 8)
       return src;
 
     mp_integer num_elements;
@@ -100,12 +102,14 @@ static exprt unpack_rec(
 
     for(const auto &comp : components)
     {
-      mp_integer element_width=pointer_offset_bits(comp.type(), ns);
+      auto element_width = pointer_offset_bits(comp.type(), ns);
 
       // the next member would be misaligned, abort
-      if(element_width<=0 || element_width%8!=0)
+      if(
+        !element_width.has_value() || *element_width == 0 ||
+        *element_width % 8 != 0)
       {
-        throw non_byte_alignedt(struct_type, comp, element_width);
+        throw non_byte_alignedt(struct_type, comp, *element_width);
       }
 
       member_exprt member(src, comp.get_name(), comp.type());
@@ -119,8 +123,12 @@ static exprt unpack_rec(
   {
     // a basic type; we turn that into extractbits while considering
     // endianness
-    mp_integer bits=pointer_offset_bits(type, ns);
-    if(bits<0)
+    auto bits_opt = pointer_offset_bits(type, ns);
+    mp_integer bits;
+
+    if(bits_opt.has_value())
+      bits = *bits_opt;
+    else
     {
       if(to_integer(max_bytes, bits))
       {
@@ -228,12 +236,13 @@ exprt flatten_byte_extract(
     const array_typet &array_type=to_array_type(type);
     const typet &subtype=array_type.subtype();
 
-    mp_integer element_width=pointer_offset_bits(subtype, ns);
+    auto element_width = pointer_offset_bits(subtype, ns);
     mp_integer num_elements;
     // TODO: consider ways of dealing with arrays of unknown subtype
     // size or with a subtype size that does not fit byte boundaries
-    if(element_width>0 && element_width%8==0 &&
-       to_integer(array_type.size(), num_elements))
+    if(
+      element_width.has_value() && *element_width >= 1 &&
+      *element_width % 8 == 0 && to_integer(array_type.size(), num_elements))
     {
       array_exprt array(array_type);
 
@@ -241,7 +250,7 @@ exprt flatten_byte_extract(
       {
         plus_exprt new_offset(
           unpacked.offset(),
-          from_integer(i*element_width, unpacked.offset().type()));
+          from_integer(i * (*element_width), unpacked.offset().type()));
 
         byte_extract_exprt tmp(unpacked);
         tmp.type()=subtype;
@@ -263,10 +272,12 @@ exprt flatten_byte_extract(
 
     for(const auto &comp : components)
     {
-      mp_integer element_width=pointer_offset_bits(comp.type(), ns);
+      auto element_width = pointer_offset_bits(comp.type(), ns);
 
       // the next member would be misaligned, abort
-      if(element_width<=0 || element_width%8!=0)
+      if(
+        !element_width.has_value() || *element_width == 0 ||
+        *element_width % 8 != 0)
       {
         failed=true;
         break;
@@ -295,14 +306,17 @@ exprt flatten_byte_extract(
   const array_typet &array_type=to_array_type(root.type());
   const typet &subtype=array_type.subtype();
 
-  DATA_INVARIANT(pointer_offset_bits(subtype, ns)==8,
-                 "offset bits are byte aligned");
+  auto subtype_bits = pointer_offset_bits(subtype, ns);
 
-  mp_integer size_bits=pointer_offset_bits(unpacked.type(), ns);
-  if(size_bits<0)
+  DATA_INVARIANT(
+    subtype_bits.has_value() && *subtype_bits == 8,
+    "offset bits are byte aligned");
+
+  auto size_bits = pointer_offset_bits(unpacked.type(), ns);
+  if(!size_bits.has_value())
   {
-    mp_integer op0_bits=pointer_offset_bits(unpacked.op().type(), ns);
-    if(op0_bits<0)
+    auto op0_bits = pointer_offset_bits(unpacked.op().type(), ns);
+    if(op0_bits.has_value())
     {
       throw non_const_byte_extraction_sizet(unpacked);
     }
@@ -310,8 +324,8 @@ exprt flatten_byte_extract(
       size_bits=op0_bits;
   }
 
-  mp_integer num_elements=
-    size_bits/8+((size_bits%8==0)?0:1);
+  mp_integer num_elements =
+    (*size_bits) / 8 + (((*size_bits) % 8 == 0) ? 0 : 1);
 
   const typet &offset_type=ns.follow(offset.type());
 
@@ -346,14 +360,16 @@ exprt flatten_byte_update(
   const namespacet &ns,
   bool negative_offset)
 {
-  mp_integer element_size = pointer_offset_size(src.value().type(), ns);
+  const auto element_size_opt = pointer_offset_size(src.value().type(), ns);
 
   INVARIANT_WITH_DIAGNOSTICS(
-    element_size >= 0,
+    element_size_opt.has_value(),
     "size of type in bytes must be known",
     irep_pretty_diagnosticst(src));
 
-  const typet &t = ns.follow(src.op().type());
+  const mp_integer &element_size = *element_size_opt;
+
+  const typet &t=ns.follow(src.op0().type());
 
   if(t.id()==ID_array)
   {
@@ -367,11 +383,13 @@ exprt flatten_byte_update(
        subtype.id()==ID_c_bool ||
        subtype.id()==ID_pointer)
     {
-      mp_integer sub_size=pointer_offset_size(subtype, ns);
+      auto sub_size_opt = pointer_offset_size(subtype, ns);
 
       INVARIANT(
-        sub_size >= 0,
+        sub_size_opt.has_value(),
         "bit width (rounded to full bytes) of subtype must be known");
+
+      const mp_integer &sub_size = *sub_size_opt;
 
       // byte array?
       if(sub_size==1)
@@ -534,9 +552,9 @@ exprt flatten_byte_update(
           t.id()==ID_pointer)
   {
     // do a shift, mask and OR
-    mp_integer type_width=pointer_offset_bits(t, ns);
-    CHECK_RETURN(type_width > 0);
-    std::size_t width=integer2size_t(type_width);
+    const auto type_width = pointer_offset_bits(t, ns);
+    CHECK_RETURN(type_width.has_value() && *type_width > 0);
+    const std::size_t width = integer2size_t(*type_width);
 
     INVARIANT(
       element_size * 8 <= width,

--- a/src/solvers/flattening/pointer_logic.cpp
+++ b/src/solvers/flattening/pointer_logic.cpp
@@ -110,14 +110,13 @@ exprt pointer_logict::object_rec(
 {
   if(src.type().id()==ID_array)
   {
-    mp_integer size=
-      pointer_offset_size(src.type().subtype(), ns);
+    auto size = pointer_offset_size(src.type().subtype(), ns);
 
-    if(size<=0)
+    if(!size.has_value() || *size == 0)
       return src;
 
-    mp_integer index=offset/size;
-    mp_integer rest=offset%size;
+    mp_integer index = offset / (*size);
+    mp_integer rest = offset % (*size);
     if(rest<0)
       rest=-rest;
 
@@ -146,9 +145,10 @@ exprt pointer_logict::object_rec(
 
       const typet &subtype=c.type();
 
-      mp_integer sub_size=pointer_offset_size(subtype, ns);
-      CHECK_RETURN(sub_size > 0);
-      mp_integer new_offset=current_offset+sub_size;
+      const auto sub_size = pointer_offset_size(subtype, ns);
+      CHECK_RETURN(sub_size.has_value() && *sub_size != 0);
+
+      mp_integer new_offset = current_offset + *sub_size;
 
       if(new_offset>offset)
       {

--- a/src/solvers/lowering/popcount.cpp
+++ b/src/solvers/lowering/popcount.cpp
@@ -26,12 +26,12 @@ exprt lower_popcount(const popcount_exprt &expr, const namespacet &ns)
 
   // make sure the operand width is a power of two
   exprt x = expr.op();
-  const mp_integer x_width = pointer_offset_bits(x.type(), ns);
-  CHECK_RETURN(x_width > 0);
-  const std::size_t bits = address_bits(x_width);
+  const auto x_width = pointer_offset_bits(x.type(), ns);
+  CHECK_RETURN(x_width.has_value() && *x_width >= 1);
+  const std::size_t bits = address_bits(*x_width);
   const std::size_t new_width = integer2size_t(power(2, bits));
   const bool need_typecast =
-    new_width > x_width || x.type().id() != ID_unsignedbv;
+    new_width > *x_width || x.type().id() != ID_unsignedbv;
   if(need_typecast)
     x.make_typecast(unsignedbv_typet(new_width));
 

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -562,15 +562,15 @@ void smt2_convt::convert_address_of_rec(
 
     const irep_idt &component_name = member_expr.get_component_name();
 
-    mp_integer offset = member_offset(struct_type, component_name, ns);
-    CHECK_RETURN(offset >= 0);
+    const auto offset = member_offset(struct_type, component_name, ns);
+    CHECK_RETURN(offset.has_value() && *offset >= 0);
 
     unsignedbv_typet index_type(boolbv_width(result_type));
 
     // pointer arithmetic
     out << "(bvadd ";
     convert_address_of_rec(struct_op, result_type);
-    convert_expr(from_integer(offset, index_type));
+    convert_expr(from_integer(*offset, index_type));
     out << ")"; // bvadd
   }
   else if(expr.id()==ID_if)
@@ -3033,18 +3033,18 @@ void smt2_convt::convert_plus(const plus_exprt &expr)
         p.type().id() == ID_pointer,
         "one of the operands should have pointer type");
 
-      mp_integer element_size = pointer_offset_size(expr.type().subtype(), ns);
-      CHECK_RETURN(element_size > 0);
+      const auto element_size = pointer_offset_size(expr.type().subtype(), ns);
+      CHECK_RETURN(element_size.has_value() && *element_size >= 1);
 
       out << "(bvadd ";
       convert_expr(p);
       out << " ";
 
-      if(element_size >= 2)
+      if(*element_size >= 2)
       {
         out << "(bvmul ";
         convert_expr(i);
-        out << " (_ bv" << element_size << " " << boolbv_width(expr.type())
+        out << " (_ bv" << *element_size << " " << boolbv_width(expr.type())
             << "))";
       }
       else
@@ -3212,12 +3212,11 @@ void smt2_convt::convert_minus(const minus_exprt &expr)
     if(expr.op0().type().id()==ID_pointer &&
        expr.op1().type().id()==ID_pointer)
     {
-      // Pointer difference.
-      mp_integer element_size=
-        pointer_offset_size(expr.op0().type().subtype(), ns);
-      CHECK_RETURN(element_size > 0);
+      // Pointer difference
+      auto element_size = pointer_offset_size(expr.op0().type().subtype(), ns);
+      CHECK_RETURN(element_size.has_value() && *element_size >= 1);
 
-      if(element_size>=2)
+      if(*element_size >= 2)
         out << "(bvsdiv ";
 
       INVARIANT(
@@ -3231,9 +3230,9 @@ void smt2_convt::convert_minus(const minus_exprt &expr)
       convert_expr(expr.op1());
       out << ")";
 
-      if(element_size>=2)
-        out << " (_ bv" << element_size
-            << " " << boolbv_width(expr.type()) << "))";
+      if(*element_size >= 2)
+        out << " (_ bv" << *element_size << " " << boolbv_width(expr.type())
+            << "))";
     }
     else
     {
@@ -3853,12 +3852,13 @@ void smt2_convt::convert_member(const member_exprt &expr)
     {
       // we extract
       std::size_t member_width=boolbv_width(expr.type());
-      mp_integer member_offset=::member_offset(struct_type, name, ns);
-      CHECK_RETURN_WITH_DIAGNOSTICS(
-        member_offset != -1, "failed to get struct member offset");
+      const auto member_offset = ::member_offset(struct_type, name, ns);
 
-      out << "((_ extract " << (member_offset*8+member_width-1)
-          << " " << member_offset*8 << ") ";
+      CHECK_RETURN_WITH_DIAGNOSTICS(
+        member_offset.has_value(), "failed to get struct member offset");
+
+      out << "((_ extract " << ((*member_offset) * 8 + member_width - 1) << " "
+          << (*member_offset) * 8 << ") ";
       convert_expr(struct_op);
       out << ")";
     }

--- a/src/util/endianness_map.cpp
+++ b/src/util/endianness_map.cpp
@@ -37,11 +37,12 @@ void endianness_mapt::build(const typet &src, bool little_endian)
 
 void endianness_mapt::build_little_endian(const typet &src)
 {
-  mp_integer s=pointer_offset_bits(src, ns); // error is -1
-  if(s<=0)
+  auto s = pointer_offset_bits(src, ns);
+
+  if(!s.has_value())
     return;
 
-  std::size_t new_size=map.size()+integer2size_t(s);
+  std::size_t new_size = map.size() + integer2size_t(*s);
   map.reserve(new_size);
 
   for(std::size_t i=map.size(); i<new_size; ++i)
@@ -62,10 +63,10 @@ void endianness_mapt::build_big_endian(const typet &src)
           src.id()==ID_c_bit_field)
   {
     // these do get re-ordered!
-    mp_integer bits=pointer_offset_bits(src, ns); // error is -1
-    CHECK_RETURN(bits>=0);
+    auto bits = pointer_offset_bits(src, ns); // error is -1
+    CHECK_RETURN(bits.has_value());
 
-    size_t bits_int=integer2size_t(bits), base=map.size();
+    size_t bits_int = integer2size_t(*bits), base = map.size();
 
     for(size_t bit=0; bit<bits_int; bit++)
     {
@@ -115,11 +116,12 @@ void endianness_mapt::build_big_endian(const typet &src)
   {
     // everything else (unions in particular)
     // is treated like a byte-array
-    mp_integer s=pointer_offset_bits(src, ns); // error is -1
-    if(s<=0)
+    auto s = pointer_offset_bits(src, ns); // error is -1
+
+    if(!s.has_value())
       return;
 
-    std::size_t new_size=map.size()+integer2size_t(s);
+    std::size_t new_size = map.size() + integer2size_t(*s);
     map.reserve(new_size);
 
     for(std::size_t i=map.size(); i<new_size; ++i)

--- a/src/util/expr_initializer.cpp
+++ b/src/util/expr_initializer.cpp
@@ -254,13 +254,13 @@ exprt expr_initializert<nondet>::expr_initializer_rec(
       if(c.type().id() == ID_code)
         continue;
 
-      mp_integer bits = pointer_offset_bits(c.type(), ns);
+      auto bits = pointer_offset_bits(c.type(), ns);
 
-      if(bits>component_size)
+      if(bits.has_value() && *bits > component_size)
       {
         component = c;
         found=true;
-        component_size=bits;
+        component_size = *bits;
       }
     }
 

--- a/src/util/pointer_offset_size.h
+++ b/src/util/pointer_offset_size.h
@@ -12,8 +12,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_POINTER_OFFSET_SIZE_H
 #define CPROVER_UTIL_POINTER_OFFSET_SIZE_H
 
-#include "mp_arith.h"
 #include "irep.h"
+#include "mp_arith.h"
+#include "optional.h"
 
 class exprt;
 class namespacet;
@@ -22,7 +23,7 @@ class typet;
 class member_exprt;
 class constant_exprt;
 
-// these return -1 on failure
+// these return 'nullopt' on failure
 
 // NOLINTNEXTLINE(readability/identifiers)
 class member_offset_iterator
@@ -40,27 +41,24 @@ public:
   const refst* operator->() const { return &current; }
 };
 
-mp_integer member_offset(
+optionalt<mp_integer> member_offset(
   const struct_typet &type,
   const irep_idt &member,
   const namespacet &ns);
 
-mp_integer member_offset_bits(
+optionalt<mp_integer> member_offset_bits(
   const struct_typet &type,
   const irep_idt &member,
   const namespacet &ns);
 
-mp_integer pointer_offset_size(
-  const typet &type,
-  const namespacet &ns);
+optionalt<mp_integer>
+pointer_offset_size(const typet &type, const namespacet &ns);
 
-mp_integer pointer_offset_bits(
-  const typet &type,
-  const namespacet &ns);
+optionalt<mp_integer>
+pointer_offset_bits(const typet &type, const namespacet &ns);
 
-mp_integer compute_pointer_offset(
-  const exprt &expr,
-  const namespacet &ns);
+optionalt<mp_integer>
+compute_pointer_offset(const exprt &expr, const namespacet &ns);
 
 // these return 'nil' on failure
 

--- a/src/util/simplify_expr_array.cpp
+++ b/src/util/simplify_expr_array.cpp
@@ -190,12 +190,12 @@ bool simplify_exprt::simplify_index(exprt &expr)
       // This rewrites byte_extract(s, o, array_type)[i]
       // to byte_extract(s, o+offset, sub_type)
 
-      mp_integer sub_size=pointer_offset_size(array_type.subtype(), ns);
-      if(sub_size==-1)
+      auto sub_size = pointer_offset_size(array_type.subtype(), ns);
+      if(!sub_size.has_value())
         return true;
 
       // add offset to index
-      mult_exprt offset(from_integer(sub_size, array.op1().type()), index);
+      mult_exprt offset(from_integer(*sub_size, array.op1().type()), index);
       plus_exprt final_offset(array.op1(), offset);
       simplify_node(final_offset);
 

--- a/src/util/simplify_expr_struct.cpp
+++ b/src/util/simplify_expr_struct.cpp
@@ -156,12 +156,12 @@ bool simplify_exprt::simplify_member(exprt &expr)
         return true;
 
       // add member offset to index
-      mp_integer offset_int=member_offset(struct_type, component_name, ns);
-      if(offset_int==-1)
+      auto offset_int = member_offset(struct_type, component_name, ns);
+      if(!offset_int.has_value())
         return true;
 
       const exprt &struct_offset=op.op1();
-      exprt member_offset=from_integer(offset_int, struct_offset.type());
+      exprt member_offset = from_integer(*offset_int, struct_offset.type());
       plus_exprt final_offset(struct_offset, member_offset);
       simplify_node(final_offset);
 
@@ -203,12 +203,11 @@ bool simplify_exprt::simplify_member(exprt &expr)
     }
 
     // need to convert!
-    mp_integer target_size=
-      pointer_offset_size(expr.type(), ns);
+    auto target_size = pointer_offset_size(expr.type(), ns);
 
-    if(target_size!=-1)
+    if(target_size.has_value())
     {
-      mp_integer target_bits=target_size*8;
+      mp_integer target_bits = target_size.value() * 8;
       const auto bits=expr2bits(op, true);
 
       if(bits.has_value() &&


### PR DESCRIPTION
This removes another case of using -1 as 'error value': pointer_offset_size and variants.