### PR TITLE
Make mode an argument of goto convert methods

### DIFF
--- a/src/goto-instrument/model_argc_argv.cpp
+++ b/src/goto-instrument/model_argc_argv.cpp
@@ -143,7 +143,8 @@ bool model_argc_argv(
     to_code(value),
     goto_model.symbol_table,
     init_instructions,
-    message_handler);
+    message_handler,
+    main_symbol.mode);
 
   Forall_goto_program_instructions(it, init_instructions)
   {

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -438,7 +438,7 @@ void goto_convertt::do_cpp_new(
       count.make_typecast(object_size.type());
 
     // might have side-effect
-    clean_expr(count, dest);
+    clean_expr(count, dest, ID_cpp);
   }
 
   exprt tmp_symbol_expr;
@@ -473,7 +473,7 @@ void goto_convertt::do_cpp_new(
     new_call.lhs()=tmp_symbol_expr;
     new_call.add_source_location()=rhs.source_location();
 
-    convert(new_call, dest);
+    convert(new_call, dest, ID_cpp);
   }
   else if(rhs.operands().size()==1)
   {
@@ -509,7 +509,7 @@ void goto_convertt::do_cpp_new(
       if(new_call.arguments()[i].type()!=code_type.parameters()[i].type())
         new_call.arguments()[i].make_typecast(code_type.parameters()[i].type());
 
-    convert(new_call, dest);
+    convert(new_call, dest, ID_cpp);
   }
   else
   {
@@ -551,7 +551,7 @@ void goto_convertt::cpp_new_initializer(
       const dereference_exprt deref_lhs(lhs, rhs.type().subtype());
 
       replace_new_object(deref_lhs, initializer);
-      convert(to_code(initializer), dest);
+      convert(to_code(initializer), dest, ID_cpp);
     }
     else
       UNREACHABLE;

--- a/src/goto-programs/convert_nondet.cpp
+++ b/src/goto-programs/convert_nondet.cpp
@@ -35,7 +35,8 @@ static goto_programt::targett insert_nondet_init_code(
   const goto_programt::targett &target,
   symbol_table_baset &symbol_table,
   message_handlert &message_handler,
-  const object_factory_parameterst &object_factory_parameters)
+  const object_factory_parameterst &object_factory_parameters,
+  const irep_idt &mode)
 {
   // Return if the instruction isn't an assignment
   const auto next_instr=std::next(target);
@@ -96,7 +97,8 @@ static goto_programt::targett insert_nondet_init_code(
 
   // Convert this code into goto instructions
   goto_programt new_instructions;
-  goto_convert(init_code, symbol_table, new_instructions, message_handler);
+  goto_convert(
+    init_code, symbol_table, new_instructions, message_handler, mode);
 
   // Insert the new instructions into the instruction list
   goto_program.destructive_insert(next_instr, new_instructions);
@@ -116,25 +118,28 @@ void convert_nondet(
   goto_programt &goto_program,
   symbol_table_baset &symbol_table,
   message_handlert &message_handler,
-  const object_factory_parameterst &object_factory_parameters)
+  const object_factory_parameterst &object_factory_parameters,
+  const irep_idt &mode)
 {
   for(auto instruction_iterator=goto_program.instructions.begin(),
         end=goto_program.instructions.end();
       instruction_iterator!=end;)
   {
-    instruction_iterator=insert_nondet_init_code(
+    instruction_iterator = insert_nondet_init_code(
       goto_program,
       instruction_iterator,
       symbol_table,
       message_handler,
-      object_factory_parameters);
+      object_factory_parameters,
+      mode);
   }
 }
 
 void convert_nondet(
   goto_model_functiont &function,
   message_handlert &message_handler,
-  const object_factory_parameterst &object_factory_parameters)
+  const object_factory_parameterst &object_factory_parameters,
+  const irep_idt &mode)
 {
   object_factory_parameterst parameters = object_factory_parameters;
   parameters.function_id = function.get_function_id();
@@ -142,7 +147,8 @@ void convert_nondet(
     function.get_goto_function().body,
     function.get_symbol_table(),
     message_handler,
-    parameters);
+    parameters,
+    mode);
 
   function.compute_location_numbers();
 }
@@ -167,7 +173,8 @@ void convert_nondet(
         f_it.second.body,
         symbol_table,
         message_handler,
-        object_factory_parameters);
+        object_factory_parameters,
+        symbol.mode);
     }
   }
 

--- a/src/goto-programs/convert_nondet.h
+++ b/src/goto-programs/convert_nondet.h
@@ -13,6 +13,7 @@ Author: Reuben Thomas, reuben.thomas@diffblue.com
 #define CPROVER_GOTO_PROGRAMS_CONVERT_NONDET_H
 
 #include <cstddef> // size_t
+#include <util/irep.h>
 
 class goto_functionst;
 class symbol_table_baset;
@@ -48,6 +49,7 @@ void convert_nondet(
 void convert_nondet(
   goto_model_functiont &function,
   message_handlert &message_handler,
-  const object_factory_parameterst &object_factory_parameters);
+  const object_factory_parameterst &object_factory_parameters,
+  const irep_idt &mode);
 
 #endif

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -2105,6 +2105,7 @@ symbolt &goto_convertt::new_tmp_symbol(
   const source_locationt &source_location,
   const irep_idt &mode)
 {
+  PRECONDITION(!mode.empty());
   symbolt &new_symbol = get_fresh_aux_symbol(
     type,
     tmp_symbol_prefix,

--- a/src/goto-programs/goto_convert.h
+++ b/src/goto-programs/goto_convert.h
@@ -22,7 +22,8 @@ void goto_convert(
   const codet &code,
   symbol_table_baset &symbol_table,
   goto_programt &dest,
-  message_handlert &message_handler);
+  message_handlert &message_handler,
+  const irep_idt &mode);
 
 // start from "main"
 void goto_convert(

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -26,7 +26,8 @@ Author: Daniel Kroening, kroening@kroening.com
 class goto_convertt:public messaget
 {
 public:
-  void goto_convert(const codet &code, goto_programt &dest);
+  void
+  goto_convert(const codet &code, goto_programt &dest, const irep_idt &mode);
 
   goto_convertt(
     symbol_table_baset &_symbol_table,
@@ -47,7 +48,10 @@ protected:
   namespacet ns;
   std::string tmp_symbol_prefix;
 
-  void goto_convert_rec(const codet &code, goto_programt &dest);
+  void goto_convert_rec(
+    const codet &code,
+    goto_programt &dest,
+    const irep_idt &mode);
 
   //
   // tools for symbols
@@ -64,7 +68,8 @@ protected:
 
   symbol_exprt make_compound_literal(
     const exprt &expr,
-    goto_programt &dest);
+    goto_programt &dest,
+    const irep_idt &mode);
 
   //
   // translation of C expressions (with side effects)
@@ -74,18 +79,19 @@ protected:
   void clean_expr(
     exprt &expr,
     goto_programt &dest,
-    bool result_is_used=true);
+    const irep_idt &mode,
+    bool result_is_used = true);
 
-  void clean_expr_address_of(
-    exprt &expr,
-    goto_programt &dest);
+  void
+  clean_expr_address_of(exprt &expr, goto_programt &dest, const irep_idt &mode);
 
   static bool needs_cleaning(const exprt &expr);
 
   void make_temp_symbol(
     exprt &expr,
     const std::string &suffix,
-    goto_programt &);
+    goto_programt &,
+    const irep_idt &mode);
 
   void rewrite_boolean(exprt &dest);
 
@@ -95,22 +101,27 @@ protected:
   void remove_side_effect(
     side_effect_exprt &expr,
     goto_programt &dest,
+    const irep_idt &mode,
     bool result_is_used);
   void remove_assignment(
     side_effect_exprt &expr,
     goto_programt &dest,
-    bool result_is_used);
+    bool result_is_used,
+    const irep_idt &mode);
   void remove_pre(
     side_effect_exprt &expr,
     goto_programt &dest,
-    bool result_is_used);
+    bool result_is_used,
+    const irep_idt &mode);
   void remove_post(
     side_effect_exprt &expr,
     goto_programt &dest,
+    const irep_idt &mode,
     bool result_is_used);
   void remove_function_call(
     side_effect_exprt &expr,
     goto_programt &dest,
+    const irep_idt &mode,
     bool result_is_used);
   void remove_cpp_new(
     side_effect_exprt &expr,
@@ -123,6 +134,7 @@ protected:
   void remove_malloc(
     side_effect_exprt &expr,
     goto_programt &dest,
+    const irep_idt &mode,
     bool result_is_used);
   void remove_temporary_object(
     side_effect_exprt &expr,
@@ -131,10 +143,12 @@ protected:
   void remove_statement_expression(
     side_effect_exprt &expr,
     goto_programt &dest,
+    const irep_idt &mode,
     bool result_is_used);
   void remove_gcc_conditional_expression(
     exprt &expr,
-    goto_programt &dest);
+    goto_programt &dest,
+    const irep_idt &mode);
 
   virtual void do_cpp_new(
     const exprt &lhs,
@@ -168,13 +182,15 @@ protected:
     const exprt &lhs,
     const exprt &function,
     const exprt::operandst &arguments,
-    goto_programt &dest);
+    goto_programt &dest,
+    const irep_idt &mode);
 
   virtual void do_function_call_if(
     const exprt &lhs,
     const if_exprt &function,
     const exprt::operandst &arguments,
-    goto_programt &dest);
+    goto_programt &dest,
+    const irep_idt &mode);
 
   virtual void do_function_call_symbol(
     const exprt &lhs,
@@ -195,35 +211,87 @@ protected:
   //
   // conversion
   //
-  void convert_block(const code_blockt &code, goto_programt &dest);
-  void convert_decl(const code_declt &code, goto_programt &dest);
+  void convert_block(
+    const code_blockt &code,
+    goto_programt &dest,
+    const irep_idt &mode);
+  void convert_decl(
+    const code_declt &code,
+    goto_programt &dest,
+    const irep_idt &mode);
   void convert_decl_type(const codet &code, goto_programt &dest);
-  void convert_expression(const code_expressiont &code, goto_programt &dest);
-  void convert_assign(const code_assignt &code, goto_programt &dest);
+  void convert_expression(
+    const code_expressiont &code,
+    goto_programt &dest,
+    const irep_idt &mode);
+  void convert_assign(
+    const code_assignt &code,
+    goto_programt &dest,
+    const irep_idt &mode);
   void convert_cpp_delete(const codet &code, goto_programt &dest);
-  void convert_loop_invariant(const codet &code, goto_programt::targett loop);
-  void convert_for(const code_fort &code, goto_programt &dest);
-  void convert_while(const code_whilet &code, goto_programt &dest);
-  void convert_dowhile(const codet &code, goto_programt &dest);
-  void convert_assume(const code_assumet &code, goto_programt &dest);
-  void convert_assert(const code_assertt &code, goto_programt &dest);
-  void convert_switch(const code_switcht &code, goto_programt &dest);
-  void convert_break(const code_breakt &code, goto_programt &dest);
-  void convert_return(const code_returnt &code, goto_programt &dest);
-  void convert_continue(const code_continuet &code, goto_programt &dest);
-  void convert_ifthenelse(const code_ifthenelset &code, goto_programt &dest);
-  void convert_init(const codet &code, goto_programt &dest);
+  void convert_loop_invariant(
+    const codet &code,
+    goto_programt::targett loop,
+    const irep_idt &mode);
+  void
+  convert_for(const code_fort &code, goto_programt &dest, const irep_idt &mode);
+  void convert_while(
+    const code_whilet &code,
+    goto_programt &dest,
+    const irep_idt &mode);
+  void
+  convert_dowhile(const codet &code, goto_programt &dest, const irep_idt &mode);
+  void convert_assume(
+    const code_assumet &code,
+    goto_programt &dest,
+    const irep_idt &mode);
+  void convert_assert(
+    const code_assertt &code,
+    goto_programt &dest,
+    const irep_idt &mode);
+  void convert_switch(
+    const code_switcht &code,
+    goto_programt &dest,
+    const irep_idt &mode);
+  void convert_break(
+    const code_breakt &code,
+    goto_programt &dest,
+    const irep_idt &mode);
+  void convert_return(
+    const code_returnt &code,
+    goto_programt &dest,
+    const irep_idt &mode);
+  void convert_continue(
+    const code_continuet &code,
+    goto_programt &dest,
+    const irep_idt &mode);
+  void convert_ifthenelse(
+    const code_ifthenelset &code,
+    goto_programt &dest,
+    const irep_idt &mode);
+  void
+  convert_init(const codet &code, goto_programt &dest, const irep_idt &mode);
   void convert_goto(const codet &code, goto_programt &dest);
   void convert_gcc_computed_goto(const codet &code, goto_programt &dest);
   void convert_skip(const codet &code, goto_programt &dest);
   void convert_non_deterministic_goto(const codet &code, goto_programt &dest);
-  void convert_label(const code_labelt &code, goto_programt &dest);
+  void convert_label(
+    const code_labelt &code,
+    goto_programt &dest,
+    const irep_idt &mode);
   void convert_gcc_local_label(const codet &code, goto_programt &dest);
-  void convert_switch_case(const code_switch_caset &code, goto_programt &dest);
-  void convert_gcc_switch_case_range(const codet &code, goto_programt &dest);
+  void convert_switch_case(
+    const code_switch_caset &code,
+    goto_programt &dest,
+    const irep_idt &mode);
+  void convert_gcc_switch_case_range(
+    const codet &code,
+    goto_programt &dest,
+    const irep_idt &mode);
   void convert_function_call(
     const code_function_callt &code,
-    goto_programt &dest);
+    goto_programt &dest,
+    const irep_idt &mode);
   void convert_specc_notify(const codet &code, goto_programt &dest);
   void convert_specc_wait(const codet &code, goto_programt &dest);
   void convert_specc_par(const codet &code, goto_programt &dest);
@@ -233,16 +301,37 @@ protected:
   void convert_end_thread(const codet &code, goto_programt &dest);
   void convert_atomic_begin(const codet &code, goto_programt &dest);
   void convert_atomic_end(const codet &code, goto_programt &dest);
-  void convert_msc_try_finally(const codet &code, goto_programt &dest);
-  void convert_msc_try_except(const codet &code, goto_programt &dest);
-  void convert_msc_leave(const codet &code, goto_programt &dest);
-  void convert_try_catch(const codet &code, goto_programt &dest);
-  void convert_CPROVER_try_catch(const codet &code, goto_programt &dest);
-  void convert_CPROVER_try_finally(const codet &code, goto_programt &dest);
-  void convert_CPROVER_throw(const codet &code, goto_programt &dest);
+  void convert_msc_try_finally(
+    const codet &code,
+    goto_programt &dest,
+    const irep_idt &mode);
+  void convert_msc_try_except(
+    const codet &code,
+    goto_programt &dest,
+    const irep_idt &mode);
+  void convert_msc_leave(
+    const codet &code,
+    goto_programt &dest,
+    const irep_idt &mode);
+  void convert_try_catch(
+    const codet &code,
+    goto_programt &dest,
+    const irep_idt &mode);
+  void convert_CPROVER_try_catch(
+    const codet &code,
+    goto_programt &dest,
+    const irep_idt &mode);
+  void convert_CPROVER_try_finally(
+    const codet &code,
+    goto_programt &dest,
+    const irep_idt &mode);
+  void convert_CPROVER_throw(
+    const codet &code,
+    goto_programt &dest,
+    const irep_idt &mode);
   void convert_asm(const code_asmt &code, goto_programt &dest);
 
-  void convert(const codet &code, goto_programt &dest);
+  void convert(const codet &code, goto_programt &dest, const irep_idt &mode);
 
   void copy(
     const codet &code,
@@ -259,18 +348,20 @@ protected:
   void unwind_destructor_stack(
     const source_locationt &,
     std::size_t stack_size,
-    goto_programt &dest);
+    goto_programt &dest,
+    const irep_idt &mode);
   void unwind_destructor_stack(
     const source_locationt &,
     std::size_t stack_size,
     goto_programt &dest,
-    destructor_stackt &stack);
+    destructor_stackt &stack,
+    const irep_idt &mode);
 
   //
   // gotos
   //
 
-  void finish_gotos(goto_programt &dest);
+  void finish_gotos(goto_programt &dest, const irep_idt &mode);
   void finish_computed_gotos(goto_programt &dest);
   void finish_guarded_gotos(goto_programt &dest);
 
@@ -481,7 +572,8 @@ protected:
     goto_programt &true_case,
     goto_programt &false_case,
     const source_locationt &,
-    goto_programt &dest);
+    goto_programt &dest,
+    const irep_idt &mode);
 
   // if(guard) goto target_true; else goto target_false;
   void generate_conditional_branch(
@@ -489,14 +581,16 @@ protected:
     goto_programt::targett target_true,
     goto_programt::targett target_false,
     const source_locationt &,
-    goto_programt &dest);
+    goto_programt &dest,
+    const irep_idt &mode);
 
   // if(guard) goto target;
   void generate_conditional_branch(
     const exprt &guard,
     goto_programt::targett target_true,
     const source_locationt &,
-    goto_programt &dest);
+    goto_programt &dest,
+    const irep_idt &mode);
 
   // turn a OP b OP c into a list a, b, c
   static void collect_operands(
@@ -507,7 +601,8 @@ protected:
   // START_THREAD; ... END_THREAD;
   void generate_thread_block(
     const code_blockt &thread_body,
-    goto_programt &dest);
+    goto_programt &dest,
+    const irep_idt &mode);
 
   //
   // misc

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -141,6 +141,7 @@ void goto_convert_functionst::convert_function(
   goto_functionst::goto_functiont &f)
 {
   const symbolt &symbol=ns.lookup(identifier);
+  const irep_idt mode = symbol.mode;
 
   if(f.body_available())
     return; // already converted
@@ -184,7 +185,7 @@ void goto_convert_functionst::convert_function(
     f.type.return_type().id()!=ID_constructor &&
     f.type.return_type().id()!=ID_destructor;
 
-  goto_convert_rec(code, f.body);
+  goto_convert_rec(code, f.body, mode);
 
   // add non-det return value, if needed
   if(targets.has_return_value)

--- a/src/java_bytecode/remove_java_new.cpp
+++ b/src/java_bytecode/remove_java_new.cpp
@@ -309,7 +309,7 @@ goto_programt::targett remove_java_newt::lower_java_new_array(
     for_loop.iter() = inc;
     for_loop.body() = for_body;
 
-    goto_convert(for_loop, symbol_table, tmp, get_message_handler());
+    goto_convert(for_loop, symbol_table, tmp, get_message_handler(), ID_java);
 
     // lower new side effects recursively
     lower_java_new(tmp);

--- a/src/jbmc/jbmc_parse_options.cpp
+++ b/src/jbmc/jbmc_parse_options.cpp
@@ -756,10 +756,7 @@ void jbmc_parse_optionst::process_goto_function(
         ? std::stoul(cmdline.get_value("java-max-input-tree-depth"))
         : MAX_NONDET_TREE_DEPTH;
 
-    convert_nondet(
-      function,
-      get_message_handler(),
-      factory_params);
+    convert_nondet(function, get_message_handler(), factory_params, ID_java);
 
     // add generic checks
     goto_check(ns, options, ID_java, function.get_goto_function());


### PR DESCRIPTION
This passes the mode as an argument of these functions instead of trying
to deduce it from the expression.
This avoids creating symbols with empty mode which can lead to problems
in later stages of the analysis.