### PR TITLE
Handle empty structs in the back-end (and a number of induced fixes)

### DIFF
--- a/regression/cbmc/Empty_struct2/main.c
+++ b/regression/cbmc/Empty_struct2/main.c
@@ -1,0 +1,26 @@
+#include <assert.h>
+
+struct empty
+{
+};
+
+#pragma pack(1)
+struct S
+{
+  char x;
+  struct empty e;
+  char y;
+};
+#pragma pack()
+
+int main()
+{
+  struct S s;
+  assert(sizeof(struct S) == 2);
+
+  struct empty *p = &s.e;
+
+  assert(p == (char *)&s + 1);
+
+  return 0;
+}

--- a/regression/cbmc/Empty_struct2/test.desc
+++ b/regression/cbmc/Empty_struct2/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -29,6 +29,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/options.h>
 #include <util/pointer_offset_size.h>
 #include <util/pointer_predicates.h>
+#include <util/simplify_expr.h>
 #include <util/ssa_expr.h>
 
 // global data, horrible
@@ -471,6 +472,8 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
       // try to build a member/index expression - do not use byte_extract
       exprt subexpr = get_subexpression_at_offset(
         root_object_subexpression, o.offset(), dereference_type, ns);
+      if(subexpr.is_not_nil())
+        simplify(subexpr, ns);
       if(subexpr.is_not_nil() && subexpr.id() != byte_extract_id())
       {
         // Successfully found a member, array index, or combination thereof

--- a/src/solvers/flattening/pointer_logic.h
+++ b/src/solvers/flattening/pointer_logic.h
@@ -78,11 +78,6 @@ protected:
   exprt pointer_expr(
     const mp_integer &offset,
     const exprt &object) const;
-
-  exprt object_rec(
-    const mp_integer &offset,
-    const typet &pointer_type,
-    const exprt &src) const;
 };
 
 #endif // CPROVER_SOLVERS_FLATTENING_POINTER_LOGIC_H

--- a/src/util/pointer_offset_size.cpp
+++ b/src/util/pointer_offset_size.cpp
@@ -722,12 +722,11 @@ exprt get_subexpression_at_offset(
     }
   }
 
-  const byte_extract_exprt be(
+  return byte_extract_exprt(
     byte_extract_id(),
     expr,
     from_integer(offset_bytes, index_type()),
     target_type_raw);
-  return simplify_expr(be, ns);
 }
 
 exprt get_subexpression_at_offset(


### PR DESCRIPTION
I will need to break this PR apart, but I'll publish it in full for visibility. My original intent was just to fix the problem didn't handle empty structs (regression test included), which causes unnecessary failures in SV-COMP.

While I will split it up to enable reasonable reviewing, it should actually be clean and be ready for an evaluation against test-gen.