### PR TITLE
Add dashboard webhooks to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -286,3 +286,14 @@ script:
 
 before_cache:
   - ccache -s
+
+notifications:
+  webhooks:
+    urls:
+      - http://dashboard.diffblue.com/api/travis-webhooks
+    on_success: always
+    on_failure: always
+    on_start: never
+    on_cancel: never
+    on_error: always
+    


### PR DESCRIPTION
The dashboard is going to be updated to use webhooks. This commit enables travis webhooks for firebase.