### PR TITLE
Introduce expression/type formatting functor

### DIFF
--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -13,7 +13,7 @@ Author: Peter Schrammel
 
 #ifdef DEBUG
 #include <iostream>
-#include <util/format_expr.h>
+#include <util/formatter.h>
 #endif
 
 #include <util/ieee_float.h>
@@ -223,7 +223,7 @@ bool constant_propagator_domaint::two_way_propagate_rec(
   const namespacet &ns)
 {
 #ifdef DEBUG
-  std::cout << "two_way_propagate_rec: " << format(expr) << '\n';
+  std::cout << "two_way_propagate_rec: " << debug_formatter(expr) << '\n';
 #endif
 
   bool change=false;

--- a/src/ansi-c/Makefile
+++ b/src/ansi-c/Makefile
@@ -2,6 +2,7 @@ SRC = anonymous_member.cpp \
       ansi_c_convert_type.cpp \
       ansi_c_declaration.cpp \
       ansi_c_entry_point.cpp \
+      ansi_c_formatter.cpp \
       ansi_c_internal_additions.cpp \
       ansi_c_language.cpp \
       ansi_c_lex.yy.cpp \

--- a/src/ansi-c/ansi_c_formatter.cpp
+++ b/src/ansi-c/ansi_c_formatter.cpp
@@ -1,0 +1,29 @@
+/*******************************************************************\
+
+Module:
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#include "ansi_c_formatter.h"
+
+#include "expr2c.h"
+
+#include <ostream>
+
+std::ostream &ansi_c_formattert::format(std::ostream &os, const exprt &expr)
+{
+  return os << expr2c(expr, ns);
+}
+
+std::ostream &ansi_c_formattert::format(std::ostream &os, const typet &type)
+{
+  return os << type2c(type, ns);
+}
+
+std::ostream &
+ansi_c_formattert::format(std::ostream &os, const source_locationt &loc)
+{
+  return os << loc;
+}

--- a/src/ansi-c/ansi_c_formatter.h
+++ b/src/ansi-c/ansi_c_formatter.h
@@ -1,0 +1,28 @@
+/*******************************************************************\
+
+Module:
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_ANSI_C_FORMATTER_H
+#define CPROVER_ANSI_C_FORMATTER_H
+
+#include <util/formatter.h>
+
+class ansi_c_formattert : public formattert
+{
+public:
+  explicit ansi_c_formattert(const namespacet &_ns) : ns(_ns)
+  {
+  }
+
+  std::ostream &format(std::ostream &, const exprt &) override;
+  std::ostream &format(std::ostream &, const typet &) override;
+  std::ostream &format(std::ostream &, const source_locationt &) override;
+
+  const namespacet &ns;
+};
+
+#endif // CPROVER_ANSI_C_FORMATTER_H

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -25,6 +25,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <langapi/language.h>
 
 #include <ansi-c/c_preprocess.h>
+#include <ansi-c/ansi_c_formatter.h>
 
 #include <goto-programs/adjust_float_expressions.h>
 #include <goto-programs/initialize_goto_model.h>
@@ -595,7 +596,9 @@ int cbmc_parse_optionst::get_goto_program(
 
     if(cmdline.isset("show-symbol-table"))
     {
-      show_symbol_table(goto_model, ui_message_handler.get_ui());
+      namespacet ns(goto_model.symbol_table);
+      ansi_c_formattert formatter(ns);
+      show_symbol_table(goto_model, ui_message_handler.get_ui(), formatter);
       return CPROVER_EXIT_SUCCESS;
     }
 

--- a/src/cpp/Makefile
+++ b/src/cpp/Makefile
@@ -6,6 +6,7 @@ SRC = cpp_constructor.cpp \
       cpp_destructor.cpp \
       cpp_enum_type.cpp \
       cpp_exception_id.cpp \
+      cpp_formatter.cpp \
       cpp_id.cpp \
       cpp_instantiate_template.cpp \
       cpp_internal_additions.cpp \

--- a/src/cpp/cpp_formatter.cpp
+++ b/src/cpp/cpp_formatter.cpp
@@ -1,0 +1,29 @@
+/*******************************************************************\
+
+Module:
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#include "cpp_formatter.h"
+
+#include "expr2cpp.h"
+
+#include <ostream>
+
+std::ostream &cpp_formattert::format(std::ostream &os, const exprt &expr)
+{
+  return os << expr2cpp(expr, ns);
+}
+
+std::ostream &cpp_formattert::format(std::ostream &os, const typet &type)
+{
+  return os << type2cpp(type, ns);
+}
+
+std::ostream &
+cpp_formattert::format(std::ostream &os, const source_locationt &loc)
+{
+  return os << loc;
+}

--- a/src/cpp/cpp_formatter.h
+++ b/src/cpp/cpp_formatter.h
@@ -1,0 +1,28 @@
+/*******************************************************************\
+
+Module:
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_CPP_FORMATTER_H
+#define CPROVER_CPP_FORMATTER_H
+
+#include <util/formatter.h>
+
+class cpp_formattert : public formattert
+{
+public:
+  explicit cpp_formattert(const namespacet &_ns) : ns(_ns)
+  {
+  }
+
+  std::ostream &format(std::ostream &, const exprt &) override;
+  std::ostream &format(std::ostream &, const typet &) override;
+  std::ostream &format(std::ostream &, const source_locationt &) override;
+
+  const namespacet &ns;
+};
+
+#endif // CPROVER_CPP_FORMATTER_H

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -21,6 +21,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/json.h>
 #include <util/exit_codes.h>
 
+#include <ansi-c/ansi_c_formatter.h>
+
 #include <goto-programs/class_hierarchy.h>
 #include <goto-programs/goto_convert_functions.h>
 #include <goto-programs/remove_calls_no_body.h>
@@ -463,7 +465,9 @@ int goto_instrument_parse_optionst::doit()
 
     if(cmdline.isset("show-symbol-table"))
     {
-      ::show_symbol_table(goto_model, get_ui());
+      namespacet ns(goto_model.symbol_table);
+      ansi_c_formattert formatter(ns);
+      ::show_symbol_table(goto_model, get_ui(), formatter);
       return CPROVER_EXIT_SUCCESS;
     }
 

--- a/src/goto-programs/generate_function_bodies.cpp
+++ b/src/goto-programs/generate_function_bodies.cpp
@@ -9,7 +9,7 @@ Author: Diffblue Ltd.
 #include "generate_function_bodies.h"
 
 #include <util/arith_tools.h>
-#include <util/format_expr.h>
+#include <util/formatter.h>
 #include <util/make_unique.h>
 #include <util/string_utils.h>
 
@@ -102,7 +102,7 @@ protected:
     const namespacet ns(symbol_table);
     std::ostringstream comment_stream;
     comment_stream << id2string(ID_assertion) << " "
-                   << format(assert_instruction->guard);
+                   << debug_formatter(assert_instruction->guard);
     assert_instruction->source_location.set_comment(comment_stream.str());
     assert_instruction->source_location.set_property_class(ID_assertion);
     auto end_instruction = add_instruction();
@@ -134,7 +134,7 @@ protected:
     const namespacet ns(symbol_table);
     std::ostringstream comment_stream;
     comment_stream << id2string(ID_assertion) << " "
-                   << format(assert_instruction->guard);
+                   << debug_formatter(assert_instruction->guard);
     assert_instruction->source_location.set_comment(comment_stream.str());
     assert_instruction->source_location.set_property_class(ID_assertion);
     auto assume_instruction = add_instruction();
@@ -203,7 +203,7 @@ private:
           bool constant_known_array_size = lhs_array_type.size().is_constant();
           if(!constant_known_array_size)
           {
-            warning() << "Cannot havoc non-const array " << format(lhs)
+            warning() << "Cannot havoc non-const array " << debug_formatter(lhs)
                       << " in function " << function_name
                       << ": Unknown array size" << eom;
           }
@@ -219,7 +219,7 @@ private:
               // Pretty much the same thing as a unknown size array
               // Technically not allowed by the C standard, but we model
               // unknown size arrays in structs this way
-              warning() << "Cannot havoc non-const array " << format(lhs)
+              warning() << "Cannot havoc non-const array " << debug_formatter(lhs)
                         << " in function " << function_name << ": Array size 0"
                         << eom;
             }

--- a/src/goto-programs/goto_trace.cpp
+++ b/src/goto-programs/goto_trace.cpp
@@ -17,7 +17,7 @@ Author: Daniel Kroening
 #include <ostream>
 
 #include <util/arith_tools.h>
-#include <util/format_expr.h>
+#include <util/formatter.h>
 #include <util/symbol.h>
 
 #include <ansi-c/printf_formatter.h>
@@ -74,8 +74,8 @@ void goto_trace_stept::output(
 
   if(is_assignment())
   {
-    out << "  " << format(full_lhs)
-        << " = " << format(full_lhs_value)
+    out << "  " << debug_formatter(full_lhs)
+        << " = " << debug_formatter(full_lhs_value)
         << '\n';
   }
 
@@ -95,7 +95,7 @@ void goto_trace_stept::output(
       if(!comment.empty())
         out << "  " << comment << '\n';
 
-      out << "  " << format(pc->guard) << '\n';
+      out << "  " << debug_formatter(pc->guard) << '\n';
       out << '\n';
     }
   }

--- a/src/goto-programs/show_symbol_table.cpp
+++ b/src/goto-programs/show_symbol_table.cpp
@@ -19,13 +19,14 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_model.h"
 
-void show_symbol_table_xml_ui()
+void show_symbol_table_xml_ui(formattert &)
 {
 }
 
 void show_symbol_table_brief_plain(
   const symbol_tablet &symbol_table,
-  std::ostream &out)
+  std::ostream &out,
+  formattert &formatter)
 {
   // we want to sort alphabetically
   std::set<std::string> symbols;
@@ -41,29 +42,17 @@ void show_symbol_table_brief_plain(
   {
     const symbolt &symbol=ns.lookup(id);
 
-    std::unique_ptr<languaget> ptr;
-
-    if(symbol.mode=="")
-      ptr=get_default_language();
-    else
-    {
-      ptr=get_language_from_mode(symbol.mode);
-      if(ptr==nullptr)
-        throw "symbol "+id2string(symbol.name)+" has unknown mode";
-    }
-
-    std::string type_str;
-
     if(symbol.type.is_not_nil())
-      ptr->from_type(symbol.type, type_str, ns);
-
-    out << symbol.name << " " << type_str << '\n';
+      out << symbol.name << " " << formatter(symbol.type) << '\n';
+    else
+      out << symbol.name << '\n';
   }
 }
 
 void show_symbol_table_plain(
   const symbol_tablet &symbol_table,
-  std::ostream &out)
+  std::ostream &out,
+  formattert &formatter)
 {
   out << '\n' << "Symbols:" << '\n' << '\n';
 
@@ -81,35 +70,24 @@ void show_symbol_table_plain(
   {
     const symbolt &symbol=ns.lookup(id);
 
-    std::unique_ptr<languaget> ptr;
-
-    if(symbol.mode=="")
-    {
-      ptr=get_default_language();
-    }
-    else
-    {
-      ptr=get_language_from_mode(symbol.mode);
-    }
-
-    if(!ptr)
-      throw "symbol "+id2string(symbol.name)+" has unknown mode";
-
     std::string type_str, value_str;
-
-    if(symbol.type.is_not_nil())
-      ptr->from_type(symbol.type, type_str, ns);
-
-    if(symbol.value.is_not_nil())
-      ptr->from_expr(symbol.value, value_str, ns);
 
     out << "Symbol......: " << symbol.name << '\n' << std::flush;
     out << "Pretty name.: " << symbol.pretty_name << '\n';
     out << "Module......: " << symbol.module << '\n';
     out << "Base name...: " << symbol.base_name << '\n';
     out << "Mode........: " << symbol.mode << '\n';
-    out << "Type........: " << type_str << '\n';
-    out << "Value.......: " << value_str << '\n';
+
+    out << "Type........: ";
+    if(symbol.type.is_not_nil())
+      out << formatter(symbol.type);
+    out << '\n';
+
+    out << "Value.......: ";
+    if(symbol.value.is_not_nil())
+      out << formatter(symbol.value);
+    out << '\n';
+
     out << "Flags.......:";
 
     if(symbol.is_lvalue)
@@ -146,7 +124,7 @@ void show_symbol_table_plain(
       out << " volatile";
 
     out << '\n';
-    out << "Location....: " << symbol.location << '\n';
+    out << "Location....: " << formatter(symbol.location) << '\n';
 
     out << '\n' << std::flush;
   }
@@ -154,16 +132,17 @@ void show_symbol_table_plain(
 
 void show_symbol_table(
   const symbol_tablet &symbol_table,
-  ui_message_handlert::uit ui)
+  ui_message_handlert::uit ui,
+  formattert &formatter)
 {
   switch(ui)
   {
   case ui_message_handlert::uit::PLAIN:
-    show_symbol_table_plain(symbol_table, std::cout);
+    show_symbol_table_plain(symbol_table, std::cout, formatter);
     break;
 
   case ui_message_handlert::uit::XML_UI:
-    show_symbol_table_xml_ui();
+    show_symbol_table_xml_ui(formatter);
     break;
 
   default:
@@ -173,23 +152,25 @@ void show_symbol_table(
 
 void show_symbol_table(
   const goto_modelt &goto_model,
-  ui_message_handlert::uit ui)
+  ui_message_handlert::uit ui,
+  formattert &formatter)
 {
-  show_symbol_table(goto_model.symbol_table, ui);
+  show_symbol_table(goto_model.symbol_table, ui, formatter);
 }
 
 void show_symbol_table_brief(
   const symbol_tablet &symbol_table,
-  ui_message_handlert::uit ui)
+  ui_message_handlert::uit ui,
+  formattert &formatter)
 {
   switch(ui)
   {
   case ui_message_handlert::uit::PLAIN:
-    show_symbol_table_brief_plain(symbol_table, std::cout);
+    show_symbol_table_brief_plain(symbol_table, std::cout, formatter);
     break;
 
   case ui_message_handlert::uit::XML_UI:
-    show_symbol_table_xml_ui();
+    show_symbol_table_xml_ui(formatter);
     break;
 
   default:
@@ -199,7 +180,8 @@ void show_symbol_table_brief(
 
 void show_symbol_table_brief(
   const goto_modelt &goto_model,
-  ui_message_handlert::uit ui)
+  ui_message_handlert::uit ui,
+  formattert &formatter)
 {
-  show_symbol_table_brief(goto_model.symbol_table, ui);
+  show_symbol_table_brief(goto_model.symbol_table, ui, formatter);
 }

--- a/src/goto-programs/show_symbol_table.h
+++ b/src/goto-programs/show_symbol_table.h
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_GOTO_PROGRAMS_SHOW_SYMBOL_TABLE_H
 #define CPROVER_GOTO_PROGRAMS_SHOW_SYMBOL_TABLE_H
 
+#include <util/formatter.h>
 #include <util/ui_message.h>
 
 class symbol_tablet;
@@ -19,18 +20,22 @@ class goto_modelt;
 
 void show_symbol_table(
   const symbol_tablet &,
-  ui_message_handlert::uit ui);
+  ui_message_handlert::uit ui,
+  formattert & = debug_formatter);
 
 void show_symbol_table_brief(
   const symbol_tablet &,
-  ui_message_handlert::uit ui);
+  ui_message_handlert::uit ui,
+  formattert & = debug_formatter);
 
 void show_symbol_table(
   const goto_modelt &,
-  ui_message_handlert::uit ui);
+  ui_message_handlert::uit ui,
+  formattert & = debug_formatter);
 
 void show_symbol_table_brief(
   const goto_modelt &,
-  ui_message_handlert::uit ui);
+  ui_message_handlert::uit ui,
+  formattert & = debug_formatter);
 
 #endif // CPROVER_GOTO_PROGRAMS_SHOW_SYMBOL_TABLE_H

--- a/src/goto-symex/equation_conversion_exceptions.h
+++ b/src/goto-symex/equation_conversion_exceptions.h
@@ -14,7 +14,7 @@ Author: Diffblue Ltd.
 
 #include <sstream>
 
-#include <util/format_expr.h>
+#include <util/formatter.h>
 
 #include "symex_target_equation.h"
 
@@ -28,7 +28,7 @@ public:
   {
     std::ostringstream error_msg;
     error_msg << runtime_error::what();
-    error_msg << "\nSource GOTO statement: " << format(step.source.pc->code);
+    error_msg << "\nSource GOTO statement: " << debug_formatter(step.source.pc->code);
     error_msg << "\nStep:\n";
     step.output(error_msg);
     error_message = error_msg.str();

--- a/src/goto-symex/slice_by_trace.cpp
+++ b/src/goto-symex/slice_by_trace.cpp
@@ -21,7 +21,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/arith_tools.h>
 #include <util/std_expr.h>
 #include <util/guard.h>
-#include <util/format_expr.h>
+#include <util/formatter.h>
 
 void symex_slice_by_tracet::slice_by_trace(
   std::string trace_files,
@@ -257,10 +257,10 @@ void symex_slice_by_tracet::compute_ts_back(
 
 #if 0
       std::cout << "EVENT:  " << event << '\n';
-      std::cout << "GUARD:  " << format(guard) << '\n';
+      std::cout << "GUARD:  " << debug_formatter(guard) << '\n';
       for(size_t j=0; j < t.size(); j++)
       {
-        std::cout << "t[" << j << "]=" << format(t[j]) <<
+        std::cout << "t[" << j << "]=" << debug_formatter(t[j]) <<
           '\n';
       }
 #endif

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -11,7 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "symex_target_equation.h"
 
-#include <util/format_expr.h>
+#include <util/formatter.h>
 #include <util/std_expr.h>
 #include <util/throw_with_nested.h>
 #include <util/unwrap_nested_exception.h>
@@ -795,10 +795,10 @@ void symex_target_equationt::SSA_stept::output(std::ostream &out) const
   switch(type)
   {
   case goto_trace_stept::typet::ASSERT:
-    out << "ASSERT " << format(cond_expr) << '\n';
+    out << "ASSERT " << debug_formatter(cond_expr) << '\n';
     break;
   case goto_trace_stept::typet::ASSUME:
-    out << "ASSUME " << format(cond_expr) << '\n';
+    out << "ASSUME " << debug_formatter(cond_expr) << '\n';
     break;
   case goto_trace_stept::typet::LOCATION:
     out << "LOCATION" << '\n';
@@ -812,7 +812,7 @@ void symex_target_equationt::SSA_stept::output(std::ostream &out) const
 
   case goto_trace_stept::typet::DECL:
     out << "DECL" << '\n';
-    out << format(ssa_lhs) << '\n';
+    out << debug_formatter(ssa_lhs) << '\n';
     break;
 
   case goto_trace_stept::typet::ASSIGNMENT:
@@ -876,7 +876,7 @@ void symex_target_equationt::SSA_stept::output(std::ostream &out) const
     out << "MEMORY_BARRIER\n";
     break;
   case goto_trace_stept::typet::GOTO:
-    out << "IF " << format(cond_expr) << " GOTO\n";
+    out << "IF " << debug_formatter(cond_expr) << " GOTO\n";
     break;
 
   default:
@@ -884,13 +884,13 @@ void symex_target_equationt::SSA_stept::output(std::ostream &out) const
   }
 
   if(is_assert() || is_assume() || is_assignment() || is_constraint())
-    out << format(cond_expr) << '\n';
+    out << debug_formatter(cond_expr) << '\n';
 
   if(is_assert() || is_constraint())
     out << comment << '\n';
 
   if(is_shared_read() || is_shared_write())
-    out << format(ssa_lhs) << '\n';
+    out << debug_formatter(ssa_lhs) << '\n';
 
-  out << "Guard: " << format(guard) << '\n';
+  out << "Guard: " << debug_formatter(guard) << '\n';
 }

--- a/src/java_bytecode/Makefile
+++ b/src/java_bytecode/Makefile
@@ -22,6 +22,7 @@ SRC = bytecode_info.cpp \
       java_class_loader_limit.cpp \
       java_enum_static_init_unwind_handler.cpp \
       java_entry_point.cpp \
+      java_formatter.cpp \
       java_local_variable_table.cpp \
       java_object_factory.cpp \
       java_pointer_casts.cpp \

--- a/src/java_bytecode/java_formatter.cpp
+++ b/src/java_bytecode/java_formatter.cpp
@@ -1,0 +1,29 @@
+/*******************************************************************\
+
+Module:
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#include "java_formatter.h"
+
+#include "expr2java.h"
+
+#include <ostream>
+
+std::ostream &java_formattert::format(std::ostream &os, const exprt &expr)
+{
+  return os << expr2java(expr, ns);
+}
+
+std::ostream &java_formattert::format(std::ostream &os, const typet &type)
+{
+  return os << type2java(type, ns);
+}
+
+std::ostream &
+java_formattert::format(std::ostream &os, const source_locationt &loc)
+{
+  return os << loc;
+}

--- a/src/java_bytecode/java_formatter.h
+++ b/src/java_bytecode/java_formatter.h
@@ -1,0 +1,28 @@
+/*******************************************************************\
+
+Module:
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_JAVA_FORMATTER_H
+#define CPROVER_JAVA_FORMATTER_H
+
+#include <util/formatter.h>
+
+class java_formattert : public formattert
+{
+public:
+  explicit java_formattert(const namespacet &_ns) : ns(_ns)
+  {
+  }
+
+  std::ostream &format(std::ostream &, const exprt &) override;
+  std::ostream &format(std::ostream &, const typet &) override;
+  std::ostream &format(std::ostream &, const source_locationt &) override;
+
+  const namespacet &ns;
+};
+
+#endif // CPROVER_JAVA_FORMATTER_H

--- a/src/jbmc/jbmc_parse_options.cpp
+++ b/src/jbmc/jbmc_parse_options.cpp
@@ -55,6 +55,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <java_bytecode/convert_java_nondet.h>
 #include <java_bytecode/java_bytecode_language.h>
 #include <java_bytecode/java_enum_static_init_unwind_handler.h>
+#include <java_bytecode/java_formatter.h>
 #include <java_bytecode/remove_exceptions.h>
 #include <java_bytecode/remove_instanceof.h>
 #include <java_bytecode/remove_java_new.h>
@@ -671,8 +672,10 @@ int jbmc_parse_optionst::get_goto_program(
     // values, etc
     if(cmdline.isset("show-symbol-table"))
     {
+      const namespacet ns(lazy_goto_model.symbol_table);
+      java_formattert formatter(ns);
       show_symbol_table(
-        lazy_goto_model.symbol_table, ui_message_handler.get_ui());
+        lazy_goto_model.symbol_table, ui_message_handler.get_ui(), formatter);
       return 0;
     }
 
@@ -850,8 +853,10 @@ bool jbmc_parse_optionst::show_loaded_functions(
 {
   if(cmdline.isset("show-symbol-table"))
   {
+    namespacet ns(goto_model.get_symbol_table());
+    java_formattert formatter(ns);
     show_symbol_table(
-      goto_model.get_symbol_table(), ui_message_handler.get_ui());
+      goto_model.get_symbol_table(), ui_message_handler.get_ui(), formatter);
     return true;
   }
 

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -13,7 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #ifdef DEBUG
 #include <iostream>
-#include <util/format_expr.h>
+#include <util/formatter.h>
 #endif
 
 #include <util/std_expr.h>
@@ -37,7 +37,7 @@ exprt dereferencet::operator()(const exprt &pointer)
   const typet &type=pointer.type().subtype();
 
   #ifdef DEBUG
-  std::cout << "DEREF: " << format(pointer) << '\n';
+  std::cout << "DEREF: " << debug_formatter(pointer) << '\n';
   #endif
 
   return dereference_rec(

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -24,8 +24,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #ifdef DEBUG
 #include <iostream>
-#include <util/format_expr.h>
-#include <util/format_type.h>
+#include <util/formatter.h>
 #endif
 
 #include "add_failed_symbols.h"
@@ -327,7 +326,7 @@ void value_sett::get_value_set(
   #if 0
   for(value_setst::valuest::const_iterator it=dest.begin();
       it!=dest.end(); it++)
-    std::cout << "GET_VALUE_SET: " << format(*it) << '\n';
+    std::cout << "GET_VALUE_SET: " << debug_formatter(*it) << '\n';
   #endif
 }
 
@@ -352,7 +351,7 @@ void value_sett::get_value_set_rec(
   const namespacet &ns) const
 {
   #if 0
-  std::cout << "GET_VALUE_SET_REC EXPR: " << format(expr) << "\n";
+  std::cout << "GET_VALUE_SET_REC EXPR: " << debug_formatter(expr) << "\n";
   std::cout << "GET_VALUE_SET_REC SUFFIX: " << suffix << '\n';
   #endif
 
@@ -884,7 +883,7 @@ void value_sett::get_value_set_rec(
   for(const auto &obj : dest.read())
   {
     const exprt &e=to_expr(obj);
-    std::cout << "  " << format(e) << "\n";
+    std::cout << "  " << debug_formatter(e) << "\n";
   }
   std::cout << "\n";
   #endif
@@ -929,7 +928,7 @@ void value_sett::get_reference_set_rec(
   const namespacet &ns) const
 {
   #if 0
-  std::cout << "GET_REFERENCE_SET_REC EXPR: " << format(expr)
+  std::cout << "GET_REFERENCE_SET_REC EXPR: " << debug_formatter(expr)
             << '\n';
   #endif
 
@@ -956,7 +955,7 @@ void value_sett::get_reference_set_rec(
     #if 0
     for(expr_sett::const_iterator it=value_set.begin();
         it!=value_set.end(); it++)
-      std::cout << "VALUE_SET: " << format(*it) << '\n';
+      std::cout << "VALUE_SET: " << debug_formatter(*it) << '\n';
     #endif
 
     return;
@@ -1093,10 +1092,10 @@ void value_sett::assign(
   bool add_to_sets)
 {
 #if 0
-  std::cout << "ASSIGN LHS: " << format(lhs) << " : "
-            << format(lhs.type()) << '\n';
-  std::cout << "ASSIGN RHS: " << format(rhs) << " : "
-            << format(rhs.type()) << '\n';
+  std::cout << "ASSIGN LHS: " << debug_formatter(lhs) << " : "
+            << debug_formatter(lhs.type()) << '\n';
+  std::cout << "ASSIGN RHS: " << debug_formatter(rhs) << " : "
+            << debug_formatter(rhs.type()) << '\n';
   std::cout << "--------------------------------------------\n";
   output(ns, std::cout);
 #endif
@@ -1301,7 +1300,7 @@ void value_sett::assign_rec(
   bool add_to_sets)
 {
   #if 0
-  std::cout << "ASSIGN_REC LHS: " << format(lhs) << '\n';
+  std::cout << "ASSIGN_REC LHS: " << debug_formatter(lhs) << '\n';
   std::cout << "ASSIGN_REC LHS ID: " << lhs.id() << '\n';
   std::cout << "ASSIGN_REC SUFFIX: " << suffix << '\n';
 
@@ -1309,7 +1308,7 @@ void value_sett::assign_rec(
       it!=values_rhs.read().end();
       it++)
     std::cout << "ASSIGN_REC RHS: " <<
-      format(object_numbering[it->first]) << '\n';
+      debug_formatter(object_numbering[it->first]) << '\n';
   std::cout << '\n';
   #endif
 

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -13,7 +13,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #ifdef DEBUG
 #include <iostream>
-#include <util/format_expr.h>
 #endif
 
 #include <util/arith_tools.h>
@@ -23,7 +22,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/c_types.h>
 #include <util/config.h>
 #include <util/cprover_prefix.h>
-#include <util/format_type.h>
+#include <util/formatter.h>
 #include <util/guard.h>
 #include <util/options.h>
 #include <util/pointer_offset_size.h>
@@ -77,7 +76,7 @@ exprt value_set_dereferencet::dereference(
   const typet &type=pointer.type().subtype();
 
   #if 0
-  std::cout << "DEREF: " << format(pointer) << '\n';
+  std::cout << "DEREF: " << debug_formatter(pointer) << '\n';
   #endif
 
   // collect objects the pointer may point to
@@ -90,7 +89,7 @@ exprt value_set_dereferencet::dereference(
       it=points_to_set.begin();
       it!=points_to_set.end();
       it++)
-    std::cout << "P: " << format(*it) << '\n';
+    std::cout << "P: " << debug_formatter(*it) << '\n';
   #endif
 
   // get the values of these
@@ -105,8 +104,8 @@ exprt value_set_dereferencet::dereference(
     valuet value=build_reference_to(*it, mode, pointer, guard);
 
     #if 0
-    std::cout << "V: " << format(value.pointer_guard) << " --> ";
-    std::cout << format(value.value) << '\n';
+    std::cout << "V: " << debug_formatter(value.pointer_guard) << " --> ";
+    std::cout << debug_formatter(value.value) << '\n';
     #endif
 
     values.push_back(value);
@@ -191,7 +190,7 @@ exprt value_set_dereferencet::dereference(
   }
 
   #if 0
-  std::cout << "R: " << format(value) << "\n\n";
+  std::cout << "R: " << debug_formatter(value) << "\n\n";
   #endif
 
   return value;
@@ -281,7 +280,7 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
   const exprt &object=o.object();
 
   #if 0
-  std::cout << "O: " << format(root_object) << '\n';
+  std::cout << "O: " << debug_formatter(root_object) << '\n';
   #endif
 
   valuet result;
@@ -561,8 +560,8 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
         {
           std::ostringstream msg;
           msg << "memory model not applicable (got `"
-              << format(result.value.type()) << "', expected `"
-              << format(dereference_type) << "')";
+              << debug_formatter(result.value.type()) << "', expected `"
+              << debug_formatter(dereference_type) << "')";
 
           dereference_callback.dereference_failure(
             "pointer dereference", msg.str(), tmp_guard);

--- a/src/solvers/refinement/string_constraint.h
+++ b/src/solvers/refinement/string_constraint.h
@@ -23,8 +23,7 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include "bv_refinement.h"
 #include "string_refinement_invariant.h"
 
-#include <util/format_expr.h>
-#include <util/format_type.h>
+#include <util/formatter.h>
 #include <util/refined_string_type.h>
 #include <util/string_expr.h>
 
@@ -140,9 +139,9 @@ extern inline string_constraintt &to_string_constraint(exprt &expr)
 inline std::string to_string(const string_constraintt &expr)
 {
   std::ostringstream out;
-  out << "forall " << format(expr.univ_var()) << " in ["
-      << format(expr.lower_bound()) << ", " << format(expr.upper_bound())
-      << "). " << format(expr.premise()) << " => " << format(expr.body());
+  out << "forall " << debug_formatter(expr.univ_var()) << " in ["
+      << debug_formatter(expr.lower_bound()) << ", " << debug_formatter(expr.upper_bound())
+      << "). " << debug_formatter(expr.premise()) << " => " << debug_formatter(expr.body());
   return out.str();
 }
 
@@ -212,12 +211,12 @@ public:
 inline std::string to_string(const string_not_contains_constraintt &expr)
 {
   std::ostringstream out;
-  out << "forall x in [" << format(expr.univ_lower_bound()) << ", "
-      << format(expr.univ_upper_bound()) << "). " << format(expr.premise())
+  out << "forall x in [" << debug_formatter(expr.univ_lower_bound()) << ", "
+      << debug_formatter(expr.univ_upper_bound()) << "). " << debug_formatter(expr.premise())
       << " => ("
-      << "exists y in [" << format(expr.exists_lower_bound()) << ", "
-      << format(expr.exists_upper_bound()) << "). " << format(expr.s0())
-      << "[x+y] != " << format(expr.s1()) << "[y])";
+      << "exists y in [" << debug_formatter(expr.exists_lower_bound()) << ", "
+      << debug_formatter(expr.exists_upper_bound()) << "). " << debug_formatter(expr.s0())
+      << "[x+y] != " << debug_formatter(expr.s1()) << "[y])";
   return out.str();
 }
 

--- a/src/solvers/refinement/string_refinement_util.cpp
+++ b/src/solvers/refinement/string_refinement_util.cpp
@@ -6,19 +6,22 @@
 
 \*******************************************************************/
 
+#include <util/arith_tools.h>
+#include <util/expr_util.h>
+#include <util/expr_iterator.h>
+#include <util/formatter.h>
+#include <util/graph.h>
+#include <util/magic.h>
+#include <util/make_unique.h>
+#include <util/ssa_expr.h>
+#include <util/std_expr.h>
+
 #include <algorithm>
 #include <numeric>
 #include <functional>
 #include <iostream>
-#include <util/arith_tools.h>
-#include <util/expr_util.h>
-#include <util/ssa_expr.h>
-#include <util/std_expr.h>
-#include <util/expr_iterator.h>
-#include <util/graph.h>
-#include <util/magic.h>
-#include <util/make_unique.h>
 #include <unordered_set>
+
 #include "string_refinement_util.h"
 
 /// Applies `f` on all strings contained in `e` that are not if-expressions.
@@ -474,7 +477,7 @@ void string_dependenciest::output_dot(std::ostream &stream) const
       ostream << '"' << builtin_function_nodes[n.index].data->name() << '_'
               << n.index << '"';
     else
-      ostream << '"' << format(string_nodes[n.index].expr) << '"';
+      ostream << '"' << debug_formatter(string_nodes[n.index].expr) << '"';
     return ostream.str();
   };
   stream << "digraph dependencies {\n";

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -18,6 +18,7 @@ SRC = arith_tools.cpp \
       fixedbv.cpp \
       format_constant.cpp \
       format_expr.cpp \
+      formatter.cpp \
       format_number_range.cpp \
       format_type.cpp \
       fresh_symbol.cpp \

--- a/src/util/formatter.cpp
+++ b/src/util/formatter.cpp
@@ -1,0 +1,38 @@
+/*******************************************************************\
+
+Module: Expression Pretty Printing
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+/// \file
+/// Expression Pretty Printing
+
+#include "formatter.h"
+#include "format_expr.h"
+#include "format_type.h"
+
+debug_formattert debug_formatter;
+default_debug_formattert default_debug_formatter;
+
+std::ostream &default_debug_formattert::format(
+  std::ostream &out,
+  const exprt &src)
+{
+  return out << ::format(src);
+}
+
+std::ostream &default_debug_formattert::format(
+  std::ostream &out,
+  const typet &src)
+{
+  return out << ::format(src);
+}
+
+std::ostream &default_debug_formattert::format(
+  std::ostream &out,
+  const source_locationt &src)
+{
+  return out << src;
+}

--- a/src/util/formatter.h
+++ b/src/util/formatter.h
@@ -1,0 +1,104 @@
+/*******************************************************************\
+
+Module:
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_FORMATTER_H
+#define CPROVER_UTIL_FORMATTER_H
+
+#include "expr.h"
+
+class formattert;
+
+//! The below enables convenient syntax for feeding
+//! formatters and objects into streams, via stream << formatter(o)
+template <typename T>
+class formatter_containert
+{
+public:
+  explicit formatter_containert(
+    formattert &_formatter,
+    const T &_o) : formatter(_formatter), o(_o)
+  {
+  }
+
+  class formattert &formatter;
+  const T &o;
+};
+
+//! This is an abstract interface for a expr/type formatter
+class formattert
+{
+public:
+  // use these
+  formatter_containert<exprt> operator()(const exprt &o)
+  {
+    return formatter_containert<exprt>(*this, o);
+  }
+
+  formatter_containert<typet> operator()(const typet &o)
+  {
+    return formatter_containert<typet>(*this, o);
+  }
+
+  formatter_containert<source_locationt> operator()(const source_locationt &o)
+  {
+    return formatter_containert<source_locationt>(*this, o);
+  }
+
+  // overload those
+  virtual std::ostream &format(std::ostream &, const exprt &) = 0;
+  virtual std::ostream &format(std::ostream &, const typet &) = 0;
+  virtual std::ostream &format(std::ostream &, const source_locationt &) = 0;
+};
+
+//! enable feeding into output streams
+template<typename T>
+inline std::ostream &
+operator<<(std::ostream &os, formatter_containert<T> c)
+{
+  return c.formatter.format(os, c.o);
+}
+
+//! this is the default debug formatter
+class default_debug_formattert:public formattert
+{
+  std::ostream &format(std::ostream &, const exprt &) override;
+  std::ostream &format(std::ostream &, const typet &) override;
+  std::ostream &format(std::ostream &, const source_locationt &) override;
+};
+
+extern default_debug_formattert default_debug_formatter;
+
+//! this is the debug formatter, defaulting to the above
+class debug_formattert:public formattert
+{
+public:
+  debug_formattert():formatter(&default_debug_formatter)
+  {
+  }
+
+  std::ostream &format(std::ostream &os, const exprt &o) override
+  {
+    return formatter->format(os, o);
+  }
+
+  std::ostream &format(std::ostream &os, const typet &o) override
+  {
+    return formatter->format(os, o);
+  }
+
+  std::ostream &format(std::ostream &os, const source_locationt &o) override
+  {
+    return formatter->format(os, o);
+  }
+
+  formattert *formatter;
+};
+
+extern debug_formattert debug_formatter;
+
+#endif // CPROVER_UTIL_FORMATTER_H


### PR DESCRIPTION
The interface comes with an exemplar of an application (show_symbol_table).
Note that this can replace util/format_expr.h and util/format_type.h.

This is extensible, i.e., it is possible to make the debug_formatter treat particular cases differently; it is possible to pass further data along with the formatter, say a symbol table, a wide space policy, etc., if needed. The formatter can be stateful (say for indents, parentheses, etc.).