### PR TITLE
Reachability slicer: mark reachable code more precisely

### DIFF
--- a/regression/cbmc/reachability-slice-interproc/test.c
+++ b/regression/cbmc/reachability-slice-interproc/test.c
@@ -1,0 +1,76 @@
+#include <assert.h>
+
+// After a reachability slice based on the assertion in `target`, we should
+// retain both its possible callers (...may_call_target_1, ...may_call_target_2)
+// and their callees, but should be more precise concerning before_target and
+// after_target, which even though they are also called by
+// `unreachable_calls_before_target` and `unreachable_calls_after_target`, those
+// functions are not reachable.
+
+void before_target()
+{
+  const char *local = "before_target_kept";
+}
+
+void after_target()
+{
+  const char *local = "after_target_kept";
+}
+
+void target()
+{
+  const char *local = "target_kept";
+
+  before_target();
+  assert(0);
+  after_target();
+}
+
+void unreachable_calls_before_target()
+{
+  const char *local = "unreachable_calls_before_target_kept";
+  before_target();
+}
+
+void unreachable_calls_after_target()
+{
+  const char *local = "unreachable_calls_after_target_kept";
+  after_target();
+}
+
+void reachable_before_target_caller_1()
+{
+  const char *local = "reachable_before_target_caller_1_kept";
+}
+
+void reachable_after_target_caller_1()
+{
+  const char *local = "reachable_after_target_caller_1_kept";
+}
+
+void reachable_may_call_target_1()
+{
+  const char *local = "reachable_may_call_target_1_kept";
+  reachable_before_target_caller_1();
+  target();
+  reachable_after_target_caller_1();
+}
+
+void reachable_before_target_caller_2()
+{
+  const char *local = "reachable_before_target_caller_2_kept";
+}
+
+void reachable_after_target_caller_2()
+{
+  const char *local = "reachable_after_target_caller_2_kept";
+}
+
+void reachable_may_call_target_2()
+{
+  const char *local = "reachable_may_call_target_2_kept";
+  reachable_before_target_caller_2();
+  target();
+  reachable_after_target_caller_2();
+}
+

--- a/regression/cbmc/reachability-slice-interproc/test.desc
+++ b/regression/cbmc/reachability-slice-interproc/test.desc
@@ -1,0 +1,13 @@
+CORE
+test.c
+--reachability-slice-fb --show-goto-functions
+target_kept
+reachable_before_target_caller_1_kept
+reachable_after_target_caller_1_kept
+reachable_may_call_target_1_kept
+reachable_before_target_caller_2_kept
+reachable_after_target_caller_2_kept
+reachable_may_call_target_2_kept
+--
+unreachable_calls_before_target_kept
+unreachable_calls_after_target_kept

--- a/src/goto-instrument/reachability_slicer_class.h
+++ b/src/goto-instrument/reachability_slicer_class.h
@@ -51,6 +51,29 @@ protected:
 
   typedef std::stack<cfgt::entryt> queuet;
 
+  /// A search stack entry, used in tracking nodes to mark reachable when
+  /// walking over the CFG in `fixedpoint_to_assertions` and
+  /// `fixedpoint_from_assertions`.
+  struct search_stack_entryt
+  {
+    /// CFG node to mark reachable
+    cfgt::node_indext node_index;
+
+    /// If true, this function's caller is known and has already been queued to
+    /// mark reachable, so there is no need to queue anything when walking out
+    /// of the function, whether forwards (via END_FUNCTION) or backwards (via a
+    /// callsite).
+    /// If false, this function's caller is not known, so when walking forwards
+    /// from the end or backwards from the beginning we should queue all
+    /// possible callers.
+    bool caller_is_known;
+
+    search_stack_entryt(cfgt::node_indext node_index, bool caller_is_known) :
+      node_index(node_index), caller_is_known(caller_is_known)
+    {
+    }
+  };
+
   void fixedpoint_to_assertions(
     const is_threadedt &is_threaded,
     slicing_criteriont &criterion);


### PR DESCRIPTION
The reachability slicer currently uses a very simple graph walk, and in particular walks out of a function to all possible callers, regardless of whether we know the actual caller. This commit fixes that  shortcoming by adding the callsite successor *at the callsite*, and tracking the fact that the callee's successor has already been taken care of in the graph search stack, thus allowing it to ignore the END_FUNCTION -> 
 allsite edges which are less precise.

Functions whose caller is genuinely unknown, such as the root function containing a reachability target 
 e.g. assert instruction) are treated as before, considering all possible callees. The backwards search is improved similarly to the forwards.

This needs some tests of course, but is ready to review in the meantime.