### PR TITLE
Fix perl regular expressions in regression test descriptions

### DIFF
--- a/regression/goto-analyzer/approx-const-fp-array-variable-cast-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-cast-const-fp/test.desc
@@ -9,10 +9,10 @@ main.c
 ^SIGNAL=0$
 --
 ^warning: ignoring
-^\s*IF fp_tbl\[\(signed long int\)i\] == f1 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f5 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f6 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f7 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f8 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f9 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f1 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f5 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f6 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f7 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f8 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f9 THEN GOTO [0-9]$
 function \w+: replacing function pointer by 9 possible targets

--- a/regression/goto-analyzer/approx-const-fp-array-variable-const-fp-with-null/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-const-fp-with-null/test.desc
@@ -10,10 +10,10 @@ replacing function pointer by 3 possible targets
 ^SIGNAL=0$
 --
 ^warning: ignoring
-^\s*IF fp_tbl\[\(signed long int\)i\] == f1 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f5 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f6 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f7 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f8 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f9 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f1 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f5 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f6 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f7 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f8 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f9 THEN GOTO [0-9]$
 function \w+: replacing function pointer by 9 possible targets

--- a/regression/goto-analyzer/approx-const-fp-array-variable-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-const-fp/test.desc
@@ -9,10 +9,10 @@ main.c
 ^SIGNAL=0$
 --
 ^warning: ignoring
-^\s*IF fp_tbl\[\(signed long int\)i\] == f1 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f5 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f6 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f7 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f8 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f9 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f1 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f5 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f6 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f7 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f8 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f9 THEN GOTO [0-9]$
 function \w+: replacing function pointer by 9 possible targets

--- a/regression/goto-analyzer/approx-const-fp-array-variable-const-pointer-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-const-pointer-const-struct-non-const-fp/test.desc
@@ -9,10 +9,10 @@ main.c
 ^SIGNAL=0$
 --
 ^warning: ignoring
-^\s*IF fp_tbl\[\(signed long int\)i\] == f1 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f5 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f6 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f7 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f8 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f9 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f1 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f5 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f6 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f7 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f8 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f9 THEN GOTO [0-9]$
 function \w+: replacing function pointer by 9 possible targets

--- a/regression/goto-analyzer/approx-const-fp-array-variable-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-const-struct-non-const-fp/test.desc
@@ -9,10 +9,10 @@ main.c
 ^SIGNAL=0$
 --
 ^warning: ignoring
-^\s*IF fp_tbl\[\(signed long int\)i\] == f1 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f5 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f6 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f7 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f8 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f9 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f1 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f5 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f6 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f7 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f8 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f9 THEN GOTO [0-9]$
 function \w+: replacing function pointer by 9 possible targets

--- a/regression/goto-analyzer/approx-const-fp-array-variable-invalid-cast-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-invalid-cast-const-fp/test.desc
@@ -9,10 +9,10 @@ main.c
 ^SIGNAL=0$
 --
 ^warning: ignoring
-^\s*IF fp_tbl\[\(signed long int\)i\] == f1 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f5 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f6 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f7 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f8 THEN GOTO [0-9]$
-^\s*IF fp_tbl\[\(signed long int\)i\] == f9 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f1 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f5 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f6 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f7 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f8 THEN GOTO [0-9]$
+^\s*IF fp_tbl\[\(signed( long)? long int\)i\] == f9 THEN GOTO [0-9]$
 function \w+: replacing function pointer by 9 possible targets

--- a/regression/goto-analyzer/constant_propagation_05/test.desc
+++ b/regression/goto-analyzer/constant_propagation_05/test.desc
@@ -3,6 +3,6 @@ main.c
 --constants --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] file main.c line 12 function main, assertion j!=3: Failure (if reachable)$
+^\[main.assertion.1\] file main.c line 12 function main, assertion j != 3: Failure \(if reachable\)$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_10/test.desc
+++ b/regression/goto-analyzer/constant_propagation_10/test.desc
@@ -3,6 +3,6 @@ main.c
 --constants --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] file main.c line 10 function main, assertion a\[0\]==2: Failure$
+^\[main.assertion.1\] file main.c line 10 function main, assertion a\[(\(signed( long)? long int\))?0\] == 2: Failure$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_11/test.desc
+++ b/regression/goto-analyzer/constant_propagation_11/test.desc
@@ -3,7 +3,7 @@ main.c
 --constants --simplify out.gb
 ^EXIT=0$
 ^SIGNAL=0$
-^Simplified:  assert: 1, assume: 0, goto: 0$
-^Unmodified:     assert: 0, assume: 0, goto: 0$
+^Simplified:  assert: 1, assume: 0, goto: 0, assigns: 0, function calls: 0$
+^Unmodified:  assert: 0, assume: 0, goto: 0, assigns: 0, function calls: 0$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_13/test.desc
+++ b/regression/goto-analyzer/constant_propagation_13/test.desc
@@ -3,6 +3,6 @@ main.c
 --constants --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] file main.c line 9 function main, assertion y==0: Failure (if reachable)$
+^\[main.assertion.1\] file main.c line 9 function main, assertion y == 0: Failure \(if reachable\)$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_14/test.desc
+++ b/regression/goto-analyzer/constant_propagation_14/test.desc
@@ -3,7 +3,7 @@ main.c
 --constants --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] file main.c line 11 function main, assertion a\[0\]==1 || a\[0\]==2: Success$
-^\[main.assertion.2\] file main.c line 12 function main, assertion a\[0\]==1 && a\[0\]==2: Failure$
+^\[main.assertion.1\] file main.c line 11 function main, assertion tmp_if_expr: Success$
+^\[main.assertion.2\] file main.c line 12 function main, assertion tmp_if_expr\$1: Failure$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_15/test.desc
+++ b/regression/goto-analyzer/constant_propagation_15/test.desc
@@ -3,6 +3,6 @@ main.c
 --constants --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] file main.c line 9 function main, assertion a\[0\]==2: Failure$
+^\[main.assertion.1\] file main.c line 9 function main, assertion a\[(\(signed( long)? long int\))?0\] == 2: Failure$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/intervals_02/test.desc
+++ b/regression/goto-analyzer/intervals_02/test.desc
@@ -1,8 +1,8 @@
-KNOWNBUG
+CORE
 main.c
 --intervals --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] file main.c line 7 function main, assertion x > -10 && x < 100: Success$
+^\[main.assertion.1\] file main.c line 5 function main, assertion x > -10 \&\& x < 100: Success$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/intervals_03/test.desc
+++ b/regression/goto-analyzer/intervals_03/test.desc
@@ -3,6 +3,6 @@ main.c
 --intervals --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] file main.c line 7 function main, assertion x > -10 || x < 100: Success$
+^\[main.assertion.1\] file main.c line 6 function main, assertion x > -10 \|\| x < 100: Success$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/intervals_04/test.desc
+++ b/regression/goto-analyzer/intervals_04/test.desc
@@ -1,8 +1,8 @@
-KNOWNBUG
+CORE
 main.c
 --intervals --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] file main.c line 9 function main, assertion i >= 1 && i <= 2: Success$
+^\[main.assertion.1\] file main.c line 8 function main, assertion i >= 1 && i <= 2: Success$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/intervals_05/test.desc
+++ b/regression/goto-analyzer/intervals_05/test.desc
@@ -3,6 +3,6 @@ main.c
 --intervals --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] file main.c line 9 function main, assertion i >= 1 || i <= 2: Success$
+^\[main.assertion.1\] file main.c line 8 function main, assertion i >= 1 \|\| i <= 2: Success$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/intervals_06/test.desc
+++ b/regression/goto-analyzer/intervals_06/test.desc
@@ -3,6 +3,6 @@ main.c
 --intervals --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] file main.c line 7 function main, assertion x < -10 || x > 100: Failure (if reachable)$
+^\[main.assertion.1\] file main.c line 7 function main, assertion x < -10 \|\| x > 100: Failure \(if reachable\)$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/intervals_07/test.desc
+++ b/regression/goto-analyzer/intervals_07/test.desc
@@ -3,6 +3,6 @@ main.c
 --intervals --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] file main.c line 7 function main, assertion x < -10 && x > 100: Failure (if reachable)$
+^\[main.assertion.1\] file main.c line 7 function main, assertion x < -10 \&\& x > 100: Failure \(if reachable\)$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/intervals_08/test.desc
+++ b/regression/goto-analyzer/intervals_08/test.desc
@@ -3,6 +3,6 @@ main.c
 --intervals --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] file main.c line 6 function main, assertion x < -10 && x < 100: Failure (if reachable)$
+^\[main.assertion.1\] file main.c line 6 function main, assertion x < -10 \&\& x < 100: Failure \(if reachable\)$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/intervals_09/test.desc
+++ b/regression/goto-analyzer/intervals_09/test.desc
@@ -1,8 +1,8 @@
-KNOWNBUG
+CORE
 main.c
 --intervals --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] file main.c line 9 function main, assertion i>=1 && i<=2: Success$
+^\[main.assertion.1\] file main.c line 8 function main, assertion i >= 1 \&\& i <= 2: Success$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/intervals_10/test.desc
+++ b/regression/goto-analyzer/intervals_10/test.desc
@@ -5,8 +5,8 @@ main.c
 ^SIGNAL=0$
 ^\[main.assertion.1\] file main.c line 8 function main, assertion j<=100: Success$
 ^\[main.assertion.2\] file main.c line 11 function main, assertion j<101: Success$
-^\[main.assertion.3\] file main.c line 14 function main, assertion j>100: Failure (if reachable)$
+^\[main.assertion.3\] file main.c line 14 function main, assertion j>100: Failure \(if reachable\)$
 ^\[main.assertion.4\] file main.c line 17 function main, assertion j<99: Unknown$
-^\[main.assertion.5\] file main.c line 20 function main, assertion j==100: Failure (if reachable)$
+^\[main.assertion.5\] file main.c line 20 function main, assertion j==100: Failure \(if reachable\)$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/intervals_11/test.desc
+++ b/regression/goto-analyzer/intervals_11/test.desc
@@ -3,7 +3,7 @@ main.c
 --intervals --verify
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.1\] file main.c line 30 function main, assertion y\[i\]>=-1.0f && y\[i\]<=1.0f: Unknown$
-^\[main.assertion.2\] file main.c line 35 function main, assertion y\[i\]>=-1.0f && y\[i\]<=1.0f: Unknown$
+^\[main.assertion.1\] file main.c line 30 function main, assertion y\[i\]>=-1.0f \&\& y\[i\]<=1.0f: Unknown$
+^\[main.assertion.2\] file main.c line 35 function main, assertion y\[i\]>=-1.0f \&\& y\[i\]<=1.0f: Unknown$
 --
 ^warning: ignoring

--- a/regression/strings/test_index_of/test.desc
+++ b/regression/strings/test_index_of/test.desc
@@ -5,5 +5,5 @@ test.c
 ^SIGNAL=0$
 ^\[main.assertion.1\] assertion firstSlash == 3: SUCCESS$
 ^\[main.assertion.2\] assertion lastSlash == 7: SUCCESS$
-^\[main.assertion.3\] assertion firstSlash != 3 || lastSlash != 7: FAILURE$
+^\[main.assertion.3\] assertion firstSlash != 3 \|\| lastSlash != 7: FAILURE$
 --

--- a/regression/strings/test_int/test.desc
+++ b/regression/strings/test_int/test.desc
@@ -6,5 +6,5 @@ test.c
 ^\[main.assertion.1\] assertion __CPROVER_char_at\(s,0\) == .1.: SUCCESS$
 ^\[main.assertion.2\] assertion __CPROVER_char_at\(s,1\) == .2.: SUCCESS$
 ^\[main.assertion.3\] assertion j == 234: SUCCESS$
-^\[main.assertion.4\] assertion j < 233 || __CPROVER_char_at\(s,2\) == .4.: FAILURE$
+^\[main.assertion.4\] assertion j < 233 \|\| __CPROVER_char_at\(s,2\) == .4.: FAILURE$
 --


### PR DESCRIPTION
Parentheses need to be escaped, and || as well as && are interpreted by perl as
or/and (and thus need escaping as well).