### PR TITLE
Travis/OSX follow-up cleanup: remove unnecessary environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,10 +99,7 @@ jobs:
       before_install:
         - HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache parallel
         - export PATH=$PATH:/usr/local/opt/ccache/libexec
-      env:
-        - COMPILER="ccache clang++"
-        - EXTRA_CXXFLAGS="-Qunused-arguments -fcolor-diagnostics"
-        - CCACHE_CPP2=yes
+      env: COMPILER="ccache clang++"
 
     # Ubuntu Linux with glibc using g++-5, debug mode
     - stage: Test different OS/CXX/Flags


### PR DESCRIPTION
On OS X (and possibly elsewhere, but this isn't verified)
run_second_cpp/CCACHE_CPP2 is the default, and setting it to "yes" is thus
redundant. Overriding the CXX flags seems unnecessary as it had not be done in
the g++ variant of the build that was just removed.