### PR TITLE
Move definition of can-be-constant-propagated to a central location

### DIFF
--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -179,10 +179,6 @@ public:
     bool record_value,
     bool allow_pointer_unsoundness=false);
 
-  // what to propagate
-  bool constant_propagation(const exprt &expr) const;
-  bool constant_propagation_reference(const exprt &expr) const;
-
   // undoes all levels of renaming
   void get_original_name(exprt &expr) const;
   void get_original_name(typet &type) const;

--- a/src/util/expr_util.h
+++ b/src/util/expr_util.h
@@ -78,4 +78,23 @@ if_exprt lift_if(const exprt &, std::size_t operand_number);
 /// find the expression nested inside typecasts, if any
 const exprt &skip_typecast(const exprt &expr);
 
+/// Determine whether an expression is constant.  A literal constant is
+/// constant, but so are, e.g., sums over constants or addresses of objects.
+/// An implementation derive from this class to refine what it considers
+/// constant in a particular context by overriding is_constant and/or
+/// is_constant_address_of.
+class is_constantt
+{
+public:
+  /// returns true iff the expression can be considered constant
+  bool operator()(const exprt &e) const
+  {
+    return is_constant(e);
+  }
+
+protected:
+  virtual bool is_constant(const exprt &) const;
+  virtual bool is_constant_address_of(const exprt &) const;
+};
+
 #endif // CPROVER_UTIL_EXPR_UTIL_H


### PR DESCRIPTION
This is re-usable, for example for the constant-propagation data-flow analysis.

This is factored out from #2132.