### PR TITLE
Inline get_string_container

### DIFF
--- a/src/util/string_container.cpp
+++ b/src/util/string_container.cpp
@@ -74,10 +74,3 @@ unsigned string_containert::get(const std::string &s)
 
   return r;
 }
-
-/// Get a reference to the global string container.
-string_containert &get_string_container()
-{
-  static string_containert ret;
-  return ret;
-}

--- a/src/util/string_container.h
+++ b/src/util/string_container.h
@@ -89,6 +89,11 @@ protected:
   string_vectort string_vector;
 };
 
-string_containert &get_string_container();
+/// Get a reference to the global string container.
+inline string_containert &get_string_container()
+{
+  static string_containert ret;
+  return ret;
+}
 
 #endif // CPROVER_UTIL_STRING_CONTAINER_H


### PR DESCRIPTION
The C standard guarantees that the static local variable remains unique.

This reduces the total cost of 1.6 billion uses of `irept::find` or `irept::get` from 20 seconds to 1.8 seconds.