### PR TITLE
Simplify lhs before passing to symex_assign

### DIFF
--- a/regression/cbmc/Pointer_byte_extract5/program-only.desc
+++ b/regression/cbmc/Pointer_byte_extract5/program-only.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--bounds-check --32 --program-only
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+byte_update

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -14,6 +14,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/byte_operators.h>
 #include <util/c_types.h>
 #include <util/cprover_prefix.h>
+#include <util/expr_util.h>
+#include <util/invariant.h>
 #include <util/pointer_offset_size.h>
 
 #include "goto_symex_state.h"
@@ -28,6 +30,19 @@ void goto_symext::symex_assign(
   exprt rhs=code.rhs();
 
   clean_expr(lhs, state, true);
+  // make the structure of the lhs as simple as possible to avoid,
+  // e.g., (b ? s1 : s2).member=X resulting in
+  // (b ? s1 : s2)=(b ? s1 : s2) with member:=X and then
+  // s1=b ? ((b ? s1 : s2) with member:=X) : s1
+  // when all we need is
+  // s1=s1 with member:=X [and guard b]
+  // s2=s2 with member:=X [and guard !b]
+  do_simplify(lhs);
+  // make sure simplify has not re-introduced any dereferencing that
+  // had previously been cleaned away
+  INVARIANT(
+    !has_subexpr(lhs, ID_dereference),
+    "simplify re-introduced dereferencing");
   clean_expr(rhs, state, false);
 
   if(rhs.id()==ID_side_effect)


### PR DESCRIPTION
This can help avoid some uses of byte_update, as the regression test shows.

This is the same as #34, created as a new PR to hopefully make Travis happy again.