### PR TITLE
ignore size of arrays on ptr-to-array conversions

### DIFF
--- a/regression/ansi-c/Function_pointer1/conversion.c
+++ b/regression/ansi-c/Function_pointer1/conversion.c
@@ -1,0 +1,8 @@
+int (*ptr2)[2];
+int (*ptrX)[];
+
+int main()
+{
+  ptrX=ptr2;
+  ptr2=ptrX;
+}

--- a/regression/ansi-c/Function_pointer1/test_conversion.desc
+++ b/regression/ansi-c/Function_pointer1/test_conversion.desc
@@ -1,0 +1,8 @@
+CORE
+conversion.c
+--verbosity 3
+^EXIT=0$
+^SIGNAL=0$
+--
+incompatible pointer types
+^CONVERSION ERROR$

--- a/src/ansi-c/c_typecast.cpp
+++ b/src/ansi-c/c_typecast.cpp
@@ -543,6 +543,13 @@ void c_typecastt::implicit_typecast_followed(
         // Also generous: between any to scalar types it's ok.
         // We should probably check the size.
       }
+      else if(src_sub.id()==ID_array &&
+              dest_sub.id()==ID_array &&
+              base_type_eq(src_sub.subtype(), dest_sub.subtype(), ns))
+      {
+        // we ignore the size of the top-level array
+        // in the case of pointers to arrays
+      }
       else
         warnings.push_back("incompatible pointer types");
 


### PR DESCRIPTION
Neither gcc nor clang warn about the size of arrays in pointer-to-array conversions.

Example:
int (*ptr2)[2];
vs.
int (*ptrX)[];

Occurs, e.g., in the Linux kernel.