### PR TITLE
fix ordering problem in solvers/Makefile

### DIFF
--- a/src/common
+++ b/src/common
@@ -158,11 +158,6 @@ else
   $(error Invalid setting for BUILD_ENV: $(BUILD_ENV_))
 endif
 
-# select default solver to be minisat2 if no other is specified
-ifeq ($(BOOLEFORCE)$(CHAFF)$(GLUCOSE)$(IPASIR)$(LINGELING)$(MINISAT)$(MINISAT2)$(PICOSAT)$(CADICAL),)
-  MINISAT2 = ../../minisat-2.2.1
-endif
-
 ifneq ($(IPASIR),)
   CP_CXXFLAGS += -DHAVE_IPASIR
 endif

--- a/src/config.inc
+++ b/src/config.inc
@@ -30,6 +30,11 @@ endif
 # when linking against an IPASIR solver.
 LIBSOLVER =
 
+# select default solver to be minisat2 if no other is specified
+ifeq ($(BOOLEFORCE)$(CHAFF)$(GLUCOSE)$(IPASIR)$(LINGELING)$(MINISAT)$(MINISAT2)$(PICOSAT)$(CADICAL),)
+  MINISAT2 = ../../minisat-2.2.1
+endif
+
 ifneq ($(PICOSAT),)
   CP_CXXFLAGS += -DSATCHECK_PICOSAT
 endif

--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -1,5 +1,4 @@
 include ../config.inc
-include ../common
 
 ifneq ($(CHAFF),)
   CHAFF_SRC=sat/satcheck_zchaff.cpp sat/satcheck_zcore.cpp
@@ -194,6 +193,8 @@ SRC = $(BOOLEFORCE_SRC) \
       smt2/smt2_tokenizer.cpp \
       smt2/smt2irep.cpp \
       # Empty last line
+
+include ../common
 
 INCLUDES += -I .. \
   $(CHAFF_INCLUDE) $(BOOLEFORCE_INCLUDE) $(MINISAT_INCLUDE) $(MINISAT2_INCLUDE) \


### PR DESCRIPTION
D_FILES depends on SRC, which was defined after the 'common' include. The result is that the files in solvers/ have no dependencies.

The solver default should not be in common; if it's in config.inc, then the solver is known after including that.
