### PR TITLE
Fix clang++'s warning about self-assign

### DIFF
--- a/src/util/sharing_node.h
+++ b/src/util/sharing_node.h
@@ -43,7 +43,7 @@ Author: Daniel Poetzl
 #define SN_ASSERT_USE(v, b) SN_ASSERT(b)
 #else
 #define SN_ASSERT(b)
-#define SN_ASSERT_USE(v, b) v = v;
+#define SN_ASSERT_USE(v, b) static_cast<void>(v);
 #endif
 
 // clang-format off


### PR DESCRIPTION
Currently `develop` does not compile for me because of the self-assign in `SN_ASSERT`. This fixes this warning.