### PR TITLE
smt2: bswap and popcount

### DIFF
--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2190,7 +2190,8 @@ exprt c_typecheck_baset::do_special_functions(
       throw 0;
     }
 
-    bswap_exprt bswap_expr(expr.arguments().front(), expr.type());
+    // these are hard-wired to 8 bits according to the gcc manual
+    bswap_exprt bswap_expr(expr.arguments().front(), 8, expr.type());
     bswap_expr.add_source_location()=source_location;
 
     return bswap_expr;

--- a/src/solvers/flattening/boolbv_bswap.cpp
+++ b/src/solvers/flattening/boolbv_bswap.cpp
@@ -8,7 +8,6 @@ Author: Michael Tautschnig
 
 #include "boolbv.h"
 
-#include <util/config.h>
 #include <util/invariant.h>
 
 bvt boolbvt::convert_bswap(const bswap_exprt &expr)
@@ -16,7 +15,7 @@ bvt boolbvt::convert_bswap(const bswap_exprt &expr)
   const std::size_t width = boolbv_width(expr.type());
 
   // width must be multiple of bytes
-  const std::size_t byte_bits = config.ansi_c.char_width;
+  const std::size_t byte_bits = expr.get_bits_per_byte();
   if(width % byte_bits != 0)
     return conversion_failed(expr);
 

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -29,9 +29,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/string_constant.h>
 
 #include <solvers/flattening/boolbv_width.h>
-#include <solvers/flattening/flatten_byte_operators.h>
 #include <solvers/flattening/c_bit_field_replacement_type.h>
+#include <solvers/flattening/flatten_byte_operators.h>
 #include <solvers/floatbv/float_bv.h>
+#include <solvers/lowering/expr_lowering.h>
 
 // Mark different kinds of error condition
 // General
@@ -1865,6 +1866,11 @@ void smt2_convt::convert_expr(const exprt &expr)
       UNEXPECTEDCASE("bswap must get bitvector operand");
 
     out << ')'; // let bswap_op
+  }
+  else if(expr.id() == ID_popcount)
+  {
+    exprt lowered = lower_popcount(to_popcount_expr(expr), ns);
+    convert_expr(lowered);
   }
   else
     UNEXPECTEDCASE(

--- a/src/util/irep_ids.def
+++ b/src/util/irep_ids.def
@@ -664,6 +664,7 @@ IREP_ID_TWO(overlay_class, java::com.diffblue.OverlayClassImplementation)
 IREP_ID_TWO(overlay_method, java::com.diffblue.OverlayMethodImplementation)
 IREP_ID_TWO(C_annotations, #annotations)
 IREP_ID_ONE(final)
+IREP_ID_ONE(bits_per_byte)
 
 // Projects depending on this code base that wish to extend the list of
 // available ids should provide a file local_irep_ids.h in their source tree and

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -28,18 +28,19 @@ bool simplify_exprt::simplify_bswap(bswap_exprt &expr)
 {
   if(expr.type().id() == ID_unsignedbv && expr.op().is_constant())
   {
+    auto bits_per_byte = expr.get_bits_per_byte();
     std::size_t width=to_bitvector_type(expr.type()).get_width();
     mp_integer value;
     to_integer(expr.op(), value);
     std::vector<mp_integer> bytes;
 
     // take apart
-    for(std::size_t bit=0; bit<width; bit+=8)
-      bytes.push_back((value >> bit)%256);
+    for(std::size_t bit = 0; bit < width; bit += bits_per_byte)
+      bytes.push_back((value >> bit)%power(2, bits_per_byte));
 
     // put back together, but backwards
     mp_integer new_value=0;
-    for(std::size_t bit=0; bit<width; bit+=8)
+    for(std::size_t bit = 0; bit < width; bit += bits_per_byte)
     {
       assert(!bytes.empty());
       new_value+=bytes.back()<<bit;

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -506,18 +506,25 @@ inline void validate_expr(const unary_minus_exprt &value)
 class bswap_exprt: public unary_exprt
 {
 public:
-  bswap_exprt(): unary_exprt(ID_bswap)
-  {
-  }
-
-  bswap_exprt(const exprt &_op, const typet &_type)
+  bswap_exprt(const exprt &_op, std::size_t bits_per_byte, const typet &_type)
     : unary_exprt(ID_bswap, _op, _type)
   {
+    set_bits_per_byte(bits_per_byte);
   }
 
-  explicit bswap_exprt(const exprt &_op)
+  explicit bswap_exprt(const exprt &_op, std::size_t &_bits_per_byte)
     : unary_exprt(ID_bswap, _op, _op.type())
   {
+  }
+
+  std::size_t get_bits_per_byte() const
+  {
+    return get_size_t(ID_bits_per_byte);
+  }
+
+  void set_bits_per_byte(std::size_t bits_per_byte)
+  {
+    set(ID_bits_per_byte, bits_per_byte);
   }
 };
 


### PR DESCRIPTION
This adds the encoding of bswap and popcount to the SMT2 back-end
