### PR TITLE
Fix doxyfile to include JBMC documentation

### DIFF
--- a/src/doxyfile
+++ b/src/doxyfile
@@ -771,7 +771,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = . ../doc
+INPUT                  = . ../doc ../jbmc/src ../unit/testing-utils ../jbmc/unit/java-testing-utils
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
Also include unit test utilities in the documentation.

As pointed out by @antlechner (though I didn't spot their message) cprover.diffblue.com doesn't include files from JBMC since the split. That is because the directory wasn't included. While I was fixing that, I got it to include the unit test utilities as well. 