### PR TITLE
Use !shouldfail rather than !mayfail on unit tests

### DIFF
--- a/jbmc/unit/java_bytecode/ci_lazy_methods/lazy_load_lambdas.cpp
+++ b/jbmc/unit/java_bytecode/ci_lazy_methods/lazy_load_lambdas.cpp
@@ -12,7 +12,7 @@
 
 SCENARIO(
   "Lazy load lambda methods",
-  "[core][java_bytecode][ci_lazy_methods][lambdas][!mayfail]")
+  "[core][java_bytecode][ci_lazy_methods][lambdas][!shouldfail]")
 {
   GIVEN("A class with some locally declared lambdas")
   {
@@ -192,7 +192,7 @@ SCENARIO(
 
 SCENARIO(
   "Lazy load lambda methods in seperate class",
-  "[core][java_bytecode][ci_lazy_methods][lambdas][!mayfail]")
+  "[core][java_bytecode][ci_lazy_methods][lambdas][!shouldfail]")
 {
   const symbol_tablet symbol_table = load_java_class_lazy(
     "ExternalLambdaAccessor",

--- a/jbmc/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -195,7 +195,7 @@ void validate_local_variable_lambda_assignment(
 SCENARIO(
   "Converting invokedynamic with a local lambda",
   "[core]"
-  "[lambdas][java_bytecode][java_bytecode_convert_method][!mayfail]")
+  "[lambdas][java_bytecode][java_bytecode_convert_method][!shouldfail]")
 {
   // NOLINTNEXTLINE(whitespace/braces)
   run_test_with_compilers([](const std::string &compiler) {
@@ -387,7 +387,7 @@ void validate_member_variable_lambda_assignment(
 SCENARIO(
   "Converting invokedynamic with a member lambda",
   "[core]"
-  "[lamdba][java_bytecode][java_bytecode_convert_method][!mayfail]")
+  "[lamdba][java_bytecode][java_bytecode_convert_method][!shouldfail]")
 {
   // NOLINTNEXTLINE(whitespace/braces)
   run_test_with_compilers([](const std::string &compiler) {
@@ -555,7 +555,7 @@ void validate_static_member_variable_lambda_assignment(
 SCENARIO(
   "Converting invokedynamic with a static member lambda",
   "[core]"
-  "[lamdba][java_bytecode][java_bytecode_convert_method][!mayfail]")
+  "[lamdba][java_bytecode][java_bytecode_convert_method][!shouldfail]")
 {
   // NOLINTNEXTLINE(whitespace/braces)
   run_test_with_compilers([](const std::string &compiler) {

--- a/jbmc/unit/solvers/refinement/string_constraint_instantiation/instantiate_not_contains.cpp
+++ b/jbmc/unit/solvers/refinement/string_constraint_instantiation/instantiate_not_contains.cpp
@@ -159,9 +159,9 @@ decision_proceduret::resultt check_sat(const exprt &expr, const namespacet &ns)
   return solver();
 }
 
-// The [!mayfail] tag allows tests to fail while reporting the failure
+// The [!shouldfail] tag checks the tests fail
 SCENARIO("instantiate_not_contains",
-  "[!mayfail][core][solvers][refinement][string_constraint_instantiation]")
+  "[!shouldfail][core][solvers][refinement][string_constraint_instantiation]")
 {
   // For printing expression
   register_language(new_java_bytecode_language);

--- a/unit/util/irep_sharing.cpp
+++ b/unit/util/irep_sharing.cpp
@@ -7,7 +7,7 @@
 
 #ifdef SHARING
 
-SCENARIO("irept_sharing_trade_offs", "[!mayfail][core][utils][irept]")
+SCENARIO("irept_sharing_trade_offs", "[!shouldfail][core][utils][irept]")
 {
   GIVEN("An irept created with move_to_sub")
   {
@@ -114,7 +114,7 @@ SCENARIO("irept_sharing", "[core][utils][irept]")
 
 #include <util/expr.h>
 
-SCENARIO("exprt_sharing_trade_offs", "[!mayfail][core][utils][exprt]")
+SCENARIO("exprt_sharing_trade_offs", "[!shouldfail][core][utils][exprt]")
 {
   GIVEN("An expression created with move_to_operands")
   {


### PR DESCRIPTION
May fail runs the test and if it fails prints the output. Should fail runs the test and only prints the output if it actually passes. This makes it easier when looking at build output to determine which unit test has actually failed.