### PR TITLE
Fix CMake macro

### DIFF
--- a/jbmc/regression/CMakeLists.txt
+++ b/jbmc/regression/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(test_pl_path "${CMAKE_SOURCE_DIR}/regression/test.pl")
+set(test_pl_path "${CBMC_SOURCE_DIR}/../regression/test.pl")
 
 # For the best possible utilisation of multiple cores when
 # running tests in parallel, it is important that these directories are


### PR DESCRIPTION
Using ${CMAKE_SOURCE_DIR} doesn't work e.g. in a repository including
cbmc as a subtree. Instead we use "${CBMC_SOURCE_DIR}/..".