### PR TITLE
Change the symex merge to use the full merge rather than ignoring comments

### DIFF
--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -320,7 +320,7 @@ public:
 
 protected:
   // for enforcing sharing in the expressions stored
-  merge_irept merge_irep;
+  merge_full_irept merge_irep;
   void merge_ireps(SSA_stept &SSA_step);
 };
 


### PR DESCRIPTION
This ensures ireps that differ only by comments aren't inadvertently lost.

Not sure if this is a good idea - discussion welcome!