### PR TITLE
Note when symbol-table entries are abstract methods

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -404,6 +404,9 @@ void java_bytecode_convert_method_lazy(
   }
 
   method_symbol.type=member_type;
+  // Not used in jbmc at present, but other codebases that use jbmc as a library
+  // use this information.
+  method_symbol.type.set(ID_C_abstract, m.is_abstract);
   symbol_table.add(method_symbol);
 }
 

--- a/src/util/irep_ids.def
+++ b/src/util/irep_ids.def
@@ -665,6 +665,7 @@ IREP_ID_TWO(overlay_method, java::com.diffblue.OverlayMethodImplementation)
 IREP_ID_TWO(C_annotations, #annotations)
 IREP_ID_ONE(final)
 IREP_ID_ONE(bits_per_byte)
+IREP_ID_TWO(C_abstract, #abstract)
 
 // Projects depending on this code base that wish to extend the list of
 // available ids should provide a file local_irep_ids.h in their source tree and


### PR DESCRIPTION
Currently Deeptest relies on the somewhat odd, largely accidental behaviour that abstract methods get nondet bodies, rather than just empty bodies as one might expect. This exposes the abstract attribute (as a comment, since abstract and non-abstract methods are type compatible) such that we can make the current odd behaviour a driver-program choice, while the Java frontend does the sensible thing (providing an empty body) per default.