### PR TITLE
Add webhook to invoke a compatibility check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -286,6 +286,7 @@ notifications:
   webhooks:
     urls:
       - http://dashboard.diffblue.com/api/travis-webhooks
+      - https://us-central1-dev-user-joelallred.cloudfunctions.net/trigger-testgen-from-cbmc
     on_success: always
     on_failure: always
     on_start: never


### PR DESCRIPTION
This webhook will trigger a compatibility check with test-generator.
https://github.com/diffblue/test-gen/pull/1883 must be merged first.