### PR TITLE
Install doxygen 1.8.14 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,17 +46,35 @@ jobs:
       before_cache:
 
     - stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 test
-      env: NAME="DOXYGEN-CHECK"
+      env:
+        NAME: "DOXYGEN-CHECK"
+        DOXYGEN_VERSION: "1.8.14"
       addons:
         apt:
           sources:
             - sourceline: 'deb http://packages.cloud.google.com/apt cloud-sdk-trusty main'
               key_url: 'https://packages.cloud.google.com/apt/doc/apt-key.gpg'
           packages:
-            - doxygen
+            - cmake
             - google-cloud-sdk
+      cache:
+        directories:
+          - ${TRAVIS_BUILD_DIR}/doxygen/build/bin
       install:
-      script: scripts/travis_doxygen.sh
+        - |
+          # Build doxygen if it is not in Travis cache
+          if ! [ -x doxygen/build/bin/doxygen ]
+          then
+            mkdir -p doxygen/build \
+            && wget http://ftp.stack.nl/pub/users/dimitri/doxygen-${DOXYGEN_VERSION}.src.tar.gz -O- | tar -xz --strip-components=1 --directory doxygen \
+            && ( cd doxygen/build && cmake .. ) \
+            && make -j4 -C doxygen/build
+          fi
+        - export PATH="$PATH:${TRAVIS_BUILD_DIR}/doxygen/build/bin"
+      script:
+        - echo $PATH
+        - doxygen --version
+        - scripts/travis_doxygen.sh
       before_cache:
       after_success:
         # Google Cloud Integration


### PR DESCRIPTION
travis uses doxygen 1.8.6 which is lacking some essential features, e.g. embedding dot graphs.