### PR TITLE
show-callsites: add an analysis to dump a CFG

### DIFF
--- a/regression/goto-instrument/show-callsites/main.c
+++ b/regression/goto-instrument/show-callsites/main.c
@@ -1,0 +1,61 @@
+#include <stdio.h>
+
+typedef void (*void_fp)(void);
+
+struct ops
+{
+  void_fp a;
+  void_fp b;
+};
+
+void f0(void)
+{
+  printf("%i\n", 0);
+}
+void f1(void)
+{
+  printf("%i\n", 1);
+}
+void f2(void)
+{
+  printf("%i\n", 2);
+}
+void f3(void)
+{
+  void_fp a = f0;
+  printf("%i\n", 3);
+}
+void f4(void)
+{
+  printf("%i\n", 5);
+}
+void f5(void)
+{
+  f4();
+}
+void f6(void)
+{
+  f5();
+}
+
+const void_fp fp_tbl[] = {f2, NULL, f1};
+
+void func()
+{
+  fp_tbl[0]();
+  fp_tbl[1]();
+}
+
+int main()
+{
+  struct ops o;
+
+  o.a = f4;
+  o.b = f5;
+
+  func();
+
+  o.a();
+
+  return 0;
+}

--- a/regression/goto-instrument/show-callsites/test.desc
+++ b/regression/goto-instrument/show-callsites/test.desc
@@ -1,0 +1,28 @@
+CORE
+main.c
+--show-callsites -
+^EXIT=0$
+^SIGNAL=0$
+^main -> func$
+^main -> f5$
+^main -> f4$
+^main -> f2$
+^main -> f0$
+^main -> f1$
+^f5 -> f4$
+^f6 -> f5$
+^func -> f2$
+^__BY_ADDRESS__ -> f1$
+^__BY_ADDRESS__ -> f0$
+^__BY_ADDRESS__ -> f2$
+^__BY_ADDRESS__ -> f4$
+^__BY_ADDRESS__ -> f5$
+--
+^warning: ignoring
+^__BY_ADDRESS__ -> f6$
+^__BY_ADDRESS__ -> main$
+^f4 -> f5$5
+__CPROVER__start ->
+-> __CPROVER__start
+__CPROVER_initialize ->
+-> __CPROVER_initialize

--- a/src/analyses/call_graph.cpp
+++ b/src/analyses/call_graph.cpp
@@ -330,3 +330,17 @@ void call_grapht::drop_internal_functions()
 
   edges.swap(keep_edges);
 }
+
+void call_grapht::add_by_address(
+  const goto_functionst &goto_functions,
+  const irep_idt &caller_name)
+{
+  std::unordered_set<irep_idt> address_functions;
+  compute_address_taken_functions(goto_functions, address_functions);
+
+  for(const auto &address_function : address_functions)
+    if(!is_internal_name(id2string(address_function)))
+      add(caller_name, address_function);
+
+  nodes.insert(caller_name);
+}

--- a/src/analyses/call_graph.cpp
+++ b/src/analyses/call_graph.cpp
@@ -11,6 +11,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "call_graph.h"
 
+#include <goto-programs/compute_called_functions.h>
+
 #include <util/std_expr.h>
 #include <util/xml.h>
 
@@ -303,4 +305,28 @@ optionalt<std::size_t> call_grapht::directed_grapht::get_node_index(
     return optionalt<node_indext>();
   else
     return findit->second;
+}
+
+/// return true, in case name has a CPROVER prefix, or contains a '$' character
+static bool is_internal_name(const irep_idt &name)
+{
+  return has_prefix(id2string(name), CPROVER_PREFIX) ||
+         id2string(name).find('$') != std::string::npos;
+}
+
+void call_grapht::drop_internal_functions()
+{
+  nodest keep_nodes;
+  for(auto &node : nodes)
+    if(!is_internal_name(node))
+      keep_nodes.insert(node);
+
+  nodes.swap(keep_nodes);
+
+  edgest keep_edges;
+  for(auto &edge : edges)
+    if(!is_internal_name(edge.first) && !is_internal_name(edge.second))
+      keep_edges.insert(edge);
+
+  edges.swap(keep_edges);
 }

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -160,6 +160,13 @@ public:
   /// Remove all nodes and edges that refer to internal functions
   void drop_internal_functions();
 
+  /// Add edges from caller_name to all functions whose address is consumed
+  /// \param goto_functions: function of the program to analyze
+  /// \param caller_name: name of the node to be used as the caller
+  void add_by_address(
+    const goto_functionst &goto_functions,
+    const irep_idt &caller_name);
+
 protected:
   void add(const irep_idt &function,
            const goto_programt &body);

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -157,6 +157,9 @@ public:
 
   directed_grapht get_directed_graph() const;
 
+  /// Remove all nodes and edges that refer to internal functions
+  void drop_internal_functions();
+
 protected:
   void add(const irep_idt &function,
            const goto_programt &body);

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -54,7 +54,7 @@ Author: Daniel Kroening, kroening@kroening.com
   "(log):" \
   "(max-var):(max-po-trans):(ignore-arrays)" \
   "(cfg-kill)(no-dependencies)(force-loop-duplication)" \
-  "(call-graph)(reachable-call-graph)" \
+  "(call-graph)(show-callsites):(reachable-call-graph)" \
   OPT_SHOW_CLASS_HIERARCHY \
   "(no-po-rendering)(render-cluster-file)(render-cluster-function)" \
   "(nondet-volatile)(isr):" \


### PR DESCRIPTION
This more or less dumps a CFG, and adds a line that shows all functions
whose address has been consumed. The output is in CSV, so that it can
be consumed easily by further automation.