### PR TITLE
Unstall AppVeyor by checking for the correct file path

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,7 @@ install:
      & 7z x minisat2_2.2.1.orig.tar.gz
      &7z x minisat2_2.2.1.orig.tar
     }
-    if (!(Test-Path jml)) {
+    if (!(Test-Path java-models-library-master\.gitignore)) {
      & appveyor downloadfile https://github.com/diffblue/java-models-library/archive/master.zip -FileName jml.zip
      & 7z x jml.zip
     }


### PR DESCRIPTION
AppVeyor found files existed already:

Extracting archive: jml.zip
--
Path = jml.zip
Type = zip
Physical Size = 89524
Comment = f8c2338ab30278f951c542c7049a0b591689679f
Would you like to replace the existing file:
  Path:     .\java-models-library-master\.gitignore
  Size:     36 bytes (1 KiB)
  Modified: 2018-06-04 10:53:06
with the file from archive:
  Path:     java-models-library-master\.gitignore
  Size:     36 bytes (1 KiB)
  Modified: 2018-06-04 10:53:06