### PR TITLE
Do not use c_qualifiers on goto-program expressions

### DIFF
--- a/src/analyses/does_remove_const.cpp
+++ b/src/analyses/does_remove_const.cpp
@@ -16,7 +16,6 @@
 #include <util/expr.h>
 #include <util/std_code.h>
 #include <util/base_type.h>
-#include <ansi-c/c_qualifiers.h>
 
 /// A naive analysis to look for casts that remove const-ness from pointers.
 /// \param goto_program: the goto program to check
@@ -163,8 +162,6 @@ bool does_remove_constt::does_type_preserve_const_correctness(
 bool does_remove_constt::is_type_at_least_as_const_as(
   const typet &type_more_const, const typet &type_compare) const
 {
-  const c_qualifierst type_compare_qualifiers(type_compare);
-  const c_qualifierst more_constant_qualifiers(type_more_const);
-  return !type_compare_qualifiers.is_constant ||
-    more_constant_qualifiers.is_constant;
+  return !type_compare.get_bool(ID_C_constant) ||
+         type_more_const.get_bool(ID_C_constant);
 }

--- a/src/analyses/module_dependencies.txt
+++ b/src/analyses/module_dependencies.txt
@@ -1,5 +1,4 @@
 analyses
-ansi-c # should go away
 goto-programs
 langapi # should go away
 pointer-analysis

--- a/src/goto-programs/remove_const_function_pointers.cpp
+++ b/src/goto-programs/remove_const_function_pointers.cpp
@@ -16,8 +16,6 @@ Author: Thomas Kiley, thomas.kiley@diffblue.com
 #include <util/std_expr.h>
 #include <util/symbol_table.h>
 
-#include <ansi-c/c_qualifiers.h>
-
 #include "goto_functions.h"
 
 #define LOG(message, irep) \
@@ -786,16 +784,10 @@ bool remove_const_function_pointerst::is_const_expression(
 ///   arrays are implicitly const in C.
 bool remove_const_function_pointerst::is_const_type(const typet &type) const
 {
-  c_qualifierst qualifers(type);
-  if(type.id()==ID_array)
-  {
-    c_qualifierst array_type_qualifers(type.subtype());
-    return qualifers.is_constant || array_type_qualifers.is_constant;
-  }
-  else
-  {
-    return qualifers.is_constant;
-  }
+  if(type.id() == ID_array && type.subtype().get_bool(ID_C_constant))
+    return true;
+
+  return type.get_bool(ID_C_constant);
 }
 
 /// To extract the value of the specific component within a struct

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -20,7 +20,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/type_eq.h>
 #include <util/message.h>
 #include <util/base_type.h>
-#include <ansi-c/c_qualifiers.h>
+
 #include <analyses/does_remove_const.h>
 #include <util/invariant.h>
 


### PR DESCRIPTION
goto-programs are not C specific.

This is step 2 of 3 to remove the (direct) ansi-c dependency of goto-programs. It does right away remove the (direct) dependency on ansi-c of analyses/.