### PR TITLE
Extract some methods from ci lazy methods

### DIFF
--- a/jbmc/src/java_bytecode/ci_lazy_methods.h
+++ b/jbmc/src/java_bytecode/ci_lazy_methods.h
@@ -169,6 +169,9 @@ private:
   const std::vector<irep_idt> &extra_instantiated_classes;
   const select_pointer_typet &pointer_type_selector;
   const synthetic_methods_mapt &synthetic_methods;
+
+  std::unordered_set<irep_idt>
+  entry_point_methods(const symbol_tablet &symbol_table);
 };
 
 #endif // CPROVER_JAVA_BYTECODE_GATHER_METHODS_LAZILY_H

--- a/jbmc/src/java_bytecode/ci_lazy_methods.h
+++ b/jbmc/src/java_bytecode/ci_lazy_methods.h
@@ -188,6 +188,12 @@ private:
     std::unordered_set<irep_idt> &methods_to_convert_later,
     std::unordered_set<irep_idt> &instantiated_classes,
     std::unordered_set<exprt, irep_hash> &virtual_function_calls);
+
+  bool handle_virtual_methods_with_no_callees(
+    std::unordered_set<irep_idt> &methods_to_convert_later,
+    std::unordered_set<irep_idt> &instantiated_classes,
+    const std::unordered_set<exprt, irep_hash> &virtual_function_calls,
+    symbol_tablet &symbol_table);
 };
 
 #endif // CPROVER_JAVA_BYTECODE_GATHER_METHODS_LAZILY_H

--- a/jbmc/src/java_bytecode/ci_lazy_methods.h
+++ b/jbmc/src/java_bytecode/ci_lazy_methods.h
@@ -172,6 +172,22 @@ private:
 
   std::unordered_set<irep_idt>
   entry_point_methods(const symbol_tablet &symbol_table);
+
+  struct convert_method_resultt
+  {
+    bool class_initializer_seen = false;
+    bool new_method_seen = false;
+  };
+
+  convert_method_resultt convert_and_analyze_method(
+    const method_convertert &method_converter,
+    std::unordered_set<irep_idt> &methods_already_populated,
+    const bool class_initializer_already_seen,
+    const irep_idt &method_name,
+    symbol_tablet &symbol_table,
+    std::unordered_set<irep_idt> &methods_to_convert_later,
+    std::unordered_set<irep_idt> &instantiated_classes,
+    std::unordered_set<exprt, irep_hash> &virtual_function_calls);
 };
 
 #endif // CPROVER_JAVA_BYTECODE_GATHER_METHODS_LAZILY_H


### PR DESCRIPTION
This extracts some functions form the ci_lazy_methods operator() whose definition is too long.
I'm not sure about the naming of the extracted function, so please suggest better names if you can.