### PR TITLE
Address selected warnings raised by Visual Studio/AppVeyor

### DIFF
--- a/src/goto-programs/goto_function.h
+++ b/src/goto-programs/goto_function.h
@@ -46,7 +46,7 @@ public:
     type.set(ID_C_hide, true);
   }
 
-  goto_functiont()
+  goto_functiont() : body(), type({}, empty_typet())
   {
   }
 

--- a/src/goto-programs/goto_model.h
+++ b/src/goto-programs/goto_model.h
@@ -92,7 +92,8 @@ public:
 
   bool can_produce_function(const irep_idt &id) const override
   {
-    return goto_functions.function_map.count(id);
+    return goto_functions.function_map.find(id) !=
+           goto_functions.function_map.end();
   }
 };
 
@@ -127,7 +128,8 @@ public:
 
   bool can_produce_function(const irep_idt &id) const override
   {
-    return goto_functions.function_map.count(id);
+    return goto_functions.function_map.find(id) !=
+           goto_functions.function_map.end();
   }
 
 private:

--- a/src/util/arith_tools.h
+++ b/src/util/arith_tools.h
@@ -10,14 +10,13 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_ARITH_TOOLS_H
 #define CPROVER_UTIL_ARITH_TOOLS_H
 
+#include "invariant.h"
 #include "mp_arith.h"
 #include "optional.h"
-#include "invariant.h"
+#include "std_expr.h"
 
 #include "deprecate.h"
 
-class exprt;
-class constant_exprt;
 class typet;
 
 // this one will go away
@@ -49,7 +48,7 @@ struct numeric_castt<mp_integer> final
   optionalt<mp_integer> operator()(const exprt &expr) const
   {
     mp_integer out;
-    if(to_integer(expr, out))
+    if(expr.id() != ID_constant || to_integer(to_constant_expr(expr), out))
       return {};
     return out;
   }

--- a/src/util/arith_tools.h
+++ b/src/util/arith_tools.h
@@ -26,8 +26,6 @@ DEPRECATED("Use the constant_exprt version instead")
 bool to_integer(const exprt &expr, mp_integer &int_value);
 
 // returns 'true' on error
-/// \deprecated: use numeric_cast<mp_integer> instead
-DEPRECATED("Use numeric_cast<mp_integer> instead")
 bool to_integer(const constant_exprt &expr, mp_integer &int_value);
 
 // returns 'true' on error


### PR DESCRIPTION
The AppVeyor log has become almost unreadable for it is cluttered with warnings. The commits in this PR address some of the most frequent ones.