### PR TITLE
Revert undocumented change of 27153d142e

### DIFF
--- a/src/util/ssa_expr.h
+++ b/src/util/ssa_expr.h
@@ -65,7 +65,7 @@ public:
 
   const irep_idt get_l1_object_identifier() const
   {
-    #if 1
+    #if 0
     return get_l1_object().get_identifier();
     #else
     // the above is the clean version, this is the fast one, using


### PR DESCRIPTION
While the functional behaviour is identical, there is a ~10% performance penalty
during symbolic execution when using the non-optimised version.