### PR TITLE
Avoid Visual Studio linker warning

### DIFF
--- a/src/common
+++ b/src/common
@@ -138,7 +138,7 @@ else ifeq ($(BUILD_ENV_),MSVC)
   CP_CXXFLAGS +=
   LINKLIB = lib /NOLOGO /OUT:$@ $^
   LINKBIN = $(CXX) $(LINKFLAGS) /Fe$@ $^ $(LIBS)
-  LINKNATIVE = $(HOSTCXX) /Fe$@ $^
+  LINKNATIVE = $(HOSTCXX) /Fe$@ /nologo /EHsc $^
 ifeq ($(origin CC),default)
   CC = cl
 endif


### PR DESCRIPTION
Now uses the same basic flags for building build tools as it does for compiling
other objects.