### PR TITLE
big-int copyright line

### DIFF
--- a/src/big-int/bigint.hh
+++ b/src/big-int/bigint.hh
@@ -1,5 +1,5 @@
 // $Id: bigint.hh,v 1.12 2009-01-24 15:14:46 kroening Exp $
-
+// Author: Dirk Zoller
 // My own BigInt class, declaration.
 
 #ifndef BIGINT_HH


### PR DESCRIPTION
The linter complains about the absence of a suitably-formatted copyright line (the information is actually present in the file).