### PR TITLE
C++ front-end: support =delete method declarations

### DIFF
--- a/regression/cbmc-cpp/Makefile
+++ b/regression/cbmc-cpp/Makefile
@@ -1,10 +1,10 @@
 default: tests.log
 
 test:
-	@../test.pl -c ../../../src/cbmc/cbmc
+	@../test.pl -p -c ../../../src/cbmc/cbmc
 
 tests.log: ../test.pl
-	@../test.pl -c ../../../src/cbmc/cbmc
+	@../test.pl -p -c ../../../src/cbmc/cbmc
 
 show:
 	@for dir in *; do \

--- a/regression/cbmc-cpp/MethodParam1/main.cpp
+++ b/regression/cbmc-cpp/MethodParam1/main.cpp
@@ -2,6 +2,7 @@
 unsigned x;
 
 class ct {
+public:
   void f(int i) {
     x=x+i;
   }

--- a/regression/cpp/Method_qualifier1/main.cpp
+++ b/regression/cpp/Method_qualifier1/main.cpp
@@ -1,4 +1,4 @@
-#include <assert.h>
+#include <cassert>
 
 class my_class
 {

--- a/regression/cpp/auto1/main.cpp
+++ b/regression/cpp/auto1/main.cpp
@@ -1,4 +1,4 @@
-#include <assert.h>
+#include <cassert>
 
 const auto i=1;
 

--- a/regression/cpp/deleted_function1/main.cpp
+++ b/regression/cpp/deleted_function1/main.cpp
@@ -1,0 +1,19 @@
+class A
+{
+public:
+  void foo() {}
+};
+
+class B : public A
+{
+public:
+  void foo() = delete;
+};
+
+int main()
+{
+  B b;
+  b.foo();
+
+  return 0;
+}

--- a/regression/cpp/deleted_function1/test.desc
+++ b/regression/cpp/deleted_function1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.cpp
+-std=c++11
+^EXIT=(64|1)$
+^SIGNAL=0$
+not accessible
+--
+^warning: ignoring

--- a/regression/cpp/switch1/main.cpp
+++ b/regression/cpp/switch1/main.cpp
@@ -1,4 +1,4 @@
-#include <assert.h>
+#include <cassert>
 
 int main()
 {

--- a/regression/systemc/Array1/main.cpp
+++ b/regression/systemc/Array1/main.cpp
@@ -1,4 +1,4 @@
-#include <assert.h>
+#include <cassert>
 
 #define COPY
 

--- a/regression/systemc/Array2/main.cpp
+++ b/regression/systemc/Array2/main.cpp
@@ -1,4 +1,4 @@
-#include <assert.h>
+#include <cassert>
 
 class myarray {
 

--- a/regression/systemc/Array3/main.cpp
+++ b/regression/systemc/Array3/main.cpp
@@ -1,4 +1,4 @@
-#include <assert.h>
+#include <cassert>
 
 #define FUNCTION
 

--- a/regression/systemc/Array4/main.cpp
+++ b/regression/systemc/Array4/main.cpp
@@ -1,4 +1,4 @@
-#include <assert.h>
+#include <cassert>
 
 #define CLASS
 

--- a/regression/systemc/BitvectorCpp1/main.cpp
+++ b/regression/systemc/BitvectorCpp1/main.cpp
@@ -1,4 +1,4 @@
-#include <assert.h>
+#include <cassert>
 
 int main(int argc, char** argv)
 {

--- a/regression/systemc/BitvectorCpp2/main.cpp
+++ b/regression/systemc/BitvectorCpp2/main.cpp
@@ -1,4 +1,4 @@
-#include <assert.h>
+#include <cassert>
 
 int main(int argc, char** argv)
 {

--- a/regression/systemc/This1/main.cpp
+++ b/regression/systemc/This1/main.cpp
@@ -1,4 +1,4 @@
-#include <assert.h>
+#include <cassert>
 
 class Foo;
 

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -749,8 +749,18 @@ and                 { return cpp98_keyword(TOK_ANDAND); }
 and_eq              { return cpp98_keyword(TOK_ANDASSIGN); }
 bool                { return cpp98_keyword(TOK_BOOL); }
 catch               { return cpp98_keyword(TOK_CATCH); }
-char16_t            { return cpp11_keyword(TOK_CHAR16_T); } // C++11
-char32_t            { return cpp11_keyword(TOK_CHAR32_T); } // C++11
+char16_t            { // C++11, but Visual Studio uses typedefs
+                      if(PARSER.mode == configt::ansi_ct::flavourt::VISUAL_STUDIO)
+                        return make_identifier();
+                      else
+                        return cpp11_keyword(TOK_CHAR16_T);
+                    }
+char32_t            { // C++11, but Visual Studio uses typedefs
+                      if(PARSER.mode == configt::ansi_ct::flavourt::VISUAL_STUDIO)
+                        return make_identifier();
+                      else
+                        return cpp11_keyword(TOK_CHAR32_T);
+                    }
 class               { return cpp98_keyword(TOK_CLASS); }
 compl               { return cpp98_keyword('~'); }
 constexpr           { return cpp11_keyword(TOK_CONSTEXPR); } // C++11

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -450,6 +450,14 @@ void cpp_typecheckt::typecheck_compound_declarator(
 
   if(is_method)
   {
+    if(
+      value.id() == ID_code &&
+      to_code(value).get_statement() == ID_cpp_delete)
+    {
+      value.make_nil();
+      component.set(ID_access, "noaccess");
+    }
+
     component.set(ID_is_inline, declaration.member_spec().is_inline());
 
     // the 'virtual' name of the function

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -1487,13 +1487,11 @@ bool cpp_typecheckt::get_component(
         }
         else
         {
-          #if 0
           error().source_location=source_location;
-          str << "error: member `" << component_name
-              << "' is not accessible (" << component.get(ID_access) << ")";
-          str << "\nstruct name: " << final_type.get(ID_name);
+          error() << "error: member `" << component_name
+                  << "' is not accessible (" << component.get(ID_access) << ")"
+                  << eom;
           throw 0;
-          #endif
         }
       }
 
@@ -1523,12 +1521,10 @@ bool cpp_typecheckt::get_component(
         {
           if(check_component_access(component, final_type))
           {
-            #if 0
             error().source_location=source_location;
-            str << "error: member `" << component_name
-                << "' is not accessible";
+            error() << "error: member `" << component_name
+                    << "' is not accessible" << eom;
             throw 0;
-            #endif
           }
 
           if(object.get_bool(ID_C_lvalue))

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -2494,6 +2494,12 @@ bool Parser::rConstructorDecl(
 
     case TOK_DEFAULT: // C++0x
       {
+        if(!ansi_c_parser.cpp11)
+        {
+          SyntaxError();
+          return false;
+        }
+
         constructor.value()=codet(ID_default);
         set_location(constructor.value(), value);
       }
@@ -2501,6 +2507,12 @@ bool Parser::rConstructorDecl(
 
     case TOK_DELETE: // C++0x
       {
+        if(!ansi_c_parser.cpp11)
+        {
+          SyntaxError();
+          return false;
+        }
+
         constructor.value()=codet(ID_cpp_delete);
         set_location(constructor.value(), value);
       }
@@ -2675,12 +2687,24 @@ bool Parser::rDeclaratorWithInit(
 
       if(lex.LookAhead(0)==TOK_DEFAULT) // C++0x
       {
+        if(!ansi_c_parser.cpp11)
+        {
+          SyntaxError();
+          return false;
+        }
+
         lex.get_token(tk);
         declarator.value()=codet(ID_default);
         set_location(declarator.value(), tk);
       }
       else if(lex.LookAhead(0)==TOK_DELETE) // C++0x
       {
+        if(!ansi_c_parser.cpp11)
+        {
+          SyntaxError();
+          return false;
+        }
+
         lex.get_token(tk);
         declarator.value()=codet(ID_cpp_delete);
         set_location(declarator.value(), tk);

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -663,7 +663,11 @@ configt::cppt::cpp_standardt configt::cppt::default_cpp_standard()
   // g++ 6.3 uses gnu++14
   // g++ 5.4 uses gnu++98
   // clang 6.0 uses c++14
+  #if defined _WIN32
+  return cpp_standardt::CPP14;
+  #else
   return cpp_standardt::CPP98;
+  #endif
 }
 
 void configt::set_arch(const irep_idt &arch)


### PR DESCRIPTION
This enables us to use use cassert instead of assert.h in C++ regression tests,
as Visual Studio's header files make use of this.