### PR TITLE
C++ front-end: fix auto+references after already-typechecked cleanup

### DIFF
--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -61,7 +61,9 @@ bool cpp_typecheckt::has_auto(const typet &type)
 {
   if(type.id() == ID_auto)
     return true;
-  else if(type.id() == ID_merged_type || type.id() == ID_frontend_pointer)
+  else if(
+    type.id() == ID_merged_type || type.id() == ID_frontend_pointer ||
+    type.id() == ID_pointer)
   {
     forall_subtypes(it, type)
       if(has_auto(*it))

--- a/src/cpp/cpp_typecheck_initializer.cpp
+++ b/src/cpp/cpp_typecheck_initializer.cpp
@@ -63,6 +63,14 @@ void cpp_typecheckt::convert_initializer(symbolt &symbol)
   if(is_reference(symbol.type))
   {
     typecheck_expr(symbol.value);
+
+    if(has_auto(symbol.type))
+    {
+      cpp_convert_auto(symbol.type, symbol.value.type());
+      typecheck_type(symbol.type);
+      implicit_typecast(symbol.value, symbol.type);
+    }
+
     reference_initializer(symbol.value, symbol.type);
   }
   else if(cpp_is_pod(symbol.type))


### PR DESCRIPTION
The fixes in 4a47de68416 made apparent that af83568bfb was incomplete.