### PR TITLE
Work around G++ 8 warnings

### DIFF
--- a/jbmc/unit/java_bytecode/java_types/erase_type_arguments.cpp
+++ b/jbmc/unit/java_bytecode/java_types/erase_type_arguments.cpp
@@ -63,6 +63,6 @@ SCENARIO("erase_type_arguments", "[core][java_types]")
     REQUIRE_THROWS_AS(
       erase_type_arguments(
         "testClassName<testTypeArgument1<testTypeArgument2>"),
-      unsupported_java_class_signature_exceptiont &);
+      unsupported_java_class_signature_exceptiont);
   }
 }

--- a/src/util/small_map.h
+++ b/src/util/small_map.h
@@ -146,7 +146,10 @@ private:
     if(n == 0)
       return nullptr;
 
-    T *mem = (T *)realloc(ptr, sizeof(T) * n);
+    // explicitly cast to char * as GCC 8 warns about not using new/delete for
+    // class sharing_node_innert<dstringt, std::basic_string<char>,
+    // std::equal_to<dstringt> >
+    T *mem = (T *)realloc((char *)ptr, sizeof(T) * n);
 
     if(!mem)
       throw std::bad_alloc();
@@ -486,7 +489,11 @@ public:
       std::size_t n = size();
       if(ii < n - 1)
       {
-        memmove(p + ii, p + ii + 1, sizeof(T) * (n - ii - 1));
+        // explicitly cast to char * as GCC 8 warns about not using new/delete
+        // for
+        // class sharing_node_innert<dstringt, std::basic_string<char>,
+        // std::equal_to<dstringt> >
+        memmove((char *)(p + ii), p + ii + 1, sizeof(T) * (n - ii - 1));
       }
 
       p = allocate(p, n - 1);

--- a/unit/testing-utils/catch.hpp
+++ b/unit/testing-utils/catch.hpp
@@ -2245,7 +2245,7 @@ namespace Catch {
                 static_cast<void>(expr); \
                 __catchResult.captureResult( Catch::ResultWas::DidntThrowException ); \
             } \
-            catch( exceptionType ) { \
+            catch( const exceptionType & ) { \
                 __catchResult.captureResult( Catch::ResultWas::Ok ); \
             } \
             catch( ... ) { \


### PR DESCRIPTION
The previous G++-8 cleanup did not include unit tests.