### PR TITLE
Compiling with Solaris 11

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -88,11 +88,8 @@ We assume that you have a Debian/Ubuntu or Red Hat-like distribution.
    ```
 3. Get MiniSat2 by entering
    ```
-   cd cbmc-git
-   wget http://ftp.debian.org/debian/pool/main/m/minisat2/minisat2_2.2.1.orig.tar.gz
-   gtar xfz minisat_2.2.1.orig.tar.gz
-   mv minisat2-2.2.1 minisat-2.2.1
-   (cd minisat-2.2.1; patch -p1 < ../scripts/minisat-2.2.1-patch)
+   cd cbmc-git/src
+   gmake minisat2-download DOWNLOADER=wget
    ```
 4. Type
    ```

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -79,21 +79,23 @@ We assume that you have a Debian/Ubuntu or Red Hat-like distribution.
 
 1. As root, get the necessary development tools:
    ```
-   pkg install system/header developer/lexer/flex developer/parser/bison developer/versioning/git
-   pkg install --accept developer/gcc/gcc-c++-5
+   pkgadd -d http://get.opencsw.org/now
+   /opt/csw/bin/pkgutil -U
+   /opt/csw/bin/pkgutil -i gcc5g++ bison flex git
    ```
 2. As a user, get the CBMC source via
    ```
+   export PATH=/opt/csw/bin:$PATH
    git clone https://github.com/diffblue/cbmc cbmc-git
    ```
 3. Get MiniSat2 by entering
    ```
    cd cbmc-git/src
-   gmake minisat2-download DOWNLOADER=wget
+   gmake minisat2-download DOWNLOADER=wget TAR=gtar
    ```
-4. Type
+4. To compile, type
    ```
-   cd src; gmake
+   gmake
    ```
    That should do it. To run, you will need
    ```

--- a/src/Makefile
+++ b/src/Makefile
@@ -87,11 +87,12 @@ $(patsubst %, %_clean, $(DIRS)):
 # minisat2 and glucose download, for your convenience
 
 DOWNLOADER = lwp-download
+TAR = tar
 
 minisat2-download:
 	@echo "Downloading Minisat 2.2.1"
 	@$(DOWNLOADER) http://ftp.debian.org/debian/pool/main/m/minisat2/minisat2_2.2.1.orig.tar.gz
-	@tar xfz minisat2_2.2.1.orig.tar.gz
+	@$(TAR) xfz minisat2_2.2.1.orig.tar.gz
 	@rm -Rf ../minisat-2.2.1
 	@mv minisat2-2.2.1 ../minisat-2.2.1
 	@(cd ../minisat-2.2.1; patch -p1 < ../scripts/minisat-2.2.1-patch)
@@ -100,7 +101,7 @@ minisat2-download:
 glucose-download:
 	@echo "Downloading glucose-syrup"
 	@$(DOWNLOADER) http://www.labri.fr/perso/lsimon/downloads/softwares/glucose-syrup.tgz
-	@tar xfz glucose-syrup.tgz
+	@$(TAR) xfz glucose-syrup.tgz
 	@rm -Rf ../glucose-syrup
 	@mv glucose-syrup ../
 	@(cd ../glucose-syrup; patch -p1 < ../scripts/glucose-syrup-patch)


### PR DESCRIPTION
This makes installation slightly easier on systems that do not have GNU tar as default (say Solaris).