### PR TITLE
Documentation wording for replace function bodies

### DIFF
--- a/src/goto-programs/generate_function_bodies.h
+++ b/src/goto-programs/generate_function_bodies.h
@@ -37,8 +37,8 @@ protected:
 public:
   virtual ~generate_function_bodiest() = default;
 
-  /// Replace the function body with one based on the implementation
-  /// This will work the same whether or not the function already has a body
+  /// Replace the function body with one based on the replace_function_body
+  /// class being used.
   /// \param function whose body to replace
   /// \param symbol_table of the current goto program
   /// \param function_name Identifier of function


### PR DESCRIPTION
I am closing the PR's I had related to havoc-ing function bodies, as they are superseded by the generate_function_bodies stuff. But I have some minor fixes to the documentation for that class:

~~~
"Replace the function body with one based on the implementation"
~~~
Use of the word "implementation" is confusing, as "implementation" usually means "function body".  Here "implementation" is intended to refer to the derived class used by generate_function_bodies.

The previous wording could be interpreted as "replace the function body with one based on the function body, i.e., a summary of the function body code", which isn't what was intended.

~~~
"This will work the same whether or not the function already has a body"
~~~
Actually there is a PRECONDITION that the function body is not available, so it won't work the same whether or not the function already has a body.