### PR TITLE
Remove unused function get_writeable_symbol

### DIFF
--- a/src/util/symbol_table_base.h
+++ b/src/util/symbol_table_base.h
@@ -178,13 +178,6 @@ public:
     {
       return &**this;
     }
-
-    symbolt &get_writeable_symbol(const irep_idt &identifier)
-    {
-      if(on_get_writeable)
-        on_get_writeable((*this)->first);
-      return it->second;
-    }
   };
 
   virtual iteratort begin() = 0;


### PR DESCRIPTION
The function has no user and no documentation, it's purpose is not entirely
obvious, the named parameter was not used -- a lot of code smell overall.