### PR TITLE
Depth limited search

### DIFF
--- a/src/analyses/call_graph_helpers.cpp
+++ b/src/analyses/call_graph_helpers.cpp
@@ -70,3 +70,29 @@ std::set<irep_idt> get_reaching_functions(
 {
   return get_connected_functions(graph, function, false);
 }
+
+std::set<irep_idt> get_functions_reachable_within_n_steps(
+  const call_grapht::directed_grapht &graph,
+  const std::set<irep_idt> &start_functions,
+  std::size_t &n)
+{
+  std::vector<std::size_t> start_indices;
+  std::set<irep_idt> result;
+
+  for(const auto &func : start_functions)
+    start_indices.push_back(*(graph.get_node_index(func)));
+
+  for(const auto &index : graph.depth_limited_search(start_indices, n))
+    result.insert(graph[index].function);
+
+  return result;
+}
+
+std::set<irep_idt> get_functions_reachable_within_n_steps(
+  const call_grapht::directed_grapht &graph,
+  const irep_idt &start_function,
+  std::size_t &n)
+{
+  std::set<irep_idt> start_functions({ start_function });
+  return get_functions_reachable_within_n_steps(graph, start_functions, n);
+}

--- a/src/analyses/call_graph_helpers.h
+++ b/src/analyses/call_graph_helpers.h
@@ -49,4 +49,28 @@ std::set<irep_idt> get_reachable_functions(
 std::set<irep_idt> get_reaching_functions(
   const call_grapht::directed_grapht &graph, const irep_idt &function);
 
+/// Get either callers or callees reachable from a given
+/// list of functions within N steps
+/// \param graph: call graph
+/// \param start_functions: set of start functions
+/// \param n: number of steps to consider
+/// \return set of functions that can be reached from the start function
+/// including the start function
+std::set<irep_idt> get_functions_reachable_within_n_steps(
+  const call_grapht::directed_grapht &graph,
+  const std::set<irep_idt> &start_functions,
+  std::size_t &n);
+
+/// Get either callers or callees reachable from a given
+/// list of functions within N steps
+/// \param graph: call graph
+/// \param start_function: single start function
+/// \param n: number of steps to consider
+/// \return set of functions that can be reached from the start function
+/// including the start function
+std::set<irep_idt> get_functions_reachable_within_n_steps(
+  const call_grapht::directed_grapht &graph,
+  const irep_idt &start_function,
+  std::size_t &n);
+
 #endif

--- a/unit/analyses/call_graph.cpp
+++ b/unit/analyses/call_graph.cpp
@@ -223,6 +223,48 @@ SCENARIO("call_graph",
         REQUIRE(exported.has_edge(nodes_by_name["B"], nodes_by_name["D"]));
       }
 
+      THEN("We expect {A,B} to be reachable from {A} in 1 step")
+      {
+        irep_idt function_name = "A";
+        std::size_t depth = 1;
+        std::set<irep_idt> reachable = get_functions_reachable_within_n_steps(
+          exported, function_name, depth);
+        REQUIRE(reachable.size() == 2);
+        REQUIRE(reachable.count("A"));
+        REQUIRE(reachable.count("B"));
+      }
+      THEN("We expect {A,B,C,D} to be reachable from {A} in 2 and 3 steps")
+      {
+        irep_idt function_name = "A";
+        std::size_t depth = 2;
+        std::set<irep_idt> reachable = get_functions_reachable_within_n_steps(
+          exported, function_name, depth);
+        REQUIRE(reachable.size() == 4);
+        REQUIRE(reachable.count("A"));
+        REQUIRE(reachable.count("B"));
+        REQUIRE(reachable.count("C"));
+        REQUIRE(reachable.count("D"));
+
+        depth = 3;
+        reachable = get_functions_reachable_within_n_steps(
+          exported, function_name, depth);
+        REQUIRE(reachable.size() == 4);
+        REQUIRE(reachable.count("A"));
+        REQUIRE(reachable.count("B"));
+        REQUIRE(reachable.count("C"));
+        REQUIRE(reachable.count("D"));
+      }
+
+      THEN("We expect only {A} to be reachable from {A} in 0 steps")
+      {
+        irep_idt function_name = "A";
+        std::size_t depth = 0;
+        std::set<irep_idt> reachable = get_functions_reachable_within_n_steps(
+          exported, function_name, depth);
+        REQUIRE(reachable.size() == 1);
+        REQUIRE(reachable.count("A"));
+      }
+
       THEN("We expect A to have successors {A, B}")
       {
         std::set<irep_idt> successors = get_callees(exported, "A");


### PR DESCRIPTION
Implements a depth limited search on a grapht, and a call_grapht helper function that uses this on the directed graph from a a call graph to get functions reachable within N steps. 

This is part of the re-doing of PR #1587