### PR TITLE
Fix: several grapht functions were uncompilable if ever called

### DIFF
--- a/src/util/graph.h
+++ b/src/util/graph.h
@@ -575,12 +575,11 @@ std::size_t grapht<N>::connected_subgraphs(
 
       const nodet &node=nodes[n];
 
-      for(typename edgest::const_iterator
-          it=node.out.begin();
-          it!=node.out.end();
-          it++)
-        if(!visited[*it])
-          s.push(*it);
+      for(const auto &o : node.out)
+      {
+        if(!visited[o.first])
+          s.push(o.first);
+      }
     }
 
     nr++;
@@ -671,20 +670,13 @@ void grapht<N>::make_chordal()
     const nodet &n=tmp[i];
 
     // connect all the nodes in n.out with each other
-
-    for(typename edgest::const_iterator
-        it1=n.out.begin();
-        it1!=n.out.end();
-        it1++)
-      for(typename edgest::const_iterator
-          it2=n.out.begin();
-          it2!=n.out.end();
-          it2++)
+    for(const auto &o1 : n.out)
+      for(const auto &o2 : n.out)
       {
-        if(*it1!=*it2)
+        if(o1.first!=o2.first)
         {
-          tmp.add_undirected_edge(*it1, *it2);
-          this->add_undirected_edge(*it1, *it2);
+          tmp.add_undirected_edge(o1.first, o2.first);
+          this->add_undirected_edge(o1.first, o2.first);
         }
       }
 


### PR DESCRIPTION
This code didn't compile because it accessed `visited`, a `vector<bool>`, using a pair from  `maps<node_indext, nodet> edgest` as the position. It should instead have used the node_indext, the first element of the pair.

These functions are never used in CBMC, and presumably not used by any other tools using CBMC (since the code didn't compile) so they might be candidates for removal anyway.

I've also updated the for loops.