### PR TITLE
Remove dummy implementations from propt

### DIFF
--- a/src/solvers/prop/prop.cpp
+++ b/src/solvers/prop/prop.cpp
@@ -8,30 +8,11 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "prop.h"
 
-#include <cassert>
-
 /// asserts a==b in the propositional formula
 void propt::set_equal(literalt a, literalt b)
 {
   lcnf(a, !b);
   lcnf(!a, b);
-}
-
-void propt::set_assignment(literalt a, bool value)
-{
-  assert(false);
-}
-
-void propt::copy_assignment_from(const propt &src)
-{
-  assert(false);
-}
-
-/// \return true iff the given literal is part of the final conflict
-bool propt::is_in_conflict(literalt l) const
-{
-  assert(false);
-  return false;
 }
 
 /// generates a bitvector of given width with new variables

--- a/src/solvers/prop/prop.h
+++ b/src/solvers/prop/prop.h
@@ -98,13 +98,13 @@ public:
 
   // satisfying assignment
   virtual tvt l_get(literalt a) const=0;
-  virtual void set_assignment(literalt a, bool value);
-  virtual void copy_assignment_from(const propt &prop);
+  virtual void set_assignment(literalt a, bool value) = 0;
 
-  // Returns true if an assumption is in the final conflict.
-  // Note that only literals that are assumptions (see set_assumptions)
-  // may be queried.
-  virtual bool is_in_conflict(literalt l) const;
+  /// Returns true if an assumption is in the final conflict.
+  /// Note that only literals that are assumptions (see set_assumptions)
+  /// may be queried.
+  /// \return true iff the given literal is part of the final conflict
+  virtual bool is_in_conflict(literalt l) const = 0;
   virtual bool has_is_in_conflict() const { return false; }
 
   // an incremental solver may remove any variables that aren't frozen

--- a/src/solvers/sat/dimacs_cnf.cpp
+++ b/src/solvers/sat/dimacs_cnf.cpp
@@ -9,6 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "dimacs_cnf.h"
 
+#include <util/invariant.h>
 #include <util/magic.h>
 
 #include <iostream>
@@ -16,6 +17,17 @@ Author: Daniel Kroening, kroening@kroening.com
 
 dimacs_cnft::dimacs_cnft():break_lines(false)
 {
+}
+
+void dimacs_cnft::set_assignment(literalt a, bool value)
+{
+  UNIMPLEMENTED;
+}
+
+bool dimacs_cnft::is_in_conflict(literalt l) const
+{
+  UNREACHABLE;
+  return false;
 }
 
 dimacs_cnf_dumpt::dimacs_cnf_dumpt(std::ostream &_out):out(_out)

--- a/src/solvers/sat/dimacs_cnf.h
+++ b/src/solvers/sat/dimacs_cnf.h
@@ -24,10 +24,13 @@ public:
 
   // dummy functions
 
-  virtual const std::string solver_text()
+  const std::string solver_text() override
   {
     return "DIMACS CNF";
   }
+
+  void set_assignment(literalt a, bool value) override;
+  bool is_in_conflict(literalt l) const override;
 
 protected:
   void write_problem_line(std::ostream &out);

--- a/unit/miniBDD_new.cpp
+++ b/unit/miniBDD_new.cpp
@@ -163,6 +163,17 @@ public:
 
   bool has_set_to() const override { return false; }
   bool cnf_handled_well() const override { return false; }
+
+  void set_assignment(literalt, bool) override
+  {
+    UNIMPLEMENTED;
+  }
+
+  bool is_in_conflict(literalt) const override
+  {
+    UNREACHABLE;
+    return false;
+  }
 };
 
 SCENARIO("miniBDD", "[core][solver][miniBDD]")


### PR DESCRIPTION
copy_assignment_from is only implemented by cnf_clause_list_assignmentt, and
thus is no longer part of the propt API.