### PR TITLE
Fix coreModels test to match latest java models library

### DIFF
--- a/jbmc/regression/jbmc/coreModels/test.desc
+++ b/jbmc/regression/jbmc/coreModels/test.desc
@@ -3,7 +3,7 @@ test.class
 --show-symbol-table --cp ../../../src/java_bytecode/library/core-models.jar:.
 ^EXIT=0$
 ^SIGNAL=0$
-^Symbol\s*\.*\: java\:\:org\.cprover\.CProver\.\<clinit\>\:\(\)V$
+^Symbol\s*\.*\: java\:\:org\.cprover\.CProver\.\<init\>\:\(\)V$
 --
 --
-tests that the core models are  being loaded by checking if the static initializer for the CProver class was
+tests that the core models are being loaded by checking if the constructor for the CProver class was


### PR DESCRIPTION
As of the update in https://github.com/diffblue/java-models-library/pull/5
cprover.CProver no longer has a static initializer.