### PR TITLE
Fix invariant: value must be strictly positive

### DIFF
--- a/src/solvers/refinement/string_constraint_generator_format.cpp
+++ b/src/solvers/refinement/string_constraint_generator_format.cpp
@@ -374,7 +374,7 @@ exprt string_constraint_generatort::add_axioms_for_format(
         }
         else
         {
-          INVARIANT(fs.index>=0, "index in format should be positive");
+          INVARIANT(fs.index > 0, "index in format should be positive");
           INVARIANT(
             static_cast<std::size_t>(fs.index)<=args.size(),
             "number of format must match specifiers");


### PR DESCRIPTION
A value of zero would result in an invalid memory access later on.