### PR TITLE
Bound the number of attempts my_mkstemps tries to compute a file name

### DIFF
--- a/src/util/tempfile.cpp
+++ b/src/util/tempfile.cpp
@@ -62,7 +62,7 @@ int my_mkstemps(char *template_str, int suffix_len)
   static long long unsigned int random_state;
   random_state+=getpid()+123;
 
-  for(unsigned attempt=0; ; ++attempt)
+  for(unsigned attempt = 0; attempt < 1000; ++attempt)
   {
     unsigned long long number=random_state;
 


### PR DESCRIPTION
Without this bound there are unreachable instructions at the end of the
function.