### PR TITLE
Move unnecessarily inlined implementations to otherwise empty cpp file

### DIFF
--- a/src/util/decision_procedure.cpp
+++ b/src/util/decision_procedure.cpp
@@ -11,4 +11,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "decision_procedure.h"
 
-
+decision_proceduret::~decision_proceduret()
+{
+}

--- a/src/util/decision_procedure.h
+++ b/src/util/decision_procedure.h
@@ -24,6 +24,8 @@ public:
   {
   }
 
+  virtual ~decision_proceduret();
+
   // get a value from satisfying instance if satisfiable
   // returns nil if not available
   virtual exprt get(const exprt &expr) const=0;

--- a/src/util/dstring.cpp
+++ b/src/util/dstring.cpp
@@ -10,3 +10,10 @@ Author: Daniel Kroening, kroening@kroening.com
 /// Container for C-Strings
 
 #include "dstring.h"
+
+#include <ostream>
+
+std::ostream &dstringt::operator<<(std::ostream &out) const
+{
+  return out << as_string();
+}

--- a/src/util/dstring.h
+++ b/src/util/dstring.h
@@ -123,10 +123,7 @@ public:
 
   // output
 
-  std::ostream &operator<<(std::ostream &out) const
-  {
-    return out << as_string();
-  }
+  std::ostream &operator<<(std::ostream &out) const;
 
   // non-standard
 


### PR DESCRIPTION
This provides guidance to the compiler on where to place virtual tables, and
also silences a linker warning.