### PR TITLE
Fix delayed method body conversion for templates

### DIFF
--- a/regression/cpp/Function_Overloading2/main.cpp
+++ b/regression/cpp/Function_Overloading2/main.cpp
@@ -1,10 +1,16 @@
+#ifdef __GNUC__
+#define NOTHROW __attribute__((nothrow))
+#else
+#define NOTHROW
+#endif
+
 namespace std {
   extern "C" {
-    double fabs(double) __attribute__((nothrow)) ;
+    double fabs(double) NOTHROW ;
   }
 
-  __inline float fabs(float x) __attribute__((nothrow));
-  __inline long double fabs(long double x) __attribute__((nothrow));
+  __inline float fabs(float x) NOTHROW;
+  __inline long double fabs(long double x) NOTHROW;
 
   /* original code from CodeWarrior */
   template <class _T>

--- a/regression/cpp/Function_Overloading2/test.desc
+++ b/regression/cpp/Function_Overloading2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cpp/Template_Instantiation5/test.desc
+++ b/regression/cpp/Template_Instantiation5/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/BitvectorSc1/test.desc
+++ b/regression/systemc/BitvectorSc1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 
 ^EXIT=10$

--- a/regression/systemc/BitvectorSc2/test.desc
+++ b/regression/systemc/BitvectorSc2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/EqualOp1/test.desc
+++ b/regression/systemc/EqualOp1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/EqualOp2/test.desc
+++ b/regression/systemc/EqualOp2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 
 ^EXIT=10$

--- a/regression/systemc/EqualOp3/test.desc
+++ b/regression/systemc/EqualOp3/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 
 ^EXIT=10$

--- a/regression/systemc/FunTempl1/test.desc
+++ b/regression/systemc/FunTempl1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/SimpleSc1/test.desc
+++ b/regression/systemc/SimpleSc1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/Template1/test.desc
+++ b/regression/systemc/Template1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/src/cpp/cpp_declarator_converter.cpp
+++ b/src/cpp/cpp_declarator_converter.cpp
@@ -346,9 +346,6 @@ void cpp_declarator_convertert::handle_initializer(
     // no initial value yet
     symbol.value.swap(value);
 
-    if(is_code && declarator.type().id()!=ID_template)
-      cpp_typecheck.add_method_body(&symbol);
-
     if(!is_code)
       cpp_typecheck.convert_initializer(symbol);
   }

--- a/src/cpp/cpp_typecheck.cpp
+++ b/src/cpp/cpp_typecheck.cpp
@@ -54,6 +54,8 @@ void cpp_typecheckt::typecheck()
   for(auto &item : cpp_parse_tree.items)
     convert(item);
 
+  typecheck_method_bodies();
+
   static_and_dynamic_initialization();
 
   do_not_typechecked();

--- a/src/cpp/cpp_typecheck.h
+++ b/src/cpp/cpp_typecheck.h
@@ -338,13 +338,10 @@ protected:
   };
 
   typedef std::list<method_bodyt> method_bodiest;
+  std::set<irep_idt> methods_seen;
   method_bodiest method_bodies;
 
-  void add_method_body(symbolt *_method_symbol)
-  {
-    method_bodies.push_back(method_bodyt(
-      _method_symbol, template_map, instantiation_stack));
-  }
+  void add_method_body(symbolt *_method_symbol);
 
   bool builtin_factory(const irep_idt &);
 
@@ -384,7 +381,7 @@ protected:
   void typecheck_compound_body(symbolt &symbol);
   void typecheck_compound_body(struct_union_typet &type) { UNREACHABLE; }
   void typecheck_enum_body(symbolt &symbol);
-  void typecheck_method_bodies(method_bodiest &);
+  void typecheck_method_bodies();
   void typecheck_compound_bases(struct_typet &type);
   void add_anonymous_members_to_scope(const symbolt &struct_union_symbol);
 

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -11,6 +11,10 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "cpp_typecheck.h"
 
+#ifdef DEBUG
+#include <iostream>
+#endif
+
 #include <algorithm>
 
 #include <util/arith_tools.h>
@@ -395,7 +399,7 @@ void cpp_typecheckt::typecheck_compound_declarator(
   irep_idt identifier;
 
   // the below is a temporary hack
-  // if(is_method || is_static)d
+  // if(is_method || is_static)
   if(id2string(cpp_scopes.current_scope().prefix).find("#anon")==
      std::string::npos ||
      is_method || is_static)

--- a/src/cpp/cpp_typecheck_declaration.cpp
+++ b/src/cpp/cpp_typecheck_declaration.cpp
@@ -6,6 +6,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 \********************************************************************/
 
+
 /// \file
 /// C++ Language Type Checking
 
@@ -19,21 +20,15 @@ void cpp_typecheckt::convert(cpp_declarationt &declaration)
   if(declaration.is_empty())
     return;
 
-  // Record the function bodies so we can check them later.
-  // This function is used recursively, so we save them.
-  method_bodiest old_method_bodies;
-  old_method_bodies.swap(method_bodies);
+  // The function bodies must not be checked here,
+  // but only at the very end when all declarations have been
+  // processed (or considering forward declarations at least)
 
   // templates are done in a dedicated function
   if(declaration.is_template())
     convert_template_declaration(declaration);
   else
     convert_non_template_declaration(declaration);
-
-  method_bodiest b;
-  b.swap(method_bodies);
-  typecheck_method_bodies(b);
-  method_bodies.swap(old_method_bodies);
 }
 
 void cpp_typecheckt::convert_anonymous_union(

--- a/src/cpp/cpp_typecheck_method_bodies.cpp
+++ b/src/cpp/cpp_typecheck_method_bodies.cpp
@@ -9,19 +9,28 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 /// \file
 /// C++ Language Type Checking
 
+#ifdef DEBUG
+#include <iostream>
+#endif
+
 #include "cpp_typecheck.h"
 
-void cpp_typecheckt::typecheck_method_bodies(
-  method_bodiest &bodies)
+void cpp_typecheckt::typecheck_method_bodies()
 {
   instantiation_stackt old_instantiation_stack;
   old_instantiation_stack.swap(instantiation_stack);
 
-  for(auto &b : bodies)
+  while(!method_bodies.empty())
   {
-    symbolt &method_symbol=*b.method_symbol;
-    template_map.swap(b.template_map);
-    instantiation_stack.swap(b.instantiation_stack);
+    // Dangerous not to take a copy here. We'll have to make sure that
+    // convert is never called with the same symbol twice.
+    method_bodyt &method_body = *method_bodies.begin();
+    symbolt &method_symbol = *method_body.method_symbol;
+
+    template_map.swap(method_body.template_map);
+    instantiation_stack.swap(method_body.instantiation_stack);
+
+    method_bodies.erase(method_bodies.begin());
 
     if(method_symbol.name==ID_main)
       add_argc_argv(method_symbol);
@@ -30,9 +39,37 @@ void cpp_typecheckt::typecheck_method_bodies(
     if(body.id()=="cpp_not_typechecked")
       continue;
 
+#ifdef DEBUG
+  std::cout << "convert_method_body: " << method_symbol.name << std::endl;
+  std::cout << "  is_not_nil: " << body.is_not_nil() << std::endl;
+  std::cout << "  !is_zero: " << (!body.is_zero()) << std::endl;
+#endif
     if(body.is_not_nil() && !body.is_zero())
       convert_function(method_symbol);
   }
 
   old_instantiation_stack.swap(instantiation_stack);
+}
+
+void cpp_typecheckt::add_method_body(symbolt *_method_symbol)
+{
+#ifdef DEBUG
+  std::cout << "add_method_body: " << _method_symbol->name << std::endl;
+#endif
+
+  // We have to prevent the same method to be added multiple times
+  //   otherwise we get duplicated symbol prefixes
+  if(methods_seen.find(_method_symbol->name) != methods_seen.end())
+  {
+#ifdef DEBUG
+    std::cout << "  already exists" << std::endl;
+#endif
+    return;
+  }
+  method_bodies.push_back(
+    method_bodyt(_method_symbol, template_map, instantiation_stack));
+
+  // Converting a method body might add method bodies for methods
+  // that we have already analyzed. Hence, we have to keep track.
+  methods_seen.insert(_method_symbol->name);
 }

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -11,6 +11,10 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "cpp_typecheck_resolve.h"
 
+#ifdef DEBUG
+#include <iostream>
+#endif
+
 #include <cstdlib>
 #include <algorithm>
 
@@ -189,6 +193,11 @@ void cpp_typecheck_resolvet::remove_duplicates(
 exprt cpp_typecheck_resolvet::convert_template_parameter(
   const cpp_idt &identifier)
 {
+#ifdef DEBUG
+  std::cout << "RESOLVE MAP:" << std::endl;
+  cpp_typecheck.template_map.print(std::cout);
+#endif
+
   // look up the parameter in the template map
   exprt e=cpp_typecheck.template_map.lookup(identifier.identifier);
 
@@ -668,8 +677,23 @@ void cpp_typecheck_resolvet::make_constructors(
   identifiers.swap(new_identifiers);
 }
 
+void cpp_typecheck_resolvet::resolve_argument(
+  exprt &argument,
+  const cpp_typecheck_fargst &fargs)
+{
+  if(argument.id()=="ambiguous") // could come from a template parameter
+  {
+    // this must be resolved in the template scope
+    cpp_save_scopet save_scope(cpp_typecheck.cpp_scopes);
+    cpp_typecheck.cpp_scopes.go_to(*original_scope);
+
+    argument = resolve(to_cpp_name(argument.type()), wantt::VAR, fargs, false);
+  }
+}
+
 exprt cpp_typecheck_resolvet::do_builtin(
   const irep_idt &base_name,
+  const cpp_typecheck_fargst &fargs,
   const cpp_template_args_non_tct &template_args)
 {
   exprt dest;
@@ -689,7 +713,7 @@ exprt cpp_typecheck_resolvet::do_builtin(
       throw 0;
     }
 
-    const exprt &argument=arguments.front();
+    exprt argument=arguments.front(); // copy
 
     if(argument.id()==ID_type)
     {
@@ -699,6 +723,8 @@ exprt cpp_typecheck_resolvet::do_builtin(
         << "but got type" << messaget::eom;
       throw 0;
     }
+
+    resolve_argument(argument, fargs);
 
     mp_integer i;
     if(to_integer(argument, i))
@@ -732,8 +758,10 @@ exprt cpp_typecheck_resolvet::do_builtin(
       throw 0;
     }
 
-    const exprt &argument0=arguments[0];
-    const exprt &argument1=arguments[1];
+    exprt argument0=arguments[0];
+    resolve_argument(argument0, fargs);
+    exprt argument1=arguments[1];
+    resolve_argument(argument1, fargs);
 
     if(argument0.id()==ID_type)
     {
@@ -901,12 +929,13 @@ cpp_scopet &cpp_typecheck_resolvet::resolve_scope(
           cpp_idt::id_classt::TEMPLATE,
           id_set);
 
-        // std::cout << "S: "
-        //           << cpp_typecheck.cpp_scopes.current_scope().identifier
-        //           << '\n';
-        // cpp_typecheck.cpp_scopes.current_scope().print(std::cout);
-        // std::cout << "X: " << id_set.size() << '\n';
-
+#ifdef DEBUG
+        std::cout << "S: "
+                  << cpp_typecheck.cpp_scopes.current_scope().identifier
+                  << '\n';
+        cpp_typecheck.cpp_scopes.current_scope().print(std::cout);
+        std::cout << "X: " << id_set.size() << '\n';
+#endif
         symbol_typet instance=
           disambiguate_template_classes(final_base_name, id_set, template_args);
 
@@ -1380,6 +1409,14 @@ exprt cpp_typecheck_resolvet::resolve(
   // this changes the scope
   resolve_scope(cpp_name, base_name, template_args);
 
+#ifdef DEBUG
+  std::cout << "base name: " << base_name << std::endl;
+  std::cout << "template args: " << template_args.pretty() << std::endl;
+  std::cout << "original-scope: " << original_scope->prefix << std::endl;
+  std::cout << "scope: "
+            << cpp_typecheck.cpp_scopes.current_scope().prefix << std::endl;
+#endif
+
   const source_locationt &source_location=cpp_name.source_location();
   bool qualified=cpp_name.is_qualified();
 
@@ -1387,7 +1424,7 @@ exprt cpp_typecheck_resolvet::resolve(
   if(qualified)
   {
     if(cpp_typecheck.cpp_scopes.current_scope().identifier=="__CPROVER")
-      return do_builtin(base_name, template_args);
+      return do_builtin(base_name, fargs, template_args);
   }
   else
   {

--- a/src/cpp/cpp_typecheck_resolve.h
+++ b/src/cpp/cpp_typecheck_resolve.h
@@ -116,8 +116,13 @@ protected:
     unsigned &args_distance,
     const cpp_typecheck_fargst &fargs);
 
+  void resolve_argument(
+    exprt &argument,
+    const cpp_typecheck_fargst &fargs);
+
   exprt do_builtin(
     const irep_idt &base_name,
+    const cpp_typecheck_fargst &fargs,
     const cpp_template_args_non_tct &template_args);
 
   void show_identifiers(


### PR DESCRIPTION
Do not add method body on declaration - they are handled upon use.