### PR TITLE
Deprecate get_unsigned_int

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -974,11 +974,11 @@ codet java_bytecode_convert_methodt::get_clinit_call(
   }
 }
 
-static unsigned get_bytecode_type_width(const typet &ty)
+static std::size_t get_bytecode_type_width(const typet &ty)
 {
   if(ty.id()==ID_pointer)
     return 32;
-  return ty.get_unsigned_int(ID_width);
+  return ty.get_size_t(ID_width);
 }
 
 codet java_bytecode_convert_methodt::convert_instructions(

--- a/jbmc/src/java_bytecode/java_utils.cpp
+++ b/jbmc/src/java_bytecode/java_utils.cpp
@@ -34,9 +34,7 @@ unsigned java_local_variable_slots(const typet &t)
   if(t.id()==ID_pointer)
     return 1;
 
-  unsigned bitwidth;
-
-  bitwidth=t.get_unsigned_int(ID_width);
+  const std::size_t bitwidth = t.get_size_t(ID_width);
   INVARIANT(
     bitwidth==8 ||
     bitwidth==16 ||

--- a/src/ansi-c/c_typecast.cpp
+++ b/src/ansi-c/c_typecast.cpp
@@ -277,7 +277,7 @@ typet c_typecastt::follow_with_qualifiers(const typet &src_type)
 c_typecastt::c_typet c_typecastt::get_c_type(
   const typet &type) const
 {
-  unsigned width=type.get_int(ID_width);
+  const std::size_t width = type.get_size_t(ID_width);
 
   if(type.id()==ID_signedbv)
   {

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -1368,7 +1368,7 @@ void c_typecheck_baset::typecheck_c_bit_field_type(c_bit_field_typet &type)
       throw 0;
     }
 
-    sub_width=c_enum_type.subtype().get_int(ID_width);
+    sub_width = c_enum_type.subtype().get_size_t(ID_width);
   }
   else
   {

--- a/src/ansi-c/padding.cpp
+++ b/src/ansi-c/padding.cpp
@@ -124,7 +124,7 @@ underlying_width(const c_bit_field_typet &type, const namespacet &ns)
     const typet &c_enum_type = ns.follow_tag(to_c_enum_tag_type(subtype));
 
     if(c_enum_type.id() == ID_c_enum)
-      return c_enum_type.subtype().get_int(ID_width);
+      return c_enum_type.subtype().get_size_t(ID_width);
     else
       return {};
   }

--- a/src/goto-instrument/accelerate/overflow_instrumenter.cpp
+++ b/src/goto-instrument/accelerate/overflow_instrumenter.cpp
@@ -110,8 +110,8 @@ void overflow_instrumentert::overflow_expr(
     }
 
     const typet &old_type=ns.follow(expr.op0().type());
-    std::size_t new_width=expr.type().get_int(ID_width);
-    std::size_t old_width=old_type.get_int(ID_width);
+    const std::size_t new_width = expr.type().get_size_t(ID_width);
+    const std::size_t old_width = old_type.get_size_t(ID_width);
 
     if(type.id()==ID_signedbv)
     {

--- a/src/solvers/flattening/boolbv_not.cpp
+++ b/src/solvers/flattening/boolbv_not.cpp
@@ -23,7 +23,7 @@ bvt boolbvt::convert_not(const not_exprt &expr)
   {
     if((expr.type().id()==ID_verilog_signedbv ||
         expr.type().id()==ID_verilog_unsignedbv) &&
-        expr.type().get_int(ID_width)==1)
+        expr.type().get_size_t(ID_width) == 1)
     {
       literalt has_x_or_z=bv_utils.verilog_bv_has_x_or_z(op_bv);
       literalt normal_bits_zero=

--- a/src/solvers/flattening/boolbv_reduction.cpp
+++ b/src/solvers/flattening/boolbv_reduction.cpp
@@ -76,7 +76,7 @@ bvt boolbvt::convert_bv_reduction(const unary_exprt &expr)
   {
     if((expr.type().id()==ID_verilog_signedbv ||
         expr.type().id()==ID_verilog_unsignedbv) &&
-        expr.type().get_int(ID_width)==1)
+        expr.type().get_size_t(ID_width) == 1)
     {
       bvt bv;
       bv.resize(2);

--- a/src/solvers/flattening/boolbv_width.cpp
+++ b/src/solvers/flattening/boolbv_width.cpp
@@ -110,7 +110,7 @@ const boolbv_widtht::entryt &boolbv_widtht::get_entry(const typet &type) const
           type_id==ID_verilog_unsignedbv)
   {
     // we encode with two bits
-    entry.total_width=type.get_unsigned_int(ID_width)*2;
+    entry.total_width = type.get_size_t(ID_width) * 2;
     assert(entry.total_width!=0);
   }
   else if(type_id==ID_range)
@@ -186,7 +186,7 @@ const boolbv_widtht::entryt &boolbv_widtht::get_entry(const typet &type) const
   else if(type_id==ID_c_enum)
   {
     // these have a subtype
-    entry.total_width=type.subtype().get_unsigned_int(ID_width);
+    entry.total_width = type.subtype().get_size_t(ID_width);
     assert(entry.total_width!=0);
   }
   else if(type_id==ID_incomplete_c_enum)

--- a/src/util/arith_tools.cpp
+++ b/src/util/arith_tools.cpp
@@ -152,7 +152,8 @@ constant_exprt from_integer(
   }
   else if(type_id==ID_c_enum)
   {
-    std::size_t width=to_c_enum_type(type).subtype().get_unsigned_int(ID_width);
+    const std::size_t width =
+      to_c_enum_type(type).subtype().get_size_t(ID_width);
     constant_exprt result(type);
     result.set_value(integer2binary(int_value, width));
     return result;

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <string>
 #include <vector>
 
+#include "deprecate.h"
 #include "irep_ids.h"
 
 #define SHARING
@@ -207,6 +208,8 @@ public:
   const irep_idt &get(const irep_namet &name) const;
   bool get_bool(const irep_namet &name) const;
   signed int get_int(const irep_namet &name) const;
+  /// \deprecated use get_size_t instead
+  DEPRECATED("Use get_size_t instead")
   unsigned int get_unsigned_int(const irep_namet &name) const;
   std::size_t get_size_t(const irep_namet &name) const;
   long long get_long_long(const irep_namet &name) const;

--- a/unit/util/irep.cpp
+++ b/unit/util/irep.cpp
@@ -185,7 +185,6 @@ SCENARIO("irept_memory", "[core][utils][irept]")
       // variants in the API
       REQUIRE(!irep.get_bool("no_such_id"));
       REQUIRE(irep.get_int("no_such_id") == 0);
-      REQUIRE(irep.get_unsigned_int("no_such_id") == 0u);
       REQUIRE(irep.get_size_t("no_such_id") == 0u);
       REQUIRE(irep.get_long_long("no_such_id") == 0);
 
@@ -199,7 +198,6 @@ SCENARIO("irept_memory", "[core][utils][irept]")
       irep.set("numeric_id", 42);
       REQUIRE(!irep.get_bool("numeric_id"));
       REQUIRE(irep.get_int("numeric_id") == 42);
-      REQUIRE(irep.get_unsigned_int("numeric_id") == 42u);
       REQUIRE(irep.get_size_t("numeric_id") == 42u);
       REQUIRE(irep.get_long_long("numeric_id") == 42);
 


### PR DESCRIPTION
Using "unsigned" is almost always wrong - the type is unrelated to both the
machine type the code is compiled on as well as the width of the platform we are
running an analysis for.

get_unsigned_int specifically was used inconsistently: the same entry (ID_width)
is set via APIs with a parameter of type size_t and several places already used
get_size_t.