### PR TITLE
Replace lambda by member function reference to silence Visual Studio

### DIFF
--- a/src/pointer-analysis/value_set_analysis.cpp
+++ b/src/pointer-analysis/value_set_analysis.cpp
@@ -19,7 +19,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <langapi/language_util.h>
 
 void value_sets_to_xml(
-  std::function<const value_sett &(goto_programt::const_targett)> get_value_set,
+  const std::function<const value_sett &(goto_programt::const_targett)>
+    &get_value_set,
   const goto_programt &goto_program,
   xmlt &dest)
 {

--- a/src/pointer-analysis/value_set_analysis.h
+++ b/src/pointer-analysis/value_set_analysis.h
@@ -21,7 +21,8 @@ Author: Daniel Kroening, kroening@kroening.com
 class xmlt;
 
 void value_sets_to_xml(
-  std::function<const value_sett &(goto_programt::const_targett)> get_value_set,
+  const std::function<const value_sett &(goto_programt::const_targett)>
+    &get_value_set,
   const goto_programt &goto_program,
   xmlt &dest);
 
@@ -39,12 +40,18 @@ public:
   {
   }
 
+  const value_sett &get_value_set(goto_programt::const_targett t)
+  {
+    return (*this)[t].value_set;
+  }
+
   void convert(
     const goto_programt &goto_program,
     xmlt &dest) const
   {
+    using std::placeholders::_1;
     value_sets_to_xml(
-      [this](locationt l) { return (*this)[l].value_set; },
+      std::bind(&value_set_analysis_templatet::get_value_set, *this, _1),
       goto_program,
       dest);
   }


### PR DESCRIPTION
Visual Studio previously warned about a reference to a local or temporary being
returned. This seems spurious, possibly caused by "this" being passed by-value
to the lambda and Visual Studio thus assuming a copy was being created. Going
via a reference to a member function makes Visual Studio happy (and should not
change the behaviour in any way).