### PR TITLE
Make direct children of a class publicly available

### DIFF
--- a/jbmc/unit/java_bytecode/goto-programs/class_hierarchy_graph.cpp
+++ b/jbmc/unit/java_bytecode/goto-programs/class_hierarchy_graph.cpp
@@ -27,7 +27,7 @@ void require_parent_child_relationship(
 }
 
 SCENARIO(
-  "Output a simple class hierarchy"
+  "Output a simple class hierarchy graph",
   "[core][goto-programs][class_hierarchy_graph]")
 {
   symbol_tablet symbol_table =

--- a/jbmc/unit/java_bytecode/goto-programs/class_hierarchy_graph.cpp
+++ b/jbmc/unit/java_bytecode/goto-programs/class_hierarchy_graph.cpp
@@ -46,3 +46,91 @@ SCENARIO(
   require_parent_child_relationship(
     "HierarchyTestInterface2", "HierarchyTestGrandchild", hierarchy);
 }
+
+SCENARIO(
+  "class_hierarchy_graph",
+  "[core][goto-programs][class_hierarchy_graph]")
+{
+  symbol_tablet symbol_table =
+    load_java_class("HierarchyTest", "./java_bytecode/goto-programs/");
+  class_hierarchy_grapht hierarchy;
+  hierarchy.populate(symbol_table);
+
+  WHEN("Retrieving direct children of a given class")
+  {
+    const class_hierarchy_grapht::idst ht_direct_children =
+      hierarchy.get_direct_children("java::HierarchyTest");
+    THEN("The correct list of direct children should be returned")
+    {
+      REQUIRE(ht_direct_children.size() == 2);
+      REQUIRE(
+        find(
+          ht_direct_children.begin(),
+          ht_direct_children.end(),
+          "java::HierarchyTestChild1") != ht_direct_children.end());
+      REQUIRE(
+        find(
+          ht_direct_children.begin(),
+          ht_direct_children.end(),
+          "java::HierarchyTestChild2") != ht_direct_children.end());
+    }
+  }
+  WHEN("Retrieving all children of a given class")
+  {
+    const class_hierarchy_grapht::idst ht_all_children =
+      hierarchy.get_children_trans("java::HierarchyTest");
+    THEN("The correct list of children should be returned")
+    {
+      REQUIRE(ht_all_children.size() == 3);
+      REQUIRE(
+        find(
+          ht_all_children.begin(),
+          ht_all_children.end(),
+          "java::HierarchyTestChild1") != ht_all_children.end());
+      REQUIRE(
+        find(
+          ht_all_children.begin(),
+          ht_all_children.end(),
+          "java::HierarchyTestChild2") != ht_all_children.end());
+      REQUIRE(
+        find(
+          ht_all_children.begin(),
+          ht_all_children.end(),
+          "java::HierarchyTestGrandchild") != ht_all_children.end());
+    }
+  }
+  WHEN("Retrieving all parents of a given class")
+  {
+    const class_hierarchy_grapht::idst htg_all_parents =
+      hierarchy.get_parents_trans("java::HierarchyTestGrandchild");
+    THEN("The correct list of parents should be returned")
+    {
+      REQUIRE(htg_all_parents.size() == 5);
+      REQUIRE(
+        find(
+          htg_all_parents.begin(),
+          htg_all_parents.end(),
+          "java::HierarchyTestChild1") != htg_all_parents.end());
+      REQUIRE(
+        find(
+          htg_all_parents.begin(),
+          htg_all_parents.end(),
+          "java::HierarchyTest") != htg_all_parents.end());
+      REQUIRE(
+        find(
+          htg_all_parents.begin(),
+          htg_all_parents.end(),
+          "java::HierarchyTestInterface1") != htg_all_parents.end());
+      REQUIRE(
+        find(
+          htg_all_parents.begin(),
+          htg_all_parents.end(),
+          "java::HierarchyTestInterface2") != htg_all_parents.end());
+      REQUIRE(
+        find(
+          htg_all_parents.begin(),
+          htg_all_parents.end(),
+          "java::java.lang.Object") != htg_all_parents.end());
+    }
+  }
+}

--- a/jbmc/unit/java_bytecode/goto-programs/class_hierarchy_output.cpp
+++ b/jbmc/unit/java_bytecode/goto-programs/class_hierarchy_output.cpp
@@ -30,7 +30,7 @@ void require_parent_child_relationship(
 }
 
 SCENARIO(
-  "Output a simple class hierarchy"
+  "Output a simple class hierarchy",
   "[core][goto-programs][class_hierarchy]")
 {
   symbol_tablet symbol_table =

--- a/src/goto-programs/class_hierarchy.cpp
+++ b/src/goto-programs/class_hierarchy.cpp
@@ -20,37 +20,6 @@ Date: April 2016
 #include <util/std_types.h>
 #include <util/symbol_table.h>
 
-/// Looks for all the struct types in the symbol table and construct a map from
-/// class names to a data structure that contains lists of parent and child
-/// classes for each struct type (ie class).
-/// \param symbol_table: The symbol table to analyze
-void class_hierarchyt::operator()(const symbol_tablet &symbol_table)
-{
-  for(const auto &symbol_pair : symbol_table.symbols)
-  {
-    if(symbol_pair.second.is_type && symbol_pair.second.type.id() == ID_struct)
-    {
-      const struct_typet &struct_type = to_struct_type(symbol_pair.second.type);
-
-      class_map[symbol_pair.first].is_abstract =
-        struct_type.get_bool(ID_abstract);
-
-      const irept::subt &bases=
-        struct_type.find(ID_bases).get_sub();
-
-      for(const auto &base : bases)
-      {
-        irep_idt parent=base.find(ID_type).get(ID_identifier);
-        if(parent.empty())
-          continue;
-
-        class_map[parent].children.push_back(symbol_pair.first);
-        class_map[symbol_pair.first].parents.push_back(parent);
-      }
-    }
-  }
-}
-
 /// Populate the class hierarchy graph, such that there is a node for every
 /// struct type in the symbol table and an edge representing each superclass
 /// <-> subclass relationship, pointing from parent to child.
@@ -168,6 +137,36 @@ void class_hierarchyt::get_children_trans_rec(
   // recursive calls
   for(const auto &child : entry.children)
     get_children_trans_rec(child, dest);
+}
+
+/// Looks for all the struct types in the symbol table and construct a map from
+/// class names to a data structure that contains lists of parent and child
+/// classes for each struct type (ie class).
+/// \param symbol_table: The symbol table to analyze
+void class_hierarchyt::operator()(const symbol_tablet &symbol_table)
+{
+  for(const auto &symbol_pair : symbol_table.symbols)
+  {
+    if(symbol_pair.second.is_type && symbol_pair.second.type.id() == ID_struct)
+    {
+      const struct_typet &struct_type = to_struct_type(symbol_pair.second.type);
+
+      class_map[symbol_pair.first].is_abstract =
+        struct_type.get_bool(ID_abstract);
+
+      const irept::subt &bases = struct_type.find(ID_bases).get_sub();
+
+      for(const auto &base : bases)
+      {
+        irep_idt parent = base.find(ID_type).get(ID_identifier);
+        if(parent.empty())
+          continue;
+
+        class_map[parent].children.push_back(symbol_pair.first);
+        class_map[symbol_pair.first].parents.push_back(parent);
+      }
+    }
+  }
 }
 
 /// Get all the classes that class c inherits from (directly or indirectly). The

--- a/src/goto-programs/class_hierarchy.h
+++ b/src/goto-programs/class_hierarchy.h
@@ -89,6 +89,8 @@ public:
 class class_hierarchy_grapht : public grapht<class_hierarchy_graph_nodet>
 {
 public:
+  typedef std::vector<irep_idt> idst;
+
   /// Maps class identifiers onto node indices
   typedef std::unordered_map<irep_idt, node_indext> nodes_by_namet;
 
@@ -101,9 +103,19 @@ public:
     return nodes_by_name;
   }
 
+  idst get_direct_children(const irep_idt &c) const;
+
+  idst get_children_trans(const irep_idt &c) const;
+
+  idst get_parents_trans(const irep_idt &c) const;
+
 private:
   /// Maps class identifiers onto node indices
   nodes_by_namet nodes_by_name;
+
+  idst ids_from_indices(const std::vector<node_indext> &nodes) const;
+
+  idst get_other_reachable_ids(const irep_idt &c, bool forwards) const;
 };
 
 /// Output the class hierarchy

--- a/src/goto-programs/class_hierarchy.h
+++ b/src/goto-programs/class_hierarchy.h
@@ -34,6 +34,12 @@ class symbol_tablet;
 class json_stream_arrayt;
 class message_handlert;
 
+/// Non-graph-based representation of the class hierarchy.
+/// \deprecated `class_hierarchy_grapht` is a more advanced graph-based
+///   representation of the class hierarchy and its use is preferred over
+///   `class_hierarchy_classt`.
+/// \todo Implement missing functions from `class_hierarchyt` in
+///   `class_hierarchy_grapht` so that `class_hierarchyt` can be fully replaced.
 class class_hierarchyt
 {
 public:


### PR DESCRIPTION
Previously it was only possible to retrieve all children of a class (i.e. those that inherit directly and those that inherit by transitivity) given its ID. The new function retrieves only those children that inherit directly from the given class.

This new function is not used anywhere in CBMC but will be useful for Diffblue code.

I'm not sure how I would write a unit test for this, so if you think a test is necessary, some advice on that would be appreciated. It looks like there are no tests for anything in `class_hierarchy.h` in `cbmc/unit`, but there are some tests related to this file in `jbmc/unit/java_bytecode/goto-programs`. I'm not sure if those tests are supposed to be in the `jbmc` folder as the code in `goto-programs` is not Java-specific? In any case, the change in this PR is quite small so maybe a test is not necessary. Let me know what you think.