### PR TITLE
add noexcept to frequently used constructors

### DIFF
--- a/src/big-int/bigint.cc
+++ b/src/big-int/bigint.cc
@@ -464,8 +464,7 @@ BigInt::BigInt (BigInt const &y)
   memcpy (digit, y.digit, length * sizeof (onedig_t));
 }
 
-BigInt::BigInt (BigInt &&y)
-  : BigInt()
+BigInt::BigInt(BigInt &&y) noexcept : BigInt()
 {
   swap(y);
 }

--- a/src/big-int/bigint.hh
+++ b/src/big-int/bigint.hh
@@ -168,7 +168,7 @@ public:
   BigInt (llong_t) _fast;
   BigInt (ullong_t) _fast;
   BigInt (BigInt const &) _fast;
-  BigInt (BigInt &&) _fast;
+  BigInt (BigInt &&) noexcept _fast;
   BigInt (char const *, onedig_t = 10) _fast;
 
   BigInt &operator= (BigInt const &) _fast;

--- a/src/util/dstring.h
+++ b/src/util/dstring.h
@@ -36,10 +36,11 @@ class dstringt final
 {
 public:
   // this is safe for static objects
-  #ifdef __GNUC__
+#ifdef __GNUC__
   constexpr
-  #endif
-  dstringt():no(0)
+#endif
+    dstringt() noexcept
+    : no(0)
   {
   }
 

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -57,7 +57,9 @@ public:
   typedef std::vector<exprt> operandst;
 
   // constructors
-  exprt() { }
+  exprt() noexcept
+  {
+  }
   explicit exprt(const irep_idt &_id):irept(_id) { }
   exprt(const irep_idt &_id, const typet &_type):irept(_id)
   {

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -169,9 +169,9 @@ public:
   bool is_nil() const { return id()==ID_nil; }
   bool is_not_nil() const { return id()!=ID_nil; }
 
-  explicit irept(const irep_idt &_id)
+  explicit irept(const irep_idt &_id) noexcept
 #ifdef SHARING
-    :data(&empty_d)
+    : data(&empty_d)
 #endif
   {
     id(_id);
@@ -179,12 +179,12 @@ public:
 
   #ifdef SHARING
   // constructor for blank irep
-  irept():data(&empty_d)
+  irept() noexcept : data(&empty_d)
   {
   }
 
   // copy constructor
-  irept(const irept &irep):data(irep.data)
+  irept(const irept &irep) noexcept : data(irep.data)
   {
     if(data!=&empty_d)
     {
@@ -201,7 +201,7 @@ public:
   // Copy from rvalue reference.
   // Note that this does avoid a branch compared to the
   // standard copy constructor above.
-  irept(irept &&irep):data(irep.data)
+  irept(irept &&irep) noexcept : data(irep.data)
   {
     #ifdef IREP_DEBUG
     std::cout << "COPY MOVE\n";
@@ -231,7 +231,7 @@ public:
   #ifdef USE_MOVE
   // Note that the move assignment operator does avoid
   // three branches compared to standard operator above.
-  irept &operator=(irept &&irep)
+  irept &operator=(irept &&irep) noexcept
   {
     #ifdef IREP_DEBUG
     std::cout << "ASSIGN MOVE\n";


### PR DESCRIPTION
noexcept on move constructors may help with some STL methods, e.g., vector::push_back.
The benefit should be measured.
