### PR TITLE
Compiling Xen with CBMC: docker file "expensive regression test"

### DIFF
--- a/integration/xen/Dockerfile
+++ b/integration/xen/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get --no-install-recommends -y install \
+        build-essential gcc git make flex bison \
+        software-properties-common libwww-perl python \
+        bin86 gdb bcc liblzma-dev python-dev gettext iasl \
+        uuid-dev libncurses5-dev libncursesw5-dev pkg-config \
+        libgtk2.0-dev libyajl-dev sudo time
+
+ADD integration/xen/docker_compile_xen.sh docker_compile_xen.sh
+ADD src /tmp/cbmc/src
+RUN ./docker_compile_xen.sh
+VOLUME /tmp/cbmc
+VOLUME /tmp/xen_compilation

--- a/integration/xen/Makefile
+++ b/integration/xen/Makefile
@@ -1,0 +1,9 @@
+CONTAINER_ID = xen_build_container
+IMAGE_ID = xen_image
+
+all:
+	if docker ps | grep -q ^$(CONTAINER_ID) ; then \
+		docker rm xen_build_container ; \
+	fi
+	cd ../../ && docker build -t $(IMAGE_ID) -f integration/xen/Dockerfile .
+	docker run -i -t --name $(CONTAINER_ID) $(IMAGE_ID) /bin/bash

--- a/integration/xen/docker_compile_xen.sh
+++ b/integration/xen/docker_compile_xen.sh
@@ -1,0 +1,34 @@
+#/bin/bash
+
+set -e
+
+cd /tmp/cbmc/src
+
+make minisat2-download
+make -j$(nproc)
+
+mkdir /tmp/xen_compilation
+cd /tmp/xen_compilation
+ln -s /tmp/cbmc/src/goto-cc/goto-cc goto-ld
+ln -s /tmp/cbmc/src/goto-cc/goto-cc goto-gcc
+ln -s /tmp/cbmc/src/goto-cc/goto-cc goto-diff
+
+git clone https://github.com/awslabs/one-line-scan.git
+
+git clone git://xenbits.xen.org/xen.git
+
+export PATH=$(pwd)/one-line-scan/configuration:$PATH
+export PATH=$(pwd):$PATH
+
+cd xen
+if one-line-scan \
+  --no-analysis --trunc-existing \
+  --extra-cflags -Wno-error \
+  -o CPROVER -j $(($(nproc)/4)) -- make xen -j$(nproc)
+then
+  echo "SUCCESS: Compilation of Xen succeeded"
+else
+  echo -n "FAILED: Compilation of Xen failed."
+  echo -n " The build log can be found in"
+  echo " /tmp/xen_compilation/xen/CPROVER/build.log"
+fi


### PR DESCRIPTION
Compilation of Xen with goto-cc currently fails, although at some point in the past it has worked. I would obviously like the compilation to work again (and for that separate issues are being filed), but I would also like some kind of "expensive" regression test to prevent this kind of degradation happening in future. 

This PR adds scripts to create a docker container that compiles Xen with goto-cc. In effect, everything we need the regression test to do. I don't know how it would be best to have this set up as an actual regression test though.

To create the docker file, on a machine with docker installed, run the following script from the cbmc top directory
~~~
./make_xen_docker_container.sh
~~~
This creates a docker container based on the Dockerfile. The docker container runs the script "scrpts/docker_compile_xen.sh", which:
- adds the soft links required from goto-cc to goto-ld, goto-gcc and goto-diff
- downloads https://github.com/awslabs/one-line-scan.git
- downloads Xen
- attempts to compile Xen with goto-cc
- shows an error message, and paths to the build log if the compilation fails
