### PR TITLE
represent numerical values in CBMC trace in hex

### DIFF
--- a/regression/cbmc/hex_trace/main.c
+++ b/regression/cbmc/hex_trace/main.c
@@ -1,0 +1,12 @@
+int main()
+{
+	int a;
+	unsigned int b;
+	a = 0;
+	a = -100;
+	a = 2147483647;
+	b = a*2;
+	a = -2147483647;
+	__CPROVER_assert(0,"");
+
+}

--- a/regression/cbmc/hex_trace/test.desc
+++ b/regression/cbmc/hex_trace/test.desc
@@ -4,10 +4,10 @@ main.c
 ^EXIT=10$
 ^SIGNAL=0$
 a=0 \s*\(0x0\)
-b=0u \s*\(0x0\)
+b=0ul? \s*\(0x0\)
 a=-100 \s*\(0xFFFFFF9C\)
 a=2147483647 \s*\(0x7FFFFFFF\)
-b=4294967294u \s*\(0xFFFFFFFE\)
+b=4294967294ul? \s*\(0xFFFFFFFE\)
 a=-2147483647 \s*\(0x80000001\)
 ^VERIFICATION FAILED$
 --

--- a/regression/cbmc/hex_trace/test.desc
+++ b/regression/cbmc/hex_trace/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--trace-hex --trace
+^EXIT=10$
+^SIGNAL=0$
+a=0 \s*\(0x0\)
+b=0u \s*\(0x0\)
+a=-100 \s*\(0xFFFFFF9C\)
+a=2147483647 \s*\(0x7FFFFFFF\)
+b=4294967294u \s*\(0xFFFFFFFE\)
+a=-2147483647 \s*\(0x80000001\)
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/src/cbmc/all_properties.cpp
+++ b/src/cbmc/all_properties.cpp
@@ -175,7 +175,8 @@ void bmc_all_propertiest::report(const cover_goalst &cover_goals)
           if(g.second.status==goalt::statust::FAILURE)
           {
             result() << "\n" << "Trace for " << g.first << ":" << "\n";
-            show_goto_trace(result(), bmc.ns, g.second.goto_trace);
+            show_goto_trace(
+              result(), bmc.ns, g.second.goto_trace, bmc.trace_options());
           }
       }
       result() << eom;

--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -55,7 +55,7 @@ void bmct::error_trace()
   {
   case ui_message_handlert::uit::PLAIN:
     result() << "Counterexample:" << eom;
-    show_goto_trace(result(), ns, goto_trace);
+    show_goto_trace(result(), ns, goto_trace, trace_options());
     result() << eom;
     break;
 

--- a/src/goto-programs/goto_trace.h
+++ b/src/goto-programs/goto_trace.h
@@ -195,10 +195,40 @@ public:
   }
 };
 
+struct trace_optionst
+{
+  bool json_full_lhs;
+  bool hex_representation;
+  bool base_prefix;
+
+  static const trace_optionst default_options;
+
+  explicit trace_optionst(const optionst &options)
+  {
+    json_full_lhs = options.get_bool_option("trace-json-extended");
+    hex_representation = options.get_bool_option("trace-hex");
+    base_prefix = hex_representation;
+  };
+
+private:
+  trace_optionst()
+  {
+    json_full_lhs = false;
+    hex_representation = false;
+    base_prefix = false;
+  };
+};
+
 void show_goto_trace(
   std::ostream &out,
   const namespacet &,
   const goto_tracet &);
+
+void show_goto_trace(
+  std::ostream &out,
+  const namespacet &,
+  const goto_tracet &,
+  const trace_optionst &);
 
 void trace_value(
   std::ostream &out,
@@ -208,32 +238,18 @@ void trace_value(
   const exprt &value);
 
 
-struct trace_optionst
-{
-  bool json_full_lhs;
-
-  static const trace_optionst default_options;
-
-  explicit trace_optionst(const optionst &options)
-  {
-    json_full_lhs = options.get_bool_option("trace-json-extended");
-  };
-
-private:
-  trace_optionst()
-  {
-    json_full_lhs = false;
-  };
-};
-
-#define OPT_GOTO_TRACE "(trace-json-extended)"
+#define OPT_GOTO_TRACE "(trace-json-extended)" \
+                       "(trace-hex)"
 
 #define HELP_GOTO_TRACE                                                        \
-  " --trace-json-extended        add rawLhs property to trace\n"
+  " --trace-json-extended        add rawLhs property to trace\n"              \
+  " --trace-hex                  represent plain trace values in hex\n"
 
 #define PARSE_OPTIONS_GOTO_TRACE(cmdline, options)                             \
   if(cmdline.isset("trace-json-extended"))                                     \
-    options.set_option("trace-json-extended", true);
+    options.set_option("trace-json-extended", true);                           \
+  if(cmdline.isset("trace-hex"))                                               \
+    options.set_option("trace-hex", true);
 
 
 #endif // CPROVER_GOTO_PROGRAMS_GOTO_TRACE_H


### PR DESCRIPTION
This adds an option to represent numeric values in the CBMC trace in hex