### PR TITLE
Value set: fix types of ID_unknown returned from an address-of operator

### DIFF
--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -448,7 +448,26 @@ void value_sett::get_value_set_rec(
     if(expr.operands().size()!=1)
       throw expr.id_string()+" expected to have one operand";
 
-    get_reference_set(expr.op0(), dest, ns);
+    object_mapt references;
+    get_reference_set(expr.op0(), references, ns);
+
+    for(auto &value : references.read())
+    {
+      const exprt &expr = object_numbering[value.first];
+      if(expr.id() == ID_unknown)
+      {
+        // Translate Unknown(type) -> Unknown(Type *)
+        // Note this is only needed for unknowns as object descriptors are
+        // expected to have the dereferenced type.
+        exprt new_expr = expr;
+        new_expr.type() = original_type;
+        insert(dest, new_expr, value.second);
+      }
+      else
+      {
+        insert(dest, value);
+      }
+    }
   }
   else if(expr.id()==ID_dereference)
   {

--- a/unit/pointer-analysis/value_set_type_consistency.cpp
+++ b/unit/pointer-analysis/value_set_type_consistency.cpp
@@ -1,0 +1,109 @@
+/*******************************************************************\
+
+Module: Value-set type consistency tests
+
+Author: Diffblue Ltd, 2018
+
+\*******************************************************************/
+
+#include <testing-utils/catch.hpp>
+
+#include <ansi-c/ansi_c_language.h>
+
+#include <cbmc/cbmc_parse_options.h>
+
+#include <langapi/language_ui.h>
+#include <langapi/language_util.h>
+#include <langapi/mode.h>
+
+#include <pointer-analysis/value_set_analysis.h>
+
+#include <util/config.h>
+
+#include <iostream>
+
+SCENARIO("value-set type consistency")
+{
+  GIVEN("A simple C program that manipulates pointers")
+  {
+    register_language(new_ansi_c_language);
+    cmdlinet cmdline;
+    cmdline.args.push_back(
+      "pointer-analysis/value_set_type_consistency_test.c");
+    config.main = "main";
+    config.set(cmdline);
+
+    optionst opts;
+    cbmc_parse_optionst::set_default_options(opts);
+
+    ui_message_handlert msg_handler(cmdline, "value-set-type-consistency-test");
+    messaget msg(msg_handler);
+
+    goto_modelt goto_model;
+    int ret = cbmc_parse_optionst::get_goto_program(
+      goto_model, opts, cmdline, msg, msg_handler);
+    REQUIRE(ret == -1);
+
+    namespacet ns(goto_model.symbol_table);
+    value_set_analysist vsa(ns);
+
+    WHEN("Value-set analysis analyses the program")
+    {
+      vsa(goto_model.goto_functions);
+
+      THEN("All value sets should be type-consistent with the query expression")
+      {
+        forall_goto_functions(function_it, goto_model.goto_functions)
+        {
+          // Gather expressions to query -- we could be more thorough, but for
+          // now we'll check any expression used as an assignment LHS.
+          std::vector<exprt> exprs_to_query;
+
+          forall_goto_program_instructions(
+            instruction_it, function_it->second.body)
+          {
+            if(instruction_it->is_assign())
+            {
+              exprs_to_query.push_back(
+                to_code_assign(instruction_it->code).lhs());
+            }
+          }
+
+          // Check that at every program point, any ID_unknown expression
+          // returned has the same type as the query expression.
+
+          forall_goto_program_instructions(
+            instruction_it, function_it->second.body)
+          {
+            const value_sett &value_set = vsa[instruction_it].value_set;
+            for(const exprt &expr : exprs_to_query)
+            {
+              value_setst::valuest result;
+              value_set.get_value_set(expr, result, ns);
+
+              for(const exprt &result_expr : result)
+              {
+                if(result_expr.id() == ID_unknown)
+                {
+                  if(result_expr.type() != expr.type())
+                  {
+                    // Known bug / inconsistency: the __CPROVER_threads_exited
+                    // variable is of type _Bool [INFINITY()], but get_value_set
+                    // returns an unknown of type _Bool.
+                    if(expr.type().id() == ID_array)
+                      continue;
+
+                    std::cerr << from_type(ns, "", result_expr.type())
+                              << " vs. " << from_type(ns, "", expr.type())
+                              << "(" << from_expr(ns, "", expr) << ")\n";
+                  }
+                  REQUIRE(result_expr.type() == expr.type());
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/unit/pointer-analysis/value_set_type_consistency_test.c
+++ b/unit/pointer-analysis/value_set_type_consistency_test.c
@@ -1,0 +1,34 @@
+
+#include <stdlib.h>
+
+static char global_object;
+
+struct composite {
+  int x;
+  int y;
+};
+
+int main(int argc, char **argv) {
+
+  char stack_object;
+  char *dynamic_pointer = (char*)malloc(1);
+  char *stack_pointer = &stack_object;
+  char *global_pointer = &global_object;
+  // Integer -> pointer is denoted integer_address, but float -> pointer gets a
+  // general ID_unknown.
+  char *unknown_pointer = (char*)1.0;
+
+  char *any_pointer =
+    argc == 0 ? dynamic_pointer :
+    argc == 1 ? stack_pointer :
+    argc == 2 ? global_pointer :
+    unknown_pointer;
+
+  char *dynamic_pointer_with_offset = &(dynamic_pointer[4]);
+  char *stack_pointer_with_offset = &(stack_pointer[4]);
+  char *global_pointer_with_offset = &(global_pointer[4]);
+  char *unknown_pointer_with_offset = &(unknown_pointer[4]);
+
+  struct composite *unknown_struct_pointer = (struct composite *)1.0;
+  int *unknown_member_pointer = &(unknown_struct_pointer->y);
+}


### PR DESCRIPTION
In the security project we noticed that when `get_value_set` returned an `ID_unknown` it would almost always have the same type as the query expression, but very occasionally the types would differ. This fixes a particular example of difference, but this may or may not be welcome depending on whether the types were supposed to match in the first place.

For example, `get_value_set` on `(char*)1.0` is an ID_unknown of type `char *`, but `get_value_set` on `&((struct X*)1.0)->field`, where `field` has type `Y`, results in an ID_unknown of type `Y` (not `Y *`, the type of the expression). This patch gives it type `Y *` to match the query expression.

Alternatively perhaps the type is supposed to vary to give some indication of where the ID_unknown came from? If this is the case we should drop this PR and instead document that fact, and I will change the security product to infer the intended type a different way.