### PR TITLE
Explicit casts to avoid conversion warnings [blocks: #2310]

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -788,7 +788,7 @@ code_blockt &java_bytecode_convert_methodt::get_or_create_block_for_pcrange(
   {
     // Range wholly contained within a child block
     return get_or_create_block_for_pcrange(
-      tree.branch[child_offset],
+      tree.branch[narrow_cast<std::size_t>(child_offset)],
       child_block,
       address_start,
       address_limit,
@@ -855,7 +855,7 @@ code_blockt &java_bytecode_convert_methodt::get_or_create_block_for_pcrange(
   for(auto blockidx=child_offset, blocklim=child_offset+nblocks;
       blockidx!=blocklim;
       ++blockidx)
-    newblock.add(this_block_children[blockidx]);
+    newblock.add(this_block_children[narrow_cast<std::size_t>(blockidx)]);
 
   // Relabel the inner header:
   to_code_label(newblock.statements()[0]).set_label(new_label_irep);
@@ -868,7 +868,7 @@ code_blockt &java_bytecode_convert_methodt::get_or_create_block_for_pcrange(
   auto dellim=delfirst;
   std::advance(dellim, nblocks-1);
   this_block_children.erase(delfirst, dellim);
-  this_block_children[child_offset].swap(newlabel);
+  this_block_children[narrow_cast<std::size_t>(child_offset)].swap(newlabel);
 
   // Perform the same transformation on the index tree:
   block_tree_nodet newnode;
@@ -895,14 +895,13 @@ code_blockt &java_bytecode_convert_methodt::get_or_create_block_for_pcrange(
   ++branchaddriter;
   tree.branch_addresses.erase(branchaddriter, branchaddrlim);
 
-  tree.branch[child_offset]=std::move(newnode);
+  tree.branch[narrow_cast<std::size_t>(child_offset)] = std::move(newnode);
 
   assert(tree.branch.size()==tree.branch_addresses.size());
 
-  return
-    to_code_block(
-      to_code_label(
-        this_block_children[child_offset]).code());
+  return to_code_block(
+    to_code_label(this_block_children[narrow_cast<std::size_t>(child_offset)])
+      .code());
 }
 
 static void gather_symbol_live_ranges(

--- a/jbmc/src/java_bytecode/java_bytecode_parser.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_parser.cpp
@@ -729,7 +729,7 @@ void java_bytecode_parsert::rconstant_pool()
         std::string s;
         s.resize(bytes);
         for(std::string::iterator s_it=s.begin(); s_it!=s.end(); s_it++)
-          *s_it=read_u1();
+          *s_it = narrow_cast<char>(read_u1());
         it->s=s; // hashes
       }
       break;
@@ -987,7 +987,7 @@ void java_bytecode_parsert::rbytecode(
 
     case 'b': // a signed byte
       {
-        s1 c=read_u1();
+        s1 c = narrow_cast<s1>(read_u1());
         instruction.args.push_back(from_integer(c, signedbv_typet(8)));
       }
       address+=1;
@@ -995,7 +995,7 @@ void java_bytecode_parsert::rbytecode(
 
     case 'o': // two byte branch offset, signed
       {
-        s2 offset=read_u2();
+        s2 offset = narrow_cast<s2>(read_u2());
         // By converting the signed offset into an absolute address (by adding
         // the current address) the number represented becomes unsigned.
         instruction.args.push_back(
@@ -1006,7 +1006,7 @@ void java_bytecode_parsert::rbytecode(
 
     case 'O': // four byte branch offset, signed
       {
-        s4 offset=read_u4();
+        s4 offset = narrow_cast<s4>(read_u4());
         // By converting the signed offset into an absolute address (by adding
         // the current address) the number represented becomes unsigned.
         instruction.args.push_back(
@@ -1039,7 +1039,7 @@ void java_bytecode_parsert::rbytecode(
       {
         u2 v=read_u2();
         instruction.args.push_back(from_integer(v, unsignedbv_typet(16)));
-        s2 c=read_u2();
+        s2 c = narrow_cast<s2>(read_u2());
         instruction.args.push_back(from_integer(c, signedbv_typet(16)));
         address+=4;
       }
@@ -1047,7 +1047,7 @@ void java_bytecode_parsert::rbytecode(
       {
         u1 v=read_u1();
         instruction.args.push_back(from_integer(v, unsignedbv_typet(8)));
-        s1 c=read_u1();
+        s1 c = narrow_cast<s1>(read_u1());
         instruction.args.push_back(from_integer(c, signedbv_typet(8)));
         address+=2;
       }
@@ -1073,7 +1073,7 @@ void java_bytecode_parsert::rbytecode(
         while(((address+1)&3)!=0) { read_u1(); address++; }
 
         // now default value
-        s4 default_value=read_u4();
+        s4 default_value = narrow_cast<s4>(read_u4());
         // By converting the signed offset into an absolute address (by adding
         // the current address) the number represented becomes unsigned.
         instruction.args.push_back(
@@ -1086,8 +1086,8 @@ void java_bytecode_parsert::rbytecode(
 
         for(std::size_t i=0; i<npairs; i++)
         {
-          s4 match=read_u4();
-          s4 offset=read_u4();
+          s4 match = narrow_cast<s4>(read_u4());
+          s4 offset = narrow_cast<s4>(read_u4());
           instruction.args.push_back(
             from_integer(match, signedbv_typet(32)));
           // By converting the signed offset into an absolute address (by adding
@@ -1107,23 +1107,23 @@ void java_bytecode_parsert::rbytecode(
         while(((address+1)&3)!=0) { read_u1(); address++; }
 
         // now default value
-        s4 default_value=read_u4();
+        s4 default_value = narrow_cast<s4>(read_u4());
         instruction.args.push_back(
           from_integer(base_offset+default_value, signedbv_typet(32)));
         address+=4;
 
         // now low value
-        s4 low_value=read_u4();
+        s4 low_value = narrow_cast<s4>(read_u4());
         address+=4;
 
         // now high value
-        s4 high_value=read_u4();
+        s4 high_value = narrow_cast<s4>(read_u4());
         address+=4;
 
         // there are high-low+1 offsets, and they are signed
         for(s4 i=low_value; i<=high_value; i++)
         {
-          s4 offset=read_u4();
+          s4 offset = narrow_cast<s4>(read_u4());
           instruction.args.push_back(from_integer(i, signedbv_typet(32)));
           // By converting the signed offset into an absolute address (by adding
           // the current address) the number represented becomes unsigned.
@@ -1167,7 +1167,7 @@ void java_bytecode_parsert::rbytecode(
 
     case 's': // a signed short
       {
-        s2 s=read_u2();
+        s2 s = narrow_cast<s2>(read_u2());
         instruction.args.push_back(from_integer(s, signedbv_typet(16)));
       }
       address+=2;

--- a/jbmc/src/java_bytecode/java_types.cpp
+++ b/jbmc/src/java_bytecode/java_types.cpp
@@ -605,7 +605,8 @@ optionalt<typet> java_type_from_string(
          subtype_letter=='[' || // Array-of-arrays
          subtype_letter=='T')   // Array of generic types
         subtype_letter='A';
-      typet tmp=java_array_type(std::tolower(subtype_letter));
+      typet tmp =
+        java_array_type(narrow_cast<char>(std::tolower(subtype_letter)));
       tmp.subtype().set(ID_element_type, std::move(*subtype));
       return std::move(tmp);
     }

--- a/jbmc/src/java_bytecode/mz_zip_archive.cpp
+++ b/jbmc/src/java_bytecode/mz_zip_archive.cpp
@@ -14,6 +14,8 @@ Author: Diffblue Ltd
 #define _LARGEFILE64_SOURCE 1
 #include <miniz/miniz.h>
 
+#include <util/narrow.h>
+
 // Original struct is an anonymous struct with a typedef, This is
 // required to remove internals from the header file
 class mz_zip_archive_statet final:public mz_zip_archive

--- a/jbmc/unit/java_bytecode/java_bytecode_instrument/virtual_call_null_checks.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_instrument/virtual_call_null_checks.cpp
@@ -61,11 +61,10 @@ SCENARIO(
       {
         // This just checks that the class actually makes the expected call,
         // i.e. that it hasn't been optimised away or similar.
-        std::size_t found_virtualmethod_calls =
-          std::count_if(
-            main_function.body.instructions.begin(),
-            main_function.body.instructions.end(),
-            is_expected_virtualmethod_call);
+        auto found_virtualmethod_calls = std::count_if(
+          main_function.body.instructions.begin(),
+          main_function.body.instructions.end(),
+          is_expected_virtualmethod_call);
 
         REQUIRE(found_virtualmethod_calls == 1);
       }

--- a/jbmc/unit/pointer-analysis/custom_value_set_analysis.cpp
+++ b/jbmc/unit/pointer-analysis/custom_value_set_analysis.cpp
@@ -151,8 +151,8 @@ get_values(const VST &value_set, const namespacet &ns, const exprt &expr)
   return vals;
 }
 
-static std::size_t exprs_with_id(
-  const value_setst::valuest &exprs, const irep_idt &id)
+static std::ptrdiff_t
+exprs_with_id(const value_setst::valuest &exprs, const irep_idt &id)
 {
   return std::count_if(
     exprs.begin(),

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -741,7 +741,7 @@ void goto_checkt::integer_overflow_check(
         }
       }
 
-      const unsigned number_of_top_bits =
+      const auto number_of_top_bits =
         allow_shift_into_sign_bit ? op_width : op_width + 1;
 
       const exprt top_bits = extractbits_exprt(

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -163,8 +163,8 @@ void rw_range_sett::get_objects_byte_extract(
       be.op().type(),
       be.id()==ID_byte_extract_little_endian,
       ns);
-    range_spect offset =
-      range_start + map.map_bit(numeric_cast_v<std::size_t>(*index));
+    range_spect offset = narrow_cast<range_spect>(
+      range_start + map.map_bit(numeric_cast_v<std::size_t>(*index)));
     get_objects_rec(mode, be.op(), offset, size);
   }
 }
@@ -318,8 +318,8 @@ void rw_range_sett::get_objects_array(
 
   range_spect offset=0;
   range_spect full_r_s=range_start==-1 ? 0 : range_start;
-  range_spect full_r_e=
-    size==-1 ? sub_size*expr.operands().size() : full_r_s+size;
+  range_spect full_r_e = narrow_cast<range_spect>(
+    size == -1 ? sub_size * expr.operands().size() : full_r_s + size);
 
   forall_operands(it, expr)
   {

--- a/src/analyses/local_bitvector_analysis.cpp
+++ b/src/analyses/local_bitvector_analysis.cpp
@@ -369,10 +369,8 @@ void local_bitvector_analysist::output(
         p_it!=loc_info.end();
         p_it++)
     {
-      out << "  " << pointers[p_it-loc_info.begin()]
-          << ": "
-          << *p_it
-          << "\n";
+      out << "  " << pointers[narrow_cast<std::size_t>(p_it - loc_info.begin())]
+          << ": " << *p_it << "\n";
     }
 
     out << "\n";

--- a/src/ansi-c/c_qualifiers.h
+++ b/src/ansi-c/c_qualifiers.h
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <memory>
 
 #include <util/expr.h>
+#include <util/narrow.h>
 
 class qualifierst
 {
@@ -149,8 +150,9 @@ public:
 
   virtual std::size_t count() const override
   {
-    return is_constant+is_volatile+is_restricted+is_atomic+
-           is_ptr32+is_ptr64+is_noreturn;
+    return narrow_cast<std::size_t>(
+      is_constant + is_volatile + is_restricted + is_atomic + is_ptr32 +
+      is_ptr64 + is_noreturn);
   }
 };
 

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -2141,7 +2141,7 @@ std::string expr2ct::convert_array(const exprt &src)
       if(last_was_hex)
       {
         // we use "string splicing" to avoid ambiguity
-        if(isxdigit(ch))
+        if(isxdigit(narrow_cast<int>(ch)))
           dest+="\" \"";
 
         last_was_hex=false;

--- a/src/ansi-c/literals/convert_string_literal.cpp
+++ b/src/ansi-c/literals/convert_string_literal.cpp
@@ -39,7 +39,7 @@ std::basic_string<unsigned int> convert_one_string_literal(
     // pad into wide string
     value.resize(utf8_value.size());
     for(std::size_t i=0; i<utf8_value.size(); i++)
-      value[i]=utf8_value[i];
+      value[i] = narrow_cast<unsigned int>(utf8_value[i]);
 
     return value;
   }
@@ -62,7 +62,7 @@ std::basic_string<unsigned int> convert_one_string_literal(
     std::basic_string<unsigned int> value;
     value.resize(char_value.size());
     for(std::size_t i=0; i<char_value.size(); i++)
-      value[i]=char_value[i];
+      value[i] = narrow_cast<unsigned int>(char_value[i]);
 
     return value;
   }
@@ -150,7 +150,7 @@ exprt convert_string_literal(const std::string &src)
     {
       // Loss of data here if value[i]>255.
       // gcc issues a warning in this case.
-      char_value[i]=value[i];
+      char_value[i] = narrow_cast<char>(value[i]);
     }
 
     return string_constantt(char_value);

--- a/src/ansi-c/literals/parse_float.cpp
+++ b/src/ansi-c/literals/parse_float.cpp
@@ -11,6 +11,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "parse_float.h"
 
+#include <util/narrow.h>
+
 #include <algorithm>
 #include <cctype>
 #include <cstring>
@@ -30,8 +32,10 @@ parse_floatt::parse_floatt(const std::string &src)
   // by first converting to lower case.
 
   std::string src_lower=src;
-  std::transform(src_lower.begin(), src_lower.end(),
-                 src_lower.begin(), ::tolower);
+  std::transform(
+    src_lower.begin(), src_lower.end(), src_lower.begin(), [](char c) {
+      return narrow_cast<char>(std::tolower(c));
+    });
 
   const char *p=src_lower.c_str();
 

--- a/src/ansi-c/literals/unescape_string.cpp
+++ b/src/ansi-c/literals/unescape_string.cpp
@@ -44,7 +44,7 @@ std::basic_string<T> unescape_string_templ(const std::string &src)
 
   for(unsigned i=0; i<src.size(); i++)
   {
-    T ch=(unsigned char)src[i];
+    T ch = narrow_cast<T>(narrow_cast<unsigned char>(src[i]));
 
     if(ch=='\\') // escape?
     {
@@ -52,7 +52,7 @@ std::basic_string<T> unescape_string_templ(const std::string &src)
       i++;
       assert(i<src.size()); // backslash can't be last character
 
-      ch=(unsigned char)src[i];
+      ch = narrow_cast<T>(narrow_cast<unsigned char>(src[i]));
       switch(ch)
       {
       case '\\': dest.push_back(ch); break;
@@ -106,7 +106,7 @@ std::basic_string<T> unescape_string_templ(const std::string &src)
           // go back
           i--;
 
-          ch=hex_to_unsigned(hex.c_str(), hex.size());
+          ch = narrow_cast<T>(hex_to_unsigned(hex.c_str(), hex.size()));
         }
 
         // if T isn't sufficiently wide to hold unsigned values
@@ -117,7 +117,7 @@ std::basic_string<T> unescape_string_templ(const std::string &src)
         break;
 
       default:
-        if(isdigit(ch)) // octal
+        if(isdigit(narrow_cast<int>(ch))) // octal
         {
           std::string octal;
 
@@ -130,7 +130,7 @@ std::basic_string<T> unescape_string_templ(const std::string &src)
           // go back
           i--;
 
-          ch=octal_to_unsigned(octal.c_str(), octal.size());
+          ch = narrow_cast<T>(octal_to_unsigned(octal.c_str(), octal.size()));
           dest.push_back(ch);
         }
         else

--- a/src/ansi-c/literals/unescape_string.cpp
+++ b/src/ansi-c/literals/unescape_string.cpp
@@ -44,7 +44,7 @@ std::basic_string<T> unescape_string_templ(const std::string &src)
 
   for(unsigned i=0; i<src.size(); i++)
   {
-    T ch = narrow_cast<T>(narrow_cast<unsigned char>(src[i]));
+    T ch = narrow_cast<T>(src[i]);
 
     if(ch=='\\') // escape?
     {
@@ -52,7 +52,7 @@ std::basic_string<T> unescape_string_templ(const std::string &src)
       i++;
       assert(i<src.size()); // backslash can't be last character
 
-      ch = narrow_cast<T>(narrow_cast<unsigned char>(src[i]));
+      ch = narrow_cast<T>(src[i]);
       switch(ch)
       {
       case '\\': dest.push_back(ch); break;

--- a/src/cpp/cpp_convert_type.cpp
+++ b/src/cpp/cpp_convert_type.cpp
@@ -340,11 +340,11 @@ void cpp_convert_plain_type(typet &type, message_handlert &message_handler)
   {
     // add width -- we use int, but the standard
     // doesn't guarantee that
-    type.set(ID_width, config.ansi_c.int_width);
+    type.set(ID_width, narrow_cast<long long>(config.ansi_c.int_width));
   }
   else if(type.id() == ID_c_bool)
   {
-    type.set(ID_width, config.ansi_c.bool_width);
+    type.set(ID_width, narrow_cast<long long>(config.ansi_c.bool_width));
   }
   else
   {

--- a/src/cpp/cpp_token_buffer.cpp
+++ b/src/cpp/cpp_token_buffer.cpp
@@ -124,6 +124,7 @@ void cpp_token_buffert::Insert(const cpp_tokent &token)
 
   tokens.push_back(token);
 
-  token_vector.insert(token_vector.begin()+current_pos,
-                      --tokens.end());
+  token_vector.insert(
+    token_vector.begin() + narrow_cast<std::ptrdiff_t>(current_pos),
+    --tokens.end());
 }

--- a/src/goto-cc/gcc_cmdline.cpp
+++ b/src/goto-cc/gcc_cmdline.cpp
@@ -16,6 +16,7 @@ Author: CM Wintersteiger, 2006
 #include <iostream>
 #include <fstream>
 
+#include <util/narrow.h>
 #include <util/prefix.h>
 
 // clang-format off
@@ -226,7 +227,7 @@ bool gcc_cmdlinet::parse(int argc, const char **argv)
   add_arg(argv[0]);
 
   argst current_args;
-  current_args.reserve(argc - 1);
+  current_args.reserve(narrow_cast<std::size_t>(argc - 1));
 
   for(int i=1; i<argc; i++)
     current_args.push_back(argv[i]);

--- a/src/goto-cc/goto_cc_main.cpp
+++ b/src/goto-cc/goto_cc_main.cpp
@@ -12,6 +12,7 @@ Date: May 2006
 /// GOTO-CC Main Module
 
 #include <algorithm>
+#include <cctype>
 #include <iostream>
 
 #include <util/unicode.h>
@@ -37,7 +38,9 @@ Date: May 2006
 std::string to_lower_string(const std::string &s)
 {
   std::string result=s;
-  transform(result.begin(), result.end(), result.begin(), tolower);
+  transform(result.begin(), result.end(), result.begin(), [](char c) {
+    return narrow_cast<char>(std::tolower(c));
+  });
   return result;
 }
 

--- a/src/goto-cc/ms_link_cmdline.cpp
+++ b/src/goto-cc/ms_link_cmdline.cpp
@@ -11,7 +11,7 @@ Author: Daniel Kroening
 
 #include "ms_link_cmdline.h"
 
-#include <cassert>
+#include <cctype>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
@@ -319,7 +319,9 @@ const char *ms_link_options[] = {
 static std::string to_upper_string(const std::string &s)
 {
   std::string result = s;
-  transform(result.begin(), result.end(), result.begin(), toupper);
+  transform(result.begin(), result.end(), result.begin(), [](char c) {
+    return narrow_cast<char>(std::toupper(c));
+  });
   return result;
 }
 

--- a/src/goto-checker/symex_coverage.cpp
+++ b/src/goto-checker/symex_coverage.cpp
@@ -189,7 +189,8 @@ goto_program_coverage_recordt::goto_program_coverage_recordt(
         xmlt &condition = conditions.new_element("condition");
         condition.set_attribute("number", std::to_string(number++));
         condition.set_attribute("type", "jump");
-        unsigned taken = c.second.false_taken + c.second.true_taken;
+        unsigned taken =
+          narrow_cast<unsigned>(c.second.false_taken + c.second.true_taken);
         total_taken += taken;
         condition.set_attribute("coverage", rate(taken, 2, true));
       }

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -1556,7 +1556,8 @@ void goto_program2codet::cleanup_code_block(
       operands.size()>1 && i<operands.size();
      ) // no ++i
   {
-    exprt::operandst::iterator it=operands.begin()+i;
+    exprt::operandst::iterator it =
+      operands.begin() + narrow_cast<std::ptrdiff_t>(i);
     // remove skip
     if(to_code(*it).get_statement()==ID_skip &&
        it->source_location().get_comment().empty())
@@ -1574,9 +1575,11 @@ void goto_program2codet::cleanup_code_block(
 
       if(!has_decl)
       {
-        operands.insert(operands.begin()+i+1,
-            it->operands().begin(), it->operands().end());
-        operands.erase(operands.begin()+i);
+        operands.insert(
+          operands.begin() + narrow_cast<std::ptrdiff_t>(i) + 1,
+          it->operands().begin(),
+          it->operands().end());
+        operands.erase(operands.begin() + narrow_cast<std::ptrdiff_t>(i));
         // no ++i
       }
       else

--- a/src/goto-programs/elf_reader.cpp
+++ b/src/goto-programs/elf_reader.cpp
@@ -58,7 +58,8 @@ elf_readert::elf_readert(std::istream &_in):in(_in)
     for(std::size_t i=0; i<elf32_section_header_table.size(); i++)
     {
       // go to right place
-      in.seekg(elf32_header.e_shoff+i*elf32_header.e_shentsize);
+      in.seekg(narrow_cast<std::streamoff>(
+        elf32_header.e_shoff + i * elf32_header.e_shentsize));
 
       // read section header
       in.read(
@@ -105,7 +106,8 @@ elf_readert::elf_readert(std::istream &_in):in(_in)
     for(std::size_t i=0; i<elf64_section_header_table.size(); i++)
     {
       // go to right place
-      in.seekg(elf64_header.e_shoff+i*elf64_header.e_shentsize);
+      in.seekg(narrow_cast<std::streamoff>(
+        elf64_header.e_shoff + i * elf64_header.e_shentsize));
 
       // read section header
       in.read(

--- a/src/goto-programs/elf_reader.h
+++ b/src/goto-programs/elf_reader.h
@@ -16,6 +16,8 @@ Author:
 #include <string>
 #include <vector>
 
+#include <util/narrow.h>
+
 // we follow
 // http://www.skyfree.org/linux/references/ELF_Format.pdf
 // http://downloads.openwatcom.org/ftp/devel/docs/elf-64-gen.pdf
@@ -143,9 +145,14 @@ public:
 
   std::streampos section_offset(std::size_t index) const
   {
-    return
-      elf_class==ELF32?elf32_section_header_table[index].sh_offset:
-                       elf64_section_header_table[index].sh_offset;
+    // Visual Studio insists on a type cast to std::streamoff, for an unknown
+    // reason
+    if(elf_class == ELF32)
+      return narrow_cast<std::streamoff>(
+        elf32_section_header_table[index].sh_offset);
+    else
+      return narrow_cast<std::streamoff>(
+        elf64_section_header_table[index].sh_offset);
   }
 
   bool has_section(const std::string &name) const;

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -135,7 +135,7 @@ void interpretert::command()
     return;
   }
 
-  char ch=tolower(command[0]);
+  char ch = narrow_cast<char>(tolower(narrow_cast<int>(command[0])));
   if(ch=='q')
     done=true;
   else if(ch=='h')
@@ -157,7 +157,7 @@ void interpretert::command()
   {
     json_arrayt json_steps;
     convert<json_arrayt>(ns, steps, json_steps);
-    ch=tolower(command[1]);
+    ch = narrow_cast<char>(tolower(command[1]));
     if(ch==' ')
     {
       std::ofstream file;
@@ -173,12 +173,12 @@ void interpretert::command()
   }
   else if(ch=='m')
   {
-    ch=tolower(command[1]);
+    ch = narrow_cast<char>(tolower(command[1]));
     print_memory(ch=='i');
   }
   else if(ch=='o')
   {
-    ch=tolower(command[1]);
+    ch = narrow_cast<char>(tolower(command[1]));
     if(ch==' ')
     {
       std::ofstream file;
@@ -194,14 +194,14 @@ void interpretert::command()
   }
   else if(ch=='r')
   {
-    ch=tolower(command[1]);
+    ch = narrow_cast<char>(tolower(command[1]));
     initialize(ch!='0');
   }
   else if((ch=='s') || (ch==0))
   {
     num_steps=1;
     stack_depth=npos;
-    ch=tolower(command[1]);
+    ch = narrow_cast<char>(tolower(command[1]));
     if(ch=='e')
       num_steps=npos;
     else if(ch=='o')

--- a/src/goto-programs/read_bin_goto_object.cpp
+++ b/src/goto-programs/read_bin_goto_object.cpp
@@ -111,7 +111,8 @@ static bool read_bin_goto_object(
                               irepconverter.read_gb_word(in);
       instruction.guard =
         static_cast<const exprt &>(irepconverter.reference_convert(in));
-      instruction.target_number = irepconverter.read_gb_word(in);
+      instruction.target_number =
+        narrow_cast<unsigned>(irepconverter.read_gb_word(in));
       if(instruction.is_target() &&
          rev_target_map.insert(
            rev_target_map.end(),
@@ -121,7 +122,8 @@ static bool read_bin_goto_object(
       std::size_t t_count = irepconverter.read_gb_word(in); // # of targets
       for(std::size_t i=0; i<t_count; i++)
         // just save the target numbers
-        target_map[itarget].push_back(irepconverter.read_gb_word(in));
+        target_map[itarget].push_back(
+          narrow_cast<unsigned>(irepconverter.read_gb_word(in)));
 
       std::size_t l_count = irepconverter.read_gb_word(in); // # of labels
 

--- a/src/goto-programs/read_goto_binary.cpp
+++ b/src/goto-programs/read_goto_binary.cpp
@@ -77,10 +77,10 @@ static bool read_goto_binary(
   }
 
   char hdr[4];
-  hdr[0]=in.get();
-  hdr[1]=in.get();
-  hdr[2]=in.get();
-  hdr[3]=in.get();
+  hdr[0] = narrow_cast<char>(in.get());
+  hdr[1] = narrow_cast<char>(in.get());
+  hdr[2] = narrow_cast<char>(in.get());
+  hdr[3] = narrow_cast<char>(in.get());
   in.seekg(0);
 
   if(hdr[0]==0x7f && hdr[1]=='G' && hdr[2]=='B' && hdr[3]=='F')
@@ -201,10 +201,10 @@ bool is_goto_binary(
   // 2. ELF binaries, marked with 0x7f ELF
 
   char hdr[4];
-  hdr[0]=in.get();
-  hdr[1]=in.get();
-  hdr[2]=in.get();
-  hdr[3]=in.get();
+  hdr[0] = narrow_cast<char>(in.get());
+  hdr[1] = narrow_cast<char>(in.get());
+  hdr[2] = narrow_cast<char>(in.get());
+  hdr[3] = narrow_cast<char>(in.get());
 
   if(hdr[0]==0x7f && hdr[1]=='G' && hdr[2]=='B' && hdr[3]=='F')
   {

--- a/src/goto-programs/read_goto_binary.cpp
+++ b/src/goto-programs/read_goto_binary.cpp
@@ -99,7 +99,7 @@ static bool read_goto_binary(
       for(unsigned i=0; i<elf_reader.number_of_sections; i++)
         if(elf_reader.section_name(i)=="goto-cc")
         {
-          in.seekg(elf_reader.section_offset(i));
+          in.seekg(std::streamoff{elf_reader.section_offset(i)});
           return read_bin_goto_object(
             in, filename, symbol_table, goto_functions, message_handler);
         }

--- a/src/jsil/jsil_types.cpp
+++ b/src/jsil/jsil_types.cpp
@@ -159,7 +159,7 @@ jsil_union_typet jsil_union_typet::union_with(
     elements1.begin(), elements1.end(),
     elements2.begin(), elements2.end(),
     elements.begin(), compare_components);
-  elements.resize(it-elements.begin());
+  elements.resize(narrow_cast<std::size_t>(it - elements.begin()));
 
   return result;
 }
@@ -176,7 +176,7 @@ jsil_union_typet jsil_union_typet::intersect_with(
     elements1.begin(), elements1.end(),
     elements2.begin(), elements2.end(),
     elements.begin(), compare_components);
-  elements.resize(it-elements.begin());
+  elements.resize(narrow_cast<std::size_t>(it - elements.begin()));
 
   return result;
 }

--- a/src/solvers/flattening/boolbv_complex.cpp
+++ b/src/solvers/flattening/boolbv_complex.cpp
@@ -61,7 +61,7 @@ bvt boolbvt::convert_complex_imag(const complex_imag_exprt &expr)
 
   bvt bv = convert_bv(expr.op(), width * 2);
 
-  bv.erase(bv.begin(), bv.begin()+width);
+  bv.erase(bv.begin(), bv.begin() + narrow_cast<std::ptrdiff_t>(width));
 
   return bv;
 }

--- a/src/solvers/flattening/boolbv_extractbits.cpp
+++ b/src/solvers/flattening/boolbv_extractbits.cpp
@@ -57,7 +57,9 @@ bvt boolbvt::convert_extractbits(const extractbits_exprt &expr)
 
   const std::size_t offset = numeric_cast_v<std::size_t>(lower_as_int);
 
-  bvt result_bv(src_bv.begin() + offset, src_bv.begin() + offset + bv_width);
+  bvt result_bv(
+    src_bv.begin() + narrow_cast<std::ptrdiff_t>(offset),
+    src_bv.begin() + narrow_cast<std::ptrdiff_t>(offset + bv_width));
 
   return result_bv;
 }

--- a/src/solvers/flattening/boolbv_floatbv_op.cpp
+++ b/src/solvers/flattening/boolbv_floatbv_op.cpp
@@ -145,11 +145,11 @@ bvt boolbvt::convert_floatbv_op(const exprt &expr)
         bvt lhs_sub_bv, rhs_sub_bv, sub_result_bv;
 
         lhs_sub_bv.assign(
-          lhs_as_bv.begin() + i * sub_width,
-          lhs_as_bv.begin() + (i + 1) * sub_width);
+          lhs_as_bv.begin() + narrow_cast<std::ptrdiff_t>(i * sub_width),
+          lhs_as_bv.begin() + narrow_cast<std::ptrdiff_t>((i + 1) * sub_width));
         rhs_sub_bv.assign(
-          rhs_as_bv.begin() + i * sub_width,
-          rhs_as_bv.begin() + (i + 1) * sub_width);
+          rhs_as_bv.begin() + narrow_cast<std::ptrdiff_t>(i * sub_width),
+          rhs_as_bv.begin() + narrow_cast<std::ptrdiff_t>((i + 1) * sub_width));
 
         if(expr.id()==ID_floatbv_plus)
           sub_result_bv = float_utils.add_sub(lhs_sub_bv, rhs_sub_bv, false);
@@ -171,7 +171,7 @@ bvt boolbvt::convert_floatbv_op(const exprt &expr)
         std::copy(
           sub_result_bv.begin(),
           sub_result_bv.end(),
-          result_bv.begin() + i * sub_width);
+          result_bv.begin() + narrow_cast<std::ptrdiff_t>(i * sub_width));
       }
 
       return result_bv;

--- a/src/solvers/flattening/boolbv_map.cpp
+++ b/src/solvers/flattening/boolbv_map.cpp
@@ -96,7 +96,7 @@ void boolbv_mapt::get_literals(
   Forall_literals(it, literals)
   {
     literalt &l=*it;
-    const std::size_t bit=it-literals.begin();
+    const std::size_t bit = narrow_cast<std::size_t>(it - literals.begin());
 
     INVARIANT(
       bit < map_entry.literal_map.size(), "bit index shall be within bounds");
@@ -135,7 +135,7 @@ void boolbv_mapt::set_literals(
       literal.is_constant() || literal.var_no() < prop.no_variables(),
       "variable number of non-constant literals shall be within bounds");
 
-    const std::size_t bit = it - literals.begin();
+    const std::size_t bit = narrow_cast<std::size_t>(it - literals.begin());
 
     INVARIANT(
       bit < map_entry.literal_map.size(), "bit index shall be within bounds");

--- a/src/solvers/flattening/boolbv_mult.cpp
+++ b/src/solvers/flattening/boolbv_mult.cpp
@@ -53,7 +53,8 @@ bvt boolbvt::convert_mult(const mult_exprt &expr)
       bv=bv_utils.signed_multiplier(bv, op);
 
       // cut it down again
-      bv.erase(bv.begin(), bv.begin()+fraction_bits);
+      bv.erase(
+        bv.begin(), bv.begin() + narrow_cast<std::ptrdiff_t>(fraction_bits));
     }
 
     return bv;

--- a/src/solvers/flattening/boolbv_overflow.cpp
+++ b/src/solvers/flattening/boolbv_overflow.cpp
@@ -134,7 +134,8 @@ literalt boolbvt::convert_overflow(const exprt &expr)
     if(rep == bv_utilst::representationt::UNSIGNED)
     {
       // get top result bits
-      result.erase(result.begin(), result.begin() + old_size);
+      result.erase(
+        result.begin(), result.begin() + narrow_cast<std::ptrdiff_t>(old_size));
 
       // one of the top bits is non-zero
       overflow=prop.lor(result);
@@ -143,7 +144,9 @@ literalt boolbvt::convert_overflow(const exprt &expr)
     {
       // get top result bits plus sign bit
       DATA_INVARIANT(old_size != 0, "zero-size operand");
-      result.erase(result.begin(), result.begin() + old_size - 1);
+      result.erase(
+        result.begin(),
+        result.begin() + narrow_cast<std::ptrdiff_t>(old_size) - 1);
 
       // the sign bit has changed
       literalt sign_change=!prop.lequal(bv0.back(), result.front());

--- a/src/solvers/flattening/boolbv_typecast.cpp
+++ b/src/solvers/flattening/boolbv_typecast.cpp
@@ -79,8 +79,10 @@ bool boolbvt::type_conversion(
     {
       // recursively do both halfs
       bvt lower, upper, lower_res, upper_res;
-      lower.assign(src.begin(), src.begin()+src.size()/2);
-      upper.assign(src.begin()+src.size()/2, src.end());
+      lower.assign(
+        src.begin(), src.begin() + narrow_cast<std::ptrdiff_t>(src.size() / 2));
+      upper.assign(
+        src.begin() + narrow_cast<std::ptrdiff_t>(src.size() / 2), src.end());
       type_conversion(
         src_type.subtype(), lower, dest_type.subtype(), lower_res);
       type_conversion(

--- a/src/solvers/flattening/boolbv_unary_minus.cpp
+++ b/src/solvers/flattening/boolbv_unary_minus.cpp
@@ -55,7 +55,8 @@ bvt boolbvt::convert_unary_minus(const unary_minus_exprt &expr)
     {
       bvt tmp_op;
 
-      const auto sub_it = std::next(op_bv.begin(), sub_idx);
+      const auto sub_it =
+        std::next(op_bv.begin(), narrow_cast<std::ptrdiff_t>(sub_idx));
       std::copy_n(sub_it, sub_width, std::back_inserter(tmp_op));
 
       if(type.subtype().id() == ID_floatbv)

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -558,7 +558,8 @@ bvt bv_pointerst::convert_bitvector(const exprt &expr)
 
     // erase offset bits
 
-    op0.erase(op0.begin()+0, op0.begin()+offset_bits);
+    op0.erase(
+      op0.begin(), op0.begin() + narrow_cast<std::ptrdiff_t>(offset_bits));
 
     return bv_utils.zero_extension(op0, width);
   }
@@ -747,10 +748,13 @@ void bv_pointerst::do_postponed(
       bvt bv;
       encode(number, bv);
 
-      bv.erase(bv.begin(), bv.begin()+offset_bits);
+      bv.erase(
+        bv.begin(), bv.begin() + narrow_cast<std::ptrdiff_t>(offset_bits));
 
       bvt saved_bv=postponed.op;
-      saved_bv.erase(saved_bv.begin(), saved_bv.begin()+offset_bits);
+      saved_bv.erase(
+        saved_bv.begin(),
+        saved_bv.begin() + narrow_cast<std::ptrdiff_t>(offset_bits));
 
       POSTCONDITION(bv.size()==saved_bv.size());
       PRECONDITION(postponed.bv.size()==1);
@@ -793,10 +797,13 @@ void bv_pointerst::do_postponed(
       bvt bv;
       encode(number, bv);
 
-      bv.erase(bv.begin(), bv.begin()+offset_bits);
+      bv.erase(
+        bv.begin(), bv.begin() + narrow_cast<std::ptrdiff_t>(offset_bits));
 
       bvt saved_bv=postponed.op;
-      saved_bv.erase(saved_bv.begin(), saved_bv.begin()+offset_bits);
+      saved_bv.erase(
+        saved_bv.begin(),
+        saved_bv.begin() + narrow_cast<std::ptrdiff_t>(offset_bits));
 
       bvt size_bv = convert_bv(object_size);
 

--- a/src/solvers/flattening/bv_utils.cpp
+++ b/src/solvers/flattening/bv_utils.cpp
@@ -49,7 +49,8 @@ bvt bv_utilst::extract(const bvt &a, std::size_t first, std::size_t last)
   bvt result=a;
   result.resize(last+1);
   if(first!=0)
-    result.erase(result.begin(), result.begin()+first);
+    result.erase(
+      result.begin(), result.begin() + narrow_cast<std::ptrdiff_t>(first));
 
   POSTCONDITION(result.size() == last - first + 1);
   return result;
@@ -61,7 +62,9 @@ bvt bv_utilst::extract_msb(const bvt &a, std::size_t n)
   PRECONDITION(n <= a.size());
 
   bvt result=a;
-  result.erase(result.begin(), result.begin()+(result.size()-n));
+  result.erase(
+    result.begin(),
+    result.begin() + narrow_cast<std::ptrdiff_t>(result.size() - n));
 
   POSTCONDITION(result.size() == n);
   return result;

--- a/src/solvers/floatbv/float_bv.cpp
+++ b/src/solvers/floatbv/float_bv.cpp
@@ -338,7 +338,7 @@ exprt float_bvt::conversion(
 
   int sourceSmallestNormalExponent = -((1 << (src_spec.e - 1)) - 1);
   int sourceSmallestDenormalExponent =
-    sourceSmallestNormalExponent - src_spec.f;
+    sourceSmallestNormalExponent - narrow_cast<int>(src_spec.f);
 
   // Using the fact that f doesn't include the hidden bit
 

--- a/src/solvers/floatbv/float_utils.cpp
+++ b/src/solvers/floatbv/float_utils.cpp
@@ -389,7 +389,9 @@ bvt float_utilst::limit_distance(
   std::size_t nb_bits = address_bits(limit);
 
   bvt upper_bits=dist;
-  upper_bits.erase(upper_bits.begin(), upper_bits.begin()+nb_bits);
+  upper_bits.erase(
+    upper_bits.begin(),
+    upper_bits.begin() + narrow_cast<std::ptrdiff_t>(nb_bits));
   literalt or_upper_bits=prop.lor(upper_bits);
 
   bvt lower_bits=dist;
@@ -706,7 +708,8 @@ literalt float_utilst::exponent_all_ones(const bvt &src)
   bvt exponent=src;
 
   // removes the fractional part
-  exponent.erase(exponent.begin(), exponent.begin()+spec.f);
+  exponent.erase(
+    exponent.begin(), exponent.begin() + narrow_cast<std::ptrdiff_t>(spec.f));
 
   // removes the sign
   exponent.resize(spec.e);
@@ -719,7 +722,8 @@ literalt float_utilst::exponent_all_zeros(const bvt &src)
   bvt exponent=src;
 
   // removes the fractional part
-  exponent.erase(exponent.begin(), exponent.begin()+spec.f);
+  exponent.erase(
+    exponent.begin(), exponent.begin() + narrow_cast<std::ptrdiff_t>(spec.f));
 
   // removes the sign
   exponent.resize(spec.e);

--- a/src/solvers/floatbv/float_utils.cpp
+++ b/src/solvers/floatbv/float_utils.cpp
@@ -168,7 +168,7 @@ bvt float_utilst::conversion(
 
   int sourceSmallestNormalExponent=-((1 << (spec.e - 1)) - 1);
   int sourceSmallestDenormalExponent =
-    sourceSmallestNormalExponent - spec.f;
+    sourceSmallestNormalExponent - narrow_cast<int>(spec.f);
 
   // Using the fact that f doesn't include the hidden bit
 

--- a/src/solvers/sat/cnf.cpp
+++ b/src/solvers/sat/cnf.cpp
@@ -387,7 +387,7 @@ literalt cnft::lselect(literalt a, literalt b, literalt c)
 literalt cnft::new_variable()
 {
   literalt l;
-  l.set(_no_variables, false);
+  l.set(narrow_cast<literalt::var_not>(_no_variables), false);
 
   set_no_variables(_no_variables+1);
 

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -53,9 +53,9 @@ tvt satcheck_minisat2_baset<T>::l_get(literalt a) const
 
   using Minisat::lbool;
 
-  if(solver->model[a.var_no()]==l_True)
+  if(solver->model[narrow_cast<std::size_t>(a.var_no())] == l_True)
     result=tvt(true);
-  else if(solver->model[a.var_no()]==l_False)
+  else if(solver->model[narrow_cast<std::size_t>(a.var_no())] == l_False)
     result=tvt(false);
   else
     return tvt::unknown();

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -277,7 +277,7 @@ void satcheck_minisat2_baset<T>::set_assignment(literalt a, bool value)
 
   try
   {
-    unsigned v = a.var_no();
+    unsigned v = narrow_cast<unsigned>(a.var_no());
     bool sign = a.sign();
 
     // MiniSat2 kills the model in case of UNSAT
@@ -361,7 +361,7 @@ void satcheck_minisat_simplifiert::set_frozen(literalt a)
     if(!a.is_constant())
     {
       add_variables();
-      solver->setFrozen(a.var_no(), true);
+      solver->setFrozen(narrow_cast<int>(a.var_no()), true);
     }
   }
   catch(const Minisat::OutOfMemoryException &)
@@ -376,5 +376,5 @@ bool satcheck_minisat_simplifiert::is_eliminated(literalt a) const
 {
   PRECONDITION(!a.is_constant());
 
-  return solver->isEliminated(a.var_no());
+  return solver->isEliminated(narrow_cast<int>(a.var_no()));
 }

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -712,7 +712,7 @@ literalt smt2_convt::convert(const exprt &expr)
 
   exprt prepared_expr = prepare_for_convert_expr(expr);
 
-  literalt l(no_boolean_variables, false);
+  literalt l(narrow_cast<unsigned>(no_boolean_variables), false);
   no_boolean_variables++;
 
   out << "; convert\n";

--- a/src/solvers/strings/string_builtin_function.cpp
+++ b/src/solvers/strings/string_builtin_function.cpp
@@ -132,8 +132,8 @@ std::vector<mp_integer> string_concatenation_builtin_functiont::eval(
   std::vector<mp_integer> eval_result(input1_value);
   eval_result.insert(
     eval_result.end(),
-    input2_value.begin() + numeric_cast_v<std::size_t>(start_index),
-    input2_value.begin() + numeric_cast_v<std::size_t>(end_index));
+    input2_value.begin() + numeric_cast_v<std::ptrdiff_t>(start_index),
+    input2_value.begin() + numeric_cast_v<std::ptrdiff_t>(end_index));
   return eval_result;
 }
 
@@ -474,9 +474,9 @@ std::vector<mp_integer> string_insertion_builtin_functiont::eval(
 
   std::vector<mp_integer> eval_result(input1_value);
   eval_result.insert(
-    eval_result.begin() + numeric_cast_v<std::size_t>(offset),
-    input2_value.begin() + numeric_cast_v<std::size_t>(start),
-    input2_value.begin() + numeric_cast_v<std::size_t>(end));
+    eval_result.begin() + numeric_cast_v<std::ptrdiff_t>(offset),
+    input2_value.begin() + numeric_cast_v<std::ptrdiff_t>(start),
+    input2_value.begin() + numeric_cast_v<std::ptrdiff_t>(end));
   return eval_result;
 }
 

--- a/src/solvers/strings/string_constraint_generator_float.cpp
+++ b/src/solvers/strings/string_constraint_generator_float.cpp
@@ -77,7 +77,7 @@ exprt constant_float(const double f, const ieee_float_spect &float_spec)
 {
   ieee_floatt fl(float_spec);
   if(float_spec == ieee_float_spect::single_precision())
-    fl.from_float(f);
+    fl.from_float(narrow_cast<float>(f));
   else if(float_spec == ieee_float_spect::double_precision())
     fl.from_double(f);
   else

--- a/src/solvers/strings/string_constraint_generator_format.cpp
+++ b/src/solvers/strings/string_constraint_generator_format.cpp
@@ -382,7 +382,7 @@ add_axioms_for_format_specifier(
   case format_specifiert::HASHCODE_UPPER:
   {
     format_specifiert fs_lower = fs;
-    fs_lower.conversion = tolower(fs.conversion);
+    fs_lower.conversion = narrow_cast<char>(tolower(fs.conversion));
     auto format_specifier_result = add_axioms_for_format_specifier(
       fresh_symbol,
       fs_lower,

--- a/src/solvers/strings/string_constraint_generator_format.cpp
+++ b/src/solvers/strings/string_constraint_generator_format.cpp
@@ -609,7 +609,8 @@ utf16_constant_array_to_java(const array_exprt &arr, std::size_t length)
   std::wstring out(length, '?');
 
   for(std::size_t i = 0; i < arr.operands().size() && i < length; i++)
-    out[i] = numeric_cast_v<unsigned>(to_constant_expr(arr.operands()[i]));
+    out[i] = narrow_cast<wchar_t>(
+      numeric_cast_v<unsigned>(to_constant_expr(arr.operands()[i])));
 
   return utf16_native_endian_to_java(out);
 }

--- a/src/solvers/strings/string_constraint_generator_format.cpp
+++ b/src/solvers/strings/string_constraint_generator_format.cpp
@@ -233,7 +233,8 @@ static std::vector<format_elementt> parse_format_string(std::string s)
   {
     if(match.position() != 0)
     {
-      std::string pre_match = s.substr(0, match.position());
+      std::string pre_match =
+        s.substr(0, narrow_cast<std::size_t>(match.position()));
       al.emplace_back(pre_match);
     }
 
@@ -518,7 +519,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_format(
             "number of format must match specifiers");
 
           // first argument `args[0]` corresponds to index 1
-          arg = to_struct_expr(args[fs.index - 1]);
+          arg = to_struct_expr(args[narrow_cast<std::size_t>(fs.index - 1)]);
         }
 
         INVARIANT(

--- a/src/util/arith_tools.cpp
+++ b/src/util/arith_tools.cpp
@@ -281,7 +281,8 @@ bool get_bvrep_bit(
     "bvrep is hexadecimal, upper-case");
 
   const unsigned char nibble_value =
-    isdigit(nibble) ? nibble - '0' : nibble - 'A' + 10;
+    isdigit(nibble) ? narrow_cast<unsigned char>(nibble - '0')
+                    : narrow_cast<unsigned char>(nibble - 'A' + 10);
 
   return ((nibble_value >> (bit_index % 4)) & 1) != 0;
 }

--- a/src/util/irep_hash.h
+++ b/src/util/irep_hash.h
@@ -72,6 +72,8 @@ static FORCE_INLINE uint64_t ROTL64(uint64_t x, int8_t r)
 
 #ifdef IREP_HASH_BASIC
 
+#  include "narrow.h"
+
 template<int>
 std::size_t basic_hash_combine(
   std::size_t h1,
@@ -82,7 +84,8 @@ inline std::size_t basic_hash_combine<32>(
   std::size_t h1,
   std::size_t h2)
 {
-  return ROTL32(h1, 7)^h2;
+  return narrow_cast<std::size_t>(
+    ROTL32(narrow_cast<uint32_t>(h1), 7) ^ narrow_cast<uint32_t>(h2));
 }
 
 template<>

--- a/src/util/irep_serialization.cpp
+++ b/src/util/irep_serialization.cpp
@@ -17,6 +17,7 @@ Date: May 2007
 #include <iostream>
 
 #include "exception_utils.h"
+#include "narrow.h"
 #include "string_hash.h"
 
 void irep_serializationt::write_irep(
@@ -142,7 +143,7 @@ void write_gb_word(std::ostream &out, std::size_t u)
 
     if(u==0)
     {
-      out.put(value);
+      out.put(narrow_cast<char>(value));
       break;
     }
 

--- a/src/util/run.cpp
+++ b/src/util/run.cpp
@@ -303,7 +303,7 @@ int run(
   CloseHandle(piProcInfo.hProcess);
   CloseHandle(piProcInfo.hThread);
 
-  return exit_code;
+  return narrow_cast<int>(exit_code);
 
 #else
   int stdin_fd = stdio_redirection(STDIN_FILENO, std_input);

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -898,7 +898,8 @@ bool simplify_exprt::simplify_concatenation(exprt &expr)
         to_constant_expr(opi).set_value(new_value);
         to_bitvector_type(opi.type()).set_width(new_width);
         // erase opn
-        expr.operands().erase(expr.operands().begin()+i+1);
+        expr.operands().erase(
+          expr.operands().begin() + narrow_cast<std::ptrdiff_t>(i) + 1);
         result = false;
       }
       else
@@ -929,7 +930,8 @@ bool simplify_exprt::simplify_concatenation(exprt &expr)
         to_bitvector_type(opi.type()).set_width(new_value.size());
         opi.type().id(ID_verilog_unsignedbv);
         // erase opn
-        expr.operands().erase(expr.operands().begin()+i+1);
+        expr.operands().erase(
+          expr.operands().begin() + narrow_cast<std::ptrdiff_t>(i) + 1);
         result = false;
       }
       else

--- a/src/util/small_map.h
+++ b/src/util/small_map.h
@@ -22,6 +22,7 @@ Author: Daniel Poetzl
 #include <utility>
 
 #include "invariant.h"
+#include "narrow.h"
 
 //#define _SMALL_MAP_REALLOC_STATS
 
@@ -380,7 +381,7 @@ public:
 
   const_value_iterator value_begin() const
   {
-    return const_value_iterator(*this, size() - 1);
+    return const_value_iterator(*this, narrow_cast<int>(size()) - 1);
   }
 
   const_value_iterator value_end() const

--- a/src/util/ssa_expr.h
+++ b/src/util/ssa_expr.h
@@ -87,19 +87,19 @@ public:
 
   void set_level_0(unsigned i)
   {
-    set(ID_L0, i);
+    set(ID_L0, narrow_cast<long long>(i));
     update_identifier();
   }
 
   void set_level_1(unsigned i)
   {
-    set(ID_L1, i);
+    set(ID_L1, narrow_cast<long long>(i));
     update_identifier();
   }
 
   void set_level_2(unsigned i)
   {
-    set(ID_L2, i);
+    set(ID_L2, narrow_cast<long long>(i));
     update_identifier();
   }
 

--- a/src/util/string_container.cpp
+++ b/src/util/string_container.cpp
@@ -13,6 +13,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <cstring>
 
+#include "narrow.h"
+
 string_ptrt::string_ptrt(const char *_s):s(_s), len(strlen(_s))
 {
 }
@@ -38,7 +40,7 @@ unsigned string_containert::get(const char *s)
   if(it!=hash_table.end())
     return it->second;
 
-  size_t r=hash_table.size();
+  const unsigned r = narrow_cast<unsigned>(hash_table.size());
 
   // these are stable
   string_list.push_back(std::string(s));
@@ -61,7 +63,7 @@ unsigned string_containert::get(const std::string &s)
   if(it!=hash_table.end())
     return it->second;
 
-  size_t r=hash_table.size();
+  const unsigned r = narrow_cast<unsigned>(hash_table.size());
 
   // these are stable
   string_list.push_back(s);

--- a/src/util/string_utils.cpp
+++ b/src/util/string_utils.cpp
@@ -29,11 +29,11 @@ std::string strip_string(const std::string &s)
   if(left==s.end())
     return "";
 
-  std::string::size_type i=std::distance(s.begin(), left);
+  const auto i = std::distance(s.begin(), left);
 
   std::string::const_reverse_iterator right
     =std::find_if_not(s.rbegin(), s.rend(), pred);
-  std::string::size_type j=std::distance(right, s.rend())-1;
+  const auto j = std::distance(right, s.rend()) - 1;
 
   return s.substr(
     narrow_cast<std::size_t>(i), narrow_cast<std::size_t>(j - i + 1));

--- a/src/util/string_utils.cpp
+++ b/src/util/string_utils.cpp
@@ -7,8 +7,10 @@ Author: Daniel Poetzl
 \*******************************************************************/
 
 #include "string_utils.h"
+
 #include "exception_utils.h"
 #include "invariant.h"
+#include "narrow.h"
 
 #include <cassert>
 #include <cctype>
@@ -33,7 +35,8 @@ std::string strip_string(const std::string &s)
     =std::find_if_not(s.rbegin(), s.rend(), pred);
   std::string::size_type j=std::distance(right, s.rend())-1;
 
-  return s.substr(i, (j-i+1));
+  return s.substr(
+    narrow_cast<std::size_t>(i), narrow_cast<std::size_t>(j - i + 1));
 }
 
 /// Given a string s, split into a sequence of substrings when separated by

--- a/src/util/tempfile.cpp
+++ b/src/util/tempfile.cpp
@@ -34,6 +34,7 @@ Author: Daniel Kroening
 #include <cstring>
 
 #include "exception_utils.h"
+#include "narrow.h"
 
 #if defined(__linux__) || \
     defined(__FreeBSD_kernel__) || \
@@ -128,7 +129,7 @@ std::string get_temporary_file(
 
   char *t_ptr=strdup(t_template.c_str());
 
-  int fd=mkstemps(t_ptr, suffix.size());
+  int fd = mkstemps(t_ptr, narrow_cast<int>(suffix.size()));
 
   if(fd<0)
     throw system_exceptiont("Failed to open temporary file");

--- a/src/util/unicode.cpp
+++ b/src/util/unicode.cpp
@@ -36,7 +36,7 @@ std::string narrow(const wchar_t *s)
   int slength=static_cast<int>(wcslen(s));
   int rlength=
     WideCharToMultiByte(CP_UTF8, 0, s, slength, NULL, 0, NULL, NULL);
-  std::string r(rlength, 0);
+  std::string r(narrow_cast<std::size_t>(rlength), 0);
   WideCharToMultiByte(CP_UTF8, 0, s, slength, &r[0], rlength, NULL, NULL);
   return r;
 
@@ -61,7 +61,7 @@ std::wstring widen(const char *s)
   int slength=static_cast<int>(strlen(s));
   int rlength=
     MultiByteToWideChar(CP_UTF8, 0, s, slength, NULL, 0);
-  std::wstring r(rlength, 0);
+  std::wstring r(narrow_cast<std::size_t>(rlength), 0);
   MultiByteToWideChar(CP_UTF8, 0, s, slength, &r[0], rlength);
   return r;
 
@@ -86,7 +86,7 @@ std::string narrow(const std::wstring &s)
   int slength=static_cast<int>(s.size());
   int rlength=
     WideCharToMultiByte(CP_UTF8, 0, &s[0], slength, NULL, 0, NULL, NULL);
-  std::string r(rlength, 0);
+  std::string r(narrow_cast<std::size_t>(rlength), 0);
   WideCharToMultiByte(CP_UTF8, 0, &s[0], slength, &r[0], rlength, NULL, NULL);
   return r;
 
@@ -103,7 +103,7 @@ std::wstring widen(const std::string &s)
   int slength=static_cast<int>(s.size());
   int rlength=
     MultiByteToWideChar(CP_UTF8, 0, &s[0], slength, NULL, 0);
-  std::wstring r(rlength, 0);
+  std::wstring r(narrow_cast<std::size_t>(rlength), 0);
   MultiByteToWideChar(CP_UTF8, 0, &s[0], slength, &r[0], rlength);
   return r;
 
@@ -160,7 +160,7 @@ std::vector<std::string> narrow_argv(int argc, const wchar_t **argv_wide)
     return std::vector<std::string>();
 
   std::vector<std::string> argv_narrow;
-  argv_narrow.reserve(argc);
+  argv_narrow.reserve(narrow_cast<std::size_t>(argc));
 
   for(int i=0; i!=argc; ++i)
     argv_narrow.push_back(narrow(argv_wide[i]));

--- a/src/util/unicode.cpp
+++ b/src/util/unicode.cpp
@@ -205,7 +205,7 @@ std::wstring utf8_to_utf16_native_endian(const std::string &in)
     std::string::size_type i=0;
     while(i<in.size())
     {
-      unsigned char c=in[i++];
+      unsigned char c = narrow_cast<unsigned char>(in[i++]);
       unsigned int code=0;
       // the ifs that follow find out how many UTF8 characters (1-4) store the
       // next unicode character. This is determined by the few most
@@ -221,25 +221,25 @@ std::wstring utf8_to_utf16_native_endian(const std::string &in)
         // we should check that whatever follows first character starts with
         // bits 10.
         code = (c & 0x1Fu) << 6;
-        c=in[i++];
+        c = narrow_cast<unsigned char>(in[i++]);
         code += c & 0x3Fu;
       }
       else if(c<=0xEF && i+1<in.size())
       {
         code = (c & 0xFu) << 12;
-        c=in[i++];
+        c = narrow_cast<unsigned char>(in[i++]);
         code += (c & 0x3Fu) << 6;
-        c=in[i++];
+        c = narrow_cast<unsigned char>(in[i++]);
         code += c & 0x3Fu;
       }
       else if(c<=0xF7 && i+2<in.size())
       {
         code = (c & 0x7u) << 18;
-        c=in[i++];
+        c = narrow_cast<unsigned char>(in[i++]);
         code += (c & 0x3Fu) << 12;
-        c=in[i++];
+        c = narrow_cast<unsigned char>(in[i++]);
         code += (c & 0x3Fu) << 6;
-        c=in[i++];
+        c = narrow_cast<unsigned char>(in[i++]);
         code += c & 0x3Fu;
       }
       else

--- a/src/util/unicode.h
+++ b/src/util/unicode.h
@@ -14,6 +14,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <string>
 #include <vector>
 
+#include "narrow.h"
+
 // we follow the ideas suggested at
 // http://www.utf8everywhere.org/
 
@@ -55,7 +57,8 @@ template <typename It>
 std::vector<const char *> to_c_str_array(It b, It e)
 {
   // Assumes that walking the range will be faster than repeated allocation
-  std::vector<const char *> ret(std::distance(b, e) + 1, nullptr);
+  std::vector<const char *> ret(
+    narrow_cast<std::size_t>(std::distance(b, e) + 1), nullptr);
   std::transform(b, e, std::begin(ret), [] (const std::string & s)
     {
       return s.c_str();

--- a/src/util/union_find.h
+++ b/src/util/union_find.h
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <vector>
 
 #include "invariant.h"
+#include "narrow.h"
 #include "numbering.h"
 
 // Standard union find with weighting and path compression.
@@ -163,7 +164,8 @@ public:
   bool make_union(typename numbering<T>::const_iterator it_a,
                   typename numbering<T>::const_iterator it_b)
   {
-    size_type na=it_a-numbers.begin(), nb=it_b-numbers.begin();
+    size_type na = narrow_cast<size_type>(it_a - numbers.begin()),
+              nb = narrow_cast<size_type>(it_b - numbers.begin());
     bool is_union=find_number(na)==find_number(nb);
     uuf.make_union(na, nb);
     return is_union;
@@ -186,12 +188,14 @@ public:
   bool same_set(typename numbering<T>::const_iterator it_a,
                 typename numbering<T>::const_iterator it_b) const
   {
-    return uuf.same_set(it_a-numbers.begin(), it_b-numbers.begin());
+    return uuf.same_set(
+      narrow_cast<size_type>(it_a - numbers.begin()),
+      narrow_cast<size_type>(it_b - numbers.begin()));
   }
 
   const T &find(typename numbering<T>::const_iterator it) const
   {
-    return numbers[find_number(it-numbers.begin())];
+    return numbers[find_number(narrow_cast<size_type>(it - numbers.begin()))];
   }
 
   const T &find(const T &a)
@@ -201,7 +205,7 @@ public:
 
   size_type find_number(typename numbering<T>::const_iterator it) const
   {
-    return find_number(it-numbers.begin());
+    return find_number(narrow_cast<size_type>(it - numbers.begin()));
   }
 
   size_type find_number(size_type a) const
@@ -230,7 +234,7 @@ public:
 
   bool is_root(typename numbering<T>::const_iterator it) const
   {
-    return uuf.is_root(it-numbers.begin());
+    return uuf.is_root(narrow_cast<size_type>(it - numbers.begin()));
   }
 
   size_type number(const T &a)
@@ -253,7 +257,7 @@ public:
 
   void isolate(typename numbering<T>::const_iterator it)
   {
-    uuf.isolate(it-numbers.begin());
+    uuf.isolate(narrow_cast<size_type>(it - numbers.begin()));
   }
 
   void isolate(const T &a)

--- a/src/util/xml.cpp
+++ b/src/util/xml.cpp
@@ -236,7 +236,8 @@ std::string xmlt::unescape(const std::string &str)
         result+='&';
       else if(tmp[0]=='#' && tmp[1]!='x')
       {
-        char c=unsafe_string2int(tmp.substr(1, tmp.size()-1));
+        char c =
+          narrow_cast<char>(unsafe_string2int(tmp.substr(1, tmp.size() - 1)));
         result+=c;
       }
       else

--- a/unit/util/irep.cpp
+++ b/unit/util/irep.cpp
@@ -153,7 +153,7 @@ SCENARIO("irept_memory", "[core][utils][irept]")
       irep.add("a_new_element", irep2);
       REQUIRE(!irept::is_comment("a_new_element"));
       REQUIRE(irep.find("a_new_element").id() == "second_irep");
-      std::size_t named_sub_size =
+      auto named_sub_size =
         std::distance(irep.get_named_sub().begin(), irep.get_named_sub().end());
       REQUIRE(named_sub_size == 1);
 

--- a/unit/util/range.cpp
+++ b/unit/util/range.cpp
@@ -229,8 +229,7 @@ SCENARIO(
     THEN("A range of made from the vector can be filtered.")
     {
       const auto odds_filter = make_range(input).filter(is_odd);
-      const std::size_t total =
-        std::distance(odds_filter.begin(), odds_filter.end());
+      const auto total = std::distance(odds_filter.begin(), odds_filter.end());
       REQUIRE(total == 5);
       auto iterator = odds_filter.begin();
       REQUIRE((iterator++)->value == 1);


### PR DESCRIPTION
Visual Studio warns about signed/unsigned conversion and limited range of types.