### PR TITLE
goto-ld: handle EFI binaries gracefully

### DIFF
--- a/.github/workflows/build-and-test-Xen.yaml
+++ b/.github/workflows/build-and-test-Xen.yaml
@@ -56,7 +56,7 @@ jobs:
           ln -s goto-cc src/goto-cc/goto-g++
 
       - name: Compile Xen with CBMC via one-line-scan, and check for goto-cc section
-        run: one-line-scan/one-line-scan --add-to-path $(pwd)/src/cbmc --add-to-path $(pwd)/src/goto-diff  --add-to-path $(pwd)/src/goto-cc --no-analysis --trunc-existing --extra-cflags -Wno-error -o CPROVER -j 3 -- make -C xen_4_13 xen -j $(nproc) -k || true
+        run: one-line-scan/one-line-scan --add-to-path $(pwd)/src/cbmc --add-to-path $(pwd)/src/goto-diff  --add-to-path $(pwd)/src/goto-cc --no-analysis --trunc-existing --extra-cflags -Wno-error -o CPROVER -j 3 -- make -C xen_4_13 xen -j $(nproc)
         
       - name: Check for goto-cc section in xen-syms binary
         run: objdump -h xen_4_13/xen/xen-syms | grep "goto-cc"

--- a/src/goto-cc/hybrid_binary.h
+++ b/src/goto-cc/hybrid_binary.h
@@ -25,11 +25,19 @@ Date: May 2018
 /// \param output_file: The name of the object file; the result is stored here.
 /// \param building_executable: The \p output_file is an executable.
 /// \param message_handler: Message handler for output.
+/// \param linking_efi: Set to true if linking x86 EFI binaries to relax error
+///   checking.
 int hybrid_binary(
   const std::string &compiler_or_linker,
   const std::string &goto_binary_file,
   const std::string &output_file,
   bool building_executable,
-  message_handlert &message_handler);
+  message_handlert &message_handler,
+  bool linking_efi = false);
+
+/// Return the name of the objcopy tool matching the chosen compiler or linker
+/// command.
+/// \param compiler_or_linker: Compiler or linker commmand
+std::string objcopy_command(const std::string &compiler_or_linker);
 
 #endif // CPROVER_GOTO_CC_HYBRID_BINARY_H

--- a/src/goto-cc/ld_mode.h
+++ b/src/goto-cc/ld_mode.h
@@ -40,7 +40,14 @@ protected:
   /// \brief call ld with original command line
   int run_ld();
 
-  int ld_hybrid_binary(bool);
+  /// Build an ELF or Mach-O binary containing a goto-cc section.
+  /// \param building_executable: set to true iff the target file is an
+  ///   executable
+  /// \param object_files: object files to be linked
+  /// \return zero, unless an error occurred
+  int ld_hybrid_binary(
+    bool building_executable,
+    const std::list<std::string> &object_files);
 };
 
 #endif // CPROVER_GOTO_CC_LD_MODE_H


### PR DESCRIPTION
Running objcopy on EFI binaries does not work, hence we need to give up on the
goto-cc sections in a graceful manner.