### PR TITLE
Document git submodule update in COMPILING.md

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -185,7 +185,7 @@ Follow these instructions:
    make -C src DOWNLOADER=wget minisat2-download
    make -C src
    ```
-5. To compile JMBC, open the Cygwin shell and type
+5. To compile JBMC, open the Cygwin shell and type
    ```
    make -C jbmc/src setup-submodules
    make -C jbmc/src

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -242,7 +242,7 @@ require manual modification of build files.
    first.
 3. Update git submodules:
    ```
-   git submodule update --init --recursive
+   git submodule update --init
    ```
 4. Generate build files with CMake:
    ```

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -66,7 +66,7 @@ We assume that you have a Debian/Ubuntu or Red Hat-like distribution.
 
 5. To compile JBMC, do
    ```
-   make -C jbmc/src java-models-library-download
+   make -C jbmc/src setup-submodules
    make -C jbmc/src
    ```
 
@@ -92,7 +92,7 @@ We assume that you have a Debian/Ubuntu or Red Hat-like distribution.
    ```
 4. To compile JBMC, type
    ```
-   gmake -C jbmc/src java-models-library-download
+   gmake -C jbmc/src setup-submodules
    gmake -C jbmc/src
    ```
 
@@ -118,7 +118,7 @@ We assume that you have a Debian/Ubuntu or Red Hat-like distribution.
    ```
 4. To compile JBMC, do
    ```
-   gmake -C jbmc/src java-models-library-download
+   gmake -C jbmc/src setup-submodules
    gmake -C jbmc/src
    ```
 
@@ -144,7 +144,7 @@ Follow these instructions:
    ```
 4. To compile JBMC, do
    ```
-   make -C jbmc/src java-models-library-download
+   make -C jbmc/src setup-submodules
    make -C jbmc/src
    ```
 
@@ -187,7 +187,7 @@ Follow these instructions:
    ```
 5. To compile JMBC, open the Cygwin shell and type
    ```
-   make -C jbmc/src java-models-library-download
+   make -C jbmc/src setup-submodules
    make -C jbmc/src
    ```
 
@@ -240,7 +240,11 @@ require manual modification of build files.
 2. Navigate to the *top level* folder of the project. This is different from
    the Makefile build, which requires you to navigate to the `src` directory
    first.
-3. Generate build files with CMake:
+3. Update git submodules:
+   ```
+   git submodule update --init --recursive
+   ```
+4. Generate build files with CMake:
    ```
    cmake -H. -Bbuild
    ```
@@ -264,7 +268,7 @@ require manual modification of build files.
    Finally, to enable building universal binaries on macOS, you can pass the
    flag `-DCMAKE_OSX_ARCHITECTURES=i386;x86_64`. If you don't supply this flag,
    the build will just be for the architecture of your machine.
-4. Run the build:
+5. Run the build:
    ```
    cmake --build build
    ```

--- a/jbmc/README.md
+++ b/jbmc/README.md
@@ -27,9 +27,10 @@ JBMC compiles CBMC as part of its build process and as such has all the pre-requ
 Compilation
 ===========
 
-Before compilation, update git submodules using the command:
+Before compilation, run the commands:
 
 ```bash
+make -C src DOWNLOADER=wget minisat2-download
 make -C jbmc/src setup-submodules
 ```
 

--- a/jbmc/README.md
+++ b/jbmc/README.md
@@ -27,10 +27,15 @@ JBMC compiles CBMC as part of its build process and as such has all the pre-requ
 Compilation
 ===========
 
-To compile you need to run the command:
+Before compilation, update git submodules using the command:
 
 ```bash
-make -C jbmc/src java-models-library-download
+make -C jbmc/src setup-submodules
+```
+
+Then compile using:
+
+```bash
 make -C jbmc/src
 ```
 

--- a/jbmc/src/Makefile
+++ b/jbmc/src/Makefile
@@ -55,7 +55,7 @@ dist_clean:
 	rm -rf $(ROOT)dist
 
 setup-submodules:
-	git submodule update --init --recursive
+	git submodule update --init
 
 .PHONY: dist
 dist: setup-submodules all


### PR DESCRIPTION
Update build documentation (COMPILING.md and jbmc/README.md), given that JBMC now uses a git submodule.  **Also,** this PR has now been extended to remove `--recursive` from the submodule update in the  makefile.