### PR TITLE
Upstream ls parse

### DIFF
--- a/scripts/ls_parse.py
+++ b/scripts/ls_parse.py
@@ -15,6 +15,7 @@ import re
 import subprocess
 import sys
 import textwrap
+import traceback
 
 
 def epilog():
@@ -282,6 +283,7 @@ def close_brace_fun(state, _, buf):
         state["UNKNOWN"] = False
     else:
         error("Not in block\n%s", buf)
+        traceback.print_stack()
         exit(1)
 
 


### PR DESCRIPTION
This change fixes a failure when trying to parse Xens linker script with the ls_parse.py script provided by goto-ld.