### PR TITLE
ANSI-C: Floating-point constant folding

### DIFF
--- a/regression/cbmc/switch7/main.c
+++ b/regression/cbmc/switch7/main.c
@@ -1,0 +1,23 @@
+// These need to be constant-folded at compile time
+
+#define C1 (int)(0. / 1. + 0.5)
+#define C2 (int)(1. / 1. + 0.5)
+
+int nondet_int();
+
+int main(void)
+{
+  int i = nondet_int();
+
+  switch(i)
+  {
+  case C1:
+    break;
+
+  case C2:
+    break;
+
+  default:
+    break;
+  }
+}

--- a/regression/cbmc/switch7/test.desc
+++ b/regression/cbmc/switch7/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -24,6 +24,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/simplify_expr.h>
 #include <util/string_constant.h>
 
+#include <goto-programs/adjust_float_expressions.h>
+
 #include "builtin_factory.h"
 #include "c_typecast.h"
 #include "c_qualifiers.h"
@@ -3372,6 +3374,13 @@ void c_typecheck_baset::typecheck_side_effect_assignment(
 
 void c_typecheck_baset::make_constant(exprt &expr)
 {
+  // Floating-point expressions may require a rounding mode.
+  // ISO 9899:1999 F.7.2 says that the default is "round to nearest".
+  // Some compilers have command-line options to override.
+  const auto rounding_mode =
+    from_integer(ieee_floatt::ROUND_TO_EVEN, signed_int_type());
+  adjust_float_expressions(expr, rounding_mode);
+
   simplify(expr, *this);
 
   if(!expr.is_constant() &&

--- a/src/goto-programs/adjust_float_expressions.h
+++ b/src/goto-programs/adjust_float_expressions.h
@@ -22,6 +22,8 @@ void adjust_float_expressions(
   exprt &expr,
   const namespacet &ns);
 
+void adjust_float_expressions(exprt &expr, const exprt &rounding_mode);
+
 void adjust_float_expressions(
   goto_functionst::goto_functiont &goto_function,
   const namespacet &ns);


### PR DESCRIPTION
This allows constant-folding of expressions that use floating-point in the ANSI-C front-end. The specified rounding-mode is used.

Fixes #2583