### PR TITLE
Print log suffix when running tests

### DIFF
--- a/regression/test.pl
+++ b/regression/test.pl
@@ -392,7 +392,13 @@ if($opt_j>1 && $has_thread_pool && $count>1)
   );
 }
 
-print "Running tests\n";
+if ($log_suffix) {
+  print "Running tests with log suffix: $log_suffix\n";
+}
+else
+{
+  print "Running tests\n";
+}
 foreach my $test (@tests) {
   if(defined($pool))
   {


### PR DESCRIPTION
This allows to distinguish between successive test runs with different log suffixes.

Example:
```
╰─$ make -C jbmc/regression/strings-smoke-tests test                                                                                                                                   85s  
make: Entering directory '/home/joel/test-gen/lib/cbmc/jbmc/regression/strings-smoke-tests'
Loading
  105 tests found

Running tests
  Running java_append_char/test.desc  [OK] in 0 seconds
  Running java_append_int/test.desc  [SKIPPED]
  Running java_append_string/test.desc  [OK] in 0 seconds
 ...
  Running max_input_length/test2.desc  [OK] in 0 seconds

All tests were successful, 25 tests skipped
Loading
  105 tests found

Running tests with log suffix: symex-driven-loading
  Running java_append_char/test.desc  [OK] in 0 seconds
  Running java_append_int/test.desc  [SKIPPED]
  Running java_append_string/test.desc  [OK] in 0 seconds
...
```

Without that, it is difficult to work out in which configuration tests are failing.