### PR TITLE
Install graphviz for doxygen job on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ jobs:
           packages:
             - cmake
             - google-cloud-sdk
+            - graphviz
       cache:
         directories:
           - ${TRAVIS_BUILD_DIR}/doxygen/build/bin


### PR DESCRIPTION
otherwise it won't generate any diagrams