### PR TITLE
added support for _int64 keyword

### DIFF
--- a/regression/ansi-c/VS_extensions1/main.c
+++ b/regression/ansi-c/VS_extensions1/main.c
@@ -54,6 +54,8 @@ __int16 i16;
 
 __int32 i32;
 
+_int64 i64_with_just_one_underscore;
+
 __int64 i64;
 
 __int8 i8;

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -552,6 +552,11 @@ void ansi_c_scanner_init()
                   else
                     return make_identifier();
                 }
+"_int64"        { if(PARSER.mode==configt::ansi_ct::flavourt::VISUAL_STUDIO)
+                    { loc(); return TOK_INT64; }
+                  else
+                    return make_identifier();
+                }
 "__ptr32"       { return MSC_Keyword(TOK_PTR32); }
 "__ptr64"       { return MSC_Keyword(TOK_PTR64); }
 


### PR DESCRIPTION
Visual Studio understands _int64 in addition to __int64. I tried _int32, etc., but these don't seem to exist.