### PR TITLE
SSA trace: don't concretise steps that will subsequently be dropped

### DIFF
--- a/src/cbmc/all_properties.cpp
+++ b/src/cbmc/all_properties.cpp
@@ -41,10 +41,7 @@ void bmc_all_propertiest::goal_covered(const cover_goalst::goalt &)
       if(solver.l_get(cond).is_false())
       {
         g.second.status=goalt::statust::FAILURE;
-        symex_target_equationt::SSA_stepst::iterator next=c;
-        next++; // include the assertion
-        build_goto_trace(bmc.equation, next, solver, bmc.ns,
-                         g.second.goto_trace);
+        build_goto_trace(bmc.equation, c, solver, bmc.ns, g.second.goto_trace);
         break;
       }
     }

--- a/src/cbmc/bmc_cover.cpp
+++ b/src/cbmc/bmc_cover.cpp
@@ -144,6 +144,13 @@ protected:
   bmct &bmc;
 };
 
+static bool is_failed_assumption_step(
+  symex_target_equationt::SSA_stepst::const_iterator step,
+  const prop_convt &prop_conv)
+{
+  return step->is_assume() && prop_conv.l_get(step->cond_literal).is_false();
+}
+
 void bmc_covert::satisfying_assignment()
 {
   tests.push_back(testt());
@@ -173,21 +180,8 @@ void bmc_covert::satisfying_assignment()
     }
   }
 
-  build_goto_trace(bmc.equation, bmc.equation.SSA_steps.end(),
-                   solver, bmc.ns, test.goto_trace);
-
-  goto_tracet &goto_trace=test.goto_trace;
-
-  // Now delete anything after first failed assumption
-  for(goto_tracet::stepst::iterator
-      s_it1=goto_trace.steps.begin();
-      s_it1!=goto_trace.steps.end();
-      s_it1++)
-    if(s_it1->is_assume() && !s_it1->cond_value)
-    {
-      goto_trace.steps.erase(++s_it1, goto_trace.steps.end());
-      break;
-    }
+  build_goto_trace(
+    bmc.equation, is_failed_assumption_step, solver, bmc.ns, test.goto_trace);
 }
 
 bool bmc_covert::operator()()

--- a/src/cbmc/fault_localization.cpp
+++ b/src/cbmc/fault_localization.cpp
@@ -336,10 +336,8 @@ void fault_localizationt::goal_covered(
       if(solver.l_get(cond).is_false())
       {
         goal_pair.second.status=goalt::statust::FAILURE;
-        symex_target_equationt::SSA_stepst::iterator next=inst;
-        next++; // include the assertion
         build_goto_trace(
-          bmc.equation, next, solver, bmc.ns, goal_pair.second.goto_trace);
+          bmc.equation, inst, solver, bmc.ns, goal_pair.second.goto_trace);
 
         // localize faults
         run(goal_pair.first);

--- a/src/goto-symex/build_goto_trace.h
+++ b/src/goto-symex/build_goto_trace.h
@@ -24,10 +24,22 @@ void build_goto_trace(
   const namespacet &ns,
   goto_tracet &goto_trace);
 
-// builds a trace that stops after given step
+// builds a trace that stops after the given step
 void build_goto_trace(
   const symex_target_equationt &target,
-  symex_target_equationt::SSA_stepst::const_iterator stop,
+  symex_target_equationt::SSA_stepst::const_iterator last_step_to_keep,
+  const prop_convt &prop_conv,
+  const namespacet &ns,
+  goto_tracet &goto_trace);
+
+typedef std::function<
+  bool(symex_target_equationt::SSA_stepst::const_iterator, const prop_convt &)>
+  ssa_step_predicatet;
+
+// builds a trace that stops after the step matching a given condition
+void build_goto_trace(
+  const symex_target_equationt &target,
+  ssa_step_predicatet stop_after_predicate,
   const prop_convt &prop_conv,
   const namespacet &ns,
   goto_tracet &goto_trace);


### PR DESCRIPTION
Previously the SSA trace did all concretisation (taking the solver's output
and turning it into concrete expressions to be output in the result trace) before
sorting the steps by time and determining what belongs in the final trace. This
was generally harmless, but could result in much wasted time and potentially
memory exhaustion when concretising very large arrays and strings.

Therefore, we now perform the time-order sort and figure out which steps are
to be kept first, *then* concretise them.

Please read the explanatory comments below!