### PR TITLE
Moves is_lvalue to expr_util.c

### DIFF
--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -17,6 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/c_types.h>
 #include <util/cprover_prefix.h>
 #include <util/expr_initializer.h>
+#include <util/expr_util.h>
 #include <util/pointer_offset_size.h>
 #include <util/rational.h>
 #include <util/rational_tools.h>
@@ -613,20 +614,6 @@ void goto_convertt::do_array_op(
     array_op_statement.copy_to_operands(lhs);
 
   copy(array_op_statement, OTHER, dest);
-}
-
-bool is_lvalue(const exprt &expr)
-{
-  if(expr.id()==ID_index)
-    return is_lvalue(to_index_expr(expr).op0());
-  else if(expr.id()==ID_member)
-    return is_lvalue(to_member_expr(expr).op0());
-  else if(expr.id()==ID_dereference)
-    return true;
-  else if(expr.id()==ID_symbol)
-    return true;
-  else
-    return false;
 }
 
 exprt make_va_list(const exprt &expr)

--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -22,9 +22,9 @@ Author: Daniel Kroening, kroening@kroening.com
 bool is_lvalue(const exprt &expr)
 {
   if(expr.id() == ID_index)
-    return is_lvalue(to_index_expr(expr).op0());
+    return is_lvalue(to_index_expr(expr).array());
   else if(expr.id() == ID_member)
-    return is_lvalue(to_member_expr(expr).op0());
+    return is_lvalue(to_member_expr(expr).compound());
   else if(expr.id() == ID_dereference)
     return true;
   else if(expr.id() == ID_symbol)

--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -19,6 +19,19 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "namespace.h"
 #include "arith_tools.h"
 
+bool is_lvalue(const exprt &expr)
+{
+  if(expr.id() == ID_index)
+    return is_lvalue(to_index_expr(expr).op0());
+  else if(expr.id() == ID_member)
+    return is_lvalue(to_member_expr(expr).op0());
+  else if(expr.id() == ID_dereference)
+    return true;
+  else if(expr.id() == ID_symbol)
+    return true;
+  else
+    return false;
+}
 exprt make_binary(const exprt &expr)
 {
   const exprt::operandst &operands=expr.operands();

--- a/src/util/expr_util.h
+++ b/src/util/expr_util.h
@@ -30,6 +30,9 @@ class symbolt;
 class typet;
 class namespacet;
 
+/// Returns true iff the argument is (syntactically) an lvalue.
+bool is_lvalue(const exprt &expr);
+
 /// splits an expression with >=3 operands into nested binary expressions
 exprt make_binary(const exprt &);
 


### PR DESCRIPTION
This change exposes is_lvalue for use outside of
goto-programs/builtin_functions.cpp.