### PR TITLE
Class loading utils

### DIFF
--- a/jbmc/src/java_bytecode/java_class_loader_limit.cpp
+++ b/jbmc/src/java_bytecode/java_class_loader_limit.cpp
@@ -24,7 +24,11 @@ void java_class_loader_limitt::setup_class_load_limit(
   // '@' signals file reading with list of class files to load
   use_regex_match = java_cp_include_files[0] != '@';
   if(use_regex_match)
+  {
     regex_matcher=std::regex(java_cp_include_files);
+    debug() << "Limit loading to classes matching '" << java_cp_include_files
+            << "'" << eom;
+  }
   else
   {
     assert(java_cp_include_files.length()>1);
@@ -54,7 +58,10 @@ bool java_class_loader_limitt::load_class_file(const std::string &file_name)
   if(use_regex_match)
   {
     std::smatch string_matches;
-    return std::regex_match(file_name, string_matches, regex_matcher);
+    if(std::regex_match(file_name, string_matches, regex_matcher))
+      return true;
+    debug() << file_name + " discarded since not matching loader regexp" << eom;
+    return false;
   }
   else
     // load .class file only if it is in the match set

--- a/src/util/string_utils.cpp
+++ b/src/util/string_utils.cpp
@@ -148,3 +148,24 @@ std::string escape(const std::string &s)
 
   return result;
 }
+
+/// Replace all occurrences of a string inside a string
+/// \param [out] str: string to search
+/// \param from: string to replace
+/// \param to: string to replace with
+/// Copyright notice:
+/// Attributed to Gauthier Boaglio
+/// Source: https://stackoverflow.com/a/24315631/7501486
+/// Used under MIT license
+void replace_all(
+  std::string &str,
+  const std::string &from,
+  const std::string &to)
+{
+  size_t start_pos = 0;
+  while((start_pos = str.find(from, start_pos)) != std::string::npos)
+  {
+    str.replace(start_pos, from.length(), to);
+    start_pos += to.length();
+  }
+}

--- a/src/util/string_utils.h
+++ b/src/util/string_utils.h
@@ -67,4 +67,6 @@ Stream &join_strings(
 /// programming language.
 std::string escape(const std::string &);
 
+void replace_all(std::string &, const std::string &, const std::string &);
+
 #endif


### PR DESCRIPTION
Useful for class loading strategies.

This replaces: https://github.com/diffblue/cbmc/pull/2633. The core functionality has been moved out of cbmc.