### PR TITLE
CMake version.cpp: switch back to add_custom_target

### DIFF
--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -30,17 +30,19 @@ endif()
 
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/version.cpp.in
   "const char *CBMC_VERSION=\"@CBMC_RELEASE@ (@GIT_INFO@)\";\n")
-add_custom_command(
-  OUTPUT version.cpp
+add_custom_target(
+  generate_version_cpp
   COMMAND ${CMAKE_COMMAND}
     -D CBMC_SOURCE_DIR=${CBMC_SOURCE_DIR}
     -D CUR=${CMAKE_CURRENT_BINARY_DIR}
     -P ${CMAKE_BINARY_DIR}/version.cmake
-)
+    )
 
 add_library(util
   ${sources}
   version.cpp)
+
+add_dependencies(util generate_version_cpp)
 
 generic_includes(util)
 


### PR DESCRIPTION
Custom commands (per default) only run if the generated file doesn't exist; custom targets always run
(but configure_file refrains from actually making a change if not necessary).

add_dependencies is still necessary in this case, to note that anything that needs `util` should check `version.cpp`.

(@kroening was slightly too slow getting to testing https://github.com/diffblue/cbmc/pull/2638 sorry :))