### PR TITLE
Second try: fix cmake version file generation

### DIFF
--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -30,8 +30,9 @@ endif()
 
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/version.cpp.in
   "const char *CBMC_VERSION=\"@CBMC_RELEASE@ (@GIT_INFO@)\";\n")
-add_custom_command(
-  OUTPUT version.cpp
+add_custom_target(
+  generate_version_cpp
+  BYPRODUCTS version.cpp
   COMMAND ${CMAKE_COMMAND}
     -D CBMC_SOURCE_DIR=${CBMC_SOURCE_DIR}
     -D CUR=${CMAKE_CURRENT_BINARY_DIR}
@@ -41,6 +42,8 @@ add_custom_command(
 add_library(util
   ${sources}
   version.cpp)
+
+add_dependencies(util generate_version_cpp)
 
 generic_includes(util)
 


### PR DESCRIPTION
This used to refer to a target, but the target went away when custom-command became custom-target; now refers to the generated file.