### PR TITLE
Extra documentation and refactoring of the Invariant definitions

### DIFF
--- a/regression/invariants/driver.cpp
+++ b/regression/invariants/driver.cpp
@@ -40,16 +40,18 @@ public:
     const std::string &function,
     int line,
     const std::string &backtrace,
+    const std::string &condition,
     int code,
-    const std::string &_description):
-    invariant_failedt(
-      file,
-      function,
-      line,
-      backtrace,
-      pretty_print(code, _description)),
-    error_code(code),
-    description(_description)
+    const std::string &_description)
+    : invariant_failedt(
+        file,
+        function,
+        line,
+        backtrace,
+        condition,
+        pretty_print(code, _description)),
+      error_code(code),
+      description(_description)
   {
   }
 };

--- a/src/util/invariant.cpp
+++ b/src/util/invariant.cpp
@@ -79,8 +79,6 @@ void print_backtrace(
   std::ostream &out)
 {
 #ifdef __GLIBC__
-    out << "Backtrace\n" << std::flush;
-
     void * stack[50] = {};
 
     std::size_t entries=backtrace(stack, sizeof(stack) / sizeof(void *));
@@ -116,21 +114,14 @@ void report_exception_to_stderr(const invariant_failedt &reason)
   std::cerr << "--- end invariant violation report ---\n";
 }
 
-std::string invariant_failedt::get_invariant_failed_message(
-  const std::string &file,
-  const std::string &function,
-  int line,
-  const std::string &backtrace,
-  const std::string &reason) const
+std::string invariant_failedt::what() const noexcept
 {
   std::ostringstream out;
   out << "Invariant check failed\n"
-      << "File " << file
-      << " function " << function
-      << " line " << line << '\n'
+      << "File: " << file << ":" << line << " function: " << function << '\n'
       << "Condition: " << condition << '\n'
-      << "Reason: " << reason
-      << "\nBacktrace:\n"
+      << "Reason: " << reason << '\n'
+      << "Backtrace:" << '\n'
       << backtrace << '\n';
   return out.str();
 }

--- a/src/util/invariant.cpp
+++ b/src/util/invariant.cpp
@@ -8,7 +8,7 @@ Author: Martin Brain, martin.brain@diffblue.com
 
 #include "invariant.h"
 
-#include "util/freer.h"
+#include "freer.h"
 
 #include <memory>
 #include <string>
@@ -121,13 +121,14 @@ std::string invariant_failedt::get_invariant_failed_message(
   const std::string &function,
   int line,
   const std::string &backtrace,
-  const std::string &reason)
+  const std::string &reason) const
 {
   std::ostringstream out;
   out << "Invariant check failed\n"
       << "File " << file
       << " function " << function
       << " line " << line << '\n'
+      << "Condition: " << condition << '\n'
       << "Reason: " << reason
       << "\nBacktrace:\n"
       << backtrace << '\n';

--- a/src/util/invariant.h
+++ b/src/util/invariant.h
@@ -225,8 +225,13 @@ inline void invariant_violated_string(
 // for INVARIANT.
 
 // The condition should only contain (unmodified) arguments to the method.
+// Inputs include arguments passed to the function, as well as member
+// variables that the function may read.
 // "The design of the system means that the arguments to this method
 //  will always meet this condition".
+//
+// The PRECONDITION documents / checks assumptions about the inputs
+// that is the caller's responsibility to make happen before the call.
 #define PRECONDITION(CONDITION) INVARIANT(CONDITION, "Precondition")
 #define PRECONDITION_STRUCTURED(CONDITION, TYPENAME, ...) \
   INVARIANT_STRUCTURED(CONDITION, TYPENAME, __VA_ARGS__)
@@ -234,6 +239,11 @@ inline void invariant_violated_string(
 // The condition should only contain variables that will be returned /
 // output without further modification.
 // "The implementation of this method means that the condition will hold".
+//
+// A POSTCONDITION documents what the function can guarantee about its
+// output when it returns, given that it was called with valid inputs.
+// Outputs include the return value of the function, as well as member
+// variables that the function may write.
 #define POSTCONDITION(CONDITION) INVARIANT(CONDITION, "Postcondition")
 #define POSTCONDITION_STRUCTURED(CONDITION, TYPENAME, ...) \
   INVARIANT_STRUCTURED(CONDITION, TYPENAME, __VA_ARGS__)
@@ -242,6 +252,10 @@ inline void invariant_violated_string(
 // changed by a previous method call.
 // "The contract of the previous method call means the following
 //  condition holds".
+//
+// A difference between CHECK_RETURN and POSTCONDITION is that CHECK_RETURN is
+// a statement about what the caller expects from a function, whereas a
+// POSTCONDITION is a statement about guarantees made by the function itself.
 #define CHECK_RETURN(CONDITION) INVARIANT(CONDITION, "Check return value")
 #define CHECK_RETURN_STRUCTURED(CONDITION, TYPENAME, ...)  \
   INVARIANT_STRUCTURED(CONDITION, TYPENAME, __VA_ARGS__)
@@ -261,7 +275,7 @@ inline void invariant_violated_string(
 // Legacy annotations
 
 // The following should not be used in new code and are only intended
-// to migrate documentation and "error handling" in older code
+// to migrate documentation and "error handling" in older code.
 #define TODO           INVARIANT(false, "Todo")
 #define UNIMPLEMENTED  INVARIANT(false, "Unimplemented")
 #define UNHANDLED_CASE INVARIANT(false, "Unhandled case")

--- a/src/util/invariant.h
+++ b/src/util/invariant.h
@@ -75,40 +75,29 @@ Author: Martin Brain, martin.brain@diffblue.com
 class invariant_failedt
 {
  private:
-   std::string get_invariant_failed_message(
-     const std::string &file,
-     const std::string &function,
-     int line,
-     const std::string &backtrace,
-     const std::string &reason) const;
-
- public:
   const std::string file;
   const std::string function;
   const int line;
   const std::string backtrace;
-  const std::string reason;
   const std::string condition;
+  const std::string reason;
 
-  std::string what() const noexcept
-  {
-    return get_invariant_failed_message(
-      file, function, line, backtrace, reason);
-  };
+public:
+  std::string what() const noexcept;
 
   invariant_failedt(
     const std::string &_file,
     const std::string &_function,
     int _line,
     const std::string &_backtrace,
-    const std::string &_reason,
-    const std::string &_condition)
+    const std::string &_condition,
+    const std::string &_reason)
     : file(_file),
       function(_function),
       line(_line),
       backtrace(_backtrace),
-      reason(_reason),
-      condition(_condition)
+      condition(_condition),
+      reason(_reason)
   {
   }
 };
@@ -172,8 +161,8 @@ invariant_violated_structured(
     function,
     line,
     backtrace,
-    std::forward<Params>(params)...,
-    condition);
+    condition,
+    std::forward<Params>(params)...);
   // We now have a structured exception ready to use;
   // in future this is the place to put a 'throw'.
   report_exception_to_stderr(to_throw);
@@ -232,8 +221,8 @@ invariant_violated_string(
         __FILE__,                                                              \
         __this_function__,                                                     \
         __LINE__,                                                              \
-        __VA_ARGS__,                                                           \
-        #CONDITION); /* NOLINT */                                              \
+        #CONDITION,                                                            \
+        __VA_ARGS__); /* NOLINT */                                             \
   } while(false)
 
 #endif // End CPROVER_DO_NOT_CHECK / CPROVER_ASSERT / ... if block


### PR DESCRIPTION
This PR contains some augmentations to the documentation, and some refactorings that we deemed necessary after an internal meeting, so that the definition and the usage of the various different kinds of invariant macros becomes clearer.