### PR TITLE
Remove no-longer-used ifdef

### DIFF
--- a/src/goto-instrument/full_slicer.cpp
+++ b/src/goto-instrument/full_slicer.cpp
@@ -14,8 +14,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/find_symbols.h>
 #include <util/cprover_prefix.h>
-#ifdef DEBUG_FULL_SLICERT
-#endif
 
 #include <goto-programs/remove_skip.h>
 


### PR DESCRIPTION
This is no longer necessary as of 2db625aacd9dfe66c128908dfdff2cf8ea7e1412.