### PR TITLE
expose remove_preconditions

### DIFF
--- a/src/goto-programs/instrument_preconditions.cpp
+++ b/src/goto-programs/instrument_preconditions.cpp
@@ -146,3 +146,14 @@ void instrument_preconditions(goto_modelt &goto_model)
   for(auto &f_it : goto_model.goto_functions.function_map)
     remove_preconditions(f_it.second.body);
 }
+
+void remove_preconditions(goto_functiont &goto_function)
+{
+  remove_preconditions(goto_function.body);
+}
+
+void remove_preconditions(goto_modelt &goto_model)
+{
+  for(auto &f_it : goto_model.goto_functions.function_map)
+    remove_preconditions(f_it.second);
+}

--- a/src/goto-programs/instrument_preconditions.h
+++ b/src/goto-programs/instrument_preconditions.h
@@ -15,5 +15,7 @@ Date:   September 2017
 #include <goto-programs/goto_model.h>
 
 void instrument_preconditions(goto_modelt &);
+void remove_preconditions(goto_modelt &);
+void remove_preconditions(goto_functiont &);
 
 #endif // CPROVER_GOTO_PROGRAMS_INSTRUMENT_PRECONDITIONS_H


### PR DESCRIPTION
Library preconditions aren't useful for all applications (e.g., generating tests) -- this provides an option to remove them.
