### PR TITLE
AWS codebuild: cache apt lists and packages

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -31,4 +31,6 @@ artifacts:
   files:
 cache:
   paths:
+    - '/var/cache/apt/**/*'
+    - '/var/lib/apt/lists/**/*'
     - '/root/.ccache/**/*'


### PR DESCRIPTION
This appears to save about 50s in the "INSTALL" phase.