### PR TITLE
Update test to match Visual-Studio behaviour

### DIFF
--- a/regression/goto-cl/Fo/Fo-directory.desc
+++ b/regression/goto-cl/Fo/Fo-directory.desc
@@ -1,6 +1,6 @@
 CORE
 
---verbosity 10 /c main1.c main2.c /Fo dir
+--verbosity 10 /c main1.c main2.c /Fodir/
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/goto-cl/Fo/Fo-no-directory.desc
+++ b/regression/goto-cl/Fo/Fo-no-directory.desc
@@ -1,0 +1,12 @@
+CORE
+
+--verbosity 10 /c main1.c main2.c /Fodir
+^EXIT=64$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+--
+Visual Studio expects a / or \ at the end of a directory name to be treating it
+as a directory. Using multiple translation units without a target directory is
+not permitted.

--- a/src/goto-cc/ms_cl_mode.cpp
+++ b/src/goto-cc/ms_cl_mode.cpp
@@ -118,6 +118,16 @@ int ms_cl_modet::doit()
       compiler.output_file_object = Fo_value;
   }
 
+  if(
+    compiler.mode == compilet::COMPILE_ONLY &&
+    cmdline.args.size() > 1 &&
+    compiler.output_directory_object.empty())
+  {
+    error() << "output directory required for /c with multiple input files"
+            << eom;
+    return EX_USAGE;
+  }
+
   if(cmdline.isset("Fe"))
   {
     compiler.output_file_executable=cmdline.get_value("Fe");


### PR DESCRIPTION
Visual Studio only places files in a directory when the target name ends in a
slash or backslash. Also test the case of not using a slash.