### PR TITLE
Feature/context sensitive ait merge 3

### DIFF
--- a/regression/goto-analyzer/location-insensitive-basic/main.c
+++ b/regression/goto-analyzer/location-insensitive-basic/main.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+
+void f00(int x, int y)
+{
+  assert(x == 0); // Safe even in location-insensitive
+
+  int z = 23;
+  z = x;
+
+  assert(z == 0); // Needs location sensitivity
+
+  assert(y == 23 || y == 42); // Needs context sensitivity
+}
+
+int main(int argc, char **argv)
+{
+  f00(0, 23);
+
+  f00(0, 42);
+
+  return 0;
+}

--- a/regression/goto-analyzer/location-insensitive-basic/test.desc
+++ b/regression/goto-analyzer/location-insensitive-basic/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--verify --location-insensitive --constants
+^EXIT=0$
+^SIGNAL=0$
+assertion x == 0: Success$
+assertion z == 0: Unknown$
+assertion y == 23 || y == 42: Unknown$
+--
+^warning: ignoring

--- a/src/analyses/Makefile
+++ b/src/analyses/Makefile
@@ -1,5 +1,6 @@
 SRC = ai.cpp \
       ai_domain.cpp \
+      ai_history.cpp \
       call_graph.cpp \
       call_graph_helpers.cpp \
       constant_propagator.cpp \

--- a/src/analyses/ai.cpp
+++ b/src/analyses/ai.cpp
@@ -313,6 +313,33 @@ bool ai_baset::visit(
   return new_data;
 }
 
+bool ai_baset::visit_edge(
+  locationt l,
+  working_sett &working_set,
+  const locationt &to_l,
+  const namespacet &ns)
+{
+  // Abstract domains are mutable so we must copy before we transform
+  statet &current = get_state(l);
+
+  std::unique_ptr<statet> tmp_state(make_temporary_state(current));
+  statet &new_values = *tmp_state;
+
+  // Apply transformer
+  new_values.transform(l, to_l, *this, ns);
+
+  // Initialize state(s), if necessary
+  get_state(to_l);
+
+  if(merge(new_values, l, to_l))
+  {
+    put_in_working_set(working_set, to_l);
+    return true;
+  }
+
+  return false;
+}
+
 bool ai_baset::do_function_call(
   locationt l_call, locationt l_return,
   const goto_functionst &goto_functions,

--- a/src/analyses/ai.cpp
+++ b/src/analyses/ai.cpp
@@ -201,10 +201,8 @@ void ai_baset::initialize(const goto_functionst::goto_functiont &goto_function)
 
 void ai_baset::initialize(const goto_programt &goto_program)
 {
-  // we mark everything as unreachable as starting point
-
-  forall_goto_program_instructions(i_it, goto_program)
-    get_state(i_it).make_bottom();
+  // Domains are created and set to bottom on access.
+  // So we do not need to set them to be bottom before hand.
 }
 
 void ai_baset::initialize(const goto_functionst &goto_functions)

--- a/src/analyses/ai.h
+++ b/src/analyses/ai.h
@@ -386,8 +386,8 @@ private:
   // not implemented in sequential analyses
   bool merge_shared(
     const statet &src,
-    goto_programt::const_targett from,
-    goto_programt::const_targett to,
+    locationt from,
+    locationt to,
     const namespacet &ns) override
   {
     throw "not implemented";
@@ -407,13 +407,13 @@ public:
 
   bool merge_shared(
     const statet &src,
-    goto_programt::const_targett from,
-    goto_programt::const_targett to,
+    locationt from,
+    locationt to,
     const namespacet &ns) override
   {
     statet &dest=this->get_state(to);
-    return static_cast<domainT &>(dest).merge_shared(
-      static_cast<const domainT &>(src), from, to, ns);
+    return static_cast<domaint &>(dest).merge_shared(
+      static_cast<const domaint &>(src), from, to, ns);
   }
 
 protected:

--- a/src/analyses/ai.h
+++ b/src/analyses/ai.h
@@ -508,6 +508,36 @@ protected:
     return find_state(h.current_location()->function);
   }
 
+  void output(
+    const namespacet &ns,
+    const goto_programt &goto_program,
+    const irep_idt &identifier,
+    std::ostream &out) const override
+  {
+    auto it = goto_program.instructions.begin();
+    abstract_state_before(it)->output(out, *this, ns);
+    out << "\n";
+    return;
+  }
+
+  jsont output_json(
+    const namespacet &ns,
+    const goto_programt &goto_program,
+    const irep_idt &identifier) const override
+  {
+    auto it = goto_program.instructions.begin();
+    return abstract_state_before(it)->output_json(*this, ns);
+  }
+
+  xmlt output_xml(
+    const namespacet &ns,
+    const goto_programt &goto_program,
+    const irep_idt &identifier) const override
+  {
+    auto it = goto_program.instructions.begin();
+    return abstract_state_before(it)->output_xml(*this, ns);
+  }
+
 private:
   state_mapt state_map;
 };

--- a/src/analyses/ai.h
+++ b/src/analyses/ai.h
@@ -260,6 +260,13 @@ protected:
     const goto_functionst &goto_functions,
     const namespacet &ns);
 
+  // The most basic step, computing one edge / transformer application.
+  bool visit_edge(
+    locationt l,
+    working_sett &working_set,
+    const locationt &to_l,
+    const namespacet &ns);
+
   // function calls
   bool do_function_call_rec(
     locationt l_call, locationt l_return,

--- a/src/analyses/ai_history.cpp
+++ b/src/analyses/ai_history.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************\
+
+Module: Abstract Interpretation
+
+Author: Martin Brain, martin.brain@cs.ox.ac.uk
+
+\*******************************************************************/
+
+/// \file
+/// Abstract Interpretation history
+
+#include "ai_history.h"
+
+bool history_ptrt::operator<(const history_ptrt &op) const
+{
+  return *p < *op.p;
+}
+
+bool history_ptrt::operator==(const history_ptrt &op) const
+{
+  return *p == *op.p;
+}
+
+jsont ai_history_baset::output_json(void) const
+{
+  std::ostringstream out;
+  output(out);
+  json_stringt json(out.str());
+  return json;
+}
+
+xmlt ai_history_baset::output_xml(void) const
+{
+  std::ostringstream out;
+  output(out);
+  xmlt xml("abstract_state");
+  xml.data = out.str();
+  return xml;
+}

--- a/src/analyses/ai_history.h
+++ b/src/analyses/ai_history.h
@@ -1,0 +1,227 @@
+/*******************************************************************\
+
+Module: Abstract Interpretation
+
+Author: Martin Brain, martin.brain@cs.ox.ac.uk
+
+\*******************************************************************/
+
+/// \file
+/// Abstract Interpretation history
+///
+/// This is an abstraction of the history of the program counter
+/// / the history of the execution of the program.
+/// It is used to track and control how the abstract interpreter
+/// explores the program and for context sensitive analyses it is
+/// also used as the key for the state map.
+///
+/// The abstract interpreter works with instances of ai_history_baset
+/// (and history_ptrt's when dealing with storage) but this is just
+/// an abstract interface much like ai_domain_baset, actual implementations
+/// derive from it.
+
+#ifndef CPROVER_ANALYSES_AI_HISTORY_H
+#define CPROVER_ANALYSES_AI_HISTORY_H
+
+#include <memory>
+
+#include <goto-programs/goto_model.h>
+
+#include <util/json.h>
+#include <util/xml.h>
+
+/// We make heavy use of reference counted pointers to history objects
+class ai_history_baset;
+
+class history_ptrt
+{
+public:
+  typedef std::shared_ptr<const ai_history_baset> ptrt;
+
+  history_ptrt(ptrt _p) : p(_p)
+  {
+  }
+
+  history_ptrt(const ai_history_baset *h) : p(h)
+  {
+  }
+
+  // Order and compare on the contents not the pointers
+  bool operator<(const history_ptrt &op) const;
+  bool operator==(const history_ptrt &op) const;
+
+  const ai_history_baset &operator*(void) const
+  {
+    return *p;
+  }
+
+private:
+  ptrt p;
+};
+
+/// This is the base interface; derive from this.
+class ai_history_baset
+{
+public:
+  typedef goto_programt::const_targett locationt;
+  typedef irep_idt function_namet;
+
+  ai_history_baset(const ai_history_baset &)
+  {
+  }
+
+  /// Create a new history starting from a given location
+  /// This is used to start the analysis from scratch
+  /// PRECONDITION(l.is_dereferenceable());
+  explicit ai_history_baset(locationt)
+  {
+  }
+
+  enum class step_statust
+  {
+    NEW_FORCE_CONTINUE,
+    NEW,
+    MERGED,
+    BLOCKED
+  };
+
+  typedef std::pair<step_statust, history_ptrt> step_returnt;
+  typedef std::set<history_ptrt> history_sett;
+
+  /// Step creates a new history by advancing the current one to location "to"
+  /// It is given the set of all other histories that have reached this point.
+
+  virtual step_returnt step(locationt to, history_sett &others) const = 0;
+
+  /// PRECONDITION(to.is_dereferenceable());
+  /// PRECONDITION(to in goto_program.get_successors(current_location()) ||
+  ///              current_location()->is_function_call() ||
+  ///              current_location()->is_end_function());
+  ///
+  /// Step may do one of four things :
+  ///  1. Create a new history object in others and return a pointer to it.
+  ///     Always adds the history to the worklist.
+  ///     POSTCONDITION(IMPLIES(result.first ==step_statust::NEW_FORCE_CONTINUE,
+  ///                           result.second is a new element of others));
+  ///
+  ///  2. Create a new history object in others and return a pointer to it.
+  ///     Adds the history to the worklist if visit_edge increases the domain.
+  ///     POSTCONDITION(IMPLIES(result.first == step_statust::NEW,
+  ///                           result.second is a new element of others));
+  ///
+  ///  3. Merge with an existing history.
+  ///     Will requeue the history if visit_edge increases the domain.
+  ///     POSTCONDITION(IMPLIES(result.first == step_statust::MERGED,
+  ///                           result.second is an element of others and
+  ///                           others is unchanged));
+  ///
+  ///  4. Block this flow of execution (this may omit some program traces).
+  ///     The abstract interpreter will skip this edge and not queue.
+  ///     POSTCONDITION(IMPLIES(result.first == step_statust::BLOCKED,
+  ///                           result.second == nullptr()));
+
+  /// The order for history_sett
+  virtual bool operator<(const ai_history_baset &op) const = 0;
+
+  /// History objects should be comparable
+  virtual bool operator==(const ai_history_baset &op) const = 0;
+
+  /// The most recent location in the history
+  /// POSTCONDITION(return value is dereferenceable)
+  virtual const locationt &current_location(void) const = 0;
+
+  /// Domains with a substantial height (such as intervals) may need to widen
+  /// when merging this method allows the history to provide a hint on when to
+  /// do this.
+  virtual bool widen(const ai_history_baset &other) const
+  {
+    return false;
+  }
+
+  virtual void output(std::ostream &out) const = 0;
+  virtual jsont output_json(void) const;
+  virtual xmlt output_xml(void) const;
+};
+
+/// The common case of history is to only care about where you are now,
+/// not how you got there!
+/// Invariants are not checkable due to C++...
+class ahistoricalt : public ai_history_baset
+{
+private:
+  // DATA_INVARIANT(current.is_dereferenceable(), "Must not be _::end()")
+  locationt current;
+
+public:
+  ahistoricalt(locationt i) : ai_history_baset(i), current(i)
+  {
+  }
+
+  ahistoricalt(const ahistoricalt &old)
+    : ai_history_baset(old), current(old.current)
+  {
+  }
+
+  /// This will visit all reachable locations at least once.
+  /// Locations will be visited more than once only when this is needed
+  /// for convergence of the domains.
+  step_returnt step(locationt to, history_sett &others) const override
+  {
+    if(others.empty())
+    {
+      history_ptrt next(new ahistoricalt(to));
+      const auto r = others.insert(next);
+      CHECK_RETURN(r.second);
+
+      return std::make_pair(step_statust::NEW_FORCE_CONTINUE, next);
+    }
+    else
+    {
+      // Aggressively merge histories because they are indistinguishable
+      INVARIANT(others.size() == 1, "Only needs one history per location");
+
+      const auto it = others.begin();
+      INVARIANT(
+        (*(*it)).current_location() == to,
+        "The history in the set others must be for that location to");
+
+      return std::make_pair(step_statust::MERGED, *it);
+    }
+  }
+
+  bool operator<(const ai_history_baset &op) const override
+  {
+    PRECONDITION(dynamic_cast<const ahistoricalt *>(&op) != nullptr);
+
+    return this->current_location()->location_number <
+           op.current_location()->location_number;
+  }
+
+  bool operator==(const ai_history_baset &op) const override
+  {
+    PRECONDITION(dynamic_cast<const ahistoricalt *>(&op) != nullptr);
+
+    // It would be nice to:
+    //  return this->current == op.current
+    // But they may point to different goto_programs, undefined behaviour in C++
+    // So (safe due to data invariant & uniqueness of location numbers) ...
+    return this->current_location()->location_number ==
+           op.current_location()->location_number;
+  }
+
+  const locationt &current_location(void) const override
+  {
+    return current;
+  }
+
+  // Use default widening
+  // without history there is no reason to say any location is better than
+  // another to widen.
+
+  void output(std::ostream &out) const override
+  {
+    out << "ahistorical : location " << current_location()->location_number;
+  }
+};
+
+#endif // CPROVER_ANALYSES_AI_HISTORY_H

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -219,7 +219,7 @@ void goto_analyzer_parse_optionst::get_command_line_options(optionst &options)
     options.set_option("intervals", true);
     options.set_option("domain set", true);
   }
-  else if(cmdline.isset("(show-non-null)"))
+  else if(cmdline.isset("show-non-null"))
   {
     // For backwards compatibility
     options.set_option("show", true);

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -239,6 +239,8 @@ void goto_analyzer_parse_optionst::get_command_line_options(optionst &options)
     // Abstract interpreter choice
     if(cmdline.isset("location-sensitive"))
       options.set_option("location-sensitive", true);
+    else if(cmdline.isset("location-insensitive"))
+      options.set_option("location-insensitive", true);
     else if(cmdline.isset("concurrent"))
       options.set_option("concurrent", true);
     else
@@ -323,6 +325,18 @@ ai_baset *goto_analyzer_parse_optionst::build_analyzer(
       domain=new ait<non_null_domaint>();
     }
 #endif
+  }
+  else if(options.get_bool_option("location-insensitive"))
+  {
+    if(options.get_bool_option("constants"))
+    {
+      domain = new location_insensitive_ait<ahistoricalt,
+                                            constant_propagator_domaint>();
+    }
+    else if(options.get_bool_option("intervals"))
+    {
+      domain = new location_insensitive_ait<ahistoricalt, interval_domaint>();
+    }
   }
   else if(options.get_bool_option("concurrent"))
   {
@@ -810,8 +824,10 @@ void goto_analyzer_parse_optionst::help()
     "\n"
     "Abstract interpreter options:\n"
     // NOLINTNEXTLINE(whitespace/line_length)
-    " --location-sensitive         use location-sensitive abstract interpreter\n"
-    " --concurrent                 use concurrency-aware abstract interpreter\n"
+    " --location-sensitive         one domain per location\n"
+    " --location-insensitive       one domain per function\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    " --concurrent                 one domain per location and concurrency analysis\n"
     "\n"
     "Domain options:\n"
     " --constants                  constant domain\n"

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -824,19 +824,20 @@ void goto_analyzer_parse_optionst::help()
     "\n"
     "Abstract interpreter options:\n"
     // NOLINTNEXTLINE(whitespace/line_length)
-    " --location-sensitive         one domain per location\n"
+    " --location-sensitive         one domain per location (default)\n"
     " --location-insensitive       one domain per function\n"
     // NOLINTNEXTLINE(whitespace/line_length)
     " --concurrent                 one domain per location and concurrency analysis\n"
     "\n"
     "Domain options:\n"
-    " --constants                  constant domain\n"
+    " --constants                  constant domain (default)\n"
     " --intervals                  interval domain\n"
     " --non-null                   non-null domain\n"
     " --dependence-graph           data and control dependencies between instructions\n" // NOLINT(*)
     "\n"
     "Output options:\n"
-    " --text file_name             output results in plain text to given file\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    " --text file_name             output results in plain text to given file (default)\n"
     // NOLINTNEXTLINE(whitespace/line_length)
     " --json file_name             output results in JSON format to given file\n"
     " --xml file_name              output results in XML format to given file\n"

--- a/src/goto-analyzer/goto_analyzer_parse_options.h
+++ b/src/goto-analyzer/goto_analyzer_parse_options.h
@@ -147,6 +147,7 @@ class optionst;
   "(dependence-graph)" \
   "(show)(verify)(simplify):" \
   "(location-sensitive)(concurrent)" \
+  "(location-insensitive)" \
   "(no-simplify-slicing)" \
 // clang-format on
 

--- a/src/goto-instrument/full_slicer.cpp
+++ b/src/goto-instrument/full_slicer.cpp
@@ -20,9 +20,11 @@ Author: Daniel Kroening, kroening@kroening.com
 void full_slicert::add_dependencies(
   const cfgt::nodet &node,
   queuet &queue,
-  const dependence_grapht &dep_graph,
+  dependence_grapht &dep_graph,
   const dep_node_to_cfgt &dep_node_to_cfg)
 {
+  // node.PC may not have been previously explored
+  // so dep_graph cannot be const as this may create new domains
   const dependence_grapht::nodet &d_node=
     dep_graph[dep_graph[node.PC].get_node_id()];
 
@@ -217,7 +219,7 @@ void full_slicert::fixedpoint(
   queuet &queue,
   jumpst &jumps,
   decl_deadt &decl_dead,
-  const dependence_grapht &dep_graph)
+  dependence_grapht &dep_graph)
 {
   std::vector<cfgt::entryt> dep_node_to_cfg;
   dep_node_to_cfg.reserve(dep_graph.size());

--- a/src/goto-instrument/full_slicer_class.h
+++ b/src/goto-instrument/full_slicer_class.h
@@ -69,12 +69,12 @@ protected:
     queuet &queue,
     jumpst &jumps,
     decl_deadt &decl_dead,
-    const dependence_grapht &dep_graph);
+    dependence_grapht &dep_graph);
 
   void add_dependencies(
     const cfgt::nodet &node,
     queuet &queue,
-    const dependence_grapht &dep_graph,
+    dependence_grapht &dep_graph,
     const dep_node_to_cfgt &dep_node_to_cfg);
 
   void add_function_calls(


### PR DESCRIPTION
The next part of the history sensitivity patch set.  Unlike previous PRs, this really starts changing things.  The key commits split out storage of domains into a separate layer and replace locations with histories (abstract sequences of histories).  Other commits perform supporting refactoring, add examples that use the new functionality, etc.  The changes are quite major however they should not alter the externally visible behaviour of the abstract interpreter at all!

As before, I would recommend reviewing a patch at a time.