### PR TITLE
Fixed a bug where the rw_set range not being set correctly

### DIFF
--- a/regression/goto-analyzer/dependence-graph14/main.c
+++ b/regression/goto-analyzer/dependence-graph14/main.c
@@ -1,0 +1,8 @@
+int main()
+{
+  int a[10];
+  a[2] = 2;
+  a[1] = 1;
+  int out = a[2];
+  return out;
+}

--- a/regression/goto-analyzer/dependence-graph14/test.desc
+++ b/regression/goto-analyzer/dependence-graph14/test.desc
@@ -4,11 +4,9 @@ main.c
 activate-multi-line-match
 ^EXIT=0$
 ^SIGNAL=0$
-// Assignment has a data dependency on the assignment of a[2]
-\/\/ ([0-9]+).*\n.*a\[\(signed long int\)2\] = 2;(.*\n)*Data dependencies: (\1)\n(.*\n){2,3}.*out = *
+\/\/ ([0-9]+).*\n.*a\[\(signed long( long)? int\)2\] = 2;(.*\n)*Data dependencies: (\1)\n(.*\n){2,3}.*out = *
 --
-// Assignment has no data dependency on the assignment of a[1]
-\/\/ ([0-9]+).*\n.*a\[\(signed long int\)1\] = 1;(.*\n)*Data dependencies: (\1)\n(.*\n){2,3}.*out = *
+\/\/ ([0-9]+).*\n.*a\[\(signed long( long)? int\)1\] = 1;(.*\n)*Data dependencies: (\1)\n(.*\n){2,3}.*out = *
 ^warning: ignoring
 --
 

--- a/regression/goto-analyzer/dependence-graph14/test.desc
+++ b/regression/goto-analyzer/dependence-graph14/test.desc
@@ -1,0 +1,28 @@
+CORE
+main.c
+--dependence-graph --show
+activate-multi-line-match
+^EXIT=0$
+^SIGNAL=0$
+// Assignment has a data dependency on the assignment of a[2]
+\/\/ ([0-9]+).*\n.*a\[\(signed long int\)2\] = 2;(.*\n)*Data dependencies: (\1)\n(.*\n){2,3}.*out = *
+--
+// Assignment has no data dependency on the assignment of a[1]
+\/\/ ([0-9]+).*\n.*a\[\(signed long int\)1\] = 1;(.*\n)*Data dependencies: (\1)\n(.*\n){2,3}.*out = *
+^warning: ignoring
+--
+
+The two regex above matches output portions like shown below (with <N> being a
+location number). The intention is to make sure the rw_set recognize the range
+of the assignment to an array index correctly.
+
+        // <N> file main.c line 4 function main
+        a[(signed long int)2] = 2;
+        ...
+
+**** 4 file main.c line 6 function main
+Data dependencies: <N>
+
+        // 4 file main.c line 6 function main
+        out = a[(signed long int)2];
+

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -542,7 +542,7 @@ void rw_range_sett::get_objects_rec(
     {
       range_spect range_end=size==-1 ? -1 : range_start+size;
       if(size!=-1 && full_size!=-1)
-        range_end=std::max(range_end, full_size);
+        range_end=std::min(range_end, full_size);
 
       add(mode, identifier, range_start, range_end);
     }


### PR DESCRIPTION
This pull request contains the fix of a bug where the range upper bound of `rw_set` is not generated correctly for array elements. For example, the code snippet
```cpp
int a[10];
a[1] = 1;
```
would yield a write set of `a[32:320]` rather than `a[32:64]`.