### PR TITLE
goto-cc: use result of native compiler detection

### DIFF
--- a/src/goto-cc/gcc_mode.cpp
+++ b/src/goto-cc/gcc_mode.cpp
@@ -564,10 +564,13 @@ int gcc_modet::doit()
     config.ansi_c.mode=configt::ansi_ct::flavourt::VISUAL_STUDIO;
     debug() << "Enabling Visual Studio syntax" << eom;
   }
-  else if(config.this_operating_system()=="macos")
-    config.ansi_c.mode = configt::ansi_ct::flavourt::CLANG;
   else
-    config.ansi_c.mode=configt::ansi_ct::flavourt::GCC;
+  {
+    if(gcc_version.flavor == gcc_versiont::flavort::CLANG)
+      config.ansi_c.mode = configt::ansi_ct::flavourt::CLANG;
+    else
+      config.ansi_c.mode = configt::ansi_ct::flavourt::GCC;
+  }
 
   if(compiler.mode==compilet::ASSEMBLE_ONLY)
     compiler.object_file_extension="s";

--- a/src/goto-cc/gcc_mode.cpp
+++ b/src/goto-cc/gcc_mode.cpp
@@ -61,6 +61,9 @@ static std::string compiler_name(
      base_name.find("goto-bcc")!=std::string::npos)
     return "bcc";
 
+  if(base_name=="goto-clang")
+    return "clang";
+
   std::string::size_type pos=base_name.find("goto-gcc");
 
   if(pos==std::string::npos ||


### PR DESCRIPTION
We can now actually distinguish clang from gcc, so let's use the result of gcc_version to set the C language flavor.

This benefits FreeBSD, which uses clang by default, and Linux users who have clang installed.