### PR TITLE
Minor fixes to documentation outline

### DIFF
--- a/doc/architectural/background-concepts.md
+++ b/doc/architectural/background-concepts.md
@@ -13,15 +13,15 @@ To be documented.
 
 To be documented.
 
-### SSA ###
+## SSA ##
 
 To be documented.
 
 # Analysis techniques #
 
-## Bounded model checking (from the CBMC manual) ##
+## Bounded model checking ##
 
-To be documented.
+To be documented (can copy from the CBMC manual).
 
 ## SAT and SMT ##
 

--- a/doc/architectural/cbmc-architecture.md
+++ b/doc/architectural/cbmc-architecture.md
@@ -55,23 +55,23 @@ it’s saved output. These include a wide range of analysis and
 transformation tools (see \ref section-other-tools).
 
 # Concepts #
-## {C, java bytecode} → Parse tree → Symbol table → GOTO programs → GOTO program transformations → BMC → counterexample (goto_tracet) → printing ##
+## {C, java bytecode} -> Parse tree -> Symbol table -> GOTO programs -> GOTO program transformations -> BMC -> counterexample (goto_tracet) -> printing ##
 
 To be documented.
 
-## Instrumentation: goto functions → goto functions ##
+## Instrumentation: goto functions -> goto functions ##
 
 To be documented.
 
-## Goto functions → BMC → Counterexample (trace) ##
+## Goto functions -> BMC -> Counterexample (trace) ##
 
 To be documented.
 
-## Trace → interpreter → memory map ##
+## Trace -> interpreter -> memory map ##
 
 To be documented.
 
-## Goto functions → abstract interpretation ##
+## Goto functions -> abstract interpretation ##
 
 To be documented.
 

--- a/doc/architectural/cbmc-architecture.md
+++ b/doc/architectural/cbmc-architecture.md
@@ -59,25 +59,23 @@ transformation tools (see \ref section-other-tools).
 
 To be documented.
 
-## Instrumentation (for test gen & CBMC & ...): Goto functions -> goto functions ##
+## Instrumentation: goto functions → goto functions ##
 
 To be documented.
 
-## Goto functions -> BMC -> Counterexample (trace) ##
+## Goto functions → BMC → Counterexample (trace) ##
 
 To be documented.
 
-## Trace -> interpreter -> memory map ##
+## Trace → interpreter → memory map ##
 
 To be documented.
 
-## Goto functions -> abstract interpretation ##
+## Goto functions → abstract interpretation ##
 
 To be documented.
 
 ## Executables (flow of transformations): ##
-
-To be documented.
 
 ### goto-cc ###
 

--- a/doc/architectural/cbmc-architecture.md
+++ b/doc/architectural/cbmc-architecture.md
@@ -55,23 +55,23 @@ it’s saved output. These include a wide range of analysis and
 transformation tools (see \ref section-other-tools).
 
 # Concepts #
-## {C, java bytecode} -> Parse tree -> Symbol table -> GOTO programs -> GOTO program transformations -> BMC -> counterexample (goto_tracet) -> printing ##
+## {C, java bytecode} &rarr; Parse tree &rarr; Symbol table &rarr; GOTO programs &rarr; GOTO program transformations &rarr; BMC &rarr; counterexample (goto_tracet) &rarr; printing ##
 
 To be documented.
 
-## Instrumentation: goto functions -> goto functions ##
+## Instrumentation: goto functions &rarr; goto functions ##
 
 To be documented.
 
-## Goto functions -> BMC -> Counterexample (trace) ##
+## Goto functions &rarr; BMC &rarr; Counterexample (trace) ##
 
 To be documented.
 
-## Trace -> interpreter -> memory map ##
+## Trace &rarr; interpreter &rarr; memory map ##
 
 To be documented.
 
-## Goto functions -> abstract interpretation ##
+## Goto functions &rarr; abstract interpretation ##
 
 To be documented.
 

--- a/doc/architectural/data-structures-core-structures-and-ast.md
+++ b/doc/architectural/data-structures-core-structures-and-ast.md
@@ -87,19 +87,16 @@ To be documented.
 
 To be documented.
 
-
 ## Examples: how to represent the AST of statements, in C and in java ##
-
-To be documented.
-
-### struct Array { int length, int *data }; ###
-
-To be documented.
 
 ### x = y + 123 ###
 
-To be documented.
+To be documented..
 
 ### if (x > 10) { y = 2 } else { v[3] = 4 } ###
+
+To be documented.
+
+### Java arrays: struct Array { int length, int *data }; ###
 
 To be documented.

--- a/doc/architectural/data-structures-from-ast-to-goto-program.md
+++ b/doc/architectural/data-structures-from-ast-to-goto-program.md
@@ -5,19 +5,15 @@
 
 ## goto_programt ##
 
-To be documented.
-
-### The CFG of a function ###
-
-To be documented.
+See \ref goto_programt.
 
 ### instructiont ###
 
-See documentation at \ref instructiont.
+See [instructiont](\ref goto_programt::instructiont).
 
-#### Types, motivation of each type (dead?) #####
+#### Types, motivation of each type #####
 
-To be documented.
+See [instructiont](\ref goto_programt::instructiont).
 
 #### Accepted code (codet) values ####
 
@@ -29,23 +25,17 @@ To be documented.
 
 ## goto_functionst ##
 
-To be documented.
-
-### A map from function names to function bodies (CFGs) ###
+\ref goto_functionst is a map from function names to function bodies (CFGs).
 
 To be documented.
 
 ## goto_modelt ##
 
-To be documented.
-
-### A compilation unit ###
+\ref goto_modelt is a compilation unit.
 
 To be documented.
 
 ## Example: ##
-
-To be documented.
 
 ### Unsigned mult (unsigned a, unsigned b) { int acc, i; for (i = 0; i < b; i++) acc += a; return acc; } ###
 

--- a/doc/architectural/front-end-languages-generating-codet-from-multiple-languages.md
+++ b/doc/architectural/front-end-languages-generating-codet-from-multiple-languages.md
@@ -3,13 +3,7 @@
 
 \author Martin Brain, Peter Schrammel
 
-## Front-end languages: generating codet from multiple languages ##
-
-To be documented.
-
-### language_uit, language_filest, languaget classes: ###
-
-To be documented.
+## language_uit, language_filest, languaget classes: ##
 
 ### Purpose ###
 
@@ -27,14 +21,16 @@ To be documented.
 
 To be documented.
 
-## Java bytecode: ##
-
-To be documented.
+## Java bytecode ##
 
 ### Explain how a java program / class is represented in a .class ###
 
 To be documented.
 
-### Explain the 2 step conversion from bytecode to codet; give an example with a class? ###
+### Explain the 2 step conversion from bytecode to codet ###
+
+To be documented.
+
+### A worked example of converting java bytecode to codet ###
 
 To be documented.


### PR DESCRIPTION
Moved a few headings around, removed "To be documented" in a few places where I don't think anything needs to be written (for non-leaf nodes in the hierarchy) and tidied up a few heading names