### PR TITLE
Cleanup error handling of cbmc/ folder

### DIFF
--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <chrono>
 #include <iostream>
 
+#include <util/exception_utils.h>
 #include <util/exit_codes.h>
 
 #include <langapi/language_util.h>
@@ -214,9 +215,8 @@ void bmct::get_memory_model()
     memory_model=util_make_unique<memory_model_psot>(ns);
   else
   {
-    error() << "Invalid memory model " << mm
-            << " -- use one of sc, tso, pso" << eom;
-    throw "invalid memory model";
+    throw invalid_user_input_exceptiont(
+      "invalid parameter " + mm, "--mm", "try values of sc, tso, pso");
   }
 }
 

--- a/src/cbmc/bmc_cover.cpp
+++ b/src/cbmc/bmc_cover.cpp
@@ -239,8 +239,8 @@ bool bmc_covert::operator()()
     cover_goals.add(l);
   }
 
-  INVARIANT(
-    cover_goals.size() == goal_map.size(), "we add coverage for each goal");
+  INVARIANT(cover_goals.size() == goal_map.size(),
+    "we add coverage for each goal");
 
 
   status() << "Running " << solver.decision_procedure_text() << eom;

--- a/src/cbmc/bmc_cover.cpp
+++ b/src/cbmc/bmc_cover.cpp
@@ -219,7 +219,7 @@ bool bmc_covert::operator()()
   {
     if(it->is_assert())
     {
-      assert(it->source.pc->is_assert());
+      PRECONDITION(it->source.pc->is_assert());
       const and_exprt c(
         literal_exprt(it->guard_literal), literal_exprt(!it->cond_literal));
       literalt l_c=solver.convert(c);
@@ -239,7 +239,9 @@ bool bmc_covert::operator()()
     cover_goals.add(l);
   }
 
-  assert(cover_goals.size()==goal_map.size());
+  INVARIANT(
+    cover_goals.size() == goal_map.size(), "we add coverage for each goal");
+
 
   status() << "Running " << solver.decision_procedure_text() << eom;
 

--- a/src/cbmc/cbmc_main.cpp
+++ b/src/cbmc/cbmc_main.cpp
@@ -43,7 +43,7 @@ int main(int argc, const char **argv)
 #endif
   cbmc_parse_optionst parse_options(argc, argv);
 
-  int res=parse_options.main();
+  int res = parse_options.main();
 
   #ifdef IREP_HASH_STATS
   std::cout << "IREP_HASH_CNT=" << irep_hash_cnt << '\n';

--- a/src/cbmc/cbmc_solvers.cpp
+++ b/src/cbmc/cbmc_solvers.cpp
@@ -14,7 +14,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <string>
 
+#include <util/exception_utils.h>
 #include <util/make_unique.h>
 #include <util/unicode.h>
 #include <util/version.h>
@@ -164,8 +166,10 @@ std::unique_ptr<cbmc_solverst::solvert> cbmc_solverst::get_smt2(
   {
     if(solver==smt2_dect::solvert::GENERIC)
     {
-      error() << "please use --outfile" << eom;
-      throw 0;
+      throw invalid_user_input_exceptiont(
+        "required filename not provided",
+        "--outfile",
+        "provide a filename with --outfile");
     }
 
     auto smt2_dec = util_make_unique<smt2_dect>(
@@ -207,8 +211,8 @@ std::unique_ptr<cbmc_solverst::solvert> cbmc_solverst::get_smt2(
 
     if(!*out)
     {
-      error() << "failed to open " << filename << eom;
-      throw 0;
+      throw invalid_user_input_exceptiont(
+        "failed to open file: " + filename, "--outfile");
     }
 
     auto smt2_conv = util_make_unique<smt2_convt>(
@@ -232,18 +236,32 @@ void cbmc_solverst::no_beautification()
 {
   if(options.get_bool_option("beautify"))
   {
-    error() << "sorry, this solver does not support beautification" << eom;
-    throw 0;
+    throw invalid_user_input_exceptiont(
+      "the chosen solver does not support beautification", "--beautify");
   }
 }
 
 void cbmc_solverst::no_incremental_check()
 {
-  if(options.get_bool_option("all-properties") ||
-     options.get_option("cover")!="" ||
-     options.get_option("incremental-check")!="")
+  const bool all_properties = options.get_bool_option("all-properties");
+  const bool cover = options.is_set("cover");
+  const bool incremental_check = options.is_set("incremental-check");
+
+  if(all_properties)
   {
-    error() << "sorry, this solver does not support incremental solving" << eom;
-    throw 0;
+    throw invalid_user_input_exceptiont(
+      "the chosen solver does not support incremental solving",
+      "--all_properties");
+  }
+  else if(cover)
+  {
+    throw invalid_user_input_exceptiont(
+      "the chosen solver does not support incremental solving", "--cover");
+  }
+  else if(incremental_check)
+  {
+    throw invalid_user_input_exceptiont(
+      "the chosen solver does not support incremental solving",
+      "--incremental-check");
   }
 }

--- a/src/cbmc/cbmc_solvers.cpp
+++ b/src/cbmc/cbmc_solvers.cpp
@@ -32,7 +32,8 @@ Author: Daniel Kroening, kroening@kroening.com
 /// \return An smt2_dect::solvert giving the solver to use.
 smt2_dect::solvert cbmc_solverst::get_smt2_solver_type() const
 {
-  assert(options.get_bool_option("smt2"));
+  // we shouldn't get here if this option isn't set
+  PRECONDITION(options.get_bool_option("smt2"));
 
   smt2_dect::solvert s=smt2_dect::solvert::GENERIC;
 

--- a/src/cbmc/cbmc_solvers.h
+++ b/src/cbmc/cbmc_solvers.h
@@ -68,13 +68,13 @@ public:
 
     prop_convt &prop_conv() const
     {
-      PRECONDITION(prop_conv_ptr!=nullptr);
+      PRECONDITION(prop_conv_ptr != nullptr);
       return *prop_conv_ptr;
     }
 
     propt &prop() const
     {
-      PRECONDITION(prop_ptr!=nullptr);
+      PRECONDITION(prop_ptr != nullptr);
       return *prop_ptr;
     }
 

--- a/src/cbmc/cbmc_solvers.h
+++ b/src/cbmc/cbmc_solvers.h
@@ -68,13 +68,13 @@ public:
 
     prop_convt &prop_conv() const
     {
-      assert(prop_conv_ptr!=nullptr);
+      PRECONDITION(prop_conv_ptr!=nullptr);
       return *prop_conv_ptr;
     }
 
     propt &prop() const
     {
-      assert(prop_ptr!=nullptr);
+      PRECONDITION(prop_ptr!=nullptr);
       return *prop_ptr;
     }
 

--- a/src/cbmc/fault_localization.cpp
+++ b/src/cbmc/fault_localization.cpp
@@ -81,7 +81,7 @@ fault_localizationt::get_failed_property()
 bool fault_localizationt::check(const lpointst &lpoints,
                                 const lpoints_valuet &value)
 {
-  assert(value.size()==lpoints.size());
+  PRECONDITION(value.size() == lpoints.size());
   bvt assumptions;
   lpoints_valuet::const_iterator v_it=value.begin();
   for(const auto &l : lpoints)
@@ -142,7 +142,7 @@ void fault_localizationt::run(irep_idt goal_id)
 {
   // find failed property
   failed=get_failed_property();
-  assert(failed!=bmc.equation.SSA_steps.end());
+  PRECONDITION(failed != bmc.equation.SSA_steps.end());
 
   if(goal_id==ID_nil)
     goal_id=failed->source.pc->source_location.get_property_id();

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -13,6 +13,7 @@ SRC = arith_tools.cpp \
       expr.cpp \
       expr_initializer.cpp \
       expr_util.cpp \
+      exception_utils.cpp \
       file_util.cpp \
       find_macros.cpp \
       find_symbols.cpp \

--- a/src/util/exception_utils.cpp
+++ b/src/util/exception_utils.cpp
@@ -1,0 +1,20 @@
+/*******************************************************************\
+
+Module: Exception helper utilities
+
+Author: Fotis Koutoulakis, fotis.koutoulakis@diffblue.com
+
+\*******************************************************************/
+
+#include "exception_utils.h"
+
+std::string invalid_user_input_exceptiont::what() const noexcept
+{
+  std::string res;
+  res += "\nInvalid User Input\n";
+  res += "Option: " + option + "\n";
+  res += "Reason: " + reason;
+  // Print an optional correct usage message assuming correct input parameters have been passed
+  res += correct_input + "\n";
+  return res;
+}

--- a/src/util/exception_utils.h
+++ b/src/util/exception_utils.h
@@ -13,8 +13,12 @@ Author: Fotis Koutoulakis, fotis.koutoulakis@diffblue.com
 
 class invalid_user_input_exceptiont
 {
+  /// The reason this exception was generated.
   std::string reason;
+  /// The full command line option (not the argument) that got
+  /// erroneous input.
   std::string option;
+  /// In case we have samples of correct input to the option.
   std::string correct_input;
 
 public:

--- a/src/util/exception_utils.h
+++ b/src/util/exception_utils.h
@@ -1,0 +1,32 @@
+/*******************************************************************\
+
+Module: Exception helper utilities
+
+Author: Fotis Koutoulakis, fotis.koutoulakis@diffblue.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_EXCEPTION_UTILS_H
+#define CPROVER_UTIL_EXCEPTION_UTILS_H
+
+#include <string>
+
+class invalid_user_input_exceptiont
+{
+  std::string reason;
+  std::string option;
+  std::string correct_input;
+
+public:
+  invalid_user_input_exceptiont(
+    std::string reason,
+    std::string option,
+    std::string correct_input = "")
+    : reason(reason), option(option), correct_input(correct_input)
+  {
+  }
+
+  std::string what() const noexcept;
+};
+
+#endif // CPROVER_UTIL_EXCEPTION_UTILS_H


### PR DESCRIPTION
Perform various cleanups of the error handling mechanisms in the `src/cbmc/` folder. These include turning `assert`s into `INVARIANT`s and `PRECONDITION`s as well as a new custom exception class.