### PR TITLE
Improvement for data dependency across function calls [blocks: #2871]

### DIFF
--- a/regression/goto-analyzer/dependence-graph13/main.c
+++ b/regression/goto-analyzer/dependence-graph13/main.c
@@ -1,0 +1,12 @@
+void bar(int a, int b)
+{
+  int result = b;
+}
+
+void main()
+{
+  int a = 1;
+  int b = 2;
+  int c = 3;
+  bar(a, b + c);
+}

--- a/regression/goto-analyzer/dependence-graph13/test.desc
+++ b/regression/goto-analyzer/dependence-graph13/test.desc
@@ -1,0 +1,26 @@
+CORE
+main.c
+--dependence-graph --show
+activate-multi-line-match
+^EXIT=0$
+^SIGNAL=0$
+\/\/ ([0-9]+).*\n.*b = 2;(.*\n)*Data dependencies: (([0-9]+,\1)|(\1,[0-9]+))\n(.*\n){2,3}.*result = b
+\/\/ ([0-9]+).*\n.*c = 3;(.*\n)*Data dependencies: (([0-9]+,\1)|(\1,[0-9]+))\n(.*\n){2,3}.*result = b
+--
+^warning: ignoring
+--
+
+The two regular expressions above match output portions like shown below (with
+<N> being a location number). The intention is to check whether a function
+parameter in the callee correctly depends on the caller-provided argument.
+
+      // 3 file main.c line 11 function main
+        b = 2;
+...
+**** 12 file main.c line 5 function bar
+Data dependencies: (<N>,...)|(...,<N>)
+
+        // 12 file main.c line 5 function bar
+        result = b;
+
+The second regex matches for c.

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -493,6 +493,23 @@ void rw_range_sett::add(
 
   static_cast<range_domaint&>(*entry->second).push_back(
     {range_start, range_end});
+
+  // add to the single expression read set
+  if(mode == get_modet::READ && expr_r_range_set.has_value())
+  {
+    objectst::iterator expr_entry =
+      expr_r_range_set
+        ->insert(
+          std::pair<const irep_idt &, std::unique_ptr<range_domain_baset>>(
+            identifier, nullptr))
+        .first;
+
+    if(expr_entry->second == nullptr)
+      expr_entry->second = util_make_unique<range_domaint>();
+
+    static_cast<range_domaint &>(*expr_entry->second)
+      .push_back({range_start, range_end});
+  }
 }
 
 void rw_range_sett::get_objects_rec(

--- a/src/analyses/goto_rw.h
+++ b/src/analyses/goto_rw.h
@@ -121,8 +121,7 @@ public:
 
   virtual ~rw_range_sett();
 
-  explicit rw_range_sett(const namespacet &_ns):
-    ns(_ns)
+  explicit rw_range_sett(const namespacet &_ns) : ns(_ns)
   {
   }
 
@@ -134,6 +133,21 @@ public:
   const objectst &get_w_set() const
   {
     return w_range_set;
+  }
+
+  /// Enable maintaining a read set for a single expression
+  void enable_expr_read_set()
+  {
+    expr_r_range_set = objectst{};
+  }
+
+  /// Obtain the read set for a single expression. Requires a prior call to
+  /// \ref enable_expr_read_set.
+  objectst fetch_expr_read_set()
+  {
+    objectst result = std::move(*expr_r_range_set);
+    expr_r_range_set.reset();
+    return result;
   }
 
   const range_domaint &get_ranges(objectst::const_iterator it) const
@@ -167,6 +181,7 @@ protected:
   const namespacet &ns;
 
   objectst r_range_set, w_range_set;
+  optionalt<objectst> expr_r_range_set;
 
   virtual void get_objects_rec(
     get_modet mode,


### PR DESCRIPTION
This pull request includes an improvement for the data dependency generation across function calls.

#### Description of the issue in original data dependency implementation:

When generating dependence for an argument in a function call, its data dependence node is set to be the line this function call happens. The result is unrelated variables are pulled into the dependence, as shown in the following example:

```cpp
void foo(){
    int a = 1;
    int b = 2;
    bar(a, b);
}

int bar(int a, int b){
   int result = b;
   return result;
}
```

In the code, `result` only depends on `b` in function `foo`, so when tracing the leaf dependence node for `result`, the expected node is the line `int b = 2`. 
However, the current data dependence graph would point `result`'s data dependence to the line `bar(a,b)`. And since `bar(a,b)` depends on both `int a = 1` and `int b = 2`, the leaf nodes of `result`'s dependence graph would be `int a = 1` and line `int b = 2`. 
In large code base with many nested function calls, this easily generates too many unnecessary dependences for function call arguments. 

#### The improvement:
The cause of this issue is how reaching definition is constructed. Reaching definition can be considered as a data structure that keeps information about the state of all variables at a program location. The state here means a set of possible locations where the variable could get its current value. In the process of the reaching definition construction, if a given source location `call_loc` is a function call, every parameter in this function would have this `call_loc` added to this set. But this `call_loc` is not exactly where the parameters get their values, and this is why the issue happens. 

The fix does a 1-1 mapping between the symbols of function call parameters and the symbols of the arguments given for the call (utilizing information in symbol table and `rw_set`). Then rather than adding the function call location as the state of the parameter, it adds the current state of its corresponding argument in the call. 

The modification in `goto_rw.cpp` are for the purpose of generating the read set from the expression of a single argument.