### PR TITLE
Add support for getting components by name to `struct_exprt`

### DIFF
--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -1823,6 +1823,9 @@ public:
     exprt(ID_struct, _type)
   {
   }
+
+  exprt &component(const irep_idt &name, const namespacet &ns);
+  const exprt &component(const irep_idt &name, const namespacet &ns) const;
 };
 
 /*! \brief Cast a generic exprt to a \ref struct_exprt


### PR DESCRIPTION
Add support for getting components by name to `struct_exprt`