### PR TITLE
Configurable expr2c

### DIFF
--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -3965,6 +3965,18 @@ std::string expr2ct::convert(const exprt &src)
   return convert_with_precedence(src, precedence);
 }
 
+/// Build a declaration string, which requires converting both a type and
+/// putting an identifier in the syntactically correct position.
+/// \param src: the type to convert
+/// \param identifier: the identifier to use as the type
+/// \return A C declaration of the given type with the right identifier.
+std::string expr2ct::convert_with_identifier(
+  const typet &src,
+  const std::string &identifier)
+{
+  return convert_rec(src, c_qualifierst(), identifier);
+}
+
 std::string expr2c(
   const exprt &expr,
   const namespacet &ns,
@@ -3994,4 +4006,14 @@ std::string type2c(
 std::string type2c(const typet &type, const namespacet &ns)
 {
   return type2c(type, ns, expr2c_configurationt::default_configuration);
+}
+
+std::string type2c(
+  const typet &type,
+  const std::string &identifier,
+  const namespacet &ns,
+  const expr2c_configurationt &configuration)
+{
+  expr2ct expr2c(ns, configuration);
+  return expr2c.convert_with_identifier(type, identifier);
 }

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -36,6 +36,12 @@ expr2c_configurationt expr2c_configurationt::default_configuration{true,
                                                                    "TRUE",
                                                                    "FALSE"};
 
+expr2c_configurationt expr2c_configurationt::clean_configuration{false,
+                                                                 false,
+                                                                 false,
+                                                                 "1",
+                                                                 "0"};
+
 /*
 
 Precedences are as follows. Higher values mean higher precedence.

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -30,18 +30,27 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "c_qualifiers.h"
 #include "expr2c_class.h"
 
-expr2c_configurationt expr2c_configurationt::default_configuration{true,
-                                                                   true,
-                                                                   true,
-                                                                   "TRUE",
-                                                                   "FALSE"};
+// clang-format off
 
-expr2c_configurationt expr2c_configurationt::clean_configuration{false,
-                                                                 false,
-                                                                 false,
-                                                                 "1",
-                                                                 "0"};
+expr2c_configurationt expr2c_configurationt::default_configuration
+{
+  true,
+  true,
+  true,
+  "TRUE",
+  "FALSE"
+};
 
+expr2c_configurationt expr2c_configurationt::clean_configuration
+{
+  false,
+  false,
+  false,
+  "1",
+  "0"
+};
+
+// clang-format on
 /*
 
 Precedences are as follows. Higher values mean higher precedence.

--- a/src/ansi-c/expr2c.h
+++ b/src/ansi-c/expr2c.h
@@ -73,4 +73,10 @@ std::string type2c(
   const namespacet &ns,
   const expr2c_configurationt &configuration);
 
+std::string type2c(
+  const typet &type,
+  const std::string &identifier,
+  const namespacet &ns,
+  const expr2c_configurationt &configuration);
+
 #endif // CPROVER_ANSI_C_EXPR2C_H

--- a/src/ansi-c/expr2c.h
+++ b/src/ansi-c/expr2c.h
@@ -16,7 +16,57 @@ class exprt;
 class namespacet;
 class typet;
 
+/// Used for configuring the behaviour of expr2c and type2c
+struct expr2c_configurationt final
+{
+  /// When printing struct_typet or struct_exprt, include the artificial padding
+  /// components introduced to keep the struct aligned.
+  bool include_struct_padding_components;
+
+  /// When printing a struct_typet, should the components of the struct be
+  /// printed inline.
+  bool print_struct_body_in_type;
+
+  /// When printing array_typet, should the size of the array be printed
+  bool include_array_size;
+
+  /// This is the string that will be printed for the true boolean expression
+  std::string true_string;
+
+  /// This is the string that will be printed for the false boolean expression
+  std::string false_string;
+
+  expr2c_configurationt(
+    const bool include_struct_padding_components,
+    const bool print_struct_body_in_type,
+    const bool include_array_size,
+    std::string true_string,
+    std::string false_string)
+    : include_struct_padding_components(include_struct_padding_components),
+      print_struct_body_in_type(print_struct_body_in_type),
+      include_array_size(include_array_size),
+      true_string(std::move(true_string)),
+      false_string(std::move(false_string))
+  {
+  }
+
+  /// This prints a human readable C like syntax that closely mirrors the
+  /// internals of the GOTO program
+  static expr2c_configurationt default_configuration;
+};
+
 std::string expr2c(const exprt &expr, const namespacet &ns);
+
+std::string expr2c(
+  const exprt &expr,
+  const namespacet &ns,
+  const expr2c_configurationt &configuration);
+
 std::string type2c(const typet &type, const namespacet &ns);
+
+std::string type2c(
+  const typet &type,
+  const namespacet &ns,
+  const expr2c_configurationt &configuration);
 
 #endif // CPROVER_ANSI_C_EXPR2C_H

--- a/src/ansi-c/expr2c.h
+++ b/src/ansi-c/expr2c.h
@@ -53,6 +53,10 @@ struct expr2c_configurationt final
   /// This prints a human readable C like syntax that closely mirrors the
   /// internals of the GOTO program
   static expr2c_configurationt default_configuration;
+
+  /// This prints compilable C that loses some of the internal details of the
+  /// GOTO program
+  static expr2c_configurationt clean_configuration;
 };
 
 std::string expr2c(const exprt &expr, const namespacet &ns);

--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -10,6 +10,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_ANSI_C_EXPR2C_CLASS_H
 #define CPROVER_ANSI_C_EXPR2C_CLASS_H
 
+#include "expr2c.h"
+
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -23,7 +25,13 @@ class namespacet;
 class expr2ct
 {
 public:
-  explicit expr2ct(const namespacet &_ns):ns(_ns), sizeof_nesting(0) { }
+  explicit expr2ct(
+    const namespacet &_ns,
+    const expr2c_configurationt &configuration =
+      expr2c_configurationt::default_configuration)
+    : ns(_ns), configuration(configuration), sizeof_nesting(0)
+  {
+  }
   virtual ~expr2ct() { }
 
   virtual std::string convert(const typet &src);
@@ -33,6 +41,7 @@ public:
 
 protected:
   const namespacet &ns;
+  const expr2c_configurationt &configuration;
 
   virtual std::string convert_rec(
     const typet &src,

--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -39,6 +39,9 @@ public:
 
   void get_shorthands(const exprt &expr);
 
+  std::string
+  convert_with_identifier(const typet &src, const std::string &identifier);
+
 protected:
   const namespacet &ns;
   const expr2c_configurationt &configuration;


### PR DESCRIPTION
Subsumes #2704

Commit by commit probably makes the most sense for reviewing, the "extended interface" I alluded to in discussions in #2704 is the method added in the last commit. If memory serves, it is useful for when you have an array of a struct Foo, with variable name "var_name" and you want to print something like:

```C
struct Foo var_name[]
```

then you can call `type2c(type, "var_name", ns) ` and get what you want, otherwise you have to split apart `struct Foo []` to insert your identifier. 