### PR TITLE
CodeBuild: Remove empty artifact stanza

### DIFF
--- a/buildspec-windows.yml
+++ b/buildspec-windows.yml
@@ -80,9 +80,6 @@ phases:
         $env:Path = "C:\tools\cygwin\bin;$env:Path"
         cmd /c 'call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64 && bash -c "make -C jbmc/unit test BUILD_ENV=MSVC" '
 
-artifacts:
-  files:
-
 cache:
   paths:
     - 'c:\clcache\**\*'

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -27,8 +27,6 @@ phases:
       - make -C jbmc/unit test
       - make -C jbmc/regression test
       - echo Build completed on `date`
-artifacts:
-  files:
 cache:
   paths:
     - '/var/cache/apt/**/*'


### PR DESCRIPTION
It seems that CodeBuild has become more picky about this, making builds fail
when the list of artifacts resolves to an empty list.