### PR TITLE
Make unit tests quiet

### DIFF
--- a/unit/goto-programs/goto_trace_output.cpp
+++ b/unit/goto-programs/goto_trace_output.cpp
@@ -9,7 +9,7 @@
 #include <testing-utils/catch.hpp>
 #include <goto-programs/goto_program.h>
 #include <goto-programs/goto_trace.h>
-#include <iostream>
+#include <sstream>
 
 SCENARIO(
   "Output trace with nil lhs object",
@@ -22,5 +22,16 @@ SCENARIO(
   goto_trace_stept step;
   step.pc = instructions.begin();
   step.type = goto_trace_stept::typet::ATOMIC_BEGIN;
-  step.output(ns, std::cout);
+
+  std::ostringstream oss;
+  step.output(ns, oss);
+
+  std::istringstream iss(oss.str());
+  std::string line;
+  std::getline(iss, line);
+  REQUIRE(line == "*** ATOMIC_BEGIN");
+  std::getline(iss, line);
+  REQUIRE(line == "OTHER");
+  std::getline(iss, line);
+  REQUIRE(line.empty());
 }

--- a/unit/path_strategies.cpp
+++ b/unit/path_strategies.cpp
@@ -314,6 +314,7 @@ void _check_with_strategy(
   }
 
   ui_message_handlert mh(cmdline, "path-explore");
+  mh.set_verbosity(0);
   messaget log(mh);
 
   path_strategy_choosert chooser;


### PR DESCRIPTION
Two of the unit tests previously produced output, which rendered unit tests
noisy with no validation value (the generated text was not inspected).

Fixes: #2372