### PR TITLE
replace_symbolt: hide {expr,type}_map

### DIFF
--- a/src/analyses/constant_propagator.h
+++ b/src/analyses/constant_propagator.h
@@ -105,7 +105,7 @@ public:
 
     void set_to(const irep_idt &lhs, const exprt &rhs)
     {
-      replace_const.expr_map[lhs]=rhs;
+      replace_const.get_expr_map()[lhs] = rhs;
       is_bottom=false;
     }
 
@@ -129,7 +129,7 @@ public:
 
     bool is_empty() const
     {
-      return replace_const.expr_map.empty();
+      return replace_const.empty();
     }
 
     void output(std::ostream &out, const namespacet &ns) const;

--- a/src/goto-programs/link_goto_model.cpp
+++ b/src/goto-programs/link_goto_model.cpp
@@ -140,7 +140,7 @@ static bool link_functions(
       rename_symbols_in_function(dest_it->second, final_id, macro_application);
     }
 
-  if(!object_type_updates.expr_map.empty())
+  if(!object_type_updates.empty())
   {
     Forall_goto_functions(dest_it, dest_functions)
       Forall_goto_program_instructions(iit, dest_it->second.body)

--- a/src/util/replace_symbol.h
+++ b/src/util/replace_symbol.h
@@ -19,6 +19,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <unordered_map>
 
+/// Replace expression or type symbols by an expression or type, respectively.
 class replace_symbolt
 {
 public:
@@ -79,9 +80,31 @@ public:
     return expr_map.empty() && type_map.empty();
   }
 
+  std::size_t erase(const irep_idt &id)
+  {
+    return expr_map.erase(id) + type_map.erase(id);
+  }
+
+  bool replaces_symbol(const irep_idt &id) const
+  {
+    return expr_map.find(id) != expr_map.end() ||
+           type_map.find(id) != type_map.end();
+  }
+
   replace_symbolt();
   virtual ~replace_symbolt();
 
+  const expr_mapt &get_expr_map() const
+  {
+    return expr_map;
+  }
+
+  expr_mapt &get_expr_map()
+  {
+    return expr_map;
+  }
+
+protected:
   expr_mapt expr_map;
   type_mapt type_map;
 

--- a/unit/util/replace_symbol.cpp
+++ b/unit/util/replace_symbol.cpp
@@ -26,7 +26,11 @@ TEST_CASE("Replace all symbols in expression", "[core][util][replace_symbol]")
   exprt other_expr("other");
 
   replace_symbolt r;
+  REQUIRE(r.empty());
+
   r.insert("a", other_expr);
+  REQUIRE(r.replaces_symbol("a"));
+  REQUIRE(r.get_expr_map().size() == 1);
 
   REQUIRE(r.replace(binary) == false);
   REQUIRE(binary.op0() == other_expr);
@@ -37,8 +41,12 @@ TEST_CASE("Replace all symbols in expression", "[core][util][replace_symbol]")
   REQUIRE(r.replace(s2) == true);
   REQUIRE(s2 == symbol_exprt("b", typet("some_type")));
 
+
   REQUIRE(r.replace(array_type) == false);
   REQUIRE(array_type.size() == other_expr);
+
+  REQUIRE(r.erase("a") == 1);
+  REQUIRE(r.empty());
 }
 
 TEST_CASE("Lvalue only", "[core][util][replace_symbol]")


### PR DESCRIPTION
Values should only be added via insert. Add expr_map access functions as some
code still does access the expr_map.