### PR TITLE
Constant propagation: Check type consistency before adding to replacement map

### DIFF
--- a/src/analyses/constant_propagator.h
+++ b/src/analyses/constant_propagator.h
@@ -78,7 +78,7 @@ public:
     bool is_bottom;
 
     bool merge(const valuest &src);
-    bool meet(const valuest &src);
+    bool meet(const valuest &src, const namespacet &ns);
 
     // set whole state
 


### PR DESCRIPTION
Constant propagation directly writes to replace_symbolt's expression map, and
must thus itself take care of type consistency checks.