### PR TITLE
Cleanup constant_propagator_domaint::valuest

### DIFF
--- a/src/analyses/constant_propagator.h
+++ b/src/analyses/constant_propagator.h
@@ -70,12 +70,9 @@ public:
 
   struct valuest
   {
-  public:
-    valuest():is_bottom(true) {}
-
     // maps variables to constants
     replace_symbolt replace_const;
-    bool is_bottom;
+    bool is_bottom = true;
 
     bool merge(const valuest &src);
     bool meet(const valuest &src);


### PR DESCRIPTION
Use C++-11 initialisation of member and remove unnecessary "public" as all
members are public.