### PR TITLE
replace_symbolt refactoring and stricter type checking

### DIFF
--- a/regression/goto-instrument/constant-propagation2/main.c
+++ b/regression/goto-instrument/constant-propagation2/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+
+int main()
+{
+  int i = 0;
+  int *p = &i;
+  assert(*p == 0);
+  return 0;
+}

--- a/regression/goto-instrument/constant-propagation2/test.desc
+++ b/regression/goto-instrument/constant-propagation2/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--constant-propagator
+^EXIT=0$
+^SIGNAL=0$
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/src/analyses/constant_propagator.h
+++ b/src/analyses/constant_propagator.h
@@ -81,7 +81,7 @@ public:
   struct valuest
   {
     // maps variables to constants
-    replace_symbolt replace_const;
+    address_of_aware_replace_symbolt replace_const;
     bool is_bottom = true;
 
     bool merge(const valuest &src);

--- a/src/goto-instrument/code_contracts.cpp
+++ b/src/goto-instrument/code_contracts.cpp
@@ -189,7 +189,10 @@ void code_contractst::apply_contract(
 
   // TODO: return value could be nil
   if(type.return_type()!=empty_typet())
-    replace.insert("__CPROVER_return_value", call.lhs());
+  {
+    symbol_exprt ret_val(CPROVER_PREFIX "return_value", call.lhs().type());
+    replace.insert(ret_val, call.lhs());
+  }
 
   // formal parameters
   code_function_callt::argumentst::const_iterator a_it=
@@ -200,7 +203,10 @@ void code_contractst::apply_contract(
       a_it!=call.arguments().end();
       ++p_it, ++a_it)
     if(!p_it->get_identifier().empty())
-      replace.insert(p_it->get_identifier(), *a_it);
+    {
+      symbol_exprt p(p_it->get_identifier(), p_it->type());
+      replace.insert(p, *a_it);
+    }
 
   replace(requires);
   replace(ensures);
@@ -318,7 +324,8 @@ void code_contractst::add_contract_check(
 
     call.lhs()=r;
 
-    replace.insert("__CPROVER_return_value", r);
+    symbol_exprt ret_val(CPROVER_PREFIX "return_value", call.lhs().type());
+    replace.insert(ret_val, r);
   }
 
   // decl parameter1 ...
@@ -339,7 +346,10 @@ void code_contractst::add_contract_check(
     call.arguments().push_back(p);
 
     if(!p_it->get_identifier().empty())
-      replace.insert(p_it->get_identifier(), p);
+    {
+      symbol_exprt cur_p(p_it->get_identifier(), p_it->type());
+      replace.insert(cur_p, p);
+    }
   }
 
   // assume(requires)

--- a/src/goto-instrument/concurrency.cpp
+++ b/src/goto-instrument/concurrency.cpp
@@ -89,11 +89,9 @@ void concurrency_instrumentationt::instrument(exprt &expr)
   {
     if(s_it->id()==ID_symbol)
     {
-      const irep_idt identifier=
-        to_symbol_expr(*s_it).get_identifier();
+      const symbol_exprt &s = to_symbol_expr(*s_it);
 
-      shared_varst::const_iterator
-        v_it=shared_vars.find(identifier);
+      shared_varst::const_iterator v_it = shared_vars.find(s.get_identifier());
 
       if(v_it!=shared_vars.end())
       {
@@ -101,7 +99,7 @@ void concurrency_instrumentationt::instrument(exprt &expr)
         // new_expr.array()=symbol_expr();
         // new_expr.index()=symbol_expr();
 
-        replace_symbol.insert(identifier, new_expr);
+        replace_symbol.insert(s, new_expr);
       }
     }
   }

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -915,7 +915,7 @@ void dump_ct::cleanup_harness(code_blockt &b)
   if(!ns.lookup("argc'", argc_sym))
   {
     symbol_exprt argc("argc", argc_sym->type);
-    replace.insert(argc_sym->name, argc);
+    replace.insert(argc_sym->symbol_expr(), argc);
     code_declt d(argc);
     decls.add(d);
   }
@@ -923,7 +923,7 @@ void dump_ct::cleanup_harness(code_blockt &b)
   if(!ns.lookup("argv'", argv_sym))
   {
     symbol_exprt argv("argv", argv_sym->type);
-    replace.insert(argv_sym->name, argv);
+    replace.insert(argv_sym->symbol_expr(), argv);
     code_declt d(argv);
     decls.add(d);
   }
@@ -931,7 +931,7 @@ void dump_ct::cleanup_harness(code_blockt &b)
   if(!ns.lookup("return'", return_sym))
   {
     symbol_exprt return_value("return_value", return_sym->type);
-    replace.insert(return_sym->name, return_value);
+    replace.insert(return_sym->symbol_expr(), return_value);
     code_declt d(return_value);
     decls.add(d);
   }

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -923,7 +923,10 @@ void dump_ct::cleanup_harness(code_blockt &b)
   if(!ns.lookup("argv'", argv_sym))
   {
     symbol_exprt argv("argv", argv_sym->type);
-    replace.insert(argv_sym->symbol_expr(), argv);
+    // replace argc' by argc in the type of argv['] to maintain type consistency
+    // while replacing
+    replace(argv);
+    replace.insert(symbol_exprt(argv_sym->name, argv.type()), argv);
     code_declt d(argv);
     decls.add(d);
   }

--- a/src/goto-instrument/model_argc_argv.cpp
+++ b/src/goto-instrument/model_argc_argv.cpp
@@ -130,7 +130,7 @@ bool model_argc_argv(
     {
       value = symbol_pair.second.value;
 
-      replace_symbolt replace;
+      unchecked_replace_symbolt replace;
       replace.insert(ARGC, ns.lookup("argc'").symbol_expr());
       replace.insert(ARGV, ns.lookup("argv'").symbol_expr());
       replace(value);

--- a/src/goto-instrument/model_argc_argv.cpp
+++ b/src/goto-instrument/model_argc_argv.cpp
@@ -74,6 +74,11 @@ bool model_argc_argv(
     return false;
   }
 
+  const symbolt &argc_primed = ns.lookup("argc'");
+  symbol_exprt ARGC("ARGC", argc_primed.type);
+  const symbolt &argv_primed = ns.lookup("argv'");
+  symbol_exprt ARGV("ARGV", argv_primed.type);
+
   // set the size of ARGV storage to 4096, which matches the minimum
   // guaranteed by POSIX (_POSIX_ARG_MAX):
   // http://pubs.opengroup.org/onlinepubs/009695399/basedefs/limits.h.html
@@ -126,8 +131,8 @@ bool model_argc_argv(
       value = symbol_pair.second.value;
 
       replace_symbolt replace;
-      replace.insert("ARGC", ns.lookup("argc'").symbol_expr());
-      replace.insert("ARGV", ns.lookup("argv'").symbol_expr());
+      replace.insert(ARGC, ns.lookup("argc'").symbol_expr());
+      replace.insert(ARGV, ns.lookup("argv'").symbol_expr());
       replace(value);
     }
     else if(

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -993,7 +993,8 @@ void linkingt::duplicate_object_symbol(
     else if(set_to_new)
       old_symbol.type=new_symbol.type;
 
-    object_type_updates.insert(old_symbol.name, old_symbol.symbol_expr());
+    object_type_updates.insert(
+      old_symbol.symbol_expr(), old_symbol.symbol_expr());
   }
 
   // care about initializers

--- a/src/linking/linking_class.h
+++ b/src/linking/linking_class.h
@@ -35,7 +35,7 @@ public:
   virtual void typecheck();
 
   rename_symbolt rename_symbol;
-  replace_symbolt object_type_updates;
+  unchecked_replace_symbolt object_type_updates;
 
 protected:
   bool needs_renaming_type(

--- a/src/solvers/flattening/flatten_byte_operators.cpp
+++ b/src/solvers/flattening/flatten_byte_operators.cpp
@@ -79,7 +79,7 @@ static exprt unpack_rec(
     {
       index_exprt index(src, from_integer(i, index_type()));
       replace_symbolt replace;
-      replace.insert(ID_C_incomplete, index);
+      replace.insert(dummy, index);
 
       for(const auto &op : sub.operands())
       {

--- a/src/solvers/smt2/smt2_solver.cpp
+++ b/src/solvers/smt2/smt2_solver.cpp
@@ -106,10 +106,9 @@ void smt2_solvert::expand_function_applications(exprt &expr)
       std::map<irep_idt, exprt> parameter_map;
       for(std::size_t i=0; i<f_type.domain().size(); i++)
       {
-        const irep_idt p_identifier=
-          f_type.domain()[i].get_identifier();
-
-        replace_symbol.insert(p_identifier, app.arguments()[i]);
+        const auto &var = f_type.domain()[i];
+        const symbol_exprt s(var.get_identifier(), var.type());
+        replace_symbol.insert(s, app.arguments()[i]);
       }
 
       exprt body=f.definition;

--- a/src/util/replace_symbol.cpp
+++ b/src/util/replace_symbol.cpp
@@ -110,7 +110,7 @@ bool replace_symbolt::replace(
 
 bool replace_symbolt::have_to_replace(const exprt &dest) const
 {
-  if(expr_map.empty() && type_map.empty())
+  if(expr_map.empty())
     return false;
 
   // first look at type
@@ -186,17 +186,6 @@ bool replace_symbolt::replace(typet &dest) const
       if(!replace(*it))
         result=false;
   }
-  else if(dest.id() == ID_symbol_type)
-  {
-    type_mapt::const_iterator it =
-      type_map.find(to_symbol_type(dest).get_identifier());
-
-    if(it!=type_map.end())
-    {
-      dest=it->second;
-      result=false;
-    }
-  }
   else if(dest.id()==ID_array)
   {
     array_typet &array_type=to_array_type(dest);
@@ -209,7 +198,7 @@ bool replace_symbolt::replace(typet &dest) const
 
 bool replace_symbolt::have_to_replace(const typet &dest) const
 {
-  if(expr_map.empty() && type_map.empty())
+  if(expr_map.empty())
     return false;
 
   if(dest.has_subtype())
@@ -250,11 +239,6 @@ bool replace_symbolt::have_to_replace(const typet &dest) const
         it++)
       if(have_to_replace(*it))
         return true;
-  }
-  else if(dest.id() == ID_symbol_type)
-  {
-    const irep_idt &identifier = to_symbol_type(dest).get_identifier();
-    return type_map.find(identifier) != type_map.end();
   }
   else if(dest.id()==ID_array)
     return have_to_replace(to_array_type(dest).size());

--- a/src/util/replace_symbol.cpp
+++ b/src/util/replace_symbol.cpp
@@ -245,3 +245,10 @@ bool replace_symbolt::have_to_replace(const typet &dest) const
 
   return false;
 }
+
+void unchecked_replace_symbolt::insert(
+  const symbol_exprt &old_expr,
+  const exprt &new_expr)
+{
+  expr_map.emplace(old_expr.get_identifier(), new_expr);
+}

--- a/src/util/replace_symbol.cpp
+++ b/src/util/replace_symbol.cpp
@@ -8,8 +8,9 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "replace_symbol.h"
 
-#include "std_types.h"
+#include "invariant.h"
 #include "std_expr.h"
+#include "std_types.h"
 
 replace_symbolt::replace_symbolt()
 {
@@ -23,6 +24,7 @@ void replace_symbolt::insert(
   const symbol_exprt &old_expr,
   const exprt &new_expr)
 {
+  PRECONDITION(old_expr.type() == new_expr.type());
   expr_map.insert(std::pair<irep_idt, exprt>(
     old_expr.get_identifier(), new_expr));
 }
@@ -34,6 +36,9 @@ bool replace_symbolt::replace_symbol_expr(symbol_exprt &s) const
   if(it == expr_map.end())
     return true;
 
+  DATA_INVARIANT(
+    s.type() == it->second.type(),
+    "type of symbol to be replaced should match");
   static_cast<exprt &>(s) = it->second;
 
   return false;
@@ -247,6 +252,18 @@ void unchecked_replace_symbolt::insert(
   const exprt &new_expr)
 {
   expr_map.emplace(old_expr.get_identifier(), new_expr);
+}
+
+bool unchecked_replace_symbolt::replace_symbol_expr(symbol_exprt &s) const
+{
+  expr_mapt::const_iterator it = expr_map.find(s.get_identifier());
+
+  if(it == expr_map.end())
+    return true;
+
+  static_cast<exprt &>(s) = it->second;
+
+  return false;
 }
 
 bool address_of_aware_replace_symbolt::replace(exprt &dest) const

--- a/src/util/replace_symbol.h
+++ b/src/util/replace_symbol.h
@@ -97,4 +97,14 @@ protected:
   bool have_to_replace(const typet &type) const;
 };
 
+class unchecked_replace_symbolt : public replace_symbolt
+{
+public:
+  unchecked_replace_symbolt()
+  {
+  }
+
+  void insert(const symbol_exprt &old_expr, const exprt &new_expr);
+};
+
 #endif // CPROVER_UTIL_REPLACE_SYMBOL_H

--- a/src/util/replace_symbol.h
+++ b/src/util/replace_symbol.h
@@ -24,16 +24,9 @@ class replace_symbolt
 {
 public:
   typedef std::unordered_map<irep_idt, exprt> expr_mapt;
-  typedef std::unordered_map<irep_idt, typet> type_mapt;
 
   void insert(const class symbol_exprt &old_expr,
               const exprt &new_expr);
-
-  void insert(const irep_idt &identifier,
-                     const typet &type)
-  {
-    type_map.insert(std::pair<irep_idt, typet>(identifier, type));
-  }
 
   /// \brief Replaces a symbol with a constant
   /// If you are replacing symbols with constants in an l-value, you can
@@ -66,23 +59,21 @@ public:
   void clear()
   {
     expr_map.clear();
-    type_map.clear();
   }
 
   bool empty() const
   {
-    return expr_map.empty() && type_map.empty();
+    return expr_map.empty();
   }
 
   std::size_t erase(const irep_idt &id)
   {
-    return expr_map.erase(id) + type_map.erase(id);
+    return expr_map.erase(id);
   }
 
   bool replaces_symbol(const irep_idt &id) const
   {
-    return expr_map.find(id) != expr_map.end() ||
-           type_map.find(id) != type_map.end();
+    return expr_map.find(id) != expr_map.end();
   }
 
   replace_symbolt();
@@ -100,7 +91,6 @@ public:
 
 protected:
   expr_mapt expr_map;
-  type_mapt type_map;
 
 protected:
   bool have_to_replace(const exprt &dest) const;

--- a/src/util/replace_symbol.h
+++ b/src/util/replace_symbol.h
@@ -26,12 +26,6 @@ public:
   typedef std::unordered_map<irep_idt, exprt> expr_mapt;
   typedef std::unordered_map<irep_idt, typet> type_mapt;
 
-  void insert(const irep_idt &identifier,
-                     const exprt &expr)
-  {
-    expr_map.insert(std::pair<irep_idt, exprt>(identifier, expr));
-  }
-
   void insert(const class symbol_exprt &old_expr,
               const exprt &new_expr);
 

--- a/src/util/replace_symbol.h
+++ b/src/util/replace_symbol.h
@@ -20,6 +20,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <unordered_map>
 
 /// Replace expression or type symbols by an expression or type, respectively.
+/// The resolved type of the symbol must match the type of the replacement.
 class replace_symbolt
 {
 public:
@@ -91,6 +92,9 @@ public:
   }
 
   void insert(const symbol_exprt &old_expr, const exprt &new_expr);
+
+private:
+  bool replace_symbol_expr(symbol_exprt &dest) const override;
 };
 
 /// Replace symbols with constants while maintaining syntactically valid

--- a/unit/util/replace_symbol.cpp
+++ b/unit/util/replace_symbol.cpp
@@ -28,7 +28,7 @@ TEST_CASE("Replace all symbols in expression", "[core][util][replace_symbol]")
   replace_symbolt r;
   REQUIRE(r.empty());
 
-  r.insert("a", other_expr);
+  r.insert(s1, other_expr);
   REQUIRE(r.replaces_symbol("a"));
   REQUIRE(r.get_expr_map().size() == 1);
 
@@ -63,7 +63,7 @@ TEST_CASE("Lvalue only", "[core][util][replace_symbol]")
   constant_exprt c("some_value", typet("some_type"));
 
   replace_symbolt r;
-  r.insert("a", c);
+  r.insert(s1, c);
 
   REQUIRE(r.replace(binary) == false);
   REQUIRE(binary.op0() == address_of_exprt(s1));

--- a/unit/util/replace_symbol.cpp
+++ b/unit/util/replace_symbol.cpp
@@ -62,11 +62,35 @@ TEST_CASE("Lvalue only", "[core][util][replace_symbol]")
 
   constant_exprt c("some_value", typet("some_type"));
 
-  replace_symbolt r;
+  address_of_aware_replace_symbolt r;
   r.insert(s1, c);
 
   REQUIRE(r.replace(binary) == false);
   REQUIRE(binary.op0() == address_of_exprt(s1));
+  const index_exprt &index_expr =
+    to_index_expr(to_address_of_expr(binary.op1()).object());
+  REQUIRE(to_array_type(index_expr.array().type()).size() == c);
+  REQUIRE(index_expr.index() == c);
+}
+
+TEST_CASE("Replace always", "[core][util][replace_symbol]")
+{
+  symbol_exprt s1("a", typet("some_type"));
+  array_typet array_type(typet("some_type"), s1);
+  symbol_exprt array("b", array_type);
+  index_exprt index(array, s1);
+
+  exprt binary("binary", typet("some_type"));
+  binary.copy_to_operands(address_of_exprt(s1));
+  binary.copy_to_operands(address_of_exprt(index));
+
+  constant_exprt c("some_value", typet("some_type"));
+
+  unchecked_replace_symbolt r;
+  r.insert(s1, c);
+
+  REQUIRE(r.replace(binary) == false);
+  REQUIRE(binary.op0() == address_of_exprt(c));
   const index_exprt &index_expr =
     to_index_expr(to_address_of_expr(binary.op1()).object());
   REQUIRE(to_array_type(index_expr.array().type()).size() == c);

--- a/unit/util/replace_symbol.cpp
+++ b/unit/util/replace_symbol.cpp
@@ -23,7 +23,7 @@ TEST_CASE("Replace all symbols in expression", "[core][util][replace_symbol]")
   array_typet array_type(typet("sub-type"), s1);
   REQUIRE(array_type.size() == s1);
 
-  exprt other_expr("other");
+  exprt other_expr("other", typet("some_type"));
 
   replace_symbolt r;
   REQUIRE(r.empty());


### PR DESCRIPTION
The first three commits are in separate pull requests already (#2720, #2721, #2722). The last three commits are actually new. Please provide feedback whether this design is acceptable/better (@kroening in particular).