### PR TITLE
switch Windows console to UTF-8

### DIFF
--- a/src/util/cout_message.h
+++ b/src/util/cout_message.h
@@ -38,15 +38,18 @@ public:
 
   console_message_handlert() : always_flush(false)
   {
+    setup_console();
   }
 
   explicit console_message_handlert(bool always_flush)
     : always_flush(always_flush)
   {
+    setup_console();
   }
 
 protected:
   const bool always_flush;
+  void setup_console();
 };
 
 class gcc_message_handlert:public ui_message_handlert


### PR DESCRIPTION
A side benefit is to remove one layer of buffering. The key benefit us that this enables that we can eventually expose a raw stream as the message_handlert interface.