### PR TITLE
Upstream slice functions

### DIFF
--- a/regression/goto-instrument/fp-reachability-slice1/main.c
+++ b/regression/goto-instrument/fp-reachability-slice1/main.c
@@ -1,0 +1,34 @@
+void a()
+{
+  int e;
+}
+
+void b()
+{
+  double f;
+  if(f == 0)
+    a();
+}
+
+void c()
+{
+  int d;
+}
+
+int main()
+{
+  int k;
+  if(k == 0)
+  {
+    int l;
+    a();
+    c();
+  }
+  else
+  {
+    b();
+  }
+  int n;
+  a();
+  return n;
+}

--- a/regression/goto-instrument/fp-reachability-slice1/test.desc
+++ b/regression/goto-instrument/fp-reachability-slice1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--fp-reachability-slice c
+^EXIT=0$
+^SIGNAL=0$
+1: ASSUME FALSE
+dead e;
+dead d;
+--
+^warning: ignoring
+dead f;

--- a/regression/goto-instrument/fp-reachability-slice2/main.c
+++ b/regression/goto-instrument/fp-reachability-slice2/main.c
@@ -1,0 +1,34 @@
+void a()
+{
+  int e;
+}
+
+void b()
+{
+  double f;
+  if(f == 0)
+    a();
+}
+
+void c()
+{
+  int d;
+}
+
+int main()
+{
+  int k;
+  if(k == 0)
+  {
+    int l;
+    a();
+    c();
+  }
+  else
+  {
+    b();
+  }
+  int n;
+  a();
+  return n;
+}

--- a/regression/goto-instrument/fp-reachability-slice2/test.desc
+++ b/regression/goto-instrument/fp-reachability-slice2/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--fp-reachability-slice a,c
+^EXIT=0$
+^SIGNAL=0$
+dead d;
+dead e;
+--
+^warning: ignoring
+dead f;

--- a/regression/goto-instrument/fp-reachability-slice3/main.c
+++ b/regression/goto-instrument/fp-reachability-slice3/main.c
@@ -1,0 +1,34 @@
+void a()
+{
+  int e;
+}
+
+void b()
+{
+  double f;
+  if(f == 0)
+    a();
+}
+
+void c()
+{
+  int d;
+}
+
+int main()
+{
+  int k;
+  if(k == 0)
+  {
+    int l;
+    a();
+    c();
+  }
+  else
+  {
+    b();
+  }
+  int n;
+  a();
+  return n;
+}

--- a/regression/goto-instrument/fp-reachability-slice3/test.desc
+++ b/regression/goto-instrument/fp-reachability-slice3/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--fp-reachability-slice b,c
+^EXIT=0$
+^SIGNAL=0$
+1 file main.c line 34
+--
+^warning: ignoring
+dead d;
+dead e;
+dead f;

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -933,6 +933,7 @@ void cbmc_parse_optionst::help()
     " --cover CC                   create test-suite with coverage criterion CC\n" // NOLINT(*)
     " --mm MM                      memory consistency model for concurrent programs\n" // NOLINT(*)
     HELP_REACHABILITY_SLICER
+    HELP_REACHABILITY_SLICER_FB
     " --full-slice                 run full slicer (experimental)\n" // NOLINT(*)
     " --drop-unused-functions      drop functions trivially unreachable from main function\n" // NOLINT(*)
     "\n"

--- a/src/goto-instrument/full_slicer_class.h
+++ b/src/goto-instrument/full_slicer_class.h
@@ -113,6 +113,23 @@ public:
   }
 };
 
+class in_function_criteriont : public slicing_criteriont
+{
+public:
+  explicit in_function_criteriont(const std::string &function_name)
+    : target_function(function_name)
+  {
+  }
+
+  virtual bool operator()(goto_programt::const_targett target)
+  {
+    return target->function == target_function;
+  }
+
+protected:
+  const irep_idt target_function;
+};
+
 class properties_criteriont:public slicing_criteriont
 {
 public:

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1430,6 +1430,15 @@ void goto_instrument_parse_optionst::instrument_goto_program()
       reachability_slicer(goto_model);
   }
 
+  if(cmdline.isset("fp-reachability-slice"))
+  {
+    do_indirect_call_and_rtti_removal();
+
+    status() << "Performing a function pointer reachability slice" << eom;
+    function_path_reachability_slicer(
+      goto_model, cmdline.get_comma_separated_values("fp-reachability-slice"));
+  }
+
   // full slice?
   if(cmdline.isset("full-slice"))
   {
@@ -1610,7 +1619,7 @@ void goto_instrument_parse_optionst::help()
     " --render-cluster-function    clusterises the dot by functions\n"
     "\n"
     "Slicing:\n"
-    " --reachability-slice         slice away instructions that can't reach assertions\n" // NOLINT(*)
+    HELP_REACHABILITY_SLICER
     " --full-slice                 slice away instructions that don't affect assertions\n" // NOLINT(*)
     " --property id                slice with respect to specific property only\n" // NOLINT(*)
     " --slice-global-inits         slice away initializations of unused global variables\n" // NOLINT(*)

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -71,6 +71,7 @@ Author: Daniel Kroening, kroening@kroening.com
   "(show-struct-alignment)(interval-analysis)(show-intervals)" \
   "(show-uninitialized)(show-locations)" \
   "(full-slice)(reachability-slice)(slice-global-inits)" \
+  "(fp-reachability-slice):" \
   "(inline)(partial-inline)(function-inline):(log):(no-caching)" \
   OPT_REMOVE_CONST_FUNCTION_POINTERS \
   "(print-internal-representation)" \

--- a/src/goto-instrument/reachability_slicer.cpp
+++ b/src/goto-instrument/reachability_slicer.cpp
@@ -245,17 +245,15 @@ void reachability_slicer(
 /// Perform reachability slicing on goto_model for selected functions.
 /// \param goto_model Goto program to slice
 /// \param functions_list The functions relevant for the slicing (i.e. starting
-/// point for the search in the cfg). Anything that is reachable in the CFG
+/// point for the search in the CFG). Anything that is reachable in the CFG
 /// starting from these functions will be kept.
 void function_path_reachability_slicer(
   goto_modelt &goto_model,
-  const std::string &functions_list)
+  const std::list<std::string> &functions_list)
 {
-  std::istringstream functions_stream(functions_list);
-  std::string single_function;
-  while(std::getline(functions_stream, single_function, ','))
+  for(const auto &function : functions_list)
   {
-    in_function_criteriont matching_criterion(single_function);
+    in_function_criteriont matching_criterion(function);
     reachability_slicert slicer;
     slicer(goto_model.goto_functions, matching_criterion, true);
   }

--- a/src/goto-instrument/reachability_slicer.h
+++ b/src/goto-instrument/reachability_slicer.h
@@ -23,6 +23,10 @@ void reachability_slicer(
   goto_modelt &,
   const std::list<std::string> &properties);
 
+void function_path_reachability_slicer(
+  goto_modelt &goto_model,
+  const std::string &functions_list);
+
 void reachability_slicer(
   goto_modelt &,
   const bool include_forward_reachability);
@@ -33,13 +37,16 @@ void reachability_slicer(
   const bool include_forward_reachability);
 
 // clang-format off
-#define OPT_REACHABILITY_SLICER \
-  "(reachability-slice)(reachability-slice-fb)" // NOLINT(*)
+#define OPT_REACHABILITY_SLICER                                                \
+  "(fp-reachability-slice):(reachability-slice)(reachability-slice-fb)" // NOLINT(*)
 
-#define HELP_REACHABILITY_SLICER \
-  " --reachability-slice         remove instructions that cannot appear on\n" \
-  "                              a trace from entry point to a property\n" \
-  " --reachability-slice-fb      remove instructions that cannot appear on\n" \
-  "                              a trace from entry point through a property\n" // NOLINT(*)
+#define HELP_REACHABILITY_SLICER                                               \
+  " --fp-reachability-slice <f>  remove instructions that cannot appear on a " \
+  "trace that visits all given functions. The list of functions has to be "    \
+  "given as a comma separated list.\n"                                         \
+  " --reachability-slice         remove instructions that cannot appear on a " \
+  "trace from entry point to a property\n"                                     \
+  " --reachability-slice-fb      remove instructions that cannot appear on a " \
+  "trace from entry point through a property\n" // NOLINT(*)
 // clang-format on
 #endif // CPROVER_GOTO_INSTRUMENT_REACHABILITY_SLICER_H

--- a/src/goto-instrument/reachability_slicer.h
+++ b/src/goto-instrument/reachability_slicer.h
@@ -25,7 +25,7 @@ void reachability_slicer(
 
 void function_path_reachability_slicer(
   goto_modelt &goto_model,
-  const std::string &functions_list);
+  const std::list<std::string> &functions_list);
 
 void reachability_slicer(
   goto_modelt &,
@@ -40,13 +40,15 @@ void reachability_slicer(
 #define OPT_REACHABILITY_SLICER                                                \
   "(fp-reachability-slice):(reachability-slice)(reachability-slice-fb)" // NOLINT(*)
 
-#define HELP_REACHABILITY_SLICER                                               \
-  " --fp-reachability-slice <f>  remove instructions that cannot appear on a " \
-  "trace that visits all given functions. The list of functions has to be "    \
-  "given as a comma separated list.\n"                                         \
-  " --reachability-slice         remove instructions that cannot appear on a " \
-  "trace from entry point to a property\n"                                     \
-  " --reachability-slice-fb      remove instructions that cannot appear on a " \
-  "trace from entry point through a property\n" // NOLINT(*)
+#define HELP_REACHABILITY_SLICER                                                      \
+  " --fp-reachability-slice f    remove instructions that cannot appear on a trace\n" \
+  "                              that visits all given functions. The list of\n"      \
+  "                              functions has to be given as a comma separated\n"    \
+  "                              list f.\n"                                           \
+  " --reachability-slice         remove instructions that cannot appear on a trace\n" \
+  "                              from entry point to a property\n" // NOLINT(*)
+#define HELP_REACHABILITY_SLICER_FB                                                   \
+  " --reachability-slice-fb      remove instructions that cannot appear on a trace\n" \
+  "                              from entry point through a property\n" // NOLINT(*)
 // clang-format on
 #endif // CPROVER_GOTO_INSTRUMENT_REACHABILITY_SLICER_H

--- a/src/util/cmdline.cpp
+++ b/src/util/cmdline.cpp
@@ -118,6 +118,23 @@ const std::list<std::string> &cmdlinet::get_values(
     return immutable_empty_list;
 }
 
+std::list<std::string>
+cmdlinet::get_comma_separated_values(const char *option) const
+{
+  std::list<std::string> separated_values;
+  auto i = getoptnr(option);
+  if(i.has_value() && !options[*i].values.empty())
+  {
+    std::istringstream values_stream(options[*i].values.front());
+    std::string single_value;
+    while(std::getline(values_stream, single_value, ','))
+    {
+      separated_values.push_back(single_value);
+    }
+  }
+  return separated_values;
+}
+
 optionalt<std::size_t> cmdlinet::getoptnr(char option) const
 {
   for(std::size_t i=0; i<options.size(); i++)

--- a/src/util/cmdline.h
+++ b/src/util/cmdline.h
@@ -27,6 +27,8 @@ public:
   const std::list<std::string> &get_values(const std::string &option) const;
   const std::list<std::string> &get_values(char option) const;
 
+  std::list<std::string> get_comma_separated_values(const char *option) const;
+
   virtual bool isset(char option) const;
   virtual bool isset(const char *option) const;
   virtual void set(const std::string &option);


### PR DESCRIPTION
This change allows to slice based on functions remaining reachable. This slicing allows to reduce the search space to a user chosen subset of the prorgam.