### PR TITLE
Change the order of appearance of class methods

### DIFF
--- a/src/doxyfile
+++ b/src/doxyfile
@@ -571,7 +571,7 @@ SORT_BRIEF_DOCS        = NO
 # detailed member documentation.
 # The default value is: NO.
 
-SORT_MEMBERS_CTORS_1ST = NO
+SORT_MEMBERS_CTORS_1ST = YES
 
 # If the SORT_GROUP_NAMES tag is set to YES then doxygen will sort the hierarchy
 # of group names into alphabetical order. If set to NO the group names will


### PR DESCRIPTION
Constuctors and destructors for each class appear
before the rest of the methods. The rest appear in
alphabetical order as set by SORT_MEMBER_DOCS.