### PR TITLE
Add JSON symbol table

### DIFF
--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -377,7 +377,7 @@ int janalyzer_parse_optionst::doit()
   // show it?
   if(cmdline.isset("show-symbol-table"))
   {
-    ::show_symbol_table(goto_model.symbol_table, get_ui());
+    ::show_symbol_table(goto_model.symbol_table, ui_message_handler);
     return CPROVER_EXIT_SUCCESS;
   }
 

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -652,7 +652,7 @@ int jbmc_parse_optionst::get_goto_program(
     if(cmdline.isset("show-symbol-table"))
     {
       show_symbol_table(
-        lazy_goto_model.symbol_table, ui_message_handler.get_ui());
+        lazy_goto_model.symbol_table, ui_message_handler);
       return 0;
     }
 
@@ -832,7 +832,7 @@ bool jbmc_parse_optionst::show_loaded_functions(
   if(cmdline.isset("show-symbol-table"))
   {
     show_symbol_table(
-      goto_model.get_symbol_table(), ui_message_handler.get_ui());
+      goto_model.get_symbol_table(), ui_message_handler);
     return true;
   }
 

--- a/regression/goto-instrument/list-symbols-json/test.c
+++ b/regression/goto-instrument/list-symbols-json/test.c
@@ -1,0 +1,5 @@
+
+int main(int argc, char** argv) {
+  int x = 5;
+  ++x;
+}

--- a/regression/goto-instrument/list-symbols-json/test.desc
+++ b/regression/goto-instrument/list-symbols-json/test.desc
@@ -1,0 +1,10 @@
+CORE
+test.c
+--list-symbols --json-ui
+"symbolTable": \{
+"main": \{
+"main::1::x": \{
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/goto-instrument/show-symbol-table-json/test.c
+++ b/regression/goto-instrument/show-symbol-table-json/test.c
@@ -1,0 +1,5 @@
+
+int main(int argc, char** argv) {
+  int x = 5;
+  ++x;
+}

--- a/regression/goto-instrument/show-symbol-table-json/test.desc
+++ b/regression/goto-instrument/show-symbol-table-json/test.desc
@@ -1,0 +1,10 @@
+CORE
+test.c
+--show-symbol-table --json-ui
+"symbolTable": \{
+"main": \{
+"main::1::x": \{
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -587,7 +587,7 @@ int cbmc_parse_optionst::get_goto_program(
 
     if(cmdline.isset("show-symbol-table"))
     {
-      show_symbol_table(goto_model, ui_message_handler.get_ui());
+      show_symbol_table(goto_model, ui_message_handler);
       return CPROVER_EXIT_SUCCESS;
     }
 

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -409,7 +409,7 @@ int goto_analyzer_parse_optionst::doit()
   // show it?
   if(cmdline.isset("show-symbol-table"))
   {
-    ::show_symbol_table(goto_model.symbol_table, get_ui());
+    ::show_symbol_table(goto_model.symbol_table, ui_message_handler);
     return CPROVER_EXIT_SUCCESS;
   }
 

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -464,7 +464,7 @@ int goto_instrument_parse_optionst::doit()
 
     if(cmdline.isset("show-symbol-table"))
     {
-      ::show_symbol_table(goto_model, get_ui());
+      ::show_symbol_table(goto_model, ui_message_handler);
       return CPROVER_EXIT_SUCCESS;
     }
 
@@ -519,7 +519,7 @@ int goto_instrument_parse_optionst::doit()
 
     if(cmdline.isset("list-symbols"))
     {
-      show_symbol_table_brief(goto_model, get_ui());
+      show_symbol_table_brief(goto_model, ui_message_handler);
       return CPROVER_EXIT_SUCCESS;
     }
 

--- a/src/goto-programs/show_symbol_table.cpp
+++ b/src/goto-programs/show_symbol_table.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "show_symbol_table.h"
 
+#include <algorithm>
 #include <iostream>
 #include <memory>
 
@@ -68,16 +69,16 @@ void show_symbol_table_plain(
   out << '\n' << "Symbols:" << '\n' << '\n';
 
   // we want to sort alphabetically
-  std::set<std::string> symbols;
+  std::vector<std::string> symbols;
+  symbols.reserve(symbol_table.symbols.size());
 
   for(const auto &symbol_pair : symbol_table.symbols)
-  {
-    symbols.insert(id2string(symbol_pair.first));
-  }
+    symbols.push_back(id2string(symbol_pair.first));
+  std::sort(symbols.begin(), symbols.end());
 
   const namespacet ns(symbol_table);
 
-  for(const std::string &id : symbols)
+  for(const irep_idt &id : symbols)
   {
     const symbolt &symbol=ns.lookup(id);
 

--- a/src/goto-programs/show_symbol_table.h
+++ b/src/goto-programs/show_symbol_table.h
@@ -19,18 +19,18 @@ class goto_modelt;
 
 void show_symbol_table(
   const symbol_tablet &,
-  ui_message_handlert::uit ui);
+  ui_message_handlert &ui);
 
 void show_symbol_table_brief(
   const symbol_tablet &,
-  ui_message_handlert::uit ui);
+  ui_message_handlert &ui);
 
 void show_symbol_table(
   const goto_modelt &,
-  ui_message_handlert::uit ui);
+  ui_message_handlert &ui);
 
 void show_symbol_table_brief(
   const goto_modelt &,
-  ui_message_handlert::uit ui);
+  ui_message_handlert &ui);
 
 #endif // CPROVER_GOTO_PROGRAMS_SHOW_SYMBOL_TABLE_H

--- a/src/util/json_stream.h
+++ b/src/util/json_stream.h
@@ -169,6 +169,25 @@ public:
       return it->second;
   }
 
+  /// Push back a JSON element into the current object stream.
+  /// Note the pushed key won't be available via operator[], as it has been
+  /// output already.
+  /// Provided for compatibility with `jsont`.
+  /// \param key: new key to create in the streamed object
+  /// \param json: a non-streaming JSON element
+  void push_back(const std::string &key, const jsont &json)
+  {
+    PRECONDITION(open);
+    // Check the key is not already due to be output later:
+    PRECONDITION(!object.count(key));
+    // To ensure consistency of the output, we flush and
+    // close the current child stream before printing the given element.
+    output_child_stream();
+    output_delimiter();
+    jsont::output_key(out, key);
+    json.output_rec(out, indent + 1);
+  }
+
   json_stream_objectt &push_back_stream_object(const std::string &key);
   json_stream_arrayt &push_back_stream_array(const std::string &key);
 


### PR DESCRIPTION
As requested for the memory models work, AFAIK in that use-case to filter out type symbols.

Also includes a small cleanup for ordinary plain-text symbol table printing while I'm at it -- I can split this off into a different PR if you like (it's already a different commit).