### PR TITLE
Correct incomplete_array_typet [DOC-12]

### DIFF
--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -1051,8 +1051,8 @@ public:
   {
   }
 
-  explicit incomplete_array_typet(const typet &_subtype):
-    type_with_subtypet(ID_array, _subtype)
+  explicit incomplete_array_typet(const typet &_subtype)
+    : type_with_subtypet(ID_incomplete_array, _subtype)
   {
   }
 };
@@ -1063,7 +1063,7 @@ public:
 template <>
 inline bool can_cast_type<incomplete_array_typet>(const typet &type)
 {
-  return type.id() == ID_array;
+  return type.id() == ID_incomplete_array;
 }
 
 /// \brief Cast a typet to an \ref incomplete_array_typet

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -1050,11 +1050,6 @@ public:
   incomplete_array_typet():type_with_subtypet(ID_incomplete_array)
   {
   }
-
-  explicit incomplete_array_typet(const typet &_subtype)
-    : type_with_subtypet(ID_incomplete_array, _subtype)
-  {
-  }
 };
 
 /// Check whether a reference to a typet is a \ref incomplete_array_typet.


### PR DESCRIPTION
This is part of the `typet` cleanup, based on top of https://github.com/diffblue/cbmc/pull/2815, please review only the last two commits.