### PR TITLE
Deprecate nil_typet [DOC-12]

### DIFF
--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -32,9 +32,10 @@ public:
   }
 };
 
-/// The NIL type, i.e., an invalid type, no value. Use `optional<typet>`
-/// instead where possible.
-class nil_typet:public typet
+/// The NIL type, i.e., an invalid type, no value.
+/// \deprecated Use `optional<typet>` instead.
+// NOLINTNEXTLINE
+class DEPRECATED("Use `optional<typet>` instead.") nil_typet : public typet
 {
 public:
   nil_typet():typet(static_cast<const typet &>(get_nil_irep()))


### PR DESCRIPTION
This is part of the `typet` cleanup, based on top of https://github.com/diffblue/cbmc/pull/2815, please review only the last commit.