### PR TITLE
cpp_typecheckt::cpp_constructor now returns optionalt<codet>

### DIFF
--- a/src/cpp/cpp_constructor.cpp
+++ b/src/cpp/cpp_constructor.cpp
@@ -115,13 +115,8 @@ optionalt<codet> cpp_typecheckt::cpp_constructor(
 
         auto i_code = cpp_constructor(source_location, index, tmp_operands);
 
-        if(!i_code.has_value())
-        {
-          new_code.is_nil();
-          break;
-        }
-
-        new_code.move(i_code.value());
+        if(i_code.has_value())
+          new_code.move(i_code.value());
       }
       return new_code;
     }

--- a/src/cpp/cpp_destructor.cpp
+++ b/src/cpp/cpp_destructor.cpp
@@ -16,7 +16,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <util/c_types.h>
 
 /// \return typechecked code
-codet cpp_typecheckt::cpp_destructor(
+optionalt<codet> cpp_typecheckt::cpp_destructor(
   const source_locationt &source_location,
   const exprt &object)
 {
@@ -31,10 +31,7 @@ codet cpp_typecheckt::cpp_destructor(
 
   // PODs don't need a destructor
   if(cpp_is_pod(tmp_type))
-  {
-    new_code.make_nil();
-    return new_code;
-  }
+    return {};
 
   if(tmp_type.id()==ID_array)
   {
@@ -42,11 +39,7 @@ codet cpp_typecheckt::cpp_destructor(
       to_array_type(tmp_type).size();
 
     if(size_expr.id()=="infinity")
-    {
-      // don't initialize
-      new_code.make_nil();
-      return new_code;
-    }
+      return {}; // don't initialize
 
     exprt tmp_size=size_expr;
     make_constant_index(tmp_size);
@@ -73,9 +66,9 @@ codet cpp_typecheckt::cpp_destructor(
       index_exprt index(object, constant);
       index.add_source_location()=source_location;
 
-      exprt i_code = cpp_destructor(source_location, index);
-
-      new_code.move_to_operands(i_code);
+      auto i_code = cpp_destructor(source_location, index);
+      if(i_code.has_value())
+        new_code.move_to_operands(i_code.value());
     }
   }
   else

--- a/src/cpp/cpp_typecheck.cpp
+++ b/src/cpp/cpp_typecheck.cpp
@@ -188,11 +188,10 @@ void cpp_typecheckt::static_and_dynamic_initialization()
       // use default constructor
       exprt::operandst ops;
 
-      codet call=
-        cpp_constructor(symbol.location, symbol_expr, ops);
+      auto call = cpp_constructor(symbol.location, symbol_expr, ops);
 
-      if(call.is_not_nil())
-        init_block.move_to_operands(call);
+      if(call.has_value())
+        init_block.move(call.value());
     }
   }
 

--- a/src/cpp/cpp_typecheck.h
+++ b/src/cpp/cpp_typecheck.h
@@ -99,7 +99,7 @@ public:
 
   bool cpp_is_pod(const typet &type) const;
 
-  codet cpp_constructor(
+  optionalt<codet> cpp_constructor(
     const source_locationt &source_location,
     const exprt &object,
     const exprt::operandst &operands);

--- a/src/cpp/cpp_typecheck.h
+++ b/src/cpp/cpp_typecheck.h
@@ -427,9 +427,8 @@ protected:
 
   const struct_typet &this_struct_type();
 
-  codet cpp_destructor(
-      const source_locationt &source_location,
-      const exprt &object);
+  optionalt<codet>
+  cpp_destructor(const source_locationt &source_location, const exprt &object);
 
   // expressions
   void explicit_typecast_ambiguity(exprt &expr);

--- a/src/cpp/cpp_typecheck_code.cpp
+++ b/src/cpp/cpp_typecheck_code.cpp
@@ -327,16 +327,17 @@ void cpp_typecheckt::typecheck_member_initializer(codet &code)
         // it's a data member
         already_typechecked(symbol_expr);
 
-        exprt call=
+        auto call =
           cpp_constructor(code.source_location(), symbol_expr, code.operands());
 
-        if(call.is_nil())
+        if(call.has_value())
+          code.swap(call.value());
+        else
         {
-          call=codet(ID_skip);
-          call.add_source_location()=code.source_location();
+          auto source_location = code.source_location();
+          code = codet(ID_skip);
+          code.add_source_location() = source_location;
         }
-
-        code.swap(call);
       }
     }
     else
@@ -434,14 +435,11 @@ void cpp_typecheckt::typecheck_decl(codet &code)
 
       already_typechecked(object_expr);
 
-      exprt constructor_call=
-        cpp_constructor(
-          symbol.location,
-          object_expr,
-          declarator.init_args().operands());
+      auto constructor_call = cpp_constructor(
+        symbol.location, object_expr, declarator.init_args().operands());
 
-      if(constructor_call.is_not_nil())
-        new_code.move_to_operands(constructor_call);
+      if(constructor_call.has_value())
+        new_code.move_to_operands(constructor_call.value());
     }
   }
 

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -740,10 +740,10 @@ void cpp_typecheckt::typecheck_compound_declarator(
 
         exprt::operandst ops;
         ops.push_back(value);
-        codet defcode =
-          cpp_constructor(source_locationt(), symexpr, ops);
+        auto defcode = cpp_constructor(source_locationt(), symexpr, ops);
+        CHECK_RETURN(defcode.has_value());
 
-        new_symbol->value.swap(defcode);
+        new_symbol->value.swap(defcode.value());
       }
     }
   }

--- a/src/cpp/cpp_typecheck_declaration.cpp
+++ b/src/cpp/cpp_typecheck_declaration.cpp
@@ -178,11 +178,15 @@ void cpp_typecheckt::convert_non_template_declaration(
     if(symbol.is_lvalue &&
        declarator.init_args().has_operands())
     {
-      symbol.value=
-        cpp_constructor(
-          symbol.location,
-          cpp_symbol_expr(symbol),
-          declarator.init_args().operands());
+      auto constructor = cpp_constructor(
+        symbol.location,
+        cpp_symbol_expr(symbol),
+        declarator.init_args().operands());
+
+      if(constructor.has_value())
+        symbol.value = constructor.value();
+      else
+        symbol.value = nil_exprt();
     }
   }
 }

--- a/src/cpp/cpp_typecheck_destructor.cpp
+++ b/src/cpp/cpp_typecheck_destructor.cpp
@@ -144,11 +144,11 @@ codet cpp_typecheckt::dtor(const symbolt &symbol)
 
     const bool disabled_access_control = disable_access_control;
     disable_access_control = true;
-    codet dtor_code = cpp_destructor(source_location, member);
+    auto dtor_code = cpp_destructor(source_location, member);
     disable_access_control = disabled_access_control;
 
-    if(dtor_code.is_not_nil())
-      block.move_to_operands(dtor_code);
+    if(dtor_code.has_value())
+      block.move_to_operands(dtor_code.value());
   }
 
   const irept::subt &bases=symbol.type.find(ID_bases).get_sub();
@@ -169,11 +169,11 @@ codet cpp_typecheckt::dtor(const symbolt &symbol)
 
     const bool disabled_access_control = disable_access_control;
     disable_access_control = true;
-    exprt dtor_code = cpp_destructor(source_location, object);
+    auto dtor_code = cpp_destructor(source_location, object);
     disable_access_control = disabled_access_control;
 
-    if(dtor_code.is_not_nil())
-      block.move_to_operands(dtor_code);
+    if(dtor_code.has_value())
+      block.move_to_operands(dtor_code.value());
   }
 
   return block;

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -1074,15 +1074,16 @@ void cpp_typecheckt::typecheck_expr_delete(exprt &expr)
 
   already_typechecked(new_object);
 
-  codet destructor_code=cpp_destructor(
-    expr.source_location(),
-    new_object);
+  auto destructor_code = cpp_destructor(expr.source_location(), new_object);
 
-  // this isn't typechecked yet
-  if(destructor_code.is_not_nil())
-    typecheck_code(destructor_code);
-
-  expr.set(ID_destructor, destructor_code);
+  if(destructor_code.has_value())
+  {
+    // this isn't typechecked yet
+    typecheck_code(destructor_code.value());
+    expr.set(ID_destructor, destructor_code.value());
+  }
+  else
+    expr.set(ID_destructor, nil_exprt());
 }
 
 void cpp_typecheckt::typecheck_expr_typecast(exprt &)

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -852,13 +852,13 @@ void cpp_typecheckt::typecheck_expr_new(exprt &expr)
     throw 0;
   }
 
-  exprt code=
-    cpp_constructor(
-      expr.find_source_location(),
-      object_expr,
-      initializer.operands());
+  auto code = cpp_constructor(
+    expr.find_source_location(), object_expr, initializer.operands());
 
-  expr.add(ID_initializer).swap(code);
+  if(code.has_value())
+    expr.add(ID_initializer).swap(code.value());
+  else
+    expr.add(ID_initializer) = nil_exprt();
 
   // we add the size of the object for convenience of the
   // runtime library

--- a/src/cpp/cpp_typecheck_initializer.cpp
+++ b/src/cpp/cpp_typecheck_initializer.cpp
@@ -180,10 +180,13 @@ void cpp_typecheckt::convert_initializer(symbolt &symbol)
     exprt::operandst ops;
     ops.push_back(symbol.value);
 
-    symbol.value = cpp_constructor(
-      symbol.value.source_location(),
-      expr_symbol,
-      ops);
+    auto constructor =
+      cpp_constructor(symbol.value.source_location(), expr_symbol, ops);
+
+    if(constructor.has_value())
+      symbol.value = constructor.value();
+    else
+      symbol.value = nil_exprt();
   }
 }
 


### PR DESCRIPTION
This replaces returning nil_exprt() in case there's no constructor.