### PR TITLE
use code_blockt::statements() where appropriate

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1773,8 +1773,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
               more_code.statements().end());
           }
           else
-            for(const auto &statement : more_code.statements())
-              c.copy_to_operands(statement);
+            to_code_block(c).append(more_code);
         }
       }
       a_it2->second.stack=stack;

--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -125,7 +125,7 @@ protected:
 
   virtual void typecheck_assign(codet &expr);
   virtual void typecheck_asm(codet &code);
-  virtual void typecheck_block(codet &code);
+  virtual void typecheck_block(code_blockt &code);
   virtual void typecheck_break(codet &code);
   virtual void typecheck_continue(codet &code);
   virtual void typecheck_decl(codet &code);

--- a/src/ansi-c/c_typecheck_code.cpp
+++ b/src/ansi-c/c_typecheck_code.cpp
@@ -43,7 +43,7 @@ void c_typecheck_baset::typecheck_code(codet &code)
   else if(statement==ID_gcc_switch_case_range)
     typecheck_gcc_switch_case_range(code);
   else if(statement==ID_block)
-    typecheck_block(code);
+    typecheck_block(to_code_block(code));
   else if(statement==ID_decl_block)
   {
   }
@@ -181,22 +181,20 @@ void c_typecheck_baset::typecheck_assign(codet &code)
   implicit_typecast(code.op1(), code.op0().type());
 }
 
-void c_typecheck_baset::typecheck_block(codet &code)
+void c_typecheck_baset::typecheck_block(code_blockt &code)
 {
-  Forall_operands(it, code)
-    typecheck_code(to_code(*it));
+  for(auto &c : code.statements())
+    typecheck_code(c);
 
   // do decl-blocks
 
   code_blockt new_ops;
-  new_ops.operands().reserve(code.operands().size());
+  new_ops.statements().reserve(code.statements().size());
 
-  Forall_operands(it1, code)
+  for(auto &code_op : code.statements())
   {
-    if(it1->is_nil())
+    if(code_op.is_nil())
       continue;
-
-    codet &code_op=to_code(*it1);
 
     if(code_op.get_statement()==ID_label)
     {
@@ -217,7 +215,7 @@ void c_typecheck_baset::typecheck_block(codet &code)
       new_ops.move(code_op);
   }
 
-  code.operands().swap(new_ops.operands());
+  code.statements().swap(new_ops.statements());
 }
 
 void c_typecheck_baset::typecheck_break(codet &code)

--- a/src/cpp/cpp_typecheck.h
+++ b/src/cpp/cpp_typecheck.h
@@ -424,7 +424,7 @@ protected:
   void typecheck_try_catch(codet &);
   void typecheck_member_initializer(codet &);
   void typecheck_decl(codet &) override;
-  void typecheck_block(codet &) override;
+  void typecheck_block(code_blockt &) override;
   void typecheck_ifthenelse(code_ifthenelset &) override;
   void typecheck_while(code_whilet &) override;
   void typecheck_switch(code_switcht &) override;

--- a/src/cpp/cpp_typecheck_code.cpp
+++ b/src/cpp/cpp_typecheck_code.cpp
@@ -446,7 +446,7 @@ void cpp_typecheckt::typecheck_decl(codet &code)
   code.swap(new_code);
 }
 
-void cpp_typecheckt::typecheck_block(codet &code)
+void cpp_typecheckt::typecheck_block(code_blockt &code)
 {
   cpp_save_scopet saved_scope(cpp_scopes);
   cpp_scopes.new_block_scope();

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -621,7 +621,7 @@ void dump_ct::cleanup_decl(
     system_headers);
   p2s();
 
-  POSTCONDITION(b.operands().size()==1);
+  POSTCONDITION(b.statements().size() == 1);
   decl.swap(b.op0());
 }
 
@@ -943,10 +943,8 @@ void dump_ct::cleanup_harness(code_blockt &b)
     decls.add(d);
   }
 
-  Forall_operands(it, b)
+  for(auto &code : b.statements())
   {
-    codet &code=to_code(*it);
-
     if(code.get_statement()==ID_function_call)
     {
       exprt &func=to_code_function_call(code).function();

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -1681,12 +1681,9 @@ static bool has_labels(const codet &code)
   return false;
 }
 
-static bool move_label_ifthenelse(
-    exprt &expr,
-    exprt &label_dest)
+static bool move_label_ifthenelse(exprt &expr, exprt &label_dest)
 {
-  if(expr.is_nil() ||
-      to_code(expr).get_statement()!=ID_block)
+  if(expr.is_nil() || to_code(expr).get_statement() != ID_block)
     return false;
 
   code_blockt &block=to_code_block(to_code(expr));


### PR DESCRIPTION
add/move are type-safe; copy_to_operands and move_to_operands are not.
