### PR TITLE
Remove jdiff from janalyzer/module_dependencies.txt

### DIFF
--- a/jbmc/src/janalyzer/module_dependencies.txt
+++ b/jbmc/src/janalyzer/module_dependencies.txt
@@ -1,7 +1,6 @@
 analyses
 ansi-c # should go away
 java_bytecode
-jdiff
 goto-analyzer
 goto-programs
 langapi # should go away


### PR DESCRIPTION
jdiff is not (and should not be) a dependency of janalyzer.