### PR TITLE
Travis: Mark all Linux builds as sudo-required as maven workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ jobs:
     # Ubuntu Linux with glibc using g++-5
     - stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 test
       os: linux
-      sudo: false
+      sudo: true
       compiler: gcc
       cache: ccache
       addons:
@@ -121,7 +121,7 @@ jobs:
     # Ubuntu Linux with glibc using g++-5, debug mode
     - stage: Test different OS/CXX/Flags
       os: linux
-      sudo: false
+      sudo: true
       compiler: gcc
       cache: ccache
       addons:
@@ -207,6 +207,7 @@ jobs:
     # cmake build using g++-5
     - stage: Test different OS/CXX/Flags
       os: linux
+      sudo: true
       compiler: gcc
       cache: ccache
       env:
@@ -232,6 +233,7 @@ jobs:
     # cmake build using g++-7
     - stage: Test different OS/CXX/Flags
       os: linux
+      sudo: true
       compiler: gcc
       cache: ccache
       env:
@@ -257,6 +259,7 @@ jobs:
     # cmake build using clang++-6
     - stage: Test different OS/CXX/Flags
       os: linux
+      sudo: true
       compiler: clang
       cache: ccache
       env:
@@ -311,7 +314,7 @@ jobs:
     - stage: Test different OS/CXX/Flags
       if: type = cron
       os: linux
-      sudo: false
+      sudo: true
       compiler: gcc
       cache: ccache
       addons:


### PR DESCRIPTION
Running maven yields access-denied errors:

[ERROR] Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 or one of its
dependencies could not be resolved: Failed to read artifact descriptor for
org.apache.maven.plugins:maven-resources-plugin:jar:2.6: Could not transfer
artifact org.apache.maven.plugins:maven-resources-plugin:pom:2.6 from/to central
(https://repo.maven.apache.org/maven2): Access denied to:
https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.pom
, ReasonPhrase:Forbidden. -> [Help 1]

This appears to be a recurring issue, described at
https://github.com/travis-ci/travis-ci/issues/6593 - now applying the workaround
described in the same issue.