### PR TITLE
Support `force_non_null` flag in objct factory

### DIFF
--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -856,13 +856,19 @@ void java_object_factoryt::gen_nondet_pointer_init(
   const bool allow_null =
     depth > object_factory_parameters.max_nonnull_tree_depth;
 
+  const bool force_non_null =
+    object_factory_parameters.force_non_null && depth == 1;
+  INVARIANT(
+    !(force_non_null && must_be_null),
+    "we cannot prevent and require null object creation at the same time");
+
   if(must_be_null)
   {
     // Add the following code to assignments:
     // <expr> = nullptr;
     new_object_assignments.add(set_null_inst);
   }
-  else if(!allow_null)
+  else if(!allow_null || force_non_null)
   {
     // Add the following code to assignments:
     // <expr> = <aoe>;

--- a/jbmc/src/java_bytecode/object_factory_parameters.h
+++ b/jbmc/src/java_bytecode/object_factory_parameters.h
@@ -53,6 +53,9 @@ struct object_factory_parameterst final
 
   /// Function id, used as a prefix for identifiers of temporaries
   irep_idt function_id;
+
+  /// Force non-null at depth 0.
+  bool force_non_null = false;
 };
 
 #endif


### PR DESCRIPTION
In the case of `force_non_null`, the object factory will not allow a null object
at the initial depth.