### PR TITLE
Cleanup asserts - replace with invariants

### DIFF
--- a/src/cpp/cpp_typecheck_fargs.h
+++ b/src/cpp/cpp_typecheck_fargs.h
@@ -12,6 +12,8 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #ifndef CPROVER_CPP_CPP_TYPECHECK_FARGS_H
 #define CPROVER_CPP_CPP_TYPECHECK_FARGS_H
 
+#include <cassert>
+
 #include <util/std_code.h>
 
 class cpp_typecheckt;

--- a/src/util/irep.cpp
+++ b/src/util/irep.cpp
@@ -13,7 +13,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <ostream>
 
-#include "invariant.h"
 #include "string2int.h"
 #include "string_hash.h"
 #include "irep_hash.h"

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -10,11 +10,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_IREP_H
 #define CPROVER_UTIL_IREP_H
 
-#include <cassert>
 #include <string>
 #include <vector>
 
 #include "deprecate.h"
+#include "invariant.h"
 #include "irep_ids.h"
 
 #define SHARING
@@ -192,7 +192,7 @@ public:
     if(data!=&empty_d)
     {
       // NOLINTNEXTLINE(build/deprecated)
-      assert(data->ref_count!=0);
+      PRECONDITION(data->ref_count != 0);
       data->ref_count++;
       #ifdef IREP_DEBUG
       std::cout << "COPY " << data << " " << data->ref_count << '\n';


### PR DESCRIPTION
Remove all `assert()` statements, replacing with appropriate `INVARIANT`, `PRECONDITION`, etc.

The target files for PR have no throw statements - no cleanup required w.r. to throw statements.
