### PR TITLE
Cleanup asserts & throws - replace with invariants - dir util/s* (part1)

### DIFF
--- a/src/util/simplify_expr_boolean.cpp
+++ b/src/util/simplify_expr_boolean.cpp
@@ -8,10 +8,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "simplify_expr_class.h"
 
-#include <cassert>
 #include <unordered_set>
 
 #include "expr.h"
+#include "invariant.h"
 #include "namespace.h"
 #include "std_expr.h"
 
@@ -213,13 +213,11 @@ bool simplify_exprt::simplify_not(exprt &expr)
   }
   else if(op.id()==ID_exists) // !(exists: a) <-> forall: not a
   {
-    assert(op.operands().size()==2);
-    exprt tmp;
-    tmp.swap(op);
-    expr.swap(tmp);
-    expr.id(ID_forall);
-    expr.op1().make_not();
-    simplify_node(expr.op1());
+    auto const &op_as_exists = to_exists_expr(op);
+    forall_exprt rewritten_op(
+      op_as_exists.symbol(), not_exprt(op_as_exists.where()));
+    simplify_node(rewritten_op.where());
+    expr = rewritten_op;
     return false;
   }
 

--- a/src/util/simplify_expr_floatbv.cpp
+++ b/src/util/simplify_expr_floatbv.cpp
@@ -8,13 +8,12 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "simplify_expr_class.h"
 
-#include <cassert>
-
-#include "expr.h"
-#include "namespace.h"
-#include "ieee_float.h"
-#include "std_expr.h"
 #include "arith_tools.h"
+#include "expr.h"
+#include "ieee_float.h"
+#include "invariant.h"
+#include "namespace.h"
+#include "std_expr.h"
 
 bool simplify_exprt::simplify_isinf(exprt &expr)
 {
@@ -286,17 +285,25 @@ bool simplify_exprt::simplify_floatbv_op(exprt &expr)
 {
   const typet &type=ns.follow(expr.type());
 
-  if(type.id()!=ID_floatbv)
-    return true;
-
-  assert(expr.operands().size()==3);
+  PRECONDITION(type.id() == ID_floatbv);
+  PRECONDITION(
+    expr.id() == ID_floatbv_plus || expr.id() == ID_floatbv_minus ||
+    expr.id() == ID_floatbv_mult || expr.id() == ID_floatbv_div);
+  DATA_INVARIANT(
+    expr.operands().size() == 3,
+    "binary operations have two operands, here an addtional parameter "
+    "is for the rounding mode");
 
   exprt op0=expr.op0();
   exprt op1=expr.op1();
   exprt op2=expr.op2(); // rounding mode
 
-  assert(ns.follow(op0.type())==type);
-  assert(ns.follow(op1.type())==type);
+  INVARIANT(
+    ns.follow(op0.type()) == type,
+    "expression type of operand must match type of expression");
+  INVARIANT(
+    ns.follow(op1.type()) == type,
+    "expression type of operand must match type of expression");
 
   // Remember that floating-point addition is _NOT_ associative.
   // Thus, we don't re-sort the operands.
@@ -347,8 +354,8 @@ bool simplify_exprt::simplify_floatbv_op(exprt &expr)
 
 bool simplify_exprt::simplify_ieee_float_relation(exprt &expr)
 {
-  assert(expr.id()==ID_ieee_float_equal ||
-         expr.id()==ID_ieee_float_notequal);
+  PRECONDITION(
+    expr.id() == ID_ieee_float_equal || expr.id() == ID_ieee_float_notequal);
 
   exprt::operandst &operands=expr.operands();
 

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -4512,6 +4512,24 @@ public:
   }
 };
 
+inline const exists_exprt &to_exists_expr(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_exists);
+  DATA_INVARIANT(
+    expr.operands().size() == 2,
+    "exists expressions have exactly two operands");
+  return static_cast<const exists_exprt &>(expr);
+}
+
+inline exists_exprt &to_exists_expr(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_exists);
+  DATA_INVARIANT(
+    expr.operands().size() == 2,
+    "exists expressions have exactly two operands");
+  return static_cast<exists_exprt &>(expr);
+}
+
 /// \brief The popcount (counting the number of bits set to 1) expression
 class popcount_exprt: public unary_exprt
 {


### PR DESCRIPTION
Cleanup of asserts - replaced with invariants.

Removed all unstructured `throw(...)` statements, replacing with `INVARIANT`, `PRECONDITION`, etc. where appropriate.
