### PR TITLE
Travis: revert sudo-workarounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,14 +49,18 @@ jobs:
       env:
         NAME: "DOXYGEN-CHECK"
         DOXYGEN_VERSION: "1.8.14"
+      addons:
+        apt:
+          sources:
+            - sourceline: 'deb http://packages.cloud.google.com/apt cloud-sdk-trusty main'
+              key_url: 'https://packages.cloud.google.com/apt/doc/apt-key.gpg'
+          packages:
+            - cmake
+            - google-cloud-sdk
+            - graphviz
       cache:
         directories:
           - ${TRAVIS_BUILD_DIR}/doxygen/build/bin
-      before_install:
-        - curl -sSL "https://packages.cloud.google.com/apt/doc/apt-key.gpg" | sudo -E apt-key add -
-        - echo "deb http://packages.cloud.google.com/apt cloud-sdk-trusty main" | sudo tee -a /etc/apt/sources.list > /dev/null
-        - sudo apt-get update --option Acquire::Retries=100 --option Acquire::http::Timeout="60"
-        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install cmake google-cloud-sdk graphviz
       install:
         - |
           # Build doxygen if it is not in Travis cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ jobs:
     # Ubuntu Linux with glibc using g++-5
     - stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 test
       os: linux
-      sudo: true
+      sudo: false
       compiler: gcc
       cache: ccache
       addons:
@@ -121,7 +121,7 @@ jobs:
     # Ubuntu Linux with glibc using g++-5, debug mode
     - stage: Test different OS/CXX/Flags
       os: linux
-      sudo: true
+      sudo: false
       compiler: gcc
       cache: ccache
       addons:
@@ -207,7 +207,6 @@ jobs:
     # cmake build using g++-5
     - stage: Test different OS/CXX/Flags
       os: linux
-      sudo: true
       compiler: gcc
       cache: ccache
       env:
@@ -233,7 +232,6 @@ jobs:
     # cmake build using g++-7
     - stage: Test different OS/CXX/Flags
       os: linux
-      sudo: true
       compiler: gcc
       cache: ccache
       env:
@@ -259,7 +257,6 @@ jobs:
     # cmake build using clang++-6
     - stage: Test different OS/CXX/Flags
       os: linux
-      sudo: true
       compiler: clang
       cache: ccache
       env:
@@ -314,7 +311,7 @@ jobs:
     - stage: Test different OS/CXX/Flags
       if: type = cron
       os: linux
-      sudo: true
+      sudo: false
       compiler: gcc
       cache: ccache
       addons:


### PR DESCRIPTION
This just reverts recent changes as Travis appear to have gotten their infrastructure back under control. Container builds start up quicker, and the Travis configuration file becomes simpler again.