### PR TITLE
Cleanup of asserts and throws under the goto-symex directory

### DIFF
--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -15,9 +15,10 @@ Author: Daniel Kroening
 
 #include <cassert>
 
-#include <util/threeval.h>
-#include <util/simplify_expr.h>
 #include <util/arith_tools.h>
+#include <util/byte_operators.h>
+#include <util/simplify_expr.h>
+#include <util/threeval.h>
 
 #include <solvers/prop/prop_conv.h>
 #include <solvers/prop/prop.h>
@@ -92,10 +93,11 @@ exprt build_full_lhs_rec(
           id==ID_byte_extract_big_endian)
   {
     exprt tmp=src_original;
-    DATA_INVARIANT(
-      tmp.operands().size() == 2,
-      "byte_extract_exprt should have two operands.");
-    tmp.op0()=build_full_lhs_rec(prop_conv, ns, tmp.op0(), src_ssa.op0());
+    tmp.op0() = build_full_lhs_rec(
+      prop_conv,
+      ns,
+      to_byte_extract_expr(tmp).op(),
+      to_byte_extract_expr(src_ssa).op());
 
     // re-write into big case-split
   }
@@ -231,7 +233,7 @@ void build_goto_trace(
       else if(it->is_atomic_end() && current_time<0)
         current_time*=-1;
 
-      assert(current_time>=0);
+      INVARIANT(current_time >= 0, "time keeping inconsistency");
       // move any steps gathered in an atomic section
 
       if(time_before<0)

--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -92,7 +92,9 @@ exprt build_full_lhs_rec(
           id==ID_byte_extract_big_endian)
   {
     exprt tmp=src_original;
-    assert(tmp.operands().size()==2);
+    DATA_INVARIANT(
+      tmp.operands().size() == 2,
+      "byte_extract_exprt should have two operands.");
     tmp.op0()=build_full_lhs_rec(prop_conv, ns, tmp.op0(), src_ssa.op0());
 
     // re-write into big case-split

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -187,8 +187,8 @@ bool goto_symex_statet::constant_propagation_reference(const exprt &expr) const
   }
   else if(expr.id()==ID_member)
   {
-    if(expr.operands().size()!=1)
-      throw "member expects one operand";
+    DATA_INVARIANT(
+      expr.operands().size() == 1, "member_exprt takes one operand.");
 
     return constant_propagation_reference(expr.op0());
   }

--- a/src/goto-symex/memory_model_pso.cpp
+++ b/src/goto-symex/memory_model_pso.cpp
@@ -30,8 +30,8 @@ bool memory_model_psot::program_order_is_relaxed(
   partial_order_concurrencyt::event_it e1,
   partial_order_concurrencyt::event_it e2) const
 {
-  assert(e1->is_shared_read() || e1->is_shared_write());
-  assert(e2->is_shared_read() || e2->is_shared_write());
+  PRECONDITION(e1->is_shared_read() || e1->is_shared_write());
+  PRECONDITION(e2->is_shared_read() || e2->is_shared_write());
 
   // no po relaxation within atomic sections
   if(e1->atomic_section_id!=0 &&

--- a/src/goto-symex/memory_model_sc.cpp
+++ b/src/goto-symex/memory_model_sc.cpp
@@ -36,8 +36,8 @@ bool memory_model_sct::program_order_is_relaxed(
   partial_order_concurrencyt::event_it e1,
   partial_order_concurrencyt::event_it e2) const
 {
-  assert(e1->is_shared_read() || e1->is_shared_write());
-  assert(e2->is_shared_read() || e2->is_shared_write());
+  PRECONDITION(e1->is_shared_read() || e1->is_shared_write());
+  PRECONDITION(e2->is_shared_read() || e2->is_shared_write());
 
   return false;
 }

--- a/src/goto-symex/memory_model_tso.cpp
+++ b/src/goto-symex/memory_model_tso.cpp
@@ -39,8 +39,8 @@ bool memory_model_tsot::program_order_is_relaxed(
   partial_order_concurrencyt::event_it e1,
   partial_order_concurrencyt::event_it e2) const
 {
-  assert(e1->is_shared_read() || e1->is_shared_write());
-  assert(e2->is_shared_read() || e2->is_shared_write());
+  PRECONDITION(e1->is_shared_read() || e1->is_shared_write());
+  PRECONDITION(e2->is_shared_read() || e2->is_shared_write());
 
   // no po relaxation within atomic sections
   if(e1->atomic_section_id!=0 &&

--- a/src/goto-symex/partial_order_concurrency.cpp
+++ b/src/goto-symex/partial_order_concurrency.cpp
@@ -143,7 +143,7 @@ symbol_exprt partial_order_concurrencyt::clock(
   axiomt axiom)
 {
   irep_idt identifier;
-  assert(!numbering.empty());
+  PRECONDITION(!numbering.empty());
 
   if(event->is_shared_write())
     identifier=rw_clock_id(event, axiom);
@@ -163,7 +163,7 @@ symbol_exprt partial_order_concurrencyt::clock(
 
 void partial_order_concurrencyt::build_clock_type()
 {
-  assert(!numbering.empty());
+  PRECONDITION(!numbering.empty());
 
   std::size_t width = address_bits(numbering.size());
   clock_type = unsignedbv_typet(width);

--- a/src/goto-symex/partial_order_concurrency.cpp
+++ b/src/goto-symex/partial_order_concurrency.cpp
@@ -142,8 +142,8 @@ symbol_exprt partial_order_concurrencyt::clock(
   event_it event,
   axiomt axiom)
 {
-  irep_idt identifier;
   PRECONDITION(!numbering.empty());
+  irep_idt identifier;
 
   if(event->is_shared_write())
     identifier=rw_clock_id(event, axiom);
@@ -198,7 +198,7 @@ exprt partial_order_concurrencyt::before(
         binary_relation_exprt(clock(e1, ax), ID_lt, clock(e2, ax)));
   }
 
-  assert(!ops.empty());
+  POSTCONDITION(!ops.empty());
 
   return conjunction(ops);
 }

--- a/src/goto-symex/postcondition.cpp
+++ b/src/goto-symex/postcondition.cpp
@@ -76,7 +76,8 @@ bool postconditiont::is_used_address_of(
   }
   else if(expr.id()==ID_index)
   {
-    assert(expr.operands().size()==2);
+    DATA_INVARIANT(
+      expr.operands().size() == 2, "index_exprt takes two operands.");
 
     return
       is_used_address_of(expr.op0(), identifier) ||
@@ -84,12 +85,14 @@ bool postconditiont::is_used_address_of(
   }
   else if(expr.id()==ID_member)
   {
-    assert(expr.operands().size()==1);
+    DATA_INVARIANT(
+      expr.operands().size() == 1, "member_exprt takes one operand.");
     return is_used_address_of(expr.op0(), identifier);
   }
   else if(expr.id()==ID_dereference)
   {
-    assert(expr.operands().size()==1);
+    DATA_INVARIANT(
+      expr.operands().size() == 1, "dereference_exprt takes one operand.");
     return is_used(expr.op0(), identifier);
   }
 
@@ -155,7 +158,8 @@ bool postconditiont::is_used(
   if(expr.id()==ID_address_of)
   {
     // only do index!
-    assert(expr.operands().size()==1);
+    DATA_INVARIANT(
+      expr.operands().size() == 1, "address_of_exprt takes one operand.");
     return is_used_address_of(expr.op0(), identifier);
   }
   else if(expr.id()==ID_symbol &&
@@ -169,7 +173,8 @@ bool postconditiont::is_used(
   }
   else if(expr.id()==ID_dereference)
   {
-    assert(expr.operands().size()==1);
+    DATA_INVARIANT(
+      expr.operands().size() == 1, "dereference_exprt takes one operand.");
 
     // aliasing may happen here
 

--- a/src/goto-symex/postcondition.cpp
+++ b/src/goto-symex/postcondition.cpp
@@ -76,24 +76,16 @@ bool postconditiont::is_used_address_of(
   }
   else if(expr.id()==ID_index)
   {
-    DATA_INVARIANT(
-      expr.operands().size() == 2, "index_exprt takes two operands.");
-
-    return
-      is_used_address_of(expr.op0(), identifier) ||
-      is_used(expr.op1(), identifier);
+    return is_used_address_of(to_index_expr(expr).array(), identifier) ||
+           is_used(to_index_expr(expr).index(), identifier);
   }
   else if(expr.id()==ID_member)
   {
-    DATA_INVARIANT(
-      expr.operands().size() == 1, "member_exprt takes one operand.");
-    return is_used_address_of(expr.op0(), identifier);
+    return is_used_address_of(to_member_expr(expr).compound(), identifier);
   }
   else if(expr.id()==ID_dereference)
   {
-    DATA_INVARIANT(
-      expr.operands().size() == 1, "dereference_exprt takes one operand.");
-    return is_used(expr.op0(), identifier);
+    return is_used(to_dereference_expr(expr).pointer(), identifier);
   }
 
   return false;
@@ -157,10 +149,7 @@ bool postconditiont::is_used(
 {
   if(expr.id()==ID_address_of)
   {
-    // only do index!
-    DATA_INVARIANT(
-      expr.operands().size() == 1, "address_of_exprt takes one operand.");
-    return is_used_address_of(expr.op0(), identifier);
+    return is_used_address_of(to_address_of_expr(expr).object(), identifier);
   }
   else if(expr.id()==ID_symbol &&
           expr.get_bool(ID_C_SSA_symbol))
@@ -173,13 +162,9 @@ bool postconditiont::is_used(
   }
   else if(expr.id()==ID_dereference)
   {
-    DATA_INVARIANT(
-      expr.operands().size() == 1, "dereference_exprt takes one operand.");
-
     // aliasing may happen here
-
     value_setst::valuest expr_set;
-    value_set.get_value_set(expr.op0(), expr_set, ns);
+    value_set.get_value_set(to_dereference_expr(expr).pointer(), expr_set, ns);
     std::unordered_set<irep_idt> symbols;
 
     for(value_setst::valuest::const_iterator

--- a/src/goto-symex/precondition.cpp
+++ b/src/goto-symex/precondition.cpp
@@ -78,22 +78,17 @@ void preconditiont::compute_address_of(exprt &dest)
   }
   else if(dest.id()==ID_index)
   {
-    DATA_INVARIANT(
-      dest.operands().size() == 2, "index_exprt takes two operands.");
-    compute_address_of(dest.op0());
-    compute(dest.op1());
+    auto &index_expr = to_index_expr(dest);
+    compute_address_of(index_expr.array());
+    compute(index_expr.index());
   }
   else if(dest.id()==ID_member)
   {
-    DATA_INVARIANT(
-      dest.operands().size() == 1, "member_exprt takes one operand.");
-    compute_address_of(dest.op0());
+    compute_address_of(to_member_expr(dest).compound());
   }
   else if(dest.id()==ID_dereference)
   {
-    DATA_INVARIANT(
-      dest.operands().size() == 1, "dereference_exprt takes one operand.");
-    compute(dest.op0());
+    compute(to_dereference_expr(dest).pointer());
   }
 }
 
@@ -107,21 +102,18 @@ void preconditiont::compute_rec(exprt &dest)
   if(dest.id()==ID_address_of)
   {
     // only do index!
-    DATA_INVARIANT(
-      dest.operands().size() == 1, "address_of_exprt takes one operand.");
-    compute_address_of(dest.op0());
+    compute_address_of(to_address_of_expr(dest).object());
   }
   else if(dest.id()==ID_dereference)
   {
-    DATA_INVARIANT(
-      dest.operands().size() == 1, "dereference_exprt takes one operand.");
+    auto &deref_expr = to_dereference_expr(dest);
 
     const irep_idt &lhs_identifier=SSA_step.ssa_lhs.get_object_name();
 
     // aliasing may happen here
 
     value_setst::valuest expr_set;
-    value_sets.get_values(target, dest.op0(), expr_set);
+    value_sets.get_values(target, deref_expr.pointer(), expr_set);
     std::unordered_set<irep_idt> symbols;
 
     for(value_setst::valuest::const_iterator
@@ -134,15 +126,15 @@ void preconditiont::compute_rec(exprt &dest)
     {
       // may alias!
       exprt tmp;
-      tmp.swap(dest.op0());
+      tmp.swap(deref_expr.pointer());
       dereference(target, tmp, ns, value_sets);
-      dest.swap(tmp);
-      compute_rec(dest);
+      deref_expr.swap(tmp);
+      compute_rec(deref_expr);
     }
     else
     {
       // nah, ok
-      compute_rec(dest.op0());
+      compute_rec(deref_expr.pointer());
     }
   }
   else if(dest==SSA_step.ssa_lhs.get_original_expr())

--- a/src/goto-symex/precondition.cpp
+++ b/src/goto-symex/precondition.cpp
@@ -78,18 +78,21 @@ void preconditiont::compute_address_of(exprt &dest)
   }
   else if(dest.id()==ID_index)
   {
-    assert(dest.operands().size()==2);
+    DATA_INVARIANT(
+      dest.operands().size() == 2, "index_exprt takes two operands.");
     compute_address_of(dest.op0());
     compute(dest.op1());
   }
   else if(dest.id()==ID_member)
   {
-    assert(dest.operands().size()==1);
+    DATA_INVARIANT(
+      dest.operands().size() == 1, "member_exprt takes one operand.");
     compute_address_of(dest.op0());
   }
   else if(dest.id()==ID_dereference)
   {
-    assert(dest.operands().size()==1);
+    DATA_INVARIANT(
+      dest.operands().size() == 1, "dereference_exprt takes one operand.");
     compute(dest.op0());
   }
 }
@@ -104,12 +107,14 @@ void preconditiont::compute_rec(exprt &dest)
   if(dest.id()==ID_address_of)
   {
     // only do index!
-    assert(dest.operands().size()==1);
+    DATA_INVARIANT(
+      dest.operands().size() == 1, "address_of_exprt takes one operand.");
     compute_address_of(dest.op0());
   }
   else if(dest.id()==ID_dereference)
   {
-    assert(dest.operands().size()==1);
+    DATA_INVARIANT(
+      dest.operands().size() == 1, "dereference_exprt takes one operand.");
 
     const irep_idt &lhs_identifier=SSA_step.ssa_lhs.get_object_name();
 

--- a/src/goto-symex/show_vcc.cpp
+++ b/src/goto-symex/show_vcc.cpp
@@ -19,6 +19,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <langapi/language_util.h>
 #include <langapi/mode.h>
 
+#include <util/exception_utils.h>
 #include <util/json.h>
 #include <util/json_expr.h>
 #include <util/ui_message.h>
@@ -165,7 +166,8 @@ void show_vcc(
   {
     of.open(filename);
     if(!of)
-      throw "failed to open file " + filename;
+      throw invalid_user_input_exceptiont(
+        "invalid file to read trace from: " + filename, "--outfile");
   }
 
   std::ostream &out = have_file ? of : std::cout;

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -127,8 +127,7 @@ void symex_slicet::slice_assignment(
 void symex_slicet::slice_decl(
   symex_target_equationt::SSA_stept &SSA_step)
 {
-  PRECONDITION(SSA_step.ssa_lhs.id() == ID_symbol);
-  const irep_idt &id=SSA_step.ssa_lhs.get_identifier();
+  const irep_idt &id = to_symbol_expr(SSA_step.ssa_lhs).get_identifier();
 
   if(depends.find(id)==depends.end())
   {

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -112,7 +112,7 @@ void symex_slicet::slice(symex_target_equationt::SSA_stept &SSA_step)
 void symex_slicet::slice_assignment(
   symex_target_equationt::SSA_stept &SSA_step)
 {
-  assert(SSA_step.ssa_lhs.id()==ID_symbol);
+  PRECONDITION(SSA_step.ssa_lhs.id() == ID_symbol);
   const irep_idt &id=SSA_step.ssa_lhs.get_identifier();
 
   if(depends.find(id)==depends.end())
@@ -127,7 +127,7 @@ void symex_slicet::slice_assignment(
 void symex_slicet::slice_decl(
   symex_target_equationt::SSA_stept &SSA_step)
 {
-  assert(SSA_step.ssa_lhs.id()==ID_symbol);
+  PRECONDITION(SSA_step.ssa_lhs.id() == ID_symbol);
   const irep_idt &id=SSA_step.ssa_lhs.get_identifier();
 
   if(depends.find(id)==depends.end())

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -91,7 +91,7 @@ exprt goto_symext::add_to_lhs(
   const exprt &lhs,
   const exprt &what)
 {
-  assert(lhs.id()!=ID_symbol);
+  PRECONDITION(lhs.id() != ID_symbol);
   exprt tmp_what=what;
 
   if(tmp_what.id()!=ID_symbol)
@@ -170,8 +170,8 @@ void goto_symext::symex_assign_rec(
   }
   else if(lhs.id() == ID_complex_real)
   {
+    // this is stuff like __real__ x = 1;
     const complex_real_exprt &complex_real_expr = to_complex_real_expr(lhs);
-
     const complex_imag_exprt complex_imag_expr(complex_real_expr.op());
 
     complex_exprt new_rhs(
@@ -284,7 +284,7 @@ void goto_symext::symex_assign_typecast(
 {
   // these may come from dereferencing on the lhs
 
-  assert(lhs.operands().size()==1);
+  PRECONDITION(lhs.operands().size() == 1);
 
   exprt rhs_typecasted=rhs;
   rhs_typecasted.make_typecast(lhs.op0().type());
@@ -306,9 +306,7 @@ void goto_symext::symex_assign_array(
   // lhs must be index operand
   // that takes two operands: the first must be an array
   // the second is the index
-
-  if(lhs.operands().size()!=2)
-    throw "index must have two operands";
+  DATA_INVARIANT(lhs.operands().size() == 2, "index_exprt takes two operands");
 
   const exprt &lhs_array=lhs.array();
   const exprt &lhs_index=lhs.index();
@@ -369,7 +367,8 @@ void goto_symext::symex_assign_struct_member(
   // typecasts involved? C++ does that for inheritance.
   if(lhs_struct.id()==ID_typecast)
   {
-    assert(lhs_struct.operands().size()==1);
+    DATA_INVARIANT(
+      lhs_struct.operands().size() == 1, "typecast_exprt takes one operand.");
 
     if(lhs_struct.op0().id() == ID_null_object)
     {

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/byte_operators.h>
 #include <util/c_types.h>
 #include <util/cprover_prefix.h>
+#include <util/exception_utils.h>
 #include <util/pointer_offset_size.h>
 
 #include "goto_symex_state.h"
@@ -37,15 +38,19 @@ void goto_symext::symex_assign(
 
     if(statement==ID_function_call)
     {
-      assert(!side_effect_expr.operands().empty());
+      DATA_INVARIANT(
+        !side_effect_expr.operands().empty(),
+        "function call stamement expects non-empty list of side effects");
 
-      if(side_effect_expr.op0().id()!=ID_symbol)
-        throw "symex_assign: expected symbol as function";
+      DATA_INVARIANT(
+        side_effect_expr.op0().id() == ID_symbol,
+        "expected symbol as function");
 
       const irep_idt &identifier=
         to_symbol_expr(side_effect_expr.op0()).get_identifier();
 
-      throw "symex_assign: unexpected function call: "+id2string(identifier);
+      throw unsupported_operation_exceptiont(
+        "symex_assign: unexpected function call: " + id2string(identifier));
     }
     else if(
       statement == ID_cpp_new || statement == ID_cpp_new_array ||
@@ -55,14 +60,13 @@ void goto_symext::symex_assign(
       symex_allocate(state, lhs, side_effect_expr);
     else if(statement==ID_printf)
     {
-      if(lhs.is_not_nil())
-        throw "printf: unexpected assignment";
+      PRECONDITION(lhs.is_nil());
       symex_printf(state, side_effect_expr);
     }
     else if(statement==ID_gcc_builtin_va_arg_next)
       symex_gcc_builtin_va_arg_next(state, lhs, side_effect_expr);
     else
-      throw "symex_assign: unexpected side effect: "+id2string(statement);
+      UNREACHABLE;
   }
   else
   {
@@ -96,7 +100,7 @@ exprt goto_symext::add_to_lhs(
 
   if(tmp_what.id()!=ID_symbol)
   {
-    assert(tmp_what.operands().size()>=1);
+    PRECONDITION(tmp_what.operands().size() >= 1);
     tmp_what.op0().make_nil();
   }
 
@@ -106,12 +110,16 @@ exprt goto_symext::add_to_lhs(
 
   while(p->is_not_nil())
   {
-    assert(p->id()!=ID_symbol);
-    assert(p->operands().size()>=1);
+    INVARIANT(
+      p->id() != ID_symbol,
+      "expected pointed-to expression not to be a symbol");
+    INVARIANT(
+      p->operands().size() >= 1,
+      "expected pointed-to expression to have at least one operand");
     p=&p->op0();
   }
 
-  assert(p->is_nil());
+  INVARIANT(p->is_nil(), "expected pointed-to expression to be nil");
 
   *p=tmp_what;
   return new_lhs;
@@ -141,12 +149,13 @@ void goto_symext::symex_assign_rec(
     else if(type.id()==ID_union)
     {
       // should have been replaced by byte_extract
-      throw "symex_assign_rec: unexpected assignment to union member";
+      throw unsupported_operation_exceptiont(
+        "symex_assign_rec: unexpected assignment to union member");
     }
     else
-      throw
-        "symex_assign_rec: unexpected assignment to member of `"+
-        type.id_string()+"'";
+      throw unsupported_operation_exceptiont(
+        "symex_assign_rec: unexpected assignment to member of `" +
+        type.id_string() + "'");
   }
   else if(lhs.id()==ID_if)
     symex_assign_if(
@@ -172,6 +181,7 @@ void goto_symext::symex_assign_rec(
   {
     // this is stuff like __real__ x = 1;
     const complex_real_exprt &complex_real_expr = to_complex_real_expr(lhs);
+
     const complex_imag_exprt complex_imag_expr(complex_real_expr.op());
 
     complex_exprt new_rhs(
@@ -193,7 +203,8 @@ void goto_symext::symex_assign_rec(
       state, complex_imag_expr.op(), full_lhs, new_rhs, guard, assignment_type);
   }
   else
-    throw "assignment to `"+lhs.id_string()+"' not handled";
+    throw unsupported_operation_exceptiont(
+      "assignment to `" + lhs.id_string() + "' not handled");
 }
 
 void goto_symext::symex_assign_symbol(
@@ -283,9 +294,6 @@ void goto_symext::symex_assign_typecast(
   assignment_typet assignment_type)
 {
   // these may come from dereferencing on the lhs
-
-  PRECONDITION(lhs.operands().size() == 1);
-
   exprt rhs_typecasted=rhs;
   rhs_typecasted.make_typecast(lhs.op0().type());
 
@@ -303,27 +311,20 @@ void goto_symext::symex_assign_array(
   guardt &guard,
   assignment_typet assignment_type)
 {
-  // lhs must be index operand
-  // that takes two operands: the first must be an array
-  // the second is the index
-  DATA_INVARIANT(lhs.operands().size() == 2, "index_exprt takes two operands");
-
   const exprt &lhs_array=lhs.array();
   const exprt &lhs_index=lhs.index();
-  const typet &lhs_type=ns.follow(lhs_array.type());
+  const typet &lhs_index_type = ns.follow(lhs_array.type());
 
-  if(lhs_type.id()!=ID_array)
-    throw "index must take array type operand, but got `"+
-          lhs_type.id_string()+"'";
+  PRECONDITION(lhs_index_type.id() == ID_array);
 
-  #ifdef USE_UPDATE
+#ifdef USE_UPDATE
 
   // turn
   //   a[i]=e
   // into
   //   a'==UPDATE(a, [i], e)
 
-  update_exprt new_rhs(lhs_type);
+  update_exprt new_rhs(lhs_index_type);
   new_rhs.old()=lhs_array;
   new_rhs.designator().push_back(index_designatort(lhs_index));
   new_rhs.new_value()=rhs;
@@ -340,7 +341,7 @@ void goto_symext::symex_assign_array(
   //   a'==a WITH [i:=e]
 
   with_exprt new_rhs(lhs_array, lhs_index, rhs);
-  new_rhs.type() = lhs_type;
+  new_rhs.type() = lhs_index_type;
 
   exprt new_full_lhs=add_to_lhs(full_lhs, lhs);
 
@@ -367,10 +368,7 @@ void goto_symext::symex_assign_struct_member(
   // typecasts involved? C++ does that for inheritance.
   if(lhs_struct.id()==ID_typecast)
   {
-    DATA_INVARIANT(
-      lhs_struct.operands().size() == 1, "typecast_exprt takes one operand.");
-
-    if(lhs_struct.op0().id() == ID_null_object)
+    if(to_typecast_expr(lhs_struct).op0().id() == ID_null_object)
     {
       // ignore, and give up
       return;

--- a/src/goto-symex/symex_dead.cpp
+++ b/src/goto-symex/symex_dead.cpp
@@ -21,30 +21,23 @@ void goto_symext::symex_dead(statet &state)
 {
   const goto_programt::instructiont &instruction=*state.source.pc;
 
-  const codet &code = instruction.code;
-
-  if(code.operands().size()!=1)
-    throw "dead expects one operand";
-
-  if(code.op0().id()!=ID_symbol)
-    throw "dead expects symbol as first operand";
+  const code_deadt &code = to_code_dead(instruction.code);
 
   // We increase the L2 renaming to make these non-deterministic.
   // We also prevent propagation of old values.
 
-  ssa_exprt ssa(to_symbol_expr(code.op0()));
+  ssa_exprt ssa(to_symbol_expr(code.symbol()));
   state.rename(ssa, ns, goto_symex_statet::L1);
 
   // in case of pointers, put something into the value set
   if(ns.follow(code.op0().type()).id()==ID_pointer)
   {
-    exprt failed=
-      get_failed_symbol(to_symbol_expr(code.op0()), ns);
+    exprt failed = get_failed_symbol(to_symbol_expr(code.symbol()), ns);
 
     exprt rhs;
 
     if(failed.is_not_nil())
-      rhs=address_of_exprt(failed, to_pointer_type(code.op0().type()));
+      rhs = address_of_exprt(failed, to_pointer_type(code.symbol().type()));
     else
       rhs=exprt(ID_invalid);
 

--- a/src/goto-symex/symex_decl.cpp
+++ b/src/goto-symex/symex_decl.cpp
@@ -25,14 +25,10 @@ void goto_symext::symex_decl(statet &state)
 
   const codet &code = instruction.code;
 
-  if(code.operands().size()==2)
-    throw "two-operand decl not supported here";
-
-  if(code.operands().size()!=1)
-    throw "decl expects one operand";
-
-  if(code.op0().id()!=ID_symbol)
-    throw "decl expects symbol as first operand";
+  // two-operand decl not supported here
+  // we handle the decl with only one operand
+  PRECONDITION(code.operands().size() == 1);
+  PRECONDITION(code.op0().id() == ID_symbol);
 
   symex_decl(state, to_symbol_expr(code.op0()));
 }

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/base_type.h>
 #include <util/byte_operators.h>
 #include <util/c_types.h>
+#include <util/exception_utils.h>
 #include <util/invariant.h>
 #include <util/pointer_offset_size.h>
 
@@ -215,7 +216,8 @@ exprt goto_symext::address_arithmetic(
       result=address_of_exprt(result);
   }
   else
-    throw "goto_symext::address_arithmetic does not handle "+expr.id_string();
+    throw unsupported_operation_exceptiont(
+      "goto_symext::address_arithmetic does not handle " + expr.id_string());
 
   const typet &expr_type=ns.follow(expr.type());
   INVARIANT((expr_type.id()==ID_array && !keep_array) ||
@@ -233,9 +235,7 @@ void goto_symext::dereference_rec(
 {
   if(expr.id()==ID_dereference)
   {
-    if(expr.operands().size()!=1)
-      throw "dereference takes one operand";
-
+    dereference_exprt to_check = to_dereference_expr(expr);
     bool expr_is_not_null = false;
 
     if(state.threads.size() == 1)
@@ -243,7 +243,6 @@ void goto_symext::dereference_rec(
       const irep_idt &expr_function = state.source.pc->function;
       if(!expr_function.empty())
       {
-        dereference_exprt to_check = to_dereference_expr(expr);
         state.get_original_name(to_check);
 
         expr_is_not_null =

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <algorithm>
 
+#include <util/exception_utils.h>
 #include <util/invariant.h>
 #include <util/pointer_offset_size.h>
 #include <util/std_expr.h>
@@ -48,8 +49,8 @@ void goto_symext::symex_goto(statet &state)
     !instruction.targets.empty(), "goto should have at least one target");
 
   // we only do deterministic gotos for now
-  if(instruction.targets.size()!=1)
-    throw "no support for non-deterministic gotos";
+  DATA_INVARIANT(
+    instruction.targets.size() == 1, "no support for non-deterministic gotos");
 
   goto_programt::const_targett goto_target=
     instruction.get_target();
@@ -345,8 +346,10 @@ void goto_symext::merge_goto(
   statet &state)
 {
   // check atomic section
-  if(state.atomic_section_id!=goto_state.atomic_section_id)
-    throw "atomic sections differ across branches";
+  if(state.atomic_section_id != goto_state.atomic_section_id)
+    throw incorrect_goto_program_exceptiont(
+      "atomic sections differ across branches",
+      state.source.pc->source_location);
 
   // do SSA phi functions
   phi_function(goto_state, state);

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -14,10 +14,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <cassert>
 #include <memory>
 
+#include <util/exception_utils.h>
+#include <util/make_unique.h>
+#include <util/replace_symbol.h>
 #include <util/std_expr.h>
 #include <util/symbol_table.h>
-#include <util/replace_symbol.h>
-#include <util/make_unique.h>
 
 #include <analyses/dirty.h>
 
@@ -107,13 +108,12 @@ void goto_symext::rewrite_quantifiers(exprt &expr, statet &state)
   {
     // forall X. P -> P
     // we keep the quantified variable unique by means of L2 renaming
-    PRECONDITION(expr.operands().size()==2);
-    PRECONDITION(expr.op0().id()==ID_symbol);
-    symbol_exprt tmp0=
-      to_symbol_expr(to_ssa_expr(expr.op0()).get_original_expr());
+    auto &quant_expr = to_quantifier_expr(expr);
+    symbol_exprt tmp0 =
+      to_symbol_expr(to_ssa_expr(quant_expr.symbol()).get_original_expr());
     symex_decl(state, tmp0);
-    exprt tmp=expr.op1();
-    expr.swap(tmp);
+    exprt tmp = quant_expr.where();
+    quant_expr.swap(tmp);
   }
 }
 
@@ -283,7 +283,7 @@ void goto_symext::symex_from_entry_point_of(
   }
   catch(const std::out_of_range &)
   {
-    throw "the program has no entry point";
+    throw unsupported_operation_exceptiont("the program has no entry point");
   }
 
   statet state;
@@ -461,9 +461,9 @@ void goto_symext::symex_step(
     break;
 
   case NO_INSTRUCTION_TYPE:
-    throw "symex got NO_INSTRUCTION";
+    throw unsupported_operation_exceptiont("symex got NO_INSTRUCTION");
 
   default:
-    throw "symex got unexpected instruction";
+    UNREACHABLE;
   }
 }

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -140,7 +140,7 @@ void goto_symext::symex_other(
     // - array_replace: the type of the second array (even if it is smaller)
     DATA_INVARIANT(
       code.operands().size() == 2,
-      "array_copy/array_replace takes two operands");
+      "expected array_copy/array_replace statement to have two operands");
 
     // we need to add dereferencing for both operands
     dereference_exprt dest_array(code.op0());
@@ -188,7 +188,9 @@ void goto_symext::symex_other(
     // process_array_expr)
     // 3. use the type of the resulting array to construct an array_of
     // expression
-    DATA_INVARIANT(code.operands().size() == 2, "array_set takes two operands");
+    DATA_INVARIANT(
+      code.operands().size() == 2,
+      "expected array_set statement to have two operands");
 
     // we need to add dereferencing for the first operand
     exprt array_expr = dereference_exprt(code.op0());
@@ -235,7 +237,7 @@ void goto_symext::symex_other(
     // if the types don't match the result trivially is false
     DATA_INVARIANT(
       code.operands().size() == 3,
-      "array_equal expected to take three arguments");
+      "expected array_equal statement to have three operands");
 
     // we need to add dereferencing for the first two
     dereference_exprt array1(code.op0());
@@ -267,8 +269,9 @@ void goto_symext::symex_other(
   }
   else if(statement==ID_havoc_object)
   {
-    DATA_INVARIANT(code.operands().size()==1,
-                   "havoc_object must have one operand");
+    DATA_INVARIANT(
+      code.operands().size() == 1,
+      "expected havoc_object statement to have one operand");
 
     // we need to add dereferencing for the first operand
     dereference_exprt object(code.op0(), empty_typet());
@@ -277,5 +280,5 @@ void goto_symext::symex_other(
     havoc_rec(state, guardt(), object);
   }
   else
-    throw "unexpected statement: "+id2string(statement);
+    UNREACHABLE;
 }

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_symex.h"
 
+#include <util/exception_utils.h>
 #include <util/expr_initializer.h>
 
 void goto_symext::symex_start_thread(statet &state)
@@ -18,18 +19,18 @@ void goto_symext::symex_start_thread(statet &state)
   if(state.guard.is_false())
     return;
 
-  // we don't allow spawning threads out of atomic sections
-  // this would require amendments to ordering constraints
-  if(state.atomic_section_id!=0)
-    throw "start_thread in atomic section detected";
+  if(state.atomic_section_id != 0)
+    throw incorrect_goto_program_exceptiont(
+      "spawning threads out of atomic sections is not allowed; "
+      "this would require amendments to ordering constraints",
+      state.source.pc->source_location);
 
   // record this
   target.spawn(state.guard.as_expr(), state.source);
 
   const goto_programt::instructiont &instruction=*state.source.pc;
 
-  if(instruction.targets.size()!=1)
-    throw "start_thread expects one target";
+  INVARIANT(instruction.targets.size() == 1, "start_thread expects one target");
 
   goto_programt::const_targett thread_target=
     instruction.get_target();


### PR DESCRIPTION
This PR is similar in spirit to #2703 but it targets the `goto-symex/` directory.