### PR TITLE
Cleanup of throws and asserts of goto_convert.cpp

### DIFF
--- a/regression/ansi-c/goto_convert_break/main.c
+++ b/regression/ansi-c/goto_convert_break/main.c
@@ -1,0 +1,5 @@
+int main()
+{
+  break;
+  return 0;
+}

--- a/regression/ansi-c/goto_convert_break/test.desc
+++ b/regression/ansi-c/goto_convert_break/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=1$
+^SIGNAL=0$
+^CONVERSION ERROR$
+--
+^warning: ignoring

--- a/regression/ansi-c/goto_convert_continue/main.c
+++ b/regression/ansi-c/goto_convert_continue/main.c
@@ -1,0 +1,5 @@
+int main()
+{
+  continue;
+  return 0;
+}

--- a/regression/ansi-c/goto_convert_continue/test.desc
+++ b/regression/ansi-c/goto_convert_continue/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=1$
+^SIGNAL=0$
+^CONVERSION ERROR$
+--
+^warning: ignoring

--- a/regression/ansi-c/goto_convert_invalid_goto_label/main.c
+++ b/regression/ansi-c/goto_convert_invalid_goto_label/main.c
@@ -1,0 +1,8 @@
+int main()
+{
+  goto x;
+
+  // x:
+
+  return 0;
+}

--- a/regression/ansi-c/goto_convert_invalid_goto_label/test.desc
+++ b/regression/ansi-c/goto_convert_invalid_goto_label/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^CONVERSION ERROR$
+^EXIT=1$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/ansi-c/goto_convert_switch_range_bounds/main.c
+++ b/regression/ansi-c/goto_convert_switch_range_bounds/main.c
@@ -1,0 +1,13 @@
+int main()
+{
+  int x;
+  int n = 5;
+  switch(x)
+  {
+  case 0 ... n:
+    break;
+  default:
+    break;
+  }
+  return 0;
+}

--- a/regression/ansi-c/goto_convert_switch_range_bounds/test.desc
+++ b/regression/ansi-c/goto_convert_switch_range_bounds/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^CONVERSION ERROR$
+^EXIT=1$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/ansi-c/goto_convert_switch_range_case_valid/main.c
+++ b/regression/ansi-c/goto_convert_switch_range_case_valid/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+#define false 0
+
+int main(void)
+{
+  int x = 5;
+  switch (x)
+  {
+    case 0 ... 10:
+      break;
+    default:
+      assert(false);
+      break;
+  }
+}

--- a/regression/ansi-c/goto_convert_switch_range_case_valid/test.desc
+++ b/regression/ansi-c/goto_convert_switch_range_case_valid/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^Invariant check failed

--- a/regression/ansi-c/goto_convert_switch_range_empty/main.c
+++ b/regression/ansi-c/goto_convert_switch_range_empty/main.c
@@ -1,0 +1,12 @@
+int main()
+{
+  int x;
+  switch(x)
+  {
+  case 10 ... 0:
+    break;
+  default:
+    break;
+  }
+  return 0;
+}

--- a/regression/ansi-c/goto_convert_switch_range_empty/test.desc
+++ b/regression/ansi-c/goto_convert_switch_range_empty/test.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^Invariant check failed

--- a/regression/ansi-c/goto_convert_switch_range_operands_count/main.c
+++ b/regression/ansi-c/goto_convert_switch_range_operands_count/main.c
@@ -1,0 +1,12 @@
+int main()
+{
+  int x;
+  switch(x)
+  {
+  case 0 ... 10 20:
+    break;
+  default:
+    break;
+  }
+  return 0;
+}

--- a/regression/ansi-c/goto_convert_switch_range_operands_count/test.desc
+++ b/regression/ansi-c/goto_convert_switch_range_operands_count/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=1$
+^SIGNAL=0$
+^PARSING ERROR$
+--
+^warning: ignoring

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -17,6 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <memory>
 
 #include <util/config.h>
+#include <util/exception_utils.h>
 #include <util/exit_codes.h>
 #include <util/invariant.h>
 #include <util/unicode.h>
@@ -609,6 +610,12 @@ int cbmc_parse_optionst::get_goto_program(
     }
 
     log.status() << config.object_bits_info() << log.eom;
+  }
+
+  catch(incorrect_goto_program_exceptiont &e)
+  {
+    log.error() << e.what() << log.eom;
+    return CPROVER_EXIT_EXCEPTION;
   }
 
   catch(const char *e)

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1153,27 +1153,28 @@ exprt goto_convertt::case_guard(
   const exprt &value,
   const exprt::operandst &case_op)
 {
-  exprt dest=exprt(ID_or, bool_typet());
-  dest.reserve_operands(case_op.size());
+  PRECONDITION(!case_op.empty());
 
-  forall_expr(it, case_op)
+  if(case_op.size() == 1)
+    return equal_exprt(value, case_op.at(0));
+  else
   {
-    equal_exprt eq_expr;
-    eq_expr.lhs()=value;
-    eq_expr.rhs()=*it;
-    dest.move_to_operands(eq_expr);
+    exprt dest = exprt(ID_or, bool_typet());
+    dest.reserve_operands(case_op.size());
+
+    forall_expr(it, case_op)
+    {
+      equal_exprt eq_expr;
+      eq_expr.lhs() = value;
+      eq_expr.rhs() = *it;
+      dest.move_to_operands(eq_expr);
+    }
+    INVARIANT(
+      case_op.size() == dest.operands().size(),
+      "case guard conversion should preserve the number of cases");
+
+    return dest;
   }
-
-  CHECK_RETURN(!dest.operands().empty());
-
-  if(dest.operands().size()==1)
-  {
-    exprt tmp;
-    tmp.swap(dest.op0());
-    dest.swap(tmp);
-  }
-
-  return dest;
 }
 
 void goto_convertt::convert_switch(

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -315,6 +315,9 @@ inline const code_declt &to_code_decl(const codet &code)
   // will be size()==1 in the future
   DATA_INVARIANT(
     code.operands().size() >= 1, "decls must have one or more operands");
+  DATA_INVARIANT(
+    code.op0().id() == ID_symbol, "decls symbols must be a \"symbol\"");
+
   return static_cast<const code_declt &>(code);
 }
 


### PR DESCRIPTION
In the same spirit as #2904 I am taking over development of #2814 because the original repository is now defunct, and I can't go further with that PR. This PR will host further development of that line of work.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [n/a] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->