### PR TITLE
Cleanup asserts & throws - replace with invariants - dir util/s* (part2)

### DIFF
--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -43,7 +43,10 @@ bool simplify_exprt::simplify_bswap(bswap_exprt &expr)
     mp_integer new_value=0;
     for(std::size_t bit = 0; bit < width; bit += bits_per_byte)
     {
-      assert(!bytes.empty());
+      INVARIANT(
+        !bytes.empty(),
+        "bytes is not empty because we just pushed just as many elements on "
+        "top of it as we are popping now");
       new_value+=bytes.back()<<bit;
       bytes.pop_back();
     }
@@ -180,7 +183,7 @@ bool simplify_exprt::simplify_mult(exprt &expr)
   exprt::operandst::iterator constant;
 
   // true if we have found a constant
-  bool found = false;
+  bool constant_found = false;
 
   typet c_sizeof_type=nil_typet();
 
@@ -212,7 +215,7 @@ bool simplify_exprt::simplify_mult(exprt &expr)
         c_sizeof_type=
           static_cast<const typet &>(it->find(ID_C_c_sizeof_type));
 
-      if(found)
+      if(constant_found)
       {
         // update the constant factor
         if(!mul_expr(to_constant_expr(*constant), to_constant_expr(*it)))
@@ -222,7 +225,7 @@ bool simplify_exprt::simplify_mult(exprt &expr)
       {
         // set it as the constant factor if this is the first
         constant=it;
-        found=true;
+        constant_found = true;
       }
     }
 
@@ -238,7 +241,10 @@ bool simplify_exprt::simplify_mult(exprt &expr)
 
   if(c_sizeof_type.is_not_nil())
   {
-    assert(found);
+    INVARIANT(
+      constant_found,
+      "c_sizeof_type is only set to a non-nil value "
+      "if a constant has been found");
     constant->set(ID_C_c_sizeof_type, c_sizeof_type);
   }
 
@@ -252,7 +258,7 @@ bool simplify_exprt::simplify_mult(exprt &expr)
   else
   {
     // if the constant is a one and there are other factors
-    if(found && constant->is_one())
+    if(constant_found && constant->is_one())
     {
       // just delete it
       operands.erase(constant);
@@ -523,7 +529,7 @@ bool simplify_exprt::simplify_plus(exprt &expr)
                          to_constant_expr(*it)))
             {
               *it=from_integer(0, it->type());
-              assert(it->is_not_nil());
+              CHECK_RETURN(it->is_not_nil());
               result=false;
             }
           }
@@ -556,7 +562,7 @@ bool simplify_exprt::simplify_plus(exprt &expr)
       {
         *(itm->second)=from_integer(0, expr.type());
         *it=from_integer(0, expr.type());
-        assert(it->is_not_nil());
+        CHECK_RETURN(it->is_not_nil());
         expr_map.erase(itm);
         result=false;
       }
@@ -583,7 +589,7 @@ bool simplify_exprt::simplify_plus(exprt &expr)
   if(operands.empty())
   {
     expr=from_integer(0, expr.type());
-    assert(expr.is_not_nil());
+    CHECK_RETURN(expr.is_not_nil());
     return false;
   }
   else if(operands.size()==1)
@@ -646,7 +652,7 @@ bool simplify_exprt::simplify_minus(exprt &expr)
     if(operands[0]==operands[1])
     {
       exprt zero=from_integer(0, expr.type());
-      assert(zero.is_not_nil());
+      CHECK_RETURN(zero.is_not_nil());
       expr=zero;
       return false;
     }
@@ -741,7 +747,9 @@ bool simplify_exprt::simplify_bitwise(exprt &expr)
     if(expr.op1().type()!=expr.type())
       break;
 
-    assert(a_str.size()==b_str.size());
+    INVARIANT(
+      a_str.size() == b_str.size(),
+      "bitvectors of the same type have the same size");
 
     std::string new_value;
     new_value.resize(width);
@@ -847,32 +855,40 @@ bool simplify_exprt::simplify_bitwise(exprt &expr)
 
 bool simplify_exprt::simplify_extractbit(exprt &expr)
 {
-  const typet &op0_type=expr.op0().type();
+  PRECONDITION(expr.id() == ID_extractbit);
+  const auto &extractbit_expr = to_extractbit_expr(expr);
 
-  if(!is_bitvector_type(op0_type))
+  const typet &src_type = extractbit_expr.src().type();
+
+  if(!is_bitvector_type(src_type))
     return true;
 
-  std::size_t width=to_bitvector_type(op0_type).get_width();
+  const std::size_t src_bit_width = to_bitvector_type(src_type).get_width();
 
-  assert(expr.operands().size()==2);
-
-  mp_integer i;
-
-  if(to_integer(expr.op1(), i))
+  const auto index_converted_to_int =
+    numeric_cast<mp_integer>(extractbit_expr.index());
+  if(!index_converted_to_int.has_value())
+  {
+    return true;
+  }
+  const mp_integer index_as_int = index_converted_to_int.value();
+  if(!extractbit_expr.src().is_constant())
     return true;
 
-  if(!expr.op0().is_constant())
+  if(index_as_int < 0 || index_as_int >= src_bit_width)
     return true;
 
-  if(i<0 || i>=width)
+  const irep_idt &src_value =
+    to_constant_expr(extractbit_expr.src()).get_value();
+
+  std::string src_value_as_string = id2string(src_value);
+
+  if(src_value_as_string.size() != src_bit_width)
     return true;
 
-  const irep_idt &value=expr.op0().get(ID_value);
-
-  if(value.size()!=width)
-    return true;
-
-  bool bit=(id2string(value)[width-integer2size_t(i)-1]=='1');
+  const bool bit =
+    (src_value_as_string[src_bit_width -
+                         numeric_cast_v<std::size_t>(index_as_int) - 1] == '1');
 
   expr.make_bool(bit);
 
@@ -1580,7 +1596,9 @@ bool simplify_exprt::simplify_inequality_not_constant(exprt &expr)
 
   // now we only have >=, =
 
-  assert(expr.id()==ID_ge || expr.id()==ID_equal);
+  INVARIANT(
+    expr.id() == ID_ge || expr.id() == ID_equal,
+    "we previously converted all other cases to >= or ==");
 
   // syntactically equal?
 
@@ -1662,7 +1680,7 @@ bool simplify_exprt::simplify_inequality_not_constant(exprt &expr)
 bool simplify_exprt::simplify_inequality_constant(exprt &expr)
 {
   // the constant is always on the RHS
-  assert(expr.op1().is_constant());
+  PRECONDITION(expr.op1().is_constant());
 
   if(expr.op0().id()==ID_if && expr.op0().operands().size()==3)
   {
@@ -1766,7 +1784,7 @@ bool simplify_exprt::simplify_inequality_constant(exprt &expr)
           {
             constant+=i;
             *it=from_integer(0, it->type());
-            assert(it->is_not_nil());
+            CHECK_RETURN(it->is_not_nil());
             changed=true;
           }
         }
@@ -1906,9 +1924,7 @@ bool simplify_exprt::simplify_inequality_constant(exprt &expr)
     }
     else if(expr.id()==ID_gt)
     {
-      mp_integer i;
-      if(to_integer(expr.op1(), i))
-        throw "bit-vector constant unexpectedly non-integer";
+      mp_integer i = numeric_cast_v<mp_integer>(expr.op1());
 
       if(i==max)
       {
@@ -1932,9 +1948,7 @@ bool simplify_exprt::simplify_inequality_constant(exprt &expr)
     }
     else if(expr.id()==ID_le)
     {
-      mp_integer i;
-      if(to_integer(expr.op1(), i))
-        throw "bit-vector constant unexpectedly non-integer";
+      mp_integer i = numeric_cast_v<mp_integer>(expr.op1());
 
       if(i==max)
       {

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -196,9 +196,8 @@ bool simplify_exprt::simplify_address_of(exprt &expr)
   else if(object.id()==ID_dereference)
   {
     // simplify &*p to p
-    assert(object.operands().size()==1);
-    exprt tmp=object.op0();
-    expr=tmp;
+    auto const &object_as_dereference_expr = to_dereference_expr(object);
+    expr = object_as_dereference_expr.pointer();
     return false;
   }
 
@@ -410,9 +409,10 @@ bool simplify_exprt::simplify_pointer_offset(exprt &expr)
 
 bool simplify_exprt::simplify_inequality_address_of(exprt &expr)
 {
-  assert(expr.type().id()==ID_bool);
-  assert(expr.operands().size()==2);
-  assert(expr.id()==ID_equal || expr.id()==ID_notequal);
+  PRECONDITION(expr.id() == ID_equal || expr.id() == ID_notequal);
+  PRECONDITION(expr.type().id() == ID_bool);
+  DATA_INVARIANT(
+    expr.operands().size() == 2, "(in)equalities have two operands");
 
   exprt tmp0=expr.op0();
   if(tmp0.id()==ID_typecast)
@@ -426,8 +426,8 @@ bool simplify_exprt::simplify_inequality_address_of(exprt &expr)
   if(tmp1.op0().id()==ID_index &&
      to_index_expr(tmp1.op0()).index().is_zero())
     tmp1=address_of_exprt(to_index_expr(tmp1.op0()).array());
-  assert(tmp0.id()==ID_address_of);
-  assert(tmp1.id()==ID_address_of);
+  INVARIANT(tmp0.id() == ID_address_of, "id must be ID_address_of");
+  INVARIANT(tmp1.id() == ID_address_of, "id must be ID_address_of");
 
   if(tmp0.operands().size()!=1)
     return true;
@@ -450,14 +450,15 @@ bool simplify_exprt::simplify_inequality_address_of(exprt &expr)
 
 bool simplify_exprt::simplify_inequality_pointer_object(exprt &expr)
 {
-  assert(expr.type().id()==ID_bool);
-  assert(expr.operands().size()==2);
-  assert(expr.id()==ID_equal || expr.id()==ID_notequal);
+  PRECONDITION(expr.id() == ID_equal || expr.id() == ID_notequal);
+  PRECONDITION(expr.type().id() == ID_bool);
+  DATA_INVARIANT(
+    expr.operands().size() == 2, "(in)equalities have two operands");
 
   forall_operands(it, expr)
   {
-    assert(it->id()==ID_pointer_object);
-    assert(it->operands().size()==1);
+    PRECONDITION(it->id() == ID_pointer_object);
+    PRECONDITION(it->operands().size() == 1);
     const exprt &op=it->op0();
 
     if(op.id()==ID_address_of)

--- a/src/util/ssa_expr.h
+++ b/src/util/ssa_expr.h
@@ -153,9 +153,9 @@ public:
 */
 inline const ssa_exprt &to_ssa_expr(const exprt &expr)
 {
-  assert(expr.id()==ID_symbol &&
-         expr.get_bool(ID_C_SSA_symbol) &&
-         !expr.has_operands());
+  PRECONDITION(
+    expr.id() == ID_symbol && expr.get_bool(ID_C_SSA_symbol) &&
+    !expr.has_operands());
   return static_cast<const ssa_exprt &>(expr);
 }
 
@@ -164,9 +164,9 @@ inline const ssa_exprt &to_ssa_expr(const exprt &expr)
 */
 inline ssa_exprt &to_ssa_expr(exprt &expr)
 {
-  assert(expr.id()==ID_symbol &&
-         expr.get_bool(ID_C_SSA_symbol) &&
-         !expr.has_operands());
+  PRECONDITION(
+    expr.id() == ID_symbol && expr.get_bool(ID_C_SSA_symbol) &&
+    !expr.has_operands());
   return static_cast<ssa_exprt &>(expr);
 }
 

--- a/src/util/std_expr.cpp
+++ b/src/util/std_expr.cpp
@@ -74,7 +74,7 @@ static void build_object_descriptor_rec(
     build_object_descriptor_rec(ns, index.array(), dest);
 
     exprt sub_size=size_of_expr(expr.type(), ns);
-    assert(sub_size.is_not_nil());
+    CHECK_RETURN(sub_size.is_not_nil());
 
     dest.offset()=
       plus_exprt(dest.offset(),
@@ -89,7 +89,7 @@ static void build_object_descriptor_rec(
     build_object_descriptor_rec(ns, struct_op, dest);
 
     exprt offset=member_offset_expr(member, ns);
-    assert(offset.is_not_nil());
+    CHECK_RETURN(offset.is_not_nil());
 
     dest.offset()=
       plus_exprt(dest.offset(),
@@ -124,7 +124,7 @@ void object_descriptor_exprt::build(
   const exprt &expr,
   const namespacet &ns)
 {
-  assert(object().id()==ID_unknown);
+  PRECONDITION(object().id() == ID_unknown);
   object()=expr;
 
   if(offset().id()==ID_unknown)
@@ -132,7 +132,7 @@ void object_descriptor_exprt::build(
 
   build_object_descriptor_rec(ns, expr, *this);
 
-  assert(root_object().type().id()!=ID_empty);
+  POSTCONDITION(root_object().type().id() != ID_empty);
 }
 
 shift_exprt::shift_exprt(
@@ -158,7 +158,7 @@ extractbits_exprt::extractbits_exprt(
   const typet &_type):
   exprt(ID_extractbits, _type)
 {
-  assert(_upper>=_lower);
+  PRECONDITION(_upper >= _lower);
   operands().resize(3);
   src()=_src;
   upper()=from_integer(_upper, integer_typet());
@@ -204,7 +204,8 @@ const exprt &object_descriptor_exprt::root_object() const
 
   while(p->id() == ID_member || p->id() == ID_index)
   {
-    assert(!p->operands().empty());
+    DATA_INVARIANT(
+      p->has_operands(), "member and index expressions have operands");
     p = &p->op0();
   }
 

--- a/src/util/std_types.cpp
+++ b/src/util/std_types.cpp
@@ -20,14 +20,14 @@ Author: Daniel Kroening, kroening@kroening.com
 std::size_t fixedbv_typet::get_integer_bits() const
 {
   const irep_idt integer_bits=get(ID_integer_bits);
-  assert(!integer_bits.empty());
+  DATA_INVARIANT(!integer_bits.empty(), "integer bits should be set");
   return unsafe_string2unsigned(id2string(integer_bits));
 }
 
 std::size_t floatbv_typet::get_f() const
 {
   const irep_idt &f=get(ID_f);
-  assert(!f.empty());
+  DATA_INVARIANT(!f.empty(), "the mantissa should be set");
   return unsafe_string2unsigned(id2string(f));
 }
 
@@ -66,7 +66,7 @@ const typet &
 struct_union_typet::component_type(const irep_idt &component_name) const
 {
   const auto &c = get_component(component_name);
-  assert(c.is_not_nil());
+  CHECK_RETURN(c.is_not_nil());
   return c.type();
 }
 

--- a/src/util/string_constant.h
+++ b/src/util/string_constant.h
@@ -33,13 +33,13 @@ public:
 
 inline const string_constantt &to_string_constant(const exprt &expr)
 {
-  assert(expr.id()==ID_string_constant);
+  PRECONDITION(expr.id() == ID_string_constant);
   return static_cast<const string_constantt &>(expr);
 }
 
 inline string_constantt &to_string_constant(exprt &expr)
 {
-  assert(expr.id()==ID_string_constant);
+  PRECONDITION(expr.id() == ID_string_constant);
   return static_cast<string_constantt &>(expr);
 }
 

--- a/src/util/string_utils.cpp
+++ b/src/util/string_utils.cpp
@@ -109,8 +109,7 @@ void split_string(
   std::vector<std::string> result;
 
   split_string(s, delim, result, strip);
-  if(result.size()!=2)
-    throw "split string did not generate exactly 2 parts";
+  CHECK_RETURN(result.size() == 2);
 
   left=result[0];
   right=result[1];


### PR DESCRIPTION
Cleanup of asserts - replaced with invariants.

Removed all unstructured throw(...) statements, replacing with INVARIANT, PRECONDITION, etc. where appropriate.