### PR TITLE
Separate parsing of language options from languaget

### DIFF
--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -77,6 +77,8 @@ void janalyzer_parse_optionst::get_command_line_options(optionst &options)
     exit(CPROVER_EXIT_USAGE_ERROR);
   }
 
+  parse_java_language_options(cmdline, options);
+
   // check assertions
   if(cmdline.isset("no-assertions"))
     options.set_option("assertions", false);
@@ -350,7 +352,7 @@ int janalyzer_parse_optionst::doit()
 
   try
   {
-    goto_model = initialize_goto_model(cmdline, get_message_handler());
+    goto_model = initialize_goto_model(cmdline, get_message_handler(), options);
   }
 
   catch(const char *e)

--- a/jbmc/src/java_bytecode/Makefile
+++ b/jbmc/src/java_bytecode/Makefile
@@ -35,6 +35,7 @@ SRC = bytecode_info.cpp \
       java_types.cpp \
       java_utils.cpp \
       load_method_by_regex.cpp \
+      object_factory_parameters.cpp \
       mz_zip_archive.cpp \
       remove_exceptions.cpp \
       remove_instanceof.cpp \

--- a/jbmc/src/java_bytecode/java_bytecode_language.h
+++ b/jbmc/src/java_bytecode/java_bytecode_language.h
@@ -88,7 +88,7 @@ enum lazy_methods_modet
 class java_bytecode_languaget:public languaget
 {
 public:
-  virtual void get_language_options(const cmdlinet &) override;
+  void set_language_options(const optionst &) override;
 
   virtual bool preprocess(
     std::istream &instream,
@@ -196,7 +196,7 @@ protected:
 
 private:
   virtual std::vector<load_extra_methodst>
-  build_extra_entry_points(const cmdlinet &command_line) const;
+  build_extra_entry_points(const optionst &) const;
   const std::unique_ptr<const select_pointer_typet> pointer_type_selector;
 
   /// Maps synthetic method names on to the particular type of synthetic method
@@ -212,5 +212,7 @@ private:
 };
 
 std::unique_ptr<languaget> new_java_bytecode_language();
+
+void parse_java_language_options(const cmdlinet &cmd, optionst &options);
 
 #endif // CPROVER_JAVA_BYTECODE_JAVA_BYTECODE_LANGUAGE_H

--- a/jbmc/src/java_bytecode/java_class_loader_limit.cpp
+++ b/jbmc/src/java_bytecode/java_class_loader_limit.cpp
@@ -13,6 +13,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <json/json_parser.h>
 
+#include <util/invariant.h>
+
 /// Initializes class with either regex matcher or match set. If the string
 /// starts with an `@` it is treated as a path to a JSON file. Otherwise, it is
 /// treated as a regex.
@@ -48,8 +50,7 @@ Author: Daniel Kroening, kroening@kroening.com
 void java_class_loader_limitt::setup_class_load_limit(
   const std::string &java_cp_include_files)
 {
-  if(java_cp_include_files.empty())
-    throw "class regexp cannot be empty, `get_language_options` not called?";
+  PRECONDITION(!java_cp_include_files.empty());
 
   // '@' signals file reading with list of class files to load
   use_regex_match = java_cp_include_files[0] != '@';

--- a/jbmc/src/java_bytecode/object_factory_parameters.cpp
+++ b/jbmc/src/java_bytecode/object_factory_parameters.cpp
@@ -1,0 +1,71 @@
+/*******************************************************************\
+
+Module: Java Object Factory
+
+Author: Diffblue Ltd
+
+\*******************************************************************/
+
+#include "object_factory_parameters.h"
+
+#include <util/cmdline.h>
+#include <util/options.h>
+
+void object_factory_parameterst::set(const optionst &options)
+{
+  if(options.is_set("max-nondet-array-length"))
+  {
+    max_nondet_array_length =
+      options.get_unsigned_int_option("max-nondet-array-length");
+  }
+  if(options.is_set("max-nondet-tree-depth"))
+  {
+    max_nondet_tree_depth =
+      options.get_unsigned_int_option("max-nondet-tree-depth");
+  }
+  if(options.is_set("max-nondet-string-length"))
+  {
+    max_nondet_string_length =
+      options.get_unsigned_int_option("max-nondet-string-length");
+  }
+  if(options.is_set("string-printable"))
+  {
+    string_printable = options.get_bool_option("string-printable");
+  }
+  if(options.is_set("min-nondet-string-length"))
+  {
+    min_nondet_string_length =
+      options.get_unsigned_int_option("min-nondet-string-length");
+  }
+}
+
+/// Parse the object factory parameters from a given command line
+/// \param cmdline Command line
+/// \param [out] options The options object that will be updated.
+void parse_object_factory_options(const cmdlinet &cmdline, optionst &options)
+{
+  if(cmdline.isset("max-nondet-array-length"))
+  {
+    options.set_option(
+      "max-nondet-array-length", cmdline.get_value("max-nondet-array-length"));
+  }
+  if(cmdline.isset("max-nondet-tree-depth"))
+  {
+    options.set_option(
+      "max-nondet-tree-depth", cmdline.get_value("max-nondet-tree-depth"));
+  }
+  if(cmdline.isset("max-nondet-string-length"))
+  {
+    options.set_option(
+      "max-nondet-string-length",
+      cmdline.get_value("max-nondet-string-length"));
+  }
+  if(cmdline.isset("string-printable"))
+  {
+    options.set_option("string-printable", cmdline.isset("string-printable"));
+  }
+  if(cmdline.isset("string-non-empty"))
+  {
+    options.set_option("min-nondet-string-length", 1);
+  }
+}

--- a/jbmc/src/java_bytecode/object_factory_parameters.h
+++ b/jbmc/src/java_bytecode/object_factory_parameters.h
@@ -14,6 +14,9 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/irep.h>
 
+class cmdlinet;
+class optionst;
+
 #define MAX_NONDET_ARRAY_LENGTH_DEFAULT 5
 #define MAX_NONDET_STRING_LENGTH \
   static_cast<std::size_t>(std::numeric_limits<std::int32_t>::max())
@@ -56,6 +59,11 @@ struct object_factory_parameterst final
 
   /// Function id, used as a prefix for identifiers of temporaries
   irep_idt function_id;
+
+  /// Assigns the parameters from given options
+  void set(const optionst &);
 };
+
+void parse_object_factory_options(const cmdlinet &, optionst &);
 
 #endif

--- a/jbmc/src/jdiff/jdiff_languages.h
+++ b/jbmc/src/jdiff/jdiff_languages.h
@@ -20,8 +20,9 @@ class jdiff_languagest : public language_uit
 public:
   explicit jdiff_languagest(
     const cmdlinet &cmdline,
-    ui_message_handlert &ui_message_handler)
-    : language_uit(cmdline, ui_message_handler)
+    ui_message_handlert &ui_message_handler,
+    optionst *options)
+    : language_uit(cmdline, ui_message_handler, options)
   {
     register_languages();
   }

--- a/jbmc/src/jdiff/jdiff_parse_options.cpp
+++ b/jbmc/src/jdiff/jdiff_parse_options.cpp
@@ -61,11 +61,13 @@ Author: Peter Schrammel
 #include <goto-diff/goto_diff.h>
 #include <goto-diff/unified_diff.h>
 
+// TODO: do not use language_uit for this; requires a refactoring of
+//   initialize_goto_model to support parsing specific command line files
 jdiff_parse_optionst::jdiff_parse_optionst(int argc, const char **argv)
   : parse_options_baset(JDIFF_OPTIONS, argc, argv),
-    jdiff_languagest(cmdline, ui_message_handler),
+    jdiff_languagest(cmdline, ui_message_handler, &options),
     ui_message_handler(cmdline, std::string("JDIFF ") + CBMC_VERSION),
-    languages2(cmdline, ui_message_handler)
+    languages2(cmdline, ui_message_handler, &options)
 {
 }
 
@@ -74,9 +76,9 @@ jdiff_parse_optionst::jdiff_parse_optionst(int argc, const char **argv)
   const char **argv,
   const std::string &extra_options)
   : parse_options_baset(JDIFF_OPTIONS + extra_options, argc, argv),
-    jdiff_languagest(cmdline, ui_message_handler),
+    jdiff_languagest(cmdline, ui_message_handler, &options),
     ui_message_handler(cmdline, std::string("JDIFF ") + CBMC_VERSION),
-    languages2(cmdline, ui_message_handler)
+    languages2(cmdline, ui_message_handler, &options)
 {
 }
 
@@ -93,6 +95,7 @@ void jdiff_parse_optionst::get_command_line_options(optionst &options)
   // we always require these options
   cmdline.set("no-lazy-methods");
   cmdline.set("no-refine-strings");
+  parse_java_language_options(cmdline, options);
 
   if(cmdline.isset("cover"))
     parse_cover_options(cmdline, options);

--- a/jbmc/src/jdiff/jdiff_parse_options.h
+++ b/jbmc/src/jdiff/jdiff_parse_options.h
@@ -14,6 +14,7 @@ Author: Peter Schrammel
 
 #include <analyses/goto_check.h>
 
+#include <util/options.h>
 #include <util/parse_options.h>
 #include <util/timestamper.h>
 #include <util/ui_message.h>
@@ -25,7 +26,6 @@ Author: Peter Schrammel
 #include "jdiff_languages.h"
 
 class goto_modelt;
-class optionst;
 
 // clang-format off
 #define JDIFF_OPTIONS \
@@ -55,6 +55,7 @@ public:
     const std::string &extra_options);
 
 protected:
+  optionst options;
   ui_message_handlert ui_message_handler;
   jdiff_languagest languages2;
 

--- a/jbmc/unit/java-testing-utils/load_java_class.cpp
+++ b/jbmc/unit/java-testing-utils/load_java_class.cpp
@@ -14,6 +14,7 @@
 #include <testing-utils/message.h>
 
 #include <util/config.h>
+#include <util/options.h>
 #include <util/suffix.h>
 
 #include <goto-programs/lazy_goto_model.h>
@@ -119,9 +120,12 @@ goto_modelt load_goto_model_from_java_class(
 
   std::istringstream java_code_stream("ignored");
 
+  optionst options;
+  parse_java_language_options(command_line, options);
+
   // Configure the language, load the class files
   language.set_message_handler(null_message_handler);
-  language.get_language_options(command_line);
+  language.set_language_options(options);
   language.parse(java_code_stream, filename);
   language.typecheck(lazy_goto_model.symbol_table, "");
   language.generate_support_functions(lazy_goto_model.symbol_table);

--- a/jbmc/unit/java_bytecode/java_bytecode_parser/module_dependencies.txt
+++ b/jbmc/unit/java_bytecode/java_bytecode_parser/module_dependencies.txt
@@ -1,3 +1,4 @@
 java-testing-utils
 testing-utils
 java_bytecode
+util

--- a/jbmc/unit/java_bytecode/java_bytecode_parser/parse_java_annotations.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parser/parse_java_annotations.cpp
@@ -14,6 +14,7 @@
 #include <testing-utils/catch.hpp>
 #include <testing-utils/free_form_cmdline.h>
 #include <testing-utils/message.h>
+#include <util/options.h>
 
 class test_java_bytecode_languaget : public java_bytecode_languaget
 {
@@ -173,7 +174,9 @@ SCENARIO(
       command_line.add_flag("no-refine-strings");
       test_java_bytecode_languaget language;
       language.set_message_handler(null_message_handler);
-      language.get_language_options(command_line);
+      optionst options;
+      parse_java_language_options(command_line, options);
+      language.set_language_options(options);
 
       std::istringstream java_code_stream("ignored");
       language.parse(java_code_stream, "AnnotationsEverywhere.class");

--- a/jbmc/unit/pointer-analysis/custom_value_set_analysis.cpp
+++ b/jbmc/unit/pointer-analysis/custom_value_set_analysis.cpp
@@ -17,6 +17,7 @@ Author: Chris Smowton, chris@smowton.net
 #include <langapi/mode.h>
 #include <pointer-analysis/value_set_analysis.h>
 #include <util/config.h>
+#include <util/options.h>
 
 /// An example customised value_sett. It makes a series of small changes
 /// to the underlying value_sett logic, which can then be verified by the
@@ -180,9 +181,11 @@ SCENARIO("test_value_set_analysis",
     command_line.args.push_back("pointer-analysis/CustomVSATest.jar");
 
     register_language(new_java_bytecode_language);
+    optionst options;
+    parse_java_language_options(command_line, options);
 
     goto_modelt goto_model =
-      initialize_goto_model(command_line, null_message_handler);
+      initialize_goto_model(command_line, null_message_handler, options);
 
     null_message_handlert message_handler;
     remove_java_new(goto_model, message_handler);

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -457,7 +457,7 @@ int cbmc_parse_optionst::doit()
 
   if(cmdline.isset("preprocess"))
   {
-    preprocessing();
+    preprocessing(options);
     return CPROVER_EXIT_SUCCESS;
   }
 
@@ -495,7 +495,7 @@ int cbmc_parse_optionst::doit()
       return CPROVER_EXIT_INCORRECT_TASK;
     }
 
-    language->get_language_options(cmdline);
+    language->set_language_options(options);
     language->set_message_handler(get_message_handler());
 
     status() << "Parsing " << filename << eom;
@@ -578,7 +578,7 @@ int cbmc_parse_optionst::get_goto_program(
 
   try
   {
-    goto_model = initialize_goto_model(cmdline, ui_message_handler);
+    goto_model = initialize_goto_model(cmdline, ui_message_handler, options);
 
     if(cmdline.isset("show-symbol-table"))
     {
@@ -645,7 +645,7 @@ int cbmc_parse_optionst::get_goto_program(
   return -1; // no error, continue
 }
 
-void cbmc_parse_optionst::preprocessing()
+void cbmc_parse_optionst::preprocessing(const optionst &options)
 {
   try
   {
@@ -666,7 +666,7 @@ void cbmc_parse_optionst::preprocessing()
     }
 
     std::unique_ptr<languaget> language=get_language_from_filename(filename);
-    language->get_language_options(cmdline);
+    language->set_language_options(options);
 
     if(language==nullptr)
     {

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -112,7 +112,7 @@ protected:
 
   void register_languages();
   void get_command_line_options(optionst &);
-  void preprocessing();
+  void preprocessing(const optionst &);
   bool set_properties();
 };
 

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -377,7 +377,7 @@ int goto_analyzer_parse_optionst::doit()
 
   try
   {
-    goto_model=initialize_goto_model(cmdline, get_message_handler());
+    goto_model = initialize_goto_model(cmdline, get_message_handler(), options);
   }
 
   catch(const char *e)

--- a/src/goto-programs/initialize_goto_model.cpp
+++ b/src/goto-programs/initialize_goto_model.cpp
@@ -14,7 +14,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <fstream>
 #include <iostream>
 
+#include <util/cmdline.h>
 #include <util/config.h>
+#include <util/message.h>
 #include <util/unicode.h>
 
 #include <langapi/mode.h>
@@ -27,7 +29,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 goto_modelt initialize_goto_model(
   const cmdlinet &cmdline,
-  message_handlert &message_handler)
+  message_handlert &message_handler,
+  const optionst &options)
 {
   messaget msg(message_handler);
   const std::vector<std::string> &files=cmdline.args;
@@ -85,7 +88,7 @@ goto_modelt initialize_goto_model(
 
       languaget &language=*lf.language;
       language.set_message_handler(message_handler);
-      language.get_language_options(cmdline);
+      language.set_language_options(options);
 
       msg.status() << "Parsing " << filename << messaget::eom;
 
@@ -125,9 +128,7 @@ goto_modelt initialize_goto_model(
     // Rebuild the entry-point, using the language annotation of the
     // existing __CPROVER_start function:
     rebuild_goto_start_functiont rebuild_existing_start(
-      cmdline,
-      goto_model,
-      msg.get_message_handler());
+      options, goto_model, msg.get_message_handler());
     entry_point_generation_failed=rebuild_existing_start();
   }
   else if(!binaries_provided_start)

--- a/src/goto-programs/initialize_goto_model.h
+++ b/src/goto-programs/initialize_goto_model.h
@@ -12,13 +12,15 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_GOTO_PROGRAMS_INITIALIZE_GOTO_MODEL_H
 #define CPROVER_GOTO_PROGRAMS_INITIALIZE_GOTO_MODEL_H
 
-#include <util/message.h>
-#include <util/cmdline.h>
-
 #include "goto_model.h"
+
+class cmdlinet;
+class message_handlert;
+class optionst;
 
 goto_modelt initialize_goto_model(
   const cmdlinet &cmdline,
-  message_handlert &message_handler);
+  message_handlert &message_handler,
+  const optionst &options);
 
 #endif // CPROVER_GOTO_PROGRAMS_INITIALIZE_GOTO_MODEL_H

--- a/src/goto-programs/lazy_goto_model.cpp
+++ b/src/goto-programs/lazy_goto_model.cpp
@@ -87,7 +87,9 @@ lazy_goto_modelt::lazy_goto_modelt(lazy_goto_modelt &&other)
 }
 //! @endcond
 
-void lazy_goto_modelt::initialize(const cmdlinet &cmdline)
+void lazy_goto_modelt::initialize(
+  const cmdlinet &cmdline,
+  const optionst &options)
 {
   messaget msg(message_handler);
 
@@ -141,7 +143,7 @@ void lazy_goto_modelt::initialize(const cmdlinet &cmdline)
 
       languaget &language=*lf.language;
       language.set_message_handler(message_handler);
-      language.get_language_options(cmdline);
+      language.set_language_options(options);
 
       msg.status() << "Parsing " << filename << messaget::eom;
 
@@ -181,7 +183,7 @@ void lazy_goto_modelt::initialize(const cmdlinet &cmdline)
     // Rebuild the entry-point, using the language annotation of the
     // existing __CPROVER_start function:
     rebuild_lazy_goto_start_functiont rebuild_existing_start(
-      cmdline, *this, message_handler);
+      options, *this, message_handler);
     entry_point_generation_failed=rebuild_existing_start();
   }
   else if(!binaries_provided_start)

--- a/src/goto-programs/lazy_goto_model.h
+++ b/src/goto-programs/lazy_goto_model.h
@@ -82,7 +82,7 @@ public:
       message_handler);
   }
 
-  void initialize(const cmdlinet &cmdline);
+  void initialize(const cmdlinet &cmdline, const optionst &options);
 
   /// Eagerly loads all functions from the symbol table.
   void load_all_functions() const;

--- a/src/goto-programs/rebuild_goto_start_function.cpp
+++ b/src/goto-programs/rebuild_goto_start_function.cpp
@@ -24,15 +24,13 @@
 ///   function) and symbol table (to replace the _start function symbol) of the
 ///   program.
 /// \param _message_handler: The message handler to report any messages with
-template<typename maybe_lazy_goto_modelt>
+template <typename maybe_lazy_goto_modelt>
 rebuild_goto_start_function_baset<maybe_lazy_goto_modelt>::
-rebuild_goto_start_function_baset(
-  const cmdlinet &cmdline,
-  maybe_lazy_goto_modelt &goto_model,
-  message_handlert &message_handler):
-    messaget(message_handler),
-    cmdline(cmdline),
-    goto_model(goto_model)
+  rebuild_goto_start_function_baset(
+    const optionst &options,
+    maybe_lazy_goto_modelt &goto_model,
+    message_handlert &message_handler)
+  : messaget(message_handler), options(options), goto_model(goto_model)
 {
 }
 
@@ -53,7 +51,7 @@ bool rebuild_goto_start_function_baset<maybe_lazy_goto_modelt>::operator()()
   std::unique_ptr<languaget> language=get_language_from_mode(mode);
   INVARIANT(language, "No language found for mode: "+id2string(mode));
   language->set_message_handler(get_message_handler());
-  language->get_language_options(cmdline);
+  language->set_language_options(options);
 
   // To create a new entry point we must first remove the old one
   remove_existing_entry_point();

--- a/src/goto-programs/rebuild_goto_start_function.h
+++ b/src/goto-programs/rebuild_goto_start_function.h
@@ -10,7 +10,7 @@
 #define CPROVER_GOTO_PROGRAMS_REBUILD_GOTO_START_FUNCTION_H
 
 #include <util/message.h>
-class cmdlinet;
+class optionst;
 
 #include "lazy_goto_model.h"
 
@@ -29,7 +29,7 @@ class rebuild_goto_start_function_baset: public messaget
 {
 public:
   rebuild_goto_start_function_baset(
-    const cmdlinet &cmdline,
+    const optionst &options,
     maybe_lazy_goto_modelt &goto_model,
     message_handlert &message_handler);
 
@@ -40,7 +40,7 @@ private:
 
   void remove_existing_entry_point();
 
-  const cmdlinet &cmdline;
+  const optionst &options;
   maybe_lazy_goto_modelt &goto_model;
 };
 

--- a/src/langapi/language.h
+++ b/src/langapi/language.h
@@ -27,8 +27,8 @@ class symbol_tablet;
 class symbol_table_baset;
 class exprt;
 class namespacet;
+class optionst;
 class typet;
-class cmdlinet;
 
 #define OPT_FUNCTIONS \
   "(function):"
@@ -39,8 +39,10 @@ class cmdlinet;
 class languaget:public messaget
 {
 public:
-  // Parse language-specific options
-  virtual void get_language_options(const cmdlinet &) {}
+  /// Set language-specific options
+  virtual void set_language_options(const optionst &)
+  {
+  }
 
   // parse file
 

--- a/src/langapi/language_ui.cpp
+++ b/src/langapi/language_ui.cpp
@@ -23,9 +23,11 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 /// Constructor
 language_uit::language_uit(
   const cmdlinet &cmdline,
-  ui_message_handlert &_ui_message_handler):
-  _cmdline(cmdline),
-  ui_message_handler(_ui_message_handler)
+  ui_message_handlert &_ui_message_handler,
+  optionst *_options)
+  : _cmdline(cmdline),
+    ui_message_handler(_ui_message_handler),
+    options(_options)
 {
   set_message_handler(ui_message_handler);
 }
@@ -72,7 +74,9 @@ bool language_uit::parse(const std::string &filename)
 
   languaget &language=*lf.language;
   language.set_message_handler(get_message_handler());
-  language.get_language_options(_cmdline);
+
+  if(options != nullptr)
+    language.set_language_options(*options);
 
   status() << "Parsing " << filename << eom;
 

--- a/src/langapi/language_ui.h
+++ b/src/langapi/language_ui.h
@@ -26,7 +26,8 @@ public:
 
   language_uit(
     const cmdlinet &cmdline,
-    ui_message_handlert &ui_message_handler);
+    ui_message_handlert &ui_message_handler,
+    optionst *options = nullptr);
   virtual ~language_uit();
 
   virtual bool parse();
@@ -53,6 +54,7 @@ public:
 protected:
   const cmdlinet &_cmdline;
   ui_message_handlert &ui_message_handler;
+  optionst *options;
 };
 
 #endif // CPROVER_LANGAPI_LANGUAGE_UI_H


### PR DESCRIPTION
The command line should first be converted into `optionst` and then be used. This principle has been broken in many places, leading to cases where options are parsed several times because they are parsed from cmdline in one place and options is used in another place.

This PR does not fix the general problem, but only removes one instance of double parsing that concerns the object factory parameters. Fixes #2908.

The size of this PR shows how entangled the situation is and it mostly just shifts some ugliness from one part of the code base to another part. Particular complications arise from `language_uit`, which will hopefully disappear in near future (together with some of the ugliness that is required here to work around it...).

An important next step to improve the situation would be to enforce that `cmdlinet` is parsed into `optionst` first and after that only `optionst` is used.

