### PR TITLE
Add operator< to source_locationt

### DIFF
--- a/src/util/source_location.cpp
+++ b/src/util/source_location.cpp
@@ -9,6 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "source_location.h"
 
 #include <ostream>
+#include <tuple>
 
 #include "file_util.h"
 
@@ -79,4 +80,20 @@ std::ostream &operator << (
     return out;
   out << source_location.as_string();
   return out;
+}
+
+bool operator<(const source_locationt &s1, const source_locationt &s2)
+{
+  if(s1.is_nil())
+  {
+    if(s2.is_nil())
+      return false;
+    return true;
+  }
+  if(s2.is_nil())
+    return false;
+  unsigned s1_line = std::stoul(s1.get_line().c_str());
+  unsigned s2_line = std::stoul(s2.get_line().c_str());
+  return std::tie(s1.get_file(), s1_line, s1) <
+         std::tie(s2.get_file(), s2_line, s2);
 }

--- a/src/util/source_location.h
+++ b/src/util/source_location.h
@@ -201,4 +201,7 @@ struct diagnostics_helpert<source_locationt>
   }
 };
 
+/// \brief Compare file names lexicographically, then line numbers numerically
+bool operator<(const source_locationt &, const source_locationt &);
+
 #endif // CPROVER_UTIL_SOURCE_LOCATION_H


### PR DESCRIPTION
Prior to this commit, source locations were sorted in ASCIIbetical
order, as follows:

    file event-loop.c line 1
    file event-loop.c line 12 function main
    file event-loop.c line 13 function main
    file event-loop.c line 3 function main
    file event-loop.c line 5 function main

which is highly distracting. This commit implements a comparator
operator that sorts by filename first, breaking ties by sorting line
numbers numerically rather than lexicographically:

    file event-loop.c line 1
    file event-loop.c line 3 function main
    file event-loop.c line 5 function main
    file event-loop.c line 12 function main
    file event-loop.c line 13 function main