### PR TITLE
Correct input initialization in builtin function

### DIFF
--- a/src/solvers/refinement/string_builtin_function.h
+++ b/src/solvers/refinement/string_builtin_function.h
@@ -83,7 +83,7 @@ public:
     array_string_exprt input)
     : string_builtin_functiont(std::move(return_code)),
       result(std::move(result)),
-      input(std::move(result))
+      input(std::move(input))
   {
   }
 


### PR DESCRIPTION
Result was moved twice instead of initializing `input` field with the
given `input`.