### PR TITLE
Fix string_builtin_functiont constructor

### DIFF
--- a/src/solvers/refinement/string_builtin_function.h
+++ b/src/solvers/refinement/string_builtin_function.h
@@ -83,7 +83,7 @@ public:
     array_string_exprt input)
     : string_builtin_functiont(std::move(return_code)),
       result(std::move(result)),
-      input(std::move(result))
+      input(std::move(input))
   {
   }
 


### PR DESCRIPTION
This wrongly std::move'd the same input parameter twice, causing a fault when casting the now-nil exprt. I don't know how this ever worked; possibly in some circumstances the move constructor is elided.