### PR TITLE
remove dereference checks during symex

### DIFF
--- a/src/goto-symex/symex_dereference_state.cpp
+++ b/src/goto-symex/symex_dereference_state.cpp
@@ -13,13 +13,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/symbol_table.h>
 
-void symex_dereference_statet::dereference_failure(
-  const std::string &,
-  const std::string &,
-  const guardt &)
-{
-}
-
 bool symex_dereference_statet::has_failed_symbol(
   const exprt &expr,
   const symbolt *&symbol)

--- a/src/goto-symex/symex_dereference_state.h
+++ b/src/goto-symex/symex_dereference_state.h
@@ -32,11 +32,6 @@ protected:
   goto_symext &goto_symex;
   goto_symext::statet &state;
 
-  virtual void dereference_failure(
-    const std::string &property,
-    const std::string &msg,
-    const guardt &guard);
-
   virtual void get_value_set(
     const exprt &expr,
     value_setst::valuest &value_set);

--- a/src/pointer-analysis/dereference_callback.h
+++ b/src/pointer-analysis/dereference_callback.h
@@ -27,11 +27,6 @@ class dereference_callbackt
 public:
   virtual ~dereference_callbackt();
 
-  virtual void dereference_failure(
-    const std::string &property,
-    const std::string &msg,
-    const guardt &guard)=0;
-
   virtual void get_value_set(
     const exprt &expr,
     value_setst::valuest &value_set)=0;

--- a/src/pointer-analysis/value_set_dereference.h
+++ b/src/pointer-analysis/value_set_dereference.h
@@ -146,11 +146,6 @@ private:
 
   static const exprt &get_symbol(const exprt &object);
 
-  void bounds_check(const index_exprt &expr, const guardt &guard);
-  void valid_check(const exprt &expr, const guardt &guard, const modet mode);
-
-  void invalid_pointer(const exprt &expr, const guardt &guard);
-
   bool memory_model(
     exprt &value,
     const typet &type,


### PR DESCRIPTION
This code has been unused since the introduction of pointer checks
in goto_check; this has happened prior to 2011.