### PR TITLE
Escape braces in regression test regexes

### DIFF
--- a/regression/cbmc/trace-values/trace-values.desc
+++ b/regression/cbmc/trace-values/trace-values.desc
@@ -12,7 +12,7 @@ trace-values.c
 ^  null\$object=6 .*$
 ^  junk\$object=7 .*$
 ^  dynamic_object1\[1.*\]=8 .*$
-^  my_nested\[1.*\]={ .f=0, .array={ 0, 4, 0 } } .*$
+^  my_nested\[1.*\]=\{ .f=0, .array=\{ 0, 4, 0 \} \} .*$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/cbmc/union10/union_list2.desc
+++ b/regression/cbmc/union10/union_list2.desc
@@ -11,8 +11,8 @@ Value sets do not record byte-extract operations with sufficient detail:
   struct list_item *p1 = u.my_list.index;
   struct list_item *p2 = p1->previous;
 yields
-  (29) p1!0@1#2 == byte_extract_little_endian(u!0@1#4, 8l, struct list_item { unsigned int value; unsigned int $pad1; struct list_item *previous; } *)
-  (30) p2!0@1#2 == p1$object#0.previous
+  \(29\) p1!0@1#2 == byte_extract_little_endian\(u!0@1#4, 8l, struct list_item \{ unsigned int value; unsigned int $pad1; struct list_item *previous; \} *\)
+  \(30\) p2!0@1#2 == p1$object#0.previous
 as
-  main::1::p1 = { <integer_address, *, unsigned char> }
+  main::1::p1 = \{ <integer_address, *, unsigned char> \}
 is the only information stored in the value set.

--- a/regression/cpp-linter/do-while1/test.desc
+++ b/regression/cpp-linter/do-while1/test.desc
@@ -1,8 +1,8 @@
 CORE
 main.cpp
 
-^main\.cpp:31:  Empty loop bodies should use {} or continue  \[whitespace/empty_loop_body\] \[5\]$
-^main\.cpp:38:  Empty loop bodies should use {} or continue  \[whitespace/empty_loop_body\] \[5\]$
+^main\.cpp:31:  Empty loop bodies should use \{\} or continue  \[whitespace/empty_loop_body\] \[5\]$
+^main\.cpp:38:  Empty loop bodies should use \{\} or continue  \[whitespace/empty_loop_body\] \[5\]$
 ^Total errors found: 2$
 ^SIGNAL=0$
 --


### PR DESCRIPTION
Braces that are meant to be literals need to be escaped in Perl regexes.