### PR TITLE
Stop unneccessary copies of class_hierarchyt

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -129,7 +129,7 @@ protected:
   bool method_has_this;
   std::map<irep_idt, bool> class_has_clinit_method;
   std::map<irep_idt, bool> any_superclass_has_clinit_method;
-  class_hierarchyt class_hierarchy;
+  const class_hierarchyt &class_hierarchy;
 
   enum instruction_sizet
   {

--- a/src/goto-programs/class_hierarchy.h
+++ b/src/goto-programs/class_hierarchy.h
@@ -57,6 +57,10 @@ public:
 
   void operator()(const symbol_tablet &);
 
+  class_hierarchyt() = default;
+  class_hierarchyt(const class_hierarchyt &) = delete;
+  class_hierarchyt &operator=(const class_hierarchyt &) = delete;
+
   // transitively gets all children
   idst get_children_trans(const irep_idt &id) const
   {

--- a/src/goto-programs/resolve_inherited_component.cpp
+++ b/src/goto-programs/resolve_inherited_component.cpp
@@ -10,23 +10,14 @@
 
 #include "resolve_inherited_component.h"
 
-/// See the operator() method comment.
-/// \param symbol_table: The symbol table to resolve the component against
-resolve_inherited_componentt::resolve_inherited_componentt(
-  const symbol_tablet &symbol_table):
-    symbol_table(symbol_table)
-{
-  class_hierarchy(symbol_table);
-}
-
 /// See the operator() method comment
 /// \param symbol_table: The symbol table to resolve the component against
 /// \param class_hierarchy: A prebuilt class_hierachy based on the symbol_table
 ///
 resolve_inherited_componentt::resolve_inherited_componentt(
-  const symbol_tablet &symbol_table, const class_hierarchyt &class_hierarchy):
-    class_hierarchy(class_hierarchy),
-    symbol_table(symbol_table)
+  const symbol_tablet &symbol_table,
+  const class_hierarchyt &clas_hierarchy)
+  : class_hierarchy(clas_hierarchy), symbol_table(symbol_table)
 {
   // We require the class_hierarchy to be already populated if we are being
   // supplied it.
@@ -67,18 +58,21 @@ resolve_inherited_componentt::inherited_componentt
       return inherited_componentt(current_class, component_name);
     }
 
-    const class_hierarchyt::idst &parents=
-      class_hierarchy.class_map[current_class].parents;
+    const auto current_class_id = class_hierarchy.class_map.find(current_class);
+    if(current_class_id != class_hierarchy.class_map.end())
+    {
+      const class_hierarchyt::idst &parents = current_class_id->second.parents;
 
-    if(include_interfaces)
-    {
-      classes_to_visit.insert(
-        classes_to_visit.end(), parents.begin(), parents.end());
-    }
-    else
-    {
-      if(!parents.empty())
-        classes_to_visit.push_back(parents.front());
+      if(include_interfaces)
+      {
+        classes_to_visit.insert(
+          classes_to_visit.end(), parents.begin(), parents.end());
+      }
+      else
+      {
+        if(!parents.empty())
+          classes_to_visit.push_back(parents.front());
+      }
     }
   }
 

--- a/src/goto-programs/resolve_inherited_component.h
+++ b/src/goto-programs/resolve_inherited_component.h
@@ -21,7 +21,6 @@
 class resolve_inherited_componentt
 {
 public:
-  explicit resolve_inherited_componentt(const symbol_tablet &symbol_table);
   resolve_inherited_componentt(
     const symbol_tablet &symbol_table, const class_hierarchyt &class_hierarchy);
 
@@ -70,7 +69,7 @@ private:
     const irep_idt &component_name,
     const irep_idt &user_class_name);
 
-  class_hierarchyt class_hierarchy;
+  const class_hierarchyt &class_hierarchy;
   const symbol_tablet &symbol_table;
 };
 


### PR DESCRIPTION
If the symbol table is large enough all the copies cause a significant slowdown to the transformation of Java -> GOTO.

This just adds references to a few places where it seems they were missed.