### PR TITLE
Do not use outdated *-mod.gb file

### DIFF
--- a/regression/contracts/chain.sh
+++ b/regression/contracts/chain.sh
@@ -19,6 +19,7 @@ else
   $goto_cc -o "${name}.gb" "${name}.c"
 fi
 
+rm -f "${name}-mod.gb"
 $goto_instrument ${args} "${name}.gb" "${name}-mod.gb"
 if [ ! -e "${name}-mod.gb" ] ; then
   cp "$name.gb" "${name}-mod.gb"

--- a/regression/goto-instrument/chain.sh
+++ b/regression/goto-instrument/chain.sh
@@ -19,6 +19,7 @@ else
   $goto_cc -o "${name}.gb" "${name}.c"
 fi
 
+rm -f "${name}-mod.gb"
 $goto_instrument ${args} "${name}.gb" "${name}-mod.gb"
 if [ ! -e "${name}-mod.gb" ] ; then
   cp "$name.gb" "${name}-mod.gb"


### PR DESCRIPTION
The regression test wrapper scripts perform a conditional copy of the goto
binary, which is meant to cover the case that an invocation of goto-instrument
does not generate a goto binary. When regression tests are re-run without an
intermittent "clean", the conditional copy was not performed. This may lead to
spurious test failures when goto binary versions change.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
