### PR TITLE
Workaround for Google Cloud SDK packaging problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
               key_url: 'https://packages.cloud.google.com/apt/doc/apt-key.gpg'
           packages:
             - cmake
-            - google-cloud-sdk
+            - google-cloud-sdk=216.0.0-0
             - graphviz
       cache:
         directories:


### PR DESCRIPTION
Version 217.0.0-0 of the google-cloud-sdk package using XZ compression,
which is not supported by the version of dpkg available on Ubuntu
Trusty. This change fixes the package to the prior version, which should
remain in place until https://issuetracker.google.com/issues/116076881
has been fixed.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
