### PR TITLE
Make struct_union_typet::component_type return a const reference

### DIFF
--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -392,12 +392,14 @@ java_string_library_preprocesst::process_equals_function_operands(
 /// \param type: a type containing a "data" component
 /// \param symbol_table: symbol table
 /// \return type of the "data" component
-static typet get_data_type(const typet &type, const symbol_tablet &symbol_table)
+static const typet &
+get_data_type(const typet &type, const symbol_tablet &symbol_table)
 {
   PRECONDITION(type.id() == ID_struct || type.id() == ID_symbol_type);
   if(type.id() == ID_symbol_type)
   {
-    symbolt sym=*symbol_table.lookup(to_symbol_type(type).get_identifier());
+    const symbolt &sym =
+      symbol_table.lookup_ref(to_symbol_type(type).get_identifier());
     CHECK_RETURN(sym.type.id() != ID_symbol_type);
     return get_data_type(sym.type, symbol_table);
   }
@@ -410,13 +412,14 @@ static typet get_data_type(const typet &type, const symbol_tablet &symbol_table)
 /// \param type: a type containing a "length" component
 /// \param symbol_table: symbol table
 /// \return type of the "length" component
-static typet
+static const typet &
 get_length_type(const typet &type, const symbol_tablet &symbol_table)
 {
   PRECONDITION(type.id() == ID_struct || type.id() == ID_symbol_type);
   if(type.id() == ID_symbol_type)
   {
-    symbolt sym=*symbol_table.lookup(to_symbol_type(type).get_identifier());
+    const symbolt &sym =
+      symbol_table.lookup_ref(to_symbol_type(type).get_identifier());
     CHECK_RETURN(sym.type.id() != ID_symbol_type);
     return get_length_type(sym.type, symbol_table);
   }

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1756,7 +1756,7 @@ exprt value_sett::make_member(
   }
 
   // give up
-  typet subtype=struct_union_type.component_type(component_name);
+  const typet &subtype = struct_union_type.component_type(component_name);
   member_exprt member_expr(src, component_name, subtype);
 
   return member_expr;

--- a/src/util/std_types.cpp
+++ b/src/util/std_types.cpp
@@ -62,10 +62,10 @@ const struct_union_typet::componentt &struct_union_typet::get_component(
   return static_cast<const componentt &>(get_nil_irep());
 }
 
-typet struct_union_typet::component_type(
-  const irep_idt &component_name) const
+const typet &
+struct_union_typet::component_type(const irep_idt &component_name) const
 {
-  const exprt c=get_component(component_name);
+  const auto &c = get_component(component_name);
   assert(c.is_not_nil());
   return c.type();
 }

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -212,7 +212,7 @@ public:
     const irep_idt &component_name) const;
 
   std::size_t component_number(const irep_idt &component_name) const;
-  typet component_type(const irep_idt &component_name) const;
+  const typet &component_type(const irep_idt &component_name) const;
 
   irep_idt get_tag() const { return get(ID_tag); }
   void set_tag(const irep_idt &tag) { set(ID_tag, tag); }


### PR DESCRIPTION
There is no need for a copy.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
