### PR TITLE
Improve typing in cpp_typecheckt::reference_binding

### DIFF
--- a/src/cpp/cpp_typecheck_conversions.cpp
+++ b/src/cpp/cpp_typecheck_conversions.cpp
@@ -1295,25 +1295,18 @@ bool cpp_typecheckt::reference_binding(
   }
 
   // conversion operators
-  typet from_type=follow(expr.type());
+  const typet &from_type = follow(expr.type());
   if(from_type.id()==ID_struct)
   {
-    struct_typet from_struct=to_struct_type(from_type);
-
-    for(struct_typet::componentst::const_iterator
-        it=from_struct.components().begin();
-        it != from_struct.components().end(); it++)
+    for(const auto &component : to_struct_type(from_type).components())
     {
-      const irept &component=*it;
-
       if(component.get_bool(ID_from_base))
         continue;
 
       if(!component.get_bool("is_cast_operator"))
         continue;
 
-      const code_typet &component_type =
-        to_code_type(static_cast<const typet&>(component.find(ID_type)));
+      const code_typet &component_type = to_code_type(component.type());
 
       // otherwise it cannot bind directly (not an lvalue)
       if(!is_reference(component_type.return_type()))


### PR DESCRIPTION
We do not need to fall back to an irept and can make use of const references.
Furthermore the loop can use a simpler syntax by using C++11 ranged for.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
