### PR TITLE
Restrict signature of prop_conv_solvert::literal to only supported type

### DIFF
--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -37,7 +37,7 @@ bool boolbvt::literal(
   if(expr.type().id()==ID_bool)
   {
     assert(bit==0);
-    return prop_conv_solvert::literal(expr, dest);
+    return prop_conv_solvert::literal(to_symbol_expr(expr), dest);
   }
   else
   {

--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -70,8 +70,6 @@ public:
     std::size_t bit,
     literalt &literal) const;
 
-  using arrayst::literal;
-
   enum class unbounded_arrayt { U_NONE, U_ALL, U_AUTO };
   unbounded_arrayt unbounded_array;
 

--- a/src/solvers/prop/prop_conv.cpp
+++ b/src/solvers/prop/prop_conv.cpp
@@ -33,24 +33,19 @@ void prop_convt::set_frozen(const bvt &bv)
       set_frozen(bit);
 }
 
-bool prop_conv_solvert::literal(const exprt &expr, literalt &dest) const
+bool prop_conv_solvert::literal(const symbol_exprt &expr, literalt &dest) const
 {
   assert(expr.type().id()==ID_bool);
 
-  if(expr.id()==ID_symbol)
-  {
-    const irep_idt &identifier=
-      to_symbol_expr(expr).get_identifier();
+  const irep_idt &identifier = expr.get_identifier();
 
-    symbolst::const_iterator result=symbols.find(identifier);
+  symbolst::const_iterator result = symbols.find(identifier);
 
-    if(result==symbols.end())
-      return true;
-    dest=result->second;
-    return false;
-  }
+  if(result == symbols.end())
+    return true;
 
-  throw "found no literal for expression";
+  dest = result->second;
+  return false;
 }
 
 literalt prop_conv_solvert::get_literal(const irep_idt &identifier)

--- a/src/solvers/prop/prop_conv.h
+++ b/src/solvers/prop/prop_conv.h
@@ -106,7 +106,7 @@ public:
   { return prop.has_is_in_conflict(); }
 
   // get literal for expression, if available
-  virtual bool literal(const exprt &expr, literalt &literal) const;
+  bool literal(const symbol_exprt &expr, literalt &literal) const;
 
   bool use_cache = true;
   bool equality_propagation = true;


### PR DESCRIPTION
Any invocation of prop_conv_solvert::literal with an expression other than a
symbol_exprt would have resulted in an exception being thrown.

Also remove unnecessary use of virtual as there are no classes overriding it.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
