### PR TITLE
remove optiont to store subtypes in a named sub-irep

### DIFF
--- a/src/util/type.h
+++ b/src/util/type.h
@@ -15,9 +15,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "source_location.h"
 
-#define SUBTYPE_IN_GETSUB
-#define SUBTYPES_IN_GETSUB
-
 /// The type of an expression, extends irept. Types may have subtypes. This is
 /// modeled with two subs named “subtype” (a single type) and “subtypes”
 /// (a vector of types). The class typet only adds specialized methods
@@ -35,64 +32,36 @@ public:
   }
 
   const typet &subtype() const
-  #ifdef SUBTYPE_IN_GETSUB
   {
     if(get_sub().empty())
       return static_cast<const typet &>(get_nil_irep());
     return static_cast<const typet &>(get_sub().front());
   }
-  #else
-  { return (typet &)find(ID_subtype); }
-  #endif
 
   typet &subtype()
-  #ifdef SUBTYPE_IN_GETSUB
   {
     subt &sub=get_sub();
     if(sub.empty())
       sub.resize(1);
     return static_cast<typet &>(sub.front());
   }
-  #else
-  { return (typet &)add(ID_subtype); }
-  #endif
 
   typedef std::vector<typet> subtypest;
 
   subtypest &subtypes()
-  #ifdef SUBTYPES_IN_GETSUB
   { return (subtypest &)get_sub(); }
-  #else
-  { return (subtypest &)add(ID_subtypes).get_sub(); }
-  #endif
 
   const subtypest &subtypes() const
-  #ifdef SUBTYPES_IN_GETSUB
   { return (const subtypest &)get_sub(); }
-  #else
-  { return (const subtypest &)find(ID_subtypes).get_sub(); }
-  #endif
 
   bool has_subtypes() const
-  #ifdef SUBTYPES_IN_GETSUB
   { return !get_sub().empty(); }
-  #else
-  { return !find(ID_subtypes).is_nil(); }
-  #endif
 
   bool has_subtype() const
-  #ifdef SUBTYPE_IN_GETSUB
   { return !get_sub().empty(); }
-  #else
-  { return !find(ID_subtype).is_nil(); }
-  #endif
 
   void remove_subtype()
-  #ifdef SUBTYPE_IN_GETSUB
   { get_sub().clear(); }
-  #else
-  { remove(ID_subtype); }
-  #endif
 
   void move_to_subtypes(typet &type);
 


### PR DESCRIPTION
The option is controlled using a define which was introduced for performance
benchmarking in 2014.  There is no longer any consideration to revert to the
old scheme.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
