### PR TITLE
Test Pointer_byte_extract8 now passes

### DIFF
--- a/regression/cbmc/Pointer_byte_extract8/main.i
+++ b/regression/cbmc/Pointer_byte_extract8/main.i
@@ -12,14 +12,11 @@ typedef struct
   Union List[1];
 } __attribute__((packed)) Struct3;
 
-extern size_t __CPROVER_malloc_size;
-
 int main()
 {
   Struct3 *p = malloc (sizeof (int) + 2 * sizeof(Union));
   p->Count = 3;
   int po=0;
-  size_t m=__CPROVER_malloc_size;
 
   // this should be fine
   p->List[0].a = 555;

--- a/regression/cbmc/Pointer_byte_extract8/test.desc
+++ b/regression/cbmc/Pointer_byte_extract8/test.desc
@@ -1,9 +1,9 @@
-KNOWNBUG
+CORE
 main.i
 --bounds-check --32 --no-simplify
-^EXIT=0$
+^EXIT=10$
 ^SIGNAL=0$
-^\[main\.array_bounds\.5\] array.List upper bound: FAILED$
-^\*\* 1 of 9 failed 
+^\[main\.array_bounds\..*\] array.List dynamic object upper bound .*: FAILURE$
+^\*\* 1 of .* failed
 --
 ^warning: ignoring


### PR DESCRIPTION
Pointer_byte_extract8 now passes, with minor adaptation to changes
that have happened in the meantime.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
