### PR TITLE
Move is_class and default_access to struct_union_typet

### DIFF
--- a/src/cpp/cpp_typecheck_bases.cpp
+++ b/src/cpp/cpp_typecheck_bases.cpp
@@ -18,8 +18,7 @@ void cpp_typecheckt::typecheck_compound_bases(struct_typet &type)
   std::set<irep_idt> bases;
   std::set<irep_idt> vbases;
 
-  irep_idt default_class_access=
-    type.get_bool(ID_C_class)?ID_private:ID_public;
+  irep_idt default_class_access = type.default_access();
 
   irept::subt &bases_irep=type.add(ID_bases).get_sub();
 

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -977,8 +977,7 @@ void cpp_typecheckt::typecheck_compound_body(symbolt &symbol)
   symbol.type.set(ID_name, symbol.name);
 
   // default access
-  irep_idt access=
-    type.get_bool(ID_C_class)?ID_private:ID_public;
+  irep_idt access = type.default_access();
 
   bool found_ctor=false;
   bool found_dtor=false;
@@ -1119,8 +1118,7 @@ void cpp_typecheckt::typecheck_compound_body(symbolt &symbol)
   }
 
   // Reset the access type
-  access=
-    type.get_bool(ID_C_class)?ID_private:ID_public;
+  access = type.default_access();
 
   // All the data members are now known.
   // We now deal with the constructors that we are given.

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -216,6 +216,19 @@ public:
 
   irep_idt get_tag() const { return get(ID_tag); }
   void set_tag(const irep_idt &tag) { set(ID_tag, tag); }
+
+  /// A struct may be a class, where members may have access restrictions.
+  bool is_class() const
+  {
+    return id() == ID_struct && get_bool(ID_C_class);
+  }
+
+  /// Return the access specification for members where access has not been
+  /// modified.
+  irep_idt default_access() const
+  {
+    return is_class() ? ID_private : ID_public;
+  }
 };
 
 /// Check whether a reference to a typet is a \ref struct_union_typet.
@@ -311,16 +324,6 @@ public:
   componentst &methods()
   {
     return (methodst &)(add(ID_methods).get_sub());
-  }
-
-  bool is_class() const
-  {
-    return get_bool(ID_C_class);
-  }
-
-  irep_idt default_access() const
-  {
-    return is_class()?ID_private:ID_public;
   }
 
   class baset:public exprt


### PR DESCRIPTION
A class_typet would always return true for is_class() and ID_private for
default_access(). Only when available for both a struct_typet and a
class_typet do they enable non-trivial use.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
