### PR TITLE
Do not use redundant comparison with true or false

### DIFF
--- a/jbmc/src/java_bytecode/java_static_initializers.cpp
+++ b/jbmc/src/java_bytecode/java_static_initializers.cpp
@@ -656,7 +656,7 @@ codet get_clinit_wrapper_body(
   //
   // java::C::clinit_wrapper()
   // {
-  //   if (java::C::clinit_already_run == false)
+  //   if (!java::C::clinit_already_run)
   //   {
   //     java::C::clinit_already_run = true; // before recursive calls!
   //

--- a/src/cpp/cpp_typecheck_code.cpp
+++ b/src/cpp/cpp_typecheck_code.cpp
@@ -256,9 +256,10 @@ void cpp_typecheckt::typecheck_member_initializer(codet &code)
   else
   {
     // a reference member
-    if(symbol_expr.id() == ID_dereference &&
-       symbol_expr.op0().id() == ID_member &&
-       symbol_expr.get_bool(ID_C_implicit))
+    if(
+      symbol_expr.id() == ID_dereference &&
+      symbol_expr.op0().id() == ID_member &&
+      symbol_expr.get_bool(ID_C_implicit))
     {
       // treat references as normal pointers
       exprt tmp = symbol_expr.op0();
@@ -284,9 +285,10 @@ void cpp_typecheckt::typecheck_member_initializer(codet &code)
         symbol_expr=resolve(member, cpp_typecheck_resolvet::wantt::VAR, fargs);
       }
 
-      if(symbol_expr.id() == ID_dereference &&
-         symbol_expr.op0().id() == ID_member &&
-         symbol_expr.get_bool(ID_C_implicit))
+      if(
+        symbol_expr.id() == ID_dereference &&
+        symbol_expr.op0().id() == ID_member &&
+        symbol_expr.get_bool(ID_C_implicit))
       {
         // treat references as normal pointers
         exprt tmp = symbol_expr.op0();

--- a/src/cpp/cpp_typecheck_code.cpp
+++ b/src/cpp/cpp_typecheck_code.cpp
@@ -258,7 +258,7 @@ void cpp_typecheckt::typecheck_member_initializer(codet &code)
     // a reference member
     if(symbol_expr.id() == ID_dereference &&
        symbol_expr.op0().id() == ID_member &&
-       symbol_expr.get_bool(ID_C_implicit) == true)
+       symbol_expr.get_bool(ID_C_implicit))
     {
       // treat references as normal pointers
       exprt tmp = symbol_expr.op0();
@@ -286,7 +286,7 @@ void cpp_typecheckt::typecheck_member_initializer(codet &code)
 
       if(symbol_expr.id() == ID_dereference &&
          symbol_expr.op0().id() == ID_member &&
-         symbol_expr.get_bool(ID_C_implicit) == true)
+         symbol_expr.get_bool(ID_C_implicit))
       {
         // treat references as normal pointers
         exprt tmp = symbol_expr.op0();

--- a/src/cpp/cpp_typecheck_conversions.cpp
+++ b/src/cpp/cpp_typecheck_conversions.cpp
@@ -1643,7 +1643,7 @@ bool cpp_typecheckt::const_typecast(
   const typet &type,
   exprt &new_expr)
 {
-  assert(is_reference(expr.type())==false);
+  PRECONDITION(!is_reference(expr.type()));
 
   exprt curr_expr=expr;
 

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -4102,7 +4102,7 @@ void smt2_convt::set_to(const exprt &expr, bool value)
   // special treatment for "set_to(a=b, true)" where
   // a is a new symbol
 
-  if(expr.id()==ID_equal && value==true)
+  if(expr.id() == ID_equal && value)
   {
     const equal_exprt &equal_expr=to_equal_expr(expr);
 

--- a/unit/util/optional.cpp
+++ b/unit/util/optional.cpp
@@ -12,7 +12,7 @@
 TEST_CASE("Optional without a value", "[core][util][optional]")
 {
   optionalt<bool> maybe_value;
-  REQUIRE(maybe_value.has_value()==false);
+  REQUIRE(!maybe_value.has_value());
   REQUIRE_THROWS_AS(maybe_value.value(), bad_optional_accesst);
 }
 
@@ -20,7 +20,7 @@ TEST_CASE("Optional with a value", "[core][util][optional]")
 {
   optionalt<bool> maybe_value=false;
   REQUIRE(maybe_value.has_value());
-  REQUIRE(maybe_value.value()==false);
+  REQUIRE(!maybe_value.value());
 }
 
 
@@ -28,5 +28,5 @@ TEST_CASE("Optional with a value (operator access)", "[core][util][optional]")
 {
   optionalt<bool> maybe_value=true;
   REQUIRE(maybe_value.has_value());
-  REQUIRE(*maybe_value==true);
+  REQUIRE(*maybe_value);
 }

--- a/unit/util/replace_symbol.cpp
+++ b/unit/util/replace_symbol.cpp
@@ -41,7 +41,6 @@ TEST_CASE("Replace all symbols in expression", "[core][util][replace_symbol]")
   REQUIRE(r.replace(s2));
   REQUIRE(s2 == symbol_exprt("b", typet("some_type")));
 
-
   REQUIRE(!r.replace(array_type));
   REQUIRE(array_type.size() == other_expr);
 

--- a/unit/util/replace_symbol.cpp
+++ b/unit/util/replace_symbol.cpp
@@ -32,17 +32,17 @@ TEST_CASE("Replace all symbols in expression", "[core][util][replace_symbol]")
   REQUIRE(r.replaces_symbol("a"));
   REQUIRE(r.get_expr_map().size() == 1);
 
-  REQUIRE(r.replace(binary) == false);
+  REQUIRE(!r.replace(binary));
   REQUIRE(binary.op0() == other_expr);
 
-  REQUIRE(r.replace(s1) == false);
+  REQUIRE(!r.replace(s1));
   REQUIRE(s1 == other_expr);
 
-  REQUIRE(r.replace(s2) == true);
+  REQUIRE(r.replace(s2));
   REQUIRE(s2 == symbol_exprt("b", typet("some_type")));
 
 
-  REQUIRE(r.replace(array_type) == false);
+  REQUIRE(!r.replace(array_type));
   REQUIRE(array_type.size() == other_expr);
 
   REQUIRE(r.erase("a") == 1);
@@ -65,7 +65,7 @@ TEST_CASE("Lvalue only", "[core][util][replace_symbol]")
   address_of_aware_replace_symbolt r;
   r.insert(s1, c);
 
-  REQUIRE(r.replace(binary) == false);
+  REQUIRE(!r.replace(binary));
   REQUIRE(binary.op0() == address_of_exprt(s1));
   const index_exprt &index_expr =
     to_index_expr(to_address_of_expr(binary.op1()).object());
@@ -76,7 +76,7 @@ TEST_CASE("Lvalue only", "[core][util][replace_symbol]")
   r.erase("a");
   r.insert(s1, address_of);
 
-  REQUIRE(r.replace(binary) == true);
+  REQUIRE(r.replace(binary));
   REQUIRE(binary.op0() == address_of_exprt(s1));
 }
 
@@ -96,7 +96,7 @@ TEST_CASE("Replace always", "[core][util][replace_symbol]")
   unchecked_replace_symbolt r;
   r.insert(s1, c);
 
-  REQUIRE(r.replace(binary) == false);
+  REQUIRE(!r.replace(binary));
   REQUIRE(binary.op0() == address_of_exprt(c));
   const index_exprt &index_expr =
     to_index_expr(to_address_of_expr(binary.op1()).object());


### PR DESCRIPTION
We generally don't do so, and using it in selected places is an unnecessary surprise to the (code) reader.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
