### PR TITLE
Change order of parameters in invariant_violated_string constructor

### DIFF
--- a/regression/invariants/invariant-failure/test.desc
+++ b/regression/invariants/invariant-failure/test.desc
@@ -7,6 +7,8 @@ string
 Test invariant failure
 Invariant check failed
 ^(Backtrace)|(Backtraces not supported)$
+^Condition: false$
+^Reason: Test invariant failure$
 --
 ^warning: ignoring
 ^VERIFICATION SUCCESSFUL$

--- a/src/util/invariant.h
+++ b/src/util/invariant.h
@@ -382,7 +382,7 @@ CBMC_NORETURN void report_invariant_failure(
     if(!(CONDITION))                                                           \
     {                                                                          \
       invariant_violated_string(                                               \
-        __FILE__, CURRENT_FUNCTION_NAME, __LINE__, REASON, #CONDITION);        \
+        __FILE__, CURRENT_FUNCTION_NAME, __LINE__, #CONDITION, REASON);        \
     }                                                                          \
   } while(false)
 


### PR DESCRIPTION
This is a trivial change, fixing a small regression introduced during a previous refactoring. Without it you get the wrong condition and reason when an invariant is getting triggered, like this:

```
Condition: true case of to_if_expr should be of same type as false case
Reason: expr.op1().type() == expr.op2().type()
```

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.