### PR TITLE
introduce merged_typet

### DIFF
--- a/src/ansi-c/ansi_c_declaration.cpp
+++ b/src/ansi-c/ansi_c_declaration.cpp
@@ -18,6 +18,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/std_types.h>
 #include <util/invariant.h>
 
+#include "merged_type.h"
+
 void ansi_c_declaratort::build(irept &src)
 {
   typet *p=static_cast<typet *>(&src);
@@ -47,8 +49,8 @@ void ansi_c_declaratort::build(irept &src)
     else if(t.id()==ID_merged_type)
     {
       // we always walk down the _last_ member of a merged type
-      assert(!t.subtypes().empty());
-      p=&(t.subtypes().back());
+      auto &merged_type = to_merged_type(t);
+      p = &merged_type.last_type();
     }
     else
       p=&t.subtype();
@@ -105,8 +107,8 @@ typet ansi_c_declarationt::full_type(
     else if(p->id()==ID_merged_type)
     {
       // we always go down on the right-most subtype
-      assert(!p->subtypes().empty());
-      p=&(p->subtypes().back());
+      auto &merged_type = to_merged_type(*p);
+      p = &merged_type.last_type();
     }
     else
       UNREACHABLE;

--- a/src/ansi-c/merged_type.h
+++ b/src/ansi-c/merged_type.h
@@ -1,0 +1,48 @@
+/*******************************************************************\
+
+Module: A type that holds a combination of types
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_ANSI_C_MERGED_TYPE_H
+#define CPROVER_ANSI_C_MERGED_TYPE_H
+
+#include <util/type.h>
+
+/// holds a combination of types
+class merged_typet : public type_with_subtypest
+{
+public:
+  merged_typet() : type_with_subtypest(ID_merged_type)
+  {
+  }
+
+  typet &last_type()
+  {
+    return subtypes().back();
+  }
+};
+
+/// conversion to merged_typet
+inline const merged_typet &to_merged_type(const typet &type)
+{
+  PRECONDITION(type.id() == ID_merged_type);
+  DATA_INVARIANT(
+    !static_cast<const type_with_subtypest &>(type).subtypes().empty(),
+    "merge_typet has at least one subtype");
+  return static_cast<const merged_typet &>(type);
+}
+
+/// conversion to merged_typet
+inline merged_typet &to_merged_type(typet &type)
+{
+  PRECONDITION(type.id() == ID_merged_type);
+  DATA_INVARIANT(
+    !static_cast<const type_with_subtypest &>(type).subtypes().empty(),
+    "merge_typet has at least one subtype");
+  return static_cast<merged_typet &>(type);
+}
+
+#endif // CPROVER_ANSI_C_MERGED_TYPE_H

--- a/src/ansi-c/parser_static.inc
+++ b/src/ansi-c/parser_static.inc
@@ -4,6 +4,8 @@
 #include <util/std_expr.h>
 #include <util/string2int.h>
 
+#include "merged_type.h"
+
 #define YYSTYPE unsigned
 #define YYSTYPE_IS_TRIVIAL 1
 
@@ -115,7 +117,7 @@ static void merge_types(irept &dest, irept &src)
   if(dest.id()!=ID_merged_type)
   {
     source_locationt location=static_cast<const exprt &>(dest).source_location();
-    typet new_type(ID_merged_type);
+    merged_typet new_type;
     new_type.move_to_subtypes((typet &)(dest));
     dest.swap(new_type);
     static_cast<exprt &>(dest).add_source_location()=location;
@@ -203,8 +205,8 @@ static void make_subtype(typet &dest, typet &src)
     if(p->id()==ID_merged_type)
     {
       // do last one
-      assert(!p->subtypes().empty());
-      sub=&(p->subtypes().back());
+      auto &merged_type = to_merged_type(*p);
+      sub = &merged_type.last_type();
     }
 
     if(sub->id()==ID_frontend_pointer ||
@@ -243,8 +245,8 @@ static void make_subtype(typet &dest, typet &src)
           }
           else if(p->id()==ID_merged_type)
           {
-            assert(!p->subtypes().empty());
-            p=&(p->subtypes().back());
+            auto &merged_type = to_merged_type(*p);
+            p=&merged_type.last_type();
           }
           else if(p->id()==irep_idt())
             assert(false);

--- a/src/cpp/cpp_declarator.cpp
+++ b/src/cpp/cpp_declarator.cpp
@@ -11,6 +11,8 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "cpp_declarator.h"
 
+#include <ansi-c/merged_type.h>
+
 #include <ostream>
 #include <cassert>
 
@@ -44,8 +46,8 @@ typet cpp_declaratort::merge_type(const typet &declaration_type) const
     else if(t.id()==ID_merged_type)
     {
       // the chain continues with the last one
-      assert(!t.subtypes().empty());
-      p=&t.subtypes().back();
+      auto &merged_type = to_merged_type(t);
+      p = &merged_type.last_type();
     }
     else
     {

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -26,6 +26,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <util/string_constant.h>
 
 #include <ansi-c/anonymous_member.h>
+#include <ansi-c/merged_type.h>
 
 #include "cpp_typecheck.h"
 #include "cpp_template_type.h"
@@ -1892,12 +1893,9 @@ void cpp_typecheck_resolvet::guess_template_args(
   else if(template_type.id()==ID_merged_type)
   {
     // look at subtypes
-    for(typet::subtypest::const_iterator
-        it=template_type.subtypes().begin();
-        it!=template_type.subtypes().end();
-        it++)
+    for(const auto &t : to_merged_type(template_type).subtypes())
     {
-      guess_template_args(*it, desired_type);
+      guess_template_args(t, desired_type);
     }
   }
   else if(is_reference(template_type) ||

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -14,13 +14,14 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <cassert>
 #include <map>
 
+#include <util/c_types.h>
 #include <util/expr.h>
 #include <util/std_code.h>
 #include <util/std_expr.h>
 #include <util/std_types.h>
 
 #include <ansi-c/ansi_c_y.tab.h>
-#include <util/c_types.h>
+#include <ansi-c/merged_type.h>
 
 #include "cpp_token_buffer.h"
 #include "cpp_member_spec.h"
@@ -401,8 +402,8 @@ protected:
     {
       if(p->id()==ID_merged_type)
       {
-        assert(!p->subtypes().empty());
-        p=&p->subtypes().back();
+        auto &merged_type = to_merged_type(*p);
+        p = &merged_type.last_type();
       }
       else
         p=&p->subtype();
@@ -470,7 +471,7 @@ void Parser::merge_types(const typet &src, typet &dest)
     if(dest.id()!=ID_merged_type)
     {
       source_locationt location=dest.source_location();
-      typet tmp(ID_merged_type);
+      merged_typet tmp;
       tmp.move_to_subtypes(dest);
       tmp.add_source_location()=location;
       dest=tmp;
@@ -481,7 +482,6 @@ void Parser::merge_types(const typet &src, typet &dest)
     // merged_types
     typet::subtypest &sub=dest.subtypes();
     sub.emplace(sub.begin(), src);
-    POSTCONDITION(!dest.subtypes().empty());
   }
 }
 
@@ -3344,8 +3344,8 @@ bool Parser::optPtrOperator(typet &ptrs)
   {
     if(it->id()==ID_merged_type)
     {
-      assert(!it->subtypes().empty());
-      it->subtypes().back().subtype().swap(ptrs);
+      auto &merged_type = to_merged_type(*it);
+      merged_type.last_type().subtype().swap(ptrs);
     }
     else
     {


### PR DESCRIPTION
This replaces direct accesses to typet::subtypes(), thereby increasing type
safety.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
