### PR TITLE
Use cpp_namet's and namet's constructors

### DIFF
--- a/src/cpp/cpp_constructor.cpp
+++ b/src/cpp/cpp_constructor.cpp
@@ -228,14 +228,10 @@ optionalt<codet> cpp_typecheckt::cpp_constructor(
     // there is always a constructor for non-PODs
     assert(constructor_name!="");
 
-    irept cpp_name(ID_cpp_name);
-    cpp_name.get_sub().push_back(irept(ID_name));
-    cpp_name.get_sub().back().set(ID_identifier, constructor_name);
-    cpp_name.get_sub().back().set(ID_C_source_location, source_location);
-
     side_effect_expr_function_callt function_call;
     function_call.add_source_location()=source_location;
-    function_call.function().swap(static_cast<exprt&>(cpp_name));
+    function_call.function() =
+      cpp_namet(constructor_name, source_location).as_expr();
     function_call.arguments().reserve(operands_tc.size());
 
     for(exprt::operandst::iterator

--- a/src/cpp/cpp_declarator_converter.cpp
+++ b/src/cpp/cpp_declarator_converter.cpp
@@ -45,8 +45,7 @@ symbolt &cpp_declarator_convertert::convert(
     type.swap(declarator.name().get_sub().back());
     declarator.type().subtype()=type;
     cpp_typecheck.typecheck_type(type);
-    irept name(ID_name);
-    name.set(ID_identifier, "("+cpp_type2name(type)+")");
+    cpp_namet::namet name("(" + cpp_type2name(type) + ")");
     declarator.name().get_sub().back().swap(name);
   }
 

--- a/src/cpp/cpp_destructor.cpp
+++ b/src/cpp/cpp_destructor.cpp
@@ -102,10 +102,7 @@ optionalt<codet> cpp_typecheckt::cpp_destructor(
     // there is always a destructor for non-PODs
     assert(dtor_name!="");
 
-    irept cpp_name(ID_cpp_name);
-    cpp_name.get_sub().push_back(irept(ID_name));
-    cpp_name.get_sub().back().set(ID_identifier, dtor_name);
-    cpp_name.get_sub().back().set(ID_C_source_location, source_location);
+    cpp_namet cpp_name(dtor_name, source_location);
 
     exprt member(ID_member);
     member.add(ID_component_cpp_name) = cpp_name;

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -301,8 +301,7 @@ void cpp_typecheckt::typecheck_compound_declarator(
     typet type=static_cast<typet &>(declarator.name().get_sub()[1]);
     declarator.type().subtype()=type;
 
-    irept name(ID_name);
-    name.set(ID_identifier, "("+cpp_type2name(type)+")");
+    cpp_namet::namet name("(" + cpp_type2name(type) + ")");
     declarator.name().get_sub().back().swap(name);
   }
 

--- a/src/cpp/cpp_typecheck_conversions.cpp
+++ b/src/cpp/cpp_typecheck_conversions.cpp
@@ -1087,10 +1087,7 @@ bool cpp_typecheckt::user_defined_conversion_sequence(
       {
         // To take care of the possible virtual case,
         // we build the function as a member expression.
-        irept func_name(ID_name);
-        func_name.set(ID_identifier, component.get_base_name());
-        cpp_namet cpp_func_name;
-        cpp_func_name.get_sub().push_back(func_name);
+        const cpp_namet cpp_func_name(component.get_base_name());
 
         exprt member_func(ID_member);
         member_func.add(ID_component_cpp_name)=cpp_func_name;
@@ -1318,10 +1315,7 @@ bool cpp_typecheckt::reference_binding(
       {
         // To take care of the possible virtual case,
         // we build the function as a member expression.
-        irept func_name(ID_name);
-        func_name.set(ID_identifier, component.get_base_name());
-        cpp_namet cpp_func_name;
-        cpp_func_name.get_sub().push_back(func_name);
+        const cpp_namet cpp_func_name(component.get_base_name());
 
         exprt member_func(ID_member);
         member_func.add(ID_component_cpp_name)=cpp_func_name;

--- a/src/cpp/cpp_typecheck_declaration.cpp
+++ b/src/cpp/cpp_typecheck_declaration.cpp
@@ -41,12 +41,7 @@ void cpp_typecheckt::convert_anonymous_union(
   // unnamed object
   std::string identifier="#anon_union"+std::to_string(anon_counter++);
 
-  irept name(ID_name);
-  name.set(ID_identifier, identifier);
-  name.set(ID_C_source_location, declaration.source_location());
-
-  cpp_namet cpp_name;
-  cpp_name.move_to_sub(name);
+  const cpp_namet cpp_name(identifier, declaration.source_location());
   cpp_declaratort declarator;
   declarator.name()=cpp_name;
 

--- a/src/cpp/cpp_typecheck_destructor.cpp
+++ b/src/cpp/cpp_typecheck_destructor.cpp
@@ -32,14 +32,8 @@ void cpp_typecheckt::default_dtor(
   assert(symbol.type.id()==ID_struct ||
          symbol.type.id()==ID_union);
 
-  irept name;
-  name.id(ID_name);
-  name.set(ID_identifier, "~"+id2string(symbol.base_name));
-  name.set(ID_C_source_location, symbol.location);
-
   cpp_declaratort decl;
-  decl.name().id(ID_cpp_name);
-  decl.name().move_to_sub(name);
+  decl.name() = cpp_namet("~" + id2string(symbol.base_name), symbol.location);
   decl.type().id(ID_function_type);
   decl.type().subtype().make_nil();
 
@@ -78,11 +72,7 @@ codet cpp_typecheckt::dtor(const symbolt &symbol)
   {
     if(c.get_bool(ID_is_vtptr))
     {
-      exprt name(ID_name);
-      name.set(ID_identifier, c.get_base_name());
-
-      cpp_namet cppname;
-      cppname.move_to_sub(name);
+      const cpp_namet cppname(c.get_base_name());
 
       const symbolt &virtual_table_symbol_type =
         lookup(c.type().subtype().get(ID_identifier));
@@ -123,12 +113,7 @@ codet cpp_typecheckt::dtor(const symbolt &symbol)
        cpp_is_pod(type))
       continue;
 
-    irept name(ID_name);
-    name.set(ID_identifier, cit->get_base_name());
-    name.set(ID_C_source_location, source_location);
-
-    cpp_namet cppname;
-    cppname.get_sub().push_back(name);
+    const cpp_namet cppname(cit->get_base_name(), source_location);
 
     exprt member(ID_ptrmember, type);
     member.set(ID_component_cpp_name, cppname);

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -391,15 +391,9 @@ void cpp_typecheckt::typecheck_function_expr(
       function_call.add_source_location()=expr.source_location();
 
       // first do function/operator
-      cpp_namet cpp_name;
-      cpp_name.get_sub().push_back(irept(ID_name));
-      cpp_name.get_sub().back().set(ID_identifier, op_name);
-      cpp_name.get_sub().back().add(ID_C_source_location)=
-        expr.source_location();
+      const cpp_namet cpp_name(op_name, expr.source_location());
 
-      function_call.function()=
-        static_cast<const exprt &>(
-          static_cast<const irept &>(cpp_name));
+      function_call.function() = cpp_name.as_expr();
 
       // now do the argument
       function_call.arguments().push_back(expr.op0());
@@ -500,10 +494,7 @@ bool cpp_typecheckt::operator_is_overloaded(exprt &expr)
     function_call.arguments().reserve(expr.operands().size());
     function_call.add_source_location()=expr.source_location();
 
-    cpp_namet cpp_name;
-    cpp_name.get_sub().push_back(irept(ID_name));
-    cpp_name.get_sub().back().set(ID_identifier, op_name);
-    cpp_name.get_sub().back().add(ID_C_source_location)=expr.source_location();
+    const cpp_namet cpp_name(op_name, expr.source_location());
 
     // See if the struct declares the cast operator as a member
     bool found_in_struct=false;
@@ -572,11 +563,7 @@ bool cpp_typecheckt::operator_is_overloaded(exprt &expr)
       std::string op_name=std::string("operator")+e->op_name;
 
       // first do function/operator
-      cpp_namet cpp_name;
-      cpp_name.get_sub().push_back(irept(ID_name));
-      cpp_name.get_sub().back().set(ID_identifier, op_name);
-      cpp_name.get_sub().back().add(ID_C_source_location)=
-        expr.source_location();
+      const cpp_namet cpp_name(op_name, expr.source_location());
 
       // turn this into a function call
       side_effect_expr_function_callt function_call;
@@ -2120,12 +2107,7 @@ void cpp_typecheckt::typecheck_side_effect_function_call(
   }
   else if(expr.function().type().id()==ID_struct)
   {
-    irept name(ID_name);
-    name.set(ID_identifier, "operator()");
-    name.set(ID_C_source_location, expr.source_location());
-
-    cpp_namet cppname;
-    cppname.get_sub().push_back(name);
+    const cpp_namet cppname("operator()", expr.source_location());
 
     exprt member(ID_member);
     member.add(ID_component_cpp_name)=cppname;
@@ -2502,10 +2484,7 @@ void cpp_typecheckt::typecheck_side_effect_assignment(side_effect_exprt &expr)
     throw 0;
   }
 
-  cpp_namet cpp_name;
-  cpp_name.get_sub().push_back(irept(ID_name));
-  cpp_name.get_sub().front().set(ID_identifier, strop);
-  cpp_name.get_sub().front().set(ID_C_source_location, expr.source_location());
+  const cpp_namet cpp_name(strop, expr.source_location());
 
   // expr.op0() is already typechecked
   exprt already_typechecked(ID_already_typechecked);
@@ -2576,10 +2555,7 @@ void cpp_typecheckt::typecheck_side_effect_inc_dec(
     throw 0;
   }
 
-  cpp_namet cpp_name;
-  cpp_name.get_sub().push_back(irept(ID_name));
-  cpp_name.get_sub().front().set(ID_identifier, str_op);
-  cpp_name.get_sub().front().set(ID_C_source_location, expr.source_location());
+  const cpp_namet cpp_name(str_op, expr.source_location());
 
   exprt already_typechecked(ID_already_typechecked);
   already_typechecked.move_to_operands(expr.op0());

--- a/src/cpp/cpp_typecheck_initializer.cpp
+++ b/src/cpp/cpp_typecheck_initializer.cpp
@@ -268,12 +268,7 @@ void cpp_typecheckt::zero_initializer(
 
     if(max_comp_size>0)
     {
-      irept name(ID_name);
-      name.set(ID_identifier, comp.get_base_name());
-      name.set(ID_C_source_location, source_location);
-
-      cpp_namet cpp_name;
-      cpp_name.move_to_sub(name);
+      const cpp_namet cpp_name(comp.get_base_name(), source_location);
 
       exprt member(ID_member);
       member.copy_to_operands(object);

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -886,7 +886,6 @@ cpp_scopet &cpp_typecheck_resolvet::resolve_scope(
   irep_idt &base_name,
   cpp_template_args_non_tct &template_args)
 {
-  assert(cpp_name.id()==ID_cpp_name);
   assert(!cpp_name.get_sub().empty());
 
   original_scope=&cpp_typecheck.cpp_scopes.current_scope();

--- a/src/cpp/cpp_typecheck_template.cpp
+++ b/src/cpp/cpp_typecheck_template.cpp
@@ -209,7 +209,7 @@ void cpp_typecheckt::typecheck_function_template(
   assert(declaration.declarators().size()==1);
 
   cpp_declaratort &declarator=declaration.declarators()[0];
-  const cpp_namet &cpp_name=to_cpp_name(declarator.add(ID_name));
+  const cpp_namet &cpp_name = declarator.name();
 
   // do template arguments
   // this also sets up the template scope
@@ -312,7 +312,7 @@ void cpp_typecheckt::typecheck_class_template_member(
   assert(declaration.declarators().size()==1);
 
   cpp_declaratort &declarator=declaration.declarators()[0];
-  const cpp_namet &cpp_name=to_cpp_name(declarator.add(ID_name));
+  const cpp_namet &cpp_name = declarator.name();
 
   assert(cpp_name.is_qualified() ||
          cpp_name.has_template_args());
@@ -755,12 +755,7 @@ cpp_scopet &cpp_typecheckt::typecheck_template_parameters(
 
     // it may be anonymous
     if(declarator.name().is_nil())
-    {
-      irept name(ID_name);
-      name.set(ID_identifier, "anon#"+std::to_string(++anon_count));
-      declarator.name()=cpp_namet();
-      declarator.name().get_sub().push_back(name);
-    }
+      declarator.name() = cpp_namet("anon#" + std::to_string(++anon_count));
 
     #if 1
     // The declarator needs to be just a name
@@ -1070,7 +1065,7 @@ void cpp_typecheckt::convert_template_declaration(
     assert(declaration.declarators().size()>=1);
 
     cpp_declaratort &declarator=declaration.declarators()[0];
-    const cpp_namet &cpp_name=to_cpp_name(declarator.add(ID_name));
+    const cpp_namet &cpp_name = declarator.name();
 
     if(cpp_name.is_qualified() ||
        cpp_name.has_template_args())

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -1186,15 +1186,11 @@ bool Parser::rTempArgDeclaration(cpp_declarationt &declaration)
 
     if(lex.LookAhead(0) == TOK_IDENTIFIER)
     {
-      cpp_namet cpp_name;
       cpp_tokent tk2;
       lex.get_token(tk2);
 
-      exprt name(ID_name);
-      name.set(ID_identifier, tk2.data.get(ID_C_base_name));
-      set_location(name, tk2);
-      cpp_name.get_sub().push_back(name);
-      declarator.name().swap(cpp_name);
+      declarator.name() = cpp_namet(tk2.data.get(ID_C_base_name));
+      set_location(declarator.name(), tk2);
 
       add_id(declarator.name(), new_scopet::kindt::TYPE_TEMPLATE_PARAMETER);
 
@@ -3549,8 +3545,7 @@ bool Parser::rName(irept &name)
       std::cout << std::string(__indent, ' ') << "Parser::rName 5\n";
       #endif
       lex.get_token(tk);
-      components.push_back(irept(ID_name));
-      components.back().set(ID_identifier, tk.data.get(ID_C_base_name));
+      components.push_back(cpp_namet::namet(tk.data.get(ID_C_base_name)));
       set_location(components.back(), tk);
 
       {
@@ -3814,8 +3809,7 @@ bool Parser::rPtrToMember(irept &ptr_to_mem)
 
     case TOK_IDENTIFIER:
       lex.get_token(tk);
-      components.push_back(irept(ID_name));
-      components.back().set(ID_identifier, tk.data.get(ID_C_base_name));
+      components.push_back(cpp_namet::namet(tk.data.get(ID_C_base_name)));
       set_location(components.back(), tk);
 
       {
@@ -6930,7 +6924,7 @@ bool Parser::rVarNameCore(exprt &name)
   std::cout << std::string(__indent, ' ') << "Parser::rVarNameCore 0\n";
   #endif
 
-  name=exprt(ID_cpp_name);
+  name = cpp_namet().as_expr();
   irept::subt &components=name.get_sub();
 
   if(lex.LookAhead(0)==TOK_TYPENAME)
@@ -6979,8 +6973,7 @@ bool Parser::rVarNameCore(exprt &name)
       #endif
 
       lex.get_token(tk);
-      components.push_back(irept(ID_name));
-      components.back().set(ID_identifier, tk.data.get(ID_C_base_name));
+      components.push_back(cpp_namet::namet(tk.data.get(ID_C_base_name)));
       set_location(components.back(), tk);
 
       // may be followed by template arguments
@@ -7817,12 +7810,7 @@ bool Parser::rTryStatement(codet &statement)
       assert(declaration.declarators().size()==1);
 
       if(declaration.declarators().front().name().is_nil())
-      {
-        irept name(ID_name);
-        name.set(ID_identifier, "#anon");
-        declaration.declarators().front().name()=cpp_namet();
-        declaration.declarators().front().name().get_sub().push_back(name);
-      }
+        declaration.declarators().front().name() = cpp_namet("#anon");
 
       codet code_decl;
       code_decl.set_statement(ID_decl);


### PR DESCRIPTION
Constructing the underlying irept manually is error-prone. Also don't
reduandantly assert that a cpp_namet has id() == ID_cpp_name.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
