### PR TITLE
Move class_typet::baset to struct_typet

### DIFF
--- a/src/cpp/cpp_declarator_converter.cpp
+++ b/src/cpp/cpp_declarator_converter.cpp
@@ -152,20 +152,16 @@ symbolt &cpp_declarator_convertert::convert(
 
       irep_idt identifier=symbol_expr.type().get(ID_identifier);
       const symbolt &symb=cpp_typecheck.lookup(identifier);
-      const typet &type = symb.type;
-      assert(type.id()==ID_struct);
+      const struct_typet &type = to_struct_type(symb.type);
 
       if(declarator.find(ID_member_initializers).is_nil())
         declarator.set(ID_member_initializers, ID_member_initializers);
 
       cpp_typecheck.check_member_initializers(
-        type.find(ID_bases),
-        to_struct_type(type).components(),
-        declarator.member_initializers());
+        type.bases(), type.components(), declarator.member_initializers());
 
       cpp_typecheck.full_member_initialization(
-        to_struct_type(type),
-        declarator.member_initializers());
+        type, declarator.member_initializers());
     }
 
     if(!storage_spec.is_extern())

--- a/src/cpp/cpp_exception_id.cpp
+++ b/src/cpp/cpp_exception_id.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include "cpp_exception_id.h"
 
 #include <util/invariant.h>
+#include <util/std_types.h>
 
 /// turns a type into a list of relevant exception IDs
 void cpp_exception_list_rec(
@@ -48,13 +49,8 @@ void cpp_exception_list_rec(
     dest.push_back("struct_"+src.get_string(ID_tag));
 
     // now do any bases, recursively
-    const irept::subt &bases=src.find(ID_bases).get_sub();
-
-    forall_irep(it, bases)
-    {
-      const typet &type=static_cast<const typet &>(it->find(ID_type));
-      cpp_exception_list_rec(type, ns, suffix, dest);
-    }
+    for(const auto &b : to_struct_type(src).bases())
+      cpp_exception_list_rec(b.type(), ns, suffix, dest);
   }
   else
   {

--- a/src/cpp/cpp_typecheck.h
+++ b/src/cpp/cpp_typecheck.h
@@ -262,7 +262,7 @@ protected:
   codet dtor(const symbolt &symb);
 
   void check_member_initializers(
-    const irept &bases,
+    const struct_typet::basest &bases,
     const struct_typet::componentst &components,
     const irept &initializers);
 

--- a/src/cpp/cpp_typecheck_bases.cpp
+++ b/src/cpp/cpp_typecheck_bases.cpp
@@ -141,19 +141,18 @@ void cpp_typecheckt::add_base_components(
     vbases.insert(from_name);
 
   // look at the the parents of the base type
-  forall_irep(it, from.find(ID_bases).get_sub())
+  for(const auto &b : from.bases())
   {
-    irep_idt sub_access=it->get(ID_access);
+    irep_idt sub_access = b.get(ID_access);
 
     if(access==ID_private)
       sub_access=ID_private;
     else if(access==ID_protected && sub_access!=ID_private)
       sub_access=ID_protected;
 
-    const symbolt &symb=
-      lookup(it->find(ID_type).get(ID_identifier));
+    const symbolt &symb = lookup(to_symbol_type(b.type()).get_identifier());
 
-    bool is_virtual=it->get_bool(ID_virtual);
+    const bool is_virtual = b.get_bool(ID_virtual);
 
     // recursive call
     add_base_components(

--- a/src/cpp/cpp_typecheck_destructor.cpp
+++ b/src/cpp/cpp_typecheck_destructor.cpp
@@ -130,17 +130,18 @@ codet cpp_typecheckt::dtor(const symbolt &symbol)
       block.move_to_operands(dtor_code.value());
   }
 
-  const irept::subt &bases=symbol.type.find(ID_bases).get_sub();
+  if(symbol.type.id() == ID_union)
+    return block;
+
+  const auto &bases = to_struct_type(symbol.type).bases();
 
   // call the base destructors in the reverse order
-  for(irept::subt::const_reverse_iterator
-      bit=bases.rbegin();
-      bit!=bases.rend();
+  for(class_typet::basest::const_reverse_iterator bit = bases.rbegin();
+      bit != bases.rend();
       bit++)
   {
-    assert(bit->id()==ID_base);
-    assert(bit->find(ID_type).id() == ID_symbol_type);
-    const symbolt &psymb = lookup(bit->find(ID_type).get(ID_identifier));
+    DATA_INVARIANT(bit->id() == ID_base, "base class expression expected");
+    const symbolt &psymb = lookup(to_symbol_type(bit->type()).get_identifier());
 
     symbol_exprt this_ptr(ID_this, pointer_type(symbol.type));
     dereference_exprt object(this_ptr, psymb.type);

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -33,11 +33,12 @@ bool cpp_typecheckt::find_parent(
   const irep_idt &base_name,
   irep_idt &identifier)
 {
-  forall_irep(bit, symb.type.find(ID_bases).get_sub())
+  for(const auto &b : to_struct_type(symb.type).bases())
   {
-    if(lookup(bit->find(ID_type).get(ID_identifier)).base_name == base_name)
+    const irep_idt &id = to_symbol_type(b.type()).get_identifier();
+    if(lookup(id).base_name == base_name)
     {
-      identifier=bit->find(ID_type).get(ID_identifier);
+      identifier = id;
       return true;
     }
   }

--- a/src/goto-programs/class_hierarchy.cpp
+++ b/src/goto-programs/class_hierarchy.cpp
@@ -43,9 +43,9 @@ void class_hierarchy_grapht::populate(const symbol_tablet &symbol_table)
   {
     if(symbol_pair.second.is_type && symbol_pair.second.type.id() == ID_struct)
     {
-      const class_typet &class_type = to_class_type(symbol_pair.second.type);
+      const struct_typet &struct_type = to_struct_type(symbol_pair.second.type);
 
-      for(const auto &base : class_type.bases())
+      for(const auto &base : struct_type.bases())
       {
         const irep_idt &parent = to_symbol_type(base.type()).get_identifier();
         if(!parent.empty())
@@ -157,11 +157,9 @@ void class_hierarchyt::operator()(const symbol_tablet &symbol_table)
       class_map[symbol_pair.first].is_abstract =
         struct_type.get_bool(ID_abstract);
 
-      const irept::subt &bases = struct_type.find(ID_bases).get_sub();
-
-      for(const auto &base : bases)
+      for(const auto &base : struct_type.bases())
       {
-        irep_idt parent = base.find(ID_type).get(ID_identifier);
+        const irep_idt &parent = to_symbol_type(base.type()).get_identifier();
         if(parent.empty())
           continue;
 

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -280,6 +280,67 @@ public:
   }
 
   bool is_prefix_of(const struct_typet &other) const;
+
+  /// A struct may be a class, where members may have access restrictions.
+  bool is_class() const
+  {
+    return get_bool(ID_C_class);
+  }
+
+  /// Base class or struct that a class or struct inherits from.
+  class baset : public exprt
+  {
+  public:
+    baset() : exprt(ID_base)
+    {
+    }
+
+    explicit baset(const typet &base) : exprt(ID_base, base)
+    {
+    }
+  };
+
+  typedef std::vector<baset> basest;
+
+  /// Get the collection of base classes/structs.
+  const basest &bases() const
+  {
+    return (const basest &)find(ID_bases).get_sub();
+  }
+
+  /// Get the collection of base classes/structs.
+  basest &bases()
+  {
+    return (basest &)add(ID_bases).get_sub();
+  }
+
+  /// Add a base class/struct
+  /// \param base: Type of case/class struct to be added.
+  void add_base(const symbol_typet &base)
+  {
+    bases().push_back(baset(base));
+  }
+
+  /// Return the base with the given name, if exists.
+  /// \param id The name of the base we are looking for.
+  /// \return The base if exists.
+  optionalt<baset> get_base(const irep_idt &id) const
+  {
+    for(const auto &b : bases())
+    {
+      if(to_symbol_type(b.type()).get_identifier() == id)
+        return b;
+    }
+    return {};
+  }
+
+  /// Test whether `id` is a base class/struct.
+  /// \param id: symbol type name
+  /// \return True if, and only if, the symbol type `id` is a base class/struct.
+  bool has_base(const irep_idt &id) const
+  {
+    return get_base(id).has_value();
+  }
 };
 
 /// Check whether a reference to a typet is a \ref struct_typet.
@@ -334,53 +395,6 @@ public:
   componentst &methods()
   {
     return (methodst &)(add(ID_methods).get_sub());
-  }
-
-  class baset:public exprt
-  {
-  public:
-    baset():exprt(ID_base)
-    {
-    }
-
-    explicit baset(const typet &base):exprt(ID_base, base)
-    {
-    }
-  };
-
-  typedef std::vector<baset> basest;
-
-  const basest &bases() const
-  {
-    return (const basest &)find(ID_bases).get_sub();
-  }
-
-  basest &bases()
-  {
-    return (basest &)add(ID_bases).get_sub();
-  }
-
-  void add_base(const typet &base)
-  {
-    bases().push_back(baset(base));
-  }
-
-  /// Return the base with the given name, if exists.
-  /// \param id The name of the base we are looking for.
-  /// \return The base if exists.
-  optionalt<baset> get_base(const irep_idt &id) const
-  {
-    for(const auto &b : bases())
-    {
-      if(to_symbol_type(b.type()).get_identifier() == id)
-        return b;
-    }
-    return {};
-  }
-
-  bool has_base(const irep_idt &id) const
-  {
-    return get_base(id).has_value();
   }
 
   bool is_abstract() const


### PR DESCRIPTION
Structs can have base classes/structs. This enables wide use of the bases() API.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
