### PR TITLE
Pragma to silence Visual Studio conversion warnings

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -769,8 +769,11 @@ code_blockt &java_bytecode_convert_methodt::get_or_create_block_for_pcrange(
   assert(afterstart!=tree.branch_addresses.begin());
   auto findstart=afterstart;
   --findstart;
-  auto child_offset=
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
+  std::size_t child_offset =
     std::distance(tree.branch_addresses.begin(), findstart);
+#include <util/pragma_pop.def>
 
   // Find child block starting >= address_limit:
   auto findlim=

--- a/jbmc/src/java_bytecode/java_bytecode_parser.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_parser.cpp
@@ -705,7 +705,10 @@ void java_bytecode_parsert::rconstant_pool()
         std::string s;
         s.resize(bytes);
         for(std::string::iterator s_it=s.begin(); s_it!=s.end(); s_it++)
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
           *s_it=read_u1();
+#include <util/pragma_pop.def>
         it->s=s; // hashes
       }
       break;
@@ -968,7 +971,10 @@ void java_bytecode_parsert::rbytecode(
 
     case 'b': // a signed byte
       {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
         s1 c=read_u1();
+#include <util/pragma_pop.def>
         instruction.args.push_back(from_integer(c, signedbv_typet(8)));
       }
       address+=1;
@@ -976,7 +982,10 @@ void java_bytecode_parsert::rbytecode(
 
     case 'o': // two byte branch offset, signed
       {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
         s2 offset=read_u2();
+#include <util/pragma_pop.def>
         // By converting the signed offset into an absolute address (by adding
         // the current address) the number represented becomes unsigned.
         instruction.args.push_back(
@@ -987,7 +996,10 @@ void java_bytecode_parsert::rbytecode(
 
     case 'O': // four byte branch offset, signed
       {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
         s4 offset=read_u4();
+#include <util/pragma_pop.def>
         // By converting the signed offset into an absolute address (by adding
         // the current address) the number represented becomes unsigned.
         instruction.args.push_back(
@@ -1020,7 +1032,10 @@ void java_bytecode_parsert::rbytecode(
       {
         u2 v=read_u2();
         instruction.args.push_back(from_integer(v, unsignedbv_typet(16)));
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
         s2 c=read_u2();
+#include <util/pragma_pop.def>
         instruction.args.push_back(from_integer(c, signedbv_typet(16)));
         address+=4;
       }
@@ -1028,7 +1043,10 @@ void java_bytecode_parsert::rbytecode(
       {
         u1 v=read_u1();
         instruction.args.push_back(from_integer(v, unsignedbv_typet(8)));
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
         s1 c=read_u1();
+#include <util/pragma_pop.def>
         instruction.args.push_back(from_integer(c, signedbv_typet(8)));
         address+=2;
       }
@@ -1054,7 +1072,10 @@ void java_bytecode_parsert::rbytecode(
         while(((address+1)&3)!=0) { read_u1(); address++; }
 
         // now default value
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
         s4 default_value=read_u4();
+#include <util/pragma_pop.def>
         // By converting the signed offset into an absolute address (by adding
         // the current address) the number represented becomes unsigned.
         instruction.args.push_back(
@@ -1067,8 +1088,11 @@ void java_bytecode_parsert::rbytecode(
 
         for(std::size_t i=0; i<npairs; i++)
         {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
           s4 match=read_u4();
           s4 offset=read_u4();
+#include <util/pragma_pop.def>
           instruction.args.push_back(
             from_integer(match, signedbv_typet(32)));
           // By converting the signed offset into an absolute address (by adding
@@ -1088,23 +1112,35 @@ void java_bytecode_parsert::rbytecode(
         while(((address+1)&3)!=0) { read_u1(); address++; }
 
         // now default value
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
         s4 default_value=read_u4();
+#include <util/pragma_pop.def>
         instruction.args.push_back(
           from_integer(base_offset+default_value, signedbv_typet(32)));
         address+=4;
 
         // now low value
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
         s4 low_value=read_u4();
+#include <util/pragma_pop.def>
         address+=4;
 
         // now high value
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
         s4 high_value=read_u4();
+#include <util/pragma_pop.def>
         address+=4;
 
         // there are high-low+1 offsets, and they are signed
         for(s4 i=low_value; i<=high_value; i++)
         {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
           s4 offset=read_u4();
+#include <util/pragma_pop.def>
           instruction.args.push_back(from_integer(i, signedbv_typet(32)));
           // By converting the signed offset into an absolute address (by adding
           // the current address) the number represented becomes unsigned.
@@ -1148,7 +1184,10 @@ void java_bytecode_parsert::rbytecode(
 
     case 's': // a signed short
       {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
         s2 s=read_u2();
+#include <util/pragma_pop.def>
         instruction.args.push_back(from_integer(s, signedbv_typet(16)));
       }
       address+=2;

--- a/jbmc/src/java_bytecode/java_types.cpp
+++ b/jbmc/src/java_bytecode/java_types.cpp
@@ -566,7 +566,10 @@ typet java_type_from_string(
          subtype_letter=='[' || // Array-of-arrays
          subtype_letter=='T')   // Array of generic types
         subtype_letter='A';
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       typet tmp=java_array_type(std::tolower(subtype_letter));
+#include <util/pragma_pop.def>
       tmp.subtype().set(ID_element_type, subtype);
       return tmp;
     }

--- a/jbmc/src/java_bytecode/java_types.h
+++ b/jbmc/src/java_bytecode/java_types.h
@@ -705,7 +705,10 @@ inline const optionalt<size_t> java_generics_get_index_for_subtype(
     return {};
   }
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   return std::distance(gen_types.cbegin(), iter);
+#include <util/pragma_pop.def>
 }
 
 void get_dependencies_from_generic_parameters(

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -160,7 +160,10 @@ void rw_range_sett::get_objects_byte_extract(
       be.id()==ID_byte_extract_little_endian,
       ns);
     assert(index<std::numeric_limits<size_t>::max());
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
     range_spect offset=range_start + map.map_bit(integer2size_t(index));
+#include <util/pragma_pop.def>
     get_objects_rec(mode, be.op(), offset, size);
   }
 }
@@ -315,8 +318,11 @@ void rw_range_sett::get_objects_array(
 
   range_spect offset=0;
   range_spect full_r_s=range_start==-1 ? 0 : range_start;
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   range_spect full_r_e=
     size==-1 ? sub_size*expr.operands().size() : full_r_s+size;
+#include <util/pragma_pop.def>
 
   forall_operands(it, expr)
   {

--- a/src/analyses/local_bitvector_analysis.cpp
+++ b/src/analyses/local_bitvector_analysis.cpp
@@ -342,10 +342,13 @@ void local_bitvector_analysist::output(
         p_it!=loc_info.end();
         p_it++)
     {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       out << "  " << pointers[p_it-loc_info.begin()]
           << ": "
           << *p_it
           << "\n";
+#include <util/pragma_pop.def>
     }
 
     out << "\n";

--- a/src/ansi-c/c_qualifiers.h
+++ b/src/ansi-c/c_qualifiers.h
@@ -149,8 +149,11 @@ public:
 
   virtual std::size_t count() const override
   {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
     return is_constant+is_volatile+is_restricted+is_atomic+
            is_ptr32+is_ptr64+is_noreturn;
+#include <util/pragma_pop.def>
   }
 };
 

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -2227,7 +2227,10 @@ std::string expr2ct::convert_array(
       if(last_was_hex)
       {
         // we use "string splicing" to avoid ambiguity
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
         if(isxdigit(ch))
+#include <util/pragma_pop.def>
           dest+="\" \"";
 
         last_was_hex=false;

--- a/src/ansi-c/literals/convert_integer_literal.cpp
+++ b/src/ansi-c/literals/convert_integer_literal.cpp
@@ -168,7 +168,10 @@ exprt convert_integer_literal(const std::string &src)
 
   typet type=typet(is_signed?ID_signedbv:ID_unsignedbv);
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   type.set(ID_width, width);
+#include <util/pragma_pop.def>
   type.set(ID_C_c_type, c_type);
 
   exprt result;

--- a/src/ansi-c/literals/convert_string_literal.cpp
+++ b/src/ansi-c/literals/convert_string_literal.cpp
@@ -39,7 +39,10 @@ std::basic_string<unsigned int> convert_one_string_literal(
     // pad into wide string
     value.resize(utf8_value.size());
     for(std::size_t i=0; i<utf8_value.size(); i++)
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       value[i]=utf8_value[i];
+#include <util/pragma_pop.def>
 
     return value;
   }
@@ -62,7 +65,10 @@ std::basic_string<unsigned int> convert_one_string_literal(
     std::basic_string<unsigned int> value;
     value.resize(char_value.size());
     for(std::size_t i=0; i<char_value.size(); i++)
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       value[i]=char_value[i];
+#include <util/pragma_pop.def>
 
     return value;
   }
@@ -150,7 +156,10 @@ exprt convert_string_literal(const std::string &src)
     {
       // Loss of data here if value[i]>255.
       // gcc issues a warning in this case.
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       char_value[i]=value[i];
+#include <util/pragma_pop.def>
     }
 
     string_constantt result;

--- a/src/ansi-c/literals/parse_float.cpp
+++ b/src/ansi-c/literals/parse_float.cpp
@@ -11,7 +11,11 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "parse_float.h"
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
 #include <algorithm>
+#include <util/pragma_pop.def>
+
 #include <cctype>
 #include <cstring>
 

--- a/src/ansi-c/literals/unescape_string.cpp
+++ b/src/ansi-c/literals/unescape_string.cpp
@@ -44,7 +44,10 @@ std::basic_string<T> unescape_string_templ(const std::string &src)
 
   for(unsigned i=0; i<src.size(); i++)
   {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
     T ch=(unsigned char)src[i];
+#include <util/pragma_pop.def>
 
     if(ch=='\\') // escape?
     {
@@ -52,7 +55,10 @@ std::basic_string<T> unescape_string_templ(const std::string &src)
       i++;
       assert(i<src.size()); // backslash can't be last character
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       ch=(unsigned char)src[i];
+#include <util/pragma_pop.def>
       switch(ch)
       {
       case '\\': dest.push_back(ch); break;
@@ -106,7 +112,10 @@ std::basic_string<T> unescape_string_templ(const std::string &src)
           // go back
           i--;
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
           ch=hex_to_unsigned(hex.c_str(), hex.size());
+#include <util/pragma_pop.def>
         }
 
         // if T isn't sufficiently wide to hold unsigned values
@@ -117,7 +126,10 @@ std::basic_string<T> unescape_string_templ(const std::string &src)
         break;
 
       default:
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
         if(isdigit(ch)) // octal
+#include <util/pragma_pop.def>
         {
           std::string octal;
 
@@ -130,7 +142,10 @@ std::basic_string<T> unescape_string_templ(const std::string &src)
           // go back
           i--;
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
           ch=octal_to_unsigned(octal.c_str(), octal.size());
+#include <util/pragma_pop.def>
           dest.push_back(ch);
         }
         else

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -26,6 +26,8 @@ extern char *yyansi_ctext;
 
 #include "ansi_c_y.tab.h"
 
+#include <util/pragma_wconversion.def>
+
 // statements have right recursion, deep nesting of statements thus
 // requires more stack space
 #define YYMAXDEPTH 25600

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -44,6 +44,8 @@ extern int yyansi_cdebug;
 #define loc() \
   { newstack(yyansi_clval); PARSER.set_source_location(stack(yyansi_clval)); }
 
+#include <util/pragma_wconversion.def>
+
 int make_identifier()
 {
   loc();

--- a/src/assembler/scanner.l
+++ b/src/assembler/scanner.l
@@ -12,6 +12,7 @@
 
 #include "assembler_parser.h"
 
+#include <util/pragma_wconversion.def>
 #include <util/pragma_wsign_compare.def>
 #include <util/pragma_wnull_conversion.def>
 #include <util/pragma_wdeprecated_register.def>

--- a/src/cbmc/symex_coverage.cpp
+++ b/src/cbmc/symex_coverage.cpp
@@ -206,7 +206,10 @@ goto_program_coverage_recordt::goto_program_coverage_recordt(
         xmlt &condition=conditions.new_element("condition");
         condition.set_attribute("number", std::to_string(number++));
         condition.set_attribute("type", "jump");
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
         unsigned taken=c.second.false_taken+c.second.true_taken;
+#include <util/pragma_pop.def>
         total_taken+=taken;
         condition.set_attribute("coverage", rate(taken, 2, true));
       }

--- a/src/cpp/cpp_convert_type.cpp
+++ b/src/cpp/cpp_convert_type.cpp
@@ -601,7 +601,10 @@ void cpp_convert_plain_type(typet &type)
   {
     // add width -- we use int, but the standard
     // doesn't guarantee that
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
     type.set(ID_width, config.ansi_c.int_width);
+#include <util/pragma_pop.def>
   }
   else
   {

--- a/src/cpp/cpp_token_buffer.cpp
+++ b/src/cpp/cpp_token_buffer.cpp
@@ -124,6 +124,9 @@ void cpp_token_buffert::Insert(const cpp_tokent &token)
 
   tokens.push_back(token);
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   token_vector.insert(token_vector.begin()+current_pos,
                       --tokens.end());
+#include <util/pragma_pop.def>
 }

--- a/src/goto-cc/gcc_cmdline.cpp
+++ b/src/goto-cc/gcc_cmdline.cpp
@@ -222,7 +222,10 @@ bool gcc_cmdlinet::parse(int argc, const char **argv)
   add_arg(argv[0]);
 
   argst args;
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   args.reserve(argc-1);
+#include <util/pragma_pop.def>
 
   for(int i=1; i<argc; i++)
     args.push_back(argv[i]);

--- a/src/goto-cc/goto_cc_main.cpp
+++ b/src/goto-cc/goto_cc_main.cpp
@@ -11,7 +11,11 @@ Date: May 2006
 /// \file
 /// GOTO-CC Main Module
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
 #include <algorithm>
+#include <util/pragma_pop.def>
+
 #include <iostream>
 
 #include <util/unicode.h>

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -1606,7 +1606,10 @@ void goto_program2codet::cleanup_code_block(
       operands.size()>1 && i<operands.size();
      ) // no ++i
   {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
     exprt::operandst::iterator it=operands.begin()+i;
+#include <util/pragma_pop.def>
     // remove skip
     if(to_code(*it).get_statement()==ID_skip &&
        it->source_location().get_comment().empty())
@@ -1624,10 +1627,13 @@ void goto_program2codet::cleanup_code_block(
 
       if(!has_decl)
       {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
         operands.insert(operands.begin()+i+1,
             it->operands().begin(), it->operands().end());
         operands.erase(operands.begin()+i);
         // no ++i
+#include <util/pragma_pop.def>
       }
       else
         ++i;

--- a/src/goto-programs/elf_reader.cpp
+++ b/src/goto-programs/elf_reader.cpp
@@ -57,7 +57,10 @@ elf_readert::elf_readert(std::istream &_in):in(_in)
     for(std::size_t i=0; i<elf32_section_header_table.size(); i++)
     {
       // go to right place
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       in.seekg(elf32_header.e_shoff+i*elf32_header.e_shentsize);
+#include <util/pragma_pop.def>
 
       // read section header
       in.read(
@@ -104,7 +107,10 @@ elf_readert::elf_readert(std::istream &_in):in(_in)
     for(std::size_t i=0; i<elf64_section_header_table.size(); i++)
     {
       // go to right place
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       in.seekg(elf64_header.e_shoff+i*elf64_header.e_shentsize);
+#include <util/pragma_pop.def>
 
       // read section header
       in.read(

--- a/src/goto-programs/elf_reader.h
+++ b/src/goto-programs/elf_reader.h
@@ -143,9 +143,12 @@ public:
 
   std::streampos section_offset(std::size_t index) const
   {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
     return
       elf_class==ELF32?elf32_section_header_table[index].sh_offset:
                        elf64_section_header_table[index].sh_offset;
+#include <util/pragma_pop.def>
   }
 
   bool has_section(const std::string &name) const;

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -134,6 +134,8 @@ void interpretert::command()
     return;
   }
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   char ch=tolower(command[0]);
   if(ch=='q')
     done=true;
@@ -225,6 +227,7 @@ void interpretert::command()
     }
     return;
   }
+#include <util/pragma_pop.def>
   show_state();
 }
 

--- a/src/goto-programs/read_bin_goto_object.cpp
+++ b/src/goto-programs/read_bin_goto_object.cpp
@@ -107,7 +107,10 @@ static bool read_bin_goto_object_v4(
       instruction.guard.make_nil();
       irepconverter.reference_convert(in, instruction.guard);
       irepconverter.read_string_ref(in); // former event
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       instruction.target_number = irepconverter.read_gb_word(in);
+#include <util/pragma_pop.def>
       if(instruction.is_target() &&
          rev_target_map.insert(
            rev_target_map.end(),
@@ -117,7 +120,10 @@ static bool read_bin_goto_object_v4(
       std::size_t t_count = irepconverter.read_gb_word(in); // # of targets
       for(std::size_t i=0; i<t_count; i++)
         // just save the target numbers
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
         target_map[itarget].push_back(irepconverter.read_gb_word(in));
+#include <util/pragma_pop.def>
 
       std::size_t l_count = irepconverter.read_gb_word(in); // # of labels
 

--- a/src/goto-programs/read_goto_binary.cpp
+++ b/src/goto-programs/read_goto_binary.cpp
@@ -87,10 +87,13 @@ bool read_goto_binary(
   }
 
   char hdr[4];
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   hdr[0]=in.get();
   hdr[1]=in.get();
   hdr[2]=in.get();
   hdr[3]=in.get();
+#include <util/pragma_pop.def>
   in.seekg(0);
 
   if(hdr[0]==0x7f && hdr[1]=='G' && hdr[2]=='B' && hdr[3]=='F')
@@ -177,10 +180,13 @@ bool is_goto_binary(const std::string &filename)
   // 2. ELF binaries, marked with 0x7f ELF
 
   char hdr[4];
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   hdr[0]=in.get();
   hdr[1]=in.get();
   hdr[2]=in.get();
   hdr[3]=in.get();
+#include <util/pragma_pop.def>
 
   if(hdr[0]==0x7f && hdr[1]=='G' && hdr[2]=='B' && hdr[3]=='F')
   {

--- a/src/jsil/jsil_types.cpp
+++ b/src/jsil/jsil_types.cpp
@@ -159,7 +159,10 @@ jsil_union_typet jsil_union_typet::union_with(
     elements1.begin(), elements1.end(),
     elements2.begin(), elements2.end(),
     elements.begin(), compare_components);
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   elements.resize(it-elements.begin());
+#include <util/pragma_pop.def>
 
   return result;
 }
@@ -176,7 +179,10 @@ jsil_union_typet jsil_union_typet::intersect_with(
     elements1.begin(), elements1.end(),
     elements2.begin(), elements2.end(),
     elements.begin(), compare_components);
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   elements.resize(it-elements.begin());
+#include <util/pragma_pop.def>
 
   return result;
 }

--- a/src/jsil/parser.y
+++ b/src/jsil/parser.y
@@ -16,6 +16,9 @@ extern char *yyjsiltext;
 #include <util/string_constant.h>
 
 #include "jsil_y.tab.h"
+
+#include <util/pragma_wconversion.def>
+
 /*** token declaration **************************************************/
 %}
 

--- a/src/jsil/scanner.l
+++ b/src/jsil/scanner.l
@@ -34,6 +34,7 @@ static int make_identifier()
   return TOK_IDENTIFIER;
 }
 
+#include <util/pragma_wconversion.def>
 #include <util/pragma_wsign_compare.def>
 #include <util/pragma_wnull_conversion.def>
 #include <util/pragma_wdeprecated_register.def>

--- a/src/json/parser.y
+++ b/src/json/parser.y
@@ -1,4 +1,6 @@
 %{
+#include <util/pragma_wconversion.def>
+
 // Strictly follows http://www.json.org/
 %}
 

--- a/src/json/scanner.l
+++ b/src/json/scanner.l
@@ -17,6 +17,7 @@
 #include "json_parser.h"
 #include "json_y.tab.h"
 
+#include <util/pragma_wconversion.def>
 #include <util/pragma_wsign_compare.def>
 #include <util/pragma_wnull_conversion.def>
 #include <util/pragma_wdeprecated_register.def>

--- a/src/solvers/flattening/boolbv_complex.cpp
+++ b/src/solvers/flattening/boolbv_complex.cpp
@@ -70,7 +70,10 @@ bvt boolbvt::convert_complex_imag(const complex_imag_exprt &expr)
   bvt bv = convert_bv(expr.op());
 
   assert(bv.size()==width*2);
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   bv.erase(bv.begin(), bv.begin()+width);
+#include <util/pragma_pop.def>
 
   return bv;
 }

--- a/src/solvers/flattening/boolbv_floatbv_op.cpp
+++ b/src/solvers/flattening/boolbv_floatbv_op.cpp
@@ -135,8 +135,11 @@ bvt boolbvt::convert_floatbv_op(const exprt &expr)
       {
         bvt tmp_bv0, tmp_bv1, tmp_bv;
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
         tmp_bv0.assign(bv0.begin()+i*sub_width, bv0.begin()+(i+1)*sub_width);
         tmp_bv1.assign(bv1.begin()+i*sub_width, bv1.begin()+(i+1)*sub_width);
+#include <util/pragma_pop.def>
 
         if(expr.id()==ID_floatbv_plus)
           tmp_bv=float_utils.add_sub(tmp_bv0, tmp_bv1, false);
@@ -151,7 +154,10 @@ bvt boolbvt::convert_floatbv_op(const exprt &expr)
 
         assert(tmp_bv.size()==sub_width);
         assert(i*sub_width+sub_width-1<bv.size());
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
         std::copy(tmp_bv.begin(), tmp_bv.end(), bv.begin()+i*sub_width);
+#include <util/pragma_pop.def>
       }
 
       return bv;

--- a/src/solvers/flattening/boolbv_map.cpp
+++ b/src/solvers/flattening/boolbv_map.cpp
@@ -95,7 +95,10 @@ void boolbv_mapt::get_literals(
   Forall_literals(it, literals)
   {
     literalt &l=*it;
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
     const std::size_t bit=it-literals.begin();
+#include <util/pragma_pop.def>
 
     assert(bit<map_entry.literal_map.size());
     map_bitt &mb=map_entry.literal_map[bit];
@@ -128,7 +131,10 @@ void boolbv_mapt::set_literals(
   forall_literals(it, literals)
   {
     const literalt &literal=*it;
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
     const std::size_t bit=it-literals.begin();
+#include <util/pragma_pop.def>
 
     assert(literal.is_constant() ||
            literal.var_no()<prop.no_variables());

--- a/src/solvers/flattening/boolbv_mult.cpp
+++ b/src/solvers/flattening/boolbv_mult.cpp
@@ -60,7 +60,10 @@ bvt boolbvt::convert_mult(const exprt &expr)
       bv=bv_utils.signed_multiplier(bv, op);
 
       // cut it down again
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       bv.erase(bv.begin(), bv.begin()+fraction_bits);
+#include <util/pragma_pop.def>
     }
 
     return bv;

--- a/src/solvers/flattening/boolbv_overflow.cpp
+++ b/src/solvers/flattening/boolbv_overflow.cpp
@@ -135,7 +135,10 @@ literalt boolbvt::convert_overflow(const exprt &expr)
     if(rep == bv_utilst::representationt::UNSIGNED)
     {
       // get top result bits
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       result.erase(result.begin(), result.begin() + old_size);
+#include <util/pragma_pop.def>
 
       // one of the top bits is non-zero
       overflow=prop.lor(result);
@@ -144,7 +147,10 @@ literalt boolbvt::convert_overflow(const exprt &expr)
     {
       // get top result bits plus sign bit
       DATA_INVARIANT(old_size != 0, "zero-size operand");
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       result.erase(result.begin(), result.begin() + old_size - 1);
+#include <util/pragma_pop.def>
 
       // the sign bit has changed
       literalt sign_change=!prop.lequal(bv0.back(), result.front());

--- a/src/solvers/flattening/boolbv_typecast.cpp
+++ b/src/solvers/flattening/boolbv_typecast.cpp
@@ -81,8 +81,11 @@ bool boolbvt::type_conversion(
     {
       // recursively do both halfs
       bvt lower, upper, lower_res, upper_res;
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       lower.assign(src.begin(), src.begin()+src.size()/2);
       upper.assign(src.begin()+src.size()/2, src.end());
+#include <util/pragma_pop.def>
       type_conversion(
         ns.follow(src_type.subtype()),
         lower,

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -569,7 +569,10 @@ bvt bv_pointerst::convert_bitvector(const exprt &expr)
 
     // erase offset bits
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
     op0.erase(op0.begin()+0, op0.begin()+offset_bits);
+#include <util/pragma_pop.def>
 
     return bv_utils.zero_extension(op0, width);
   }
@@ -752,10 +755,16 @@ void bv_pointerst::do_postponed(
       bvt bv;
       encode(number, bv);
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       bv.erase(bv.begin(), bv.begin()+offset_bits);
+#include <util/pragma_pop.def>
 
       bvt saved_bv=postponed.op;
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       saved_bv.erase(saved_bv.begin(), saved_bv.begin()+offset_bits);
+#include <util/pragma_pop.def>
 
       POSTCONDITION(bv.size()==saved_bv.size());
       PRECONDITION(postponed.bv.size()==1);
@@ -798,10 +807,16 @@ void bv_pointerst::do_postponed(
       bvt bv;
       encode(number, bv);
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       bv.erase(bv.begin(), bv.begin()+offset_bits);
+#include <util/pragma_pop.def>
 
       bvt saved_bv=postponed.op;
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       saved_bv.erase(saved_bv.begin(), saved_bv.begin()+offset_bits);
+#include <util/pragma_pop.def>
 
       bvt size_bv = convert_bv(object_size);
 

--- a/src/solvers/flattening/bv_utils.cpp
+++ b/src/solvers/flattening/bv_utils.cpp
@@ -49,7 +49,10 @@ bvt bv_utilst::extract(const bvt &a, std::size_t first, std::size_t last)
   bvt result=a;
   result.resize(last+1);
   if(first!=0)
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
     result.erase(result.begin(), result.begin()+first);
+#include <util/pragma_pop.def>
 
   POSTCONDITION(result.size() == last - first + 1);
   return result;
@@ -61,7 +64,10 @@ bvt bv_utilst::extract_msb(const bvt &a, std::size_t n)
   PRECONDITION(n <= a.size());
 
   bvt result=a;
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   result.erase(result.begin(), result.begin()+(result.size()-n));
+#include <util/pragma_pop.def>
 
   POSTCONDITION(result.size() == n);
   return result;

--- a/src/solvers/floatbv/float_bv.cpp
+++ b/src/solvers/floatbv/float_bv.cpp
@@ -340,9 +340,12 @@ exprt float_bvt::conversion(
   // new format.  Note that this is rare and will only
   // happen with very non-standard formats.
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   int sourceSmallestNormalExponent = -((1 << (src_spec.e - 1)) - 1);
   int sourceSmallestDenormalExponent =
     sourceSmallestNormalExponent - src_spec.f;
+#include <util/pragma_pop.def>
 
   // Using the fact that f doesn't include the hidden bit
 

--- a/src/solvers/floatbv/float_utils.cpp
+++ b/src/solvers/floatbv/float_utils.cpp
@@ -168,9 +168,12 @@ bvt float_utilst::conversion(
   // new format.  Note that this is rare and will only
   // happen with very non-standard formats.
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   int sourceSmallestNormalExponent=-((1 << (spec.e - 1)) - 1);
   int sourceSmallestDenormalExponent =
     sourceSmallestNormalExponent - spec.f;
+#include <util/pragma_pop.def>
 
   // Using the fact that f doesn't include the hidden bit
 
@@ -391,7 +394,10 @@ bvt float_utilst::limit_distance(
   std::size_t nb_bits = address_bits(limit);
 
   bvt upper_bits=dist;
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   upper_bits.erase(upper_bits.begin(), upper_bits.begin()+nb_bits);
+#include <util/pragma_pop.def>
   literalt or_upper_bits=prop.lor(upper_bits);
 
   bvt lower_bits=dist;
@@ -709,7 +715,10 @@ literalt float_utilst::exponent_all_ones(const bvt &src)
   bvt exponent=src;
 
   // removes the fractional part
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   exponent.erase(exponent.begin(), exponent.begin()+spec.f);
+#include <util/pragma_pop.def>
 
   // removes the sign
   exponent.resize(spec.e);
@@ -722,7 +731,10 @@ literalt float_utilst::exponent_all_zeros(const bvt &src)
   bvt exponent=src;
 
   // removes the fractional part
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   exponent.erase(exponent.begin(), exponent.begin()+spec.f);
+#include <util/pragma_pop.def>
 
   // removes the sign
   exponent.resize(spec.e);

--- a/src/solvers/prop/literal.h
+++ b/src/solvers/prop/literal.h
@@ -115,7 +115,10 @@ public:
   //
   int dimacs() const
   {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
     int result=var_no();
+#include <util/pragma_pop.def>
 
     if(sign())
       result=-result;
@@ -128,7 +131,10 @@ public:
     bool sign=d<0;
     if(sign)
       d=-d;
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
     set(d, sign);
+#include <util/pragma_pop.def>
   }
 
   void clear()

--- a/src/solvers/refinement/string_builtin_function.cpp
+++ b/src/solvers/refinement/string_builtin_function.cpp
@@ -130,10 +130,13 @@ std::vector<mp_integer> string_concatenation_builtin_functiont::eval(
       : input2_size;
 
   std::vector<mp_integer> result(input1_value);
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   result.insert(
     result.end(),
     input2_value.begin() + numeric_cast_v<std::size_t>(start_index),
     input2_value.begin() + numeric_cast_v<std::size_t>(end_index));
+#include <util/pragma_pop.def>
   return result;
 }
 
@@ -459,10 +462,13 @@ std::vector<mp_integer> string_insertion_builtin_functiont::eval(
       : input2_size;
 
   std::vector<mp_integer> result(input1_value);
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   result.insert(
     result.begin() + numeric_cast_v<std::size_t>(offset),
     input2_value.begin() + numeric_cast_v<std::size_t>(start),
     input2_value.begin() + numeric_cast_v<std::size_t>(end));
+#include <util/pragma_pop.def>
   return result;
 }
 

--- a/src/solvers/refinement/string_constraint_generator_float.cpp
+++ b/src/solvers/refinement/string_constraint_generator_float.cpp
@@ -75,6 +75,8 @@ exprt get_significand(
 /// \return an expression representing this floating point
 exprt constant_float(const double f, const ieee_float_spect &float_spec)
 {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   ieee_floatt fl(float_spec);
   if(float_spec==ieee_float_spect::single_precision())
     fl.from_float(f);
@@ -83,6 +85,7 @@ exprt constant_float(const double f, const ieee_float_spect &float_spec)
   else
     UNREACHABLE;
   return fl.to_expr();
+#include <util/pragma_pop.def>
 }
 
 /// Round a float expression to an integer closer to 0

--- a/src/solvers/refinement/string_constraint_generator_format.cpp
+++ b/src/solvers/refinement/string_constraint_generator_format.cpp
@@ -218,7 +218,10 @@ static std::vector<format_elementt> parse_format_string(std::string s)
   {
     if(match.position()!=0)
     {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       std::string pre_match=s.substr(0, match.position());
+#include <util/pragma_pop.def>
       al.emplace_back(pre_match);
     }
 
@@ -329,7 +332,10 @@ add_axioms_for_format_specifier(
   case format_specifiert::HASHCODE_UPPER:
   {
     format_specifiert fs_lower = fs;
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
     fs_lower.conversion=tolower(fs.conversion);
+#include <util/pragma_pop.def>
     auto format_specifier_result = add_axioms_for_format_specifier(
       fresh_symbol,
       fs_lower,
@@ -417,7 +423,10 @@ std::pair<exprt, string_constraintst> add_axioms_for_format(
             "number of format must match specifiers");
 
           // first argument `args[0]` corresponds to index 1
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
           arg=to_struct_expr(args[fs.index-1]);
+#include <util/pragma_pop.def>
         }
       }
       auto result = add_axioms_for_format_specifier(
@@ -490,7 +499,10 @@ utf16_constant_array_to_java(const array_exprt &arr, std::size_t length)
     bool conversion_failed=to_unsigned_integer(
       to_constant_expr(arr.operands()[i]), c);
     INVARIANT(!conversion_failed, "constant should be convertible to unsigned");
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
     out[i]=c;
+#include <util/pragma_pop.def>
   }
   return utf16_native_endian_to_java(out);
 }

--- a/src/solvers/sat/cnf.cpp
+++ b/src/solvers/sat/cnf.cpp
@@ -387,7 +387,10 @@ literalt cnft::lselect(literalt a, literalt b, literalt c)
 literalt cnft::new_variable()
 {
   literalt l;
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   l.set(_no_variables, false);
+#include <util/pragma_pop.def>
 
   set_no_variables(_no_variables+1);
 

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -20,8 +20,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/invariant.h>
 #include <util/threeval.h>
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
 #include <minisat/core/Solver.h>
 #include <minisat/simp/SimpSolver.h>
+#include <util/pragma_pop.def>
 
 #ifndef HAVE_MINISAT2
 #error "Expected HAVE_MINISAT2"
@@ -35,7 +38,10 @@ void convert(const bvt &bv, Minisat::vec<Minisat::Lit> &dest)
 
   forall_literals(it, bv)
     if(!it->is_false())
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       dest.push(Minisat::mkLit(it->var_no(), it->sign()));
+#include <util/pragma_pop.def>
 }
 
 template<typename T>
@@ -53,12 +59,15 @@ tvt satcheck_minisat2_baset<T>::l_get(literalt a) const
 
   using Minisat::lbool;
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   if(solver->model[a.var_no()]==l_True)
     result=tvt(true);
   else if(solver->model[a.var_no()]==l_False)
     result=tvt(false);
   else
     return tvt::unknown();
+#include <util/pragma_pop.def>
 
   if(a.sign())
     result=!result;
@@ -280,7 +289,10 @@ void satcheck_minisat2_baset<T>::set_assignment(literalt a, bool value)
 
   try
   {
-    unsigned v = a.var_no();
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
+    int v = a.var_no();
+#include <util/pragma_pop.def>
     bool sign = a.sign();
 
     // MiniSat2 kills the model in case of UNSAT
@@ -317,7 +329,10 @@ satcheck_minisat2_baset<Minisat::SimpSolver>::~satcheck_minisat2_baset()
 template<typename T>
 bool satcheck_minisat2_baset<T>::is_in_conflict(literalt a) const
 {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   int v=a.var_no();
+#include <util/pragma_pop.def>
 
   for(int i=0; i<solver->conflict.size(); i++)
     if(var(solver->conflict[i])==v)
@@ -356,7 +371,10 @@ void satcheck_minisat_simplifiert::set_frozen(literalt a)
     if(!a.is_constant())
     {
       add_variables();
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       solver->setFrozen(a.var_no(), true);
+#include <util/pragma_pop.def>
     }
   }
   catch(Minisat::OutOfMemoryException)
@@ -371,5 +389,8 @@ bool satcheck_minisat_simplifiert::is_eliminated(literalt a) const
 {
   PRECONDITION(!a.is_constant());
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   return solver->isEliminated(a.var_no());
+#include <util/pragma_pop.def>
 }

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -726,7 +726,10 @@ literalt smt2_convt::convert(const exprt &expr)
 
   find_symbols(expr);
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   literalt l(no_boolean_variables, false);
+#include <util/pragma_pop.def>
   no_boolean_variables++;
 
   out << "; convert\n";

--- a/src/util/expr_iterator.h
+++ b/src/util/expr_iterator.h
@@ -187,8 +187,11 @@ protected:
       auto &operands = expr->operands();
       // Get iterators into the operands of the new expr corresponding to the
       // ones into the operands of the old expr
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       const auto i=operands.size()-(state.end-state.it);
       const auto it=operands.begin()+i;
+#include <util/pragma_pop.def>
       state.expr = *expr;
       state.it=it;
       state.end=operands.end();

--- a/src/util/irep_hash.h
+++ b/src/util/irep_hash.h
@@ -82,7 +82,10 @@ inline std::size_t basic_hash_combine<32>(
   std::size_t h1,
   std::size_t h2)
 {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   return ROTL32(h1, 7)^h2;
+#include <util/pragma_pop.def>
 }
 
 template<>

--- a/src/util/irep_serialization.cpp
+++ b/src/util/irep_serialization.cpp
@@ -174,7 +174,10 @@ void write_gb_word(std::ostream &out, std::size_t u)
 
     if(u==0)
     {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       out.put(value);
+#include <util/pragma_pop.def>
       break;
     }
 

--- a/src/util/pragma_wconversion.def
+++ b/src/util/pragma_wconversion.def
@@ -1,0 +1,13 @@
+#if defined __clang__
+  // dummy as #pragma diagnostic push must be follows by another #pragma
+  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#elif defined __GNUC__
+  // dummy as #pragma diagnostic push must be follows by another #pragma
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined _MSC_VER
+  #pragma warning(disable:4242)
+  #pragma warning(disable:4244)
+  #pragma warning(disable:4245)
+  #pragma warning(disable:4267)
+  #pragma warning(disable:4365)
+#endif

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -913,9 +913,12 @@ bool simplify_exprt::simplify_concatenation(exprt &expr)
         const std::string new_value=
           opi.get_string(ID_value)+opn.get_string(ID_value);
         opi.set(ID_value, new_value);
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
         opi.type().set(ID_width, new_value.size());
         // erase opn
         expr.operands().erase(expr.operands().begin()+i+1);
+#include <util/pragma_pop.def>
         result=true;
       }
       else
@@ -943,10 +946,13 @@ bool simplify_exprt::simplify_concatenation(exprt &expr)
         const std::string new_value=
           opi.get_string(ID_value)+opn.get_string(ID_value);
         opi.set(ID_value, new_value);
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
         opi.type().set(ID_width, new_value.size());
         opi.type().id(ID_verilog_unsignedbv);
         // erase opn
         expr.operands().erase(expr.operands().begin()+i+1);
+#include <util/pragma_pop.def>
         result=true;
       }
       else

--- a/src/util/ssa_expr.h
+++ b/src/util/ssa_expr.h
@@ -82,19 +82,28 @@ public:
 
   void set_level_0(unsigned i)
   {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
     set(ID_L0, i);
+#include <util/pragma_pop.def>
     update_identifier();
   }
 
   void set_level_1(unsigned i)
   {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
     set(ID_L1, i);
+#include <util/pragma_pop.def>
     update_identifier();
   }
 
   void set_level_2(unsigned i)
   {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
     set(ID_L2, i);
+#include <util/pragma_pop.def>
     update_identifier();
   }
 

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -585,7 +585,10 @@ public:
 
   void set_bits_per_byte(std::size_t bits_per_byte)
   {
+#include "pragma_push.def"
+#include "pragma_wconversion.def"
     set(ID_bits_per_byte, bits_per_byte);
+#include "pragma_pop.def"
   }
 };
 
@@ -1722,7 +1725,10 @@ public:
 
   void set_component_number(std::size_t component_number)
   {
+#include "pragma_push.def"
+#include "pragma_wconversion.def"
     set(ID_component_number, component_number);
+#include "pragma_pop.def"
   }
 };
 

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -1136,7 +1136,10 @@ public:
 
   void set_width(std::size_t width)
   {
+#include "pragma_push.def"
+#include "pragma_wconversion.def"
     set(ID_width, width);
+#include "pragma_pop.def"
   }
 };
 
@@ -1329,7 +1332,10 @@ public:
 
   void set_integer_bits(std::size_t b)
   {
+#include "pragma_push.def"
+#include "pragma_wconversion.def"
     set(ID_integer_bits, b);
+#include "pragma_pop.def"
   }
 };
 
@@ -1381,7 +1387,10 @@ public:
 
   void set_f(std::size_t b)
   {
+#include "pragma_push.def"
+#include "pragma_wconversion.def"
     set(ID_f, b);
+#include "pragma_pop.def"
   }
 };
 

--- a/src/util/string_container.cpp
+++ b/src/util/string_container.cpp
@@ -38,7 +38,10 @@ unsigned string_containert::get(const char *s)
   if(it!=hash_table.end())
     return it->second;
 
-  size_t r=hash_table.size();
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
+  const unsigned r = hash_table.size();
+#include <util/pragma_pop.def>
 
   // these are stable
   string_list.push_back(std::string(s));
@@ -61,7 +64,10 @@ unsigned string_containert::get(const std::string &s)
   if(it!=hash_table.end())
     return it->second;
 
-  size_t r=hash_table.size();
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
+  const unsigned r = hash_table.size();
+#include <util/pragma_pop.def>
 
   // these are stable
   string_list.push_back(s);

--- a/src/util/string_utils.cpp
+++ b/src/util/string_utils.cpp
@@ -26,13 +26,16 @@ std::string strip_string(const std::string &s)
   if(left==s.end())
     return "";
 
-  std::string::size_type i=std::distance(s.begin(), left);
+  const auto i = std::distance(s.begin(), left);
 
   std::string::const_reverse_iterator right
     =std::find_if_not(s.rbegin(), s.rend(), pred);
-  std::string::size_type j=std::distance(right, s.rend())-1;
+  const auto j = std::distance(right, s.rend()) - 1;
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   return s.substr(i, (j-i+1));
+#include <util/pragma_pop.def>
 }
 
 /// Given a string s, split into a sequence of substrings when separated by

--- a/src/util/tempfile.cpp
+++ b/src/util/tempfile.cpp
@@ -124,7 +124,10 @@ std::string get_temporary_file(
 
   char *t_ptr=strdup(t_template.c_str());
 
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   int fd=mkstemps(t_ptr, suffix.size());
+#include <util/pragma_pop.def>
 
   if(fd<0)
     throw "mkstemps failed";

--- a/src/util/unicode.cpp
+++ b/src/util/unicode.cpp
@@ -31,7 +31,10 @@ std::string narrow(const wchar_t *s)
   int slength=static_cast<int>(wcslen(s));
   int rlength=
     WideCharToMultiByte(CP_UTF8, 0, s, slength, NULL, 0, NULL, NULL);
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   std::string r(rlength, 0);
+#include <util/pragma_pop.def>
   WideCharToMultiByte(CP_UTF8, 0, s, slength, &r[0], rlength, NULL, NULL);
   return r;
 
@@ -56,7 +59,10 @@ std::wstring widen(const char *s)
   int slength=static_cast<int>(strlen(s));
   int rlength=
     MultiByteToWideChar(CP_UTF8, 0, s, slength, NULL, 0);
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   std::wstring r(rlength, 0);
+#include <util/pragma_pop.def>
   MultiByteToWideChar(CP_UTF8, 0, s, slength, &r[0], rlength);
   return r;
 
@@ -81,7 +87,10 @@ std::string narrow(const std::wstring &s)
   int slength=static_cast<int>(s.size());
   int rlength=
     WideCharToMultiByte(CP_UTF8, 0, &s[0], slength, NULL, 0, NULL, NULL);
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   std::string r(rlength, 0);
+#include <util/pragma_pop.def>
   WideCharToMultiByte(CP_UTF8, 0, &s[0], slength, &r[0], rlength, NULL, NULL);
   return r;
 
@@ -98,7 +107,10 @@ std::wstring widen(const std::string &s)
   int slength=static_cast<int>(s.size());
   int rlength=
     MultiByteToWideChar(CP_UTF8, 0, &s[0], slength, NULL, 0);
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   std::wstring r(rlength, 0);
+#include <util/pragma_pop.def>
   MultiByteToWideChar(CP_UTF8, 0, &s[0], slength, &r[0], rlength);
   return r;
 
@@ -155,7 +167,10 @@ std::vector<std::string> narrow_argv(int argc, const wchar_t **argv_wide)
     return std::vector<std::string>();
 
   std::vector<std::string> argv_narrow;
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   argv_narrow.reserve(argc);
+#include <util/pragma_pop.def>
 
   for(int i=0; i!=argc; ++i)
     argv_narrow.push_back(narrow(argv_wide[i]));
@@ -200,6 +215,8 @@ std::wstring utf8_to_utf16_native_endian(const std::string &in)
     std::string::size_type i=0;
     while(i<in.size())
     {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
       unsigned char c=in[i++];
       unsigned int code=0;
       // the ifs that follow find out how many UTF8 characters (1-4) store the
@@ -245,6 +262,7 @@ std::wstring utf8_to_utf16_native_endian(const std::string &in)
         // For now, let's replace the character with a space
         code=32;
       }
+#include <util/pragma_pop.def>
 
       utf16_append_code(code, result);
     }

--- a/src/util/unicode.h
+++ b/src/util/unicode.h
@@ -35,7 +35,10 @@ template <typename It>
 std::vector<const char *> to_c_str_array(It b, It e)
 {
   // Assumes that walking the range will be faster than repeated allocation
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
   std::vector<const char *> ret(std::distance(b, e) + 1, nullptr);
+#include <util/pragma_pop.def>
   std::transform(b, e, std::begin(ret), [] (const std::string & s)
     {
       return s.c_str();

--- a/src/util/union_find.h
+++ b/src/util/union_find.h
@@ -182,12 +182,18 @@ public:
   bool same_set(typename numbering<T>::const_iterator it_a,
                 typename numbering<T>::const_iterator it_b) const
   {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
     return uuf.same_set(it_a-numbers.begin(), it_b-numbers.begin());
+#include <util/pragma_pop.def>
   }
 
   const T &find(typename numbering<T>::const_iterator it) const
   {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
     return numbers[find_number(it-numbers.begin())];
+#include <util/pragma_pop.def>
   }
 
   const T &find(const T &a)
@@ -226,7 +232,10 @@ public:
 
   bool is_root(typename numbering<T>::const_iterator it) const
   {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
     return uuf.is_root(it-numbers.begin());
+#include <util/pragma_pop.def>
   }
 
   size_type number(const T &a)

--- a/src/util/xml.cpp
+++ b/src/util/xml.cpp
@@ -236,7 +236,10 @@ std::string xmlt::unescape(const std::string &str)
         result+='&';
       else if(tmp[0]=='#' && tmp[1]!='x')
       {
+#include <util/pragma_push.def>
+#include <util/pragma_wconversion.def>
         char c=unsafe_string2int(tmp.substr(1, tmp.size()-1));
+#include <util/pragma_pop.def>
         result+=c;
       }
       else

--- a/src/xmllang/parser.y
+++ b/src/xmllang/parser.y
@@ -12,6 +12,7 @@ int yyxmlerror(const std::string &error)
   return 0;
 }
 
+#include <util/pragma_wconversion.def>
 %}
 
 %error-verbose

--- a/src/xmllang/scanner.l
+++ b/src/xmllang/scanner.l
@@ -29,6 +29,7 @@ static char *word(char *s)
   return buf;
 }
 
+#include <util/pragma_wconversion.def>
 #include <util/pragma_wsign_compare.def>
 #include <util/pragma_wnull_conversion.def>
 #include <util/pragma_wdeprecated_register.def>


### PR DESCRIPTION
There are several cases of conversion from size_t to int that we cannot fix as
we use system library functions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
