### PR TITLE
Feature invariant cleanup flattening/boolbv_equality.cpp

### DIFF
--- a/src/solvers/flattening/boolbv_equality.cpp
+++ b/src/solvers/flattening/boolbv_equality.cpp
@@ -41,24 +41,24 @@ literalt boolbvt::convert_equality(const equal_exprt &expr)
     return record_array_equality(expr);
   }
 
-  const bvt &bv0=convert_bv(expr.lhs());
-  const bvt &bv1=convert_bv(expr.rhs());
+  const bvt &lhs_bv = convert_bv(expr.lhs());
+  const bvt &rhs_bv = convert_bv(expr.rhs());
 
   DATA_INVARIANT(
-    bv0.size() == bv1.size(),
-    std::string("unexpected size mismatch on equality:\n") + "lhs: " +
-      expr.lhs().pretty() + '\n' + "lhs size: " + std::to_string(bv0.size()) +
-      '\n' + "rhs: " + expr.rhs().pretty() + '\n' +
-      "rhs size: " + std::to_string(bv1.size()));
+    lhs_bv.size() == rhs_bv.size(),
+    std::string("unexpected size mismatch on equality:\n") +
+      "lhs: " + expr.lhs().pretty() + '\n' + "lhs size: " +
+      std::to_string(lhs_bv.size()) + '\n' + "rhs: " + expr.rhs().pretty() +
+      '\n' + "rhs size: " + std::to_string(rhs_bv.size()));
 
-  if(bv0.empty())
+  if(lhs_bv.empty())
   {
     // An empty bit-vector comparison. It's not clear
     // what this is meant to say.
     return prop.new_variable();
   }
 
-  return bv_utils.equal(bv0, bv1);
+  return bv_utils.equal(lhs_bv, rhs_bv);
 }
 
 literalt boolbvt::convert_verilog_case_equality(
@@ -75,18 +75,18 @@ literalt boolbvt::convert_verilog_case_equality(
       "######### lhs: " + expr.lhs().pretty() + '\n' +
       "######### rhs: " + expr.rhs().pretty());
 
-  const bvt &bv0=convert_bv(expr.lhs());
-  const bvt &bv1=convert_bv(expr.rhs());
+  const bvt &lhs_bv = convert_bv(expr.lhs());
+  const bvt &rhs_bv = convert_bv(expr.rhs());
 
   DATA_INVARIANT(
-    bv0.size() == bv1.size(),
+    lhs_bv.size() == rhs_bv.size(),
     std::string("unexpected size mismatch on verilog_case_equality:\n") +
       "lhs: " + expr.lhs().pretty() + '\n' + "lhs size: " +
-      std::to_string(bv0.size()) + '\n' + "rhs: " + expr.rhs().pretty() + '\n' +
-      "rhs size: " + std::to_string(bv1.size()));
+      std::to_string(lhs_bv.size()) + '\n' + "rhs: " + expr.rhs().pretty() +
+      '\n' + "rhs size: " + std::to_string(rhs_bv.size()));
 
   if(expr.id()==ID_verilog_case_inequality)
-    return !bv_utils.equal(bv0, bv1);
+    return !bv_utils.equal(lhs_bv, rhs_bv);
   else
-    return bv_utils.equal(bv0, bv1);
+    return bv_utils.equal(lhs_bv, rhs_bv);
 }

--- a/src/solvers/flattening/boolbv_equality.cpp
+++ b/src/solvers/flattening/boolbv_equality.cpp
@@ -19,13 +19,11 @@ literalt boolbvt::convert_equality(const equal_exprt &expr)
 {
   const bool is_base_type_eq =
     base_type_eq(expr.lhs().type(), expr.rhs().type(), ns);
-  if(!is_base_type_eq)
-  {
-    const std::string error_msg =
-      std::string("equality without matching types:\n") + "######### lhs: " +
-      expr.lhs().pretty() + '\n' + "######### rhs: " + expr.rhs().pretty();
-    throw bitvector_conversion_exceptiont(error_msg, expr);
-  }
+  DATA_INVARIANT_WITH_DIAGNOSTICS(
+    is_base_type_eq,
+    "types of expressions on each side of equality should match",
+    irep_pretty_diagnosticst{expr.lhs()},
+    irep_pretty_diagnosticst{expr.rhs()});
 
   // see if it is an unbounded array
   if(is_unbounded_array(expr.lhs().type()))
@@ -44,12 +42,13 @@ literalt boolbvt::convert_equality(const equal_exprt &expr)
   const bvt &lhs_bv = convert_bv(expr.lhs());
   const bvt &rhs_bv = convert_bv(expr.rhs());
 
-  DATA_INVARIANT(
+  DATA_INVARIANT_WITH_DIAGNOSTICS(
     lhs_bv.size() == rhs_bv.size(),
-    std::string("unexpected size mismatch on equality:\n") +
-      "lhs: " + expr.lhs().pretty() + '\n' + "lhs size: " +
-      std::to_string(lhs_bv.size()) + '\n' + "rhs: " + expr.rhs().pretty() +
-      '\n' + "rhs size: " + std::to_string(rhs_bv.size()));
+    "sizes of lhs and rhs bitvectors should match",
+    irep_pretty_diagnosticst{expr.lhs()},
+    "lhs size: " + std::to_string(lhs_bv.size()),
+    irep_pretty_diagnosticst{expr.rhs()},
+    "rhs size: " + std::to_string(rhs_bv.size()));
 
   if(lhs_bv.empty())
   {
@@ -69,21 +68,22 @@ literalt boolbvt::convert_verilog_case_equality(
 
   const bool is_base_type_eq =
     base_type_eq(expr.lhs().type(), expr.rhs().type(), ns);
-  DATA_INVARIANT(
+  DATA_INVARIANT_WITH_DIAGNOSTICS(
     is_base_type_eq,
-    std::string("verilog_case_equality without matching types:\n") +
-      "######### lhs: " + expr.lhs().pretty() + '\n' +
-      "######### rhs: " + expr.rhs().pretty());
+    "lhs and rhs types should match in verilog_case_equality",
+    irep_pretty_diagnosticst{expr.lhs()},
+    irep_pretty_diagnosticst{expr.rhs()});
 
   const bvt &lhs_bv = convert_bv(expr.lhs());
   const bvt &rhs_bv = convert_bv(expr.rhs());
 
-  DATA_INVARIANT(
+  DATA_INVARIANT_WITH_DIAGNOSTICS(
     lhs_bv.size() == rhs_bv.size(),
-    std::string("unexpected size mismatch on verilog_case_equality:\n") +
-      "lhs: " + expr.lhs().pretty() + '\n' + "lhs size: " +
-      std::to_string(lhs_bv.size()) + '\n' + "rhs: " + expr.rhs().pretty() +
-      '\n' + "rhs size: " + std::to_string(rhs_bv.size()));
+    "bitvector arguments to verilog_case_equality should have the same size",
+    irep_pretty_diagnosticst{expr.lhs()},
+    "lhs size: " + std::to_string(lhs_bv.size()),
+    irep_pretty_diagnosticst{expr.rhs()},
+    "rhs size: " + std::to_string(rhs_bv.size()));
 
   if(expr.id()==ID_verilog_case_inequality)
     return !bv_utils.equal(lhs_bv, rhs_bv);


### PR DESCRIPTION
Most importantly we replace throws with INVARIANTS where errors should've been caught by typechecking and clean up the message of another to make it more in line with the definition of invariants in invariant.h

Also contains some minor refactoring in a separate commit.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed). **(Not applicable)**
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
