### PR TITLE
Do not use deprecated symbol_exprt() in header file

### DIFF
--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -4335,13 +4335,13 @@ class function_application_exprt:public binary_exprt
 public:
   function_application_exprt():binary_exprt(ID_function_application)
   {
-    op0()=symbol_exprt();
+    op0().id(ID_symbol);
   }
 
   explicit function_application_exprt(const typet &_type):
     binary_exprt(ID_function_application, _type)
   {
-    op0()=symbol_exprt();
+    op0().id(ID_symbol);
   }
 
   function_application_exprt(


### PR DESCRIPTION
std_expr.h is widely used, and using a deprecated constructor results in
spamming of log files.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
