### PR TITLE
Remove let_exprt's default constructor

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -4754,13 +4754,10 @@ exprt smt2_convt::letify_rec(
   if(map.find(current)->second.count < LET_COUNT)
     return letify_rec(expr, let_order, map, i+1);
 
-  let_exprt let;
-
-  let.symbol() = map.find(current)->second.let_symbol;
-  let.value() = substitute_let(current, map);
-  let.where() = letify_rec(expr, let_order, map, i+1);
-
-  return let;
+  return let_exprt(
+    map.find(current)->second.let_symbol,
+    substitute_let(current, map),
+    letify_rec(expr, let_order, map, i + 1));
 }
 
 void smt2_convt::collect_bindings(

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -188,11 +188,10 @@ exprt smt2_parsert::let_expression()
   // go backwards, build let_expr
   for(auto r_it=bindings.rbegin(); r_it!=bindings.rend(); r_it++)
   {
-    let_exprt let;
-    let.symbol()=symbol_exprt(r_it->first, r_it->second.type());
-    let.value()=r_it->second;
-    let.type()=result.type();
-    let.where().swap(result);
+    const let_exprt let(
+      symbol_exprt(r_it->first, r_it->second.type()),
+      r_it->second,
+      result);
     result=let;
   }
 

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -4491,13 +4491,15 @@ public:
 };
 
 /// \brief A let expression
-class let_exprt:public exprt
+class let_exprt : public ternary_exprt
 {
 public:
-  let_exprt():exprt(ID_let)
+  let_exprt(
+    const symbol_exprt &symbol,
+    const exprt &value,
+    const exprt &where)
+    : ternary_exprt(ID_let, symbol, value, where, where.type())
   {
-    operands().resize(3);
-    op0()=symbol_exprt();
   }
 
   symbol_exprt &symbol()


### PR DESCRIPTION
This fosters RIAA and avoids using the deprecated symbol_exprt() constructor.
Also make let_exprt a ternary_exprt.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
