### PR TITLE
Remove unused quantifier_exprt default constructor

### DIFF
--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -4565,11 +4565,6 @@ inline void validate_expr(const let_exprt &value)
 class quantifier_exprt:public binary_predicate_exprt
 {
 public:
-  explicit quantifier_exprt(const irep_idt &_id):binary_predicate_exprt(_id)
-  {
-    op0()=symbol_exprt();
-  }
-
   quantifier_exprt(
     const irep_idt &_id,
     const symbol_exprt &_symbol,
@@ -4635,10 +4630,6 @@ inline void validate_expr(const quantifier_exprt &value)
 class forall_exprt:public quantifier_exprt
 {
 public:
-  forall_exprt():quantifier_exprt(ID_forall)
-  {
-  }
-
   forall_exprt(const symbol_exprt &_symbol, const exprt &_where)
     : quantifier_exprt(ID_forall, _symbol, _where)
   {
@@ -4649,10 +4640,6 @@ public:
 class exists_exprt:public quantifier_exprt
 {
 public:
-  exists_exprt():quantifier_exprt(ID_exists)
-  {
-  }
-
   exists_exprt(const symbol_exprt &_symbol, const exprt &_where)
     : quantifier_exprt(ID_exists, _symbol, _where)
   {


### PR DESCRIPTION
It made use of the deprecated symbol_exprt() constructor and was never used
anyway.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
