### PR TITLE
Remove unused type temp_working_dirt

### DIFF
--- a/src/util/tempdir.cpp
+++ b/src/util/tempdir.cpp
@@ -101,17 +101,3 @@ temp_dirt::~temp_dirt()
 {
   clear();
 }
-
-temp_working_dirt::temp_working_dirt(const std::string &name_template):
-  temp_dirt(name_template)
-{
-  old_working_directory=get_current_working_directory();
-  if(chdir(path.c_str())!=0)
-    CHECK_RETURN(false);
-}
-
-temp_working_dirt::~temp_working_dirt()
-{
-  if(chdir(old_working_directory.c_str())!=0)
-    CHECK_RETURN(false);
-}

--- a/src/util/tempdir.h
+++ b/src/util/tempdir.h
@@ -29,17 +29,4 @@ public:
   ~temp_dirt();
 };
 
-// Produces a temporary directory,
-// chdir()s there,
-// and deletes it upon destruction,
-// and goes back to the old working directory.
-class temp_working_dirt:public temp_dirt
-{
-public:
-  std::string old_working_directory;
-
-  explicit temp_working_dirt(const std::string &name_template);
-  ~temp_working_dirt();
-};
-
 #endif // CPROVER_UTIL_TEMPDIR_H


### PR DESCRIPTION
This type has been added in 2012 and is presently unused. In its present state
it is difficult to use as it doesn't permit any way to recover from potential
errors (it is instead asserted that no errors can happen, which is not true).

Should functionally like this be needed in the future, I'd recommend a wrapper
function like

```
template<typename Closure>
void run_with_different_working_dir(
  const std::string& working_dir, Closure closure);
```

Which would change the working directory, execute the closure and change the
working directory back afterwards, throwing a system_exceptiont on failure.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
