### PR TITLE
Fix handling of case range statement in special case

### DIFF
--- a/regression/ansi-c/goto_convert_switch_range_empty/test.desc
+++ b/regression/ansi-c/goto_convert_switch_range_empty/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/goto_convert_switch_range_empty_nodefault/main.c
+++ b/regression/ansi-c/goto_convert_switch_range_empty_nodefault/main.c
@@ -1,0 +1,10 @@
+int main()
+{
+  int x;
+  switch(x)
+  {
+  case 10 ... 0:
+    break;
+  }
+  return 0;
+}

--- a/regression/ansi-c/goto_convert_switch_range_empty_nodefault/test.desc
+++ b/regression/ansi-c/goto_convert_switch_range_empty_nodefault/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^Invariant check failed

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1249,7 +1249,8 @@ void goto_convertt::convert_switch(
   {
     const caset &case_ops=case_pair.second;
 
-    assert(!case_ops.empty());
+    if (case_ops.empty())
+      continue;
 
     exprt guard_expr=case_guard(argument, case_ops);
 


### PR DESCRIPTION
In the case where a gcc case range switch statement has a case that reduces to an empty expression, both gcc and clang reluctantly accept it, producing warnings. CBMC up until now was asserting against that case, and this divergence in behaviour was unwanted.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
  - Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
 - My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
