### PR TITLE
Revert "Workaround for Google Cloud SDK packaging problem"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
               key_url: 'https://packages.cloud.google.com/apt/doc/apt-key.gpg'
           packages:
             - cmake
-            - google-cloud-sdk=216.0.0-0
+            - google-cloud-sdk
             - graphviz
       cache:
         directories:


### PR DESCRIPTION
This reverts commit 60540c7fa5c98ee644a2ace64556a02b6f1c9ec2.

The problem has been addressed in version 218.0.0-0 of the Google Cloud SDK.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [n/a] My contribution is formatted in line with CODING_STANDARD.md.
- [n/a] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [n/a] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
