### PR TITLE
Some extra tests for do_function_call_symbol

### DIFF
--- a/regression/cbmc/assert_func_four/main.c
+++ b/regression/cbmc/assert_func_four/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  __assert_func();
+
+  return 0;
+}

--- a/regression/cbmc/assert_func_four/test.desc
+++ b/regression/cbmc/assert_func_four/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+expected to have four arguments
+--

--- a/regression/cbmc/assert_lhs/main.c
+++ b/regression/cbmc/assert_lhs/main.c
@@ -1,0 +1,7 @@
+int main()
+{
+  int n;
+  int m = assert(n > 5);
+
+  return 0;
+}

--- a/regression/cbmc/assert_lhs/test.desc
+++ b/regression/cbmc/assert_lhs/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+expected not to have LHS
+--

--- a/regression/cbmc/assert_one/main.c
+++ b/regression/cbmc/assert_one/main.c
@@ -1,0 +1,7 @@
+int main()
+{
+  int n;
+  int m = assert(n > 5, 5);
+
+  return 0;
+}

--- a/regression/cbmc/assert_one/test.desc
+++ b/regression/cbmc/assert_one/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+expected to have one argument
+--

--- a/regression/cbmc/assert_rtn_four/main.c
+++ b/regression/cbmc/assert_rtn_four/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  __assert_rtn();
+
+  return 0;
+}

--- a/regression/cbmc/assert_rtn_four/test.desc
+++ b/regression/cbmc/assert_rtn_four/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+expected to have four arguments
+--

--- a/regression/cbmc/builtin_is/main.c
+++ b/regression/cbmc/builtin_is/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int n, m;
+  __builtin_isgreater(n, m);
+  return 0;
+}

--- a/regression/cbmc/builtin_is/test.desc
+++ b/regression/cbmc/builtin_is/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+expected to have two float/double arguments
+--

--- a/regression/cbmc/builtin_va_copy_lvalue/main.c
+++ b/regression/cbmc/builtin_va_copy_lvalue/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int n;
+  __builtin_va_copy(5, n);
+  return 0;
+}

--- a/regression/cbmc/builtin_va_copy_lvalue/test.desc
+++ b/regression/cbmc/builtin_va_copy_lvalue/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+argument expected to be lvalue
+--

--- a/regression/cbmc/builtin_va_copy_two/main.c
+++ b/regression/cbmc/builtin_va_copy_two/main.c
@@ -1,0 +1,5 @@
+int main()
+{
+  __builtin_va_copy();
+  return 0;
+}

--- a/regression/cbmc/builtin_va_copy_two/test.desc
+++ b/regression/cbmc/builtin_va_copy_two/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+wrong number of function arguments
+--

--- a/regression/cbmc/builtin_va_end_lvalue/main.c
+++ b/regression/cbmc/builtin_va_end_lvalue/main.c
@@ -1,0 +1,5 @@
+int main()
+{
+  __builtin_va_end(5);
+  return 0;
+}

--- a/regression/cbmc/builtin_va_end_lvalue/test.desc
+++ b/regression/cbmc/builtin_va_end_lvalue/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+argument expected to be lvalue
+--

--- a/regression/cbmc/builtin_va_end_one/main.c
+++ b/regression/cbmc/builtin_va_end_one/main.c
@@ -1,0 +1,5 @@
+int main()
+{
+  __builtin_va_end();
+  return 0;
+}

--- a/regression/cbmc/builtin_va_end_one/test.desc
+++ b/regression/cbmc/builtin_va_end_one/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+wrong number of function arguments
+--

--- a/regression/cbmc/builtin_va_start_lvalue/main.c
+++ b/regression/cbmc/builtin_va_start_lvalue/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int n;
+  __builtin_va_start(5, n);
+  return 0;
+}

--- a/regression/cbmc/builtin_va_start_lvalue/test.desc
+++ b/regression/cbmc/builtin_va_start_lvalue/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+argument expected to be lvalue
+--

--- a/regression/cbmc/builtin_va_start_two/main.c
+++ b/regression/cbmc/builtin_va_start_two/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int n;
+  __builtin_va_start(n, 5, 5);
+  return 0;
+}

--- a/regression/cbmc/builtin_va_start_two/test.desc
+++ b/regression/cbmc/builtin_va_start_two/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+expected to have two arguments
+--

--- a/regression/cbmc/cprover_assert_lhs/main.c
+++ b/regression/cbmc/cprover_assert_lhs/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  void m = __CPROVER_assert("n>5", "foo");
+
+  return 0;
+}

--- a/regression/cbmc/cprover_assert_lhs/test.desc
+++ b/regression/cbmc/cprover_assert_lhs/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+expected not to have LHS
+--

--- a/regression/cbmc/cprover_assert_two/main.c
+++ b/regression/cbmc/cprover_assert_two/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  __CPROVER_assert();
+
+  return 0;
+}

--- a/regression/cbmc/cprover_assert_two/test.desc
+++ b/regression/cbmc/cprover_assert_two/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+wrong number of function arguments
+--

--- a/regression/cbmc/cprover_fence_one/main.c
+++ b/regression/cbmc/cprover_fence_one/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  __CPROVER_fence();
+
+  return 0;
+}

--- a/regression/cbmc/cprover_fence_one/test.desc
+++ b/regression/cbmc/cprover_fence_one/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+not enough function arguments
+--

--- a/regression/cbmc/cprover_havoc_object_lhs/main.c
+++ b/regression/cbmc/cprover_havoc_object_lhs/main.c
@@ -1,0 +1,7 @@
+int main()
+{
+  int n;
+  void m = __CPROVER_havoc_object(n);
+
+  return 0;
+}

--- a/regression/cbmc/cprover_havoc_object_lhs/test.desc
+++ b/regression/cbmc/cprover_havoc_object_lhs/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+expected not to have LHS
+--

--- a/regression/cbmc/cprover_havoc_object_one/main.c
+++ b/regression/cbmc/cprover_havoc_object_one/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  __CPROVER_havoc_object();
+
+  return 0;
+}

--- a/regression/cbmc/cprover_havoc_object_one/test.desc
+++ b/regression/cbmc/cprover_havoc_object_one/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+wrong number of function arguments
+--

--- a/regression/cbmc/cprover_input_lhs/main.c
+++ b/regression/cbmc/cprover_input_lhs/main.c
@@ -1,0 +1,7 @@
+int main()
+{
+  int n;
+  void m = __CPROVER_input(n);
+
+  return 0;
+}

--- a/regression/cbmc/cprover_input_lhs/test.desc
+++ b/regression/cbmc/cprover_input_lhs/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+expected not to have LHS
+--

--- a/regression/cbmc/cprover_output_lhs/main.c
+++ b/regression/cbmc/cprover_output_lhs/main.c
@@ -1,0 +1,7 @@
+int main()
+{
+  int n;
+  void m = __CPROVER_output(n);
+
+  return 0;
+}

--- a/regression/cbmc/cprover_output_lhs/test.desc
+++ b/regression/cbmc/cprover_output_lhs/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+expected not to have LHS
+--

--- a/regression/cbmc/function_not_found/main.c
+++ b/regression/cbmc/function_not_found/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  foo();
+
+  return 0;
+}

--- a/regression/cbmc/function_not_found/test.desc
+++ b/regression/cbmc/function_not_found/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+expected not to have LHS
+--

--- a/regression/cbmc/gcc_builtin_va_arg_one/main.c
+++ b/regression/cbmc/gcc_builtin_va_arg_one/main.c
@@ -1,0 +1,8 @@
+int main()
+{
+  int n;
+
+  gcc_builtin_va_arg();
+
+  return 0;
+}

--- a/regression/cbmc/gcc_builtin_va_arg_one/test.desc
+++ b/regression/cbmc/gcc_builtin_va_arg_one/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+expected to have one argument
+--

--- a/regression/cbmc/sync_X_and_fetch_pointer/main.c
+++ b/regression/cbmc/sync_X_and_fetch_pointer/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int n, *m;
+  __sync_add_and_fetch(n, m);
+  return 0;
+}

--- a/regression/cbmc/sync_X_and_fetch_pointer/test.desc
+++ b/regression/cbmc/sync_X_and_fetch_pointer/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+primitives take pointer as first argument
+CONVERSION ERROR
+--

--- a/regression/cbmc/sync_X_and_fetch_two/main.c
+++ b/regression/cbmc/sync_X_and_fetch_two/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int *n;
+  __sync_add_and_fetch(n);
+  return 0;
+}

--- a/regression/cbmc/sync_X_and_fetch_two/test.desc
+++ b/regression/cbmc/sync_X_and_fetch_two/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+expected to have at least two arguments
+--

--- a/regression/cbmc/sync_bool_compare_pointer/main.c
+++ b/regression/cbmc/sync_bool_compare_pointer/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int n, *m, *o;
+  __sync_bool_compare_and_swap(n, m, o);
+  return 0;
+}

--- a/regression/cbmc/sync_bool_compare_pointer/test.desc
+++ b/regression/cbmc/sync_bool_compare_pointer/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+expected to have pointer argument
+--

--- a/regression/cbmc/sync_bool_compare_three/main.c
+++ b/regression/cbmc/sync_bool_compare_three/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int *n, *m;
+  __sync_bool_compare_and_swap(n, m);
+  return 0;
+}

--- a/regression/cbmc/sync_bool_compare_three/test.desc
+++ b/regression/cbmc/sync_bool_compare_three/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+expected to have at least three arguments
+--

--- a/regression/cbmc/sync_fetch_and_X_pointer/main.c
+++ b/regression/cbmc/sync_fetch_and_X_pointer/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int n, *m;
+  __sync_fetch_and_add(n, m);
+  return 0;
+}

--- a/regression/cbmc/sync_fetch_and_X_pointer/test.desc
+++ b/regression/cbmc/sync_fetch_and_X_pointer/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+primitives take pointer as first argument
+CONVERSION ERROR
+--

--- a/regression/cbmc/sync_fetch_and_X_two/main.c
+++ b/regression/cbmc/sync_fetch_and_X_two/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int *n;
+  __sync_fetch_and_add(n);
+  return 0;
+}

--- a/regression/cbmc/sync_fetch_and_X_two/test.desc
+++ b/regression/cbmc/sync_fetch_and_X_two/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+expected to have at least two arguments
+--

--- a/regression/cbmc/sync_val_compare_pointer/main.c
+++ b/regression/cbmc/sync_val_compare_pointer/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int n, *m, *o;
+  __sync_val_compare_and_swap(n, m, o);
+  return 0;
+}

--- a/regression/cbmc/sync_val_compare_pointer/test.desc
+++ b/regression/cbmc/sync_val_compare_pointer/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+primitives take pointer as first argument
+CONVERSION ERROR
+--

--- a/regression/cbmc/sync_val_compare_three/main.c
+++ b/regression/cbmc/sync_val_compare_three/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int *n, *m;
+  __sync_val_compare_and_swap(n, m);
+  return 0;
+}

--- a/regression/cbmc/sync_val_compare_three/test.desc
+++ b/regression/cbmc/sync_val_compare_three/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+expected to have at least three arguments
+--

--- a/regression/cbmc/verifier_assume_lhs/main.c
+++ b/regression/cbmc/verifier_assume_lhs/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  void m = __VERIFIER_assume(5);
+
+  return 0;
+}

--- a/regression/cbmc/verifier_assume_lhs/test.desc
+++ b/regression/cbmc/verifier_assume_lhs/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+expected not to have LHS
+--

--- a/regression/cbmc/verifier_assume_one/main.c
+++ b/regression/cbmc/verifier_assume_one/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  __VERIFIER_assume();
+
+  return 0;
+}

--- a/regression/cbmc/verifier_assume_one/test.desc
+++ b/regression/cbmc/verifier_assume_one/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+wrong number of function arguments
+--

--- a/regression/cbmc/verifier_error_lhs/main.c
+++ b/regression/cbmc/verifier_error_lhs/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int m = __VERIFIER_error();
+
+  return 0;
+}

--- a/regression/cbmc/verifier_error_lhs/test.desc
+++ b/regression/cbmc/verifier_error_lhs/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+expected not to have LHS
+--

--- a/regression/cbmc/verifier_error_zero/main.c
+++ b/regression/cbmc/verifier_error_zero/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  __VERIFIER_error(4);
+
+  return 0;
+}

--- a/regression/cbmc/verifier_error_zero/test.desc
+++ b/regression/cbmc/verifier_error_zero/test.desc
@@ -1,0 +1,7 @@
+KNOWNBUG
+main.c
+
+^EXIT=6$
+^SIGNAL=0$
+expected to have no arguments
+--


### PR DESCRIPTION
These tests demonstrate that 'error' conditions in builtin_functions.cpp can currently be reached; This will be useful for improving the frontend to catch them earlier.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
