### PR TITLE
trigger library build in top-level Makefile

### DIFF
--- a/jbmc/src/Makefile
+++ b/jbmc/src/Makefile
@@ -4,7 +4,7 @@ ROOT = ../
 include config.inc
 
 .PHONY: all
-all: janalyzer.dir jbmc.dir jdiff.dir
+all: janalyzer.dir jbmc.dir jdiff.dir library
 
 # building cbmc proper
 .PHONY: cprover.dir
@@ -25,6 +25,19 @@ jdiff.dir: java_bytecode.dir cprover.dir
 
 .PHONY: miniz.dir
 miniz.dir:
+
+LIBRARY_DIR = ../lib/java-models-library
+
+clean: clean_library
+
+.PHONY: clean_library
+clean_library:
+	rm -rf core-models.jar
+	if [ -d $(LIBRARY_DIR) ]; then cd $(LIBRARY_DIR); mvn clean; fi
+
+.PHONY: library
+library:
+	if [ -d $(LIBRARY_DIR) ]; then (cd $(LIBRARY_DIR); mvn package); cp $(LIBRARY_DIR)/target/core-models.jar java_bytecode/library/ ; fi
 
 $(patsubst %, %.dir, $(DIRS)):
 	## Entering $(basename $@)

--- a/jbmc/src/java_bytecode/Makefile
+++ b/jbmc/src/java_bytecode/Makefile
@@ -52,17 +52,7 @@ include ../$(CPROVER_DIR)/src/common
 
 CLEANFILES = java_bytecode$(LIBEXT)
 
-all: library java_bytecode$(LIBEXT)
-
-clean: clean_library
-
-.PHONY: clean_library
-clean_library:
-	$(MAKE) clean -C library
-
-.PHONY: library
-library:
-	$(MAKE) -C library
+all: java_bytecode$(LIBEXT)
 
 ###############################################################################
 


### PR DESCRIPTION
This matches what the cmake build does, and prevents an unnecessary ~2s
delay when 'make' is called in java_bytecode.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
