### PR TITLE
Make regression test pass when sizeof(size_t) == sizeof(int)

### DIFF
--- a/regression/goto-analyzer/dependence-graph14/test.desc
+++ b/regression/goto-analyzer/dependence-graph14/test.desc
@@ -4,9 +4,9 @@ main.c
 activate-multi-line-match
 ^EXIT=0$
 ^SIGNAL=0$
-\/\/ ([0-9]+).*\n.*a\[\(signed long( long)? int\)2\] = 2;(.*\n)*Data dependencies: (\1)\n(.*\n){2,3}.*out = *
+\/\/ ([0-9]+).*\n.*a\[(\(signed long( long)? int\))?2\] = 2;(.*\n)*Data dependencies: (\1)\n(.*\n){2,3}.*out = *
 --
-\/\/ ([0-9]+).*\n.*a\[\(signed long( long)? int\)1\] = 1;(.*\n)*Data dependencies: (\1)\n(.*\n){2,3}.*out = *
+\/\/ ([0-9]+).*\n.*a\[(\(signed long( long)? int\))?1\] = 1;(.*\n)*Data dependencies: (\1)\n(.*\n){2,3}.*out = *
 ^warning: ignoring
 --
 


### PR DESCRIPTION
The type cast previously tested for in the regression test will only be
introduced when the type of an array index is not the same as int. Thus the test
spuriously failed on 32-bit x86 platforms.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [n/a] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [n/a] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
