### PR TITLE
Little-endian PowerPC-64 uses __ieee128 instead of __float128

### DIFF
--- a/src/ansi-c/ansi_c_internal_additions.cpp
+++ b/src/ansi-c/ansi_c_internal_additions.cpp
@@ -194,15 +194,20 @@ void ansi_c_internal_additions(std::string &code)
 
     if(
       config.ansi_c.arch == "i386" || config.ansi_c.arch == "x86_64" ||
-      config.ansi_c.arch == "x32" || config.ansi_c.arch == "powerpc" ||
-      config.ansi_c.arch == "ppc64" || config.ansi_c.arch == "ppc64le" ||
-      config.ansi_c.arch == "ia64")
+      config.ansi_c.arch == "x32" || config.ansi_c.arch == "ia64" ||
+      config.ansi_c.arch == "powerpc" || config.ansi_c.arch == "ppc64")
     {
       // https://gcc.gnu.org/onlinedocs/gcc/Floating-Types.html
       // For clang, __float128 is a keyword.
       // For gcc, this is a typedef and not a keyword.
       if(config.ansi_c.mode != configt::ansi_ct::flavourt::CLANG)
         code += "typedef __CPROVER_Float128 __float128;\n";
+    }
+    else if(config.ansi_c.arch == "ppc64le")
+    {
+      // https://patchwork.ozlabs.org/patch/792295/
+      if(config.ansi_c.mode != configt::ansi_ct::flavourt::CLANG)
+        code += "typedef __CPROVER_Float128 __ieee128;\n";
     }
     else if(config.ansi_c.arch == "hppa")
     {


### PR DESCRIPTION
GCC set a macro re-defining __float128 to __ieee128, but just on this one
architecture. See
https://buildd.debian.org/status/logs.php?pkg=cbmc&arch=ppc64el,
https://buildd.debian.org/status/logs.php?pkg=cbmc&arch=ppc64,
https://buildd.debian.org/status/logs.php?pkg=cbmc&arch=powerpc,
with the build logs for 5.10-2 vs. 5.10-3.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [n/a] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [n/a] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
