### PR TITLE
Only test for __float80 on architectures where it is available

### DIFF
--- a/regression/ansi-c/gcc_float_types1/main.c
+++ b/regression/ansi-c/gcc_float_types1/main.c
@@ -1,9 +1,12 @@
 // for gcc, __float80 and __float128 are typedefs
 // for clang, __float128 is a keyword, and __float80 doesn't exist.
 
-#ifdef __clang__
+#if defined(__clang__) || \
+    !(defined(__ia64__) || defined(__x86_64__) || defined(__i386__))
 int __float80;
+#if (defined(__hppa__) || defined(__powerpc__))
 __float128 f128;
+#endif
 #else
 __float80 f80;
 __float128 f128;

--- a/regression/ansi-c/gcc_types_compatible_p1/main.c
+++ b/regression/ansi-c/gcc_types_compatible_p1/main.c
@@ -98,7 +98,8 @@ STATIC_ASSERT(!__builtin_types_compatible_p(unsigned, signed));
 STATIC_ASSERT(!__builtin_types_compatible_p(__int128, unsigned __int128));
 
 // clang doesn't have these
-#if !defined(__clang__)
+#if !defined(__clang__) && \
+    (defined(__ia64__) || defined(__x86_64__) || defined(__i386__))
 #if __GNUC__ >= 7
 STATIC_ASSERT(!__builtin_types_compatible_p(_Float32, float));
 STATIC_ASSERT(!__builtin_types_compatible_p(_Float64, double));


### PR DESCRIPTION
Our C front-end carefully selects the architectures where it should be
supported, but regression tests were entirely general.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [n/a] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [n/a] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
