### PR TITLE
Update link to build CBMC from source in cbmc-user-manual

### DIFF
--- a/doc/cbmc-user-manual.md
+++ b/doc/cbmc-user-manual.md
@@ -145,11 +145,7 @@ You are now ready to \ref man_cbmc-tutorial "use CBMC"!
 
 ### Building CBMC from Source
 
-Alternatively, the CBMC source code is available [via
-SVN](http://www.cprover.org/svn/cbmc/). To compile the source code,
-follow [these
-instructions](http://www.cprover.org/svn/cbmc/trunk/COMPILING).
-
+See \ref compilation-and-development
 
 
 \subsection man_install-eclipse Installing the Eclipse Plugin


### PR DESCRIPTION
There were out of date links in the cbmc user manual about getting the source code and building it.  These have been replaced with a link to compilation-and-development.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
