### PR TITLE
deprecates exprt::move_to_operands(...)

### DIFF
--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -105,8 +105,13 @@ public:
   void reserve_operands(operandst::size_type n)
   { operands().reserve(n) ; }
 
+  DEPRECATED("use copy_to_operands(expr) instead")
   void move_to_operands(exprt &expr);
+
+  DEPRECATED("use copy_to_operands(e1, e2) instead")
   void move_to_operands(exprt &e1, exprt &e2);
+
+  DEPRECATED("use copy_to_operands(e1, e2, e3) instead")
   void move_to_operands(exprt &e1, exprt &e2, exprt &e3);
 
   /// Copy the given argument to the end of `exprt`'s operands.


### PR DESCRIPTION
Since sharing has been introduced there is no measureable performance
benefit when using move_to_operands compared to copying.  Moving has the
disadvantage that there is a side-effect on the object that is moved.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
