### PR TITLE
allow binary arithmetic of a vector type and a scalar type

### DIFF
--- a/regression/cbmc/gcc_vector1/main.c
+++ b/regression/cbmc/gcc_vector1/main.c
@@ -18,6 +18,7 @@ int main()
 
   vector_u x, y, z;
 
+  // vector operator vector
   z.v=x.v+y.v;
 
   assert(z.members[0]==x.members[0]+y.members[0]);
@@ -45,6 +46,22 @@ int main()
   assert(z.members[1]==~x.members[1]);
   assert(z.members[2]==~x.members[2]);
   assert(z.members[3]==~x.members[3]);
+
+  // vector operator scalar
+  z=x;
+  z.v=z.v+1;
+  assert(z.members[0]==x.members[0]+1);
+  assert(z.members[1]==x.members[1]+1);
+  assert(z.members[2]==x.members[2]+1);
+  assert(z.members[3]==x.members[3]+1);
+
+  // unary operators on vectors
+  z=x;
+  z.v=-z.v;
+  assert(z.members[0]==-x.members[0]);
+  assert(z.members[1]==-x.members[1]);
+  assert(z.members[2]==-x.members[2]);
+  assert(z.members[3]==-x.members[3]);
 
   // build vector with typecast
   z.v=(v4si){ 0, 1, 2, 3 };

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2983,6 +2983,24 @@ void c_typecheck_baset::typecheck_expr_binary_arithmetic(exprt &expr)
       return;
     }
   }
+  else if(
+    o_type0.id() == ID_vector && o_type1.id() != ID_vector &&
+    is_number(o_type1))
+  {
+    // convert op1 to the vector type
+    op1.make_typecast(o_type0);
+    expr.type() = o_type0;
+    return;
+  }
+  else if(
+    o_type0.id() != ID_vector && o_type1.id() == ID_vector &&
+    is_number(o_type0))
+  {
+    // convert op0 to the vector type
+    op0.make_typecast(o_type1);
+    expr.type() = o_type1;
+    return;
+  }
 
   // promote!
 

--- a/src/goto-programs/remove_vector.cpp
+++ b/src/goto-programs/remove_vector.cpp
@@ -135,6 +135,23 @@ static void remove_vector(exprt &expr)
     {
       expr.id(ID_array);
     }
+    else if(expr.id() == ID_typecast)
+    {
+      const auto &op = to_typecast_expr(expr).op();
+
+      if(op.type().id() != ID_array)
+      {
+        // (vector-type) x ==> { x, x, ..., x }
+        remove_vector(expr.type());
+        array_typet array_type = to_array_type(expr.type());
+        const auto dimension = numeric_cast_v<std::size_t>(array_type.size());
+        exprt casted_op =
+          typecast_exprt::conditional_cast(op, array_type.subtype());
+        array_exprt array_expr(array_type);
+        array_expr.operands().resize(dimension, op);
+        expr = array_expr;
+      }
+    }
   }
 
   remove_vector(expr.type());


### PR DESCRIPTION
This is required for regression/ansi-c/MMX2 to pass on newer versions of
clang.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
