### PR TITLE
Fix SMT2 parse bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,7 @@ jobs:
             - parallel
       before_install:
         - mkdir bin
+        - wget --directory-prefix=bin https://github.com/Z3Prover/z3/releases/download/z3-4.7.1/z3-4.7.1-x64-ubuntu-14.04.zip && unzip -d bin bin/z3-4.7.1-x64-ubuntu-14.04.zip && ln -s $PWD/bin/z3-4.7.1-x64-ubuntu-14.04/bin/z3 bin/z3
         - ln -s /usr/bin/gcc-5 bin/gcc
         - ln -s /usr/bin/g++-5 bin/g++
       # env: COMPILER=g++-5 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover -fno-omit-frame-pointer"
@@ -118,7 +119,7 @@ jobs:
       compiler: clang
       cache: ccache
       before_install:
-        - HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache parallel
+        - HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache parallel z3
         - export PATH=$PATH:/usr/local/opt/ccache/libexec
       env: COMPILER="ccache clang++"
 
@@ -171,7 +172,7 @@ jobs:
         - ln -s /usr/bin/gcc-5 bin/gcc
         - ln -s /usr/bin/c++-5 bin/g++
         - export CCACHE_CPP2=yes
-      # env: COMPILER=clang++-3.7 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined,integer -fno-omit-frame-pointer"
+        - wget --directory-prefix=bin https://github.com/Z3Prover/z3/releases/download/z3-4.7.1/z3-4.7.1-x64-ubuntu-14.04.zip && unzip -d bin bin/z3-4.7.1-x64-ubuntu-14.04.zip && ln -s $PWD/bin/z3-4.7.1-x64-ubuntu-14.04/bin/z3 bin/z3
       env:
         - COMPILER="ccache /usr/bin/clang++-3.7"
         - EXTRA_CXXFLAGS="-Qunused-arguments -fcolor-diagnostics -DNDEBUG"
@@ -361,6 +362,7 @@ install:
 script:
   - if [ -e bin/gcc ] ; then export PATH=$PWD/bin:$PATH ; fi ;
   - env UBSAN_OPTIONS=print_stacktrace=1 make -C regression test-parallel "CXX=${COMPILER} ${EXTRA_CXXFLAGS}" -j2 JOBS=2
+  - env UBSAN_OPTIONS=print_stacktrace=1 make -C regression/cbmc-smt test "CXX=${COMPILER} ${EXTRA_CXXFLAGS}" -j2 JOBS=2
   - make -C unit "CXX=${COMPILER} ${EXTRA_CXXFLAGS}" -j2
   - make -C unit test
   - env UBSAN_OPTIONS=print_stacktrace=1 make -C jbmc/regression test-parallel "CXX=${COMPILER} ${EXTRA_CXXFLAGS}" -j2 JOBS=2

--- a/buildspec-windows.yml
+++ b/buildspec-windows.yml
@@ -6,6 +6,11 @@ phases:
       - choco install cyg-get -y --no-progress
       - cyg-get bash patch bison flex make wget perl
       - nuget install clcache -OutputDirectory "c:\tools" -ExcludeVersion -Version 4.1.0
+      - |
+        $env:Path = "C:\tools\cygwin\bin;$env:Path"
+        cmd /c 'wget --directory-prefix=/cygdrive/c/tools https://github.com/Z3Prover/z3/releases/download/z3-4.7.1/z3-4.7.1-x64-win.zip'
+        Expand-Archive c:\tools\z3-4.7.1-x64-win.zip -DestinationPath C:\tools
+        
 
   build:
     commands:
@@ -64,9 +69,10 @@ phases:
         cd ../..
 
       - |
-        $env:Path = "C:\tools\cygwin\bin;$env:Path"
+        $env:Path = "C:\tools\cygwin\bin;C:\tools\cygwin\bin;c:\tools\z3-4.7.1-x64-win\bin;$env:Path"
         cmd /c 'call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64 && bash -c "make -C regression test BUILD_ENV=MSVC" '
         cmd /c 'call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64 && bash -c "make -C regression/goto-cl test BUILD_ENV=MSVC" '
+        cmd /c 'call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64 && bash -c "make -C regression/cbmc-smt test BUILD_ENV=MSVC" '
 
       - |
         $env:Path = "C:\tools\cygwin\bin;$env:Path"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,6 +11,7 @@ phases:
       - apt-get install -y openjdk-8-jdk
       - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 1
       - update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 1
+      - wget --directory-prefix=bin https://github.com/Z3Prover/z3/releases/download/z3-4.7.1/z3-4.7.1-x64-ubuntu-14.04.zip && unzip -d bin bin/z3-4.7.1-x64-ubuntu-14.04.zip && ln -s $PWD/bin/z3-4.7.1-x64-ubuntu-14.04/bin/z3 /usr/bin/z3
   build:
     commands:
       - echo Build started on `date`
@@ -24,6 +25,7 @@ phases:
     commands:
       - make -C unit test
       - make -C regression test
+      - make -C regression/cbmc-smt test
       - make -C jbmc/unit test
       - make -C jbmc/regression test
       - echo Build completed on `date`

--- a/regression/cbmc-smt/Makefile
+++ b/regression/cbmc-smt/Makefile
@@ -1,0 +1,19 @@
+default: tests.log
+
+test:
+	@../test.pl -p -c ../../../src/cbmc/cbmc
+
+tests.log: ../test.pl
+	@../test.pl -p -c ../../../src/cbmc/cbmc
+
+show:
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			vim -o "$$dir/*.c" "$$dir/*.out"; \
+		fi; \
+	done;
+
+clean:
+	find -name '*.out' -execdir $(RM) '{}' \;
+	find -name '*.smt2' -execdir $(RM) '{}' \;
+	$(RM) tests.log

--- a/regression/cbmc-smt/assert1/main.c
+++ b/regression/cbmc-smt/assert1/main.c
@@ -1,0 +1,4 @@
+int main(void)
+{
+  __CPROVER_assert((__CPROVER_bool)0, "");
+}

--- a/regression/cbmc-smt/assert1/test.desc
+++ b/regression/cbmc-smt/assert1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--smt2
+activate-multi-line-match
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/cbmc-smt/float1/main.c
+++ b/regression/cbmc-smt/float1/main.c
@@ -1,0 +1,8 @@
+int main(void)
+{
+  float f = 0.5;
+  float g;
+
+  float result = f + g;
+  __CPROVER_assert(result >= 1.5, "");
+}

--- a/regression/cbmc-smt/float1/test.desc
+++ b/regression/cbmc-smt/float1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--smt2 --fpa
+activate-multi-line-match
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/cbmc-smt/struct1/main.c
+++ b/regression/cbmc-smt/struct1/main.c
@@ -1,0 +1,13 @@
+struct datat
+{
+  char c;
+  int i;
+};
+
+int main(void)
+{
+  struct datat data;
+  data.c = '\0';
+
+  __CPROVER_assert(data.i == 0, "");
+}

--- a/regression/cbmc-smt/struct1/test.desc
+++ b/regression/cbmc-smt/struct1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--smt2 --no-data-types
+activate-multi-line-match
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/cbmc-smt/union1/main.c
+++ b/regression/cbmc-smt/union1/main.c
@@ -1,0 +1,13 @@
+union datat
+{
+  char c;
+  int i;
+};
+
+int main(void)
+{
+  union datat data;
+  data.c = '\0';
+
+  __CPROVER_assert(data.i == 0, "");
+}

--- a/regression/cbmc-smt/union1/test.desc
+++ b/regression/cbmc-smt/union1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--smt2
+activate-multi-line-match
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -322,6 +322,9 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
   if(cmdline.isset("fpa"))
     options.set_option("fpa", true);
 
+  if(cmdline.isset("no-data-types"))
+    options.set_option("data-types", false);
+
   bool solver_set=false;
 
   if(cmdline.isset("boolector"))

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -47,6 +47,7 @@ class optionst;
   "(no-assertions)(no-assumptions)" \
   "(xml-ui)(xml-interface)(json-ui)" \
   "(smt1)(smt2)(fpa)(cvc3)(cvc4)(boolector)(yices)(z3)(opensmt)(mathsat)" \
+  "(no-data-types)" \
   "(no-sat-preprocessor)" \
   "(beautify)" \
   "(dimacs)(refine)(max-node-refinement):(refine-arrays)(refine-arithmetic)"\

--- a/src/cbmc/cbmc_solvers.cpp
+++ b/src/cbmc/cbmc_solvers.cpp
@@ -182,6 +182,9 @@ std::unique_ptr<cbmc_solverst::solvert> cbmc_solverst::get_smt2(
     if(options.get_bool_option("fpa"))
       smt2_dec->use_FPA_theory=true;
 
+    if(options.is_set("data-types") && !options.get_bool_option("data-types"))
+      smt2_dec->use_datatypes=false;
+
     return util_make_unique<solvert>(std::move(smt2_dec));
   }
   else if(filename=="-")

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -470,7 +470,7 @@ exprt smt2_convt::parse_rec(const irept &src, const typet &_type)
   {
     // these come in as bit-vector literals
     std::size_t width=boolbv_width(type);
-    constant_exprt bv_expr=parse_literal(src, bv_typet(width));
+    constant_exprt bv_expr=parse_literal(src, unsignedbv_typet(width));
 
     mp_integer v = numeric_cast_v<mp_integer>(bv_expr);
 

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -265,11 +265,11 @@ constant_exprt smt2_convt::parse_literal(
     if(type.id()==ID_floatbv)
     {
       const floatbv_typet &floatbv_type=to_floatbv_type(type);
-      constant_exprt s1=parse_literal(src.get_sub()[1], bv_typet(1));
+      constant_exprt s1=parse_literal(src.get_sub()[1], unsignedbv_typet(1));
       constant_exprt s2=
-        parse_literal(src.get_sub()[2], bv_typet(floatbv_type.get_e()));
+        parse_literal(src.get_sub()[2], unsignedbv_typet(floatbv_type.get_e()));
       constant_exprt s3=
-        parse_literal(src.get_sub()[3], bv_typet(floatbv_type.get_f()));
+        parse_literal(src.get_sub()[3], unsignedbv_typet(floatbv_type.get_f()));
       // stitch the bits together
       std::string bits=id2string(s1.get_value())+
                        id2string(s2.get_value())+
@@ -306,7 +306,6 @@ constant_exprt smt2_convt::parse_literal(
 
   if(type.id()==ID_signedbv ||
      type.id()==ID_unsignedbv ||
-     type.id()==ID_bv ||
      type.id()==ID_c_enum ||
      type.id()==ID_c_bool)
   {
@@ -373,7 +372,7 @@ exprt smt2_convt::parse_union(
   PRECONDITION(!type.components().empty());
   const union_typet::componentt &first=type.components().front();
   std::size_t width=boolbv_width(type);
-  exprt value=parse_rec(src, bv_typet(width));
+  exprt value=parse_rec(src, unsignedbv_typet(width));
   if(value.is_nil())
     return nil_exprt();
   const typecast_exprt converted(value, first.type());
@@ -412,7 +411,7 @@ exprt smt2_convt::parse_struct(
   {
     // These are just flattened, i.e., we expect to see a monster bit vector.
     std::size_t total_width=boolbv_width(type);
-    exprt l=parse_literal(src, bv_typet(total_width));
+    exprt l=parse_literal(src, unsignedbv_typet(total_width));
     if(!l.is_constant())
       return nil_exprt();
 
@@ -453,7 +452,6 @@ exprt smt2_convt::parse_rec(const irept &src, const typet &_type)
      type.id()==ID_integer ||
      type.id()==ID_rational ||
      type.id()==ID_real ||
-     type.id()==ID_bv ||
      type.id()==ID_fixedbv ||
      type.id()==ID_floatbv)
   {


### PR DESCRIPTION
`bv_typet` is not supported by `numeric_cast_v`, so this always fails.
`parse_literal` creates a simple literal, hence we use an `unsignedbv`
instead.