### PR TITLE
added code_blockt::statements(), which is a vector of codet

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -789,16 +789,16 @@ code_blockt &java_bytecode_convert_methodt::get_or_create_block_for_pcrange(
     return this_block;
 
   // Find the child code_blockt where the queried range begins:
-  auto child_iter=this_block.operands().begin();
+  auto child_iter = this_block.statements().begin();
   // Skip any top-of-block declarations;
   // all other children are labelled subblocks.
-  while(child_iter!=this_block.operands().end() &&
-        to_code(*child_iter).get_statement()==ID_decl)
+  while(child_iter != this_block.statements().end() &&
+        child_iter->get_statement() == ID_decl)
     ++child_iter;
-  assert(child_iter!=this_block.operands().end());
+  assert(child_iter != this_block.statements().end());
   std::advance(child_iter, child_offset);
-  assert(child_iter!=this_block.operands().end());
-  auto &child_label=to_code_label(to_code(*child_iter));
+  assert(child_iter != this_block.statements().end());
+  auto &child_label=to_code_label(*child_iter);
   auto &child_block=to_code_block(child_label.code());
 
   bool single_child(afterstart==findlim);
@@ -868,7 +868,7 @@ code_blockt &java_bytecode_convert_methodt::get_or_create_block_for_pcrange(
           << findlim_block_start_address << eom;
 
   // Make a new block containing every child of interest:
-  auto &this_block_children=this_block.operands();
+  auto &this_block_children = this_block.statements();
   assert(tree.branch.size()==this_block_children.size());
   for(auto blockidx=child_offset, blocklim=child_offset+nblocks;
       blockidx!=blocklim;
@@ -876,7 +876,7 @@ code_blockt &java_bytecode_convert_methodt::get_or_create_block_for_pcrange(
     newblock.move_to_operands(this_block_children[blockidx]);
 
   // Relabel the inner header:
-  to_code_label(to_code(newblock.operands()[0])).set_label(new_label_irep);
+  to_code_label(newblock.statements()[0]).set_label(new_label_irep);
   // Relabel internal gotos:
   replace_goto_target(newblock, child_label_name, new_label_irep);
 
@@ -920,7 +920,7 @@ code_blockt &java_bytecode_convert_methodt::get_or_create_block_for_pcrange(
   return
     to_code_block(
       to_code_label(
-        to_code(this_block_children[child_offset])).code());
+        this_block_children[child_offset]).code());
 }
 
 static void gather_symbol_live_ranges(
@@ -1766,12 +1766,12 @@ codet java_bytecode_convert_methodt::convert_instructions(
             last_statement.make_block();
             last_statement.operands().insert(
               last_statement.operands().begin(),
-              more_code.operands().begin(),
-              more_code.operands().end());
+              more_code.statements().begin(),
+              more_code.statements().end());
           }
           else
-            forall_operands(o_it, more_code)
-              c.copy_to_operands(*o_it);
+            for(const auto &statement : more_code.statements())
+              c.copy_to_operands(statement);
         }
       }
       a_it2->second.stack=stack;
@@ -1845,7 +1845,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
 
     if(c.get_statement()!=ID_skip)
     {
-      auto &lastlabel=to_code_label(to_code(root_block.operands().back()));
+      auto &lastlabel = to_code_label(root_block.statements().back());
       auto &add_to_block=to_code_block(lastlabel.code());
       add_to_block.add(c);
     }
@@ -1909,10 +1909,10 @@ codet java_bytecode_convert_methodt::convert_instructions(
       v.start_pc + v.length,
       std::numeric_limits<method_offsett>::max());
     code_declt d(v.symbol_expr);
-    block.operands().insert(block.operands().begin(), d);
+    block.statements().insert(block.statements().begin(), d);
   }
 
-  for(auto &block : root_block.operands())
+  for(auto &block : root_block.statements())
     code.move_to_operands(block);
 
   return code;

--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -273,8 +273,9 @@ exprt allocate_dynamic_object_with_decl(
     output_code.add(decl);
   }
 
-  for(const exprt &code : tmp_block.operands())
-    output_code.add(to_code(code));
+  for(const auto &code : tmp_block.statements())
+    output_code.add(code);
+
   return dynamic_object;
 }
 

--- a/jbmc/src/java_bytecode/simple_method_stubbing.cpp
+++ b/jbmc/src/java_bytecode/simple_method_stubbing.cpp
@@ -127,14 +127,14 @@ void java_simple_method_stubst::create_method_stub_at(
                     : update_in_placet::NO_UPDATE_IN_PLACE);
 
   // Insert new_instructions into parent block.
-  if(!new_instructions.operands().empty())
+  if(!new_instructions.statements().empty())
   {
-    auto insert_position = parent_block.operands().begin();
+    auto insert_position = parent_block.statements().begin();
     std::advance(insert_position, insert_before_index);
-    parent_block.operands().insert(
+    parent_block.statements().insert(
       insert_position,
-      new_instructions.operands().begin(),
-      new_instructions.operands().end());
+      new_instructions.statements().begin(),
+      new_instructions.statements().end());
   }
 }
 

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -2835,12 +2835,12 @@ std::string expr2ct::convert_code_block(
   std::string dest=indent_str(indent);
   dest+="{\n";
 
-  forall_operands(it, src)
+  for(const auto &statement : src.statements())
   {
-    if(it->get(ID_statement)==ID_label)
-      dest+=convert_code(to_code(*it), indent);
+    if(statement.get_statement() == ID_label)
+      dest += convert_code(statement, indent);
     else
-      dest+=convert_code(to_code(*it), indent+2);
+      dest += convert_code(statement, indent + 2);
 
     dest+="\n";
   }

--- a/src/cpp/cpp_constructor.cpp
+++ b/src/cpp/cpp_constructor.cpp
@@ -247,11 +247,13 @@ optionalt<codet> cpp_typecheckt::cpp_constructor(
 
     tmp_this=address_of_exprt(object_tc);
 
-    if(block.operands().empty())
-      return to_code(initializer);
+    const auto &initializer_code=to_code(initializer);
+
+    if(block.statements().empty())
+      return initializer_code;
     else
     {
-      block.move_to_operands(initializer);
+      block.add(initializer_code);
       return block;
     }
   }

--- a/src/cpp/cpp_typecheck_destructor.cpp
+++ b/src/cpp/cpp_typecheck_destructor.cpp
@@ -92,7 +92,7 @@ codet cpp_typecheckt::dtor(const symbolt &symbol)
       ptrmember.operands().push_back(exprt("cpp-this"));
 
       code_assignt assign(ptrmember, address);
-      block.operands().push_back(assign);
+      block.add(assign);
       continue;
     }
   }

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -1695,14 +1695,20 @@ static bool move_label_ifthenelse(
     return false;
 
   code_blockt &block=to_code_block(to_code(expr));
-  if(!block.has_operands() ||
-      to_code(block.operands().back()).get_statement()!=ID_label)
+  if(
+    !block.has_operands() ||
+    block.statements().back().get_statement() != ID_label)
+  {
     return false;
+  }
 
-  code_labelt &label=to_code_label(to_code(block.operands().back()));
+  code_labelt &label = to_code_label(block.statements().back());
+
   if(label.get_label().empty() ||
       label.code().get_statement()!=ID_skip)
+  {
     return false;
+  }
 
   label_dest=label;
   code_skipt s;

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -547,11 +547,8 @@ void goto_convertt::convert_block(
   std::size_t old_stack_size=targets.destructor_stack.size();
 
   // now convert block
-  forall_operands(it, code)
-  {
-    const codet &b_code=to_code(*it);
+  for(const auto &b_code : code.statements())
     convert(b_code, dest, mode);
-  }
 
   // see if we need to do any destructors -- may have been processed
   // in a prior break/continue/return already, don't create dead code

--- a/src/jsil/jsil_parse_tree.cpp
+++ b/src/jsil/jsil_parse_tree.cpp
@@ -22,10 +22,8 @@ static bool insert_at_label(
   const irep_idt &label,
   code_blockt &dest)
 {
-  Forall_operands(it, dest)
+  for(auto &c : dest.statements())
   {
-    codet &c=to_code(*it);
-
     if(c.get_statement()!=ID_label)
       continue;
 

--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -270,7 +270,7 @@ std::ostream &format_rec(std::ostream &os, const exprt &expr)
     else if(statement == ID_block)
     {
       os << '{';
-      for(const auto &s : to_code_block(code).operands())
+      for(const auto &s : to_code_block(code).statements())
         os << ' ' << format(s);
       return os << " }";
     }

--- a/src/util/std_code.cpp
+++ b/src/util/std_code.cpp
@@ -111,11 +111,11 @@ const codet &codet::last_statement() const
 /// \param extra_block: The input code_blockt
 void code_blockt::append(const code_blockt &extra_block)
 {
-  operands().reserve(operands().size()+extra_block.operands().size());
+  statements().reserve(statements().size() + extra_block.statements().size());
 
-  for(const auto &operand : extra_block.operands())
+  for(const auto &statement : extra_block.statements())
   {
-    add(to_code(operand));
+    add(statement);
   }
 }
 
@@ -125,8 +125,8 @@ code_blockt create_fatal_assertion(
   code_blockt result;
   result.copy_to_operands(code_assertt(condition));
   result.copy_to_operands(code_assumet(condition));
-  for(auto &op : result.operands())
-    op.add_source_location() = loc;
+  for(auto &statement : result.statements())
+    statement.add_source_location() = loc;
   result.add_source_location() = loc;
   return result;
 }

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -105,9 +105,21 @@ public:
   {
   }
 
+  typedef std::vector<codet> code_operandst;
+
+  code_operandst &statements()
+  {
+    return (code_operandst &)get_sub();
+  }
+
+  const code_operandst &statements() const
+  {
+    return (const code_operandst &)get_sub();
+  }
+
   explicit code_blockt(const std::list<codet> &_list):codet(ID_block)
   {
-    operandst &o=operands();
+    auto &o = statements();
     reserve_operands(_list.size());
     for(std::list<codet>::const_iterator
         it=_list.begin();


### PR DESCRIPTION
The key benefit is that clients no longer need to do conversion of the
operands to codet.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
