### PR TITLE
Reduce doxygen warnings

### DIFF
--- a/src/doxyfile
+++ b/src/doxyfile
@@ -1020,7 +1020,7 @@ VERBATIM_HEADERS       = YES
 # generated with the -Duse-libclang=ON option for CMake.
 # The default value is: NO.
 
-CLANG_ASSISTED_PARSING = NO
+#CLANG_ASSISTED_PARSING = NO
 
 # If clang assisted parsing is enabled you can provide the compiler with command
 # line options that you would normally use when invoking the compiler. Note that
@@ -1028,7 +1028,7 @@ CLANG_ASSISTED_PARSING = NO
 # specified with INPUT and INCLUDE_PATH.
 # This tag requires that the tag CLANG_ASSISTED_PARSING is set to YES.
 
-CLANG_OPTIONS          =
+#CLANG_OPTIONS          =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the alphabetical class index

--- a/src/goto-programs/goto_trace.h
+++ b/src/goto-programs/goto_trace.h
@@ -14,13 +14,6 @@ Date: July 2005
 #ifndef CPROVER_GOTO_PROGRAMS_GOTO_TRACE_H
 #define CPROVER_GOTO_PROGRAMS_GOTO_TRACE_H
 
-/*! \file goto-symex/goto_trace.h
- * \brief Traces through goto programs
- *
- * \author Daniel Kroening <kroening@kroening.com>
- * \date   Sun Jul 31 21:54:44 BST 2011
-*/
-
 #include <iosfwd>
 #include <vector>
 

--- a/src/goto-symex/README.md
+++ b/src/goto-symex/README.md
@@ -81,7 +81,7 @@ the instruction type, i.e. goto_symext::symex_function_call() if the
 current instruction is a function call, goto_symext::symex_goto() if the
 current instruction is a goto, etc.
 
-\subsection Loop and recursion unwinding
+\subsection symex-loop-and-recursion-unwinding Loop and recursion unwinding
 
 Each backwards goto and recursive call has a separate counter
 (handled by \ref cbmc or another driver program, see the `--unwind` and
@@ -91,7 +91,7 @@ be handled completely (assuming the unwinding limit is sufficient).
 When an unwind or recursion limit is reached, an assertion can be added to
 explicitly show when analysis is incomplete.
 
-\subsection \ref goto_symext::clean_expr
+\subsection goto-symext-clean-expr goto_symext::clean_expr
 
 Before any expression is incorporated into the output equation set it is passed
 through \ref goto_symext::clean_expr and thus \ref goto_symext::dereference,


### PR DESCRIPTION
This PR includes 3 commits, fixing separate issues, which between them get rid of the first 4 warnings that I see when running doxygen.  I think it should be obvious what is changed and why by looking at the individual commits.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
