### PR TITLE
Add cmdlinet::has_option

### DIFF
--- a/src/util/cmdline.h
+++ b/src/util/cmdline.h
@@ -35,6 +35,11 @@ public:
   virtual void set(const std::string &option, const std::string &value);
   virtual void clear();
 
+  bool has_option(const std::string &option) const
+  {
+    return getoptnr(option).has_value();
+  }
+
   typedef std::vector<std::string> argst;
   argst args;
   std::string unknown_arg;

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -29,6 +29,7 @@ SRC += analyses/ai/ai.cpp \
        solvers/refinement/string_refinement/sparse_array.cpp \
        solvers/refinement/string_refinement/substitute_array_list.cpp \
        solvers/refinement/string_refinement/union_find_replace.cpp \
+       util/cmdline.cpp \
        util/expr_cast/expr_cast.cpp \
        util/expr.cpp \
        util/file_util.cpp \

--- a/unit/util/cmdline.cpp
+++ b/unit/util/cmdline.cpp
@@ -1,0 +1,19 @@
+/*******************************************************************\
+
+ Module: cmdlinet unit tests
+
+ Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include <testing-utils/catch.hpp>
+#include <util/cmdline.h>
+
+TEST_CASE("cmdlinet::has_option", "[core][util][cmdline]")
+{
+  cmdlinet cmdline;
+  REQUIRE(!cmdline.parse(0, nullptr, "(a)(b):"));
+  REQUIRE(cmdline.has_option("a"));
+  REQUIRE(cmdline.has_option("b"));
+  REQUIRE(!cmdline.has_option("c"));
+}


### PR DESCRIPTION
Previously `cmdlinet` could parse a whole command-line, but it wasn't possible to verify before using `cmdlinet::set` that an option was valid. This is useful when a driver program receives options in a format other than a string (e.g. a structured list) and wishes to check that the options would have been valid if supplied conventionally, rather than silently drop invalid args.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
