### PR TITLE
do not access typet::subtype() without cast

### DIFF
--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -616,8 +616,9 @@ void rw_range_sett::get_objects_rec(const typet &type)
   // TODO should recurse into various composite types
   if(type.id()==ID_array)
   {
-    get_objects_rec(type.subtype());
-    get_objects_rec(get_modet::READ, to_array_type(type).size());
+    const auto &array_type = to_array_type(type);
+    get_objects_rec(array_type.subtype());
+    get_objects_rec(get_modet::READ, array_type.size());
   }
 }
 

--- a/src/goto-instrument/thread_instrumentation.cpp
+++ b/src/goto-instrument/thread_instrumentation.cpp
@@ -140,5 +140,7 @@ void mutex_init_instrumentation(goto_modelt &goto_model)
 
   Forall_goto_functions(f_it, goto_model.goto_functions)
     mutex_init_instrumentation(
-      goto_model.symbol_table, f_it->second.body, lock_type.subtype());
+      goto_model.symbol_table,
+      f_it->second.body,
+      to_pointer_type(lock_type).subtype());
 }

--- a/src/goto-symex/auto_objects.cpp
+++ b/src/goto-symex/auto_objects.cpp
@@ -57,7 +57,7 @@ void goto_symext::initialize_auto_object(
   else if(type.id()==ID_pointer)
   {
     const pointer_typet &pointer_type=to_pointer_type(type);
-    const typet &subtype=ns.follow(type.subtype());
+    const typet &subtype = ns.follow(pointer_type.subtype());
 
     // we don't like function pointers and
     // we don't like void *
@@ -67,7 +67,7 @@ void goto_symext::initialize_auto_object(
       // could be NULL nondeterministically
 
       address_of_exprt address_of_expr(
-        make_auto_object(type.subtype(), state), pointer_type);
+        make_auto_object(pointer_type.subtype(), state), pointer_type);
 
       if_exprt rhs(
         side_effect_expr_nondett(bool_typet(), expr.source_location()),

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -211,7 +211,7 @@ static bool check_renaming(const typet &type)
         return true;
   }
   else if(type.has_subtype())
-    return check_renaming(type.subtype());
+    return check_renaming(to_type_with_subtype(type).subtype());
 
   return false;
 }
@@ -489,7 +489,7 @@ void goto_symex_statet::rename(
   {
     auto &address_of_expr = to_address_of_expr(expr);
     rename_address(address_of_expr.object(), ns, level);
-    expr.type().subtype() = address_of_expr.object().type();
+    to_pointer_type(expr.type()).subtype() = address_of_expr.object().type();
   }
   else
   {
@@ -725,7 +725,7 @@ void goto_symex_statet::rename_address(
 
       rename_address(index_expr.array(), ns, level);
       PRECONDITION(index_expr.array().type().id() == ID_array);
-      expr.type()=index_expr.array().type().subtype();
+      expr.type() = to_array_type(index_expr.array().type()).subtype();
 
       // the index is not an address
       rename(index_expr.index(), ns, level);
@@ -810,8 +810,9 @@ void goto_symex_statet::rename(
 
   if(type.id()==ID_array)
   {
-    rename(type.subtype(), irep_idt(), ns, level);
-    rename(to_array_type(type).size(), ns, level);
+    auto &array_type = to_array_type(type);
+    rename(array_type.subtype(), irep_idt(), ns, level);
+    rename(array_type.size(), ns, level);
   }
   else if(type.id()==ID_struct ||
           type.id()==ID_union ||
@@ -832,7 +833,7 @@ void goto_symex_statet::rename(
   }
   else if(type.id()==ID_pointer)
   {
-    rename(type.subtype(), irep_idt(), ns, level);
+    rename(to_pointer_type(type).subtype(), irep_idt(), ns, level);
   }
   else if(type.id() == ID_symbol_type)
   {
@@ -876,8 +877,9 @@ void goto_symex_statet::get_original_name(typet &type) const
 
   if(type.id()==ID_array)
   {
-    get_original_name(type.subtype());
-    get_original_name(to_array_type(type).size());
+    auto &array_type = to_array_type(type);
+    get_original_name(array_type.subtype());
+    get_original_name(array_type.size());
   }
   else if(type.id()==ID_struct ||
           type.id()==ID_union ||
@@ -894,7 +896,7 @@ void goto_symex_statet::get_original_name(typet &type) const
   }
   else if(type.id()==ID_pointer)
   {
-    get_original_name(type.subtype());
+    get_original_name(to_pointer_type(type).subtype());
   }
 }
 

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -321,8 +321,11 @@ void goto_symext::dereference_rec(
     exprt &object=address_of_expr.object();
 
     const typet &expr_type=ns.follow(expr.type());
-    expr=address_arithmetic(object, state, guard,
-                            expr_type.subtype().id()==ID_array);
+    expr = address_arithmetic(
+      object,
+      state,
+      guard,
+      to_pointer_type(expr_type).subtype().id() == ID_array);
   }
   else if(expr.id()==ID_typecast)
   {

--- a/src/util/arith_tools.cpp
+++ b/src/util/arith_tools.cpp
@@ -72,7 +72,7 @@ bool to_integer(const constant_exprt &expr, mp_integer &int_value)
   }
   else if(type_id==ID_c_bit_field)
   {
-    const typet &subtype=type.subtype();
+    const typet &subtype = to_c_bit_field_type(type).subtype();
     if(subtype.id()==ID_signedbv)
     {
       int_value=binary2integer(id2string(value), true);

--- a/src/util/expr_initializer.cpp
+++ b/src/util/expr_initializer.cpp
@@ -116,7 +116,8 @@ exprt expr_initializert<nondet>::expr_initializer_rec(
       result = side_effect_expr_nondett(type, source_location);
     else
     {
-      exprt sub_zero = expr_initializer_rec(type.subtype(), source_location);
+      exprt sub_zero =
+        expr_initializer_rec(to_complex_type(type).subtype(), source_location);
       result = complex_exprt(sub_zero, sub_zero, to_complex_type(type));
     }
 

--- a/src/util/find_symbols.cpp
+++ b/src/util/find_symbols.cpp
@@ -124,7 +124,7 @@ void find_symbols(kindt kind, const typet &src, find_symbols_sett &dest)
      src.id()!=ID_pointer)
   {
     if(src.has_subtype())
-      find_symbols(kind, src.subtype(), dest);
+      find_symbols(kind, to_type_with_subtype(src).subtype(), dest);
 
     forall_subtypes(it, src)
       find_symbols(kind, *it, dest);

--- a/src/util/format_type.cpp
+++ b/src/util/format_type.cpp
@@ -60,14 +60,14 @@ std::ostream &format_rec(std::ostream &os, const typet &type)
   const auto &id = type.id();
 
   if(id == ID_pointer)
-    return os << '*' << format(type.subtype());
+    return os << '*' << format(to_pointer_type(type).subtype());
   else if(id == ID_array)
   {
     const auto &t = to_array_type(type);
     if(t.is_complete())
-      return os << format(type.subtype()) << '[' << format(t.size()) << ']';
+      return os << format(t.subtype()) << '[' << format(t.size()) << ']';
     else
-      return os << format(type.subtype()) << "[]";
+      return os << format(t.subtype()) << "[]";
   }
   else if(id == ID_struct)
     return format_rec(os, to_struct_type(type));

--- a/src/util/json_expr.cpp
+++ b/src/util/json_expr.cpp
@@ -154,7 +154,10 @@ json_objectt json(
   else if(type.id()==ID_c_enum_tag)
   {
     // we return the base type
-    return json(ns.follow_tag(to_c_enum_tag_type(type)).subtype(), ns, mode);
+    return json(
+      to_c_enum_type(ns.follow_tag(to_c_enum_tag_type(type))).subtype(),
+      ns,
+      mode);
   }
   else if(type.id()==ID_fixedbv)
   {
@@ -165,7 +168,7 @@ json_objectt json(
   else if(type.id()==ID_pointer)
   {
     result["name"]=json_stringt("pointer");
-    result["subtype"]=json(type.subtype(), ns, mode);
+    result["subtype"] = json(to_pointer_type(type).subtype(), ns, mode);
   }
   else if(type.id()==ID_bool)
   {
@@ -174,12 +177,12 @@ json_objectt json(
   else if(type.id()==ID_array)
   {
     result["name"]=json_stringt("array");
-    result["subtype"]=json(type.subtype(), ns, mode);
+    result["subtype"] = json(to_array_type(type).subtype(), ns, mode);
   }
   else if(type.id()==ID_vector)
   {
     result["name"]=json_stringt("vector");
-    result["subtype"]=json(type.subtype(), ns, mode);
+    result["subtype"] = json(to_vector_type(type).subtype(), ns, mode);
     result["size"]=json(to_vector_type(type).size(), ns, mode);
   }
   else if(type.id()==ID_struct)
@@ -242,9 +245,8 @@ json_objectt json(
         lang=std::unique_ptr<languaget>(get_default_language());
     }
 
-    const typet &underlying_type=
-      type.id()==ID_c_bit_field?type.subtype():
-      type;
+    const typet &underlying_type =
+      type.id() == ID_c_bit_field ? to_c_bit_field_type(type).subtype() : type;
 
     std::string type_string;
     bool error=lang->from_type(underlying_type, type_string, ns);
@@ -270,7 +272,8 @@ json_objectt json(
     {
       result["name"]=json_stringt("integer");
       result["binary"] = json_stringt(constant_expr.get_value());
-      result["width"]=json_numbert(type.subtype().get_string(ID_width));
+      result["width"] =
+        json_numbert(to_c_enum_type(type).subtype().get_string(ID_width));
       result["type"]=json_stringt("enum");
       result["data"]=json_stringt(value_string);
     }

--- a/src/util/refined_string_type.h
+++ b/src/util/refined_string_type.h
@@ -29,10 +29,10 @@ public:
   refined_string_typet(const typet &index_type, const typet &char_type);
 
   // Type for the content (list of characters) of a string
-  const typet &get_content_type() const
+  const array_typet &get_content_type() const
   {
     PRECONDITION(components().size()==2);
-    return components()[1].type();
+    return to_array_type(components()[1].type());
   }
 
   const typet &get_char_type() const

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -321,7 +321,7 @@ bool simplify_exprt::simplify_typecast(exprt &expr)
       (expr.op0().op0().is_constant() &&
        to_constant_expr(expr.op0().op0()).get_value()==ID_NULL)))
   {
-    auto sub_size = pointer_offset_size(op_type.subtype(), ns);
+    auto sub_size = pointer_offset_size(to_pointer_type(op_type).subtype(), ns);
     if(sub_size.has_value())
     {
       // void*
@@ -393,7 +393,7 @@ bool simplify_exprt::simplify_typecast(exprt &expr)
      op_type.id()==ID_pointer &&
      expr.op0().id()==ID_plus)
   {
-    const auto step = pointer_offset_size(op_type.subtype(), ns);
+    const auto step = pointer_offset_size(to_pointer_type(op_type).subtype(), ns);
 
     if(step.has_value() && *step != 0)
     {
@@ -684,8 +684,8 @@ bool simplify_exprt::simplify_typecast(exprt &expr)
     }
     else if(op_type_id==ID_c_enum_tag) // enum to int
     {
-      const typet &base_type=
-        ns.follow_tag(to_c_enum_tag_type(op_type)).subtype();
+      const typet &base_type =
+        to_c_enum_type(ns.follow_tag(to_c_enum_tag_type(op_type))).subtype();
       if(base_type.id()==ID_signedbv || base_type.id()==ID_unsignedbv)
       {
         // enum constants use the representation of their base type
@@ -1504,7 +1504,7 @@ exprt simplify_exprt::bits2expr(
   }
   else if(type.id()==ID_c_enum)
   {
-    exprt val=bits2expr(bits, type.subtype(), little_endian);
+    exprt val = bits2expr(bits, to_c_enum_type(type).subtype(), little_endian);
     val.type()=type;
     return val;
   }
@@ -1570,7 +1570,7 @@ exprt simplify_exprt::bits2expr(
       UNREACHABLE;
     std::size_t n_el=integer2size_t(size);
 
-    const auto el_size_opt = pointer_offset_bits(type.subtype(), ns);
+    const auto el_size_opt = pointer_offset_bits(array_type.subtype(), ns);
     CHECK_RETURN(el_size_opt.has_value() && *el_size_opt > 0);
 
     const std::size_t el_size = integer2size_t(*el_size_opt);
@@ -1581,7 +1581,7 @@ exprt simplify_exprt::bits2expr(
     for(std::size_t i=0; i<n_el; ++i)
     {
       std::string el_bits=std::string(bits, i*el_size, el_size);
-      exprt el=bits2expr(el_bits, type.subtype(), little_endian);
+      exprt el = bits2expr(el_bits, array_type.subtype(), little_endian);
       if(el.is_nil())
         return nil_exprt();
       result.move_to_operands(el);
@@ -2012,7 +2012,7 @@ bool simplify_exprt::simplify_byte_update(byte_update_exprt &expr)
       }
       else if(tp.id()==ID_array)
       {
-        auto i = pointer_offset_size(tp.subtype(), ns);
+        auto i = pointer_offset_size(to_array_type(tp).subtype(), ns);
         if(i.has_value())
         {
           const exprt &index=with.where();

--- a/src/util/simplify_expr_array.cpp
+++ b/src/util/simplify_expr_array.cpp
@@ -183,10 +183,10 @@ bool simplify_exprt::simplify_index(exprt &expr)
   else if(array.id()==ID_byte_extract_little_endian ||
           array.id()==ID_byte_extract_big_endian)
   {
-    const typet &array_type=ns.follow(array.type());
-
-    if(array_type.id()==ID_array)
+    if(array.type().id() == ID_array)
     {
+      const auto &array_type = to_array_type(array.type());
+
       // This rewrites byte_extract(s, o, array_type)[i]
       // to byte_extract(s, o+offset, sub_type)
 

--- a/src/util/std_types.cpp
+++ b/src/util/std_types.cpp
@@ -249,7 +249,7 @@ bool is_constant_or_has_constant_components(
   // struct contains_constant_pointer b[3] = { {23, &y}, {23, &y}, {23, &y} };
   if(type.has_subtype())
   {
-    const auto &subtype = type.subtype();
+    const auto &subtype = to_type_with_subtype(type).subtype();
     return is_constant_or_has_constant_components(subtype, ns);
   }
 

--- a/src/util/string_constant.cpp
+++ b/src/util/string_constant.cpp
@@ -35,7 +35,7 @@ array_exprt string_constantt::to_array_expr() const
 {
   const std::string &str=get_string(ID_value);
   std::size_t string_size=str.size()+1; // we add the zero
-  const typet &char_type=type().subtype();
+  const typet &char_type = to_array_type(type()).subtype();
   bool char_is_unsigned=char_type.id()==ID_unsignedbv;
 
   exprt size=from_integer(string_size, index_type());
@@ -78,7 +78,7 @@ bool string_constantt::from_array_expr(const array_exprt &src)
   id(ID_string_constant);
   type()=src.type();
 
-  const typet &subtype=type().subtype();
+  const typet &subtype = to_array_type(type()).subtype();
 
   // check subtype
   if(subtype!=signed_char_type() &&

--- a/src/util/xml_expr.cpp
+++ b/src/util/xml_expr.cpp
@@ -84,7 +84,8 @@ xmlt xml(
   else if(type.id()==ID_c_enum_tag)
   {
     // we return the base type
-    return xml(ns.follow_tag(to_c_enum_tag_type(type)).subtype(), ns);
+    return xml(
+      to_c_enum_type(ns.follow_tag(to_c_enum_tag_type(type))).subtype(), ns);
   }
   else if(type.id()==ID_fixedbv)
   {
@@ -94,7 +95,8 @@ xmlt xml(
   else if(type.id()==ID_pointer)
   {
     result.name="pointer";
-    result.new_element("subtype").new_element()=xml(type.subtype(), ns);
+    result.new_element("subtype").new_element() =
+      xml(to_pointer_type(type).subtype(), ns);
   }
   else if(type.id()==ID_bool)
   {
@@ -103,12 +105,14 @@ xmlt xml(
   else if(type.id()==ID_array)
   {
     result.name="array";
-    result.new_element("subtype").new_element()=xml(type.subtype(), ns);
+    result.new_element("subtype").new_element() =
+      xml(to_array_type(type).subtype(), ns);
   }
   else if(type.id()==ID_vector)
   {
     result.name="vector";
-    result.new_element("subtype").new_element()=xml(type.subtype(), ns);
+    result.new_element("subtype").new_element() =
+      xml(to_vector_type(type).subtype(), ns);
     result.new_element("size").new_element()=
       xml(to_vector_type(type).size(), ns);
   }
@@ -163,9 +167,9 @@ xmlt xml(
         id2string(to_constant_expr(expr).get_value()));
       result.set_attribute("width", width);
 
-      const typet &underlying_type=
-        type.id()==ID_c_bit_field?type.subtype():
-        type;
+      const typet &underlying_type = type.id() == ID_c_bit_field
+                                       ? to_c_bit_field_type(type).subtype()
+                                       : type;
 
       bool is_signed=underlying_type.id()==ID_signedbv;
 
@@ -190,7 +194,8 @@ xmlt xml(
     {
       result.name="integer";
       result.set_attribute("binary", expr.get_string(ID_value));
-      result.set_attribute("width", type.subtype().get_string(ID_width));
+      result.set_attribute(
+        "width", to_c_enum_type(type).subtype().get_string(ID_width));
       result.set_attribute("c_type", "enum");
 
       mp_integer i;


### PR DESCRIPTION
Rationale: not every type has a subtype, and if a type doesn't have one,
then accessing subtype() results in a memory safety violation.  Casting to
the right specialisation prevents this.

Eventually, typet::subtype() will be removed to enforce this.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
