### PR TITLE
simple test for mismatching return types accross compilation units

### DIFF
--- a/regression/cbmc/Linking7/return_type.desc
+++ b/regression/cbmc/Linking7/return_type.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 return_type1.c
 return_type2.c
 ^EXIT=0$

--- a/regression/cbmc/Linking7/return_type.desc
+++ b/regression/cbmc/Linking7/return_type.desc
@@ -1,0 +1,10 @@
+KNOWNBUG
+return_type1.c
+return_type2.c
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Note issue #3081

--- a/regression/cbmc/Linking7/return_type1.c
+++ b/regression/cbmc/Linking7/return_type1.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+
+struct S
+{
+  int i;
+};
+
+struct S *function();
+
+int main()
+{
+  assert(function() != 0);
+}

--- a/regression/cbmc/Linking7/return_type2.c
+++ b/regression/cbmc/Linking7/return_type2.c
@@ -1,0 +1,10 @@
+struct S
+{
+  int i;
+  int j; // extra member
+} some_var;
+
+struct S *function()
+{
+  return &some_var;
+}

--- a/src/goto-programs/remove_returns.cpp
+++ b/src/goto-programs/remove_returns.cpp
@@ -189,7 +189,13 @@ void remove_returnst::do_function_calls(
           exprt rhs;
 
           if(!is_stub)
-            rhs=return_value;
+          {
+            // The return type in the definition of the function may differ
+            // from the return type in the declaration.  We therefore do a
+            // cast.
+            rhs = typecast_exprt::conditional_cast(
+              return_value, function_call.lhs().type());
+          }
           else
             rhs = side_effect_expr_nondett(
               function_call.lhs().type(), i_it->source_location);
@@ -208,7 +214,7 @@ void remove_returnst::do_function_calls(
             goto_programt::targett t_d=goto_program.insert_after(t_a);
             t_d->make_dead();
             t_d->source_location=i_it->source_location;
-            t_d->code=code_deadt(rhs);
+            t_d->code = code_deadt(return_value);
             t_d->function=i_it->function;
           }
         }


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [X] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
