### PR TITLE
C front-end: Do not wrongly propagate const-ness

### DIFF
--- a/regression/ansi-c/const2/main.c
+++ b/regression/ansi-c/const2/main.c
@@ -1,0 +1,36 @@
+#if TEST == 0
+const struct buffer *foo();
+
+typedef struct buffer
+{
+  int head;
+} buffer_t;
+#endif
+
+#if TEST == 1
+struct buffer *foo();
+
+typedef struct buffer
+{
+  int head;
+} buffer_t;
+#endif
+
+#if TEST == 2
+typedef struct buffer
+{
+  int head;
+} buffer_t;
+
+const struct buffer *foo();
+#endif
+
+static void clear(buffer_t *buf)
+{
+  buf->head = 0u;
+}
+
+int main()
+{
+  return 0;
+}

--- a/regression/ansi-c/const2/test0.desc
+++ b/regression/ansi-c/const2/test0.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+-DTEST=0
+^EXIT=0$
+^SIGNAL=0$
+--
+^.*: .* is constant$

--- a/regression/ansi-c/const2/test1.desc
+++ b/regression/ansi-c/const2/test1.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+-DTEST=1
+^EXIT=0$
+^SIGNAL=0$
+--
+^.*: .* is constant$

--- a/regression/ansi-c/const2/test2.desc
+++ b/regression/ansi-c/const2/test2.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+-DTEST=2
+^EXIT=0$
+^SIGNAL=0$
+--
+^.*: .* is constant$

--- a/src/ansi-c/anonymous_member.cpp
+++ b/src/ansi-c/anonymous_member.cpp
@@ -29,10 +29,11 @@ static exprt make_member_expr(
   const typet &type=
     ns.follow(struct_union.type());
 
-  if(result.get_bool(ID_C_constant) ||
-     type.get_bool(ID_C_constant) ||
-     struct_union.type().get_bool(ID_C_constant))
-    result.set(ID_C_constant, true);
+  if(
+    type.get_bool(ID_C_constant) || struct_union.type().get_bool(ID_C_constant))
+  {
+    result.type().set(ID_C_constant, true);
+  }
 
   return result;
 }

--- a/src/ansi-c/c_typecast.cpp
+++ b/src/ansi-c/c_typecast.cpp
@@ -555,12 +555,6 @@ void c_typecastt::implicit_typecast_followed(
 
       // check qualifiers
 
-      /*
-      if(src_type.subtype().get_bool(ID_C_constant) &&
-         !dest_type.subtype().get_bool(ID_C_constant))
-        warnings.push_back("disregarding const");
-      */
-
       if(src_type.subtype().get_bool(ID_C_volatile) &&
          !dest_type.subtype().get_bool(ID_C_volatile))
         warnings.push_back("disregarding volatile");

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -358,8 +358,8 @@ void c_typecheck_baset::typecheck_expr_main(exprt &expr)
       if(op.get_bool(ID_C_lvalue))
         complex_real_expr.set(ID_C_lvalue, true);
 
-      if(op.get_bool(ID_C_constant))
-        complex_real_expr.set(ID_C_constant, true);
+      if(op.type().get_bool(ID_C_constant))
+        complex_real_expr.type().set(ID_C_constant, true);
 
       expr.swap(complex_real_expr);
     }
@@ -396,8 +396,8 @@ void c_typecheck_baset::typecheck_expr_main(exprt &expr)
       if(op.get_bool(ID_C_lvalue))
         complex_imag_expr.set(ID_C_lvalue, true);
 
-      if(op.get_bool(ID_C_constant))
-        complex_imag_expr.set(ID_C_constant, true);
+      if(op.type().get_bool(ID_C_constant))
+        complex_imag_expr.type().set(ID_C_constant, true);
 
       expr.swap(complex_imag_expr);
     }
@@ -2853,7 +2853,7 @@ void c_typecheck_baset::typecheck_function_call_arguments(
       if(type.id()==ID_array)
       {
         typet dest_type=pointer_type(void_type());
-        dest_type.subtype().set(ID_C_constant, ID_1);
+        dest_type.subtype().set(ID_C_constant, true);
         implicit_typecast(op, dest_type);
       }
     }

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -722,6 +722,16 @@ void c_typecheck_baset::typecheck_compound_type(struct_union_typet &type)
 
   bool have_body=type.find(ID_components).is_not_nil();
 
+  c_qualifierst original_qualifiers(type);
+
+  // the type symbol, which may get re-used in other declarations, must not
+  // carry any qualifiers (other than transparent_union, which isn't really a
+  // qualifier)
+  c_qualifierst remove_qualifiers;
+  remove_qualifiers.is_transparent_union =
+    original_qualifiers.is_transparent_union;
+  remove_qualifiers.write(type);
+
   if(type.find(ID_tag).is_nil())
   {
     // Anonymous? Must come with body.
@@ -817,8 +827,6 @@ void c_typecheck_baset::typecheck_compound_type(struct_union_typet &type)
       }
     }
   }
-
-  c_qualifierst original_qualifiers(type);
 
   typet tag_type;
 


### PR DESCRIPTION
This bug has been lingering for a longer time, but only started showing up with
the propagation fix in 2c16231b48cc67a63a5410e7457a7150419bc21d.

1. Qualifiers (and const-ness in particular) are a property of the type, and not
an expression. Make sure all uses of ID_C_constant affect the type.
2. Qualifiers go with the type of the symbol being declared, and aren't a
property that applies across uses of the same type.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [n/a] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [n/a] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
