### PR TITLE
Rename invalid_user_input_exceptiont

### DIFF
--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -217,7 +217,7 @@ void bmct::get_memory_model()
     memory_model=util_make_unique<memory_model_psot>(ns);
   else
   {
-    throw invalid_user_input_exceptiont(
+    throw invalid_command_line_argument_exceptiont(
       "invalid parameter " + mm, "--mm", "try values of sc, tso, pso");
   }
 }

--- a/src/cbmc/cbmc_solvers.cpp
+++ b/src/cbmc/cbmc_solvers.cpp
@@ -166,7 +166,7 @@ std::unique_ptr<cbmc_solverst::solvert> cbmc_solverst::get_smt2(
   {
     if(solver==smt2_dect::solvert::GENERIC)
     {
-      throw invalid_user_input_exceptiont(
+      throw invalid_command_line_argument_exceptiont(
         "required filename not provided",
         "--outfile",
         "provide a filename with --outfile");
@@ -211,7 +211,7 @@ std::unique_ptr<cbmc_solverst::solvert> cbmc_solverst::get_smt2(
 
     if(!*out)
     {
-      throw invalid_user_input_exceptiont(
+      throw invalid_command_line_argument_exceptiont(
         "failed to open file: " + filename, "--outfile");
     }
 
@@ -236,7 +236,7 @@ void cbmc_solverst::no_beautification()
 {
   if(options.get_bool_option("beautify"))
   {
-    throw invalid_user_input_exceptiont(
+    throw invalid_command_line_argument_exceptiont(
       "the chosen solver does not support beautification", "--beautify");
   }
 }
@@ -249,18 +249,18 @@ void cbmc_solverst::no_incremental_check()
 
   if(all_properties)
   {
-    throw invalid_user_input_exceptiont(
+    throw invalid_command_line_argument_exceptiont(
       "the chosen solver does not support incremental solving",
       "--all_properties");
   }
   else if(cover)
   {
-    throw invalid_user_input_exceptiont(
+    throw invalid_command_line_argument_exceptiont(
       "the chosen solver does not support incremental solving", "--cover");
   }
   else if(incremental_check)
   {
-    throw invalid_user_input_exceptiont(
+    throw invalid_command_line_argument_exceptiont(
       "the chosen solver does not support incremental solving",
       "--incremental-check");
   }

--- a/src/goto-symex/show_vcc.cpp
+++ b/src/goto-symex/show_vcc.cpp
@@ -165,7 +165,7 @@ void show_vcc(
   {
     of.open(filename);
     if(!of)
-      throw invalid_user_input_exceptiont(
+      throw invalid_command_line_argument_exceptiont(
         "invalid file to read trace from: " + filename, "--outfile");
   }
 

--- a/src/goto-symex/slice_by_trace.cpp
+++ b/src/goto-symex/slice_by_trace.cpp
@@ -124,7 +124,7 @@ void symex_slice_by_tracet::read_trace(std::string filename)
   std::cout << "Reading trace from file " << filename << '\n';
   std::ifstream file(filename);
   if(file.fail())
-    throw invalid_user_input_exceptiont(
+    throw invalid_command_line_argument_exceptiont(
       "invalid file to read trace from: " + filename, "");
 
   // In case not the first trace read

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -1053,7 +1053,7 @@ bool configt::set(const cmdlinet &cmdline)
     if(!(0<bv_encoding.object_bits &&
          bv_encoding.object_bits<ansi_c.pointer_width))
     {
-      throw invalid_user_input_exceptiont(
+      throw invalid_command_line_argument_exceptiont(
         "object-bits must be positive and less than the pointer width (" +
           std::to_string(ansi_c.pointer_width) + ") ",
         "--object_bits");

--- a/src/util/exception_utils.cpp
+++ b/src/util/exception_utils.cpp
@@ -9,7 +9,7 @@ Author: Fotis Koutoulakis, fotis.koutoulakis@diffblue.com
 #include "exception_utils.h"
 #include <utility>
 
-std::string invalid_user_input_exceptiont::what() const
+std::string invalid_command_line_argument_exceptiont::what() const
 {
   std::string res;
   res += "Invalid User Input";
@@ -23,10 +23,11 @@ std::string invalid_user_input_exceptiont::what() const
   return res;
 }
 
-invalid_user_input_exceptiont::invalid_user_input_exceptiont(
-  std::string reason,
-  std::string option,
-  std::string correct_input)
+invalid_command_line_argument_exceptiont::
+  invalid_command_line_argument_exceptiont(
+    std::string reason,
+    std::string option,
+    std::string correct_input)
   : reason(std::move(reason)),
     option(std::move(option)),
     correct_input(std::move(correct_input))

--- a/src/util/exception_utils.h
+++ b/src/util/exception_utils.h
@@ -28,7 +28,7 @@ public:
 /// Thrown when users pass incorrect command line arguments,
 /// for example passing no files to analysis or setting
 /// two mutually exclusive flags
-class invalid_user_input_exceptiont : public cprover_exception_baset
+class invalid_command_line_argument_exceptiont : public cprover_exception_baset
 {
   /// The reason this exception was generated.
   std::string reason;
@@ -39,7 +39,7 @@ class invalid_user_input_exceptiont : public cprover_exception_baset
   std::string correct_input;
 
 public:
-  invalid_user_input_exceptiont(
+  invalid_command_line_argument_exceptiont(
     std::string reason,
     std::string option,
     std::string correct_input = "");

--- a/src/util/parse_options.cpp
+++ b/src/util/parse_options.cpp
@@ -71,7 +71,7 @@ int parse_options_baset::main()
 
     return doit();
   }
-  catch(const invalid_user_input_exceptiont &e)
+  catch(const invalid_command_line_argument_exceptiont &e)
   {
     std::cerr << e.what() << "\n";
     return CPROVER_EXIT_USAGE_ERROR;


### PR DESCRIPTION
Rename invalid_user_input_exceptiont to invalid_command_line_argument_exceptiont
as the previous name was a bit misleading about its purpose.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
