### PR TITLE
Clean up replace_symbolt interface

### DIFF
--- a/src/analyses/constant_propagator.h
+++ b/src/analyses/constant_propagator.h
@@ -111,25 +111,13 @@ public:
       return !is_bottom && replace_const.empty();
     }
 
-    // set single identifier
-
-    void set_to(const irep_idt &lhs, const exprt &rhs)
+    void set_to(const symbol_exprt &lhs, const exprt &rhs)
     {
-      replace_const.get_expr_map()[lhs] = rhs;
+      replace_const.set(lhs, rhs);
       is_bottom=false;
     }
 
-    void set_to(const symbol_exprt &lhs, const exprt &rhs)
-    {
-      set_to(lhs.get_identifier(), rhs);
-    }
-
-    bool set_to_top(const symbol_exprt &expr)
-    {
-      return set_to_top(expr.get_identifier());
-    }
-
-    bool set_to_top(const irep_idt &id);
+    bool set_to_top(const symbol_exprt &expr);
 
     void set_dirty_to_top(const dirtyt &dirty, const namespacet &ns);
 

--- a/src/util/replace_symbol.cpp
+++ b/src/util/replace_symbol.cpp
@@ -30,6 +30,13 @@ void replace_symbolt::insert(
     old_expr.get_identifier(), new_expr));
 }
 
+void replace_symbolt::set(const symbol_exprt &old_expr, const exprt &new_expr)
+{
+  PRECONDITION(old_expr.type() == new_expr.type());
+  expr_map[old_expr.get_identifier()] = new_expr;
+}
+
+
 bool replace_symbolt::replace_symbol_expr(symbol_exprt &s) const
 {
   expr_mapt::const_iterator it = expr_map.find(s.get_identifier());

--- a/src/util/replace_symbol.h
+++ b/src/util/replace_symbol.h
@@ -26,8 +26,14 @@ class replace_symbolt
 public:
   typedef std::unordered_map<irep_idt, exprt> expr_mapt;
 
+  /// Sets old_expr to be replaced by new_expr if we don't already have a
+  /// replacement; otherwise does nothing (i.e. std::map::insert-like
+  /// behaviour).
   void insert(const class symbol_exprt &old_expr,
               const exprt &new_expr);
+
+  /// Sets old_expr to be replaced by new_expr
+  void set(const class symbol_exprt &old_expr, const exprt &new_expr);
 
   virtual bool replace(exprt &dest) const;
   virtual bool replace(typet &dest) const;
@@ -55,6 +61,11 @@ public:
   std::size_t erase(const irep_idt &id)
   {
     return expr_map.erase(id);
+  }
+
+  expr_mapt::iterator erase(expr_mapt::iterator it)
+  {
+    return expr_map.erase(it);
   }
 
   bool replaces_symbol(const irep_idt &id) const


### PR DESCRIPTION
Add set(), with meaning similar to insert() but overwriting any existing value, and
an overload of erase() that takes an iterator. These allow the constant propagator to use
it more cleanly (though not entirely; it still needs get_expr_map() for some tasks such
as merging two replace_symbolt objects).

No behavioural change is intended here.

Doing this partial cleanup because the security product's out-of-tree changes required us to intercept some operations that the constant propagator directly executed against `expr_map`; these cleanups bring the two versions closer together, and are hopefully code quality improvements regardless.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
~- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).~
~- [ ] My commit message includes data points confirming performance improvements (if claimed).~
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
