### PR TITLE
remove bitwise_neg(mp_integer)

### DIFF
--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -528,7 +528,9 @@ void interpretert::evaluate(
     evaluate(expr.op0(), tmp);
     if(tmp.size()==1)
     {
-      dest.push_back(bitwise_neg(tmp.front()));
+      const auto width = to_bitvector_type(expr.op0().type()).get_width();
+      const mp_integer mask = power(2, width) - 1;
+      dest.push_back(bitwise_xor(tmp.front(), mask));
       return;
     }
   }

--- a/src/util/mp_arith.cpp
+++ b/src/util/mp_arith.cpp
@@ -249,16 +249,6 @@ mp_integer bitwise_xor(const mp_integer &a, const mp_integer &b)
   return result;
 }
 
-/// bitwise negation bitwise operations only make sense on native objects, hence
-/// the largest object size should be the largest available c++ integer size
-/// (currently long long)
-mp_integer bitwise_neg(const mp_integer &a)
-{
-  PRECONDITION(a.is_ulong());
-  ullong_t result=~a.to_ulong();
-  return result;
-}
-
 /// arithmetic left shift bitwise operations only make sense on native objects,
 /// hence the largest object size should be the largest available c++ integer
 /// size (currently long long)

--- a/src/util/mp_arith.h
+++ b/src/util/mp_arith.h
@@ -27,7 +27,6 @@ mp_integer operator<<(const mp_integer &, const mp_integer &);
 mp_integer bitwise_or(const mp_integer &, const mp_integer &);
 mp_integer bitwise_and(const mp_integer &, const mp_integer &);
 mp_integer bitwise_xor(const mp_integer &, const mp_integer &);
-mp_integer bitwise_neg(const mp_integer &);
 
 mp_integer arith_left_shift(
   const mp_integer &, const mp_integer &, std::size_t true_size);


### PR DESCRIPTION
The semantics of this operation is highly machine-dependent, and thus, it's
difficult to use.  The single user is replaced by xor -1.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
