### PR TITLE
boolbvt::convert_constant is now independent of bitvector representation

### DIFF
--- a/src/solvers/flattening/boolbv_constant.cpp
+++ b/src/solvers/flattening/boolbv_constant.cpp
@@ -6,6 +6,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
+#include <util/arith_tools.h>
 
 #include "boolbv.h"
 
@@ -78,9 +79,9 @@ bvt boolbvt::convert_constant(const constant_exprt &expr)
           expr_type.id()==ID_c_bit_field ||
           expr_type.id()==ID_incomplete_c_enum)
   {
-    const std::string &binary=id2string(expr.get_value());
+    const auto &value = expr.get_value();
 
-    if(binary.size()!=width)
+    if(value.size() != width)
     {
       error().source_location=expr.find_source_location();
       error() << "wrong value length in constant: "
@@ -90,7 +91,7 @@ bvt boolbvt::convert_constant(const constant_exprt &expr)
 
     for(std::size_t i=0; i<width; i++)
     {
-      bool bit=(binary[binary.size()-i-1]=='1');
+      const bool bit = get_bitvector_bit(value, i);
       bv[i]=const_literal(bit);
     }
 

--- a/src/util/arith_tools.cpp
+++ b/src/util/arith_tools.cpp
@@ -262,3 +262,14 @@ void mp_max(mp_integer &a, const mp_integer &b)
   if(b>a)
     a=b;
 }
+
+/// Get a bit with given index from bit-vector representation.
+/// \param src: the bitvector representation
+/// \param bit_index: index (0 is the least significant)
+bool get_bitvector_bit(const irep_idt &src, std::size_t bit_index)
+{
+  // The representation is binary, using '0'/'1',
+  // most significant bit first.
+  PRECONDITION(bit_index < src.size());
+  return src[src.size() - 1 - bit_index] == '1';
+}

--- a/src/util/arith_tools.h
+++ b/src/util/arith_tools.h
@@ -164,4 +164,6 @@ mp_integer power(const mp_integer &base, const mp_integer &exponent);
 void mp_min(mp_integer &a, const mp_integer &b);
 void mp_max(mp_integer &a, const mp_integer &b);
 
+bool get_bitvector_bit(const irep_idt &src, std::size_t bit_index);
+
 #endif // CPROVER_UTIL_ARITH_TOOLS_H

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -135,25 +135,22 @@ bool simplify_exprt::simplify_popcount(popcount_exprt &expr)
 
   if(op.is_constant())
   {
-    const typet &type=ns.follow(op.type());
+    const typet &op_type = op.type();
 
-    if(type.id()==ID_signedbv ||
-       type.id()==ID_unsignedbv)
+    if(op_type.id() == ID_signedbv || op_type.id() == ID_unsignedbv)
     {
-      mp_integer value;
-      if(!to_integer(op, value))
-      {
-        std::size_t result;
+      const auto width = to_bitvector_type(op_type).get_width();
+      const auto &value = to_constant_expr(op).get_value();
+      std::size_t result = 0;
 
-        for(result=0; value!=0; value=value>>1)
-          if(value.is_odd())
-            result++;
+      for(std::size_t i = 0; i < width; i++)
+        if(get_bitvector_bit(value, i))
+          result++;
 
-        exprt simp_result = from_integer(result, expr.type());
-        expr.swap(simp_result);
+      auto result_expr = from_integer(result, expr.type());
+      expr.swap(result_expr);
 
-        return false;
-      }
+      return false;
     }
   }
 


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [X] My contribution is formatted in line with CODING_STANDARD.md.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
