### PR TITLE
Bitvectors are now hexadecimal

### DIFF
--- a/regression/invariants/invariant-irep-diagnostic/test.desc
+++ b/regression/invariants/invariant-irep-diagnostic/test.desc
@@ -5,5 +5,5 @@ invariant-with-irep-diagnostics
 ^SIGNAL=0$
 --- begin invariant violation report ---
 Invariant check failed
-value: 00000000000000000000000000001000
-value: 00000000000000000000000000001101
+value: 8
+value: [dD]

--- a/src/solvers/flattening/boolbv_constant.cpp
+++ b/src/solvers/flattening/boolbv_constant.cpp
@@ -81,14 +81,6 @@ bvt boolbvt::convert_constant(const constant_exprt &expr)
   {
     const auto &value = expr.get_value();
 
-    if(value.size() != width)
-    {
-      error().source_location=expr.find_source_location();
-      error() << "wrong value length in constant: "
-              << expr.pretty() << eom;
-      throw 0;
-    }
-
     for(std::size_t i=0; i<width; i++)
     {
       const bool bit = get_bvrep_bit(value, width, i);


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] My contribution is formatted in line with CODING_STANDARD.md.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->

Note that an alternative would be to go to a binary representation, which is not much different compared to this PR. This would save another 2x in memory, but has the disadvantage that ireps are then more difficult to read.

This will require a bump in the goto-binary version number, which I would prefer to do together with a few other changes.