### PR TITLE
introduce to_dstring

### DIFF
--- a/src/util/dstring.cpp
+++ b/src/util/dstring.cpp
@@ -17,3 +17,15 @@ std::ostream &dstringt::operator<<(std::ostream &out) const
 {
   return out << as_string();
 }
+
+dstringt get_dstring_number(std::size_t value)
+{
+  static const dstringt *const dstring_numbers = [] {
+    dstringt *array = new dstringt[DSTRING_NUMBERS_MAX + 1];
+    for(std::size_t i = 0; i <= DSTRING_NUMBERS_MAX; i++)
+      array[i] = dstringt(std::to_string(i));
+    return array;
+  }();
+
+  return dstring_numbers[value];
+}

--- a/src/util/dstring.h
+++ b/src/util/dstring.h
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <string>
 
 #include "invariant.h"
+#include "magic.h"
 #include "string_container.h"
 
 /// \ref dstringt has one field, an unsigned integer \ref no which is an index
@@ -219,5 +220,20 @@ struct diagnostics_helpert<dstringt>
     return as_string(dstring);
   }
 };
+
+dstringt get_dstring_number(std::size_t);
+
+/// equivalent to dstringt(std::to_string(value)), i.e., produces a string
+/// from a number
+template <typename T>
+static inline
+  typename std::enable_if<std::is_integral<T>::value, dstringt>::type
+  to_dstring(T value)
+{
+  if(value >= 0 && value <= static_cast<T>(DSTRING_NUMBERS_MAX))
+    return get_dstring_number(value);
+  else
+    return std::to_string(value);
+}
 
 #endif // CPROVER_UTIL_DSTRING_H

--- a/src/util/irep.cpp
+++ b/src/util/irep.cpp
@@ -126,7 +126,11 @@ long long irept::get_long_long(const irep_namet &name) const
 
 void irept::set(const irep_namet &name, const long long value)
 {
+#ifdef USE_DSTRING
+  add(name).id(to_dstring(value));
+#else
   add(name).id(std::to_string(value));
+#endif
 }
 
 void irept::remove(const irep_namet &name)

--- a/src/util/magic.h
+++ b/src/util/magic.h
@@ -13,4 +13,7 @@ const std::size_t STRING_REFINEMENT_MAX_CHAR_WIDTH = 16;
 // Limit the size of strings in traces to 64M chars to avoid memout
 const std::size_t MAX_CONCRETE_STRING_SIZE = 1 << 26;
 
+// The top end of the range of integers for which dstrings are precomputed
+constexpr std::size_t DSTRING_NUMBERS_MAX = 64;
+
 #endif


### PR DESCRIPTION
As std::to_string, to_dstring produces a string from a number.  A key
feature is that dstrings for values <=64 are pre-computed; generating
strings for such numbers is 50x faster than going via std::to_string.
```
int main()
{
  for(unsigned i=0; i<20000000; i++)
  {
    dstringt d;
    int j=20;
    d=dstringt(std::to_string(j));
  }
}
```
This is 2.5s as above, and 0.05s with to_dstring.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [X] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
