### PR TITLE
Add SMT regression tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,7 @@ jobs:
             - parallel
       before_install:
         - mkdir bin
+        - wget --directory-prefix=bin https://github.com/Z3Prover/z3/releases/download/z3-4.7.1/z3-4.7.1-x64-ubuntu-14.04.zip && unzip -d bin bin/z3-4.7.1-x64-ubuntu-14.04.zip && ln -s $PWD/bin/z3-4.7.1-x64-ubuntu-14.04/bin/z3 bin/z3
         - ln -s /usr/bin/gcc-5 bin/gcc
         - ln -s /usr/bin/g++-5 bin/g++
       # env: COMPILER=g++-5 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover -fno-omit-frame-pointer"
@@ -118,7 +119,7 @@ jobs:
       compiler: clang
       cache: ccache
       before_install:
-        - HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache parallel
+        - HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache parallel z3
         - export PATH=$PATH:/usr/local/opt/ccache/libexec
       env: COMPILER="ccache clang++"
 
@@ -171,7 +172,7 @@ jobs:
         - ln -s /usr/bin/gcc-5 bin/gcc
         - ln -s /usr/bin/c++-5 bin/g++
         - export CCACHE_CPP2=yes
-      # env: COMPILER=clang++-3.7 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined,integer -fno-omit-frame-pointer"
+        - wget --directory-prefix=bin https://github.com/Z3Prover/z3/releases/download/z3-4.7.1/z3-4.7.1-x64-ubuntu-14.04.zip && unzip -d bin bin/z3-4.7.1-x64-ubuntu-14.04.zip && ln -s $PWD/bin/z3-4.7.1-x64-ubuntu-14.04/bin/z3 bin/z3
       env:
         - COMPILER="ccache /usr/bin/clang++-3.7"
         - EXTRA_CXXFLAGS="-Qunused-arguments -fcolor-diagnostics -DNDEBUG"
@@ -361,6 +362,7 @@ install:
 script:
   - if [ -e bin/gcc ] ; then export PATH=$PWD/bin:$PATH ; fi ;
   - env UBSAN_OPTIONS=print_stacktrace=1 make -C regression test-parallel "CXX=${COMPILER} ${EXTRA_CXXFLAGS}" -j2 JOBS=2
+  - env UBSAN_OPTIONS=print_stacktrace=1 make -C regression/cbmc-smt test "CXX=${COMPILER} ${EXTRA_CXXFLAGS}" -j2 JOBS=2
   - make -C unit "CXX=${COMPILER} ${EXTRA_CXXFLAGS}" -j2
   - make -C unit test
   - env UBSAN_OPTIONS=print_stacktrace=1 make -C jbmc/regression test-parallel "CXX=${COMPILER} ${EXTRA_CXXFLAGS}" -j2 JOBS=2

--- a/buildspec-windows.yml
+++ b/buildspec-windows.yml
@@ -6,6 +6,11 @@ phases:
       - choco install cyg-get -y --no-progress
       - cyg-get bash patch bison flex make wget perl
       - nuget install clcache -OutputDirectory "c:\tools" -ExcludeVersion -Version 4.1.0
+      - |
+        $env:Path = "C:\tools\cygwin\bin;$env:Path"
+        cmd /c 'wget --directory-prefix=/cygdrive/c/tools https://github.com/Z3Prover/z3/releases/download/z3-4.7.1/z3-4.7.1-x64-win.zip'
+        Expand-Archive c:\tools\z3-4.7.1-x64-win.zip -DestinationPath C:\tools
+        
 
   build:
     commands:
@@ -64,9 +69,10 @@ phases:
         cd ../..
 
       - |
-        $env:Path = "C:\tools\cygwin\bin;$env:Path"
+        $env:Path = "C:\tools\cygwin\bin;C:\tools\cygwin\bin;c:\tools\z3-4.7.1-x64-win\bin;$env:Path"
         cmd /c 'call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64 && bash -c "make -C regression test BUILD_ENV=MSVC" '
         cmd /c 'call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64 && bash -c "make -C regression/goto-cl test BUILD_ENV=MSVC" '
+        cmd /c 'call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64 && bash -c "make -C regression/cbmc-smt test BUILD_ENV=MSVC" '
 
       - |
         $env:Path = "C:\tools\cygwin\bin;$env:Path"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,6 +11,7 @@ phases:
       - apt-get install -y openjdk-8-jdk
       - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 1
       - update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 1
+      - wget --directory-prefix=bin https://github.com/Z3Prover/z3/releases/download/z3-4.7.1/z3-4.7.1-x64-ubuntu-14.04.zip && unzip -d bin bin/z3-4.7.1-x64-ubuntu-14.04.zip && ln -s $PWD/bin/z3-4.7.1-x64-ubuntu-14.04/bin/z3 /usr/bin/z3
   build:
     commands:
       - echo Build started on `date`
@@ -24,6 +25,7 @@ phases:
     commands:
       - make -C unit test
       - make -C regression test
+      - make -C regression/cbmc-smt test
       - make -C jbmc/unit test
       - make -C jbmc/regression test
       - echo Build completed on `date`

--- a/regression/cbmc-smt/Makefile
+++ b/regression/cbmc-smt/Makefile
@@ -1,0 +1,19 @@
+default: tests.log
+
+test:
+	@../test.pl -p -c ../../../src/cbmc/cbmc
+
+tests.log: ../test.pl
+	@../test.pl -p -c ../../../src/cbmc/cbmc
+
+show:
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			vim -o "$$dir/*.c" "$$dir/*.out"; \
+		fi; \
+	done;
+
+clean:
+	find -name '*.out' -execdir $(RM) '{}' \;
+	find -name '*.smt2' -execdir $(RM) '{}' \;
+	$(RM) tests.log

--- a/regression/cbmc-smt/assert1/main.c
+++ b/regression/cbmc-smt/assert1/main.c
@@ -1,0 +1,4 @@
+int main(void)
+{
+  __CPROVER_assert((__CPROVER_bool)0, "");
+}

--- a/regression/cbmc-smt/assert1/test.desc
+++ b/regression/cbmc-smt/assert1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--smt2
+activate-multi-line-match
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/cbmc-smt/float1/main.c
+++ b/regression/cbmc-smt/float1/main.c
@@ -1,0 +1,8 @@
+int main(void)
+{
+  float f = 0.5;
+  float g;
+
+  float result = f + g;
+  __CPROVER_assert(result >= 1.5, "");
+}

--- a/regression/cbmc-smt/float1/test.desc
+++ b/regression/cbmc-smt/float1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--smt2 --fpa
+activate-multi-line-match
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/cbmc-smt/union1/main.c
+++ b/regression/cbmc-smt/union1/main.c
@@ -1,0 +1,13 @@
+union datat
+{
+  char c;
+  int i;
+};
+
+int main(void)
+{
+  union datat data;
+  data.c = '\0';
+
+  __CPROVER_assert(data.i == 0, "");
+}

--- a/regression/cbmc-smt/union1/test.desc
+++ b/regression/cbmc-smt/union1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--smt2
+activate-multi-line-match
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring


### PR DESCRIPTION
Add SMT back-end regression tests for entities with a conversion to bitvectors.

These tests test the bugfix of the SMT2 back-end introduced in https://github.com/diffblue/cbmc/pull/3119 and will only pass once it is merged.