### PR TITLE
Add `data-types` option

### DIFF
--- a/regression/cbmc-smt/struct1/main.c
+++ b/regression/cbmc-smt/struct1/main.c
@@ -1,0 +1,13 @@
+struct datat
+{
+  char c;
+  int i;
+};
+
+int main(void)
+{
+  struct datat data;
+  data.c = '\0';
+
+  __CPROVER_assert(data.i == 0, "");
+}

--- a/regression/cbmc-smt/struct1/test.desc
+++ b/regression/cbmc-smt/struct1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--smt2 --no-data-types
+activate-multi-line-match
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -321,6 +321,9 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
   if(cmdline.isset("fpa"))
     options.set_option("fpa", true);
 
+  if(cmdline.isset("no-data-types"))
+    options.set_option("data-types", false);
+
   bool solver_set=false;
 
   if(cmdline.isset("boolector"))

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -47,6 +47,7 @@ class optionst;
   "(no-assertions)(no-assumptions)" \
   "(xml-ui)(xml-interface)(json-ui)" \
   "(smt1)(smt2)(fpa)(cvc3)(cvc4)(boolector)(yices)(z3)(opensmt)(mathsat)" \
+  "(no-data-types)" \
   "(no-sat-preprocessor)" \
   "(beautify)" \
   "(dimacs)(refine)(max-node-refinement):(refine-arrays)(refine-arithmetic)"\

--- a/src/cbmc/cbmc_solvers.cpp
+++ b/src/cbmc/cbmc_solvers.cpp
@@ -182,6 +182,9 @@ std::unique_ptr<cbmc_solverst::solvert> cbmc_solverst::get_smt2(
     if(options.get_bool_option("fpa"))
       smt2_dec->use_FPA_theory=true;
 
+    if(options.is_set("data-types") && !options.get_bool_option("data-types"))
+      smt2_dec->use_datatypes=false;
+
     return util_make_unique<solvert>(std::move(smt2_dec));
   }
   else if(filename=="-")


### PR DESCRIPTION
Make SMT `data-types` option explicitly configurable, to allow disabling
it e.g. when using `z3`.

This is an extension of the tests introduced in https://github.com/diffblue/cbmc/pull/3120 and depends on it.