### PR TITLE
Skeleton for well-formedness checking of goto models [blocks: #3118, #3147, #3188, #3191, #3187, #3193]

### DIFF
--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -530,6 +530,11 @@ int cbmc_parse_optionst::doit()
   if(set_properties())
     return CPROVER_EXIT_SET_PROPERTIES_FAILED;
 
+  if(cmdline.isset("validate-goto-model"))
+  {
+    goto_model.validate(validation_modet::INVARIANT);
+  }
+
   return bmct::do_language_agnostic_bmc(
     path_strategy_chooser, options, goto_model, ui_message_handler);
 }
@@ -977,6 +982,8 @@ void cbmc_parse_optionst::help()
     " --xml-ui                     use XML-formatted output\n"
     " --xml-interface              bi-directional XML interface\n"
     " --json-ui                    use JSON-formatted output\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    HELP_VALIDATE
     HELP_GOTO_TRACE
     HELP_FLUSH
     " --verbosity #                verbosity level\n"

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -12,9 +12,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_CBMC_CBMC_PARSE_OPTIONS_H
 #define CPROVER_CBMC_CBMC_PARSE_OPTIONS_H
 
-#include <util/ui_message.h>
 #include <util/parse_options.h>
 #include <util/timestamper.h>
+#include <util/ui_message.h>
+#include <util/validation_interface.h>
 
 #include <langapi/language.h>
 
@@ -73,6 +74,7 @@ class optionst;
   OPT_FLUSH \
   "(localize-faults)(localize-faults-method):" \
   OPT_GOTO_TRACE \
+  OPT_VALIDATE \
   "(claim):(show-claims)(floatbv)(all-claims)(all-properties)" // legacy, and will eventually disappear // NOLINT(whitespace/line_length)
 // clang-format on
 

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -406,6 +406,11 @@ int goto_analyzer_parse_optionst::doit()
   if(process_goto_program(options))
     return CPROVER_EXIT_INTERNAL_ERROR;
 
+  if(cmdline.isset("validate-goto-model"))
+  {
+    goto_model.validate(validation_modet::INVARIANT);
+  }
+
   // show it?
   if(cmdline.isset("show-symbol-table"))
   {
@@ -875,6 +880,7 @@ void goto_analyzer_parse_optionst::help()
     HELP_GOTO_CHECK
     "\n"
     "Other options:\n"
+    HELP_VALIDATE
     " --version                    show version and exit\n"
     HELP_FLUSH
     HELP_TIMESTAMP

--- a/src/goto-analyzer/goto_analyzer_parse_options.h
+++ b/src/goto-analyzer/goto_analyzer_parse_options.h
@@ -101,9 +101,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_GOTO_ANALYZER_GOTO_ANALYZER_PARSE_OPTIONS_H
 #define CPROVER_GOTO_ANALYZER_GOTO_ANALYZER_PARSE_OPTIONS_H
 
-#include <util/ui_message.h>
 #include <util/parse_options.h>
 #include <util/timestamper.h>
+#include <util/ui_message.h>
+#include <util/validation_interface.h>
 
 #include <langapi/language.h>
 
@@ -148,6 +149,7 @@ class optionst;
   "(show)(verify)(simplify):" \
   "(location-sensitive)(concurrent)" \
   "(no-simplify-slicing)" \
+  OPT_VALIDATE \
 // clang-format on
 
 class goto_analyzer_parse_optionst:

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -125,7 +125,26 @@ int goto_instrument_parse_optionst::doit()
 
     get_goto_program();
 
+    {
+      const bool validate_only = cmdline.isset("validate-goto-binary");
+
+      if(validate_only || cmdline.isset("validate-goto-model"))
+      {
+        goto_model.validate(validation_modet::EXCEPTION);
+
+        if(validate_only)
+        {
+          return CPROVER_EXIT_SUCCESS;
+        }
+      }
+    }
+
     instrument_goto_program();
+
+    if(cmdline.isset("validate-goto-model"))
+    {
+      goto_model.validate(validation_modet::INVARIANT);
+    }
 
     {
       bool unwind_given=cmdline.isset("unwind");
@@ -1572,6 +1591,10 @@ void goto_instrument_parse_optionst::help()
     " --show-local-safe-pointers   show pointer expressions that are trivially dominated by a not-null check\n" // NOLINT(*)
     " --show-safe-dereferences     show pointer expressions that are trivially dominated by a not-null check\n" // NOLINT(*)
     "                              *and* used as a dereference operand\n" // NOLINT(*)
+    HELP_VALIDATE
+    // NOLINTNEXTLINE(whitespace/line_length)
+    " --validate-goto-binary       check the well-formedness of the passed in goto\n"
+    "                              binary and then exit\n"
     "\n"
     "Safety checks:\n"
     " --no-assertions              ignore user assertions\n"

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -12,9 +12,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_GOTO_INSTRUMENT_GOTO_INSTRUMENT_PARSE_OPTIONS_H
 #define CPROVER_GOTO_INSTRUMENT_GOTO_INSTRUMENT_PARSE_OPTIONS_H
 
-#include <util/ui_message.h>
 #include <util/parse_options.h>
 #include <util/timestamper.h>
+#include <util/ui_message.h>
+#include <util/validation_interface.h>
 
 #include <goto-programs/class_hierarchy.h>
 #include <goto-programs/goto_functions.h>
@@ -101,6 +102,8 @@ Author: Daniel Kroening, kroening@kroening.com
   OPT_GOTO_PROGRAM_STATS \
   "(show-local-safe-pointers)(show-safe-dereferences)" \
   OPT_REPLACE_CALLS \
+  "(validate-goto-binary)" \
+  OPT_VALIDATE \
   // empty last line
 
 // clang-format on

--- a/src/goto-programs/goto_function.h
+++ b/src/goto-programs/goto_function.h
@@ -110,6 +110,16 @@ public:
     parameter_identifiers = std::move(other.parameter_identifiers);
     return *this;
   }
+
+  /// Check that the goto function is well-formed
+  ///
+  /// The validation mode indicates whether well-formedness check failures are
+  /// reported via DATA_INVARIANT violations or exceptions.
+  void validate(const namespacet &ns, const validation_modet vm) const
+  {
+    body.validate(ns, vm);
+    validate_full_type(type, ns, vm);
+  }
 };
 
 void get_local_identifiers(const goto_functiont &, std::set<irep_idt> &dest);

--- a/src/goto-programs/goto_functions.h
+++ b/src/goto-programs/goto_functions.h
@@ -117,6 +117,19 @@ public:
 
   std::vector<function_mapt::const_iterator> sorted() const;
   std::vector<function_mapt::iterator> sorted();
+
+  /// Check that the goto functions are well-formed
+  ///
+  /// The validation mode indicates whether well-formedness check failures are
+  /// reported via DATA_INVARIANT violations or exceptions.
+  void validate(const namespacet &ns, const validation_modet vm) const
+  {
+    for(const auto &entry : function_map)
+    {
+      const goto_functiont &goto_function = entry.second;
+      goto_function.validate(ns, vm);
+    }
+  }
 };
 
 #define Forall_goto_functions(it, functions) \

--- a/src/goto-programs/goto_model.h
+++ b/src/goto-programs/goto_model.h
@@ -89,6 +89,18 @@ public:
     return goto_functions.function_map.find(id) !=
            goto_functions.function_map.end();
   }
+
+  /// Check that the goto model is well-formed
+  ///
+  /// The validation mode indicates whether well-formedness check failures are
+  /// reported via DATA_INVARIANT violations or exceptions.
+  void validate(const validation_modet vm) const
+  {
+    symbol_table.validate();
+
+    const namespacet ns(symbol_table);
+    goto_functions.validate(ns, vm);
+  }
 };
 
 /// Class providing the abstract GOTO model interface onto an unrelated

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <iomanip>
 
 #include <util/std_expr.h>
+#include <util/validate.h>
 
 #include <langapi/language_util.h>
 
@@ -666,6 +667,62 @@ bool goto_programt::instructiont::equals(const instructiont &other) const
     targets.size() == other.targets.size() &&
     labels == other.labels;
   // clang-format on
+}
+
+void goto_programt::instructiont::validate(
+  const namespacet &ns,
+  const validation_modet vm) const
+{
+  validate_full_code(code, ns, vm);
+  validate_full_expr(guard, ns, vm);
+
+  switch(type)
+  {
+  case NO_INSTRUCTION_TYPE:
+    break;
+  case GOTO:
+    break;
+  case ASSUME:
+    break;
+  case ASSERT:
+    break;
+  case OTHER:
+    break;
+  case SKIP:
+    break;
+  case START_THREAD:
+    break;
+  case END_THREAD:
+    break;
+  case LOCATION:
+    break;
+  case END_FUNCTION:
+    break;
+  case ATOMIC_BEGIN:
+    break;
+  case ATOMIC_END:
+    break;
+  case RETURN:
+    break;
+  case ASSIGN:
+    DATA_CHECK(
+      code.get_statement() == ID_assign,
+      "assign instruction should contain an assign statement");
+    DATA_CHECK(targets.empty(), "assign instruction should not have a target");
+    break;
+  case DECL:
+    break;
+  case DEAD:
+    break;
+  case FUNCTION_CALL:
+    break;
+  case THROW:
+    break;
+  case CATCH:
+    break;
+  case INCOMPLETE_GOTO:
+    break;
+  }
 }
 
 bool goto_programt::equals(const goto_programt &other) const

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -20,10 +20,12 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/invariant.h>
 #include <util/namespace.h>
-#include <util/symbol_table.h>
 #include <util/source_location.h>
-#include <util/std_expr.h>
 #include <util/std_code.h>
+#include <util/std_expr.h>
+#include <util/symbol_table.h>
+
+enum class validation_modet;
 
 /// The type of an instruction in a GOTO program.
 enum goto_program_instruction_typet
@@ -403,11 +405,7 @@ public:
     ///
     /// The validation mode indicates whether well-formedness check failures are
     /// reported via DATA_INVARIANT violations or exceptions.
-    void validate(const namespacet &ns, const validation_modet vm) const
-    {
-      validate_full_code(code, ns, vm);
-      validate_full_expr(guard, ns, vm);
-    }
+    void validate(const namespacet &ns, const validation_modet vm) const;
   };
 
   // Never try to change this to vector-we mutate the list while iterating

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -398,6 +398,16 @@ public:
     /// only be evaluated in the context of a goto_programt (see
     /// goto_programt::equals).
     bool equals(const instructiont &other) const;
+
+    /// Check that the instruction is well-formed
+    ///
+    /// The validation mode indicates whether well-formedness check failures are
+    /// reported via DATA_INVARIANT violations or exceptions.
+    void validate(const namespacet &ns, const validation_modet vm) const
+    {
+      validate_full_code(code, ns, vm);
+      validate_full_expr(guard, ns, vm);
+    }
   };
 
   // Never try to change this to vector-we mutate the list while iterating
@@ -677,6 +687,18 @@ public:
   /// the same number of instructions, each pair of instructions compares equal,
   /// and relative jumps have the same distance.
   bool equals(const goto_programt &other) const;
+
+  /// Check that the goto program is well-formed
+  ///
+  /// The validation mode indicates whether well-formedness check failures are
+  /// reported via DATA_INVARIANT violations or exceptions.
+  void validate(const namespacet &ns, const validation_modet vm) const
+  {
+    for(const instructiont &ins : instructions)
+    {
+      ins.validate(ns, vm);
+    }
+  }
 };
 
 /// Get control-flow successors of a given instruction. The instruction is

--- a/src/goto-programs/initialize_goto_model.cpp
+++ b/src/goto-programs/initialize_goto_model.cpp
@@ -165,6 +165,11 @@ goto_modelt initialize_goto_model(
     goto_model.goto_functions,
     message_handler);
 
+  if(cmdline.isset("validate-goto-model"))
+  {
+    goto_model.validate(validation_modet::EXCEPTION);
+  }
+
   // stupid hack
   config.set_object_bits_from_symbol_table(
     goto_model.symbol_table);

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -97,6 +97,7 @@ SRC = arith_tools.cpp \
       union_find_replace.cpp \
       unwrap_nested_exception.cpp \
       validate_expressions.cpp \
+      validate_types.cpp \
       version.cpp \
       xml.cpp \
       xml_expr.cpp \

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -96,6 +96,7 @@ SRC = arith_tools.cpp \
       union_find.cpp \
       union_find_replace.cpp \
       unwrap_nested_exception.cpp \
+      validate_code.cpp \
       validate_expressions.cpp \
       validate_types.cpp \
       version.cpp \

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -96,6 +96,7 @@ SRC = arith_tools.cpp \
       union_find.cpp \
       union_find_replace.cpp \
       unwrap_nested_exception.cpp \
+      validate_expressions.cpp \
       version.cpp \
       xml.cpp \
       xml_expr.cpp \

--- a/src/util/exception_utils.cpp
+++ b/src/util/exception_utils.cpp
@@ -55,25 +55,23 @@ std::string deserialization_exceptiont::what() const
 }
 
 incorrect_goto_program_exceptiont::incorrect_goto_program_exceptiont(
-  std::string message,
-  source_locationt source_location)
-  : message(std::move(message)), source_location(std::move(source_location))
-{
-}
-
-std::string incorrect_goto_program_exceptiont::what() const
-{
-  if(source_location.is_nil())
-    return message;
-  else
-    return message + " (at: " + source_location.as_string() + ")";
-}
-
-incorrect_goto_program_exceptiont::incorrect_goto_program_exceptiont(
   std::string message)
   : message(std::move(message))
 {
   source_location.make_nil();
+}
+
+std::string incorrect_goto_program_exceptiont::what() const
+{
+  std::string ret(message);
+
+  if(!source_location.is_nil())
+    ret += " (at: " + source_location.as_string() + ")";
+
+  if(!diagnostics.empty())
+    ret += "\n" + diagnostics;
+
+  return ret;
 }
 
 unsupported_operation_exceptiont::unsupported_operation_exceptiont(

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -12,6 +12,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <list>
 
+#include "base_type.h"
+#include "expr.h"
 #include "expr_cast.h"
 #include "invariant.h"
 #include "std_expr.h"
@@ -285,6 +287,39 @@ public:
   {
     return op1();
   }
+
+  static void check(
+    const codet &code,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    DATA_CHECK(
+      code.operands().size() == 2, "assignment must have two operands");
+  }
+
+  static void validate(
+    const codet &code,
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    check(code, vm);
+
+    DATA_CHECK(
+      base_type_eq(code.op0().type(), code.op1().type(), ns),
+      "lhs and rhs of assignment must have same type");
+  }
+
+  static void validate_full(
+    const codet &code,
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    for(const exprt &op : code.operands())
+    {
+      validate_full_expr(op, ns, vm);
+    }
+
+    validate(code, ns, vm);
+  }
 };
 
 template<> inline bool can_cast_expr<code_assignt>(const exprt &base)
@@ -300,16 +335,14 @@ inline void validate_expr(const code_assignt & x)
 inline const code_assignt &to_code_assign(const codet &code)
 {
   PRECONDITION(code.get_statement() == ID_assign);
-  DATA_INVARIANT(
-    code.operands().size() == 2, "assignment must have two operands");
+  code_assignt::check(code);
   return static_cast<const code_assignt &>(code);
 }
 
 inline code_assignt &to_code_assign(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_assign);
-  DATA_INVARIANT(
-    code.operands().size() == 2, "assignment must have two operands");
+  code_assignt::check(code);
   return static_cast<code_assignt &>(code);
 }
 

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -15,6 +15,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "expr_cast.h"
 #include "invariant.h"
 #include "std_expr.h"
+#include "validate.h"
+#include "validate_code.h"
 
 /// Data structure for representing an arbitrary statement in a program. Every
 /// specific type of statement (e.g. block of statements, assignment,
@@ -59,6 +61,53 @@ public:
   codet &last_statement();
   const codet &last_statement() const;
   class code_blockt &make_block();
+
+  /// Check that the code statement is well-formed (shallow checks only, i.e.,
+  /// enclosed statements, subexpressions, etc. are not checked)
+  ///
+  /// Subclasses may override this function to provide specific well-formedness
+  /// checks for the corresponding types.
+  ///
+  /// The validation mode indicates whether well-formedness check failures are
+  /// reported via DATA_INVARIANT violations or exceptions.
+  static void check(
+    const codet &code,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+  }
+
+  /// Check that the code statement is well-formed, assuming that all its
+  /// enclosed statements, subexpressions, etc. have all ready been checked for
+  /// well-formedness.
+  ///
+  /// Subclasses may override this function to provide specific well-formedness
+  /// checks for the corresponding types.
+  ///
+  /// The validation mode indicates whether well-formedness check failures are
+  /// reported via DATA_INVARIANT violations or exceptions.
+  static void validate(
+    const codet &code,
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    check_code(code, vm);
+  }
+
+  /// Check that the code statement is well-formed (full check, including checks
+  /// of all subexpressions)
+  ///
+  /// Subclasses may override this function to provide specific well-formedness
+  /// checks for the corresponding types.
+  ///
+  /// The validation mode indicates whether well-formedness check failures are
+  /// reported via DATA_INVARIANT violations or exceptions.
+  static void validate_full(
+    const codet &code,
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    check_code(code, vm);
+  }
 };
 
 namespace detail // NOLINT

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 /// \file util/std_expr.h
 /// API to expression classes
 
+#include "base_type.h"
 #include "expr_cast.h"
 #include "invariant.h"
 #include "mathematical_types.h"
@@ -771,6 +772,22 @@ public:
     add_to_operands(_lhs, _rhs);
   }
 
+  static void check(
+    const exprt &expr,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    DATA_CHECK(
+      expr.operands().size() == 2, "binary expression must have two operands");
+  }
+
+  static void validate(
+    const exprt &expr,
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    check(expr, vm);
+  }
+
   const exprt &op2() const = delete;
   exprt &op2() = delete;
   const exprt &op3() const = delete;
@@ -826,6 +843,25 @@ public:
     const exprt &_op1):binary_exprt(_op0, _id, _op1, bool_typet())
   {
   }
+
+  static void check(
+    const exprt &expr,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    binary_exprt::check(expr, vm);
+  }
+
+  static void validate(
+    const exprt &expr,
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    binary_exprt::validate(expr, ns, vm);
+
+    DATA_CHECK(
+      expr.type().id() == ID_bool,
+      "result of binary predicate expression should be of type bool");
+  }
 };
 
 /// \brief A base class for relations, i.e., binary predicates
@@ -847,6 +883,26 @@ public:
     const exprt &_rhs):
     binary_predicate_exprt(_lhs, _id, _rhs)
   {
+  }
+
+  static void check(
+    const exprt &expr,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    binary_predicate_exprt::check(expr, vm);
+  }
+
+  static void validate(
+    const exprt &expr,
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    binary_predicate_exprt::validate(expr, ns, vm);
+
+    // check types
+    DATA_CHECK(
+      base_type_eq(expr.op0().type(), expr.op1().type(), ns),
+      "lhs and rhs of binary relation expression should have same type");
   }
 
   exprt &lhs()
@@ -1414,6 +1470,21 @@ public:
     binary_relation_exprt(_lhs, ID_equal, _rhs)
   {
   }
+
+  static void check(
+    const exprt &expr,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    binary_relation_exprt::check(expr, vm);
+  }
+
+  static void validate(
+    const exprt &expr,
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    binary_relation_exprt::validate(expr, ns, vm);
+  }
 };
 
 /// \brief Cast an exprt to an \ref equal_exprt
@@ -1425,7 +1496,7 @@ public:
 inline const equal_exprt &to_equal_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_equal);
-  DATA_INVARIANT(expr.operands().size()==2, "Equality must have two operands");
+  equal_exprt::check(expr);
   return static_cast<const equal_exprt &>(expr);
 }
 
@@ -1433,7 +1504,7 @@ inline const equal_exprt &to_equal_expr(const exprt &expr)
 inline equal_exprt &to_equal_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_equal);
-  DATA_INVARIANT(expr.operands().size()==2, "Equality must have two operands");
+  equal_exprt::check(expr);
   return static_cast<equal_exprt &>(expr);
 }
 

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -14,9 +14,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_UTIL_STD_TYPES_H
 
 #include "expr.h"
-#include "mp_arith.h"
-#include "invariant.h"
 #include "expr_cast.h"
+#include "invariant.h"
+#include "mp_arith.h"
+#include "validate.h"
 
 #include <unordered_map>
 
@@ -1143,6 +1144,13 @@ public:
   {
     set(ID_width, width);
   }
+
+  static void check(
+    const typet &type,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    DATA_CHECK(!type.get(ID_width).empty(), "bitvector type must have width");
+  }
 };
 
 /// Check whether a reference to a typet is a \ref bitvector_typet.
@@ -1245,6 +1253,13 @@ public:
   constant_exprt smallest_expr() const;
   constant_exprt zero_expr() const;
   constant_exprt largest_expr() const;
+
+  static void check(
+    const typet &type,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    bitvector_typet::check(type, vm);
+  }
 };
 
 /// Check whether a reference to a typet is a \ref unsignedbv_typet.
@@ -1254,12 +1269,6 @@ template <>
 inline bool can_cast_type<unsignedbv_typet>(const typet &type)
 {
   return type.id() == ID_unsignedbv;
-}
-
-inline void validate_type(const unsignedbv_typet &type)
-{
-  DATA_INVARIANT(
-    !type.get(ID_width).empty(), "unsigned bitvector type must have width");
 }
 
 /// \brief Cast a typet to an \ref unsignedbv_typet
@@ -1273,18 +1282,16 @@ inline void validate_type(const unsignedbv_typet &type)
 inline const unsignedbv_typet &to_unsignedbv_type(const typet &type)
 {
   PRECONDITION(can_cast_type<unsignedbv_typet>(type));
-  const unsignedbv_typet &ret = static_cast<const unsignedbv_typet &>(type);
-  validate_type(ret);
-  return ret;
+  unsignedbv_typet::check(type);
+  return static_cast<const unsignedbv_typet &>(type);
 }
 
 /// \copydoc to_unsignedbv_type(const typet &)
 inline unsignedbv_typet &to_unsignedbv_type(typet &type)
 {
   PRECONDITION(can_cast_type<unsignedbv_typet>(type));
-  unsignedbv_typet &ret = static_cast<unsignedbv_typet &>(type);
-  validate_type(ret);
-  return ret;
+  unsignedbv_typet::check(type);
+  return static_cast<unsignedbv_typet &>(type);
 }
 
 /// Fixed-width bit-vector with two's complement interpretation

--- a/src/util/symbol_table.h
+++ b/src/util/symbol_table.h
@@ -109,6 +109,11 @@ public:
   {
     return iteratort(internal_symbols.end());
   }
+
+  /// Check that the symbol table is well-formed
+  void validate() const
+  {
+  }
 };
 
 #endif // CPROVER_UTIL_SYMBOL_TABLE_H

--- a/src/util/validate.h
+++ b/src/util/validate.h
@@ -1,0 +1,62 @@
+/*******************************************************************\
+
+Module: Goto program validation macros
+
+Author: Daniel Poetzl
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_VALIDATE_H
+#define CPROVER_UTIL_VALIDATE_H
+
+#include <type_traits>
+
+#include "exception_utils.h"
+#include "validation_mode.h"
+
+/// This macro takes a condition which denotes a well-formedness criterion on
+/// goto programs, expressions, instructions, etc. When invoking the macro, a
+/// variable named `vm` of type `const validation_modet` should be in scope. It
+/// indicates whether DATA_INVARIANT() is used to check the condition, or if an
+/// exception is thrown when the condition does not hold.
+#define DATA_CHECK(condition, message)                                         \
+  do                                                                           \
+  {                                                                            \
+    static_assert(                                                             \
+      std::is_same<decltype(vm), const validation_modet>::value,               \
+      "when invoking the macro DATA_CHECK(), a variable named `vm` of type "   \
+      "`const validation_modet` should be in scope which indicates the "       \
+      "validation mode (see `validate.h`");                                    \
+    switch(vm)                                                                 \
+    {                                                                          \
+    case validation_modet::INVARIANT:                                          \
+      DATA_INVARIANT(condition, message);                                      \
+      break;                                                                   \
+    case validation_modet::EXCEPTION:                                          \
+      if(!(condition))                                                         \
+        throw incorrect_goto_program_exceptiont(message);                      \
+      break;                                                                   \
+    }                                                                          \
+  } while(0)
+
+#define DATA_CHECK_WITH_DIAGNOSTICS(condition, message, ...)                   \
+  do                                                                           \
+  {                                                                            \
+    static_assert(                                                             \
+      std::is_same<decltype(vm), const validation_modet>::value,               \
+      "when invoking the macro DATA_CHECK_WITH_DIAGNOSTICS(), a variable "     \
+      "named `vm` of type `const validation_modet` should be in scope which "  \
+      "indicates the validation mode (see `validate.h`");                      \
+    switch(vm)                                                                 \
+    {                                                                          \
+    case validation_modet::INVARIANT:                                          \
+      DATA_INVARIANT_WITH_DIAGNOSTICS(condition, message, __VA_ARGS__);        \
+      break;                                                                   \
+    case validation_modet::EXCEPTION:                                          \
+      if(!(condition))                                                         \
+        throw incorrect_goto_program_exceptiont(message, __VA_ARGS__);         \
+      break;                                                                   \
+    }                                                                          \
+  } while(0)
+
+#endif /* CPROVER_UTIL_VALIDATE_H */

--- a/src/util/validate_code.cpp
+++ b/src/util/validate_code.cpp
@@ -1,0 +1,90 @@
+/*******************************************************************\
+
+Module: Validate code
+
+Author: Daniel Poetzl
+
+\*******************************************************************/
+
+#include "validate_code.h"
+
+#ifdef REPORT_UNIMPLEMENTED_CODE_CHECKS
+#include <iostream>
+#endif
+
+#include "namespace.h"
+#include "std_code.h"
+#include "validate.h"
+#include "validate_helpers.h"
+
+#define CALL_ON_CODE(code_type)                                                \
+  C<codet, code_type>()(code, std::forward<Args>(args)...)
+
+template <template <typename, typename> class C, typename... Args>
+void call_on_code(const codet &code, Args &&... args)
+{
+  if(code.get_statement() == ID_assign)
+  {
+    CALL_ON_CODE(code_assignt);
+  }
+  else if(code.get_statement() == ID_decl)
+  {
+    CALL_ON_CODE(code_declt);
+  }
+  else
+  {
+#ifdef REPORT_UNIMPLEMENTED_CODE_CHECKS
+    std::cerr << "Unimplemented well-formedness check for code statement with "
+                 "id: "
+              << code.get_statement().id_string() << std::endl;
+#endif
+
+    CALL_ON_CODE(codet);
+  }
+}
+
+/// Check that the given code statement is well-formed (shallow checks only,
+/// i.e., enclosed statements, subexpressions, etc. are not checked)
+///
+/// The function determines the type `T` of the statement `code` (by inspecting
+/// the `id()` field) and then calls `T::check(code, vm)`.
+///
+/// The validation mode indicates whether well-formedness check failures are
+/// reported via DATA_INVARIANT violations or exceptions.
+void check_code(const codet &code, const validation_modet vm)
+{
+  call_on_code<call_checkt>(code, vm);
+}
+
+/// Check that the given code statement is well-formed, assuming that all its
+/// enclosed statements, subexpressions, etc. have already been checked for
+/// well-formedness.
+///
+/// The function determines the type `T` of the statement `code` (by inspecting
+/// the `id()` field) and then calls `T::validate(code, ns, vm)`.
+///
+/// The validation mode indicates whether well-formedness check failures are
+/// reported via DATA_INVARIANT violations or exceptions.
+void validate_code(
+  const codet &code,
+  const namespacet &ns,
+  const validation_modet vm)
+{
+  call_on_code<call_validatet>(code, ns, vm);
+}
+
+/// Check that the given code statement is well-formed (full check, including
+/// checks of all subexpressions)
+///
+/// The function determines the type `T` of the statement `code` (by inspecting
+/// the `id()` field) and then calls `T::validate_full(code, ns, vm)`.
+///
+/// The validation mode indicates whether well-formedness check failures are
+/// reported via DATA_INVARIANT violations or exceptions.
+void validate_full_code(
+  const codet &code,
+  const namespacet &ns,
+  const validation_modet vm)
+{
+  call_on_code<call_validate_fullt>(code, ns, vm);
+}

--- a/src/util/validate_code.h
+++ b/src/util/validate_code.h
@@ -1,0 +1,28 @@
+/*******************************************************************\
+
+Module: Validate code
+
+Author: Daniel Poetzl
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_VALIDATE_CODE_H
+#define CPROVER_UTIL_VALIDATE_CODE_H
+
+class codet;
+class namespacet;
+enum class validation_modet;
+
+void check_code(const codet &code, const validation_modet vm);
+
+void validate_code(
+  const codet &code,
+  const namespacet &ns,
+  const validation_modet vm);
+
+void validate_full_code(
+  const codet &code,
+  const namespacet &ns,
+  const validation_modet vm);
+
+#endif /* CPROVER_UTIL_VALIDATE_CODE_H */

--- a/src/util/validate_expressions.cpp
+++ b/src/util/validate_expressions.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************\
+
+Module: Validate expressions
+
+Author: Daniel Poetzl
+
+\*******************************************************************/
+
+#include "validate_expressions.h"
+#include "validate_helpers.h"
+
+#ifdef REPORT_UNIMPLEMENTED_EXPRESSION_CHECKS
+#include <iostream>
+#endif
+
+#include "expr.h"
+#include "namespace.h"
+#include "std_expr.h"
+#include "validate.h"
+
+#define CALL_ON_EXPR(expr_type)                                                \
+  C<exprt, expr_type>()(expr, std::forward<Args>(args)...)
+
+template <template <typename, typename> class C, typename... Args>
+void call_on_expr(const exprt &expr, Args &&... args)
+{
+  if(expr.id() == ID_equal)
+  {
+    CALL_ON_EXPR(equal_exprt);
+  }
+  else if(expr.id() == ID_plus)
+  {
+    CALL_ON_EXPR(plus_exprt);
+  }
+  else
+  {
+#ifdef REPORT_UNIMPLEMENTED_EXPRESSION_CHECKS
+    std::cerr << "Unimplemented well-formedness check for expression with id: "
+              << expr.id_string() std::endl;
+#endif
+
+    CALL_ON_EXPR(exprt);
+  }
+}
+
+/// Check that the given expression is well-formed (shallow checks only, i.e.,
+/// subexpressions and its type are not checked)
+///
+/// The function determines the type `T` of the expression `expr` (by inspecting
+/// the `id()` field) and then calls `T::check(expr, vm)`.
+///
+/// The validation mode indicates whether well-formedness check failures are
+/// reported via `DATA_INVARIANT` violations or exceptions.
+void check_expr(const exprt &expr, const validation_modet vm)
+{
+  call_on_expr<call_checkt>(expr, vm);
+}
+
+/// Check that the given expression is well-formed, assuming that its
+/// subexpression and type have already been checked for well-formedness.
+///
+/// The function determines the type `T` of the expression `expr` (by inspecting
+/// the `id()` field) and then calls `T::validate(expr, ns, vm)`.
+///
+/// The validation mode indicates whether well-formedness check failures are
+/// reported via `DATA_INVARIANT` violations or exceptions.
+void validate_expr(
+  const exprt &expr,
+  const namespacet &ns,
+  const validation_modet vm)
+{
+  call_on_expr<call_validatet>(expr, ns, vm);
+}
+
+/// Check that the given expression is well-formed (full check, including checks
+/// of all subexpressions and the type)
+///
+/// The function determines the type `T` of the expression `expr` (by inspecting
+/// the `id()` field) and then calls `T::validate_full(expr, ns, vm)`.
+///
+/// The validation mode indicates whether well-formedness check failures are
+/// reported via `DATA_INVARIANT` violations or exceptions.
+void validate_full_expr(
+  const exprt &expr,
+  const namespacet &ns,
+  const validation_modet vm)
+{
+  call_on_expr<call_validate_fullt>(expr, ns, vm);
+}

--- a/src/util/validate_expressions.h
+++ b/src/util/validate_expressions.h
@@ -1,0 +1,28 @@
+/*******************************************************************\
+
+Module: Validate expressions
+
+Author: Daniel Poetzl
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_VALIDATE_EXPRESSIONS_H
+#define CPROVER_UTIL_VALIDATE_EXPRESSIONS_H
+
+class exprt;
+class namespacet;
+enum class validation_modet;
+
+void check_expr(const exprt &expr, const validation_modet vm);
+
+void validate_expr(
+  const exprt &expr,
+  const namespacet &ns,
+  const validation_modet vm);
+
+void validate_full_expr(
+  const exprt &expr,
+  const namespacet &ns,
+  const validation_modet vm);
+
+#endif /* CPROVER_UTIL_VALIDATE_EXPRESSIONS_H */

--- a/src/util/validate_helpers.h
+++ b/src/util/validate_helpers.h
@@ -1,0 +1,52 @@
+/*******************************************************************\
+
+Module: Goto program validation helper templates
+
+Author: Daniel Poetzl
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_VALIDATE_HELPERS_H
+#define CPROVER_UTIL_VALIDATE_HELPERS_H
+
+#include <type_traits>
+
+class namespacet;
+enum class validation_modet;
+
+template <typename Base, typename T>
+struct call_checkt
+{
+  static_assert(std::is_base_of<Base, T>::value, "");
+
+  void operator()(const Base &base, const validation_modet vm)
+  {
+    T::check(base, vm);
+  }
+};
+
+template <typename Base, typename T>
+struct call_validatet
+{
+  static_assert(std::is_base_of<Base, T>::value, "");
+
+  void
+  operator()(const Base &base, const namespacet &ns, const validation_modet vm)
+  {
+    T::validate(base, ns, vm);
+  }
+};
+
+template <typename Base, typename T>
+struct call_validate_fullt
+{
+  static_assert(std::is_base_of<Base, T>::value, "");
+
+  void
+  operator()(const Base &base, const namespacet &ns, const validation_modet vm)
+  {
+    T::validate_full(base, ns, vm);
+  }
+};
+
+#endif /* CPROVER_UTIL_VALIDATE_HELPERS_H */

--- a/src/util/validate_types.cpp
+++ b/src/util/validate_types.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************\
+
+Module: Validate types
+
+Author: Daniel Poetzl
+
+\*******************************************************************/
+
+#include "validate_types.h"
+
+#ifdef REPORT_UNIMPLEMENTED_TYPE_CHECKS
+#include <iostream>
+#endif
+
+#include "namespace.h"
+#include "std_types.h"
+#include "type.h"
+#include "validate.h"
+#include "validate_helpers.h"
+
+#define CALL_ON_TYPE(type_type)                                                \
+  C<typet, type_type>()(type, std::forward<Args>(args)...)
+
+template <template <typename, typename> class C, typename... Args>
+void call_on_type(const typet &type, Args &&... args)
+{
+  if(type.id() == ID_signedbv)
+  {
+    CALL_ON_TYPE(signedbv_typet);
+  }
+  else if(type.id() == ID_unsignedbv)
+  {
+    CALL_ON_TYPE(unsignedbv_typet);
+  }
+  else
+  {
+#ifdef REPORT_UNIMPLEMENTED_TYPE_CHECKS
+    std::cerr << "Unimplemented well-formedness check for type with id: "
+              << type.id_string() << std::endl;
+#endif
+
+    CALL_ON_TYPE(typet);
+  }
+}
+
+/// Check that the given type is well-formed (shallow checks only, i.e.,
+/// subtypes are not checked)
+///
+/// The function determines the type `T` of the type `type` (by inspecting
+/// the id() field) and then calls T::check(type, vm).
+///
+/// The validation mode indicates whether well-formedness check failures are
+/// reported via DATA_INVARIANT violations or exceptions.
+void check_type(const typet &type, const validation_modet vm)
+{
+  call_on_type<call_checkt>(type, vm);
+}
+
+/// Check that the given type is well-formed, assuming that its subtypes have
+/// already been checked for well-formedness.
+///
+/// The function determines the type `T` of the type `type` (by inspecting
+/// the id() field) and then calls T::validate(type, ns, vm).
+///
+/// The validation mode indicates whether well-formedness check failures are
+/// reported via DATA_INVARIANT violations or exceptions.
+void validate_type(
+  const typet &type,
+  const namespacet &ns,
+  const validation_modet vm)
+{
+  call_on_type<call_validatet>(type, ns, vm);
+}
+
+/// Check that the given type is well-formed (full check, including checks of
+/// subtypes)
+///
+/// The function determines the type `T` of the type `type` (by inspecting
+/// the id() field) and then calls T::validate_full(type, ns, vm).
+///
+/// The validation mode indicates whether well-formedness check failures are
+/// reported via DATA_INVARIANT violations or exceptions.
+void validate_full_type(
+  const typet &type,
+  const namespacet &ns,
+  const validation_modet vm)
+{
+  call_on_type<call_validate_fullt>(type, ns, vm);
+}

--- a/src/util/validate_types.h
+++ b/src/util/validate_types.h
@@ -1,0 +1,28 @@
+/*******************************************************************\
+
+Module: Validate types
+
+Author: Daniel Poetzl
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_VALIDATE_TYPES_H
+#define CPROVER_UTIL_VALIDATE_TYPES_H
+
+class typet;
+class namespacet;
+enum class validation_modet;
+
+void check_type(const typet &type, const validation_modet vm);
+
+void validate_type(
+  const typet &type,
+  const namespacet &ns,
+  const validation_modet vm);
+
+void validate_full_type(
+  const typet &type,
+  const namespacet &ns,
+  const validation_modet vm);
+
+#endif /* CPROVER_UTIL_VALIDATE_TYPES_H */

--- a/src/util/validation_interface.h
+++ b/src/util/validation_interface.h
@@ -1,0 +1,19 @@
+/*******************************************************************\
+
+Module: Goto program validation common command line options
+
+Author: Daniel Poetzl
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_VALIDATION_INTERFACE_H
+#define CPROVER_UTIL_VALIDATION_INTERFACE_H
+
+#define OPT_VALIDATE "(validate-goto-model)"
+
+#define HELP_VALIDATE                                                          \
+  " --validate-goto-model        enable additional well-formedness checks on " \
+  "the\n"                                                                      \
+  "                              goto program\n"
+
+#endif /* CPROVER_UTIL_VALIDATION_INTERFACE_H */

--- a/src/util/validation_mode.h
+++ b/src/util/validation_mode.h
@@ -1,0 +1,18 @@
+/*******************************************************************\
+
+Module: Goto program validation mode
+
+Author: Daniel Poetzl
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_VALIDATION_MODE_H
+#define CPROVER_UTIL_VALIDATION_MODE_H
+
+enum class validation_modet
+{
+  INVARIANT,
+  EXCEPTION
+};
+
+#endif /* CPROVER_UTIL_VALIDATION_MODE_H */


### PR DESCRIPTION
This PR introduces a framework for well-formedness checking of goto models. It also introduces two new macros `DATA_CHECK()` and `DATA_CHECK_WITH_DIAGNOSTICS()` for use in the various validation methods (like `validate()`, `validate_full()` on expressions). Based on the value of a variable `vm` (the validation mode, which is an enum with values `INVARIANT` or `EXCEPTION`), when a well-formedness check fails either a `DATA_INVARIANT()` fails or an `incorrect_goto_program_exceptiont` is thrown.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
