### PR TITLE
Remove the __CPROVER_HIDE label when inlining

### DIFF
--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -285,6 +285,13 @@ void goto_inlinet::insert_function_body(
     for(auto &instruction : body.instructions)
       instruction.function=target->function;
 
+  // make sure the inlined function does not introduce hiding
+  if(goto_function.is_hidden())
+  {
+    for(auto &instruction : body.instructions)
+      instruction.labels.remove("__CPROVER_HIDE");
+  }
+
   replace_return(body, lhs);
 
   goto_programt tmp1;


### PR DESCRIPTION
Leaving this label in place will mark the function being inlined into as hidden,
which messes up, e.g., coverage instrumentation.

Consider hidden.c:

 #include <string.h>
 int foo() { char *a, *b; return memcmp(a, b, 1); }
 int main() { foo(); return 0; }

goto-cc hidden.c
goto-instrument --add-library a.out b.out (add library function with hiding)
goto-analyzer --simplify c.out b.out (goto-analyzer does inlining)
cbmc --cover location c.out (will be missing any coverage targets in foo)
cbmc --cover location b.out (has coverage targets in foo)

With this patch, cbmc --cover location c.out also has coverage targets in foo.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
