### PR TITLE
Include pointer offset in counterexample output

### DIFF
--- a/regression/cbmc/trace_address_arithmetic1/main.c
+++ b/regression/cbmc/trace_address_arithmetic1/main.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+
+typedef struct
+{
+  int inta;
+  int intb;
+} struct_t;
+
+typedef union {
+  int intaa;
+  struct_t structbb;
+} union_struct_t;
+
+int main()
+{
+  union_struct_t uuu;
+  char *ptr = (char *)&uuu.structbb.intb;
+  int A[2];
+  int *ip = &A[1];
+  uuu.structbb.intb = 1;
+  assert(0);
+}

--- a/regression/cbmc/trace_address_arithmetic1/test.desc
+++ b/regression/cbmc/trace_address_arithmetic1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--trace
+^EXIT=10$
+^SIGNAL=0$
+ptr=\(char \*\)&uuu!0@1 \+ 4(l+)? \(.*\)$
+ip=A!0@1 \+ 1(l+)? \(.*\)$
+^VERIFICATION FAILED$
+--
+^warning: ignoring


### PR DESCRIPTION
While the bit-level pointer output would convey the information, the
human-readable expression previously did not consider non-zero offsets except
for null pointers.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
