### PR TITLE
Add a virtual destructor to cprover_exception_baset

### DIFF
--- a/src/util/exception_utils.h
+++ b/src/util/exception_utils.h
@@ -16,6 +16,10 @@ Author: Fotis Koutoulakis, fotis.koutoulakis@diffblue.com
 /// Base class for exceptions thrown in the cprover project.
 /// Intended to be used as a convenient way to have a
 /// "catch all and report errors" from application entry points.
+/// Note that the reason we use a custom base class as opposed to
+/// std::exception or one of its derivates to avoid them being accidentally
+/// caught by code expecting standard exceptions to be only thrown by the
+/// standard library.
 class cprover_exception_baset
 {
 public:
@@ -23,6 +27,7 @@ public:
   /// For readability, implementors should not add a leading
   /// or trailing newline to this description.
   virtual std::string what() const = 0;
+  virtual ~cprover_exception_baset() = default;
 };
 
 /// Thrown when users pass incorrect command line arguments,


### PR DESCRIPTION
While exceptions under normal usage scenarios don't need a virtual destructor
(when an exception is thrown, it is the runtimes responsibility to properly
destroy it, and it does know the type of the exception at the point where it's
thrown), it is just generally good practice to have virtual destructors in base
classes to accomodate for situations where a polymorphic destruction may be
needed.

This also adds an explanation for why we use this class in the first place instead of just deriving from `std::exception`

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
