### PR TITLE
Make incorrect_goto_program_exceptiont only output '(at: ..)' if there is a source_location

### DIFF
--- a/src/util/exception_utils.cpp
+++ b/src/util/exception_utils.cpp
@@ -63,7 +63,6 @@ incorrect_goto_program_exceptiont::incorrect_goto_program_exceptiont(
 
 std::string incorrect_goto_program_exceptiont::what() const
 {
-  return message + " (at: " + source_location.as_string() + ")";
   if(source_location.is_nil())
     return message;
   else


### PR DESCRIPTION


<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
