### PR TITLE
Re-try Minisat download (up to two times) in case it fails

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -89,7 +89,13 @@ TAR = tar
 
 minisat2-download:
 	@echo "Downloading Minisat 2.2.1"
-	@$(DOWNLOADER) http://ftp.debian.org/debian/pool/main/m/minisat2/minisat2_2.2.1.orig.tar.gz
+	@for i in $$(seq 1 3) ; do \
+	  $(DOWNLOADER) \
+	    http://ftp.debian.org/debian/pool/main/m/minisat2/minisat2_2.2.1.orig.tar.gz && \
+	    exit 0 ; \
+		$(RM) minisat2_2.2.1.orig.tar.gz ; \
+	  if [ $$i -lt 3 ] ; then echo "Re-trying in 10 seconds" 1>&2 ; sleep 10 ; fi ; \
+	done ; exit 1
 	@$(TAR) xfz minisat2_2.2.1.orig.tar.gz
 	@rm -Rf ../minisat-2.2.1
 	@mv minisat2-2.2.1 ../minisat-2.2.1

--- a/src/solvers/CMakeLists.txt
+++ b/src/solvers/CMakeLists.txt
@@ -60,6 +60,9 @@ include("${CBMC_SOURCE_DIR}/../cmake/DownloadProject.cmake")
 if("${sat_impl}" STREQUAL "minisat2")
     message(STATUS "Building solvers with minisat2")
 
+    # once we upgrade to CMake 3.7 or higher we can specify multiple URLs as a
+    # fall-back in case the first URL fails (the Makefile-based build retries up
+    # to 2 times)
     download_project(PROJ minisat2
         URL http://ftp.debian.org/debian/pool/main/m/minisat2/minisat2_2.2.1.orig.tar.gz
         PATCH_COMMAND patch -p1 -i ${CBMC_SOURCE_DIR}/../scripts/minisat-2.2.1-patch


### PR DESCRIPTION
Running in CI we do see transient network access errors from time to time, which
should not result in task failures (as long as they are genuinely transient).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a My contribution is formatted in line with CODING_STANDARD.md.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
