### PR TITLE
Replace symbol: factor address_of_aware variant to use the unchecked variant

### DIFF
--- a/src/util/replace_symbol.cpp
+++ b/src/util/replace_symbol.cpp
@@ -323,17 +323,16 @@ bool address_of_aware_replace_symbolt::replace(exprt &dest) const
 bool address_of_aware_replace_symbolt::replace_symbol_expr(
   symbol_exprt &s) const
 {
-  expr_mapt::const_iterator it = expr_map.find(s.get_identifier());
-
-  if(it == expr_map.end())
+  symbol_exprt s_copy = s;
+  if(unchecked_replace_symbolt::replace_symbol_expr(s_copy))
     return true;
 
-  const exprt &e = it->second;
-
-  if(require_lvalue && !is_lvalue(e))
+  if(require_lvalue && !is_lvalue(s_copy))
     return true;
 
-  static_cast<exprt &>(s) = e;
+  // Note s_copy is no longer a symbol_exprt due to the replace operation,
+  // and after this line `s` won't be either
+  s = s_copy;
 
   return false;
 }

--- a/src/util/replace_symbol.h
+++ b/src/util/replace_symbol.h
@@ -104,7 +104,7 @@ public:
 
   void insert(const symbol_exprt &old_expr, const exprt &new_expr);
 
-private:
+protected:
   bool replace_symbol_expr(symbol_exprt &dest) const override;
 };
 


### PR DESCRIPTION
Just a simple refactor that proved useful out-of-tree to avoid duplicating code.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- ~Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.~
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- ~My commit message includes data points confirming performance improvements (if claimed).~
- [x] My PR is restricted to a single feature or bugfix.
- ~White-space or formatting changes outside the feature-related changed lines are in commits of their own.~

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
