### PR TITLE
Value set: indirect values.find operations via a helper function

### DIFF
--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -317,6 +317,15 @@ public:
     values.clear();
   }
 
+  /// Finds an entry in this value-set. The interface differs from get_entry
+  /// because get_value_set_rec wants to check for a struct's first component
+  /// before stripping the suffix as is done in get_entry.
+  /// \param id: identifier to find.
+  /// \return a constant pointer to an entry if found, or null otherwise.
+  ///   Note the pointer may be invalidated by insert operations, including
+  ///   get_entry.
+  const entryt *find_entry(const idt &id) const;
+
   /// Gets or inserts an entry in this value-set.
   /// \param e: entry to find. Its `id` and `suffix` fields will be used
   ///   to find a corresponding entry; if a fresh entry is created its


### PR DESCRIPTION
This means when the underlying datastructure changes we don't have to update several users.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- ~My commit message includes data points confirming performance improvements (if claimed).~
- [x] My PR is restricted to a single feature or bugfix.
- ~White-space or formatting changes outside the feature-related changed lines are in commits of their own.~

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
