### PR TITLE
Remove unused make_any methods

### DIFF
--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -306,12 +306,6 @@ public:
     const idt &identifier,
     const std::string &suffix);
 
-  /// Clears value set (not used in the CBMC repository)
-  void make_any()
-  {
-    values.clear();
-  }
-
   void clear()
   {
     values.clear();

--- a/src/pointer-analysis/value_set_fi.h
+++ b/src/pointer-analysis/value_set_fi.h
@@ -212,11 +212,6 @@ public:
     const idt &identifier,
     const std::string &suffix);
 
-  void make_any()
-  {
-    values.clear();
-  }
-
   void clear()
   {
     values.clear();

--- a/src/pointer-analysis/value_set_fivr.h
+++ b/src/pointer-analysis/value_set_fivr.h
@@ -242,11 +242,6 @@ public:
     const idt &identifier,
     const std::string &suffix);
 
-  void make_any()
-  {
-    values.clear();
-  }
-
   void clear()
   {
     values.clear();

--- a/src/pointer-analysis/value_set_fivrns.h
+++ b/src/pointer-analysis/value_set_fivrns.h
@@ -234,11 +234,6 @@ public:
     const idt &identifier,
     const std::string &suffix);
 
-  void make_any()
-  {
-    values.clear();
-  }
-
   void clear()
   {
     values.clear();


### PR DESCRIPTION
This cleans up an out-of-tree extension of clear(), avoiding code duplication
