### PR TITLE
replace_symbolt: avoid a couple of direct references to expr_map

### DIFF
--- a/src/util/replace_symbol.cpp
+++ b/src/util/replace_symbol.cpp
@@ -119,7 +119,7 @@ bool replace_symbolt::replace(exprt &dest) const
 
 bool replace_symbolt::have_to_replace(const exprt &dest) const
 {
-  if(expr_map.empty())
+  if(empty())
     return false;
 
   // first look at type
@@ -132,7 +132,7 @@ bool replace_symbolt::have_to_replace(const exprt &dest) const
   if(dest.id()==ID_symbol)
   {
     const irep_idt &identifier = to_symbol_expr(dest).get_identifier();
-    return expr_map.find(identifier) != expr_map.end();
+    return replaces_symbol(identifier);
   }
 
   forall_operands(it, dest)


### PR DESCRIPTION
Makes out-of-tree alterations to replace_symbolt easier by using its own interface rather
than directly inspecting its data structures where possible.
