### PR TITLE
Move to clang-format-6.0 and cleanup config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,14 @@ jobs:
       env: NAME="clang-format"
       addons:
         apt:
+          sources:
+            - llvm-toolchain-trusty-6.0
           packages:
-            - clang-format-3.8
+            - clang-format-6.0
       install:
       script: |
-        # Apparently update-alternatives doesn't work in Travis containers
-        mkdir -p priority-symlinks
-        ln -s /usr/bin/clang-format-3.8 priority-symlinks/clang-format
-        export PATH=${PWD}/priority-symlinks:${PATH}
-
-        # Now we can do the formatting pass
         clang-format --version
-        git-clang-format-3.8 "${TRAVIS_BRANCH}"
+        git-clang-format-6.0 --binary clang-format-6.0 "${TRAVIS_BRANCH}"
         git diff > formatted.diff
         if [[ -s formatted.diff ]] ; then
           echo 'Formatting error! The following diff shows the required changes'


### PR DESCRIPTION
As we are moving to clang-6.0 in other parts of the Travis configuration we
might as well use clang-format-6.0 in line with this. Also clean up the script
that used to ack around paths by just specifying the binary to use on the
command-line.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a My contribution is formatted in line with CODING_STANDARD.md.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
