### PR TITLE
Reduce Doxygen warnings (in goto-symex and cpp)

### DIFF
--- a/src/cpp/cpp_typecheck_constructor.cpp
+++ b/src/cpp/cpp_typecheck_constructor.cpp
@@ -19,9 +19,11 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "cpp_util.h"
 
+/// Generate code to copy the parent.
+/// \param source_location: location for generated code
 /// \param parent_base_name: base name of typechecked parent
-/// \param block: non-typechecked block
-/// \return generate code to copy the parent
+/// \param arg_name: name of argument that is being copied
+/// \param [out] block: non-typechecked block
 static void copy_parent(
   const source_locationt &source_location,
   const irep_idt &parent_base_name,
@@ -48,9 +50,11 @@ static void copy_parent(
   block.operands().push_back(code);
 }
 
+/// Generate code to copy the member.
+/// \param source_location: location for generated code
 /// \param member_base_name: name of a member
-/// \param block: non-typechecked block
-/// \return generate code to copy the member
+/// \param arg_name: name of argument that is being copied
+/// \param [out] block: non-typechecked block
 static void copy_member(
   const source_locationt &source_location,
   const irep_idt &member_base_name,
@@ -75,10 +79,12 @@ static void copy_member(
   block.operands().push_back(code);
 }
 
+/// Generate code to copy the member.
+/// \param source_location: location for generated code
 /// \param member_base_name: name of array member
-/// \param index: index to copy
-/// \param block: non-typechecked block
-/// \return generate code to copy the member
+/// \param i: index to copy
+/// \param arg_name: name of argument that is being copied
+/// \param [out] block: non-typechecked block
 static void copy_array(
   const source_locationt &source_location,
   const irep_idt &member_base_name,

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -226,7 +226,7 @@ void collect_open_variables(
 
 /// Slice the symex trace with respect to a list of expressions
 /// \param equation: symex trace to be sliced
-/// \param expression: list of expressions, targets for slicing
+/// \param expressions: list of expressions, targets for slicing
 /// \return None. But equation is modified as a side-effect.
 void slice(
   symex_target_equationt &equation,


### PR DESCRIPTION
This addresses a few more of the warnings that are produced when running doxygen, by updating documentation for parameters.

This PR addresses some of the issues in src/goto-symex and src/cpp.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
