### PR TITLE
Make get_subexpression_at_offset return an exprt for consistency

### DIFF
--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -466,18 +466,18 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
       if(ns.follow(result.value.type())!=ns.follow(dereference_type))
         result.value.make_typecast(dereference_type);
     }
-    else if(get_subexpression_at_offset(
-        root_object_subexpression,
-        o.offset(),
-        dereference_type,
-        ns))
-    {
-      // Successfully found a member, array index, or combination thereof
-      // that matches the desired type and offset:
-      result.value=root_object_subexpression;
-    }
     else
     {
+      exprt subexpr = get_subexpression_at_offset(
+        root_object_subexpression, o.offset(), dereference_type, ns);
+      if(subexpr.is_not_nil())
+      {
+        // Successfully found a member, array index, or combination thereof
+        // that matches the desired type and offset:
+        result.value = subexpr;
+        return result;
+      }
+
       // we extract something from the root object
       result.value=o.root_object();
 

--- a/src/util/pointer_offset_size.cpp
+++ b/src/util/pointer_offset_size.cpp
@@ -630,17 +630,18 @@ exprt build_sizeof_expr(
   return result;
 }
 
-bool get_subexpression_at_offset(
-  exprt &result,
+exprt get_subexpression_at_offset(
+  const exprt &expr,
   mp_integer offset,
   const typet &target_type_raw,
   const namespacet &ns)
 {
+  exprt result = expr;
   const typet &source_type=ns.follow(result.type());
   const typet &target_type=ns.follow(target_type_raw);
 
   if(offset==0 && source_type==target_type)
-    return true;
+    return result;
 
   if(source_type.id()==ID_struct)
   {
@@ -667,7 +668,7 @@ bool get_subexpression_at_offset(
       }
       ++offsets;
     }
-    return false;
+    return nil_exprt();
   }
   else if(source_type.id()==ID_array)
   {
@@ -678,12 +679,12 @@ bool get_subexpression_at_offset(
     auto elem_size = pointer_offset_size(at.subtype(), ns);
 
     if(!elem_size.has_value())
-      return false;
+      return nil_exprt();
 
     mp_integer cellidx = offset / (*elem_size);
 
     if(cellidx < 0 || !cellidx.is_long())
-      return false;
+      return nil_exprt();
 
     offset = offset % (*elem_size);
 
@@ -691,11 +692,11 @@ bool get_subexpression_at_offset(
     return get_subexpression_at_offset(result, offset, target_type, ns);
   }
   else
-    return false;
+    return nil_exprt();
 }
 
-bool get_subexpression_at_offset(
-  exprt &result,
+exprt get_subexpression_at_offset(
+  const exprt &expr,
   const exprt &offset,
   const typet &target_type,
   const namespacet &ns)
@@ -703,7 +704,7 @@ bool get_subexpression_at_offset(
   mp_integer offset_const;
 
   if(to_integer(offset, offset_const))
-    return false;
+    return nil_exprt();
   else
-    return get_subexpression_at_offset(result, offset_const, target_type, ns);
+    return get_subexpression_at_offset(expr, offset_const, target_type, ns);
 }

--- a/src/util/pointer_offset_size.h
+++ b/src/util/pointer_offset_size.h
@@ -79,14 +79,14 @@ exprt build_sizeof_expr(
   const constant_exprt &expr,
   const namespacet &ns);
 
-bool get_subexpression_at_offset(
-  exprt &result,
+exprt get_subexpression_at_offset(
+  const exprt &expr,
   mp_integer offset,
   const typet &target_type,
   const namespacet &ns);
 
-bool get_subexpression_at_offset(
-  exprt &result,
+exprt get_subexpression_at_offset(
+  const exprt &expr,
   const exprt &offset,
   const typet &target_type,
   const namespacet &ns);


### PR DESCRIPTION
All other functions declared in that block in pointer_offset_size.h return an
exprt and the comment explicitly states that they return nil_exprt() on failure.
get_subexpression_at_offset used to return "true" on success (and false on
failure), which is the opposite of what most of the code base does. (But the
interpretation of true/false as return values is non-obvious anyway and thus
returning an expression adds clarity.)

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
