### PR TITLE
type_with_subtypest now has constructors that take the subtypes

### DIFF
--- a/src/util/type.h
+++ b/src/util/type.h
@@ -114,11 +114,22 @@ inline type_with_subtypet &to_type_with_subtype(typet &type)
 class type_with_subtypest:public typet
 {
 public:
+  typedef std::vector<typet> subtypest;
+
   type_with_subtypest() { }
 
   explicit type_with_subtypest(const irep_idt &_id):typet(_id) { }
 
-  typedef std::vector<typet> subtypest;
+  type_with_subtypest(const irep_idt &_id, const subtypest &_subtypes)
+    : typet(_id)
+  {
+    subtypes() = _subtypes;
+  }
+
+  type_with_subtypest(const irep_idt &_id, subtypest &&_subtypes) : typet(_id)
+  {
+    subtypes() = std::move(_subtypes);
+  }
 
   subtypest &subtypes()
   {


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [X] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
