### PR TITLE
use a separate message for show_goto_functions() for the console

### DIFF
--- a/src/goto-programs/goto_functions.cpp
+++ b/src/goto-programs/goto_functions.cpp
@@ -13,6 +13,8 @@ Date: June 2003
 
 #include "goto_functions.h"
 
+#include <algorithm>
+
 void goto_functionst::compute_location_numbers()
 {
   unused_location_number = 0;
@@ -53,4 +55,45 @@ void goto_functionst::compute_loop_numbers()
   {
     func.second.body.compute_loop_numbers();
   }
+}
+
+/// returns a vector of the iterators in alphabetical order
+std::vector<goto_functionst::function_mapt::const_iterator>
+goto_functionst::sorted() const
+{
+  std::vector<function_mapt::const_iterator> result;
+
+  result.reserve(function_map.size());
+
+  for(auto it = function_map.begin(); it != function_map.end(); it++)
+    result.push_back(it);
+
+  std::sort(
+    result.begin(),
+    result.end(),
+    [](function_mapt::const_iterator a, function_mapt::const_iterator b) {
+      return id2string(a->first) < id2string(b->first);
+    });
+
+  return result;
+}
+
+/// returns a vector of the iterators in alphabetical order
+std::vector<goto_functionst::function_mapt::iterator> goto_functionst::sorted()
+{
+  std::vector<function_mapt::iterator> result;
+
+  result.reserve(function_map.size());
+
+  for(auto it = function_map.begin(); it != function_map.end(); it++)
+    result.push_back(it);
+
+  std::sort(
+    result.begin(),
+    result.end(),
+    [](function_mapt::iterator a, function_mapt::iterator b) {
+      return id2string(a->first) < id2string(b->first);
+    });
+
+  return result;
 }

--- a/src/goto-programs/goto_functions.cpp
+++ b/src/goto-programs/goto_functions.cpp
@@ -13,25 +13,6 @@ Date: June 2003
 
 #include "goto_functions.h"
 
-void goto_functionst::output(
-  const namespacet &ns,
-  std::ostream &out) const
-{
-  for(const auto &fun : function_map)
-  {
-    if(fun.second.body_available())
-    {
-      out << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\n";
-
-      const symbolt &symbol=ns.lookup(fun.first);
-      out << symbol.display_name() << " /* " << symbol.name << " */\n";
-      fun.second.body.output(ns, symbol.name, out);
-
-      out << std::flush;
-    }
-  }
-}
-
 void goto_functionst::compute_location_numbers()
 {
   unused_location_number = 0;

--- a/src/goto-programs/goto_functions.h
+++ b/src/goto-programs/goto_functions.h
@@ -114,6 +114,9 @@ public:
     for(const auto &fun : other.function_map)
       function_map[fun.first].copy_from(fun.second);
   }
+
+  std::vector<function_mapt::const_iterator> sorted() const;
+  std::vector<function_mapt::iterator> sorted();
 };
 
 #define Forall_goto_functions(it, functions) \

--- a/src/goto-programs/goto_functions.h
+++ b/src/goto-programs/goto_functions.h
@@ -72,10 +72,6 @@ public:
     function_map.clear();
   }
 
-  void output(
-    const namespacet &ns,
-    std::ostream &out) const;
-
   void compute_location_numbers();
   void compute_location_numbers(goto_programt &);
   void compute_loop_numbers();

--- a/src/goto-programs/goto_model.h
+++ b/src/goto-programs/goto_model.h
@@ -37,12 +37,6 @@ public:
     goto_functions.clear();
   }
 
-  void output(std::ostream &out) const
-  {
-    namespacet ns(symbol_table);
-    goto_functions.output(ns, out);
-  }
-
   goto_modelt()
   {
   }

--- a/src/goto-programs/show_goto_functions.cpp
+++ b/src/goto-programs/show_goto_functions.cpp
@@ -75,7 +75,8 @@ void show_goto_functions(
           out << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\n";
 
           const symbolt &symbol = ns.lookup(fun.first);
-          out << symbol.display_name() << " /* " << symbol.name << " */\n";
+          out << messaget::bold << symbol.display_name() << messaget::reset
+              << " /* " << symbol.name << " */\n";
           fun.second.body.output(ns, symbol.name, out);
           msg.status() << messaget::eom;
         }

--- a/src/goto-programs/show_goto_functions.cpp
+++ b/src/goto-programs/show_goto_functions.cpp
@@ -51,10 +51,13 @@ void show_goto_functions(
 
   case ui_message_handlert::uit::PLAIN:
     {
-      for(const auto &fun : goto_functions.function_map)
+      // sort alphabetically
+      const auto sorted = goto_functions.sorted();
+
+      for(const auto &fun : sorted)
       {
-        const symbolt &symbol = ns.lookup(fun.first);
-        const bool has_body = fun.second.body_available();
+        const symbolt &symbol = ns.lookup(fun->first);
+        const bool has_body = fun->second.body_available();
 
         if(list_only)
         {
@@ -67,10 +70,9 @@ void show_goto_functions(
         {
           msg.status() << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\n";
 
-          const symbolt &symbol = ns.lookup(fun.first);
           msg.status() << messaget::bold << symbol.display_name()
                        << messaget::reset << " /* " << symbol.name << " */\n";
-          fun.second.body.output(ns, symbol.name, msg.status());
+          fun->second.body.output(ns, symbol.name, msg.status());
           msg.status() << messaget::eom;
         }
       }

--- a/src/goto-programs/show_goto_functions.cpp
+++ b/src/goto-programs/show_goto_functions.cpp
@@ -62,14 +62,24 @@ void show_goto_functions(
                      << (fun.second.body_available() ? ""
                                                      : ", body not available")
                      << " */";
+        msg.status() << messaget::eom;
       }
-
-      msg.status() << messaget::eom;
     }
     else
     {
-      goto_functions.output(ns, msg.status());
-      msg.status() << messaget::eom;
+      auto &out = msg.status();
+      for(const auto &fun : goto_functions.function_map)
+      {
+        if(fun.second.body_available())
+        {
+          out << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\n";
+
+          const symbolt &symbol = ns.lookup(fun.first);
+          out << symbol.display_name() << " /* " << symbol.name << " */\n";
+          fun.second.body.output(ns, symbol.name, out);
+          msg.status() << messaget::eom;
+        }
+      }
     }
 
     break;

--- a/src/goto-programs/show_goto_functions.cpp
+++ b/src/goto-programs/show_goto_functions.cpp
@@ -52,32 +52,27 @@ void show_goto_functions(
   break;
 
   case ui_message_handlert::uit::PLAIN:
-    if(list_only)
     {
       for(const auto &fun : goto_functions.function_map)
       {
         const symbolt &symbol = ns.lookup(fun.first);
-        msg.status() << '\n'
-                     << symbol.display_name() << " /* " << symbol.name
-                     << (fun.second.body_available() ? ""
-                                                     : ", body not available")
-                     << " */";
-        msg.status() << messaget::eom;
-      }
-    }
-    else
-    {
-      auto &out = msg.status();
-      for(const auto &fun : goto_functions.function_map)
-      {
-        if(fun.second.body_available())
+        const bool has_body = fun.second.body_available();
+
+        if(list_only)
         {
-          out << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\n";
+          msg.status() << '\n'
+                       << symbol.display_name() << " /* " << symbol.name
+                       << (has_body ? "" : ", body not available") << " */";
+          msg.status() << messaget::eom;
+        }
+        else if(has_body)
+        {
+          msg.status() << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\n";
 
           const symbolt &symbol = ns.lookup(fun.first);
-          out << messaget::bold << symbol.display_name() << messaget::reset
-              << " /* " << symbol.name << " */\n";
-          fun.second.body.output(ns, symbol.name, out);
+          msg.status() << messaget::bold << symbol.display_name()
+                       << messaget::reset << " /* " << symbol.name << " */\n";
+          fun.second.body.output(ns, symbol.name, msg.status());
           msg.status() << messaget::eom;
         }
       }

--- a/src/goto-programs/show_goto_functions.cpp
+++ b/src/goto-programs/show_goto_functions.cpp
@@ -11,8 +11,6 @@ Author: Peter Schrammel
 
 #include "show_goto_functions.h"
 
-#include <iostream>
-
 #include <util/xml.h>
 #include <util/json.h>
 #include <util/json_expr.h>

--- a/src/goto-programs/show_goto_functions_json.cpp
+++ b/src/goto-programs/show_goto_functions_json.cpp
@@ -41,10 +41,13 @@ json_objectt show_goto_functions_jsont::convert(
 {
   json_arrayt json_functions;
   const json_irept no_comments_irep_converter(false);
-  for(const auto &function_entry : goto_functions.function_map)
+
+  const auto sorted = goto_functions.sorted();
+
+  for(const auto &function_entry : sorted)
   {
-    const irep_idt &function_name=function_entry.first;
-    const goto_functionst::goto_functiont &function=function_entry.second;
+    const irep_idt &function_name = function_entry->first;
+    const goto_functionst::goto_functiont &function = function_entry->second;
 
     json_objectt &json_function=
       json_functions.push_back(jsont()).make_object();

--- a/src/goto-programs/show_goto_functions_xml.cpp
+++ b/src/goto-programs/show_goto_functions_xml.cpp
@@ -43,10 +43,13 @@ xmlt show_goto_functions_xmlt::convert(
   const goto_functionst &goto_functions)
 {
   xmlt xml_functions=xmlt("functions");
-  for(const auto &function_entry : goto_functions.function_map)
+
+  const auto sorted = goto_functions.sorted();
+
+  for(const auto &function_entry : sorted)
   {
-    const irep_idt &function_name=function_entry.first;
-    const goto_functionst::goto_functiont &function=function_entry.second;
+    const irep_idt &function_name = function_entry->first;
+    const goto_functionst::goto_functiont &function = function_entry->second;
 
     xmlt &xml_function=xml_functions.new_element("function");
     xml_function.set_attribute("name", id2string(function_name));


### PR DESCRIPTION
Rationale: the messages are output into a string buffer, which does not
scale well in case there are many functions.  Output can be delayed
substantially.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] My contribution is formatted in line with CODING_STANDARD.md.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
