### PR TITLE
Generalise get_subexpression_at_offset to extract parts of members

### DIFF
--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -468,9 +468,10 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
     }
     else
     {
+      // try to build a member/index expression - do not use byte_extract
       exprt subexpr = get_subexpression_at_offset(
         root_object_subexpression, o.offset(), dereference_type, ns);
-      if(subexpr.is_not_nil())
+      if(subexpr.is_not_nil() && subexpr.id() != byte_extract_id())
       {
         // Successfully found a member, array index, or combination thereof
         // that matches the desired type and offset:

--- a/src/util/pointer_offset_size.h
+++ b/src/util/pointer_offset_size.h
@@ -81,7 +81,7 @@ exprt build_sizeof_expr(
 
 exprt get_subexpression_at_offset(
   const exprt &expr,
-  mp_integer offset,
+  const mp_integer &offset,
   const typet &target_type,
   const namespacet &ns);
 

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -1679,17 +1679,26 @@ bool simplify_exprt::simplify_byte_extract(byte_extract_exprt &expr)
   if(to_integer(expr.offset(), offset) || offset<0)
     return true;
 
-  // byte extract of full object is object
   // don't do any of the following if endianness doesn't match, as
   // bytes need to be swapped
-  if(
-    offset == 0 && base_type_eq(expr.type(), expr.op().type(), ns) &&
-    byte_extract_id() == expr.id())
+  if(offset == 0 && byte_extract_id() == expr.id())
   {
-    exprt tmp=expr.op();
-    expr.swap(tmp);
+    // byte extract of full object is object
+    if(base_type_eq(expr.type(), expr.op().type(), ns))
+    {
+      exprt tmp = expr.op();
+      expr.swap(tmp);
 
-    return false;
+      return false;
+    }
+    else if(
+      expr.type().id() == ID_pointer && expr.op().type().id() == ID_pointer)
+    {
+      typecast_exprt tc(expr.op(), expr.type());
+      expr.swap(tc);
+
+      return false;
+    }
   }
 
   // no proper simplification for expr.type()==void

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -40,6 +40,7 @@ SRC += analyses/ai/ai.cpp \
        util/irep_sharing.cpp \
        util/message.cpp \
        util/optional.cpp \
+       util/pointer_offset_size.cpp \
        util/replace_symbol.cpp \
        util/sharing_map.cpp \
        util/sharing_node.cpp \

--- a/unit/util/pointer_offset_size.cpp
+++ b/unit/util/pointer_offset_size.cpp
@@ -1,0 +1,120 @@
+/*******************************************************************\
+
+ Module: Unit tests of expression size/offset computation
+
+ Author: Michael Tautschnig
+
+\*******************************************************************/
+
+#include <testing-utils/catch.hpp>
+
+#include <util/arith_tools.h>
+#include <util/byte_operators.h>
+#include <util/c_types.h>
+#include <util/cmdline.h>
+#include <util/config.h>
+#include <util/namespace.h>
+#include <util/pointer_offset_size.h>
+#include <util/std_expr.h>
+#include <util/symbol_table.h>
+
+TEST_CASE("Build subexpression to access element at offset into array")
+{
+  // this test does require a proper architecture to be set so that byte extract
+  // uses adequate endianness
+  cmdlinet cmdline;
+  config.set(cmdline);
+
+  symbol_tablet symbol_table;
+  namespacet ns(symbol_table);
+
+  const signedbv_typet t(32);
+
+  array_typet array_type(t, from_integer(2, size_type()));
+  symbol_exprt a("array", array_type);
+
+  {
+    const exprt result = get_subexpression_at_offset(a, 0, t, ns);
+    REQUIRE(result == index_exprt(a, from_integer(0, index_type())));
+  }
+
+  {
+    const exprt result = get_subexpression_at_offset(a, 32 / 8, t, ns);
+    REQUIRE(result == index_exprt(a, from_integer(1, index_type())));
+  }
+
+  {
+    const exprt result =
+      get_subexpression_at_offset(a, from_integer(0, size_type()), t, ns);
+    REQUIRE(result == index_exprt(a, from_integer(0, index_type())));
+  }
+
+  {
+    const exprt result =
+      get_subexpression_at_offset(a, size_of_expr(t, ns), t, ns);
+    REQUIRE(result == index_exprt(a, from_integer(1, index_type())));
+  }
+
+  {
+    const signedbv_typet small_t(8);
+    const exprt result = get_subexpression_at_offset(a, 1, small_t, ns);
+    REQUIRE(
+      result == byte_extract_exprt(
+                  byte_extract_id(),
+                  index_exprt(a, from_integer(0, index_type())),
+                  from_integer(1, index_type()),
+                  small_t));
+  }
+}
+
+TEST_CASE("Build subexpression to access element at offset into struct")
+{
+  // this test does require a proper architecture to be set so that byte extract
+  // uses adequate endianness
+  cmdlinet cmdline;
+  config.set(cmdline);
+
+  symbol_tablet symbol_table;
+  namespacet ns(symbol_table);
+
+  const signedbv_typet t(32);
+
+  struct_typet st;
+  st.components().emplace_back("foo", t);
+  st.components().emplace_back("bar", t);
+
+  symbol_exprt s("struct", st);
+
+  {
+    const exprt result = get_subexpression_at_offset(s, 0, t, ns);
+    REQUIRE(result == member_exprt(s, "foo", t));
+  }
+
+  {
+    const exprt result = get_subexpression_at_offset(s, 32 / 8, t, ns);
+    REQUIRE(result == member_exprt(s, "bar", t));
+  }
+
+  {
+    const exprt result =
+      get_subexpression_at_offset(s, from_integer(0, size_type()), t, ns);
+    REQUIRE(result == member_exprt(s, "foo", t));
+  }
+
+  {
+    const exprt result =
+      get_subexpression_at_offset(s, size_of_expr(t, ns), t, ns);
+    REQUIRE(result == member_exprt(s, "bar", t));
+  }
+
+  {
+    const signedbv_typet small_t(8);
+    const exprt result = get_subexpression_at_offset(s, 1, small_t, ns);
+    REQUIRE(
+      result == byte_extract_exprt(
+                  byte_extract_id(),
+                  member_exprt(s, "foo", t),
+                  from_integer(1, index_type()),
+                  small_t));
+  }
+}


### PR DESCRIPTION
This enables re-use in the simplifier and other places. Adding a unit test of
get_subexpression_at_offset.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My contribution is formatted in line with CODING_STANDARD.md.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
