### PR TITLE
Make maven invocations quiet

### DIFF
--- a/jbmc/CMakeLists.txt
+++ b/jbmc/CMakeLists.txt
@@ -3,7 +3,7 @@ add_subdirectory(src)
 add_subdirectory(unit)
 
 add_custom_target(java-models-library ALL
-    COMMAND mvn --quiet package
+    COMMAND mvn --quiet -Dmaven.test.skip=true package
     COMMAND cp target/core-models.jar ${CMAKE_CURRENT_SOURCE_DIR}/src/java_bytecode/library/
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib/java-models-library
 )

--- a/jbmc/CMakeLists.txt
+++ b/jbmc/CMakeLists.txt
@@ -3,7 +3,7 @@ add_subdirectory(src)
 add_subdirectory(unit)
 
 add_custom_target(java-models-library ALL
-    COMMAND mvn package
+    COMMAND mvn --quiet package
     COMMAND cp target/core-models.jar ${CMAKE_CURRENT_SOURCE_DIR}/src/java_bytecode/library/
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib/java-models-library
 )

--- a/jbmc/src/java_bytecode/library/Makefile
+++ b/jbmc/src/java_bytecode/library/Makefile
@@ -22,11 +22,14 @@ clean: clean_library
 .PHONY: clean_library
 clean_library:
 	rm -rf core-models.jar
-	if [ -d $(LIBRARY_DIR) ]; then cd $(LIBRARY_DIR); mvn clean; fi
+	if [ -d $(LIBRARY_DIR) ]; then cd $(LIBRARY_DIR); mvn --quiet clean; fi
 
 .PHONY: library
 library:
-	if [ -d $(LIBRARY_DIR) ]; then (cd $(LIBRARY_DIR); mvn package); cp $(LIBRARY_DIR)/target/core-models.jar .; fi
+	if [ -d $(LIBRARY_DIR) ]; then \
+		(cd $(LIBRARY_DIR); mvn --quiet package); \
+		cp $(LIBRARY_DIR)/target/core-models.jar .; \
+	fi
 
 ###############################################################################
 

--- a/jbmc/src/java_bytecode/library/Makefile
+++ b/jbmc/src/java_bytecode/library/Makefile
@@ -27,7 +27,7 @@ clean_library:
 .PHONY: library
 library:
 	if [ -d $(LIBRARY_DIR) ]; then \
-		(cd $(LIBRARY_DIR); mvn --quiet package); \
+		(cd $(LIBRARY_DIR); mvn --quiet -Dmaven.test.skip=true package); \
 		cp $(LIBRARY_DIR)/target/core-models.jar .; \
 	fi
 


### PR DESCRIPTION
The status messages make it unnecessarily hard to spot other compilation errors.
Also disable the attempt to run tests as there aren't any.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a My contribution is formatted in line with CODING_STANDARD.md.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
