### PR TITLE
Add sources for libstdc++6 >= 4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,12 @@ jobs:
         apt:
           sources:
             - llvm-toolchain-trusty-6.0
+            - ubuntu-toolchain-r-test
           packages:
             - clang-format-6.0
       install:
       script: |
-        clang-format --version
+        clang-format-6.0 --version
         git-clang-format-6.0 --binary clang-format-6.0 "${TRAVIS_BRANCH}"
         git diff > formatted.diff
         if [[ -s formatted.diff ]] ; then


### PR DESCRIPTION
clang-format-6.0 requires a libstc++6 version newer than what Ubuntu 14.04 ships
by default; such a version is available from the ubuntu-toolchain-r-test PPA.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a My contribution is formatted in line with CODING_STANDARD.md.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
