### PR TITLE
Travis: Make linter and clang-format failures fatal

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,6 @@ Thank you for your contribution. Please make sure your pull request fulfils all 
 --->
 
 - [ ] Each commit message has a non-empty body, explaining why the change was made.
-- [ ] My contribution is formatted in line with CODING_STANDARD.md.
 - [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
 - [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
 - [ ] My commit message includes data points confirming performance improvements (if claimed).

--- a/.travis.yml
+++ b/.travis.yml
@@ -341,10 +341,6 @@ jobs:
         - COMPILER="ccache g++"
       script: echo "This is coverity build. No need for tests."
 
-  allow_failures:
-    - <<: *formatting-stage
-    - <<: *linter-stage
-
 install:
   - ccache -z
   - ccache --max-size=1G


### PR DESCRIPTION
Instead of requesting contributors to tick "my contribution is formatted ..."
just make CI fail if it isn't properly formatted. When there are good reasons to
ignore the formatting recommendations use // clang-format {off,on} and // NOLINT
with clang-format and the linter, respectively.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a My contribution is formatted in line with CODING_STANDARD.md.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
