### PR TITLE
Reduce Doxygen warnings in goto-instrument

### DIFF
--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -54,10 +54,7 @@ void instrument_cover_goals(
 /// \deprecated use instrument_cover_goals(goto_programt &goto_program,
 /// const cover_instrumenterst &instrumenters,
 /// message_handlert &message_handler, const irep_idt mode) instead
-DEPRECATED(
-  "use instrument_cover_goals(goto_programt &goto_program,"
-  "const cover_instrumenterst &instrumenters,"
-  "message_handlert &message_handler, const irep_idt mode) instead")
+DEPRECATED("use instrument_cover_goals(goto_programt &...) instead")
 void instrument_cover_goals(
   const symbol_tablet &symbol_table,
   goto_programt &goto_program,

--- a/src/goto-instrument/model_argc_argv.cpp
+++ b/src/goto-instrument/model_argc_argv.cpp
@@ -31,8 +31,8 @@ Date: April 2016
 #include <goto-programs/remove_skip.h>
 
 /// Set up argv with up to max_argc pointers into an array of 4096 bytes.
-/// \param symbol_table: Input program's symbol table
-/// \param goto_functions: Input program's intermediate representation
+/// \param goto_model: Contains the input program's symbol table and
+///   intermediate representation
 /// \param max_argc: User-specified maximum number of arguments to be modelled
 /// \param message_handler: message logging
 /// \return True, if and only if modelling succeeded


### PR DESCRIPTION
Reduce Doxygen warnings by updating some parameter documentation, and abbreviating a "deprecated" message (where Doxygen was getting confused by multi-line macro parameters).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
