### PR TITLE
Add missing ID_range to range_typet

### DIFF
--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -1714,7 +1714,7 @@ inline string_typet &to_string_type(typet &type)
 class range_typet:public typet
 {
 public:
-  range_typet(const mp_integer &_from, const mp_integer &_to)
+  range_typet(const mp_integer &_from, const mp_integer &_to) : typet(ID_range)
   {
     set_from(_from);
     set_to(_to);


### PR DESCRIPTION
This commit adds a missing ID_range to the constructor
of range_typet. This was missing because up until this
point we didn't construct a range_typet at all, and
checks for it where checking against a manually inserted
ID_range. This ensures sound construction of the type.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [-] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
