### PR TITLE
Distinguish __CPROVER_bool from _Bool in output

### DIFF
--- a/regression/cbmc/cprover_bool1/main.c
+++ b/regression/cbmc/cprover_bool1/main.c
@@ -1,0 +1,8 @@
+#include <assert.h>
+
+int main()
+{
+  int y;
+  __CPROVER_bool x = y;
+  assert(x != (__CPROVER_bool)y);
+}

--- a/regression/cbmc/cprover_bool1/test.desc
+++ b/regression/cbmc/cprover_bool1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--trace
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+x != \(__CPROVER_bool\)y
+--
+x != \(_Bool\)y
+^warning: ignoring

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -205,7 +205,7 @@ std::string expr2ct::convert_rec(
 
   if(src.id()==ID_bool)
   {
-    return q+"_Bool"+d;
+    return q + CPROVER_PREFIX + "bool" + d;
   }
   else if(src.id()==ID_c_bool)
   {


### PR DESCRIPTION
A __CPROVER_bool is a single bit and should not be output the same way as a
_Bool, which may be one or more bytes wide.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
