### PR TITLE
Evaluating sizeof over __CPROVER_bool requires special cases

### DIFF
--- a/regression/ansi-c/cprover_bool1/main.c
+++ b/regression/ansi-c/cprover_bool1/main.c
@@ -1,0 +1,46 @@
+#define STATIC_ASSERT(condition) int some_array##__LINE__[(condition) ? 1 : -1]
+
+struct bits
+{
+  __CPROVER_bool b1;
+  __CPROVER_bool b2;
+  __CPROVER_bool b3;
+  __CPROVER_bool b4;
+  __CPROVER_bool b5;
+  __CPROVER_bool b6;
+  __CPROVER_bool b7;
+  __CPROVER_bool b8;
+  int i;
+};
+
+STATIC_ASSERT(sizeof(struct bits) == 2 * sizeof(int));
+
+#include <limits.h>
+
+#if CHAR_BIT >= 8
+#pragma pack(1)
+struct packed_bits
+{
+  __CPROVER_bool b1;
+  __CPROVER_bool b2;
+  __CPROVER_bool b3;
+  __CPROVER_bool b4;
+  __CPROVER_bool b5;
+  __CPROVER_bool b6;
+  __CPROVER_bool b7;
+  __CPROVER_bool b8;
+  int i;
+};
+#pragma pack()
+
+STATIC_ASSERT(sizeof(struct packed_bits) == sizeof(int) + 1);
+#endif
+
+// a _Bool is at least one byte wide
+STATIC_ASSERT(sizeof(_Bool[CHAR_BIT]) >= CHAR_BIT);
+// __CPROVER_bool is just a single bit
+STATIC_ASSERT(sizeof(__CPROVER_bool[CHAR_BIT]) == 1);
+
+int main()
+{
+}

--- a/regression/ansi-c/cprover_bool1/test.desc
+++ b/regression/ansi-c/cprover_bool1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -985,6 +985,12 @@ void c_typecheck_baset::typecheck_expr_sizeof(exprt &expr)
     error() << "sizeof cannot be applied to bit fields" << eom;
     throw 0;
   }
+  else if(type.id() == ID_bool)
+  {
+    err_location(expr);
+    error() << "sizeof cannot be applied to single bits" << eom;
+    throw 0;
+  }
   else if(type.id() == ID_empty)
   {
     // This is a gcc extension.
@@ -1737,6 +1743,13 @@ void c_typecheck_baset::typecheck_expr_address_of(exprt &expr)
   {
     err_location(expr);
     error() << "cannot take address of a bit field" << eom;
+    throw 0;
+  }
+
+  if(op.type().id() == ID_bool)
+  {
+    err_location(expr);
+    error() << "cannot take address of a single bit" << eom;
     throw 0;
   }
 

--- a/src/ansi-c/padding.cpp
+++ b/src/ansi-c/padding.cpp
@@ -226,6 +226,10 @@ static void add_padding_msvc(struct_typet &type, const namespacet &ns)
         const auto width = to_c_bit_field_type(it->type()).get_width();
         bit_field_bits += width;
       }
+      else if(it->type().id() == ID_bool)
+      {
+        ++bit_field_bits;
+      }
       else
       {
         // keep track of offset
@@ -280,6 +284,10 @@ static void add_padding_gcc(struct_typet &type, const namespacet &ns)
         // count the bits
         const std::size_t width = to_c_bit_field_type(it->type()).get_width();
         bit_field_bits+=width;
+      }
+      else if(it->type().id() == ID_bool)
+      {
+        ++bit_field_bits;
       }
       else if(bit_field_bits!=0)
       {
@@ -346,6 +354,18 @@ static void add_padding_gcc(struct_typet &type, const namespacet &ns)
         offset+=bytes;
         continue;
       }
+    }
+    else if(it_type.id() == ID_bool)
+    {
+      a = alignment(it_type, ns);
+      if(max_alignment < a)
+        max_alignment = a;
+
+      ++bit_field_bits;
+      const std::size_t bytes = bit_field_bits / config.ansi_c.char_width;
+      bit_field_bits %= config.ansi_c.char_width;
+      offset += bytes;
+      continue;
     }
     else
       a=alignment(it_type, ns);

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -1947,10 +1947,10 @@ bool simplify_exprt::simplify_byte_update(byte_update_exprt &expr)
       {
         const struct_typet &struct_type=to_struct_type(tp);
         const irep_idt &component_name=with.where().get(ID_component_name);
+        const typet &c_type = struct_type.get_component(component_name).type();
 
         // is this a bit field?
-        if(struct_type.get_component(component_name).type().id()==
-           ID_c_bit_field)
+        if(c_type.id() == ID_c_bit_field || c_type.id() == ID_bool)
         {
           // don't touch -- might not be byte-aligned
         }

--- a/src/util/simplify_expr_struct.cpp
+++ b/src/util/simplify_expr_struct.cpp
@@ -152,8 +152,12 @@ bool simplify_exprt::simplify_member(exprt &expr)
       const struct_typet::componentt &component=
         struct_type.get_component(component_name);
 
-      if(component.is_nil() || component.type().id()==ID_c_bit_field)
+      if(
+        component.is_nil() || component.type().id() == ID_c_bit_field ||
+        component.type().id() == ID_bool)
+      {
         return true;
+      }
 
       // add member offset to index
       auto offset_int = member_offset(struct_type, component_name, ns);


### PR DESCRIPTION
__CPROVER_bool is just a single bit, and not part of any language standard
describing the semantics of sizeof. We can declare arrays of __CPROVER_bool,
which will thus have elements that are not aligned on byte boundaries. Using
sizeof with such an array thus requires specific handling.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
