### PR TITLE
C++ bool is at least one byte wide

### DIFF
--- a/regression/cpp/cprover_bool1/main.cpp
+++ b/regression/cpp/cprover_bool1/main.cpp
@@ -1,0 +1,12 @@
+#include <limits.h>
+
+static_assert(
+  sizeof(bool[CHAR_BIT]) >= CHAR_BIT,
+  "a bool is at least one byte wide");
+static_assert(
+  sizeof(__CPROVER_bool[CHAR_BIT]) == 1,
+  "__CPROVER_bool is just a single bit");
+
+int main(int argc, char *argv[])
+{
+}

--- a/regression/cpp/cprover_bool1/test.desc
+++ b/regression/cpp/cprover_bool1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.cpp
+-std=c++11
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/src/cpp/cpp_convert_type.cpp
+++ b/src/cpp/cpp_convert_type.cpp
@@ -104,7 +104,7 @@ void cpp_convert_typet::read_rec(const typet &type)
     int128_cnt++;
   else if(type.id()==ID_complex)
     complex_cnt++;
-  else if(type.id()==ID_bool)
+  else if(type.id() == ID_c_bool)
     cpp_bool_cnt++;
   else if(type.id()==ID_proper_bool)
     proper_bool_cnt++;
@@ -414,7 +414,7 @@ void cpp_convert_typet::write(typet &type)
        int64_cnt || int128_cnt || ptr32_cnt || ptr64_cnt)
       throw "illegal type modifier for C++ bool";
 
-    type.id(ID_bool);
+    type = c_bool_type();
   }
   else if(proper_bool_cnt)
   {
@@ -602,6 +602,10 @@ void cpp_convert_plain_type(typet &type)
     // add width -- we use int, but the standard
     // doesn't guarantee that
     type.set(ID_width, config.ansi_c.int_width);
+  }
+  else if(type.id() == ID_c_bool)
+  {
+    type.set(ID_width, config.ansi_c.bool_width);
   }
   else
   {

--- a/src/cpp/cpp_type2name.cpp
+++ b/src/cpp/cpp_type2name.cpp
@@ -13,8 +13,9 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include <string>
 
-#include <util/type.h>
+#include <util/cprover_prefix.h>
 #include <util/std_types.h>
+#include <util/type.h>
 
 static std::string do_prefix(const std::string &s)
 {
@@ -103,8 +104,10 @@ std::string cpp_type2name(const typet &type)
 
   if(type.id()==ID_empty || type.id()==ID_void)
     result+="void";
-  else if(type.id()==ID_bool)
+  else if(type.id() == ID_c_bool)
     result+="bool";
+  else if(type.id() == ID_bool)
+    result += CPROVER_PREFIX "bool";
   else if(type.id()==ID_pointer)
   {
     if(is_reference(type))

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -970,12 +970,10 @@ cpp_scopet &cpp_typecheck_resolvet::resolve_scope(
       irept::subt::const_iterator next=pos+1;
       assert(next != cpp_name.get_sub().end());
 
-      if(next->id() == ID_cpp_name ||
-         next->id() == ID_pointer ||
-         next->id() == ID_int ||
-         next->id() == ID_char ||
-         next->id() == ID_bool ||
-         next->id() == ID_merged_type)
+      if(
+        next->id() == ID_cpp_name || next->id() == ID_pointer ||
+        next->id() == ID_int || next->id() == ID_char ||
+        next->id() == ID_c_bool || next->id() == ID_merged_type)
       {
         // it's a cast operator
         irept next_ir=*next;

--- a/src/cpp/cpp_typecheck_type.cpp
+++ b/src/cpp/cpp_typecheck_type.cpp
@@ -178,12 +178,10 @@ void cpp_typecheckt::typecheck_type(typet &type)
   {
     typecheck_c_bit_field_type(to_c_bit_field_type(type));
   }
-  else if(type.id()==ID_unsignedbv ||
-          type.id()==ID_signedbv ||
-          type.id()==ID_bool ||
-          type.id()==ID_floatbv ||
-          type.id()==ID_fixedbv ||
-          type.id()==ID_empty)
+  else if(
+    type.id() == ID_unsignedbv || type.id() == ID_signedbv ||
+    type.id() == ID_bool || type.id() == ID_c_bool || type.id() == ID_floatbv ||
+    type.id() == ID_fixedbv || type.id() == ID_empty)
   {
   }
   else if(type.id() == ID_symbol_type)

--- a/src/cpp/expr2cpp.cpp
+++ b/src/cpp/expr2cpp.cpp
@@ -110,7 +110,7 @@ std::string expr2cppt::convert_constant(
   const constant_exprt &src,
   unsigned &precedence)
 {
-  if(src.type().id()==ID_bool)
+  if(src.type().id() == ID_c_bool)
   {
     // C++ has built-in Boolean constants, in contrast to C
     if(src.is_true())
@@ -346,6 +346,10 @@ std::string expr2cppt::convert_rec(
   {
     // only really used in error messages
     return "{ ... }";
+  }
+  else if(src.id() == ID_c_bool)
+  {
+    return q + "bool" + d;
   }
   else
     return expr2ct::convert_rec(src, qualifiers, declarator);

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -2453,7 +2453,9 @@ bool Parser::optIntegralTypeOrClassSpec(typet &p)
     case TOK_GCC_INT128: type_id=ID_gcc_int128; break;
     case TOK_GCC_FLOAT80: type_id=ID_gcc_float80; break;
     case TOK_GCC_FLOAT128: type_id=ID_gcc_float128; break;
-    case TOK_BOOL: type_id=ID_bool; break;
+    case TOK_BOOL:
+      type_id = ID_c_bool;
+      break;
     case TOK_CPROVER_BOOL: type_id=ID_proper_bool; break;
     case TOK_AUTO: type_id = ID_auto; break;
     default: type_id=irep_idt();
@@ -6713,7 +6715,7 @@ bool Parser::rPrimaryExpr(exprt &exp)
 
   case TOK_TRUE:
     lex.get_token(tk);
-    exp=true_exprt();
+    exp = typecast_exprt(true_exprt(), c_bool_type());
     set_location(exp, tk);
     #ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 4\n";
@@ -6722,7 +6724,7 @@ bool Parser::rPrimaryExpr(exprt &exp)
 
   case TOK_FALSE:
     lex.get_token(tk);
-    exp=false_exprt();
+    exp = typecast_exprt(false_exprt(), c_bool_type());
     set_location(exp, tk);
     #ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 5\n";


### PR DESCRIPTION
Do not treat "bool" as a single bit, which is what __CPROVER_bool is for.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
