### PR TITLE
Remove member_offset_iterator

### DIFF
--- a/src/util/pointer_offset_size.h
+++ b/src/util/pointer_offset_size.h
@@ -25,22 +25,6 @@ class constant_exprt;
 
 // these return 'nullopt' on failure
 
-// NOLINTNEXTLINE(readability/identifiers)
-class member_offset_iterator
-{
-  typedef std::pair<size_t, mp_integer> refst;
-  refst current;
-  const struct_typet &type;
-  const namespacet &ns;
-  size_t bit_field_bits;
-public:
-  member_offset_iterator(const struct_typet &_type,
-                         const namespacet &_ns);
-  member_offset_iterator &operator++();
-  const refst &operator*() const { return current; }
-  const refst* operator->() const { return &current; }
-};
-
 optionalt<mp_integer> member_offset(
   const struct_typet &type,
   const irep_idt &member,


### PR DESCRIPTION
It was undocumented and its fields did't carry descriptive names, thus code using it was hard to read and understand. With all the preceding work it only had a single user left.

Only the first commit is new. Marking do-not-merged until #3167 is merged.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
