### PR TITLE
Change syntax used in Doxygen comment

### DIFF
--- a/jbmc/src/java_bytecode/load_method_by_regex.cpp
+++ b/jbmc/src/java_bytecode/load_method_by_regex.cpp
@@ -48,7 +48,7 @@ bool does_pattern_miss_descriptor(const std::string &pattern)
 
 /// Create a lambda that returns the symbols that the given pattern should be
 /// loaded.If the pattern doesn't include a colon for matching the descriptor,
-/// append a `:\(.*\).*` to the regex. Note this will mean all overloaded
+/// append a :\(.*\).* to the regex. Note this will mean all overloaded
 /// methods will be marked as extra entry points for CI lazy loading.
 /// If the pattern doesn't include the java:: prefix, prefix that
 /// \param pattern: The user provided pattern


### PR DESCRIPTION
In a Doxygen comment, there was a regular expression surrounded by backticks, with the intention that it should be displayed using a typewriter font.  However, Doxygen was confused by the *\ in the regular expression (which it interpreted as the end of a comment), and it gave 8 warning messages, such as

    warning: end of comment block while expecting command </code>

Removing the backticks fixes 8 warning messages.

The regular expression is still not displayed correctly in the generated documentation.  However, it is no worse than it was before this change.  I looked for ways to fix the generated documentation, but couldn't find anything that looked ok in _both_ the generated documentation _and_ the source code.  (It would be possible to copy and paste the comment, adapt one version for Doxygen and make the other one legible in the source file.)

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
