### PR TITLE
Check symbol table mappings

### DIFF
--- a/src/goto-programs/goto_model.h
+++ b/src/goto-programs/goto_model.h
@@ -96,7 +96,7 @@ public:
   /// reported via DATA_INVARIANT violations or exceptions.
   void validate(const validation_modet vm) const
   {
-    symbol_table.validate();
+    symbol_table.validate(vm);
 
     const namespacet ns(symbol_table);
     goto_functions.validate(ns, vm);

--- a/src/util/symbol_table.h
+++ b/src/util/symbol_table.h
@@ -111,9 +111,7 @@ public:
   }
 
   /// Check that the symbol table is well-formed
-  void validate() const
-  {
-  }
+  void validate(const validation_modet vm = validation_modet::INVARIANT) const;
 };
 
 #endif // CPROVER_UTIL_SYMBOL_TABLE_H


### PR DESCRIPTION
This PR builds upon/depends upon #3123 (merged). It adds some basic sanity checking of the symbol table structure, namely that symbols are correctly keyed, and that `base_name` and `module` maps are in sync with the symbols.
 <!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
