### PR TITLE
Cleanup in string preprocessing

### DIFF
--- a/jbmc/src/java_bytecode/convert_java_nondet.cpp
+++ b/jbmc/src/java_bytecode/convert_java_nondet.cpp
@@ -15,12 +15,12 @@ Author: Reuben Thomas, reuben.thomas@diffblue.com
 #include <goto-programs/goto_model.h>
 #include <goto-programs/remove_skip.h>
 
-#include <util/fresh_symbol.h>
 #include <util/irep_ids.h>
 
 #include <memory>
 
 #include "java_object_factory.h" // gen_nondet_init
+#include "java_utils.h"
 
 /// Returns true if `expr` is a nondet pointer that isn't a function pointer or
 /// a void* pointer as these can be meaningfully non-det initialized.
@@ -116,13 +116,8 @@ static std::pair<goto_programt::targett, bool> insert_nondet_init_code(
     //   target2: instruction containing op, with op replaced by aux_symbol
     //            dead aux_symbol
 
-    symbolt &aux_symbol = get_fresh_aux_symbol(
-      op.type(),
-      id2string(function_identifier),
-      "nondet_tmp",
-      source_loc,
-      ID_java,
-      symbol_table);
+    symbolt &aux_symbol = fresh_java_symbol(
+      op.type(), "nondet_tmp", source_loc, function_identifier, symbol_table);
 
     const symbol_exprt aux_symbol_expr = aux_symbol.symbol_expr();
     op = aux_symbol_expr;

--- a/jbmc/src/java_bytecode/java_bytecode_concurrency_instrumentation.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_concurrency_instrumentation.cpp
@@ -9,12 +9,12 @@ Author: Kurt Degiogrio, kurt.degiorgio@diffblue.com
 #include "java_bytecode_concurrency_instrumentation.h"
 #include "expr2java.h"
 #include "java_types.h"
+#include "java_utils.h"
 
 #include <util/expr_iterator.h>
 #include <util/namespace.h>
 #include <util/cprover_prefix.h>
 #include <util/std_types.h>
-#include <util/fresh_symbol.h>
 #include <util/arith_tools.h>
 
 // Disable linter to allow an std::string constant.
@@ -229,12 +229,11 @@ static void instrument_synchronized_code(
   code_pop_catcht catch_pop;
 
   // Create the finally block with the same label targeted in the catch-push
-  const symbolt &tmp_symbol = get_fresh_aux_symbol(
+  const symbolt &tmp_symbol = fresh_java_symbol(
     java_reference_type(struct_tag_typet("java::java.lang.Throwable")),
-    id2string(symbol.name),
     "caught-synchronized-exception",
     code.source_location(),
-    ID_java,
+    id2string(symbol.name),
     symbol_table);
   symbol_exprt catch_var(tmp_symbol.name, tmp_symbol.type);
   catch_var.set(ID_C_base_name, tmp_symbol.base_name);

--- a/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
@@ -11,7 +11,6 @@ Date:   June 2017
 #include "java_bytecode_instrument.h"
 
 #include <util/arith_tools.h>
-#include <util/fresh_symbol.h>
 #include <util/std_code.h>
 #include <util/std_expr.h>
 #include <util/c_types.h>
@@ -112,14 +111,8 @@ code_ifthenelset java_bytecode_instrumentt::throw_exception(
 
   // Allocate and throw an instance of the exception class:
 
-  symbolt &new_symbol=
-    get_fresh_aux_symbol(
-      exc_ptr_type,
-      "new_exception",
-      "new_exception",
-      original_loc,
-      ID_java,
-      symbol_table);
+  symbolt &new_symbol = fresh_java_symbol(
+    exc_ptr_type, "new_exception", original_loc, "new_exception", symbol_table);
 
   side_effect_exprt new_instance(ID_java_new, exc_ptr_type, original_loc);
   code_assignt assign_new(new_symbol.symbol_expr(), new_instance);

--- a/jbmc/src/java_bytecode/java_entry_point.cpp
+++ b/jbmc/src/java_bytecode/java_entry_point.cpp
@@ -375,12 +375,11 @@ exprt::operandst java_build_arguments(
       // method(..., param, ...)
       //
 
-      const symbolt result_symbol = get_fresh_aux_symbol(
+      const symbolt result_symbol = fresh_java_symbol(
         p.type(),
-        id2string(function.name),
         "nondet_parameter_" + std::to_string(param_number),
         function.location,
-        ID_java,
+        function.name,
         symbol_table);
       main_arguments[param_number] = result_symbol.symbol_expr();
 

--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -476,7 +476,7 @@ void initialize_nondet_string_fields(
     index_exprt(data_expr, from_integer(0, java_int_type())));
 
   add_pointer_to_array_association(
-    array_pointer, data_expr, symbol_table, loc, code);
+    array_pointer, data_expr, symbol_table, loc, function_id, code);
 
   add_array_to_length_association(
     data_expr, length_expr, symbol_table, loc, code);

--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -9,7 +9,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "java_object_factory.h"
 
 #include <util/expr_initializer.h>
-#include <util/fresh_symbol.h>
 #include <util/nondet_bool.h>
 #include <util/nondet.h>
 #include <util/pointer_offset_size.h>
@@ -20,6 +19,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "generic_parameter_specialization_map_keys.h"
 #include "java_root_class.h"
 #include "java_string_literals.h"
+#include "java_utils.h"
 
 class java_object_factoryt
 {
@@ -442,13 +442,8 @@ void initialize_nondet_string_fields(
 
   /// \todo Refactor with make_nondet_string_expr
   // length_expr = nondet(int);
-  const symbolt length_sym = get_fresh_aux_symbol(
-    java_int_type(),
-    id2string(function_id),
-    "tmp_object_factory",
-    loc,
-    ID_java,
-    symbol_table);
+  const symbolt length_sym = fresh_java_symbol(
+    java_int_type(), "tmp_object_factory", loc, function_id, symbol_table);
   const symbol_exprt length_expr = length_sym.symbol_expr();
   const side_effect_expr_nondett nondet_length(length_expr.type(), loc);
   code.add(code_declt(length_expr));
@@ -745,12 +740,11 @@ symbol_exprt java_object_factoryt::gen_nondet_subtype_pointer_init(
   size_t depth,
   const source_locationt &location)
 {
-  symbolt new_symbol = get_fresh_aux_symbol(
+  symbolt new_symbol = fresh_java_symbol(
     replacement_pointer,
-    id2string(object_factory_parameters.function_id),
     "tmp_object_factory",
-    loc,
-    ID_java,
+    location,
+    object_factory_parameters.function_id,
     symbol_table);
 
   // Generate a new object into this new symbol

--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -479,7 +479,7 @@ void initialize_nondet_string_fields(
     array_pointer, data_expr, symbol_table, loc, function_id, code);
 
   add_array_to_length_association(
-    data_expr, length_expr, symbol_table, loc, code);
+    data_expr, length_expr, symbol_table, loc, function_id, code);
 
   struct_expr.operands()[struct_type.component_number("data")] = array_pointer;
 

--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -487,7 +487,7 @@ void initialize_nondet_string_fields(
   if(printable)
   {
     add_character_set_constraint(
-      array_pointer, length_expr, " -~", symbol_table, loc, code);
+      array_pointer, length_expr, " -~", symbol_table, loc, function_id, code);
   }
 }
 

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -316,9 +316,8 @@ exprt::operandst java_string_library_preprocesst::process_operands(
   for(const auto &p : operands)
   {
     if(implements_java_char_sequence_pointer(p.type()))
-      ops.push_back(
-        convert_exprt_to_string_exprt(
-          p, loc, symbol_table, function_id, init_code));
+      ops.push_back(convert_exprt_to_string_exprt(
+        p, loc, symbol_table, function_id, init_code));
     else if(is_java_char_array_pointer_type(p.type()))
       ops.push_back(
         replace_char_array(p, loc, function_id, symbol_table, init_code));

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -478,7 +478,7 @@ refined_string_exprt java_string_library_preprocesst::replace_char_array(
     char_array, array_typet(java_char_type(), infinity_exprt(java_int_type())));
 
   add_pointer_to_array_association(
-    string_expr.content(), inf_array, symbol_table, loc, code);
+    string_expr.content(), inf_array, symbol_table, loc, function_id, code);
 
   return string_expr;
 }
@@ -564,7 +564,7 @@ refined_string_exprt java_string_library_preprocesst::make_nondet_string_expr(
     index_exprt(nondet_array_expr, from_integer(0, java_int_type())));
 
   add_pointer_to_array_association(
-    array_pointer, nondet_array_expr, symbol_table, loc, code);
+    array_pointer, nondet_array_expr, symbol_table, loc, function_id, code);
 
   add_array_to_length_association(
     nondet_array_expr, str.length(), symbol_table, loc, code);
@@ -677,12 +677,14 @@ exprt make_nondet_infinite_char_array(
 /// \param array: a character array expression
 /// \param symbol_table: the symbol table
 /// \param loc: source location
+/// \param function_id: name of the function in which the code will be added
 /// \param [out] code: code block to which declaration and calls get added
 void add_pointer_to_array_association(
   const exprt &pointer,
   const exprt &array,
   symbol_table_baset &symbol_table,
   const source_locationt &loc,
+  const irep_idt &function_id,
   code_blockt &code)
 {
   PRECONDITION(array.type().id() == ID_array);

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -328,42 +328,6 @@ exprt::operandst java_string_library_preprocesst::process_operands(
   return ops;
 }
 
-/// Converts the operands of the equals function to string expressions and
-/// outputs these conversions. As a side effect of the conversions it adds some
-/// code to init_code.
-/// \param operands: a list of expressions
-/// \param loc: location in the source
-/// \param symbol_table: symbol table
-/// \param init_code: code block, in which declaration of some arguments may be
-///   added
-/// \return a list of expressions
-exprt::operandst
-java_string_library_preprocesst::process_equals_function_operands(
-  const exprt::operandst &operands,
-  const source_locationt &loc,
-  symbol_table_baset &symbol_table,
-  code_blockt &init_code)
-{
-  PRECONDITION(operands.size()==2);
-  exprt::operandst ops;
-  const exprt &op0=operands[0];
-  const exprt &op1 = operands[1];
-  PRECONDITION(implements_java_char_sequence_pointer(op0.type()));
-
-  ops.push_back(
-    convert_exprt_to_string_exprt(
-      op0, loc, symbol_table, loc.get_function(), init_code));
-
-  // TODO: Manage the case where we have a non-String Object (this should
-  // probably be handled upstream. At any rate, the following code should be
-  // protected with assertions on the type of op1.
-  const typecast_exprt tcast(op1, to_pointer_type(op0.type()));
-  ops.push_back(
-    convert_exprt_to_string_exprt(
-      tcast, loc, symbol_table, loc.get_function(), init_code));
-  return ops;
-}
-
 /// Finds the type of the data component
 /// \param type: a type containing a "data" component
 /// \param symbol_table: symbol table

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -567,7 +567,7 @@ refined_string_exprt java_string_library_preprocesst::make_nondet_string_expr(
     array_pointer, nondet_array_expr, symbol_table, loc, function_id, code);
 
   add_array_to_length_association(
-    nondet_array_expr, str.length(), symbol_table, loc, code);
+    nondet_array_expr, str.length(), symbol_table, loc, function_id, code);
 
   code.add(code_assignt(str.content(), array_pointer), loc);
 
@@ -713,12 +713,14 @@ void add_pointer_to_array_association(
 /// \param length: integer expression
 /// \param symbol_table: the symbol table
 /// \param loc: source location
+/// \param function_id: name of the function in which the code will be added
 /// \param [out] code: code block to which declaration and calls get added
 void add_array_to_length_association(
   const exprt &array,
   const exprt &length,
   symbol_table_baset &symbol_table,
   const source_locationt &loc,
+  const irep_idt &function_id,
   code_blockt &code)
 {
   const symbolt &return_sym = get_fresh_aux_symbol(

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -430,11 +430,13 @@ refined_string_exprt java_string_library_preprocesst::replace_char_array(
 /// given type
 /// \param type: a type for refined strings
 /// \param loc: a location in the program
+/// \param function_id: name of the function in which the code will be added
 /// \param symbol_table: symbol table
 /// \return a new symbol
 symbol_exprt java_string_library_preprocesst::fresh_string(
   const typet &type,
   const source_locationt &loc,
+  const irep_idt &function_id,
   symbol_table_baset &symbol_table)
 {
   symbolt string_symbol=get_fresh_aux_symbol(
@@ -531,7 +533,7 @@ exprt java_string_library_preprocesst::allocate_fresh_string(
   symbol_table_baset &symbol_table,
   code_blockt &code)
 {
-  const exprt str = fresh_string(type, loc, symbol_table);
+  const exprt str = fresh_string(type, loc, function_id, symbol_table);
 
   allocate_objectst allocate_objects(ID_java, loc, function_id, symbol_table);
 

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -695,6 +695,7 @@ void add_array_to_length_association(
 ///   lower case ascii letters.
 /// \param symbol_table: the symbol table
 /// \param loc: source location
+/// \param function_id: the name of the function
 /// \param [out] code: code block to which declaration and calls get added
 void add_character_set_constraint(
   const exprt &pointer,
@@ -702,6 +703,7 @@ void add_character_set_constraint(
   const irep_idt &char_set,
   symbol_table_baset &symbol_table,
   const source_locationt &loc,
+  const irep_idt &function_id,
   code_blockt &code)
 {
   PRECONDITION(pointer.type().id() == ID_pointer);

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -341,7 +341,8 @@ exprt::operandst java_string_library_preprocesst::process_operands(
         convert_exprt_to_string_exprt(
           p, loc, symbol_table, function_id, init_code));
     else if(is_java_char_array_pointer_type(p.type()))
-      ops.push_back(replace_char_array(p, loc, symbol_table, init_code));
+      ops.push_back(
+        replace_char_array(p, loc, function_id, symbol_table, init_code));
     else
       ops.push_back(p);
   }
@@ -447,12 +448,14 @@ static exprt get_data(const exprt &expr, const symbol_tablet &symbol_table)
 /// array.
 /// \param array_pointer: an expression of type char array pointer
 /// \param loc: location in the source
+/// \param function_id: name of the function in which the string is defined
 /// \param symbol_table: symbol table
 /// \param code: code block, in which some assignments will be added
 /// \return a string expression
 refined_string_exprt java_string_library_preprocesst::replace_char_array(
   const exprt &array_pointer,
   const source_locationt &loc,
+  const irep_idt &function_id,
   symbol_table_baset &symbol_table,
   code_blockt &code)
 {

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -407,8 +407,8 @@ refined_string_exprt java_string_library_preprocesst::replace_char_array(
     checked_dereference(array_pointer, array_pointer.type().subtype());
   // array_data is array_pointer-> data
   const exprt array_data = get_data(array, symbol_table);
-  const symbolt &sym_char_array = get_fresh_aux_symbol(
-    array_data.type(), "char_array", "char_array", loc, ID_java, symbol_table);
+  const symbolt &sym_char_array = fresh_java_symbol(
+    array_data.type(), "char_array", loc, function_id, symbol_table);
   const symbol_exprt char_array = sym_char_array.symbol_expr();
   // char_array = array_pointer->data
   code.add(code_assignt(char_array, array_data), loc);
@@ -439,8 +439,8 @@ symbol_exprt java_string_library_preprocesst::fresh_string(
   const irep_idt &function_id,
   symbol_table_baset &symbol_table)
 {
-  symbolt string_symbol=get_fresh_aux_symbol(
-    type, "cprover_string", "cprover_string", loc, ID_java, symbol_table);
+  symbolt string_symbol =
+    fresh_java_symbol(type, "cprover_string", loc, function_id, symbol_table);
   string_symbol.is_static_lifetime=true;
   return string_symbol.symbol_expr();
 }
@@ -458,22 +458,12 @@ refined_string_exprt java_string_library_preprocesst::decl_string_expr(
   symbol_table_baset &symbol_table,
   code_blockt &code)
 {
-  const symbolt &sym_length = get_fresh_aux_symbol(
-    index_type,
-    "cprover_string_length",
-    "cprover_string_length",
-    loc,
-    ID_java,
-    symbol_table);
+  const symbolt &sym_length = fresh_java_symbol(
+    index_type, "cprover_string_length", loc, function_id, symbol_table);
   const symbol_exprt length_field = sym_length.symbol_expr();
   const pointer_typet array_type = pointer_type(java_char_type());
-  const symbolt &sym_content = get_fresh_aux_symbol(
-    array_type,
-    "cprover_string_content",
-    "cprover_string_content",
-    loc,
-    ID_java,
-    symbol_table);
+  const symbolt &sym_content = fresh_java_symbol(
+    array_type, "cprover_string_content", loc, function_id, symbol_table);
   const symbol_exprt content_field = sym_content.symbol_expr();
   code.add(code_declt(content_field), loc);
   const refined_string_exprt str{
@@ -599,12 +589,11 @@ exprt make_nondet_infinite_char_array(
 {
   const array_typet array_type(
     java_char_type(), infinity_exprt(java_int_type()));
-  const symbolt data_sym = get_fresh_aux_symbol(
+  const symbolt data_sym = fresh_java_symbol(
     pointer_type(array_type),
-    id2string(function_id),
     "nondet_infinite_array_pointer",
     loc,
-    ID_java,
+    function_id,
     symbol_table);
 
   const symbol_exprt data_pointer = data_sym.symbol_expr();
@@ -634,13 +623,8 @@ void add_pointer_to_array_association(
 {
   PRECONDITION(array.type().id() == ID_array);
   PRECONDITION(pointer.type().id() == ID_pointer);
-  const symbolt &return_sym = get_fresh_aux_symbol(
-    java_int_type(),
-    "return_array",
-    "return_array",
-    loc,
-    ID_java,
-    symbol_table);
+  const symbolt &return_sym = fresh_java_symbol(
+    java_int_type(), "return_array", loc, function_id, symbol_table);
   const auto return_expr = return_sym.symbol_expr();
   code.add(code_declt(return_expr), loc);
   code.add(
@@ -668,13 +652,8 @@ void add_array_to_length_association(
   const irep_idt &function_id,
   code_blockt &code)
 {
-  const symbolt &return_sym = get_fresh_aux_symbol(
-    java_int_type(),
-    "return_array",
-    "return_array",
-    loc,
-    ID_java,
-    symbol_table);
+  const symbolt &return_sym = fresh_java_symbol(
+    java_int_type(), "return_array", loc, function_id, symbol_table);
   const auto return_expr = return_sym.symbol_expr();
   code.add(code_declt(return_expr), loc);
   code.add(
@@ -707,8 +686,8 @@ void add_character_set_constraint(
   code_blockt &code)
 {
   PRECONDITION(pointer.type().id() == ID_pointer);
-  const symbolt &return_sym = get_fresh_aux_symbol(
-    java_int_type(), "cnstr_added", "cnstr_added", loc, ID_java, symbol_table);
+  const symbolt &return_sym = fresh_java_symbol(
+    java_int_type(), "cnstr_added", loc, function_id, symbol_table);
   const auto return_expr = return_sym.symbol_expr();
   code.add(code_declt(return_expr), loc);
   const constant_exprt char_set_expr(char_set, string_typet());
@@ -745,12 +724,11 @@ refined_string_exprt java_string_library_preprocesst::string_expr_of_function(
   code_blockt &code)
 {
   // int return_code;
-  const symbolt &return_code_sym = get_fresh_aux_symbol(
+  const symbolt return_code_sym = fresh_java_symbol(
     java_int_type(),
     std::string("return_code_") + function_id.c_str(),
-    std::string("return_code_") + function_id.c_str(),
     loc,
-    ID_java,
+    function_id,
     symbol_table);
   const auto return_code = return_code_sym.symbol_expr();
   code.add(code_declt(return_code), loc);
@@ -1212,8 +1190,8 @@ java_string_library_preprocesst::get_primitive_value_of_object(
 
   // declare tmp_type_name to hold the value
   const std::string aux_name = "tmp_" + id2string(type_name);
-  const symbolt &symbol = get_fresh_aux_symbol(
-    value_type, aux_name, aux_name, loc, ID_java, symbol_table);
+  const symbolt &symbol =
+    fresh_java_symbol(value_type, aux_name, loc, function_id, symbol_table);
   const auto value = symbol.symbol_expr();
 
   // Check that the type of the object is in the symbol table,
@@ -1318,8 +1296,8 @@ struct_exprt java_string_library_preprocesst::make_argument_for_format(
     if(name!="string_expr")
     {
       std::string tmp_name="tmp_"+id2string(name);
-      const symbolt &field_symbol = get_fresh_aux_symbol(
-        type, id2string(function_id), tmp_name, loc, ID_java, symbol_table);
+      const symbolt &field_symbol =
+        fresh_java_symbol(type, tmp_name, loc, function_id, symbol_table);
       auto field_symbol_expr = field_symbol.symbol_expr();
       field_expr = field_symbol_expr;
       code.add(code_declt(field_symbol_expr), loc);
@@ -1334,13 +1312,8 @@ struct_exprt java_string_library_preprocesst::make_argument_for_format(
 
   // arg_i = argv[index]
   const exprt obj = get_object_at_index(argv, index);
-  const symbolt &object_symbol = get_fresh_aux_symbol(
-    obj.type(),
-    id2string(function_id),
-    "tmp_format_obj",
-    loc,
-    ID_java,
-    symbol_table);
+  const symbolt &object_symbol = fresh_java_symbol(
+    obj.type(), "tmp_format_obj", loc, function_id, symbol_table);
   const symbol_exprt arg_i = object_symbol.symbol_expr();
 
   allocate_objectst allocate_objects(ID_java, loc, function_id, symbol_table);
@@ -1485,8 +1458,8 @@ code_blockt java_string_library_preprocesst::make_object_get_class_code(
   // > Class class1;
   const pointer_typet class_type =
     java_reference_type(symbol_table.lookup_ref("java::java.lang.Class").type);
-  const symbolt &class1_sym = get_fresh_aux_symbol(
-    class_type, "class_symbol", "class_symbol", loc, ID_java, symbol_table);
+  const symbolt &class1_sym = fresh_java_symbol(
+    class_type, "class_symbol", loc, function_id, symbol_table);
   const symbol_exprt class1 = class1_sym.symbol_expr();
   code.add(code_declt(class1), loc);
 

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -306,7 +306,7 @@ java_string_library_preprocesst::convert_exprt_to_string_exprt(
 {
   PRECONDITION(implements_java_char_sequence_pointer(expr_to_process.type()));
   const refined_string_exprt string_expr =
-    decl_string_expr(loc, symbol_table, init_code);
+    decl_string_expr(loc, function_id, symbol_table, init_code);
   code_assign_java_string_to_string_expr(
     string_expr, expr_to_process, loc, symbol_table, init_code);
   return string_expr;
@@ -496,11 +496,13 @@ symbol_exprt java_string_library_preprocesst::fresh_string(
 /// Add declaration of a refined string expr whose content and length are
 /// fresh symbols.
 /// \param loc: source location
+/// \param function_id: name of the function in which the string is defined
 /// \param symbol_table: the symbol table
 /// \param [out] code: code block to which the declaration is added
 /// \return refined string expr with fresh content and length symbols
 refined_string_exprt java_string_library_preprocesst::decl_string_expr(
   const source_locationt &loc,
+  const irep_idt &function_id,
   symbol_table_baset &symbol_table,
   code_blockt &code)
 {
@@ -542,7 +544,8 @@ refined_string_exprt java_string_library_preprocesst::make_nondet_string_expr(
   code_blockt &code)
 {
   /// \todo refactor with initialize_nonddet_string_struct
-  const refined_string_exprt str = decl_string_expr(loc, symbol_table, code);
+  const refined_string_exprt str =
+    decl_string_expr(loc, function_id, symbol_table, code);
 
   const side_effect_expr_nondett nondet_length(str.length().type(), loc);
   code.add(code_assignt(str.length(), nondet_length), loc);
@@ -1671,7 +1674,7 @@ code_blockt java_string_library_preprocesst::make_copy_string_code(
 
   // String expression that will hold the result
   const refined_string_exprt string_expr =
-    decl_string_expr(loc, symbol_table, code);
+    decl_string_expr(loc, function_id, symbol_table, code);
 
   // Assign the argument to string_expr
   const java_method_typet::parametert &op = type.parameters()[0];
@@ -1718,7 +1721,7 @@ code_blockt java_string_library_preprocesst::make_copy_constructor_code(
 
   // String expression that will hold the result
   const refined_string_exprt string_expr =
-    decl_string_expr(loc, symbol_table, code);
+    decl_string_expr(loc, function_id, symbol_table, code);
 
   // Assign argument to a string_expr
   const java_method_typet::parameterst &params = type.parameters();

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -241,27 +241,6 @@ void java_string_library_preprocesst::add_string_type(
   string_symbol->mode = ID_java;
 }
 
-/// add a symbol in the table with static lifetime and name containing
-/// `cprover_string_array` and given type
-/// \param type: an array type
-/// \param location: a location in the program
-/// \param symbol_table: symbol table
-symbol_exprt java_string_library_preprocesst::fresh_array(
-  const typet &type,
-  const source_locationt &location,
-  symbol_tablet &symbol_table)
-{
-  symbolt array_symbol=get_fresh_aux_symbol(
-    type,
-    "cprover_string_array",
-    "cprover_string_array",
-    location,
-    ID_java,
-    symbol_table);
-  array_symbol.is_static_lifetime=true;
-  return array_symbol.symbol_expr();
-}
-
 /// calls string_refine_preprocesst::process_operands with a list of parameters.
 /// \param params: a list of function parameters
 /// \param loc: location in the source

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -1145,6 +1145,7 @@ code_blockt java_string_library_preprocesst::make_assign_function_from_call(
 ///   one of the following: ID_boolean, ID_char, ID_byte, ID_short, ID_int,
 ///   ID_long, ID_float, ID_double, ID_void
 /// \param loc: a location in the source
+/// \param function_id: the name of the function
 /// \param symbol_table: the symbol table
 /// \param code: code block to which we are adding some assignments
 /// \return An expression containing a symbol `tmp_type_name` where `type_name`
@@ -1155,6 +1156,7 @@ java_string_library_preprocesst::get_primitive_value_of_object(
   const exprt &object,
   irep_idt type_name,
   const source_locationt &loc,
+  const irep_idt &function_id,
   symbol_table_baset &symbol_table,
   code_blockt &code)
 {
@@ -1379,7 +1381,7 @@ struct_exprt java_string_library_preprocesst::make_argument_for_format(
     else if(name==ID_int || name==ID_float || name==ID_char || name==ID_boolean)
     {
       const auto value = get_primitive_value_of_object(
-        arg_i, name, loc, symbol_table, code_not_null);
+        arg_i, name, loc, function_id, symbol_table, code_not_null);
       if(value.has_value())
         code_not_null.add(code_assignt(field_expr, *value), loc);
       else

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.h
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.h
@@ -185,6 +185,7 @@ private:
   exprt::operandst process_parameters(
     const java_method_typet::parameterst &params,
     const source_locationt &loc,
+    const irep_idt &function_name,
     symbol_table_baset &symbol_table,
     code_blockt &init_code);
 
@@ -207,6 +208,7 @@ private:
   exprt::operandst process_operands(
     const exprt::operandst &operands,
     const source_locationt &loc,
+    const irep_idt &function_name,
     symbol_table_baset &symbol_table,
     code_blockt &init_code);
 

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.h
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.h
@@ -222,6 +222,7 @@ private:
   symbol_exprt fresh_string(
     const typet &type,
     const source_locationt &loc,
+    const irep_idt &function_id,
     symbol_table_baset &symbol_table);
 
   refined_string_exprt decl_string_expr(

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.h
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.h
@@ -361,6 +361,7 @@ void add_character_set_constraint(
   const irep_idt &char_set,
   symbol_table_baset &symbol_table,
   const source_locationt &loc,
+  const irep_idt &function_id,
   code_blockt &code);
 
 #endif // CPROVER_JAVA_BYTECODE_JAVA_STRING_LIBRARY_PREPROCESS_H

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.h
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.h
@@ -327,6 +327,7 @@ private:
     const exprt &object,
     irep_idt type_name,
     const source_locationt &loc,
+    const irep_idt &function_id,
     symbol_table_baset &symbol_table,
     code_blockt &code);
 

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.h
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.h
@@ -212,12 +212,6 @@ private:
     symbol_table_baset &symbol_table,
     code_blockt &init_code);
 
-  exprt::operandst process_equals_function_operands(
-    const exprt::operandst &operands,
-    const source_locationt &loc,
-    symbol_table_baset &symbol_table,
-    code_blockt &init_code);
-
   refined_string_exprt replace_char_array(
     const exprt &array_pointer,
     const source_locationt &loc,

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.h
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.h
@@ -221,6 +221,7 @@ private:
   refined_string_exprt replace_char_array(
     const exprt &array_pointer,
     const source_locationt &loc,
+    const irep_idt &function_name,
     symbol_table_baset &symbol_table,
     code_blockt &code);
 

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.h
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.h
@@ -234,6 +234,7 @@ private:
 
   refined_string_exprt decl_string_expr(
     const source_locationt &loc,
+    const irep_idt &function_id,
     symbol_table_baset &symbol_table,
     code_blockt &code);
 
@@ -251,13 +252,13 @@ private:
     code_blockt &code);
 
   codet code_return_function_application(
-    const irep_idt &function_name,
+    const irep_idt &function_id,
     const exprt::operandst &arguments,
     const typet &type,
     symbol_table_baset &symbol_table);
 
   refined_string_exprt string_expr_of_function(
-    const irep_idt &function_name,
+    const irep_idt &function_id,
     const exprt::operandst &arguments,
     const source_locationt &loc,
     symbol_table_baset &symbol_table,
@@ -290,32 +291,32 @@ private:
     code_blockt &code);
 
   code_blockt make_function_from_call(
-    const irep_idt &function_name,
+    const irep_idt &function_id,
     const java_method_typet &type,
     const source_locationt &loc,
     symbol_table_baset &symbol_table);
 
   code_blockt make_init_function_from_call(
-    const irep_idt &function_name,
+    const irep_idt &function_id,
     const java_method_typet &type,
     const source_locationt &loc,
     symbol_table_baset &symbol_table,
     bool is_constructor = true);
 
   code_blockt make_assign_and_return_function_from_call(
-    const irep_idt &function_name,
+    const irep_idt &function_id,
     const java_method_typet &type,
     const source_locationt &loc,
     symbol_table_baset &symbol_table);
 
   code_blockt make_assign_function_from_call(
-    const irep_idt &function_name,
+    const irep_idt &function_id,
     const java_method_typet &type,
     const source_locationt &loc,
     symbol_table_baset &symbol_table);
 
   code_blockt make_string_returning_function_from_call(
-    const irep_idt &function_name,
+    const irep_idt &function_id,
     const java_method_typet &type,
     const source_locationt &loc,
     symbol_table_baset &symbol_table);

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.h
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.h
@@ -362,6 +362,7 @@ void add_array_to_length_association(
   const exprt &length,
   symbol_table_baset &symbol_table,
   const source_locationt &loc,
+  const irep_idt &function_id,
   code_blockt &code);
 
 void add_character_set_constraint(

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.h
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.h
@@ -354,6 +354,7 @@ void add_pointer_to_array_association(
   const exprt &array,
   symbol_table_baset &symbol_table,
   const source_locationt &loc,
+  const irep_idt &function_id,
   code_blockt &code);
 
 void add_array_to_length_association(

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.h
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.h
@@ -230,11 +230,6 @@ private:
     const source_locationt &loc,
     symbol_table_baset &symbol_table);
 
-  symbol_exprt fresh_array(
-    const typet &type,
-    const source_locationt &loc,
-    symbol_tablet &symbol_table);
-
   refined_string_exprt decl_string_expr(
     const source_locationt &loc,
     const irep_idt &function_id,

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.h
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.h
@@ -193,6 +193,7 @@ private:
     java_string_library_preprocesst &preprocess,
     const exprt &deref,
     const source_locationt &loc,
+    const irep_idt &function_id,
     symbol_tablet &symbol_table,
     code_blockt &init_code);
 
@@ -200,6 +201,7 @@ private:
     const exprt &deref,
     const source_locationt &loc,
     symbol_table_baset &symbol_table,
+    const irep_idt &function_name,
     code_blockt &init_code);
 
   exprt::operandst process_operands(

--- a/jbmc/src/java_bytecode/java_utils.cpp
+++ b/jbmc/src/java_bytecode/java_utils.cpp
@@ -10,6 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "java_root_class.h"
 
+#include <util/fresh_symbol.h>
 #include <util/invariant.h>
 #include <util/mathematical_expr.h>
 #include <util/message.h>
@@ -433,3 +434,23 @@ const std::unordered_set<std::string> cprover_methods_to_ignore
   "endThread",
   "getCurrentThreadID"
 };
+
+/// \param type: type of new symbol
+/// \param basename_prefix: new symbol will be named
+///   function_name::basename_prefix$num
+/// \param source_location: new symbol source loc
+/// \param function_name: name of the function in which the symbol is defined
+/// \param symbol_table: table to add the new symbol to
+/// \return fresh-named symbol with the requested name pattern
+symbolt &fresh_java_symbol(
+  const typet &type,
+  const std::string &basename_prefix,
+  const source_locationt &source_location,
+  const irep_idt &function_name,
+  symbol_table_baset &symbol_table)
+{
+  PRECONDITION(!function_name.empty());
+  const std::string name_prefix = id2string(function_name);
+  return get_fresh_aux_symbol(
+    type, name_prefix, basename_prefix, source_location, ID_java, symbol_table);
+}

--- a/jbmc/src/java_bytecode/java_utils.h
+++ b/jbmc/src/java_bytecode/java_utils.h
@@ -109,4 +109,11 @@ bool is_non_null_library_global(const irep_idt &);
 
 extern const std::unordered_set<std::string> cprover_methods_to_ignore;
 
+symbolt &fresh_java_symbol(
+  const typet &type,
+  const std::string &basename_prefix,
+  const source_locationt &source_location,
+  const irep_idt &function_name,
+  symbol_table_baset &symbol_table);
+
 #endif // CPROVER_JAVA_BYTECODE_JAVA_UTILS_H

--- a/jbmc/src/java_bytecode/remove_instanceof.cpp
+++ b/jbmc/src/java_bytecode/remove_instanceof.cpp
@@ -10,12 +10,12 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 /// Remove Instance-of Operators
 
 #include "remove_instanceof.h"
+#include "java_utils.h"
 
 #include <goto-programs/class_hierarchy.h>
 #include <goto-programs/class_identifier.h>
 #include <goto-programs/goto_convert.h>
 
-#include <util/fresh_symbol.h>
 #include <java_bytecode/java_types.h>
 
 #include <sstream>
@@ -116,20 +116,18 @@ bool remove_instanceoft::lower_instanceof(
   auto jlo = to_struct_tag_type(java_lang_object_type().subtype());
   exprt object_clsid = get_class_identifier_field(check_ptr, jlo, ns);
 
-  symbolt &clsid_tmp_sym = get_fresh_aux_symbol(
+  symbolt &clsid_tmp_sym = fresh_java_symbol(
     object_clsid.type(),
-    id2string(function_identifier),
     "class_identifier_tmp",
-    source_locationt(),
-    ID_java,
+    this_inst->source_location,
+    function_identifier,
     symbol_table);
 
-  symbolt &instanceof_result_sym = get_fresh_aux_symbol(
+  symbolt &instanceof_result_sym = fresh_java_symbol(
     bool_typet(),
-    id2string(function_identifier),
     "instanceof_result_tmp",
-    source_locationt(),
-    ID_java,
+    this_inst->source_location,
+    function_identifier,
     symbol_table);
 
   // Create

--- a/jbmc/src/java_bytecode/remove_java_new.cpp
+++ b/jbmc/src/java_bytecode/remove_java_new.cpp
@@ -14,11 +14,11 @@ Author: Peter Schrammel
 #include <goto-programs/class_identifier.h>
 #include <goto-programs/goto_convert.h>
 
+#include "java_utils.h"
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/expr_cast.h>
 #include <util/expr_initializer.h>
-#include <util/fresh_symbol.h>
 #include <util/message.h>
 #include <util/pointer_offset_size.h>
 
@@ -212,12 +212,11 @@ goto_programt::targett remove_java_newt::lower_java_new_array(
   // Must directly assign the new array to a temporary
   // because goto-symex will notice `x=side_effect_exprt` but not
   // `x=typecast_exprt(side_effect_exprt(...))`
-  symbol_exprt new_array_data_symbol = get_fresh_aux_symbol(
+  symbol_exprt new_array_data_symbol = fresh_java_symbol(
                                          data_java_new_expr.type(),
-                                         id2string(function_identifier),
                                          "tmp_new_data_array",
                                          location,
-                                         ID_java,
+                                         function_identifier,
                                          symbol_table)
                                          .symbol_expr();
   code_declt array_decl(new_array_data_symbol);
@@ -260,14 +259,10 @@ goto_programt::targett remove_java_newt::lower_java_new_array(
 
     goto_programt tmp;
 
-    symbol_exprt tmp_i = get_fresh_aux_symbol(
-                           length.type(),
-                           id2string(function_identifier),
-                           "tmp_index",
-                           location,
-                           ID_java,
-                           symbol_table)
-                           .symbol_expr();
+    symbol_exprt tmp_i =
+      fresh_java_symbol(
+        length.type(), "tmp_index", location, function_identifier, symbol_table)
+        .symbol_expr();
     code_declt decl(tmp_i);
     decl.add_source_location() = location;
     goto_programt::targett t_decl = tmp.insert_before(tmp.instructions.begin());
@@ -292,14 +287,10 @@ goto_programt::targett remove_java_newt::lower_java_new_array(
       plus_exprt(data, tmp_i), data.type().subtype());
 
     code_blockt for_body;
-    symbol_exprt init_sym = get_fresh_aux_symbol(
-                              sub_type,
-                              id2string(function_identifier),
-                              "subarray_init",
-                              location,
-                              ID_java,
-                              symbol_table)
-                              .symbol_expr();
+    symbol_exprt init_sym =
+      fresh_java_symbol(
+        sub_type, "subarray_init", location, function_identifier, symbol_table)
+        .symbol_expr();
     code_declt init_decl(init_sym);
     init_decl.add_source_location() = location;
     for_body.add(std::move(init_decl));

--- a/jbmc/src/java_bytecode/simple_method_stubbing.cpp
+++ b/jbmc/src/java_bytecode/simple_method_stubbing.cpp
@@ -14,7 +14,7 @@ Author: Diffblue Ltd.
 #include <java_bytecode/java_object_factory.h>
 #include <java_bytecode/java_pointer_casts.h>
 
-#include <util/fresh_symbol.h>
+#include "java_utils.h"
 #include <util/invariant_utils.h>
 #include <util/namespace.h>
 #include <util/std_code.h>
@@ -161,12 +161,11 @@ void java_simple_method_stubst::create_method_stub(symbolt &symbol)
   {
     const auto &this_argument = required_type.parameters()[0];
     const typet &this_type = this_argument.type();
-    symbolt &init_symbol = get_fresh_aux_symbol(
+    symbolt &init_symbol = fresh_java_symbol(
       this_type,
-      id2string(symbol.name),
       "to_construct",
       synthesized_source_location,
-      ID_java,
+      symbol.name,
       symbol_table);
     const symbol_exprt &init_symbol_expression = init_symbol.symbol_expr();
     code_assignt get_argument(
@@ -189,12 +188,11 @@ void java_simple_method_stubst::create_method_stub(symbolt &symbol)
     const typet &required_return_type = required_type.return_type();
     if(required_return_type != java_void_type())
     {
-      symbolt &to_return_symbol = get_fresh_aux_symbol(
+      symbolt &to_return_symbol = fresh_java_symbol(
         required_return_type,
-        id2string(symbol.name),
         "to_return",
         synthesized_source_location,
-        ID_java,
+        symbol.name,
         symbol_table);
       const exprt &to_return = to_return_symbol.symbol_expr();
       if(to_return_symbol.type.id() != ID_pointer)

--- a/jbmc/unit/java_bytecode/java_string_library_preprocess/convert_exprt_to_string_exprt.cpp
+++ b/jbmc/unit/java_bytecode/java_string_library_preprocess/convert_exprt_to_string_exprt.cpp
@@ -21,11 +21,12 @@ refined_string_exprt convert_exprt_to_string_exprt_unit_test(
   java_string_library_preprocesst &preprocess,
   const exprt &deref,
   const source_locationt &loc,
+  const irep_idt &function_id,
   symbol_tablet &symbol_table,
   code_blockt &init_code)
 {
   return preprocess.convert_exprt_to_string_exprt(
-    deref, loc, symbol_table, init_code);
+    deref, loc, symbol_table, function_id, init_code);
 }
 
 TEST_CASE("Convert exprt to string exprt")
@@ -33,6 +34,7 @@ TEST_CASE("Convert exprt to string exprt")
   GIVEN("A location, a string expression, and a symbol table")
   {
     source_locationt loc;
+    loc.set_function("function_name");
     symbol_tablet symbol_table;
     namespacet ns(symbol_table);
     code_blockt code;
@@ -45,9 +47,9 @@ TEST_CASE("Convert exprt to string exprt")
     {
       refined_string_exprt string_expr =
         convert_exprt_to_string_exprt_unit_test(
-          preprocess, expr, loc, symbol_table, code);
+          preprocess, expr, loc, "function_id", symbol_table, code);
 
-      THEN("The type of the returd expression is that of refined strings")
+      THEN("The type of the returned expression is that of refined strings")
       {
         REQUIRE(string_expr.id() == ID_struct);
         REQUIRE(is_refined_string_type(string_expr.type()));


### PR DESCRIPTION

This is based on https://github.com/diffblue/cbmc/pull/2374
The goal is to ensure location is set for each created symbol.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their 

