### PR TITLE
Add checks for symbol well-formedness.

### DIFF
--- a/src/util/symbol.cpp
+++ b/src/util/symbol.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "source_location.h"
 #include "std_expr.h"
+#include "suffix.h"
 
 /// Dump the state of a symbol object to a given output stream.
 /// \param out: The stream to output object state to.
@@ -120,4 +121,26 @@ void symbolt::swap(symbolt &b)
 symbol_exprt symbolt::symbol_expr() const
 {
   return symbol_exprt(name, type);
+}
+
+/// Check that the instance object is well formed.
+/// \return: true if well-formed; false otherwise.
+bool symbolt::is_well_formed() const
+{
+  // Well-formedness criterion number 1 is for a symbol
+  // to have a non-empty mode (see #1880)
+  if(mode.empty())
+  {
+    return false;
+  }
+
+  // Well-formedness criterion number 2 is for a symbol
+  // to have it's base name as a suffix to it's more
+  // general name.
+  if(!has_suffix(id2string(name), id2string(base_name)))
+  {
+    return false;
+  }
+
+  return true;
 }

--- a/src/util/symbol.h
+++ b/src/util/symbol.h
@@ -121,6 +121,9 @@ public:
     PRECONDITION(type.id() == ID_code);
     value = exprt(ID_compiled);
   }
+
+  /// Check that a symbol is well formed.
+  bool is_well_formed() const;
 };
 
 std::ostream &operator<<(std::ostream &out, const symbolt &symbol);

--- a/src/util/symbol_table.cpp
+++ b/src/util/symbol_table.cpp
@@ -128,6 +128,10 @@ void symbol_tablet::validate(const validation_modet vm) const
     const auto symbol_key = elem.first;
     const auto &symbol = elem.second;
 
+    // First of all, ensure symbol well-formedness
+    DATA_CHECK_WITH_DIAGNOSTICS(
+      vm, symbol.is_well_formed(), "Symbol is malformed: ", symbol_key);
+
     // Check that symbols[id].name == id
     DATA_CHECK_WITH_DIAGNOSTICS(
       vm,

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -63,6 +63,7 @@ SRC += analyses/ai/ai.cpp \
        util/string_utils/split_string.cpp \
        util/string_utils/strip_string.cpp \
        util/symbol_table.cpp \
+       util/symbol.cpp \
        util/unicode.cpp \
        # Empty last line
 

--- a/unit/goto-programs/goto_model_function_type_consistency.cpp
+++ b/unit/goto-programs/goto_model_function_type_consistency.cpp
@@ -22,6 +22,7 @@ SCENARIO(
     code_typet fun_type2({}, type2);
 
     symbolt function_symbol;
+    function_symbol.mode = "C";
     irep_idt function_symbol_name = "foo";
     function_symbol.name = function_symbol_name;
 

--- a/unit/util/symbol.cpp
+++ b/unit/util/symbol.cpp
@@ -1,0 +1,54 @@
+/// Author: Diffblue Ltd.
+
+/// \file Tests for symbol_tablet
+
+#include <testing-utils/catch.hpp>
+#include <util/exception_utils.h>
+#include <util/symbol.h>
+
+SCENARIO(
+  "Constructed symbol validity checks",
+  "[core][utils][symbol__validity_checks]")
+{
+  GIVEN("A valid symbol")
+  {
+    symbolt symbol;
+    irep_idt symbol_name = "Test_TestBase";
+    symbol.name = symbol_name;
+    symbol.base_name = "TestBase";
+    symbol.module = "TestModule";
+    symbol.mode = "C";
+
+    THEN("Symbol should be well formed")
+    {
+      REQUIRE(symbol.is_well_formed());
+    }
+  }
+
+  GIVEN("An improperly initialised symbol")
+  {
+    symbolt symbol;
+
+    WHEN("The symbol doesn't have a valid mode")
+    {
+      symbol.mode = "";
+
+      THEN("Symbol well-formedness check should fail")
+      {
+        REQUIRE_FALSE(symbol.is_well_formed());
+      }
+    }
+
+    WHEN("The symbol doesn't have base name as a suffix to name")
+    {
+      symbol.name = "TEST";
+      symbol.base_name = "TestBase";
+      symbol.mode = "C";
+
+      THEN("Symbol well-formedness check should fail")
+      {
+        REQUIRE_FALSE(symbol.is_well_formed());
+      }
+    }
+  }
+}

--- a/unit/util/symbol_table.cpp
+++ b/unit/util/symbol_table.cpp
@@ -35,10 +35,11 @@ SCENARIO(
     symbol_tablet symbol_table;
 
     symbolt symbol;
-    irep_idt symbol_name = "Test";
+    irep_idt symbol_name = "Test_TestBase";
     symbol.name = symbol_name;
     symbol.base_name = "TestBase";
     symbol.module = "TestModule";
+    symbol.mode = "C";
 
     symbol_table.insert(symbol);
 


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

Add a well-formedness check method to the symbol class, and add it as an extra criterion to the
soundness of a symbol table that every symbol is well-formed.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
