### PR TITLE
Remove unused includes from regression tests

### DIFF
--- a/regression/cbmc/Endianness6/main.c
+++ b/regression/cbmc/Endianness6/main.c
@@ -1,4 +1,4 @@
-#include <stdio.h>
+#include <assert.h>
 
 int main()
 {

--- a/regression/cbmc/Function_Pointer13/main.c
+++ b/regression/cbmc/Function_Pointer13/main.c
@@ -1,5 +1,3 @@
-#include <stdlib.h>
-#include <stdio.h>
 #include <assert.h>
 
 typedef unsigned int u32;
@@ -17,11 +15,11 @@ u32 myfunc_2(u32 value2){
 }
 
 int main(void){
-myfuncptr fptr=NULL;
+  myfuncptr fptr = 0;
 u32 value;
 
 
-assert(fptr == NULL);
+  assert(fptr == 0);
 
 fptr=myfunc_1;
 value=2;

--- a/regression/cbmc/Function_Pointer13/main.c
+++ b/regression/cbmc/Function_Pointer13/main.c
@@ -5,29 +5,28 @@ typedef unsigned long long int u64;
 
 typedef u32 (*myfuncptr)(u32 value);
 
-u32 myfunc_1(u32 value1){
-   return value1*2;
+u32 myfunc_1(u32 value1)
+{
+  return value1 * 2;
 }
 
 u32 myfunc_2(u32 value2){
-   assert(value2==4);
-   return value2*4;
+  assert(value2 == 4);
+  return value2 * 4;
 }
 
 int main(void){
   myfuncptr fptr = 0;
-u32 value;
-
+  u32 value;
 
   assert(fptr == 0);
 
-fptr=myfunc_1;
-value=2;
-value=fptr(value);    //value should be 4 after this
-assert(value == 4);
+  fptr = myfunc_1;
+  value = 2;
+  value = fptr(value); //value should be 4 after this
+  assert(value == 4);
 
-fptr=myfunc_2;
-value=fptr(value);    //value should be 16 after this
-assert(value == 16);
-
+  fptr = myfunc_2;
+  value = fptr(value); //value should be 16 after this
+  assert(value == 16);
 }

--- a/regression/cbmc/Variadic1/main.c
+++ b/regression/cbmc/Variadic1/main.c
@@ -1,5 +1,4 @@
 #include <stdarg.h>
-#include <stdio.h>
 #include <assert.h>
 
 // how to do it:

--- a/regression/cbmc/byte_update1/main.c
+++ b/regression/cbmc/byte_update1/main.c
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include <assert.h>
 
 struct A {

--- a/regression/cbmc/byte_update3/main.c
+++ b/regression/cbmc/byte_update3/main.c
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include <assert.h>
 
 int main(int argc, char** argv) {

--- a/regression/cbmc/byte_update4/main.c
+++ b/regression/cbmc/byte_update4/main.c
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include <assert.h>
 
 int main(int argc, char** argv) {

--- a/regression/cbmc/byte_update5/main.c
+++ b/regression/cbmc/byte_update5/main.c
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include <assert.h>
 
 int main(int argc, char** argv) {

--- a/regression/cbmc/complex1/main.c
+++ b/regression/cbmc/complex1/main.c
@@ -1,5 +1,4 @@
 #include <assert.h>
-#include <stdio.h>
 
 int main()
 {

--- a/regression/cbmc/dynamic_sizeof1/main.c
+++ b/regression/cbmc/dynamic_sizeof1/main.c
@@ -1,4 +1,3 @@
-#include <stdlib.h>
 #include <assert.h>
 
 int main()

--- a/regression/cbmc/pointer-extra-checks/main.c
+++ b/regression/cbmc/pointer-extra-checks/main.c
@@ -1,6 +1,3 @@
-#include <assert.h>
-#include <stdlib.h>
-
 int main()
 {
   {

--- a/regression/cbmc/va_list3/main.c
+++ b/regression/cbmc/va_list3/main.c
@@ -1,4 +1,3 @@
-#include <stdio.h> 
 #include <stdarg.h> 
 #include <assert.h> 
 


### PR DESCRIPTION
This cleanup avoids giving the false impression we would be testing any
functions declared in those header files.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
