### PR TITLE
Fix is_bmp_code_point

### DIFF
--- a/jbmc/src/java_bytecode/character_refine_preprocess.cpp
+++ b/jbmc/src/java_bytecode/character_refine_preprocess.cpp
@@ -402,8 +402,9 @@ codet character_refine_preprocesst::convert_is_alphabetic(
 exprt character_refine_preprocesst::expr_of_is_bmp_code_point(
   const exprt &chr, const typet &type)
 {
-  binary_relation_exprt is_bmp(chr, ID_le, from_integer(0xFFFF, chr.type()));
-  return is_bmp;
+  return and_exprt(
+    binary_relation_exprt(chr, ID_le, from_integer(0xFFFF, chr.type())),
+    binary_relation_exprt(chr, ID_ge, from_integer(0, chr.type())));
 }
 
 /// Converts function call to an assignment of an expression corresponding to


### PR DESCRIPTION
The implementation was not correct for negative integers.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
