### PR TITLE
Fix index expression in interpretert::evaluate

### DIFF
--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -930,8 +930,7 @@ void interpretert::evaluate(
         evaluate(expr.op1(), idx);
         if(idx.size() == 1)
         {
-          evaluated_index.op1() =
-            constant_exprt(integer2string(idx[0]), expr.op1().type());
+          evaluated_index.op1() = from_integer(idx[0], expr.op1().type());
         }
         simplified = simplify_expr(evaluated_index, ns);
       }


### PR DESCRIPTION
Using integer2string here lead to a value having bad widths.

Sorry for the lack of regression test but I was not able to reproduce this using jbmc. There is however a test-gen regression test that catches the pre-existing bug.

This fixes a bug revealed (but not introduced) by https://github.com/diffblue/cbmc/pull/3100. The bug was only observed on test-gen.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
