### PR TITLE
coding style: encourage documenting interfaces in the header file

### DIFF
--- a/CODING_STANDARD.md
+++ b/CODING_STANDARD.md
@@ -81,10 +81,15 @@ Formatting is enforced using clang-format. For more information about this, see
 - The priority of documentation is readability. Therefore, feel free to use
   Doxygen features, or to add whitespace for multi-paragraph comment blocks if
   necessary.
-- A comment block should immediately precede the definition of the entity it
-  documents, which will generally mean that it will live in the source file.
-  This allows us to take advantage of the one definition rule. If each entity
-  is defined only once, then it is also documented only once.
+- For functions or methods that provide an interface to a module, a comment
+  block should immediately precede the declaration of the entity
+  it documents. This implies that it will live in the header file.
+  The documentions should focus on the externally visible behavior, and
+  should discuss the implementation only to the extent necessary for
+  understanding usage. The implementation should be explained using
+  comments in the definition of the function or method.
+- Functions or methods that are internal to a module are documented in a
+  comment block that precedes the definition.
 - The documentation block must *immediately* precede the entity it documents.
   Don't insert empty lines between docs and functions, because this will
   confuse Doxygen.


### PR DESCRIPTION
The rationale is that users of an interface prefer documentation in the
class or the header file.  They furthermore prefer to hear about the
contract rather than implementation details.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
