### PR TITLE
Only safety-check paths when new VCCs get added

### DIFF
--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -153,9 +153,14 @@ bmct::run_decision_procedure(prop_convt &prop_conv)
 
 void bmct::report_success()
 {
-  result() << bold << "VERIFICATION SUCCESSFUL" << reset << eom;
+  report_success(*this, ui_message_handler);
+}
 
-  switch(ui_message_handler.get_ui())
+void bmct::report_success(messaget &log, ui_message_handlert &handler)
+{
+  log.result() << log.bold << "VERIFICATION SUCCESSFUL" << log.reset << log.eom;
+
+  switch(handler.get_ui())
   {
   case ui_message_handlert::uit::PLAIN:
     break;
@@ -164,7 +169,7 @@ void bmct::report_success()
     {
       xmlt xml("cprover-status");
       xml.data="SUCCESS";
-      result() << xml;
+      log.result() << xml;
     }
     break;
 
@@ -172,7 +177,7 @@ void bmct::report_success()
     {
       json_objectt json_result;
       json_result["cProverStatus"]=json_stringt("success");
-      result() << json_result;
+      log.result() << json_result;
     }
     break;
   }
@@ -180,9 +185,14 @@ void bmct::report_success()
 
 void bmct::report_failure()
 {
-  result() << bold << "VERIFICATION FAILED" << reset << eom;
+  report_failure(*this, ui_message_handler);
+}
 
-  switch(ui_message_handler.get_ui())
+void bmct::report_failure(messaget &log, ui_message_handlert &handler)
+{
+  log.result() << log.bold << "VERIFICATION FAILED" << log.reset << log.eom;
+
+  switch(handler.get_ui())
   {
   case ui_message_handlert::uit::PLAIN:
     break;
@@ -191,7 +201,7 @@ void bmct::report_failure()
     {
       xmlt xml("cprover-status");
       xml.data="FAILURE";
-      result() << xml;
+      log.result() << xml;
     }
     break;
 
@@ -199,7 +209,7 @@ void bmct::report_failure()
     {
       json_objectt json_result;
       json_result["cProverStatus"]=json_stringt("failure");
-      result() << json_result;
+      log.result() << json_result;
     }
     break;
   }

--- a/src/cbmc/bmc.h
+++ b/src/cbmc/bmc.h
@@ -208,6 +208,9 @@ protected:
   virtual void report_success();
   virtual void report_failure();
 
+  static void report_success(messaget &, ui_message_handlert &);
+  static void report_failure(messaget &, ui_message_handlert &);
+
   virtual void error_trace();
   void output_graphml(resultt result);
 

--- a/src/goto-programs/safety_checker.h
+++ b/src/goto-programs/safety_checker.h
@@ -42,10 +42,6 @@ public:
     /// doing path exploration; the symex state has been saved, and symex should
     /// be resumed by the caller.
     PAUSED,
-    /// We haven't yet assigned a safety check result to this object. A value of
-    /// UNKNOWN can be used to initialize a resultt object, and that object may
-    /// then safely be used with the |= and &= operators.
-    UNKNOWN
   };
 
   // check whether all assertions in goto_functions are safe
@@ -76,9 +72,6 @@ operator&=(safety_checkert::resultt &a, safety_checkert::resultt const &b)
     b != safety_checkert::resultt::PAUSED);
   switch(a)
   {
-  case safety_checkert::resultt::UNKNOWN:
-    a = b;
-    return a;
   case safety_checkert::resultt::ERROR:
     return a;
   case safety_checkert::resultt::SAFE:
@@ -107,9 +100,6 @@ operator|=(safety_checkert::resultt &a, safety_checkert::resultt const &b)
     b != safety_checkert::resultt::PAUSED);
   switch(a)
   {
-  case safety_checkert::resultt::UNKNOWN:
-    a = b;
-    return a;
   case safety_checkert::resultt::SAFE:
     return a;
   case safety_checkert::resultt::ERROR:

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -70,6 +70,7 @@ public:
       log(mh),
       guard_identifier("goto_symex::\\guard"),
       path_storage(path_storage),
+      path_segment_vccs(0),
       _total_vccs(std::numeric_limits<unsigned>::max()),
       _remaining_vccs(std::numeric_limits<unsigned>::max())
   {
@@ -463,6 +464,18 @@ protected:
   void rewrite_quantifiers(exprt &, statet &);
 
   path_storaget &path_storage;
+
+public:
+  /// \brief Number of VCCs generated during the run of this goto_symext object
+  ///
+  /// This member is always initialized to `0` upon construction of this object.
+  /// It therefore differs from goto_symex_statet::total_vccs, which persists
+  /// across the creation of several goto_symext objects. When CBMC is run in
+  /// path-exploration mode, the meaning of this member is "the number of VCCs
+  /// generated between the last branch point and the current instruction,"
+  /// while goto_symex_statet::total_vccs records the total number of VCCs
+  /// generated along the entire path from the beginning of the program.
+  std::size_t path_segment_vccs;
 
 protected:
   /// @{\name Statistics

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -52,6 +52,7 @@ void goto_symext::vcc(
   statet &state)
 {
   state.total_vccs++;
+  path_segment_vccs++;
 
   exprt expr=vcc_expr;
 

--- a/unit/path_strategies.cpp
+++ b/unit/path_strategies.cpp
@@ -81,7 +81,6 @@ SCENARIO("path strategies")
       opts_callback,
       c,
       {symex_eventt::resume(symex_eventt::enumt::JUMP, 7),
-       symex_eventt::result(symex_eventt::enumt::SUCCESS),
        symex_eventt::resume(symex_eventt::enumt::NEXT, 5),
        symex_eventt::result(symex_eventt::enumt::SUCCESS)});
     check_with_strategy(
@@ -89,7 +88,6 @@ SCENARIO("path strategies")
       opts_callback,
       c,
       {symex_eventt::resume(symex_eventt::enumt::NEXT, 5),
-       symex_eventt::result(symex_eventt::enumt::SUCCESS),
        symex_eventt::resume(symex_eventt::enumt::JUMP, 7),
        symex_eventt::result(symex_eventt::enumt::SUCCESS)});
   }
@@ -125,14 +123,11 @@ SCENARIO("path strategies")
       {// Outer else, inner else
        symex_eventt::resume(symex_eventt::enumt::JUMP, 13),
        symex_eventt::resume(symex_eventt::enumt::JUMP, 16),
-       symex_eventt::result(symex_eventt::enumt::SUCCESS),
        // Outer else, inner if
        symex_eventt::resume(symex_eventt::enumt::NEXT, 14),
-       symex_eventt::result(symex_eventt::enumt::SUCCESS),
        // Outer if, inner else
        symex_eventt::resume(symex_eventt::enumt::NEXT, 6),
        symex_eventt::resume(symex_eventt::enumt::JUMP, 9),
-       symex_eventt::result(symex_eventt::enumt::SUCCESS),
        // Outer if, inner if
        symex_eventt::resume(symex_eventt::enumt::NEXT, 7),
        symex_eventt::result(symex_eventt::enumt::SUCCESS)});
@@ -147,13 +142,9 @@ SCENARIO("path strategies")
        symex_eventt::resume(symex_eventt::enumt::JUMP, 13),
        // Expand inner if of the outer if
        symex_eventt::resume(symex_eventt::enumt::NEXT, 7),
-       // No more branch points, so complete the path
-       symex_eventt::result(symex_eventt::enumt::SUCCESS),
-       // Continue BFSing
+       // No more branch points, so complete the path. Then continue BFSing
        symex_eventt::resume(symex_eventt::enumt::JUMP, 9),
-       symex_eventt::result(symex_eventt::enumt::SUCCESS),
        symex_eventt::resume(symex_eventt::enumt::NEXT, 14),
-       symex_eventt::result(symex_eventt::enumt::SUCCESS),
        symex_eventt::resume(symex_eventt::enumt::JUMP, 16),
        symex_eventt::result(symex_eventt::enumt::SUCCESS)});
   }
@@ -199,6 +190,9 @@ SCENARIO("path strategies")
         // infeasible.
         symex_eventt::resume(symex_eventt::enumt::NEXT, 7),
         symex_eventt::result(symex_eventt::enumt::SUCCESS),
+
+        // Overall we fail.
+        symex_eventt::result(symex_eventt::enumt::FAILURE),
       });
 
     check_with_strategy(
@@ -223,6 +217,9 @@ SCENARIO("path strategies")
         // Pop line 7 that we saved from above and bail out. That corresponds to
         // executing the loop once, decrementing x to 0; assert(x) should fail.
         symex_eventt::resume(symex_eventt::enumt::JUMP, 9),
+        symex_eventt::result(symex_eventt::enumt::FAILURE),
+
+        // Overall we fail.
         symex_eventt::result(symex_eventt::enumt::FAILURE),
       });
   }
@@ -253,6 +250,8 @@ SCENARIO("path strategies")
         {symex_eventt::resume(symex_eventt::enumt::JUMP, 7),
          symex_eventt::result(symex_eventt::enumt::FAILURE),
          symex_eventt::resume(symex_eventt::enumt::NEXT, 5),
+         symex_eventt::result(symex_eventt::enumt::FAILURE),
+         // Overall result
          symex_eventt::result(symex_eventt::enumt::FAILURE)});
     }
     GIVEN("stopping on failure")
@@ -262,6 +261,8 @@ SCENARIO("path strategies")
         halt_callback,
         c,
         {symex_eventt::resume(symex_eventt::enumt::JUMP, 7),
+         symex_eventt::result(symex_eventt::enumt::FAILURE),
+         // Overall result
          symex_eventt::result(symex_eventt::enumt::FAILURE)});
     }
   }
@@ -380,14 +381,20 @@ void _check_with_strategy(
   prop_convt &pc = cbmc_solver->prop_conv();
   std::function<bool(void)> callback = []() { return false; };
 
-  bmct bmc(opts, gm.get_symbol_table(), mh, pc, *worklist, callback);
-  safety_checkert::resultt result = bmc.run(gm);
-
+  safety_checkert::resultt overall_result = safety_checkert::resultt::SAFE;
   std::size_t expected_results_cnt = 0;
-  symex_eventt::validate_result(events, result, expected_results_cnt);
+
+  bmct bmc(opts, gm.get_symbol_table(), mh, pc, *worklist, callback);
+  safety_checkert::resultt tmp_result = bmc.run(gm);
+
+  if(tmp_result != safety_checkert::resultt::PAUSED)
+  {
+    symex_eventt::validate_result(events, tmp_result, expected_results_cnt);
+    overall_result &= tmp_result;
+  }
 
   if(
-    result == safety_checkert::resultt::UNSAFE &&
+    overall_result == safety_checkert::resultt::UNSAFE &&
     opts.get_bool_option("stop-on-fail") && opts.is_set("paths"))
   {
     worklist->clear();
@@ -411,17 +418,25 @@ void _check_with_strategy(
       resume.state,
       *worklist,
       callback);
-    result = pe.run(gm);
+    tmp_result = pe.run(gm);
 
-    symex_eventt::validate_result(events, result, expected_results_cnt);
+    if(tmp_result != safety_checkert::resultt::PAUSED)
+    {
+      symex_eventt::validate_result(events, tmp_result, expected_results_cnt);
+      overall_result &= tmp_result;
+    }
     worklist->pop();
 
     if(
-      result == safety_checkert::resultt::UNSAFE &&
+      overall_result == safety_checkert::resultt::UNSAFE &&
       opts.get_bool_option("stop-on-fail"))
     {
       worklist->clear();
     }
   }
+
+  symex_eventt::validate_result(events, overall_result, expected_results_cnt);
+
+  INFO("The expected results list contains " << events.size() << " items");
   REQUIRE(events.empty());
 }

--- a/unit/path_strategies.h
+++ b/unit/path_strategies.h
@@ -36,10 +36,13 @@ public:
     return pairt(kind, -1);
   }
 
-  static void
-  validate_result(listt &events, const safety_checkert::resultt result);
+  static void validate_result(
+    listt &events,
+    const safety_checkert::resultt result,
+    std::size_t &);
 
-  static void validate_resume(listt &events, const goto_symex_statet &state);
+  static void
+  validate_resume(listt &events, const goto_symex_statet &state, std::size_t &);
 };
 
 void _check_with_strategy(


### PR DESCRIPTION
CBMC will no longer bother running safety checks on path segments that
did not generate any new VCCs when running in path-exploration mode.

A "path segment" is a list of instructions between two program branch
points. CBMC would previously pause symbolic execution and run safety
checks at every branch point, which is wasteful when no additional VCCs
have been generated since the last pause. As of this commit, CBMC will
check to see if new VCCs have been added, and only do the safety check
if so.

To support this, the new member goto_symext::path_segment_vccs records
the number of VCCs that were newly generated along this path segment. It
differs from the VCC counters in goto_symex_statet, which hold the
number of VCCs generated along the current path since the start of the
program. goto_symext objects are minted for each path segment, so they
don't hold any information about the VCCs previously along the path.

This commit also removes the "Starting new path" output, since this no
longer makes much sense. On the other hand, there is an additional final
status output; CBMC will report failure after the entire program has
been explored if even a single path contained a failing assertion, and
report success otherwise.

The unit tests have been updated to reflect the fact that CBMC no longer
emits "SUCCESS" at each branch point and at the end of paths, and also
that CBMC makes one final report of the program safety as a whole.

This commit fixes #2684.