### PR TITLE
Wrap local vars in std::move (Clang 7 build fix)

### DIFF
--- a/jbmc/src/java_bytecode/character_refine_preprocess.cpp
+++ b/jbmc/src/java_bytecode/character_refine_preprocess.cpp
@@ -319,7 +319,7 @@ exprt character_refine_preprocesst::expr_of_high_surrogate(
   exprt u400=from_integer(0x0400, type);
 
   plus_exprt high_surrogate(uD800, div_exprt(minus_exprt(chr, u10000), u400));
-  return high_surrogate;
+  return std::move(high_surrogate);
 }
 
 /// Converts function call to an assignment of an expression corresponding to
@@ -496,7 +496,7 @@ exprt character_refine_preprocesst::expr_of_is_digit(
   or_exprt digit(
     or_exprt(latin_digit, or_exprt(arabic_indic_digit, extended_digit)),
     or_exprt(devanagari_digit, fullwidth_digit));
-  return digit;
+  return std::move(digit);
 }
 
 /// Converts function call to an assignment of an expression corresponding to
@@ -555,7 +555,7 @@ exprt character_refine_preprocesst::expr_of_is_identifier_ignorable(
      or_exprt(
       in_interval_expr(chr, 0x000E, 0x001B),
       in_interval_expr(chr, 0x007F, 0x009F)));
-  return ignorable;
+  return std::move(ignorable);
 }
 
 /// Converts function call to an assignment of an expression corresponding to
@@ -1235,7 +1235,7 @@ exprt character_refine_preprocesst::expr_of_to_lower_case(
     plus_exprt(chr, from_integer('a', type)), from_integer('A', type));
 
   if_exprt res(expr_of_is_ascii_upper_case(chr, type), transformed, chr);
-  return res;
+  return std::move(res);
 }
 
 /// Converts function call to an assignment of an expression corresponding to
@@ -1291,7 +1291,7 @@ exprt character_refine_preprocesst::expr_of_to_title_case(
           plus_9,
           chr))));
 
-  return res;
+  return std::move(res);
 }
 
 /// Converts function call to an assignment of an expression corresponding to
@@ -1328,7 +1328,7 @@ exprt character_refine_preprocesst::expr_of_to_upper_case(
     plus_exprt(chr, from_integer('A', type)), from_integer('a', type));
 
   if_exprt res(expr_of_is_ascii_lower_case(chr, type), transformed, chr);
-  return res;
+  return std::move(res);
 }
 
 /// Converts function call to an assignment of an expression corresponding to

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -231,7 +231,7 @@ const exprt java_bytecode_convert_methodt::variable(
     symbol_exprt result(identifier, t);
     result.set(ID_C_base_name, base_name);
     used_local_names.insert(result);
-    return result;
+    return std::move(result);
   }
   else
   {
@@ -1913,7 +1913,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
   for(auto &block : root_block.statements())
     code.add(block);
 
-  return code;
+  return std::move(code);
 }
 
 codet java_bytecode_convert_methodt::convert_pop(
@@ -1983,7 +1983,7 @@ codet java_bytecode_convert_methodt::convert_switch(
   }
 
   code_switch.body() = code_block;
-  return code_switch;
+  return std::move(code_switch);
 }
 
 codet java_bytecode_convert_methodt::convert_monitorenterexit(
@@ -2006,7 +2006,7 @@ codet java_bytecode_convert_methodt::convert_monitorenterexit(
   call.add_source_location() = source_location;
   if(needed_lazy_methods && symbol_table.has_symbol(descriptor))
     needed_lazy_methods->add_needed_method(descriptor);
-  return call;
+  return std::move(call);
 }
 
 void java_bytecode_convert_methodt::convert_dup2(
@@ -2566,7 +2566,7 @@ codet java_bytecode_convert_methodt::convert_putstatic(
     bytecode_write_typet::STATIC_FIELD,
     symbol_expr.get_identifier());
   block.add(code_assignt(symbol_expr, op[0]));
-  return block;
+  return std::move(block);
 }
 
 codet java_bytecode_convert_methodt::convert_putfield(
@@ -2581,7 +2581,7 @@ codet java_bytecode_convert_methodt::convert_putfield(
     bytecode_write_typet::FIELD,
     arg0.get(ID_component_name));
   block.add(code_assignt(to_member(op[0], arg0), op[1]));
-  return block;
+  return std::move(block);
 }
 
 void java_bytecode_convert_methodt::convert_getstatic(
@@ -2722,7 +2722,7 @@ codet java_bytecode_convert_methodt::convert_iinc(
     plus_exprt(variable(arg0, 'i', address, CAST_AS_NEEDED), arg1_int_type));
   block.add(code_assign);
 
-  return block;
+  return std::move(block);
 }
 
 codet java_bytecode_convert_methodt::convert_ifnull(
@@ -2740,7 +2740,7 @@ codet java_bytecode_convert_methodt::convert_ifnull(
   code_branch.then_case().add_source_location() =
     address_map.at(label_number).source->source_location;
   code_branch.add_source_location() = location;
-  return code_branch;
+  return std::move(code_branch);
 }
 
 codet java_bytecode_convert_methodt::convert_ifnonull(
@@ -2758,7 +2758,7 @@ codet java_bytecode_convert_methodt::convert_ifnonull(
   code_branch.then_case().add_source_location() =
     address_map.at(label_number).source->source_location;
   code_branch.add_source_location() = location;
-  return code_branch;
+  return std::move(code_branch);
 }
 
 codet java_bytecode_convert_methodt::convert_if(
@@ -2780,7 +2780,7 @@ codet java_bytecode_convert_methodt::convert_if(
   code_branch.then_case().add_source_location().set_function(method_id);
   code_branch.add_source_location() = location;
   code_branch.add_source_location().set_function(method_id);
-  return code_branch;
+  return std::move(code_branch);
 }
 
 codet java_bytecode_convert_methodt::convert_if_cmp(
@@ -2809,7 +2809,7 @@ codet java_bytecode_convert_methodt::convert_if_cmp(
     address_map.at(label_number).source->source_location;
   code_branch.add_source_location() = location;
 
-  return code_branch;
+  return std::move(code_branch);
 }
 
 code_blockt java_bytecode_convert_methodt::convert_ret(
@@ -2889,7 +2889,7 @@ codet java_bytecode_convert_methodt::convert_store(
   code_assignt assign(var, toassign);
   assign.add_source_location() = location;
   block.add(assign);
-  return block;
+  return std::move(block);
 }
 
 codet java_bytecode_convert_methodt::convert_astore(
@@ -2921,7 +2921,7 @@ codet java_bytecode_convert_methodt::convert_astore(
   code_assignt array_put(element, op[2]);
   array_put.add_source_location() = location;
   block.add(array_put);
-  return block;
+  return std::move(block);
 }
 
 optionalt<exprt> java_bytecode_convert_methodt::convert_invoke_dynamic(

--- a/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
@@ -133,7 +133,7 @@ codet java_bytecode_instrumentt::throw_exception(
   if_code.cond()=cond;
   if_code.then_case() = code_blockt({assign_new, code_expressiont(throw_expr)});
 
-  return if_code;
+  return std::move(if_code);
 }
 
 
@@ -205,7 +205,7 @@ codet java_bytecode_instrumentt::check_array_access(
   bounds_checks.add(create_fatal_assertion(ge_zero, low_check_loc));
   bounds_checks.add(create_fatal_assertion(lt_length, high_check_loc));
 
-  return bounds_checks;
+  return std::move(bounds_checks);
 }
 
 /// Checks whether `class1` is an instance of `class2` and throws
@@ -255,7 +255,7 @@ codet java_bytecode_instrumentt::check_class_cast(
   notequal_exprt op_not_null(null_check_op, null_pointer_exprt(voidptr));
   conditional_check.cond()=std::move(op_not_null);
   conditional_check.then_case()=std::move(check_code);
-  return conditional_check;
+  return std::move(conditional_check);
 }
 
 /// Checks whether `expr` is null and throws NullPointerException/
@@ -540,7 +540,7 @@ optionalt<codet> java_bytecode_instrumentt::instrument_expr(const exprt &expr)
   if(result==code_blockt())
     return {};
   else
-    return result;
+    return std::move(result);
 }
 
 /// Instruments `expr`

--- a/jbmc/src/java_bytecode/java_bytecode_parser.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_parser.cpp
@@ -1572,7 +1572,7 @@ exprt java_bytecode_parsert::get_relement_value()
       {
         values.operands().push_back(get_relement_value());
       }
-      return values;
+      return std::move(values);
     }
 
   case 's':

--- a/jbmc/src/java_bytecode/java_static_initializers.cpp
+++ b/jbmc/src/java_bytecode/java_static_initializers.cpp
@@ -627,7 +627,7 @@ codet get_thread_safe_clinit_wrapper_body(
     function_body.add(code_returnt());
   }
 
-  return function_body;
+  return std::move(function_body);
 }
 
 /// Produces the static initializer wrapper body for the given function.
@@ -702,7 +702,7 @@ codet get_clinit_wrapper_body(
 
   wrapper_body.then_case() = init_body;
 
-  return wrapper_body;
+  return std::move(wrapper_body);
 }
 
 
@@ -891,5 +891,5 @@ codet stub_global_initializer_factoryt::get_stub_initializer_body(
       update_in_placet::NO_UPDATE_IN_PLACE);
   }
 
-  return static_init_body;
+  return std::move(static_init_body);
 }

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -1039,7 +1039,7 @@ codet java_string_library_preprocesst::make_float_to_string_code(
 
   // Return str
   code.add(code_returnt(str), loc);
-  return code;
+  return std::move(code);
 }
 
 /// Generate the goto code for string initialization.
@@ -1088,7 +1088,7 @@ codet java_string_library_preprocesst::make_init_function_from_call(
     code_assign_string_expr_to_java_string(arg_this, string_expr, symbol_table),
     loc);
 
-  return code;
+  return std::move(code);
 }
 
 /// Call a cprover internal function, assign the result to object `this` and
@@ -1114,7 +1114,7 @@ codet java_string_library_preprocesst::
     loc);
   const symbol_exprt arg_this(params[0].get_identifier(), params[0].type());
   code.add(code_returnt(arg_this), loc);
-  return code;
+  return std::move(code);
 }
 
 /// Call a cprover internal function and assign the result to object `this`.
@@ -1266,7 +1266,7 @@ exprt java_string_library_preprocesst::get_object_at_index(
     data_member, from_integer(index, java_int_type()), data_member.type());
   dereference_exprt data_at_index(
     data_pointer_plus_index, data_pointer_plus_index.type().subtype());
-  return data_at_index;
+  return std::move(data_at_index);
 }
 
 /// Helper for format function. Adds code:
@@ -1393,7 +1393,7 @@ exprt java_string_library_preprocesst::make_argument_for_format(
   }
 
   code.add(code_not_null, loc);
-  return arg_i_struct;
+  return std::move(arg_i_struct);
 }
 
 /// Used to provide code for the Java String.format function.
@@ -1451,7 +1451,7 @@ codet java_string_library_preprocesst::make_string_format_code(
       java_string, string_expr, symbol_table),
     loc);
   code.add(code_returnt(java_string), loc);
-  return code;
+  return std::move(code);
 }
 
 /// Used to provide our own implementation of the java.lang.Object.getClass()
@@ -1532,7 +1532,7 @@ codet java_string_library_preprocesst::make_object_get_class_code(
 
   // > return class1;
   code.add(code_returnt(class1), loc);
-  return code;
+  return std::move(code);
 }
 
 /// Provide code for a function that calls a function from the solver and simply
@@ -1558,7 +1558,7 @@ codet java_string_library_preprocesst::make_function_from_call(
     code_return_function_application(
       function_name, args, type.return_type(), symbol_table),
     loc);
-  return code;
+  return std::move(code);
 }
 
 /// Provide code for a function that calls a function from the solver and return
@@ -1600,7 +1600,7 @@ codet java_string_library_preprocesst::make_string_returning_function_from_call(
 
   // Return value
   code.add(code_returnt(str), loc);
-  return code;
+  return std::move(code);
 }
 
 /// Generates code for a function which copies a string object to a new string
@@ -1643,7 +1643,7 @@ codet java_string_library_preprocesst::make_copy_string_code(
 
   // Return value
   code.add(code_returnt(str), loc);
-  return code;
+  return std::move(code);
 }
 
 /// Generates code for a constructor of a string object from another string
@@ -1684,7 +1684,7 @@ codet java_string_library_preprocesst::make_copy_constructor_code(
     code_assign_string_expr_to_java_string(arg_this, string_expr, symbol_table),
     loc);
 
-  return code;
+  return std::move(code);
 }
 
 /// Generates code for the String.length method
@@ -1714,7 +1714,7 @@ codet java_string_library_preprocesst::make_string_length_code(
   code_returnt ret(get_length(deref, symbol_table));
   ret.add_source_location() = loc;
 
-  return ret;
+  return std::move(ret);
 }
 
 bool java_string_library_preprocesst::implements_function(

--- a/jbmc/src/java_bytecode/java_types.cpp
+++ b/jbmc/src/java_bytecode/java_types.cpp
@@ -415,7 +415,7 @@ build_class_name(const std::string &src, const std::string &class_name_prefix)
       // Look for the next generic type info (if it exists)
       f_pos = src.find('<', e_pos + 1);
     } while(f_pos != std::string::npos);
-    return result;
+    return std::move(result);
   }
 
   return java_reference_type(symbol_type);

--- a/src/analyses/ai.cpp
+++ b/src/analyses/ai.cpp
@@ -82,7 +82,7 @@ jsont ai_baset::output_json(
     }
   }
 
-  return result;
+  return std::move(result);
 }
 
 /// Output the domains for a single function as JSON
@@ -113,7 +113,7 @@ jsont ai_baset::output_json(
     contents.push_back(location);
   }
 
-  return contents;
+  return std::move(contents);
 }
 
 /// Output the domains for the whole program as XML

--- a/src/analyses/ai_domain.cpp
+++ b/src/analyses/ai_domain.cpp
@@ -19,7 +19,7 @@ jsont ai_domain_baset::output_json(const ai_baset &ai, const namespacet &ns)
   std::ostringstream out;
   output(out, ai, ns);
   json_stringt json(out.str());
-  return json;
+  return std::move(json);
 }
 
 xmlt ai_domain_baset::output_xml(const ai_baset &ai, const namespacet &ns) const

--- a/src/analyses/dependence_graph.cpp
+++ b/src/analyses/dependence_graph.cpp
@@ -299,7 +299,7 @@ jsont dep_graph_domaint::output_json(
     link["type"]=json_stringt("data");
   }
 
-  return graph;
+  return std::move(graph);
 }
 
 void dependence_grapht::add_dep(

--- a/src/ansi-c/anonymous_member.cpp
+++ b/src/ansi-c/anonymous_member.cpp
@@ -35,7 +35,7 @@ static exprt make_member_expr(
     result.type().set(ID_C_constant, true);
   }
 
-  return result;
+  return std::move(result);
 }
 
 exprt get_component_rec(

--- a/src/ansi-c/c_nondet_symbol_factory.cpp
+++ b/src/ansi-c/c_nondet_symbol_factory.cpp
@@ -269,5 +269,5 @@ exprt c_nondet_symbol_factory(
     init_code.move(input_code);
   }
 
-  return main_symbol_expr;
+  return std::move(main_symbol_expr);
 }

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2095,7 +2095,7 @@ exprt c_typecheck_baset::do_special_functions(
       expr.arguments()[0], "get_must", expr.arguments()[1]);
     get_must_expr.add_source_location()=source_location;
 
-    return get_must_expr;
+    return std::move(get_must_expr);
   }
   else if(identifier==CPROVER_PREFIX "get_may")
   {
@@ -2112,7 +2112,7 @@ exprt c_typecheck_baset::do_special_functions(
       expr.arguments()[0], "get_may", expr.arguments()[1]);
     get_may_expr.add_source_location()=source_location;
 
-    return get_may_expr;
+    return std::move(get_may_expr);
   }
   else if(identifier==CPROVER_PREFIX "invalid_pointer")
   {
@@ -2157,7 +2157,7 @@ exprt c_typecheck_baset::do_special_functions(
     is_zero_string_expr.set(ID_C_lvalue, true); // make it an lvalue
     is_zero_string_expr.add_source_location()=source_location;
 
-    return is_zero_string_expr;
+    return std::move(is_zero_string_expr);
   }
   else if(identifier==CPROVER_PREFIX "zero_string_length")
   {
@@ -2217,7 +2217,7 @@ exprt c_typecheck_baset::do_special_functions(
       ID_object_size, expr.arguments()[0], size_type());
     object_size_expr.add_source_location() = source_location;
 
-    return object_size_expr;
+    return std::move(object_size_expr);
   }
   else if(identifier==CPROVER_PREFIX "POINTER_OBJECT")
   {
@@ -2250,7 +2250,7 @@ exprt c_typecheck_baset::do_special_functions(
     bswap_exprt bswap_expr(expr.arguments().front(), 8, expr.type());
     bswap_expr.add_source_location()=source_location;
 
-    return bswap_expr;
+    return std::move(bswap_expr);
   }
   else if(identifier=="__builtin_nontemporal_load")
   {
@@ -2363,7 +2363,7 @@ exprt c_typecheck_baset::do_special_functions(
         ieee_float_spect::double_precision()).to_expr();
     inf_expr.add_source_location()=source_location;
 
-    return inf_expr;
+    return std::move(inf_expr);
   }
   else if(identifier==CPROVER_PREFIX "inff")
   {
@@ -2372,7 +2372,7 @@ exprt c_typecheck_baset::do_special_functions(
         ieee_float_spect::single_precision()).to_expr();
     inff_expr.add_source_location()=source_location;
 
-    return inff_expr;
+    return std::move(inff_expr);
   }
   else if(identifier==CPROVER_PREFIX "infl")
   {
@@ -2381,7 +2381,7 @@ exprt c_typecheck_baset::do_special_functions(
       ieee_floatt::plus_infinity(ieee_float_spect(type)).to_expr();
     infl_expr.add_source_location()=source_location;
 
-    return infl_expr;
+    return std::move(infl_expr);
   }
   else if(identifier==CPROVER_PREFIX "abs" ||
           identifier==CPROVER_PREFIX "labs" ||
@@ -2400,7 +2400,7 @@ exprt c_typecheck_baset::do_special_functions(
     abs_exprt abs_expr(expr.arguments().front());
     abs_expr.add_source_location()=source_location;
 
-    return abs_expr;
+    return std::move(abs_expr);
   }
   else if(identifier==CPROVER_PREFIX "allocate")
   {
@@ -2414,7 +2414,7 @@ exprt c_typecheck_baset::do_special_functions(
     side_effect_exprt malloc_expr(ID_allocate, expr.type(), source_location);
     malloc_expr.operands()=expr.arguments();
 
-    return malloc_expr;
+    return std::move(malloc_expr);
   }
   else if(
     identifier == CPROVER_PREFIX "r_ok" || identifier == CPROVER_PREFIX "w_ok")
@@ -2431,7 +2431,7 @@ exprt c_typecheck_baset::do_special_functions(
     predicate_exprt ok_expr(id, expr.arguments()[0], expr.arguments()[1]);
     ok_expr.add_source_location() = source_location;
 
-    return ok_expr;
+    return std::move(ok_expr);
   }
   else if(identifier==CPROVER_PREFIX "isinff" ||
           identifier==CPROVER_PREFIX "isinfd" ||
@@ -2536,7 +2536,7 @@ exprt c_typecheck_baset::do_special_functions(
     popcount_exprt popcount_expr(expr.arguments().front(), expr.type());
     popcount_expr.add_source_location()=source_location;
 
-    return popcount_expr;
+    return std::move(popcount_expr);
   }
   else if(identifier==CPROVER_PREFIX "equal")
   {
@@ -2559,7 +2559,7 @@ exprt c_typecheck_baset::do_special_functions(
       throw 0;
     }
 
-    return equality_expr;
+    return std::move(equality_expr);
   }
   else if(identifier=="__builtin_expect")
   {

--- a/src/ansi-c/literals/convert_string_literal.cpp
+++ b/src/ansi-c/literals/convert_string_literal.cpp
@@ -156,6 +156,6 @@ exprt convert_string_literal(const std::string &src)
     string_constantt result;
     result.set_value(char_value);
 
-    return result;
+    return std::move(result);
   }
 }

--- a/src/cpp/cpp_constructor.cpp
+++ b/src/cpp/cpp_constructor.cpp
@@ -118,7 +118,7 @@ optionalt<codet> cpp_typecheckt::cpp_constructor(
         if(i_code.has_value())
           new_code.move(i_code.value());
       }
-      return new_code;
+      return std::move(new_code);
     }
   }
   else if(cpp_is_pod(tmp_type))
@@ -146,7 +146,7 @@ optionalt<codet> cpp_typecheckt::cpp_constructor(
       typecheck_side_effect_assignment(assign);
       code_expressiont new_code;
       new_code.expression()=assign;
-      return new_code;
+      return std::move(new_code);
     }
     else
     {
@@ -254,7 +254,7 @@ optionalt<codet> cpp_typecheckt::cpp_constructor(
     else
     {
       block.add(initializer_code);
-      return block;
+      return std::move(block);
     }
   }
   else

--- a/src/cpp/cpp_typecheck_destructor.cpp
+++ b/src/cpp/cpp_typecheck_destructor.cpp
@@ -131,7 +131,7 @@ codet cpp_typecheckt::dtor(const symbolt &symbol)
   }
 
   if(symbol.type.id() == ID_union)
-    return block;
+    return std::move(block);
 
   const auto &bases = to_struct_type(symbol.type).bases();
 
@@ -156,5 +156,5 @@ codet cpp_typecheckt::dtor(const symbolt &symbol)
       block.add(dtor_code.value());
   }
 
-  return block;
+  return std::move(block);
 }

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -1395,7 +1395,7 @@ exprt cpp_typecheck_resolvet::resolve(
       string_constantt s;
       s.set_value(source_location.get_function());
       s.add_source_location()=source_location;
-      return s;
+      return std::move(s);
     }
   }
 

--- a/src/cpp/cpp_util.cpp
+++ b/src/cpp/cpp_util.cpp
@@ -18,5 +18,5 @@ exprt cpp_symbol_expr(const symbolt &symbol)
   if(symbol.is_lvalue)
     tmp.set(ID_C_lvalue, true);
 
-  return tmp;
+  return std::move(tmp);
 }

--- a/src/goto-instrument/unwind.cpp
+++ b/src/goto-instrument/unwind.cpp
@@ -346,5 +346,5 @@ jsont goto_unwindt::unwind_logt::output_log_json() const
       target->location_number));
   }
 
-  return json_result;
+  return std::move(json_result);
 }

--- a/src/goto-programs/class_identifier.cpp
+++ b/src/goto-programs/class_identifier.cpp
@@ -41,7 +41,7 @@ static exprt build_class_identifier(
     if(first_member_name=="@class_identifier")
     {
       // found it
-      return member_expr;
+      return std::move(member_expr);
     }
     else
     {

--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -911,5 +911,5 @@ jsont goto_inlinet::goto_inline_logt::output_inline_log_json() const
     json_new.push_back()=json_numbert(std::to_string(end->location_number));
   }
 
-  return json_result;
+  return std::move(json_result);
 }

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -482,7 +482,7 @@ exprt interpretert::get_value(
       result.copy_to_operands(operand);
     }
 
-    return result;
+    return std::move(result);
   }
   else if(real_type.id()==ID_array)
   {
@@ -509,7 +509,7 @@ exprt interpretert::get_value(
         offset+i*subtype_size);
       result.copy_to_operands(operand);
     }
-    return result;
+    return std::move(result);
   }
   if(use_non_det &&
      memory[integer2ulong(offset)].initialized!=
@@ -547,7 +547,7 @@ exprt interpretert::get_value(
       tmp_offset+=size;
       result.copy_to_operands(operand);
     }
-    return result;
+    return std::move(result);
   }
   else if(real_type.id()==ID_array)
   {
@@ -575,7 +575,7 @@ exprt interpretert::get_value(
           offset+i*subtype_size);
       result.copy_to_operands(operand);
     }
-    return result;
+    return std::move(result);
   }
   else if(real_type.id()==ID_floatbv)
   {
@@ -628,7 +628,7 @@ exprt interpretert::get_value(
         symbol_expr,
         from_integer(offset, integer_typet()));
 
-      return index_expr;
+      return std::move(index_expr);
     }
 
     error() << "interpreter: invalid pointer " << rhs[integer2size_t(offset)]

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -1367,5 +1367,5 @@ exprt string_abstractiont::member(const exprt &a, whatt what)
 
   member_exprt result(struct_op, component_name, build_type(what));
 
-  return result;
+  return std::move(result);
 }

--- a/src/goto-programs/string_instrumentation.cpp
+++ b/src/goto-programs/string_instrumentation.cpp
@@ -33,7 +33,7 @@ exprt is_zero_string(
   predicate_exprt result("is_zero_string");
   result.copy_to_operands(what);
   result.set("lhs", write);
-  return result;
+  return std::move(result);
 }
 
 exprt zero_string_length(

--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -50,7 +50,7 @@ exprt build_full_lhs_rec(
         build_full_lhs_rec(prop_conv, ns,
           to_index_expr(src_original).array(),
           to_index_expr(src_ssa).array());
-      return tmp;
+      return std::move(tmp);
     }
 
     return src_original;
@@ -80,14 +80,14 @@ exprt build_full_lhs_rec(
     else if(tmp.is_false())
       return tmp2.false_case();
     else
-      return tmp2;
+      return std::move(tmp2);
   }
   else if(id==ID_typecast)
   {
     typecast_exprt tmp=to_typecast_expr(src_original);
     tmp.op()=build_full_lhs_rec(prop_conv, ns,
       to_typecast_expr(src_original).op(), to_typecast_expr(src_ssa).op());
-    return tmp;
+    return std::move(tmp);
   }
   else if(id==ID_byte_extract_little_endian ||
           id==ID_byte_extract_big_endian)

--- a/src/pointer-analysis/pointer_offset_sum.cpp
+++ b/src/pointer-analysis/pointer_offset_sum.cpp
@@ -29,5 +29,5 @@ exprt pointer_offset_sum(const exprt &a, const exprt &b)
   if(b.type() != a.type())
     new_offset.op1().make_typecast(a.type());
 
-  return new_offset;
+  return std::move(new_offset);
 }

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -207,7 +207,7 @@ exprt value_sett::to_expr(const object_map_dt::value_type &it) const
 
   od.type()=od.object().type();
 
-  return od;
+  return std::move(od);
 }
 
 bool value_sett::make_union(const value_sett::valuest &new_values)
@@ -1666,5 +1666,5 @@ exprt value_sett::make_member(
   const typet &subtype = struct_union_type.component_type(component_name);
   member_exprt member_expr(src, component_name, subtype);
 
-  return member_expr;
+  return std::move(member_expr);
 }

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -238,7 +238,7 @@ exprt value_set_fit::to_expr(const object_map_dt::value_type &it) const
 
   od.type()=od.object().type();
 
-  return od;
+  return std::move(od);
 }
 
 bool value_set_fit::make_union(const value_set_fit::valuest &new_values)

--- a/src/pointer-analysis/value_set_fivr.cpp
+++ b/src/pointer-analysis/value_set_fivr.cpp
@@ -357,7 +357,7 @@ exprt value_set_fivrt::to_expr(object_map_dt::const_iterator it) const
 
   od.type()=od.object().type();
 
-  return od;
+  return std::move(od);
 }
 
 bool value_set_fivrt::make_union(

--- a/src/pointer-analysis/value_set_fivrns.cpp
+++ b/src/pointer-analysis/value_set_fivrns.cpp
@@ -216,7 +216,7 @@ exprt value_set_fivrnst::to_expr(object_map_dt::const_iterator it) const
 
   od.type()=od.object().type();
 
-  return od;
+  return std::move(od);
 }
 
 bool value_set_fivrnst::make_union(

--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -157,7 +157,7 @@ exprt boolbvt::bv_get_rec(
 
       struct_exprt dest(type);
       dest.operands().swap(op);
-      return dest;
+      return std::move(dest);
     }
     else if(type.id()==ID_union)
     {
@@ -178,7 +178,7 @@ exprt boolbvt::bv_get_rec(
 
       value.op()=bv_get_rec(bv, unknown, offset, subtype);
 
-      return value;
+      return std::move(value);
     }
     else if(type.id()==ID_vector)
     {
@@ -195,7 +195,7 @@ exprt boolbvt::bv_get_rec(
           value.operands().push_back(
             bv_get_rec(bv, unknown, i*sub_width, subtype));
 
-        return value;
+        return std::move(value);
       }
     }
     else if(type.id()==ID_complex)

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -647,7 +647,7 @@ exprt bv_pointerst::bv_get_rec(
   result.copy_to_operands(
     pointer_logic.pointer_expr(pointer, to_pointer_type(type)));
 
-  return result;
+  return std::move(result);
 }
 
 void bv_pointerst::encode(std::size_t addr, bvt &bv)

--- a/src/solvers/flattening/c_bit_field_replacement_type.cpp
+++ b/src/solvers/flattening/c_bit_field_replacement_type.cpp
@@ -21,7 +21,7 @@ typet c_bit_field_replacement_type(
   {
     bitvector_typet result=to_bitvector_type(subtype);
     result.set_width(src.get_width());
-    return result;
+    return std::move(result);
   }
   else if(subtype.id()==ID_c_enum_tag)
   {
@@ -33,7 +33,7 @@ typet c_bit_field_replacement_type(
     {
       bitvector_typet result=to_bitvector_type(sub_subtype);
       result.set_width(src.get_width());
-      return result;
+      return std::move(result);
     }
     else
       return nil_typet();

--- a/src/solvers/flattening/flatten_byte_operators.cpp
+++ b/src/solvers/flattening/flatten_byte_operators.cpp
@@ -156,7 +156,7 @@ static exprt unpack_rec(
   to_array_type(array.type()).size()=
     from_integer(array.operands().size(), size_type());
 
-  return array;
+  return std::move(array);
 }
 
 /// rewrite byte extraction from an array to byte extraction from a

--- a/src/solvers/flattening/functions.cpp
+++ b/src/solvers/flattening/functions.cpp
@@ -50,7 +50,7 @@ exprt functionst::arguments_equal(const exprt::operandst &o1,
     conjuncts[i]=equal_exprt(lhs, rhs);
   }
 
-  return and_expr;
+  return std::move(and_expr);
 }
 
 void functionst::add_function_constraints(const function_infot &info)

--- a/src/solvers/flattening/pointer_logic.cpp
+++ b/src/solvers/flattening/pointer_logic.cpp
@@ -77,7 +77,7 @@ exprt pointer_logict::pointer_expr(
     if(pointer.offset==0)
     {
       null_pointer_exprt result(type);
-      return result;
+      return std::move(result);
     }
     else
     {

--- a/src/solvers/floatbv/float_bv.cpp
+++ b/src/solvers/floatbv/float_bv.cpp
@@ -788,7 +788,7 @@ exprt float_bvt::relation(
       and_bv.copy_to_operands(not_exprt(both_zero));
       and_bv.copy_to_operands(not_exprt(nan));
 
-      return and_bv;
+      return std::move(and_bv);
     }
     else if(rel==relt::LE)
     {

--- a/src/solvers/refinement/string_constraint_generator_code_points.cpp
+++ b/src/solvers/refinement/string_constraint_generator_code_points.cpp
@@ -112,7 +112,7 @@ exprt pair_value(exprt char1, exprt char2, typet return_type)
   mult_exprt m1(mod_exprt(char1, hex0800), hex0400);
   mod_exprt m2(char2, hex0400);
   plus_exprt pair_value(hex010000, plus_exprt(m1, m2));
-  return pair_value;
+  return std::move(pair_value);
 }
 
 /// add axioms corresponding to the String.codePointAt java function

--- a/src/solvers/refinement/string_constraint_generator_valueof.cpp
+++ b/src/solvers/refinement/string_constraint_generator_valueof.cpp
@@ -632,7 +632,7 @@ exprt is_digit_with_radix(
     }
     else
     {
-      return is_digit_when_radix_gt_10;
+      return std::move(is_digit_when_radix_gt_10);
     }
   }
 }

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -392,7 +392,7 @@ exprt smt2_convt::parse_struct(
   result.operands().resize(components.size(), nil_exprt());
 
   if(components.empty())
-    return result;
+    return std::move(result);
 
   if(use_datatypes)
   {
@@ -400,7 +400,7 @@ exprt smt2_convt::parse_struct(
     //  (mk-struct.1 <component0> <component1> ... <componentN>)
 
     if(src.get_sub().size()!=components.size()+1)
-      return result; // give up
+      return std::move(result); // give up
 
     for(std::size_t i=0; i<components.size(); i++)
     {
@@ -441,7 +441,7 @@ exprt smt2_convt::parse_struct(
     }
   }
 
-  return result;
+  return std::move(result);
 }
 
 exprt smt2_convt::parse_rec(const irept &src, const typet &_type)

--- a/src/util/c_types.cpp
+++ b/src/util/c_types.cpp
@@ -122,13 +122,13 @@ bitvector_typet char_type()
   {
     unsignedbv_typet result(config.ansi_c.char_width);
     result.set(ID_C_c_type, ID_char);
-    return result;
+    return std::move(result);
   }
   else
   {
     signedbv_typet result(config.ansi_c.char_width);
     result.set(ID_C_c_type, ID_char);
-    return result;
+    return std::move(result);
   }
 }
 
@@ -152,13 +152,13 @@ bitvector_typet wchar_t_type()
   {
     unsignedbv_typet result(config.ansi_c.wchar_t_width);
     result.set(ID_C_c_type, ID_wchar_t);
-    return result;
+    return std::move(result);
   }
   else
   {
     signedbv_typet result(config.ansi_c.wchar_t_width);
     result.set(ID_C_c_type, ID_wchar_t);
-    return result;
+    return std::move(result);
   }
 }
 

--- a/src/util/expr_initializer.cpp
+++ b/src/util/expr_initializer.cpp
@@ -136,7 +136,7 @@ exprt expr_initializert<nondet>::expr_initializer_rec(
       value.type().id(ID_array);
       value.type().set(ID_size, from_integer(0, size_type()));
       value.add_source_location()=source_location;
-      return value;
+      return std::move(value);
     }
     else
     {
@@ -152,7 +152,7 @@ exprt expr_initializert<nondet>::expr_initializer_rec(
 
         array_of_exprt value(tmpval, array_type);
         value.add_source_location()=source_location;
-        return value;
+        return std::move(value);
       }
       else if(to_integer(array_type.size(), array_size))
       {
@@ -176,7 +176,7 @@ exprt expr_initializert<nondet>::expr_initializer_rec(
       array_exprt value(array_type);
       value.operands().resize(integer2size_t(array_size), tmpval);
       value.add_source_location()=source_location;
-      return value;
+      return std::move(value);
     }
   }
   else if(type_id==ID_vector)
@@ -209,7 +209,7 @@ exprt expr_initializert<nondet>::expr_initializer_rec(
     value.operands().resize(integer2size_t(vector_size), tmpval);
     value.add_source_location()=source_location;
 
-    return value;
+    return std::move(value);
   }
   else if(type_id==ID_struct)
   {
@@ -234,7 +234,7 @@ exprt expr_initializert<nondet>::expr_initializer_rec(
 
     value.add_source_location()=source_location;
 
-    return value;
+    return std::move(value);
   }
   else if(type_id==ID_union)
   {
@@ -279,7 +279,7 @@ exprt expr_initializert<nondet>::expr_initializer_rec(
         expr_initializer_rec(component.type(), source_location);
     }
 
-    return value;
+    return std::move(value);
   }
   else if(type_id == ID_symbol_type)
   {

--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -121,7 +121,7 @@ exprt is_not_zero(
   binary_exprt comparison(src, id, zero, bool_typet());
   comparison.add_source_location()=src.source_location();
 
-  return comparison;
+  return std::move(comparison);
 }
 
 exprt boolean_negate(const exprt &src)

--- a/src/util/pointer_offset_size.cpp
+++ b/src/util/pointer_offset_size.cpp
@@ -331,7 +331,7 @@ exprt size_of_expr(
     mult_exprt result(size, sub);
     simplify(result, ns);
 
-    return result;
+    return std::move(result);
   }
   else if(type.id()==ID_vector)
   {
@@ -351,7 +351,7 @@ exprt size_of_expr(
     mult_exprt result(size, sub);
     simplify(result, ns);
 
-    return result;
+    return std::move(result);
   }
   else if(type.id()==ID_complex)
   {
@@ -364,7 +364,7 @@ exprt size_of_expr(
     mult_exprt result(size, sub);
     simplify(result, ns);
 
-    return result;
+    return std::move(result);
   }
   else if(type.id()==ID_struct)
   {

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -1519,7 +1519,7 @@ exprt simplify_exprt::bits2expr(
       m_offset_bits += *m_size;
     }
 
-    return result;
+    return std::move(result);
   }
   else if(type.id()==ID_array)
   {
@@ -1547,7 +1547,7 @@ exprt simplify_exprt::bits2expr(
       result.move_to_operands(el);
     }
 
-    return result;
+    return std::move(result);
   }
 
   return nil_exprt();

--- a/src/util/std_expr.cpp
+++ b/src/util/std_expr.cpp
@@ -33,7 +33,7 @@ exprt disjunction(const exprt::operandst &op)
   {
     or_exprt result;
     result.operands()=op;
-    return result;
+    return std::move(result);
   }
 }
 
@@ -57,7 +57,7 @@ exprt conjunction(const exprt::operandst &op)
   {
     and_exprt result;
     result.operands()=op;
-    return result;
+    return std::move(result);
   }
 }
 


### PR DESCRIPTION
This commit fixes #3238, a warning emitted by clang 7.0:

```
java_bytecode_convert_method.cpp:2924:10: error: local variable
'block' will be copied despite being returned by name
[-Werror,-Wreturn-std-move]
  return block;
         ^~~~~
java_bytecode_convert_method.cpp:2924:10: note: call 'std::move'
explicitly to avoid copying
  return block;
         ^~~~~
         std::move(block)
```

The fix is to wrap all such returned local variables in a call to
std::move().

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.