### PR TITLE
all-properties now shows results in an ordering

### DIFF
--- a/regression/cbmc/Multiple_Properties1/test.desc
+++ b/regression/cbmc/Multiple_Properties1/test.desc
@@ -1,10 +1,10 @@
 CORE
 main.c
 --property main.assertion.1 --property main.assertion.3
+activate-multi-line-match
 ^EXIT=10$
 ^SIGNAL=0$
-^VERIFICATION FAILED
-^.*main.assertion.1.*SUCCESS
-^.*main.assertion.3.*FAILURE
+^VERIFICATION FAILED$
+^main.c function main\n\[main\.assertion\.1\] .* SUCCESS\n\[main\.assertion\.3\] .* FAILURE$
 --
 ^warning: ignoring

--- a/src/cbmc/all_properties_class.h
+++ b/src/cbmc/all_properties_class.h
@@ -40,6 +40,7 @@ public:
       instancest;
     instancest instances;
     std::string description;
+    source_locationt source_location;
 
     // if failed, we compute a goto_trace for the first failing instance
     enum statust { UNKNOWN, FAILURE, SUCCESS, ERROR } status;
@@ -64,6 +65,7 @@ public:
       const goto_programt::instructiont &instruction):
       status(statust::UNKNOWN)
     {
+      source_location = instruction.source_location;
       description=id2string(instruction.source_location.get_comment());
     }
 


### PR DESCRIPTION
Previously, results got shown in irep_idt ordering.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
