### PR TITLE
solvers: also link MiniSat2 options

### DIFF
--- a/scripts/minisat-2.2.1-patch
+++ b/scripts/minisat-2.2.1-patch
@@ -179,6 +179,23 @@ index 2dba10f..7d2e83a 100644
          if (verbose){
              fprintf(stderr, "\n        %s\n", description);
              fprintf(stderr, "\n");
+diff --git a/minisat/utils/Options.cc b/minisat/utils/Options.cc
+index 83c40e8..15bfca1 100644
+--- a/minisat/utils/Options.cc
++++ b/minisat/utils/Options.cc
+@@ -43,10 +43,12 @@ void Minisat::parseOptions(int& argc, char** argv, bool strict)
+             }
+
+             if (!parsed_ok)
++            {
+                 if (strict && match(argv[i], "-"))
+                     fprintf(stderr, "ERROR! Unknown flag \"%s\". Use '--%shelp' for help.\n", argv[i], Option::getHelpPrefixString()), exit(1);
+                 else
+                     argv[j++] = argv[i];
++            }
+         }
+     }
+
 diff --git a/minisat/utils/ParseUtils.h b/minisat/utils/ParseUtils.h
 index d307164..7b46f09 100644
 --- a/minisat/utils/ParseUtils.h

--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -17,7 +17,7 @@ endif
 ifneq ($(MINISAT2),)
   MINISAT2_SRC=sat/satcheck_minisat2.cpp
   MINISAT2_INCLUDE=-I $(MINISAT2)
-  MINISAT2_LIB=$(MINISAT2)/minisat/simp/SimpSolver$(OBJEXT) $(MINISAT2)/minisat/core/Solver$(OBJEXT)
+  MINISAT2_LIB=$(MINISAT2)/minisat/simp/SimpSolver$(OBJEXT) $(MINISAT2)/minisat/core/Solver$(OBJEXT) $(MINISAT2)/minisat/utils/Options$(OBJEXT)
   CP_CXXFLAGS += -DHAVE_MINISAT2 -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
   CLEANFILES += $(MINISAT2_LIB) $(patsubst %$(OBJEXT), %$(DEPEXT), $(MINISAT2_LIB))
 endif


### PR DESCRIPTION
To be able to parse options again when setting up a solver, the
parseOption method has to be present. Hence, link against the
Options.cc file of MiniSat2 as well.

Signed-off-by: Norbert Manthey <nmanthey@amazon.de>

Note: For the current CBMC, nothing will change from a feature or performance perspective (except binary size). This change allows to exchange the existing MiniSat with other versions of that solver, especially https://github.com/conp-solutions/minisat. This fork comes with solver performance improvements, and which allows to specify SAT solver parameters via environment variable - to allow SAT solver tuning for CBMC more easily.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.