### PR TITLE
Do not use exprt::move_to_operands as it is marked as deprecated

### DIFF
--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -104,8 +104,7 @@ void exprt::make_not()
   }
   else
   {
-    new_expr=exprt(ID_not, type());
-    new_expr.move_to_operands(*this);
+    new_expr = not_exprt(*this);
   }
 
   swap(new_expr);


### PR DESCRIPTION
In particular, the use in std_code.h triggers a series of warnings every time
this file is included.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
