### PR TITLE
Fix typecast in interpreter

### DIFF
--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -18,6 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/string_container.h>
 
 #include <langapi/language_util.h>
+#include <util/expr_util.h>
 
 /// Reads a memory address and loads it into the `dest` variable.
 /// Marks cell as `READ_BEFORE_WRITTEN` if cell has never been written.
@@ -347,12 +348,13 @@ void interpretert::evaluate(
     {
       if(expr.has_operands())
       {
-        if(expr.op0().id() == ID_address_of)
+        const exprt &object = skip_typecast(expr.op0());
+        if(object.id() == ID_address_of)
         {
-          evaluate(expr.op0(), dest);
+          evaluate(object, dest);
           return;
         }
-        else if(const auto i = numeric_cast<mp_integer>(expr.op0()))
+        else if(const auto i = numeric_cast<mp_integer>(object))
         {
           dest.push_back(*i);
           return;

--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -345,24 +345,28 @@ void interpretert::evaluate(
     }
     else if(expr.type().id() == ID_pointer)
     {
-      mp_integer i=0;
       if(expr.has_operands() && expr.op0().id()==ID_address_of)
       {
         evaluate(expr.op0(), dest);
         return;
       }
-      else if(expr.has_operands() && !to_integer(expr.op0(), i))
+      else if(expr.has_operands())
       {
-        dest.push_back(i);
-        return;
+        if(const auto i = numeric_cast<mp_integer>(expr.op0()))
+        {
+          dest.push_back(*i);
+          return;
+        }
       }
       // check if expression is constant null pointer without operands
-      else if(
-        !expr.has_operands() && !to_integer(to_constant_expr(expr), i) &&
-        i.is_zero())
+      else if(!expr.has_operands())
       {
-        dest.push_back(i);
-        return;
+        const auto i = numeric_cast<mp_integer>(expr);
+        if(i && i->is_zero())
+        {
+          dest.push_back(*i);
+          return;
+        }
       }
     }
     else if(expr.type().id()==ID_floatbv)

--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -345,21 +345,21 @@ void interpretert::evaluate(
     }
     else if(expr.type().id() == ID_pointer)
     {
-      if(expr.has_operands() && expr.op0().id()==ID_address_of)
+      if(expr.has_operands())
       {
-        evaluate(expr.op0(), dest);
-        return;
-      }
-      else if(expr.has_operands())
-      {
-        if(const auto i = numeric_cast<mp_integer>(expr.op0()))
+        if(expr.op0().id() == ID_address_of)
+        {
+          evaluate(expr.op0(), dest);
+          return;
+        }
+        else if(const auto i = numeric_cast<mp_integer>(expr.op0()))
         {
           dest.push_back(*i);
           return;
         }
       }
       // check if expression is constant null pointer without operands
-      else if(!expr.has_operands())
+      else
       {
         const auto i = numeric_cast<mp_integer>(expr);
         if(i && i->is_zero())


### PR DESCRIPTION
After https://github.com/diffblue/cbmc/pull/3135 was merged, the interpreter started failing to interpret some expressions of type pointer, this was because they contained additional typecast. 
This fixes the issue by making the interpreter look inside the typecast.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->

The reason I haven't added test here, is we have tests in another repository (which are failing at the moment), and I don't think the interpreter is much used in CBMC so it may be a bit difficult to test it here.