### PR TITLE
Get rid of the string_exprt class

### DIFF
--- a/src/solvers/refinement/string_constraint_generator_code_points.cpp
+++ b/src/solvers/refinement/string_constraint_generator_code_points.cpp
@@ -43,10 +43,10 @@ std::pair<exprt, string_constraintst> add_axioms_for_code_point(
   exprt hex0400=from_integer(0x0400, type);
 
   binary_relation_exprt small(code_point, ID_lt, hex010000);
-  implies_exprt a1(small, res.axiom_for_has_length(1));
+  implies_exprt a1(small, axiom_for_has_length(res, 1));
   constraints.existential.push_back(a1);
 
-  implies_exprt a2(not_exprt(small), res.axiom_for_has_length(2));
+  implies_exprt a2(not_exprt(small), axiom_for_has_length(res, 2));
   constraints.existential.push_back(a2);
 
   typecast_exprt code_point_as_char(code_point, char_type);

--- a/src/solvers/refinement/string_constraint_generator_code_points.cpp
+++ b/src/solvers/refinement/string_constraint_generator_code_points.cpp
@@ -43,10 +43,10 @@ std::pair<exprt, string_constraintst> add_axioms_for_code_point(
   exprt hex0400=from_integer(0x0400, type);
 
   binary_relation_exprt small(code_point, ID_lt, hex010000);
-  implies_exprt a1(small, axiom_for_has_length(res, 1));
+  implies_exprt a1(small, length_eq(res, 1));
   constraints.existential.push_back(a1);
 
-  implies_exprt a2(not_exprt(small), axiom_for_has_length(res, 2));
+  implies_exprt a2(not_exprt(small), length_eq(res, 2));
   constraints.existential.push_back(a2);
 
   typecast_exprt code_point_as_char(code_point, char_type);

--- a/src/solvers/refinement/string_constraint_generator_comparison.cpp
+++ b/src/solvers/refinement/string_constraint_generator_comparison.cpp
@@ -211,7 +211,7 @@ string_constraint_generatort::add_axioms_for_hash_code(
       equal_exprt(it.first.length(), str.length()),
       and_exprt(
         notequal_exprt(str[i], it.first[i]),
-        and_exprt(str.axiom_for_length_gt(i), is_positive(i))));
+        and_exprt(axiom_for_length_gt(str, i), is_positive(i))));
     constraints.existential.push_back(or_exprt(c1, or_exprt(c2, c3)));
   }
   return {hash, std::move(constraints)};
@@ -274,12 +274,15 @@ std::pair<exprt, string_constraintst> add_axioms_for_compare_to(
       typecast_exprt(s1.length(), return_type),
       typecast_exprt(s2.length(), return_type)));
   const or_exprt guard1(
-    and_exprt(s1.axiom_for_length_le(s2.length()), s1.axiom_for_length_gt(x)),
-    and_exprt(s1.axiom_for_length_ge(s2.length()), s2.axiom_for_length_gt(x)));
+    and_exprt(axiom_for_length_le(s1, s2.length()), axiom_for_length_gt(s1, x)),
+    and_exprt(
+      axiom_for_length_ge(s1, s2.length()), axiom_for_length_gt(s2, x)));
   const and_exprt cond1(ret_char_diff, guard1);
   const or_exprt guard2(
-    and_exprt(s2.axiom_for_length_gt(s1.length()), s1.axiom_for_has_length(x)),
-    and_exprt(s1.axiom_for_length_gt(s2.length()), s2.axiom_for_has_length(x)));
+    and_exprt(
+      axiom_for_length_gt(s2, s1.length()), axiom_for_has_length(s1, x)),
+    and_exprt(
+      axiom_for_length_gt(s1, s2.length()), axiom_for_has_length(s2, x)));
   const and_exprt cond2(ret_length_diff, guard2);
 
   const implies_exprt a3(
@@ -346,7 +349,7 @@ string_constraint_generatort::add_axioms_for_intern(
               equal_exprt(str.length(), it.first.length()),
               and_exprt(
                 notequal_exprt(str[i], it.first[i]),
-                and_exprt(str.axiom_for_length_gt(i), is_positive(i)))))));
+                and_exprt(axiom_for_length_gt(str, i), is_positive(i)))))));
     }
 
   return {intern, std::move(constraints)};

--- a/src/solvers/refinement/string_constraint_generator_comparison.cpp
+++ b/src/solvers/refinement/string_constraint_generator_comparison.cpp
@@ -278,8 +278,8 @@ std::pair<exprt, string_constraintst> add_axioms_for_compare_to(
     and_exprt(length_ge(s1, s2.length()), length_gt(s2, x)));
   const and_exprt cond1(ret_char_diff, guard1);
   const or_exprt guard2(
-    and_exprt(length_gt(s2, s1.length()), axiom_for_has_length(s1, x)),
-    and_exprt(length_gt(s1, s2.length()), axiom_for_has_length(s2, x)));
+    and_exprt(length_gt(s2, s1.length()), length_eq(s1, x)),
+    and_exprt(length_gt(s1, s2.length()), length_eq(s2, x)));
   const and_exprt cond2(ret_length_diff, guard2);
 
   const implies_exprt a3(

--- a/src/solvers/refinement/string_constraint_generator_comparison.cpp
+++ b/src/solvers/refinement/string_constraint_generator_comparison.cpp
@@ -211,7 +211,7 @@ string_constraint_generatort::add_axioms_for_hash_code(
       equal_exprt(it.first.length(), str.length()),
       and_exprt(
         notequal_exprt(str[i], it.first[i]),
-        and_exprt(axiom_for_length_gt(str, i), is_positive(i))));
+        and_exprt(length_gt(str, i), is_positive(i))));
     constraints.existential.push_back(or_exprt(c1, or_exprt(c2, c3)));
   }
   return {hash, std::move(constraints)};
@@ -274,14 +274,12 @@ std::pair<exprt, string_constraintst> add_axioms_for_compare_to(
       typecast_exprt(s1.length(), return_type),
       typecast_exprt(s2.length(), return_type)));
   const or_exprt guard1(
-    and_exprt(axiom_for_length_le(s1, s2.length()), axiom_for_length_gt(s1, x)),
-    and_exprt(length_ge(s1, s2.length()), axiom_for_length_gt(s2, x)));
+    and_exprt(length_le(s1, s2.length()), length_gt(s1, x)),
+    and_exprt(length_ge(s1, s2.length()), length_gt(s2, x)));
   const and_exprt cond1(ret_char_diff, guard1);
   const or_exprt guard2(
-    and_exprt(
-      axiom_for_length_gt(s2, s1.length()), axiom_for_has_length(s1, x)),
-    and_exprt(
-      axiom_for_length_gt(s1, s2.length()), axiom_for_has_length(s2, x)));
+    and_exprt(length_gt(s2, s1.length()), axiom_for_has_length(s1, x)),
+    and_exprt(length_gt(s1, s2.length()), axiom_for_has_length(s2, x)));
   const and_exprt cond2(ret_length_diff, guard2);
 
   const implies_exprt a3(
@@ -339,16 +337,15 @@ string_constraint_generatort::add_axioms_for_intern(
     if(it.second!=str)
     {
       symbol_exprt i = fresh_symbol("index_intern", index_type);
-      constraints.existential.push_back(
+      constraints.existential.push_back(or_exprt(
+        equal_exprt(it.second, intern),
         or_exprt(
-          equal_exprt(it.second, intern),
-          or_exprt(
-            notequal_exprt(str.length(), it.first.length()),
+          notequal_exprt(str.length(), it.first.length()),
+          and_exprt(
+            equal_exprt(str.length(), it.first.length()),
             and_exprt(
-              equal_exprt(str.length(), it.first.length()),
-              and_exprt(
-                notequal_exprt(str[i], it.first[i]),
-                and_exprt(axiom_for_length_gt(str, i), is_positive(i)))))));
+              notequal_exprt(str[i], it.first[i]),
+              and_exprt(length_gt(str, i), is_positive(i)))))));
     }
 
   return {intern, std::move(constraints)};

--- a/src/solvers/refinement/string_constraint_generator_comparison.cpp
+++ b/src/solvers/refinement/string_constraint_generator_comparison.cpp
@@ -275,8 +275,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_compare_to(
       typecast_exprt(s2.length(), return_type)));
   const or_exprt guard1(
     and_exprt(axiom_for_length_le(s1, s2.length()), axiom_for_length_gt(s1, x)),
-    and_exprt(
-      axiom_for_length_ge(s1, s2.length()), axiom_for_length_gt(s2, x)));
+    and_exprt(length_ge(s1, s2.length()), axiom_for_length_gt(s2, x)));
   const and_exprt cond1(ret_char_diff, guard1);
   const or_exprt guard2(
     and_exprt(

--- a/src/solvers/refinement/string_constraint_generator_float.cpp
+++ b/src/solvers/refinement/string_constraint_generator_float.cpp
@@ -278,8 +278,8 @@ std::pair<exprt, string_constraintst> add_axioms_for_fractional_part(
   // no_trailing_zero: forall j:[2, max_size[. !(|res| = j+1 && res[j] = '0')
   // a3 : int_expr = sum_j 10^j (j < |res| ? res[j] - '0' : 0)
 
-  and_exprt a1(res.axiom_for_length_gt(1),
-               res.axiom_for_length_le(max));
+  const and_exprt a1(
+    axiom_for_length_gt(res, 1), axiom_for_length_le(res, max));
   constraints.existential.push_back(a1);
 
   equal_exprt starts_with_dot(res[0], from_integer('.', char_type));

--- a/src/solvers/refinement/string_constraint_generator_float.cpp
+++ b/src/solvers/refinement/string_constraint_generator_float.cpp
@@ -278,7 +278,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_fractional_part(
   // no_trailing_zero: forall j:[2, max_size[. !(|res| = j+1 && res[j] = '0')
   // a3 : int_expr = sum_j 10^j (j < |res| ? res[j] - '0' : 0)
 
-  const and_exprt a1(length_gt(res, 1), axiom_for_length_le(res, max));
+  const and_exprt a1(length_gt(res, 1), length_le(res, max));
   constraints.existential.push_back(a1);
 
   equal_exprt starts_with_dot(res[0], from_integer('.', char_type));

--- a/src/solvers/refinement/string_constraint_generator_float.cpp
+++ b/src/solvers/refinement/string_constraint_generator_float.cpp
@@ -278,8 +278,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_fractional_part(
   // no_trailing_zero: forall j:[2, max_size[. !(|res| = j+1 && res[j] = '0')
   // a3 : int_expr = sum_j 10^j (j < |res| ? res[j] - '0' : 0)
 
-  const and_exprt a1(
-    axiom_for_length_gt(res, 1), axiom_for_length_le(res, max));
+  const and_exprt a1(length_gt(res, 1), axiom_for_length_le(res, max));
   constraints.existential.push_back(a1);
 
   equal_exprt starts_with_dot(res[0], from_integer('.', char_type));

--- a/src/solvers/refinement/string_constraint_generator_testing.cpp
+++ b/src/solvers/refinement/string_constraint_generator_testing.cpp
@@ -67,7 +67,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_is_prefix(
     const exprt witness = fresh_symbol("witness_not_isprefix", index_type);
     const exprt strings_differ_at_witness = and_exprt(
       is_positive(witness),
-      axiom_for_length_gt(prefix, witness),
+      length_gt(prefix, witness),
       notequal_exprt(str[plus_exprt(witness, offset)], prefix[witness]));
     const exprt s1_does_not_start_with_s0 = or_exprt(
       not_exprt(offset_within_bounds),
@@ -199,11 +199,11 @@ std::pair<exprt, string_constraintst> add_axioms_for_is_suffix(
   const plus_exprt shifted(witness, minus_exprt(s1.length(), s0.length()));
   or_exprt constr3(
     and_exprt(
-      axiom_for_length_gt(s0, s1.length()),
+      length_gt(s0, s1.length()),
       equal_exprt(witness, from_integer(-1, index_type))),
     and_exprt(
       notequal_exprt(s0[witness], s1[shifted]),
-      and_exprt(axiom_for_length_gt(s0, witness), is_positive(witness))));
+      and_exprt(length_gt(s0, witness), is_positive(witness))));
   implies_exprt a3(not_exprt(issuffix), constr3);
 
   constraints.existential.push_back(a3);

--- a/src/solvers/refinement/string_constraint_generator_testing.cpp
+++ b/src/solvers/refinement/string_constraint_generator_testing.cpp
@@ -137,8 +137,8 @@ std::pair<exprt, string_constraintst> add_axioms_for_is_empty(
   symbol_exprt is_empty = fresh_symbol("is_empty");
   array_string_exprt s0 = get_string_expr(array_pool, f.arguments()[0]);
   std::vector<exprt> constraints;
-  constraints.push_back(implies_exprt(is_empty, axiom_for_has_length(s0, 0)));
-  constraints.push_back(implies_exprt(axiom_for_has_length(s0, 0), is_empty));
+  constraints.push_back(implies_exprt(is_empty, length_eq(s0, 0)));
+  constraints.push_back(implies_exprt(length_eq(s0, 0), is_empty));
   return {typecast_exprt(is_empty, f.type()), {constraints}};
 }
 

--- a/src/solvers/refinement/string_constraint_generator_testing.cpp
+++ b/src/solvers/refinement/string_constraint_generator_testing.cpp
@@ -67,11 +67,11 @@ std::pair<exprt, string_constraintst> add_axioms_for_is_prefix(
     const exprt witness = fresh_symbol("witness_not_isprefix", index_type);
     const exprt strings_differ_at_witness = and_exprt(
       is_positive(witness),
-      prefix.axiom_for_length_gt(witness),
+      axiom_for_length_gt(prefix, witness),
       notequal_exprt(str[plus_exprt(witness, offset)], prefix[witness]));
     const exprt s1_does_not_start_with_s0 = or_exprt(
       not_exprt(offset_within_bounds),
-      not_exprt(str.axiom_for_length_ge(plus_exprt(prefix.length(), offset))),
+      not_exprt(axiom_for_length_ge(str, plus_exprt(prefix.length(), offset))),
       strings_differ_at_witness);
     return implies_exprt(not_exprt(isprefix), s1_does_not_start_with_s0);
   }());
@@ -137,8 +137,8 @@ std::pair<exprt, string_constraintst> add_axioms_for_is_empty(
   symbol_exprt is_empty = fresh_symbol("is_empty");
   array_string_exprt s0 = get_string_expr(array_pool, f.arguments()[0]);
   std::vector<exprt> constraints;
-  constraints.push_back(implies_exprt(is_empty, s0.axiom_for_has_length(0)));
-  constraints.push_back(implies_exprt(s0.axiom_for_has_length(0), is_empty));
+  constraints.push_back(implies_exprt(is_empty, axiom_for_has_length(s0, 0)));
+  constraints.push_back(implies_exprt(axiom_for_has_length(s0, 0), is_empty));
   return {typecast_exprt(is_empty, f.type()), {constraints}};
 }
 
@@ -184,7 +184,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_is_suffix(
     get_string_expr(array_pool, args[swap_arguments ? 0u : 1u]);
   const typet &index_type=s0.length().type();
 
-  implies_exprt a1(issuffix, s1.axiom_for_length_ge(s0.length()));
+  implies_exprt a1(issuffix, axiom_for_length_ge(s1, s0.length()));
   constraints.existential.push_back(a1);
 
   symbol_exprt qvar = fresh_symbol("QA_suffix", index_type);
@@ -199,11 +199,11 @@ std::pair<exprt, string_constraintst> add_axioms_for_is_suffix(
   const plus_exprt shifted(witness, minus_exprt(s1.length(), s0.length()));
   or_exprt constr3(
     and_exprt(
-      s0.axiom_for_length_gt(s1.length()),
+      axiom_for_length_gt(s0, s1.length()),
       equal_exprt(witness, from_integer(-1, index_type))),
     and_exprt(
       notequal_exprt(s0[witness], s1[shifted]),
-      and_exprt(s0.axiom_for_length_gt(witness), is_positive(witness))));
+      and_exprt(axiom_for_length_gt(s0, witness), is_positive(witness))));
   implies_exprt a3(not_exprt(issuffix), constr3);
 
   constraints.existential.push_back(a3);
@@ -244,7 +244,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_contains(
   const symbol_exprt contains = fresh_symbol("contains");
   const symbol_exprt startpos = fresh_symbol("startpos_contains", index_type);
 
-  const implies_exprt a1(contains, s0.axiom_for_length_ge(s1.length()));
+  const implies_exprt a1(contains, axiom_for_length_ge(s0, s1.length()));
   constraints.existential.push_back(a1);
 
   minus_exprt length_diff(s0.length(), s1.length());
@@ -269,7 +269,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_contains(
   const string_not_contains_constraintt a5 = {
     from_integer(0, index_type),
     plus_exprt(from_integer(1, index_type), length_diff),
-    and_exprt(not_exprt(contains), s0.axiom_for_length_ge(s1.length())),
+    and_exprt(not_exprt(contains), axiom_for_length_ge(s0, s1.length())),
     from_integer(0, index_type),
     s1.length(),
     s0,

--- a/src/solvers/refinement/string_constraint_generator_testing.cpp
+++ b/src/solvers/refinement/string_constraint_generator_testing.cpp
@@ -71,7 +71,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_is_prefix(
       notequal_exprt(str[plus_exprt(witness, offset)], prefix[witness]));
     const exprt s1_does_not_start_with_s0 = or_exprt(
       not_exprt(offset_within_bounds),
-      not_exprt(axiom_for_length_ge(str, plus_exprt(prefix.length(), offset))),
+      not_exprt(length_ge(str, plus_exprt(prefix.length(), offset))),
       strings_differ_at_witness);
     return implies_exprt(not_exprt(isprefix), s1_does_not_start_with_s0);
   }());
@@ -184,7 +184,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_is_suffix(
     get_string_expr(array_pool, args[swap_arguments ? 0u : 1u]);
   const typet &index_type=s0.length().type();
 
-  implies_exprt a1(issuffix, axiom_for_length_ge(s1, s0.length()));
+  implies_exprt a1(issuffix, length_ge(s1, s0.length()));
   constraints.existential.push_back(a1);
 
   symbol_exprt qvar = fresh_symbol("QA_suffix", index_type);
@@ -244,7 +244,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_contains(
   const symbol_exprt contains = fresh_symbol("contains");
   const symbol_exprt startpos = fresh_symbol("startpos_contains", index_type);
 
-  const implies_exprt a1(contains, axiom_for_length_ge(s0, s1.length()));
+  const implies_exprt a1(contains, length_ge(s0, s1.length()));
   constraints.existential.push_back(a1);
 
   minus_exprt length_diff(s0.length(), s1.length());
@@ -269,7 +269,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_contains(
   const string_not_contains_constraintt a5 = {
     from_integer(0, index_type),
     plus_exprt(from_integer(1, index_type), length_diff),
-    and_exprt(not_exprt(contains), axiom_for_length_ge(s0, s1.length())),
+    and_exprt(not_exprt(contains), length_ge(s0, s1.length())),
     from_integer(0, index_type),
     s1.length(),
     s0,

--- a/src/solvers/refinement/string_constraint_generator_transformation.cpp
+++ b/src/solvers/refinement/string_constraint_generator_transformation.cpp
@@ -208,7 +208,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_trim(
   const exprt a4 = length_ge(res, from_integer(0, index_type));
   constraints.existential.push_back(a4);
 
-  const exprt a5 = axiom_for_length_le(res, str.length());
+  const exprt a5 = length_le(res, str.length());
   constraints.existential.push_back(a5);
 
   symbol_exprt n = fresh_symbol("QA_index_trim", index_type);

--- a/src/solvers/refinement/string_constraint_generator_transformation.cpp
+++ b/src/solvers/refinement/string_constraint_generator_transformation.cpp
@@ -197,15 +197,15 @@ std::pair<exprt, string_constraintst> add_axioms_for_trim(
 
   // Axiom 1.
   constraints.existential.push_back(
-    axiom_for_length_ge(str, plus_exprt(idx, res.length())));
+    length_ge(str, plus_exprt(idx, res.length())));
 
   binary_relation_exprt a2(idx, ID_ge, from_integer(0, index_type));
   constraints.existential.push_back(a2);
 
-  const exprt a3 = axiom_for_length_ge(str, idx);
+  const exprt a3 = length_ge(str, idx);
   constraints.existential.push_back(a3);
 
-  const exprt a4 = axiom_for_length_ge(res, from_integer(0, index_type));
+  const exprt a4 = length_ge(res, from_integer(0, index_type));
   constraints.existential.push_back(a4);
 
   const exprt a5 = axiom_for_length_le(res, str.length());

--- a/src/solvers/refinement/string_constraint_generator_transformation.cpp
+++ b/src/solvers/refinement/string_constraint_generator_transformation.cpp
@@ -53,7 +53,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_set_length(
   // a2 : forall i< min(|s1|, k) .res[i] = s1[i]
   // a3 : forall |s1| <= i < |res|. res[i] = 0
 
-  constraints.existential.push_back(axiom_for_has_length(res, k));
+  constraints.existential.push_back(length_eq(res, k));
 
   const symbol_exprt idx = fresh_symbol("QA_index_set_length", index_type);
   const string_constraintt a2(

--- a/src/solvers/refinement/string_constraint_generator_transformation.cpp
+++ b/src/solvers/refinement/string_constraint_generator_transformation.cpp
@@ -53,7 +53,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_set_length(
   // a2 : forall i< min(|s1|, k) .res[i] = s1[i]
   // a3 : forall |s1| <= i < |res|. res[i] = 0
 
-  constraints.existential.push_back(res.axiom_for_has_length(k));
+  constraints.existential.push_back(axiom_for_has_length(res, k));
 
   const symbol_exprt idx = fresh_symbol("QA_index_set_length", index_type);
   const string_constraintt a2(
@@ -197,19 +197,18 @@ std::pair<exprt, string_constraintst> add_axioms_for_trim(
 
   // Axiom 1.
   constraints.existential.push_back(
-    str.axiom_for_length_ge(plus_exprt(idx, res.length())));
+    axiom_for_length_ge(str, plus_exprt(idx, res.length())));
 
   binary_relation_exprt a2(idx, ID_ge, from_integer(0, index_type));
   constraints.existential.push_back(a2);
 
-  exprt a3=str.axiom_for_length_ge(idx);
+  const exprt a3 = axiom_for_length_ge(str, idx);
   constraints.existential.push_back(a3);
 
-  exprt a4=res.axiom_for_length_ge(
-    from_integer(0, index_type));
+  const exprt a4 = axiom_for_length_ge(res, from_integer(0, index_type));
   constraints.existential.push_back(a4);
 
-  exprt a5 = res.axiom_for_length_le(str.length());
+  const exprt a5 = axiom_for_length_le(res, str.length());
   constraints.existential.push_back(a5);
 
   symbol_exprt n = fresh_symbol("QA_index_trim", index_type);

--- a/src/solvers/refinement/string_constraint_generator_valueof.cpp
+++ b/src/solvers/refinement/string_constraint_generator_valueof.cpp
@@ -245,7 +245,7 @@ std::pair<exprt, string_constraintst> add_axioms_from_int_hex(
 
   size_t max_size=8;
   constraints.existential.push_back(
-    and_exprt(length_gt(res, 0), axiom_for_length_le(res, max_size)));
+    and_exprt(length_gt(res, 0), length_le(res, max_size)));
 
   for(size_t size=1; size<=max_size; size++)
   {
@@ -388,7 +388,7 @@ string_constraintst add_axioms_for_correct_number_format(
   constraints.existential.push_back(contains_digit);
 
   // |str| <= max_size
-  constraints.existential.push_back(axiom_for_length_le(str, max_size));
+  constraints.existential.push_back(length_le(str, max_size));
 
   // forall 1 <= i < |str| . is_digit_with_radix(str[i], radix)
   // We unfold the above because we know that it will be used for all i up to

--- a/src/solvers/refinement/string_constraint_generator_valueof.cpp
+++ b/src/solvers/refinement/string_constraint_generator_valueof.cpp
@@ -103,7 +103,7 @@ std::pair<exprt, string_constraintst> add_axioms_from_bool(
   // a4 : forall i < |"false"|. !eq => res[i]="false"[i]
 
   std::string str_true="true";
-  implies_exprt a1(eq, res.axiom_for_has_length(str_true.length()));
+  const implies_exprt a1(eq, axiom_for_has_length(res, str_true.length()));
   constraints.existential.push_back(a1);
 
   for(std::size_t i=0; i<str_true.length(); i++)
@@ -114,7 +114,8 @@ std::pair<exprt, string_constraintst> add_axioms_from_bool(
   }
 
   std::string str_false="false";
-  implies_exprt a3(not_exprt(eq), res.axiom_for_has_length(str_false.length()));
+  const implies_exprt a3(
+    not_exprt(eq), axiom_for_has_length(res, str_false.length()));
   constraints.existential.push_back(a3);
 
   for(std::size_t i=0; i<str_false.length(); i++)
@@ -244,7 +245,7 @@ std::pair<exprt, string_constraintst> add_axioms_from_int_hex(
 
   size_t max_size=8;
   constraints.existential.push_back(
-    and_exprt(res.axiom_for_length_gt(0), res.axiom_for_length_le(max_size)));
+    and_exprt(axiom_for_length_gt(res, 0), axiom_for_length_le(res, max_size)));
 
   for(size_t size=1; size<=max_size; size++)
   {
@@ -267,7 +268,7 @@ std::pair<exprt, string_constraintst> add_axioms_from_int_hex(
       all_numbers=and_exprt(all_numbers, is_number);
     }
 
-    equal_exprt premise(res.axiom_for_has_length(size));
+    const equal_exprt premise = axiom_for_has_length(res, size);
     constraints.existential.push_back(
       implies_exprt(premise, and_exprt(equal_exprt(i, sum), all_numbers)));
 
@@ -331,7 +332,7 @@ std::pair<exprt, string_constraintst> add_axioms_from_char(
   const array_string_exprt &res,
   const exprt &c)
 {
-  const and_exprt lemma(equal_exprt(res[0], c), res.axiom_for_has_length(1));
+  const and_exprt lemma(equal_exprt(res[0], c), axiom_for_has_length(res, 1));
   return {from_integer(0, get_return_code_type()), {{lemma}}};
 }
 
@@ -363,7 +364,7 @@ string_constraintst add_axioms_for_correct_number_format(
     is_digit_with_radix(chr, strict_formatting, radix_as_char, radix_ul);
 
   // |str| > 0
-  const exprt non_empty=str.axiom_for_length_ge(from_integer(1, index_type));
+  const exprt non_empty = axiom_for_length_ge(str, from_integer(1, index_type));
   constraints.existential.push_back(non_empty);
 
   if(strict_formatting)
@@ -383,11 +384,11 @@ string_constraintst add_axioms_for_correct_number_format(
   // str[0]='+' or '-' ==> |str| > 1
   const implies_exprt contains_digit(
     or_exprt(starts_with_minus, starts_with_plus),
-    str.axiom_for_length_ge(from_integer(2, index_type)));
+    axiom_for_length_ge(str, from_integer(2, index_type)));
   constraints.existential.push_back(contains_digit);
 
   // |str| <= max_size
-  constraints.existential.push_back(str.axiom_for_length_le(max_size));
+  constraints.existential.push_back(axiom_for_length_le(str, max_size));
 
   // forall 1 <= i < |str| . is_digit_with_radix(str[i], radix)
   // We unfold the above because we know that it will be used for all i up to
@@ -396,7 +397,7 @@ string_constraintst add_axioms_for_correct_number_format(
   {
     /// index < length => is_digit_with_radix(str[index], radix)
     const implies_exprt character_at_index_is_digit(
-      str.axiom_for_length_ge(from_integer(index+1, index_type)),
+      axiom_for_length_ge(str, from_integer(index + 1, index_type)),
       is_digit_with_radix(
         str[index], strict_formatting, radix_as_char, radix_ul));
     constraints.existential.push_back(character_at_index_is_digit);
@@ -409,7 +410,7 @@ string_constraintst add_axioms_for_correct_number_format(
     // no_leading_zero : str[0] = '0' => |str| = 1
     const implies_exprt no_leading_zero(
       equal_exprt(chr, zero_char),
-      str.axiom_for_has_length(from_integer(1, index_type)));
+      axiom_for_has_length(str, from_integer(1, index_type)));
     constraints.existential.push_back(no_leading_zero);
 
     // no_leading_zero_after_minus : str[0]='-' => str[1]!='0'
@@ -455,7 +456,7 @@ string_constraintst add_axioms_for_characters_in_integer_string(
   /// add_axioms_for_correct_number_format which say that the string must
   /// contain at least one digit, so we don't have to worry about "+" or "-".
   constraints.existential.push_back(
-    implies_exprt(str.axiom_for_has_length(1), equal_exprt(input_int, sum)));
+    implies_exprt(axiom_for_has_length(str, 1), equal_exprt(input_int, sum)));
 
   for(size_t size=2; size<=max_string_length; size++)
   {
@@ -493,7 +494,7 @@ string_constraintst add_axioms_for_characters_in_integer_string(
     }
     sum=new_sum;
 
-    const equal_exprt premise=str.axiom_for_has_length(size);
+    const equal_exprt premise = axiom_for_has_length(str, size);
 
     if(!digit_constraints.empty())
     {

--- a/src/solvers/refinement/string_constraint_generator_valueof.cpp
+++ b/src/solvers/refinement/string_constraint_generator_valueof.cpp
@@ -245,7 +245,7 @@ std::pair<exprt, string_constraintst> add_axioms_from_int_hex(
 
   size_t max_size=8;
   constraints.existential.push_back(
-    and_exprt(axiom_for_length_gt(res, 0), axiom_for_length_le(res, max_size)));
+    and_exprt(length_gt(res, 0), axiom_for_length_le(res, max_size)));
 
   for(size_t size=1; size<=max_size; size++)
   {

--- a/src/solvers/refinement/string_constraint_generator_valueof.cpp
+++ b/src/solvers/refinement/string_constraint_generator_valueof.cpp
@@ -103,7 +103,7 @@ std::pair<exprt, string_constraintst> add_axioms_from_bool(
   // a4 : forall i < |"false"|. !eq => res[i]="false"[i]
 
   std::string str_true="true";
-  const implies_exprt a1(eq, axiom_for_has_length(res, str_true.length()));
+  const implies_exprt a1(eq, length_eq(res, str_true.length()));
   constraints.existential.push_back(a1);
 
   for(std::size_t i=0; i<str_true.length(); i++)
@@ -114,8 +114,7 @@ std::pair<exprt, string_constraintst> add_axioms_from_bool(
   }
 
   std::string str_false="false";
-  const implies_exprt a3(
-    not_exprt(eq), axiom_for_has_length(res, str_false.length()));
+  const implies_exprt a3(not_exprt(eq), length_eq(res, str_false.length()));
   constraints.existential.push_back(a3);
 
   for(std::size_t i=0; i<str_false.length(); i++)
@@ -268,7 +267,7 @@ std::pair<exprt, string_constraintst> add_axioms_from_int_hex(
       all_numbers=and_exprt(all_numbers, is_number);
     }
 
-    const equal_exprt premise = axiom_for_has_length(res, size);
+    const equal_exprt premise = length_eq(res, size);
     constraints.existential.push_back(
       implies_exprt(premise, and_exprt(equal_exprt(i, sum), all_numbers)));
 
@@ -332,7 +331,7 @@ std::pair<exprt, string_constraintst> add_axioms_from_char(
   const array_string_exprt &res,
   const exprt &c)
 {
-  const and_exprt lemma(equal_exprt(res[0], c), axiom_for_has_length(res, 1));
+  const and_exprt lemma(equal_exprt(res[0], c), length_eq(res, 1));
   return {from_integer(0, get_return_code_type()), {{lemma}}};
 }
 
@@ -455,7 +454,7 @@ string_constraintst add_axioms_for_characters_in_integer_string(
   /// add_axioms_for_correct_number_format which say that the string must
   /// contain at least one digit, so we don't have to worry about "+" or "-".
   constraints.existential.push_back(
-    implies_exprt(axiom_for_has_length(str, 1), equal_exprt(input_int, sum)));
+    implies_exprt(length_eq(str, 1), equal_exprt(input_int, sum)));
 
   for(size_t size=2; size<=max_string_length; size++)
   {
@@ -493,7 +492,7 @@ string_constraintst add_axioms_for_characters_in_integer_string(
     }
     sum=new_sum;
 
-    const equal_exprt premise = axiom_for_has_length(str, size);
+    const equal_exprt premise = length_eq(str, size);
 
     if(!digit_constraints.empty())
     {

--- a/src/solvers/refinement/string_constraint_generator_valueof.cpp
+++ b/src/solvers/refinement/string_constraint_generator_valueof.cpp
@@ -364,7 +364,7 @@ string_constraintst add_axioms_for_correct_number_format(
     is_digit_with_radix(chr, strict_formatting, radix_as_char, radix_ul);
 
   // |str| > 0
-  const exprt non_empty = axiom_for_length_ge(str, from_integer(1, index_type));
+  const exprt non_empty = length_ge(str, from_integer(1, index_type));
   constraints.existential.push_back(non_empty);
 
   if(strict_formatting)
@@ -384,7 +384,7 @@ string_constraintst add_axioms_for_correct_number_format(
   // str[0]='+' or '-' ==> |str| > 1
   const implies_exprt contains_digit(
     or_exprt(starts_with_minus, starts_with_plus),
-    axiom_for_length_ge(str, from_integer(2, index_type)));
+    length_ge(str, from_integer(2, index_type)));
   constraints.existential.push_back(contains_digit);
 
   // |str| <= max_size
@@ -397,7 +397,7 @@ string_constraintst add_axioms_for_correct_number_format(
   {
     /// index < length => is_digit_with_radix(str[index], radix)
     const implies_exprt character_at_index_is_digit(
-      axiom_for_length_ge(str, from_integer(index + 1, index_type)),
+      length_ge(str, from_integer(index + 1, index_type)),
       is_digit_with_radix(
         str[index], strict_formatting, radix_as_char, radix_ul));
     constraints.existential.push_back(character_at_index_is_digit);

--- a/src/solvers/refinement/string_constraint_generator_valueof.cpp
+++ b/src/solvers/refinement/string_constraint_generator_valueof.cpp
@@ -409,8 +409,7 @@ string_constraintst add_axioms_for_correct_number_format(
 
     // no_leading_zero : str[0] = '0' => |str| = 1
     const implies_exprt no_leading_zero(
-      equal_exprt(chr, zero_char),
-      axiom_for_has_length(str, from_integer(1, index_type)));
+      equal_exprt(chr, zero_char), length_eq(str, from_integer(1, index_type)));
     constraints.existential.push_back(no_leading_zero);
 
     // no_leading_zero_after_minus : str[0]='-' => str[1]!='0'

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -182,8 +182,9 @@ inline void validate_expr(const refined_string_exprt &x)
 {
   INVARIANT(x.id() == ID_struct, "refined string exprs are struct");
   validate_operands(x, 2, "refined string expr has length and content fields");
-  INVARIANT(x.length().type().id() == ID_signedbv, "length is an unsigned int");
-  INVARIANT(x.content().type().id() == ID_array, "content is an array");
+  INVARIANT(
+    x.length().type().id() == ID_signedbv, "length should be a signed int");
+  INVARIANT(x.content().type().id() == ID_array, "content should be an array");
 }
 
 #endif

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -55,12 +55,6 @@ public:
 
   // Comparison on the length of the strings
   binary_relation_exprt axiom_for_length_ge(
-    const string_exprt &rhs) const
-  {
-    return binary_relation_exprt(length(), ID_ge, rhs.length());
-  }
-
-  binary_relation_exprt axiom_for_length_ge(
     const exprt &rhs) const
   {
     PRECONDITION(rhs.type() == length().type());
@@ -74,21 +68,9 @@ public:
     return binary_relation_exprt(rhs, ID_lt, length());
   }
 
-  binary_relation_exprt axiom_for_length_gt(
-    const string_exprt &rhs) const
-  {
-    return binary_relation_exprt(rhs.length(), ID_lt, length());
-  }
-
   binary_relation_exprt axiom_for_length_gt(mp_integer i) const
   {
     return axiom_for_length_gt(from_integer(i, length().type()));
-  }
-
-  binary_relation_exprt axiom_for_length_le(
-    const string_exprt &rhs) const
-  {
-    return binary_relation_exprt(length(), ID_le, rhs.length());
   }
 
   binary_relation_exprt axiom_for_length_le(
@@ -101,25 +83,6 @@ public:
   binary_relation_exprt axiom_for_length_le(mp_integer i) const
   {
     return axiom_for_length_le(from_integer(i, length().type()));
-  }
-
-  binary_relation_exprt axiom_for_length_lt(
-    const string_exprt &rhs) const
-  {
-    return binary_relation_exprt(length(), ID_lt, rhs.length());
-  }
-
-  binary_relation_exprt axiom_for_length_lt(
-    const exprt &rhs) const
-  {
-    PRECONDITION(rhs.type() == length().type());
-    return binary_relation_exprt(length(), ID_lt, rhs);
-  }
-
-  equal_exprt axiom_for_has_same_length_as(
-    const string_exprt &rhs) const
-  {
-    return equal_exprt(length(), rhs.length());
   }
 
   equal_exprt axiom_for_has_length(const exprt &rhs) const

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -155,8 +155,6 @@ public:
     return op1();
   }
 
-  static exprt within_bounds(const exprt &idx, const exprt &bound);
-
   friend inline refined_string_exprt &to_string_expr(exprt &expr);
 };
 

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -118,11 +118,6 @@ public:
   {
   }
 
-  explicit refined_string_exprt(const typet &type) : struct_exprt(type)
-  {
-    operands().resize(2);
-  }
-
   refined_string_exprt(
     const exprt &_length,
     const exprt &_content,

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -26,14 +26,17 @@ private:
   {
     return static_cast<child_t *>(this)->length();
   }
+
   const exprt &length() const
   {
     return static_cast<const child_t *>(this)->length();
   }
+
   exprt &content()
   {
     return static_cast<child_t *>(this)->content();
   }
+
   const exprt &content() const
   {
     return static_cast<const child_t *>(this)->content();
@@ -48,54 +51,58 @@ public:
     return index_exprt(content(), i);
   }
 
-  index_exprt operator[] (int i) const
+  index_exprt operator[](int i) const
   {
     return index_exprt(content(), from_integer(i, length().type()));
   }
-
-  // Comparison on the length of the strings
-  binary_relation_exprt axiom_for_length_ge(
-    const exprt &rhs) const
-  {
-    PRECONDITION(rhs.type() == length().type());
-    return binary_relation_exprt(length(), ID_ge, rhs);
-  }
-
-  binary_relation_exprt axiom_for_length_gt(
-    const exprt &rhs) const
-  {
-    PRECONDITION(rhs.type() == length().type());
-    return binary_relation_exprt(rhs, ID_lt, length());
-  }
-
-  binary_relation_exprt axiom_for_length_gt(mp_integer i) const
-  {
-    return axiom_for_length_gt(from_integer(i, length().type()));
-  }
-
-  binary_relation_exprt axiom_for_length_le(
-    const exprt &rhs) const
-  {
-    PRECONDITION(rhs.type() == length().type());
-    return binary_relation_exprt(length(), ID_le, rhs);
-  }
-
-  binary_relation_exprt axiom_for_length_le(mp_integer i) const
-  {
-    return axiom_for_length_le(from_integer(i, length().type()));
-  }
-
-  equal_exprt axiom_for_has_length(const exprt &rhs) const
-  {
-    PRECONDITION(rhs.type() == length().type());
-    return equal_exprt(length(), rhs);
-  }
-
-  equal_exprt axiom_for_has_length(mp_integer i) const
-  {
-    return axiom_for_has_length(from_integer(i, length().type()));
-  }
 };
+
+// Comparison on the length of the strings
+template <typename T>
+binary_relation_exprt axiom_for_length_ge(const T &lhs, const exprt &rhs)
+{
+  PRECONDITION(rhs.type() == lhs.length().type());
+  return binary_relation_exprt(lhs.length(), ID_ge, rhs);
+}
+
+template <typename T>
+binary_relation_exprt axiom_for_length_gt(const T &lhs, const exprt &rhs)
+{
+  PRECONDITION(rhs.type() == lhs.length().type());
+  return binary_relation_exprt(rhs, ID_lt, lhs.length());
+}
+
+template <typename T>
+binary_relation_exprt axiom_for_length_gt(const T &lhs, mp_integer i)
+{
+  return axiom_for_length_gt(lhs, from_integer(i, lhs.length().type()));
+}
+
+template <typename T>
+binary_relation_exprt axiom_for_length_le(const T &lhs, const exprt &rhs)
+{
+  PRECONDITION(rhs.type() == lhs.length().type());
+  return binary_relation_exprt(lhs.length(), ID_le, rhs);
+}
+
+template <typename T>
+binary_relation_exprt axiom_for_length_le(const T &lhs, mp_integer i)
+{
+  return axiom_for_length_le(lhs, from_integer(i, lhs.length().type()));
+}
+
+template <typename T>
+equal_exprt axiom_for_has_length(const T &lhs, const exprt &rhs)
+{
+  PRECONDITION(rhs.type() == lhs.length().type());
+  return equal_exprt(lhs.length(), rhs);
+}
+
+template <typename T>
+equal_exprt axiom_for_has_length(const T &lhs, mp_integer i)
+{
+  return axiom_for_has_length(lhs, from_integer(i, lhs.length().type()));
+}
 
 // Representation of strings as arrays
 class array_string_exprt : public string_exprt<array_string_exprt>, public exprt

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -66,7 +66,7 @@ binary_relation_exprt length_ge(const T &lhs, const exprt &rhs)
 }
 
 template <typename T>
-binary_relation_exprt axiom_for_length_gt(const T &lhs, const exprt &rhs)
+binary_relation_exprt length_gt(const T &lhs, const exprt &rhs)
 {
   PRECONDITION(rhs.type() == lhs.length().type());
   return binary_relation_exprt(rhs, ID_lt, lhs.length());
@@ -75,7 +75,7 @@ binary_relation_exprt axiom_for_length_gt(const T &lhs, const exprt &rhs)
 template <typename T>
 binary_relation_exprt axiom_for_length_gt(const T &lhs, mp_integer i)
 {
-  return axiom_for_length_gt(lhs, from_integer(i, lhs.length().type()));
+  return length_gt(lhs, from_integer(i, lhs.length().type()));
 }
 
 template <typename T>

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -79,7 +79,7 @@ binary_relation_exprt length_gt(const T &lhs, mp_integer i)
 }
 
 template <typename T>
-binary_relation_exprt axiom_for_length_le(const T &lhs, const exprt &rhs)
+binary_relation_exprt length_le(const T &lhs, const exprt &rhs)
 {
   PRECONDITION(rhs.type() == lhs.length().type());
   return binary_relation_exprt(lhs.length(), ID_le, rhs);
@@ -88,7 +88,7 @@ binary_relation_exprt axiom_for_length_le(const T &lhs, const exprt &rhs)
 template <typename T>
 binary_relation_exprt axiom_for_length_le(const T &lhs, mp_integer i)
 {
-  return axiom_for_length_le(lhs, from_integer(i, lhs.length().type()));
+  return length_le(lhs, from_integer(i, lhs.length().type()));
 }
 
 template <typename T>

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -99,7 +99,7 @@ equal_exprt length_eq(const T &lhs, const exprt &rhs)
 }
 
 template <typename T>
-equal_exprt axiom_for_has_length(const T &lhs, mp_integer i)
+equal_exprt length_eq(const T &lhs, mp_integer i)
 {
   return length_eq(lhs, from_integer(i, lhs.length().type()));
 }

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -92,7 +92,7 @@ binary_relation_exprt length_le(const T &lhs, mp_integer i)
 }
 
 template <typename T>
-equal_exprt axiom_for_has_length(const T &lhs, const exprt &rhs)
+equal_exprt length_eq(const T &lhs, const exprt &rhs)
 {
   PRECONDITION(rhs.type() == lhs.length().type());
   return equal_exprt(lhs.length(), rhs);
@@ -101,7 +101,7 @@ equal_exprt axiom_for_has_length(const T &lhs, const exprt &rhs)
 template <typename T>
 equal_exprt axiom_for_has_length(const T &lhs, mp_integer i)
 {
-  return axiom_for_has_length(lhs, from_integer(i, lhs.length().type()));
+  return length_eq(lhs, from_integer(i, lhs.length().type()));
 }
 
 // Representation of strings as arrays

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -59,7 +59,7 @@ public:
 
 // Comparison on the length of the strings
 template <typename T>
-binary_relation_exprt axiom_for_length_ge(const T &lhs, const exprt &rhs)
+binary_relation_exprt length_ge(const T &lhs, const exprt &rhs)
 {
   PRECONDITION(rhs.type() == lhs.length().type());
   return binary_relation_exprt(lhs.length(), ID_ge, rhs);

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -86,7 +86,7 @@ binary_relation_exprt length_le(const T &lhs, const exprt &rhs)
 }
 
 template <typename T>
-binary_relation_exprt axiom_for_length_le(const T &lhs, mp_integer i)
+binary_relation_exprt length_le(const T &lhs, mp_integer i)
 {
   return length_le(lhs, from_integer(i, lhs.length().type()));
 }

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -44,17 +44,6 @@ private:
 
 protected:
   string_exprt() = default;
-
-public:
-  exprt operator[](const exprt &i) const
-  {
-    return index_exprt(content(), i);
-  }
-
-  index_exprt operator[](int i) const
-  {
-    return index_exprt(content(), from_integer(i, length().type()));
-  }
 };
 
 // Comparison on the length of the strings
@@ -126,6 +115,16 @@ public:
   const exprt &content() const
   {
     return *this;
+  }
+
+  exprt operator[](const exprt &i) const
+  {
+    return index_exprt(content(), i);
+  }
+
+  index_exprt operator[](int i) const
+  {
+    return index_exprt(content(), from_integer(i, length().type()));
   }
 };
 

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -16,36 +16,6 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include "refined_string_type.h"
 #include "std_expr.h"
 
-// Given an representation of strings as exprt that implements `length` and
-// `content` this provides additional useful methods.
-template <typename child_t>
-class string_exprt
-{
-private:
-  exprt &length()
-  {
-    return static_cast<child_t *>(this)->length();
-  }
-
-  const exprt &length() const
-  {
-    return static_cast<const child_t *>(this)->length();
-  }
-
-  exprt &content()
-  {
-    return static_cast<child_t *>(this)->content();
-  }
-
-  const exprt &content() const
-  {
-    return static_cast<const child_t *>(this)->content();
-  }
-
-protected:
-  string_exprt() = default;
-};
-
 // Comparison on the length of the strings
 template <typename T>
 binary_relation_exprt length_ge(const T &lhs, const exprt &rhs)
@@ -94,7 +64,7 @@ equal_exprt length_eq(const T &lhs, mp_integer i)
 }
 
 // Representation of strings as arrays
-class array_string_exprt : public string_exprt<array_string_exprt>, public exprt
+class array_string_exprt : public exprt
 {
 public:
   exprt &length()
@@ -141,8 +111,7 @@ inline const array_string_exprt &to_array_string_expr(const exprt &expr)
 }
 
 // Represent strings as a struct with a length field and a content field
-class refined_string_exprt : public struct_exprt,
-                             public string_exprt<refined_string_exprt>
+class refined_string_exprt : public struct_exprt
 {
 public:
   refined_string_exprt() : struct_exprt()

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -73,7 +73,7 @@ binary_relation_exprt length_gt(const T &lhs, const exprt &rhs)
 }
 
 template <typename T>
-binary_relation_exprt axiom_for_length_gt(const T &lhs, mp_integer i)
+binary_relation_exprt length_gt(const T &lhs, mp_integer i)
 {
   return length_gt(lhs, from_integer(i, lhs.length().type()));
 }


### PR DESCRIPTION
This class was used to provide additional utility functions to expressions representing string.
These can be replaced by templates, which make them more reusable and avoid the complicated inheritance that was used.
 

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
