### PR TITLE
Allocate nondet char array

### DIFF
--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -632,17 +632,28 @@ exprt make_nondet_infinite_char_array(
   const array_typet array_type(
     java_char_type(), infinity_exprt(java_int_type()));
   const symbolt data_sym = get_fresh_aux_symbol(
-    array_type,
+    pointer_type(array_type),
     id2string(function_id),
-    "nondet_infinite_array",
+    "nondet_infinite_array_pointer",
     loc,
     ID_java,
     symbol_table);
-  const symbol_exprt data_expr = data_sym.symbol_expr();
-  code.add(code_declt(data_expr), loc);
-  const side_effect_expr_nondett nondet_data(data_expr.type(), loc);
-  code.add(code_assignt(data_expr, nondet_data), loc);
-  return data_expr;
+
+  const exprt data_pointer = data_sym.symbol_expr();
+  std::vector<const symbolt *> created_symbols;
+  allocate_dynamic_object(
+    data_pointer,
+    array_type,
+    symbol_table,
+    loc,
+    function_id,
+    code,
+    created_symbols,
+    false);
+  const exprt nondet_data = side_effect_expr_nondett(array_type, loc);
+  const exprt data = dereference_exprt(data_pointer, array_type);
+  code.add(code_assignt(data, nondet_data), loc);
+  return data;
 }
 
 /// Add a call to a primitive of the string solver, letting it know that

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -617,6 +617,18 @@ codet java_string_library_preprocesst::code_return_function_application(
   return code_returnt(fun_app);
 }
 
+/// Create code allocating object of size `size` and assigning it to `lhs`
+/// \param lhs : pointer which will be allocated
+/// \param size : size of the object
+/// \return code allocation object and assigning `lhs`
+static codet make_allocate_code(const symbol_exprt &lhs, const exprt &size)
+{
+  side_effect_exprt alloc(ID_allocate, lhs.type(), lhs.source_location());
+  alloc.add_to_operands(size);
+  alloc.add_to_operands(false_exprt());
+  return code_assignt(lhs, alloc);
+}
+
 /// Declare a fresh symbol of type array of character with infinite size.
 /// \param symbol_table: the symbol table
 /// \param loc: source location
@@ -639,17 +651,9 @@ exprt make_nondet_infinite_char_array(
     ID_java,
     symbol_table);
 
-  const exprt data_pointer = data_sym.symbol_expr();
-  std::vector<const symbolt *> created_symbols;
-  allocate_dynamic_object(
-    data_pointer,
-    array_type,
-    symbol_table,
-    loc,
-    function_id,
-    code,
-    created_symbols,
-    false);
+  const symbol_exprt data_pointer = data_sym.symbol_expr();
+  code.add(code_declt(data_pointer));
+  code.add(make_allocate_code(data_pointer, array_type.size()));
   const exprt nondet_data = side_effect_expr_nondett(array_type, loc);
   const exprt data = dereference_exprt(data_pointer, array_type);
   code.add(code_assignt(data, nondet_data), loc);

--- a/jbmc/unit/java_bytecode/java_object_factory/gen_nondet_string_init.cpp
+++ b/jbmc/unit/java_bytecode/java_object_factory/gen_nondet_string_init.cpp
@@ -84,22 +84,20 @@ SCENARIO(
           "tmp_object_factory = NONDET(int);",
           CPROVER_PREFIX "assume(tmp_object_factory >= 0);",
           CPROVER_PREFIX "assume(tmp_object_factory <= 20);",
-          "char (*string_data_pointer)[INFINITY()];",
-          "string_data_pointer = "
+          "char (*nondet_infinite_array_pointer)[INFINITY()];",
+          "nondet_infinite_array_pointer = "
             "ALLOCATE(char [INFINITY()], INFINITY(), false);",
-          "char nondet_infinite_array[INFINITY()];",
-          "nondet_infinite_array = NONDET(char [INFINITY()]);",
-          "*string_data_pointer = nondet_infinite_array;",
+          "*nondet_infinite_array_pointer = NONDET(char [INFINITY()]);",
           "int return_array;",
           "return_array = cprover_associate_array_to_pointer_func"
-            "(*string_data_pointer, *string_data_pointer);",
+            "(*nondet_infinite_array_pointer, *nondet_infinite_array_pointer);",
           "int return_array;",
           "return_array = cprover_associate_length_to_array_func"
-            "(*string_data_pointer, tmp_object_factory);",
+            "(*nondet_infinite_array_pointer, tmp_object_factory);",
           "arg = { .@java.lang.Object={ .@class_identifier"
             "=\"java::java.lang.String\" },"
             " .length=tmp_object_factory, "
-            ".data=*string_data_pointer };"};
+            ".data=*nondet_infinite_array_pointer };"};
         // clang-format on
 
         for(std::size_t i = 0;


### PR DESCRIPTION
`make_nondet_infonite_char_array` was not allocating the array as a
dynamic object. This means if this code was added in a function called
several times then the array would get overwritten each time.
This problem was not visible by the string refinement as it associates a
independent array to each string and does not care about memory
allocation, but can be a problem for the interpreter.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
