### PR TITLE
avoid direct access to exprt::opX

### DIFF
--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -92,12 +92,9 @@ exprt build_full_lhs_rec(
   else if(id==ID_byte_extract_little_endian ||
           id==ID_byte_extract_big_endian)
   {
-    exprt tmp=src_original;
-    tmp.op0() = build_full_lhs_rec(
-      prop_conv,
-      ns,
-      to_byte_extract_expr(tmp).op(),
-      to_byte_extract_expr(src_ssa).op());
+    byte_extract_exprt tmp = to_byte_extract_expr(src_original);
+    tmp.op() = build_full_lhs_rec(
+      prop_conv, ns, tmp.op(), to_byte_extract_expr(src_ssa).op());
 
     // re-write into big case-split
   }

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -132,13 +132,20 @@ static bool check_renaming(const exprt &expr)
   if(check_renaming(expr.type()))
     return true;
 
-  if(expr.id()==ID_address_of &&
-     expr.op0().id()==ID_symbol)
-    return check_renaming_l1(expr.op0());
-  else if(expr.id()==ID_address_of &&
-          expr.op0().id()==ID_index)
-    return check_renaming_l1(expr.op0().op0()) ||
-           check_renaming(expr.op0().op1());
+  if(
+    expr.id() == ID_address_of &&
+    to_address_of_expr(expr).object().id() == ID_symbol)
+  {
+    return check_renaming_l1(to_address_of_expr(expr).object());
+  }
+  else if(
+    expr.id() == ID_address_of &&
+    to_address_of_expr(expr).object().id() == ID_index)
+  {
+    const auto index_expr = to_index_expr(to_address_of_expr(expr).object());
+    return check_renaming_l1(index_expr.array()) ||
+           check_renaming(index_expr.index());
+  }
   else if(expr.id()==ID_symbol)
   {
     if(!expr.get_bool(ID_C_SSA_symbol))

--- a/src/goto-symex/symex_dead.cpp
+++ b/src/goto-symex/symex_dead.cpp
@@ -30,7 +30,7 @@ void goto_symext::symex_dead(statet &state)
   state.rename(ssa, ns, goto_symex_statet::L1);
 
   // in case of pointers, put something into the value set
-  if(ns.follow(code.op0().type()).id()==ID_pointer)
+  if(ns.follow(code.symbol().type()).id() == ID_pointer)
   {
     exprt failed = get_failed_symbol(to_symbol_expr(code.symbol()), ns);
 

--- a/src/goto-symex/symex_decl.cpp
+++ b/src/goto-symex/symex_decl.cpp
@@ -28,9 +28,8 @@ void goto_symext::symex_decl(statet &state)
   // two-operand decl not supported here
   // we handle the decl with only one operand
   PRECONDITION(code.operands().size() == 1);
-  PRECONDITION(code.op0().id() == ID_symbol);
 
-  symex_decl(state, to_symbol_expr(code.op0()));
+  symex_decl(state, to_symbol_expr(to_code_decl(code).symbol()));
 }
 
 void goto_symext::symex_decl(statet &state, const symbol_exprt &expr)

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -270,7 +270,7 @@ void goto_symext::dereference_rec(
     }
 
     exprt tmp1;
-    tmp1.swap(expr.op0());
+    tmp1.swap(to_dereference_expr(expr).pointer());
 
     // first make sure there are no dereferences in there
     dereference_rec(tmp1, state, guard, false);

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -435,7 +435,7 @@ void goto_symext::return_assignment(statet &state)
 
   PRECONDITION(code.operands().size() == 1 || frame.return_value.is_nil());
 
-  exprt value = code.op0();
+  exprt value = code.return_value();
 
   if(frame.return_value.is_not_nil())
   {

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -233,11 +233,13 @@ void goto_symext::symex_goto(statet &state)
     // produce new guard symbol
     exprt guard_expr;
 
-    if(new_guard.id()==ID_symbol ||
-       (new_guard.id()==ID_not &&
-        new_guard.operands().size()==1 &&
-        new_guard.op0().id()==ID_symbol))
+    if(
+      new_guard.id() == ID_symbol ||
+      (new_guard.id() == ID_not &&
+       to_not_expr(new_guard).op().id() == ID_symbol))
+    {
       guard_expr=new_guard;
+    }
     else
     {
       symbol_exprt guard_symbol_expr=

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -1101,13 +1101,14 @@ static irep_idt string_from_ns(
   const exprt &tmp=symbol->value;
 
   INVARIANT(
-    tmp.id() == ID_address_of && tmp.operands().size() == 1 &&
-      tmp.op0().id() == ID_index && tmp.op0().operands().size() == 2 &&
-      tmp.op0().op0().id() == ID_string_constant,
+    tmp.id() == ID_address_of &&
+      to_address_of_expr(tmp).object().id() == ID_index &&
+      to_index_expr(to_address_of_expr(tmp).object()).array().id() ==
+        ID_string_constant,
     "symbol table configuration entry `" + id2string(id) +
       "' must be a string constant");
 
-  return tmp.op0().op0().get(ID_value);
+  return to_index_expr(to_address_of_expr(tmp).object()).array().get(ID_value);
 }
 
 static unsigned unsigned_from_ns(

--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -56,8 +56,8 @@ exprt make_binary(const exprt &expr)
     exprt tmp=expr;
     tmp.operands().clear();
     tmp.operands().resize(2);
-    tmp.op0().swap(previous);
-    tmp.op1()=*it;
+    to_binary_expr(tmp).op0().swap(previous);
+    to_binary_expr(tmp).op1() = *it;
     previous.swap(tmp);
   }
 
@@ -126,8 +126,8 @@ exprt is_not_zero(
 
 exprt boolean_negate(const exprt &src)
 {
-  if(src.id()==ID_not && src.operands().size()==1)
-    return src.op0();
+  if(src.id() == ID_not)
+    return to_not_expr(src).op();
   else if(src.is_true())
     return false_exprt();
   else if(src.is_false())

--- a/src/util/ssa_expr.cpp
+++ b/src/util/ssa_expr.cpp
@@ -77,9 +77,10 @@ bool ssa_exprt::can_build_identifier(const exprt &expr)
 {
   if(expr.id()==ID_symbol)
     return true;
-  else if(expr.id()==ID_member ||
-          expr.id()==ID_index)
-    return can_build_identifier(expr.op0());
+  else if(expr.id() == ID_member)
+    return can_build_identifier(to_member_expr(expr).compound());
+  else if(expr.id() == ID_index)
+    return can_build_identifier(to_index_expr(expr).array());
   else
     return false;
 }

--- a/src/util/std_code.cpp
+++ b/src/util/std_code.cpp
@@ -134,9 +134,7 @@ codet &code_blockt::find_last_statement()
     }
     else if(statement==ID_label)
     {
-      DATA_INVARIANT(
-        last->operands().size() == 1, "label must have one operand");
-      last=&(to_code(last->op0()));
+      last = &(to_code_label(*last).code());
     }
     else
       break;


### PR DESCRIPTION
Rationale: accesses to exprt::opX can be memory safety violations; it's
better to cast to higher type, and then use the named access methods.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
