### PR TITLE
Use typecast_exprt::conditional_cast

### DIFF
--- a/src/pointer-analysis/pointer_offset_sum.cpp
+++ b/src/pointer-analysis/pointer_offset_sum.cpp
@@ -24,10 +24,6 @@ exprt pointer_offset_sum(const exprt &a, const exprt &b)
   else if(b.is_zero())
     return a;
 
-  plus_exprt new_offset(a, b);
-
-  if(b.type() != a.type())
-    new_offset.op1().make_typecast(a.type());
-
+  plus_exprt new_offset(a, typecast_exprt::conditional_cast(b, a.type()));
   return std::move(new_offset);
 }

--- a/src/solvers/flattening/functions.cpp
+++ b/src/solvers/flattening/functions.cpp
@@ -42,11 +42,7 @@ exprt functionst::arguments_equal(const exprt::operandst &o1,
   for(std::size_t i=0; i<o1.size(); i++)
   {
     exprt lhs=o1[i];
-    exprt rhs=o2[i];
-
-    if(lhs.type()!=rhs.type())
-      rhs.make_typecast(lhs.type());
-
+    exprt rhs = typecast_exprt::conditional_cast(o2[i], o1[i].type());
     conjuncts[i]=equal_exprt(lhs, rhs);
   }
 


### PR DESCRIPTION
This avoids repeated use of if(t1 != t2) x = typecast_exprt(x, t2) and thus
shortens the code.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
