### PR TITLE
Use more specific return type instead of generic codet/exprt

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -991,7 +991,7 @@ static std::size_t get_bytecode_type_width(const typet &ty)
   return ty.get_size_t(ID_width);
 }
 
-codet java_bytecode_convert_methodt::convert_instructions(
+code_blockt java_bytecode_convert_methodt::convert_instructions(
   const methodt &method,
   const java_class_typet::java_lambda_method_handlest &lambda_method_handles)
 {
@@ -1913,7 +1913,7 @@ codet java_bytecode_convert_methodt::convert_instructions(
   for(auto &block : root_block.statements())
     code.add(block);
 
-  return std::move(code);
+  return code;
 }
 
 codet java_bytecode_convert_methodt::convert_pop(
@@ -1932,7 +1932,7 @@ codet java_bytecode_convert_methodt::convert_pop(
   return c;
 }
 
-codet java_bytecode_convert_methodt::convert_switch(
+code_switcht java_bytecode_convert_methodt::convert_switch(
   java_bytecode_convert_methodt::address_mapt &address_map,
   const exprt::operandst &op,
   const java_bytecode_parse_treet::instructiont::argst &args,
@@ -1983,7 +1983,7 @@ codet java_bytecode_convert_methodt::convert_switch(
   }
 
   code_switch.body() = code_block;
-  return std::move(code_switch);
+  return code_switch;
 }
 
 codet java_bytecode_convert_methodt::convert_monitorenterexit(
@@ -2537,7 +2537,7 @@ void java_bytecode_convert_methodt::convert_new(
   results[0] = tmp;
 }
 
-codet java_bytecode_convert_methodt::convert_putstatic(
+code_blockt java_bytecode_convert_methodt::convert_putstatic(
   const source_locationt &location,
   const exprt &arg0,
   const exprt::operandst &op,
@@ -2566,10 +2566,10 @@ codet java_bytecode_convert_methodt::convert_putstatic(
     bytecode_write_typet::STATIC_FIELD,
     symbol_expr.get_identifier());
   block.add(code_assignt(symbol_expr, op[0]));
-  return std::move(block);
+  return block;
 }
 
-codet java_bytecode_convert_methodt::convert_putfield(
+code_blockt java_bytecode_convert_methodt::convert_putfield(
   const exprt &arg0,
   const exprt::operandst &op)
 {
@@ -2581,7 +2581,7 @@ codet java_bytecode_convert_methodt::convert_putfield(
     bytecode_write_typet::FIELD,
     arg0.get(ID_component_name));
   block.add(code_assignt(to_member(op[0], arg0), op[1]));
-  return std::move(block);
+  return block;
 }
 
 void java_bytecode_convert_methodt::convert_getstatic(
@@ -2698,7 +2698,7 @@ exprt::operandst &java_bytecode_convert_methodt::convert_ushr(
   return results;
 }
 
-codet java_bytecode_convert_methodt::convert_iinc(
+code_blockt java_bytecode_convert_methodt::convert_iinc(
   const exprt &arg0,
   const exprt &arg1,
   const source_locationt &location,
@@ -2722,10 +2722,10 @@ codet java_bytecode_convert_methodt::convert_iinc(
     plus_exprt(variable(arg0, 'i', address, CAST_AS_NEEDED), arg1_int_type));
   block.add(code_assign);
 
-  return std::move(block);
+  return block;
 }
 
-codet java_bytecode_convert_methodt::convert_ifnull(
+code_ifthenelset java_bytecode_convert_methodt::convert_ifnull(
   const java_bytecode_convert_methodt::address_mapt &address_map,
   const exprt::operandst &op,
   const mp_integer &number,
@@ -2740,10 +2740,10 @@ codet java_bytecode_convert_methodt::convert_ifnull(
   code_branch.then_case().add_source_location() =
     address_map.at(label_number).source->source_location;
   code_branch.add_source_location() = location;
-  return std::move(code_branch);
+  return code_branch;
 }
 
-codet java_bytecode_convert_methodt::convert_ifnonull(
+code_ifthenelset java_bytecode_convert_methodt::convert_ifnonull(
   const java_bytecode_convert_methodt::address_mapt &address_map,
   const exprt::operandst &op,
   const mp_integer &number,
@@ -2758,10 +2758,10 @@ codet java_bytecode_convert_methodt::convert_ifnonull(
   code_branch.then_case().add_source_location() =
     address_map.at(label_number).source->source_location;
   code_branch.add_source_location() = location;
-  return std::move(code_branch);
+  return code_branch;
 }
 
-codet java_bytecode_convert_methodt::convert_if(
+code_ifthenelset java_bytecode_convert_methodt::convert_if(
   const java_bytecode_convert_methodt::address_mapt &address_map,
   const exprt::operandst &op,
   const irep_idt &id,
@@ -2780,10 +2780,10 @@ codet java_bytecode_convert_methodt::convert_if(
   code_branch.then_case().add_source_location().set_function(method_id);
   code_branch.add_source_location() = location;
   code_branch.add_source_location().set_function(method_id);
-  return std::move(code_branch);
+  return code_branch;
 }
 
-codet java_bytecode_convert_methodt::convert_if_cmp(
+code_ifthenelset java_bytecode_convert_methodt::convert_if_cmp(
   const java_bytecode_convert_methodt::address_mapt &address_map,
   const irep_idt &statement,
   const exprt::operandst &op,
@@ -2809,7 +2809,7 @@ codet java_bytecode_convert_methodt::convert_if_cmp(
     address_map.at(label_number).source->source_location;
   code_branch.add_source_location() = location;
 
-  return std::move(code_branch);
+  return code_branch;
 }
 
 code_blockt java_bytecode_convert_methodt::convert_ret(
@@ -2864,7 +2864,7 @@ exprt java_bytecode_convert_methodt::convert_aload(
   return java_bytecode_promotion(element);
 }
 
-codet java_bytecode_convert_methodt::convert_store(
+code_blockt java_bytecode_convert_methodt::convert_store(
   const irep_idt &statement,
   const exprt &arg0,
   const exprt::operandst &op,
@@ -2889,10 +2889,10 @@ codet java_bytecode_convert_methodt::convert_store(
   code_assignt assign(var, toassign);
   assign.add_source_location() = location;
   block.add(assign);
-  return std::move(block);
+  return block;
 }
 
-codet java_bytecode_convert_methodt::convert_astore(
+code_blockt java_bytecode_convert_methodt::convert_astore(
   const irep_idt &statement,
   const exprt::operandst &op,
   const source_locationt &location)
@@ -2921,7 +2921,7 @@ codet java_bytecode_convert_methodt::convert_astore(
   code_assignt array_put(element, op[2]);
   array_put.add_source_location() = location;
   block.add(array_put);
-  return std::move(block);
+  return block;
 }
 
 optionalt<exprt> java_bytecode_convert_methodt::convert_invoke_dynamic(

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -268,7 +268,7 @@ protected:
   // conversion
   void convert(const symbolt &class_symbol, const methodt &);
 
-  codet convert_instructions(
+  code_blockt convert_instructions(
     const methodt &,
     const java_class_typet::java_lambda_method_handlest &);
 
@@ -321,12 +321,12 @@ protected:
     const source_locationt &location,
     const exprt &arg0);
 
-  codet convert_astore(
+  code_blockt convert_astore(
     const irep_idt &statement,
     const exprt::operandst &op,
     const source_locationt &location);
 
-  codet convert_store(
+  code_blockt convert_store(
     const irep_idt &statement,
     const exprt &arg0,
     const exprt::operandst &op,
@@ -342,33 +342,33 @@ protected:
     const source_locationt &location,
     const method_offsett address);
 
-  codet convert_if_cmp(
+  code_ifthenelset convert_if_cmp(
     const java_bytecode_convert_methodt::address_mapt &address_map,
     const irep_idt &statement,
     const exprt::operandst &op,
     const mp_integer &number,
     const source_locationt &location) const;
 
-  codet convert_if(
+  code_ifthenelset convert_if(
     const java_bytecode_convert_methodt::address_mapt &address_map,
     const exprt::operandst &op,
     const irep_idt &id,
     const mp_integer &number,
     const source_locationt &location) const;
 
-  codet convert_ifnonull(
+  code_ifthenelset convert_ifnonull(
     const java_bytecode_convert_methodt::address_mapt &address_map,
     const exprt::operandst &op,
     const mp_integer &number,
     const source_locationt &location) const;
 
-  codet convert_ifnull(
+  code_ifthenelset convert_ifnull(
     const java_bytecode_convert_methodt::address_mapt &address_map,
     const exprt::operandst &op,
     const mp_integer &number,
     const source_locationt &location) const;
 
-  codet convert_iinc(
+  code_blockt convert_iinc(
     const exprt &arg0,
     const exprt &arg1,
     const source_locationt &location,
@@ -394,9 +394,9 @@ protected:
     codet &c,
     exprt::operandst &results);
 
-  codet convert_putfield(const exprt &arg0, const exprt::operandst &op);
+  code_blockt convert_putfield(const exprt &arg0, const exprt::operandst &op);
 
-  codet convert_putstatic(
+  code_blockt convert_putstatic(
     const source_locationt &location,
     const exprt &arg0,
     const exprt::operandst &op,
@@ -466,7 +466,7 @@ protected:
 
   void convert_dup2(exprt::operandst &op, exprt::operandst &results);
 
-  codet convert_switch(
+  code_switcht convert_switch(
     java_bytecode_convert_methodt::address_mapt &address_map,
     const exprt::operandst &op,
     const java_bytecode_parse_treet::instructiont::argst &args,

--- a/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
@@ -43,7 +43,7 @@ protected:
   const bool throw_runtime_exceptions;
   message_handlert &message_handler;
 
-  codet throw_exception(
+  code_ifthenelset throw_exception(
     const exprt &cond,
     const source_locationt &original_loc,
     const irep_idt &exc_name);
@@ -61,7 +61,7 @@ protected:
     const exprt &expr,
     const source_locationt &original_loc);
 
-  codet check_class_cast(
+  code_ifthenelset check_class_cast(
     const exprt &class1,
     const exprt &class2,
     const source_locationt &original_loc);
@@ -92,7 +92,7 @@ const std::vector<std::string> exception_needed_classes = {
 /// \param exc_name: the name of the exception to be thrown
 /// \return Returns the code initialising the throwing the
 /// exception
-codet java_bytecode_instrumentt::throw_exception(
+code_ifthenelset java_bytecode_instrumentt::throw_exception(
   const exprt &cond,
   const source_locationt &original_loc,
   const irep_idt &exc_name)
@@ -133,7 +133,7 @@ codet java_bytecode_instrumentt::throw_exception(
   if_code.cond()=cond;
   if_code.then_case() = code_blockt({assign_new, code_expressiont(throw_expr)});
 
-  return std::move(if_code);
+  return if_code;
 }
 
 
@@ -218,7 +218,7 @@ codet java_bytecode_instrumentt::check_array_access(
 /// \return Based on the value of the flag `throw_runtime_exceptions`,
 /// it returns code that either throws an ClassCastException or emits an
 /// assertion checking the subtype relation
-codet java_bytecode_instrumentt::check_class_cast(
+code_ifthenelset java_bytecode_instrumentt::check_class_cast(
   const exprt &class1,
   const exprt &class2,
   const source_locationt &original_loc)
@@ -255,7 +255,7 @@ codet java_bytecode_instrumentt::check_class_cast(
   notequal_exprt op_not_null(null_check_op, null_pointer_exprt(voidptr));
   conditional_check.cond()=std::move(op_not_null);
   conditional_check.then_case()=std::move(check_code);
-  return std::move(conditional_check);
+  return conditional_check;
 }
 
 /// Checks whether `expr` is null and throws NullPointerException/

--- a/jbmc/src/java_bytecode/java_static_initializers.cpp
+++ b/jbmc/src/java_bytecode/java_static_initializers.cpp
@@ -445,7 +445,7 @@ static void create_clinit_wrapper_symbols(
 /// \param pointer_type_selector: used to choose concrete types for abstract-
 ///   typed globals and fields (only needed if nondet-static is true)
 /// \return the body of the static initializer wrapper
-codet get_thread_safe_clinit_wrapper_body(
+code_blockt get_thread_safe_clinit_wrapper_body(
   const irep_idt &function_id,
   symbol_table_baset &symbol_table,
   const bool nondet_static,
@@ -626,7 +626,7 @@ codet get_thread_safe_clinit_wrapper_body(
     function_body.add(code_returnt());
   }
 
-  return std::move(function_body);
+  return function_body;
 }
 
 /// Produces the static initializer wrapper body for the given function.
@@ -641,7 +641,7 @@ codet get_thread_safe_clinit_wrapper_body(
 /// \param pointer_type_selector: used to choose concrete types for abstract-
 ///   typed globals and fields (only needed if nondet-static is true)
 /// \return the body of the static initializer wrapper
-codet get_clinit_wrapper_body(
+code_ifthenelset get_clinit_wrapper_body(
   const irep_idt &function_id,
   symbol_table_baset &symbol_table,
   const bool nondet_static,
@@ -701,7 +701,7 @@ codet get_clinit_wrapper_body(
 
   wrapper_body.then_case() = init_body;
 
-  return std::move(wrapper_body);
+  return wrapper_body;
 }
 
 
@@ -841,7 +841,7 @@ void stub_global_initializer_factoryt::create_stub_global_initializer_symbols(
 /// \param pointer_type_selector: used to choose concrete types for abstract-
 ///   typed globals and fields.
 /// \return synthetic static initializer body.
-codet stub_global_initializer_factoryt::get_stub_initializer_body(
+code_blockt stub_global_initializer_factoryt::get_stub_initializer_body(
   const irep_idt &function_id,
   symbol_table_baset &symbol_table,
   const object_factory_parameterst &object_factory_parameters,
@@ -890,5 +890,5 @@ codet stub_global_initializer_factoryt::get_stub_initializer_body(
       update_in_placet::NO_UPDATE_IN_PLACE);
   }
 
-  return std::move(static_init_body);
+  return static_init_body;
 }

--- a/jbmc/src/java_bytecode/java_static_initializers.h
+++ b/jbmc/src/java_bytecode/java_static_initializers.h
@@ -27,14 +27,14 @@ void create_static_initializer_wrappers(
   synthetic_methods_mapt &synthetic_methods,
   const bool thread_safe);
 
-codet get_thread_safe_clinit_wrapper_body(
+code_blockt get_thread_safe_clinit_wrapper_body(
   const irep_idt &function_id,
   symbol_table_baset &symbol_table,
   const bool nondet_static,
   const object_factory_parameterst &object_factory_parameters,
   const select_pointer_typet &pointer_type_selector);
 
-codet get_clinit_wrapper_body(
+code_ifthenelset get_clinit_wrapper_body(
   const irep_idt &function_id,
   symbol_table_baset &symbol_table,
   const bool nondet_static,
@@ -53,7 +53,7 @@ public:
     const std::unordered_set<irep_idt> &stub_globals_set,
     synthetic_methods_mapt &synthetic_methods);
 
-  codet get_stub_initializer_body(
+  code_blockt get_stub_initializer_body(
     const irep_idt &function_id,
     symbol_table_baset &symbol_table,
     const object_factory_parameterst &object_factory_parameters,

--- a/src/ansi-c/anonymous_member.cpp
+++ b/src/ansi-c/anonymous_member.cpp
@@ -14,7 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/std_types.h>
 #include <util/std_expr.h>
 
-static exprt make_member_expr(
+static member_exprt make_member_expr(
   const exprt &struct_union,
   const struct_union_typet::componentt &component,
   const namespacet &ns)
@@ -35,7 +35,7 @@ static exprt make_member_expr(
     result.type().set(ID_C_constant, true);
   }
 
-  return std::move(result);
+  return result;
 }
 
 exprt get_component_rec(
@@ -55,12 +55,12 @@ exprt get_component_rec(
 
     if(comp.get_name()==component_name)
     {
-      return make_member_expr(struct_union, comp, ns);
+      return std::move(make_member_expr(struct_union, comp, ns));
     }
     else if(comp.get_anonymous() &&
             (type.id()==ID_struct || type.id()==ID_union))
     {
-      exprt tmp=make_member_expr(struct_union, comp, ns);
+      const member_exprt tmp = make_member_expr(struct_union, comp, ns);
       exprt result=get_component_rec(tmp, component_name, ns);
       if(result.is_not_nil())
         return result;

--- a/src/ansi-c/c_nondet_symbol_factory.cpp
+++ b/src/ansi-c/c_nondet_symbol_factory.cpp
@@ -207,7 +207,7 @@ void symbol_factoryt::gen_nondet_init(
 /// \param loc: The location to assign to generated code
 /// \param allow_null: Whether to allow a null value when type is a pointer
 /// \return Returns the symbol_exprt for the symbol created
-exprt c_nondet_symbol_factory(
+symbol_exprt c_nondet_symbol_factory(
   code_blockt &init_code,
   symbol_tablet &symbol_table,
   const irep_idt base_name,
@@ -269,5 +269,5 @@ exprt c_nondet_symbol_factory(
     init_code.move(input_code);
   }
 
-  return std::move(main_symbol_expr);
+  return main_symbol_expr;
 }

--- a/src/ansi-c/c_nondet_symbol_factory.h
+++ b/src/ansi-c/c_nondet_symbol_factory.h
@@ -15,7 +15,7 @@ Author: Diffblue Ltd.
 #include <util/std_code.h>
 #include <util/symbol_table.h>
 
-exprt c_nondet_symbol_factory(
+symbol_exprt c_nondet_symbol_factory(
   code_blockt &init_code,
   symbol_tablet &symbol_table,
   const irep_idt base_name,

--- a/src/goto-programs/string_instrumentation.cpp
+++ b/src/goto-programs/string_instrumentation.cpp
@@ -26,14 +26,12 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/goto_model.h>
 #include <goto-programs/remove_skip.h>
 
-exprt is_zero_string(
-  const exprt &what,
-  bool write)
+predicate_exprt is_zero_string(const exprt &what, bool write)
 {
   predicate_exprt result("is_zero_string");
   result.copy_to_operands(what);
   result.set("lhs", write);
-  return std::move(result);
+  return result;
 }
 
 exprt zero_string_length(

--- a/src/goto-programs/string_instrumentation.h
+++ b/src/goto-programs/string_instrumentation.h
@@ -52,7 +52,7 @@ void string_instrumentation(
   goto_modelt &,
   message_handlert &);
 
-exprt is_zero_string(const exprt &what, bool write=false);
+predicate_exprt is_zero_string(const exprt &what, bool write = false);
 exprt zero_string_length(const exprt &what, bool write=false);
 exprt buffer_size(const exprt &what);
 


### PR DESCRIPTION
If functions can only ever return a single kind of codet/exprt, there is no need
to use the generic codet/exprt and std::move.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
