### PR TITLE
Return converted code by value for consistency

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -408,19 +408,17 @@ protected:
     codet &c,
     exprt::operandst &results);
 
-  void convert_newarray(
+  code_blockt convert_newarray(
     const source_locationt &location,
     const irep_idt &statement,
     const exprt &arg0,
     const exprt::operandst &op,
-    codet &c,
     exprt::operandst &results);
 
-  void convert_multianewarray(
+  code_blockt convert_multianewarray(
     const source_locationt &location,
     const exprt &arg0,
     const exprt::operandst &op,
-    codet &c,
     exprt::operandst &results);
 
   codet &do_exception_handling(


### PR DESCRIPTION
All other methods in this API that always return a value did so via the return
value, and thus this change adds consistency.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
