### PR TITLE
C front-end: cleanup label statement type checking

### DIFF
--- a/regression/cbmc/nested_label1/main.c
+++ b/regression/cbmc/nested_label1/main.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+
+int main()
+{
+  goto label2;
+  goto out;
+label1:
+label2:
+label3:
+  assert(0);
+out:
+  return 0;
+}

--- a/regression/cbmc/nested_label1/test.desc
+++ b/regression/cbmc/nested_label1/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+--
+This test checks that the assertion is reachable despite being wrapped in a
+nested list of labels, and that jumping to a label in the middle of that list is
+handled correctly.

--- a/scripts/delete_failing_smt2_solver_tests
+++ b/scripts/delete_failing_smt2_solver_tests
@@ -262,6 +262,7 @@ rm memory_allocation1/test.desc
 rm memset1/test.desc
 rm memset3/test.desc
 rm mm_io1/test.desc
+rm nested_label1/test.desc
 rm no_nondet_static/test.desc
 rm null1/test.desc
 rm null2/test.desc

--- a/src/ansi-c/c_typecheck_code.cpp
+++ b/src/ansi-c/c_typecheck_code.cpp
@@ -193,26 +193,8 @@ void c_typecheck_baset::typecheck_block(code_blockt &code)
 
   for(auto &code_op : code.statements())
   {
-    if(code_op.is_nil())
-      continue;
-
-    if(code_op.get_statement()==ID_label)
-    {
-      // these may be nested
-      codet *code_ptr=&code_op;
-
-      while(code_ptr->get_statement()==ID_label)
-      {
-        assert(code_ptr->operands().size()==1);
-        code_ptr=&to_code(code_ptr->op0());
-      }
-
-      // codet &label_op=*code_ptr;
-
-      new_ops.move(code_op);
-    }
-    else
-      new_ops.move(code_op);
+    if(code_op.is_not_nil())
+      new_ops.add(std::move(code_op));
   }
 
   code.statements().swap(new_ops.statements());


### PR DESCRIPTION
The code used to contain a loop that had no effect. The regression test confirms
that we properly handle nested labels anyway.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
