### PR TITLE
Simplify and modernise array-is-uniform code

### DIFF
--- a/regression/cbmc/uniform_array1/main.c
+++ b/regression/cbmc/uniform_array1/main.c
@@ -1,0 +1,8 @@
+int main()
+{
+  int A[] = {1, 1};
+  int i;
+  __CPROVER_assert(i < 0 || i > 1 || A[i] == 1, "valid access into array of 1");
+  __CPROVER_assert(A[i] == 1, "possible out-of-bounds access");
+  return 0;
+}

--- a/regression/cbmc/uniform_array1/test.desc
+++ b/regression/cbmc/uniform_array1/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+^\*\* 1 of 2 failed
+--
+^warning: ignoring

--- a/scripts/delete_failing_smt2_solver_tests
+++ b/scripts/delete_failing_smt2_solver_tests
@@ -301,6 +301,7 @@ rm trace_options_json_extended/non-extended.desc
 rm trace_show_code/test.desc
 rm trace_show_function_calls/test.desc
 rm uncaught_exceptions_analysis1/test.desc
+rm uniform_array1/test.desc
 rm union11/union_list.desc
 rm union3/test.desc
 rm union5/test.desc


### PR DESCRIPTION
Having two Booleans that need to be kept in sync makes it harder to reason
about. Instead, use a single Boolean and use C++-11 std::all_of instead of
rolling our own loop.

Additional cleanup: remove unused cassert header.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
