### PR TITLE
Ensure floating-point literals preserve distinction between types with same representation

### DIFF
--- a/src/ansi-c/literals/convert_float_literal.cpp
+++ b/src/ansi-c/literals/convert_float_literal.cpp
@@ -84,13 +84,21 @@ exprt convert_float_literal(const std::string &src)
   else
     UNREACHABLE;
 
-  const constant_exprt result = a.to_expr();
+  constant_exprt result = a.to_expr();
+  // ieee_floatt::to_expr gives us the representation, but doesn't preserve the
+  // distinction between bitwise-identical types such as _Float32 vs. float,
+  // so ensure we preserve that here:
+  result.type() = type;
 
   if(parsed_float.is_imaginary)
   {
     const complex_typet complex_type(type);
-    return complex_exprt(
-      ieee_floatt::zero(type).to_expr(), result, complex_type);
+
+    constant_exprt zero_real_component = ieee_floatt::zero(type).to_expr();
+    // As above, ensure we preserve the exact type of the literal:
+    zero_real_component.type() = type;
+
+    return complex_exprt(zero_real_component, result, complex_type);
   }
 
   return result;


### PR DESCRIPTION
For example, `_Float32 `and `float` are bitwise identical but must be distinguished by `__builtin_types_compatible`.

Bug introduced by https://github.com/diffblue/cbmc/commit/72957a9128d597e3d2f315df39f5396232f2a53c (thanks @hannes-steffenhagen-diffblue), spotted by test `ansi-c/float_constant1`, missed in CI because only evident with GCC >= 7 (requires `_Float32` et al to be real types). Fixes #3271.