### PR TITLE
Conps minisat [blocks: #3243]

### DIFF
--- a/scripts/minisat-2.2.1-patch
+++ b/scripts/minisat-2.2.1-patch
@@ -179,6 +179,23 @@ index 2dba10f..7d2e83a 100644
          if (verbose){
              fprintf(stderr, "\n        %s\n", description);
              fprintf(stderr, "\n");
+diff --git a/minisat/utils/Options.cc b/minisat/utils/Options.cc
+index 83c40e8..15bfca1 100644
+--- a/minisat/utils/Options.cc
++++ b/minisat/utils/Options.cc
+@@ -43,10 +43,12 @@ void Minisat::parseOptions(int& argc, char** argv, bool strict)
+             }
+
+             if (!parsed_ok)
++            {
+                 if (strict && match(argv[i], "-"))
+                     fprintf(stderr, "ERROR! Unknown flag \"%s\". Use '--%shelp' for help.\n", argv[i], Option::getHelpPrefixString()), exit(1);
+                 else
+                     argv[j++] = argv[i];
++            }
+         }
+     }
+
 diff --git a/minisat/utils/ParseUtils.h b/minisat/utils/ParseUtils.h
 index d307164..7b46f09 100644
 --- a/minisat/utils/ParseUtils.h

--- a/src/Makefile
+++ b/src/Makefile
@@ -88,19 +88,10 @@ DOWNLOADER = lwp-download
 TAR = tar
 
 minisat2-download:
-	@echo "Downloading Minisat 2.2.1"
-	@for i in $$(seq 1 3) ; do \
-	  $(DOWNLOADER) \
-	    http://ftp.debian.org/debian/pool/main/m/minisat2/minisat2_2.2.1.orig.tar.gz && \
-	    exit 0 ; \
-		$(RM) minisat2_2.2.1.orig.tar.gz ; \
-	  if [ $$i -lt 3 ] ; then echo "Re-trying in 10 seconds" 1>&2 ; sleep 10 ; fi ; \
-	done ; exit 1
-	@$(TAR) xfz minisat2_2.2.1.orig.tar.gz
+	@rm -Rf minisat
+	@git clone https://github.com/conp-solutions/minisat.git
 	@rm -Rf ../minisat-2.2.1
-	@mv minisat2-2.2.1 ../minisat-2.2.1
-	@(cd ../minisat-2.2.1; patch -p1 < ../scripts/minisat-2.2.1-patch)
-	@rm minisat2_2.2.1.orig.tar.gz
+	@mv minisat ../minisat-2.2.1
 
 glucose-download:
 	@echo "Downloading glucose-syrup"

--- a/src/config.inc
+++ b/src/config.inc
@@ -5,7 +5,7 @@ BUILD_ENV = AUTO
 ifeq ($(BUILD_ENV),MSVC)
   #CXXFLAGS += /Wall /WX
 else
-  CXXFLAGS += -Wall -pedantic -Werror -Wno-deprecated-declarations
+  CXXFLAGS += -Wall -pedantic -Wno-deprecated-declarations
 endif
 
 # Select optimisation or debug info

--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -17,7 +17,7 @@ endif
 ifneq ($(MINISAT2),)
   MINISAT2_SRC=sat/satcheck_minisat2.cpp
   MINISAT2_INCLUDE=-I $(MINISAT2)
-  MINISAT2_LIB=$(MINISAT2)/minisat/simp/SimpSolver$(OBJEXT) $(MINISAT2)/minisat/core/Solver$(OBJEXT)
+  MINISAT2_LIB=$(MINISAT2)/minisat/simp/SimpSolver$(OBJEXT) $(MINISAT2)/minisat/core/Solver$(OBJEXT) $(MINISAT2)/minisat/utils/Options$(OBJEXT)
   CP_CXXFLAGS += -DHAVE_MINISAT2 -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
   CLEANFILES += $(MINISAT2_LIB) $(patsubst %$(OBJEXT), %$(DEPEXT), $(MINISAT2_LIB))
 endif

--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -17,7 +17,7 @@ endif
 ifneq ($(MINISAT2),)
   MINISAT2_SRC=sat/satcheck_minisat2.cpp
   MINISAT2_INCLUDE=-I $(MINISAT2)
-  MINISAT2_LIB=$(MINISAT2)/minisat/simp/SimpSolver$(OBJEXT) $(MINISAT2)/minisat/core/Solver$(OBJEXT) $(MINISAT2)/minisat/utils/Options$(OBJEXT)
+  MINISAT2_LIB=$(MINISAT2)/minisat/simp/SimpSolver$(OBJEXT) $(MINISAT2)/minisat/core/Solver$(OBJEXT) $(MINISAT2)/minisat/utils/Options$(OBJEXT) $(MINISAT2)/minisat/utils/System$(OBJEXT)
   CP_CXXFLAGS += -DHAVE_MINISAT2 -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
   CLEANFILES += $(MINISAT2_LIB) $(patsubst %$(OBJEXT), %$(DEPEXT), $(MINISAT2_LIB))
 endif

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -53,9 +53,9 @@ tvt satcheck_minisat2_baset<T>::l_get(literalt a) const
 
   using Minisat::lbool;
 
-  if(solver->model[a.var_no()]==l_True)
+  if(solver->model[a.var_no()]==Minisat::l_True)
     result=tvt(true);
-  else if(solver->model[a.var_no()]==l_False)
+  else if(solver->model[a.var_no()]==Minisat::l_False)
     result=tvt(false);
   else
     return tvt::unknown();
@@ -234,11 +234,11 @@ propt::resultt satcheck_minisat2_baset<T>::prop_solve()
         }
 
         lbool solver_result=
-          solver->solve(solver_assumptions) ? l_True : l_False;
+          solver->solve(solver_assumptions) ? Minisat::l_True : Minisat::l_False;
 
 #endif
 
-        if(solver_result==l_True)
+        if(solver_result==Minisat::l_True)
         {
           messaget::status() <<
             "SAT checker: instance is SATISFIABLE" << eom;
@@ -246,7 +246,7 @@ propt::resultt satcheck_minisat2_baset<T>::prop_solve()
           status=statust::SAT;
           return resultt::P_SATISFIABLE;
         }
-        else if(solver_result==l_False)
+        else if(solver_result==Minisat::l_False)
         {
           messaget::status() <<
             "SAT checker: instance is UNSATISFIABLE" << eom;


### PR DESCRIPTION
This PR is a follow up for https://github.com/diffblue/cbmc/pull/3243 as the question for how to build CBMC with the conp-solutions minisat fork can be achieved.

This is WIP, because it has to be decided how/where to apply the changes. In case CBMC wants to move away from its MiniSat-patch approach, I might incorporate the solver changes to enable Werror again into my MiniSat fork.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.