### PR TITLE
Wrap XML in Doxygen comment with \code block

### DIFF
--- a/scripts/expected_doxygen_warnings.txt
+++ b/scripts/expected_doxygen_warnings.txt
@@ -155,16 +155,6 @@
   parameter 'clas_hierarchy'
 /cbmc/jbmc/src/java_bytecode/select_pointer_type.h:50: warning: The following parameters of select_pointer_typet::specialize_generics(const pointer_typet &pointer_type, const generic_parameter_specialization_mapt &generic_parameter_specialization_map, generic_parameter_recursion_trackingt &visited_nodes) const are not documented:
   parameter 'visited_nodes'
-/cbmc/src/goto-programs/show_goto_functions_xml.cpp:35: warning: Unsupported xml/html tag <functions> found
-/cbmc/src/goto-programs/show_goto_functions_xml.cpp:36: warning: Unsupported xml/html tag <function> found
-/cbmc/src/goto-programs/show_goto_functions_xml.cpp:37: warning: Unsupported xml/html tag <instructions> found
-/cbmc/src/goto-programs/show_goto_functions_xml.cpp:37: warning: Unsupported xml/html tag <location> found
-/cbmc/src/goto-programs/show_goto_functions_xml.cpp:38: warning: Unsupported xml/html tag <instruction_value> found
-/cbmc/src/goto-programs/show_goto_functions_xml.cpp:39: warning: Unsupported xml/html tag </instruction_value> found
-/cbmc/src/goto-programs/show_goto_functions_xml.cpp:39: warning: Unsupported xml/html tag </instruction> found
-/cbmc/src/goto-programs/show_goto_functions_xml.cpp:39: warning: Unsupported xml/html tag </instructions> found
-/cbmc/src/goto-programs/show_goto_functions_xml.cpp:39: warning: Unsupported xml/html tag </function> found
-/cbmc/src/goto-programs/show_goto_functions_xml.cpp:39: warning: Unsupported xml/html tag </functions> found
 /cbmc/src/solvers/refinement/string_refinement.cpp:2099: warning: argument 'expr' of command @param is not found in the argument list of string_constraintt::universal_only_in_index(const string_constraintt &constr)
 /cbmc/src/solvers/refinement/string_refinement.cpp:2106: warning: The following parameters of string_constraintt::universal_only_in_index(const string_constraintt &constr) are not documented:
   parameter 'constr'

--- a/src/goto-programs/show_goto_functions_xml.cpp
+++ b/src/goto-programs/show_goto_functions_xml.cpp
@@ -33,11 +33,13 @@ show_goto_functions_xmlt::show_goto_functions_xmlt(
 {}
 
 /// Walks through all of the functions in the program and returns an xml object
-/// representing all their functions. Produces output like this: <functions>
+/// representing all their functions. Produces output like this: \code{.xml}
+/// <functions>
 /// <function name=main, is_body_available=true, is_internal=false>
 /// <instructions> <instruction_id=ASSIGN> <location file="main.c" line="14"/>
 /// <instruction_value> // 34 file main.c line 1 s = { 'a', 'b', 'c', 0 };
-/// </instruction_value> </instruction> </instructions> </function> </functions>
+/// </instruction_value> </instruction> </instructions> </function>
+/// </functions> \endcode
 /// \param goto_functions: the goto functions that make up the program
 xmlt show_goto_functions_xmlt::convert(
   const goto_functionst &goto_functions)


### PR DESCRIPTION
This fixes 8 Doxygen warnings about unknown XML tags and adds syntax highlighting to the documentation using the Doxygen `\code{.xml}` and `\endcode` commands.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
