### PR TITLE
Use irept instead of symbol_exprt in java_lambda_method_handlest [blocks: #2310]

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -316,11 +316,11 @@ optionalt<symbolt> java_bytecode_convert_methodt::get_lambda_method_symbol(
   const java_class_typet::java_lambda_method_handlest &lambda_method_handles,
   const size_t index)
 {
-  const symbol_exprt &lambda_method_handle = lambda_method_handles.at(index);
+  const irept &lambda_method_handle = lambda_method_handles.at(index);
   // If the lambda method handle has an unknown type, it does not refer to
-  // any symbol (it is a symbol expression with empty identifier)
-  if(!lambda_method_handle.get_identifier().empty())
-    return symbol_table.lookup_ref(lambda_method_handle.get_identifier());
+  // any symbol (it has an empty identifier)
+  if(!lambda_method_handle.id().empty())
+    return symbol_table.lookup_ref(lambda_method_handle.id());
   return {};
 }
 

--- a/jbmc/src/java_bytecode/java_types.h
+++ b/jbmc/src/java_bytecode/java_types.h
@@ -171,19 +171,28 @@ class java_class_typet:public class_typet
     set(ID_final, is_final);
   }
 
-  typedef std::vector<symbol_exprt> java_lambda_method_handlest;
+  // it may be better to introduce a class like
+  // class java_lambda_method_handlet : private irept
+  // {
+  //   java_lambda_method_handlet(const irep_idt &id) : irept(id)
+  //   {
+  //   }
+  //
+  //   const irep_idt &get_lambda_method_handle() const
+  //   {
+  //     return id();
+  //   }
+  // };
+  using java_lambda_method_handlest = irept::subt;
 
   const java_lambda_method_handlest &lambda_method_handles() const
   {
-    return (const java_lambda_method_handlest &)find(
-             ID_java_lambda_method_handles)
-      .get_sub();
+    return find(ID_java_lambda_method_handles).get_sub();
   }
 
   java_lambda_method_handlest &lambda_method_handles()
   {
-    return (java_lambda_method_handlest &)add(ID_java_lambda_method_handles)
-      .get_sub();
+    return add(ID_java_lambda_method_handles).get_sub();
   }
 
   void add_lambda_method_handle(const irep_idt &identifier)

--- a/jbmc/unit/java-testing-utils/require_type.cpp
+++ b/jbmc/unit/java-testing-utils/require_type.cpp
@@ -527,9 +527,9 @@ require_type::require_lambda_method_handles(
       lambda_method_handles.end(),
       expected_identifiers.begin(),
       [](
-        const symbol_exprt &lambda_method_handle,
+        const irept &lambda_method_handle,
         const std::string &expected_identifier) { //NOLINT
-        return lambda_method_handle.get_identifier() == expected_identifier;
+        return lambda_method_handle.id() == expected_identifier;
       }));
   return lambda_method_handles;
 }

--- a/jbmc/unit/java-testing-utils/require_type.cpp
+++ b/jbmc/unit/java-testing-utils/require_type.cpp
@@ -521,15 +521,14 @@ require_type::require_lambda_method_handles(
     class_type.lambda_method_handles();
   REQUIRE(lambda_method_handles.size() == expected_identifiers.size());
 
-  REQUIRE(
-    std::equal(
-      lambda_method_handles.begin(),
-      lambda_method_handles.end(),
-      expected_identifiers.begin(),
-      [](
-        const irept &lambda_method_handle,
-        const std::string &expected_identifier) { //NOLINT
-        return lambda_method_handle.id() == expected_identifier;
-      }));
+  REQUIRE(std::equal(
+    lambda_method_handles.begin(),
+    lambda_method_handles.end(),
+    expected_identifiers.begin(),
+    [](
+      const irept &lambda_method_handle,
+      const std::string &expected_identifier) { //NOLINT
+      return lambda_method_handle.id() == expected_identifier;
+    }));
   return lambda_method_handles;
 }


### PR DESCRIPTION
A java_lambda_method_handlest really is just a collection of identifiers - there
is no need to put them into a symbol_exprt, instead the identifier can directly
be used as the id of an irept. This reduces the memory footprint, but more
importantly avoids a warning of using a deprecated symbol_exprt constructor.
This warning is well placed, because those symbol_exprt would never have a type
set, which makes them invalid symbol_exprt anyway.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
