### PR TITLE
Well-formedness checking of SSA equation [depends on #3480]

### DIFF
--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -639,6 +639,12 @@ void bmct::perform_symbolic_execution(
   goto_symext::get_goto_functiont get_goto_function)
 {
   symex.symex_from_entry_point_of(get_goto_function, symex_symbol_table);
+
+  if(options.get_bool_option("validate-ssa-equation"))
+  {
+    symex.validate(ns, validation_modet::INVARIANT);
+  }
+
   INVARIANT(
     options.get_bool_option("paths") || path_storage.empty(),
     "Branch points were saved even though we should have been "

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -398,6 +398,11 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
       "symex-coverage-report",
       cmdline.get_value("symex-coverage-report"));
 
+  if(cmdline.isset("validate-ssa-equation"))
+  {
+    options.set_option("validate-ssa-equation", true);
+  }
+
   PARSE_OPTIONS_GOTO_TRACE(cmdline, options);
 }
 

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -706,9 +706,11 @@ void goto_programt::instructiont::validate(
     break;
   case ASSIGN:
     DATA_CHECK(
+      vm,
       code.get_statement() == ID_assign,
       "assign instruction should contain an assign statement");
-    DATA_CHECK(targets.empty(), "assign instruction should not have a target");
+    DATA_CHECK(
+      vm, targets.empty(), "assign instruction should not have a target");
     break;
   case DECL:
     break;

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -61,6 +61,12 @@ struct symex_configt final
   bool partial_loops;
   mp_integer debug_level;
 
+  /// \brief Should the additional validation checks be run?
+  ///
+  /// If this flag is set the checks for renaming (both level1 and level2) are
+  /// executed in the goto_symex_statet (in the assignment method).
+  bool run_validation_checks;
+
   explicit symex_configt(const optionst &options);
 };
 
@@ -454,6 +460,11 @@ public:
       "symex_threaded_step should have been executed at least once before "
       "attempting to read remaining_vccs");
     return _remaining_vccs;
+  }
+
+  void validate(const namespacet &ns, const validation_modet vm) const
+  {
+    target.validate(ns, vm);
   }
 };
 

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -268,6 +268,9 @@ public:
   /// of a GOTO
   bool has_saved_next_instruction;
 
+  /// \brief Should the additional validation checks be run?
+  bool run_validation_checks;
+
 private:
   /// \brief Dangerous, do not use
   ///

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -34,7 +34,8 @@ symex_configt::symex_configt(const optionst &options)
     simplify_opt(options.get_bool_option("simplify")),
     unwinding_assertions(options.get_bool_option("unwinding-assertions")),
     partial_loops(options.get_bool_option("partial-loops")),
-    debug_level(unsafe_string2int(options.get_option("debug-level")))
+    debug_level(unsafe_string2int(options.get_option("debug-level"))),
+    run_validation_checks(options.get_bool_option("validate-ssa-equation"))
 {
 }
 
@@ -306,6 +307,8 @@ void goto_symext::symex_from_entry_point_of(
   }
 
   statet state;
+
+  state.run_validation_checks = symex_config.run_validation_checks;
 
   initialize_entry_point(
     state,

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -267,6 +267,8 @@ public:
       std::ostream &out) const;
 
     void output(std::ostream &out) const;
+
+    void validate(const namespacet &ns, const validation_modet vm) const;
   };
 
   std::size_t count_assertions() const
@@ -321,6 +323,12 @@ public:
         return true;
 
     return false;
+  }
+
+  void validate(const namespacet &ns, const validation_modet vm) const
+  {
+    for(const SSA_stept &step : SSA_steps)
+      step.validate(ns, vm);
   }
 
 protected:

--- a/src/util/ssa_expr.h
+++ b/src/util/ssa_expr.h
@@ -139,6 +139,27 @@ public:
   /* Used to determine whether or not an identifier can be built
    * before trying and getting an exception */
   static bool can_build_identifier(const exprt &src);
+
+  static void check(
+    const exprt &expr,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    DATA_CHECK(
+      vm, !expr.has_operands(), "SSA expression should not have operands");
+    DATA_CHECK(
+      vm, expr.id() == ID_symbol, "SSA expression symbols are symbols");
+    DATA_CHECK(vm, expr.get_bool(ID_C_SSA_symbol), "wrong SSA expression ID");
+  }
+
+  static void validate(
+    const exprt &expr,
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    check(expr, vm);
+    validate_full_expr(
+      static_cast<const exprt &>(expr.find(ID_expression)), ns, vm);
+  }
 };
 
 /*! \brief Cast a generic exprt to an \ref ssa_exprt

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -291,7 +291,7 @@ public:
     const validation_modet vm = validation_modet::INVARIANT)
   {
     DATA_CHECK(
-      code.operands().size() == 2, "assignment must have two operands");
+      vm, code.operands().size() == 2, "assignment must have two operands");
   }
 
   static void validate(
@@ -302,6 +302,7 @@ public:
     check(code, vm);
 
     DATA_CHECK(
+      vm,
       base_type_eq(code.op0().type(), code.op1().type(), ns),
       "lhs and rhs of assignment must have same type");
   }

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -777,7 +777,9 @@ public:
     const validation_modet vm = validation_modet::INVARIANT)
   {
     DATA_CHECK(
-      expr.operands().size() == 2, "binary expression must have two operands");
+      vm,
+      expr.operands().size() == 2,
+      "binary expression must have two operands");
   }
 
   static void validate(
@@ -859,6 +861,7 @@ public:
     binary_exprt::validate(expr, ns, vm);
 
     DATA_CHECK(
+      vm,
       expr.type().id() == ID_bool,
       "result of binary predicate expression should be of type bool");
   }
@@ -901,6 +904,7 @@ public:
 
     // check types
     DATA_CHECK(
+      vm,
       base_type_eq(expr.op0().type(), expr.op1().type(), ns),
       "lhs and rhs of binary relation expression should have same type");
   }

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -1149,7 +1149,8 @@ public:
     const typet &type,
     const validation_modet vm = validation_modet::INVARIANT)
   {
-    DATA_CHECK(!type.get(ID_width).empty(), "bitvector type must have width");
+    DATA_CHECK(
+      vm, !type.get(ID_width).empty(), "bitvector type must have width");
   }
 };
 

--- a/src/util/symbol_table.cpp
+++ b/src/util/symbol_table.cpp
@@ -130,6 +130,7 @@ void symbol_tablet::validate(const validation_modet vm) const
 
     // Check that symbols[id].name == id
     DATA_CHECK_WITH_DIAGNOSTICS(
+      vm,
       symbol.name == symbol_key,
       "Symbol table entry must map to a symbol with the correct identifier",
       "Symbol table key '",
@@ -152,6 +153,7 @@ void symbol_tablet::validate(const validation_modet vm) const
           }) != symbol_base_map.end();
 
       DATA_CHECK_WITH_DIAGNOSTICS(
+        vm,
         base_map_matches_symbol,
         "The base_name of a symbol should map to itself",
         "Symbol table key '",
@@ -174,6 +176,7 @@ void symbol_tablet::validate(const validation_modet vm) const
           }) != symbol_module_map.end();
 
       DATA_CHECK_WITH_DIAGNOSTICS(
+        vm,
         module_map_matches_symbol,
         "Symbol table module map should map to symbol",
         "Symbol table key '",
@@ -188,6 +191,7 @@ void symbol_tablet::validate(const validation_modet vm) const
   for(auto base_map_entry : symbol_base_map)
   {
     DATA_CHECK_WITH_DIAGNOSTICS(
+      vm,
       has_symbol(base_map_entry.second),
       "Symbol table base_name map entries must map to a symbol name",
       "base_name map entry '",
@@ -201,6 +205,7 @@ void symbol_tablet::validate(const validation_modet vm) const
   for(auto module_map_entry : symbol_module_map)
   {
     DATA_CHECK_WITH_DIAGNOSTICS(
+      vm,
       has_symbol(module_map_entry.second),
       "Symbol table module map entries must map to a symbol name",
       "base_name map entry '",

--- a/src/util/validate.h
+++ b/src/util/validate.h
@@ -15,18 +15,13 @@ Author: Daniel Poetzl
 #include "validation_mode.h"
 
 /// This macro takes a condition which denotes a well-formedness criterion on
-/// goto programs, expressions, instructions, etc. When invoking the macro, a
-/// variable named `vm` of type `const validation_modet` should be in scope. It
-/// indicates whether DATA_INVARIANT() is used to check the condition, or if an
-/// exception is thrown when the condition does not hold.
-#define DATA_CHECK(condition, message)                                         \
+/// goto programs, expressions, instructions, etc. The first parameter should be
+/// of type `validate_modet` and indicates whether DATA_INVARIANT() is used to
+/// check the condition, or if an exception is thrown when the condition does
+/// not hold.
+#define DATA_CHECK(vm, condition, message)                                     \
   do                                                                           \
   {                                                                            \
-    static_assert(                                                             \
-      std::is_same<decltype(vm), const validation_modet>::value,               \
-      "when invoking the macro DATA_CHECK(), a variable named `vm` of type "   \
-      "`const validation_modet` should be in scope which indicates the "       \
-      "validation mode (see `validate.h`");                                    \
     switch(vm)                                                                 \
     {                                                                          \
     case validation_modet::INVARIANT:                                          \
@@ -39,14 +34,9 @@ Author: Daniel Poetzl
     }                                                                          \
   } while(0)
 
-#define DATA_CHECK_WITH_DIAGNOSTICS(condition, message, ...)                   \
+#define DATA_CHECK_WITH_DIAGNOSTICS(vm, condition, message, ...)               \
   do                                                                           \
   {                                                                            \
-    static_assert(                                                             \
-      std::is_same<decltype(vm), const validation_modet>::value,               \
-      "when invoking the macro DATA_CHECK_WITH_DIAGNOSTICS(), a variable "     \
-      "named `vm` of type `const validation_modet` should be in scope which "  \
-      "indicates the validation mode (see `validate.h`");                      \
     switch(vm)                                                                 \
     {                                                                          \
     case validation_modet::INVARIANT:                                          \

--- a/src/util/validate_expressions.cpp
+++ b/src/util/validate_expressions.cpp
@@ -15,6 +15,7 @@ Author: Daniel Poetzl
 
 #include "expr.h"
 #include "namespace.h"
+#include "ssa_expr.h"
 #include "std_expr.h"
 #include "validate.h"
 
@@ -31,6 +32,10 @@ void call_on_expr(const exprt &expr, Args &&... args)
   else if(expr.id() == ID_plus)
   {
     CALL_ON_EXPR(plus_exprt);
+  }
+  else if(expr.get_bool(ID_C_SSA_symbol))
+  {
+    CALL_ON_EXPR(ssa_exprt);
   }
   else
   {

--- a/src/util/validation_interface.h
+++ b/src/util/validation_interface.h
@@ -9,11 +9,16 @@ Author: Daniel Poetzl
 #ifndef CPROVER_UTIL_VALIDATION_INTERFACE_H
 #define CPROVER_UTIL_VALIDATION_INTERFACE_H
 
-#define OPT_VALIDATE "(validate-goto-model)"
+#define OPT_VALIDATE                                                           \
+  "(validate-goto-model)"                                                      \
+  "(validate-ssa-equation)"
 
 #define HELP_VALIDATE                                                          \
   " --validate-goto-model        enable additional well-formedness checks on " \
   "the\n"                                                                      \
-  "                              goto program\n"
+  "                              goto program\n"                               \
+  " --validate-ssa-equation      enable additional well-formedness checks on " \
+  "the\n"                                                                      \
+  "                              SSA representation\n"
 
 #endif /* CPROVER_UTIL_VALIDATION_INTERFACE_H */

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -16,6 +16,7 @@ SRC += analyses/ai/ai.cpp \
        analyses/does_remove_const/is_type_at_least_as_const_as.cpp \
        compound_block_locations.cpp \
        goto-programs/goto_trace_output.cpp \
+       goto-symex/ssa_equation.cpp \
        interpreter/interpreter.cpp \
        json/json_parser.cpp \
        path_strategies.cpp \

--- a/unit/goto-symex/module_dependencies.txt
+++ b/unit/goto-symex/module_dependencies.txt
@@ -1,0 +1,3 @@
+goto-symex
+testing-utils
+util

--- a/unit/goto-symex/ssa_equation.cpp
+++ b/unit/goto-symex/ssa_equation.cpp
@@ -1,0 +1,53 @@
+/*******************************************************************\
+
+   Module: Unit tests for symex_target_equation::validate
+
+   Author: Diffblue Ltd.
+
+ \*******************************************************************/
+
+#include <goto-symex/symex_target_equation.h>
+#include <testing-utils/catch.hpp>
+#include <util/arith_tools.h>
+
+SCENARIO("Validation of well-formed SSA steps", "[core][goto-symex][validate]")
+{
+  GIVEN("A program with one function return")
+  {
+    symbol_tablet symbol_table;
+    const typet type1 = signedbv_typet(32);
+    const code_typet code_type({}, type1);
+
+    symbolt fun_symbol;
+    irep_idt fun_name = "foo";
+    fun_symbol.name = fun_name;
+    symbol_exprt fun_foo(fun_name, code_type);
+
+    symex_target_equationt equation;
+    equation.SSA_steps.push_back(symex_target_equationt::SSA_stept());
+    auto &step = equation.SSA_steps.back();
+    step.type = goto_trace_stept::typet::FUNCTION_RETURN;
+    step.called_function = fun_name;
+
+    WHEN("Called function is in symbol table")
+    {
+      symbol_table.insert(fun_symbol);
+      namespacet ns(symbol_table);
+
+      THEN("The consistency check succeeds")
+      {
+        REQUIRE_NOTHROW(equation.validate(ns, validation_modet::INVARIANT));
+      }
+    }
+
+    WHEN("Called function is not in symbol table")
+    {
+      namespacet ns(symbol_table);
+
+      THEN("The consistency check fails")
+      {
+        REQUIRE_THROWS(equation.validate(ns, validation_modet::EXCEPTION));
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is an attempt at introducing well-formedness checking into SSA equation. It follows the process of #3123 by implementing the `validate` method in `SSA_stept` and extending `ssa_exprt` with `check/validate` functionality. Unit tests will be included if the attempt is deemed worthy of pursuing.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
