### PR TITLE
Add source locations to compound blocks

### DIFF
--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -577,6 +577,9 @@ goto_programt::const_targett goto_program2codet::convert_goto_while(
   goto_programt::const_targett after_loop=loop_end;
   ++after_loop;
   assert(after_loop!=goto_program.instructions.end());
+
+  copy_source_location(target, w);
+
   if(target->get_target()==after_loop)
   {
     w.cond()=not_exprt(target->guard);

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -615,6 +615,8 @@ goto_programt::const_targett goto_program2codet::convert_goto_while(
     simplify(i.cond(), ns);
     i.then_case()=code_breakt();
 
+    copy_source_location(target, i);
+
     w.body().move_to_operands(i);
   }
 
@@ -1098,6 +1100,8 @@ goto_programt::const_targett goto_program2codet::convert_goto_if(
   code_ifthenelset i;
   i.then_case()=code_blockt();
 
+  copy_source_location(target, i);
+
   // some nesting of loops and branches we might not be able to deal with
   if(target->is_backwards_goto() ||
       (upper_bound!=goto_program.instructions.end() &&
@@ -1181,6 +1185,8 @@ goto_programt::const_targett goto_program2codet::convert_goto_break_continue(
       simplify(i.cond(), ns);
       i.then_case().swap(cont);
 
+      copy_source_location(target, i);
+
       dest.move_to_operands(i);
     }
     else
@@ -1212,6 +1218,8 @@ goto_programt::const_targett goto_program2codet::convert_goto_break_continue(
     i.cond()=target->guard;
     simplify(i.cond(), ns);
     i.then_case().swap(brk);
+
+    copy_source_location(target, i);
 
     if(i.cond().is_true())
       dest.move_to_operands(i.then_case());
@@ -1277,6 +1285,8 @@ goto_programt::const_targett goto_program2codet::convert_goto_goto(
     i.cond()=target->guard;
     simplify(i.cond(), ns);
     i.then_case().swap(goto_code);
+
+    copy_source_location(target, i);
 
     dest.move_to_operands(i);
   }
@@ -2020,4 +2030,14 @@ void goto_program2codet::cleanup_expr(exprt &expr, bool no_typecast)
       }
     }
   }
+}
+
+void goto_program2codet::copy_source_location(
+  goto_programt::const_targett src,
+  codet &dst)
+{
+  if(src->code.source_location().is_not_nil())
+    dst.add_source_location() = src->code.source_location();
+  else if(src->source_location.is_not_nil())
+    dst.add_source_location() = src->source_location;
 }

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -636,6 +636,8 @@ goto_programt::const_targett goto_program2codet::convert_goto_while(
     w.body().operands().pop_back();
     f.iter().id(ID_side_effect);
 
+    copy_source_location(target, f);
+
     f.body().swap(w.body());
 
     f.swap(w);

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -921,6 +921,8 @@ goto_programt::const_targett goto_program2codet::convert_goto_switch(
   s.value()=to_equal_expr(eq_cand).lhs();
   s.body()=code_blockt();
 
+  copy_source_location(target, s);
+
   // find the cases or fall back to convert_goto_if
   cases_listt cases;
   goto_programt::const_targett first_target=

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -526,6 +526,8 @@ goto_programt::const_targett goto_program2codet::convert_do_while(
   simplify(d.cond(), ns);
   d.body()=code_blockt();
 
+  copy_source_location(loop_end->targets.front(), d);
+
   loop_last_stack.push_back(std::make_pair(loop_end, true));
 
   for( ; target!=loop_end; ++target)
@@ -658,6 +660,8 @@ goto_programt::const_targett goto_program2codet::convert_goto_while(
 
       w.body().operands().pop_back();
       d.body().swap(w.body());
+
+      copy_source_location(target, d);
 
       d.swap(w);
     }

--- a/src/goto-instrument/goto_program2code.h
+++ b/src/goto-instrument/goto_program2code.h
@@ -96,6 +96,8 @@ protected:
   std::unordered_set<irep_idt> type_names_set;
   std::unordered_set<irep_idt> const_removed;
 
+  void copy_source_location(goto_programt::const_targett, codet &dst);
+
   void build_loop_map();
   void build_dead_map();
   void scan_for_varargs();

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -14,6 +14,7 @@ SRC += analyses/ai/ai.cpp \
        analyses/does_remove_const/does_expr_lose_const.cpp \
        analyses/does_remove_const/does_type_preserve_const_correctness.cpp \
        analyses/does_remove_const/is_type_at_least_as_const_as.cpp \
+       compound_block_locations.cpp \
        goto-programs/goto_trace_output.cpp \
        interpreter/interpreter.cpp \
        json/json_parser.cpp \
@@ -90,6 +91,7 @@ BMC_DEPS =../src/cbmc/all_properties$(OBJEXT) \
           ../src/goto-instrument/cover_instrument_mcdc$(OBJEXT) \
           ../src/goto-instrument/cover_instrument_other$(OBJEXT) \
           ../src/goto-instrument/cover_util$(OBJEXT) \
+          ../src/goto-instrument/goto_program2code$(OBJEXT) \
           ../src/goto-instrument/reachability_slicer$(OBJEXT) \
           ../src/goto-instrument/nondet_static$(OBJEXT) \
           ../src/goto-instrument/full_slicer$(OBJEXT) \

--- a/unit/compound_block_locations.cpp
+++ b/unit/compound_block_locations.cpp
@@ -178,6 +178,58 @@ SCENARIO("Compound blocks should have a location")
     "/* 10 */    }                            \n"
     "/* 11 */  }                              \n",
     {{ID_for, 3}, {ID_for, 6}});
+
+  // In the absence of a better place to put it, the source location of a
+  // do-while block is equal to the source location of its first statement.
+
+  checker.check(
+    "/*  1 */  int main()                     \n"
+    "/*  2 */  {                              \n"
+    "/*  3 */    do                           \n"
+    "/*  4 */    {                            \n"
+    "/*  5 */      int x;                     \n"
+    "/*  6 */    } while(1);                  \n"
+    "/*  7 */  }                              \n",
+    {{ID_dowhile, 5}});
+
+  checker.check(
+    "/*  1 */  int main()                     \n"
+    "/*  2 */  {                              \n"
+    "/*  3 */    do                           \n"
+    "/*  4 */    {                            \n"
+    "/*  5 */      int x;                     \n"
+    "/*  6 */      int y;                     \n"
+    "/*  7 */      int z = x + y;             \n"
+    "/*  8 */    } while(1);                  \n"
+    "/*  9 */  }                              \n",
+    {{ID_dowhile, 5}});
+
+  checker.check(
+    "/*  1 */  int main()                     \n"
+    "/*  2 */  {                              \n"
+    "/*  3 */    int x;                       \n"
+    "/*  4 */    do                           \n"
+    "/*  5 */    {                            \n"
+    "/*  6 */      int x;                     \n"
+    "/*  7 */      int y;                     \n"
+    "/*  8 */      int z = x + y;             \n"
+    "/*  9 */    } while(x);                  \n"
+    "/* 10 */  }                              \n",
+    {{ID_dowhile, 6}});
+
+  checker.check(
+    "/*  1 */  int main()                     \n"
+    "/*  2 */  {                              \n"
+    "/*  3 */    int x;                       \n"
+    "/*  4 */    if(x)                        \n"
+    "/*  5 */    {                            \n"
+    "/*  6 */      do                         \n"
+    "/*  7 */      {                          \n"
+    "/*  8 */        int y;                   \n"
+    "/*  9 */      } while(x);                \n"
+    "/* 10 */    }                            \n"
+    "/* 11 */  }                              \n",
+    {{ID_ifthenelse, 4}, {ID_dowhile, 8}});
 }
 
 void compound_block_locationst::check(

--- a/unit/compound_block_locations.cpp
+++ b/unit/compound_block_locations.cpp
@@ -154,6 +154,30 @@ SCENARIO("Compound blocks should have a location")
     "/* 20 */    }                            \n"
     "/* 21 */  }                              \n",
     {{ID_ifthenelse, 4}, {ID_while, 6}, {ID_while, 13}, {ID_while, 15}});
+
+  checker.check(
+    "/*  1 */  int main()                     \n"
+    "/*  2 */  {                              \n"
+    "/*  3 */    for(int i = 0; i < 1; ++i)   \n"
+    "/*  4 */    {                            \n"
+    "/*  5 */      int x;                     \n"
+    "/*  6 */    }                            \n"
+    "/*  7 */  }                              \n",
+    {{ID_for, 3}});
+
+  checker.check(
+    "/*  1 */  int main()                     \n"
+    "/*  2 */  {                              \n"
+    "/*  3 */    for(int i = 0; i < 1; ++i)   \n"
+    "/*  4 */    {                            \n"
+    "/*  5 */      int x;                     \n"
+    "/*  6 */      for(int j = 0; j < 3; ++j) \n"
+    "/*  7 */      {                          \n"
+    "/*  8 */        int y;                   \n"
+    "/*  9 */      }                          \n"
+    "/* 10 */    }                            \n"
+    "/* 11 */  }                              \n",
+    {{ID_for, 3}, {ID_for, 6}});
 }
 
 void compound_block_locationst::check(

--- a/unit/compound_block_locations.cpp
+++ b/unit/compound_block_locations.cpp
@@ -81,6 +81,79 @@ SCENARIO("Compound blocks should have a location")
     "/* 12 */      x = 1;         \n"
     "/* 13 */  }                  \n",
     {{ID_ifthenelse, 4}, {ID_ifthenelse, 6}});
+
+  checker.check(
+    "/*  1 */  int main()                     \n"
+    "/*  2 */  {                              \n"
+    "/*  3 */    while(1)                     \n"
+    "/*  4 */    {                            \n"
+    "/*  5 */      int x = 2;                 \n"
+    "/*  6 */    }                            \n"
+    "/*  7 */  }                              \n",
+    {{ID_while, 3}});
+
+  checker.check(
+    "/*  1 */  int main()                     \n"
+    "/*  2 */  {                              \n"
+    "/*  3 */    while(1)                     \n"
+    "/*  4 */    {                            \n"
+    "/*  5 */      while(1)                   \n"
+    "/*  5 */      {                          \n"
+    "/*  6 */        int x = 1;               \n"
+    "/*  7 */      }                          \n"
+    "/*  8 */    }                            \n"
+    "/*  9 */  }                              \n",
+    {{ID_while, 3}, {ID_while, 5}});
+
+  checker.check(
+    "/*  1 */  int main()                     \n"
+    "/*  2 */  {                              \n"
+    "/*  3 */    while(1)                     \n"
+    "/*  4 */    {                            \n"
+    "/*  5 */      int x;                     \n"
+    "/*  6 */      if(x)                      \n"
+    "/*  7 */        int x = 1;               \n"
+    "/*  8 */    }                            \n"
+    "/*  9 */  }                              \n",
+    {{ID_while, 3}, {ID_ifthenelse, 6}});
+
+  checker.check(
+    "/*  1 */  int main()                     \n"
+    "/*  2 */  {                              \n"
+    "/*  3 */    int x;                       \n"
+    "/*  4 */    if(x)                        \n"
+    "/*  5 */    {                            \n"
+    "/*  6 */      while(1)                   \n"
+    "/*  7 */      {                          \n"
+    "/*  8 */        int y = 1;               \n"
+    "/*  9 */      }                          \n"
+    "/* 10 */    }                            \n"
+    "/* 11 */  }                              \n",
+    {{ID_ifthenelse, 4}, {ID_while, 6}});
+
+  checker.check(
+    "/*  1 */  int main()                     \n"
+    "/*  2 */  {                              \n"
+    "/*  3 */    int x;                       \n"
+    "/*  4 */    if(x)                        \n"
+    "/*  5 */    {                            \n"
+    "/*  6 */      while(1)                   \n"
+    "/*  7 */      {                          \n"
+    "/*  8 */        int y = 1;               \n"
+    "/*  9 */      }                          \n"
+    "/* 10 */    }                            \n"
+    "/* 11 */    else                         \n"
+    "/* 12 */    {                            \n"
+    "/* 13 */      while(1)                   \n"
+    "/* 14 */      {                          \n"
+    "/* 15 */        while(1)                 \n"
+    "/* 16 */        {                        \n"
+    "/* 17 */          int y = 1;             \n"
+    "/* 18 */        }                        \n"
+    "/* 19 */      }                          \n"
+    "/* 20 */    }                            \n"
+    "/* 21 */  }                              \n",
+    {{ID_ifthenelse, 4}, {ID_while, 6}, {ID_while, 13}, {ID_while, 15}});
 }
 
 void compound_block_locationst::check(

--- a/unit/compound_block_locations.cpp
+++ b/unit/compound_block_locations.cpp
@@ -230,6 +230,30 @@ SCENARIO("Compound blocks should have a location")
     "/* 10 */    }                            \n"
     "/* 11 */  }                              \n",
     {{ID_ifthenelse, 4}, {ID_dowhile, 8}});
+
+  checker.check(
+    "/*  1 */  int main()                     \n"
+    "/*  2 */  {                              \n"
+    "/*  3 */    int x;                       \n"
+    "/*  4 */    switch(x)                    \n"
+    "/*  5 */    {                            \n"
+    "/*  6 */    case 1:                      \n"
+    "/*  7 */      int y = 1;                 \n"
+    "/*  8 */      break;                     \n"
+    "/*  9 */    case 2:                      \n"
+    "/* 10 */      int y = 2;                 \n"
+    "/* 11 */      int z = 2;                 \n"
+    "/* 12 */      break;                     \n"
+    "/* 13 */    case 3:                      \n"
+    "/* 14 */      int y = 3;                 \n"
+    "/* 15 */    case 4:                      \n"
+    "/* 16 */      int y = 4;                 \n"
+    "/* 17 */      break;                     \n"
+    "/* 18 */    default:                     \n"
+    "/* 19 */      int y = 5;                 \n"
+    "/* 20 */    }                            \n"
+    "/* 21 */  }                              \n",
+    {{ID_switch, 6}});
 }
 
 void compound_block_locationst::check(

--- a/unit/compound_block_locations.h
+++ b/unit/compound_block_locations.h
@@ -1,0 +1,47 @@
+/// \file Test that goto_program2code adds locations to compound blocks
+///
+/// \author Kareem Khazem <karkhaz@karkhaz.com>
+
+#ifndef CPROVER_COMPOUND_BLOCK_LOCATIONS_H
+#define CPROVER_COMPOUND_BLOCK_LOCATIONS_H
+
+#include <util/irep.h>
+#include <util/std_expr.h>
+
+#include <string>
+
+class compound_block_locationst
+{
+public:
+  compound_block_locationst()
+    : types({
+        {ID_dowhile, "dowhile"},
+        {ID_for, "for"},
+        {ID_ifthenelse, "ifthenelse"},
+        {ID_switch, "switch"},
+        {ID_while, "while"},
+      })
+  {
+  }
+
+  /// For each pair of \ref codet type and line number in expected, check that
+  /// there's a goto-instruction of that type with that line number in prog
+  /// after running goto_program2code on it.
+  void check(
+    const std::string &prog,
+    const std::list<std::pair<const irep_idt, const unsigned>> &expected);
+
+protected:
+  void check_compound_block_locations(
+    const std::string &prog,
+    const std::list<std::pair<const irep_idt, const unsigned>> &expected);
+
+  void recurse_on_block(
+    const exprt &,
+    std::list<std::pair<const irep_idt, const unsigned>> &);
+
+  const std::unordered_map<const irep_idt, const std::string, irep_id_hash>
+    types;
+};
+
+#endif // CPROVER_COMPOUND_BLOCK_LOCATIONS_H

--- a/unit/module_dependencies.txt
+++ b/unit/module_dependencies.txt
@@ -1,6 +1,7 @@
 ansi-c
 cbmc
 cpp
+goto-instrument
 goto-programs
 goto-symex
 json


### PR DESCRIPTION
Prior to this PR, 'compound' block types (like `code_ifthenelset`, `code_whilet`, etc.) did not have a `source_location` when they were synthesized by `goto_program2codet`. This PR gives these code blocks the correct source locations, which are checked in the included unit test.