### PR TITLE
Split parse_list_types into two functions

### DIFF
--- a/jbmc/src/java_bytecode/java_types.cpp
+++ b/jbmc/src/java_bytecode/java_types.cpp
@@ -334,13 +334,39 @@ std::vector<typet> parse_list_types(
   const char opening_bracket,
   const char closing_bracket)
 {
+  // Loop over the types in the given string, parsing each one in turn
+  // and adding to the type_list
+  std::vector<typet> type_list;
+  for(const std::string &raw_type :
+      parse_raw_list_types(src, opening_bracket, closing_bracket))
+  {
+    const typet new_type = java_type_from_string(raw_type, class_name_prefix);
+    INVARIANT(new_type != nil_typet(), "Failed to parse type");
+    type_list.push_back(new_type);
+  }
+  return type_list;
+}
+
+/// Given a substring of a descriptor or signature that contains one or more
+/// types parse out the individual type strings.
+/// \param src: The input string that is wrapped in either ( ) or < >
+/// \param opening_bracket: For checking string is passed in as expected, the
+///   opening bracket (i.e. '(' or '<').
+/// \param closing_bracket: For checking string is passed in as expected, the
+///   closing bracket (i.e. ')' or '>').
+/// \return A vector of strings that represent the bytecode type.
+std::vector<std::string> parse_raw_list_types(
+  const std::string src,
+  const char opening_bracket,
+  const char closing_bracket)
+{
   PRECONDITION(src.size() >= 2);
   PRECONDITION(src[0] == opening_bracket);
   PRECONDITION(src[src.size() - 1] == closing_bracket);
 
   // Loop over the types in the given string, parsing each one in turn
   // and adding to the type_list
-  std::vector<typet> type_list;
+  std::vector<std::string> type_list;
   for(std::size_t i = 1; i < src.size() - 1; i++)
   {
     size_t start = i;
@@ -369,10 +395,7 @@ std::vector<typet> parse_list_types(
     }
 
     std::string sub_str = src.substr(start, i - start + 1);
-    const typet &new_type = java_type_from_string(sub_str, class_name_prefix);
-    INVARIANT(new_type != nil_typet(), "Failed to parse type");
-
-    type_list.push_back(new_type);
+    type_list.emplace_back(sub_str);
   }
   return type_list;
 }

--- a/jbmc/src/java_bytecode/java_types.h
+++ b/jbmc/src/java_bytecode/java_types.h
@@ -362,6 +362,10 @@ size_t find_closing_semi_colon_for_reference_type(
   const std::string src,
   size_t starting_point = 0);
 
+std::vector<std::string> parse_raw_list_types(
+  std::string src,
+  char opening_bracket,
+  char closing_bracket);
 
 bool is_java_array_tag(const irep_idt &tag);
 bool is_valid_java_array(const struct_typet &);


### PR DESCRIPTION
In some situations you might want to know what the bytecode type is and then manually perform some operation afterwards, in this case it's useful to have a method that returns the string representation of the bytecode type.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.