### PR TITLE
Remove codeowners from expected_doxygen_warnings.txt

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -59,5 +59,7 @@
 /jbmc/regression/
 
 /scripts/ @diffblue/devops @thk123 @forejtv @peterschrammel
+/scripts/expected_doxygen_warnings.txt
+
 /.travis.yml @diffblue/devops @thk123 @forejtv @peterschrammel
 /appveyor.yml @diffblue/devops @thk123 @forejtv @peterschrammel


### PR DESCRIPTION
When warnings are removed from expected_doxygen_warnings.txt, it should be adequate for the codeowners of the relevant source files to review the change, and it seems better not to also require the codeowners of the scripts folder.

(Hopefully, we won't generally be _adding_ to the list of expected Doxygen warnings, but we are planning to fix some warnings and remove them from the list.)

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
