### PR TITLE
Adding smallest_unused_suffix cache

### DIFF
--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -22,6 +22,7 @@ Date: June 2006
 #include <util/file_util.h>
 #include <util/get_base_name.h>
 #include <util/suffix.h>
+#include <util/symbol_table_builder.h>
 #include <util/tempdir.h>
 #include <util/unicode.h>
 #include <util/version.h>
@@ -692,29 +693,32 @@ void compilet::add_compiler_specific_defines(configt &config) const
 
 void compilet::convert_symbols(goto_functionst &dest)
 {
+  symbol_table_buildert symbol_table_builder =
+    symbol_table_buildert::wrap(goto_model.symbol_table);
+
   goto_convert_functionst converter(
-    goto_model.symbol_table, get_message_handler());
+    symbol_table_builder, get_message_handler());
 
   // the compilation may add symbols!
 
   symbol_tablet::symbolst::size_type before=0;
 
-  while(before != goto_model.symbol_table.symbols.size())
+  while(before != symbol_table_builder.symbols.size())
   {
-    before = goto_model.symbol_table.symbols.size();
+    before = symbol_table_builder.symbols.size();
 
     typedef std::set<irep_idt> symbols_sett;
     symbols_sett symbols;
 
-    for(const auto &named_symbol : goto_model.symbol_table.symbols)
+    for(const auto &named_symbol : symbol_table_builder.symbols)
       symbols.insert(named_symbol.first);
 
     // the symbol table iterators aren't stable
     for(const auto &symbol : symbols)
     {
       symbol_tablet::symbolst::const_iterator s_it =
-        goto_model.symbol_table.symbols.find(symbol);
-      CHECK_RETURN(s_it != goto_model.symbol_table.symbols.end());
+        symbol_table_builder.symbols.find(symbol);
+      CHECK_RETURN(s_it != symbol_table_builder.symbols.end());
 
       if(
         s_it->second.is_function() && !s_it->second.is_compiled() &&
@@ -722,7 +726,7 @@ void compilet::convert_symbols(goto_functionst &dest)
       {
         debug() << "Compiling " << s_it->first << eom;
         converter.convert_function(s_it->first, dest.function_map[s_it->first]);
-        goto_model.symbol_table.get_writeable_ref(symbol).set_compiled();
+        symbol_table_builder.get_writeable_ref(symbol).set_compiled();
       }
     }
   }

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "goto_convert.h"
 
 #include <util/arith_tools.h>
+#include <util/c_types.h>
 #include <util/cprover_prefix.h>
 #include <util/exception_utils.h>
 #include <util/expr_util.h>
@@ -20,8 +21,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/simplify_expr.h>
 #include <util/std_expr.h>
 #include <util/symbol_table.h>
-
-#include <util/c_types.h>
+#include <util/symbol_table_builder.h>
 
 #include "goto_convert_class.h"
 #include "destructor.h"
@@ -1939,7 +1939,9 @@ void goto_convert(
   message_handlert &message_handler,
   const irep_idt &mode)
 {
-  goto_convertt goto_convert(symbol_table, message_handler);
+  symbol_table_buildert symbol_table_builder =
+    symbol_table_buildert::wrap(symbol_table);
+  goto_convertt goto_convert(symbol_table_builder, message_handler);
   goto_convert.goto_convert(code, dest, mode);
 }
 

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -11,10 +11,11 @@ Date: June 2003
 #include "goto_convert_functions.h"
 
 #include <util/base_type.h>
+#include <util/fresh_symbol.h>
+#include <util/prefix.h>
 #include <util/std_code.h>
 #include <util/symbol_table.h>
-#include <util/prefix.h>
-#include <util/fresh_symbol.h>
+#include <util/symbol_table_builder.h>
 
 #include "goto_inline.h"
 
@@ -217,10 +218,11 @@ void goto_convert(
   goto_modelt &goto_model,
   message_handlert &message_handler)
 {
+  symbol_table_buildert symbol_table_builder =
+    symbol_table_buildert::wrap(goto_model.symbol_table);
+
   goto_convert(
-    goto_model.symbol_table,
-    goto_model.goto_functions,
-    message_handler);
+    symbol_table_builder, goto_model.goto_functions, message_handler);
 }
 
 void goto_convert(
@@ -228,7 +230,11 @@ void goto_convert(
   goto_functionst &functions,
   message_handlert &message_handler)
 {
-  goto_convert_functionst goto_convert_functions(symbol_table, message_handler);
+  symbol_table_buildert symbol_table_builder =
+    symbol_table_buildert::wrap(symbol_table);
+
+  goto_convert_functionst goto_convert_functions(
+    symbol_table_builder, message_handler);
 
   goto_convert_functions.goto_convert(functions);
 }
@@ -239,7 +245,11 @@ void goto_convert(
   goto_functionst &functions,
   message_handlert &message_handler)
 {
-  goto_convert_functionst goto_convert_functions(symbol_table, message_handler);
+  symbol_table_buildert symbol_table_builder =
+    symbol_table_buildert::wrap(symbol_table);
+
+  goto_convert_functionst goto_convert_functions(
+    symbol_table_builder, message_handler);
 
   goto_convert_functions.convert_function(
     identifier, functions.function_map[identifier]);

--- a/src/goto-programs/lazy_goto_functions_map.h
+++ b/src/goto-programs/lazy_goto_functions_map.h
@@ -11,9 +11,10 @@
 #include "goto_functions.h"
 #include "goto_convert_functions.h"
 
-#include <util/message.h>
 #include <langapi/language_file.h>
 #include <util/journalling_symbol_table.h>
+#include <util/message.h>
+#include <util/symbol_table_builder.h>
 
 /// Provides a wrapper for a map of lazily loaded goto_functiont.
 /// This incrementally builds a goto-functions object, while permitting
@@ -142,8 +143,11 @@ private:
   // const first
   reference ensure_function_loaded_internal(const key_type &name) const
   {
+    symbol_table_buildert symbol_table_builder =
+      symbol_table_buildert::wrap(symbol_table);
+
     journalling_symbol_tablet journalling_table =
-      journalling_symbol_tablet::wrap(symbol_table);
+      journalling_symbol_tablet::wrap(symbol_table_builder);
     reference named_function=ensure_entry_converted(name, journalling_table);
     mapped_type function=named_function.second;
     if(processed_functions.count(name)==0)

--- a/src/jsil/jsil_typecheck.h
+++ b/src/jsil/jsil_typecheck.h
@@ -14,9 +14,10 @@ Author: Michael Tautschnig, tautschn@amazon.com
 
 #include <unordered_set>
 
-#include <util/typecheck.h>
 #include <util/namespace.h>
 #include <util/std_code.h>
+#include <util/symbol_table_base.h>
+#include <util/typecheck.h>
 
 class symbol_exprt;
 class codet;
@@ -34,12 +35,12 @@ class jsil_typecheckt:public typecheckt
 {
 public:
   jsil_typecheckt(
-    symbol_tablet &_symbol_table,
-    message_handlert &_message_handler):
-    typecheckt(_message_handler),
-    symbol_table(_symbol_table),
-    ns(symbol_table),
-    proc_name()
+    symbol_table_baset &_symbol_table,
+    message_handlert &_message_handler)
+    : typecheckt(_message_handler),
+      symbol_table(_symbol_table),
+      ns(symbol_table),
+      proc_name()
   {
   }
 
@@ -49,7 +50,7 @@ public:
   virtual void typecheck_expr(exprt &expr);
 
 protected:
-  symbol_tablet &symbol_table;
+  symbol_table_baset &symbol_table;
   const namespacet ns;
   // prefix to variables which is set in typecheck_declaration
   irep_idt proc_name;

--- a/src/linking/linking_class.h
+++ b/src/linking/linking_class.h
@@ -28,13 +28,13 @@ class linkingt:public typecheckt
 {
 public:
   linkingt(
-    symbol_tablet &_main_symbol_table,
-    symbol_tablet &_src_symbol_table,
-    message_handlert &_message_handler):
-    typecheckt(_message_handler),
-    main_symbol_table(_main_symbol_table),
-    src_symbol_table(_src_symbol_table),
-    ns(_main_symbol_table)
+    symbol_table_baset &_main_symbol_table,
+    symbol_table_baset &_src_symbol_table,
+    message_handlert &_message_handler)
+    : typecheckt(_message_handler),
+      main_symbol_table(_main_symbol_table),
+      src_symbol_table(_src_symbol_table),
+      ns(_main_symbol_table)
   {
   }
 
@@ -167,8 +167,8 @@ protected:
     const struct_typet &old_type,
     const struct_typet &new_type);
 
-  symbol_tablet &main_symbol_table;
-  symbol_tablet &src_symbol_table;
+  symbol_table_baset &main_symbol_table;
+  symbol_table_baset &src_symbol_table;
 
   namespacet ns;
 

--- a/src/util/journalling_symbol_table.h
+++ b/src/util/journalling_symbol_table.h
@@ -100,6 +100,11 @@ public:
     return result;
   }
 
+  std::size_t next_unused_suffix(const std::string &prefix) const override
+  {
+    return base_symbol_table.next_unused_suffix(prefix);
+  }
+
   virtual std::pair<symbolt &, bool> insert(symbolt symbol) override
   {
     std::pair<symbolt &, bool> result =

--- a/src/util/namespace.cpp
+++ b/src/util/namespace.cpp
@@ -19,24 +19,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "string2int.h"
 #include "symbol_table.h"
 
-/// Find smallest unused integer i so that prefix + std::to_string(i)
-/// does not exist in the list \p symbols.
-/// \param prefix: A string denoting the prefix we want to find the
-///   smallest suffix of.
-/// \param symbols: The list of symbols we look in for.
-/// \return The small unused suffix size.
-static std::size_t smallest_unused_suffix(
-  const std::string &prefix,
-  const symbol_tablet::symbolst &symbols)
-{
-  std::size_t max_nr = 0;
-
-  while(symbols.find(prefix + std::to_string(max_nr)) != symbols.end())
-    ++max_nr;
-
-  return max_nr;
-}
-
 namespace_baset::~namespace_baset()
 {
 }
@@ -168,10 +150,10 @@ std::size_t namespacet::smallest_unused_suffix(const std::string &prefix) const
   std::size_t m = 0;
 
   if(symbol_table1!=nullptr)
-    m = std::max(m, ::smallest_unused_suffix(prefix, symbol_table1->symbols));
+    m = std::max(m, symbol_table1->smallest_unused_suffix(prefix));
 
   if(symbol_table2!=nullptr)
-    m = std::max(m, ::smallest_unused_suffix(prefix, symbol_table2->symbols));
+    m = std::max(m, symbol_table2->smallest_unused_suffix(prefix));
 
   return m;
 }
@@ -221,7 +203,7 @@ multi_namespacet::smallest_unused_suffix(const std::string &prefix) const
   std::size_t m = 0;
 
   for(const auto &st : symbol_table_list)
-    m = std::max(m, ::smallest_unused_suffix(prefix, st->symbols));
+    m = std::max(m, st->smallest_unused_suffix(prefix));
 
   return m;
 }

--- a/src/util/namespace.cpp
+++ b/src/util/namespace.cpp
@@ -150,10 +150,10 @@ std::size_t namespacet::smallest_unused_suffix(const std::string &prefix) const
   std::size_t m = 0;
 
   if(symbol_table1!=nullptr)
-    m = std::max(m, symbol_table1->smallest_unused_suffix(prefix));
+    m = std::max(m, symbol_table1->next_unused_suffix(prefix));
 
   if(symbol_table2!=nullptr)
-    m = std::max(m, symbol_table2->smallest_unused_suffix(prefix));
+    m = std::max(m, symbol_table2->next_unused_suffix(prefix));
 
   return m;
 }
@@ -203,7 +203,7 @@ multi_namespacet::smallest_unused_suffix(const std::string &prefix) const
   std::size_t m = 0;
 
   for(const auto &st : symbol_table_list)
-    m = std::max(m, st->smallest_unused_suffix(prefix));
+    m = std::max(m, st->next_unused_suffix(prefix));
 
   return m;
 }

--- a/src/util/namespace.h
+++ b/src/util/namespace.h
@@ -26,6 +26,7 @@ class c_enum_typet;
 class union_tag_typet;
 class struct_tag_typet;
 class c_enum_tag_typet;
+class symbol_table_baset;
 
 /// Basic interface for a namespace. This is not used
 /// in practice, as the one being used is \ref namespacet
@@ -93,20 +94,20 @@ class namespacet:public namespace_baset
 {
 public:
   // constructors
-  explicit namespacet(const symbol_tablet &_symbol_table)
+  explicit namespacet(const symbol_table_baset &_symbol_table)
   { symbol_table1=&_symbol_table; symbol_table2=nullptr; }
 
   namespacet(
-    const symbol_tablet &_symbol_table1,
-    const symbol_tablet &_symbol_table2)
+    const symbol_table_baset &_symbol_table1,
+    const symbol_table_baset &_symbol_table2)
   {
     symbol_table1=&_symbol_table1;
     symbol_table2=&_symbol_table2;
   }
 
   namespacet(
-    const symbol_tablet *_symbol_table1,
-    const symbol_tablet *_symbol_table2)
+    const symbol_table_baset *_symbol_table1,
+    const symbol_table_baset *_symbol_table2)
   {
     symbol_table1=_symbol_table1;
     symbol_table2=_symbol_table2;
@@ -122,13 +123,13 @@ public:
   std::size_t smallest_unused_suffix(const std::string &prefix) const override;
 
   /// Return first symbol table registered with the namespace.
-  const symbol_tablet &get_symbol_table() const
+  const symbol_table_baset &get_symbol_table() const
   {
     return *symbol_table1;
   }
 
 protected:
-  const symbol_tablet *symbol_table1, *symbol_table2;
+  const symbol_table_baset *symbol_table1, *symbol_table2;
 };
 
 /// A multi namespace is essentially a namespace,
@@ -143,8 +144,8 @@ public:
   {
   }
 
-  explicit multi_namespacet(
-    const symbol_tablet &symbol_table):namespacet(nullptr, nullptr)
+  explicit multi_namespacet(const symbol_table_baset &symbol_table)
+    : namespacet(nullptr, nullptr)
   {
     add(symbol_table);
   }
@@ -161,13 +162,13 @@ public:
   /// is working with.
   /// \param symbol_table: Reference to the symbol table to be added to this
   /// namespace.
-  void add(const symbol_tablet &symbol_table)
+  void add(const symbol_table_baset &symbol_table)
   {
     symbol_table_list.push_back(&symbol_table);
   }
 
 protected:
-  typedef std::vector<const symbol_tablet *> symbol_table_listt;
+  typedef std::vector<const symbol_table_baset *> symbol_table_listt;
   symbol_table_listt symbol_table_list;
 };
 

--- a/src/util/symbol_table_base.h
+++ b/src/util/symbol_table_base.h
@@ -48,15 +48,22 @@ public:
   /// does not exist in the list \p symbols.
   /// \param prefix: A string denoting the prefix we want to find the
   ///   smallest suffix of.
+  /// \param start_number: The starting suffix number to search from.
   /// \return The small unused suffix size.
-  std::size_t smallest_unused_suffix(const std::string &prefix) const
+  std::size_t smallest_unused_suffix(
+      const std::string &prefix,
+      std::size_t start_number) const
   {
-    std::size_t max_nr = 0;
+    while(this->symbols.find(prefix + std::to_string(start_number)) != symbols.end())
+      ++start_number;
 
-    while(this->symbols.find(prefix + std::to_string(max_nr)) != symbols.end())
-      ++max_nr;
+    return start_number;
+  }
 
-    return max_nr;
+  virtual std::size_t smallest_unused_suffix(
+      const std::string &prefix) const
+  {
+    return smallest_unused_suffix(prefix, 0);
   }
 
   /// Permits implicit cast to const symbol_tablet &

--- a/src/util/symbol_table_base.h
+++ b/src/util/symbol_table_base.h
@@ -50,20 +50,19 @@ public:
   ///   smallest suffix of.
   /// \param start_number: The starting suffix number to search from.
   /// \return The small unused suffix size.
-  std::size_t smallest_unused_suffix(
-      const std::string &prefix,
-      std::size_t start_number) const
+  std::size_t
+  next_unused_suffix(const std::string &prefix, std::size_t start_number) const
   {
-    while(this->symbols.find(prefix + std::to_string(start_number)) != symbols.end())
+    while(this->symbols.find(prefix + std::to_string(start_number)) !=
+          symbols.end())
       ++start_number;
 
     return start_number;
   }
 
-  virtual std::size_t smallest_unused_suffix(
-      const std::string &prefix) const
+  virtual std::size_t next_unused_suffix(const std::string &prefix) const
   {
-    return smallest_unused_suffix(prefix, 0);
+    return next_unused_suffix(prefix, 0);
   }
 
   /// Permits implicit cast to const symbol_tablet &

--- a/src/util/symbol_table_base.h
+++ b/src/util/symbol_table_base.h
@@ -44,7 +44,21 @@ public:
 
   virtual ~symbol_table_baset();
 
-public:
+  /// Find smallest unused integer i so that prefix + std::to_string(i)
+  /// does not exist in the list \p symbols.
+  /// \param prefix: A string denoting the prefix we want to find the
+  ///   smallest suffix of.
+  /// \return The small unused suffix size.
+  std::size_t smallest_unused_suffix(const std::string &prefix) const
+  {
+    std::size_t max_nr = 0;
+
+    while(this->symbols.find(prefix + std::to_string(max_nr)) != symbols.end())
+      ++max_nr;
+
+    return max_nr;
+  }
+
   /// Permits implicit cast to const symbol_tablet &
   operator const symbol_tablet &() const
   {

--- a/src/util/symbol_table_builder.h
+++ b/src/util/symbol_table_builder.h
@@ -1,0 +1,110 @@
+/// Author: Diffblue Ltd.
+
+// \file Contains a symbol table wrapper that keeps track of suffixes
+// that have been used for their prefix
+
+#ifndef CPROVER_UTIL_SYMBOL_TABLE_BUILDER_H
+#define CPROVER_UTIL_SYMBOL_TABLE_BUILDER_H
+
+#include "symbol_table_base.h"
+
+/// Wrapper around a symbol table that keeps track of suffixes for faster
+/// calculation of the smallest unused suffix.
+class symbol_table_buildert : public symbol_table_baset
+{
+private:
+  symbol_table_baset &base_symbol_table;
+  mutable std::map<std::string, std::size_t> next_free_suffix_for_prefix;
+
+public:
+  explicit symbol_table_buildert(symbol_table_baset &base_symbol_table)
+    : symbol_table_baset(
+        base_symbol_table.symbols,
+        base_symbol_table.symbol_base_map,
+        base_symbol_table.symbol_module_map),
+      base_symbol_table(base_symbol_table)
+  {
+  }
+
+  symbol_table_buildert(symbol_table_buildert &&other)
+    : symbol_table_baset(
+        other.symbols,
+        other.symbol_base_map,
+        other.symbol_module_map),
+      base_symbol_table(other.base_symbol_table)
+  {
+  }
+
+  symbol_table_buildert(const symbol_table_buildert &) = delete;
+  symbol_table_buildert &operator=(const symbol_table_buildert &) = delete;
+  symbol_table_buildert &operator=(symbol_table_buildert &&) = default;
+
+  static symbol_table_buildert wrap(symbol_table_baset &base_symbol_table)
+  {
+    return symbol_table_buildert(base_symbol_table);
+  }
+
+  const symbol_tablet &get_symbol_table() const override
+  {
+    return base_symbol_table.get_symbol_table();
+  }
+
+  void erase(const symbolst::const_iterator &entry) override
+  {
+    base_symbol_table.erase(entry);
+  }
+
+  void clear() override
+  {
+    base_symbol_table.clear();
+    next_free_suffix_for_prefix.clear();
+  }
+
+  bool move(symbolt &symbol, symbolt *&new_symbol) override
+  {
+    return base_symbol_table.move(symbol, new_symbol);
+  }
+
+  symbolt *get_writeable(const irep_idt &identifier) override
+  {
+    return base_symbol_table.get_writeable(identifier);
+  }
+
+  std::pair<symbolt &, bool> insert(symbolt symbol) override
+  {
+    return base_symbol_table.insert(std::move(symbol));
+  }
+
+  iteratort begin() override
+  {
+    return base_symbol_table.begin();
+  }
+
+  iteratort end() override
+  {
+    return base_symbol_table.end();
+  }
+
+  /// Try to find the next free identity for the passed-in prefix in
+  /// this symbol table.
+  /// \remark
+  ///     This method needs to generate names deterministically in regards
+  ///     to operations that generate the same prefix (and any other operation
+  ///     shouldn't affect this).
+  ///
+  ///     Due to this requirement we don't do anything fancy in regards to
+  ///     attempting to find the absolute earliest free suffix if one has been
+  ///     deleted, only the next free increment from our last stored value.
+  std::size_t next_unused_suffix(const std::string &prefix) const override
+  {
+    // Check if we have an entry for this particular suffix, if not,
+    // create baseline.
+    auto suffix_iter = next_free_suffix_for_prefix.insert({prefix, 0}).first;
+    std::size_t free_suffix =
+      base_symbol_table.next_unused_suffix(prefix, suffix_iter->second);
+    suffix_iter->second = free_suffix + 1;
+    return free_suffix;
+  }
+};
+
+#endif // CPROVER_UTIL_SYMBOL_TABLE_BUILDER_H


### PR DESCRIPTION
This just speeds up symbol name generation in situations where there are large amounts of symbols already existing with the same prefix. A similar approach to the journalling_symbol_tablet in how it works - you just wrap any current symbol table, and as long as that instance lasts it'll store what the next available index is so usually you'll only need to do a minimal amount of finds to get the next free suffix.

It doesn't go overboard with trying to work out if there are any holes in the symbol table that we could re-use because it's essential that each suffix + prefix combo be predictable, so only clears the cache when you clear the whole symbol table.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
