### PR TITLE
Add Doxygen version check

### DIFF
--- a/doc/architectural/compilation-and-development.md
+++ b/doc/architectural/compilation-and-development.md
@@ -197,7 +197,9 @@ The doxygen documentation can be [accessed online](http://cprover.diffblue.com).
 To build it locally, run `scripts/run_doxygen.sh`.  HTML output will be created
 in `doc/html/`. The index page is `doc/html/index.html`.  This script will
 filter out expected warning messages from doxygen, so that new problems are more
-obvious.  In the event that any change fixes an old warning, then the
+obvious.  It is important to use the correct version of doxygen, as specified
+in `run_doxygen.sh`, so that there are no unexpected changes to the list of
+expected warnings.  In the event that any change fixes an old warning, then the 
 corresponding line(s) should be deleted from
 `scripts/expected_doxygen_warnings.txt`.  We want to avoid adding any more
 warnings to this list of expected warnings, but that can be done to work around

--- a/scripts/run_doxygen.sh
+++ b/scripts/run_doxygen.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# Check doxygen version
+EXPECTED_VERSION="1.8.14"
+doxygen --version | grep -x $EXPECTED_VERSION > /dev/null
+if [ $? -ne 0 ]
+then
+  echo "WARNING: Using wrong version of doxygen.\
+  The list of expected warnings is for version $EXPECTED_VERSION."
+fi
+
+# Run doxygen and filter warnings
 SCRIPT_FOLDER=`dirname $0`
 cd $SCRIPT_FOLDER/../src
 doxygen 2>&1 | ../scripts/filter_expected_warnings.py ../scripts/expected_doxygen_warnings.txt


### PR DESCRIPTION
The warnings produced by doxygen are different for different versions of doxygen, so it is important, when comparing a list of expected warnings, to use the right version of doxygen.

This PR adds a version check in ./scripts/run_doxygen.sh, and also adds a sentence to the documentation about using the correct version.


<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
