### PR TITLE
to_bitvector_type must not be used on enum types

### DIFF
--- a/regression/cbmc/enum7/main.c
+++ b/regression/cbmc/enum7/main.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+
+enum E
+{
+  A = 1,
+  B = 2
+};
+
+int main()
+{
+  enum E array[2] = {A, B};
+  unsigned *p = array;
+  assert(*p == 1);
+  return 0;
+}

--- a/regression/cbmc/enum7/test.desc
+++ b/regression/cbmc/enum7/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -1558,24 +1558,33 @@ optionalt<std::string> simplify_exprt::expr2bits(
 
   if(expr.id()==ID_constant)
   {
+    const auto &value = to_constant_expr(expr).get_value();
+
     if(type.id()==ID_unsignedbv ||
        type.id()==ID_signedbv ||
-       type.id()==ID_c_enum ||
-       type.id()==ID_c_enum_tag ||
        type.id()==ID_floatbv ||
        type.id()==ID_fixedbv)
     {
       const auto width = to_bitvector_type(type).get_width();
-      const auto &bvrep = to_constant_expr(expr).get_value();
 
       endianness_mapt map(type, little_endian, ns);
 
       std::string result(width, ' ');
 
       for(std::string::size_type i = 0; i < width; ++i)
-        result[map.map_bit(i)] = get_bvrep_bit(bvrep, width, i) ? '1' : '0';
+        result[map.map_bit(i)] = get_bvrep_bit(value, width, i) ? '1' : '0';
 
       return result;
+    }
+    else if(type.id() == ID_c_enum_tag)
+    {
+      const typet &c_enum_type = ns.follow_tag(to_c_enum_tag_type(type));
+      return expr2bits(constant_exprt(value, c_enum_type), little_endian);
+    }
+    else if(type.id() == ID_c_enum)
+    {
+      return expr2bits(
+        constant_exprt(value, to_c_enum_type(type).subtype()), little_endian);
     }
   }
   else if(expr.id()==ID_union)


### PR DESCRIPTION
We need to resolve the tag type and look into the subtype.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
