### PR TITLE
show-properties: do not skip functions marked for inlining

### DIFF
--- a/regression/cbmc/show_properties1/main.c
+++ b/regression/cbmc/show_properties1/main.c
@@ -1,0 +1,11 @@
+inline int foo()
+{
+  int *p;
+  return *p;
+}
+
+int main()
+{
+  foo();
+  return 0;
+}

--- a/regression/cbmc/show_properties1/test.desc
+++ b/regression/cbmc/show_properties1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--pointer-check --show-properties
+^EXIT=0$
+^SIGNAL=0$
+^Property foo.pointer_dereference.1:$
+--
+^warning: ignoring

--- a/src/goto-programs/show_properties.cpp
+++ b/src/goto-programs/show_properties.cpp
@@ -152,8 +152,7 @@ void show_properties_json(
   json_arrayt json_properties;
 
   for(const auto &fct : goto_functions.function_map)
-    if(!fct.second.is_inlined())
-      convert_properties_json(json_properties, ns, fct.first, fct.second.body);
+    convert_properties_json(json_properties, ns, fct.first, fct.second.body);
 
   json_objectt json_result;
   json_result["properties"] = json_properties;
@@ -170,8 +169,7 @@ void show_properties(
     show_properties_json(ns, message_handler, goto_functions);
   else
     for(const auto &fct : goto_functions.function_map)
-      if(!fct.second.is_inlined())
-        show_properties(ns, fct.first, message_handler, ui, fct.second.body);
+      show_properties(ns, fct.first, message_handler, ui, fct.second.body);
 }
 
 void show_properties(


### PR DESCRIPTION
As of f443b1815e34bb we don't do (partial) inlining by default anymore. Thus
show-properties ended up with incomplete output.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
