### PR TITLE
Remove unused left-hand side e2 [blocks: #2310]

### DIFF
--- a/unit/util/irep.cpp
+++ b/unit/util/irep.cpp
@@ -139,7 +139,7 @@ SCENARIO("irept_memory", "[core][utils][irept]")
       REQUIRE(irep.find("a_new_element").id() == "some_id");
 
       irept irep2("second_irep");
-      irept &e2 = irep.add("a_new_element", irep2);
+      irep.add("a_new_element", irep2);
       REQUIRE(irep.find("a_new_element").id() == "second_irep");
       REQUIRE(irep.get_named_sub().size() == 1);
 


### PR DESCRIPTION
The subsequent steps intentionally use `find` instead of using the available
reference.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
