### PR TITLE
Do not shadow local variable type [blocks: #2310]

### DIFF
--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -668,11 +668,11 @@ bool simplify_exprt::simplify_object_size(exprt &expr)
 
       if(size.is_not_nil())
       {
-        typet type=expr.type();
+        const typet &expr_type = expr.type();
 
-        if(size.type()!=type)
+        if(size.type() != expr_type)
         {
-          size.make_typecast(type);
+          size.make_typecast(expr_type);
           simplify_node(size);
         }
 


### PR DESCRIPTION
"type" is already used to refer to expr.op0().op0().type(), do not also use it
to refer to expr.type().

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
