### PR TITLE
Do not shadow local variables solvers, pc [blocks: #2310]

### DIFF
--- a/unit/path_strategies.cpp
+++ b/unit/path_strategies.cpp
@@ -376,15 +376,16 @@ void _check_with_strategy(
   ret = cbmc_parse_optionst::get_goto_program(gm, opts, cmdline, log, mh);
   REQUIRE(ret == -1);
 
-  cbmc_solverst solvers(opts, gm.get_symbol_table(), mh, false);
-  std::unique_ptr<cbmc_solverst::solvert> cbmc_solver = solvers.get_solver();
-  prop_convt &pc = cbmc_solver->prop_conv();
+  cbmc_solverst initial_solvers(opts, gm.get_symbol_table(), mh, false);
+  std::unique_ptr<cbmc_solverst::solvert> cbmc_solver =
+    initial_solvers.get_solver();
+  prop_convt &initial_pc = cbmc_solver->prop_conv();
   std::function<bool(void)> callback = []() { return false; };
 
   safety_checkert::resultt overall_result = safety_checkert::resultt::SAFE;
   std::size_t expected_results_cnt = 0;
 
-  bmct bmc(opts, gm.get_symbol_table(), mh, pc, *worklist, callback);
+  bmct bmc(opts, gm.get_symbol_table(), mh, initial_pc, *worklist, callback);
   safety_checkert::resultt tmp_result = bmc.run(gm);
 
   if(tmp_result != safety_checkert::resultt::PAUSED)


### PR DESCRIPTION
Instead rename the outer variant to initial_solvers, initial_pc.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
