### PR TITLE
Avoid warning about result_fd being possibly uninitialized [blocks: #2310]

### DIFF
--- a/src/util/run.cpp
+++ b/src/util/run.cpp
@@ -53,9 +53,8 @@ using fdt = int;
 /// open given file to replace either stdin, stderr, stdout
 static fdt stdio_redirection(int fd, const std::string &file)
 {
-  fdt result_fd;
-
 #ifdef _WIN32
+  fdt result_fd = INVALID_HANDLE_VALUE;
   std::string name;
 
   SECURITY_ATTRIBUTES SecurityAttributes;
@@ -142,7 +141,7 @@ static fdt stdio_redirection(int fd, const std::string &file)
     UNREACHABLE;
   }
 
-  result_fd = open(file.c_str(), flags, mode);
+  const fdt result_fd = open(file.c_str(), flags, mode);
 
   if(result_fd == -1)
     perror(("Failed to open " + name + " file " + file).c_str());


### PR DESCRIPTION
The default branch of the Windows version indeed did not initialize result_fd,
but is guarded by "UNREACHABLE".

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
