### PR TITLE
show_vcc no longer requires a namespace [blocks: #2310]

### DIFF
--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -308,7 +308,7 @@ safety_checkert::resultt bmct::execute(
 
     if(options.get_bool_option("show-vcc"))
     {
-      show_vcc(options, ui_message_handler, ns, equation);
+      show_vcc(options, ui_message_handler, equation);
       return safety_checkert::resultt::SAFE; // to indicate non-error
     }
 
@@ -443,7 +443,7 @@ void bmct::show()
 {
   if(options.get_bool_option("show-vcc"))
   {
-    show_vcc(options, ui_message_handler, ns, equation);
+    show_vcc(options, ui_message_handler, equation);
   }
 
   if(options.get_bool_option("program-only"))

--- a/src/goto-symex/show_vcc.cpp
+++ b/src/goto-symex/show_vcc.cpp
@@ -26,7 +26,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 void show_vcc_plain(
   messaget::mstreamt &out,
-  const namespacet &ns,
   const symex_target_equationt &equation)
 {
   bool has_threads = equation.has_threads();
@@ -103,7 +102,6 @@ void show_vcc_plain(
 
 void show_vcc_json(
   std::ostream &out,
-  const namespacet &ns,
   const symex_target_equationt &equation)
 {
   json_objectt json_result;
@@ -163,7 +161,6 @@ void show_vcc_json(
 void show_vcc(
   const optionst &options,
   ui_message_handlert &ui_message_handler,
-  const namespacet &ns,
   const symex_target_equationt &equation)
 {
   messaget msg(ui_message_handler);
@@ -190,7 +187,7 @@ void show_vcc(
     return;
 
   case ui_message_handlert::uit::JSON_UI:
-    show_vcc_json(out, ns, equation);
+    show_vcc_json(out, equation);
     break;
 
   case ui_message_handlert::uit::PLAIN:
@@ -200,12 +197,12 @@ void show_vcc(
                    << messaget::eom;
       stream_message_handlert mout_handler(out);
       messaget mout(mout_handler);
-      show_vcc_plain(mout.status(), ns, equation);
+      show_vcc_plain(mout.status(), equation);
     }
     else
     {
       msg.status() << "VERIFICATION CONDITIONS:\n" << messaget::eom;
-      show_vcc_plain(msg.status(), ns, equation);
+      show_vcc_plain(msg.status(), equation);
     }
     break;
   }

--- a/src/goto-symex/show_vcc.h
+++ b/src/goto-symex/show_vcc.h
@@ -14,14 +14,12 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/ui_message.h>
 
-class namespacet;
 class optionst;
 class symex_target_equationt;
 
 void show_vcc(
   const optionst &options,
   ui_message_handlert &ui_message_handler,
-  const namespacet &ns,
   const symex_target_equationt &equation);
 
 #endif // CPROVER_GOTO_SYMEX_SHOW_VCC_H


### PR DESCRIPTION
With the use of format_expr a namespace is no longer used.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
