### PR TITLE
Rename result to result_expr to avoid shadowing [blocks: #2310]

### DIFF
--- a/src/util/simplify_expr_array.cpp
+++ b/src/util/simplify_expr_array.cpp
@@ -200,9 +200,9 @@ bool simplify_exprt::simplify_index(exprt &expr)
       plus_exprt final_offset(array.op1(), offset);
       simplify_node(final_offset);
 
-      exprt result(array.id(), expr.type());
-      result.add_to_operands(array.op0(), final_offset);
-      expr.swap(result);
+      exprt result_expr(array.id(), expr.type());
+      result_expr.add_to_operands(array.op0(), final_offset);
+      expr.swap(result_expr);
 
       simplify_rec(expr);
 


### PR DESCRIPTION
result is already a declared Boolean variable.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
