### PR TITLE
Remove unused parameter message_handler from static_lifetime_init [blocks: #2310]

### DIFF
--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -177,7 +177,7 @@ bool ansi_c_entry_point(
     return false; // give up
   }
 
-  static_lifetime_init(symbol_table, symbol.location, message_handler);
+  static_lifetime_init(symbol_table, symbol.location);
 
   return generate_ansi_c_start_function(symbol, symbol_table, message_handler);
 }

--- a/src/linking/static_lifetime_init.cpp
+++ b/src/linking/static_lifetime_init.cpp
@@ -24,8 +24,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 void static_lifetime_init(
   symbol_tablet &symbol_table,
-  const source_locationt &source_location,
-  message_handlert &message_handler)
+  const source_locationt &source_location)
 {
   PRECONDITION(symbol_table.has_symbol(INITIALIZE_FUNCTION));
 

--- a/src/linking/static_lifetime_init.h
+++ b/src/linking/static_lifetime_init.h
@@ -18,8 +18,7 @@ class symbol_tablet;
 
 void static_lifetime_init(
   symbol_tablet &symbol_table,
-  const source_locationt &source_location,
-  message_handlert &message_handler);
+  const source_locationt &source_location);
 
 #define INITIALIZE_FUNCTION CPROVER_PREFIX "initialize"
 


### PR DESCRIPTION
It is no longer needed as errors in there are now invariants.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
