### PR TITLE
Renamed shadowing call_graph_from_goto_functions  [blocks: #2310]

### DIFF
--- a/unit/analyses/call_graph.cpp
+++ b/unit/analyses/call_graph.cpp
@@ -114,11 +114,12 @@ SCENARIO("call_graph",
 
     WHEN("A call graph is constructed with call-site tracking")
     {
-      call_grapht call_graph_from_goto_functions(goto_model, true);
+      call_grapht call_graph_from_goto_functions_tracking(goto_model, true);
       THEN("We expect two callsites for the A -> B edge, one for all others")
       {
-        const auto &check_callsites=call_graph_from_goto_functions.callsites;
-        for(const auto &edge : call_graph_from_goto_functions.edges)
+        const auto &check_callsites =
+          call_graph_from_goto_functions_tracking.callsites;
+        for(const auto &edge : call_graph_from_goto_functions_tracking.edges)
         {
           if(edge==call_grapht::edgest::value_type("A", "B"))
             REQUIRE(check_callsites.at(edge).size()==2);
@@ -128,7 +129,8 @@ SCENARIO("call_graph",
       }
       WHEN("Such a graph is inverted")
       {
-        call_grapht inverted=call_graph_from_goto_functions.get_inverted();
+        call_grapht inverted =
+          call_graph_from_goto_functions_tracking.get_inverted();
         THEN("The callsite data should be discarded")
         {
           REQUIRE(inverted.callsites.empty());
@@ -284,9 +286,9 @@ SCENARIO("call_graph",
 
     WHEN("The call graph, with call sites, is exported as a grapht")
     {
-      call_grapht call_graph_from_goto_functions(goto_model, true);
-      call_grapht::directed_grapht exported=
-        call_graph_from_goto_functions.get_directed_graph();
+      call_grapht call_graph_from_goto_functions_tracking(goto_model, true);
+      call_grapht::directed_grapht exported =
+        call_graph_from_goto_functions_tracking.get_directed_graph();
 
       typedef call_grapht::directed_grapht::node_indext node_indext;
       std::map<irep_idt, node_indext> nodes_by_name;


### PR DESCRIPTION
Don't use the same name for two different call graphs.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
