### PR TITLE
Rename parameter hiding class member [blocks: #2310]

### DIFF
--- a/src/util/xml.cpp
+++ b/src/util/xml.cpp
@@ -150,23 +150,23 @@ void xmlt::do_indent(std::ostream &out, unsigned indent)
   out << std::string(indent, ' ');
 }
 
-xmlt::elementst::const_iterator xmlt::find(const std::string &name) const
+xmlt::elementst::const_iterator xmlt::find(const std::string &key) const
 {
   for(elementst::const_iterator it=elements.begin();
       it!=elements.end();
       it++)
-    if(it->name==name)
+    if(it->name == key)
       return it;
 
   return elements.end();
 }
 
-xmlt::elementst::iterator xmlt::find(const std::string &name)
+xmlt::elementst::iterator xmlt::find(const std::string &key)
 {
   for(elementst::iterator it=elements.begin();
       it!=elements.end();
       it++)
-    if(it->name==name)
+    if(it->name == key)
       return it;
 
   return elements.end();

--- a/src/util/xml.h
+++ b/src/util/xml.h
@@ -32,8 +32,8 @@ public:
   attributest attributes;
   elementst elements;
 
-  elementst::const_iterator find(const std::string &name) const;
-  elementst::iterator find(const std::string &name);
+  elementst::const_iterator find(const std::string &key) const;
+  elementst::iterator find(const std::string &key);
 
   void set_attribute(
     const std::string &attribute,
@@ -83,10 +83,10 @@ public:
     return "";
   }
 
-  xmlt &new_element(const std::string &name)
+  xmlt &new_element(const std::string &key)
   {
     elements.push_back(xmlt());
-    elements.back().name=name;
+    elements.back().name = key;
     return elements.back();
   }
 


### PR DESCRIPTION
Visual Studio now warns when using the same name for a parameter that a class
member already has.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
