### PR TITLE
Do not shadow local variable l [blocks: #2310]

### DIFF
--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -283,9 +283,9 @@ const source_locationt &exprt::find_source_location() const
 
   forall_operands(it, (*this))
   {
-    const source_locationt &l=it->find_source_location();
-    if(l.is_not_nil())
-      return l;
+    const source_locationt &op_l = it->find_source_location();
+    if(op_l.is_not_nil())
+      return op_l;
   }
 
   return static_cast<const source_locationt &>(get_nil_irep());


### PR DESCRIPTION
l is the top-level source location, use op_l for the source location of the
operand.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
