### PR TITLE
Do not use arbitrarily bounded integer types [blocks: #2310]

### DIFF
--- a/scripts/expected_doxygen_warnings.txt
+++ b/scripts/expected_doxygen_warnings.txt
@@ -24,14 +24,6 @@
   parameter 'witnesses'
 /cbmc/src/solvers/refinement/string_refinement.cpp:1052: warning: The following parameters of substitute_array_access(const with_exprt &expr, const exprt &index, const bool left_propagate) are not documented:
   parameter 'left_propagate'
-/cbmc/src/util/nondet.cpp:35: warning: The following parameters of generate_nondet_int(const int64_t min_value, const int64_t max_value, const std::string &name_prefix, const typet &int_type, const irep_idt &mode, const source_locationt &source_location, symbol_table_baset &symbol_table, code_blockt &instructions) are not documented:
-  parameter 'mode'
-/cbmc/src/util/nondet.cpp:85: warning: The following parameters of generate_nondet_switch(const irep_idt &name_prefix, const alternate_casest &switch_cases, const typet &int_type, const irep_idt &mode, const source_locationt &source_location, symbol_table_baset &symbol_table) are not documented:
-  parameter 'mode'
-/cbmc/src/util/nondet.h:16: warning: The following parameters of generate_nondet_int(const int64_t min_value, const int64_t max_value, const std::string &name_prefix, const typet &int_type, const irep_idt &mode, const source_locationt &source_location, symbol_table_baset &symbol_table, code_blockt &instructions) are not documented:
-  parameter 'mode'
-/cbmc/src/util/nondet.h:28: warning: The following parameters of generate_nondet_switch(const irep_idt &name_prefix, const alternate_casest &switch_cases, const typet &int_type, const irep_idt &mode, const source_locationt &source_location, symbol_table_baset &symbol_table) are not documented:
-  parameter 'mode'
 /cbmc/doc/architectural/howto.md:260: warning: found </div> at different nesting level (6) than expected (3)
 /cbmc/doc/architectural/howto.md:261: warning: end of comment block while expecting command </div>
 /cbmc/src/solvers/README.md:4: warning: @copydetails or @copydoc target 'generate_instantiations(messaget::mstreamt &stream, const string_constraint_generatort &generator, const index_set_pairt &index_set, const string_axiomst &axioms, const std::map<string_not_contains_constraintt, symbol_exprt> &not_contain_witnesses).' not found

--- a/src/util/nondet.cpp
+++ b/src/util/nondet.cpp
@@ -26,6 +26,7 @@ Module: Non-deterministic object init and choice for CBMC
 ///   function id)
 /// \param int_type: The type of the int used to non-deterministically choose
 ///   one of the switch cases.
+/// \param mode: Mode (language) of the symbol to be generated.
 /// \param source_location: The location to mark the generated int with.
 /// \param symbol_table: The global symbol table.
 /// \param instructions [out]: Output instructions are written to
@@ -78,6 +79,7 @@ symbol_exprt generate_nondet_int(
 /// \param switch_cases: List of codet objects to execute in each switch case.
 /// \param int_type: The type of the int used to non-deterministically choose
 ///   one of the switch cases.
+/// \param mode: Mode (language) of the symbol to be generated.
 /// \param source_location: The location to mark the generated int with.
 /// \param symbol_table: The global symbol table.
 /// \return Returns a nondet-switch choosing between switch_cases. The resulting

--- a/src/util/nondet.cpp
+++ b/src/util/nondet.cpp
@@ -33,8 +33,8 @@ Module: Non-deterministic object init and choice for CBMC
 ///   assume statements) a fresh integer.
 /// \return Returns a symbol expression for the resulting integer.
 symbol_exprt generate_nondet_int(
-  const int64_t min_value,
-  const int64_t max_value,
+  const mp_integer &min_value,
+  const mp_integer &max_value,
   const std::string &name_prefix,
   const typet &int_type,
   const irep_idt &mode,

--- a/src/util/nondet.h
+++ b/src/util/nondet.h
@@ -14,8 +14,8 @@
 #include <util/symbol_table.h>
 
 symbol_exprt generate_nondet_int(
-  int64_t min_value,
-  int64_t max_value,
+  const mp_integer &min_value,
+  const mp_integer &max_value,
   const std::string &name_prefix,
   const typet &int_type,
   const irep_idt &mode,


### PR DESCRIPTION
We generate expressions, there is no need to restrict values to machine-specific
bounded integer types.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
