### PR TITLE
Rename mstream parameter to avoid shadowing [blocks: #2310]

### DIFF
--- a/src/util/message.cpp
+++ b/src/util/message.cpp
@@ -123,19 +123,19 @@ unsigned messaget::eval_verbosity(
   return v;
 }
 
-/// Generate output to \p mstream using \p output_generator if the configured
-/// verbosity is at least as high as that of \p mstream.  Use whenever
-/// generating output involves additional computational effort that should only
-/// be spent when such output will actually be displayed.
-/// \param mstream  Output message stream
+/// Generate output to \p message_stream using \p output_generator if the
+/// configured verbosity is at least as high as that of \p message_stream.  Use
+/// whenever generating output involves additional computational effort that
+/// should only be spent when such output will actually be displayed.
+/// \param message_stream  Output message stream
 /// \param output_generator  Function generating output
 void messaget::conditional_output(
-  mstreamt &mstream,
+  mstreamt &message_stream,
   const std::function<void(mstreamt &)> &output_generator) const
 {
   if(
     message_handler &&
-    message_handler->get_verbosity() >= mstream.message_level)
+    message_handler->get_verbosity() >= message_stream.message_level)
   {
     output_generator(mstream);
   }


### PR DESCRIPTION
The class also as a member named mstream, thus rename the parameter to
message_stream.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
