### PR TITLE
Remove unused parameters from reaching definitions transformers [blocks: #2310]

### DIFF
--- a/src/analyses/reaching_definitions.cpp
+++ b/src/analyses/reaching_definitions.cpp
@@ -80,10 +80,10 @@ void rd_range_domaint::transform(
     transform_start_thread(ns, *rd);
   // do argument-to-parameter assignments
   else if(from->is_function_call())
-    transform_function_call(ns, function_from, from, function_to, to, *rd);
+    transform_function_call(ns, function_from, from, function_to, *rd);
   // cleanup parameters
   else if(from->is_end_function())
-    transform_end_function(ns, function_from, from, function_to, to, *rd);
+    transform_end_function(ns, function_from, from, to, *rd);
   // lhs assignments
   else if(from->is_assign())
     transform_assign(ns, from, from, *rd);
@@ -171,7 +171,6 @@ void rd_range_domaint::transform_function_call(
   const irep_idt &function_from,
   locationt from,
   const irep_idt &function_to,
-  locationt to,
   reaching_definitions_analysist &rd)
 {
   const code_function_callt &code=to_code_function_call(from->code);
@@ -234,7 +233,6 @@ void rd_range_domaint::transform_end_function(
   const namespacet &ns,
   const irep_idt &function_from,
   locationt from,
-  const irep_idt &function_to,
   locationt to,
   reaching_definitions_analysist &rd)
 {

--- a/src/analyses/reaching_definitions.h
+++ b/src/analyses/reaching_definitions.h
@@ -219,13 +219,11 @@ private:
     const irep_idt &function_from,
     locationt from,
     const irep_idt &function_to,
-    locationt to,
     reaching_definitions_analysist &rd);
   void transform_end_function(
     const namespacet &ns,
     const irep_idt &function_from,
     locationt from,
-    const irep_idt &function_to,
     locationt to,
     reaching_definitions_analysist &rd);
   void transform_assign(


### PR DESCRIPTION
There is no need to have the very same interface in all internal functions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
