### PR TITLE
Rename parameters of div_and_round [blocks: #2310]

### DIFF
--- a/src/util/ieee_float.cpp
+++ b/src/util/ieee_float.cpp
@@ -646,11 +646,11 @@ void ieee_floatt::align()
 }
 
 void ieee_floatt::divide_and_round(
-  mp_integer &fraction,
-  const mp_integer &factor)
+  mp_integer &dividend,
+  const mp_integer &divisor)
 {
-  mp_integer remainder=fraction%factor;
-  fraction/=factor;
+  const mp_integer remainder = dividend % divisor;
+  dividend /= divisor;
 
   if(remainder!=0)
   {
@@ -658,19 +658,19 @@ void ieee_floatt::divide_and_round(
     {
     case ROUND_TO_EVEN:
       {
-        mp_integer factor_middle=factor/2;
-        if(remainder<factor_middle)
+        mp_integer divisor_middle = divisor / 2;
+        if(remainder < divisor_middle)
         {
           // crop
         }
-        else if(remainder>factor_middle)
+        else if(remainder > divisor_middle)
         {
-          ++fraction;
+          ++dividend;
         }
         else // exactly in the middle -- go to even
         {
-          if((fraction%2)!=0)
-            ++fraction;
+          if((dividend % 2) != 0)
+            ++dividend;
         }
       }
       break;
@@ -681,12 +681,12 @@ void ieee_floatt::divide_and_round(
 
     case ROUND_TO_MINUS_INF:
       if(sign_flag)
-        ++fraction;
+        ++dividend;
       break;
 
     case ROUND_TO_PLUS_INF:
       if(!sign_flag)
-        ++fraction;
+        ++dividend;
       break;
 
     default:

--- a/src/util/ieee_float.h
+++ b/src/util/ieee_float.h
@@ -301,7 +301,7 @@ public:
   bool ieee_not_equal(const ieee_floatt &other) const;
 
 protected:
-  void divide_and_round(mp_integer &fraction, const mp_integer &factor);
+  void divide_and_round(mp_integer &dividend, const mp_integer &divisor);
   void align();
   void next_representable(bool greater);
 


### PR DESCRIPTION
This avoids shadowing the "fraction" class member and also uses the correct
mathematical terminology.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
