### PR TITLE
run: Remove parameters that aren't supported outside Windows [blocks: #2310]

### DIFF
--- a/src/ansi-c/c_preprocess.cpp
+++ b/src/ansi-c/c_preprocess.cpp
@@ -384,8 +384,7 @@ bool c_preprocess_visual_studio(
 
   // _popen isn't very reliable on WIN32
   // that's why we use run()
-  int result =
-    run("cl", {"cl", "@" + command_file_name()}, "", outstream, stderr_file());
+  int result = run("cl", {"cl", "@" + command_file_name()}, outstream);
 
   // errors/warnings
   std::ifstream stderr_stream(stderr_file());
@@ -654,9 +653,11 @@ bool c_preprocess_gcc_clang(
 
   // the file that is to be preprocessed
   argv.push_back(file);
+  argv.push_back("2>");
+  argv.push_back(stderr_file());
 
   // execute clang or gcc
-  result = run(argv[0], argv, "", outstream, stderr_file());
+  result = run(argv[0], argv, outstream);
 
   // errors/warnings
   std::ifstream stderr_stream(stderr_file());
@@ -723,11 +724,13 @@ bool c_preprocess_arm(
 
   // the file that is to be preprocessed
   argv.push_back(file);
+  argv.push_back("2>");
+  argv.push_back(stderr_file());
 
   int result;
 
   // execute armcc
-  result = run(argv[0], argv, "", outstream, stderr_file());
+  result = run(argv[0], argv, outstream);
 
   // errors/warnings
   std::ifstream stderr_stream(stderr_file());

--- a/src/util/run.cpp
+++ b/src/util/run.cpp
@@ -475,14 +475,12 @@ static std::string shell_quote(const std::string &src)
 int run(
   const std::string &what,
   const std::vector<std::string> &argv,
-  const std::string &std_input,
-  std::ostream &std_output,
-  const std::string &std_error)
+  std::ostream &std_output)
 {
   #ifdef _WIN32
   temporary_filet tmpi("tmp.stdout", "");
 
-  int result = run(what, argv, std_input, tmpi(), std_error);
+  int result = run(what, argv, "", tmpi(), "");
 
   std::ifstream instream(tmpi());
 

--- a/src/util/run.h
+++ b/src/util/run.h
@@ -29,8 +29,6 @@ int run(
 int run(
   const std::string &what,
   const std::vector<std::string> &argv,
-  const std::string &std_input,
-  std::ostream &std_output,
-  const std::string &std_error);
+  std::ostream &std_output);
 
 #endif // CPROVER_UTIL_RUN_H


### PR DESCRIPTION
In this variant of run, the callers either did not make use of them (on Windows)
or expected something to happen that actually wouldn't (the redirect of stderr,
on Linux).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
