### PR TITLE
fix a run() variant on non-Windows OSs [blocks: #2310]

### DIFF
--- a/src/util/run.cpp
+++ b/src/util/run.cpp
@@ -493,8 +493,25 @@ int run(
   #else
   std::string command;
 
+  bool first = true;
+
+  // note we use 'what' instead of 'argv[0]' as the name of the executable
   for(const auto &arg : argv)
-    command += " " + shell_quote(arg);
+  {
+    if(first) // this is argv[0]
+    {
+      command += shell_quote(what);
+      first = false;
+    }
+    else
+      command += " " + shell_quote(arg);
+  }
+
+  if(!std_input.empty())
+    command += " < " + shell_quote(std_input);
+
+  if(!std_error.empty())
+    command += " 2> " + shell_quote(std_error);
 
   FILE *stream=popen(command.c_str(), "r");
 

--- a/src/util/run.h
+++ b/src/util/run.h
@@ -18,6 +18,12 @@ Date: August 2012
 
 int run(const std::string &what, const std::vector<std::string> &argv);
 
+/// This runs the executable given by the file name \p what.
+/// Control returns when execution has finished.
+/// Stdin, stdout and stderr may be redirected from/to a given file.
+/// Give the empty string to retain the default handle.
+/// Any shell-meta characters in the executable, \p argv and the I/O
+/// redirect files are escaped as needed.
 int run(
   const std::string &what,
   const std::vector<std::string> &argv,
@@ -25,7 +31,13 @@ int run(
   const std::string &std_output,
   const std::string &std_error);
 
-/// A variant that streams the stdout of the child into an ostream
+/// This runs the executable given by the file name \p what.
+/// Control returns when execution has finished.
+/// Stdin and stderr may be redirected from/to a given file.
+/// Give the empty string to retain the default handle.
+/// Any output to stdout is stored in the \p std_output stream buffer.
+/// Any shell-meta characters in the executable, \p argv and the I/O
+/// redirect files are escaped as needed.
 int run(
   const std::string &what,
   const std::vector<std::string> &argv,


### PR DESCRIPTION
This is to address the bug identified in #3332.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
