### PR TITLE
Remove unused parameter tmp_var_type from save_stack_entries [blocks: #2310]

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -2536,7 +2536,6 @@ code_blockt java_bytecode_convert_methodt::convert_putstatic(
 
   save_stack_entries(
     "stack_static_field",
-    symbol_expr.type(),
     block,
     bytecode_write_typet::STATIC_FIELD,
     symbol_expr.get_identifier());
@@ -2551,7 +2550,6 @@ code_blockt java_bytecode_convert_methodt::convert_putfield(
   code_blockt block;
   save_stack_entries(
     "stack_field",
-    op[1].type(),
     block,
     bytecode_write_typet::FIELD,
     arg0.get(ID_component_name));
@@ -2685,7 +2683,6 @@ code_blockt java_bytecode_convert_methodt::convert_iinc(
   const exprt &locvar = variable(arg0, 'i', address, NO_CAST);
   save_stack_entries(
     "stack_iinc",
-    java_int_type(),
     block,
     bytecode_write_typet::VARIABLE,
     to_symbol_expr(locvar).get_identifier());
@@ -2851,7 +2848,6 @@ code_blockt java_bytecode_convert_methodt::convert_store(
 
   save_stack_entries(
     "stack_store",
-    toassign.type(),
     block,
     bytecode_write_typet::VARIABLE,
     var_name);
@@ -2885,7 +2881,7 @@ code_blockt java_bytecode_convert_methodt::convert_astore(
   block.add_source_location() = location;
 
   save_stack_entries(
-    "stack_astore", element_type, block, bytecode_write_typet::ARRAY_REF, "");
+    "stack_astore", block, bytecode_write_typet::ARRAY_REF, "");
 
   code_assignt array_put(element, op[2]);
   array_put.add_source_location() = location;
@@ -3133,13 +3129,11 @@ irep_idt java_bytecode_convert_methodt::get_static_field(
 /// Create temporary variables if a write instruction can have undesired side-
 /// effects.
 /// \param tmp_var_prefix: The prefix string to use for new temporary variables
-/// \param tmp_var_type: The type of the temporary variable.
 /// \param[out] block: The code block the assignment is added to if required.
 /// \param write_type: The enumeration type of the write instruction.
 /// \param identifier: The identifier of the symbol in the write instruction.
 void java_bytecode_convert_methodt::save_stack_entries(
   const std::string &tmp_var_prefix,
-  const typet &tmp_var_type,
   code_blockt &block,
   const bytecode_write_typet write_type,
   const irep_idt &identifier)

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -293,7 +293,6 @@ protected:
 
   void save_stack_entries(
     const std::string &,
-    const typet &,
     code_blockt &,
     const bytecode_write_typet,
     const irep_idt &);


### PR DESCRIPTION
This is a follow-up cleanup to 767003e6e81, which removed the use of this
parameter.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
