### PR TITLE
Avoid shadowing index_expr and fix type cast [blocks: #2310]

### DIFF
--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1057,13 +1057,9 @@ void value_sett::get_reference_set_rec(
         insert(dest, exprt(ID_unknown, expr.type()));
       else
       {
-        index_exprt index_expr(expr.type());
-        index_expr.array()=object;
-        index_expr.index()=from_integer(0, index_type());
-
-        // adjust type?
-        if(ns.follow(object.type())!=array_type)
-          index_expr.make_typecast(array.type());
+        const index_exprt deref_index_expr(
+          typecast_exprt::conditional_cast(object, array_type),
+          from_integer(0, index_type()));
 
         offsett o = a_it->second;
         mp_integer i;
@@ -1083,7 +1079,7 @@ void value_sett::get_reference_set_rec(
         else
           o.reset();
 
-        insert(dest, index_expr, o);
+        insert(dest, deref_index_expr, o);
       }
     }
 


### PR DESCRIPTION
We need to type cast the array operand, not the resulting index expression.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
