### PR TITLE
Remove unused messaget parameter from static_verifier_text [blocks: #2310]

### DIFF
--- a/src/goto-analyzer/static_verifier.cpp
+++ b/src/goto-analyzer/static_verifier.cpp
@@ -107,7 +107,6 @@ static void static_verifier_xml(
 static void static_verifier_text(
   const std::vector<static_verifier_resultt> &results,
   const namespacet &ns,
-  messaget &m,
   std::ostream &out)
 {
   irep_idt last_function_id;
@@ -287,7 +286,7 @@ bool static_verifier(
   }
   else if(options.get_bool_option("text"))
   {
-    static_verifier_text(results, ns, m, out);
+    static_verifier_text(results, ns, out);
   }
   else
   {


### PR DESCRIPTION
There is no use of it in the text output, unlike other forms of output.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
