### PR TITLE
Do not shadow size variable [blocks: #2310]

### DIFF
--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -127,7 +127,7 @@ void goto_symext::symex_allocate(
     if(object_type.id()==ID_array &&
        !to_array_type(object_type).size().is_constant())
     {
-      exprt &size=to_array_type(object_type).size();
+      exprt &array_size = to_array_type(object_type).size();
 
       auxiliary_symbolt size_symbol;
 
@@ -137,12 +137,12 @@ void goto_symext::symex_allocate(
       size_symbol.type=tmp_size.type();
       size_symbol.mode = mode;
       size_symbol.type.set(ID_C_constant, true);
-      size_symbol.value = size;
+      size_symbol.value = array_size;
 
       state.symbol_table.add(size_symbol);
 
-      code_assignt assignment(size_symbol.symbol_expr(), size);
-      size=assignment.lhs();
+      code_assignt assignment(size_symbol.symbol_expr(), array_size);
+      array_size = assignment.lhs();
 
       symex_assign(state, assignment);
     }


### PR DESCRIPTION
The requested allocation size is different from the specific reference into the
array, which is later on used to replace the array size. Different names will
help avoid any confusion.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
