### PR TITLE
Refactor show_program [blocks: #2310]

### DIFF
--- a/src/goto-symex/show_program.cpp
+++ b/src/goto-symex/show_program.cpp
@@ -17,87 +17,64 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <langapi/language_util.h>
 
+/// Output a single SSA step
+/// \param ns: Namespace
+/// \param step: SSA step
+/// \param annotation: Additonal information to include in step output
+/// \param count: Step number, incremented after output
+static void show_step(
+  const namespacet &ns,
+  const symex_target_equationt::SSA_stept &step,
+  const std::string &annotation,
+  std::size_t &count)
+{
+  const irep_idt &function = step.source.function;
+
+  std::string string_value = (step.is_shared_read() || step.is_shared_write())
+                               ? from_expr(ns, function, step.ssa_lhs)
+                               : from_expr(ns, function, step.cond_expr);
+  std::cout << '(' << count << ") ";
+  if(annotation.empty())
+    std::cout << string_value;
+  else
+    std::cout << annotation << '(' << string_value << ')';
+  std::cout << '\n';
+
+  if(!step.guard.is_true())
+  {
+    const std::string guard_string = from_expr(ns, function, step.guard);
+    std::cout << std::string(std::to_string(count).size() + 3, ' ');
+    std::cout << "guard: " << guard_string << '\n';
+  }
+
+  ++count;
+}
+
 void show_program(const namespacet &ns, const symex_target_equationt &equation)
 {
-  unsigned count = 1;
+  std::size_t count = 1;
 
-  std::cout << "\n"
-            << "Program constraints:"
-            << "\n";
+  std::cout << '\n' << "Program constraints:" << '\n';
 
   for(const auto &step : equation.SSA_steps)
   {
     std::cout << "// " << step.source.pc->location_number << " ";
     std::cout << step.source.pc->source_location.as_string() << "\n";
-    const irep_idt &function = step.source.function;
 
     if(step.is_assignment())
-    {
-      std::string string_value = from_expr(ns, function, step.cond_expr);
-      std::cout << "(" << count << ") " << string_value << "\n";
-
-      if(!step.guard.is_true())
-      {
-        std::string string_value = from_expr(ns, function, step.guard);
-        std::cout << std::string(std::to_string(count).size() + 3, ' ');
-        std::cout << "guard: " << string_value << "\n";
-      }
-
-      count++;
-    }
+      show_step(ns, step, "", count);
     else if(step.is_assert())
-    {
-      std::string string_value = from_expr(ns, function, step.cond_expr);
-      std::cout << "(" << count << ") ASSERT(" << string_value << ") "
-                << "\n";
-
-      if(!step.guard.is_true())
-      {
-        std::string string_value = from_expr(ns, function, step.guard);
-        std::cout << std::string(std::to_string(count).size() + 3, ' ');
-        std::cout << "guard: " << string_value << "\n";
-      }
-
-      count++;
-    }
+      show_step(ns, step, "ASSERT", count);
     else if(step.is_assume())
-    {
-      std::string string_value = from_expr(ns, function, step.cond_expr);
-      std::cout << "(" << count << ") ASSUME(" << string_value << ") "
-                << "\n";
-
-      if(!step.guard.is_true())
-      {
-        std::string string_value = from_expr(ns, function, step.guard);
-        std::cout << std::string(std::to_string(count).size() + 3, ' ');
-        std::cout << "guard: " << string_value << "\n";
-      }
-
-      count++;
-    }
+      show_step(ns, step, "ASSUME", count);
     else if(step.is_constraint())
     {
-      std::string string_value = from_expr(ns, function, step.cond_expr);
-      std::cout << "(" << count << ") CONSTRAINT(" << string_value << ") "
-                << "\n";
-
-      count++;
+      PRECONDITION(step.guard.is_true());
+      show_step(ns, step, "CONSTRAINT", count);
     }
-    else if(step.is_shared_read() || step.is_shared_write())
-    {
-      std::string string_value = from_expr(ns, function, step.ssa_lhs);
-      std::cout << "(" << count << ") SHARED_"
-                << (step.is_shared_write() ? "WRITE" : "READ") << "("
-                << string_value << ")\n";
-
-      if(!step.guard.is_true())
-      {
-        std::string string_value = from_expr(ns, function, step.guard);
-        std::cout << std::string(std::to_string(count).size() + 3, ' ');
-        std::cout << "guard: " << string_value << "\n";
-      }
-
-      count++;
-    }
+    else if(step.is_shared_read())
+      show_step(ns, step, "SHARED_READ", count);
+    else if(step.is_shared_write())
+      show_step(ns, step, "SHARED_WRITE", count);
   }
 }


### PR DESCRIPTION
The code previously shadowed the variable string_value, and really did so in
each kind of output. Instead of having (almost) the same code four times, factor
it out into a separate function. Furthermore includes minor cleanup (use of
std::size_t instead of unsigned, single quotes around single characters in
output).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
