### PR TITLE
Remove duplicate definition of "root_object" [blocks: #2310]

### DIFF
--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -401,7 +401,6 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
     tmp_guard.add(result.pointer_guard);
 
     const typet &object_type=ns.follow(object.type());
-    const exprt &root_object=o.root_object();
     const typet &root_object_type=ns.follow(root_object.type());
 
     exprt root_object_subexpression=root_object;


### PR DESCRIPTION
Both definitions have the same name and value.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
