### PR TITLE
Remove unused parameter address_map [blocks: #2310]

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1627,7 +1627,7 @@ code_blockt java_bytecode_convert_methodt::convert_instructions(
             statement=="lookupswitch")
     {
       PRECONDITION(op.size() == 1 && results.empty());
-      c = convert_switch(address_map, op, i_it->args, i_it->source_location);
+      c = convert_switch(op, i_it->args, i_it->source_location);
     }
     else if(statement=="pop" || statement=="pop2")
     {
@@ -1913,7 +1913,6 @@ codet java_bytecode_convert_methodt::convert_pop(
 }
 
 code_switcht java_bytecode_convert_methodt::convert_switch(
-  java_bytecode_convert_methodt::address_mapt &address_map,
   const exprt::operandst &op,
   const java_bytecode_parse_treet::instructiont::argst &args,
   const source_locationt &location)

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -465,7 +465,6 @@ protected:
   void convert_dup2(exprt::operandst &op, exprt::operandst &results);
 
   code_switcht convert_switch(
-    java_bytecode_convert_methodt::address_mapt &address_map,
     const exprt::operandst &op,
     const java_bytecode_parse_treet::instructiont::argst &args,
     const source_locationt &location);


### PR DESCRIPTION
convert_switch does not use it (anymore).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
