### PR TITLE
Avoid shadowing in escape analysis [blocks: #2310]

### DIFF
--- a/src/analyses/escape_analysis.cpp
+++ b/src/analyses/escape_analysis.cpp
@@ -192,9 +192,9 @@ void escape_domaint::transform(
       get_rhs_cleanup(code_assign.rhs(), cleanup_functions);
       assign_lhs_cleanup(code_assign.lhs(), cleanup_functions);
 
-      std::set<irep_idt> aliases;
-      get_rhs_aliases(code_assign.rhs(), aliases);
-      assign_lhs_aliases(code_assign.lhs(), aliases);
+      std::set<irep_idt> rhs_aliases;
+      get_rhs_aliases(code_assign.rhs(), rhs_aliases);
+      assign_lhs_aliases(code_assign.lhs(), rhs_aliases);
     }
     break;
 
@@ -238,9 +238,9 @@ void escape_domaint::transform(
               std::set<irep_idt> lhs_set;
               get_rhs_aliases(lhs, lhs_set);
 
-              for(const auto &lhs : lhs_set)
+              for(const auto &l : lhs_set)
               {
-                cleanup_map[lhs].cleanup_functions.insert(cleanup_function);
+                cleanup_map[l].cleanup_functions.insert(cleanup_function);
               }
             }
           }


### PR DESCRIPTION
aliases is (also) a class member, lhs is already a declared local - rename their
shadowing variants.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
