### PR TITLE
Do not shadow "code" local variable [blocks: #2310]

### DIFF
--- a/src/analyses/reaching_definitions.cpp
+++ b/src/analyses/reaching_definitions.cpp
@@ -222,9 +222,7 @@ void rd_range_domaint::transform_function_call(
   else
   {
     // handle return values of undefined functions
-    const code_function_callt &code=to_code_function_call(from->code);
-
-    if(code.lhs().is_not_nil())
+    if(to_code_function_call(from->code).lhs().is_not_nil())
       transform_assign(ns, from, from, rd);
   }
 }


### PR DESCRIPTION
Just remove the temporary shadowing it.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
