### PR TITLE
Do not shadow the "result" variable and fix one use of it [blocks: #2310]

### DIFF
--- a/unit/util/symbol_table.cpp
+++ b/unit/util/symbol_table.cpp
@@ -69,10 +69,10 @@ SCENARIO("journalling_symbol_table_writer",
       }
       WHEN("Adding the same symbol again")
       {
-        auto result=symbol_table.insert(symbol);
+        const auto result_re_insert = symbol_table.insert(symbol);
         THEN("The insert should fail")
         {
-          REQUIRE(!result.second);
+          REQUIRE(!result_re_insert.second);
         }
       }
     }
@@ -106,10 +106,10 @@ SCENARIO("journalling_symbol_table_writer",
       WHEN("Moving the same symbol again")
       {
         symbolt *symbol_in_table2;
-        auto result=symbol_table.move(symbol, symbol_in_table2);
+        const auto result_move = symbol_table.move(symbol, symbol_in_table2);
         THEN("The move should fail")
         {
-          REQUIRE(result);
+          REQUIRE(result_move);
         }
         THEN("The returned pointer should match the previous move result")
         {
@@ -145,10 +145,10 @@ SCENARIO("journalling_symbol_table_writer",
       }
       WHEN("Adding the same symbol again")
       {
-        auto result=symbol_table.add(symbol);
+        auto result_add_2 = symbol_table.add(symbol);
         THEN("The insert should fail")
         {
-          REQUIRE(result);
+          REQUIRE(result_add_2);
         }
       }
     }
@@ -259,16 +259,16 @@ SCENARIO("journalling_symbol_table_writer",
     {
       symbolt symbol;
       symbol.name = symbol_name;
-      auto result=symbol_table.add(symbol);
+      const auto result_add_1 = symbol_table.add(symbol);
       symbol_table.remove(symbol.name);
-      auto result2=symbol_table.add(symbol);
+      const auto result_add_2 = symbol_table.add(symbol);
       THEN("The first add should succeed")
       {
-        REQUIRE(!result);
+        REQUIRE(!result_add_1);
       }
       THEN("The second add should succeed")
       {
-        REQUIRE(!result);
+        REQUIRE(!result_add_2);
       }
       THEN("The symbol should be journalled as updated but not removed")
       {


### PR DESCRIPTION
result2 was never used, although it was meant to be tested for. Renamed it to
result_add_2 (and result_add_1) instead to make it clearer and more obvious.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
