### PR TITLE
Avoid warning about unsigned/enum type mix in conditional expression [blocks: #2310]

### DIFF
--- a/src/goto-diff/change_impact.cpp
+++ b/src/goto-diff/change_impact.cpp
@@ -568,8 +568,8 @@ void change_impactt::output_change_impact(
   {
     goto_program_change_impactt::const_iterator c_entry=
       c_i.find(target);
-    const unsigned mod_flags=
-      c_entry==c_i.end() ? SAME : c_entry->second;
+    const unsigned mod_flags =
+      c_entry == c_i.end() ? static_cast<unsigned>(SAME) : c_entry->second;
 
     char prefix = ' ';
     // syntactic changes are preferred over data/control-dependence
@@ -623,8 +623,9 @@ void change_impactt::output_change_impact(
   {
     goto_program_change_impactt::const_iterator o_c_entry=
       o_c_i.find(o_target);
-    const unsigned old_mod_flags=
-      o_c_entry==o_c_i.end() ? SAME : o_c_entry->second;
+    const unsigned old_mod_flags = o_c_entry == o_c_i.end()
+                                     ? static_cast<unsigned>(SAME)
+                                     : o_c_entry->second;
 
     if(old_mod_flags&DELETED)
     {
@@ -636,8 +637,8 @@ void change_impactt::output_change_impact(
 
     goto_program_change_impactt::const_iterator c_entry=
       n_c_i.find(target);
-    const unsigned mod_flags=
-      c_entry==n_c_i.end() ? SAME : c_entry->second;
+    const unsigned mod_flags =
+      c_entry == n_c_i.end() ? static_cast<unsigned>(SAME) : c_entry->second;
 
     char prefix = ' ';
     // syntactic changes are preferred over data/control-dependence
@@ -688,8 +689,9 @@ void change_impactt::output_change_impact(
   {
     goto_program_change_impactt::const_iterator o_c_entry=
       o_c_i.find(o_target);
-    const unsigned old_mod_flags=
-      o_c_entry==o_c_i.end() ? SAME : o_c_entry->second;
+    const unsigned old_mod_flags = o_c_entry == o_c_i.end()
+                                     ? static_cast<unsigned>(SAME)
+                                     : o_c_entry->second;
 
     char prefix = ' ';
     // syntactic changes are preferred over data/control-dependence


### PR DESCRIPTION
The enum values serve as bits in a bit field, convert them to unsigned.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
