### PR TITLE
Do not shadow "type" function parameter [blocks: #2310]

### DIFF
--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -439,13 +439,13 @@ void c_typecheck_baset::typecheck_code_type(code_typet &type)
         code_typet::parametert parameter;
 
         // first fix type
-        typet &type=parameter.type();
-        type=declaration.full_type(declaration.declarator());
+        typet &param_type = parameter.type();
+        param_type = declaration.full_type(declaration.declarator());
         std::list<codet> tmp_clean_code;
         tmp_clean_code.swap(clean_code); // ignore side-effects
-        typecheck_type(type);
+        typecheck_type(param_type);
         tmp_clean_code.swap(clean_code);
-        adjust_function_parameter(type);
+        adjust_function_parameter(param_type);
 
         // adjust the identifier
         irep_idt identifier=declaration.declarator().get_name();
@@ -459,7 +459,7 @@ void c_typecheck_baset::typecheck_code_type(code_typet &type)
         else
         {
           // make visible now, later parameters might use it
-          parameter_map[identifier]=type;
+          parameter_map[identifier] = param_type;
           parameter.set_base_name(declaration.declarator().get_base_name());
           parameter.add_source_location()=
             declaration.declarator().source_location();


### PR DESCRIPTION
One is the function type, the other is the parameter type.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
