### PR TITLE
Avoid default no-ops, force derived classes to override [blocks: #2310]

### DIFF
--- a/src/util/cout_message.h
+++ b/src/util/cout_message.h
@@ -29,6 +29,14 @@ public:
 class console_message_handlert : public message_handlert
 {
 public:
+  void print(unsigned, const xmlt &) override
+  {
+  }
+
+  void print(unsigned, const jsont &) override
+  {
+  }
+
   // level 4 and upwards go to cout, level 1-3 to cerr
   virtual void print(
     unsigned level,
@@ -57,6 +65,14 @@ protected:
 class gcc_message_handlert : public console_message_handlert
 {
 public:
+  void print(unsigned, const xmlt &) override
+  {
+  }
+
+  void print(unsigned, const jsont &) override
+  {
+  }
+
   // aims to imitate the messages gcc prints
   virtual void print(
     unsigned level,

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -30,25 +30,16 @@ public:
 
   virtual void print(unsigned level, const std::string &message)=0;
 
-  virtual void print(unsigned level, const xmlt &xml)
-  {
-    // no-op by default
-  }
+  virtual void print(unsigned level, const xmlt &xml) = 0;
 
-  virtual void print(unsigned level, const jsont &json)
-  {
-    // no-op by default
-  }
+  virtual void print(unsigned level, const jsont &json) = 0;
 
   virtual void print(
     unsigned level,
     const std::string &message,
     const source_locationt &location);
 
-  virtual void flush(unsigned level)
-  {
-    // no-op by default
-  }
+  virtual void flush(unsigned) = 0;
 
   virtual ~message_handlert()
   {
@@ -80,17 +71,29 @@ protected:
 class null_message_handlert:public message_handlert
 {
 public:
-  virtual void print(unsigned level, const std::string &message)
+  void print(unsigned level, const std::string &message) override
   {
     message_handlert::print(level, message);
   }
 
-  virtual void print(
+  void print(unsigned, const xmlt &) override
+  {
+  }
+
+  void print(unsigned, const jsont &) override
+  {
+  }
+
+  void print(
     unsigned level,
     const std::string &message,
-    const source_locationt &)
+    const source_locationt &) override
   {
     print(level, message);
+  }
+
+  void flush(unsigned) override
+  {
   }
 };
 
@@ -101,7 +104,7 @@ public:
   {
   }
 
-  virtual void print(unsigned level, const std::string &message)
+  void print(unsigned level, const std::string &message) override
   {
     message_handlert::print(level, message);
 
@@ -109,7 +112,15 @@ public:
       out << message << '\n';
   }
 
-  virtual void flush(unsigned level)
+  void print(unsigned, const xmlt &) override
+  {
+  }
+
+  void print(unsigned, const jsont &) override
+  {
+  }
+
+  void flush(unsigned) override
   {
     out << std::flush;
   }


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
