### PR TITLE
Use Boolean operators compute xor, or, and over bool [blocks: #2310]

### DIFF
--- a/src/util/mp_arith.cpp
+++ b/src/util/mp_arith.cpp
@@ -269,7 +269,7 @@ mp_integer bitwise_xor(const mp_integer &a, const mp_integer &b)
   if(a.is_ulong() && b.is_ulong())
     return a.to_ulong() ^ b.to_ulong();
 
-  return bitwise(a, b, [](bool a, bool b) { return a ^ b; });
+  return bitwise(a, b, [](bool a, bool b) { return a != b; });
 }
 
 /// arithmetic left shift bitwise operations only make sense on native objects,

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -734,11 +734,11 @@ bool simplify_exprt::simplify_bitwise(exprt &expr)
     std::function<bool(bool, bool)> f;
 
     if(expr.id()==ID_bitand)
-      f = [](bool a, bool b) { return a & b; };
+      f = [](bool a, bool b) { return a && b; };
     else if(expr.id()==ID_bitor)
-      f = [](bool a, bool b) { return a | b; };
+      f = [](bool a, bool b) { return a || b; };
     else if(expr.id()==ID_bitxor)
-      f = [](bool a, bool b) { return a ^ b; };
+      f = [](bool a, bool b) { return a != b; };
     else
       UNREACHABLE;
 


### PR DESCRIPTION
Using bitwise xor (^) is an operation over integers, and triggers a warning by
Visual Studio. The same is true for |, &; the latter were only sometimes used
for this purpose, which also makes this a consistency-fix.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
