### PR TITLE
String refinement: Remove generator parameter where unused [blocks: #2310]

### DIFF
--- a/scripts/expected_doxygen_warnings.txt
+++ b/scripts/expected_doxygen_warnings.txt
@@ -20,8 +20,6 @@
 /cbmc/src/solvers/refinement/string_refinement.cpp:1511: warning: argument 'stream' of command @param is not found in the argument list of compute_inverse_function(const exprt &qvar, const exprt &val, const exprt &f)
 /cbmc/src/solvers/refinement/string_refinement.cpp:239: warning: Invalid list item found
 /cbmc/src/solvers/refinement/string_refinement.cpp:1823: warning: argument 'stream' of command @param is not found in the argument list of instantiate(const string_constraintt &axiom, const exprt &str, const exprt &val)
-/cbmc/src/solvers/refinement/string_refinement.cpp:112: warning: The following parameters of instantiate(const string_not_contains_constraintt &axiom, const index_set_pairt &index_set, const string_constraint_generatort &generator, const std::unordered_map< string_not_contains_constraintt, symbol_exprt > &witnesses) are not documented:
-  parameter 'witnesses'
 /cbmc/src/solvers/refinement/string_refinement.cpp:1052: warning: The following parameters of substitute_array_access(const with_exprt &expr, const exprt &index, const bool left_propagate) are not documented:
   parameter 'left_propagate'
 /cbmc/doc/architectural/howto.md:260: warning: found </div> at different nesting level (6) than expected (3)

--- a/src/solvers/README.md
+++ b/src/solvers/README.md
@@ -302,8 +302,8 @@ allocates a new string before calling a primitive.
     \copybrief add_axioms_from_float_scientific_notation
     \link add_axioms_from_float_scientific_notation More... \endlink
   * `cprover_string_of_char` :
-    \copybrief add_axioms_from_char(symbol_generatort &fresh_symbol, const function_application_exprt &f, array_poolt &array_pool)
-    \link add_axioms_from_char(symbol_generatort &fresh_symbol, const function_application_exprt &f, array_poolt &array_pool) More... \endlink
+    \copybrief add_axioms_from_char(const function_application_exprt &f, array_poolt &array_pool)
+    \link add_axioms_from_char(const function_application_exprt &f, array_poolt &array_pool) More... \endlink
   * `cprover_string_parse_int` :
     \copybrief add_axioms_for_parse_int
     \link add_axioms_for_parse_int More... \endlink

--- a/src/solvers/refinement/string_builtin_function.cpp
+++ b/src/solvers/refinement/string_builtin_function.cpp
@@ -567,7 +567,7 @@ string_constraintst string_of_int_builtin_functiont::constraints(
   string_constraint_generatort &generator) const
 {
   auto pair = add_axioms_for_string_of_int_with_radix(
-    generator.fresh_symbol, result, arg, radix, 0, generator.ns);
+    result, arg, radix, 0, generator.ns);
   pair.second.existential.push_back(equal_exprt(pair.first, return_code));
   return pair.second;
 }

--- a/src/solvers/refinement/string_constraint_generator.h
+++ b/src/solvers/refinement/string_constraint_generator.h
@@ -198,7 +198,6 @@ std::pair<exprt, string_constraintst> add_axioms_for_insert(
   const array_string_exprt &s2,
   const exprt &offset);
 std::pair<exprt, string_constraintst> add_axioms_for_string_of_int_with_radix(
-  symbol_generatort &fresh_symbol,
   const array_string_exprt &res,
   const exprt &input_int,
   const exprt &radix,
@@ -357,38 +356,30 @@ std::pair<exprt, string_constraintst> add_axioms_from_literal(
   array_poolt &array_pool);
 
 std::pair<exprt, string_constraintst> add_axioms_for_string_of_int(
-  symbol_generatort &fresh_symbol,
   const array_string_exprt &res,
   const exprt &input_int,
   size_t max_size,
   const namespacet &ns);
 std::pair<exprt, string_constraintst> add_axioms_from_int_hex(
-  symbol_generatort &fresh_symbol,
   const array_string_exprt &res,
   const exprt &i);
 std::pair<exprt, string_constraintst> add_axioms_from_int_hex(
-  symbol_generatort &fresh_symbol,
   const function_application_exprt &f,
   array_poolt &array_pool);
 std::pair<exprt, string_constraintst> add_axioms_from_long(
-  symbol_generatort &fresh_symbol,
   const function_application_exprt &f,
   array_poolt &array_pool,
   const namespacet &ns);
 std::pair<exprt, string_constraintst> add_axioms_from_bool(
-  symbol_generatort &fresh_symbol,
   const function_application_exprt &f,
   array_poolt &array_pool);
 std::pair<exprt, string_constraintst> add_axioms_from_bool(
-  symbol_generatort &fresh_symbol,
   const array_string_exprt &res,
   const exprt &i);
 std::pair<exprt, string_constraintst> add_axioms_from_char(
-  symbol_generatort &fresh_symbol,
   const function_application_exprt &f,
   array_poolt &array_pool);
 std::pair<exprt, string_constraintst> add_axioms_from_char(
-  symbol_generatort &fresh_symbol,
   const array_string_exprt &res,
   const exprt &i);
 std::pair<exprt, string_constraintst> add_axioms_for_index_of(

--- a/src/solvers/refinement/string_constraint_generator_float.cpp
+++ b/src/solvers/refinement/string_constraint_generator_float.cpp
@@ -232,8 +232,8 @@ std::pair<exprt, string_constraintst> add_axioms_for_string_of_float(
   // part of the float.
   const array_string_exprt integer_part_str =
     array_pool.fresh_string(index_type, char_type);
-  auto result2 = add_axioms_for_string_of_int(
-    fresh_symbol, integer_part_str, integer_part, 8, ns);
+  auto result2 =
+    add_axioms_for_string_of_int(integer_part_str, integer_part, 8, ns);
 
   auto result3 = add_axioms_for_concat(
     fresh_symbol, res, integer_part_str, fractional_part_str);
@@ -458,7 +458,7 @@ std::pair<exprt, string_constraintst> add_axioms_from_float_scientific_notation(
   array_string_exprt string_expr_integer_part =
     array_pool.fresh_string(index_type, char_type);
   auto result1 = add_axioms_for_string_of_int(
-    fresh_symbol, string_expr_integer_part, dec_significand_int, 3, ns);
+    string_expr_integer_part, dec_significand_int, 3, ns);
   minus_exprt fractional_part(
     dec_significand, floatbv_of_int_expr(dec_significand_int, float_spec));
 
@@ -505,8 +505,8 @@ std::pair<exprt, string_constraintst> add_axioms_from_float_scientific_notation(
   // exponent_string = string_of_int(decimal_exponent)
   const array_string_exprt exponent_string =
     array_pool.fresh_string(index_type, char_type);
-  auto result6 = add_axioms_for_string_of_int(
-    fresh_symbol, exponent_string, decimal_exponent, 3, ns);
+  auto result6 =
+    add_axioms_for_string_of_int(exponent_string, decimal_exponent, 3, ns);
 
   // string_expr = concat(string_expr_with_E, exponent_string)
   auto result7 = add_axioms_for_concat(

--- a/src/solvers/refinement/string_constraint_generator_format.cpp
+++ b/src/solvers/refinement/string_constraint_generator_format.cpp
@@ -274,11 +274,11 @@ add_axioms_for_format_specifier(
   {
   case format_specifiert::DECIMAL_INTEGER:
     return_code = add_axioms_for_string_of_int(
-      fresh_symbol, res, get_component_in_struct(arg, ID_int), 0, ns);
+      res, get_component_in_struct(arg, ID_int), 0, ns);
     return {res, std::move(return_code.second)};
   case format_specifiert::HEXADECIMAL_INTEGER:
-    return_code = add_axioms_from_int_hex(
-      fresh_symbol, res, get_component_in_struct(arg, ID_int));
+    return_code =
+      add_axioms_from_int_hex(res, get_component_in_struct(arg, ID_int));
     return {res, std::move(return_code.second)};
   case format_specifiert::SCIENTIFIC:
     return_code = add_axioms_from_float_scientific_notation(
@@ -297,12 +297,12 @@ add_axioms_for_format_specifier(
       ns);
     return {res, std::move(return_code.second)};
   case format_specifiert::CHARACTER:
-    return_code = add_axioms_from_char(
-      fresh_symbol, res, get_component_in_struct(arg, ID_char));
+    return_code =
+      add_axioms_from_char(res, get_component_in_struct(arg, ID_char));
     return {res, std::move(return_code.second)};
   case format_specifiert::BOOLEAN:
-    return_code = add_axioms_from_bool(
-      fresh_symbol, res, get_component_in_struct(arg, ID_boolean));
+    return_code =
+      add_axioms_from_bool(res, get_component_in_struct(arg, ID_boolean));
     return {res, std::move(return_code.second)};
   case format_specifiert::STRING:
     return {
@@ -310,7 +310,7 @@ add_axioms_for_format_specifier(
       {}};
   case format_specifiert::HASHCODE:
     return_code = add_axioms_for_string_of_int(
-      fresh_symbol, res, get_component_in_struct(arg, "hashcode"), 0, ns);
+      res, get_component_in_struct(arg, "hashcode"), 0, ns);
     return {res, std::move(return_code.second)};
   case format_specifiert::LINE_SEPARATOR:
     // TODO: the constant should depend on the system: System.lineSeparator()

--- a/src/solvers/refinement/string_constraint_generator_insert.cpp
+++ b/src/solvers/refinement/string_constraint_generator_insert.cpp
@@ -156,7 +156,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_insert_int(
   const typet &char_type = s1.content().type().subtype();
   const array_string_exprt s2 = array_pool.fresh_string(index_type, char_type);
   return combine_results(
-    add_axioms_for_string_of_int(fresh_symbol, s2, f.arguments()[4], 0, ns),
+    add_axioms_for_string_of_int(s2, f.arguments()[4], 0, ns),
     add_axioms_for_insert(fresh_symbol, res, s1, s2, offset));
 }
 
@@ -182,7 +182,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_insert_bool(
   const typet &char_type = s1.content().type().subtype();
   const array_string_exprt s2 = array_pool.fresh_string(index_type, char_type);
   return combine_results(
-    add_axioms_from_bool(fresh_symbol, s2, f.arguments()[4]),
+    add_axioms_from_bool(s2, f.arguments()[4]),
     add_axioms_for_insert(fresh_symbol, res, s1, s2, offset));
 }
 
@@ -207,7 +207,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_insert_char(
   const typet &char_type = s1.content().type().subtype();
   const array_string_exprt s2 = array_pool.fresh_string(index_type, char_type);
   return combine_results(
-    add_axioms_from_char(fresh_symbol, s2, f.arguments()[4]),
+    add_axioms_from_char(s2, f.arguments()[4]),
     add_axioms_for_insert(fresh_symbol, res, s1, s2, offset));
 }
 

--- a/src/solvers/refinement/string_constraint_generator_main.cpp
+++ b/src/solvers/refinement/string_constraint_generator_main.cpp
@@ -440,7 +440,7 @@ string_constraint_generatort::add_axioms_for_function_application(
   else if(id==ID_cprover_string_copy_func)
     return add_axioms_for_copy(fresh_symbol, expr, array_pool);
   else if(id==ID_cprover_string_of_int_hex_func)
-    return add_axioms_from_int_hex(fresh_symbol, expr, array_pool);
+    return add_axioms_from_int_hex(expr, array_pool);
   else if(id==ID_cprover_string_of_float_func)
     return add_axioms_for_string_of_float(fresh_symbol, expr, array_pool, ns);
   else if(id==ID_cprover_string_of_float_scientific_notation_func)
@@ -449,11 +449,11 @@ string_constraint_generatort::add_axioms_for_function_application(
   else if(id==ID_cprover_string_of_double_func)
     return add_axioms_from_double(fresh_symbol, expr, array_pool, ns);
   else if(id==ID_cprover_string_of_long_func)
-    return add_axioms_from_long(fresh_symbol, expr, array_pool, ns);
+    return add_axioms_from_long(expr, array_pool, ns);
   else if(id==ID_cprover_string_of_bool_func)
-    return add_axioms_from_bool(fresh_symbol, expr, array_pool);
+    return add_axioms_from_bool(expr, array_pool);
   else if(id==ID_cprover_string_of_char_func)
-    return add_axioms_from_char(fresh_symbol, expr, array_pool);
+    return add_axioms_from_char(expr, array_pool);
   else if(id==ID_cprover_string_set_length_func)
     return add_axioms_for_set_length(fresh_symbol, expr, array_pool);
   else if(id==ID_cprover_string_delete_func)

--- a/src/solvers/refinement/string_constraint_generator_valueof.cpp
+++ b/src/solvers/refinement/string_constraint_generator_valueof.cpp
@@ -37,14 +37,12 @@ static unsigned long to_integer_or_default(
 
 /// Add axioms corresponding to the String.valueOf(J) java function.
 /// \deprecated should use add_axioms_from_int instead
-/// \param fresh_symbol: generator of fresh symbols
 /// \param f: function application with one long argument
 /// \param array_pool: pool of arrays representing strings
 /// \param ns: namespace
 /// \return a new string expression
 DEPRECATED("should use add_axioms_for_string_of_int instead")
 std::pair<exprt, string_constraintst> add_axioms_from_long(
-  symbol_generatort &fresh_symbol,
   const function_application_exprt &f,
   array_poolt &array_pool,
   const namespacet &ns)
@@ -54,40 +52,35 @@ std::pair<exprt, string_constraintst> add_axioms_from_long(
     char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
   if(f.arguments().size() == 4)
     return add_axioms_for_string_of_int_with_radix(
-      fresh_symbol, res, f.arguments()[2], f.arguments()[3], 0, ns);
+      res, f.arguments()[2], f.arguments()[3], 0, ns);
   else
-    return add_axioms_for_string_of_int(
-      fresh_symbol, res, f.arguments()[2], 0, ns);
+    return add_axioms_for_string_of_int(res, f.arguments()[2], 0, ns);
 }
 
 /// Add axioms corresponding to the String.valueOf(Z) java function.
 /// \deprecated This is Java specific and should be implemented in Java instead
-/// \param fresh_symbol: generator of fresh symbols
 /// \param f: function application with a Boolean argument
 /// \param array_pool: pool of arrays representing strings
 /// \return a new string expression
 DEPRECATED("This is Java specific and should be implemented in Java instead")
 std::pair<exprt, string_constraintst> add_axioms_from_bool(
-  symbol_generatort &fresh_symbol,
   const function_application_exprt &f,
   array_poolt &array_pool)
 {
   PRECONDITION(f.arguments().size() == 3);
   const array_string_exprt res =
     char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
-  return add_axioms_from_bool(fresh_symbol, res, f.arguments()[2]);
+  return add_axioms_from_bool(res, f.arguments()[2]);
 }
 
 /// Add axioms stating that the returned string equals "true" when the Boolean
 /// expression is true and "false" when it is false.
 /// \deprecated This is Java specific and should be implemented in Java instead
-/// \param fresh_symbol: generator of fresh symbols
 /// \param res: string expression for the result
 /// \param b: Boolean expression
 /// \return code 0 on success
 DEPRECATED("This is Java specific and should be implemented in Java instead")
 std::pair<exprt, string_constraintst> add_axioms_from_bool(
-  symbol_generatort &fresh_symbol,
   const array_string_exprt &res,
   const exprt &b)
 {
@@ -130,7 +123,6 @@ std::pair<exprt, string_constraintst> add_axioms_from_bool(
 /// Add axioms enforcing that the string corresponds to the result
 /// of String.valueOf(I) or String.valueOf(J) Java functions applied
 /// on the integer expression.
-/// \param fresh_symbol: generator of fresh symbols
 /// \param res: string expression for the result
 /// \param input_int: a signed integer expression
 /// \param max_size: a maximal size for the string representation (default 0,
@@ -138,7 +130,6 @@ std::pair<exprt, string_constraintst> add_axioms_from_bool(
 /// \param ns: namespace
 /// \return code 0 on success
 std::pair<exprt, string_constraintst> add_axioms_for_string_of_int(
-  symbol_generatort &fresh_symbol,
   const array_string_exprt &res,
   const exprt &input_int,
   size_t max_size,
@@ -146,13 +137,12 @@ std::pair<exprt, string_constraintst> add_axioms_for_string_of_int(
 {
   const constant_exprt radix=from_integer(10, input_int.type());
   return add_axioms_for_string_of_int_with_radix(
-    fresh_symbol, res, input_int, radix, max_size, ns);
+    res, input_int, radix, max_size, ns);
 }
 
 /// Add axioms enforcing that the string corresponds to the result
 /// of String.valueOf(II) or String.valueOf(JI) Java functions applied
 /// on the integer expression.
-/// \param fresh_symbol: generator of fresh symbols
 /// \param res: string expression for the result
 /// \param input_int: a signed integer expression
 /// \param radix: the radix to use
@@ -161,7 +151,6 @@ std::pair<exprt, string_constraintst> add_axioms_for_string_of_int(
 /// \param ns: namespace
 /// \return code 0 on success
 std::pair<exprt, string_constraintst> add_axioms_for_string_of_int_with_radix(
-  symbol_generatort &fresh_symbol,
   const array_string_exprt &res,
   const exprt &input_int,
   const exprt &radix,
@@ -220,13 +209,11 @@ static exprt int_of_hex_char(const exprt &chr)
 /// Add axioms stating that the string `res` corresponds to the integer
 /// argument written in hexadecimal.
 /// \deprecated use add_axioms_from_int_with_radix instead
-/// \param fresh_symbol: generator of fresh symbols
 /// \param res: string expression for the result
 /// \param i: an integer argument
 /// \return code 0 on success
 DEPRECATED("use add_axioms_for_string_of_int_with_radix instead")
 std::pair<exprt, string_constraintst> add_axioms_from_int_hex(
-  symbol_generatort &fresh_symbol,
   const array_string_exprt &res,
   const exprt &i)
 {
@@ -280,54 +267,48 @@ std::pair<exprt, string_constraintst> add_axioms_from_int_hex(
 }
 
 /// Add axioms corresponding to the Integer.toHexString(I) java function
-/// \param fresh_symbol: generator of fresh symbols
 /// \param f: function application with an integer argument
 /// \param array_pool: pool of arrays representing strings
 /// \return code 0 on success
 std::pair<exprt, string_constraintst> add_axioms_from_int_hex(
-  symbol_generatort &fresh_symbol,
   const function_application_exprt &f,
   array_poolt &array_pool)
 {
   PRECONDITION(f.arguments().size() == 3);
   const array_string_exprt res =
     char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
-  return add_axioms_from_int_hex(fresh_symbol, res, f.arguments()[2]);
+  return add_axioms_from_int_hex(res, f.arguments()[2]);
 }
 
 /// Conversion from char to string
 ///
 // NOLINTNEXTLINE
-/// \copybrief add_axioms_from_char(symbol_generatort &fresh_symbol, const array_string_exprt &res, const exprt &c)
+/// \copybrief add_axioms_from_char(const array_string_exprt &res, const exprt &c)
 // NOLINTNEXTLINE
-/// \link add_axioms_from_char(symbol_generatort &fresh_symbol, const array_string_exprt &res, const exprt &c)
+/// \link add_axioms_from_char(const array_string_exprt &res, const exprt &c)
 ///    (More...) \endlink
-/// \param fresh_symbol: generator of fresh symbols
 /// \param f: function application with arguments integer `|res|`, character
 ///           pointer `&res[0]` and character `c`
 /// \param array_pool: pool of arrays representing strings
 /// \return code 0 on success
 std::pair<exprt, string_constraintst> add_axioms_from_char(
-  symbol_generatort &fresh_symbol,
   const function_application_exprt &f,
   array_poolt &array_pool)
 {
   PRECONDITION(f.arguments().size() == 3);
   const array_string_exprt res =
     char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
-  return add_axioms_from_char(fresh_symbol, res, f.arguments()[2]);
+  return add_axioms_from_char(res, f.arguments()[2]);
 }
 
 /// Add axiom stating that string `res` has length 1 and the character
 /// it contains equals `c`.
 ///
 /// This axiom is: \f$ |{\tt res}| = 1 \land {\tt res}[0] = {\tt c} \f$.
-/// \param fresh_symbol: generator of fresh symbols
 /// \param res: array of characters expression
 /// \param c: character expression
 /// \return code 0 on success
 std::pair<exprt, string_constraintst> add_axioms_from_char(
-  symbol_generatort &fresh_symbol,
   const array_string_exprt &res,
   const exprt &c)
 {

--- a/src/solvers/refinement/string_refinement.cpp
+++ b/src/solvers/refinement/string_refinement.cpp
@@ -112,7 +112,6 @@ static exprt instantiate(
 static std::vector<exprt> instantiate(
   const string_not_contains_constraintt &axiom,
   const index_set_pairt &index_set,
-  const string_constraint_generatort &generator,
   const std::unordered_map<string_not_contains_constraintt, symbol_exprt>
     &witnesses);
 
@@ -226,10 +225,9 @@ static void display_index_set(
 ///     \f$\forall x. P(x) \Rightarrow \exists y .s_0[x+y] \ne s_1[y]) \f$ we
 ///     need to look at the index set of both `s_0` and `s_1`.
 // NOLINTNEXTLINE(whitespace/line_length)
-///     (See `instantiate(const string_not_contains_constraintt&,const index_set_pairt&,const string_constraint_generatort&,const std::map<string_not_contains_constraintt, symbol_exprt>&)`
+///     (See `instantiate(const string_not_contains_constraintt&,const index_set_pairt&,const std::map<string_not_contains_constraintt, symbol_exprt>&)`
 ///      for details)
 static std::vector<exprt> generate_instantiations(
-  const string_constraint_generatort &generator,
   const index_set_pairt &index_set,
   const string_axiomst &axioms,
   const std::unordered_map<string_not_contains_constraintt, symbol_exprt>
@@ -247,7 +245,7 @@ static std::vector<exprt> generate_instantiations(
   for(const auto &nc_axiom : axioms.not_contains)
   {
     for(const auto &instance :
-        instantiate(nc_axiom, index_set, generator, not_contain_witnesses))
+        instantiate(nc_axiom, index_set, not_contain_witnesses))
       lemmas.push_back(instance);
   }
   return lemmas;
@@ -771,8 +769,8 @@ decision_proceduret::resultt string_refinementt::dec_solve()
   initial_index_set(index_sets, ns, axioms);
   update_index_set(index_sets, ns, current_constraints);
   current_constraints.clear();
-  const auto instances = generate_instantiations(
-    generator, index_sets, axioms, not_contain_witnesses);
+  const auto instances =
+    generate_instantiations(index_sets, axioms, not_contain_witnesses);
   for(const auto &instance : instances)
     add_lemma(instance);
 
@@ -829,8 +827,8 @@ decision_proceduret::resultt string_refinementt::dec_solve()
         }
       }
       current_constraints.clear();
-      const auto instances = generate_instantiations(
-        generator, index_sets, axioms, not_contain_witnesses);
+      const auto instances =
+        generate_instantiations(index_sets, axioms, not_contain_witnesses);
       for(const auto &instance : instances)
         add_lemma(instance);
     }
@@ -1882,12 +1880,11 @@ static exprt instantiate(
 /// entailed by a (transformed) axiom.
 /// \param [in] axiom: the axiom to instantiate
 /// \param index_set: set of indexes
-/// \param generator: constraint generator object
+/// \param witnesses: \p axiom's witnesses for non-containment
 /// \return the lemmas produced through instantiation
 static std::vector<exprt> instantiate(
   const string_not_contains_constraintt &axiom,
   const index_set_pairt &index_set,
-  const string_constraint_generatort &generator,
   const std::unordered_map<string_not_contains_constraintt, symbol_exprt>
     &witnesses)
 {


### PR DESCRIPTION
The generator is no longer used in the implementation, and thus does not need to
be passed around. Also update the documentation.

@romainbrenguier Existing PRs of yours might make this one redundant, happy to close it and wait for them to be merged.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
