### PR TITLE
Explicitly compare to zero to avoid Visual Studio warning [blocks: #2310]

### DIFF
--- a/src/util/small_shared_two_way_ptr.h
+++ b/src/util/small_shared_two_way_ptr.h
@@ -272,7 +272,7 @@ public:
 
   bool is_derived_v() const
   {
-    return use_count_ & ~mask;
+    return (use_count_ & ~mask) != 0;
   }
 
   bool is_same_type(const small_shared_two_way_pointeet &other) const


### PR DESCRIPTION
Visual Studio complains: forcing value to bool 'true' or 'false' (performance
warning)

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
