### PR TITLE
Do not shadow class member "symbol_table" [blocks: #2310]

### DIFF
--- a/src/goto-programs/lazy_goto_model.cpp
+++ b/src/goto-programs/lazy_goto_model.cpp
@@ -247,16 +247,16 @@ void lazy_goto_modelt::load_all_functions() const
 bool lazy_goto_modelt::finalize()
 {
   messaget msg(message_handler);
-  journalling_symbol_tablet symbol_table=
-    journalling_symbol_tablet::wrap(this->symbol_table);
-  if(language_files.final(symbol_table))
+  journalling_symbol_tablet j_symbol_table =
+    journalling_symbol_tablet::wrap(symbol_table);
+  if(language_files.final(j_symbol_table))
   {
     msg.error() << "CONVERSION ERROR" << messaget::eom;
     return true;
   }
-  for(const irep_idt &updated_symbol_id : symbol_table.get_updated())
+  for(const irep_idt &updated_symbol_id : j_symbol_table.get_updated())
   {
-    if(symbol_table.lookup_ref(updated_symbol_id).is_function())
+    if(j_symbol_table.lookup_ref(updated_symbol_id).is_function())
     {
       // Re-convert any that already exist
       goto_functions.unload(updated_symbol_id);


### PR DESCRIPTION
Prefix the journalling symbol table with "j_"

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
