### PR TITLE
Avoid implicit conversion to bool and actually use return value [blocks: #2310]

### DIFF
--- a/src/goto-programs/osx_fat_reader.cpp
+++ b/src/goto-programs/osx_fat_reader.cpp
@@ -88,5 +88,7 @@ bool osx_fat_readert::extract_gb(
 {
   PRECONDITION(has_gb_arch);
 
-  return run("lipo", {"lipo", "-thin", "hppa7100LC", "-output", dest, source});
+  return run(
+           "lipo", {"lipo", "-thin", "hppa7100LC", "-output", dest, source}) !=
+         0;
 }

--- a/src/goto-programs/read_goto_binary.cpp
+++ b/src/goto-programs/read_goto_binary.cpp
@@ -135,7 +135,11 @@ bool read_goto_binary(
     if(osx_fat_reader.has_gb())
     {
       temporary_filet tempname("tmp.goto-binary", ".gb");
-      osx_fat_reader.extract_gb(filename, tempname());
+      if(osx_fat_reader.extract_gb(filename, tempname()))
+      {
+        message.error() << "failed to extract goto binary" << messaget::eom;
+        return true;
+      }
 
       std::ifstream temp_in(tempname(), std::ios::binary);
       if(!temp_in)


### PR DESCRIPTION
The function was declared to return a bool (that was never read) and did so from
a function call returning an int. Make conversion explicit and actually test on
that return value.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
