### PR TITLE
Avoid shadowing "symbol" [blocks: #2310]

### DIFF
--- a/src/cpp/cpp_typecheck.cpp
+++ b/src/cpp/cpp_typecheck.cpp
@@ -232,7 +232,7 @@ void cpp_typecheckt::do_not_typechecked()
         symbol.value.get_bool(ID_is_used))
       {
         assert(symbol.type.id()==ID_code);
-        symbolt &symbol=*symbol_table.get_writeable(named_symbol.first);
+        exprt value = symbol.value;
 
         if(symbol.base_name=="operator=")
         {
@@ -240,19 +240,21 @@ void cpp_typecheckt::do_not_typechecked()
           declarator.add_source_location() = symbol.location;
           default_assignop_value(
             lookup(symbol.type.get(ID_C_member_name)), declarator);
-          symbol.value.swap(declarator.value());
-          convert_function(symbol);
+          value.swap(declarator.value());
           cont=true;
         }
         else if(symbol.value.operands().size()==1)
         {
-          exprt tmp = symbol.value.op0();
-          symbol.value.swap(tmp);
-          convert_function(symbol);
+          value = symbol.value.op0();
           cont=true;
         }
         else
           UNREACHABLE; // Don't know what to do!
+
+        symbolt &writable_symbol =
+          *symbol_table.get_writeable(named_symbol.first);
+        writable_symbol.value.swap(value);
+        convert_function(writable_symbol);
       }
     }
   }


### PR DESCRIPTION
It used to refer to both the writable and the non-writable reference of it.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
