### PR TITLE
Do not shadow "resolved" [blocks: #2310]

### DIFF
--- a/src/goto-programs/remove_const_function_pointers.cpp
+++ b/src/goto-programs/remove_const_function_pointers.cpp
@@ -697,11 +697,10 @@ bool remove_const_function_pointerst::try_resolve_dereference(
         address_of_exprt address_expr=to_address_of_expr(pointer_val);
         bool object_const=false;
         expressionst out_object_values;
-        bool resolved=
-          try_resolve_expression(
-            address_expr.object(), out_object_values, object_const);
+        const bool resolved_address = try_resolve_expression(
+          address_expr.object(), out_object_values, object_const);
 
-        if(resolved)
+        if(resolved_address)
         {
           out_expressions.insert(
             out_expressions.end(),


### PR DESCRIPTION
The values refer to different invocations of the resolving attempt.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
