### PR TITLE
Make messaget a member [blocks: #2310]

### DIFF
--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -30,7 +30,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "compute_called_functions.h"
 #include "remove_const_function_pointers.h"
 
-class remove_function_pointerst:public messaget
+class remove_function_pointerst
 {
 public:
   remove_function_pointerst(
@@ -59,6 +59,7 @@ public:
     const functionst &functions);
 
 protected:
+  messaget log;
   const namespacet ns;
   symbol_tablet &symbol_table;
   bool add_safety_assertion;
@@ -112,13 +113,14 @@ protected:
 remove_function_pointerst::remove_function_pointerst(
   message_handlert &_message_handler,
   symbol_tablet &_symbol_table,
-  bool _add_safety_assertion, bool only_resolve_const_fps,
-  const goto_functionst &goto_functions):
-  messaget(_message_handler),
-  ns(_symbol_table),
-  symbol_table(_symbol_table),
-  add_safety_assertion(_add_safety_assertion),
-  only_resolve_const_fps(only_resolve_const_fps)
+  bool _add_safety_assertion,
+  bool only_resolve_const_fps,
+  const goto_functionst &goto_functions)
+  : log(_message_handler),
+    ns(_symbol_table),
+    symbol_table(_symbol_table),
+    add_safety_assertion(_add_safety_assertion),
+    only_resolve_const_fps(only_resolve_const_fps)
 {
   compute_address_taken_in_symbols(address_taken);
   compute_address_taken_functions(goto_functions, address_taken);
@@ -304,15 +306,16 @@ void remove_function_pointerst::remove_function_pointer(
   const auto does_remove_const = const_removal_check();
   if(does_remove_const.first)
   {
-    warning().source_location = does_remove_const.second;
-    warning() << "cast from const to non-const pointer found, only worst case"
-              << " function pointer removal will be done." << eom;
+    log.warning().source_location = does_remove_const.second;
+    log.warning() << "cast from const to non-const pointer found, "
+                  << "only worst case function pointer removal will be done."
+                  << messaget::eom;
     found_functions=false;
   }
   else
   {
     remove_const_function_pointerst fpr(
-    get_message_handler(), ns, symbol_table);
+      log.get_message_handler(), ns, symbol_table);
 
     found_functions=fpr(pointer, functions);
 
@@ -455,14 +458,13 @@ void remove_function_pointerst::remove_function_pointer(
   target->type=OTHER;
 
   // report statistics
-  statistics().source_location=target->source_location;
-  statistics() << "replacing function pointer by "
-               << functions.size() << " possible targets" << eom;
+  log.statistics().source_location = target->source_location;
+  log.statistics() << "replacing function pointer by " << functions.size()
+                   << " possible targets" << messaget::eom;
 
   // list the names of functions when verbosity is at debug level
-  conditional_output(
-    debug(),
-    [&functions](mstreamt &mstream) {
+  log.conditional_output(
+    log.debug(), [&functions](messaget::mstreamt &mstream) {
       mstream << "targets: ";
 
       bool first = true;
@@ -475,7 +477,7 @@ void remove_function_pointerst::remove_function_pointer(
         first = false;
       }
 
-      mstream << eom;
+      mstream << messaget::eom;
     });
 }
 


### PR DESCRIPTION
remove_function_pointerst is not a logger, but instead it now has one. This
avoids a somewhat surprising shadowing of an "mstream" class member, which
really just is messaget's class member.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
