### PR TITLE
Inline single use of compute_address_taken_in_symbols [blocks: #2310]

### DIFF
--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -98,15 +98,6 @@ protected:
   void fix_return_type(
     code_function_callt &function_call,
     goto_programt &dest);
-
-  void
-  compute_address_taken_in_symbols(std::unordered_set<irep_idt> &address_taken)
-  {
-    const symbol_tablet &symbol_table=ns.get_symbol_table();
-
-    for(const auto &s : symbol_table.symbols)
-      compute_address_taken_functions(s.second.value, address_taken);
-  }
 };
 
 remove_function_pointerst::remove_function_pointerst(
@@ -120,7 +111,9 @@ remove_function_pointerst::remove_function_pointerst(
   add_safety_assertion(_add_safety_assertion),
   only_resolve_const_fps(only_resolve_const_fps)
 {
-  compute_address_taken_in_symbols(address_taken);
+  for(const auto &s : symbol_table.symbols)
+    compute_address_taken_functions(s.second.value, address_taken);
+
   compute_address_taken_functions(goto_functions, address_taken);
 
   // build type map


### PR DESCRIPTION
This avoids multiple variable shadowing and just overall shortens the code.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
