### PR TITLE
RFC: enabling redaction of sensitive cprover output [design only]

### DIFF
--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -20,6 +20,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/exception_utils.h>
 #include <util/exit_codes.h>
 #include <util/invariant.h>
+#include <util/ostream_redactedt.h>
 #include <util/unicode.h>
 #include <util/version.h>
 
@@ -403,7 +404,10 @@ int cbmc_parse_optionst::doit()
 {
   if(cmdline.isset("version"))
   {
-    std::cout << CBMC_VERSION << '\n';
+    //redact, but disable for next
+    ostream_redacted_cout<< redact_off_next << CBMC_VERSION << '\n';
+    //always disable redaction for next is also possible
+    ostream_redact_off_cout<<CBMC_VERSION << '\n';
     return CPROVER_EXIT_SUCCESS;
   }
 

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -17,6 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "invariant.h"
 #include "json.h"
+#include "ostream_redactedt.h"
 #include "source_location.h"
 
 class xmlt;
@@ -185,7 +186,7 @@ public:
 
   virtual ~messaget();
 
-  class mstreamt:public std::ostringstream
+  class mstreamt : public ostream_redactedt
   {
   public:
     mstreamt(
@@ -236,7 +237,7 @@ public:
     template <class T>
     mstreamt &operator << (const T &x)
     {
-      static_cast<std::ostream &>(*this) << x;
+      redact(x);
       return *this;
     }
 

--- a/src/util/ostream_redactedt.cpp
+++ b/src/util/ostream_redactedt.cpp
@@ -1,0 +1,16 @@
+/*******************************************************************\
+
+Module: ostream_redactedt
+
+Author: Diffblue
+
+Date: Oct 2018
+
+\*******************************************************************/
+#include "ostream_redactedt.h"
+
+ostream_redactedt ostream_redacted_cout(std::cout);
+ostream_redactedt ostream_redacted_cerr(std::cerr);
+
+ostream_redactedt ostream_redact_off_cout(std::cout, false);
+ostream_redactedt ostream_redact_off_cerr(std::cerr, false);

--- a/src/util/ostream_redactedt.h
+++ b/src/util/ostream_redactedt.h
@@ -1,0 +1,241 @@
+/*******************************************************************\
+
+Module: ostream_redactedt
+
+Author: Diffblue
+
+Date: Oct 2018
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_OSTREAM_REDACTEDT_H
+#define CPROVER_UTIL_OSTREAM_REDACTEDT_H
+
+#include <cstring>
+#include <iostream>
+#include <ostream>
+#include <regex>
+#include <sstream>
+#include <string>
+
+class ostream_redactedt : public std::ostringstream
+{
+private:
+  // utility ostream and streambuf classes to enable sync with cin flushing - as happens for cout
+  // this method of implmentation is required due to:
+  // (ostream has non-virtual flush & no sync function,
+  // only streambuf has a virtual sync() function
+  class Sync_ostream : public std::ostream
+  {
+  private:
+    class outbuf : public std::streambuf
+    {
+    private:
+      int sync() override
+      {
+        parentstream->flush();
+        return 0;
+      };
+
+    public:
+      ostream_redactedt *parentstream;
+    };
+    outbuf syncbuffer;
+
+  public:
+    Sync_ostream() : std::ostream{&syncbuffer}
+    {
+    }
+
+    void operator()(ostream_redactedt *parent)
+    {
+      syncbuffer.parentstream = parent;
+    }
+  };
+  Sync_ostream sync_ostream;
+
+public:
+  ostream_redactedt(std::ostream &stream=std::cout, bool redact_on=true) :
+    flush_output{&stream}, redact_on{redact_on}
+  {
+    sync_ostream(this);
+    // sync with cin is non-essential, but nice to have the option to do so
+    // when class is used as an alternative to std::cout
+    // (this enables automatic output flush prior to cin, as is customary for
+    // std::cout)
+    std::cin.tie(get_sync_ostream());
+  }
+
+  ~ostream_redactedt()
+  {
+    flush();
+  }
+
+  Sync_ostream *get_sync_ostream()
+  {
+    return &sync_ostream;
+  }
+
+  template <typename T>
+  void redact(const T &val){
+    if (redact_on)
+    {
+      static_cast<std::ostream &>(*this)
+        << redactstartTOKEN << val << redactendTOKEN;
+    }else{
+      static_cast<std::ostream &>(*this)<<val;
+    }
+  }
+
+  template <typename T>
+  ostream_redactedt &operator<<(const T &val)
+  {
+    redact(val);
+    return *this;
+  }
+
+  // enable new line flushing behaviour ("\n")
+  ostream_redactedt &operator<<(const char *str)
+  {
+    auto &sstemp = static_cast<std::ostream &>(*this);
+    //C/ this if block forces each new line to be wrapped in redaction tokens
+    if(strcmp("\n", str) == 0)
+    {
+      sstemp << str; // no need for redact tokens around a new line
+    }
+    else
+    {
+      redact(str);
+    }
+    return *this;
+  }
+
+  // enable new line flushing behaviour (single char, i.e. '\n')
+  ostream_redactedt &operator<<(const char character)
+  {
+    auto &sstemp = static_cast<std::ostream &>(*this);
+
+    if(character == '\n')
+    {
+      sstemp << character; // no need for redact tokens around a new line
+    }
+    else
+    {
+      redact(character);
+    }
+    return *this;
+  }
+
+  // std::endl support
+  ostream_redactedt &operator<<(std::ostream &(*fp)(std::ostream &))
+  {
+    // detect std::endl and act accordingly
+    if(fp == static_cast<std::ostream &(*)(std::ostream &)>(&std::endl))
+    {
+      static_cast<std::ostream &>(*this) << "\n";
+      flush();
+    }
+    else
+    {
+      static_cast<std::ostream &>(*this) << fp;
+    }
+    return *this;
+  }
+
+  // std::hex et al support
+  ostream_redactedt &operator<<(std::ios_base &(*fp)(std::ios_base &))
+  {
+    static_cast<std::ostream &>(*this) << fp;
+    return *this;
+  }
+
+  std::string str()
+  {
+    // quite likely this method implementation can be optimised
+    std::string sbufstring{std::ostringstream::str()};
+    std::regex pattern(redactendTOKEN + redactstartTOKEN);
+    sbufstring = std::regex_replace(sbufstring, pattern, "");
+
+    // replace redaction tokens with user choice
+    pattern = redactstartTOKEN;
+    sbufstring = std::regex_replace(sbufstring, pattern, redactstart);
+    pattern = redactendTOKEN;
+    sbufstring = std::regex_replace(sbufstring, pattern, redactend);
+
+    return sbufstring;
+  }
+
+  void str(std::string str)
+  {
+      std::ostringstream::str(str);
+  }
+
+  void flush()
+  { // nb called upon destruction
+    if (flush_output)
+    {
+      *flush_output << str();
+      clear(); //clear any bad bits
+      std::ostringstream::str("");
+    }
+  }
+
+private:
+  std::ostream *flush_output;
+
+  std::string redactstartTOKEN{"_CPROVER_REDACT_ON_"};
+  std::string redactendTOKEN{"_CPROVER_REDACT_OFF_"};
+
+  std::string redactstart{"_<<<_"};
+  std::string redactend{"_>>>_"};
+
+  bool redact_on{true};
+};
+
+// ----------------------------------------------------------------------
+class redact_off_nextt
+{
+public:
+  redact_off_nextt(ostream_redactedt &message) : message{message}
+  {
+  }
+
+  template <typename T>
+  ostream_redactedt &operator<<(const T &val)
+  {
+    static_cast<std::ostringstream &>(message) << val;
+    return message;
+  }
+
+  ostream_redactedt &message;
+};
+
+// NB redact_off_next.message is a reference, so no expensive copy involved
+// here.
+inline redact_off_nextt operator<<(
+  redact_off_nextt redact_off_next,
+  std::ios_base &(*fp)(std::ios_base &))
+{
+  static_cast<std::ostringstream &>(redact_off_next.message) << fp;
+  return redact_off_nextt{redact_off_next.message};
+}
+
+// ----------------------------------------------
+// function pointer as dummy variable
+inline void redact_off_next(){}
+
+inline redact_off_nextt operator<<(ostream_redactedt &message, void (*)())
+{
+  // Standard procedure would be to call the function pointer to return
+  // an instance of the required type, overkill for this poc
+  return redact_off_nextt{message};
+}
+
+// ----------------------------------------------------------------------
+extern ostream_redactedt ostream_redacted_cout;
+extern ostream_redactedt ostream_redact_off_cout;
+
+extern ostream_redactedt ostream_redact_off_cout;
+extern ostream_redactedt ostream_redact_off_cerr;
+
+#endif //PROJECT_OSTREAM_REDACTEDT_H

--- a/src/util/ui_message.cpp
+++ b/src/util/ui_message.cpp
@@ -29,7 +29,7 @@ ui_message_handlert::ui_message_handlert(
     _ui(__ui),
     always_flush(always_flush),
     time(timestampert::make(clock_type)),
-    out(std::cout),
+    out(ostream_redacted_cout),
     json_stream(nullptr)
 {
   switch(_ui)

--- a/src/util/ui_message.h
+++ b/src/util/ui_message.h
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "cout_message.h"
 #include "json_stream.h"
+#include "ostream_redactedt.h"
 #include "timestamper.h"
 
 class ui_message_handlert : public message_handlert
@@ -46,7 +47,7 @@ protected:
   uit _ui;
   const bool always_flush;
   std::unique_ptr<const timestampert> time;
-  std::ostream &out;
+  ostream_redactedt &out;
   std::unique_ptr<json_stream_arrayt> json_stream;
 
   ui_message_handlert(


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
**Objective:** enable redaction of sensitive cprover output.

QUICK SUMMARY: a custom ostream class is provided that can act as a temporary drop in replacement for std::cout/cerr. It is also an example of how to extend messaget to provide redaction. Key intent was to provide a quick/foolproof way to ensure *all* output is potentially redactable and assist with the transition removing std::cout/cerr. 

NB: this POC does not redact all output of cbmc - a lot of additional work will be needed to make all of that work smoothly. A design for a class that implements redaction is introduced - with a couple of examples of how it could be used.

**Key design choice:** "redaction first" - by default, output is redacted.

** - scroll to the end for examples of redaction behaviour - **

**Context:**
When tools built using CPROVER are run by end users, they may be run on source code which is sensitive or restricted in some way.
Some information about the source code may be contained in the output of the tools. For example variable, function and file names, string constants and line and column numbers. 
We need a simple, reliable and high confidence way of removing this information from the output. All such information can be bracketed by a specific string (for example <<< and >>>) so that we can do something like:
perl -p -e 's/<<<(.*)?>>>/REDACTED/' < log > redacted_log

**Implementation notes:**
A custom stream class (ostream_redactedt) has has been implemented. 
This is based around stringstream to store the input characters for post-processing, but can act as an ostream (flushing enabled).

The custom class _inherits_ from stringstream, for greater flexibility while doing the work of replacement of instances of std::cout et al, - but I would suggest encapsulation (using a stringstream member) as a better alternative in the long-term. 
The custom class demonstrates how to enable support for std::ios_base manipulators, so we know support for this does not need to get in the way of an encapsulated design.

A number of features are to assist with the temporary task of replacing instances of 
std::cout, std::cerr et al. 
e.g. global instances that support embedding std::cout  / std::error printing
ostream_redactedt ostream_redacted_cout(std::cout);
ostream_redactedt ostream_redacted_cerr(std::cerr);
ostream_redactedt ostream_redact_off_cout(std::cout, false);
ostream_redactedt ostream_redact_off_cerr(std::cerr, false);
(these last two are utility classes that by default do not redact output - here to show how they can be implemented, and should assist with the transition).

The redacted_output type when initialised with an output eg. std::cout, preserves the some essential std::cout behaviours:
-	will flush output when std::endl, "\n", '\n' is received
-	sync with std::cin to flush prior to any input.

While many instances of std::cout will be replaced by appropriate messages (these require passing 'eomt' for flushing), this preserves the option of direct ostream output with standard flush behaviour - which should make the work of transition easier.

Sync with std::cin is currently implemented via a workaround  (an embedded custom streambuf due to restrictions in the design of the standard library's iostream hierarchy - (ostream has non-virtual flush & no sync function, only streambuf has a virtual sync() function).

**Provisos:**
• std::cout instances can be replaced with the custom stream class and later replaced with appropriate use of messaget and levels.

• Invariants may contain sensitive information in the "reason" field - this can be disabled
entirely or redacted on a global or individual basis.

• a number of global / user-defefined variables are desirable/ can be considered
-	user defined redaction token 
-	disabling/enabling redaction globally via commandline parameter 

• current implementation is a Proof of Concept  
-	additional manipulators can be added e.g redact_off (until re-enabled) etc. 
-	some simple edge cases are not handled yet (e.g. "\n" embedded in a string)
-	redaction implementation may be optimised 
- 	a separate class for mstreamt may be preferable (rather than inheriting from the custom stream class) - but based on this design for redaction implementation.

&nbsp; &nbsp;
**Examples of redaction:**
```
ostream_redacted_cout<< CBMC_VERSION << '\n'; //(not sensitive info - just an example)
```
will print as:
```
_<<<_5.10 (cbmc-5.10-1558-g820be7475-dirty)_>>>_
```
and
```
ostream_redacted_cout<<"one "<< "two " << redact_off_next <<std::hex << 17 <<"three";"
```
will print as:
```
_<<<_one two _>>>_11_<<<_three_>>>_
```
A more complex example:
```
ostream_redacted_cout <<"foo "<<"bar "<< redact_off_next <<"not-redacted! "<<"do-redact!"<<std::endl;
ostream_redacted_cout <<"next-line "<<"a-word"<<"\n" << "after-newline!; ";
ostream_redacted_cout <<"hexadecimal: "<< std::hex << 33 <<"\n"<<"decimal: " << std::dec <<10;
```
will print as:
```
_<<<_foo bar _>>>_not-redacted! _<<<_do-redact!_>>>_
_<<<_next-line a-word_>>>_
_<<<_after-newline!; hexadecimal: 21_>>>_
_<<<_decimal: 10_>>>_
```

**An example of the sync with cin flush behaviour would be:**
```
ostream_redactedt out(std::cout);
std::cin.tie(out.get_sync_ostream());
out<<"one!"<<"two!"<<"\n";
out<<"This and previous will be flushed before the request for input";
std::string input;
std::cin >> input;
sleep (3);
std::cout<< "input was: "<<input;
```
which would result in
```
_<<<_one!two!_>>>_
_<<<_This and previous will be flushed before the request for input_>>>_
_(pause for input)_
_(sleep for 3 sec after input)_
oh
input was: oh
```