### PR TITLE
Fix Doxygen warnings in ansi-c/ folder

### DIFF
--- a/scripts/expected_doxygen_warnings.txt
+++ b/scripts/expected_doxygen_warnings.txt
@@ -33,14 +33,6 @@
 /cbmc/src/solvers/flattening/bv_utils.h:134: warning: The following parameters of bv_utilst::equal(const bvt &op0, const bvt &op1) are not documented:
   parameter 'op0'
   parameter 'op1'
-/cbmc/src/ansi-c/c_typecheck_initializer.cpp:347: warning: argument 'pre' of command @param is not found in the argument list of c_typecheck_baset::do_designated_initializer(exprt &result, designatort &designator, const exprt &initializer_list, exprt::operandst::const_iterator init_it, bool force_constant)
-/cbmc/src/ansi-c/c_typecheck_initializer.cpp:347: warning: argument 'initialized' of command @param is not found in the argument list of c_typecheck_baset::do_designated_initializer(exprt &result, designatort &designator, const exprt &initializer_list, exprt::operandst::const_iterator init_it, bool force_constant)
-/cbmc/src/ansi-c/c_typecheck_base.h:98: warning: The following parameters of c_typecheck_baset::do_designated_initializer(exprt &result, designatort &designator, const exprt &initializer_list, exprt::operandst::const_iterator init_it, bool force_constant) are not documented:
-  parameter 'result'
-  parameter 'designator'
-  parameter 'initializer_list'
-  parameter 'init_it'
-  parameter 'force_constant'
 /cbmc/src/ansi-c/c_typecheck_expr.cpp:2779: warning: argument 'type' of command @param is not found in the argument list of c_typecheck_baset::typecheck_function_call_arguments(side_effect_expr_function_callt &expr)
 /cbmc/src/ansi-c/c_typecheck_expr.cpp:2779: warning: argument 'checked' of command @param is not found in the argument list of c_typecheck_baset::typecheck_function_call_arguments(side_effect_expr_function_callt &expr)
 /cbmc/src/ansi-c/c_typecheck_base.h:195: warning: The following parameters of c_typecheck_baset::typecheck_function_call_arguments(side_effect_expr_function_callt &expr) are not documented:

--- a/scripts/expected_doxygen_warnings.txt
+++ b/scripts/expected_doxygen_warnings.txt
@@ -33,10 +33,6 @@
 /cbmc/src/solvers/flattening/bv_utils.h:134: warning: The following parameters of bv_utilst::equal(const bvt &op0, const bvt &op1) are not documented:
   parameter 'op0'
   parameter 'op1'
-/cbmc/src/ansi-c/c_typecheck_expr.cpp:2779: warning: argument 'type' of command @param is not found in the argument list of c_typecheck_baset::typecheck_function_call_arguments(side_effect_expr_function_callt &expr)
-/cbmc/src/ansi-c/c_typecheck_expr.cpp:2779: warning: argument 'checked' of command @param is not found in the argument list of c_typecheck_baset::typecheck_function_call_arguments(side_effect_expr_function_callt &expr)
-/cbmc/src/ansi-c/c_typecheck_base.h:195: warning: The following parameters of c_typecheck_baset::typecheck_function_call_arguments(side_effect_expr_function_callt &expr) are not documented:
-  parameter 'expr'
 /cbmc/jbmc/src/java_bytecode/ci_lazy_methods.h:100: warning: The following parameters of ci_lazy_methodst::ci_lazy_methodst(const symbol_tablet &symbol_table, const irep_idt &main_class, const std::vector< irep_idt > &main_jar_classes, const std::vector< load_extra_methodst > &lazy_methods_extra_entry_points, java_class_loadert &java_class_loader, const std::vector< irep_idt > &extra_instantiated_classes, const select_pointer_typet &pointer_type_selector, message_handlert &message_handler, const synthetic_methods_mapt &synthetic_methods) are not documented:
   parameter 'synthetic_methods'
 /cbmc/src/goto-instrument/wmm/event_graph.h:506: warning: The following parameters of event_grapht::explore_copy_segment(std::set< event_idt > &explored, event_idt begin, event_idt end) const are not documented:

--- a/scripts/expected_doxygen_warnings.txt
+++ b/scripts/expected_doxygen_warnings.txt
@@ -49,19 +49,6 @@
   parameter 'has_to_be_unsafe'
   parameter 'var_to_avoid'
   parameter 'model'
-/cbmc/src/ansi-c/expr2c_class.h:66: warning: The following parameters of expr2ct::convert_array_type(const typet &src, const qualifierst &qualifiers, const std::string &declarator_str) are not documented:
-  parameter 'qualifiers'
-  parameter 'declarator_str'
-/cbmc/src/ansi-c/expr2c_class.h:71: warning: The following parameters of expr2ct::convert_array_type(const typet &src, const qualifierst &qualifiers, const std::string &declarator_str, bool inc_size_if_possible) are not documented:
-  parameter 'qualifiers'
-  parameter 'declarator_str'
-/cbmc/src/ansi-c/expr2c_class.h:264: warning: The following parameters of expr2ct::convert_struct(const exprt &src, unsigned &precedence, bool include_padding_components) are not documented:
-  parameter 'precedence'
-/cbmc/src/ansi-c/expr2c.cpp:671: warning: argument 'qualifiers' of command @param is not found in the argument list of expr2ct::convert_struct_type(const typet &src, const std::string &qualifiers_str, const std::string &declarator_str)
-/cbmc/src/ansi-c/expr2c.cpp:671: warning: argument 'declarator' of command @param is not found in the argument list of expr2ct::convert_struct_type(const typet &src, const std::string &qualifiers_str, const std::string &declarator_str)
-/cbmc/src/ansi-c/expr2c_class.h:54: warning: The following parameters of expr2ct::convert_struct_type(const typet &src, const std::string &qualifiers_str, const std::string &declarator_str) are not documented:
-  parameter 'qualifiers_str'
-  parameter 'declarator_str'
 /cbmc/src/goto-instrument/wmm/goto2graph.h:260: warning: The following parameters of instrumentert::cfg_visitort::visit_cfg_function(value_setst &value_sets, memory_modelt model, bool no_dependencies, loop_strategyt duplicate_body, const irep_idt &function, std::set< nodet > &ending_vertex) are not documented:
   parameter 'model'
   parameter 'no_dependencies'

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2794,8 +2794,8 @@ exprt c_typecheck_baset::do_special_functions(
     return nil_exprt();
 }
 
-/// \param type:checked arguments, type-checked function
-/// \return type-adjusted function arguments
+/// Typecheck the parameters in a function call expression, and where
+/// necessary, make implicit casts around parameters explicit.
 void c_typecheck_baset::typecheck_function_call_arguments(
   side_effect_expr_function_callt &expr)
 {

--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -350,8 +350,6 @@ void c_typecheck_baset::designator_enter(
   designator.push_entry(entry);
 }
 
-/// \param pre:initialized result, designator
-/// \return sets result
 exprt::operandst::const_iterator c_typecheck_baset::do_designated_initializer(
   exprt &result,
   designatort &designator,

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -668,8 +668,8 @@ std::string expr2ct::convert_rec(
 
 /// To generate C-like string for defining the given struct
 /// \param src: the struct type being converted
-/// \param qualifiers: any qualifiers on the type
-/// \param declarator: the declarator on the type
+/// \param qualifiers_str: any qualifiers on the type
+/// \param declarator_str: the declarator on the type
 /// \return Returns a type declaration for a struct, containing the body of the
 ///   struct and in that body the padding parameters.
 std::string expr2ct::convert_struct_type(
@@ -746,8 +746,8 @@ std::string expr2ct::convert_struct_type(
 /// To generate a C-like type declaration of an array. Includes the size of the
 /// array in the []
 /// \param src: The array type to convert
-/// qualifier
-/// declarator_str
+/// \param qualifiers: Any qualifiers on the type
+/// \param declarator_str: Previously computed string denoting the array symbol
 /// \return A C-like type declaration of an array
 std::string expr2ct::convert_array_type(
   const typet &src,
@@ -761,8 +761,8 @@ std::string expr2ct::convert_array_type(
 /// To generate a C-like type declaration of an array. Optionally can include or
 /// exclude the size of the array in the []
 /// \param src: The array type to convert
-/// qualifier
-/// declarator_str
+/// \param qualifiers: Any qualifiers on the type
+/// \param declarator_str: Previously computed string denoting the array symbol
 /// \param inc_size_if_possible: Should the generated string include the size of
 ///   the array (if it is known).
 /// \return A C-like type declaration of an array
@@ -2035,7 +2035,8 @@ std::string expr2ct::convert_struct(
 /// To generate a C-like string representing a struct. Can optionally include
 /// the padding parameters.
 /// \param src: The struct declaration expression
-/// precedence
+/// \param [out] precedence: Precedence of the top level operator in the
+///   resulting string, used to decide about adding parentheses
 /// \param include_padding_components: Should the generated C code include the
 ///   padding members added to structs for GOTOs benefit
 /// \return A string representation of the struct expression


### PR DESCRIPTION
Delete one out-of-date (and unhelpful) comment and update other comments about functions and their arguments

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
