### PR TITLE
Class and function documentation for goto-symex-target [DOC-79]

### DIFF
--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -397,6 +397,12 @@ protected:
     guardt &,
     assignment_typet);
 
+  /// Store the \p what expression by recursively descending into the operands
+  /// of \p lhs until the first operand \c op0 is _nil_: this _nil_ operand
+  /// is then replaced with \p what.
+  /// \param lhs: Non-symbol pointed-to expression
+  /// \param what: The expression to be added to the \p lhs
+  /// \return The resulting expression
   static exprt add_to_lhs(const exprt &lhs, const exprt &what);
 
   virtual void symex_gcc_builtin_va_arg_next(

--- a/src/goto-symex/symex_target.h
+++ b/src/goto-symex/symex_target.h
@@ -17,6 +17,9 @@ Author: Daniel Kroening, kroening@kroening.com
 class ssa_exprt;
 class symbol_exprt;
 
+/// The interface of the target _container_ for symbolic execution to record its
+/// symbolic steps into. Presently, \ref symex_target_equationt is the only
+/// implementation of this interface.
 class symex_targett
 {
 public:
@@ -26,6 +29,9 @@ public:
 
   virtual ~symex_targett() { }
 
+  /// Identifies source in the context of symbolic execution. Thread number
+  /// `thread_nr` is zero by default and the program counter `pc` points to the
+  /// first instruction of the input GOTO program.
   struct sourcet
   {
     unsigned thread_nr;
@@ -65,21 +71,45 @@ public:
     GUARD,
   };
 
-  // read event
+  /// Read from a shared variable \p ssa_object (which is both the left- and the
+  /// right--hand side of assignment): we effectively assign the value stored in
+  /// \p ssa_object by another thread to \p ssa_object in the memory scope of
+  /// this thread.
+  /// \param guard: Precondition for this read event
+  /// \param ssa_object: Variable to be read from
+  /// \param atomic_section_id: ID of the atomic section in which this read
+  ///  takes place (if any)
+  /// \param source: Pointer to location in the input GOTO program of this read
   virtual void shared_read(
     const exprt &guard,
-    const ssa_exprt &ssa_rhs,
+    const ssa_exprt &ssa_object,
     unsigned atomic_section_id,
-    const sourcet &source)=0;
+    const sourcet &source) = 0;
 
-  // write event
+  /// Write to a shared variable \p ssa_object: we effectively assign a value
+  /// from this thread to be visible by other threads.
+  /// \param guard: Precondition for this write event
+  /// \param ssa_object: Variable to be written to
+  /// \param atomic_section_id: ID of the atomic section in which this write
+  ///  takes place (if any)
+  /// \param source: Pointer to location in the input GOTO program of this write
   virtual void shared_write(
     const exprt &guard,
-    const ssa_exprt &ssa_rhs,
+    const ssa_exprt &ssa_object,
     unsigned atomic_section_id,
-    const sourcet &source)=0;
+    const sourcet &source) = 0;
 
-  // write event - lhs must be symbol
+  /// Write to a local variable. The `cond_expr` is _lhs==rhs_.
+  /// \param guard: Precondition for this read event
+  /// \param ssa_lhs: Variable to be written to, must be a symbol (and not nil)
+  /// \param ssa_full_lhs: Full left-hand side with symex level annotations
+  /// \param original_full_lhs: Full left-hand side without symex level
+  ///  annotations
+  /// \param ssa_rhs: Right-hand side of the assignment
+  /// \param source: Pointer to location in the input GOTO program of this
+  ///  assignment
+  /// \param assignment_type: To distinguish between different types of
+  ///  assignments (some may be hidden for the further analysis)
   virtual void assignment(
     const exprt &guard,
     const ssa_exprt &ssa_lhs,
@@ -89,20 +119,36 @@ public:
     const sourcet &source,
     assignment_typet assignment_type)=0;
 
-  // declare fresh variable - lhs must be symbol
+  /// Declare a fresh variable. The `cond_expr` is _lhs==lhs_.
+  /// \param guard: Precondition for a declaration of this variable
+  /// \param ssa_lhs: Variable to be declared, must be symbol (and not nil)
+  /// \param source: Pointer to location in the input GOTO program of this
+  ///  declaration
+  /// \param assignment_type: To distinguish between different types of
+  ///  assignments (some may be hidden for the further analysis)
   virtual void decl(
     const exprt &guard,
     const ssa_exprt &ssa_lhs,
     const sourcet &source,
     assignment_typet assignment_type)=0;
 
-  // note the death of a variable - lhs must be symbol
+  /// Remove a variable from the scope.
+  /// \param guard: Precondition for removal of this variable
+  /// \param ssa_lhs: Variable to be removed, must be symbol
+  /// \param source: Pointer to location in the input GOTO program of this
+  ///  removal
   virtual void dead(
     const exprt &guard,
     const ssa_exprt &ssa_lhs,
     const sourcet &source)=0;
 
-  // record a function call
+  /// Record a function call.
+  /// \param guard: Precondition for calling a function
+  /// \param function_identifier: Name of the function
+  /// \param ssa_function_arguments: Vector of arguments in SSA form
+  /// \param source: To location in the input GOTO program of this
+  /// \param hidden: Should this step be recorded as hidden?
+  ///  function call
   virtual void function_call(
     const exprt &guard,
     const irep_idt &function_identifier,
@@ -110,23 +156,41 @@ public:
     const sourcet &source,
     bool hidden) = 0;
 
-  // record return from a function
+  /// Record return from a function.
+  /// \param guard: Precondition for returning from a function
+  /// \param source: Pointer to location in the input GOTO program of this
+  /// \param hidden: Should this step be recorded as hidden?
+  ///  function return
   virtual void
   function_return(const exprt &guard, const sourcet &source, bool hidden) = 0;
 
-  // just record a location
+  /// Record a location.
+  /// \param guard: Precondition for reaching this location
+  /// \param source: Pointer to location in the input GOTO program to be
+  ///  recorded
   virtual void location(
     const exprt &guard,
     const sourcet &source)=0;
 
-  // record output
+  /// Record an output.
+  /// \param guard: Precondition for writing to the output
+  /// \param source: Pointer to location in the input GOTO program of this
+  ///  output
+  /// \param output_id: Name of the output
+  /// \param args: A list of IO arguments
   virtual void output(
     const exprt &guard,
     const sourcet &source,
     const irep_idt &output_id,
     const std::list<exprt> &args)=0;
 
-  // record formatted output
+  /// Record formatted output.
+  /// \param guard: Precondition for writing to the output
+  /// \param source: Pointer to location in the input GOTO program of this
+  ///  output
+  /// \param output_id: Name of the output
+  /// \param fmt: Formatting string
+  /// \param args: A list of IO arguments
   virtual void output_fmt(
     const exprt &guard,
     const sourcet &source,
@@ -134,59 +198,102 @@ public:
     const irep_idt &fmt,
     const std::list<exprt> &args)=0;
 
-  // record input
+  /// Record an input.
+  /// \param guard: Precondition for reading from the input
+  /// \param source: Pointer to location in the input GOTO program of this
+  ///  input
+  /// \param input_id: Name of the input
+  /// \param args: A list of IO arguments
   virtual void input(
     const exprt &guard,
     const sourcet &source,
     const irep_idt &input_id,
     const std::list<exprt> &args)=0;
 
-  // record an assumption
+  /// Record an assumption.
+  /// \param guard: Precondition for reaching this assumption
+  /// \param cond: Condition this assumption represents
+  /// \param source: Pointer to location in the input GOTO program of this
+  ///  assumption
   virtual void assumption(
     const exprt &guard,
     const exprt &cond,
     const sourcet &source)=0;
 
-  // record an assertion
+  /// Record an assertion.
+  /// \param guard: Precondition for reaching this assertion
+  /// \param cond: Condition this assertion represents
+  /// \param msg: The message associated with this assertion
+  /// \param source: Pointer to location in the input GOTO program of this
+  ///  assertion
   virtual void assertion(
     const exprt &guard,
     const exprt &cond,
     const std::string &msg,
     const sourcet &source)=0;
 
-  // record a goto
+  /// Record a goto instruction.
+  /// \param guard: Precondition for reaching this goto instruction
+  /// \param cond: Condition under which this goto should be taken
+  /// \param source: Pointer to location in the input GOTO program of this
+  ///  goto instruction
   virtual void goto_instruction(
     const exprt &guard,
     const exprt &cond,
     const sourcet &source)=0;
 
-  // record a constraint
+  /// Record a _global_ constraint: there is no guard limiting its scope.
+  /// \param cond: Condition represented by this constraint
+  /// \param msg: The message associated with this constraint
+  /// \param source: Pointer to location in the input GOTO program of this
+  ///  constraint
   virtual void constraint(
     const exprt &cond,
     const std::string &msg,
     const sourcet &source)=0;
 
-  // record thread spawn
+  /// Record spawning a new thread
+  /// \param guard: Precondition for reaching spawning a new thread
+  /// \param source: Pointer to location in the input GOTO program where a new
+  ///  thread is to be spawned
   virtual void spawn(
     const exprt &guard,
     const sourcet &source)=0;
 
-  // record memory barrier
+  /// Record creating a memory barrier
+  /// \param guard: Precondition for reaching this barrier
+  /// \param source: Pointer to location in the input GOTO program where a new
+  ///  barrier is created
   virtual void memory_barrier(
     const exprt &guard,
     const sourcet &source)=0;
 
-  // record atomic section
+  /// Record a beginning of an atomic section
+  /// \param guard: Precondition for reaching this atomic section
+  /// \param atomic_section_id: Identifier for this atomic section
+  /// \param source: Pointer to location in the input GOTO program where an
+  ///  atomic section begins
   virtual void atomic_begin(
     const exprt &guard,
     unsigned atomic_section_id,
     const sourcet &source)=0;
+
+  /// Record ending an atomic section
+  /// \param guard: Precondition for reaching the end of this atomic section
+  /// \param atomic_section_id: Identifier for this atomic section
+  /// \param source: Pointer to location in the input GOTO program where an
+  ///  atomic section ends
   virtual void atomic_end(
     const exprt &guard,
     unsigned atomic_section_id,
     const sourcet &source)=0;
 };
 
+/// Base class comparison operator for symbolic execution targets. Order first
+/// by thread numbers and then by program counters.
+/// \param a: Left-hand target
+/// \param b: Right-hand target
+/// \return _True_ if `a` precedes `b`.
 bool operator < (
   const symex_targett::sourcet &a,
   const symex_targett::sourcet &b);

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -8,6 +8,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 /// \file
 /// Symbolic Execution
+/// Implementation of functions to build SSA equation.
 
 #include "symex_target_equation.h"
 
@@ -27,7 +28,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "equation_conversion_exceptions.h"
 #include "goto_symex_state.h"
 
-/// read from a shared variable
 void symex_target_equationt::shared_read(
   const exprt &guard,
   const ssa_exprt &ssa_object,
@@ -46,7 +46,6 @@ void symex_target_equationt::shared_read(
   merge_ireps(SSA_step);
 }
 
-/// write to a sharedvariable
 void symex_target_equationt::shared_write(
   const exprt &guard,
   const ssa_exprt &ssa_object,
@@ -124,7 +123,6 @@ void symex_target_equationt::atomic_end(
   merge_ireps(SSA_step);
 }
 
-/// write to a variable
 void symex_target_equationt::assignment(
   const exprt &guard,
   const ssa_exprt &ssa_lhs,
@@ -155,7 +153,6 @@ void symex_target_equationt::assignment(
   merge_ireps(SSA_step);
 }
 
-/// declare a fresh variable
 void symex_target_equationt::decl(
   const exprt &guard,
   const ssa_exprt &ssa_lhs,
@@ -191,7 +188,6 @@ void symex_target_equationt::dead(
   // we currently don't record these
 }
 
-/// just record a location
 void symex_target_equationt::location(
   const exprt &guard,
   const sourcet &source)
@@ -206,7 +202,6 @@ void symex_target_equationt::location(
   merge_ireps(SSA_step);
 }
 
-/// just record a location
 void symex_target_equationt::function_call(
   const exprt &guard,
   const irep_idt &function_identifier,
@@ -227,7 +222,6 @@ void symex_target_equationt::function_call(
   merge_ireps(SSA_step);
 }
 
-/// just record a location
 void symex_target_equationt::function_return(
   const exprt &guard,
   const sourcet &source,
@@ -244,7 +238,6 @@ void symex_target_equationt::function_return(
   merge_ireps(SSA_step);
 }
 
-/// just record output
 void symex_target_equationt::output(
   const exprt &guard,
   const sourcet &source,
@@ -263,7 +256,6 @@ void symex_target_equationt::output(
   merge_ireps(SSA_step);
 }
 
-/// just record formatted output
 void symex_target_equationt::output_fmt(
   const exprt &guard,
   const sourcet &source,
@@ -285,7 +277,6 @@ void symex_target_equationt::output_fmt(
   merge_ireps(SSA_step);
 }
 
-/// just record input
 void symex_target_equationt::input(
   const exprt &guard,
   const sourcet &source,
@@ -304,7 +295,6 @@ void symex_target_equationt::input(
   merge_ireps(SSA_step);
 }
 
-/// record an assumption
 void symex_target_equationt::assumption(
   const exprt &guard,
   const exprt &cond,
@@ -321,7 +311,6 @@ void symex_target_equationt::assumption(
   merge_ireps(SSA_step);
 }
 
-/// record an assertion
 void symex_target_equationt::assertion(
   const exprt &guard,
   const exprt &cond,
@@ -340,7 +329,6 @@ void symex_target_equationt::assertion(
   merge_ireps(SSA_step);
 }
 
-/// record a goto instruction
 void symex_target_equationt::goto_instruction(
   const exprt &guard,
   const exprt &cond,
@@ -357,7 +345,6 @@ void symex_target_equationt::goto_instruction(
   merge_ireps(SSA_step);
 }
 
-/// record a constraint
 void symex_target_equationt::constraint(
   const exprt &cond,
   const std::string &msg,
@@ -399,9 +386,6 @@ void symex_target_equationt::convert(
   }
 }
 
-/// converts assignments
-/// \par parameters: decision procedure
-/// \return -
 void symex_target_equationt::convert_assignments(
   decision_proceduret &decision_procedure) const
 {
@@ -421,8 +405,6 @@ void symex_target_equationt::convert_assignments(
   }
 }
 
-/// converts declarations
-/// \return -
 void symex_target_equationt::convert_decls(
   prop_convt &prop_conv) const
 {
@@ -446,8 +428,6 @@ void symex_target_equationt::convert_decls(
   }
 }
 
-/// converts guards
-/// \return -
 void symex_target_equationt::convert_guards(
   prop_convt &prop_conv)
 {
@@ -478,8 +458,6 @@ void symex_target_equationt::convert_guards(
   }
 }
 
-/// converts assumptions
-/// \return -
 void symex_target_equationt::convert_assumptions(
   prop_convt &prop_conv)
 {
@@ -513,8 +491,6 @@ void symex_target_equationt::convert_assumptions(
   }
 }
 
-/// converts goto instructions
-/// \return -
 void symex_target_equationt::convert_goto_instructions(
   prop_convt &prop_conv)
 {
@@ -548,9 +524,6 @@ void symex_target_equationt::convert_goto_instructions(
   }
 }
 
-/// converts constraints
-/// \par parameters: decision procedure
-/// \return -
 void symex_target_equationt::convert_constraints(
   decision_proceduret &decision_procedure) const
 {
@@ -582,8 +555,6 @@ void symex_target_equationt::convert_constraints(
   }
 }
 
-/// converts assertions
-/// \return -
 void symex_target_equationt::convert_assertions(
   prop_convt &prop_conv)
 {
@@ -665,9 +636,6 @@ void symex_target_equationt::convert_assertions(
   prop_conv.set_to_true(disjunction(disjuncts));
 }
 
-/// converts function calls
-/// \par parameters: decision procedure
-/// \return -
 void symex_target_equationt::convert_function_calls(
   decision_proceduret &dec_proc)
 {
@@ -698,9 +666,6 @@ void symex_target_equationt::convert_function_calls(
     }
 }
 
-/// converts I/O
-/// \par parameters: decision procedure
-/// \return -
 void symex_target_equationt::convert_io(
   decision_proceduret &dec_proc)
 {


### PR DESCRIPTION
Adding class and function documentation to goto-symex/symex_target. {h,cpp} and goto-symex/symex_target_equation.{h,cpp}.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
