### PR TITLE
enable -flto for unix systems

### DIFF
--- a/src/common
+++ b/src/common
@@ -35,6 +35,9 @@ endif
   CFLAGS ?= -Wall -O2
   CP_CFLAGS = -MMD -MP
   CXXFLAGS ?= -Wall -O2
+  CXXFLAGS += -flto
+  LINKFLAGS += -flto
+  AR = gcc-ar
 ifeq ($(filter-out OSX OSX_Universal,$(BUILD_ENV_)),)
   CP_CXXFLAGS += -MMD -MP -mmacosx-version-min=10.9 -std=c++11 -stdlib=libc++
   LINKFLAGS += -mmacosx-version-min=10.9 -stdlib=libc++

--- a/src/common
+++ b/src/common
@@ -20,6 +20,8 @@ else
   BUILD_ENV_ := $(BUILD_ENV)
 endif
 
+AR = ar
+
 ifeq ($(filter-out Unix MinGW OSX OSX_Universal FreeBSD,$(BUILD_ENV_)),)
   # Linux-ish
   LIBEXT = .a
@@ -62,7 +64,7 @@ ifeq ($(filter-out OSX OSX_Universal,$(BUILD_ENV_)),)
   endif
 else ifeq ($(filter-out FreeBSD,$(BUILD_ENV_)),)
   CP_CXXFLAGS +=
-  LINKLIB = ar rcT $@ $^
+  LINKLIB = $(AR) rcT $@ $^
   LINKBIN = $(CXX) $(LINKFLAGS) -o $@ -Wl,--start-group $^ -Wl,--end-group $(LIBS)
   LINKNATIVE = $(HOSTCXX) -o $@ $^
   ifeq ($(origin CC),default)
@@ -72,7 +74,7 @@ else ifeq ($(filter-out FreeBSD,$(BUILD_ENV_)),)
     CXX    = clang++
   endif
 else
-  LINKLIB = ar rcT $@ $^
+  LINKLIB = $(AR) rcT $@ $^
   LINKBIN = $(CXX) $(LINKFLAGS) -o $@ -Wl,--start-group $^ -Wl,--end-group $(LIBS)
   LINKNATIVE = $(HOSTCXX) -o $@ $^
   ifeq ($(origin CC),default)
@@ -106,7 +108,7 @@ else ifeq ($(BUILD_ENV_),Cygwin)
   # Cygwin-g++ has problems with statically linking exception code.
   # If linking fails, remove -static.
   LINKFLAGS = -static -std=c++11
-  LINKLIB = ar rcT $@ $^
+  LINKLIB = $(AR) rcT $@ $^
   LINKBIN = $(CXX) $(LINKFLAGS) -o $@ -Wl,--start-group $^ -Wl,--end-group $(LIBS)
   LINKNATIVE = $(HOSTCXX) -std=c++11 -o $@ $^ -static
 ifeq ($(origin CC),default)


### PR DESCRIPTION
These changes might improve the performance of CBMC, as well as allow to spot compilation problems earlier.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
