### PR TITLE
DOC-50: Add some documentation to abstract interpretation

### DIFF
--- a/src/analyses/ai.cpp
+++ b/src/analyses/ai.cpp
@@ -61,7 +61,8 @@ void ai_baset::output(
 }
 
 /// Output the domains for the whole program as JSON
-/// \par parameters: The namespace and goto_functions
+/// \param ns: The namespace
+/// \param goto_functions: The goto functions
 /// \return The JSON object
 jsont ai_baset::output_json(
   const namespacet &ns,
@@ -86,7 +87,10 @@ jsont ai_baset::output_json(
 }
 
 /// Output the domains for a single function as JSON
-/// \par parameters: The namespace, goto_program and its identifier
+/// \param ns: The namespace
+/// \param goto_program: The goto program
+/// \param identifier: the identifier used to find a symbol to identify the
+///   source language
 /// \return The JSON object
 jsont ai_baset::output_json(
   const namespacet &ns,
@@ -117,7 +121,8 @@ jsont ai_baset::output_json(
 }
 
 /// Output the domains for the whole program as XML
-/// \par parameters: The namespace and goto_functions
+/// \param ns: The namespace
+/// \param goto_functions: The goto functions
 /// \return The XML object
 xmlt ai_baset::output_xml(
   const namespacet &ns,
@@ -145,7 +150,10 @@ xmlt ai_baset::output_xml(
 }
 
 /// Output the domains for a single function as XML
-/// \par parameters: The namespace, goto_program and its identifier
+/// \param ns: The namespace
+/// \param goto_program: The goto program
+/// \param identifier: the identifier used to find a symbol to identify the
+///   source language
 /// \return The XML object
 xmlt ai_baset::output_xml(
   const namespacet &ns,

--- a/src/analyses/ai.cpp
+++ b/src/analyses/ai.cpp
@@ -86,7 +86,7 @@ jsont ai_baset::output_json(
 }
 
 /// Output the domains for a single function as JSON
-/// \par parameters: The namespace, goto_program and it's identifier
+/// \par parameters: The namespace, goto_program and its identifier
 /// \return The JSON object
 jsont ai_baset::output_json(
   const namespacet &ns,
@@ -145,7 +145,7 @@ xmlt ai_baset::output_xml(
 }
 
 /// Output the domains for a single function as XML
-/// \par parameters: The namespace, goto_program and it's identifier
+/// \par parameters: The namespace, goto_program and its identifier
 /// \return The XML object
 xmlt ai_baset::output_xml(
   const namespacet &ns,
@@ -341,7 +341,7 @@ bool ai_baset::do_function_call(
 
   if(!goto_function.body_available())
   {
-    // if we don't have a body, we just do an edige call -> return
+    // if we don't have a body, we just do an edge call -> return
     std::unique_ptr<statet> tmp_state(make_temporary_state(get_state(l_call)));
     tmp_state->transform(
       calling_function_identifier,

--- a/src/analyses/ai.cpp
+++ b/src/analyses/ai.cpp
@@ -60,10 +60,6 @@ void ai_baset::output(
   }
 }
 
-/// Output the domains for the whole program as JSON
-/// \param ns: The namespace
-/// \param goto_functions: The goto functions
-/// \return The JSON object
 jsont ai_baset::output_json(
   const namespacet &ns,
   const goto_functionst &goto_functions) const
@@ -120,10 +116,6 @@ jsont ai_baset::output_json(
   return std::move(contents);
 }
 
-/// Output the domains for the whole program as XML
-/// \param ns: The namespace
-/// \param goto_functions: The goto functions
-/// \return The XML object
 xmlt ai_baset::output_xml(
   const namespacet &ns,
   const goto_functionst &goto_functions) const

--- a/src/analyses/ai.cpp
+++ b/src/analyses/ai.cpp
@@ -85,7 +85,7 @@ jsont ai_baset::output_json(
 /// Output the domains for a single function as JSON
 /// \param ns: The namespace
 /// \param goto_program: The goto program
-/// \param identifier: the identifier used to find a symbol to identify the
+/// \param identifier: The identifier used to find a symbol to identify the
 ///   source language
 /// \return The JSON object
 jsont ai_baset::output_json(
@@ -144,7 +144,7 @@ xmlt ai_baset::output_xml(
 /// Output the domains for a single function as XML
 /// \param ns: The namespace
 /// \param goto_program: The goto program
-/// \param identifier: the identifier used to find a symbol to identify the
+/// \param identifier: The identifier used to find a symbol to identify the
 ///   source language
 /// \return The XML object
 xmlt ai_baset::output_xml(
@@ -341,7 +341,7 @@ bool ai_baset::do_function_call(
 
   if(!goto_function.body_available())
   {
-    // if we don't have a body, we just do an edge call -> return
+    // If we don't have a body, we just do an edge call -> return
     std::unique_ptr<statet> tmp_state(make_temporary_state(get_state(l_call)));
     tmp_state->transform(
       calling_function_identifier,

--- a/src/analyses/ai.h
+++ b/src/analyses/ai.h
@@ -25,7 +25,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "ai_domain.h"
 
-/// The basic interface of an abstract interpreter.  This should be enough
+/// The basic interface of an abstract interpreter. This should be enough
 /// to create, run and query an abstract interpreter.
 // don't use me -- I am just a base class
 // use ait instead

--- a/src/analyses/ai.h
+++ b/src/analyses/ai.h
@@ -96,10 +96,10 @@ public:
   /// use \ref get_state or \ref find_state to access the actual underlying
   /// state.
   /// PRECONDITION(l is dereferenceable)
-  /// \param l: The location we want the domain before
-  /// \return The domain before `l`. We return a pointer to a copy as the method
-  ///   should be const and there are some non-trivial cases including merging
-  ///   domains, etc.
+  /// \param l: The location before which we want the abstract state
+  /// \return The abstract state before `l`. We return a pointer to a copy as
+  ///   the method should be const and there are some non-trivial cases
+  ///   including merging abstract states, etc.
   virtual std::unique_ptr<statet> abstract_state_before(locationt l) const = 0;
 
   /// Get a copy of the abstract state after the given instruction, without
@@ -107,10 +107,10 @@ public:
   /// for users of the abstract interpreter; derived classes should
   /// use \ref get_state or \ref find_state to access the actual underlying
   /// state.
-  /// \param l: The location we want the domain after
-  /// \return The domain after `l`. We return a pointer to a copy as the method
-  ///   should be const and there are some non-trivial cases including merging
-  ///   domains, etc.
+  /// \param l: The location before which we want the abstract state
+  /// \return The abstract state after `l`. We return a pointer to a copy as
+  ///   the method should be const and there are some non-trivial cases
+  ///   including merging abstract states, etc.
   virtual std::unique_ptr<statet> abstract_state_after(locationt l) const
   {
     /// PRECONDITION(l is dereferenceable && std::next(l) is dereferenceable)
@@ -119,18 +119,18 @@ public:
     return abstract_state_before(std::next(l));
   }
 
-  /// Reset the domain
+  /// Reset the abstract state
   virtual void clear()
   {
   }
 
-  /// Output the domains for a whole program
+  /// Output the abstract states for a whole program
   virtual void output(
     const namespacet &ns,
     const goto_functionst &goto_functions,
     std::ostream &out) const;
 
-  /// Output the domains for a whole program
+  /// Output the abstract states for a whole program
   void output(
     const goto_modelt &goto_model,
     std::ostream &out) const
@@ -139,7 +139,7 @@ public:
     output(ns, goto_model.goto_functions, out);
   }
 
-  /// Output the domains for a function
+  /// Output the abstract states for a function
   void output(
     const namespacet &ns,
     const goto_programt &goto_program,
@@ -148,7 +148,7 @@ public:
     output(ns, goto_program, "", out);
   }
 
-  /// Output the domains for a function
+  /// Output the abstract states for a function
   void output(
     const namespacet &ns,
     const goto_functionst::goto_functiont &goto_function,
@@ -157,12 +157,12 @@ public:
     output(ns, goto_function.body, "", out);
   }
 
-  /// Output the domains for the whole program as JSON
+  /// Output the abstract states for the whole program as JSON
   virtual jsont output_json(
     const namespacet &ns,
     const goto_functionst &goto_functions) const;
 
-  /// Output the domains for a whole program as JSON
+  /// Output the abstract states for a whole program as JSON
   jsont output_json(
     const goto_modelt &goto_model) const
   {
@@ -170,7 +170,7 @@ public:
     return output_json(ns, goto_model.goto_functions);
   }
 
-  /// Output the domains for a single function as JSON
+  /// Output the abstract states for a single function as JSON
   jsont output_json(
     const namespacet &ns,
     const goto_programt &goto_program) const
@@ -178,7 +178,7 @@ public:
     return output_json(ns, goto_program, "");
   }
 
-  /// Output the domains for a single function as JSON
+  /// Output the abstract states for a single function as JSON
   jsont output_json(
     const namespacet &ns,
     const goto_functionst::goto_functiont &goto_function) const
@@ -186,12 +186,12 @@ public:
     return output_json(ns, goto_function.body, "");
   }
 
-  /// Output the domains for the whole program as XML
+  /// Output the abstract states for the whole program as XML
   virtual xmlt output_xml(
     const namespacet &ns,
     const goto_functionst &goto_functions) const;
 
-  /// Output the domains for the whole program as XML
+  /// Output the abstract states for the whole program as XML
   xmlt output_xml(
     const goto_modelt &goto_model) const
   {
@@ -199,7 +199,7 @@ public:
     return output_xml(ns, goto_model.goto_functions);
   }
 
-  /// Output the domains for a single function as XML
+  /// Output the abstract states for a single function as XML
   xmlt output_xml(
     const namespacet &ns,
     const goto_programt &goto_program) const
@@ -207,7 +207,7 @@ public:
     return output_xml(ns, goto_program, "");
   }
 
-  /// Output the domains for a single function as XML
+  /// Output the abstract states for a single function as XML
   xmlt output_xml(
     const namespacet &ns,
     const goto_functionst::goto_functiont &goto_function) const
@@ -216,30 +216,33 @@ public:
   }
 
 protected:
-  /// Initialize all the domains for a single function. Override this to do
-  /// custom per-domain initialization.
+  /// Initialize all the abstract states for a single function. Override this to
+  /// do custom per-domain initialization.
   virtual void initialize(const goto_programt &goto_program);
 
-  /// Initialize all the domains for a single function.
+  /// Initialize all the abstract states for a single function.
   virtual void initialize(const goto_functionst::goto_functiont &goto_function);
 
-  /// Initialize all the domains for a whole program. Override this to do custom
-  /// per-analysis initialization.
+  /// Initialize all the abstract states for a whole program. Override this to
+  /// do custom per-analysis initialization.
   virtual void initialize(const goto_functionst &goto_functions);
 
-  /// Override this to add a cleanup step after fixedpoint has run
+  /// Override this to add a cleanup or post-processing step after fixedpoint
+  /// has run
   virtual void finalize();
 
-  /// Ensure the entry point to a single function has a reasonable state
-  void entry_state(const goto_programt &goto_functions);
+  /// Set the abstract state of the entry location of a single function to the
+  /// entry state required by the analysis
+  void entry_state(const goto_programt &goto_program);
 
-  /// Ensure the entry point to a whole program has a reasonable state
-  void entry_state(const goto_functionst &goto_program);
+  /// Set the abstract state of the entry location of a whole program to the
+  /// entry state required by the analysis
+  void entry_state(const goto_functionst &goto_functions);
 
-  /// Output the domains for a single function
+  /// Output the abstract states for a single function
   /// \param ns: The namespace
   /// \param goto_program: The goto program
-  /// \param identifier: the identifier used to find a symbol to identify the
+  /// \param identifier: The identifier used to find a symbol to identify the
   ///   source language
   /// \param out: The ostream to direct output to
   virtual void output(
@@ -248,10 +251,10 @@ protected:
     const irep_idt &identifier,
     std::ostream &out) const;
 
-  /// Output the domains for a single function as JSON
+  /// Output the abstract states for a single function as JSON
   /// \param ns: The namespace
   /// \param goto_program: The goto program
-  /// \param identifier: the identifier used to find a symbol to identify the
+  /// \param identifier: The identifier used to find a symbol to identify the
   ///   source language
   /// \return The JSON object
   virtual jsont output_json(
@@ -259,10 +262,10 @@ protected:
     const goto_programt &goto_program,
     const irep_idt &identifier) const;
 
-  /// Output the domains for a single function as XML
+  /// Output the abstract states for a single function as XML
   /// \param ns: The namespace
   /// \param goto_program: The goto program
-  /// \param identifier: the identifier used to find a symbol to identify the
+  /// \param identifier: The identifier used to find a symbol to identify the
   ///   source language
   /// \return The XML object
   virtual xmlt output_xml(

--- a/src/analyses/ai.h
+++ b/src/analyses/ai.h
@@ -90,9 +90,11 @@ public:
     finalize();
   }
 
-  /// Get the abstract state before the given instruction, without needing to
-  /// know what kind of domain or history is used. Note: intended for
-  /// users of the abstract interpreter; don't use internally.
+  /// Get a copy of the abstract state before the given instruction, without
+  /// needing to know what kind of domain or history is used. Note: intended
+  /// for users of the abstract interpreter; derived classes should
+  /// use \ref get_state or \ref find_state to access the actual underlying
+  /// state.
   /// PRECONDITION(l is dereferenceable)
   /// \param l: The location we want the domain before
   /// \return The domain before `l`. We return a pointer to a copy as the method
@@ -100,9 +102,11 @@ public:
   ///   domains, etc.
   virtual std::unique_ptr<statet> abstract_state_before(locationt l) const = 0;
 
-  /// Get the abstract state after the given instruction, without needing to
-  /// know what kind of domain or history is used. Note: intended for
-  /// users of the abstract interpreter; don't use internally.
+  /// Get a copy of the abstract state after the given instruction, without
+  /// needing to know what kind of domain or history is used. Note: intended
+  /// for users of the abstract interpreter; derived classes should
+  /// use \ref get_state or \ref find_state to access the actual underlying
+  /// state.
   /// \param l: The location we want the domain after
   /// \return The domain after `l`. We return a pointer to a copy as the method
   ///   should be const and there are some non-trivial cases including merging
@@ -212,16 +216,15 @@ public:
   }
 
 protected:
-  /// Initialize all the domains for a single function. Overloaded this to add a
-  /// factory.
+  /// Initialize all the domains for a single function. Override this to do
+  /// custom per-domain initialization.
   virtual void initialize(const goto_programt &goto_program);
 
-  /// Initialize all the domains for a single function. Overloaded this to add a
-  /// factory.
+  /// Initialize all the domains for a single function.
   virtual void initialize(const goto_functionst::goto_functiont &goto_function);
 
-  /// Initialize all the domains for a whole program. Overloaded this to add a
-  /// factory.
+  /// Initialize all the domains for a whole program. Override this to do custom
+  /// per-analysis initialization.
   virtual void initialize(const goto_functionst &goto_functions);
 
   /// Override this to add a cleanup step after fixedpoint has run
@@ -341,8 +344,16 @@ protected:
     locationt from,
     locationt to,
     const namespacet &ns)=0;
+
+  /// Get the state for the given location, creating it in a default way if it
+  /// doesn't exist
   virtual statet &get_state(locationt l)=0;
+
+  /// Get the state for the given location if it already exists; throw an
+  /// exception if it doesn't
   virtual const statet &find_state(locationt l) const=0;
+
+  /// Make a copy of a state
   virtual std::unique_ptr<statet> make_temporary_state(const statet &s)=0;
 };
 

--- a/src/analyses/ai_domain.cpp
+++ b/src/analyses/ai_domain.cpp
@@ -35,8 +35,8 @@ xmlt ai_domain_baset::output_xml(const ai_baset &ai, const namespacet &ns) const
 /// an assignment. This for example won't simplify symbols to their values, but
 /// does simplify indices in arrays, members of structs and dereferencing of
 /// pointers
-/// \param condition: the expression to simplify
-/// \param ns: the namespace
+/// \param condition: The expression to simplify
+/// \param ns: The namespace
 /// \return True if condition did not change. False otherwise. condition will be
 ///   updated with the simplified condition if it has worked
 bool ai_domain_baset::ai_simplify_lhs(exprt &condition, const namespacet &ns)

--- a/src/analyses/ai_domain.h
+++ b/src/analyses/ai_domain.h
@@ -46,7 +46,7 @@ public:
   ///    (this also needs to set the LHS, if applicable)
   ///
   /// "this" is the domain before the instruction "from"
-  /// "from" is the instruction to be interpretted
+  /// "from" is the instruction to be interpreted
   /// "to" is the next instruction (for GOTO, FUNCTION_CALL, END_FUNCTION)
   ///
   /// PRECONDITION(from.is_dereferenceable(), "Must not be _::end()")

--- a/src/analyses/ai_domain.h
+++ b/src/analyses/ai_domain.h
@@ -78,7 +78,7 @@ public:
   /// and domains may refuse to implement it.
   virtual void make_top() = 0;
 
-  /// a reasonable entry-point state
+  /// Make this domain a reasonable entry-point state
   virtual void make_entry() = 0;
 
   virtual bool is_bottom() const = 0;


### PR DESCRIPTION
The task is far from complete, but I should commit what I have at the end of doc day.

Where function comments appear to have been deleted they have actually been moved into the header file, as they are part of the interface of the class. Even protected methods are part of the interface as the purpose of `ait` is for other analyses to derive from.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.