### PR TITLE
Avoid warning about not returning a value [blocks: #2548]

### DIFF
--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -485,6 +485,8 @@ safety_checkert::resultt bmct::stop_on_fail(prop_convt &prop_conv)
 
     return resultt::ERROR;
   }
+
+  UNREACHABLE;
 }
 
 /// Perform core BMC, using an abstract model to supply GOTO function bodies

--- a/src/cbmc/fault_localization.cpp
+++ b/src/cbmc/fault_localization.cpp
@@ -315,6 +315,8 @@ safety_checkert::resultt fault_localizationt::stop_on_fail()
 
     return safety_checkert::resultt::ERROR;
   }
+
+  UNREACHABLE;
 }
 
 void fault_localizationt::goal_covered(

--- a/src/cpp/cpp_id.cpp
+++ b/src/cpp/cpp_id.cpp
@@ -13,6 +13,8 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include <ostream>
 
+#include <util/invariant.h>
+
 #include "cpp_scope.h"
 
 cpp_idt::cpp_idt():
@@ -111,4 +113,6 @@ std::ostream &operator<<(std::ostream &out, const cpp_idt::id_classt &id_class)
   case cpp_idt::id_classt::NAMESPACE:         return out<<"NAMESPACE";
   default: return out << "(OTHER)";
   }
+
+  UNREACHABLE;
 }

--- a/src/goto-programs/format_strings.cpp
+++ b/src/goto-programs/format_strings.cpp
@@ -11,11 +11,11 @@ Author: CM Wintersteiger
 
 #include "format_strings.h"
 
-#include <util/exception_utils.h>
-#include <util/std_types.h>
-#include <util/std_expr.h>
-
 #include <util/c_types.h>
+#include <util/exception_utils.h>
+#include <util/invariant.h>
+#include <util/std_expr.h>
+#include <util/std_types.h>
 
 #include <cctype>
 
@@ -293,4 +293,6 @@ typet get_type(const format_tokent &token)
   default:
     return nil_typet();
   }
+
+  UNREACHABLE;
 }

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/expr_iterator.h>
 #include <util/find_symbols.h>
+#include <util/invariant.h>
 #include <util/std_expr.h>
 #include <util/validate.h>
 

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -138,21 +138,15 @@ bool remove_function_pointerst::arg_is_type_compatible(
      call_type.id()==ID_c_enum ||
      call_type.id()==ID_c_enum_tag)
   {
-    if(function_type.id()==ID_signedbv ||
-       function_type.id()==ID_unsigned ||
-       function_type.id()==ID_bool ||
-       function_type.id()==ID_pointer ||
-       function_type.id()==ID_c_enum ||
-       function_type.id()==ID_c_enum_tag)
-      return true;
-
-    return false;
+    return function_type.id() == ID_signedbv ||
+           function_type.id() == ID_unsigned || function_type.id() == ID_bool ||
+           function_type.id() == ID_pointer ||
+           function_type.id() == ID_c_enum ||
+           function_type.id() == ID_c_enum_tag;
   }
 
   return pointer_offset_bits(call_type, ns) ==
          pointer_offset_bits(function_type, ns);
-
-  return false;
 }
 
 bool remove_function_pointerst::is_type_compatible(

--- a/src/solvers/flattening/boolbv_extractbit.cpp
+++ b/src/solvers/flattening/boolbv_extractbit.cpp
@@ -85,6 +85,4 @@ literalt boolbvt::convert_extractbit(const extractbit_exprt &expr)
       return literal;
     }
   }
-
-  return SUB::convert_rest(expr);
 }

--- a/src/solvers/flattening/bv_utils.cpp
+++ b/src/solvers/flattening/bv_utils.cpp
@@ -818,8 +818,9 @@ bvt bv_utilst::multiplier(
   {
   case representationt::SIGNED: return signed_multiplier(op0, op1);
   case representationt::UNSIGNED: return unsigned_multiplier(op0, op1);
-  default: UNREACHABLE;
   }
+
+  UNREACHABLE;
 }
 
 bvt bv_utilst::multiplier_no_overflow(
@@ -833,8 +834,9 @@ bvt bv_utilst::multiplier_no_overflow(
     return signed_multiplier_no_overflow(op0, op1);
   case representationt::UNSIGNED:
     return unsigned_multiplier_no_overflow(op0, op1);
-  default: UNREACHABLE;
   }
+
+  UNREACHABLE;
 }
 
 void bv_utilst::signed_divider(
@@ -887,8 +889,6 @@ void bv_utilst::divider(
     signed_divider(op0, op1, result, remainer); break;
   case representationt::UNSIGNED:
     unsigned_divider(op0, op1, result, remainer); break;
-  default:
-    UNREACHABLE;
   }
 }
 

--- a/src/solvers/prop/prop_conv.cpp
+++ b/src/solvers/prop/prop_conv.cpp
@@ -480,6 +480,8 @@ decision_proceduret::resultt prop_conv_solvert::dec_solve()
     case propt::resultt::P_UNSATISFIABLE: return resultt::D_UNSATISFIABLE;
     default: return resultt::D_ERROR;
   }
+
+  UNREACHABLE;
 }
 
 exprt prop_conv_solvert::get(const exprt &expr) const

--- a/src/solvers/refinement/bv_refinement_loop.cpp
+++ b/src/solvers/refinement/bv_refinement_loop.cpp
@@ -108,6 +108,8 @@ decision_proceduret::resultt bv_refinementt::prop_solve()
     case propt::resultt::P_UNSATISFIABLE: return resultt::D_UNSATISFIABLE;
     default: return resultt::D_ERROR;
   }
+
+  UNREACHABLE;
 }
 
 void bv_refinementt::check_SAT()

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/arith_tools.h>
 #include <util/ieee_float.h>
+#include <util/invariant.h>
 #include <util/range.h>
 
 #include <numeric>
@@ -906,6 +907,8 @@ exprt smt2_parsert::function_application()
 
     return tmp;
   }
+
+  UNREACHABLE;
 }
 
 exprt smt2_parsert::expression()
@@ -997,6 +1000,8 @@ exprt smt2_parsert::expression()
   default:
     throw error("unexpected token in an expression");
   }
+
+  UNREACHABLE;
 }
 
 typet smt2_parsert::sort()
@@ -1080,6 +1085,8 @@ typet smt2_parsert::sort()
   default:
     throw error() << "unexpected token in a sort: `" << buffer << '\'';
   }
+
+  UNREACHABLE;
 }
 
 smt2_parsert::signature_with_parameter_idst

--- a/src/util/byte_operators.cpp
+++ b/src/util/byte_operators.cpp
@@ -23,6 +23,8 @@ irep_idt byte_extract_id()
   default:
     UNREACHABLE;
   }
+
+  UNREACHABLE;
 }
 
 irep_idt byte_update_id()
@@ -38,4 +40,6 @@ irep_idt byte_update_id()
   default:
     UNREACHABLE;
   }
+
+  UNREACHABLE;
 }

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -1102,6 +1102,8 @@ std::string configt::ansi_ct::os_to_string(ost os)
   case ost::OS_WIN: return "win";
   default: return "none";
   }
+
+  UNREACHABLE;
 }
 
 configt::ansi_ct::ost configt::ansi_ct::string_to_os(const std::string &os)

--- a/src/util/invariant.h
+++ b/src/util/invariant.h
@@ -149,7 +149,7 @@ public:
 
 #ifdef __GNUC__
 #define CBMC_NORETURN __attribute((noreturn))
-#elif defined(_MSV_VER)
+#elif defined(_MSC_VER)
 #define CBMC_NORETURN __declspec(noreturn)
 #elif __cplusplus >= 201703L
 #define CBMC_NORETURN [[noreturn]]
@@ -391,8 +391,6 @@ CBMC_NORETURN void report_invariant_failure(
         __VA_ARGS__); /* NOLINT */                                             \
   } while(false)
 
-#endif // End CPROVER_DO_NOT_CHECK / CPROVER_ASSERT / ... if block
-
 // Short hand macros. The variants *_STRUCTURED below allow to specify a custom
 // exception, and are equivalent to INVARIANT_STRUCTURED.
 
@@ -425,6 +423,8 @@ CBMC_NORETURN void report_invariant_failure(
         __VA_ARGS__);                                                          \
     }                                                                          \
   } while(false)
+
+#endif // End CPROVER_DO_NOT_CHECK / CPROVER_ASSERT / ... if block
 
 // The condition should only contain (unmodified) inputs to the method. Inputs
 // include arguments passed to the function, as well as member variables that

--- a/src/util/std_types.cpp
+++ b/src/util/std_types.cpp
@@ -46,7 +46,6 @@ std::size_t struct_union_typet::component_number(
   }
 
   UNREACHABLE;
-  return 0;
 }
 
 /// Get the reference to a component with given name.


### PR DESCRIPTION
Compilers differ in their ability to infer dead code, and the use of INVARIANT
etc. may result in end-of-function being reachable when they are configured
as no-ops. Make compilers happy, even when that may result in statements that
really shouldn't be reachable.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
