### PR TITLE
Fix lots of simple Doxygen errors

### DIFF
--- a/doc/architectural/cbmc-architecture.md
+++ b/doc/architectural/cbmc-architecture.md
@@ -1,4 +1,4 @@
-\ingroup module_hidden 
+\ingroup module_hidden
 \page cbmc-architecture CBMC Architecture
 
 \author Martin Brain, Peter Schrammel
@@ -33,7 +33,7 @@ digraph G {
   2 [label="preprocessing,\nparsing" URL="\ref preprocessing"];
   3 [label="language\ntype-checking" URL="\ref type-checking"];
   4 [label="goto\nconversion" URL="\ref goto-conversion"];
-  5 [label="instrumentation" URL="\ref instrumentation"];
+  5 [label="instrumentation" URL="\ref section-goto-transforms"];
   6 [label="symbolic\nexecution" URL="\ref symbolic-execution"];
   7 [label="SAT/SMT\nencoding" URL="\ref sat-smt-encoding"];
   8 [label="decision\nprocedure" URL="\ref decision-procedure"];

--- a/jbmc/src/java_bytecode/README.md
+++ b/jbmc/src/java_bytecode/README.md
@@ -267,7 +267,7 @@ for(tmp_index = 0; tmp_index < dim_size; ++tmp_index)
 
 When \ref remove_exceptions is called on the \ref goto_modelt, the
 goto model contains complex instructions (\ref goto_program_instruction_typet)
-such as `CATCH-POP`, `CATCH-PUSH` and `THROW`. In order to analyze the goto 
+such as `CATCH-POP`, `CATCH-PUSH` and `THROW`. In order to analyze the goto
 model, the instructions must be simplified to use more basic instructions - this
 is called "lowering". This class lowers the `CATCH` and `THROW` instructions.
 

--- a/jbmc/src/java_bytecode/ci_lazy_methods.cpp
+++ b/jbmc/src/java_bytecode/ci_lazy_methods.cpp
@@ -30,6 +30,10 @@
 ///   implementation for `List` interface.
 /// \param pointer_type_selector: selector to handle correct pointer types
 /// \param message_handler: the message handler to use for output
+/// \param synthetic_methods: map from synthetic method names to the type of
+///   synthetic method (e.g. stub class static initialiser). Indicates that
+///   these method bodies are produced internally, rather than generated from
+///   Java bytecode.
 ci_lazy_methodst::ci_lazy_methodst(
   const symbol_tablet &symbol_table,
   const irep_idt &main_class,

--- a/jbmc/src/java_bytecode/ci_lazy_methods_needed.cpp
+++ b/jbmc/src/java_bytecode/ci_lazy_methods_needed.cpp
@@ -19,7 +19,7 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 
 /// Notes `method_symbol_name` is referenced from some reachable function, and
 /// should therefore be elaborated.
-/// \param: `method_symbol_name`: method name; must exist in symbol table.
+/// \param method_symbol_name: method name; must exist in symbol table.
 void ci_lazy_methods_neededt::add_needed_method(
   const irep_idt &method_symbol_name)
 {
@@ -47,7 +47,7 @@ void ci_lazy_methods_neededt::add_clinit_call(
 /// Notes class `class_symbol_name` will be instantiated, or a static field
 /// belonging to it will be accessed. Also notes that its static initializer is
 /// therefore reachable.
-/// \param: `class_symbol_name`: class name; must exist in symbol table.
+/// \param class_symbol_name: class name; must exist in symbol table.
 /// \return Returns true if `class_symbol_name` is new (not seen before).
 bool ci_lazy_methods_neededt::add_needed_class(
   const irep_idt &class_symbol_name)

--- a/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
@@ -263,7 +263,7 @@ code_ifthenelset java_bytecode_instrumentt::check_class_cast(
 /// Exceptions are thrown when the `throw_runtime_exceptions` flag is set.
 /// Otherwise, assertions are emitted.
 /// \param expr: the checked expression
-/// `original_loc: source location in the original code
+/// \param original_loc: source location in the original code
 /// \return Based on the value of the flag `throw_runtime_exceptions`,
 /// it returns code that either throws an NullPointerException or emits an
 /// assertion checking the subtype relation
@@ -351,9 +351,9 @@ void java_bytecode_instrumentt::prepend_instrumentation(
   }
 }
 
-/// Augments `expr` with instrumentation in the form of either
+/// Augments `code` with instrumentation in the form of either
 /// assertions or runtime exceptions
-/// \param `expr` the expression to be instrumented
+/// \param code: the expression to be instrumented
 void java_bytecode_instrumentt::instrument_code(codet &code)
 {
   source_locationt old_source_location=code.source_location();
@@ -543,8 +543,8 @@ optionalt<codet> java_bytecode_instrumentt::instrument_expr(const exprt &expr)
     return std::move(result);
 }
 
-/// Instruments `expr`
-/// \param expr: the expression to be instrumented
+/// Instruments `code`
+/// \param code: the expression to be instrumented
 void java_bytecode_instrumentt::operator()(codet &code)
 {
   instrument_code(code);

--- a/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
@@ -258,7 +258,7 @@ code_ifthenelset java_bytecode_instrumentt::check_class_cast(
   return conditional_check;
 }
 
-/// Checks whether `expr` is null and throws NullPointerException/
+/// Checks whether \p expr is null and throws NullPointerException/
 /// generates an assertion when necessary;
 /// Exceptions are thrown when the `throw_runtime_exceptions` flag is set.
 /// Otherwise, assertions are emitted.
@@ -287,7 +287,7 @@ codet java_bytecode_instrumentt::check_null_dereference(
   return create_fatal_assertion(not_exprt(equal_expr), check_loc);
 }
 
-/// Checks whether `length`>=0 and throws NegativeArraySizeException/
+/// Checks whether \p length >= 0 and throws NegativeArraySizeException/
 /// generates an assertion when necessary;
 /// Exceptions are thrown when the `throw_runtime_exceptions` flag is set.
 /// Otherwise, assertions are emitted.
@@ -316,8 +316,8 @@ codet java_bytecode_instrumentt::check_array_length(
   return create_fatal_assertion(ge_zero, check_loc);
 }
 
-/// Checks whether `expr` requires instrumentation, and if so adds it
-/// to `block`.
+/// Checks whether \p expr requires instrumentation, and if so adds it
+/// to \p block.
 /// \param [out] block: block where instrumentation will be added
 /// \param expr: expression to instrument
 void java_bytecode_instrumentt::add_expr_instrumentation(
@@ -333,8 +333,8 @@ void java_bytecode_instrumentt::add_expr_instrumentation(
   }
 }
 
-/// Appends `code` to `instrumentation` and overwrites reference `code`
-/// with the augmented block if `instrumentation` is non-empty.
+/// Appends \p code to \p instrumentation and overwrites reference \p code
+/// with the augmented block if \p instrumentation is non-empty.
 /// \param [in, out] code: code being instrumented
 /// \param instrumentation: instrumentation code block to prepend
 void java_bytecode_instrumentt::prepend_instrumentation(
@@ -351,7 +351,7 @@ void java_bytecode_instrumentt::prepend_instrumentation(
   }
 }
 
-/// Augments `code` with instrumentation in the form of either
+/// Augments \p code with instrumentation in the form of either
 /// assertions or runtime exceptions
 /// \param code: the expression to be instrumented
 void java_bytecode_instrumentt::instrument_code(codet &code)
@@ -464,11 +464,11 @@ void java_bytecode_instrumentt::instrument_code(codet &code)
     merge_source_location_rec(code, old_source_location);
 }
 
-/// Computes the instrumentation for `expr` in the form of
+/// Computes the instrumentation for \p expr in the form of
 /// either assertions or runtime exceptions.
 /// \param expr: the expression for which we compute
 /// instrumentation
-/// \return: The instrumentation for `expr` if required
+/// \return: The instrumentation for \p expr if required
 optionalt<codet> java_bytecode_instrumentt::instrument_expr(const exprt &expr)
 {
   code_blockt result;
@@ -543,16 +543,16 @@ optionalt<codet> java_bytecode_instrumentt::instrument_expr(const exprt &expr)
     return std::move(result);
 }
 
-/// Instruments `code`
+/// Instruments \p code
 /// \param code: the expression to be instrumented
 void java_bytecode_instrumentt::operator()(codet &code)
 {
   instrument_code(code);
 }
 
-/// Instruments the code attached to `symbol` with
+/// Instruments the code attached to \p symbol with
 /// runtime exceptions or corresponding assertions.
-/// Exceptions are thrown when the `throw_runtime_exceptions` flag is set.
+/// Exceptions are thrown when the \p throw_runtime_exceptions flag is set.
 /// Otherwise, assertions are emitted.
 /// \param symbol_table: global symbol table (may gain exception type stubs and
 ///   similar)
@@ -603,7 +603,7 @@ void java_bytecode_instrument_uncaught_exceptions(
 
 /// Instruments all the code in the symbol_table with
 /// runtime exceptions or corresponding assertions.
-/// Exceptions are thrown when the `throw_runtime_exceptions` flag is set.
+/// Exceptions are thrown when the \p throw_runtime_exceptions flag is set.
 /// Otherwise, assertions are emitted.
 /// \param symbol_table: global symbol table, all of whose code members
 ///   will be annotated (may gain exception type stubs and similar)

--- a/jbmc/src/java_bytecode/java_class_loader.cpp
+++ b/jbmc/src/java_bytecode/java_class_loader.cpp
@@ -97,7 +97,10 @@ static bool is_overlay_class(const java_bytecode_parse_treet::classt &c)
 }
 
 /// Check through all the places class parse trees can appear and returns the
-/// first implementation it finds plus any overlay class implementations
+/// first implementation it finds plus any overlay class implementations.
+/// Uses \p class_loader_limit to limit the class files that it might (directly
+/// or indirectly) load and returns a default-constructed parse tree when unable
+/// to find the .class file.
 /// \param class_loader_limit: Filter to decide whether to load classes
 /// \param class_name: Name of class to load
 /// \returns The list of valid implementations, including overlays

--- a/jbmc/src/java_bytecode/java_class_loader.h
+++ b/jbmc/src/java_bytecode/java_class_loader.h
@@ -43,13 +43,6 @@ public:
 
   parse_tree_with_overlayst &operator()(const irep_idt &class_name);
 
-  /// Given a \p class_name (e.g. "java.lang.Thread") try to load the
-  /// corresponding .class file by first scanning all .jar files whose
-  /// pathname is stored in \ref jar_files, and if that doesn't work, then scan
-  /// the actual filesystem using `config.java.classpath` as class path. Uses
-  /// \p limit to limit the class files that it might (directly or indirectly)
-  /// load and returns a default-constructed parse tree when unable to find the
-  /// .class file.
   parse_tree_with_overlayst &get_parse_tree(
     java_class_loader_limitt &class_loader_limit,
     const irep_idt &class_name);

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -562,6 +562,7 @@ refined_string_exprt java_string_library_preprocesst::make_nondet_string_expr(
 /// declare a new String and allocate it
 /// \param type: a type for string
 /// \param loc: a location in the program
+/// \param function_id: function the fresh string is created in
 /// \param symbol_table: symbol table
 /// \param code: code block to which allocation instruction will be added
 /// \return a new string
@@ -928,6 +929,7 @@ java_string_library_preprocesst::string_literal_to_string_expr(
 /// Provide code for the String.valueOf(F) function.
 /// \param type: type of the function call
 /// \param loc: location in the program_invocation_name
+/// \param function_id: function the generated code will be added to
 /// \param symbol_table: symbol table
 /// \return Code corresponding to the Java conversion of floats to strings.
 codet java_string_library_preprocesst::make_float_to_string_code(
@@ -1065,14 +1067,14 @@ codet java_string_library_preprocesst::make_float_to_string_code(
 /// \param ignore_first_arg: boolean flag telling that the first argument should
 ///   not be part of the arguments of the call (but only used to be assigned the
 ///   result)
-/// \return code for the String.<init>(args) function:
-/// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/// cprover_string_length = fun(arg).length;
-/// cprover_string_array = fun(arg).data;
-/// this->length = cprover_string_length;
-/// this->data = cprover_string_array;
-/// cprover_string = {.=cprover_string_length, .=cprover_string_array};
-/// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/// \return code for the `String.<init>(args)` function:
+///
+///     cprover_string_length = fun(arg).length;
+///     cprover_string_array = fun(arg).data;
+///     this->length = cprover_string_length;
+///     this->data = cprover_string_array;
+///     cprover_string = {.=cprover_string_length, .=cprover_string_array};
+///
 codet java_string_library_preprocesst::make_init_function_from_call(
   const irep_idt &function_name,
   const java_method_typet &type,
@@ -1314,6 +1316,7 @@ exprt java_string_library_preprocesst::get_object_at_index(
 /// \param index: index of the desired argument
 /// \param structured_type: type for arguments of the internal format function
 /// \param loc: a location in the source
+/// \param function_id: function the generated expression will be used in
 /// \param symbol_table: the symbol table
 /// \param code: code block to which we are adding some assignments
 /// \return An expression of type `structured_type` representing the possible
@@ -1422,6 +1425,7 @@ exprt java_string_library_preprocesst::make_argument_for_format(
 /// 10 arguments
 /// \param type: type of the function call
 /// \param loc: location in the program_invocation_name
+/// \param function_id: function the generated code will be used in
 /// \param symbol_table: symbol table
 /// \return Code implementing the Java String.format function.
 ///         Since the exact class of the arguments is not known, we give as
@@ -1478,6 +1482,7 @@ codet java_string_library_preprocesst::make_string_format_code(
 /// function.
 /// \param type: type of the function called
 /// \param loc: location in the source
+/// \param function_id: function the generated code will be added to
 /// \param symbol_table: the symbol table
 /// \return Code corresponding to
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1627,6 +1632,7 @@ codet java_string_library_preprocesst::make_string_returning_function_from_call(
 /// object.
 /// \param type: type of the function
 /// \param loc: location in the source
+/// \param function_id: function the generated code will be added to
 /// \param symbol_table: symbol table
 /// \return Code corresponding to:
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1772,9 +1778,7 @@ void java_string_library_preprocesst::get_all_function_names(
 
 /// Should be called to provide code for string functions that are used in the
 /// code but for which no implementation is provided.
-/// \param function_id: name of the function
-/// \param type: its type
-/// \param loc: location in the program
+/// \param symbol: symbol of the function to provide code for
 /// \param symbol_table: a symbol table
 /// \return Code for the body of the String functions if they are part of the
 ///   supported String functions, nil_exprt otherwise.

--- a/jbmc/src/java_bytecode/remove_exceptions.cpp
+++ b/jbmc/src/java_bytecode/remove_exceptions.cpp
@@ -46,7 +46,7 @@ Date:   December 2016
 /// (in instruction->code.exception_list()) and a corresponding GOTO program
 /// target for each (in instruction->targets).
 /// Thrown instructions are currently always matched to tags using
-/// java_instanceof, optionally lowered to a check on the @class_identifier
+/// java_instanceof, optionally lowered to a check on the `@class_identifier`
 /// field, so a language frontend wanting to use this class must use
 /// exceptions with a Java-compatible structure.
 ///

--- a/jbmc/src/java_bytecode/simple_method_stubbing.cpp
+++ b/jbmc/src/java_bytecode/simple_method_stubbing.cpp
@@ -66,6 +66,8 @@ protected:
 ///   type.
 /// \param ptr: pointer to the memory to initialize
 /// \param loc: source location to set for the opaque method stub
+/// \param function_id: name of the function we're generated stub code for; used
+///   to ensure any generated temporaries are created in the correct scope.
 /// \param [out] parent_block: The parent block in which the new instructions
 ///   will be added.
 /// \param insert_before_index: The position in which the new instructions

--- a/scripts/expected_doxygen_warnings.txt
+++ b/scripts/expected_doxygen_warnings.txt
@@ -15,26 +15,10 @@
   template <>
   satcheck_minisat2_baset< Minisat::SimpSolver >::~satcheck_minisat2_baset()
 
-/cbmc/src/solvers/refinement/string_constraint_generator_transformation.cpp:255: warning: The following parameters of to_char_pair(exprt expr1, exprt expr2, std::function< array_string_exprt(const exprt &)> get_string_expr) are not documented:
-  parameter 'get_string_expr'
-/cbmc/src/solvers/refinement/string_refinement.cpp:1511: warning: argument 'stream' of command @param is not found in the argument list of compute_inverse_function(const exprt &qvar, const exprt &val, const exprt &f)
 /cbmc/src/solvers/refinement/string_refinement.cpp:239: warning: Invalid list item found
-/cbmc/src/solvers/refinement/string_refinement.cpp:1823: warning: argument 'stream' of command @param is not found in the argument list of instantiate(const string_constraintt &axiom, const exprt &str, const exprt &val)
-/cbmc/src/solvers/refinement/string_refinement.cpp:1052: warning: The following parameters of substitute_array_access(const with_exprt &expr, const exprt &index, const bool left_propagate) are not documented:
-  parameter 'left_propagate'
 /cbmc/doc/architectural/howto.md:260: warning: found </div> at different nesting level (6) than expected (3)
 /cbmc/doc/architectural/howto.md:261: warning: end of comment block while expecting command </div>
-/cbmc/src/solvers/README.md:4: warning: @copydetails or @copydoc target 'generate_instantiations(messaget::mstreamt &stream, const string_constraint_generatort &generator, const index_set_pairt &index_set, const string_axiomst &axioms, const std::map<string_not_contains_constraintt, symbol_exprt> &not_contain_witnesses).' not found
-/cbmc/src/cbmc/bmc.cpp:473: warning: argument 'message' of command @param is not found in the argument list of bmct::do_language_agnostic_bmc(const path_strategy_choosert &path_strategy_chooser, const optionst &opts, abstract_goto_modelt &model, ui_message_handlert &ui, std::function< void(bmct &, const symbol_tablet &)> driver_configure_bmc=nullptr, std::function< bool(void)> callback_after_symex=nullptr)
-/cbmc/src/cbmc/bmc.h:124: warning: The following parameters of bmct::do_language_agnostic_bmc(const path_strategy_choosert &path_strategy_chooser, const optionst &opts, abstract_goto_modelt &model, ui_message_handlert &ui, std::function< void(bmct &, const symbol_tablet &)> driver_configure_bmc=nullptr, std::function< bool(void)> callback_after_symex=nullptr) are not documented:
-  parameter 'path_strategy_chooser'
-/cbmc/src/solvers/flattening/bv_utils.cpp:1113: warning: argument 'Bit' of command @param is not found in the argument list of bv_utilst::equal(const bvt &op0, const bvt &op1)
-/cbmc/src/solvers/flattening/bv_utils.cpp:1113: warning: argument 'vectors' of command @param is not found in the argument list of bv_utilst::equal(const bvt &op0, const bvt &op1)
-/cbmc/src/solvers/flattening/bv_utils.h:134: warning: The following parameters of bv_utilst::equal(const bvt &op0, const bvt &op1) are not documented:
-  parameter 'op0'
-  parameter 'op1'
-/cbmc/jbmc/src/java_bytecode/ci_lazy_methods.h:100: warning: The following parameters of ci_lazy_methodst::ci_lazy_methodst(const symbol_tablet &symbol_table, const irep_idt &main_class, const std::vector< irep_idt > &main_jar_classes, const std::vector< load_extra_methodst > &lazy_methods_extra_entry_points, java_class_loadert &java_class_loader, const std::vector< irep_idt > &extra_instantiated_classes, const select_pointer_typet &pointer_type_selector, message_handlert &message_handler, const synthetic_methods_mapt &synthetic_methods) are not documented:
-  parameter 'synthetic_methods'
+/cbmc/src/solvers/README.md:434: warning: Invalid list item found
 /cbmc/src/goto-instrument/wmm/event_graph.h:506: warning: The following parameters of event_grapht::explore_copy_segment(std::set< event_idt > &explored, event_idt begin, event_idt end) const are not documented:
   parameter 'explored'
 /cbmc/src/goto-instrument/wmm/cycle_collection.cpp:149: warning: argument 'get_po_only' of command @param is not found in the argument list of event_grapht::graph_explorert::backtrack(std::set< critical_cyclet > &set_of_cycles, event_idt source, event_idt vertex, bool unsafe_met, event_idt po_trans, bool same_var_pair, bool lwfence_met, bool has_to_be_unsafe, irep_idt var_to_avoid, memory_modelt model)
@@ -53,48 +37,3 @@
   parameter 'model'
   parameter 'no_dependencies'
   parameter 'duplicate_body'
-/cbmc/jbmc/src/java_bytecode/java_bytecode_instrument.cpp:60: warning: The following parameters of java_bytecode_instrumentt::check_null_dereference(const exprt &expr, const source_locationt &original_loc) are not documented:
-  parameter 'original_loc'
-/cbmc/jbmc/src/java_bytecode/java_bytecode_instrument.cpp:354: warning: argument 'tt' of command @param is not found in the argument list of java_bytecode_instrumentt::instrument_code(codet &code)
-/cbmc/jbmc/src/java_bytecode/java_bytecode_instrument.cpp:354: warning: argument 'expr' of command @param is not found in the argument list of java_bytecode_instrumentt::instrument_code(codet &code)
-/cbmc/jbmc/src/java_bytecode/java_bytecode_instrument.cpp:354: warning: argument 'tt' of command @param is not found in the argument list of java_bytecode_instrumentt::instrument_code(codet &code)
-/cbmc/jbmc/src/java_bytecode/java_bytecode_instrument.cpp:73: warning: The following parameters of java_bytecode_instrumentt::instrument_code(codet &code) are not documented:
-  parameter 'code'
-/cbmc/jbmc/src/java_bytecode/java_bytecode_instrument.cpp:546: warning: argument 'expr' of command @param is not found in the argument list of java_bytecode_instrumentt::operator()(codet &code)
-/cbmc/jbmc/src/java_bytecode/java_bytecode_instrument.cpp:39: warning: The following parameters of java_bytecode_instrumentt::operator()(codet &code) are not documented:
-  parameter 'code'
-/cbmc/jbmc/src/java_bytecode/java_class_loader.cpp:104: warning: unable to resolve reference to `jar_files' for \ref command
-/cbmc/jbmc/src/java_bytecode/simple_method_stubbing.cpp:38: warning: The following parameters of java_simple_method_stubst::create_method_stub_at(const typet &expected_type, const exprt &ptr, const source_locationt &loc, const irep_idt &function_id, code_blockt &parent_block, unsigned insert_before_index, bool is_constructor, bool update_in_place) are not documented:
-  parameter 'function_id'
-/cbmc/jbmc/src/java_bytecode/java_string_library_preprocess.h:250: warning: The following parameters of java_string_library_preprocesst::allocate_fresh_string(const typet &type, const source_locationt &loc, const irep_idt &function_id, symbol_table_baset &symbol_table, code_blockt &code) are not documented:
-  parameter 'function_id'
-/cbmc/jbmc/src/java_bytecode/java_string_library_preprocess.cpp:1835: warning: argument 'function_id' of command @param is not found in the argument list of java_string_library_preprocesst::code_for_function(const symbolt &symbol, symbol_table_baset &symbol_table)
-/cbmc/jbmc/src/java_bytecode/java_string_library_preprocess.cpp:1835: warning: argument 'type' of command @param is not found in the argument list of java_string_library_preprocesst::code_for_function(const symbolt &symbol, symbol_table_baset &symbol_table)
-/cbmc/jbmc/src/java_bytecode/java_string_library_preprocess.cpp:1835: warning: argument 'loc' of command @param is not found in the argument list of java_string_library_preprocesst::code_for_function(const symbolt &symbol, symbol_table_baset &symbol_table)
-/cbmc/jbmc/src/java_bytecode/java_string_library_preprocess.h:52: warning: The following parameters of java_string_library_preprocesst::code_for_function(const symbolt &symbol, symbol_table_baset &symbol_table) are not documented:
-  parameter 'symbol'
-/cbmc/jbmc/src/java_bytecode/java_string_library_preprocess.h:332: warning: The following parameters of java_string_library_preprocesst::make_argument_for_format(const exprt &argv, std::size_t index, const struct_typet &structured_type, const source_locationt &loc, const irep_idt &function_id, symbol_table_baset &symbol_table, code_blockt &code) are not documented:
-  parameter 'function_id'
-/cbmc/jbmc/src/java_bytecode/java_string_library_preprocess.h:166: warning: The following parameters of java_string_library_preprocesst::make_copy_string_code(const java_method_typet &type, const source_locationt &loc, const irep_idt &function_id, symbol_table_baset &symbol_table) are not documented:
-  parameter 'function_id'
-/cbmc/jbmc/src/java_bytecode/java_string_library_preprocess.h:148: warning: The following parameters of java_string_library_preprocesst::make_float_to_string_code(const java_method_typet &type, const source_locationt &loc, const irep_idt &function_id, symbol_table_baset &symbol_table) are not documented:
-  parameter 'function_id'
-/cbmc/jbmc/src/java_bytecode/java_string_library_preprocess.cpp:1085: warning: Unsupported xml/html tag <init> found
-/cbmc/jbmc/src/java_bytecode/java_string_library_preprocess.h:184: warning: The following parameters of java_string_library_preprocesst::make_object_get_class_code(const java_method_typet &type, const source_locationt &loc, const irep_idt &function_id, symbol_table_baset &symbol_table) are not documented:
-  parameter 'function_id'
-/cbmc/jbmc/src/java_bytecode/java_string_library_preprocess.h:160: warning: The following parameters of java_string_library_preprocesst::make_string_format_code(const java_method_typet &type, const source_locationt &loc, const irep_idt &function_id, symbol_table_baset &symbol_table) are not documented:
-  parameter 'function_id'
-/cbmc/src/langapi/language_file.cpp:51: warning: argument 'should_generate_stubs' of command @param is not found in the argument list of language_filest::set_should_generate_opaque_method_stubs(bool stubs_enabled)
-/cbmc/src/langapi/language_file.h:104: warning: The following parameters of language_filest::set_should_generate_opaque_method_stubs(bool stubs_enabled) are not documented:
-  parameter 'stubs_enabled'
-/cbmc/src/langapi/language.cpp:121: warning: argument 'parameter_type' of command @param is not found in the argument list of languaget::build_stub_parameter_symbol(const symbolt &function_symbol, size_t parameter_index, const code_typet::parametert &parameter)
-/cbmc/src/langapi/language.h:176: warning: The following parameters of languaget::build_stub_parameter_symbol(const symbolt &function_symbol, size_t parameter_index, const code_typet::parametert &parameter) are not documented:
-  parameter 'parameter'
-/cbmc/jbmc/src/java_bytecode/remove_exceptions.cpp:47: warning: Found unknown command `\class_identifier'
-/cbmc/src/solvers/refinement/string_refinement.cpp:2099: warning: argument 'expr' of command @param is not found in the argument list of string_constraintt::universal_only_in_index(const string_constraintt &constr)
-/cbmc/src/solvers/refinement/string_refinement.cpp:2106: warning: The following parameters of string_constraintt::universal_only_in_index(const string_constraintt &constr) are not documented:
-  parameter 'constr'
-/cbmc/jbmc/src/java_bytecode/ci_lazy_methods_needed.h:40: warning: The following parameters of ci_lazy_methods_neededt::add_needed_class(const irep_idt &class_symbol_name) are not documented:
-  parameter 'class_symbol_name'
-/cbmc/jbmc/src/java_bytecode/ci_lazy_methods_needed.h:38: warning: The following parameters of ci_lazy_methods_neededt::add_needed_method(const irep_idt &method_symbol_name) are not documented:
-  parameter 'method_symbol_name'

--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -488,11 +488,12 @@ safety_checkert::resultt bmct::stop_on_fail(prop_convt &prop_conv)
 
 /// Perform core BMC, using an abstract model to supply GOTO function bodies
 /// (perhaps created on demand).
+/// \param path_strategy_chooser: controls whether symex generates a single
+///   large equation for the whole program or an equation per path
 /// \param opts: command-line options affecting BMC
 /// \param model: provides goto function bodies and the symbol table, perhaps
 //    creating those function bodies on demand.
 /// \param ui: user-interface mode (plain text, XML output, JSON output, ...)
-/// \param message: used for logging
 /// \param driver_configure_bmc: function provided by the driver program,
 ///   which applies driver-specific configuration to a bmct before running.
 /// \param callback_after_symex: optional callback to be run after symex.

--- a/src/langapi/language.cpp
+++ b/src/langapi/language.cpp
@@ -126,7 +126,7 @@ irep_idt languaget::generate_opaque_stub_body(
 /// \param function_symbol: the symbol of an opaque function
 /// \param parameter_index: the index of the parameter within the the parameter
 ///   list
-/// \param parameter_type: the type of the parameter
+/// \param parameter: the parameter description, including its type and name
 /// \return A named symbol to be added to the symbol table representing one of
 ///   the parameters in this opaque function.
 parameter_symbolt languaget::build_stub_parameter_symbol(

--- a/src/langapi/language_file.cpp
+++ b/src/langapi/language_file.cpp
@@ -49,7 +49,7 @@ void language_filest::show_parse(std::ostream &out)
 }
 
 /// Turn on or off stub generation for all the languages
-/// \param should_generate_stubs: Should stub generation be enabled
+/// \param stubs_enabled: Should stub generation be enabled
 void language_filest::set_should_generate_opaque_method_stubs(
   bool stubs_enabled)
 {

--- a/src/pointer-analysis/dereference.h
+++ b/src/pointer-analysis/dereference.h
@@ -22,7 +22,6 @@ class typecast_exprt;
 class dereferencet
 {
 public:
-  /// \param _ns: Namespace
   explicit dereferencet(
     const namespacet &_ns):
     ns(_ns)

--- a/src/solvers/README.md
+++ b/src/solvers/README.md
@@ -348,8 +348,8 @@ allocates a new string before calling a primitive.
 
 \subsection instantiation Instantiation
 
-This is done by generate_instantiations(messaget::mstreamt &stream, const string_constraint_generatort &generator, const index_set_pairt &index_set, const string_axiomst &axioms, const std::map<string_not_contains_constraintt, symbol_exprt> &not_contain_witnesses).
-\copydetails generate_instantiations(messaget::mstreamt &stream, const string_constraint_generatort &generator, const index_set_pairt &index_set, const string_axiomst &axioms, const std::map<string_not_contains_constraintt, symbol_exprt> &not_contain_witnesses).
+This is done by generate_instantiations(const index_set_pairt &index_set, const string_axiomst &axioms, const std::unordered_map<string_not_contains_constraintt, symbol_exprt> &not_contain_witnesses).
+\copydetails generate_instantiations(const index_set_pairt &index_set, const string_axiomst &axioms, const std::unordered_map<string_not_contains_constraintt, symbol_exprt> &not_contain_witnesses).
 
 \subsection axiom-check Axiom check
 

--- a/src/solvers/flattening/bv_utils.cpp
+++ b/src/solvers/flattening/bv_utils.cpp
@@ -1110,7 +1110,8 @@ literalt bv_utilst::equal_const(const bvt &var, const bvt &constant)
 #endif
 
 /// Bit-blasting ID_equal and use in other encodings.
-/// \param Bit:vectors for the two things to compare.
+/// \param op0: Lhs bitvector to compare
+/// \param op1: Rhs bitvector to compare
 /// \return The literal that is true if and only if they are equal.
 literalt bv_utilst::equal(const bvt &op0, const bvt &op1)
 {

--- a/src/solvers/refinement/string_constraint_generator_transformation.cpp
+++ b/src/solvers/refinement/string_constraint_generator_transformation.cpp
@@ -250,6 +250,9 @@ std::pair<exprt, string_constraintst> add_axioms_for_trim(
 /// Otherwise return empty optional
 /// \param expr1 First expression
 /// \param expr2 Second expression
+/// \param get_string_expr: Function that yields an array_string_exprt
+///   corresponding to either `expr1` or `expr2`, for the case where they are
+///   not primitive chars.
 /// \return Optional pair of two expressions
 static optionalt<std::pair<exprt, exprt>> to_char_pair(
   exprt expr1,

--- a/src/solvers/refinement/string_refinement.cpp
+++ b/src/solvers/refinement/string_refinement.cpp
@@ -99,7 +99,6 @@ static void update_index_set(
 /// For instance, if `axiom` corresponds to \f$\forall q.\ s[q+x]='a' \land
 /// t[q]='b'\f$, `instantiate(axiom,s,v)` would return an expression for
 /// \f$s[v]='a' \land t[v-x]='b'\f$.
-/// \param stream: output stream
 /// \param axiom: a universally quantified formula
 /// \param str: an array of char variable
 /// \param val: an index expression
@@ -1050,13 +1049,13 @@ void debug_model(
 /// 'if' expressions. e.g. for an array access arr[index], where: `arr :=
 /// array_of(12) with {0:=24} with {2:=42}` the constructed expression will be:
 /// `index==0 ? 24 : index==2 ? 42 : 12`
-/// If `left_propagate` is set to true, the expression will look like
-/// `index<=0 ? 24 : index<=2 ? 42 : 12`
 /// \param expr: A (possibly nested) 'with' expression on an `array_of`
 ///   expression. The function checks that the expression is of the form
 ///   `with_expr(with_expr(...(array_of(...)))`. This is the form in which
 ///   array valuations coming from the underlying solver are given.
 /// \param index: An index with which to build the equality condition
+/// \param left_propagate: If set to true, the expression will look like
+/// `index<=0 ? 24 : index<=2 ? 42 : 12`
 /// \return An expression containing no 'with' expression
 static exprt substitute_array_access(
   const with_exprt &expr,
@@ -1517,7 +1516,6 @@ exprt simplify_sum(const exprt &f)
   return sum_over_map(map, f.type());
 }
 
-/// \param stream: an output stream
 /// \param qvar: a symbol representing a universally quantified variable
 /// \param val: an expression
 /// \param f: an expression containing `+` and `-`
@@ -2108,7 +2106,7 @@ is_linear_arithmetic_expr(const exprt &expr, const symbol_exprt &var)
 /// expressions in the body of a string constraint. This function returns true
 /// if this is the case and false otherwise.
 /// \related string_constraintt
-/// \param [in] expr: The string constraint to check
+/// \param [in] constr: The string constraint to check
 /// \return true if the universal variable only occurs in index expressions,
 ///   false otherwise.
 static bool universal_only_in_index(const string_constraintt &constr)


### PR DESCRIPTION
This is mainly just documenting missing parameters and fixing syntax mistakes. This removes about 2/3 or so of the expected warnings. This also fixes the mysterious `<unknown-file>` error that was tripping up the filter script.