### PR TITLE
Remove unnecessary assertion about using 0-size objects

### DIFF
--- a/regression/cbmc/void_pointer4/main.c
+++ b/regression/cbmc/void_pointer4/main.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+
+struct S
+{
+  int a;
+};
+
+void foo(struct S *x)
+{
+  x->a = 42;
+  assert(x->a == 42);
+}
+
+int main()
+{
+  void *p;
+  foo(p);
+}

--- a/regression/cbmc/void_pointer4/test.desc
+++ b/regression/cbmc/void_pointer4/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/scripts/delete_failing_smt2_solver_tests
+++ b/scripts/delete_failing_smt2_solver_tests
@@ -192,4 +192,5 @@ rm union9/test.desc
 rm unsigned___int128/test.desc
 rm void_pointer2/test.desc
 rm void_pointer3/test.desc
+rm void_pointer4/test.desc
 rm while1/test.desc

--- a/src/util/std_expr.cpp
+++ b/src/util/std_expr.cpp
@@ -131,8 +131,6 @@ void object_descriptor_exprt::build(
     offset()=from_integer(0, index_type());
 
   build_object_descriptor_rec(ns, expr, *this);
-
-  POSTCONDITION(root_object().type().id() != ID_empty);
 }
 
 shift_exprt::shift_exprt(


### PR DESCRIPTION
Reading from or writing to such will yield non-deterministic values, but it's ok
to let back-ends deal with that.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
