### PR TITLE
Remove names of unused parameters [blocks: #2310]

### DIFF
--- a/jbmc/src/java_bytecode/select_pointer_type.cpp
+++ b/jbmc/src/java_bytecode/select_pointer_type.cpp
@@ -228,7 +228,7 @@ select_pointer_typet::get_recursively_instantiated_type(
 std::set<symbol_typet> select_pointer_typet::get_parameter_alternative_types(
   const irep_idt &function_name,
   const irep_idt &parameter_name,
-  const namespacet &ns) const
+  const namespacet &) const
 {
   // unused parameters
   (void)function_name;

--- a/jbmc/unit/pointer-analysis/custom_value_set_analysis.cpp
+++ b/jbmc/unit/pointer-analysis/custom_value_set_analysis.cpp
@@ -91,7 +91,7 @@ public:
 
   void adjust_assign_rhs_values(
     const exprt &expr,
-    const namespacet &ns,
+    const namespacet &,
     object_mapt &dest) const override
   {
     // Always add an ID_unknown to reads from variables containing
@@ -109,7 +109,7 @@ public:
 
   void apply_assign_side_effects(
     const exprt &lhs,
-    const exprt &rhs,
+    const exprt &,
     const namespacet &ns) override
   {
     // Whenever someone touches the variable "cause", null the

--- a/jbmc/unit/util/has_subtype.cpp
+++ b/jbmc/unit/util/has_subtype.cpp
@@ -80,7 +80,7 @@ SCENARIO("has_subtype", "[core][utils][has_subtype]")
     THEN("has_subtype terminates")
     {
       REQUIRE_FALSE(
-        has_subtype(struct_type, [&](const typet &t) { return false; }, ns));
+        has_subtype(struct_type, [&](const typet &) { return false; }, ns));
     }
     THEN("symbol type is a subtype")
     {

--- a/src/analyses/ai_domain.h
+++ b/src/analyses/ai_domain.h
@@ -63,7 +63,7 @@ public:
     const namespacet &ns) = 0;
 
   virtual void
-  output(std::ostream &out, const ai_baset &ai, const namespacet &ns) const
+  output(std::ostream &, const ai_baset &, const namespacet &) const
   {
   }
 
@@ -102,7 +102,7 @@ public:
   /// simplification
 
   /// return true if unchanged
-  virtual bool ai_simplify(exprt &condition, const namespacet &ns) const
+  virtual bool ai_simplify(exprt &condition, const namespacet &) const
   {
     (void)condition; // unused parameter
     return true;

--- a/src/analyses/escape_analysis.cpp
+++ b/src/analyses/escape_analysis.cpp
@@ -166,9 +166,9 @@ void escape_domaint::get_rhs_aliases_address_of(
 }
 
 void escape_domaint::transform(
-  const irep_idt &function_from,
+  const irep_idt &,
   locationt from,
-  const irep_idt &function_to,
+  const irep_idt &,
   locationt,
   ai_baset &,
   const namespacet &)

--- a/src/analyses/global_may_alias.cpp
+++ b/src/analyses/global_may_alias.cpp
@@ -76,9 +76,9 @@ void global_may_alias_domaint::get_rhs_aliases_address_of(
 }
 
 void global_may_alias_domaint::transform(
-  const irep_idt &function_from,
+  const irep_idt &,
   locationt from,
-  const irep_idt &function_to,
+  const irep_idt &,
   locationt,
   ai_baset &,
   const namespacet &)

--- a/src/analyses/interval_domain.cpp
+++ b/src/analyses/interval_domain.cpp
@@ -57,9 +57,9 @@ void interval_domaint::output(
 }
 
 void interval_domaint::transform(
-  const irep_idt &function_from,
+  const irep_idt &,
   locationt from,
-  const irep_idt &function_to,
+  const irep_idt &,
   locationt to,
   ai_baset &,
   const namespacet &ns)

--- a/src/analyses/invariant_set_domain.cpp
+++ b/src/analyses/invariant_set_domain.cpp
@@ -14,9 +14,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/simplify_expr.h>
 
 void invariant_set_domaint::transform(
-  const irep_idt &function_from,
+  const irep_idt &,
   locationt from_l,
-  const irep_idt &function_to,
+  const irep_idt &,
   locationt to_l,
   ai_baset &,
   const namespacet &ns)

--- a/src/analyses/uninitialized_domain.cpp
+++ b/src/analyses/uninitialized_domain.cpp
@@ -19,9 +19,9 @@ Date: January 2010
 #include <list>
 
 void uninitialized_domaint::transform(
-  const irep_idt &function_from,
+  const irep_idt &,
   locationt from,
-  const irep_idt &function_to,
+  const irep_idt &,
   locationt,
   ai_baset &,
   const namespacet &ns)

--- a/src/pointer-analysis/value_set_domain_transform.inc
+++ b/src/pointer-analysis/value_set_domain_transform.inc
@@ -16,7 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 template<class VST>
 void value_set_domain_templatet<VST>::transform(
   const namespacet &ns,
-  const irep_idt &function_from,
+  const irep_idt &,
   locationt from_l,
   const irep_idt &function_to,
   locationt to_l)

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -156,6 +156,7 @@ static Minisat::Solver *solver_to_interrupt=nullptr;
 
 static void interrupt_solver(int signum)
 {
+  (void)signum; // unused parameter -- just removing the name trips up cpplint
   solver_to_interrupt->interrupt();
 }
 

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -246,9 +246,7 @@ public:
   ///
   /// The validation mode indicates whether well-formedness check failures are
   /// reported via DATA_INVARIANT violations or exceptions.
-  static void check(
-    const exprt &expr,
-    const validation_modet vm = validation_modet::INVARIANT)
+  static void check(const exprt &, const validation_modet)
   {
   }
 
@@ -262,7 +260,7 @@ public:
   /// reported via DATA_INVARIANT violations or exceptions.
   static void validate(
     const exprt &expr,
-    const namespacet &ns,
+    const namespacet &,
     const validation_modet vm = validation_modet::INVARIANT)
   {
     check_expr(expr, vm);

--- a/src/util/graph.h
+++ b/src/util/graph.h
@@ -78,7 +78,7 @@ private:
   ///        << "\"]";
   ///     return ss.str();
   ///
-  virtual std::string dot_attributes(const node_indext &idx) const
+  virtual std::string dot_attributes(const node_indext &) const
   {
     return "";
   }

--- a/src/util/small_shared_ptr.h
+++ b/src/util/small_shared_ptr.h
@@ -185,17 +185,17 @@ public:
   small_shared_pointeet() = default;
 
   // These can't be `= default` because we need the use_count_ to be unaffected
-  small_shared_pointeet(const small_shared_pointeet &rhs)
+  small_shared_pointeet(const small_shared_pointeet &)
   {
   }
-  small_shared_pointeet &operator=(const small_shared_pointeet &rhs)
+  small_shared_pointeet &operator=(const small_shared_pointeet &)
   {
     return *this;
   }
-  small_shared_pointeet(small_shared_pointeet &&rhs)
+  small_shared_pointeet(small_shared_pointeet &&)
   {
   }
-  small_shared_pointeet &operator=(small_shared_pointeet &&rhs)
+  small_shared_pointeet &operator=(small_shared_pointeet &&)
   {
     return *this;
   }

--- a/src/util/small_shared_two_way_ptr.h
+++ b/src/util/small_shared_two_way_ptr.h
@@ -225,13 +225,13 @@ public:
   small_shared_two_way_pointeet() = default;
 
   // The use count shall be unaffected
-  small_shared_two_way_pointeet(const small_shared_two_way_pointeet &rhs)
+  small_shared_two_way_pointeet(const small_shared_two_way_pointeet &)
   {
   }
 
   // The use count shall be unaffected
   small_shared_two_way_pointeet &
-  operator=(const small_shared_two_way_pointeet &rhs)
+  operator=(const small_shared_two_way_pointeet &)
   {
     return *this;
   }

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -72,9 +72,7 @@ public:
   ///
   /// The validation mode indicates whether well-formedness check failures are
   /// reported via DATA_INVARIANT violations or exceptions.
-  static void check(
-    const codet &code,
-    const validation_modet vm = validation_modet::INVARIANT)
+  static void check(const codet &, const validation_modet)
   {
   }
 
@@ -89,7 +87,7 @@ public:
   /// reported via DATA_INVARIANT violations or exceptions.
   static void validate(
     const codet &code,
-    const namespacet &ns,
+    const namespacet &,
     const validation_modet vm = validation_modet::INVARIANT)
   {
     check_code(code, vm);
@@ -105,7 +103,7 @@ public:
   /// reported via DATA_INVARIANT violations or exceptions.
   static void validate_full(
     const codet &code,
-    const namespacet &ns,
+    const namespacet &,
     const validation_modet vm = validation_modet::INVARIANT)
   {
     check_code(code, vm);

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -782,7 +782,7 @@ public:
 
   static void validate(
     const exprt &expr,
-    const namespacet &ns,
+    const namespacet &,
     const validation_modet vm = validation_modet::INVARIANT)
   {
     check(expr, vm);

--- a/src/util/type.h
+++ b/src/util/type.h
@@ -87,9 +87,7 @@ public:
   ///
   /// The validation mode indicates whether well-formedness check failures are
   /// reported via DATA_INVARIANT violations or exceptions.
-  static void check(
-    const typet &type,
-    const validation_modet vm = validation_modet::INVARIANT)
+  static void check(const typet &, const validation_modet)
   {
   }
 
@@ -103,7 +101,7 @@ public:
   /// reported via DATA_INVARIANT violations or exceptions.
   static void validate(
     const typet &type,
-    const namespacet &ns,
+    const namespacet &,
     const validation_modet vm = validation_modet::INVARIANT)
   {
     check_type(type, vm);

--- a/unit/analyses/ai/ai.cpp
+++ b/unit/analyses/ai/ai.cpp
@@ -70,7 +70,7 @@ public:
     return true;
   }
 
-  bool merge(const instruction_counter_domaint &b, locationt from, locationt to)
+  bool merge(const instruction_counter_domaint &b, locationt, locationt)
   {
     if(b.is_bottom())
       return false;

--- a/unit/path_strategies.cpp
+++ b/unit/path_strategies.cpp
@@ -64,7 +64,7 @@ SCENARIO("path strategies")
   std::string c;
   GIVEN("a simple conditional program")
   {
-    std::function<void(optionst &)> opts_callback = [](optionst &opts) {};
+    std::function<void(optionst &)> opts_callback = [](optionst &) {};
 
     c =
       "/*  1 */  int main()      \n"
@@ -94,7 +94,7 @@ SCENARIO("path strategies")
 
   GIVEN("a program with nested conditionals")
   {
-    std::function<void(optionst &)> opts_callback = [](optionst &opts) {};
+    std::function<void(optionst &)> opts_callback = [](optionst &) {};
 
     c =
       "/*  1 */  int main()            \n"
@@ -229,7 +229,7 @@ SCENARIO("path strategies")
     std::function<void(optionst &)> halt_callback = [](optionst &opts) {
       opts.set_option("stop-on-fail", true);
     };
-    std::function<void(optionst &)> no_halt_callback = [](optionst &opts) {};
+    std::function<void(optionst &)> no_halt_callback = [](optionst &) {};
 
     c =
       "/*  1 */  int main()      \n"

--- a/unit/solvers/miniBDD/miniBDD.cpp
+++ b/unit/solvers/miniBDD/miniBDD.cpp
@@ -61,7 +61,7 @@ public:
     return to_literal(to_bdd(a) & to_bdd(b));
   }
 
-  literalt lor(literalt a, literalt b) override
+  literalt lor(literalt, literalt) override
   {
     UNREACHABLE;
     return {};
@@ -92,19 +92,19 @@ public:
     return to_literal(to_bdd(a) ^ to_bdd(b));
   }
 
-  literalt lxor(const bvt &bv) override
+  literalt lxor(const bvt &) override
   {
     UNREACHABLE;
     return {};
   }
 
-  literalt lnand(literalt a, literalt b) override
+  literalt lnand(literalt, literalt) override
   {
     UNREACHABLE;
     return {};
   }
 
-  literalt lnor(literalt a, literalt b) override
+  literalt lnor(literalt, literalt) override
   {
     UNREACHABLE;
     return {};
@@ -115,19 +115,19 @@ public:
     return to_literal(to_bdd(a)==to_bdd(b));
   }
 
-  literalt limplies(literalt a, literalt b) override
+  literalt limplies(literalt, literalt) override
   {
     UNREACHABLE;
     return {};
   }
 
-  literalt lselect(literalt a, literalt b, literalt c) override
+  literalt lselect(literalt, literalt, literalt) override
   {
     UNREACHABLE;
     return {};
   }
 
-  void lcnf(const bvt &bv) override
+  void lcnf(const bvt &) override
   {
     UNREACHABLE;
   }
@@ -153,7 +153,7 @@ public:
     return {};
   }
 
-  tvt l_get(literalt a) const override
+  tvt l_get(literalt) const override
   {
     UNREACHABLE;
     return {};


### PR DESCRIPTION
Removing the parameter completely is not an option for these as they are part of
inherited APIs, but at the same time the names do not have value in terms of
documentation.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
