### PR TITLE
Include User Guide item in pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@ Thank you for your contribution. Please make sure your pull request fulfils all 
 
 - [ ] Each commit message has a non-empty body, explaining why the change was made.
 - [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
+- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
 - [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
 - [ ] My commit message includes data points confirming performance improvements (if claimed).
 - [ ] My PR is restricted to a single feature or bugfix.


### PR DESCRIPTION
Following the documentation day here, a few people commented that it would be good if code reviewers were a little more strict on encouraging developers to update the User Guide documentation (and not just the Doxygen). I thought an additional item in the PR checklist might help. 
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
