### PR TITLE
Group symex options into symex_config structure

### DIFF
--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -17,7 +17,7 @@ unsigned goto_symext::dynamic_counter=0;
 
 void goto_symext::do_simplify(exprt &expr)
 {
-  if(simplify_opt)
+  if(symex_config.simplify_opt)
     simplify(expr, ns);
 }
 

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -48,6 +48,22 @@ private:
   unsigned nondet_count = 0;
 };
 
+/// Configuration of the symbolic execution
+struct symex_configt final
+{
+  unsigned max_depth;
+  bool doing_path_exploration;
+  bool allow_pointer_unsoundness;
+  bool constant_propagation;
+  bool self_loops_to_assumptions;
+  bool simplify_opt;
+  bool unwinding_assertions;
+  bool partial_loops;
+  std::string debug_level;
+
+  explicit symex_configt(const optionst &options);
+};
+
 /// \brief The main class for the forward symbolic simulator
 ///
 /// Higher-level architectural information on symbolic execution is
@@ -65,18 +81,8 @@ public:
     const optionst &options,
     path_storaget &path_storage)
     : should_pause_symex(false),
-      max_depth(options.get_unsigned_int_option("depth")),
-      doing_path_exploration(options.is_set("paths")),
-      allow_pointer_unsoundness(
-        options.get_bool_option("allow-pointer-unsoundness")),
+      symex_config(options),
       language_mode(),
-      constant_propagation(options.get_bool_option("propagation")),
-      self_loops_to_assumptions(
-        options.get_bool_option("self-loops-to-assumptions")),
-      simplify_opt(options.get_bool_option("simplify")),
-      unwinding_assertions(options.get_bool_option("unwinding-assertions")),
-      partial_loops(options.get_bool_option("partial-loops")),
-      debug_level(options.get_option("debug-level")),
       outer_symbol_table(outer_symbol_table),
       ns(outer_symbol_table),
       target(_target),
@@ -150,6 +156,8 @@ public:
   bool should_pause_symex;
 
 protected:
+  const symex_configt symex_config;
+
   /// Initialise the symbolic execution and the given state with <code>pc</code>
   /// as entry point.
   /// \param state Symex state to initialise.
@@ -176,10 +184,6 @@ protected:
     const get_goto_functiont &,
     statet &);
 
-  const unsigned max_depth;
-  const bool doing_path_exploration;
-  const bool allow_pointer_unsoundness;
-
 public:
 
   /// language_mode: ID_java, ID_C or another language identifier
@@ -187,12 +191,6 @@ public:
   irep_idt language_mode;
 
 protected:
-  const bool constant_propagation;
-  const bool self_loops_to_assumptions;
-  const bool simplify_opt;
-  const bool unwinding_assertions;
-  const bool partial_loops;
-  const std::string debug_level;
 
   /// The symbol table associated with the goto-program that we're
   /// executing. This symbol table will not additionally contain objects

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -59,7 +59,7 @@ struct symex_configt final
   bool simplify_opt;
   bool unwinding_assertions;
   bool partial_loops;
-  std::string debug_level;
+  mp_integer debug_level;
 
   explicit symex_configt(const optionst &options);
 };

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -247,9 +247,9 @@ void goto_symext::symex_assign_symbol(
     ssa_lhs,
     ssa_rhs,
     ns,
-    simplify_opt,
-    constant_propagation,
-    allow_pointer_unsoundness);
+    symex_config.simplify_opt,
+    symex_config.constant_propagation,
+    symex_config.allow_pointer_unsoundness);
 
   exprt ssa_full_lhs=full_lhs;
   ssa_full_lhs=add_to_lhs(ssa_full_lhs, ssa_lhs);

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -458,7 +458,7 @@ void goto_symext::symex_trace(
 {
   PRECONDITION(code.arguments().size() >= 2);
 
-  int debug_thresh = unsafe_string2int(debug_level);
+  int debug_thresh = unsafe_string2int(symex_config.debug_level);
 
   mp_integer debug_lvl;
   optionalt<mp_integer> maybe_debug =

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -458,8 +458,6 @@ void goto_symext::symex_trace(
 {
   PRECONDITION(code.arguments().size() >= 2);
 
-  int debug_thresh = unsafe_string2int(symex_config.debug_level);
-
   mp_integer debug_lvl;
   optionalt<mp_integer> maybe_debug =
     numeric_cast<mp_integer>(code.arguments()[0]);
@@ -473,7 +471,7 @@ void goto_symext::symex_trace(
       code.arguments()[1].op0().id() == ID_string_constant,
     "CBMC_trace expects string constant as second argument");
 
-  if(mp_integer(debug_thresh)>=debug_lvl)
+  if(symex_config.debug_level >= debug_lvl)
   {
     std::list<exprt> vars;
 

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -236,13 +236,13 @@ void goto_symext::symex_function_call_code(
   // see if it's too much
   if(stop_recursing)
   {
-    if(partial_loops)
+    if(symex_config.partial_loops)
     {
       // it's ok, ignore
     }
     else
     {
-      if(unwinding_assertions)
+      if(symex_config.unwinding_assertions)
         vcc(false_exprt(), "recursion unwinding assertion", state);
 
       // add to state guard to prevent further assignments

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -61,7 +61,7 @@ void goto_symext::symex_goto(statet &state)
   {
     // is it label: goto label; or while(cond); - popular in SV-COMP
     if(
-      self_loops_to_assumptions &&
+      symex_config.self_loops_to_assumptions &&
       (goto_target == state.source.pc ||
        (instruction.incoming_edges.size() == 1 &&
         *instruction.incoming_edges.begin() == goto_target)))
@@ -109,7 +109,7 @@ void goto_symext::symex_goto(statet &state)
     (simpl_state_guard.is_true() ||
      // or there is another block, but we're doing path exploration so
      // we're going to skip over it for now and return to it later.
-     doing_path_exploration))
+     symex_config.doing_path_exploration))
   {
     DATA_INVARIANT(
       instruction.targets.size() > 0,
@@ -176,7 +176,7 @@ void goto_symext::symex_goto(statet &state)
     log.debug() << "Resuming from next instruction '"
                 << state_pc->source_location << "'" << log.eom;
   }
-  else if(doing_path_exploration)
+  else if(symex_config.doing_path_exploration)
   {
     // We should save both the instruction after this goto, and the target of
     // the goto.
@@ -490,9 +490,9 @@ void goto_symext::loop_bound_exceeded(
   else
     negated_cond=not_exprt(guard);
 
-  if(!partial_loops)
+  if(!symex_config.partial_loops)
   {
-    if(unwinding_assertions)
+    if(symex_config.unwinding_assertions)
     {
       // Generate VCC for unwinding assertion.
       vcc(negated_cond,

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -18,6 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/make_unique.h>
 #include <util/replace_symbol.h>
 #include <util/std_expr.h>
+#include <util/string2int.h>
 #include <util/symbol_table.h>
 
 #include <analyses/dirty.h>
@@ -33,7 +34,7 @@ symex_configt::symex_configt(const optionst &options)
     simplify_opt(options.get_bool_option("simplify")),
     unwinding_assertions(options.get_bool_option("unwinding-assertions")),
     partial_loops(options.get_bool_option("partial-loops")),
-    debug_level(options.get_option("debug-level"))
+    debug_level(unsafe_string2int(options.get_option("debug-level")))
 {
 }
 

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -22,6 +22,21 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <analyses/dirty.h>
 
+symex_configt::symex_configt(const optionst &options)
+  : max_depth(options.get_unsigned_int_option("depth")),
+    doing_path_exploration(options.is_set("paths")),
+    allow_pointer_unsoundness(
+      options.get_bool_option("allow-pointer-unsoundness")),
+    constant_propagation(options.get_bool_option("propagation")),
+    self_loops_to_assumptions(
+      options.get_bool_option("self-loops-to-assumptions")),
+    simplify_opt(options.get_bool_option("simplify")),
+    unwinding_assertions(options.get_bool_option("unwinding-assertions")),
+    partial_loops(options.get_bool_option("partial-loops")),
+    debug_level(options.get_option("debug-level"))
+{
+}
+
 void symex_transition(
   goto_symext::statet &state,
   goto_programt::const_targett to,
@@ -317,11 +332,11 @@ void goto_symext::symex_step(
 
   const goto_programt::instructiont &instruction=*state.source.pc;
 
-  if(!doing_path_exploration)
+  if(!symex_config.doing_path_exploration)
     merge_gotos(state);
 
   // depth exceeded?
-  if(max_depth != 0 && state.depth > max_depth)
+  if(symex_config.max_depth != 0 && state.depth > symex_config.max_depth)
     state.guard.add(false_exprt());
   state.depth++;
 


### PR DESCRIPTION
This makes it easy to separate the constant parameters of that class
from the other fields.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [na] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
