### PR TITLE
Remove templating from most of natural_loopst

### DIFF
--- a/src/analyses/natural_loops.cpp
+++ b/src/analyses/natural_loops.cpp
@@ -11,6 +11,88 @@ Author: Georg Weissenbacher, georg@weissenbacher.name
 
 #include "natural_loops.h"
 
+#ifdef DEBUG
+#include <iostream>
+#endif
+
+/// Finds all back-edges and computes the natural
+std::map<goto_programt::const_targett, std::set<goto_programt::const_targett>>
+natural_loops_baset::compute(const goto_programt &program)
+{
+  std::map<targett, std::set<targett>> result;
+
+  cfg_dominators(program);
+
+#ifdef DEBUG
+  cfg_dominators.output(std::cout);
+#endif
+
+  // find back-edges m->n
+  for(auto m_it=program.instructions.begin();
+      m_it!=program.instructions.end();
+      ++m_it)
+  {
+    if(m_it->is_backwards_goto())
+    {
+      const auto &target=m_it->get_target();
+
+      if(target->location_number<=m_it->location_number)
+      {
+        const nodet &node=
+          cfg_dominators.cfg[cfg_dominators.cfg.entry_map[m_it]];
+
+        #ifdef DEBUG
+        std::cout << "Computing loop for "
+                  << m_it->location_number << " -> "
+                  << target->location_number << "\n";
+        #endif
+
+        if(node.dominators.find(target)!=node.dominators.end())
+          result[target] = compute_natural_loop(m_it, target);
+      }
+    }
+  }
+
+  return result;
+}
+
+/// Computes the natural loop for a given back-edge (see Muchnick section 7.4)
+
+std::set<goto_programt::const_targett>
+natural_loops_baset::compute_natural_loop(targett m, targett n)
+{
+  assert(n->location_number<=m->location_number);
+
+  std::stack<targett> stack;
+
+  std::set<targett> loop;
+
+  loop.insert(n);
+  loop.insert(m);
+
+  if(n!=m)
+    stack.push(m);
+
+  while(!stack.empty())
+  {
+    targett p=stack.top();
+    stack.pop();
+
+    const nodet &node=
+      cfg_dominators.cfg[cfg_dominators.cfg.entry_map[p]];
+
+    for(const auto &edge : node.in)
+    {
+      targett q = cfg_dominators.cfg[edge.first].PC;
+      auto result = loop.insert(q);
+      if(result.second)
+        stack.push(q);
+    }
+  }
+
+  return loop;
+}
+
 void show_natural_loops(
   const goto_modelt &goto_model,
   std::ostream &out)

--- a/src/util/const_cast_iterator.h
+++ b/src/util/const_cast_iterator.h
@@ -1,0 +1,20 @@
+/*******************************************************************\
+
+Module:
+
+Author: Diffblue Ltd
+
+\*******************************************************************/
+
+
+#ifndef CPROVER_UTIL_CONST_CAST_ITERATOR_H
+#define CPROVER_UTIL_CONST_CAST_ITERATOR_H
+
+template <typename Container, typename ConstIterator>
+typename Container::iterator get_nonconst_iterator(
+  Container& c, ConstIterator it)
+{
+  return c.erase(it, it);
+}
+
+#endif // CPROVER_UTIL_CONST_CAST_ITERATOR_H


### PR DESCRIPTION
What do we think -- remove templating at the cost of a const-iterator -> nonconst-iterator pass after the core analysis has run? This will slightly increase runtime cost but means less template instantiation by users.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
