### PR TITLE
Refactoring in symex, replace nondet_count by a functor

### DIFF
--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -13,7 +13,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/simplify_expr.h>
 
-unsigned goto_symext::nondet_count=0;
 unsigned goto_symext::dynamic_counter=0;
 
 void goto_symext::do_simplify(exprt &expr)
@@ -22,7 +21,7 @@ void goto_symext::do_simplify(exprt &expr)
     simplify(expr, ns);
 }
 
-nondet_symbol_exprt build_symex_nondet(typet &type, unsigned &nondet_count)
+nondet_symbol_exprt symex_nondet_generatort::operator()(typet &type)
 {
   irep_idt identifier = "symex::nondet" + std::to_string(nondet_count++);
   nondet_symbol_exprt new_expr(identifier, type);

--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -22,23 +22,24 @@ void goto_symext::do_simplify(exprt &expr)
     simplify(expr, ns);
 }
 
-nondet_symbol_exprt goto_symext::build_symex_nondet(typet &type)
+nondet_symbol_exprt build_symex_nondet(typet &type, unsigned &nondet_count)
 {
   irep_idt identifier = "symex::nondet" + std::to_string(nondet_count++);
   nondet_symbol_exprt new_expr(identifier, type);
   return new_expr;
 }
 
-void goto_symext::replace_nondet(exprt &expr)
+void replace_nondet(exprt &expr, unsigned &nondet_count)
 {
   if(expr.id()==ID_side_effect &&
      expr.get(ID_statement)==ID_nondet)
   {
-    nondet_symbol_exprt new_expr = build_symex_nondet(expr.type());
+    nondet_symbol_exprt new_expr =
+      build_symex_nondet(expr.type(), nondet_count);
     new_expr.add_source_location()=expr.source_location();
     expr.swap(new_expr);
   }
   else
     Forall_operands(it, expr)
-      replace_nondet(*it);
+      replace_nondet(*it, nondet_count);
 }

--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -28,18 +28,3 @@ nondet_symbol_exprt build_symex_nondet(typet &type, unsigned &nondet_count)
   nondet_symbol_exprt new_expr(identifier, type);
   return new_expr;
 }
-
-void replace_nondet(exprt &expr, unsigned &nondet_count)
-{
-  if(expr.id()==ID_side_effect &&
-     expr.get(ID_statement)==ID_nondet)
-  {
-    nondet_symbol_exprt new_expr =
-      build_symex_nondet(expr.type(), nondet_count);
-    new_expr.add_source_location()=expr.source_location();
-    expr.swap(new_expr);
-  }
-  else
-    Forall_operands(it, expr)
-      replace_nondet(*it, nondet_count);
-}

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -238,19 +238,6 @@ protected:
 
   const irep_idt guard_identifier;
 
-  // symex
-  virtual void symex_transition(
-    statet &,
-    goto_programt::const_targett to,
-    bool is_backwards_goto);
-
-  virtual void symex_transition(statet &state)
-  {
-    goto_programt::const_targett next=state.source.pc;
-    ++next;
-    symex_transition(state, next, false);
-  }
-
   virtual void symex_goto(statet &);
   virtual void symex_start_thread(statet &);
   virtual void symex_atomic_begin(statet &);
@@ -464,5 +451,12 @@ public:
     return _remaining_vccs;
   }
 };
+
+void symex_transition(goto_symext::statet &state);
+
+void symex_transition(
+  goto_symext::statet &,
+  goto_programt::const_targett to,
+  bool is_backwards_goto);
 
 #endif // CPROVER_GOTO_SYMEX_GOTO_SYMEX_H

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -38,6 +38,16 @@ class namespacet;
 class side_effect_exprt;
 class typecast_exprt;
 
+/// Functor generating fresh nondet symbols
+class symex_nondet_generatort
+{
+public:
+  nondet_symbol_exprt operator()(typet &type);
+
+private:
+  unsigned nondet_count = 0;
+};
+
 /// \brief The main class for the forward symbolic simulator
 ///
 /// Higher-level architectural information on symbolic execution is
@@ -399,7 +409,7 @@ protected:
   virtual void symex_input(statet &, const codet &);
   virtual void symex_output(statet &, const codet &);
 
-  static unsigned nondet_count;
+  symex_nondet_generatort build_symex_nondet;
   static unsigned dynamic_counter;
 
   void rewrite_quantifiers(exprt &, statet &);
@@ -448,8 +458,6 @@ public:
     return _remaining_vccs;
   }
 };
-
-nondet_symbol_exprt build_symex_nondet(typet &type, unsigned &nondet_count);
 
 void symex_transition(goto_symext::statet &state);
 

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -451,8 +451,6 @@ public:
 
 nondet_symbol_exprt build_symex_nondet(typet &type, unsigned &nondet_count);
 
-void replace_nondet(exprt &, unsigned &);
-
 void symex_transition(goto_symext::statet &state);
 
 void symex_transition(

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -320,8 +320,6 @@ protected:
     statet &,
     const goto_functionst::goto_functiont &);
 
-  nondet_symbol_exprt build_symex_nondet(typet &type);
-
   // exceptions
   void symex_throw(statet &);
   void symex_catch(statet &);
@@ -404,7 +402,6 @@ protected:
   static unsigned nondet_count;
   static unsigned dynamic_counter;
 
-  void replace_nondet(exprt &);
   void rewrite_quantifiers(exprt &, statet &);
 
   path_storaget &path_storage;
@@ -451,6 +448,10 @@ public:
     return _remaining_vccs;
   }
 };
+
+nondet_symbol_exprt build_symex_nondet(typet &type, unsigned &nondet_count);
+
+void replace_nondet(exprt &, unsigned &);
 
 void symex_transition(goto_symext::statet &state);
 

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -177,7 +177,7 @@ void goto_symext::symex_allocate(
   }
   else
   {
-    const exprt nondet = build_symex_nondet(object_type);
+    const exprt nondet = build_symex_nondet(object_type, nondet_count);
     const code_assignt assignment(value_symbol.symbol_expr(), nondet);
     symex_assign(state, assignment);
   }

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -177,7 +177,7 @@ void goto_symext::symex_allocate(
   }
   else
   {
-    const exprt nondet = build_symex_nondet(object_type, nondet_count);
+    const exprt nondet = build_symex_nondet(object_type);
     const code_assignt assignment(value_symbol.symbol_expr(), nondet);
     symex_assign(state, assignment);
   }

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -135,6 +135,22 @@ static void adjust_byte_extract_rec(exprt &expr, const namespacet &ns)
   }
 }
 
+static void replace_nondet(exprt &expr, unsigned &nondet_count)
+{
+  if(expr.id() == ID_side_effect && expr.get(ID_statement) == ID_nondet)
+  {
+    nondet_symbol_exprt new_expr =
+      build_symex_nondet(expr.type(), nondet_count);
+    new_expr.add_source_location() = expr.source_location();
+    expr.swap(new_expr);
+  }
+  else
+  {
+    Forall_operands(it, expr)
+      replace_nondet(*it, nondet_count);
+  }
+}
+
 void goto_symext::clean_expr(
   exprt &expr,
   statet &state,

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -135,19 +135,19 @@ static void adjust_byte_extract_rec(exprt &expr, const namespacet &ns)
   }
 }
 
-static void replace_nondet(exprt &expr, unsigned &nondet_count)
+static void
+replace_nondet(exprt &expr, symex_nondet_generatort &build_symex_nondet)
 {
   if(expr.id() == ID_side_effect && expr.get(ID_statement) == ID_nondet)
   {
-    nondet_symbol_exprt new_expr =
-      build_symex_nondet(expr.type(), nondet_count);
+    nondet_symbol_exprt new_expr = build_symex_nondet(expr.type());
     new_expr.add_source_location() = expr.source_location();
     expr.swap(new_expr);
   }
   else
   {
     Forall_operands(it, expr)
-      replace_nondet(*it, nondet_count);
+      replace_nondet(*it, build_symex_nondet);
   }
 }
 
@@ -156,7 +156,7 @@ void goto_symext::clean_expr(
   statet &state,
   const bool write)
 {
-  replace_nondet(expr, nondet_count);
+  replace_nondet(expr, build_symex_nondet);
   dereference(expr, state, write);
 
   // make sure all remaining byte extract operations use the root

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -140,7 +140,7 @@ void goto_symext::clean_expr(
   statet &state,
   const bool write)
 {
-  replace_nondet(expr);
+  replace_nondet(expr, nondet_count);
   dereference(expr, state, write);
 
   // make sure all remaining byte extract operations use the root

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -22,8 +22,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <analyses/dirty.h>
 
-void goto_symext::symex_transition(
-  statet &state,
+void symex_transition(
+  goto_symext::statet &state,
   goto_programt::const_targett to,
   bool is_backwards_goto)
 {
@@ -34,7 +34,7 @@ void goto_symext::symex_transition(
     // 1. the transition from state.source.pc to "to" is not a backwards goto
     // or
     // 2. we are arriving from an outer loop
-    statet::framet &frame=state.top();
+    goto_symext::statet::framet &frame = state.top();
     const goto_programt::instructiont &instruction=*to;
     for(const auto &i_e : instruction.incoming_edges)
       if(i_e->is_goto() && i_e->is_backwards_goto() &&
@@ -44,6 +44,13 @@ void goto_symext::symex_transition(
   }
 
   state.source.pc=to;
+}
+
+void symex_transition(goto_symext::statet &state)
+{
+  goto_programt::const_targett next = state.source.pc;
+  ++next;
+  symex_transition(state, next, false);
 }
 
 void goto_symext::vcc(


### PR DESCRIPTION
It is clearer to have a functor that can only be used for generating symbols, than a counter. 

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [na] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
