### PR TITLE
Move symex state levels to a new file

### DIFF
--- a/src/goto-instrument/accelerate/scratch_program.cpp
+++ b/src/goto-instrument/accelerate/scratch_program.cpp
@@ -35,8 +35,6 @@ bool scratch_programt::check_sat(bool do_slice)
   output(ns, "scratch", std::cout);
 #endif
 
-  goto_symex_statet::propagationt::valuest constants;
-
   symex.symex_with_state(symex_state, functions, symex_symbol_table);
 
   if(do_slice)

--- a/src/goto-symex/Makefile
+++ b/src/goto-symex/Makefile
@@ -10,6 +10,7 @@ SRC = auto_objects.cpp \
       path_storage.cpp \
       postcondition.cpp \
       precondition.cpp \
+      renaming_level.cpp \
       show_program.cpp \
       show_vcc.cpp \
       slice.cpp \

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -227,9 +227,9 @@ void goto_symex_statet::assignment(
   // for value propagation -- the RHS is L2
 
   if(!is_shared && record_value && goto_symex_is_constantt()(rhs))
-    propagation.values[l1_identifier]=rhs;
+    propagation[l1_identifier] = rhs;
   else
-    propagation.remove(l1_identifier);
+    propagation.erase(l1_identifier);
 
   {
     // update value sets
@@ -322,10 +322,9 @@ void goto_symex_statet::rename(
       {
         // We also consider propagation if we go up to L2.
         // L1 identifiers are used for propagation!
-        propagationt::valuest::const_iterator p_it=
-          propagation.values.find(ssa.get_identifier());
+        auto p_it = propagation.find(ssa.get_identifier());
 
-        if(p_it!=propagation.values.end())
+        if(p_it != propagation.end())
           expr=p_it->second; // already L2
         else
           set_ssa_indices(ssa, ns, L2);

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -38,50 +38,6 @@ goto_symex_statet::goto_symex_statet()
 
 goto_symex_statet::~goto_symex_statet()=default;
 
-void goto_symex_statet::level0t::operator()(
-  ssa_exprt &ssa_expr,
-  const namespacet &ns,
-  unsigned thread_nr)
-{
-  // already renamed?
-  if(!ssa_expr.get_level_0().empty())
-    return;
-
-  const irep_idt &obj_identifier=ssa_expr.get_object_name();
-
-  // guards are not L0-renamed
-  if(obj_identifier=="goto_symex::\\guard")
-    return;
-
-  const symbolt *s;
-  const bool found_l0 = !ns.lookup(obj_identifier, s);
-  INVARIANT(found_l0, "level0: failed to find " + id2string(obj_identifier));
-
-  // don't rename shared variables or functions
-  if(s->type.id()==ID_code ||
-     s->is_shared())
-    return;
-
-  // rename!
-  ssa_expr.set_level_0(thread_nr);
-}
-
-void goto_symex_statet::level1t::operator()(ssa_exprt &ssa_expr)
-{
-  // already renamed?
-  if(!ssa_expr.get_level_1().empty())
-    return;
-
-  const irep_idt l0_name=ssa_expr.get_l1_object_identifier();
-
-  current_namest::const_iterator it=current_names.find(l0_name);
-  if(it==current_names.end())
-    return;
-
-  // rename!
-  ssa_expr.set_level_1(it->second.second);
-}
-
 /// write to a variable
 static bool check_renaming(const exprt &expr);
 

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -253,27 +253,6 @@ void goto_symex_statet::assignment(
   #endif
 }
 
-void goto_symex_statet::propagationt::operator()(exprt &expr)
-{
-  if(expr.id()==ID_symbol)
-  {
-    valuest::const_iterator it =
-      values.find(to_symbol_expr(expr).get_identifier());
-    if(it!=values.end())
-      expr=it->second;
-  }
-  else if(expr.id()==ID_address_of)
-  {
-    // ignore
-  }
-  else
-  {
-    // do this recursively
-    Forall_operands(it, expr)
-      operator()(*it);
-  }
-}
-
 void goto_symex_statet::set_ssa_indices(
   ssa_exprt &ssa_expr,
   const namespacet &ns,

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -81,10 +81,8 @@ public:
 
     void get_variables(std::unordered_set<ssa_exprt, irep_hash> &vars) const
     {
-      for(current_namest::const_iterator it=current_names.begin();
-          it!=current_names.end();
-          it++)
-        vars.insert(it->second.first);
+      for(const auto &pair : current_names)
+        vars.insert(pair.second.first);
     }
   };
 

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -65,17 +65,8 @@ public:
   symex_level1t level1;
   symex_level2t level2;
 
-  // this maps L1 names to (L2) constants
-  class propagationt
-  {
-  public:
-    typedef std::map<irep_idt, exprt> valuest;
-    valuest values;
-    void remove(const irep_idt &identifier)
-    {
-      values.erase(identifier);
-    }
-  } propagation;
+  // Map L1 names to (L2) constants
+  std::map<irep_idt, exprt> propagation;
 
   enum levelt { L0=0, L1=1, L2=2 };
 
@@ -124,7 +115,7 @@ public:
     value_sett value_set;
     guardt guard;
     symex_targett::sourcet source;
-    propagationt propagation;
+    std::map<irep_idt, exprt> propagation;
     unsigned atomic_section_id;
     std::unordered_map<irep_idt, local_safe_pointerst> safe_pointers;
     unsigned total_vccs, remaining_vccs;

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -108,20 +108,17 @@ public:
 
     void restore_from(const current_namest &other)
     {
-      current_namest::iterator it=current_names.begin();
-      for(current_namest::const_iterator
-          ito=other.begin();
-          ito!=other.end();
-          ++ito)
+      auto it = current_names.begin();
+      for(const auto &pair : other)
       {
-        while(it!=current_names.end() && it->first<ito->first)
+        while(it != current_names.end() && it->first < pair.first)
           ++it;
-        if(it==current_names.end() || ito->first<it->first)
-          current_names.insert(it, *ito);
+        if(it == current_names.end() || pair.first < it->first)
+          current_names.insert(it, pair);
         else if(it!=current_names.end())
         {
-          PRECONDITION(it->first == ito->first);
-          it->second=ito->second;
+          PRECONDITION(it->first == pair.first);
+          it->second = pair.second;
           ++it;
         }
       }

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -58,8 +58,7 @@ public:
   symex_target_equationt *symex_target;
 
   // we remember all L1 renamings
-  typedef std::set<irep_idt> l1_historyt;
-  l1_historyt l1_history;
+  std::set<irep_idt> l1_history;
 
   struct renaming_levelt
   {

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -92,7 +92,10 @@ public:
 protected:
   void rename_address(exprt &expr, const namespacet &ns, levelt level);
 
-  void set_ssa_indices(ssa_exprt &expr, const namespacet &ns, levelt level=L2);
+  void set_l0_indices(ssa_exprt &expr, const namespacet &ns);
+  void set_l1_indices(ssa_exprt &expr, const namespacet &ns);
+  void set_l2_indices(ssa_exprt &expr, const namespacet &ns);
+
   // only required for value_set.assign
   void get_l1_name(exprt &expr) const;
 

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -62,7 +62,7 @@ public:
 
   struct renaming_levelt
   {
-    virtual ~renaming_levelt() { }
+    virtual ~renaming_levelt() = default;
 
     typedef std::map<irep_idt, std::pair<ssa_exprt, unsigned> > current_namest;
     current_namest current_names;
@@ -97,8 +97,8 @@ public:
       const namespacet &ns,
       unsigned thread_nr);
 
-    level0t() { }
-    virtual ~level0t() { }
+    level0t() = default;
+    ~level0t() override = default;
   } level0;
 
   // level 1 -- function frames
@@ -129,16 +129,16 @@ public:
       }
     }
 
-    level1t() { }
-    virtual ~level1t() { }
+    level1t() = default;
+    ~level1t() override = default;
   } level1;
 
   // level 2 -- SSA
 
   struct level2t:public renaming_levelt
   {
-    level2t() { }
-    virtual ~level2t() { }
+    level2t() = default;
+    ~level2t() override = default;
   } level2;
 
   // this maps L1 names to (L2) constants

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -69,8 +69,7 @@ public:
 
     unsigned current_count(const irep_idt &identifier) const
     {
-      current_namest::const_iterator it=
-        current_names.find(identifier);
+      const auto it = current_names.find(identifier);
       return it==current_names.end()?0:it->second.second;
     }
 
@@ -235,8 +234,7 @@ public:
 
     unsigned level2_current_count(const irep_idt &identifier) const
     {
-      level2t::current_namest::const_iterator it=
-        level2_current_names.find(identifier);
+      const auto it = level2_current_names.find(identifier);
       return it==level2_current_names.end()?0:it->second.second;
     }
   };

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -71,8 +71,6 @@ public:
   public:
     typedef std::map<irep_idt, exprt> valuest;
     valuest values;
-    void operator()(exprt &expr);
-
     void remove(const irep_idt &identifier)
     {
       values.erase(identifier);

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -225,11 +225,8 @@ public:
     void level2_get_variables(
       std::unordered_set<ssa_exprt, irep_hash> &vars) const
     {
-      for(level2t::current_namest::const_iterator
-          it=level2_current_names.begin();
-          it!=level2_current_names.end();
-          it++)
-        vars.insert(it->second.first);
+      for(const auto &pair : level2_current_names)
+        vars.insert(pair.second.first);
     }
 
     unsigned level2_current_count(const irep_idt &identifier) const

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -57,10 +57,6 @@ public:
   symex_targett::sourcet source;
   symex_target_equationt *symex_target;
 
-  // we have a two-level renaming
-
-  typedef std::map<irep_idt, irep_idt> original_identifierst;
-
   // we remember all L1 renamings
   typedef std::set<irep_idt> l1_historyt;
   l1_historyt l1_history;

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -185,7 +185,7 @@ public:
     exprt return_value;
     bool hidden_function;
 
-    renaming_levelt::current_namest old_level1;
+    symex_renaming_levelt::current_namest old_level1;
 
     typedef std::set<irep_idt> local_objectst;
     local_objectst local_objects;

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -48,7 +48,7 @@ void symex_level1t::operator()(ssa_exprt &ssa_expr)
 
   const irep_idt l0_name = ssa_expr.get_l1_object_identifier();
 
-  current_namest::const_iterator it = current_names.find(l0_name);
+  const auto it = current_names.find(l0_name);
   if(it == current_names.end())
     return;
 

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -56,7 +56,8 @@ void symex_level1t::operator()(ssa_exprt &ssa_expr)
   ssa_expr.set_level_1(it->second.second);
 }
 
-void symex_level1t::restore_from(const renaming_levelt::current_namest &other)
+void symex_level1t::restore_from(
+  const symex_renaming_levelt::current_namest &other)
 {
   auto it = current_names.begin();
   for(const auto &pair : other)

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -1,0 +1,57 @@
+/*******************************************************************\
+
+Module: Symbolic Execution
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+/// \file
+/// Renaming levels
+
+#include "renaming_level.h"
+
+#include <util/namespace.h>
+#include <util/ssa_expr.h>
+#include <util/symbol.h>
+
+void symex_level0t::
+operator()(ssa_exprt &ssa_expr, const namespacet &ns, unsigned thread_nr)
+{
+  // already renamed?
+  if(!ssa_expr.get_level_0().empty())
+    return;
+
+  const irep_idt &obj_identifier = ssa_expr.get_object_name();
+
+  // guards are not L0-renamed
+  if(obj_identifier == "goto_symex::\\guard")
+    return;
+
+  const symbolt *s;
+  const bool found_l0 = !ns.lookup(obj_identifier, s);
+  INVARIANT(found_l0, "level0: failed to find " + id2string(obj_identifier));
+
+  // don't rename shared variables or functions
+  if(s->type.id() == ID_code || s->is_shared())
+    return;
+
+  // rename!
+  ssa_expr.set_level_0(thread_nr);
+}
+
+void symex_level1t::operator()(ssa_exprt &ssa_expr)
+{
+  // already renamed?
+  if(!ssa_expr.get_level_1().empty())
+    return;
+
+  const irep_idt l0_name = ssa_expr.get_l1_object_identifier();
+
+  current_namest::const_iterator it = current_names.find(l0_name);
+  if(it == current_names.end())
+    return;
+
+  // rename!
+  ssa_expr.set_level_1(it->second.second);
+}

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -55,3 +55,21 @@ void symex_level1t::operator()(ssa_exprt &ssa_expr)
   // rename!
   ssa_expr.set_level_1(it->second.second);
 }
+
+void symex_level1t::restore_from(const renaming_levelt::current_namest &other)
+{
+  auto it = current_names.begin();
+  for(const auto &pair : other)
+  {
+    while(it != current_names.end() && it->first < pair.first)
+      ++it;
+    if(it == current_names.end() || pair.first < it->first)
+      current_names.insert(it, pair);
+    else if(it != current_names.end())
+    {
+      PRECONDITION(it->first == pair.first);
+      it->second = pair.second;
+      ++it;
+    }
+  }
+}

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -62,23 +62,7 @@ struct symex_level1t : public renaming_levelt
 {
   void operator()(ssa_exprt &ssa_expr);
 
-  void restore_from(const current_namest &other)
-  {
-    auto it = current_names.begin();
-    for(const auto &pair : other)
-    {
-      while(it != current_names.end() && it->first < pair.first)
-        ++it;
-      if(it == current_names.end() || pair.first < it->first)
-        current_names.insert(it, pair);
-      else if(it != current_names.end())
-      {
-        PRECONDITION(it->first == pair.first);
-        it->second = pair.second;
-        ++it;
-      }
-    }
-  }
+  void restore_from(const current_namest &other);
 
   symex_level1t() = default;
   ~symex_level1t() override = default;

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -18,25 +18,33 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include <util/irep.h>
 #include <util/ssa_expr.h>
 
+/// Wrapper for a \c current_names map, which maps each identifier to an SSA
+/// expression and a counter.
+/// This is extended by the different symex_level structures which are used
+/// during symex to ensure static single assignment (SSA) form.
 struct renaming_levelt
 {
   virtual ~renaming_levelt() = default;
 
+  /// Map identifier to ssa_exprt and counter
   typedef std::map<irep_idt, std::pair<ssa_exprt, unsigned>> current_namest;
   current_namest current_names;
 
+  /// Counter corresponding to an identifier
   unsigned current_count(const irep_idt &identifier) const
   {
     const auto it = current_names.find(identifier);
     return it == current_names.end() ? 0 : it->second.second;
   }
 
+  /// Increase the counter corresponding to an identifier
   void increase_counter(const irep_idt &identifier)
   {
     PRECONDITION(current_names.find(identifier) != current_names.end());
     ++current_names[identifier].second;
   }
 
+  /// Add the \c ssa_exprt of current_names to vars
   void get_variables(std::unordered_set<ssa_exprt, irep_hash> &vars) const
   {
     for(const auto &pair : current_names)
@@ -44,8 +52,9 @@ struct renaming_levelt
   }
 };
 
-// level 0 -- threads!
-// renaming built for one particular interleaving
+/// Functor to set the level 0 renaming of SSA expressions.
+/// Level 0 corresponds to threads.
+/// The renaming is built for one particular interleaving.
 struct symex_level0t : public renaming_levelt
 {
   void
@@ -55,20 +64,23 @@ struct symex_level0t : public renaming_levelt
   ~symex_level0t() override = default;
 };
 
-// level 1 -- function frames
-// this is to preserve locality in case of recursion
-
+/// Functor to set the level 1 renaming of SSA expressions.
+/// Level 1 corresponds to function frames.
+/// This is to preserve locality in case of recursion
 struct symex_level1t : public renaming_levelt
 {
   void operator()(ssa_exprt &ssa_expr);
 
+  /// Insert the content of \p other into this renaming
   void restore_from(const current_namest &other);
 
   symex_level1t() = default;
   ~symex_level1t() override = default;
 };
 
-// level 2 -- SSA
+/// Functor to set the level 2 renaming of SSA expressions.
+/// Level 2 corresponds to SSA.
+/// This is to ensure each variable is only assigned once.
 struct symex_level2t : public renaming_levelt
 {
   symex_level2t() = default;

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -22,9 +22,9 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 /// expression and a counter.
 /// This is extended by the different symex_level structures which are used
 /// during symex to ensure static single assignment (SSA) form.
-struct renaming_levelt
+struct symex_renaming_levelt
 {
-  virtual ~renaming_levelt() = default;
+  virtual ~symex_renaming_levelt() = default;
 
   /// Map identifier to ssa_exprt and counter
   typedef std::map<irep_idt, std::pair<ssa_exprt, unsigned>> current_namest;
@@ -55,7 +55,7 @@ struct renaming_levelt
 /// Functor to set the level 0 renaming of SSA expressions.
 /// Level 0 corresponds to threads.
 /// The renaming is built for one particular interleaving.
-struct symex_level0t : public renaming_levelt
+struct symex_level0t : public symex_renaming_levelt
 {
   void
   operator()(ssa_exprt &ssa_expr, const namespacet &ns, unsigned thread_nr);
@@ -67,7 +67,7 @@ struct symex_level0t : public renaming_levelt
 /// Functor to set the level 1 renaming of SSA expressions.
 /// Level 1 corresponds to function frames.
 /// This is to preserve locality in case of recursion
-struct symex_level1t : public renaming_levelt
+struct symex_level1t : public symex_renaming_levelt
 {
   void operator()(ssa_exprt &ssa_expr);
 
@@ -81,7 +81,7 @@ struct symex_level1t : public renaming_levelt
 /// Functor to set the level 2 renaming of SSA expressions.
 /// Level 2 corresponds to SSA.
 /// This is to ensure each variable is only assigned once.
-struct symex_level2t : public renaming_levelt
+struct symex_level2t : public symex_renaming_levelt
 {
   symex_level2t() = default;
   ~symex_level2t() override = default;

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -1,0 +1,94 @@
+/*******************************************************************\
+
+Module: Symbolic Execution
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+/// \file
+/// Renaming levels
+
+#ifndef CPROVER_GOTO_SYMEX_RENAMING_LEVEL_H
+#define CPROVER_GOTO_SYMEX_RENAMING_LEVEL_H
+
+#include <map>
+#include <unordered_set>
+
+#include <util/irep.h>
+#include <util/ssa_expr.h>
+
+struct renaming_levelt
+{
+  virtual ~renaming_levelt() = default;
+
+  typedef std::map<irep_idt, std::pair<ssa_exprt, unsigned>> current_namest;
+  current_namest current_names;
+
+  unsigned current_count(const irep_idt &identifier) const
+  {
+    const auto it = current_names.find(identifier);
+    return it == current_names.end() ? 0 : it->second.second;
+  }
+
+  void increase_counter(const irep_idt &identifier)
+  {
+    PRECONDITION(current_names.find(identifier) != current_names.end());
+    ++current_names[identifier].second;
+  }
+
+  void get_variables(std::unordered_set<ssa_exprt, irep_hash> &vars) const
+  {
+    for(const auto &pair : current_names)
+      vars.insert(pair.second.first);
+  }
+};
+
+// level 0 -- threads!
+// renaming built for one particular interleaving
+struct symex_level0t : public renaming_levelt
+{
+  void
+  operator()(ssa_exprt &ssa_expr, const namespacet &ns, unsigned thread_nr);
+
+  symex_level0t() = default;
+  ~symex_level0t() override = default;
+};
+
+// level 1 -- function frames
+// this is to preserve locality in case of recursion
+
+struct symex_level1t : public renaming_levelt
+{
+  void operator()(ssa_exprt &ssa_expr);
+
+  void restore_from(const current_namest &other)
+  {
+    auto it = current_names.begin();
+    for(const auto &pair : other)
+    {
+      while(it != current_names.end() && it->first < pair.first)
+        ++it;
+      if(it == current_names.end() || pair.first < it->first)
+        current_names.insert(it, pair);
+      else if(it != current_names.end())
+      {
+        PRECONDITION(it->first == pair.first);
+        it->second = pair.second;
+        ++it;
+      }
+    }
+  }
+
+  symex_level1t() = default;
+  ~symex_level1t() override = default;
+};
+
+// level 2 -- SSA
+struct symex_level2t : public renaming_levelt
+{
+  symex_level2t() = default;
+  ~symex_level2t() override = default;
+};
+
+#endif // CPROVER_GOTO_SYMEX_RENAMING_LEVEL_H

--- a/src/goto-symex/symex_dead.cpp
+++ b/src/goto-symex/symex_dead.cpp
@@ -49,7 +49,7 @@ void goto_symext::symex_dead(statet &state)
   const irep_idt &l1_identifier=ssa_lhs.get_identifier();
 
   // prevent propagation
-  state.propagation.remove(l1_identifier);
+  state.propagation.erase(l1_identifier);
 
   // L2 renaming
   if(state.level2.current_names.find(l1_identifier)!=

--- a/src/goto-symex/symex_decl.cpp
+++ b/src/goto-symex/symex_decl.cpp
@@ -63,7 +63,7 @@ void goto_symext::symex_decl(statet &state, const symbol_exprt &expr)
   }
 
   // prevent propagation
-  state.propagation.remove(l1_identifier);
+  state.propagation.erase(l1_identifier);
 
   // L2 renaming
   // inlining may yield multiple declarations of the same identifier

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -330,8 +330,7 @@ void goto_symext::pop_frame(statet &state)
     state.level1.restore_from(frame.old_level1);
 
     // clear function-locals from L2 renaming
-    for(renaming_levelt::current_namest::iterator c_it =
-          state.level2.current_names.begin();
+    for(auto c_it = state.level2.current_names.begin();
         c_it != state.level2.current_names.end();) // no ++c_it
     {
       const irep_idt l1_o_id=c_it->second.first.get_l1_object_identifier();
@@ -344,7 +343,7 @@ void goto_symext::pop_frame(statet &state)
         ++c_it;
         continue;
       }
-      renaming_levelt::current_namest::iterator cur = c_it;
+      auto cur = c_it;
       ++c_it;
       state.level2.current_names.erase(cur);
     }
@@ -391,8 +390,7 @@ void goto_symext::locality(
     const irep_idt l0_name=ssa.get_identifier();
 
     // save old L1 name for popping the frame
-    symex_level1t::current_namest::const_iterator c_it =
-      state.level1.current_names.find(l0_name);
+    const auto c_it = state.level1.current_names.find(l0_name);
 
     if(c_it!=state.level1.current_names.end())
       frame.old_level1[l0_name]=c_it->second;

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -330,10 +330,9 @@ void goto_symext::pop_frame(statet &state)
     state.level1.restore_from(frame.old_level1);
 
     // clear function-locals from L2 renaming
-    for(goto_symex_statet::renaming_levelt::current_namest::iterator
-        c_it=state.level2.current_names.begin();
-        c_it!=state.level2.current_names.end();
-       ) // no ++c_it
+    for(renaming_levelt::current_namest::iterator c_it =
+          state.level2.current_names.begin();
+        c_it != state.level2.current_names.end();) // no ++c_it
     {
       const irep_idt l1_o_id=c_it->second.first.get_l1_object_identifier();
       // could use iteration over local_objects as l1_o_id is prefix
@@ -345,8 +344,7 @@ void goto_symext::pop_frame(statet &state)
         ++c_it;
         continue;
       }
-      goto_symex_statet::renaming_levelt::current_namest::iterator
-        cur=c_it;
+      renaming_levelt::current_namest::iterator cur = c_it;
       ++c_it;
       state.level2.current_names.erase(cur);
     }
@@ -393,7 +391,7 @@ void goto_symext::locality(
     const irep_idt l0_name=ssa.get_identifier();
 
     // save old L1 name for popping the frame
-    statet::level1t::current_namest::const_iterator c_it=
+    symex_level1t::current_namest::const_iterator c_it =
       state.level1.current_names.find(l0_name);
 
     if(c_it!=state.level1.current_names.end())

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -413,10 +413,9 @@ void goto_symext::phi_function(
     exprt goto_state_rhs=*it, dest_state_rhs=*it;
 
     {
-      goto_symex_statet::propagationt::valuest::const_iterator p_it=
-        goto_state.propagation.values.find(l1_identifier);
+      const auto p_it = goto_state.propagation.find(l1_identifier);
 
-      if(p_it!=goto_state.propagation.values.end())
+      if(p_it != goto_state.propagation.end())
         goto_state_rhs=p_it->second;
       else
         to_ssa_expr(goto_state_rhs).set_level_2(
@@ -424,10 +423,9 @@ void goto_symext::phi_function(
     }
 
     {
-      goto_symex_statet::propagationt::valuest::const_iterator p_it=
-        dest_state.propagation.values.find(l1_identifier);
+      const auto p_it = dest_state.propagation.find(l1_identifier);
 
-      if(p_it!=dest_state.propagation.values.end())
+      if(p_it != dest_state.propagation.end())
         dest_state_rhs=p_it->second;
       else
         to_ssa_expr(dest_state_rhs).set_level_2(

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -52,9 +52,9 @@ void goto_symext::symex_start_thread(statet &state)
   // create a copy of the local variables for the new thread
   statet::framet &frame=state.top();
 
-  for(goto_symex_statet::renaming_levelt::current_namest::const_iterator
-      c_it=state.level2.current_names.begin();
-      c_it!=state.level2.current_names.end();
+  for(renaming_levelt::current_namest::const_iterator c_it =
+        state.level2.current_names.begin();
+      c_it != state.level2.current_names.end();
       ++c_it)
   {
     const irep_idt l1_o_id=c_it->second.first.get_l1_object_identifier();

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -52,8 +52,7 @@ void goto_symext::symex_start_thread(statet &state)
   // create a copy of the local variables for the new thread
   statet::framet &frame=state.top();
 
-  for(renaming_levelt::current_namest::const_iterator c_it =
-        state.level2.current_names.begin();
+  for(auto c_it = state.level2.current_names.begin();
       c_it != state.level2.current_names.end();
       ++c_it)
   {


### PR DESCRIPTION
No functional change. 
The goal is to reduce the complexity of goto_symex_state by extracting a module which takes care of the renaming levels. 

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [na] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
