### PR TITLE
fix function depth display in case of hidden calls/returns

### DIFF
--- a/src/goto-programs/goto_trace.cpp
+++ b/src/goto-programs/goto_trace.cpp
@@ -490,6 +490,12 @@ void show_full_goto_trace(
 
   for(const auto &step : goto_trace.steps)
   {
+    // update function depth, including for hidden calls and returns
+    if(step.type == goto_trace_stept::typet::FUNCTION_CALL)
+      function_depth++;
+    else if(step.type == goto_trace_stept::typet::FUNCTION_RETURN)
+      function_depth--;
+
     // hide the hidden ones
     if(step.hidden)
       continue;
@@ -626,7 +632,6 @@ void show_full_goto_trace(
       break;
 
     case goto_trace_stept::typet::FUNCTION_CALL:
-      function_depth++;
       if(options.show_function_calls)
       {
         out << "\n#### Function call: " << step.called_function;
@@ -648,7 +653,6 @@ void show_full_goto_trace(
       break;
 
     case goto_trace_stept::typet::FUNCTION_RETURN:
-      function_depth--;
       if(options.show_function_calls)
       {
         out << "\n#### Function return from " << step.function << " (depth "


### PR DESCRIPTION
Previously, hidden function calls or hidden functions could cause the depth
count to get out of sync.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
