### PR TITLE
Remove check for using the using keyword

### DIFF
--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -6265,9 +6265,6 @@ def CheckNamespaceOrUsing(filename, clean_lines, linenum, error):
       if '{' in current_line:
         break
       current_linenum+=1
-  if Match(r'^using\s', line):
-    error(filename, linenum, 'readability/namespace', 4,
-          'Do not use using')
 
 def CheckForEndl(filename, clean_lines, linenum, error):
   """Check that the line does not contain std::endl."""


### PR DESCRIPTION
This was encouraged in #3270 but the linter was not updated.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
