### PR TITLE
remove-function-body: remove file-local (static) marking

### DIFF
--- a/src/goto-instrument/remove_function.cpp
+++ b/src/goto-instrument/remove_function.cpp
@@ -51,7 +51,9 @@ void remove_function(
     message.status() << "Removing body of " << identifier
                      << messaget::eom;
     entry->second.clear();
-    goto_model.symbol_table.get_writeable_ref(identifier).value.make_nil();
+    symbolt &symbol = goto_model.symbol_table.get_writeable_ref(identifier);
+    symbol.value.make_nil();
+    symbol.is_file_local = false;
   }
 }
 


### PR DESCRIPTION
When removing the implementation of a function, we often do so in order to
replace it with an implementation provided in a model/harness file. For static
(file-local) functions, this would fail, as the symbol was still file-local and
therefore different from any symbol defined in a different translation unit.
Linking thus (correctly) renamed the file-local symbol, making function calls
not use the modelled function.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] (It was documented already) The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
