### PR TITLE
Introduce range class and use it to optimize symex

### DIFF
--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -386,12 +386,10 @@ void goto_symext::phi_function(
     diff_guard-=dest_state.guard;
   }
 
-  for(auto it = all_current_names_range.begin();
-      it != all_current_names_range.end();
-      ++it)
+  for(const auto &ssa : all_current_names_range)
   {
-    const irep_idt l1_identifier=it->get_identifier();
-    const irep_idt &obj_identifier=it->get_object_name();
+    const irep_idt l1_identifier = ssa.get_identifier();
+    const irep_idt &obj_identifier = ssa.get_object_name();
 
     if(obj_identifier==guard_identifier)
       continue; // just a guard, don't bother
@@ -416,11 +414,12 @@ void goto_symext::phi_function(
     // may have been introduced by symex_start_thread (and will
     // only later be removed from level2.current_names by pop_frame
     // once the thread is executed)
-    if(!it->get_level_0().empty() &&
-       it->get_level_0()!=std::to_string(dest_state.source.thread_nr))
+    if(
+      !ssa.get_level_0().empty() &&
+      ssa.get_level_0() != std::to_string(dest_state.source.thread_nr))
       continue;
 
-    exprt goto_state_rhs=*it, dest_state_rhs=*it;
+    exprt goto_state_rhs = ssa, dest_state_rhs = ssa;
 
     {
       const auto p_it = goto_state.propagation.find(l1_identifier);
@@ -466,7 +465,7 @@ void goto_symext::phi_function(
       do_simplify(rhs);
     }
 
-    ssa_exprt new_lhs=*it;
+    ssa_exprt new_lhs = ssa;
     const bool record_events=dest_state.record_events;
     dest_state.record_events=false;
     dest_state.assignment(new_lhs, rhs, ns, true, true);

--- a/src/util/range.h
+++ b/src/util/range.h
@@ -1,0 +1,363 @@
+/*******************************************************************\
+
+Module: Range
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+/// \file
+/// Ranges: pair of begin and end iterators, which can be initialized from
+/// containers, provide useful methods such as map, filter and concat which only
+/// manipulate iterators, and can be used with ranged-for.
+
+#ifndef CPROVER_UTIL_RANGE_H
+#define CPROVER_UTIL_RANGE_H
+
+#include <functional>
+
+#include <util/invariant.h>
+#include <util/make_unique.h>
+
+/// Iterator which applies some given function \c f after each increment and
+/// returns its result on dereference.
+template <typename iteratort, typename outputt>
+class map_iteratort
+{
+public:
+  using difference_type = void; // Requiered by STL
+  using value_type = outputt;
+  using pointer = const outputt *;
+  using reference = const outputt &;
+  using iterator_category = std::forward_iterator_tag;
+
+  bool operator==(const map_iteratort &other) const
+  {
+    return underlying == other.underlying;
+  }
+
+  bool operator!=(const map_iteratort &other) const
+  {
+    return !(this->underlying == other.underlying);
+  }
+
+  /// Preincrement operator
+  map_iteratort &operator++()
+  {
+    PRECONDITION(underlying != underlying_end);
+    ++underlying;
+    if(underlying != underlying_end)
+      current = util_make_unique<outputt>((*f)(*underlying));
+    return *this;
+  }
+
+  /// Postincrement operator
+  const map_iteratort operator++(int)
+  {
+    map_iteratort tmp(*this);
+    this->operator++();
+    return tmp;
+  }
+
+  const value_type &operator*() const
+  {
+    return *current.get();
+  }
+
+  const value_type *operator->() const
+  {
+    return &(*current.get());
+  }
+
+  explicit map_iteratort(
+    iteratort underlying,
+    iteratort underlying_end,
+    std::shared_ptr<
+      std::function<value_type(const typename iteratort::value_type &)>> f)
+    : underlying(std::move(underlying)),
+      underlying_end(std::move(underlying_end)),
+      f(std::move(f))
+  {
+    if(this->underlying != this->underlying_end)
+      current = util_make_unique<outputt>((*this->f)(*this->underlying));
+  }
+
+  map_iteratort(const map_iteratort &other)
+    : underlying(other.underlying),
+      underlying_end(other.underlying_end),
+      f(other.f)
+  {
+    if(other.current != nullptr)
+      current = util_make_unique<outputt>(*other.current.get());
+  }
+
+private:
+  iteratort underlying;
+  iteratort underlying_end;
+  std::shared_ptr<
+    std::function<value_type(const typename iteratort::value_type &)>>
+    f;
+
+  /// Stores the result of \c f at the current position of the iterator.
+  /// Equals nullptr if the iterator reached \c underlying_end.
+  std::unique_ptr<outputt> current = nullptr;
+};
+
+/// Iterator which only stops at elements for which some given function \c f is
+/// true.
+template <typename iteratort>
+class filter_iteratort
+{
+public:
+  using difference_type = void; // Required by STL
+  using value_type = typename iteratort::value_type;
+  using pointer = const value_type *;
+  using reference = const value_type &;
+  using iterator_category = std::forward_iterator_tag;
+
+  bool operator==(const filter_iteratort &other) const
+  {
+    return underlying == other.underlying;
+  }
+
+  bool operator!=(const filter_iteratort &other) const
+  {
+    return !(this->underlying == other.underlying);
+  }
+
+  /// Preincrement operator
+  filter_iteratort &operator++()
+  {
+    ++underlying;
+    point_to_first_to_peek();
+    return *this;
+  }
+
+  /// Postincrement operator
+  const filter_iteratort operator++(int)
+  {
+    filter_iteratort tmp(*this);
+    this->operator++();
+    return tmp;
+  }
+
+  const value_type &operator*() const
+  {
+    return *underlying;
+  }
+
+  const value_type *operator->() const
+  {
+    return &(*underlying);
+  }
+
+  /// Filter between \p underlying and \p end using \p f.
+  /// If \c f is not true for any element between \p underlying and \p end, the
+  /// constructed iterator is equal to the one which would have been constructed
+  /// using
+  /// ```
+  /// filter_iteratort(f, end, end)
+  /// ```
+  filter_iteratort(
+    std::shared_ptr<std::function<bool(const value_type &)>> f,
+    iteratort underlying,
+    iteratort end)
+    : underlying(std::move(underlying)),
+      underlying_end(std::move(end)),
+      f(std::move(f))
+  {
+    point_to_first_to_peek();
+  }
+
+private:
+  iteratort underlying;
+  const iteratort underlying_end;
+  std::shared_ptr<std::function<bool(const value_type &)>> f;
+
+  /// Ensure that the underlying iterator is always positioned on an element
+  /// for which `f` is true.
+  /// This does nothing if \c f is satisfied at the current position.
+  /// If \c f is not true for any element between underlying and underlying_end
+  /// underlying will be incremented until underlying_end is reached.
+  void point_to_first_to_peek()
+  {
+    while(underlying != underlying_end && !(*f)(*underlying))
+      ++underlying;
+  }
+};
+
+/// On increment, increments a first iterator and when the corresponding end
+/// iterator is reached, starts to increment a second one.
+/// Dereference corresponds to dereference on the first iterator if the end is
+/// not reached yet, and on the second one otherwise.
+template <typename first_iteratort, typename second_iteratort>
+struct concat_iteratort
+{
+public:
+  using difference_type = void; // Requiered by STL
+  using value_type = typename first_iteratort::value_type;
+  using pointer = const value_type *;
+  using reference = const value_type &;
+  using iterator_category = std::forward_iterator_tag;
+
+  static_assert(
+    std::is_same<value_type, typename first_iteratort::value_type>::value,
+    "Concatenated iterators should have the same value type");
+
+  bool operator==(const concat_iteratort &other) const
+  {
+    return first_begin == other.first_begin && first_end == other.first_end &&
+           second_begin == other.second_begin;
+  }
+
+  bool operator!=(const concat_iteratort &other) const
+  {
+    return !(*this == other);
+  }
+
+  /// Preincrement operator
+  concat_iteratort &operator++()
+  {
+    if(first_begin == first_end)
+      ++second_begin;
+    else
+      ++first_begin;
+    return *this;
+  }
+
+  /// Postincrement operator
+  const concat_iteratort operator++(int)
+  {
+    concat_iteratort tmp(first_begin, first_end, second_begin);
+    this->operator++();
+    return tmp;
+  }
+
+  const value_type &operator*() const
+  {
+    if(first_begin == first_end)
+      return *second_begin;
+    return *first_begin;
+  }
+
+  const value_type *operator->() const
+  {
+    if(first_begin == first_end)
+      return &(*second_begin);
+    return &(*first_begin);
+  }
+
+  concat_iteratort(
+    first_iteratort first_begin,
+    first_iteratort first_end,
+    second_iteratort second_begin)
+    : first_begin(std::move(first_begin)),
+      first_end(std::move(first_end)),
+      second_begin(std::move(second_begin))
+  {
+  }
+
+private:
+  first_iteratort first_begin;
+  first_iteratort first_end;
+  second_iteratort second_begin;
+};
+
+/// A range is a pair of a begin and an end iterators.
+/// The class provides useful methods such as map, filter and concat which only
+/// manipulate iterators and thus don't have to create instances of heavy data
+/// structures and avoid copies.
+/// For instance, to iterate over two vectors, instead of writing
+///
+///     std::vector new_vector;
+///     std::copy(v1.begin(), v1.end(), std::back_inserter(new_vector));
+///     std::copy(v2.begin(), v2.end(), std::back_inserter(new_vector));
+///     for(const auto &a : new_vector) {...}
+///
+/// It is possible to write:
+///
+///     auto range = make_range(v1).concat(make_range(v2));
+///     for(const auto &a : range) {...}
+///
+/// Which is clearer and has the advantage of avoiding the creation of the
+/// intermediary vector and the potentially expensive copies.
+template <typename iteratort>
+struct ranget final
+{
+public:
+  using value_typet = typename iteratort::value_type;
+
+  ranget(iteratort begin, iteratort end) : begin_value(begin), end_value(end)
+  {
+  }
+
+  ranget<filter_iteratort<iteratort>>
+  filter(std::function<bool(const value_typet &)> f)
+  {
+    auto shared_f = std::make_shared<decltype(f)>(std::move(f));
+    filter_iteratort<iteratort> filter_begin(shared_f, begin(), end());
+    filter_iteratort<iteratort> filter_end(shared_f, end(), end());
+    return ranget<filter_iteratort<iteratort>>(filter_begin, filter_end);
+  }
+
+  /// Template argument type `outputt` has to be specified when \p f is given as
+  /// a lambda.
+  template <typename outputt>
+  ranget<map_iteratort<iteratort, outputt>>
+  map(std::function<outputt(const value_typet &)> f)
+  {
+    auto shared_f = std::make_shared<decltype(f)>(std::move(f));
+    auto map_begin =
+      map_iteratort<iteratort, outputt>(begin(), end(), shared_f);
+    auto map_end = map_iteratort<iteratort, outputt>(end(), end(), shared_f);
+    return ranget<map_iteratort<iteratort, outputt>>(
+      std::move(map_begin), std::move(map_end));
+  }
+
+  template <typename other_iteratort>
+  ranget<concat_iteratort<iteratort, other_iteratort>>
+  concat(ranget<other_iteratort> other)
+  {
+    auto concat_begin = concat_iteratort<iteratort, other_iteratort>(
+      begin(), end(), other.begin());
+    auto concat_end =
+      concat_iteratort<iteratort, other_iteratort>(end(), end(), other.end());
+    return ranget<concat_iteratort<iteratort, other_iteratort>>(
+      concat_begin, concat_end);
+  }
+
+  bool empty() const
+  {
+    return begin_value == end_value;
+  }
+
+  iteratort begin()
+  {
+    return begin_value;
+  }
+
+  const iteratort &end() const
+  {
+    return end_value;
+  }
+
+private:
+  iteratort begin_value;
+  iteratort end_value;
+};
+
+template <typename iteratort>
+ranget<iteratort> make_range(iteratort begin, iteratort end)
+{
+  return ranget<iteratort>(begin, end);
+}
+
+template <
+  typename containert,
+  typename iteratort = typename containert::const_iterator>
+ranget<iteratort> make_range(const containert &container)
+{
+  return ranget<iteratort>(container.begin(), container.end());
+}
+
+#endif // CPROVER_UTIL_RANGE_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -42,6 +42,7 @@ SRC += analyses/ai/ai.cpp \
        util/message.cpp \
        util/optional.cpp \
        util/pointer_offset_size.cpp \
+       util/range.cpp \
        util/replace_symbol.cpp \
        util/sharing_map.cpp \
        util/sharing_node.cpp \

--- a/unit/util/range.cpp
+++ b/unit/util/range.cpp
@@ -1,0 +1,67 @@
+/*******************************************************************\
+
+Module: Unit tests for range
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+#include <vector>
+
+#include <testing-utils/catch.hpp>
+#include <util/range.h>
+
+SCENARIO("range tests", "[core][util][range]")
+{
+  GIVEN("A vector with three strings")
+  {
+    std::vector<std::string> list;
+    list.emplace_back("abc");
+    list.emplace_back("cdef");
+    list.emplace_back("acdef");
+    auto range = make_range(list);
+    std::size_t total_length = 0;
+    THEN("Use range-for to compute the total length")
+    {
+      for(const auto &s : range)
+        total_length += s.length();
+      REQUIRE(total_length == 12);
+    }
+    THEN("Use map to compute individual lengths")
+    {
+      auto length_range = make_range(list).map<std::size_t>(
+        [](const std::string &s) { return s.length(); });
+      auto it = length_range.begin();
+      REQUIRE(*it == 3);
+      ++it;
+      REQUIRE(*it == 4);
+      ++it;
+      REQUIRE(*it == 5);
+      ++it;
+      REQUIRE(it == length_range.end());
+    }
+    THEN("Filter using lengths")
+    {
+      auto filtered_range = make_range(list).filter(
+        [&](const std::string &s) { return s.length() == 4; });
+      auto it = filtered_range.begin();
+      REQUIRE(*it == "cdef");
+      ++it;
+      REQUIRE(it == filtered_range.end());
+    }
+    THEN("Filter, map and use range-for on the same list")
+    {
+      auto range =
+        make_range(list)
+          .filter([&](const std::string &s) -> bool { return s[0] == 'a'; })
+          .map<std::size_t>([&](const std::string &s) { return s.length(); });
+      // Note that everything is performed on the fly, so none of the filter
+      // and map functions have been computed yet, and no intermediary container
+      // is created.
+      std::size_t total = 0;
+      for(const auto &l : range)
+        total += l;
+      REQUIRE(total == 8);
+    }
+  }
+}


### PR DESCRIPTION
The goal of this PR is to make symex faster by avoiding a set copy and merging, to do this without making the code too complicated, the PR introduce the following.
It adds map, filter and concat iterators which can be used to iterate over transformed containers without having to make copy of them, and it adds a `ranget` class which make it easy to use these new iterators.

This part of the code is executed in all our tests so the fact that all existing tests pass should show these work correctly.

The performance difference for this change were evaluate on 143 methods
from tika, which were chosen because analysis time was taking between 1
second and 1 minute for them.
The time of symex step was evaluated alone (options --show-vcc --verbosity 0).
The comparison of the time results is here:
![perf_range_optimization](https://user-images.githubusercontent.com/11854194/48894660-31283580-ee3b-11e8-9a18-513a79683159.png)

The total execution time was reduced by 21% and the average speed up is 14% (the difference between the two means the optimization seems to have less influence on simpler benchmarks).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
