### PR TITLE
Hide calls/returns from/to hidden functions

### DIFF
--- a/regression/cbmc/trace_show_function_calls/test.desc
+++ b/regression/cbmc/trace_show_function_calls/test.desc
@@ -9,3 +9,4 @@ Function call: function_to_call\(-2\) \(depth 2\)
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring
+__CPROVER_initialize

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -202,6 +202,9 @@ bool generate_ansi_c_start_function(
   PRECONDITION(!symbol.value.is_nil());
   code_blockt init_code;
 
+  // add 'HIDE' label
+  init_code.add(code_labelt(CPROVER_PREFIX "HIDE", code_skipt()));
+
   // build call to initialization function
 
   {

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -258,16 +258,19 @@ void goto_symext::symex_function_call_code(
   for(auto &a : arguments)
     state.rename(a, ns);
 
+  // we hide the call if the caller and callee are both hidden
+  const bool hidden = state.top().hidden_function && goto_function.is_hidden();
+
   // record the call
   target.function_call(
-    state.guard.as_expr(), identifier, arguments, state.source);
+    state.guard.as_expr(), identifier, arguments, state.source, hidden);
 
   if(!goto_function.body_available())
   {
     no_body(identifier);
 
     // record the return
-    target.function_return(state.guard.as_expr(), state.source);
+    target.function_return(state.guard.as_expr(), state.source, hidden);
 
     if(call.lhs().is_not_nil())
     {
@@ -354,8 +357,10 @@ void goto_symext::pop_frame(statet &state)
 /// do function call by inlining
 void goto_symext::symex_end_of_function(statet &state)
 {
+  const bool hidden = state.top().hidden_function;
+
   // first record the return
-  target.function_return(state.guard.as_expr(), state.source);
+  target.function_return(state.guard.as_expr(), state.source, hidden);
 
   // then get rid of the frame
   pop_frame(state);

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -160,6 +160,8 @@ void goto_symext::initialize_entry_point(
 
   const goto_functiont &entry_point_function = get_goto_function(pc->function);
 
+  state.top().hidden_function = entry_point_function.is_hidden();
+
   auto emplace_safe_pointers_result =
     state.safe_pointers.emplace(pc->function, local_safe_pointerst{ns});
   if(emplace_safe_pointers_result.second)

--- a/src/goto-symex/symex_target.h
+++ b/src/goto-symex/symex_target.h
@@ -107,12 +107,12 @@ public:
     const exprt &guard,
     const irep_idt &function_identifier,
     const std::vector<exprt> &ssa_function_arguments,
-    const sourcet &source) = 0;
+    const sourcet &source,
+    bool hidden) = 0;
 
   // record return from a function
-  virtual void function_return(
-    const exprt &guard,
-    const sourcet &source)=0;
+  virtual void
+  function_return(const exprt &guard, const sourcet &source, bool hidden) = 0;
 
   // just record a location
   virtual void location(

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -211,7 +211,8 @@ void symex_target_equationt::function_call(
   const exprt &guard,
   const irep_idt &function_identifier,
   const std::vector<exprt> &ssa_function_arguments,
-  const sourcet &source)
+  const sourcet &source,
+  const bool hidden)
 {
   SSA_steps.push_back(SSA_stept());
   SSA_stept &SSA_step=SSA_steps.back();
@@ -221,6 +222,7 @@ void symex_target_equationt::function_call(
   SSA_step.source = source;
   SSA_step.called_function = function_identifier;
   SSA_step.ssa_function_arguments = ssa_function_arguments;
+  SSA_step.hidden = hidden;
 
   merge_ireps(SSA_step);
 }
@@ -228,7 +230,8 @@ void symex_target_equationt::function_call(
 /// just record a location
 void symex_target_equationt::function_return(
   const exprt &guard,
-  const sourcet &source)
+  const sourcet &source,
+  const bool hidden)
 {
   SSA_steps.push_back(SSA_stept());
   SSA_stept &SSA_step=SSA_steps.back();
@@ -236,6 +239,7 @@ void symex_target_equationt::function_return(
   SSA_step.guard = guard;
   SSA_step.type = goto_trace_stept::typet::FUNCTION_RETURN;
   SSA_step.source = source;
+  SSA_step.hidden = hidden;
 
   merge_ireps(SSA_step);
 }

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -76,12 +76,12 @@ public:
     const exprt &guard,
     const irep_idt &function_identifier,
     const std::vector<exprt> &ssa_function_arguments,
-    const sourcet &source);
+    const sourcet &source,
+    bool hidden);
 
   // record return from a function
-  virtual void function_return(
-    const exprt &guard,
-    const sourcet &source);
+  virtual void
+  function_return(const exprt &guard, const sourcet &source, bool hidden);
 
   // just record a location
   virtual void location(


### PR DESCRIPTION
This removes clutter in any counterexample traces; these functions have no
meaning for the user.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
