### PR TITLE
bugfix: set assignment type for actual parameters correctly

### DIFF
--- a/regression/cbmc/compact-trace/test.desc
+++ b/regression/cbmc/compact-trace/test.desc
@@ -5,6 +5,6 @@ activate-multi-line-match
 ^EXIT=10$
 ^SIGNAL=0$
 ^↳ main\.c:10 main\(\)\n  12: x=1 .*$
-^↳ main.c:13 bar\(0\)\n  13: bar_a=0 .*\n  5: x=2 .*\n  6: x=3 .*$
+^↳ main\.c:13 bar\(0\)\n  5: x=2 .*\n  6: x=3 .*$
 --
 ^warning: ignoring

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -125,7 +125,21 @@ void goto_symext::parameter_assignments(
         }
       }
 
-      symex_assign(state, code_assignt(lhs, rhs));
+      assignment_typet assignment_type;
+
+      // We hide if we are in a hidden function.
+      if(state.top().hidden_function)
+        assignment_type =
+          symex_targett::assignment_typet::HIDDEN_ACTUAL_PARAMETER;
+      else
+        assignment_type =
+          symex_targett::assignment_typet::VISIBLE_ACTUAL_PARAMETER;
+
+      clean_expr(lhs, state, true);
+      clean_expr(rhs, state, false);
+
+      guardt guard;
+      symex_assign_rec(state, lhs, nil_exprt(), rhs, guard, assignment_type);
     }
 
     if(it1!=arguments.end())


### PR DESCRIPTION
A test requires a user. The compact-trace feature (#3458) is an opportunity for this.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
