### PR TITLE
Check for memory leaks on exit and abort

### DIFF
--- a/doc/man/cbmc.1
+++ b/doc/man/cbmc.1
@@ -178,6 +178,10 @@ enable pointer checks
 \fB\-\-memory\-leak\-check\fR
 enable memory leak checks
 .TP
+\fB\-\-memory\-cleanup\-check\fR
+Enable memory cleanup checks: assert that all dynamically allocated memory is
+explicitly freed before terminating the program.
+.TP
 \fB\-\-div\-by\-zero\-check\fR
 enable division by zero checks
 .TP

--- a/doc/man/goto-analyzer.1
+++ b/doc/man/goto-analyzer.1
@@ -506,6 +506,10 @@ enable pointer checks
 \fB\-\-memory\-leak\-check\fR
 enable memory leak checks
 .TP
+\fB\-\-memory\-cleanup\-check\fR
+Enable memory cleanup checks: assert that all dynamically allocated memory is
+explicitly freed before terminating the program.
+.TP
 \fB\-\-div\-by\-zero\-check\fR
 enable division by zero checks
 .TP

--- a/doc/man/goto-diff.1
+++ b/doc/man/goto-diff.1
@@ -47,6 +47,10 @@ enable pointer checks
 \fB\-\-memory\-leak\-check\fR
 enable memory leak checks
 .TP
+\fB\-\-memory\-cleanup\-check\fR
+Enable memory cleanup checks: assert that all dynamically allocated memory is
+explicitly freed before terminating the program.
+.TP
 \fB\-\-div\-by\-zero\-check\fR
 enable division by zero checks
 .TP

--- a/doc/man/goto-instrument.1
+++ b/doc/man/goto-instrument.1
@@ -187,6 +187,10 @@ enable pointer checks
 \fB\-\-memory\-leak\-check\fR
 enable memory leak checks
 .TP
+\fB\-\-memory\-cleanup\-check\fR
+Enable memory cleanup checks: assert that all dynamically allocated memory is
+explicitly freed before terminating the program.
+.TP
 \fB\-\-div\-by\-zero\-check\fR
 enable division by zero checks
 .TP

--- a/regression/cbmc/Memory_leak_abort/main.c
+++ b/regression/cbmc/Memory_leak_abort/main.c
@@ -1,0 +1,18 @@
+#include <stdlib.h>
+
+extern void __VERIFIER_error();
+
+int main()
+{
+  int *p = malloc(sizeof(int));
+  if(*p == 0)
+    abort();
+  if(*p == 1)
+    exit(1);
+  if(*p == 2)
+    _Exit(1);
+  if(*p == 3)
+    __VERIFIER_error();
+  free(p);
+  return 0;
+}

--- a/regression/cbmc/Memory_leak_abort/test.desc
+++ b/regression/cbmc/Memory_leak_abort/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--memory-leak-check --memory-cleanup-check --no-assertions
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+_Exit\.memory-leak\.1.*FAILURE
+__CPROVER__start\.memory-leak\.1.*SUCCESS
+abort\.memory-leak\.1.*FAILURE
+exit\.memory-leak\.1.*FAILURE
+main\.memory-leak\.1.*FAILURE
+--
+main\.assertion\.1.*FAILURE
+^warning: ignoring

--- a/src/ansi-c/goto_check_c.h
+++ b/src/ansi-c/goto_check_c.h
@@ -38,7 +38,7 @@ void goto_check_c(
   message_handlert &message_handler);
 
 #define OPT_GOTO_CHECK                                                         \
-  "(bounds-check)(pointer-check)(memory-leak-check)"                           \
+  "(bounds-check)(pointer-check)(memory-leak-check)(memory-cleanup-check)"     \
   "(div-by-zero-check)(enum-range-check)"                                      \
   "(signed-overflow-check)(unsigned-overflow-check)"                           \
   "(pointer-overflow-check)(conversion-check)(undefined-shift-check)"          \
@@ -54,6 +54,7 @@ void goto_check_c(
   " --bounds-check               enable array bounds checks\n" \
   " --pointer-check              enable pointer checks\n" /* NOLINT(whitespace/line_length) */ \
   " --memory-leak-check          enable memory leak checks\n" \
+  " --memory-cleanup-check       enable memory cleanup checks\n" \
   " --div-by-zero-check          enable division by zero checks\n" \
   " --signed-overflow-check      enable signed arithmetic over- and underflow checks\n" /* NOLINT(whitespace/line_length) */ \
   " --unsigned-overflow-check    enable arithmetic over- and underflow checks\n" /* NOLINT(whitespace/line_length) */  \
@@ -75,6 +76,7 @@ void goto_check_c(
   options.set_option("bounds-check", cmdline.isset("bounds-check")); \
   options.set_option("pointer-check", cmdline.isset("pointer-check")); \
   options.set_option("memory-leak-check", cmdline.isset("memory-leak-check")); \
+  options.set_option("memory-cleanup-check", cmdline.isset("memory-cleanup-check")); /* NOLINT(whitespace/line_length) */ \
   options.set_option("div-by-zero-check", cmdline.isset("div-by-zero-check")); \
   options.set_option("enum-range-check", cmdline.isset("enum-range-check")); \
   options.set_option("signed-overflow-check", cmdline.isset("signed-overflow-check")); /* NOLINT(whitespace/line_length) */  \

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -831,6 +831,7 @@ void goto_convertt::do_function_call_symbol(
     annotated_location = function.source_location();
     annotated_location.set("user-provided", true);
     dest.add(goto_programt::make_assumption(false_exprt(), annotated_location));
+    dest.instructions.back().labels.push_back("__VERIFIER_abort");
   }
   else if(
     identifier == "assert" &&


### PR DESCRIPTION
This has become relevant in the SV-COMP MemCleanup category.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
