### PR TITLE
Print value-set types briefly

### DIFF
--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -17,6 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/arith_tools.h>
 #include <util/base_type.h>
 #include <util/c_types.h>
+#include <util/format_type.h>
 #include <util/pointer_offset_size.h>
 #include <util/simplify_expr.h>
 
@@ -166,7 +167,13 @@ void value_sett::output(
         if(o.type().is_nil())
           result+=", ?";
         else
-          result+=", "+from_type(ns, identifier, o.type());
+        {
+          std::stringstream s;
+          // Format the type in brief form --
+          // "struct A" not "struct { int member; ... }"
+          format_rec(s, o.type(), true);
+          result += ", " + s.str();
+        }
 
         result+='>';
       }

--- a/src/util/format_type.cpp
+++ b/src/util/format_type.cpp
@@ -13,10 +13,19 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <ostream>
 
 /// format a \ref struct_typet
-static std::ostream &format_rec(std::ostream &os, const struct_typet &src)
+static std::ostream &format_rec(
+  std::ostream &os,
+  const struct_typet &src,
+  bool brief)
 {
-  os << "struct"
-     << " {";
+  os << "struct ";
+  if(brief && !src.get_tag().empty())
+  {
+    os << src.get_tag();
+    return os;
+  }
+
+  os << "{";
   bool first = true;
 
   for(const auto &c : src.components())
@@ -33,10 +42,19 @@ static std::ostream &format_rec(std::ostream &os, const struct_typet &src)
 }
 
 /// format a \ref union_typet
-static std::ostream &format_rec(std::ostream &os, const union_typet &src)
+static std::ostream &format_rec(
+  std::ostream &os,
+  const union_typet &src,
+  bool brief)
 {
-  os << "union"
-     << " {";
+  os << "union ";
+  if(brief && !src.get_tag().empty())
+  {
+    os << src.get_tag();
+    return os;
+  }
+
+  os << "{";
   bool first = true;
 
   for(const auto &c : src.components())
@@ -55,7 +73,7 @@ static std::ostream &format_rec(std::ostream &os, const union_typet &src)
 // The below generates a string in a generic syntax
 // that is inspired by C/C++/Java, and is meant for debugging
 // purposes.
-std::ostream &format_rec(std::ostream &os, const typet &type)
+std::ostream &format_rec(std::ostream &os, const typet &type, bool brief)
 {
   const auto &id = type.id();
 
@@ -70,9 +88,9 @@ std::ostream &format_rec(std::ostream &os, const typet &type)
       return os << format(t.subtype()) << "[]";
   }
   else if(id == ID_struct)
-    return format_rec(os, to_struct_type(type));
+    return format_rec(os, to_struct_type(type), brief);
   else if(id == ID_union)
-    return format_rec(os, to_union_type(type));
+    return format_rec(os, to_union_type(type), brief);
   else if(id == ID_union_tag)
     return os << "union " << to_union_tag_type(type).get_identifier();
   else if(id == ID_struct_tag)

--- a/src/util/format_type.h
+++ b/src/util/format_type.h
@@ -14,6 +14,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 //! Formats a type in a generic syntax
 //! that is inspired by C/C++/Java, and is meant for debugging
-std::ostream &format_rec(std::ostream &, const typet &);
+std::ostream &format_rec(std::ostream &, const typet &, bool brief = false);
 
 #endif // CPROVER_UTIL_FORMAT_TYPE_H


### PR DESCRIPTION
Goal: readably print large expressions that feature types in their pretty-printed form (e.g. value-set object descriptions and typecasts) without drowning in text, by printing `struct A` not `struct A { ... }`.

I don't imagine this will make it through in present form, but I'm putting it up for feedback about the right way to go.

Ideas: 
* stream modifiers for format_rec and cousins (so `stream << brief_structs << type << reset_structs`)
* Various pretty-printing routes still use `from_type` and cousins, but adding an options parameter there looks like a pain. If we did though, we'd want to generalise the `expr2c_configurationt` already present in `expr2c` so that we have a neutral `pretty_printer_configurationt` that carries language-neutral options, which can be passed to `from_type/expr` -> `languaget::from_type/expr` -> `expr2c/java/...`. That would mean expr2c has even more forms though, as it could be paramterised via the language-neutral from_expr route, more specifically by a direct call, or not at all.

Thoughts?