### PR TITLE
irept: use single map for all named sub-nodes

### DIFF
--- a/src/ansi-c/README.md
+++ b/src/ansi-c/README.md
@@ -78,9 +78,9 @@ data structures. In particular, \ref exprt "expressions",
 An irep is a tree of ireps. A subtlety is that an irep is actually the
 root of _three_ (possibly empty) trees, i.e. it has three disjoint sets
 of children: \ref irept::get_sub() returns a list of children, and
-\ref irept::get_named_sub() and \ref irept::get_comments() each return an
-association from names to children. **Most clients never use these
-functions directly**, as subtypes of irept generally provide more
+\ref irept::get_named_sub() returns an association from names to children.
+**Most clients never use these functions directly**,
+as subtypes of irept generally provide more
 descriptive functions. For example, the operands of an
 \ref exprt "expression" (\ref exprt::op0() "op0", op1 etc) are
 really that expression's children; the

--- a/src/cpp/cpp_type2name.cpp
+++ b/src/cpp/cpp_type2name.cpp
@@ -36,30 +36,29 @@ static void irep2name(const irept &irep, std::string &result)
   if(irep.id()!="")
     result+=do_prefix(irep.id_string());
 
-  if(irep.get_named_sub().empty() &&
-     irep.get_sub().empty() &&
-     irep.get_comments().empty())
+  if(irep.get_named_sub().empty() && irep.get_sub().empty())
     return;
 
   result+='(';
   bool first=true;
 
   forall_named_irep(it, irep.get_named_sub())
-  {
-    if(first)
-      first=false;
-    else
-      result+=',';
+    if(!irept::is_comment(it->first))
+    {
+      if(first)
+        first = false;
+      else
+        result += ',';
 
-    result+=do_prefix(name2string(it->first));
+      result += do_prefix(name2string(it->first));
 
-    result+='=';
-    std::string tmp;
-    irep2name(it->second, tmp);
-    result+=tmp;
-  }
+      result += '=';
+      std::string tmp;
+      irep2name(it->second, tmp);
+      result += tmp;
+    }
 
-  forall_named_irep(it, irep.get_comments())
+  forall_named_irep(it, irep.get_named_sub())
     if(it->first==ID_C_constant ||
        it->first==ID_C_volatile ||
        it->first==ID_C_restricted)

--- a/src/util/README.md
+++ b/src/util/README.md
@@ -14,15 +14,15 @@ CPROVER codebase.
 
 See detailed documentation at \ref irept.
 
-[irept](\ref irept)s are generic tree nodes. You
-should think of each node as holding a single string ([data](\ref irept::data),
-actually an \ref irep_idt) and lots of child nodes, some of which are numbered
-([sub](\ref irept::dt::sub)) and some of which are labelled, and the label
-can either start with a “\#” ([comments](\ref irept::dt::comments)) or without
-one ([named_sub](\ref irept::dt::named_sub)). The meaning of the “\#” is that
-this child shouldn't be counted when comparing two [irept](\ref irept)s for
-equality; this is usually used when making an advisory annotation which does
-not alter the semantics of the program.
+[irept](\ref irept)s are generic tree nodes.  You should think of each node
+as holding a single string ([data](\ref irept::data), actually an \ref
+irep_idt) and lots of child nodes, some of which are numbered ([sub](\ref
+irept::dt::sub)) and some of which are labelled ([named_sub](\ref
+irept::dt::named_sub)).  The the label can either start with a “\#” or
+without one.  The meaning of the “\#” is that this child shouldn't be
+considered when comparing two [irept](\ref irept)s for equality; this is
+usually used when making an advisory annotation which does not alter the
+semantics of the program.
 
 They are used to represent many kinds of structured objects throughout the
 CPROVER codebase, such as expressions, types and code. An \ref exprt represents
@@ -72,9 +72,8 @@ standard data structures as in irept.
 
 \subsection irep_idt_section Strings: dstringt, the string_container and the ID_*
 
-Within cbmc, strings are represented using \ref irep_idt, or \ref irep_namet
-for keys to [named_sub](\ref irept::dt::named_sub) or
-[comments](\ref irept::dt::comments). By default these are both
+Within cbmc, strings are represented using \ref irep_idt or \ref irep_namet
+for keys to [named_sub](\ref irept::dt::named_sub). By default these are both
 typedefed to \ref dstringt. For debugging purposes you can set `USE_STD_STRING`,
 in which case they are both typedefed to `std::string`. You can also easily
 convert an [irep_idt](\ref irep_idt) or [irep_namet](\ref irep_namet) to a
@@ -91,11 +90,10 @@ in `irep_ids.def` is `“IREP_ID_ONE(type)”`, so the string “type” has ind
 You can refer to this \ref irep_idt as `ID_type`. The other kind of line you
 see is \c "IREP_ID_TWO(C_source_location, #source_location)", which means the
 \ref irep_idt for the string “\#source_location” can be referred to as
-`ID_C_source_location`. The “C” is for comment, meaning that it should be
-stored in the [comments](\ref irept::dt::comments). Any strings that need
-to be stored as [irep_idt](\ref irep_idt)s which aren't in `irep_ids.def`
-are added to the end of the table when they are first encountered, and the
-same index is used for all instances.
+`ID_C_source_location`.  The “C” is for comment, meaning that it starts with
+“\#”.  Any strings that need to be stored as [irep_idt](\ref irep_idt)s
+which aren't in `irep_ids.def` are added to the end of the table when they
+are first encountered, and the same index is used for all instances.
 
 See documentation at \ref dstringt.
 
@@ -125,8 +123,8 @@ of size 2 (for the two arguments of minus).
 
 Recall that every \ref irept has one piece of data of its own, i.e. its
 [id()](\ref irept::id()), and all other information is in its
-[named_sub](\ref irept::dt::named_sub), [comments](\ref irept::dt::comments)
-or [sub](\ref irept::dt::sub). For [exprt](\ref exprt)s, the
+[named_sub](\ref irept::dt::named_sub) or [sub](\ref irept::dt::sub).
+For [exprt](\ref exprt)s, the
 [id()](\ref irept::id()) is used to specify why kind of \ref exprt this is,
 so a \ref minus_exprt has `ID_minus` as its [id()](\ref irept::id()). This
 means that a \ref minus_exprt can be passed wherever an \ref exprt is

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -99,11 +99,8 @@ const irept &get_nil_irep();
 ///
 /// * \ref irept::dt::named_sub : A map from `irep_namet` (a string) to \ref
 ///   irept. This is used for named children, i.e.  subexpressions, parameters,
-///   etc.
-///
-/// * \ref irept::dt::comments : Another map from `irep_namet` to \ref irept
-///   which is used for annotations and other ‘non-semantic’ information. Note
-///   that this map is ignored by the default \ref operator==.
+///   etc. Children whose name begins with '#' are ignored by the
+///   default \ref operator==.
 ///
 /// * \ref irept::dt::sub : A vector of \ref irept which is used to store
 ///   ordered but unnamed children.
@@ -318,8 +315,6 @@ public:
   const subt &get_sub() const { return read().sub; }
   named_subt &get_named_sub() { return write().named_sub; } // DANGEROUS
   const named_subt &get_named_sub() const { return read().named_sub; }
-  named_subt &get_comments() { return write().comments; } // DANGEROUS
-  const named_subt &get_comments() const { return read().comments; }
 
   std::size_t hash() const;
   std::size_t full_hash() const;
@@ -328,11 +323,13 @@ public:
 
   std::string pretty(unsigned indent=0, unsigned max_indent=0) const;
 
-protected:
+public:
   static bool is_comment(const irep_namet &name)
   { return !name.empty() && name[0]=='#'; }
 
-public:
+  /// count the number of named_sub elements that are not comments
+  static std::size_t number_of_non_comments(const named_subt &);
+
   class dt
   {
   private:
@@ -347,7 +344,6 @@ public:
     irep_idt data;
 
     named_subt named_sub;
-    named_subt comments;
     subt sub;
 
     #ifdef HASH_CODE
@@ -359,7 +355,6 @@ public:
       data.clear();
       sub.clear();
       named_sub.clear();
-      comments.clear();
       #ifdef HASH_CODE
       hash_code=0;
       #endif
@@ -370,7 +365,6 @@ public:
       d.data.swap(data);
       d.sub.swap(sub);
       d.named_sub.swap(named_sub);
-      d.comments.swap(comments);
       #ifdef HASH_CODE
       std::swap(d.hash_code, hash_code);
       #endif

--- a/src/util/irep_serialization.cpp
+++ b/src/util/irep_serialization.cpp
@@ -38,13 +38,6 @@ void irep_serializationt::write_irep(
     reference_convert(it->second, out);
   }
 
-  forall_named_irep(it, irep.get_comments())
-  {
-    out.put('C');
-    write_string_ref(out, it->first);
-    reference_convert(it->second, out);
-  }
-
   out.put(0); // terminator
 }
 

--- a/src/util/json_irep.cpp
+++ b/src/util/json_irep.cpp
@@ -40,9 +40,6 @@ json_objectt json_irept::convert_from_irep(const irept &irep) const
   convert_sub_tree("sub", irep.get_sub(), irep_object);
   convert_named_sub_tree("namedSub", irep.get_named_sub(), irep_object);
 
-  if(include_comments)
-    convert_named_sub_tree("comment", irep.get_comments(), irep_object);
-
   return irep_object;
 }
 
@@ -86,10 +83,11 @@ void json_irept::convert_named_sub_tree(
   {
     json_objectt sub_objects;
     for(const auto &sub_tree : sub_trees)
-    {
-      json_objectt sub_object=convert_from_irep(sub_tree.second);
-      sub_objects[id2string(sub_tree.first)]=sub_object;
-    }
+      if(include_comments || !irept::is_comment(sub_tree.first))
+      {
+        json_objectt sub_object = convert_from_irep(sub_tree.second);
+        sub_objects[id2string(sub_tree.first)] = sub_object;
+      }
     parent[sub_tree_id]=sub_objects;
   }
 }

--- a/src/util/lispirep.cpp
+++ b/src/util/lispirep.cpp
@@ -46,9 +46,7 @@ void irep2lisp(const irept &src, lispexprt &dest)
   dest.value="";
   dest.type=lispexprt::List;
 
-  dest.reserve(2+2*src.get_sub().size()
-                +2*src.get_named_sub().size()
-                +2*src.get_comments().size());
+  dest.reserve(2 + 2 * src.get_sub().size() + 2 * src.get_named_sub().size());
 
   lispexprt id;
   id.type=lispexprt::String;
@@ -71,19 +69,6 @@ void irep2lisp(const irept &src, lispexprt &dest)
   }
 
   forall_named_irep(it, src.get_named_sub())
-  {
-    lispexprt name;
-    name.type=lispexprt::String;
-    name.value=name2string(it->first);
-    dest.push_back(name);
-
-    lispexprt sub;
-
-    irep2lisp(it->second, sub);
-    dest.push_back(sub);
-  }
-
-  forall_named_irep(it, src.get_comments())
   {
     lispexprt name;
     name.type=lispexprt::String;

--- a/src/util/merge_irep.cpp
+++ b/src/util/merge_irep.cpp
@@ -148,17 +148,6 @@ const irept &merge_irept::merged(const irept &irep)
     dest_named_sub[it->first]=merged(it->second); // recursive call
     #endif
 
-  const irept::named_subt &src_comments=irep.get_comments();
-  irept::named_subt &dest_comments=new_irep.get_comments();
-
-  forall_named_irep(it, src_comments)
-    #ifdef SUB_IS_LIST
-    dest_comments.push_back(
-      std::make_pair(it->first, merged(it->second))); // recursive call
-    #else
-    dest_comments[it->first]=merged(it->second); // recursive call
-    #endif
-
   return *irep_store.insert(new_irep).first;
 }
 
@@ -194,17 +183,6 @@ const irept &merge_full_irept::merged(const irept &irep)
       std::make_pair(it->first, merged(it->second))); // recursive call
     #else
     dest_named_sub[it->first]=merged(it->second); // recursive call
-    #endif
-
-  const irept::named_subt &src_comments=irep.get_comments();
-  irept::named_subt &dest_comments=new_irep.get_comments();
-
-  forall_named_irep(it, src_comments)
-    #ifdef SUB_IS_LIST
-    dest_comments.push_back(
-      std::make_pair(it->first, merged(it->second))); // recursive call
-    #else
-    dest_comments[it->first]=merged(it->second); // recursive call
     #endif
 
   return *irep_store.insert(new_irep).first;

--- a/src/util/xml_irep.cpp
+++ b/src/util/xml_irep.cpp
@@ -30,18 +30,20 @@ void convert(
   }
 
   forall_named_irep(it, irep.get_named_sub())
-  {
-    xmlt &x_nsub=xml.new_element("named_sub");
-    x_nsub.set_attribute("name", name2string(it->first));
-    convert(it->second, x_nsub);
-  }
+    if(!irept::is_comment(it->first))
+    {
+      xmlt &x_nsub = xml.new_element("named_sub");
+      x_nsub.set_attribute("name", name2string(it->first));
+      convert(it->second, x_nsub);
+    }
 
-  forall_named_irep(it, irep.get_comments())
-  {
-    xmlt &x_com = xml.new_element("comment");
-    x_com.set_attribute("name", name2string(it->first));
-    convert(it->second, x_com);
-  }
+  forall_named_irep(it, irep.get_named_sub())
+    if(!irept::is_comment(it->first))
+    {
+      xmlt &x_com = xml.new_element("comment");
+      x_com.set_attribute("name", name2string(it->first));
+      convert(it->second, x_com);
+    }
 }
 
 void convert(

--- a/unit/util/irep.cpp
+++ b/unit/util/irep.cpp
@@ -61,8 +61,7 @@ SCENARIO("irept_memory", "[core][utils][irept]")
 
       REQUIRE(
         sizeof(irept::dt) ==
-        ref_count_size + data_size + sub_size + 2 * named_size +
-          hash_code_size);
+        ref_count_size + data_size + sub_size + named_size + hash_code_size);
     }
 
     THEN("get_nil_irep yields ID_nil")
@@ -131,7 +130,6 @@ SCENARIO("irept_memory", "[core][utils][irept]")
     {
       REQUIRE(irep.get_sub().empty());
       REQUIRE(irep.get_named_sub().empty());
-      REQUIRE(irep.get_comments().empty());
 
       irept &e = irep.add("a_new_element");
       REQUIRE(e.id().empty());
@@ -140,12 +138,15 @@ SCENARIO("irept_memory", "[core][utils][irept]")
 
       irept irep2("second_irep");
       irep.add("a_new_element", irep2);
+      REQUIRE(!irept::is_comment("a_new_element"));
       REQUIRE(irep.find("a_new_element").id() == "second_irep");
       REQUIRE(irep.get_named_sub().size() == 1);
 
       irep.add("#a_comment", irep2);
+      REQUIRE(irept::is_comment("#a_comment"));
       REQUIRE(irep.find("#a_comment").id() == "second_irep");
-      REQUIRE(irep.get_comments().size() == 1);
+      REQUIRE(irep.get_named_sub().size() == 2);
+      REQUIRE(irept::number_of_non_comments(irep.get_named_sub()) == 1);
 
       irept bak(irep);
       irep.remove("no_such_id");
@@ -159,19 +160,17 @@ SCENARIO("irept_memory", "[core][utils][irept]")
 
       irep.move_to_named_sub("another_entry", irep2);
       REQUIRE(irep.get_sub().size() == 1);
-      REQUIRE(irep.get_named_sub().size() == 1);
-      REQUIRE(irep.get_comments().size() == 1);
+      REQUIRE(irep.get_named_sub().size() == 2);
 
       irept irep3;
       irep.move_to_named_sub("#a_comment", irep3);
       REQUIRE(irep.find("#a_comment").id().empty());
       REQUIRE(irep.get_sub().size() == 1);
-      REQUIRE(irep.get_named_sub().size() == 1);
-      REQUIRE(irep.get_comments().size() == 1);
+      REQUIRE(irep.get_named_sub().size() == 2);
 
       irept irep4;
       irep.move_to_named_sub("#another_comment", irep4);
-      REQUIRE(irep.get_comments().size() == 2);
+      REQUIRE(irep.get_named_sub().size() == 3);
     }
 
     THEN("Setting and getting works")
@@ -205,13 +204,11 @@ SCENARIO("irept_memory", "[core][utils][irept]")
       REQUIRE(irep.id().empty());
       REQUIRE(irep.get_sub().empty());
       REQUIRE(irep.get_named_sub().empty());
-      REQUIRE(irep.get_comments().empty());
 
       irep.make_nil();
       REQUIRE(irep.id() == ID_nil);
       REQUIRE(irep.get_sub().empty());
       REQUIRE(irep.get_named_sub().empty());
-      REQUIRE(irep.get_comments().empty());
     }
 
     THEN("Pretty printing works")


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
