### PR TITLE
Make split_string check&throw instead of assert return value

### DIFF
--- a/src/util/string_utils.cpp
+++ b/src/util/string_utils.cpp
@@ -7,6 +7,7 @@ Author: Daniel Poetzl
 \*******************************************************************/
 
 #include "string_utils.h"
+#include "exception_utils.h"
 #include "invariant.h"
 
 #include <cassert>
@@ -109,7 +110,14 @@ void split_string(
   std::vector<std::string> result;
 
   split_string(s, delim, result, strip);
-  CHECK_RETURN(result.size() == 2);
+  if(result.size() != 2)
+  {
+    throw deserialization_exceptiont{"expected string `" + s +
+                                     "' to contain two substrings "
+                                     "delimited by " +
+                                     delim + " but has " +
+                                     std::to_string(result.size())};
+  }
 
   left=result[0];
   right=result[1];


### PR DESCRIPTION
The 2-string version of split_string previously asserted that the split would
result in the right number of substrings. That made it not very useful for
parsing user input, as using it would require parsing the string before passing
it to split_string.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
