### PR TITLE
Add optional_lookup utility function

### DIFF
--- a/src/util/optional_utils.h
+++ b/src/util/optional_utils.h
@@ -1,0 +1,28 @@
+/*******************************************************************\
+
+ Module: functions that are useful with optionalt
+
+ Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_OPTIONAL_UTILS_H
+#define CPROVER_UTIL_OPTIONAL_UTILS_H
+
+#include "optional.h"
+
+/// Lookup a key in a map, if found return the associated value,
+/// nullopt otherwise
+template <typename map_like_collectiont, typename keyt>
+auto optional_lookup(const map_like_collectiont &map, const keyt &key)
+  -> optionalt<decltype(map.find(key)->second)>
+{
+  auto const it = map.find(key);
+  if(it != map.end())
+  {
+    return it->second;
+  }
+  return nullopt;
+}
+
+#endif // CPROVER_UTIL_OPTIONAL_UTILS_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -41,6 +41,7 @@ SRC += analyses/ai/ai.cpp \
        util/irep_sharing.cpp \
        util/message.cpp \
        util/optional.cpp \
+       util/optional_utils.cpp \
        util/pointer_offset_size.cpp \
        util/range.cpp \
        util/replace_symbol.cpp \

--- a/unit/util/optional_utils.cpp
+++ b/unit/util/optional_utils.cpp
@@ -1,0 +1,44 @@
+/*******************************************************************\
+
+ Module: optional_utils unit tests
+
+ Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include <testing-utils/catch.hpp>
+
+#include <util/optional_utils.h>
+
+#include <map>
+#include <string>
+#include <unordered_map>
+
+namespace
+{
+template <typename map_like_collectiont>
+void do_optional_lookup_test(map_like_collectiont &map)
+{
+  map.insert({"hello", "world"});
+  map.insert({"pwd", "/home"});
+  auto const hello_result = optional_lookup(map, "hello");
+  REQUIRE(hello_result.has_value());
+  REQUIRE(hello_result.value() == "world");
+  auto const pwd_result = optional_lookup(map, "pwd");
+  REQUIRE(pwd_result.has_value());
+  REQUIRE(pwd_result.value() == "/home");
+  REQUIRE_FALSE(optional_lookup(map, "does not exit").has_value());
+}
+} // namespace
+
+TEST_CASE("Using optional_lookup with std::map")
+{
+  auto map = std::map<std::string, std::string>{};
+  do_optional_lookup_test(map);
+}
+
+TEST_CASE("Using optional_lookup with std::unordered_map")
+{
+  auto map = std::unordered_map<std::string, std::string>{};
+  do_optional_lookup_test(map);
+}


### PR DESCRIPTION
This provides a more ergonomic interface over map::find for the case when you don't need an iterator

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
