### PR TITLE
Document the flag needed for function names in stack backtraces.

### DIFF
--- a/src/config.inc
+++ b/src/config.inc
@@ -12,6 +12,9 @@ endif
 #CXXFLAGS += -O2 -DNDEBUG
 #CXXFLAGS += -O0 -g
 
+# With GCC this adds function names in stack backtraces
+#LINKFLAGS="-rdynamic"
+
 # If GLPK is available; this is used by goto-instrument and musketeer.
 #LIB_GLPK = -lglpk
 


### PR DESCRIPTION
Glibc and Apple's libc both provide support for stack introspection.
This is used by the invariant code to generate a stack backtrace
on invariant failure.  By default GCC strips out the function names
so an additional LINKFLAG is needed to get function names in the
backtrace.  This was hidden^Wdocumented in util/invariant.cpp, this
patch adds it to config.inc so it can be more widely understood
and used.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
