### PR TITLE
smt2_solver: use smt2_format instead of .pretty()

### DIFF
--- a/src/solvers/smt2/smt2_solver.cpp
+++ b/src/solvers/smt2/smt2_solver.cpp
@@ -167,9 +167,7 @@ void smt2_solvert::command(const std::string &c)
       // this is a command that Z3 appears to implement
       exprt e=expression();
       if(e.is_not_nil())
-      {
-        std::cout << e.pretty() << '\n'; // need to do an 'smt2_format'
-      }
+        std::cout << smt2_format(e) << '\n';
     }
     else if(c == "get-value")
     {
@@ -237,7 +235,7 @@ void smt2_solvert::command(const std::string &c)
         const symbol_tablet symbol_table;
         const namespacet ns(symbol_table);
         exprt e_simplified=simplify_expr(e, ns);
-        std::cout << e.pretty() << '\n'; // need to do an 'smt2_format'
+        std::cout << smt2_format(e) << '\n';
       }
     }
     #if 0


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
