### PR TITLE
add begin() and end() to dstring containers

### DIFF
--- a/regression/smt2_solver/echo/echo1.desc
+++ b/regression/smt2_solver/echo/echo1.desc
@@ -1,0 +1,9 @@
+CORE
+echo1.smt2
+
+^EXIT=20$
+^SIGNAL=0$
+\(error "line 2: expected string literal"\)
+"whatnot"
+"what""not"
+--

--- a/regression/smt2_solver/echo/echo1.smt2
+++ b/regression/smt2_solver/echo/echo1.smt2
@@ -1,0 +1,9 @@
+; error: must be string literal
+(echo 123)
+
+; ok
+(echo "whatnot")
+
+; with escaping
+(echo "what""not")
+

--- a/src/solvers/smt2/smt2_format.cpp
+++ b/src/solvers/smt2/smt2_format.cpp
@@ -57,6 +57,23 @@ std::ostream &smt2_format_rec(std::ostream &out, const exprt &expr)
     {
       out << value;
     }
+    else if(expr_type.id() == ID_string)
+    {
+      const auto &value_string = id2string(value);
+
+      out << '"';
+
+      for(const auto &c : value_string)
+      {
+        // " is the only escape sequence
+        if(c == '"')
+          out << '"' << '"';
+        else
+          out << c;
+      }
+
+      out << '"';
+    }
     else
       DATA_INVARIANT(false, "unhandled constant: " + expr_type.id_string());
   }

--- a/src/solvers/smt2/smt2_format.cpp
+++ b/src/solvers/smt2/smt2_format.cpp
@@ -59,11 +59,9 @@ std::ostream &smt2_format_rec(std::ostream &out, const exprt &expr)
     }
     else if(expr_type.id() == ID_string)
     {
-      const auto &value_string = id2string(value);
-
       out << '"';
 
-      for(const auto &c : value_string)
+      for(const auto &c : value)
       {
         // " is the only escape sequence
         if(c == '"')

--- a/src/solvers/smt2/smt2_solver.cpp
+++ b/src/solvers/smt2/smt2_solver.cpp
@@ -225,6 +225,13 @@ void smt2_solvert::command(const std::string &c)
 
       std::cout << ")\n";
     }
+    else if(c == "echo")
+    {
+      if(next_token() != STRING_LITERAL)
+        throw error("expected string literal");
+
+      std::cout << smt2_format(constant_exprt(buffer, string_typet())) << '\n';
+    }
     else if(c == "simplify")
     {
       // this is a command that Z3 appears to implement
@@ -248,8 +255,6 @@ void smt2_solvert::command(const std::string &c)
     | ( define-fun-rec hfunction_def i )
     | ( define-funs-rec ( hfunction_deci n+1 ) ( htermi n+1 ) )
     | ( define-sort hsymboli ( hsymboli ??? ) hsorti )
-    | ( echo hstringi )
-    | ( exit )
     | ( get-assertions )
     | ( get-assignment )
     | ( get-info hinfo_flag i )

--- a/src/util/dstring.h
+++ b/src/util/dstring.h
@@ -151,6 +151,17 @@ public:
     return no;
   }
 
+  // iterators for the underlying string
+  std::string::const_iterator begin() const
+  {
+    return as_string().begin();
+  }
+
+  std::string::const_iterator end() const
+  {
+    return as_string().end();
+  }
+
 private:
   #ifdef __GNUC__
   constexpr


### PR DESCRIPTION
Only look at last commit.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
