### PR TITLE
Make validation mode parameter explicit in DATA_CHECK macros [blocks #3287]

### DIFF
--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -706,9 +706,11 @@ void goto_programt::instructiont::validate(
     break;
   case ASSIGN:
     DATA_CHECK(
+      vm,
       code.get_statement() == ID_assign,
       "assign instruction should contain an assign statement");
-    DATA_CHECK(targets.empty(), "assign instruction should not have a target");
+    DATA_CHECK(
+      vm, targets.empty(), "assign instruction should not have a target");
     break;
   case DECL:
     break;

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -291,7 +291,7 @@ public:
     const validation_modet vm = validation_modet::INVARIANT)
   {
     DATA_CHECK(
-      code.operands().size() == 2, "assignment must have two operands");
+      vm, code.operands().size() == 2, "assignment must have two operands");
   }
 
   static void validate(
@@ -302,6 +302,7 @@ public:
     check(code, vm);
 
     DATA_CHECK(
+      vm,
       base_type_eq(code.op0().type(), code.op1().type(), ns),
       "lhs and rhs of assignment must have same type");
   }

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -777,7 +777,9 @@ public:
     const validation_modet vm = validation_modet::INVARIANT)
   {
     DATA_CHECK(
-      expr.operands().size() == 2, "binary expression must have two operands");
+      vm,
+      expr.operands().size() == 2,
+      "binary expression must have two operands");
   }
 
   static void validate(
@@ -859,6 +861,7 @@ public:
     binary_exprt::validate(expr, ns, vm);
 
     DATA_CHECK(
+      vm,
       expr.type().id() == ID_bool,
       "result of binary predicate expression should be of type bool");
   }
@@ -901,6 +904,7 @@ public:
 
     // check types
     DATA_CHECK(
+      vm,
       base_type_eq(expr.op0().type(), expr.op1().type(), ns),
       "lhs and rhs of binary relation expression should have same type");
   }

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -1149,7 +1149,8 @@ public:
     const typet &type,
     const validation_modet vm = validation_modet::INVARIANT)
   {
-    DATA_CHECK(!type.get(ID_width).empty(), "bitvector type must have width");
+    DATA_CHECK(
+      vm, !type.get(ID_width).empty(), "bitvector type must have width");
   }
 };
 

--- a/src/util/symbol_table.cpp
+++ b/src/util/symbol_table.cpp
@@ -130,6 +130,7 @@ void symbol_tablet::validate(const validation_modet vm) const
 
     // Check that symbols[id].name == id
     DATA_CHECK_WITH_DIAGNOSTICS(
+      vm,
       symbol.name == symbol_key,
       "Symbol table entry must map to a symbol with the correct identifier",
       "Symbol table key '",
@@ -152,6 +153,7 @@ void symbol_tablet::validate(const validation_modet vm) const
           }) != symbol_base_map.end();
 
       DATA_CHECK_WITH_DIAGNOSTICS(
+        vm,
         base_map_matches_symbol,
         "The base_name of a symbol should map to itself",
         "Symbol table key '",
@@ -174,6 +176,7 @@ void symbol_tablet::validate(const validation_modet vm) const
           }) != symbol_module_map.end();
 
       DATA_CHECK_WITH_DIAGNOSTICS(
+        vm,
         module_map_matches_symbol,
         "Symbol table module map should map to symbol",
         "Symbol table key '",
@@ -188,6 +191,7 @@ void symbol_tablet::validate(const validation_modet vm) const
   for(auto base_map_entry : symbol_base_map)
   {
     DATA_CHECK_WITH_DIAGNOSTICS(
+      vm,
       has_symbol(base_map_entry.second),
       "Symbol table base_name map entries must map to a symbol name",
       "base_name map entry '",
@@ -201,6 +205,7 @@ void symbol_tablet::validate(const validation_modet vm) const
   for(auto module_map_entry : symbol_module_map)
   {
     DATA_CHECK_WITH_DIAGNOSTICS(
+      vm,
       has_symbol(module_map_entry.second),
       "Symbol table module map entries must map to a symbol name",
       "base_name map entry '",

--- a/src/util/validate.h
+++ b/src/util/validate.h
@@ -15,18 +15,13 @@ Author: Daniel Poetzl
 #include "validation_mode.h"
 
 /// This macro takes a condition which denotes a well-formedness criterion on
-/// goto programs, expressions, instructions, etc. When invoking the macro, a
-/// variable named `vm` of type `const validation_modet` should be in scope. It
-/// indicates whether DATA_INVARIANT() is used to check the condition, or if an
-/// exception is thrown when the condition does not hold.
-#define DATA_CHECK(condition, message)                                         \
+/// goto programs, expressions, instructions, etc. The first parameter should be
+/// of type `validate_modet` and indicates whether DATA_INVARIANT() is used to
+/// check the condition, or if an exception is thrown when the condition does
+/// not hold.
+#define DATA_CHECK(vm, condition, message)                                     \
   do                                                                           \
   {                                                                            \
-    static_assert(                                                             \
-      std::is_same<decltype(vm), const validation_modet>::value,               \
-      "when invoking the macro DATA_CHECK(), a variable named `vm` of type "   \
-      "`const validation_modet` should be in scope which indicates the "       \
-      "validation mode (see `validate.h`");                                    \
     switch(vm)                                                                 \
     {                                                                          \
     case validation_modet::INVARIANT:                                          \
@@ -39,14 +34,9 @@ Author: Daniel Poetzl
     }                                                                          \
   } while(0)
 
-#define DATA_CHECK_WITH_DIAGNOSTICS(condition, message, ...)                   \
+#define DATA_CHECK_WITH_DIAGNOSTICS(vm, condition, message, ...)               \
   do                                                                           \
   {                                                                            \
-    static_assert(                                                             \
-      std::is_same<decltype(vm), const validation_modet>::value,               \
-      "when invoking the macro DATA_CHECK_WITH_DIAGNOSTICS(), a variable "     \
-      "named `vm` of type `const validation_modet` should be in scope which "  \
-      "indicates the validation mode (see `validate.h`");                      \
     switch(vm)                                                                 \
     {                                                                          \
     case validation_modet::INVARIANT:                                          \


### PR DESCRIPTION
As requested by @tautschnig in a comment to an earlier PR, this makes the validation mode an explicit parameter of the `DATA_CHECK()` macros.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
