### PR TITLE
Patch set for SV-COMP'19 [depends-on: #2000, #3462]

### DIFF
--- a/regression/cbmc/Local_out_of_scope4/main.c
+++ b/regression/cbmc/Local_out_of_scope4/main.c
@@ -1,0 +1,15 @@
+int main()
+{
+  int *p = 0;
+
+  for(int i = 0; i < 3; ++i)
+  {
+    {
+      int x = 42;
+      p = &x;
+      *p = 1;
+    }
+  }
+
+  return 0;
+}

--- a/regression/cbmc/Local_out_of_scope4/test.desc
+++ b/regression/cbmc/Local_out_of_scope4/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc/Memory_leak_abort/main.c
+++ b/regression/cbmc/Memory_leak_abort/main.c
@@ -1,0 +1,16 @@
+#include <stdlib.h>
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+int main()
+{
+  int *p = malloc(sizeof(int));
+  if(*p == 0)
+    abort();
+  if(*p == 1)
+    exit(1);
+  if(*p == 2)
+    _Exit(1);
+  free(p);
+  return 0;
+}

--- a/regression/cbmc/Memory_leak_abort/main.c
+++ b/regression/cbmc/Memory_leak_abort/main.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 
-extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_error() __attribute__((__noreturn__));
 
 int main()
 {
@@ -11,6 +11,8 @@ int main()
     exit(1);
   if(*p == 2)
     _Exit(1);
+  if(*p == 3)
+    __VERIFIER_error();
   free(p);
   return 0;
 }

--- a/regression/cbmc/Memory_leak_abort/test.desc
+++ b/regression/cbmc/Memory_leak_abort/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---memory-leak-check
+--memory-leak-check --no-assertions
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
@@ -8,5 +8,7 @@ _Exit\.memory-leak\.1.*FAILURE
 __CPROVER__start\.memory-leak\.1.*SUCCESS
 abort\.memory-leak\.1.*FAILURE
 exit\.memory-leak\.1.*FAILURE
+main\.memory-leak\.1.*FAILURE
 --
+main\.assertion\.1.*FAILURE
 ^warning: ignoring

--- a/regression/cbmc/Memory_leak_abort/test.desc
+++ b/regression/cbmc/Memory_leak_abort/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--memory-leak-check
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+_Exit\.memory-leak\.1.*FAILURE
+__CPROVER__start\.memory-leak\.1.*SUCCESS
+abort\.memory-leak\.1.*FAILURE
+exit\.memory-leak\.1.*FAILURE
+--
+^warning: ignoring

--- a/regression/cbmc/alloca1/main.c
+++ b/regression/cbmc/alloca1/main.c
@@ -1,0 +1,8 @@
+#include <stdlib.h>
+
+int main()
+{
+  int *p = alloca(sizeof(int));
+  *p = 42;
+  free(p);
+}

--- a/regression/cbmc/alloca1/test.desc
+++ b/regression/cbmc/alloca1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--pointer-check
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+free called for stack-allocated object: FAILURE$
+^\*\* 1 of 12 failed
+--
+^warning: ignoring

--- a/regression/cbmc/graphml_witness1/test.desc
+++ b/regression/cbmc/graphml_witness1/test.desc
@@ -7,26 +7,14 @@ main.c
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <key attr.name="invariant" attr.type="string" for="node" id="invariant"/>
   <key attr.name="invariant.scope" attr.type="string" for="node" id="invariant.scope"/>
-  <key attr.name="nodeType" attr.type="string" for="node" id="nodetype">
-    <default>path</default>
-  </key>
-  <key attr.name="isFrontierNode" attr.type="boolean" for="node" id="frontier">
-    <default>false</default>
-  </key>
   <key attr.name="isViolationNode" attr.type="boolean" for="node" id="violation">
     <default>false</default>
   </key>
   <key attr.name="isEntryNode" attr.type="boolean" for="node" id="entry">
     <default>false</default>
   </key>
-  <key attr.name="isSinkNode" attr.type="boolean" for="node" id="sink">
-    <default>false</default>
-  </key>
   <key attr.name="enterLoopHead" attr.type="boolean" for="edge" id="enterLoopHead">
     <default>false</default>
-  </key>
-  <key attr.name="threadNumber" attr.type="int" for="node" id="thread">
-    <default>0</default>
   </key>
   <key attr.name="sourcecodeLanguage" attr.type="string" for="graph" id="sourcecodelang"/>
   <key attr.name="programFile" attr.type="string" for="graph" id="programfile"/>
@@ -34,7 +22,6 @@ main.c
   <key attr.name="specification" attr.type="string" for="graph" id="specification"/>
   <key attr.name="architecture" attr.type="string" for="graph" id="architecture"/>
   <key attr.name="producer" attr.type="string" for="graph" id="producer"/>
-  <key attr.name="sourcecode" attr.type="string" for="edge" id="sourcecode"/>
   <key attr.name="startline" attr.type="int" for="edge" id="startline"/>
   <key attr.name="control" attr.type="string" for="edge" id="control"/>
   <key attr.name="assumption" attr.type="string" for="edge" id="assumption"/>
@@ -45,7 +32,6 @@ main.c
   <key attr.name="witness-type" attr.type="string" for="graph" id="witness-type"/>
   <graph edgedefault="directed">
     <data key="sourcecodelang">C</data>
-    <node id="sink"/>
     <node id="[0-9\.]*">
       <data key="entry">true</data>
     </node>
@@ -68,10 +54,6 @@ main.c
     <node id="[0-9\.]*">
       <data key="violation">true</data>
     </node>
-    <edge source="[0-9\.]*" target="sink">
-      <data key="originfile">main.c</data>
-      <data key="startline">31</data>
-    </edge>
   </graph>
 </graphml>
 --

--- a/regression/goto-analyzer/constant_propagation_01/test.desc
+++ b/regression/goto-analyzer/constant_propagation_01/test.desc
@@ -3,7 +3,7 @@ main.c
 --constants --simplify out.gb
 ^EXIT=0$
 ^SIGNAL=0$
-^Simplified:  assert: 1, assume: 0, goto: 1, assigns: 5, function calls: 0$
-^Unmodified:  assert: 0, assume: 0, goto: 0, assigns: 12, function calls: 2$
+^Simplified:  assert: 1, assume: 0, goto: 1, assigns: 6, function calls: 0$
+^Unmodified:  assert: 0, assume: 0, goto: 0, assigns: 15, function calls: 2$
 --
 ^warning: ignoring

--- a/regression/goto-analyzer/constant_propagation_02/test.desc
+++ b/regression/goto-analyzer/constant_propagation_02/test.desc
@@ -3,7 +3,7 @@ main.c
 --constants --simplify out.gb
 ^EXIT=0$
 ^SIGNAL=0$
-^Simplified:  assert: 1, assume: 0, goto: 1, assigns: 6, function calls: 0$
-^Unmodified:  assert: 0, assume: 0, goto: 0, assigns: 11, function calls: 2$
+^Simplified:  assert: 1, assume: 0, goto: 1, assigns: 7, function calls: 0$
+^Unmodified:  assert: 0, assume: 0, goto: 0, assigns: 14, function calls: 2$
 --
 ^warning: ignoring

--- a/regression/goto-instrument/print_global_state_size1/main.c
+++ b/regression/goto-instrument/print_global_state_size1/main.c
@@ -3,7 +3,7 @@
 uint32_t some_global_var;
 int8_t other_global_var;
 
-int main(int argc, char *argv[])
+int main()
 {
   return 0;
 }

--- a/scripts/delete_failing_smt2_solver_tests
+++ b/scripts/delete_failing_smt2_solver_tests
@@ -53,6 +53,7 @@ rm Malloc23/test.desc
 rm Malloc24/test.desc
 rm Memory_leak1/test.desc
 rm Memory_leak2/test.desc
+rm Memory_leak_abort/test.desc
 rm Multi_Dimensional_Array1/test.desc
 rm Multi_Dimensional_Array2/test.desc
 rm Multi_Dimensional_Array3/test.desc

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1708,7 +1708,8 @@ void goto_checkt::goto_check(
       if(
         enable_memory_leak_check && simplified_guard.is_false() &&
         (i.function == "abort" || i.function == "exit" ||
-         i.function == "_Exit"))
+         i.function == "_Exit" ||
+         (i.labels.size() == 1 && i.labels.front() == "__VERIFIER_abort")))
       {
         memory_leak_check(i.function);
       }

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1703,6 +1703,15 @@ void goto_checkt::goto_check(
     }
     else if(i.is_assume())
     {
+      // These are further 'exit points' of the program
+      const exprt simplified_guard = simplify_expr(i.guard, ns);
+      if(
+        enable_memory_leak_check && simplified_guard.is_false() &&
+        (i.function == "abort" || i.function == "exit" ||
+         i.function == "_Exit"))
+      {
+        memory_leak_check(i.function);
+      }
       if(!enable_assumptions)
       {
         i.make_skip();

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1711,6 +1711,34 @@ void goto_checkt::goto_check(
         }
       }
     }
+    else if(i.is_decl())
+    {
+      if(enable_pointer_check)
+      {
+        assert(i.code.operands().size()==1);
+        const symbol_exprt &variable=to_symbol_expr(i.code.op0());
+
+        // is it dirty?
+        if(local_bitvector_analysis->dirty(variable))
+        {
+          // reset the dead marker
+          goto_programt::targett t=new_code.add_instruction(ASSIGN);
+          exprt address_of_expr=address_of_exprt(variable);
+          exprt lhs=ns.lookup(CPROVER_PREFIX "dead_object").symbol_expr();
+          if(!base_type_eq(lhs.type(), address_of_expr.type(), ns))
+            address_of_expr.make_typecast(lhs.type());
+          exprt rhs=
+            if_exprt(
+              equal_exprt(lhs, address_of_expr),
+              null_pointer_exprt(to_pointer_type(address_of_expr.type())),
+              lhs,
+              lhs.type());
+          t->source_location=i.source_location;
+          t->code=code_assignt(lhs, rhs);
+          t->code.add_source_location()=i.source_location;
+        }
+      }
+    }
     else if(i.is_end_function())
     {
       if(i.function==goto_functionst::entry_point() &&

--- a/src/ansi-c/ansi_c_internal_additions.cpp
+++ b/src/ansi-c/ansi_c_internal_additions.cpp
@@ -136,6 +136,12 @@ void ansi_c_internal_additions(std::string &code)
     CPROVER_PREFIX "bool " CPROVER_PREFIX "threads_exited["
       CPROVER_PREFIX "constant_infinity_uint];\n"
     "unsigned long " CPROVER_PREFIX "next_thread_id=0;\n"
+    CPROVER_PREFIX "thread_local const void* " CPROVER_PREFIX "thread_keys["
+      CPROVER_PREFIX "constant_infinity_uint];\n"
+    CPROVER_PREFIX "thread_local void (*" CPROVER_PREFIX "thread_key_dtors["
+      CPROVER_PREFIX "constant_infinity_uint])(void *);\n"
+    CPROVER_PREFIX "thread_local unsigned long "
+      CPROVER_PREFIX "next_thread_key = 0;\n"
     "extern unsigned char " CPROVER_PREFIX "memory["
       CPROVER_PREFIX "constant_infinity_uint];\n"
 

--- a/src/ansi-c/ansi_c_internal_additions.cpp
+++ b/src/ansi-c/ansi_c_internal_additions.cpp
@@ -154,6 +154,7 @@ void ansi_c_internal_additions(std::string &code)
     "const void *" CPROVER_PREFIX "memory_leak=0;\n"
     "void *" CPROVER_PREFIX "allocate("
       CPROVER_PREFIX "size_t size, " CPROVER_PREFIX "bool zero);\n"
+    "const void *" CPROVER_PREFIX "alloca_object = 0;\n"
 
     // this is ANSI-C
     "extern " CPROVER_PREFIX "thread_local const char __func__["

--- a/src/ansi-c/c_typecheck_argc_argv.cpp
+++ b/src/ansi-c/c_typecheck_argc_argv.cpp
@@ -42,6 +42,7 @@ void c_typecheck_baset::add_argc_argv(const symbolt &main_symbol)
     argc_symbol.type=op0.type();
     argc_symbol.is_static_lifetime=true;
     argc_symbol.is_lvalue=true;
+    argc_symbol.value = side_effect_expr_nondett(op0.type());
 
     if(argc_symbol.type.id()!=ID_signedbv &&
        argc_symbol.type.id()!=ID_unsignedbv)
@@ -81,6 +82,7 @@ void c_typecheck_baset::add_argc_argv(const symbolt &main_symbol)
     argv_symbol.type=argv_type;
     argv_symbol.is_static_lifetime=true;
     argv_symbol.is_lvalue=true;
+    argv_symbol.value = side_effect_expr_nondett(argv_type);
 
     symbolt *argv_new_symbol;
     move_symbol(argv_symbol, argv_new_symbol);
@@ -99,6 +101,7 @@ void c_typecheck_baset::add_argc_argv(const symbolt &main_symbol)
     envp_size_symbol.name="envp_size'";
     envp_size_symbol.type=op0.type(); // same type as argc!
     envp_size_symbol.is_static_lifetime=true;
+    envp_size_symbol.value = side_effect_expr_nondett(op0.type());
     move_symbol(envp_size_symbol, envp_new_size_symbol);
 
     if(envp_symbol.type.id()!=ID_pointer)
@@ -113,6 +116,7 @@ void c_typecheck_baset::add_argc_argv(const symbolt &main_symbol)
 
     envp_symbol.type.id(ID_array);
     envp_symbol.type.add(ID_size).swap(size_expr);
+    envp_symbol.value = side_effect_expr_nondett(envp_symbol.type);
 
     symbolt *envp_new_symbol;
     move_symbol(envp_symbol, envp_new_symbol);

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -1972,14 +1972,14 @@ std::string expr2ct::convert_constant(
   {
     if(value==ID_NULL)
     {
-      dest="NULL";
+      dest="0";
       if(type.subtype().id()!=ID_empty)
         dest="(("+convert(type)+")"+dest+")";
     }
     else if(value==std::string(value.size(), '0') &&
             config.ansi_c.NULL_is_zero)
     {
-      dest="NULL";
+      dest="0";
       if(type.subtype().id()!=ID_empty)
         dest="(("+convert(type)+")"+dest+")";
     }

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -715,6 +715,7 @@ std::string expr2ct::convert_struct_type(
   if(tag!="")
     dest+=" "+id2string(tag);
 
+#if 0
   if(inc_struct_body)
   {
     dest+=" {";
@@ -737,6 +738,7 @@ std::string expr2ct::convert_struct_type(
 
     dest+=" }";
   }
+#endif
 
   dest+=declarator;
 

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -39,7 +39,8 @@ expr2c_configurationt expr2c_configurationt::default_configuration
   true,
   true,
   "TRUE",
-  "FALSE"
+  "FALSE",
+  "NULL"
 };
 
 expr2c_configurationt expr2c_configurationt::clean_configuration
@@ -48,6 +49,7 @@ expr2c_configurationt expr2c_configurationt::clean_configuration
   false,
   false,
   "1",
+  "0",
   "0"
 };
 
@@ -1972,14 +1974,14 @@ std::string expr2ct::convert_constant(
   {
     if(value==ID_NULL)
     {
-      dest="0";
+      dest = configuration.null_pointer_string;
       if(type.subtype().id()!=ID_empty)
         dest="(("+convert(type)+")"+dest+")";
     }
     else if(value==std::string(value.size(), '0') &&
             config.ansi_c.NULL_is_zero)
     {
-      dest="0";
+      dest = configuration.null_pointer_string;
       if(type.subtype().id()!=ID_empty)
         dest="(("+convert(type)+")"+dest+")";
     }

--- a/src/ansi-c/expr2c.h
+++ b/src/ansi-c/expr2c.h
@@ -36,17 +36,22 @@ struct expr2c_configurationt final
   /// This is the string that will be printed for the false boolean expression
   std::string false_string;
 
+  /// This is the string that will be printed for null pointers
+  std::string null_pointer_string;
+
   expr2c_configurationt(
     const bool include_struct_padding_components,
     const bool print_struct_body_in_type,
     const bool include_array_size,
     std::string true_string,
-    std::string false_string)
+    std::string false_string,
+    const std::string &null_pointer_string)
     : include_struct_padding_components(include_struct_padding_components),
       print_struct_body_in_type(print_struct_body_in_type),
       include_array_size(include_array_size),
       true_string(std::move(true_string)),
-      false_string(std::move(false_string))
+      false_string(std::move(false_string)),
+      null_pointer_string(null_pointer_string)
   {
   }
 

--- a/src/ansi-c/library/pthread_lib.c
+++ b/src/ansi-c/library/pthread_lib.c
@@ -674,8 +674,8 @@ inline int pthread_cond_wait(
   #endif
 
   __CPROVER_atomic_begin();
-  __CPROVER_assume(*((unsigned *)cond));
-  (*((unsigned *)cond))--;
+  if(*((unsigned *)cond))
+    (*((unsigned *)cond))--;
   __CPROVER_atomic_end();
 
   return 0; // we never fail

--- a/src/ansi-c/library/pthread_lib.c
+++ b/src/ansi-c/library/pthread_lib.c
@@ -293,10 +293,21 @@ inline int pthread_mutex_destroy(pthread_mutex_t *mutex)
 extern __CPROVER_bool __CPROVER_threads_exited[];
 extern __CPROVER_thread_local unsigned long __CPROVER_thread_id;
 
+extern __CPROVER_thread_local const void* __CPROVER_thread_keys[];
+extern __CPROVER_thread_local void (*__CPROVER_thread_key_dtors[])(void*);
+extern __CPROVER_thread_local unsigned long __CPROVER_next_thread_key;
+
 inline void pthread_exit(void *value_ptr)
 {
   __CPROVER_HIDE:;
   if(value_ptr!=0) (void)*(char*)value_ptr;
+  for(unsigned long i = 0; i < __CPROVER_next_thread_key; ++i)
+  {
+    const void *key = __CPROVER_thread_keys[i];
+    __CPROVER_thread_keys[i] = 0;
+    if(__CPROVER_thread_key_dtors[i] && key)
+      __CPROVER_thread_key_dtors[i](key);
+  }
   __CPROVER_threads_exited[__CPROVER_thread_id]=1;
   __CPROVER_assume(0);
 }
@@ -522,6 +533,40 @@ extern __CPROVER_bool __CPROVER_threads_exited[];
 extern __CPROVER_thread_local unsigned long __CPROVER_thread_id;
 extern unsigned long __CPROVER_next_thread_id;
 
+extern __CPROVER_thread_local const void* __CPROVER_thread_keys[];
+extern __CPROVER_thread_local void (*__CPROVER_thread_key_dtors[])(void*);
+extern __CPROVER_thread_local unsigned long __CPROVER_next_thread_key;
+
+inline void __spawned_thread(
+  unsigned long this_thread_id,
+  void (**thread_key_dtors)(void*),
+  unsigned long next_thread_key,
+  void * (*start_routine)(void *),
+  void *arg)
+{
+  __CPROVER_HIDE:;
+  __CPROVER_thread_id = this_thread_id;
+  __CPROVER_next_thread_key = next_thread_key;
+  for(unsigned long i = 0; i < __CPROVER_next_thread_key; ++i)
+    __CPROVER_thread_key_dtors[i] = thread_key_dtors[i];
+  #ifdef __CPROVER_CUSTOM_BITVECTOR_ANALYSIS
+  // Clear all locked mutexes; locking must happen in same thread.
+  __CPROVER_clear_must(0, "mutex-locked");
+  __CPROVER_clear_may(0, "mutex-locked");
+  #endif
+  start_routine(arg);
+  __CPROVER_fence("WWfence", "RRfence", "RWfence", "WRfence",
+                  "WWcumul", "RRcumul", "RWcumul", "WRcumul");
+  for(unsigned long i = 0; i < __CPROVER_next_thread_key; ++i)
+  {
+    const void *key = __CPROVER_thread_keys[i];
+    __CPROVER_thread_keys[i] = 0;
+    if(__CPROVER_thread_key_dtors[i] && key)
+      __CPROVER_thread_key_dtors[i](key);
+  }
+  __CPROVER_threads_exited[this_thread_id] = 1;
+}
+
 inline int pthread_create(
   pthread_t *thread, // must not be null
   const pthread_attr_t *attr, // may be null
@@ -543,17 +588,12 @@ inline int pthread_create(
 
   if(attr) (void)*attr;
 
+  unsigned long next_thread_key = __CPROVER_next_thread_key;
+  void (**thread_key_dtors)(void*) = __CPROVER_thread_key_dtors;
+
   __CPROVER_ASYNC_1:
-    __CPROVER_thread_id=this_thread_id,
-    #ifdef __CPROVER_CUSTOM_BITVECTOR_ANALYSIS
-    // Clear all locked mutexes; locking must happen in same thread.
-    __CPROVER_clear_must(0, "mutex-locked"),
-    __CPROVER_clear_may(0, "mutex-locked"),
-    #endif
-    start_routine(arg),
-    __CPROVER_fence("WWfence", "RRfence", "RWfence", "WRfence",
-                    "WWcumul", "RRcumul", "RWcumul", "WRcumul"),
-    __CPROVER_threads_exited[this_thread_id]=1;
+    __spawned_thread(
+      this_thread_id, thread_key_dtors, next_thread_key, start_routine, arg);
 
   return 0;
 }
@@ -807,3 +847,70 @@ inline int pthread_barrier_wait(pthread_barrier_t *barrier)
   return result;
 }
 #endif
+
+/* FUNCTION: pthread_key_create */
+
+#ifndef __CPROVER_PTHREAD_H_INCLUDED
+#include <pthread.h>
+#define __CPROVER_PTHREAD_H_INCLUDED
+#endif
+
+extern __CPROVER_thread_local const void* __CPROVER_thread_keys[];
+extern __CPROVER_thread_local void (*__CPROVER_thread_key_dtors[])(void*);
+extern __CPROVER_thread_local unsigned long __CPROVER_next_thread_key;
+
+inline int pthread_key_create(pthread_key_t *key, void (*destructor)(void*))
+{
+  __CPROVER_HIDE:;
+  __CPROVER_thread_keys[__CPROVER_next_thread_key] = 0;
+  __CPROVER_thread_key_dtors[__CPROVER_next_thread_key] = destructor;
+  *key = __CPROVER_next_thread_key++;
+  return 0;
+}
+
+/* FUNCTION: pthread_key_delete */
+
+#ifndef __CPROVER_PTHREAD_H_INCLUDED
+#include <pthread.h>
+#define __CPROVER_PTHREAD_H_INCLUDED
+#endif
+
+extern __CPROVER_thread_local const void* __CPROVER_thread_keys[];
+
+inline int pthread_key_delete(pthread_key_t key)
+{
+  __CPROVER_HIDE:;
+  __CPROVER_thread_keys[key] = 0;
+  return 0;
+}
+
+/* FUNCTION: pthread_getspecific */
+
+#ifndef __CPROVER_PTHREAD_H_INCLUDED
+#include <pthread.h>
+#define __CPROVER_PTHREAD_H_INCLUDED
+#endif
+
+extern __CPROVER_thread_local const void* __CPROVER_thread_keys[];
+
+inline void* pthread_getspecific(pthread_key_t key)
+{
+  __CPROVER_HIDE:;
+  return (void *)__CPROVER_thread_keys[key];
+}
+
+/* FUNCTION: pthread_setspecific */
+
+#ifndef __CPROVER_PTHREAD_H_INCLUDED
+#include <pthread.h>
+#define __CPROVER_PTHREAD_H_INCLUDED
+#endif
+
+extern __CPROVER_thread_local const void* __CPROVER_thread_keys[];
+
+inline int pthread_setspecific(pthread_key_t key, const void *value)
+{
+  __CPROVER_HIDE:;
+  __CPROVER_thread_keys[key] = value;
+  return 0;
+}

--- a/src/ansi-c/library/stdlib.c
+++ b/src/ansi-c/library/stdlib.c
@@ -147,6 +147,18 @@ inline void *__builtin_alloca(__CPROVER_size_t alloca_size)
   return res;
 }
 
+/* FUNCTION: alloca */
+
+#undef alloca
+
+void *__builtin_alloca(__CPROVER_size_t alloca_size);
+
+inline void *alloca(__CPROVER_size_t alloca_size)
+{
+  __CPROVER_HIDE:;
+  return __builtin_alloca(alloca_size);
+}
+
 /* FUNCTION: free */
 
 #undef free

--- a/src/ansi-c/library/stdlib.c
+++ b/src/ansi-c/library/stdlib.c
@@ -128,6 +128,7 @@ inline void *malloc(__CPROVER_size_t malloc_size)
 /* FUNCTION: __builtin_alloca */
 
 __CPROVER_bool __VERIFIER_nondet___CPROVER_bool();
+extern void *__CPROVER_alloca_object;
 
 inline void *__builtin_alloca(__CPROVER_size_t alloca_size)
 {
@@ -143,6 +144,10 @@ inline void *__builtin_alloca(__CPROVER_size_t alloca_size)
   __CPROVER_malloc_object=record_malloc?res:__CPROVER_malloc_object;
   __CPROVER_malloc_size=record_malloc?alloca_size:__CPROVER_malloc_size;
   __CPROVER_malloc_is_new_array=record_malloc?0:__CPROVER_malloc_is_new_array;
+
+  // record alloca to detect invalid free
+  __CPROVER_bool record_alloca = __VERIFIER_nondet___CPROVER_bool();
+  __CPROVER_alloca_object = record_alloca ? res : __CPROVER_alloca_object;
 
   return res;
 }
@@ -164,6 +169,7 @@ inline void *alloca(__CPROVER_size_t alloca_size)
 #undef free
 
 __CPROVER_bool __VERIFIER_nondet___CPROVER_bool();
+extern void *__CPROVER_alloca_object;
 
 inline void free(void *ptr)
 {
@@ -184,6 +190,11 @@ inline void free(void *ptr)
                          __CPROVER_malloc_object!=ptr ||
                          !__CPROVER_malloc_is_new_array,
                          "free called for new[] object");
+
+  // catch people who try to use free(...) with alloca
+  __CPROVER_precondition(
+    ptr == 0 || __CPROVER_alloca_object != ptr,
+    "free called for stack-allocated object");
 
   if(ptr!=0)
   {

--- a/src/cpp/cpp_internal_additions.cpp
+++ b/src/cpp/cpp_internal_additions.cpp
@@ -72,6 +72,16 @@ void cpp_internal_additions(std::ostream &out)
       << CPROVER_PREFIX "threads_exited[__CPROVER::constant_infinity_uint];"
       << '\n';
   out << "unsigned long " CPROVER_PREFIX "next_thread_id = 0;" << '\n';
+  // TODO: thread_local is still broken
+  out << "void* "
+      << CPROVER_PREFIX "thread_keys[__CPROVER::constant_infinity_uint];"
+      << '\n';
+  // TODO: thread_local is still broken
+  out << "void (*"
+      << CPROVER_PREFIX "thread_key_dtors[__CPROVER::constant_infinity_uint])"
+      << "(void *);" << '\n';
+  // TODO: thread_local is still broken
+  out << "unsigned long " CPROVER_PREFIX "next_thread_key = 0;" << '\n';
   out << "extern unsigned char "
       << CPROVER_PREFIX "memory[__CPROVER::constant_infinity_uint];" << '\n';
 

--- a/src/cpp/cpp_internal_additions.cpp
+++ b/src/cpp/cpp_internal_additions.cpp
@@ -95,6 +95,7 @@ void cpp_internal_additions(std::ostream &out)
   out << "const void *" CPROVER_PREFIX "memory_leak = 0;" << '\n';
   out << "void *" CPROVER_PREFIX "allocate("
       << CPROVER_PREFIX "size_t size, " CPROVER_PREFIX "bool zero);" << '\n';
+  out << "const void *" CPROVER_PREFIX "alloca_object = 0;" << '\n';
 
   // auxiliaries for new/delete
   out << "void *__new(__CPROVER::size_t);" << '\n';

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -711,6 +711,7 @@ void goto_convertt::do_function_call_symbol(
     // are being checked
     goto_programt::targett a=dest.add_instruction(ASSUME);
     a->guard=false_exprt();
+    a->labels.push_back("__VERIFIER_abort");
     a->source_location=function.source_location();
     a->source_location.set("user-provided", true);
   }

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -17,6 +17,7 @@ Author: Daniel Kroening
 #include <util/byte_operators.h>
 #include <util/c_types.h>
 #include <util/arith_tools.h>
+#include <util/cprover_prefix.h>
 #include <util/prefix.h>
 #include <util/ssa_expr.h>
 #include <util/std_pair_hash.h>
@@ -221,7 +222,11 @@ static bool filter_out(
      source_location.get_file().empty() ||
      source_location.is_built_in() ||
      source_location.get_line().empty())
-    return true;
+  {
+    const irep_idt id=source_location.get_function();
+    if(!(has_prefix(id2string(id), CPROVER_PREFIX) && it->is_assert()))
+      return true;
+  }
 
   return false;
 }
@@ -337,6 +342,7 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
     graphml[node].line=source_location.get_line();
     graphml[node].is_violation=
       it->type==goto_trace_stept::typet::ASSERT && !it->cond_value;
+
     graphml[node].has_invariant=false;
 
     step_to_node[it->step_nr]=node;

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -542,17 +542,6 @@ void graphml_witnesst::operator()(const symex_target_equationt &equation)
           graphml[to].invariant_scope=
             id2string(it->source.pc->source_location.get_function());
         }
-        else if(it->is_goto() &&
-                it->source.pc->is_goto())
-        {
-          xmlt &val=edge.new_element("data");
-          val.set_attribute("key", "sourcecode");
-          exprt clean_cond=it->cond_expr;
-          remove_l0_l1(clean_cond);
-          const std::string cond=expr_to_string(ns, it->source.function, clean_cond);
-            from_expr(ns, it->source.function, not_exprt(clean_cond));
-          val.data="["+cond+"]";
-        }
 
         graphml[to].in[from].xml_node=edge;
         graphml[from].out[to].xml_node=edge;

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -17,6 +17,8 @@ Author: Daniel Kroening
 #include <util/arith_tools.h>
 #include <util/prefix.h>
 #include <util/ssa_expr.h>
+#include <util/std_pair_hash.h>
+#include <unordered_map>
 
 #include <langapi/language_util.h>
 #include <langapi/mode.h>
@@ -66,6 +68,13 @@ std::string graphml_witnesst::convert_assign_rec(
   const irep_idt &identifier,
   const code_assignt &assign)
 {
+  static std::unordered_map<std::pair<unsigned int, const irept::dt *>, std::string> cache;
+  {
+      const auto cit = cache.find({identifier.get_no(), &assign.read()});
+      if(cit != cache.end())
+          return cit->second;
+  }
+
   std::string result;
 
   if(assign.rhs().id()==ID_array)
@@ -151,6 +160,7 @@ std::string graphml_witnesst::convert_assign_rec(
     result=lhs+" = "+expr_to_string(ns, identifier, clean_rhs)+";";
   }
 
+  cache.insert({{identifier.get_no(), &assign.read()}, result});
   return result;
 }
 

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -79,7 +79,29 @@ std::string graphml_witnesst::convert_assign_rec(
 
   std::string result;
 
-  if(assign.rhs().id()==ID_array)
+  if(assign.rhs().id()=="array-list")
+  {
+    const array_typet &type=
+      to_array_type(ns.follow(assign.rhs().type()));
+
+    const auto ops=assign.rhs().operands();
+    DATA_INVARIANT(
+      ops.size()%2==0,
+      "array-list has odd number of operands");
+
+    for(size_t listidx=0; listidx!=ops.size(); listidx+=2)
+    {
+      index_exprt index(
+        assign.lhs(),
+        ops[listidx],
+        type.subtype());
+      if(!result.empty())
+        result+=' ';
+      result+=
+        convert_assign_rec(identifier, code_assignt(index, ops[listidx+1]));
+    }
+  }
+  else if(assign.rhs().id()==ID_array)
   {
     const array_typet &type=
       to_array_type(ns.follow(assign.rhs().type()));
@@ -163,7 +185,6 @@ std::string graphml_witnesst::convert_assign_rec(
 
     result=lhs+" = "+expr_to_string(ns, identifier, clean_rhs)+";";
   }
-
   cache.insert({{identifier.get_no(), &assign.read()}, result});
   return result;
 }
@@ -200,6 +221,21 @@ static bool filter_out(
      source_location.get_line().empty())
     return true;
 
+  return false;
+}
+
+static bool contains_symbol_prefix(const exprt &expr, const std::string &prefix){
+  if(expr.id()==ID_symbol &&
+     has_prefix(id2string(to_symbol_expr(expr).get_identifier()), prefix))
+  {
+    return true;
+  }
+
+  forall_operands(it, expr)
+  {
+    if(contains_symbol_prefix(*it, prefix))
+      return true;
+  }
   return false;
 }
 
@@ -314,30 +350,37 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
 
         if(it->type==goto_trace_stept::typet::ASSIGNMENT &&
            it->full_lhs_value.is_not_nil() &&
-           it->full_lhs.is_not_nil())
+           it->full_lhs.is_not_nil() &&
+           it->full_lhs.id() == ID_symbol)
         {
-          if(id2string(it->lhs_object.get_identifier())
+          const symbol_exprt &lhs_symbol = to_symbol_expr(it->full_lhs);
+          if(id2string(lhs_symbol.get_identifier())
              .find("pthread_create::thread")!=std::string::npos)
           {
             xmlt &data_t=edge.new_element("data");
             data_t.set_attribute("key", "createThread");
             data_t.data=std::to_string(++thread_id);
           }
-          else if(id2string(it->lhs_object.get_identifier())
-               .find("#return_value")==std::string::npos &&
-             id2string(it->lhs_object.get_identifier())
-               .find("thread")==std::string::npos &&
-             id2string(it->lhs_object.get_identifier())
-               .find("mutex")==std::string::npos &&
-             (!it->lhs_object_value.is_constant() ||
-              !it->lhs_object_value.has_operands() ||
-              !has_prefix(id2string(it->lhs_object_value.op0().get(ID_value)),
-                          "INVALID-")))
+          else if(
+            id2string(lhs_symbol.get_identifier())
+              .find("#return_value")==std::string::npos &&
+            !contains_symbol_prefix(
+              it->full_lhs_value, "symex_dynamic::dynamic_object") &&
+            !contains_symbol_prefix(
+              it->full_lhs, "symex_dynamic::dynamic_object") &&
+            id2string(lhs_symbol.get_identifier())
+              .find("thread")==std::string::npos &&
+            id2string(lhs_symbol.get_identifier())
+              .find("mutex")==std::string::npos &&
+            (!it->full_lhs_value.is_constant() ||
+             !it->full_lhs_value.has_operands() ||
+             !has_prefix(id2string(it->full_lhs_value.op0().get(ID_value)),
+                         "INVALID-")))
           {
             xmlt &val=edge.new_element("data");
             val.set_attribute("key", "assumption");
             code_assignt assign(it->full_lhs, it->full_lhs_value);
-            irep_idt identifier=it->full_lhs.get_identifier();
+            irep_idt identifier=lhs_symbol.get_identifier();
             val.data=convert_assign_rec(identifier, assign);
 
             xmlt &val_s=edge.new_element("data");

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -348,35 +348,6 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
         else if(it->type==goto_trace_stept::typet::GOTO &&
                 it->pc->is_goto())
         {
-          xmlt &val=edge.new_element("data");
-          val.set_attribute("key", "sourcecode");
-          exprt clean_cond=it->cond_expr;
-          remove_l0_l1(clean_cond);
-          const std::string cond=expr_to_string(ns, it->function, clean_cond);
-          const std::string neg_cond=
-            from_expr(ns, it->function, not_exprt(clean_cond));
-          val.data="["+(it->cond_value ? cond : neg_cond)+"]";
-
-          #if 0
-          xmlt edge2("edge");
-          edge2.set_attribute("source", graphml[from].node_name);
-          edge2.set_attribute("target", graphml[sink].node_name);
-
-          xmlt &data_f2=edge2.new_element("data");
-          data_f2.set_attribute("key", "originfile");
-          data_f2.data=id2string(graphml[from].file);
-
-          xmlt &data_l2=edge2.new_element("data");
-          data_l2.set_attribute("key", "startline");
-          data_l2.data=id2string(graphml[from].line);
-
-          xmlt &val2=edge2.new_element("data");
-          val2.set_attribute("key", "sourcecode");
-          val2.data="["+(it->cond_value ? neg_cond : cond)+"]";
-
-          graphml[sink].in[from].xml_node=edge2;
-          graphml[from].out[sink].xml_node=edge2;
-          #endif
         }
 
         graphml[to].in[from].xml_node=edge;

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -155,7 +155,9 @@ std::string graphml_witnesst::convert_assign_rec(
     exprt clean_rhs=assign.rhs();
     remove_l0_l1(clean_rhs);
 
-    std::string lhs=expr_to_string(ns, identifier, assign.lhs());
+    exprt clean_lhs=assign.lhs();
+    remove_l0_l1(clean_lhs);
+    std::string lhs=expr_to_string(ns, identifier, clean_lhs);
     if(lhs.find('$')!=std::string::npos)
       lhs="\\result";
 
@@ -348,10 +350,11 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
         {
           xmlt &val=edge.new_element("data");
           val.set_attribute("key", "sourcecode");
-          const std::string cond =
-            expr_to_string(ns, it->function, it->cond_expr);
-          const std::string neg_cond =
-            expr_to_string(ns, it->function, not_exprt(it->cond_expr));
+          exprt clean_cond=it->cond_expr;
+          remove_l0_l1(clean_cond);
+          const std::string cond=expr_to_string(ns, it->function, clean_cond);
+          const std::string neg_cond=
+            from_expr(ns, it->function, not_exprt(clean_cond));
           val.data="["+(it->cond_value ? cond : neg_cond)+"]";
 
           #if 0
@@ -530,8 +533,10 @@ void graphml_witnesst::operator()(const symex_target_equationt &equation)
         {
           xmlt &val=edge.new_element("data");
           val.set_attribute("key", "sourcecode");
-          const std::string cond =
-            expr_to_string(ns, it->source.function, it->cond_expr);
+          exprt clean_cond=it->cond_expr;
+          remove_l0_l1(clean_cond);
+          const std::string cond=expr_to_string(ns, it->source.function, clean_cond);
+            from_expr(ns, it->source.function, not_exprt(clean_cond));
           val.data="["+cond+"]";
         }
 

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -254,7 +254,8 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
   {
     const std::size_t from=step_to_node[it->step_nr];
 
-    if(from==sink)
+    // no outgoing edges from sinks or violation nodes
+    if(from==sink || graphml[from].is_violation)
     {
       ++it;
       continue;

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -180,7 +180,9 @@ std::string graphml_witnesst::convert_assign_rec(
     exprt clean_lhs=assign.lhs();
     remove_l0_l1(clean_lhs);
     std::string lhs=expr_to_string(ns, identifier, clean_lhs);
-    if(lhs.find('$')!=std::string::npos)
+    if(lhs.find("#return_value")!=std::string::npos ||
+       (lhs.find('$')!=std::string::npos &&
+        lhs.find("return_value___VERIFIER_nondet_")==0U))
       lhs="\\result";
 
     result=lhs+" = "+expr_to_string(ns, identifier, clean_rhs)+";";

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -38,6 +38,7 @@ goto_symex_statet::goto_symex_statet()
 
 goto_symex_statet::~goto_symex_statet()=default;
 
+#if 0
 /// write to a variable
 static bool check_renaming(const exprt &expr);
 
@@ -120,10 +121,11 @@ static bool check_renaming(const exprt &expr)
 
   return false;
 }
+#endif
 
 static void assert_l1_renaming(const exprt &expr)
 {
-  #if 1
+  #if 0
   if(check_renaming_l1(expr))
   {
     std::cerr << expr.pretty() << '\n';
@@ -136,7 +138,7 @@ static void assert_l1_renaming(const exprt &expr)
 
 static void assert_l2_renaming(const exprt &expr)
 {
-  #if 1
+  #if 0
   if(check_renaming(expr))
   {
     std::cerr << expr.pretty() << '\n';

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -218,17 +218,6 @@ void goto_symext::symex_assign_symbol(
   guardt &guard,
   assignment_typet assignment_type)
 {
-  // do not assign to L1 objects that have gone out of scope --
-  // pointer dereferencing may yield such objects; parameters do not
-  // have an L2 entry set up beforehand either, so exempt them from
-  // this check (all other L1 objects should have seen a declaration)
-  const symbolt *s;
-  if(!ns.lookup(lhs.get_object_name(), s) &&
-     !s->is_parameter &&
-     !lhs.get_level_1().empty() &&
-     state.level2.current_count(lhs.get_identifier())==0)
-    return;
-
   exprt ssa_rhs=rhs;
 
   // put assignment guard into the rhs

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -184,18 +184,20 @@ void goto_symext::symex_allocate(
 
   exprt rhs;
 
+  symbol_exprt v=value_symbol.symbol_expr();
+  v.add("#dynamic_guard", state.guard);
+
   if(object_type.id()==ID_array)
   {
-    const auto &array_type = to_array_type(object_type);
+    const auto &array_type = to_array_type(value_symbol.type);
     index_exprt index_expr(array_type.subtype());
-    index_expr.array()=value_symbol.symbol_expr();
+    index_expr.array() = v;
     index_expr.index()=from_integer(0, index_type());
     rhs = address_of_exprt(index_expr, pointer_type(array_type.subtype()));
   }
   else
   {
-    rhs=address_of_exprt(
-      value_symbol.symbol_expr(), pointer_type(value_symbol.type));
+    rhs = address_of_exprt(v, pointer_type(value_symbol.type));
   }
 
   if(rhs.type()!=lhs.type())

--- a/src/goto-symex/symex_decl.cpp
+++ b/src/goto-symex/symex_decl.cpp
@@ -66,11 +66,8 @@ void goto_symext::symex_decl(statet &state, const symbol_exprt &expr)
   state.propagation.erase(l1_identifier);
 
   // L2 renaming
-  // inlining may yield multiple declarations of the same identifier
-  // within the same L1 context
-  if(state.level2.current_names.find(l1_identifier)==
-     state.level2.current_names.end())
-    state.level2.current_names[l1_identifier]=std::make_pair(ssa, 0);
+  state.level2.current_names.insert(
+    std::make_pair(l1_identifier, std::make_pair(ssa, 0)));
   state.level2.increase_counter(l1_identifier);
   const bool record_events=state.record_events;
   state.record_events=false;

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -452,17 +452,23 @@ void goto_symext::phi_function(
     //  1. Either guard is false, so we can't follow that branch.
     //  2. Either identifier is of generation zero, and so hasn't been
     //     initialized and therefor an invalid target.
-    if(dest_state.guard.is_false())
-      rhs=goto_state_rhs;
-    else if(goto_state.guard.is_false())
-      rhs=dest_state_rhs;
-    else if(goto_state.level2_current_count(l1_identifier) == 0)
+    if(
+      dest_state.guard.is_false() ||
+      dest_state.level2.current_count(l1_identifier) == 0)
     {
-      rhs = dest_state_rhs;
-    }
-    else if(dest_state.level2.current_count(l1_identifier) == 0)
-    {
+      if(goto_state.level2_current_count(l1_identifier) == 0)
+        continue;
+
       rhs = goto_state_rhs;
+    }
+    else if(
+      goto_state.guard.is_false() ||
+      goto_state.level2_current_count(l1_identifier) == 0)
+    {
+      if(dest_state.level2.current_count(l1_identifier) == 0)
+        continue;
+
+      rhs = dest_state_rhs;
     }
     else
     {

--- a/src/linking/static_lifetime_init.cpp
+++ b/src/linking/static_lifetime_init.cpp
@@ -67,11 +67,7 @@ void static_lifetime_init(
        identifier==CPROVER_PREFIX "memory" ||
        identifier=="__func__" ||
        identifier=="__FUNCTION__" ||
-       identifier=="__PRETTY_FUNCTION__" ||
-       identifier=="argc'" ||
-       identifier=="argv'" ||
-       identifier=="envp'" ||
-       identifier=="envp_size'")
+       identifier=="__PRETTY_FUNCTION__")
       continue;
 
     // just for linking

--- a/src/linking/static_lifetime_init.cpp
+++ b/src/linking/static_lifetime_init.cpp
@@ -63,12 +63,13 @@ void static_lifetime_init(
       continue;
 
     // special values
-    if(identifier==CPROVER_PREFIX "constant_infinity_uint" ||
-       identifier==CPROVER_PREFIX "memory" ||
-       identifier=="__func__" ||
-       identifier=="__FUNCTION__" ||
-       identifier=="__PRETTY_FUNCTION__")
+    if(
+      identifier == CPROVER_PREFIX "constant_infinity_uint" ||
+      identifier == CPROVER_PREFIX "memory" || identifier == "__func__" ||
+      identifier == "__FUNCTION__" || identifier == "__PRETTY_FUNCTION__")
+    {
       continue;
+    }
 
     // just for linking
     if(has_prefix(id, CPROVER_PREFIX "architecture_"))

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -12,7 +12,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/c_types.h>
 #include <util/config.h>
 #include <util/exception_utils.h>
+#include <util/invariant.h>
 #include <util/pointer_offset_size.h>
+#include <util/prefix.h>
+#include <util/ssa_expr.h>
+#include <util/std_expr.h>
 
 literalt bv_pointerst::convert_rest(const exprt &expr)
 {
@@ -25,24 +29,15 @@ literalt bv_pointerst::convert_rest(const exprt &expr)
     if(operands.size()==1 &&
        operands[0].type().id()==ID_pointer)
     {
-      const bvt &bv=convert_bv(operands[0]);
+      // we postpone
+      literalt l=prop.new_variable();
 
-      if(!bv.empty())
-      {
-        bvt invalid_bv;
-        encode(pointer_logic.get_invalid_object(), invalid_bv);
+      postponed_list.push_back(postponedt());
+      postponed_list.back().op=convert_bv(operands[0]);
+      postponed_list.back().bv.push_back(l);
+      postponed_list.back().expr=expr;
 
-        bvt equal_invalid_bv;
-        equal_invalid_bv.resize(object_bits);
-
-        for(std::size_t i=0; i<object_bits; i++)
-        {
-          equal_invalid_bv[i]=prop.lequal(bv[offset_bits+i],
-                                          invalid_bv[offset_bits+i]);
-        }
-
-        return prop.land(equal_invalid_bv);
-      }
+      return l;
     }
   }
   else if(expr.id()==ID_dynamic_object)
@@ -819,6 +814,78 @@ void bv_pointerst::do_postponed(
 
       prop.l_set_to(prop.limplies(l1, l2), true);
     }
+  }
+  else if(postponed.expr.id()==ID_invalid_pointer)
+  {
+    const pointer_logict::objectst &objects=pointer_logic.objects;
+
+    bvt disj;
+    disj.reserve(objects.size());
+
+    bvt saved_bv=postponed.op;
+    saved_bv.erase(saved_bv.begin(), saved_bv.begin()+offset_bits);
+
+    bvt invalid_bv, null_bv;
+    encode(pointer_logic.get_invalid_object(), invalid_bv);
+    invalid_bv.erase(invalid_bv.begin(), invalid_bv.begin()+offset_bits);
+    encode(pointer_logic.get_null_object(),    null_bv);
+    null_bv.erase(null_bv.begin(), null_bv.begin()+offset_bits);
+
+    disj.push_back(bv_utils.equal(saved_bv, invalid_bv));
+    disj.push_back(bv_utils.equal(saved_bv, null_bv));
+
+    // compare object part to non-allocated dynamic objects
+    std::size_t number=0;
+
+    for(pointer_logict::objectst::const_iterator
+        it=objects.begin();
+        it!=objects.end();
+        it++, number++)
+    {
+      const exprt &expr=*it;
+
+      if(!pointer_logic.is_dynamic_object(expr) ||
+         !is_ssa_expr(expr))
+        continue;
+
+      // only compare object part
+      bvt bv;
+      encode(number, bv);
+
+      bv.erase(bv.begin(), bv.begin()+offset_bits);
+      assert(bv.size()==saved_bv.size());
+
+      literalt l1=bv_utils.equal(bv, saved_bv);
+
+      const ssa_exprt &ssa=to_ssa_expr(expr);
+
+      const exprt &guard=
+        static_cast<const exprt&>(
+          ssa.get_original_expr().find("#dynamic_guard"));
+
+      if(guard.is_nil())
+        continue;
+
+      const bvt &guard_bv=convert_bv(guard);
+      assert(guard_bv.size()==1);
+      literalt l_guard=guard_bv[0];
+
+      disj.push_back(prop.land(!l_guard, l1));
+    }
+
+    // compare object part to max object number
+    bvt bv;
+    encode(number, bv);
+
+    bv.erase(bv.begin(), bv.begin()+offset_bits);
+    assert(bv.size()==saved_bv.size());
+
+    disj.push_back(
+      bv_utils.rel(saved_bv, ID_ge, bv, bv_utilst::representationt::UNSIGNED));
+
+    assert(postponed.bv.size()==1);
+    literalt l=postponed.bv.front();
+    prop.l_set_to(prop.lequal(prop.lor(disj), l), true);
   }
   else
     UNREACHABLE;

--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -27,6 +27,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "string2int.h"
 #include "string_utils.h"
 
+#include <map>
 #include <ostream>
 #include <stack>
 

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -23,7 +23,7 @@ Author: Daniel Kroening, kroening@kroening.com
 // #define SUB_IS_LIST
 
 #ifdef SUB_IS_LIST
-#include <list>
+#include <forward_list>
 #else
 #include <map>
 #endif
@@ -164,7 +164,7 @@ public:
   // memory and increase efficiency.
 
   #ifdef SUB_IS_LIST
-  typedef std::list<std::pair<irep_namet, irept> > named_subt;
+  typedef std::forward_list<std::pair<irep_namet, irept> > named_subt;
   #else
   typedef std::map<irep_namet, irept> named_subt;
   #endif

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -18,9 +18,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "irep_ids.h"
 
 #define SHARING
-// #define HASH_CODE
+#define HASH_CODE
 #define USE_MOVE
-// #define SUB_IS_LIST
+#define SUB_IS_LIST
 
 #ifdef SUB_IS_LIST
 #include <forward_list>

--- a/src/util/irep_hash_container.cpp
+++ b/src/util/irep_hash_container.cpp
@@ -51,9 +51,16 @@ void irep_hash_container_baset::pack(
   const irept::named_subt &named_sub=irep.get_named_sub();
   const irept::named_subt &comments=irep.get_comments();
 
-  packed.reserve(
-    1+1+sub.size()+named_sub.size()*2+
-    (full?comments.size()*2:0));
+#ifdef SUB_IS_LIST
+  const std::size_t named_sub_size =
+    std::distance(named_sub.begin(), named_sub.end());
+  const std::size_t comments_size = full ?
+    std::distance(comments.begin(), comments.end()) : 0;
+#else
+  const std::size_t named_sub_size = named_sub.size();
+  const std::size_t comments_size = full ? comments.size() : 0;
+#endif
+  packed.reserve(1 + 1 + sub.size() + named_sub_size * 2 + comments_size * 2);
 
   packed.push_back(irep_id_hash()(irep.id()));
 
@@ -61,7 +68,7 @@ void irep_hash_container_baset::pack(
   forall_irep(it, sub)
     packed.push_back(number(*it));
 
-  packed.push_back(named_sub.size());
+  packed.push_back(named_sub_size);
   forall_named_irep(it, named_sub)
   {
     packed.push_back(irep_id_hash()(it->first)); // id
@@ -70,7 +77,7 @@ void irep_hash_container_baset::pack(
 
   if(full)
   {
-    packed.push_back(comments.size());
+    packed.push_back(comments_size);
     forall_named_irep(it, comments)
     {
       packed.push_back(irep_id_hash()(it->first)); // id

--- a/src/util/lispirep.cpp
+++ b/src/util/lispirep.cpp
@@ -46,9 +46,17 @@ void irep2lisp(const irept &src, lispexprt &dest)
   dest.value="";
   dest.type=lispexprt::List;
 
-  dest.reserve(2+2*src.get_sub().size()
-                +2*src.get_named_sub().size()
-                +2*src.get_comments().size());
+#ifdef SUB_IS_LIST
+  const std::size_t named_sub_size =
+    std::distance(src.get_named_sub().begin(), src.get_named_sub().end());
+  const std::size_t comments_size =
+    std::distance(src.get_comments().begin(), src.get_comments().end());
+#else
+  const std::size_t named_sub_size = src.get_named_sub().size();
+  const std::size_t comments_size = src.get_comments().size();
+#endif
+  dest.reserve(
+    2 + 2 * src.get_sub().size() + 2 * named_sub_size + 2 * comments_size);
 
   lispexprt id;
   id.type=lispexprt::String;

--- a/src/util/merge_irep.cpp
+++ b/src/util/merge_irep.cpp
@@ -28,7 +28,13 @@ std::size_t to_be_merged_irept::hash() const
         result, static_cast<const merged_irept &>(it->second).hash());
   }
 
-  result=hash_finalize(result, named_sub.size()+sub.size());
+#ifdef SUB_IS_LIST
+  const std::size_t named_sub_size =
+    std::distance(named_sub.begin(), named_sub.end());
+#else
+  const std::size_t named_sub_size = named_sub.size();
+#endif
+  result = hash_finalize(result, named_sub_size + sub.size());
 
   return result;
 }
@@ -44,9 +50,16 @@ bool to_be_merged_irept::operator == (const to_be_merged_irept &other) const
   const irept::named_subt &o_named_sub=other.get_named_sub();
 
   if(sub.size()!=o_sub.size())
-    return true;
+    return false;
+#ifdef SUB_IS_LIST
+  if(
+    std::distance(named_sub.begin(), named_sub.end()) !=
+    std::distance(o_named_sub.begin(), o_named_sub.end()))
+    return false;
+#else
   if(named_sub.size()!=o_named_sub.size())
-    return true;
+    return false;
+#endif
 
   {
     irept::subt::const_iterator s_it=sub.begin();
@@ -95,13 +108,19 @@ const merged_irept &merged_irepst::merged(const irept &irep)
   const irept::named_subt &src_named_sub=irep.get_named_sub();
   irept::named_subt &dest_named_sub=new_irep.get_named_sub();
 
+#ifdef SUB_IS_LIST
+  irept::named_subt::iterator before = dest_named_sub.before_begin();
+#endif
   forall_named_irep(it, src_named_sub)
+  {
     #ifdef SUB_IS_LIST
-    dest_named_sub.push_back(
-      std::make_pair(it->first, merged(it->second))); // recursive call
+    dest_named_sub.emplace_after(
+      before, it->first, merged(it->second)); // recursive call
+    ++before;
     #else
     dest_named_sub[it->first]=merged(it->second); // recursive call
     #endif
+  }
 
   std::pair<to_be_merged_irep_storet::const_iterator, bool> result=
     to_be_merged_irep_store.insert(to_be_merged_irept(new_irep));
@@ -140,24 +159,36 @@ const irept &merge_irept::merged(const irept &irep)
   const irept::named_subt &src_named_sub=irep.get_named_sub();
   irept::named_subt &dest_named_sub=new_irep.get_named_sub();
 
+#ifdef SUB_IS_LIST
+  irept::named_subt::iterator before = dest_named_sub.before_begin();
+#endif
   forall_named_irep(it, src_named_sub)
+  {
     #ifdef SUB_IS_LIST
-    dest_named_sub.push_back(
-      std::make_pair(it->first, merged(it->second))); // recursive call
+    dest_named_sub.emplace_after(
+      before, it->first, merged(it->second)); // recursive call
+    ++before;
     #else
     dest_named_sub[it->first]=merged(it->second); // recursive call
     #endif
+  }
 
   const irept::named_subt &src_comments=irep.get_comments();
   irept::named_subt &dest_comments=new_irep.get_comments();
 
+#ifdef SUB_IS_LIST
+  before = dest_comments.before_begin();
+#endif
   forall_named_irep(it, src_comments)
+  {
     #ifdef SUB_IS_LIST
-    dest_comments.push_back(
-      std::make_pair(it->first, merged(it->second))); // recursive call
+    dest_comments.emplace_after(
+      before, it->first, merged(it->second)); // recursive call
+    ++before;
     #else
     dest_comments[it->first]=merged(it->second); // recursive call
     #endif
+  }
 
   return *irep_store.insert(new_irep).first;
 }
@@ -188,24 +219,36 @@ const irept &merge_full_irept::merged(const irept &irep)
   const irept::named_subt &src_named_sub=irep.get_named_sub();
   irept::named_subt &dest_named_sub=new_irep.get_named_sub();
 
+#ifdef SUB_IS_LIST
+  irept::named_subt::iterator before = dest_named_sub.before_begin();
+#endif
   forall_named_irep(it, src_named_sub)
+  {
     #ifdef SUB_IS_LIST
-    dest_named_sub.push_back(
-      std::make_pair(it->first, merged(it->second))); // recursive call
+    dest_named_sub.emplace_after(
+      before, it->first, merged(it->second)); // recursive call
+    ++before;
     #else
     dest_named_sub[it->first]=merged(it->second); // recursive call
     #endif
+  }
 
   const irept::named_subt &src_comments=irep.get_comments();
   irept::named_subt &dest_comments=new_irep.get_comments();
 
+#ifdef SUB_IS_LIST
+  before = dest_comments.before_begin();
+#endif
   forall_named_irep(it, src_comments)
+  {
     #ifdef SUB_IS_LIST
-    dest_comments.push_back(
-      std::make_pair(it->first, merged(it->second))); // recursive call
+    dest_comments.emplace_after(
+      before, it->first, merged(it->second)); // recursive call
+    ++before;
     #else
     dest_comments[it->first]=merged(it->second); // recursive call
     #endif
+  }
 
   return *irep_store.insert(new_irep).first;
 }

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2127,7 +2127,7 @@ bool simplify_exprt::simplify_node(exprt &expr)
 
   bool result=true;
 
-  result=sort_and_join(expr) && result;
+  result = sort_and_join(expr, false) && result;
 
   if(expr.id()==ID_typecast)
     result=simplify_typecast(expr) && result;

--- a/src/util/simplify_utils.cpp
+++ b/src/util/simplify_utils.cpp
@@ -119,7 +119,7 @@ static const struct saj_tablet &sort_and_join(
   return saj_table[i];
 }
 
-bool sort_and_join(exprt &expr)
+bool sort_and_join(exprt &expr, bool do_sort)
 {
   bool result=true;
 
@@ -158,8 +158,9 @@ bool sort_and_join(exprt &expr)
   }
 
   // sort it
+  if(do_sort)
+    result = sort_operands(new_ops) && result;
 
-  result=sort_operands(new_ops) && result;
   expr.operands().swap(new_ops);
 
   return result;

--- a/src/util/simplify_utils.h
+++ b/src/util/simplify_utils.h
@@ -14,6 +14,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 bool sort_operands(exprt::operandst &operands);
 
-bool sort_and_join(exprt &expr);
+bool sort_and_join(exprt &expr, bool do_sort=true);
 
 #endif // CPROVER_UTIL_SIMPLIFY_UTILS_H

--- a/src/util/std_pair_hash.h
+++ b/src/util/std_pair_hash.h
@@ -1,0 +1,35 @@
+/*******************************************************************\
+
+Module: util/std_pair_hash
+
+Author: Marek Trtik, marek.trtik@diffblue.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_STD_PAIR_HASH_H
+#define CPROVER_UTIL_STD_PAIR_HASH_H
+
+#include <functional>
+
+template <typename T>
+inline void hash_combine(std::size_t & seed, const T & v)
+{
+  std::hash<T> hasher;
+  seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+namespace std
+{
+  template<typename S, typename T> struct hash<pair<S, T> >
+  {
+    inline size_t operator()(const pair<S, T> & v) const
+    {
+      size_t seed = 0;
+      ::hash_combine(seed, v.first);
+      ::hash_combine(seed, v.second);
+      return seed;
+    }
+  };
+}
+
+#endif

--- a/src/xmllang/graphml.cpp
+++ b/src/xmllang/graphml.cpp
@@ -403,15 +403,6 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
     key.set_attribute("id", "producer");
   }
 
-  // <key attr.name="sourcecode" attr.type="string" for="edge" id="sourcecode"/>
-  {
-    xmlt &key=graphml.new_element("key");
-    key.set_attribute("attr.name", "sourcecode");
-    key.set_attribute("attr.type", "string");
-    key.set_attribute("for", "edge");
-    key.set_attribute("id", "sourcecode");
-  }
-
   // <key attr.name="startline" attr.type="int" for="edge" id="startline"/>
   {
     xmlt &key=graphml.new_element("key");

--- a/src/xmllang/graphml.cpp
+++ b/src/xmllang/graphml.cpp
@@ -54,7 +54,6 @@ static bool build_graph_rec(
     node.node_name=node_name;
     node.is_violation=false;
     node.has_invariant=false;
-    node.thread_nr=0;
 
     for(xmlt::elementst::const_iterator
         e_it=xml.elements.begin();
@@ -66,8 +65,6 @@ static bool build_graph_rec(
       if(e_it->get_attribute("key")=="violation" &&
          e_it->data=="true")
         node.is_violation=e_it->data=="true";
-      else if(e_it->get_attribute("key")=="threadNumber")
-        node.thread_nr=safe_string2unsigned(e_it->data);
       else if(e_it->get_attribute("key")=="entry" &&
               e_it->data=="true")
         entrynode=node_name;
@@ -337,13 +334,24 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
   }
 
   // <key attr.name="threadId" attr.type="string" for="edge" id="threadId"/>
-  // TODO: format for multi-threaded programs not defined yet
   {
     xmlt &key=graphml.new_element("key");
-    key.set_attribute("attr.name", "threadNumber");
+    key.set_attribute("attr.name", "threadId");
     key.set_attribute("attr.type", "int");
-    key.set_attribute("for", "node");
-    key.set_attribute("id", "thread");
+    key.set_attribute("for", "edge");
+    key.set_attribute("id", "threadId");
+
+    key.new_element("default").data="0";
+  }
+
+  // <key attr.name="createThread" attr.type="string"
+  //      for="edge" id="createThread"/>
+  {
+    xmlt &key=graphml.new_element("key");
+    key.set_attribute("attr.name", "createThread");
+    key.set_attribute("attr.type", "int");
+    key.set_attribute("for", "edge");
+    key.set_attribute("id", "createThread");
 
     key.new_element("default").data="0";
   }
@@ -523,13 +531,6 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
       entry.data="true";
 
       entry_done=true;
-    }
-
-    if(n.thread_nr!=0)
-    {
-      xmlt &entry=node.new_element("data");
-      entry.set_attribute("key", "threadNumber");
-      entry.data=std::to_string(n.thread_nr);
     }
 
     // <node id="A14">

--- a/src/xmllang/graphml.cpp
+++ b/src/xmllang/graphml.cpp
@@ -252,33 +252,6 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
     key.set_attribute("id", "invariant.scope");
   }
 
-  // <key attr.name="nodeType" attr.type="string" for="node" id="nodetype">
-  //     <default>path</default>
-  // </key>
-  {
-    xmlt &key=graphml.new_element("key");
-    key.set_attribute("attr.name", "nodeType");
-    key.set_attribute("attr.type", "string");
-    key.set_attribute("for", "node");
-    key.set_attribute("id", "nodetype");
-
-    key.new_element("default").data="path";
-  }
-
-  // <key attr.name="isFrontierNode" attr.type="boolean" for="node"
-  //      id="frontier">
-  //     <default>false</default>
-  // </key>
-  {
-    xmlt &key=graphml.new_element("key");
-    key.set_attribute("attr.name", "isFrontierNode");
-    key.set_attribute("attr.type", "boolean");
-    key.set_attribute("for", "node");
-    key.set_attribute("id", "frontier");
-
-    key.new_element("default").data="false";
-  }
-
   // <key attr.name="isViolationNode" attr.type="boolean" for="node"
   //      id="violation">
   //     <default>false</default>
@@ -329,6 +302,20 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
     key.set_attribute("attr.type", "boolean");
     key.set_attribute("for", "edge");
     key.set_attribute("id", "enterLoopHead");
+
+    key.new_element("default").data="false";
+  }
+
+  // <key attr.name="cyclehead" attr.type="boolean" for="edge"
+  //      id="cyclehead">
+  //   <default>false</default>
+  // </key>
+  {
+    xmlt &key=graphml.new_element("key");
+    key.set_attribute("attr.name", "cyclehead");
+    key.set_attribute("attr.type", "boolean");
+    key.set_attribute("for", "edge");
+    key.set_attribute("id", "cyclehead");
 
     key.new_element("default").data="false";
   }

--- a/src/xmllang/graphml.h
+++ b/src/xmllang/graphml.h
@@ -32,7 +32,6 @@ struct xml_graph_nodet:public graph_nodet<xml_edget>
   std::string node_name;
   irep_idt file;
   irep_idt line;
-  unsigned thread_nr;
   bool is_violation;
   bool has_invariant;
   std::string invariant;

--- a/unit/util/irep.cpp
+++ b/unit/util/irep.cpp
@@ -141,11 +141,15 @@ SCENARIO("irept_memory", "[core][utils][irept]")
       irept irep2("second_irep");
       irep.add("a_new_element", irep2);
       REQUIRE(irep.find("a_new_element").id() == "second_irep");
-      REQUIRE(irep.get_named_sub().size() == 1);
+      std::size_t named_sub_size = std::distance(
+        irep.get_named_sub().begin(), irep.get_named_sub().end());
+      REQUIRE(named_sub_size == 1);
 
       irep.add("#a_comment", irep2);
       REQUIRE(irep.find("#a_comment").id() == "second_irep");
-      REQUIRE(irep.get_comments().size() == 1);
+      std::size_t comments_size =
+        std::distance(irep.get_comments().begin(), irep.get_comments().end());
+      REQUIRE(comments_size == 1);
 
       irept bak(irep);
       irep.remove("no_such_id");
@@ -159,19 +163,29 @@ SCENARIO("irept_memory", "[core][utils][irept]")
 
       irep.move_to_named_sub("another_entry", irep2);
       REQUIRE(irep.get_sub().size() == 1);
-      REQUIRE(irep.get_named_sub().size() == 1);
-      REQUIRE(irep.get_comments().size() == 1);
+      named_sub_size = std::distance(
+        irep.get_named_sub().begin(), irep.get_named_sub().end());
+      REQUIRE(named_sub_size == 1);
+      comments_size =
+        std::distance(irep.get_comments().begin(), irep.get_comments().end());
+      REQUIRE(comments_size == 1);
 
       irept irep3;
       irep.move_to_named_sub("#a_comment", irep3);
       REQUIRE(irep.find("#a_comment").id().empty());
       REQUIRE(irep.get_sub().size() == 1);
-      REQUIRE(irep.get_named_sub().size() == 1);
-      REQUIRE(irep.get_comments().size() == 1);
+      named_sub_size = std::distance(
+        irep.get_named_sub().begin(), irep.get_named_sub().end());
+      REQUIRE(named_sub_size == 1);
+      comments_size =
+        std::distance(irep.get_comments().begin(), irep.get_comments().end());
+      REQUIRE(comments_size == 1);
 
       irept irep4;
       irep.move_to_named_sub("#another_comment", irep4);
-      REQUIRE(irep.get_comments().size() == 2);
+      comments_size =
+        std::distance(irep.get_comments().begin(), irep.get_comments().end());
+      REQUIRE(comments_size == 2);
     }
 
     THEN("Setting and getting works")


### PR DESCRIPTION
This is just to provide a to-do list of PRs to be created or existing PRs to be merged to put in place the fixes applied for CBMC's SV-COMP'19 submission. No review needed or expected.

- [x] #2001 (bugfix: graph-ml counterexample)
- [x] #1997 (performance: don't sort operands)
- [x] #1996 (bugfix: local dead objects)
- [x] #1991 (performance: no SSA sanity checks)
- [ ] #2000 (bugfix: invalid object)
- [x] #1992 (performance: hash code, size of irept)
- [x] #2220 (bugfix: phi nodes)
- [ ] #3462 (feature: memory leak checks)
- [x] #4269 (feature: alloca)
- [x] #4270 (feature: alloca-allocated object being free'd)
- [x] #4271 (bugfix: pthread_cond_wait semantics)
- [x] #4272 (feature: pthread_key support)
- [x] #4458 (performance: size of irept)