### PR TITLE
Remove deprecated exprt::make_false

### DIFF
--- a/src/goto-instrument/code_contracts.cpp
+++ b/src/goto-instrument/code_contracts.cpp
@@ -156,7 +156,7 @@ static void check_apply_invariants(
   loop_end->targets.clear();
   loop_end->type=ASSUME;
   if(loop_head->is_goto())
-    loop_end->guard.make_false();
+    loop_end->guard = false_exprt();
   else
     loop_end->guard.make_not();
 }

--- a/src/goto-instrument/unwind.cpp
+++ b/src/goto-instrument/unwind.cpp
@@ -122,8 +122,7 @@ void goto_unwindt::unwind(
     t--;
     assert(t->is_backwards_goto());
 
-    exprt exit_cond;
-    exit_cond.make_false(); // default is false
+    exprt exit_cond = false_exprt(); // default is false
 
     if(!t->guard.is_true()) // cond in backedge
     {

--- a/src/goto-symex/memory_model_tso.cpp
+++ b/src/goto-symex/memory_model_tso.cpp
@@ -81,9 +81,8 @@ void memory_model_tsot::program_order(
       event_listt::const_iterator next=e_it;
       ++next;
 
-      exprt mb_guard_r, mb_guard_w;
-      mb_guard_r.make_false();
-      mb_guard_w.make_false();
+      exprt mb_guard_r = false_exprt();
+      exprt mb_guard_w = false_exprt();
 
       for(event_listt::const_iterator
           e_it2=next;

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -224,7 +224,7 @@ void goto_symext::symex_goto(statet &state)
   // adjust guards
   if(new_guard.is_true())
   {
-    state.guard.make_false();
+    state.guard = false_exprt();
   }
   else
   {

--- a/src/jsil/parser.y
+++ b/src/jsil/parser.y
@@ -418,7 +418,7 @@ literal: TOK_IDENTIFIER
        }
        | TOK_FALSE
        {
-         newstack($$).make_false();
+         newstack($$) = false_exprt();
        }
        | TOK_FLOATING
        | TOK_STRING

--- a/src/solvers/flattening/boolbv_quantifier.cpp
+++ b/src/solvers/flattening/boolbv_quantifier.cpp
@@ -34,8 +34,7 @@ exprt get_quantifier_var_min(
 {
   PRECONDITION(quantifier_expr.id() == ID_or || quantifier_expr.id() == ID_and);
 
-  exprt res;
-  res.make_false();
+  exprt res = false_exprt();
   if(quantifier_expr.id()==ID_or)
   {
     /**
@@ -81,8 +80,7 @@ exprt get_quantifier_var_max(
   const exprt &quantifier_expr)
 {
   PRECONDITION(quantifier_expr.id() == ID_or || quantifier_expr.id() == ID_and);
-  exprt res;
-  res.make_false();
+  exprt res = false_exprt();
   if(quantifier_expr.id()==ID_or)
   {
     /**

--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -152,14 +152,6 @@ void exprt::make_true()
   set(ID_value, ID_true);
 }
 
-/// Replace the expression by a Boolean expression representing false.
-/// \deprecated use constructors instead
-void exprt::make_false()
-{
-  *this=exprt(ID_constant, typet(ID_bool));
-  set(ID_value, ID_false);
-}
-
 /// Return whether the expression represents a Boolean.
 /// \return True if is a Boolean, false otherwise.
 bool exprt::is_boolean() const

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -216,7 +216,6 @@ public:
   void make_not();
 
   void make_true();
-  void make_false();
   void make_bool(bool value);
 
   bool is_constant() const;


### PR DESCRIPTION
All users should use false_exprt() instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
