### PR TITLE
Remove deprecated exprt::make_true

### DIFF
--- a/src/analyses/goto_rw.h
+++ b/src/analyses/goto_rw.h
@@ -343,7 +343,7 @@ public:
     get_modet mode,
     const exprt &expr)
   {
-    guard.make_true();
+    guard = true_exprt();
 
     rw_range_set_value_sett::get_objects_rec(_target, mode, expr);
   }

--- a/src/analyses/interval_domain.cpp
+++ b/src/analyses/interval_domain.cpp
@@ -474,7 +474,7 @@ bool interval_domaint::ai_simplify(
     if(!a.join(d))                        // If d (this) is included in a...
     {                                     // Then the condition is always true
       unchanged=condition.is_true();
-      condition.make_true();
+      condition = true_exprt();
     }
   }
   else if(condition.id()==ID_symbol)
@@ -487,7 +487,7 @@ bool interval_domaint::ai_simplify(
     if(d.is_bottom())                     // If there there are none...
     {                                     // Then the condition is always true
       unchanged=condition.is_true();
-      condition.make_true();
+      condition = true_exprt();
     }
   }
 

--- a/src/goto-symex/slice_by_trace.cpp
+++ b/src/goto-symex/slice_by_trace.cpp
@@ -102,7 +102,6 @@ void symex_slice_by_tracet::slice_by_trace(
   slice_SSA_steps(equation, implications); // Slice based on implications
 
   guardt t_guard;
-  t_guard.make_true();
   symex_targett::sourcet empty_source;
   equation.SSA_steps.push_front(symex_target_equationt::SSA_stept());
   symex_target_equationt::SSA_stept &SSA_step=equation.SSA_steps.front();
@@ -505,7 +504,6 @@ void symex_slice_by_tracet::assign_merges(
     merge_sym.set_level_2(merge_count);
     merge_count--;
     guardt t_guard;
-    t_guard.make_true();
     symex_targett::sourcet empty_source;
 
     exprt merge_copy(*i);

--- a/src/jsil/parser.y
+++ b/src/jsil/parser.y
@@ -414,7 +414,7 @@ literal: TOK_IDENTIFIER
        }
        | TOK_TRUE
        {
-         newstack($$).make_true();
+         newstack($$) = true_exprt();
        }
        | TOK_FALSE
        {

--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -112,14 +112,6 @@ void exprt::make_bool(bool value)
   set(ID_value, value?ID_true:ID_false);
 }
 
-/// Replace the expression by a Boolean expression representing true.
-/// \deprecated use constructors instead
-void exprt::make_true()
-{
-  *this=exprt(ID_constant, typet(ID_bool));
-  set(ID_value, ID_true);
-}
-
 /// Return whether the expression represents a Boolean.
 /// \return True if is a Boolean, false otherwise.
 bool exprt::is_boolean() const

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -214,7 +214,6 @@ public:
 
   void make_typecast(const typet &_type);
 
-  void make_true();
   void make_bool(bool value);
 
   bool is_constant() const;

--- a/src/util/guard.cpp
+++ b/src/util/guard.cpp
@@ -113,7 +113,7 @@ guardt &operator |= (guardt &g1, const guardt &g2)
     exprt tmp(boolean_negate(g2));
 
     if(tmp==g1)
-      g1.make_true();
+      g1 = true_exprt();
     else
       g1=or_exprt(g1, g2);
 

--- a/src/util/guard.h
+++ b/src/util/guard.h
@@ -14,14 +14,14 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <iosfwd>
 
-#include "expr.h"
+#include "std_expr.h"
 
 class guardt:public exprt
 {
 public:
   guardt()
   {
-    make_true();
+    *this = true_exprt();
   }
 
   guardt &operator=(const exprt &e)


### PR DESCRIPTION
All users should use true_exprt() instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
