### PR TITLE
Refactoring: use value_is_zero_string

### DIFF
--- a/src/util/json_expr.cpp
+++ b/src/util/json_expr.cpp
@@ -37,12 +37,11 @@ static exprt simplify_json_expr(
 
     if(type.id()==ID_pointer)
     {
-      const irep_idt &value=to_constant_expr(src).get_value();
+      const constant_exprt &c = to_constant_expr(src);
 
       if(
-        value != ID_NULL &&
-        (value != std::string(value.size(), '0') ||
-         !config.ansi_c.NULL_is_zero) &&
+        c.get_value() != ID_NULL &&
+        (!c.value_is_zero_string() || !config.ansi_c.NULL_is_zero) &&
         src.operands().size() == 1 &&
         to_unary_expr(src).op().id() != ID_constant)
       // try to simplify the constant pointer


### PR DESCRIPTION
Avoids repeating the same code multiple times.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
