### PR TITLE
Remove "const" without effect

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -189,7 +189,7 @@ symbol_exprt java_bytecode_convert_methodt::tmp_variable(
   return result;
 }
 
-/// Returns a symbol_exprt indicating a local variable suitable to load/store
+/// Returns an expression indicating a local variable suitable to load/store
 /// from a bytecode at address `address` a value of type `type_char` stored in
 /// the JVM's slot `arg`.
 ///
@@ -204,7 +204,8 @@ symbol_exprt java_bytecode_convert_methodt::tmp_variable(
 ///   Indicates whether we should return the original symbol_exprt or a
 ///   typecast_exprt if the type of the symbol_exprt does not equal that
 ///   represented by `type_char`.
-const exprt java_bytecode_convert_methodt::variable(
+/// \return symbol_exprt or type-cast symbol_exprt
+exprt java_bytecode_convert_methodt::variable(
   const exprt &arg,
   char type_char,
   size_t address,

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -151,7 +151,7 @@ protected:
     NO_CAST
   };
 
-  const exprt variable(
+  exprt variable(
     const exprt &arg,
     char type_char,
     size_t address,


### PR DESCRIPTION
The return value is returned-by-value, const has no effect. Also update the
documentation to match what actually is returned.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
