### PR TITLE
Add a new constructor to java_bytecode_parse_treet

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_parse_tree.h
+++ b/jbmc/src/java_bytecode/java_bytecode_parse_tree.h
@@ -199,6 +199,11 @@ struct java_bytecode_parse_treet
   {
     classt() = default;
 
+    /// Create a class \p name.
+    explicit classt(const irep_idt &name) : name(name)
+    {
+    }
+
     // Disallow copy construction and copy assignment, but allow move
     // construction and move assignment.
     #ifndef _MSC_VER // Ommit this on MS VC2013 as move is not supported.
@@ -307,9 +312,14 @@ struct java_bytecode_parse_treet
   typedef std::set<irep_idt> class_refst;
   class_refst class_refs;
 
-  bool loading_successful;
+  bool loading_successful = false;
 
-  java_bytecode_parse_treet():loading_successful(false)
+  /// An empty bytecode parse tree, no class name set
+  java_bytecode_parse_treet() = default;
+
+  /// Create a blank parse tree for class \p class_name.
+  explicit java_bytecode_parse_treet(const irep_idt &class_name)
+    : parsed_class(class_name)
   {
   }
 };

--- a/jbmc/src/java_bytecode/java_bytecode_parse_tree.h
+++ b/jbmc/src/java_bytecode/java_bytecode_parse_tree.h
@@ -301,7 +301,6 @@ struct java_bytecode_parse_treet
     }
 
     void output(std::ostream &out) const;
-
   };
 
   classt parsed_class;

--- a/jbmc/src/java_bytecode/java_class_loader.cpp
+++ b/jbmc/src/java_bytecode/java_class_loader.cpp
@@ -120,9 +120,7 @@ java_class_loadert::get_parse_tree(
   if(!class_loader_limit.load_class_file(class_name_to_jar_file(class_name)))
   {
     debug() << "not loading " << class_name << " because of limit" << eom;
-    java_bytecode_parse_treet parse_tree;
-    parse_tree.parsed_class.name = class_name;
-    parse_trees.push_back(std::move(parse_tree));
+    parse_trees.emplace_back(class_name);
     return parse_trees;
   }
 
@@ -179,9 +177,7 @@ java_class_loadert::get_parse_tree(
 
   // Not found or failed to load
   warning() << "failed to load class `" << class_name << '\'' << eom;
-  java_bytecode_parse_treet parse_tree;
-  parse_tree.parsed_class.name=class_name;
-  parse_trees.push_back(std::move(parse_tree));
+  parse_trees.emplace_back(class_name);
   return parse_trees;
 }
 


### PR DESCRIPTION
Constructing a java_bytecode_parse_treet from an irep_idt avoids two uses of
short-lived local variables.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
