### PR TITLE
Use a constructor instead of a method-to-construct

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_parse_tree.h
+++ b/jbmc/src/java_bytecode/java_bytecode_parse_tree.h
@@ -232,23 +232,24 @@ struct java_bytecode_parse_treet
     typedef std::vector<u2> u2_valuest;
     struct lambda_method_handlet
     {
-      method_handle_typet handle_type;
+      method_handle_typet handle_type = method_handle_typet::UNKNOWN_HANDLE;
       irep_idt lambda_method_name;
       irep_idt lambda_method_ref;
       irep_idt interface_type;
       irep_idt method_type;
       u2_valuest u2_values;
-      lambda_method_handlet() : handle_type(method_handle_typet::UNKNOWN_HANDLE)
+      lambda_method_handlet() = default;
+
+      /// Construct a lambda method handle with parameters \p params.
+      explicit lambda_method_handlet(const u2_valuest &params)
+        : u2_values(params)
       {
       }
 
-      static lambda_method_handlet
-      create_unknown_handle(const u2_valuest params)
+      /// Construct a lambda method handle with parameters \p params.
+      explicit lambda_method_handlet(u2_valuest &&params)
+        : u2_values(std::move(params))
       {
-        lambda_method_handlet lambda_method_handle;
-        lambda_method_handle.handle_type = method_handle_typet::UNKNOWN_HANDLE;
-        lambda_method_handle.u2_values = std::move(params);
-        return lambda_method_handle;
       }
 
       bool is_unknown_handle() const
@@ -285,7 +286,9 @@ struct java_bytecode_parse_treet
       return methods.back();
     }
 
-    void add_method_handle(size_t bootstrap_index, lambda_method_handlet handle)
+    void add_method_handle(
+      size_t bootstrap_index,
+      const lambda_method_handlet &handle)
     {
       lambda_method_handle_map[{name, bootstrap_index}] = handle;
     }

--- a/jbmc/src/java_bytecode/java_bytecode_parser.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_parser.cpp
@@ -2145,7 +2145,6 @@ void java_bytecode_parsert::store_unknown_method_handle(
   size_t bootstrap_method_index,
   java_bytecode_parsert::u2_valuest u2_values) const
 {
-  const lambda_method_handlet lambda_method_handle =
-    lambda_method_handlet::create_unknown_handle(move(u2_values));
+  const lambda_method_handlet lambda_method_handle(std::move(u2_values));
   parsed_class.add_method_handle(bootstrap_method_index, lambda_method_handle);
 }


### PR DESCRIPTION
There is no need for a named method constructing local objects and then
returning them by-value.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
