### PR TITLE
extractbits_exprt has a single correct operand order

### DIFF
--- a/src/solvers/flattening/boolbv_extractbits.cpp
+++ b/src/solvers/flattening/boolbv_extractbits.cpp
@@ -42,8 +42,9 @@ bvt boolbvt::convert_extractbits(const extractbits_exprt &expr)
     expr.find_source_location(),
     irep_pretty_diagnosticst{expr});
 
-  if(lower_as_int > upper_as_int)
-    std::swap(upper_as_int, lower_as_int);
+  DATA_INVARIANT(
+    lower_as_int <= upper_as_int,
+    "upper bound must be greater or equal to lower bound");
 
   // now lower_as_int <= upper_as_int
 


### PR DESCRIPTION
Let's not trade some sort of "userfriendliness" for an unclear semantics.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.