### PR TITLE
Ensure proper dependencies on json.dir [blocks: #3425]

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -42,24 +42,23 @@ cpp.dir: ansi-c.dir linking.dir
 
 languages: util.dir langapi.dir \
            cpp.dir ansi-c.dir xmllang.dir assembler.dir \
-           jsil.dir json-symtab-language.dir
+           jsil.dir json.dir json-symtab-language.dir
 
 solvers.dir: util.dir langapi.dir
 
 goto-instrument.dir: languages goto-programs.dir pointer-analysis.dir \
-                     goto-symex.dir linking.dir analyses.dir solvers.dir \
-                     json.dir
+                     goto-symex.dir linking.dir analyses.dir solvers.dir
 
 cbmc.dir: languages solvers.dir goto-symex.dir analyses.dir \
           pointer-analysis.dir goto-programs.dir linking.dir \
           goto-instrument.dir
 
 goto-analyzer.dir: languages analyses.dir goto-programs.dir linking.dir \
-                   json.dir goto-instrument.dir
+                   goto-instrument.dir
 
 goto-diff.dir: languages goto-programs.dir pointer-analysis.dir \
                linking.dir analyses.dir goto-instrument.dir \
-               solvers.dir json.dir goto-symex.dir
+               solvers.dir goto-symex.dir
 
 goto-cc.dir: languages goto-programs.dir linking.dir
 


### PR DESCRIPTION
json-symtab will always add a dependency on json, and we had depended on json in
goto-cc for a while already. It seems just by chance that we didn't see any
build failures up until today.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.