### PR TITLE
Use code_typet::parameters

### DIFF
--- a/src/cpp/cpp_convert_type.cpp
+++ b/src/cpp/cpp_convert_type.cpp
@@ -234,20 +234,17 @@ void cpp_convert_typet::read_function_type(const typet &type)
     cpp_convert_plain_type(return_type);
 
   // take care of parameter types
-  irept &parameters=t.add(ID_parameters);
+  code_typet::parameterst &parameters = t.parameters();
 
   // see if we have an ellipsis
-  if(!parameters.get_sub().empty() &&
-     parameters.get_sub().back().id()==ID_ellipsis)
+  if(!parameters.empty() && parameters.back().id() == ID_ellipsis)
   {
-    parameters.set(ID_ellipsis, true);
-    parameters.get_sub().erase(--parameters.get_sub().end());
+    t.make_ellipsis();
+    parameters.pop_back();
   }
 
-  Forall_irep(it, parameters.get_sub())
+  for(auto &parameter_expr : parameters)
   {
-    exprt &parameter_expr=static_cast<exprt &>(*it);
-
     if(parameter_expr.id()==ID_cpp_declaration)
     {
       cpp_declarationt &declaration=to_cpp_declaration(parameter_expr);
@@ -264,7 +261,7 @@ void cpp_convert_typet::read_function_type(const typet &type)
       // do we have a declarator?
       if(declarator.is_nil())
       {
-        parameter_expr=exprt(ID_parameter, declaration.type());
+        parameter_expr = code_typet::parametert(declaration.type());
         parameter_expr.add_source_location()=type_location;
       }
       else
@@ -313,9 +310,8 @@ void cpp_convert_typet::read_function_type(const typet &type)
   }
 
   // if we just have one parameter of type void, remove it
-  if(parameters.get_sub().size()==1 &&
-     parameters.get_sub().front().find(ID_type).id()==ID_empty)
-    parameters.get_sub().clear();
+  if(parameters.size() == 1 && parameters.front().type().id() == ID_empty)
+    parameters.clear();
 }
 
 void cpp_convert_typet::write(typet &type)

--- a/src/cpp/cpp_typecheck_conversions.cpp
+++ b/src/cpp/cpp_typecheck_conversions.cpp
@@ -949,12 +949,12 @@ bool cpp_typecheckt::user_defined_conversion_sequence(
 
         // TODO: ellipsis
 
-        const irept &parameters=comp_type.find(ID_parameters);
+        const auto &parameters = to_code_type(comp_type).parameters();
 
-        if(parameters.get_sub().size() != 2)
+        if(parameters.size() != 2)
           continue;
 
-        exprt curr_arg1=static_cast<const exprt&> (parameters.get_sub()[1]);
+        exprt curr_arg1 = parameters[1];
         typet arg1_type=curr_arg1.type();
 
         if(is_reference(arg1_type))


### PR DESCRIPTION
Avoid direct use of the implementation detail that parameters are stored under
the ID_parameters key.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.