### PR TITLE
Remove names of unused parameters [blocks: #2310]

### DIFF
--- a/src/json-symtab-language/json_symtab_language.h
+++ b/src/json-symtab-language/json_symtab_language.h
@@ -29,11 +29,9 @@ public:
 
   void show_parse(std::ostream &out) override;
 
-  bool to_expr(
-    const std::string &code,
-    const std::string &module,
-    exprt &expr,
-    const namespacet &ns) override
+  bool
+  to_expr(const std::string &, const std::string &, exprt &, const namespacet &)
+    override
   {
     UNIMPLEMENTED;
   }


### PR DESCRIPTION
Removing the parameter completely is not an option for these as they are part of
inherited APIs, but at the same time the names do not have value in terms of
documentation.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.