### PR TITLE
Enable perfect forwarding with irept/exprt/typet constructors

### DIFF
--- a/src/util/dstring.h
+++ b/src/util/dstring.h
@@ -71,6 +71,18 @@ public:
   {
   }
 
+  dstringt(const dstringt &) = default;
+
+  /// Move constructor. There is no need and no point in actually destroying the
+  /// source object \p other, this is effectively just a copy constructor.
+#ifdef __GNUC__
+  constexpr
+#endif
+    dstringt(dstringt &&other)
+    : no(other.no)
+  {
+  }
+
   // access
 
   bool empty() const
@@ -135,6 +147,14 @@ public:
 
   dstringt &operator=(const dstringt &b)
   { no=b.no; return *this; }
+
+  /// Move assignment. There is no need and no point in actually destroying the
+  /// source object \p other, this is effectively just an assignment.
+  dstringt &operator=(dstringt &&other)
+  {
+    no = other.no;
+    return *this;
+  }
 
   // output
 

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -57,9 +57,18 @@ public:
   // constructors
   exprt() { }
   explicit exprt(const irep_idt &_id):irept(_id) { }
-  exprt(const irep_idt &_id, const typet &_type):irept(_id)
+
+  exprt(irep_idt _id, typet _type)
+    : irept(std::move(_id), {{ID_type, std::move(_type)}}, {})
   {
-    add(ID_type, _type);
+  }
+
+  exprt(irep_idt _id, typet _type, operandst &&_operands)
+    : irept(
+        std::move(_id),
+        {{ID_type, std::move(_type)}},
+        std::move((irept::subt &&) _operands))
+  {
   }
 
   /// Return the type of the expression
@@ -324,7 +333,13 @@ class expr_protectedt : public exprt
 {
 protected:
   // constructors
-  expr_protectedt(const irep_idt &_id, const typet &_type) : exprt(_id, _type)
+  expr_protectedt(irep_idt _id, typet _type)
+    : exprt(std::move(_id), std::move(_type))
+  {
+  }
+
+  expr_protectedt(irep_idt _id, typet _type, operandst _operands)
+    : exprt(std::move(_id), std::move(_type), std::move(_operands))
   {
   }
 

--- a/src/util/irep.cpp
+++ b/src/util/irep.cpp
@@ -189,7 +189,7 @@ irept &irept::add(const irep_namet &name)
 #endif
 }
 
-irept &irept::add(const irep_namet &name, const irept &irep)
+irept &irept::add(const irep_namet &name, irept irep)
 {
   named_subt &s = get_named_sub();
 
@@ -202,18 +202,20 @@ irept &irept::add(const irep_namet &name, const irept &irep)
     named_subt::iterator before = s.before_begin();
     while(std::next(before) != it)
       ++before;
-    it = s.emplace_after(before, name, irep);
+    it = s.emplace_after(before, name, std::move(irep));
   }
   else
-    it->second=irep;
+    it->second = std::move(irep);
 
   return it->second;
 #else
-  std::pair<named_subt::iterator, bool> entry=
-    s.insert(std::make_pair(name, irep));
+  std::pair<named_subt::iterator, bool> entry = s.emplace(
+    std::piecewise_construct,
+    std::forward_as_tuple(name),
+    std::forward_as_tuple(irep));
 
   if(!entry.second)
-    entry.first->second=irep;
+    entry.first->second = std::move(irep);
 
   return entry.first->second;
 #endif

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -421,7 +421,7 @@ public:
 
   const irept &find(const irep_namet &name) const;
   irept &add(const irep_namet &name);
-  irept &add(const irep_namet &name, const irept &irep);
+  irept &add(const irep_namet &name, irept irep);
 
   const std::string &get_string(const irep_namet &name) const
   {
@@ -435,9 +435,13 @@ public:
   long long get_long_long(const irep_namet &name) const;
 
   void set(const irep_namet &name, const irep_idt &value)
-  { add(name).id(value); }
-  void set(const irep_namet &name, const irept &irep)
-  { add(name, irep); }
+  {
+    add(name, irept(value));
+  }
+  void set(const irep_namet &name, irept irep)
+  {
+    add(name, std::move(irep));
+  }
   void set(const irep_namet &name, const long long value);
 
   void remove(const irep_namet &name);

--- a/src/util/ssa_expr.h
+++ b/src/util/ssa_expr.h
@@ -18,7 +18,7 @@ class ssa_exprt:public symbol_exprt
 public:
   /// Constructor
   /// \param expr: Expression to be converted to SSA symbol
-  explicit ssa_exprt(const exprt &expr) : symbol_exprt(irep_idt(), expr.type())
+  explicit ssa_exprt(const exprt &expr) : symbol_exprt(expr.type())
   {
     set(ID_C_SSA_symbol, true);
     add(ID_expression, expr);
@@ -42,15 +42,13 @@ public:
     if(original_expr.id() == ID_symbol)
       return to_symbol_expr(original_expr).get_identifier();
 
-    object_descriptor_exprt ode;
-    ode.object() = original_expr;
+    object_descriptor_exprt ode(original_expr);
     return to_symbol_expr(ode.root_object()).get_identifier();
   }
 
   const ssa_exprt get_l1_object() const
   {
-    object_descriptor_exprt ode;
-    ode.object()=get_original_expr();
+    object_descriptor_exprt ode(get_original_expr());
 
     ssa_exprt root(ode.root_object());
     root.set(ID_L0, get(ID_L0));

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -206,10 +206,10 @@ public:
     add_to_operands(std::move(code));
   }
 
-  void add(codet code, const source_locationt &loc)
+  void add(codet code, source_locationt loc)
   {
-    code.add_source_location() = loc;
-    add(code);
+    code.add_source_location().swap(loc);
+    add(std::move(code));
   }
 
   void append(const code_blockt &extra_block);
@@ -290,8 +290,8 @@ public:
     operands().resize(2);
   }
 
-  code_assignt(const exprt &lhs, const exprt &rhs)
-    : codet(ID_assign, {lhs, rhs})
+  code_assignt(exprt lhs, exprt rhs)
+    : codet(ID_assign, {std::move(lhs), std::move(rhs)})
   {
   }
 
@@ -387,9 +387,8 @@ inline code_assignt &to_code_assign(codet &code)
 class code_declt:public codet
 {
 public:
-  explicit code_declt(const symbol_exprt &symbol) : codet(ID_decl)
+  explicit code_declt(symbol_exprt symbol) : codet(ID_decl, {std::move(symbol)})
   {
-    add_to_operands(symbol);
   }
 
   symbol_exprt &symbol()
@@ -453,7 +452,7 @@ inline code_declt &to_code_decl(codet &code)
 class code_deadt:public codet
 {
 public:
-  explicit code_deadt(const symbol_exprt &symbol) : codet(ID_dead, {symbol})
+  explicit code_deadt(symbol_exprt symbol) : codet(ID_dead, {std::move(symbol)})
   {
   }
 
@@ -527,7 +526,7 @@ public:
     operands().resize(1);
   }
 
-  explicit code_assumet(const exprt &expr) : codet(ID_assume, {expr})
+  explicit code_assumet(exprt expr) : codet(ID_assume, {std::move(expr)})
   {
   }
 
@@ -585,7 +584,7 @@ public:
     operands().resize(1);
   }
 
-  explicit code_assertt(const exprt &expr) : codet(ID_assert, {expr})
+  explicit code_assertt(exprt expr) : codet(ID_assert, {std::move(expr)})
   {
   }
 
@@ -660,17 +659,18 @@ public:
   }
 
   /// An if \p condition then \p then_code else \p else_code statement.
-  code_ifthenelset(
-    const exprt &condition,
-    const codet &then_code,
-    const codet &else_code)
-    : codet(ID_ifthenelse, {condition, then_code, else_code})
+  code_ifthenelset(exprt condition, codet then_code, codet else_code)
+    : codet(
+        ID_ifthenelse,
+        {std::move(condition), std::move(then_code), std::move(else_code)})
   {
   }
 
   /// An if \p condition then \p then_code statement (no "else" case).
-  code_ifthenelset(const exprt &condition, const codet &then_code)
-    : codet(ID_ifthenelse, {condition, then_code, nil_exprt()})
+  code_ifthenelset(exprt condition, codet then_code)
+    : codet(
+        ID_ifthenelse,
+        {std::move(condition), std::move(then_code), nil_exprt()})
   {
   }
 
@@ -752,8 +752,8 @@ public:
     operands().resize(2);
   }
 
-  code_switcht(const exprt &_value, const codet &_body)
-    : codet(ID_switch, {_value, _body})
+  code_switcht(exprt _value, codet _body)
+    : codet(ID_switch, {std::move(_value), std::move(_body)})
   {
   }
 
@@ -820,8 +820,8 @@ public:
     operands().resize(2);
   }
 
-  code_whilet(const exprt &_cond, const codet &_body)
-    : codet(ID_while, {_cond, _body})
+  code_whilet(exprt _cond, codet _body)
+    : codet(ID_while, {std::move(_cond), std::move(_body)})
   {
   }
 
@@ -888,8 +888,8 @@ public:
     operands().resize(2);
   }
 
-  code_dowhilet(const exprt &_cond, const codet &_body)
-    : codet(ID_dowhile, {_cond, _body})
+  code_dowhilet(exprt _cond, codet _body)
+    : codet(ID_dowhile, {std::move(_cond), std::move(_body)})
   {
   }
 
@@ -958,12 +958,13 @@ public:
 
   /// A statement describing a for loop with initializer \p _init, loop
   /// condition \p _cond, increment \p _iter, and body \p _body.
-  code_fort(
-    const exprt &_init,
-    const exprt &_cond,
-    const exprt &_iter,
-    const codet &_body)
-    : codet(ID_for, {_init, _cond, _iter, _body})
+  code_fort(exprt _init, exprt _cond, exprt _iter, codet _body)
+    : codet(
+        ID_for,
+        {std::move(_init),
+         std::move(_cond),
+         std::move(_iter),
+         std::move(_body)})
   {
   }
 
@@ -1114,46 +1115,27 @@ public:
     op2().id(ID_arguments);
   }
 
-  explicit code_function_callt(const exprt &_function) : codet(ID_function_call)
+  explicit code_function_callt(exprt _function)
+    : codet(
+        ID_function_call,
+        {nil_exprt(), std::move(_function), exprt(ID_arguments)})
   {
-    operands().resize(3);
-    lhs().make_nil();
-    op2().id(ID_arguments);
-    function() = _function;
   }
 
   typedef exprt::operandst argumentst;
 
-  code_function_callt(
-    const exprt &_lhs,
-    const exprt &_function,
-    argumentst &&_arguments)
-    : code_function_callt(_function)
-  {
-    lhs() = _lhs;
-    arguments() = std::move(_arguments);
-  }
-
-  code_function_callt(
-    const exprt &_lhs,
-    const exprt &_function,
-    const argumentst &_arguments)
-    : code_function_callt(_function)
-  {
-    lhs() = _lhs;
-    arguments() = _arguments;
-  }
-
-  code_function_callt(const exprt &_function, argumentst &&_arguments)
-    : code_function_callt(_function)
+  code_function_callt(exprt _lhs, exprt _function, argumentst _arguments)
+    : codet(
+        ID_function_call,
+        {std::move(_lhs), std::move(_function), exprt(ID_arguments)})
   {
     arguments() = std::move(_arguments);
   }
 
-  code_function_callt(const exprt &_function, const argumentst &_arguments)
-    : code_function_callt(_function)
+  code_function_callt(exprt _function, argumentst _arguments)
+    : code_function_callt(std::move(_function))
   {
-    arguments() = _arguments;
+    arguments() = std::move(_arguments);
   }
 
   exprt &lhs()
@@ -1264,7 +1246,7 @@ public:
   {
   }
 
-  explicit code_returnt(const exprt &_op) : codet(ID_return, {_op})
+  explicit code_returnt(exprt _op) : codet(ID_return, {std::move(_op)})
   {
   }
 
@@ -1338,8 +1320,8 @@ public:
     set_label(_label);
   }
 
-  code_labelt(const irep_idt &_label, const codet &_code)
-    : codet(ID_label, {_code})
+  code_labelt(const irep_idt &_label, codet _code)
+    : codet(ID_label, {std::move(_code)})
   {
     set_label(_label);
   }
@@ -1408,8 +1390,8 @@ public:
     operands().resize(2);
   }
 
-  code_switch_caset(const exprt &_case_op, const codet &_code)
-    : codet(ID_switch_case, {_case_op, _code})
+  code_switch_caset(exprt _case_op, codet _code)
+    : codet(ID_switch_case, {std::move(_case_op), std::move(_code)})
   {
   }
 
@@ -1642,7 +1624,7 @@ public:
   {
   }
 
-  explicit code_asmt(const exprt &expr) : codet(ID_asm, {expr})
+  explicit code_asmt(exprt expr) : codet(ID_asm, {std::move(expr)})
   {
   }
 
@@ -1785,7 +1767,8 @@ public:
     operands().resize(1);
   }
 
-  explicit code_expressiont(const exprt &expr) : codet(ID_expression, {expr})
+  explicit code_expressiont(exprt expr)
+    : codet(ID_expression, {std::move(expr)})
   {
   }
 
@@ -1853,27 +1836,27 @@ public:
     set_statement(statement);
   }
 
-  side_effect_exprt(
-    const irep_idt &statement,
-    const typet &_type,
-    const source_locationt &loc)
-    : exprt(ID_side_effect, _type)
-  {
-    set_statement(statement);
-    add_source_location() = loc;
-  }
-
   /// constructor with operands
   side_effect_exprt(
     const irep_idt &statement,
-    operandst &&_operands,
-    const typet &_type,
-    const source_locationt &loc)
-    : exprt(ID_side_effect, _type)
+    operandst _operands,
+    typet _type,
+    source_locationt loc)
+    : exprt(ID_side_effect, std::move(_type))
   {
     set_statement(statement);
     operands() = std::move(_operands);
-    add_source_location() = loc;
+    add_source_location().swap(loc);
+  }
+
+  side_effect_exprt(
+    const irep_idt &statement,
+    typet _type,
+    source_locationt loc)
+    : exprt(ID_side_effect, std::move(_type))
+  {
+    set_statement(statement);
+    add_source_location().swap(loc);
   }
 
   const irep_idt &get_statement() const
@@ -1939,8 +1922,8 @@ public:
     set_nullable(true);
   }
 
-  side_effect_expr_nondett(const typet &_type, const source_locationt &loc)
-    : side_effect_exprt(ID_nondet, _type, loc)
+  side_effect_expr_nondett(typet _type, source_locationt loc)
+    : side_effect_exprt(ID_nondet, std::move(_type), std::move(loc))
   {
     set_nullable(true);
   }
@@ -1996,25 +1979,15 @@ public:
 
   /// construct an assignment side-effect, given lhs, rhs and the type
   side_effect_expr_assignt(
-    const exprt &_lhs,
-    const exprt &_rhs,
-    const typet &_type,
-    const source_locationt &loc)
-    : side_effect_exprt(ID_assign, {_lhs, _rhs}, _type, loc)
-  {
-  }
-
-  /// construct an assignment side-effect, given lhs, rhs and the type
-  side_effect_expr_assignt(
-    exprt &&_lhs,
-    exprt &&_rhs,
-    typet &&_type,
-    const source_locationt &loc)
+    exprt _lhs,
+    exprt _rhs,
+    typet _type,
+    source_locationt loc)
     : side_effect_exprt(
         ID_assign,
         {std::move(_lhs), std::move(_rhs)},
         std::move(_type),
-        loc)
+        std::move(loc))
   {
   }
 
@@ -2104,17 +2077,17 @@ public:
   }
 
   side_effect_expr_function_callt(
-    const exprt &_function,
-    const exprt::operandst &_arguments,
-    const typet &_type,
-    const source_locationt &loc)
+    exprt _function,
+    exprt::operandst _arguments,
+    typet _type,
+    source_locationt loc)
     : side_effect_exprt(
         ID_function_call,
-        {_function, exprt(ID_arguments)},
-        _type,
-        loc)
+        {std::move(_function),
+         multi_ary_exprt{ID_arguments, std::move(_arguments), typet{}}},
+        std::move(_type),
+        std::move(loc))
   {
-    arguments() = _arguments;
   }
 
   exprt &function()
@@ -2174,12 +2147,12 @@ public:
   }
 
   side_effect_expr_throwt(
-    const irept &exception_list,
-    const typet &type,
-    const source_locationt &loc)
-    : side_effect_exprt(ID_throw, type, loc)
+    irept exception_list,
+    typet type,
+    source_locationt loc)
+    : side_effect_exprt(ID_throw, std::move(type), std::move(loc))
   {
-    set(ID_exception_list, exception_list);
+    set(ID_exception_list, std::move(exception_list));
   }
 };
 
@@ -2356,11 +2329,12 @@ class code_landingpadt:public codet
   {
     operands().resize(1);
   }
-  explicit code_landingpadt(const exprt &catch_expr):
-  codet(ID_exception_landingpad)
+
+  explicit code_landingpadt(exprt catch_expr)
+    : codet(ID_exception_landingpad, {std::move(catch_expr)})
   {
-    add_to_operands(catch_expr);
   }
+
   const exprt &catch_expr() const
   {
     return op0();
@@ -2408,8 +2382,8 @@ public:
   }
 
   /// A statement representing try \p _try_code catch ...
-  explicit code_try_catcht(const codet &_try_code)
-    : codet(ID_try_catch, {_try_code})
+  explicit code_try_catcht(codet _try_code)
+    : codet(ID_try_catch, {std::move(_try_code)})
   {
   }
 

--- a/src/util/std_expr.cpp
+++ b/src/util/std_expr.cpp
@@ -152,33 +152,33 @@ void object_descriptor_exprt::build(
 }
 
 shift_exprt::shift_exprt(
-  const exprt &_src,
+  exprt _src,
   const irep_idt &_id,
-  const std::size_t _distance):
-  binary_exprt(_src, _id, from_integer(_distance, integer_typet()))
+  const std::size_t _distance)
+  : binary_exprt(std::move(_src), _id, from_integer(_distance, integer_typet()))
 {
 }
 
-extractbit_exprt::extractbit_exprt(
-  const exprt &_src,
-  const std::size_t _index):
-  binary_predicate_exprt(
-    _src, ID_extractbit, from_integer(_index, integer_typet()))
+extractbit_exprt::extractbit_exprt(exprt _src, const std::size_t _index)
+  : binary_predicate_exprt(
+      std::move(_src),
+      ID_extractbit,
+      from_integer(_index, integer_typet()))
 {
 }
 
 extractbits_exprt::extractbits_exprt(
-  const exprt &_src,
+  exprt _src,
   const std::size_t _upper,
   const std::size_t _lower,
-  const typet &_type)
-  : expr_protectedt(ID_extractbits, _type)
+  typet _type)
+  : expr_protectedt(ID_extractbits, std::move(_type))
 {
   PRECONDITION(_upper >= _lower);
-  operands().resize(3);
-  src()=_src;
-  upper()=from_integer(_upper, integer_typet());
-  lower()=from_integer(_lower, integer_typet());
+  add_to_operands(
+    std::move(_src),
+    from_integer(_upper, integer_typet()),
+    from_integer(_lower, integer_typet()));
 }
 
 address_of_exprt::address_of_exprt(const exprt &_op):

--- a/src/util/std_types.cpp
+++ b/src/util/std_types.cpp
@@ -80,7 +80,8 @@ const struct_tag_typet &struct_typet::baset::type() const
   return to_struct_tag_type(exprt::type());
 }
 
-struct_typet::baset::baset(const struct_tag_typet &base) : exprt(ID_base, base)
+struct_typet::baset::baset(struct_tag_typet base)
+  : exprt(ID_base, std::move(base))
 {
 }
 

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -69,10 +69,10 @@ public:
   public:
     componentt() = default;
 
-    componentt(const irep_idt &_name, const typet &_type)
+    componentt(const irep_idt &_name, typet _type)
     {
       set_name(_name);
-      type()=_type;
+      type().swap(_type);
     }
 
     const irep_idt &get_name() const
@@ -148,8 +148,7 @@ public:
 
   typedef std::vector<componentt> componentst;
 
-  struct_union_typet(const irep_idt &_id, componentst &&_components)
-    : typet(_id)
+  struct_union_typet(const irep_idt &_id, componentst _components) : typet(_id)
   {
     components() = std::move(_components);
   }
@@ -244,7 +243,7 @@ public:
   {
   }
 
-  explicit struct_typet(componentst &&_components)
+  explicit struct_typet(componentst _components)
     : struct_union_typet(ID_struct, std::move(_components))
   {
   }
@@ -263,7 +262,7 @@ public:
   public:
     struct_tag_typet &type();
     const struct_tag_typet &type() const;
-    explicit baset(const struct_tag_typet &base);
+    explicit baset(struct_tag_typet base);
   };
 
   typedef std::vector<baset> basest;
@@ -398,7 +397,7 @@ public:
   {
   }
 
-  explicit union_typet(componentst &&_components)
+  explicit union_typet(componentst _components)
     : struct_union_typet(ID_union, std::move(_components))
   {
   }
@@ -621,8 +620,8 @@ inline enumeration_typet &to_enumeration_type(typet &type)
 class c_enum_typet:public type_with_subtypet
 {
 public:
-  explicit c_enum_typet(const typet &_subtype):
-    type_with_subtypet(ID_c_enum, _subtype)
+  explicit c_enum_typet(typet _subtype)
+    : type_with_subtypet(ID_c_enum, std::move(_subtype))
   {
   }
 
@@ -743,20 +742,10 @@ public:
   /// Constructs a new code type, i.e., function type.
   /// \param _parameters: The vector of function parameters.
   /// \param _return_type: The return type.
-  code_typet(parameterst &&_parameters, typet &&_return_type) : typet(ID_code)
+  code_typet(parameterst _parameters, typet _return_type) : typet(ID_code)
   {
     parameters().swap(_parameters);
     return_type().swap(_return_type);
-  }
-
-  /// Constructs a new code type, i.e., function type.
-  /// \param _parameters: The vector of function parameters.
-  /// \param _return_type: The return type.
-  code_typet(parameterst &&_parameters, const typet &_return_type)
-    : typet(ID_code)
-  {
-    parameters().swap(_parameters);
-    return_type() = _return_type;
   }
 
   /// \deprecated
@@ -986,11 +975,10 @@ inline code_typet &to_code_type(typet &type)
 class array_typet:public type_with_subtypet
 {
 public:
-  array_typet(
-    const typet &_subtype,
-    const exprt &_size):type_with_subtypet(ID_array, _subtype)
+  array_typet(typet _subtype, exprt _size)
+    : type_with_subtypet(ID_array, std::move(_subtype))
   {
-    size()=_size;
+    add(ID_size, std::move(_size));
   }
 
   const exprt &size() const
@@ -1458,10 +1446,10 @@ inline floatbv_typet &to_floatbv_type(typet &type)
 class c_bit_field_typet:public bitvector_typet
 {
 public:
-  explicit c_bit_field_typet(const typet &_subtype, std::size_t width)
+  explicit c_bit_field_typet(typet _subtype, std::size_t width)
     : bitvector_typet(ID_c_bit_field, width)
   {
-    subtype() = _subtype;
+    subtype().swap(_subtype);
   }
 
   // These have a sub-type
@@ -1503,10 +1491,10 @@ inline c_bit_field_typet &to_c_bit_field_type(typet &type)
 class pointer_typet:public bitvector_typet
 {
 public:
-  pointer_typet(const typet &_subtype, std::size_t width)
+  pointer_typet(typet _subtype, std::size_t width)
     : bitvector_typet(ID_pointer, width)
   {
-    subtype() = _subtype;
+    subtype().swap(_subtype);
   }
 
   signedbv_typet difference_type() const
@@ -1561,8 +1549,8 @@ inline pointer_typet &to_pointer_type(typet &type)
 class reference_typet:public pointer_typet
 {
 public:
-  reference_typet(const typet &_subtype, std::size_t _width):
-    pointer_typet(_subtype, _width)
+  reference_typet(typet _subtype, std::size_t _width)
+    : pointer_typet(std::move(_subtype), _width)
   {
     set(ID_C_reference, true);
   }
@@ -1798,8 +1786,8 @@ public:
   {
   }
 
-  explicit complex_typet(const typet &_subtype):
-    type_with_subtypet(ID_complex, _subtype)
+  explicit complex_typet(typet _subtype)
+    : type_with_subtypet(ID_complex, std::move(_subtype))
   {
   }
 };

--- a/src/util/type.h
+++ b/src/util/type.h
@@ -31,9 +31,10 @@ public:
   typet() { }
 
   explicit typet(const irep_idt &_id):irept(_id) { }
-  typet(const irep_idt &_id, const typet &_subtype):irept(_id)
+
+  typet(irep_idt _id, typet _subtype)
+    : irept(std::move(_id), {}, {std::move(_subtype)})
   {
-    subtype()=_subtype;
   }
 
   const typet &subtype() const
@@ -140,10 +141,9 @@ public:
   DEPRECATED("use type_with_subtypet(id, subtype) instead")
   explicit type_with_subtypet(const irep_idt &_id):typet(_id) { }
 
-  type_with_subtypet(const irep_idt &_id, const typet &_subtype):
-    typet(_id)
+  type_with_subtypet(irep_idt _id, typet _subtype)
+    : typet(std::move(_id), std::move(_subtype))
   {
-    subtype()=_subtype;
   }
 
   #if 0

--- a/unit/util/irep.cpp
+++ b/unit/util/irep.cpp
@@ -194,6 +194,13 @@ SCENARIO("irept_memory", "[core][utils][irept]")
       named_sub_size =
         std::distance(irep.get_named_sub().begin(), irep.get_named_sub().end());
       REQUIRE(named_sub_size == 3);
+
+      irept irep5("moved_irep");
+      irep.add("a_moved_element", std::move(irep5));
+      REQUIRE(irep.find("a_moved_element").id() == "moved_irep");
+      named_sub_size =
+        std::distance(irep.get_named_sub().begin(), irep.get_named_sub().end());
+      REQUIRE(named_sub_size == 4);
     }
 
     THEN("Setting and getting works")
@@ -222,6 +229,10 @@ SCENARIO("irept_memory", "[core][utils][irept]")
       REQUIRE(irep.get_int("numeric_id") == 42);
       REQUIRE(irep.get_size_t("numeric_id") == 42u);
       REQUIRE(irep.get_long_long("numeric_id") == 42);
+
+      irept irep3("move me");
+      irep.set("another_moved_element", std::move(irep3));
+      REQUIRE(irep.find("another_moved_element").id() == "move me");
 
       irep.clear();
       REQUIRE(irep.id().empty());


### PR DESCRIPTION
This should enable use (with performance benefit) of rvalue references in
higher-level APIs.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.