### PR TITLE
Inline side_effect_exprt* constructors

### DIFF
--- a/src/util/std_code.cpp
+++ b/src/util/std_code.cpp
@@ -145,34 +145,3 @@ code_blockt create_fatal_assertion(
 
   return result;
 }
-
-side_effect_exprt::side_effect_exprt(
-  const irep_idt &statement,
-  const typet &_type,
-  const source_locationt &loc)
-  : exprt(ID_side_effect, _type)
-{
-  set_statement(statement);
-  add_source_location() = loc;
-}
-
-side_effect_expr_nondett::side_effect_expr_nondett(
-  const typet &_type,
-  const source_locationt &loc)
-  : side_effect_exprt(ID_nondet, _type, loc)
-{
-  set_nullable(true);
-}
-
-side_effect_expr_function_callt::side_effect_expr_function_callt(
-  const exprt &_function,
-  const exprt::operandst &_arguments,
-  const typet &_type,
-  const source_locationt &loc)
-  : side_effect_exprt(ID_function_call, _type, loc)
-{
-  operands().resize(2);
-  op1().id(ID_arguments);
-  function() = _function;
-  arguments() = _arguments;
-}

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -1443,7 +1443,12 @@ public:
   side_effect_exprt(
     const irep_idt &statement,
     const typet &_type,
-    const source_locationt &loc);
+    const source_locationt &loc)
+    : exprt(ID_side_effect, _type)
+  {
+    set_statement(statement);
+    add_source_location() = loc;
+  }
 
   const irep_idt &get_statement() const
   {
@@ -1508,7 +1513,11 @@ public:
     set_nullable(true);
   }
 
-  side_effect_expr_nondett(const typet &_type, const source_locationt &loc);
+  side_effect_expr_nondett(const typet &_type, const source_locationt &loc)
+    : side_effect_exprt(ID_nondet, _type, loc)
+  {
+    set_nullable(true);
+  }
 
   void set_nullable(bool nullable)
   {
@@ -1592,7 +1601,12 @@ public:
     const exprt &_function,
     const exprt::operandst &_arguments,
     const typet &_type,
-    const source_locationt &loc);
+    const source_locationt &loc)
+    : side_effect_exprt(ID_function_call, _type, loc)
+  {
+    add_to_operands(_function, exprt(ID_arguments));
+    arguments() = _arguments;
+  }
 
   exprt &function()
   {


### PR DESCRIPTION
There is no particular reason not to inline those, as we do for all trivial
ones.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
