### PR TITLE
Mark deprecated constructors as such

### DIFF
--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -576,6 +576,7 @@ code_blockt create_fatal_assertion(
 class code_ifthenelset:public codet
 {
 public:
+  DEPRECATED("use code_ifthenelset(condition, then_code[, else_code]) instead")
   code_ifthenelset():codet(ID_ifthenelse)
   {
     operands().resize(3);
@@ -837,6 +838,7 @@ inline code_dowhilet &to_code_dowhile(codet &code)
 class code_fort:public codet
 {
 public:
+  DEPRECATED("use code_fort(init, cond, iter, body) instead")
   code_fort():codet(ID_for)
   {
     operands().resize(4);
@@ -1860,6 +1862,7 @@ static inline const code_landingpadt &to_code_landingpad(const codet &code)
 class code_try_catcht:public codet
 {
 public:
+  DEPRECATED("use code_try_catcht(try_code) instead")
   code_try_catcht():codet(ID_try_catch)
   {
     operands().resize(1);

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -351,6 +351,7 @@ public:
     add_to_operands(_op);
   }
 
+  DEPRECATED("use unary_exprt(id, op, type) instead")
   unary_exprt(
     const irep_idt &_id,
     const typet &_type):exprt(_id, _type)
@@ -632,6 +633,7 @@ inline void validate_expr(const bswap_exprt &value)
 class predicate_exprt:public exprt
 {
 public:
+  DEPRECATED("use predicate_exprt(id) instead")
   predicate_exprt():exprt(irep_idt(), bool_typet())
   {
   }
@@ -641,6 +643,7 @@ public:
   {
   }
 
+  DEPRECATED("use unary_predicate_exprt(id, op) instead")
   predicate_exprt(
     const irep_idt &_id,
     const exprt &_op):exprt(_id, bool_typet())
@@ -648,6 +651,7 @@ public:
     add_to_operands(_op);
   }
 
+  DEPRECATED("use binary_predicate_exprt(op1, id, op2) instead")
   predicate_exprt(
     const irep_idt &_id,
     const exprt &_op0,
@@ -662,10 +666,12 @@ public:
 class unary_predicate_exprt:public unary_exprt
 {
 public:
+  DEPRECATED("use unary_predicate_exprt(id, op) instead")
   unary_predicate_exprt():unary_exprt(irep_idt(), bool_typet())
   {
   }
 
+  DEPRECATED("use unary_predicate_exprt(id, op) instead")
   explicit unary_predicate_exprt(const irep_idt &_id):
     unary_exprt(_id, bool_typet())
   {
@@ -687,6 +693,7 @@ protected:
 class sign_exprt:public unary_predicate_exprt
 {
 public:
+  DEPRECATED("use sign_exprt(op) instead")
   sign_exprt()
   {
   }
@@ -746,6 +753,7 @@ public:
     operands().resize(2);
   }
 
+  DEPRECATED("use binary_exprt(lhs, id, rhs, type) instead")
   binary_exprt(
     const irep_idt &_id,
     const typet &_type):exprt(_id, _type)
@@ -830,10 +838,12 @@ template<> inline bool can_cast_expr<binary_exprt>(const exprt &base)
 class binary_predicate_exprt:public binary_exprt
 {
 public:
+  DEPRECATED("use binary_predicate_exprt(lhs, id, rhs) instead")
   binary_predicate_exprt():binary_exprt(irep_idt(), bool_typet())
   {
   }
 
+  DEPRECATED("use binary_predicate_exprt(lhs, id, rhs) instead")
   explicit binary_predicate_exprt(const irep_idt &_id):
     binary_exprt(_id, bool_typet())
   {
@@ -871,10 +881,12 @@ public:
 class binary_relation_exprt:public binary_predicate_exprt
 {
 public:
+  DEPRECATED("use binary_relation_exprt(lhs, id, rhs) instead")
   binary_relation_exprt()
   {
   }
 
+  DEPRECATED("use binary_relation_exprt(lhs, id, rhs) instead")
   explicit binary_relation_exprt(const irep_idt &id):
     binary_predicate_exprt(id)
   {
@@ -3965,6 +3977,7 @@ public:
   {
   }
 
+  DEPRECATED("use isnan_exprt(op) instead")
   isnan_exprt():unary_predicate_exprt(ID_isnan)
   {
   }
@@ -4010,6 +4023,7 @@ public:
   {
   }
 
+  DEPRECATED("use isinf_exprt(op) instead")
   isinf_exprt():unary_predicate_exprt(ID_isinf)
   {
   }
@@ -4059,6 +4073,7 @@ public:
   {
   }
 
+  DEPRECATED("use isfinite_exprt(op) instead")
   isfinite_exprt():unary_predicate_exprt(ID_isfinite)
   {
   }
@@ -4104,6 +4119,7 @@ public:
   {
   }
 
+  DEPRECATED("use isnormal_exprt(op) instead")
   isnormal_exprt():unary_predicate_exprt(ID_isnormal)
   {
   }
@@ -4144,6 +4160,7 @@ inline void validate_expr(const isnormal_exprt &value)
 class ieee_float_equal_exprt:public binary_relation_exprt
 {
 public:
+  DEPRECATED("use ieee_float_equal_exprt(lhs, rhs) instead")
   ieee_float_equal_exprt():binary_relation_exprt(ID_ieee_float_equal)
   {
   }
@@ -4194,6 +4211,7 @@ inline void validate_expr(const ieee_float_equal_exprt &value)
 class ieee_float_notequal_exprt:public binary_relation_exprt
 {
 public:
+  DEPRECATED("use ieee_float_notequal_exprt(lhs, rhs) instead")
   ieee_float_notequal_exprt():
     binary_relation_exprt(ID_ieee_float_notequal)
   {
@@ -4246,6 +4264,7 @@ inline void validate_expr(const ieee_float_notequal_exprt &value)
 class ieee_float_op_exprt:public exprt
 {
 public:
+  DEPRECATED("use ieee_float_op_exprt(lhs, id, rhs, rm) instead")
   ieee_float_op_exprt()
   {
     operands().resize(3);

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -1828,6 +1828,7 @@ inline vector_typet &to_vector_type(typet &type)
 class complex_typet:public type_with_subtypet
 {
 public:
+  DEPRECATED("use complex_typet(type) instead")
   complex_typet():type_with_subtypet(ID_complex)
   {
   }

--- a/src/util/type.h
+++ b/src/util/type.h
@@ -135,7 +135,9 @@ public:
 class type_with_subtypet:public typet
 {
 public:
+  DEPRECATED("use type_with_subtypet(id, subtype) instead")
   explicit type_with_subtypet(const irep_idt &_id):typet(_id) { }
+
   type_with_subtypet(const irep_idt &_id, const typet &_subtype):
     typet(_id)
   {
@@ -169,8 +171,10 @@ class type_with_subtypest:public typet
 public:
   typedef std::vector<typet> subtypest;
 
+  DEPRECATED("use type_with_subtypest(id, subtypes) instead")
   type_with_subtypest() { }
 
+  DEPRECATED("use type_with_subtypest(id, subtypes) instead")
   explicit type_with_subtypest(const irep_idt &_id):typet(_id) { }
 
   type_with_subtypest(const irep_idt &_id, const subtypest &_subtypes)


### PR DESCRIPTION
Each class has constructors that enable RAII.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
