### PR TITLE
Remove unnecessary "explicit"

### DIFF
--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -1650,7 +1650,7 @@ public:
   {
   }
 
-  explicit side_effect_expr_throwt(
+  side_effect_expr_throwt(
     const irept &exception_list,
     const typet &type,
     const source_locationt &loc)

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -1832,11 +1832,11 @@ public:
   {
   }
 
-  explicit union_exprt(
+  union_exprt(
     const irep_idt &_component_name,
     const exprt &_value,
-    const typet &_type):
-    unary_exprt(ID_union, _value, _type)
+    const typet &_type)
+    : unary_exprt(ID_union, _value, _type)
   {
     set_component_name(_component_name);
   }
@@ -1954,9 +1954,11 @@ public:
   {
   }
 
-  explicit complex_exprt(
-    const exprt &_real, const exprt &_imag, const complex_typet &_type):
-    binary_exprt(_real, ID_complex, _imag, _type)
+  complex_exprt(
+    const exprt &_real,
+    const exprt &_imag,
+    const complex_typet &_type)
+    : binary_exprt(_real, ID_complex, _imag, _type)
   {
   }
 
@@ -4534,9 +4536,8 @@ public:
   {
   }
 
-  explicit concatenation_exprt(
-    const exprt &_op0, const exprt &_op1, const typet &_type):
-    exprt(ID_concatenation, _type)
+  concatenation_exprt(const exprt &_op0, const exprt &_op1, const typet &_type)
+    : exprt(ID_concatenation, _type)
   {
     add_to_operands(_op0, _op1);
   }


### PR DESCRIPTION
The constructor has more than one parameter.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
