### PR TITLE
Add a non-deprecated constructor to code_try_catcht

### DIFF
--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -7766,16 +7766,13 @@ bool Parser::rTryStatement(codet &statement)
     if(lex.get_token(try_token)!=TOK_TRY)
       return false;
 
-    statement=codet(ID_try_catch);
-    statement.operands().reserve(2);
-    set_location(statement, try_token);
-
     codet body;
 
     if(!rCompoundStatement(body))
       return false;
 
-    statement.move_to_operands(body);
+    statement = code_try_catcht(std::move(body));
+    set_location(statement, try_token);
   }
 
   // iterate while there are catch clauses

--- a/src/jsil/jsil_convert.cpp
+++ b/src/jsil/jsil_convert.cpp
@@ -89,8 +89,7 @@ bool jsil_convertt::convert_code(const symbolt &symbol, codet &code)
         to_symbol_expr(a.rhs().op1()).get_identifier();
       code_gotot g(c_target);
 
-      code_try_catcht t_c;
-      t_c.try_code().swap(t);
+      code_try_catcht t_c(std::move(t));
       // Adding empty symbol to catch decl
       code_declt d(symbol_exprt("decl_symbol"));
       t_c.add_catch(d, g);

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -1865,6 +1865,12 @@ public:
     operands().resize(1);
   }
 
+  /// A statement representing try \p _try_code catch ...
+  explicit code_try_catcht(const codet &_try_code) : codet(ID_try_catch)
+  {
+    add_to_operands(_try_code);
+  }
+
   codet &try_code()
   {
     return static_cast<codet &>(op0());


### PR DESCRIPTION
Also use this new constructor in the two places that creates a code_try_catcht.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
