### PR TITLE
Remove unused code_ifthenelset object

### DIFF
--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -1295,17 +1295,14 @@ exprt java_string_library_preprocesst::get_object_at_index(
 /// char tmp_char;
 /// boolean tmp_boolean;
 /// Object* arg_i=get_object_at_index(argv, index)
-/// if(arg_i!=NULL)
+/// if(arg_i.@class_identifier=="java::java.lang.String")
 /// {
-///   if(arg_i.@class_identifier=="java::java.lang.String")
-///   {
-///     arg_i_string_expr = (string_expr)((String*)arg_i_as_string)
-///   }
-///   tmp_int=((Integer)arg_i)->value
-///   tmp_float=((Float)arg_i)->value
-///   tmp_char=((Char)arg_i)->value
-///   tmp_boolean=((Boolean)arg_i)->value
+///   arg_i_string_expr = (string_expr)((String*)arg_i_as_string)
 /// }
+/// tmp_int=((Integer)arg_i)->value
+/// tmp_float=((Float)arg_i)->value
+/// tmp_char=((Char)arg_i)->value
+/// tmp_boolean=((Boolean)arg_i)->value
 /// arg_i_struct = { string_expr=arg_i_string_expr;
 ///   integer=tmp_int; float=tmp_float; char=tmp_char; boolean=tmp_boolean}
 /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1375,10 +1372,6 @@ exprt java_string_library_preprocesst::make_argument_for_format(
         equal_exprt(arg_i, null_pointer_exprt(to_pointer_type(arg_i.type()))))),
     loc);
 
-  // if arg_i != null then [code_not_null]
-  code_ifthenelset code_avoid_null_arg;
-  code_avoid_null_arg.cond()=not_exprt(equal_exprt(
-    arg_i, null_pointer_exprt(to_pointer_type(arg_i.type()))));
   code_blockt code_not_null;
 
   // Assigning all the fields of arg_i_struct


### PR DESCRIPTION
Although the comments claimed to construct a conditional branch, the body is
eventually added without the precondition. The code_ifthenelset object can thus
be removed. Comments updated accordingly.

@romainbrenguier It is perfectly possible that this conditional should instead be used, in which case there ought to be some regression test to witness the need for it. (And it should then be re-labelled "bugfix" rather than "cleanup.")

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
