### PR TITLE
bv_arithmetict: Lift precondition to from_expr's interface

### DIFF
--- a/src/util/bv_arithmetic.cpp
+++ b/src/util/bv_arithmetic.cpp
@@ -82,7 +82,7 @@ mp_integer bv_arithmetict::pack() const
   return value+power(2, spec.width);
 }
 
-exprt bv_arithmetict::to_expr() const
+constant_exprt bv_arithmetict::to_expr() const
 {
   return constant_exprt(integer2bvrep(value, spec.width), spec.to_type());
 }
@@ -180,10 +180,8 @@ void bv_arithmetict::change_spec(const bv_spect &dest_spec)
   adjust();
 }
 
-void bv_arithmetict::from_expr(const exprt &expr)
+void bv_arithmetict::from_expr(const constant_exprt &expr)
 {
-  PRECONDITION(expr.is_constant());
   spec=bv_spect(expr.type());
-  value = bvrep2integer(
-    to_constant_expr(expr).get_value(), spec.width, spec.is_signed);
+  value = bvrep2integer(expr.get_value(), spec.width, spec.is_signed);
 }

--- a/src/util/bv_arithmetic.h
+++ b/src/util/bv_arithmetic.h
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "mp_arith.h"
 #include "format_spec.h"
 
+class constant_exprt;
 class exprt;
 class typet;
 
@@ -60,7 +61,7 @@ public:
   {
   }
 
-  explicit bv_arithmetict(const exprt &expr)
+  explicit bv_arithmetict(const constant_exprt &expr)
   {
     from_expr(expr);
   }
@@ -91,8 +92,8 @@ public:
   std::string format(const format_spect &format_spec) const;
 
   // expressions
-  exprt to_expr() const;
-  void from_expr(const exprt &expr);
+  constant_exprt to_expr() const;
+  void from_expr(const constant_exprt &expr);
 
   bv_arithmetict &operator/=(const bv_arithmetict &other);
   bv_arithmetict &operator*=(const bv_arithmetict &other);


### PR DESCRIPTION
Only constant_exprt are accepted, thus input parameter's type should guarantee
this. Also update to_expr, which can only generate constant_exprt. Note that
neither of these functions is currently used in the code base.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
