### PR TITLE
Remove unused value_set_dereferencet::get_symbol

### DIFF
--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -32,14 +32,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/simplify_expr.h>
 #include <util/ssa_expr.h>
 
-const exprt &value_set_dereferencet::get_symbol(const exprt &expr)
-{
-  if(expr.id()==ID_member || expr.id()==ID_index)
-    return get_symbol(expr.op0());
-
-  return expr;
-}
-
 exprt value_set_dereferencet::dereference(
   const exprt &pointer,
   const guardt &guard,

--- a/src/pointer-analysis/value_set_dereference.h
+++ b/src/pointer-analysis/value_set_dereference.h
@@ -95,8 +95,6 @@ private:
 
   valuet build_reference_to(const exprt &what, const exprt &pointer);
 
-  static const exprt &get_symbol(const exprt &object);
-
   bool memory_model(exprt &value, const typet &type, const exprt &offset);
 
   bool memory_model_bytes(


### PR DESCRIPTION
What this method attempts is better done via, e.g., object_descriptor_exprt. But
it's never used anyway, so just remove it without replacement.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
