### PR TITLE
Optimize loop of phi_function

### DIFF
--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -17,7 +17,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/expr_util.h>
 #include <util/invariant.h>
 #include <util/pointer_offset_size.h>
-#include <util/range.h>
 #include <util/std_expr.h>
 
 #include <analyses/dirty.h>
@@ -517,26 +516,9 @@ void goto_symext::phi_function(
   const statet::goto_statet &goto_state,
   statet &dest_state)
 {
-  auto ssa_of_current_name =
-    [&](const std::pair<irep_idt, std::pair<ssa_exprt, unsigned>> &pair) {
-      return pair.second.first;
-    };
-
-  auto dest_state_names_range =
-    make_range(dest_state.level2.current_names)
-      .filter(
-        [&](const std::pair<irep_idt, std::pair<ssa_exprt, unsigned>> &pair) {
-          // We ignore the identifiers that are already in goto_state names
-          return goto_state.level2_current_names.count(pair.first) == 0;
-        })
-      .map<const ssa_exprt>(ssa_of_current_name);
-
-  // go over all variables to see what changed
-  auto all_current_names_range = make_range(goto_state.level2_current_names)
-                                   .map<const ssa_exprt>(ssa_of_current_name)
-                                   .concat(dest_state_names_range);
-
-  if(all_current_names_range.empty())
+  if(
+    goto_state.level2_current_names.empty() &&
+    dest_state.level2.current_names.empty())
     return;
 
   guardt diff_guard = goto_state.guard;

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -376,14 +376,12 @@ void goto_symext::phi_function(
                                    .map<const ssa_exprt>(ssa_of_current_name)
                                    .concat(dest_state_names_range);
 
-  guardt diff_guard;
-  if(!all_current_names_range.empty())
-  {
-    diff_guard=goto_state.guard;
+  if(all_current_names_range.empty())
+    return;
 
-    // this gets the diff between the guards
-    diff_guard-=dest_state.guard;
-  }
+  guardt diff_guard = goto_state.guard;
+  // this gets the diff between the guards
+  diff_guard -= dest_state.guard;
 
   for(const auto &ssa : all_current_names_range)
   {

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -366,6 +366,8 @@ void goto_symext::merge_value_sets(
 ///   added to the target be simplified
 /// \param[out] target: equation that will receive the resulting assignment
 /// \param ssa: SSA expression to merge
+/// \param goto_count: current level 2 count in \p goto_state of \p l1_identifier
+/// \param dest_count: level 2 count in \p dest_state of \p l1_identifier
 static void merge_names(
   const goto_symext::statet::goto_statet &goto_state,
   goto_symext::statet &dest_state,
@@ -375,7 +377,9 @@ static void merge_names(
   messaget &log,
   const bool do_simplify,
   symex_target_equationt &target,
-  const ssa_exprt &ssa)
+  const ssa_exprt &ssa,
+  const unsigned goto_count,
+  const unsigned dest_count)
 {
   const irep_idt l1_identifier = ssa.get_identifier();
   const irep_idt &obj_identifier = ssa.get_object_name();
@@ -383,9 +387,7 @@ static void merge_names(
   if(obj_identifier == guard_identifier)
     return; // just a guard, don't bother
 
-  if(
-    goto_state.level2_current_count(l1_identifier) ==
-    dest_state.level2.current_count(l1_identifier))
+  if(goto_count == dest_count)
     return; // not at all changed
 
   // changed!
@@ -417,8 +419,7 @@ static void merge_names(
     if(p_it != goto_state.propagation.end())
       goto_state_rhs = p_it->second;
     else
-      to_ssa_expr(goto_state_rhs)
-        .set_level_2(goto_state.level2_current_count(l1_identifier));
+      to_ssa_expr(goto_state_rhs).set_level_2(goto_count);
   }
 
   {
@@ -427,8 +428,7 @@ static void merge_names(
     if(p_it != dest_state.propagation.end())
       dest_state_rhs = p_it->second;
     else
-      to_ssa_expr(dest_state_rhs)
-        .set_level_2(dest_state.level2.current_count(l1_identifier));
+      to_ssa_expr(dest_state_rhs).set_level_2(dest_count);
   }
 
   exprt rhs;
@@ -441,11 +441,11 @@ static void merge_names(
     rhs = goto_state_rhs;
   else if(goto_state.guard.is_false())
     rhs = dest_state_rhs;
-  else if(goto_state.level2_current_count(l1_identifier) == 0)
+  else if(goto_count == 0)
   {
     rhs = dest_state_rhs;
   }
-  else if(dest_state.level2.current_count(l1_identifier) == 0)
+  else if(dest_count == 0)
   {
     rhs = goto_state_rhs;
   }
@@ -511,6 +511,8 @@ void goto_symext::phi_function(
 
   for(const auto &ssa : all_current_names_range)
   {
+    const unsigned goto_count = goto_state.level2_current_count(l1_identifier);
+    const unsigned dest_count = dest_state.level2.current_count(l1_identifier);
     merge_names(
       goto_state,
       dest_state,
@@ -520,7 +522,9 @@ void goto_symext::phi_function(
       log,
       symex_config.simplify_opt,
       target,
-      ssa);
+      ssa,
+      goto_count,
+      dest_count);
   }
 }
 

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -21,6 +21,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/std_expr.h>
 
 #include <analyses/dirty.h>
+#include <util/simplify_expr.h>
 
 void goto_symext::symex_goto(statet &state)
 {
@@ -459,7 +460,8 @@ void goto_symext::phi_function(
     else
     {
       rhs=if_exprt(diff_guard.as_expr(), goto_state_rhs, dest_state_rhs);
-      do_simplify(rhs);
+      if(symex_config.simplify_opt)
+        simplify(rhs, ns);
     }
 
     ssa_exprt new_lhs = ssa;

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -354,6 +354,18 @@ void goto_symext::merge_value_sets(
   dest.value_set.make_union(src.value_set);
 }
 
+/// Helper function for \c phi_function which merges the names of an identifier
+/// for two different states.
+/// \param goto_state: first state
+/// \param[in, out] dest_state: second state
+/// \param ns: namespace
+/// \param diff_guard: difference between the guards of the two states
+/// \param guard_identifier: prefix used for goto symex guards
+/// \param[out] log: logger for debug messages
+/// \param do_simplify: should the right-hand-side of the assignment that is
+///   added to the target be simplified
+/// \param[out] target: equation that will receive the resulting assignment
+/// \param ssa: SSA expression to merge
 static void merge_names(
   const goto_symext::statet::goto_statet &goto_state,
   goto_symext::statet &dest_state,

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -439,9 +439,8 @@ static void merge_names(
   // may have been introduced by symex_start_thread (and will
   // only later be removed from level2.current_names by pop_frame
   // once the thread is executed)
-  if(
-    !ssa.get_level_0().empty() &&
-    ssa.get_level_0() != std::to_string(dest_state.source.thread_nr))
+  const irep_idt level_0 = ssa.get_level_0();
+  if(!level_0.empty() && level_0 != std::to_string(dest_state.source.thread_nr))
     return;
 
   exprt goto_state_rhs = ssa, dest_state_rhs = ssa;


### PR DESCRIPTION
This function was performing unnecessary lookups (even after `ranget`), we avoid this by introducing a function which goes through both maps and use the fact that they are ordered.

I tested this optimization on 73 methods from tika which where taking between 600ms and 30s with --show-vcc and --verbosity 0,  the total time was improved by 20% (from 229s to 185s). Here is a comparison of the execution times 
![perf_out](https://user-images.githubusercontent.com/11854194/49379661-8b60aa80-f707-11e8-8800-08b4862ce8e0.png)




<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
