### PR TITLE
Treat unexpected Doxygen output as warnings

### DIFF
--- a/scripts/filter_expected_warnings.py
+++ b/scripts/filter_expected_warnings.py
@@ -55,10 +55,11 @@ class WarningsList(object):
             elif line.startswith('  '):
                 current.otherlines.append(line.strip())
             else:
-                # Assuming all warnings are of the form [path:line: warning:...]
+                # Warnings are usually of the form [path:line: warning:...]
                 # (and the warnings about too many nodes have been filtered out).
-                print('Error filtering warnings: Unexpected input format.')
-                print('  Input:' + line)
+                # Treat any unexpected input lines as warnings.
+                current = DoxygenWarning(line, '', line)
+                self.warnings_list.append(current)
 
     def contains(self, warning):
         """Check if a similar warning is in this list."""


### PR DESCRIPTION
This changes the Doxygen output filter (filter_expected_warnings.py) so that the Travis job fails when it
encounters something unexpected.

Previously, the script was printing a message to the log when it encountered something unexpected, but not changing the return code.  For example, around 2018-11-14 (see e.g. commit af4b0b7de), the Travis job succeeded because this warning was not recognised as a warning:

    <unknown>:97: warning: unable to resolve reference to `instrumentation' for \ref command

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
