### PR TITLE
separate parameter identifiers from (mathematical) function signature

### DIFF
--- a/src/solvers/smt2/smt2_parser.h
+++ b/src/solvers/smt2/smt2_parser.h
@@ -37,6 +37,7 @@ public:
 
     typet type;
     exprt definition;
+    std::vector<irep_idt> parameters;
   };
 
   using id_mapt=std::map<irep_idt, idt>;
@@ -73,13 +74,35 @@ protected:
   irep_idt get_fresh_id(const irep_idt &);
   irep_idt rename_id(const irep_idt &) const;
 
+  struct signature_with_parameter_idst
+  {
+    typet type;
+    std::vector<irep_idt> parameters;
+
+    explicit signature_with_parameter_idst(const typet &_type) : type(_type)
+    {
+    }
+
+    signature_with_parameter_idst(
+      const typet &_type,
+      const std::vector<irep_idt> &_parameters)
+      : type(_type), parameters(_parameters)
+    {
+      PRECONDITION(
+        (_type.id() == ID_mathematical_function &&
+         to_mathematical_function_type(_type).domain().size() ==
+           _parameters.size()) ||
+        (_type.id() != ID_mathematical_function && _parameters.empty()));
+    }
+  };
+
   void ignore_command();
   exprt expression();
   exprt function_application();
   typet sort();
   exprt::operandst operands();
   typet function_signature_declaration();
-  typet function_signature_definition();
+  signature_with_parameter_idst function_signature_definition();
   exprt multi_ary(irep_idt, const exprt::operandst &);
   exprt binary_predicate(irep_idt, const exprt::operandst &);
   exprt binary(irep_idt, const exprt::operandst &);

--- a/src/solvers/smt2/smt2_solver.cpp
+++ b/src/solvers/smt2/smt2_solver.cpp
@@ -103,17 +103,18 @@ void smt2_solvert::expand_function_applications(exprt &expr)
       const auto f_type=
         to_mathematical_function_type(f.type);
 
-      DATA_INVARIANT(f_type.domain().size()==
-                     app.arguments().size(),
-                     "number of function parameters");
+      const auto &domain = f_type.domain();
+
+      DATA_INVARIANT(
+        domain.size() == app.arguments().size(),
+        "number of function parameters");
 
       replace_symbolt replace_symbol;
 
       std::map<irep_idt, exprt> parameter_map;
-      for(std::size_t i=0; i<f_type.domain().size(); i++)
+      for(std::size_t i = 0; i < domain.size(); i++)
       {
-        const auto &var = f_type.domain()[i];
-        const symbol_exprt s(var.get_identifier(), var.type());
+        const symbol_exprt s(f.parameters[i], domain[i]);
         replace_symbol.insert(s, app.arguments()[i]);
       }
 

--- a/src/util/mathematical_types.h
+++ b/src/util/mathematical_types.h
@@ -59,33 +59,8 @@ class mathematical_function_typet : public type_with_subtypest
 {
 public:
   // the domain of the function is composed of zero, one, or
-  // many variables
-  class variablet : public irept
-  {
-  public:
-    // the identifier is optional
-    irep_idt get_identifier() const
-    {
-      return get(ID_identifier);
-    }
-
-    void set_identifier(const irep_idt &identifier)
-    {
-      return set(ID_identifier, identifier);
-    }
-
-    typet &type()
-    {
-      return static_cast<typet &>(add(ID_type));
-    }
-
-    const typet &type() const
-    {
-      return static_cast<const typet &>(find(ID_type));
-    }
-  };
-
-  using domaint = std::vector<variablet>;
+  // many variables, given by their type
+  using domaint = std::vector<typet>;
 
   mathematical_function_typet(const domaint &_domain, const typet &_codomain)
     : type_with_subtypest(ID_mathematical_function)
@@ -105,11 +80,9 @@ public:
     return (const domaint &)to_type_with_subtypes(subtypes()[0]).subtypes();
   }
 
-  variablet &add_variable()
+  void add_variable(const typet &_type)
   {
-    auto &d = domain();
-    d.push_back(variablet());
-    return d.back();
+    domain().push_back(_type);
   }
 
   /// Return the codomain, i.e., the set of values that the function maps to


### PR DESCRIPTION
The parameter identifiers are not part of the function signature; removing
them enables direct comparison of types.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
