### PR TITLE
Fix symex-backtrace when the stack is empty

### DIFF
--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -765,6 +765,12 @@ void goto_symex_statet::get_l1_name(exprt &expr) const
 /// \param out: stream to write to
 void goto_symex_statet::print_backtrace(std::ostream &out) const
 {
+  if(threads[source.thread_nr].call_stack.empty())
+  {
+    out << "No stack!\n";
+    return;
+  }
+
   out << source.pc->function << " " << source.pc->location_number << "\n";
 
   for(auto stackit = threads[source.thread_nr].call_stack.rbegin(),


### PR DESCRIPTION
This happens when symex is about to exit; in this (and AFAIK only this) situation
the iterator source is invalid.
