### PR TITLE
Updated language use in Introduction

### DIFF
--- a/doc/cprover-manual/introduction.md
+++ b/doc/cprover-manual/introduction.md
@@ -4,11 +4,11 @@
 
 Numerous tools to hunt down functional design flaws in silicon have been
 available for many years, mainly due to the enormous cost of hardware
-bugs. The use of such tools is wide-spread. In contrast, the market for
+bugs. The use of such tools is widespread. In contrast, the market for
 tools that address the need for quality software is still in its
 infancy.
 
-Research in software quality has an enormous breadth. We focus the
+Research in software quality has enormous breadth. We focus the
 presentation using two criteria:
 
 1.  We believe that any form of quality requires a specific *guarantee*,
@@ -40,4 +40,4 @@ formally verify such bounds by means of *unwinding assertions*. Once
 this bound is established, CBMC is able to prove the absence of errors.
 
 A more detailed description of how to apply CBMC to verify programs is
-in the [CBMC Tutorial](../cbmc/tutorial/).
+in our [CBMC Tutorial](../cbmc/tutorial/).


### PR DESCRIPTION
First of a series of PRs to correct language use and to suggest improvements to CProver documentation.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] NOT RELEVANT Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [X] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] NOT RELEVANT Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [X] NOT RELEVANT My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.