### PR TITLE
Java now uses struct_tag types (2nd edition)

### DIFF
--- a/jbmc/src/java_bytecode/ci_lazy_methods.cpp
+++ b/jbmc/src/java_bytecode/ci_lazy_methods.cpp
@@ -65,7 +65,7 @@ ci_lazy_methodst::ci_lazy_methodst(
 ///   class
 static bool references_class_model(const exprt &expr)
 {
-  static const symbol_typet class_type("java::java.lang.Class");
+  static const struct_tag_typet class_type("java::java.lang.Class");
 
   for(auto it = expr.depth_begin(); it != expr.depth_end(); ++it)
   {

--- a/jbmc/src/java_bytecode/ci_lazy_methods_needed.cpp
+++ b/jbmc/src/java_bytecode/ci_lazy_methods_needed.cpp
@@ -101,7 +101,7 @@ void ci_lazy_methods_neededt::initialize_instantiated_classes_from_pointer(
   const pointer_typet &pointer_type,
   const namespacet &ns)
 {
-  const symbol_typet &class_type = to_symbol_type(pointer_type.subtype());
+  const auto &class_type = to_struct_tag_type(pointer_type.subtype());
   const auto &param_classid = class_type.get_identifier();
 
   // Note here: different arrays may have different element types, so we should
@@ -139,10 +139,10 @@ void ci_lazy_methods_neededt::gather_field_types(
   {
     // If class_type is not a symbol this may be a reference array,
     // but we can't tell what type.
-    if(class_type.id() == ID_symbol_type)
+    if(class_type.id() == ID_struct_tag)
     {
       const typet &element_type =
-        java_array_element_type(to_symbol_type(class_type));
+        java_array_element_type(to_struct_tag_type(class_type));
       if(element_type.id() == ID_pointer)
       {
         // This is a reference array -- mark its element type available.
@@ -154,11 +154,11 @@ void ci_lazy_methods_neededt::gather_field_types(
   {
     for(const auto &field : underlying_type.components())
     {
-      if(field.type().id() == ID_struct || field.type().id() == ID_symbol_type)
+      if(field.type().id() == ID_struct || field.type().id() == ID_struct_tag)
         gather_field_types(field.type(), ns);
       else if(field.type().id() == ID_pointer)
       {
-        if(field.type().subtype().id() == ID_symbol_type)
+        if(field.type().subtype().id() == ID_struct_tag)
         {
           add_all_needed_classes(to_pointer_type(field.type()));
         }

--- a/jbmc/src/java_bytecode/generic_parameter_specialization_map_keys.cpp
+++ b/jbmc/src/java_bytecode/generic_parameter_specialization_map_keys.cpp
@@ -147,7 +147,8 @@ void generic_parameter_specialization_map_keyst::insert_pairs_for_symbol(
   // - an incomplete class or
   // - a class that is neither generic nor implicitly generic (this
   //  may be due to unsupported class signature)
-  // then ignore the generic types in the struct_tag_type and do not add any pairs.
+  // then ignore the generic types in the struct_tag_type and do not add any
+  // pairs.
   // TODO TG-1996 should decide how mocking and generics should work
   // together. Currently an incomplete class is never marked as generic. If
   // this changes in TG-1996 then the condition below should be updated.

--- a/jbmc/src/java_bytecode/generic_parameter_specialization_map_keys.cpp
+++ b/jbmc/src/java_bytecode/generic_parameter_specialization_map_keys.cpp
@@ -136,29 +136,29 @@ void generic_parameter_specialization_map_keyst::insert_pairs_for_pointer(
 /// in the form of a symbol rather than a pointer (as opposed to the function
 /// insert_pairs_for_pointer). Own the keys and pop from their stack
 /// on destruction; otherwise do nothing.
-/// \param symbol_type symbol type to get the specialized generic types from
+/// \param struct_tag_type symbol type to get the specialized generic types from
 /// \param symbol_struct struct type of the symbol type, must be generic if
 /// the symbol is generic
 void generic_parameter_specialization_map_keyst::insert_pairs_for_symbol(
-  const symbol_typet &symbol_type,
+  const struct_tag_typet &struct_tag_type,
   const typet &symbol_struct)
 {
   // If the struct is:
   // - an incomplete class or
   // - a class that is neither generic nor implicitly generic (this
   //  may be due to unsupported class signature)
-  // then ignore the generic types in the symbol_type and do not add any pairs.
+  // then ignore the generic types in the struct_tag_type and do not add any pairs.
   // TODO TG-1996 should decide how mocking and generics should work
   // together. Currently an incomplete class is never marked as generic. If
   // this changes in TG-1996 then the condition below should be updated.
   if(
-    is_java_generic_symbol_type(symbol_type) &&
+    is_java_generic_struct_tag_type(struct_tag_type) &&
     !to_java_class_type(symbol_struct).get_is_stub() &&
     (is_java_generic_class_type(symbol_struct) ||
      is_java_implicitly_generic_class_type(symbol_struct)))
   {
-    const java_generic_symbol_typet &generic_symbol =
-      to_java_generic_symbol_type(symbol_type);
+    const java_generic_struct_tag_typet &generic_symbol =
+      to_java_generic_struct_tag_type(struct_tag_type);
 
     const std::vector<java_generic_parametert> &generic_parameters =
       get_all_generic_parameters(symbol_struct);

--- a/jbmc/src/java_bytecode/generic_parameter_specialization_map_keys.h
+++ b/jbmc/src/java_bytecode/generic_parameter_specialization_map_keys.h
@@ -1,3 +1,4 @@
+
 /// Author: Diffblue Ltd.
 
 #ifndef CPROVER_JAVA_BYTECODE_GENERIC_PARAMETER_SPECIALIZATION_MAP_KEYS_H
@@ -50,9 +51,8 @@ public:
   void insert_pairs_for_pointer(
     const pointer_typet &pointer_type,
     const typet &pointer_subtype_struct);
-  void insert_pairs_for_symbol(
-    const symbol_typet &symbol_type,
-    const typet &symbol_struct);
+  void
+  insert_pairs_for_symbol(const struct_tag_typet &, const typet &symbol_struct);
 
 private:
   /// Generic parameter specialization map to modify

--- a/jbmc/src/java_bytecode/java_bytecode_concurrency_instrumentation.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_concurrency_instrumentation.cpp
@@ -230,7 +230,7 @@ static void instrument_synchronized_code(
 
   // Create the finally block with the same label targeted in the catch-push
   const symbolt &tmp_symbol = get_fresh_aux_symbol(
-    java_reference_type(symbol_typet("java::java.lang.Throwable")),
+    java_reference_type(struct_tag_typet("java::java.lang.Throwable")),
     id2string(symbol.name),
     "caught-synchronized-exception",
     code.source_location(),

--- a/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
@@ -108,8 +108,7 @@ code_ifthenelset java_bytecode_instrumentt::throw_exception(
       struct_union_typet::componentst{});
   }
 
-  pointer_typet exc_ptr_type=
-    pointer_type(symbol_typet(exc_class_name));
+  pointer_typet exc_ptr_type = pointer_type(struct_tag_typet(exc_class_name));
 
   // Allocate and throw an instance of the exception class:
 

--- a/jbmc/src/java_bytecode/java_bytecode_language.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_language.cpp
@@ -362,7 +362,7 @@ static void infer_opaque_type_fields(
 static symbol_exprt get_or_create_class_literal_symbol(
   const irep_idt &class_id, symbol_tablet &symbol_table)
 {
-  symbol_typet java_lang_Class("java::java.lang.Class");
+  struct_tag_typet java_lang_Class("java::java.lang.Class");
   symbol_exprt symbol_expr(
     id2string(class_id) + JAVA_CLASS_MODEL_SUFFIX,
     java_lang_Class);

--- a/jbmc/src/java_bytecode/java_bytecode_parse_tree.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_parse_tree.cpp
@@ -105,8 +105,8 @@ java_bytecode_parse_treet::find_annotation(
       if(annotation.type.id() != ID_pointer)
         return false;
       const typet &type = annotation.type.subtype();
-      return type.id() == ID_symbol_type &&
-             to_symbol_type(type).get_identifier() == annotation_type_name;
+      return type.id() == ID_struct_tag &&
+             to_struct_tag_type(type).get_identifier() == annotation_type_name;
     });
   if(annotation_it == annotations.end())
     return {};

--- a/jbmc/src/java_bytecode/java_bytecode_parse_tree.h
+++ b/jbmc/src/java_bytecode/java_bytecode_parse_tree.h
@@ -117,7 +117,7 @@ struct java_bytecode_parse_treet
       std::size_t start_pc;
       std::size_t end_pc;
       std::size_t handler_pc;
-      symbol_typet catch_type;
+      struct_tag_typet catch_type;
     };
 
     typedef std::vector<exceptiont> exception_tablet;

--- a/jbmc/src/java_bytecode/java_bytecode_parser.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_parser.cpp
@@ -629,7 +629,7 @@ void java_bytecode_parsert::get_class_refs_rec(const typet &src)
     for(const auto &p : ct.parameters())
       get_class_refs_rec(p.type());
   }
-  else if(src.id()==ID_symbol_type)
+  else if(src.id() == ID_struct_tag)
   {
     irep_idt name=src.get(ID_C_base_name);
     if(has_prefix(id2string(name), "array["))
@@ -797,11 +797,9 @@ void java_bytecode_parsert::rconstant_pool()
         const pool_entryt &class_name_entry=pool_entry(class_entry.ref1);
         typet type=type_entry(nameandtype_entry.ref2);
 
-        symbol_typet class_symbol=
-          java_classname(id2string(class_name_entry.s));
+        auto class_tag = java_classname(id2string(class_name_entry.s));
 
-        fieldref_exprt fieldref(
-          type, name_entry.s, class_symbol.get_identifier());
+        fieldref_exprt fieldref(type, name_entry.s, class_tag.get_identifier());
 
         it->expr=fieldref;
       }
@@ -816,15 +814,13 @@ void java_bytecode_parsert::rconstant_pool()
         const pool_entryt &class_name_entry=pool_entry(class_entry.ref1);
         typet type=type_entry(nameandtype_entry.ref2);
 
-        symbol_typet class_symbol=
-          java_classname(id2string(class_name_entry.s));
+        auto class_tag = java_classname(id2string(class_name_entry.s));
 
         irep_idt component_name=
           id2string(name_entry.s)+
           ":"+id2string(pool_entry(nameandtype_entry.ref2).s);
 
-        irep_idt class_name=
-          class_symbol.get_identifier();
+        irep_idt class_name = class_tag.get_identifier();
 
         irep_idt identifier=
           id2string(class_name)+"."+id2string(component_name);
@@ -1252,8 +1248,8 @@ void java_bytecode_parsert::rmethod_attribute(methodt &method)
       method.exception_table[e].end_pc=end_pc;
       method.exception_table[e].handler_pc=handler_pc;
       if(catch_type!=0)
-        method.exception_table[e].catch_type=
-          to_symbol_type(pool_entry(catch_type).expr.type());
+        method.exception_table[e].catch_type =
+          to_struct_tag_type(pool_entry(catch_type).expr.type());
     }
 
     u2 attributes_count=read_u2();

--- a/jbmc/src/java_bytecode/java_bytecode_typecheck_type.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_typecheck_type.cpp
@@ -16,9 +16,9 @@ Author: Daniel Kroening, kroening@kroening.com
 
 void java_bytecode_typecheckt::typecheck_type(typet &type)
 {
-  if(type.id() == ID_symbol_type)
+  if(type.id() == ID_struct_tag)
   {
-    irep_idt identifier=to_symbol_type(type).get_identifier();
+    irep_idt identifier = to_struct_tag_type(type).get_identifier();
 
     auto type_symbol = symbol_table.lookup(identifier);
     DATA_INVARIANT(

--- a/jbmc/src/java_bytecode/java_entry_point.cpp
+++ b/jbmc/src/java_bytecode/java_entry_point.cpp
@@ -106,7 +106,7 @@ static const symbolt *get_class_literal_initializer(
 {
   if(symbol.value.is_not_nil())
     return nullptr;
-  if(symbol.type != symbol_typet("java::java.lang.Class"))
+  if(symbol.type != struct_tag_typet("java::java.lang.Class"))
     return nullptr;
   if(!has_suffix(id2string(symbol.name), JAVA_CLASS_MODEL_SUFFIX))
     return nullptr;
@@ -202,7 +202,7 @@ static void java_static_lifetime_init(
           throw 0;
         }
         set_class_identifier(
-          to_struct_expr(*zero_object), ns, to_symbol_type(sym.type));
+          to_struct_expr(*zero_object), ns, to_struct_tag_type(sym.type));
 
         code_block.add(
           std::move(code_assignt(sym.symbol_expr(), *zero_object)));
@@ -370,7 +370,7 @@ exprt::operandst java_build_arguments(
       main_arguments[param_number] = result_symbol.symbol_expr();
 
       std::vector<codet> cases(alternatives.size());
-      const auto initialize_parameter = [&](const symbol_typet &type) {
+      const auto initialize_parameter = [&](const struct_tag_typet &type) {
         code_blockt init_code_for_type;
         exprt init_expr_for_parameter = object_factory(
           java_reference_type(type),

--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -602,7 +602,7 @@ bool initialize_nondet_string_fields(
   if(struct_type.get_tag() == "java.lang.CharSequence")
   {
     set_class_identifier(
-      struct_expr, ns, symbol_typet("java::java.lang.String"));
+      struct_expr, ns, struct_tag_typet("java::java.lang.String"));
   }
 
   // OK, this is a String type with the expected fields -- add code to `code`
@@ -1018,7 +1018,7 @@ void java_object_factoryt::gen_nondet_struct_init(
     CHECK_RETURN(initial_object.has_value());
     irep_idt qualified_clsid = "java::" + id2string(class_identifier);
     set_class_identifier(
-      to_struct_expr(*initial_object), ns, symbol_typet(qualified_clsid));
+      to_struct_expr(*initial_object), ns, struct_tag_typet(qualified_clsid));
 
     // If the initialised type is a special-cased String type (one with length
     // and data fields introduced by string-library preprocessing), initialise
@@ -1191,9 +1191,9 @@ void java_object_factoryt::gen_nondet_init(
     if(is_sub)
     {
       const typet &symbol = override_ ? override_type : expr.type();
-      PRECONDITION(symbol.id() == ID_symbol_type);
+      PRECONDITION(symbol.id() == ID_struct_tag);
       generic_parameter_specialization_map_keys.insert_pairs_for_symbol(
-        to_symbol_type(symbol), struct_type);
+        to_struct_tag_type(symbol), struct_type);
     }
 
     gen_nondet_struct_init(
@@ -1327,7 +1327,7 @@ void java_object_factoryt::gen_nondet_array_init(
   const source_locationt &location)
 {
   PRECONDITION(expr.type().id()==ID_pointer);
-  PRECONDITION(expr.type().subtype().id() == ID_symbol_type);
+  PRECONDITION(expr.type().subtype().id() == ID_struct_tag);
   PRECONDITION(update_in_place!=update_in_placet::MAY_UPDATE_IN_PLACE);
 
   const typet &type=ns.follow(expr.type().subtype());

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -36,8 +36,8 @@ Date:   April 2017
 static irep_idt get_tag(const typet &type)
 {
   /// \todo Use follow instead of assuming tag to symbol relationship.
-  if(type.id() == ID_symbol_type)
-    return to_symbol_type(type).get_identifier();
+  if(type.id() == ID_struct_tag)
+    return to_struct_tag_type(type).get_identifier();
   else if(type.id() == ID_struct)
     return irep_idt("java::" + id2string(to_struct_type(type).get_tag()));
   else
@@ -214,7 +214,8 @@ void java_string_library_preprocesst::add_string_type(
   string_type.components().resize(3);
   string_type.components()[0].set_name("@java.lang.Object");
   string_type.components()[0].set_pretty_name("@java.lang.Object");
-  string_type.components()[0].type()=symbol_typet("java::java.lang.Object");
+  string_type.components()[0].type() =
+    struct_tag_typet("java::java.lang.Object");
   string_type.components()[1].set_name("length");
   string_type.components()[1].set_pretty_name("length");
   string_type.components()[1].type()=string_length_type();
@@ -222,11 +223,11 @@ void java_string_library_preprocesst::add_string_type(
   string_type.components()[2].set_pretty_name("data");
   string_type.components()[2].type() = pointer_type(java_char_type());
   string_type.set_access(ID_public);
-  string_type.add_base(symbol_typet("java::java.lang.Object"));
+  string_type.add_base(struct_tag_typet("java::java.lang.Object"));
 
   std::vector<irep_idt> bases = get_string_type_base_classes(class_name);
   for(const irep_idt &base_name : bases)
-    string_type.add_base(symbol_typet("java::" + id2string(base_name)));
+    string_type.add_base(struct_tag_typet("java::" + id2string(base_name)));
 
   symbolt tmp_string_symbol;
   tmp_string_symbol.name="java::"+id2string(class_name);
@@ -383,12 +384,12 @@ java_string_library_preprocesst::process_equals_function_operands(
 static const typet &
 get_data_type(const typet &type, const symbol_tablet &symbol_table)
 {
-  PRECONDITION(type.id() == ID_struct || type.id() == ID_symbol_type);
-  if(type.id() == ID_symbol_type)
+  PRECONDITION(type.id() == ID_struct || type.id() == ID_struct_tag);
+  if(type.id() == ID_struct_tag)
   {
     const symbolt &sym =
-      symbol_table.lookup_ref(to_symbol_type(type).get_identifier());
-    CHECK_RETURN(sym.type.id() != ID_symbol_type);
+      symbol_table.lookup_ref(to_struct_tag_type(type).get_identifier());
+    CHECK_RETURN(sym.type.id() != ID_struct_tag);
     return get_data_type(sym.type, symbol_table);
   }
   // else type id is ID_struct
@@ -403,12 +404,12 @@ get_data_type(const typet &type, const symbol_tablet &symbol_table)
 static const typet &
 get_length_type(const typet &type, const symbol_tablet &symbol_table)
 {
-  PRECONDITION(type.id() == ID_struct || type.id() == ID_symbol_type);
-  if(type.id() == ID_symbol_type)
+  PRECONDITION(type.id() == ID_struct || type.id() == ID_struct_tag);
+  if(type.id() == ID_struct_tag)
   {
     const symbolt &sym =
-      symbol_table.lookup_ref(to_symbol_type(type).get_identifier());
-    CHECK_RETURN(sym.type.id() != ID_symbol_type);
+      symbol_table.lookup_ref(to_struct_tag_type(type).get_identifier());
+    CHECK_RETURN(sym.type.id() != ID_struct_tag);
     return get_length_type(sym.type, symbol_table);
   }
   // else type id is ID_struct
@@ -881,9 +882,11 @@ void java_string_library_preprocesst::code_assign_java_string_to_string_expr(
   PRECONDITION(implements_java_char_sequence_pointer(rhs.type()));
 
   typet deref_type;
-  if(rhs.type().subtype().id() == ID_symbol_type)
-    deref_type=symbol_table.lookup_ref(
-      to_symbol_type(rhs.type().subtype()).get_identifier()).type;
+  if(rhs.type().subtype().id() == ID_struct_tag)
+    deref_type =
+      symbol_table
+        .lookup_ref(to_struct_tag_type(rhs.type().subtype()).get_identifier())
+        .type;
   else
     deref_type=rhs.type().subtype();
 
@@ -1180,48 +1183,48 @@ java_string_library_preprocesst::get_primitive_value_of_object(
   symbol_table_baset &symbol_table,
   code_blockt &code)
 {
-  optionalt<symbol_typet> object_type;
+  optionalt<struct_tag_typet> object_type;
 
   typet value_type;
   if(type_name==ID_boolean)
   {
     value_type=java_boolean_type();
-    object_type=symbol_typet("java::java.lang.Boolean");
+    object_type = struct_tag_typet("java::java.lang.Boolean");
   }
   else if(type_name==ID_char)
   {
     value_type=java_char_type();
-    object_type=symbol_typet("java::java.lang.Character");
+    object_type = struct_tag_typet("java::java.lang.Character");
   }
   else if(type_name==ID_byte)
   {
     value_type=java_byte_type();
-    object_type=symbol_typet("java::java.lang.Byte");
+    object_type = struct_tag_typet("java::java.lang.Byte");
   }
   else if(type_name==ID_short)
   {
     value_type=java_short_type();
-    object_type=symbol_typet("java::java.lang.Short");
+    object_type = struct_tag_typet("java::java.lang.Short");
   }
   else if(type_name==ID_int)
   {
     value_type=java_int_type();
-    object_type=symbol_typet("java::java.lang.Integer");
+    object_type = struct_tag_typet("java::java.lang.Integer");
   }
   else if(type_name==ID_long)
   {
     value_type=java_long_type();
-    object_type=symbol_typet("java::java.lang.Long");
+    object_type = struct_tag_typet("java::java.lang.Long");
   }
   else if(type_name==ID_float)
   {
     value_type=java_float_type();
-    object_type=symbol_typet("java::java.lang.Float");
+    object_type = struct_tag_typet("java::java.lang.Float");
   }
   else if(type_name==ID_double)
   {
     value_type=java_double_type();
-    object_type=symbol_typet("java::java.lang.Double");
+    object_type = struct_tag_typet("java::java.lang.Double");
   }
   else if(type_name==ID_void)
     return {};
@@ -1381,8 +1384,8 @@ struct_exprt java_string_library_preprocesst::make_argument_for_format(
 
     if(name=="string_expr")
     {
-      pointer_typet string_pointer=
-        java_reference_type(symbol_typet("java::java.lang.String"));
+      pointer_typet string_pointer =
+        java_reference_type(struct_tag_typet("java::java.lang.String"));
       typecast_exprt arg_i_as_string(arg_i, string_pointer);
       code_assign_java_string_to_string_expr(
         to_string_expr(field_expr),

--- a/jbmc/src/java_bytecode/java_string_literals.cpp
+++ b/jbmc/src/java_bytecode/java_string_literals.cpp
@@ -70,7 +70,7 @@ symbol_exprt get_or_create_string_literal_symbol(
 {
   PRECONDITION(string_expr.id() == ID_java_string_literal);
   const irep_idt value = string_expr.get(ID_value);
-  const symbol_typet string_type("java::java.lang.String");
+  const struct_tag_typet string_type("java::java.lang.String");
 
   const std::string escaped_symbol_name = escape_non_alnum(id2string(value));
   const std::string escaped_symbol_name_with_prefix =
@@ -96,7 +96,7 @@ symbol_exprt get_or_create_string_literal_symbol(
 
   // Regardless of string refinement setting, at least initialize
   // the literal with @clsid = String
-  symbol_typet jlo_symbol("java::java.lang.Object");
+  struct_tag_typet jlo_symbol("java::java.lang.Object");
   const auto &jlo_struct = to_struct_type(ns.follow(jlo_symbol));
   struct_exprt jlo_init(jlo_symbol);
   const auto &jls_struct = to_struct_type(ns.follow(string_type));

--- a/jbmc/src/java_bytecode/java_types.cpp
+++ b/jbmc/src/java_bytecode/java_types.cpp
@@ -917,10 +917,10 @@ void get_dependencies_from_generic_parameters(
 /// This assumes that the class named \p class_name_prefix extends or implements
 /// the class \p type, and that \p base_ref corresponds to a generic class.
 /// For instance since HashMap<K,V> extends Map<K,V> we would call
-/// `java_generic_struct_tag_typet(struct_tag_typet("Map"), "Ljava/util/Map<TK;TV;>;",
-/// "java.util.HashMap")` which generates a symbol type with identifier "Map",
-/// and two generic types with identifier "java.util.HashMap::K" and
-/// "java.util.HashMap::V" respectively.
+/// `java_generic_struct_tag_typet(struct_tag_typet("Map"),
+/// "Ljava/util/Map<TK;TV;>;", "java.util.HashMap")` which generates a symbol
+/// type with identifier "Map", and two generic types with identifier
+/// "java.util.HashMap::K" and "java.util.HashMap::V" respectively.
 java_generic_struct_tag_typet::java_generic_struct_tag_typet(
   const struct_tag_typet &type,
   const std::string &base_ref,

--- a/jbmc/src/java_bytecode/java_types.h
+++ b/jbmc/src/java_bytecode/java_types.h
@@ -358,11 +358,11 @@ typet java_boolean_type();
 typet java_void_type();
 reference_typet java_reference_type(const typet &subtype);
 reference_typet java_lang_object_type();
-symbol_typet java_classname(const std::string &);
+struct_tag_typet java_classname(const std::string &);
 
 reference_typet java_array_type(const char subtype);
-const typet &java_array_element_type(const symbol_typet &array_symbol);
-typet &java_array_element_type(symbol_typet &array_symbol);
+const typet &java_array_element_type(const struct_tag_typet &array_symbol);
+typet &java_array_element_type(struct_tag_typet &array_symbol);
 bool is_java_array_type(const typet &type);
 bool is_multidim_java_array_type(const typet &type);
 
@@ -397,15 +397,15 @@ bool equal_java_types(const typet &type1, const typet &type2);
 class java_generic_parametert:public reference_typet
 {
 public:
-  typedef symbol_typet type_variablet;
+  typedef struct_tag_typet type_variablet;
 
   java_generic_parametert(
     const irep_idt &_type_var_name,
-    const symbol_typet &_bound):
-    reference_typet(java_reference_type(_bound))
+    const struct_tag_typet &_bound)
+    : reference_typet(java_reference_type(_bound))
   {
     set(ID_C_java_generic_parameter, true);
-    type_variables().push_back(symbol_typet(_type_var_name));
+    type_variables().push_back(struct_tag_typet(_type_var_name));
   }
 
   /// \return the type variable as symbol type
@@ -748,16 +748,16 @@ void get_dependencies_from_generic_parameters(
   const typet &,
   std::set<irep_idt> &);
 
-/// Type for a generic symbol, extends symbol_typet with a
+/// Type for a generic symbol, extends struct_tag_typet with a
 /// vector of java generic types.
 /// This is used to store the type of generic superclasses and interfaces.
-class java_generic_symbol_typet : public symbol_typet
+class java_generic_struct_tag_typet : public struct_tag_typet
 {
 public:
   typedef std::vector<reference_typet> generic_typest;
 
-  java_generic_symbol_typet(
-    const symbol_typet &type,
+  java_generic_struct_tag_typet(
+    const struct_tag_typet &type,
     const std::string &base_ref,
     const std::string &class_name_prefix);
 
@@ -777,26 +777,27 @@ public:
 
 /// \param type: the type to check
 /// \return true if the type is a symbol type with generics
-inline bool is_java_generic_symbol_type(const typet &type)
+inline bool is_java_generic_struct_tag_type(const typet &type)
 {
   return type.get_bool(ID_C_java_generic_symbol);
 }
 
 /// \param type: the type to convert
 /// \return the converted type
-inline const java_generic_symbol_typet &
-to_java_generic_symbol_type(const typet &type)
+inline const java_generic_struct_tag_typet &
+to_java_generic_struct_tag_type(const typet &type)
 {
-  PRECONDITION(is_java_generic_symbol_type(type));
-  return static_cast<const java_generic_symbol_typet &>(type);
+  PRECONDITION(is_java_generic_struct_tag_type(type));
+  return static_cast<const java_generic_struct_tag_typet &>(type);
 }
 
 /// \param type: the type to convert
 /// \return the converted type
-inline java_generic_symbol_typet &to_java_generic_symbol_type(typet &type)
+inline java_generic_struct_tag_typet &
+to_java_generic_struct_tag_type(typet &type)
 {
-  PRECONDITION(is_java_generic_symbol_type(type));
-  return static_cast<java_generic_symbol_typet &>(type);
+  PRECONDITION(is_java_generic_struct_tag_type(type));
+  return static_cast<java_generic_struct_tag_typet &>(type);
 }
 
 /// Take a signature string and remove everything in angle brackets allowing for

--- a/jbmc/src/java_bytecode/remove_exceptions.cpp
+++ b/jbmc/src/java_bytecode/remove_exceptions.cpp
@@ -348,7 +348,7 @@ void remove_exceptionst::add_exception_dispatch_sequence(
         t_exc->function=instr_it->function;
 
         // use instanceof to check that this is the correct handler
-        symbol_typet type(stack_catch[i][j].first);
+        struct_tag_typet type(stack_catch[i][j].first);
         type_exprt expr(type);
 
         binary_predicate_exprt check(exc_thrown, ID_java_instanceof, expr);

--- a/jbmc/src/java_bytecode/remove_instanceof.cpp
+++ b/jbmc/src/java_bytecode/remove_instanceof.cpp
@@ -87,10 +87,10 @@ bool remove_instanceoft::lower_instanceof(
 
   // Find all types we know about that satisfy the given requirement:
   INVARIANT(
-    target_type.id() == ID_symbol_type,
+    target_type.id() == ID_struct_tag,
     "instanceof second operand should have a simple type");
-  const irep_idt &target_name=
-    to_symbol_type(target_type).get_identifier();
+  const irep_idt &target_name =
+    to_struct_tag_type(target_type).get_identifier();
   std::vector<irep_idt> children=
     class_hierarchy.get_children_trans(target_name);
   children.push_back(target_name);
@@ -104,7 +104,7 @@ bool remove_instanceoft::lower_instanceof(
   // Make temporaries to store the class identifier (avoids repeated derefs) and
   // the instanceof result:
 
-  symbol_typet jlo=to_symbol_type(java_lang_object_type().subtype());
+  auto jlo = to_struct_tag_type(java_lang_object_type().subtype());
   exprt object_clsid = get_class_identifier_field(check_ptr, jlo, ns);
 
   symbolt &clsid_tmp_sym = get_fresh_aux_symbol(

--- a/jbmc/src/java_bytecode/remove_java_new.cpp
+++ b/jbmc/src/java_bytecode/remove_java_new.cpp
@@ -96,7 +96,7 @@ goto_programt::targett remove_java_newt::lower_java_new(
   auto zero_object = zero_initializer(object_type, location, ns);
   CHECK_RETURN(zero_object.has_value());
   set_class_identifier(
-    to_struct_expr(*zero_object), ns, to_symbol_type(object_type));
+    to_struct_expr(*zero_object), ns, to_struct_tag_type(object_type));
   goto_programt::targett t_i = dest.insert_after(target);
   t_i->make_assignment(code_assignt(deref, *zero_object));
   t_i->source_location = location;
@@ -156,7 +156,7 @@ goto_programt::targett remove_java_newt::lower_java_new_array(
   auto zero_object = zero_initializer(object_type, location, ns);
   CHECK_RETURN(zero_object.has_value());
   set_class_identifier(
-    to_struct_expr(*zero_object), ns, to_symbol_type(object_type));
+    to_struct_expr(*zero_object), ns, to_struct_tag_type(object_type));
   goto_programt::targett t_i = dest.insert_before(next);
   t_i->make_assignment(code_assignt(deref, *zero_object));
   t_i->source_location = location;

--- a/jbmc/src/java_bytecode/select_pointer_type.cpp
+++ b/jbmc/src/java_bytecode/select_pointer_type.cpp
@@ -82,10 +82,10 @@ pointer_typet select_pointer_typet::specialize_generics(
     visited_nodes.erase(parameter_name);
     return returned_type;
   }
-  else if(pointer_type.subtype().id() == ID_symbol_type)
+  else if(pointer_type.subtype().id() == ID_struct_tag)
   {
     // if the pointer is an array, recursively specialize its element type
-    const symbol_typet &array_subtype = to_symbol_type(pointer_type.subtype());
+    const auto &array_subtype = to_struct_tag_type(pointer_type.subtype());
     if(is_java_array_tag(array_subtype.get_identifier()))
     {
       const typet &array_element_type = java_array_element_type(array_subtype);
@@ -208,7 +208,8 @@ select_pointer_typet::get_recursively_instantiated_type(
   return inst_val;
 }
 
-std::set<symbol_typet> select_pointer_typet::get_parameter_alternative_types(
+std::set<struct_tag_typet>
+select_pointer_typet::get_parameter_alternative_types(
   const irep_idt &function_name,
   const irep_idt &parameter_name,
   const namespacet &) const

--- a/jbmc/src/java_bytecode/select_pointer_type.h
+++ b/jbmc/src/java_bytecode/select_pointer_type.h
@@ -11,6 +11,8 @@
 /// \file
 /// Handle selection of correct pointer type (for example changing abstract
 /// classes to concrete versions).
+#include "java_types.h"
+
 #include <vector>
 
 #include "java_types.h"
@@ -56,7 +58,7 @@ public:
   /// the function body. In the base class we just return an empty set.
   /// Derived classes can override this behaviour to provide more
   /// sophisticated alternative type identification.
-  virtual std::set<symbol_typet> get_parameter_alternative_types(
+  virtual std::set<struct_tag_typet> get_parameter_alternative_types(
     const irep_idt &function_name,
     const irep_idt &parameter_name,
     const namespacet &ns) const;

--- a/jbmc/unit/java-testing-utils/require_goto_statements.cpp
+++ b/jbmc/unit/java-testing-utils/require_goto_statements.cpp
@@ -340,7 +340,7 @@ const irep_idt &require_goto_statements::require_struct_component_assignment(
     {
       REQUIRE(component_assignment_rhs.type().id() == ID_pointer);
       REQUIRE(
-        to_symbol_type(
+        to_struct_tag_type(
           to_pointer_type(component_assignment_rhs.type()).subtype())
           .get(ID_identifier) == typecast_name.value());
     }
@@ -423,7 +423,8 @@ require_goto_statements::require_struct_array_component_assignment(
   // Check the type we are casting to matches the array type
   REQUIRE(component_assignment_rhs.type().id() == ID_pointer);
   REQUIRE(
-    to_symbol_type(to_pointer_type(component_assignment_rhs.type()).subtype())
+    to_struct_tag_type(
+      to_pointer_type(component_assignment_rhs.type()).subtype())
       .get(ID_identifier) == array_type_name);
 
   // Get the tmp_object name and find assignments to it, there should be only

--- a/jbmc/unit/java-testing-utils/require_type.cpp
+++ b/jbmc/unit/java-testing-utils/require_type.cpp
@@ -140,7 +140,7 @@ bool require_java_generic_type_argument_expectation(
   case require_type::type_argument_kindt::Inst:
   {
     REQUIRE(!is_java_generic_parameter(type_argument));
-    REQUIRE(type_argument.subtype() == symbol_typet(expected.description));
+    REQUIRE(type_argument.subtype() == struct_tag_typet(expected.description));
     return true;
   }
   }
@@ -227,7 +227,7 @@ java_generic_parametert require_type::require_java_generic_parameter(
 /// \return The value passed in the first argument
 const typet &require_type::require_java_non_generic_type(
   const typet &type,
-  const optionalt<symbol_typet> &expect_subtype)
+  const optionalt<struct_tag_typet> &expect_subtype)
 {
   REQUIRE(!is_java_generic_parameter(type));
   REQUIRE(!is_java_generic_type(type));
@@ -447,11 +447,11 @@ require_type::require_complete_java_non_generic_class(const typet &class_type)
 /// \param type: The type to check
 /// \param identifier: The identifier the symbol type should have
 /// \return The cast version of the input type
-const symbol_typet &
-require_type::require_symbol(const typet &type, const irep_idt &identifier)
+const struct_tag_typet &
+require_type::require_struct_tag(const typet &type, const irep_idt &identifier)
 {
-  REQUIRE(type.id() == ID_symbol_type);
-  const symbol_typet &result = to_symbol_type(type);
+  REQUIRE(type.id() == ID_struct_tag);
+  const struct_tag_typet &result = to_struct_tag_type(type);
   if(identifier != "")
   {
     REQUIRE(result.get_identifier() == identifier);
@@ -462,21 +462,22 @@ require_type::require_symbol(const typet &type, const irep_idt &identifier)
 /// Verify a given type is a java generic symbol type
 /// \param type: The type to check
 /// \param identifier: The identifier to match
-/// \return The type, cast to a java_generic_symbol_typet
-java_generic_symbol_typet require_type::require_java_generic_symbol_type(
+/// \return The type, cast to a java_generic_struct_tag_typet
+java_generic_struct_tag_typet
+require_type::require_java_generic_struct_tag_type(
   const typet &type,
   const std::string &identifier)
 {
-  symbol_typet symbol_type = require_symbol(type, identifier);
-  REQUIRE(is_java_generic_symbol_type(type));
-  return to_java_generic_symbol_type(type);
+  struct_tag_typet struct_tag_type = require_struct_tag(type, identifier);
+  REQUIRE(is_java_generic_struct_tag_type(type));
+  return to_java_generic_struct_tag_type(type);
 }
 
 /// Verify a given type is a java generic symbol type, checking
 /// that it's associated type arguments match a given set of identifiers.
 /// Expected usage is something like this:
 ///
-/// require_java_generic_symbol_type(type, "java::Generic",
+/// require_java_generic_struct_tag_type(type, "java::Generic",
 ///   {{require_type::type_argument_kindt::Inst, "java::java.lang.Integer"},
 ///    {require_type::type_argument_kindt::Var, "T"}})
 ///
@@ -484,14 +485,15 @@ java_generic_symbol_typet require_type::require_java_generic_symbol_type(
 /// \param identifier: The identifier to match
 /// \param type_expectations: A set of type argument kinds and identifiers
 ///  which should be expected as the type arguments of the given generic type
-/// \return The given type, cast to a java_generic_symbol_typet
-java_generic_symbol_typet require_type::require_java_generic_symbol_type(
+/// \return The given type, cast to a java_generic_struct_tag_typet
+java_generic_struct_tag_typet
+require_type::require_java_generic_struct_tag_type(
   const typet &type,
   const std::string &identifier,
   const require_type::expected_type_argumentst &type_expectations)
 {
-  const java_generic_symbol_typet &generic_base_type =
-    require_java_generic_symbol_type(type, identifier);
+  const java_generic_struct_tag_typet &generic_base_type =
+    require_java_generic_struct_tag_type(type, identifier);
 
   const java_generic_typet::generic_type_argumentst &generic_type_arguments =
     generic_base_type.generic_types();

--- a/jbmc/unit/java-testing-utils/require_type.h
+++ b/jbmc/unit/java-testing-utils/require_type.h
@@ -25,8 +25,8 @@ namespace require_type
 pointer_typet
 require_pointer(const typet &type, const optionalt<typet> &subtype);
 
-const symbol_typet &
-require_symbol(const typet &type, const irep_idt &identifier = "");
+const struct_tag_typet &
+require_struct_tag(const typet &type, const irep_idt &identifier = "");
 
 struct_typet::componentt require_component(
   const struct_typet &struct_type,
@@ -71,7 +71,7 @@ java_generic_parametert require_java_generic_parameter(
 
 const typet &require_java_non_generic_type(
   const typet &type,
-  const optionalt<symbol_typet> &expect_subtype);
+  const optionalt<struct_tag_typet> &expect_subtype);
 
 class_typet require_complete_class(const typet &class_type);
 
@@ -110,11 +110,11 @@ java_class_typet require_java_non_generic_class(const typet &class_type);
 java_class_typet
 require_complete_java_non_generic_class(const typet &class_type);
 
-java_generic_symbol_typet require_java_generic_symbol_type(
+java_generic_struct_tag_typet require_java_generic_struct_tag_type(
   const typet &type,
   const std::string &identifier);
 
-java_generic_symbol_typet require_java_generic_symbol_type(
+java_generic_struct_tag_typet require_java_generic_struct_tag_type(
   const typet &type,
   const std::string &identifier,
   const require_type::expected_type_argumentst &type_expectations);

--- a/jbmc/unit/java_bytecode/goto_program_generics/generic_parameters_test.cpp
+++ b/jbmc/unit/java_bytecode/goto_program_generics/generic_parameters_test.cpp
@@ -116,7 +116,7 @@ SCENARIO(
         const java_generic_typet &type =
           require_type::require_java_generic_type(component.type());
         require_type::require_pointer(
-          type.generic_type_arguments()[0], symbol_typet{"java::BWrapper"});
+          type.generic_type_arguments()[0], struct_tag_typet{"java::BWrapper"});
       }
 
       THEN("Object 'this' has field 'field_input1' of type Wrapper")

--- a/jbmc/unit/java_bytecode/goto_program_generics/mutually_recursive_generics.cpp
+++ b/jbmc/unit/java_bytecode/goto_program_generics/mutually_recursive_generics.cpp
@@ -47,7 +47,7 @@ SCENARIO(
     // ... which is of type `KeyValue` ...
     const auto &subtype = gen_type.subtype();
     const auto &key_value =
-      symbol_table.lookup_ref(to_symbol_type(subtype).get_identifier());
+      symbol_table.lookup_ref(to_struct_tag_type(subtype).get_identifier());
     REQUIRE(key_value.type.id() == ID_struct);
     REQUIRE(key_value.name == "java::KeyValue");
 
@@ -63,8 +63,9 @@ SCENARIO(
         next.type(),
         {{require_type::type_argument_kindt::Var, "java::KeyValue::K"},
          {require_type::type_argument_kindt::Var, "java::KeyValue::V"}});
-    REQUIRE(next_type.subtype().id() == ID_symbol_type);
-    const symbol_typet &next_symbol = to_symbol_type(next_type.subtype());
+    REQUIRE(next_type.subtype().id() == ID_struct_tag);
+    const struct_tag_typet &next_symbol =
+      to_struct_tag_type(next_type.subtype());
     REQUIRE(
       symbol_table.lookup_ref(next_symbol.get_identifier()).name ==
       "java::KeyValue");
@@ -75,8 +76,9 @@ SCENARIO(
         reverse.type(),
         {{require_type::type_argument_kindt::Var, "java::KeyValue::V"},
          {require_type::type_argument_kindt::Var, "java::KeyValue::K"}});
-    REQUIRE(next_type.subtype().id() == ID_symbol_type);
-    const symbol_typet &reverse_symbol = to_symbol_type(reverse_type.subtype());
+    REQUIRE(next_type.subtype().id() == ID_struct_tag);
+    const struct_tag_typet &reverse_symbol =
+      to_struct_tag_type(reverse_type.subtype());
     REQUIRE(
       symbol_table.lookup_ref(next_symbol.get_identifier()).name ==
       "java::KeyValue");

--- a/jbmc/unit/java_bytecode/java_bytecode_convert_class/convert_abstract_class.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_convert_class/convert_abstract_class.cpp
@@ -31,10 +31,10 @@ SCENARIO("java_bytecode_convert_abstract_class",
       THEN("The symbol type should be abstract")
       {
         const symbolt &class_symbol=*new_symbol_table.lookup("java::I");
-        const typet &symbol_type=class_symbol.type;
+        const typet &struct_tag_type = class_symbol.type;
 
-        REQUIRE(symbol_type.id()==ID_struct);
-        class_typet class_type=to_class_type(symbol_type);
+        REQUIRE(struct_tag_type.id() == ID_struct);
+        class_typet class_type = to_class_type(struct_tag_type);
         REQUIRE(class_type.is_class());
         REQUIRE(class_type.is_abstract());
       }
@@ -46,10 +46,10 @@ SCENARIO("java_bytecode_convert_abstract_class",
       THEN("The symbol type should be abstract")
       {
         const symbolt &class_symbol=*new_symbol_table.lookup("java::A");
-        const typet &symbol_type=class_symbol.type;
+        const typet &struct_tag_type = class_symbol.type;
 
-        REQUIRE(symbol_type.id()==ID_struct);
-        class_typet class_type=to_class_type(symbol_type);
+        REQUIRE(struct_tag_type.id() == ID_struct);
+        class_typet class_type = to_class_type(struct_tag_type);
         REQUIRE(class_type.is_class());
         REQUIRE(class_type.is_abstract());
       }
@@ -61,10 +61,10 @@ SCENARIO("java_bytecode_convert_abstract_class",
       THEN("The symbol type should not be abstract")
       {
         const symbolt &class_symbol=*new_symbol_table.lookup("java::C");
-        const typet &symbol_type=class_symbol.type;
+        const typet &struct_tag_type = class_symbol.type;
 
-        REQUIRE(symbol_type.id()==ID_struct);
-        class_typet class_type=to_class_type(symbol_type);
+        REQUIRE(struct_tag_type.id() == ID_struct);
+        class_typet class_type = to_class_type(struct_tag_type);
         REQUIRE(class_type.is_class());
         REQUIRE_FALSE(class_type.is_abstract());
       }
@@ -79,10 +79,10 @@ SCENARIO("java_bytecode_convert_abstract_class",
       {
         const symbolt &class_symbol=
           *new_symbol_table.lookup("java::Implementor");
-        const typet &symbol_type=class_symbol.type;
+        const typet &struct_tag_type = class_symbol.type;
 
-        REQUIRE(symbol_type.id()==ID_struct);
-        class_typet class_type=to_class_type(symbol_type);
+        REQUIRE(struct_tag_type.id() == ID_struct);
+        class_typet class_type = to_class_type(struct_tag_type);
         REQUIRE(class_type.is_class());
         REQUIRE_FALSE(class_type.is_abstract());
       }
@@ -97,10 +97,10 @@ SCENARIO("java_bytecode_convert_abstract_class",
       {
         const symbolt &class_symbol=
           *new_symbol_table.lookup("java::Extender");
-        const typet &symbol_type=class_symbol.type;
+        const typet &struct_tag_type = class_symbol.type;
 
-        REQUIRE(symbol_type.id()==ID_struct);
-        class_typet class_type=to_class_type(symbol_type);
+        REQUIRE(struct_tag_type.id() == ID_struct);
+        class_typet class_type = to_class_type(struct_tag_type);
         REQUIRE(class_type.is_class());
         REQUIRE_FALSE(class_type.is_abstract());
       }

--- a/jbmc/unit/java_bytecode/java_bytecode_convert_class/convert_java_annotations.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_convert_class/convert_java_annotations.cpp
@@ -35,7 +35,7 @@ SCENARIO(
         REQUIRE(annotations.size() == 1);
         const auto &annotation = annotations.front();
         const auto &identifier =
-          to_symbol_type(annotation.type.subtype()).get_identifier();
+          to_struct_tag_type(annotation.type.subtype()).get_identifier();
         REQUIRE(id2string(identifier) == "java::MyClassAnnotation");
         const auto &element_value_pair = annotation.element_value_pairs.front();
         const auto &element_name = element_value_pair.element_name;
@@ -62,7 +62,7 @@ SCENARIO(
         REQUIRE(annotations.size() == 1);
         const auto &annotation = annotations.front();
         const auto &identifier =
-          to_symbol_type(annotation.type.subtype()).get_identifier();
+          to_struct_tag_type(annotation.type.subtype()).get_identifier();
         REQUIRE(id2string(identifier) == "java::MyMethodAnnotation");
         const auto &element_value_pair = annotation.element_value_pairs.front();
         const auto &element_name = element_value_pair.element_name;

--- a/jbmc/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -72,8 +72,8 @@ void validate_lambda_assignment(
   const pointer_typet &lambda_temp_type =
     require_type::require_pointer(side_effect_expr.type(), {});
 
-  const symbol_typet &lambda_implementor_type =
-    require_type::require_symbol(lambda_temp_type.subtype());
+  const struct_tag_typet &lambda_implementor_type =
+    require_type::require_struct_tag(lambda_temp_type.subtype());
 
   const irep_idt &tmp_class_identifier =
     lambda_implementor_type.get_identifier();
@@ -110,7 +110,7 @@ void validate_lambda_assignment(
   const java_class_typet::componentt super_class_component =
     require_type::require_component(tmp_lambda_class_type, "@java.lang.Object");
 
-  const symbol_typet &super_class_type = require_type::require_symbol(
+  const struct_tag_typet &super_class_type = require_type::require_struct_tag(
     super_class_component.type(), "java::java.lang.Object");
 
   THEN("The function in the class should call the lambda method")

--- a/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_bounded_generic_inner_classes.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_bounded_generic_inner_classes.cpp
@@ -96,7 +96,7 @@ SCENARIO(
       require_type::require_component(
         to_struct_type(class_symbol.type), "belem");
     require_type::require_pointer(
-      belem_type.type(), symbol_typet(class_prefix + "$BoundedInner"));
+      belem_type.type(), struct_tag_typet(class_prefix + "$BoundedInner"));
     require_type::require_java_generic_type(
       belem_type.type(),
       {{require_type::type_argument_kindt::Inst, "java::java.lang.Integer"}});

--- a/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_derived_generic_class.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_derived_generic_class.cpp
@@ -31,7 +31,7 @@ SCENARIO(
     {
       REQUIRE(derived_class_type.bases().size() == 1);
       const typet &base_type = derived_class_type.bases().at(0).type();
-      require_type::require_java_generic_symbol_type(
+      require_type::require_java_generic_struct_tag_type(
         base_type,
         "java::Generic",
         {{require_type::type_argument_kindt::Inst,
@@ -54,7 +54,7 @@ SCENARIO(
     {
       REQUIRE(derived_class_type.bases().size() == 1);
       const typet &base_type = derived_class_type.bases().at(0).type();
-      require_type::require_java_generic_symbol_type(
+      require_type::require_java_generic_struct_tag_type(
         base_type,
         "java::GenericTwoParam",
         {{require_type::type_argument_kindt::Inst,
@@ -77,7 +77,7 @@ SCENARIO(
     {
       REQUIRE(derived_class_type.bases().size() == 1);
       const typet &base_type = derived_class_type.bases().at(0).type();
-      require_type::require_java_generic_symbol_type(
+      require_type::require_java_generic_struct_tag_type(
         base_type,
         "java::Generic",
         {{require_type::type_argument_kindt::Var,
@@ -99,7 +99,7 @@ SCENARIO(
     {
       REQUIRE(derived_class_type.bases().size() == 1);
       const typet &base_type = derived_class_type.bases().at(0).type();
-      require_type::require_java_generic_symbol_type(
+      require_type::require_java_generic_struct_tag_type(
         base_type,
         "java::Generic",
         {{require_type::type_argument_kindt::Inst,
@@ -121,7 +121,7 @@ SCENARIO(
     {
       REQUIRE(derived_class_type.bases().size() == 1);
       const typet &base_type = derived_class_type.bases().at(0).type();
-      require_type::require_java_generic_symbol_type(
+      require_type::require_java_generic_struct_tag_type(
         base_type,
         "java::GenericTwoParam",
         {{require_type::type_argument_kindt::Var,
@@ -145,7 +145,7 @@ SCENARIO(
     {
       REQUIRE(derived_class_type.bases().size() == 1);
       const typet &base_type = derived_class_type.bases().at(0).type();
-      require_type::require_java_generic_symbol_type(
+      require_type::require_java_generic_struct_tag_type(
         base_type,
         "java::Generic",
         {{require_type::type_argument_kindt::Inst, "java::java.lang.Integer"}});
@@ -168,7 +168,7 @@ SCENARIO(
     {
       REQUIRE(derived_class_type.bases().size() == 1);
       const typet &base_type = derived_class_type.bases().at(0).type();
-      require_type::require_java_generic_symbol_type(
+      require_type::require_java_generic_struct_tag_type(
         base_type,
         "java::Generic",
         {{require_type::type_argument_kindt::Var,
@@ -193,7 +193,7 @@ SCENARIO(
     {
       REQUIRE(derived_class_type.bases().size() == 1);
       const typet &base_type = derived_class_type.bases().at(0).type();
-      require_type::require_java_generic_symbol_type(
+      require_type::require_java_generic_struct_tag_type(
         base_type,
         "java::Generic",
         {{require_type::type_argument_kindt::Var,
@@ -216,7 +216,7 @@ SCENARIO(
     {
       REQUIRE(derived_class_type.bases().size() == 1);
       const typet &base_type = derived_class_type.bases().at(0).type();
-      require_type::require_java_generic_symbol_type(
+      require_type::require_java_generic_struct_tag_type(
         base_type,
         "java::DerivedGenericMixed2",
         {{require_type::type_argument_kindt::Inst, "java::java.lang.String"}});
@@ -243,12 +243,12 @@ SCENARIO(
       THEN("The superclass is correct")
       {
         const typet &base_type = derived_class_type.bases().at(0).type();
-        require_type::require_symbol(base_type, "java::java.lang.Object");
+        require_type::require_struct_tag(base_type, "java::java.lang.Object");
       }
       THEN("The second interface is correct")
       {
         const typet &base_type = derived_class_type.bases().at(1).type();
-        require_type::require_java_generic_symbol_type(
+        require_type::require_java_generic_struct_tag_type(
           base_type,
           "java::InterfaceGeneric",
           {{require_type::type_argument_kindt::Inst,
@@ -275,12 +275,12 @@ SCENARIO(
       THEN("The superclass is correct")
       {
         const typet &base_type = derived_class_type.bases().at(0).type();
-        require_type::require_symbol(base_type, "java::java.lang.Object");
+        require_type::require_struct_tag(base_type, "java::java.lang.Object");
       }
       THEN("The second interface is correct")
       {
         const typet &base_type = derived_class_type.bases().at(1).type();
-        require_type::require_java_generic_symbol_type(
+        require_type::require_java_generic_struct_tag_type(
           base_type,
           "java::InterfaceGeneric",
           {{require_type::type_argument_kindt::Var,
@@ -309,12 +309,12 @@ SCENARIO(
       THEN("The superclass is correct")
       {
         const typet &base_type = derived_class_type.bases().at(0).type();
-        require_type::require_symbol(base_type, "java::java.lang.Object");
+        require_type::require_struct_tag(base_type, "java::java.lang.Object");
       }
       THEN("The second interface is correct")
       {
         const typet &base_type = derived_class_type.bases().at(1).type();
-        require_type::require_java_generic_symbol_type(
+        require_type::require_java_generic_struct_tag_type(
           base_type,
           "java::InterfaceGeneric",
           {{require_type::type_argument_kindt::Inst,
@@ -323,7 +323,7 @@ SCENARIO(
       THEN("The first interface is correct")
       {
         const typet &base_type = derived_class_type.bases().at(2).type();
-        require_type::require_symbol(base_type, "java::Interface");
+        require_type::require_struct_tag(base_type, "java::Interface");
       }
     }
   }
@@ -348,7 +348,7 @@ SCENARIO(
       THEN("The superclass is correct")
       {
         const typet &base_type = derived_class_type.bases().at(0).type();
-        require_type::require_java_generic_symbol_type(
+        require_type::require_java_generic_struct_tag_type(
           base_type,
           "java::Generic",
           {{require_type::type_argument_kindt::Inst,
@@ -357,12 +357,12 @@ SCENARIO(
       THEN("The first interface is correct")
       {
         const typet &base_type = derived_class_type.bases().at(1).type();
-        require_type::require_symbol(base_type, "java::Interface");
+        require_type::require_struct_tag(base_type, "java::Interface");
       }
       THEN("The second interface is correct")
       {
         const typet &base_type = derived_class_type.bases().at(2).type();
-        require_type::require_java_generic_symbol_type(
+        require_type::require_java_generic_struct_tag_type(
           base_type,
           "java::InterfaceGeneric",
           {{require_type::type_argument_kindt::Inst,
@@ -390,7 +390,7 @@ SCENARIO(
       THEN("The superclass is correct")
       {
         const typet &base_type = derived_class_type.bases().at(0).type();
-        require_type::require_java_generic_symbol_type(
+        require_type::require_java_generic_struct_tag_type(
           base_type,
           "java::GenericTwoParam",
           {{require_type::type_argument_kindt::Var,
@@ -401,12 +401,12 @@ SCENARIO(
       THEN("The first interface is correct")
       {
         const typet &base_type = derived_class_type.bases().at(1).type();
-        require_type::require_symbol(base_type, "java::Interface");
+        require_type::require_struct_tag(base_type, "java::Interface");
       }
       THEN("The second interface is correct")
       {
         const typet &base_type = derived_class_type.bases().at(2).type();
-        require_type::require_java_generic_symbol_type(
+        require_type::require_java_generic_struct_tag_type(
           base_type,
           "java::InterfaceGeneric",
           {{require_type::type_argument_kindt::Var,
@@ -435,20 +435,20 @@ SCENARIO(
       THEN("The superclass is correct")
       {
         const typet &base_type = derived_class_type.bases().at(0).type();
-        require_type::require_java_generic_symbol_type(
+        require_type::require_java_generic_struct_tag_type(
           base_type,
           "java::Generic",
           {{require_type::type_argument_kindt::Inst,
-             "java::InterfaceGeneric"}});
+            "java::InterfaceGeneric"}});
       }
       THEN("The interface is correct")
       {
         const typet &base_type = derived_class_type.bases().at(1).type();
-        require_type::require_java_generic_symbol_type(
+        require_type::require_java_generic_struct_tag_type(
           base_type,
           "java::InterfaceGeneric",
           {{require_type::type_argument_kindt::Inst,
-             "java::java.lang.Integer"}});
+            "java::java.lang.Integer"}});
       }
     }
   }
@@ -473,12 +473,12 @@ SCENARIO(
       THEN("The superclass is correct")
       {
         const typet &base_type = derived_class_type.bases().at(0).type();
-        const java_generic_symbol_typet &superclass_type =
-          require_type::require_java_generic_symbol_type(
+        const java_generic_struct_tag_typet &superclass_type =
+          require_type::require_java_generic_struct_tag_type(
             base_type,
             "java::Generic",
             {{require_type::type_argument_kindt::Inst,
-               "java::InterfaceGeneric"}});
+              "java::InterfaceGeneric"}});
 
         const typet &type_argument = superclass_type.generic_types().at(0);
         require_type::require_java_generic_type(
@@ -489,11 +489,11 @@ SCENARIO(
       THEN("The interface is correct")
       {
         const typet &base_type = derived_class_type.bases().at(1).type();
-        require_type::require_java_generic_symbol_type(
+        require_type::require_java_generic_struct_tag_type(
           base_type,
           "java::InterfaceGeneric",
           {{require_type::type_argument_kindt::Inst,
-             "java::java.lang.Integer"}});
+            "java::java.lang.Integer"}});
       }
     }
   }
@@ -517,20 +517,20 @@ SCENARIO(
       THEN("The superclass is correct")
       {
         const typet &base_type = derived_class_type.bases().at(0).type();
-        require_type::require_java_generic_symbol_type(
+        require_type::require_java_generic_struct_tag_type(
           base_type,
           "java::Generic",
           {{require_type::type_argument_kindt::Inst,
-             "java::InterfaceGeneric"}});
+            "java::InterfaceGeneric"}});
       }
       THEN("The interface is correct")
       {
         const typet &base_type = derived_class_type.bases().at(1).type();
-        require_type::require_java_generic_symbol_type(
+        require_type::require_java_generic_struct_tag_type(
           base_type,
           "java::InterfaceGeneric",
           {{require_type::type_argument_kindt::Var,
-             "java::ExtendsAndImplementsSameInterfaceGeneric::T"}});
+            "java::ExtendsAndImplementsSameInterfaceGeneric::T"}});
       }
     }
   }
@@ -549,7 +549,7 @@ SCENARIO(
     {
       REQUIRE(derived_class_type.bases().size() == 1);
       const typet &base_type = derived_class_type.bases().at(0).type();
-      require_type::require_java_generic_symbol_type(
+      require_type::require_java_generic_struct_tag_type(
         base_type,
         "java::GenericBase$ImplicitGeneric",
         {{require_type::type_argument_kindt::Var, "java::GenericBase::T"}});
@@ -570,7 +570,7 @@ SCENARIO(
     {
       REQUIRE(derived_class_type.bases().size() == 1);
       const typet &base_type = derived_class_type.bases().at(0).type();
-      require_type::require_java_generic_symbol_type(
+      require_type::require_java_generic_struct_tag_type(
         base_type,
         "java::GenericBase$ImplicitAndExplicitGeneric",
         {{require_type::type_argument_kindt::Var, "java::GenericBase::T"},
@@ -593,7 +593,7 @@ SCENARIO(
     {
       REQUIRE(derived_class_type.bases().size() == 1);
       const typet &base_type = derived_class_type.bases().at(0).type();
-      require_type::require_java_generic_symbol_type(
+      require_type::require_java_generic_struct_tag_type(
         base_type,
         "java::GenericBase2$ImplicitAndExplicitGeneric",
         {{require_type::type_argument_kindt::Var, "java::GenericBase2::T"},

--- a/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_functions_with_generics.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_functions_with_generics.cpp
@@ -40,7 +40,7 @@ SCENARIO(
         const java_method_typet::parametert &param_x =
           require_type::require_parameter(func_code, "x");
         require_type::require_pointer(
-          param_x.type(), symbol_typet("java::Generic"));
+          param_x.type(), struct_tag_typet("java::Generic"));
 
         THEN("x is generic with parameter pointing to java.lang.Integer")
         {
@@ -55,7 +55,7 @@ SCENARIO(
       {
         const typet return_type = func_code.return_type();
         require_type::require_pointer(
-          return_type, symbol_typet("java::Generic"));
+          return_type, struct_tag_typet("java::Generic"));
 
         THEN("It is generic with parameter pointing to java.lang.Integer")
         {
@@ -89,7 +89,7 @@ SCENARIO(
         const java_method_typet::parametert &param_s =
           require_type::require_parameter(func_code, "s");
         require_type::require_pointer(
-          param_s.type(), symbol_typet("java::Generic"));
+          param_s.type(), struct_tag_typet("java::Generic"));
 
         THEN("s is generic with parameter pointing to java.lang.String")
         {
@@ -104,7 +104,7 @@ SCENARIO(
       {
         const typet return_type = func_code.return_type();
         require_type::require_pointer(
-          return_type, symbol_typet("java::Generic"));
+          return_type, struct_tag_typet("java::Generic"));
 
         THEN("It is generic with parameter pointing to java.lang.Integer")
         {
@@ -138,7 +138,7 @@ SCENARIO(
         const java_method_typet::parametert &param_x =
           require_type::require_parameter(func_code, "x");
         require_type::require_pointer(
-          param_x.type(), symbol_typet("java::Generic"));
+          param_x.type(), struct_tag_typet("java::Generic"));
 
         THEN("x is generic with parameter pointing to java.lang.Integer")
         {
@@ -154,7 +154,7 @@ SCENARIO(
         const java_method_typet::parametert &param_y =
           require_type::require_parameter(func_code, "y");
         require_type::require_pointer(
-          param_y.type(), symbol_typet("java::Generic"));
+          param_y.type(), struct_tag_typet("java::Generic"));
 
         THEN("y is generic with parameter pointing to java.lang.Integer")
         {
@@ -169,7 +169,7 @@ SCENARIO(
       {
         const typet return_type = func_code.return_type();
         require_type::require_pointer(
-          return_type, symbol_typet("java::Generic"));
+          return_type, struct_tag_typet("java::Generic"));
 
         THEN("It is generic with parameter pointing to java.lang.Integer")
         {
@@ -203,7 +203,7 @@ SCENARIO(
         const java_method_typet::parametert &param_s =
           require_type::require_parameter(func_code, "s");
         require_type::require_pointer(
-          param_s.type(), symbol_typet("java::Generic"));
+          param_s.type(), struct_tag_typet("java::Generic"));
 
         THEN("s is generic with parameter pointing to java.lang.String")
         {
@@ -219,7 +219,7 @@ SCENARIO(
         const java_method_typet::parametert &param_b =
           require_type::require_parameter(func_code, "b");
         require_type::require_pointer(
-          param_b.type(), symbol_typet("java::Generic"));
+          param_b.type(), struct_tag_typet("java::Generic"));
 
         THEN("b is generic with parameter pointing to java.lang.Boolean")
         {
@@ -234,7 +234,7 @@ SCENARIO(
       {
         const typet return_type = func_code.return_type();
         require_type::require_pointer(
-          return_type, symbol_typet("java::Generic"));
+          return_type, struct_tag_typet("java::Generic"));
 
         THEN("It is generic with parameter pointing to java.lang.Integer")
         {
@@ -269,14 +269,14 @@ SCENARIO(
         const java_method_typet::parametert &param_inner =
           require_type::require_parameter(func_code, "inner");
         require_type::require_pointer(
-          param_inner.type(), symbol_typet(class_prefix + "$Inner"));
+          param_inner.type(), struct_tag_typet(class_prefix + "$Inner"));
       }
 
       THEN("It has return type pointing to Generic")
       {
         const typet return_type = func_code.return_type();
         require_type::require_pointer(
-          return_type, symbol_typet("java::Generic"));
+          return_type, struct_tag_typet("java::Generic"));
 
         THEN("It is generic with parameter pointing to java.lang.Integer")
         {

--- a/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_generic_array_class.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_generic_array_class.cpp
@@ -33,10 +33,10 @@ SCENARIO(
     THEN("It is an array")
     {
       const pointer_typet &field_t_pointer = require_type::require_pointer(
-        field_t.type(), symbol_typet("java::array[reference]"));
+        field_t.type(), struct_tag_typet("java::array[reference]"));
 
-      const symbol_typet &field_t_subtype =
-        to_symbol_type(field_t_pointer.subtype());
+      const struct_tag_typet &field_t_subtype =
+        to_struct_tag_type(field_t_pointer.subtype());
       const struct_typet &subtype_type = to_struct_type(
         new_symbol_table.lookup_ref(field_t_subtype.get_identifier()).type);
       REQUIRE(is_valid_java_array(subtype_type));
@@ -58,10 +58,10 @@ SCENARIO(
     THEN("It is an array")
     {
       const pointer_typet &field_t2_pointer = require_type::require_pointer(
-        field_t2.type(), symbol_typet("java::array[reference]"));
+        field_t2.type(), struct_tag_typet("java::array[reference]"));
 
-      const symbol_typet &field_t2_subtype =
-        to_symbol_type(field_t2_pointer.subtype());
+      const struct_tag_typet &field_t2_subtype =
+        to_struct_tag_type(field_t2_pointer.subtype());
       const struct_typet &subtype_struct = to_struct_type(
         new_symbol_table.lookup_ref(field_t2_subtype.get_identifier()).type);
       REQUIRE(is_valid_java_array(subtype_struct));
@@ -69,7 +69,8 @@ SCENARIO(
       THEN("The elements have type Generic<T>")
       {
         const typet &element = java_array_element_type(field_t2_subtype);
-        require_type::require_pointer(element, symbol_typet("java::Generic"));
+        require_type::require_pointer(
+          element, struct_tag_typet("java::Generic"));
         require_type::require_java_generic_type(
           element,
           {{require_type::type_argument_kindt::Var, class_prefix + "::T"}});
@@ -85,10 +86,10 @@ SCENARIO(
     THEN("It is an array")
     {
       const pointer_typet &field_t3_pointer = require_type::require_pointer(
-        field_t3.type(), symbol_typet("java::array[reference]"));
+        field_t3.type(), struct_tag_typet("java::array[reference]"));
 
-      const symbol_typet &field_t3_subtype =
-        to_symbol_type(field_t3_pointer.subtype());
+      const struct_tag_typet &field_t3_subtype =
+        to_struct_tag_type(field_t3_pointer.subtype());
       const struct_typet &subtype_struct = to_struct_type(
         new_symbol_table.lookup_ref(field_t3_subtype.get_identifier()).type);
       REQUIRE(is_valid_java_array(subtype_struct));
@@ -96,7 +97,8 @@ SCENARIO(
       THEN("The elements have type Generic<Integer>")
       {
         const typet &element = java_array_element_type(field_t3_subtype);
-        require_type::require_pointer(element, symbol_typet("java::Generic"));
+        require_type::require_pointer(
+          element, struct_tag_typet("java::Generic"));
         require_type::require_java_generic_type(
           element,
           {{require_type::type_argument_kindt::Inst,

--- a/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_generic_class.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_generic_class.cpp
@@ -48,7 +48,7 @@ SCENARIO(
         const struct_union_typet::componentt &field_g =
           require_type::require_component(class_struct, "g");
         require_type::require_pointer(
-          field_g.type(), symbol_typet("java::Generic"));
+          field_g.type(), struct_tag_typet("java::Generic"));
 
         THEN("It is generic with parameter pointing to java.lang.Integer")
         {

--- a/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_generic_class_with_generic_inner_classes.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_generic_class_with_generic_inner_classes.cpp
@@ -37,7 +37,7 @@ SCENARIO(
         require_type::require_component(java_generic_class, "field");
 
       require_type::require_pointer(
-        field_component.type(), symbol_typet(class_prefix + "$InnerClass"));
+        field_component.type(), struct_tag_typet(class_prefix + "$InnerClass"));
 
       THEN("The pointer should be generic")
       {
@@ -56,7 +56,7 @@ SCENARIO(
 
       require_type::require_pointer(
         field_component.type(),
-        symbol_typet(class_prefix + "$GenericInnerClass"));
+        struct_tag_typet(class_prefix + "$GenericInnerClass"));
 
       THEN("The pointer should be generic")
       {
@@ -78,7 +78,7 @@ SCENARIO(
 
       require_type::require_pointer(
         field_component.type(),
-        symbol_typet(class_prefix + "$GenericInnerClass"));
+        struct_tag_typet(class_prefix + "$GenericInnerClass"));
 
       THEN("The pointer should be generic")
       {
@@ -98,7 +98,7 @@ SCENARIO(
 
       require_type::require_pointer(
         field_component.type(),
-        symbol_typet(
+        struct_tag_typet(
           class_prefix + "$GenericInnerClass$DoublyNestedInnerClass"));
 
       THEN("The pointer should be generic")
@@ -121,7 +121,7 @@ SCENARIO(
 
       require_type::require_pointer(
         field_component.type(),
-        symbol_typet(
+        struct_tag_typet(
           class_prefix + "$GenericInnerClass$DoublyNestedInnerClass"));
 
       THEN("The pointer should be generic")
@@ -142,7 +142,7 @@ SCENARIO(
 
       require_type::require_pointer(
         field_component.type(),
-        symbol_typet(
+        struct_tag_typet(
           class_prefix + "$GenericInnerClass$DoublyNestedInnerGenericClass"));
 
       THEN("The pointer should be generic")
@@ -167,7 +167,7 @@ SCENARIO(
 
       require_type::require_pointer(
         field_component.type(),
-        symbol_typet(
+        struct_tag_typet(
           class_prefix + "$GenericInnerClass$DoublyNestedInnerGenericClass"));
 
       THEN("The pointer should be generic")
@@ -189,7 +189,7 @@ SCENARIO(
 
       require_type::require_pointer(
         field_component.type(),
-        symbol_typet(class_prefix + "$TwoParamInnerClass"));
+        struct_tag_typet(class_prefix + "$TwoParamInnerClass"));
 
       THEN("The pointer should be generic")
       {
@@ -213,7 +213,7 @@ SCENARIO(
 
       require_type::require_pointer(
         field_component.type(),
-        symbol_typet(class_prefix + "$TwoParamInnerClass"));
+        struct_tag_typet(class_prefix + "$TwoParamInnerClass"));
 
       THEN("The pointer should be generic")
       {
@@ -237,7 +237,7 @@ SCENARIO(
 
       require_type::require_pointer(
         field_component.type(),
-        symbol_typet(class_prefix + "$TwoParamInnerClass"));
+        struct_tag_typet(class_prefix + "$TwoParamInnerClass"));
 
       THEN("The pointer should be generic")
       {
@@ -263,7 +263,7 @@ SCENARIO(
 
       require_type::require_pointer(
         field_component.type(),
-        symbol_typet(
+        struct_tag_typet(
           class_prefix + "$GenericInnerClass$DoublyNestedInnerGenericClass"));
 
       THEN("The pointer should be GenericClassWithGenericInnerClasses")
@@ -324,7 +324,7 @@ SCENARIO(
       const auto &param_type =
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
-        param_type.type(), symbol_typet(class_prefix + "$InnerClass"));
+        param_type.type(), struct_tag_typet(class_prefix + "$InnerClass"));
       require_type::require_java_generic_type(
         param_type.type(),
         {{require_type::type_argument_kindt::Var, class_prefix + "::T"}});
@@ -353,7 +353,7 @@ SCENARIO(
       const auto &param_type =
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
-        param_type.type(), symbol_typet(class_prefix + "$InnerClass"));
+        param_type.type(), struct_tag_typet(class_prefix + "$InnerClass"));
       require_type::require_java_generic_type(
         param_type.type(),
         {{require_type::type_argument_kindt::Var, class_prefix + "::T"}});
@@ -361,7 +361,7 @@ SCENARIO(
       const auto &param_type2 =
         require_type::require_parameter(function_call, "input2");
       require_type::require_pointer(
-        param_type2.type(), symbol_typet(class_prefix + "$InnerClass"));
+        param_type2.type(), struct_tag_typet(class_prefix + "$InnerClass"));
       require_type::require_java_generic_type(
         param_type2.type(),
         {{require_type::type_argument_kindt::Var, class_prefix + "::T"}});
@@ -389,7 +389,8 @@ SCENARIO(
       const auto &param_type =
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
-        param_type.type(), symbol_typet(class_prefix + "$GenericInnerClass"));
+        param_type.type(),
+        struct_tag_typet(class_prefix + "$GenericInnerClass"));
       require_type::require_java_generic_type(
         param_type.type(),
         {{require_type::type_argument_kindt::Var,
@@ -420,7 +421,8 @@ SCENARIO(
       const auto &param_type =
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
-        param_type.type(), symbol_typet(class_prefix + "$GenericInnerClass"));
+        param_type.type(),
+        struct_tag_typet(class_prefix + "$GenericInnerClass"));
       require_type::require_java_generic_type(
         param_type.type(),
         {{require_type::type_argument_kindt::Var, class_prefix + "::T"},
@@ -451,7 +453,7 @@ SCENARIO(
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
         param_type.type(),
-        symbol_typet(
+        struct_tag_typet(
           class_prefix + "$GenericInnerClass$DoublyNestedInnerClass"));
       require_type::require_java_generic_type(
         param_type.type(),
@@ -485,7 +487,7 @@ SCENARIO(
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
         param_type.type(),
-        symbol_typet(
+        struct_tag_typet(
           class_prefix + "$GenericInnerClass$DoublyNestedInnerClass"));
       require_type::require_java_generic_type(
         param_type.type(),
@@ -517,7 +519,7 @@ SCENARIO(
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
         param_type.type(),
-        symbol_typet(
+        struct_tag_typet(
           class_prefix + "$GenericInnerClass$DoublyNestedInnerGenericClass"));
       require_type::require_java_generic_type(
         param_type.type(),
@@ -553,7 +555,7 @@ SCENARIO(
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
         param_type.type(),
-        symbol_typet(
+        struct_tag_typet(
           class_prefix + "$GenericInnerClass$DoublyNestedInnerGenericClass"));
       require_type::require_java_generic_type(
         param_type.type(),
@@ -584,7 +586,8 @@ SCENARIO(
       const auto &param_type =
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
-        param_type.type(), symbol_typet(class_prefix + "$TwoParamInnerClass"));
+        param_type.type(),
+        struct_tag_typet(class_prefix + "$TwoParamInnerClass"));
       require_type::require_java_generic_type(
         param_type.type(),
         {{require_type::type_argument_kindt::Var,
@@ -617,7 +620,8 @@ SCENARIO(
       const auto &param_type =
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
-        param_type.type(), symbol_typet(class_prefix + "$TwoParamInnerClass"));
+        param_type.type(),
+        struct_tag_typet(class_prefix + "$TwoParamInnerClass"));
       require_type::require_java_generic_type(
         param_type.type(),
         {{require_type::type_argument_kindt::Var,
@@ -650,7 +654,8 @@ SCENARIO(
       const auto &param_type =
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
-        param_type.type(), symbol_typet(class_prefix + "$TwoParamInnerClass"));
+        param_type.type(),
+        struct_tag_typet(class_prefix + "$TwoParamInnerClass"));
       require_type::require_java_generic_type(
         param_type.type(),
         {{require_type::type_argument_kindt::Var, class_prefix + "::T"},
@@ -679,7 +684,7 @@ SCENARIO(
     {
       require_type::require_pointer(
         function_call.return_type(),
-        symbol_typet(class_prefix + "$InnerClass"));
+        struct_tag_typet(class_prefix + "$InnerClass"));
       require_type::require_java_generic_type(
         function_call.return_type(),
         {{require_type::type_argument_kindt::Var, class_prefix + "::T"}});
@@ -706,7 +711,7 @@ SCENARIO(
     {
       require_type::require_pointer(
         function_call.return_type(),
-        symbol_typet(class_prefix + "$GenericInnerClass"));
+        struct_tag_typet(class_prefix + "$GenericInnerClass"));
       require_type::require_java_generic_type(
         function_call.return_type(),
         {{require_type::type_argument_kindt::Var,
@@ -736,7 +741,7 @@ SCENARIO(
     {
       require_type::require_pointer(
         function_call.return_type(),
-        symbol_typet(class_prefix + "$GenericInnerClass"));
+        struct_tag_typet(class_prefix + "$GenericInnerClass"));
       require_type::require_java_generic_type(
         function_call.return_type(),
         {{require_type::type_argument_kindt::Var, class_prefix + "::T"},
@@ -765,7 +770,7 @@ SCENARIO(
     {
       require_type::require_pointer(
         function_call.return_type(),
-        symbol_typet(
+        struct_tag_typet(
           class_prefix + "$GenericInnerClass$DoublyNestedInnerClass"));
       require_type::require_java_generic_type(
         function_call.return_type(),
@@ -797,7 +802,7 @@ SCENARIO(
     {
       require_type::require_pointer(
         function_call.return_type(),
-        symbol_typet(
+        struct_tag_typet(
           class_prefix + "$GenericInnerClass$DoublyNestedInnerClass"));
       require_type::require_java_generic_type(
         function_call.return_type(),
@@ -827,7 +832,7 @@ SCENARIO(
     {
       require_type::require_pointer(
         function_call.return_type(),
-        symbol_typet(
+        struct_tag_typet(
           class_prefix + "$GenericInnerClass$DoublyNestedInnerGenericClass"));
       require_type::require_java_generic_type(
         function_call.return_type(),
@@ -861,7 +866,7 @@ SCENARIO(
     {
       require_type::require_pointer(
         function_call.return_type(),
-        symbol_typet(
+        struct_tag_typet(
           class_prefix + "$GenericInnerClass$DoublyNestedInnerGenericClass"));
       require_type::require_java_generic_type(
         function_call.return_type(),
@@ -892,7 +897,7 @@ SCENARIO(
     {
       require_type::require_pointer(
         function_call.return_type(),
-        symbol_typet(class_prefix + "$TwoParamInnerClass"));
+        struct_tag_typet(class_prefix + "$TwoParamInnerClass"));
       require_type::require_java_generic_type(
         function_call.return_type(),
         {{require_type::type_argument_kindt::Var,
@@ -924,7 +929,7 @@ SCENARIO(
     {
       require_type::require_pointer(
         function_call.return_type(),
-        symbol_typet(class_prefix + "$TwoParamInnerClass"));
+        struct_tag_typet(class_prefix + "$TwoParamInnerClass"));
       require_type::require_java_generic_type(
         function_call.return_type(),
         {{require_type::type_argument_kindt::Var,
@@ -956,7 +961,7 @@ SCENARIO(
     {
       require_type::require_pointer(
         function_call.return_type(),
-        symbol_typet(class_prefix + "$TwoParamInnerClass"));
+        struct_tag_typet(class_prefix + "$TwoParamInnerClass"));
       require_type::require_java_generic_type(
         function_call.return_type(),
         {{require_type::type_argument_kindt::Var, class_prefix + "::T"},

--- a/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_generic_class_with_inner_classes.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_generic_class_with_inner_classes.cpp
@@ -32,7 +32,7 @@ SCENARIO(
     {
       const auto &field = require_type::require_component(generic_class, "f1");
       require_type::require_pointer(
-        field.type(), symbol_typet(outer_class_prefix + "$Inner"));
+        field.type(), struct_tag_typet(outer_class_prefix + "$Inner"));
       require_type::require_java_generic_type(
         field.type(),
         {{require_type::type_argument_kindt::Var, outer_class_prefix + "::T"}});
@@ -41,7 +41,8 @@ SCENARIO(
     {
       const auto &field = require_type::require_component(generic_class, "f2");
       require_type::require_pointer(
-        field.type(), symbol_typet(outer_class_prefix + "$Inner$InnerInner"));
+        field.type(),
+        struct_tag_typet(outer_class_prefix + "$Inner$InnerInner"));
       require_type::require_java_generic_type(
         field.type(),
         {{require_type::type_argument_kindt::Var, outer_class_prefix + "::T"}});
@@ -50,7 +51,7 @@ SCENARIO(
     {
       const auto &field = require_type::require_component(generic_class, "f3");
       require_type::require_pointer(
-        field.type(), symbol_typet(outer_class_prefix + "$GenericInner"));
+        field.type(), struct_tag_typet(outer_class_prefix + "$GenericInner"));
       require_type::require_java_generic_type(
         field.type(),
         {{require_type::type_argument_kindt::Var, outer_class_prefix + "::T"},
@@ -85,7 +86,7 @@ SCENARIO(
       {
         const auto &field = require_type::require_component(java_class, "t2");
         require_type::require_pointer(
-          field.type(), symbol_typet("java::Generic"));
+          field.type(), struct_tag_typet("java::Generic"));
         require_type::require_java_generic_type(
           field.type(),
           {{require_type::type_argument_kindt::Var,
@@ -122,7 +123,7 @@ SCENARIO(
       {
         const auto &field = require_type::require_component(java_class, "tt2");
         require_type::require_pointer(
-          field.type(), symbol_typet("java::Generic"));
+          field.type(), struct_tag_typet("java::Generic"));
         const java_generic_typet &generic_field =
           require_type::require_java_generic_type(
             field.type(),
@@ -171,7 +172,7 @@ SCENARIO(
         const auto &field =
           require_type::require_component(generic_class, "gt2");
         require_type::require_pointer(
-          field.type(), symbol_typet("java::GenericTwoParam"));
+          field.type(), struct_tag_typet("java::GenericTwoParam"));
         require_type::require_java_generic_type(
           field.type(),
           {{require_type::type_argument_kindt::Var,

--- a/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_generic_fields.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_generic_fields.cpp
@@ -45,7 +45,7 @@ SCENARIO(
         const struct_typet::componentt &field =
           require_type::require_component(class_struct, "f2");
         require_type::require_pointer(
-          field.type(), symbol_typet("java::Generic"));
+          field.type(), struct_tag_typet("java::Generic"));
         THEN("The pointer should be generic")
         {
           require_type::require_java_generic_type(
@@ -59,7 +59,7 @@ SCENARIO(
         const struct_typet::componentt &field =
           require_type::require_component(class_struct, "f3");
         require_type::require_pointer(
-          field.type(), symbol_typet("java::Generic"));
+          field.type(), struct_tag_typet("java::Generic"));
         THEN("The pointer should be generic")
         {
           require_type::require_java_generic_type(
@@ -74,7 +74,7 @@ SCENARIO(
         const struct_typet::componentt &field =
           require_type::require_component(class_struct, "f4");
         require_type::require_pointer(
-          field.type(), symbol_typet("java::Generic"));
+          field.type(), struct_tag_typet("java::Generic"));
         THEN("The pointer should be generic")
         {
           const java_generic_typet &generic_field =
@@ -95,7 +95,7 @@ SCENARIO(
         const struct_typet::componentt &field =
           require_type::require_component(class_struct, "f5");
         require_type::require_pointer(
-          field.type(), symbol_typet("java::Generic"));
+          field.type(), struct_tag_typet("java::Generic"));
         THEN("The pointer should be generic")
         {
           const java_generic_typet &generic_field =
@@ -124,7 +124,7 @@ SCENARIO(
         const struct_typet::componentt &field =
           require_type::require_component(class_struct, "f6");
         require_type::require_pointer(
-          field.type(), symbol_typet("java::GenericTwoParam"));
+          field.type(), struct_tag_typet("java::GenericTwoParam"));
         THEN("The pointer should be generic")
         {
           require_type::require_java_generic_type(
@@ -139,7 +139,7 @@ SCENARIO(
         const struct_typet::componentt &field =
           require_type::require_component(class_struct, "f7");
         require_type::require_pointer(
-          field.type(), symbol_typet("java::GenericTwoParam"));
+          field.type(), struct_tag_typet("java::GenericTwoParam"));
         THEN("The pointer should be generic")
         {
           require_type::require_java_generic_type(
@@ -154,7 +154,7 @@ SCENARIO(
         const struct_typet::componentt &field =
           require_type::require_component(class_struct, "f8");
         require_type::require_pointer(
-          field.type(), symbol_typet("java::GenericTwoParam"));
+          field.type(), struct_tag_typet("java::GenericTwoParam"));
         THEN("The pointer should be generic")
         {
           require_type::require_java_generic_type(
@@ -171,7 +171,7 @@ SCENARIO(
         const struct_typet::componentt &field =
           require_type::require_component(class_struct, "f9");
         require_type::require_pointer(
-          field.type(), symbol_typet("java::GenericTwoParam"));
+          field.type(), struct_tag_typet("java::GenericTwoParam"));
         THEN("The pointer should be generic")
         {
           require_type::require_java_generic_type(
@@ -188,7 +188,7 @@ SCENARIO(
         const struct_typet::componentt &field =
           require_type::require_component(class_struct, "f10");
         require_type::require_pointer(
-          field.type(), symbol_typet("java::GenericTwoParam"));
+          field.type(), struct_tag_typet("java::GenericTwoParam"));
         THEN("The pointer should be generic")
         {
           require_type::require_java_generic_type(
@@ -205,7 +205,7 @@ SCENARIO(
         const struct_typet::componentt &field =
           require_type::require_component(class_struct, "f11");
         require_type::require_pointer(
-          field.type(), symbol_typet("java::GenericTwoParam"));
+          field.type(), struct_tag_typet("java::GenericTwoParam"));
         THEN("The pointer should be generic")
         {
           const java_generic_typet &generic_field =

--- a/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_generic_functions.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_generic_functions.cpp
@@ -39,7 +39,7 @@ SCENARIO(
         const java_method_typet::parametert &param_x =
           require_type::require_parameter(func_code, "x");
         require_type::require_pointer(
-          param_x.type(), symbol_typet("java::Generic"));
+          param_x.type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -66,7 +66,7 @@ SCENARIO(
         const java_method_typet::parametert &param_x =
           require_type::require_parameter(func_code, "x");
         require_type::require_pointer(
-          param_x.type(), symbol_typet("java::Generic"));
+          param_x.type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -93,7 +93,7 @@ SCENARIO(
         const java_method_typet::parametert &param_x =
           require_type::require_parameter(func_code, "x");
         require_type::require_pointer(
-          param_x.type(), symbol_typet("java::Generic"));
+          param_x.type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -120,7 +120,7 @@ SCENARIO(
         const java_method_typet::parametert &param_x =
           require_type::require_parameter(func_code, "x");
         require_type::require_pointer(
-          param_x.type(), symbol_typet("java::java.lang.Number"));
+          param_x.type(), struct_tag_typet("java::java.lang.Number"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -147,7 +147,7 @@ SCENARIO(
         const java_method_typet::parametert &param_x =
           require_type::require_parameter(func_code, "x");
         require_type::require_pointer(
-          param_x.type(), symbol_typet("java::Generic"));
+          param_x.type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -174,7 +174,7 @@ SCENARIO(
         const java_method_typet::parametert &param_x =
           require_type::require_parameter(func_code, "x");
         require_type::require_pointer(
-          param_x.type(), symbol_typet("java::Generic"));
+          param_x.type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -202,7 +202,7 @@ SCENARIO(
         const java_method_typet::parametert &param_t =
           require_type::require_parameter(func_code, "t");
         require_type::require_pointer(
-          param_t.type(), symbol_typet("java::Generic"));
+          param_t.type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -212,7 +212,7 @@ SCENARIO(
         const java_method_typet::parametert &param_u =
           require_type::require_parameter(func_code, "u");
         require_type::require_pointer(
-          param_u.type(), symbol_typet("java::Generic"));
+          param_u.type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -240,7 +240,7 @@ SCENARIO(
         const java_method_typet::parametert &param_t =
           require_type::require_parameter(func_code, "t");
         require_type::require_pointer(
-          param_t.type(), symbol_typet("java::Generic"));
+          param_t.type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -250,7 +250,7 @@ SCENARIO(
         const java_method_typet::parametert &param_u =
           require_type::require_parameter(func_code, "u");
         require_type::require_pointer(
-          param_u.type(), symbol_typet("java::Generic"));
+          param_u.type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -276,7 +276,7 @@ SCENARIO(
       THEN("It has return type pointing to Generic")
       {
         require_type::require_pointer(
-          func_code.return_type(), symbol_typet("java::Generic"));
+          func_code.return_type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -302,7 +302,7 @@ SCENARIO(
       THEN("It has return type pointing to java.lang.Object")
       {
         require_type::require_pointer(
-          func_code.return_type(), symbol_typet("java::java.lang.Object"));
+          func_code.return_type(), struct_tag_typet("java::java.lang.Object"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -326,7 +326,7 @@ SCENARIO(
       THEN("It has return type pointing to Generic")
       {
         require_type::require_pointer(
-          func_code.return_type(), symbol_typet("java::Generic"));
+          func_code.return_type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -351,7 +351,7 @@ SCENARIO(
       THEN("It has return type pointing to Generic")
       {
         require_type::require_pointer(
-          func_code.return_type(), symbol_typet("java::Generic"));
+          func_code.return_type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -376,7 +376,7 @@ SCENARIO(
       THEN("It has return type pointing to Generic")
       {
         require_type::require_pointer(
-          func_code.return_type(), symbol_typet("java::Generic"));
+          func_code.return_type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -401,7 +401,7 @@ SCENARIO(
       THEN("It has return type pointing to Generic")
       {
         require_type::require_pointer(
-          func_code.return_type(), symbol_typet("java::Generic"));
+          func_code.return_type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -430,7 +430,7 @@ SCENARIO(
         const java_method_typet::parametert &param_x =
           require_type::require_parameter(func_code, "x");
         require_type::require_pointer(
-          param_x.type(), symbol_typet("java::Generic"));
+          param_x.type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -439,7 +439,7 @@ SCENARIO(
       THEN("It has return type pointing to Generic")
       {
         require_type::require_pointer(
-          func_code.return_type(), symbol_typet("java::Generic"));
+          func_code.return_type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -467,7 +467,7 @@ SCENARIO(
         const java_method_typet::parametert &param_x =
           require_type::require_parameter(func_code, "x");
         require_type::require_pointer(
-          param_x.type(), symbol_typet("java::Generic"));
+          param_x.type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -476,7 +476,7 @@ SCENARIO(
       THEN("It has return type pointing to Generic")
       {
         require_type::require_pointer(
-          func_code.return_type(), symbol_typet("java::Generic"));
+          func_code.return_type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -504,7 +504,7 @@ SCENARIO(
         const java_method_typet::parametert &param_x =
           require_type::require_parameter(func_code, "x");
         require_type::require_pointer(
-          param_x.type(), symbol_typet("java::Generic"));
+          param_x.type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -513,7 +513,7 @@ SCENARIO(
       THEN("It has return type pointing to Generic")
       {
         require_type::require_pointer(
-          func_code.return_type(), symbol_typet("java::Generic"));
+          func_code.return_type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -541,7 +541,7 @@ SCENARIO(
         const java_method_typet::parametert &param_x =
           require_type::require_parameter(func_code, "x");
         require_type::require_pointer(
-          param_x.type(), symbol_typet("java::Generic"));
+          param_x.type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -550,7 +550,7 @@ SCENARIO(
       THEN("It has return type pointing to Generic")
       {
         require_type::require_pointer(
-          func_code.return_type(), symbol_typet("java::Generic"));
+          func_code.return_type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -579,7 +579,7 @@ SCENARIO(
         const java_method_typet::parametert &param_x =
           require_type::require_parameter(func_code, "x");
         require_type::require_pointer(
-          param_x.type(), symbol_typet("java::Generic"));
+          param_x.type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -588,7 +588,7 @@ SCENARIO(
       THEN("It has return type pointing to Generic")
       {
         require_type::require_pointer(
-          func_code.return_type(), symbol_typet("java::Generic"));
+          func_code.return_type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -616,7 +616,7 @@ SCENARIO(
         const java_method_typet::parametert &param_u =
           require_type::require_parameter(func_code, "u");
         require_type::require_pointer(
-          param_u.type(), symbol_typet("java::Generic"));
+          param_u.type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -625,7 +625,7 @@ SCENARIO(
       THEN("It has return type pointing to Generic")
       {
         require_type::require_pointer(
-          func_code.return_type(), symbol_typet("java::Generic"));
+          func_code.return_type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -653,7 +653,7 @@ SCENARIO(
         const java_method_typet::parametert &param_u =
           require_type::require_parameter(func_code, "u");
         require_type::require_pointer(
-          param_u.type(), symbol_typet("java::Generic"));
+          param_u.type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -662,7 +662,7 @@ SCENARIO(
       THEN("It has return type pointing to Generic")
       {
         require_type::require_pointer(
-          func_code.return_type(), symbol_typet("java::Generic"));
+          func_code.return_type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -690,7 +690,7 @@ SCENARIO(
         const java_method_typet::parametert &param_u =
           require_type::require_parameter(func_code, "u");
         require_type::require_pointer(
-          param_u.type(), symbol_typet("java::Generic"));
+          param_u.type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -701,7 +701,7 @@ SCENARIO(
         const java_method_typet::parametert &param_v =
           require_type::require_parameter(func_code, "v");
         require_type::require_pointer(
-          param_v.type(), symbol_typet("java::Generic"));
+          param_v.type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -710,7 +710,7 @@ SCENARIO(
       THEN("It has return type pointing to Generic")
       {
         require_type::require_pointer(
-          func_code.return_type(), symbol_typet("java::Generic"));
+          func_code.return_type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -738,7 +738,7 @@ SCENARIO(
         const java_method_typet::parametert &param_u =
           require_type::require_parameter(func_code, "u");
         require_type::require_pointer(
-          param_u.type(), symbol_typet("java::Generic"));
+          param_u.type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -749,7 +749,7 @@ SCENARIO(
         const java_method_typet::parametert &param_v =
           require_type::require_parameter(func_code, "v");
         require_type::require_pointer(
-          param_v.type(), symbol_typet("java::Generic"));
+          param_v.type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286
@@ -758,7 +758,7 @@ SCENARIO(
       THEN("It has return type pointing to Generic")
       {
         require_type::require_pointer(
-          func_code.return_type(), symbol_typet("java::Generic"));
+          func_code.return_type(), struct_tag_typet("java::Generic"));
 
         // TODO: the bounds are not parsed yet; extend tests when fixed -
         // issue TG-1286

--- a/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_generic_superclasses.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_generic_superclasses.cpp
@@ -36,9 +36,9 @@ SCENARIO(
       const java_class_typet &upper_type =
         to_java_class_type(upper_symbol.type);
       REQUIRE(upper_type.bases().size() == 1);
-      const symbol_typet base_type = require_type::require_symbol(
+      const struct_tag_typet base_type = require_type::require_struct_tag(
         upper_type.bases().at(0).type(), base_generic);
-      REQUIRE_FALSE(is_java_generic_symbol_type(base_type));
+      REQUIRE_FALSE(is_java_generic_struct_tag_type(base_type));
     }
     {
       const symbolt &lower_symbol =
@@ -46,9 +46,9 @@ SCENARIO(
       const java_class_typet &lower_type =
         to_java_class_type(lower_symbol.type);
       REQUIRE(lower_type.bases().size() == 1);
-      const symbol_typet base_type = require_type::require_symbol(
+      const struct_tag_typet base_type = require_type::require_struct_tag(
         lower_type.bases().at(0).type(), base_generic);
-      REQUIRE_FALSE(is_java_generic_symbol_type(base_type));
+      REQUIRE_FALSE(is_java_generic_struct_tag_type(base_type));
     }
     {
       const symbolt &interface_symbol =
@@ -56,9 +56,9 @@ SCENARIO(
       const java_class_typet &interface_type =
         to_java_class_type(interface_symbol.type);
       REQUIRE(interface_type.bases().size() == 2);
-      const symbol_typet base_type = require_type::require_symbol(
+      const struct_tag_typet base_type = require_type::require_struct_tag(
         interface_type.bases().at(1).type(), base_generic_interface);
-      REQUIRE_FALSE(is_java_generic_symbol_type(base_type));
+      REQUIRE_FALSE(is_java_generic_struct_tag_type(base_type));
     }
   }
 }

--- a/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_nested_generics.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_nested_generics.cpp
@@ -31,7 +31,7 @@ SCENARIO(
       const struct_typet::componentt &field_component =
         require_type::require_component(class_type, "field");
       require_type::require_pointer(
-        field_component.type(), symbol_typet("java::Generic"));
+        field_component.type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -54,7 +54,7 @@ SCENARIO(
       const struct_typet::componentt &field_component =
         require_type::require_component(class_type, "field2");
       require_type::require_pointer(
-        field_component.type(), symbol_typet("java::Generic"));
+        field_component.type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -77,7 +77,7 @@ SCENARIO(
       const struct_typet::componentt &field_component =
         require_type::require_component(class_type, "field3");
       require_type::require_pointer(
-        field_component.type(), symbol_typet("java::Generic"));
+        field_component.type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -107,7 +107,7 @@ SCENARIO(
       const struct_typet::componentt &field_component =
         require_type::require_component(class_type, "field4");
       require_type::require_pointer(
-        field_component.type(), symbol_typet("java::Generic"));
+        field_component.type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -137,7 +137,7 @@ SCENARIO(
       const struct_typet::componentt &field_component =
         require_type::require_component(class_type, "field5");
       require_type::require_pointer(
-        field_component.type(), symbol_typet("java::Generic"));
+        field_component.type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -163,7 +163,7 @@ SCENARIO(
       const struct_typet::componentt &field_component =
         require_type::require_component(class_type, "field6");
       require_type::require_pointer(
-        field_component.type(), symbol_typet("java::Generic"));
+        field_component.type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -189,7 +189,7 @@ SCENARIO(
       const struct_typet::componentt &field_component =
         require_type::require_component(class_type, "field7");
       require_type::require_pointer(
-        field_component.type(), symbol_typet("java::Generic"));
+        field_component.type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -215,7 +215,7 @@ SCENARIO(
       const struct_typet::componentt &field_component =
         require_type::require_component(class_type, "field8");
       require_type::require_pointer(
-        field_component.type(), symbol_typet("java::GenericTwoParam"));
+        field_component.type(), struct_tag_typet("java::GenericTwoParam"));
 
       THEN("The pointer should be generic")
       {
@@ -246,7 +246,7 @@ SCENARIO(
       const struct_typet::componentt &field_component =
         require_type::require_component(class_type, "field9");
       require_type::require_pointer(
-        field_component.type(), symbol_typet("java::GenericTwoParam"));
+        field_component.type(), struct_tag_typet("java::GenericTwoParam"));
 
       THEN("The pointer should be generic")
       {
@@ -277,7 +277,7 @@ SCENARIO(
       const struct_typet::componentt &field_component =
         require_type::require_component(class_type, "field10");
       require_type::require_pointer(
-        field_component.type(), symbol_typet("java::GenericTwoParam"));
+        field_component.type(), struct_tag_typet("java::GenericTwoParam"));
 
       THEN("The pointer should be generic")
       {
@@ -308,7 +308,7 @@ SCENARIO(
       const struct_typet::componentt &field_component =
         require_type::require_component(class_type, "field11");
       require_type::require_pointer(
-        field_component.type(), symbol_typet("java::GenericTwoParam"));
+        field_component.type(), struct_tag_typet("java::GenericTwoParam"));
 
       THEN("The pointer should be generic")
       {
@@ -334,7 +334,7 @@ SCENARIO(
       const struct_typet::componentt &field_component =
         require_type::require_component(class_type, "field12");
       require_type::require_pointer(
-        field_component.type(), symbol_typet("java::GenericTwoParam"));
+        field_component.type(), struct_tag_typet("java::GenericTwoParam"));
 
       THEN("The pointer should be generic")
       {
@@ -367,7 +367,7 @@ SCENARIO(
       const struct_typet::componentt &field_component =
         require_type::require_component(class_type, "field13");
       require_type::require_pointer(
-        field_component.type(), symbol_typet("java::GenericTwoParam"));
+        field_component.type(), struct_tag_typet("java::GenericTwoParam"));
 
       THEN("The pointer should be generic")
       {
@@ -425,7 +425,7 @@ SCENARIO(
       const auto &param_type =
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
-        param_type.type(), symbol_typet("java::Generic"));
+        param_type.type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -463,7 +463,7 @@ SCENARIO(
       const auto &param_type =
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
-        param_type.type(), symbol_typet("java::Generic"));
+        param_type.type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -501,7 +501,7 @@ SCENARIO(
       const auto &param_type =
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
-        param_type.type(), symbol_typet("java::Generic"));
+        param_type.type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -546,7 +546,7 @@ SCENARIO(
       const auto &param_type =
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
-        param_type.type(), symbol_typet("java::Generic"));
+        param_type.type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -591,7 +591,7 @@ SCENARIO(
       const auto &param_type =
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
-        param_type.type(), symbol_typet("java::Generic"));
+        param_type.type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -632,7 +632,7 @@ SCENARIO(
       const auto &param_type =
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
-        param_type.type(), symbol_typet("java::Generic"));
+        param_type.type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -673,7 +673,7 @@ SCENARIO(
       const auto &param_type =
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
-        param_type.type(), symbol_typet("java::Generic"));
+        param_type.type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -714,7 +714,7 @@ SCENARIO(
       const auto &param_type =
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
-        param_type.type(), symbol_typet("java::GenericTwoParam"));
+        param_type.type(), struct_tag_typet("java::GenericTwoParam"));
 
       THEN("The pointer should be generic")
       {
@@ -759,7 +759,7 @@ SCENARIO(
       const auto &param_type =
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
-        param_type.type(), symbol_typet("java::GenericTwoParam"));
+        param_type.type(), struct_tag_typet("java::GenericTwoParam"));
 
       THEN("The pointer should be generic")
       {
@@ -804,7 +804,7 @@ SCENARIO(
       const auto &param_type =
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
-        param_type.type(), symbol_typet("java::GenericTwoParam"));
+        param_type.type(), struct_tag_typet("java::GenericTwoParam"));
 
       THEN("The pointer should be generic")
       {
@@ -849,7 +849,7 @@ SCENARIO(
       const auto &param_type =
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
-        param_type.type(), symbol_typet("java::GenericTwoParam"));
+        param_type.type(), struct_tag_typet("java::GenericTwoParam"));
 
       THEN("The pointer should be generic")
       {
@@ -890,7 +890,7 @@ SCENARIO(
       const auto &param_type =
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
-        param_type.type(), symbol_typet("java::GenericTwoParam"));
+        param_type.type(), struct_tag_typet("java::GenericTwoParam"));
 
       THEN("The pointer should be generic")
       {
@@ -937,7 +937,7 @@ SCENARIO(
       const auto &param_type =
         require_type::require_parameter(function_call, "input");
       require_type::require_pointer(
-        param_type.type(), symbol_typet("java::GenericTwoParam"));
+        param_type.type(), struct_tag_typet("java::GenericTwoParam"));
 
       THEN("The pointer should be generic")
       {
@@ -982,7 +982,7 @@ SCENARIO(
     THEN("The return type is correct")
     {
       require_type::require_pointer(
-        function_call.return_type(), symbol_typet("java::Generic"));
+        function_call.return_type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -1018,7 +1018,7 @@ SCENARIO(
     THEN("The return type is correct")
     {
       require_type::require_pointer(
-        function_call.return_type(), symbol_typet("java::Generic"));
+        function_call.return_type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -1054,7 +1054,7 @@ SCENARIO(
     THEN("The return type is correct")
     {
       require_type::require_pointer(
-        function_call.return_type(), symbol_typet("java::Generic"));
+        function_call.return_type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -1096,7 +1096,7 @@ SCENARIO(
     THEN("The return type is correct")
     {
       require_type::require_pointer(
-        function_call.return_type(), symbol_typet("java::Generic"));
+        function_call.return_type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -1138,7 +1138,7 @@ SCENARIO(
     THEN("The return type is correct")
     {
       require_type::require_pointer(
-        function_call.return_type(), symbol_typet("java::Generic"));
+        function_call.return_type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -1177,7 +1177,7 @@ SCENARIO(
     THEN("The return type is correct")
     {
       require_type::require_pointer(
-        function_call.return_type(), symbol_typet("java::Generic"));
+        function_call.return_type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -1216,7 +1216,7 @@ SCENARIO(
     THEN("The return type is correct")
     {
       require_type::require_pointer(
-        function_call.return_type(), symbol_typet("java::Generic"));
+        function_call.return_type(), struct_tag_typet("java::Generic"));
 
       THEN("The pointer should be generic")
       {
@@ -1255,7 +1255,7 @@ SCENARIO(
     THEN("The return type is correct")
     {
       require_type::require_pointer(
-        function_call.return_type(), symbol_typet("java::GenericTwoParam"));
+        function_call.return_type(), struct_tag_typet("java::GenericTwoParam"));
 
       THEN("The pointer should be generic")
       {
@@ -1298,7 +1298,7 @@ SCENARIO(
     THEN("The return type is correct")
     {
       require_type::require_pointer(
-        function_call.return_type(), symbol_typet("java::GenericTwoParam"));
+        function_call.return_type(), struct_tag_typet("java::GenericTwoParam"));
 
       THEN("The pointer should be generic")
       {
@@ -1341,7 +1341,7 @@ SCENARIO(
     THEN("The return type is correct")
     {
       require_type::require_pointer(
-        function_call.return_type(), symbol_typet("java::GenericTwoParam"));
+        function_call.return_type(), struct_tag_typet("java::GenericTwoParam"));
 
       THEN("The pointer should be generic")
       {
@@ -1384,7 +1384,7 @@ SCENARIO(
     THEN("The return type is correct")
     {
       require_type::require_pointer(
-        function_call.return_type(), symbol_typet("java::GenericTwoParam"));
+        function_call.return_type(), struct_tag_typet("java::GenericTwoParam"));
 
       THEN("The pointer should be generic")
       {
@@ -1423,7 +1423,7 @@ SCENARIO(
     THEN("The return type is correct")
     {
       require_type::require_pointer(
-        function_call.return_type(), symbol_typet("java::GenericTwoParam"));
+        function_call.return_type(), struct_tag_typet("java::GenericTwoParam"));
 
       THEN("The pointer should be generic")
       {
@@ -1468,7 +1468,7 @@ SCENARIO(
     THEN("The return type is correct")
     {
       require_type::require_pointer(
-        function_call.return_type(), symbol_typet("java::GenericTwoParam"));
+        function_call.return_type(), struct_tag_typet("java::GenericTwoParam"));
 
       THEN("The pointer should be generic")
       {

--- a/jbmc/unit/java_bytecode/java_bytecode_parse_lambdas/java_bytecode_parse_lambda_method_table.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parse_lambdas/java_bytecode_parse_lambda_method_table.cpp
@@ -285,7 +285,7 @@ SCENARIO(
           REQUIRE(id2string(lambda_method.descriptor) == method_type);
 
           const reference_typet dummy_generic_reference_type =
-            java_reference_type(symbol_typet{"java.lang.Object"});
+            java_reference_type(struct_tag_typet{"java.lang.Object"});
 
           // NOLINTNEXTLINE(whitespace/braces)
           fieldref_exprt fieldref{
@@ -318,7 +318,7 @@ SCENARIO(
           REQUIRE(id2string(lambda_method.descriptor) == method_type);
 
           const reference_typet dummy_generic_reference_type =
-            java_reference_type(symbol_typet{"DummyGeneric"});
+            java_reference_type(struct_tag_typet{"DummyGeneric"});
 
           fieldref_exprt fieldref{dummy_generic_reference_type,
                                   "staticSpecalisedGeneric",
@@ -912,7 +912,7 @@ SCENARIO(
             REQUIRE_FALSE(lambda_method.is_static);
 
             const reference_typet dummy_generic_reference_type =
-              java_reference_type(symbol_typet{"java.lang.Object"});
+              java_reference_type(struct_tag_typet{"java.lang.Object"});
 
             // NOLINTNEXTLINE(whitespace/braces)
             const fieldref_exprt reference_fieldref{
@@ -951,7 +951,7 @@ SCENARIO(
             REQUIRE_FALSE(lambda_method.is_static);
 
             const reference_typet dummy_generic_reference_type =
-              java_reference_type(symbol_typet{"DummyGeneric"});
+              java_reference_type(struct_tag_typet{"DummyGeneric"});
 
             // NOLINTNEXTLINE(whitespace/braces)
             const fieldref_exprt generic_reference_fieldref{
@@ -999,7 +999,7 @@ SCENARIO(
 
           // Field ref for getting the outer class
           const reference_typet outer_class_reference_type =
-            java_reference_type(symbol_typet{"OuterMemberLambdas"});
+            java_reference_type(struct_tag_typet{"OuterMemberLambdas"});
           // NOLINTNEXTLINE(whitespace/braces)
           const fieldref_exprt outer_fieldref{
             outer_class_reference_type, "this$0", "OuterMemberLambdas$Inner"};
@@ -1065,7 +1065,7 @@ SCENARIO(
             REQUIRE_FALSE(lambda_method.is_static);
 
             const reference_typet dummy_generic_reference_type =
-              java_reference_type(symbol_typet{"java.lang.Object"});
+              java_reference_type(struct_tag_typet{"java.lang.Object"});
 
             // NOLINTNEXTLINE(whitespace/braces)
             const fieldref_exprt reference_fieldref{
@@ -1107,7 +1107,7 @@ SCENARIO(
             REQUIRE_FALSE(lambda_method.is_static);
 
             const reference_typet dummy_generic_reference_type =
-              java_reference_type(symbol_typet{"DummyGeneric"});
+              java_reference_type(struct_tag_typet{"DummyGeneric"});
 
             // NOLINTNEXTLINE(whitespace/braces)
             const fieldref_exprt generic_reference_fieldref{

--- a/jbmc/unit/java_bytecode/java_bytecode_parser/parse_java_annotations.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parser/parse_java_annotations.cpp
@@ -93,7 +93,7 @@ SCENARIO(
           to_symbol_expr(element_value_pair.value).get_identifier();
         const auto &java_type = java_type_from_string(id2string(id));
         const std::string &class_name =
-          id2string(to_symbol_type(java_type.subtype()).get_identifier());
+          id2string(to_struct_tag_type(java_type.subtype()).get_identifier());
         REQUIRE(id2string(class_name) == "java::java.lang.String");
       }
     }

--- a/jbmc/unit/java_bytecode/java_object_factory/gen_nondet_string_init.cpp
+++ b/jbmc/unit/java_bytecode/java_object_factory/gen_nondet_string_init.cpp
@@ -43,7 +43,7 @@ SCENARIO(
     namespacet ns(symbol_table);
 
     // Declare a String named arg
-    symbol_typet java_string_type("java::java.lang.String");
+    struct_tag_typet java_string_type("java::java.lang.String");
     symbol_exprt expr("arg", java_string_type);
 
     java_object_factory_parameterst object_factory_parameters;

--- a/jbmc/unit/java_bytecode/java_string_library_preprocess/convert_exprt_to_string_exprt.cpp
+++ b/jbmc/unit/java_bytecode/java_string_library_preprocess/convert_exprt_to_string_exprt.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Convert exprt to string exprt")
     code_blockt code;
     java_string_library_preprocesst preprocess;
     preprocess.add_string_type("java.lang.String", symbol_table);
-    symbol_typet java_string_type("java::java.lang.String");
+    struct_tag_typet java_string_type("java::java.lang.String");
     symbol_exprt expr("a", pointer_type(java_string_type));
 
     WHEN("String expression is converted to refined string expression")

--- a/jbmc/unit/java_bytecode/java_types/generic_type_index.cpp
+++ b/jbmc/unit/java_bytecode/java_types/generic_type_index.cpp
@@ -14,21 +14,22 @@ SCENARIO("generic_type_index", "[core][java_types]")
   GIVEN("PrefixClassName<X, value> extends GenericClass<X,value>, "
           "and parameters X, value, Z")
   {
-    const auto symbol_type = symbol_typet("java::GenericClass");
-    const auto generic_symbol_type = java_generic_symbol_typet(
-      symbol_type, "LGenericClass<TX;Tvalue;>;", "PrefixClassName");
+    const auto struct_tag_type = struct_tag_typet("java::GenericClass");
+    const auto generic_struct_tag_type = java_generic_struct_tag_typet(
+      struct_tag_type, "LGenericClass<TX;Tvalue;>;", "PrefixClassName");
     java_generic_parametert paramX(
-      "PrefixClassName::X", symbol_typet(irep_idt()));
+      "PrefixClassName::X", struct_tag_typet(irep_idt()));
     java_generic_parametert value(
-      "PrefixClassName::value", symbol_typet(irep_idt()));
+      "PrefixClassName::value", struct_tag_typet(irep_idt()));
     java_generic_parametert paramZ(
-      "PrefixClassName::Z", symbol_typet(irep_idt()));
+      "PrefixClassName::Z", struct_tag_typet(irep_idt()));
 
     WHEN("Looking for parameter indexes")
     {
-      const auto indexX = generic_symbol_type.generic_type_index(paramX);
-      const auto index_value = generic_symbol_type.generic_type_index(value);
-      const auto indexZ = generic_symbol_type.generic_type_index(paramZ);
+      const auto indexX = generic_struct_tag_type.generic_type_index(paramX);
+      const auto index_value =
+        generic_struct_tag_type.generic_type_index(value);
+      const auto indexZ = generic_struct_tag_type.generic_type_index(paramZ);
 
       THEN("X has index 0, Y index 1 and Z is not found")
       {
@@ -43,21 +44,24 @@ SCENARIO("generic_type_index", "[core][java_types]")
 
   GIVEN("HashMap<K,V> extends Map<K,V>, and parameters K, V, T")
   {
-    const auto symbol_type = symbol_typet("java::java.util.Map");
-    const auto generic_symbol_type = java_generic_symbol_typet(
-      symbol_type, "Ljava/util/Map<TK;TV;>;", "java.util.HashMap");
+    const auto struct_tag_type = struct_tag_typet("java::java.util.Map");
+    const auto generic_struct_tag_type = java_generic_struct_tag_typet(
+      struct_tag_type, "Ljava/util/Map<TK;TV;>;", "java.util.HashMap");
     java_generic_parametert param0(
-      "java.util.HashMap::K", symbol_typet(irep_idt()));
+      "java.util.HashMap::K", struct_tag_typet(irep_idt()));
     java_generic_parametert param1(
-      "java.util.HashMap::V", symbol_typet(irep_idt()));
+      "java.util.HashMap::V", struct_tag_typet(irep_idt()));
     java_generic_parametert param2(
-      "java.util.HashMap::T", symbol_typet(irep_idt()));
+      "java.util.HashMap::T", struct_tag_typet(irep_idt()));
 
     WHEN("Looking for parameter indexes")
     {
-      const auto index_param0 = generic_symbol_type.generic_type_index(param0);
-      const auto index_param1 = generic_symbol_type.generic_type_index(param1);
-      const auto index_param2 = generic_symbol_type.generic_type_index(param2);
+      const auto index_param0 =
+        generic_struct_tag_type.generic_type_index(param0);
+      const auto index_param1 =
+        generic_struct_tag_type.generic_type_index(param1);
+      const auto index_param2 =
+        generic_struct_tag_type.generic_type_index(param2);
 
       THEN("K has index 0, V index 1 and T is not found")
       {

--- a/jbmc/unit/java_bytecode/java_types/java_generic_symbol_type.cpp
+++ b/jbmc/unit/java_bytecode/java_types/java_generic_symbol_type.cpp
@@ -9,17 +9,17 @@
 #include <testing-utils/catch.hpp>
 #include <java_bytecode/java_types.h>
 
-SCENARIO("java_generic_symbol_type", "[core][java_types]")
+SCENARIO("java_generic_struct_tag_type", "[core][java_types]")
 {
   GIVEN("LGenericClass<TX;TY;>;")
   {
-    auto symbol_type = symbol_typet("java::GenericClass");
-    const auto generic_symbol_type = java_generic_symbol_typet(
-      symbol_type, "LGenericClass<TX;TY;>;", "PrefixClassName");
+    auto struct_tag_type = struct_tag_typet("java::GenericClass");
+    const auto generic_struct_tag_type = java_generic_struct_tag_typet(
+      struct_tag_type, "LGenericClass<TX;TY;>;", "PrefixClassName");
 
-    REQUIRE(generic_symbol_type.get_identifier() == "java::GenericClass");
+    REQUIRE(generic_struct_tag_type.get_identifier() == "java::GenericClass");
 
-    auto types = generic_symbol_type.generic_types();
+    auto types = generic_struct_tag_type.generic_types();
     REQUIRE(types.size() == 2);
 
     auto generic_var0 = to_java_generic_parameter(types[0]).type_variable();

--- a/jbmc/unit/java_bytecode/java_types/java_type_from_string.cpp
+++ b/jbmc/unit/java_bytecode/java_types/java_type_from_string.cpp
@@ -41,8 +41,8 @@ SCENARIO("java_type_from_string", "[core][java_types]")
 
   GIVEN("Ljava/util/Map<TK;TV;>;")
   {
-    const auto generic_symbol_type =
+    const auto generic_struct_tag_type =
       java_type_from_string("Ljava/util/Map<TK;TV;>;", "java.util.Map");
-    REQUIRE(generic_symbol_type != nil_typet());
+    REQUIRE(generic_struct_tag_type != nil_typet());
   }
 }

--- a/jbmc/unit/util/has_subtype.cpp
+++ b/jbmc/unit/util/has_subtype.cpp
@@ -66,8 +66,8 @@ SCENARIO("has_subtype", "[core][utils][has_subtype]")
 
   GIVEN("a recursive struct definition")
   {
-    symbol_typet symbol_type("A-struct");
-    struct_typet::componentt comp("ptr", pointer_type(symbol_type));
+    struct_tag_typet struct_tag("A-struct");
+    struct_typet::componentt comp("ptr", pointer_type(struct_tag));
     struct_typet struct_type;
     struct_type.components().push_back(comp);
 
@@ -84,7 +84,7 @@ SCENARIO("has_subtype", "[core][utils][has_subtype]")
     }
     THEN("symbol type is a subtype")
     {
-      REQUIRE(has_subtype(struct_type, is_type(pointer_type(symbol_type)), ns));
+      REQUIRE(has_subtype(struct_type, is_type(pointer_type(struct_tag)), ns));
     }
     THEN("struct type is a subtype")
     {

--- a/src/analyses/uncaught_exceptions_analysis.cpp
+++ b/src/analyses/uncaught_exceptions_analysis.cpp
@@ -19,8 +19,8 @@ irep_idt uncaught_exceptions_domaint::get_exception_type(const typet &type)
 {
   PRECONDITION(type.id()==ID_pointer);
 
-  if(type.subtype().id() == ID_symbol_type)
-    return to_symbol_type(type.subtype()).get_identifier();
+  if(type.subtype().id() == ID_struct_tag)
+    return to_struct_tag_type(type.subtype()).get_identifier();
   else
     return ID_empty;
 }

--- a/src/cpp/cpp_typecheck_bases.cpp
+++ b/src/cpp/cpp_typecheck_bases.cpp
@@ -43,10 +43,10 @@ void cpp_typecheckt::typecheck_compound_bases(struct_typet &type)
     // elaborate any class template instances given as bases
     elaborate_class_template(base_symbol_expr.type());
 
-    if(base_symbol_expr.type().id() == ID_struct_tag)
-      base_symbol_expr.type().id(ID_symbol_type);
+    if(base_symbol_expr.type().id() == ID_symbol_type)
+      base_symbol_expr.type().id(ID_struct_tag);
 
-    if(base_symbol_expr.type().id() != ID_symbol_type)
+    if(base_symbol_expr.type().id() != ID_struct_tag)
     {
       error().source_location=name.source_location();
       error() << "expected type symbol as struct/class base" << eom;
@@ -54,7 +54,7 @@ void cpp_typecheckt::typecheck_compound_bases(struct_typet &type)
     }
 
     const symbolt &base_symbol =
-      lookup(to_symbol_type(base_symbol_expr.type()));
+      lookup(to_struct_tag_type(base_symbol_expr.type()));
 
     if(base_symbol.type.id()==ID_incomplete_struct)
     {

--- a/src/goto-programs/class_identifier.cpp
+++ b/src/goto-programs/class_identifier.cpp
@@ -55,7 +55,7 @@ static exprt build_class_identifier(
 /// \return Member expression to access a class identifier, as above.
 exprt get_class_identifier_field(
   const exprt &this_expr_in,
-  const symbol_typet &suggested_type,
+  const struct_tag_typet &suggested_type,
   const namespacet &ns)
 {
   // Get a pointer from which we can extract a clsid.
@@ -82,7 +82,7 @@ exprt get_class_identifier_field(
 void set_class_identifier(
   struct_exprt &expr,
   const namespacet &ns,
-  const symbol_typet &class_type)
+  const struct_tag_typet &class_type)
 {
   const struct_typet &struct_type=to_struct_type(ns.follow(expr.type()));
   const struct_typet::componentst &components=struct_type.components();

--- a/src/goto-programs/class_identifier.h
+++ b/src/goto-programs/class_identifier.h
@@ -14,17 +14,17 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 
 class exprt;
 class namespacet;
-class symbol_typet;
+class struct_tag_typet;
 class struct_exprt;
 
 exprt get_class_identifier_field(
   const exprt &this_expr,
-  const symbol_typet &suggested_type,
+  const struct_tag_typet &suggested_type,
   const namespacet &ns);
 
 void set_class_identifier(
   struct_exprt &expr,
   const namespacet &ns,
-  const symbol_typet &class_type);
+  const struct_tag_typet &class_type);
 
 #endif

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -1031,7 +1031,7 @@ mp_integer interpretert::get_size(const typet &type)
     }
     return subtype_size;
   }
-  else if(type.id() == ID_symbol_type)
+  else if(type.id() == ID_symbol_type || type.id() == ID_struct_tag)
   {
     return get_size(ns.follow(type));
   }

--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -206,7 +206,7 @@ goto_programt::targett remove_virtual_functionst::remove_virtual_function(
   // So long as `this` is already not `void*` typed, the second parameter
   // is ignored:
   exprt this_class_identifier =
-    get_class_identifier_field(this_expr, symbol_typet(irep_idt()), ns);
+    get_class_identifier_field(this_expr, struct_tag_typet(irep_idt()), ns);
 
   // If instructed, add an ASSUME(FALSE) to handle the case where we don't
   // match any expected type:

--- a/src/goto-programs/string_abstraction.h
+++ b/src/goto-programs/string_abstraction.h
@@ -52,7 +52,7 @@ protected:
 
   bool is_char_type(const typet &type) const
   {
-    if(type.id() == ID_symbol_type)
+    if(type.id() == ID_struct_tag)
       return is_char_type(ns.follow(type));
 
     if(type.id()!=ID_signedbv &&

--- a/src/solvers/refinement/string_refinement_util.cpp
+++ b/src/solvers/refinement/string_refinement_util.cpp
@@ -36,8 +36,8 @@ bool is_char_type(const typet &type)
 
 bool is_char_array_type(const typet &type, const namespacet &ns)
 {
-  if(type.id() == ID_symbol_type)
-    return is_char_array_type(ns.follow(type), ns);
+  if(type.id() == ID_struct_tag)
+    return is_char_array_type(ns.follow_tag(to_struct_tag_type(type)), ns);
   return type.id() == ID_array && is_char_type(type.subtype());
 }
 

--- a/src/util/std_types.cpp
+++ b/src/util/std_types.cpp
@@ -70,6 +70,35 @@ struct_union_typet::component_type(const irep_idt &component_name) const
   return c.type();
 }
 
+struct_tag_typet &struct_typet::baset::type()
+{
+  return to_struct_tag_type(exprt::type());
+}
+
+const struct_tag_typet &struct_typet::baset::type() const
+{
+  return to_struct_tag_type(exprt::type());
+}
+
+struct_typet::baset::baset(const struct_tag_typet &base) : exprt(ID_base, base)
+{
+}
+
+void struct_typet::add_base(const struct_tag_typet &base)
+{
+  bases().push_back(baset(base));
+}
+
+optionalt<struct_typet::baset> struct_typet::get_base(const irep_idt &id) const
+{
+  for(const auto &b : bases())
+  {
+    if(to_struct_tag_type(b.type()).get_identifier() == id)
+      return b;
+  }
+  return {};
+}
+
 /// Returns true if the struct is a prefix of \a other, i.e., if this struct
 /// has n components then the component types and names of this struct must
 /// match the first n components of \a other struct.

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -270,6 +270,8 @@ inline struct_union_typet &to_struct_union_type(typet &type)
   return static_cast<struct_union_typet &>(type);
 }
 
+class struct_tag_typet;
+
 /// Structure type, corresponds to C style structs
 class struct_typet:public struct_union_typet
 {
@@ -290,19 +292,9 @@ public:
   class baset : public exprt
   {
   public:
-    symbol_typet &type()
-    {
-      return to_symbol_type(exprt::type());
-    }
-
-    const symbol_typet &type() const
-    {
-      return to_symbol_type(exprt::type());
-    }
-
-    explicit baset(const symbol_typet &base) : exprt(ID_base, base)
-    {
-    }
+    struct_tag_typet &type();
+    const struct_tag_typet &type() const;
+    explicit baset(const struct_tag_typet &base);
   };
 
   typedef std::vector<baset> basest;
@@ -321,23 +313,12 @@ public:
 
   /// Add a base class/struct
   /// \param base: Type of case/class struct to be added.
-  void add_base(const symbol_typet &base)
-  {
-    bases().push_back(baset(base));
-  }
+  void add_base(const struct_tag_typet &base);
 
   /// Return the base with the given name, if exists.
   /// \param id The name of the base we are looking for.
   /// \return The base if exists.
-  optionalt<baset> get_base(const irep_idt &id) const
-  {
-    for(const auto &b : bases())
-    {
-      if(to_symbol_type(b.type()).get_identifier() == id)
-        return b;
-    }
-    return {};
-  }
+  optionalt<baset> get_base(const irep_idt &id) const;
 
   /// Test whether `id` is a base class/struct.
   /// \param id: symbol type name


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

Replacement for https://github.com/diffblue/cbmc/pull/3102 with the following changes:
* Added a missing condition in `interpretert::get_size()` (last commit)
* Rebased on cbmc/develop

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
