### PR TITLE
Add brace initialisers to coding standard

### DIFF
--- a/CODING_STANDARD.md
+++ b/CODING_STANDARD.md
@@ -209,6 +209,8 @@ Formatting is enforced using clang-format. For more information about this, see
   point to heap-allocated memory should be private data members of an object
   which safely manages the pointer. As such, `new` should only be used in
   constructors, and `delete` in destructors. Never use `malloc` or `free`.
+- Prefer brace style initialisation (i.e. `type_name{arguments...}`) over
+  parentheses for constructor calls
 
 # CProver conventions
 - Avoid if at all possible using irept methods like `get(ID_name)`, instead cast


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

Major benefit:
* C++ standard requires a diagnostic on narrow conversions in brace initialisers, e.g.
```
#include <iostream>

struct X {
  char x; 
  X(char x) : x(x) {}
};

struct Y {
  float x;
  Y(float x) : x(x) {}
};

int main()
{
  int val = 10;
  // may or may not warn (does not by default in g++)
  auto const a = X(val);
  // diagnostic required by C++ standard!
  auto const b = X{val};

  double dval = 3.0;
  // again, no warning with g++
  auto const c = Y(dval);
  // diagnostic required
  auto const d = Y{dval};
}
```

Minor benefits:
* Can visually distinguish constructor from function calls
* Can use slightly more consistent syntax `type_name variable_name{};` instead of `type_name variable_name;` (parentheses version doesn't work because it's indistinguishable from a function declaration)

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
