### PR TITLE
Make `ranget.map` work without specifying the type

### DIFF
--- a/src/goto-programs/goto_trace.cpp
+++ b/src/goto-programs/goto_trace.cpp
@@ -441,7 +441,7 @@ void show_compact_goto_trace(
 
       {
         auto arg_strings = make_range(step.function_arguments)
-                             .map<std::string>([&ns, &step](const exprt &arg) {
+                             .map([&ns, &step](const exprt &arg) {
                                return from_expr(ns, step.function, arg);
                              });
 

--- a/unit/util/range.cpp
+++ b/unit/util/range.cpp
@@ -29,8 +29,8 @@ SCENARIO("range tests", "[core][util][range]")
     }
     THEN("Use map to compute individual lengths")
     {
-      auto length_range = make_range(list).map<std::size_t>(
-        [](const std::string &s) { return s.length(); });
+      auto length_range =
+        make_range(list).map([](const std::string &s) { return s.length(); });
       auto it = length_range.begin();
       REQUIRE(*it == 3);
       ++it;
@@ -54,7 +54,7 @@ SCENARIO("range tests", "[core][util][range]")
       auto range =
         make_range(list)
           .filter([&](const std::string &s) -> bool { return s[0] == 'a'; })
-          .map<std::size_t>([&](const std::string &s) { return s.length(); });
+          .map([&](const std::string &s) { return s.length(); });
       // Note that everything is performed on the fly, so none of the filter
       // and map functions have been computed yet, and no intermediary container
       // is created.


### PR DESCRIPTION
This commit updates `ranget.map` so that the type is inferred from the
return type of the function passed. This makes the usage of `map` less
verbose and makes it more inline with other `ranget` operations like
`filter`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
