### PR TITLE
Optimize calls to increase_counter

### DIFF
--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -185,8 +185,9 @@ void goto_symex_statet::assignment(
 #endif
 
   // do the l2 renaming
-  level2.current_names.emplace(l1_identifier, std::make_pair(lhs, 0));
-  level2.increase_counter(l1_identifier);
+  const auto level2_it =
+    level2.current_names.emplace(l1_identifier, std::make_pair(lhs, 0)).first;
+  symex_renaming_levelt::increase_counter(level2_it);
   set_l2_indices(lhs, ns);
 
   // in case we happen to be multi-threaded, record the memory access
@@ -439,8 +440,10 @@ bool goto_symex_statet::l2_thread_read_encoding(
 
     if(a_s_read.second.empty())
     {
-      level2.current_names.emplace(l1_identifier, std::make_pair(ssa_l1, 0));
-      level2.increase_counter(l1_identifier);
+      auto level2_it =
+        level2.current_names.emplace(l1_identifier, std::make_pair(ssa_l1, 0))
+          .first;
+      symex_renaming_levelt::increase_counter(level2_it);
       a_s_read.first=level2.current_count(l1_identifier);
     }
 
@@ -476,7 +479,9 @@ bool goto_symex_statet::l2_thread_read_encoding(
     return true;
   }
 
-  level2.current_names.emplace(l1_identifier, std::make_pair(ssa_l1, 0));
+  const auto level2_it =
+    level2.current_names.emplace(l1_identifier, std::make_pair(ssa_l1, 0))
+      .first;
 
   // No event and no fresh index, but avoid constant propagation
   if(!record_events)
@@ -487,7 +492,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
   }
 
   // produce a fresh L2 name
-  level2.increase_counter(l1_identifier);
+  symex_renaming_levelt::increase_counter(level2_it);
   set_l2_indices(ssa_l1, ns);
   expr=ssa_l1;
 

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -185,8 +185,7 @@ void goto_symex_statet::assignment(
 #endif
 
   // do the l2 renaming
-  if(level2.current_names.find(l1_identifier)==level2.current_names.end())
-    level2.current_names[l1_identifier]=std::make_pair(lhs, 0);
+  level2.current_names.emplace(l1_identifier, std::make_pair(lhs, 0));
   level2.increase_counter(l1_identifier);
   set_l2_indices(lhs, ns);
 
@@ -440,8 +439,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
 
     if(a_s_read.second.empty())
     {
-      if(level2.current_names.find(l1_identifier)==level2.current_names.end())
-        level2.current_names[l1_identifier]=std::make_pair(ssa_l1, 0);
+      level2.current_names.emplace(l1_identifier, std::make_pair(ssa_l1, 0));
       level2.increase_counter(l1_identifier);
       a_s_read.first=level2.current_count(l1_identifier);
     }
@@ -478,8 +476,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
     return true;
   }
 
-  if(level2.current_names.find(l1_identifier)==level2.current_names.end())
-    level2.current_names[l1_identifier]=std::make_pair(ssa_l1, 0);
+  level2.current_names.emplace(l1_identifier, std::make_pair(ssa_l1, 0));
 
   // No event and no fresh index, but avoid constant propagation
   if(!record_events)

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -38,10 +38,9 @@ struct symex_renaming_levelt
   }
 
   /// Increase the counter corresponding to an identifier
-  void increase_counter(const irep_idt &identifier)
+  static void increase_counter(const current_namest::iterator &it)
   {
-    PRECONDITION(current_names.find(identifier) != current_names.end());
-    ++current_names[identifier].second;
+    ++it->second.second;
   }
 
   /// Add the \c ssa_exprt of current_names to vars

--- a/src/goto-symex/symex_dead.cpp
+++ b/src/goto-symex/symex_dead.cpp
@@ -52,7 +52,7 @@ void goto_symext::symex_dead(statet &state)
   state.propagation.erase(l1_identifier);
 
   // L2 renaming
-  if(state.level2.current_names.find(l1_identifier)!=
-     state.level2.current_names.end())
-    state.level2.increase_counter(l1_identifier);
+  auto level2_it = state.level2.current_names.find(l1_identifier);
+  if(level2_it != state.level2.current_names.end())
+    symex_renaming_levelt::increase_counter(level2_it);
 }

--- a/src/goto-symex/symex_decl.cpp
+++ b/src/goto-symex/symex_decl.cpp
@@ -68,9 +68,7 @@ void goto_symext::symex_decl(statet &state, const symbol_exprt &expr)
   // L2 renaming
   // inlining may yield multiple declarations of the same identifier
   // within the same L1 context
-  if(state.level2.current_names.find(l1_identifier)==
-     state.level2.current_names.end())
-    state.level2.current_names[l1_identifier]=std::make_pair(ssa, 0);
+  state.level2.current_names.emplace(l1_identifier, std::make_pair(ssa, 0));
   state.level2.increase_counter(l1_identifier);
   const bool record_events=state.record_events;
   state.record_events=false;

--- a/src/goto-symex/symex_decl.cpp
+++ b/src/goto-symex/symex_decl.cpp
@@ -68,8 +68,10 @@ void goto_symext::symex_decl(statet &state, const symbol_exprt &expr)
   // L2 renaming
   // inlining may yield multiple declarations of the same identifier
   // within the same L1 context
-  state.level2.current_names.emplace(l1_identifier, std::make_pair(ssa, 0));
-  state.level2.increase_counter(l1_identifier);
+  const auto level2_it =
+    state.level2.current_names.emplace(l1_identifier, std::make_pair(ssa, 0))
+      .first;
+  symex_renaming_levelt::increase_counter(level2_it);
   const bool record_events=state.record_events;
   state.record_events=false;
   state.rename(ssa, ns);

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -410,15 +410,21 @@ void goto_symext::locality(
     // save old L1 name for popping the frame
     const auto c_it = state.level1.current_names.find(l0_name);
 
-    if(c_it!=state.level1.current_names.end())
+    if(c_it != state.level1.current_names.end())
+    {
       frame.old_level1[l0_name]=c_it->second;
+      c_it->second = std::make_pair(ssa, frame_nr);
+    }
+    else
+    {
+      state.level1.current_names.emplace(
+        l0_name, std::make_pair(ssa, frame_nr));
+    }
 
     // do L1 renaming -- these need not be unique, as
     // identifiers may be shared among functions
     // (e.g., due to inlining or other code restructuring)
 
-    state.level1.current_names[l0_name]=
-      std::make_pair(ssa, frame_nr);
     state.rename(ssa, ns, goto_symex_statet::L1);
 
     irep_idt l1_name=ssa.get_identifier();

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -408,7 +408,7 @@ void goto_symext::locality(
     const irep_idt l0_name=ssa.get_identifier();
 
     // save old L1 name for popping the frame
-    const auto c_it = state.level1.current_names.find(l0_name);
+    auto c_it = state.level1.current_names.find(l0_name);
 
     if(c_it != state.level1.current_names.end())
     {
@@ -417,8 +417,9 @@ void goto_symext::locality(
     }
     else
     {
-      state.level1.current_names.emplace(
-        l0_name, std::make_pair(ssa, frame_nr));
+      c_it = state.level1.current_names
+               .emplace(l0_name, std::make_pair(ssa, frame_nr))
+               .first;
     }
 
     // do L1 renaming -- these need not be unique, as
@@ -432,7 +433,7 @@ void goto_symext::locality(
 
     while(state.l1_history.find(l1_name)!=state.l1_history.end())
     {
-      state.level1.increase_counter(l0_name);
+      symex_renaming_levelt::increase_counter(c_it);
       ++offset;
       ssa.set_level_1(frame_nr+offset);
       l1_name=ssa.get_identifier();


### PR DESCRIPTION
`increase_counter` is always called after a lookup in the corresponding map, and performs two additional lookup, we can get rid of this redundancy by passing an iterator as argument.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
