### PR TITLE
Reserve exit code for VERIFICATION INCONCLUSIVE

### DIFF
--- a/src/util/exit_codes.h
+++ b/src/util/exit_codes.h
@@ -24,6 +24,11 @@ Author: Martin Brain, martin.brain@diffblue.com
 /// error AND the software is not safe (w.r.t. current analysis / config / spec)
 #define CPROVER_EXIT_VERIFICATION_UNSAFE 10
 
+/// Verification inconclusive indicates the analysis has been performed without
+/// error AND the software is neither safe nor unsafe
+/// (w.r.t. current analysis / config / spec)
+#define CPROVER_EXIT_VERIFICATION_INCONCLUSIVE 5
+
 /// A usage error is returned when the command line is invalid or conflicting.
 #define CPROVER_EXIT_USAGE_ERROR 1
 // should contemplate EX_USAGE from sysexits.h

--- a/src/util/exit_codes.h
+++ b/src/util/exit_codes.h
@@ -16,11 +16,11 @@ Author: Martin Brain, martin.brain@diffblue.com
 #define CPROVER_EXIT_SUCCESS 0
 // should contemplate EX_OK from sysexits.h
 
-/// Verification successful indiciates the analysis has been performed without
+/// Verification successful indicates the analysis has been performed without
 /// error AND the software is safe (w.r.t. the current analysis / config / spec)
 #define CPROVER_EXIT_VERIFICATION_SAFE 0
 
-/// Verification successful indiciates the analysis has been performed without
+/// Verification successful indicates the analysis has been performed without
 /// error AND the software is not safe (w.r.t. current analysis / config / spec)
 #define CPROVER_EXIT_VERIFICATION_UNSAFE 10
 


### PR DESCRIPTION
This exit code should be returned when the verification
has run without error, but has not concluded with SUCCESSFUL
or FAILED. 2LS has been using this exit code for 4 years.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
