### PR TITLE
Optimize remove_level_2

### DIFF
--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -222,7 +222,7 @@ void goto_symex_statet::assignment(
     get_l1_name(l1_rhs);
 
     ssa_exprt l1_lhs(lhs);
-    get_l1_name(l1_lhs);
+    l1_lhs.remove_level_2();
 
     if(run_validation_checks)
     {

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -25,6 +25,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <analyses/dirty.h>
 
+static void get_l1_name(exprt &expr);
+
 goto_symex_statet::goto_symex_statet()
   : depth(0),
     symex_target(nullptr),
@@ -750,7 +752,7 @@ void goto_symex_statet::get_original_name(typet &type) const
   }
 }
 
-void goto_symex_statet::get_l1_name(exprt &expr) const
+static void get_l1_name(exprt &expr)
 {
   // do not reset the type !
 

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -97,9 +97,6 @@ protected:
   void set_l1_indices(ssa_exprt &expr, const namespacet &ns);
   void set_l2_indices(ssa_exprt &expr, const namespacet &ns);
 
-  // only required for value_set.assign
-  void get_l1_name(exprt &expr) const;
-
   // this maps L1 names to (L2) types
   typedef std::unordered_map<irep_idt, typet> l1_typest;
   l1_typest l1_types;

--- a/src/util/ssa_expr.cpp
+++ b/src/util/ssa_expr.cpp
@@ -13,6 +13,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/arith_tools.h>
 
+/// If \p expr is a symbol "s" add to \p os "s!l0@l1#l2" and to \p l1_object_os
+/// "s!l0@l1".
+/// If \p expr is a member or index expression, recursively apply the procedure
+/// and add ".component_name" or "[index]" to \p os.
 static void build_ssa_identifier_rec(
   const exprt &expr,
   const irep_idt &l0,

--- a/src/util/ssa_expr.cpp
+++ b/src/util/ssa_expr.cpp
@@ -82,7 +82,7 @@ bool ssa_exprt::can_build_identifier(const exprt &expr)
     return false;
 }
 
-std::pair<irep_idt, irep_idt> ssa_exprt::build_identifier(
+static std::pair<irep_idt, irep_idt> build_identifier(
   const exprt &expr,
   const irep_idt &l0,
   const irep_idt &l1,

--- a/src/util/ssa_expr.cpp
+++ b/src/util/ssa_expr.cpp
@@ -95,3 +95,14 @@ std::pair<irep_idt, irep_idt> ssa_exprt::build_identifier(
 
   return std::make_pair(irep_idt(oss.str()), irep_idt(l1_object_oss.str()));
 }
+
+void ssa_exprt::update_identifier()
+{
+  const irep_idt &l0 = get_level_0();
+  const irep_idt &l1 = get_level_1();
+  const irep_idt &l2 = get_level_2();
+
+  auto idpair = build_identifier(get_original_expr(), l0, l1, l2);
+  set_identifier(idpair.first);
+  set(ID_L1_object_identifier, idpair.second);
+}

--- a/src/util/ssa_expr.h
+++ b/src/util/ssa_expr.h
@@ -101,7 +101,7 @@ public:
   void remove_level_2()
   {
     remove(ID_L2);
-    update_identifier();
+    set_identifier(get_l1_object_identifier());
   }
 
   const irep_idt get_level_0() const

--- a/src/util/ssa_expr.h
+++ b/src/util/ssa_expr.h
@@ -121,12 +121,6 @@ public:
 
   void update_identifier();
 
-  static std::pair<irep_idt, irep_idt> build_identifier(
-    const exprt &src,
-    const irep_idt &l0,
-    const irep_idt &l1,
-    const irep_idt &l2);
-
   /* Used to determine whether or not an identifier can be built
    * before trying and getting an exception */
   static bool can_build_identifier(const exprt &src);

--- a/src/util/ssa_expr.h
+++ b/src/util/ssa_expr.h
@@ -119,16 +119,7 @@ public:
     return get(ID_L2);
   }
 
-  void update_identifier()
-  {
-    const irep_idt &l0=get_level_0();
-    const irep_idt &l1=get_level_1();
-    const irep_idt &l2=get_level_2();
-
-    auto idpair=build_identifier(get_original_expr(), l0, l1, l2);
-    set_identifier(idpair.first);
-    set(ID_L1_object_identifier, idpair.second);
-  }
+  void update_identifier();
 
   static std::pair<irep_idt, irep_idt> build_identifier(
     const exprt &src,


### PR DESCRIPTION
Instead of rebuilding the identifier from scratch when we remove the level 2 of the ssa_exprt, we can just strip the suffix, which is more efficient. On benchmarks I ran locally (70 methods from tika) this has improved the execution time of symex by about 8% (from 77.2 sec to 70.8). 

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
