### PR TITLE
Fix small bug in lazy loading of generic types

### DIFF
--- a/jbmc/src/java_bytecode/ci_lazy_methods_needed.cpp
+++ b/jbmc/src/java_bytecode/ci_lazy_methods_needed.cpp
@@ -120,9 +120,7 @@ void ci_lazy_methods_neededt::initialize_instantiated_classes_from_pointer(
     for(const auto &generic_arg : generic_args)
     {
       if(!is_java_generic_parameter(generic_arg))
-      {
-        initialize_instantiated_classes_from_pointer(generic_arg, ns);
-      }
+        add_all_needed_classes(generic_arg);
     }
   }
 }


### PR DESCRIPTION
When we find a reference to a generic type, we should get all types referenced from it or from its replacement type if it has one. Previously this recursive function excluded replacement types.

Tests are not included in this PR as we currently don't use replacement pointer types in JBMC. I will add tests in the TG pointer bump.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
