### PR TITLE
Fix typos

### DIFF
--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -43,7 +43,7 @@ void goto_symext::symex_assign(
 
       DATA_INVARIANT(
         !side_effect_expr.operands().empty(),
-        "function call stamement expects non-empty list of side effects");
+        "function call statement expects non-empty list of side effects");
 
       DATA_INVARIANT(
         function_call.function().id() == ID_symbol,

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -468,7 +468,7 @@ static void merge_names(
   // Don't add a conditional to the assignment when:
   //  1. Either guard is false, so we can't follow that branch.
   //  2. Either identifier is of generation zero, and so hasn't been
-  //     initialized and therefor an invalid target.
+  //     initialized and therefore an invalid target.
   if(dest_state.guard.is_false())
     rhs = goto_state_rhs;
   else if(goto_state.guard.is_false())


### PR DESCRIPTION
- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
