### PR TITLE
Use rvalue constructor when building a concatenation_exprt

### DIFF
--- a/src/solvers/floatbv/float_bv.cpp
+++ b/src/solvers/floatbv/float_bv.cpp
@@ -1374,10 +1374,7 @@ exprt float_bvt::pack(
 
   // stitch all three together
   return concatenation_exprt(
-    sign_bit,
-      concatenation_exprt(
-      exponent, fraction,
-      unsignedbv_typet(spec.e+spec.f)),
+    {std::move(sign_bit), std::move(exponent), std::move(fraction)},
     spec.to_type());
 }
 

--- a/src/solvers/floatbv/float_bv.cpp
+++ b/src/solvers/floatbv/float_bv.cpp
@@ -1373,8 +1373,10 @@ exprt float_bvt::pack(
     infinity_or_NaN, from_integer(-1, src.exponent.type()), src.exponent);
 
   // stitch all three together
-  return concatenation_exprt(
-    {std::move(sign_bit), std::move(exponent), std::move(fraction)},
+  return typecast_exprt(
+    concatenation_exprt(
+      {std::move(sign_bit), std::move(exponent), std::move(fraction)},
+      bv_typet(spec.f + spec.e + 1)),
     spec.to_type());
 }
 

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -349,8 +349,7 @@ exprt lower_byte_extract(const byte_extract_exprt &src, const namespacet &ns)
     return simplify_expr(typecast_exprt(op.front(), src.type()), ns);
   else // width_bytes>=2
   {
-    concatenation_exprt concatenation(src.type());
-    concatenation.operands().swap(op);
+    concatenation_exprt concatenation(std::move(op), src.type());
     return simplify_expr(concatenation, ns);
   }
 }

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -438,10 +438,8 @@ exprt smt2_parsert::function_application_fp(const exprt::operandst &op)
   const auto width_f = to_unsignedbv_type(op[2].type()).get_width();
 
   // stitch the bits together
-  concatenation_exprt c(bv_typet(width_e + width_f + 1));
-  c.operands() = {op[0], op[1], op[2]};
-
-  return typecast_exprt(c, ieee_float_spect(width_f, width_e).to_type());
+  return concatenation_exprt(
+    exprt::operandst(op), ieee_float_spect(width_f, width_e).to_type());
 }
 
 exprt smt2_parsert::function_application()

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -438,8 +438,9 @@ exprt smt2_parsert::function_application_fp(const exprt::operandst &op)
   const auto width_f = to_unsignedbv_type(op[2].type()).get_width();
 
   // stitch the bits together
-  return concatenation_exprt(
-    exprt::operandst(op), ieee_float_spect(width_f, width_e).to_type());
+  return typecast_exprt(
+    concatenation_exprt(exprt::operandst(op), bv_typet(width_f + width_e + 1)),
+    ieee_float_spect(width_f, width_e).to_type());
 }
 
 exprt smt2_parsert::function_application()
@@ -665,9 +666,8 @@ exprt smt2_parsert::function_application()
         const std::size_t total_width =
           std::accumulate(op_width.begin(), op_width.end(), 0);
 
-        const unsignedbv_typet t(total_width);
-
-        return concatenation_exprt(std::move(op), t);
+        return concatenation_exprt(
+          std::move(op), unsignedbv_typet(total_width));
       }
       else if(id=="distinct")
       {


### PR DESCRIPTION
Also don't do any unnecessary type cast or nesting of expressions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
