### PR TITLE
Use string_constantt's API

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -32,7 +32,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/simplify_expr.h>
 #include <util/std_expr.h>
 #include <util/string2int.h>
-#include <util/string_constant.h>
 #include <util/threeval.h>
 
 #include <goto-programs/cfg.h>

--- a/src/analyses/custom_bitvector_analysis.cpp
+++ b/src/analyses/custom_bitvector_analysis.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/expr_util.h>
 #include <util/simplify_expr.h>
+#include <util/string_constant.h>
 #include <util/xml_expr.h>
 
 #include <langapi/language_util.h>
@@ -182,10 +183,7 @@ unsigned custom_bitvector_analysist::get_bit_nr(
   else if(string_expr.id()==ID_index)
     return get_bit_nr(to_index_expr(string_expr).array());
   else if(string_expr.id()==ID_string_constant)
-  {
-    irep_idt value=string_expr.get(ID_value);
-    return bits.number(value);
-  }
+    return bits.number(to_string_constant(string_expr).get_value());
   else
     return bits.number("(unknown)");
 }

--- a/src/ansi-c/ansi_c_convert_type.cpp
+++ b/src/ansi-c/ansi_c_convert_type.cpp
@@ -13,12 +13,13 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <cassert>
 
+#include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/config.h>
 #include <util/namespace.h>
 #include <util/simplify_expr.h>
-#include <util/arith_tools.h>
 #include <util/std_types.h>
+#include <util/string_constant.h>
 
 #include "gcc_types.h"
 
@@ -50,13 +51,13 @@ void ansi_c_convert_typet::read_rec(const typet &type)
   {
     if(type.has_subtype() &&
        type.subtype().id()==ID_string_constant)
-      c_storage_spec.asm_label=type.subtype().get(ID_value);
+      c_storage_spec.asm_label = to_string_constant(type.subtype()).get_value();
   }
   else if(type.id()==ID_section &&
           type.has_subtype() &&
           type.subtype().id()==ID_string_constant)
   {
-    c_storage_spec.section=type.subtype().get(ID_value);
+    c_storage_spec.section = to_string_constant(type.subtype()).get_value();
   }
   else if(type.id()==ID_const)
     c_qualifiers.is_constant=true;
@@ -230,7 +231,7 @@ void ansi_c_convert_typet::read_rec(const typet &type)
           type.has_subtype() &&
           type.subtype().id()==ID_string_constant)
   {
-    c_storage_spec.alias=type.subtype().get(ID_value);
+    c_storage_spec.alias = to_string_constant(type.subtype()).get_value();
   }
   else if(type.id()==ID_frontend_pointer)
   {

--- a/src/ansi-c/c_storage_spec.cpp
+++ b/src/ansi-c/c_storage_spec.cpp
@@ -9,6 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "c_storage_spec.h"
 
 #include <util/expr.h>
+#include <util/string_constant.h>
 
 void c_storage_spect::read(const typet &type)
 {
@@ -50,18 +51,18 @@ void c_storage_spect::read(const typet &type)
           type.has_subtype() &&
           type.subtype().id()==ID_string_constant)
   {
-    alias=type.subtype().get(ID_value);
+    alias = to_string_constant(type.subtype()).get_value();
   }
   else if(type.id()==ID_asm &&
           type.has_subtype() &&
           type.subtype().id()==ID_string_constant)
   {
-    asm_label=type.subtype().get(ID_value);
+    asm_label = to_string_constant(type.subtype()).get_value();
   }
   else if(type.id()==ID_section &&
           type.has_subtype() &&
           type.subtype().id()==ID_string_constant)
   {
-    section=type.subtype().get(ID_value);
+    section = to_string_constant(type.subtype()).get_value();
   }
 }

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -24,6 +24,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/lispirep.h>
 #include <util/namespace.h>
 #include <util/pointer_offset_size.h>
+#include <util/string_constant.h>
 #include <util/suffix.h>
 #include <util/symbol.h>
 
@@ -3867,7 +3868,8 @@ std::string expr2ct::convert_with_precedence(
     return convert_constant(to_constant_expr(src), precedence);
 
   else if(src.id()==ID_string_constant)
-    return '"'+MetaString(src.get_string(ID_value))+'"';
+    return '"' + MetaString(id2string(to_string_constant(src).get_value())) +
+           '"';
 
   else if(src.id()==ID_struct)
     return convert_struct(src, precedence);

--- a/src/ansi-c/literals/convert_string_literal.cpp
+++ b/src/ansi-c/literals/convert_string_literal.cpp
@@ -153,9 +153,6 @@ exprt convert_string_literal(const std::string &src)
       char_value[i]=value[i];
     }
 
-    string_constantt result;
-    result.set_value(char_value);
-
-    return std::move(result);
+    return string_constantt(char_value);
   }
 }

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -1388,8 +1388,7 @@ exprt cpp_typecheck_resolvet::resolve(
     {
       // __func__ is an ANSI-C standard compliant hack to get the function name
       // __FUNCTION__ and __PRETTY_FUNCTION__ are GCC-specific
-      string_constantt s;
-      s.set_value(source_location.get_function());
+      string_constantt s(source_location.get_function());
       s.add_source_location()=source_location;
       return std::move(s);
     }

--- a/src/cpp/cpp_typecheck_static_assert.cpp
+++ b/src/cpp/cpp_typecheck_static_assert.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include "cpp_typecheck.h"
 
 #include <util/std_types.h>
+#include <util/string_constant.h>
 
 void cpp_typecheckt::convert(cpp_static_assertt &cpp_static_assert)
 {
@@ -31,7 +32,8 @@ void cpp_typecheckt::convert(cpp_static_assertt &cpp_static_assert)
     error().source_location=cpp_static_assert.source_location();
     error() << "static assertion failed";
     if(cpp_static_assert.op1().id()==ID_string_constant)
-      error() << ": " << cpp_static_assert.op1().get(ID_value);
+      error() << ": "
+              << to_string_constant(cpp_static_assert.op1()).get_value();
     error() << eom;
     throw 0;
   }

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -20,6 +20,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/prefix.h>
 #include <util/simplify_expr.h>
 #include <util/std_expr.h>
+#include <util/string_constant.h>
 #include <util/symbol_table.h>
 #include <util/symbol_table_builder.h>
 
@@ -1819,7 +1820,10 @@ bool goto_convertt::get_string_constant(
     simplify(index_op, ns);
 
     if(index_op.id()==ID_string_constant)
-      return value=index_op.get(ID_value), false;
+    {
+      value = to_string_constant(index_op).get_value();
+      return false;
+    }
     else if(index_op.id()==ID_array)
     {
       std::string result;
@@ -1839,7 +1843,10 @@ bool goto_convertt::get_string_constant(
   }
 
   if(expr.id()==ID_string_constant)
-    return value=expr.get(ID_value), false;
+  {
+    value = to_string_constant(expr).get_value();
+    return false;
+  }
 
   return true;
 }

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -18,6 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/exception_utils.h>
 #include <util/expr_util.h>
 #include <util/pointer_predicates.h>
+#include <util/string_constant.h>
 #include <util/type_eq.h>
 
 #include "pointer_arithmetic.h"
@@ -763,7 +764,8 @@ bool string_abstractiont::build(const exprt &object, exprt &dest, bool write)
 
   if(object.id()==ID_string_constant)
   {
-    const std::string &str_value = id2string(object.get(ID_value));
+    const std::string &str_value =
+      id2string(to_string_constant(object).get_value());
     // make sure we handle the case of a string constant with string-terminating
     // \0 in it
     const std::size_t str_len =

--- a/src/goto-programs/string_instrumentation.cpp
+++ b/src/goto-programs/string_instrumentation.cpp
@@ -20,6 +20,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/message.h>
 #include <util/std_code.h>
 #include <util/std_expr.h>
+#include <util/string_constant.h>
 #include <util/symbol_table.h>
 
 #include <goto-programs/format_strings.h>
@@ -399,8 +400,8 @@ void string_instrumentationt::do_format_string_read(
      format_arg.op0().id()==ID_index &&
      format_arg.op0().op0().id()==ID_string_constant)
   {
-    format_token_listt token_list=
-      parse_format_string(format_arg.op0().op0().get_string(ID_value));
+    format_token_listt token_list = parse_format_string(
+      id2string(to_string_constant(format_arg.op0().op0()).get_value()));
 
     std::size_t args=0;
 
@@ -502,8 +503,8 @@ void string_instrumentationt::do_format_string_write(
      format_arg.op0().id()==ID_index &&
      format_arg.op0().op0().id()==ID_string_constant) // constant format
   {
-    format_token_listt token_list=
-      parse_format_string(format_arg.op0().op0().get_string(ID_value));
+    format_token_listt token_list = parse_format_string(
+      id2string(to_string_constant(format_arg.op0().op0()).get_value()));
 
     std::size_t args=0;
 

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -19,6 +19,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/pointer_offset_size.h>
 #include <util/simplify_expr.h>
 #include <util/string2int.h>
+#include <util/string_constant.h>
 
 inline static typet c_sizeof_type_rec(const exprt &expr)
 {
@@ -288,7 +289,7 @@ irep_idt get_string_argument_rec(const exprt &src)
         index_expr.index().is_zero())
       {
         const exprt &fmt_str = index_expr.array();
-        return fmt_str.get_string(ID_value);
+        return to_string_constant(fmt_str).get_value();
       }
     }
   }
@@ -476,7 +477,7 @@ void goto_symext::symex_trace(
   {
     std::list<exprt> vars;
 
-    irep_idt event=code.arguments()[1].op0().get(ID_value);
+    irep_idt event = to_string_constant(code.arguments()[1].op0()).get_value();
 
     for(std::size_t j=2; j<code.arguments().size(); j++)
     {

--- a/src/solvers/refinement/string_constraint_generator_constants.cpp
+++ b/src/solvers/refinement/string_constraint_generator_constants.cpp
@@ -12,7 +12,6 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include <solvers/refinement/string_constraint_generator.h>
 
 #include <util/prefix.h>
-#include <util/string_constant.h>
 #include <util/unicode.h>
 
 /// Add axioms ensuring that the provided string expression and constant are

--- a/src/solvers/refinement/string_constraint_generator_main.cpp
+++ b/src/solvers/refinement/string_constraint_generator_main.cpp
@@ -543,8 +543,8 @@ std::pair<exprt, string_constraintst> add_axioms_for_char_literal(
      arg.op0().op0().operands().size()==2 &&
      arg.op0().op0().op0().id()==ID_string_constant)
   {
-    const string_constantt s=to_string_constant(arg.op0().op0().op0());
-    irep_idt sval=s.get_value();
+    const string_constantt &s = to_string_constant(arg.op0().op0().op0());
+    const std::string &sval = id2string(s.get_value());
     CHECK_RETURN(sval.size()==1);
     return {from_integer(unsigned(sval[0]), arg.type()), {}};
   }

--- a/src/util/format_constant.cpp
+++ b/src/util/format_constant.cpp
@@ -10,10 +10,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "format_constant.h"
 
 #include "arith_tools.h"
+#include "expr.h"
 #include "fixedbv.h"
 #include "ieee_float.h"
-#include "expr.h"
 #include "std_expr.h"
+#include "string_constant.h"
 
 std::string format_constantt::operator()(const exprt &expr)
 {
@@ -40,7 +41,7 @@ std::string format_constantt::operator()(const exprt &expr)
     }
   }
   else if(expr.id()==ID_string_constant)
-    return expr.get_string(ID_value);
+    return id2string(to_string_constant(expr).get_value());
 
   return "(format-constant failed: "+expr.id_string()+")";
 }

--- a/src/util/simplify_expr_array.cpp
+++ b/src/util/simplify_expr_array.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "pointer_offset_size.h"
 #include "replace_expr.h"
 #include "std_expr.h"
+#include "string_constant.h"
 
 bool simplify_exprt::simplify_index(exprt &expr)
 {
@@ -137,7 +138,7 @@ bool simplify_exprt::simplify_index(exprt &expr)
   {
     const auto i = numeric_cast<mp_integer>(expr.op1());
 
-    const irep_idt &value=array.get(ID_value);
+    const std::string &value = id2string(to_string_constant(array).get_value());
 
     if(!i.has_value())
     {

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -18,6 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "pointer_offset_size.h"
 #include "pointer_predicates.h"
 #include "std_expr.h"
+#include "string_constant.h"
 #include "threeval.h"
 
 static bool is_dereference_integer_object(
@@ -683,7 +684,8 @@ bool simplify_exprt::simplify_object_size(exprt &expr)
     else if(op.op0().id()==ID_string_constant)
     {
       typet type=expr.type();
-      expr=from_integer(op.op0().get(ID_value).size()+1, type);
+      expr =
+        from_integer(to_string_constant(op.op0()).get_value().size() + 1, type);
       return false;
     }
   }

--- a/src/util/string_constant.cpp
+++ b/src/util/string_constant.cpp
@@ -12,11 +12,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "c_types.h"
 #include "std_expr.h"
 
-string_constantt::string_constantt() : nullary_exprt(ID_string_constant)
-{
-  set_value(irep_idt());
-}
-
 string_constantt::string_constantt(const irep_idt &_value)
   : nullary_exprt(ID_string_constant)
 {

--- a/src/util/string_constant.h
+++ b/src/util/string_constant.h
@@ -15,9 +15,6 @@ Author: Daniel Kroening, kroening@kroening.com
 class string_constantt : public nullary_exprt
 {
 public:
-  DEPRECATED("use string_constantt(value) instead")
-  string_constantt();
-
   explicit string_constantt(const irep_idt &value);
 
   void set_value(const irep_idt &value);
@@ -37,10 +34,20 @@ inline const string_constantt &to_string_constant(const exprt &expr)
   return static_cast<const string_constantt &>(expr);
 }
 
+inline const string_constantt &to_string_constant(const typet &type)
+{
+  return to_string_constant((const exprt &)type);
+}
+
 inline string_constantt &to_string_constant(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_string_constant);
   return static_cast<string_constantt &>(expr);
+}
+
+inline string_constantt &to_string_constant(typet &type)
+{
+  return to_string_constant((exprt &)type);
 }
 
 #endif // CPROVER_ANSI_C_STRING_CONSTANT_H


### PR DESCRIPTION
Do not access ID_value directly, use get_value() instead. Also use the
constructor and remove the deprecated zero-argument constructor.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
