### PR TITLE
Unit test of expr2bits/bits2expr [blocks: #3592]

### DIFF
--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -16,6 +16,7 @@
 #include <util/namespace.h>
 #include <util/pointer_predicates.h>
 #include <util/simplify_expr.h>
+#include <util/simplify_expr_class.h>
 #include <util/std_expr.h>
 #include <util/symbol_table.h>
 
@@ -79,4 +80,29 @@ TEST_CASE("Simplify byte extract")
   exprt simp = simplify_expr(be, ns);
 
   REQUIRE(simp == s);
+}
+
+TEST_CASE("expr2bits and bits2expr respect bit order")
+{
+  symbol_tablet symbol_table;
+  namespacet ns(symbol_table);
+  simplify_exprt simp(ns);
+
+  exprt deadbeef = from_integer(0xdeadbeef, unsignedbv_typet(32));
+
+  const auto le = simp.expr2bits(deadbeef, true);
+  REQUIRE(le.has_value());
+  REQUIRE(le->size() == 32);
+
+  const exprt should_be_deadbeef1 =
+    simp.bits2expr(*le, unsignedbv_typet(32), true);
+  REQUIRE(deadbeef == should_be_deadbeef1);
+
+  const auto be = simp.expr2bits(deadbeef, false);
+  REQUIRE(be.has_value());
+  REQUIRE(be->size() == 32);
+
+  const exprt should_be_deadbeef2 =
+    simp.bits2expr(*be, unsignedbv_typet(32), false);
+  REQUIRE(deadbeef == should_be_deadbeef2);
 }


### PR DESCRIPTION
This is just to confirm that these work correctly for either endianness and with
the added work required by hexadecimal value coding.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
