### PR TITLE
Fix simplify_extractbit and simplify_extractbits

### DIFF
--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -3085,12 +3085,14 @@ public:
   {
   }
 
+  /// Extract the \p _index-th least significant bit from \p _src.
   extractbit_exprt(
     const exprt &_src,
     const exprt &_index):binary_predicate_exprt(_src, ID_extractbit, _index)
   {
   }
 
+  /// \copydoc extractbit_exprt(const exprt &, const exprt &)
   extractbit_exprt(
     const exprt &_src,
     const std::size_t _index);
@@ -3161,7 +3163,11 @@ public:
     operands().resize(3);
   }
 
-  // the ordering upper-lower matches the SMT-LIB
+  /// Extract the bits [\p _lower .. \p _upper] from \p _src to produce a result
+  /// of type \p _type. Note that this specifies a closed interval, i.e., both
+  /// bits \p _lower and \p _upper are included. Indices count from the
+  /// least-significant bit, and are not affected by endianness.
+  /// The ordering upper-lower matches what SMT-LIB uses.
   extractbits_exprt(
     const exprt &_src,
     const exprt &_upper,
@@ -3171,6 +3177,8 @@ public:
     add_to_operands(_src, _upper, _lower);
   }
 
+  // NOLINTNEXTLINE(whitespace/line_length)
+  /// \copydoc extractbits_exprt(const exprt &, const exprt &, const exprt &, const typet &)
   extractbits_exprt(
     const exprt &_src,
     const std::size_t _upper,


### PR DESCRIPTION
With hexadecimal coding of constants we need to use expr2bits/bits2expr to
evaluate extractbits, and just the underlying get_bvrep_bit for extractbit. Also
document these expressions to clarify their semantics with regard to endianness.

Only the second commit is new, the first one is #3591.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
