### PR TITLE
Fix binary value string in XML representation of expressions

### DIFF
--- a/src/util/xml_expr.cpp
+++ b/src/util/xml_expr.cpp
@@ -164,8 +164,8 @@ xmlt xml(
       std::size_t width=to_bitvector_type(type).get_width();
 
       result.name="integer";
-      result.set_attribute("binary",
-        id2string(to_constant_expr(expr).get_value()));
+      result.set_attribute(
+        "binary", integer2binary(numeric_cast_v<mp_integer>(expr), width));
       result.set_attribute("width", width);
 
       const typet &underlying_type = type.id() == ID_c_bit_field

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -65,6 +65,7 @@ SRC += analyses/ai/ai.cpp \
        util/symbol_table.cpp \
        util/symbol.cpp \
        util/unicode.cpp \
+       util/xml_expr.cpp \
        # Empty last line
 
 INCLUDES= -I ../src/ -I.

--- a/unit/util/xml_expr.cpp
+++ b/unit/util/xml_expr.cpp
@@ -1,0 +1,29 @@
+/*******************************************************************\
+
+ Module: Unit tests of expression to xmlt conversion
+
+ Author: Michael Tautschnig
+
+\*******************************************************************/
+
+#include <testing-utils/catch.hpp>
+
+#include <util/arith_tools.h>
+#include <util/config.h>
+#include <util/namespace.h>
+#include <util/std_expr.h>
+#include <util/symbol_table.h>
+#include <util/xml_expr.h>
+
+TEST_CASE("Constant expression to XML")
+{
+  config.set_arch("none");
+
+  const symbol_tablet symbol_table;
+  const namespacet ns(symbol_table);
+
+  const constant_exprt number = from_integer(0xFF, unsignedbv_typet(8));
+  const xmlt x = xml(number, ns);
+
+  REQUIRE(x.get_attribute("binary") == "11111111");
+}


### PR DESCRIPTION
The hexadecimal encoding of values implies that the value stored in a constant
cannot directly be used as a binary representation.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
