### PR TITLE
format_{expr,type}: Beautify array and pointer output

### DIFF
--- a/jbmc/regression/jbmc/simplify-classid-of-interface/test_no_simplify_vccs.desc
+++ b/jbmc/regression/jbmc/simplify-classid-of-interface/test_no_simplify_vccs.desc
@@ -3,7 +3,7 @@ Test.class
 --function Test.main --no-simplify --unwind 10 --show-vcc
 ^EXIT=0$
 ^SIGNAL=0$
-"java::Impl1" = cast\(\{ \{ "java::Impl1"\}, 0\}, struct \{ struct \{ string @class_identifier \} @java.lang.Object \}\)\.@java.lang.Object\.@class_identifier
+"java::Impl1" = cast\(\{ \{ "java::Impl1" \}, 0 \}, struct \{ struct \{ string @class_identifier \} @java.lang.Object \}\)\.@java.lang.Object\.@class_identifier
 --
 ^warning: ignoring
 --

--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -294,7 +294,7 @@ std::ostream &format_rec(std::ostream &os, const exprt &expr)
       os << format(op);
     }
 
-    return os << '}';
+    return os << " }";
   }
   else if(id == ID_if)
   {

--- a/src/util/format_type.cpp
+++ b/src/util/format_type.cpp
@@ -60,7 +60,7 @@ std::ostream &format_rec(std::ostream &os, const typet &type)
   const auto &id = type.id();
 
   if(id == ID_pointer)
-    return os << '*' << format(to_pointer_type(type).subtype());
+    return os << format(to_pointer_type(type).subtype()) << '*';
   else if(id == ID_array)
   {
     const auto &t = to_array_type(type);


### PR DESCRIPTION
Array expressions were missing a space before the closing brace. Pointer types
had the asterisk before the subtype, which isn't C-like (which we otherwise stay
close to).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
