### PR TITLE
Remove no-longer-used system_symbols

### DIFF
--- a/src/langapi/language.h
+++ b/src/langapi/language.h
@@ -12,17 +12,16 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_LANGAPI_LANGUAGE_H
 #define CPROVER_LANGAPI_LANGUAGE_H
 
-#include <unordered_set>
 #include <iosfwd>
-#include <string>
 #include <memory> // unique_ptr
+#include <set>
+#include <string>
+#include <unordered_set>
 
 #include <util/message.h>
 #include <util/std_types.h>
 #include <util/symbol.h>
 #include <util/symbol_table_base.h>
-
-#include <goto-programs/system_library_symbols.h>
 
 class symbol_tablet;
 class exprt;
@@ -188,7 +187,6 @@ public:
 
 protected:
   bool language_options_initialized=false;
-  system_library_symbolst system_symbols;
 };
 
 #endif // CPROVER_UTIL_LANGUAGE_H

--- a/src/langapi/module_dependencies.txt
+++ b/src/langapi/module_dependencies.txt
@@ -1,3 +1,2 @@
-goto-programs
 langapi
 util


### PR DESCRIPTION
This is a follow-up to the cleanup done in 2725a059296d0. Creating a
system_symbol_libraryt every time a languaget is created (effectively everytime
from_expr is called) is costly, because of all the strings being looked up in
the string table. Furthermore this removes this undesirable dependency on
goto-prorgrams from langapi.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
