### PR TITLE
irept-related fixes [blocks: #2035]

### DIFF
--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -27,6 +27,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "string2int.h"
 #include "string_utils.h"
 
+#include <map>
 #include <ostream>
 #include <stack>
 

--- a/src/util/irep_hash_container.cpp
+++ b/src/util/irep_hash_container.cpp
@@ -52,7 +52,9 @@ void irep_hash_container_baset::pack(
 
   if(full)
   {
-    packed.reserve(1 + 1 + sub.size() + named_sub.size());
+    // we pack: the irep id, the sub size, the subs, the named-sub size, and
+    // each of the named subs with their ids
+    packed.reserve(1 + 1 + sub.size() + 1 + named_sub.size() * 2);
 
     packed.push_back(irep_id_hash()(irep.id()));
 
@@ -72,7 +74,9 @@ void irep_hash_container_baset::pack(
     const std::size_t non_comment_count =
       irept::number_of_non_comments(named_sub);
 
-    packed.reserve(1 + 1 + sub.size() + non_comment_count);
+    // we pack: the irep id, the sub size, the subs, the named-sub size, and
+    // each of the non-comment named subs with their ids
+    packed.reserve(1 + 1 + sub.size() + 1 + non_comment_count * 2);
 
     packed.push_back(irep_id_hash()(irep.id()));
 

--- a/src/util/merge_irep.cpp
+++ b/src/util/merge_irep.cpp
@@ -44,9 +44,9 @@ bool to_be_merged_irept::operator == (const to_be_merged_irept &other) const
   const irept::named_subt &o_named_sub=other.get_named_sub();
 
   if(sub.size()!=o_sub.size())
-    return true;
+    return false;
   if(named_sub.size()!=o_named_sub.size())
-    return true;
+    return false;
 
   {
     irept::subt::const_iterator s_it=sub.begin();

--- a/src/util/merge_irep.cpp
+++ b/src/util/merge_irep.cpp
@@ -148,7 +148,7 @@ const irept &merge_irept::merged(const irept &irep)
     dest_named_sub[it->first]=merged(it->second); // recursive call
     #endif
 
-  return *irep_store.insert(new_irep).first;
+  return *irep_store.insert(std::move(new_irep)).first;
 }
 
 void merge_full_irept::operator()(irept &irep)
@@ -185,5 +185,5 @@ const irept &merge_full_irept::merged(const irept &irep)
     dest_named_sub[it->first]=merged(it->second); // recursive call
     #endif
 
-  return *irep_store.insert(new_irep).first;
+  return *irep_store.insert(std::move(new_irep)).first;
 }


### PR DESCRIPTION
Four independent smaller fixes all triggered by reviewing code around irept/SUB_IS_LIST-related changes.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
