### PR TITLE
Use CATCH's REQUIRE_THROWS_AS [blocks: #2310]

### DIFF
--- a/unit/goto-programs/goto_model_function_type_consistency.cpp
+++ b/unit/goto-programs/goto_model_function_type_consistency.cpp
@@ -52,16 +52,9 @@ SCENARIO(
 
       THEN("The consistency check fails")
       {
-        bool caught = false;
-        try
-        {
-          goto_model.validate(validation_modet::EXCEPTION);
-        }
-        catch(incorrect_goto_program_exceptiont &e)
-        {
-          caught = true;
-        }
-        REQUIRE(caught);
+        REQUIRE_THROWS_AS(
+          goto_model.validate(validation_modet::EXCEPTION),
+          incorrect_goto_program_exceptiont);
       }
     }
   }

--- a/unit/goto-programs/goto_program_assume.cpp
+++ b/unit/goto-programs/goto_program_assume.cpp
@@ -53,16 +53,9 @@ SCENARIO(
       instructions.back().targets.push_back(instructions.begin());
       THEN("The consistency check fails")
       {
-        bool caught = false;
-        try
-        {
-          goto_function.body.validate(ns, validation_modet::EXCEPTION);
-        }
-        catch(incorrect_goto_program_exceptiont &e)
-        {
-          caught = true;
-        }
-        REQUIRE(caught);
+        REQUIRE_THROWS_AS(
+          goto_function.body.validate(ns, validation_modet::EXCEPTION),
+          incorrect_goto_program_exceptiont);
       }
     }
   }

--- a/unit/goto-programs/goto_program_dead.cpp
+++ b/unit/goto-programs/goto_program_dead.cpp
@@ -56,16 +56,9 @@ SCENARIO(
 
       THEN("The consistency check fails")
       {
-        bool caught = false;
-        try
-        {
-          goto_function.body.validate(ns, validation_modet::EXCEPTION);
-        }
-        catch(incorrect_goto_program_exceptiont &e)
-        {
-          caught = true;
-        }
-        REQUIRE(caught);
+        REQUIRE_THROWS_AS(
+          goto_function.body.validate(ns, validation_modet::EXCEPTION),
+          incorrect_goto_program_exceptiont);
       }
     }
   }

--- a/unit/goto-programs/goto_program_declaration.cpp
+++ b/unit/goto-programs/goto_program_declaration.cpp
@@ -55,16 +55,9 @@ SCENARIO(
 
       THEN("The consistency check fails")
       {
-        bool caught = false;
-        try
-        {
-          goto_function.body.validate(ns, validation_modet::EXCEPTION);
-        }
-        catch(incorrect_goto_program_exceptiont &e)
-        {
-          caught = true;
-        }
-        REQUIRE(caught);
+        REQUIRE_THROWS_AS(
+          goto_function.body.validate(ns, validation_modet::EXCEPTION),
+          incorrect_goto_program_exceptiont);
       }
     }
   }

--- a/unit/goto-programs/goto_program_function_call.cpp
+++ b/unit/goto-programs/goto_program_function_call.cpp
@@ -69,16 +69,9 @@ SCENARIO(
 
       THEN("The consistency check fails")
       {
-        bool caught = false;
-        try
-        {
-          goto_function.body.validate(ns, validation_modet::EXCEPTION);
-        }
-        catch(incorrect_goto_program_exceptiont &e)
-        {
-          caught = true;
-        }
-        REQUIRE(caught);
+        REQUIRE_THROWS_AS(
+          goto_function.body.validate(ns, validation_modet::EXCEPTION),
+          incorrect_goto_program_exceptiont);
       }
     }
   }

--- a/unit/goto-programs/goto_program_goto_target.cpp
+++ b/unit/goto-programs/goto_program_goto_target.cpp
@@ -58,16 +58,9 @@ SCENARIO(
     {
       THEN("The consistency check fails")
       {
-        bool caught = false;
-        try
-        {
-          goto_function.body.validate(ns, validation_modet::EXCEPTION);
-        }
-        catch(incorrect_goto_program_exceptiont &e)
-        {
-          caught = true;
-        }
-        REQUIRE(caught);
+        REQUIRE_THROWS_AS(
+          goto_function.body.validate(ns, validation_modet::EXCEPTION),
+          incorrect_goto_program_exceptiont);
       }
     }
   }

--- a/unit/goto-programs/goto_program_symbol_type_table_consistency.cpp
+++ b/unit/goto-programs/goto_program_symbol_type_table_consistency.cpp
@@ -59,16 +59,9 @@ SCENARIO(
 
       THEN("The consistency check fails")
       {
-        bool caught = false;
-        try
-        {
-          goto_function.validate(ns, validation_modet::EXCEPTION);
-        }
-        catch(incorrect_goto_program_exceptiont &e)
-        {
-          caught = true;
-        }
-        REQUIRE(caught);
+        REQUIRE_THROWS_AS(
+          goto_function.validate(ns, validation_modet::EXCEPTION),
+          incorrect_goto_program_exceptiont);
       }
     }
   }

--- a/unit/goto-programs/goto_program_table_consistency.cpp
+++ b/unit/goto-programs/goto_program_table_consistency.cpp
@@ -51,16 +51,9 @@ SCENARIO(
       const namespacet ns(symbol_table);
       THEN("The consistency check fails")
       {
-        bool caught = false;
-        try
-        {
-          goto_function.validate(ns, validation_modet::EXCEPTION);
-        }
-        catch(incorrect_goto_program_exceptiont &e)
-        {
-          caught = true;
-        }
-        REQUIRE(caught);
+        REQUIRE_THROWS_AS(
+          goto_function.validate(ns, validation_modet::EXCEPTION),
+          incorrect_goto_program_exceptiont);
       }
     }
   }

--- a/unit/goto-symex/ssa_equation.cpp
+++ b/unit/goto-symex/ssa_equation.cpp
@@ -46,7 +46,9 @@ SCENARIO("Validation of well-formed SSA steps", "[core][goto-symex][validate]")
 
       THEN("The consistency check fails")
       {
-        REQUIRE_THROWS(equation.validate(ns, validation_modet::EXCEPTION));
+        REQUIRE_THROWS_AS(
+          equation.validate(ns, validation_modet::EXCEPTION),
+          incorrect_goto_program_exceptiont);
       }
     }
   }


### PR DESCRIPTION
This avoids warnings about unused local variables and also is more concise. Also
change one use of REQUIRE_THROWS to the more precise REQUIRE_THROWS_AS to make
sure we are seeing the expected kind of exception.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
