### PR TITLE
Actually use the parameter of set_is_stub [blocks: #2310]

### DIFF
--- a/jbmc/src/java_bytecode/java_types.h
+++ b/jbmc/src/java_bytecode/java_types.h
@@ -171,9 +171,9 @@ class java_class_typet:public class_typet
     set(ID_final, is_final);
   }
 
-  void set_is_stub(const bool &is_stub)
+  void set_is_stub(bool is_stub)
   {
-    set(ID_incomplete_class, true);
+    set(ID_incomplete_class, is_stub);
   }
 
   bool get_is_stub() const


### PR DESCRIPTION
Also pass it by value, a reference is likely more costly in this case.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
