### PR TITLE
Fix expected exit codes for Windows/Visual Studio [blocks: #2310, #3627]

### DIFF
--- a/regression/ansi-c/goto_convert_break/test.desc
+++ b/regression/ansi-c/goto_convert_break/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 
-^EXIT=1$
+^EXIT=(1|64)$
 ^SIGNAL=0$
 ^CONVERSION ERROR$
 --

--- a/regression/ansi-c/goto_convert_continue/test.desc
+++ b/regression/ansi-c/goto_convert_continue/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 
-^EXIT=1$
+^EXIT=(1|64)$
 ^SIGNAL=0$
 ^CONVERSION ERROR$
 --

--- a/regression/ansi-c/goto_convert_invalid_goto_label/test.desc
+++ b/regression/ansi-c/goto_convert_invalid_goto_label/test.desc
@@ -2,7 +2,7 @@ CORE
 main.c
 
 ^CONVERSION ERROR$
-^EXIT=1$
+^EXIT=(1|64)$
 ^SIGNAL=0$
 --
 ^warning: ignoring

--- a/regression/ansi-c/goto_convert_switch_range_bounds/test.desc
+++ b/regression/ansi-c/goto_convert_switch_range_bounds/test.desc
@@ -2,7 +2,7 @@ CORE
 main.c
 
 ^CONVERSION ERROR$
-^EXIT=1$
+^EXIT=(1|64)$
 ^SIGNAL=0$
 --
 ^warning: ignoring

--- a/regression/ansi-c/goto_convert_switch_range_operands_count/test.desc
+++ b/regression/ansi-c/goto_convert_switch_range_operands_count/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 
-^EXIT=1$
+^EXIT=(1|64)$
 ^SIGNAL=0$
 ^PARSING ERROR$
 --


### PR DESCRIPTION
goto-cl exits with exit code 64 as cl does. (Tests fail on Windows, but this wasn't noticed due Powershell not aborting on failing commands.)

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
