### PR TITLE
Fix type mismatch between value at call site and declaration [blocks: #2310]

### DIFF
--- a/unit/solvers/refinement/string_constraint_generator_valueof/calculate_max_string_length.cpp
+++ b/unit/solvers/refinement/string_constraint_generator_valueof/calculate_max_string_length.cpp
@@ -14,7 +14,7 @@ Author: Diffblue Ltd.
 
 /// Get the string length needed to print any value of the given type with the
 /// given radix.
-static size_t expected_length(const int radix, const typet &type)
+static size_t expected_length(unsigned long radix, const typet &type)
 {
   std::string longest("");
   if(radix==2)


### PR DESCRIPTION
All values passed in are of type unsigned long. Also remove an unnecessary const
with a POD parameter type.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
