### PR TITLE
bugfix: symbol_factoryt must preserve struct_tag types [blocks: #3652]

### DIFF
--- a/src/ansi-c/c_nondet_symbol_factory.cpp
+++ b/src/ansi-c/c_nondet_symbol_factory.cpp
@@ -96,18 +96,17 @@ void symbol_factoryt::gen_nondet_init(
   const std::size_t depth,
   recursion_sett recursion_set)
 {
-  const typet &type=ns.follow(expr.type());
+  const typet &type = expr.type();
 
   if(type.id()==ID_pointer)
   {
     // dereferenced type
     const pointer_typet &pointer_type=to_pointer_type(type);
-    const typet &subtype=ns.follow(pointer_type.subtype());
+    const typet &subtype = pointer_type.subtype();
 
-    if(subtype.id() == ID_struct)
+    if(subtype.id() == ID_struct_tag)
     {
-      const struct_typet &struct_type = to_struct_type(subtype);
-      const irep_idt struct_tag = struct_type.get_tag();
+      const irep_idt struct_tag = to_struct_tag_type(subtype).get_identifier();
 
       if(
         recursion_set.find(struct_tag) != recursion_set.end() &&
@@ -153,13 +152,15 @@ void symbol_factoryt::gen_nondet_init(
       assignments.add(std::move(null_check));
     }
   }
-  else if(type.id() == ID_struct)
+  else if(type.id() == ID_struct_tag)
   {
-    const struct_typet &struct_type = to_struct_type(type);
+    const auto &struct_tag_type = to_struct_tag_type(type);
 
-    const irep_idt struct_tag = struct_type.get_tag();
+    const irep_idt struct_tag = struct_tag_type.get_identifier();
 
     recursion_set.insert(struct_tag);
+
+    const auto &struct_type = to_struct_type(ns.follow_tag(struct_tag_type));
 
     for(const auto &component : struct_type.components())
     {


### PR DESCRIPTION
The struct_tag type is currently expanded into the corresponding struct
type; this yields an invalid assignment instruction where the type of lhs()
and rhs() differs.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
