### PR TITLE
Simplifier: in pointer-typed (a + b) + c the pointer may be c [blocks: #2064]

### DIFF
--- a/regression/cbmc/Pointer_Arithmetic15/main.c
+++ b/regression/cbmc/Pointer_Arithmetic15/main.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+
+int main()
+{
+  int *p, *q;
+  long a, b;
+
+  p = p + a;
+  p = a + p + b;
+  p = a + p;
+  p = a + b + p;
+
+  p = p - a;
+  p = a + p - b;
+
+  a = p - q;
+
+  assert(0);
+}

--- a/regression/cbmc/Pointer_Arithmetic15/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic15/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=10$
@@ -7,5 +7,5 @@ main.c
 --
 ^warning: ignoring
 --
-Symbolic execution currently messes up the typing in "p = a + b + p;" making the
+The simplifier previously messed up the typing in "p = a + b + p;" making the
 right-hand side signed long rather than a pointer.

--- a/regression/cbmc/Pointer_Arithmetic15/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic15/test.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+main.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+--
+Symbolic execution currently messes up the typing in "p = a + b + p;" making the
+right-hand side signed long rather than a pointer.

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -472,7 +472,9 @@ bool simplify_exprt::simplify_plus(exprt &expr)
     // ((T*)p+a)+b -> (T*)p+(a+b)
     if(
       plus_expr.type().id() == ID_pointer && plus_expr.operands().size() == 2 &&
-      plus_expr.op0().id() == ID_plus && plus_expr.op0().operands().size() == 2)
+      plus_expr.op0().id() == ID_plus &&
+      plus_expr.op0().type().id() == ID_pointer &&
+      plus_expr.op0().operands().size() == 2)
     {
       exprt op0 = plus_expr.op0();
 


### PR DESCRIPTION
Pointer arithmetic using multiple operands left of the pointer is currently
broken.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
