### PR TITLE
Make the simplifier preserve syntactically equal types [blocks: #2064]

### DIFF
--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -955,7 +955,9 @@ bool simplify_exprt::simplify_concatenation(exprt &expr)
   }
 
   // { x } = x
-  if(expr.operands().size()==1)
+  if(
+    expr.operands().size() == 1 &&
+    base_type_eq(expr.op0().type(), expr.type(), ns))
   {
     exprt tmp;
     tmp.swap(expr.op0());

--- a/src/util/simplify_expr_struct.cpp
+++ b/src/util/simplify_expr_struct.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "arith_tools.h"
 #include "base_type.h"
 #include "byte_operators.h"
+#include "invariant.h"
 #include "namespace.h"
 #include "pointer_offset_size.h"
 #include "std_expr.h"
@@ -45,6 +46,9 @@ bool simplify_exprt::simplify_member(exprt &expr)
         if(op1.get(ID_component_name)==component_name)
         {
           // found it!
+          DATA_INVARIANT(
+            base_type_eq(op2.type(), expr.type(), ns),
+            "member expression type must match component type");
           exprt tmp;
           tmp.swap(op2);
           expr.swap(tmp);
@@ -134,6 +138,9 @@ bool simplify_exprt::simplify_member(exprt &expr)
       if(struct_type.has_component(component_name))
       {
         std::size_t number=struct_type.component_number(component_name);
+        DATA_INVARIANT(
+          base_type_eq(op.operands()[number].type(), expr.type(), ns),
+          "member expression type must match component type");
         exprt tmp;
         tmp.swap(op.operands()[number]);
         expr.swap(tmp);


### PR DESCRIPTION
base_type_eq guarantees semantic equality, but the resulting expression should
always have exactly the same type.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
