### PR TITLE
Make the SMT2 parser have-a lexer [blocks: #2310]

### DIFF
--- a/src/solvers/smt2/smt2_dec.cpp
+++ b/src/solvers/smt2/smt2_dec.cpp
@@ -141,7 +141,7 @@ decision_proceduret::resultt smt2_dect::read_result(std::istream &in)
 
   while(in)
   {
-    irept parsed=smt2irep(in);
+    irept parsed = smt2irep(in, get_message_handler());
 
     if(parsed.id()=="sat")
       res=resultt::D_SATISFIABLE;

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -925,75 +925,74 @@ exprt smt2_parsert::expression()
   switch(next_token())
   {
   case smt2_tokenizert::SYMBOL:
+  {
+    // hash it
+    const irep_idt identifier = smt2_tokenizer.get_buffer();
+
+    if(identifier == ID_true)
+      return true_exprt();
+    else if(identifier == ID_false)
+      return false_exprt();
+    else if(identifier == "roundNearestTiesToEven")
     {
-      // hash it
-      const irep_idt identifier=smt2_tokenizer.get_buffer();
-
-      if(identifier==ID_true)
-        return true_exprt();
-      else if(identifier==ID_false)
-        return false_exprt();
-      else if(identifier == "roundNearestTiesToEven")
-      {
-        // we encode as 32-bit unsignedbv
-        return from_integer(ieee_floatt::ROUND_TO_EVEN, unsignedbv_typet(32));
-      }
-      else if(identifier == "roundNearestTiesToAway")
-      {
-        throw error("unsupported rounding mode");
-      }
-      else if(identifier == "roundTowardPositive")
-      {
-        // we encode as 32-bit unsignedbv
-        return from_integer(
-          ieee_floatt::ROUND_TO_PLUS_INF, unsignedbv_typet(32));
-      }
-      else if(identifier == "roundTowardNegative")
-      {
-        // we encode as 32-bit unsignedbv
-        return from_integer(
-          ieee_floatt::ROUND_TO_MINUS_INF, unsignedbv_typet(32));
-      }
-      else if(identifier == "roundTowardZero")
-      {
-        // we encode as 32-bit unsignedbv
-        return from_integer(ieee_floatt::ROUND_TO_ZERO, unsignedbv_typet(32));
-      }
-      else
-      {
-        // rummage through id_map
-        const irep_idt final_id=rename_id(identifier);
-        auto id_it=id_map.find(final_id);
-        if(id_it!=id_map.end())
-        {
-          symbol_exprt symbol_expr(final_id, id_it->second.type);
-          if(smt2_tokenizer.token_is_quoted_symbol())
-            symbol_expr.set(ID_C_quoted, true);
-          return std::move(symbol_expr);
-        }
-
-        throw error() << "unknown expression `" << identifier << '\'';
-      }
+      // we encode as 32-bit unsignedbv
+      return from_integer(ieee_floatt::ROUND_TO_EVEN, unsignedbv_typet(32));
     }
+    else if(identifier == "roundNearestTiesToAway")
+    {
+      throw error("unsupported rounding mode");
+    }
+    else if(identifier == "roundTowardPositive")
+    {
+      // we encode as 32-bit unsignedbv
+      return from_integer(ieee_floatt::ROUND_TO_PLUS_INF, unsignedbv_typet(32));
+    }
+    else if(identifier == "roundTowardNegative")
+    {
+      // we encode as 32-bit unsignedbv
+      return from_integer(
+        ieee_floatt::ROUND_TO_MINUS_INF, unsignedbv_typet(32));
+    }
+    else if(identifier == "roundTowardZero")
+    {
+      // we encode as 32-bit unsignedbv
+      return from_integer(ieee_floatt::ROUND_TO_ZERO, unsignedbv_typet(32));
+    }
+    else
+    {
+      // rummage through id_map
+      const irep_idt final_id = rename_id(identifier);
+      auto id_it = id_map.find(final_id);
+      if(id_it != id_map.end())
+      {
+        symbol_exprt symbol_expr(final_id, id_it->second.type);
+        if(smt2_tokenizer.token_is_quoted_symbol())
+          symbol_expr.set(ID_C_quoted, true);
+        return std::move(symbol_expr);
+      }
+
+      throw error() << "unknown expression `" << identifier << '\'';
+    }
+  }
 
   case smt2_tokenizert::NUMERAL:
   {
     const std::string &buffer = smt2_tokenizer.get_buffer();
-    if(buffer.size()>=2 && buffer[0]=='#' && buffer[1]=='x')
+    if(buffer.size() >= 2 && buffer[0] == '#' && buffer[1] == 'x')
     {
-      mp_integer value=
+      mp_integer value =
         string2integer(std::string(buffer, 2, std::string::npos), 16);
-      const std::size_t width = 4*(buffer.size() - 2);
-      CHECK_RETURN(width!=0 && width%4==0);
+      const std::size_t width = 4 * (buffer.size() - 2);
+      CHECK_RETURN(width != 0 && width % 4 == 0);
       unsignedbv_typet type(width);
       return from_integer(value, type);
     }
-    else if(buffer.size()>=2 && buffer[0]=='#' && buffer[1]=='b')
+    else if(buffer.size() >= 2 && buffer[0] == '#' && buffer[1] == 'b')
     {
-      mp_integer value=
+      mp_integer value =
         string2integer(std::string(buffer, 2, std::string::npos), 2);
       const std::size_t width = buffer.size() - 2;
-      CHECK_RETURN(width!=0);
+      CHECK_RETURN(width != 0);
       unsignedbv_typet type(width);
       return from_integer(value, type);
     }

--- a/src/solvers/smt2/smt2_parser.h
+++ b/src/solvers/smt2/smt2_parser.h
@@ -15,18 +15,19 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "smt2_tokenizer.h"
 
-class smt2_parsert:public smt2_tokenizert
+class smt2_parsert
 {
 public:
   explicit smt2_parsert(std::istream &_in)
-    : smt2_tokenizert(_in), exit(false), parenthesis_level(0)
+    : exit(false), smt2_tokenizer(_in), parenthesis_level(0)
   {
   }
 
-  bool parse() override
+  virtual ~smt2_parsert() = default;
+
+  void parse()
   {
     command_sequence();
-    return false;
   }
 
   struct idt
@@ -54,13 +55,24 @@ public:
 
   bool exit;
 
+  smt2_tokenizert::smt2_errort error(const std::string &message)
+  {
+    return smt2_tokenizer.error(message);
+  }
+
+  smt2_tokenizert::smt2_errort error()
+  {
+    return smt2_tokenizer.error();
+  }
+
   /// This skips tokens until all bracketed expressions are closed
   void skip_to_end_of_list();
 
 protected:
-  // we override next_token to track the parenthesis level
+  smt2_tokenizert smt2_tokenizer;
+  // we extend next_token to track the parenthesis level
   std::size_t parenthesis_level;
-  tokent next_token() override;
+  smt2_tokenizert::tokent next_token();
 
   void command_sequence();
 

--- a/src/solvers/smt2/smt2_solver.cpp
+++ b/src/solvers/smt2/smt2_solver.cpp
@@ -167,13 +167,16 @@ void smt2_solvert::command(const std::string &c)
     {
       std::vector<exprt> ops;
 
-      if(next_token() != OPEN)
+      if(next_token() != smt2_tokenizert::OPEN)
         throw error("get-value expects list as argument");
 
-      while(peek() != CLOSE && peek() != END_OF_FILE)
+      while(smt2_tokenizer.peek() != smt2_tokenizert::CLOSE &&
+            smt2_tokenizer.peek() != smt2_tokenizert::END_OF_FILE)
+      {
         ops.push_back(expression()); // any term
+      }
 
-      if(next_token() != CLOSE)
+      if(next_token() != smt2_tokenizert::CLOSE)
         throw error("get-value expects ')' at end of list");
 
       if(status != SAT)
@@ -217,10 +220,12 @@ void smt2_solvert::command(const std::string &c)
     }
     else if(c == "echo")
     {
-      if(next_token() != STRING_LITERAL)
+      if(next_token() != smt2_tokenizert::STRING_LITERAL)
         throw error("expected string literal");
 
-      std::cout << smt2_format(constant_exprt(buffer, string_typet())) << '\n';
+      std::cout << smt2_format(constant_exprt(
+                     smt2_tokenizer.get_buffer(), string_typet()))
+                << '\n';
     }
     else if(c == "get-assignment")
     {
@@ -374,7 +379,6 @@ int solver(std::istream &in)
   boolbv.set_message_handler(message_handler);
 
   smt2_solvert smt2_solver(in, boolbv);
-  smt2_solver.set_message_handler(message_handler);
   bool error_found = false;
 
   while(!smt2_solver.exit)
@@ -383,11 +387,10 @@ int solver(std::istream &in)
     {
       smt2_solver.parse();
     }
-    catch(const smt2_solvert::smt2_errort &error)
+    catch(const smt2_tokenizert::smt2_errort &error)
     {
       smt2_solver.skip_to_end_of_list();
       error_found = true;
-      messaget message(message_handler);
       message.error().source_location.set_line(error.get_line_no());
       message.error() << error.what() << messaget::eom;
     }
@@ -395,7 +398,6 @@ int solver(std::istream &in)
     {
       smt2_solver.skip_to_end_of_list();
       error_found = true;
-      messaget message(message_handler);
       message.error() << error.what() << messaget::eom;
     }
   }

--- a/src/solvers/smt2/smt2_tokenizer.h
+++ b/src/solvers/smt2/smt2_tokenizer.h
@@ -10,12 +10,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_SOLVERS_SMT2_SMT2_TOKENIZER_H
 
 #include <util/exception_utils.h>
-#include <util/parser.h>
 
 #include <sstream>
 #include <string>
 
-class smt2_tokenizert:public parsert
+class smt2_tokenizert
 {
 public:
   explicit smt2_tokenizert(std::istream &_in) : peeked(false), token(NONE)
@@ -57,10 +56,6 @@ public:
     unsigned line_no;
   };
 
-protected:
-  std::string buffer;
-  bool quoted_symbol = false;
-  bool peeked;
   using tokent = enum {
     NONE,
     END_OF_FILE,
@@ -71,9 +66,8 @@ protected:
     OPEN,
     CLOSE
   };
-  tokent token;
 
-  virtual tokent next_token();
+  tokent next_token();
 
   tokent peek()
   {
@@ -87,9 +81,15 @@ protected:
     }
   }
 
-  /// skip any tokens until all parentheses are closed
-  /// or the end of file is reached
-  void skip_to_end_of_list();
+  const std::string &get_buffer() const
+  {
+    return buffer;
+  }
+
+  bool token_is_quoted_symbol() const
+  {
+    return quoted_symbol;
+  }
 
   /// generate an error exception, pre-filled with a message
   smt2_errort error(const std::string &message)
@@ -102,6 +102,18 @@ protected:
   {
     return smt2_errort(line_no);
   }
+
+protected:
+  std::istream *in;
+  unsigned line_no;
+  std::string buffer;
+  bool quoted_symbol = false;
+  bool peeked;
+  tokent token;
+
+  /// skip any tokens until all parentheses are closed
+  /// or the end of file is reached
+  void skip_to_end_of_list();
 
 private:
   tokent get_decimal_numeral();

--- a/src/solvers/smt2/smt2irep.cpp
+++ b/src/solvers/smt2/smt2irep.cpp
@@ -8,6 +8,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "smt2irep.h"
 
+#include <util/message.h>
+
 #include <stack>
 
 #include "smt2_tokenizer.h"
@@ -15,7 +17,8 @@ Author: Daniel Kroening, kroening@kroening.com
 class smt2irept:public smt2_tokenizert
 {
 public:
-  explicit smt2irept(std::istream &_in):smt2_tokenizert(_in)
+  smt2irept(std::istream &_in, message_handlert &message_handler)
+    : smt2_tokenizert(_in), log(message_handler)
   {
   }
 
@@ -25,9 +28,10 @@ public:
     return result;
   }
 
-  bool parse() override;
+  bool parse();
 
 protected:
+  messaget log;
   irept result;
 };
 
@@ -88,13 +92,13 @@ bool smt2irept::parse()
   }
   catch(const smt2_errort &e)
   {
-    messaget::error().source_location.set_line(e.get_line_no());
-    messaget::error() << e.what() << eom;
+    log.error().source_location.set_line(e.get_line_no());
+    log.error() << e.what() << messaget::eom;
     return true;
   }
 }
 
-irept smt2irep(std::istream &in)
+irept smt2irep(std::istream &in, message_handlert &message_handler)
 {
-  return smt2irept(in)();
+  return smt2irept(in, message_handler)();
 }

--- a/src/solvers/smt2/smt2irep.h
+++ b/src/solvers/smt2/smt2irep.h
@@ -14,6 +14,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/irep.h>
 
-irept smt2irep(std::istream &);
+class message_handlert;
+
+irept smt2irep(std::istream &, message_handlert &);
 
 #endif // CPROVER_SOLVERS_SMT2_SMT2IREP_H


### PR DESCRIPTION
Do not inherit - a lexer isn't a parser. This also fixes shadowing of "token"
and "message."

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
