### PR TITLE
Visual Studio 2017 warns about throwing functions passed to C functions [blocks: #2310]

### DIFF
--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -63,6 +63,8 @@ Date: June 2006
 #ifdef _MSC_VER
 #pragma warning(disable:4668)
   // using #if/#elif on undefined macro
+#pragma warning(disable : 5039)
+// pointer or reference to potentially throwing function passed to extern C
 #endif
 #include <direct.h>
 #include <windows.h>

--- a/src/util/cout_message.cpp
+++ b/src/util/cout_message.cpp
@@ -15,6 +15,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifdef _MSC_VER
 #pragma warning(disable:4668)
   // using #if/#elif on undefined macro
+#pragma warning(disable : 5039)
+// pointer or reference to potentially throwing function passed to extern C
 #endif
 #include <windows.h>
 #include <fcntl.h>

--- a/src/util/file_util.cpp
+++ b/src/util/file_util.cpp
@@ -36,6 +36,8 @@ Date: January 2012
 #ifdef _MSC_VER
 #pragma warning(disable:4668)
   // using #if/#elif on undefined macro
+#pragma warning(disable : 5039)
+// pointer or reference to potentially throwing function passed to extern C
 #endif
 #include <io.h>
 #include <windows.h>

--- a/src/util/memory_info.cpp
+++ b/src/util/memory_info.cpp
@@ -23,6 +23,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifdef _MSC_VER
 #pragma warning(disable:4668)
   // using #if/#elif on undefined macro
+#pragma warning(disable : 5039)
+// pointer or reference to potentially throwing function passed to extern C
 #endif
 #include <windows.h>
 #include <psapi.h>

--- a/src/util/run.cpp
+++ b/src/util/run.cpp
@@ -16,6 +16,8 @@ Date: August 2012
 #ifdef _MSC_VER
 #pragma warning(disable:4668)
   // using #if/#elif on undefined macro
+#pragma warning(disable:5039)
+// pointer or reference to potentially throwing function passed to extern C
 #endif
 #include <process.h>
 #include <windows.h>

--- a/src/util/tempdir.cpp
+++ b/src/util/tempdir.cpp
@@ -13,6 +13,8 @@ Author: CM Wintersteiger
 #ifdef _MSC_VER
 #pragma warning(disable:4668)
   // using #if/#elif on undefined macro
+#pragma warning(disable : 5039)
+// pointer or reference to potentially throwing function passed to extern C
 #endif
 #include <windows.h>
 #include <io.h>

--- a/src/util/tempfile.cpp
+++ b/src/util/tempfile.cpp
@@ -13,6 +13,8 @@ Author: Daniel Kroening
 #ifdef _MSC_VER
 #pragma warning(disable:4668)
   // using #if/#elif on undefined macro
+#pragma warning(disable : 5039)
+// pointer or reference to potentially throwing function passed to extern C
 #endif
 #include <process.h>
 #include <sys/stat.h>

--- a/src/util/unicode.cpp
+++ b/src/util/unicode.cpp
@@ -19,6 +19,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifdef _MSC_VER
 #pragma warning(disable:4668)
   // using #if/#elif on undefined macro
+#pragma warning(disable : 5039)
+// pointer or reference to potentially throwing function passed to extern C
 #endif
 #include <windows.h>
 #include <util/pragma_pop.def>


### PR DESCRIPTION
This is done in winbase.h, there is nothing we can do about it.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
