### PR TITLE
__int128 is not supported by Visual Studio

### DIFF
--- a/buildspec-windows.yml
+++ b/buildspec-windows.yml
@@ -48,7 +48,6 @@ phases:
         Remove-Item cbmc\byte_update5 -Force -Recurse
         Remove-Item cbmc\byte_update6 -Force -Recurse
         Remove-Item cbmc\byte_update7 -Force -Recurse
-        Remove-Item cbmc\unsigned___int128 -Force -Recurse
         Remove-Item cbmc-library\pipe-01 -Force -Recurse
         Remove-Item cpp -Force -Recurse
         Remove-Item cbmc-cpp -Force -Recurse

--- a/regression/cbmc/unsigned___int128/main.c
+++ b/regression/cbmc/unsigned___int128/main.c
@@ -1,3 +1,8 @@
+#ifndef __GNUC__
+void reduce()
+{
+}
+#else
 # include <stdint.h>
 
 typedef unsigned __int128 uint128_t;
@@ -109,3 +114,4 @@ void reduce(
           out[2] < p[1] || (out[2]==p[1] && (out[1]<p[2] || out[1]==p[2]
           && (out[0]<p[3]))))));
 }
+#endif


### PR DESCRIPTION
Make the test trivially pass on Windows when not using Cygwin.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
