### PR TITLE
C++ front-end: Distinguish references from rvalue references [blocks: #3659]

### DIFF
--- a/buildspec-windows.yml
+++ b/buildspec-windows.yml
@@ -47,10 +47,8 @@ phases:
         Remove-Item cbmc\byte_update5 -Force -Recurse
         Remove-Item cbmc\byte_update6 -Force -Recurse
         Remove-Item cbmc\byte_update7 -Force -Recurse
-        Remove-Item cpp -Force -Recurse
-        Remove-Item cbmc-cpp -Force -Recurse
+        Remove-Item cpp\virtual1 -Force -Recurse
         Remove-Item goto-gcc -Force -Recurse
-        Remove-Item systemc -Force -Recurse
         cd ..
         cd jbmc/regression
         Remove-Item jbmc\VarLengthArrayTrace1 -Force -Recurse

--- a/src/cpp/cpp_type2name.cpp
+++ b/src/cpp/cpp_type2name.cpp
@@ -33,7 +33,18 @@ static void irep2name(const irept &irep, std::string &result)
   if(is_reference(static_cast<const typet&>(irep)))
     result+="reference";
 
-  if(irep.id()!="")
+  if(is_rvalue_reference(static_cast<const typet &>(irep)))
+    result += "rvalue_reference";
+
+  if(irep.id() == ID_frontend_pointer)
+  {
+    if(irep.get_bool(ID_C_reference))
+      result += "reference";
+
+    if(irep.get_bool(ID_C_rvalue_reference))
+      result += "rvalue_reference";
+  }
+  else if(!irep.id().empty())
     result+=do_prefix(irep.id_string());
 
   if(irep.get_named_sub().empty() && irep.get_sub().empty())


### PR DESCRIPTION
Template specialisation previously would produce the same symbol name for both
template<typename T> struct S<T&> as well as template<typename T> struct S<T&&>.
As Visual Studio uses both of these in system headers, any test involving
includes failed on Windows.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
