### PR TITLE
Avoid shadowing "message" [blocks: #2310]

### DIFF
--- a/src/goto-analyzer/taint_parser.cpp
+++ b/src/goto-analyzer/taint_parser.cpp
@@ -54,11 +54,6 @@ bool taint_parser(
     taint_parse_treet::rulet rule;
 
     const std::string kind = taint_spec["kind"].value;
-    const std::string function = taint_spec["function"].value;
-    const std::string where = taint_spec["where"].value;
-    const std::string taint = taint_spec["taint"].value;
-    const std::string message = taint_spec["message"].value;
-    const std::string id = taint_spec["id"].value;
 
     if(kind=="source")
       rule.kind=taint_parse_treet::rulet::SOURCE;
@@ -75,6 +70,8 @@ bool taint_parser(
       return true;
     }
 
+    const std::string function = taint_spec["function"].value;
+
     if(function.empty())
     {
       messaget message(message_handler);
@@ -84,6 +81,8 @@ bool taint_parser(
     }
     else
       rule.function_identifier=function;
+
+    const std::string where = taint_spec["where"].value;
 
     if(where=="return_value")
     {
@@ -109,9 +108,9 @@ bool taint_parser(
       return true;
     }
 
-    rule.taint=taint;
-    rule.message=message;
-    rule.id=id;
+    rule.taint = taint_spec["taint"].value;
+    rule.message = taint_spec["message"].value;
+    rule.id = taint_spec["id"].value;
 
     dest.rules.push_back(rule);
   }


### PR DESCRIPTION
Just move the declarations closer to their use, and get rid of some temporaries
altogether.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
