### PR TITLE
Do not shadow "mstream" [blocks: #2310]

### DIFF
--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -445,10 +445,10 @@ int jbmc_parse_optionst::doit()
   switch(ui_message_handler.get_ui())
   {
     case ui_message_handlert::uit::PLAIN:
-      conditional_output(debug(), [&options](messaget::mstreamt &mstream) {
-        mstream << "\nOptions: \n";
-        options.output(mstream);
-        mstream << messaget::eom;
+      conditional_output(debug(), [&options](messaget::mstreamt &debug_stream) {
+        debug_stream << "\nOptions: \n";
+        options.output(debug_stream);
+        debug_stream << messaget::eom;
       });
       break;
     case ui_message_handlert::uit::JSON_UI:


### PR DESCRIPTION
The code inherits from messaget (which should be fixed), and thus has an mstream
member. Rename this use to debug_stream.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
