### PR TITLE
signed left-shift overflow depends on standard version

### DIFF
--- a/regression/cbmc/Overflow_Leftshift1/main.c
+++ b/regression/cbmc/Overflow_Leftshift1/main.c
@@ -3,7 +3,7 @@ int main()
   unsigned char x;
 
   // signed, owing to promotion, and may overflow
-  unsigned r=x << ((sizeof(unsigned)-1)*8);
+  unsigned r = x << ((sizeof(unsigned) - 1) * 8 + 1);
 
   // signed, owing to promotion, and cannot overflow
   r=x << ((sizeof(unsigned)-1)*8-1);
@@ -19,6 +19,9 @@ int main()
 
   // distance too far, not an overflow
   s = s << 100;
+
+  // not an overflow in ANSI-C, but undefined in C99
+  s = 1 << (sizeof(int) * 8 - 1);
 
   return 0;
 }

--- a/regression/cbmc/Overflow_Leftshift1/test-c89.desc
+++ b/regression/cbmc/Overflow_Leftshift1/test-c89.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---signed-overflow-check
+--signed-overflow-check --c89
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*\] line 6 arithmetic overflow on signed shl in .*: FAILURE$
@@ -13,3 +13,4 @@ main.c
 ^warning: ignoring
 ^\[.*\] line 12 arithmetic overflow on signed shl in .*: .*
 ^\[.*\] line 21 arithmetic overflow on signed shl in .*: .*
+^\[.*\] line 24 arithmetic overflow on signed shl in .*: .*

--- a/src/ansi-c/c_preprocess.cpp
+++ b/src/ansi-c/c_preprocess.cpp
@@ -610,7 +610,7 @@ bool c_preprocess_gcc_clang(
     switch(config.ansi_c.c_standard)
     {
     case configt::ansi_ct::c_standardt::C89:
-      argv.push_back("-std=gnu++89");
+      argv.push_back("-std=gnu89");
       break;
 
     case configt::ansi_ct::c_standardt::C99:


### PR DESCRIPTION
The semantics of signed left shifts are contentious for the case
that a '1' is shifted into the signed bit.
Assuming 32-bit integers, 1<<31 is implementation-defined
in ANSI C and C++98, but is explicitly undefined by C99,
C11 and C++11.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
