### PR TITLE
Replace all uses of move_to_operands

### DIFF
--- a/jbmc/src/java_bytecode/character_refine_preprocess.cpp
+++ b/jbmc/src/java_bytecode/character_refine_preprocess.cpp
@@ -1191,9 +1191,8 @@ exprt character_refine_preprocesst::expr_of_to_chars(
   array_exprt case2(array_type);
   exprt low_surrogate=expr_of_low_surrogate(chr, char_type);
   case1.copy_to_operands(low_surrogate);
-  case2.move_to_operands(low_surrogate);
-  exprt high_surrogate=expr_of_high_surrogate(chr, char_type);
-  case2.move_to_operands(high_surrogate);
+  case2.add_to_operands(
+    std::move(low_surrogate), expr_of_high_surrogate(chr, char_type));
   return if_exprt(expr_of_is_bmp_code_point(chr, type), case1, case2);
 }
 

--- a/jbmc/src/java_bytecode/java_bytecode_convert_class.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_class.cpp
@@ -879,9 +879,8 @@ void java_bytecode_convert_classt::add_array_types(symbol_tablet &symbol_table)
       // TODO use this instead of a loop.
     codet array_copy;
     array_copy.set_statement(ID_array_copy);
-    array_copy.move_to_operands(new_data);
-    array_copy.move_to_operands(old_data);
-    clone_body.move_to_operands(array_copy);
+    array_copy.add_to_operands(std::move(new_data), std::move(old_data));
+    clone_body.add_to_operands(std::move(array_copy));
     */
 
     // Begin for-loop to replace:

--- a/jbmc/src/java_bytecode/java_string_literals.cpp
+++ b/jbmc/src/java_bytecode/java_string_literals.cpp
@@ -173,8 +173,8 @@ symbol_exprt get_or_create_string_literal_symbol(
     // _return_value global for its side-effects.
     exprt init_comma_expr(ID_comma);
     init_comma_expr.type() = literal_init.type();
-    init_comma_expr.copy_to_operands(return_symbol.symbol_expr());
-    init_comma_expr.move_to_operands(literal_init);
+    init_comma_expr.add_to_operands(
+      return_symbol.symbol_expr(), std::move(literal_init));
     new_symbol.value = init_comma_expr;
   }
   else if(jls_struct.components().size()>=1 &&

--- a/jbmc/unit/util/expr_iterator.cpp
+++ b/jbmc/unit/util/expr_iterator.cpp
@@ -176,8 +176,8 @@ SCENARIO("depth_iterator_mutate_root", "[core][utils][depth_iterator]")
     exprt test_root;
     // This is the expression we might mutate when we find it
     exprt test_operand(ID_1);
-    test_root.move_to_operands(test_operand);
-    test_expr.move_to_operands(test_root);
+    test_root.add_to_operands(std::move(test_operand));
+    test_expr.add_to_operands(std::move(test_root));
     WHEN("Iteration occurs without mutation")
     {
       // Create shared copies

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1413,10 +1413,7 @@ void goto_checkt::add_guarded_claim(
   if(guard.is_true())
     new_expr.swap(expr);
   else
-  {
-    new_expr=exprt(ID_implies, bool_typet());
-    new_expr.add_to_operands(guard.as_expr(), std::move(expr));
-  }
+    new_expr = implies_exprt(guard.as_expr(), std::move(expr));
 
   if(assertions.insert(new_expr).second)
   {

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -943,7 +943,7 @@ void c_typecheck_baset::typecheck_side_effect_statement_expression(
     {
       side_effect_exprt assign(
         ID_assign, sideeffect.type(), fc.source_location());
-      assign.move_to_operands(fc.lhs(), sideeffect);
+      assign.add_to_operands(fc.lhs(), std::move(sideeffect));
 
       code_expressiont code_expr(assign);
       code_expr.add_source_location() = fc.source_location();
@@ -1302,7 +1302,7 @@ void c_typecheck_baset::typecheck_expr_index(exprt &expr)
     typecheck_arithmetic_pointer(expr.op0());
     exprt addition(ID_plus, array_expr.type());
     addition.operands().swap(expr.operands());
-    expr.move_to_operands(addition);
+    expr.add_to_operands(std::move(addition));
     expr.id(ID_dereference);
     expr.set(ID_C_lvalue, true);
     expr.type() = final_array_type.subtype();

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -442,8 +442,7 @@ offsetof_member_designator:
         {
           $$=$1;
           set($2, ID_index);
-          exprt tmp=convert_integer_literal("0");
-          stack($2).move_to_operands(tmp);
+          stack($2).add_to_operands(convert_integer_literal("0"));
           mto($$, $2);
           set($2, ID_member);
           stack($2).set(ID_component_name, stack($3).get(ID_C_base_name));
@@ -574,7 +573,7 @@ postfix_expression:
           tmp.operands().swap(stack($5).operands());
           $$=$1;
           set($$, ID_typecast);
-          stack($$).move_to_operands(tmp);
+          stack($$).add_to_operands(std::move(tmp));
           stack($$).type().swap(stack($2));
         }
         | '(' type_name ')' '{' initializer_list ',' '}'
@@ -585,7 +584,7 @@ postfix_expression:
           tmp.operands().swap(stack($5).operands());
           $$=$1;
           set($$, ID_typecast);
-          stack($$).move_to_operands(tmp);
+          stack($$).add_to_operands(std::move(tmp));
           stack($$).type().swap(stack($2));
         }
         ;
@@ -2080,7 +2079,7 @@ initializer_list:
           exprt tmp;
           tmp.swap(stack($$));
           stack($$).clear();
-          stack($$).move_to_operands(tmp);
+          stack($$).add_to_operands(std::move(tmp));
         }
         | initializer_list ',' designated_initializer
         {
@@ -2123,7 +2122,7 @@ designated_initializer:
           exprt designator;
           exprt member(ID_member);
           member.set(ID_component_name, stack($1).get(ID_C_base_name));
-          designator.move_to_operands(member);
+          designator.add_to_operands(std::move(member));
           stack($$).add(ID_designator).swap(designator);
           mto($$, $3);
         }
@@ -2638,14 +2637,14 @@ gcc_asm_output:
         {
           $$=$2;
           stack($$).id(ID_gcc_asm_output);
-          stack($$).move_to_operands(stack($1), stack($3)); 
+          stack($$).add_to_operands(std::move(stack($1)), std::move(stack($3)));
         }
         | '[' identifier_or_typedef_name ']'
           string '(' comma_expression ')'
         {
           $$=$5;
           stack($$).id(ID_gcc_asm_output);
-          stack($$).move_to_operands(stack($4), stack($6)); 
+          stack($$).add_to_operands(std::move(stack($4)), std::move(stack($6)));
         }
         ;
 
@@ -2675,14 +2674,14 @@ gcc_asm_input:
         {
           $$=$2;
           stack($$).id(ID_gcc_asm_input);
-          stack($$).move_to_operands(stack($1), stack($3)); 
+          stack($$).add_to_operands(std::move(stack($1)), std::move(stack($3)));
         }
         | '[' identifier_or_typedef_name ']'
           string '(' comma_expression ')'
         {
           $$=$5;
           stack($$).id(ID_gcc_asm_input);
-          stack($$).move_to_operands(stack($4), stack($6)); 
+          stack($$).add_to_operands(std::move(stack($4)), std::move(stack($6)));
         }
         ;
 

--- a/src/ansi-c/parser_static.inc
+++ b/src/ansi-c/parser_static.inc
@@ -9,7 +9,7 @@
 #define YYSTYPE unsigned
 #define YYSTYPE_IS_TRIVIAL 1
 
-#define mto(x, y) stack(x).move_to_operands(stack(y))
+#define mto(x, y) stack(x).add_to_operands(std::move(stack(y)))
 #define mts(x, y) (to_type_with_subtypes(stack_type(x)).move_to_subtypes(stack_type(y)))
 #define binary(x, y, l, id, z) { init(x, id); \
   stack(x).add_source_location()=stack(l).source_location(); \

--- a/src/cpp/cpp_constructor.cpp
+++ b/src/cpp/cpp_constructor.cpp
@@ -190,7 +190,7 @@ optionalt<codet> cpp_typecheckt::cpp_constructor(
         val=true_exprt();
 
       side_effect_exprt assign(ID_assign, typet(), source_location);
-      assign.move_to_operands(member, val);
+      assign.add_to_operands(std::move(member), std::move(val));
       typecheck_side_effect_assignment(assign);
       block.add(code_expressiont(std::move(assign)));
     }
@@ -285,7 +285,7 @@ void cpp_typecheckt::new_temporary(
   if(new_code.has_value())
   {
     if(new_code->get_statement() == ID_assign)
-      tmp_object_expr.move_to_operands(new_code->op1());
+      tmp_object_expr.add_to_operands(std::move(new_code->op1()));
     else
       tmp_object_expr.add(ID_initializer) = *new_code;
   }

--- a/src/cpp/cpp_destructor.cpp
+++ b/src/cpp/cpp_destructor.cpp
@@ -68,7 +68,7 @@ optionalt<codet> cpp_typecheckt::cpp_destructor(
 
       auto i_code = cpp_destructor(source_location, index);
       if(i_code.has_value())
-        new_code.move_to_operands(i_code.value());
+        new_code.add_to_operands(std::move(i_code.value()));
     }
   }
   else

--- a/src/cpp/cpp_typecheck.cpp
+++ b/src/cpp/cpp_typecheck.cpp
@@ -196,8 +196,6 @@ void cpp_typecheckt::static_and_dynamic_initialization()
 
   dynamic_initializations.clear();
 
-  // block_sini.move_to_operands(block_dini);
-
   // Create the dynamic initialization procedure
   symbolt init_symbol;
 

--- a/src/cpp/cpp_typecheck_code.cpp
+++ b/src/cpp/cpp_typecheck_code.cpp
@@ -418,7 +418,7 @@ void cpp_typecheckt::typecheck_decl(codet &code)
         "declarator type should match symbol type");
     }
 
-    new_code.move_to_operands(decl_statement);
+    new_code.add_to_operands(std::move(decl_statement));
 
     // is there a constructor to be called?
     if(symbol.value.is_not_nil())
@@ -439,7 +439,7 @@ void cpp_typecheckt::typecheck_decl(codet &code)
         symbol.location, object_expr, declarator.init_args().operands());
 
       if(constructor_call.has_value())
-        new_code.move_to_operands(constructor_call.value());
+        new_code.add_to_operands(std::move(constructor_call.value()));
     }
   }
 

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -668,14 +668,14 @@ void cpp_typecheckt::typecheck_compound_declarator(
         {
           expr_call.type()=to_code_type(component.type()).return_type();
           exprt already_typechecked(ID_already_typechecked);
-          already_typechecked.move_to_operands(expr_call);
+          already_typechecked.add_to_operands(std::move(expr_call));
 
           func_symb.value = code_returnt(already_typechecked).make_block();
         }
         else
         {
           exprt already_typechecked(ID_already_typechecked);
-          already_typechecked.move_to_operands(expr_call);
+          already_typechecked.add_to_operands(std::move(expr_call));
 
           func_symb.value = code_expressiont(already_typechecked).make_block();
         }
@@ -1103,12 +1103,12 @@ void cpp_typecheckt::typecheck_compound_body(symbolt &symbol)
   {
     // it's public!
     exprt cpp_public("cpp-public");
-    body.move_to_operands(cpp_public);
+    body.add_to_operands(std::move(cpp_public));
 
     // build declaration
     cpp_declarationt ctor;
     default_ctor(symbol.type.source_location(), symbol.base_name, ctor);
-    body.move_to_operands(ctor);
+    body.add_to_operands(std::move(ctor));
   }
 
   // Reset the access type

--- a/src/cpp/cpp_typecheck_conversions.cpp
+++ b/src/cpp/cpp_typecheck_conversions.cpp
@@ -1398,7 +1398,7 @@ bool cpp_typecheckt::reference_binding(
       tmp.set(ID_statement, ID_temporary_object);
       tmp.add_source_location()=expr.source_location();
       // tmp.set(ID_C_lvalue, true);
-      tmp.move_to_operands(new_expr);
+      tmp.add_to_operands(std::move(new_expr));
       new_expr.swap(tmp);
     }
 

--- a/src/cpp/cpp_typecheck_declaration.cpp
+++ b/src/cpp/cpp_typecheck_declaration.cpp
@@ -57,9 +57,7 @@ void cpp_typecheckt::convert_anonymous_union(
     throw 0;
   }
 
-  code_declt decl_statement(cpp_symbol_expr(symbol));
-
-  new_code.move_to_operands(decl_statement);
+  new_code.add_to_operands(code_declt(cpp_symbol_expr(symbol)));
 
   // do scoping
   symbolt union_symbol=

--- a/src/cpp/cpp_typecheck_destructor.cpp
+++ b/src/cpp/cpp_typecheck_destructor.cpp
@@ -45,7 +45,7 @@ void cpp_typecheckt::default_dtor(
 
   dtor.add(ID_type).id(ID_destructor);
   dtor.add(ID_storage_spec).id(ID_cpp_storage_spec);
-  dtor.move_to_operands(decl);
+  dtor.add_to_operands(std::move(decl));
 }
 
 /// produces destructor code for a class object

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -538,7 +538,7 @@ bool cpp_typecheckt::operator_is_overloaded(exprt &expr)
     {
       add_implicit_dereference(function_call);
       exprt tmp(ID_already_typechecked);
-      tmp.move_to_operands(function_call);
+      tmp.add_to_operands(std::move(function_call));
       expr.op0().swap(tmp);
       typecheck_expr(expr);
       return true;
@@ -658,7 +658,7 @@ bool cpp_typecheckt::operator_is_overloaded(exprt &expr)
           {
             add_implicit_dereference(function_call);
             exprt tmp(ID_already_typechecked);
-            tmp.move_to_operands(function_call);
+            tmp.add_to_operands(std::move(function_call));
             expr.op0()=tmp;
             typecheck_expr(expr);
             return true;
@@ -809,7 +809,7 @@ void cpp_typecheckt::typecheck_expr_new(exprt &expr)
 
   {
     exprt tmp(ID_already_typechecked);
-    tmp.move_to_operands(object_expr);
+    tmp.add_to_operands(std::move(object_expr));
     object_expr.swap(tmp);
   }
 
@@ -931,7 +931,7 @@ void cpp_typecheckt::typecheck_expr_explicit_typecast(exprt &expr)
       // or an expression for a pointer or scalar.
       // We produce a compound_literal expression.
       exprt tmp(ID_compound_literal, expr.type());
-      tmp.move_to_operands(expr.op0());
+      tmp.add_to_operands(std::move(expr.op0()));
       expr=tmp;
       expr.set(ID_C_lvalue, true); // these are l-values
       return;
@@ -1284,7 +1284,7 @@ void cpp_typecheckt::typecheck_expr_ptrmember(
   op.swap(tmp);
 
   op.id(ID_dereference);
-  op.move_to_operands(tmp);
+  op.add_to_operands(std::move(tmp));
   op.add_source_location()=expr.source_location();
   typecheck_expr_dereference(op);
 
@@ -2047,13 +2047,13 @@ void cpp_typecheckt::typecheck_side_effect_function_call(
       if(op0.id()==ID_member || op0.id()==ID_ptrmember)
       {
         vtptr_member.id(op0.id());
-        vtptr_member.move_to_operands(op0.op0());
+        vtptr_member.add_to_operands(std::move(op0.op0()));
       }
       else
       {
         vtptr_member.id(ID_ptrmember);
         exprt this_expr("cpp-this");
-        vtptr_member.move_to_operands(this_expr);
+        vtptr_member.add_to_operands(std::move(this_expr));
       }
 
       // get the virtual table
@@ -2113,7 +2113,7 @@ void cpp_typecheckt::typecheck_side_effect_function_call(
     exprt member(ID_member);
     member.add(ID_component_cpp_name)=cppname;
 
-    member.move_to_operands(op0);
+    member.add_to_operands(std::move(op0));
 
     expr.function().swap(member);
     typecheck_side_effect_function_call(expr);
@@ -2488,11 +2488,11 @@ void cpp_typecheckt::typecheck_side_effect_assignment(side_effect_exprt &expr)
 
   // expr.op0() is already typechecked
   exprt already_typechecked(ID_already_typechecked);
-  already_typechecked.move_to_operands(expr.op0());
+  already_typechecked.add_to_operands(std::move(expr.op0()));
 
   exprt member(ID_member);
   member.set(ID_component_cpp_name, cpp_name);
-  member.move_to_operands(already_typechecked);
+  member.add_to_operands(std::move(already_typechecked));
 
   side_effect_expr_function_callt new_expr;
   new_expr.function().swap(member);
@@ -2558,11 +2558,11 @@ void cpp_typecheckt::typecheck_side_effect_inc_dec(
   const cpp_namet cpp_name(str_op, expr.source_location());
 
   exprt already_typechecked(ID_already_typechecked);
-  already_typechecked.move_to_operands(expr.op0());
+  already_typechecked.add_to_operands(std::move(expr.op0()));
 
   exprt member(ID_member);
   member.set(ID_component_cpp_name, cpp_name);
-  member.move_to_operands(already_typechecked);
+  member.add_to_operands(std::move(already_typechecked));
 
   side_effect_expr_function_callt new_expr;
   new_expr.function().swap(member);

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -295,7 +295,7 @@ exprt cpp_typecheck_resolvet::convert_identifier(
       if(object.is_not_nil())
       {
         // we got an object
-        e.move_to_operands(object);
+        e.add_to_operands(std::move(object));
 
         bool old_value=cpp_typecheck.disable_access_control;
         cpp_typecheck.disable_access_control=true;

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -487,7 +487,7 @@ void Parser::merge_types(const typet &src, typet &dest)
 
 bool Parser::SyntaxError()
 {
-  #define ERROR_TOKENS 4
+#define ERROR_TOKENS 4
 
   cpp_tokent t[ERROR_TOKENS];
 
@@ -553,11 +553,11 @@ bool Parser::rDefinition(cpp_itemt &item)
 {
   int t=lex.LookAhead(0);
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rDefinition 1 " << t
             << '\n';
-  #endif
+#endif
 
   if(t==';')
     return rNullDeclaration(item.make_declaration());
@@ -608,10 +608,10 @@ bool Parser::rTypedef(cpp_declarationt &declaration)
   if(lex.get_token(tk)!=TOK_TYPEDEF)
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rTypedef 1\n";
-  #endif
+#endif
 
   declaration=cpp_declarationt();
   set_location(declaration, tk);
@@ -637,10 +637,10 @@ bool Parser::rTypedefUsing(cpp_declarationt &declaration)
   if(lex.get_token(tk)!=TOK_USING)
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rTypedefUsing 1\n";
-  #endif
+#endif
 
   declaration=cpp_declarationt();
   set_location(declaration, tk);
@@ -654,9 +654,9 @@ bool Parser::rTypedefUsing(cpp_declarationt &declaration)
   name.name()=cpp_namet(tk.data.get(ID_C_base_name));
   name.type().make_nil();
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rTypedefUsing 2\n";
-  #endif
+#endif
 
   if(lex.get_token(tk)!='=')
     return false;
@@ -671,9 +671,9 @@ bool Parser::rTypedefUsing(cpp_declarationt &declaration)
   if(lex.get_token(tk)!=';')
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rTypedefUsing 3\n";
-  #endif
+#endif
 
   return true;
 }
@@ -691,10 +691,10 @@ bool Parser::rTypedefStatement(codet &statement)
 */
 bool Parser::rTypeSpecifier(typet &tspec, bool check)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rTypeSpecifier 0\n";
-  #endif
+#endif
 
   typet cv_q;
 
@@ -703,9 +703,9 @@ bool Parser::rTypeSpecifier(typet &tspec, bool check)
   if(!optCvQualify(cv_q))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rTypeSpecifier 0.1\n";
-  #endif
+#endif
 
   if(!optIntegralTypeOrClassSpec(tspec))
     return false;
@@ -715,34 +715,34 @@ bool Parser::rTypeSpecifier(typet &tspec, bool check)
     cpp_tokent tk;
     lex.LookAhead(0, tk);
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rTypeSpecifier 1\n";
-    #endif
+#endif
 
     if(check)
       if(!MaybeTypeNameOrClassTemplate(tk))
         return false;
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rTypeSpecifier 2\n";
-    #endif
+#endif
 
     if(!rName(tspec))
       return false;
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rTypeSpecifier 3\n";
-  #endif
+#endif
 
   if(!optCvQualify(cv_q))
     return false;
 
   merge_types(cv_q, tspec);
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rTypeSpecifier 4\n";
-  #endif
+#endif
 
   return true;
 }
@@ -1021,12 +1021,12 @@ bool Parser::rTemplateDecl(cpp_declarationt &decl)
   switch(kind)
   {
   case tdk_decl:
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "BODY: "
               << body.pretty() << '\n';
     std::cout << std::string(__indent, ' ') << "TEMPLATE_TYPE: "
               << template_type.pretty() << '\n';
-    #endif
+#endif
     body.add(ID_template_type).swap(template_type);
     body.set(ID_is_template, true);
     decl.swap(body);
@@ -1146,10 +1146,10 @@ bool Parser::rTempArgList(irept &args)
 */
 bool Parser::rTempArgDeclaration(cpp_declarationt &declaration)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rTempArgDeclaration 0\n";
-  #endif
+#endif
 
   int t0=lex.LookAhead(0);
 
@@ -1222,9 +1222,9 @@ bool Parser::rTempArgDeclaration(cpp_declarationt &declaration)
     lex.Restore(pos);
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rTempArgDeclaration 1\n";
-  #endif
+#endif
 
   if(t0==TOK_TEMPLATE)
   {
@@ -1260,10 +1260,10 @@ bool Parser::rTempArgDeclaration(cpp_declarationt &declaration)
   }
   else
   {
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ')
               << "Parser::rTempArgDeclaration 2\n";
-    #endif
+#endif
 
     declaration=cpp_declarationt();
     declaration.set(ID_is_type, false);
@@ -1271,10 +1271,10 @@ bool Parser::rTempArgDeclaration(cpp_declarationt &declaration)
     if(!rTypeSpecifier(declaration.type(), true))
       return false;
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ')
               << "Parser::rTempArgDeclaration 3\n";
-    #endif
+#endif
 
     bool has_ellipsis=false;
 
@@ -1292,10 +1292,10 @@ bool Parser::rTempArgDeclaration(cpp_declarationt &declaration)
     if(!rDeclarator(declarator, kArgDeclarator, true, false))
       return false;
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ')
               << "Parser::rTempArgDeclaration 4\n";
-    #endif
+#endif
 
     add_id(declarator.name(), new_scopet::kindt::NON_TYPE_TEMPLATE_PARAMETER);
 
@@ -1378,11 +1378,11 @@ bool Parser::rExternTemplateDecl(cpp_declarationt &decl)
 
 bool Parser::rDeclaration(cpp_declarationt &declaration)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rDeclaration 0.1  token: "
             << lex.LookAhead(0) << '\n';
-  #endif
+#endif
 
   if(!optAttribute(declaration.type()))
     return false;
@@ -1391,25 +1391,25 @@ bool Parser::rDeclaration(cpp_declarationt &declaration)
   if(!optMemberSpec(member_spec))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rDeclaration 0.2\n";
-  #endif
+#endif
 
   cpp_storage_spect storage_spec;
   if(!optStorageSpec(storage_spec))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rDeclaration 1\n";
-  #endif
+#endif
 
   if(member_spec.is_empty())
     if(!optMemberSpec(member_spec))
       return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rDeclaration 3\n";
-  #endif
+#endif
 
   typet cv_q, integral;
   cv_q.make_nil();
@@ -1424,9 +1424,9 @@ bool Parser::rDeclaration(cpp_declarationt &declaration)
   if(!optCvQualify(cv_q))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rDeclaration 4\n";
-  #endif
+#endif
 
   if(!optIntegralTypeOrClassSpec(integral))
     return false;
@@ -1438,9 +1438,9 @@ bool Parser::rDeclaration(cpp_declarationt &declaration)
 
   if(integral.is_not_nil())
   {
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rDeclaration 5\n";
-    #endif
+#endif
     return
       rIntegralDeclaration(
         declaration, storage_spec, member_spec, integral, cv_q);
@@ -1449,10 +1449,10 @@ bool Parser::rDeclaration(cpp_declarationt &declaration)
   {
     int t=lex.LookAhead(0);
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rDeclaration 6 " << t
               << "\n";
-    #endif
+#endif
 
     if(cv_q.is_not_nil() &&
        ((t==TOK_IDENTIFIER && lex.LookAhead(1)=='=') || t=='*'))
@@ -1529,25 +1529,25 @@ bool Parser::rIntegralDeclaration(
   typet &integral,
   typet &cv_q)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ')
             << "Parser::rIntegralDeclaration 1  token: "
             << static_cast<char>(lex.LookAhead(0)) << "\n";
-  #endif
+#endif
 
   if(!optCvQualify(cv_q))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rIntegralDeclaration 2\n";
-  #endif
+#endif
 
   merge_types(cv_q, integral);
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rIntegralDeclaration 3\n";
-  #endif
+#endif
 
   declaration.type().swap(integral);
   declaration.storage_spec().swap(storage_spec);
@@ -1558,19 +1558,19 @@ bool Parser::rIntegralDeclaration(
   switch(lex.LookAhead(0))
   {
   case ';':
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ')
               << "Parser::rIntegralDeclaration 4\n";
-    #endif
+#endif
 
     lex.get_token(tk);
     return true;
 
   case ':':        // bit field
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ')
               << "Parser::rIntegralDeclaration 5\n";
-    #endif
+#endif
 
     lex.get_token(tk);
 
@@ -1588,11 +1588,11 @@ bool Parser::rIntegralDeclaration(
     return true;
 
   default:
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ')
               << "Parser::rIntegralDeclaration 6 "
               << lex.LookAhead(0) << "\n";
-    #endif
+#endif
 
     if(!rDeclarators(declaration.declarators(), true))
       return false;
@@ -1608,27 +1608,27 @@ bool Parser::rIntegralDeclaration(
       declaration.declarators().front().type().subtype().make_nil();
     }
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ')
               << "Parser::rIntegralDeclaration 7\n";
-    #endif
+#endif
 
     if(lex.LookAhead(0)==';')
     {
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ')
                 << "Parser::rIntegralDeclaration 8 "
                 << declaration.pretty() << '\n';
-      #endif
+#endif
       lex.get_token(tk);
       return true;
     }
     else
     {
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ')
                 << "Parser::rIntegralDeclaration 9\n";
-      #endif
+#endif
 
       if(declaration.declarators().size()!=1)
         return false;
@@ -1636,10 +1636,10 @@ bool Parser::rIntegralDeclaration(
       if(!rFunctionBody(declaration.declarators().front()))
         return false;
 
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ')
                 << "Parser::rIntegralDeclaration 10\n";
-      #endif
+#endif
 
       return true;
     }
@@ -1648,10 +1648,10 @@ bool Parser::rIntegralDeclaration(
 
 bool Parser::rConstDeclaration(cpp_declarationt &declaration)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rConstDeclaration\n";
-  #endif
+#endif
 
   if(!rDeclarators(declaration.declarators(), false))
     return false;
@@ -1673,19 +1673,19 @@ bool Parser::rOtherDeclaration(
 {
   typet type_name;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rOtherDeclaration 1\n";
-  #endif
+#endif
 
   if(!rName(type_name))
     return false;
 
   merge_types(cv_q, type_name);
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rOtherDeclaration 2\n";
-  #endif
+#endif
 
   // added this one to do "typename inline foo();"
   if(member_spec.is_empty())
@@ -1697,18 +1697,18 @@ bool Parser::rOtherDeclaration(
     if(!optStorageSpec(storage_spec))
       return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rOtherDeclaration 3\n";
-  #endif
+#endif
 
   bool is_constructor = isConstructorDecl();
   bool is_operator = false;
 
   if(is_constructor)
   {
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rOtherDeclaration 4\n";
-    #endif
+#endif
 
     assert(!type_name.get_sub().empty());
 
@@ -1724,9 +1724,9 @@ bool Parser::rOtherDeclaration(
 
   if(is_operator && is_constructor)
   {
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rOtherDeclaration 5\n";
-    #endif
+#endif
 
     // it's a conversion operator
     typet type = type_name;
@@ -1744,9 +1744,9 @@ bool Parser::rOtherDeclaration(
   }
   else if(cv_q.is_nil() && is_constructor)
   {
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rOtherDeclaration 6\n";
-    #endif
+#endif
 
     assert(!type_name.get_sub().empty());
 
@@ -1764,9 +1764,9 @@ bool Parser::rOtherDeclaration(
         constructor_declarator, type_name, trailing_return_type))
       return false;
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rOtherDeclaration 7\n";
-    #endif
+#endif
 
     // type_name above is the name declarator, not the return type
     if(storage_spec.is_auto())
@@ -1778,9 +1778,9 @@ bool Parser::rOtherDeclaration(
   }
   else if(!member_spec.is_empty() && lex.LookAhead(0)==';')
   {
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rOtherDeclaration 8\n";
-    #endif
+#endif
 
     // FRIEND name ';'
     // if(Ptree::Length(member_spec)==1 && member_spec->Car()->What()==FRIEND)
@@ -1796,9 +1796,9 @@ bool Parser::rOtherDeclaration(
   }
   else
   {
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rOtherDeclaration 9\n";
-    #endif
+#endif
 
     if(!optCvQualify(cv_q))
       return false;
@@ -1813,24 +1813,24 @@ bool Parser::rOtherDeclaration(
   declaration.storage_spec().swap(storage_spec);
   declaration.member_spec().swap(member_spec);
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rOtherDeclaration 10\n";
-  #endif
+#endif
 
   if(lex.LookAhead(0)==';')
   {
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rOtherDeclaration 11\n";
-    #endif
+#endif
 
     cpp_tokent tk;
     lex.get_token(tk);
   }
   else
   {
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rOtherDeclaration 12\n";
-    #endif
+#endif
 
     if(declaration.declarators().size()!=1)
       return false;
@@ -1851,11 +1851,11 @@ bool Parser::rOtherDeclaration(
 */
 bool Parser::isConstructorDecl()
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::isConstructorDecl "
             << lex.LookAhead(0) << "  "<< lex.LookAhead(1) << "\n";
-  #endif
+#endif
 
   if(lex.LookAhead(0)!='(')
     return false;
@@ -2157,11 +2157,11 @@ bool Parser::optAlignas(typet &cv)
 
 bool Parser::rAttribute(typet &t)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rAttribute "
             << lex.LookAhead(0);
-  #endif
+#endif
   cpp_tokent tk;
   lex.get_token(tk);
 
@@ -2402,11 +2402,11 @@ bool Parser::optAttribute(typet &t)
 */
 bool Parser::optIntegralTypeOrClassSpec(typet &p)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ')
             << "Parser::optIntegralTypeOrClassSpec 0\n";
-  #endif // DEBUG
+#endif // DEBUG
 
   // This makes no sense, but is used in Visual Studio header files.
   if(lex.LookAhead(0)==TOK_TYPENAME)
@@ -2424,10 +2424,10 @@ bool Parser::optIntegralTypeOrClassSpec(typet &p)
   {
     t=lex.LookAhead(0);
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ')
               << "Parser::optIntegralTypeOrClassSpec 1\n";
-    #endif // DEBUG
+#endif // DEBUG
 
     irep_idt type_id;
 
@@ -2477,18 +2477,18 @@ bool Parser::optIntegralTypeOrClassSpec(typet &p)
       break;
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ')
             << "Parser::optIntegralTypeOrClassSpec 2\n";
-  #endif // DEBUG
+#endif // DEBUG
 
   if(is_integral)
     return true;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ')
             << "Parser::optIntegralTypeOrClassSpec 3\n";
-  #endif // DEBUG
+#endif // DEBUG
 
   if(t==TOK_CLASS || t==TOK_STRUCT || t==TOK_UNION || t==TOK_INTERFACE)
     return rClassSpec(p);
@@ -2496,18 +2496,18 @@ bool Parser::optIntegralTypeOrClassSpec(typet &p)
     return rEnumSpec(p);
   else if(t==TOK_TYPEOF)
   {
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ')
               << "Parser::optIntegralTypeOrClassSpec 4\n";
-    #endif // DEBUG
+#endif // DEBUG
 
     cpp_tokent typeof_tk;
     lex.get_token(typeof_tk);
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ')
               << "Parser::optIntegralTypeOrClassSpec 5\n";
-    #endif // DEBUG
+#endif // DEBUG
 
     p=typet(ID_typeof);
     set_location(p, typeof_tk);
@@ -2534,27 +2534,27 @@ bool Parser::optIntegralTypeOrClassSpec(typet &p)
       lex.Restore(pos);
     }
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ')
               << "Parser::optIntegralTypeOrClassSpec 6\n";
-    #endif // DEBUG
+#endif // DEBUG
 
     exprt expr;
     if(!rCommaExpression(expr))
       return false;
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ')
               << "Parser::optIntegralTypeOrClassSpec 7\n";
-    #endif // DEBUG
+#endif // DEBUG
 
     if(lex.get_token(tk)!=')')
       return false;
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ')
               << "Parser::optIntegralTypeOrClassSpec 8\n";
-    #endif // DEBUG
+#endif // DEBUG
 
     p.add(ID_expr_arg).swap(expr);
 
@@ -2630,10 +2630,10 @@ bool Parser::rConstructorDecl(
   typet &type_name,
   typet &trailing_return_type)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rConstructorDecl 0\n";
-  #endif
+#endif
 
   trailing_return_type.make_nil();
 
@@ -2645,9 +2645,9 @@ bool Parser::rConstructorDecl(
   if(lex.get_token(op)!='(')
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rConstructorDecl 1\n";
-  #endif
+#endif
 
   irept &parameters=constructor.type().add(ID_parameters);
 
@@ -2658,9 +2658,9 @@ bool Parser::rConstructorDecl(
   cpp_tokent cp;
   lex.get_token(cp);
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rConstructorDecl 2\n";
-  #endif
+#endif
 
   typet &cv=static_cast<typet &>(constructor.add(ID_method_qualifier));
   cv.make_nil();
@@ -2670,9 +2670,9 @@ bool Parser::rConstructorDecl(
 
   if(lex.LookAhead(0)==TOK_ARROW)
   {
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rConstructorDecl 3\n";
-    #endif
+#endif
 
     // C++11 trailing return type
     cpp_tokent arrow;
@@ -2682,9 +2682,9 @@ bool Parser::rConstructorDecl(
       return false;
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rConstructorDecl 4\n";
-  #endif
+#endif
 
   if(lex.LookAhead(0)==':')
   {
@@ -2696,9 +2696,9 @@ bool Parser::rConstructorDecl(
       return false;
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rConstructorDecl 5\n";
-  #endif
+#endif
 
   if(lex.LookAhead(0)=='=')
   {
@@ -3002,10 +3002,10 @@ bool Parser::rDeclarator(
 {
   int t;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rDeclarator2 1\n";
-  #endif
+#endif
 
   // we can have one or more declarator qualifiers
   if(!rDeclaratorQualifier())
@@ -3025,17 +3025,17 @@ bool Parser::rDeclarator(
   if(!rDeclaratorQualifier())
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rDeclarator2 2\n";
-  #endif
+#endif
 
   t=lex.LookAhead(0);
 
   if(t=='(')
   {
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rDeclarator2 3\n";
-    #endif
+#endif
 
     cpp_tokent op;
     lex.get_token(op);
@@ -3044,9 +3044,9 @@ bool Parser::rDeclarator(
     if(!rDeclarator(declarator2, kind, true, false))
       return false;
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rDeclarator2 4\n";
-    #endif
+#endif
 
     cpp_tokent cp;
 
@@ -3063,9 +3063,9 @@ bool Parser::rDeclarator(
       }
     }
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rDeclarator2 5\n";
-    #endif
+#endif
 
     d_inner.swap(declarator2.type());
     name.swap(declarator2.name());
@@ -3073,18 +3073,18 @@ bool Parser::rDeclarator(
   else if(kind!=kCastDeclarator &&
           (kind==kDeclarator || t==TOK_IDENTIFIER || t==TOK_SCOPE))
   {
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rDeclarator2 6\n";
-    #endif
+#endif
 
     // if this is an argument declarator, "int (*)()" is valid.
     if(!rName(name))
       return false;
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rDeclarator2 7\n";
-  #endif
+#endif
 
   exprt init_args(static_cast<const exprt &>(get_nil_irep()));
   // const...
@@ -3095,9 +3095,9 @@ bool Parser::rDeclarator(
     t=lex.LookAhead(0);
     if(t=='(') // function
     {
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rDeclarator2 8\n";
-      #endif
+#endif
 
       cpp_tokent op, cp;
       exprt args;
@@ -3132,18 +3132,18 @@ bool Parser::rDeclarator(
         // loop should end here
       }
 
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rDeclarator2 9\n";
-      #endif
+#endif
 
       irept throw_decl;
       optThrowDecl(throw_decl); // ignore in this version
 
       if(lex.LookAhead(0)==TOK_ARROW)
       {
-        #ifdef DEBUG
+#ifdef DEBUG
         std::cout << std::string(__indent, ' ') << "Parser::rDeclarator2 10\n";
-        #endif
+#endif
 
         // C++11 trailing return type, but we already have
         // a return type. We should report this as an error.
@@ -3162,9 +3162,9 @@ bool Parser::rDeclarator(
 
       if(lex.LookAhead(0)==':')
       {
-        #ifdef DEBUG
+#ifdef DEBUG
         std::cout << std::string(__indent, ' ') << "Parser::rDeclarator2 11\n";
-        #endif
+#endif
 
         irept mi;
         if(rMemberInitializers(mi))
@@ -3180,9 +3180,9 @@ bool Parser::rDeclarator(
     }
     else if(t=='[')         // array
     {
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rDeclarator2 12\n";
-      #endif
+#endif
 
       cpp_tokent ob, cb;
       exprt expr;
@@ -3219,9 +3219,9 @@ bool Parser::rDeclarator(
 
   optCvQualify(d_outer);
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rDeclarator2 13\n";
-  #endif
+#endif
 
   declarator=cpp_declaratort();
 
@@ -3244,10 +3244,10 @@ bool Parser::rDeclarator(
 */
 bool Parser::optPtrOperator(typet &ptrs)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::optPtrOperator 1\n";
-  #endif // DEBUG
+#endif // DEBUG
 
   std::list<typet> t_list;
 
@@ -3255,10 +3255,10 @@ bool Parser::optPtrOperator(typet &ptrs)
   {
     int t=lex.LookAhead(0);
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::optPtrOperator 2 "
               << t << "\n";
-    #endif
+#endif
 
     if(t=='*')
     {
@@ -3396,19 +3396,19 @@ bool Parser::rMemberInitializers(irept &init)
 */
 bool Parser::rMemberInit(exprt &init)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rMemberInit 1\n";
-  #endif
+#endif
 
   irept name;
 
   if(!rName(name))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rMemberInit 2\n";
-  #endif
+#endif
 
   init=codet(ID_member_initializer);
   init.add(ID_member).swap(name);
@@ -3420,9 +3420,9 @@ bool Parser::rMemberInit(exprt &init)
   if(tk1.kind=='{' ||
      (tk1.kind=='(' && lex.LookAhead(0)=='{'))
   {
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rMemberInit 3\n";
-    #endif
+#endif
     exprt exp;
     if(!rInitializeExpr(exp))
       return false;
@@ -3439,9 +3439,9 @@ bool Parser::rMemberInit(exprt &init)
     if(tk1.kind!='(')
       return false;
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rMemberInit 4\n";
-    #endif
+#endif
 
     exprt args;
 
@@ -3478,10 +3478,10 @@ bool Parser::rMemberInit(exprt &init)
 */
 bool Parser::rName(irept &name)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rName 0\n";
-  #endif
+#endif
 
   name=cpp_namet();
   irept::subt &components=name.get_sub();
@@ -3499,25 +3499,25 @@ bool Parser::rName(irept &name)
     set_location(name, tk);
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rName 1\n";
-  #endif
+#endif
 
   for(;;)
   {
     cpp_tokent tk;
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rName 2 "
               << lex.LookAhead(0) << "\n";
-    #endif
+#endif
 
     switch(lex.LookAhead(0))
     {
     case TOK_TEMPLATE:
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rName 3\n";
-      #endif
+#endif
       lex.get_token(tk);
       // Skip template token, next will be identifier
       if(lex.LookAhead(0)!=TOK_IDENTIFIER)
@@ -3525,9 +3525,9 @@ bool Parser::rName(irept &name)
       break;
 
     case '<':
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rName 4\n";
-      #endif
+#endif
       {
         irept args;
         if(!rTemplateArgs(args))
@@ -3543,9 +3543,9 @@ bool Parser::rName(irept &name)
       break;
 
     case TOK_IDENTIFIER:
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rName 5\n";
-      #endif
+#endif
       lex.get_token(tk);
       components.push_back(cpp_namet::namet(tk.data.get(ID_C_base_name)));
       set_location(components.back(), tk);
@@ -3559,18 +3559,18 @@ bool Parser::rName(irept &name)
       break;
 
     case TOK_SCOPE:
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rName 6\n";
-      #endif
+#endif
       lex.get_token(tk);
       components.push_back(irept("::"));
       set_location(components.back(), tk);
       break;
 
     case '~':
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rName 7\n";
-      #endif
+#endif
       lex.get_token(tk);
 
       // identifier must be next
@@ -3582,9 +3582,9 @@ bool Parser::rName(irept &name)
       break;
 
     case TOK_OPERATOR:
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rName 8\n";
-      #endif
+#endif
       lex.get_token(tk);
       {
         components.push_back(irept(ID_operator));
@@ -3765,10 +3765,10 @@ bool Parser::rCastOperatorName(irept &name)
 */
 bool Parser::rPtrToMember(irept &ptr_to_mem)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rPtrToMember 0\n";
-  #endif
+#endif
 
   typet ptm(ID_frontend_pointer); // width gets set during conversion
   irept &name = ptm.add(ID_to_member);
@@ -3832,10 +3832,9 @@ bool Parser::rPtrToMember(irept &ptr_to_mem)
         lex.get_token(tk);
         ptr_to_mem.swap(ptm);
 
-
-        #ifdef DEBUG
+#ifdef DEBUG
         std::cout << std::string(__indent, ' ') << "Parser::rPtrToMember 1\n";
-        #endif
+#endif
 
         return true;
       }
@@ -3863,10 +3862,10 @@ bool Parser::rPtrToMember(irept &ptr_to_mem)
 */
 bool Parser::rTemplateArgs(irept &template_args)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rTemplateArgs 0\n";
-  #endif
+#endif
 
   cpp_tokent tk1;
 
@@ -3875,9 +3874,9 @@ bool Parser::rTemplateArgs(irept &template_args)
 
   set_location(template_args, tk1);
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') <<  "Parser::rTemplateArgs 1\n";
-  #endif
+#endif
 
   // in case of Foo<>
   if(lex.LookAhead(0)=='>')
@@ -3887,18 +3886,18 @@ bool Parser::rTemplateArgs(irept &template_args)
     return true;
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') <<  "Parser::rTemplateArgs 2\n";
-  #endif
+#endif
 
   for(;;)
   {
     exprt exp;
     cpp_token_buffert::post pos=lex.Save();
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') <<  "Parser::rTemplateArgs 3\n";
-    #endif
+#endif
 
     typet a;
 
@@ -3911,9 +3910,9 @@ bool Parser::rTemplateArgs(irept &template_args)
           lex.LookAhead(1)==TOK_SHIFTRIGHT)))
         )
     {
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') <<  "Parser::rTemplateArgs 4\n";
-      #endif
+#endif
 
       // ok
       exp=exprt(ID_type);
@@ -3925,9 +3924,9 @@ bool Parser::rTemplateArgs(irept &template_args)
       exprt tmp;
       if(rConditionalExpr(tmp, true))
         exp.id(ID_ambiguous);
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') <<  "Parser::rTemplateArgs 4.1\n";
-      #endif
+#endif
       lex.Restore(pos);
       rTypeNameOrFunctionType(a);
 
@@ -3937,16 +3936,16 @@ bool Parser::rTemplateArgs(irept &template_args)
 
         // TODO
       }
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') <<  "Parser::rTemplateArgs 4.2\n";
-      #endif
+#endif
     }
     else
     {
       // parsing failed, try expression
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') <<  "Parser::rTemplateArgs 5\n";
-      #endif
+#endif
 
       lex.Restore(pos);
 
@@ -3962,9 +3961,9 @@ bool Parser::rTemplateArgs(irept &template_args)
       }
     }
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') <<  "Parser::rTemplateArgs 6\n";
-    #endif
+#endif
 
     template_args.get_sub().push_back(irept(irep_idt()));
     template_args.get_sub().back().swap(exp);
@@ -4274,10 +4273,10 @@ bool Parser::rFunctionArguments(exprt &args)
 */
 bool Parser::rEnumSpec(typet &spec)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rEnumSpec 1\n";
-  #endif
+#endif
 
   cpp_tokent tk;
 
@@ -4309,9 +4308,9 @@ bool Parser::rEnumSpec(typet &spec)
     spec.add(ID_tag).swap(name);
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rEnumSpec 2\n";
-  #endif
+#endif
 
   // C++11 enums have an optional underlying type
   if(lex.LookAhead(0)==':')
@@ -4321,9 +4320,9 @@ bool Parser::rEnumSpec(typet &spec)
       return false;
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rEnumSpec 3\n";
-  #endif
+#endif
 
   if(lex.LookAhead(0)!='{')
     return true; // ok, no body
@@ -4344,9 +4343,9 @@ bool Parser::rEnumSpec(typet &spec)
   if(lex.get_token(tk)!='}')
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rEnumSpec 4\n";
-  #endif
+#endif
 
   return true;
 }
@@ -4415,19 +4414,19 @@ bool Parser::rClassSpec(typet &spec)
 {
   cpp_tokent tk;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rClassSpec 1\n";
-  #endif
+#endif
 
   int t=lex.get_token(tk);
   if(t!=TOK_CLASS && t!=TOK_STRUCT &&
      t!=TOK_UNION && t!=TOK_INTERFACE)
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rClassSpec 2\n";
-  #endif
+#endif
 
   if(t==TOK_CLASS)
   {
@@ -4448,16 +4447,16 @@ bool Parser::rClassSpec(typet &spec)
 
   set_location(spec, tk);
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rClassSpec 3\n";
-  #endif
+#endif
 
   if(lex.LookAhead(0)=='{')
   {
     // no tag
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rClassSpec 4\n";
-    #endif
+#endif
   }
   else
   {
@@ -4479,9 +4478,9 @@ bool Parser::rClassSpec(typet &spec)
 
     spec.add(ID_tag).swap(name);
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rClassSpec 5\n";
-    #endif
+#endif
 
     t=lex.LookAhead(0);
 
@@ -4499,9 +4498,9 @@ bool Parser::rClassSpec(typet &spec)
     }
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rClassSpec 6\n";
-  #endif
+#endif
 
   save_scopet saved_scope(current_scope);
   make_sub_scope(spec.find(ID_tag), new_scopet::kindt::TAG);
@@ -4511,9 +4510,9 @@ bool Parser::rClassSpec(typet &spec)
   if(!rClassBody(body))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rClassSpec 7\n";
-  #endif
+#endif
 
   ((exprt&)spec.add(ID_body)).operands().swap(body.operands());
   return true;
@@ -4601,10 +4600,10 @@ bool Parser::rClassBody(exprt &body)
 {
   cpp_tokent tk;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rClassBody 0\n";
-  #endif
+#endif
 
   if(lex.get_token(tk)!='{')
     return false;
@@ -4627,10 +4626,10 @@ bool Parser::rClassBody(exprt &body)
       // body=Ptree::List(ob, nil, new Leaf(tk));
       return true;        // error recovery
     }
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rClassBody "
               << member.pretty() << '\n';
-    #endif
+#endif
 
     members.add_to_operands(
       std::move(static_cast<exprt &>(static_cast<irept &>(member))));
@@ -4663,11 +4662,11 @@ bool Parser::rClassMember(cpp_itemt &member)
 
   int t=lex.LookAhead(0);
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rClassMember 0 " << t
             << '\n';
-  #endif // DEBUG
+#endif // DEBUG
 
   if(t==TOK_PUBLIC || t==TOK_PROTECTED || t==TOK_PRIVATE)
   {
@@ -4752,17 +4751,17 @@ bool Parser::rAccessDecl(cpp_declarationt &mem)
 */
 bool Parser::rCommaExpression(exprt &exp)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rCommaExpression 0\n";
-  #endif
+#endif
 
   if(!rExpression(exp, false))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rCommaExpression 1\n";
-  #endif
+#endif
 
   while(lex.LookAhead(0)==',')
   {
@@ -4782,9 +4781,9 @@ bool Parser::rCommaExpression(exprt &exp)
     set_location(exp, tk);
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rCommaExpression 2\n";
-  #endif
+#endif
 
   return true;
 }
@@ -4797,17 +4796,17 @@ bool Parser::rExpression(exprt &exp, bool template_args)
 {
   cpp_tokent tk;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rExpression 0\n";
-  #endif
+#endif
 
   if(!rConditionalExpr(exp, template_args))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rExpression 1\n";
-  #endif
+#endif
 
   int t=lex.LookAhead(0);
 
@@ -4819,17 +4818,17 @@ bool Parser::rExpression(exprt &exp, bool template_args)
   {
     lex.get_token(tk);
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rExpression 2\n";
-    #endif
+#endif
 
     exprt right;
     if(!rExpression(right, template_args))
       return false;
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rExpression 3\n";
-    #endif
+#endif
 
     exprt left;
     left.swap(exp);
@@ -4863,9 +4862,9 @@ bool Parser::rExpression(exprt &exp, bool template_args)
     set_location(exp, tk);
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rExpression 4\n";
-  #endif
+#endif
 
   return true;
 }
@@ -4876,17 +4875,17 @@ bool Parser::rExpression(exprt &exp, bool template_args)
 */
 bool Parser::rConditionalExpr(exprt &exp, bool template_args)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rConditionalExpr 0\n";
-  #endif
+#endif
 
   if(!rLogicalOrExpr(exp, template_args))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rConditionalExpr 1\n";
-  #endif
+#endif
 
   if(lex.LookAhead(0)=='?')
   {
@@ -4897,9 +4896,9 @@ bool Parser::rConditionalExpr(exprt &exp, bool template_args)
     if(!rCommaExpression(then))
       return false;
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rConditionalExpr 2\n";
-    #endif
+#endif
 
     if(lex.get_token(tk2)!=':')
       return false;
@@ -4925,17 +4924,17 @@ bool Parser::rConditionalExpr(exprt &exp, bool template_args)
 */
 bool Parser::rLogicalOrExpr(exprt &exp, bool template_args)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rLogicalOrExpr 0\n";
-  #endif
+#endif
 
   if(!rLogicalAndExpr(exp, template_args))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rLogicalOrExpr 1\n";
-  #endif
+#endif
 
   while(lex.LookAhead(0)==TOK_OROR)
   {
@@ -4964,17 +4963,17 @@ bool Parser::rLogicalOrExpr(exprt &exp, bool template_args)
 */
 bool Parser::rLogicalAndExpr(exprt &exp, bool template_args)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rLogicalAndExpr 1\n";
-  #endif
+#endif
 
   if(!rInclusiveOrExpr(exp, template_args))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rLogicalAndExpr 1\n";
-  #endif
+#endif
 
   while(lex.LookAhead(0)==TOK_ANDAND)
   {
@@ -5003,17 +5002,17 @@ bool Parser::rLogicalAndExpr(exprt &exp, bool template_args)
 */
 bool Parser::rInclusiveOrExpr(exprt &exp, bool template_args)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rInclusiveOrExpr 0\n";
-  #endif
+#endif
 
   if(!rExclusiveOrExpr(exp, template_args))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rInclusiveOrExpr 1\n";
-  #endif
+#endif
 
   while(lex.LookAhead(0)=='|')
   {
@@ -5042,17 +5041,17 @@ bool Parser::rInclusiveOrExpr(exprt &exp, bool template_args)
 */
 bool Parser::rExclusiveOrExpr(exprt &exp, bool template_args)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rExclusiveOrExpr 0\n";
-  #endif
+#endif
 
   if(!rAndExpr(exp, template_args))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rExclusiveOrExpr 1\n";
-  #endif
+#endif
 
   while(lex.LookAhead(0)=='^')
   {
@@ -5081,17 +5080,17 @@ bool Parser::rExclusiveOrExpr(exprt &exp, bool template_args)
 */
 bool Parser::rAndExpr(exprt &exp, bool template_args)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rAndExpr 0\n";
-  #endif
+#endif
 
   if(!rEqualityExpr(exp, template_args))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rAndExpr 1\n";
-  #endif
+#endif
 
   while(lex.LookAhead(0)=='&')
   {
@@ -5120,17 +5119,17 @@ bool Parser::rAndExpr(exprt &exp, bool template_args)
 */
 bool Parser::rEqualityExpr(exprt &exp, bool template_args)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rEqualityExpr 0\n";
-  #endif
+#endif
 
   if(!rRelationalExpr(exp, template_args))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rEqualityExpr 1\n";
-  #endif
+#endif
 
   while(lex.LookAhead(0)==TOK_EQ ||
         lex.LookAhead(0)==TOK_NE)
@@ -5160,17 +5159,17 @@ bool Parser::rEqualityExpr(exprt &exp, bool template_args)
 */
 bool Parser::rRelationalExpr(exprt &exp, bool template_args)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rRelationalExpr 0\n";
-  #endif
+#endif
 
   if(!rShiftExpr(exp, template_args))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rRelationalExpr 1\n";
-  #endif
+#endif
 
   int t;
 
@@ -5212,17 +5211,17 @@ bool Parser::rRelationalExpr(exprt &exp, bool template_args)
 */
 bool Parser::rShiftExpr(exprt &exp, bool template_args)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rShiftExpr 0\n";
-  #endif
+#endif
 
   if(!rAdditiveExpr(exp))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rShiftExpr 1\n";
-  #endif
+#endif
 
   while(lex.LookAhead(0)==TOK_SHIFTLEFT ||
         (lex.LookAhead(0)==TOK_SHIFTRIGHT && !template_args))
@@ -5252,17 +5251,17 @@ bool Parser::rShiftExpr(exprt &exp, bool template_args)
 */
 bool Parser::rAdditiveExpr(exprt &exp)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rAdditiveExpr 0\n";
-  #endif
+#endif
 
   if(!rMultiplyExpr(exp))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rAdditiveExpr 1\n";
-  #endif
+#endif
 
   int t;
   while(t=lex.LookAhead(0), (t=='+' || t=='-'))
@@ -5299,17 +5298,17 @@ bool Parser::rAdditiveExpr(exprt &exp)
 */
 bool Parser::rMultiplyExpr(exprt &exp)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rMultiplyExpr 0\n";
-  #endif
+#endif
 
   if(!rPmExpr(exp))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rMultiplyExpr 1\n";
-  #endif
+#endif
 
   int t;
   while(t=lex.LookAhead(0), (t=='*' || t=='/' || t=='%'))
@@ -5337,9 +5336,9 @@ bool Parser::rMultiplyExpr(exprt &exp)
     set_location(exp, tk);
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rMultiplyExpr 2\n";
-  #endif
+#endif
 
   return true;
 }
@@ -5352,17 +5351,17 @@ bool Parser::rMultiplyExpr(exprt &exp)
 */
 bool Parser::rPmExpr(exprt &exp)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rPmExpr 0\n";
-  #endif
+#endif
 
   if(!rCastExpr(exp))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rPmExpr 1\n";
-  #endif
+#endif
 
   while(lex.LookAhead(0)==TOK_DOTPM ||
         lex.LookAhead(0)==TOK_ARROWPM)
@@ -5382,9 +5381,9 @@ bool Parser::rPmExpr(exprt &exp)
     set_location(exp, tk);
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rPmExpr 2\n";
-  #endif
+#endif
 
   return true;
 }
@@ -5396,10 +5395,10 @@ bool Parser::rPmExpr(exprt &exp)
 */
 bool Parser::rCastExpr(exprt &exp)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rCastExpr 0\n";
-  #endif
+#endif
 
   if(lex.LookAhead(0)!='(')
     return rUnaryExpr(exp);
@@ -5413,9 +5412,9 @@ bool Parser::rCastExpr(exprt &exp)
     cpp_tokent tk1, tk2;
     typet tname;
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rCastExpr 1\n";
-    #endif
+#endif
 
     cpp_token_buffert::post pos=lex.Save();
     lex.get_token(tk1);
@@ -5456,19 +5455,19 @@ bool Parser::rCastExpr(exprt &exp)
 */
 bool Parser::rTypeName(typet &tname)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rTypeName 0\n";
-  #endif
+#endif
 
   typet type_name;
 
   if(!rTypeSpecifier(type_name, true))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rTypeName 1\n";
-  #endif
+#endif
 
   cpp_declaratort declarator;
 
@@ -5486,9 +5485,9 @@ bool Parser::rTypeName(typet &tname)
   // make type_name subtype of arg
   make_subtype(type_name, tname);
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rTypeName 2\n";
-  #endif
+#endif
 
   return true;
 }
@@ -5500,20 +5499,20 @@ bool Parser::rTypeName(typet &tname)
 */
 bool Parser::rTypeNameOrFunctionType(typet &tname)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ')
             << "Parser::rTypeNameOrFunctionType 0\n";
-  #endif
+#endif
 
   cpp_token_buffert::post pos=lex.Save();
 
   if(rTypeName(tname) && lex.LookAhead(0)!='(')
   {
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ')
               << "Parser::rTypeNameOrFunctionType 1\n";
-    #endif
+#endif
 
     if(!optPtrOperator(tname))
       return false;
@@ -5523,19 +5522,19 @@ bool Parser::rTypeNameOrFunctionType(typet &tname)
 
   lex.Restore(pos);
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ')
             << "Parser::rTypeNameOrFunctionType 2\n";
-  #endif
+#endif
 
   typet return_type;
   if(!rCastOperatorName(return_type))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ')
             << "Parser::rTypeNameOrFunctionType 3\n";
-  #endif
+#endif
 
   if(lex.LookAhead(0)!='(')
   {
@@ -5547,10 +5546,10 @@ bool Parser::rTypeNameOrFunctionType(typet &tname)
     return true;
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ')
             << "Parser::rTypeNameOrFunctionType 4\n";
-  #endif
+#endif
 
   code_typet type({}, return_type);
   cpp_tokent op;
@@ -5596,10 +5595,10 @@ bool Parser::rTypeNameOrFunctionType(typet &tname)
   {
     // function type parameters
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ')
               << "Parser::rTypeNameOrFunctionType 5\n";
-    #endif
+#endif
 
     int t=lex.LookAhead(0);
     if(t==')')
@@ -5639,10 +5638,10 @@ bool Parser::rTypeNameOrFunctionType(typet &tname)
     }
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ')
             << "Parser::rTypeNameOrFunctionType 6\n";
-  #endif
+#endif
 
   cpp_tokent cp;
   lex.get_token(cp);
@@ -5651,10 +5650,10 @@ bool Parser::rTypeNameOrFunctionType(typet &tname)
   if(!optCvQualify(type))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ')
             << "Parser::rTypeNameOrFunctionType 7\n";
-  #endif
+#endif
 
   // not sure where this one belongs
   if(!optPtrOperator(type))
@@ -5662,10 +5661,10 @@ bool Parser::rTypeNameOrFunctionType(typet &tname)
 
   tname.swap(type);
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ')
             << "Parser::rTypeNameOrFunctionType 8\n";
-  #endif
+#endif
 
   return true;
 }
@@ -5684,10 +5683,10 @@ bool Parser::rUnaryExpr(exprt &exp)
 {
   int t=lex.LookAhead(0);
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rUnaryExpr 0\n";
-  #endif
+#endif
 
   if(t=='*' || t=='&' || t=='+' ||
      t=='-' || t=='!' || t=='~' ||
@@ -5696,17 +5695,17 @@ bool Parser::rUnaryExpr(exprt &exp)
     cpp_tokent tk;
     lex.get_token(tk);
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rUnaryExpr 1\n";
-    #endif
+#endif
 
     exprt right;
     if(!rCastExpr(right))
       return false;
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rUnaryExpr 2\n";
-    #endif
+#endif
 
     switch(t)
     {
@@ -5791,10 +5790,10 @@ bool Parser::rThrowExpr(exprt &exp)
 {
   cpp_tokent tk;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rThrowExpr 0\n";
-  #endif
+#endif
 
   if(lex.get_token(tk)!=TOK_THROW)
     return false;
@@ -5830,10 +5829,10 @@ bool Parser::rTypeidExpr(exprt &exp)
 {
   cpp_tokent tk;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rTypeidExpr 0\n";
-  #endif
+#endif
 
   if(lex.get_token(tk)!=TOK_TYPEID)
     return false;
@@ -5896,10 +5895,10 @@ bool Parser::rSizeofExpr(exprt &exp)
 {
   cpp_tokent tk;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rSizeofExpr 0\n";
-  #endif
+#endif
 
   if(lex.get_token(tk)!=TOK_SIZEOF)
     return false;
@@ -5996,10 +5995,10 @@ bool Parser::rNoexceptExpr(exprt &exp)
 {
   cpp_tokent tk;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rNoexceptExpr 0\n";
-  #endif
+#endif
 
   if(lex.get_token(tk)!=TOK_NOEXCEPT)
     return false;
@@ -6047,10 +6046,10 @@ bool Parser::rAllocateExpr(exprt &exp)
   cpp_tokent tk;
   irept head=get_nil_irep();
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rAllocateExpr 0\n";
-  #endif
+#endif
 
   int t=lex.LookAhead(0);
   if(t==TOK_SCOPE)
@@ -6059,15 +6058,15 @@ bool Parser::rAllocateExpr(exprt &exp)
     // TODO one can put 'new'/'delete' into a namespace!
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rAllocateExpr 1\n";
-  #endif
+#endif
 
   t=lex.get_token(tk);
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rAllocateExpr 2\n";
-  #endif
+#endif
 
   if(t==TOK_DELETE)
   {
@@ -6100,9 +6099,9 @@ bool Parser::rAllocateExpr(exprt &exp)
   }
   else if(t==TOK_NEW)
   {
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rAllocateExpr 3\n";
-    #endif
+#endif
 
     exp=exprt(ID_side_effect);
     exp.set(ID_statement, ID_cpp_new);
@@ -6113,9 +6112,9 @@ bool Parser::rAllocateExpr(exprt &exp)
     if(!rAllocateType(arguments, exp.type(), initializer))
       return false;
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rAllocateExpr 4\n";
-    #endif
+#endif
 
     exp.add(ID_initializer).swap(initializer);
     exp.operands().swap(arguments.operands());
@@ -6318,17 +6317,17 @@ bool Parser::rAllocateInitializer(exprt &init)
 */
 bool Parser::rPostfixExpr(exprt &exp)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rPostfixExpr 0\n";
-  #endif
+#endif
 
   if(!rPrimaryExpr(exp))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rPostfixExpr 1\n";
-  #endif
+#endif
 
   exprt e;
   cpp_tokent cp, op;
@@ -6343,9 +6342,9 @@ bool Parser::rPostfixExpr(exprt &exp)
       if(!rCommaExpression(e))
         return false;
 
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rPostfixExpr 2\n";
-      #endif
+#endif
 
       if(lex.get_token(cp)!=']')
         return false;
@@ -6361,9 +6360,9 @@ bool Parser::rPostfixExpr(exprt &exp)
       break;
 
     case '(':
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rPostfixExpr 3\n";
-      #endif
+#endif
 
       lex.get_token(op);
       if(!rFunctionArguments(e))
@@ -6372,9 +6371,9 @@ bool Parser::rPostfixExpr(exprt &exp)
       if(lex.get_token(cp)!=')')
         return false;
 
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rPostfixExpr 4\n";
-      #endif
+#endif
 
       {
         side_effect_expr_function_callt fc;
@@ -6415,16 +6414,16 @@ bool Parser::rPostfixExpr(exprt &exp)
     case TOK_ARROW:
       t2=lex.get_token(op);
 
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rPostfixExpr 5\n";
-      #endif
+#endif
 
       if(!rVarName(e))
         return false;
 
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rPostfixExpr 6\n";
-      #endif
+#endif
 
       {
         exprt left;
@@ -6674,11 +6673,11 @@ bool Parser::rPrimaryExpr(exprt &exp)
 {
   cpp_tokent tk, tk2;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 0 "
             << lex.LookAhead(0) << ' ' << lex.current_token().text << '\n';
-  #endif
+#endif
 
   switch(lex.LookAhead(0))
   {
@@ -6688,45 +6687,45 @@ bool Parser::rPrimaryExpr(exprt &exp)
     lex.get_token(tk);
     exp.swap(tk.data);
     set_location(exp, tk);
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 1\n";
-    #endif
+#endif
     return true;
 
   case TOK_STRING:
     rString(tk);
     exp.swap(tk.data);
     set_location(exp, tk);
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 2\n";
-    #endif
+#endif
     return true;
 
   case TOK_THIS:
     lex.get_token(tk);
     exp=exprt("cpp-this");
     set_location(exp, tk);
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 3\n";
-    #endif
+#endif
     return true;
 
   case TOK_TRUE:
     lex.get_token(tk);
     exp = typecast_exprt(true_exprt(), c_bool_type());
     set_location(exp, tk);
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 4\n";
-    #endif
+#endif
     return true;
 
   case TOK_FALSE:
     lex.get_token(tk);
     exp = typecast_exprt(false_exprt(), c_bool_type());
     set_location(exp, tk);
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 5\n";
-    #endif
+#endif
     return true;
 
   case TOK_NULLPTR:
@@ -6734,15 +6733,15 @@ bool Parser::rPrimaryExpr(exprt &exp)
     // as an exception, we set the width of pointer
     exp=constant_exprt(ID_NULL, pointer_type(typet(ID_nullptr)));
     set_location(exp, tk);
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 6\n";
-    #endif
+#endif
     return true;
 
   case '(':
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 7\n";
-    #endif
+#endif
     lex.get_token(tk);
 
     if(lex.LookAhead(0)=='{') // GCC extension
@@ -6767,9 +6766,9 @@ bool Parser::rPrimaryExpr(exprt &exp)
       if(!rCommaExpression(exp2))
         return false;
 
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 8\n";
-      #endif
+#endif
 
       if(lex.get_token(tk2)!=')')
         return false;
@@ -6777,15 +6776,15 @@ bool Parser::rPrimaryExpr(exprt &exp)
       exp.swap(exp2);
     }
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 9\n";
-    #endif
+#endif
     return true;
 
   case '{': // C++11 initialisation expression
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 10\n";
-    #endif
+#endif
     return rInitializeExpr(exp);
 
   case TOK_TYPEID:
@@ -6793,39 +6792,39 @@ bool Parser::rPrimaryExpr(exprt &exp)
 
   case TOK_UNARY_TYPE_PREDICATE:
   case TOK_BINARY_TYPE_PREDICATE:
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 11\n";
-    #endif
+#endif
     return rTypePredicate(exp);
 
   case TOK_MSC_UUIDOF:
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 12\n";
-    #endif
+#endif
     return rMSCuuidof(exp);
 
   // not quite appropriate: these allow more general
   // token streams, not just expressions
   case TOK_MSC_IF_EXISTS:
   case TOK_MSC_IF_NOT_EXISTS:
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 13\n";
-    #endif
+#endif
     return rMSC_if_existsExpr(exp);
 
   default:
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 14\n";
-    #endif
+#endif
     {
       typet type;
 
       if(!optIntegralTypeOrClassSpec(type))
         return false;
 
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 15\n";
-      #endif
+#endif
 
       if(type.is_not_nil() && lex.LookAhead(0)==TOK_SCOPE)
       {
@@ -6836,9 +6835,9 @@ bool Parser::rPrimaryExpr(exprt &exp)
       }
       else if(type.is_not_nil())
       {
-        #ifdef DEBUG
+#ifdef DEBUG
         std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 16\n";
-        #endif
+#endif
         if(lex.LookAhead(0)=='{')
         {
           lex.LookAhead(0, tk);
@@ -6886,9 +6885,9 @@ bool Parser::rPrimaryExpr(exprt &exp)
         }
       }
     }
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 17\n";
-    #endif
+#endif
 
     return true;
   }
@@ -6906,10 +6905,10 @@ bool Parser::rPrimaryExpr(exprt &exp)
 */
 bool Parser::rVarName(exprt &name)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rVarName 0\n";
-  #endif
+#endif
 
   if(rVarNameCore(name))
     return true;
@@ -6919,10 +6918,10 @@ bool Parser::rVarName(exprt &name)
 
 bool Parser::rVarNameCore(exprt &name)
 {
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rVarNameCore 0\n";
-  #endif
+#endif
 
   name = cpp_namet().as_expr();
   irept::subt &components=name.get_sub();
@@ -6940,27 +6939,27 @@ bool Parser::rVarNameCore(exprt &name)
     set_location(name, tk);
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rVarNameCore 1\n";
-  #endif
+#endif
 
   for(;;)
   {
     cpp_tokent tk;
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rVarNameCore 1.1 "
               << lex.LookAhead(0)
               << '\n';
-    #endif
+#endif
 
     switch(lex.LookAhead(0))
     {
     case TOK_TEMPLATE:
       // this may be a template member function, for example
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rVarNameCore 2\n";
-      #endif
+#endif
       lex.get_token(tk);
       // Skip template token, next will be identifier
       if(lex.LookAhead(0)!=TOK_IDENTIFIER)
@@ -6968,9 +6967,9 @@ bool Parser::rVarNameCore(exprt &name)
       break;
 
     case TOK_IDENTIFIER:
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rVarNameCore 3\n";
-      #endif
+#endif
 
       lex.get_token(tk);
       components.push_back(cpp_namet::namet(tk.data.get(ID_C_base_name)));
@@ -6981,9 +6980,9 @@ bool Parser::rVarNameCore(exprt &name)
       {
         cpp_token_buffert::post pos=lex.Save();
 
-        #ifdef DEBUG
+#ifdef DEBUG
         std::cout << std::string(__indent, ' ') << "Parser::rVarNameCore 4\n";
-        #endif
+#endif
 
         irept args;
         if(!rTemplateArgs(args))
@@ -7001,9 +7000,9 @@ bool Parser::rVarNameCore(exprt &name)
       break;
 
     case TOK_SCOPE:
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rVarNameCore 5\n";
-      #endif
+#endif
 
       lex.get_token(tk);
       components.push_back(irept("::"));
@@ -7011,9 +7010,9 @@ bool Parser::rVarNameCore(exprt &name)
       break;
 
     case '~':
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rVarNameCore 6\n";
-      #endif
+#endif
 
       lex.get_token(tk);
 
@@ -7025,9 +7024,9 @@ bool Parser::rVarNameCore(exprt &name)
       break;
 
     case TOK_OPERATOR:
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rVarNameCore 7\n";
-      #endif
+#endif
 
       lex.get_token(tk);
 
@@ -7071,10 +7070,10 @@ bool Parser::maybeTemplateArgs()
   int i=0;
   int t=lex.LookAhead(i++);
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::maybeTemplateArgs 0\n";
-  #endif
+#endif
 
   if(t=='<')
   {
@@ -7094,17 +7093,17 @@ bool Parser::maybeTemplateArgs()
 
     while(n>0)
     {
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ')
                 << "Parser::maybeTemplateArgs 1\n";
-      #endif
+#endif
 
       int u=lex.LookAhead(i++);
 
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ')
                 << "Parser::maybeTemplateArgs 2\n";
-      #endif
+#endif
 
       if(u=='<')
         ++n;
@@ -7117,10 +7116,10 @@ bool Parser::maybeTemplateArgs()
         {
           int v=lex.LookAhead(i++);
 
-          #ifdef DEBUG
+#ifdef DEBUG
           std::cout << std::string(__indent, ' ')
                     << "Parser::maybeTemplateArgs 3\n";
-          #endif
+#endif
 
           if(v=='(')
             ++m;
@@ -7135,29 +7134,29 @@ bool Parser::maybeTemplateArgs()
       else if(u==TOK_SHIFTRIGHT && n>=2)
         n-=2;
 
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ')
                 << "Parser::maybeTemplateArgs 4\n";
-      #endif
+#endif
     }
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::maybeTemplateArgs 5\n";
-    #endif
+#endif
 
     t=lex.LookAhead(i);
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::maybeTemplateArgs 6\n";
-    #endif
+#endif
 
     return t==TOK_SCOPE || t=='(';
 #endif
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::maybeTemplateArgs 7\n";
-  #endif
+#endif
 
   return false;
 }
@@ -7219,17 +7218,17 @@ bool Parser::rCompoundStatement(codet &statement)
 {
   cpp_tokent ob, cb;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rCompoundStatement 1\n";
-  #endif
+#endif
 
   if(lex.get_token(ob)!='{')
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rCompoundStatement 2\n";
-  #endif
+#endif
 
   statement=code_blockt();
   set_location(statement, ob);
@@ -7283,11 +7282,11 @@ bool Parser::rStatement(codet &statement)
   cpp_tokent tk1, tk2, tk3;
   int k;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rStatement 0 "
             << lex.LookAhead(0) << "\n";
-  #endif
+#endif
 
   switch(k=lex.LookAhead(0))
   {
@@ -7338,9 +7337,9 @@ bool Parser::rStatement(codet &statement)
     return true;
 
   case TOK_RETURN:
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rStatement RETURN 0\n";
-    #endif
+#endif
 
     lex.get_token(tk1);
 
@@ -7349,28 +7348,28 @@ bool Parser::rStatement(codet &statement)
 
     if(lex.LookAhead(0)==';')
     {
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ')
                 << "Parser::rStatement RETURN 1\n";
-      #endif
+#endif
       lex.get_token(tk2);
     }
     else
     {
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ')
                 << "Parser::rStatement RETURN 2\n";
-      #endif
+#endif
 
       exprt exp;
 
       if(!rCommaExpression(exp))
         return false;
 
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ')
                 << "Parser::rStatement RETURN 3\n";
-      #endif
+#endif
 
       if(lex.get_token(tk2)!=';')
         return false;
@@ -7912,10 +7911,10 @@ bool Parser::rGCCAsmStatement(codet &statement)
 {
   cpp_tokent tk;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rGCCAsmStatement 1\n";
-  #endif // DEBUG
+#endif // DEBUG
 
   // asm [volatile] ("stuff" [ : ["=S" [(__res)], ... ]]) ;
 
@@ -7930,9 +7929,9 @@ bool Parser::rGCCAsmStatement(codet &statement)
   if(lex.LookAhead(0)==TOK_VOLATILE)
     lex.get_token(tk);
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rGCCAsmStatement 3\n";
-  #endif // DEBUG
+#endif // DEBUG
 
   if(lex.get_token(tk)!='(')
     return false;
@@ -7941,15 +7940,15 @@ bool Parser::rGCCAsmStatement(codet &statement)
 
   statement.op0()=tk.data;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rGCCAsmStatement 3\n";
-  #endif // DEBUG
+#endif // DEBUG
 
   while(lex.LookAhead(0)!=')')
   {
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rGCCAsmStatement 4\n";
-    #endif // DEBUG
+#endif // DEBUG
 
     // get ':'
     if(lex.get_token(tk)!=':')
@@ -7968,19 +7967,19 @@ bool Parser::rGCCAsmStatement(codet &statement)
         // get '('
         lex.get_token(tk);
 
-        #ifdef DEBUG
+#ifdef DEBUG
         std::cout << std::string(__indent, ' ')
                   << "Parser::rGCCAsmStatement 5\n";
-        #endif // DEBUG
+#endif // DEBUG
 
         exprt expr;
         if(!rCommaExpression(expr))
           return false;
 
-        #ifdef DEBUG
+#ifdef DEBUG
         std::cout << std::string(__indent, ' ')
                   << "Parser::rGCCAsmStatement 6\n";
-        #endif // DEBUG
+#endif // DEBUG
 
         if(lex.get_token(tk)!=')')
           return false;
@@ -7993,18 +7992,18 @@ bool Parser::rGCCAsmStatement(codet &statement)
     }
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rGCCAsmStatement 7\n";
-  #endif // DEBUG
+#endif // DEBUG
 
   if(lex.get_token(tk)!=')')
     return false;
   if(lex.get_token(tk)!=';')
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rGCCAsmStatement 8\n";
-  #endif // DEBUG
+#endif // DEBUG
 
   return true;
 }
@@ -8013,10 +8012,10 @@ bool Parser::rMSCAsmStatement(codet &statement)
 {
   cpp_tokent tk;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rMSCAsmStatement 1\n";
-  #endif // DEBUG
+#endif // DEBUG
 
   // asm "STUFF"
   // asm { "STUFF" }
@@ -8028,17 +8027,17 @@ bool Parser::rMSCAsmStatement(codet &statement)
   statement.set(ID_flavor, ID_msc);
   set_location(statement, tk);
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rMSCAsmStatement 2\n";
-  #endif // DEBUG
+#endif // DEBUG
 
   if(lex.LookAhead(0)=='{')
   {
     lex.get_token(tk); // eat the '{'
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rMSCAsmStatement 3\n";
-    #endif // DEBUG
+#endif // DEBUG
 
     if(lex.LookAhead(0)!=TOK_ASM_STRING)
       return true;
@@ -8049,15 +8048,15 @@ bool Parser::rMSCAsmStatement(codet &statement)
     if(lex.get_token(tk)!='}')
       return false;
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rMSCAsmStatement 4\n";
-    #endif // DEBUG
+#endif // DEBUG
   }
   else
   {
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rMSCAsmStatement 5\n";
-    #endif // DEBUG
+#endif // DEBUG
 
     if(lex.LookAhead(0)!=TOK_ASM_STRING)
       return true;
@@ -8065,14 +8064,14 @@ bool Parser::rMSCAsmStatement(codet &statement)
     lex.get_token(tk);
     statement.add_to_operands(std::move(tk.data));
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rMSCAsmStatement 6\n";
-    #endif // DEBUG
+#endif // DEBUG
   }
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rMSCAsmStatement 7\n";
-  #endif // DEBUG
+#endif // DEBUG
 
   return true;
 }
@@ -8089,16 +8088,16 @@ bool Parser::rExprStatement(codet &statement)
 {
   cpp_tokent tk;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rExprStatement 0\n";
-  #endif
+#endif
 
   if(lex.LookAhead(0)==';')
   {
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rExprStatement 1\n";
-    #endif
+#endif
 
     lex.get_token(tk);
     statement = code_skipt();
@@ -8107,18 +8106,18 @@ bool Parser::rExprStatement(codet &statement)
   }
   else
   {
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rExprStatement 2\n";
-    #endif
+#endif
 
     cpp_token_buffert::post pos=lex.Save();
 
     if(rDeclarationStatement(statement))
     {
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "rDe "
                 << statement.pretty() << '\n';
-      #endif
+#endif
       return true;
     }
     else
@@ -8127,28 +8126,28 @@ bool Parser::rExprStatement(codet &statement)
 
       lex.Restore(pos);
 
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rExprStatement 3\n";
-      #endif
+#endif
 
       if(!rCommaExpression(exp))
         return false;
 
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rExprStatement 4\n";
-      #endif
+#endif
 
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rExprStatement 5 "
                 << lex.LookAhead(0) << "\n";
-      #endif
+#endif
 
       if(lex.get_token(tk)!=';')
         return false;
 
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ') << "Parser::rExprStatement 6\n";
-      #endif
+#endif
 
       statement=codet(ID_expression);
       statement.add_source_location()=exp.source_location();
@@ -8203,11 +8202,11 @@ bool Parser::rDeclarationStatement(codet &statement)
   typet cv_q, integral;
   cpp_member_spect member_spec;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ')
             << "Parser::rDeclarationStatement 1\n";
-  #endif
+#endif
 
   if(!optStorageSpec(storage_spec))
     return false;
@@ -8227,10 +8226,10 @@ bool Parser::rDeclarationStatement(codet &statement)
   if(!optIntegralTypeOrClassSpec(integral))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ')
             << "Parser::rDeclarationStatement 2\n";
-  #endif
+#endif
 
   if(integral.is_not_nil())
     return rIntegralDeclStatement(statement, storage_spec, integral, cv_q);
@@ -8238,18 +8237,18 @@ bool Parser::rDeclarationStatement(codet &statement)
   {
     int t=lex.LookAhead(0);
 
-    #ifdef DEBUG
+#ifdef DEBUG
     std::cout << std::string(__indent, ' ')
               << "Parser::rDeclarationStatement 3 " << t << "\n";
-    #endif
+#endif
 
     if(cv_q.is_not_nil() &&
        ((t==TOK_IDENTIFIER && lex.LookAhead(1)=='=') || t=='*'))
     {
-      #ifdef DEBUG
+#ifdef DEBUG
       std::cout << std::string(__indent, ' ')
                 << "Parser::rDeclarationStatement 4\n";
-      #endif
+#endif
 
       statement=codet(ID_decl);
       statement.operands().resize(1);
@@ -8318,24 +8317,24 @@ bool Parser::rOtherDeclStatement(
   typet type_name;
   cpp_tokent tk;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   indenter _i;
   std::cout << std::string(__indent, ' ') << "Parser::rOtherDeclStatement 1\n";
-  #endif // DEBUG
+#endif // DEBUG
 
   if(!rName(type_name))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rOtherDeclStatement 2\n";
-  #endif // DEBUG
+#endif // DEBUG
 
   if(!optCvQualify(cv_q))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rOtherDeclStatement 3\n";
-  #endif // DEBUG
+#endif // DEBUG
 
   merge_types(cv_q, type_name);
 
@@ -8346,9 +8345,9 @@ bool Parser::rOtherDeclStatement(
   if(!rDeclarators(declaration.declarators(), false, true))
     return false;
 
-  #ifdef DEBUG
+#ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rOtherDeclStatement 4\n";
-  #endif // DEBUG
+#endif // DEBUG
 
   if(lex.get_token(tk)!=';')
     return false;
@@ -8392,9 +8391,9 @@ bool Parser::operator()()
     item.clear();
   }
 
-  #if 0
+#if 0
   root_scope.print(std::cout);
-  #endif
+#endif
 
   return number_of_errors!=0;
 }

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -4197,7 +4197,7 @@ bool Parser::rInitializeExpr(exprt &expr)
       return true;           // error recovery
     }
 
-    expr.move_to_operands(tmp);
+    expr.add_to_operands(std::move(tmp));
 
     t=lex.LookAhead(0);
     if(t=='}')
@@ -4246,7 +4246,7 @@ bool Parser::rFunctionArguments(exprt &args)
     if(!rExpression(exp, false))
       return false;
 
-    args.move_to_operands(exp);
+    args.add_to_operands(std::move(exp));
 
     if(lex.LookAhead(0)==TOK_ELLIPSIS &&
        (lex.LookAhead(1)==')' || lex.LookAhead(1)==','))
@@ -4632,8 +4632,8 @@ bool Parser::rClassBody(exprt &body)
               << member.pretty() << '\n';
     #endif
 
-    members.move_to_operands(
-      static_cast<exprt &>(static_cast<irept &>(member)));
+    members.add_to_operands(
+      std::move(static_cast<exprt &>(static_cast<irept &>(member))));
   }
 
   lex.get_token(tk);
@@ -4778,7 +4778,7 @@ bool Parser::rCommaExpression(exprt &exp)
     left.swap(exp);
 
     exp=exprt(ID_comma);
-    exp.move_to_operands(left, right);
+    exp.add_to_operands(std::move(left), std::move(right));
     set_location(exp, tk);
   }
 
@@ -4859,7 +4859,7 @@ bool Parser::rExpression(exprt &exp, bool template_args)
     else if(t==TOK_ORASSIGN)
       exp.set(ID_statement, ID_assign_bitor);
 
-    exp.move_to_operands(left, right);
+    exp.add_to_operands(std::move(left), std::move(right));
     set_location(exp, tk);
   }
 
@@ -4910,8 +4910,8 @@ bool Parser::rConditionalExpr(exprt &exp, bool template_args)
     exprt cond;
     cond.swap(exp);
 
-    exp=exprt(ID_if);
-    exp.move_to_operands(cond, then, otherwise);
+    exp =
+      if_exprt(std::move(cond), std::move(then), std::move(otherwise), typet());
     set_location(exp, tk1);
   }
 
@@ -4950,7 +4950,7 @@ bool Parser::rLogicalOrExpr(exprt &exp, bool template_args)
     left.swap(exp);
 
     exp=exprt(ID_or);
-    exp.move_to_operands(left, right);
+    exp.add_to_operands(std::move(left), std::move(right));
     set_location(exp, tk);
   }
 
@@ -4989,7 +4989,7 @@ bool Parser::rLogicalAndExpr(exprt &exp, bool template_args)
     left.swap(exp);
 
     exp=exprt(ID_and);
-    exp.move_to_operands(left, right);
+    exp.add_to_operands(std::move(left), std::move(right));
     set_location(exp, tk);
   }
 
@@ -5028,7 +5028,7 @@ bool Parser::rInclusiveOrExpr(exprt &exp, bool template_args)
     left.swap(exp);
 
     exp=exprt(ID_bitor);
-    exp.move_to_operands(left, right);
+    exp.add_to_operands(std::move(left), std::move(right));
     set_location(exp, tk);
   }
 
@@ -5067,7 +5067,7 @@ bool Parser::rExclusiveOrExpr(exprt &exp, bool template_args)
     left.swap(exp);
 
     exp=exprt(ID_bitxor);
-    exp.move_to_operands(left, right);
+    exp.add_to_operands(std::move(left), std::move(right));
     set_location(exp, tk);
   }
 
@@ -5106,7 +5106,7 @@ bool Parser::rAndExpr(exprt &exp, bool template_args)
     left.swap(exp);
 
     exp=exprt(ID_bitand);
-    exp.move_to_operands(left, right);
+    exp.add_to_operands(std::move(left), std::move(right));
     set_location(exp, tk);
   }
 
@@ -5146,7 +5146,7 @@ bool Parser::rEqualityExpr(exprt &exp, bool template_args)
     left.swap(exp);
 
     exp=exprt(tk.kind==TOK_EQ?ID_equal:ID_notequal);
-    exp.move_to_operands(left, right);
+    exp.add_to_operands(std::move(left), std::move(right));
     set_location(exp, tk);
   }
 
@@ -5198,7 +5198,7 @@ bool Parser::rRelationalExpr(exprt &exp, bool template_args)
     }
 
     exp=exprt(id);
-    exp.move_to_operands(left, right);
+    exp.add_to_operands(std::move(left), std::move(right));
     set_location(exp, tk);
   }
 
@@ -5238,7 +5238,7 @@ bool Parser::rShiftExpr(exprt &exp, bool template_args)
     left.swap(exp);
 
     exp=exprt((tk.kind==TOK_SHIFTRIGHT)?ID_shr:ID_shl);
-    exp.move_to_operands(left, right);
+    exp.add_to_operands(std::move(left), std::move(right));
     set_location(exp, tk);
   }
 
@@ -5285,7 +5285,7 @@ bool Parser::rAdditiveExpr(exprt &exp)
     }
 
     exp=exprt(id);
-    exp.move_to_operands(left, right);
+    exp.add_to_operands(std::move(left), std::move(right));
     set_location(exp, tk);
   }
 
@@ -5333,7 +5333,7 @@ bool Parser::rMultiplyExpr(exprt &exp)
     }
 
     exp=exprt(id);
-    exp.move_to_operands(left, right);
+    exp.add_to_operands(std::move(left), std::move(right));
     set_location(exp, tk);
   }
 
@@ -5378,7 +5378,7 @@ bool Parser::rPmExpr(exprt &exp)
     left.swap(exp);
 
     exp = exprt(ID_pointer_to_member);
-    exp.move_to_operands(left, right);
+    exp.add_to_operands(std::move(left), std::move(right));
     set_location(exp, tk);
   }
 
@@ -5437,7 +5437,7 @@ bool Parser::rCastExpr(exprt &exp)
 
           exp=exprt("explicit-typecast");
           exp.type().swap(tname);
-          exp.move_to_operands(op);
+          exp.add_to_operands(std::move(op));
           set_location(exp, tk1);
 
           return true;
@@ -5748,7 +5748,7 @@ bool Parser::rUnaryExpr(exprt &exp)
       UNREACHABLE;
     }
 
-    exp.move_to_operands(right);
+    exp.add_to_operands(std::move(right));
     set_location(exp, tk);
 
     return true;
@@ -5773,7 +5773,7 @@ bool Parser::rUnaryExpr(exprt &exp)
       return false;
 
     exp=exprt(t==TOK_REAL?ID_complex_real:ID_complex_imag);
-    exp.move_to_operands(unary);
+    exp.add_to_operands(std::move(unary));
     set_location(exp, tk);
     return true;
   }
@@ -5815,7 +5815,7 @@ bool Parser::rThrowExpr(exprt &exp)
     if(!rExpression(e, false))
       return false;
 
-    exp.move_to_operands(e);
+    exp.add_to_operands(std::move(e));
   }
 
   return true;
@@ -5954,7 +5954,7 @@ bool Parser::rSizeofExpr(exprt &exp)
     return false;
 
   exp=exprt(ID_sizeof);
-  exp.move_to_operands(unary);
+  exp.add_to_operands(std::move(unary));
   set_location(exp, tk);
   return true;
 }
@@ -6017,7 +6017,7 @@ bool Parser::rNoexceptExpr(exprt &exp)
       {
         // TODO
         exp=exprt(ID_noexcept);
-        exp.move_to_operands(subexp);
+        exp.add_to_operands(std::move(subexp));
         set_location(exp, tk);
         return true;
       }
@@ -6094,7 +6094,7 @@ bool Parser::rAllocateExpr(exprt &exp)
     if(!rCastExpr(obj))
        return false;
 
-    exp.move_to_operands(obj);
+    exp.add_to_operands(std::move(obj));
 
     return true;
   }
@@ -6278,7 +6278,7 @@ bool Parser::rAllocateInitializer(exprt &init)
     if(!rInitializeExpr(exp))
       return false;
 
-    init.move_to_operands(exp);
+    init.add_to_operands(std::move(exp));
 
     if(lex.LookAhead(0)==TOK_ELLIPSIS)
     {
@@ -6355,7 +6355,7 @@ bool Parser::rPostfixExpr(exprt &exp)
         left.swap(exp);
 
         exp=exprt(ID_index);
-        exp.move_to_operands(left, e);
+        exp.add_to_operands(std::move(left), std::move(e));
         set_location(exp, op);
       }
       break;
@@ -6394,7 +6394,7 @@ bool Parser::rPostfixExpr(exprt &exp)
 
       {
         side_effect_exprt tmp(ID_postincrement, typet(), source_locationt());
-        tmp.move_to_operands(exp);
+        tmp.add_to_operands(std::move(exp));
         set_location(tmp, op);
         exp.swap(tmp);
       }
@@ -6405,7 +6405,7 @@ bool Parser::rPostfixExpr(exprt &exp)
 
       {
         side_effect_exprt tmp(ID_postdecrement, typet(), source_locationt());
-        tmp.move_to_operands(exp);
+        tmp.add_to_operands(std::move(exp));
         set_location(tmp, op);
         exp.swap(tmp);
       }
@@ -6435,7 +6435,7 @@ bool Parser::rPostfixExpr(exprt &exp)
         else // ARROW
           exp=exprt(ID_ptrmember);
 
-        exp.move_to_operands(left);
+        exp.add_to_operands(std::move(left));
         set_location(exp, op);
       }
 
@@ -6494,7 +6494,7 @@ bool Parser::rMSCuuidof(exprt &expr)
     return false;
 
   expr=exprt(ID_msc_uuidof);
-  expr.move_to_operands(unary);
+  expr.add_to_operands(std::move(unary));
   set_location(expr, tk);
   return true;
 }
@@ -6542,7 +6542,7 @@ bool Parser::rMSC_if_existsExpr(exprt &expr)
     tk1.kind==TOK_MSC_IF_EXISTS?ID_msc_if_exists:
                                 ID_msc_if_not_exists);
 
-  expr.move_to_operands(name, op);
+  expr.add_to_operands(std::move(name), std::move(op));
 
   set_location(expr, tk1);
 
@@ -6584,7 +6584,7 @@ bool Parser::rMSC_if_existsStatement(codet &code)
     if(!rStatement(statement))
       return false;
 
-    block.move_to_operands(statement);
+    block.add_to_operands(std::move(statement));
   }
 
   if(lex.get_token(tk2)!='}')
@@ -6594,7 +6594,7 @@ bool Parser::rMSC_if_existsStatement(codet &code)
     tk1.kind==TOK_MSC_IF_EXISTS?ID_msc_if_exists:
                                 ID_msc_if_not_exists);
 
-  code.move_to_operands(name, block);
+  code.add_to_operands(std::move(name), std::move(block));
 
   set_location(code, tk1);
 
@@ -6755,7 +6755,7 @@ bool Parser::rPrimaryExpr(exprt &exp)
       exp=exprt(ID_side_effect);
       exp.set(ID_statement, ID_statement_expression);
       set_location(exp, tk);
-      exp.move_to_operands(code);
+      exp.add_to_operands(std::move(code));
 
       if(lex.get_token(tk2)!=')')
         return false;
@@ -6849,7 +6849,7 @@ bool Parser::rPrimaryExpr(exprt &exp)
 
           exp=exprt("explicit-constructor-call");
           exp.type().swap(type);
-          exp.move_to_operands(exp2);
+          exp.add_to_operands(std::move(exp2));
           set_location(exp, tk);
         }
         else if(lex.LookAhead(0)=='(')
@@ -7248,7 +7248,7 @@ bool Parser::rCompoundStatement(codet &statement)
       return true;        // error recovery
     }
 
-    statement.move_to_operands(statement2);
+    statement.add_to_operands(std::move(statement2));
   }
 
   if(lex.get_token(cb)!='}')
@@ -7375,7 +7375,7 @@ bool Parser::rStatement(codet &statement)
       if(lex.get_token(tk2)!=';')
         return false;
 
-      statement.move_to_operands(exp);
+      statement.add_to_operands(std::move(exp));
     }
 
     return true;
@@ -7491,7 +7491,7 @@ bool Parser::rStatement(codet &statement)
       if(!rStatement(statement2))
         return false;
 
-      statement.move_to_operands(statement2);
+      statement.add_to_operands(std::move(statement2));
       return true;
     }
 
@@ -7612,7 +7612,7 @@ bool Parser::rSwitchStatement(codet &statement)
   if(!rStatement(body))
     return false;
 
-  statement.move_to_operands(exp, body);
+  statement.add_to_operands(std::move(exp), std::move(body));
 
   return true;
 }
@@ -7645,7 +7645,7 @@ bool Parser::rWhileStatement(codet &statement)
   if(!rStatement(body))
     return false;
 
-  statement.move_to_operands(exp, body);
+  statement.add_to_operands(std::move(exp), std::move(body));
 
   return true;
 }
@@ -7684,7 +7684,7 @@ bool Parser::rDoStatement(codet &statement)
   if(lex.get_token(tk4)!=';')
     return false;
 
-  statement.move_to_operands(exp, body);
+  statement.add_to_operands(std::move(exp), std::move(body));
 
   return true;
 }
@@ -7742,10 +7742,10 @@ bool Parser::rForStatement(codet &statement)
     return false;
 
   statement.reserve_operands(4);
-  statement.move_to_operands(exp1);
-  statement.move_to_operands(exp2);
-  statement.move_to_operands(exp3);
-  statement.move_to_operands(body);
+  statement.add_to_operands(std::move(exp1));
+  statement.add_to_operands(std::move(exp2));
+  statement.add_to_operands(std::move(exp3));
+  statement.add_to_operands(std::move(body));
 
   return true;
 }
@@ -7811,7 +7811,7 @@ bool Parser::rTryStatement(codet &statement)
 
       codet code_decl;
       code_decl.set_statement(ID_decl);
-      code_decl.move_to_operands(declaration);
+      code_decl.add_to_operands(std::move(declaration));
       set_location(code_decl, catch_token);
 
       catch_op=code_decl;
@@ -7829,7 +7829,7 @@ bool Parser::rTryStatement(codet &statement)
 
     body.operands().insert(body.operands().begin(), catch_op);
 
-    statement.move_to_operands(body);
+    statement.add_to_operands(std::move(body));
   }
   while(lex.LookAhead(0)==TOK_CATCH);
 
@@ -7873,7 +7873,8 @@ bool Parser::rMSC_tryStatement(codet &statement)
     if(!rCompoundStatement(body2))
       return false;
 
-    statement.move_to_operands(body1, exp, body2);
+    statement.add_to_operands(
+      std::move(body1), std::move(exp), std::move(body2));
   }
   else if(lex.LookAhead(0)==TOK_MSC_FINALLY)
   {
@@ -7883,7 +7884,7 @@ bool Parser::rMSC_tryStatement(codet &statement)
     if(!rCompoundStatement(body2))
       return false;
 
-    statement.move_to_operands(body1, body2);
+    statement.add_to_operands(std::move(body1), std::move(body2));
   }
   else
     return false;
@@ -8044,7 +8045,7 @@ bool Parser::rMSCAsmStatement(codet &statement)
 
     lex.get_token(tk);
 
-    statement.move_to_operands(tk.data);
+    statement.add_to_operands(std::move(tk.data));
     if(lex.get_token(tk)!='}')
       return false;
 
@@ -8062,7 +8063,7 @@ bool Parser::rMSCAsmStatement(codet &statement)
       return true;
 
     lex.get_token(tk);
-    statement.move_to_operands(tk.data);
+    statement.add_to_operands(std::move(tk.data));
 
     #ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rMSCAsmStatement 6\n";
@@ -8151,7 +8152,7 @@ bool Parser::rExprStatement(codet &statement)
 
       statement=codet(ID_expression);
       statement.add_source_location()=exp.source_location();
-      statement.move_to_operands(exp);
+      statement.add_to_operands(std::move(exp));
       return true;
     }
   }
@@ -8168,7 +8169,7 @@ bool Parser::rCondition(exprt &statement)
   if(rSimpleDeclaration(declaration))
   {
     statement=codet(ID_decl);
-    statement.move_to_operands(declaration);
+    statement.add_to_operands(std::move(declaration));
     return true;
   }
   else
@@ -8286,7 +8287,7 @@ bool Parser::rIntegralDeclStatement(
     lex.get_token(tk);
     statement=codet(ID_decl);
     set_location(statement, tk);
-    statement.move_to_operands(declaration);
+    statement.add_to_operands(std::move(declaration));
   }
   else
   {
@@ -8299,7 +8300,7 @@ bool Parser::rIntegralDeclStatement(
     statement=codet(ID_decl);
     set_location(statement, tk);
 
-    statement.move_to_operands(declaration);
+    statement.add_to_operands(std::move(declaration));
   }
 
   return true;
@@ -8354,7 +8355,7 @@ bool Parser::rOtherDeclStatement(
 
   statement=codet(ID_decl);
   set_location(statement, tk);
-  statement.move_to_operands(declaration);
+  statement.add_to_operands(std::move(declaration));
 
   return true;
 }

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -1237,7 +1237,7 @@ void dump_ct::cleanup_expr(exprt &expr)
       if(!old_comp.get_is_padding() && !is_zero_bit_field)
       {
         type.components().push_back(old_comp);
-        expr.move_to_operands(*o_it);
+        expr.add_to_operands(std::move(*o_it));
       }
       ++o_it;
     }

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1156,8 +1156,7 @@ exprt goto_convertt::case_guard(
 
     forall_expr(it, case_op)
     {
-      equal_exprt eq_expr(value, *it);
-      dest.move_to_operands(eq_expr);
+      dest.add_to_operands(equal_exprt(value, *it));
     }
     INVARIANT(
       case_op.size() == dest.operands().size(),

--- a/src/goto-programs/goto_convert_side_effect.cpp
+++ b/src/goto-programs/goto_convert_side_effect.cpp
@@ -206,10 +206,7 @@ void goto_convertt::remove_pre(
       UNREACHABLE;
     }
 
-    exprt constant=from_integer(1, constant_type);
-
-    rhs.copy_to_operands(expr.op0());
-    rhs.move_to_operands(constant);
+    rhs.add_to_operands(expr.op0(), from_integer(1, constant_type));
     rhs.type()=expr.op0().type();
   }
 
@@ -306,8 +303,7 @@ void goto_convertt::remove_post(
     else
       constant=from_integer(1, constant_type);
 
-    rhs.copy_to_operands(expr.op0());
-    rhs.move_to_operands(constant);
+    rhs.add_to_operands(expr.op0(), std::move(constant));
     rhs.type()=expr.op0().type();
   }
 
@@ -479,8 +475,7 @@ void goto_convertt::remove_malloc(
   }
   else
   {
-    call=codet(ID_expression);
-    call.move_to_operands(expr);
+    call = code_expressiont(std::move(expr));
   }
 
   convert(call, dest, mode);

--- a/src/goto-symex/slice_by_trace.cpp
+++ b/src/goto-symex/slice_by_trace.cpp
@@ -285,14 +285,10 @@ void symex_slice_by_tracet::compute_ts_back(
 
             for(const auto &sigma_val : sigma_vals[j])
             {
-              exprt equal_cond=exprt(ID_equal, bool_typet());
-              equal_cond.operands().reserve(2);
-              equal_cond.copy_to_operands(*pvi);
               // Should eventually change to handle non-bv types!
               exprt constant_value = from_integer(
                 unsafe_string2int(id2string(sigma_val)), (*pvi).type());
-              equal_cond.move_to_operands(constant_value);
-              eq_conds.push_back(equal_cond);
+              eq_conds.push_back(equal_exprt(*pvi, std::move(constant_value)));
               pvi++;
             }
 
@@ -305,7 +301,7 @@ void symex_slice_by_tracet::compute_ts_back(
               val_merge.copy_to_operands(eq_cond);
             }
 
-            u_lhs.move_to_operands(val_merge);
+            u_lhs.add_to_operands(std::move(val_merge));
           }
           else
           {

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -434,8 +434,8 @@ void goto_symext::symex_cpp_new(
 
   if(do_array)
   {
-    index_exprt index_expr(symbol.symbol_expr(), from_integer(0, index_type()));
-    rhs.move_to_operands(index_expr);
+    rhs.add_to_operands(
+      index_exprt(symbol.symbol_expr(), from_integer(0, index_type())));
   }
   else
     rhs.copy_to_operands(symbol.symbol_expr());
@@ -506,7 +506,7 @@ void goto_symext::symex_fkt(
     if(first)
       first=false;
     else
-      new_fc.move_to_operands(*it);
+      new_fc.add_to_operands(std::move(*it));
 
   new_fc.set(ID_identifier, fc.op0().get(ID_identifier));
 

--- a/src/jsil/parser.y
+++ b/src/jsil/parser.y
@@ -179,12 +179,12 @@ parameters_opt: /* empty */
 parameters: TOK_IDENTIFIER
           {
             newstack($$).id(ID_parameters);
-            stack($$).move_to_operands(stack($1));
+            stack($$).add_to_operands(std::move(stack($1)));
           }
           | parameters ',' TOK_IDENTIFIER
           {
             $$=$1;
-            stack($$).move_to_operands(stack($3));
+            stack($$).add_to_operands(std::move(stack($3)));
           }
           ;
 
@@ -199,12 +199,12 @@ statements: statement
           {
             newstack($$).id(ID_code);
             to_code(stack($$)).set_statement(ID_block);
-            stack($$).move_to_operands(stack($1));
+            stack($$).add_to_operands(std::move(stack($1)));
           }
           | statements statement
           {
             $$=$1;
-            stack($$).move_to_operands(stack($2));
+            stack($$).add_to_operands(std::move(stack($2)));
           }
           ;
 
@@ -280,8 +280,7 @@ rhs: expression
    | TOK_HAS_FIELD '(' expression ',' expression ')'
    {
      exprt has_field("hasField");
-     has_field.move_to_operands(stack($3));
-     has_field.move_to_operands(stack($5));
+     has_field.add_to_operands(std::move(stack($3)), std::move(stack($5)));
 
      newstack($$).swap(has_field);
    }
@@ -293,24 +292,21 @@ rhs: expression
    | TOK_DELETE '(' expression ',' expression ')'
    {
      exprt d("delete");
-     d.move_to_operands(stack($3));
-     d.move_to_operands(stack($5));
+     d.add_to_operands(std::move(stack($3)), std::move(stack($5)));
 
      newstack($$).swap(d);
    }
    | TOK_PROTO_FIELD '(' expression ',' expression ')'
    {
      exprt proto_field("protoField");
-     proto_field.move_to_operands(stack($3));
-     proto_field.move_to_operands(stack($5));
+     proto_field.add_to_operands(std::move(stack($3)), std::move(stack($5)));
 
      newstack($$).swap(proto_field);
    }
    | TOK_PROTO_OBJ '(' expression ',' expression ')'
    {
      exprt proto_obj("protoObj");
-     proto_obj.move_to_operands(stack($3));
-     proto_obj.move_to_operands(stack($5));
+     proto_obj.add_to_operands(std::move(stack($3)), std::move(stack($5)));
 
      newstack($$).swap(proto_obj);
    }
@@ -336,12 +332,12 @@ expressions_opt: /* empty */
 expressions: expression
            {
              newstack($$).id(ID_expression_list);
-             stack($$).move_to_operands(stack($1));
+             stack($$).add_to_operands(std::move(stack($1)));
            }
            | expressions ',' expression
            {
              $$=$1;
-             stack($$).move_to_operands(stack($3));
+             stack($$).add_to_operands(std::move(stack($3)));
            }
            ;
 
@@ -349,8 +345,7 @@ expression: atom_expression
           | expression binary_op atom_expression
           {
             $$=$2;
-            stack($$).move_to_operands(stack($1));
-            stack($$).move_to_operands(stack($3));
+            stack($$).add_to_operands(std::move(stack($1)), std::move(stack($3)));
           }
           ;
 
@@ -358,7 +353,7 @@ atom_expression: literal
                | unary_op atom_expression
                {
                  $$=$1;
-                 stack($$).move_to_operands(stack($2));
+                 stack($$).add_to_operands(std::move(stack($2)));
                }
                | '(' expression ')'
                {
@@ -367,30 +362,31 @@ atom_expression: literal
                | TOK_REF '(' expression ',' expression ',' ref_type ')'
                {
                  exprt ref("ref");
-                 ref.move_to_operands(stack($3));
-                 ref.move_to_operands(stack($5));
-                 ref.move_to_operands(stack($7));
+                 ref.add_to_operands(
+                   std::move(stack($3)),
+                   std::move(stack($5)),
+                   std::move(stack($7)));
 
                  newstack($$).swap(ref);
                }
                | TOK_FIELD '(' expression ')'
                {
                  exprt field("field");
-                 field.move_to_operands(stack($3));
+                 field.add_to_operands(std::move(stack($3)));
 
                  newstack($$).swap(field);
                }
                | TOK_BASE '(' expression ')'
                {
                  exprt base(ID_base);
-                 base.move_to_operands(stack($3));
+                 base.add_to_operands(std::move(stack($3)));
 
                  newstack($$).swap(base);
                }
                | TOK_TYPEOF '(' expression ')'
                {
                  exprt typeof_expr(ID_typeof);
-                 typeof_expr.move_to_operands(stack($3));
+                 typeof_expr.add_to_operands(std::move(stack($3)));
 
                  newstack($$).swap(typeof_expr);
                }

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -289,7 +289,7 @@ exprt lower_byte_extract(const byte_extract_exprt &src, const namespacet &ns)
       tmp.type()=comp.type();
       tmp.offset()=new_offset;
 
-      s.move_to_operands(tmp);
+      s.add_to_operands(std::move(tmp));
     }
 
     if(!failed)

--- a/src/solvers/qbf/qbf_bdd_core.cpp
+++ b/src/solvers/qbf/qbf_bdd_core.cpp
@@ -351,7 +351,7 @@ const exprt qbf_bdd_certificatet::f_get(literalt l)
         if(cube[i]!=2)
         {
           exprt subf=f_get(literalt(quantifiers[i].var_no, (cube[i]==1)));
-          prime.move_to_operands(subf);
+          prime.add_to_operands(std::move(subf));
         }
       }
 
@@ -360,9 +360,9 @@ const exprt qbf_bdd_certificatet::f_get(literalt l)
       if(prime.operands().empty())
         result.copy_to_operands(true_exprt());
       else if(prime.operands().size()==1)
-        result.move_to_operands(prime.op0());
+        result.add_to_operands(std::move(prime.op0()));
       else
-        result.move_to_operands(prime);
+        result.add_to_operands(std::move(prime));
     }
 
     cube=NULL; // cube is free'd by nextCube

--- a/src/solvers/qbf/qbf_squolem_core.cpp
+++ b/src/solvers/qbf/qbf_squolem_core.cpp
@@ -262,7 +262,7 @@ const exprt qbf_squolem_coret::f_get_cnf(WitnessStack *wsp)
       exprt subf=f_get(literalt(var(lit), isPositive(lit))); // negated!
       if(find(clause.operands().begin(), clause.operands().end(), subf)==
          clause.operands().end())
-        clause.move_to_operands(subf);
+        clause.add_to_operands(std::move(subf));
     }
 
     if(clause.operands().empty())
@@ -304,7 +304,7 @@ const exprt qbf_squolem_coret::f_get_dnf(WitnessStack *wsp)
       exprt subf=f_get(literalt(var(lit), !isPositive(lit)));
       if(find(cube.operands().begin(), cube.operands().end(), subf)==
          cube.operands().end())
-        cube.move_to_operands(subf);
+        cube.add_to_operands(std::move(subf));
 
       simplify_extractbits(cube);
     }

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -1515,7 +1515,7 @@ exprt simplify_exprt::bits2expr(
       exprt comp=bits2expr(comp_bits, component.type(), little_endian);
       if(comp.is_nil())
         return nil_exprt();
-      result.move_to_operands(comp);
+      result.add_to_operands(std::move(comp));
 
       m_offset_bits += *m_size;
     }
@@ -1549,7 +1549,7 @@ exprt simplify_exprt::bits2expr(
       exprt el = bits2expr(el_bits, array_type.subtype(), little_endian);
       if(el.is_nil())
         return nil_exprt();
-      result.move_to_operands(el);
+      result.add_to_operands(std::move(el));
     }
 
     return std::move(result);

--- a/src/util/std_code.cpp
+++ b/src/util/std_code.cpp
@@ -26,7 +26,7 @@ code_blockt &codet::make_block()
   tmp.swap(*this);
 
   *this = codet(ID_block);
-  move_to_operands(tmp);
+  add_to_operands(std::move(tmp));
 
   return static_cast<code_blockt &>(*this);
 }

--- a/unit/analyses/ai/ai.cpp
+++ b/unit/analyses/ai/ai.cpp
@@ -224,7 +224,7 @@ SCENARIO(
 
   loop.body() = loop_body;
 
-  f_body.move_to_operands(loop);
+  f_body.add_to_operands(std::move(loop));
 
   f_body.copy_to_operands(make_void_call(g.symbol_expr()));
 

--- a/unit/analyses/call_graph.cpp
+++ b/unit/analyses/call_graph.cpp
@@ -47,24 +47,19 @@ SCENARIO("call_graph",
     code_typet void_function_type({}, empty_typet());
 
     {
-      code_blockt calls;
-      code_function_callt call1(symbol_exprt("A", void_function_type));
-      code_function_callt call2(symbol_exprt("B", void_function_type));
-      code_function_callt call3(symbol_exprt("B", void_function_type));
-      calls.move_to_operands(call1);
-      calls.move_to_operands(call2);
-      calls.move_to_operands(call3);
+      code_blockt calls(
+        {code_function_callt(symbol_exprt("A", void_function_type)),
+         code_function_callt(symbol_exprt("B", void_function_type)),
+         code_function_callt(symbol_exprt("B", void_function_type))});
 
       goto_model.symbol_table.add(
         create_void_function_symbol("A", calls));
     }
 
     {
-      code_blockt calls;
-      code_function_callt call1(symbol_exprt("C", void_function_type));
-      code_function_callt call2(symbol_exprt("D", void_function_type));
-      calls.move_to_operands(call1);
-      calls.move_to_operands(call2);
+      code_blockt calls(
+        {code_function_callt(symbol_exprt("C", void_function_type)),
+         code_function_callt(symbol_exprt("D", void_function_type))});
 
       goto_model.symbol_table.add(
         create_void_function_symbol("B", calls));

--- a/unit/analyses/dependence_graph.cpp
+++ b/unit/analyses/dependence_graph.cpp
@@ -64,9 +64,7 @@ SCENARIO("dependence_graph", "[core][analyses][dependence_graph]")
 
     const code_typet void_function_type({}, empty_typet());
 
-    code_blockt a_body;
-    code_declt declare_x(x_symbol.symbol_expr());
-    a_body.move_to_operands(declare_x);
+    code_blockt a_body({code_declt(x_symbol.symbol_expr())});
 
     code_function_callt call(symbol_exprt("b", void_function_type));
     code_assignt assign_x(

--- a/unit/analyses/disconnect_unreachable_nodes_in_graph.cpp
+++ b/unit/analyses/disconnect_unreachable_nodes_in_graph.cpp
@@ -47,31 +47,25 @@ SCENARIO("graph", "[core][util][graph]")
     code_typet void_function_type({}, empty_typet());
 
     {
-      code_blockt calls;
-      code_function_callt call1(symbol_exprt("A", void_function_type));
-      code_function_callt call2(symbol_exprt("B", void_function_type));
-      calls.move_to_operands(call1);
-      calls.move_to_operands(call2);
+      code_blockt calls(
+        {code_function_callt(symbol_exprt("A", void_function_type)),
+         code_function_callt(symbol_exprt("B", void_function_type))});
 
       goto_model.symbol_table.add(create_void_function_symbol("A", calls));
     }
 
     {
-      code_blockt calls;
-      code_function_callt call1(symbol_exprt("C", void_function_type));
-      code_function_callt call2(symbol_exprt("D", void_function_type));
-      calls.move_to_operands(call1);
-      calls.move_to_operands(call2);
+      code_blockt calls(
+        {code_function_callt(symbol_exprt("C", void_function_type)),
+         code_function_callt(symbol_exprt("D", void_function_type))});
 
       goto_model.symbol_table.add(create_void_function_symbol("B", calls));
     }
 
     {
-      code_blockt calls;
-      code_function_callt call1(symbol_exprt("F", void_function_type));
-      code_function_callt call2(symbol_exprt("G", void_function_type));
-      calls.move_to_operands(call1);
-      calls.move_to_operands(call2);
+      code_blockt calls(
+        {code_function_callt(symbol_exprt("F", void_function_type)),
+         code_function_callt(symbol_exprt("G", void_function_type))});
 
       goto_model.symbol_table.add(create_void_function_symbol("E", calls));
     }

--- a/unit/interpreter/interpreter.cpp
+++ b/unit/interpreter/interpreter.cpp
@@ -60,10 +60,8 @@ SCENARIO("interpreter evaluation null pointer expressions")
       "0000000000000000000000000000000000000000000000000000000000000000",
       outer_pointer_type);
 
-    pointer_typet inner_pointer_type(empty_typet(), 64);
-    constant_exprt inner_expression(ID_NULL, inner_pointer_type);
-
-    outer_expression.move_to_operands(inner_expression);
+    outer_expression.add_to_operands(
+      null_pointer_exprt(pointer_typet(empty_typet(), 64)));
 
     mp_vectort mp_vector = interpreter_test.evaluate(outer_expression);
 

--- a/unit/util/irep_sharing.cpp
+++ b/unit/util/irep_sharing.cpp
@@ -116,13 +116,13 @@ SCENARIO("irept_sharing", "[core][utils][irept]")
 
 SCENARIO("exprt_sharing_trade_offs", "[!mayfail][core][utils][exprt]")
 {
-  GIVEN("An expression created with move_to_operands")
+  GIVEN("An expression created with add_to_operands(std::move(...))")
   {
     exprt test_expr(ID_1);
     exprt test_subexpr(ID_1);
     exprt test_subsubexpr(ID_1);
-    test_subexpr.move_to_operands(test_subsubexpr);
-    test_expr.move_to_operands(test_subexpr);
+    test_subexpr.add_to_operands(std::move(test_subsubexpr));
+    test_expr.add_to_operands(std::move(test_subexpr));
     THEN("Calling read() on a copy should return object with the same address")
     {
       exprt expr = test_expr;
@@ -150,13 +150,13 @@ SCENARIO("exprt_sharing_trade_offs", "[!mayfail][core][utils][exprt]")
 
 SCENARIO("exprt_sharing", "[core][utils][exprt]")
 {
-  GIVEN("An expression created with move_to_operands")
+  GIVEN("An expression created with add_to_operands(std::move(...))")
   {
     exprt test_expr(ID_1);
     exprt test_subexpr(ID_1);
     exprt test_subsubexpr(ID_1);
-    test_subexpr.move_to_operands(test_subsubexpr);
-    test_expr.move_to_operands(test_subexpr);
+    test_subexpr.add_to_operands(std::move(test_subsubexpr));
+    test_expr.add_to_operands(std::move(test_subexpr));
     THEN("Copies of a copy should return object with the same address")
     {
       exprt expr1 = test_expr;


### PR DESCRIPTION
move_to_operands is deprecated, use add_to_operands(std::move(...)) or proper
constructors instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
