### PR TITLE
Replaces uses of reserve; add_to_operands by a single add_to_operands

### DIFF
--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -2324,27 +2324,21 @@ selection_statement:
         {
           $$=$1;
           statement($$, ID_ifthenelse);
-          stack($$).operands().reserve(3);
-          mto($$, $3);
-          mto($$, $5);
-          stack($$).copy_to_operands(nil_exprt());
+          stack($$).add_to_operands(
+            std::move(stack($3)), std::move(stack($5)), nil_exprt());
         }
         | TOK_IF '(' comma_expression ')' statement TOK_ELSE statement
         {
           $$=$1;
           statement($$, ID_ifthenelse);
-          stack($$).operands().reserve(3);
-          mto($$, $3);
-          mto($$, $5);
-          mto($$, $7);
+          stack($$).add_to_operands(
+            std::move(stack($3)), std::move(stack($5)), std::move(stack($7)));
         }
         | TOK_SWITCH '(' comma_expression ')' statement
         {
           $$=$1;
           statement($$, ID_switch);
-          stack($$).operands().reserve(2);
-          mto($$, $3);
-          mto($$, $5);
+          stack($$).add_to_operands(std::move(stack($3)), std::move(stack($5)));
         }
         ;
 
@@ -2359,9 +2353,7 @@ iteration_statement:
         {
           $$=$1;
           statement($$, ID_while);
-          stack($$).operands().reserve(2);
-          mto($$, $3);
-          mto($$, $6);
+          stack($$).add_to_operands(std::move(stack($3)), std::move(stack($6)));
 
           if(stack($5).is_not_nil())
             stack($$).add(ID_C_spec_loop_invariant).swap(stack($5));
@@ -2371,9 +2363,7 @@ iteration_statement:
         {
           $$=$1;
           statement($$, ID_dowhile);
-          stack($$).operands().reserve(2);
-          mto($$, $5);
-          mto($$, $2);
+          stack($$).add_to_operands(std::move(stack($5)), std::move(stack($2)));
 
           if(stack($7).is_not_nil())
             stack($$).add(ID_C_spec_loop_invariant).swap(stack($7));

--- a/src/ansi-c/parser_static.inc
+++ b/src/ansi-c/parser_static.inc
@@ -13,7 +13,7 @@
 #define mts(x, y) (to_type_with_subtypes(stack_type(x)).move_to_subtypes(stack_type(y)))
 #define binary(x, y, l, id, z) { init(x, id); \
   stack(x).add_source_location()=stack(l).source_location(); \
-  stack(x).reserve_operands(2); mto(x, y); mto(x, z); }
+  stack(x).add_to_operands(std::move(stack(y)), std::move(stack(z))); }
 
 /*******************************************************************\
 


### PR DESCRIPTION
This reduces the lines of code and simplifies maintenance.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
