### PR TITLE
test signed left-shift overflow for C99

### DIFF
--- a/regression/cbmc/Overflow_Leftshift1/test-c99.desc
+++ b/regression/cbmc/Overflow_Leftshift1/test-c99.desc
@@ -1,0 +1,16 @@
+CORE
+main.c
+--signed-overflow-check --c99
+^EXIT=10$
+^SIGNAL=0$
+^\[.*\] line 6 arithmetic overflow on signed shl in .*: FAILURE$
+^\[.*\] line 9 arithmetic overflow on signed shl in .*: SUCCESS$
+^\[.*\] line 15 arithmetic overflow on signed shl in .*: SUCCESS$
+^\[.*\] line 18 arithmetic overflow on signed shl in .*: FAILURE$
+^\[.*\] line 24 arithmetic overflow on signed shl in .*: FAILURE$
+^\*\* 3 of 6 failed
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+^\[.*\] line 12 arithmetic overflow on signed shl in .*: .*
+^\[.*\] line 21 arithmetic overflow on signed shl in .*: .*


### PR DESCRIPTION
The semantics of signed left shifts are contentious for the case
that a '1' is shifted into the signed bit. This tests the C99 case.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
