### PR TITLE
test for promotion in compound assignment

### DIFF
--- a/regression/cbmc/compound-assignment/compound_promotion.c
+++ b/regression/cbmc/compound-assignment/compound_promotion.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+
+int main()
+{
+  unsigned char x = 50;
+  short y = -5;
+  x /= y;
+  assert(x == (unsigned char)-10);
+  return 0;
+}

--- a/regression/cbmc/compound-assignment/compound_promotion.desc
+++ b/regression/cbmc/compound-assignment/compound_promotion.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+compound_promition.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+The C frontend needs to apply the usual arithmetic promotion rules in
+compound assignments. Issue #3706.


### PR DESCRIPTION
The C frontend needs to apply the usual arithmetic promotion rules in
compound assignments. Issue #3706.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
