### PR TITLE
fix anonymous struct member initialization

### DIFF
--- a/regression/cbmc/Struct_Initialization1/main.c
+++ b/regression/cbmc/Struct_Initialization1/main.c
@@ -3,7 +3,9 @@
 struct tag1 {
   int f;
   int : 32; // unnamed bit-field, ignored during initialization
-  int g;
+  union {
+    int g;
+  }; // anonymous, but not ignored
   int *p;
   int a[2];
 } x;

--- a/regression/cbmc/Struct_Initialization1/test.desc
+++ b/regression/cbmc/Struct_Initialization1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=0$

--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -665,10 +665,16 @@ void c_typecheck_baset::increment_designator(designatort &designator)
       assert(components.size()==entry.size);
 
       // we skip over any padding or code
-      while(entry.index<entry.size &&
+      // we also skip over anonymous members
+      while(entry.index < entry.size &&
             (components[entry.index].get_is_padding() ||
-             components[entry.index].type().id()==ID_code))
+             (components[entry.index].get_anonymous() &&
+              components[entry.index].type().id() != ID_struct_tag &&
+              components[entry.index].type().id() != ID_union_tag) ||
+             components[entry.index].type().id() == ID_code))
+      {
         entry.index++;
+      }
 
       if(entry.index<entry.size)
         entry.subtype=components[entry.index].type();


### PR DESCRIPTION
The C front-end needs to ignore the unnamed bit-field during struct
initialization; issue #3709.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
