### PR TITLE
fix promotion for C bit fields

### DIFF
--- a/regression/cbmc/Bitfields1/test.desc
+++ b/regression/cbmc/Bitfields1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=0$

--- a/src/ansi-c/c_typecast.cpp
+++ b/src/ansi-c/c_typecast.cpp
@@ -354,7 +354,30 @@ c_typecastt::c_typet c_typecastt::get_c_type(
   else if(type.id()==ID_complex)
     return COMPLEX;
   else if(type.id()==ID_c_bit_field)
-    return get_c_type(to_c_bit_field_type(type).subtype());
+  {
+    const auto &bit_field_type = to_c_bit_field_type(type);
+
+    // We take the underlying type, and then apply the number
+    // of bits given
+    typet underlying_type;
+
+    if(bit_field_type.subtype().id() == ID_c_enum_tag)
+    {
+      const auto &followed =
+        ns.follow_tag(to_c_enum_tag_type(bit_field_type.subtype()));
+      if(followed.is_incomplete())
+        return INT;
+      else
+        underlying_type = followed.subtype();
+    }
+    else
+      underlying_type = bit_field_type.subtype();
+
+    const bitvector_typet new_type(
+      underlying_type.id(), bit_field_type.get_width());
+
+    return get_c_type(new_type);
+  }
 
   return OTHER;
 }


### PR DESCRIPTION
promotion rules apply to bit-fields, based on number of bits, not based on
underlying type

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
