### PR TITLE
Ensure ssa_expr's l1-identifier is consistent with its identifier [blocks: #2574]

### DIFF
--- a/src/util/ssa_expr.cpp
+++ b/src/util/ssa_expr.cpp
@@ -32,6 +32,7 @@ static void build_ssa_identifier_rec(
     build_ssa_identifier_rec(member.struct_op(), l0, l1, l2, os, l1_object_os);
 
     os << '.' << member.get_component_name();
+    l1_object_os << '.' << member.get_component_name();
   }
   else if(expr.id()==ID_index)
   {
@@ -41,6 +42,7 @@ static void build_ssa_identifier_rec(
 
     const mp_integer idx = numeric_cast_v<mp_integer>(index.index());
     os << '[' << idx << ']';
+    l1_object_os << '[' << idx << ']';
   }
   else if(expr.id()==ID_symbol)
   {


### PR DESCRIPTION
The new cases for ssa-expressions describing members or indices didn't contribute to the l1-id
as they ought to.

This is a bugfix for a code path not currently executed. #2574 will bring it to life.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
