### PR TITLE
Fix compound assignment promotion

### DIFF
--- a/regression/cbmc/Fixedbv1/main.c
+++ b/regression/cbmc/Fixedbv1/main.c
@@ -5,13 +5,13 @@ int main() {
   int y;
 
   x=2;
-  x-=0.6;
+  x -= (__CPROVER_fixedbv[64][32])0.6;
   y=x; // this yields 1.4, which is cut off
 
   assert(y==1);
 
   x=2;
-  x-=0.4;
+  x -= (__CPROVER_fixedbv[64][32])0.4;
   y=x; // this yields 1.6, which is cut off, too!
 
   assert(y==1);

--- a/regression/cbmc/compound-assignment/compound_promotion.desc
+++ b/regression/cbmc/compound-assignment/compound_promotion.desc
@@ -1,5 +1,5 @@
-KNOWNBUG
-compound_promition.c
+CORE
+compound_promotion.c
 
 ^EXIT=0$
 ^SIGNAL=0$

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -3459,7 +3459,7 @@ void c_typecheck_baset::typecheck_side_effect_assignment(
     }
     else
     {
-      implicit_typecast(op1, o_type0);
+      implicit_typecast_arithmetic(op0, op1);
 
       if(is_number(op1.type()) ||
          op1.type().id()==ID_bool ||


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
