### PR TITLE
ansi-c: unnecessary follow() calls

### DIFF
--- a/src/ansi-c/c_typecheck_code.cpp
+++ b/src/ansi-c/c_typecheck_code.cpp
@@ -642,9 +642,9 @@ void c_typecheck_baset::typecheck_return(codet &code)
 {
   if(code.operands().empty())
   {
-    if(follow(return_type).id()!=ID_empty &&
-       return_type.id()!=ID_constructor &&
-       return_type.id()!=ID_destructor)
+    if(
+      return_type.id() != ID_empty && return_type.id() != ID_constructor &&
+      return_type.id() != ID_destructor)
     {
       // gcc doesn't actually complain, it just warns!
       warning().source_location = code.source_location();
@@ -658,16 +658,16 @@ void c_typecheck_baset::typecheck_return(codet &code)
   {
     typecheck_expr(code.op0());
 
-    if(follow(return_type).id()==ID_empty)
+    if(return_type.id() == ID_empty)
     {
       // gcc doesn't actually complain, it just warns!
-      if(follow(code.op0().type()).id()!=ID_empty)
+      if(code.op0().type().id() != ID_empty)
       {
         warning().source_location=code.source_location();
 
         warning() << "function has return void ";
         warning() << "but a return statement returning ";
-        warning() << to_string(follow(code.op0().type()));
+        warning() << to_string(code.op0().type());
         warning() << eom;
 
         code.op0().make_typecast(return_type);

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -420,7 +420,7 @@ void c_typecheck_baset::typecheck_expr_main(exprt &expr)
     // This is one of the few places where it's detectable
     // that we are using "bool" for boolean operators instead
     // of "int". We convert for this reason.
-    if(follow(expr.op0().type()).id()==ID_bool)
+    if(expr.op0().type().id() == ID_bool)
       expr.op0().make_typecast(signed_int_type());
 
     irept::subt &generic_associations=
@@ -1104,7 +1104,7 @@ void c_typecheck_baset::typecheck_expr_typecast(exprt &expr)
     // This is one of the few places where it's detectable
     // that we are using "bool" for boolean operators instead
     // of "int". We convert for this reason.
-    if(follow(op.type()).id()==ID_bool)
+    if(op.type().id() == ID_bool)
       op.make_typecast(signed_int_type());
 
     // we need to find a member with the right type
@@ -1273,15 +1273,14 @@ void c_typecheck_baset::typecheck_expr_index(exprt &expr)
   // we might have to swap them
 
   {
-    const typet &array_full_type=follow(array_expr.type());
-    const typet &index_full_type=follow(index_expr.type());
+    const typet &array_type = array_expr.type();
+    const typet &index_type = index_expr.type();
 
-    if(array_full_type.id()!=ID_array &&
-       array_full_type.id()!=ID_pointer &&
-       array_full_type.id()!=ID_vector &&
-       (index_full_type.id()==ID_array ||
-        index_full_type.id()==ID_pointer ||
-        index_full_type.id()==ID_vector))
+    if(
+      array_type.id() != ID_array && array_type.id() != ID_pointer &&
+      array_type.id() != ID_vector &&
+      (index_type.id() == ID_array || index_type.id() == ID_pointer ||
+       index_type.id() == ID_vector))
       std::swap(array_expr, index_expr);
   }
 
@@ -1290,7 +1289,7 @@ void c_typecheck_baset::typecheck_expr_index(exprt &expr)
   // array_expr is a reference to one of expr.operands(), when that vector is
   // swapped below the reference is no longer valid. final_array_type exists
   // beyond that point so can't be a reference
-  const typet final_array_type = follow(array_expr.type());
+  const typet final_array_type = array_expr.type();
 
   if(final_array_type.id()==ID_array ||
      final_array_type.id()==ID_vector)
@@ -1329,7 +1328,7 @@ void c_typecheck_baset::adjust_float_rel(exprt &expr)
   // equality and disequality on float is not mathematical equality!
   assert(expr.operands().size()==2);
 
-  if(follow(expr.op0().type()).id()==ID_floatbv)
+  if(expr.op0().type().id() == ID_floatbv)
   {
     if(expr.id()==ID_equal)
       expr.id(ID_ieee_float_equal);
@@ -1347,8 +1346,7 @@ void c_typecheck_baset::typecheck_expr_rel(
   const typet o_type0=op0.type();
   const typet o_type1=op1.type();
 
-  if(follow(o_type0).id()==ID_vector ||
-     follow(o_type1).id()==ID_vector)
+  if(o_type0.id() == ID_vector || o_type1.id() == ID_vector)
   {
     typecheck_expr_rel_vector(expr);
     return;
@@ -1360,8 +1358,7 @@ void c_typecheck_baset::typecheck_expr_rel(
   {
     if(follow(o_type0)==follow(o_type1))
     {
-      const typet &final_type=follow(o_type0);
-      if(final_type.id() != ID_array)
+      if(o_type0.id() != ID_array)
       {
         adjust_float_rel(expr);
         return; // no promotion necessary
@@ -1449,12 +1446,12 @@ void c_typecheck_baset::typecheck_expr_rel_vector(
   exprt &op0=expr.op0();
   exprt &op1=expr.op1();
 
-  const typet o_type0=follow(op0.type());
-  const typet o_type1=follow(op1.type());
+  const typet o_type0 = op0.type();
+  const typet o_type1 = op1.type();
 
-  if(o_type0.id()!=ID_vector ||
-     o_type1.id()!=ID_vector ||
-     follow(o_type0.subtype())!=follow(o_type1.subtype()))
+  if(
+    o_type0.id() != ID_vector || o_type1.id() != ID_vector ||
+    o_type0.subtype() != o_type1.subtype())
   {
     error().source_location = expr.source_location();
     error() << "vector operator `" << expr.id()
@@ -1478,17 +1475,17 @@ void c_typecheck_baset::typecheck_expr_ptrmember(exprt &expr)
     throw 0;
   }
 
-  const typet &final_op0_type=follow(expr.op0().type());
+  const typet &op0_type = expr.op0().type();
 
-  if(final_op0_type.id()==ID_array)
+  if(op0_type.id() == ID_array)
   {
     // a->f is the same as a[0].f
     exprt zero=from_integer(0, index_type());
-    index_exprt index_expr(expr.op0(), zero, final_op0_type.subtype());
+    index_exprt index_expr(expr.op0(), zero, op0_type.subtype());
     index_expr.set(ID_C_lvalue, true);
     expr.op0().swap(index_expr);
   }
-  else if(final_op0_type.id()==ID_pointer)
+  else if(op0_type.id() == ID_pointer)
   {
     // turn x->y into (*x).y
     dereference_exprt deref_expr(expr.op0());
@@ -1667,7 +1664,7 @@ void c_typecheck_baset::typecheck_expr_trinary(if_exprt &expr)
     return;
   }
 
-  if(follow(operands[1].type())==follow(operands[2].type()))
+  if(operands[1].type() == operands[2].type())
   {
     expr.type()=operands[1].type();
 
@@ -1808,7 +1805,7 @@ void c_typecheck_baset::typecheck_expr_dereference(exprt &expr)
 
   exprt &op=expr.op0();
 
-  const typet op_type=follow(op.type());
+  const typet op_type = op.type();
 
   if(op_type.id()==ID_array)
   {
@@ -1868,7 +1865,6 @@ void c_typecheck_baset::typecheck_expr_side_effect(side_effect_exprt &expr)
 
     const exprt &op0=expr.op0();
     const typet &type0=op0.type();
-    const typet &final_type0=follow(type0);
 
     if(!op0.get_bool(ID_C_lvalue))
     {
@@ -1886,9 +1882,9 @@ void c_typecheck_baset::typecheck_expr_side_effect(side_effect_exprt &expr)
       throw 0;
     }
 
-    if(final_type0.id()==ID_c_enum_tag)
+    if(type0.id() == ID_c_enum_tag)
     {
-      if(follow_tag(to_c_enum_tag_type(final_type0)).is_incomplete())
+      if(follow_tag(to_c_enum_tag_type(type0)).is_incomplete())
       {
         error().source_location = expr.source_location();
         error() << "operator `" << statement
@@ -1899,18 +1895,18 @@ void c_typecheck_baset::typecheck_expr_side_effect(side_effect_exprt &expr)
       else
         expr.type()=type0;
     }
-    else if(final_type0.id()==ID_c_bit_field)
+    else if(type0.id() == ID_c_bit_field)
     {
       // promote to underlying type
-      typet underlying_type=to_c_bit_field_type(final_type0).subtype();
+      typet underlying_type = to_c_bit_field_type(type0).subtype();
       expr.op0().make_typecast(underlying_type);
       expr.type()=underlying_type;
     }
-    else if(is_numeric_type(final_type0))
+    else if(is_numeric_type(type0))
     {
       expr.type()=type0;
     }
-    else if(final_type0.id()==ID_pointer)
+    else if(type0.id() == ID_pointer)
     {
       expr.type()=type0;
       typecheck_arithmetic_pointer(op0);

--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -32,7 +32,7 @@ void c_typecheck_baset::do_initializer(
 
   if(type.id()==ID_array)
   {
-    const typet &result_type=follow(result.type());
+    const typet &result_type = result.type();
     DATA_INVARIANT(result_type.id()==ID_array &&
                    to_array_type(result_type).size().is_not_nil(),
                    "any array must have a size");
@@ -232,8 +232,9 @@ void c_typecheck_baset::do_initializer(symbolt &symbol)
       do_initializer(symbol.value, symbol.type, true);
 
       // need to adjust size?
-      if(follow(symbol.type).id()==ID_array &&
-         to_array_type(follow(symbol.type)).size().is_nil())
+      if(
+        symbol.type.id() == ID_array &&
+        to_array_type(symbol.type).size().is_nil())
         symbol.type=symbol.value.type();
     }
   }
@@ -254,8 +255,9 @@ void c_typecheck_baset::do_initializer(symbolt &symbol)
       do_initializer(symbol.value, symbol.type, true);
 
       // need to adjust size?
-      if(follow(symbol.type).id()==ID_array &&
-         to_array_type(follow(symbol.type)).size().is_nil())
+      if(
+        symbol.type.id() == ID_array &&
+        to_array_type(symbol.type).size().is_nil())
         symbol.type=symbol.value.type();
     }
   }
@@ -564,9 +566,10 @@ exprt::operandst::const_iterator c_typecheck_baset::do_designated_initializer(
       // We stop for initializers that are string-constants,
       // which are like arrays. We only do so if we are to
       // initialize an array of scalars.
-      if(full_type.id()==ID_array &&
-         (follow(full_type.subtype()).id()==ID_signedbv ||
-          follow(full_type.subtype()).id()==ID_unsignedbv))
+      if(
+        full_type.id() == ID_array &&
+        (full_type.subtype().id() == ID_signedbv ||
+         full_type.subtype().id() == ID_unsignedbv))
       {
         *dest=do_initializer_rec(value, type, force_constant);
         return ++init_it; // done

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -475,8 +475,7 @@ void c_typecheck_baset::typecheck_code_type(code_typet &type)
 
     parameter_map.clear();
 
-    if(parameters.size()==1 &&
-       follow(parameters[0].type()).id()==ID_empty)
+    if(parameters.size() == 1 && parameters[0].type().id() == ID_empty)
     {
       // if we just have one parameter of type void, remove it
       parameters.clear();
@@ -489,7 +488,7 @@ void c_typecheck_baset::typecheck_code_type(code_typet &type)
   // "A function declarator shall not specify a return type that
   // is a function type or an array type."
 
-  const typet &decl_return_type = follow(type.return_type());
+  const typet &decl_return_type = type.return_type();
 
   if(decl_return_type.id() == ID_array)
   {
@@ -1403,7 +1402,7 @@ void c_typecheck_baset::typecheck_c_bit_field_type(c_bit_field_typet &type)
     type.remove(ID_size);
   }
 
-  const typet &subtype=follow(type.subtype());
+  const typet &subtype = type.subtype();
 
   std::size_t sub_width=0;
 


### PR DESCRIPTION
follow() is no longer needed for typedefs; it is only needed for
struct/union tag types.  This commit removes unnecessary applications of
follow().

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
