### PR TITLE
COMPILING.md: Amazon Linux needs tar

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -31,7 +31,7 @@ We assume that you have a Debian/Ubuntu or Red Hat-like distribution.
 
    On Amazon Linux and similar distributions, do as root:
    ```
-   yum install gcc72-c++ flex bison perl-libwww-perl patch
+   yum install gcc72-c++ flex bison perl-libwww-perl patch tar
    ```
 
    To compile JBMC, you additionally need the JDK and Maven 3.


### PR DESCRIPTION
The docker images for Amazon Linux do not have tar by default, but tar is
needed to unpack the Minisat archive.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
