### PR TITLE
Use BDDs for encoding symex guards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -201,7 +201,7 @@ jobs:
         - cmake --build build -- -j4
       script: (cd build; bin/unit "[core][irept]")
 
-    # cmake build using g++-7, enable CMAKE_USE_CUDD
+    # cmake build using g++-7, enable CMAKE_USE_CUDD and BDD_GUARDS
     - stage: Test different OS/CXX/Flags
       os: linux
       sudo: false
@@ -223,7 +223,7 @@ jobs:
       install:
         - ccache -z
         - ccache --max-size=1G
-        - cmake -H. -Bbuild '-DCMAKE_BUILD_TYPE=Release'  '-DCMAKE_CXX_COMPILER=/usr/bin/g++-7' '-DCMAKE_USE_CUDD=true'
+        - cmake -H. -Bbuild '-DCMAKE_BUILD_TYPE=Release'  '-DCMAKE_CXX_COMPILER=/usr/bin/g++-7' '-DCMAKE_USE_CUDD=true' -DCMAKE_CXX_FLAGS="-DBDD_GUARDS"
         - git submodule update --init --recursive
         - cmake --build build -- -j4
       script: (cd build; ctest -V -L CORE -j2)

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -310,3 +310,22 @@ If compiling with cmake:
    ```
    cmake --build build
    ```
+
+## Use BDDs for guards
+
+There are two implementation for symex guards. The default one uses the
+internal representation of expression. The other one uses BDDs and
+though experimental, it is expected to have better performance,
+in particular when used in conjunction with CUDD.
+
+To use the BDD implementation of guards, add the `BDD_GUARDS`
+compilation flag:
+  * If compiling with make:
+    ```
+    make -C src CXXFLAGS="-O2 -DBDD_GUARDS"
+    ```
+  * If compiling with CMake:
+    ```
+    cmake -H. -Bbuild -DCMAKE_CXX_FLAGS="-DBDD_GUARDS"
+    ```
+    and then `cmake --build build`

--- a/jbmc/regression/jbmc/CMakeLists.txt
+++ b/jbmc/regression/jbmc/CMakeLists.txt
@@ -2,9 +2,18 @@ add_test_pl_tests(
     "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation"
 )
 
-add_test_pl_profile(
-    "jbmc-symex-driven-lazy-loading"
-    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading"
-    "-C;-X;symex-driven-lazy-loading-expected-failure;-s;symex-driven-loading"
-    "CORE"
-)
+if(DEFINED BDD_GUARDS)
+    add_test_pl_profile(
+            "jbmc-symex-driven-lazy-loading"
+            "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading"
+            "-C;-X;symex-driven-lazy-loading-expected-failure;-s;symex-driven-loading"
+            "CORE"
+    )
+else()
+    add_test_pl_profile(
+            "jbmc-symex-driven-lazy-loading"
+            "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading"
+            "-C;-X;symex-driven-lazy-loading-expected-failure;-X;bdd-expected-timeout;-s;symex-driven-loading"
+            "CORE"
+    )
+endif()

--- a/jbmc/regression/jbmc/Makefile
+++ b/jbmc/regression/jbmc/Makefile
@@ -4,11 +4,19 @@ include ../../src/config.inc
 
 test:
 	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation"
+ifeq ($(filter %DBDD_GUARDS, $(CXXFLAGS)),)
 	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+else
+	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -X bdd-expected-timeout -s symex-driven-loading
+endif
 
 tests.log: ../$(CPROVER_DIR)/regression/test.pl
 	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation"
+ifeq ($(filter %DBDD_GUARDS, $(CXXFLAGS)),)
 	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+else
+	@../$(CPROVER_DIR)/regression/test.pl -e -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -X bdd-expected-timeout -s symex-driven-loading
+endif
 
 show:
 	@for dir in *; do \

--- a/jbmc/regression/jbmc/class-literals/test.desc
+++ b/jbmc/regression/jbmc/class-literals/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE bdd-expected-timeout
 Test.class
 --function Test.main
 ^EXIT=0$
@@ -6,3 +6,8 @@ Test.class
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
+--
+This test is deactivated for the build with BDDs because it takes more
+than 10 minutes for the test to complete.
+This is due to the size of the BDD representing the guards growing more than
+they do when represented as exprt.

--- a/src/analyses/CMakeLists.txt
+++ b/src/analyses/CMakeLists.txt
@@ -3,4 +3,8 @@ add_library(analyses ${sources})
 
 generic_includes(analyses)
 
-target_link_libraries(analyses util pointer-analysis)
+if(CMAKE_USE_CUDD)
+    target_include_directories(analyses PUBLIC ${CUDD_INCLUDE}/cudd/)
+endif()
+
+target_link_libraries(analyses util pointer-analysis solvers)

--- a/src/analyses/Makefile
+++ b/src/analyses/Makefile
@@ -13,6 +13,7 @@ SRC = ai.cpp \
       goto_check.cpp \
       goto_rw.cpp \
       guard.cpp \
+      guard_bdd.cpp \
       interval_analysis.cpp \
       interval_domain.cpp \
       invariant_propagation.cpp \

--- a/src/analyses/Makefile
+++ b/src/analyses/Makefile
@@ -12,8 +12,8 @@ SRC = ai.cpp \
       global_may_alias.cpp \
       goto_check.cpp \
       goto_rw.cpp \
-      guard.cpp \
       guard_bdd.cpp \
+      guard_expr.cpp \
       interval_analysis.cpp \
       interval_domain.cpp \
       invariant_propagation.cpp \

--- a/src/analyses/Makefile
+++ b/src/analyses/Makefile
@@ -12,6 +12,7 @@ SRC = ai.cpp \
       global_may_alias.cpp \
       goto_check.cpp \
       goto_rw.cpp \
+      guard.cpp \
       interval_analysis.cpp \
       interval_domain.cpp \
       invariant_propagation.cpp \

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -84,6 +84,7 @@ protected:
   const namespacet &ns;
   std::unique_ptr<local_bitvector_analysist> local_bitvector_analysis;
   goto_programt::const_targett current_target;
+  guard_managert guard_manager;
 
   void check_rec(
     const exprt &expr,
@@ -1650,7 +1651,7 @@ void goto_checkt::check_rec(const exprt &expr, guardt &guard, bool address)
 
 void goto_checkt::check(const exprt &expr)
 {
-  guardt guard{true_exprt{}};
+  guardt guard{true_exprt{}, guard_manager};
   check_rec(expr, guard, false);
 }
 
@@ -1782,7 +1783,7 @@ void goto_checkt::goto_check(
             "pointer dereference",
             i.source_location,
             pointer,
-            guardt(true_exprt()));
+            guardt(true_exprt(), guard_manager));
         }
       }
 
@@ -1820,7 +1821,7 @@ void goto_checkt::goto_check(
           "pointer dereference",
           i.source_location,
           pointer,
-          guardt(true_exprt()));
+          guardt(true_exprt(), guard_manager));
       }
 
       // this has no successor
@@ -1897,7 +1898,7 @@ void goto_checkt::goto_check(
           "memory-leak",
           source_location,
           eq,
-          guardt(true_exprt()));
+          guardt(true_exprt(), guard_manager));
       }
     }
 

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -20,7 +20,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/cprover_prefix.h>
 #include <util/expr_util.h>
 #include <util/find_symbols.h>
-#include <util/guard.h>
 #include <util/ieee_float.h>
 #include <util/invariant.h>
 #include <util/make_unique.h>
@@ -36,6 +35,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <goto-programs/remove_skip.h>
 
+#include "guard.h"
 #include "local_bitvector_analysis.h"
 
 class goto_checkt

--- a/src/analyses/goto_rw.h
+++ b/src/analyses/goto_rw.h
@@ -17,7 +17,7 @@ Date: April 2010
 #include <map>
 #include <memory> // unique_ptr
 
-#include <util/guard.h>
+#include "guard.h"
 
 #include <goto-programs/goto_model.h>
 

--- a/src/analyses/goto_rw.h
+++ b/src/analyses/goto_rw.h
@@ -352,8 +352,11 @@ class rw_guarded_range_set_value_sett:public rw_range_set_value_sett
 public:
   rw_guarded_range_set_value_sett(
     const namespacet &_ns,
-    value_setst &_value_sets):
-    rw_range_set_value_sett(_ns, _value_sets)
+    value_setst &_value_sets,
+    guard_managert &guard_manager)
+    : rw_range_set_value_sett(_ns, _value_sets),
+      guard_manager(guard_manager),
+      guard(true_exprt(), guard_manager)
   {
   }
 
@@ -370,7 +373,7 @@ public:
     get_modet mode,
     const exprt &expr) override
   {
-    guard = guardt(true_exprt());
+    guard = guardt(true_exprt(), guard_manager);
 
     rw_range_set_value_sett::get_objects_rec(_function, _target, mode, expr);
   }
@@ -384,7 +387,8 @@ public:
   }
 
 protected:
-  guardt guard = guardt(true_exprt());
+  guard_managert &guard_manager;
+  guardt guard;
 
   using rw_range_sett::get_objects_rec;
 

--- a/src/analyses/guard.cpp
+++ b/src/analyses/guard.cpp
@@ -13,10 +13,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <ostream>
 
-#include "expr_util.h"
-#include "invariant.h"
-#include "simplify_utils.h"
-#include "std_expr.h"
+#include <util/expr_util.h>
+#include <util/invariant.h>
+#include <util/simplify_utils.h>
+#include <util/std_expr.h>
 
 void guardt::guard_expr(exprt &dest) const
 {

--- a/src/analyses/guard.h
+++ b/src/analyses/guard.h
@@ -16,11 +16,26 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/std_expr.h>
 
+/// This is unused by this implementation of guards, but can be used by other
+/// implementations of the same interface.
+struct guard_managert
+{
+};
+
 class guardt
 {
 public:
-  explicit guardt(const exprt &e) : expr(e)
+  /// Construct a BDD from an expression
+  /// The \c guard_managert parameter is not used, but we keep it for uniformity
+  /// with other implementations of guards which may use it.
+  explicit guardt(const exprt &e, guard_managert &) : expr(e)
   {
+  }
+
+  guardt &operator=(const guardt &other)
+  {
+    expr = other.expr;
+    return *this;
   }
 
   void add(const exprt &expr);

--- a/src/analyses/guard.h
+++ b/src/analyses/guard.h
@@ -14,4 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "guard_expr.h"
 
+using guard_managert = guard_expr_managert;
+using guardt = guard_exprt;
+
 #endif // CPROVER_ANALYSES_GUARD_H

--- a/src/analyses/guard.h
+++ b/src/analyses/guard.h
@@ -12,9 +12,20 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_ANALYSES_GUARD_H
 #define CPROVER_ANALYSES_GUARD_H
 
+#ifdef BDD_GUARDS
+
+#include "guard_bdd.h"
+
+using guard_managert = bdd_exprt;
+using guardt = guard_bddt;
+
+#else
+
 #include "guard_expr.h"
 
 using guard_managert = guard_expr_managert;
 using guardt = guard_exprt;
+
+#endif // BDD_GUARDS
 
 #endif // CPROVER_ANALYSES_GUARD_H

--- a/src/analyses/guard.h
+++ b/src/analyses/guard.h
@@ -9,12 +9,12 @@ Author: Daniel Kroening, kroening@kroening.com
 /// \file
 /// Guard Data Structure
 
-#ifndef CPROVER_UTIL_GUARD_H
-#define CPROVER_UTIL_GUARD_H
+#ifndef CPROVER_ANALYSES_GUARD_H
+#define CPROVER_ANALYSES_GUARD_H
 
 #include <iosfwd>
 
-#include "std_expr.h"
+#include <util/std_expr.h>
 
 class guardt
 {
@@ -54,4 +54,4 @@ private:
   exprt expr;
 };
 
-#endif // CPROVER_UTIL_GUARD_H
+#endif // CPROVER_ANALYSES_GUARD_H

--- a/src/analyses/guard.h
+++ b/src/analyses/guard.h
@@ -12,61 +12,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_ANALYSES_GUARD_H
 #define CPROVER_ANALYSES_GUARD_H
 
-#include <iosfwd>
-
-#include <util/std_expr.h>
-
-/// This is unused by this implementation of guards, but can be used by other
-/// implementations of the same interface.
-struct guard_managert
-{
-};
-
-class guardt
-{
-public:
-  /// Construct a BDD from an expression
-  /// The \c guard_managert parameter is not used, but we keep it for uniformity
-  /// with other implementations of guards which may use it.
-  explicit guardt(const exprt &e, guard_managert &) : expr(e)
-  {
-  }
-
-  guardt &operator=(const guardt &other)
-  {
-    expr = other.expr;
-    return *this;
-  }
-
-  void add(const exprt &expr);
-
-  void append(const guardt &guard)
-  {
-    add(guard.as_expr());
-  }
-
-  exprt as_expr() const
-  {
-    return expr;
-  }
-
-  void guard_expr(exprt &dest) const;
-
-  bool is_true() const
-  {
-    return expr.is_true();
-  }
-
-  bool is_false() const
-  {
-    return expr.is_false();
-  }
-
-  friend guardt &operator-=(guardt &g1, const guardt &g2);
-  friend guardt &operator|=(guardt &g1, const guardt &g2);
-
-private:
-  exprt expr;
-};
+#include "guard_expr.h"
 
 #endif // CPROVER_ANALYSES_GUARD_H

--- a/src/analyses/guard_bdd.cpp
+++ b/src/analyses/guard_bdd.cpp
@@ -44,24 +44,22 @@ guard_bddt &guard_bddt::operator=(guard_bddt &&other)
   return *this;
 }
 
-void guard_bddt::guard_expr(exprt &dest) const
+exprt guard_bddt::guard_expr(exprt expr) const
 {
   if(is_true())
   {
     // do nothing
+    return expr;
   }
   else
   {
-    if(dest.is_false())
+    if(expr.is_false())
     {
-      dest = boolean_negate(as_expr());
+      return boolean_negate(as_expr());
     }
     else
     {
-      implies_exprt tmp;
-      tmp.op0() = as_expr();
-      tmp.op1().swap(dest);
-      dest.swap(tmp);
+      return implies_exprt{as_expr(), expr};
     }
   }
 }

--- a/src/analyses/guard_bdd.cpp
+++ b/src/analyses/guard_bdd.cpp
@@ -1,0 +1,96 @@
+/*******************************************************************\
+
+Module: Guard Data Structure
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+/// \file
+/// Implementation of guards using BDDs
+
+#include "guard_bdd.h"
+
+#include <algorithm>
+#include <ostream>
+#include <set>
+
+#include <solvers/bdd/bdd.h>
+#include <solvers/prop/bdd_expr.h>
+#include <util/expr_util.h>
+#include <util/invariant.h>
+#include <util/make_unique.h>
+#include <util/namespace.h>
+#include <util/simplify_utils.h>
+#include <util/std_expr.h>
+#include <util/symbol_table.h>
+
+guard_bddt::guard_bddt(const exprt &e, bdd_exprt &manager)
+  : manager(manager), bdd(manager.from_expr(e))
+{
+}
+
+guard_bddt &guard_bddt::operator=(const guard_bddt &other)
+{
+  PRECONDITION(&manager == &other.manager);
+  bdd = other.bdd;
+  return *this;
+}
+
+guard_bddt &guard_bddt::operator=(guard_bddt &&other)
+{
+  PRECONDITION(&manager == &other.manager);
+  std::swap(bdd, other.bdd);
+  return *this;
+}
+
+void guard_bddt::guard_expr(exprt &dest) const
+{
+  if(is_true())
+  {
+    // do nothing
+  }
+  else
+  {
+    if(dest.is_false())
+    {
+      dest = boolean_negate(as_expr());
+    }
+    else
+    {
+      implies_exprt tmp;
+      tmp.op0() = as_expr();
+      tmp.op1().swap(dest);
+      dest.swap(tmp);
+    }
+  }
+}
+
+guard_bddt &guard_bddt::append(const guard_bddt &guard)
+{
+  bdd = bdd.bdd_and(guard.bdd);
+  return *this;
+}
+
+guard_bddt &guard_bddt::add(const exprt &expr)
+{
+  bdd = bdd.bdd_and(manager.from_expr(expr));
+  return *this;
+}
+
+guard_bddt &operator-=(guard_bddt &g1, const guard_bddt &g2)
+{
+  g1.bdd = g1.bdd.constrain(g2.bdd.bdd_or(g1.bdd));
+  return g1;
+}
+
+guard_bddt &operator|=(guard_bddt &g1, const guard_bddt &g2)
+{
+  g1.bdd = g1.bdd.bdd_or(g2.bdd);
+  return g1;
+}
+
+exprt guard_bddt::as_expr() const
+{
+  return manager.as_expr(bdd);
+}

--- a/src/analyses/guard_bdd.h
+++ b/src/analyses/guard_bdd.h
@@ -35,6 +35,11 @@ public:
   guard_bddt &append(const guard_bddt &guard);
   exprt as_expr() const;
 
+  /// BDDs are always in a simplified form and thus no further simplification
+  /// is required after calls to \ref as_expr().
+  /// This can vary according to the guard implementation.
+  static constexpr bool is_always_simplified = true;
+
   /// Assign dest to `guard => dest` unless guard or dest are trivial.
   void guard_expr(exprt &dest) const;
 

--- a/src/analyses/guard_bdd.h
+++ b/src/analyses/guard_bdd.h
@@ -1,0 +1,72 @@
+/*******************************************************************\
+
+Module: Guard Data Structure
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+/// \file
+/// Guard Data Structure
+/// Implementation using BDDs
+
+#ifndef CPROVER_ANALYSES_GUARD_BDD_H
+#define CPROVER_ANALYSES_GUARD_BDD_H
+
+#include <iosfwd>
+#include <memory>
+
+#include <solvers/bdd/bdd.h>
+#include <solvers/prop/bdd_expr.h>
+#include <util/make_unique.h>
+#include <util/std_expr.h>
+
+class guard_bddt
+{
+public:
+  guard_bddt(const exprt &e, bdd_exprt &manager);
+  guard_bddt(const guard_bddt &other) : manager(other.manager), bdd(other.bdd)
+  {
+  }
+
+  guard_bddt &operator=(const guard_bddt &other);
+  guard_bddt &operator=(guard_bddt &&other);
+  guard_bddt &add(const exprt &expr);
+  guard_bddt &append(const guard_bddt &guard);
+  exprt as_expr() const;
+
+  /// Assign dest to `guard => dest` unless guard or dest are trivial.
+  void guard_expr(exprt &dest) const;
+
+  bool is_true() const
+  {
+    return bdd.is_true();
+  }
+
+  bool is_false() const
+  {
+    return bdd.is_false();
+  }
+
+  /// Transforms \p g1 into \c g1' such that `g1' & g2 => g1 => g1'`
+  /// and returns a reference to g1.
+  friend guard_bddt &operator-=(guard_bddt &g1, const guard_bddt &g2);
+
+  friend guard_bddt &operator|=(guard_bddt &g1, const guard_bddt &g2);
+
+  guard_bddt operator!() const
+  {
+    return guard_bddt(manager, bdd.bdd_not());
+  }
+
+private:
+  bdd_exprt &manager;
+  bddt bdd;
+
+  guard_bddt(bdd_exprt &manager, bddt bdd)
+    : manager(manager), bdd(std::move(bdd))
+  {
+  }
+};
+
+#endif // CPROVER_ANALYSES_GUARD_BDD_H

--- a/src/analyses/guard_bdd.h
+++ b/src/analyses/guard_bdd.h
@@ -40,8 +40,9 @@ public:
   /// This can vary according to the guard implementation.
   static constexpr bool is_always_simplified = true;
 
-  /// Assign dest to `guard => dest` unless guard or dest are trivial.
-  void guard_expr(exprt &dest) const;
+  /// Return `guard => dest` or a simplified variant thereof if either guard or
+  /// dest are trivial.
+  exprt guard_expr(exprt expr) const;
 
   bool is_true() const
   {

--- a/src/analyses/guard_expr.cpp
+++ b/src/analyses/guard_expr.cpp
@@ -18,7 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/simplify_utils.h>
 #include <util/std_expr.h>
 
-void guardt::guard_expr(exprt &dest) const
+void guard_exprt::guard_expr(exprt &dest) const
 {
   if(is_true())
   {
@@ -38,7 +38,7 @@ void guardt::guard_expr(exprt &dest) const
   }
 }
 
-void guardt::add(const exprt &expr)
+void guard_exprt::add(const exprt &expr)
 {
   PRECONDITION(expr.type().id() == ID_bool);
 
@@ -64,7 +64,7 @@ void guardt::add(const exprt &expr)
     op.push_back(expr);
 }
 
-guardt &operator-=(guardt &g1, const guardt &g2)
+guard_exprt &operator-=(guard_exprt &g1, const guard_exprt &g2)
 {
   if(g1.expr.id() != ID_and || g2.expr.id() != ID_and)
     return g1;
@@ -91,7 +91,7 @@ guardt &operator-=(guardt &g1, const guardt &g2)
   return g1;
 }
 
-guardt &operator|=(guardt &g1, const guardt &g2)
+guard_exprt &operator|=(guard_exprt &g1, const guard_exprt &g2)
 {
   if(g2.is_false() || g1.is_true())
     return g1;

--- a/src/analyses/guard_expr.cpp
+++ b/src/analyses/guard_expr.cpp
@@ -9,7 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 /// \file
 /// Symbolic Execution
 
-#include "guard.h"
+#include "guard_expr.h"
 
 #include <ostream>
 

--- a/src/analyses/guard_expr.cpp
+++ b/src/analyses/guard_expr.cpp
@@ -18,22 +18,22 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/simplify_utils.h>
 #include <util/std_expr.h>
 
-void guard_exprt::guard_expr(exprt &dest) const
+exprt guard_exprt::guard_expr(exprt expr) const
 {
   if(is_true())
   {
     // do nothing
+    return expr;
   }
   else
   {
-    if(dest.is_false())
+    if(expr.is_false())
     {
-      dest = boolean_negate(as_expr());
+      return boolean_negate(as_expr());
     }
     else
     {
-      implies_exprt tmp(as_expr(), dest);
-      dest.swap(tmp);
+      return implies_exprt{as_expr(), expr};
     }
   }
 }

--- a/src/analyses/guard_expr.h
+++ b/src/analyses/guard_expr.h
@@ -1,0 +1,72 @@
+/*******************************************************************\
+
+Module: Guard Data Structure
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+/// \file
+/// Guard Data Structure
+
+#ifndef CPROVER_ANALYSES_GUARD_EXPR_H
+#define CPROVER_ANALYSES_GUARD_EXPR_H
+
+#include <iosfwd>
+
+#include <util/std_expr.h>
+
+/// This is unused by this implementation of guards, but can be used by other
+/// implementations of the same interface.
+struct guard_managert
+{
+};
+
+class guardt
+{
+public:
+  /// Construct a BDD from an expression
+  /// The \c guard_managert parameter is not used, but we keep it for uniformity
+  /// with other implementations of guards which may use it.
+  explicit guardt(const exprt &e, guard_managert &) : expr(e)
+  {
+  }
+
+  guardt &operator=(const guardt &other)
+  {
+    expr = other.expr;
+    return *this;
+  }
+
+  void add(const exprt &expr);
+
+  void append(const guardt &guard)
+  {
+    add(guard.as_expr());
+  }
+
+  exprt as_expr() const
+  {
+    return expr;
+  }
+
+  void guard_expr(exprt &dest) const;
+
+  bool is_true() const
+  {
+    return expr.is_true();
+  }
+
+  bool is_false() const
+  {
+    return expr.is_false();
+  }
+
+  friend guardt &operator-=(guardt &g1, const guardt &g2);
+  friend guardt &operator|=(guardt &g1, const guardt &g2);
+
+private:
+  exprt expr;
+};
+
+#endif // CPROVER_ANALYSES_GUARD_EXPR_H

--- a/src/analyses/guard_expr.h
+++ b/src/analyses/guard_expr.h
@@ -50,6 +50,11 @@ public:
     return expr;
   }
 
+  /// The result of \ref as_expr is not always in a simplified form
+  /// and may requires some simplification.
+  /// This can vary according to the guard implementation.
+  static constexpr bool is_always_simplified = false;
+
   void guard_expr(exprt &dest) const;
 
   bool is_true() const

--- a/src/analyses/guard_expr.h
+++ b/src/analyses/guard_expr.h
@@ -18,21 +18,21 @@ Author: Daniel Kroening, kroening@kroening.com
 
 /// This is unused by this implementation of guards, but can be used by other
 /// implementations of the same interface.
-struct guard_managert
+struct guard_expr_managert
 {
 };
 
-class guardt
+class guard_exprt
 {
 public:
   /// Construct a BDD from an expression
   /// The \c guard_managert parameter is not used, but we keep it for uniformity
   /// with other implementations of guards which may use it.
-  explicit guardt(const exprt &e, guard_managert &) : expr(e)
+  explicit guard_exprt(const exprt &e, guard_expr_managert &) : expr(e)
   {
   }
 
-  guardt &operator=(const guardt &other)
+  guard_exprt &operator=(const guard_exprt &other)
   {
     expr = other.expr;
     return *this;
@@ -40,7 +40,7 @@ public:
 
   void add(const exprt &expr);
 
-  void append(const guardt &guard)
+  void append(const guard_exprt &guard)
   {
     add(guard.as_expr());
   }
@@ -62,8 +62,8 @@ public:
     return expr.is_false();
   }
 
-  friend guardt &operator-=(guardt &g1, const guardt &g2);
-  friend guardt &operator|=(guardt &g1, const guardt &g2);
+  friend guard_exprt &operator-=(guard_exprt &g1, const guard_exprt &g2);
+  friend guard_exprt &operator|=(guard_exprt &g1, const guard_exprt &g2);
 
 private:
   exprt expr;

--- a/src/analyses/guard_expr.h
+++ b/src/analyses/guard_expr.h
@@ -55,7 +55,9 @@ public:
   /// This can vary according to the guard implementation.
   static constexpr bool is_always_simplified = false;
 
-  void guard_expr(exprt &dest) const;
+  /// Return `guard => dest` or a simplified variant thereof if either guard or
+  /// dest are trivial.
+  exprt guard_expr(exprt expr) const;
 
   bool is_true() const
   {

--- a/src/analyses/module_dependencies.txt
+++ b/src/analyses/module_dependencies.txt
@@ -2,4 +2,6 @@ analyses
 goto-programs
 langapi # should go away
 pointer-analysis
+solvers/bdd
+solvers/prop
 util

--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -257,6 +257,7 @@ int bmct::do_language_agnostic_bmc(
   namespacet ns(symbol_table);
   messaget message(ui);
   std::unique_ptr<path_storaget> worklist;
+  guard_managert guard_manager;
   std::string strategy = opts.get_option("exploration-strategy");
   worklist = get_path_strategy(strategy);
   try
@@ -268,7 +269,14 @@ int bmct::do_language_agnostic_bmc(
       std::unique_ptr<solver_factoryt::solvert> cbmc_solver =
         solvers.get_solver();
       prop_convt &pc = cbmc_solver->prop_conv();
-      bmct bmc(opts, symbol_table, ui, pc, *worklist, callback_after_symex);
+      bmct bmc(
+        opts,
+        symbol_table,
+        ui,
+        pc,
+        *worklist,
+        callback_after_symex,
+        guard_manager);
       if(driver_configure_bmc)
         driver_configure_bmc(bmc, symbol_table);
       tmp_result = bmc.run(model);
@@ -319,6 +327,7 @@ int bmct::do_language_agnostic_bmc(
         resume.equation,
         resume.state,
         *worklist,
+        guard_manager,
         callback_after_symex);
       if(driver_configure_bmc)
         driver_configure_bmc(pe, symbol_table);

--- a/src/cbmc/bmc.h
+++ b/src/cbmc/bmc.h
@@ -70,19 +70,22 @@ public:
     ui_message_handlert &_message_handler,
     prop_convt &_prop_conv,
     path_storaget &_path_storage,
-    std::function<bool(void)> callback_after_symex)
+    std::function<bool(void)> callback_after_symex,
+    guard_managert &guard_manager)
     : safety_checkert(ns, _message_handler),
       options(_options),
       outer_symbol_table(outer_symbol_table),
       ns(outer_symbol_table, symex_symbol_table),
       equation(_message_handler),
+      guard_manager(guard_manager),
       path_storage(_path_storage),
       symex(
         _message_handler,
         outer_symbol_table,
         equation,
         options,
-        path_storage),
+        path_storage,
+        guard_manager),
       prop_conv(_prop_conv),
       ui_message_handler(_message_handler),
       driver_callback_after_symex(callback_after_symex)
@@ -140,19 +143,22 @@ protected:
     prop_convt &_prop_conv,
     symex_target_equationt &_equation,
     path_storaget &_path_storage,
-    std::function<bool(void)> callback_after_symex)
+    std::function<bool(void)> callback_after_symex,
+    guard_managert &guard_manager)
     : safety_checkert(ns, _message_handler),
       options(_options),
       outer_symbol_table(outer_symbol_table),
       ns(outer_symbol_table),
       equation(_equation),
+      guard_manager(guard_manager),
       path_storage(_path_storage),
       symex(
         _message_handler,
         outer_symbol_table,
         equation,
         options,
-        path_storage),
+        path_storage,
+        guard_manager),
       prop_conv(_prop_conv),
       ui_message_handler(_message_handler),
       driver_callback_after_symex(callback_after_symex)
@@ -170,6 +176,7 @@ protected:
   symbol_tablet symex_symbol_table;
   namespacet ns;
   symex_target_equationt equation;
+  guard_managert &guard_manager;
   path_storaget &path_storage;
   symex_bmct symex;
   prop_convt &prop_conv;
@@ -231,6 +238,7 @@ public:
     symex_target_equationt &saved_equation,
     const goto_symex_statet &saved_state,
     path_storaget &path_storage,
+    guard_managert &guard_manager,
     std::function<bool(void)> callback_after_symex)
     : bmct(
         _options,
@@ -239,7 +247,8 @@ public:
         _prop_conv,
         saved_equation,
         path_storage,
-        callback_after_symex),
+        callback_after_symex,
+        guard_manager),
       saved_state(saved_state)
   {
   }

--- a/src/goto-checker/multi_path_symex_only_checker.cpp
+++ b/src/goto-checker/multi_path_symex_only_checker.cpp
@@ -32,7 +32,8 @@ multi_path_symex_only_checkert::multi_path_symex_only_checkert(
       goto_model.get_symbol_table(),
       equation,
       options,
-      path_storage)
+      path_storage,
+      guard_manager)
 {
   setup_symex(symex, ns, options, ui_message_handler);
 }

--- a/src/goto-checker/multi_path_symex_only_checker.h
+++ b/src/goto-checker/multi_path_symex_only_checker.h
@@ -31,6 +31,7 @@ protected:
   symbol_tablet symex_symbol_table;
   namespacet ns;
   symex_target_equationt equation;
+  guard_managert guard_manager;
   path_fifot path_storage; // should go away
   symex_bmct symex;
 };

--- a/src/goto-checker/single_path_symex_checker.cpp
+++ b/src/goto-checker/single_path_symex_checker.cpp
@@ -55,7 +55,8 @@ operator()(propertiest &properties)
       goto_model.get_symbol_table(),
       equation,
       options,
-      *worklist);
+      *worklist,
+      guard_manager);
     setup_symex(symex);
 
     symex.initialize_path_storage_from_entry_point_of(
@@ -70,7 +71,8 @@ operator()(propertiest &properties)
       goto_model.get_symbol_table(),
       resume.equation,
       options,
-      *worklist);
+      *worklist,
+      guard_manager);
     setup_symex(symex);
 
     symex.resume_symex_from_saved_state(

--- a/src/goto-checker/single_path_symex_only_checker.cpp
+++ b/src/goto-checker/single_path_symex_only_checker.cpp
@@ -45,7 +45,8 @@ operator()(propertiest &properties)
       goto_model.get_symbol_table(),
       equation,
       options,
-      *worklist);
+      *worklist,
+      guard_manager);
     setup_symex(symex);
 
     symex.initialize_path_storage_from_entry_point_of(
@@ -60,7 +61,8 @@ operator()(propertiest &properties)
       goto_model.get_symbol_table(),
       resume.equation,
       options,
-      *worklist);
+      *worklist,
+      guard_manager);
     setup_symex(symex);
 
     symex.resume_symex_from_saved_state(

--- a/src/goto-checker/single_path_symex_only_checker.h
+++ b/src/goto-checker/single_path_symex_only_checker.h
@@ -35,6 +35,7 @@ protected:
   abstract_goto_modelt &goto_model;
   symbol_tablet symex_symbol_table;
   namespacet ns;
+  guard_managert guard_manager;
   std::unique_ptr<path_storaget> worklist;
 
   void equation_output(

--- a/src/goto-checker/symex_bmc.cpp
+++ b/src/goto-checker/symex_bmc.cpp
@@ -23,8 +23,15 @@ symex_bmct::symex_bmct(
   const symbol_tablet &outer_symbol_table,
   symex_target_equationt &_target,
   const optionst &options,
-  path_storaget &path_storage)
-  : goto_symext(mh, outer_symbol_table, _target, options, path_storage),
+  path_storaget &path_storage,
+  guard_managert &guard_manager)
+  : goto_symext(
+      mh,
+      outer_symbol_table,
+      _target,
+      options,
+      path_storage,
+      guard_manager),
     record_coverage(!options.get_option("symex-coverage-report").empty()),
     symex_coverage(ns)
 {

--- a/src/goto-checker/symex_bmc.h
+++ b/src/goto-checker/symex_bmc.h
@@ -30,7 +30,8 @@ public:
     const symbol_tablet &outer_symbol_table,
     symex_target_equationt &_target,
     const optionst &options,
-    path_storaget &path_storage);
+    path_storaget &path_storage,
+    guard_managert &guard_manager);
 
   // To show progress
   source_locationt last_source_location;

--- a/src/goto-instrument/accelerate/accelerate.cpp
+++ b/src/goto-instrument/accelerate/accelerate.cpp
@@ -115,7 +115,8 @@ int acceleratet::accelerate_loop(goto_programt::targett &loop_header)
     program,
     loop,
     loop_header,
-    accelerate_limit);
+    accelerate_limit,
+    guard_manager);
 #else
   disjunctive_polynomial_accelerationt
     acceleration(symbol_table, goto_functions, program, loop, loop_header);
@@ -335,7 +336,7 @@ void acceleratet::set_dirty_vars(path_acceleratort &accelerator)
 
     if(jt==dirty_vars_map.end())
     {
-      scratch_programt scratch(symbol_table, message_handler);
+      scratch_programt scratch(symbol_table, message_handler, guard_manager);
       symbolt new_sym=utils.fresh_symbol("accelerate::dirty", bool_typet());
       dirty_var=new_sym.symbol_expr();
       dirty_vars_map[*it]=dirty_var;
@@ -512,7 +513,8 @@ void acceleratet::insert_automaton(trace_automatont &automaton)
   // machine.
   for(const auto &sym : automaton.alphabet)
   {
-    scratch_programt state_machine(symbol_table, message_handler);
+    scratch_programt state_machine{
+      symbol_table, message_handler, guard_manager};
     trace_automatont::sym_range_pairt p=transitions.equal_range(sym);
 
     build_state_machine(p.first, p.second, accept_states, state, next_state,
@@ -651,13 +653,14 @@ int acceleratet::accelerate_loops()
 void accelerate_functions(
   goto_modelt &goto_model,
   message_handlert &message_handler,
-  bool use_z3)
+  bool use_z3,
+  guard_managert &guard_manager)
 {
   Forall_goto_functions(it, goto_model.goto_functions)
   {
     std::cout << "Accelerating function " << it->first << '\n';
     acceleratet accelerate(
-      it->second.body, goto_model, message_handler, use_z3);
+      it->second.body, goto_model, message_handler, use_z3, guard_manager);
 
     int num_accelerated=accelerate.accelerate_loops();
 

--- a/src/goto-instrument/accelerate/accelerate.h
+++ b/src/goto-instrument/accelerate/accelerate.h
@@ -34,11 +34,13 @@ public:
     goto_programt &_program,
     goto_modelt &_goto_model,
     message_handlert &message_handler,
-    bool _use_z3)
+    bool _use_z3,
+    guard_managert &guard_manager)
     : message_handler(message_handler),
       program(_program),
       goto_functions(_goto_model.goto_functions),
       symbol_table(_goto_model.symbol_table),
+      guard_manager(guard_manager),
       ns(_goto_model.symbol_table),
       utils(symbol_table, message_handler, goto_functions),
       use_z3(_use_z3)
@@ -113,6 +115,7 @@ protected:
   goto_programt &program;
   goto_functionst &goto_functions;
   symbol_tablet &symbol_table;
+  guard_managert &guard_manager;
   namespacet ns;
   natural_loops_mutablet natural_loops;
   subsumed_pathst subsumed;
@@ -130,6 +133,7 @@ protected:
 void accelerate_functions(
   goto_modelt &,
   message_handlert &message_handler,
-  bool use_z3);
+  bool use_z3,
+  guard_managert &guard_manager);
 
 #endif // CPROVER_GOTO_INSTRUMENT_ACCELERATE_ACCELERATE_H

--- a/src/goto-instrument/accelerate/acceleration_utils.cpp
+++ b/src/goto-instrument/accelerate/acceleration_utils.cpp
@@ -110,10 +110,10 @@ void acceleration_utilst::find_modified(
   }
 }
 
-
 bool acceleration_utilst::check_inductive(
   std::map<exprt, polynomialt> polynomials,
-  patht &path)
+  patht &path,
+  guard_managert &guard_manager)
 {
   // Checking that our polynomial is inductive with respect to the loop body is
   // equivalent to checking safety of the following program:
@@ -126,7 +126,7 @@ bool acceleration_utilst::check_inductive(
   // assert (target1==polynomial1);
   // assert (target2==polynomial2);
   // ...
-  scratch_programt program(symbol_table, message_handler);
+  scratch_programt program(symbol_table, message_handler, guard_manager);
   std::vector<exprt> polynomials_hold;
   substitutiont substitution;
 
@@ -162,7 +162,7 @@ bool acceleration_utilst::check_inductive(
 
   try
   {
-    if(program.check_sat())
+    if(program.check_sat(guard_manager))
     {
       // We found a counterexample to inductiveness... :-(
   #ifdef DEBUG
@@ -353,7 +353,8 @@ void acceleration_utilst::push_nondet(exprt &expr)
 bool acceleration_utilst::do_assumptions(
   std::map<exprt, polynomialt> polynomials,
   patht &path,
-  exprt &guard)
+  exprt &guard,
+  guard_managert &guard_manager)
 {
   // We want to check that if an assumption fails, the next iteration can't be
   // feasible again.  To do this we check the following program for safety:
@@ -380,7 +381,7 @@ bool acceleration_utilst::do_assumptions(
   // assert(!precondition);
 
   exprt condition=precondition(path);
-  scratch_programt program(symbol_table, message_handler);
+  scratch_programt program(symbol_table, message_handler, guard_manager);
 
   substitutiont substitution;
   stash_polynomials(program, polynomials, substitution, path);
@@ -445,7 +446,7 @@ bool acceleration_utilst::do_assumptions(
 
   try
   {
-    if(program.check_sat())
+    if(program.check_sat(guard_manager))
     {
   #ifdef DEBUG
       std::cout << "Path is not monotone\n";

--- a/src/goto-instrument/accelerate/acceleration_utils.h
+++ b/src/goto-instrument/accelerate/acceleration_utils.h
@@ -64,12 +64,15 @@ public:
   {
   }
 
-  void extract_polynomial(scratch_programt &program,
-                          std::set<std::pair<expr_listt, exprt> > &coefficients,
-                          polynomialt &polynomial);
+  void extract_polynomial(
+    scratch_programt &program,
+    std::set<std::pair<expr_listt, exprt>> &coefficients,
+    polynomialt &polynomial);
 
-  bool check_inductive(std::map<exprt, polynomialt> polynomials,
-                       patht &path);
+  bool check_inductive(
+    std::map<exprt, polynomialt> polynomials,
+    patht &path,
+    guard_managert &guard_manager);
   void stash_variables(scratch_programt &program,
                        expr_sett modified,
                        substitutiont &substitution);
@@ -82,9 +85,11 @@ public:
   void abstract_arrays(exprt &expr, expr_mapt &abstractions);
   void push_nondet(exprt &expr);
 
-  bool do_assumptions(std::map<exprt, polynomialt> polynomials,
-                      patht &body,
-                      exprt &guard);
+  bool do_assumptions(
+    std::map<exprt, polynomialt> polynomials,
+    patht &body,
+    exprt &guard,
+    guard_managert &guard_manager);
 
   typedef std::pair<exprt, exprt> expr_pairt;
   typedef std::vector<expr_pairt> expr_pairst;

--- a/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
+++ b/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
@@ -50,7 +50,7 @@ bool disjunctive_polynomial_accelerationt::accelerate(
   path_acceleratort &accelerator)
 {
   std::map<exprt, polynomialt> polynomials;
-  scratch_programt program(symbol_table, message_handler);
+  scratch_programt program{symbol_table, message_handler, guard_manager};
 
   accelerator.clear();
 
@@ -143,7 +143,7 @@ bool disjunctive_polynomial_accelerationt::accelerate(
   expr_sett dirty;
   utils.find_modified(accelerator.path, dirty);
   polynomial_acceleratort path_acceleration(
-    message_handler, symbol_table, goto_functions, loop_counter);
+    message_handler, symbol_table, goto_functions, loop_counter, guard_manager);
   goto_programt::instructionst assigns;
 
   for(patht::iterator it=accelerator.path.begin();
@@ -212,7 +212,7 @@ bool disjunctive_polynomial_accelerationt::accelerate(
       std::map<exprt, polynomialt> this_poly;
       this_poly[target]=poly;
 
-      if(utils.check_inductive(this_poly, accelerator.path))
+      if(utils.check_inductive(this_poly, accelerator.path, guard_manager))
       {
         polynomials[target]=poly;
         accelerator.changed_vars.insert(target);
@@ -245,7 +245,8 @@ bool disjunctive_polynomial_accelerationt::accelerate(
 
   try
   {
-    path_is_monotone=utils.do_assumptions(polynomials, path, guard);
+    path_is_monotone =
+      utils.do_assumptions(polynomials, path, guard, guard_manager);
   }
   catch(const std::string &s)
   {
@@ -337,7 +338,7 @@ bool disjunctive_polynomial_accelerationt::accelerate(
 
 bool disjunctive_polynomial_accelerationt::find_path(patht &path)
 {
-  scratch_programt program(symbol_table, message_handler);
+  scratch_programt program{symbol_table, message_handler, guard_manager};
 
   program.append(fixed);
   program.append(fixed);
@@ -373,7 +374,7 @@ bool disjunctive_polynomial_accelerationt::find_path(patht &path)
 
   try
   {
-    if(program.check_sat())
+    if(program.check_sat(guard_manager))
     {
 #ifdef DEBUG
       std::cout << "Found a path\n";
@@ -405,7 +406,7 @@ bool disjunctive_polynomial_accelerationt::fit_polynomial(
   std::vector<expr_listt> parameters;
   std::set<std::pair<expr_listt, exprt> > coefficients;
   expr_listt exprs;
-  scratch_programt program(symbol_table, message_handler);
+  scratch_programt program{symbol_table, message_handler, guard_manager};
   expr_sett influence;
 
   cone_of_influence(var, influence);
@@ -619,7 +620,7 @@ bool disjunctive_polynomial_accelerationt::fit_polynomial(
   // relevant coefficients and return the expression.
   try
   {
-    if(program.check_sat())
+    if(program.check_sat(guard_manager))
     {
 #ifdef DEBUG
       std::cout << "Found a polynomial\n";
@@ -855,7 +856,7 @@ void disjunctive_polynomial_accelerationt::build_path(
  */
 void disjunctive_polynomial_accelerationt::build_fixed()
 {
-  scratch_programt scratch(symbol_table, message_handler);
+  scratch_programt scratch{symbol_table, message_handler, guard_manager};
   std::map<exprt, exprt> shadow_distinguishers;
 
   fixed.copy_from(goto_program);

--- a/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.h
+++ b/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.h
@@ -39,12 +39,14 @@ public:
     goto_functionst &_goto_functions,
     goto_programt &_goto_program,
     natural_loops_mutablet::natural_loopt &_loop,
-    goto_programt::targett _loop_header)
+    goto_programt::targett _loop_header,
+    guard_managert &guard_manager)
     : message_handler(message_handler),
       symbol_table(_symbol_table),
       ns(symbol_table),
       goto_functions(_goto_functions),
       goto_program(_goto_program),
+      guard_manager(guard_manager),
       loop(_loop),
       loop_header(_loop_header),
       utils(symbol_table, message_handler, goto_functions, loop_counter)
@@ -89,6 +91,7 @@ protected:
   namespacet ns;
   goto_functionst &goto_functions;
   goto_programt &goto_program;
+  guard_managert &guard_manager;
   natural_loops_mutablet::natural_loopt &loop;
   goto_programt::targett loop_header;
 

--- a/src/goto-instrument/accelerate/enumerating_loop_acceleration.h
+++ b/src/goto-instrument/accelerate/enumerating_loop_acceleration.h
@@ -50,15 +50,14 @@ public:
         goto_functions,
         guard_manager),
       path_limit(_path_limit),
-      path_enumerator(
-        util_make_unique<sat_path_enumeratort>(
-          message_handler,
-          symbol_table,
-          goto_functions,
-          goto_program,
-          loop,
-          loop_header,
-          guard_manager))
+      path_enumerator(util_make_unique<sat_path_enumeratort>(
+        message_handler,
+        symbol_table,
+        goto_functions,
+        goto_program,
+        loop,
+        loop_header,
+        guard_manager))
   {
   }
 

--- a/src/goto-instrument/accelerate/enumerating_loop_acceleration.h
+++ b/src/goto-instrument/accelerate/enumerating_loop_acceleration.h
@@ -36,13 +36,19 @@ public:
     goto_programt &_goto_program,
     natural_loops_mutablet::natural_loopt &_loop,
     goto_programt::targett _loop_header,
-    int _path_limit)
+    int _path_limit,
+    guard_managert &guard_manager)
     : symbol_table(_symbol_table),
       goto_functions(_goto_functions),
       goto_program(_goto_program),
       loop(_loop),
       loop_header(_loop_header),
-      polynomial_accelerator(message_handler, symbol_table, goto_functions),
+      guard_manager(guard_manager),
+      polynomial_accelerator(
+        message_handler,
+        symbol_table,
+        goto_functions,
+        guard_manager),
       path_limit(_path_limit),
       path_enumerator(
         util_make_unique<sat_path_enumeratort>(
@@ -51,7 +57,8 @@ public:
           goto_functions,
           goto_program,
           loop,
-          loop_header))
+          loop_header,
+          guard_manager))
   {
   }
 
@@ -63,6 +70,7 @@ protected:
   goto_programt &goto_program;
   natural_loops_mutablet::natural_loopt &loop;
   goto_programt::targett loop_header;
+  guard_managert &guard_manager;
   polynomial_acceleratort polynomial_accelerator;
   int path_limit;
 

--- a/src/goto-instrument/accelerate/polynomial_accelerator.cpp
+++ b/src/goto-instrument/accelerate/polynomial_accelerator.cpp
@@ -58,7 +58,7 @@ bool polynomial_acceleratort::accelerate(
 
   expr_sett targets;
   std::map<exprt, polynomialt> polynomials;
-  scratch_programt program(symbol_table, message_handler);
+  scratch_programt program{symbol_table, message_handler, guard_manager};
   goto_programt::instructionst assigns;
 
   utils.find_modified(body, targets);
@@ -178,7 +178,8 @@ bool polynomial_acceleratort::accelerate(
 
   try
   {
-    path_is_monotone=utils.do_assumptions(polynomials, loop, guard);
+    path_is_monotone =
+      utils.do_assumptions(polynomials, loop, guard, guard_manager);
   }
   catch(const std::string &s)
   {
@@ -284,7 +285,7 @@ bool polynomial_acceleratort::fit_polynomial_sliced(
   std::vector<expr_listt> parameters;
   std::set<std::pair<expr_listt, exprt> > coefficients;
   expr_listt exprs;
-  scratch_programt program(symbol_table, message_handler);
+  scratch_programt program{symbol_table, message_handler, guard_manager};
   exprt overflow_var =
     utils.fresh_symbol("polynomial::overflow", bool_typet()).symbol_expr();
   overflow_instrumentert overflow(program, overflow_var, symbol_table);
@@ -412,7 +413,7 @@ bool polynomial_acceleratort::fit_polynomial_sliced(
   // relevant coefficients and return the expression.
   try
   {
-    if(program.check_sat())
+    if(program.check_sat(guard_manager))
     {
       utils.extract_polynomial(program, coefficients, polynomial);
       return true;
@@ -666,7 +667,7 @@ bool polynomial_acceleratort::check_inductive(
   // assert (target1==polynomial1);
   // assert (target2==polynomial2);
   // ...
-  scratch_programt program(symbol_table, message_handler);
+  scratch_programt program{symbol_table, message_handler, guard_manager};
   std::vector<exprt> polynomials_hold;
   substitutiont substitution;
 
@@ -703,7 +704,7 @@ bool polynomial_acceleratort::check_inductive(
 
   try
   {
-    if(program.check_sat())
+    if(program.check_sat(guard_manager))
     {
       // We found a counterexample to inductiveness... :-(
   #ifdef DEBUG

--- a/src/goto-instrument/accelerate/polynomial_accelerator.h
+++ b/src/goto-instrument/accelerate/polynomial_accelerator.h
@@ -34,11 +34,13 @@ public:
   polynomial_acceleratort(
     message_handlert &message_handler,
     const symbol_tablet &_symbol_table,
-    const goto_functionst &_goto_functions)
+    const goto_functionst &_goto_functions,
+    guard_managert &guard_manager)
     : message_handler(message_handler),
       symbol_table(const_cast<symbol_tablet &>(_symbol_table)),
       ns(symbol_table),
       goto_functions(_goto_functions),
+      guard_manager(guard_manager),
       utils(symbol_table, message_handler, goto_functions, loop_counter)
   {
     loop_counter=nil_exprt();
@@ -48,11 +50,13 @@ public:
     message_handlert &message_handler,
     const symbol_tablet &_symbol_table,
     const goto_functionst &_goto_functions,
-    exprt &_loop_counter)
+    exprt &_loop_counter,
+    guard_managert &guard_manager)
     : message_handler(message_handler),
       symbol_table(const_cast<symbol_tablet &>(_symbol_table)),
       ns(symbol_table),
       goto_functions(_goto_functions),
+      guard_manager(guard_manager),
       utils(symbol_table, message_handler, goto_functions, loop_counter),
       loop_counter(_loop_counter)
   {
@@ -153,6 +157,7 @@ protected:
   symbol_tablet &symbol_table;
   const namespacet ns;
   const goto_functionst &goto_functions;
+  guard_managert &guard_manager;
   acceleration_utilst utils;
 
   exprt loop_counter;

--- a/src/goto-instrument/accelerate/sat_path_enumerator.cpp
+++ b/src/goto-instrument/accelerate/sat_path_enumerator.cpp
@@ -47,7 +47,7 @@ Author: Matt Lewis
 
 bool sat_path_enumeratort::next(patht &path)
 {
-  scratch_programt program(symbol_table, message_handler);
+  scratch_programt program{symbol_table, message_handler, guard_manager};
 
   program.append(fixed);
   program.append(fixed);
@@ -83,7 +83,7 @@ bool sat_path_enumeratort::next(patht &path)
 
   try
   {
-    if(program.check_sat())
+    if(program.check_sat(guard_manager))
     {
 #ifdef DEBUG
       std::cout << "Found a path\n";
@@ -212,7 +212,7 @@ void sat_path_enumeratort::build_path(
  */
 void sat_path_enumeratort::build_fixed()
 {
-  scratch_programt scratch(symbol_table, message_handler);
+  scratch_programt scratch{symbol_table, message_handler, guard_manager};
   std::map<exprt, exprt> shadow_distinguishers;
 
   fixed.copy_from(goto_program);

--- a/src/goto-instrument/accelerate/sat_path_enumerator.h
+++ b/src/goto-instrument/accelerate/sat_path_enumerator.h
@@ -39,7 +39,8 @@ public:
     goto_functionst &_goto_functions,
     goto_programt &_goto_program,
     natural_loops_mutablet::natural_loopt &_loop,
-    goto_programt::targett _loop_header)
+    goto_programt::targett _loop_header,
+    guard_managert &guard_manager)
     : message_handler(message_handler),
       symbol_table(_symbol_table),
       ns(symbol_table),
@@ -47,7 +48,8 @@ public:
       goto_program(_goto_program),
       loop(_loop),
       loop_header(_loop_header),
-      utils(symbol_table, message_handler, goto_functions, loop_counter)
+      utils(symbol_table, message_handler, goto_functions, loop_counter),
+      guard_manager(guard_manager)
   {
     find_distinguishing_points();
     build_fixed();
@@ -75,6 +77,7 @@ protected:
   typedef std::map<exprt, bool> distinguish_valuest;
 
   acceleration_utilst utils;
+  guard_managert &guard_manager;
   exprt loop_counter;
   distinguish_mapt distinguishing_points;
   std::list<exprt> distinguishers;

--- a/src/goto-instrument/accelerate/scratch_program.cpp
+++ b/src/goto-instrument/accelerate/scratch_program.cpp
@@ -22,7 +22,7 @@ Author: Matt Lewis
 #include <iostream>
 #endif
 
-bool scratch_programt::check_sat(bool do_slice)
+bool scratch_programt::check_sat(bool do_slice, guard_managert &guard_manager)
 {
   fix_types();
 
@@ -36,7 +36,8 @@ bool scratch_programt::check_sat(bool do_slice)
 #endif
 
   symex_state = util_make_unique<goto_symex_statet>(
-    symex_targett::sourcet(goto_functionst::entry_point(), *this));
+    symex_targett::sourcet(goto_functionst::entry_point(), *this),
+    guard_manager);
   symex.symex_with_state(
     *symex_state,
     [this](const irep_idt &key) -> const goto_functionst::goto_functiont & {

--- a/src/goto-instrument/accelerate/scratch_program.h
+++ b/src/goto-instrument/accelerate/scratch_program.h
@@ -36,7 +36,10 @@ Author: Matt Lewis
 class scratch_programt:public goto_programt
 {
 public:
-  scratch_programt(symbol_tablet &_symbol_table, message_handlert &mh)
+  scratch_programt(
+    symbol_tablet &_symbol_table,
+    message_handlert &mh,
+    guard_managert &guard_manager)
     : constant_propagation(true),
       symbol_table(_symbol_table),
       symex_symbol_table(),
@@ -44,7 +47,7 @@ public:
       equation(mh),
       path_storage(),
       options(get_default_options()),
-      symex(mh, symbol_table, equation, options, path_storage),
+      symex(mh, symbol_table, equation, options, path_storage, guard_manager),
       satcheck(util_make_unique<satcheckt>(mh)),
       satchecker(ns, *satcheck),
       z3(ns, "accelerate", "", "", smt2_dect::solvert::Z3),
@@ -60,11 +63,11 @@ public:
   targett assign(const exprt &lhs, const exprt &rhs);
   targett assume(const exprt &guard);
 
-  bool check_sat(bool do_slice);
+  bool check_sat(bool do_slice, guard_managert &guard_manager);
 
-  bool check_sat()
+  bool check_sat(guard_managert &guard_manager)
   {
-    return check_sat(true);
+    return check_sat(true, guard_manager);
   }
 
   exprt eval(const exprt &e);

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -764,8 +764,9 @@ int goto_instrument_parse_optionst::doit()
       remove_calls_no_body(goto_model.goto_functions);
 
       status() << "Accelerating" << eom;
+      guard_managert guard_manager;
       accelerate_functions(
-        goto_model, get_message_handler(), cmdline.isset("z3"));
+        goto_model, get_message_handler(), cmdline.isset("z3"), guard_manager);
       remove_skip(goto_model);
     }
 

--- a/src/goto-symex/CMakeLists.txt
+++ b/src/goto-symex/CMakeLists.txt
@@ -3,4 +3,8 @@ add_library(goto-symex ${sources})
 
 generic_includes(goto-symex)
 
+if(CMAKE_USE_CUDD)
+    target_include_directories(goto-symex PUBLIC ${CUDD_INCLUDE}/cudd/)
+endif()
+
 target_link_libraries(goto-symex util)

--- a/src/goto-symex/goto_state.h
+++ b/src/goto-symex/goto_state.h
@@ -12,9 +12,9 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #ifndef CPROVER_GOTO_SYMEX_GOTO_STATE_H
 #define CPROVER_GOTO_SYMEX_GOTO_STATE_H
 
+#include <analyses/guard.h>
 #include <analyses/local_safe_pointers.h>
 #include <pointer-analysis/value_set.h>
-#include <util/guard.h>
 
 #include "renaming_level.h"
 #include "symex_target_equation.h"
@@ -39,7 +39,7 @@ public:
   // the if branch will be guarded by the condition of the if (and if there
   // is an else branch then instructions on it will be guarded by the negation
   // of the condition of the if).
-  guardt guard{true_exprt{}};
+  guardt guard;
 
   symex_targett::sourcet source;
 
@@ -62,7 +62,11 @@ public:
 
   /// Constructors
   explicit goto_statet(const class goto_symex_statet &s);
-  explicit goto_statet(const symex_targett::sourcet &_source) : source(_source)
+
+  goto_statet(
+    const symex_targett::sourcet &_source,
+    guard_managert &guard_manager)
+    : guard(true_exprt(), guard_manager), source(_source)
   {
   }
 };

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -89,16 +89,19 @@ public:
   /// \param options: The options to use to configure this execution
   /// \param path_storage: Place to storage symbolic execution paths that have
   /// been halted and can be resumed later
+  /// \param guard_manager: Manager for creating guards
   goto_symext(
     message_handlert &mh,
     const symbol_tablet &outer_symbol_table,
     symex_target_equationt &_target,
     const optionst &options,
-    path_storaget &path_storage)
+    path_storaget &path_storage,
+    guard_managert &guard_manager)
     : should_pause_symex(false),
       symex_config(options),
       outer_symbol_table(outer_symbol_table),
       ns(outer_symbol_table),
+      guard_manager(guard_manager),
       target(_target),
       atomic_section_counter(0),
       log(mh),
@@ -244,6 +247,11 @@ protected:
   /// used during symbolic execution to look up names from the original
   /// goto-program, and the names of dynamically-created objects.
   namespacet ns;
+
+  /// Used to create guards. Guards created with different guard managers cannot
+  /// be combined together, so guards created by goto-symex should not escape
+  /// the scope of this manager.
+  guard_managert &guard_manager;
 
   /// The equation that this execution is building up
   symex_target_equationt &target;

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -27,7 +27,6 @@ class code_assignt;
 class code_function_callt;
 class exprt;
 class goto_symex_statet;
-class guardt;
 class if_exprt;
 class index_exprt;
 class symbol_exprt;

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -445,49 +445,49 @@ protected:
     const exprt &lhs,
     const exprt &full_lhs,
     const exprt &rhs,
-    guardt &,
+    exprt::operandst &,
     assignment_typet);
   void symex_assign_symbol(
     statet &,
     const ssa_exprt &lhs,
     const exprt &full_lhs,
     const exprt &rhs,
-    guardt &,
+    exprt::operandst &,
     assignment_typet);
   void symex_assign_typecast(
     statet &,
     const typecast_exprt &lhs,
     const exprt &full_lhs,
     const exprt &rhs,
-    guardt &,
+    exprt::operandst &,
     assignment_typet);
   void symex_assign_array(
     statet &,
     const index_exprt &lhs,
     const exprt &full_lhs,
     const exprt &rhs,
-    guardt &,
+    exprt::operandst &,
     assignment_typet);
   void symex_assign_struct_member(
     statet &,
     const member_exprt &lhs,
     const exprt &full_lhs,
     const exprt &rhs,
-    guardt &,
+    exprt::operandst &,
     assignment_typet);
   void symex_assign_if(
     statet &,
     const if_exprt &lhs,
     const exprt &full_lhs,
     const exprt &rhs,
-    guardt &,
+    exprt::operandst &,
     assignment_typet);
   void symex_assign_byte_extract(
     statet &,
     const byte_extract_exprt &lhs,
     const exprt &full_lhs,
     const exprt &rhs,
-    guardt &,
+    exprt::operandst &,
     assignment_typet);
 
   /// Store the \p what expression by recursively descending into the operands

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -16,9 +16,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <unordered_set>
 
 #include <analyses/dirty.h>
+#include <analyses/guard.h>
 
 #include <util/invariant.h>
-#include <util/guard.h>
 #include <util/std_expr.h>
 #include <util/ssa_expr.h>
 #include <util/make_unique.h>

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -41,7 +41,7 @@ Author: Daniel Kroening, kroening@kroening.com
 class goto_symex_statet final : public goto_statet
 {
 public:
-  explicit goto_symex_statet(const symex_targett::sourcet &);
+  goto_symex_statet(const symex_targett::sourcet &, guard_managert &manager);
   ~goto_symex_statet();
 
   /// \brief Fake "copy constructor" that initializes the `symex_target` member
@@ -58,6 +58,8 @@ public:
   /// for error traces even after symbolic execution has finished.
   symbol_tablet symbol_table;
 
+  // Manager is required to be able to resize the thread vector
+  guard_managert &guard_manager;
   symex_target_equationt *symex_target;
 
   symex_level0t level0;
@@ -155,10 +157,14 @@ public:
   struct threadt
   {
     goto_programt::const_targett pc;
-    guardt guard{true_exprt{}};
+    guardt guard;
     call_stackt call_stack;
     std::map<irep_idt, unsigned> function_frame;
     unsigned atomic_section_id = 0;
+    explicit threadt(guard_managert &guard_manager)
+      : guard(true_exprt(), guard_manager)
+    {
+    }
   };
 
   std::vector<threadt> threads;

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -134,8 +134,9 @@ void goto_symext::parameter_assignments(
       clean_expr(lhs, state, true);
       clean_expr(rhs, state, false);
 
-      guardt guard{true_exprt{}};
-      symex_assign_rec(state, lhs, nil_exprt(), rhs, guard, assignment_type);
+      exprt::operandst lhs_conditions;
+      symex_assign_rec(
+        state, lhs, nil_exprt(), rhs, lhs_conditions, assignment_type);
     }
 
     if(it1!=arguments.end())

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -217,7 +217,7 @@ void goto_symext::symex_goto(statet &state)
   // adjust guards
   if(new_guard.is_true())
   {
-    state.guard = guardt(false_exprt());
+    state.guard = guardt(false_exprt(), guard_manager);
   }
   else
   {
@@ -241,7 +241,7 @@ void goto_symext::symex_goto(statet &state)
         state.rename_ssa<L1>(ssa_exprt{guard_symbol_expr}, ns);
       state.assignment(new_lhs, new_rhs, ns, true, false);
 
-      guardt guard{true_exprt{}};
+      guardt guard{true_exprt{}, guard_manager};
 
       log.conditional_output(
         log.debug(),

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -328,7 +328,8 @@ std::unique_ptr<goto_symext::statet> goto_symext::initialize_entry_point_state(
 
   // create and prepare the state
   auto state = util_make_unique<statet>(
-    symex_targett::sourcet(entry_point_id, start_function->body));
+    symex_targett::sourcet(entry_point_id, start_function->body),
+    guard_manager);
   CHECK_RETURN(!state->threads.empty());
   CHECK_RETURN(!state->call_stack().empty());
 

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -116,8 +116,7 @@ void goto_symext::vcc(
   if(condition.is_true())
     return;
 
-  exprt guarded_condition = condition;
-  state.guard.guard_expr(guarded_condition);
+  const exprt guarded_condition = state.guard.guard_expr(condition);
 
   state.remaining_vccs++;
   target.assertion(state.guard.as_expr(), guarded_condition, msg, state.source);
@@ -146,8 +145,7 @@ void goto_symext::symex_assume_l2(statet &state, const exprt &cond)
 
   if(state.threads.size()==1)
   {
-    exprt tmp = rewritten_cond;
-    state.guard.guard_expr(tmp);
+    exprt tmp = state.guard.guard_expr(rewritten_cond);
     target.assumption(state.guard.as_expr(), tmp, state.source);
   }
   // symex_target_equationt::convert_assertions would fail to

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -274,7 +274,7 @@ void goto_symext::symex_other(
     clean_expr(object, state, false);
 
     process_array_expr(state, object);
-    havoc_rec(state, guardt(true_exprt()), object);
+    havoc_rec(state, guardt(true_exprt(), guard_manager), object);
   }
   else
     UNREACHABLE;

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -37,7 +37,7 @@ void goto_symext::symex_start_thread(statet &state)
 
   // put into thread vector
   std::size_t t=state.threads.size();
-  state.threads.push_back(statet::threadt());
+  state.threads.push_back(statet::threadt(guard_manager));
   // statet::threadt &cur_thread=state.threads[state.source.thread_nr];
   statet::threadt &new_thread=state.threads.back();
   new_thread.pc=thread_target;

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -84,7 +84,7 @@ void goto_symext::symex_start_thread(statet &state)
     // make copy
     ssa_exprt rhs=c_it->second.first;
 
-    guardt guard{true_exprt{}};
+    exprt::operandst lhs_conditions;
     const bool record_events=state.record_events;
     state.record_events=false;
     symex_assign_symbol(
@@ -92,7 +92,7 @@ void goto_symext::symex_start_thread(statet &state)
       lhs_l1,
       nil_exprt(),
       rhs,
-      guard,
+      lhs_conditions,
       symex_targett::assignment_typet::HIDDEN);
     state.record_events=record_events;
   }
@@ -123,13 +123,13 @@ void goto_symext::symex_start_thread(statet &state)
       rhs = *zero;
     }
 
-    guardt guard{true_exprt{}};
+    exprt::operandst lhs_conditions;
     symex_assign_symbol(
       state,
       lhs,
       nil_exprt(),
       rhs,
-      guard,
+      lhs_conditions,
       symex_targett::assignment_typet::HIDDEN);
   }
 }

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -15,7 +15,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/simplify_expr.h>
 #include <util/std_code.h>
 #include <util/symbol_table.h>
-#include <util/guard.h>
 #include <util/options.h>
 
 /// \param expr: expression to check

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -24,7 +24,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/cprover_prefix.h>
 #include <util/format_type.h>
 #include <util/fresh_symbol.h>
-#include <util/guard.h>
 #include <util/options.h>
 #include <util/pointer_offset_size.h>
 #include <util/pointer_predicates.h>

--- a/src/solvers/bdd/bdd_cudd.h
+++ b/src/solvers/bdd/bdd_cudd.h
@@ -51,10 +51,13 @@ public:
     return bdd_nodet(Cudd_E(node));
   }
 
+  /// Return type for \ref id()
+  using idt = DdNode *;
+
   /// Unique identifier of the node
-  long id() const
+  idt id() const
   {
-    return (long)node;
+    return node;
   }
 
 private:

--- a/src/solvers/bdd/bdd_miniBDD.h
+++ b/src/solvers/bdd/bdd_miniBDD.h
@@ -55,10 +55,13 @@ public:
     return bdd_nodet(node->low.node, bdd_var_to_index);
   }
 
+  /// Return type for \ref id()
+  using idt = mini_bdd_nodet *;
+
   /// Unique identifier of the node
-  long id() const
+  idt id() const
   {
-    return (long)node;
+    return node;
   }
 
 private:

--- a/src/solvers/prop/bdd_expr.cpp
+++ b/src/solvers/prop/bdd_expr.cpp
@@ -88,9 +88,9 @@ bddt bdd_exprt::from_expr_rec(const exprt &expr)
   }
 }
 
-void bdd_exprt::from_expr(const exprt &expr)
+bddt bdd_exprt::from_expr(const exprt &expr)
 {
-  root=from_expr_rec(expr);
+  return from_expr_rec(expr);
 }
 
 exprt bdd_exprt::as_expr(const bdd_nodet &r, bool complement) const
@@ -148,7 +148,7 @@ exprt bdd_exprt::as_expr(const bdd_nodet &r, bool complement) const
     as_expr(r.else_branch(), r.else_branch().is_complement() != complement));
 }
 
-exprt bdd_exprt::as_expr() const
+exprt bdd_exprt::as_expr(const bddt &root) const
 {
   const bdd_nodet node = bdd_mgr.bdd_node(root);
   return as_expr(node, node.is_complement());

--- a/src/solvers/prop/bdd_expr.h
+++ b/src/solvers/prop/bdd_expr.h
@@ -40,11 +40,18 @@ protected:
   bdd_managert bdd_mgr;
 
   typedef std::unordered_map<exprt, bddt, irep_hash> expr_mapt;
+
   expr_mapt expr_map;
+
+  /// Mapping from BDD variables to expressions: the expression at index \c i
+  /// of \p node_map corresponds to the i-th variable
   std::vector<exprt> node_map;
 
   bddt from_expr_rec(const exprt &expr);
-  exprt as_expr(const bdd_nodet &r, bool complement) const;
+  exprt as_expr(
+    const bdd_nodet &r,
+    bool complement,
+    std::unordered_map<bdd_nodet::idt, exprt> &cache) const;
 };
 
 #endif // CPROVER_SOLVERS_PROP_BDD_EXPR_H

--- a/src/solvers/prop/bdd_expr.h
+++ b/src/solvers/prop/bdd_expr.h
@@ -25,14 +25,12 @@ Author: Michael Tautschnig, michael.tautschnig@qmul.ac.uk
 
 #include <unordered_map>
 
-class namespacet;
-
 /*! \brief TO_BE_DOCUMENTED
 */
 class bdd_exprt
 {
 public:
-  explicit bdd_exprt(const namespacet &_ns) : ns(_ns), root(bdd_mgr.bdd_true())
+  explicit bdd_exprt() : root(bdd_mgr.bdd_true())
   {
   }
 
@@ -40,7 +38,6 @@ public:
   exprt as_expr() const;
 
 protected:
-  const namespacet &ns;
   bdd_managert bdd_mgr;
   bddt root;
 

--- a/src/solvers/prop/bdd_expr.h
+++ b/src/solvers/prop/bdd_expr.h
@@ -25,21 +25,19 @@ Author: Michael Tautschnig, michael.tautschnig@qmul.ac.uk
 
 #include <unordered_map>
 
-/*! \brief TO_BE_DOCUMENTED
-*/
+/// Conversion between \c exprt and \c bbdt
+/// This encapsulate a bdd_managert, thus BDDs created with this class should
+/// only be combined with BDDs created using the same instance of
+/// \ref bdd_exprt .
+/// See unit tests in unit/solvers/prop/bdd_expr.cpp for examples.
 class bdd_exprt
 {
 public:
-  explicit bdd_exprt() : root(bdd_mgr.bdd_true())
-  {
-  }
-
-  void from_expr(const exprt &expr);
-  exprt as_expr() const;
+  bddt from_expr(const exprt &expr);
+  exprt as_expr(const bddt &root) const;
 
 protected:
   bdd_managert bdd_mgr;
-  bddt root;
 
   typedef std::unordered_map<exprt, bddt, irep_hash> expr_mapt;
   expr_mapt expr_map;

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -26,7 +26,6 @@ SRC = allocate_objects.cpp \
       fresh_symbol.cpp \
       get_base_name.cpp \
       get_module.cpp \
-      guard.cpp \
       identifier.cpp \
       ieee_float.cpp \
       invariant.cpp \

--- a/src/util/guard.cpp
+++ b/src/util/guard.cpp
@@ -58,15 +58,13 @@ void guardt::add(const exprt &expr)
 
   exprt::operandst &op = this->expr.operands();
 
-  if(expr.id()==ID_and)
-    op.insert(op.end(),
-              expr.operands().begin(),
-              expr.operands().end());
+  if(expr.id() == ID_and)
+    op.insert(op.end(), expr.operands().begin(), expr.operands().end());
   else
     op.push_back(expr);
 }
 
-guardt &operator -= (guardt &g1, const guardt &g2)
+guardt &operator-=(guardt &g1, const guardt &g2)
 {
   if(g1.expr.id() != ID_and || g2.expr.id() != ID_and)
     return g1;
@@ -76,18 +74,16 @@ guardt &operator -= (guardt &g1, const guardt &g2)
   sort_and_join(g2_sorted);
 
   exprt::operandst &op1 = g1.expr.operands();
-  const exprt::operandst &op2=g2_sorted.operands();
+  const exprt::operandst &op2 = g2_sorted.operands();
 
-  exprt::operandst::iterator it1=op1.begin();
-  for(exprt::operandst::const_iterator
-      it2=op2.begin();
-      it2!=op2.end();
+  exprt::operandst::iterator it1 = op1.begin();
+  for(exprt::operandst::const_iterator it2 = op2.begin(); it2 != op2.end();
       ++it2)
   {
-    while(it1!=op1.end() && *it1<*it2)
+    while(it1 != op1.end() && *it1 < *it2)
       ++it1;
-    if(it1!=op1.end() && *it1==*it2)
-      it1=op1.erase(it1);
+    if(it1 != op1.end() && *it1 == *it2)
+      it1 = op1.erase(it1);
   }
 
   g1.expr = conjunction(op1);
@@ -95,7 +91,7 @@ guardt &operator -= (guardt &g1, const guardt &g2)
   return g1;
 }
 
-guardt &operator |= (guardt &g1, const guardt &g2)
+guardt &operator|=(guardt &g1, const guardt &g2)
 {
   if(g2.is_false() || g1.is_true())
     return g1;
@@ -125,46 +121,44 @@ guardt &operator |= (guardt &g1, const guardt &g2)
   sort_and_join(g2_sorted);
 
   exprt::operandst &op1 = g1.expr.operands();
-  const exprt::operandst &op2=g2_sorted.operands();
+  const exprt::operandst &op2 = g2_sorted.operands();
 
   exprt::operandst n_op1, n_op2;
   n_op1.reserve(op1.size());
   n_op2.reserve(op2.size());
 
-  exprt::operandst::iterator it1=op1.begin();
-  for(exprt::operandst::const_iterator
-      it2=op2.begin();
-      it2!=op2.end();
+  exprt::operandst::iterator it1 = op1.begin();
+  for(exprt::operandst::const_iterator it2 = op2.begin(); it2 != op2.end();
       ++it2)
   {
-    while(it1!=op1.end() && *it1<*it2)
+    while(it1 != op1.end() && *it1 < *it2)
     {
       n_op1.push_back(*it1);
-      it1=op1.erase(it1);
+      it1 = op1.erase(it1);
     }
-    if(it1!=op1.end() && *it1==*it2)
+    if(it1 != op1.end() && *it1 == *it2)
       ++it1;
     else
       n_op2.push_back(*it2);
   }
-  while(it1!=op1.end())
+  while(it1 != op1.end())
   {
     n_op1.push_back(*it1);
-    it1=op1.erase(it1);
+    it1 = op1.erase(it1);
   }
 
   if(n_op2.empty())
     return g1;
 
   // end of common prefix
-  exprt and_expr1=conjunction(n_op1);
-  exprt and_expr2=conjunction(n_op2);
+  exprt and_expr1 = conjunction(n_op1);
+  exprt and_expr2 = conjunction(n_op2);
 
   g1.expr = conjunction(op1);
 
   exprt tmp(boolean_negate(and_expr2));
 
-  if(tmp!=and_expr1)
+  if(tmp != and_expr1)
   {
     if(and_expr1.is_true() || and_expr2.is_true())
     {

--- a/src/util/guard.h
+++ b/src/util/guard.h
@@ -47,8 +47,8 @@ public:
     return expr.is_false();
   }
 
-  friend guardt &operator -= (guardt &g1, const guardt &g2);
-  friend guardt &operator |= (guardt &g1, const guardt &g2);
+  friend guardt &operator-=(guardt &g1, const guardt &g2);
+  friend guardt &operator|=(guardt &g1, const guardt &g2);
 
 private:
   exprt expr;

--- a/unit/path_strategies.cpp
+++ b/unit/path_strategies.cpp
@@ -369,6 +369,7 @@ void _check_with_strategy(
 
   REQUIRE(is_valid_path_strategy(strategy));
   std::unique_ptr<path_storaget> worklist = get_path_strategy(strategy);
+  guard_managert guard_manager;
 
   goto_modelt gm;
   int ret;
@@ -385,7 +386,14 @@ void _check_with_strategy(
   safety_checkert::resultt overall_result = safety_checkert::resultt::SAFE;
   std::size_t expected_results_cnt = 0;
 
-  bmct bmc(opts, gm.get_symbol_table(), mh, initial_pc, *worklist, callback);
+  bmct bmc(
+    opts,
+    gm.get_symbol_table(),
+    mh,
+    initial_pc,
+    *worklist,
+    callback,
+    guard_manager);
   safety_checkert::resultt tmp_result = bmc.run(gm);
 
   if(tmp_result != safety_checkert::resultt::PAUSED)
@@ -417,6 +425,7 @@ void _check_with_strategy(
       resume.equation,
       resume.state,
       *worklist,
+      guard_manager,
       callback);
     tmp_result = pe.run(gm);
 

--- a/unit/solvers/bdd/miniBDD/miniBDD.cpp
+++ b/unit/solvers/bdd/miniBDD/miniBDD.cpp
@@ -341,12 +341,12 @@ SCENARIO("miniBDD", "[core][solver][miniBDD]")
       REQUIRE(oss.str() == "(a ∧ b) ∨ ¬a");
     }
 
-    bdd_exprt t;
-    t.from_expr(o);
+    bdd_exprt bdd_expr_converter;
+    bddt t = bdd_expr_converter.from_expr(o);
 
     {
       std::ostringstream oss;
-      oss << format(t.as_expr());
+      oss << format(bdd_expr_converter.as_expr(t));
       REQUIRE(oss.str() == "¬a ∨ b");
     }
   }

--- a/unit/solvers/bdd/miniBDD/miniBDD.cpp
+++ b/unit/solvers/bdd/miniBDD/miniBDD.cpp
@@ -341,7 +341,7 @@ SCENARIO("miniBDD", "[core][solver][miniBDD]")
       REQUIRE(oss.str() == "(a ∧ b) ∨ ¬a");
     }
 
-    bdd_exprt t(ns);
+    bdd_exprt t;
     t.from_expr(o);
 
     {

--- a/unit/solvers/prop/bdd_expr.cpp
+++ b/unit/solvers/prop/bdd_expr.cpp
@@ -23,7 +23,7 @@ SCENARIO("bdd_expr", "[core][solver][prop][bdd_expr]")
 
   GIVEN("A bdd for x&!x")
   {
-    bdd_exprt bdd{ns};
+    bdd_exprt bdd;
     const symbol_exprt var("x", bool_typet());
     bdd.from_expr(and_exprt(var, not_exprt(var)));
     REQUIRE(bdd.as_expr() == false_exprt());
@@ -34,12 +34,12 @@ SCENARIO("bdd_expr", "[core][solver][prop][bdd_expr]")
     const symbol_exprt a("a", bool_typet());
     const symbol_exprt b("b", bool_typet());
 
-    bdd_exprt bdd{ns};
+    bdd_exprt bdd;
     bdd.from_expr(or_exprt(and_exprt(a, b), not_exprt(a)));
 
     THEN("It is equal to the BDD for (!a|b)")
     {
-      bdd_exprt bdd2{ns};
+      bdd_exprt bdd2;
       bdd2.from_expr(or_exprt(not_exprt(a), b));
       REQUIRE(bdd.as_expr() == bdd2.as_expr());
     }
@@ -50,7 +50,7 @@ SCENARIO("bdd_expr", "[core][solver][prop][bdd_expr]")
     const symbol_exprt a("a", bool_typet());
     const symbol_exprt b("b", bool_typet());
 
-    bdd_exprt bdd{ns};
+    bdd_exprt bdd;
     bdd.from_expr(and_exprt(a, not_exprt(b)));
 
     WHEN("It is converted to an exprt")

--- a/unit/solvers/prop/bdd_expr.cpp
+++ b/unit/solvers/prop/bdd_expr.cpp
@@ -20,13 +20,14 @@ SCENARIO("bdd_expr", "[core][solver][prop][bdd_expr]")
 {
   symbol_tablet symbol_table;
   namespacet ns{symbol_table};
+  bdd_exprt bdd_expr_converter;
 
   GIVEN("A bdd for x&!x")
   {
-    bdd_exprt bdd;
     const symbol_exprt var("x", bool_typet());
-    bdd.from_expr(and_exprt(var, not_exprt(var)));
-    REQUIRE(bdd.as_expr() == false_exprt());
+    const bddt bdd =
+      bdd_expr_converter.from_expr(and_exprt(var, not_exprt(var)));
+    REQUIRE(bdd_expr_converter.as_expr(bdd) == false_exprt());
   }
 
   GIVEN("A bdd for (a&b)|!a")
@@ -34,14 +35,14 @@ SCENARIO("bdd_expr", "[core][solver][prop][bdd_expr]")
     const symbol_exprt a("a", bool_typet());
     const symbol_exprt b("b", bool_typet());
 
-    bdd_exprt bdd;
-    bdd.from_expr(or_exprt(and_exprt(a, b), not_exprt(a)));
+    const bddt bdd =
+      bdd_expr_converter.from_expr(or_exprt(and_exprt(a, b), not_exprt(a)));
 
     THEN("It is equal to the BDD for (!a|b)")
     {
-      bdd_exprt bdd2;
-      bdd2.from_expr(or_exprt(not_exprt(a), b));
-      REQUIRE(bdd.as_expr() == bdd2.as_expr());
+      const bddt bdd2 = bdd_expr_converter.from_expr(or_exprt(not_exprt(a), b));
+      REQUIRE(
+        bdd_expr_converter.as_expr(bdd) == bdd_expr_converter.as_expr(bdd2));
     }
   }
 
@@ -50,12 +51,11 @@ SCENARIO("bdd_expr", "[core][solver][prop][bdd_expr]")
     const symbol_exprt a("a", bool_typet());
     const symbol_exprt b("b", bool_typet());
 
-    bdd_exprt bdd;
-    bdd.from_expr(and_exprt(a, not_exprt(b)));
+    const bddt bdd = bdd_expr_converter.from_expr(and_exprt(a, not_exprt(b)));
 
     WHEN("It is converted to an exprt")
     {
-      const exprt result = bdd.as_expr();
+      const exprt result = bdd_expr_converter.as_expr(bdd);
       THEN("It is equal to the expression (a & !b) or (!b & a)")
       {
         REQUIRE(result.id() == ID_and);


### PR DESCRIPTION
The main commit is "Use BDDs for encoding guards in symex". Commits that are before are in preparation for this one (in particular getting rid of usage of functions the new version will not implement). Commits that follow are clean-up in the code that use the guard (in particular getting rid of simplifications that are now unnecessary).

I still wan't to run this on more benchmarks before it is merged. For what I've seen so far, this is about 10% faster than the current symex, but this is not uniform across benchmarks (it doesn't help for "simple" instances, i.e. which take less than 2s).


<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
