### PR TITLE
Make linter check scenario has tags

### DIFF
--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -253,7 +253,7 @@ _ERROR_CATEGORIES = [
     'runtime/string',
     'runtime/threadsafe_fn',
     'runtime/vlog',
-    'runtime/catch_scenario',
+    'runtime/catch_test_tags',
     'whitespace/blank_line',
     'whitespace/braces',
     'whitespace/comma',
@@ -6150,24 +6150,23 @@ def AssembleString(clean_lines, start_lineno, start_linepos, end_lineno, end_lin
     full_string += clean_lines.elided[end_lineno][:end_linepos]
     return full_string
 
-def CheckScenarioHasTags(filename, clean_lines, linenum, error):
+def CheckCatchTestHasTags(filename, clean_lines, linenum, error):
     line = clean_lines.elided[linenum]
-    scenario = Match(r'^SCENARIO\(', line)
-    if not scenario: return
+    test = Match(r'^(SCENARIO|TEST_CASE)\(', line)
+    if not test: return
 
     closing_line, closing_linenum, closing_pos = CloseExpression(clean_lines, linenum, line.find('('))
 
     if closing_pos == -1:
         error(filename, linenum,
-            'runtime/catch_scenario', 4, "Can't find closing bracket for scenario")
+            'runtime/catch_test_tags', 4, "Can't find closing bracket for catch test")
 
     full_string = AssembleString(
         clean_lines, linenum, line.find('(') + 1, closing_linenum, closing_pos - 1)
 
     if(full_string.find(',') == -1):
         error(filename, linenum,
-            'runtime/catch_scenario', 4, "Can't find `,\' seperating scenario name and the tags: " + str(clean_lines.lines[linenum]))
-
+            'runtime/catch_test_tags', 4, "Can't find `,\' seperating test name and the tags: " + str(clean_lines.lines[linenum]))
 
 def CheckRedundantVirtual(filename, clean_lines, linenum, error):
   """Check if line contains a redundant "virtual" function-specifier.
@@ -6362,7 +6361,7 @@ def ProcessLine(filename, file_extension, clean_lines, line,
   CheckInvalidIncrement(filename, clean_lines, line, error)
   CheckMakePairUsesDeduction(filename, clean_lines, line, error)
   CheckRedundantVirtual(filename, clean_lines, line, error)
-  CheckScenarioHasTags(filename, clean_lines, line, error)
+  CheckCatchTestHasTags(filename, clean_lines, line, error)
   CheckNamespaceOrUsing(filename, clean_lines, line, error)
   CheckForEndl(filename, clean_lines, line, error)
   for check_fn in extra_check_functions:

--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -52,6 +52,7 @@ import sre_compile
 import string
 import sys
 import unicodedata
+import itertools
 
 
 _USAGE = """
@@ -6121,6 +6122,32 @@ def CheckMakePairUsesDeduction(filename, clean_lines, linenum, error):
           'For C++11-compatibility, omit template arguments from make_pair'
           ' OR use pair directly OR if appropriate, construct a pair directly')
 
+def AssembleString(clean_lines, start_lineno, start_linepos, end_lineno, end_linepos):
+    """
+    Concatenates all the strings between the starting line position and
+    the ending line position.
+
+    Note: this operated on the elided (no strings and comments) view of the
+    code.
+
+    Args:
+        clean_lines: All the lines
+        start_lineno: The starting line number
+        start_linepos: The index of the first character to include
+        end_lineno: The last line
+        end_linepos: The index of the first character not to include
+    """
+    if end_lineno < start_lineno:
+        return ''
+
+    if start_lineno == end_lineno:
+        return clean_lines.elided[start_lineno][start_linepos : end_linepos]
+
+    full_string = clean_lines.elided[start_lineno][start_linepos:]
+    for line in itertools.islice(clean_lines.elided, start_lineno + 1, end_lineno):
+        full_string += line
+    full_string += clean_lines.elided[end_lineno][:end_linepos]
+    return full_string
 
 def CheckRedundantVirtual(filename, clean_lines, linenum, error):
   """Check if line contains a redundant "virtual" function-specifier.

--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -1745,6 +1745,9 @@ def CloseExpression(clean_lines, linenum, pos):
   and have CloseExpression be just a simple lookup, but due to preprocessor
   tricks, this is not so easy.
 
+  Note this operates on the *elided lines* - the position will be wrong if you
+  want strings (or comments) to be included.
+
   Args:
     clean_lines: A CleansedLines instance containing the file.
     linenum: The number of the line to check.


### PR DESCRIPTION
- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message). - we don't have tests for the linter, but perhaps we should?
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

Note: this (annoyingly) won't report if someone deletes a comma from an existing multi-line test since the error is reported on the line of `SCENARIO`/`TEST_CASE`, which might not be modified. But for the common case that you are adding a new test, it will work. 

This work was done because it seemed like untagged tests weren't being run, but this doesn't actually seem to be the case. None the less, tests should be tagged per coding guidelines. 