### PR TITLE
Remove (unused) langapi dependency from solvers/

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -45,7 +45,7 @@ languages: util.dir langapi.dir \
            cpp.dir ansi-c.dir xmllang.dir assembler.dir \
            jsil.dir json.dir json-symtab-language.dir
 
-solvers.dir: util.dir langapi.dir
+solvers.dir: util.dir
 
 goto-instrument.dir: languages goto-programs.dir pointer-analysis.dir \
                      goto-symex.dir linking.dir analyses.dir solvers.dir

--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -229,5 +229,5 @@ solvers$(LIBEXT): $(OBJ) $(SOLVER_LIB)
 -include $(smt2/smt2_solver$(DEPEXT))
 
 smt2_solver$(EXEEXT): $(OBJ) smt2/smt2_solver$(OBJEXT) \
-	../util/util$(LIBEXT) ../langapi/langapi$(LIBEXT) ../big-int/big-int$(LIBEXT) $(SOLVER_LIB)
+	../util/util$(LIBEXT) ../big-int/big-int$(LIBEXT) $(SOLVER_LIB)
 	$(LINKBIN)

--- a/src/solvers/refinement/module_dependencies.txt
+++ b/src/solvers/refinement/module_dependencies.txt
@@ -1,4 +1,3 @@
-langapi # should go away
 solvers/flattening
 solvers/floatbv
 solvers/refinement

--- a/src/solvers/refinement/refine_arithmetic.cpp
+++ b/src/solvers/refinement/refine_arithmetic.cpp
@@ -13,8 +13,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/expr_util.h>
 #include <util/arith_tools.h>
 
-#include <langapi/language_util.h>
-
 #include <solvers/refinement/string_refinement_invariant.h>
 #include <solvers/floatbv/float_utils.h>
 
@@ -528,9 +526,5 @@ bv_refinementt::add_approximation(
 
 std::string bv_refinementt::approximationt::as_string() const
 {
-  #if 0
-  return from_expr(expr);
-  #else
   return std::to_string(id_nr)+"/"+id2string(expr.id());
-  #endif
 }


### PR DESCRIPTION
The code using from_expr was disabled via #if 0. Now the code is removed and the dependency can be dropped.

This currently includes commits from #3711, which thus needs to go in first.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
