### PR TITLE
Remove unnecessary ns.follow in symex_dereference [blocks: #3652]

### DIFF
--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -108,15 +108,14 @@ exprt goto_symext::address_arithmetic(
     // recursive call
     result=address_arithmetic(be.op(), state, guard, keep_array);
 
-    if(ns.follow(be.op().type()).id()==ID_array &&
-       result.id()==ID_address_of)
+    if(be.op().type().id() == ID_array && result.id() == ID_address_of)
     {
       address_of_exprt &a=to_address_of_expr(result);
 
       // turn &a of type T[i][j] into &(a[0][0])
-      for(const typet *t=&(ns.follow(a.type().subtype()));
-          t->id()==ID_array && !base_type_eq(expr.type(), *t, ns);
-          t=&(ns.follow(*t).subtype()))
+      for(const typet *t = &(a.type().subtype());
+          t->id() == ID_array && !base_type_eq(expr.type(), *t, ns);
+          t = &(t->subtype()))
         a.object()=index_exprt(a.object(), from_integer(0, index_type()));
     }
 
@@ -130,7 +129,7 @@ exprt goto_symext::address_arithmetic(
     result=plus_exprt(result, offset);
 
     // treat &array as &array[0]
-    const typet &expr_type=ns.follow(expr.type());
+    const typet &expr_type = expr.type();
     typet dest_type_subtype;
 
     if(expr_type.id()==ID_array && !keep_array)
@@ -188,7 +187,7 @@ exprt goto_symext::address_arithmetic(
     dereference_rec(result, state, guard, false);
 
     // turn &array into &array[0]
-    if(ns.follow(result.type()).id()==ID_array && !keep_array)
+    if(result.type().id() == ID_array && !keep_array)
       result=index_exprt(result, from_integer(0, index_type()));
 
     // handle field-sensitive SSA symbol
@@ -223,7 +222,7 @@ exprt goto_symext::address_arithmetic(
     result = address_arithmetic(tc_expr.op(), state, guard, keep_array);
 
     // treat &array as &array[0]
-    const typet &expr_type = ns.follow(expr.type());
+    const typet &expr_type = expr.type();
     typet dest_type_subtype;
 
     if(expr_type.id() == ID_array && !keep_array)
@@ -237,7 +236,7 @@ exprt goto_symext::address_arithmetic(
     throw unsupported_operation_exceptiont(
       "goto_symext::address_arithmetic does not handle " + expr.id_string());
 
-  const typet &expr_type=ns.follow(expr.type());
+  const typet &expr_type = expr.type();
   INVARIANT((expr_type.id()==ID_array && !keep_array) ||
             base_type_eq(pointer_type(expr_type), result.type(), ns),
             "either non-persistent array or pointer to result");
@@ -300,10 +299,9 @@ void goto_symext::dereference_rec(
     // this may yield a new auto-object
     trigger_auto_object(expr, state);
   }
-  else if(expr.id()==ID_index &&
-          to_index_expr(expr).array().id()==ID_member &&
-          to_array_type(ns.follow(to_index_expr(expr).array().type())).
-            size().is_zero())
+  else if(
+    expr.id() == ID_index && to_index_expr(expr).array().id() == ID_member &&
+    to_array_type(to_index_expr(expr).array().type()).size().is_zero())
   {
     // This is an expression of the form x.a[i],
     // where a is a zero-sized array. This gets
@@ -336,12 +334,11 @@ void goto_symext::dereference_rec(
 
     exprt &object=address_of_expr.object();
 
-    const typet &expr_type=ns.follow(expr.type());
     expr = address_arithmetic(
       object,
       state,
       guard,
-      to_pointer_type(expr_type).subtype().id() == ID_array);
+      to_pointer_type(expr.type()).subtype().id() == ID_array);
   }
   else if(expr.id()==ID_typecast)
   {


### PR DESCRIPTION
arrays are never hidden behind symbol or tag types.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
