### PR TITLE
strengthen type of parameter of gather_field_types

### DIFF
--- a/jbmc/src/java_bytecode/ci_lazy_methods_needed.h
+++ b/jbmc/src/java_bytecode/ci_lazy_methods_needed.h
@@ -20,7 +20,7 @@ class namespacet;
 class pointer_typet;
 class select_pointer_typet;
 class symbol_table_baset;
-class typet;
+class struct_tag_typet;
 
 class ci_lazy_methods_neededt
 {
@@ -64,7 +64,8 @@ private:
     const pointer_typet &pointer_type,
     const namespacet &ns);
 
-  void gather_field_types(const typet &class_type, const namespacet &ns);
+  void
+  gather_field_types(const struct_tag_typet &class_type, const namespacet &ns);
 };
 
 #endif


### PR DESCRIPTION
The first parameter of ci_lazy_methods_neededt::gather_field_types is always
a struct_tag_typet. This is now reflected in the signature.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
