### PR TITLE
signature of java_object_factoryt::gen_nondet_struct_init

### DIFF
--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -143,7 +143,6 @@ private:
     irep_idt class_identifier,
     bool skip_classid,
     lifetimet lifetime,
-    const struct_typet &struct_type,
     size_t depth,
     const update_in_placet &update_in_place,
     const source_locationt &location);
@@ -829,13 +828,13 @@ void java_object_factoryt::gen_nondet_struct_init(
   irep_idt class_identifier,
   bool skip_classid,
   lifetimet lifetime,
-  const struct_typet &struct_type,
   size_t depth,
   const update_in_placet &update_in_place,
   const source_locationt &location)
 {
-  PRECONDITION(ns.follow(expr.type()).id()==ID_struct);
-  PRECONDITION(struct_type.id()==ID_struct);
+  PRECONDITION(expr.type().id() == ID_struct_tag);
+  const struct_typet &struct_type =
+    ns.follow_tag(to_struct_tag_type(expr.type()));
 
   typedef struct_typet::componentst componentst;
   const irep_idt &struct_tag=struct_type.get_tag();
@@ -1039,7 +1038,6 @@ void java_object_factoryt::gen_nondet_init(
   const typet &type=
     override_ ? ns.follow(override_type) : ns.follow(expr.type());
 
-
   if(type.id()==ID_pointer)
   {
     // dereferenced type
@@ -1064,20 +1062,19 @@ void java_object_factoryt::gen_nondet_init(
   }
   else if(type.id()==ID_struct)
   {
-    const struct_typet struct_type=to_struct_type(type);
-
     // If we are about to initialize a generic class (as a superclass object
     // for a different object), add its concrete types to the map and delete
     // them on leaving this function scope.
     generic_parameter_specialization_map_keyst
       generic_parameter_specialization_map_keys(
         generic_parameter_specialization_map);
+
     if(is_sub)
     {
       const typet &symbol = override_ ? override_type : expr.type();
       PRECONDITION(symbol.id() == ID_struct_tag);
       generic_parameter_specialization_map_keys.insert_pairs_for_symbol(
-        to_struct_tag_type(symbol), struct_type);
+        to_struct_tag_type(symbol), to_struct_type(type));
     }
 
     gen_nondet_struct_init(
@@ -1087,7 +1084,6 @@ void java_object_factoryt::gen_nondet_init(
       class_identifier,
       skip_classid,
       lifetime,
-      struct_type,
       depth,
       update_in_place,
       location);


### PR DESCRIPTION
java_object_factoryt::gen_nondet_struct_init takes an expression as
parameter, whose type is the tag type that refers to a struct that is always
given as another parameter. The redundant parameter is removed.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
