### PR TITLE
JBMC: enable model and SSA equation verification

### DIFF
--- a/jbmc/regression/jbmc-concurrency/CMakeLists.txt
+++ b/jbmc/regression/jbmc-concurrency/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_test_pl_tests(
-    "$<TARGET_FILE:jbmc>"
+    "$<TARGET_FILE:jbmc> --validate-goto-model"
 )

--- a/jbmc/regression/jbmc-concurrency/CMakeLists.txt
+++ b/jbmc/regression/jbmc-concurrency/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_test_pl_tests(
-    "$<TARGET_FILE:jbmc> --validate-goto-model"
+    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation"
 )

--- a/jbmc/regression/jbmc-concurrency/Makefile
+++ b/jbmc/regression/jbmc-concurrency/Makefile
@@ -3,10 +3,10 @@ default: tests.log
 include ../../src/config.inc
 
 test:
-	@../$(CPROVER_DIR)/regression/test.pl -p -c ../../../src/jbmc/jbmc
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
 
 tests.log: ../$(CPROVER_DIR)/regression/test.pl
-	@../$(CPROVER_DIR)/regression/test.pl -p -c ../../../src/jbmc/jbmc
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
 
 show:
 	@for dir in *; do \

--- a/jbmc/regression/jbmc-concurrency/Makefile
+++ b/jbmc/regression/jbmc-concurrency/Makefile
@@ -3,10 +3,10 @@ default: tests.log
 include ../../src/config.inc
 
 test:
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation"
 
 tests.log: ../$(CPROVER_DIR)/regression/test.pl
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation"
 
 show:
 	@for dir in *; do \

--- a/jbmc/regression/jbmc-generics/CMakeLists.txt
+++ b/jbmc/regression/jbmc-generics/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_test_pl_tests(
-    "$<TARGET_FILE:jbmc> --validate-goto-model"
+    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation"
 )
 
 add_test_pl_profile(
     "jbmc-generics-symex-driven-lazy-loading"
-    "$<TARGET_FILE:jbmc> --validate-goto-model --symex-driven-lazy-loading"
+    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading"
     "-C;-X;symex-driven-lazy-loading-expected-failure;-s;symex-driven-loading"
     "CORE"
 )

--- a/jbmc/regression/jbmc-generics/CMakeLists.txt
+++ b/jbmc/regression/jbmc-generics/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_test_pl_tests(
-    "$<TARGET_FILE:jbmc>"
+    "$<TARGET_FILE:jbmc> --validate-goto-model"
 )
 
 add_test_pl_profile(
     "jbmc-generics-symex-driven-lazy-loading"
-    "$<TARGET_FILE:jbmc> --symex-driven-lazy-loading"
+    "$<TARGET_FILE:jbmc> --validate-goto-model --symex-driven-lazy-loading"
     "-C;-X;symex-driven-lazy-loading-expected-failure;-s;symex-driven-loading"
     "CORE"
 )

--- a/jbmc/regression/jbmc-generics/Makefile
+++ b/jbmc/regression/jbmc-generics/Makefile
@@ -3,12 +3,12 @@ default: tests.log
 include ../../src/config.inc
 
 test:
-	@../$(CPROVER_DIR)/regression/test.pl -p -c ../../../src/jbmc/jbmc
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
 
 tests.log: ../$(CPROVER_DIR)/regression/test.pl
-	@../$(CPROVER_DIR)/regression/test.pl -p -c ../../../src/jbmc/jbmc
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
 
 show:
 	@for dir in *; do \

--- a/jbmc/regression/jbmc-generics/Makefile
+++ b/jbmc/regression/jbmc-generics/Makefile
@@ -3,12 +3,12 @@ default: tests.log
 include ../../src/config.inc
 
 test:
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation"
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
 
 tests.log: ../$(CPROVER_DIR)/regression/test.pl
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation"
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
 
 show:
 	@for dir in *; do \

--- a/jbmc/regression/jbmc-inheritance/CMakeLists.txt
+++ b/jbmc/regression/jbmc-inheritance/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_test_pl_tests(
-    "$<TARGET_FILE:jbmc>"
+    "$<TARGET_FILE:jbmc> --validate-goto-model"
 )

--- a/jbmc/regression/jbmc-inheritance/CMakeLists.txt
+++ b/jbmc/regression/jbmc-inheritance/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_test_pl_tests(
-    "$<TARGET_FILE:jbmc> --validate-goto-model"
+    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation"
 )

--- a/jbmc/regression/jbmc-inheritance/Makefile
+++ b/jbmc/regression/jbmc-inheritance/Makefile
@@ -3,10 +3,10 @@ default: tests.log
 include ../../src/config.inc
 
 test:
-	@../$(CPROVER_DIR)/regression/test.pl -p -c ../../../src/jbmc/jbmc
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
 
 tests.log: ../$(CPROVER_DIR)/regression/test.pl
-	@../$(CPROVER_DIR)/regression/test.pl -p -c ../../../src/jbmc/jbmc
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
 
 show:
 	@for dir in *; do \

--- a/jbmc/regression/jbmc-inheritance/Makefile
+++ b/jbmc/regression/jbmc-inheritance/Makefile
@@ -3,10 +3,10 @@ default: tests.log
 include ../../src/config.inc
 
 test:
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation"
 
 tests.log: ../$(CPROVER_DIR)/regression/test.pl
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation"
 
 show:
 	@for dir in *; do \

--- a/jbmc/regression/jbmc-strings/CMakeLists.txt
+++ b/jbmc/regression/jbmc-strings/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_test_pl_tests(
-    "$<TARGET_FILE:jbmc>"
+    "$<TARGET_FILE:jbmc> --validate-goto-model"
 )
 
 add_test_pl_profile(
     "jbmc-strings-symex-driven-lazy-loading"
-    "$<TARGET_FILE:jbmc> --symex-driven-lazy-loading"
+    "$<TARGET_FILE:jbmc> --validate-goto-model --symex-driven-lazy-loading"
     "-C;-X;symex-driven-lazy-loading-expected-failure;-s;symex-driven-loading"
     "CORE"
 )

--- a/jbmc/regression/jbmc-strings/CMakeLists.txt
+++ b/jbmc/regression/jbmc-strings/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_test_pl_tests(
-    "$<TARGET_FILE:jbmc> --validate-goto-model"
+    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation"
 )
 
 add_test_pl_profile(
     "jbmc-strings-symex-driven-lazy-loading"
-    "$<TARGET_FILE:jbmc> --validate-goto-model --symex-driven-lazy-loading"
+    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading"
     "-C;-X;symex-driven-lazy-loading-expected-failure;-s;symex-driven-loading"
     "CORE"
 )

--- a/jbmc/regression/jbmc-strings/Makefile
+++ b/jbmc/regression/jbmc-strings/Makefile
@@ -3,20 +3,20 @@ default: tests.log
 include ../../src/config.inc
 
 test:
-	@../$(CPROVER_DIR)/regression/test.pl -p -c ../../../src/jbmc/jbmc
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
 
 testfuture:
-	@../$(CPROVER_DIR)/regression/test.pl -p -c ../../../src/jbmc/jbmc -CF
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -CF -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model" -CF
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -CF -s symex-driven-loading
 
 testall:
-	@../$(CPROVER_DIR)/regression/test.pl -p -c ../../../src/jbmc/jbmc -CFTK
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -CFTK -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model" -CFTK
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -CFTK -s symex-driven-loading
 
 tests.log: ../$(CPROVER_DIR)/regression/test.pl
-	@../$(CPROVER_DIR)/regression/test.pl -p -c ../../../src/jbmc/jbmc
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
 
 show:
 	@for dir in *; do \

--- a/jbmc/regression/jbmc-strings/Makefile
+++ b/jbmc/regression/jbmc-strings/Makefile
@@ -3,20 +3,20 @@ default: tests.log
 include ../../src/config.inc
 
 test:
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation"
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
 
 testfuture:
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model" -CF
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -CF -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation" -CF
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -CF -s symex-driven-loading
 
 testall:
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model" -CFTK
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -CFTK -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation" -CFTK
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -CFTK -s symex-driven-loading
 
 tests.log: ../$(CPROVER_DIR)/regression/test.pl
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation"
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
 
 show:
 	@for dir in *; do \

--- a/jbmc/regression/jbmc/CMakeLists.txt
+++ b/jbmc/regression/jbmc/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_test_pl_tests(
-    "$<TARGET_FILE:jbmc> --validate-goto-model"
+    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation"
 )
 
 add_test_pl_profile(
     "jbmc-symex-driven-lazy-loading"
-    "$<TARGET_FILE:jbmc> --validate-goto-model --symex-driven-lazy-loading"
+    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading"
     "-C;-X;symex-driven-lazy-loading-expected-failure;-s;symex-driven-loading"
     "CORE"
 )

--- a/jbmc/regression/jbmc/CMakeLists.txt
+++ b/jbmc/regression/jbmc/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_test_pl_tests(
-    "$<TARGET_FILE:jbmc>"
+    "$<TARGET_FILE:jbmc> --validate-goto-model"
 )
 
 add_test_pl_profile(
     "jbmc-symex-driven-lazy-loading"
-    "$<TARGET_FILE:jbmc> --symex-driven-lazy-loading"
+    "$<TARGET_FILE:jbmc> --validate-goto-model --symex-driven-lazy-loading"
     "-C;-X;symex-driven-lazy-loading-expected-failure;-s;symex-driven-loading"
     "CORE"
 )

--- a/jbmc/regression/jbmc/Makefile
+++ b/jbmc/regression/jbmc/Makefile
@@ -3,12 +3,12 @@ default: tests.log
 include ../../src/config.inc
 
 test:
-	@../$(CPROVER_DIR)/regression/test.pl -p -c ../../../src/jbmc/jbmc
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
 
 tests.log: ../$(CPROVER_DIR)/regression/test.pl
-	@../$(CPROVER_DIR)/regression/test.pl -p -c ../../../src/jbmc/jbmc
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
 
 show:
 	@for dir in *; do \

--- a/jbmc/regression/jbmc/Makefile
+++ b/jbmc/regression/jbmc/Makefile
@@ -3,12 +3,12 @@ default: tests.log
 include ../../src/config.inc
 
 test:
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation"
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
 
 tests.log: ../$(CPROVER_DIR)/regression/test.pl
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation"
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
 
 show:
 	@for dir in *; do \

--- a/jbmc/regression/strings-smoke-tests/CMakeLists.txt
+++ b/jbmc/regression/strings-smoke-tests/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_test_pl_tests(
-    "$<TARGET_FILE:jbmc> --validate-goto-model"
+    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation"
 )
 
 add_test_pl_profile(
     "strings-smoke-tests-symex-driven-lazy-loading"
-    "$<TARGET_FILE:jbmc> --validate-goto-model --symex-driven-lazy-loading"
+    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading"
     "-C;-X;symex-driven-lazy-loading-expected-failure;-s;symex-driven-loading"
     "CORE"
 )

--- a/jbmc/regression/strings-smoke-tests/CMakeLists.txt
+++ b/jbmc/regression/strings-smoke-tests/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_test_pl_tests(
-    "$<TARGET_FILE:jbmc>"
+    "$<TARGET_FILE:jbmc> --validate-goto-model"
 )
 
 add_test_pl_profile(
     "strings-smoke-tests-symex-driven-lazy-loading"
-    "$<TARGET_FILE:jbmc> --symex-driven-lazy-loading"
+    "$<TARGET_FILE:jbmc> --validate-goto-model --symex-driven-lazy-loading"
     "-C;-X;symex-driven-lazy-loading-expected-failure;-s;symex-driven-loading"
     "CORE"
 )

--- a/jbmc/regression/strings-smoke-tests/Makefile
+++ b/jbmc/regression/strings-smoke-tests/Makefile
@@ -3,20 +3,20 @@ default: tests.log
 include ../../src/config.inc
 
 test:
-	@../$(CPROVER_DIR)/regression/test.pl -p -c ../../../src/jbmc/jbmc
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
 
 testfuture:
-	@../$(CPROVER_DIR)/regression/test.pl -p -c ../../../src/jbmc/jbmc -CF
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -CF -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model" -CF
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -CF -s symex-driven-loading
 
 testall:
-	@../$(CPROVER_DIR)/regression/test.pl -p -c ../../../src/jbmc/jbmc -CFTK
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -CFTK -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model" -CFTK
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -CFTK -s symex-driven-loading
 
 tests.log: ../$(CPROVER_DIR)/regression/test.pl
-	@../$(CPROVER_DIR)/regression/test.pl -p -c ../../../src/jbmc/jbmc
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
 
 show:
 	@for dir in *; do \

--- a/jbmc/regression/strings-smoke-tests/Makefile
+++ b/jbmc/regression/strings-smoke-tests/Makefile
@@ -3,20 +3,20 @@ default: tests.log
 include ../../src/config.inc
 
 test:
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation"
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
 
 testfuture:
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model" -CF
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -CF -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation" -CF
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -CF -s symex-driven-loading
 
 testall:
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model" -CFTK
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -CFTK -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation" -CFTK
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -CFTK -s symex-driven-loading
 
 tests.log: ../$(CPROVER_DIR)/regression/test.pl
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model"
-	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation"
+	@../$(CPROVER_DIR)/regression/test.pl -p -c "../../../src/jbmc/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -X symex-driven-lazy-loading-expected-failure -s symex-driven-loading
 
 show:
 	@for dir in *; do \

--- a/jbmc/src/java_bytecode/simple_method_stubbing.cpp
+++ b/jbmc/src/java_bytecode/simple_method_stubbing.cpp
@@ -170,7 +170,8 @@ void java_simple_method_stubst::create_method_stub(symbolt &symbol)
       symbol_table);
     const symbol_exprt &init_symbol_expression = init_symbol.symbol_expr();
     code_assignt get_argument(
-      init_symbol_expression, symbol_exprt(this_argument.get_identifier()));
+      init_symbol_expression,
+      symbol_exprt(this_argument.get_identifier(), this_type));
     get_argument.add_source_location() = synthesized_source_location;
     new_instructions.add(get_argument);
     create_method_stub_at(

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -369,6 +369,16 @@ void jbmc_parse_optionst::get_command_line_options(optionst &options)
       "symex-coverage-report",
       cmdline.get_value("symex-coverage-report"));
 
+  if(cmdline.isset("validate-ssa-equation"))
+  {
+    options.set_option("validate-ssa-equation", true);
+  }
+
+  if(cmdline.isset("validate-goto-model"))
+  {
+    options.set_option("validate-goto-model", true);
+  }
+
   PARSE_OPTIONS_GOTO_TRACE(cmdline, options);
 
   if(cmdline.isset("no-lazy-methods"))
@@ -553,6 +563,11 @@ int jbmc_parse_optionst::doit()
     if(set_properties(goto_model))
       return 7; // should contemplate EX_USAGE from sysexits.h
 
+    if(cmdline.isset("validate-goto-model"))
+    {
+      goto_model.validate(validation_modet::INVARIANT);
+    }
+
     // The `configure_bmc` callback passed will enable enum-unwind-static if
     // applicable.
     return bmct::do_language_agnostic_bmc(
@@ -584,6 +599,11 @@ int jbmc_parse_optionst::doit()
     // Add failed symbols for any symbol created prior to loading any
     // particular function:
     add_failed_symbols(lazy_goto_model.symbol_table);
+
+    if(cmdline.isset("validate-goto-model"))
+    {
+      lazy_goto_model.validate(validation_modet::INVARIANT);
+    }
 
     // Provide show-goto-functions and similar dump functions after symex
     // executes. If --paths is active, these dump routines run after every
@@ -1141,6 +1161,7 @@ void jbmc_parse_optionst::help()
     " --version                    show version and exit\n"
     " --xml-ui                     use XML-formatted output\n"
     " --json-ui                    use JSON-formatted output\n"
+    HELP_VALIDATE
     HELP_GOTO_TRACE
     HELP_FLUSH
     " --verbosity #                verbosity level\n"

--- a/jbmc/src/jbmc/jbmc_parse_options.h
+++ b/jbmc/src/jbmc/jbmc_parse_options.h
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/ui_message.h>
 #include <util/parse_options.h>
 #include <util/timestamper.h>
+#include <util/validation_interface.h>
 
 #include <langapi/language.h>
 
@@ -80,6 +81,7 @@ class optionst;
   "(localize-faults)(localize-faults-method):" \
   "(java-threading)" \
   OPT_GOTO_TRACE \
+  OPT_VALIDATE \
   "(symex-driven-lazy-loading)"
 // clang-format on
 

--- a/jbmc/src/jbmc/jbmc_parse_options.h
+++ b/jbmc/src/jbmc/jbmc_parse_options.h
@@ -12,9 +12,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_JBMC_JBMC_PARSE_OPTIONS_H
 #define CPROVER_JBMC_JBMC_PARSE_OPTIONS_H
 
-#include <util/ui_message.h>
 #include <util/parse_options.h>
 #include <util/timestamper.h>
+#include <util/ui_message.h>
 #include <util/validation_interface.h>
 
 #include <langapi/language.h>

--- a/src/goto-programs/abstract_goto_model.h
+++ b/src/goto-programs/abstract_goto_model.h
@@ -49,6 +49,12 @@ public:
   /// underneath them, so this should only be used to lend a reference to code
   /// that cannot also call get_goto_function.
   virtual const symbol_tablet &get_symbol_table() const = 0;
+
+  /// Check that the goto model is well-formed
+  ///
+  /// The validation mode indicates whether well-formedness check failures are
+  /// reported via DATA_INVARIANT violations or exceptions.
+  virtual void validate(const validation_modet vm) const = 0;
 };
 
 #endif

--- a/src/goto-programs/goto_model.h
+++ b/src/goto-programs/goto_model.h
@@ -94,7 +94,7 @@ public:
   ///
   /// The validation mode indicates whether well-formedness check failures are
   /// reported via DATA_INVARIANT violations or exceptions.
-  void validate(const validation_modet vm) const
+  void validate(const validation_modet vm) const override
   {
     symbol_table.validate(vm);
 
@@ -136,6 +136,18 @@ public:
   {
     return goto_functions.function_map.find(id) !=
            goto_functions.function_map.end();
+  }
+
+  /// Check that the goto model is well-formed
+  ///
+  /// The validation mode indicates whether well-formedness check failures are
+  /// reported via DATA_INVARIANT violations or exceptions.
+  void validate(const validation_modet vm) const override
+  {
+    symbol_table.validate(vm);
+
+    const namespacet ns(symbol_table);
+    goto_functions.validate(ns, vm);
   }
 
 private:

--- a/src/goto-programs/lazy_goto_model.h
+++ b/src/goto-programs/lazy_goto_model.h
@@ -243,6 +243,15 @@ public:
     return goto_functions.at(id);
   }
 
+  /// Check that the goto model is well-formed
+  ///
+  /// The validation mode indicates whether well-formedness check failures are
+  /// reported via DATA_INVARIANT violations or exceptions.
+  void validate(const validation_modet vm) const override
+  {
+    goto_model->validate(vm);
+  }
+
 private:
   std::unique_ptr<goto_modelt> goto_model;
 

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -973,7 +973,7 @@ void symex_target_equationt::SSA_stept::validate(
     validate_full_expr(ssa_rhs, ns, vm);
     DATA_CHECK(
       vm,
-      base_type_eq(ssa_lhs.get_original_expr(), ssa_rhs, ns),
+      base_type_eq(ssa_lhs.get_original_expr().type(), ssa_rhs.type(), ns),
       "Type inequality in SSA assignment\nlhs-type: " +
         ssa_lhs.get_original_expr().type().id_string() +
         "\nrhs-type: " + ssa_rhs.type().id_string());

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -961,8 +961,12 @@ void symex_target_equationt::SSA_stept::validate(
   case goto_trace_stept::typet::CONSTRAINT:
     validate_full_expr(cond_expr, ns, vm);
     break;
-  case goto_trace_stept::typet::ASSIGNMENT:
   case goto_trace_stept::typet::DECL:
+    validate_full_expr(ssa_lhs, ns, vm);
+    validate_full_expr(ssa_full_lhs, ns, vm);
+    validate_full_expr(original_full_lhs, ns, vm);
+    break;
+  case goto_trace_stept::typet::ASSIGNMENT:
     validate_full_expr(ssa_lhs, ns, vm);
     validate_full_expr(ssa_full_lhs, ns, vm);
     validate_full_expr(original_full_lhs, ns, vm);

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -303,7 +303,7 @@ public:
 
     DATA_CHECK(
       vm,
-      code.op0().type() == code.op1().type(),
+      base_type_eq(code.op0().type(), code.op1().type(), ns),
       "lhs and rhs of assignment must have same type");
   }
 

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -296,7 +296,7 @@ public:
 
   static void validate(
     const codet &code,
-    const namespacet &,
+    const namespacet &ns,
     const validation_modet vm = validation_modet::INVARIANT)
   {
     check(code, vm);

--- a/src/util/symbol.cpp
+++ b/src/util/symbol.cpp
@@ -137,10 +137,11 @@ bool symbolt::is_well_formed() const
   // Well-formedness criterion number 2 is for a symbol
   // to have it's base name as a suffix to it's more
   // general name.
-  if(!has_suffix(id2string(name), id2string(base_name)))
-  {
+  // Exception: Java symbols' base names do not have type signatures
+  // (for example, they can have name "someclass.method:(II)V" and base name
+  // "method")
+  if(!has_suffix(id2string(name), id2string(base_name)) && mode != ID_java)
     return false;
-  }
 
   return true;
 }


### PR DESCRIPTION
This enables validation of the GOTO model and SSA equations in all JBMC regression tests, making the minimal modifications such that they work:

* Fixing an accidentally untyped expression
* Disabling basename validation for Java, which presently uses a different convention that C for name-to-basename relationship
* Loosening type comparison to only require `base_type_eq`, not exact equality
* Fixing SSA expression type verification
* Fixing SSA DECL verification

I package these together here because this enables all these small fixes to be checked throughout the whole regression test suite, but if people prefer they can be split apart. Naturally, recommend reviewing commit by commit.