### PR TITLE
change verbosity of runtime output

### DIFF
--- a/regression/cbmc/Failing_Assert1/test.desc
+++ b/regression/cbmc/Failing_Assert1/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
-
+--verbosity 8
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/src/cbmc/all_properties.cpp
+++ b/src/cbmc/all_properties.cpp
@@ -134,9 +134,10 @@ safety_checkert::resultt bmc_all_propertiest::operator()()
   {
     auto solver_stop = std::chrono::steady_clock::now();
 
-    status() << "Runtime decision procedure: "
-             << std::chrono::duration<double>(solver_stop-solver_start).count()
-             << "s" << eom;
+    statistics()
+      << "Runtime decision procedure: "
+      << std::chrono::duration<double>(solver_stop - solver_start).count()
+      << "s" << eom;
   }
 
   // report

--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -61,9 +61,10 @@ decision_proceduret::resultt bmct::run_decision_procedure()
 
   {
     auto solver_stop = std::chrono::steady_clock::now();
-    status() << "Runtime decision procedure: "
-             << std::chrono::duration<double>(solver_stop-solver_start).count()
-             << "s" << eom;
+    statistics()
+      << "Runtime decision procedure: "
+      << std::chrono::duration<double>(solver_stop - solver_start).count()
+      << "s" << eom;
   }
 
   return dec_result;

--- a/src/cbmc/fault_localization.cpp
+++ b/src/cbmc/fault_localization.cpp
@@ -263,9 +263,10 @@ fault_localizationt::run_decision_procedure(prop_convt &prop_conv)
 
   {
     auto solver_stop=std::chrono::steady_clock::now();
-    status() << "Runtime decision procedure: "
-             << std::chrono::duration<double>(solver_stop-solver_start).count()
-             << "s" << eom;
+    statistics()
+      << "Runtime decision procedure: "
+      << std::chrono::duration<double>(solver_stop - solver_start).count()
+      << "s" << eom;
   }
 
   return dec_result;


### PR DESCRIPTION
The current verbosity of runtime measurements is 'status' (6), and this
commit changes that to 'statistics' (8).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
