### PR TITLE
Feature nondet array initialization [blocks: #3572]

### DIFF
--- a/regression/cbmc/pointer-to-array-function-parameters-max-size/test.c
+++ b/regression/cbmc/pointer-to-array-function-parameters-max-size/test.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+void test(int *arr, int sz)
+{
+  assert(sz <= 10);
+  for(int i = 0; i < sz; ++i)
+  {
+    arr[i] = 0;
+  }
+}

--- a/regression/cbmc/pointer-to-array-function-parameters-max-size/test.desc
+++ b/regression/cbmc/pointer-to-array-function-parameters-max-size/test.desc
@@ -1,0 +1,12 @@
+CORE
+test.c
+--function test --pointers-to-treat-as-arrays arr --max-dynamic-array-size 20 --pointer-check --unwind 20 --associated-array-sizes arr:sz
+\[test.assertion.1\] line \d+ assertion sz <= 10: FAILURE
+\[test.pointer_dereference.1\] line \d+ dereference failure: pointer NULL in arr\[\(signed( long)* int\)i\]: SUCCESS
+\[test.pointer_dereference.2\] line \d+ dereference failure: pointer invalid in arr\[\(signed( long)* int\)i\]: SUCCESS
+\[test.pointer_dereference.3\] line \d+ dereference failure: deallocated dynamic object in arr\[\(signed( long)* int\)i\]: SUCCESS
+\[test.pointer_dereference.4\] line \d+ dereference failure: dead object in arr\[\(signed( long)* int\)i\]: SUCCESS
+\[test.pointer_dereference.5\] line \d+ dereference failure: pointer outside dynamic object bounds in arr\[\(signed( long)* int\)i\]: SUCCESS
+\[test.pointer_dereference.6\] line \d+ dereference failure: pointer outside object bounds in arr\[\(signed( long)* int\)i\]: SUCCESS
+EXIT=10
+SIGNAL=0

--- a/regression/cbmc/pointer-to-array-function-parameters-multi-arg-right/test.c
+++ b/regression/cbmc/pointer-to-array-function-parameters-multi-arg-right/test.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+
+int is_prefix_of(
+  const char *string,
+  int string_size,
+  const char *prefix,
+  int prefix_size)
+{
+  if(string_size < prefix_size)
+  {
+    return 0;
+  }
+
+  for(int ix = 0; ix < prefix_size; ++ix)
+  {
+    if(string[ix] != prefix[ix])
+    {
+      return 0;
+    }
+  }
+  return 1;
+}

--- a/regression/cbmc/pointer-to-array-function-parameters-multi-arg-right/test.desc
+++ b/regression/cbmc/pointer-to-array-function-parameters-multi-arg-right/test.desc
@@ -1,0 +1,6 @@
+CORE
+test.c
+--function is_prefix_of --pointers-to-treat-as-arrays string,prefix --associated-array-sizes string:string_size,prefix:prefix_size --pointer-check --unwind 20
+SIGNAL=0
+EXIT=0
+VERIFICATION SUCCESSFUL

--- a/regression/cbmc/pointer-to-array-function-parameters-multi-arg-wrong/test.c
+++ b/regression/cbmc/pointer-to-array-function-parameters-multi-arg-wrong/test.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+#include <stddef.h>
+
+int is_prefix_of(
+  const char *string,
+  size_t string_size,
+  const char *prefix,
+  size_t prefix_size)
+{
+  if(string_size < prefix_size)
+  {
+    return 0;
+  }
+  assert(prefix_size <= string_size);
+  // oh no! we should have used prefix_size here
+  for(int ix = 0; ix < string_size; ++ix)
+  {
+    if(string[ix] != prefix[ix])
+    {
+      return 0;
+    }
+  }
+  return 1;
+}

--- a/regression/cbmc/pointer-to-array-function-parameters-multi-arg-wrong/test.desc
+++ b/regression/cbmc/pointer-to-array-function-parameters-multi-arg-wrong/test.desc
@@ -1,0 +1,7 @@
+CORE
+test.c
+--function is_prefix_of --pointers-to-treat-as-arrays string,prefix --associated-array-sizes string:string_size,prefix:prefix_size --pointer-check --unwind 10
+EXIT=10
+SIGNAL=0
+\[is_prefix_of.pointer_dereference.\d+\] line \d+ dereference failure: pointer outside dynamic object bounds in prefix\[\(signed( long)* int\)ix\]: FAILURE
+VERIFICATION FAILED

--- a/regression/cbmc/pointer-to-array-function-parameters-with-size/test.c
+++ b/regression/cbmc/pointer-to-array-function-parameters-with-size/test.c
@@ -1,0 +1,7 @@
+void test(int *arr, int sz)
+{
+  for(int i = 0; i < sz; ++i)
+  {
+    arr[i] = 0;
+  }
+}

--- a/regression/cbmc/pointer-to-array-function-parameters-with-size/test.desc
+++ b/regression/cbmc/pointer-to-array-function-parameters-with-size/test.desc
@@ -1,0 +1,11 @@
+CORE
+test.c
+--function test --pointers-to-treat-as-arrays arr --pointer-check --unwind 10 --associated-array-sizes arr:sz
+EXIT=0
+SIGNAL=0
+\[test.pointer_dereference.1\] line \d+ dereference failure: pointer NULL in arr\[\(signed( long)* int\)i\]: SUCCESS
+\[test.pointer_dereference.2\] line \d+ dereference failure: pointer invalid in arr\[\(signed( long)* int\)i\]: SUCCESS
+\[test.pointer_dereference.3\] line \d+ dereference failure: deallocated dynamic object in arr\[\(signed( long)* int\)i\]: SUCCESS
+\[test.pointer_dereference.4\] line \d+ dereference failure: dead object in arr\[\(signed( long)* int\)i\]: SUCCESS
+\[test.pointer_dereference.5\] line \d+ dereference failure: pointer outside dynamic object bounds in arr\[\(signed( long)* int\)i\]: SUCCESS
+\[test.pointer_dereference.6\] line \d+ dereference failure: pointer outside object bounds in arr\[\(signed( long)* int\)i\]: SUCCESS

--- a/regression/cbmc/pointer-to-array-function-parameters/test.c
+++ b/regression/cbmc/pointer-to-array-function-parameters/test.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+
+void test(int *arr)
+{
+  // works because the arrays we generate have at least one element
+  arr[0] = 5;
+
+  // doesn't work because our arrays have at most ten elements
+  arr[10] = 10;
+}

--- a/regression/cbmc/pointer-to-array-function-parameters/test.desc
+++ b/regression/cbmc/pointer-to-array-function-parameters/test.desc
@@ -1,0 +1,6 @@
+CORE
+test.c
+--function test --pointers-to-treat-as-arrays arr --pointer-check --unwind 20
+\[test.pointer_dereference.5\] line \d+ dereference failure: pointer outside dynamic object bounds in arr\[\(signed( long)* int\)0\]: SUCCESS
+\[test.pointer_dereference.12\] line \d+ dereference failure: pointer outside dynamic object bounds in arr\[\(signed( long)* int\)10\]: FAILURE
+--

--- a/scripts/delete_failing_smt2_solver_tests
+++ b/scripts/delete_failing_smt2_solver_tests
@@ -49,6 +49,8 @@ rm Quantifiers-invalid-var-range/test.desc
 rm Quantifiers-type/test.desc
 rm Union_Initialization1/test.desc
 rm address_space_size_limit1/test.desc
+rm address_space_size_limit3/test.desc
+rm argv1/test.desc
 rm array-function-parameters/test.desc
 rm array-tests/test.desc
 rm bounds_check1/test.desc
@@ -68,6 +70,15 @@ rm memory_allocation1/test.desc
 rm pointer-function-parameters-struct-mutual-recursion/test.desc
 rm pointer-function-parameters-struct-simple-recursion/test.desc
 rm pointer-function-parameters-struct-simple-recursion-2/test.desc
+rm pointer-function-parameters-struct-simple-recursion-3/test.desc
+rm pointer-to-array-function-parameters-max-size/test.desc
+rm pointer-to-array-function-parameters-multi-arg-right/test.desc
+rm pointer-to-array-function-parameters-multi-arg-wrong/test.desc
+rm pointer-to-array-function-parameters-with-size/test.desc
+rm pointer-to-array-function-parameters/test.desc
+rm read1/test.desc
+rm realloc1/test.desc
+rm realloc2/test.desc
 rm scanf1/test.desc
 rm stack-trace/test.desc
 rm struct6/test.desc

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -27,7 +27,7 @@ exprt::operandst build_function_environment(
 {
   exprt::operandst main_arguments;
   main_arguments.resize(parameters.size());
-
+  std::map<irep_idt, irep_idt> deferred_array_sizes;
   for(std::size_t param_number=0;
       param_number<parameters.size();
       param_number++)
@@ -42,7 +42,8 @@ exprt::operandst build_function_environment(
       base_name,
       p.type(),
       p.source_location(),
-      object_factory_parameters);
+      object_factory_parameters,
+      deferred_array_sizes);
   }
 
   return main_arguments;

--- a/src/ansi-c/ansi_c_language.h
+++ b/src/ansi-c/ansi_c_language.h
@@ -22,13 +22,26 @@ Author: Daniel Kroening, kroening@kroening.com
 // clang-format off
 #define OPT_ANSI_C_LANGUAGE \
   "(max-nondet-tree-depth):" \
-  "(min-null-tree-depth):"
+  "(min-null-tree-depth):" \
+  "(pointers-to-treat-as-arrays):" \
+  "(associated-array-sizes):" \
+  "(max-dynamic-array-size):" \
 
 #define HELP_ANSI_C_LANGUAGE \
   " --max-nondet-tree-depth N    limit size of nondet (e.g. input) object tree;\n" /* NOLINT(*) */\
   "                              at level N pointers are set to null\n" \
   " --min-null-tree-depth N      minimum level at which a pointer can first be\n" /* NOLINT(*) */\
-  "                              NULL in a recursively nondet initialized struct\n" /* NOLINT(*) */
+  "                              NULL in a recursively nondet initialized struct\n" /* NOLINT(*) */\
+  " --pointers-to-treat-as-arrays <identifier,...>  comma separated list of\n" \
+  "                               identifiers that should be initialized as arrays\n" /* NOLINT(*) */ \
+  " --associated-array-sizes <identifier:identifier...>\n" \
+  "                               comma separated list of colon separated pairs\n" /* NOLINT(*) */ \
+  "                               of identifiers; The first element of the pair \n" /* NOLINT(*) */ \
+  "                               should be the name of an array pointer \n" \
+  "                               (see --pointers-to-treat-as-arrays),\n" \
+  "                               the second an integer parameter that\n" \
+  "                               should hold its size\n" \
+  " --max-dynamic-array-size <size>  max size for dynamically allocated arrays\n" /* NOLINT(*) */
 // clang-format on
 
 class ansi_c_languaget:public languaget

--- a/src/ansi-c/c_nondet_symbol_factory.h
+++ b/src/ansi-c/c_nondet_symbol_factory.h
@@ -22,7 +22,8 @@ symbol_exprt c_nondet_symbol_factory(
   symbol_tablet &symbol_table,
   const irep_idt base_name,
   const typet &type,
-  const source_locationt &,
-  const c_object_factory_parameterst &object_factory_parameters);
+  const source_locationt &loc,
+  const c_object_factory_parameterst &object_factory_parameters,
+  std::map<irep_idt, irep_idt> &deferred_array_sizes);
 
 #endif // CPROVER_ANSI_C_C_NONDET_SYMBOL_FACTORY_H

--- a/src/ansi-c/c_object_factory_parameters.cpp
+++ b/src/ansi-c/c_object_factory_parameters.cpp
@@ -8,7 +8,118 @@ Author: Daniel Poetzl
 
 #include "c_object_factory_parameters.h"
 
+#include <util/cmdline.h>
+#include <util/exception_utils.h>
+#include <util/optional_utils.h>
+#include <util/string_utils.h>
+
+#include <algorithm>
+#include <iterator>
+#include <string>
+
 void parse_c_object_factory_options(const cmdlinet &cmdline, optionst &options)
 {
   parse_object_factory_options(cmdline, options);
+  if(cmdline.isset("pointers-to-treat-as-arrays"))
+  {
+    options.set_option(
+      "pointers-to-treat-as-arrays",
+      cmdline.get_comma_separated_values("pointers-to-treat-as-arrays"));
+  }
+  if(cmdline.isset("associated-array-sizes"))
+  {
+    options.set_option(
+      "associated-array-sizes",
+      cmdline.get_comma_separated_values("associated-array-sizes"));
+  }
+  if(cmdline.isset("max-dynamic-array-size"))
+  {
+    options.set_option(
+      "max-dynamic-array-size", cmdline.get_value("max-dynamic-array-size"));
+  }
+}
+
+void c_object_factory_parameterst::set(const optionst &options)
+{
+  object_factory_parameterst::set(options);
+  auto const &pointers_to_treat_as_array =
+    options.get_list_option("pointers-to-treat-as-arrays");
+  std::transform(
+    std::begin(pointers_to_treat_as_array),
+    std::end(pointers_to_treat_as_array),
+    std::inserter(
+      this->pointers_to_treat_as_array, this->pointers_to_treat_as_array.end()),
+    id2string);
+
+  if(options.is_set("max-dynamic-array-size"))
+  {
+    max_dynamic_array_size =
+      options.get_unsigned_int_option("max-dynamic-array-size");
+    if(max_dynamic_array_size == 0)
+    {
+      throw invalid_command_line_argument_exceptiont(
+        "Max dynamic array size must be >= 1", "--max-dynamic-array-size");
+    }
+  }
+  if(options.is_set("associated-array-sizes"))
+  {
+    array_name_to_associated_array_size_variable.clear();
+    variables_that_hold_array_sizes.clear();
+    auto const &array_size_pairs =
+      options.get_list_option("associated-array-sizes");
+    for(auto const &array_size_pair : array_size_pairs)
+    {
+      std::string array_name;
+      std::string size_name;
+      try
+      {
+        split_string(array_size_pair, ':', array_name, size_name);
+      }
+      catch(const deserialization_exceptiont &e)
+      {
+        throw invalid_command_line_argument_exceptiont{
+          "can't parse parameter value",
+          "--associated-array-sizes",
+          "pairs of array/size parameter names, separated by a ':' colon"};
+      }
+      auto const mapping_insert_result =
+        array_name_to_associated_array_size_variable.insert(
+          {irep_idt{array_name}, irep_idt{size_name}});
+      if(!mapping_insert_result.second)
+      {
+        throw invalid_command_line_argument_exceptiont{
+          "duplicate associated size entries for array `" + array_name +
+            "', existing: `" + id2string(mapping_insert_result.first->second) +
+            "', tried to insert: `" + size_name + "'",
+          "--associated-array-sizes"};
+      }
+      auto const size_name_insert_result =
+        variables_that_hold_array_sizes.insert(irep_idt{size_name});
+      if(!size_name_insert_result.second)
+      {
+        throw invalid_command_line_argument_exceptiont{
+          "using size parameter `" + size_name + "' more than once",
+          "--associated-array-sizes"};
+      }
+    }
+  }
+}
+
+bool c_object_factory_parameterst::is_array_size_parameter(irep_idt id) const
+{
+  return variables_that_hold_array_sizes.find(id) !=
+         end(variables_that_hold_array_sizes);
+}
+
+optionalt<irep_idt> c_object_factory_parameterst::get_associated_size_variable(
+  irep_idt array_id) const
+{
+  return optional_lookup(
+    array_name_to_associated_array_size_variable, array_id);
+}
+
+bool c_object_factory_parameterst::should_be_treated_as_array(irep_idt id) const
+{
+  return pointers_to_treat_as_array.find(id) !=
+         pointers_to_treat_as_array.end();
 }

--- a/src/ansi-c/c_object_factory_parameters.h
+++ b/src/ansi-c/c_object_factory_parameters.h
@@ -9,7 +9,11 @@ Author: Daniel Poetzl
 #ifndef CPROVER_ANSI_C_C_OBJECT_FACTORY_PARAMETERS_H
 #define CPROVER_ANSI_C_C_OBJECT_FACTORY_PARAMETERS_H
 
+#include <map>
+#include <set>
 #include <util/object_factory_parameters.h>
+#include <util/optional.h>
+#include <util/options.h>
 
 struct c_object_factory_parameterst final : public object_factory_parameterst
 {
@@ -21,6 +25,19 @@ struct c_object_factory_parameterst final : public object_factory_parameterst
     : object_factory_parameterst(options)
   {
   }
+
+  bool should_be_treated_as_array(irep_idt id) const;
+  bool is_array_size_parameter(irep_idt id) const;
+  optionalt<irep_idt> get_associated_size_variable(irep_idt array_id) const;
+
+  void set(const optionst &options) override;
+
+  std::size_t max_dynamic_array_size = 2;
+
+private:
+  std::set<irep_idt> pointers_to_treat_as_array;
+  std::set<irep_idt> variables_that_hold_array_sizes;
+  std::map<irep_idt, irep_idt> array_name_to_associated_array_size_variable;
 };
 
 /// Parse the c object factory parameters from a given command line

--- a/src/util/object_factory_parameters.h
+++ b/src/util/object_factory_parameters.h
@@ -77,7 +77,7 @@ struct object_factory_parameterst
   irep_idt function_id;
 
   /// Assigns the parameters from given options
-  void set(const optionst &);
+  virtual void set(const optionst &);
 };
 
 void parse_object_factory_options(const cmdlinet &, optionst &);


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

This PR adds options that let a user generate initialisation code for "dynamic" array parameters (i.e. pointers which point to an array, optionally coupled with a parameter holding their size). This is "opt-in", i.e. the user has to declare which of their function parameters are meant to be arrays (and which parameter holds the size of which array, if any).

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
