### PR TITLE
change default verbosity of CBMC to 'status'

### DIFF
--- a/regression/cbmc/BV_Arithmetic3/test.desc
+++ b/regression/cbmc/BV_Arithmetic3/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
-
+--verbosity 8
 ^EXIT=0$
 ^SIGNAL=0$
 (Starting CEGAR Loop|^Generated 1 VCC\(s\), 0 remaining after simplification$)

--- a/regression/cbmc/Fixedbv4/test.desc
+++ b/regression/cbmc/Fixedbv4/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
-
+--verbosity 8
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/goto-instrument/unwind-continue-as-loops1/test.desc
+++ b/regression/goto-instrument/unwind-continue-as-loops1/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---unwind 5 --continue-as-loops
+--unwind 5 --continue-as-loops --verbosity 8
 ^Unwinding loop.*iteration 5
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-instrument/unwind-unwindset1/test.desc
+++ b/regression/goto-instrument/unwind-unwindset1/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---unwind 9 --unwindset main.0:10 --unwinding-assertions
+--unwind 9 --unwindset main.0:10 --unwinding-assertions --verbosity 8
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/goto-instrument/unwind-unwindset2/test.desc
+++ b/regression/goto-instrument/unwind-unwindset2/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---unwindset main.0:10 --unwinding-assertions
+--unwindset main.0:10 --unwinding-assertions --verbosity 8
 ^Unwinding loop
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-instrument/unwind-unwindset3/test.desc
+++ b/regression/goto-instrument/unwind-unwindset3/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---unwind 10 --unwindset main.0:
+--unwind 10 --unwindset main.0: --verbosity 8
 ^Unwinding loop
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-instrument/unwind-unwindset4/test.desc
+++ b/regression/goto-instrument/unwind-unwindset4/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---unwindset main.0:10,f.0:10,g.0:10,g.1:10 --unwinding-assertions
+--unwindset main.0:10,f.0:10,g.0:10,g.1:10 --unwinding-assertions --verbosity 8
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/goto-instrument/unwind-unwindset5/test.desc
+++ b/regression/goto-instrument/unwind-unwindset5/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---unwindset main.0:10,main.1:10,main.2:10 --unwinding-assertions
+--unwindset main.0:10,main.1:10,main.2:10 --unwinding-assertions --verbosity 8
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/goto-instrument/unwind-zero-unwind2/test.desc
+++ b/regression/goto-instrument/unwind-zero-unwind2/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---unwind 0 --continue-as-loops
+--unwind 0 --continue-as-loops --verbosity 8
 ^Unwinding loop.*iteration 10
 ^EXIT=0$
 ^SIGNAL=0$

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -450,7 +450,7 @@ int cbmc_parse_optionst::doit()
   get_command_line_options(options);
 
   eval_verbosity(
-    cmdline.get_value("verbosity"), messaget::M_STATISTICS, ui_message_handler);
+    cmdline.get_value("verbosity"), messaget::M_STATUS, ui_message_handler);
 
   //
   // Print a banner


### PR DESCRIPTION
This reduces the amount of default output on the console.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
