### PR TITLE
Tighten up global extern detection in phi_function

### DIFF
--- a/jbmc/regression/jbmc/phi-merge_uninitialized_values/field.desc
+++ b/jbmc/regression/jbmc/phi-merge_uninitialized_values/field.desc
@@ -5,8 +5,8 @@ activate-multi-line-match
 ^EXIT=0$
 ^SIGNAL=0$
 --
-^.*:\s+(dynamic_object|new_tmp)[0-9]+(@[0-9]+)?#0\)
-^.*\?\s+(dynamic_object|new_tmp)[0-9]+(@[0-9]+)?#0\s+:
+\([^\s]+guard[^\s]+ \? [^\s]+#0 : [^\s]+\)
+\([^\s]+guard[^\s]+ \? [^\s]+ : [^\s]+#0\)
 --
 These regexes are making sure that a variable of generation 0 dosen't appear in a phi merge, so the below
 statement:

--- a/jbmc/regression/jbmc/phi-merge_uninitialized_values/local.desc
+++ b/jbmc/regression/jbmc/phi-merge_uninitialized_values/local.desc
@@ -5,8 +5,8 @@ activate-multi-line-match
 ^EXIT=0$
 ^SIGNAL=0$
 --
-^.*:\s+(dynamic_object|new_tmp)[0-9]+(@[0-9]+)?#0\)
-^.*\?\s+(dynamic_object|new_tmp)[0-9]+(@[0-9]+)?#0\s+:
+\([^\s]+guard[^\s]+ \? [^\s]+#0 : [^\s]+\)
+\([^\s]+guard[^\s]+ \? [^\s]+ : [^\s]+#0\)
 --
 These regexes are making sure that a variable of generation 0 dosen't appear in a phi merge, so the below
 statement:

--- a/jbmc/regression/jbmc/phi-merge_uninitialized_values/static_field.desc
+++ b/jbmc/regression/jbmc/phi-merge_uninitialized_values/static_field.desc
@@ -5,8 +5,8 @@ activate-multi-line-match
 ^EXIT=0$
 ^SIGNAL=0$
 --
-^.*:\s+(dynamic_object|new_tmp)[0-9]+(@[0-9]+)?#0\)
-^.*\?\s+(dynamic_object|new_tmp)[0-9]+(@[0-9]+)?#0\s+:
+\([^\s]+guard[^\s]+ \? [^\s]+#0 : [^\s]+\)
+\([^\s]+guard[^\s]+ \? [^\s]+ : [^\s]+#0\)
 --
 These regexes are making sure that a variable of generation 0 dosen't appear in a phi merge, so the below
 statement:

--- a/regression/cbmc/phi-merge_uninitialized_values/dynamic.desc
+++ b/regression/cbmc/phi-merge_uninitialized_values/dynamic.desc
@@ -5,8 +5,8 @@ activate-multi-line-match
 ^EXIT=0$
 ^SIGNAL=0$
 --
-^.*:\s+dynamic_object[0-9]+(@[0-9]+)?#0\)
-^.*\?\s+dynamic_object[0-9]+(@[0-9]+)?#0\s+:
+\([^\s]+guard[^\s]+ \? [^\s]+#0 : [^\s]+\)
+\([^\s]+guard[^\s]+ \? [^\s]+ : [^\s]+#0\)
 --
 These regexes are making sure that a variable of generation 0 dosen't appear in a phi merge, so the below
 statement:

--- a/regression/cbmc/phi-merge_uninitialized_values/global.desc
+++ b/regression/cbmc/phi-merge_uninitialized_values/global.desc
@@ -5,8 +5,8 @@ activate-multi-line-match
 ^EXIT=0$
 ^SIGNAL=0$
 --
-^.*:\s+global(@[0-9]+)?#0\)
-^.*\?\s+global(@[0-9]+)?#0\s+:
+\([^\s]+guard[^\s]+ \? [^\s]+#0 : [^\s]+\)
+\([^\s]+guard[^\s]+ \? [^\s]+ : [^\s]+#0\)
 --
 These regexes are making sure that a variable of generation 0 dosen't appear in a phi merge, so the below
 statement:

--- a/regression/cbmc/phi-merge_uninitialized_values/local.desc
+++ b/regression/cbmc/phi-merge_uninitialized_values/local.desc
@@ -5,8 +5,8 @@ activate-multi-line-match
 ^EXIT=0$
 ^SIGNAL=0$
 --
-^.*:\s+local(@[0-9]+)?#0\)
-^.*\?\s+local(@[0-9]+)?#0\s+:
+\([^\s]+guard[^\s]+ \? [^\s]+#0 : [^\s]+\)
+\([^\s]+guard[^\s]+ \? [^\s]+ : [^\s]+#0\)
 --
 These regexes are making sure that a variable of generation 0 dosen't appear in a phi merge, so the below
 statement:

--- a/regression/cbmc/phi-merge_uninitialized_values/static_local.desc
+++ b/regression/cbmc/phi-merge_uninitialized_values/static_local.desc
@@ -5,8 +5,8 @@ activate-multi-line-match
 ^EXIT=0$
 ^SIGNAL=0$
 --
-^.*:\s+staticLocal(@[0-9]+)?#0\)
-^.*\?\s+staticLocal(@[0-9]+)?#0\s+:
+\([^\s]+guard[^\s]+ \? [^\s]+#0 : [^\s]+\)
+\([^\s]+guard[^\s]+ \? [^\s]+ : [^\s]+#0\)
 --
 These regexes are making sure that a variable of generation 0 dosen't appear in a phi merge, so the below
 statement:

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -476,15 +476,17 @@ static void merge_names(
   //  1. Either guard is false, so we can't follow that branch.
   //  2. Either identifier is of generation zero, and so hasn't been
   //     initialized and therefore an invalid target.
+
+  // These rules only apply to dynamic objects and locals.
   if(dest_state.guard.is_false())
     rhs = goto_state_rhs;
   else if(goto_state.guard.is_false())
     rhs = dest_state_rhs;
-  else if(goto_count == 0 && symbol.value.is_not_nil())
+  else if(goto_count == 0 && !symbol.is_static_lifetime)
   {
     rhs = dest_state_rhs;
   }
-  else if(dest_count == 0 && symbol.value.is_not_nil())
+  else if(dest_count == 0 && !symbol.is_static_lifetime)
   {
     rhs = goto_state_rhs;
   }


### PR DESCRIPTION
The external check was a little too broad and some gen 0 dynamic objects were getting put into guards accidentally. The tests that would have helped show something had changed were also quite badly out of date which didn't help matters.

@tautschnig I made sure your additional test passes, but please just check that the new condition is good for whatever you needed too. (I was thinking the the is_not_nil could go if global externs should never be considered for removal)

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.