### PR TITLE
Load memory snapshot into cbmc

### DIFF
--- a/regression/cbmc/load-snapshot-json-snapshots/global-int-x-1-snapshot.json
+++ b/regression/cbmc/load-snapshot-json-snapshots/global-int-x-1-snapshot.json
@@ -1,0 +1,62 @@
+{
+  "symbolTable": {
+    "x": {
+      "baseName": "x",
+      "isAuxiliary": false,
+      "isExported": false,
+      "isExtern": false,
+      "isFileLocal": false,
+      "isInput": false,
+      "isLvalue": true,
+      "isMacro": false,
+      "isOutput": false,
+      "isParameter": false,
+      "isProperty": false,
+      "isStateVar": false,
+      "isStaticLifetime": true,
+      "isThreadLocal": false,
+      "isType": false,
+      "isVolatile": false,
+      "isWeak": false,
+      "location": {},
+      "mode": "C",
+      "module": "main",
+      "name": "x",
+      "prettyName": "x",
+      "type": {
+        "id": "signedbv",
+        "namedSub": {
+          "#c_type": {
+            "id": "signed_int"
+          },
+          "width": {
+            "id": "32"
+          }
+        }
+      },
+      "value": {
+        "id": "constant",
+        "namedSub": {
+          "#base": {
+            "id": "10"
+          },
+          "#source_location": {},
+          "type": {
+            "id": "signedbv",
+            "namedSub": {
+              "#c_type": {
+                "id": "signed_int"
+              },
+              "width": {
+                "id": "32"
+              }
+            }
+          },
+          "value": {
+            "id": "1"
+          }
+        }
+      }
+    }
+  }
+}

--- a/regression/cbmc/load-snapshot-static-global-array-01/main.c
+++ b/regression/cbmc/load-snapshot-static-global-array-01/main.c
@@ -1,0 +1,10 @@
+int x[] = {1, 2, 3};
+
+int main()
+{
+  assert(x[0] == 4);
+  assert(x[1] == 5);
+  assert(x[2] == 6);
+
+  return 0;
+}

--- a/regression/cbmc/load-snapshot-static-global-array-01/snapshot.json
+++ b/regression/cbmc/load-snapshot-static-global-array-01/snapshot.json
@@ -1,0 +1,181 @@
+{
+  "symbolTable": {
+    "x": {
+      "baseName": "x",
+      "isAuxiliary": false,
+      "isExported": false,
+      "isExtern": false,
+      "isFileLocal": false,
+      "isInput": false,
+      "isLvalue": true,
+      "isMacro": false,
+      "isOutput": false,
+      "isParameter": false,
+      "isProperty": false,
+      "isStateVar": false,
+      "isStaticLifetime": true,
+      "isThreadLocal": false,
+      "isType": false,
+      "isVolatile": false,
+      "isWeak": false,
+      "location": {},
+      "mode": "C",
+      "module": "test",
+      "name": "x",
+      "prettyName": "x",
+      "type": {
+        "id": "array",
+        "namedSub": {
+          "#source_location": {},
+          "size": {
+            "id": "constant",
+            "namedSub": {
+              "type": {
+                "id": "signedbv",
+                "namedSub": {
+                  "#c_type": {
+                    "id": "signed_long_int"
+                  },
+                  "width": {
+                    "id": "64"
+                  }
+                }
+              },
+              "value": {
+                "id": "3"
+              }
+            }
+          }
+        },
+        "sub": [
+          {
+            "id": "signedbv",
+            "namedSub": {
+              "#c_type": {
+                "id": "signed_int"
+              },
+              "width": {
+                "id": "32"
+              }
+            }
+          }
+        ]
+      },
+      "value": {
+        "id": "array",
+        "namedSub": {
+          "#source_location": {},
+          "type": {
+            "id": "array",
+            "namedSub": {
+              "#source_location": {},
+              "size": {
+                "id": "constant",
+                "namedSub": {
+                  "type": {
+                    "id": "signedbv",
+                    "namedSub": {
+                      "#c_type": {
+                        "id": "signed_long_int"
+                      },
+                      "width": {
+                        "id": "64"
+                      }
+                    }
+                  },
+                  "value": {
+                    "id": "3"
+                  }
+                }
+              }
+            },
+            "sub": [
+              {
+                "id": "signedbv",
+                "namedSub": {
+                  "#c_type": {
+                    "id": "signed_int"
+                  },
+                  "width": {
+                    "id": "32"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "sub": [
+          {
+            "id": "constant",
+            "namedSub": {
+              "#base": {
+                "id": "10"
+              },
+              "#source_location": {},
+              "type": {
+                "id": "signedbv",
+                "namedSub": {
+                  "#c_type": {
+                    "id": "signed_int"
+                  },
+                  "width": {
+                    "id": "32"
+                  }
+                }
+              },
+              "value": {
+                "id": "4"
+              }
+            }
+          },
+          {
+            "id": "constant",
+            "namedSub": {
+              "#base": {
+                "id": "10"
+              },
+              "#source_location": {},
+              "type": {
+                "id": "signedbv",
+                "namedSub": {
+                  "#c_type": {
+                    "id": "signed_int"
+                  },
+                  "width": {
+                    "id": "32"
+                  }
+                }
+              },
+              "value": {
+                "id": "5"
+              }
+            }
+          },
+          {
+            "id": "constant",
+            "namedSub": {
+              "#base": {
+                "id": "10"
+              },
+              "#source_location": {},
+              "type": {
+                "id": "signedbv",
+                "namedSub": {
+                  "#c_type": {
+                    "id": "signed_int"
+                  },
+                  "width": {
+                    "id": "32"
+                  }
+                }
+              },
+              "value": {
+                "id": "6"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/regression/cbmc/load-snapshot-static-global-array-01/test.desc
+++ b/regression/cbmc/load-snapshot-static-global-array-01/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--memory-snapshot snapshot.json --initial-location main:0
+^EXIT=0$
+^SIGNAL=0$
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/regression/cbmc/load-snapshot-static-global-int-01/main.c
+++ b/regression/cbmc/load-snapshot-static-global-int-01/main.c
@@ -1,0 +1,8 @@
+int x;
+
+int main()
+{
+  assert(x == 1);
+
+  return 0;
+}

--- a/regression/cbmc/load-snapshot-static-global-int-01/test.desc
+++ b/regression/cbmc/load-snapshot-static-global-int-01/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-location main:0
+^EXIT=0$
+^SIGNAL=0$
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/regression/cbmc/load-snapshot-static-global-int-02/main.c
+++ b/regression/cbmc/load-snapshot-static-global-int-02/main.c
@@ -1,0 +1,10 @@
+int x;
+int y; // snapshot contains no value for y
+
+int main()
+{
+  assert(x == 1);
+  assert(y == 1);
+
+  return 0;
+}

--- a/regression/cbmc/load-snapshot-static-global-int-02/test.desc
+++ b/regression/cbmc/load-snapshot-static-global-int-02/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-location main:0
+^EXIT=10$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion x == 1: SUCCESS
+\[main.assertion.2\] line [0-9]+ assertion y == 1: FAILURE
+--
+^warning: ignoring

--- a/regression/cbmc/load-snapshot-static-global-int-03/main.c
+++ b/regression/cbmc/load-snapshot-static-global-int-03/main.c
@@ -1,0 +1,14 @@
+int x;
+
+void func()
+{
+}
+
+int main()
+{
+  func();
+
+  assert(x == 1);
+
+  return 0;
+}

--- a/regression/cbmc/load-snapshot-static-global-int-03/test.desc
+++ b/regression/cbmc/load-snapshot-static-global-int-03/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-location main:0
+^EXIT=0$
+^SIGNAL=0$
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/regression/cbmc/load-snapshot-static-global-int-paths-01/main.c
+++ b/regression/cbmc/load-snapshot-static-global-int-paths-01/main.c
@@ -1,0 +1,19 @@
+int x;
+int y;
+
+int main()
+{
+  if(nondet_int())
+  {
+    y = 1;
+  }
+  else
+  {
+    y = 2;
+  }
+
+  assert(x == 1);
+  assert(y == 1 || y == 2);
+
+  return 0;
+}

--- a/regression/cbmc/load-snapshot-static-global-int-paths-01/test.desc
+++ b/regression/cbmc/load-snapshot-static-global-int-paths-01/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--paths lifo --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-location main:0
+^EXIT=0$
+^SIGNAL=0$
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/regression/cbmc/load-snapshot-static-global-pointer-01/main.c
+++ b/regression/cbmc/load-snapshot-static-global-pointer-01/main.c
@@ -1,0 +1,11 @@
+int x;
+int *p; // has value &x in the snapshot
+
+int main()
+{
+  x = 1;
+
+  assert(*p == 1);
+
+  return 0;
+}

--- a/regression/cbmc/load-snapshot-static-global-pointer-01/snapshot.json
+++ b/regression/cbmc/load-snapshot-static-global-pointer-01/snapshot.json
@@ -1,0 +1,102 @@
+{
+  "symbolTable": {
+    "p": {
+      "baseName": "p",
+      "isAuxiliary": false,
+      "isExported": false,
+      "isExtern": false,
+      "isFileLocal": false,
+      "isInput": false,
+      "isLvalue": true,
+      "isMacro": false,
+      "isOutput": false,
+      "isParameter": false,
+      "isProperty": false,
+      "isStateVar": false,
+      "isStaticLifetime": true,
+      "isThreadLocal": false,
+      "isType": false,
+      "isVolatile": false,
+      "isWeak": false,
+      "location": {},
+      "mode": "C",
+      "module": "main",
+      "name": "p",
+      "prettyName": "p",
+      "type": {
+        "id": "pointer",
+        "namedSub": {
+          "#source_location": {},
+          "width": {
+            "id": "64"
+          }
+        },
+        "sub": [
+          {
+            "id": "signedbv",
+            "namedSub": {
+              "#c_type": {
+                "id": "signed_int"
+              },
+              "width": {
+                "id": "32"
+              }
+            }
+          }
+        ]
+      },
+      "value": {
+        "id": "address_of",
+        "namedSub": {
+          "#source_location": {},
+          "type": {
+            "id": "pointer",
+            "namedSub": {
+              "width": {
+                "id": "64"
+              }
+            },
+            "sub": [
+              {
+                "id": "signedbv",
+                "namedSub": {
+                  "#c_type": {
+                    "id": "signed_int"
+                  },
+                  "width": {
+                    "id": "32"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "sub": [
+          {
+            "id": "symbol",
+            "namedSub": {
+              "#lvalue": {
+                "id": "1"
+              },
+              "#source_location": {},
+              "identifier": {
+                "id": "x"
+              },
+              "type": {
+                "id": "signedbv",
+                "namedSub": {
+                  "#c_type": {
+                    "id": "signed_int"
+                  },
+                  "width": {
+                    "id": "32"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/regression/cbmc/load-snapshot-static-global-pointer-01/test.desc
+++ b/regression/cbmc/load-snapshot-static-global-pointer-01/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--memory-snapshot snapshot.json --initial-location main:0
+^EXIT=0$
+^SIGNAL=0$
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -413,6 +413,33 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
     options.set_option("validate-goto-model", true);
   }
 
+  {
+    const bool memory_snapshot = cmdline.isset("memory-snapshot");
+    const bool initial_location = cmdline.isset("initial-location");
+
+    if(memory_snapshot || initial_location)
+    {
+      if(!memory_snapshot)
+      {
+        throw invalid_command_line_argument_exceptiont(
+          "--initial-location also requires --memory-snapshot",
+          "--initial-location");
+      }
+      else if(!initial_location)
+      {
+        throw invalid_command_line_argument_exceptiont(
+          "--memory-snapshot also requires --initial-location",
+          "--memory-snapshot");
+      }
+
+      options.set_option(
+        "memory-snapshot", cmdline.get_value("memory-snapshot"));
+
+      options.set_option(
+        "initial-location", cmdline.get_value("initial-location"));
+    }
+  }
+
   PARSE_OPTIONS_GOTO_TRACE(cmdline, options);
 }
 

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -87,7 +87,9 @@ void slice(
   "(unwind):" \
   "(unwindset):" \
   "(graphml-witness):" \
-  "(unwindset):"
+  "(unwindset):" \
+  "(memory-snapshot):" \
+  "(initial-location):"
 
 #define HELP_BMC \
   " --paths [strategy]           explore paths one at a time\n" \
@@ -106,7 +108,13 @@ void slice(
   " --no-self-loops-to-assumptions\n" \
   "                              do not simplify while(1){} to assume(0)\n" \
   " --no-pretty-names            do not simplify identifiers\n" \
-  " --graphml-witness filename   write the witness in GraphML format to filename\n" // NOLINT(*)
+  " --graphml-witness filename   write the witness in GraphML format to " \
+  "filename\n" \
+  " --memory-snapshot <file>     initialize memory from given JSON memory " \
+  "snapshot\n" \
+  " --initial-location <func[:<n>]\n" \
+  "                              start symex from given function and " \
+  "location\n number (use with --memory-snapshot)\n"
 // clang-format on
 
 #endif // CPROVER_GOTO_CHECKER_BMC_UTIL_H

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -118,6 +118,22 @@ public:
     const get_goto_functiont &get_goto_function,
     symbol_tablet &new_symbol_table);
 
+  /// Symex program starting from given instruction and initialize the memory
+  /// with the given snapshot
+  ///
+  /// \param get_goto_function mapping from function ids to goto functions
+  /// \param new_symbol_table symbol table to which to add symbols generated
+  ///   during symex
+  /// \param snapshot memory snapshot represented as a symbol table, the `value`
+  ///   field of each symbol holds the value to initialize the corresponding
+  ///   symbol expression with
+  /// \param it iterator to goto instruction to start symex from
+  virtual void symex_from_instruction_with_snapshot(
+    const get_goto_functiont &get_goto_function,
+    symbol_tablet &new_symbol_table,
+    const symbol_tablet &snapshot,
+    goto_programt::const_targett it);
+
   /// Performs symbolic execution using a state and equation that have
   /// already been used to symex part of the program. The state is not
   /// re-initialized; instead, symbolic execution resumes from the program

--- a/src/util/symbol_table.h
+++ b/src/util/symbol_table.h
@@ -117,6 +117,18 @@ public:
     return iteratort(internal_symbols.end());
   }
 
+  typedef symbolst::const_iterator const_iteratort;
+
+  virtual const_iteratort begin() const
+  {
+    return internal_symbols.begin();
+  }
+
+  virtual const_iteratort end() const
+  {
+    return internal_symbols.end();
+  }
+
   /// Check that the symbol table is well-formed
   void validate(const validation_modet vm = validation_modet::INVARIANT) const;
 


### PR DESCRIPTION
This is a basic first version of loading a concrete memory snapshot (represented as a JSON symbol table) to initialize goto symex with, and then start symex from a given program location.

This is done in goto symex (as opposed to generating a goto program harness) as this will allow to potentially make the stack part of the snapshot in the future, which would allow to return from functions that have been called during the concrete execution.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
