### PR TITLE
Remove unnecessary use of ns.follow in goto-cc/

### DIFF
--- a/src/goto-cc/linker_script_merge.cpp
+++ b/src/goto-cc/linker_script_merge.cpp
@@ -114,72 +114,76 @@ int linker_script_merget::add_linker_script_definitions()
 }
 
 linker_script_merget::linker_script_merget(
-      compilet &compiler,
-      const std::string &elf_binary,
-      const std::string &goto_binary,
-      const cmdlinet &cmdline,
-      message_handlert &message_handler) :
-    messaget(message_handler), compiler(compiler),
-    elf_binary(elf_binary), goto_binary(goto_binary),
+  compilet &compiler,
+  const std::string &elf_binary,
+  const std::string &goto_binary,
+  const cmdlinet &cmdline,
+  message_handlert &message_handler)
+  : messaget(message_handler),
+    compiler(compiler),
+    elf_binary(elf_binary),
+    goto_binary(goto_binary),
     cmdline(cmdline),
     replacement_predicates(
-    {
-      replacement_predicatet("address of array's first member",
-        [](const exprt &expr) -> const symbol_exprt&
-        { return to_symbol_expr(expr.op0().op0()); },
-        [](const exprt &expr, const namespacet &)
-        {
-          return expr.id()==ID_address_of &&
-                 expr.type().id()==ID_pointer &&
+      {replacement_predicatet(
+         "address of array's first member",
+         [](const exprt &expr) -> const symbol_exprt & {
+           return to_symbol_expr(expr.op0().op0());
+         },
+         [](const exprt &expr) {
+           return expr.id() == ID_address_of &&
+                  expr.type().id() == ID_pointer &&
 
-                 expr.op0().id()==ID_index &&
-                 expr.op0().type().id()==ID_unsignedbv &&
+                  expr.op0().id() == ID_index &&
+                  expr.op0().type().id() == ID_unsignedbv &&
 
-                 expr.op0().op0().id()==ID_symbol &&
-                 expr.op0().op0().type().id()==ID_array &&
+                  expr.op0().op0().id() == ID_symbol &&
+                  expr.op0().op0().type().id() == ID_array &&
 
-                 expr.op0().op1().id()==ID_constant &&
-                 expr.op0().op1().type().id()==ID_signedbv;
-        }),
-      replacement_predicatet("address of array",
-        [](const exprt &expr) -> const symbol_exprt&
-        { return to_symbol_expr(expr.op0()); },
-        [](const exprt &expr, const namespacet &)
-        {
-          return expr.id()==ID_address_of &&
-                 expr.type().id()==ID_pointer &&
+                  expr.op0().op1().id() == ID_constant &&
+                  expr.op0().op1().type().id() == ID_signedbv;
+         }),
+       replacement_predicatet(
+         "address of array",
+         [](const exprt &expr) -> const symbol_exprt & {
+           return to_symbol_expr(expr.op0());
+         },
+         [](const exprt &expr) {
+           return expr.id() == ID_address_of &&
+                  expr.type().id() == ID_pointer &&
 
-                 expr.op0().id()==ID_symbol &&
-                 expr.op0().type().id()==ID_array;
-        }),
-      replacement_predicatet("address of struct",
-        [](const exprt &expr) -> const symbol_exprt&
-        { return to_symbol_expr(expr.op0()); },
-        [](const exprt &expr, const namespacet &ns)
-        {
-          return expr.id()==ID_address_of &&
-                 expr.type().id()==ID_pointer &&
+                  expr.op0().id() == ID_symbol &&
+                  expr.op0().type().id() == ID_array;
+         }),
+       replacement_predicatet(
+         "address of struct",
+         [](const exprt &expr) -> const symbol_exprt & {
+           return to_symbol_expr(expr.op0());
+         },
+         [](const exprt &expr) {
+           return expr.id() == ID_address_of &&
+                  expr.type().id() == ID_pointer &&
 
-                 expr.op0().id()==ID_symbol &&
-                 ns.follow(expr.op0().type()).id()==ID_struct;
-        }),
-      replacement_predicatet("array variable",
-        [](const exprt &expr) -> const symbol_exprt&
-        { return to_symbol_expr(expr); },
-        [](const exprt &expr, const namespacet &)
-        {
-          return expr.id()==ID_symbol &&
-                 expr.type().id()==ID_array;
-        }),
-      replacement_predicatet("pointer (does not need pointerizing)",
-        [](const exprt &expr) -> const symbol_exprt&
-        { return to_symbol_expr(expr); },
-        [](const exprt &expr, const namespacet &)
-        {
-          return expr.id()==ID_symbol &&
-                 expr.type().id()==ID_pointer;
-        })
-    })
+                  expr.op0().id() == ID_symbol &&
+                  (expr.op0().type().id() == ID_struct ||
+                   expr.op0().type().id() == ID_struct_tag);
+         }),
+       replacement_predicatet(
+         "array variable",
+         [](const exprt &expr) -> const symbol_exprt & {
+           return to_symbol_expr(expr);
+         },
+         [](const exprt &expr) {
+           return expr.id() == ID_symbol && expr.type().id() == ID_array;
+         }),
+       replacement_predicatet(
+         "pointer (does not need pointerizing)",
+         [](const exprt &expr) -> const symbol_exprt & {
+           return to_symbol_expr(expr);
+         },
+         [](const exprt &expr) {
+           return expr.id() == ID_symbol && expr.type().id() == ID_pointer;
+         })})
 {}
 
 int linker_script_merget::pointerize_linker_defined_symbols(
@@ -215,8 +219,7 @@ int linker_script_merget::pointerize_linker_defined_symbols(
     int fail = pointerize_subexprs_of(
       goto_model.symbol_table.get_writeable_ref(pair.first).value,
       to_pointerize,
-      linker_values,
-      ns);
+      linker_values);
     if(to_pointerize.empty() && fail==0)
       continue;
     ret=1;
@@ -241,8 +244,7 @@ int linker_script_merget::pointerize_linker_defined_symbols(
         if(to_pointerize.empty())
           continue;
         debug() << "Pointerizing a program expression..." << eom;
-        int fail = pointerize_subexprs_of(
-          *insts, to_pointerize, linker_values, ns);
+        int fail = pointerize_subexprs_of(*insts, to_pointerize, linker_values);
         if(to_pointerize.empty() && fail==0)
           continue;
         ret=1;
@@ -283,16 +285,15 @@ int linker_script_merget::replace_expr(
 }
 
 int linker_script_merget::pointerize_subexprs_of(
-    exprt &expr,
-    std::list<symbol_exprt> &to_pointerize,
-    const linker_valuest &linker_values,
-    const namespacet &ns)
+  exprt &expr,
+  std::list<symbol_exprt> &to_pointerize,
+  const linker_valuest &linker_values)
 {
   int fail=0, tmp=0;
   for(auto const &pair : linker_values)
     for(auto const &pattern : replacement_predicates)
     {
-      if(!pattern.match(expr, ns))
+      if(!pattern.match(expr))
         continue;
       // take a copy, expr will be changed below
       const symbol_exprt inner_symbol=pattern.inner_symbol(expr);
@@ -320,7 +321,7 @@ int linker_script_merget::pointerize_subexprs_of(
 
   for(auto &op : expr.operands())
   {
-    tmp=pointerize_subexprs_of(op, to_pointerize, linker_values, ns);
+    tmp = pointerize_subexprs_of(op, to_pointerize, linker_values);
     fail=tmp?tmp:fail;
   }
   return fail;

--- a/src/goto-cc/linker_script_merge.h
+++ b/src/goto-cc/linker_script_merge.h
@@ -23,12 +23,10 @@ class replacement_predicatet
 {
 public:
   replacement_predicatet(
-      const std::string &description,
-      const std::function<const symbol_exprt&(const exprt&)> inner_symbol,
-      const std::function<bool(const exprt&, const namespacet&)> match)
-    : _description(description),
-      _inner_symbol(inner_symbol),
-      _match(match)
+    const std::string &description,
+    const std::function<const symbol_exprt &(const exprt &)> inner_symbol,
+    const std::function<bool(const exprt &)> match)
+    : _description(description), _inner_symbol(inner_symbol), _match(match)
   {}
 
   /// \brief a textual description of the expression that we're trying to match
@@ -49,15 +47,15 @@ public:
   /// If this function returns true, the entire expression should be replaced by
   /// a pointer whose underlying symbol is the symbol returned by
   /// replacement_predicatet::inner_symbol().
-  bool match(const exprt &expr, const namespacet &ns) const
+  bool match(const exprt &expr) const
   {
-    return _match(expr, ns);
+    return _match(expr);
   };
 
 private:
   std::string _description;
   std::function<const symbol_exprt&(const exprt&)> _inner_symbol;
-  std::function<bool(const exprt&, const namespacet&)> _match;
+  std::function<bool(const exprt &)> _match;
 };
 
 /// \brief Synthesise definitions of symbols that are defined in linker scripts
@@ -161,7 +159,6 @@ protected:
   /// \param to_pointerize: The symbols that are contained in the subexpressions
   ///   that we will pointerize.
   /// \param linker_values: the names of symbols defined in linker scripts.
-  /// \param ns: a namespace to look up types.
   ///
   /// The subexpressions that we pointerize should be in one-to-one
   /// correspondence with the symbols in `to_pointerize`. Every time we
@@ -170,10 +167,9 @@ protected:
   /// `to_pointerize` should be empty. If it is not, then the symbol is
   /// contained in a subexpression whose shape is not recognised.
   int pointerize_subexprs_of(
-      exprt &expr,
-      std::list<symbol_exprt> &to_pointerize,
-      const linker_valuest &linker_values,
-      const namespacet &ns);
+    exprt &expr,
+    std::list<symbol_exprt> &to_pointerize,
+    const linker_valuest &linker_values);
 
   /// \brief do the actual replacement of an expr with a new pointer expr
   int replace_expr(


### PR DESCRIPTION
Only structs, unions, enums can be hidden behind tags. This also makes
unnecessary to pass around a namespace.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
