### PR TITLE
Remove unnecessary use of ns.follow in cpp/

### DIFF
--- a/src/cpp/cpp_typecheck_code.cpp
+++ b/src/cpp/cpp_typecheck_code.cpp
@@ -374,7 +374,7 @@ void cpp_typecheckt::typecheck_decl(codet &code)
   if(declaration.declarators().empty() &&
      follow(type).get_bool(ID_C_is_anonymous))
   {
-    if(follow(type).id()!=ID_union)
+    if(type.id() != ID_union_tag)
     {
       error().source_location=code.find_source_location();
       error() << "declaration statement does not declare anything"

--- a/src/cpp/cpp_typecheck_conversions.cpp
+++ b/src/cpp/cpp_typecheck_conversions.cpp
@@ -931,12 +931,6 @@ bool cpp_typecheckt::user_defined_conversion_sequence(
     }
     else
     {
-      struct_typet from_struct;
-      from_struct.make_nil();
-
-      if(from.id()==ID_struct)
-        from_struct=to_struct_type(from);
-
       bool found=false;
 
       for(const auto &component : to_struct_type(to).components())
@@ -971,16 +965,8 @@ bool cpp_typecheckt::user_defined_conversion_sequence(
           arg1_type.swap(tmp);
         }
 
-        struct_typet arg1_struct;
-        arg1_struct.make_nil();
-        {
-          typet tmp=follow(arg1_type);
-          if(tmp.id()==ID_struct)
-            arg1_struct=to_struct_type(tmp);
-        }
-
         unsigned tmp_rank=0;
-        if(arg1_struct.is_nil())
+        if(arg1_type.id() != ID_struct_tag)
         {
             exprt tmp_expr;
             if(standard_conversion_sequence(
@@ -1020,7 +1006,7 @@ bool cpp_typecheckt::user_defined_conversion_sequence(
               rank += tmp_rank;
             }
           }
-          else if(from_struct.is_not_nil() && arg1_struct.is_not_nil())
+          else if(from.id() == ID_struct && arg1_type.id() == ID_struct_tag)
           {
             // try derived-to-base conversion
             address_of_exprt expr_pfrom(expr, pointer_type(expr.type()));
@@ -1389,7 +1375,7 @@ bool cpp_typecheckt::reference_binding(
 
   exprt arg_expr=expr;
 
-  if(follow(arg_expr.type()).id()==ID_struct)
+  if(arg_expr.type().id() == ID_struct_tag)
   {
     // required to initialize the temporary
     arg_expr.set(ID_C_lvalue, true);
@@ -1730,7 +1716,7 @@ bool cpp_typecheckt::dynamic_typecast(
 
   if(is_reference(type))
   {
-    if(follow(type.subtype()).id() != ID_struct)
+    if(type.subtype().id() != ID_struct_tag)
       return false;
   }
   else if(type.id()==ID_pointer)
@@ -1744,7 +1730,7 @@ bool cpp_typecheckt::dynamic_typecast(
         return false;
       UNREACHABLE; // currently not supported
     }
-    else if(follow(type.subtype()).id()==ID_struct)
+    else if(type.subtype().id() == ID_struct_tag)
     {
       if(e.get_bool(ID_C_lvalue))
       {

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -1841,29 +1841,20 @@ void cpp_typecheck_resolvet::guess_template_args(
   }
   else if(template_type.id()==ID_pointer)
   {
-    const typet &desired_type_followed=
-      cpp_typecheck.follow(desired_type);
-
-    if(desired_type_followed.id()==ID_pointer)
-      guess_template_args(
-        template_type.subtype(), desired_type_followed.subtype());
+    if(desired_type.id() == ID_pointer)
+      guess_template_args(template_type.subtype(), desired_type.subtype());
   }
   else if(template_type.id()==ID_array)
   {
-    const typet &desired_type_followed=
-      cpp_typecheck.follow(desired_type);
-
-    if(desired_type_followed.id()==ID_array)
+    if(desired_type.id() == ID_array)
     {
       // look at subtype first
-      guess_template_args(
-        template_type.subtype(),
-        desired_type_followed.subtype());
+      guess_template_args(template_type.subtype(), desired_type.subtype());
 
       // size (e.g., buffer size guessing)
       guess_template_args(
         to_array_type(template_type).size(),
-        to_array_type(desired_type_followed).size());
+        to_array_type(desired_type).size());
     }
   }
 }


### PR DESCRIPTION
Only structs, unions, enums can be hidden behind tags.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
