### PR TITLE
Remove unnecessary use of ns.follow in ansi-c/

### DIFF
--- a/src/ansi-c/anonymous_member.cpp
+++ b/src/ansi-c/anonymous_member.cpp
@@ -51,14 +51,15 @@ exprt get_component_rec(
 
   for(const auto &comp : components)
   {
-    const typet &type=ns.follow(comp.type());
+    const typet &type = comp.type();
 
     if(comp.get_name()==component_name)
     {
       return std::move(make_member_expr(struct_union, comp, ns));
     }
-    else if(comp.get_anonymous() &&
-            (type.id()==ID_struct || type.id()==ID_union))
+    else if(
+      comp.get_anonymous() &&
+      (type.id() == ID_struct_tag || type.id() == ID_union_tag))
     {
       const member_exprt tmp = make_member_expr(struct_union, comp, ns);
       exprt result=get_component_rec(tmp, component_name, ns);

--- a/src/ansi-c/c_typecast.cpp
+++ b/src/ansi-c/c_typecast.cpp
@@ -388,14 +388,12 @@ void c_typecastt::implicit_typecast_arithmetic(
 {
   typet new_type;
 
-  const typet &expr_type=ns.follow(expr.type());
-
   switch(c_type)
   {
   case PTR:
-    if(expr_type.id()==ID_array)
+    if(expr.type().id() == ID_array)
     {
-      new_type=pointer_type(expr_type.subtype());
+      new_type = pointer_type(expr.type().subtype());
       break;
     }
     return;
@@ -423,7 +421,7 @@ void c_typecastt::implicit_typecast_arithmetic(
   default: return;
   }
 
-  if(new_type!=expr_type)
+  if(new_type != expr.type())
     do_typecast(expr, new_type);
 }
 
@@ -538,8 +536,8 @@ void c_typecastt::implicit_typecast_followed(
     {
       // we are quite generous about pointers
 
-      const typet &src_sub=ns.follow(src_type.subtype());
-      const typet &dest_sub=ns.follow(dest_type.subtype());
+      const typet &src_sub = src_type.subtype();
+      const typet &dest_sub = dest_type.subtype();
 
       if(is_void_pointer(src_type) ||
          is_void_pointer(dest_type))
@@ -603,8 +601,8 @@ void c_typecastt::implicit_typecast_arithmetic(
   exprt &expr1,
   exprt &expr2)
 {
-  const typet &type1=ns.follow(expr1.type());
-  const typet &type2=ns.follow(expr2.type());
+  const typet &type1 = expr1.type();
+  const typet &type2 = expr2.type();
 
   c_typet c_type1=minimum_promotion(type1),
           c_type2=minimum_promotion(type2);
@@ -718,7 +716,7 @@ void c_typecastt::do_typecast(exprt &expr, const typet &dest_type)
   // special case: array -> pointer is actually
   // something like address_of
 
-  const typet &src_type=ns.follow(expr.type());
+  const typet &src_type = expr.type();
 
   if(src_type.id()==ID_array)
   {
@@ -726,9 +724,7 @@ void c_typecastt::do_typecast(exprt &expr, const typet &dest_type)
     index.array()=expr;
     index.index()=from_integer(0, index_type());
     index.type()=src_type.subtype();
-    expr=address_of_exprt(index);
-    if(ns.follow(expr.type())!=ns.follow(dest_type))
-      expr.make_typecast(dest_type);
+    expr = typecast_exprt::conditional_cast(address_of_exprt(index), dest_type);
     return;
   }
 

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -284,8 +284,7 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
   }
 
   // do initializer, this may change the type
-  if(follow(new_symbol.type).id()!=ID_code &&
-     !new_symbol.is_macro)
+  if(new_symbol.type.id() != ID_code && !new_symbol.is_macro)
     do_initializer(new_symbol);
 
   const typet &final_new=follow(new_symbol.type);
@@ -419,22 +418,20 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
       PRECONDITION(old_symbol.type.id() != ID_symbol_type);
       old_symbol.type=new_symbol.type;
     }
-    else if(final_old.id()==ID_pointer &&
-            follow(final_old).subtype().id()==ID_code &&
-            to_code_type(follow(final_old).subtype()).has_ellipsis() &&
-            final_new.id()==ID_pointer &&
-            follow(final_new).subtype().id()==ID_code)
+    else if(
+      final_old.id() == ID_pointer && final_old.subtype().id() == ID_code &&
+      to_code_type(final_old.subtype()).has_ellipsis() &&
+      final_new.id() == ID_pointer && final_new.subtype().id() == ID_code)
     {
       // to allow
       // int (*f) ();
       // int (*f) (int)=0;
       old_symbol.type=new_symbol.type;
     }
-    else if(final_old.id()==ID_pointer &&
-            follow(final_old).subtype().id()==ID_code &&
-            final_new.id()==ID_pointer &&
-            follow(final_new).subtype().id()==ID_code &&
-            to_code_type(follow(final_new).subtype()).has_ellipsis())
+    else if(
+      final_old.id() == ID_pointer && final_old.subtype().id() == ID_code &&
+      final_new.id() == ID_pointer && final_new.subtype().id() == ID_code &&
+      to_code_type(final_new.subtype()).has_ellipsis())
     {
       // to allow
       // int (*f) (int)=0;

--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -794,8 +794,9 @@ designatort c_typecheck_baset::make_designator(
               entry.type=tmp_type;
             }
             else if(
-              c.get_anonymous() && (follow(c.type()).id() == ID_struct ||
-                                    follow(c.type()).id() == ID_union) &&
+              c.get_anonymous() &&
+              (c.type().id() == ID_struct_tag ||
+               c.type().id() == ID_union_tag) &&
               has_component_rec(c.type(), component_name, *this))
             {
               entry.index=number;

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -1287,7 +1287,7 @@ std::string expr2ct::convert_complex(
   // float complex CMPLXF(float x, float y);
   // long double complex CMPLXL(long double x, long double y);
 
-  const typet &subtype = ns.follow(src.type()).subtype();
+  const typet &subtype = src.type().subtype();
 
   std::string name;
 
@@ -1749,7 +1749,7 @@ std::string expr2ct::convert_constant(
   unsigned &precedence)
 {
   const irep_idt &base=src.get(ID_C_base);
-  const typet &type=ns.follow(src.type());
+  const typet &type = src.type();
   const irep_idt value=src.get_value();
   std::string dest;
 


### PR DESCRIPTION
Only structs, unions, enums can be hidden behind tags.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
