### PR TITLE
Remove unnecessary use of ns.follow in analyses/

### DIFF
--- a/src/analyses/custom_bitvector_analysis.cpp
+++ b/src/analyses/custom_bitvector_analysis.cpp
@@ -230,7 +230,7 @@ void custom_bitvector_domaint::assign_struct_rec(
   custom_bitvector_analysist &cba,
   const namespacet &ns)
 {
-  if(ns.follow(lhs.type()).id()==ID_struct)
+  if(lhs.type().id() == ID_struct || lhs.type().id() == ID_struct_tag)
   {
     const struct_typet &struct_type=
       to_struct_type(ns.follow(lhs.type()));

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -264,8 +264,7 @@ void goto_checkt::undefined_shift_check(
   // Undefined for all types and shifts if distance exceeds width,
   // and also undefined for negative distances.
 
-  const typet &distance_type=
-    ns.follow(expr.distance().type());
+  const typet &distance_type = expr.distance().type();
 
   if(distance_type.id()==ID_signedbv)
   {
@@ -281,8 +280,7 @@ void goto_checkt::undefined_shift_check(
       guard);
   }
 
-  const typet &op_type=
-    ns.follow(expr.op().type());
+  const typet &op_type = expr.op().type();
 
   if(op_type.id()==ID_unsignedbv || op_type.id()==ID_signedbv)
   {
@@ -390,7 +388,7 @@ void goto_checkt::conversion_check(
     return;
 
   // First, check type.
-  const typet &type=ns.follow(expr.type());
+  const typet &type = expr.type();
 
   if(type.id()!=ID_signedbv &&
      type.id()!=ID_unsignedbv)
@@ -403,7 +401,7 @@ void goto_checkt::conversion_check(
     if(expr.operands().size()!=1)
       throw "typecast takes one operand";
 
-    const typet &old_type=ns.follow(expr.op0().type());
+    const typet &old_type = expr.op0().type();
 
     if(type.id()==ID_signedbv)
     {
@@ -563,7 +561,7 @@ void goto_checkt::integer_overflow_check(
     return;
 
   // First, check type.
-  const typet &type=ns.follow(expr.type());
+  const typet &type = expr.type();
 
   if(type.id()==ID_signedbv && !enable_signed_overflow_check)
     return;
@@ -781,7 +779,7 @@ void goto_checkt::float_overflow_check(
     return;
 
   // First, check type.
-  const typet &type=ns.follow(expr.type());
+  const typet &type = expr.type();
 
   if(type.id()!=ID_floatbv)
     return;
@@ -794,7 +792,7 @@ void goto_checkt::float_overflow_check(
     // to smaller type.
     assert(expr.operands().size()==1);
 
-    if(ns.follow(expr.op0().type()).id()==ID_floatbv)
+    if(expr.op0().type().id() == ID_floatbv)
     {
       // float-to-float
       const isinf_exprt op0_inf(expr.op0());
@@ -1229,7 +1227,7 @@ void goto_checkt::bounds_check(
      !expr.get_bool("bounds_check"))
     return;
 
-  typet array_type=ns.follow(expr.array().type());
+  typet array_type = expr.array().type();
 
   if(array_type.id()==ID_pointer)
     throw "index got pointer as array type";

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -222,16 +222,15 @@ void rw_range_sett::get_objects_member(
   const range_spect &range_start,
   const range_spect &size)
 {
-  const typet &type=ns.follow(expr.struct_op().type());
+  const typet &type = expr.struct_op().type();
 
-  if(type.id()==ID_union ||
-     range_start==-1)
+  if(type.id() == ID_union || type.id() == ID_union_tag || range_start == -1)
   {
     get_objects_rec(mode, expr.struct_op(), range_start, size);
     return;
   }
 
-  const struct_typet &struct_type=to_struct_type(type);
+  const struct_typet &struct_type = to_struct_type(ns.follow(type));
 
   auto offset_bits =
     member_offset_bits(struct_type, expr.get_component_name(), ns);
@@ -259,7 +258,7 @@ void rw_range_sett::get_objects_index(
     return;
 
   range_spect sub_size=0;
-  const typet &type=ns.follow(expr.array().type());
+  const typet &type = expr.array().type();
 
   if(type.id()==ID_vector)
   {
@@ -302,8 +301,7 @@ void rw_range_sett::get_objects_array(
   const range_spect &range_start,
   const range_spect &size)
 {
-  const array_typet &array_type=
-    to_array_type(ns.follow(expr.type()));
+  const array_typet &array_type = to_array_type(expr.type());
 
   auto subtype_bits = pointer_offset_bits(array_type.subtype(), ns);
 

--- a/src/analyses/invariant_propagation.cpp
+++ b/src/analyses/invariant_propagation.cpp
@@ -90,12 +90,13 @@ void invariant_propagationt::get_objects_rec(
   const exprt &src,
   std::list<exprt> &dest)
 {
-  const typet &t=ns.follow(src.type());
+  const typet &t = src.type();
 
-  if(t.id()==ID_struct ||
-     t.id()==ID_union)
+  if(
+    t.id() == ID_struct || t.id() == ID_union || t.id() == ID_struct_tag ||
+    t.id() == ID_union_tag)
   {
-    const struct_typet &struct_type=to_struct_type(t);
+    const struct_union_typet &struct_type = to_struct_union_type(ns.follow(t));
 
     for(const auto &component : struct_type.components())
     {
@@ -184,8 +185,9 @@ bool invariant_propagationt::check_type(const typet &type) const
 {
   if(type.id()==ID_pointer)
     return true;
-  else if(type.id()==ID_struct ||
-          type.id()==ID_union)
+  else if(
+    type.id() == ID_struct || type.id() == ID_union ||
+    type.id() == ID_struct_tag || type.id() == ID_union_tag)
     return false;
   else if(type.id()==ID_array)
     return false;

--- a/src/analyses/invariant_set.cpp
+++ b/src/analyses/invariant_set.cpp
@@ -486,12 +486,11 @@ void invariant_sett::strengthen_rec(const exprt &expr)
   {
     const auto &equal_expr = to_equal_expr(expr);
 
-    const typet &op_type = ns->follow(equal_expr.op0().type());
+    const typet &op_type = equal_expr.op0().type();
 
-    if(op_type.id()==ID_struct)
+    if(op_type.id() == ID_struct || op_type.id() == ID_struct_tag)
     {
-      const struct_typet &struct_type=to_struct_type(op_type);
-
+      const struct_typet &struct_type = to_struct_type(ns->follow(op_type));
 
       for(const auto &comp : struct_type.components())
       {


### PR DESCRIPTION
Only structs, unions, enums can be hidden behind tags.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
