### PR TITLE
Enable validation of symbol table read from JSON

### DIFF
--- a/src/json-symtab-language/json_symbol_table.cpp
+++ b/src/json-symtab-language/json_symbol_table.cpp
@@ -49,4 +49,6 @@ void symbol_table_from_json(const jsont &in, symbol_tablet &symbol_table)
         "symbol_table_from_json: duplicate symbol name `" +
         id2string(symbol.name) + "`");
   }
+
+  symbol_table.validate(validation_modet::EXCEPTION);
 }


### PR DESCRIPTION
The `symbol_table_from_json()` function reads a symbol table in JSON format, using in turn the functions to read ireps from JSON. The JSON ireps could correspond to various malformed expression types, hence we unconditionally validate the symbol table after reading it in (even when `--validate-goto-model` is not given).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
