### PR TITLE
Replace all uses of deprecated symbol_exprt constructors [blocks: #3768]

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -118,10 +118,40 @@ public:
     symbol_exprt symbol_expr;
     size_t start_pc;
     size_t length;
-    bool is_parameter;
+    bool is_parameter = false;
     std::vector<holet> holes;
 
-    variablet() : symbol_expr(), start_pc(0), length(0), is_parameter(false)
+    variablet(
+      const symbol_exprt &_symbol_expr,
+      std::size_t _start_pc,
+      std::size_t _length)
+      : symbol_expr(_symbol_expr), start_pc(_start_pc), length(_length)
+    {
+    }
+
+    variablet(
+      const symbol_exprt &_symbol_expr,
+      std::size_t _start_pc,
+      std::size_t _length,
+      bool _is_parameter)
+      : symbol_expr(_symbol_expr),
+        start_pc(_start_pc),
+        length(_length),
+        is_parameter(_is_parameter)
+    {
+    }
+
+    variablet(
+      const symbol_exprt &_symbol_expr,
+      std::size_t _start_pc,
+      std::size_t _length,
+      bool _is_parameter,
+      std::vector<holet> &&_holes)
+      : symbol_expr(_symbol_expr),
+        start_pc(_start_pc),
+        length(_length),
+        is_parameter(_is_parameter),
+        holes(std::move(_holes))
     {
     }
   };

--- a/jbmc/src/java_bytecode/java_local_variable_table.cpp
+++ b/jbmc/src/java_bytecode/java_local_variable_table.cpp
@@ -773,7 +773,7 @@ void java_bytecode_convert_methodt::setup_local_variables(
   // to calculate which variable to use, one uses the address of the instruction
   // that uses the variable, the size of the instruction and the start_pc /
   // length values in the local variable table
-  for(const auto &v : vars_with_holes)
+  for(auto &v : vars_with_holes)
   {
     if(v.is_parameter)
       continue;
@@ -807,12 +807,8 @@ void java_bytecode_convert_methodt::setup_local_variables(
     // Create a new local variable in the variables[] array, the result of
     // merging multiple local variables with equal name (parameters excluded)
     // into a single local variable with holes
-    variables[v.var.index].push_back(variablet());
-    auto &newv=variables[v.var.index].back();
-    newv.symbol_expr=result;
-    newv.start_pc=v.var.start_pc;
-    newv.length=v.var.length;
-    newv.holes=std::move(v.holes);
+    variables[v.var.index].emplace_back(
+      result, v.var.start_pc, v.var.length, false, std::move(v.holes));
 
     // Register the local variable in the symbol table
     symbolt new_symbol;
@@ -862,9 +858,7 @@ java_bytecode_convert_methodt::find_variable_for_slot(
   // with scope from 0 to SIZE_T_MAX
   // as it is at the end of the vector, it will only be taken into account
   // if no other variable is valid
-  size_t list_length=var_list.size();
-  var_list.resize(list_length+1);
-  var_list[list_length].start_pc=0;
-  var_list[list_length].length=std::numeric_limits<size_t>::max();
-  return var_list[list_length];
+  var_list.emplace_back(
+    symbol_exprt(irep_idt(), typet()), 0, std::numeric_limits<size_t>::max());
+  return var_list.back();
 }

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -1559,14 +1559,14 @@ code_blockt java_string_library_preprocesst::make_object_get_class_code(
     loc);
 
   // > class1 = Class.forName(string1)
+  java_method_typet fun_type(
+    {java_method_typet::parametert(string_ptr_type)}, class_type);
   code_function_callt fun_call(
     class1,
     symbol_exprt(
-      "java::java.lang.Class.forName:(Ljava/lang/String;)Ljava/lang/Class;"),
+      "java::java.lang.Class.forName:(Ljava/lang/String;)Ljava/lang/Class;",
+      std::move(fun_type)),
     {string1});
-  const java_method_typet fun_type(
-    {java_method_typet::parametert(string_ptr_type)}, class_type);
-  fun_call.function().type()=fun_type;
   code.add(fun_call, loc);
 
   // > return class1;

--- a/jbmc/unit/solvers/strings/string_constraint_instantiation/instantiate_not_contains.cpp
+++ b/jbmc/unit/solvers/strings/string_constraint_instantiation/instantiate_not_contains.cpp
@@ -224,7 +224,7 @@ SCENARIO(
         simplify(sc.premise, empty_ns);
         simplify(sc.s0, empty_ns);
         simplify(sc.s1, empty_ns);
-        witnesses[sc] = generator.fresh_symbol("w", t.witness_type());
+        witnesses.emplace(sc, generator.fresh_symbol("w", t.witness_type()));
         nc_axioms.push_back(sc);
         return accu + to_string(sc) + "\n\n";
       });
@@ -296,7 +296,7 @@ SCENARIO(
     // Create witness for axiom
     string_constraint_generatort generator(empty_ns);
     std::unordered_map<string_not_contains_constraintt, symbol_exprt> witnesses;
-    witnesses[vacuous] = generator.fresh_symbol("w", t.witness_type());
+    witnesses.emplace(vacuous, generator.fresh_symbol("w", t.witness_type()));
 
     INFO("Original axiom:\n");
     INFO(to_string(vacuous) + "\n\n");
@@ -346,7 +346,7 @@ SCENARIO(
     // Create witness for axiom
     string_constraint_generatort generator(empty_ns);
     std::unordered_map<string_not_contains_constraintt, symbol_exprt> witnesses;
-    witnesses[trivial] = generator.fresh_symbol("w", t.witness_type());
+    witnesses.emplace(trivial, generator.fresh_symbol("w", t.witness_type()));
 
     INFO("Original axiom:\n");
     INFO(to_string(trivial) + "\n\n");
@@ -397,7 +397,7 @@ SCENARIO(
     // Create witness for axiom
     string_constraint_generatort generator(empty_ns);
     std::unordered_map<string_not_contains_constraintt, symbol_exprt> witnesses;
-    witnesses[trivial] = generator.fresh_symbol("w", t.witness_type());
+    witnesses.emplace(trivial, generator.fresh_symbol("w", t.witness_type()));
 
     INFO("Original axiom:\n");
     INFO(to_string(trivial) + "\n\n");
@@ -450,7 +450,7 @@ SCENARIO(
     // Create witness for axiom
     string_constraint_generatort generator(empty_ns);
     std::unordered_map<string_not_contains_constraintt, symbol_exprt> witnesses;
-    witnesses[trivial] = generator.fresh_symbol("w", t.witness_type());
+    witnesses.emplace(trivial, generator.fresh_symbol("w", t.witness_type()));
 
     INFO("Original axiom:\n");
     INFO(to_string(trivial) + "\n\n");
@@ -501,7 +501,7 @@ SCENARIO(
     // Create witness for axiom
     string_constraint_generatort generator(empty_ns);
     std::unordered_map<string_not_contains_constraintt, symbol_exprt> witnesses;
-    witnesses[trivial] = generator.fresh_symbol("w", t.witness_type());
+    witnesses.emplace(trivial, generator.fresh_symbol("w", t.witness_type()));
 
     INFO("Original axiom:\n");
     INFO(to_string(trivial) + "\n\n");

--- a/src/analyses/locals.cpp
+++ b/src/analyses/locals.cpp
@@ -21,12 +21,13 @@ void localst::build(const goto_functiont &goto_function)
     if(it->is_decl())
     {
       const code_declt &code_decl=to_code_decl(it->code);
-      locals_map[code_decl.get_identifier()] = code_decl.symbol();
+      locals_map.emplace(code_decl.get_identifier(), code_decl.symbol());
     }
 
   for(const auto &param : goto_function.type.parameters())
-    locals_map[param.get_identifier()]=
-      symbol_exprt(param.get_identifier(), param.type());
+    locals_map.emplace(
+      param.get_identifier(),
+      symbol_exprt(param.get_identifier(), param.type()));
 }
 
 void localst::output(std::ostream &out) const

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -635,9 +635,7 @@ void c_typecheck_baset::typecheck_array_type(array_typet &type)
       symbol_table.add(new_symbol);
 
       // produce the code that declares and initializes the symbol
-      symbol_exprt symbol_expr;
-      symbol_expr.set_identifier(temp_identifier);
-      symbol_expr.type() = new_symbol.type;
+      symbol_exprt symbol_expr(temp_identifier, new_symbol.type);
 
       code_declt declaration(symbol_expr);
       declaration.add_source_location() = size_source_location;

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -1451,13 +1451,11 @@ void cpp_typecheckt::typecheck_expr_cpp_name(
         throw 0;
       }
 
-      symbol_exprt result;
-      result.add_source_location()=source_location;
-      result.set_identifier(identifier);
       code_typet t(
         {code_typet::parametert(ptr_arg.type())}, ptr_arg.type().subtype());
       t.make_ellipsis();
-      result.type()=t;
+      symbol_exprt result(identifier, t);
+      result.add_source_location() = source_location;
       expr.swap(result);
       return;
     }
@@ -1484,14 +1482,12 @@ void cpp_typecheckt::typecheck_expr_cpp_name(
         throw 0;
       }
 
-      symbol_exprt result;
-      result.add_source_location()=source_location;
-      result.set_identifier(identifier);
       const code_typet t(
         {code_typet::parametert(ptr_arg.type()),
          code_typet::parametert(signed_int_type())},
         ptr_arg.type().subtype());
-      result.type()=t;
+      symbol_exprt result(identifier, t);
+      result.add_source_location() = source_location;
       expr.swap(result);
       return;
     }
@@ -1518,15 +1514,13 @@ void cpp_typecheckt::typecheck_expr_cpp_name(
         throw 0;
       }
 
-      symbol_exprt result;
-      result.add_source_location()=source_location;
-      result.set_identifier(identifier);
       const code_typet t(
         {code_typet::parametert(ptr_arg.type()),
          code_typet::parametert(ptr_arg.type().subtype()),
          code_typet::parametert(signed_int_type())},
         empty_typet());
-      result.type()=t;
+      symbol_exprt result(identifier, t);
+      result.add_source_location() = source_location;
       expr.swap(result);
       return;
     }
@@ -1553,15 +1547,13 @@ void cpp_typecheckt::typecheck_expr_cpp_name(
         throw 0;
       }
 
-      symbol_exprt result;
-      result.add_source_location()=source_location;
-      result.set_identifier(identifier);
       const code_typet t(
         {code_typet::parametert(ptr_arg.type()),
          code_typet::parametert(ptr_arg.type().subtype()),
          code_typet::parametert(signed_int_type())},
         ptr_arg.type().subtype());
-      result.type()=t;
+      symbol_exprt result(identifier, t);
+      result.add_source_location() = source_location;
       expr.swap(result);
       return;
     }
@@ -1596,15 +1588,13 @@ void cpp_typecheckt::typecheck_expr_cpp_name(
 
       const exprt &ptr_arg=fargs.operands.front();
 
-      symbol_exprt result;
-      result.add_source_location()=source_location;
-      result.set_identifier(identifier);
       const code_typet t(
         {code_typet::parametert(ptr_arg.type()),
          code_typet::parametert(ptr_arg.type()),
          code_typet::parametert(signed_int_type())},
         empty_typet());
-      result.type()=t;
+      symbol_exprt result(identifier, t);
+      result.add_source_location() = source_location;
       expr.swap(result);
       return;
     }
@@ -1645,16 +1635,14 @@ void cpp_typecheckt::typecheck_expr_cpp_name(
 
       const exprt &ptr_arg=fargs.operands.front();
 
-      symbol_exprt result;
-      result.add_source_location()=source_location;
-      result.set_identifier(identifier);
       const code_typet t(
         {code_typet::parametert(ptr_arg.type()),
          code_typet::parametert(ptr_arg.type()),
          code_typet::parametert(ptr_arg.type()),
          code_typet::parametert(signed_int_type())},
         empty_typet());
-      result.type()=t;
+      symbol_exprt result(identifier, t);
+      result.add_source_location() = source_location;
       expr.swap(result);
       return;
     }
@@ -1700,9 +1688,6 @@ void cpp_typecheckt::typecheck_expr_cpp_name(
 
       const exprt &ptr_arg=fargs.operands.front();
 
-      symbol_exprt result;
-      result.add_source_location()=source_location;
-      result.set_identifier(identifier);
       code_typet::parameterst parameters;
       parameters.push_back(code_typet::parametert(ptr_arg.type()));
       parameters.push_back(code_typet::parametert(ptr_arg.type()));
@@ -1716,7 +1701,8 @@ void cpp_typecheckt::typecheck_expr_cpp_name(
       parameters.push_back(code_typet::parametert(signed_int_type()));
       parameters.push_back(code_typet::parametert(signed_int_type()));
       code_typet t(std::move(parameters), c_bool_type());
-      result.type()=t;
+      symbol_exprt result(identifier, t);
+      result.add_source_location() = source_location;
       expr.swap(result);
       return;
     }
@@ -1745,13 +1731,11 @@ void cpp_typecheckt::typecheck_expr_cpp_name(
         throw 0;
       }
 
-      symbol_exprt result;
-      result.add_source_location()=source_location;
-      result.set_identifier(identifier);
       code_typet t(
         {code_typet::parametert(ptr_arg.type())}, ptr_arg.type().subtype());
       t.make_ellipsis();
-      result.type()=t;
+      symbol_exprt result(identifier, t);
+      result.add_source_location() = source_location;
       expr.swap(result);
       return;
     }
@@ -1780,13 +1764,11 @@ void cpp_typecheckt::typecheck_expr_cpp_name(
         throw 0;
       }
 
-      symbol_exprt result;
-      result.add_source_location()=source_location;
-      result.set_identifier(identifier);
       code_typet t(
         {code_typet::parametert(ptr_arg.type())}, ptr_arg.type().subtype());
       t.make_ellipsis();
-      result.type()=t;
+      symbol_exprt result(identifier, t);
+      result.add_source_location() = source_location;
       expr.swap(result);
       return;
     }

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -2132,7 +2132,7 @@ bool cpp_typecheck_resolvet::disambiguate_functions(
       {
         // it's a constructor
         const typet &object_type=parameter.type().subtype();
-        symbol_exprt object(object_type);
+        symbol_exprt object(irep_idt(), object_type);
         object.set(ID_C_lvalue, true);
 
         cpp_typecheck_fargst new_fargs(fargs);

--- a/src/goto-cc/linker_script_merge.cpp
+++ b/src/goto-cc/linker_script_merge.cpp
@@ -440,8 +440,8 @@ int linker_script_merget::ls_data2instructions(
 
     // Linker-defined symbol_exprt pointing to start address
     symbol_exprt start_sym(d["start-symbol"].value, pointer_type(char_type()));
-    linker_values[d["start-symbol"].value]=std::make_pair(start_sym,
-        array_start);
+    linker_values.emplace(
+      d["start-symbol"].value, std::make_pair(start_sym, array_start));
 
     // Since the value of the pointer will be a random CBMC address, write a
     // note about the real address in the object file
@@ -479,7 +479,8 @@ int linker_script_merget::ls_data2instructions(
       plus_exprt array_end(array_start, array_size_expr);
 
       symbol_exprt end_sym(d["end-symbol"].value, pointer_type(char_type()));
-      linker_values[d["end-symbol"].value]=std::make_pair(end_sym, array_end);
+      linker_values.emplace(
+        d["end-symbol"].value, std::make_pair(end_sym, array_end));
 
       auto entry = std::find_if(
         to_json_array(data["addresses"]).begin(),
@@ -578,7 +579,8 @@ int linker_script_merget::ls_data2instructions(
     exprt rhs_tc(rhs);
     rhs_tc.make_typecast(pointer_type(char_type()));
 
-    linker_values[irep_idt(d["sym"].value)]=std::make_pair(lhs, rhs_tc);
+    linker_values.emplace(
+      irep_idt(d["sym"].value), std::make_pair(lhs, rhs_tc));
 
     code_assignt assign(lhs, rhs_tc);
     assign.add_source_location()=loc;
@@ -641,7 +643,8 @@ int linker_script_merget::ls_data2instructions(
     exprt rhs_tc(rhs);
     rhs_tc.make_typecast(pointer_type(char_type()));
 
-    linker_values[irep_idt(d["sym"].value)]=std::make_pair(lhs, rhs_tc);
+    linker_values.emplace(
+      irep_idt(d["sym"].value), std::make_pair(lhs, rhs_tc));
 
     code_assignt assign(lhs, rhs_tc);
     assign.add_source_location()=loc;

--- a/src/goto-instrument/rw_set.cpp
+++ b/src/goto-instrument/rw_set.cpp
@@ -96,22 +96,18 @@ void _rw_set_loct::read_write_rec(
 
     if(r)
     {
-      entryt &entry=r_entries[object];
-      entry.object=object;
-      entry.symbol_expr=symbol_expr;
-      entry.guard=guard.as_expr(); // should 'OR'
+      const auto &entry =
+        r_entries.emplace(object, entryt(symbol_expr, object, guard.as_expr()));
 
-      track_deref(entry, true);
+      track_deref(entry.first->second, true);
     }
 
     if(w)
     {
-      entryt &entry=w_entries[object];
-      entry.object=object;
-      entry.symbol_expr=symbol_expr;
-      entry.guard=guard.as_expr(); // should 'OR'
+      const auto &entry =
+        w_entries.emplace(object, entryt(symbol_expr, object, guard.as_expr()));
 
-      track_deref(entry, false);
+      track_deref(entry.first->second, false);
     }
   }
   else if(expr.id()==ID_member)

--- a/src/goto-instrument/rw_set.h
+++ b/src/goto-instrument/rw_set.h
@@ -48,7 +48,11 @@ public:
     irep_idt object;
     exprt guard;
 
-    entryt():guard(true_exprt())
+    entryt(
+      const symbol_exprt &_symbol_expr,
+      const irep_idt &_object,
+      const exprt &_guard)
+      : symbol_expr(_symbol_expr), object(_object), guard(_guard)
     {
     }
   };

--- a/src/goto-instrument/uninitialized.cpp
+++ b/src/goto-instrument/uninitialized.cpp
@@ -121,9 +121,7 @@ void uninitializedt::add_assertions(
         const irep_idt new_identifier=
           id2string(identifier)+"#initialized";
 
-        symbol_exprt symbol_expr;
-        symbol_expr.set_identifier(new_identifier);
-        symbol_expr.type()=bool_typet();
+        symbol_exprt symbol_expr(new_identifier, bool_typet());
         i1->type=DECL;
         i1->source_location=instruction.source_location;
         i1->code=code_declt(symbol_expr);

--- a/src/goto-symex/memory_model.cpp
+++ b/src/goto-symex/memory_model.cpp
@@ -84,8 +84,7 @@ void memory_model_baset::read_from(symex_target_equationt &equation)
         symbol_exprt s=nondet_bool_symbol("rf");
 
         // record the symbol
-        choice_symbols[
-          std::make_pair(r, w)]=s;
+        choice_symbols.emplace(std::make_pair(r, w), s);
 
         // We rely on the fact that there is at least
         // one write event that has guard 'true'.

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -408,7 +408,7 @@ void goto_symext::locality(
 
     if(c_it != state.level1.current_names.end())
     {
-      frame.old_level1[l0_name]=c_it->second;
+      frame.old_level1.emplace(l0_name, c_it->second);
       c_it->second = std::make_pair(ssa, frame_nr);
     }
     else

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -645,9 +645,9 @@ void symex_target_equationt::convert_io(
           step.converted_io_args.push_back(arg);
         else
         {
-          symbol_exprt symbol;
-          symbol.type()=arg.type();
-          symbol.set_identifier("symex::io::"+std::to_string(io_count++));
+          const irep_idt identifier =
+            "symex::io::" + std::to_string(io_count++);
+          symbol_exprt symbol(identifier, arg.type());
 
           equal_exprt eq(arg, symbol);
           merge_irep(eq);

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -500,9 +500,8 @@ exprt smt2_parsert::function_application()
           {
             const symbol_exprt symbol_expr(
               smt2_tokenizer.get_buffer(), bool_typet());
-            auto &named_term = named_terms[symbol_expr.get_identifier()];
-            named_term.term = term;
-            named_term.name = symbol_expr;
+            named_terms.emplace(
+              symbol_expr.get_identifier(), named_termt(term, symbol_expr));
           }
           else
             throw error("invalid name attribute, expected symbol");

--- a/src/solvers/smt2/smt2_parser.h
+++ b/src/solvers/smt2/smt2_parser.h
@@ -47,6 +47,13 @@ public:
 
   struct named_termt
   {
+    /// Default-constructing a symbol_exprt is deprecated, thus make sure we
+    /// always construct a named_termt from an initialized \p _name
+    named_termt(const exprt &_term, const symbol_exprt &_name)
+      : term(_term), name(_name)
+    {
+    }
+
     exprt term;
     symbol_exprt name;
   };

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -735,8 +735,8 @@ decision_proceduret::resultt string_refinementt::dec_solve()
       const typet &index_type = rtype.size().type();
       return array_typet(index_type, infinity_exprt(index_type));
     }();
-    not_contain_witnesses[nc_axiom] =
-      generator.fresh_symbol("not_contains_witness", witness_type);
+    not_contain_witnesses.emplace(
+      nc_axiom, generator.fresh_symbol("not_contains_witness", witness_type));
   }
 
   for(const exprt &lemma : generator.constraints.existential)

--- a/src/util/ssa_expr.h
+++ b/src/util/ssa_expr.h
@@ -16,15 +16,9 @@ Author: Daniel Kroening, kroening@kroening.com
 class ssa_exprt:public symbol_exprt
 {
 public:
-  ssa_exprt()
-  {
-    set(ID_C_SSA_symbol, true);
-  }
-
   /// Constructor
   /// \param expr: Expression to be converted to SSA symbol
-  explicit ssa_exprt(const exprt &expr):
-    symbol_exprt(expr.type())
+  explicit ssa_exprt(const exprt &expr) : symbol_exprt(irep_idt(), expr.type())
   {
     set(ID_C_SSA_symbol, true);
     add(ID_expression, expr);

--- a/unit/util/expr_cast/expr_cast.cpp
+++ b/unit/util/expr_cast/expr_cast.cpp
@@ -19,7 +19,7 @@ Author: Nathan Phillips <Nathan.Phillips@diffblue.com>
 SCENARIO("expr_dynamic_cast",
   "[core][utils][expr_cast][expr_dynamic_cast]")
 {
-  symbol_exprt symbol_expr;
+  symbol_exprt symbol_expr("dummy", empty_typet());
 
   GIVEN("A const exprt reference to a symbolt")
   {


### PR DESCRIPTION
This helps type safety has it avoids constructing symbol_exprts that never get
a proper type (or identifier).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
