### PR TITLE
Move promotion rule application to C front-end [blocks: #3725, #3800]

### DIFF
--- a/regression/cbmc/Overflow_Addition3/test.desc
+++ b/regression/cbmc/Overflow_Addition3/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --signed-overflow-check --conversion-check
 ^EXIT=10$

--- a/regression/cbmc/complex1/main.c
+++ b/regression/cbmc/complex1/main.c
@@ -2,7 +2,7 @@
 
 int main()
 {
-  #ifdef __GNUC__
+#ifdef __GNUC__
   _Complex c; // this is usually '_Complex double'
   c=1.0i+2;
 
@@ -21,10 +21,10 @@ int main()
 
   // The real part is stored first in memory on i386.
   // Need to find out about other architectures.
-  #if defined(__i386__) || defined(__amd64__)
+#if defined(__i386__) || defined(__amd64__)
   assert(((signed char *)&char_complex)[0]==-2);
   assert(((signed char *)&char_complex)[1]==3);
-  #endif
+#endif
 
   assert(__real__ char_complex == -2);
   assert(__imag__ char_complex == 3);
@@ -44,18 +44,35 @@ int main()
   char_complex++;
   assert(__real__ char_complex == 101);
   assert(__imag__ char_complex == 3);
+  ++char_complex;
+  assert(__real__ char_complex == 102);
+  assert(__imag__ char_complex == 3);
+  char_complex += 1;
+  assert(__real__ char_complex == 103);
+  assert(__imag__ char_complex == 3);
 
   // also separately
   (__real__ char_complex)++;
-  assert(__real__ char_complex == 102);
+  assert(__real__ char_complex == 104);
   assert(__imag__ char_complex == 3);
 
   // casts to reals produce the real part
-  assert((int) char_complex == 102);
+  assert((int)char_complex == 104);
 
-  #else
+  // can be decremented
+  char_complex--;
+  assert(__real__ char_complex == 103);
+  assert(__imag__ char_complex == 3);
+  --char_complex;
+  assert(__real__ char_complex == 102);
+  assert(__imag__ char_complex == 3);
+  char_complex -= 1;
+  assert(__real__ char_complex == 101);
+  assert(__imag__ char_complex == 3);
+
+#else
 
   // Visual studio doesn't have it
 
-  #endif
+#endif
 }

--- a/regression/cbmc/enum8/main.c
+++ b/regression/cbmc/enum8/main.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+
+enum E
+{
+  A = 1,
+  B = 16
+};
+
+int main()
+{
+  enum E e = A;
+  e <<= 4;
+  assert(e == B);
+  e >>= 4;
+  assert(e == A);
+  e |= B;
+  e ^= A;
+  assert(e == B);
+  e -= 15;
+  assert(e == A);
+  return 0;
+}

--- a/regression/cbmc/enum8/test.desc
+++ b/regression/cbmc/enum8/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/goto-programs/goto_convert_side_effect.cpp
+++ b/src/goto-programs/goto_convert_side_effect.cpp
@@ -44,10 +44,13 @@ void goto_convertt::remove_assignment(
 
   if(statement==ID_assign)
   {
-    exprt tmp=expr;
-    tmp.id(ID_code);
-    // just interpret as code
-    convert_assign(to_code_assign(to_code(tmp)), dest, mode);
+    exprt new_lhs = skip_typecast(expr.op0());
+    exprt new_rhs =
+      typecast_exprt::conditional_cast(expr.op1(), new_lhs.type());
+    code_assignt assign(std::move(new_lhs), std::move(new_rhs));
+    assign.add_source_location() = expr.source_location();
+
+    convert_assign(assign, dest, mode);
   }
   else if(statement==ID_assign_plus ||
           statement==ID_assign_minus ||
@@ -107,7 +110,11 @@ void goto_convertt::remove_assignment(
     rhs.type() = expr.op0().type();
     rhs.add_source_location() = expr.source_location();
 
-    code_assignt assignment(expr.op0(), rhs);
+    exprt new_lhs = skip_typecast(expr.op0());
+    rhs = typecast_exprt::conditional_cast(rhs, new_lhs.type());
+    rhs.add_source_location() = expr.source_location();
+
+    code_assignt assignment(new_lhs, rhs);
     assignment.add_source_location()=expr.source_location();
 
     convert(assignment, dest, mode);


### PR DESCRIPTION
The front-ends handle type conversion when doing arithmetic over enum types. The
case of an enum tag is not expected in goto-program conversion. That, however,
was only the case for some operators. Made the C front-end properly handle all
assignment operators.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
