### PR TITLE
transt: add a non-deprecated constructor

### DIFF
--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -93,7 +93,18 @@ public:
 class transt : public ternary_exprt
 {
 public:
+  DEPRECATED("use transt(op0, op1, op2) instead")
   transt() : ternary_exprt(ID_trans)
+  {
+  }
+
+  transt(
+    const irep_idt &_id,
+    const exprt &_op0,
+    const exprt &_op1,
+    const exprt &_op2,
+    const typet &_type)
+    : ternary_exprt(_id, _op0, _op1, _op2, _type)
   {
   }
 


### PR DESCRIPTION
The only existing constructor relied on a constructor of ternary_exprt that is
marked deprecated. Thus mark the existing one deprecated and add one that will
survive removal of deprecated functions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
