### PR TITLE
Mark constructors depending on deprecated parent constructors as deprecated

### DIFF
--- a/src/util/byte_operators.h
+++ b/src/util/byte_operators.h
@@ -25,10 +25,12 @@ Author: Daniel Kroening, kroening@kroening.com
 class byte_extract_exprt:public binary_exprt
 {
 public:
+  DEPRECATED("use byte_extract_exprt(id, op, offset, type) instead")
   explicit byte_extract_exprt(irep_idt _id):binary_exprt(_id)
   {
   }
 
+  DEPRECATED("use byte_extract_exprt(id, op, offset, type) instead")
   explicit byte_extract_exprt(irep_idt _id, const typet &_type):
     binary_exprt(_id, _type)
   {

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -1046,6 +1046,7 @@ public:
   {
   }
 
+  DEPRECATED("use plus_exprt(lhs, rhs, type) instead")
   plus_exprt(const typet &type) : multi_ary_exprt(ID_plus, type)
   {
   }
@@ -1743,6 +1744,7 @@ public:
   {
   }
 
+  DEPRECATED("use array_exprt(operands, type) instead")
   explicit array_exprt(const array_typet &_type)
     : multi_ary_exprt(ID_array, _type)
   {
@@ -1778,6 +1780,7 @@ template<> inline bool can_cast_expr<array_exprt>(const exprt &base)
 class array_list_exprt : public multi_ary_exprt
 {
 public:
+  DEPRECATED("use array_list_exprt(operands, type) instead")
   explicit array_list_exprt(const array_typet &_type)
     : multi_ary_exprt(ID_array_list, _type)
   {
@@ -1804,6 +1807,7 @@ public:
   {
   }
 
+  DEPRECATED("use vector_exprt(operands, type) instead")
   explicit vector_exprt(const vector_typet &_type)
     : multi_ary_exprt(ID_vector, _type)
   {
@@ -1924,6 +1928,7 @@ public:
   {
   }
 
+  DEPRECATED("use struct_exprt(component_name, value, type) instead")
   explicit struct_exprt(const typet &_type) : multi_ary_exprt(ID_struct, _type)
   {
   }
@@ -2408,6 +2413,7 @@ inline void validate_expr(const floatbv_typecast_exprt &value)
 class and_exprt:public multi_ary_exprt
 {
 public:
+  DEPRECATED("use and_exprt(op, op) instead")
   and_exprt():multi_ary_exprt(ID_and, bool_typet())
   {
   }
@@ -2530,6 +2536,7 @@ inline void validate_expr(const implies_exprt &value)
 class or_exprt:public multi_ary_exprt
 {
 public:
+  DEPRECATED("use or_exprt(op, op) instead")
   or_exprt():multi_ary_exprt(ID_or, bool_typet())
   {
   }
@@ -2606,6 +2613,7 @@ template<> inline bool can_cast_expr<or_exprt>(const exprt &base)
 class xor_exprt:public multi_ary_exprt
 {
 public:
+  DEPRECATED("use xor_exprt(op, op) instead")
   xor_exprt():multi_ary_exprt(ID_bitxor, bool_typet())
   {
   }
@@ -3336,6 +3344,7 @@ public:
     PRECONDITION(op.type().id()==ID_bool);
   }
 
+  DEPRECATED("use not_exprt(op) instead")
   not_exprt():unary_exprt(ID_not, bool_typet())
   {
   }
@@ -4889,6 +4898,7 @@ inline void validate_expr(const popcount_exprt &value)
 class cond_exprt : public multi_ary_exprt
 {
 public:
+  DEPRECATED("use cond_exprt(operands, type) instead")
   explicit cond_exprt(const typet &_type) : multi_ary_exprt(ID_cond, _type)
   {
   }

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -114,6 +114,7 @@ inline const array_string_exprt &to_array_string_expr(const exprt &expr)
 class refined_string_exprt : public struct_exprt
 {
 public:
+  DEPRECATED("use refined_string_exprt(length, content, type) instead")
   refined_string_exprt() : struct_exprt()
   {
   }


### PR DESCRIPTION
Removing the deprecated parent constructors would imply compilation failures.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
