### PR TITLE
Add a cond_exprt constructor

### DIFF
--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -4944,7 +4944,7 @@ inline const cond_exprt &to_cond_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_cond);
   DATA_INVARIANT(
-    expr.operands().size() % 2 != 0, "cond must have even number of operands");
+    expr.operands().size() % 2 == 0, "cond must have even number of operands");
   return static_cast<const cond_exprt &>(expr);
 }
 

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -4917,6 +4917,11 @@ public:
   {
   }
 
+  cond_exprt(operandst &&_operands, const typet &_type)
+    : multi_ary_exprt(ID_cond, std::move(_operands), _type)
+  {
+  }
+
   /// adds a case to a cond expression
   /// \param condition: the condition for the case
   /// \param value: the value for the case


### PR DESCRIPTION
The existing constructor requires a deprecated parent constructor.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
