### PR TITLE
Construct struct_exprt in a non-deprecated way

### DIFF
--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -836,14 +836,11 @@ codet java_string_library_preprocesst::code_assign_components_to_java_string(
     // A String has a field Object with @clsid = String
     const symbolt &jlo_symbol = *symbol_table.lookup("java::java.lang.Object");
     const struct_typet &jlo_struct = to_struct_type(jlo_symbol.type);
-    struct_exprt jlo_init(jlo_struct);
+    struct_exprt jlo_init({}, jlo_struct);
     irep_idt clsid = get_tag(lhs.type().subtype());
     java_root_class_init(jlo_init, jlo_struct, clsid);
 
-    struct_exprt struct_rhs(deref.type());
-    struct_rhs.copy_to_operands(jlo_init);
-    struct_rhs.copy_to_operands(rhs_length);
-    struct_rhs.copy_to_operands(rhs_array);
+    struct_exprt struct_rhs({jlo_init, rhs_length, rhs_array}, deref.type());
     return code_assignt(
       checked_dereference(lhs, lhs.type().subtype()), struct_rhs);
   }
@@ -1342,7 +1339,7 @@ struct_exprt java_string_library_preprocesst::make_argument_for_format(
 {
   // Declarations of the fields of arg_i_struct
   // arg_i_struct is { arg_i_string_expr, tmp_int, tmp_char, ... }
-  struct_exprt arg_i_struct(structured_type);
+  struct_exprt arg_i_struct({}, structured_type);
   std::list<exprt> field_exprs;
   for(const auto & comp : structured_type.components())
   {

--- a/jbmc/src/java_bytecode/java_string_literals.cpp
+++ b/jbmc/src/java_bytecode/java_string_literals.cpp
@@ -98,7 +98,7 @@ symbol_exprt get_or_create_string_literal_symbol(
   // the literal with @clsid = String
   struct_tag_typet jlo_symbol("java::java.lang.Object");
   const auto &jlo_struct = to_struct_type(ns.follow(jlo_symbol));
-  struct_exprt jlo_init(jlo_symbol);
+  struct_exprt jlo_init({}, jlo_symbol);
   const auto &jls_struct = to_struct_type(ns.follow(string_type));
   java_root_class_init(jlo_init, jlo_struct, "java::java.lang.String");
 
@@ -109,7 +109,7 @@ symbol_exprt get_or_create_string_literal_symbol(
     const array_exprt data =
       utf16_to_array(utf8_to_utf16_native_endian(id2string(value)));
 
-    struct_exprt literal_init(new_symbol.type);
+    struct_exprt literal_init({}, new_symbol.type);
     literal_init.operands().resize(jls_struct.components().size());
     const std::size_t jlo_nb = jls_struct.component_number("@java.lang.Object");
     literal_init.operands()[jlo_nb] = jlo_init;
@@ -183,8 +183,7 @@ symbol_exprt get_or_create_string_literal_symbol(
     // Case where something defined java.lang.String, so it has
     // a proper base class (always java.lang.Object in practical
     // JDKs seen so far)
-    struct_exprt literal_init(new_symbol.type);
-    literal_init.move_to_operands(jlo_init);
+    struct_exprt literal_init({std::move(jlo_init)}, new_symbol.type);
     for(const auto &comp : jls_struct.components())
     {
       if(comp.get_name()=="@java.lang.Object")

--- a/jbmc/unit/solvers/refinement/string_refinement/dependency_graph.cpp
+++ b/jbmc/unit/solvers/refinement/string_refinement/dependency_graph.cpp
@@ -37,10 +37,7 @@ struct_exprt make_string_argument(std::string name)
 
   const symbol_exprt length(name + "_length", length_type());
   const symbol_exprt content(name + "_content", pointer_type(java_char_type()));
-  struct_exprt expr(type);
-  expr.operands().push_back(length);
-  expr.operands().push_back(content);
-  return expr;
+  return struct_exprt({length, content}, type);
 }
 
 SCENARIO("dependency_graph", "[core][solvers][refinement][string_refinement]")

--- a/jbmc/unit/solvers/refinement/string_refinement/string_symbol_resolution.cpp
+++ b/jbmc/unit/solvers/refinement/string_refinement/string_symbol_resolution.cpp
@@ -39,9 +39,7 @@ SCENARIO("string_identifiers_resolution_from_equations",
     struct_typet struct_type;
     struct_type.components().emplace_back("str1", string_typet());
     struct_type.components().emplace_back("str2", string_typet());
-    struct_exprt struct_expr(struct_type);
-    struct_expr.operands().push_back(a);
-    struct_expr.operands().push_back(f);
+    struct_exprt struct_expr({a, f}, struct_type);
     symbol_exprt symbol_struct("sym_struct", struct_type);
 
     std::vector<equal_exprt> equations;

--- a/src/cpp/cpp_typecheck_virtual_table.cpp
+++ b/src/cpp/cpp_typecheck_virtual_table.cpp
@@ -81,7 +81,7 @@ void cpp_typecheckt::do_virtual_table(const symbolt &symbol)
     // do the values
     const struct_typet &vt_type=to_struct_type(vt_symb_type.type);
 
-    struct_exprt values(struct_tag_typet(vt_symb_type.name));
+    struct_exprt values({}, struct_tag_typet(vt_symb_type.name));
 
     for(const auto &compo : vt_type.components())
     {

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -1253,7 +1253,7 @@ void dump_ct::cleanup_expr(exprt &expr)
     {
       if(u_type_f.get_component(u.get_component_name()).get_is_padding())
         // we just use an empty struct to fake an empty union
-        expr=struct_exprt(struct_typet());
+        expr = struct_exprt({}, struct_typet());
     }
     // add a typecast for NULL
     else if(u.op().id()==ID_constant &&

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -465,7 +465,7 @@ exprt interpretert::get_value(
   const typet real_type=ns.follow(type);
   if(real_type.id()==ID_struct)
   {
-    struct_exprt result(real_type);
+    struct_exprt result({}, real_type);
     const struct_typet &struct_type=to_struct_type(real_type);
     const struct_typet::componentst &components=struct_type.components();
 
@@ -532,7 +532,7 @@ exprt interpretert::get_value(
 
   if(real_type.id()==ID_struct)
   {
-    struct_exprt result(real_type);
+    struct_exprt result({}, real_type);
     const struct_typet &struct_type=to_struct_type(real_type);
     const struct_typet::componentst &components=struct_type.components();
 

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -429,12 +429,13 @@ symbol_exprt string_abstractiont::add_dummy_symbol_and_value(
   if(source_type.id()==ID_array && is_char_type(source_type.subtype()) &&
       type_eq(type, string_struct, ns))
   {
-    new_symbol.value=struct_exprt(string_struct);
-    new_symbol.value.operands().resize(3);
-    new_symbol.value.op0()=build_unknown(whatt::IS_ZERO, false);
-    new_symbol.value.op1()=build_unknown(whatt::LENGTH, false);
-    new_symbol.value.op2()=to_array_type(source_type).size().id()==ID_infinity?
-      build_unknown(whatt::SIZE, false):to_array_type(source_type).size();
+    new_symbol.value = struct_exprt(
+      {build_unknown(whatt::IS_ZERO, false),
+       build_unknown(whatt::LENGTH, false),
+       to_array_type(source_type).size().id() == ID_infinity
+         ? build_unknown(whatt::SIZE, false)
+         : to_array_type(source_type).size()},
+      string_struct);
     make_type(new_symbol.value.op2(), build_type(whatt::SIZE));
   }
   else
@@ -1032,12 +1033,11 @@ bool string_abstractiont::build_symbol_constant(
     new_symbol.is_file_local=false;
 
     {
-      struct_exprt value(string_struct);
-      value.operands().resize(3);
-
-      value.op0()=true_exprt();
-      value.op1()=from_integer(zero_length, build_type(whatt::LENGTH));
-      value.op2()=from_integer(buf_size, build_type(whatt::SIZE));
+      struct_exprt value(
+        {true_exprt(),
+         from_integer(zero_length, build_type(whatt::LENGTH)),
+         from_integer(buf_size, build_type(whatt::SIZE))},
+        string_struct);
 
       // initialization
       goto_programt::targett assignment1=initialization.add_instruction();

--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -152,9 +152,7 @@ exprt boolbvt::bv_get_rec(
         }
       }
 
-      struct_exprt dest(type);
-      dest.operands().swap(op);
-      return std::move(dest);
+      return struct_exprt(std::move(op), type);
     }
     else if(type.id()==ID_union)
     {

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -264,7 +264,7 @@ exprt lower_byte_extract(const byte_extract_exprt &src, const namespacet &ns)
     const struct_typet::componentst &components=struct_type.components();
 
     bool failed=false;
-    struct_exprt s(src.type());
+    struct_exprt s({}, src.type());
 
     for(const auto &comp : components)
     {

--- a/src/solvers/refinement/string_constraint_generator_format.cpp
+++ b/src/solvers/refinement/string_constraint_generator_format.cpp
@@ -401,10 +401,11 @@ std::pair<exprt, string_constraintst> add_axioms_for_format(
     if(fe.is_format_specifier())
     {
       const format_specifiert &fs=fe.get_format_specifier();
-      struct_exprt arg;
       if(fs.conversion!=format_specifiert::PERCENT_SIGN &&
          fs.conversion!=format_specifiert::LINE_SEPARATOR)
       {
+        exprt arg;
+
         if(fs.index==-1)
         {
           INVARIANT(
@@ -421,11 +422,19 @@ std::pair<exprt, string_constraintst> add_axioms_for_format(
           // first argument `args[0]` corresponds to index 1
           arg=to_struct_expr(args[fs.index-1]);
         }
+
+        auto result = add_axioms_for_format_specifier(
+          fresh_symbol,
+          fs,
+          to_struct_expr(arg),
+          index_type,
+          char_type,
+          array_pool,
+          message,
+          ns);
+        merge(constraints, std::move(result.second));
+        intermediary_strings.push_back(result.first);
       }
-      auto result = add_axioms_for_format_specifier(
-        fresh_symbol, fs, arg, index_type, char_type, array_pool, message, ns);
-      merge(constraints, std::move(result.second));
-      intermediary_strings.push_back(result.first);
     }
     else
     {

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -393,9 +393,7 @@ exprt smt2_convt::parse_struct(
   const struct_typet::componentst &components =
     type.components();
 
-  struct_exprt result(type);
-
-  result.operands().resize(components.size(), nil_exprt());
+  struct_exprt result(exprt::operandst(components.size(), nil_exprt()), type);
 
   if(components.empty())
     return std::move(result);

--- a/src/util/expr_initializer.cpp
+++ b/src/util/expr_initializer.cpp
@@ -188,7 +188,7 @@ exprt expr_initializert<nondet>::expr_initializer_rec(
     const struct_typet::componentst &components=
       to_struct_type(type).components();
 
-    struct_exprt value(type);
+    struct_exprt value({}, type);
 
     value.operands().reserve(components.size());
 

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -1492,7 +1492,7 @@ exprt simplify_exprt::bits2expr(
     const struct_typet::componentst &components=
       struct_type.components();
 
-    struct_exprt result(type);
+    struct_exprt result({}, type);
     result.reserve_operands(components.size());
 
     mp_integer m_offset_bits=0;

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -1944,6 +1944,11 @@ public:
   {
   }
 
+  struct_exprt(operandst &&_operands, const typet &_type)
+    : multi_ary_exprt(ID_struct, std::move(_operands), _type)
+  {
+  }
+
   exprt &component(const irep_idt &name, const namespacet &ns);
   const exprt &component(const irep_idt &name, const namespacet &ns) const;
 };

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -123,9 +123,8 @@ public:
     const exprt &_length,
     const exprt &_content,
     const typet &type)
-    : struct_exprt(type)
+    : struct_exprt({_length, _content}, type)
   {
-    add_to_operands(_length, _content);
   }
 
   refined_string_exprt(const exprt &_length, const exprt &_content)

--- a/unit/pointer-analysis/value_set.cpp
+++ b/unit/pointer-analysis/value_set.cpp
@@ -211,11 +211,10 @@ SCENARIO(
 
     WHEN("We query what '{ .x = &a2, .y = &a3 }.x' points to")
     {
-      struct_exprt struct_constant(struct_tag_typet(A_symbol.name));
-      struct_constant.copy_to_operands(
-        address_of_exprt(a2_symbol.symbol_expr()));
-      struct_constant.copy_to_operands(
-        address_of_exprt(a3_symbol.symbol_expr()));
+      struct_exprt struct_constant(
+        {address_of_exprt(a2_symbol.symbol_expr()),
+         address_of_exprt(a3_symbol.symbol_expr())},
+        struct_tag_typet(A_symbol.name));
 
       member_exprt member_of_constant(struct_constant, A_x);
 


### PR DESCRIPTION
The existing struct_exprt constructor relies on other deprecated constructors;
instead introduce a non-deprecated one and use it across the codebase.

@romainbrenguier Could you please take a careful look at the second commit?

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
