### PR TITLE
Construct equal_exprt in a non-deprecated way

### DIFF
--- a/src/analyses/invariant_set.cpp
+++ b/src/analyses/invariant_set.cpp
@@ -752,9 +752,8 @@ void invariant_sett::nnf(exprt &expr, bool negate)
       typecast_expr.op().type().id() == ID_unsignedbv ||
       typecast_expr.op().type().id() == ID_signedbv)
     {
-      equal_exprt tmp;
-      tmp.lhs() = typecast_expr.op();
-      tmp.rhs() = from_integer(0, typecast_expr.op().type());
+      equal_exprt tmp(
+        typecast_expr.op(), from_integer(0, typecast_expr.op().type()));
       nnf(tmp, !negate);
       expr.swap(tmp);
     }
@@ -1053,9 +1052,7 @@ void invariant_sett::assignment(
   const exprt &lhs,
   const exprt &rhs)
 {
-  equal_exprt equality;
-  equality.lhs()=lhs;
-  equality.rhs()=rhs;
+  equal_exprt equality(lhs, rhs);
 
   // first evaluate RHS
   simplify(equality.rhs());

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2540,8 +2540,8 @@ exprt c_typecheck_baset::do_special_functions(
       throw 0;
     }
 
-    equal_exprt equality_expr;
-    equality_expr.operands()=expr.arguments();
+    equal_exprt equality_expr(
+      expr.arguments().front(), expr.arguments().back());
     equality_expr.add_source_location()=source_location;
 
     if(!base_type_eq(equality_expr.lhs().type(),

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1156,9 +1156,7 @@ exprt goto_convertt::case_guard(
 
     forall_expr(it, case_op)
     {
-      equal_exprt eq_expr;
-      eq_expr.lhs() = value;
-      eq_expr.rhs() = *it;
+      equal_exprt eq_expr(value, *it);
       dest.move_to_operands(eq_expr);
     }
     INVARIANT(

--- a/src/solvers/flattening/boolbv_byte_extract.cpp
+++ b/src/solvers/flattening/boolbv_byte_extract.cpp
@@ -143,9 +143,6 @@ bvt boolbvt::convert_byte_extract(const byte_extract_exprt &expr)
 
       // add implications
 
-      equal_exprt equality;
-      equality.lhs() = expr.offset(); // index operand
-
       // type of index operand
       const typet &constant_type = expr.offset().type();
 
@@ -154,8 +151,6 @@ bvt boolbvt::convert_byte_extract(const byte_extract_exprt &expr)
 
       for(std::size_t i=0; i<bytes; i++)
       {
-        equality.rhs()=from_integer(i, constant_type);
-
         std::size_t offset=i*byte_width;
 
         for(std::size_t j=0; j<width; j++)
@@ -164,23 +159,20 @@ bvt boolbvt::convert_byte_extract(const byte_extract_exprt &expr)
           else
             equal_bv[j]=const_literal(true);
 
-        prop.l_set_to_true(
-          prop.limplies(convert(equality), prop.land(equal_bv)));
+        prop.l_set_to_true(prop.limplies(
+          convert(equal_exprt(expr.offset(), from_integer(i, constant_type))),
+          prop.land(equal_bv)));
       }
     }
     else
     {
-      equal_exprt equality;
-      equality.lhs() = expr.offset(); // index operand
-
       // type of index operand
       const typet &constant_type = expr.offset().type();
 
       for(std::size_t i=0; i<bytes; i++)
       {
-        equality.rhs()=from_integer(i, constant_type);
-
-        literalt e=convert(equality);
+        literalt e =
+          convert(equal_exprt(expr.offset(), from_integer(i, constant_type)));
 
         std::size_t offset=i*byte_width;
 

--- a/src/solvers/flattening/boolbv_byte_update.cpp
+++ b/src/solvers/flattening/boolbv_byte_update.cpp
@@ -85,9 +85,8 @@ bvt boolbvt::convert_byte_update(const byte_update_exprt &expr)
   for(std::size_t offset=0; offset<bv.size(); offset+=byte_width)
   {
     // index condition
-    equal_exprt equality;
-    equality.lhs()=offset_expr;
-    equality.rhs()=from_integer(offset/byte_width, offset_expr.type());
+    equal_exprt equality(
+      offset_expr, from_integer(offset / byte_width, offset_expr.type()));
     literalt equal=convert(equality);
 
     bv_endianness_mapt map_op(op.type(), little_endian, ns, boolbv_width);

--- a/src/solvers/flattening/boolbv_extractbit.cpp
+++ b/src/solvers/flattening/boolbv_extractbit.cpp
@@ -51,11 +51,8 @@ literalt boolbvt::convert_extractbit(const extractbit_exprt &expr)
       std::max(address_bits(src_bv_width), index_bv_width);
     unsignedbv_typet index_type(index_width);
 
-    equal_exprt equality;
-    equality.lhs() = expr.index();
-
-    if(index_type!=equality.lhs().type())
-      equality.lhs().make_typecast(index_type);
+    equal_exprt equality(
+      typecast_exprt::conditional_cast(expr.index(), index_type), exprt());
 
     if(prop.has_set_to())
     {


### PR DESCRIPTION
The default constructor is deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
