### PR TITLE
Use non-deprecated variants of parent constructors

### DIFF
--- a/src/ansi-c/ansi_c_declaration.h
+++ b/src/ansi-c/ansi_c_declaration.h
@@ -20,7 +20,7 @@ Author: Daniel Kroening, kroening@kroening.com
 class ansi_c_declaratort : public nullary_exprt
 {
 public:
-  ansi_c_declaratort() : nullary_exprt(ID_declarator)
+  ansi_c_declaratort() : nullary_exprt(ID_declarator, typet())
   {
   }
 

--- a/src/util/byte_operators.h
+++ b/src/util/byte_operators.h
@@ -36,11 +36,11 @@ public:
 
   byte_extract_exprt(
     irep_idt _id,
-    const exprt &_op, const exprt &_offset, const typet &_type):
-    binary_exprt(_id, _type)
+    const exprt &_op,
+    const exprt &_offset,
+    const typet &_type)
+    : binary_exprt(_op, _id, _offset, _type)
   {
-    op()=_op;
-    offset()=_offset;
   }
 
   exprt &op() { return op0(); }

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -2135,10 +2135,9 @@ class namespacet;
 class object_descriptor_exprt:public binary_exprt
 {
 public:
-  object_descriptor_exprt():binary_exprt(ID_object_descriptor)
+  object_descriptor_exprt()
+    : binary_exprt(exprt(ID_unknown), ID_object_descriptor, exprt(ID_unknown))
   {
-    op0().id(ID_unknown);
-    op1().id(ID_unknown);
   }
 
   void build(const exprt &expr, const namespacet &ns);
@@ -2207,17 +2206,18 @@ inline void validate_expr(const object_descriptor_exprt &value)
 class dynamic_object_exprt:public binary_exprt
 {
 public:
-  dynamic_object_exprt():binary_exprt(ID_dynamic_object)
+  dynamic_object_exprt()
+    : binary_exprt(exprt(ID_unknown), ID_dynamic_object, exprt(ID_unknown))
   {
-    op0().id(ID_unknown);
-    op1().id(ID_unknown);
   }
 
-  explicit dynamic_object_exprt(const typet &type):
-    binary_exprt(ID_dynamic_object, type)
+  explicit dynamic_object_exprt(const typet &type)
+    : binary_exprt(
+        exprt(ID_unknown),
+        ID_dynamic_object,
+        exprt(ID_unknown),
+        type)
   {
-    op0().id(ID_unknown);
-    op1().id(ID_unknown);
   }
 
   void set_instance(unsigned int instance);
@@ -2417,25 +2417,18 @@ public:
   {
   }
 
-  and_exprt(const exprt &op0, const exprt &op1, const exprt &op2):
-    multi_ary_exprt(ID_and, bool_typet())
+  and_exprt(const exprt &op0, const exprt &op1, const exprt &op2)
+    : multi_ary_exprt(ID_and, {op0, op1, op2}, bool_typet())
   {
-    add_to_operands(op0, op1, op2);
   }
 
   and_exprt(
     const exprt &op0,
     const exprt &op1,
     const exprt &op2,
-    const exprt &op3):
-    multi_ary_exprt(ID_and, bool_typet())
+    const exprt &op3)
+    : multi_ary_exprt(ID_and, {op0, op1, op2, op3}, bool_typet())
   {
-    exprt::operandst &op=operands();
-    op.resize(4);
-    op[0]=op0;
-    op[1]=op1;
-    op[2]=op2;
-    op[3]=op3;
   }
 };
 
@@ -2539,25 +2532,18 @@ public:
   {
   }
 
-  or_exprt(const exprt &op0, const exprt &op1, const exprt &op2):
-    multi_ary_exprt(ID_or, bool_typet())
+  or_exprt(const exprt &op0, const exprt &op1, const exprt &op2)
+    : multi_ary_exprt(ID_or, {op0, op1, op2}, bool_typet())
   {
-    add_to_operands(op0, op1, op2);
   }
 
   or_exprt(
     const exprt &op0,
     const exprt &op1,
     const exprt &op2,
-    const exprt &op3):
-    multi_ary_exprt(ID_or, bool_typet())
+    const exprt &op3)
+    : multi_ary_exprt(ID_or, {op0, op1, op2, op3}, bool_typet())
   {
-    exprt::operandst &op=operands();
-    op.resize(4);
-    op[0]=op0;
-    op[1]=op1;
-    op[2]=op2;
-    op[3]=op3;
   }
 };
 
@@ -2706,10 +2692,9 @@ public:
   {
   }
 
-  bitor_exprt(const exprt &_op0, const exprt &_op1):
-    multi_ary_exprt(ID_bitor, _op0.type())
+  bitor_exprt(const exprt &_op0, const exprt &_op1)
+    : multi_ary_exprt(_op0, ID_bitor, _op1, _op0.type())
   {
-    add_to_operands(_op0, _op1);
   }
 };
 
@@ -2815,10 +2800,9 @@ public:
   {
   }
 
-  bitand_exprt(const exprt &_op0, const exprt &_op1):
-    multi_ary_exprt(ID_bitand, _op0.type())
+  bitand_exprt(const exprt &_op0, const exprt &_op1)
+    : multi_ary_exprt(_op0, ID_bitand, _op1, _op0.type())
   {
-    add_to_operands(_op0, _op1);
   }
 };
 
@@ -4508,9 +4492,8 @@ public:
     const symbol_exprt &_function,
     const argumentst &_arguments,
     const typet &_type)
-    : binary_exprt(ID_function_application, _type)
+    : binary_exprt(_function, ID_function_application, exprt(), _type)
   {
-    function()=_function;
     arguments() = _arguments;
   }
 

--- a/src/util/string_constant.cpp
+++ b/src/util/string_constant.cpp
@@ -13,7 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "std_expr.h"
 
 string_constantt::string_constantt(const irep_idt &_value)
-  : nullary_exprt(ID_string_constant)
+  : nullary_exprt(ID_string_constant, typet())
 {
   set_value(_value);
 }


### PR DESCRIPTION
Several *_exprt constructors invoked deprecated constructors of their parent
class. Use non-deprecated variants instead to make removal of the deprecated
constructors safe.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
