### PR TITLE
Construct union_exprt in a non-deprecated way

### DIFF
--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1111,10 +1111,8 @@ void c_typecheck_baset::typecheck_expr_typecast(exprt &expr)
       if(base_type_eq(c.type(), op.type(), *this))
       {
         // found! build union constructor
-        union_exprt union_expr(expr.type());
+        union_exprt union_expr(c.get_name(), op, expr.type());
         union_expr.add_source_location()=expr.source_location();
-        union_expr.op()=op;
-        union_expr.set_component_name(c.get_name());
         expr=union_expr;
         expr.set(ID_C_lvalue, true);
         return;

--- a/src/util/expr_initializer.cpp
+++ b/src/util/expr_initializer.cpp
@@ -219,8 +219,6 @@ exprt expr_initializert<nondet>::expr_initializer_rec(
     const union_typet::componentst &components=
       to_union_type(type).components();
 
-    union_exprt value(type);
-
     union_typet::componentt component;
     bool found=false;
     mp_integer component_size=0;
@@ -243,12 +241,12 @@ exprt expr_initializert<nondet>::expr_initializer_rec(
       }
     }
 
+    union_exprt value("", nil_exprt(), type);
     value.add_source_location()=source_location;
 
     if(!found)
     {
       // stupid empty union
-      value.op()=nil_exprt();
     }
     else
     {


### PR DESCRIPTION
All modified invocation sites used deprecated constructors of union_exprt.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
