### PR TITLE
Construct with_exprt in a non-deprecated way

### DIFF
--- a/src/goto-programs/wp.cpp
+++ b/src/goto-programs/wp.cpp
@@ -166,12 +166,8 @@ void rewrite_assignment(exprt &lhs, exprt &rhs)
     irep_idt component_name=member_expr.get_component_name();
     exprt new_lhs=member_expr.struct_op();
 
-    with_exprt new_rhs;
-    new_rhs.type()=new_lhs.type();
-    new_rhs.old()=new_lhs;
-    new_rhs.where().id(ID_member_name);
+    with_exprt new_rhs(new_lhs, exprt(ID_member_name), rhs);
     new_rhs.where().set(ID_component_name, component_name);
-    new_rhs.new_value()=rhs;
 
     lhs=new_lhs;
     rhs=new_rhs;
@@ -183,11 +179,7 @@ void rewrite_assignment(exprt &lhs, exprt &rhs)
     const index_exprt index_expr=to_index_expr(lhs);
     exprt new_lhs=index_expr.array();
 
-    with_exprt new_rhs;
-    new_rhs.type()=new_lhs.type();
-    new_rhs.old()=new_lhs;
-    new_rhs.where()=index_expr.index();
-    new_rhs.new_value()=rhs;
+    with_exprt new_rhs(new_lhs, index_expr.index(), rhs);
 
     lhs=new_lhs;
     rhs=new_rhs;

--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -69,12 +69,12 @@ with_exprt make_with_expr(const update_exprt &src)
   const exprt::operandst &designator=src.designator();
   PRECONDITION(!designator.empty());
 
-  with_exprt result;
+  with_exprt result{exprt{}, exprt{}, exprt{}};
   exprt *dest=&result;
 
   forall_expr(it, designator)
   {
-    with_exprt tmp;
+    with_exprt tmp{exprt{}, exprt{}, exprt{}};
 
     if(it->id()==ID_index_designator)
     {


### PR DESCRIPTION
The default constructor is deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.
<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
