### PR TITLE
Construct dereference_exprt in a non-deprecated way

### DIFF
--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -1108,8 +1108,7 @@ void goto_convertt::do_function_call_symbol(
     if(lhs.is_not_nil())
     {
       typet t=pointer_type(lhs.type());
-      dereference_exprt rhs(lhs.type());
-      rhs.op0()=typecast_exprt(list_arg, t);
+      dereference_exprt rhs(typecast_exprt(list_arg, t), lhs.type());
       rhs.add_source_location()=function.source_location();
       goto_programt::targett t2=dest.add_instruction(ASSIGN);
       t2->source_location=function.source_location();

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -312,9 +312,8 @@ void goto_symext::dereference_rec(
     address_of_exprt address_of_expr(index_expr.array());
     address_of_expr.type()=pointer_type(expr.type());
 
-    dereference_exprt tmp;
-    tmp.pointer()=plus_exprt(address_of_expr, index_expr.index());
-    tmp.type()=expr.type();
+    dereference_exprt tmp(
+      plus_exprt(address_of_expr, index_expr.index()), expr.type());
     tmp.add_source_location()=expr.source_location();
 
     // recursive call

--- a/src/pointer-analysis/rewrite_index.cpp
+++ b/src/pointer-analysis/rewrite_index.cpp
@@ -16,9 +16,8 @@ Author: Daniel Kroening, kroening@kroening.com
 /// rewrite a[i] to *(a+i)
 dereference_exprt rewrite_index(const index_exprt &index_expr)
 {
-  dereference_exprt result;
-  result.pointer()=plus_exprt(index_expr.array(), index_expr.index());
-  result.type()=index_expr.type();
+  dereference_exprt result(
+    plus_exprt(index_expr.array(), index_expr.index()), index_expr.type());
   result.add_source_location()=index_expr.source_location();
   return result;
 }


### PR DESCRIPTION
The default constructor is deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
