### PR TITLE
Construct type_exprt in a non-deprecated way

### DIFF
--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -324,24 +324,24 @@ exprt cpp_typecheck_resolvet::convert_identifier(
 
     if(symbol.is_type)
     {
-      e=type_exprt();
+      e.make_nil();
 
       if(symbol.is_macro) // includes typedefs
       {
-        e.type()=symbol.type;
+        e = type_exprt(symbol.type);
         assert(symbol.type.is_not_nil());
       }
       else if(symbol.type.id()==ID_c_enum)
       {
-        e.type()=c_enum_tag_typet(symbol.name);
+        e = type_exprt(c_enum_tag_typet(symbol.name));
       }
       else if(symbol.type.id() == ID_struct)
       {
-        e.type() = struct_tag_typet(symbol.name);
+        e = type_exprt(struct_tag_typet(symbol.name));
       }
       else if(symbol.type.id() == ID_union)
       {
-        e.type() = union_tag_typet(symbol.name);
+        e = type_exprt(union_tag_typet(symbol.name));
       }
     }
     else if(symbol.is_macro)


### PR DESCRIPTION
The default constructor is deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
