### PR TITLE
Construct if_exprt in a non-deprecated way

### DIFF
--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1698,10 +1698,7 @@ void c_typecheck_baset::typecheck_side_effect_gcc_conditional_expression(
 
   // use typechecking code for "if"
 
-  if_exprt if_expr;
-  if_expr.cond()=operands[0];
-  if_expr.true_case()=operands[0];
-  if_expr.false_case()=operands[1];
+  if_exprt if_expr(operands[0], operands[0], operands[1]);
   if_expr.add_source_location()=expr.source_location();
 
   typecheck_expr_trinary(if_expr);

--- a/src/goto-programs/goto_clean_expr.cpp
+++ b/src/goto-programs/goto_clean_expr.cpp
@@ -504,12 +504,7 @@ void goto_convertt::remove_gcc_conditional_expression(
   clean_expr(expr.op0(), dest, mode);
 
   // now we can copy op0 safely
-  if_exprt if_expr;
-
-  if_expr.cond()=expr.op0();
-  if_expr.true_case()=expr.op0();
-  if_expr.false_case()=expr.op1();
-  if_expr.type()=expr.type();
+  if_exprt if_expr(expr.op0(), expr.op0(), expr.op1(), expr.type());
   if_expr.add_source_location()=expr.source_location();
 
   if(if_expr.cond().type()!=bool_typet())

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -223,11 +223,7 @@ void goto_symext::symex_assign_symbol(
   // put assignment guard into the rhs
   if(!guard.is_true())
   {
-    if_exprt tmp_ssa_rhs;
-    tmp_ssa_rhs.type()=ssa_rhs.type();
-    tmp_ssa_rhs.cond()=guard.as_expr();
-    tmp_ssa_rhs.true_case()=ssa_rhs;
-    tmp_ssa_rhs.false_case()=lhs;
+    if_exprt tmp_ssa_rhs(guard.as_expr(), ssa_rhs, lhs, ssa_rhs.type());
     tmp_ssa_rhs.swap(ssa_rhs);
   }
 

--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -205,12 +205,8 @@ if_exprt lift_if(const exprt &src, std::size_t operand_number)
   const exprt true_case=if_expr.true_case();
   const exprt false_case=if_expr.false_case();
 
-  if_exprt result;
-  result.cond()=if_expr.cond();
-  result.type()=src.type();
-  result.true_case()=src;
+  if_exprt result(if_expr.cond(), src, src);
   result.true_case().operands()[operand_number]=true_case;
-  result.false_case()=src;
   result.false_case().operands()[operand_number]=false_case;
 
   return result;


### PR DESCRIPTION
The default constructor is deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
