### PR TITLE
Construct array_list_exprt in a non-deprecated way

### DIFF
--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -361,7 +361,7 @@ exprt boolbvt::bv_get_unbounded_array(const exprt &expr) const
 
   if(size_mpint>100 || size.id()==ID_infinity)
   {
-    result = array_list_exprt(to_array_type(type));
+    result = array_list_exprt({}, to_array_type(type));
     result.type().set(ID_size, integer2string(size_mpint));
 
     result.operands().reserve(values.size()*2);

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -1796,6 +1796,11 @@ public:
     : multi_ary_exprt(ID_array_list, _type)
   {
   }
+
+  array_list_exprt(operandst &&_operands, const array_typet &_type)
+    : multi_ary_exprt(ID_array_list, std::move(_operands), _type)
+  {
+  }
 };
 
 template <>

--- a/unit/solvers/refinement/string_refinement/substitute_array_list.cpp
+++ b/unit/solvers/refinement/string_refinement/substitute_array_list.cpp
@@ -21,7 +21,6 @@ SCENARIO("substitute_array_list",
   const typet char_type=unsignedbv_typet(16);
   const typet int_type=signedbv_typet(32);
   const array_typet array_type(char_type, infinity_exprt(int_type));
-  array_list_exprt arr(array_type);
   const exprt index0=from_integer(0, int_type);
   const exprt charx=from_integer('x', char_type);
   const exprt index1=from_integer(1, int_type);
@@ -29,8 +28,9 @@ SCENARIO("substitute_array_list",
   const exprt index100=from_integer(100, int_type);
 
   // arr is `array-list [ 0 , 'x' , 1 , 'y' , 2 , 'z']`
-  arr.operands()=
-    { index0, charx, index1, chary, index100, from_integer('z', char_type) };
+  array_list_exprt arr(
+    {index0, charx, index1, chary, index100, from_integer('z', char_type)},
+    array_type);
 
   // Max length is 2, so index 2 should get ignored.
   const exprt subst=substitute_array_lists(arr, 2);


### PR DESCRIPTION
The existing array_list_exprt constructor relies on other deprecated
constructors; instead introduce a non-deprecated one and use it across the
codebase.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
