### PR TITLE
Construct and_exprt in a non-deprecated way

### DIFF
--- a/src/solvers/flattening/functions.cpp
+++ b/src/solvers/flattening/functions.cpp
@@ -32,21 +32,17 @@ exprt functionst::arguments_equal(const exprt::operandst &o1,
 {
   PRECONDITION(o1.size() == o2.size());
 
-  if(o1.empty())
-    return true_exprt();
-
-  and_exprt and_expr;
-  and_exprt::operandst &conjuncts=and_expr.operands();
-  conjuncts.resize(o1.size());
+  exprt::operandst conjuncts;
+  conjuncts.reserve(o1.size());
 
   for(std::size_t i=0; i<o1.size(); i++)
   {
     exprt lhs=o1[i];
     exprt rhs = typecast_exprt::conditional_cast(o2[i], o1[i].type());
-    conjuncts[i]=equal_exprt(lhs, rhs);
+    conjuncts.push_back(equal_exprt(lhs, rhs));
   }
 
-  return std::move(and_expr);
+  return conjunction(conjuncts);
 }
 
 void functionst::add_function_constraints(const function_infot &info)

--- a/src/solvers/floatbv/float_bv.cpp
+++ b/src/solvers/floatbv/float_bv.cpp
@@ -777,13 +777,11 @@ exprt float_bvt::relation(
 
     if(rel==relt::LT)
     {
-      and_exprt and_bv;
-      and_bv.reserve_operands(4);
-      and_bv.copy_to_operands(less_than3);
-      // for the case of two negative numbers
-      and_bv.copy_to_operands(not_exprt(bitwise_equal));
-      and_bv.copy_to_operands(not_exprt(both_zero));
-      and_bv.copy_to_operands(not_exprt(nan));
+      and_exprt and_bv{{less_than3,
+                        // for the case of two negative numbers
+                        not_exprt(bitwise_equal),
+                        not_exprt(both_zero),
+                        not_exprt(nan)}};
 
       return std::move(and_bv);
     }

--- a/src/util/guard.cpp
+++ b/src/util/guard.cpp
@@ -52,8 +52,7 @@ void guardt::add(const exprt &expr)
   }
   else if(id()!=ID_and)
   {
-    and_exprt a;
-    a.add_to_operands(*this);
+    and_exprt a({*this});
     *this=a;
   }
 

--- a/src/util/std_expr.cpp
+++ b/src/util/std_expr.cpp
@@ -55,9 +55,7 @@ exprt conjunction(const exprt::operandst &op)
     return op.front();
   else
   {
-    and_exprt result;
-    result.operands()=op;
-    return std::move(result);
+    return and_exprt(exprt::operandst(op));
   }
 }
 

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -2467,6 +2467,11 @@ public:
     : multi_ary_exprt(ID_and, {op0, op1, op2, op3}, bool_typet())
   {
   }
+
+  explicit and_exprt(exprt::operandst &&_operands)
+    : multi_ary_exprt(ID_and, std::move(_operands), bool_typet())
+  {
+  }
 };
 
 /// 1) generates a conjunction for two or more operands


### PR DESCRIPTION
The default constructor is deprecated. To facilitate construction with an
arbitrary number of operands a new constructor taking a initializer list is
added.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
