### PR TITLE
Construct vector_exprt in a non-deprecated way

### DIFF
--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -181,7 +181,7 @@ exprt boolbvt::bv_get_rec(
       if(sub_width!=0 && width%sub_width==0)
       {
         std::size_t size=width/sub_width;
-        vector_exprt value(to_vector_type(type));
+        vector_exprt value({}, to_vector_type(type));
         value.reserve_operands(size);
 
         for(std::size_t i=0; i<size; i++)

--- a/src/util/expr_initializer.cpp
+++ b/src/util/expr_initializer.cpp
@@ -177,7 +177,7 @@ exprt expr_initializert<nondet>::expr_initializer_rec(
     if(vector_size < 0)
       return nil_exprt();
 
-    vector_exprt value(vector_type);
+    vector_exprt value({}, vector_type);
     value.operands().resize(numeric_cast_v<std::size_t>(vector_size), tmpval);
     value.add_source_location()=source_location;
 

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -1823,6 +1823,11 @@ public:
     : multi_ary_exprt(ID_vector, _type)
   {
   }
+
+  vector_exprt(operandst &&_operands, const vector_typet &_type)
+    : multi_ary_exprt(ID_vector, std::move(_operands), _type)
+  {
+  }
 };
 
 /// \brief Cast an exprt to an \ref vector_exprt


### PR DESCRIPTION
The existing vector_exprt constructor relies on other deprecated constructors;
instead introduce a non-deprecated one and use it across the codebase.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
