### PR TITLE
Construct plus_exprt in a non-deprecated way

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -3077,13 +3077,13 @@ void smt2_convt::convert_plus(const plus_exprt &expr)
     // add component-by-component
     for(mp_integer i = 0; i != size; ++i)
     {
-      plus_exprt tmp(vector_type.subtype());
-      forall_operands(it, expr)
-        tmp.copy_to_operands(
-          index_exprt(
-            *it,
-            from_integer(size - i - 1, index_type),
-            vector_type.subtype()));
+      exprt::operandst summands;
+      summands.reserve(expr.operands().size());
+      for(const auto &op : expr.operands())
+        summands.push_back(index_exprt(
+          op, from_integer(size - i - 1, index_type), vector_type.subtype()));
+
+      plus_exprt tmp(std::move(summands), vector_type.subtype());
 
       out << " ";
       convert_expr(tmp);

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -1076,6 +1076,11 @@ public:
     multi_ary_exprt(_lhs, ID_plus, _rhs, _type)
   {
   }
+
+  plus_exprt(operandst &&_operands, const typet &_type)
+    : multi_ary_exprt(ID_plus, std::move(_operands), _type)
+  {
+  }
 };
 
 /// \brief Cast an exprt to a \ref plus_exprt


### PR DESCRIPTION
The default constructor is deprecated. To facilitate construction with an
arbitrary number of operands a new constructor taking a initializer list is
added.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
