### PR TITLE
Construct binary_relation_exprt in a non-deprecated way

### DIFF
--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -218,11 +218,11 @@ bool simplify_exprt::simplify_typecast(exprt &expr)
   if(expr_type.id()==ID_bool)
   {
     // rewrite (bool)x to x!=0
-    binary_relation_exprt inequality;
-    inequality.id(op_type.id()==ID_floatbv?ID_ieee_float_notequal:ID_notequal);
+    binary_relation_exprt inequality(
+      expr.op0(),
+      op_type.id() == ID_floatbv ? ID_ieee_float_notequal : ID_notequal,
+      from_integer(0, op_type));
     inequality.add_source_location()=expr.source_location();
-    inequality.lhs()=expr.op0();
-    inequality.rhs()=from_integer(0, op_type);
     CHECK_RETURN(inequality.rhs().is_not_nil());
     simplify_node(inequality);
     expr.swap(inequality);


### PR DESCRIPTION
The default constructor is deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
