### PR TITLE
Construct implies_exprt in a non-deprecated way

### DIFF
--- a/src/util/guard.cpp
+++ b/src/util/guard.cpp
@@ -32,9 +32,7 @@ void guardt::guard_expr(exprt &dest) const
     }
     else
     {
-      implies_exprt tmp;
-      tmp.op0()=as_expr();
-      tmp.op1().swap(dest);
+      implies_exprt tmp(as_expr(), dest);
       dest.swap(tmp);
     }
   }


### PR DESCRIPTION
The default constructor is deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
