### PR TITLE
Construct byte_extract_exprt in a non-deprecated way

### DIFF
--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -151,22 +151,24 @@ void goto_symext::symex_other(
     // check for size (or type) mismatch and adjust
     if(!base_type_eq(dest_array.type(), src_array.type(), ns))
     {
-      byte_extract_exprt be(byte_extract_id());
-
       if(statement==ID_array_copy)
       {
-        be.op()=src_array;
-        be.offset()=from_integer(0, index_type());
-        be.type()=dest_array.type();
+        byte_extract_exprt be(
+          byte_extract_id(),
+          src_array,
+          from_integer(0, index_type()),
+          dest_array.type());
         src_array.swap(be);
         do_simplify(src_array);
       }
       else
       {
         // ID_array_replace
-        be.op()=dest_array;
-        be.offset()=from_integer(0, index_type());
-        be.type()=src_array.type();
+        byte_extract_exprt be(
+          byte_extract_id(),
+          dest_array,
+          from_integer(0, index_type()),
+          src_array.type());
         dest_array.swap(be);
         do_simplify(dest_array);
       }

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -411,10 +411,9 @@ static exprt lower_byte_update(
               src.id() == ID_byte_update_little_endian
                 ? ID_byte_extract_little_endian
                 : ID_byte_extract_big_endian,
+              src.value(),
+              i_expr,
               subtype);
-
-            byte_extract_expr.op() = src.value();
-            byte_extract_expr.offset()=i_expr;
 
             new_value=lower_byte_extract(byte_extract_expr, ns);
           }
@@ -483,10 +482,8 @@ static exprt lower_byte_update(
               src.id() == ID_byte_update_little_endian
                 ? ID_byte_extract_little_endian
                 : ID_byte_extract_big_endian,
+                src.value(), stored_value_offset,
               element_size < sub_size ? src.value().type() : subtype);
-
-            byte_extract_expr.op() = src.value();
-            byte_extract_expr.offset()=stored_value_offset;
 
             new_value=lower_byte_extract(byte_extract_expr, ns);
           }


### PR DESCRIPTION
The default constructor and the single-argument constructor are deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.
<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
