### PR TITLE
Construct or_exprt in a non-deprecated way

### DIFF
--- a/src/goto-symex/memory_model.cpp
+++ b/src/goto-symex/memory_model.cpp
@@ -120,8 +120,7 @@ void memory_model_baset::read_from(symex_target_equationt &equation)
         rf_some=rf_some_operands.front();
       else
       {
-        rf_some=or_exprt();
-        rf_some.operands().swap(rf_some_operands);
+        rf_some = or_exprt(std::move(rf_some_operands));
       }
 
       // Add the read's guard, each of the writes' guards is implied

--- a/src/solvers/floatbv/float_bv.cpp
+++ b/src/solvers/floatbv/float_bv.cpp
@@ -789,11 +789,7 @@ exprt float_bvt::relation(
     }
     else if(rel==relt::LE)
     {
-      or_exprt or_bv;
-      or_bv.reserve_operands(3);
-      or_bv.copy_to_operands(less_than3);
-      or_bv.copy_to_operands(both_zero);
-      or_bv.copy_to_operands(bitwise_equal);
+      or_exprt or_bv{{less_than3, both_zero, bitwise_equal}};
 
       return and_exprt(or_bv, not_exprt(nan));
     }

--- a/src/solvers/prop/minimize.cpp
+++ b/src/solvers/prop/minimize.cpp
@@ -81,11 +81,12 @@ literalt prop_minimizet::constraint()
     return or_clause.front();
   else
   {
-    or_exprt or_expr;
+    exprt::operandst disjuncts;
+    disjuncts.reserve(or_clause.size());
     forall_literals(it, or_clause)
-      or_expr.copy_to_operands(literal_exprt(*it));
+      disjuncts.push_back(literal_exprt(*it));
 
-    return prop_conv.convert(or_expr);
+    return prop_conv.convert(disjunction(disjuncts));
   }
 }
 

--- a/src/util/std_expr.cpp
+++ b/src/util/std_expr.cpp
@@ -31,9 +31,7 @@ exprt disjunction(const exprt::operandst &op)
     return op.front();
   else
   {
-    or_exprt result;
-    result.operands()=op;
-    return std::move(result);
+    return or_exprt(exprt::operandst(op));
   }
 }
 

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -2563,6 +2563,11 @@ public:
     : multi_ary_exprt(ID_or, {op0, op1, op2, op3}, bool_typet())
   {
   }
+
+  explicit or_exprt(exprt::operandst &&_operands)
+    : multi_ary_exprt(ID_or, std::move(_operands), bool_typet())
+  {
+  }
 };
 
 /// 1) generates a disjunction for two or more operands


### PR DESCRIPTION
The default constructor is deprecated. To facilitate construction with an
arbitrary number of operands a new constructor taking a initializer list is
added.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
