### PR TITLE
Do not shadow "bv" [blocks: #2310]

### DIFF
--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -362,9 +362,9 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
       if(it->type().id()!=ID_unsignedbv &&
          it->type().id()!=ID_signedbv)
       {
-        bvt bv;
-        conversion_failed(plus_expr, bv);
-        return bv;
+        bvt failed_bv;
+        conversion_failed(plus_expr, failed_bv);
+        return failed_bv;
       }
 
       bv_utilst::representationt rep=
@@ -398,8 +398,6 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
       minus_expr.op0().type().id() == ID_pointer,
       "first operand should be of pointer type");
 
-    bvt bv;
-
     if(
       minus_expr.op1().type().id() != ID_unsignedbv &&
       minus_expr.op1().type().id() != ID_signedbv)
@@ -411,7 +409,7 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
 
     const unary_minus_exprt neg_op1(minus_expr.op1());
 
-    bv = convert_bv(minus_expr.op0());
+    bvt bv = convert_bv(minus_expr.op0());
 
     typet pointer_sub_type = minus_expr.op0().type().subtype();
     mp_integer element_size;


### PR DESCRIPTION
Rename one shadowing instance to "failed_bv" and move another declaration
further down to the point of its use.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
