### PR TITLE
Remove unnecessary use of ns.follow

### DIFF
--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2875,7 +2875,7 @@ void c_typecheck_baset::typecheck_expr_unary_arithmetic(exprt &expr)
 
   if(o_type.id()==ID_vector)
   {
-    if(is_number(follow(o_type.subtype())))
+    if(is_number(o_type.subtype()))
     {
       // Vector arithmetic.
       expr.type()=operand.type();

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -121,7 +121,6 @@ void cpp_typecheckt::typecheck_expr_main(exprt &expr)
     // these appear to have type "struct _GUID"
     // and they are lvalues!
     expr.type() = struct_tag_typet("tag-_GUID");
-    follow(expr.type());
     expr.set(ID_C_lvalue, true);
   }
   else if(expr.id()==ID_noexcept)
@@ -415,15 +414,18 @@ bool cpp_typecheckt::overloadable(const exprt &expr)
 
   forall_operands(it, expr)
   {
-    typet t=follow(it->type());
+    typet t = it->type();
 
     if(is_reference(t))
       t=t.subtype();
 
-    if(t.id()==ID_struct ||
-       t.id()==ID_union ||
-       t.id()==ID_c_enum || t.id() == ID_c_enum_tag)
+    if(
+      t.id() == ID_struct || t.id() == ID_union || t.id() == ID_c_enum ||
+      t.id() == ID_c_enum_tag || t.id() == ID_struct_tag ||
+      t.id() == ID_union_tag)
+    {
       return true;
+    }
   }
 
   return false;

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -414,7 +414,7 @@ void dump_ct::convert_compound(
 
   for(const auto &comp : type.components())
   {
-    const typet &comp_type=ns.follow(comp.type());
+    const typet &comp_type = comp.type();
 
     if(comp_type.id()==ID_code ||
        comp.get_bool(ID_from_base) ||

--- a/src/goto-programs/string_instrumentation.cpp
+++ b/src/goto-programs/string_instrumentation.cpp
@@ -410,7 +410,6 @@ void string_instrumentationt::do_format_string_read(
       if(token.type==format_tokent::token_typet::STRING)
       {
         const exprt &arg=arguments[argument_start_inx+args];
-        const typet &arg_type=ns.follow(arg.type());
 
         if(arg.id()!=ID_string_constant) // we don't need to check constants
         {
@@ -423,7 +422,7 @@ void string_instrumentationt::do_format_string_read(
 
           exprt temp(arg);
 
-          if(arg_type.id()!=ID_pointer)
+          if(arg.type().id() != ID_pointer)
           {
             index_exprt index(temp, from_integer(0, index_type()));
             temp=address_of_exprt(index);
@@ -456,10 +455,8 @@ void string_instrumentationt::do_format_string_read(
     for(std::size_t i=2; i<arguments.size(); i++)
     {
       const exprt &arg=arguments[i];
-      const typet &arg_type=ns.follow(arguments[i].type());
 
-      if(arguments[i].id()!=ID_string_constant &&
-         is_string_type(arg_type))
+      if(arguments[i].id() != ID_string_constant && is_string_type(arg.type()))
       {
         goto_programt::targett assertion=dest.add_instruction();
         assertion->source_location=target->source_location;
@@ -469,7 +466,7 @@ void string_instrumentationt::do_format_string_read(
 
         exprt temp(arg);
 
-        if(arg_type.id()!=ID_pointer)
+        if(arg.type().id() != ID_pointer)
         {
           index_exprt index(temp, from_integer(0, index_type()));
           temp=address_of_exprt(index);
@@ -514,7 +511,7 @@ void string_instrumentationt::do_format_string_write(
         case format_tokent::token_typet::STRING:
         {
           const exprt &argument=arguments[argument_start_inx+args];
-          const typet &arg_type=ns.follow(argument.type());
+          const typet &arg_type = argument.type();
 
           goto_programt::targett assertion=dest.add_instruction();
           assertion->source_location=target->source_location;
@@ -566,7 +563,7 @@ void string_instrumentationt::do_format_string_write(
         default: // everything else
         {
           const exprt &argument=arguments[argument_start_inx+args];
-          const typet &arg_type=ns.follow(argument.type());
+          const typet &arg_type = argument.type();
 
           goto_programt::targett assignment=dest.add_instruction(ASSIGN);
           assignment->source_location=target->source_location;
@@ -587,7 +584,7 @@ void string_instrumentationt::do_format_string_write(
   {
     for(std::size_t i=argument_start_inx; i<arguments.size(); i++)
     {
-      const typet &arg_type=ns.follow(arguments[i].type());
+      const typet &arg_type = arguments[i].type();
 
       // Note: is_string_type() is a `good guess' here. Actually
       // any of the pointers could point into an array. But it

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -145,11 +145,11 @@ void goto_symext::symex_assign_rec(
       state, to_index_expr(lhs), full_lhs, rhs, guard, assignment_type);
   else if(lhs.id()==ID_member)
   {
-    const typet &type=ns.follow(to_member_expr(lhs).struct_op().type());
-    if(type.id()==ID_struct)
+    const typet &type = to_member_expr(lhs).struct_op().type();
+    if(type.id() == ID_struct || type.id() == ID_struct_tag)
       symex_assign_struct_member(
         state, to_member_expr(lhs), full_lhs, rhs, guard, assignment_type);
-    else if(type.id()==ID_union)
+    else if(type.id() == ID_union || type.id() == ID_union_tag)
     {
       // should have been replaced by byte_extract
       throw unsupported_operation_exceptiont(

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -86,24 +86,27 @@ void goto_symext::parameter_assignments(
       // It should be the same exact type.
       if(!base_type_eq(parameter_type, rhs.type(), ns))
       {
-        const typet &f_parameter_type=ns.follow(parameter_type);
-        const typet &f_rhs_type=ns.follow(rhs.type());
+        const typet &rhs_type = rhs.type();
 
         // But we are willing to do some limited conversion.
         // This is highly dubious, obviously.
-        if((f_parameter_type.id()==ID_signedbv ||
-            f_parameter_type.id()==ID_unsignedbv ||
-            f_parameter_type.id()==ID_c_enum_tag ||
-            f_parameter_type.id()==ID_bool ||
-            f_parameter_type.id()==ID_pointer ||
-            f_parameter_type.id()==ID_union) &&
-           (f_rhs_type.id()==ID_signedbv ||
-            f_rhs_type.id()==ID_unsignedbv ||
-            f_rhs_type.id()==ID_c_bit_field ||
-            f_rhs_type.id()==ID_c_enum_tag ||
-            f_rhs_type.id()==ID_bool ||
-            f_rhs_type.id()==ID_pointer ||
-            f_rhs_type.id()==ID_union))
+        // clang-format off
+        if(
+          (parameter_type.id() == ID_signedbv ||
+           parameter_type.id() == ID_unsignedbv ||
+           parameter_type.id() == ID_c_enum_tag ||
+           parameter_type.id() == ID_bool ||
+           parameter_type.id() == ID_pointer ||
+           parameter_type.id() == ID_union ||
+           parameter_type.id() == ID_union_tag) &&
+          (rhs_type.id() == ID_signedbv ||
+           rhs_type.id() == ID_unsignedbv ||
+           rhs_type.id() == ID_c_bit_field ||
+           rhs_type.id() == ID_c_enum_tag ||
+           rhs_type.id() == ID_bool ||
+           rhs_type.id() == ID_pointer ||
+           rhs_type.id() == ID_union ||
+           rhs_type.id() == ID_union_tag))
         {
           rhs=
             byte_extract_exprt(
@@ -120,6 +123,7 @@ void goto_symext::parameter_assignments(
                 << ", expected " << parameter_type.pretty();
           throw unsupported_operation_exceptiont(error.str());
         }
+        // clang-format on
       }
 
       assignment_typet assignment_type;

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -391,8 +391,8 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
       result.pointer_guard=same_object(pointer_expr, object_pointer);
     }
 
-    const typet &object_type=ns.follow(object.type());
-    const typet &root_object_type=ns.follow(root_object.type());
+    const typet &object_type = object.type();
+    const typet &root_object_type = root_object.type();
 
     exprt root_object_subexpression=root_object;
 
@@ -402,10 +402,7 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
       // The simplest case: types match, and offset is zero!
       // This is great, we are almost done.
 
-      result.value=object;
-
-      if(object_type!=ns.follow(dereference_type))
-        result.value.make_typecast(dereference_type);
+      result.value = typecast_exprt::conditional_cast(object, dereference_type);
     }
     else if(root_object_type.id()==ID_array &&
             dereference_type_compare(
@@ -582,19 +579,18 @@ bool value_set_dereferencet::memory_model_bytes(
 
   // See if we have an array of bytes already,
   // and we want something byte-sized.
-  auto from_type_subtype_size =
-    pointer_offset_size(ns.follow(from_type).subtype(), ns);
+  auto from_type_subtype_size = pointer_offset_size(from_type.subtype(), ns);
 
   auto to_type_size = pointer_offset_size(to_type, ns);
 
   if(
     from_type.id() == ID_array && from_type_subtype_size.has_value() &&
     *from_type_subtype_size == 1 && to_type_size.has_value() &&
-    *to_type_size == 1 && is_a_bv_type(ns.follow(from_type).subtype()) &&
+    *to_type_size == 1 && is_a_bv_type(from_type.subtype()) &&
     is_a_bv_type(to_type))
   {
     // yes, can use 'index'
-    result=index_exprt(value, offset, ns.follow(from_type).subtype());
+    result = index_exprt(value, offset, from_type.subtype());
 
     // possibly need to convert
     if(!base_type_eq(result.type(), to_type, ns))

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -909,13 +909,14 @@ void value_set_fit::get_reference_set_sharing_rec(
     forall_objects(it, struct_references.read())
     {
       const exprt &object=object_numbering[it->first];
-      const typet &obj_type=ns.follow(object.type());
+      const typet &obj_type = object.type();
 
       if(object.id()==ID_unknown)
         insert(dest, exprt(ID_unknown, expr.type()));
-      else if(object.id()==ID_dynamic_object &&
-              obj_type.id()!=ID_struct &&
-              obj_type.id()!=ID_union)
+      else if(
+        object.id() == ID_dynamic_object && obj_type.id() != ID_struct &&
+        obj_type.id() != ID_union && obj_type.id() != ID_struct_tag &&
+        obj_type.id() != ID_union_tag)
       {
         // we catch dynamic objects of the wrong type,
         // to avoid non-integral typecasts.

--- a/src/pointer-analysis/value_set_fivr.cpp
+++ b/src/pointer-analysis/value_set_fivr.cpp
@@ -1022,13 +1022,14 @@ void value_set_fivrt::get_reference_set_sharing_rec(
     forall_objects(it, object_map)
     {
       const exprt &object=object_numbering[it->first];
-      const typet &obj_type=ns.follow(object.type());
+      const typet &obj_type = object.type();
 
       if(object.id()==ID_unknown)
         insert_from(dest, exprt(ID_unknown, expr.type()));
-      else if(object.id()==ID_dynamic_object &&
-              obj_type.id()!=ID_struct &&
-              obj_type.id()!=ID_union)
+      else if(
+        object.id() == ID_dynamic_object && obj_type.id() != ID_struct &&
+        obj_type.id() != ID_union && obj_type.id() != ID_struct_tag &&
+        obj_type.id() != ID_union_tag)
       {
         // we catch dynamic objects of the wrong type,
         // to avoid non-integral typecasts.

--- a/src/pointer-analysis/value_set_fivrns.cpp
+++ b/src/pointer-analysis/value_set_fivrns.cpp
@@ -715,13 +715,14 @@ void value_set_fivrnst::get_reference_set_rec(
     forall_objects(it, object_map)
     {
       const exprt &object=object_numbering[it->first];
-      const typet &obj_type=ns.follow(object.type());
+      const typet &obj_type = object.type();
 
       if(object.id()==ID_unknown)
         insert_from(dest, exprt(ID_unknown, expr.type()));
-      else if(object.id()==ID_dynamic_object &&
-              obj_type.id()!=ID_struct &&
-              obj_type.id()!=ID_union)
+      else if(
+        object.id() == ID_dynamic_object && obj_type.id() != ID_struct &&
+        obj_type.id() != ID_union && obj_type.id() != ID_struct_tag &&
+        obj_type.id() != ID_union_tag)
       {
         // we catch dynamic objects of the wrong type,
         // to avoid non-integral typecasts.


### PR DESCRIPTION
Further cleanup of some remaining unnecessary ns.follow calls after the earlier
removal of ns.follow in these directories.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
