### PR TITLE
Make sure boolbv::get returns tag types when requested [blocks: #3652]

### DIFF
--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -120,15 +120,17 @@ exprt boolbvt::bv_get_rec(
     }
     else if(type.id()==ID_struct_tag)
     {
-      return
-        bv_get_rec(
-          bv, unknown, offset, ns.follow_tag(to_struct_tag_type(type)));
+      exprt result = bv_get_rec(
+        bv, unknown, offset, ns.follow_tag(to_struct_tag_type(type)));
+      result.type() = type;
+      return result;
     }
     else if(type.id()==ID_union_tag)
     {
-      return
-        bv_get_rec(
-          bv, unknown, offset, ns.follow_tag(to_union_tag_type(type)));
+      exprt result =
+        bv_get_rec(bv, unknown, offset, ns.follow_tag(to_union_tag_type(type)));
+      result.type() = type;
+      return result;
     }
     else if(type.id()==ID_struct)
     {


### PR DESCRIPTION
boolbv::get should return expressions of exactly the same type, not an expanded
version of the type.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
