### PR TITLE
Remove namespacet where it is no longer needed [blocks: #2310]

### DIFF
--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -36,10 +36,7 @@ Author: Daniel Kroening, kroening@kroening.com
 const value_sett::object_map_dt value_sett::object_map_dt::blank{};
 object_numberingt value_sett::object_numbering;
 
-bool value_sett::field_sensitive(
-  const irep_idt &id,
-  const typet &type,
-  const namespacet &ns)
+bool value_sett::field_sensitive(const irep_idt &id, const typet &type)
 {
   // we always track fields on these
   if(has_prefix(id2string(id), "value_set::dynamic_object") ||
@@ -58,14 +55,11 @@ const value_sett::entryt *value_sett::find_entry(const value_sett::idt &id)
   return found == values.end() ? nullptr : &found->second;
 }
 
-value_sett::entryt &value_sett::get_entry(
-  const entryt &e,
-  const typet &type,
-  const namespacet &ns)
+value_sett::entryt &value_sett::get_entry(const entryt &e, const typet &type)
 {
   irep_idt index;
 
-  if(field_sensitive(e.identifier, type, ns))
+  if(field_sensitive(e.identifier, type))
     index=id2string(e.identifier)+e.suffix;
   else
     index=e.identifier;
@@ -1291,7 +1285,7 @@ void value_sett::assign_rec(
   {
     const irep_idt &identifier=to_symbol_expr(lhs).get_identifier();
 
-    entryt &e=get_entry(entryt(identifier, suffix), lhs.type(), ns);
+    entryt &e = get_entry(entryt(identifier, suffix), lhs.type());
 
     if(add_to_sets)
       make_union(e.object_map, values_rhs);
@@ -1307,7 +1301,7 @@ void value_sett::assign_rec(
       "value_set::dynamic_object"+
       std::to_string(dynamic_object.get_instance());
 
-    entryt &e=get_entry(entryt(name, suffix), lhs.type(), ns);
+    entryt &e = get_entry(entryt(name, suffix), lhs.type());
 
     make_union(e.object_map, values_rhs);
   }

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -47,10 +47,7 @@ public:
 
   virtual ~value_sett() = default;
 
-  static bool field_sensitive(
-    const irep_idt &id,
-    const typet &type,
-    const namespacet &);
+  static bool field_sensitive(const irep_idt &id, const typet &type);
 
   /// Matches the location_number field of the instruction that corresponds
   /// to this value_sett instance in value_set_domaint's state map
@@ -329,10 +326,7 @@ public:
   /// \param type: type of `e.identifier`, used to determine whether `e`'s
   ///   suffix should be used to find a field-sensitive value-set or whether
   ///   a single entry should be shared by all of symbol `e.identifier`.
-  /// \param ns: global namespace
-  entryt &get_entry(
-    const entryt &e, const typet &type,
-    const namespacet &ns);
+  entryt &get_entry(const entryt &e, const typet &type);
 
   /// Pretty-print this value-set
   /// \param ns: global namespace


### PR DESCRIPTION
The ns.follow cleanup made it redundant.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
