### PR TITLE
Fix a typo in the dependencies between the unit tests and src/

### DIFF
--- a/unit/Makefile
+++ b/unit/Makefile
@@ -143,7 +143,7 @@ CLEANFILES = $(CATCH_TEST) testing-utils/testing-utils$(LIBEXT)
 
 # only add a dependency for libraries to avoid triggering implicit rules, which
 # would cause unnecessary rebuilds
-$(filter %$(LIBEXT), CPROVER_LIBS): cprover.dir
+$(filter %$(LIBEXT), $(CPROVER_LIBS)): cprover.dir
 
 all: $(CATCH_TEST)
 


### PR DESCRIPTION
This should only affect the case when the main part of CPROVER
hasn't been built but we try to run the test cases first.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
