### PR TITLE
Improve the support for `json_objectt` usage with STL algorithms.

### DIFF
--- a/src/util/json.h
+++ b/src/util/json.h
@@ -290,7 +290,7 @@ public:
 
   const jsont &operator[](const std::string &key) const
   {
-    objectt::const_iterator it=object.find(key);
+    const_iterator it = object.find(key);
     if(it==object.end())
       return null_json_object;
     else
@@ -302,42 +302,42 @@ public:
     return object.insert(it, std::move(value));
   }
 
-  objectt::iterator find(const std::string &key)
+  iterator find(const std::string &key)
   {
     return object.find(key);
   }
 
-  objectt::const_iterator find(const std::string &key) const
+  const_iterator find(const std::string &key) const
   {
     return object.find(key);
   }
 
-  objectt::iterator begin()
+  iterator begin()
   {
     return object.begin();
   }
 
-  objectt::const_iterator begin() const
+  const_iterator begin() const
   {
     return object.begin();
   }
 
-  objectt::const_iterator cbegin() const
+  const_iterator cbegin() const
   {
     return object.cbegin();
   }
 
-  objectt::iterator end()
+  iterator end()
   {
     return object.end();
   }
 
-  objectt::const_iterator end() const
+  const_iterator end() const
   {
     return object.end();
   }
 
-  objectt::const_iterator cend() const
+  const_iterator cend() const
   {
     return object.cend();
   }

--- a/src/util/json.h
+++ b/src/util/json.h
@@ -270,6 +270,10 @@ public:
 class json_objectt:public jsont
 {
 public:
+  using value_type = objectt::value_type;
+  using iterator = objectt::iterator;
+  using const_iterator = objectt::const_iterator;
+
   json_objectt():jsont(kindt::J_OBJECT)
   {
   }
@@ -291,6 +295,11 @@ public:
       return null_json_object;
     else
       return it->second;
+  }
+
+  iterator insert(const_iterator it, value_type value)
+  {
+    return object.insert(it, std::move(value));
   }
 
   objectt::iterator find(const std::string &key)
@@ -332,8 +341,6 @@ public:
   {
     return object.cend();
   }
-
-  typedef jsont value_type; // NOLINT(readability/identifiers)
 };
 
 class json_truet:public jsont

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -51,6 +51,7 @@ SRC += analyses/ai/ai.cpp \
        util/graph.cpp \
        util/irep.cpp \
        util/irep_sharing.cpp \
+       util/json_object.cpp \
        util/memory_info.cpp \
        util/message.cpp \
        util/optional.cpp \

--- a/unit/util/json_object.cpp
+++ b/unit/util/json_object.cpp
@@ -1,0 +1,48 @@
+/*******************************************************************\
+
+Module: Catch tests for json_objectt
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include <testing-utils/catch.hpp>
+#include <util/json.h>
+#include <util/optional.h>
+#include <util/optional_utils.h>
+
+#include <algorithm>
+#include <iterator>
+
+SCENARIO(
+  "Test that json_objectt is compatible with STL algorithms",
+  "[core][util][json]")
+{
+  GIVEN("An empty json_objectt")
+  {
+    json_objectt object;
+    THEN("std::transform can be used to insert into the json_object.")
+    {
+      const std::vector<std::string> input_values = {"one", "two", "three"};
+      const std::insert_iterator<json_objectt> insert_it =
+        std::inserter(object, object.end());
+      std::transform(
+        input_values.begin(),
+        input_values.end(),
+        insert_it,
+        [](const std::string &number) {
+          return make_pair(number, json_stringt{number});
+        });
+
+      const optionalt<jsont> one = optional_lookup(object, "one");
+      REQUIRE(one);
+      REQUIRE(one->value == "one");
+      const optionalt<jsont> two = optional_lookup(object, "two");
+      REQUIRE(two);
+      REQUIRE(two->value == "two");
+      const optionalt<jsont> three = optional_lookup(object, "three");
+      REQUIRE(three);
+      REQUIRE(three->value == "three");
+    }
+  }
+}


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
This PR adds the  `insert` member function to `json_objectt`. This adds support for `std::insert_iterator` / `std::inserter` to `json_objectt`. Which means it can then be used as the output container for a call to `std::transform`.
