### PR TITLE
Define big-int operators for signed long [blocks: #2551]

### DIFF
--- a/src/big-int/bigint.hh
+++ b/src/big-int/bigint.hh
@@ -221,6 +221,10 @@ public:
 
   // Eliminate need for explicit casts when comparing.
 
+  int compare(long n) const
+  {
+    return compare(static_cast<llong_t>(n));
+  }
   int compare (unsigned long n) const { return compare (static_cast<ullong_t>(n)); }
   int compare (int n) const           { return compare (static_cast<llong_t> (n)); }
   int compare (unsigned n) const      { return compare (static_cast<ullong_t>(n)); }
@@ -257,6 +261,7 @@ public:
   BigInt &operator/=(FROM x) { return operator/=(static_cast<TO>(x)); } \
   BigInt &operator%=(FROM x) { return operator%=(static_cast<TO>(x)); }
 
+  OVERLOAD_IN_PLACE_OPERATOR(long, llong_t)
   OVERLOAD_IN_PLACE_OPERATOR(unsigned long, ullong_t)
   OVERLOAD_IN_PLACE_OPERATOR(int, llong_t)
   OVERLOAD_IN_PLACE_OPERATOR(unsigned, ullong_t)
@@ -317,6 +322,7 @@ inline BigInt operator% (const BigInt &lhs, const BigInt &rhs) { return BigInt(l
 
 BINARY_ARITHMETIC_OPERATORS(BigInt::llong_t)
 BINARY_ARITHMETIC_OPERATORS(BigInt::ullong_t)
+BINARY_ARITHMETIC_OPERATORS(long)
 BINARY_ARITHMETIC_OPERATORS(unsigned long)
 BINARY_ARITHMETIC_OPERATORS(int)
 BINARY_ARITHMETIC_OPERATORS(unsigned)
@@ -350,6 +356,7 @@ inline bool operator!= (const BigInt &lhs, const BigInt &rhs) { return lhs.compa
 
 COMPARISON_OPERATORS(BigInt::llong_t)
 COMPARISON_OPERATORS(BigInt::ullong_t)
+COMPARISON_OPERATORS(long)
 COMPARISON_OPERATORS(unsigned long)
 COMPARISON_OPERATORS(int)
 COMPARISON_OPERATORS(unsigned)


### PR DESCRIPTION
Trying to use numeric_cast_v<signed long> resulted in ambiguous overload errors.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
