### PR TITLE
Do not pass class member "file_name" as argument [blocks: #2310]

### DIFF
--- a/src/goto-checker/symex_coverage.cpp
+++ b/src/goto-checker/symex_coverage.cpp
@@ -87,7 +87,6 @@ protected:
 
   void compute_coverage_lines(
     const goto_programt &goto_program,
-    const irep_idt &file_name,
     const symex_coveraget::coveraget &coverage,
     coverage_lines_mapt &dest);
 };
@@ -145,8 +144,7 @@ goto_program_coverage_recordt::goto_program_coverage_recordt(
 
   // compute the maximum coverage of individual source-code lines
   coverage_lines_mapt coverage_lines_map;
-  compute_coverage_lines(
-    gf_it->second.body, file_name, coverage, coverage_lines_map);
+  compute_coverage_lines(gf_it->second.body, coverage, coverage_lines_map);
 
   // <method name="foo" signature="int(int)" line-rate="1.0" branch-rate="1.0">
   //   <lines>
@@ -205,7 +203,6 @@ goto_program_coverage_recordt::goto_program_coverage_recordt(
 
 void goto_program_coverage_recordt::compute_coverage_lines(
   const goto_programt &goto_program,
-  const irep_idt &file_name,
   const symex_coveraget::coveraget &coverage,
   coverage_lines_mapt &dest)
 {


### PR DESCRIPTION
This is just unnecessary and not doing so avoids shadowing. (Patch applied again
as it got lost during the goto-checker refactoring.)

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
