### PR TITLE
Silence warning about unused parameter [blocks: #2310]

### DIFF
--- a/src/json-symtab-language/json_symtab_language.cpp
+++ b/src/json-symtab-language/json_symtab_language.cpp
@@ -32,6 +32,8 @@ bool json_symtab_languaget::typecheck(
   symbol_tablet &symbol_table,
   const std::string &module)
 {
+  (void)module; // unused parameter
+
   try
   {
     symbol_table_from_json(parsed_json_file, symbol_table);


### PR DESCRIPTION
The parameter is documented, thus its name cannot be removed.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
