### PR TITLE
Object factory string options parsing fixes

### DIFF
--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -255,8 +255,9 @@ void jbmc_parse_optionst::get_command_line_options(optionst &options)
   {
     if(cmdline.isset("no-refine-strings"))
     {
-      warning() << "--string-printable ignored due to --no-refine-strings"
-                << eom;
+      throw invalid_command_line_argument_exceptiont(
+        "cannot use --string-printable with --no-refine-strings",
+        "--string-printable");
     }
     options.set_option("string-printable", true);
   }
@@ -265,8 +266,9 @@ void jbmc_parse_optionst::get_command_line_options(optionst &options)
   {
     if(cmdline.isset("no-refine-strings"))
     {
-      warning() << "--string-input-value ignored due to --no-refine-strings"
-                << eom;
+      throw invalid_command_line_argument_exceptiont(
+        "cannot use --string-input-value with --no-refine-strings",
+        "--string-input-value");
     }
     options.set_option(
       "string-input-value",
@@ -277,8 +279,9 @@ void jbmc_parse_optionst::get_command_line_options(optionst &options)
     cmdline.isset("no-refine-strings") &&
     cmdline.isset("max-nondet-string-length"))
   {
-    warning() << "--max-nondet-string-length ignored due to "
-              << "--no-refine-strings" << eom;
+    throw invalid_command_line_argument_exceptiont(
+      "cannot use --max-nondet-string-length with --no-refine-strings",
+      "--max-nondet-string-length");
   }
 
   if(cmdline.isset("max-node-refinement"))

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -251,28 +251,18 @@ void jbmc_parse_optionst::get_command_line_options(optionst &options)
   if(cmdline.isset("no-refine-strings"))
     options.set_option("refine-strings", false);
 
-  if(cmdline.isset("string-printable"))
+  if(cmdline.isset("string-printable") && cmdline.isset("no-refine-strings"))
   {
-    if(cmdline.isset("no-refine-strings"))
-    {
-      throw invalid_command_line_argument_exceptiont(
-        "cannot use --string-printable with --no-refine-strings",
-        "--string-printable");
-    }
-    options.set_option("string-printable", true);
+    throw invalid_command_line_argument_exceptiont(
+      "cannot use --string-printable with --no-refine-strings",
+      "--string-printable");
   }
 
-  if(cmdline.isset("string-input-value"))
+  if(cmdline.isset("string-input-value") && cmdline.isset("no-refine-strings"))
   {
-    if(cmdline.isset("no-refine-strings"))
-    {
-      throw invalid_command_line_argument_exceptiont(
-        "cannot use --string-input-value with --no-refine-strings",
-        "--string-input-value");
-    }
-    options.set_option(
-      "string-input-value",
-      cmdline.get_values("string-input-value"));
+    throw invalid_command_line_argument_exceptiont(
+      "cannot use --string-input-value with --no-refine-strings",
+      "--string-input-value");
   }
 
   if(

--- a/src/util/object_factory_parameters.cpp
+++ b/src/util/object_factory_parameters.cpp
@@ -82,4 +82,9 @@ void parse_object_factory_options(const cmdlinet &cmdline, optionst &options)
   {
     options.set_option("min-nondet-string-length", 1);
   }
+  if(cmdline.isset("string-input-value"))
+  {
+    options.set_option(
+      "string-input-value", cmdline.get_values("string-input-value"));
+  }
 }

--- a/src/util/object_factory_parameters.cpp
+++ b/src/util/object_factory_parameters.cpp
@@ -76,7 +76,7 @@ void parse_object_factory_options(const cmdlinet &cmdline, optionst &options)
   }
   if(cmdline.isset("string-printable"))
   {
-    options.set_option("string-printable", cmdline.isset("string-printable"));
+    options.set_option("string-printable", true);
   }
   if(cmdline.isset("string-non-empty"))
   {


### PR DESCRIPTION
This moves object factory string options parsing into `parse_object_factory_options()`, and throws an `invalid_command_line_argument_exceptiont` for options that can't be used together instead of ignoring an option.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
