### PR TITLE
Get property ID for SSA step assert

### DIFF
--- a/src/cbmc/all_properties.cpp
+++ b/src/cbmc/all_properties.cpp
@@ -78,20 +78,16 @@ safety_checkert::resultt bmc_all_propertiest::operator()()
   {
     if(it->is_assert())
     {
-      irep_idt property_id;
+      irep_idt property_id = it->get_property_id();
 
-      if(it->source.pc->is_assert())
-        property_id=it->source.pc->source_location.get_property_id();
-      else if(it->source.pc->is_goto())
-      {
-        // this is likely an unwinding assertion
-        property_id=id2string(
-          it->source.pc->source_location.get_function())+".unwind."+
-          std::to_string(it->source.pc->loop_number);
-        goal_map[property_id].description=it->comment;
-      }
-      else
+      if(property_id.empty())
         continue;
+
+      if(it->source.pc->is_goto())
+      {
+        // goto may yield an unwinding assertion
+        goal_map[property_id].description = it->comment;
+      }
 
       goal_map[property_id].instances.push_back(it);
     }

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -1003,3 +1003,27 @@ void symex_target_equationt::SSA_stept::validate(
     break;
   }
 }
+
+irep_idt symex_target_equationt::SSA_stept::get_property_id() const
+{
+  PRECONDITION(is_assert());
+
+  irep_idt property_id;
+
+  if(source.pc->is_assert())
+  {
+    property_id = source.pc->source_location.get_property_id();
+  }
+  else if(source.pc->is_goto())
+  {
+    // this is likely an unwinding assertion
+    property_id = id2string(source.pc->source_location.get_function()) +
+                  ".unwind." + std::to_string(source.pc->loop_number);
+  }
+  else
+  {
+    // return empty
+  }
+
+  return property_id;
+}

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -279,6 +279,9 @@ public:
     // NOLINTNEXTLINE(whitespace/line_length)
     bool is_atomic_end() const      { return type==goto_trace_stept::typet::ATOMIC_END; }
 
+    // return the property ID if this is an assertion step
+    irep_idt get_property_id() const;
+
     // we may choose to hide
     bool hidden=false;
 


### PR DESCRIPTION
Make reusable to avoid error-prone duplication.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
