### PR TITLE
Remove guardt inheritance on exprt [TG-5977]

### DIFF
--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1491,8 +1491,7 @@ void goto_checkt::check_rec(const exprt &expr, guardt &guard, bool address)
         guard.add(op);
     }
 
-    guard.swap(old_guard);
-
+    guard = std::move(old_guard);
     return;
   }
   else if(expr.id()==ID_if)
@@ -1514,14 +1513,14 @@ void goto_checkt::check_rec(const exprt &expr, guardt &guard, bool address)
       guardt old_guard=guard;
       guard.add(expr.op0());
       check_rec(expr.op1(), guard, false);
-      guard.swap(old_guard);
+      guard = std::move(old_guard);
     }
 
     {
       guardt old_guard=guard;
       guard.add(not_exprt(expr.op0()));
       check_rec(expr.op2(), guard, false);
-      guard.swap(old_guard);
+      guard = std::move(old_guard);
     }
 
     return;

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1632,7 +1632,7 @@ void goto_checkt::check_rec(const exprt &expr, guardt &guard, bool address)
 
 void goto_checkt::check(const exprt &expr)
 {
-  guardt guard;
+  guardt guard{true_exprt{}};
   check_rec(expr, guard, false);
 }
 
@@ -1762,7 +1762,7 @@ void goto_checkt::goto_check(
             "pointer dereference",
             i.source_location,
             pointer,
-            guardt());
+            guardt(true_exprt()));
         }
       }
 
@@ -1800,7 +1800,7 @@ void goto_checkt::goto_check(
           "pointer dereference",
           i.source_location,
           pointer,
-          guardt());
+          guardt(true_exprt()));
       }
 
       // this has no successor
@@ -1881,7 +1881,7 @@ void goto_checkt::goto_check(
           "memory-leak",
           source_location,
           eq,
-          guardt());
+          guardt(true_exprt()));
       }
     }
 

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1407,16 +1407,15 @@ void goto_checkt::add_guarded_claim(
     return;
 
   // add the guard
-  exprt guard_expr=guard.as_expr();
 
   exprt new_expr;
 
-  if(guard_expr.is_true())
+  if(guard.is_true())
     new_expr.swap(expr);
   else
   {
     new_expr=exprt(ID_implies, bool_typet());
-    new_expr.move_to_operands(guard_expr, expr);
+    new_expr.add_to_operands(guard.as_expr(), std::move(expr));
   }
 
   if(assertions.insert(new_expr).second)

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -685,15 +685,15 @@ void rw_guarded_range_set_value_sett::get_objects_if(
   {
     get_objects_rec(get_modet::READ, if_expr.cond());
 
-    guardt guard_bak1(guard), guard_bak2(guard);
+    guardt copy = guard;
 
     guard.add(not_exprt(if_expr.cond()));
     get_objects_rec(mode, if_expr.false_case(), range_start, size);
-    guard.swap(guard_bak1);
+    guard = copy;
 
     guard.add(if_expr.cond());
     get_objects_rec(mode, if_expr.true_case(), range_start, size);
-    guard.swap(guard_bak2);
+    guard = std::move(copy);
   }
 }
 

--- a/src/analyses/goto_rw.h
+++ b/src/analyses/goto_rw.h
@@ -370,7 +370,7 @@ public:
     get_modet mode,
     const exprt &expr) override
   {
-    guard = true_exprt();
+    guard = guardt();
 
     rw_range_set_value_sett::get_objects_rec(_function, _target, mode, expr);
   }

--- a/src/analyses/goto_rw.h
+++ b/src/analyses/goto_rw.h
@@ -370,7 +370,7 @@ public:
     get_modet mode,
     const exprt &expr) override
   {
-    guard = guardt();
+    guard = guardt(true_exprt());
 
     rw_range_set_value_sett::get_objects_rec(_function, _target, mode, expr);
   }
@@ -384,7 +384,7 @@ public:
   }
 
 protected:
-  guardt guard;
+  guardt guard = guardt(true_exprt());
 
   using rw_range_sett::get_objects_rec;
 

--- a/src/goto-instrument/rw_set.cpp
+++ b/src/goto-instrument/rw_set.cpp
@@ -79,7 +79,7 @@ void _rw_set_loct::compute()
 void _rw_set_loct::assign(const exprt &lhs, const exprt &rhs)
 {
   read(rhs);
-  read_write_rec(lhs, false, true, "", guardt());
+  read_write_rec(lhs, false, true, "", guardt(true_exprt()));
 }
 
 void _rw_set_loct::read_write_rec(

--- a/src/goto-instrument/rw_set.h
+++ b/src/goto-instrument/rw_set.h
@@ -149,7 +149,7 @@ protected:
 
   void read(const exprt &expr)
   {
-    read_write_rec(expr, true, false, "", guardt());
+    read_write_rec(expr, true, false, "", guardt(true_exprt()));
   }
 
   void read(const exprt &expr, const guardt &guard)
@@ -159,7 +159,7 @@ protected:
 
   void write(const exprt &expr)
   {
-    read_write_rec(expr, false, true, "", guardt());
+    read_write_rec(expr, false, true, "", guardt(true_exprt()));
   }
 
   void compute();

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -389,8 +389,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
   // see whether we are within an atomic section
   if(atomic_section_id!=0)
   {
-    guardt write_guard;
-    write_guard.add(false_exprt());
+    guardt write_guard{false_exprt{}};
 
     const auto a_s_writes = written_in_atomic_section.find(ssa_l1);
     if(a_s_writes!=written_in_atomic_section.end())
@@ -414,8 +413,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
     // we cannot determine for sure that there has been a write already
     // so generate a read even if l1_identifier has been written on
     // all branches flowing into this read
-    guardt read_guard;
-    read_guard.add(false_exprt());
+    guardt read_guard{false_exprt{}};
 
     a_s_r_entryt &a_s_read=read_in_atomic_section[ssa_l1];
     for(const auto &a_s_read_guard : a_s_read.second)
@@ -433,11 +431,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
 
     guardt cond = read_guard;
     if(!no_write.op().is_false())
-    {
-      guardt no_write_guard;
-      no_write_guard.add(no_write.op());
-      cond |= no_write_guard;
-    }
+      cond |= guardt{no_write.op()};
 
     if_exprt tmp(cond.as_expr(), ssa_l1, ssa_l1);
     set_l2_indices(to_ssa_expr(tmp.true_case()), ns);

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -384,6 +384,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
   ssa_exprt ssa_l1=expr;
   ssa_l1.remove_level_2();
   const irep_idt &l1_identifier=ssa_l1.get_identifier();
+  const exprt guard_as_expr = guard.as_expr();
 
   // see whether we are within an atomic section
   if(atomic_section_id!=0)
@@ -430,11 +431,15 @@ bool goto_symex_statet::l2_thread_read_encoding(
       read_guard |= a_s_read_guard;
     }
 
-    exprt cond=read_guard.as_expr();
+    guardt cond = read_guard;
     if(!no_write.op().is_false())
-      cond=or_exprt(no_write.op(), cond);
+    {
+      guardt no_write_guard;
+      no_write_guard.add(no_write.op());
+      cond |= no_write_guard;
+    }
 
-    if_exprt tmp(cond, ssa_l1, ssa_l1);
+    if_exprt tmp(cond.as_expr(), ssa_l1, ssa_l1);
     set_l2_indices(to_ssa_expr(tmp.true_case()), ns);
 
     if(a_s_read.second.empty())
@@ -460,7 +465,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
     record_events=record_events_bak;
 
     symex_target->assignment(
-      guard.as_expr(),
+      guard_as_expr,
       ssa_l1,
       ssa_l1,
       ssa_l1.get_original_expr(),
@@ -498,11 +503,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
   // and record that
   INVARIANT_STRUCTURED(
     symex_target!=nullptr, nullptr_exceptiont, "symex_target is null");
-  symex_target->shared_read(
-    guard.as_expr(),
-    expr,
-    atomic_section_id,
-    source);
+  symex_target->shared_read(guard_as_expr, expr, atomic_section_id, source);
 
   return true;
 }

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -54,7 +54,7 @@ public:
   /// distance from entry
   unsigned depth;
 
-  guardt guard;
+  guardt guard{true_exprt{}};
   symex_targett::sourcet source;
   symex_target_equationt *symex_target;
 
@@ -254,7 +254,7 @@ public:
   struct threadt
   {
     goto_programt::const_targett pc;
-    guardt guard;
+    guardt guard{true_exprt{}};
     call_stackt call_stack;
     std::map<irep_idt, unsigned> function_frame;
     unsigned atomic_section_id = 0;

--- a/src/goto-symex/slice_by_trace.cpp
+++ b/src/goto-symex/slice_by_trace.cpp
@@ -85,13 +85,12 @@ void symex_slice_by_tracet::slice_by_trace(
 
   slice_SSA_steps(equation, implications); // Slice based on implications
 
-  guardt t_guard;
   symex_targett::sourcet empty_source;
   equation.SSA_steps.emplace_front(
     empty_source, goto_trace_stept::typet::ASSUME);
   symex_target_equationt::SSA_stept &SSA_step=equation.SSA_steps.front();
 
-  SSA_step.guard=t_guard.as_expr();
+  SSA_step.guard = true_exprt();
   SSA_step.ssa_lhs.make_nil();
   SSA_step.cond_expr.swap(trace_condition);
 
@@ -485,7 +484,6 @@ void symex_slice_by_tracet::assign_merges(
     ssa_exprt merge_sym(merge_symbol);
     merge_sym.set_level_2(merge_count);
     merge_count--;
-    guardt t_guard;
     symex_targett::sourcet empty_source;
 
     exprt merge_copy(*i);
@@ -494,7 +492,7 @@ void symex_slice_by_tracet::assign_merges(
       empty_source, goto_trace_stept::typet::ASSIGNMENT);
     symex_target_equationt::SSA_stept &SSA_step=equation.SSA_steps.front();
 
-    SSA_step.guard=t_guard.as_expr();
+    SSA_step.guard = true_exprt();
     SSA_step.ssa_lhs=merge_sym;
     SSA_step.ssa_rhs.swap(merge_copy);
     SSA_step.assignment_type=symex_targett::assignment_typet::HIDDEN;

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -89,7 +89,7 @@ void goto_symext::symex_assign(
     if(state.source.pc->source_location.get_hide())
       assignment_type=symex_targett::assignment_typet::HIDDEN;
 
-    guardt guard; // NOT the state guard!
+    guardt guard{true_exprt{}}; // NOT the state guard!
     symex_assign_rec(state, lhs, nil_exprt(), rhs, guard, assignment_type);
   }
 }

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -431,7 +431,7 @@ void goto_symext::symex_assign_if(
     guard.add(renamed_guard);
     symex_assign_rec(
       state, lhs.true_case(), full_lhs, rhs, guard, assignment_type);
-    guard.swap(old_guard);
+    guard = std::move(old_guard);
   }
 
   if(!renamed_guard.is_true())
@@ -439,7 +439,7 @@ void goto_symext::symex_assign_if(
     guard.add(not_exprt(renamed_guard));
     symex_assign_rec(
       state, lhs.false_case(), full_lhs, rhs, guard, assignment_type);
-    guard.swap(old_guard);
+    guard = std::move(old_guard);
   }
 }
 

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -384,7 +384,7 @@ void goto_symext::dereference(
   state.rename(expr, ns, goto_symex_statet::L1);
 
   // start the recursion!
-  guardt guard;
+  guardt guard{true_exprt{}};
   dereference_rec(expr, state, guard, write);
   // dereferencing may introduce new symbol_exprt
   // (like __CPROVER_memory)

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -139,7 +139,7 @@ void goto_symext::parameter_assignments(
       clean_expr(lhs, state, true);
       clean_expr(rhs, state, false);
 
-      guardt guard;
+      guardt guard{true_exprt{}};
       symex_assign_rec(state, lhs, nil_exprt(), rhs, guard, assignment_type);
     }
 

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -249,7 +249,7 @@ void goto_symext::symex_goto(statet &state)
       state.rename(new_lhs, ns, goto_symex_statet::L1);
       state.assignment(new_lhs, new_rhs, ns, true, false);
 
-      guardt guard;
+      guardt guard{true_exprt{}};
 
       log.conditional_output(
         log.debug(),

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -225,7 +225,7 @@ void goto_symext::symex_goto(statet &state)
   // adjust guards
   if(new_guard.is_true())
   {
-    state.guard = false_exprt();
+    state.guard = guardt(false_exprt());
   }
   else
   {

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -275,7 +275,7 @@ void goto_symext::symex_other(
     dereference_exprt object(code.op0(), empty_typet());
     clean_expr(object, state, true);
 
-    havoc_rec(state, guardt(), object);
+    havoc_rec(state, guardt(true_exprt()), object);
   }
   else
     UNREACHABLE;

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -81,7 +81,7 @@ void goto_symext::symex_start_thread(statet &state)
     // make copy
     ssa_exprt rhs=c_it->second.first;
 
-    guardt guard;
+    guardt guard{true_exprt{}};
     const bool record_events=state.record_events;
     state.record_events=false;
     symex_assign_symbol(
@@ -120,7 +120,7 @@ void goto_symext::symex_start_thread(statet &state)
       rhs = *zero;
     }
 
-    guardt guard;
+    guardt guard{true_exprt{}};
     symex_assign_symbol(
       state,
       lhs,

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -251,7 +251,7 @@ void goto_program_dereferencet::dereference_expr(
   const bool checks_only,
   const value_set_dereferencet::modet mode)
 {
-  guardt guard;
+  guardt guard{true_exprt{}};
 
   if(checks_only)
   {

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -132,8 +132,7 @@ void goto_program_dereferencet::dereference_rec(
         guard.add(op);
     }
 
-    guard.swap(old_guard);
-
+    guard = std::move(old_guard);
     return;
   }
   else if(expr.id()==ID_if)
@@ -159,7 +158,7 @@ void goto_program_dereferencet::dereference_rec(
       guardt old_guard=guard;
       guard.add(expr.op0());
       dereference_rec(expr.op1(), guard, mode);
-      guard.swap(old_guard);
+      guard = std::move(old_guard);
     }
 
     if(o2)
@@ -167,7 +166,7 @@ void goto_program_dereferencet::dereference_rec(
       guardt old_guard=guard;
       guard.add(boolean_negate(expr.op0()));
       dereference_rec(expr.op2(), guard, mode);
-      guard.swap(old_guard);
+      guard = std::move(old_guard);
     }
 
     return;

--- a/src/util/guard.cpp
+++ b/src/util/guard.cpp
@@ -46,17 +46,17 @@ void guardt::add(const exprt &expr)
     return;
   else if(is_true() || expr.is_false())
   {
-    *this=expr;
+    this->expr = expr;
 
     return;
   }
-  else if(id()!=ID_and)
+  else if(this->expr.id() != ID_and)
   {
-    and_exprt a({*this});
-    *this=a;
+    and_exprt a({this->expr});
+    this->expr = a;
   }
 
-  operandst &op=operands();
+  exprt::operandst &op = this->expr.operands();
 
   if(expr.id()==ID_and)
     op.insert(op.end(),
@@ -68,14 +68,14 @@ void guardt::add(const exprt &expr)
 
 guardt &operator -= (guardt &g1, const guardt &g2)
 {
-  if(g1.id()!=ID_and || g2.id()!=ID_and)
+  if(g1.expr.id() != ID_and || g2.expr.id() != ID_and)
     return g1;
 
-  sort_and_join(g1);
-  guardt g2_sorted=g2;
+  sort_and_join(g1.expr);
+  exprt g2_sorted = g2.as_expr();
   sort_and_join(g2_sorted);
 
-  exprt::operandst &op1=g1.operands();
+  exprt::operandst &op1 = g1.expr.operands();
   const exprt::operandst &op2=g2_sorted.operands();
 
   exprt::operandst::iterator it1=op1.begin();
@@ -90,7 +90,7 @@ guardt &operator -= (guardt &g1, const guardt &g2)
       it1=op1.erase(it1);
   }
 
-  g1=conjunction(op1);
+  g1.expr = conjunction(op1);
 
   return g1;
 }
@@ -101,18 +101,18 @@ guardt &operator |= (guardt &g1, const guardt &g2)
     return g1;
   if(g1.is_false() || g2.is_true())
   {
-    g1=g2;
+    g1.expr = g2.expr;
     return g1;
   }
 
-  if(g1.id()!=ID_and || g2.id()!=ID_and)
+  if(g1.expr.id() != ID_and || g2.expr.id() != ID_and)
   {
-    exprt tmp(boolean_negate(g2));
+    exprt tmp(boolean_negate(g2.as_expr()));
 
-    if(tmp==g1)
-      g1 = true_exprt();
+    if(tmp == g1.as_expr())
+      g1.expr = true_exprt();
     else
-      g1=or_exprt(g1, g2);
+      g1.expr = or_exprt(g1.as_expr(), g2.as_expr());
 
     // TODO: make simplify more capable and apply here
 
@@ -120,11 +120,11 @@ guardt &operator |= (guardt &g1, const guardt &g2)
   }
 
   // find common prefix
-  sort_and_join(g1);
-  guardt g2_sorted=g2;
+  sort_and_join(g1.expr);
+  exprt g2_sorted = g2.as_expr();
   sort_and_join(g2_sorted);
 
-  exprt::operandst &op1=g1.operands();
+  exprt::operandst &op1 = g1.expr.operands();
   const exprt::operandst &op2=g2_sorted.operands();
 
   exprt::operandst n_op1, n_op2;
@@ -160,7 +160,7 @@ guardt &operator |= (guardt &g1, const guardt &g2)
   exprt and_expr1=conjunction(n_op1);
   exprt and_expr2=conjunction(n_op2);
 
-  g1=conjunction(op1);
+  g1.expr = conjunction(op1);
 
   exprt tmp(boolean_negate(and_expr2));
 

--- a/src/util/guard.h
+++ b/src/util/guard.h
@@ -16,47 +16,46 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "std_expr.h"
 
-class guardt : private exprt
+class guardt
 {
 public:
-  guardt()
+  guardt() : expr(true_exprt())
   {
-    *this = true_exprt();
   }
 
-  guardt &operator=(const exprt &e)
+  explicit guardt(const exprt &e) : expr(e)
   {
-    *this=static_cast<const guardt&>(e);
-
-    return *this;
   }
 
   void add(const exprt &expr);
 
   void append(const guardt &guard)
   {
-    add(guard);
+    add(guard.as_expr());
   }
 
   exprt as_expr() const
   {
-    return *this;
+    return expr;
   }
 
   void guard_expr(exprt &dest) const;
 
   bool is_true() const
   {
-    return exprt::is_true();
+    return expr.is_true();
   }
 
   bool is_false() const
   {
-    return exprt::is_false();
+    return expr.is_false();
   }
 
   friend guardt &operator -= (guardt &g1, const guardt &g2);
   friend guardt &operator |= (guardt &g1, const guardt &g2);
+
+private:
+  exprt expr;
 };
 
 #endif // CPROVER_UTIL_GUARD_H

--- a/src/util/guard.h
+++ b/src/util/guard.h
@@ -16,7 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "std_expr.h"
 
-class guardt:public exprt
+class guardt : private exprt
 {
 public:
   guardt()
@@ -44,6 +44,16 @@ public:
   }
 
   void guard_expr(exprt &dest) const;
+
+  bool is_true() const
+  {
+    return exprt::is_true();
+  }
+
+  bool is_false() const
+  {
+    return exprt::is_false();
+  }
 
   friend guardt &operator -= (guardt &g1, const guardt &g2);
   friend guardt &operator |= (guardt &g1, const guardt &g2);

--- a/src/util/guard.h
+++ b/src/util/guard.h
@@ -19,10 +19,6 @@ Author: Daniel Kroening, kroening@kroening.com
 class guardt
 {
 public:
-  guardt() : expr(true_exprt())
-  {
-  }
-
   explicit guardt(const exprt &e) : expr(e)
   {
   }


### PR DESCRIPTION
This is in preparation for providing other implementations of guardt, in particular using BDDs as is done here: https://github.com/diffblue/cbmc/pull/3730

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
