### PR TITLE
Simplify conditions created in symex_goto

### DIFF
--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -490,6 +490,18 @@ static void merge_names(
   {
     rhs = goto_state_rhs;
   }
+  else if(diff_guard.is_false())
+  {
+    if(do_simplify)
+      simplify(dest_state_rhs, ns);
+    rhs = dest_state_rhs;
+  }
+  else if(diff_guard.is_true())
+  {
+    if(do_simplify)
+      simplify(goto_state_rhs, ns);
+    rhs = goto_state_rhs;
+  }
   else
   {
     rhs = if_exprt(diff_guard.as_expr(), goto_state_rhs, dest_state_rhs);


### PR DESCRIPTION
This can make the conditions created by merge_names simpler, and can
happen often if the simplification of guards is efficient, it would be
the case in particular if we used BDDs to simplify guards, as is done in https://github.com/diffblue/cbmc/pull/3730

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
