### PR TITLE
Finished applying fixes for jbmc for assignment consistency

### DIFF
--- a/jbmc/regression/jbmc/remove_virtual_function_typecast/test.desc
+++ b/jbmc/regression/jbmc/remove_virtual_function_typecast/test.desc
@@ -10,3 +10,5 @@ VirtualFunctions.class
 --
 --
 This doesn't work under symex-driven lazy loading because it is incompatible with lazy-methods (default)
+Note the space before the checks for virtual function call on a and b, this
+verifies there is no cast.

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -43,6 +43,7 @@ public:
     bool threading_support)
     : messaget(_message_handler),
       symbol_table(symbol_table),
+      ns(symbol_table),
       max_array_length(_max_array_length),
       throw_assertion_error(throw_assertion_error),
       threading_support(threading_support),
@@ -69,6 +70,7 @@ public:
 
 protected:
   symbol_table_baset &symbol_table;
+  namespacet ns;
   const size_t max_array_length;
   const bool throw_assertion_error;
   const bool threading_support;

--- a/jbmc/src/java_bytecode/java_bytecode_typecheck.h
+++ b/jbmc/src/java_bytecode/java_bytecode_typecheck.h
@@ -69,7 +69,6 @@ protected:
   void typecheck_code(codet &);
   void typecheck_type(typet &);
   void typecheck_expr_symbol(symbol_exprt &);
-  void typecheck_expr_member(member_exprt &);
   void typecheck_expr_java_new(side_effect_exprt &);
   void typecheck_expr_java_new_array(side_effect_exprt &);
 

--- a/jbmc/src/java_bytecode/java_bytecode_typecheck_expr.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_typecheck_expr.cpp
@@ -52,8 +52,6 @@ void java_bytecode_typecheckt::typecheck_expr(exprt &expr)
     else if(statement==ID_java_new_array)
       typecheck_expr_java_new_array(to_side_effect_expr(expr));
   }
-  else if(expr.id()==ID_member)
-    typecheck_expr_member(to_member_expr(expr));
 }
 
 void java_bytecode_typecheckt::typecheck_expr_java_new(side_effect_exprt &expr)
@@ -119,47 +117,4 @@ void java_bytecode_typecheckt::typecheck_expr_symbol(symbol_exprt &expr)
     // type the expression
     expr.type()=symbol.type;
   }
-}
-
-void java_bytecode_typecheckt::typecheck_expr_member(member_exprt &expr)
-{
-  // The member might be in a parent class or an opaque class, which we resolve
-  // here.
-  const irep_idt component_name=expr.get_component_name();
-
-  while(1)
-  {
-    typet base_type(ns.follow(expr.struct_op().type()));
-
-    if(base_type.id()!=ID_struct)
-      break; // give up
-
-    struct_typet &struct_type=
-      to_struct_type(base_type);
-
-    if(struct_type.has_component(component_name))
-      return; // done
-
-    // look at parent
-    struct_typet::componentst &components=
-      struct_type.components();
-
-    if(components.empty())
-      break;
-
-    const struct_typet::componentt &c=components.front();
-
-    member_exprt m(expr.struct_op(), c.get_name(), c.type());
-    m.add_source_location()=expr.source_location();
-
-    expr.struct_op()=m;
-  }
-
-  warning().source_location=expr.source_location();
-  warning() << "failed to find field `"
-            << component_name << "` in class hierarchy" << eom;
-
-  // We replace by a non-det of same type
-  side_effect_expr_nondett nondet(expr.type(), expr.source_location());
-  expr.swap(nondet);
 }

--- a/jbmc/src/java_bytecode/java_pointer_casts.cpp
+++ b/jbmc/src/java_bytecode/java_pointer_casts.cpp
@@ -118,8 +118,12 @@ exprt make_clean_pointer_cast(
     return bare_ptr;
 
   exprt superclass_ptr=bare_ptr;
+  // Looking at base types discards generic qualifiers (because those are
+  // recorded on the pointer, not the pointee), so it may still be necessary
+  // to use a cast to reintroduce the qualifier (for example, the base might
+  // be recorded as a List, when we're looking for a List<E>)
   if(find_superclass_with_type(superclass_ptr, target_base, ns))
-    return superclass_ptr;
+    return typecast_exprt::conditional_cast(superclass_ptr, target_type);
 
   return typecast_exprt(bare_ptr, target_type);
 }

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -28,6 +28,9 @@ void goto_symext::symex_assign(
   exprt lhs=code.lhs();
   exprt rhs=code.rhs();
 
+  DATA_INVARIANT(
+    lhs.type() == rhs.type(), "assignments must be type consistent");
+
   clean_expr(lhs, state, true);
   clean_expr(rhs, state, false);
 

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -29,7 +29,8 @@ void goto_symext::symex_assign(
   exprt rhs=code.rhs();
 
   DATA_INVARIANT(
-    lhs.type() == rhs.type(), "assignments must be type consistent");
+    base_type_eq(lhs.type(), rhs.type(), ns),
+    "assignments must be type consistent");
 
   clean_expr(lhs, state, true);
   clean_expr(rhs, state, false);

--- a/src/util/allocate_objects.cpp
+++ b/src/util/allocate_objects.cpp
@@ -212,12 +212,8 @@ exprt allocate_objectst::allocate_non_dynamic_object(
   aux_symbol.is_static_lifetime = static_lifetime;
   symbols_created.push_back(&aux_symbol);
 
-  exprt aoe =
-    ns.follow(aux_symbol.symbol_expr().type()) !=
-        ns.follow(target_expr.type().subtype())
-      ? (exprt)typecast_exprt(
-          address_of_exprt(aux_symbol.symbol_expr()), target_expr.type())
-      : address_of_exprt(aux_symbol.symbol_expr());
+  exprt aoe = typecast_exprt::conditional_cast(
+    address_of_exprt(aux_symbol.symbol_expr()), target_expr.type());
 
   code_assignt code(target_expr, aoe);
   code.add_source_location() = source_location;

--- a/src/util/expr_initializer.cpp
+++ b/src/util/expr_initializer.cpp
@@ -270,10 +270,13 @@ exprt expr_initializert<nondet>::expr_initializer_rec(
   }
   else if(type_id==ID_c_enum_tag)
   {
-    return
-      expr_initializer_rec(
-        ns.follow_tag(to_c_enum_tag_type(type)),
-        source_location);
+    exprt result = expr_initializer_rec(
+      ns.follow_tag(to_c_enum_tag_type(type)), source_location);
+
+    // use the tag type
+    result.type() = type;
+
+    return result;
   }
   else if(type_id==ID_struct_tag)
   {


### PR DESCRIPTION
- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [n/a] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message). TODO
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
