### PR TITLE
dot: use irep_idt for function identifier [blocks: #3126]

### DIFF
--- a/src/goto-instrument/dot.cpp
+++ b/src/goto-instrument/dot.cpp
@@ -44,10 +44,8 @@ protected:
   std::list<exprt> function_calls;
   std::list<exprt> clusters;
 
-  void write_dot_subgraph(
-    std::ostream &,
-    const std::string &,
-    const goto_programt &);
+  void
+  write_dot_subgraph(std::ostream &, const irep_idt &, const goto_programt &);
 
   void do_dot_function_calls(std::ostream &);
 
@@ -64,21 +62,23 @@ protected:
                  std::set<goto_programt::const_targett> &);
 };
 
-/// writes the dot graph that corresponds to the goto program to the output
+/// Write the dot graph that corresponds to the goto program to the output
 /// stream.
-/// \par parameters: output stream, name and goto program
+/// \param out: output stream
+/// \param function_id: name of \p goto_program
+/// \param goto_program: goto program the dot graph of which is written
 /// \return true on error, false otherwise
 void dott::write_dot_subgraph(
   std::ostream &out,
-  const std::string &name,
+  const irep_idt &function_id,
   const goto_programt &goto_program)
 {
   clusters.push_back(exprt("cluster"));
-  clusters.back().set("name", name);
+  clusters.back().set("name", function_id);
   clusters.back().set("nr", subgraphscount);
 
-  out << "subgraph \"cluster_" << name << "\" {\n";
-  out << "label=\"" << name << "\";\n";
+  out << "subgraph \"cluster_" << function_id << "\" {\n";
+  out << "label=\"" << function_id << "\";\n";
 
   const goto_programt::instructionst &instructions =
     goto_program.instructions;
@@ -111,7 +111,7 @@ void dott::write_dot_subgraph(
           tmp.str("Goto");
         else
         {
-          std::string t = from_expr(ns, it->function, it->guard);
+          std::string t = from_expr(ns, function_id, it->guard);
           while(t[ t.size()-1 ]=='\n')
             t = t.substr(0, t.size()-1);
           tmp << escape(t) << "?";
@@ -119,14 +119,14 @@ void dott::write_dot_subgraph(
       }
       else if(it->is_assume())
       {
-        std::string t = from_expr(ns, it->function, it->guard);
+        std::string t = from_expr(ns, function_id, it->guard);
         while(t[ t.size()-1 ]=='\n')
           t = t.substr(0, t.size()-1);
         tmp << "Assume\\n(" << escape(t) << ")";
       }
       else if(it->is_assert())
       {
-        std::string t = from_expr(ns, it->function, it->guard);
+        std::string t = from_expr(ns, function_id, it->guard);
         while(t[ t.size()-1 ]=='\n')
           t = t.substr(0, t.size()-1);
         tmp << "Assert\\n(" << escape(t) << ")";
@@ -145,7 +145,7 @@ void dott::write_dot_subgraph(
         tmp.str("Atomic End");
       else if(it->is_function_call())
       {
-        std::string t = from_expr(ns, it->function, it->code);
+        std::string t = from_expr(ns, function_id, it->code);
         while(t[ t.size()-1 ]=='\n')
           t = t.substr(0, t.size()-1);
         tmp.str(escape(t));
@@ -162,7 +162,7 @@ void dott::write_dot_subgraph(
               it->is_return() ||
               it->is_other())
       {
-        std::string t = from_expr(ns, it->function, it->code);
+        std::string t = from_expr(ns, function_id, it->code);
         while(t[ t.size()-1 ]=='\n')
           t = t.substr(0, t.size()-1);
         tmp.str(escape(t));
@@ -266,7 +266,7 @@ void dott::output(std::ostream &out)
 
   forall_goto_functions(it, goto_model.goto_functions)
     if(it->second.body_available())
-      write_dot_subgraph(out, id2string(it->first), it->second.body);
+      write_dot_subgraph(out, it->first, it->second.body);
 
   do_dot_function_calls(out);
 


### PR DESCRIPTION
We are working towards removing the "function" field from
goto_programt::instructionst::instructiont. Thus we should use an available
function identifier, rather than reading it from instructiont, where possible.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
