### PR TITLE
goto_check() now gets function identifier [blocks: #3126]

### DIFF
--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -806,7 +806,8 @@ void jbmc_parse_optionst::process_goto_function(
     }
 
     // add generic checks
-    goto_check(ns, options, ID_java, function.get_goto_function());
+    goto_check(
+      function.get_function_id(), function.get_goto_function(), ns, options);
 
     // Replace Java new side effects
     remove_java_new(goto_function, symbol_table, get_message_handler());

--- a/src/analyses/goto_check.h
+++ b/src/analyses/goto_check.h
@@ -24,10 +24,10 @@ void goto_check(
   goto_functionst &goto_functions);
 
 void goto_check(
+  const irep_idt &function_identifier,
+  goto_functionst::goto_functiont &goto_function,
   const namespacet &ns,
-  const optionst &options,
-  const irep_idt &mode,
-  goto_functionst::goto_functiont &goto_function);
+  const optionst &options);
 
 void goto_check(
   const optionst &options,


### PR DESCRIPTION
We are working towards removing the "function" field from
goto_programt::instructionst::instructiont, and thus need to pass the identifier
of the function whenever it actually is required. Consequently the mode is no
longer required as we can obtain it from the symbol table.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
