### PR TITLE
Coverage instrumentation now passes a function identifier [blocks: #3126]

### DIFF
--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -25,12 +25,14 @@ Date: May 2016
 #include "cover_basic_blocks.h"
 
 /// Applies instrumenters to given goto program
+/// \param function_id: name of \p goto_program
 /// \param goto_program: the goto program
 /// \param instrumenters: the instrumenters
 /// \param mode: mode of the function to instrument (for instance ID_C or
 ///   ID_java)
 /// \param message_handler: a message handler
 void instrument_cover_goals(
+  const irep_idt &function_id,
   goto_programt &goto_program,
   const cover_instrumenterst &instrumenters,
   const irep_idt &mode,
@@ -42,12 +44,14 @@ void instrument_cover_goals(
                     : std::unique_ptr<cover_blocks_baset>(
                         new cover_basic_blockst(goto_program));
 
-  basic_blocks->report_block_anomalies(goto_program, message_handler);
-  instrumenters(goto_program, *basic_blocks);
+  basic_blocks->report_block_anomalies(
+    function_id, goto_program, message_handler);
+  instrumenters(function_id, goto_program, *basic_blocks);
 }
 
 /// Instruments goto program for a given coverage criterion
 /// \param symbol_table: the symbol table
+/// \param function_id: name of \p goto_program
 /// \param goto_program: the goto program
 /// \param criterion: the coverage criterion
 /// \param message_handler: a message handler
@@ -57,6 +61,7 @@ void instrument_cover_goals(
 DEPRECATED("use instrument_cover_goals(goto_programt &...) instead")
 void instrument_cover_goals(
   const symbol_tablet &symbol_table,
+  const irep_idt &function_id,
   goto_programt &goto_program,
   coverage_criteriont criterion,
   message_handlert &message_handler)
@@ -68,7 +73,7 @@ void instrument_cover_goals(
   instrumenters.add_from_criterion(criterion, symbol_table, goal_filters);
 
   instrument_cover_goals(
-    goto_program, instrumenters, ID_unknown, message_handler);
+    function_id, goto_program, instrumenters, ID_unknown, message_handler);
 }
 
 /// Create and add an instrumenter based on the given criterion
@@ -249,7 +254,7 @@ std::unique_ptr<cover_configt> get_cover_config(
 /// Instruments a single goto program based on the given configuration
 /// \param cover_config: configuration, produced using get_cover_config
 /// \param function_id: function name
-/// \param function: function function to instrument
+/// \param function: function to instrument
 /// \param message_handler: log output
 static void instrument_cover_goals(
   const cover_configt &cover_config,
@@ -281,6 +286,7 @@ static void instrument_cover_goals(
   if(cover_config.function_filters(function_id, function))
   {
     instrument_cover_goals(
+      function_id,
       function.body,
       cover_config.cover_instrumenters,
       cover_config.mode,

--- a/src/goto-instrument/cover_basic_blocks.cpp
+++ b/src/goto-instrument/cover_basic_blocks.cpp
@@ -109,6 +109,7 @@ cover_basic_blockst::source_location_of(const std::size_t block_nr) const
 }
 
 void cover_basic_blockst::report_block_anomalies(
+  const irep_idt &function_id,
   const goto_programt &goto_program,
   message_handlert &message_handler)
 {
@@ -133,7 +134,7 @@ void cover_basic_blockst::report_block_anomalies(
       block_info.source_location.is_nil())
     {
       msg.warning() << "Ignoring block " << (block_nr + 1) << " location "
-                    << it->location_number << " " << it->function
+                    << it->location_number << " " << function_id
                     << " (missing source location)" << messaget::eom;
     }
     // The location numbers printed here are those

--- a/src/goto-instrument/cover_basic_blocks.h
+++ b/src/goto-instrument/cover_basic_blocks.h
@@ -43,13 +43,16 @@ public:
   virtual void output(std::ostream &out) const = 0;
 
   /// Output warnings about ignored blocks
+  /// \param function_id: name of \p goto_program
   /// \param goto_program: The goto program
   /// \param message_handler: The message handler
   virtual void report_block_anomalies(
+    const irep_idt &function_id,
     const goto_programt &goto_program,
     message_handlert &message_handler)
   {
     // unused parameters
+    (void)function_id;
     (void)goto_program;
     (void)message_handler;
   }
@@ -78,9 +81,11 @@ public:
   source_location_of(std::size_t block_nr) const override;
 
   /// Output warnings about ignored blocks
+  /// \param function_id: name of \p goto_program
   /// \param goto_program: The goto program
   /// \param message_handler: The message handler
   void report_block_anomalies(
+    const irep_idt &function_id,
     const goto_programt &goto_program,
     message_handlert &message_handler) override;
 

--- a/src/goto-instrument/cover_filter.cpp
+++ b/src/goto-instrument/cover_filter.cpp
@@ -14,24 +14,24 @@ Author: Peter Schrammel
 #include <linking/static_lifetime_init.h>
 
 /// Filter out functions that are not considered provided by the user
-/// \param identifier: a function name
+/// \param function_id: a function name
 /// \param goto_function: a goto function
 /// \return returns true if function is considered user-provided
 bool internal_functions_filtert::operator()(
-  const irep_idt &identifier,
+  const irep_idt &function_id,
   const goto_functionst::goto_functiont &goto_function) const
 {
-  if(identifier == goto_functionst::entry_point())
+  if(function_id == goto_functionst::entry_point())
     return false;
 
-  if(identifier == INITIALIZE_FUNCTION)
+  if(function_id == INITIALIZE_FUNCTION)
     return false;
 
   if(goto_function.is_hidden())
     return false;
 
   // ignore Java built-ins (synthetic functions)
-  if(has_prefix(id2string(identifier), "java::array["))
+  if(has_prefix(id2string(function_id), "java::array["))
     return false;
 
   // ignore if built-in library
@@ -44,16 +44,17 @@ bool internal_functions_filtert::operator()(
 }
 
 /// Filter functions whose name match the regex
-/// \param identifier: a function name
+/// \param function_id: a function name
 /// \param goto_function: a goto function
 /// \return returns true if the function name matches
 bool include_pattern_filtert::operator()(
-  const irep_idt &identifier,
+  const irep_idt &function_id,
   const goto_functionst::goto_functiont &goto_function) const
 {
   (void)goto_function; // unused parameter
   std::smatch string_matcher;
-  return std::regex_match(id2string(identifier), string_matcher, regex_matcher);
+  return std::regex_match(
+    id2string(function_id), string_matcher, regex_matcher);
 }
 
 /// Call a goto_program non-trivial if it has:
@@ -61,14 +62,14 @@ bool include_pattern_filtert::operator()(
 ///  * At least 2 branches
 ///  * At least 5 assignments
 /// These criteria are arbitrarily chosen.
-/// \param identifier: a function name
+/// \param function_id: name of \p goto_function
 /// \param goto_function: a goto function
 /// \return returns true if non-trivial
 bool trivial_functions_filtert::operator()(
-  const irep_idt &identifier,
+  const irep_idt &function_id,
   const goto_functionst::goto_functiont &goto_function) const
 {
-  (void)identifier; // unused parameter
+  (void)function_id; // unused parameter
   unsigned long count_assignments = 0, count_goto = 0;
   forall_goto_program_instructions(i_it, goto_function.body)
   {

--- a/src/goto-instrument/cover_instrument.h
+++ b/src/goto-instrument/cover_instrument.h
@@ -37,15 +37,17 @@ public:
   }
 
   /// Instruments a goto program
+  /// \param function_id: name of \p goto_program
   /// \param goto_program: a goto program
   /// \param basic_blocks: detected basic blocks
   virtual void operator()(
+    const irep_idt &function_id,
     goto_programt &goto_program,
     const cover_blocks_baset &basic_blocks) const
   {
     Forall_goto_program_instructions(i_it, goto_program)
     {
-      instrument(goto_program, i_it, basic_blocks);
+      instrument(function_id, goto_program, i_it, basic_blocks);
     }
   }
 
@@ -58,6 +60,7 @@ protected:
 
   /// Override this method to implement an instrumenter
   virtual void instrument(
+    const irep_idt &function_id,
     goto_programt &,
     goto_programt::targett &,
     const cover_blocks_baset &) const = 0;
@@ -65,13 +68,13 @@ protected:
   void initialize_source_location(
     goto_programt::targett t,
     const std::string &comment,
-    const irep_idt &function) const
+    const irep_idt &function_id) const
   {
     t->source_location.set_comment(comment);
     t->source_location.set(ID_coverage_criterion, coverage_criterion);
     t->source_location.set_property_class(property_class);
-    t->source_location.set_function(function);
-    t->function = function;
+    t->source_location.set_function(function_id);
+    t->function = function_id;
   }
 
   bool is_non_cover_assertion(goto_programt::const_targett t) const
@@ -91,14 +94,16 @@ public:
     const goal_filterst &);
 
   /// Applies all instrumenters to the given goto program
+  /// \param function_id: name of \p goto_program
   /// \param goto_program: a goto program
   /// \param basic_blocks: detected basic blocks of the goto program
   void operator()(
+    const irep_idt &function_id,
     goto_programt &goto_program,
     const cover_blocks_baset &basic_blocks) const
   {
     for(const auto &instrumenter : instrumenters)
-      (*instrumenter)(goto_program, basic_blocks);
+      (*instrumenter)(function_id, goto_program, basic_blocks);
   }
 
 private:
@@ -118,6 +123,7 @@ public:
 
 protected:
   void instrument(
+    const irep_idt &function_id,
     goto_programt &,
     goto_programt::targett &,
     const cover_blocks_baset &) const override;
@@ -136,6 +142,7 @@ public:
 
 protected:
   void instrument(
+    const irep_idt &function_id,
     goto_programt &,
     goto_programt::targett &,
     const cover_blocks_baset &) const override;
@@ -154,6 +161,7 @@ public:
 
 protected:
   void instrument(
+    const irep_idt &function_id,
     goto_programt &,
     goto_programt::targett &,
     const cover_blocks_baset &) const override;
@@ -172,6 +180,7 @@ public:
 
 protected:
   void instrument(
+    const irep_idt &function_id,
     goto_programt &,
     goto_programt::targett &,
     const cover_blocks_baset &) const override;
@@ -190,6 +199,7 @@ public:
 
 protected:
   void instrument(
+    const irep_idt &function_id,
     goto_programt &,
     goto_programt::targett &,
     const cover_blocks_baset &) const override;
@@ -208,6 +218,7 @@ public:
 
 protected:
   void instrument(
+    const irep_idt &function_id,
     goto_programt &,
     goto_programt::targett &,
     const cover_blocks_baset &) const override;
@@ -226,6 +237,7 @@ public:
 
 protected:
   void instrument(
+    const irep_idt &function_id,
     goto_programt &,
     goto_programt::targett &,
     const cover_blocks_baset &) const override;
@@ -244,13 +256,14 @@ public:
 
 protected:
   void instrument(
+    const irep_idt &function_id,
     goto_programt &,
     goto_programt::targett &,
     const cover_blocks_baset &) const override;
 };
 
 void cover_instrument_end_of_function(
-  const irep_idt &function,
+  const irep_idt &function_id,
   goto_programt &goto_program);
 
 #endif // CPROVER_GOTO_INSTRUMENT_COVER_INSTRUMENT_H

--- a/src/goto-instrument/cover_instrument_branch.cpp
+++ b/src/goto-instrument/cover_instrument_branch.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening
 #include "cover_basic_blocks.h"
 
 void cover_branch_instrumentert::instrument(
+  const irep_idt &function_id,
   goto_programt &goto_program,
   goto_programt::targett &i_it,
   const cover_blocks_baset &basic_blocks) const
@@ -31,7 +32,7 @@ void cover_branch_instrumentert::instrument(
     goto_programt::targett t = goto_program.insert_before(i_it);
     t->make_assertion(false_exprt());
     t->source_location = source_location;
-    initialize_source_location(t, comment, i_it->function);
+    initialize_source_location(t, comment, function_id);
   }
 
   if(
@@ -44,18 +45,17 @@ void cover_branch_instrumentert::instrument(
     std::string false_comment = "block " + b + " branch false";
 
     exprt guard = i_it->guard;
-    const irep_idt function = i_it->function;
     source_locationt source_location = i_it->source_location;
 
     goto_program.insert_before_swap(i_it);
     i_it->make_assertion(not_exprt(guard));
     i_it->source_location = source_location;
-    initialize_source_location(i_it, true_comment, function);
+    initialize_source_location(i_it, true_comment, function_id);
 
     goto_program.insert_before_swap(i_it);
     i_it->make_assertion(guard);
     i_it->source_location = source_location;
-    initialize_source_location(i_it, false_comment, function);
+    initialize_source_location(i_it, false_comment, function_id);
 
     std::advance(i_it, 2);
   }

--- a/src/goto-instrument/cover_instrument_condition.cpp
+++ b/src/goto-instrument/cover_instrument_condition.cpp
@@ -17,6 +17,7 @@ Author: Daniel Kroening
 #include "cover_basic_blocks.h"
 
 void cover_condition_instrumentert::instrument(
+  const irep_idt &function_id,
   goto_programt &goto_program,
   goto_programt::targett &i_it,
   const cover_blocks_baset &) const
@@ -33,20 +34,19 @@ void cover_condition_instrumentert::instrument(
 
     for(const auto &c : conditions)
     {
-      const std::string c_string = from_expr(ns, i_it->function, c);
+      const std::string c_string = from_expr(ns, function_id, c);
 
       const std::string comment_t = "condition `" + c_string + "' true";
-      const irep_idt function = i_it->function;
       goto_program.insert_before_swap(i_it);
       i_it->make_assertion(c);
       i_it->source_location = source_location;
-      initialize_source_location(i_it, comment_t, function);
+      initialize_source_location(i_it, comment_t, function_id);
 
       const std::string comment_f = "condition `" + c_string + "' false";
       goto_program.insert_before_swap(i_it);
       i_it->make_assertion(not_exprt(c));
       i_it->source_location = source_location;
-      initialize_source_location(i_it, comment_f, function);
+      initialize_source_location(i_it, comment_f, function_id);
     }
 
     for(std::size_t i = 0; i < conditions.size() * 2; i++)

--- a/src/goto-instrument/cover_instrument_decision.cpp
+++ b/src/goto-instrument/cover_instrument_decision.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening
 #include "cover_util.h"
 
 void cover_decision_instrumentert::instrument(
+  const irep_idt &function_id,
   goto_programt &goto_program,
   goto_programt::targett &i_it,
   const cover_blocks_baset &) const
@@ -32,20 +33,19 @@ void cover_decision_instrumentert::instrument(
 
     for(const auto &d : decisions)
     {
-      const std::string d_string = from_expr(ns, i_it->function, d);
+      const std::string d_string = from_expr(ns, function_id, d);
 
       const std::string comment_t = "decision `" + d_string + "' true";
-      const irep_idt function = i_it->function;
       goto_program.insert_before_swap(i_it);
       i_it->make_assertion(d);
       i_it->source_location = source_location;
-      initialize_source_location(i_it, comment_t, function);
+      initialize_source_location(i_it, comment_t, function_id);
 
       const std::string comment_f = "decision `" + d_string + "' false";
       goto_program.insert_before_swap(i_it);
       i_it->make_assertion(not_exprt(d));
       i_it->source_location = source_location;
-      initialize_source_location(i_it, comment_f, function);
+      initialize_source_location(i_it, comment_f, function_id);
     }
 
     // advance iterator beyond the inserted instructions

--- a/src/goto-instrument/cover_instrument_location.cpp
+++ b/src/goto-instrument/cover_instrument_location.cpp
@@ -15,6 +15,7 @@ Author: Daniel Kroening
 #include "cover_filter.h"
 
 void cover_location_instrumentert::instrument(
+  const irep_idt &function_id,
   goto_programt &goto_program,
   goto_programt::targett &i_it,
   const cover_blocks_baset &basic_blocks) const
@@ -28,18 +29,17 @@ void cover_location_instrumentert::instrument(
   if(representative_instruction && *representative_instruction == i_it)
   {
     const std::string b = std::to_string(block_nr + 1); // start with 1
-    const std::string id = id2string(i_it->function) + "#" + b;
+    const std::string id = id2string(function_id) + "#" + b;
     const auto source_location = basic_blocks.source_location_of(block_nr);
 
     // filter goals
     if(goal_filters(source_location))
     {
       const std::string comment = "block " + b;
-      const irep_idt function = i_it->function;
       goto_program.insert_before_swap(i_it);
       i_it->make_assertion(false_exprt());
       i_it->source_location = source_location;
-      initialize_source_location(i_it, comment, function);
+      initialize_source_location(i_it, comment, function_id);
       i_it++;
     }
   }

--- a/src/goto-instrument/cover_instrument_mcdc.cpp
+++ b/src/goto-instrument/cover_instrument_mcdc.cpp
@@ -620,6 +620,7 @@ void minimize_mcdc_controlling(
 }
 
 void cover_mcdc_instrumentert::instrument(
+  const irep_idt &function_id,
   goto_programt &goto_program,
   goto_programt::targett &i_it,
   const cover_blocks_baset &) const
@@ -656,18 +657,17 @@ void cover_mcdc_instrumentert::instrument(
                                   ? "decision/condition"
                                   : is_decision ? "decision" : "condition";
 
-      std::string p_string = from_expr(ns, i_it->function, p);
+      std::string p_string = from_expr(ns, function_id, p);
 
       std::string comment_t = description + " `" + p_string + "' true";
-      const irep_idt function = i_it->function;
       goto_program.insert_before_swap(i_it);
       i_it->make_assertion(not_exprt(p));
       i_it->source_location = source_location;
       i_it->source_location.set_comment(comment_t);
       i_it->source_location.set(ID_coverage_criterion, coverage_criterion);
       i_it->source_location.set_property_class(property_class);
-      i_it->source_location.set_function(function);
-      i_it->function = function;
+      i_it->source_location.set_function(function_id);
+      i_it->function = function_id;
 
       std::string comment_f = description + " `" + p_string + "' false";
       goto_program.insert_before_swap(i_it);
@@ -676,8 +676,8 @@ void cover_mcdc_instrumentert::instrument(
       i_it->source_location.set_comment(comment_f);
       i_it->source_location.set(ID_coverage_criterion, coverage_criterion);
       i_it->source_location.set_property_class(property_class);
-      i_it->source_location.set_function(function);
-      i_it->function = function;
+      i_it->source_location.set_function(function_id);
+      i_it->function = function_id;
     }
 
     std::set<exprt> controlling;
@@ -692,20 +692,19 @@ void cover_mcdc_instrumentert::instrument(
 
     for(const auto &p : controlling)
     {
-      std::string p_string = from_expr(ns, i_it->function, p);
+      std::string p_string = from_expr(ns, function_id, p);
 
       std::string description =
         "MC/DC independence condition `" + p_string + "'";
 
-      const irep_idt function = i_it->function;
       goto_program.insert_before_swap(i_it);
       i_it->make_assertion(not_exprt(p));
       i_it->source_location = source_location;
       i_it->source_location.set_comment(description);
       i_it->source_location.set(ID_coverage_criterion, coverage_criterion);
       i_it->source_location.set_property_class(property_class);
-      i_it->source_location.set_function(function);
-      i_it->function = function;
+      i_it->source_location.set_function(function_id);
+      i_it->function = function_id;
     }
 
     for(std::size_t i = 0; i < both.size() * 2 + controlling.size(); i++)

--- a/src/goto-instrument/cover_instrument_other.cpp
+++ b/src/goto-instrument/cover_instrument_other.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening
 #include "cover_util.h"
 
 void cover_path_instrumentert::instrument(
+  const irep_idt &,
   goto_programt &,
   goto_programt::targett &i_it,
   const cover_blocks_baset &) const
@@ -27,6 +28,7 @@ void cover_path_instrumentert::instrument(
 }
 
 void cover_assertion_instrumentert::instrument(
+  const irep_idt &function_id,
   goto_programt &,
   goto_programt::targett &i_it,
   const cover_blocks_baset &) const
@@ -36,11 +38,12 @@ void cover_assertion_instrumentert::instrument(
   {
     i_it->guard = false_exprt();
     initialize_source_location(
-      i_it, id2string(i_it->source_location.get_comment()), i_it->function);
+      i_it, id2string(i_it->source_location.get_comment()), function_id);
   }
 }
 
 void cover_cover_instrumentert::instrument(
+  const irep_idt &function_id,
   goto_programt &,
   goto_programt::targett &i_it,
   const cover_blocks_baset &) const
@@ -57,12 +60,11 @@ void cover_cover_instrumentert::instrument(
       code_function_call.arguments().size() == 1)
     {
       const exprt c = code_function_call.arguments()[0];
-      std::string comment =
-        "condition `" + from_expr(ns, i_it->function, c) + "'";
+      std::string comment = "condition `" + from_expr(ns, function_id, c) + "'";
       i_it->guard = not_exprt(c);
       i_it->type = ASSERT;
       i_it->code.clear();
-      initialize_source_location(i_it, comment, i_it->function);
+      initialize_source_location(i_it, comment, function_id);
     }
   }
   else if(is_non_cover_assertion(i_it))
@@ -70,7 +72,7 @@ void cover_cover_instrumentert::instrument(
 }
 
 void cover_instrument_end_of_function(
-  const irep_idt &function,
+  const irep_idt &function_id,
   goto_programt &goto_program)
 {
   auto if_it = goto_program.instructions.end();
@@ -83,6 +85,6 @@ void cover_instrument_end_of_function(
   if_it->make_assertion(false_exprt());
   if_it->source_location.set_comment(comment);
   if_it->source_location.set_property_class("reachability_constraint");
-  if_it->source_location.set_function(function);
-  if_it->function = function;
+  if_it->source_location.set_function(function_id);
+  if_it->function = function_id;
 }


### PR DESCRIPTION
We are working towards removing the "function" field from
goto_programt::instructionst::instructiont, and thus need to pass the identifier
of the function whenever it actually is required.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
