### PR TITLE
as_string() on instructions now takes function identifier [blocks: #3126]

### DIFF
--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -403,6 +403,7 @@ std::list<exprt> objects_written(
 
 std::string as_string(
   const class namespacet &ns,
+  const irep_idt &function,
   const goto_programt::instructiont &i)
 {
   std::string result;
@@ -415,9 +416,7 @@ std::string as_string(
   case GOTO:
     if(!i.guard.is_true())
     {
-      result+="IF "
-            +from_expr(ns, i.function, i.guard)
-            +" THEN ";
+      result += "IF " + from_expr(ns, function, i.guard) + " THEN ";
     }
 
     result+="GOTO ";
@@ -439,7 +438,7 @@ std::string as_string(
   case DEAD:
   case FUNCTION_CALL:
   case ASSIGN:
-    return from_expr(ns, i.function, i.code);
+    return from_expr(ns, function, i.code);
 
   case ASSUME:
   case ASSERT:
@@ -448,7 +447,7 @@ std::string as_string(
     else
       result+="ASSERT ";
 
-    result+=from_expr(ns, i.function, i.guard);
+    result += from_expr(ns, function, i.guard);
 
     {
       const irep_idt &comment=i.source_location.get_comment();

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -833,6 +833,7 @@ std::list<exprt> expressions_written(const goto_programt::instructiont &);
 
 std::string as_string(
   const namespacet &ns,
+  const irep_idt &function,
   const goto_programt::instructiont &);
 
 #endif // CPROVER_GOTO_PROGRAMS_GOTO_PROGRAM_H

--- a/src/goto-programs/goto_trace.cpp
+++ b/src/goto-programs/goto_trace.cpp
@@ -333,7 +333,7 @@ void show_state_header(
 
   if(options.show_code)
   {
-    out << as_string(ns, *state.pc) << '\n';
+    out << as_string(ns, state.function, *state.pc) << '\n';
     out << "----------------------------------------------------" << '\n';
   }
 }


### PR DESCRIPTION
We are working towards removing the "function" field from
goto_programt::instructionst::instructiont, and thus need to pass the identifier
of the function whenever it actually is required.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
