### PR TITLE
goto_unwindt now takes function identifier [blocks: #3126]

### DIFF
--- a/src/goto-instrument/k_induction.cpp
+++ b/src/goto-instrument/k_induction.cpp
@@ -24,21 +24,25 @@ Author: Daniel Kroening, kroening@kroening.com
 class k_inductiont
 {
 public:
-  typedef goto_functionst::goto_functiont goto_functiont;
-
   k_inductiont(
+    const irep_idt &_function_id,
     goto_functiont &_goto_function,
-    bool _base_case, bool _step_case,
-    unsigned _k):
-    goto_function(_goto_function),
-    local_may_alias(_goto_function),
-    natural_loops(_goto_function.body),
-    base_case(_base_case), step_case(_step_case), k(_k)
+    bool _base_case,
+    bool _step_case,
+    unsigned _k)
+    : function_id(_function_id),
+      goto_function(_goto_function),
+      local_may_alias(_goto_function),
+      natural_loops(_goto_function.body),
+      base_case(_base_case),
+      step_case(_step_case),
+      k(_k)
   {
     k_induction();
   }
 
 protected:
+  const irep_idt &function_id;
   goto_functiont &goto_function;
   local_may_aliast local_may_alias;
   natural_loops_mutablet natural_loops;
@@ -70,8 +74,13 @@ void k_inductiont::process_loop(
   {
     // now unwind k times
     goto_unwindt goto_unwind;
-    goto_unwind.unwind(goto_function.body, loop_head, loop_exit, k,
-                       goto_unwindt::unwind_strategyt::PARTIAL);
+    goto_unwind.unwind(
+      function_id,
+      goto_function.body,
+      loop_head,
+      loop_exit,
+      k,
+      goto_unwindt::unwind_strategyt::PARTIAL);
 
     // assume the loop condition has become false
     goto_programt::instructiont assume(ASSUME);
@@ -96,10 +105,11 @@ void k_inductiont::process_loop(
 
     goto_unwindt goto_unwind;
     goto_unwind.unwind(
+      function_id,
       goto_function.body,
       loop_head,
       loop_exit,
-      k+1,
+      k + 1,
       goto_unwindt::unwind_strategyt::PARTIAL,
       iteration_points);
 
@@ -155,5 +165,5 @@ void k_induction(
   unsigned k)
 {
   Forall_goto_functions(it, goto_model.goto_functions)
-    k_inductiont(it->second, base_case, step_case, k);
+    k_inductiont(it->first, it->second, base_case, step_case, k);
 }

--- a/src/goto-instrument/unwind.cpp
+++ b/src/goto-instrument/unwind.cpp
@@ -80,6 +80,7 @@ void goto_unwindt::copy_segment(
 }
 
 void goto_unwindt::unwind(
+  const irep_idt &function_id,
   goto_programt &goto_program,
   const goto_programt::const_targett loop_head,
   const goto_programt::const_targett loop_exit,
@@ -87,11 +88,18 @@ void goto_unwindt::unwind(
   const unwind_strategyt unwind_strategy)
 {
   std::vector<goto_programt::targett> iteration_points;
-  unwind(goto_program, loop_head, loop_exit, k, unwind_strategy,
-         iteration_points);
+  unwind(
+    function_id,
+    goto_program,
+    loop_head,
+    loop_exit,
+    k,
+    unwind_strategy,
+    iteration_points);
 }
 
 void goto_unwindt::unwind(
+  const irep_idt &function_id,
   goto_programt &goto_program,
   const goto_programt::const_targett loop_head,
   const goto_programt::const_targett loop_exit,
@@ -258,6 +266,7 @@ void goto_unwindt::unwind(
 }
 
 void goto_unwindt::unwind(
+  const irep_idt &function_id,
   goto_programt &goto_program,
   const unwindsett &unwindset,
   const unwind_strategyt unwind_strategy)
@@ -278,11 +287,9 @@ void goto_unwindt::unwind(
       continue;
     }
 
-    const irep_idt func=i_it->function;
-    assert(!func.empty());
-
-    const irep_idt loop_id=
-      id2string(func) + "." + std::to_string(i_it->loop_number);
+    PRECONDITION(!function_id.empty());
+    const irep_idt loop_id =
+      id2string(function_id) + "." + std::to_string(i_it->loop_number);
 
     auto limit=unwindset.get_limit(loop_id, 0);
 
@@ -298,7 +305,8 @@ void goto_unwindt::unwind(
     loop_exit++;
     assert(loop_exit!=goto_program.instructions.end());
 
-    unwind(goto_program, loop_head, loop_exit, *limit, unwind_strategy);
+    unwind(
+      function_id, goto_program, loop_head, loop_exit, *limit, unwind_strategy);
 
     // necessary as we change the goto program in the previous line
     i_it=loop_exit;
@@ -323,7 +331,7 @@ void goto_unwindt::operator()(
 
     goto_programt &goto_program=goto_function.body;
 
-    unwind(goto_program, unwindset, unwind_strategy);
+    unwind(it->first, goto_program, unwindset, unwind_strategy);
   }
 }
 

--- a/src/goto-instrument/unwind.h
+++ b/src/goto-instrument/unwind.h
@@ -28,6 +28,7 @@ public:
   // unwind loop
 
   void unwind(
+    const irep_idt &function_id,
     goto_programt &goto_program,
     const goto_programt::const_targett loop_head,
     const goto_programt::const_targett loop_exit,
@@ -35,6 +36,7 @@ public:
     const unwind_strategyt unwind_strategy);
 
   void unwind(
+    const irep_idt &function_id,
     goto_programt &goto_program,
     const goto_programt::const_targett loop_head,
     const goto_programt::const_targett loop_exit,
@@ -45,9 +47,10 @@ public:
   // unwind function
 
   void unwind(
+    const irep_idt &function_id,
     goto_programt &goto_program,
     const unwindsett &unwindset,
-    const unwind_strategyt unwind_strategy=unwind_strategyt::PARTIAL);
+    const unwind_strategyt unwind_strategy = unwind_strategyt::PARTIAL);
 
   // unwind all functions
   void operator()(


### PR DESCRIPTION
We are working towards removing the "function" field from
goto_programt::instructionst::instructiont, and thus need to pass the identifier
of the function whenever it actually is required.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
