### PR TITLE
remove_exceptions now takes function identifier [blocks: #3126]

### DIFF
--- a/jbmc/src/java_bytecode/remove_exceptions.h
+++ b/jbmc/src/java_bytecode/remove_exceptions.h
@@ -27,6 +27,7 @@ Date:   December 2016
 /// and adds the required instrumentation (GOTOs and assignments)
 /// This introduces instanceof expressions.
 void remove_exceptions_using_instanceof(
+  const irep_idt &function_identifier,
   goto_programt &,
   symbol_table_baset &,
   message_handlert &);
@@ -40,6 +41,7 @@ void remove_exceptions_using_instanceof(goto_modelt &, message_handlert &);
 /// and adds the required instrumentation (GOTOs and assignments)
 /// This does not introduce instanceof expressions.
 void remove_exceptions(
+  const irep_idt &function_identifier,
   goto_programt &,
   symbol_table_baset &,
   const class_hierarchyt &,

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -799,6 +799,7 @@ void jbmc_parse_optionst::process_goto_function(
       // the results are slightly worse than running it in whole-program mode
       // (e.g. dead catch sites will be retained)
       remove_exceptions(
+        function.get_function_id(),
         goto_function.body,
         symbol_table,
         *class_hierarchy.get(),


### PR DESCRIPTION
We are working towards removing the "function" field from
goto_programt::instructionst::instructiont, and thus need to pass the identifier
of the function whenever it actually is required.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
