### PR TITLE
remove_instanceof now takes function identifier [depends-on: #3835, blocks: #3126]

### DIFF
--- a/jbmc/src/java_bytecode/remove_exceptions.cpp
+++ b/jbmc/src/java_bytecode/remove_exceptions.cpp
@@ -364,6 +364,7 @@ void remove_exceptionst::add_exception_dispatch_sequence(
         if(remove_added_instanceof)
         {
           remove_instanceof(
+            function_identifier,
             t_exc,
             goto_program,
             symbol_table,

--- a/jbmc/src/java_bytecode/remove_instanceof.cpp
+++ b/jbmc/src/java_bytecode/remove_instanceof.cpp
@@ -35,10 +35,13 @@ public:
   }
 
   // Lower instanceof for a single function
-  bool lower_instanceof(goto_programt &);
+  bool lower_instanceof(const irep_idt &function_identifier, goto_programt &);
 
   // Lower instanceof for a single instruction
-  bool lower_instanceof(goto_programt &, goto_programt::targett);
+  bool lower_instanceof(
+    const irep_idt &function_identifier,
+    goto_programt &,
+    goto_programt::targett);
 
 protected:
   symbol_table_baset &symbol_table;
@@ -47,17 +50,22 @@ protected:
   message_handlert &message_handler;
 
   bool lower_instanceof(
-    exprt &, goto_programt &, goto_programt::targett);
+    const irep_idt &function_identifier,
+    exprt &,
+    goto_programt &,
+    goto_programt::targett);
 };
 
 /// Replaces an expression like e instanceof A with e.\@class_identifier == "A"
 /// or a big-or of similar expressions if we know of subtypes that also satisfy
 /// the given test.
+/// \param function_identifier: name of the goto function \p goto_program
 /// \param expr: Expression to lower (the code or the guard of an instruction)
 /// \param goto_program: program the expression belongs to
 /// \param this_inst: instruction the expression is found at
 /// \return true if any instanceof instructionw was replaced
 bool remove_instanceoft::lower_instanceof(
+  const irep_idt &function_identifier,
   exprt &expr,
   goto_programt &goto_program,
   goto_programt::targett this_inst)
@@ -66,7 +74,8 @@ bool remove_instanceoft::lower_instanceof(
   {
     bool changed = false;
     Forall_operands(it, expr)
-      changed |= lower_instanceof(*it, goto_program, this_inst);
+      changed |=
+        lower_instanceof(function_identifier, *it, goto_program, this_inst);
     return changed;
   }
 
@@ -109,7 +118,7 @@ bool remove_instanceoft::lower_instanceof(
 
   symbolt &clsid_tmp_sym = get_fresh_aux_symbol(
     object_clsid.type(),
-    id2string(this_inst->function),
+    id2string(function_identifier),
     "class_identifier_tmp",
     source_locationt(),
     ID_java,
@@ -117,7 +126,7 @@ bool remove_instanceoft::lower_instanceof(
 
   symbolt &instanceof_result_sym = get_fresh_aux_symbol(
     bool_typet(),
-    id2string(this_inst->function),
+    id2string(function_identifier),
     "instanceof_result_tmp",
     source_locationt(),
     ID_java,
@@ -188,10 +197,12 @@ static bool contains_instanceof(const exprt &e)
 /// Replaces expressions like e instanceof A with e.\@class_identifier == "A"
 /// or a big-or of similar expressions if we know of subtypes that also satisfy
 /// the given test. Does this for the code or guard at a specific instruction.
+/// \param function_identifier: name of the goto function \p goto_program
 /// \param goto_program: program to process
 /// \param target: instruction to check for instanceof expressions
 /// \return true if an instanceof has been replaced
 bool remove_instanceoft::lower_instanceof(
+  const irep_idt &function_identifier,
   goto_programt &goto_program,
   goto_programt::targett target)
 {
@@ -207,16 +218,21 @@ bool remove_instanceoft::lower_instanceof(
     ++target;
   }
 
-  return lower_instanceof(target->code, goto_program, target) |
-    lower_instanceof(target->guard, goto_program, target);
+  return lower_instanceof(
+           function_identifier, target->code, goto_program, target) |
+         lower_instanceof(
+           function_identifier, target->guard, goto_program, target);
 }
 
 /// Replace every instanceof in the passed function body with an explicit
 /// class-identifier test.
 /// Extra auxiliary variables may be introduced into symbol_table.
+/// \param function_identifier: name of the goto function \p goto_program
 /// \param goto_program: The function body to work on.
 /// \return true if one or more instanceof expressions have been replaced
-bool remove_instanceoft::lower_instanceof(goto_programt &goto_program)
+bool remove_instanceoft::lower_instanceof(
+  const irep_idt &function_identifier,
+  goto_programt &goto_program)
 {
   bool changed=false;
   for(goto_programt::instructionst::iterator target=
@@ -224,7 +240,8 @@ bool remove_instanceoft::lower_instanceof(goto_programt &goto_program)
     target!=goto_program.instructions.end();
     ++target)
   {
-    changed=lower_instanceof(goto_program, target) || changed;
+    changed =
+      lower_instanceof(function_identifier, goto_program, target) || changed;
   }
   if(!changed)
     return false;
@@ -235,12 +252,14 @@ bool remove_instanceoft::lower_instanceof(goto_programt &goto_program)
 /// Replace an instanceof in the expression or guard of the passed instruction
 /// of the given function body with an explicit class-identifier test.
 /// \remarks Extra auxiliary variables may be introduced into symbol_table.
+/// \param function_identifier: name of the goto function \p goto_program
 /// \param target: The instruction to work on.
 /// \param goto_program: The function body containing the instruction.
 /// \param symbol_table: The symbol table to add symbols to.
 /// \param class_hierarchy: class hierarchy analysis of symbol_table
 /// \param message_handler: logging output
 void remove_instanceof(
+  const irep_idt &function_identifier,
   goto_programt::targett target,
   goto_programt &goto_program,
   symbol_table_baset &symbol_table,
@@ -248,24 +267,26 @@ void remove_instanceof(
   message_handlert &message_handler)
 {
   remove_instanceoft rem(symbol_table, class_hierarchy, message_handler);
-  rem.lower_instanceof(goto_program, target);
+  rem.lower_instanceof(function_identifier, goto_program, target);
 }
 
 /// Replace every instanceof in the passed function with an explicit
 /// class-identifier test.
 /// \remarks Extra auxiliary variables may be introduced into symbol_table.
+/// \param function_identifier: name of the goto function \p function
 /// \param function: The function to work on.
 /// \param symbol_table: The symbol table to add symbols to.
 /// \param class_hierarchy: class hierarchy analysis of symbol_table
 /// \param message_handler: logging output
 void remove_instanceof(
+  const irep_idt &function_identifier,
   goto_functionst::goto_functiont &function,
   symbol_table_baset &symbol_table,
   const class_hierarchyt &class_hierarchy,
   message_handlert &message_handler)
 {
   remove_instanceoft rem(symbol_table, class_hierarchy, message_handler);
-  rem.lower_instanceof(function.body);
+  rem.lower_instanceof(function_identifier, function.body);
 }
 
 /// Replace every instanceof in every function with an explicit
@@ -284,7 +305,7 @@ void remove_instanceof(
   remove_instanceoft rem(symbol_table, class_hierarchy, message_handler);
   bool changed=false;
   for(auto &f : goto_functions.function_map)
-    changed=rem.lower_instanceof(f.second.body) || changed;
+    changed = rem.lower_instanceof(f.first, f.second.body) || changed;
   if(changed)
     goto_functions.compute_location_numbers();
 }

--- a/jbmc/src/java_bytecode/remove_instanceof.h
+++ b/jbmc/src/java_bytecode/remove_instanceof.h
@@ -87,6 +87,7 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 #include <util/symbol_table.h>
 
 void remove_instanceof(
+  const irep_idt &function_identifier,
   goto_programt::targett target,
   goto_programt &goto_program,
   symbol_table_baset &symbol_table,
@@ -94,6 +95,7 @@ void remove_instanceof(
   message_handlert &);
 
 void remove_instanceof(
+  const irep_idt &function_identifier,
   goto_functionst::goto_functiont &function,
   symbol_table_baset &symbol_table,
   const class_hierarchyt &class_hierarchy,

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -771,7 +771,11 @@ void jbmc_parse_optionst::process_goto_function(
   {
     // Removal of RTTI inspection:
     remove_instanceof(
-      goto_function, symbol_table, *class_hierarchy, get_message_handler());
+      function.get_function_id(),
+      goto_function,
+      symbol_table,
+      *class_hierarchy,
+      get_message_handler());
     // Java virtual functions -> explicit dispatch tables:
     remove_virtual_functions(function);
 

--- a/jbmc/unit/java_bytecode/java_replace_nondet/replace_nondet.cpp
+++ b/jbmc/unit/java_bytecode/java_replace_nondet/replace_nondet.cpp
@@ -143,7 +143,11 @@ void load_and_test_method(
   // is called.
   class_hierarchyt class_hierarchy(symbol_table);
   remove_instanceof(
-    goto_function, symbol_table, class_hierarchy, null_message_handler);
+    function_name,
+    goto_function,
+    symbol_table,
+    class_hierarchy,
+    null_message_handler);
 
   remove_virtual_functions(model_function);
 


### PR DESCRIPTION
We are working towards removing the "function" field from
goto_programt::instructionst::instructiont, and thus need to pass the identifier
of the function whenever it actually is required.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
