### PR TITLE
convert_java_nondet passes down function identifier [blocks: #3126]

### DIFF
--- a/jbmc/src/java_bytecode/convert_java_nondet.cpp
+++ b/jbmc/src/java_bytecode/convert_java_nondet.cpp
@@ -68,6 +68,7 @@ static goto_programt get_gen_nondet_init_instructions(
 /// Checks an instruction to see whether it contains an assignment from
 /// side_effect_expr_nondet.  If so, replaces the instruction with a range of
 /// instructions to properly nondet-initialize the lhs.
+/// \param function_identifier: Name of the function containing \p target.
 /// \param goto_program: The goto program to modify.
 /// \param target: One of the steps in that goto program.
 /// \param symbol_table: The global symbol table.
@@ -78,6 +79,7 @@ static goto_programt get_gen_nondet_init_instructions(
 /// \return The next instruction to process with this function and a boolean
 ///   indicating whether any changes were made to the goto program.
 static std::pair<goto_programt::targett, bool> insert_nondet_init_code(
+  const irep_idt &function_identifier,
   goto_programt &goto_program,
   const goto_programt::targett &target,
   symbol_table_baset &symbol_table,
@@ -116,7 +118,7 @@ static std::pair<goto_programt::targett, bool> insert_nondet_init_code(
 
     symbolt &aux_symbol = get_fresh_aux_symbol(
       op.type(),
-      id2string(goto_programt::get_function_id(goto_program)),
+      id2string(function_identifier),
       "nondet_tmp",
       source_loc,
       ID_java,
@@ -162,6 +164,7 @@ static std::pair<goto_programt::targett, bool> insert_nondet_init_code(
 /// For each instruction in the goto program, checks if it is an assignment from
 /// nondet and replaces it with the appropriate composite initialization code if
 /// so.
+/// \param function_identifier: Name of the function \p goto_program.
 /// \param goto_program: The goto program to modify.
 /// \param symbol_table: The global symbol table.
 /// \param message_handler: Handles logging.
@@ -169,6 +172,7 @@ static std::pair<goto_programt::targett, bool> insert_nondet_init_code(
 ///   objects.
 /// \param mode: Language mode
 void convert_nondet(
+  const irep_idt &function_identifier,
   goto_programt &goto_program,
   symbol_table_baset &symbol_table,
   message_handlert &message_handler,
@@ -181,6 +185,7 @@ void convert_nondet(
   while(instruction_iterator != goto_program.instructions.end())
   {
     auto ret = insert_nondet_init_code(
+      function_identifier,
       goto_program,
       instruction_iterator,
       symbol_table,
@@ -206,6 +211,7 @@ void convert_nondet(
   java_object_factory_parameterst parameters = object_factory_parameters;
   parameters.function_id = function.get_function_id();
   convert_nondet(
+    function.get_function_id(),
     function.get_goto_function().body,
     function.get_symbol_table(),
     message_handler,
@@ -232,6 +238,7 @@ void convert_nondet(
       java_object_factory_parameterst parameters = object_factory_parameters;
       parameters.function_id = f_it.first;
       convert_nondet(
+        f_it.first,
         f_it.second.body,
         symbol_table,
         message_handler,


### PR DESCRIPTION
We are working towards removing the "function" field from
goto_programt::instructionst::instructiont, and thus need to pass the identifier
of the function whenever it actually is required.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
