### PR TITLE
Weak-memory-model instrumentation: do not use instructiont::function [blocks: #3126]

### DIFF
--- a/src/goto-instrument/wmm/goto2graph.h
+++ b/src/goto-instrument/wmm/goto2graph.h
@@ -114,16 +114,20 @@ protected:
     void visit_cfg_thread() const;
     void visit_cfg_propagate(goto_programt::instructionst::iterator i_it);
     void visit_cfg_body(
+      const goto_programt &goto_program,
       goto_programt::const_targett i_it,
       loop_strategyt replicate_body,
       value_setst &value_sets
-      #ifdef LOCAL_MAY
-      , local_may_aliast &local_may
-      #endif
+#ifdef LOCAL_MAY
+      ,
+      local_may_aliast &local_may
+#endif
     ); // deprecated  NOLINT(whitespace/parens)
     void inline visit_cfg_backedge(goto_programt::const_targett targ,
       goto_programt::const_targett i_it);
-    void inline visit_cfg_duplicate(goto_programt::const_targett targ,
+    void inline visit_cfg_duplicate(
+      const goto_programt &goto_program,
+      goto_programt::const_targett targ,
       goto_programt::const_targett i_it);
     void visit_cfg_assign(
       value_setst &value_sets,
@@ -144,14 +148,16 @@ protected:
       bool no_dependenciess,
       loop_strategyt duplicate_body);
     void visit_cfg_goto(
+      const goto_programt &goto_program,
       goto_programt::instructionst::iterator i_it,
       /* forces the duplication of all the loops, with array or not
          otherwise, duplication of loops with array accesses only */
       loop_strategyt replicate_body,
       value_setst &value_sets
-      #ifdef LOCAL_MAY
-      , local_may_aliast &local_may
-      #endif
+#ifdef LOCAL_MAY
+      ,
+      local_may_aliast &local_may
+#endif
     ); // NOLINT(whitespace/parens)
     void visit_cfg_reference_function(irep_idt id_function);
 
@@ -224,16 +230,16 @@ protected:
       coming_from = 0;
     }
 
-    void inline enter_function(const irep_idt &function)
+    void inline enter_function(const irep_idt &function_id)
     {
-      if(functions_met.find(function)!=functions_met.end())
+      if(functions_met.find(function_id) != functions_met.end())
         throw "sorry, doesn't handle recursive function for the moment";
-      functions_met.insert(function);
+      functions_met.insert(function_id);
     }
 
-    void inline leave_function(const irep_idt &function)
+    void inline leave_function(const irep_idt &function_id)
     {
-      functions_met.erase(function);
+      functions_met.erase(function_id);
     }
 
     void inline visit_cfg(
@@ -241,17 +247,22 @@ protected:
       memory_modelt model,
       bool no_dependencies,
       loop_strategyt duplicate_body,
-      const irep_idt &function)
+      const irep_idt &function_id)
     {
       /* ignore recursive calls -- underapproximation */
       try
       {
         /* forbids recursive function */
-        enter_function(function);
+        enter_function(function_id);
         std::set<nodet> end_out;
-        visit_cfg_function(value_sets, model, no_dependencies, duplicate_body,
-          function, end_out);
-        leave_function(function);
+        visit_cfg_function(
+          value_sets,
+          model,
+          no_dependencies,
+          duplicate_body,
+          function_id,
+          end_out);
+        leave_function(function_id);
       }
       catch(const std::string &s)
       {
@@ -265,14 +276,14 @@ protected:
     /// \param no_dependencies: Option to disable dependency analysis
     /// \param duplicate_body: Control which loop body segments should
     ///   be duplicated
-    /// \param function: Function to analyse
+    /// \param function_id: Function to analyse
     /// \param ending_vertex: Outcoming edges
     virtual void visit_cfg_function(
       value_setst &value_sets,
       memory_modelt model,
       bool no_dependencies,
       loop_strategyt duplicate_body,
-      const irep_idt &function,
+      const irep_idt &function_id,
       std::set<nodet> &ending_vertex);
 
     bool inline local(const irep_idt &i);

--- a/src/goto-instrument/wmm/shared_buffers.h
+++ b/src/goto-instrument/wmm/shared_buffers.h
@@ -117,6 +117,7 @@ public:
     const unsigned current_thread);
 
   void nondet_flush(
+    const irep_idt &function_id,
     goto_programt &goto_program,
     goto_programt::targett &t,
     const source_locationt &source_location,
@@ -156,9 +157,9 @@ public:
     return true;
   }
 
-  irep_idt choice(const irep_idt &function, const std::string &suffix)
+  irep_idt choice(const irep_idt &function_id, const std::string &suffix)
   {
-    const auto maybe_symbol=symbol_table.lookup(function);
+    const auto maybe_symbol = symbol_table.lookup(function_id);
     const std::string function_base_name =
       maybe_symbol
         ? id2string(maybe_symbol->base_name)
@@ -213,10 +214,10 @@ public:
       max_thread = 0;
     }
 
-  void weak_memory(
-    value_setst &value_sets,
-    const irep_idt &function,
-    memory_modelt model);
+    void weak_memory(
+      value_setst &value_sets,
+      const irep_idt &function_id,
+      memory_modelt model);
   };
 
 protected:


### PR DESCRIPTION
We are working towards removing the "function" field from
goto_programt::instructionst::instructiont, and thus need to pass the identifier
of the function whenever it actually is required.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
