### PR TITLE
Slicers: do not rely on goto_programt::instructiont::function [blocks: #3126]

### DIFF
--- a/src/goto-instrument/aggressive_slicer.cpp
+++ b/src/goto-instrument/aggressive_slicer.cpp
@@ -46,8 +46,8 @@ void aggressive_slicert::get_all_functions_containing_properties()
       for(const auto &ins : fct.second.body.instructions)
         if(ins.is_assert())
         {
-          if(functions_to_keep.insert(ins.function).second)
-            note_functions_to_keep(ins.function);
+          if(functions_to_keep.insert(fct.first).second)
+            note_functions_to_keep(fct.first);
         }
     }
   }

--- a/src/goto-instrument/full_slicer.h
+++ b/src/goto-instrument/full_slicer.h
@@ -33,7 +33,9 @@ class slicing_criteriont
 {
 public:
   virtual ~slicing_criteriont();
-  virtual bool operator()(goto_programt::const_targett) const = 0;
+  virtual bool operator()(
+    const irep_idt &function_id,
+    goto_programt::const_targett) const = 0;
 };
 
 void full_slicer(

--- a/src/goto-instrument/full_slicer_class.h
+++ b/src/goto-instrument/full_slicer_class.h
@@ -51,6 +51,7 @@ protected:
     }
 
     bool node_required;
+    irep_idt function_id;
 #ifdef DEBUG_FULL_SLICERT
     std::set<unsigned> required_by;
 #endif
@@ -109,7 +110,8 @@ protected:
 class assert_criteriont:public slicing_criteriont
 {
 public:
-  virtual bool operator()(goto_programt::const_targett target) const
+  virtual bool
+  operator()(const irep_idt &, goto_programt::const_targett target) const
   {
     return target->is_assert();
   }
@@ -123,9 +125,10 @@ public:
   {
   }
 
-  virtual bool operator()(goto_programt::const_targett target) const
+  virtual bool
+  operator()(const irep_idt &function_id, goto_programt::const_targett) const
   {
-    return target->function == target_function;
+    return function_id == target_function;
   }
 
 protected:
@@ -141,7 +144,8 @@ public:
   {
   }
 
-  virtual bool operator()(goto_programt::const_targett target) const
+  virtual bool
+  operator()(const irep_idt &, goto_programt::const_targett target) const
   {
     if(!target->is_assert())
       return false;

--- a/src/goto-instrument/reachability_slicer.cpp
+++ b/src/goto-instrument/reachability_slicer.cpp
@@ -40,20 +40,27 @@ reachability_slicert::get_sources(
   std::vector<cfgt::node_indext> sources;
   for(const auto &e_it : cfg.entry_map)
   {
-    if(criterion(e_it.first) || is_threaded(e_it.first))
+    if(
+      criterion(cfg[e_it.second].function_id, e_it.first) ||
+      is_threaded(e_it.first))
       sources.push_back(e_it.second);
   }
 
   return sources;
 }
 
-static bool is_same_target(
+bool reachability_slicert::is_same_target(
   goto_programt::const_targett it1,
-  goto_programt::const_targett it2)
+  goto_programt::const_targett it2) const
 {
   // Avoid comparing iterators belonging to different functions, and therefore
   // different std::lists.
-  return it1->function == it2->function && it1 == it2;
+  cfgt::entry_mapt::const_iterator it1_entry = cfg.entry_map.find(it1);
+  cfgt::entry_mapt::const_iterator it2_entry = cfg.entry_map.find(it2);
+  return it1_entry != cfg.entry_map.end() && it2_entry != cfg.entry_map.end() &&
+         cfg[it1_entry->second].function_id ==
+           cfg[it2_entry->second].function_id &&
+         it1 == it2;
 }
 
 /// Perform backward depth-first search of the control-flow graph of the

--- a/src/goto-instrument/reachability_slicer_class.h
+++ b/src/goto-instrument/reachability_slicer_class.h
@@ -28,6 +28,12 @@ public:
     bool include_forward_reachability)
   {
     cfg(goto_functions);
+    forall_goto_functions(f_it, goto_functions)
+    {
+      forall_goto_program_instructions(i_it, f_it->second.body)
+        cfg[cfg.entry_map[i_it]].function_id = f_it->first;
+    }
+
     is_threadedt is_threaded(goto_functions);
     fixedpoint_to_assertions(is_threaded, criterion);
     if(include_forward_reachability)
@@ -42,9 +48,14 @@ protected:
     {
     }
 
+    irep_idt function_id;
     bool reaches_assertion;
     bool reachable_from_assertion;
   };
+
+  bool is_same_target(
+    goto_programt::const_targett it1,
+    goto_programt::const_targett it2) const;
 
   typedef cfg_baset<slicer_entryt> cfgt;
   cfgt cfg;


### PR DESCRIPTION
We are working towards removing the "function" field from
goto_programt::instructionst::instructiont, and thus need to pass the identifier
of the function whenever it actually is required.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
