### PR TITLE
goto_rw: store function name alongside instruction reference [blocks: #3126]

### DIFF
--- a/src/analyses/dependence_graph.cpp
+++ b/src/analyses/dependence_graph.cpp
@@ -162,7 +162,7 @@ void dep_graph_domaint::data_dependencies(
   value_setst &value_sets=
     dep_graph.reaching_definitions().get_value_sets();
   rw_range_set_value_sett rw_set(ns, value_sets);
-  goto_rw(to, rw_set);
+  goto_rw(to->function, to, rw_set);
 
   forall_rw_range_set_r_objects(it, rw_set)
   {

--- a/src/analyses/reaching_definitions.cpp
+++ b/src/analyses/reaching_definitions.cpp
@@ -91,13 +91,13 @@ void rd_range_domaint::transform(
     transform_function_call(ns, function_from, from, function_to, *rd);
   // cleanup parameters
   else if(from->is_end_function())
-    transform_end_function(ns, function_from, from, to, *rd);
+    transform_end_function(ns, function_from, from, function_to, to, *rd);
   // lhs assignments
   else if(from->is_assign())
-    transform_assign(ns, from, from, *rd);
+    transform_assign(ns, from, function_from, from, *rd);
   // initial (non-deterministic) value
   else if(from->is_decl())
-    transform_assign(ns, from, from, *rd);
+    transform_assign(ns, from, function_from, from, *rd);
 
 #if 0
   // handle return values
@@ -233,7 +233,7 @@ void rd_range_domaint::transform_function_call(
   {
     // handle return values of undefined functions
     if(to_code_function_call(from->code).lhs().is_not_nil())
-      transform_assign(ns, from, from, rd);
+      transform_assign(ns, from, function_from, from, rd);
   }
 }
 
@@ -241,6 +241,7 @@ void rd_range_domaint::transform_end_function(
   const namespacet &ns,
   const irep_idt &function_from,
   locationt from,
+  const irep_idt &function_to,
   locationt to,
   reaching_definitions_analysist &rd)
 {
@@ -301,18 +302,19 @@ void rd_range_domaint::transform_end_function(
     assert(rd_state!=0);
     rd_state->
 #endif
-      transform_assign(ns, from, call, rd);
+    transform_assign(ns, from, function_to, call, rd);
   }
 }
 
 void rd_range_domaint::transform_assign(
   const namespacet &ns,
   locationt from,
+  const irep_idt &function_to,
   locationt to,
   reaching_definitions_analysist &rd)
 {
   rw_range_set_value_sett rw_set(ns, rd.get_value_sets());
-  goto_rw(to, rw_set);
+  goto_rw(function_to, to, rw_set);
   const bool is_must_alias=rw_set.get_w_set().size()==1;
 
   forall_rw_range_set_w_objects(it, rw_set)

--- a/src/analyses/reaching_definitions.h
+++ b/src/analyses/reaching_definitions.h
@@ -309,11 +309,13 @@ private:
     const namespacet &ns,
     const irep_idt &function_from,
     locationt from,
+    const irep_idt &function_to,
     locationt to,
     reaching_definitions_analysist &rd);
   void transform_assign(
     const namespacet &ns,
     locationt from,
+    const irep_idt &function_to,
     locationt to,
     reaching_definitions_analysist &rd);
 


### PR DESCRIPTION
We are working towards removing the "function" field from
goto_programt::instructionst::instructiont, and thus need to pass the identifier
of the function whenever it actually is required. goto_rw does not yet make use
of this, but will need to once dereferencing is updated to require a function
name.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
