### PR TITLE
added constructor for goto_symex_statet::framet

### DIFF
--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -196,6 +196,11 @@ public:
       bool is_recursion = false;
     };
     std::unordered_map<irep_idt, loop_infot> loop_iterations;
+
+    explicit framet(const symex_targett::sourcet &_calling_location)
+      : calling_location(_calling_location)
+    {
+    }
   };
 
   typedef std::vector<framet> call_stackt;
@@ -224,8 +229,14 @@ public:
     return call_stack().back();
   }
 
-  framet &new_frame() { call_stack().push_back(framet()); return top(); }
+  framet &new_frame()
+  {
+    call_stack().emplace_back(source);
+    return top();
+  }
+
   void pop_frame() { call_stack().pop_back(); }
+
   const framet &previous_frame() { return *(--(--call_stack().end())); }
 
   void print_backtrace(std::ostream &) const;

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -311,7 +311,6 @@ void goto_symext::symex_function_call_code(
 
   frame.end_of_function=--goto_function.body.instructions.end();
   frame.return_value=call.lhs();
-  frame.calling_location=state.source;
   frame.function_identifier=identifier;
   frame.hidden_function=goto_function.is_hidden();
 


### PR DESCRIPTION
This enables removing the default constructor for sourcet.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
