### PR TITLE
extend constructor of SSA_stept

### DIFF
--- a/src/goto-symex/partial_order_concurrency.cpp
+++ b/src/goto-symex/partial_order_concurrency.cpp
@@ -56,16 +56,15 @@ void partial_order_concurrencyt::add_init_writes(
        e_it->is_shared_read() ||
        !e_it->guard.is_true())
     {
-      init_steps.push_back(symex_target_equationt::SSA_stept());
+      init_steps.emplace_back(
+        e_it->source, goto_trace_stept::typet::SHARED_WRITE);
       symex_target_equationt::SSA_stept &SSA_step=init_steps.back();
 
       SSA_step.guard=true_exprt();
       // no SSA L2 index, thus nondet value
       SSA_step.ssa_lhs=e_it->ssa_lhs;
       SSA_step.ssa_lhs.remove_level_2();
-      SSA_step.type=goto_trace_stept::typet::SHARED_WRITE;
       SSA_step.atomic_section_id=0;
-      SSA_step.source=e_it->source;
     }
 
     init_done.insert(a);

--- a/src/goto-symex/slice_by_trace.cpp
+++ b/src/goto-symex/slice_by_trace.cpp
@@ -103,14 +103,13 @@ void symex_slice_by_tracet::slice_by_trace(
 
   guardt t_guard;
   symex_targett::sourcet empty_source;
-  equation.SSA_steps.push_front(symex_target_equationt::SSA_stept());
+  equation.SSA_steps.emplace_front(
+    empty_source, goto_trace_stept::typet::ASSUME);
   symex_target_equationt::SSA_stept &SSA_step=equation.SSA_steps.front();
 
   SSA_step.guard=t_guard.as_expr();
   SSA_step.ssa_lhs.make_nil();
   SSA_step.cond_expr.swap(trace_condition);
-  SSA_step.type=goto_trace_stept::typet::ASSUME;
-  SSA_step.source=empty_source;
 
   assign_merges(equation); // Now add the merge variable assignments to eqn
 
@@ -508,7 +507,8 @@ void symex_slice_by_tracet::assign_merges(
 
     exprt merge_copy(*i);
 
-    equation.SSA_steps.push_front(symex_target_equationt::SSA_stept());
+    equation.SSA_steps.emplace_front(
+      empty_source, goto_trace_stept::typet::ASSIGNMENT);
     symex_target_equationt::SSA_stept &SSA_step=equation.SSA_steps.front();
 
     SSA_step.guard=t_guard.as_expr();
@@ -517,8 +517,6 @@ void symex_slice_by_tracet::assign_merges(
     SSA_step.assignment_type=symex_targett::assignment_typet::HIDDEN;
 
     SSA_step.cond_expr=equal_exprt(SSA_step.ssa_lhs, SSA_step.ssa_rhs);
-    SSA_step.type=goto_trace_stept::typet::ASSIGNMENT;
-    SSA_step.source=empty_source;
   }
 }
 

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -34,14 +34,12 @@ void symex_target_equationt::shared_read(
   unsigned atomic_section_id,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
+  SSA_steps.emplace_back(source, goto_trace_stept::typet::SHARED_READ);
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
   SSA_step.ssa_lhs=ssa_object;
-  SSA_step.type=goto_trace_stept::typet::SHARED_READ;
   SSA_step.atomic_section_id=atomic_section_id;
-  SSA_step.source=source;
 
   merge_ireps(SSA_step);
 }
@@ -52,14 +50,12 @@ void symex_target_equationt::shared_write(
   unsigned atomic_section_id,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
+  SSA_steps.emplace_back(source, goto_trace_stept::typet::SHARED_WRITE);
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
   SSA_step.ssa_lhs=ssa_object;
-  SSA_step.type=goto_trace_stept::typet::SHARED_WRITE;
   SSA_step.atomic_section_id=atomic_section_id;
-  SSA_step.source=source;
 
   merge_ireps(SSA_step);
 }
@@ -69,11 +65,9 @@ void symex_target_equationt::spawn(
   const exprt &guard,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
+  SSA_steps.emplace_back(source, goto_trace_stept::typet::SPAWN);
   SSA_stept &SSA_step=SSA_steps.back();
   SSA_step.guard=guard;
-  SSA_step.type=goto_trace_stept::typet::SPAWN;
-  SSA_step.source=source;
 
   merge_ireps(SSA_step);
 }
@@ -82,11 +76,9 @@ void symex_target_equationt::memory_barrier(
   const exprt &guard,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
+  SSA_steps.emplace_back(source, goto_trace_stept::typet::MEMORY_BARRIER);
   SSA_stept &SSA_step=SSA_steps.back();
   SSA_step.guard=guard;
-  SSA_step.type=goto_trace_stept::typet::MEMORY_BARRIER;
-  SSA_step.source=source;
 
   merge_ireps(SSA_step);
 }
@@ -97,12 +89,10 @@ void symex_target_equationt::atomic_begin(
   unsigned atomic_section_id,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
+  SSA_steps.emplace_back(source, goto_trace_stept::typet::ATOMIC_BEGIN);
   SSA_stept &SSA_step=SSA_steps.back();
   SSA_step.guard=guard;
-  SSA_step.type=goto_trace_stept::typet::ATOMIC_BEGIN;
   SSA_step.atomic_section_id=atomic_section_id;
-  SSA_step.source=source;
 
   merge_ireps(SSA_step);
 }
@@ -113,12 +103,10 @@ void symex_target_equationt::atomic_end(
   unsigned atomic_section_id,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
+  SSA_steps.emplace_back(source, goto_trace_stept::typet::ATOMIC_END);
   SSA_stept &SSA_step=SSA_steps.back();
   SSA_step.guard=guard;
-  SSA_step.type=goto_trace_stept::typet::ATOMIC_END;
   SSA_step.atomic_section_id=atomic_section_id;
-  SSA_step.source=source;
 
   merge_ireps(SSA_step);
 }
@@ -134,7 +122,7 @@ void symex_target_equationt::assignment(
 {
   PRECONDITION(ssa_lhs.is_not_nil());
 
-  SSA_steps.push_back(SSA_stept());
+  SSA_steps.emplace_back(source, goto_trace_stept::typet::ASSIGNMENT);
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
@@ -145,10 +133,8 @@ void symex_target_equationt::assignment(
   SSA_step.assignment_type=assignment_type;
 
   SSA_step.cond_expr=equal_exprt(SSA_step.ssa_lhs, SSA_step.ssa_rhs);
-  SSA_step.type=goto_trace_stept::typet::ASSIGNMENT;
   SSA_step.hidden=(assignment_type!=assignment_typet::STATE &&
                    assignment_type!=assignment_typet::VISIBLE_ACTUAL_PARAMETER);
-  SSA_step.source=source;
 
   merge_ireps(SSA_step);
 }
@@ -161,15 +147,13 @@ void symex_target_equationt::decl(
 {
   PRECONDITION(ssa_lhs.is_not_nil());
 
-  SSA_steps.push_back(SSA_stept());
+  SSA_steps.emplace_back(source, goto_trace_stept::typet::DECL);
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
   SSA_step.ssa_lhs=ssa_lhs;
   SSA_step.ssa_full_lhs=ssa_lhs;
   SSA_step.original_full_lhs=ssa_lhs.get_original_expr();
-  SSA_step.type=goto_trace_stept::typet::DECL;
-  SSA_step.source=source;
   SSA_step.hidden=(assignment_type!=assignment_typet::STATE);
 
   // the condition is trivially true, and only
@@ -192,12 +176,10 @@ void symex_target_equationt::location(
   const exprt &guard,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
+  SSA_steps.emplace_back(source, goto_trace_stept::typet::LOCATION);
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
-  SSA_step.type=goto_trace_stept::typet::LOCATION;
-  SSA_step.source=source;
 
   merge_ireps(SSA_step);
 }
@@ -209,12 +191,10 @@ void symex_target_equationt::function_call(
   const sourcet &source,
   const bool hidden)
 {
-  SSA_steps.push_back(SSA_stept());
+  SSA_steps.emplace_back(source, goto_trace_stept::typet::FUNCTION_CALL);
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard = guard;
-  SSA_step.type = goto_trace_stept::typet::FUNCTION_CALL;
-  SSA_step.source = source;
   SSA_step.called_function = function_identifier;
   SSA_step.ssa_function_arguments = ssa_function_arguments;
   SSA_step.hidden = hidden;
@@ -227,12 +207,10 @@ void symex_target_equationt::function_return(
   const sourcet &source,
   const bool hidden)
 {
-  SSA_steps.push_back(SSA_stept());
+  SSA_steps.emplace_back(source, goto_trace_stept::typet::FUNCTION_RETURN);
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard = guard;
-  SSA_step.type = goto_trace_stept::typet::FUNCTION_RETURN;
-  SSA_step.source = source;
   SSA_step.hidden = hidden;
 
   merge_ireps(SSA_step);
@@ -244,12 +222,10 @@ void symex_target_equationt::output(
   const irep_idt &output_id,
   const std::list<exprt> &args)
 {
-  SSA_steps.push_back(SSA_stept());
+  SSA_steps.emplace_back(source, goto_trace_stept::typet::OUTPUT);
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
-  SSA_step.type=goto_trace_stept::typet::OUTPUT;
-  SSA_step.source=source;
   SSA_step.io_args=args;
   SSA_step.io_id=output_id;
 
@@ -263,12 +239,10 @@ void symex_target_equationt::output_fmt(
   const irep_idt &fmt,
   const std::list<exprt> &args)
 {
-  SSA_steps.push_back(SSA_stept());
+  SSA_steps.emplace_back(source, goto_trace_stept::typet::OUTPUT);
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
-  SSA_step.type=goto_trace_stept::typet::OUTPUT;
-  SSA_step.source=source;
   SSA_step.io_args=args;
   SSA_step.io_id=output_id;
   SSA_step.formatted=true;
@@ -283,12 +257,10 @@ void symex_target_equationt::input(
   const irep_idt &input_id,
   const std::list<exprt> &args)
 {
-  SSA_steps.push_back(SSA_stept());
+  SSA_steps.emplace_back(source, goto_trace_stept::typet::INPUT);
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
-  SSA_step.type=goto_trace_stept::typet::INPUT;
-  SSA_step.source=source;
   SSA_step.io_args=args;
   SSA_step.io_id=input_id;
 
@@ -300,13 +272,11 @@ void symex_target_equationt::assumption(
   const exprt &cond,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
+  SSA_steps.emplace_back(source, goto_trace_stept::typet::ASSUME);
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
   SSA_step.cond_expr=cond;
-  SSA_step.type=goto_trace_stept::typet::ASSUME;
-  SSA_step.source=source;
 
   merge_ireps(SSA_step);
 }
@@ -317,13 +287,11 @@ void symex_target_equationt::assertion(
   const std::string &msg,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
+  SSA_steps.emplace_back(source, goto_trace_stept::typet::ASSERT);
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
   SSA_step.cond_expr=cond;
-  SSA_step.type=goto_trace_stept::typet::ASSERT;
-  SSA_step.source=source;
   SSA_step.comment=msg;
 
   merge_ireps(SSA_step);
@@ -334,13 +302,11 @@ void symex_target_equationt::goto_instruction(
   const exprt &cond,
   const sourcet &source)
 {
-  SSA_steps.push_back(SSA_stept());
+  SSA_steps.emplace_back(source, goto_trace_stept::typet::GOTO);
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
   SSA_step.cond_expr=cond;
-  SSA_step.type=goto_trace_stept::typet::GOTO;
-  SSA_step.source=source;
 
   merge_ireps(SSA_step);
 }
@@ -351,13 +317,11 @@ void symex_target_equationt::constraint(
   const sourcet &source)
 {
   // like assumption, but with global effect
-  SSA_steps.push_back(SSA_stept());
+  SSA_steps.emplace_back(source, goto_trace_stept::typet::CONSTRAINT);
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=true_exprt();
   SSA_step.cond_expr=cond;
-  SSA_step.type=goto_trace_stept::typet::CONSTRAINT;
-  SSA_step.source=source;
   SSA_step.comment=msg;
 
   merge_ireps(SSA_step);

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -318,21 +318,22 @@ public:
     // for slicing
     bool ignore=false;
 
-    SSA_stept():
-      type(goto_trace_stept::typet::NONE),
-      hidden(false),
-      guard(static_cast<const exprt &>(get_nil_irep())),
-      guard_literal(const_literal(false)),
-      ssa_lhs(static_cast<const ssa_exprt &>(get_nil_irep())),
-      ssa_full_lhs(static_cast<const exprt &>(get_nil_irep())),
-      original_full_lhs(static_cast<const exprt &>(get_nil_irep())),
-      ssa_rhs(static_cast<const exprt &>(get_nil_irep())),
-      assignment_type(assignment_typet::STATE),
-      cond_expr(static_cast<const exprt &>(get_nil_irep())),
-      cond_literal(const_literal(false)),
-      formatted(false),
-      atomic_section_id(0),
-      ignore(false)
+    SSA_stept(const sourcet &_source, goto_trace_stept::typet _type)
+      : source(_source),
+        type(_type),
+        hidden(false),
+        guard(static_cast<const exprt &>(get_nil_irep())),
+        guard_literal(const_literal(false)),
+        ssa_lhs(static_cast<const ssa_exprt &>(get_nil_irep())),
+        ssa_full_lhs(static_cast<const exprt &>(get_nil_irep())),
+        original_full_lhs(static_cast<const exprt &>(get_nil_irep())),
+        ssa_rhs(static_cast<const exprt &>(get_nil_irep())),
+        assignment_type(assignment_typet::STATE),
+        cond_expr(static_cast<const exprt &>(get_nil_irep())),
+        cond_literal(const_literal(false)),
+        formatted(false),
+        atomic_section_id(0),
+        ignore(false)
     {
     }
 

--- a/unit/goto-symex/ssa_equation.cpp
+++ b/unit/goto-symex/ssa_equation.cpp
@@ -24,9 +24,10 @@ SCENARIO("Validation of well-formed SSA steps", "[core][goto-symex][validate]")
     symbol_exprt fun_foo(fun_name, code_type);
 
     symex_target_equationt equation;
-    equation.SSA_steps.push_back(symex_target_equationt::SSA_stept());
+    symex_targett::sourcet empty_source;
+    equation.SSA_steps.emplace_back(
+      empty_source, goto_trace_stept::typet::FUNCTION_RETURN);
     auto &step = equation.SSA_steps.back();
-    step.type = goto_trace_stept::typet::FUNCTION_RETURN;
     step.called_function = fun_name;
 
     WHEN("Called function is in symbol table")


### PR DESCRIPTION
This enforces initialisation of two members used in all instances of
SSA_stept.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
