### PR TITLE
ieee_float_op_exprt is a ternary_exprt

### DIFF
--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -4334,23 +4334,16 @@ inline void validate_expr(const ieee_float_notequal_exprt &value)
 /// \brief IEEE floating-point operations
 /// These have two data operands (op0 and op1) and one rounding mode (op2).
 /// The type of the result is that of the data operands.
-class ieee_float_op_exprt:public exprt
+class ieee_float_op_exprt : public ternary_exprt
 {
 public:
-  DEPRECATED("use ieee_float_op_exprt(lhs, id, rhs, rm) instead")
-  ieee_float_op_exprt()
-  {
-    operands().resize(3);
-  }
-
   ieee_float_op_exprt(
     const exprt &_lhs,
     const irep_idt &_id,
     const exprt &_rhs,
     const exprt &_rm)
-    : exprt(_id, _lhs.type())
+    : ternary_exprt(_id, _lhs, _rhs, _rm, _lhs.type())
   {
-    add_to_operands(_lhs, _rhs, _rm);
   }
 
   exprt &lhs()


### PR DESCRIPTION
ieee_float_op_exprt has three operands, and thus, the appropriate base type
is ternary_exprt.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
