### PR TITLE
use member_exprt::compound() instead of op0

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
@@ -484,10 +484,10 @@ optionalt<codet> java_bytecode_instrumentt::instrument_expr(const exprt &expr)
     if(plus_expr.op0().id()==ID_member)
     {
       const member_exprt &member_expr=to_member_expr(plus_expr.op0());
-      if(member_expr.op0().id()==ID_dereference)
+      if(member_expr.compound().id() == ID_dereference)
       {
-        const dereference_exprt &dereference_expr=
-          to_dereference_expr(member_expr.op0());
+        const dereference_exprt &dereference_expr =
+          to_dereference_expr(member_expr.compound());
         codet bounds_check=
           check_array_access(
             dereference_expr,

--- a/jbmc/unit/java-testing-utils/require_goto_statements.cpp
+++ b/jbmc/unit/java-testing-utils/require_goto_statements.cpp
@@ -95,7 +95,7 @@ require_goto_statements::find_struct_component_assignments(
             member_expr.compound().id() == ID_member)
           {
             const member_exprt &superclass_expr =
-              to_member_expr(member_expr.op0());
+              to_member_expr(member_expr.compound());
             const irep_idt supercomponent_name =
               "@" + id2string(superclass_name.value());
 

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -1528,39 +1528,37 @@ std::string expr2ct::convert_member(
   const member_exprt &src,
   unsigned precedence)
 {
-  if(src.operands().size()!=1)
-    return convert_norep(src, precedence);
+  const auto &compound = src.compound();
 
   unsigned p;
   std::string dest;
 
-  if(src.op0().id()==ID_dereference &&
-     src.operands().size()==1)
+  if(compound.id() == ID_dereference && src.operands().size() == 1)
   {
-    std::string op=convert_with_precedence(src.op0().op0(), p);
+    std::string op = convert_with_precedence(compound.op0(), p);
 
-    if(precedence>p || src.op0().op0().id()==ID_typecast)
+    if(precedence > p || compound.op0().id() == ID_typecast)
       dest+='(';
     dest+=op;
-    if(precedence>p || src.op0().op0().id()==ID_typecast)
+    if(precedence > p || compound.op0().id() == ID_typecast)
       dest+=')';
 
     dest+="->";
   }
   else
   {
-    std::string op=convert_with_precedence(src.op0(), p);
+    std::string op = convert_with_precedence(compound, p);
 
-    if(precedence>p || src.op0().id()==ID_typecast)
+    if(precedence > p || compound.id() == ID_typecast)
       dest+='(';
     dest+=op;
-    if(precedence>p || src.op0().id()==ID_typecast)
+    if(precedence > p || compound.id() == ID_typecast)
       dest+=')';
 
     dest+='.';
   }
 
-  const typet &full_type=ns.follow(src.op0().type());
+  const typet &full_type = ns.follow(compound.type());
 
   if(full_type.id()!=ID_struct &&
      full_type.id()!=ID_union)

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1115,7 +1115,7 @@ void value_sett::get_reference_set_rec(
         {
           // adjust type?
           if(ns.follow(struct_op.type())!=final_object_type)
-            member_expr.op0().make_typecast(struct_op.type());
+            member_expr.compound().make_typecast(struct_op.type());
 
           insert(dest, member_expr, o);
         }

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -930,7 +930,7 @@ void value_set_fit::get_reference_set_sharing_rec(
 
         // adjust type?
         if(ns.follow(struct_op.type())!=ns.follow(object.type()))
-          member_expr.op0().make_typecast(struct_op.type());
+          member_expr.compound().make_typecast(struct_op.type());
 
         insert(dest, member_expr, o);
       }

--- a/src/pointer-analysis/value_set_fivr.cpp
+++ b/src/pointer-analysis/value_set_fivr.cpp
@@ -1043,7 +1043,7 @@ void value_set_fivrt::get_reference_set_sharing_rec(
 
         // adjust type?
         if(ns.follow(struct_op.type())!=ns.follow(object.type()))
-          member_expr.op0().make_typecast(struct_op.type());
+          member_expr.compound().make_typecast(struct_op.type());
 
         insert_from(dest, member_expr, o);
       }

--- a/src/pointer-analysis/value_set_fivrns.cpp
+++ b/src/pointer-analysis/value_set_fivrns.cpp
@@ -736,7 +736,7 @@ void value_set_fivrnst::get_reference_set_rec(
 
         // adjust type?
         if(ns.follow(struct_op.type())!=ns.follow(object.type()))
-          member_expr.op0().make_typecast(struct_op.type());
+          member_expr.compound().make_typecast(struct_op.type());
 
         insert_from(dest, member_expr, o);
       }

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -160,7 +160,7 @@ bool bv_pointerst::convert_address_of_rec(
   else if(expr.id()==ID_member)
   {
     const member_exprt &member_expr=to_member_expr(expr);
-    const exprt &struct_op=member_expr.op0();
+    const exprt &struct_op = member_expr.compound();
     const typet &struct_op_type=ns.follow(struct_op.type());
 
     // recursive call


### PR DESCRIPTION
This will eventually allow us to protect exprt::opX().

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
