### PR TITLE
use unary_exprt::op() instead of op0()

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
@@ -525,10 +525,8 @@ optionalt<codet> java_bytecode_instrumentt::instrument_expr(const exprt &expr)
   {
     // Check pointer non-null before access:
     const dereference_exprt &dereference_expr = to_dereference_expr(expr);
-    codet null_dereference_check=
-      check_null_dereference(
-        dereference_expr.op0(),
-        dereference_expr.source_location());
+    codet null_dereference_check = check_null_dereference(
+      dereference_expr.pointer(), dereference_expr.source_location());
     result.add(std::move(null_dereference_check));
   }
 

--- a/jbmc/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -53,8 +53,7 @@ void validate_lambda_assignment(
   const typecast_exprt &rhs_value =
     require_expr::require_typecast(lambda_assignment.rhs());
 
-  const symbol_exprt &rhs_symbol =
-    require_expr::require_symbol(rhs_value.op0());
+  const symbol_exprt &rhs_symbol = require_expr::require_symbol(rhs_value.op());
 
   const irep_idt &tmp_object_symbol = rhs_symbol.get_identifier();
 

--- a/src/goto-programs/remove_complex.cpp
+++ b/src/goto-programs/remove_complex.cpp
@@ -217,11 +217,11 @@ static void remove_complex(exprt &expr)
 
   if(expr.id()==ID_complex_real)
   {
-    expr = complex_member(to_complex_real_expr(expr).op0(), ID_real);
+    expr = complex_member(to_complex_real_expr(expr).op(), ID_real);
   }
   else if(expr.id()==ID_complex_imag)
   {
-    expr = complex_member(to_complex_imag_expr(expr).op0(), ID_imag);
+    expr = complex_member(to_complex_imag_expr(expr).op(), ID_imag);
   }
 
   remove_complex(expr.type());

--- a/src/goto-programs/remove_vector.cpp
+++ b/src/goto-programs/remove_vector.cpp
@@ -132,7 +132,7 @@ static void remove_vector(exprt &expr)
         exprt index=from_integer(i, array_type.size().type());
 
         array_expr.operands()[i] = unary_exprt(
-          unary_expr.id(), index_exprt(unary_expr.op0(), index, subtype));
+          unary_expr.id(), index_exprt(unary_expr.op(), index, subtype));
       }
 
       expr=array_expr;

--- a/src/solvers/flattening/boolbv_union.cpp
+++ b/src/solvers/flattening/boolbv_union.cpp
@@ -46,7 +46,7 @@ bvt boolbvt::convert_union(const union_exprt &expr)
       "endianness should be set to either little endian or big endian");
 
     bv_endianness_mapt map_u(expr.type(), false, ns, boolbv_width);
-    bv_endianness_mapt map_op(expr.op0().type(), false, ns, boolbv_width);
+    bv_endianness_mapt map_op(expr.op().type(), false, ns, boolbv_width);
 
     for(std::size_t i=0; i<op_bv.size(); i++)
       bv[map_u.map_bit(i)]=op_bv[map_op.map_bit(i)];

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -242,7 +242,7 @@ bool simplify_exprt::simplify_typecast(exprt &expr)
       const auto &typecast=expr_checked_cast<typecast_exprt>(expr.op0());
       if(typecast.op().type()==expr_type)
       {
-        expr=typecast.op0();
+        expr = typecast.op();
         return false;
       }
     }


### PR DESCRIPTION
This will eventually allow us to protect exprt::opX().

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
