### PR TITLE
Trace output: use source location's function [depends-on: #3514]

### DIFF
--- a/src/goto-programs/goto_trace.cpp
+++ b/src/goto-programs/goto_trace.cpp
@@ -282,8 +282,7 @@ void trace_value(
   out << '\n';
 }
 
-static std::string
-state_location(const goto_trace_stept &state, const namespacet &ns)
+static std::string state_location(const goto_trace_stept &state)
 {
   std::string result;
 
@@ -292,12 +291,11 @@ state_location(const goto_trace_stept &state, const namespacet &ns)
   if(!source_location.get_file().empty())
     result += "file " + id2string(source_location.get_file());
 
-  if(!state.function.empty())
+  if(!source_location.get_function().empty())
   {
-    const symbolt &symbol = ns.lookup(state.function);
     if(!result.empty())
       result += ' ';
-    result += "function " + id2string(symbol.display_name());
+    result += "function " + id2string(source_location.get_function());
   }
 
   if(!source_location.get_line().empty())
@@ -328,7 +326,7 @@ void show_state_header(
   else
     out << "State " << step_nr;
 
-  out << ' ' << state_location(state, ns) << '\n';
+  out << ' ' << state_location(state) << '\n';
   out << "----------------------------------------------------" << '\n';
 
   if(options.show_code)
@@ -382,7 +380,7 @@ void show_compact_goto_trace(
         out << '\n';
         out << messaget::red << "Violated property:" << messaget::reset << '\n';
         if(!step.pc->source_location.is_nil())
-          out << "  " << state_location(step, ns) << '\n';
+          out << "  " << state_location(step) << '\n';
 
         out << "  " << messaget::red << step.comment << messaget::reset << '\n';
 
@@ -501,7 +499,7 @@ void show_full_goto_trace(
         out << messaget::red << "Violated property:" << messaget::reset << '\n';
         if(!step.pc->source_location.is_nil())
         {
-          out << "  " << state_location(step, ns) << '\n';
+          out << "  " << state_location(step) << '\n';
         }
 
         out << "  " << messaget::red << step.comment << messaget::reset << '\n';


### PR DESCRIPTION
The function identifier stored with a step is an internal name, which need not
coincide with the function name used in source code.

I am aware that this breaks several Java regression tests, thus I would welcome discussion whether I'm on the wrong track here, or whether the Java front-end needs fixing.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
