### PR TITLE
rw_set: store function identifier alongside instruction reference [blocks: #3126]

### DIFF
--- a/src/goto-instrument/mmio.cpp
+++ b/src/goto-instrument/mmio.cpp
@@ -21,9 +21,10 @@ Date: September 2011
 #include <analyses/local_may_alias.h>
 #endif
 
-void mmio(
+static void mmio(
   value_setst &value_sets,
   const symbol_tablet &symbol_table,
+  const irep_idt &function_id,
 #ifdef LOCAL_MAY
   const goto_functionst::goto_functiont &goto_function,
 #endif
@@ -41,9 +42,14 @@ void mmio(
 
     if(instruction.is_assign())
     {
-      rw_set_loct rw_set(ns, value_sets, i_it
+      rw_set_loct rw_set(
+        ns,
+        value_sets,
+        function_id,
+        i_it
 #ifdef LOCAL_MAY
-        , local_may
+        ,
+        local_may
 #endif
       ); // NOLINT(whitespace/parens)
 
@@ -159,7 +165,10 @@ void mmio(
   Forall_goto_functions(f_it, goto_model.goto_functions)
     if(f_it->first != INITIALIZE_FUNCTION &&
        f_it->first!=goto_functionst::entry_point())
-      mmio(value_sets, goto_model.symbol_table,
+      mmio(
+        value_sets,
+        goto_model.symbol_table,
+        f_it->first,
 #ifdef LOCAL_MAY
         f_it->second,
 #endif

--- a/src/goto-instrument/race_check.h
+++ b/src/goto-instrument/race_check.h
@@ -20,11 +20,11 @@ Date: February 2006
 void race_check(
   value_setst &,
   class symbol_tablet &,
+  const irep_idt &function_id,
 #ifdef LOCAL_MAY
   const goto_functionst::goto_functiont &goto_function,
 #endif
-  goto_programt &goto_program
-);
+  goto_programt &goto_program);
 
 void race_check(value_setst &, goto_modelt &);
 

--- a/src/goto-instrument/rw_set.cpp
+++ b/src/goto-instrument/rw_set.cpp
@@ -199,10 +199,10 @@ void rw_set_functiont::compute_rec(const exprt &function)
 {
   if(function.id()==ID_symbol)
   {
-    const irep_idt &id=to_symbol_expr(function).get_identifier();
+    const irep_idt &function_id = to_symbol_expr(function).get_identifier();
 
-    goto_functionst::function_mapt::const_iterator f_it=
-      goto_functions.function_map.find(id);
+    goto_functionst::function_mapt::const_iterator f_it =
+      goto_functions.function_map.find(function_id);
 
     if(f_it!=goto_functions.function_map.end())
     {
@@ -220,9 +220,14 @@ void rw_set_functiont::compute_rec(const exprt &function)
 
       forall_goto_program_instructions(i_it, body)
       {
-        *this+=rw_set_loct(ns, value_sets, i_it
+        *this += rw_set_loct(
+          ns,
+          value_sets,
+          function_id,
+          i_it
 #ifdef LOCAL_MAY
-        , local_may
+          ,
+          local_may
 #endif
         ); // NOLINT(whitespace/parens)
       }

--- a/src/goto-instrument/rw_set.h
+++ b/src/goto-instrument/rw_set.h
@@ -121,26 +121,31 @@ public:
   _rw_set_loct(
     const namespacet &_ns,
     value_setst &_value_sets,
+    const irep_idt &_function_id,
     goto_programt::const_targett _target,
-    local_may_aliast &may):
-    rw_set_baset(_ns),
-    value_sets(_value_sets),
-    target(_target),
-    local_may(may)
+    local_may_aliast &may)
+    : rw_set_baset(_ns),
+      value_sets(_value_sets),
+      function_id(_function_id),
+      target(_target),
+      local_may(may)
 #else
   _rw_set_loct(
     const namespacet &_ns,
     value_setst &_value_sets,
-    goto_programt::const_targett _target):
-    rw_set_baset(_ns),
-    value_sets(_value_sets),
-    target(_target)
+    const irep_idt &_function_id,
+    goto_programt::const_targett _target)
+    : rw_set_baset(_ns),
+      value_sets(_value_sets),
+      function_id(_function_id),
+      target(_target)
 #endif
   {
   }
 
 protected:
   value_setst &value_sets;
+  const irep_idt function_id;
   const goto_programt::const_targett target;
 
 #ifdef LOCAL_MAY
@@ -180,15 +185,17 @@ public:
   rw_set_loct(
     const namespacet &_ns,
     value_setst &_value_sets,
+    const irep_idt &_function_id,
     goto_programt::const_targett _target,
-    local_may_aliast &may):
-    _rw_set_loct(_ns, _value_sets, _target, may)
+    local_may_aliast &may)
+    : _rw_set_loct(_ns, _value_sets, _function_id, _target, may)
 #else
   rw_set_loct(
     const namespacet &_ns,
     value_setst &_value_sets,
-    goto_programt::const_targett _target):
-    _rw_set_loct(_ns, _value_sets, _target)
+    const irep_idt &_function_id,
+    goto_programt::const_targett _target)
+    : _rw_set_loct(_ns, _value_sets, _function_id, _target)
 #endif
   {
     compute();
@@ -239,17 +246,19 @@ public:
   rw_set_with_trackt(
     const namespacet &_ns,
     value_setst &_value_sets,
+    const irep_idt &_function_id,
     goto_programt::const_targett _target,
-    local_may_aliast &may):
-    _rw_set_loct(_ns, _value_sets, _target, may),
-    dereferencing(false)
+    local_may_aliast &may)
+    : _rw_set_loct(_ns, _value_sets, _function_id, _target, may),
+      dereferencing(false)
 #else
   rw_set_with_trackt(
     const namespacet &_ns,
     value_setst &_value_sets,
-    goto_programt::const_targett _target):
-    _rw_set_loct(_ns, _value_sets, _target),
-    dereferencing(false)
+    const irep_idt &_function_id,
+    goto_programt::const_targett _target)
+    : _rw_set_loct(_ns, _value_sets, _function_id, _target),
+      dereferencing(false)
 #endif
   {
     compute();

--- a/src/goto-instrument/wmm/goto2graph.h
+++ b/src/goto-instrument/wmm/goto2graph.h
@@ -102,18 +102,21 @@ protected:
     unsigned coming_from;
 
     bool contains_shared_array(
+      const irep_idt &function_id,
       goto_programt::const_targett targ,
       goto_programt::const_targett i_it,
       value_setst &value_sets
-      #ifdef LOCAL_MAY
-      , local_may_aliast local_may
-      #endif
-    ) const; // NOLINT(whitespace/parens)
+#ifdef LOCAL_MAY
+      ,
+      local_may_aliast local_may
+#endif
+      ) const; // NOLINT(whitespace/parens)
 
     /* transformers */
     void visit_cfg_thread() const;
     void visit_cfg_propagate(goto_programt::instructionst::iterator i_it);
     void visit_cfg_body(
+      const irep_idt &function_id,
       const goto_programt &goto_program,
       goto_programt::const_targett i_it,
       loop_strategyt replicate_body,
@@ -131,6 +134,7 @@ protected:
       goto_programt::const_targett i_it);
     void visit_cfg_assign(
       value_setst &value_sets,
+      const irep_idt &function_id,
       goto_programt::instructionst::iterator &i_it,
       bool no_dependencies
 #ifdef LOCAL_MAY
@@ -148,6 +152,7 @@ protected:
       bool no_dependenciess,
       loop_strategyt duplicate_body);
     void visit_cfg_goto(
+      const irep_idt &function_id,
       const goto_programt &goto_program,
       goto_programt::instructionst::iterator i_it,
       /* forces the duplication of all the loops, with array or not

--- a/src/goto-instrument/wmm/shared_buffers.cpp
+++ b/src/goto-instrument/wmm/shared_buffers.cpp
@@ -1035,11 +1035,16 @@ void shared_bufferst::affected_by_delay(
 
     Forall_goto_program_instructions(i_it, f_it->second.body)
     {
-        rw_set_loct rw_set(ns, value_sets, i_it
+      rw_set_loct rw_set(
+        ns,
+        value_sets,
+        f_it->first,
+        i_it
 #ifdef LOCAL_MAY
-        , local_may
+        ,
+        local_may
 #endif
-        ); // NOLINT(whitespace/parens)
+      ); // NOLINT(whitespace/parens)
         forall_rw_set_w_entries(w_it, rw_set)
           forall_rw_set_r_entries(r_it, rw_set)
           {
@@ -1093,9 +1098,14 @@ void shared_bufferst::cfg_visitort::weak_memory(
     {
       try
       {
-        rw_set_loct rw_set(ns, value_sets, i_it
+        rw_set_loct rw_set(
+          ns,
+          value_sets,
+          function_id,
+          i_it
 #ifdef LOCAL_MAY
-        , local_may
+          ,
+          local_may
 #endif
         ); // NOLINT(whitespace/parens)
 

--- a/src/goto-instrument/wmm/weak_memory.cpp
+++ b/src/goto-instrument/wmm/weak_memory.cpp
@@ -36,7 +36,7 @@ Date: September 2011
 void introduce_temporaries(
   value_setst &value_sets,
   symbol_tablet &symbol_table,
-  const irep_idt &function,
+  const irep_idt &function_id,
   goto_programt &goto_program,
 #ifdef LOCAL_MAY
   const goto_functionst::goto_functiont &goto_function,
@@ -60,9 +60,14 @@ void introduce_temporaries(
        instruction.is_assert() ||
        instruction.is_assume())
     {
-      rw_set_loct rw_set(ns, value_sets, i_it
+      rw_set_loct rw_set(
+        ns,
+        value_sets,
+        function_id,
+        i_it
 #ifdef LOCAL_MAY
-      , local_may
+        ,
+        local_may
 #endif
       ); // NOLINT(whitespace/parens)
       if(rw_set.empty())
@@ -70,8 +75,8 @@ void introduce_temporaries(
 
       symbolt new_symbol;
       new_symbol.base_name="$tmp_guard";
-      new_symbol.name=
-        id2string(function)+"$tmp_guard"+std::to_string(tmp_counter++);
+      new_symbol.name =
+        id2string(function_id) + "$tmp_guard" + std::to_string(tmp_counter++);
       new_symbol.type=bool_typet();
       new_symbol.is_static_lifetime=true;
       new_symbol.is_thread_local=true;


### PR DESCRIPTION
We are working towards removing the "function" field from
goto_programt::instructionst::instructiont, and thus need to pass the identifier
of the function whenever it actually is required. rw_set does not yet make use
of this, but will need to once dereferencing is updated to require a function
name.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
