### PR TITLE
Dependence graph now tracks a function identifier [blocks: #3126]

### DIFF
--- a/src/analyses/dependence_graph.cpp
+++ b/src/analyses/dependence_graph.cpp
@@ -52,6 +52,7 @@ bool dep_graph_domaint::merge(
 }
 
 void dep_graph_domaint::control_dependencies(
+  const irep_idt &function_id,
   goto_programt::const_targett from,
   goto_programt::const_targett to,
   dependence_grapht &dep_graph)
@@ -82,7 +83,7 @@ void dep_graph_domaint::control_dependencies(
 
   // Get postdominators
 
-  const irep_idt id=from->function;
+  const irep_idt id = function_id;
   const cfg_post_dominatorst &pd=dep_graph.cfg_post_dominators().at(id);
 
   // Check all candidates
@@ -151,6 +152,7 @@ static bool may_be_def_use_pair(
 
 void dep_graph_domaint::data_dependencies(
   goto_programt::const_targett,
+  const irep_idt &function_to,
   goto_programt::const_targett to,
   dependence_grapht &dep_graph,
   const namespacet &ns)
@@ -162,7 +164,7 @@ void dep_graph_domaint::data_dependencies(
   value_setst &value_sets=
     dep_graph.reaching_definitions().get_value_sets();
   rw_range_set_value_sett rw_set(ns, value_sets);
-  goto_rw(to->function, to, rw_set);
+  goto_rw(function_to, to, rw_set);
 
   forall_rw_range_set_r_objects(it, rw_set)
   {
@@ -205,7 +207,7 @@ void dep_graph_domaint::transform(
   {
     if(function_from == function_to)
     {
-      control_dependencies(from, to, *dep_graph);
+      control_dependencies(function_from, from, to, *dep_graph);
     }
     else
     {
@@ -231,9 +233,9 @@ void dep_graph_domaint::transform(
     }
   }
   else
-    control_dependencies(from, to, *dep_graph);
+    control_dependencies(function_from, from, to, *dep_graph);
 
-  data_dependencies(from, to, *dep_graph, ns);
+  data_dependencies(from, function_to, to, *dep_graph, ns);
 }
 
 void dep_graph_domaint::output(

--- a/src/analyses/dependence_graph.h
+++ b/src/analyses/dependence_graph.h
@@ -203,12 +203,14 @@ private:
     dependence_graph_test_get_data_deps(const dep_graph_domaint &);
 
   void control_dependencies(
+    const irep_idt &function_id,
     goto_programt::const_targett from,
     goto_programt::const_targett to,
     dependence_grapht &dep_graph);
 
   void data_dependencies(
     goto_programt::const_targett from,
+    const irep_idt &function_to,
     goto_programt::const_targett to,
     dependence_grapht &dep_graph,
     const namespacet &ns);


### PR DESCRIPTION
We are working towards removing the "function" field from
goto_programt::instructionst::instructiont, and thus need to pass the identifier
of the function whenever it actually is required.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
