### PR TITLE
value_sets now have function identifiers [blocks: #3126]

### DIFF
--- a/src/analyses/flow_insensitive_analysis.h
+++ b/src/analyses/flow_insensitive_analysis.h
@@ -47,8 +47,10 @@ public:
 
   virtual bool transform(
     const namespacet &ns,
+    const irep_idt &function_from,
     locationt from,
-    locationt to)=0;
+    const irep_idt &function_to,
+    locationt to) = 0;
 
   virtual ~flow_insensitive_abstract_domain_baset()
   {
@@ -126,8 +128,8 @@ public:
 
   virtual void update(const goto_functionst &goto_functions);
 
-  virtual void operator()(
-    const goto_programt &goto_program);
+  virtual void
+  operator()(const irep_idt &function_id, const goto_programt &goto_program);
 
   virtual void operator()(
     const goto_functionst &goto_functions);
@@ -146,19 +148,12 @@ public:
     std::ostream &out);
 
   virtual void output(
+    const irep_idt &function_id,
     const goto_programt &goto_program,
-    std::ostream &out)
-  {
-    output(goto_program, "", out);
-  }
+    std::ostream &out);
 
 protected:
   const namespacet &ns;
-
-  virtual void output(
-    const goto_programt &goto_program,
-    const irep_idt &identifier,
-    std::ostream &out) const;
 
   typedef std::priority_queue<locationt> working_sett;
 
@@ -173,6 +168,7 @@ protected:
 
   // true = found something new
   bool fixedpoint(
+    const irep_idt &function_id,
     const goto_programt &goto_program,
     const goto_functionst &goto_functions);
 
@@ -185,6 +181,7 @@ protected:
 
   // true = found something new
   bool visit(
+    const irep_idt &function_id,
     locationt l,
     working_sett &working_set,
     const goto_programt &goto_program,
@@ -206,6 +203,7 @@ protected:
 
   // function calls
   bool do_function_call_rec(
+    const irep_idt &calling_function,
     locationt l_call,
     const exprt &function,
     const exprt::operandst &arguments,
@@ -213,6 +211,7 @@ protected:
     const goto_functionst &goto_functions);
 
   bool do_function_call(
+    const irep_idt &calling_function,
     locationt l_call,
     const goto_functionst &goto_functions,
     const goto_functionst::function_mapt::const_iterator f_it,

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -626,7 +626,7 @@ void rw_range_set_value_sett::get_objects_dereference(
     size);
 
   exprt object=deref;
-  dereference(target, object, ns, value_sets);
+  dereference(function, target, object, ns, value_sets);
 
   auto type_bits = pointer_offset_bits(object.type(), ns);
 

--- a/src/goto-instrument/rw_set.cpp
+++ b/src/goto-instrument/rw_set.cpp
@@ -159,7 +159,7 @@ void _rw_set_loct::read_write_rec(
       read_write_rec(*it, r, w, suffix, guard);
     }
     #else
-    dereference(target, tmp, ns, value_sets);
+    dereference(function_id, target, tmp, ns, value_sets);
 
     read_write_rec(tmp, r, w, suffix, guard);
     #endif

--- a/src/goto-symex/precondition.cpp
+++ b/src/goto-symex/precondition.cpp
@@ -113,7 +113,8 @@ void preconditiont::compute_rec(exprt &dest)
     // aliasing may happen here
 
     value_setst::valuest expr_set;
-    value_sets.get_values(target, deref_expr.pointer(), expr_set);
+    value_sets.get_values(
+      SSA_step.source.function_id, target, deref_expr.pointer(), expr_set);
     std::unordered_set<irep_idt> symbols;
 
     for(value_setst::valuest::const_iterator
@@ -127,7 +128,7 @@ void preconditiont::compute_rec(exprt &dest)
       // may alias!
       exprt tmp;
       tmp.swap(deref_expr.pointer());
-      dereference(target, tmp, ns, value_sets);
+      dereference(SSA_step.source.function_id, target, tmp, ns, value_sets);
       deref_expr.swap(tmp);
       compute_rec(deref_expr);
     }

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -227,7 +227,7 @@ void goto_program_dereferencet::get_value_set(
   const exprt &expr,
   value_setst::valuest &dest)
 {
-  value_sets.get_values(current_target, expr, dest);
+  value_sets.get_values(current_function, current_target, expr, dest);
 }
 
 /// Remove dereference expressions contained in `expr`.
@@ -357,9 +357,11 @@ void goto_program_dereferencet::dereference_instruction(
 
 /// Set the current target to `target` and remove derefence from expr.
 void goto_program_dereferencet::dereference_expression(
+  const irep_idt &function_id,
   goto_programt::const_targett target,
   exprt &expr)
 {
+  current_function = function_id;
   current_target=target;
   #if 0
   valid_local_variables=&target->local_variables;
@@ -448,6 +450,7 @@ void pointer_checks(
 /// Remove dereferences in `expr` using `value_sets` to determine to what
 /// objects the pointers may be pointing to.
 void dereference(
+  const irep_idt &function_id,
   goto_programt::const_targett target,
   exprt &expr,
   const namespacet &ns,
@@ -457,5 +460,5 @@ void dereference(
   symbol_tablet new_symbol_table;
   goto_program_dereferencet
     goto_program_dereference(ns, new_symbol_table, options, value_sets);
-  goto_program_dereference.dereference_expression(target, expr);
+  goto_program_dereference.dereference_expression(function_id, target, expr);
 }

--- a/src/pointer-analysis/goto_program_dereference.h
+++ b/src/pointer-analysis/goto_program_dereference.h
@@ -52,6 +52,7 @@ public:
   void pointer_checks(goto_functionst &goto_functions);
 
   void dereference_expression(
+    const irep_idt &function_id,
     goto_programt::const_targett target,
     exprt &expr);
 
@@ -93,6 +94,7 @@ protected:
 #if 0
   const std::set<irep_idt> *valid_local_variables;
 #endif
+  irep_idt current_function;
   goto_programt::const_targett current_target;
 
   /// Unused
@@ -106,6 +108,7 @@ protected:
 };
 
 void dereference(
+  const irep_idt &function_id,
   goto_programt::const_targett target,
   exprt &expr,
   const namespacet &,

--- a/src/pointer-analysis/value_set_analysis.h
+++ b/src/pointer-analysis/value_set_analysis.h
@@ -59,6 +59,7 @@ public:
 public:
   // interface value_sets
   virtual void get_values(
+    const irep_idt &,
     locationt l,
     const exprt &expr,
     value_setst::valuest &dest)

--- a/src/pointer-analysis/value_set_analysis_fi.h
+++ b/src/pointer-analysis/value_set_analysis_fi.h
@@ -35,8 +35,8 @@ public:
 
   typedef flow_insensitive_analysist<value_set_domain_fit> baset;
 
-  virtual void initialize(const goto_programt &goto_program);
-  virtual void initialize(const goto_functionst &goto_functions);
+  void initialize(const goto_programt &goto_program) override;
+  void initialize(const goto_functionst &goto_functions) override;
 
 protected:
   track_optionst track_options;
@@ -58,15 +58,16 @@ protected:
 
 public:
   // interface value_sets
-  virtual void get_values(
+  void get_values(
+    const irep_idt &function_id,
     locationt l,
     const exprt &expr,
-    std::list<exprt> &dest)
+    std::list<exprt> &dest) override
   {
     state.value_set.from_function =
-      state.value_set.function_numbering.number(l->function);
+      state.value_set.function_numbering.number(function_id);
     state.value_set.to_function =
-      state.value_set.function_numbering.number(l->function);
+      state.value_set.function_numbering.number(function_id);
     state.value_set.from_target_index = l->location_number;
     state.value_set.to_target_index = l->location_number;
     state.value_set.get_value_set(expr, dest, ns);

--- a/src/pointer-analysis/value_set_analysis_fivr.h
+++ b/src/pointer-analysis/value_set_analysis_fivr.h
@@ -35,25 +35,28 @@ public:
 
   typedef flow_insensitive_analysist<value_set_domain_fivrt> baset;
 
-  virtual void initialize(const goto_programt &goto_program);
-  virtual void initialize(const goto_functionst &goto_functions);
+  void initialize(const goto_programt &goto_program) override;
+  void initialize(const goto_functionst &goto_functions) override;
 
   using baset::output;
-  void output(locationt l, std::ostream &out)
+  void output(const irep_idt &function_id, locationt l, std::ostream &out)
   {
-    state.value_set.set_from(l->function, l->location_number);
-    state.value_set.set_to(l->function, l->location_number);
+    state.value_set.set_from(function_id, l->location_number);
+    state.value_set.set_to(function_id, l->location_number);
     state.output(ns, out);
   }
 
-  void output(const goto_programt &goto_program, std::ostream &out)
+  void output(
+    const irep_idt &function_id,
+    const goto_programt &goto_program,
+    std::ostream &out) override
   {
     forall_goto_program_instructions(it, goto_program)
     {
       out << "**** " << it->source_location << '\n';
-      output(it, out);
+      output(function_id, it, out);
       out << '\n';
-      goto_program.output_instruction(ns, "", out, *it);
+      goto_program.output_instruction(ns, function_id, out, *it);
       out << '\n';
     }
   }
@@ -78,15 +81,16 @@ protected:
 
 public:
   // interface value_sets
-  virtual void get_values(
+  void get_values(
+    const irep_idt &function_id,
     locationt l,
     const exprt &expr,
-    std::list<exprt> &dest)
+    std::list<exprt> &dest) override
   {
     state.value_set.from_function =
-      state.value_set.function_numbering.number(l->function);
+      state.value_set.function_numbering.number(function_id);
     state.value_set.to_function =
-      state.value_set.function_numbering.number(l->function);
+      state.value_set.function_numbering.number(function_id);
     state.value_set.from_target_index = l->location_number;
     state.value_set.to_target_index = l->location_number;
     state.value_set.get_value_set(expr, dest, ns);

--- a/src/pointer-analysis/value_set_analysis_fivrns.h
+++ b/src/pointer-analysis/value_set_analysis_fivrns.h
@@ -41,21 +41,24 @@ public:
 
   using baset::output;
 
-  virtual void output(locationt l, std::ostream &out)
+  void output(const irep_idt &function_id, locationt l, std::ostream &out)
   {
-    state.value_set.set_from(l->function, l->location_number);
-    state.value_set.set_to(l->function, l->location_number);
+    state.value_set.set_from(function_id, l->location_number);
+    state.value_set.set_to(function_id, l->location_number);
     state.output(ns, out);
   }
 
-  void output(const goto_programt &goto_program, std::ostream &out)
+  void output(
+    const irep_idt &function_id,
+    const goto_programt &goto_program,
+    std::ostream &out)
   {
     forall_goto_program_instructions(it, goto_program)
     {
       out << "**** " << it->source_location << '\n';
-      output(it, out);
+      output(function_id, it, out);
       out << '\n';
-      goto_program.output_instruction(ns, "", out, *it);
+      goto_program.output_instruction(ns, function_id, out, *it);
       out << '\n';
     }
   }
@@ -81,14 +84,15 @@ protected:
 public:
   // interface value_sets
   virtual void get_values(
+    const irep_idt &function_id,
     locationt l,
     const exprt &expr,
     std::list<exprt> &dest)
   {
     state.value_set.from_function =
-      state.value_set.function_numbering.number(l->function);
+      state.value_set.function_numbering.number(function_id);
     state.value_set.to_function =
-      state.value_set.function_numbering.number(l->function);
+      state.value_set.function_numbering.number(function_id);
     state.value_set.from_target_index = l->location_number;
     state.value_set.to_target_index = l->location_number;
     state.value_set.get_value_set(expr, dest, ns);

--- a/src/pointer-analysis/value_set_domain_fi.cpp
+++ b/src/pointer-analysis/value_set_domain_fi.cpp
@@ -16,17 +16,19 @@ Author: Daniel Kroening, kroening@kroening.com
 
 bool value_set_domain_fit::transform(
   const namespacet &ns,
+  const irep_idt &function_from,
   locationt from_l,
+  const irep_idt &function_to,
   locationt to_l)
 {
   value_set.changed = false;
 
-  value_set.set_from(from_l->function, from_l->location_number);
-  value_set.set_to(to_l->function, to_l->location_number);
+  value_set.set_from(function_from, from_l->location_number);
+  value_set.set_to(function_to, to_l->location_number);
 
-//  std::cout << "transforming: " <<
-//      from_l->function << " " << from_l->location_number << " to " <<
-//      to_l->function << " " << to_l->location_number << '\n';
+  //  std::cout << "transforming: " <<
+  //      from_l->function << " " << from_l->location_number << " to " <<
+  //      to_l->function << " " << to_l->location_number << '\n';
 
   switch(from_l->type)
   {
@@ -49,7 +51,7 @@ bool value_set_domain_fit::transform(
       const code_function_callt &code=
         to_code_function_call(from_l->code);
 
-      value_set.do_function_call(to_l->function, code.arguments(), ns);
+      value_set.do_function_call(function_to, code.arguments(), ns);
     }
     break;
 

--- a/src/pointer-analysis/value_set_domain_fi.h
+++ b/src/pointer-analysis/value_set_domain_fi.h
@@ -29,32 +29,32 @@ public:
 //    return value_set.make_union(other.value_set);
 //  }
 
-  virtual void output(
-    const namespacet &ns,
-    std::ostream &out) const
+  void output(const namespacet &ns, std::ostream &out) const override
   {
     value_set.output(ns, out);
   }
 
-  virtual void initialize(const namespacet &)
+  void initialize(const namespacet &) override
   {
     value_set.clear();
   }
 
-  virtual bool transform(
+  bool transform(
     const namespacet &ns,
+    const irep_idt &function_from,
     locationt from_l,
-    locationt to_l);
+    const irep_idt &function_to,
+    locationt to_l) override;
 
-  virtual void get_reference_set(
+  void get_reference_set(
     const namespacet &ns,
     const exprt &expr,
-    expr_sett &expr_set)
+    expr_sett &expr_set) override
   {
     value_set.get_reference_set(expr, expr_set, ns);
   }
 
-  virtual void clear(void)
+  void clear(void) override
   {
     value_set.clear();
   }

--- a/src/pointer-analysis/value_set_domain_fivr.cpp
+++ b/src/pointer-analysis/value_set_domain_fivr.cpp
@@ -16,17 +16,19 @@ Author: Daniel Kroening, kroening@kroening.com
 
 bool value_set_domain_fivrt::transform(
   const namespacet &ns,
+  const irep_idt &function_from,
   locationt from_l,
+  const irep_idt &function_to,
   locationt to_l)
 {
-  value_set.set_from(from_l->function, from_l->location_number);
-  value_set.set_to(to_l->function, to_l->location_number);
+  value_set.set_from(function_from, from_l->location_number);
+  value_set.set_to(function_to, to_l->location_number);
 
-  #if 0
+#if 0
   std::cout << "Transforming: " <<
     from_l->function << " " << from_l->location_number << " to " <<
     to_l->function << " " << to_l->location_number << '\n';
-  #endif
+#endif
 
   switch(from_l->type)
   {
@@ -45,7 +47,7 @@ bool value_set_domain_fivrt::transform(
       const code_function_callt &code=
         to_code_function_call(from_l->code);
 
-      value_set.do_function_call(to_l->function, code.arguments(), ns);
+      value_set.do_function_call(function_to, code.arguments(), ns);
       break;
     }
 

--- a/src/pointer-analysis/value_set_domain_fivr.h
+++ b/src/pointer-analysis/value_set_domain_fivr.h
@@ -24,33 +24,32 @@ public:
 
   // overloading
 
-  virtual void output(
-    const namespacet &ns,
-    std::ostream &out) const
+  void output(const namespacet &ns, std::ostream &out) const override
   {
     value_set.output(ns, out);
   }
 
-  virtual void initialize(
-    const namespacet &)
+  void initialize(const namespacet &) override
   {
     value_set.clear();
   }
 
-  virtual bool transform(
+  bool transform(
     const namespacet &ns,
+    const irep_idt &function_from,
     locationt from_l,
-    locationt to_l);
+    const irep_idt &function_to,
+    locationt to_l) override;
 
-  virtual void get_reference_set(
+  void get_reference_set(
     const namespacet &ns,
     const exprt &expr,
-    expr_sett &expr_set)
+    expr_sett &expr_set) override
   {
     value_set.get_reference_set(expr, expr_set, ns);
   }
 
-  virtual void clear(void)
+  void clear(void) override
   {
     value_set.clear();
   }

--- a/src/pointer-analysis/value_set_domain_fivrns.cpp
+++ b/src/pointer-analysis/value_set_domain_fivrns.cpp
@@ -16,17 +16,19 @@ Author: Daniel Kroening, kroening@kroening.com
 
 bool value_set_domain_fivrnst::transform(
   const namespacet &ns,
+  const irep_idt &function_from,
   locationt from_l,
+  const irep_idt &function_to,
   locationt to_l)
 {
-  value_set.set_from(from_l->function, from_l->location_number);
-  value_set.set_to(to_l->function, to_l->location_number);
+  value_set.set_from(function_from, from_l->location_number);
+  value_set.set_to(function_to, to_l->location_number);
 
-  #if 0
+#if 0
   std::cout << "Transforming: " <<
     from_l->function << " " << from_l->location_number << " to " <<
     to_l->function << " " << to_l->location_number << '\n';
-  #endif
+#endif
 
   switch(from_l->type)
   {
@@ -45,7 +47,7 @@ bool value_set_domain_fivrnst::transform(
       const code_function_callt &code=
         to_code_function_call(from_l->code);
 
-      value_set.do_function_call(to_l->function, code.arguments(), ns);
+      value_set.do_function_call(function_to, code.arguments(), ns);
       break;
     }
 

--- a/src/pointer-analysis/value_set_domain_fivrns.h
+++ b/src/pointer-analysis/value_set_domain_fivrns.h
@@ -40,7 +40,9 @@ public:
 
   virtual bool transform(
     const namespacet &ns,
+    const irep_idt &function_from,
     locationt from_l,
+    const irep_idt &function_to,
     locationt to_l);
 
   virtual void get_reference_set(

--- a/src/pointer-analysis/value_sets.h
+++ b/src/pointer-analysis/value_sets.h
@@ -29,9 +29,10 @@ public:
 
   // this is not const to allow a lazy evaluation
   virtual void get_values(
+    const irep_idt &function_id,
     goto_programt::const_targett l,
     const exprt &expr,
-    valuest &dest)=0;
+    valuest &dest) = 0;
 
   virtual ~value_setst()
   {


### PR DESCRIPTION
We are working towards removing the "function" field from
goto_programt::instructionst::instructiont, and thus need to pass the identifier
of the function whenever it actually is required.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
