### PR TITLE
Improve documentation in gen_nondet_array_init

### DIFF
--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -1426,7 +1426,7 @@ void java_object_factoryt::gen_nondet_array_init(
 
   if(element_type.id() == ID_pointer || element_type.id() == ID_c_bool)
   {
-    // For arrays of non-primitive types, nondeterministically initialize each
+    // For arrays of non-primitive type, nondeterministically initialize each
     // element of the array
     array_loop_init_code(
       assignments,
@@ -1440,10 +1440,10 @@ void java_object_factoryt::gen_nondet_array_init(
   }
   else
   {
-    // Arrays of primitive types can be initialized with a single instruction
-    // We don't do this for arrays of Booleans, because Bools are represented
-    // as bytes, so each cell must be initialized in a particular way (see
-    // gen_nondet_init).
+    // Arrays of primitive type can be initialized with a single instruction.
+    // We don't do this for arrays of primitive booleans, because booleans are
+    // represented as unsigned bytes, so each cell must be initialized as
+    // 0 or 1 (see gen_nondet_init).
     array_primitive_init_code(
       assignments,
       init_array_expr,


### PR DESCRIPTION
Remove ambiguity between primitive boolean and Boolean objects.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
