### PR TITLE
Initialise symbol_exprt in the constructor [blocks: #3768]

### DIFF
--- a/src/goto-symex/slice_by_trace.cpp
+++ b/src/goto-symex/slice_by_trace.cpp
@@ -31,10 +31,6 @@ void symex_slice_by_tracet::slice_by_trace(
 {
   std::cout << "Slicing by trace...\n";
 
-  merge_identifier="goto_symex::\\merge";
-  merge_symbol=symbol_exprt(typet(ID_bool));
-  merge_symbol.set_identifier(merge_identifier);
-
   std::vector<exprt> trace_conditions;
 
   size_t length=trace_files.length();

--- a/src/goto-symex/slice_by_trace.h
+++ b/src/goto-symex/slice_by_trace.h
@@ -17,9 +17,11 @@ Author: Alex Groce (agroce@gmail.com)
 class symex_slice_by_tracet
 {
 public:
-  explicit symex_slice_by_tracet(const namespacet &_ns):
-    ns(_ns),
-    alphabet_parity(false)
+  explicit symex_slice_by_tracet(const namespacet &_ns)
+    : ns(_ns),
+      alphabet_parity(false),
+      merge_symbol("goto_symex::\\merge", bool_typet())
+
   {
   }
 


### PR DESCRIPTION
No need to delay initialisation - do proper RAII.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
