### PR TITLE
Use generic exprt to avoid deprecated default constructor of symbol_exprt [blocks: #3768]

### DIFF
--- a/src/goto-instrument/concurrency.cpp
+++ b/src/goto-instrument/concurrency.cpp
@@ -15,6 +15,7 @@ Date: October 2012
 
 #include <util/find_symbols.h>
 #include <util/invariant.h>
+#include <util/optional.h>
 #include <util/replace_symbol.h>
 #include <util/std_expr.h>
 
@@ -58,14 +59,14 @@ protected:
   {
   public:
     typet type;
-    symbol_exprt array_symbol, w_index_symbol;
+    optionalt<symbol_exprt> array_symbol, w_index_symbol;
   };
 
   class thread_local_vart
   {
   public:
     typet type;
-    symbol_exprt array_symbol;
+    optionalt<symbol_exprt> array_symbol;
   };
 
   typedef std::map<irep_idt, shared_vart> shared_varst;
@@ -101,7 +102,7 @@ void concurrency_instrumentationt::instrument(exprt &expr)
         // initialized anywhere
         const shared_vart &shared_var = v_it->second;
         const index_exprt new_expr(
-          shared_var.array_symbol, shared_var.w_index_symbol);
+          *shared_var.array_symbol, *shared_var.w_index_symbol);
 
         replace_symbol.insert(s, new_expr);
       }


### PR DESCRIPTION
The implementation here is highly incomplete, in particular those symbols are
never set. If at some future date the implementation is completed then the type
of those members might be changed again.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
