### PR TITLE
Use numeric_cast_v<unsigned> instead to_ulong with incompatible types [blocks: #3800]

### DIFF
--- a/src/goto-instrument/accelerate/acceleration_utils.cpp
+++ b/src/goto-instrument/accelerate/acceleration_utils.cpp
@@ -1235,7 +1235,7 @@ void acceleration_utilst::extract_polynomial(
     std::map<exprt, int> degrees;
 
     mp_integer mp=binary2integer(concrete_term.get_value().c_str(), true);
-    monomial.coeff=mp.to_long();
+    monomial.coeff = numeric_cast_v<int>(mp);
 
     if(monomial.coeff==0)
     {

--- a/src/util/arith_tools.cpp
+++ b/src/util/arith_tools.cpp
@@ -231,7 +231,7 @@ mp_integer power(const mp_integer &base,
     case 2:
       {
         mp_integer result;
-        result.setPower2(exponent.to_ulong());
+        result.setPower2(numeric_cast_v<unsigned>(exponent));
         return result;
       }
     case 1: return 1;

--- a/src/util/ieee_float.cpp
+++ b/src/util/ieee_float.cpp
@@ -8,7 +8,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "ieee_float.h"
 
-#include <cstdint>
 #include <ostream>
 #include <cmath>
 #include <limits>
@@ -1242,11 +1241,7 @@ float ieee_floatt::to_float() const
       return std::numeric_limits<float>::quiet_NaN();
   }
 
-  mp_integer i=pack();
-  CHECK_RETURN(i.is_ulong());
-  CHECK_RETURN(i <= std::numeric_limits<std::uint32_t>::max());
-
-  a.i=i.to_ulong();
+  a.i = numeric_cast_v<uint32_t>(pack());
   return a.f;
 }
 


### PR DESCRIPTION
An unsigned need not be as wide as an unsigned long - make good use of
numeric_cast instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
