### PR TITLE
Replace uses of deprecated integer2ulong [blocks: #3800]

### DIFF
--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -1831,7 +1831,7 @@ std::string expr2ct::convert_constant(
       else if(int_value>=' ' && int_value<126)
       {
         dest+='\'';
-        dest+=static_cast<char>(integer2ulong(int_value));
+        dest += numeric_cast_v<char>(int_value);
         dest+='\'';
       }
       else

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -511,12 +511,14 @@ exprt interpretert::get_value(
     }
     return std::move(result);
   }
-  if(use_non_det &&
-     memory[integer2ulong(offset)].initialized!=
-     memory_cellt::initializedt::WRITTEN_BEFORE_READ)
+  if(
+    use_non_det && memory[numeric_cast_v<std::size_t>(offset)].initialized !=
+                     memory_cellt::initializedt::WRITTEN_BEFORE_READ)
+  {
     return side_effect_expr_nondett(type, source_locationt());
+  }
   mp_vectort rhs;
-  rhs.push_back(memory[integer2ulong(offset)].value);
+  rhs.push_back(memory[numeric_cast_v<std::size_t>(offset)].value);
   return get_value(type, rhs);
 }
 
@@ -647,7 +649,7 @@ exprt interpretert::get_value(
   }
 
   // Retrieve value of basic data type
-  return from_integer(rhs[integer2ulong(offset)], type);
+  return from_integer(rhs[numeric_cast_v<std::size_t>(offset)], type);
 }
 
 /// executes the assign statement at the current pc value
@@ -690,7 +692,7 @@ void interpretert::execute_assign()
 
       for(mp_integer i=0; i<size; ++i)
       {
-        memory[integer2ulong(address+i)].initialized=
+        memory[numeric_cast_v<std::size_t>(address + i)].initialized =
           memory_cellt::initializedt::READ_BEFORE_WRITTEN;
       }
     }
@@ -707,7 +709,7 @@ void interpretert::assign(
     if((address+i)<memory.size())
     {
       mp_integer address_val=address+i;
-      memory_cellt &cell=memory[integer2ulong(address_val)];
+      memory_cellt &cell = memory[numeric_cast_v<std::size_t>(address_val)];
       if(show)
       {
         status() << total_steps << " ** assigning "
@@ -884,7 +886,7 @@ void interpretert::build_memory_map(const symbolt &symbol)
   if(size!=0)
   {
     mp_integer address=memory.size();
-    memory.resize(integer2ulong(address+size));
+    memory.resize(numeric_cast_v<std::size_t>(address + size));
     memory_map[symbol.name]=address;
     inverse_memory_map[address]=symbol.name;
   }
@@ -942,7 +944,7 @@ mp_integer interpretert::build_memory_map(
     size=1; // This is a hack to create existence
 
   mp_integer address=memory.size();
-  memory.resize(integer2ulong(address+size));
+  memory.resize(numeric_cast_v<std::size_t>(address + size));
   memory_map[id]=address;
   inverse_memory_map[address]=id;
   dynamic_types.insert(std::pair<const irep_idt, typet>(id, alloc_type));

--- a/src/goto-programs/interpreter_class.h
+++ b/src/goto-programs/interpreter_class.h
@@ -145,7 +145,7 @@ protected:
 
   mp_integer base_address_to_actual_size(const mp_integer &address) const
   {
-    auto memory_iter=memory.find(integer2ulong(address));
+    auto memory_iter = memory.find(numeric_cast_v<std::size_t>(address));
     if(memory_iter==memory.end())
       return 0;
     mp_integer ret=0;

--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -33,7 +33,8 @@ void interpretert::read(
 
     if((address+i)<memory.size())
     {
-      const memory_cellt &cell=memory[integer2ulong(address+i)];
+      const memory_cellt &cell =
+        memory[numeric_cast_v<std::size_t>(address + i)];
       value=cell.value;
       if(cell.initialized==memory_cellt::initializedt::UNKNOWN)
         cell.initialized=memory_cellt::initializedt::READ_BEFORE_WRITTEN;
@@ -84,7 +85,7 @@ void interpretert::allocate(
   {
     if((address+i)<memory.size())
     {
-      memory_cellt &cell=memory[integer2ulong(address+i)];
+      memory_cellt &cell = memory[numeric_cast_v<std::size_t>(address + i)];
       cell.value=0;
       cell.initialized=memory_cellt::initializedt::UNKNOWN;
     }


### PR DESCRIPTION
Use suitable numeric_cast<...>.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
