### PR TITLE
Use non-deprecated variant of to_integer [blocks: #3800]

### DIFF
--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2592,7 +2592,7 @@ exprt c_typecheck_baset::do_special_functions(
       arg1=1;
     else if(expr.arguments()[1].is_false())
       arg1=0;
-    else if(to_integer(expr.arguments()[1], arg1))
+    else if(to_integer(to_constant_expr(expr.arguments()[1]), arg1))
     {
       error().source_location = f_op.source_location();
       error() << "__builtin_object_size expects constant as second argument, "

--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -726,7 +726,7 @@ designatort c_typecheck_baset::make_designator(
 
       mp_integer index, size;
 
-      if(to_integer(tmp_index, index))
+      if(to_integer(to_constant_expr(tmp_index), index))
       {
         error().source_location = d_op.op0().source_location();
         error() << "expected constant array index designator" << eom;

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -316,7 +316,7 @@ void c_typecheck_baset::typecheck_custom_type(typet &type)
   make_constant_index(size_expr);
 
   mp_integer size_int;
-  if(to_integer(size_expr, size_int))
+  if(to_integer(to_constant_expr(size_expr), size_int))
   {
     error().source_location=source_location;
     error() << "failed to convert bit vector width to constant" << eom;
@@ -354,7 +354,7 @@ void c_typecheck_baset::typecheck_custom_type(typet &type)
     make_constant_index(f_expr);
 
     mp_integer f_int;
-    if(to_integer(f_expr, f_int))
+    if(to_integer(to_constant_expr(f_expr), f_int))
     {
       error().source_location = fraction_source_location;
       error() << "failed to convert number of fraction bits to constant" << eom;
@@ -386,7 +386,7 @@ void c_typecheck_baset::typecheck_custom_type(typet &type)
     make_constant_index(f_expr);
 
     mp_integer f_int;
-    if(to_integer(f_expr, f_int))
+    if(to_integer(to_constant_expr(f_expr), f_int))
     {
       error().source_location = fraction_source_location;
       error() << "failed to convert number of fraction bits to constant" << eom;
@@ -560,7 +560,7 @@ void c_typecheck_baset::typecheck_array_type(array_typet &type)
     if(tmp_size.is_constant())
     {
       mp_integer s;
-      if(to_integer(tmp_size, s))
+      if(to_integer(to_constant_expr(tmp_size), s))
       {
         error().source_location = size_source_location;
         error() << "failed to convert constant: "
@@ -684,7 +684,7 @@ void c_typecheck_baset::typecheck_vector_type(vector_typet &type)
   make_constant_index(size);
 
   mp_integer s;
-  if(to_integer(size, s))
+  if(to_integer(to_constant_expr(size), s))
   {
     error().source_location=source_location;
     error() << "failed to convert constant: "
@@ -1174,7 +1174,9 @@ void c_typecheck_baset::typecheck_c_enum_type(typet &type)
         value=1;
       else if(tmp_v.is_false())
         value=0;
-      else if(!to_integer(tmp_v, value))
+      else if(
+        tmp_v.id() == ID_constant &&
+        !to_integer(to_constant_expr(tmp_v), value))
       {
       }
       else
@@ -1384,7 +1386,7 @@ void c_typecheck_baset::typecheck_c_bit_field_type(c_bit_field_typet &type)
     typecheck_expr(width_expr);
     make_constant_index(width_expr);
 
-    if(to_integer(width_expr, i))
+    if(to_integer(to_constant_expr(width_expr), i))
     {
       error().source_location=type.source_location();
       error() << "failed to convert bit field width" << eom;

--- a/src/cpp/cpp_constructor.cpp
+++ b/src/cpp/cpp_constructor.cpp
@@ -68,7 +68,7 @@ optionalt<codet> cpp_typecheckt::cpp_constructor(
     make_constant_index(tmp_size);
 
     mp_integer s;
-    if(to_integer(tmp_size, s))
+    if(to_integer(to_constant_expr(tmp_size), s))
     {
       error().source_location=source_location;
       error() << "array size `" << to_string(size_expr)

--- a/src/cpp/cpp_destructor.cpp
+++ b/src/cpp/cpp_destructor.cpp
@@ -45,7 +45,7 @@ optionalt<codet> cpp_typecheckt::cpp_destructor(
     make_constant_index(tmp_size);
 
     mp_integer s;
-    if(to_integer(tmp_size, s))
+    if(to_integer(to_constant_expr(tmp_size), s))
     {
       error().source_location=source_location;
       error() << "array size `" << to_string(size_expr)

--- a/src/cpp/cpp_instantiate_template.cpp
+++ b/src/cpp/cpp_instantiate_template.cpp
@@ -63,7 +63,7 @@ std::string cpp_typecheckt::template_suffix(
         i=1;
       else if(e.is_false())
         i=0;
-      else if(to_integer(e, i))
+      else if(to_integer(to_constant_expr(e), i))
       {
         error().source_location = expr.find_source_location();
         error() << "template argument expression expected to be "

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -532,7 +532,7 @@ void cpp_typecheckt::typecheck_compound_declarator(
       if(value.is_not_nil() && value.id() == ID_constant)
       {
         mp_integer i;
-        to_integer(value, i);
+        to_integer(to_constant_expr(value), i);
         if(i!=0)
         {
           error().source_location = declarator.name().source_location();

--- a/src/cpp/cpp_typecheck_enum_type.cpp
+++ b/src/cpp/cpp_typecheck_enum_type.cpp
@@ -40,7 +40,7 @@ void cpp_typecheckt::typecheck_enum_body(symbolt &enum_symbol)
       typecheck_expr(value);
       implicit_typecast(value, c_enum_type.subtype());
       make_constant(value);
-      if(to_integer(value, i))
+      if(to_integer(to_constant_expr(value), i))
       {
         error().source_location=value.find_source_location();
         error() << "failed to produce integer for enum constant" << eom;

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -82,8 +82,9 @@ void goto_convertt::do_prob_uniform(
 
   mp_integer lb, ub;
 
-  if(to_integer(arguments[0], lb) ||
-     to_integer(arguments[1], ub))
+  if(
+    to_integer(to_constant_expr(arguments[0]), lb) ||
+    to_integer(to_constant_expr(arguments[1]), ub))
   {
     error().source_location=function.find_source_location();
     error() << "error converting operands" << eom;
@@ -147,10 +148,21 @@ void goto_convertt::do_prob_coin(
     throw 0;
   }
 
+  if(
+    arguments[1].type().id() != ID_unsignedbv ||
+    arguments[1].id() != ID_constant)
+  {
+    error().source_location = function.find_source_location();
+    error() << "`" << identifier << "' expected second operand to be "
+            << "a constant literal of type unsigned long" << eom;
+    throw 0;
+  }
+
   mp_integer num, den;
 
-  if(to_integer(arguments[0], num) ||
-     to_integer(arguments[1], den))
+  if(
+    to_integer(to_constant_expr(arguments[0]), num) ||
+    to_integer(to_constant_expr(arguments[1]), den))
   {
     error().source_location=function.find_source_location();
     error() << "error converting operands" << eom;

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -1772,7 +1772,7 @@ bool simplify_exprt::simplify_inequality_constant(exprt &expr)
         if(it->is_constant())
         {
           mp_integer i;
-          if(!to_integer(*it, i))
+          if(!to_integer(to_constant_expr(*it), i))
           {
             constant+=i;
             *it=from_integer(0, it->type());

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -28,21 +28,22 @@ static bool is_dereference_integer_object(
   if(expr.id()==ID_dereference &&
      expr.operands().size()==1)
   {
-    if(expr.op0().id()==ID_typecast &&
-       expr.op0().operands().size()==1 &&
-       expr.op0().op0().is_constant() &&
-       !to_integer(expr.op0().op0(), address))
+    if(
+      expr.op0().id() == ID_typecast && expr.op0().operands().size() == 1 &&
+      expr.op0().op0().is_constant() &&
+      !to_integer(to_constant_expr(expr.op0().op0()), address))
       return true;
 
     if(expr.op0().is_constant())
     {
-      if(to_constant_expr(expr.op0()).get_value()==ID_NULL &&
-         config.ansi_c.NULL_is_zero) // NULL
+      const constant_exprt &op0 = to_constant_expr(expr.op0());
+
+      if(op0.get_value() == ID_NULL && config.ansi_c.NULL_is_zero) // NULL
       {
         address=0;
         return true;
       }
-      else if(!to_integer(expr.op0(), address))
+      else if(!to_integer(op0, address))
         return true;
     }
   }


### PR DESCRIPTION
to_integer requires a constant_exprt as first argument.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
