### PR TITLE
Use numeric_cast<mp_integer> instead of deprecated to_integer variants [blocks: #3800]

### DIFF
--- a/regression/cbmc-library/memmove-01/main.c
+++ b/regression/cbmc-library/memmove-01/main.c
@@ -47,5 +47,11 @@ int main(int argc, char *argv[])
   printf("%d %d %d %d %d %d %d\n", a[0], a[1], a[2], a[3], a[4], a[5], a[6]);
 
   assert(a[0] == -2147483600);
+  assert(a[1] == -2147221455);
+  assert(a[2] == -2147221455);
+  assert(a[3] == -2147221455);
+  assert(a[4] == 16);
+  assert(a[5] == 256);
+  assert(a[6] == 16384);
   return 0;
 }

--- a/regression/cbmc-library/memmove-01/test.desc
+++ b/regression/cbmc-library/memmove-01/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.c
 --unwind 17
 ^EXIT=0$
@@ -6,3 +6,8 @@ main.c
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
+--
+Since we cannot constant-propagate lsize, we generate byte_extract operations
+over an int-array of unknown size when invoking memmove. This could be fixed by
+not using array_copy/array_replace in memmove, extensions to the byte-operator
+lowering, or field-sensitive SSA (this regression test is fully deterministic).

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -150,22 +150,21 @@ void rw_range_sett::get_objects_byte_extract(
 {
   const exprt simp_offset=simplify_expr(be.offset(), ns);
 
-  mp_integer index;
-  if(range_start==-1 || to_integer(simp_offset, index))
+  auto index = numeric_cast<mp_integer>(simp_offset);
+  if(range_start == -1 || !index.has_value())
     get_objects_rec(mode, be.op(), -1, size);
   else
   {
-    index*=8;
-    if(index>=pointer_offset_bits(be.op().type(), ns))
+    *index *= 8;
+    if(*index >= *pointer_offset_bits(be.op().type(), ns))
       return;
 
     endianness_mapt map(
       be.op().type(),
       be.id()==ID_byte_extract_little_endian,
       ns);
-    assert(index<std::numeric_limits<size_t>::max());
     range_spect offset =
-      range_start + map.map_bit(numeric_cast_v<std::size_t>(index));
+      range_start + map.map_bit(numeric_cast_v<std::size_t>(*index));
     get_objects_rec(mode, be.op(), offset, size);
   }
 }

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2899,12 +2899,13 @@ bool c_typecheck_baset::gcc_vector_types_compatible(
   // This is relatively restrictive!
 
   // compare dimension
-  mp_integer s0, s1;
-  if(to_integer(type0.size(), s0))
+  const auto s0 = numeric_cast<mp_integer>(type0.size());
+  const auto s1 = numeric_cast<mp_integer>(type1.size());
+  if(!s0.has_value())
     return false;
-  if(to_integer(type1.size(), s1))
+  if(!s1.has_value())
     return false;
-  if(s0!=s1)
+  if(*s0 != *s1)
     return false;
 
   // compare subtype

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -703,9 +703,9 @@ void c_typecheck_baset::typecheck_vector_type(vector_typet &type)
 
   simplify(size_expr, *this);
 
-  mp_integer sub_size;
+  const auto sub_size = numeric_cast<mp_integer>(size_expr);
 
-  if(to_integer(size_expr, sub_size))
+  if(!sub_size.has_value())
   {
     error().source_location=source_location;
     error() << "failed to determine size of vector base type `"
@@ -713,7 +713,7 @@ void c_typecheck_baset::typecheck_vector_type(vector_typet &type)
     throw 0;
   }
 
-  if(sub_size==0)
+  if(*sub_size == 0)
   {
     error().source_location=source_location;
     error() << "type had size 0: `"
@@ -722,16 +722,16 @@ void c_typecheck_baset::typecheck_vector_type(vector_typet &type)
   }
 
   // adjust by width of base type
-  if(s%sub_size!=0)
+  if(s % *sub_size != 0)
   {
     error().source_location=source_location;
     error() << "vector size (" << s
-            << ") expected to be multiple of base type size (" << sub_size
+            << ") expected to be multiple of base type size (" << *sub_size
             << ")" << eom;
     throw 0;
   }
 
-  s/=sub_size;
+  s /= *sub_size;
 
   type.size()=from_integer(s, signed_size_type());
 }

--- a/src/cpp/cpp_typecheck_initializer.cpp
+++ b/src/cpp/cpp_typecheck_initializer.cpp
@@ -270,12 +270,12 @@ void cpp_typecheckt::zero_initializer(
 
       exprt component_size=size_of_expr(component.type(), *this);
 
-      mp_integer size_int;
-      if(!to_integer(component_size, size_int))
+      const auto size_int = numeric_cast<mp_integer>(component_size);
+      if(size_int.has_value())
       {
-        if(size_int>max_comp_size)
+        if(*size_int > max_comp_size)
         {
-          max_comp_size=size_int;
+          max_comp_size = *size_int;
           comp=component;
         }
       }

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -696,8 +696,8 @@ exprt cpp_typecheck_resolvet::do_builtin(
 
     resolve_argument(argument, fargs);
 
-    mp_integer i;
-    if(to_integer(argument, i))
+    const auto i = numeric_cast<mp_integer>(argument);
+    if(!i.has_value())
     {
       cpp_typecheck.error().source_location=source_location;
       cpp_typecheck.error() << "template argument must be constant"
@@ -705,7 +705,7 @@ exprt cpp_typecheck_resolvet::do_builtin(
       throw 0;
     }
 
-    if(i<1)
+    if(*i < 1)
     {
       cpp_typecheck.error().source_location=source_location;
       cpp_typecheck.error()
@@ -715,7 +715,7 @@ exprt cpp_typecheck_resolvet::do_builtin(
     }
 
     dest=type_exprt(typet(base_name));
-    dest.type().set(ID_width, integer2string(i));
+    dest.type().set(ID_width, integer2string(*i));
   }
   else if(base_name==ID_fixedbv)
   {
@@ -751,9 +751,9 @@ exprt cpp_typecheck_resolvet::do_builtin(
       throw 0;
     }
 
-    mp_integer width, integer_bits;
+    const auto width = numeric_cast<mp_integer>(argument0);
 
-    if(to_integer(argument0, width))
+    if(!width.has_value())
     {
       cpp_typecheck.error().source_location=argument0.find_source_location();
       cpp_typecheck.error() << "template argument must be constant"
@@ -761,7 +761,9 @@ exprt cpp_typecheck_resolvet::do_builtin(
       throw 0;
     }
 
-    if(to_integer(argument1, integer_bits))
+    const auto integer_bits = numeric_cast<mp_integer>(argument1);
+
+    if(!integer_bits.has_value())
     {
       cpp_typecheck.error().source_location=argument1.find_source_location();
       cpp_typecheck.error() << "template argument must be constant"
@@ -769,7 +771,7 @@ exprt cpp_typecheck_resolvet::do_builtin(
       throw 0;
     }
 
-    if(width<1)
+    if(*width < 1)
     {
       cpp_typecheck.error().source_location=argument0.find_source_location();
       cpp_typecheck.error()
@@ -778,7 +780,7 @@ exprt cpp_typecheck_resolvet::do_builtin(
       throw 0;
     }
 
-    if(integer_bits<0)
+    if(*integer_bits < 0)
     {
       cpp_typecheck.error().source_location=argument1.find_source_location();
       cpp_typecheck.error()
@@ -787,7 +789,7 @@ exprt cpp_typecheck_resolvet::do_builtin(
       throw 0;
     }
 
-    if(integer_bits>width)
+    if(*integer_bits > *width)
     {
       cpp_typecheck.error().source_location=argument1.find_source_location();
       cpp_typecheck.error()
@@ -797,8 +799,8 @@ exprt cpp_typecheck_resolvet::do_builtin(
     }
 
     dest=type_exprt(typet(base_name));
-    dest.type().set(ID_width, integer2string(width));
-    dest.type().set(ID_integer_bits, integer2string(integer_bits));
+    dest.type().set(ID_width, integer2string(*width));
+    dest.type().set(ID_integer_bits, integer2string(*integer_bits));
   }
   else if(base_name==ID_integer)
   {

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -841,17 +841,18 @@ bool string_abstractiont::build_array(const array_exprt &object,
     return true;
 
   const exprt &a_size=to_array_type(object.type()).size();
-  mp_integer size;
+  const auto size = numeric_cast<mp_integer>(a_size);
   // don't do anything, if we cannot determine the size
-  if(to_integer(a_size, size))
+  if(!size.has_value())
     return true;
   INVARIANT(
-    size == object.operands().size(), "wrong number of array object arguments");
+    *size == object.operands().size(),
+    "wrong number of array object arguments");
 
   exprt::operandst::const_iterator it=object.operands().begin();
-  for(mp_integer i=0; i<size; ++i, ++it)
+  for(mp_integer i = 0; i < *size; ++i, ++it)
     if(it->is_zero())
-      return build_symbol_constant(i, size, dest);
+      return build_symbol_constant(i, *size, dest);
 
   return true;
 }
@@ -1216,11 +1217,11 @@ goto_programt::targett string_abstractiont::value_assignments(
   if(lhs.type().id()==ID_array)
   {
     const exprt &a_size=to_array_type(lhs.type()).size();
-    mp_integer size;
+    const auto size = numeric_cast<mp_integer>(a_size);
     // don't do anything, if we cannot determine the size
-    if(to_integer(a_size, size))
+    if(!size.has_value())
       return target;
-    for(mp_integer i=0; i<size; ++i)
+    for(mp_integer i = 0; i < *size; ++i)
       target=value_assignments(dest, target,
           index_exprt(lhs, from_integer(i, a_size.type())),
           index_exprt(rhs, from_integer(i, a_size.type())));

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -553,19 +553,19 @@ void value_set_fit::get_value_set_rec(
         {
           if(expr.op0().type().id()!=ID_pointer)
           {
-            mp_integer i;
-            if(to_integer(expr.op0(), i))
+            const auto i = numeric_cast<mp_integer>(expr.op0());
+            if(!i.has_value())
               offset.reset();
             else
-              *offset = (expr.id() == ID_plus) ? i : -i;
+              *offset = (expr.id() == ID_plus) ? *i : -*i;
           }
           else
           {
-            mp_integer i;
-            if(to_integer(expr.op1(), i))
+            const auto i = numeric_cast<mp_integer>(expr.op1());
+            if(!i.has_value())
               offset.reset();
             else
-              *offset = (expr.id() == ID_plus) ? i : -i;
+              *offset = (expr.id() == ID_plus) ? *i : -*i;
           }
         }
         else
@@ -862,13 +862,13 @@ void value_set_fit::get_reference_set_sharing_rec(
           casted_index = index_expr;
 
         offsett o = a_it->second;
-        mp_integer i;
+        const auto i = numeric_cast<mp_integer>(offset);
 
         if(offset.is_zero())
         {
         }
-        else if(!to_integer(offset, i) && offset_is_zero(o))
-          *o = i;
+        else if(i.has_value() && offset_is_zero(o))
+          *o = *i;
         else
           o.reset();
 

--- a/src/pointer-analysis/value_set_fivr.cpp
+++ b/src/pointer-analysis/value_set_fivr.cpp
@@ -669,19 +669,19 @@ void value_set_fivrt::get_value_set_rec(
         {
           if(expr.op0().type().id()!=ID_pointer)
           {
-            mp_integer i;
-            if(to_integer(expr.op0(), i))
+            const auto i = numeric_cast<mp_integer>(expr.op0());
+            if(!i.has_value())
               offset.reset();
             else
-              *offset = (expr.id() == ID_plus) ? i : -i;
+              *offset = (expr.id() == ID_plus) ? *i : -*i;
           }
           else
           {
-            mp_integer i;
-            if(to_integer(expr.op1(), i))
+            const auto i = numeric_cast<mp_integer>(expr.op1());
+            if(!i.has_value())
               offset.reset();
             else
-              *offset = (expr.id() == ID_plus) ? i : -i;
+              *offset = (expr.id() == ID_plus) ? *i : -*i;
           }
         }
         else
@@ -973,13 +973,13 @@ void value_set_fivrt::get_reference_set_sharing_rec(
           casted_index = index_expr;
 
         offsett o = a_it->second;
-        mp_integer i;
+        const auto i = numeric_cast<mp_integer>(offset);
 
         if(offset.is_zero())
         {
         }
-        else if(!to_integer(offset, i) && offset_is_zero(o))
-          *o = i;
+        else if(i.has_value() && offset_is_zero(o))
+          *o = *i;
         else
           o.reset();
 

--- a/src/pointer-analysis/value_set_fivrns.cpp
+++ b/src/pointer-analysis/value_set_fivrns.cpp
@@ -459,19 +459,19 @@ void value_set_fivrnst::get_value_set_rec(
         {
           if(expr.op0().type().id()!=ID_pointer)
           {
-            mp_integer i;
-            if(to_integer(expr.op0(), i))
+            const auto i = numeric_cast<mp_integer>(expr.op0());
+            if(!i.has_value())
               offset.reset();
             else
-              *offset = (expr.id() == ID_plus) ? i : -i;
+              *offset = (expr.id() == ID_plus) ? *i : -*i;
           }
           else
           {
-            mp_integer i;
-            if(to_integer(expr.op1(), i))
+            const auto i = numeric_cast<mp_integer>(expr.op1());
+            if(!i.has_value())
               offset.reset();
             else
-              *offset = (expr.id() == ID_plus) ? i : -i;
+              *offset = (expr.id() == ID_plus) ? *i : -*i;
           }
         }
         else
@@ -666,13 +666,13 @@ void value_set_fivrnst::get_reference_set_rec(
           casted_index = index_expr;
 
         offsett o = a_it->second;
-        mp_integer i;
+        const auto i = numeric_cast<mp_integer>(offset);
 
         if(offset.is_zero())
         {
         }
-        else if(!to_integer(offset, i) && offset_is_zero(o))
-          *o = i;
+        else if(i.has_value() && offset_is_zero(o))
+          *o = *i;
         else
           o.reset();
 

--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -636,12 +636,12 @@ bool boolbvt::is_unbounded_array(const typet &type) const
 
   const exprt &size=to_array_type(type).size();
 
-  mp_integer s;
-  if(to_integer(size, s))
+  const auto s = numeric_cast<mp_integer>(size);
+  if(!s.has_value())
     return true;
 
   if(unbounded_array==unbounded_arrayt::U_AUTO)
-    if(s>MAX_FLATTENED_ARRAY_SIZE)
+    if(*s > MAX_FLATTENED_ARRAY_SIZE)
       return true;
 
   return false;

--- a/src/solvers/flattening/boolbv_array_of.cpp
+++ b/src/solvers/flattening/boolbv_array_of.cpp
@@ -37,15 +37,15 @@ bvt boolbvt::convert_array_of(const array_of_exprt &expr)
 
   const exprt &array_size=array_type.size();
 
-  mp_integer size;
+  const auto size = numeric_cast<mp_integer>(array_size);
 
-  if(to_integer(array_size, size))
+  if(!size.has_value())
     return conversion_failed(expr);
 
   const bvt &tmp = convert_bv(expr.what());
 
   INVARIANT(
-    size * tmp.size() == width,
+    *size * tmp.size() == width,
     "total array bit width shall equal the number of elements times the "
     "element bit with");
 

--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -302,12 +302,11 @@ exprt boolbvt::bv_get_unbounded_array(const exprt &expr) const
 
   if(size.id()!=ID_infinity)
   {
-    if(to_integer(size, size_mpint))
+    const auto size_opt = numeric_cast<mp_integer>(size);
+    if(!size_opt.has_value() || *size_opt < 0)
       return nil_exprt();
-
-    // simple sanity check
-    if(size_mpint<0)
-      return nil_exprt();
+    else
+      size_mpint = *size_opt;
   }
   else
     size_mpint=0;
@@ -344,14 +343,14 @@ exprt boolbvt::bv_get_unbounded_array(const exprt &expr) const
 
       if(!index_value.is_nil())
       {
-        mp_integer index_mpint;
+        const auto index_mpint = numeric_cast<mp_integer>(index_value);
 
-        if(!to_integer(index_value, index_mpint))
+        if(index_mpint.has_value())
         {
           if(value.is_nil())
-            values[index_mpint]=exprt(ID_unknown, type.subtype());
+            values[*index_mpint] = exprt(ID_unknown, type.subtype());
           else
-            values[index_mpint]=value;
+            values[*index_mpint] = value;
         }
       }
     }

--- a/src/solvers/flattening/boolbv_with.cpp
+++ b/src/solvers/flattening/boolbv_with.cpp
@@ -144,16 +144,15 @@ void boolbvt::convert_with_array(
   }
 
   // Is the index a constant?
-  mp_integer op1_value;
-  if(!to_integer(op1, op1_value))
+  if(const auto op1_value = numeric_cast<mp_integer>(op1))
   {
     // Yes, it is!
     next_bv=prev_bv;
 
-    if(op1_value >= 0 && op1_value < *size) // bounds check
+    if(*op1_value >= 0 && *op1_value < *size) // bounds check
     {
       const std::size_t offset =
-        numeric_cast_v<std::size_t>(op1_value * op2_bv.size());
+        numeric_cast_v<std::size_t>(*op1_value * op2_bv.size());
 
       for(std::size_t j=0; j<op2_bv.size(); j++)
         next_bv[offset+j]=op2_bv[j];
@@ -186,13 +185,12 @@ void boolbvt::convert_with_bv(
 {
   literalt l=convert(op2);
 
-  mp_integer op1_value;
-  if(!to_integer(op1, op1_value))
+  if(const auto op1_value = numeric_cast<mp_integer>(op1))
   {
     next_bv=prev_bv;
 
-    if(op1_value<next_bv.size())
-      next_bv[numeric_cast_v<std::size_t>(op1_value)] = l;
+    if(*op1_value < next_bv.size())
+      next_bv[numeric_cast_v<std::size_t>(*op1_value)] = l;
 
     return;
   }

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -67,12 +67,11 @@ static exprt unpack_rec(
     if(!unpack_byte_array && *element_width == 8)
       return src;
 
-    mp_integer num_elements;
-    if(to_integer(max_bytes, num_elements) &&
-       to_integer(array_type.size(), num_elements))
-    {
+    auto num_elements = numeric_cast<mp_integer>(max_bytes);
+    if(!num_elements.has_value())
+      num_elements = numeric_cast<mp_integer>(array_type.size());
+    if(!num_elements.has_value())
       throw non_const_array_sizet(array_type, max_bytes);
-    }
 
     // all array members will have the same structure; do this just
     // once and then replace the dummy symbol by a suitable index
@@ -80,7 +79,7 @@ static exprt unpack_rec(
     symbol_exprt dummy(ID_C_incomplete, subtype);
     exprt sub=unpack_rec(dummy, little_endian, max_bytes, ns, true);
 
-    for(mp_integer i=0; i<num_elements; ++i)
+    for(mp_integer i=0; i<*num_elements; ++i)
     {
       index_exprt index(src, from_integer(i, index_type()));
       replace_symbolt replace;
@@ -130,12 +129,13 @@ static exprt unpack_rec(
       bits = *bits_opt;
     else
     {
-      if(to_integer(max_bytes, bits))
+      bits_opt = numeric_cast<mp_integer>(max_bytes);
+      if(!bits_opt.has_value())
       {
         throw non_constant_widtht(src, max_bytes);
       }
       else
-        bits*=8;
+        bits = *bits_opt * 8;
     }
 
     for(mp_integer i=0; i<bits; i+=8)
@@ -233,16 +233,16 @@ exprt lower_byte_extract(const byte_extract_exprt &src, const namespacet &ns)
     const typet &subtype=array_type.subtype();
 
     auto element_width = pointer_offset_bits(subtype, ns);
-    mp_integer num_elements;
+    const auto num_elements = numeric_cast<mp_integer>(array_type.size());
     // TODO: consider ways of dealing with arrays of unknown subtype
     // size or with a subtype size that does not fit byte boundaries
     if(
       element_width.has_value() && *element_width >= 1 &&
-      *element_width % 8 == 0 && !to_integer(array_type.size(), num_elements))
+      *element_width % 8 == 0 && num_elements.has_value())
     {
       array_exprt array({}, array_type);
 
-      for(mp_integer i=0; i<num_elements; ++i)
+      for(mp_integer i=0; i< *num_elements; ++i)
       {
         plus_exprt new_offset(
           unpacked.offset(),

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -238,7 +238,7 @@ exprt lower_byte_extract(const byte_extract_exprt &src, const namespacet &ns)
     // size or with a subtype size that does not fit byte boundaries
     if(
       element_width.has_value() && *element_width >= 1 &&
-      *element_width % 8 == 0 && to_integer(array_type.size(), num_elements))
+      *element_width % 8 == 0 && !to_integer(array_type.size(), num_elements))
     {
       array_exprt array({}, array_type);
 

--- a/src/util/simplify_expr_floatbv.cpp
+++ b/src/util/simplify_expr_floatbv.cpp
@@ -190,8 +190,8 @@ bool simplify_exprt::simplify_floatbv_typecast(exprt &expr)
   // constant folding
   if(casted_expr.is_constant() && rounding_mode.is_constant())
   {
-    mp_integer rounding_mode_index;
-    if(!to_integer(rounding_mode, rounding_mode_index))
+    const auto rounding_mode_index = numeric_cast<mp_integer>(rounding_mode);
+    if(rounding_mode_index.has_value())
     {
       if(src_type.id()==ID_floatbv)
       {
@@ -200,7 +200,7 @@ bool simplify_exprt::simplify_floatbv_typecast(exprt &expr)
           ieee_floatt result(to_constant_expr(casted_expr));
           result.rounding_mode =
             (ieee_floatt::rounding_modet)numeric_cast_v<std::size_t>(
-              rounding_mode_index);
+              *rounding_mode_index);
           result.change_spec(
             ieee_float_spect(to_floatbv_type(dest_type)));
           expr=result.to_expr();
@@ -209,12 +209,12 @@ bool simplify_exprt::simplify_floatbv_typecast(exprt &expr)
         else if(dest_type.id()==ID_signedbv ||
                 dest_type.id()==ID_unsignedbv)
         {
-          if(rounding_mode_index == ieee_floatt::ROUND_TO_ZERO)
+          if(*rounding_mode_index == ieee_floatt::ROUND_TO_ZERO)
           {
             ieee_floatt result(to_constant_expr(casted_expr));
             result.rounding_mode =
               (ieee_floatt::rounding_modet)numeric_cast_v<std::size_t>(
-                rounding_mode_index);
+                *rounding_mode_index);
             mp_integer value=result.to_integer();
             expr=from_integer(value, dest_type);
             return false;
@@ -224,16 +224,16 @@ bool simplify_exprt::simplify_floatbv_typecast(exprt &expr)
       else if(src_type.id()==ID_signedbv ||
               src_type.id()==ID_unsignedbv)
       {
-        mp_integer value;
-        if(!to_integer(casted_expr, value))
+        const auto value = numeric_cast<mp_integer>(casted_expr);
+        if(value.has_value())
         {
           if(dest_type.id()==ID_floatbv) // int to float
           {
             ieee_floatt result(to_floatbv_type(dest_type));
             result.rounding_mode =
               (ieee_floatt::rounding_modet)numeric_cast_v<std::size_t>(
-                rounding_mode_index);
-            result.from_integer(value);
+                *rounding_mode_index);
+            result.from_integer(*value);
             expr=result.to_expr();
             return false;
           }
@@ -313,11 +313,12 @@ bool simplify_exprt::simplify_floatbv_op(exprt &expr)
     ieee_floatt v0(to_constant_expr(op0));
     ieee_floatt v1(to_constant_expr(op1));
 
-    mp_integer rounding_mode;
-    if(!to_integer(op2, rounding_mode))
+    const auto rounding_mode = numeric_cast<mp_integer>(op2);
+    if(rounding_mode.has_value())
     {
       v0.rounding_mode =
-        (ieee_floatt::rounding_modet)numeric_cast_v<std::size_t>(rounding_mode);
+        (ieee_floatt::rounding_modet)numeric_cast_v<std::size_t>(
+          *rounding_mode);
       v1.rounding_mode=v0.rounding_mode;
 
       ieee_floatt result=v0;

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -74,16 +74,16 @@ bool simplify_exprt::simplify_address_of_arg(exprt &expr)
 
         if(step_size.has_value())
         {
-          mp_integer index;
+          const auto index = numeric_cast<mp_integer>(expr.op1());
 
-          if(!to_integer(expr.op1(), index))
+          if(index.has_value())
           {
             pointer_typet pointer_type =
               to_pointer_type(to_dereference_expr(expr.op0()).pointer().type());
             pointer_type.subtype() = expr.type();
 
             typecast_exprt typecast_expr(
-              from_integer((*step_size) * index + address, index_type()),
+              from_integer((*step_size) * (*index) + address, index_type()),
               pointer_type);
 
             expr = dereference_exprt(typecast_expr, expr.type());


### PR DESCRIPTION
to_integer should only be used with a constant_exprt as first argument. Includes
a bugfix in goto_rw where the result of pointer_offset_bits did not have
operator* applied.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
