### PR TITLE
Use non-deprecated variants of read_goto_binary [blocks: #3800]

### DIFF
--- a/jbmc/src/jdiff/jdiff_parse_options.cpp
+++ b/jbmc/src/jdiff/jdiff_parse_options.cpp
@@ -292,12 +292,12 @@ int jdiff_parse_optionst::get_goto_program(
 
   if(is_goto_binary(cmdline.args[0]))
   {
-    if(read_goto_binary(
-         cmdline.args[0],
-         goto_model.symbol_table,
-         goto_model.goto_functions,
-         languages.get_message_handler()))
+    auto tmp_goto_model =
+      read_goto_binary(cmdline.args[0], languages.get_message_handler());
+    if(!tmp_goto_model.has_value())
       return CPROVER_EXIT_INCORRECT_TASK;
+
+    goto_model = std::move(*tmp_goto_model);
 
     config.set(cmdline);
 

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -332,12 +332,12 @@ int goto_diff_parse_optionst::get_goto_program(
 
   if(is_goto_binary(cmdline.args[0]))
   {
-    if(read_goto_binary(
-        cmdline.args[0],
-        goto_model.symbol_table,
-        goto_model.goto_functions,
-        languages.get_message_handler()))
+    auto tmp_goto_model =
+      read_goto_binary(cmdline.args[0], languages.get_message_handler());
+    if(!tmp_goto_model.has_value())
       return CPROVER_EXIT_INCORRECT_TASK;
+
+    goto_model = std::move(*tmp_goto_model);
 
     config.set(cmdline);
 

--- a/src/goto-programs/read_goto_binary.cpp
+++ b/src/goto-programs/read_goto_binary.cpp
@@ -27,20 +27,11 @@ Author:
 #include "elf_reader.h"
 #include "osx_fat_reader.h"
 
-/// \brief Read a goto binary from a file, but do not update \ref config
-/// \param filename: the file name of the goto binary
-/// \param dest: the goto model returned
-/// \param message_handler: for diagnostics
-/// \deprecated Use read_goto_binary(file, message_handler) instead
-/// \return true on failure, false on success
-bool read_goto_binary(
+static bool read_goto_binary(
   const std::string &filename,
-  goto_modelt &dest,
-  message_handlert &message_handler)
-{
-  return read_goto_binary(
-    filename, dest.symbol_table, dest.goto_functions, message_handler);
-}
+  symbol_tablet &,
+  goto_functionst &,
+  message_handlert &);
 
 /// \brief Read a goto binary from a file, but do not update \ref config
 /// \param filename: the file name of the goto binary
@@ -66,7 +57,7 @@ read_goto_binary(const std::string &filename, message_handlert &message_handler)
 /// \param goto_functions: the goto functions from the goto binary
 /// \param message_handler: for diagnostics
 /// \return true on failure, false on success
-bool read_goto_binary(
+static bool read_goto_binary(
   const std::string &filename,
   symbol_tablet &symbol_table,
   goto_functionst &goto_functions,
@@ -240,17 +231,13 @@ bool read_object_and_link(
                                          << file_name << messaget::eom;
 
   // we read into a temporary model
-  goto_modelt temp_model;
-
-  if(read_goto_binary(
-      file_name,
-      temp_model,
-      message_handler))
+  auto temp_model = read_goto_binary(file_name, message_handler);
+  if(!temp_model.has_value())
     return true;
 
   try
   {
-    link_goto_model(dest, temp_model, message_handler);
+    link_goto_model(dest, *temp_model, message_handler);
   }
   catch(...)
   {

--- a/src/goto-programs/read_goto_binary.h
+++ b/src/goto-programs/read_goto_binary.h
@@ -22,18 +22,6 @@ class goto_modelt;
 class message_handlert;
 class symbol_tablet;
 
-bool read_goto_binary(
-  const std::string &filename,
-  symbol_tablet &,
-  goto_functionst &,
-  message_handlert &);
-
-DEPRECATED("use two-parameter variant instead")
-bool read_goto_binary(
-  const std::string &filename,
-  goto_modelt &dest,
-  message_handlert &);
-
 optionalt<goto_modelt>
 read_goto_binary(const std::string &filename, message_handlert &);
 


### PR DESCRIPTION
The 4-parameter variant is deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
