### PR TITLE
Construct parametert in a non-deprecated way [blocks: #3800]

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_class.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_class.cpp
@@ -831,11 +831,11 @@ void java_bytecode_convert_classt::add_array_types(symbol_tablet &symbol_table)
 
     const irep_idt clone_name =
       id2string(struct_tag_type_identifier) + ".clone:()Ljava/lang/Object;";
-    java_method_typet::parametert this_param;
+    java_method_typet::parametert this_param(
+      java_reference_type(struct_tag_type));
     this_param.set_identifier(id2string(clone_name)+"::this");
     this_param.set_base_name(ID_this);
     this_param.set_this();
-    this_param.type() = java_reference_type(struct_tag_type);
     const java_method_typet clone_type({this_param}, java_lang_object_type());
 
     parameter_symbolt this_symbol;

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -368,10 +368,9 @@ void java_bytecode_convert_method_lazy(
   if(!m.is_static)
   {
     java_method_typet::parameterst &parameters = member_type.parameters();
-    java_method_typet::parametert this_p;
     const reference_typet object_ref_type =
       java_reference_type(struct_tag_typet(class_symbol.name));
-    this_p.type()=object_ref_type;
+    java_method_typet::parametert this_p(object_ref_type);
     this_p.set_this();
     parameters.insert(parameters.begin(), this_p);
   }

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -439,11 +439,11 @@ void c_typecheck_baset::typecheck_code_type(code_typet &type)
         ansi_c_declarationt &declaration=
           to_ansi_c_declaration(param);
 
-        code_typet::parametert parameter;
 
         // first fix type
+        code_typet::parametert parameter(
+          declaration.full_type(declaration.declarator()));
         typet &param_type = parameter.type();
-        param_type = declaration.full_type(declaration.declarator());
         std::list<codet> tmp_clean_code;
         tmp_clean_code.swap(clean_code); // ignore side-effects
         typecheck_type(param_type);

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -1349,17 +1349,6 @@ void cpp_typecheckt::add_this_to_method_type(
   code_typet &type,
   const typet &method_qualifier)
 {
-  code_typet::parameterst &parameters = type.parameters();
-
-  parameters.insert(
-    parameters.begin(), code_typet::parametert());
-
-  code_typet::parametert &parameter=parameters.front();
-
-  parameter.set_identifier(ID_this); // check? Not qualified
-  parameter.set_base_name(ID_this);
-  parameter.set_this();
-
   typet subtype;
 
   if(compound_symbol.type.id() == ID_union)
@@ -1373,7 +1362,13 @@ void cpp_typecheckt::add_this_to_method_type(
   if(has_volatile(method_qualifier))
     subtype.set(ID_C_volatile, true);
 
-  parameter.type()=pointer_type(subtype);
+  code_typet::parametert parameter(pointer_type(subtype));
+  parameter.set_identifier(ID_this); // check? Not qualified
+  parameter.set_base_name(ID_this);
+  parameter.set_this();
+
+  code_typet::parameterst &parameters = type.parameters();
+  parameters.insert(parameters.begin(), parameter);
 }
 
 void cpp_typecheckt::add_anonymous_members_to_scope(

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -5615,7 +5615,7 @@ bool Parser::rTypeNameOrFunctionType(typet &tname)
       if(!rArgDeclaration(parameter_declaration))
         return false;
 
-      code_typet::parametert parameter;
+      code_typet::parametert parameter(typet{});
       parameter.swap(parameter_declaration);
       type.parameters().push_back(parameter);
 

--- a/src/jsil/jsil_internal_additions.cpp
+++ b/src/jsil/jsil_internal_additions.cpp
@@ -56,9 +56,7 @@ void jsil_internal_additions(symbol_tablet &dest)
   // add eval
 
   {
-    code_typet eval_type;
-    code_typet::parametert p;
-    eval_type.parameters().push_back(p);
+    code_typet eval_type({code_typet::parametert(typet())}, empty_typet());
 
     symbolt symbol;
     symbol.base_name="eval";

--- a/src/jsil/parser.y
+++ b/src/jsil/parser.y
@@ -118,15 +118,15 @@ procedure_decl: TOK_PROCEDURE proc_ident '(' parameters_opt ')'
                   '{' statements_opt '}'
               {
                 symbol_exprt proc(to_symbol_expr(stack($2)));
-                code_typet ct;
+                code_typet::parameterst parameters;
                 forall_operands(it, stack($4))
                 {
                   symbol_exprt s(to_symbol_expr(*it));
-                  code_typet::parametert p;
+                  code_typet::parametert p(typet{});
                   p.set_identifier(s.get_identifier());
-                  ct.parameters().push_back(p);
+                  parameters.push_back(p);
                 }
-                proc.type().swap(ct);
+                proc.type() = code_typet(std::move(parameters), typet());
 
                 symbol_exprt rv(to_symbol_expr(stack($7)));
                 symbol_exprt rl(to_symbol_expr(stack($9)));


### PR DESCRIPTION
The default constructor is deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
