### PR TITLE
Use non-trivial constructor of code_function_callt [blocks: #3800]

### DIFF
--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -315,33 +315,31 @@ goto_programt::const_targett goto_program2codet::convert_assign_varargs(
   const exprt this_va_list_expr=assign.lhs();
   const exprt &r=skip_typecast(assign.rhs());
 
-  // we don't bother setting the type
-  code_function_callt f;
-  f.lhs().make_nil();
-
   if(r.id()==ID_constant &&
      (r.is_zero() || to_constant_expr(r).get_value()==ID_NULL))
   {
-    f.function() = symbol_exprt("va_end", code_typet({}, empty_typet()));
-    f.arguments().push_back(this_va_list_expr);
+    code_function_callt f(
+      symbol_exprt("va_end", code_typet({}, empty_typet())),
+      {this_va_list_expr});
     f.arguments().back().type().id(ID_gcc_builtin_va_list);
 
     dest.add_to_operands(std::move(f));
   }
   else if(r.id()==ID_address_of)
   {
-    f.function() = symbol_exprt("va_start", code_typet({}, empty_typet()));
-    f.arguments().push_back(this_va_list_expr);
-    f.arguments().back().type().id(ID_gcc_builtin_va_list);
-    f.arguments().push_back(to_address_of_expr(r).object());
+    code_function_callt f(
+      symbol_exprt("va_start", code_typet({}, empty_typet())),
+      {this_va_list_expr, to_address_of_expr(r).object()});
+    f.arguments().front().type().id(ID_gcc_builtin_va_list);
 
     dest.add_to_operands(std::move(f));
   }
   else if(r.id()==ID_side_effect &&
           to_side_effect_expr(r).get_statement()==ID_gcc_builtin_va_arg_next)
   {
-    f.function() = symbol_exprt("va_arg", code_typet({}, empty_typet()));
-    f.arguments().push_back(this_va_list_expr);
+    code_function_callt f(
+      symbol_exprt("va_arg", code_typet({}, empty_typet())),
+      {this_va_list_expr});
     f.arguments().back().type().id(ID_gcc_builtin_va_list);
 
     side_effect_expr_function_callt type_of;
@@ -388,10 +386,10 @@ goto_programt::const_targett goto_program2codet::convert_assign_varargs(
   }
   else
   {
-    f.function() = symbol_exprt("va_copy", code_typet({}, empty_typet()));
-    f.arguments().push_back(this_va_list_expr);
-    f.arguments().back().type().id(ID_gcc_builtin_va_list);
-    f.arguments().push_back(r);
+    code_function_callt f(
+      symbol_exprt("va_copy", code_typet({}, empty_typet())),
+      {this_va_list_expr, r});
+    f.arguments().front().type().id(ID_gcc_builtin_va_list);
 
     dest.add_to_operands(std::move(f));
   }


### PR DESCRIPTION
This is more efficient and type safe.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
