### PR TITLE
deprecate base_type_eq and type_eq

### DIFF
--- a/src/util/base_type.h
+++ b/src/util/base_type.h
@@ -12,15 +12,19 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_BASE_TYPE_H
 #define CPROVER_UTIL_BASE_TYPE_H
 
+#include "deprecate.h"
+
 class exprt;
 class typet;
 class namespacet;
 
+DEPRECATED("Use == instead")
 bool base_type_eq(
   const typet &type1,
   const typet &type2,
   const namespacet &ns);
 
+DEPRECATED("Use == instead")
 bool base_type_eq(
   const exprt &expr1,
   const exprt &expr2,

--- a/src/util/type_eq.h
+++ b/src/util/type_eq.h
@@ -13,9 +13,12 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_TYPE_EQ_H
 #define CPROVER_UTIL_TYPE_EQ_H
 
+#include "deprecate.h"
+
 class namespacet;
 class typet;
 
+DEPRECATED("Use == instead")
 bool type_eq(const typet &type1, const typet &type2, const namespacet &ns);
 
 #endif // CPROVER_UTIL_TYPE_EQ_H


### PR DESCRIPTION
Both are no longer needed as symbol_typet() is no longer in use.  Simply use
type1 == type2 instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
