### PR TITLE
extend goto_programt::instructiont API

### DIFF
--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -343,7 +343,7 @@ void goto_inlinet::insert_function_body(
         if(it->function==identifier)
         {
           // don't hide assignment to lhs
-          if(it->is_assign() && to_code_assign(it->code).lhs()==lhs)
+          if(it->is_assign() && it->get_assign().lhs()==lhs)
           {
           }
           else
@@ -502,7 +502,7 @@ void goto_inlinet::get_call(
 {
   PRECONDITION(it->is_function_call());
 
-  const code_function_callt &call=to_code_function_call(it->code);
+  const code_function_callt &call = it->get_function_call();
 
   lhs=call.lhs();
   function=call.function();

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -278,14 +278,14 @@ std::list<exprt> expressions_read(
     break;
 
   case RETURN:
-    if(to_code_return(instruction.code).return_value().is_not_nil())
-      dest.push_back(to_code_return(instruction.code).return_value());
+    if(instruction.get_return().return_value().is_not_nil())
+      dest.push_back(instruction.get_return().return_value());
     break;
 
   case FUNCTION_CALL:
     {
-      const code_function_callt &function_call=
-        to_code_function_call(instruction.code);
+      const code_function_callt &function_call =
+        instruction.get_function_call();
       forall_expr(it, function_call.arguments())
         dest.push_back(*it);
       if(function_call.lhs().is_not_nil())
@@ -295,7 +295,7 @@ std::list<exprt> expressions_read(
 
   case ASSIGN:
     {
-      const code_assignt &assignment=to_code_assign(instruction.code);
+      const code_assignt &assignment = instruction.get_assign();
       dest.push_back(assignment.rhs());
       parse_lhs_read(assignment.lhs(), dest);
     }
@@ -318,15 +318,15 @@ std::list<exprt> expressions_written(
   {
   case FUNCTION_CALL:
     {
-      const code_function_callt &function_call=
-        to_code_function_call(instruction.code);
+      const code_function_callt &function_call =
+        instruction.get_function_call();
       if(function_call.lhs().is_not_nil())
         dest.push_back(function_call.lhs());
     }
     break;
 
   case ASSIGN:
-    dest.push_back(to_code_assign(instruction.code).lhs());
+    dest.push_back(instruction.get_assign().lhs());
     break;
 
   default:
@@ -792,9 +792,9 @@ void goto_programt::instructiont::validate(
       source_location);
     DATA_CHECK_WITH_DIAGNOSTICS(
       vm,
-      !ns.lookup(to_code_decl(code).get_identifier(), table_symbol),
+      !ns.lookup(get_decl().get_identifier(), table_symbol),
       "declared symbols should be known",
-      id2string(to_code_decl(code).get_identifier()),
+      id2string(get_decl().get_identifier()),
       source_location);
     break;
   case DEAD:
@@ -805,9 +805,9 @@ void goto_programt::instructiont::validate(
       source_location);
     DATA_CHECK_WITH_DIAGNOSTICS(
       vm,
-      !ns.lookup(to_code_dead(code).get_identifier(), table_symbol),
+      !ns.lookup(get_dead().get_identifier(), table_symbol),
       "removed symbols should be known",
-      id2string(to_code_dead(code).get_identifier()),
+      id2string(get_dead().get_identifier()),
       source_location);
     break;
   case FUNCTION_CALL:

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -180,6 +180,76 @@ public:
   public:
     codet code;
 
+    /// Get the assignment for ASSIGN
+    const code_assignt &get_assign() const
+    {
+      PRECONDITION(is_assign());
+      return to_code_assign(code);
+    }
+
+    /// Get the assignment for ASSIGN
+    code_assignt &get_assign()
+    {
+      PRECONDITION(is_assign());
+      return to_code_assign(code);
+    }
+
+    /// Get the declaration for DECL
+    const code_declt &get_decl() const
+    {
+      PRECONDITION(is_decl());
+      return to_code_decl(code);
+    }
+
+    /// Get the declaration for DECL
+    code_declt &get_decl()
+    {
+      PRECONDITION(is_decl());
+      return to_code_decl(code);
+    }
+
+    /// Get the dead statement for DEAD
+    const code_deadt &get_dead() const
+    {
+      PRECONDITION(is_dead());
+      return to_code_dead(code);
+    }
+
+    /// Get the dead statement for DEAD
+    code_deadt &get_dead()
+    {
+      PRECONDITION(is_dead());
+      return to_code_dead(code);
+    }
+
+    /// Get the return statement for READ
+    const code_returnt &get_return() const
+    {
+      PRECONDITION(is_return());
+      return to_code_return(code);
+    }
+
+    /// Get the return statement for READ
+    code_returnt &get_return()
+    {
+      PRECONDITION(is_return());
+      return to_code_return(code);
+    }
+
+    /// Get the function call for FUNCTION_CALL
+    const code_function_callt &get_function_call() const
+    {
+      PRECONDITION(is_function_call());
+      return to_code_function_call(code);
+    }
+
+    /// Get the function call for FUNCTION_CALL
+    code_function_callt &get_function_call()
+    {
+      PRECONDITION(is_function_call());
+      return to_code_function_call(code);
+    }
+
     /// The function this instruction belongs to
     irep_idt function;
 
@@ -190,7 +260,15 @@ public:
     goto_program_instruction_typet type;
 
     /// Guard for gotos, assume, assert
+    /// Use get_condition() to read
     exprt guard;
+
+    /// Get the condition of gotos, assume, assert
+    const exprt &get_condition() const
+    {
+      PRECONDITION(is_goto() || is_assume() || is_assert());
+      return guard;
+    }
 
     // The below will eventually become a single target only.
     /// The target for gotos and for start_thread nodes

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -144,10 +144,10 @@ static bool filter_out(
   const goto_tracet::stepst::const_iterator &prev_it,
   goto_tracet::stepst::const_iterator &it)
 {
-  if(it->hidden &&
-     (!it->pc->is_assign() ||
-      to_code_assign(it->pc->code).rhs().id()!=ID_side_effect ||
-      to_code_assign(it->pc->code).rhs().get(ID_statement)!=ID_nondet))
+  if(
+    it->hidden && (!it->pc->is_assign() ||
+                   it->pc->get_assign().rhs().id() != ID_side_effect ||
+                   it->pc->get_assign().rhs().get(ID_statement) != ID_nondet))
     return true;
 
   if(!it->is_assignment() && !it->is_goto() && !it->is_assert())

--- a/src/goto-programs/instrument_preconditions.cpp
+++ b/src/goto-programs/instrument_preconditions.cpp
@@ -101,7 +101,7 @@ void instrument_preconditions(
     if(it->is_function_call())
     {
       // does the function we call have preconditions?
-      const auto &call=to_code_function_call(it->code);
+      const auto &call = it->get_function_call();
 
       if(call.function().id()==ID_symbol)
       {

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -745,8 +745,7 @@ void interpretert::execute_assert()
 
 void interpretert::execute_function_call()
 {
-  const code_function_callt &function_call=
-    to_code_function_call(pc->code);
+  const code_function_callt &function_call = pc->get_function_call();
 
   // function to be called
   mp_integer address=evaluate_address(function_call.function());

--- a/src/goto-programs/mm_io.cpp
+++ b/src/goto-programs/mm_io.cpp
@@ -45,7 +45,7 @@ void mm_io(
 
     if(it->is_assign())
     {
-      auto &a=to_code_assign(it->code);
+      auto &a = it->get_assign();
       collect_deref_expr(a.rhs(), deref_expr_r);
 
       if(mm_io_r.is_not_nil())

--- a/src/goto-programs/parameter_assignments.cpp
+++ b/src/goto-programs/parameter_assignments.cpp
@@ -42,7 +42,7 @@ void parameter_assignmentst::do_function_calls(
   {
     if(i_it->is_function_call())
     {
-      code_function_callt &function_call=to_code_function_call(i_it->code);
+      code_function_callt &function_call = i_it->get_function_call();
 
       // add x=y for f(y) where x is the parameter
 

--- a/src/goto-programs/remove_calls_no_body.cpp
+++ b/src/goto-programs/remove_calls_no_body.cpp
@@ -74,7 +74,7 @@ bool remove_calls_no_bodyt::is_opaque_function_call(
   if(!target->is_function_call())
     return false;
 
-  const code_function_callt &cfc = to_code_function_call(target->code);
+  const code_function_callt &cfc = target->get_function_call();
   const exprt &f = cfc.function();
 
   if(f.id() != ID_symbol)
@@ -108,7 +108,7 @@ operator()(goto_programt &goto_program, const goto_functionst &goto_functions)
   {
     if(is_opaque_function_call(it, goto_functions))
     {
-      const code_function_callt &cfc = to_code_function_call(it->code);
+      const code_function_callt &cfc = it->get_function_call();
       remove_call_no_body(goto_program, it, cfc.lhs(), cfc.arguments());
     }
     else

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -265,8 +265,7 @@ void remove_function_pointerst::remove_function_pointer(
   goto_programt &goto_program,
   goto_programt::targett target)
 {
-  const code_function_callt &code=
-    to_code_function_call(target->code);
+  const code_function_callt &code = target->get_function_call();
 
   const auto &function = to_dereference_expr(code.function());
 
@@ -312,7 +311,7 @@ void remove_function_pointerst::remove_function_pointer(
 
     if(functions.size()==1)
     {
-      to_code_function_call(target->code).function()=*functions.cbegin();
+      target->get_function_call().function() = *functions.cbegin();
       return;
     }
   }
@@ -360,7 +359,7 @@ void remove_function_pointerst::remove_function_pointer(
   goto_programt::targett target,
   const functionst &functions)
 {
-  const code_function_callt &code = to_code_function_call(target->code);
+  const code_function_callt &code = target->get_function_call();
 
   const exprt &function = code.function();
   const exprt &pointer = to_dereference_expr(function).pointer();
@@ -381,12 +380,12 @@ void remove_function_pointerst::remove_function_pointer(
     // call function
     goto_programt::targett t1=new_code_calls.add_instruction();
     t1->make_function_call(code);
-    to_code_function_call(t1->code).function()=fun;
+    t1->get_function_call().function() = fun;
 
     // the signature of the function might not match precisely
-    fix_argument_types(to_code_function_call(t1->code));
+    fix_argument_types(t1->get_function_call());
 
-    fix_return_type(to_code_function_call(t1->code), new_code_calls);
+    fix_return_type(t1->get_function_call(), new_code_calls);
     // goto final
     goto_programt::targett t3=new_code_calls.add_instruction();
     t3->make_goto(t_final, true_exprt());
@@ -474,8 +473,7 @@ bool remove_function_pointerst::remove_function_pointers(
   Forall_goto_program_instructions(target, goto_program)
     if(target->is_function_call())
     {
-      const code_function_callt &code=
-        to_code_function_call(target->code);
+      const code_function_callt &code = target->get_function_call();
 
       if(code.function().id()==ID_dereference)
       {

--- a/src/goto-programs/remove_returns.cpp
+++ b/src/goto-programs/remove_returns.cpp
@@ -149,7 +149,7 @@ void remove_returnst::do_function_calls(
   {
     if(i_it->is_function_call())
     {
-      code_function_callt &function_call=to_code_function_call(i_it->code);
+      code_function_callt &function_call = i_it->get_function_call();
 
       INVARIANT(
         function_call.function().id() == ID_symbol,
@@ -357,7 +357,7 @@ bool remove_returnst::restore_returns(
   {
     if(i_it->is_assign())
     {
-      code_assignt &assign=to_code_assign(i_it->code);
+      code_assignt &assign = i_it->get_assign();
       if(assign.lhs().id()!=ID_symbol ||
          to_symbol_expr(assign.lhs()).get_identifier()!=rv_name_id)
         continue;
@@ -386,7 +386,7 @@ void remove_returnst::undo_function_calls(
   {
     if(i_it->is_function_call())
     {
-      code_function_callt &function_call=to_code_function_call(i_it->code);
+      code_function_callt &function_call = i_it->get_function_call();
 
       // ignore function pointers
       if(function_call.function().id()!=ID_symbol)
@@ -412,7 +412,7 @@ void remove_returnst::undo_function_calls(
       if(!next->is_assign())
         continue;
 
-      const code_assignt &assign=to_code_assign(next->code);
+      const code_assignt &assign = next->get_assign();
 
       if(assign.rhs().id()!=ID_symbol)
         continue;

--- a/src/goto-programs/remove_unused_functions.cpp
+++ b/src/goto-programs/remove_unused_functions.cpp
@@ -75,7 +75,7 @@ void find_used_functions(
       {
         if(it->type==FUNCTION_CALL)
         {
-          const code_function_callt &call = to_code_function_call(it->code);
+          const code_function_callt &call = it->get_function_call();
 
           const irep_idt &identifier =
             to_symbol_expr(call.function()).get_identifier();

--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -83,8 +83,7 @@ goto_programt::targett remove_virtual_functionst::remove_virtual_function(
   goto_programt &goto_program,
   goto_programt::targett target)
 {
-  const code_function_callt &code=
-    to_code_function_call(target->code);
+  const code_function_callt &code = target->get_function_call();
 
   const exprt &function=code.function();
   INVARIANT(
@@ -150,8 +149,7 @@ goto_programt::targett remove_virtual_functionst::remove_virtual_function(
   INVARIANT(
     target->is_function_call(),
     "remove_virtual_function must target a FUNCTION_CALL instruction");
-  const code_function_callt &code=
-    to_code_function_call(target->code);
+  const code_function_callt &code = target->get_function_call();
 
   goto_programt::targett next_target = std::next(target);
 
@@ -174,9 +172,7 @@ goto_programt::targett remove_virtual_functionst::remove_virtual_function(
     else
     {
       create_static_function_call(
-        to_code_function_call(target->code),
-        *functions.front().symbol_expr,
-        ns);
+        target->get_function_call(), *functions.front().symbol_expr, ns);
     }
     return next_target;
   }
@@ -242,7 +238,7 @@ goto_programt::targett remove_virtual_functionst::remove_virtual_function(
       // call function
         t1->make_function_call(code);
         create_static_function_call(
-          to_code_function_call(t1->code), *fun.symbol_expr, ns);
+          t1->get_function_call(), *fun.symbol_expr, ns);
       }
       else
       {
@@ -530,8 +526,7 @@ bool remove_virtual_functionst::remove_virtual_functions(
   {
     if(target->is_function_call())
     {
-      const code_function_callt &code=
-        to_code_function_call(target->code);
+      const code_function_callt &code = target->get_function_call();
 
       if(code.function().id()==ID_virtual_function)
       {

--- a/src/goto-programs/replace_calls.cpp
+++ b/src/goto-programs/replace_calls.cpp
@@ -70,7 +70,7 @@ void replace_callst::operator()(
     if(!ins.is_function_call())
       continue;
 
-    code_function_callt &cfc = to_code_function_call(ins.code);
+    code_function_callt &cfc = ins.get_function_call();
     exprt &function = cfc.function();
 
     PRECONDITION(function.id() == ID_symbol);
@@ -100,7 +100,7 @@ void replace_callst::operator()(
     goto_programt::const_targett next_it = std::next(it);
     if(next_it != goto_program.instructions.end() && next_it->is_assign())
     {
-      const code_assignt &ca = to_code_assign(next_it->code);
+      const code_assignt &ca = next_it->get_assign();
       const exprt &rhs = ca.rhs();
 
       INVARIANT(

--- a/src/goto-programs/slice_global_inits.cpp
+++ b/src/goto-programs/slice_global_inits.cpp
@@ -85,7 +85,7 @@ void slice_global_inits(goto_modelt &goto_model)
   {
     if(i_it->is_assign())
     {
-      const code_assignt &code_assign=to_code_assign(i_it->code);
+      const code_assignt &code_assign = i_it->get_assign();
       const symbol_exprt &symbol_expr=to_symbol_expr(code_assign.lhs());
       const irep_idt id=symbol_expr.get_identifier();
 

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -249,8 +249,8 @@ void string_abstractiont::declare_define_locals(goto_programt &dest)
     if(it->is_decl())
       // same name may exist several times due to inlining, make sure the first
       // declaration is used
-      available_decls.insert(std::make_pair(
-            to_code_decl(it->code).get_identifier(), it));
+      available_decls.insert(
+        std::make_pair(it->get_decl().get_identifier(), it));
 
   // declare (and, if necessary, define) locals
   for(const auto &l : locals)
@@ -501,7 +501,7 @@ goto_programt::targett string_abstractiont::abstract_assign(
   goto_programt &dest,
   goto_programt::targett target)
 {
-  code_assignt &assign=to_code_assign(target->code);
+  code_assignt &assign = target->get_assign();
 
   exprt &lhs=assign.lhs();
   exprt &rhs=assign.rhs();
@@ -527,7 +527,7 @@ goto_programt::targett string_abstractiont::abstract_assign(
 void string_abstractiont::abstract_function_call(
   goto_programt::targett target)
 {
-  code_function_callt &call=to_code_function_call(target->code);
+  code_function_callt &call = target->get_function_call();
   code_function_callt::argumentst &arguments=call.arguments();
   code_function_callt::argumentst str_args;
 
@@ -1060,7 +1060,7 @@ goto_programt::targett string_abstractiont::abstract_pointer_assign(
   goto_programt &dest,
   goto_programt::targett target)
 {
-  code_assignt &assign=to_code_assign(target->code);
+  code_assignt &assign = target->get_assign();
 
   exprt &lhs=assign.lhs();
   exprt rhs=assign.rhs();
@@ -1105,7 +1105,7 @@ goto_programt::targett string_abstractiont::abstract_char_assign(
   goto_programt &dest,
   goto_programt::targett target)
 {
-  code_assignt &assign=to_code_assign(target->code);
+  code_assignt &assign = target->get_assign();
 
   exprt &lhs=assign.lhs();
   exprt *rhsp=&(assign.rhs());

--- a/src/goto-programs/string_instrumentation.cpp
+++ b/src/goto-programs/string_instrumentation.cpp
@@ -222,8 +222,7 @@ void string_instrumentationt::do_function_call(
   goto_programt &dest,
   goto_programt::targett target)
 {
-  code_function_callt &call=
-    to_code_function_call(target->code);
+  code_function_callt &call = target->get_function_call();
   exprt &function=call.function();
   // const exprt &lhs=call.lhs();
 


### PR DESCRIPTION
This adds get_X() methods that make the use of goto program instructions
more type safe.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
