### PR TITLE
Variable in test.desc file can be also separated by ':' or ';'

### DIFF
--- a/regression/test.pl
+++ b/regression/test.pl
@@ -74,6 +74,7 @@ sub test($$$$$$$$$$) {
   foreach my $key (@keys) {
     my $value = $defines->{$key};
     $options =~ s/(\$$key$|\$$key )/$value /g;
+    $options =~ s/\$$key([:;])/$value\1/g; # Variables in --classpath are separated by (semi)colons
   }
   if (scalar @keys) {
     foreach my $word (split(/\s/, $options)) {


### PR DESCRIPTION
To be able to use variables in `.desc` files also in the `--classpath` argument, we need to use `:` as a separator for variable names, currently the only separator is a space.

For example, we want to be able to use a `.desc` file in which the arguments have the following structure:
```
--classpath $PATH_TO_DEPENDENCIES:$PATH_TO_IMPORTANT_JAR:.
```