### PR TITLE
symbol_table: remove unneeded typename

### DIFF
--- a/src/util/symbol_table.cpp
+++ b/src/util/symbol_table.cpp
@@ -154,7 +154,7 @@ void symbol_tablet::validate(const validation_modet vm) const
         std::find_if(
           base_map_search.first,
           base_map_search.second,
-          [&symbol_key](const typename symbol_base_mapt::value_type &match) {
+          [&symbol_key](const symbol_base_mapt::value_type &match) {
             return match.second == symbol_key;
           }) != symbol_base_map.end();
 
@@ -177,7 +177,7 @@ void symbol_tablet::validate(const validation_modet vm) const
         std::find_if(
           module_map_search.first,
           module_map_search.second,
-          [&symbol_key](const typename symbol_module_mapt::value_type &match) {
+          [&symbol_key](const symbol_module_mapt::value_type &match) {
             return match.second == symbol_key;
           }) != symbol_module_map.end();
 


### PR DESCRIPTION
Visual Studio 2013 treats the unneeded typename as an error.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
