### PR TITLE
avoid using deprecated constructor of type_with_subtypest

### DIFF
--- a/src/ansi-c/merged_type.h
+++ b/src/ansi-c/merged_type.h
@@ -15,7 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 class merged_typet : public type_with_subtypest
 {
 public:
-  merged_typet() : type_with_subtypest(ID_merged_type)
+  merged_typet() : type_with_subtypest(ID_merged_type, {})
   {
   }
 

--- a/src/util/mathematical_types.h
+++ b/src/util/mathematical_types.h
@@ -63,11 +63,10 @@ public:
   using domaint = std::vector<typet>;
 
   mathematical_function_typet(const domaint &_domain, const typet &_codomain)
-    : type_with_subtypest(ID_mathematical_function)
+    : type_with_subtypest(
+        ID_mathematical_function,
+        {type_with_subtypest(irep_idt(), _domain), _codomain})
   {
-    subtypes().resize(2);
-    domain() = _domain;
-    codomain() = _codomain;
   }
 
   domaint &domain()


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
