### PR TITLE
remove #include "mathematical_types.h" from std_expr.h

### DIFF
--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -23,6 +23,7 @@ Author: Peter Schrammel
 #include <util/expr_util.h>
 #include <util/find_symbols.h>
 #include <util/ieee_float.h>
+#include <util/mathematical_types.h>
 #include <util/simplify_expr.h>
 
 #include <langapi/language_util.h>

--- a/src/ansi-c/c_typecast.cpp
+++ b/src/ansi-c/c_typecast.cpp
@@ -13,13 +13,14 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <cassert>
 
 #include <util/arith_tools.h>
+#include <util/base_type.h>
 #include <util/c_types.h>
 #include <util/config.h>
 #include <util/expr_util.h>
-#include <util/std_expr.h>
-#include <util/base_type.h>
-#include <util/symbol.h>
+#include <util/mathematical_types.h>
 #include <util/simplify_expr.h>
+#include <util/std_expr.h>
+#include <util/symbol.h>
 
 #include "c_qualifiers.h"
 

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -20,6 +20,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/cprover_prefix.h>
 #include <util/expr_util.h>
 #include <util/ieee_float.h>
+#include <util/mathematical_types.h>
 #include <util/pointer_offset_size.h>
 #include <util/pointer_predicates.h>
 #include <util/simplify_expr.h>

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/config.h>
+#include <util/mathematical_types.h>
 #include <util/pointer_offset_size.h>
 #include <util/simplify_expr.h>
 

--- a/src/cpp/cpp_declarator_converter.cpp
+++ b/src/cpp/cpp_declarator_converter.cpp
@@ -11,10 +11,10 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "cpp_declarator_converter.h"
 
+#include <util/c_types.h>
+#include <util/mathematical_types.h>
 #include <util/source_location.h>
 #include <util/std_types.h>
-
-#include <util/c_types.h>
 
 #include "cpp_type2name.h"
 #include "cpp_typecheck.h"

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -20,6 +20,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <util/c_types.h>
 #include <util/config.h>
 #include <util/expr_initializer.h>
+#include <util/mathematical_types.h>
 #include <util/pointer_offset_size.h>
 
 #include <ansi-c/c_qualifiers.h>

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -20,6 +20,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include <util/arith_tools.h>
 #include <util/c_types.h>
+#include <util/mathematical_types.h>
 #include <util/prefix.h>
 #include <util/std_expr.h>
 #include <util/std_types.h>

--- a/src/goto-programs/goto_convert_side_effect.cpp
+++ b/src/goto-programs/goto_convert_side_effect.cpp
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/cprover_prefix.h>
 #include <util/expr_util.h>
 #include <util/fresh_symbol.h>
+#include <util/mathematical_types.h>
 #include <util/std_expr.h>
 #include <util/symbol.h>
 

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -21,6 +21,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/fixedbv.h>
 #include <util/ieee_float.h>
 #include <util/invariant.h>
+#include <util/mathematical_types.h>
 #include <util/message.h>
 #include <util/std_expr.h>
 #include <util/std_types.h>

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -17,6 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/base_type.h>
 #include <util/find_symbols.h>
+#include <util/mathematical_types.h>
 #include <util/pointer_offset_size.h>
 #include <util/simplify_expr.h>
 

--- a/src/solvers/smt2/smt2_parser.h
+++ b/src/solvers/smt2/smt2_parser.h
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <map>
 
+#include <util/mathematical_types.h>
 #include <util/std_expr.h>
 
 #include "smt2_tokenizer.h"

--- a/src/util/rational_tools.cpp
+++ b/src/util/rational_tools.cpp
@@ -11,8 +11,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "rational_tools.h"
 
+#include "mathematical_types.h"
 #include "rational.h"
-#include "std_types.h"
 
 static mp_integer power10(size_t i)
 {

--- a/src/util/std_expr.cpp
+++ b/src/util/std_expr.cpp
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "arith_tools.h"
 #include "byte_operators.h"
 #include "c_types.h"
+#include "mathematical_types.h"
 #include "pointer_offset_size.h"
 
 bool constant_exprt::value_is_zero_string() const

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -16,7 +16,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "base_type.h"
 #include "expr_cast.h"
 #include "invariant.h"
-#include "mathematical_types.h"
 #include "std_types.h"
 
 /// An expression without operands

--- a/unit/analyses/constant_propagator.cpp
+++ b/unit/analyses/constant_propagator.cpp
@@ -14,6 +14,7 @@ Author: Diffblue Ltd
 #include <goto-programs/goto_convert_functions.h>
 
 #include <util/arith_tools.h>
+#include <util/mathematical_types.h>
 #include <util/message.h>
 
 static bool starts_with_x(const exprt &e, const namespacet &)

--- a/unit/analyses/does_remove_const/does_expr_lose_const.cpp
+++ b/unit/analyses/does_remove_const/does_expr_lose_const.cpp
@@ -11,13 +11,16 @@ Author: Diffblue Ltd.
 
 #include <testing-utils/use_catch.h>
 
-#include <util/std_expr.h>
-#include <util/std_code.h>
-#include <util/std_types.h>
 #include <util/c_types.h>
+#include <util/mathematical_types.h>
+#include <util/std_code.h>
+#include <util/std_expr.h>
+#include <util/std_types.h>
 
 #include <ansi-c/c_qualifiers.h>
+
 #include <goto-programs/goto_program.h>
+
 #include <analyses/does_remove_const.h>
 #include <analyses/does_remove_const/does_remove_const_util.h>
 

--- a/unit/analyses/does_remove_const/does_type_preserve_const_correctness.cpp
+++ b/unit/analyses/does_remove_const/does_type_preserve_const_correctness.cpp
@@ -12,11 +12,14 @@ Author: Diffblue Ltd.
 #include <testing-utils/use_catch.h>
 
 #include <util/c_types.h>
+#include <util/mathematical_types.h>
 #include <util/namespace.h>
 #include <util/symbol_table.h>
 
 #include <ansi-c/c_qualifiers.h>
+
 #include <goto-programs/goto_program.h>
+
 #include <analyses/does_remove_const/does_remove_const_util.h>
 #include <analyses/does_remove_const.h>
 

--- a/unit/analyses/does_remove_const/is_type_at_least_as_const_as.cpp
+++ b/unit/analyses/does_remove_const/is_type_at_least_as_const_as.cpp
@@ -12,11 +12,14 @@ Author: Diffblue Ltd.
 #include <testing-utils/use_catch.h>
 
 #include <util/c_types.h>
+#include <util/mathematical_types.h>
 #include <util/namespace.h>
 #include <util/symbol_table.h>
 
 #include <ansi-c/c_qualifiers.h>
+
 #include <goto-programs/goto_program.h>
+
 #include <analyses/does_remove_const/does_remove_const_util.h>
 #include <analyses/does_remove_const.h>
 

--- a/unit/util/std_expr.cpp
+++ b/unit/util/std_expr.cpp
@@ -7,7 +7,9 @@ Author: Diffblue Ltd
 \*******************************************************************/
 
 #include <testing-utils/use_catch.h>
+
 #include <util/arith_tools.h>
+#include <util/mathematical_types.h>
 #include <util/std_expr.h>
 #include <util/std_types.h>
 


### PR DESCRIPTION
std_expr.h is a frequently used header file; removing the (unused) include
from this file has the potential to improve compile times.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
