### PR TITLE
Extend object_descriptor_exprt::build and use it

### DIFF
--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -2026,6 +2026,10 @@ public:
   {
   }
 
+  /// Given an expression \p expr, attempt to find the underlying object it
+  /// represents by skipping over type casts and removing balanced
+  /// dereference/address_of operations; that object will then be available
+  /// as root_object().
   void build(const exprt &expr, const namespacet &ns);
 
   exprt &object()

--- a/unit/util/std_expr.cpp
+++ b/unit/util/std_expr.cpp
@@ -9,11 +9,16 @@ Author: Diffblue Ltd
 #include <testing-utils/use_catch.h>
 
 #include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/config.h>
 #include <util/mathematical_types.h>
+#include <util/namespace.h>
+#include <util/simplify_expr.h>
 #include <util/std_expr.h>
 #include <util/std_types.h>
+#include <util/symbol_table.h>
 
-TEST_CASE("for a division expression...")
+TEST_CASE("for a division expression...", "[unit][util][std_expr]")
 {
   auto dividend = from_integer(10, integer_typet());
   auto divisor = from_integer(5, integer_typet());
@@ -28,5 +33,44 @@ TEST_CASE("for a division expression...")
   SECTION("its type is that of its operands")
   {
     REQUIRE(div.type() == integer_typet());
+  }
+}
+
+TEST_CASE("object descriptor expression", "[unit][util][std_expr]")
+{
+  config.ansi_c.set_LP64();
+
+  symbol_tablet symbol_table;
+  const namespacet ns(symbol_table);
+
+  array_typet array_type(signed_int_type(), from_integer(2, size_type()));
+  struct_typet struct_type({{"foo", array_type}});
+
+  SECTION("object descriptors of index expressions")
+  {
+    const symbol_exprt s("array", array_type);
+    // s[1]
+    const index_exprt index(s, from_integer(1, index_type()));
+
+    object_descriptor_exprt ode;
+    ode.build(index, ns);
+    REQUIRE(ode.root_object() == s);
+    // in LP64 a signed int is 4 bytes
+    REQUIRE(simplify_expr(ode.offset(), ns) == from_integer(4, index_type()));
+  }
+
+  SECTION("object descriptors of member expressions")
+  {
+    const symbol_exprt s("struct", struct_type);
+    // s.foo
+    const member_exprt member(s, "foo", array_type);
+    // s.foo[1]
+    const index_exprt index(member, from_integer(1, index_type()));
+
+    object_descriptor_exprt ode;
+    ode.build(index, ns);
+    REQUIRE(ode.root_object() == s);
+    // in LP64 a signed int is 4 bytes
+    REQUIRE(simplify_expr(ode.offset(), ns) == from_integer(4, index_type()));
   }
 }


### PR DESCRIPTION
Move the implementation from the unit test to object_descriptor_exprt to have
all users of object_descriptor_exprt benefit from it.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
