### PR TITLE
Clean member of

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -647,6 +647,14 @@ static irep_idt get_if_cmp_operator(const irep_idt &stmt)
   throw "unhandled java comparison instruction";
 }
 
+/// Build a member exprt for accessing a specific field that may come from a
+/// base class.
+/// \param pointer: The expression to access the field on.
+/// \param fieldref: A getfield/setfield instruction produced by the bytecode
+///   parser.
+/// \param ns: Global namespace
+/// \return A member expression accessing the field, through base class
+///   components if necessary.
 static member_exprt
 to_member(const exprt &pointer, const exprt &fieldref, const namespacet &ns)
 {

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -668,28 +668,25 @@ static member_exprt to_member(
   const irep_idt &component_name = field_reference.get(ID_component_name);
 
   exprt accessed_object = checked_dereference(typed_pointer, class_type);
+  const auto type_of = [&ns](const exprt &object) {
+    return to_struct_type(ns.follow(object.type()));
+  };
 
   // The field access is described as being against a particular type, but it
   // may in fact belong to any ancestor type.
-  while(1)
+  while(type_of(accessed_object).get_component(component_name).is_nil())
   {
-    struct_typet object_type =
-      to_struct_type(ns.follow(accessed_object.type()));
-    auto component = object_type.get_component(component_name);
-
-    if(component.is_not_nil())
-      return member_exprt(accessed_object, component);
-
-    // Component not present: check the immediate parent type.
-
-    const auto &components = object_type.components();
+    const auto components = type_of(accessed_object).components();
     INVARIANT(
       components.size() != 0,
       "infer_opaque_type_fields should guarantee that a member access has a "
       "corresponding field");
 
+    // Base class access is always done through the first component
     accessed_object = member_exprt(accessed_object, components.front());
   }
+  return member_exprt(
+    accessed_object, type_of(accessed_object).get_component(component_name));
 }
 
 /// Find all goto statements in 'repl' that target 'old_label' and redirect them

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -650,20 +650,22 @@ static irep_idt get_if_cmp_operator(const irep_idt &stmt)
 /// Build a member exprt for accessing a specific field that may come from a
 /// base class.
 /// \param pointer: The expression to access the field on.
-/// \param fieldref: A getfield/setfield instruction produced by the bytecode
-///   parser.
+/// \param field_reference: A getfield/setfield instruction produced by the
+///   bytecode parser.
 /// \param ns: Global namespace
 /// \return A member expression accessing the field, through base class
 ///   components if necessary.
-static member_exprt
-to_member(const exprt &pointer, const exprt &fieldref, const namespacet &ns)
+static member_exprt to_member(
+  const exprt &pointer,
+  const exprt &field_reference,
+  const namespacet &ns)
 {
-  struct_tag_typet class_type(fieldref.get(ID_class));
+  struct_tag_typet class_type(field_reference.get(ID_class));
 
   const exprt typed_pointer =
     typecast_exprt::conditional_cast(pointer, java_reference_type(class_type));
 
-  const irep_idt &component_name = fieldref.get(ID_component_name);
+  const irep_idt &component_name = field_reference.get(ID_component_name);
 
   exprt accessed_object = checked_dereference(typed_pointer, class_type);
 

--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -139,7 +139,7 @@ static void create_static_function_call(
         call_args[i].type().id() == ID_pointer,
         "where overriding function argument types differ, "
         "those arguments must be pointer-typed");
-      call_args[i].make_typecast(need_type);
+      call_args[i] = typecast_exprt(call_args[i], need_type);
     }
   }
 }


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [n/a] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [n/a] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

@romainbrenguier @tautschnig I wasn't able to get the resolve_inherited_componentt to work because it relies on the symbols for the base fields existing, but seemingly they do not at this stage. In the mean time, I applied the clean up comments you two requested on the code that I hoped would be fixed by this. 
