### PR TITLE
add a test for error reporting when using --json-ui

### DIFF
--- a/regression/cbmc/json-ui/no_entry.c
+++ b/regression/cbmc/json-ui/no_entry.c
@@ -1,0 +1,4 @@
+int I_am_not_main()
+{
+  return 0;
+}

--- a/regression/cbmc/json-ui/no_entry.desc
+++ b/regression/cbmc/json-ui/no_entry.desc
@@ -1,0 +1,10 @@
+KNOWNBUG
+no_entry.c
+--json-ui
+activate-multi-line-match
+^EXIT=6$
+^SIGNAL=0$
+"messageText": "the program has no entry point",[\n ]*"messageType": "ERROR",
+--
+^warning: ignoring
+^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/json-ui/syntax_error.c
+++ b/regression/cbmc/json-ui/syntax_error.c
@@ -1,0 +1,6 @@
+int main()
+{
+  // clang-format off
+  I AM A SYNTAX ERROR
+  return 0;
+}

--- a/regression/cbmc/json-ui/syntax_error.desc
+++ b/regression/cbmc/json-ui/syntax_error.desc
@@ -1,0 +1,10 @@
+KNOWNBUG
+syntax_error.c
+--json-ui
+activate-multi-line-match
+^EXIT=6$
+^SIGNAL=0$
+"messageText": "syntax error before .*",[\n ]*"messageType": "ERROR",[\n ]*"sourceLocation": {[\n ]*"file": "syntax_error.c",[\n ]*"function": "main",[\n ]*"line": "4",
+--
+^warning: ignoring
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Error-reporting is important, yet undertested, as shown by #3897.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
