### PR TITLE
Construct complex_typet in a non-deprecated way [blocks: #3800]

### DIFF
--- a/src/ansi-c/ansi_c_convert_type.cpp
+++ b/src/ansi-c/ansi_c_convert_type.cpp
@@ -599,9 +599,8 @@ void ansi_c_convert_typet::write(typet &type)
   if(complex_cnt)
   {
     // These take more or less arbitrary subtypes.
-    complex_typet new_type;
+    complex_typet new_type(type);
     new_type.add_source_location()=source_location;
-    new_type.subtype()=type;
     type.swap(new_type);
   }
 

--- a/src/ansi-c/literals/convert_integer_literal.cpp
+++ b/src/ansi-c/literals/convert_integer_literal.cpp
@@ -173,10 +173,8 @@ exprt convert_integer_literal(const std::string &src)
 
   if(is_imaginary)
   {
-    complex_typet complex_type;
-    complex_type.subtype()=type;
     result = complex_exprt(
-      from_integer(0, type), from_integer(value, type), complex_type);
+      from_integer(0, type), from_integer(value, type), complex_typet(type));
   }
   else
   {


### PR DESCRIPTION
The default constructor is deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
