### PR TITLE
Use disjunction instead of deprecated or_exprt constructor [blocks: #3800]

### DIFF
--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1151,18 +1151,13 @@ exprt goto_convertt::case_guard(
     return equal_exprt(value, case_op.at(0));
   else
   {
-    exprt dest = exprt(ID_or, bool_typet());
-    dest.reserve_operands(case_op.size());
+    exprt::operandst disjuncts;
+    disjuncts.reserve(case_op.size());
 
-    forall_expr(it, case_op)
-    {
-      dest.add_to_operands(equal_exprt(value, *it));
-    }
-    INVARIANT(
-      case_op.size() == dest.operands().size(),
-      "case guard conversion should preserve the number of cases");
+    for(const auto &op : case_op)
+      disjuncts.push_back(equal_exprt(value, op));
 
-    return dest;
+    return disjunction(disjuncts);
   }
 }
 


### PR DESCRIPTION
This is more efficient, type safe, and supports even more cleanup here.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
