### PR TITLE
Use conjunction instead of piecewise construction of and_exprt [blocks: #3800]

### DIFF
--- a/src/goto-symex/slice_by_trace.cpp
+++ b/src/goto-symex/slice_by_trace.cpp
@@ -288,16 +288,10 @@ void symex_slice_by_tracet::compute_ts_back(
               pvi++;
             }
 
-            exprt val_merge=exprt(ID_and, typet(ID_bool));
-            val_merge.operands().reserve(eq_conds.size()+1);
-            val_merge.copy_to_operands(merge[j+1]);
-
-            for(const auto &eq_cond : eq_conds)
-            {
-              val_merge.copy_to_operands(eq_cond);
-            }
-
-            u_lhs.add_to_operands(std::move(val_merge));
+            exprt::operandst conjuncts(1, merge[j + 1]);
+            conjuncts.reserve(eq_conds.size() + 1);
+            conjuncts.insert(conjuncts.end(), eq_conds.begin(), eq_conds.end());
+            u_lhs.add_to_operands(conjunction(conjuncts));
           }
           else
           {


### PR DESCRIPTION
This is more efficient, and enables further cleanup.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
