### PR TITLE
Construct side_effect_expr_function_callt in a non-deprecated way [blocks: #3800]

### DIFF
--- a/src/cpp/cpp_constructor.cpp
+++ b/src/cpp/cpp_constructor.cpp
@@ -223,9 +223,9 @@ optionalt<codet> cpp_typecheckt::cpp_constructor(
 
     side_effect_expr_function_callt function_call(
       cpp_namet(constructor_name, source_location).as_expr(),
-      operands_tc);
-
-    function_call.add_source_location()=source_location;
+      operands_tc,
+      uninitialized_typet(),
+      source_location);
 
     typecheck_side_effect_function_call(function_call);
     assert(function_call.get(ID_statement)==ID_temporary_object);

--- a/src/cpp/cpp_destructor.cpp
+++ b/src/cpp/cpp_destructor.cpp
@@ -106,9 +106,8 @@ optionalt<codet> cpp_typecheckt::cpp_destructor(
     member.add(ID_component_cpp_name) = cpp_name;
     member.copy_to_operands(object);
 
-    side_effect_expr_function_callt function_call;
-    function_call.add_source_location()=source_location;
-    function_call.function().swap(member);
+    side_effect_expr_function_callt function_call(
+      std::move(member), {}, uninitialized_typet{}, source_location);
 
     typecheck_side_effect_function_call(function_call);
     already_typechecked(function_call);

--- a/src/cpp/cpp_typecheck_code.cpp
+++ b/src/cpp/cpp_typecheck_code.cpp
@@ -203,10 +203,8 @@ void cpp_typecheckt::typecheck_member_initializer(codet &code)
     assert(code_type.parameters().size()>=1);
 
     // It's a parent. Call the constructor that we got.
-    side_effect_expr_function_callt function_call;
-
-    function_call.function()=symbol_expr;
-    function_call.add_source_location()=code.source_location();
+    side_effect_expr_function_callt function_call(
+      symbol_expr, {}, uninitialized_typet{}, code.source_location());
     function_call.arguments().reserve(code.operands().size()+1);
 
     // we have to add 'this'

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -651,11 +651,12 @@ void cpp_typecheckt::typecheck_compound_declarator(
           lookup(args[0].get(ID_C_identifier)).symbol_expr(),
           to_code_type(component.type()).parameters()[0].type());
 
-        side_effect_expr_function_callt expr_call;
-        expr_call.function() =
-          symbol_exprt(component.get_name(), component.type());
+        side_effect_expr_function_callt expr_call(
+          symbol_exprt(component.get_name(), component.type()),
+          {late_cast},
+          uninitialized_typet{},
+          source_locationt{});
         expr_call.arguments().reserve(args.size());
-        expr_call.arguments().push_back(late_cast);
 
         for(const auto &arg : args)
         {

--- a/src/cpp/cpp_typecheck_conversions.cpp
+++ b/src/cpp/cpp_typecheck_conversions.cpp
@@ -991,10 +991,11 @@ bool cpp_typecheckt::user_defined_conversion_sequence(
               }
 
               // create temporary object
-              side_effect_expr_function_callt ctor_expr;
-              ctor_expr.add_source_location()=expr.source_location();
-              ctor_expr.function().swap(func_symb);
-              ctor_expr.arguments().push_back(tmp_expr);
+              side_effect_expr_function_callt ctor_expr(
+                std::move(func_symb),
+                {tmp_expr},
+                uninitialized_typet{},
+                expr.source_location());
               typecheck_side_effect_function_call(ctor_expr);
 
               new_expr.swap(ctor_expr);
@@ -1041,10 +1042,11 @@ bool cpp_typecheckt::user_defined_conversion_sequence(
                 func_symb.swap(func_symb);
               }
 
-              side_effect_expr_function_callt ctor_expr;
-              ctor_expr.add_source_location()=expr.source_location();
-              ctor_expr.function().swap(func_symb);
-              ctor_expr.arguments().push_back(expr_deref);
+              side_effect_expr_function_callt ctor_expr(
+                std::move(func_symb),
+                {expr_deref},
+                uninitialized_typet{},
+                expr.source_location());
               typecheck_side_effect_function_call(ctor_expr);
 
               new_expr.swap(ctor_expr);
@@ -1101,9 +1103,11 @@ bool cpp_typecheckt::user_defined_conversion_sequence(
         ac.copy_to_operands(expr);
         member_func.copy_to_operands(ac);
 
-        side_effect_expr_function_callt func_expr;
-        func_expr.add_source_location()=expr.source_location();
-        func_expr.function().swap(member_func);
+        side_effect_expr_function_callt func_expr(
+          std::move(member_func),
+          {},
+          uninitialized_typet{},
+          expr.source_location());
         typecheck_side_effect_function_call(func_expr);
 
         if(standard_conversion_sequence(func_expr, type, tmp_expr, tmp_rank))
@@ -1328,9 +1332,11 @@ bool cpp_typecheckt::reference_binding(
         ac.copy_to_operands(expr);
         member_func.copy_to_operands(ac);
 
-        side_effect_expr_function_callt func_expr;
-        func_expr.add_source_location()=expr.source_location();
-        func_expr.function().swap(member_func);
+        side_effect_expr_function_callt func_expr(
+          std::move(member_func),
+          {},
+          uninitialized_typet{},
+          expr.source_location());
         typecheck_side_effect_function_call(func_expr);
 
         // let's check if the returned value binds directly

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -342,9 +342,13 @@ goto_programt::const_targett goto_program2codet::convert_assign_varargs(
       {this_va_list_expr});
     f.arguments().back().type().id(ID_gcc_builtin_va_list);
 
-    side_effect_expr_function_callt type_of;
-    type_of.function() =
-      symbol_exprt("__typeof__", code_typet({}, empty_typet()));
+    // we do not bother to set the correct types here, they are not relevant for
+    // generating the correct dumped output
+    side_effect_expr_function_callt type_of(
+      symbol_exprt("__typeof__", code_typet({}, empty_typet())),
+      {},
+      typet{},
+      source_locationt{});
 
     // if the return value is used, the next instruction will be assign
     goto_programt::const_targett next=target;
@@ -486,9 +490,8 @@ goto_programt::const_targett goto_program2codet::convert_decl(
       {
         // could hack this by just erasing the first operand
         const code_function_callt &f=to_code_function_call(next->code);
-        side_effect_expr_function_callt call;
-        call.function()=f.function();
-        call.arguments()=f.arguments();
+        side_effect_expr_function_callt call(
+          f.function(), f.arguments(), typet{}, source_locationt{});
         d.copy_to_operands(call);
       }
 
@@ -1919,10 +1922,8 @@ void goto_program2codet::cleanup_expr(exprt &expr, bool no_typecast)
       symbol_exprt symbol_expr(symbol.name, symbol.type);
       symbol_expr.add_source_location()=expr.source_location();
 
-      side_effect_expr_function_callt call;
-      call.add_source_location()=expr.source_location();
-      call.function()=symbol_expr;
-      call.type()=expr.type();
+      side_effect_expr_function_callt call(
+        symbol_expr, {}, expr.type(), expr.source_location());
 
       expr.swap(call);
     }

--- a/src/jsil/parser.y
+++ b/src/jsil/parser.y
@@ -260,8 +260,7 @@ instruction: TOK_LABEL TOK_IDENTIFIER
 rhs: expression
    | proc_ident_expr '(' expressions_opt ')' with_opt
    {
-     side_effect_expr_function_callt f;
-     f.function().swap(stack($1));
+     side_effect_expr_function_callt f(stack($1), {}, typet{}, {});
      if(stack($3).is_not_nil())
        f.arguments().swap(stack($3).operands());
 


### PR DESCRIPTION
The constructor requires four arguments.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
