### PR TITLE
Construct code_typet in a non-deprecated way [blocks: #3800]

### DIFF
--- a/src/ansi-c/c_typecheck_code.cpp
+++ b/src/ansi-c/c_typecheck_code.cpp
@@ -30,7 +30,7 @@ void c_typecheck_baset::typecheck_code(codet &code)
     throw 0;
   }
 
-  code.type()=code_typet();
+  code.type() = empty_typet();
 
   const irep_idt &statement=code.get_statement();
 

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -221,7 +221,9 @@ void goto_convertt::do_printf(
     else
     {
       printf_code.id(ID_code);
-      printf_code.type()=typet(ID_code);
+      printf_code.type() = code_typet(
+        code_typet::parameterst(to_code_type(function.type()).parameters()),
+        empty_typet());
       copy(to_code(printf_code), OTHER, dest);
     }
   }

--- a/src/jsil/jsil_typecheck.cpp
+++ b/src/jsil/jsil_typecheck.cpp
@@ -348,7 +348,7 @@ void jsil_typecheckt::typecheck_expr_index(exprt &expr)
 
   // special case for function identifiers
   if(expr.op1().id()=="fid" || expr.op1().id()=="constructid")
-    expr.type()=code_typet();
+    expr.type() = code_typet({}, typet());
   else
     expr.type()=jsil_value_type();
 }
@@ -802,7 +802,7 @@ void jsil_typecheckt::typecheck_function_call(
       // Should be function, declaration not found yet
       symbolt new_symbol;
       new_symbol.name=id;
-      new_symbol.type=code_typet();
+      new_symbol.type = code_typet({}, typet());
       new_symbol.mode="jsil";
       new_symbol.is_type=false;
       new_symbol.value=exprt("no-body-just-yet");

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -17,6 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "expr_cast.h"
 #include "invariant.h"
 #include "std_expr.h"
+#include "std_types.h"
 #include "validate.h"
 #include "validate_code.h"
 
@@ -35,15 +36,14 @@ class codet:public exprt
 {
 public:
   DEPRECATED("use codet(statement) instead")
-  codet():exprt(ID_code, typet(ID_code))
+  codet() : exprt(ID_code, empty_typet())
   {
   }
 
   /// \param statement: Specifies the type of the `codet` to be constructed,
   ///   e.g. `ID_block` for a \ref code_blockt or `ID_assign` for a
   ///   \ref code_assignt.
-  explicit codet(const irep_idt &statement):
-    exprt(ID_code, typet(ID_code))
+  explicit codet(const irep_idt &statement) : exprt(ID_code, empty_typet())
   {
     set_statement(statement);
   }


### PR DESCRIPTION
The default constructor is deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
