### PR TITLE
irept constructors to avoid immediate detach() calls

### DIFF
--- a/unit/util/irep.cpp
+++ b/unit/util/irep.cpp
@@ -72,6 +72,19 @@ SCENARIO("irept_memory", "[core][utils][irept]")
     }
   }
 
+  GIVEN("Parts of an irep")
+  {
+    irept irep("some_id", {{"some_member", irept("other")}}, {irept("op")});
+
+    THEN("It is properly initialized")
+    {
+      REQUIRE(irep.id() == "some_id");
+      REQUIRE(irep.find("some_member") == irept("other"));
+      REQUIRE(irep.get_sub().size() == 1);
+      REQUIRE(irep.get_sub().front() == irept("op"));
+    }
+  }
+
   GIVEN("An initialized irep")
   {
     irept irep("some_id");


### PR DESCRIPTION
irept construction should not require multiple API calls.

This enables bottom-up construction of irept in several places, and I will follow up with PRs making use of these (the commits currently all live in #3502).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
