### PR TITLE
Encapsulate ID_already_typechecked in a proper API

### DIFF
--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -643,7 +643,7 @@ void c_typecheck_baset::typecheck_declaration(
     typecheck_type(declaration.type());
 
     // mark as 'already typechecked'
-    make_already_typechecked(declaration.type());
+    already_typechecked_typet::make_already_typechecked(declaration.type());
 
     irept contract;
 

--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -225,13 +225,6 @@ protected:
     const mp_integer &min, const mp_integer &max,
     bool is_packed) const;
 
-  void make_already_typechecked(typet &dest)
-  {
-    typet result(ID_already_typechecked);
-    result.subtype().swap(dest);
-    result.swap(dest);
-  }
-
   // this cleans expressions in array types
   std::list<codet> clean_code;
 
@@ -271,5 +264,61 @@ protected:
 
   void apply_asm_label(const irep_idt &asm_label, symbolt &symbol);
 };
+
+class already_typechecked_exprt : public expr_protectedt
+{
+public:
+  explicit already_typechecked_exprt(exprt expr)
+    : expr_protectedt(ID_already_typechecked, typet{}, {std::move(expr)})
+  {
+  }
+
+  static void make_already_typechecked(exprt &expr)
+  {
+    already_typechecked_exprt a{expr};
+    expr.swap(a);
+  }
+
+  exprt &get_expr()
+  {
+    return op0();
+  }
+};
+
+class already_typechecked_typet : public type_with_subtypet
+{
+public:
+  explicit already_typechecked_typet(typet type)
+    : type_with_subtypet(ID_already_typechecked, std::move(type))
+  {
+  }
+
+  static void make_already_typechecked(typet &type)
+  {
+    already_typechecked_typet a{type};
+    type.swap(a);
+  }
+
+  typet &get_type()
+  {
+    return subtype();
+  }
+};
+
+inline already_typechecked_exprt &to_already_typechecked_expr(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_already_typechecked);
+  PRECONDITION(expr.operands().size() == 1);
+
+  return static_cast<already_typechecked_exprt &>(expr);
+}
+
+inline already_typechecked_typet &to_already_typechecked_type(typet &type)
+{
+  PRECONDITION(type.id() == ID_already_typechecked);
+  PRECONDITION(type.has_subtype());
+
+  return static_cast<already_typechecked_typet &>(type);
+}
 
 #endif // CPROVER_ANSI_C_C_TYPECHECK_BASE_H

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -38,10 +38,7 @@ void c_typecheck_baset::typecheck_expr(exprt &expr)
 {
   if(expr.id()==ID_already_typechecked)
   {
-    assert(expr.operands().size()==1);
-    exprt tmp;
-    tmp.swap(expr.op0());
-    expr.swap(tmp);
+    expr.swap(to_already_typechecked_expr(expr).get_expr());
     return;
   }
 

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -40,14 +40,17 @@ void c_typecheck_baset::typecheck_type(typet &type)
 
   if(type.id()==ID_already_typechecked)
   {
+    already_typechecked_typet &already_typechecked =
+      to_already_typechecked_type(type);
+
     // need to preserve any qualifiers
     c_qualifierst c_qualifiers(type);
-    c_qualifiers+=c_qualifierst(type.subtype());
+    c_qualifiers += c_qualifierst(already_typechecked.get_type());
     bool packed=type.get_bool(ID_C_packed);
     exprt alignment=static_cast<const exprt &>(type.find(ID_C_alignment));
     irept _typedef=type.find(ID_C_typedef);
 
-    type=type.subtype();
+    type = already_typechecked.get_type();
 
     c_qualifiers.write(type);
     if(packed)
@@ -896,7 +899,7 @@ void c_typecheck_baset::typecheck_compound_body(
     {
       // do first half of type
       typecheck_type(declaration.type());
-      make_already_typechecked(declaration.type());
+      already_typechecked_typet::make_already_typechecked(declaration.type());
 
       for(const auto &declarator : declaration.declarators())
       {

--- a/src/cpp/cpp_constructor.cpp
+++ b/src/cpp/cpp_constructor.cpp
@@ -276,7 +276,7 @@ void cpp_typecheckt::new_temporary(
   new_object.set(ID_C_lvalue, true);
   new_object.type()=tmp_object_expr.type();
 
-  already_typechecked(new_object);
+  already_typechecked_exprt::make_already_typechecked(new_object);
 
   auto new_code = cpp_constructor(source_location, new_object, ops);
 

--- a/src/cpp/cpp_destructor.cpp
+++ b/src/cpp/cpp_destructor.cpp
@@ -109,7 +109,7 @@ optionalt<codet> cpp_typecheckt::cpp_destructor(
       std::move(member), {}, uninitialized_typet{}, source_location);
 
     typecheck_side_effect_function_call(function_call);
-    already_typechecked(function_call);
+    already_typechecked_exprt::make_already_typechecked(function_call);
 
     code_expressiont new_code(function_call);
     new_code.add_source_location() = source_location;

--- a/src/cpp/cpp_typecheck_code.cpp
+++ b/src/cpp/cpp_typecheck_code.cpp
@@ -359,7 +359,7 @@ void cpp_typecheckt::typecheck_member_initializer(codet &code)
       else
       {
         // it's a data member
-        already_typechecked(symbol_expr);
+        already_typechecked_exprt::make_already_typechecked(symbol_expr);
 
         auto call =
           cpp_constructor(code.source_location(), symbol_expr, code.operands());
@@ -423,7 +423,7 @@ void cpp_typecheckt::typecheck_decl(codet &code)
   }
 
   // mark as 'already typechecked'
-  make_already_typechecked(type);
+  already_typechecked_typet::make_already_typechecked(type);
 
   codet new_code(ID_decl_block);
   new_code.reserve_operands(declaration.declarators().size());
@@ -469,7 +469,7 @@ void cpp_typecheckt::typecheck_decl(codet &code)
     {
       exprt object_expr=cpp_symbol_expr(symbol);
 
-      already_typechecked(object_expr);
+      already_typechecked_exprt::make_already_typechecked(object_expr);
 
       auto constructor_call = cpp_constructor(
         symbol.location, object_expr, declarator.init_args().operands());

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -668,17 +668,16 @@ void cpp_typecheckt::typecheck_compound_declarator(
            code_type.return_type().id()!=ID_destructor)
         {
           expr_call.type()=to_code_type(component.type()).return_type();
-          exprt already_typechecked(ID_already_typechecked);
-          already_typechecked.add_to_operands(std::move(expr_call));
 
-          func_symb.value = code_returnt(already_typechecked).make_block();
+          func_symb.value =
+            code_returnt(already_typechecked_exprt{std::move(expr_call)})
+              .make_block();
         }
         else
         {
-          exprt already_typechecked(ID_already_typechecked);
-          already_typechecked.add_to_operands(std::move(expr_call));
-
-          func_symb.value = code_expressiont(already_typechecked).make_block();
+          func_symb.value =
+            code_expressiont(already_typechecked_exprt{std::move(expr_call)})
+              .make_block();
         }
 
         // add this new function to the list of components

--- a/src/cpp/cpp_typecheck_constructor.cpp
+++ b/src/cpp/cpp_typecheck_constructor.cpp
@@ -235,7 +235,7 @@ void cpp_typecheckt::default_cpctor(
       address_of_exprt address(var);
       assert(address.type() == mem_c.type());
 
-      already_typechecked(address);
+      already_typechecked_exprt::make_already_typechecked(address);
 
       exprt ptrmember(ID_ptrmember);
       ptrmember.set(ID_component_name, mem_c.get_name());
@@ -690,7 +690,7 @@ void cpp_typecheckt::full_member_initialization(
       address_of_exprt address(var);
       assert(address.type() == c.type());
 
-      already_typechecked(address);
+      already_typechecked_exprt::make_already_typechecked(address);
 
       exprt ptrmember(ID_ptrmember);
       ptrmember.set(ID_component_name, c.get_name());

--- a/src/cpp/cpp_typecheck_conversions.cpp
+++ b/src/cpp/cpp_typecheck_conversions.cpp
@@ -971,11 +971,7 @@ bool cpp_typecheckt::user_defined_conversion_sequence(
 
               exprt func_symb = cpp_symbol_expr(lookup(component.get_name()));
               func_symb.type()=comp_type;
-              {
-                exprt tmp(ID_already_typechecked);
-                tmp.copy_to_operands(func_symb);
-                func_symb.swap(func_symb);
-              }
+              already_typechecked_exprt::make_already_typechecked(func_symb);
 
               // create temporary object
               side_effect_expr_function_callt ctor_expr(
@@ -1023,11 +1019,7 @@ bool cpp_typecheckt::user_defined_conversion_sequence(
 
               exprt func_symb = cpp_symbol_expr(lookup(component.get_name()));
               func_symb.type()=comp_type;
-              {
-                exprt tmp(ID_already_typechecked);
-                tmp.copy_to_operands(func_symb);
-                func_symb.swap(func_symb);
-              }
+              already_typechecked_exprt::make_already_typechecked(func_symb);
 
               side_effect_expr_function_callt ctor_expr(
                 std::move(func_symb),
@@ -1086,9 +1078,7 @@ bool cpp_typecheckt::user_defined_conversion_sequence(
 
         exprt member_func(ID_member);
         member_func.add(ID_component_cpp_name)=cpp_func_name;
-        exprt ac(ID_already_typechecked);
-        ac.copy_to_operands(expr);
-        member_func.copy_to_operands(ac);
+        member_func.copy_to_operands(already_typechecked_exprt{expr});
 
         side_effect_expr_function_callt func_expr(
           std::move(member_func),
@@ -1326,9 +1316,7 @@ bool cpp_typecheckt::reference_binding(
 
         exprt member_func(ID_member);
         member_func.add(ID_component_cpp_name)=cpp_func_name;
-        exprt ac(ID_already_typechecked);
-        ac.copy_to_operands(expr);
-        member_func.copy_to_operands(ac);
+        member_func.copy_to_operands(already_typechecked_exprt{expr});
 
         side_effect_expr_function_callt func_expr(
           std::move(member_func),
@@ -1932,10 +1920,12 @@ bool cpp_typecheckt::static_typecast(
   {
     if(!cpp_is_pod(type))
     {
-      exprt tc(ID_already_typechecked);
-      tc.copy_to_operands(new_expr);
       exprt temporary;
-      new_temporary(e.source_location(), type, tc, temporary);
+      new_temporary(
+        e.source_location(),
+        type,
+        already_typechecked_exprt{new_expr},
+        temporary);
       new_expr.swap(temporary);
     }
     else

--- a/src/cpp/cpp_typecheck_declaration.cpp
+++ b/src/cpp/cpp_typecheck_declaration.cpp
@@ -116,7 +116,7 @@ void cpp_typecheckt::convert_non_template_declaration(
 
   // mark as 'already typechecked'
   if(!declaration.declarators().empty())
-    make_already_typechecked(declaration_type);
+    already_typechecked_typet::make_already_typechecked(declaration_type);
 
   // Special treatment for anonymous unions
   if(declaration.declarators().empty() &&

--- a/src/cpp/cpp_typecheck_destructor.cpp
+++ b/src/cpp/cpp_typecheck_destructor.cpp
@@ -81,7 +81,7 @@ codet cpp_typecheckt::dtor(const symbolt &symbol, const symbol_exprt &this_expr)
       address_of_exprt address(var);
       assert(address.type() == c.type());
 
-      already_typechecked(address);
+      already_typechecked_exprt::make_already_typechecked(address);
 
       exprt ptrmember(ID_ptrmember);
       ptrmember.set(ID_component_name, c.get_name());

--- a/src/cpp/cpp_typecheck_initializer.cpp
+++ b/src/cpp/cpp_typecheck_initializer.cpp
@@ -171,7 +171,7 @@ void cpp_typecheckt::convert_initializer(symbolt &symbol)
     // we need a constructor
 
     symbol_exprt expr_symbol(symbol.name, symbol.type);
-    already_typechecked(expr_symbol);
+    already_typechecked_exprt::make_already_typechecked(expr_symbol);
 
     exprt::operandst ops;
     ops.push_back(symbol.value);
@@ -297,7 +297,7 @@ void cpp_typecheckt::zero_initializer(
 
     exprt zero =
       typecast_exprt::conditional_cast(from_integer(0, enum_type), type);
-    already_typechecked(zero);
+    already_typechecked_exprt::make_already_typechecked(zero);
 
     code_assignt assign;
     assign.lhs()=object;
@@ -306,7 +306,7 @@ void cpp_typecheckt::zero_initializer(
 
     typecheck_expr(assign.lhs());
     assign.lhs().type().set(ID_C_constant, false);
-    already_typechecked(assign.lhs());
+    already_typechecked_exprt::make_already_typechecked(assign.lhs());
 
     typecheck_code(assign);
     ops.push_back(assign);
@@ -327,7 +327,7 @@ void cpp_typecheckt::zero_initializer(
 
     typecheck_expr(assign.lhs());
     assign.lhs().type().set(ID_C_constant, false);
-    already_typechecked(assign.lhs());
+    already_typechecked_exprt::make_already_typechecked(assign.lhs());
 
     typecheck_code(assign);
     ops.push_back(assign);

--- a/src/cpp/cpp_typecheck_template.cpp
+++ b/src/cpp/cpp_typecheck_template.cpp
@@ -833,7 +833,7 @@ cpp_template_args_tct cpp_typecheckt::typecheck_template_args(
   const cpp_template_args_non_tct &template_args)
 {
   // old stuff
-  assert(template_args.id()!=ID_already_typechecked);
+  PRECONDITION(template_args.id() != ID_already_typechecked);
 
   assert(template_symbol.type.get_bool(ID_is_template));
 

--- a/src/cpp/cpp_util.h
+++ b/src/cpp/cpp_util.h
@@ -15,11 +15,4 @@ Author:
 
 symbol_exprt cpp_symbol_expr(const symbolt &symbol);
 
-inline void already_typechecked(irept &irep)
-{
-  exprt tmp(ID_already_typechecked);
-  tmp.copy_to_operands(static_cast<exprt &>(irep));
-  irep.swap(tmp);
-}
-
 #endif // CPROVER_CPP_CPP_UTIL_H


### PR DESCRIPTION
The object goes out of scope, just pass it as an rvalue.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
