### PR TITLE
Remove dead code around ID_function_call

### DIFF
--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -916,43 +916,13 @@ void c_typecheck_baset::typecheck_side_effect_statement_expression(
 
     expr.type()=op.type();
   }
-  else if(last_statement==ID_function_call)
-  {
-    // this is suspected to be dead
-    UNREACHABLE;
-
-    // make the last statement an expression
-
-    code_function_callt &fc=to_code_function_call(last);
-
-    side_effect_expr_function_callt sideeffect(
-      fc.function(),
-      fc.arguments(),
-      to_code_type(fc.function().type()).return_type(),
-      fc.source_location());
-
-    expr.type()=sideeffect.type();
-
-    if(fc.lhs().is_nil())
-    {
-      code_expressiont code_expr(sideeffect);
-      code_expr.add_source_location() = fc.source_location();
-      last.swap(code_expr);
-    }
-    else
-    {
-      side_effect_exprt assign(
-        ID_assign, sideeffect.type(), fc.source_location());
-      assign.add_to_operands(fc.lhs(), std::move(sideeffect));
-
-      code_expressiont code_expr(assign);
-      code_expr.add_source_location() = fc.source_location();
-
-      last.swap(code_expr);
-    }
-  }
   else
+  {
+    // we used to do this, but don't expect it any longer
+    PRECONDITION(last_statement != ID_function_call);
+
     expr.type()=typet(ID_empty);
+  }
 }
 
 void c_typecheck_baset::typecheck_expr_sizeof(exprt &expr)

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -40,26 +40,7 @@ void goto_symext::symex_assign(
     const side_effect_exprt &side_effect_expr=to_side_effect_expr(rhs);
     const irep_idt &statement=side_effect_expr.get_statement();
 
-    if(statement==ID_function_call)
-    {
-      const auto &function_call =
-        to_side_effect_expr_function_call(side_effect_expr);
-
-      DATA_INVARIANT(
-        !side_effect_expr.operands().empty(),
-        "function call statement expects non-empty list of side effects");
-
-      DATA_INVARIANT(
-        function_call.function().id() == ID_symbol,
-        "expected symbol as function");
-
-      const irep_idt &identifier =
-        to_symbol_expr(function_call.function()).get_identifier();
-
-      throw unsupported_operation_exceptiont(
-        "symex_assign: unexpected function call: " + id2string(identifier));
-    }
-    else if(
+    if(
       statement == ID_cpp_new || statement == ID_cpp_new_array ||
       statement == ID_java_new_array_data)
       symex_cpp_new(state, lhs, side_effect_expr);


### PR DESCRIPTION
Both bits of code would necessarily have triggered a failing invariant or an
exception. We continue to fail an invariant (UNREACHABLE), but don't keep around
the poorly maintained (dead) code.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
