### PR TITLE
Use fieldref exprt

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -395,7 +395,8 @@ protected:
     codet &c,
     exprt::operandst &results);
 
-  code_blockt convert_putfield(const exprt &arg0, const exprt::operandst &op);
+  code_blockt
+  convert_putfield(const fieldref_exprt &arg0, const exprt::operandst &op);
 
   code_blockt convert_putstatic(
     const source_locationt &location,

--- a/jbmc/src/java_bytecode/java_bytecode_language.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_language.cpp
@@ -311,8 +311,9 @@ static void infer_opaque_type_fields(
       if(instruction.statement == "getfield" ||
          instruction.statement == "putfield")
       {
-        const exprt &fieldref = instruction.args[0];
-        irep_idt class_symbol_id = fieldref.get(ID_class);
+        const fieldref_exprt &fieldref =
+          expr_dynamic_cast<fieldref_exprt>(instruction.args[0]);
+        irep_idt class_symbol_id = fieldref.class_name();
         const symbolt *class_symbol = symbol_table.lookup(class_symbol_id);
         INVARIANT(
           class_symbol != nullptr,
@@ -320,7 +321,7 @@ static void infer_opaque_type_fields(
 
         const java_class_typet *class_type =
           &to_java_class_type(class_symbol->type);
-        const irep_idt &component_name = fieldref.get(ID_component_name);
+        const irep_idt &component_name = fieldref.component_name();
         while(!class_type->has_component(component_name))
         {
           if(class_type->get_is_stub())
@@ -582,12 +583,10 @@ static void create_stub_global_symbols(
         INVARIANT(
           instruction.args.size() > 0,
           "get/putstatic should have at least one argument");
-        irep_idt component = instruction.args[0].get_string(ID_component_name);
-        INVARIANT(
-          !component.empty(), "get/putstatic should specify a component");
-        irep_idt class_id = instruction.args[0].get_string(ID_class);
-        INVARIANT(
-          !class_id.empty(), "get/putstatic should specify a class");
+        const fieldref_exprt &field_ref =
+          expr_dynamic_cast<fieldref_exprt>(instruction.args[0]);
+        irep_idt component = field_ref.component_name();
+        irep_idt class_id = field_ref.class_name();
 
         // The final 'true' parameter here includes interfaces, as they can
         // define static fields.

--- a/jbmc/src/java_bytecode/java_bytecode_parse_tree.h
+++ b/jbmc/src/java_bytecode/java_bytecode_parse_tree.h
@@ -337,6 +337,22 @@ public:
     set(ID_class, class_name);
     set(ID_component_name, component_name);
   }
+
+  irep_idt class_name() const
+  {
+    return get(ID_class);
+  }
+
+  irep_idt component_name() const
+  {
+    return get(ID_component_name);
+  }
 };
+
+template <>
+inline bool can_cast_expr<fieldref_exprt>(const exprt &base)
+{
+  return base.get(ID_class) != ID_nil && base.get(ID_component_name) != ID_nil;
+}
 
 #endif // CPROVER_JAVA_BYTECODE_JAVA_BYTECODE_PARSE_TREE_H


### PR DESCRIPTION
- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [n/a] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [n/a] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.