### PR TITLE
Fix/redirect exception handler output

### DIFF
--- a/regression/cbmc/json-ui/no_entry.desc
+++ b/regression/cbmc/json-ui/no_entry.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 no_entry.c
 --json-ui
 activate-multi-line-match

--- a/regression/cbmc/json-ui/no_entry.desc
+++ b/regression/cbmc/json-ui/no_entry.desc
@@ -4,7 +4,7 @@ no_entry.c
 activate-multi-line-match
 ^EXIT=6$
 ^SIGNAL=0$
-"messageText": "the program has no entry point",[\n ]*"messageType": "ERROR",
+"messageText": "the program has no entry point",[\n ]*"messageType": "ERROR"
 --
 ^warning: ignoring
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/json-ui/syntax_error.desc
+++ b/regression/cbmc/json-ui/syntax_error.desc
@@ -4,7 +4,7 @@ syntax_error.c
 activate-multi-line-match
 ^EXIT=6$
 ^SIGNAL=0$
-"messageText": "syntax error before .*",[\n ]*"messageType": "ERROR",[\n ]*"sourceLocation": {[\n ]*"file": "syntax_error.c",[\n ]*"function": "main",[\n ]*"line": "4",
+"messageText": "syntax error before .*",[\n ]*"messageType": "ERROR",[\n ]*"sourceLocation": \{[\n ]*"file": "syntax_error.c",[\n ]*"function": "main",[\n ]*"line": "4",
 --
 ^warning: ignoring
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/json-ui/syntax_error.desc
+++ b/regression/cbmc/json-ui/syntax_error.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 syntax_error.c
 --json-ui
 activate-multi-line-match

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -121,6 +121,12 @@ protected:
   void get_command_line_options(optionst &);
   void preprocessing(const optionst &);
   bool set_properties();
+
+  virtual void error_message(const std::string &err) override
+  {
+    error() << err << eom;
+    return;
+  }
 };
 
 #endif // CPROVER_CBMC_CBMC_PARSE_OPTIONS_H

--- a/src/goto-analyzer/goto_analyzer_parse_options.h
+++ b/src/goto-analyzer/goto_analyzer_parse_options.h
@@ -181,6 +181,12 @@ protected:
   {
     return ui_message_handler.get_ui();
   }
+
+  virtual void error_message(const std::string &err) override
+  {
+    error() << err << eom;
+    return;
+  }
 };
 
 #endif // CPROVER_GOTO_ANALYZER_GOTO_ANALYZER_PARSE_OPTIONS_H

--- a/src/goto-diff/goto_diff_parse_options.h
+++ b/src/goto-diff/goto_diff_parse_options.h
@@ -71,6 +71,12 @@ protected:
     goto_modelt &goto_model);
 
   void preprocessing();
+
+  virtual void error_message(const std::string &err) override
+  {
+    error() << err << eom;
+    return;
+  }
 };
 
 #endif // CPROVER_GOTO_DIFF_GOTO_DIFF_PARSE_OPTIONS_H

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -151,6 +151,12 @@ protected:
   {
     return ui_message_handler.get_ui();
   }
+
+  virtual void error_message(const std::string &err) override
+  {
+    error() << err << eom;
+    return;
+  }
 };
 
 #endif // CPROVER_GOTO_INSTRUMENT_GOTO_INSTRUMENT_PARSE_OPTIONS_H

--- a/src/util/parse_options.cpp
+++ b/src/util/parse_options.cpp
@@ -35,8 +35,15 @@ void parse_options_baset::help()
 
 void parse_options_baset::usage_error()
 {
-  std::cerr << "Usage error!\n\n";
+  error_message("Usage error!\n");
   help();
+}
+
+/// This can be overloaded so that error messages are valid XML / JSON.
+void parse_options_baset::error_message(const std::string &err)
+{
+  std::cerr << err << '\n';
+  return;
 }
 
 /// Print an error message mentioning the option that was not recognized when
@@ -44,7 +51,7 @@ void parse_options_baset::usage_error()
 void parse_options_baset::unknown_option_msg()
 {
   if(!cmdline.unknown_arg.empty())
-    std::cerr << "Unknown option: " << cmdline.unknown_arg << "\n";
+    error_message("Unknown option: " + cmdline.unknown_arg + "\n");
 }
 
 int parse_options_baset::main()
@@ -75,43 +82,43 @@ int parse_options_baset::main()
   // CPROVER style exceptions in order of decreasing happiness
   catch(const invalid_command_line_argument_exceptiont &e)
   {
-    std::cerr << e.what() << '\n';
+    error_message(e.what());
     return CPROVER_EXIT_USAGE_ERROR;
   }
   catch(const cprover_exception_baset &e)
   {
-    std::cerr << e.what() << '\n';
+    error_message(e.what());
     return CPROVER_EXIT_EXCEPTION;
   }
   catch(const std::string &e)
   {
-    std::cerr << "C++ string exception : " << e << '\n';
+    error_message("C++ string exception : " + e);
     return CPROVER_EXIT_EXCEPTION;
   }
   catch(const char *e)
   {
-    std::cerr << "C string exception : " << e << '\n';
+    error_message(std::string("C string exception : ") + e);
     return CPROVER_EXIT_EXCEPTION;
   }
   catch(int e)
   {
-    std::cerr << "Numeric exception : " << e << '\n';
+    error_message("Numeric exception : " + std::to_string(e));
     return CPROVER_EXIT_EXCEPTION;
   }
   // C++ style exceptions
   catch(const std::bad_alloc &)
   {
-    std::cerr << "Out of memory" << '\n';
+    error_message("Out of memory");
     return CPROVER_EXIT_INTERNAL_OUT_OF_MEMORY;
   }
   catch(const std::exception &e)
   {
-    std::cerr << e.what() << '\n';
+    error_message(e.what());
     return CPROVER_EXIT_EXCEPTION;
   }
   catch(...)
   {
-    std::cerr << "Unknown exception type!" << '\n';
+    error_message("Unknown exception type!");
     return CPROVER_EXIT_EXCEPTION;
   }
 }

--- a/src/util/parse_options.h
+++ b/src/util/parse_options.h
@@ -30,6 +30,9 @@ public:
   virtual int main();
   virtual ~parse_options_baset() { }
 
+protected:
+  virtual void error_message(const std::string &err);
+
 private:
   void unknown_option_msg();
   bool parse_result;


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->

As requested by @kroening this builds on https://github.com/diffblue/cbmc/pull/3897 to allow the exception handlers output to be wrapped appropriately.  This enables the two test cases given in https://github.com/diffblue/cbmc/pull/3902/ and should get us closer to not having things dumped on std:cerr when running in JSON or XML UI modes.
