### PR TITLE
Fully rewrite nested forall during symbolic execution

### DIFF
--- a/regression/cbmc/Quantifiers-simplify/rewrite_forall.c
+++ b/regression/cbmc/Quantifiers-simplify/rewrite_forall.c
@@ -1,0 +1,18 @@
+int main()
+{
+  // clang-format off
+  __CPROVER_assert(
+    __CPROVER_forall {
+      int i;
+      // clang-format would rewrite the "==>" as "== >"
+      i >= 0 ==> __CPROVER_forall
+      {
+        int j;
+        j<0 ==> j < i
+      }
+    },
+    "rewrite");
+  // clang-format on
+
+  return 0;
+}

--- a/regression/cbmc/Quantifiers-simplify/rewrite_forall.desc
+++ b/regression/cbmc/Quantifiers-simplify/rewrite_forall.desc
@@ -1,0 +1,8 @@
+CORE
+rewrite_forall.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring


### PR DESCRIPTION
This permits (correctly) solving another simple regression test.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
