### PR TITLE
Use (non-trivial) constructors for plus_exprt, side_effect_exprt [blocks: #3800]

### DIFF
--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1270,9 +1270,9 @@ void c_typecheck_baset::typecheck_expr_index(exprt &expr)
     // p[i] is syntactic sugar for *(p+i)
 
     typecheck_arithmetic_pointer(expr.op0());
-    exprt addition(ID_plus, array_expr.type());
-    addition.operands().swap(expr.operands());
-    expr.add_to_operands(std::move(addition));
+    exprt::operandst summands;
+    std::swap(summands, expr.operands());
+    expr.add_to_operands(plus_exprt(std::move(summands), array_expr.type()));
     expr.id(ID_dereference);
     expr.set(ID_C_lvalue, true);
     expr.type() = final_array_type.subtype();

--- a/src/cpp/cpp_typecheck_conversions.cpp
+++ b/src/cpp/cpp_typecheck_conversions.cpp
@@ -1394,9 +1394,8 @@ bool cpp_typecheckt::reference_binding(
   {
     {
       // create temporary object
-      exprt tmp=exprt(ID_side_effect, type.subtype());
-      tmp.set(ID_statement, ID_temporary_object);
-      tmp.add_source_location()=expr.source_location();
+      side_effect_exprt tmp(
+        ID_temporary_object, type.subtype(), expr.source_location());
       // tmp.set(ID_C_lvalue, true);
       tmp.add_to_operands(std::move(new_expr));
       new_expr.swap(tmp);


### PR DESCRIPTION
This is more efficient, type safe, and easier to read.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
