### PR TITLE
Use non-deprecated constructors for code*t [blocks: #3800]

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1206,7 +1206,7 @@ code_blockt java_bytecode_convert_methodt::convert_instructions(
       }
     }
 
-    codet catch_instruction;
+    optionalt<codet> catch_instruction;
 
     if(catch_type!=typet())
     {
@@ -1223,8 +1223,7 @@ code_blockt java_bytecode_convert_methodt::convert_instructions(
           "caught_exception",
           java_reference_type(catch_type));
       stack.push_back(catch_var);
-      code_landingpadt catch_statement(catch_var);
-      catch_instruction=catch_statement;
+      catch_instruction = code_landingpadt(catch_var);
     }
 
     exprt::operandst op = pop(stmt_bytecode_info.pop);
@@ -1677,10 +1676,10 @@ code_blockt java_bytecode_convert_methodt::convert_instructions(
     // Finally if this is the beginning of a catch block (already determined
     // before the big bytecode switch), insert the exception 'landing pad'
     // instruction before the actual instruction:
-    if(catch_instruction!=codet())
+    if(catch_instruction.has_value())
     {
       c.make_block();
-      c.operands().insert(c.operands().begin(), catch_instruction);
+      c.operands().insert(c.operands().begin(), *catch_instruction);
     }
 
     if(!i_it->source_location.get_line().empty())

--- a/regression/goto-instrument/print-internal-representation/test.desc
+++ b/regression/goto-instrument/print-internal-representation/test.desc
@@ -3,7 +3,7 @@ main.c
 --print-internal-representation
 ^EXIT=0$
 ^SIGNAL=0$
-^  \* identifier: __CPROVER_initialize$
+\* identifier: __CPROVER_initialize$
 ^      \* identifier: main::1::x$
 ^      \* identifier: main::1::y$
 --

--- a/src/analyses/flow_insensitive_analysis.cpp
+++ b/src/analyses/flow_insensitive_analysis.cpp
@@ -217,7 +217,6 @@ bool flow_insensitive_analysis_baset::do_function_call(
     r->location_number=0;
 
     goto_programt::targett t=temp.add_instruction(END_FUNCTION);
-    t->code.set(ID_identifier, code.function());
     t->function=f_it->first;
     t->location_number=1;
 

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -648,7 +648,7 @@ void c_typecheck_baset::typecheck_declaration(
     // mark as 'already typechecked'
     make_already_typechecked(declaration.type());
 
-    codet contract;
+    irept contract;
 
     {
       exprt spec_requires=
@@ -738,7 +738,7 @@ void c_typecheck_baset::typecheck_declaration(
       // available
       symbolt &new_symbol=*symbol_table.get_writeable(identifier);
 
-      typecheck_spec_expr(contract, ID_C_spec_requires);
+      typecheck_spec_expr(static_cast<codet &>(contract), ID_C_spec_requires);
 
       typet ret_type=empty_typet();
       if(new_symbol.type.id()==ID_code)
@@ -746,7 +746,7 @@ void c_typecheck_baset::typecheck_declaration(
       assert(parameter_map.empty());
       if(ret_type.id()!=ID_empty)
         parameter_map[CPROVER_PREFIX "return_value"] = ret_type;
-      typecheck_spec_expr(contract, ID_C_spec_ensures);
+      typecheck_spec_expr(static_cast<codet &>(contract), ID_C_spec_ensures);
       parameter_map.clear();
 
       if(contract.find(ID_C_spec_requires).is_not_nil())

--- a/src/cpp/cpp_destructor.cpp
+++ b/src/cpp/cpp_destructor.cpp
@@ -20,9 +20,6 @@ optionalt<codet> cpp_typecheckt::cpp_destructor(
   const source_locationt &source_location,
   const exprt &object)
 {
-  codet new_code;
-  new_code.add_source_location()=source_location;
-
   elaborate_class_template(object.type());
 
   typet tmp_type(follow(object.type()));
@@ -53,9 +50,8 @@ optionalt<codet> cpp_typecheckt::cpp_destructor(
       throw 0;
     }
 
-    new_code.type().id(ID_code);
+    code_blockt new_code;
     new_code.add_source_location()=source_location;
-    new_code.set_statement(ID_block);
 
     // for each element of the array, call the destructor
     for(mp_integer i=0; i < s; ++i)
@@ -70,6 +66,8 @@ optionalt<codet> cpp_typecheckt::cpp_destructor(
       if(i_code.has_value())
         new_code.add_to_operands(std::move(i_code.value()));
     }
+
+    return std::move(new_code);
   }
   else
   {
@@ -115,9 +113,9 @@ optionalt<codet> cpp_typecheckt::cpp_destructor(
     typecheck_side_effect_function_call(function_call);
     already_typechecked(function_call);
 
-    new_code = code_expressiont(function_call);
+    code_expressiont new_code(function_call);
     new_code.add_source_location() = source_location;
-  }
 
-  return new_code;
+    return std::move(new_code);
+  }
 }

--- a/src/cpp/cpp_typecheck.h
+++ b/src/cpp/cpp_typecheck.h
@@ -124,9 +124,7 @@ protected:
 
   void convert_pmop(exprt &expr);
 
-  void convert_anonymous_union(
-    cpp_declarationt &declaration,
-    codet &new_code);
+  codet convert_anonymous_union(cpp_declarationt &declaration);
 
   void convert_anon_struct_union_member(
     const cpp_declarationt &declaration,

--- a/src/cpp/cpp_typecheck_code.cpp
+++ b/src/cpp/cpp_typecheck_code.cpp
@@ -384,7 +384,7 @@ void cpp_typecheckt::typecheck_decl(codet &code)
       throw 0;
     }
 
-    convert_anonymous_union(declaration, code);
+    code = convert_anonymous_union(declaration);
     return;
   }
 

--- a/src/cpp/cpp_typecheck_declaration.cpp
+++ b/src/cpp/cpp_typecheck_declaration.cpp
@@ -31,9 +31,7 @@ void cpp_typecheckt::convert(cpp_declarationt &declaration)
     convert_non_template_declaration(declaration);
 }
 
-void cpp_typecheckt::convert_anonymous_union(
-  cpp_declarationt &declaration,
-  codet &code)
+codet cpp_typecheckt::convert_anonymous_union(cpp_declarationt &declaration)
 {
   codet new_code(ID_decl_block);
   new_code.reserve_operands(declaration.declarators().size());
@@ -93,7 +91,7 @@ void cpp_typecheckt::convert_anonymous_union(
   symbol_table.get_writeable_ref(union_symbol.name)
     .type.set(ID_C_unnamed_object, symbol.base_name);
 
-  code.swap(new_code);
+  return new_code;
 }
 
 void cpp_typecheckt::convert_non_template_declaration(
@@ -135,8 +133,7 @@ void cpp_typecheckt::convert_non_template_declaration(
       throw 0;
     }
 
-    codet dummy;
-    convert_anonymous_union(declaration, dummy);
+    convert_anonymous_union(declaration);
   }
 
   // do the declarators (optional)

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -620,14 +620,13 @@ goto_programt::const_targett goto_program2codet::convert_goto_while(
   if(w.body().has_operands() &&
      to_code(w.body().operands().back()).get_statement()==ID_assign)
   {
-    code_fort f(nil_exprt(), w.cond(), w.body().operands().back(), codet());
-
+    exprt increment = w.body().operands().back();
     w.body().operands().pop_back();
-    f.iter().id(ID_side_effect);
+    increment.id(ID_side_effect);
+
+    code_fort f(nil_exprt(), w.cond(), increment, w.body());
 
     copy_source_location(target, f);
-
-    f.body().swap(w.body());
 
     f.swap(w);
   }
@@ -1523,8 +1522,7 @@ void goto_program2codet::cleanup_code(
 
     if(labels_in_use.find(label)==labels_in_use.end())
     {
-      codet tmp;
-      tmp.swap(cl.code());
+      codet tmp = cl.code();
       code.swap(tmp);
     }
   }
@@ -1624,8 +1622,7 @@ void goto_program2codet::cleanup_code_block(
           parent_stmt!=ID_nil &&
           to_code(code.op0()).get_statement()!=ID_decl)
   {
-    codet tmp;
-    tmp.swap(code.op0());
+    codet tmp = to_code(code.op0());
     code.swap(tmp);
   }
 }
@@ -1717,8 +1714,7 @@ void goto_program2codet::cleanup_code_ifthenelse(
     cond.is_true() &&
     (i_t_e.else_case().is_nil() || !has_labels(i_t_e.else_case())))
   {
-    codet tmp;
-    tmp.swap(i_t_e.then_case());
+    codet tmp = i_t_e.then_case();
     code.swap(tmp);
   }
   else if(cond.is_false() && !has_labels(i_t_e.then_case()))
@@ -1727,8 +1723,7 @@ void goto_program2codet::cleanup_code_ifthenelse(
       code=code_skipt();
     else
     {
-      codet tmp;
-      tmp.swap(i_t_e.else_case());
+      codet tmp = i_t_e.else_case();
       code.swap(tmp);
     }
   }

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -563,7 +563,10 @@ void goto_convertt::convert_block(
     unwind_destructor_stack(end_location, old_stack_size, dest, mode);
 
   // remove those destructors
-  targets.destructor_stack.resize(old_stack_size);
+  PRECONDITION(old_stack_size <= targets.destructor_stack.size());
+  targets.destructor_stack.erase(
+    targets.destructor_stack.begin() + old_stack_size,
+    targets.destructor_stack.end());
 }
 
 void goto_convertt::convert_expression(

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -167,7 +167,6 @@ void goto_convert_functionst::convert_function(
   goto_programt::targett end_function=tmp_end_function.add_instruction();
   end_function->type=END_FUNCTION;
   end_function->source_location=end_location;
-  end_function->code.set(ID_identifier, identifier);
 
   targets=targetst();
   targets.set_return(end_function);

--- a/src/goto-programs/goto_convert_side_effect.cpp
+++ b/src/goto-programs/goto_convert_side_effect.cpp
@@ -453,8 +453,6 @@ void goto_convertt::remove_malloc(
   const irep_idt &mode,
   bool result_is_used)
 {
-  codet call;
-
   if(result_is_used)
   {
     const symbolt &new_symbol = get_fresh_aux_symbol(
@@ -469,17 +467,17 @@ void goto_convertt::remove_malloc(
     decl.add_source_location()=new_symbol.location;
     convert_decl(decl, dest, mode);
 
-    call=code_assignt(new_symbol.symbol_expr(), expr);
+    code_assignt call(new_symbol.symbol_expr(), expr);
     call.add_source_location()=expr.source_location();
 
     static_cast<exprt &>(expr)=new_symbol.symbol_expr();
+
+    convert(call, dest, mode);
   }
   else
   {
-    call = code_expressiont(std::move(expr));
+    convert(code_expressiont(std::move(expr)), dest, mode);
   }
-
-  convert(call, dest, mode);
 }
 
 void goto_convertt::remove_temporary_object(

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -422,13 +422,14 @@ public:
     {
     }
 
-    explicit instructiont(goto_program_instruction_typet _type):
-      source_location(static_cast<const source_locationt &>(get_nil_irep())),
-      type(_type),
-      guard(true_exprt()),
-      location_number(0),
-      loop_number(0),
-      target_number(nil_target)
+    explicit instructiont(goto_program_instruction_typet _type)
+      : code(static_cast<const codet &>(get_nil_irep())),
+        source_location(static_cast<const source_locationt &>(get_nil_irep())),
+        type(_type),
+        guard(true_exprt()),
+        location_number(0),
+        loop_number(0),
+        target_number(nil_target)
     {
     }
 


### PR DESCRIPTION
The default constructor for codet is deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
