### PR TITLE
Avoid default code_switch(_case)t's default constructor [blocks: #3800]

### DIFF
--- a/jbmc/src/java_bytecode/java_entry_point.cpp
+++ b/jbmc/src/java_bytecode/java_entry_point.cpp
@@ -358,7 +358,6 @@ exprt::operandst java_build_arguments(
       INVARIANT(!is_this, "We cannot have different types for `this` here");
       // create a non-deterministic switch between all possible values for the
       // type of the parameter.
-      code_switcht code_switch;
 
       // the idea is to get a new symbol for the parameter value `tmp`
 
@@ -385,8 +384,10 @@ exprt::operandst java_build_arguments(
         symbol_table);
       main_arguments[param_number] = result_symbol.symbol_expr();
 
-      std::vector<codet> cases(alternatives.size());
-      const auto initialize_parameter = [&](const struct_tag_typet &type) {
+      std::vector<codet> cases;
+      cases.reserve(alternatives.size());
+      for(const auto &type : alternatives)
+      {
         code_blockt init_code_for_type;
         exprt init_expr_for_parameter = object_factory(
           java_reference_type(type),
@@ -402,14 +403,8 @@ exprt::operandst java_build_arguments(
           code_assignt(
             result_symbol.symbol_expr(),
             typecast_exprt(init_expr_for_parameter, p.type())));
-        return init_code_for_type;
-      };
-
-      std::transform(
-        alternatives.begin(),
-        alternatives.end(),
-        cases.begin(),
-        initialize_parameter);
+        cases.push_back(init_code_for_type);
+      }
 
       init_code.add(
         generate_nondet_switch(

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -904,9 +904,7 @@ goto_programt::const_targett goto_program2codet::convert_goto_switch(
     return convert_goto_if(target, upper_bound, dest);
 
   // maybe, let's try some more
-  code_switcht s;
-  s.value()=to_equal_expr(eq_cand).lhs();
-  s.body()=code_blockt();
+  code_switcht s(to_equal_expr(eq_cand).lhs(), code_blockt());
 
   copy_source_location(target, s);
 
@@ -972,7 +970,7 @@ goto_programt::const_targett goto_program2codet::convert_goto_switch(
       it!=cases.end();
       ++it)
   {
-    code_switch_caset csc;
+    code_switch_caset csc(nil_exprt{}, code_blockt{});
     // branch condition is nil_exprt for default case;
     if(it->value.is_nil())
       csc.set_default();


### PR DESCRIPTION
Construct them bottom-up, which is more efficient and type safe.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
