### PR TITLE
Avoid default constructing code_ifthenelset [blocks: #3800]

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
@@ -229,7 +229,7 @@ code_ifthenelset java_bytecode_instrumentt::check_class_cast(
   if(null_check_op.type()!=voidptr)
     null_check_op.make_typecast(voidptr);
 
-  codet check_code;
+  optionalt<codet> check_code;
   if(throw_runtime_exceptions)
   {
     check_code=
@@ -251,7 +251,7 @@ code_ifthenelset java_bytecode_instrumentt::check_class_cast(
 
   return code_ifthenelset(
     notequal_exprt(std::move(null_check_op), null_pointer_exprt(voidptr)),
-    std::move(check_code));
+    std::move(*check_code));
 }
 
 /// Checks whether \p expr is null and throws NullPointerException/


### PR DESCRIPTION
The default constructor is deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
