### PR TITLE
Avoid default constructing code_expressiont [blocks: #3800]

### DIFF
--- a/src/cpp/cpp_constructor.cpp
+++ b/src/cpp/cpp_constructor.cpp
@@ -144,9 +144,7 @@ optionalt<codet> cpp_typecheckt::cpp_constructor(
       side_effect_expr_assignt assign(
         object_tc, operands_tc.front(), typet(), source_location);
       typecheck_side_effect_assignment(assign);
-      code_expressiont new_code;
-      new_code.expression()=assign;
-      return std::move(new_code);
+      return code_expressiont(std::move(assign));
     }
     else
     {

--- a/src/cpp/cpp_typecheck_code.cpp
+++ b/src/cpp/cpp_typecheck_code.cpp
@@ -244,8 +244,7 @@ void cpp_typecheckt::typecheck_member_initializer(codet &code)
       }
     }
 
-    code_expressiont code_expression;
-    code_expression.expression()=function_call;
+    code_expressiont code_expression(function_call);
 
     code.swap(code_expression);
   }


### PR DESCRIPTION
The default constructor is deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
