### PR TITLE
Construct side_effect_expr_nondett with a source location [blocks: #3800]

### DIFF
--- a/src/goto-analyzer/taint_analysis.cpp
+++ b/src/goto-analyzer/taint_analysis.cpp
@@ -290,7 +290,8 @@ bool taint_analysist::operator()(
           t->make_function_call(call);
           calls.add_instruction()->make_goto(end.instructions.begin());
           goto_programt::targett g=gotos.add_instruction();
-          g->make_goto(t, side_effect_expr_nondett(bool_typet()));
+          g->make_goto(
+            t, side_effect_expr_nondett(bool_typet(), symbol.location));
         }
 
       goto_functionst::goto_functiont &entry=

--- a/src/util/nondet.cpp
+++ b/src/util/nondet.cpp
@@ -54,8 +54,8 @@ symbol_exprt generate_nondet_int(
 
   // Assign the symbol any non deterministic integer value.
   //   int_type name_prefix::nondet_int = NONDET(int_type)
-  instructions.add(
-    code_assignt(nondet_symbol, side_effect_expr_nondett(int_type)));
+  instructions.add(code_assignt(
+    nondet_symbol, side_effect_expr_nondett(int_type, source_location)));
 
   // Constrain the non deterministic integer with a lower bound of `min_value`.
   //   ASSUME(name_prefix::nondet_int >= min_value)

--- a/unit/analyses/dependence_graph.cpp
+++ b/unit/analyses/dependence_graph.cpp
@@ -72,7 +72,8 @@ SCENARIO("dependence_graph", "[core][analyses][dependence_graph]")
 
     code_ifthenelset if_block(
       equal_exprt(
-        side_effect_expr_nondett(int_type), from_integer(0, int_type)),
+        side_effect_expr_nondett(int_type, source_locationt{}),
+        from_integer(0, int_type)),
       code_blockt({call, assign_x}));
 
     a_body.add(std::move(if_block));


### PR DESCRIPTION
Construction without a source location is deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
