### PR TITLE
Replace use of deprecated nil_typet in acceleration [blocks: #3800]

### DIFF
--- a/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
+++ b/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
@@ -653,19 +653,19 @@ void disjunctive_polynomial_accelerationt::assert_for_values(
   exprt &target)
 {
   // First figure out what the appropriate type for this expression is.
-  typet expr_type=nil_typet();
+  optionalt<typet> expr_type;
 
   for(std::map<exprt, exprt>::iterator it=values.begin();
       it!=values.end();
       ++it)
   {
-    if(expr_type==nil_typet())
+    if(!expr_type.has_value())
     {
       expr_type=it->first.type();
     }
     else
     {
-      expr_type=join_types(expr_type, it->first.type());
+      expr_type = join_types(*expr_type, it->first.type());
     }
   }
 
@@ -690,7 +690,7 @@ void disjunctive_polynomial_accelerationt::assert_for_values(
       it!=coefficients.end();
       ++it)
   {
-    exprt concrete_value=from_integer(1, expr_type);
+    exprt concrete_value = from_integer(1, *expr_type);
 
     for(expr_listt::const_iterator e_it=it->first.begin();
         e_it!=it->first.end();
@@ -701,7 +701,7 @@ void disjunctive_polynomial_accelerationt::assert_for_values(
       if(e==loop_counter)
       {
         mult_exprt mult(
-          from_integer(num_unwindings, expr_type), concrete_value);
+          from_integer(num_unwindings, *expr_type), concrete_value);
         mult.swap(concrete_value);
       }
       else
@@ -718,7 +718,7 @@ void disjunctive_polynomial_accelerationt::assert_for_values(
     // OK, concrete_value now contains the value of all the relevant variables
     // multiplied together.  Create the term concrete_value*coefficient and add
     // it into the polynomial.
-    typecast_exprt cast(it->second, expr_type);
+    typecast_exprt cast(it->second, *expr_type);
     const mult_exprt term(concrete_value, cast);
 
     if(rhs.is_nil())

--- a/src/goto-instrument/accelerate/polynomial.cpp
+++ b/src/goto-instrument/accelerate/polynomial.cpp
@@ -23,7 +23,7 @@ Author: Matt Lewis
 exprt polynomialt::to_expr()
 {
   exprt ret=nil_exprt();
-  typet itype=nil_typet();
+  optionalt<typet> itype;
 
   // Figure out the appropriate type to do all the intermediate calculations
   // in.
@@ -35,13 +35,13 @@ exprt polynomialt::to_expr()
         t_it!=m_it->terms.end();
         ++t_it)
     {
-      if(itype==nil_typet())
+      if(itype.has_value())
       {
         itype=t_it->var.type();
       }
       else
       {
-        itype=join_types(itype, t_it->var.type());
+        itype = join_types(*itype, t_it->var.type());
       }
     }
   }
@@ -59,7 +59,7 @@ exprt polynomialt::to_expr()
       coeff=-coeff;
     }
 
-    exprt mon_expr=from_integer(coeff, itype);
+    exprt mon_expr = from_integer(coeff, *itype);
 
     for(std::vector<monomialt::termt>::iterator t_it=m_it->terms.begin();
         t_it!=m_it->terms.end();
@@ -67,7 +67,7 @@ exprt polynomialt::to_expr()
     {
       for(unsigned int i=0; i < t_it->exp; i++)
       {
-        mon_expr=mult_exprt(mon_expr, typecast_exprt(t_it->var, itype));
+        mon_expr = mult_exprt(mon_expr, typecast_exprt(t_it->var, *itype));
       }
     }
 
@@ -75,7 +75,7 @@ exprt polynomialt::to_expr()
     {
       if(neg)
       {
-        ret=unary_minus_exprt(mon_expr, itype);
+        ret = unary_minus_exprt(mon_expr, *itype);
       }
       else
       {


### PR DESCRIPTION
Use optionalt<typet> as recommended in the deprecation note.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
