### PR TITLE
Replace use of deprecated nil_typet in get_type [blocks: #3800]

### DIFF
--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -260,26 +260,26 @@ void goto_convertt::do_scanf(
 
       for(const auto &t : token_list)
       {
-        typet type=get_type(t);
+        const auto type = get_type(t);
 
-        if(type.is_not_nil())
+        if(type.has_value())
         {
           if(argument_number<arguments.size())
           {
             const typecast_exprt ptr(
-              arguments[argument_number], pointer_type(type));
+              arguments[argument_number], pointer_type(*type));
             argument_number++;
 
-            if(type.id()==ID_array)
+            if(type->id() == ID_array)
             {
               #if 0
               // A string. We first need a nondeterministic size.
               exprt size=side_effect_expr_nondett(size_type());
-              to_array_type(type).size()=size;
+              to_array_type(*type).size()=size;
 
               const symbolt &tmp_symbol=
                 new_tmp_symbol(
-                  type, "scanf_string", dest, function.source_location());
+                  *type, "scanf_string", dest, function.source_location());
 
               const address_of_exprt rhs(
                 index_exprt(
@@ -298,9 +298,9 @@ void goto_convertt::do_scanf(
               copy(array_copy_statement, OTHER, dest);
               #else
               const index_exprt new_lhs(
-                dereference_exprt(ptr, type), from_integer(0, index_type()));
+                dereference_exprt(ptr, *type), from_integer(0, index_type()));
               const side_effect_expr_nondett rhs(
-                type.subtype(), function.source_location());
+                type->subtype(), function.source_location());
               code_assignt assign(new_lhs, rhs);
               assign.add_source_location()=function.source_location();
               copy(assign, ASSIGN, dest);
@@ -309,9 +309,9 @@ void goto_convertt::do_scanf(
             else
             {
               // make it nondet for now
-              const dereference_exprt new_lhs(ptr, type);
+              const dereference_exprt new_lhs(ptr, *type);
               const side_effect_expr_nondett rhs(
-                type, function.source_location());
+                *type, function.source_location());
               code_assignt assign(new_lhs, rhs);
               assign.add_source_location()=function.source_location();
               copy(assign, ASSIGN, dest);

--- a/src/goto-programs/format_strings.cpp
+++ b/src/goto-programs/format_strings.cpp
@@ -226,7 +226,7 @@ format_token_listt parse_format_string(const std::string &arg_string)
   return token_list;
 }
 
-typet get_type(const format_tokent &token)
+optionalt<typet> get_type(const format_tokent &token)
 {
   switch(token.type)
   {
@@ -291,7 +291,7 @@ typet get_type(const format_tokent &token)
     }
 
   default:
-    return nil_typet();
+    return {};
   }
 
   UNREACHABLE;

--- a/src/goto-programs/format_strings.h
+++ b/src/goto-programs/format_strings.h
@@ -88,6 +88,6 @@ typedef std::list<format_tokent> format_token_listt;
 
 format_token_listt parse_format_string(const std::string &);
 
-typet get_type(const format_tokent &);
+optionalt<typet> get_type(const format_tokent &);
 
 #endif // CPROVER_GOTO_PROGRAMS_FORMAT_STRINGS_H


### PR DESCRIPTION
Use optionalt<typet> as recommended in the deprecation note.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
