### PR TITLE
Replace use of deprecated nil_typet in c_bit_field_replacement_type [blocks: #3800]

### DIFF
--- a/src/solvers/flattening/c_bit_field_replacement_type.cpp
+++ b/src/solvers/flattening/c_bit_field_replacement_type.cpp
@@ -6,8 +6,9 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-
 #include "c_bit_field_replacement_type.h"
+
+#include <util/invariant.h>
 
 typet c_bit_field_replacement_type(
   const c_bit_field_typet &src,
@@ -23,21 +24,18 @@ typet c_bit_field_replacement_type(
     result.set_width(src.get_width());
     return std::move(result);
   }
-  else if(subtype.id()==ID_c_enum_tag)
+  else
   {
+    PRECONDITION(subtype.id() == ID_c_enum_tag);
+
     const typet &sub_subtype=
       ns.follow_tag(to_c_enum_tag_type(subtype)).subtype();
 
-    if(sub_subtype.id()==ID_signedbv ||
-       sub_subtype.id()==ID_unsignedbv)
-    {
-      bitvector_typet result=to_bitvector_type(sub_subtype);
-      result.set_width(src.get_width());
-      return std::move(result);
-    }
-    else
-      return nil_typet();
+    PRECONDITION(
+      sub_subtype.id() == ID_signedbv || sub_subtype.id() == ID_unsignedbv);
+
+    bitvector_typet result = to_bitvector_type(sub_subtype);
+    result.set_width(src.get_width());
+    return std::move(result);
   }
-  else
-    return nil_typet();
 }


### PR DESCRIPTION
Use optionalt<typet> as recommended in the deprecation note.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
