### PR TITLE
Replace use of deprecated nil_typet in simplify_mult [blocks: #3800]

### DIFF
--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -175,7 +175,7 @@ bool simplify_exprt::simplify_mult(exprt &expr)
   // true if we have found a constant
   bool constant_found = false;
 
-  typet c_sizeof_type=nil_typet();
+  optionalt<typet> c_sizeof_type;
 
   // scan all the operands
   for(exprt::operandst::iterator it=operands.begin();
@@ -201,9 +201,13 @@ bool simplify_exprt::simplify_mult(exprt &expr)
     if(it->is_constant() && it->type()==expr.type())
     {
       // preserve the sizeof type annotation
-      if(c_sizeof_type.is_nil())
-        c_sizeof_type=
+      if(!c_sizeof_type.has_value())
+      {
+        const typet &sizeof_type =
           static_cast<const typet &>(it->find(ID_C_c_sizeof_type));
+        if(sizeof_type.is_not_nil())
+          c_sizeof_type = sizeof_type;
+      }
 
       if(constant_found)
       {
@@ -229,13 +233,13 @@ bool simplify_exprt::simplify_mult(exprt &expr)
       it++; // move to the next operand
   }
 
-  if(c_sizeof_type.is_not_nil())
+  if(c_sizeof_type.has_value())
   {
     INVARIANT(
       constant_found,
       "c_sizeof_type is only set to a non-nil value "
       "if a constant has been found");
-    constant->set(ID_C_c_sizeof_type, c_sizeof_type);
+    constant->set(ID_C_c_sizeof_type, *c_sizeof_type);
   }
 
   if(operands.size()==1)


### PR DESCRIPTION
Use optionalt<typet> as recommended in the deprecation note.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
