### PR TITLE
smt2 id_map: Do not use nil_typet when we mean "optional" [blocks: #3800]

### DIFF
--- a/regression/smt2_solver/basic-bv1/basic-bv1.smt2
+++ b/regression/smt2_solver/basic-bv1/basic-bv1.smt2
@@ -46,6 +46,9 @@
              (= a #x4) 
              (= a #x8))))
 
+; make sure this still type checks as we have used x with a different type above
+(define-fun d02 () Bool (= (bvand (bvnot x) (bvnot y)) (bvnot (bvor x y))))
+
 ; Predicates over Bitvectors
 
 (define-fun p1 () Bool (= (bvule #x0a #xf0) true))  ; unsigned less or equal

--- a/regression/smt2_solver/basic-bv1/test.desc
+++ b/regression/smt2_solver/basic-bv1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 basic-bv1.smt2
 
 ^EXIT=0$

--- a/regression/smt2_solver/basic-bv1/test.desc
+++ b/regression/smt2_solver/basic-bv1/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 basic-bv1.smt2
 
 ^EXIT=0$

--- a/src/solvers/smt2/smt2_parser.h
+++ b/src/solvers/smt2/smt2_parser.h
@@ -33,7 +33,7 @@ public:
 
   struct idt
   {
-    idt():type(nil_typet())
+    explicit idt(const exprt &expr) : type(expr.type()), definition(expr)
     {
     }
 
@@ -84,7 +84,7 @@ protected:
   renaming_mapt renaming_map;
   using renaming_counterst=std::map<irep_idt, unsigned>;
   renaming_counterst renaming_counters;
-  irep_idt get_fresh_id(const irep_idt &);
+  irep_idt add_fresh_id(const irep_idt &, const exprt &);
   irep_idt rename_id(const irep_idt &) const;
 
   struct signature_with_parameter_idst


### PR DESCRIPTION
Use optionalt<typet> instead. nil_typet is deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
