### PR TITLE
Make ui_message move constructible

### DIFF
--- a/src/util/ui_message.h
+++ b/src/util/ui_message.h
@@ -24,6 +24,7 @@ public:
   ui_message_handlert(const class cmdlinet &, const std::string &program);
 
   explicit ui_message_handlert(message_handlert &);
+  ui_message_handlert(ui_message_handlert &&) = default;
 
   virtual ~ui_message_handlert();
 


### PR DESCRIPTION
There is no particular reason why it shouldn't be

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
