### PR TITLE
Do not misuse symex dereferencing code for finding array objects [blocks: #3725]

### DIFF
--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -229,7 +229,7 @@ protected:
 
   void trigger_auto_object(const exprt &, statet &);
   void initialize_auto_object(const exprt &, statet &);
-  void process_array_expr(exprt &);
+  void process_array_expr(statet &, exprt &, bool);
   exprt make_auto_object(const typet &, statet &);
   virtual void dereference(exprt &, statet &, bool write);
 


### PR DESCRIPTION
The task of process_array_expr is to find the objects pointed to; symex
dereferencing does so as well, but also does many other things. Creating an
artificial dereference_exprt imposes restrictions on what optimisations symex
dereferencing can implement. Instead, just make process_array_expr actually get
the objects (via the value set) and then work on those. This duplicates a bit of
code from symex dereferencing, but now yields full control to process_array_expr
over what it needs to make happen. In future, the process_array_expr code may
even get rewritten without having any dependency on what symex dereferencing
exactly does.

At present, the behaviour before or after the commit is largely unchanged, but modifications such as #3725 show that these changes are actually needed.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
