### PR TITLE
remove USE_MOVE define

### DIFF
--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -19,7 +19,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #define SHARING
 // #define HASH_CODE
-#define USE_MOVE
 // #define NAMED_SUB_IS_FORWARD_LIST
 
 #ifdef NAMED_SUB_IS_FORWARD_LIST
@@ -169,19 +168,13 @@ public:
   bool is_nil() const { return id()==ID_nil; }
   bool is_not_nil() const { return id()!=ID_nil; }
 
-#if !defined(USE_MOVE) || !defined(SHARING)
+#if !defined(SHARING)
   explicit irept(const irep_idt &_id)
-#ifdef SHARING
-    :data(&empty_d)
-#endif
   {
     id(_id);
   }
 
   irept(const irep_idt &_id, const named_subt &_named_sub, const subt &_sub)
-#ifdef SHARING
-    : data(&empty_d)
-#endif
   {
     id(_id);
     get_named_sub() = _named_sub;
@@ -218,7 +211,6 @@ public:
     }
   }
 
-  #ifdef USE_MOVE
   // Copy from rvalue reference.
   // Note that this does avoid a branch compared to the
   // standard copy constructor above.
@@ -229,7 +221,6 @@ public:
     #endif
     irep.data=&empty_d;
   }
-  #endif
 
   irept &operator=(const irept &irep)
   {
@@ -249,7 +240,6 @@ public:
     return *this;
   }
 
-  #ifdef USE_MOVE
   // Note that the move assignment operator does avoid
   // three branches compared to standard operator above.
   irept &operator=(irept &&irep)
@@ -261,7 +251,6 @@ public:
     std::swap(data, irep.data);
     return *this;
   }
-  #endif
 
   ~irept()
   {
@@ -393,7 +382,6 @@ public:
 
     dt() = default;
 
-#ifdef USE_MOVE
     explicit dt(irep_idt _data) : data(std::move(_data))
     {
     }
@@ -404,7 +392,6 @@ public:
         sub(std::move(_sub))
     {
     }
-#endif
   };
 
 protected:


### PR DESCRIPTION
We no longer consider compilation with C++98.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
