### PR TITLE
added instructiont::get_other()

### DIFF
--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -785,9 +785,10 @@ void constant_propagator_ait::replace(
     }
     else if(it->is_other())
     {
-      if(it->code.get_statement()==ID_expression)
+      if(it->get_other().get_statement() == ID_expression)
       {
-        constant_propagator_domaint::partial_evaluate(d.values, it->code, ns);
+        constant_propagator_domaint::partial_evaluate(
+          d.values, it->get_other(), ns);
       }
     }
   }

--- a/src/analyses/custom_bitvector_analysis.cpp
+++ b/src/analyses/custom_bitvector_analysis.cpp
@@ -447,17 +447,18 @@ void custom_bitvector_domaint::transform(
 
   case OTHER:
     {
-      const irep_idt &statement=instruction.code.get_statement();
+      const auto &code = instruction.get_other();
+      const irep_idt &statement = code.get_statement();
 
       if(statement=="set_may" ||
          statement=="set_must" ||
          statement=="clear_may" ||
          statement=="clear_must")
       {
-        assert(instruction.code.operands().size()==2);
+        DATA_INVARIANT(
+          code.operands().size() == 2, "set/clear_may/must has two operands");
 
-        unsigned bit_nr=
-          cba.get_bit_nr(instruction.code.op1());
+        unsigned bit_nr = cba.get_bit_nr(code.op1());
 
         // initialize to make Visual Studio happy
         modet mode = modet::SET_MUST;
@@ -473,7 +474,7 @@ void custom_bitvector_domaint::transform(
         else
           UNREACHABLE;
 
-        exprt lhs=instruction.code.op0();
+        exprt lhs = code.op0();
 
         if(lhs.type().id()==ID_pointer)
         {

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1704,15 +1704,16 @@ void goto_checkt::goto_check(
 
     if(i.is_other())
     {
-      const irep_idt &statement=i.code.get(ID_statement);
+      const auto &code = i.get_other();
+      const irep_idt &statement = code.get_statement();
 
       if(statement==ID_expression)
       {
-        check(i.code);
+        check(code);
       }
       else if(statement==ID_printf)
       {
-        for(const auto &op : i.code.operands())
+        for(const auto &op : code.operands())
           check(op);
       }
     }

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -781,11 +781,11 @@ void goto_rw(
 
   case OTHER:
     // if it's printf, mark the operands as read here
-    if(target->code.get(ID_statement)==ID_printf)
+    if(target->get_other().get_statement() == ID_printf)
     {
-      forall_expr(it, target->code.operands())
+      for(const auto &op : target->get_other().operands())
         rw_set.get_objects_rec(
-          function, target, rw_range_sett::get_modet::READ, *it);
+          function, target, rw_range_sett::get_modet::READ, op);
     }
     break;
 

--- a/src/analyses/invariant_set_domain.cpp
+++ b/src/analyses/invariant_set_domain.cpp
@@ -61,7 +61,7 @@ void invariant_set_domaint::transform(
     break;
 
   case OTHER:
-    if(from_l->code.is_not_nil())
+    if(from_l->get_other().is_not_nil())
       invariant_set.apply_code(from_l->code);
     break;
 

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -250,6 +250,20 @@ public:
       return to_code_function_call(code);
     }
 
+    /// Get the statement for OTHER
+    const codet &get_other() const
+    {
+      PRECONDITION(is_other());
+      return code;
+    }
+
+    /// Get the statement for OTHER
+    codet &get_other()
+    {
+      PRECONDITION(is_other());
+      return code;
+    }
+
     /// The function this instruction belongs to
     irep_idt function;
 

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -383,7 +383,7 @@ void interpretert::execute_goto()
 /// executes side effects of 'other' instructions
 void interpretert::execute_other()
 {
-  const irep_idt &statement=pc->code.get_statement();
+  const irep_idt &statement = pc->get_other().get_statement();
   if(statement==ID_expression)
   {
     DATA_INVARIANT(

--- a/src/goto-programs/remove_asm.cpp
+++ b/src/goto-programs/remove_asm.cpp
@@ -488,7 +488,7 @@ void remove_asmt::process_function(
 
   Forall_goto_program_instructions(it, goto_function.body)
   {
-    if(it->is_other() && it->code.get_statement()==ID_asm)
+    if(it->is_other() && it->get_other().get_statement() == ID_asm)
     {
       goto_programt tmp_dest;
       process_instruction(*it, tmp_dest);

--- a/src/goto-programs/remove_skip.cpp
+++ b/src/goto-programs/remove_skip.cpp
@@ -52,10 +52,10 @@ bool is_skip(
 
   if(it->is_other())
   {
-    if(it->code.is_nil())
+    if(it->get_other().is_nil())
       return true;
 
-    const irep_idt &statement=it->code.get_statement();
+    const irep_idt &statement = it->get_other().get_statement();
 
     if(statement==ID_skip)
       return true;

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -337,7 +337,7 @@ void goto_program_dereferencet::dereference_instruction(
   }
   else if(i.is_other())
   {
-    const irep_idt &statement=i.code.get(ID_statement);
+    const irep_idt &statement = i.get_other().get_statement();
 
     if(statement==ID_expression)
     {
@@ -349,9 +349,8 @@ void goto_program_dereferencet::dereference_instruction(
     }
     else if(statement==ID_printf)
     {
-      Forall_operands(it, i.code)
-        dereference_expr(
-          *it, checks_only, value_set_dereferencet::modet::READ);
+      for(auto &op : i.get_other().operands())
+        dereference_expr(op, checks_only, value_set_dereferencet::modet::READ);
     }
   }
 }


### PR DESCRIPTION
This will eventually enable us to prevent direct access to
instructiont::code.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
