### PR TITLE
Maintain nondet and dynamic counters across symex instances [blocks: #3976]

### DIFF
--- a/regression/cbmc/Bitfields3/paths.desc
+++ b/regression/cbmc/Bitfields3/paths.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--pointer-check --bounds-check --paths lifo
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/scripts/delete_failing_smt2_solver_tests
+++ b/scripts/delete_failing_smt2_solver_tests
@@ -4,6 +4,7 @@ cd regression/cbmc
 rm Anonymous_Struct3/test.desc
 rm Array_operations1/test.desc
 rm Bitfields3/test.desc
+rm Bitfields3/paths.desc
 rm Empty_struct1/test.desc
 rm Endianness4/test.desc
 rm Endianness6/test.desc

--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -20,10 +20,3 @@ void goto_symext::do_simplify(exprt &expr)
   if(symex_config.simplify_opt)
     simplify(expr, ns);
 }
-
-nondet_symbol_exprt symex_nondet_generatort::operator()(typet &type)
-{
-  irep_idt identifier = "symex::nondet" + std::to_string(nondet_count++);
-  nondet_symbol_exprt new_expr(identifier, type);
-  return new_expr;
-}

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -38,16 +38,6 @@ class namespacet;
 class side_effect_exprt;
 class typecast_exprt;
 
-/// Functor generating fresh nondet symbols
-class symex_nondet_generatort
-{
-public:
-  nondet_symbol_exprt operator()(typet &type);
-
-private:
-  unsigned nondet_count = 0;
-};
-
 /// Configuration of the symbolic execution
 struct symex_configt final
 {
@@ -418,7 +408,6 @@ protected:
   virtual void symex_input(statet &, const codet &);
   virtual void symex_output(statet &, const codet &);
 
-  symex_nondet_generatort build_symex_nondet;
   static unsigned dynamic_counter;
 
   void rewrite_quantifiers(exprt &, statet &);

--- a/src/goto-symex/path_storage.cpp
+++ b/src/goto-symex/path_storage.cpp
@@ -13,6 +13,12 @@ Author: Kareem Khazem <karkhaz@karkhaz.com>
 #include <util/exit_codes.h>
 #include <util/make_unique.h>
 
+nondet_symbol_exprt symex_nondet_generatort::operator()(const typet &type)
+{
+  irep_idt identifier = "symex::nondet" + std::to_string(nondet_count++);
+  return nondet_symbol_exprt(identifier, type);
+}
+
 // _____________________________________________________________________________
 // path_lifot
 

--- a/src/goto-symex/path_storage.h
+++ b/src/goto-symex/path_storage.h
@@ -15,6 +15,16 @@
 
 #include <memory>
 
+/// Functor generating fresh nondet symbols
+class symex_nondet_generatort
+{
+public:
+  nondet_symbol_exprt operator()(const typet &type);
+
+private:
+  std::size_t nondet_count = 0;
+};
+
 /// \brief Storage for symbolic execution paths to be resumed later
 ///
 /// This data structure supports saving partially-executed symbolic
@@ -84,6 +94,9 @@ public:
   {
     return size() == 0;
   };
+
+  /// Counter for nondet objects, which require unique names
+  symex_nondet_generatort build_symex_nondet;
 
 private:
   // Derived classes should override these methods, allowing the base class to

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -178,7 +178,7 @@ void goto_symext::symex_allocate(
   }
   else
   {
-    const exprt nondet = build_symex_nondet(*object_type);
+    const exprt nondet = path_storage.build_symex_nondet(*object_type);
     const code_assignt assignment(value_symbol.symbol_expr(), nondet);
     symex_assign(state, assignment);
   }

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -181,7 +181,7 @@ void goto_symext::clean_expr(
   statet &state,
   const bool write)
 {
-  replace_nondet(expr, build_symex_nondet);
+  replace_nondet(expr, path_storage.build_symex_nondet);
   dereference(expr, state, write);
 
   // make sure all remaining byte extract operations use the root


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
