### PR TITLE
Make tests pass with single-path symbolic execution [depends-on: #3969, blocks: #3976]

### DIFF
--- a/regression/cbmc/gcc_switch_case_range1/test.desc
+++ b/regression/cbmc/gcc_switch_case_range1/test.desc
@@ -4,6 +4,9 @@ main.c
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
-^\*\* 4 of 4 failed
+^\[main.assertion.1\] line 12 0 works: FAILURE$
+^\[main.assertion.2\] line 19 \.\.\. works: FAILURE$
+^\[main.assertion.3\] line 22 13 works: FAILURE$
+^\[main.assertion.4\] line 25 default works: FAILURE$
 --
 ^warning: ignoring

--- a/regression/cbmc/gcc_switch_case_range2/test.desc
+++ b/regression/cbmc/gcc_switch_case_range2/test.desc
@@ -4,6 +4,8 @@ main.c
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
-^\*\* 3 of 3 failed
+^\[main.assertion.1\] line 15 0 works: FAILURE$
+^\[main.assertion.2\] line 24 \.\.\. works: FAILURE$
+^\[main.assertion.3\] line 27 default works: FAILURE$
 --
 ^warning: ignoring

--- a/regression/cbmc/havoc_object1/test.desc
+++ b/regression/cbmc/havoc_object1/test.desc
@@ -4,5 +4,12 @@ main.c
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
-^\*\* 6 of 8 failed.*$
+^\[main.assertion.1\] line 5 i==0: FAILURE$
+^\[main.assertion.2\] line 11 array\[3\]: FAILURE$
+^\[main.assertion.3\] line 15 struct i: FAILURE$
+^\[main.assertion.4\] line 16 struct j: FAILURE$
+^\[main.assertion.5\] line 26 i==20 \(A\): FAILURE$
+^\[main.assertion.6\] line 27 some_struct.i==30 \(A\): SUCCESS$
+^\[main.assertion.7\] line 31 i==20 \(B\): SUCCESS$
+^\[main.assertion.8\] line 32 some_struct\.i==30 \(B\): FAILURE$
 --


### PR DESCRIPTION
Each run of symbolic execution reports the number of properties that failed *in
this run*, and it isn't always possible to violate multiple properties along a
single path. All paths together, however, show the same property violations as
path-merging symbolic execution.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
