### PR TITLE
enable .clang-format-ignore [blocks: #3964]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ jobs:
       install:
       script: |
         clang-format-7 --version
-        git-clang-format-7 --binary clang-format-7 "${TRAVIS_BRANCH}"
+        # build a pathspec that excludes the files in .clang-format-ignore
+        while read file ; do echo EXCLUDES+="':(top,exclude)$file' " ; done < .clang-format-ignore
+        git-clang-format-7 --binary clang-format-7 "${TRAVIS_BRANCH}" -- $EXCLUDES
         git diff > formatted.diff
         if [[ -s formatted.diff ]] ; then
           echo 'Formatting error! The following diff shows the required changes'


### PR DESCRIPTION
We do have files that are imported as a whole, and clang-formatting them is
a distraction.  The requirement to add // clang-format-off to external files
makes imports via scripts more difficult.

This tweaks the build script to exclude files given in .clang-format-ignore
from git-clang-format.  The same naming convention is used by other
projects.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
