### PR TITLE
Reinstate limited symex renaming [blocks: #4164]

### DIFF
--- a/regression/cbmc/vla1/main.c
+++ b/regression/cbmc/vla1/main.c
@@ -1,0 +1,30 @@
+#include <assert.h>
+
+int main(int argc, char *argv[])
+{
+  unsigned char x = argc;
+  // make sure int multiplication below won't overflow - type casting to
+  // unsigned long long would be possible, but puts yields a challenging problem
+  // for the SAT solver
+  __CPROVER_assume(x < 1ULL << (sizeof(int) * 8 / 2 - 1));
+
+  struct S
+  {
+    int a;
+    int b[x];
+    int c;
+  };
+
+  if(x % 2 == 0)
+    x = 3;
+
+  struct S s[x];
+
+  __CPROVER_assume(x < 255);
+  ++x;
+
+  assert(sizeof(struct S) == ((unsigned char)argc + 2) * sizeof(int));
+  assert(sizeof(s) == (x - 1) * ((unsigned char)argc + 2) * sizeof(int));
+
+  return 0;
+}

--- a/regression/cbmc/vla1/program-only.desc
+++ b/regression/cbmc/vla1/program-only.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--program-only
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+\(__CPROVER_size_t\)x\$array_size
+--
+There should not be any type cast of x$array_size to __CPROVER_size_t, because
+it already is of that type.

--- a/regression/cbmc/vla1/test.desc
+++ b/regression/cbmc/vla1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -615,26 +615,27 @@ void c_typecheck_baset::typecheck_array_type(array_typet &type)
       }
 
       // Need to pull out! We insert new symbol.
-      unsigned count = 0;
+      unsigned count=0;
       irep_idt temp_identifier;
       std::string suffix;
 
       do
       {
-        suffix = "$array_size" + std::to_string(count);
-        temp_identifier = id2string(current_symbol.name) + suffix;
+        suffix="$array_size"+std::to_string(count);
+        temp_identifier=id2string(current_symbol.name)+suffix;
         count++;
-      } while(symbol_table.symbols.find(temp_identifier) !=
-              symbol_table.symbols.end());
+      }
+      while(symbol_table.symbols.find(temp_identifier)!=
+            symbol_table.symbols.end());
 
       // add the symbol to symbol table
       auxiliary_symbolt new_symbol;
-      new_symbol.name = temp_identifier;
-      new_symbol.pretty_name = id2string(current_symbol.pretty_name) + suffix;
-      new_symbol.base_name = id2string(current_symbol.base_name) + suffix;
-      new_symbol.type = size.type();
+      new_symbol.name=temp_identifier;
+      new_symbol.pretty_name=id2string(current_symbol.pretty_name)+suffix;
+      new_symbol.base_name=id2string(current_symbol.base_name)+suffix;
+      new_symbol.type=size.type();
       new_symbol.type.set(ID_C_constant, true);
-      new_symbol.value = size;
+      new_symbol.value=size;
       new_symbol.location = size_source_location;
       new_symbol.mode = mode;
 
@@ -648,7 +649,7 @@ void c_typecheck_baset::typecheck_array_type(array_typet &type)
 
       code_assignt assignment;
       assignment.lhs()=symbol_expr;
-      assignment.rhs() = size;
+      assignment.rhs()=size;
       assignment.add_source_location() = size_source_location;
 
       // store the code

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/config.h>
+#include <util/fresh_symbol.h>
 #include <util/mathematical_types.h>
 #include <util/pointer_offset_size.h>
 #include <util/simplify_expr.h>
@@ -614,42 +615,25 @@ void c_typecheck_baset::typecheck_array_type(array_typet &type)
         throw 0;
       }
 
-      // Need to pull out! We insert new symbol.
-      unsigned count=0;
-      irep_idt temp_identifier;
-      std::string suffix;
-
-      do
-      {
-        suffix="$array_size"+std::to_string(count);
-        temp_identifier=id2string(current_symbol.name)+suffix;
-        count++;
-      }
-      while(symbol_table.symbols.find(temp_identifier)!=
-            symbol_table.symbols.end());
-
-      // add the symbol to symbol table
-      auxiliary_symbolt new_symbol;
-      new_symbol.name=temp_identifier;
-      new_symbol.pretty_name=id2string(current_symbol.pretty_name)+suffix;
-      new_symbol.base_name=id2string(current_symbol.base_name)+suffix;
-      new_symbol.type=size.type();
+      symbolt &new_symbol = get_fresh_aux_symbol(
+        size_type(),
+        id2string(current_symbol.name) + "$array_size",
+        id2string(current_symbol.base_name) + "$array_size",
+        size_source_location,
+        mode,
+        symbol_table);
       new_symbol.type.set(ID_C_constant, true);
-      new_symbol.value=size;
-      new_symbol.location = size_source_location;
-      new_symbol.mode = mode;
-
-      symbol_table.add(new_symbol);
+      new_symbol.value = typecast_exprt::conditional_cast(size, size_type());
 
       // produce the code that declares and initializes the symbol
-      symbol_exprt symbol_expr(temp_identifier, new_symbol.type);
+      symbol_exprt symbol_expr = new_symbol.symbol_expr();
 
       code_declt declaration(symbol_expr);
       declaration.add_source_location() = size_source_location;
 
       code_assignt assignment;
       assignment.lhs()=symbol_expr;
-      assignment.rhs()=size;
+      assignment.rhs() = new_symbol.value;
       assignment.add_source_location() = size_source_location;
 
       // store the code

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -611,6 +611,9 @@ void goto_symex_statet::rename_address(
   }
 }
 
+/// Return true if, and only if, the \p type or one of its subtypes requires SSA
+/// renaming. Renaming is necessary when symbol expressions occur within the
+/// type, which is the case for arrays of non-constant size.
 static bool requires_renaming(const typet &type, const namespacet &ns)
 {
   if(type.id() == ID_array)
@@ -628,8 +631,12 @@ static bool requires_renaming(const typet &type, const namespacet &ns)
     for(auto &component : components)
     {
       // be careful, or it might get cyclic
-      if(component.type().id() != ID_pointer)
-        return requires_renaming(component.type(), ns);
+      if(
+        component.type().id() != ID_pointer &&
+        requires_renaming(component.type(), ns))
+      {
+        return true;
+      }
     }
 
     return false;

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -611,12 +611,63 @@ void goto_symex_statet::rename_address(
   }
 }
 
+static bool requires_renaming(const typet &type, const namespacet &ns)
+{
+  if(type.id() == ID_array)
+  {
+    const auto &array_type = to_array_type(type);
+    return requires_renaming(array_type.subtype(), ns) ||
+           !array_type.size().is_constant();
+  }
+  else if(
+    type.id() == ID_struct || type.id() == ID_union || type.id() == ID_class)
+  {
+    const struct_union_typet &s_u_type = to_struct_union_type(type);
+    const struct_union_typet::componentst &components = s_u_type.components();
+
+    for(auto &component : components)
+    {
+      // be careful, or it might get cyclic
+      if(component.type().id() != ID_pointer)
+        return requires_renaming(component.type(), ns);
+    }
+
+    return false;
+  }
+  else if(type.id() == ID_pointer)
+  {
+    return requires_renaming(to_pointer_type(type).subtype(), ns);
+  }
+  else if(type.id() == ID_symbol_type)
+  {
+    const symbolt &symbol = ns.lookup(to_symbol_type(type));
+    return requires_renaming(symbol.type, ns);
+  }
+  else if(type.id() == ID_union_tag)
+  {
+    const symbolt &symbol = ns.lookup(to_union_tag_type(type));
+    return requires_renaming(symbol.type, ns);
+  }
+  else if(type.id() == ID_struct_tag)
+  {
+    const symbolt &symbol = ns.lookup(to_struct_tag_type(type));
+    return requires_renaming(symbol.type, ns);
+  }
+
+  return false;
+}
+
 void goto_symex_statet::rename(
   typet &type,
   const irep_idt &l1_identifier,
   const namespacet &ns,
   levelt level)
 {
+  // check whether there are symbol expressions in the type; if not, there
+  // is no need to expand the struct/union tags in the type
+  if(!requires_renaming(type, ns))
+    return; // no action
+
   // rename all the symbols with their last known value
   // to the given level
 


### PR DESCRIPTION
This is a clean revert of #3947, which in turn was a revert of the symex renaming improvements for TG's benefit. All changes in this PR have previously been approved, it is now up to TG maintainers to confirm that any issues have been fixed.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself. Marking do-not-merge.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
