### PR TITLE
avoid direct access to exprt::opX()

### DIFF
--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -81,7 +81,8 @@ void c_typecheck_baset::add_rounding_mode(exprt &expr)
       else
         UNREACHABLE;
 
-      expr.op2()=from_integer(0, unsigned_int_type());
+      to_ieee_float_op_expr(expr).rounding_mode() =
+        from_integer(0, unsigned_int_type());
     }
   }
 }

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -782,14 +782,11 @@ std::string expr2ct::convert_typecast(
 }
 
 std::string expr2ct::convert_trinary(
-  const exprt &src,
+  const ternary_exprt &src,
   const std::string &symbol1,
   const std::string &symbol2,
   unsigned precedence)
 {
-  if(src.operands().size()!=3)
-    return convert_norep(src, precedence);
-
   const exprt &op0=src.op0();
   const exprt &op1=src.op1();
   const exprt &op2=src.op2();
@@ -3346,18 +3343,14 @@ std::string expr2ct::convert_extractbit(
   return dest;
 }
 
-std::string expr2ct::convert_extractbits(
-  const exprt &src,
-  unsigned precedence)
+std::string
+expr2ct::convert_extractbits(const extractbits_exprt &src, unsigned precedence)
 {
-  if(src.operands().size()!=3)
-    return convert_norep(src, precedence);
-
-  std::string dest=convert_with_precedence(src.op0(), precedence);
+  std::string dest = convert_with_precedence(src.src(), precedence);
   dest+='[';
-  dest+=convert_with_precedence(src.op1(), precedence);
+  dest += convert_with_precedence(src.upper(), precedence);
   dest+=", ";
-  dest+=convert_with_precedence(src.op2(), precedence);
+  dest += convert_with_precedence(src.lower(), precedence);
   dest+=']';
 
   return dest;
@@ -3758,7 +3751,7 @@ std::string expr2ct::convert_with_precedence(
     return convert_binary(src, "==>", precedence=3, true);
 
   else if(src.id()==ID_if)
-    return convert_trinary(src, "?", ":", precedence=3);
+    return convert_trinary(to_if_expr(src), "?", ":", precedence = 3);
 
   else if(src.id()==ID_forall)
     return convert_quantifier(src, "forall", precedence=2);
@@ -3864,7 +3857,7 @@ std::string expr2ct::convert_with_precedence(
     return convert_extractbit(src, precedence);
 
   else if(src.id()==ID_extractbits)
-    return convert_extractbits(src, precedence);
+    return convert_extractbits(to_extractbits_expr(src), precedence);
 
   else if(src.id()==ID_initializer_list ||
           src.id()==ID_compound_literal)

--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -118,8 +118,10 @@ protected:
   std::string convert_array_of(const exprt &src, unsigned precedence);
 
   std::string convert_trinary(
-    const exprt &src, const std::string &symbol1,
-    const std::string &symbol2, unsigned precedence);
+    const ternary_exprt &src,
+    const std::string &symbol1,
+    const std::string &symbol2,
+    unsigned precedence);
 
   std::string convert_overflow(
     const exprt &src, unsigned &precedence);
@@ -155,9 +157,8 @@ protected:
     const exprt &src,
     unsigned precedence);
 
-  std::string convert_extractbits(
-    const exprt &src,
-    unsigned precedence);
+  std::string
+  convert_extractbits(const extractbits_exprt &src, unsigned precedence);
 
   std::string convert_unary(
     const exprt &src, const std::string &symbol,

--- a/src/util/simplify_expr_floatbv.cpp
+++ b/src/util/simplify_expr_floatbv.cpp
@@ -293,9 +293,9 @@ bool simplify_exprt::simplify_floatbv_op(exprt &expr)
     "binary operations have two operands, here an addtional parameter "
     "is for the rounding mode");
 
-  exprt op0=expr.op0();
-  exprt op1=expr.op1();
-  exprt op2=expr.op2(); // rounding mode
+  exprt op0 = to_ieee_float_op_expr(expr).lhs();
+  exprt op1 = to_ieee_float_op_expr(expr).rhs();
+  exprt op2 = to_ieee_float_op_expr(expr).rounding_mode(); // rounding mode
 
   INVARIANT(
     op0.type() == type,

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -142,26 +142,28 @@ bool simplify_exprt::simplify_address_of_arg(exprt &expr)
     if(expr.operands().size()==3)
     {
       bool result=true;
-      if(!simplify_rec(expr.op0()))
+      auto &if_expr = to_if_expr(expr);
+
+      if(!simplify_rec(if_expr.cond()))
         result=false;
-      if(!simplify_address_of_arg(expr.op1()))
+      if(!simplify_address_of_arg(if_expr.true_case()))
         result=false;
-      if(!simplify_address_of_arg(expr.op2()))
+      if(!simplify_address_of_arg(if_expr.false_case()))
         result=false;
 
-      // op0 is a constant?
-      if(expr.op0().is_true())
+      // condition is a constant?
+      if(if_expr.cond().is_true())
       {
         result=false;
         exprt tmp;
-        tmp.swap(expr.op1());
+        tmp.swap(if_expr.true_case());
         expr.swap(tmp);
       }
-      else if(expr.op0().is_false())
+      else if(if_expr.cond().is_false())
       {
         result=false;
         exprt tmp;
-        tmp.swap(expr.op2());
+        tmp.swap(if_expr.false_case());
         expr.swap(tmp);
       }
 


### PR DESCRIPTION
This will enable us eventually to protect exprt::opX().

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
