### PR TITLE
Make format_expr handle division and xor

### DIFF
--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -226,12 +226,18 @@ std::ostream &format_rec(std::ostream &os, const exprt &expr)
 {
   const auto &id = expr.id();
 
-  if(id == ID_plus || id == ID_mult || id == ID_and || id == ID_or)
+  if(
+    id == ID_plus || id == ID_mult || id == ID_and || id == ID_or ||
+    id == ID_xor)
+  {
     return format_rec(os, to_multi_ary_expr(expr));
+  }
   else if(
-    id == ID_lt || id == ID_gt || id == ID_ge || id == ID_le ||
+    id == ID_lt || id == ID_gt || id == ID_ge || id == ID_le || id == ID_div ||
     id == ID_minus || id == ID_implies || id == ID_equal || id == ID_notequal)
+  {
     return format_rec(os, to_binary_expr(expr));
+  }
   else if(id == ID_not || id == ID_unary_minus)
     return format_rec(os, to_unary_expr(expr));
   else if(id == ID_constant)


### PR DESCRIPTION
We previously printed ID_div and ID_xor as prefixes to the operands.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
