### PR TITLE
Simplify byte_extract(constant, o, t) when sizeof(t) < sizeof(constant)

### DIFF
--- a/regression/cbmc-library/memmove-01/constant.c
+++ b/regression/cbmc-library/memmove-01/constant.c
@@ -30,7 +30,7 @@ void sort_items_by_criteria(int *item, int left, int right)
 
 int main(int argc, char *argv[])
 {
-  int a[7];
+  int a[7] = {0};
 
   // CBMC in some past version reported wrong results for 256, -2147221455,
   // -2147221455, -2147221455, 16, -2147483600, 16384

--- a/regression/cbmc-library/memmove-01/constant.desc
+++ b/regression/cbmc-library/memmove-01/constant.desc
@@ -1,0 +1,9 @@
+CORE
+constant.c
+--unwind 17
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+^Generated \d+ VCC\(s\), 0 remaining after simplification$
+--
+^warning: ignoring


### PR DESCRIPTION
We previously restricted this case to sizeof(t) == sizeof(constant) to discard
some cases of flexible arrays. It wasn't actually a sound way of detecting that
case, and also disallowed many cases where we can safely simplify. Instead, look
at the type and detect (possible) flexible array members.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
