### PR TITLE
Additional goto-symex documentation

### DIFF
--- a/src/analyses/dirty.h
+++ b/src/analyses/dirty.h
@@ -20,6 +20,9 @@ Date: March 2013
 #include <util/invariant.h>
 #include <goto-programs/goto_functions.h>
 
+/// Dirty variables are ones which have their address taken so we can't
+/// reliably work out where they may be assigned and are also considered shared
+/// state in the presence of multi-threading.
 class dirtyt
 {
 private:

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -473,6 +473,11 @@ public:
   }
 };
 
+/// Transition to the next instruction, which increments the internal program
+/// counter and initializes the loop counter when it detects a loop (or
+/// recursion) being entered. 'Next instruction' in this situation refers
+/// to the next one in program order, so it ignores things like unconditional
+/// GOTOs, and only goes until the end of the current function.
 void symex_transition(goto_symext::statet &state);
 
 void symex_transition(

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -659,6 +659,9 @@ void symex_target_equationt::convert_io(
     }
 }
 
+/// Merging causes identical ireps to be shared.
+/// This is only enabled if the definition SHARING is defined.
+/// \param SSA_step The step you want to have shared values.
 void symex_target_equationt::merge_ireps(SSA_stept &SSA_step)
 {
   merge_irep(SSA_step.guard);


### PR DESCRIPTION
Added some comments around areas in symex where it wasn't immediately obvious from a relative newcomer to the code about what precisely they did and why it was important (I was the newcomer in this situation). The field rename touches quite a bit of code, but there's nothing in there beside the rename and required clang-format changes.

Feel free to mention if there's another important area that I should try and document, as I mostly focused on areas that would've been useful to me when I originally started looking around.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.