### PR TITLE
C library/strdup: use calloc for an array that will be overwritten

### DIFF
--- a/regression/cbmc-library/String6/strdup-calloc.desc
+++ b/regression/cbmc-library/String6/strdup-calloc.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--pointer-check --bounds-check --program-only
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+dynamic_object#\d+ WITH

--- a/src/ansi-c/library/string.c
+++ b/src/ansi-c/library/string.c
@@ -571,7 +571,7 @@ inline char *strdup(const char *str)
   __CPROVER_HIDE:;
   __CPROVER_size_t bufsz;
   bufsz=(strlen(str)+1);
-  char *cpy=(char *)malloc(bufsz*sizeof(char));
+  char *cpy = (char *)calloc(bufsz * sizeof(char), sizeof(char));
   if(cpy==((void *)0)) return 0;
   #ifdef __CPROVER_STRING_ABSTRACTION
   __CPROVER_assume(__CPROVER_buffer_size(cpy)==bufsz);


### PR DESCRIPTION
calloc will zero-initialize the array, making it amenable to constant
propagation. If subsequent updates via strcpy write constants, we can keep
constant-propagating the array.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
