### PR TITLE
Add an output stream to goto-harness for parse_options_baset

### DIFF
--- a/src/goto-harness/goto_harness_parse_options.cpp
+++ b/src/goto-harness/goto_harness_parse_options.cpp
@@ -46,6 +46,7 @@ void goto_harness_parse_optionst::help()
 goto_harness_parse_optionst::goto_harness_parse_optionst(
   int argc,
   const char *argv[])
-  : parse_options_baset{GOTO_HARNESS_OPTIONS, argc, argv}
+  : parse_options_baset{GOTO_HARNESS_OPTIONS, argc, argv, ui_message_handler},
+    ui_message_handler(cmdline, std::string("GOTO-HARNESS ") + CBMC_VERSION)
 {
 }

--- a/src/goto-harness/goto_harness_parse_options.h
+++ b/src/goto-harness/goto_harness_parse_options.h
@@ -10,6 +10,7 @@ Author: Diffblue Ltd.
 #define CPROVER_GOTO_HARNESS_GOTO_HARNESS_PARSE_OPTIONS_H
 
 #include <util/parse_options.h>
+#include <util/ui_message.h>
 
 #define GOTO_HARNESS_OPTIONS "(version)" // end GOTO_HARNESS_OPTIONS
 
@@ -20,6 +21,14 @@ public:
   void help() override;
 
   goto_harness_parse_optionst(int argc, const char *argv[]);
+
+protected:
+  ui_message_handlert ui_message_handler;
+
+  ui_message_handlert::uit get_ui()
+  {
+    return ui_message_handler.get_ui();
+  }
 };
 
 #endif // CPROVER_GOTO_HARNESS_GOTO_HARNESS_PARSE_OPTIONS_H


### PR DESCRIPTION
Should fix the broken build on origin/develop.  What happened was:

1. #3952 cleanly CIs.
2. #3875 gets merged which would break #3952 but the CI is not re-run.
3. #3952 merged and thus the build is broken.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
