### PR TITLE
Make return type of set_l*_indices be a renamedt [blocks: #4333]

### DIFF
--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -235,13 +235,10 @@ void goto_symex_statet::assignment(
   #endif
 }
 
-void goto_symex_statet::set_l0_indices(
-  ssa_exprt &ssa_expr,
-  const namespacet &ns)
+renamedt<ssa_exprt, L0>
+goto_symex_statet::set_l0_indices(ssa_exprt ssa_expr, const namespacet &ns)
 {
-  renamedt<ssa_exprt, L0> renamed =
-    level0(std::move(ssa_expr), ns, source.thread_nr);
-  ssa_expr = renamed.get();
+  return level0(std::move(ssa_expr), ns, source.thread_nr);
 }
 
 void goto_symex_statet::set_l1_indices(
@@ -275,7 +272,7 @@ ssa_exprt goto_symex_statet::rename_ssa(ssa_exprt ssa, const namespacet &ns)
     level == L0 || level == L1,
     "rename_ssa can only be used for levels L0 and L1");
   if(level == L0)
-    set_l0_indices(ssa, ns);
+    ssa = set_l0_indices(std::move(ssa), ns).get();
   else if(level == L1)
     set_l1_indices(ssa, ns);
   else

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -241,17 +241,10 @@ goto_symex_statet::set_l0_indices(ssa_exprt ssa_expr, const namespacet &ns)
   return level0(std::move(ssa_expr), ns, source.thread_nr);
 }
 
-void goto_symex_statet::set_l1_indices(
-  ssa_exprt &ssa_expr,
-  const namespacet &ns)
+renamedt<ssa_exprt, L1>
+goto_symex_statet::set_l1_indices(ssa_exprt ssa_expr, const namespacet &ns)
 {
-  if(!ssa_expr.get_level_2().empty())
-    return;
-  if(!ssa_expr.get_level_1().empty())
-    return;
-  renamedt<ssa_exprt, L1> l1 =
-    level1(level0(std::move(ssa_expr), ns, source.thread_nr));
-  ssa_expr = l1.get();
+  return level1(level0(std::move(ssa_expr), ns, source.thread_nr));
 }
 
 void goto_symex_statet::set_l2_indices(
@@ -274,7 +267,7 @@ ssa_exprt goto_symex_statet::rename_ssa(ssa_exprt ssa, const namespacet &ns)
   if(level == L0)
     ssa = set_l0_indices(std::move(ssa), ns).get();
   else if(level == L1)
-    set_l1_indices(ssa, ns);
+    ssa = set_l1_indices(std::move(ssa), ns).get();
   else
     UNREACHABLE;
 
@@ -309,7 +302,7 @@ exprt goto_symex_statet::rename(exprt expr, const namespacet &ns)
     }
     else if(level==L2)
     {
-      set_l1_indices(ssa, ns);
+      ssa = set_l1_indices(std::move(ssa), ns).get();
       rename<level>(expr.type(), ssa.get_identifier(), ns);
       ssa.update_type();
 
@@ -560,7 +553,7 @@ void goto_symex_statet::rename_address(exprt &expr, const namespacet &ns)
     ssa_exprt &ssa=to_ssa_expr(expr);
 
     // only do L1!
-    set_l1_indices(ssa, ns);
+    ssa = set_l1_indices(std::move(ssa), ns).get();
 
     rename<level>(expr.type(), ssa.get_identifier(), ns);
     ssa.update_type();

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -114,7 +114,7 @@ protected:
   void rename_address(exprt &expr, const namespacet &ns);
 
   /// Update level 0 values.
-  void set_l0_indices(ssa_exprt &expr, const namespacet &ns);
+  renamedt<ssa_exprt, L0> set_l0_indices(ssa_exprt expr, const namespacet &ns);
 
   /// Update level 0 and 1 values.
   void set_l1_indices(ssa_exprt &expr, const namespacet &ns);

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -117,7 +117,7 @@ protected:
   renamedt<ssa_exprt, L0> set_l0_indices(ssa_exprt expr, const namespacet &ns);
 
   /// Update level 0 and 1 values.
-  void set_l1_indices(ssa_exprt &expr, const namespacet &ns);
+  renamedt<ssa_exprt, L1> set_l1_indices(ssa_exprt expr, const namespacet &ns);
 
   /// Update level 0, 1 and 2 values.
   void set_l2_indices(ssa_exprt &expr, const namespacet &ns);

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -120,7 +120,7 @@ protected:
   renamedt<ssa_exprt, L1> set_l1_indices(ssa_exprt expr, const namespacet &ns);
 
   /// Update level 0, 1 and 2 values.
-  void set_l2_indices(ssa_exprt &expr, const namespacet &ns);
+  renamedt<ssa_exprt, L2> set_l2_indices(ssa_exprt expr, const namespacet &ns);
 
   // this maps L1 names to (L2) types
   typedef std::unordered_map<irep_idt, typet> l1_typest;

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -67,6 +67,8 @@ operator()(renamedt<ssa_exprt, L0> l0_expr) const
 renamedt<ssa_exprt, L2> symex_level2t::
 operator()(renamedt<ssa_exprt, L1> l1_expr) const
 {
+  if(!l1_expr.get().get_level_2().empty())
+    return renamedt<ssa_exprt, L2>{std::move(l1_expr.value)};
   l1_expr.value.set_level_2(current_count(l1_expr.get().get_identifier()));
   return renamedt<ssa_exprt, L2>{std::move(l1_expr.value)};
 }

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -46,8 +46,12 @@ operator()(ssa_exprt ssa_expr, const namespacet &ns, unsigned thread_nr) const
 renamedt<ssa_exprt, L1> symex_level1t::
 operator()(renamedt<ssa_exprt, L0> l0_expr) const
 {
-  if(!l0_expr.get().get_level_1().empty())
+  if(
+    !l0_expr.get().get_level_1().empty() ||
+    !l0_expr.get().get_level_2().empty())
+  {
     return renamedt<ssa_exprt, L1>{std::move(l0_expr.value)};
+  }
 
   const irep_idt l0_name = l0_expr.get().get_l1_object_identifier();
 


### PR DESCRIPTION
This makes it easier to track through which kind of renaming the symbols have been through.
This is an intermediary step, for getting all renamed expression use this types (the next step would be to do the same for all the `rename_*` functions)

Edit: I have changed the title of the PR to better reflect its content now that it has been rebased on the preliminary PR introducing the renamedt type

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
