### PR TITLE
Set prop_convt timeout in solver factory

### DIFF
--- a/src/goto-checker/solver_factory.h
+++ b/src/goto-checker/solver_factory.h
@@ -74,6 +74,11 @@ protected:
 
   smt2_dect::solvert get_smt2_solver_type() const;
 
+  /// Sets the timeout of \p prop_conv if the `solver-time-limit` option
+  /// has a positive value (in seconds).
+  /// \note Most solvers silently ignore the time limit at the moment.
+  void set_prop_conv_time_limit(prop_convt &prop_conv);
+
   // consistency checks during solver creation
   void no_beautification();
   void no_incremental_check();


### PR DESCRIPTION
if `solver-time-limit` option is set.

This behaviour should be configured through the solver factory and not by wild calls on prop_conv from other parts of the code.

Solver timeouts are currently not used in the cbmc repository, but in some dependent projects.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
