### PR TITLE
Replace "some fixes" step in rename by invariant

### DIFF
--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -343,25 +343,20 @@ void goto_symex_statet::rename(
   }
   else
   {
-    // this could go wrong, but we would have to re-typecheck ...
     rename(expr.type(), irep_idt(), ns, level);
 
     // do this recursively
     Forall_operands(it, expr)
       rename(*it, ns, level);
 
-    // some fixes
-    if(expr.id()==ID_with)
-      expr.type()=to_with_expr(expr).old().type();
-    else if(expr.id()==ID_if)
-    {
-      DATA_INVARIANT(
-        to_if_expr(expr).true_case().type() ==
-          to_if_expr(expr).false_case().type(),
-        "true case of to_if_expr should be of same type "
-        "as false case");
-      expr.type()=to_if_expr(expr).true_case().type();
-    }
+    INVARIANT(
+      (expr.id() != ID_with ||
+       expr.type() == to_with_expr(expr).old().type()) &&
+        (expr.id() != ID_if ||
+         (expr.type() == to_if_expr(expr).true_case().type() &&
+          expr.type() == to_if_expr(expr).false_case().type())),
+      "Type of renamed expr should be the same as operands for with_exprt and "
+      "if_exprt");
   }
 }
 


### PR DESCRIPTION
This should not be necessary as the renaming works correctly.
The asserting no modification in necessary in the concerned cases.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
