### PR TITLE
C front-end: support storage class and attributes for aggregate objects

### DIFF
--- a/regression/ansi-c/gcc_attributes14/main.c
+++ b/regression/ansi-c/gcc_attributes14/main.c
@@ -1,0 +1,18 @@
+int main()
+{
+  struct S
+  {
+    int x;
+  };
+
+  struct S static __attribute__((__section__(".somewhere")))
+  elements1[] = {{0}};
+
+  struct
+  {
+    int a;
+    int b;
+  } static __attribute__((__section__(".somewhere"))) elements2[] = {{0, 0}};
+
+  return 0;
+}

--- a/regression/ansi-c/gcc_attributes14/test.desc
+++ b/regression/ansi-c/gcc_attributes14/test.desc
@@ -1,0 +1,8 @@
+CORE gcc-only
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -1172,32 +1172,30 @@ basic_type_specifier:
         }
         ;
 
-/* no gcc type attributes after the following! */
 sue_declaration_specifier:
           declaration_qualifier_list elaborated_type_name
         {
           $$=merge($1, $2);
         }
-        | sue_type_specifier storage_class
+        | sue_type_specifier storage_class gcc_type_attribute_opt
         {
-          $$=merge($1, $2);
+          $$=merge($1, merge($2, $3));
         }
-        | sue_declaration_specifier declaration_qualifier
+        | sue_declaration_specifier declaration_qualifier gcc_type_attribute_opt
         {
-          $$=merge($1, $2);
+          $$=merge($1, merge($2, $3));
         }
         ;
 
-/* no gcc type attributes after the following! */
 sue_type_specifier:
           elaborated_type_name
         | type_qualifier_list elaborated_type_name
         {
           $$=merge($1, $2);
         }
-        | sue_type_specifier type_qualifier
+        | sue_type_specifier type_qualifier gcc_type_attribute_opt
         {
-          $$=merge($1, $2);
+          $$=merge($1, merge($2, $3));
         }
         ;
 


### PR DESCRIPTION
Previously we would only support either storage class/type qualifiers _or_ GCC
attributes.

Fixes: #3990

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
