### PR TITLE
Copy constructor parameter instead of storing reference

### DIFF
--- a/src/util/allocate_objects.h
+++ b/src/util/allocate_objects.h
@@ -79,9 +79,9 @@ public:
   void mark_created_symbols_as_input(code_blockt &init_code);
 
 private:
-  const irep_idt &symbol_mode;
-  const source_locationt &source_location;
-  const irep_idt &name_prefix;
+  const irep_idt symbol_mode;
+  const source_locationt source_location;
+  const irep_idt name_prefix;
 
   symbol_table_baset &symbol_table;
   const namespacet ns;

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -42,6 +42,7 @@ SRC += analyses/ai/ai.cpp \
        solvers/strings/string_refinement/sparse_array.cpp \
        solvers/strings/string_refinement/substitute_array_list.cpp \
        solvers/strings/string_refinement/union_find_replace.cpp \
+       util/allocate_objects.cpp \
        util/cmdline.cpp \
        util/expr_cast/expr_cast.cpp \
        util/expr.cpp \

--- a/unit/util/allocate_objects.cpp
+++ b/unit/util/allocate_objects.cpp
@@ -1,0 +1,30 @@
+/*******************************************************************\
+
+Module: Unit test for allocate_objectst
+
+Author: Diffblue Ltd
+
+\*******************************************************************/
+
+#include <util/allocate_objects.h>
+#include <util/c_types.h>
+#include <util/irep_ids.h>
+#include <util/source_location.h>
+#include <util/symbol_table.h>
+
+#include <testing-utils/use_catch.h>
+
+TEST_CASE(
+  "Tests the absence of a bug that crashed allocate_objects",
+  "[core][util][allocate_objects]")
+{
+  symbol_tablet symtab{};
+  // Because __a_temp will return a const reference to temporary
+  // irep_idt, and we stored the reference instead of copying the
+  // value ...
+  allocate_objectst allocate_object{
+    ID_C, source_locationt{}, "__a_temp", symtab};
+  // This crashed because it tried to access the invalid reference
+  // to the name_prefix irep_idt
+  allocate_object.allocate_automatic_local_object(size_type());
+}


### PR DESCRIPTION
Previously we stored a reference to the name_prefix parameter in allocate objects that led to segfaults if it was constructed with a temporary. Now we store a copy instead, which prevents that from
happening.

This is work that we did jointly @hannes-steffenhagen-diffblue as part of the work on the `goto-harness` feature to fix a bug we discovered.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
