### PR TITLE
Add overload of join_string() that takes a function argument

### DIFF
--- a/src/util/string_utils.h
+++ b/src/util/string_utils.h
@@ -47,24 +47,49 @@ std::string trim_from_last_delimiter(
 /// \param b: Iterator pointing to first item to print
 /// \param e: Iterator pointing past last item to print
 /// \param delimiter: Object to print between each item in the iterator range
+/// \param transform_func: Transform to apply to the value returned by the
+///   iterator
 /// \return A reference to the ostream that was passed in
-template<typename Stream, typename It, typename Delimiter>
+template <
+  typename Stream,
+  typename It,
+  typename Delimiter,
+  typename TransformFunc>
 Stream &join_strings(
-  Stream &os,
+  Stream &&os,
   const It b,
   const It e,
-  const Delimiter &delimiter)
+  const Delimiter &delimiter,
+  TransformFunc &&transform_func)
 {
   if(b==e)
   {
     return os;
   }
-  os << *b;
+  os << transform_func(*b);
   for(auto it=std::next(b); it!=e; ++it)
   {
-    os << delimiter << *it;
+    os << delimiter << transform_func(*it);
   }
   return os;
+}
+
+/// Prints items to an stream, separated by a constant delimiter
+/// \tparam It: An iterator type
+/// \tparam Delimiter: A delimiter type which supports printing to ostreams
+/// \param os: An ostream to write to
+/// \param b: Iterator pointing to first item to print
+/// \param e: Iterator pointing past last item to print
+/// \param delimiter: Object to print between each item in the iterator range
+/// \return A reference to the ostream that was passed in
+template <typename Stream, typename It, typename Delimiter>
+Stream &
+join_strings(Stream &&os, const It b, const It e, const Delimiter &delimiter)
+{
+  using value_type = decltype(*b);
+  // Call auxiliary function with identity function
+  return join_strings(
+    os, b, e, delimiter, [](const value_type &x) { return x; });
 }
 
 /// Generic escaping of strings; this is not meant to be a particular

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -69,7 +69,8 @@ SRC += analyses/ai/ai.cpp \
        util/simplify_expr.cpp \
        util/small_map.cpp \
        util/small_shared_two_way_ptr.cpp \
-       util/std_expr.cpp \
+	util/std_expr.cpp \
+       util/string_utils/join_string.cpp \
        util/string_utils/split_string.cpp \
        util/string_utils/strip_string.cpp \
        util/symbol_table.cpp \

--- a/unit/util/string_utils/join_string.cpp
+++ b/unit/util/string_utils/join_string.cpp
@@ -1,0 +1,44 @@
+/*******************************************************************\
+
+Module: Unit tests of join_string
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+/// \file
+/// join_string Unit Tests
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <testing-utils/use_catch.h>
+#include <util/string_utils.h>
+
+TEST_CASE(
+  "join_strings() should apply the function argument its passed to the "
+  "elements of the container",
+  "[core][utils][string_utils][join_strings]")
+{
+  std::vector<int> vec{1, 2, 3};
+  auto result = join_strings(
+                  std::ostringstream(),
+                  vec.begin(),
+                  vec.end(),
+                  "-",
+                  [](int x) { return std::to_string(x + 1); })
+                  .str();
+  REQUIRE(result == "2-3-4");
+}
+
+TEST_CASE(
+  "join_strings() when passed no function argument should apply the default "
+  "identity function to the elements of the container",
+  "[core][utils][string_utils][join_strings]")
+{
+  std::vector<int> vec{1, 2, 3};
+  auto result =
+    join_strings(std::ostringstream(), vec.begin(), vec.end(), ",").str();
+  REQUIRE(result == "1,2,3");
+}


### PR DESCRIPTION
Add overload of `join_string()` that takes a function argument that it applies to the elements of the container it flattens and add tests for it.

This is work that we did jointly @hannes-steffenhagen-diffblue as part of the work on the goto-harness feature.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
