### PR TITLE
Use get_fresh_aux_symbol to construct dynamic objects

### DIFF
--- a/jbmc/regression/jbmc-generics/constant_propagation/test.desc
+++ b/jbmc/regression/jbmc-generics/constant_propagation/test.desc
@@ -3,9 +3,9 @@ Test
 --function Test.main --show-vcc
 ^EXIT=0$
 ^SIGNAL=0$
-^\{-\d+\} symex_dynamic::dynamic_object1#2\.\.@Generic\.\.@java.lang.Object\.\.@class_identifier = "java::GenericSub"$
-^\{-\d+\} symex_dynamic::dynamic_object1#2\.\.@Generic\.\.key = NULL$
-^\{-\d+\} symex_dynamic::dynamic_object1#3\.\.@Generic\.\.x = 5$
+^\{-\d+\} symex_dynamic::dynamic_object#2\.\.@Generic\.\.@java.lang.Object\.\.@class_identifier = "java::GenericSub"$
+^\{-\d+\} symex_dynamic::dynamic_object#2\.\.@Generic\.\.key = NULL$
+^\{-\d+\} symex_dynamic::dynamic_object#3\.\.@Generic\.\.x = 5$
 --
 byte_extract_(big|little)_endian
 --

--- a/jbmc/regression/jbmc-strings/StringBuilderConstructors01/test-no-arg-fail.desc
+++ b/jbmc/regression/jbmc-strings/StringBuilderConstructors01/test-no-arg-fail.desc
@@ -4,9 +4,9 @@ StringBuilderConstructors01
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
-dynamic_object2=\{\s*\}
+dynamic_object\$0=\{\s*\}
 --
 ^warning: ignoring
 --
-The check for dynamic_object2 is to make sure the array is created empty and
+The check for dynamic_object\$0 is to make sure the array is created empty and
 is not given arbitrary content before its final assignment.

--- a/jbmc/regression/jbmc-strings/long_string/test_abort.desc
+++ b/jbmc/regression/jbmc-strings/long_string/test_abort.desc
@@ -3,7 +3,7 @@ Test
 --function Test.checkAbort --trace --max-nondet-string-length 100000000
 ^EXIT=10$
 ^SIGNAL=0$
-dynamic_object[0-9]*=\(assignment removed\)
+dynamic_object\$?[0-9]*=\(assignment removed\)
 --
 --
 This tests that the object does not appear in the trace, because concretizing

--- a/jbmc/regression/jbmc/VarLengthArrayTrace1/test.desc
+++ b/jbmc/regression/jbmc/VarLengthArrayTrace1/test.desc
@@ -3,7 +3,7 @@ VarLengthArrayTrace1
 --trace --function VarLengthArrayTrace1.main
 ^EXIT=10$
 ^SIGNAL=0$
-dynamic_3_array\[1.*\]=10
+dynamic_array\$?\d*\[1.*\]=10
 --
 ^warning: ignoring
 assignment removed

--- a/jbmc/regression/jbmc/array-cell-sensitivity1/test-max-array-size-10.desc
+++ b/jbmc/regression/jbmc/array-cell-sensitivity1/test-max-array-size-10.desc
@@ -1,17 +1,17 @@
 CORE
 Test
 --function Test.main --show-vcc --max-field-sensitivity-array-size 10
-symex_dynamic::dynamic_2_array#2\[\[0\]\] =
-symex_dynamic::dynamic_2_array#2\[\[1\]\] =
-symex_dynamic::dynamic_2_array#2\[\[2\]\] =
-symex_dynamic::dynamic_2_array#2\[\[3\]\] =
-symex_dynamic::dynamic_2_array#2\[\[4\]\] =
-symex_dynamic::dynamic_2_array#2\[\[5\]\] =
-symex_dynamic::dynamic_2_array#2\[\[6\]\] =
-symex_dynamic::dynamic_2_array#2\[\[7\]\] =
-symex_dynamic::dynamic_2_array#2\[\[8\]\] =
-symex_dynamic::dynamic_2_array#2\[\[9\]\] =
-symex_dynamic::dynamic_2_array#3\[\[1\]\] = java::Test.main:\(I\)V::unknown!0@1#1
+symex_dynamic::dynamic_array#2\[\[0\]\] =
+symex_dynamic::dynamic_array#2\[\[1\]\] =
+symex_dynamic::dynamic_array#2\[\[2\]\] =
+symex_dynamic::dynamic_array#2\[\[3\]\] =
+symex_dynamic::dynamic_array#2\[\[4\]\] =
+symex_dynamic::dynamic_array#2\[\[5\]\] =
+symex_dynamic::dynamic_array#2\[\[6\]\] =
+symex_dynamic::dynamic_array#2\[\[7\]\] =
+symex_dynamic::dynamic_array#2\[\[8\]\] =
+symex_dynamic::dynamic_array#2\[\[9\]\] =
+symex_dynamic::dynamic_array#3\[\[1\]\] = java::Test.main:\(I\)V::unknown!0@1#1
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/jbmc/regression/jbmc/array-cell-sensitivity1/test-max-array-size-9.desc
+++ b/jbmc/regression/jbmc/array-cell-sensitivity1/test-max-array-size-9.desc
@@ -3,9 +3,9 @@ Test
 --function Test.main --show-vcc --max-field-sensitivity-array-size 9
 ^EXIT=0$
 ^SIGNAL=0$
-symex_dynamic::dynamic_2_array#[0-9]\[1\]
+symex_dynamic::dynamic_array#[0-9]\[1\]
 --
-symex_dynamic::dynamic_2_array#[0-9]\[\[[0-9]\]\]
+symex_dynamic::dynamic_array#[0-9]\[\[[0-9]\]\]
 --
 This checks that field sensitvity is not applied to an array of size 10
 when the max is set to 9.

--- a/jbmc/regression/jbmc/array-cell-sensitivity1/test-no-array-field-sensitivity.desc
+++ b/jbmc/regression/jbmc/array-cell-sensitivity1/test-no-array-field-sensitivity.desc
@@ -3,9 +3,9 @@ Test
 --function Test.main --show-vcc --no-array-field-sensitivity
 ^EXIT=0$
 ^SIGNAL=0$
-symex_dynamic::dynamic_2_array#[0-9]\[1\]
+symex_dynamic::dynamic_array#[0-9]\[1\]
 --
-symex_dynamic::dynamic_2_array#[0-9]\[\[[0-9]\]\]
+symex_dynamic::dynamic_array#[0-9]\[\[[0-9]\]\]
 --
 This checks that field sensitvity is not applied to arrays when
 no-array-field-sensitivity is used.

--- a/jbmc/regression/jbmc/array-cell-sensitivity1/test.desc
+++ b/jbmc/regression/jbmc/array-cell-sensitivity1/test.desc
@@ -1,21 +1,21 @@
 CORE
 Test
 --function Test.main --show-vcc
-symex_dynamic::dynamic_2_array#2\[\[0\]\] =
-symex_dynamic::dynamic_2_array#2\[\[1\]\] =
-symex_dynamic::dynamic_2_array#2\[\[2\]\] =
-symex_dynamic::dynamic_2_array#2\[\[3\]\] =
-symex_dynamic::dynamic_2_array#2\[\[4\]\] =
-symex_dynamic::dynamic_2_array#2\[\[5\]\] =
-symex_dynamic::dynamic_2_array#2\[\[6\]\] =
-symex_dynamic::dynamic_2_array#2\[\[7\]\] =
-symex_dynamic::dynamic_2_array#2\[\[8\]\] =
-symex_dynamic::dynamic_2_array#2\[\[9\]\] =
-symex_dynamic::dynamic_2_array#3\[\[1\]\] = java::Test.main:\(I\)V::unknown!0@1#1
+symex_dynamic::dynamic_array#2\[\[0\]\] =
+symex_dynamic::dynamic_array#2\[\[1\]\] =
+symex_dynamic::dynamic_array#2\[\[2\]\] =
+symex_dynamic::dynamic_array#2\[\[3\]\] =
+symex_dynamic::dynamic_array#2\[\[4\]\] =
+symex_dynamic::dynamic_array#2\[\[5\]\] =
+symex_dynamic::dynamic_array#2\[\[6\]\] =
+symex_dynamic::dynamic_array#2\[\[7\]\] =
+symex_dynamic::dynamic_array#2\[\[8\]\] =
+symex_dynamic::dynamic_array#2\[\[9\]\] =
+symex_dynamic::dynamic_array#3\[\[1\]\] = java::Test.main:\(I\)V::unknown!0@1#1
 ^EXIT=0$
 ^SIGNAL=0$
 --
-symex_dynamic::dynamic_2_array#3\[\[[023456789]\]\] =
+symex_dynamic::dynamic_array#3\[\[[023456789]\]\] =
 --
 This checks that a write to a Java array with an unknown index uses a whole-array
 write followed by array-cell expansion, but one targeting a constant index uses

--- a/jbmc/regression/jbmc/array-cell-sensitivity2/test.desc
+++ b/jbmc/regression/jbmc/array-cell-sensitivity2/test.desc
@@ -1,13 +1,13 @@
 CORE
 Test
 --function Test.main --show-vcc
-symex_dynamic::dynamic_object6#3\.\.data =
-symex_dynamic::dynamic_object3#3\.\.data =
+symex_dynamic::dynamic_object\$3#3\.\.data =
+symex_dynamic::dynamic_object\$1#3\.\.data =
 ^EXIT=0$
 ^SIGNAL=0$
 --
-symex_dynamic::dynamic_object6#3\.\.data = symex_dynamic::dynamic_object6#3\.data
-symex_dynamic::dynamic_object3#3\.\.data = symex_dynamic::dynamic_object3#3\.data
+symex_dynamic::dynamic_object\$3#3\.\.data = symex_dynamic::dynamic_object\$3#3\.data
+symex_dynamic::dynamic_object\$1#3\.\.data = symex_dynamic::dynamic_object\$1#3\.data
 --
 This checks that a write using a mix of field and array accessors uses a field-sensitive
 symbol (the data field of the possible ultimate target objects) rather than using

--- a/jbmc/regression/jbmc/json_trace3/test.desc
+++ b/jbmc/regression/jbmc/json_trace3/test.desc
@@ -4,7 +4,7 @@ Test
 activate-multi-line-match
 ^EXIT=10$
 ^SIGNAL=0$
-"lhs": "dynamic_object3\[1L?\]",\n *"mode": "java",\n *"sourceLocation": \{\n *"bytecodeIndex": "18",\n *"file": "Test\.java",\n *"function": "java::Test\.main:\(\[J\)V",\n *"line": "8"\n *\},\n *"stepType": "assignment",\n *"thread": 0,\n *"value": \{\n *"binary": "0000000000000000000000000000000000000000000000000000000000000001",\n *"data": "1L",\n *"name": "integer",\n *"type": "long",\n *"width": 64
+"lhs": "dynamic_object\$?\d*\[1L?\]",\n *"mode": "java",\n *"sourceLocation": \{\n *"bytecodeIndex": "18",\n *"file": "Test\.java",\n *"function": "java::Test\.main:\(\[J\)V",\n *"line": "8"\n *\},\n *"stepType": "assignment",\n *"thread": 0,\n *"value": \{\n *"binary": "0000000000000000000000000000000000000000000000000000000000000001",\n *"data": "1L",\n *"name": "integer",\n *"type": "long",\n *"width": 64
 --
 "name": "unknown"
 ^warning: ignoring

--- a/jbmc/regression/jbmc/throwing-function-return-value/test.desc
+++ b/jbmc/regression/jbmc/throwing-function-return-value/test.desc
@@ -1,7 +1,7 @@
 CORE
 Test
 --function Test.main --show-vcc
-java::Test\.main:\(Z\)V::14::t1!0@1#\d+ = address_of\(symex_dynamic::dynamic_object\d+\)
+java::Test\.main:\(Z\)V::14::t1!0@1#\d+ = address_of\(symex_dynamic::dynamic_object\$1\)
 java::Test\.main:\(Z\)V::9::x!0@1#\d+ = java::Test\.main:\(Z\)V::9::x!0@1#\d+ \+ 5
 java::Test\.g:\(\)I#return_value!0#[0-9]+ = 5
 ^EXIT=0$

--- a/jbmc/regression/strings-smoke-tests/java_parseint/test4.desc
+++ b/jbmc/regression/strings-smoke-tests/java_parseint/test4.desc
@@ -5,7 +5,7 @@ Test4
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 6.* FAILURE$
 ^\[.*assertion.2\].* line 9.* FAILURE$
-dynamic_object2=\{ '5', '0' \}
-dynamic_object2=\{ 'X', 'Y', 'Z', 'W' \}
+dynamic_object\$0=\{ '5', '0' \}
+dynamic_object\$0=\{ 'X', 'Y', 'Z', 'W' \}
 --
 non equal types

--- a/jbmc/regression/strings-smoke-tests/java_parselong/test_other_branches_possible.desc
+++ b/jbmc/regression/strings-smoke-tests/java_parselong/test_other_branches_possible.desc
@@ -5,7 +5,7 @@ Test_other_branches_possible
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 6.* FAILURE$
 ^\[.*assertion.2\].* line 9.* FAILURE$
-dynamic_object2=\{ '5', '0' \}
-dynamic_object2=\{ 'X', 'Y', 'Z', 'W' \}
+dynamic_object\$0=\{ '5', '0' \}
+dynamic_object\$0=\{ 'X', 'Y', 'Z', 'W' \}
 --
 non equal types

--- a/regression/cbmc/array-cell-sensitivity5/test.desc
+++ b/regression/cbmc/array-cell-sensitivity5/test.desc
@@ -1,20 +1,20 @@
 CORE
 test.c
 --show-vcc
-symex_dynamic::dynamic_object1#2\[\[1\]\] =
-symex_dynamic::dynamic_object1#2\[\[2\]\] =
-symex_dynamic::dynamic_object1#2\[\[3\]\] =
-symex_dynamic::dynamic_object1#2\[\[4\]\] =
-symex_dynamic::dynamic_object1#2\[\[5\]\] =
-symex_dynamic::dynamic_object1#2\[\[6\]\] =
-symex_dynamic::dynamic_object1#2\[\[7\]\] =
-symex_dynamic::dynamic_object1#2\[\[8\]\] =
-symex_dynamic::dynamic_object1#2\[\[9\]\] =
-symex_dynamic::dynamic_object1#3\[\[1\]\] =
+symex_dynamic::dynamic_object#2\[\[1\]\] =
+symex_dynamic::dynamic_object#2\[\[2\]\] =
+symex_dynamic::dynamic_object#2\[\[3\]\] =
+symex_dynamic::dynamic_object#2\[\[4\]\] =
+symex_dynamic::dynamic_object#2\[\[5\]\] =
+symex_dynamic::dynamic_object#2\[\[6\]\] =
+symex_dynamic::dynamic_object#2\[\[7\]\] =
+symex_dynamic::dynamic_object#2\[\[8\]\] =
+symex_dynamic::dynamic_object#2\[\[9\]\] =
+symex_dynamic::dynamic_object#3\[\[1\]\] =
 ^EXIT=0$
 ^SIGNAL=0$
 --
-symex_dynamic::dynamic_object1#[3-9]\[[0-9]+\]
+symex_dynamic::dynamic_object#[3-9]\[[0-9]+\]
 --
 This checks that a write with a non-constant index leads to a whole-array
 operation followed by expansion into individual array cells, while a write with

--- a/regression/cbmc/array-cell-sensitivity6/test.desc
+++ b/regression/cbmc/array-cell-sensitivity6/test.desc
@@ -1,20 +1,20 @@
 CORE
 test.c
 --show-vcc
-symex_dynamic::dynamic_object1#2\[\[1\]\] =
-symex_dynamic::dynamic_object1#2\[\[2\]\] =
-symex_dynamic::dynamic_object1#2\[\[3\]\] =
-symex_dynamic::dynamic_object1#2\[\[4\]\] =
-symex_dynamic::dynamic_object1#2\[\[5\]\] =
-symex_dynamic::dynamic_object1#2\[\[6\]\] =
-symex_dynamic::dynamic_object1#2\[\[7\]\] =
-symex_dynamic::dynamic_object1#2\[\[8\]\] =
-symex_dynamic::dynamic_object1#2\[\[9\]\] =
-symex_dynamic::dynamic_object1#3\[\[1\]\] =
+symex_dynamic::dynamic_object#2\[\[1\]\] =
+symex_dynamic::dynamic_object#2\[\[2\]\] =
+symex_dynamic::dynamic_object#2\[\[3\]\] =
+symex_dynamic::dynamic_object#2\[\[4\]\] =
+symex_dynamic::dynamic_object#2\[\[5\]\] =
+symex_dynamic::dynamic_object#2\[\[6\]\] =
+symex_dynamic::dynamic_object#2\[\[7\]\] =
+symex_dynamic::dynamic_object#2\[\[8\]\] =
+symex_dynamic::dynamic_object#2\[\[9\]\] =
+symex_dynamic::dynamic_object#3\[\[1\]\] =
 ^EXIT=0$
 ^SIGNAL=0$
 --
-symex_dynamic::dynamic_object1#[3-9]\[[0-9]+\]
+symex_dynamic::dynamic_object#[3-9]\[[0-9]+\]
 --
 This checks that a write with a non-constant index leads to a whole-array
 operation followed by expansion into individual array cells, while a write with

--- a/regression/cbmc/double_deref/double_deref_with_pointer_arithmetic.desc
+++ b/regression/cbmc/double_deref/double_deref_with_pointer_arithmetic.desc
@@ -1,8 +1,8 @@
 CORE
 double_deref_with_pointer_arithmetic.c
 --show-vcc
-^\{-[0-9]+\} derefd_pointer::derefd_pointer!0#1 = \{ symex_dynamic::dynamic_object1#3\[\[0\]\], symex_dynamic::dynamic_object1#3\[\[1\]\] \}\[cast\(mod\(main::argc!0@1#1, 2\), signedbv\[64\]\)\]
-^\{1\} \(derefd_pointer::derefd_pointer!0#1 = address_of\(symex_dynamic::dynamic_object[23]\) \? main::argc!0@1#1 = 2 : \(derefd_pointer::derefd_pointer!0#1 = address_of\(symex_dynamic::dynamic_object[23]\) \? main::argc!0@1#1 = 1 : symex::invalid_object!0#0 = main::argc!0@1#1\)\)
+^\{-[0-9]+\} derefd_pointer::derefd_pointer!0#1 = \{ symex_dynamic::dynamic_object#3\[\[0\]\], symex_dynamic::dynamic_object#3\[\[1\]\] \}\[cast\(mod\(main::argc!0@1#1, 2\), signedbv\[64\]\)\]
+^\{1\} \(derefd_pointer::derefd_pointer!0#1 = address_of\(symex_dynamic::dynamic_object\$[01]\) \? main::argc!0@1#1 = 2 : \(derefd_pointer::derefd_pointer!0#1 = address_of\(symex_dynamic::dynamic_object\$[01]\) \? main::argc!0@1#1 = 1 : symex::invalid_object!0#0 = main::argc!0@1#1\)\)
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/cbmc/double_deref/double_deref_with_pointer_arithmetic_single_alias.desc
+++ b/regression/cbmc/double_deref/double_deref_with_pointer_arithmetic_single_alias.desc
@@ -1,7 +1,7 @@
 CORE
 double_deref_with_pointer_arithmetic_single_alias.c
 --show-vcc
-\{1\} \(derefd_pointer::derefd_pointer!0#1 = address_of\(symex_dynamic::dynamic_object2\) \? main::argc!0@1#1 = 1 : symex::invalid_object!0#0 = main::argc!0@1#1\)
+\{1\} \(derefd_pointer::derefd_pointer!0#1 = address_of\(symex_dynamic::dynamic_object\$0\) \? main::argc!0@1#1 = 1 : symex::invalid_object!0#0 = main::argc!0@1#1\)
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/cbmc/trace-values/trace-values.desc
+++ b/regression/cbmc/trace-values/trace-values.desc
@@ -10,7 +10,7 @@ trace-values.c
 ^  my_nested\[0.*\].array\[1.*\]=4 .*$
 ^  my_nested\[1.*\].f=5 .*$
 ^  junk\$object=7 .*$
-^  dynamic_object1\[1.*\]=8 .*$
+^  dynamic_object\[1.*\]=8 .*$
 ^  my_nested\[1.*\](=\{ )?.f=0[ ,]
 ^  my_nested\[1.*\](=\{ .f=0, )?.array=\{ 0, 4, 0 \}
 ^  s\.f=42 \([0 ]+ 00101010\)$

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -1648,7 +1648,7 @@ std::string expr2ct::convert_symbol(const exprt &src)
     dest=id2string(entry->second);
 
     #if 0
-    if(has_prefix(id2string(id), SYMEX_DYNAMIC_PREFIX "dynamic_object"))
+    if(has_prefix(id2string(id), SYMEX_DYNAMIC_PREFIX "::dynamic_object"))
     {
       if(sizeof_nesting++ == 0)
         dest+=" /*"+convert(src.type());

--- a/src/goto-instrument/race_check.cpp
+++ b/src/goto-instrument/race_check.cpp
@@ -130,7 +130,7 @@ static bool is_shared(const namespacet &ns, const symbol_exprt &symbol_expr)
     identifier == "stdout" || identifier == "stderr" ||
     identifier == "sys_nerr" ||
     has_prefix(id2string(identifier), "symex::invalid_object") ||
-    has_prefix(id2string(identifier), SYMEX_DYNAMIC_PREFIX "dynamic_object"))
+    has_prefix(id2string(identifier), SYMEX_DYNAMIC_PREFIX "::dynamic_object"))
     return false; // no race check
 
   const symbolt &symbol=ns.lookup(identifier);

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -459,9 +459,9 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
         }
         else if(
           !contains_symbol_prefix(
-            it->full_lhs_value, SYMEX_DYNAMIC_PREFIX "dynamic_object") &&
+            it->full_lhs_value, SYMEX_DYNAMIC_PREFIX "::dynamic_object") &&
           !contains_symbol_prefix(
-            it->full_lhs, SYMEX_DYNAMIC_PREFIX "dynamic_object") &&
+            it->full_lhs, SYMEX_DYNAMIC_PREFIX "::dynamic_object") &&
           lhs_id.find("thread") == std::string::npos &&
           lhs_id.find("mutex") == std::string::npos &&
           (!it->full_lhs_value.is_constant() ||

--- a/src/goto-symex/auto_objects.cpp
+++ b/src/goto-symex/auto_objects.cpp
@@ -9,29 +9,28 @@ Author: Daniel Kroening, kroening@kroening.com
 /// \file
 /// Symbolic Execution of ANSI-C
 
-#include "goto_symex.h"
-
+#include <util/fresh_symbol.h>
 #include <util/pointer_expr.h>
 #include <util/prefix.h>
 #include <util/std_code.h>
 #include <util/std_expr.h>
 
+#include "goto_symex.h"
+
 exprt goto_symext::make_auto_object(const typet &type, statet &state)
 {
-  dynamic_counter++;
-
   // produce auto-object symbol
-  symbolt symbol;
+  symbolt &symbol = get_fresh_aux_symbol(
+    type,
+    "symex",
+    "auto_object",
+    state.source.pc->source_location(),
+    ID_C,
+    state.symbol_table);
+  symbol.is_thread_local = false;
+  symbol.is_file_local = false;
 
-  symbol.base_name="auto_object"+std::to_string(dynamic_counter);
-  symbol.name="symex::"+id2string(symbol.base_name);
-  symbol.is_lvalue=true;
-  symbol.type=type;
-  symbol.mode=ID_C;
-
-  state.symbol_table.add(symbol);
-
-  return symbol_exprt(symbol.name, symbol.type);
+  return symbol.symbol_expr();
 }
 
 void goto_symext::initialize_auto_object(const exprt &expr, statet &state)
@@ -85,7 +84,7 @@ void goto_symext::trigger_auto_object(const exprt &expr, statet &state)
       {
         const symbolt &symbol = ns.lookup(obj_identifier);
 
-        if(has_prefix(id2string(symbol.base_name), "auto_object"))
+        if(has_prefix(id2string(symbol.base_name), "symex::auto_object"))
         {
           // done already?
           if(!state.get_level2().current_names.has_key(

--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -29,8 +29,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <climits>
 
-unsigned goto_symext::dynamic_counter=0;
-
 void goto_symext::do_simplify(exprt &expr)
 {
   if(symex_config.simplify_opt)

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -776,9 +776,6 @@ protected:
   /// \param code: The cleaned up output instruction
   virtual void symex_output(statet &state, const codet &code);
 
-  /// A monotonically increasing index for each created dynamic object
-  static unsigned dynamic_counter;
-
   void rewrite_quantifiers(exprt &, statet &);
 
   /// \brief Symbolic execution paths to be resumed later

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -142,7 +142,7 @@ void goto_symext::symex_allocate(
       size_symbol.base_name=
         "dynamic_object_size"+std::to_string(dynamic_counter);
       size_symbol.name =
-        SYMEX_DYNAMIC_PREFIX + id2string(size_symbol.base_name);
+        SYMEX_DYNAMIC_PREFIX "::" + id2string(size_symbol.base_name);
       size_symbol.type=tmp_size.type();
       size_symbol.mode = mode;
       size_symbol.type.set(ID_C_constant, true);
@@ -161,7 +161,8 @@ void goto_symext::symex_allocate(
   symbolt value_symbol;
 
   value_symbol.base_name="dynamic_object"+std::to_string(dynamic_counter);
-  value_symbol.name = SYMEX_DYNAMIC_PREFIX + id2string(value_symbol.base_name);
+  value_symbol.name =
+    SYMEX_DYNAMIC_PREFIX "::" + id2string(value_symbol.base_name);
   value_symbol.is_lvalue=true;
   value_symbol.type = *object_type;
   value_symbol.type.set(ID_C_dynamic, true);
@@ -489,7 +490,7 @@ void goto_symext::symex_cpp_new(
   symbol.base_name=
     do_array?"dynamic_"+count_string+"_array":
              "dynamic_"+count_string+"_value";
-  symbol.name = SYMEX_DYNAMIC_PREFIX + id2string(symbol.base_name);
+  symbol.name = SYMEX_DYNAMIC_PREFIX "::" + id2string(symbol.base_name);
   symbol.is_lvalue=true;
   if(code.get(ID_statement)==ID_cpp_new_array ||
      code.get(ID_statement)==ID_cpp_new)

--- a/src/solvers/flattening/pointer_logic.cpp
+++ b/src/solvers/flattening/pointer_logic.cpp
@@ -28,7 +28,7 @@ bool pointer_logict::is_dynamic_object(const exprt &expr) const
          (expr.id() == ID_symbol &&
           has_prefix(
             id2string(to_symbol_expr(expr).get_identifier()),
-            SYMEX_DYNAMIC_PREFIX));
+            SYMEX_DYNAMIC_PREFIX "::"));
 }
 
 void pointer_logict::get_dynamic_objects(std::vector<mp_integer> &o) const

--- a/src/util/pointer_predicates.h
+++ b/src/util/pointer_predicates.h
@@ -14,7 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "std_expr.h"
 
-#define SYMEX_DYNAMIC_PREFIX "symex_dynamic::"
+#define SYMEX_DYNAMIC_PREFIX "symex_dynamic"
 
 exprt same_object(const exprt &p1, const exprt &p2);
 exprt deallocated(const exprt &pointer, const namespacet &);

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -594,7 +594,7 @@ simplify_exprt::simplify_is_dynamic_object(const unary_exprt &expr)
 
       // this is for the benefit of symex
       return make_boolean_expr(
-        has_prefix(id2string(identifier), SYMEX_DYNAMIC_PREFIX));
+        has_prefix(id2string(identifier), SYMEX_DYNAMIC_PREFIX "::"));
     }
     else if(op_object.id() == ID_string_constant)
     {


### PR DESCRIPTION
This avoids use of a global variable and reuses central infrastructure instead
of repeated local work. Note that this changes the names of dynamic objects as
the suffix now includes a $ character, and need not have any suffix, as well as
moving the counter out of the middle of C++/Java dynamic_X_array objects.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
