### PR TITLE
Tag-type related cleanup in xml_expr.cpp

### DIFF
--- a/src/goto-programs/xml_expr.cpp
+++ b/src/goto-programs/xml_expr.cpp
@@ -101,6 +101,10 @@ xmlt xml(const typet &type, const namespacet &ns)
       e.new_element("type").new_element() = xml(component.type(), ns);
     }
   }
+  else if(type.id() == ID_struct_tag)
+  {
+    return xml(ns.follow_tag(to_struct_tag_type(type)), ns);
+  }
   else if(type.id() == ID_union)
   {
     result.name = "union";
@@ -113,6 +117,10 @@ xmlt xml(const typet &type, const namespacet &ns)
       e.new_element("type").new_element() = xml(component.type(), ns);
     }
   }
+  else if(type.id() == ID_union_tag)
+  {
+    return xml(ns.follow_tag(to_union_tag_type(type)), ns);
+  }
   else
     result.name = "unknown";
 
@@ -123,11 +131,11 @@ xmlt xml(const exprt &expr, const namespacet &ns)
 {
   xmlt result;
 
-  const typet &type = ns.follow(expr.type());
-
   if(expr.id() == ID_constant)
   {
     const auto &constant_expr = to_constant_expr(expr);
+
+    const typet &type = expr.type();
 
     if(
       type.id() == ID_unsignedbv || type.id() == ID_signedbv ||
@@ -244,6 +252,8 @@ xmlt xml(const exprt &expr, const namespacet &ns)
   else if(expr.id() == ID_struct)
   {
     result.name = "struct";
+
+    const typet &type = ns.follow(expr.type());
 
     // these are expected to have a struct type
     if(type.id() == ID_struct)


### PR DESCRIPTION
1) Don't use ns.follow unless strictly necessary.
2) Support struct/uniont tag types in xml(typet)

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
