### PR TITLE
Function pointers: also support c_bool (_Bool) in loose matching

### DIFF
--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -131,15 +131,15 @@ bool remove_function_pointerst::arg_is_type_compatible(
     return true;
 
   // any integer-vs-enum-vs-pointer is ok
-  if(call_type.id()==ID_signedbv ||
-     call_type.id()==ID_unsigned ||
-     call_type.id()==ID_bool ||
-     call_type.id()==ID_pointer ||
-     call_type.id()==ID_c_enum ||
-     call_type.id()==ID_c_enum_tag)
+  if(
+    call_type.id() == ID_signedbv || call_type.id() == ID_unsigned ||
+    call_type.id() == ID_bool || call_type.id() == ID_c_bool ||
+    call_type.id() == ID_c_enum_tag || call_type.id() == ID_c_enum ||
+    call_type.id() == ID_pointer)
   {
     return function_type.id() == ID_signedbv ||
            function_type.id() == ID_unsigned || function_type.id() == ID_bool ||
+           function_type.id() == ID_c_bool ||
            function_type.id() == ID_pointer ||
            function_type.id() == ID_c_enum ||
            function_type.id() == ID_c_enum_tag;


### PR DESCRIPTION
If we do bool and signed/unsigned bv, we might as well do c_bool.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
