### PR TITLE
type-to-{JSON,XML}: output array size

### DIFF
--- a/src/goto-programs/json_expr.cpp
+++ b/src/goto-programs/json_expr.cpp
@@ -157,6 +157,7 @@ json_objectt json(const typet &type, const namespacet &ns, const irep_idt &mode)
   {
     result["name"] = json_stringt("array");
     result["subtype"] = json(to_array_type(type).subtype(), ns, mode);
+    result["size"] = json(to_array_type(type).size(), ns, mode);
   }
   else if(type.id() == ID_vector)
   {

--- a/src/goto-programs/xml_expr.cpp
+++ b/src/goto-programs/xml_expr.cpp
@@ -80,6 +80,8 @@ xmlt xml(const typet &type, const namespacet &ns)
     result.name = "array";
     result.new_element("subtype").new_element() =
       xml(to_array_type(type).subtype(), ns);
+    result.new_element("size").new_element() =
+      xml(to_array_type(type).size(), ns);
   }
   else if(type.id() == ID_vector)
   {


### PR DESCRIPTION
We do output the size of vectors, but hadn't done so for arrays for some reason.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
