### PR TITLE
Flattening of ID_nondet_symbol for unbounded arrays [blocks: #3619]

### DIFF
--- a/src/solvers/flattening/arrays.cpp
+++ b/src/solvers/flattening/arrays.cpp
@@ -180,9 +180,10 @@ void arrayst::collect_arrays(const exprt &a)
   else if(a.id()==ID_member)
   {
     DATA_INVARIANT(
-      to_member_expr(a).struct_op().id()==ID_symbol,
-      ("unexpected array expression: member with `"+
-       a.op0().id_string()+"'").c_str());
+      to_member_expr(a).struct_op().id() == ID_symbol ||
+        to_member_expr(a).struct_op().id() == ID_nondet_symbol,
+      ("unexpected array expression: member with `" + a.op0().id_string() + "'")
+        .c_str());
   }
   else if(a.id()==ID_constant ||
           a.id()==ID_array ||
@@ -450,8 +451,10 @@ void arrayst::add_array_constraints(
           expr.id()==ID_string_constant)
   {
   }
-  else if(expr.id()==ID_member &&
-          to_member_expr(expr).struct_op().id()==ID_symbol)
+  else if(
+    expr.id() == ID_member &&
+    (to_member_expr(expr).struct_op().id() == ID_symbol ||
+     to_member_expr(expr).struct_op().id() == ID_nondet_symbol))
   {
   }
   else if(expr.id()==ID_byte_update_little_endian ||

--- a/src/solvers/flattening/boolbv_index.cpp
+++ b/src/solvers/flattening/boolbv_index.cpp
@@ -51,9 +51,8 @@ bvt boolbvt::convert_index(const index_exprt &expr)
 
       // record type if array is a symbol
 
-      if(array.id()==ID_symbol)
-        map.get_map_entry(
-          to_symbol_expr(array).get_identifier(), array_type);
+      if(array.id() == ID_symbol || array.id() == ID_nondet_symbol)
+        map.get_map_entry(array.get(ID_identifier), array_type);
 
       // make sure we have the index in the cache
       convert_bv(index);

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -1127,7 +1127,7 @@ static exprt substitute_array_access(
       *if_expr, index_expr.index(), symbol_generator, left_propagate);
 
   INVARIANT(
-    array.is_nil() || array.id() == ID_symbol,
+    array.is_nil() || array.id() == ID_symbol || array.id() == ID_nondet_symbol,
     std::string(
       "in case the array is unknown, it should be a symbol or nil, id: ") +
       id2string(array.id()));
@@ -1700,7 +1700,9 @@ static void initial_index_set(
   const exprt &s,
   const exprt &i)
 {
-  PRECONDITION(s.id() == ID_symbol || s.id() == ID_array || s.id() == ID_if);
+  PRECONDITION(
+    s.id() == ID_symbol || s.id() == ID_nondet_symbol || s.id() == ID_array ||
+    s.id() == ID_if);
   if(s.id() == ID_array)
   {
     for(std::size_t j = 0; j < s.operands().size(); ++j)
@@ -2002,7 +2004,8 @@ exprt string_refinementt::get(const exprt &expr) const
     }
 
     INVARIANT(
-      array.is_nil() || array.id() == ID_symbol,
+      array.is_nil() || array.id() == ID_symbol ||
+        array.id() == ID_nondet_symbol,
       std::string("apart from symbols, array valuations can be interpreted as "
                   "sparse arrays, id: ") +
         id2string(array.id()));


### PR DESCRIPTION
symbol_exprt and nondet_symbol_exprt are to be treated the same when in comes to
the back-end: they both introduce an uninterpreted, nullary function. Note the
difference at the level of symbolic execution/programs, where the value of
symbols may change (while the value of nondet_symbol_exprts cannot).

This is factored out from #3619 to make it easier to pinpoint what exactly causes trouble with TG. The commit is exactly the same as the first one from #3619, which has been approved already.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
