### PR TITLE
Break goto_symex_state into more manageable bits

### DIFF
--- a/src/goto-checker/symex_bmc.cpp
+++ b/src/goto-checker/symex_bmc.cpp
@@ -86,9 +86,7 @@ void symex_bmct::symex_step(
   }
 }
 
-void symex_bmct::merge_goto(
-  const statet::goto_statet &goto_state,
-  statet &state)
+void symex_bmct::merge_goto(const goto_statet &goto_state, statet &state)
 {
   const goto_programt::const_targett prev_pc = goto_state.source.pc;
   const guardt prev_guard = goto_state.guard;

--- a/src/goto-checker/symex_bmc.h
+++ b/src/goto-checker/symex_bmc.h
@@ -94,8 +94,7 @@ protected:
   void symex_step(const get_goto_functiont &get_goto_function, statet &state)
     override;
 
-  void
-  merge_goto(const statet::goto_statet &goto_state, statet &state) override;
+  void merge_goto(const goto_statet &goto_state, statet &state) override;
 
   bool should_stop_unwind(
     const symex_targett::sourcet &source,

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -256,17 +256,11 @@ protected:
   // gotos
   void merge_gotos(statet &);
 
-  virtual void merge_goto(
-    const statet::goto_statet &goto_state,
-    statet &);
+  virtual void merge_goto(const goto_statet &goto_state, statet &);
 
-  void merge_value_sets(
-    const statet::goto_statet &goto_state,
-    statet &dest);
+  void merge_value_sets(const goto_statet &goto_state, statet &dest);
 
-  void phi_function(
-    const statet::goto_statet &goto_state,
-    statet &);
+  void phi_function(const goto_statet &goto_state, statet &);
 
   // determine whether to unwind a loop -- true indicates abort,
   // with false we continue.

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -28,13 +28,7 @@ Author: Daniel Kroening, kroening@kroening.com
 static void get_l1_name(exprt &expr);
 
 goto_symex_statet::goto_symex_statet()
-  : depth(0),
-    symex_target(nullptr),
-    atomic_section_id(0),
-    total_vccs(0),
-    remaining_vccs(0),
-    record_events(true),
-    dirty()
+  : symex_target(nullptr), record_events(true), dirty()
 {
   threads.resize(1);
   new_frame();
@@ -741,7 +735,7 @@ void goto_symex_statet::print_backtrace(std::ostream &out) const
 /// Print the constant propagation map in a human-friendly format.
 /// This is primarily for use from the debugger; please don't delete me just
 /// because there aren't any current callers.
-void goto_symex_statet::output_propagation_map(std::ostream &out)
+void goto_statet::output_propagation_map(std::ostream &out)
 {
   for(const auto &name_value : propagation)
   {

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -697,42 +697,6 @@ void goto_symex_statet::rename(
     l1_type_entry.first->second=type;
 }
 
-void goto_symex_statet::get_original_name(exprt &expr) const
-{
-  get_original_name(expr.type());
-
-  if(expr.id()==ID_symbol &&
-     expr.get_bool(ID_C_SSA_symbol))
-    expr=to_ssa_expr(expr).get_original_expr();
-  else
-    Forall_operands(it, expr)
-      get_original_name(*it);
-}
-
-void goto_symex_statet::get_original_name(typet &type) const
-{
-  // rename all the symbols with their last known value
-
-  if(type.id()==ID_array)
-  {
-    auto &array_type = to_array_type(type);
-    get_original_name(array_type.subtype());
-    get_original_name(array_type.size());
-  }
-  else if(type.id() == ID_struct || type.id() == ID_union)
-  {
-    struct_union_typet &s_u_type=to_struct_union_type(type);
-    struct_union_typet::componentst &components=s_u_type.components();
-
-    for(auto &component : components)
-      get_original_name(component.type());
-  }
-  else if(type.id()==ID_pointer)
-  {
-    get_original_name(to_pointer_type(type).subtype());
-  }
-}
-
 static void get_l1_name(exprt &expr)
 {
   // do not reset the type !

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -64,6 +64,43 @@ public:
   goto_statet(const class goto_symex_statet &s);
 };
 
+// stack frames -- these are used for function calls and
+// for exceptions
+struct framet
+{
+  // gotos
+  using goto_state_listt = std::list<goto_statet>;
+
+  // function calls
+  irep_idt function_identifier;
+  std::map<goto_programt::const_targett, goto_state_listt> goto_state_map;
+  symex_targett::sourcet calling_location;
+
+  goto_programt::const_targett end_of_function;
+  exprt return_value = nil_exprt();
+  bool hidden_function = false;
+
+  symex_renaming_levelt::current_namest old_level1;
+
+  std::set<irep_idt> local_objects;
+
+  // exceptions
+  std::map<irep_idt, goto_programt::targett> catch_map;
+
+  // loop and recursion unwinding
+  struct loop_infot
+  {
+    unsigned count = 0;
+    bool is_recursion = false;
+  };
+  std::unordered_map<irep_idt, loop_infot> loop_iterations;
+
+  explicit framet(symex_targett::sourcet _calling_location)
+    : calling_location(std::move(_calling_location))
+  {
+  }
+};
+
 /// Central data structure: state.
 
 /// The state is a persistent data structure that symex maintains as it
@@ -209,40 +246,6 @@ public:
     static irep_idt id = "goto_symex::\\guard";
     return id;
   }
-
-  // stack frames -- these are used for function calls and
-  // for exceptions
-  struct framet
-  {
-    // function calls
-    irep_idt function_identifier;
-    std::map<goto_programt::const_targett, goto_state_listt> goto_state_map;
-    symex_targett::sourcet calling_location;
-
-    goto_programt::const_targett end_of_function;
-    exprt return_value = nil_exprt();
-    bool hidden_function = false;
-
-    symex_renaming_levelt::current_namest old_level1;
-
-    std::set<irep_idt> local_objects;
-
-    // exceptions
-    std::map<irep_idt, goto_programt::targett> catch_map;
-
-    // loop and recursion unwinding
-    struct loop_infot
-    {
-      unsigned count = 0;
-      bool is_recursion = false;
-    };
-    std::unordered_map<irep_idt, loop_infot> loop_iterations;
-
-    explicit framet(symex_targett::sourcet _calling_location)
-      : calling_location(std::move(_calling_location))
-    {
-    }
-  };
 
   typedef std::vector<framet> call_stackt;
 

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -163,9 +163,6 @@ public:
     bool record_value,
     bool allow_pointer_unsoundness=false);
 
-  // undoes all levels of renaming
-  void get_original_name(exprt &expr) const;
-  void get_original_name(typet &type) const;
 protected:
   void rename_address(exprt &expr, const namespacet &ns, levelt level);
 

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -38,7 +38,7 @@ class goto_statet
 {
 public:
   unsigned depth;
-  symex_level2t::current_namest level2_current_names;
+  symex_level2t level2;
   value_sett value_set;
   guardt guard;
   symex_targett::sourcet source;
@@ -46,20 +46,6 @@ public:
   unsigned atomic_section_id;
   std::unordered_map<irep_idt, local_safe_pointerst> safe_pointers;
   unsigned total_vccs, remaining_vccs;
-
-  // the below replicate levelt2 member functions
-  void
-  level2_get_variables(std::unordered_set<ssa_exprt, irep_hash> &vars) const
-  {
-    for(const auto &pair : level2_current_names)
-      vars.insert(pair.second.first);
-  }
-
-  unsigned level2_current_count(const irep_idt &identifier) const
-  {
-    const auto it = level2_current_names.find(identifier);
-    return it == level2_current_names.end() ? 0 : it->second.second;
-  }
 
   goto_statet(const class goto_symex_statet &s);
 };
@@ -234,7 +220,7 @@ public:
       total_vccs(s.total_vccs),
       remaining_vccs(s.remaining_vccs)
   {
-    level2.current_names = s.level2_current_names;
+    level2.current_names = s.level2.current_names;
   }
 
   // gotos
@@ -343,7 +329,7 @@ private:
 
 inline goto_statet::goto_statet(const class goto_symex_statet &s)
   : depth(s.depth),
-    level2_current_names(s.level2.current_names),
+    level2(s.level2),
     value_set(s.value_set),
     guard(s.guard),
     source(s.source),
@@ -354,6 +340,5 @@ inline goto_statet::goto_statet(const class goto_symex_statet &s)
     remaining_vccs(s.remaining_vccs)
 {
 }
-
 
 #endif // CPROVER_GOTO_SYMEX_GOTO_SYMEX_STATE_H

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -202,8 +202,6 @@ public:
 
   // gotos
   typedef std::list<goto_statet> goto_state_listt;
-  typedef std::map<goto_programt::const_targett, goto_state_listt>
-    goto_state_mapt;
 
   // guards
   static irep_idt guard_identifier()
@@ -218,7 +216,7 @@ public:
   {
     // function calls
     irep_idt function_identifier;
-    goto_state_mapt goto_state_map;
+    std::map<goto_programt::const_targett, goto_state_listt> goto_state_map;
     symex_targett::sourcet calling_location;
 
     goto_programt::const_targett end_of_function;

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -238,8 +238,8 @@ public:
     };
     std::unordered_map<irep_idt, loop_infot> loop_iterations;
 
-    explicit framet(const symex_targett::sourcet &_calling_location)
-      : calling_location(_calling_location)
+    explicit framet(symex_targett::sourcet _calling_location)
+      : calling_location(std::move(_calling_location))
     {
     }
   };

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -37,15 +37,16 @@ Author: Daniel Kroening, kroening@kroening.com
 class goto_statet
 {
 public:
-  unsigned depth;
+  unsigned depth = 0;
   symex_level2t level2;
   value_sett value_set;
-  guardt guard;
+  guardt guard{true_exprt{}};
   symex_targett::sourcet source;
   std::map<irep_idt, exprt> propagation;
-  unsigned atomic_section_id;
+  unsigned atomic_section_id = 0;
   std::unordered_map<irep_idt, local_safe_pointerst> safe_pointers;
-  unsigned total_vccs, remaining_vccs;
+  unsigned total_vccs = 0;
+  unsigned remaining_vccs = 0;
 
   goto_statet(const class goto_symex_statet &s);
 };

--- a/src/goto-symex/postcondition.cpp
+++ b/src/goto-symex/postcondition.cpp
@@ -134,7 +134,7 @@ void postconditiont::strengthen(exprt &dest)
       return;
 
     equal_exprt equality(SSA_step.ssa_lhs, SSA_step.ssa_rhs);
-    s.get_original_name(equality);
+    get_original_name(equality);
 
     if(dest.is_true())
       dest.swap(equality);
@@ -173,7 +173,7 @@ bool postconditiont::is_used(
         it++)
     {
       exprt tmp(*it);
-      s.get_original_name(tmp);
+      get_original_name(tmp);
       find_symbols(tmp, symbols);
     }
 

--- a/src/goto-symex/precondition.cpp
+++ b/src/goto-symex/precondition.cpp
@@ -141,7 +141,7 @@ void preconditiont::compute_rec(exprt &dest)
   else if(dest==SSA_step.ssa_lhs.get_original_expr())
   {
     dest=SSA_step.ssa_rhs;
-    s.get_original_name(dest);
+    get_original_name(dest);
   }
   else
     Forall_operands(it, dest)

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -76,3 +76,38 @@ void symex_level1t::restore_from(
     }
   }
 }
+
+void get_original_name(exprt &expr)
+{
+  get_original_name(expr.type());
+
+  if(expr.id() == ID_symbol && expr.get_bool(ID_C_SSA_symbol))
+    expr = to_ssa_expr(expr).get_original_expr();
+  else
+    Forall_operands(it, expr)
+      get_original_name(*it);
+}
+
+void get_original_name(typet &type)
+{
+  // rename all the symbols with their last known value
+
+  if(type.id() == ID_array)
+  {
+    auto &array_type = to_array_type(type);
+    get_original_name(array_type.subtype());
+    get_original_name(array_type.size());
+  }
+  else if(type.id() == ID_struct || type.id() == ID_union)
+  {
+    struct_union_typet &s_u_type = to_struct_union_type(type);
+    struct_union_typet::componentst &components = s_u_type.components();
+
+    for(auto &component : components)
+      get_original_name(component.type());
+  }
+  else if(type.id() == ID_pointer)
+  {
+    get_original_name(to_pointer_type(type).subtype());
+  }
+}

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -86,4 +86,10 @@ struct symex_level2t : public symex_renaming_levelt
   ~symex_level2t() override = default;
 };
 
+/// Undo all levels of renaming
+void get_original_name(exprt &expr);
+
+/// Undo all levels of renaming
+void get_original_name(typet &type);
+
 #endif // CPROVER_GOTO_SYMEX_RENAMING_LEVEL_H

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -260,7 +260,7 @@ void goto_symext::dereference_rec(
       const irep_idt &expr_function = state.source.function_id;
       if(!expr_function.empty())
       {
-        state.get_original_name(to_check);
+        get_original_name(to_check);
 
         expr_is_not_null =
           state.safe_pointers.at(expr_function).is_safe_dereference(

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -297,7 +297,7 @@ void goto_symext::symex_function_call_code(
 
   // produce a new frame
   PRECONDITION(!state.call_stack().empty());
-  goto_symex_statet::framet &frame=state.new_frame();
+  framet &frame = state.new_frame();
 
   // preserve locality of local variables
   locality(identifier, state, goto_function);
@@ -310,7 +310,7 @@ void goto_symext::symex_function_call_code(
   frame.function_identifier=identifier;
   frame.hidden_function=goto_function.is_hidden();
 
-  const goto_symex_statet::framet &p_frame=state.previous_frame();
+  const framet &p_frame = state.previous_frame();
   for(const auto &pair : p_frame.loop_iterations)
   {
     if(pair.second.is_recursion)
@@ -332,7 +332,7 @@ void goto_symext::pop_frame(statet &state)
   PRECONDITION(!state.call_stack().empty());
 
   {
-    statet::framet &frame=state.top();
+    framet &frame = state.top();
 
     // restore program counter
     symex_transition(state, frame.calling_location.pc, false);
@@ -391,7 +391,7 @@ void goto_symext::locality(
 
   get_local_identifiers(goto_function, local_identifiers);
 
-  statet::framet &frame=state.top();
+  framet &frame = state.top();
 
   for(std::set<irep_idt>::const_iterator
       it=local_identifiers.begin();
@@ -443,7 +443,7 @@ void goto_symext::locality(
 
 void goto_symext::return_assignment(statet &state)
 {
-  statet::framet &frame=state.top();
+  framet &frame = state.top();
 
   const goto_programt::instructiont &instruction=*state.source.pc;
   PRECONDITION(instruction.is_return());

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -310,7 +310,7 @@ void goto_symext::merge_gotos(statet &state)
   statet::goto_state_listt &state_list=state_map_it->second;
 
   for(auto list_it = state_list.rbegin(); list_it != state_list.rend();
-      list_it++)
+      ++list_it)
     merge_goto(*list_it, state);
 
   // clean up to save some memory

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -518,7 +518,7 @@ void goto_symext::phi_function(
   statet &dest_state)
 {
   if(
-    goto_state.level2_current_names.empty() &&
+    goto_state.level2.current_names.empty() &&
     dest_state.level2.current_names.empty())
     return;
 
@@ -527,7 +527,7 @@ void goto_symext::phi_function(
   diff_guard -= dest_state.guard;
 
   for_each2(
-    goto_state.level2_current_names,
+    goto_state.level2.current_names,
     dest_state.level2.current_names,
     [&](const ssa_exprt &ssa, unsigned goto_count, unsigned dest_count) {
       merge_names(

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -301,8 +301,7 @@ void goto_symext::merge_gotos(statet &state)
   statet::framet &frame=state.top();
 
   // first, see if this is a target at all
-  statet::goto_state_mapt::iterator state_map_it=
-    frame.goto_state_map.find(state.source.pc);
+  auto state_map_it = frame.goto_state_map.find(state.source.pc);
 
   if(state_map_it==frame.goto_state_map.end())
     return; // nothing to do
@@ -310,9 +309,7 @@ void goto_symext::merge_gotos(statet &state)
   // we need to merge
   statet::goto_state_listt &state_list=state_map_it->second;
 
-  for(statet::goto_state_listt::reverse_iterator
-      list_it=state_list.rbegin();
-      list_it!=state_list.rend();
+  for(auto list_it = state_list.rbegin(); list_it != state_list.rend();
       list_it++)
     merge_goto(*list_it, state);
 

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -220,7 +220,7 @@ void goto_symext::symex_goto(statet &state)
   statet::goto_state_listt &goto_state_list=
     state.top().goto_state_map[new_state_pc];
 
-  goto_state_list.push_back(statet::goto_statet(state));
+  goto_state_list.emplace_back(state);
 
   symex_transition(state, state_pc, backward);
 
@@ -281,7 +281,7 @@ void goto_symext::symex_goto(statet &state)
     }
     else
     {
-      statet::goto_statet &new_state = goto_state_list.back();
+      goto_statet &new_state = goto_state_list.back();
       if(!backward)
       {
         new_state.guard.add(guard_expr);
@@ -320,9 +320,7 @@ void goto_symext::merge_gotos(statet &state)
   frame.goto_state_map.erase(state_map_it);
 }
 
-void goto_symext::merge_goto(
-  const statet::goto_statet &goto_state,
-  statet &state)
+void goto_symext::merge_goto(const goto_statet &goto_state, statet &state)
 {
   // check atomic section
   if(state.atomic_section_id != goto_state.atomic_section_id)
@@ -342,9 +340,7 @@ void goto_symext::merge_goto(
   state.depth=std::min(state.depth, goto_state.depth);
 }
 
-void goto_symext::merge_value_sets(
-  const statet::goto_statet &src,
-  statet &dest)
+void goto_symext::merge_value_sets(const goto_statet &src, statet &dest)
 {
   if(dest.guard.is_false())
   {
@@ -403,7 +399,7 @@ static void for_each2(
 ///   \p l1_identifier
 /// \param dest_count: level 2 count in \p dest_state of \p l1_identifier
 static void merge_names(
-  const goto_symext::statet::goto_statet &goto_state,
+  const goto_statet &goto_state,
   goto_symext::statet &dest_state,
   const namespacet &ns,
   const guardt &diff_guard,
@@ -521,7 +517,7 @@ static void merge_names(
 }
 
 void goto_symext::phi_function(
-  const statet::goto_statet &goto_state,
+  const goto_statet &goto_state,
   statet &dest_state)
 {
   if(

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -25,7 +25,7 @@ Author: Daniel Kroening, kroening@kroening.com
 void goto_symext::symex_goto(statet &state)
 {
   const goto_programt::instructiont &instruction=*state.source.pc;
-  statet::framet &frame=state.top();
+  framet &frame = state.top();
 
   if(state.guard.is_false())
   {
@@ -217,7 +217,7 @@ void goto_symext::symex_goto(statet &state)
   }
 
   // put into state-queue
-  statet::goto_state_listt &goto_state_list=
+  framet::goto_state_listt &goto_state_list =
     state.top().goto_state_map[new_state_pc];
 
   goto_state_list.emplace_back(state);
@@ -298,7 +298,7 @@ void goto_symext::symex_goto(statet &state)
 
 void goto_symext::merge_gotos(statet &state)
 {
-  statet::framet &frame=state.top();
+  framet &frame = state.top();
 
   // first, see if this is a target at all
   auto state_map_it = frame.goto_state_map.find(state.source.pc);
@@ -307,7 +307,7 @@ void goto_symext::merge_gotos(statet &state)
     return; // nothing to do
 
   // we need to merge
-  statet::goto_state_listt &state_list=state_map_it->second;
+  framet::goto_state_listt &state_list = state_map_it->second;
 
   for(auto list_it = state_list.rbegin(); list_it != state_list.rend();
       ++list_it)

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -53,7 +53,7 @@ void symex_transition(
     // 1. the transition from state.source.pc to "to" is not a backwards goto
     // or
     // 2. we are arriving from an outer loop
-    goto_symext::statet::framet &frame = state.top();
+    framet &frame = state.top();
     const goto_programt::instructiont &instruction=*to;
     for(const auto &i_e : instruction.incoming_edges)
       if(i_e->is_goto() && i_e->is_backwards_goto() &&

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -50,7 +50,7 @@ void goto_symext::symex_start_thread(statet &state)
   #endif
 
   // create a copy of the local variables for the new thread
-  statet::framet &frame=state.top();
+  framet &frame = state.top();
 
   for(auto c_it = state.level2.current_names.begin();
       c_it != state.level2.current_names.end();


### PR DESCRIPTION
The definition of `goto_symex_statet` is long (about 250 lines) and it is difficult to see any structure in it. This PR extracts some bits from it with the aim to make it clearer. It ends up being ~140~ 100 lines which is a bit better but still not great. 
I apologize in advance if this makes it more difficult to rebase some of your branches without really fixing anything, but I find it extremely difficult to understand what this class is doing, so it seems necessary. 

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
