### PR TITLE
Base-type-eq: check pointer types really match [blocks: #4023]

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1554,12 +1554,10 @@ code_blockt java_bytecode_convert_methodt::convert_instructions(
       const bool is_assertions_disabled_field=
         field_name.find("$assertionsDisabled")!=std::string::npos;
 
+      const irep_idt field_id(
+        get_static_field(arg0.get_string(ID_class), field_name));
       const symbol_exprt symbol_expr(
-        get_static_field(arg0.get_string(ID_class), field_name), arg0.type());
-
-      INVARIANT(
-        symbol_table.has_symbol(symbol_expr.get_identifier()),
-        "getstatic symbol should have been created before method conversion");
+        symbol_table.lookup_ref(field_id).symbol_expr());
 
       convert_getstatic(
         arg0, symbol_expr, is_assertions_disabled_field, c, results);
@@ -1574,12 +1572,10 @@ code_blockt java_bytecode_convert_methodt::convert_instructions(
       PRECONDITION(op.size() == 1 && results.empty());
       const auto &field_name=arg0.get_string(ID_component_name);
 
+      const irep_idt field_id(
+        get_static_field(arg0.get_string(ID_class), field_name));
       const symbol_exprt symbol_expr(
-        get_static_field(arg0.get_string(ID_class), field_name), arg0.type());
-
-      INVARIANT(
-        symbol_table.has_symbol(symbol_expr.get_identifier()),
-        "putstatic symbol should have been created before method conversion");
+        symbol_table.lookup_ref(field_id).symbol_expr());
 
       c = convert_putstatic(i_it->source_location, arg0, op, symbol_expr);
     }

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -238,7 +238,7 @@ exprt goto_symext::address_arithmetic(
 
   const typet &expr_type = expr.type();
   INVARIANT((expr_type.id()==ID_array && !keep_array) ||
-            base_type_eq(pointer_type(expr_type), result.type(), ns),
+            base_type_eq(expr_type, result.type().subtype(), ns),
             "either non-persistent array or pointer to result");
 
   return result;

--- a/src/util/base_type.cpp
+++ b/src/util/base_type.cpp
@@ -253,6 +253,34 @@ bool base_type_eqt::base_type_eq_rec(
   }
   else if(type1.id()==ID_pointer)
   {
+    // Types dervied from pointer, such as java_generic_parametert, may have
+    // qualifiers given as named subexpressions:
+    const auto &named_subs1 = type1.get_named_sub();
+    const auto &named_subs2 = type2.get_named_sub();
+
+    for(const auto &name_and_sub : named_subs1)
+    {
+      if(irept::is_comment(name_and_sub.first))
+        continue;
+      auto other_sub = named_subs2.find(name_and_sub.first);
+      if(
+        other_sub == named_subs2.end() ||
+        name_and_sub.second != other_sub->second)
+      {
+        return false;
+      }
+    }
+
+    for(const auto &name_and_sub : named_subs2)
+    {
+      if(irept::is_comment(name_and_sub.first))
+        continue;
+      auto other_sub = named_subs1.find(name_and_sub.first);
+      // Equality already checked above
+      if(other_sub == named_subs1.end())
+        return false;
+    }
+
     return base_type_eq_rec(
       to_pointer_type(type1).subtype(), to_pointer_type(type2).subtype());
   }


### PR DESCRIPTION
Generally base-type-eq's task is to ensure that types match up to substitution of a type's body for a symbol referring to that type. However now that derivatives of pointers exist with named subexpressions (e.g. java_generic_parametert), it is now possible for types not involving symbols to be `base_type_eq` but not `==`. This resolves that particular case by checking that the names subexpressions match exactly.