### PR TITLE
Include tags in type-to-identifier conversion

### DIFF
--- a/regression/ansi-c/anonymous_union1/main.c
+++ b/regression/ansi-c/anonymous_union1/main.c
@@ -1,0 +1,20 @@
+int main()
+{
+  typedef struct onet
+  {
+    union {
+      struct onet *next;
+    } abc;
+  } onet;
+
+  typedef struct twot
+  {
+    union {
+      struct twot *next;
+    } xyz;
+  } twot;
+  twot two;
+
+  two.xyz.next->xyz.next = 0;
+  return 0;
+}

--- a/regression/ansi-c/anonymous_union1/test.desc
+++ b/regression/ansi-c/anonymous_union1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/src/ansi-c/type2name.cpp
+++ b/src/ansi-c/type2name.cpp
@@ -44,40 +44,25 @@ static std::string type2name_tag(
      symbol->type.id()!=ID_union)
     return type2name(symbol->type, ns, symbol_number);
 
-  std::string result;
-
   // assign each symbol a number when seen for the first time
   std::pair<symbol_numbert::iterator, bool> entry=
     symbol_number.insert(std::make_pair(
         identifier,
         std::make_pair(symbol_number.size(), true)));
 
+  std::string result = "SYM" +
+                       id2string(to_struct_union_type(symbol->type).get_tag()) +
+                       '#' + std::to_string(entry.first->second.first);
+
   // new entry, add definition
   if(entry.second)
   {
-    result="SYM#"+std::to_string(entry.first->second.first);
     result+="={";
     result+=type2name(symbol->type, ns, symbol_number);
     result+='}';
 
     entry.first->second.second=false;
   }
-#if 0
-  // in recursion, print the shorthand only
-  else if(entry.first->second.second)
-    result="SYM#"+std::to_string(entry.first->second.first);
-  // entering recursion
-  else
-  {
-    entry.first->second.second=true;
-    result=type2name(symbol->type, ns, symbol_number);
-    entry.first->second.second=false;
-  }
-#else
-  // shorthand only as structs/unions are always symbols
-  else
-    result="SYM#"+std::to_string(entry.first->second.first);
-#endif
 
   return result;
 }


### PR DESCRIPTION
Within the same translation unit multiple incomplete structs/unions with
different names (tags) must be distinguished. Symbol numbering helps to keep
untagged types unique, but for tagged ones we need to take their names into
account.

Fixes: #4019

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
