### PR TITLE
use goto_programt::make_X() to create instructions [blocks: #4030]

### DIFF
--- a/src/analyses/flow_insensitive_analysis.cpp
+++ b/src/analyses/flow_insensitive_analysis.cpp
@@ -213,13 +213,12 @@ bool flow_insensitive_analysis_baset::do_function_call(
     exprt rhs =
       side_effect_expr_nondett(code.lhs().type(), l_call->source_location);
 
-    goto_programt::targett r=temp.add_instruction();
-    r->make_return();
-    r->code=code_returnt(rhs);
+    goto_programt::targett r =
+      temp.add(goto_programt::make_return(code_returnt(rhs)));
     r->function=f_it->first;
     r->location_number=0;
 
-    goto_programt::targett t=temp.add_instruction(END_FUNCTION);
+    goto_programt::targett t = temp.add(goto_programt::make_end_function());
     t->function=f_it->first;
     t->location_number=1;
 

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1834,7 +1834,6 @@ void goto_checkt::goto_check(
         if(local_bitvector_analysis->dirty(variable))
         {
           // need to mark the dead variable as dead
-          goto_programt::targett t=new_code.add_instruction(ASSIGN);
           exprt address_of_expr=address_of_exprt(variable);
           exprt lhs=ns.lookup(CPROVER_PREFIX "dead_object").symbol_expr();
           address_of_expr =
@@ -1844,8 +1843,9 @@ void goto_checkt::goto_check(
             address_of_expr,
             lhs,
             lhs.type());
-          t->source_location=i.source_location;
-          t->code=code_assignt(lhs, rhs);
+          goto_programt::targett t =
+            new_code.add(goto_programt::make_assignment(
+              code_assignt(lhs, rhs), i.source_location));
           t->code.add_source_location()=i.source_location;
         }
       }
@@ -1860,9 +1860,8 @@ void goto_checkt::goto_check(
         const symbol_exprt leak_expr=leak.symbol_expr();
 
         // add self-assignment to get helpful counterexample output
-        goto_programt::targett t=new_code.add_instruction();
-        t->make_assignment();
-        t->code=code_assignt(leak_expr, leak_expr);
+        new_code.add(
+          goto_programt::make_assignment(code_assignt(leak_expr, leak_expr)));
 
         source_locationt source_location;
         source_location.set_function(function_identifier);

--- a/src/goto-instrument/havoc_loops.cpp
+++ b/src/goto-instrument/havoc_loops.cpp
@@ -95,10 +95,9 @@ void havoc_loopst::build_havoc_code(
     exprt rhs =
       side_effect_expr_nondett(lhs.type(), loop_head->source_location);
 
-    goto_programt::targett t=dest.add_instruction(ASSIGN);
+    goto_programt::targett t = dest.add(goto_programt::make_assignment(
+      code_assignt(lhs, rhs), loop_head->source_location));
     t->function=loop_head->function;
-    t->source_location=loop_head->source_location;
-    t->code=code_assignt(lhs, rhs);
     t->code.add_source_location()=loop_head->source_location;
   }
 }

--- a/src/goto-instrument/loop_utils.cpp
+++ b/src/goto-instrument/loop_utils.cpp
@@ -48,10 +48,9 @@ void build_havoc_code(
     exprt rhs =
       side_effect_expr_nondett(lhs.type(), loop_head->source_location);
 
-    goto_programt::targett t=dest.add_instruction(ASSIGN);
+    goto_programt::targett t = dest.add(goto_programt::make_assignment(
+      code_assignt(lhs, rhs), loop_head->source_location));
     t->function=loop_head->function;
-    t->source_location=loop_head->source_location;
-    t->code=code_assignt(lhs, rhs);
     t->code.add_source_location()=loop_head->source_location;
   }
 }


### PR DESCRIPTION
This avoids repeated initialization.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
