### PR TITLE
Add try_dynamic_cast from rvalue to `optionalt`

### DIFF
--- a/src/util/expr_cast.h
+++ b/src/util/expr_cast.h
@@ -107,6 +107,32 @@ auto expr_try_dynamic_cast(TExpr &base)
   return ret;
 }
 
+/// \brief Try to cast a generic exprt to a specific derived class.
+/// \tparam T: The type to cast the \p base param to.
+/// \tparam TType: The original type to cast from, must be a exprt rvalue.
+/// \param base: A generic \ref exprt rvalue.
+/// \return Cast value in an optionalt<T> or empty if \a base is not an instance
+///         of T.
+template <typename T, typename TExpr>
+optionalt<T> expr_try_dynamic_cast(TExpr &&base)
+{
+  static_assert(
+    std::is_rvalue_reference<decltype(base)>::value,
+    "This template overload must only match where base is an rvalue.");
+  static_assert(
+    std::is_base_of<exprt, typename std::decay<TExpr>::type>::value,
+    "Tried to expr_try_dynamic_cast from something that wasn't an exprt.");
+  static_assert(
+    std::is_base_of<exprt, T>::value,
+    "The template argument T must be derived from exprt.");
+  static_assert(!std::is_const<TExpr>::value, "Attempted to move from const.");
+  if(!can_cast_expr<T>(base))
+    return {};
+  optionalt<T> ret{static_cast<T &&>(base)};
+  validate_expr(*ret);
+  return ret;
+}
+
 /// \brief Try to cast a reference to a generic typet to a specific derived
 ///   class
 /// \tparam T: The reference or const reference type to \a TUnderlying to cast
@@ -130,6 +156,32 @@ auto type_try_dynamic_cast(TType &base) ->
   if(!can_cast_type<typename std::remove_const<T>::type>(base))
     return nullptr;
   const auto ret = static_cast<returnt>(&base);
+  validate_type(*ret);
+  return ret;
+}
+
+/// \brief Try to cast a generic typet to a specific derived class.
+/// \tparam T: The type to cast the \p base param to.
+/// \tparam TType: The original type to cast from, must be a typet rvalue.
+/// \param base: A generic \ref typet rvalue.
+/// \return Cast value in an optionalt<T> or empty if \a base is not an instance
+///         of T.
+template <typename T, typename TType>
+optionalt<T> type_try_dynamic_cast(TType &&base)
+{
+  static_assert(
+    std::is_rvalue_reference<decltype(base)>::value,
+    "This template overload must only match where base is an rvalue.");
+  static_assert(
+    std::is_base_of<typet, typename std::decay<TType>::type>::value,
+    "Tried to type_try_dynamic_cast from something that wasn't an typet.");
+  static_assert(
+    std::is_base_of<typet, T>::value,
+    "The template argument T must be derived from typet.");
+  static_assert(!std::is_const<TType>::value, "Attempted to move from const.");
+  if(!can_cast_type<T>(base))
+    return {};
+  optionalt<T> ret{static_cast<T &&>(base)};
   validate_type(*ret);
   return ret;
 }

--- a/unit/util/expr_cast/expr_cast.cpp
+++ b/unit/util/expr_cast/expr_cast.cpp
@@ -25,6 +25,13 @@ SCENARIO("expr_dynamic_cast",
   {
     const exprt &expr=symbol_expr;
 
+    // Check pointer overload is used, when casting from reference.
+    static_assert(
+      std::is_same<
+        decltype(expr_try_dynamic_cast<symbol_exprt>(expr)),
+        const symbol_exprt *>::value,
+      "expr_try_dynamic_cast on a reference parameter must return a pointer.");
+
     THEN("Try-casting from exprt reference to symbol_exprt pointer "
          "returns a value")
     {
@@ -95,6 +102,126 @@ SCENARIO("expr_dynamic_cast",
       "should be fine")
     {
       REQUIRE_NOTHROW(expr_dynamic_cast<symbol_exprt>(expr_ref));
+    }
+  }
+  GIVEN("An exprt value upcast from a symbolt")
+  {
+    exprt expr = symbol_exprt{};
+
+    THEN(
+      "Trying casting from an exprt lvalue to a symbol_exprt should yield a "
+      "non null pointer.")
+    {
+      symbol_exprt *result = expr_try_dynamic_cast<symbol_exprt>(expr);
+      REQUIRE(result != nullptr);
+    }
+
+    THEN(
+      "Trying casting from an exprt lvalue to a transt should yield a null "
+      "pointer.")
+    {
+      transt *result = expr_try_dynamic_cast<transt>(expr);
+      REQUIRE(result == nullptr);
+    }
+
+    THEN(
+      "Trying casting from an exprt rvalue reference to a symbol_exprt should "
+      "yield a non empty optional.")
+    {
+      optionalt<symbol_exprt> result =
+        expr_try_dynamic_cast<symbol_exprt>(std::move(expr));
+      REQUIRE(result.has_value());
+    }
+
+    THEN(
+      "Trying casting from an exprt rvalue reference to a transt should yield "
+      "a empty optional.")
+    {
+      optionalt<transt> result = expr_try_dynamic_cast<transt>(std::move(expr));
+      REQUIRE_FALSE(result.has_value());
+    }
+  }
+}
+
+SCENARIO("type_dynamic_cast", "[core][utils][expr_cast][type_dynamic_cast]")
+{
+  string_typet string_type;
+  GIVEN("A typet value upcast from a string_typet")
+  {
+    typet type = string_type;
+
+    THEN(
+      "Trying casting from a typet lvalue to a string_typet should yield a non "
+      "null pointer.")
+    {
+      string_typet *result = type_try_dynamic_cast<string_typet>(type);
+      REQUIRE(result != nullptr);
+    }
+
+    THEN(
+      "Trying casting from a typet lvalue to a struct_typet should yield a "
+      "null pointer.")
+    {
+      struct_typet *result = type_try_dynamic_cast<struct_typet>(type);
+      REQUIRE(result == nullptr);
+    }
+
+    THEN(
+      "Trying casting from a typet rvalue reference to a symbol_exprt should "
+      "yield a non empty optional.")
+    {
+      optionalt<string_typet> result =
+        type_try_dynamic_cast<string_typet>(std::move(type));
+      REQUIRE(result.has_value());
+    }
+
+    THEN(
+      "Trying casting from a typet rvalue reference to a struct_typet should "
+      "yield a empty optional.")
+    {
+      optionalt<struct_typet> result =
+        type_try_dynamic_cast<struct_typet>(std::move(type));
+      REQUIRE_FALSE(result.has_value());
+    }
+  }
+  GIVEN("A const typet reference upcast from a string_typet")
+  {
+    const typet &type = string_type;
+
+    THEN(
+      "Trying casting from a const reference to a string_typet should yield a "
+      "non null pointer to const.")
+    {
+      const string_typet *result = type_try_dynamic_cast<string_typet>(type);
+      REQUIRE(result != nullptr);
+    }
+
+    THEN(
+      "Trying casting from a const reference to a struct_typet should yield a "
+      "null pointer to const.")
+    {
+      const struct_typet *result = type_try_dynamic_cast<struct_typet>(type);
+      REQUIRE(result == nullptr);
+    }
+  }
+  GIVEN("A typet reference upcast from a string_typet")
+  {
+    typet &type = string_type;
+
+    THEN(
+      "Trying casting from a reference to a string_typet should yield a non "
+      "null pointer.")
+    {
+      string_typet *result = type_try_dynamic_cast<string_typet>(type);
+      REQUIRE(result != nullptr);
+    }
+
+    THEN(
+      "Trying casting from a reference to a struct_typet should yield a null "
+      "pointer.")
+    {
+      struct_typet *result = type_try_dynamic_cast<struct_typet>(type);
+      REQUIRE(result == nullptr);
     }
   }
 }


### PR DESCRIPTION
This pr adds templates for `expr_try_dynamic_cast` and
`type_try_dynamic_cast` where the parameter is an rvalue and the return
type is an `optionalt`. This is implemented by moving the parameter into
the `optionalt`.

Included are unit tests of the new templates, which show that they
return the types and values expected. As well as tests and a static
assert for the existing overloads which show that they still return a
pointer.

These new templates are useful in the case where we are using the
result of a function, which returns by value but only in the case where
the value can be cast to a given type. For example with the new
overloads the following code can be written -
```
exprt enig();
void handle_struct_case(const struct_exprt &struct_expr);

void myFunction()
{
  if(const auto my_struct = expr_try_dynamic_cast<struct_exprt>(enig()))
    handle_struct_case(*my_struct);
}
```
However without the new templates and because the old ones do not bind
to rvalues, an additional temporary variable otherwise would have to be
declared -
```
void myFunction2()
{
  const exprt enigma = enig();
  if(const auto my_struct = expr_try_dynamic_cast<struct_exprt>(enigma))
    handle_struct_case(*my_struct);
}
```

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
