### PR TITLE
Fix typos in comments in `solvers`

### DIFF
--- a/src/solvers/floatbv/float_bv.cpp
+++ b/src/solvers/floatbv/float_bv.cpp
@@ -655,7 +655,7 @@ exprt float_bvt::div(
     from_integer(0, unsignedbv_typet(div_width - fraction_width)),
     unsignedbv_typet(div_width));
 
-  // zero-extend fraction2 to match faction1
+  // zero-extend fraction2 to match fraction1
   const typecast_exprt fraction2(unpacked2.fraction, fraction1.type());
 
   // divide fractions
@@ -864,7 +864,7 @@ void float_bvt::normalization_shift(
 {
   // n-log-n alignment shifter.
   // The worst-case shift is the number of fraction
-  // bits minus one, in case the faction is one exactly.
+  // bits minus one, in case the fraction is one exactly.
   std::size_t fraction_bits=to_unsignedbv_type(fraction.type()).get_width();
   std::size_t exponent_bits=to_signedbv_type(exponent.type()).get_width();
   PRECONDITION(fraction_bits != 0);

--- a/src/solvers/floatbv/float_utils.cpp
+++ b/src/solvers/floatbv/float_utils.cpp
@@ -785,7 +785,7 @@ void float_utilst::normalization_shift(bvt &fraction, bvt &exponent)
 
   // n-log-n alignment shifter.
   // The worst-case shift is the number of fraction
-  // bits minus one, in case the faction is one exactly.
+  // bits minus one, in case the fraction is one exactly.
   PRECONDITION(!fraction.empty());
   std::size_t depth = address_bits(fraction.size() - 1);
 

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -2043,7 +2043,7 @@ void smt2_convt::convert_typecast(const typecast_exprt &expr)
 
       out << " (ite (and ";
 
-      // some faction bit is not zero
+      // some fraction bit is not zero
       out << "(not (= ((_ extract " << (from_fraction_bits-1) << " 0) ?tcop) "
              "(_ bv0 " << from_fraction_bits << ")))";
 


### PR DESCRIPTION
- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
