### PR TITLE
Remove useless temporaries

### DIFF
--- a/src/analyses/flow_insensitive_analysis.cpp
+++ b/src/analyses/flow_insensitive_analysis.cpp
@@ -210,11 +210,9 @@ bool flow_insensitive_analysis_baset::do_function_call(
 
     goto_programt temp;
 
-    exprt rhs =
-      side_effect_expr_nondett(code.lhs().type(), l_call->source_location);
+    goto_programt::targett r = temp.add(goto_programt::make_return(code_returnt(
+      side_effect_expr_nondett(code.lhs().type(), l_call->source_location))));
 
-    goto_programt::targett r =
-      temp.add(goto_programt::make_return(code_returnt(rhs)));
     r->function=f_it->first;
     r->location_number=0;
 

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1834,18 +1834,16 @@ void goto_checkt::goto_check(
         if(local_bitvector_analysis->dirty(variable))
         {
           // need to mark the dead variable as dead
-          exprt address_of_expr=address_of_exprt(variable);
           exprt lhs=ns.lookup(CPROVER_PREFIX "dead_object").symbol_expr();
-          address_of_expr =
-            typecast_exprt::conditional_cast(address_of_expr, lhs.type());
-          const if_exprt rhs(
+          exprt address_of_expr = typecast_exprt::conditional_cast(
+            address_of_exprt(variable), lhs.type());
+          if_exprt rhs(
             side_effect_expr_nondett(bool_typet(), i.source_location),
-            address_of_expr,
-            lhs,
-            lhs.type());
+            std::move(address_of_expr),
+            lhs);
           goto_programt::targett t =
             new_code.add(goto_programt::make_assignment(
-              code_assignt(lhs, rhs), i.source_location));
+              code_assignt(std::move(lhs), std::move(rhs)), i.source_location));
           t->code.add_source_location()=i.source_location;
         }
       }

--- a/src/goto-instrument/loop_utils.cpp
+++ b/src/goto-instrument/loop_utils.cpp
@@ -45,11 +45,11 @@ void build_havoc_code(
       m_it++)
   {
     exprt lhs=*m_it;
-    exprt rhs =
-      side_effect_expr_nondett(lhs.type(), loop_head->source_location);
+    side_effect_expr_nondett rhs(lhs.type(), loop_head->source_location);
 
     goto_programt::targett t = dest.add(goto_programt::make_assignment(
-      code_assignt(lhs, rhs), loop_head->source_location));
+      code_assignt(std::move(lhs), std::move(rhs)),
+      loop_head->source_location));
     t->function=loop_head->function;
     t->code.add_source_location()=loop_head->source_location;
   }


### PR DESCRIPTION
When reviewing #4025 I noticed some basic cleanup opportunities. Just review the second commit, the first commit is #4025. 

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
