### PR TITLE
Remove code copies in havoc_loops

### DIFF
--- a/src/goto-instrument/function_modifies.cpp
+++ b/src/goto-instrument/function_modifies.cpp
@@ -13,34 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/std_expr.h>
 
-void function_modifiest::get_modifies_lhs(
-  const local_may_aliast &local_may_alias,
-  const goto_programt::const_targett t,
-  const exprt &lhs,
-  modifiest &modifies)
-{
-  if(lhs.id()==ID_symbol)
-    modifies.insert(lhs);
-  else if(lhs.id()==ID_dereference)
-  {
-    modifiest m=local_may_alias.get(t, to_dereference_expr(lhs).pointer());
-    for(modifiest::const_iterator m_it=m.begin();
-        m_it!=m.end(); m_it++)
-      get_modifies_lhs(local_may_alias, t, *m_it, modifies);
-  }
-  else if(lhs.id()==ID_member)
-  {
-  }
-  else if(lhs.id()==ID_index)
-  {
-  }
-  else if(lhs.id()==ID_if)
-  {
-    get_modifies_lhs(local_may_alias, t, to_if_expr(lhs).true_case(), modifies);
-    get_modifies_lhs(
-      local_may_alias, t, to_if_expr(lhs).false_case(), modifies);
-  }
-}
+#include "loop_utils.h"
 
 void function_modifiest::get_modifies(
   const local_may_aliast &local_may_alias,

--- a/src/goto-instrument/function_modifies.h
+++ b/src/goto-instrument/function_modifies.h
@@ -30,12 +30,6 @@ public:
     const goto_programt::const_targett,
     modifiest &);
 
-  void get_modifies_lhs(
-    const local_may_aliast &,
-    const goto_programt::const_targett,
-    const exprt &lhs,
-    modifiest &);
-
   void get_modifies_function(
     const exprt &,
     modifiest &);

--- a/src/goto-instrument/loop_utils.cpp
+++ b/src/goto-instrument/loop_utils.cpp
@@ -55,7 +55,7 @@ void build_havoc_code(
   }
 }
 
-static void get_modifies_lhs(
+void get_modifies_lhs(
   const local_may_aliast &local_may_alias,
   goto_programt::const_targett t,
   const exprt &lhs,

--- a/src/goto-instrument/loop_utils.h
+++ b/src/goto-instrument/loop_utils.h
@@ -24,6 +24,12 @@ void get_modifies(
   const loopt &loop,
   modifiest &modifies);
 
+void get_modifies_lhs(
+  const local_may_aliast &local_may_alias,
+  goto_programt::const_targett t,
+  const exprt &lhs,
+  modifiest &modifies);
+
 void build_havoc_code(
   const goto_programt::targett loop_head,
   const modifiest &modifies,


### PR DESCRIPTION
There were literal copies of functions, and some functions using copies of other
functions as the loop body. No changes in behaviour.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
-  n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
