### PR TITLE
value_set*: remove unused second parameter of add_var

### DIFF
--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -1264,7 +1264,7 @@ void value_set_fit::do_function_call(
   {
     const std::string identifier="value_set::" + id2string(function) + "::" +
                                  "argument$"+std::to_string(i);
-    add_var(identifier, "");
+    add_var(identifier);
     const symbol_exprt dummy_lhs(identifier, arguments[i].type());
     assign(dummy_lhs, arguments[i], ns);
   }
@@ -1282,7 +1282,7 @@ void value_set_fit::do_function_call(
     if(identifier.empty())
       continue;
 
-    add_var(identifier, "");
+    add_var(identifier);
 
     const exprt v_expr=
       symbol_exprt("value_set::" + id2string(function) + "::" +

--- a/src/pointer-analysis/value_set_fi.h
+++ b/src/pointer-analysis/value_set_fi.h
@@ -217,9 +217,9 @@ public:
     values.clear();
   }
 
-  void add_var(const idt &id, const std::string &suffix)
+  void add_var(const idt &id)
   {
-    get_entry(id, suffix);
+    get_entry(id, "");
   }
 
   void add_var(const entryt &e)

--- a/src/pointer-analysis/value_set_fivr.cpp
+++ b/src/pointer-analysis/value_set_fivr.cpp
@@ -1404,7 +1404,7 @@ void value_set_fivrt::do_function_call(
   {
     const std::string identifier="value_set::" + id2string(function) + "::" +
                                  "argument$"+std::to_string(i);
-    add_var(identifier, "");
+    add_var(identifier);
     const symbol_exprt dummy_lhs(identifier, arguments[i].type());
 
     assign(dummy_lhs, arguments[i], ns, true);
@@ -1429,10 +1429,10 @@ void value_set_fivrt::do_function_call(
       it++)
   {
     const irep_idt &identifier=it->get_identifier();
-    if(identifier=="")
+    if(identifier.empty())
       continue;
 
-    add_var(identifier, "");
+    add_var(identifier);
 
     const exprt v_expr=
       symbol_exprt("value_set::" + id2string(function) + "::" +

--- a/src/pointer-analysis/value_set_fivr.h
+++ b/src/pointer-analysis/value_set_fivr.h
@@ -247,9 +247,9 @@ public:
     values.clear();
   }
 
-  void add_var(const idt &id, const std::string &suffix)
+  void add_var(const idt &id)
   {
-    get_entry(id, suffix);
+    get_entry(id, "");
   }
 
   void add_var(const entryt &e)

--- a/src/pointer-analysis/value_set_fivrns.cpp
+++ b/src/pointer-analysis/value_set_fivrns.cpp
@@ -1065,7 +1065,7 @@ void value_set_fivrnst::do_function_call(
   {
     const std::string identifier="value_set::" + id2string(function) + "::" +
                                  "argument$"+std::to_string(i);
-    add_var(identifier, "");
+    add_var(identifier);
     const symbol_exprt dummy_lhs(identifier, arguments[i].type());
 
     assign(dummy_lhs, arguments[i], ns, true);
@@ -1090,10 +1090,10 @@ void value_set_fivrnst::do_function_call(
       it++)
   {
     const irep_idt &identifier=it->get_identifier();
-    if(identifier=="")
+    if(identifier.empty())
       continue;
 
-    add_var(identifier, "");
+    add_var(identifier);
 
     const exprt v_expr=
       symbol_exprt("value_set::" + id2string(function) + "::" +
@@ -1114,7 +1114,7 @@ void value_set_fivrnst::do_end_function(
 
   irep_idt rvs = std::string("value_set::return_value") +
                  std::to_string(from_function);
-  add_var(rvs, "");
+  add_var(rvs);
   symbol_exprt rhs(rvs, lhs.type());
 
   assign(lhs, rhs, ns);
@@ -1187,7 +1187,7 @@ void value_set_fivrnst::apply_code(
     {
       irep_idt rvs = std::string("value_set::return_value") +
                      std::to_string(from_function);
-      add_var(rvs, "");
+      add_var(rvs);
       symbol_exprt lhs(rvs, code.op0().type());
       assign(lhs, code.op0(), ns);
     }

--- a/src/pointer-analysis/value_set_fivrns.h
+++ b/src/pointer-analysis/value_set_fivrns.h
@@ -239,9 +239,9 @@ public:
     values.clear();
   }
 
-  void add_var(const idt &id, const std::string &suffix)
+  void add_var(const idt &id)
   {
-    get_entry(id, suffix);
+    get_entry(id, "");
   }
 
   void add_var(const entryt &e)


### PR DESCRIPTION
All calls pass in the empty string as second argument.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
