### PR TITLE
get_code: return std::string by value

### DIFF
--- a/src/goto-instrument/document_properties.cpp
+++ b/src/goto-instrument/document_properties.cpp
@@ -57,9 +57,7 @@ private:
 
   static void strip_space(std::list<linet> &lines);
 
-  void get_code(
-    const source_locationt &source_location,
-    std::string &dest);
+  std::string get_code(const source_locationt &source_location);
 
   struct doc_claimt
   {
@@ -148,26 +146,25 @@ bool is_empty(const std::string &s)
   return true;
 }
 
-void document_propertiest::get_code(
-  const source_locationt &source_location,
-  std::string &dest)
+std::string
+document_propertiest::get_code(const source_locationt &source_location)
 {
-  dest="";
-
   const irep_idt &file=source_location.get_file();
   const irep_idt &source_line = source_location.get_line();
 
-  if(file == "" || source_line == "")
-    return;
+  if(file.empty() || source_line.empty())
+    return "";
 
   std::ifstream in(id2string(file));
+
+  std::string dest;
 
   if(!in)
   {
     dest+="ERROR: unable to open ";
     dest+=id2string(file);
     dest+="\n";
-    return;
+    return dest;
   }
 
   int line_int = unsafe_string2int(id2string(source_line));
@@ -268,6 +265,8 @@ void document_propertiest::get_code(
 
     dest+=tmp+"\n";
   }
+
+  return dest;
 }
 
 void document_propertiest::doit()
@@ -298,10 +297,9 @@ void document_propertiest::doit()
   for(claim_sett::const_iterator it=claim_set.begin();
       it!=claim_set.end(); it++)
   {
-    std::string code;
     const source_locationt &source_location=it->first;
 
-    get_code(source_location, code);
+    std::string code = get_code(source_location);
 
     switch(format)
     {


### PR DESCRIPTION
This simplifies the contract and code, and should be at least as efficient in
C++11.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
