### PR TITLE
invariant set to_string: remove unused second parameter

### DIFF
--- a/src/analyses/invariant_set.cpp
+++ b/src/analyses/invariant_set.cpp
@@ -29,7 +29,7 @@ Author: Daniel Kroening, kroening@kroening.com
 void inv_object_storet::output(std::ostream &out) const
 {
   for(std::size_t i=0; i<entries.size(); i++)
-    out << "STORE " << i << ": " << to_string(i, "") << '\n';
+    out << "STORE " << i << ": " << map[i] << '\n';
 }
 
 bool inv_object_storet::get(const exprt &expr, unsigned &n)
@@ -313,9 +313,7 @@ tvt invariant_sett::is_le(std::pair<unsigned, unsigned> p) const
   return tvt::unknown();
 }
 
-void invariant_sett::output(
-  const irep_idt &identifier,
-  std::ostream &out) const
+void invariant_sett::output(std::ostream &out) const
 {
   if(is_false)
   {
@@ -339,7 +337,7 @@ void invariant_sett::output(
           else
             out << " = ";
 
-          out << to_string(j, identifier);
+          out << to_string(j);
         }
 
       out << '\n';
@@ -347,23 +345,17 @@ void invariant_sett::output(
 
   for(const auto &bounds : bounds_map)
   {
-    out << to_string(bounds.first, identifier)
-        << " in " << bounds.second
-        << '\n';
+    out << to_string(bounds.first) << " in " << bounds.second << '\n';
   }
 
   for(const auto &le : le_set)
   {
-    out << to_string(le.first, identifier)
-        << " <= " << to_string(le.second, identifier)
-        << '\n';
+    out << to_string(le.first) << " <= " << to_string(le.second) << '\n';
   }
 
   for(const auto &ne : ne_set)
   {
-    out << to_string(ne.first, identifier)
-        << " != " << to_string(ne.second, identifier)
-        << '\n';
+    out << to_string(ne.first) << " != " << to_string(ne.second) << '\n';
   }
 }
 
@@ -881,19 +873,15 @@ exprt invariant_sett::get_constant(const exprt &expr) const
   return static_cast<const exprt &>(get_nil_irep());
 }
 
-std::string inv_object_storet::to_string(
-  unsigned a,
-  const irep_idt &) const
+std::string inv_object_storet::to_string(unsigned a) const
 {
   return id2string(map[a]);
 }
 
-std::string invariant_sett::to_string(
-  unsigned a,
-  const irep_idt &identifier) const
+std::string invariant_sett::to_string(unsigned a) const
 {
   PRECONDITION(object_store!=nullptr);
-  return object_store->to_string(a, identifier);
+  return object_store->to_string(a);
 }
 
 bool invariant_sett::make_union(const invariant_sett &other)

--- a/src/analyses/invariant_set.h
+++ b/src/analyses/invariant_set.h
@@ -51,9 +51,7 @@ public:
 
   void output(std::ostream &out) const;
 
-  std::string to_string(
-    unsigned n,
-    const irep_idt &identifier) const;
+  std::string to_string(unsigned n) const;
 
 protected:
   const namespacet &ns;
@@ -104,9 +102,7 @@ public:
   {
   }
 
-  void output(
-    const irep_idt &identifier,
-    std::ostream &out) const;
+  void output(std::ostream &out) const;
 
   // true = added something
   bool make_union(const invariant_sett &other_invariants);
@@ -219,9 +215,7 @@ protected:
 
   void modifies(unsigned a);
 
-  std::string to_string(
-    unsigned a,
-    const irep_idt &identifier) const;
+  std::string to_string(unsigned a) const;
 
   bool get_object(
     const exprt &expr,

--- a/src/analyses/invariant_set_domain.h
+++ b/src/analyses/invariant_set_domain.h
@@ -49,7 +49,7 @@ public:
     if(has_values.is_known())
       out << has_values.to_string() << '\n';
     else
-      invariant_set.output("", out);
+      invariant_set.output(out);
   }
 
   virtual void transform(


### PR DESCRIPTION
The identifier is not required, and sometimes was an empty string.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
