### PR TITLE
Add error messages to invariants/static asserts

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_parser.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_parser.cpp
@@ -414,7 +414,7 @@ public:
     }
     case method_handle_kindt::REF_invokeInterface:
     {
-      INVARIANT(ref_entry.get_tag() == CONSTANT_InterfaceMethodref, "");
+      INVARIANT(ref_entry.get_tag() == CONSTANT_InterfaceMethodref, "4.4.8");
       break;
     }
     }

--- a/src/solvers/floatbv/float_bv.cpp
+++ b/src/solvers/floatbv/float_bv.cpp
@@ -893,7 +893,9 @@ void float_bvt::normalization_shift(
       if_exprt(prefix_is_zero, shifted, fraction);
 
     // add corresponding weight to exponent
-    INVARIANT(d < (signed int)exponent_bits, "");
+    INVARIANT(
+      d < (signed int)exponent_bits,
+      "depth must be smaller than exponent bits");
 
     exponent_delta=
       bitor_exprt(exponent_delta,

--- a/src/solvers/floatbv/float_utils.cpp
+++ b/src/solvers/floatbv/float_utils.cpp
@@ -578,7 +578,7 @@ literalt float_utilst::relation(
   else if(rel==relt::GE)
     return relation(src2, relt::LE, src1); // swapped
 
-  INVARIANT(rel == relt::EQ || rel == relt::LT || rel == relt::LE, "");
+  PRECONDITION(rel == relt::EQ || rel == relt::LT || rel == relt::LE);
 
   // special cases: -0 and 0 are equal
   literalt is_zero1=is_zero(src1);
@@ -797,7 +797,8 @@ void float_utilst::normalization_shift(bvt &fraction, bvt &exponent)
   for(int d=depth-1; d>=0; d--)
   {
     std::size_t distance=(1<<d);
-    INVARIANT(fraction.size() > distance, "");
+    INVARIANT(
+      fraction.size() > distance, "fraction must be larger than distance");
 
     // check if first 'distance'-many bits are zeros
     const bvt prefix=bv_utils.extract_msb(fraction, distance);
@@ -812,7 +813,9 @@ void float_utilst::normalization_shift(bvt &fraction, bvt &exponent)
       bv_utils.select(prefix_is_zero, shifted, fraction);
 
     // add corresponding weight to exponent
-    INVARIANT(d < (signed)exponent_delta.size(), "");
+    INVARIANT(
+      d < (signed)exponent_delta.size(),
+      "depth must be smaller than exponent size");
     exponent_delta[d]=prefix_is_zero;
   }
 
@@ -1209,7 +1212,7 @@ float_utilst::unbiased_floatt float_utilst::unpack(const bvt &src)
   result.fraction.push_back(is_normal(src)); // add hidden bit
 
   result.exponent=get_exponent(src);
-  INVARIANT(result.exponent.size() == spec.e, "");
+  CHECK_RETURN(result.exponent.size() == spec.e);
 
   // unbias the exponent
   literalt denormal=bv_utils.is_zero(result.exponent);

--- a/src/util/small_map.h
+++ b/src/util/small_map.h
@@ -73,7 +73,7 @@ public:
   }
 
 private:
-  static_assert(std::is_unsigned<Ind>::value, "");
+  static_assert(std::is_unsigned<Ind>::value, "Ind should be an unsigned type");
 
   typedef Ind index_fieldt;
 
@@ -167,7 +167,7 @@ private:
 
   static const std::size_t NUM = Num;
 
-  static_assert(NUM >= 2, "");
+  static_assert(NUM >= 2, "NUM should be at least 2");
 
   static constexpr std::size_t num_bits(const std::size_t n)
   {
@@ -187,9 +187,11 @@ private:
 
   static const index_fieldt MASK = ((index_fieldt)1 << BITS) - 1;
 
-  static_assert(S_BITS <= N_BITS, "");
+  static_assert(S_BITS <= N_BITS, "S_BITS should be no larger than N_BITS");
 
-  static_assert(std::numeric_limits<unsigned>::digits >= BITS, "");
+  static_assert(
+    std::numeric_limits<unsigned>::digits >= BITS,
+    "BITS must fit into an unsigned");
 
   // Internal
 

--- a/src/util/small_shared_two_way_ptr.h
+++ b/src/util/small_shared_two_way_ptr.h
@@ -38,8 +38,12 @@ public:
 
   typedef small_shared_two_way_pointeet<use_countt> pointeet;
 
-  static_assert(std::is_base_of<pointeet, U>::value, "");
-  static_assert(std::is_base_of<pointeet, V>::value, "");
+  static_assert(
+    std::is_base_of<pointeet, U>::value,
+    "pointeet must be a base of U");
+  static_assert(
+    std::is_base_of<pointeet, V>::value,
+    "pointeet must be a base of V");
 
   small_shared_two_way_ptrt() = default;
 
@@ -217,7 +221,7 @@ template <typename Num>
 class small_shared_two_way_pointeet
 {
 public:
-  static_assert(std::is_unsigned<Num>::value, "");
+  static_assert(std::is_unsigned<Num>::value, "Num must be an unsigned type");
 
   static const int bit_idx = std::numeric_limits<Num>::digits - 1;
   static const Num mask = ~((Num)1 << bit_idx);

--- a/src/util/validate_helpers.h
+++ b/src/util/validate_helpers.h
@@ -17,7 +17,9 @@ enum class validation_modet;
 template <typename Base, typename T>
 struct call_checkt
 {
-  static_assert(std::is_base_of<Base, T>::value, "");
+  static_assert(
+    std::is_base_of<Base, T>::value,
+    "T should be derived from Base");
 
   void operator()(const Base &base, const validation_modet vm)
   {
@@ -28,7 +30,9 @@ struct call_checkt
 template <typename Base, typename T>
 struct call_validatet
 {
-  static_assert(std::is_base_of<Base, T>::value, "");
+  static_assert(
+    std::is_base_of<Base, T>::value,
+    "T should be derived from Base");
 
   void
   operator()(const Base &base, const namespacet &ns, const validation_modet vm)
@@ -40,7 +44,9 @@ struct call_validatet
 template <typename Base, typename T>
 struct call_validate_fullt
 {
-  static_assert(std::is_base_of<Base, T>::value, "");
+  static_assert(
+    std::is_base_of<Base, T>::value,
+    "T should be derived from Base");
 
   void
   operator()(const Base &base, const namespacet &ns, const validation_modet vm)


### PR DESCRIPTION
Some static asserts/invariants just had "" as an error message.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
