### PR TITLE
A decision_proceduret isn't a messaget [blocks: #3800]

### DIFF
--- a/src/cbmc/all_properties.cpp
+++ b/src/cbmc/all_properties.cpp
@@ -54,8 +54,6 @@ safety_checkert::resultt bmc_all_propertiest::operator()()
 {
   status() << "Passing problem to " << solver.decision_procedure_text() << eom;
 
-  solver.set_message_handler(get_message_handler());
-
   auto solver_start=std::chrono::steady_clock::now();
 
   convert_symex_target_equation(

--- a/src/cbmc/bmc.cpp
+++ b/src/cbmc/bmc.cpp
@@ -45,8 +45,6 @@ decision_proceduret::resultt bmct::run_decision_procedure()
   status() << "Passing problem to "
            << prop_conv.decision_procedure_text() << eom;
 
-  prop_conv.set_message_handler(get_message_handler());
-
   auto solver_start = std::chrono::steady_clock::now();
 
   convert_symex_target_equation(equation, prop_conv, get_message_handler());
@@ -192,8 +190,6 @@ safety_checkert::resultt bmct::run(
 
 safety_checkert::resultt bmct::decide(const goto_functionst &goto_functions)
 {
-  prop_conv.set_message_handler(get_message_handler());
-
   if(options.get_bool_option("stop-on-fail"))
     return stop_on_fail();
   else

--- a/src/cbmc/bmc.h
+++ b/src/cbmc/bmc.h
@@ -75,7 +75,7 @@ public:
       options(_options),
       outer_symbol_table(outer_symbol_table),
       ns(outer_symbol_table, symex_symbol_table),
-      equation(),
+      equation(_message_handler),
       path_storage(_path_storage),
       symex(
         _message_handler,

--- a/src/goto-checker/multi_path_symex_only_checker.cpp
+++ b/src/goto-checker/multi_path_symex_only_checker.cpp
@@ -26,6 +26,7 @@ multi_path_symex_only_checkert::multi_path_symex_only_checkert(
   : incremental_goto_checkert(options, ui_message_handler),
     goto_model(goto_model),
     ns(goto_model.get_symbol_table(), symex_symbol_table),
+    equation(ui_message_handler),
     symex(
       ui_message_handler,
       goto_model.get_symbol_table(),

--- a/src/goto-checker/single_path_symex_checker.cpp
+++ b/src/goto-checker/single_path_symex_checker.cpp
@@ -49,7 +49,7 @@ operator()(propertiest &properties)
     symex_initialized = true;
 
     // Put initial state into the work list
-    symex_target_equationt equation;
+    symex_target_equationt equation(ui_message_handler);
     symex_bmct symex(
       ui_message_handler,
       goto_model.get_symbol_table(),

--- a/src/goto-checker/single_path_symex_only_checker.cpp
+++ b/src/goto-checker/single_path_symex_only_checker.cpp
@@ -39,7 +39,7 @@ operator()(propertiest &properties)
 
   {
     // Put initial state into the work list
-    symex_target_equationt equation;
+    symex_target_equationt equation(ui_message_handler);
     symex_bmct symex(
       ui_message_handler,
       goto_model.get_symbol_table(),

--- a/src/goto-checker/solver_factory.cpp
+++ b/src/goto-checker/solver_factory.cpp
@@ -268,6 +268,8 @@ solver_factoryt::get_smt2(smt2_dect::solvert solver)
     if(options.get_bool_option("fpa"))
       smt2_dec->use_FPA_theory = true;
 
+    smt2_dec->set_message_handler(message_handler);
+
     set_prop_conv_time_limit(*smt2_dec);
     return util_make_unique<solvert>(std::move(smt2_dec));
   }
@@ -283,8 +285,6 @@ solver_factoryt::get_smt2(smt2_dect::solvert solver)
 
     if(options.get_bool_option("fpa"))
       smt2_conv->use_FPA_theory = true;
-
-    smt2_conv->set_message_handler(message_handler);
 
     set_prop_conv_time_limit(*smt2_conv);
     return util_make_unique<solvert>(std::move(smt2_conv));
@@ -313,8 +313,6 @@ solver_factoryt::get_smt2(smt2_dect::solvert solver)
 
     if(options.get_bool_option("fpa"))
       smt2_conv->use_FPA_theory = true;
-
-    smt2_conv->set_message_handler(message_handler);
 
     set_prop_conv_time_limit(*smt2_conv);
     return util_make_unique<solvert>(std::move(smt2_conv), std::move(out));

--- a/src/goto-instrument/accelerate/scratch_program.h
+++ b/src/goto-instrument/accelerate/scratch_program.h
@@ -41,7 +41,7 @@ public:
       symbol_table(_symbol_table),
       symex_symbol_table(),
       ns(symbol_table, symex_symbol_table),
-      equation(),
+      equation(mh),
       path_storage(),
       options(get_default_options()),
       symex(mh, symbol_table, equation, options, path_storage),

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -359,12 +359,10 @@ void symex_target_equationt::convert_assignments(
   {
     if(step.is_assignment() && !step.ignore && !step.converted)
     {
-      decision_procedure.conditional_output(
-        decision_procedure.debug(),
-        [&step](messaget::mstreamt &mstream) {
-          step.output(mstream);
-          mstream << messaget::eom;
-        });
+      log.conditional_output(log.debug(), [&step](messaget::mstreamt &mstream) {
+        step.output(mstream);
+        mstream << messaget::eom;
+      });
 
       decision_procedure.set_to_true(step.cond_expr);
       step.converted = true;
@@ -404,12 +402,10 @@ void symex_target_equationt::convert_guards(
       step.guard_literal=const_literal(false);
     else
     {
-      prop_conv.conditional_output(
-        prop_conv.debug(),
-        [&step](messaget::mstreamt &mstream) {
-          step.output(mstream);
-          mstream << messaget::eom;
-        });
+      log.conditional_output(log.debug(), [&step](messaget::mstreamt &mstream) {
+        step.output(mstream);
+        mstream << messaget::eom;
+      });
 
       try
       {
@@ -436,9 +432,8 @@ void symex_target_equationt::convert_assumptions(
         step.cond_literal=const_literal(true);
       else
       {
-        prop_conv.conditional_output(
-          prop_conv.debug(),
-          [&step](messaget::mstreamt &mstream) {
+        log.conditional_output(
+          log.debug(), [&step](messaget::mstreamt &mstream) {
             step.output(mstream);
             mstream << messaget::eom;
           });
@@ -469,9 +464,8 @@ void symex_target_equationt::convert_goto_instructions(
         step.cond_literal=const_literal(true);
       else
       {
-        prop_conv.conditional_output(
-          prop_conv.debug(),
-          [&step](messaget::mstreamt &mstream) {
+        log.conditional_output(
+          log.debug(), [&step](messaget::mstreamt &mstream) {
             step.output(mstream);
             mstream << messaget::eom;
           });
@@ -498,11 +492,10 @@ void symex_target_equationt::convert_constraints(
   {
     if(step.is_constraint() && !step.ignore && !step.converted)
     {
-      decision_procedure.conditional_output(
-        decision_procedure.debug(), [&step](messaget::mstreamt &mstream) {
-          step.output(mstream);
-          mstream << messaget::eom;
-        });
+      log.conditional_output(log.debug(), [&step](messaget::mstreamt &mstream) {
+        step.output(mstream);
+        mstream << messaget::eom;
+      });
 
       try
       {
@@ -568,12 +561,10 @@ void symex_target_equationt::convert_assertions(
     {
       step.converted = true;
 
-      prop_conv.conditional_output(
-        prop_conv.debug(),
-        [&step](messaget::mstreamt &mstream) {
-          step.output(mstream);
-          mstream << messaget::eom;
-        });
+      log.conditional_output(log.debug(), [&step](messaget::mstreamt &mstream) {
+        step.output(mstream);
+        mstream << messaget::eom;
+      });
 
       implies_exprt implication(
         assumption,

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -18,6 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/invariant.h>
 #include <util/merge_irep.h>
+#include <util/message.h>
 #include <util/narrow.h>
 
 #include <goto-programs/goto_program.h>
@@ -37,6 +38,11 @@ class prop_convt;
 class symex_target_equationt:public symex_targett
 {
 public:
+  explicit symex_target_equationt(message_handlert &message_handler)
+    : log(message_handler)
+  {
+  }
+
   virtual ~symex_target_equationt() = default;
 
   /// \copydoc symex_targett::shared_read()
@@ -408,6 +414,8 @@ public:
   }
 
 protected:
+  messaget log;
+
   // for enforcing sharing in the expressions stored
   merge_irept merge_irep;
   void merge_ireps(SSA_stept &SSA_step);

--- a/src/solvers/prop/prop_conv.h
+++ b/src/solvers/prop/prop_conv.h
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/decision_procedure.h>
 #include <util/expr.h>
+#include <util/message.h>
 #include <util/std_expr.h>
 
 #include "literal.h"
@@ -67,7 +68,7 @@ public:
 
 /*! \brief TO_BE_DOCUMENTED
 */
-class prop_conv_solvert:public prop_convt
+class prop_conv_solvert : public prop_convt, public messaget
 {
 public:
   explicit prop_conv_solvert(propt &_prop) : prop(_prop)

--- a/src/solvers/smt2/smt2_dec.h
+++ b/src/solvers/smt2/smt2_dec.h
@@ -22,7 +22,9 @@ protected:
 
 /*! \brief Decision procedure interface for various SMT 2.x solvers
 */
-class smt2_dect:protected smt2_stringstreamt, public smt2_convt
+class smt2_dect : protected smt2_stringstreamt,
+                  public smt2_convt,
+                  public messaget
 {
 public:
   smt2_dect(

--- a/src/util/decision_procedure.h
+++ b/src/util/decision_procedure.h
@@ -12,11 +12,12 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_DECISION_PROCEDURE_H
 #define CPROVER_UTIL_DECISION_PROCEDURE_H
 
-#include "message.h"
+#include <iosfwd>
+#include <string>
 
 class exprt;
 
-class decision_proceduret:public messaget
+class decision_proceduret
 {
 public:
   virtual ~decision_proceduret();

--- a/unit/goto-symex/ssa_equation.cpp
+++ b/unit/goto-symex/ssa_equation.cpp
@@ -6,6 +6,7 @@ Author: Diffblue Ltd.
 
 \*******************************************************************/
 
+#include <testing-utils/message.h>
 #include <testing-utils/use_catch.h>
 
 #include <util/arith_tools.h>
@@ -27,7 +28,7 @@ SCENARIO("Validation of well-formed SSA steps", "[core][goto-symex][validate]")
 
     goto_programt goto_program;
     goto_program.add_instruction(END_FUNCTION);
-    symex_target_equationt equation;
+    symex_target_equationt equation(null_message_handler);
     symex_targett::sourcet at_end_function(fun_name, goto_program);
     equation.SSA_steps.emplace_back(
       at_end_function, goto_trace_stept::typet::FUNCTION_RETURN);


### PR DESCRIPTION
Some derived classes may want to generate output, but then it's safe for them to
be messaget's.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
