### PR TITLE
character_refine_preprocesst isn't a messaget [blocks: #3800]

### DIFF
--- a/jbmc/src/java_bytecode/character_refine_preprocess.h
+++ b/jbmc/src/java_bytecode/character_refine_preprocess.h
@@ -20,13 +20,12 @@ Date:   March 2017
 #ifndef CPROVER_JAVA_BYTECODE_CHARACTER_REFINE_PREPROCESS_H
 #define CPROVER_JAVA_BYTECODE_CHARACTER_REFINE_PREPROCESS_H
 
-#include <util/ui_message.h>
 #include <util/std_code.h>
 #include <util/mp_arith.h>
 
 #include <unordered_map>
 
-class character_refine_preprocesst:public messaget
+class character_refine_preprocesst
 {
 public:
   void initialize_conversion_table();


### PR DESCRIPTION
It does not use any of messaget's API, and neither does any class using
character_refine_preprocesst use it as a messaget.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
