### PR TITLE
Initialise all POD members of java_bytecode_languaget

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_language.h
+++ b/jbmc/src/java_bytecode/java_bytecode_language.h
@@ -112,12 +112,17 @@ public:
 
   virtual ~java_bytecode_languaget();
   java_bytecode_languaget(
-    std::unique_ptr<select_pointer_typet> pointer_type_selector):
+    std::unique_ptr<select_pointer_typet> pointer_type_selector)
+    : threading_support(false),
       assume_inputs_non_null(false),
       object_factory_parameters(),
       max_user_array_length(0),
       lazy_methods_mode(lazy_methods_modet::LAZY_METHODS_MODE_EAGER),
       string_refinement_enabled(false),
+      throw_runtime_exceptions(false),
+      assert_uncaught_exceptions(false),
+      throw_assertion_error(false),
+      nondet_static(false),
       pointer_type_selector(std::move(pointer_type_selector))
   {
   }


### PR DESCRIPTION
They may get set to proper values in various places, but make sure they are
consistently initialised.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
