### PR TITLE
Do not remove LHS typecasts in goto-program conversion [blocks: #3800]

### DIFF
--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -714,20 +714,6 @@ void goto_convertt::convert_assign(
     // handle above side effects
     clean_expr(rhs, dest, mode);
 
-    if(lhs.id() == ID_typecast)
-    {
-      DATA_INVARIANT(
-        lhs.operands().size() == 1, "Typecast must have one operand");
-
-      // add a typecast to the rhs
-      exprt new_rhs = rhs;
-      rhs.make_typecast(lhs.op0().type());
-
-      // remove typecast from lhs
-      exprt tmp = lhs.op0();
-      lhs.swap(tmp);
-    }
-
     code_assignt new_assign(code);
     new_assign.lhs() = lhs;
     new_assign.rhs() = rhs;
@@ -751,16 +737,6 @@ void goto_convertt::convert_assign(
   {
     // do everything else
     clean_expr(rhs, dest, mode);
-
-    if(lhs.id()==ID_typecast)
-    {
-      // add a typecast to the rhs
-      rhs.make_typecast(to_typecast_expr(lhs).op().type());
-
-      // remove typecast from lhs
-      exprt tmp=lhs.op0();
-      lhs.swap(tmp);
-    }
 
     code_assignt new_assign(code);
     new_assign.lhs()=lhs;


### PR DESCRIPTION
Producing correctly typed expressions is the job of the type checker. Should any
typecasts remain on the left-hand side we can safely let the back-end deal with
those. Some of the existing code wasn't even correct as it generated a "new_rhs"
object that was never read.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
