### PR TITLE
Move languaget::language_options_initialized to java_bytecode_languaget

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_language.h
+++ b/jbmc/src/java_bytecode/java_bytecode_language.h
@@ -113,7 +113,8 @@ public:
   virtual ~java_bytecode_languaget();
   java_bytecode_languaget(
     std::unique_ptr<select_pointer_typet> pointer_type_selector)
-    : threading_support(false),
+    : language_options_initialized(false),
+      threading_support(false),
       assume_inputs_non_null(false),
       object_factory_parameters(),
       max_user_array_length(0),
@@ -179,6 +180,7 @@ protected:
   bool do_ci_lazy_method_conversion(symbol_tablet &);
   const select_pointer_typet &get_pointer_type_selector() const;
 
+  bool language_options_initialized;
   irep_idt main_class;
   std::vector<irep_idt> main_jar_classes;
   java_class_loadert java_class_loader;

--- a/src/langapi/language.h
+++ b/src/langapi/language.h
@@ -184,9 +184,6 @@ public:
 
   languaget() { }
   virtual ~languaget() { }
-
-protected:
-  bool language_options_initialized=false;
 };
 
 #endif // CPROVER_UTIL_LANGUAGE_H


### PR DESCRIPTION
java_bytecode_languaget is the only user (writing or reading) this member.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
