### PR TITLE
languaget is not a messaget [blocks: #3800]

### DIFF
--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -376,18 +376,18 @@ int janalyzer_parse_optionst::doit()
   {
     std::unique_ptr<languaget> language = get_language_from_mode(ID_java);
     CHECK_RETURN(language != nullptr);
-    language->set_language_options(options);
-    language->set_message_handler(ui_message_handler);
+    language->set_language_options(options, ui_message_handler);
 
     log.status() << "Parsing ..." << messaget::eom;
 
-    if(static_cast<java_bytecode_languaget *>(language.get())->parse())
+    if(static_cast<java_bytecode_languaget *>(language.get())
+         ->parse(ui_message_handler))
     {
       log.error() << "PARSING ERROR" << messaget::eom;
       return CPROVER_EXIT_PARSE_ERROR;
     }
 
-    language->show_parse(std::cout);
+    language->show_parse(std::cout, ui_message_handler);
     return CPROVER_EXIT_SUCCESS;
   }
 

--- a/jbmc/src/java_bytecode/README.md
+++ b/jbmc/src/java_bytecode/README.md
@@ -674,10 +674,10 @@ determine which loading strategy to use.
 If [lazy_methods_mode](\ref java_bytecode_language_optionst::lazy_methods_mode) is
 \ref LAZY_METHODS_MODE_EAGER then eager loading is
 used. Under eager loading
-\ref java_bytecode_languaget::convert_single_method(const irep_idt &, symbol_table_baset &, lazy_class_to_declared_symbols_mapt &)
+\ref java_bytecode_languaget::convert_single_method(const irep_idt &, symbol_table_baset &, lazy_class_to_declared_symbols_mapt &, message_handlert &)
 is called once for each method listed in method_bytecode (described above). This
 then calls
-\ref java_bytecode_languaget::convert_single_method(const irep_idt &, symbol_table_baset &, optionalt<ci_lazy_methods_neededt>, lazy_class_to_declared_symbols_mapt &);
+\ref java_bytecode_languaget::convert_single_method(const irep_idt &, symbol_table_baset &, optionalt<ci_lazy_methods_neededt>, lazy_class_to_declared_symbols_mapt &, message_handlert &);
 
 without a ci_lazy_methods_neededt object, which calls
 \ref java_bytecode_convert_method, passing in the method parse tree. This in

--- a/jbmc/src/java_bytecode/ci_lazy_methods.cpp
+++ b/jbmc/src/java_bytecode/ci_lazy_methods.cpp
@@ -9,6 +9,7 @@ Author: Diffblue Ltd.
 #include "ci_lazy_methods.h"
 
 #include <util/expr_iterator.h>
+#include <util/message.h>
 #include <util/namespace.h>
 #include <util/suffix.h>
 #include <util/symbol_table.h>

--- a/jbmc/src/java_bytecode/java_bytecode_language.h
+++ b/jbmc/src/java_bytecode/java_bytecode_language.h
@@ -201,7 +201,7 @@ private:
 
 struct java_bytecode_language_optionst
 {
-  java_bytecode_language_optionst(const optionst &options, messaget &log);
+  java_bytecode_language_optionst(const optionst &options, message_handlert &);
 
   java_bytecode_language_optionst() = default;
 
@@ -260,33 +260,37 @@ struct java_bytecode_language_optionst
 class java_bytecode_languaget:public languaget
 {
 public:
-  void set_language_options(const optionst &) override;
-
-  void set_message_handler(message_handlert &message_handler) override;
+  void set_language_options(const optionst &, message_handlert &) override;
 
   virtual bool preprocess(
     std::istream &instream,
     const std::string &path,
-    std::ostream &outstream) override;
+    std::ostream &outstream,
+    message_handlert &message_handler) override;
 
   // This is an extension to languaget
   // required because parsing of Java programs can be initiated without
   // opening a file first or providing a path to a file
   // as dictated by \ref languaget.
-  virtual bool parse();
+  virtual bool parse(message_handlert &);
 
   bool parse(
     std::istream &instream,
-    const std::string &path) override;
+    const std::string &path,
+    message_handlert &message_handler) override;
 
-  bool generate_support_functions(symbol_table_baset &symbol_table) override;
+  bool generate_support_functions(
+    symbol_table_baset &symbol_table,
+    message_handlert &message_handler) override;
 
-  bool
-  typecheck(symbol_table_baset &context, const std::string &module) override;
+  bool typecheck(
+    symbol_table_baset &context,
+    const std::string &module,
+    message_handlert &message_handler) override;
 
   virtual bool final(symbol_table_baset &context) override;
 
-  void show_parse(std::ostream &out) override;
+  void show_parse(std::ostream &out, message_handlert &) override;
 
   virtual ~java_bytecode_languaget();
   java_bytecode_languaget(
@@ -316,7 +320,8 @@ public:
     const std::string &code,
     const std::string &module,
     exprt &expr,
-    const namespacet &ns) override;
+    const namespacet &ns,
+    message_handlert &message_handler) override;
 
   std::unique_ptr<languaget> new_language() override
   { return util_make_unique<java_bytecode_languaget>(); }
@@ -330,32 +335,37 @@ public:
   methods_provided(std::unordered_set<irep_idt> &methods) const override;
   virtual void convert_lazy_method(
     const irep_idt &function_id,
-    symbol_table_baset &symbol_table) override;
+    symbol_table_baset &symbol_table,
+    message_handlert &message_handler) override;
 
 protected:
   void convert_single_method(
     const irep_idt &function_id,
     symbol_table_baset &symbol_table,
-    lazy_class_to_declared_symbols_mapt &class_to_declared_symbols)
+    lazy_class_to_declared_symbols_mapt &class_to_declared_symbols,
+    message_handlert &message_handler)
   {
     convert_single_method(
       function_id,
       symbol_table,
       optionalt<ci_lazy_methods_neededt>(),
-      class_to_declared_symbols);
+      class_to_declared_symbols,
+      message_handler);
   }
   bool convert_single_method(
     const irep_idt &function_id,
     symbol_table_baset &symbol_table,
     optionalt<ci_lazy_methods_neededt> needed_lazy_methods,
-    lazy_class_to_declared_symbols_mapt &class_to_declared_symbols);
+    lazy_class_to_declared_symbols_mapt &class_to_declared_symbols,
+    message_handlert &);
   bool convert_single_method_code(
     const irep_idt &function_id,
     symbol_table_baset &symbol_table,
     optionalt<ci_lazy_methods_neededt> needed_lazy_methods,
-    lazy_class_to_declared_symbols_mapt &class_to_declared_symbols);
+    lazy_class_to_declared_symbols_mapt &class_to_declared_symbols,
+    message_handlert &);
 
-  bool do_ci_lazy_method_conversion(symbol_table_baset &);
+  bool do_ci_lazy_method_conversion(symbol_table_baset &, message_handlert &);
   const select_pointer_typet &get_pointer_type_selector() const;
 
   optionalt<java_bytecode_language_optionst> language_options;
@@ -384,8 +394,8 @@ private:
   /// IDs of such objects to symbols that store their values.
   std::unordered_map<std::string, object_creation_referencet> references;
 
-  void parse_from_main_class();
-  void initialize_class_loader();
+  void parse_from_main_class(message_handlert &);
+  void initialize_class_loader(message_handlert &);
 };
 
 std::unique_ptr<languaget> new_java_bytecode_language();

--- a/jbmc/src/java_bytecode/java_entry_point.cpp
+++ b/jbmc/src/java_bytecode/java_entry_point.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/config.h>
 #include <util/expr_initializer.h>
 #include <util/journalling_symbol_table.h>
+#include <util/message.h>
 #include <util/suffix.h>
 
 #include <goto-programs/adjust_float_expressions.h>

--- a/jbmc/src/java_bytecode/lazy_goto_model.cpp
+++ b/jbmc/src/java_bytecode/lazy_goto_model.cpp
@@ -141,12 +141,11 @@ void lazy_goto_modelt::initialize(
     CHECK_RETURN(lf.language != nullptr);
 
     languaget &language = *lf.language;
-    language.set_message_handler(message_handler);
-    language.set_language_options(options);
+    language.set_language_options(options, message_handler);
 
     msg.status() << "Parsing ..." << messaget::eom;
 
-    if(dynamic_cast<java_bytecode_languaget &>(language).parse())
+    if(dynamic_cast<java_bytecode_languaget &>(language).parse(message_handler))
     {
       throw invalid_input_exceptiont("PARSING ERROR");
     }

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -453,18 +453,18 @@ int jbmc_parse_optionst::doit()
   {
     std::unique_ptr<languaget> language = get_language_from_mode(ID_java);
     CHECK_RETURN(language != nullptr);
-    language->set_language_options(options);
-    language->set_message_handler(ui_message_handler);
+    language->set_language_options(options, ui_message_handler);
 
     log.status() << "Parsing ..." << messaget::eom;
 
-    if(static_cast<java_bytecode_languaget *>(language.get())->parse())
+    if(static_cast<java_bytecode_languaget *>(language.get())
+         ->parse(ui_message_handler))
     {
       log.error() << "PARSING ERROR" << messaget::eom;
       return CPROVER_EXIT_PARSE_ERROR;
     }
 
-    language->show_parse(std::cout);
+    language->show_parse(std::cout, ui_message_handler);
     return CPROVER_EXIT_SUCCESS;
   }
 

--- a/jbmc/unit/java-testing-utils/load_java_class.cpp
+++ b/jbmc/unit/java-testing-utils/load_java_class.cpp
@@ -115,7 +115,8 @@ goto_modelt load_goto_model_from_java_class(
   // Add the language to the model
   language_filet &lf=lazy_goto_model.add_language_file(filename);
   lf.language=std::move(java_lang);
-  languaget &language=*lf.language;
+  java_bytecode_languaget &language =
+    dynamic_cast<java_bytecode_languaget &>(*lf.language);
 
   std::istringstream java_code_stream("ignored");
 
@@ -123,11 +124,11 @@ goto_modelt load_goto_model_from_java_class(
   parse_java_language_options(command_line, options);
 
   // Configure the language, load the class files
-  language.set_message_handler(null_message_handler);
-  language.set_language_options(options);
-  language.parse(java_code_stream, filename);
-  language.typecheck(lazy_goto_model.symbol_table, "");
-  language.generate_support_functions(lazy_goto_model.symbol_table);
+  language.set_language_options(options, null_message_handler);
+  language.parse(java_code_stream, filename, null_message_handler);
+  language.typecheck(lazy_goto_model.symbol_table, "", null_message_handler);
+  language.generate_support_functions(
+    lazy_goto_model.symbol_table, null_message_handler);
   language.final(lazy_goto_model.symbol_table);
 
   lazy_goto_model.load_all_functions();

--- a/jbmc/unit/java_bytecode/java_bytecode_language/language.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_language/language.cpp
@@ -6,13 +6,15 @@ Author: Diffblue Limited.
 
 \*******************************************************************/
 
-#include <testing-utils/use_catch.h>
-
 #include <java-testing-utils/load_java_class.h>
+
+#include <util/message.h>
+#include <util/options.h>
+
 #include <java-testing-utils/require_type.h>
 #include <java_bytecode/java_bytecode_language.h>
 #include <linking/static_lifetime_init.h>
-#include <util/options.h>
+#include <testing-utils/use_catch.h>
 
 SCENARIO(
   "java_bytecode_language_opaque_field",
@@ -47,25 +49,19 @@ SCENARIO(
   }
 }
 
-static void use_external_driver(java_bytecode_languaget &language)
-{
-  optionst options;
-  options.set_option("symex-driven-lazy-loading", true);
-  language.set_language_options(options);
-}
-
 SCENARIO(
   "LAZY_METHODS_MODE_EXTERNAL_DRIVER based generation of cprover_initialise",
   "[core][java_bytecode_language]")
 {
   java_bytecode_languaget language;
   null_message_handlert null_message_handler;
-  language.set_message_handler(null_message_handler);
-  use_external_driver(language);
+  optionst options;
+  options.set_option("symex-driven-lazy-loading", true);
+  language.set_language_options(options, null_message_handler);
   symbol_tablet symbol_table;
   GIVEN("java_bytecode_languaget::typecheck is run.")
   {
-    language.typecheck(symbol_table, "");
+    language.typecheck(symbol_table, "", null_message_handler);
     THEN("The " INITIALIZE_FUNCTION " is in the symbol table without code.")
     {
       const symbolt *const initialise =
@@ -77,7 +73,8 @@ SCENARIO(
       "java_bytecode_languaget::convert_lazy_method is used to "
       "generate " INITIALIZE_FUNCTION)
     {
-      language.convert_lazy_method(INITIALIZE_FUNCTION, symbol_table);
+      language.convert_lazy_method(
+        INITIALIZE_FUNCTION, symbol_table, null_message_handler);
       THEN("The " INITIALIZE_FUNCTION " is in the symbol table with code.")
       {
         const symbolt *const initialise =
@@ -95,12 +92,11 @@ TEST_CASE(
 {
   java_bytecode_languaget language;
   null_message_handlert null_message_handler;
-  language.set_message_handler(null_message_handler);
-  language.set_language_options(optionst{});
+  language.set_language_options(optionst{}, null_message_handler);
   symbol_tablet symbol_table;
   GIVEN("java_bytecode_languaget::typecheck is run.")
   {
-    language.typecheck(symbol_table, "");
+    language.typecheck(symbol_table, "", null_message_handler);
     THEN("The " INITIALIZE_FUNCTION
          " function is in the symbol table with code.")
     {

--- a/jbmc/unit/java_bytecode/java_bytecode_parser/parse_java_annotations.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parser/parse_java_annotations.cpp
@@ -174,14 +174,14 @@ SCENARIO(
       free_form_cmdlinet command_line;
       command_line.add_flag("no-lazy-methods");
       test_java_bytecode_languaget language;
-      language.set_message_handler(null_message_handler);
       optionst options;
       parse_java_language_options(command_line, options);
-      language.set_language_options(options);
+      language.set_language_options(options, null_message_handler);
       config.java.main_class = "AnnotationsEverywhere";
 
       std::istringstream java_code_stream("ignored");
-      language.parse(java_code_stream, "AnnotationsEverywhere.class");
+      language.parse(
+        java_code_stream, "AnnotationsEverywhere.class", null_message_handler);
       const java_class_loadert::parse_tree_with_overlayst &parse_trees =
         language.get_parse_trees_for_class("AnnotationsEverywhere");
       REQUIRE(parse_trees.size() == 1);

--- a/src/ansi-c/ansi_c_language.cpp
+++ b/src/ansi-c/ansi_c_language.cpp
@@ -39,18 +39,20 @@ void ansi_c_languaget::modules_provided(std::set<std::string> &modules)
 bool ansi_c_languaget::preprocess(
   std::istream &instream,
   const std::string &path,
-  std::ostream &outstream)
+  std::ostream &outstream,
+  message_handlert &message_handler)
 {
   // stdin?
   if(path.empty())
-    return c_preprocess(instream, outstream, get_message_handler());
+    return c_preprocess(instream, outstream, message_handler);
 
-  return c_preprocess(path, outstream, get_message_handler());
+  return c_preprocess(path, outstream, message_handler);
 }
 
 bool ansi_c_languaget::parse(
   std::istream &instream,
-  const std::string &path)
+  const std::string &path,
+  message_handlert &message_handler)
 {
   // store the path
   parse_path=path;
@@ -58,7 +60,7 @@ bool ansi_c_languaget::parse(
   // preprocessing
   std::ostringstream o_preprocessed;
 
-  if(preprocess(instream, path, o_preprocessed))
+  if(preprocess(instream, path, o_preprocessed, message_handler))
     return true;
 
   std::istringstream i_preprocessed(o_preprocessed.str());
@@ -72,7 +74,7 @@ bool ansi_c_languaget::parse(
   ansi_c_parser.clear();
   ansi_c_parser.set_file(ID_built_in);
   ansi_c_parser.in=&codestr;
-  ansi_c_parser.log.set_message_handler(get_message_handler());
+  ansi_c_parser.log.set_message_handler(message_handler);
   ansi_c_parser.for_has_scope=config.ansi_c.for_has_scope;
   ansi_c_parser.ts_18661_3_Floatn_types=config.ansi_c.ts_18661_3_Floatn_types;
   ansi_c_parser.cpp98=false; // it's not C++
@@ -104,46 +106,45 @@ bool ansi_c_languaget::parse(
 bool ansi_c_languaget::typecheck(
   symbol_table_baset &symbol_table,
   const std::string &module,
+  message_handlert &message_handler,
   const bool keep_file_local)
 {
-  return typecheck(symbol_table, module, keep_file_local, {});
+  return typecheck(symbol_table, module, message_handler, keep_file_local, {});
 }
 
 bool ansi_c_languaget::typecheck(
   symbol_table_baset &symbol_table,
   const std::string &module,
+  message_handlert &message_handler,
   const bool keep_file_local,
   const std::set<irep_idt> &keep)
 {
   symbol_tablet new_symbol_table;
 
-  if(ansi_c_typecheck(
-    parse_tree,
-    new_symbol_table,
-    module,
-    get_message_handler()))
+  if(ansi_c_typecheck(parse_tree, new_symbol_table, module, message_handler))
   {
     return true;
   }
 
   remove_internal_symbols(
-    new_symbol_table, this->get_message_handler(), keep_file_local, keep);
+    new_symbol_table, message_handler, keep_file_local, keep);
 
-  if(linking(symbol_table, new_symbol_table, get_message_handler()))
+  if(linking(symbol_table, new_symbol_table, message_handler))
     return true;
 
   return false;
 }
 
 bool ansi_c_languaget::generate_support_functions(
-  symbol_table_baset &symbol_table)
+  symbol_table_baset &symbol_table,
+  message_handlert &message_handler)
 {
   // This creates __CPROVER_start and __CPROVER_initialize:
   return ansi_c_entry_point(
-    symbol_table, get_message_handler(), object_factory_params);
+    symbol_table, message_handler, object_factory_params);
 }
 
-void ansi_c_languaget::show_parse(std::ostream &out)
+void ansi_c_languaget::show_parse(std::ostream &out, message_handlert &)
 {
   parse_tree.output(out);
 }
@@ -184,7 +185,8 @@ bool ansi_c_languaget::to_expr(
   const std::string &code,
   const std::string &,
   exprt &expr,
-  const namespacet &ns)
+  const namespacet &ns,
+  message_handlert &message_handler)
 {
   expr.make_nil();
 
@@ -198,7 +200,7 @@ bool ansi_c_languaget::to_expr(
   ansi_c_parser.clear();
   ansi_c_parser.set_file(irep_idt());
   ansi_c_parser.in=&i_preprocessed;
-  ansi_c_parser.log.set_message_handler(get_message_handler());
+  ansi_c_parser.log.set_message_handler(message_handler);
   ansi_c_parser.mode=config.ansi_c.mode;
   ansi_c_parser.ts_18661_3_Floatn_types=config.ansi_c.ts_18661_3_Floatn_types;
   ansi_c_scanner_init();
@@ -212,7 +214,7 @@ bool ansi_c_languaget::to_expr(
     expr=ansi_c_parser.parse_tree.items.front().declarator().value();
 
     // typecheck it
-    result=ansi_c_typecheck(expr, get_message_handler(), ns);
+    result = ansi_c_typecheck(expr, message_handler, ns);
   }
 
   // save some memory

--- a/src/ansi-c/ansi_c_language.h
+++ b/src/ansi-c/ansi_c_language.h
@@ -36,7 +36,8 @@ Author: Daniel Kroening, kroening@kroening.com
 class ansi_c_languaget:public languaget
 {
 public:
-  void set_language_options(const optionst &options) override
+  void
+  set_language_options(const optionst &options, message_handlert &) override
   {
     object_factory_params.set(options);
   }
@@ -44,22 +45,28 @@ public:
   bool preprocess(
     std::istream &instream,
     const std::string &path,
-    std::ostream &outstream) override;
+    std::ostream &outstream,
+    message_handlert &message_handler) override;
 
   bool parse(
     std::istream &instream,
-    const std::string &path) override;
+    const std::string &path,
+    message_handlert &message_handler) override;
 
-  bool generate_support_functions(symbol_table_baset &symbol_table) override;
+  bool generate_support_functions(
+    symbol_table_baset &symbol_table,
+    message_handlert &message_handler) override;
 
   bool typecheck(
     symbol_table_baset &symbol_table,
     const std::string &module,
+    message_handlert &message_handler,
     const bool keep_file_local) override;
 
   bool typecheck(
     symbol_table_baset &symbol_table,
     const std::string &module,
+    message_handlert &message_handler,
     const bool keep_file_local,
     const std::set<irep_idt> &keep);
 
@@ -68,13 +75,15 @@ public:
     return true;
   }
 
-  bool typecheck(symbol_table_baset &symbol_table, const std::string &module)
-    override
+  bool typecheck(
+    symbol_table_baset &symbol_table,
+    const std::string &module,
+    message_handlert &message_handler) override
   {
-    return typecheck(symbol_table, module, true);
+    return typecheck(symbol_table, module, message_handler, true);
   }
 
-  void show_parse(std::ostream &out) override;
+  void show_parse(std::ostream &out, message_handlert &) override;
 
   ~ansi_c_languaget() override;
   ansi_c_languaget() { }
@@ -98,7 +107,8 @@ public:
     const std::string &code,
     const std::string &module,
     exprt &expr,
-    const namespacet &ns) override;
+    const namespacet &ns,
+    message_handlert &message_handler) override;
 
   std::unique_ptr<languaget> new_language() override
   { return util_make_unique<ansi_c_languaget>(); }

--- a/src/ansi-c/cprover_library.cpp
+++ b/src/ansi-c/cprover_library.cpp
@@ -123,10 +123,10 @@ void add_library(
   std::istringstream in(src);
 
   ansi_c_languaget ansi_c_language;
-  ansi_c_language.set_message_handler(message_handler);
-  ansi_c_language.parse(in, "");
+  ansi_c_language.parse(in, "", message_handler);
 
-  ansi_c_language.typecheck(symbol_table, "<built-in-library>", true, keep);
+  ansi_c_language.typecheck(
+    symbol_table, "<built-in-library>", message_handler, true, keep);
 }
 
 void cprover_c_library_factory_force_load(

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -523,18 +523,17 @@ int cbmc_parse_optionst::doit()
       return CPROVER_EXIT_INCORRECT_TASK;
     }
 
-    language->set_language_options(options);
-    language->set_message_handler(ui_message_handler);
+    language->set_language_options(options, ui_message_handler);
 
     log.status() << "Parsing " << filename << messaget::eom;
 
-    if(language->parse(infile, filename))
+    if(language->parse(infile, filename, ui_message_handler))
     {
       log.error() << "PARSING ERROR" << messaget::eom;
       return CPROVER_EXIT_INCORRECT_TASK;
     }
 
-    language->show_parse(std::cout);
+    language->show_parse(std::cout, ui_message_handler);
     return CPROVER_EXIT_SUCCESS;
   }
 
@@ -793,7 +792,7 @@ void cbmc_parse_optionst::preprocessing(const optionst &options)
   }
 
   std::unique_ptr<languaget> language = get_language_from_filename(filename);
-  language->set_language_options(options);
+  language->set_language_options(options, ui_message_handler);
 
   if(language == nullptr)
   {
@@ -801,9 +800,7 @@ void cbmc_parse_optionst::preprocessing(const optionst &options)
     return;
   }
 
-  language->set_message_handler(ui_message_handler);
-
-  if(language->preprocess(infile, filename, std::cout))
+  if(language->preprocess(infile, filename, std::cout, ui_message_handler))
     log.error() << "PREPROCESSING ERROR" << messaget::eom;
 }
 

--- a/src/cpp/cpp_language.h
+++ b/src/cpp/cpp_language.h
@@ -25,7 +25,8 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 class cpp_languaget:public languaget
 {
 public:
-  void set_language_options(const optionst &options) override
+  void
+  set_language_options(const optionst &options, message_handlert &) override
   {
     object_factory_params.set(options);
   }
@@ -33,16 +34,22 @@ public:
   bool preprocess(
     std::istream &instream,
     const std::string &path,
-    std::ostream &outstream) override;
+    std::ostream &outstream,
+    message_handlert &message_handler) override;
 
   bool parse(
     std::istream &instream,
-    const std::string &path) override;
+    const std::string &path,
+    message_handlert &message_handler) override;
 
-  bool generate_support_functions(symbol_table_baset &symbol_table) override;
+  bool generate_support_functions(
+    symbol_table_baset &symbol_table,
+    message_handlert &message_handler) override;
 
-  bool typecheck(symbol_table_baset &symbol_table, const std::string &module)
-    override;
+  bool typecheck(
+    symbol_table_baset &symbol_table,
+    const std::string &module,
+    message_handlert &message_handler) override;
 
   bool merge_symbol_table(
     symbol_table_baset &dest,
@@ -50,7 +57,7 @@ public:
     const std::string &module,
     class replace_symbolt &replace_symbol) const;
 
-  void show_parse(std::ostream &out) override;
+  void show_parse(std::ostream &out, message_handlert &) override;
 
   // constructor, destructor
   ~cpp_languaget() override;
@@ -78,7 +85,8 @@ public:
     const std::string &code,
     const std::string &module,
     exprt &expr,
-    const namespacet &ns) override;
+    const namespacet &ns,
+    message_handlert &message_handler) override;
 
   std::unique_ptr<languaget> new_language() override
   { return util_make_unique<cpp_languaget>(); }

--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -469,8 +469,6 @@ bool compilet::parse(
     return true;
   }
 
-  languagep->set_message_handler(log.get_message_handler());
-
   if(file_name == "-")
     return parse_stdin(*languagep);
 
@@ -506,13 +504,13 @@ bool compilet::parse(
       }
     }
 
-    lf.language->preprocess(infile, file_name, *os);
+    lf.language->preprocess(infile, file_name, *os, log.get_message_handler());
   }
   else
   {
     log.statistics() << "Parsing: " << file_name << messaget::eom;
 
-    if(lf.language->parse(infile, file_name))
+    if(lf.language->parse(infile, file_name, log.get_message_handler()))
     {
       log.error() << "PARSING ERROR" << messaget::eom;
       return true;
@@ -548,11 +546,11 @@ bool compilet::parse_stdin(languaget &language)
       }
     }
 
-    language.preprocess(std::cin, "", *os);
+    language.preprocess(std::cin, "", *os, log.get_message_handler());
   }
   else
   {
-    if(language.parse(std::cin, ""))
+    if(language.parse(std::cin, "", log.get_message_handler()))
     {
       log.error() << "PARSING ERROR" << messaget::eom;
       return true;

--- a/src/goto-instrument/contracts/memory_predicates.cpp
+++ b/src/goto-instrument/contracts/memory_predicates.cpp
@@ -172,14 +172,14 @@ void is_fresh_baset::add_declarations(const std::string &decl_string)
   std::istringstream iss(decl_string);
 
   ansi_c_languaget ansi_c_language;
-  ansi_c_language.set_message_handler(message_handler);
   configt::ansi_ct::preprocessort pp = config.ansi_c.preprocessor;
   config.ansi_c.preprocessor = configt::ansi_ct::preprocessort::NONE;
-  ansi_c_language.parse(iss, "");
+  ansi_c_language.parse(iss, "", log.get_message_handler());
   config.ansi_c.preprocessor = pp;
 
   symbol_tablet tmp_symbol_table;
-  ansi_c_language.typecheck(tmp_symbol_table, "<built-in-library>");
+  ansi_c_language.typecheck(
+    tmp_symbol_table, "<built-in-library>", log.get_message_handler());
   exprt value = nil_exprt();
 
   goto_functionst tmp_functions;

--- a/src/goto-instrument/model_argc_argv.cpp
+++ b/src/goto-instrument/model_argc_argv.cpp
@@ -105,14 +105,14 @@ bool model_argc_argv(
   std::istringstream iss(oss.str());
 
   ansi_c_languaget ansi_c_language;
-  ansi_c_language.set_message_handler(message_handler);
   configt::ansi_ct::preprocessort pp=config.ansi_c.preprocessor;
   config.ansi_c.preprocessor=configt::ansi_ct::preprocessort::NONE;
-  ansi_c_language.parse(iss, "");
+  ansi_c_language.parse(iss, "", message_handler);
   config.ansi_c.preprocessor=pp;
 
   symbol_tablet tmp_symbol_table;
-  ansi_c_language.typecheck(tmp_symbol_table, "<built-in-library>");
+  ansi_c_language.typecheck(
+    tmp_symbol_table, "<built-in-library>", message_handler);
 
   goto_programt init_instructions;
   exprt value=nil_exprt();

--- a/src/goto-programs/initialize_goto_model.cpp
+++ b/src/goto-programs/initialize_goto_model.cpp
@@ -52,9 +52,9 @@ static bool generate_entry_point_for_function(
   PRECONDITION(!entry_point_mode.empty());
   auto const entry_language = get_language_from_mode(entry_point_mode);
   CHECK_RETURN(entry_language != nullptr);
-  entry_language->set_message_handler(message_handler);
-  entry_language->set_language_options(options);
-  return entry_language->generate_support_functions(symbol_table);
+  entry_language->set_language_options(options, message_handler);
+  return entry_language->generate_support_functions(
+    symbol_table, message_handler);
 }
 
 void initialize_from_source_files(
@@ -88,12 +88,11 @@ void initialize_from_source_files(
     }
 
     languaget &language = *lf.language;
-    language.set_message_handler(message_handler);
-    language.set_language_options(options);
+    language.set_language_options(options, message_handler);
 
     msg.status() << "Parsing " << filename << messaget::eom;
 
-    if(language.parse(infile, filename))
+    if(language.parse(infile, filename, message_handler))
     {
       throw invalid_input_exceptiont("PARSING ERROR");
     }
@@ -137,7 +136,7 @@ void set_up_custom_entry_point(
 
     // Create the new entry-point
     entry_point_generation_failed =
-      language->generate_support_functions(symbol_table);
+      language->generate_support_functions(symbol_table, message_handler);
 
     // Remove the function from the goto functions so it is copied back in
     // from the symbol table during goto_convert
@@ -159,8 +158,8 @@ void set_up_custom_entry_point(
     {
       // Allow all language front-ends to try to provide the user-specified
       // (--function) entry-point, or some language-specific default:
-      entry_point_generation_failed =
-        language_files.generate_support_functions(symbol_table);
+      entry_point_generation_failed = language_files.generate_support_functions(
+        symbol_table, message_handler);
     }
   }
 

--- a/src/goto-programs/rebuild_goto_start_function.cpp
+++ b/src/goto-programs/rebuild_goto_start_function.cpp
@@ -32,8 +32,7 @@ std::unique_ptr<languaget> get_entry_point_language(
   std::unique_ptr<languaget> language = get_language_from_mode(mode);
   // This might fail if the driver program hasn't registered that language.
   INVARIANT(language, "No language found for mode: " + id2string(mode));
-  language->set_message_handler(message_handler);
-  language->set_language_options(options);
+  language->set_language_options(options, message_handler);
   return language;
 }
 

--- a/src/jsil/jsil_language.h
+++ b/src/jsil/jsil_language.h
@@ -26,16 +26,24 @@ public:
   bool preprocess(
     std::istream &instream,
     const std::string &path,
-    std::ostream &outstream) override;
+    std::ostream &outstream,
+    message_handlert &) override;
 
-  bool parse(std::istream &instream, const std::string &path) override;
+  bool parse(
+    std::istream &instream,
+    const std::string &path,
+    message_handlert &message_handler) override;
 
-  bool generate_support_functions(symbol_table_baset &symbol_table) override;
+  bool generate_support_functions(
+    symbol_table_baset &symbol_table,
+    message_handlert &message_handler) override;
 
-  bool
-  typecheck(symbol_table_baset &context, const std::string &module) override;
+  bool typecheck(
+    symbol_table_baset &context,
+    const std::string &module,
+    message_handlert &message_handler) override;
 
-  void show_parse(std::ostream &out) override;
+  void show_parse(std::ostream &out, message_handlert &) override;
 
   virtual ~jsil_languaget();
   jsil_languaget() { }
@@ -50,7 +58,8 @@ public:
     const std::string &code,
     const std::string &module,
     exprt &expr,
-    const namespacet &ns) override;
+    const namespacet &ns,
+    message_handlert &message_handler) override;
 
   std::unique_ptr<languaget> new_language() override
   { return util_make_unique<jsil_languaget>(); }
@@ -64,7 +73,9 @@ public:
   std::set<std::string> extensions() const override;
 
   void modules_provided(std::set<std::string> &modules) override;
-  bool interfaces(symbol_table_baset &symbol_table) override;
+  bool interfaces(
+    symbol_table_baset &symbol_table,
+    message_handlert &message_handler) override;
 
 protected:
   jsil_parse_treet parse_tree;

--- a/src/json-symtab-language/json_symtab_language.cpp
+++ b/src/json-symtab-language/json_symtab_language.cpp
@@ -20,21 +20,25 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 /// Parse a goto program in json form.
 /// \param instream: The input stream
 /// \param path: A file path
+/// \param message_handler: A message handler
 /// \return boolean signifying success or failure of the parsing
 bool json_symtab_languaget::parse(
   std::istream &instream,
-  const std::string &path)
+  const std::string &path,
+  message_handlert &message_handler)
 {
-  return parse_json(instream, path, get_message_handler(), parsed_json_file);
+  return parse_json(instream, path, message_handler, parsed_json_file);
 }
 
 /// Typecheck a goto program in json form.
 /// \param symbol_table: The symbol table containing symbols read from file.
 /// \param module: A useless parameter, there for interface consistency.
+/// \param message_handler: A message handler
 /// \return boolean signifying success or failure of the typechecking.
 bool json_symtab_languaget::typecheck(
   symbol_table_baset &symbol_table,
-  const std::string &module)
+  const std::string &module,
+  message_handlert &message_handler)
 {
   (void)module; // unused parameter
 
@@ -43,11 +47,12 @@ bool json_symtab_languaget::typecheck(
   try
   {
     symbol_table_from_json(parsed_json_file, new_symbol_table);
-    return linking(symbol_table, new_symbol_table, get_message_handler());
+    return linking(symbol_table, new_symbol_table, message_handler);
   }
   catch(const std::string &str)
   {
-    error() << "typecheck: " << str << eom;
+    messaget log(message_handler);
+    log.error() << "typecheck: " << str << messaget::eom;
     return true;
   }
 }
@@ -55,7 +60,11 @@ bool json_symtab_languaget::typecheck(
 /// Output the result of the parsed json file to the output stream
 /// passed as a parameter to this function.
 /// \param out: The stream to use to output the parsed_json_file.
-void json_symtab_languaget::show_parse(std::ostream &out)
+/// \param message_handler: A message handler
+void json_symtab_languaget::show_parse(
+  std::ostream &out,
+  message_handlert &message_handler)
 {
+  (void)message_handler;
   parsed_json_file.output(out);
 }

--- a/src/json-symtab-language/json_symtab_language.h
+++ b/src/json-symtab-language/json_symtab_language.h
@@ -25,16 +25,24 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 class json_symtab_languaget : public languaget
 {
 public:
-  bool parse(std::istream &instream, const std::string &path) override;
+  bool parse(
+    std::istream &instream,
+    const std::string &path,
+    message_handlert &message_handler) override;
 
-  bool typecheck(symbol_table_baset &symbol_table, const std::string &module)
-    override;
+  bool typecheck(
+    symbol_table_baset &symbol_table,
+    const std::string &module,
+    message_handlert &message_handler) override;
 
-  void show_parse(std::ostream &out) override;
+  void show_parse(std::ostream &out, message_handlert &) override;
 
-  bool
-  to_expr(const std::string &, const std::string &, exprt &, const namespacet &)
-    override
+  bool to_expr(
+    const std::string &,
+    const std::string &,
+    exprt &,
+    const namespacet &,
+    message_handlert &) override
   {
     UNIMPLEMENTED;
   }
@@ -58,7 +66,9 @@ public:
     return util_make_unique<json_symtab_languaget>();
   }
 
-  bool generate_support_functions(symbol_table_baset &symbol_table) override
+  bool generate_support_functions(
+    symbol_table_baset &symbol_table,
+    message_handlert &) override
   {
     // check if entry point is already there
     bool entry_point_exists =

--- a/src/langapi/language.cpp
+++ b/src/langapi/language.cpp
@@ -18,7 +18,7 @@ bool languaget::final(symbol_table_baset &)
   return false;
 }
 
-bool languaget::interfaces(symbol_table_baset &)
+bool languaget::interfaces(symbol_table_baset &, message_handlert &)
 {
   return false;
 }

--- a/src/langapi/language_file.h
+++ b/src/langapi/language_file.h
@@ -50,7 +50,8 @@ public:
 
   void convert_lazy_method(
     const irep_idt &id,
-    symbol_table_baset &symbol_table);
+    symbol_table_baset &symbol_table,
+    message_handlert &message_handler);
 
   explicit language_filet(const std::string &filename);
   language_filet(const language_filet &rhs);
@@ -103,9 +104,11 @@ public:
 
   bool parse(message_handlert &message_handler);
 
-  void show_parse(std::ostream &out);
+  void show_parse(std::ostream &out, message_handlert &message_handler);
 
-  bool generate_support_functions(symbol_table_baset &symbol_table);
+  bool generate_support_functions(
+    symbol_table_baset &symbol_table,
+    message_handlert &message_handler);
 
   bool
 
@@ -121,7 +124,9 @@ public:
 
   bool final(symbol_table_baset &symbol_table);
 
-  bool interfaces(symbol_table_baset &symbol_table);
+  bool interfaces(
+    symbol_table_baset &symbol_table,
+    message_handlert &message_handler);
 
   // The method must have been added to the symbol table and registered
   // in lazy_method_map (currently always in language_filest::typecheck)
@@ -134,7 +139,7 @@ public:
     PRECONDITION(symbol_table.has_symbol(id));
     lazy_method_mapt::iterator it=lazy_method_map.find(id);
     if(it!=lazy_method_map.end())
-      it->second->convert_lazy_method(id, symbol_table);
+      it->second->convert_lazy_method(id, symbol_table, message_handler);
   }
 
   bool can_convert_lazy_method(const irep_idt &id) const

--- a/src/langapi/language_util.cpp
+++ b/src/langapi/language_util.cpp
@@ -9,6 +9,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include "language_util.h"
 
 #include <util/invariant.h>
+#include <util/message.h>
 #include <util/namespace.h>
 #include <util/std_expr.h>
 #include <util/symbol_table.h>
@@ -93,14 +94,13 @@ exprt to_expr(
 {
   std::unique_ptr<languaget> p(get_language_from_identifier(ns, identifier));
 
-  null_message_handlert null_message_handler;
-  p->set_message_handler(null_message_handler);
-
   const symbolt &symbol=ns.lookup(identifier);
 
   exprt expr;
 
-  if(p->to_expr(src, id2string(symbol.module), expr, ns))
+  null_message_handlert null_message_handler;
+
+  if(p->to_expr(src, id2string(symbol.module), expr, ns, null_message_handler))
     return nil_exprt();
 
   return expr;

--- a/src/statement-list/statement_list_language.cpp
+++ b/src/statement-list/statement_list_language.cpp
@@ -22,32 +22,35 @@ Author: Matthias Weiss, matthias.weiss@diffblue.com
 #include <util/make_unique.h>
 #include <util/symbol_table.h>
 
-void statement_list_languaget::set_language_options(const optionst &options)
+void statement_list_languaget::set_language_options(
+  const optionst &options,
+  message_handlert &)
 {
   params = object_factory_parameterst{options};
 }
 
 bool statement_list_languaget::generate_support_functions(
-  symbol_table_baset &symbol_table)
+  symbol_table_baset &symbol_table,
+  message_handlert &message_handler)
 {
-  return statement_list_entry_point(symbol_table, get_message_handler());
+  return statement_list_entry_point(symbol_table, message_handler);
 }
 
 bool statement_list_languaget::typecheck(
   symbol_table_baset &symbol_table,
   const std::string &module,
+  message_handlert &message_handler,
   const bool keep_file_local)
 {
   symbol_tablet new_symbol_table;
 
   if(statement_list_typecheck(
-       parse_tree, new_symbol_table, module, get_message_handler()))
+       parse_tree, new_symbol_table, module, message_handler))
     return true;
 
-  remove_internal_symbols(
-    new_symbol_table, get_message_handler(), keep_file_local);
+  remove_internal_symbols(new_symbol_table, message_handler, keep_file_local);
 
-  if(linking(symbol_table, new_symbol_table, get_message_handler()))
+  if(linking(symbol_table, new_symbol_table, message_handler))
     return true;
 
   return false;
@@ -55,7 +58,8 @@ bool statement_list_languaget::typecheck(
 
 bool statement_list_languaget::parse(
   std::istream &instream,
-  const std::string &path)
+  const std::string &path,
+  message_handlert &message_handler)
 {
   statement_list_parser.clear();
   parse_path = path;
@@ -71,7 +75,7 @@ bool statement_list_languaget::parse(
   return result;
 }
 
-void statement_list_languaget::show_parse(std::ostream &out)
+void statement_list_languaget::show_parse(std::ostream &out, message_handlert &)
 {
   output_parse_tree(out, parse_tree);
 }
@@ -83,9 +87,10 @@ bool statement_list_languaget::can_keep_file_local()
 
 bool statement_list_languaget::typecheck(
   symbol_table_baset &symbol_table,
-  const std::string &module)
+  const std::string &module,
+  message_handlert &message_handler)
 {
-  return typecheck(symbol_table, module, true);
+  return typecheck(symbol_table, module, message_handler, true);
 }
 
 bool statement_list_languaget::from_expr(
@@ -118,7 +123,8 @@ bool statement_list_languaget::to_expr(
   const std::string &,
   const std::string &,
   exprt &,
-  const namespacet &)
+  const namespacet &,
+  message_handlert &)
 {
   return true;
 }

--- a/src/statement-list/statement_list_language.h
+++ b/src/statement-list/statement_list_language.h
@@ -26,38 +26,51 @@ public:
   /// Sets language specific options.
   /// \param options: Options that shall apply during the parse and
   ///   typecheck process.
-  void set_language_options(const optionst &options) override;
+  /// \param message_handler: Message handler.
+  void set_language_options(
+    const optionst &options,
+    message_handlert &message_handler) override;
 
   /// Parses input given by \p instream and saves this result to this
   /// instance's parse tree.
   /// \param instream: Input to parse.
   /// \param path: Path of the input.
+  /// \param message_handler: Message handler.
   /// \return False if successful.
-  bool parse(std::istream &instream, const std::string &path) override;
+  bool parse(
+    std::istream &instream,
+    const std::string &path,
+    message_handlert &message_handler) override;
 
   /// Currently unused.
-  bool generate_support_functions(symbol_table_baset &symbol_table) override;
+  bool generate_support_functions(
+    symbol_table_baset &symbol_table,
+    message_handlert &) override;
 
   /// Converts the current parse tree into a symbol table.
   /// \param [out] symbol_table: Object that shall be filled by this function.
   ///   If the symbol table is not empty when calling this function, its
   ///   contents are merged with the new entries.
   /// \param module: Name of the file that has been parsed.
+  /// \param message_handler: Message handler.
   /// \param keep_file_local: Set to true if local variables of this module
   ///   should be included in the table.
   /// \return False if no errors occurred, true otherwise.
   bool typecheck(
     symbol_table_baset &symbol_table,
     const std::string &module,
+    message_handlert &message_handler,
     const bool keep_file_local) override;
 
-  bool typecheck(symbol_table_baset &symbol_table, const std::string &module)
-    override;
+  bool typecheck(
+    symbol_table_baset &symbol_table,
+    const std::string &module,
+    message_handlert &) override;
 
   bool can_keep_file_local() override;
 
   /// Prints the parse tree to the given output stream.
-  void show_parse(std::ostream &out) override;
+  void show_parse(std::ostream &out, message_handlert &) override;
 
   // Constructor and destructor.
   ~statement_list_languaget() override;
@@ -92,12 +105,14 @@ public:
   /// \param module: prefix to be used for identifiers
   /// \param expr: the parsed expression
   /// \param ns: a namespace
+  /// \param message_handler: Message handler.
   /// \return false if the conversion succeeds
   bool to_expr(
     const std::string &code,
     const std::string &module,
     exprt &expr,
-    const namespacet &ns) override;
+    const namespacet &ns,
+    message_handlert &message_handler) override;
 
   std::unique_ptr<languaget> new_language() override;
 

--- a/src/symtab2gb/symtab2gb_parse_options.cpp
+++ b/src/symtab2gb/symtab2gb_parse_options.cpp
@@ -69,7 +69,6 @@ static void run_symtab2gb(
     cmdline_verbosity, messaget::M_STATISTICS, message_handler);
 
   auto const symtab_language = new_json_symtab_language();
-  symtab_language->set_message_handler(message_handler);
 
   symbol_tablet linked_symbol_table;
 
@@ -77,7 +76,8 @@ static void run_symtab2gb(
   {
     auto const &symtab_filename = symtab_filenames[ix];
     auto &symtab_file = symtab_files[ix];
-    if(failed(symtab_language->parse(symtab_file, symtab_filename)))
+    if(failed(
+         symtab_language->parse(symtab_file, symtab_filename, message_handler)))
     {
       source_locationt source_location;
       source_location.set_file(symtab_filename);
@@ -85,7 +85,7 @@ static void run_symtab2gb(
         "failed to parse symbol table", source_location};
     }
     symbol_tablet symtab{};
-    if(failed(symtab_language->typecheck(symtab, "<unused>")))
+    if(failed(symtab_language->typecheck(symtab, "<unused>", message_handler)))
     {
       source_locationt source_location;
       source_location.set_file(symtab_filename);

--- a/unit/analyses/ai/ai_simplify_lhs.cpp
+++ b/unit/analyses/ai/ai_simplify_lhs.cpp
@@ -72,9 +72,7 @@ bool constant_simplification_mockt::ai_simplify(
 SCENARIO("ai_domain_baset::ai_simplify_lhs",
   "[core][analyses][ai][ai_simplify_lhs]")
 {
-  ui_message_handlert message_handler(null_message_handler);
   ansi_c_languaget language;
-  language.set_message_handler(message_handler);
 
   symbol_tablet symbol_table;
   namespacet ns(symbol_table);
@@ -87,8 +85,8 @@ SCENARIO("ai_domain_baset::ai_simplify_lhs",
   {
     // Construct an expression that the simplify_expr can simplify
     exprt simplifiable_expression;
-    bool compile_failed=
-      language.to_expr("1 + 1", "", simplifiable_expression, ns);
+    bool compile_failed = language.to_expr(
+      "1 + 1", "", simplifiable_expression, ns, null_message_handler);
 
     const unsigned int array_size=5;
     array_typet array_type(

--- a/unit/testing-utils/get_goto_model_from_c.cpp
+++ b/unit/testing-utils/get_goto_model_from_c.cpp
@@ -51,10 +51,9 @@ goto_modelt get_goto_model_from_c(std::istream &in)
   CHECK_RETURN(language_file.language);
 
   languaget &language = *language_file.language;
-  language.set_message_handler(null_message_handler);
 
   {
-    const bool error = language.parse(in, "");
+    const bool error = language.parse(in, "", null_message_handler);
 
     if(error)
       throw invalid_input_exceptiont("parsing failed");
@@ -73,8 +72,8 @@ goto_modelt get_goto_model_from_c(std::istream &in)
   }
 
   {
-    const bool error =
-      language_files.generate_support_functions(goto_model.symbol_table);
+    const bool error = language_files.generate_support_functions(
+      goto_model.symbol_table, null_message_handler);
 
     if(error)
       throw invalid_input_exceptiont("support function generation failed");


### PR DESCRIPTION
Pass a message handler as an argument to several of its functions, but do not
construct a messaget object without a configured message handler as that is
deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
