### PR TITLE
Cleanup use of messaget in unit tests [blocks: #3800]

### DIFF
--- a/jbmc/unit/solvers/strings/string_refinement/string_symbol_resolution.cpp
+++ b/jbmc/unit/solvers/strings/string_refinement/string_symbol_resolution.cpp
@@ -7,6 +7,7 @@ Author: Diffblue Ltd.
 
 \*******************************************************************/
 
+#include <testing-utils/message.h>
 #include <testing-utils/use_catch.h>
 
 #include <solvers/strings/string_refinement.h>
@@ -27,7 +28,7 @@ SCENARIO(
   register_language(new_java_bytecode_language);
   symbol_tablet symbol_table;
   namespacet ns(symbol_table);
-  messaget::mstreamt &stream = messaget().debug();
+  messaget::mstreamt &stream = messaget(null_message_handler).debug();
 
   GIVEN("Some equations")
   {

--- a/unit/analyses/dependence_graph.cpp
+++ b/unit/analyses/dependence_graph.cpp
@@ -6,18 +6,19 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 
 \*******************************************************************/
 
-#include <iostream>
+#include <testing-utils/call_graph_test_utils.h>
+#include <testing-utils/message.h>
+#include <testing-utils/use_catch.h>
+
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/std_code.h>
+#include <util/symbol_table.h>
 
 #include <analyses/dependence_graph.h>
 #include <ansi-c/ansi_c_language.h>
 #include <goto-programs/goto_convert_functions.h>
 #include <langapi/mode.h>
-#include <testing-utils/call_graph_test_utils.h>
-#include <testing-utils/use_catch.h>
-#include <util/arith_tools.h>
-#include <util/c_types.h>
-#include <util/std_code.h>
-#include <util/symbol_table.h>
 
 const std::set<goto_programt::const_targett>&
     dependence_graph_test_get_control_deps(const dep_graph_domaint &domain)
@@ -83,8 +84,7 @@ SCENARIO("dependence_graph", "[core][analyses][dependence_graph]")
     goto_model.symbol_table.add(
       create_void_function_symbol("b", code_skipt()));
 
-    stream_message_handlert msg(std::cerr);
-    goto_convert(goto_model, msg);
+    goto_convert(goto_model, null_message_handler);
 
     WHEN("Constructing a dependence graph")
     {

--- a/unit/util/message.cpp
+++ b/unit/util/message.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Assign a messaget")
   messaget msg1(handler1);
 
   // Assign messaget:
-  messaget msg2;
+  messaget msg2(handler1);
   msg2=msg1;
 
   // Change its handler:


### PR DESCRIPTION
Constructing a messaget without a message handler is deprecated. Don't
unnecessarily include iostream, use a (null) message handler instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
