### PR TITLE
I/O names must be unique across multiple conversions

### DIFF
--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -603,8 +603,6 @@ void symex_target_equationt::convert_assertions(
 void symex_target_equationt::convert_function_calls(
   decision_proceduret &dec_proc)
 {
-  std::size_t argument_count=0;
-
   for(auto &step : SSA_steps)
     if(!step.ignore)
     {

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -633,8 +633,6 @@ void symex_target_equationt::convert_function_calls(
 void symex_target_equationt::convert_io(
   decision_proceduret &dec_proc)
 {
-  std::size_t io_count=0;
-
   for(auto &step : SSA_steps)
     if(!step.ignore)
     {

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -405,6 +405,9 @@ protected:
   // for enforcing sharing in the expressions stored
   merge_irept merge_irep;
   void merge_ireps(SSA_stept &SSA_step);
+
+  // for unique I/O identifiers
+  std::size_t io_count = 0;
 };
 
 inline bool operator<(

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -408,6 +408,9 @@ protected:
 
   // for unique I/O identifiers
   std::size_t io_count = 0;
+
+  // for unique function call argument identifiers
+  std::size_t argument_count = 0;
 };
 
 inline bool operator<(


### PR DESCRIPTION
Necessary for incremental unwinding, which performs incremental conversions of symex_target_equationt.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
