### PR TITLE
remove base_type_eq and type_eq: C/C++ edition

### DIFF
--- a/src/ansi-c/c_typecast.cpp
+++ b/src/ansi-c/c_typecast.cpp
@@ -13,7 +13,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <cassert>
 
 #include <util/arith_tools.h>
-#include <util/base_type.h>
 #include <util/c_types.h>
 #include <util/config.h>
 #include <util/expr_util.h>
@@ -551,7 +550,7 @@ void c_typecastt::implicit_typecast_followed(
         // very generous:
         // between any two function pointers it's ok
       }
-      else if(base_type_eq(src_sub, dest_sub, ns))
+      else if(src_sub == dest_sub)
       {
         // ok
       }
@@ -565,9 +564,9 @@ void c_typecastt::implicit_typecast_followed(
         // Also generous: between any to scalar types it's ok.
         // We should probably check the size.
       }
-      else if(src_sub.id()==ID_array &&
-              dest_sub.id()==ID_array &&
-              base_type_eq(src_sub.subtype(), dest_sub.subtype(), ns))
+      else if(
+        src_sub.id() == ID_array && dest_sub.id() == ID_array &&
+        src_sub.subtype() == dest_sub.subtype())
       {
         // we ignore the size of the top-level array
         // in the case of pointers to arrays

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -14,7 +14,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <cassert>
 
 #include <util/arith_tools.h>
-#include <util/base_type.h>
 #include <util/c_types.h>
 #include <util/config.h>
 #include <util/cprover_prefix.h>
@@ -1064,9 +1063,9 @@ void c_typecheck_baset::typecheck_expr_typecast(exprt &expr)
 
   const typet expr_type=follow(expr.type());
 
-  if(expr_type.id()==ID_union &&
-     !base_type_eq(expr_type, op.type(), *this) &&
-     op.id()!=ID_initializer_list)
+  if(
+    expr_type.id() == ID_union && expr_type != op.type() &&
+    op.id() != ID_initializer_list)
   {
     // This is a GCC extension. It's either a 'temporary union',
     // where the argument is one of the member types.
@@ -1080,7 +1079,7 @@ void c_typecheck_baset::typecheck_expr_typecast(exprt &expr)
     // we need to find a member with the right type
     for(const auto &c : to_union_type(expr_type).components())
     {
-      if(base_type_eq(c.type(), op.type(), *this))
+      if(c.type() == op.type())
       {
         // found! build union constructor
         union_exprt union_expr(c.get_name(), op, expr.type());
@@ -1131,7 +1130,7 @@ void c_typecheck_baset::typecheck_expr_typecast(exprt &expr)
   const typet op_type = op.type();
 
   // cast to same type?
-  if(base_type_eq(expr_type, op_type, *this))
+  if(expr_type == op_type)
     return; // it's ok
 
   // vectors?
@@ -2516,8 +2515,7 @@ exprt c_typecheck_baset::do_special_functions(
       expr.arguments().front(), expr.arguments().back());
     equality_expr.add_source_location()=source_location;
 
-    if(!base_type_eq(equality_expr.lhs().type(),
-                     equality_expr.rhs().type(), *this))
+    if(equality_expr.lhs().type() != equality_expr.rhs().type())
     {
       error().source_location = f_op.source_location();
       error() << "equal expects two operands of same type" << eom;

--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -19,7 +19,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/simplify_expr.h>
 #include <util/std_types.h>
 #include <util/string_constant.h>
-#include <util/type_eq.h>
 
 #include "anonymous_member.h"
 

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -16,7 +16,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #endif
 
 #include <util/arith_tools.h>
-#include <util/base_type.h>
 #include <util/c_types.h>
 #include <util/config.h>
 #include <util/expr_initializer.h>
@@ -2373,9 +2372,9 @@ void cpp_typecheckt::typecheck_method_application(
     if(expr.arguments().size()==func_type.parameters().size())
     {
       // this might be set up for base-class initialisation
-      if(!base_type_eq(expr.arguments().front().type(),
-                      func_type.parameters().front().type(),
-                      *this))
+      if(
+        expr.arguments().front().type() !=
+        func_type.parameters().front().type())
       {
         implicit_typecast(expr.arguments().front(), this_type);
         assert(is_reference(expr.arguments().front().type()));


### PR DESCRIPTION
These are no longer needed, as symbol_type is no longer in use.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
