### PR TITLE
with_exprt need only have an odd number of operands [blocks: #2068]

### DIFF
--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -3445,8 +3445,8 @@ inline const with_exprt &to_with_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_with);
   DATA_INVARIANT(
-    expr.operands().size()==3,
-    "Array/structure update must have three operands");
+    expr.operands().size() >= 3 && expr.operands().size() % 2 == 1,
+    "array/structure update must have at least three operands");
   return static_cast<const with_exprt &>(expr);
 }
 
@@ -3455,8 +3455,8 @@ inline with_exprt &to_with_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_with);
   DATA_INVARIANT(
-    expr.operands().size()==3,
-    "Array/structure update must have three operands");
+    expr.operands().size() >= 3 && expr.operands().size() % 2 == 1,
+    "array/structure update must have at least three operands");
   return static_cast<with_exprt &>(expr);
 }
 
@@ -3466,10 +3466,9 @@ template<> inline bool can_cast_expr<with_exprt>(const exprt &base)
 }
 inline void validate_expr(const with_exprt &value)
 {
-  validate_operands(
-    value,
-    3,
-    "Array/structure update must have three operands");
+  DATA_INVARIANT(
+    value.operands().size() % 2 == 1,
+    "array/structure update must have an odd number of operands");
 }
 
 class index_designatort : public expr_protectedt


### PR DESCRIPTION
More than three operands are permitted and supported.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
