### PR TITLE
Simplify index_exprt over vectors [blocks: #2068]

### DIFF
--- a/src/util/simplify_expr_array.cpp
+++ b/src/util/simplify_expr_array.cpp
@@ -111,8 +111,9 @@ bool simplify_exprt::simplify_index(exprt &expr)
       return false;
     }
   }
-  else if(array.id()==ID_constant ||
-          array.id()==ID_array)
+  else if(
+    array.id() == ID_constant || array.id() == ID_array ||
+    array.id() == ID_vector)
   {
     const auto i = numeric_cast<mp_integer>(expr.op1());
 
@@ -181,14 +182,18 @@ bool simplify_exprt::simplify_index(exprt &expr)
   else if(array.id()==ID_byte_extract_little_endian ||
           array.id()==ID_byte_extract_big_endian)
   {
-    if(array.type().id() == ID_array)
+    if(array.type().id() == ID_array || array.type().id() == ID_vector)
     {
-      const auto &array_type = to_array_type(array.type());
+      optionalt<typet> subtype;
+      if(array.type().id() == ID_array)
+        subtype = to_array_type(array.type()).subtype();
+      else
+        subtype = to_vector_type(array.type()).subtype();
 
       // This rewrites byte_extract(s, o, array_type)[i]
       // to byte_extract(s, o+offset, sub_type)
 
-      auto sub_size = pointer_offset_size(array_type.subtype(), ns);
+      auto sub_size = pointer_offset_size(*subtype, ns);
       if(!sub_size.has_value())
         return true;
 


### PR DESCRIPTION
All the simplification rules that apply for array_typet can also be used with
vector_typet.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
