### PR TITLE
byte_extract lowering: lower newly introduced byte_extract expressions [depends-on: #4061, blocks: #2068]

### DIFF
--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -289,7 +289,7 @@ exprt lower_byte_extract(const byte_extract_exprt &src, const namespacet &ns)
       tmp.type()=comp.type();
       tmp.offset()=new_offset;
 
-      s.add_to_operands(std::move(tmp));
+      s.add_to_operands(lower_byte_extract(tmp, ns));
     }
 
     if(!failed)

--- a/unit/solvers/lowering/byte_operators.cpp
+++ b/unit/solvers/lowering/byte_operators.cpp
@@ -162,9 +162,8 @@ SCENARIO("byte_extract_lowering", "[core][solvers][lowering][byte_extract]")
             const exprt lower_be = lower_byte_extract(be, ns);
             const exprt lower_be_s = simplify_expr(lower_be, ns);
 
-            // TODO: does not currently hold
-            // REQUIRE(!has_subexpr(lower_be, ID_byte_extract_little_endian));
-            // REQUIRE(!has_subexpr(lower_be, ID_byte_extract_big_endian));
+            REQUIRE(!has_subexpr(lower_be, ID_byte_extract_little_endian));
+            REQUIRE(!has_subexpr(lower_be, ID_byte_extract_big_endian));
             REQUIRE(lower_be.type() == be.type());
             // TODO: does not currently hold
             // REQUIRE(lower_be == r);


### PR DESCRIPTION
Only the second commit is new, the first one is #4061.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
