### PR TITLE
byte_extract lowering: ensure type consistency [blocks: #2068]

### DIFF
--- a/regression/cbmc/Pointer_byte_extract3/test.desc
+++ b/regression/cbmc/Pointer_byte_extract3/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Pointer_byte_extract7/test.desc
+++ b/regression/cbmc/Pointer_byte_extract7/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 main.c
 --big-endian
 ^EXIT=0$

--- a/regression/cbmc/equality_through_union1/test.desc
+++ b/regression/cbmc/equality_through_union1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/equality_through_union2/test.desc
+++ b/regression/cbmc/equality_through_union2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/equality_through_union3/test.desc
+++ b/regression/cbmc/equality_through_union3/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/gcc_vector1/test.desc
+++ b/regression/cbmc/gcc_vector1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/trace_address_arithmetic1/test.desc
+++ b/regression/cbmc/trace_address_arithmetic1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 main.c
 --trace
 ^EXIT=10$

--- a/regression/cbmc/union11/union_list.desc
+++ b/regression/cbmc/union11/union_list.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 union_list.c
 
 ^EXIT=0$

--- a/regression/cbmc/union8/test.desc
+++ b/regression/cbmc/union8/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 main.c
 
 ^EXIT=0$

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -343,8 +343,10 @@ exprt lower_byte_extract(const byte_extract_exprt &src, const namespacet &ns)
     return simplify_expr(typecast_exprt(op.front(), src.type()), ns);
   else // width_bytes>=2
   {
-    concatenation_exprt concatenation(std::move(op), src.type());
-    return simplify_expr(concatenation, ns);
+    concatenation_exprt concatenation(
+      std::move(op), bitvector_typet(subtype.id(), width_bytes * 8));
+    return simplify_expr(
+      typecast_exprt(std::move(concatenation), src.type()), ns);
   }
 }
 

--- a/unit/solvers/lowering/byte_operators.cpp
+++ b/unit/solvers/lowering/byte_operators.cpp
@@ -104,8 +104,8 @@ SCENARIO("byte_extract_lowering", "[core][solvers][lowering][byte_extract]")
     constant_exprt size = from_integer(8, size_type());
 
     std::vector<typet> types = {
-    // struct_typet({{"comp1", u16}, {"comp2", u16}}),
-    // struct_typet({{"comp1", u32}, {"comp2", u64}}),
+      struct_typet({{"comp1", u16}, {"comp2", u16}}),
+      struct_typet({{"comp1", u32}, {"comp2", u64}}),
 #if 0
       // not currently handled: components not byte aligned
       struct_typet({{"comp1", u32},
@@ -114,8 +114,8 @@ SCENARIO("byte_extract_lowering", "[core][solvers][lowering][byte_extract]")
                     {"comp2", u8}}),
 #endif
       // union_typet({{"compA", u32}, {"compB", u64}}),
-      // c_enum_typet(u16),
-      // c_enum_typet(unsignedbv_typet(128)),
+      c_enum_typet(u16),
+      c_enum_typet(unsignedbv_typet(128)),
       // array_typet(u8, size),
       // array_typet(s32, size),
       // array_typet(u64, size),
@@ -193,10 +193,8 @@ SCENARIO("byte_extract_lowering", "[core][solvers][lowering][byte_extract]")
             REQUIRE(!has_subexpr(lower_be, ID_byte_extract_little_endian));
             REQUIRE(!has_subexpr(lower_be, ID_byte_extract_big_endian));
             REQUIRE(lower_be.type() == be.type());
-            // TODO: does not currently hold
-            // REQUIRE(lower_be == r);
-            // TODO: does not currently hold
-            // REQUIRE(lower_be_s == r);
+            REQUIRE(lower_be == r);
+            REQUIRE(lower_be_s == r);
           }
         }
       }


### PR DESCRIPTION
Only the second commit is new, the first one is #4061.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
