### PR TITLE
Add function for reverting formula slicing

### DIFF
--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -262,3 +262,12 @@ void simple_slice(symex_target_equationt &equation)
       s_it->ignore=true;
   }
 }
+
+void revert_slice(symex_target_equationt &equation)
+{
+  // set ignore to false
+  for(auto step : equation.SSA_steps)
+  {
+    step.ignore = false;
+  }
+}

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -19,6 +19,9 @@ Author: Daniel Kroening, kroening@kroening.com
 // slice an equation with respect to the assertions contained therein
 void slice(symex_target_equationt &equation);
 
+/// Undo whatever has been done by `slice`
+void revert_slice(symex_target_equationt &);
+
 // this simply slices away anything after the last assertion
 void simple_slice(symex_target_equationt &equation);
 


### PR DESCRIPTION
This functionality is necessary to use slicing of symex_target_equationt
in combination with incremental unwinding.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
