### PR TITLE
Only convert not-yet-converted SSA steps

### DIFF
--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -171,12 +171,12 @@ public:
   /// Converts assignments: set the equality _lhs==rhs_ to _True_.
   /// \param decision_procedure: A handle to a particular decision procedure
   ///  interface
-  void convert_assignments(decision_proceduret &decision_procedure) const;
+  void convert_assignments(decision_proceduret &decision_procedure);
 
   /// Converts declarations: these are effectively ignored by the decision
   /// procedure.
   /// \param prop_conv: A handle to a particular decision procedure interface
-  void convert_decls(prop_convt &prop_conv) const;
+  void convert_decls(prop_convt &prop_conv);
 
   /// Converts assumptions: convert the expression the assumption represents.
   /// \param prop_conv: A handle to a particular decision procedure interface
@@ -189,7 +189,7 @@ public:
   /// Converts constraints: set the represented condition to _True_.
   /// \param decision_procedure: A handle to a particular decision procedure
   ///  interface
-  void convert_constraints(decision_proceduret &decision_procedure) const;
+  void convert_constraints(decision_proceduret &decision_procedure);
 
   /// Converts goto instructions: convert the expression representing the
   /// condition of this goto.
@@ -321,6 +321,9 @@ public:
     // for slicing
     bool ignore=false;
 
+    // for incremental conversion
+    bool converted = false;
+
     SSA_stept(const sourcet &_source, goto_trace_stept::typet _type)
       : source(_source),
         type(_type),
@@ -354,7 +357,7 @@ public:
   {
     return narrow_cast<std::size_t>(std::count_if(
       SSA_steps.begin(), SSA_steps.end(), [](const SSA_stept &step) {
-        return step.is_assert();
+        return step.is_assert() && !step.ignore && !step.converted;
       }));
   }
 


### PR DESCRIPTION
Necessary to enable incremental extension and conversion of the symex target equation during incremental unwinding. This also works in combination with `slice`.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
