### PR TITLE
smt2_convt still assumes binary encoding

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -276,6 +276,9 @@ constant_exprt smt2_convt::parse_literal(
       constant_exprt s3 =
         parse_literal(src.get_sub()[3], unsignedbv_typet(floatbv_type.get_f()));
       // stitch the bits together
+      // TODO we do not store values as binary string anymore, this appears to
+      // be unused or untested
+      UNREACHABLE;
       std::string bits=id2string(s1.get_value())+
                        id2string(s2.get_value())+
                        id2string(s3.get_value());
@@ -418,6 +421,9 @@ exprt smt2_convt::parse_struct(
     if(!l.is_constant())
       return nil_exprt();
 
+    // TODO we do not store values as binary string anymore, this appears to
+    // be unused or untested
+    UNREACHABLE;
     irep_idt binary=to_constant_expr(l).get_value();
     if(binary.size()!=total_width)
       return nil_exprt();
@@ -3110,6 +3116,9 @@ void smt2_convt::convert_rounding_mode_FPA(const exprt &expr)
   {
     const constant_exprt &cexpr=to_constant_expr(expr);
 
+    // TODO we do not store values as binary string anymore, this appears to
+    // be unused or untested
+    UNREACHABLE;
     mp_integer value=binary2integer(id2string(cexpr.get_value()), false);
 
     if(value==0)


### PR DESCRIPTION
Mark several cases as UNREACHABLE as apparently we either don't test or don't
use this code.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
