### PR TITLE
Avoid narrowing conversion in `optional`

### DIFF
--- a/src/nonstd/optional.hpp
+++ b/src/nonstd/optional.hpp
@@ -356,7 +356,7 @@ struct alignment_of_hack
     alignment_of_hack();
 };
 
-template <unsigned A, unsigned S>
+template <std::size_t A, std::size_t S>
 struct alignment_logic
 {
     enum { value = A < S ? A : S };


### PR DESCRIPTION
This issue was causing compile warnings on Ubuntu 18, when compiling
with conversion warnings enabled. The result of `size_of` was being
converted to `unsigned` which is a narrowing conversion on 64 bit
platforms. This commit fixes this issue by changing the type to
`std::size_t`, which is large enough to store the result of `size_of`
without a narrowing conversion.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
