### PR TITLE
String refinement must not rely on input equations to be simplified

### DIFF
--- a/jbmc/regression/strings-smoke-tests/java_starts_with/test-no-simplify.desc
+++ b/jbmc/regression/strings-smoke-tests/java_starts_with/test-no-simplify.desc
@@ -1,0 +1,14 @@
+CORE
+test_starts_with.class
+--verbosity 10 --max-nondet-string-length 1000 --function test_starts_with.main --unwind 1 --no-simplify
+^EXIT=10$
+^SIGNAL=0$
+^\[.*assertion.1\].* line 8.* SUCCESS$
+^\[.*assertion.2\].* line 9.* FAILURE$
+--
+non equal types
+--
+This test must also pass when not running simplification during goto-symex
+(--no-simplify). Prior to the changes in this commit the test would yield wrong
+results for either line 8, because the string solver was not able to identify
+the string object in a non-simplified expression.

--- a/src/solvers/strings/string_constraint_generator_main.cpp
+++ b/src/solvers/strings/string_constraint_generator_main.cpp
@@ -26,6 +26,7 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include <util/arith_tools.h>
 #include <util/deprecate.h>
 #include <util/pointer_predicates.h>
+#include <util/simplify_expr.h>
 #include <util/ssa_expr.h>
 #include <util/string_constant.h>
 
@@ -180,7 +181,7 @@ exprt string_constraint_generatort::associate_array_to_pointer(
                                       : f.arguments()[0]);
 
   const exprt &pointer_expr = f.arguments()[1];
-  array_pool.insert(pointer_expr, array_expr);
+  array_pool.insert(simplify_expr(pointer_expr, ns), array_expr);
   // created_strings.emplace(to_array_string_expr(array_expr));
   return from_integer(0, f.type());
 }

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -339,7 +339,7 @@ static void add_equations_for_symbol_resolution(
 
     if(is_char_pointer_type(rhs.type()))
     {
-      symbol_solver.make_union(lhs, rhs);
+      symbol_solver.make_union(lhs, simplify_expr(rhs, ns));
     }
     else if(rhs.id() == ID_function_application)
     {
@@ -439,7 +439,7 @@ static void add_string_equation_to_symbol_resolution(
 {
   if(eq.rhs().type() == string_typet())
   {
-    symbol_resolve.make_union(eq.lhs(), eq.rhs());
+    symbol_resolve.make_union(eq.lhs(), simplify_expr(eq.rhs(), ns));
   }
   else if(has_subtype(eq.lhs().type(), ID_string, ns))
   {
@@ -646,7 +646,10 @@ decision_proceduret::resultt string_refinementt::dec_solve()
   for(equal_exprt &eq : equations)
   {
     if(can_cast_expr<function_application_exprt>(eq.rhs()))
+    {
+      simplify(eq.rhs(), ns);
       string_id_symbol_resolve.replace_expr(eq.rhs());
+    }
   }
 
   // Generator is also used by get, so we have to use it as a class member


### PR DESCRIPTION
JBMC would produce wrong results when running the newly added test.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
