### PR TITLE
Update CODEOWNERS to reflect string solver move

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,6 +31,7 @@
 /src/goto-programs/ @smowton @kroening @tautschnig @peterschrammel @pkesseli
 /src/util/ @smowton @kroening @tautschnig @peterschrammel @pkesseli
 /src/solvers/refinement @martin-cs @romainbrenguier @peterschrammel
+/src/solvers/strings @martin-cs @romainbrenguier @peterschrammel
 /jbmc/src/java_bytecode/ @smowton @mgudemann @thk123 @cristina-david @cesaro @pkesseli @NathanJPhillips @peterschrammel
 /src/analyses/ @martin-cs @peterschrammel @chrisr-diffblue @thk123 @smowton
 /src/pointer-analysis/ @martin-cs @peterschrammel @chrisr-diffblue @smowton


### PR DESCRIPTION
In 39a03aad7e1710fc651fdd51a269f84f9137bfb8 several files were moved to
solvers/strings, but CODEOWNERS was not updated accordingly.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
