### PR TITLE
Remove unnecessary "--verbosity 10" from regression tests

### DIFF
--- a/jbmc/regression/jbmc-strings/StringBuilderSetCharAt/test_det.desc
+++ b/jbmc/regression/jbmc-strings/StringBuilderSetCharAt/test_det.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---function Test.det --verbosity 10
+--function Test.det
 ^EXIT=10$
 ^SIGNAL=0$
 assertion at file Test.java line 22 .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringBuilderSetCharAt/test_nondet.desc
+++ b/jbmc/regression/jbmc-strings/StringBuilderSetCharAt/test_nondet.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---function Test.nonDet --verbosity 10 --max-nondet-string-length 1000
+--function Test.nonDet --max-nondet-string-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 assertion at file Test.java line 48 .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringConcat/test_buffer_det.desc
+++ b/jbmc/regression/jbmc-strings/StringConcat/test_buffer_det.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---max-nondet-string-length 100 --function Test.bufferDet --depth 10000  --verbosity 10
+--max-nondet-string-length 100 --function Test.bufferDet --depth 10000
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/jbmc-strings/StringConcat/test_buffer_nondet_loop.desc
+++ b/jbmc/regression/jbmc-strings/StringConcat/test_buffer_nondet_loop.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---max-nondet-string-length 100 --function Test.bufferNonDetLoop --depth 10000 --unwind 5  --verbosity 10  --property 'java::Test.bufferNonDetLoop:(ILjava/lang/String;)Ljava/lang/String;.assertion.1'
+--max-nondet-string-length 100 --function Test.bufferNonDetLoop --depth 10000 --unwind 5   --property 'java::Test.bufferNonDetLoop:(ILjava/lang/String;)Ljava/lang/String;.assertion.1'
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/jbmc-strings/StringConcat/test_buffer_nondet_loop2.desc
+++ b/jbmc/regression/jbmc-strings/StringConcat/test_buffer_nondet_loop2.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---max-nondet-string-length 100 --function Test.bufferNonDetLoop2 --depth 10000 --unwind 5  --verbosity 10
+--max-nondet-string-length 100 --function Test.bufferNonDetLoop2 --depth 10000 --unwind 5
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/jbmc-strings/StringConcat/test_buffer_nondet_loop3.desc
+++ b/jbmc/regression/jbmc-strings/StringConcat/test_buffer_nondet_loop3.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---max-nondet-string-length 100 --function Test.bufferNonDetLoop3 --depth 10000 --unwind 5  --verbosity 10
+--max-nondet-string-length 100 --function Test.bufferNonDetLoop3 --depth 10000 --unwind 5
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/jbmc-strings/StringConcat/test_buffer_nondet_loop4.desc
+++ b/jbmc/regression/jbmc-strings/StringConcat/test_buffer_nondet_loop4.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---max-nondet-string-length 100 --function Test.bufferNonDetLoop4 --depth 10000 --unwind 5  --verbosity 10 --property 'java::Test.bufferNonDetLoop4:(IILjava/lang/String;)Ljava/lang/String;.assertion.1'
+--max-nondet-string-length 100 --function Test.bufferNonDetLoop4 --depth 10000 --unwind 5  --property 'java::Test.bufferNonDetLoop4:(IILjava/lang/String;)Ljava/lang/String;.assertion.1'
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/jbmc-strings/StringConcat/test_buffer_nondet_loop5.desc
+++ b/jbmc/regression/jbmc-strings/StringConcat/test_buffer_nondet_loop5.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---max-nondet-string-length 100 --function Test.bufferNonDetLoop5 --depth 10000 --unwind 3 --verbosity 10
+--max-nondet-string-length 100 --function Test.bufferNonDetLoop5 --depth 10000 --unwind 3
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/jbmc-strings/StringConcat/test_char_buffer_det.desc
+++ b/jbmc/regression/jbmc-strings/StringConcat/test_char_buffer_det.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---max-nondet-string-length 100 --function Test.charBufferDet --depth 10000  --verbosity 10
+--max-nondet-string-length 100 --function Test.charBufferDet --depth 10000
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/jbmc-strings/StringConcat/test_char_buffer_det_loop.desc
+++ b/jbmc/regression/jbmc-strings/StringConcat/test_char_buffer_det_loop.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---max-nondet-string-length 100 --function Test.charBufferDetLoop --depth 10000 --unwind 5  --verbosity 10
+--max-nondet-string-length 100 --function Test.charBufferDetLoop --depth 10000 --unwind 5
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/jbmc-strings/StringConcat/test_char_buffer_det_loop2.desc
+++ b/jbmc/regression/jbmc-strings/StringConcat/test_char_buffer_det_loop2.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---max-nondet-string-length 100 --function Test.charBufferDetLoop2 --depth 10000 --unwind 5  --verbosity 10
+--max-nondet-string-length 100 --function Test.charBufferDetLoop2 --depth 10000 --unwind 5
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/jbmc-strings/StringConcat/test_string_det.desc
+++ b/jbmc/regression/jbmc-strings/StringConcat/test_string_det.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---max-nondet-string-length 100 --function Test.stringDet --depth 10000  --verbosity 10
+--max-nondet-string-length 100 --function Test.stringDet --depth 10000
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/jbmc-strings/StringConcat/test_string_nondet.desc
+++ b/jbmc/regression/jbmc-strings/StringConcat/test_string_nondet.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---max-nondet-string-length 100 --function Test.stringNonDet --depth 10000 --unwind 5 --verbosity 10
+--max-nondet-string-length 100 --function Test.stringNonDet --depth 10000 --unwind 5
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/jbmc-strings/StringConcat_StringII/test.desc
+++ b/jbmc/regression/jbmc-strings/StringConcat_StringII/test.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---max-nondet-string-length 4 --verbosity 10 --unwind 5 --function Test.testSuccess --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 4 --unwind 5 --function Test.testSuccess --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=0$
 ^SIGNAL=0$
 assertion at file Test.java line 23 .*: SUCCESS

--- a/jbmc/regression/jbmc-strings/StringConcat_StringII/test_fail.desc
+++ b/jbmc/regression/jbmc-strings/StringConcat_StringII/test_fail.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---max-nondet-string-length 10000 --verbosity 10 --function Test.testFail
+--max-nondet-string-length 10000 --function Test.testFail
 ^EXIT=10$
 ^SIGNAL=0$
 assertion at file Test.java line 38 .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringToLowerCase/test_dependency.desc
+++ b/jbmc/regression/jbmc-strings/StringToLowerCase/test_dependency.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---function Test.withDependency  --verbosity 10 --max-nondet-string-length 10000
+--function Test.withDependency  --max-nondet-string-length 10000
 ^EXIT=10$
 ^SIGNAL=0$
 assertion at file Test.java line 48 .*: SUCCESS

--- a/jbmc/regression/jbmc-strings/StringToLowerCase/test_det.desc
+++ b/jbmc/regression/jbmc-strings/StringToLowerCase/test_det.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---function Test.det  --verbosity 10
+--function Test.det 
 ^EXIT=10$
 ^SIGNAL=0$
 assertion at file Test.java line 11 .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringToLowerCase/test_nondet.desc
+++ b/jbmc/regression/jbmc-strings/StringToLowerCase/test_nondet.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---function Test.nonDet  --verbosity 10 --max-nondet-string-length 1000
+--function Test.nonDet  --max-nondet-string-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 assertion at file Test.java line 31 .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringToUpperCase/test_dependency.desc
+++ b/jbmc/regression/jbmc-strings/StringToUpperCase/test_dependency.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---function Test.withDependency --verbosity 10 --max-nondet-string-length 10000
+--function Test.withDependency --max-nondet-string-length 10000
 ^EXIT=10$
 ^SIGNAL=0$
 assertion at file Test.java line 48 .*: SUCCESS

--- a/jbmc/regression/jbmc-strings/StringToUpperCase/test_det.desc
+++ b/jbmc/regression/jbmc-strings/StringToUpperCase/test_det.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---function Test.det  --verbosity 10
+--function Test.det
 ^EXIT=10$
 ^SIGNAL=0$
 assertion at file Test.java line 11 .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringToUpperCase/test_nondet.desc
+++ b/jbmc/regression/jbmc-strings/StringToUpperCase/test_nondet.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---function Test.nonDet --verbosity 10 --max-nondet-string-length 1000
+--function Test.nonDet --max-nondet-string-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 assertion at file Test.java line 31 .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringValueOfInt/test_det.desc
+++ b/jbmc/regression/jbmc-strings/StringValueOfInt/test_det.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---function Test.checkDet --verbosity 10
+--function Test.checkDet
 ^EXIT=10$
 ^SIGNAL=0$
 assertion at file Test.java line 26 .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringValueOfInt/test_nondet.desc
+++ b/jbmc/regression/jbmc-strings/StringValueOfInt/test_nondet.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---function Test.checkNonDet --verbosity 10
+--function Test.checkNonDet
 ^EXIT=10$
 ^SIGNAL=0$
 assertion at file Test.java line 55 .*: FAILURE

--- a/jbmc/regression/jbmc-strings/max-length/test1.desc
+++ b/jbmc/regression/jbmc-strings/max-length/test1.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---verbosity 10 --max-nondet-string-length 499999 --function Test.checkMaxInputLength
+--max-nondet-string-length 499999 --function Test.checkMaxInputLength
 ^EXIT=0$
 ^SIGNAL=0$
 assertion.* line 9 function java::Test.checkMaxInputLength.* bytecode-index 17: SUCCESS

--- a/jbmc/regression/jbmc-strings/max-length/test2.desc
+++ b/jbmc/regression/jbmc-strings/max-length/test2.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---verbosity 10 --max-nondet-string-length 500000 --function Test.checkMaxInputLength
+--max-nondet-string-length 500000 --function Test.checkMaxInputLength
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 9 function java::Test.checkMaxInputLength.* bytecode-index 17: FAILURE

--- a/jbmc/regression/jbmc-strings/max-length/test3.desc
+++ b/jbmc/regression/jbmc-strings/max-length/test3.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---verbosity 10 --max-nondet-string-length 4001 --function Test.checkMaxLength
+--max-nondet-string-length 4001 --function Test.checkMaxLength
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 25 function java::Test.checkMaxLength.* bytecode-index 27: FAILURE

--- a/jbmc/regression/jbmc-strings/max-length/test4.desc
+++ b/jbmc/regression/jbmc-strings/max-length/test4.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---verbosity 10 --max-nondet-string-length 4000 --function Test.checkMaxLength
+--max-nondet-string-length 4000 --function Test.checkMaxLength
 ^SIGNAL=0$
 --
 ^EXIT=0$

--- a/jbmc/regression/jbmc-strings/string-input-value/test1.desc
+++ b/jbmc/regression/jbmc-strings/string-input-value/test1.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---verbosity 10 --string-input-value fo --string-input-value barr --function Test.checkStringInputValue --string-input-value "" --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--string-input-value fo --string-input-value barr --function Test.checkStringInputValue --string-input-value "" --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.1.*FAILURE

--- a/jbmc/regression/jbmc-strings/string-input-value/test2.desc
+++ b/jbmc/regression/jbmc-strings/string-input-value/test2.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---verbosity 10 --function Test.checkStringInputValue --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--function Test.checkStringInputValue --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.1.*FAILURE

--- a/jbmc/regression/jbmc/annotations1/show_annotation_symbol.desc
+++ b/jbmc/regression/jbmc/annotations1/show_annotation_symbol.desc
@@ -1,6 +1,6 @@
 CORE
 annotations.class
---no-lazy-methods --verbosity 10 --show-symbol-table --function annotations.main
+--no-lazy-methods --show-symbol-table --function annotations.main
 ^EXIT=0$
 ^SIGNAL=0$
 ^Type\.\.\.\.\.\.\.\.: @java::ClassAnnotation struct annotations

--- a/jbmc/regression/jbmc/lambda2/test.desc
+++ b/jbmc/regression/jbmc/lambda2/test.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 SymStream.class
---verbosity 10 --show-goto-functions
+--show-goto-functions
 lambda function reference org/symphonyoss/symphony/clients/model/SymUser\.toSymUser in class \"SymStream\"
 ^EXIT=0
 ^SIGNAL=0

--- a/jbmc/regression/jbmc/lambda2/test_no_crash.desc
+++ b/jbmc/regression/jbmc/lambda2/test_no_crash.desc
@@ -1,6 +1,6 @@
 CORE symex-driven-lazy-loading-expected-failure
 SymStream.class
---no-lazy-methods --verbosity 10 --show-goto-functions
+--no-lazy-methods --show-goto-functions
 ^EXIT=0
 ^SIGNAL=0
 --

--- a/jbmc/regression/jbmc/lvt-unexpected/test.desc
+++ b/jbmc/regression/jbmc/lvt-unexpected/test.desc
@@ -1,6 +1,6 @@
 CORE symex-driven-lazy-loading-expected-failure
 unexpected.class
---verbosity 10 --show-symbol-table
+--show-symbol-table
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/jbmc/regression/jbmc/method_parameters1/test.desc
+++ b/jbmc/regression/jbmc/method_parameters1/test.desc
@@ -1,6 +1,6 @@
 CORE symex-driven-lazy-loading-expected-failure
 method_parameters.class
---verbosity 10 --show-symbol-table
+--show-symbol-table
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/jbmc/regression/jbmc/method_parameters2/test.desc
+++ b/jbmc/regression/jbmc/method_parameters2/test.desc
@@ -1,6 +1,6 @@
 CORE symex-driven-lazy-loading-expected-failure
 method_parameters.class
---verbosity 10 --show-symbol-table
+--show-symbol-table
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/jbmc/regression/strings-smoke-tests/java_append_char/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_append_char/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_append_char.class
---verbosity 10 --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* file test_append_char.java line 23 .* SUCCESS

--- a/jbmc/regression/strings-smoke-tests/java_append_int/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_append_int/test.desc
@@ -1,6 +1,6 @@
 FUTURE
 test_append_int.class
---verbosity 10 --max-nondet-string-length 1000
+--max-nondet-string-length 1000
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/strings-smoke-tests/java_append_string/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_append_string/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_append_string.class
---verbosity 10 --max-nondet-string-length 1000 --function test_append_string.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function test_append_string.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/strings-smoke-tests/java_case/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_case/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_case.class
---verbosity 10 --max-nondet-string-length 1000 --function test_case.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function test_case.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* file test_case.java line 10 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_char_array/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_char_array/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_char_array.class
---verbosity 10 --max-nondet-string-length 1000 --function test_char_array.main
+--max-nondet-string-length 1000 --function test_char_array.main
 ^EXIT=10$
 ^SIGNAL=0$
 .*assertion.* test_char_array.java line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_char_at/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_char_at/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_char_at.class
---verbosity 10 --max-nondet-string-length 1000 --function test_char_at.main
+--max-nondet-string-length 1000 --function test_char_at.main
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/strings-smoke-tests/java_code_point/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_code_point/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_code_point.class
---verbosity 10 --max-nondet-string-length 1000 --function test_code_point.main
+--max-nondet-string-length 1000 --function test_code_point.main
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/strings-smoke-tests/java_contains/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_contains/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_contains.class
---verbosity 10 --max-nondet-string-length 100 --function test_contains.main
+--max-nondet-string-length 100 --function test_contains.main
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 8.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_contains/test_string_printable.desc
+++ b/jbmc/regression/strings-smoke-tests/java_contains/test_string_printable.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 test_contains.class
---verbosity 10 --max-nondet-string-length 100 --string-printable --function test_contains.main
+--max-nondet-string-length 100 --string-printable --function test_contains.main
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 8.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_delete_char_at/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_delete_char_at/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_delete_char_at.class
---verbosity 10 --max-nondet-string-length 1000 --function test_delete_char_at.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function test_delete_char_at.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/strings-smoke-tests/java_endswith/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_endswith/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_endswith.class
---verbosity 10 --max-nondet-string-length 100 --function test_endswith.main
+--max-nondet-string-length 100 --function test_endswith.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 9.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_equal/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_equal/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_equal.class
---verbosity 10 --max-nondet-string-length 100 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 100 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 8.* FAILURE$

--- a/jbmc/regression/strings-smoke-tests/java_equal/test_2.desc
+++ b/jbmc/regression/strings-smoke-tests/java_equal/test_2.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 test_equal_2.class
---verbosity 10 --max-nondet-string-length 100
+--max-nondet-string-length 100
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/jbmc/regression/strings-smoke-tests/java_float/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_float/test.desc
@@ -1,6 +1,6 @@
 FUTURE
 test_float.class
---verbosity 10 --max-nondet-string-length 1000 --function test_float.main
+--max-nondet-string-length 1000 --function test_float.main
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/strings-smoke-tests/java_format/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_format/test.desc
@@ -1,6 +1,6 @@
 CORE
 test.class
---verbosity 10 --max-nondet-string-length 20 --function test.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 20 --function test.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 6.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_format2/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_format2/test.desc
@@ -1,6 +1,6 @@
 CORE
 test.class
---verbosity 10 --max-nondet-string-length 20 --function test.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 20 --function test.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 6.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_format3/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_format3/test.desc
@@ -1,6 +1,6 @@
 CORE
 test.class
---verbosity 10 --max-nondet-string-length 20 --function test.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 20 --function test.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 7.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_format4/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_format4/test.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 test.class
---verbosity 10 --max-nondet-string-length 20
+--max-nondet-string-length 20
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 8.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_format5/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_format5/test.desc
@@ -1,6 +1,6 @@
 THOROUGH
 test.class
---verbosity 10 --max-nondet-string-length 20
+--max-nondet-string-length 20
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 7.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_hash_code/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_hash_code/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_hash_code.class
---verbosity 10 --max-nondet-string-length 1000 --function test_hash_code.main
+--max-nondet-string-length 1000 --function test_hash_code.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 8.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_if/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_if/test.desc
@@ -1,6 +1,6 @@
 CORE
 test.class
---verbosity 10 --max-nondet-string-length 100 --function test.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 100 --function test.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 11.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_index_of/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_index_of/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_index_of.class
---verbosity 10 --max-nondet-string-length 1000 --function test_index_of.main
+--max-nondet-string-length 1000 --function test_index_of.main
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/strings-smoke-tests/java_index_of2/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_index_of2/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_index_of2.class
---verbosity 10 --max-nondet-string-length 1000 --function test_index_of2.main
+--max-nondet-string-length 1000 --function test_index_of2.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/strings-smoke-tests/java_index_of_char/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_index_of_char/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_index_of_char.class
---verbosity 10 --max-nondet-string-length 1000 --function test_index_of_char.main
+--max-nondet-string-length 1000 --function test_index_of_char.main
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/strings-smoke-tests/java_insert_char/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_insert_char/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_insert_char.class
---verbosity 10  --max-nondet-string-length 1000 --function test_insert_char.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+ --max-nondet-string-length 1000 --function test_insert_char.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/strings-smoke-tests/java_insert_char_array/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_insert_char_array/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_insert_char_array.class
---verbosity 10 --max-nondet-string-length 1000 --function test_insert_char_array.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function test_insert_char_array.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* file test_insert_char_array.java line 20 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_insert_multiple/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_insert_multiple/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_insert_multiple.class
---verbosity 10 --max-nondet-string-length 1000 --function test_insert_multiple.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function test_insert_multiple.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/strings-smoke-tests/java_insert_string/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_insert_string/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_insert_string.class
---verbosity 10 --max-nondet-string-length 1000 --function test_insert_string.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function test_insert_string.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/strings-smoke-tests/java_int_to_string/test1.desc
+++ b/jbmc/regression/strings-smoke-tests/java_int_to_string/test1.desc
@@ -1,6 +1,6 @@
 CORE
 Test1.class
---verbosity 10 --max-nondet-string-length 1000 --function Test1.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function Test1.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_int_to_string/test2.desc
+++ b/jbmc/regression/strings-smoke-tests/java_int_to_string/test2.desc
@@ -1,6 +1,6 @@
 CORE
 Test2.class
---verbosity 10 --max-nondet-string-length 1000 --function Test2.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function Test2.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_int_to_string/test2_bug.desc
+++ b/jbmc/regression/strings-smoke-tests/java_int_to_string/test2_bug.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 Test2.class
---verbosity 10 --function Test2.main
+--function Test2.main
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_int_to_string/test3.desc
+++ b/jbmc/regression/strings-smoke-tests/java_int_to_string/test3.desc
@@ -1,6 +1,6 @@
 CORE
 Test3.class
---verbosity 10 --max-nondet-string-length 1000 --function Test3.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function Test3.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_int_to_string/test4.desc
+++ b/jbmc/regression/strings-smoke-tests/java_int_to_string/test4.desc
@@ -1,6 +1,6 @@
 CORE
 Test4.class
---verbosity 10 --max-nondet-string-length 1000 --function Test4.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function Test4.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_int_to_string/test5.desc
+++ b/jbmc/regression/strings-smoke-tests/java_int_to_string/test5.desc
@@ -1,6 +1,6 @@
 CORE
 Test5.class
---verbosity 10 --max-nondet-string-length 1000 --function Test5.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function Test5.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_int_to_string_knownbug/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_int_to_string_knownbug/test.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 Test.class
---verbosity 10 --max-nondet-string-length 1000 --function Test.main
+--max-nondet-string-length 1000 --function Test.main
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix/test_binary1.desc
+++ b/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix/test_binary1.desc
@@ -1,6 +1,6 @@
 CORE
 Test_binary1.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_binary1.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function Test_binary1.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix/test_binary2.desc
+++ b/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix/test_binary2.desc
@@ -1,6 +1,6 @@
 CORE
 Test_binary2.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_binary2.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function Test_binary2.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix/test_binary3.desc
+++ b/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix/test_binary3.desc
@@ -1,6 +1,6 @@
 CORE
 Test_binary3.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_binary3.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function Test_binary3.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix/test_decimal.desc
+++ b/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix/test_decimal.desc
@@ -1,6 +1,6 @@
 CORE
 Test_decimal.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_decimal.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function Test_decimal.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix/test_hex1.desc
+++ b/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix/test_hex1.desc
@@ -1,6 +1,6 @@
 CORE
 Test_hex1.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_hex1.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function Test_hex1.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix/test_hex2.desc
+++ b/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix/test_hex2.desc
@@ -1,6 +1,6 @@
 CORE
 Test_hex2.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_hex2.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function Test_hex2.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix/test_hex3.desc
+++ b/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix/test_hex3.desc
@@ -1,6 +1,6 @@
 CORE
 Test_hex3.class
---verbosity 10 --max-nondet-string-length 100 --function Test_hex3.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 100 --function Test_hex3.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix/test_octal1.desc
+++ b/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix/test_octal1.desc
@@ -1,6 +1,6 @@
 CORE
 Test_octal1.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_octal1.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function Test_octal1.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix/test_octal2.desc
+++ b/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix/test_octal2.desc
@@ -1,6 +1,6 @@
 CORE
 Test_octal2.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_octal2.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function Test_octal2.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix/test_octal3.desc
+++ b/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix/test_octal3.desc
@@ -1,6 +1,6 @@
 CORE
 Test_octal3.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_octal3.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function Test_octal3.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix_knownbug/test_binary.desc
+++ b/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix_knownbug/test_binary.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 Test_binary.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_binary.main
+--max-nondet-string-length 1000 --function Test_binary.main
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix_knownbug/test_hex.desc
+++ b/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix_knownbug/test_hex.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 Test_hex.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_hex.main
+--max-nondet-string-length 1000 --function Test_hex.main
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix_knownbug/test_octal.desc
+++ b/jbmc/regression/strings-smoke-tests/java_int_to_string_with_radix_knownbug/test_octal.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 Test_octal.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_octal.main
+--max-nondet-string-length 1000 --function Test_octal.main
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_intern/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_intern/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_intern.class
---verbosity 10 --max-nondet-string-length 1000 --function test_intern.main
+--max-nondet-string-length 1000 --function test_intern.main
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 9.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_last_index_of/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_last_index_of/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_last_index_of.class
---verbosity 10 --max-nondet-string-length 1000 --function test_last_index_of.main
+--max-nondet-string-length 1000 --function test_last_index_of.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 8.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_last_index_of2/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_last_index_of2/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_last_index_of2.class
---verbosity 10 --max-nondet-string-length 1000
+--max-nondet-string-length 1000
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/strings-smoke-tests/java_last_index_of_char/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_last_index_of_char/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_last_index_of_char.class
---verbosity 10 --max-nondet-string-length 1000 --function test_last_index_of_char.main
+--max-nondet-string-length 1000 --function test_last_index_of_char.main
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/strings-smoke-tests/java_length/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_length/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_length.class
---verbosity 10 --max-nondet-string-length 1000 --function test_length.main
+--max-nondet-string-length 1000 --function test_length.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/strings-smoke-tests/java_length2/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_length2/test.desc
@@ -1,6 +1,6 @@
 FUTURE
 test.class
---verbosity 10 --max-nondet-string-length 1000 --function test.check
+--max-nondet-string-length 1000 --function test.check
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/strings-smoke-tests/java_long_to_string/test1.desc
+++ b/jbmc/regression/strings-smoke-tests/java_long_to_string/test1.desc
@@ -1,6 +1,6 @@
 CORE
 Test1.class
---verbosity 10 --max-nondet-string-length 1000 --function Test1.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function Test1.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_long_to_string/test2.desc
+++ b/jbmc/regression/strings-smoke-tests/java_long_to_string/test2.desc
@@ -1,6 +1,6 @@
 THOROUGH
 Test2.class
---verbosity 10 --max-nondet-string-length 1000 --function Test2.main
+--max-nondet-string-length 1000 --function Test2.main
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_long_to_string/test3.desc
+++ b/jbmc/regression/strings-smoke-tests/java_long_to_string/test3.desc
@@ -1,6 +1,6 @@
 THOROUGH
 Test3.class
---verbosity 10 --max-nondet-string-length 1000 --function Test3.main
+--max-nondet-string-length 1000 --function Test3.main
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_long_to_string/test4.desc
+++ b/jbmc/regression/strings-smoke-tests/java_long_to_string/test4.desc
@@ -1,6 +1,6 @@
 THOROUGH
 Test4.class
---verbosity 10 --max-nondet-string-length 1000 --function Test4.main
+--max-nondet-string-length 1000 --function Test4.main
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_long_to_string/test5.desc
+++ b/jbmc/regression/strings-smoke-tests/java_long_to_string/test5.desc
@@ -1,6 +1,6 @@
 CORE
 Test5.class
---verbosity 10 --max-nondet-string-length 1000 --function Test5.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function Test5.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_long_to_string_with_radix/test_binary1.desc
+++ b/jbmc/regression/strings-smoke-tests/java_long_to_string_with_radix/test_binary1.desc
@@ -1,6 +1,6 @@
 THOROUGH
 Test_binary1.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_binary1.main
+--max-nondet-string-length 1000 --function Test_binary1.main
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_long_to_string_with_radix/test_binary2.desc
+++ b/jbmc/regression/strings-smoke-tests/java_long_to_string_with_radix/test_binary2.desc
@@ -1,6 +1,6 @@
 THOROUGH
 Test_binary2.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_binary2.main
+--max-nondet-string-length 1000 --function Test_binary2.main
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_long_to_string_with_radix/test_binary3.desc
+++ b/jbmc/regression/strings-smoke-tests/java_long_to_string_with_radix/test_binary3.desc
@@ -1,6 +1,6 @@
 THOROUGH
 Test_binary3.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_binary3.main
+--max-nondet-string-length 1000 --function Test_binary3.main
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_long_to_string_with_radix/test_decimal.desc
+++ b/jbmc/regression/strings-smoke-tests/java_long_to_string_with_radix/test_decimal.desc
@@ -1,6 +1,6 @@
 CORE
 Test_decimal.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_decimal.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function Test_decimal.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_long_to_string_with_radix/test_hex1.desc
+++ b/jbmc/regression/strings-smoke-tests/java_long_to_string_with_radix/test_hex1.desc
@@ -1,6 +1,6 @@
 CORE
 Test_hex1.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_hex1.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function Test_hex1.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_long_to_string_with_radix/test_hex2.desc
+++ b/jbmc/regression/strings-smoke-tests/java_long_to_string_with_radix/test_hex2.desc
@@ -1,6 +1,6 @@
 CORE
 Test_hex2.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_hex2.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function Test_hex2.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_long_to_string_with_radix/test_hex3.desc
+++ b/jbmc/regression/strings-smoke-tests/java_long_to_string_with_radix/test_hex3.desc
@@ -1,6 +1,6 @@
 CORE
 Test_hex3.class
---verbosity 10 --max-nondet-string-length 100 --function Test_hex3.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 100 --function Test_hex3.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_long_to_string_with_radix/test_octal1.desc
+++ b/jbmc/regression/strings-smoke-tests/java_long_to_string_with_radix/test_octal1.desc
@@ -1,6 +1,6 @@
 CORE
 Test_octal1.class
---verbosity 10 --max-nondet-string-length 100 --function Test_octal1.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 100 --function Test_octal1.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_long_to_string_with_radix/test_octal2.desc
+++ b/jbmc/regression/strings-smoke-tests/java_long_to_string_with_radix/test_octal2.desc
@@ -1,6 +1,6 @@
 CORE
 Test_octal2.class
---verbosity 10 --max-nondet-string-length 100 --function Test_octal2.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 100 --function Test_octal2.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_long_to_string_with_radix/test_octal3.desc
+++ b/jbmc/regression/strings-smoke-tests/java_long_to_string_with_radix/test_octal3.desc
@@ -1,6 +1,6 @@
 CORE
 Test_octal3.class
---verbosity 10 --max-nondet-string-length 100 --function Test_octal3.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 100 --function Test_octal3.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_parseint/test1.desc
+++ b/jbmc/regression/strings-smoke-tests/java_parseint/test1.desc
@@ -1,6 +1,6 @@
 CORE
 Test1.class
---verbosity 10 --max-nondet-string-length 1000 --function Test1.main
+--max-nondet-string-length 1000 --function Test1.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 8.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_parseint/test2.desc
+++ b/jbmc/regression/strings-smoke-tests/java_parseint/test2.desc
@@ -1,6 +1,6 @@
 CORE
 Test2.class
---verbosity 10 --max-nondet-string-length 1000 --function Test2.main
+--max-nondet-string-length 1000 --function Test2.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 9.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_parseint/test3.desc
+++ b/jbmc/regression/strings-smoke-tests/java_parseint/test3.desc
@@ -1,6 +1,6 @@
 CORE
 Test3.class
---verbosity 10 --max-nondet-string-length 1000 --function Test3.main
+--max-nondet-string-length 1000 --function Test3.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 7.* FAILURE$

--- a/jbmc/regression/strings-smoke-tests/java_parseint_knownbug/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_parseint_knownbug/test.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 Test.class
---verbosity 10 --max-nondet-string-length 1000 --function Test.main
+--max-nondet-string-length 1000 --function Test.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 10.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_parseint_with_radix/test1.desc
+++ b/jbmc/regression/strings-smoke-tests/java_parseint_with_radix/test1.desc
@@ -1,6 +1,6 @@
 CORE
 Test1.class
---verbosity 10 --max-nondet-string-length 1000 --function Test1.main
+--max-nondet-string-length 1000 --function Test1.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 8.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_parseint_with_radix/test2.desc
+++ b/jbmc/regression/strings-smoke-tests/java_parseint_with_radix/test2.desc
@@ -1,6 +1,6 @@
 CORE
 Test2.class
---verbosity 10 --max-nondet-string-length 1000 --function Test2.main
+--max-nondet-string-length 1000 --function Test2.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 8.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_parseint_with_radix/test3.desc
+++ b/jbmc/regression/strings-smoke-tests/java_parseint_with_radix/test3.desc
@@ -1,6 +1,6 @@
 CORE
 Test3.class
---verbosity 10 --max-nondet-string-length 1000 --function Test3.main
+--max-nondet-string-length 1000 --function Test3.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 8.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_parseint_with_radix/test4.desc
+++ b/jbmc/regression/strings-smoke-tests/java_parseint_with_radix/test4.desc
@@ -1,6 +1,6 @@
 CORE
 Test4.class
---verbosity 10 --max-nondet-string-length 1000 --function Test4.main
+--max-nondet-string-length 1000 --function Test4.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 8.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_parseint_with_radix/test5.desc
+++ b/jbmc/regression/strings-smoke-tests/java_parseint_with_radix/test5.desc
@@ -1,6 +1,6 @@
 CORE
 Test5.class
---verbosity 10 --max-nondet-string-length 1000 --function Test5.main
+--max-nondet-string-length 1000 --function Test5.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 8.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_parseint_with_radix/test6.desc
+++ b/jbmc/regression/strings-smoke-tests/java_parseint_with_radix/test6.desc
@@ -1,6 +1,6 @@
 CORE
 Test6.class
---verbosity 10 --max-nondet-string-length 1000 --function Test6.main
+--max-nondet-string-length 1000 --function Test6.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 9.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_parseint_with_radix_knownbug/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_parseint_with_radix_knownbug/test.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 Test2.class
---verbosity 10 --max-nondet-string-length 1000
+--max-nondet-string-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 9.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_parselong/test_binary_min.desc
+++ b/jbmc/regression/strings-smoke-tests/java_parselong/test_binary_min.desc
@@ -1,6 +1,6 @@
 CORE
 Test_binary_min.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_binary_min.main
+--max-nondet-string-length 1000 --function Test_binary_min.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 9.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_parselong/test_decimal_max.desc
+++ b/jbmc/regression/strings-smoke-tests/java_parselong/test_decimal_max.desc
@@ -1,6 +1,6 @@
 CORE
 Test_decimal_max.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_decimal_max.main
+--max-nondet-string-length 1000 --function Test_decimal_max.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 9.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_parselong/test_decimal_min.desc
+++ b/jbmc/regression/strings-smoke-tests/java_parselong/test_decimal_min.desc
@@ -1,6 +1,6 @@
 CORE
 Test_decimal_min.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_decimal_min.main
+--max-nondet-string-length 1000 --function Test_decimal_min.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 9.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_parselong/test_hex.desc
+++ b/jbmc/regression/strings-smoke-tests/java_parselong/test_hex.desc
@@ -1,6 +1,6 @@
 CORE
 Test_hex.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_hex.main
+--max-nondet-string-length 1000 --function Test_hex.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 8.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_parselong/test_octal.desc
+++ b/jbmc/regression/strings-smoke-tests/java_parselong/test_octal.desc
@@ -1,6 +1,6 @@
 CORE
 Test_octal.class
---verbosity 10 --max-nondet-string-length 1000 --function Test_octal.main
+--max-nondet-string-length 1000 --function Test_octal.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 8.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_replace/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_replace/test.desc
@@ -1,6 +1,6 @@
 FUTURE
 test_replace.class
---verbosity 10 --max-nondet-string-length 100
+--max-nondet-string-length 100
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/strings-smoke-tests/java_replace_char/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_replace_char/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_replace_char.class
---verbosity 10 --max-nondet-string-length 1000 --function test_replace_char.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function test_replace_char.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/strings-smoke-tests/java_set_char_at/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_set_char_at/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_set_char_at.class
---verbosity 10 --max-nondet-string-length 1000 --function test_set_char_at.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function test_set_char_at.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/strings-smoke-tests/java_set_length/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_set_length/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_set_length.class
---verbosity 10 --max-nondet-string-length 100 --function test_set_length.main
+--max-nondet-string-length 100 --function test_set_length.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 8.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_starts_with/test-no-simplify.desc
+++ b/jbmc/regression/strings-smoke-tests/java_starts_with/test-no-simplify.desc
@@ -1,6 +1,6 @@
 CORE
 test_starts_with.class
---verbosity 10 --max-nondet-string-length 1000 --function test_starts_with.main --unwind 1 --no-simplify
+--max-nondet-string-length 1000 --function test_starts_with.main --unwind 1 --no-simplify
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 8.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_starts_with/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_starts_with/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_starts_with.class
---verbosity 10 --max-nondet-string-length 1000 --function test_starts_with.main
+--max-nondet-string-length 1000 --function test_starts_with.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 8.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_string_builder_length/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_string_builder_length/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_sb_length.class
---verbosity 10 --max-nondet-string-length 1000 --function test_sb_length.main
+--max-nondet-string-length 1000 --function test_sb_length.main
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/strings-smoke-tests/java_string_printable/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_string_printable/test.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---verbosity 10 --function Test.check --max-nondet-string-length 100 --string-printable --java-assume-inputs-non-null --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--function Test.check --max-nondet-string-length 100 --string-printable --java-assume-inputs-non-null --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* file Test.java line 6 .* SUCCESS

--- a/jbmc/regression/strings-smoke-tests/java_string_printable/test_char.desc
+++ b/jbmc/regression/strings-smoke-tests/java_string_printable/test_char.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---verbosity 10 --function Test.check_char --max-nondet-string-length 100 --string-printable
+--function Test.check_char --max-nondet-string-length 100 --string-printable
 ^EXIT=0$
 ^SIGNAL=0$
 assertion.* file Test.java line 18 .* SUCCESS

--- a/jbmc/regression/strings-smoke-tests/java_subsequence/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_subsequence/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_subsequence.class
---verbosity 10 --max-nondet-string-length 1000 --function test_subsequence.main
+--max-nondet-string-length 1000 --function test_subsequence.main
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/strings-smoke-tests/java_substring/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_substring/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_substring.class
---verbosity 10 --max-nondet-string-length 1000 --function test_substring.main
+--max-nondet-string-length 1000 --function test_substring.main
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/strings-smoke-tests/java_trim/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_trim/test.desc
@@ -1,6 +1,6 @@
 CORE
 test_trim.class
---verbosity 10 --max-nondet-string-length 100 --function test_trim.main
+--max-nondet-string-length 100 --function test_trim.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[.*assertion.1\].* line 6.* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_value_of_float/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_value_of_float/test.desc
@@ -1,6 +1,6 @@
 CORE
 test.class
---verbosity 10 --function test.check --max-nondet-string-length 100 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--function test.check --max-nondet-string-length 100 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* file test.java line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_value_of_float_2/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_value_of_float_2/test.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 test.class
---verbosity 10 --function test.check --max-nondet-string-length 1000
+--function test.check --max-nondet-string-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* file test.java line 6 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_value_of_float_3/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_value_of_float_3/test.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 test.class
---verbosity 10 --max-nondet-string-length 1000 --function test.check
+--max-nondet-string-length 1000 --function test.check
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* file test.java line 7 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_value_of_float_4/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_value_of_float_4/test.desc
@@ -1,6 +1,6 @@
 THOROUGH
 test.class
---verbosity 10 --max-nondet-string-length 1000 --function test.check
+--max-nondet-string-length 1000 --function test.check
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* test.java line 8 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_value_of_float_5/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_value_of_float_5/test.desc
@@ -1,6 +1,6 @@
 THOROUGH
 test.class
---verbosity 10 --max-nondet-string-length 1000 --function test.check
+--max-nondet-string-length 1000 --function test.check
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* file test.java line 6 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/java_value_of_long/test.desc
+++ b/jbmc/regression/strings-smoke-tests/java_value_of_long/test.desc
@@ -1,6 +1,6 @@
 CORE
 test.class
---verbosity 10 --max-nondet-string-length 1000 --function test.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--max-nondet-string-length 1000 --function test.main --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* file test.java line 9 .* SUCCESS$

--- a/jbmc/regression/strings-smoke-tests/max_input_length/test1.desc
+++ b/jbmc/regression/strings-smoke-tests/max_input_length/test1.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---verbosity 10 --max-nondet-string-length 31 --function Test.main
+--max-nondet-string-length 31 --function Test.main
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/strings-smoke-tests/max_input_length/test2.desc
+++ b/jbmc/regression/strings-smoke-tests/max_input_length/test2.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---verbosity 10 --max-nondet-string-length 20 --function Test.main
+--max-nondet-string-length 20 --function Test.main
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/full_slice1/test.desc
+++ b/regression/cbmc/full_slice1/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---full-slice --property main.assertion.1 --unwind 1 --verbosity 10
+--full-slice --property main.assertion.1 --unwind 1
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED

--- a/regression/cbmc/full_slice2/test.desc
+++ b/regression/cbmc/full_slice2/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---full-slice --property main.assertion.2 --unwind 1 --verbosity 10
+--full-slice --property main.assertion.2 --unwind 1
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED

--- a/regression/goto-analyzer/approx-array-variable-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-array-variable-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp_tbl\[.*i\] == f2 THEN GOTO [0-9]$
 ^\s*IF fp_tbl\[.*i\] == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/approx-const-fp-array-variable-cast-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-cast-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/approx-const-fp-array-variable-const-fp-with-null/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-const-fp-with-null/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/approx-const-fp-array-variable-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/approx-const-fp-array-variable-const-pointer-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-const-pointer-const-struct-non-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/approx-const-fp-array-variable-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-const-struct-non-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/approx-const-fp-array-variable-invalid-cast-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-invalid-cast-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == \(.*\)f2 THEN GOTO [0-9]$
 ^\s*IF fp == \(.*\)f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/approx-const-fp-array-variable-struct-const-fp-with-zero/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-struct-const-fp-with-zero/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-array-literal-const-fp-null/test.desc
+++ b/regression/goto-analyzer/no-match-array-literal-const-fp-null/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*ASSERT FALSE // invalid function pointer$
 ^EXIT=0$

--- a/regression/goto-analyzer/no-match-const-array-const-pointer-const-fp-const-lost/test.desc
+++ b/regression/goto-analyzer/no-match-const-array-const-pointer-const-fp-const-lost/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF \*fp == f1 THEN GOTO [0-9]$
 ^\s*IF \*fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-array-literal-const-fp-run-time/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-array-literal-const-fp-run-time/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-array-literal-non-const-fp-run-time/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-array-literal-non-const-fp-run-time/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-array-literal-non-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-array-literal-non-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp2 == f1 THEN GOTO [0-9]$
 ^\s*IF fp2 == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-array-non-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-array-non-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp2 == f1 THEN GOTO [0-9]$
 ^\s*IF fp2 == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-binary-op-const-lost/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-binary-op-const-lost/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-const-array-index-lost/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-array-index-lost/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF \*fp == f1 THEN GOTO [0-9]$
 ^\s*IF \*fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-const-array-lost/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-array-lost/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF \*fp == f1 THEN GOTO [0-9]$
 ^\s*IF \*fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-const-cast/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-cast/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-const-fp-null/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-fp-null/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*ASSERT FALSE // invalid function pointer$
 ^EXIT=0$

--- a/regression/goto-analyzer/no-match-const-fp-const-lost/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-lost/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-const-pointer-const-struct-const-fp-null/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-pointer-const-struct-const-fp-null/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*ASSERT FALSE // invalid function pointer$
 replacing function pointer by 9 possible targets

--- a/regression/goto-analyzer/no-match-const-fp-const-pointer-non-const-struct-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-pointer-non-const-struct-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-dereference-const-pointer-null/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-dereference-const-pointer-null/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*ASSERT FALSE // invalid function pointer$
 replacing function pointer by 9 possible targets

--- a/regression/goto-analyzer/no-match-const-fp-dereference-non-const-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-dereference-non-const-pointer-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF final_fp == f1 THEN GOTO [0-9]$
 ^\s*IF final_fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-dynamic-array-non-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-dynamic-array-non-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-non-const-fp-direct-assignment/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-non-const-fp-direct-assignment/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp2 == f1 THEN GOTO [0-9]$
 ^\s*IF fp2 == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-non-const-pointer-non-const-struct-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-non-const-pointer-non-const-struct-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-non-const-struct-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-non-const-struct-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-non-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-non-const-struct-non-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-null/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-null/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*ASSERT FALSE // invalid function pointer$
 function func: replacing function pointer by 0 possible targets

--- a/regression/goto-analyzer/no-match-const-fp-ternerary-op-const-lost/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-ternerary-op-const-lost/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-pointer-const-struct-const-fp-const-cast/test.desc
+++ b/regression/goto-analyzer/no-match-const-pointer-const-struct-const-fp-const-cast/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF container_pointer->fp == f1 THEN GOTO [0-9]$
 ^\s*IF container_pointer->fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-pointer-non-const-struct-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-pointer-non-const-struct-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF pts->go == f1 THEN GOTO [0-9]$
 ^\s*IF pts->go == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-struct-non-const-fp-null/test.desc
+++ b/regression/goto-analyzer/no-match-const-struct-non-const-fp-null/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*ASSERT FALSE // invalid function pointer$
 ^EXIT=0$

--- a/regression/goto-analyzer/no-match-dereference-const-pointer-const-array-literal-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-dereference-const-pointer-const-array-literal-pointer-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF \*container_ptr->fp_tbl\[.*1\] == f1 THEN GOTO [0-9]$
 ^\s*IF \*container_ptr->fp_tbl\[.*1\] == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-dereference-non-const-struct-const-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-dereference-non-const-struct-const-pointer-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF \*container_container\.container == f1 THEN GOTO [0-9]$
 ^\s*IF \*container_container\.container == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-dereference-non-const-struct-non-const-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-dereference-non-const-struct-non-const-pointer-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF \*container_container\.container == f1 THEN GOTO [0-9]$
 ^\s*IF \*container_container\.container == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-non-const-fp-const-fp-direct-assignment/test.desc
+++ b/regression/goto-analyzer/no-match-non-const-fp-const-fp-direct-assignment/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp2 == f1 THEN GOTO [0-9]$
 ^\s*IF fp2 == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-non-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-non-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-parameter-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-parameter-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-parameter-fp/test.desc
+++ b/regression/goto-analyzer/no-match-parameter-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-pointer-const-struct-array-literal-non-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-pointer-const-struct-array-literal-non-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*IF container_ptr->fp_tbl\[.*1\] == f1 THEN GOTO [0-9]$
 ^\s*IF container_ptr->fp_tbl\[.*1\] == f2 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/precise-array-calculation-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-array-calculation-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-array-literal-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-array-literal-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-const-fp-array-const-variable-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-array-const-variable-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-const-fp-array-literal-const-fp-run-time/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-array-literal-const-fp-run-time/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-const-fp-array-literal-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-array-literal-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-const-fp-array-literal-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-array-literal-const-struct-non-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-const-fp-array-variable-const-pointer-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-array-variable-const-pointer-const-struct-non-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f2\(\);
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-const-fp-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f2\(\);$
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-const-fp-const-struct-const-array-literal-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-const-struct-const-array-literal-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-const-fp-const-struct-non-const-array-literal-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-const-struct-non-const-array-literal-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-const-fp-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-const-struct-non-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f2\(\);
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-const-fp-dereference-const-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-dereference-const-pointer-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-const-fp-supurious-const-loss/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-supurious-const-loss/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f2\(\);
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f2\(\);
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-const-pointer-const-struct-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-pointer-const-struct-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f2\(\);$
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-struct-non-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f2\(\);
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-derefence-const-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-derefence-const-pointer-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-derefence/test.desc
+++ b/regression/goto-analyzer/precise-derefence/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f2\(\);
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-dereference-address-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-dereference-address-pointer-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-dereference-const-struct-const-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-dereference-const-struct-const-pointer-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-dereference-const-struct-const-pointer-const-struct-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-dereference-const-struct-const-pointer-const-struct-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$

--- a/regression/goto-analyzer/precise-dereference-const-struct-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-dereference-const-struct-pointer-const-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --verbosity 10 --pointer-check
+--show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$

--- a/regression/goto-instrument/approx-array-variable-const-fp-only-remove-const/test.desc
+++ b/regression/goto-instrument/approx-array-variable-const-fp-only-remove-const/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---verbosity 10 --pointer-check --remove-const-function-pointers
+--pointer-check --remove-const-function-pointers
 ^\s*IF fp_tbl\[.*i\] == f2 THEN GOTO [0-9]$
 ^\s*IF fp_tbl\[.*i\] == f3 THEN GOTO [0-9]$
 ^\s*IF fp_tbl\[.*i\] == f4 THEN GOTO [0-9]$

--- a/regression/goto-instrument/approx-array-variable-const-fp-remove-all-fp/test.desc
+++ b/regression/goto-instrument/approx-array-variable-const-fp-remove-all-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---verbosity 10 --pointer-check --remove-function-pointers
+--pointer-check --remove-function-pointers
 ^\s*IF fp_tbl\[.*i\] == f2 THEN GOTO [0-9]$
 ^\s*IF fp_tbl\[.*i\] == f3 THEN GOTO [0-9]$
 ^\s*IF fp_tbl\[.*i\] == f4 THEN GOTO [0-9]$

--- a/regression/goto-instrument/no-match-non-const-fp-only-remove-const/test.desc
+++ b/regression/goto-instrument/no-match-non-const-fp-only-remove-const/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---verbosity 10 --pointer-check --remove-const-function-pointers
+--pointer-check --remove-const-function-pointers
 ^\s*fp\(\);$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-instrument/no-match-non-const-fp-remove-all-fp/test.desc
+++ b/regression/goto-instrument/no-match-non-const-fp-remove-all-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---verbosity 10 --pointer-check --remove-function-pointers
+--pointer-check --remove-function-pointers
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-instrument/precise-const-fp-only-remove-const/test.desc
+++ b/regression/goto-instrument/precise-const-fp-only-remove-const/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---verbosity 10 --pointer-check --remove-const-function-pointers
+--pointer-check --remove-const-function-pointers
 ^\s*f2\(\);
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-instrument/precise-const-fp-remove-all-fp/test.desc
+++ b/regression/goto-instrument/precise-const-fp-remove-all-fp/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---verbosity 10 --pointer-check --remove-function-pointers
+--pointer-check --remove-function-pointers
 ^\s*f2\(\);
 ^EXIT=0$
 ^SIGNAL=0$


### PR DESCRIPTION
This reduces the test execution time by 10%, from 64s to 58s
(with ctest -V -L CORE -j8). Implemented using `sed -i '3s/ --verbosity 10 //'`
with varying amounts of whitespace. Subsequent manual edits of stray space at
the end of lines.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
