### PR TITLE
Fix Doxygen formatting in parse_options.h

### DIFF
--- a/src/util/parse_options.h
+++ b/src/util/parse_options.h
@@ -45,12 +45,13 @@ private:
 std::string
 banner_string(const std::string &front_end, const std::string &version);
 
-/// Utility for displaying help centered messages borderered by "* *"
-/// - we use this for displaying banner information and the like
-/// in help messages
-/// \example
+/// Utility for displaying help centered messages borderered by "* *".
+/// We use this for displaying banner information and the like
+/// in help messages.
+/// ```
 ///   align_center_with_border("test-text")
 ///   == "* *                        test-text                        * *"
+/// ```
 std::string align_center_with_border(const std::string &text);
 
 #endif // CPROVER_UTIL_PARSE_OPTIONS_H


### PR DESCRIPTION
The use of `\example` in this file created a new "Examples" section in the main
(side bar) menu.

![screenshot 2019-02-05 at 10 10 00](https://user-images.githubusercontent.com/32836213/52266475-69b1b880-292e-11e9-908e-8a7dadd69885.png)

In order to limit the categories in the top level menu, the formatting is changed here to be more like how examples are given in other sections of our documentation.

Also, a full stop is used to separate a method summary from more
detailed documentation, to make the generated documentation look better.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
