### PR TITLE
Constify dereference_callbackt

### DIFF
--- a/src/goto-symex/symex_dereference_state.cpp
+++ b/src/goto-symex/symex_dereference_state.cpp
@@ -15,7 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 bool symex_dereference_statet::has_failed_symbol(
   const exprt &expr,
-  const symbolt *&symbol)
+  const symbolt *&symbol) const
 {
   const namespacet &ns=goto_symex.ns;
 
@@ -70,7 +70,7 @@ bool symex_dereference_statet::has_failed_symbol(
 
 void symex_dereference_statet::get_value_set(
   const exprt &expr,
-  value_setst::valuest &value_set)
+  value_setst::valuest &value_set) const
 {
   state.value_set.get_value_set(expr, value_set, goto_symex.ns);
 

--- a/src/goto-symex/symex_dereference_state.h
+++ b/src/goto-symex/symex_dereference_state.h
@@ -32,10 +32,11 @@ protected:
   goto_symext &goto_symex;
   goto_symext::statet &state;
 
-  void
-  get_value_set(const exprt &expr, value_setst::valuest &value_set) override;
+  void get_value_set(const exprt &expr, value_setst::valuest &value_set)
+    const override;
 
-  bool has_failed_symbol(const exprt &expr, const symbolt *&symbol) override;
+  bool
+  has_failed_symbol(const exprt &expr, const symbolt *&symbol) const override;
 };
 
 #endif // CPROVER_GOTO_SYMEX_SYMEX_DEREFERENCE_STATE_H

--- a/src/pointer-analysis/dereference_callback.h
+++ b/src/pointer-analysis/dereference_callback.h
@@ -29,13 +29,11 @@ class dereference_callbackt
 public:
   virtual ~dereference_callbackt() = default;
 
-  virtual void get_value_set(
-    const exprt &expr,
-    value_setst::valuest &value_set)=0;
+  virtual void
+  get_value_set(const exprt &expr, value_setst::valuest &value_set) const = 0;
 
-  virtual bool has_failed_symbol(
-    const exprt &expr,
-    const symbolt *&symbol)=0;
+  virtual bool
+  has_failed_symbol(const exprt &expr, const symbolt *&symbol) const = 0;
 };
 
 #endif // CPROVER_POINTER_ANALYSIS_DEREFERENCE_CALLBACK_H

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -26,7 +26,7 @@ Author: Daniel Kroening, kroening@kroening.com
 ///   comment which exists in the namespace.
 bool goto_program_dereferencet::has_failed_symbol(
   const exprt &expr,
-  const symbolt *&symbol)
+  const symbolt *&symbol) const
 {
   if(expr.id()==ID_symbol)
   {
@@ -225,7 +225,7 @@ void goto_program_dereferencet::dereference_rec(
 /// \param [out] dest: gets the value set
 void goto_program_dereferencet::get_value_set(
   const exprt &expr,
-  value_setst::valuest &dest)
+  value_setst::valuest &dest) const
 {
   value_sets.get_values(current_function, current_target, expr, dest);
 }

--- a/src/pointer-analysis/goto_program_dereference.h
+++ b/src/pointer-analysis/goto_program_dereference.h
@@ -69,7 +69,8 @@ protected:
   DEPRECATED("Unused")
   virtual bool is_valid_object(const irep_idt &identifier);
 
-  bool has_failed_symbol(const exprt &expr, const symbolt *&symbol) override;
+  bool
+  has_failed_symbol(const exprt &expr, const symbolt *&symbol) const override;
 
   DEPRECATED("Unused")
   virtual void dereference_failure(
@@ -77,7 +78,8 @@ protected:
     const std::string &msg,
     const guardt &guard);
 
-  void get_value_set(const exprt &expr, value_setst::valuest &dest) override;
+  void
+  get_value_set(const exprt &expr, value_setst::valuest &dest) const override;
 
   void dereference_instruction(
     goto_programt::targett target,


### PR DESCRIPTION
has_failed_symbol in particular should always be side-effect-free. I imagine get_value_set was originally
allowed to make up new symbols, but doesn't do that in either in-tree implementation now and seems
unlikely to do so soon.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.