### PR TITLE
Move forgotten line that documents cbmc version

### DIFF
--- a/src/goto-programs/README.md
+++ b/src/goto-programs/README.md
@@ -342,6 +342,8 @@ mult /* mult */
         END_FUNCTION
 ```
 
+(The above result was produced using `cbmc version 5.11`)
+
 \section section-goto-transforms Subsequent Transformation
 
 It is normal for a program that calls `goto_convert` to immediately pass the
@@ -567,8 +569,6 @@ then it performs 'linking' of the temporary into a passed destination
 
 Details about linking of `::goto_modelt` instances can be found
 [here](\ref section-linking-goto-models).
-
-(The above result was produced using `cbmc version 5.11`)
 
 \section section-linking-goto-models Linking Goto Models
 


### PR DESCRIPTION
During my previous PR, I failed to move one line while I did some last minute clean up.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
