### PR TITLE
Document partial_order_concurrency [DOC-140]

### DIFF
--- a/src/goto-symex/README.md
+++ b/src/goto-symex/README.md
@@ -276,3 +276,10 @@ digraph G {
   2 -> 3 [label="counter-examples"];
 }
 \enddot
+
+\section Concurrency
+
+\subsection Partial Order Concurrency
+
+The class \ref partial_order_concurrencyt provides an interface for
+implementing ordering of concurrent events.


### PR DESCRIPTION
This PR is only a part of DOC-140. There are no functional changes to the code.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
