### PR TITLE
use new goto_programt::instructiont API

### DIFF
--- a/jbmc/src/java_bytecode/remove_exceptions.cpp
+++ b/jbmc/src/java_bytecode/remove_exceptions.cpp
@@ -432,7 +432,7 @@ bool remove_exceptionst::instrument_function_call(
   goto_programt::targett next_it=instr_it;
   next_it++;
 
-  code_function_callt &function_call=to_code_function_call(instr_it->code);
+  code_function_callt &function_call = instr_it->get_function_call();
   DATA_INVARIANT(
     function_call.function().id()==ID_symbol,
     "identified expected to be a symbol");
@@ -493,7 +493,7 @@ void remove_exceptionst::instrument_exceptions(
   {
     if(instr_it->is_decl())
     {
-      code_declt decl=to_code_decl(instr_it->code);
+      code_declt decl = instr_it->get_decl();
       locals.push_back(decl.symbol());
     }
     // Is it a handler push/pop or catch landing-pad?

--- a/src/goto-analyzer/static_simplifier.cpp
+++ b/src/goto-analyzer/static_simplifier.cpp
@@ -95,7 +95,7 @@ bool static_simplifier(
       }
       else if(i_it->is_assign())
       {
-        code_assignt &assign=to_code_assign(i_it->code);
+        code_assignt &assign = i_it->get_assign();
 
         // Simplification needs to be aware of which side of the
         // expression it is handling as:
@@ -115,7 +115,7 @@ bool static_simplifier(
       }
       else if(i_it->is_function_call())
       {
-        code_function_callt &fcall=to_code_function_call(i_it->code);
+        code_function_callt &fcall = i_it->get_function_call();
 
         bool unchanged =
           ai.abstract_state_before(i_it)->ai_simplify(fcall.function(), ns);

--- a/src/goto-analyzer/taint_analysis.cpp
+++ b/src/goto-analyzer/taint_analysis.cpp
@@ -73,8 +73,8 @@ void taint_analysist::instrument(
     {
     case FUNCTION_CALL:
       {
-        const code_function_callt &function_call=
-          to_code_function_call(instruction.code);
+        const code_function_callt &function_call =
+          instruction.get_function_call();
         const exprt &function=function_call.function();
 
         if(function.id()==ID_symbol)

--- a/src/goto-instrument/accelerate/accelerate.cpp
+++ b/src/goto-instrument/accelerate/accelerate.cpp
@@ -257,8 +257,8 @@ void acceleratet::make_overflow_loc(
   }
 
   goto_programt::targett t=program.insert_after(loop_header);
-  t->make_assignment();
-  t->code=code_assignt(overflow_var, false_exprt());
+  *t =
+    goto_programt::make_assignment(code_assignt(overflow_var, false_exprt()));
   t->swap(*loop_header);
   loop.insert(t);
   overflow_locs[loop_header].push_back(t);
@@ -360,8 +360,8 @@ void acceleratet::add_dirty_checks()
       it!=dirty_vars_map.end();
       ++it)
   {
-    goto_programt::instructiont assign(ASSIGN);
-    assign.code=code_assignt(it->second, false_exprt());
+    goto_programt::instructiont assign =
+      goto_programt::make_assignment(code_assignt(it->second, false_exprt()));
     program.insert_before_swap(program.instructions.begin(), assign);
   }
 
@@ -384,8 +384,8 @@ void acceleratet::add_dirty_checks()
 
       if(dirty_var!=dirty_vars_map.end())
       {
-        goto_programt::instructiont clear_flag(ASSIGN);
-        clear_flag.code=code_assignt(dirty_var->second, false_exprt());
+        goto_programt::instructiont clear_flag = goto_programt::make_assignment(
+          code_assignt(dirty_var->second, false_exprt()));
         program.insert_before_swap(it, clear_flag);
       }
     }

--- a/src/goto-instrument/count_eloc.cpp
+++ b/src/goto-instrument/count_eloc.cpp
@@ -164,7 +164,7 @@ void print_global_state_size(const goto_modelt &goto_model)
     {
       if(ins.is_assign())
       {
-        const code_assignt &code_assign = to_code_assign(ins.code);
+        const code_assignt &code_assign = ins.get_assign();
         object_descriptor_exprt ode;
         ode.build(code_assign.lhs(), ns);
 

--- a/src/goto-programs/cfg.h
+++ b/src/goto-programs/cfg.h
@@ -288,8 +288,7 @@ void cfg_baset<T, P, I>::compute_edges_function_call(
   goto_programt::const_targett next_PC,
   entryt &entry)
 {
-  const exprt &function=
-    to_code_function_call(instruction.code).function();
+  const exprt &function = instruction.get_function_call().function();
 
   if(function.id()!=ID_symbol)
     return;
@@ -339,8 +338,7 @@ void procedure_local_cfg_baset<T, P, I>::compute_edges_function_call(
   goto_programt::const_targett next_PC,
   typename cfg_baset<T, P, I>::entryt &entry)
 {
-  const exprt &function=
-    to_code_function_call(instruction.code).function();
+  const exprt &function = instruction.get_function_call().function();
 
   if(function.id()!=ID_symbol)
     return;

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -826,9 +826,11 @@ public:
       static_cast<const codet &>(get_nil_irep()), l, ASSUME, g, {});
   }
 
-  static instructiont make_other(const codet &_code)
+  static instructiont make_other(
+    const codet &_code,
+    const source_locationt &l = source_locationt::nil())
   {
-    return instructiont(_code, source_locationt::nil(), OTHER, nil_exprt(), {});
+    return instructiont(_code, l, OTHER, nil_exprt(), {});
   }
 
   static instructiont make_decl(

--- a/src/goto-symex/symex_dead.cpp
+++ b/src/goto-symex/symex_dead.cpp
@@ -21,7 +21,7 @@ void goto_symext::symex_dead(statet &state)
 {
   const goto_programt::instructiont &instruction=*state.source.pc;
 
-  const code_deadt &code = to_code_dead(instruction.code);
+  const code_deadt &code = instruction.get_dead();
 
   // We increase the L2 renaming to make these non-deterministic.
   // We also prevent propagation of old values.

--- a/src/goto-symex/symex_decl.cpp
+++ b/src/goto-symex/symex_decl.cpp
@@ -23,13 +23,13 @@ void goto_symext::symex_decl(statet &state)
 {
   const goto_programt::instructiont &instruction=*state.source.pc;
 
-  const codet &code = instruction.code;
+  const auto &code = instruction.get_decl();
 
   // two-operand decl not supported here
   // we handle the decl with only one operand
   PRECONDITION(code.operands().size() == 1);
 
-  symex_decl(state, to_code_decl(code).symbol());
+  symex_decl(state, code.symbol());
 }
 
 void goto_symext::symex_decl(statet &state, const symbol_exprt &expr)

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -447,7 +447,7 @@ void goto_symext::return_assignment(statet &state)
 
   const goto_programt::instructiont &instruction=*state.source.pc;
   PRECONDITION(instruction.is_return());
-  const code_returnt &code=to_code_return(instruction.code);
+  const code_returnt &code = instruction.get_return();
 
   target.location(state.guard.as_expr(), state.source);
 

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -440,7 +440,7 @@ void goto_symext::symex_step(
 
   case ASSIGN:
     if(!state.guard.is_false())
-      symex_assign(state, to_code_assign(instruction.code));
+      symex_assign(state, instruction.get_assign());
 
     symex_transition(state);
     break;
@@ -448,8 +448,7 @@ void goto_symext::symex_step(
   case FUNCTION_CALL:
     if(!state.guard.is_false())
     {
-      code_function_callt deref_code=
-        to_code_function_call(instruction.code);
+      code_function_callt deref_code = instruction.get_function_call();
 
       if(deref_code.lhs().is_not_nil())
         clean_expr(deref_code.lhs(), state, true);

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -79,7 +79,7 @@ void goto_symext::symex_other(
 {
   const goto_programt::instructiont &instruction=*state.source.pc;
 
-  const codet &code = instruction.code;
+  const codet &code = instruction.get_other();
 
   const irep_idt &statement=code.get_statement();
 

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -305,17 +305,16 @@ void goto_program_dereferencet::dereference_instruction(
 
   if(i.is_assign())
   {
-    if(i.code.operands().size()!=2)
-      throw "assignment expects two operands";
+    auto &assignment = i.get_assign();
 
     dereference_expr(
-      i.code.op0(), checks_only, value_set_dereferencet::modet::WRITE);
+      assignment.lhs(), checks_only, value_set_dereferencet::modet::WRITE);
     dereference_expr(
-      i.code.op1(), checks_only, value_set_dereferencet::modet::READ);
+      assignment.rhs(), checks_only, value_set_dereferencet::modet::READ);
   }
   else if(i.is_function_call())
   {
-    code_function_callt &function_call = to_code_function_call(i.code);
+    code_function_callt &function_call = i.get_function_call();
 
     if(function_call.lhs().is_not_nil())
       dereference_expr(
@@ -332,24 +331,25 @@ void goto_program_dereferencet::dereference_instruction(
   }
   else if(i.is_return())
   {
-    Forall_operands(it, i.code)
+    Forall_operands(it, i.get_return())
       dereference_expr(*it, checks_only, value_set_dereferencet::modet::READ);
   }
   else if(i.is_other())
   {
-    const irep_idt &statement = i.get_other().get_statement();
+    auto &code = i.get_other();
+    const irep_idt &statement = code.get_statement();
 
     if(statement==ID_expression)
     {
-      if(i.code.operands().size()!=1)
+      if(code.operands().size() != 1)
         throw "expression expects one operand";
 
       dereference_expr(
-        i.code.op0(), checks_only, value_set_dereferencet::modet::READ);
+        code.op0(), checks_only, value_set_dereferencet::modet::READ);
     }
     else if(statement==ID_printf)
     {
-      for(auto &op : i.get_other().operands())
+      for(auto &op : code.operands())
         dereference_expr(op, checks_only, value_set_dereferencet::modet::READ);
     }
   }

--- a/src/pointer-analysis/value_set_domain_fi.cpp
+++ b/src/pointer-analysis/value_set_domain_fi.cpp
@@ -48,8 +48,7 @@ bool value_set_domain_fit::transform(
 
   case FUNCTION_CALL:
     {
-      const code_function_callt &code=
-        to_code_function_call(from_l->code);
+      const code_function_callt &code = from_l->get_function_call();
 
       value_set.do_function_call(function_to, code.arguments(), ns);
     }


### PR DESCRIPTION
This increases type safety when accessing or construcing instructions of
goto programs.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
