### PR TITLE
Avoid deprecated symbol_exprt default construction in unit test [blocks: #3768]

### DIFF
--- a/unit/util/expr_cast/expr_cast.cpp
+++ b/unit/util/expr_cast/expr_cast.cpp
@@ -106,7 +106,7 @@ SCENARIO("expr_dynamic_cast",
   }
   GIVEN("An exprt value upcast from a symbolt")
   {
-    exprt expr = symbol_exprt{};
+    exprt expr = symbol_exprt::typeless(irep_idt());
 
     THEN(
       "Trying casting from an exprt lvalue to a symbol_exprt should yield a "


### PR DESCRIPTION
We don't care about either the type or the name in this test, so just use
symbol_exprt::typeless(irep_idt()).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
