### PR TITLE
String refinement: Do not fail if the solver returns a negative string length [blocks: #2574]

### DIFF
--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -1213,6 +1213,12 @@ static exprt negation_of_not_contains_constraint(
 
   // The negated existential becomes an universal, and this is the unrolling of
   // that universal quantifier.
+  // Ff the upper bound is smaller than the lower bound (specifically, it might
+  // actually be negative as it is initially unconstrained) then there is
+  // nothing to do (and the reserve call would fail).
+  if(ube < lbe)
+    return and_exprt(univ_bounds, get(constraint.premise));
+
   std::vector<exprt> conjuncts;
   conjuncts.reserve(numeric_cast_v<std::size_t>(ube - lbe));
   for(mp_integer i = lbe; i < ube; ++i)


### PR DESCRIPTION
The string length may initially be unconstrained, and such counterexamples
should not result in failing invariants. When enabling field sensitivity,
strings-smoke-tests/java_index_of2 was failing as the solver returned
-1073741820 for string_refinement#string_length#1 (which is a signed integer).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
