### PR TITLE
Remove unused goto_convertt::convert_init

### DIFF
--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -771,23 +771,6 @@ void goto_convertt::convert_assign(
   }
 }
 
-void goto_convertt::convert_init(
-  const codet &code,
-  goto_programt &dest,
-  const irep_idt &mode)
-{
-  INVARIANT_WITH_DIAGNOSTICS(
-    code.operands().size() == 2,
-    "init statement takes two operands",
-    code.find_source_location());
-
-  // make it an assignment
-  codet assignment=code;
-  assignment.set_statement(ID_assign);
-
-  convert(to_code_assign(assignment), dest, mode);
-}
-
 void goto_convertt::convert_cpp_delete(
   const codet &code,
   goto_programt &dest)

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -266,8 +266,6 @@ protected:
     const code_ifthenelset &code,
     goto_programt &dest,
     const irep_idt &mode);
-  void
-  convert_init(const codet &code, goto_programt &dest, const irep_idt &mode);
   void convert_goto(const code_gotot &code, goto_programt &dest);
   void convert_gcc_computed_goto(const codet &code, goto_programt &dest);
   void convert_skip(const codet &code, goto_programt &dest);


### PR DESCRIPTION
It is protected and was never called.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
