### PR TITLE
make_compound_literal: explicitly record desired lifetime

### DIFF
--- a/src/goto-programs/goto_clean_expr.cpp
+++ b/src/goto-programs/goto_clean_expr.cpp
@@ -34,7 +34,7 @@ symbol_exprt goto_convertt::make_compound_literal(
     source_location,
     mode,
     symbol_table);
-  new_symbol.is_static_lifetime=source_location.get_function().empty();
+  new_symbol.is_static_lifetime = lifetime != lifetimet::AUTOMATIC_LOCAL;
   new_symbol.value=expr;
 
   // The value might depend on a variable, thus

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -15,11 +15,12 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <list>
 #include <vector>
 
+#include <util/allocate_objects.h>
+#include <util/guard.h>
+#include <util/message.h>
 #include <util/namespace.h>
 #include <util/replace_expr.h>
-#include <util/guard.h>
 #include <util/std_code.h>
-#include <util/message.h>
 
 #include "goto_program.h"
 
@@ -47,6 +48,7 @@ protected:
   symbol_table_baset &symbol_table;
   namespacet ns;
   std::string tmp_symbol_prefix;
+  lifetimet lifetime = lifetimet::STATIC_GLOBAL;
 
   void goto_convert_rec(
     const codet &code,

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -17,6 +17,8 @@ Date: June 2003
 #include <util/symbol_table.h>
 #include <util/symbol_table_builder.h>
 
+#include <linking/static_lifetime_init.h>
+
 #include "goto_inline.h"
 
 goto_convert_functionst::goto_convert_functionst(
@@ -154,6 +156,10 @@ void goto_convert_functionst::convert_function(
      symbol.is_compiled()) /* goto_inline may have removed the body */
     return;
 
+  lifetimet parent_lifetime = lifetime;
+  lifetime = identifier == INITIALIZE_FUNCTION ? lifetimet::STATIC_GLOBAL
+                                               : lifetimet::AUTOMATIC_LOCAL;
+
   const codet &code=to_code(symbol.value);
 
   source_locationt end_location;
@@ -208,6 +214,8 @@ void goto_convert_functionst::convert_function(
 
   if(hide(f.body))
     f.make_hidden();
+
+  lifetime = parent_lifetime;
 }
 
 void goto_convert(


### PR DESCRIPTION
Do not use source_locationt::get_function as a hack to decide upon the lifetime
of a symbol to be generated. Instead, maintain the lifetime of the current
context being converted as a class member.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
