### PR TITLE
label_properties: do not rely on source_locationt's get_function()

### DIFF
--- a/jbmc/regression/jbmc-strings/ConstantEvaluationStringBufferSetCharAt/test_exception1.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationStringBufferSetCharAt/test_exception1.desc
@@ -1,6 +1,6 @@
 CORE symex-driven-lazy-loading-expected-failure
 Test
---function Test.testException1 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar ../../../lib/java-models-library/target/cprover-api.jar` --property 'java::Test.testException1:()V.1'
+--function Test.testException1 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar ../../../lib/java-models-library/target/cprover-api.jar` --property __CPROVER__start.1
 ^Generated [0-9]+ VCC\(s\), 1 remaining after simplification$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationStringBufferSetCharAt/test_exception2.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationStringBufferSetCharAt/test_exception2.desc
@@ -1,6 +1,6 @@
 CORE symex-driven-lazy-loading-expected-failure
 Test
---function Test.testException2 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar ../../../lib/java-models-library/target/cprover-api.jar` --property 'java::Test.testException2:()V.1'
+--function Test.testException2 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar ../../../lib/java-models-library/target/cprover-api.jar` --property __CPROVER__start.1
 ^Generated [0-9]+ VCC\(s\), 1 remaining after simplification$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationStringBufferSetLength/test_exception.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationStringBufferSetLength/test_exception.desc
@@ -1,6 +1,6 @@
 CORE symex-driven-lazy-loading-expected-failure
 Test
---function Test.testException --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar ../../../lib/java-models-library/target/cprover-api.jar` --property 'java::Test.testException:()V.1'
+--function Test.testException --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar ../../../lib/java-models-library/target/cprover-api.jar` --property __CPROVER__start.1
 ^Generated [0-9]+ VCC\(s\), 1 remaining after simplification$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationStringBuilderSetCharAt/test_exception1.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationStringBuilderSetCharAt/test_exception1.desc
@@ -1,6 +1,6 @@
 CORE symex-driven-lazy-loading-expected-failure
 Test
---function Test.testException1 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar ../../../lib/java-models-library/target/cprover-api.jar` --property 'java::Test.testException1:()V.1'
+--function Test.testException1 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar ../../../lib/java-models-library/target/cprover-api.jar` --property __CPROVER__start.1
 ^Generated [0-9]+ VCC\(s\), 1 remaining after simplification$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationStringBuilderSetCharAt/test_exception2.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationStringBuilderSetCharAt/test_exception2.desc
@@ -1,6 +1,6 @@
 CORE symex-driven-lazy-loading-expected-failure
 Test
---function Test.testException2 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar ../../../lib/java-models-library/target/cprover-api.jar` --property 'java::Test.testException2:()V.1'
+--function Test.testException2 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar ../../../lib/java-models-library/target/cprover-api.jar` --property __CPROVER__start.1
 ^Generated [0-9]+ VCC\(s\), 1 remaining after simplification$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationStringBuilderSetLength/test_exception.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationStringBuilderSetLength/test_exception.desc
@@ -1,6 +1,6 @@
 CORE symex-driven-lazy-loading-expected-failure
 Test
---function Test.testException --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar ../../../lib/java-models-library/target/cprover-api.jar` --property 'java::Test.testException:()V.1'
+--function Test.testException --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar ../../../lib/java-models-library/target/cprover-api.jar` --property __CPROVER__start.1
 ^Generated [0-9]+ VCC\(s\), 1 remaining after simplification$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc/exceptions28/test.desc
+++ b/jbmc/regression/jbmc/exceptions28/test.desc
@@ -1,7 +1,7 @@
 CORE
 test
 --unwind 10
-^\[java::test.main:\(\[Ljava/lang/String;\)V\.1\] line 7 no uncaught exception: FAILURE$
+^\[__CPROVER__start\.1\] line 7 no uncaught exception: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/cbmc/link_json_symtabs/test.desc
+++ b/regression/cbmc/link_json_symtabs/test.desc
@@ -3,7 +3,7 @@ one.json_symtab
 two.json_symtab
 ^EXIT=0$
 ^SIGNAL=0$
-\[1\] file two.adb line [0-9]+ assertion: SUCCESS
+\[two\.1\] file two.adb line [0-9]+ assertion: SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/cbmc/unique_labels1/bar.c
+++ b/regression/cbmc/unique_labels1/bar.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+
+static int foo()
+{
+  assert(1 < 0);
+}
+
+void bar()
+{
+  foo();
+}

--- a/regression/cbmc/unique_labels1/main.c
+++ b/regression/cbmc/unique_labels1/main.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+
+static int foo()
+{
+  assert(0);
+}
+
+void bar();
+
+int main()
+{
+  foo();
+  bar();
+}

--- a/regression/cbmc/unique_labels1/test.desc
+++ b/regression/cbmc/unique_labels1/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+bar.c
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+assertion\.2
+--
+Each of the assertions in the two functions named "foo" should have a unique
+prefix, and thus be numbered "<prefix>.assertion.1."

--- a/regression/contracts-dfcc/assigns-enforce-malloc-zero/test.desc
+++ b/regression/contracts-dfcc/assigns-enforce-malloc-zero/test.desc
@@ -1,8 +1,8 @@
 CORE dfcc-only
 main.c
 --malloc-may-fail --malloc-fail-null --dfcc main --enforce-contract foo
-^\[foo.assigns.\d+\] line \d+ Check that a\[\(signed long (long )?int\)i\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that \*out is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that a\[\(signed long (long )?int\)i\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that \*out is assignable: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts-dfcc/assigns-slice-targets/test-enforce.desc
+++ b/regression/contracts-dfcc/assigns-slice-targets/test-enforce.desc
@@ -1,34 +1,34 @@
 CORE
 main-enforce.c
 --dfcc main --enforce-contract foo
-^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)0\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)1\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)2\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)3\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)4\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)5\] is assignable: FAILURE$
-^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)6\] is assignable: FAILURE$
-^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)7\] is assignable: FAILURE$
-^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)8\] is assignable: FAILURE$
-^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)9\] is assignable: FAILURE$
-^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)0\] is assignable: FAILURE$
-^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)1\] is assignable: FAILURE$
-^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)2\] is assignable: FAILURE$
-^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)3\] is assignable: FAILURE$
-^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)4\] is assignable: FAILURE$
-^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)5\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)6\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)7\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)8\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)9\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\].* Check that ss->a is assignable: SUCCESS$
-^\[foo.assigns.\d+\].* Check that ss->arr1\[\(.*\)0\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\].* Check that ss->arr1\[\(.*\)7\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\].* Check that ss->arr1\[\(.*\)9\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\].* Check that ss->b is assignable: SUCCESS$
-^\[foo.assigns.\d+\].* Check that ss->arr2\[\(.*\)6\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\].* Check that ss->arr2\[\(.*\)8\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\].* Check that ss->c is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that s->arr1\[\(.*\)0\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that s->arr1\[\(.*\)1\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that s->arr1\[\(.*\)2\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that s->arr1\[\(.*\)3\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that s->arr1\[\(.*\)4\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that s->arr1\[\(.*\)5\] is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that s->arr1\[\(.*\)6\] is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that s->arr1\[\(.*\)7\] is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that s->arr1\[\(.*\)8\] is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that s->arr1\[\(.*\)9\] is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that s->arr2\[\(.*\)0\] is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that s->arr2\[\(.*\)1\] is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that s->arr2\[\(.*\)2\] is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that s->arr2\[\(.*\)3\] is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that s->arr2\[\(.*\)4\] is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that s->arr2\[\(.*\)5\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that s->arr2\[\(.*\)6\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that s->arr2\[\(.*\)7\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that s->arr2\[\(.*\)8\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that s->arr2\[\(.*\)9\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that ss->a is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that ss->arr1\[\(.*\)0\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that ss->arr1\[\(.*\)7\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that ss->arr1\[\(.*\)9\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that ss->b is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that ss->arr2\[\(.*\)6\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that ss->arr2\[\(.*\)8\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that ss->c is assignable: SUCCESS$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/assigns_enforce_02/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_02/test.desc
@@ -1,7 +1,7 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract foo
-^\[foo.assigns.\d+\] line 6 Check that \*x is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 6 Check that \*x is assignable: FAILURE$
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/contracts-dfcc/assigns_enforce_15/test-baz.desc
+++ b/regression/contracts-dfcc/assigns_enforce_15/test-baz.desc
@@ -1,7 +1,7 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract baz
-^\[baz.assigns.\d+\] line \d+ Check that global is assignable: FAILURE$
+^\[baz_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that global is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/assigns_enforce_15/test-qux.desc
+++ b/regression/contracts-dfcc/assigns_enforce_15/test-qux.desc
@@ -1,7 +1,7 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract qux
-^\[qux.assigns.\d+\] line \d+ Check that global is assignable: FAILURE$
+^\[qux_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that global is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/assigns_enforce_18/test-bar.desc
+++ b/regression/contracts-dfcc/assigns_enforce_18/test-bar.desc
@@ -1,7 +1,7 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract bar _ --pointer-primitive-check
-^\[bar.assigns.\d+\] line 20 Check that \*b is assignable: SUCCESS$
+^\[bar_wrapped_for_contract_checking.assigns.\d+\] line 20 Check that \*b is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/assigns_enforce_18/test-baz.desc
+++ b/regression/contracts-dfcc/assigns_enforce_18/test-baz.desc
@@ -2,7 +2,7 @@ CORE dfcc-only
 main.c
 --dfcc main --enforce-contract baz _ --pointer-primitive-check
 ^\[free.frees.\d+\].*Check that ptr is freeable: FAILURE
-^\[baz.assigns.\d+\].*Check that \*a is assignable: SUCCESS$
+^\[baz_wrapped_for_contract_checking.assigns.\d+\].*Check that \*a is assignable: SUCCESS$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/assigns_enforce_18/test-foo.desc
+++ b/regression/contracts-dfcc/assigns_enforce_18/test-foo.desc
@@ -1,8 +1,8 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract foo _ --pointer-primitive-check
-^\[foo.assigns.\d+\] line 13 Check that \*xp is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 14 Check that y is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 13 Check that \*xp is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 14 Check that y is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/assigns_enforce_19_a/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_19_a/test.desc
@@ -1,7 +1,7 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract f
-^\[f.assigns.\d+\] .* Check that a is assignable: SUCCESS$
+^\[f_wrapped_for_contract_checking.assigns.\d+\] .* Check that a is assignable: SUCCESS$
 ^\[f.postcondition.\d+\] .* Check ensures clause of contract contract::f for function f: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$

--- a/regression/contracts-dfcc/assigns_enforce_19_b/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_19_b/test.desc
@@ -1,10 +1,10 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract f
-^\[f.assigns.\d+\] line \d+ Check that b is assignable: SUCCESS$
-^\[f.assigns.\d+\] line \d+ Check that \*points_to_b is assignable: SUCCESS$
-^\[f.assigns.\d+\] line \d+ Check that c is assignable: FAILURE$
-^\[f.assigns.\d+\] line \d+ Check that \*points_to_c is assignable: FAILURE$
+^\[f_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that b is assignable: SUCCESS$
+^\[f_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that \*points_to_b is assignable: SUCCESS$
+^\[f_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that c is assignable: FAILURE$
+^\[f_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that \*points_to_c is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/assigns_enforce_20/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_20/test.desc
@@ -3,7 +3,7 @@ main.c
 --dfcc main --enforce-contract foo
 ^EXIT=10$
 ^SIGNAL=0$
-^\[foo.assigns.\d+\] line \d+ Check that x is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that x is assignable: FAILURE$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts-dfcc/assigns_enforce_arrays_02/test-f1.desc
+++ b/regression/contracts-dfcc/assigns_enforce_arrays_02/test-f1.desc
@@ -1,8 +1,8 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract f1
-^\[f1.assigns.\d+\] line 8 Check that a\[.*0\] is assignable: SUCCESS$
-^\[f1.assigns.\d+\] line 9 Check that a\[.*5\] is assignable: FAILURE$
+^\[f1_wrapped_for_contract_checking.assigns.\d+\] line 8 Check that a\[.*0\] is assignable: SUCCESS$
+^\[f1_wrapped_for_contract_checking.assigns.\d+\] line 9 Check that a\[.*5\] is assignable: FAILURE$
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/contracts-dfcc/assigns_enforce_arrays_02/test-f2.desc
+++ b/regression/contracts-dfcc/assigns_enforce_arrays_02/test-f2.desc
@@ -1,8 +1,8 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract f2
-^\[f2.assigns.\d+\] line \d+ Check that a\[.*0\] is assignable: SUCCESS$
-^\[f2.assigns.\d+\] line \d+ Check that a\[.*5\] is assignable: SUCCESS$
+^\[f2_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that a\[.*0\] is assignable: SUCCESS$
+^\[f2_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that a\[.*5\] is assignable: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts-dfcc/assigns_enforce_conditional_function_call_condition/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_conditional_function_call_condition/test.desc
@@ -2,8 +2,8 @@ CORE dfcc-only
 main.c
 --dfcc main --enforce-contract foo
 ^main.c function foo$
-^\[foo.assigns.\d+\] line 16 Check that \*x is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 20 Check that \*x is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 16 Check that \*x is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 20 Check that \*x is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/assigns_enforce_conditional_lvalue/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_conditional_lvalue/test.desc
@@ -2,12 +2,12 @@ CORE dfcc-only
 main.c
 --dfcc main --enforce-contract foo
 main.c function foo
-^\[foo.assigns.\d+\] line 7 Check that \*x is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 8 Check that \*y is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 12 Check that \*x is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 13 Check that \*y is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 16 Check that \*x is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 17 Check that \*y is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 7 Check that \*x is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 8 Check that \*y is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 12 Check that \*x is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 13 Check that \*y is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 16 Check that \*x is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 17 Check that \*y is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/assigns_enforce_conditional_lvalue_list/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_conditional_lvalue_list/test.desc
@@ -2,12 +2,12 @@ CORE dfcc-only
 main.c
 --dfcc main --enforce-contract foo
 main.c function foo
-^\[foo.assigns.\d+\] line 7 Check that \*x is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 8 Check that \*y is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 12 Check that \*x is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 13 Check that \*y is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 16 Check that \*x is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 17 Check that \*y is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 7 Check that \*x is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 8 Check that \*y is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 12 Check that \*x is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 13 Check that \*y is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 16 Check that \*x is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 17 Check that \*y is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/assigns_enforce_conditional_pointer_object/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_conditional_pointer_object/test.desc
@@ -2,12 +2,12 @@ CORE dfcc-only
 main.c
 --dfcc main --enforce-contract foo
 main.c function foo
-^\[foo.assigns.\d+\] line 13 Check that x\[\(signed (long )?long int\)0\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 14 Check that y\[\(signed (long )?long int\)0\] is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 18 Check that x\[\(signed (long )?long int\)0\] is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 19 Check that y\[\(signed (long )?long int\)0\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 22 Check that x\[\(signed (long )?long int\)0\] is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 23 Check that y\[\(signed (long )?long int\)0\] is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 13 Check that x\[\(signed (long )?long int\)0\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 14 Check that y\[\(signed (long )?long int\)0\] is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 18 Check that x\[\(signed (long )?long int\)0\] is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 19 Check that y\[\(signed (long )?long int\)0\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 22 Check that x\[\(signed (long )?long int\)0\] is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 23 Check that y\[\(signed (long )?long int\)0\] is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/assigns_enforce_conditional_pointer_object_list/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_conditional_pointer_object_list/test.desc
@@ -2,12 +2,12 @@ CORE dfcc-only
 main.c
 --dfcc main --enforce-contract foo
 main.c function foo
-^\[foo.assigns.\d+\] line 12 Check that x\[\(signed (long )?long int\)0\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 13 Check that y\[\(signed (long )?long int\)0\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 17 Check that x\[\(signed (long )?long int\)0\] is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 18 Check that y\[\(signed (long )?long int\)0\] is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 21 Check that x\[\(signed (long )?long int\)0\] is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 22 Check that y\[\(signed (long )?long int\)0\] is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 12 Check that x\[\(signed (long )?long int\)0\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 13 Check that y\[\(signed (long )?long int\)0\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 17 Check that x\[\(signed (long )?long int\)0\] is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 18 Check that y\[\(signed (long )?long int\)0\] is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 21 Check that x\[\(signed (long )?long int\)0\] is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 22 Check that y\[\(signed (long )?long int\)0\] is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/assigns_enforce_conditional_unions/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_conditional_unions/test.desc
@@ -3,11 +3,11 @@ main.c
 --dfcc main --enforce-contract update _ --pointer-check --pointer-overflow-check --signed-overflow-check --unsigned-overflow-check --conversion-check
 ^\[is_high_level.assigns.\d+\] line 52 Check that latch is assignable: SUCCESS$
 ^\[is_high_level.assigns.\d+\] line 53 Check that once is assignable: SUCCESS$
-^\[update.assigns.\d+\] line 87 Check that state->digest.high_level.first.ctx->flags is assignable: SUCCESS$
-^\[update.assigns.\d+\] line 93 Check that state->digest.high_level.second.ctx->flags is assignable: SUCCESS$
-^\[update.assigns.\d+\] line 98 Check that state->digest.high_level.second.ctx->flags is assignable: FAILURE$
-^\[update.assigns.\d+\] line 103 Check that state->digest.high_level.first.ctx->flags is assignable: FAILURE$
-^\[update.assigns.\d+\] line 107 Check that state->digest.high_level.second.ctx->flags is assignable: FAILURE$
+^\[update_wrapped_for_contract_checking.assigns.\d+\] line 87 Check that state->digest.high_level.first.ctx->flags is assignable: SUCCESS$
+^\[update_wrapped_for_contract_checking.assigns.\d+\] line 93 Check that state->digest.high_level.second.ctx->flags is assignable: SUCCESS$
+^\[update_wrapped_for_contract_checking.assigns.\d+\] line 98 Check that state->digest.high_level.second.ctx->flags is assignable: FAILURE$
+^\[update_wrapped_for_contract_checking.assigns.\d+\] line 103 Check that state->digest.high_level.first.ctx->flags is assignable: FAILURE$
+^\[update_wrapped_for_contract_checking.assigns.\d+\] line 107 Check that state->digest.high_level.second.ctx->flags is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/assigns_enforce_free_dead/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_free_dead/test.desc
@@ -1,10 +1,10 @@
 CORE dfcc-only
 main.c
 --malloc-may-fail --malloc-fail-null --dfcc main --enforce-contract foo _ --pointer-primitive-check
-^\[foo.assigns.\d+\] line 6 Check that \*x is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 9 Check that \*\(\*y\) is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 21 Check that \*\(\*y\) is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 33 Check that \*x is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 6 Check that \*x is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 9 Check that \*\(\*y\) is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 21 Check that \*\(\*y\) is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line 33 Check that \*x is assignable: FAILURE$
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/contracts-dfcc/assigns_enforce_malloc_01/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_malloc_01/test.desc
@@ -3,7 +3,7 @@ main.c
 --dfcc main --enforce-contract f
 ^EXIT=0$
 ^SIGNAL=0$
-^\[f\.assigns.\d+\] line \d+ Check that \*a is assignable: SUCCESS
+^\[f_wrapped_for_contract_checking\.assigns.\d+\] line \d+ Check that \*a is assignable: SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --
 --

--- a/regression/contracts-dfcc/assigns_enforce_malloc_02/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_malloc_02/test.desc
@@ -2,9 +2,9 @@ CORE dfcc-only
 main.c
 --dfcc main --enforce-contract f
 main.c function f
-^\[f.assigns.\d+\] line 7 Check that ptr is assignable: SUCCESS$
-^\[f.assigns.\d+\] line 12 Check that \*ptr is assignable: SUCCESS$
-^\[f.assigns.\d+\] line 13 Check that n is assignable: SUCCESS$
+^\[f_wrapped_for_contract_checking.assigns.\d+\] line 7 Check that ptr is assignable: SUCCESS$
+^\[f_wrapped_for_contract_checking.assigns.\d+\] line 12 Check that \*ptr is assignable: SUCCESS$
+^\[f_wrapped_for_contract_checking.assigns.\d+\] line 13 Check that n is assignable: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts-dfcc/assigns_enforce_malloc_03/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_malloc_03/test.desc
@@ -1,8 +1,8 @@
 CORE
 main.c
 --dfcc main --enforce-contract foo
-^\[foo.assigns.\d+\].* Check that \*loc1 is assignable: SUCCESS$
-^\[foo.assigns.\d+\].* Check that \*loc2 is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that \*loc1 is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].* Check that \*loc2 is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/assigns_enforce_offsets_2/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_offsets_2/test.desc
@@ -1,8 +1,8 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract foo _ --pointer-check
-^\[foo.assigns.*\d+\].* line 8 Check that x\[\(.*\)1\] is assignable: (SUCCESS|FAILURE)$
-^\[foo.assigns.*\d+\].* line 8 Check that x\[\(.*\)1\] is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.*\d+\].* line 8 Check that x\[\(.*\)1\] is assignable: (SUCCESS|FAILURE)$
+^\[foo_wrapped_for_contract_checking.assigns.*\d+\].* line 8 Check that x\[\(.*\)1\] is assignable: FAILURE$
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/contracts-dfcc/assigns_enforce_scoping_01/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_scoping_01/test.desc
@@ -3,7 +3,7 @@ main.c
 --dfcc main --enforce-contract f1
 ^EXIT=10$
 ^SIGNAL=0$
-^\[f1.assigns.\d+\] line \d+ Check that \*b is assignable: FAILURE$
+^\[f1_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that \*b is assignable: FAILURE$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts-dfcc/assigns_enforce_scoping_02/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_scoping_02/test.desc
@@ -3,7 +3,7 @@ main.c
 --dfcc main --enforce-contract f1
 ^EXIT=10$
 ^SIGNAL=0$
-^\[f1.assigns.\d+\] line \d+ Check that \*b is assignable: FAILURE$
+^\[f1_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that \*b is assignable: FAILURE$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts-dfcc/assigns_enforce_statics/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_statics/test.desc
@@ -1,9 +1,9 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract foo _ --pointer-primitive-check
-^\[foo.assigns.\d+\] line \d+ Check that y is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that foo\$\$1\$\$x is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that \*y is assignable: FAILURE$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that y is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that foo\$\$1\$\$x is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that \*y is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/assigns_enforce_structs_01/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_structs_01/test.desc
@@ -3,7 +3,7 @@ main.c
 --dfcc main --enforce-contract f
 ^EXIT=0$
 ^SIGNAL=0$
-^\[f.assigns.\d+\] line \d+ Check that \*a is assignable: SUCCESS$
+^\[f_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that \*a is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^\[.*assigns.*\].*: FAILURE$

--- a/regression/contracts-dfcc/assigns_enforce_structs_02/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_structs_02/test.desc
@@ -3,7 +3,7 @@ main.c
 --dfcc main --enforce-contract f
 ^EXIT=0$
 ^SIGNAL=0$
-^\[f.assigns.\d+\] line \d+ Check that \*a is assignable: SUCCESS$
+^\[f_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that \*a is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^\[.*assigns.*\].*: FAILURE$

--- a/regression/contracts-dfcc/assigns_enforce_structs_04/test-f1.desc
+++ b/regression/contracts-dfcc/assigns_enforce_structs_04/test-f1.desc
@@ -3,7 +3,7 @@ main.c
 --dfcc main --enforce-contract f1
 ^EXIT=10$
 ^SIGNAL=0$
-^\[f1.assigns.\d+\] line \d+ Check that p->y is assignable: FAILURE$
+^\[f1_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that p->y is assignable: FAILURE$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts-dfcc/assigns_enforce_structs_04/test-f2.desc
+++ b/regression/contracts-dfcc/assigns_enforce_structs_04/test-f2.desc
@@ -3,7 +3,7 @@ main.c
 --dfcc main --enforce-contract f2
 ^EXIT=10$
 ^SIGNAL=0$
-^\[f2.assigns.\d+\] line \d+ Check that p->x is assignable: FAILURE$
+^\[f2_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that p->x is assignable: FAILURE$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts-dfcc/assigns_enforce_structs_04/test-f3.desc
+++ b/regression/contracts-dfcc/assigns_enforce_structs_04/test-f3.desc
@@ -3,7 +3,7 @@ main.c
 --dfcc main --enforce-contract f3
 ^EXIT=0$
 ^SIGNAL=0$
-^\[f3.assigns.\d+\] line \d+ Check that p->y is assignable: SUCCESS$
+^\[f3_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that p->y is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 --

--- a/regression/contracts-dfcc/assigns_enforce_structs_05/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_structs_05/test.desc
@@ -3,10 +3,10 @@ main.c
 --dfcc main --enforce-contract f1
 ^EXIT=10$
 ^SIGNAL=0$
-^\[f1.assigns.\d+\] line \d+ Check that p->y is assignable: FAILURE$
-^\[f1.assigns.\d+\] line \d+ Check that p->x\[\(.*\)0\] is assignable: SUCCESS$
-^\[f1.assigns.\d+\] line \d+ Check that p->x\[\(.*\)1\] is assignable: SUCCESS$
-^\[f1.assigns.\d+\] line \d+ Check that p->x\[\(.*\)2\] is assignable: SUCCESS$
+^\[f1_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that p->y is assignable: FAILURE$
+^\[f1_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that p->x\[\(.*\)0\] is assignable: SUCCESS$
+^\[f1_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that p->x\[\(.*\)1\] is assignable: SUCCESS$
+^\[f1_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that p->x\[\(.*\)2\] is assignable: SUCCESS$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts-dfcc/assigns_enforce_structs_06/test-f1.desc
+++ b/regression/contracts-dfcc/assigns_enforce_structs_06/test-f1.desc
@@ -3,10 +3,10 @@ main.c
 --dfcc main --enforce-contract f1
 ^EXIT=10$
 ^SIGNAL=0$
-^\[f1.assigns.\d+\] line \d+ Check that p->buf\[\(.*\)0\] is assignable: SUCCESS$
-^\[f1.assigns.\d+\] line \d+ Check that p->buf\[\(.*\)1\] is assignable: SUCCESS$
-^\[f1.assigns.\d+\] line \d+ Check that p->buf\[\(.*\)2\] is assignable: SUCCESS$
-^\[f1.assigns.\d+\] line \d+ Check that p->size is assignable: FAILURE$
+^\[f1_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that p->buf\[\(.*\)0\] is assignable: SUCCESS$
+^\[f1_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that p->buf\[\(.*\)1\] is assignable: SUCCESS$
+^\[f1_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that p->buf\[\(.*\)2\] is assignable: SUCCESS$
+^\[f1_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that p->size is assignable: FAILURE$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts-dfcc/assigns_enforce_structs_06/test-f2.desc
+++ b/regression/contracts-dfcc/assigns_enforce_structs_06/test-f2.desc
@@ -3,8 +3,8 @@ main.c
 --dfcc main --enforce-contract f2
 ^EXIT=10$
 ^SIGNAL=0$
-^\[f2.assigns.\d+\] line \d+ Check that p->buf\[\(.*\)0\] is assignable: FAILURE$
-^\[f2.assigns.\d+\] line \d+ Check that p->size is assignable: SUCCESS$
+^\[f2_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that p->buf\[\(.*\)0\] is assignable: FAILURE$
+^\[f2_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that p->size is assignable: SUCCESS$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts-dfcc/assigns_enforce_structs_06/test-f3.desc
+++ b/regression/contracts-dfcc/assigns_enforce_structs_06/test-f3.desc
@@ -3,8 +3,8 @@ main.c
 --dfcc main --enforce-contract f3
 ^EXIT=0$
 ^SIGNAL=0$
-^\[f3.assigns.\d+\] line \d+ Check that p->buf is assignable: SUCCESS$
-^\[f3.assigns.\d+\] line \d+ Check that p->size is assignable: SUCCESS$
+^\[f3_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that p->buf is assignable: SUCCESS$
+^\[f3_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that p->size is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 --

--- a/regression/contracts-dfcc/assigns_enforce_structs_07/test-f1.desc
+++ b/regression/contracts-dfcc/assigns_enforce_structs_07/test-f1.desc
@@ -3,7 +3,7 @@ main.c
 --malloc-may-fail --malloc-fail-null --dfcc main --enforce-contract f1 _ --pointer-check
 ^EXIT=10$
 ^SIGNAL=0$
-^\[f1.assigns.\d+\].*line 18 Check that p->buf\[\(.*\)0\] is assignable: FAILURE$
+^\[f1_wrapped_for_contract_checking.assigns.\d+\].*line 18 Check that p->buf\[\(.*\)0\] is assignable: FAILURE$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts-dfcc/assigns_enforce_structs_07/test-f2.desc
+++ b/regression/contracts-dfcc/assigns_enforce_structs_07/test-f2.desc
@@ -3,7 +3,7 @@ main.c
 --malloc-may-fail --malloc-fail-null --dfcc main --enforce-contract f2 _ --pointer-check
 ^EXIT=10$
 ^SIGNAL=0$
-^\[f2.assigns.\d+\].*line 23 Check that pp->p->buf\[\(.*\)0\] is assignable: FAILURE$
+^\[f2_wrapped_for_contract_checking.assigns.\d+\].*line 23 Check that pp->p->buf\[\(.*\)0\] is assignable: FAILURE$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts-dfcc/assigns_enforce_structs_08/test-f1.desc
+++ b/regression/contracts-dfcc/assigns_enforce_structs_08/test-f1.desc
@@ -1,7 +1,7 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract f1 _ --malloc-may-fail --malloc-fail-null --pointer-check
-^\[f1.assigns.\d+\] line \d+ Check that p->buf\[\(.*\)0\] is assignable: SUCCESS$
+^\[f1_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that p->buf\[\(.*\)0\] is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/assigns_enforce_structs_08/test-f2.desc
+++ b/regression/contracts-dfcc/assigns_enforce_structs_08/test-f2.desc
@@ -1,7 +1,7 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract f2 _ --malloc-may-fail --malloc-fail-null --pointer-check
-^\[f2.assigns.\d+\] line \d+ Check that pp->p->buf\[\(.*\)0\] is assignable: SUCCESS$
+^\[f2_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that pp->p->buf\[\(.*\)0\] is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/assigns_function_pointer/test.desc
+++ b/regression/contracts-dfcc/assigns_function_pointer/test.desc
@@ -3,8 +3,8 @@ main.c
 --dfcc main --enforce-contract bar
 ^EXIT=0$
 ^SIGNAL=0$
-^\[bar.assigns.\d+\] line \d+ Check that s->f is assignable: SUCCESS$
-^\[bar.assigns.\d+\] line \d+ Check that \*f is assignable: SUCCESS$
+^\[bar_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that s->f is assignable: SUCCESS$
+^\[bar_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that \*f is assignable: SUCCESS$
 ^\[main.assertion.\d+\] line \d+ assertion x \=\= 1: SUCCESS$
 ^\[main.assertion.\d+\] line \d+ assertion x \=\= 2: SUCCESS$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts-dfcc/assigns_type_checking_valid_cases/test-foo10.desc
+++ b/regression/contracts-dfcc/assigns_type_checking_valid_cases/test-foo10.desc
@@ -3,8 +3,8 @@ main.c
 --dfcc main --enforce-contract foo10 _ --pointer-primitive-check
 ^EXIT=0$
 ^SIGNAL=0$
-^\[foo10.assigns.\d+\] line \d+ Check that buffer->len is assignable: SUCCESS$
-^\[foo10.assigns.\d+\] line \d+ Check that buffer->aux\.allocated is assignable: SUCCESS$
+^\[foo10_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that buffer->len is assignable: SUCCESS$
+^\[foo10_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that buffer->aux\.allocated is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 Checks whether CBMC parses correctly all standard cases for assigns clauses.

--- a/regression/contracts-dfcc/assigns_type_checking_valid_cases/test-foo3.desc
+++ b/regression/contracts-dfcc/assigns_type_checking_valid_cases/test-foo3.desc
@@ -3,7 +3,7 @@ main.c
 --dfcc main --enforce-contract foo3 _ --pointer-primitive-check
 ^EXIT=0$
 ^SIGNAL=0$
-^\[foo3.assigns.\d+\] line \d+ Check that y is assignable: SUCCESS$
+^\[foo3_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that y is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 Checks whether CBMC parses correctly all standard cases for assigns clauses.

--- a/regression/contracts-dfcc/assigns_type_checking_valid_cases/test-foo4.desc
+++ b/regression/contracts-dfcc/assigns_type_checking_valid_cases/test-foo4.desc
@@ -3,8 +3,8 @@ main.c
 --dfcc main --enforce-contract foo4 _ --pointer-primitive-check
 ^EXIT=0$
 ^SIGNAL=0$
-^\[foo4.assigns.\d+\] line \d+ Check that \*c is assignable: SUCCESS$
-^\[foo4.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
+^\[foo4_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that \*c is assignable: SUCCESS$
+^\[foo4_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 Checks whether CBMC parses correctly all standard cases for assigns clauses.

--- a/regression/contracts-dfcc/assigns_type_checking_valid_cases/test-foo6.desc
+++ b/regression/contracts-dfcc/assigns_type_checking_valid_cases/test-foo6.desc
@@ -3,8 +3,8 @@ main.c
 --dfcc main --enforce-contract foo6 _ --pointer-primitive-check
 ^EXIT=0$
 ^SIGNAL=0$
-^\[foo6.assigns.\d+\] line \d+ Check that \*buffer->data is assignable: SUCCESS$
-^\[foo6.assigns.\d+\] line \d+ Check that buffer->len is assignable: SUCCESS$
+^\[foo6_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that \*buffer->data is assignable: SUCCESS$
+^\[foo6_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that buffer->len is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 Checks whether CBMC parses correctly all standard cases for assigns clauses.

--- a/regression/contracts-dfcc/assigns_type_checking_valid_cases/test-foo7.desc
+++ b/regression/contracts-dfcc/assigns_type_checking_valid_cases/test-foo7.desc
@@ -3,8 +3,8 @@ main.c
 --dfcc main --enforce-contract foo7 _ --pointer-primitive-check
 ^EXIT=0$
 ^SIGNAL=0$
-^\[foo7.assigns.\d+\] line \d+ Check that \*buffer->data is assignable: SUCCESS$
-^\[foo7.assigns.\d+\] line \d+ Check that buffer->len is assignable: SUCCESS$
+^\[foo7_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that \*buffer->data is assignable: SUCCESS$
+^\[foo7_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that buffer->len is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 Checks whether CBMC parses correctly all standard cases for assigns clauses.

--- a/regression/contracts-dfcc/assigns_type_checking_valid_cases/test-foo8.desc
+++ b/regression/contracts-dfcc/assigns_type_checking_valid_cases/test-foo8.desc
@@ -3,16 +3,16 @@ main.c
 --dfcc main --enforce-contract foo8 _ --pointer-primitive-check
 ^EXIT=0$
 ^SIGNAL=0$
-^\[foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)0\] is assignable: SUCCESS$
-^\[foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)1\] is assignable: SUCCESS$
-^\[foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)2\] is assignable: SUCCESS$
-^\[foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)3\] is assignable: SUCCESS$
-^\[foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)4\] is assignable: SUCCESS$
-^\[foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)5\] is assignable: SUCCESS$
-^\[foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)6\] is assignable: SUCCESS$
-^\[foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)7\] is assignable: SUCCESS$
-^\[foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)8\] is assignable: SUCCESS$
-^\[foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)9\] is assignable: SUCCESS$
+^\[foo8_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that array\[\(.* int\)0\] is assignable: SUCCESS$
+^\[foo8_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that array\[\(.* int\)1\] is assignable: SUCCESS$
+^\[foo8_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that array\[\(.* int\)2\] is assignable: SUCCESS$
+^\[foo8_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that array\[\(.* int\)3\] is assignable: SUCCESS$
+^\[foo8_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that array\[\(.* int\)4\] is assignable: SUCCESS$
+^\[foo8_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that array\[\(.* int\)5\] is assignable: SUCCESS$
+^\[foo8_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that array\[\(.* int\)6\] is assignable: SUCCESS$
+^\[foo8_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that array\[\(.* int\)7\] is assignable: SUCCESS$
+^\[foo8_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that array\[\(.* int\)8\] is assignable: SUCCESS$
+^\[foo8_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that array\[\(.* int\)9\] is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 Checks whether CBMC parses correctly all standard cases for assigns clauses.

--- a/regression/contracts-dfcc/assigns_validity_pointer_02/test.desc
+++ b/regression/contracts-dfcc/assigns_validity_pointer_02/test.desc
@@ -7,7 +7,7 @@ main.c
 ^\[bar.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
 ^\[bar.assigns.\d+\] line \d+ Check that \*y is assignable: SUCCESS$
 ^\[baz.assigns.\d+\] line \d+ Check that \*z is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 --

--- a/regression/contracts-dfcc/contracts_with_function_pointers/test.desc
+++ b/regression/contracts-dfcc/contracts_with_function_pointers/test.desc
@@ -4,7 +4,7 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[bar.postcondition.\d+\].*Check ensures clause of contract contract::bar for function bar: SUCCESS$
-^\[bar.assigns.\d+\].*Check that \*return\_value\_baz is assignable: SUCCESS$
+^\[bar_wrapped_for_contract_checking.assigns.\d+\].*Check that \*return\_value\_baz is assignable: SUCCESS$
 ^\[foo.assigns.\d+\].*Check that \*y is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --

--- a/regression/contracts-dfcc/havoc-static/test-exclude.desc
+++ b/regression/contracts-dfcc/havoc-static/test-exclude.desc
@@ -1,9 +1,9 @@
 CORE
 main.c
 --dfcc main --enforce-contract foo --nondet-static-exclude main.c:a --nondet-static-exclude main.c:c
-^\[foo.assertion.\d+\].* guarded by a: SUCCESS$
-^\[foo.assertion.\d+\].* guarded by b: SUCCESS$
-^\[foo.assertion.\d+\].* guarded by c: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].* guarded by a: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].* guarded by b: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].* guarded by c: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts-dfcc/havoc-static/test.desc
+++ b/regression/contracts-dfcc/havoc-static/test.desc
@@ -1,9 +1,9 @@
 CORE
 main.c
 --dfcc main --enforce-contract foo
-^\[foo.assertion.\d+\].* guarded by a: FAILURE$
-^\[foo.assertion.\d+\].* guarded by b: SUCCESS$
-^\[foo.assertion.\d+\].* guarded by c: FAILURE$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].* guarded by a: FAILURE$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].* guarded by b: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].* guarded by c: FAILURE$
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/contracts-dfcc/history-pointer-enforce-09/test.desc
+++ b/regression/contracts-dfcc/history-pointer-enforce-09/test.desc
@@ -4,7 +4,7 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[foo.postcondition.\d+\] line \d+ Check ensures clause( of contract contract::foo for function foo)?: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that p->y is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that p->y is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 --

--- a/regression/contracts-dfcc/history-pointer-enforce-10/test-bar.desc
+++ b/regression/contracts-dfcc/history-pointer-enforce-10/test-bar.desc
@@ -4,7 +4,7 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[bar.postcondition.\d+\] line \d+ Check ensures clause of contract contract::bar for function bar: SUCCESS$
-^\[bar.assigns.\d+\] line \d+ Check that p->y is assignable: SUCCESS$
+^\[bar_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that p->y is assignable: SUCCESS$
 ^\[main.assertion.\d+\] line \d+ assertion \*\(p->y\) == 7: SUCCESS$
 ^\[main.assertion.\d+\] line \d+ assertion \*\(p->y\) == -1: SUCCESS$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts-dfcc/history-pointer-enforce-10/test-foo.desc
+++ b/regression/contracts-dfcc/history-pointer-enforce-10/test-foo.desc
@@ -4,8 +4,8 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[foo.postcondition.\d+\] line \d+ Check ensures clause of contract contract::foo for function foo: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that \*p->y is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that z is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that \*p->y is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that z is assignable: SUCCESS$
 ^\[main.assertion.\d+\] line \d+ assertion \*\(p->y\) == 7: SUCCESS$
 ^\[main.assertion.\d+\] line \d+ assertion \*\(p->y\) == -1: SUCCESS$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts-dfcc/loop-freeness-check/test.desc
+++ b/regression/contracts-dfcc/loop-freeness-check/test.desc
@@ -1,8 +1,8 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract foo
-^\[foo.assigns.\d+\].*Check that i is assignable: SUCCESS$
-^\[foo.assigns.\d+\].*Check that arr\[\(.*\)i\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].*Check that i is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].*Check that arr\[\(.*\)i\] is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/memory-predicates-is-fresh-failure-modes/test-fail-assert-bounded.desc
+++ b/regression/contracts-dfcc/memory-predicates-is-fresh-failure-modes/test-fail-assert-bounded.desc
@@ -5,12 +5,12 @@ main_bounded.c
 ^\[__CPROVER_contracts_car_set_insert.assertion.\d+\] line \d+ CAR size is less than __CPROVER_max_malloc_size: SUCCESS$
 ^\[__CPROVER_contracts_write_set_check_assignment.assertion.\d+\] line \d+ ptr NULL or writable up to size: SUCCESS$
 ^\[__CPROVER_contracts_write_set_check_assignment.assertion.\d+\] line \d+ no offset bits overflow on CAR upper bound computation: SUCCESS$
-^\[foo.assertion.\d+\] line \d+ size is capped: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that arr\[\(.*\)0\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that arr\[\(.*\)\(size - \(.*\)1\)\] is assignable: SUCCESS$
-^\[foo.pointer_arithmetic.\d+\] line \d+ pointer arithmetic: pointer outside object bounds in arr \+ \(.*\)\(size - \(.*\)1\): SUCCESS$
-^\[foo.pointer_arithmetic.\d+\] line \d+ pointer arithmetic: pointer outside object bounds in arr \+ \(.*\)\(size - \(.*\)1\): SUCCESS$
-^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: pointer outside object bounds in arr\[\(.*\)\(size - \(.*\)1\)\]: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\] line \d+ size is capped: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that arr\[\(.*\)0\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that arr\[\(.*\)\(size - \(.*\)1\)\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.pointer_arithmetic.\d+\] line \d+ pointer arithmetic: pointer outside object bounds in arr \+ \(.*\)\(size - \(.*\)1\): SUCCESS$
+^\[foo_wrapped_for_contract_checking.pointer_arithmetic.\d+\] line \d+ pointer arithmetic: pointer outside object bounds in arr \+ \(.*\)\(size - \(.*\)1\): SUCCESS$
+^\[foo_wrapped_for_contract_checking.pointer_dereference.\d+\] line \d+ dereference failure: pointer outside object bounds in arr\[\(.*\)\(size - \(.*\)1\)\]: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts-dfcc/memory-predicates-is-fresh-failure-modes/test-fail-assert.desc
+++ b/regression/contracts-dfcc/memory-predicates-is-fresh-failure-modes/test-fail-assert.desc
@@ -5,12 +5,12 @@ main.c
 ^\[__CPROVER_contracts_car_set_insert.assertion.\d+\] line \d+ CAR size is less than __CPROVER_max_malloc_size: SUCCESS$
 ^\[__CPROVER_contracts_write_set_check_assignment.assertion.\d+\] line \d+ ptr NULL or writable up to size: SUCCESS$
 ^\[__CPROVER_contracts_write_set_check_assignment.assertion.\d+\] line \d+ no offset bits overflow on CAR upper bound computation: SUCCESS$
-^\[foo.assertion.\d+\] line \d+ size is capped: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that arr\[\(.*\)0\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that arr\[\(.*\)\(size - \(.*\)1\)\] is assignable: SUCCESS$
-^\[foo.pointer_arithmetic.\d+\] line \d+ pointer arithmetic: pointer outside object bounds in arr \+ \(.*\)\(size - \(.*\)1\): SUCCESS$
-^\[foo.pointer_arithmetic.\d+\] line \d+ pointer arithmetic: pointer outside object bounds in arr \+ \(.*\)\(size - \(.*\)1\): SUCCESS$
-^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: pointer outside object bounds in arr\[\(.*\)\(size - \(.*\)1\)\]: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\] line \d+ size is capped: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that arr\[\(.*\)0\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that arr\[\(.*\)\(size - \(.*\)1\)\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.pointer_arithmetic.\d+\] line \d+ pointer arithmetic: pointer outside object bounds in arr \+ \(.*\)\(size - \(.*\)1\): SUCCESS$
+^\[foo_wrapped_for_contract_checking.pointer_arithmetic.\d+\] line \d+ pointer arithmetic: pointer outside object bounds in arr \+ \(.*\)\(size - \(.*\)1\): SUCCESS$
+^\[foo_wrapped_for_contract_checking.pointer_dereference.\d+\] line \d+ dereference failure: pointer outside object bounds in arr\[\(.*\)\(size - \(.*\)1\)\]: SUCCESS$
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/contracts-dfcc/memory-predicates-is-fresh-failure-modes/test-fail-none-bounded.desc
+++ b/regression/contracts-dfcc/memory-predicates-is-fresh-failure-modes/test-fail-none-bounded.desc
@@ -4,12 +4,12 @@ main_bounded.c
 ^\[__CPROVER_contracts_car_set_insert.assertion.\d+\] line \d+ CAR size is less than __CPROVER_max_malloc_size: SUCCESS$
 ^\[__CPROVER_contracts_write_set_check_assignment.assertion.\d+\] line \d+ ptr NULL or writable up to size: SUCCESS$
 ^\[__CPROVER_contracts_write_set_check_assignment.assertion.\d+\] line \d+ no offset bits overflow on CAR upper bound computation: SUCCESS$
-^\[foo.assertion.\d+\] line \d+ size is capped: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that arr\[\(.*\)0\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that arr\[\(.*\)\(size - \(.*\)1\)\] is assignable: SUCCESS$
-^\[foo.pointer_arithmetic.\d+\] line \d+ pointer arithmetic: pointer outside object bounds in arr \+ \(.*\)\(size - \(.*\)1\): SUCCESS$
-^\[foo.pointer_arithmetic.\d+\] line \d+ pointer arithmetic: pointer outside object bounds in arr \+ \(.*\)\(size - \(.*\)1\): SUCCESS$
-^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: pointer outside object bounds in arr\[\(.*\)\(size - \(.*\)1\)\]: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\] line \d+ size is capped: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that arr\[\(.*\)0\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that arr\[\(.*\)\(size - \(.*\)1\)\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.pointer_arithmetic.\d+\] line \d+ pointer arithmetic: pointer outside object bounds in arr \+ \(.*\)\(size - \(.*\)1\): SUCCESS$
+^\[foo_wrapped_for_contract_checking.pointer_arithmetic.\d+\] line \d+ pointer arithmetic: pointer outside object bounds in arr \+ \(.*\)\(size - \(.*\)1\): SUCCESS$
+^\[foo_wrapped_for_contract_checking.pointer_dereference.\d+\] line \d+ dereference failure: pointer outside object bounds in arr\[\(.*\)\(size - \(.*\)1\)\]: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts-dfcc/memory-predicates-is-fresh-failure-modes/test-fail-none.desc
+++ b/regression/contracts-dfcc/memory-predicates-is-fresh-failure-modes/test-fail-none.desc
@@ -1,8 +1,8 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract foo _ --pointer-check --pointer-primitive-check --pointer-overflow-check
-^\[__CPROVER_contracts_car_set_insert.assertion.\d+\] line \d+ CAR size is less than __CPROVER_max_malloc_size: FAILURE$
-^\[foo.assertion.\d+\] line \d+ size is capped: FAILURE$
+^\[__CPROVER_contracts_write_set_insert_object_from.assertion.\d+\] line \d+ CAR size is less than __CPROVER_max_malloc_size: FAILURE$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\] line \d+ size is capped: FAILURE$
 ^\*\* 2 of \d+ failed
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/memory-predicates-is-fresh-failure-modes/test-fail-null-bounded.desc
+++ b/regression/contracts-dfcc/memory-predicates-is-fresh-failure-modes/test-fail-null-bounded.desc
@@ -4,12 +4,12 @@ main_bounded.c
 ^\[__CPROVER_contracts_car_set_insert.assertion.\d+\] line \d+ CAR size is less than __CPROVER_max_malloc_size: SUCCESS$
 ^\[__CPROVER_contracts_write_set_check_assignment.assertion.\d+\] line \d+ ptr NULL or writable up to size: SUCCESS$
 ^\[__CPROVER_contracts_write_set_check_assignment.assertion.\d+\] line \d+ no offset bits overflow on CAR upper bound computation: SUCCESS$
-^\[foo.assertion.\d+\] line \d+ size is capped: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that arr\[\(.*\)0\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that arr\[\(.*\)\(size - \(.*\)1\)\] is assignable: SUCCESS$
-^\[foo.pointer_arithmetic.\d+\] line \d+ pointer arithmetic: pointer outside object bounds in arr \+ \(.*\)\(size - \(.*\)1\): SUCCESS$
-^\[foo.pointer_arithmetic.\d+\] line \d+ pointer arithmetic: pointer outside object bounds in arr \+ \(.*\)\(size - \(.*\)1\): SUCCESS$
-^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: pointer outside object bounds in arr\[\(.*\)\(size - \(.*\)1\)\]: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\] line \d+ size is capped: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that arr\[\(.*\)0\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that arr\[\(.*\)\(size - \(.*\)1\)\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.pointer_arithmetic.\d+\] line \d+ pointer arithmetic: pointer outside object bounds in arr \+ \(.*\)\(size - \(.*\)1\): SUCCESS$
+^\[foo_wrapped_for_contract_checking.pointer_arithmetic.\d+\] line \d+ pointer arithmetic: pointer outside object bounds in arr \+ \(.*\)\(size - \(.*\)1\): SUCCESS$
+^\[foo_wrapped_for_contract_checking.pointer_dereference.\d+\] line \d+ dereference failure: pointer outside object bounds in arr\[\(.*\)\(size - \(.*\)1\)\]: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts-dfcc/memory-predicates-is-fresh-failure-modes/test-fail-null.desc
+++ b/regression/contracts-dfcc/memory-predicates-is-fresh-failure-modes/test-fail-null.desc
@@ -4,12 +4,12 @@ main.c
 ^\[__CPROVER_contracts_car_set_insert.assertion.\d+\] line \d+ CAR size is less than __CPROVER_max_malloc_size: SUCCESS$
 ^\[__CPROVER_contracts_write_set_check_assignment.assertion.\d+\] line \d+ ptr NULL or writable up to size: SUCCESS$
 ^\[__CPROVER_contracts_write_set_check_assignment.assertion.\d+\] line \d+ no offset bits overflow on CAR upper bound computation: SUCCESS$
-^\[foo.assertion.\d+\] line \d+ size is capped: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that arr\[\(.*\)0\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that arr\[\(.*\)\(size - \(.*\)1\)\] is assignable: SUCCESS$
-^\[foo.pointer_arithmetic.\d+\] line \d+ pointer arithmetic: pointer outside object bounds in arr \+ \(.*\)\(size - \(.*\)1\): SUCCESS$
-^\[foo.pointer_arithmetic.\d+\] line \d+ pointer arithmetic: pointer outside object bounds in arr \+ \(.*\)\(size - \(.*\)1\): SUCCESS$
-^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: pointer outside object bounds in arr\[\(.*\)\(size - \(.*\)1\)\]: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\] line \d+ size is capped: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that arr\[\(.*\)0\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that arr\[\(.*\)\(size - \(.*\)1\)\] is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.pointer_arithmetic.\d+\] line \d+ pointer arithmetic: pointer outside object bounds in arr \+ \(.*\)\(size - \(.*\)1\): SUCCESS$
+^\[foo_wrapped_for_contract_checking.pointer_arithmetic.\d+\] line \d+ pointer arithmetic: pointer outside object bounds in arr \+ \(.*\)\(size - \(.*\)1\): SUCCESS$
+^\[foo_wrapped_for_contract_checking.pointer_dereference.\d+\] line \d+ dereference failure: pointer outside object bounds in arr\[\(.*\)\(size - \(.*\)1\)\]: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts-dfcc/quantifiers-exists-both-replace/test.desc
+++ b/regression/contracts-dfcc/quantifiers-exists-both-replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --dfcc main --replace-call-with-contract f1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[f1.precondition.\d+\] line \d+ Check requires clause of (contract contract::f1 for function f1|f1 in main): SUCCESS$
+^\[main.precondition.\d+\] line \d+ Check requires clause of (contract contract::f1 for function f1|f1 in main): SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts-dfcc/quantifiers-exists-requires-replace/test.desc
+++ b/regression/contracts-dfcc/quantifiers-exists-requires-replace/test.desc
@@ -3,8 +3,8 @@ main.c
 --dfcc main --replace-call-with-contract f1 --replace-call-with-contract f2
 ^EXIT=10$
 ^SIGNAL=0$
-^\[f1.precondition.\d+\] line \d+ Check requires clause of (contract contract::f1 for function f1|f1 in main): SUCCESS$
-^\[f2.precondition.\d+\] line \d+ Check requires clause of (contract contract::f2 for function f2|f2 in main): FAILURE$
+^\[main.precondition.\d+\] line \d+ Check requires clause of (contract contract::f1 for function f1|f1 in main): SUCCESS$
+^\[main.precondition.\d+\] line \d+ Check requires clause of (contract contract::f2 for function f2|f2 in main): FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/contracts-dfcc/quantifiers-forall-both-replace/test.desc
+++ b/regression/contracts-dfcc/quantifiers-forall-both-replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --dfcc main --replace-call-with-contract f1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[f1.precondition.\d+\] line \d+ Check requires clause of (contract contract::f1 for function f1|f1 in main): SUCCESS$
+^\[main.precondition.\d+\] line \d+ Check requires clause of (contract contract::f1 for function f1|f1 in main): SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts-dfcc/quantifiers-forall-ensures-enforce/test.desc
+++ b/regression/contracts-dfcc/quantifiers-forall-ensures-enforce/test.desc
@@ -4,7 +4,7 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[f1.postcondition.\d+\] line \d+ Check ensures clause of contract contract::f1 for function f1: SUCCESS$
-^\[f1.assigns.\d+\] line \d+ Check that arr\[\(.*\)\d\] is assignable: SUCCESS$
+^\[f1_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that arr\[\(.*\)\d\] is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts-dfcc/test_aliasing_enforce/test.desc
+++ b/regression/contracts-dfcc/test_aliasing_enforce/test.desc
@@ -4,9 +4,9 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 \[foo.postcondition.\d+\] line \d+ Check ensures clause of contract contract::foo for function foo: SUCCESS$
-\[foo.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS
-\[foo.assigns.\d+\] line \d+ Check that \*y is assignable: SUCCESS
-\[foo.assigns.\d+\] line \d+ Check that z is assignable: SUCCESS
+\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS
+\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that \*y is assignable: SUCCESS
+\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that z is assignable: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion \!\(n \< 4\): SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --

--- a/regression/contracts-dfcc/test_aliasing_ensure/test.desc
+++ b/regression/contracts-dfcc/test_aliasing_ensure/test.desc
@@ -4,9 +4,9 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 \[foo.postcondition.\d+\].*Check ensures clause of contract contract::foo for function foo: SUCCESS$
-\[foo.assigns.\d+\].*Check that \*x is assignable: SUCCESS
-\[foo.assigns.\d+\].*Check that \*y is assignable: SUCCESS
-\[foo.assigns.\d+\].*Check that z is assignable: SUCCESS
+\[foo_wrapped_for_contract_checking.assigns.\d+\].*Check that \*x is assignable: SUCCESS
+\[foo_wrapped_for_contract_checking.assigns.\d+\].*Check that \*y is assignable: SUCCESS
+\[foo_wrapped_for_contract_checking.assigns.\d+\].*Check that z is assignable: SUCCESS
 \[main.assertion.\d+\].*assertion \!\(n \< 4\): SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --

--- a/regression/contracts-dfcc/test_aliasing_ensure_indirect/test-bar.desc
+++ b/regression/contracts-dfcc/test_aliasing_ensure_indirect/test-bar.desc
@@ -2,9 +2,9 @@ CORE dfcc-only
 main_bar.c
 --dfcc main --enforce-contract bar
 ^\[bar.postcondition.\d+\].*Check ensures clause of contract contract::bar for function bar: SUCCESS$
-^\[bar.assertion.\d+\].*x is r_ok: SUCCESS$
-^\[bar.assigns.\d+\].*Check that \*x is assignable: SUCCESS$
-^\[bar.assertion.\d+\].*deref x is r_ok: SUCCESS$
+^\[bar_wrapped_for_contract_checking.assertion.\d+\].*x is r_ok: SUCCESS$
+^\[bar_wrapped_for_contract_checking.assigns.\d+\].*Check that \*x is assignable: SUCCESS$
+^\[bar_wrapped_for_contract_checking.assertion.\d+\].*deref x is r_ok: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts-dfcc/test_aliasing_ensure_indirect/test-foo.desc
+++ b/regression/contracts-dfcc/test_aliasing_ensure_indirect/test-foo.desc
@@ -2,11 +2,11 @@ CORE dfcc-only
 main_foo.c
 --dfcc main --enforce-contract foo --replace-call-with-contract bar
 ^\[foo.postcondition.\d+\].*Check ensures clause of contract contract::foo for function foo: SUCCESS$
-^\[foo.assertion.\d+\].*x1 r_ok: SUCCESS$
-^\[foo.assertion.\d+\].*x2 r_ok: SUCCESS$
-^\[foo.assertion.\d+\].*deref x2 r_ok: SUCCESS$
-^\[foo.assertion.\d+\].*deref x2 r_ok: SUCCESS$
-^\[foo.assertion.\d+\].*x2 updated: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].*x1 r_ok: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].*x2 r_ok: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].*deref x2 r_ok: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].*deref x2 r_ok: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].*x2 updated: SUCCESS$
 ^\[bar.precondition.\d+\].*Check requires clause of contract contract::bar for function bar: SUCCESS$
 ^\[bar.assigns.\d+\].*Check that the assigns clause of contract::bar is included in the caller's assigns clause: SUCCESS$
 ^\[bar.frees.\d+\].*Check that the frees clause of contract::bar is included in the caller's frees clause: SUCCESS$

--- a/regression/contracts-dfcc/test_array_memory_enforce/test.desc
+++ b/regression/contracts-dfcc/test_array_memory_enforce/test.desc
@@ -4,9 +4,9 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 \[foo.postcondition.\d+\] line \d+ Check ensures clause( of contract contract::foo for function foo)?: SUCCESS
-\[foo.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS
-\[foo.assigns.\d+\] line \d+ Check that x\[\(.* int\)5\] is assignable: SUCCESS
-\[foo.assigns.\d+\] line \d+ Check that x\[\(.* int\)9\] is assignable: SUCCESS
+\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS
+\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that x\[\(.* int\)5\] is assignable: SUCCESS
+\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that x\[\(.* int\)9\] is assignable: SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --
 --

--- a/regression/contracts-dfcc/test_is_fresh_enforce_ensures_fail_separation_against_ensures/test.desc
+++ b/regression/contracts-dfcc/test_is_fresh_enforce_ensures_fail_separation_against_ensures/test.desc
@@ -1,8 +1,8 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract foo
-^\[foo.assigns.\d+\].*Check that \*out1 is assignable: SUCCESS$
-^\[foo.assigns.\d+\].*Check that \*out2 is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].*Check that \*out1 is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].*Check that \*out2 is assignable: SUCCESS$
 ^\[foo.postcondition.\d+\].*Check ensures clause of contract contract::foo for function foo: FAILURE$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/test_is_fresh_enforce_ensures_fail_separation_against_requires/test.desc
+++ b/regression/contracts-dfcc/test_is_fresh_enforce_ensures_fail_separation_against_requires/test.desc
@@ -1,9 +1,9 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract foo
-^\[foo.assertion.\d+\].*in1 is rw_ok: SUCCESS$
-^\[foo.assertion.\d+\].*in2 is rw_ok: SUCCESS$
-^\[foo.assertion.\d+\].*in1 and in2 do not alias: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].*in1 is rw_ok: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].*in2 is rw_ok: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].*in1 and in2 do not alias: SUCCESS$
 ^\[foo.postcondition.\d+\].*Check ensures clause of contract contract::foo for function foo: FAILURE$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/test_is_fresh_enforce_ensures_fail_size/test.desc
+++ b/regression/contracts-dfcc/test_is_fresh_enforce_ensures_fail_size/test.desc
@@ -1,7 +1,7 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract foo
-^\[foo.assigns.\d+\].*Check that \*out is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].*Check that \*out is assignable: SUCCESS$
 ^\[foo.postcondition.\d+\].*Check ensures clause of contract contract::foo for function foo: FAILURE$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/test_is_fresh_enforce_ensures_pass/test.desc
+++ b/regression/contracts-dfcc/test_is_fresh_enforce_ensures_pass/test.desc
@@ -2,11 +2,11 @@ CORE dfcc-only
 main.c
 --dfcc main --enforce-contract foo
 ^\[foo.postcondition.\d+\].*Check ensures clause of contract contract::foo for function foo: SUCCESS$
-^\[foo.assertion.\d+\].*in1 is rw_ok: SUCCESS$
-^\[foo.assertion.\d+\].*in2 is rw_ok: SUCCESS$
-^\[foo.assertion.\d+\].*in1 and in2 do not alias: SUCCESS$
-^\[foo.assigns.\d+\].*Check that \*out1 is assignable: SUCCESS$
-^\[foo.assigns.\d+\].*Check that \*out2 is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].*in1 is rw_ok: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].*in2 is rw_ok: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].*in1 and in2 do not alias: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].*Check that \*out1 is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].*Check that \*out2 is assignable: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts-dfcc/test_is_fresh_enforce_requires_pass/test.desc
+++ b/regression/contracts-dfcc/test_is_fresh_enforce_requires_pass/test.desc
@@ -1,11 +1,11 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract foo
-^\[foo.assertion.\d+\].*in1 is rw_ok: SUCCESS$
-^\[foo.assertion.\d+\].*in2 is rw_ok: SUCCESS$
-^\[foo.assertion.\d+\].*in1 and in2 do not alias: SUCCESS$
-^\[foo.assertion.\d+\].*in1 is zero: SUCCESS$
-^\[foo.assertion.\d+\].*in2 is zero: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].*in1 is rw_ok: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].*in2 is rw_ok: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].*in1 and in2 do not alias: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].*in1 is zero: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assertion.\d+\].*in2 is zero: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts-dfcc/test_is_fresh_replace_ensures_pass/test-enforce.desc
+++ b/regression/contracts-dfcc/test_is_fresh_replace_ensures_pass/test-enforce.desc
@@ -1,8 +1,8 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract foo
-^\[foo.assigns.\d+\].*Check that \*out_ptr1 is assignable: SUCCESS$
-^\[foo.assigns.\d+\].*Check that \*out_ptr2 is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].*Check that \*out_ptr1 is assignable: SUCCESS$
+^\[foo_wrapped_for_contract_checking.assigns.\d+\].*Check that \*out_ptr2 is assignable: SUCCESS$
 ^\[foo.postcondition.\d+\].*Check ensures clause of contract contract::foo for function foo: SUCCESS$
 ^\[main.assertion.\d+\].*out1 is rw_ok: SUCCESS$
 ^\[main.assertion.\d+\].*out2 is rw_ok: SUCCESS$

--- a/regression/contracts-dfcc/test_scalar_memory_enforce/test.desc
+++ b/regression/contracts-dfcc/test_scalar_memory_enforce/test.desc
@@ -2,7 +2,7 @@ CORE
 main.c
 --dfcc main --enforce-contract foo
 \[foo.postcondition.\d+\].*Check ensures clause( of contract contract::foo for function foo)?: SUCCESS
-\[foo.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS
+\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/test_struct_enforce/test.desc
+++ b/regression/contracts-dfcc/test_struct_enforce/test.desc
@@ -4,8 +4,8 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 \[foo.postcondition.\d+\] line \d+ Check ensures clause( of contract contract::foo for function foo)?: SUCCESS$
-\[foo.assigns.\d+\] line \d+ Check that x->baz is assignable: SUCCESS
-\[foo.assigns.\d+\] line \d+ Check that x->qux is assignable: SUCCESS
+\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that x->baz is assignable: SUCCESS
+\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that x->qux is assignable: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion rval \=\= 10: SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --

--- a/regression/contracts-dfcc/test_struct_member_enforce/test.desc
+++ b/regression/contracts-dfcc/test_struct_member_enforce/test.desc
@@ -4,7 +4,7 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 \[foo.postcondition.\d+\] line \d+ Check ensures clause( of contract contract::foo for function foo)?: SUCCESS$
-\[foo.assigns.\d+\] line \d+ Check that x->str\[\(.*\)\(x->len - 1\)\] is assignable: SUCCESS
+\[foo_wrapped_for_contract_checking.assigns.\d+\] line \d+ Check that x->str\[\(.*\)\(x->len - 1\)\] is assignable: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion rval \=\= 128: SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --

--- a/regression/contracts-dfcc/typed_target_pointer/test.desc
+++ b/regression/contracts-dfcc/typed_target_pointer/test.desc
@@ -1,8 +1,8 @@
 CORE
 main.c
 --enforce-contract foo
-^\[foo.assigns.\d+\].* Check that __CPROVER_assignable\(\(void \*\)&x, .*, TRUE\) is valid: SUCCESS$
-^\[foo.assigns.\d+\].* Check that __CPROVER_assignable\(\(void \*\)&\(\*y\), .*, FALSE\) is valid: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\].* Check that __CPROVER_assignable\(\(void \*\)&x, .*, TRUE\) is valid: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\].* Check that __CPROVER_assignable\(\(void \*\)&\(\*y\), .*, FALSE\) is valid: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts/assigns-enforce-malloc-zero/test.desc
+++ b/regression/contracts/assigns-enforce-malloc-zero/test.desc
@@ -1,8 +1,8 @@
 CORE
 main.c
 --enforce-contract foo _ --malloc-may-fail --malloc-fail-null
-^\[foo.assigns.\d+\] line 9 Check that __CPROVER_object_whole\(\(.* \*\)a\) is valid when a != \(\(.* \*\)NULL\): SUCCESS$
-^\[foo.assigns.\d+\] line 19 Check that a\[\(signed long (long )?int\)i\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 9 Check that __CPROVER_object_whole\(\(.* \*\)a\) is valid when a != \(\(.* \*\)NULL\): SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 19 Check that a\[\(signed long (long )?int\)i\] is assignable: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/assigns-replace-ignored-return-value/test.desc
+++ b/regression/contracts/assigns-replace-ignored-return-value/test.desc
@@ -1,8 +1,8 @@
 CORE
 main.c
 --replace-call-with-contract bar --replace-call-with-contract baz --enforce-contract foo
-^\[bar.precondition.\d+\] line \d+ Check requires clause of bar in foo: SUCCESS$
-^\[baz.precondition.\d+\] line \d+ Check requires clause of baz in foo: SUCCESS$
+^\[__CPROVER_contracts_original_foo.precondition.\d+\] line \d+ Check requires clause of bar in foo: SUCCESS$
+^\[__CPROVER_contracts_original_foo.precondition.\d+\] line \d+ Check requires clause of baz in foo: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/assigns-replace-malloc-zero/test.desc
+++ b/regression/contracts/assigns-replace-malloc-zero/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --replace-call-with-contract foo _ --malloc-may-fail --malloc-fail-null
-^\[foo.precondition.\d+\] line \d+ Check requires clause of foo in main: SUCCESS$
+^\[main.precondition.\d+\] line \d+ Check requires clause of foo in main: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$
 \[main\.assertion\.1\] line 35 expecting SUCCESS: SUCCESS$

--- a/regression/contracts/assigns_enforce_02/test.desc
+++ b/regression/contracts/assigns_enforce_02/test.desc
@@ -1,8 +1,8 @@
 CORE
 main.c
 --enforce-contract foo
-^\[foo.assigns.\d+\] line 3 Check that z is valid: SUCCESS$
-^\[foo.assigns.\d+\] line 6 Check that \*x is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 3 Check that z is valid: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 6 Check that \*x is assignable: FAILURE$
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/contracts/assigns_enforce_03/test.desc
+++ b/regression/contracts/assigns_enforce_03/test.desc
@@ -1,18 +1,18 @@
 CORE
 main.c
 --enforce-contract f1 --enforce-contract f2 --enforce-contract f3
-^\[f1.assigns.\d+\] line 1 Check that \*x1 is valid: SUCCESS$
-^\[f1.assigns.\d+\] line 1 Check that \*y1 is valid: SUCCESS$
-^\[f1.assigns.\d+\] line 1 Check that \*z1 is valid: SUCCESS$
-^\[f2.assigns.\d+\] line 6 Check that \*x2 is valid: SUCCESS$
-^\[f2.assigns.\d+\] line 6 Check that \*y2 is valid: SUCCESS$
-^\[f2.assigns.\d+\] line 6 Check that \*z2 is valid: SUCCESS$
-^\[f3.assigns.\d+\] line 11 Check that \*x3 is valid: SUCCESS$
-^\[f3.assigns.\d+\] line 11 Check that \*y3 is valid: SUCCESS$
-^\[f3.assigns.\d+\] line 12 Check that \*z3 is valid: SUCCESS$
-^\[f3.assigns.\d+\] line 14 Check that \*x3 is assignable: SUCCESS$
-^\[f3.assigns.\d+\] line 15 Check that \*y3 is assignable: SUCCESS$
-^\[f3.assigns.\d+\] line 16 Check that \*z3 is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line 1 Check that \*x1 is valid: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line 1 Check that \*y1 is valid: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line 1 Check that \*z1 is valid: SUCCESS$
+^\[__CPROVER_contracts_original_f2.assigns.\d+\] line 6 Check that \*x2 is valid: SUCCESS$
+^\[__CPROVER_contracts_original_f2.assigns.\d+\] line 6 Check that \*y2 is valid: SUCCESS$
+^\[__CPROVER_contracts_original_f2.assigns.\d+\] line 6 Check that \*z2 is valid: SUCCESS$
+^\[__CPROVER_contracts_original_f3.assigns.\d+\] line 11 Check that \*x3 is valid: SUCCESS$
+^\[__CPROVER_contracts_original_f3.assigns.\d+\] line 11 Check that \*y3 is valid: SUCCESS$
+^\[__CPROVER_contracts_original_f3.assigns.\d+\] line 12 Check that \*z3 is valid: SUCCESS$
+^\[__CPROVER_contracts_original_f3.assigns.\d+\] line 14 Check that \*x3 is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f3.assigns.\d+\] line 15 Check that \*y3 is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f3.assigns.\d+\] line 16 Check that \*z3 is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_04/test.desc
+++ b/regression/contracts/assigns_enforce_04/test.desc
@@ -1,12 +1,12 @@
 CORE
 main.c
 --enforce-contract f1
-^\[f1.assigns.\d+\] line 1 Check that \*x1 is valid: SUCCESS$
-^\[f1.assigns.\d+\] line 1 Check that \*y1 is valid: SUCCESS$
-^\[f1.assigns.\d+\] line 1 Check that \*z1 is valid: SUCCESS$
-^\[f3.assigns.\d+\] line 13 Check that \*x3 is assignable: SUCCESS$
-^\[f3.assigns.\d+\] line 14 Check that \*y3 is assignable: SUCCESS$
-^\[f3.assigns.\d+\] line 15 Check that \*z3 is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line 1 Check that \*x1 is valid: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line 1 Check that \*y1 is valid: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line 1 Check that \*z1 is valid: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line 13 Check that \*x3 is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line 14 Check that \*y3 is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line 15 Check that \*z3 is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_15/test.desc
+++ b/regression/contracts/assigns_enforce_15/test.desc
@@ -1,9 +1,9 @@
 CORE
 main.c
 --enforce-contract foo --enforce-contract baz --enforce-contract qux
-^\[foo.assigns.\d+\] line \d+ Check that \*x is valid: SUCCESS$
-^\[baz.assigns.\d+\] line \d+ Check that global is assignable: FAILURE$
-^\[qux.assigns.\d+\] line \d+ Check that global is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*x is valid: SUCCESS$
+^\[__CPROVER_contracts_original_baz.assigns.\d+\] line \d+ Check that global is assignable: FAILURE$
+^\[__CPROVER_contracts_original_qux.assigns.\d+\] line \d+ Check that global is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_18/test.desc
+++ b/regression/contracts/assigns_enforce_18/test.desc
@@ -1,17 +1,17 @@
 CORE
 main.c
 --enforce-contract foo --enforce-contract bar --enforce-contract baz _ --pointer-primitive-check
-^\[foo.assigns.\d+\] line 7 Check that \*xp is valid: SUCCESS$
-^\[foo.assigns.\d+\] line 11 Check that __CPROVER_POINTER_OBJECT\(\(void \*\)yp\) is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 13 Check that \*xp is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 14 Check that y is assignable: FAILURE$
-^\[bar.assigns.\d+\] line 17 Check that \*a is valid: SUCCESS$
-^\[bar.assigns.\d+\] line 17 Check that \*b is valid: SUCCESS$
-^\[bar.assigns.\d+\] line 19 Check that __CPROVER_POINTER_OBJECT\(\(void \*\)a\) is assignable: SUCCESS$
-^\[bar.assigns.\d+\] line 20 Check that \*b is assignable: SUCCESS$
-^\[baz.assigns.\d+\] line 23 Check that \*a is valid: SUCCESS$
-^\[baz.assigns.\d+\] line 25 Check that __CPROVER_POINTER_OBJECT\(\(void \*\)c\) is assignable: FAILURE$
-^\[baz.assigns.\d+\] line 26 Check that \*a is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 7 Check that \*xp is valid: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 11 Check that __CPROVER_POINTER_OBJECT\(\(void \*\)yp\) is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 13 Check that \*xp is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 14 Check that y is assignable: FAILURE$
+^\[__CPROVER_contracts_original_bar.assigns.\d+\] line 17 Check that \*a is valid: SUCCESS$
+^\[__CPROVER_contracts_original_bar.assigns.\d+\] line 17 Check that \*b is valid: SUCCESS$
+^\[__CPROVER_contracts_original_bar.assigns.\d+\] line 19 Check that __CPROVER_POINTER_OBJECT\(\(void \*\)a\) is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_bar.assigns.\d+\] line 20 Check that \*b is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_baz.assigns.\d+\] line 23 Check that \*a is valid: SUCCESS$
+^\[__CPROVER_contracts_original_baz.assigns.\d+\] line 25 Check that __CPROVER_POINTER_OBJECT\(\(void \*\)c\) is assignable: FAILURE$
+^\[__CPROVER_contracts_original_baz.assigns.\d+\] line 26 Check that \*a is assignable: SUCCESS$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_19/test.desc
+++ b/regression/contracts/assigns_enforce_19/test.desc
@@ -1,13 +1,13 @@
 CORE
 main.c
 --enforce-contract f --enforce-contract g
-^\[f.assigns.\d+\] line \d+ Check that a is assignable: SUCCESS$
-^\[f.assigns.\d+\] line \d+ Check that aa is assignable: SUCCESS$
-^\[g.assigns.\d+\] line \d+ Check that b is valid: SUCCESS$
-^\[g.assigns.\d+\] line \d+ Check that b is assignable: SUCCESS$
-^\[g.assigns.\d+\] line \d+ Check that c is assignable: FAILURE$
-^\[g.assigns.\d+\] line \d+ Check that \*points_to_b is assignable: SUCCESS$
-^\[g.assigns.\d+\] line \d+ Check that \*points_to_c is assignable: FAILURE$
+^\[__CPROVER_contracts_original_f.assigns.\d+\] line \d+ Check that a is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f.assigns.\d+\] line \d+ Check that aa is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_g.assigns.\d+\] line \d+ Check that b is valid: SUCCESS$
+^\[__CPROVER_contracts_original_g.assigns.\d+\] line \d+ Check that b is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_g.assigns.\d+\] line \d+ Check that c is assignable: FAILURE$
+^\[__CPROVER_contracts_original_g.assigns.\d+\] line \d+ Check that \*points_to_b is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_g.assigns.\d+\] line \d+ Check that \*points_to_c is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_20/test.desc
+++ b/regression/contracts/assigns_enforce_20/test.desc
@@ -3,8 +3,8 @@ main.c
 --enforce-contract foo
 ^EXIT=10$
 ^SIGNAL=0$
-^\[foo.assigns.\d+\] line \d+ Check that __CPROVER_POINTER_OBJECT\((\(.+\))?y\) is assignable: FAILURE$
-^\[foo.assigns.\d+\] line \d+ Check that x is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that __CPROVER_POINTER_OBJECT\((\(.+\))?y\) is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that x is assignable: FAILURE$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/assigns_enforce_21/test.desc
+++ b/regression/contracts/assigns_enforce_21/test.desc
@@ -1,9 +1,9 @@
 CORE
 main.c
 --enforce-contract foo --replace-call-with-contract quz
-^\[foo.assigns.\d+\] line \d+ Check that \*y is valid: SUCCESS$
-^\[bar.assigns.\d+\] line \d+ Check that \*y is assignable: SUCCESS$
-^\[bar.assigns.\d+\] line \d+ Check that x \(assigned by the contract of quz\) is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*y is valid: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*y is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that x \(assigned by the contract of quz\) is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_arrays_02/test.desc
+++ b/regression/contracts/assigns_enforce_arrays_02/test.desc
@@ -1,13 +1,13 @@
 CORE
 main.c
 --enforce-contract f1 --enforce-contract f2
-^\[f1.assigns.\d+\] line 6 Check that \*a is valid: SUCCESS$
-^\[f1.assigns.\d+\] line 8 Check that a\[.*0\] is assignable: SUCCESS$
-^\[f1.assigns.\d+\] line 9 Check that a\[.*5\] is assignable: FAILURE$
-^\[f2.assigns.\d+\] line 12 Check that __CPROVER_object_whole\(\(.* \*\)a\) is valid: SUCCESS$
-^\[f2.assigns.\d+\] line 14 Check that a\[.*0\] is assignable: SUCCESS$
-^\[f2.assigns.\d+\] line 15 Check that a\[.*5\] is assignable: SUCCESS$
-^\[f2.assigns.\d+\] line 16 Check that __CPROVER_POINTER_OBJECT\(\(.* \*\)a\) is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line 6 Check that \*a is valid: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line 8 Check that a\[.*0\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line 9 Check that a\[.*5\] is assignable: FAILURE$
+^\[__CPROVER_contracts_original_f2.assigns.\d+\] line 12 Check that __CPROVER_object_whole\(\(.* \*\)a\) is valid: SUCCESS$
+^\[__CPROVER_contracts_original_f2.assigns.\d+\] line 14 Check that a\[.*0\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f2.assigns.\d+\] line 15 Check that a\[.*5\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f2.assigns.\d+\] line 16 Check that __CPROVER_POINTER_OBJECT\(\(.* \*\)a\) is assignable: SUCCESS$
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/contracts/assigns_enforce_arrays_05/test.desc
+++ b/regression/contracts/assigns_enforce_arrays_05/test.desc
@@ -1,8 +1,8 @@
 CORE
 main.c
 --enforce-contract uses_assigns
-^\[uses_assigns.assigns.\d+\] line \d+ Check that \*\(&a\[\(.*int\)i\]\) is valid: SUCCESS$
-^\[assigns_ptr.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_uses_assigns.assigns.\d+\] line \d+ Check that \*\(&a\[\(.*int\)i\]\) is valid: SUCCESS$
+^\[__CPROVER_contracts_original_uses_assigns.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_conditional_function_call_condition/test.desc
+++ b/regression/contracts/assigns_enforce_conditional_function_call_condition/test.desc
@@ -2,9 +2,9 @@ CORE
 main.c
 --enforce-contract foo
 ^main.c function foo$
-^\[foo.assigns.\d+\] line 10 Check that \*x is valid when .*: SUCCESS$
-^\[foo.assigns.\d+\] line 16 Check that \*x is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 20 Check that \*x is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 10 Check that \*x is valid when .*: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 16 Check that \*x is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 20 Check that \*x is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_conditional_lvalue/test.desc
+++ b/regression/contracts/assigns_enforce_conditional_lvalue/test.desc
@@ -2,14 +2,14 @@ CORE
 main.c
 --enforce-contract foo
 main.c function foo
-^\[foo.assigns.\d+\] line 3 Check that \*x is valid when a != FALSE: SUCCESS$
-^\[foo.assigns.\d+\] line 3 Check that \*y is valid when !\(a != FALSE\): SUCCESS$
-^\[foo.assigns.\d+\] line 7 Check that \*x is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 8 Check that \*y is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 12 Check that \*x is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 13 Check that \*y is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 16 Check that \*x is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 17 Check that \*y is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 3 Check that \*x is valid when a != FALSE: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 3 Check that \*y is valid when !\(a != FALSE\): SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 7 Check that \*x is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 8 Check that \*y is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 12 Check that \*x is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 13 Check that \*y is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 16 Check that \*x is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 17 Check that \*y is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_conditional_lvalue_list/test.desc
+++ b/regression/contracts/assigns_enforce_conditional_lvalue_list/test.desc
@@ -2,14 +2,14 @@ CORE
 main.c
 --enforce-contract foo
 main.c function foo
-^\[foo.assigns.\d+\] line 3 Check that \*x is valid when a != FALSE: SUCCESS$
-^\[foo.assigns.\d+\] line 3 Check that \*y is valid when a != FALSE: SUCCESS$
-^\[foo.assigns.\d+\] line 7 Check that \*x is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 8 Check that \*y is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 12 Check that \*x is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 13 Check that \*y is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 16 Check that \*x is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 17 Check that \*y is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 3 Check that \*x is valid when a != FALSE: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 3 Check that \*y is valid when a != FALSE: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 7 Check that \*x is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 8 Check that \*y is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 12 Check that \*x is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 13 Check that \*y is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 16 Check that \*x is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 17 Check that \*y is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_conditional_pointer_object/test.desc
+++ b/regression/contracts/assigns_enforce_conditional_pointer_object/test.desc
@@ -2,14 +2,14 @@ CORE
 main.c
 --enforce-contract foo
 main.c function foo
-^\[foo.assigns.\d+\] line 6 Check that __CPROVER_object_whole\(\(.* \*\)x\) is valid when a != FALSE: SUCCESS$
-^\[foo.assigns.\d+\] line 7 Check that __CPROVER_object_whole\(\(.* \*\)y\) is valid when !\(a != FALSE\): SUCCESS$
-^\[foo.assigns.\d+\] line 13 Check that x\[\(signed (long )?long int\)0\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 14 Check that y\[\(signed (long )?long int\)0\] is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 18 Check that x\[\(signed (long )?long int\)0\] is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 19 Check that y\[\(signed (long )?long int\)0\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 22 Check that x\[\(signed (long )?long int\)0\] is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 23 Check that y\[\(signed (long )?long int\)0\] is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 6 Check that __CPROVER_object_whole\(\(.* \*\)x\) is valid when a != FALSE: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 7 Check that __CPROVER_object_whole\(\(.* \*\)y\) is valid when !\(a != FALSE\): SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 13 Check that x\[\(signed (long )?long int\)0\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 14 Check that y\[\(signed (long )?long int\)0\] is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 18 Check that x\[\(signed (long )?long int\)0\] is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 19 Check that y\[\(signed (long )?long int\)0\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 22 Check that x\[\(signed (long )?long int\)0\] is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 23 Check that y\[\(signed (long )?long int\)0\] is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_conditional_pointer_object_list/test.desc
+++ b/regression/contracts/assigns_enforce_conditional_pointer_object_list/test.desc
@@ -2,14 +2,14 @@ CORE
 main.c
 --enforce-contract foo
 main.c function foo
-^\[foo.assigns.\d+\] line 6 Check that __CPROVER_object_whole\(\(.*\)x\) is valid when a != FALSE: SUCCESS$
-^\[foo.assigns.\d+\] line 6 Check that __CPROVER_object_whole\(\(.*\)y\) is valid when a != FALSE: SUCCESS$
-^\[foo.assigns.\d+\] line 12 Check that x\[\(signed (long )?long int\)0\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 13 Check that y\[\(signed (long )?long int\)0\] is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 17 Check that x\[\(signed (long )?long int\)0\] is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 18 Check that y\[\(signed (long )?long int\)0\] is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 21 Check that x\[\(signed (long )?long int\)0\] is assignable: FAILURE$
-^\[foo.assigns.\d+\] line 22 Check that y\[\(signed (long )?long int\)0\] is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 6 Check that __CPROVER_object_whole\(\(.*\)x\) is valid when a != FALSE: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 6 Check that __CPROVER_object_whole\(\(.*\)y\) is valid when a != FALSE: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 12 Check that x\[\(signed (long )?long int\)0\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 13 Check that y\[\(signed (long )?long int\)0\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 17 Check that x\[\(signed (long )?long int\)0\] is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 18 Check that y\[\(signed (long )?long int\)0\] is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 21 Check that x\[\(signed (long )?long int\)0\] is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 22 Check that y\[\(signed (long )?long int\)0\] is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_conditional_unions/test.desc
+++ b/regression/contracts/assigns_enforce_conditional_unions/test.desc
@@ -1,22 +1,22 @@
 CORE
 main.c
 --enforce-contract update _ --pointer-check --pointer-overflow-check --signed-overflow-check --unsigned-overflow-check --conversion-check
-^\[update.assigns.\d+] line 73 Check that __CPROVER_object_whole\(\(.*\)state->digest.high_level.first.ctx->digest\) is valid when .*: SUCCESS
-^\[update.assigns.\d+] line 74 Check that state->digest.high_level.first.ctx->flags is valid when .*: SUCCESS
-^\[update.assigns.\d+] line 76 Check that __CPROVER_object_whole\(\(.*\)state->digest.high_level.second.ctx->digest\) is valid when .*: SUCCESS
-^\[update.assigns.\d+] line 77 Check that state->digest.high_level.second.ctx->flags is valid when .*: SUCCESS
-^\[is_high_level.assigns.\d+\] line 50 Check that latch is assignable: SUCCESS$
-^\[is_high_level.assigns.\d+\] line 51 Check that once is assignable: SUCCESS$
-^\[update.assigns.\d+\] line 84 Check that __CPROVER_POINTER_OBJECT\(\(void \*\)state->digest.high_level.first.ctx->digest\) is assignable: SUCCESS$
-^\[update.assigns.\d+\] line 85 Check that state->digest.high_level.first.ctx->flags is assignable: SUCCESS$
-^\[update.assigns.\d+\] line 90 Check that __CPROVER_POINTER_OBJECT\(\(void \*\)state->digest.high_level.second.ctx->digest\) is assignable: SUCCESS$
-^\[update.assigns.\d+\] line 91 Check that state->digest.high_level.second.ctx->flags is assignable: SUCCESS$
-^\[update.assigns.\d+\] line 95 Check that __CPROVER_POINTER_OBJECT\(\(void \*\)state->digest.high_level.second.ctx->digest\) is assignable: FAILURE$
-^\[update.assigns.\d+\] line 96 Check that state->digest.high_level.second.ctx->flags is assignable: FAILURE$
-^\[update.assigns.\d+\] line 100 Check that __CPROVER_POINTER_OBJECT\(\(void \*\)state->digest.high_level.first.ctx->digest\) is assignable: FAILURE$
-^\[update.assigns.\d+\] line 101 Check that state->digest.high_level.first.ctx->flags is assignable: FAILURE$
-^\[update.assigns.\d+\] line 104 Check that __CPROVER_POINTER_OBJECT\(\(void \*\)state->digest.high_level.second.ctx->digest\) is assignable: FAILURE$
-^\[update.assigns.\d+\] line 105 Check that state->digest.high_level.second.ctx->flags is assignable: FAILURE$
+^\[__CPROVER_contracts_original_update.assigns.\d+] line 73 Check that __CPROVER_object_whole\(\(.*\)state->digest.high_level.first.ctx->digest\) is valid when .*: SUCCESS
+^\[__CPROVER_contracts_original_update.assigns.\d+] line 74 Check that state->digest.high_level.first.ctx->flags is valid when .*: SUCCESS
+^\[__CPROVER_contracts_original_update.assigns.\d+] line 76 Check that __CPROVER_object_whole\(\(.*\)state->digest.high_level.second.ctx->digest\) is valid when .*: SUCCESS
+^\[__CPROVER_contracts_original_update.assigns.\d+] line 77 Check that state->digest.high_level.second.ctx->flags is valid when .*: SUCCESS
+^\[__CPROVER_contracts_original_update.assigns.\d+\] line 50 Check that latch is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_update.assigns.\d+\] line 51 Check that once is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_update.assigns.\d+\] line 84 Check that __CPROVER_POINTER_OBJECT\(\(void \*\)state->digest.high_level.first.ctx->digest\) is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_update.assigns.\d+\] line 85 Check that state->digest.high_level.first.ctx->flags is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_update.assigns.\d+\] line 90 Check that __CPROVER_POINTER_OBJECT\(\(void \*\)state->digest.high_level.second.ctx->digest\) is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_update.assigns.\d+\] line 91 Check that state->digest.high_level.second.ctx->flags is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_update.assigns.\d+\] line 95 Check that __CPROVER_POINTER_OBJECT\(\(void \*\)state->digest.high_level.second.ctx->digest\) is assignable: FAILURE$
+^\[__CPROVER_contracts_original_update.assigns.\d+\] line 96 Check that state->digest.high_level.second.ctx->flags is assignable: FAILURE$
+^\[__CPROVER_contracts_original_update.assigns.\d+\] line 100 Check that __CPROVER_POINTER_OBJECT\(\(void \*\)state->digest.high_level.first.ctx->digest\) is assignable: FAILURE$
+^\[__CPROVER_contracts_original_update.assigns.\d+\] line 101 Check that state->digest.high_level.first.ctx->flags is assignable: FAILURE$
+^\[__CPROVER_contracts_original_update.assigns.\d+\] line 104 Check that __CPROVER_POINTER_OBJECT\(\(void \*\)state->digest.high_level.second.ctx->digest\) is assignable: FAILURE$
+^\[__CPROVER_contracts_original_update.assigns.\d+\] line 105 Check that state->digest.high_level.second.ctx->flags is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_detect_local_statics/test.desc
+++ b/regression/contracts/assigns_enforce_detect_local_statics/test.desc
@@ -1,9 +1,9 @@
 CORE
 main.c
 --enforce-contract bar
-^\[foo.assigns.\d+\] line 14 Check that foo\$\$1\$\$x is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 17 Check that \*y is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 20 Check that \*yy is assignable: FAILURE$
+^\[__CPROVER_contracts_original_bar.assigns.\d+\] line 14 Check that foo\$\$1\$\$x is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_bar.assigns.\d+\] line 17 Check that \*y is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_bar.assigns.\d+\] line 20 Check that \*yy is assignable: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_detect_replaced_local_statics/test.desc
+++ b/regression/contracts/assigns_enforce_detect_replaced_local_statics/test.desc
@@ -1,8 +1,8 @@
 CORE
 main.c
 --replace-call-with-contract bar --replace-call-with-contract baz --enforce-contract foo _ --pointer-check
-^\[foo.assigns.\d+\] line \d+ Check that __local_static \(assigned by the contract of bar\) is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that __local_static_arr \(assigned by the contract of bar\) is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that __local_static \(assigned by the contract of bar\) is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that __local_static_arr \(assigned by the contract of bar\) is assignable: SUCCESS$
 ^\[main.assertion.\d+\] line \d+ expecting FAILURE: FAILURE$
 ^\[main.assertion.\d+\] line \d+ expecting FAILURE: FAILURE$
 ^VERIFICATION FAILED$

--- a/regression/contracts/assigns_enforce_free_dead/test.desc
+++ b/regression/contracts/assigns_enforce_free_dead/test.desc
@@ -1,25 +1,25 @@
 CORE
 main.c
 --enforce-contract foo _ --malloc-may-fail --malloc-fail-null --pointer-primitive-check
-\[foo.assigns.\d+\] line 4 Check that \*x is valid: SUCCESS$
-\[foo.assigns.\d+\] line 4 Check that \*p is valid when .*: SUCCESS$
-\[foo.assigns.\d+\] line 4 Check that \*\(\*p\) is valid when .*: SUCCESS$
-^\[foo.assigns.\d+\] line 7 Check that \*\(\*p\) is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line 24 Check that \*\(\*p\) is assignable: FAILURE$
-^\[foo.assigns.\d+\] line \d+ Check that \*p is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that \*q is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that \*w is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that __CPROVER_POINTER_OBJECT\(\(void \*\)z\) is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 4 Check that \*x is valid: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 4 Check that \*p is valid when .*: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 4 Check that \*\(\*p\) is valid when .*: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 7 Check that \*\(\*p\) is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 24 Check that \*\(\*p\) is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*p is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*q is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*w is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that __CPROVER_POINTER_OBJECT\(\(void \*\)z\) is assignable: SUCCESS$
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
 --
-^\[foo.assigns.\d+\] line \d+ Check that \*p is assignable: FAILURE$
-^\[foo.assigns.\d+\] line \d+ Check that \*q is assignable: FAILURE$
-^\[foo.assigns.\d+\] line \d+ Check that \*w is assignable: FAILURE$
-^\[foo.assigns.\d+\] line \d+ Check that \*x is assignable: FAILURE$
-^\[foo.assigns.\d+\] line \d+ Check that __CPROVER_POINTER_OBJECT\(\(void \*\)z\) is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*p is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*q is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*w is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*x is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that __CPROVER_POINTER_OBJECT\(\(void \*\)z\) is assignable: FAILURE$
 --
 Checks that invalidated CARs are correctly tracked on `free` and `DEAD`.
 

--- a/regression/contracts/assigns_enforce_havoc_object/test.desc
+++ b/regression/contracts/assigns_enforce_havoc_object/test.desc
@@ -3,9 +3,9 @@ main.c
 --enforce-contract foo
 ^EXIT=10$
 ^SIGNAL=0$
-^\[foo.assigns.\d+\] line \d+ Check that __CPROVER_object_whole\(\(.*\)a1->u.b->c\) is valid: SUCCESS$
-^\[bar.assigns.\d+\] line \d+ Check that __CPROVER_POINTER_OBJECT\(\(void \*\)a->u\.b->c\) is assignable: SUCCESS$
-^\[bar.assigns.\d+\] line \d+ Check that __CPROVER_POINTER_OBJECT\(\(void \*\)a->u\.b->c\) is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that __CPROVER_object_whole\(\(.*\)a1->u.b->c\) is valid: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that __CPROVER_POINTER_OBJECT\(\(void \*\)a->u\.b->c\) is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that __CPROVER_POINTER_OBJECT\(\(void \*\)a->u\.b->c\) is assignable: FAILURE$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/assigns_enforce_multi_file_02/test.desc
+++ b/regression/contracts/assigns_enforce_multi_file_02/test.desc
@@ -3,8 +3,8 @@ main.c
 --enforce-contract f1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[f1.assigns.\d+\] line \d+ Check that \*a is valid: SUCCESS$
-^\[f1.assigns.\d+\] line \d+ Check that b->y is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line \d+ Check that \*a is valid: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line \d+ Check that b->y is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 --

--- a/regression/contracts/assigns_enforce_offsets_2/test.desc
+++ b/regression/contracts/assigns_enforce_offsets_2/test.desc
@@ -1,9 +1,9 @@
 CORE
 main.c
 --enforce-contract foo _ --pointer-check
-^\[foo.assigns.*\d+\].* line 5 Check that \*x is valid: SUCCESS$
-^\[foo.assigns.*\d+\].* line 8 Check that x\[\(.*\)1\] is assignable: (SUCCESS|FAILURE)$
-^\[foo.assigns.*\d+\].* line 8 Check that x\[\(.*\)1\] is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.*\d+\].* line 5 Check that \*x is valid: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.*\d+\].* line 8 Check that x\[\(.*\)1\] is assignable: (SUCCESS|FAILURE)$
+^\[__CPROVER_contracts_original_foo.assigns.*\d+\].* line 8 Check that x\[\(.*\)1\] is assignable: FAILURE$
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/contracts/assigns_enforce_offsets_4/test.desc
+++ b/regression/contracts/assigns_enforce_offsets_4/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --enforce-contract foo _ --pointer-check
-^\[foo.assigns.*\d+\].* line 5 Check that x\[\(.*\)10\] is valid: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.*\d+\].* line 5 Check that x\[\(.*\)10\] is valid: FAILURE$
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/contracts/assigns_enforce_scoping_01/test.desc
+++ b/regression/contracts/assigns_enforce_scoping_01/test.desc
@@ -3,8 +3,8 @@ main.c
 --enforce-contract f1
 ^EXIT=10$
 ^SIGNAL=0$
-^\[f1.assigns.\d+\] line \d+ Check that \*f1\$\$1\$\$1\$\$b is assignable: SUCCESS$
-^\[f1.assigns.\d+\] line \d+ Check that \*b is assignable: FAILURE$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line \d+ Check that \*f1\$\$1\$\$1\$\$b is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line \d+ Check that \*b is assignable: FAILURE$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/assigns_enforce_scoping_02/test.desc
+++ b/regression/contracts/assigns_enforce_scoping_02/test.desc
@@ -3,8 +3,8 @@ main.c
 --enforce-contract f1
 ^EXIT=10$
 ^SIGNAL=0$
-^\[f1.assigns.\d+\] line \d+ Check that \*f1\$\$1\$\$1\$\$b is assignable: SUCCESS$
-^\[f1.assigns.\d+\] line \d+ Check that \*b is assignable: FAILURE$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line \d+ Check that \*f1\$\$1\$\$1\$\$b is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line \d+ Check that \*b is assignable: FAILURE$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/assigns_enforce_statics/test.desc
+++ b/regression/contracts/assigns_enforce_statics/test.desc
@@ -3,9 +3,9 @@ main.c
 --enforce-contract foo _ --pointer-primitive-check
 ^EXIT=0$
 ^SIGNAL=0$
-^\[foo.assigns.\d+\] line \d+ Check that x is valid: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that foo\$\$1\$\$x is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that \*y is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that x is valid: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that foo\$\$1\$\$x is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*y is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^\[.*assigns.*\].*: FAILURE$

--- a/regression/contracts/assigns_enforce_structs_04/test.desc
+++ b/regression/contracts/assigns_enforce_structs_04/test.desc
@@ -3,9 +3,9 @@ main.c
 --enforce-contract f1 --enforce-contract f2 --enforce-contract f3 --enforce-contract f4
 ^EXIT=10$
 ^SIGNAL=0$
-^\[f1.assigns.\d+\] line \d+ Check that p->y is assignable: FAILURE$
-^\[f2.assigns.\d+\] line \d+ Check that p->x is assignable: FAILURE$
-^\[f3.assigns.\d+\] line \d+ Check that p->y is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line \d+ Check that p->y is assignable: FAILURE$
+^\[__CPROVER_contracts_original_f2.assigns.\d+\] line \d+ Check that p->x is assignable: FAILURE$
+^\[__CPROVER_contracts_original_f3.assigns.\d+\] line \d+ Check that p->y is assignable: SUCCESS$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/assigns_enforce_structs_06/test.desc
+++ b/regression/contracts/assigns_enforce_structs_06/test.desc
@@ -3,14 +3,14 @@ main.c
 --enforce-contract f1 --enforce-contract f2 --enforce-contract f3
 ^EXIT=10$
 ^SIGNAL=0$
-^\[f1.assigns.\d+\] line \d+ Check that p->buf\[\(.*\)0\] is assignable: SUCCESS$
-^\[f1.assigns.\d+\] line \d+ Check that p->buf\[\(.*\)1\] is assignable: SUCCESS$
-^\[f1.assigns.\d+\] line \d+ Check that p->buf\[\(.*\)2\] is assignable: SUCCESS$
-^\[f1.assigns.\d+\] line \d+ Check that p->size is assignable: FAILURE$
-^\[f2.assigns.\d+\] line \d+ Check that p->buf\[\(.*\)0\] is assignable: FAILURE$
-^\[f2.assigns.\d+\] line \d+ Check that p->size is assignable: SUCCESS$
-^\[f3.assigns.\d+\] line \d+ Check that p->buf is assignable: SUCCESS$
-^\[f3.assigns.\d+\] line \d+ Check that p->size is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line \d+ Check that p->buf\[\(.*\)0\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line \d+ Check that p->buf\[\(.*\)1\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line \d+ Check that p->buf\[\(.*\)2\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line \d+ Check that p->size is assignable: FAILURE$
+^\[__CPROVER_contracts_original_f2.assigns.\d+\] line \d+ Check that p->buf\[\(.*\)0\] is assignable: FAILURE$
+^\[__CPROVER_contracts_original_f2.assigns.\d+\] line \d+ Check that p->size is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f3.assigns.\d+\] line \d+ Check that p->buf is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f3.assigns.\d+\] line \d+ Check that p->size is assignable: SUCCESS$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/assigns_enforce_structs_07/test.desc
+++ b/regression/contracts/assigns_enforce_structs_07/test.desc
@@ -3,10 +3,10 @@ main.c
 --enforce-contract f1 --enforce-contract f2 _ --malloc-may-fail --malloc-fail-null --pointer-check
 ^EXIT=10$
 ^SIGNAL=0$
-^\[f1.assigns.\d+\].*line 16 Check that \*p->buf is valid: FAILURE$
-^\[f1.assigns.\d+\].*line 18 Check that p->buf\[\(.*\)0\] is assignable: FAILURE$
-^\[f2.assigns.\d+\].*line 21 Check that \*pp->p->buf is valid: FAILURE$
-^\[f2.assigns.\d+\].*line 23 Check that pp->p->buf\[\(.*\)0\] is assignable: FAILURE$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\].*line 16 Check that \*p->buf is valid: FAILURE$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\].*line 18 Check that p->buf\[\(.*\)0\] is assignable: FAILURE$
+^\[__CPROVER_contracts_original_f2.assigns.\d+\].*line 21 Check that \*pp->p->buf is valid: FAILURE$
+^\[__CPROVER_contracts_original_f2.assigns.\d+\].*line 23 Check that pp->p->buf\[\(.*\)0\] is assignable: FAILURE$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/assigns_enforce_structs_08/test.desc
+++ b/regression/contracts/assigns_enforce_structs_08/test.desc
@@ -1,8 +1,8 @@
 CORE
 main.c
 --enforce-contract f1 --enforce-contract f2 _ --malloc-may-fail --malloc-fail-null --pointer-check
-^\[f1.assigns.\d+\] line \d+ Check that p->buf\[\(.*\)0\] is assignable: SUCCESS$
-^\[f2.assigns.\d+\] line \d+ Check that pp->p->buf\[\(.*\)0\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line \d+ Check that p->buf\[\(.*\)0\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f2.assigns.\d+\] line \d+ Check that pp->p->buf\[\(.*\)0\] is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_subfunction_calls/test.desc
+++ b/regression/contracts/assigns_enforce_subfunction_calls/test.desc
@@ -4,13 +4,13 @@ main.c
 ^EXIT=10$
 ^SIGNAL=0$
 ^main.c function baz$
-^\[baz.assigns.\d+\] line 6 Check that \*x is assignable: SUCCESS$
-^\[baz.assigns.\d+\] line 6 Check that \*x is assignable: FAILURE$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 6 Check that \*x is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line 6 Check that \*x is assignable: FAILURE$
 ^main.c function foo$
-^\[foo.assertion.\d+\] line 20 foo.x.set: SUCCESS$
-^\[foo.assertion.\d+\] line 25 foo.local.set: SUCCESS$
-^\[foo.assertion.\d+\] line 29 foo.y.set: SUCCESS$
-^\[foo.assertion.\d+\] line 33 foo.z.set: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assertion.\d+\] line 20 foo.x.set: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assertion.\d+\] line 25 foo.local.set: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assertion.\d+\] line 29 foo.y.set: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assertion.\d+\] line 33 foo.z.set: SUCCESS$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/assigns_replace_08/test.desc
+++ b/regression/contracts/assigns_replace_08/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo --replace-call-with-contract bar _ --pointer-primitive-check
 ^EXIT=10$
 ^SIGNAL=0$
-\[foo.assigns.\d+\] line \d+ Check that \*z \(assigned by the contract of bar\) is assignable: FAILURE$
+\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*z \(assigned by the contract of bar\) is assignable: FAILURE$
 ^.* 1 of \d+ failed \(\d+ iteration.*\)$
 ^VERIFICATION FAILED$
 --

--- a/regression/contracts/assigns_replace_09/test.desc
+++ b/regression/contracts/assigns_replace_09/test.desc
@@ -3,8 +3,8 @@ main.c
 --replace-call-with-contract bar --enforce-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-^\[foo.assigns.\d+\] line \d+ Check that \*z is valid: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that \*z \(assigned by the contract of bar\) is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*z is valid: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*z \(assigned by the contract of bar\) is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^Condition: \!not\_found$

--- a/regression/contracts/assigns_type_checking_valid_cases/test.desc
+++ b/regression/contracts/assigns_type_checking_valid_cases/test.desc
@@ -3,25 +3,25 @@ main.c
 --enforce-contract foo1 --enforce-contract foo2 --enforce-contract foo3 --enforce-contract foo4 --enforce-contract foo5 --enforce-contract foo6 --enforce-contract foo7 --enforce-contract foo8 --enforce-contract foo9 --enforce-contract foo10 _ --pointer-primitive-check
 ^EXIT=0$
 ^SIGNAL=0$
-^\[foo10.assigns.\d+\] line \d+ Check that buffer->len is assignable: SUCCESS$
-^\[foo10.assigns.\d+\] line \d+ Check that buffer->aux\.allocated is assignable: SUCCESS$
-^\[foo3.assigns.\d+\] line \d+ Check that y is assignable: SUCCESS$
-^\[foo4.assigns.\d+\] line \d+ Check that \*c is assignable: SUCCESS$
-^\[foo4.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
-^\[foo6.assigns.\d+\] line \d+ Check that \*buffer->data is assignable: SUCCESS$
-^\[foo6.assigns.\d+\] line \d+ Check that buffer->len is assignable: SUCCESS$
-^\[foo7.assigns.\d+\] line \d+ Check that \*buffer->data is assignable: SUCCESS$
-^\[foo7.assigns.\d+\] line \d+ Check that buffer->len is assignable: SUCCESS$
-^\[foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)0\] is assignable: SUCCESS$
-^\[foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)1\] is assignable: SUCCESS$
-^\[foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)2\] is assignable: SUCCESS$
-^\[foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)3\] is assignable: SUCCESS$
-^\[foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)4\] is assignable: SUCCESS$
-^\[foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)5\] is assignable: SUCCESS$
-^\[foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)6\] is assignable: SUCCESS$
-^\[foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)7\] is assignable: SUCCESS$
-^\[foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)8\] is assignable: SUCCESS$
-^\[foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)9\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo10.assigns.\d+\] line \d+ Check that buffer->len is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo10.assigns.\d+\] line \d+ Check that buffer->aux\.allocated is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo3.assigns.\d+\] line \d+ Check that y is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo4.assigns.\d+\] line \d+ Check that \*c is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo4.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo6.assigns.\d+\] line \d+ Check that \*buffer->data is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo6.assigns.\d+\] line \d+ Check that buffer->len is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo7.assigns.\d+\] line \d+ Check that \*buffer->data is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo7.assigns.\d+\] line \d+ Check that buffer->len is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)0\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)1\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)2\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)3\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)4\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)5\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)6\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)7\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)8\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo8.assigns.\d+\] line \d+ Check that array\[\(.* int\)9\] is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 Checks whether CBMC parses correctly all standard cases for assigns clauses.

--- a/regression/contracts/contracts_with_function_pointers/test.desc
+++ b/regression/contracts/contracts_with_function_pointers/test.desc
@@ -4,8 +4,8 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[bar.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS$
-^\[bar.assigns.\d+\] line \d+ Check that \*return\_value\_baz is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that \*y is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_bar.assigns.\d+\] line \d+ Check that \*return\_value\_baz is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_bar.assigns.\d+\] line \d+ Check that \*y is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 Checks whether CBMC properly instrument functions with function pointers

--- a/regression/contracts/history-pointer-enforce-10/test.desc
+++ b/regression/contracts/history-pointer-enforce-10/test.desc
@@ -6,9 +6,9 @@ main.c
 ^\[bar.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS$
 ^\[baz.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS$
 ^\[foo.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS$
-^\[bar.assigns.\d+\] line \d+ Check that p->y is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that \*p->y is assignable: SUCCESS$
-^\[foo.assigns.\d+\] line \d+ Check that z is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_bar.assigns.\d+\] line \d+ Check that p->y is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*p->y is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that z is assignable: SUCCESS$
 ^\[main.assertion.\d+\] line \d+ assertion \*\(p->y\) == 7: SUCCESS$
 ^\[main.assertion.\d+\] line \d+ assertion \*\(p->y\) == -1: SUCCESS$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/history-pointer-replace-04/test.desc
+++ b/regression/contracts/history-pointer-replace-04/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=10$
 ^SIGNAL=0$
-^\[foo.precondition.\d+\] line \d+ Check requires clause of foo in main: SUCCESS$
+^\[main.precondition.\d+\] line \d+ Check requires clause of foo in main: SUCCESS$
 ^\[main.assertion.\d+\] line \d+ assertion p->y \!\= 7: FAILURE$
 ^VERIFICATION FAILED$
 --

--- a/regression/contracts/loop_assigns-05/test.desc
+++ b/regression/contracts/loop_assigns-05/test.desc
@@ -3,10 +3,10 @@ main.c
 --apply-loop-contracts
 ^EXIT=0$
 ^SIGNAL=0$
-^\[body_1.assigns.\d+\] .* Check that j is assignable: SUCCESS$
-^\[body_2.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
-^\[body_3.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
-^\[incr.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that j is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
 ^\[main.\d+\] .* Check loop invariant before entry: SUCCESS$
 ^\[main.\d+\] .* Check that loop invariant is preserved: SUCCESS$
 ^\[main.assertion.\d+\] .* assertion j == 9: SUCCESS$

--- a/regression/contracts/loop_assigns_inference-01/test.desc
+++ b/regression/contracts/loop_assigns_inference-01/test.desc
@@ -3,10 +3,10 @@ main.c
 --apply-loop-contracts
 ^EXIT=0$
 ^SIGNAL=0$
-^\[body_1.assigns.\d+\] .* Check that j is assignable: SUCCESS$
-^\[body_2.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
-^\[body_3.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
-^\[incr.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that j is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
 ^\[main.\d+\] .* Check loop invariant before entry: SUCCESS$
 ^\[main.\d+\] .* Check that loop invariant is preserved: SUCCESS$
 ^\[main.assertion.\d+\] .* assertion j == 9: SUCCESS$

--- a/regression/contracts/loop_assigns_scoped_local_statics/test.desc
+++ b/regression/contracts/loop_assigns_scoped_local_statics/test.desc
@@ -3,20 +3,20 @@ main.c
 --apply-loop-contracts
 ^EXIT=0$
 ^SIGNAL=0$
-^\[body_1.assigns.\d+\] .* Check that j is assignable: SUCCESS$
-^\[body_2.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
-^\[body_3.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
-^\[incr.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that j is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
 ^\[main.\d+\] .* Check loop invariant before entry: SUCCESS$
 ^\[main.\d+\] .* Check that loop invariant is preserved: SUCCESS$
 ^\[main.assertion.\d+\] .* assertion j == 9: SUCCESS$
-^\[body_1.assigns.\d+\] line \d+ Check that __static_local is assignable: SUCCESS$
-^\[body_2.assigns.\d+\] line \d+ Check that __static_local is assignable: SUCCESS$
-^\[body_3.assigns.\d+\] line \d+ Check that __static_local is assignable: SUCCESS$
-^\[incr.assigns.\d+\] line \d+ Check that __static_local is assignable: SUCCESS$
+^\[main.assigns.\d+\] line \d+ Check that __static_local is assignable: SUCCESS$
+^\[main.assigns.\d+\] line \d+ Check that __static_local is assignable: SUCCESS$
+^\[main.assigns.\d+\] line \d+ Check that __static_local is assignable: SUCCESS$
+^\[main.assigns.\d+\] line \d+ Check that __static_local is assignable: SUCCESS$
 ^\[main.assertion.\d+\] line \d+ assertion before_loop\(\) == 0: SUCCESS$
 ^\[main.assertion.\d+\] line \d+ assertion after_loop\(\) == 0: SUCCESS$
-^\[upperbound.assigns.\d+\] line \d+ Check that __static_local is assignable: SUCCESS$
+^\[main.assigns.\d+\] line \d+ Check that __static_local is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 --

--- a/regression/contracts/loop_guard_with_side_effects/test.desc
+++ b/regression/contracts/loop_guard_with_side_effects/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --apply-loop-contracts _ --unsigned-overflow-check
-\[check.assigns\.\d+\] line \d+ Check that \*j is assignable: SUCCESS$
+\[main.assigns\.\d+\] line \d+ Check that \*j is assignable: SUCCESS$
 \[check.overflow\.\d+\] line \d+ arithmetic overflow on unsigned \+ in \*j \+ 1u: SUCCESS
 \[check.overflow\.\d+\] line \d+ arithmetic overflow on unsigned \+ in \*j \+ 1u: SUCCESS
 \[main\.\d+\] line \d+ Check loop invariant before entry: SUCCESS$

--- a/regression/contracts/loop_guard_with_side_effects_fail/test.desc
+++ b/regression/contracts/loop_guard_with_side_effects_fail/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --apply-loop-contracts _ --unsigned-overflow-check
-\[check.assigns\.\d+\] line \d+ Check that \*j is assignable: FAILURE$
+\[main.assigns\.\d+\] line \d+ Check that \*j is assignable: FAILURE$
 \[main\.\d+\] line \d+ Check loop invariant before entry: SUCCESS$
 \[main\.\d+\] line \d+ Check that loop invariant is preserved: SUCCESS$
 \[main.assigns\.\d+\] line \d+ Check that i is assignable: SUCCESS$

--- a/regression/contracts/quantifiers-forall-ensures-enforce/test.desc
+++ b/regression/contracts/quantifiers-forall-ensures-enforce/test.desc
@@ -4,7 +4,7 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[f1.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS$
-^\[f1.assigns.\d+\] line \d+ Check that arr\[\(.*\)\d\] is assignable: SUCCESS$
+^\[__CPROVER_contracts_original_f1.assigns.\d+\] line \d+ Check that arr\[\(.*\)\d\] is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts/test_aliasing_enforce/test.desc
+++ b/regression/contracts/test_aliasing_enforce/test.desc
@@ -4,9 +4,9 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 \[foo.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS
-\[foo.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS
-\[foo.assigns.\d+\] line \d+ Check that \*y is assignable: SUCCESS
-\[foo.assigns.\d+\] line \d+ Check that z is assignable: SUCCESS
+\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS
+\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*y is assignable: SUCCESS
+\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that z is assignable: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion \!\(n \< 4\): SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --

--- a/regression/contracts/test_aliasing_ensure/test.desc
+++ b/regression/contracts/test_aliasing_ensure/test.desc
@@ -4,9 +4,9 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 \[foo.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS
-\[foo.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS
-\[foo.assigns.\d+\] line \d+ Check that \*y is assignable: SUCCESS
-\[foo.assigns.\d+\] line \d+ Check that z is assignable: SUCCESS
+\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS
+\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*y is assignable: SUCCESS
+\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that z is assignable: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion \!\(n \< 4\): SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --

--- a/regression/contracts/test_aliasing_ensure_indirect/test.desc
+++ b/regression/contracts/test_aliasing_ensure_indirect/test.desc
@@ -4,7 +4,7 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 \[foo.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS
-\[foo.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS
+\[__CPROVER_contracts_original_foo.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion \!\(n \< 4\): SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --

--- a/regression/contracts/test_array_memory_replace/test.desc
+++ b/regression/contracts/test_array_memory_replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-\[foo.precondition.\d+\] line \d+ Check requires clause of foo in main: SUCCESS
+\[main.precondition.\d+\] line \d+ Check requires clause of foo in main: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion o >\= 10 \&\& o \=\= \*n \+ 5: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion n\[9\] == 113: SUCCESS
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/test_array_memory_too_small_replace/test.desc
+++ b/regression/contracts/test_array_memory_too_small_replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=10$
 ^SIGNAL=0$
-\[foo.precondition.\d+\] line \d+ Check requires clause of foo in main: FAILURE
+\[main.precondition.\d+\] line \d+ Check requires clause of foo in main: FAILURE
 \[main.assertion.\d+\] line \d+ assertion o >\= 10 \&\& o \=\= \*n \+ 5: SUCCESS
 ^VERIFICATION FAILED$
 --

--- a/regression/contracts/test_scalar_memory_replace/test.desc
+++ b/regression/contracts/test_scalar_memory_replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-\[foo.precondition.\d+\] line \d+ Check requires clause of foo in main: SUCCESS
+\[main.precondition.\d+\] line \d+ Check requires clause of foo in main: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion \_\_CPROVER\_r\_ok\(n, sizeof\(int\)\): SUCCESS
 \[main.assertion.\d+\] line \d+ assertion o >\= 10 \&\& o \=\= \*n \+ 5: SUCCESS
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/variant_multidimensional_ackermann/test.desc
+++ b/regression/contracts/variant_multidimensional_ackermann/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --apply-loop-contracts --replace-call-with-contract ackermann
-^\[ackermann.precondition\.\d+\] line \d+ Check requires clause of ackermann in main: SUCCESS$
+^\[main.precondition\.\d+\] line \d+ Check requires clause of ackermann in main: SUCCESS$
 ^\[ackermann.precondition\.\d+\] line \d+ Check requires clause of ackermann in ackermann: SUCCESS$
 ^\[ackermann\.\d+\] line 21 Check loop invariant before entry: SUCCESS$
 ^\[ackermann\.\d+\] line 21 Check that loop invariant is preserved: SUCCESS$

--- a/regression/goto-analyzer/heap-allocation-write-2/test-constant-pointers.desc
+++ b/regression/goto-analyzer/heap-allocation-write-2/test-constant-pointers.desc
@@ -3,8 +3,8 @@ main.c
 --variable-sensitivity --vsd-pointers constants --vsd-arrays every-element --verify
 ^EXIT=0$
 ^SIGNAL=0$
-\[main.assertion.1\] .*p\[.*0\] == 10: SUCCESS
-\[main.assertion.2\] .*p\[.*1\] == 20: SUCCESS
-\[main.assertion.3\] .*q\[.*0\] == 100: SUCCESS
-\[main.assertion.4\] .*q\[.*99\] == 101: SUCCESS
+\[main.assertion.\d+\] .*p\[.*0\] == 10: SUCCESS
+\[main.assertion.\d+\] .*p\[.*1\] == 20: SUCCESS
+\[main.assertion.\d+\] .*q\[.*0\] == 100: SUCCESS
+\[main.assertion.\d+\] .*q\[.*99\] == 101: SUCCESS
 --

--- a/regression/goto-analyzer/heap-allocation-write-2/test-two-value-pointers.desc
+++ b/regression/goto-analyzer/heap-allocation-write-2/test-two-value-pointers.desc
@@ -3,8 +3,8 @@ main.c
 --variable-sensitivity --vsd-pointers top-bottom --vsd-arrays every-element --verify
 ^EXIT=0$
 ^SIGNAL=0$
-\[main.assertion.1\] .*p\[.*0\] == 10: UNKNOWN
-\[main.assertion.2\] .*p\[.*1\] == 20: UNKNOWN
-\[main.assertion.3\] .*q\[.*0\] == 100: UNKNOWN
-\[main.assertion.4\] .*q\[.*99\] == 101: UNKNOWN
+\[main.assertion.\d+\] .*p\[.*0\] == 10: UNKNOWN
+\[main.assertion.\d+\] .*p\[.*1\] == 20: UNKNOWN
+\[main.assertion.\d+\] .*q\[.*0\] == 100: UNKNOWN
+\[main.assertion.\d+\] .*q\[.*99\] == 101: UNKNOWN
 --

--- a/regression/goto-analyzer/heap-allocation-write-2/test-value-set-pointers.desc
+++ b/regression/goto-analyzer/heap-allocation-write-2/test-value-set-pointers.desc
@@ -3,8 +3,8 @@ main.c
 --variable-sensitivity --vsd-pointers value-set --vsd-arrays every-element --verify
 ^EXIT=0$
 ^SIGNAL=0$
-\[main.assertion.1\] .*p\[.*0\] == 10: SUCCESS
-\[main.assertion.2\] .*p\[.*1\] == 20: SUCCESS
-\[main.assertion.3\] .*q\[.*0\] == 100: SUCCESS
-\[main.assertion.4\] .*q\[.*99\] == 101: SUCCESS
+\[main.assertion.\d+\] .*p\[.*0\] == 10: SUCCESS
+\[main.assertion.\d+\] .*p\[.*1\] == 20: SUCCESS
+\[main.assertion.\d+\] .*q\[.*0\] == 100: SUCCESS
+\[main.assertion.\d+\] .*q\[.*99\] == 101: SUCCESS
 --

--- a/regression/goto-analyzer/heap-allocation-write/test-constant-pointers.desc
+++ b/regression/goto-analyzer/heap-allocation-write/test-constant-pointers.desc
@@ -3,8 +3,8 @@ main.c
 --variable-sensitivity --vsd-pointers constants --vsd-arrays every-element --verify
 ^EXIT=0$
 ^SIGNAL=0$
-\[main.assertion.1\] .*alias == 99: SUCCESS
-\[main.assertion.2\] .*alias == 100: SUCCESS
-\[main.assertion.3\] .*i_was_malloced\[.*0\] == 101: SUCCESS
-\[main.assertion.4\] .*alias\[.*1\] == 102: SUCCESS
+\[main.assertion.\d+\] .*alias == 99: SUCCESS
+\[main.assertion.\d+\] .*alias == 100: SUCCESS
+\[main.assertion.\d+\] .*i_was_malloced\[.*0\] == 101: SUCCESS
+\[main.assertion.\d+\] .*alias\[.*1\] == 102: SUCCESS
 --

--- a/regression/goto-analyzer/heap-allocation-write/test-two-value-pointers.desc
+++ b/regression/goto-analyzer/heap-allocation-write/test-two-value-pointers.desc
@@ -3,8 +3,8 @@ main.c
 --variable-sensitivity --vsd-pointers top-bottom --vsd-arrays every-element --verify
 ^EXIT=0$
 ^SIGNAL=0$
-\[main.assertion.1\] .*alias == 99: UNKNOWN
-\[main.assertion.2\] .*alias == 100: UNKNOWN
-\[main.assertion.3\] .*i_was_malloced\[.*0\] == 101: UNKNOWN
-\[main.assertion.4\] .*alias\[.*1\] == 102: UNKNOWN
+\[main.assertion.\d+\] .*alias == 99: UNKNOWN
+\[main.assertion.\d+\] .*alias == 100: UNKNOWN
+\[main.assertion.\d+\] .*i_was_malloced\[.*0\] == 101: UNKNOWN
+\[main.assertion.\d+\] .*alias\[.*1\] == 102: UNKNOWN
 --

--- a/regression/goto-analyzer/heap-allocation-write/test-value-set-pointers.desc
+++ b/regression/goto-analyzer/heap-allocation-write/test-value-set-pointers.desc
@@ -3,8 +3,8 @@ main.c
 --variable-sensitivity --vsd-pointers value-set --vsd-arrays every-element --verify
 ^EXIT=0$
 ^SIGNAL=0$
-\[main.assertion.1\] .*alias == 99: SUCCESS
-\[main.assertion.2\] .*alias == 100: SUCCESS
-\[main.assertion.3\] .*i_was_malloced\[.*0\] == 101: SUCCESS
-\[main.assertion.4\] .*alias\[.*1\] == 102: SUCCESS
+\[main.assertion.\d+\] .*alias == 99: SUCCESS
+\[main.assertion.\d+\] .*alias == 100: SUCCESS
+\[main.assertion.\d+\] .*i_was_malloced\[.*0\] == 101: SUCCESS
+\[main.assertion.\d+\] .*alias\[.*1\] == 102: SUCCESS
 --

--- a/regression/symtab2gb/multiple_symtabs/test.desc
+++ b/regression/symtab2gb/multiple_symtabs/test.desc
@@ -3,8 +3,8 @@ entry_point.json_symtab
 user.json_symtab library.json_symtab
 ^EXIT=10$
 ^SIGNAL=0$
-^\[1\] file library.adb line \d+ assertion: FAILURE$
-^\[2\] file library.adb line \d+ assertion: FAILURE$
+^\[library\.1\] file library.adb line \d+ assertion: FAILURE$
+^\[library\.2\] file library.adb line \d+ assertion: FAILURE$
 ^VERIFICATION FAILED$
 --
 error

--- a/regression/symtab2gb/single_symtab/test.desc
+++ b/regression/symtab2gb/single_symtab/test.desc
@@ -3,8 +3,8 @@ entry_point.json_symtab
 
 ^EXIT=10$
 ^SIGNAL=0$
-^\[1\] file entry_point.adb line \d+ assertion: FAILURE$
-^\[2\] file entry_point.adb line \d+ assertion: SUCCESS$
+^\[entry_point\.1\] file entry_point.adb line \d+ assertion: FAILURE$
+^\[entry_point\.2\] file entry_point.adb line \d+ assertion: SUCCESS$
 ^VERIFICATION FAILED$
 --
 error

--- a/src/goto-instrument/aggressive_slicer.cpp
+++ b/src/goto-instrument/aggressive_slicer.cpp
@@ -100,7 +100,7 @@ void aggressive_slicert::doit()
     auto property_loc = find_property(p, goto_model.goto_functions);
     if(!property_loc.has_value())
       throw "unable to find property in call graph";
-    note_functions_to_keep(property_loc.value().get_function());
+    note_functions_to_keep(property_loc->first);
   }
 
   // Add functions within distance of shortest path functions

--- a/src/goto-programs/set_properties.cpp
+++ b/src/goto-programs/set_properties.cpp
@@ -67,13 +67,12 @@ void label_properties(
       it->source_location_nonconst().set_function(function_identifier);
     }
 
-    irep_idt function = it->source_location().get_function();
+    PRECONDITION(!function_identifier.empty());
+    std::string prefix = id2string(function_identifier);
 
-    std::string prefix=id2string(function);
     if(!it->source_location().get_property_class().empty())
     {
-      if(!prefix.empty())
-        prefix+=".";
+      prefix += ".";
 
       std::string class_infix =
         id2string(it->source_location().get_property_class());
@@ -84,8 +83,7 @@ void label_properties(
       prefix+=class_infix;
     }
 
-    if(!prefix.empty())
-      prefix+=".";
+    prefix += ".";
 
     std::size_t &count=property_counters[prefix];
 

--- a/src/goto-programs/show_properties.cpp
+++ b/src/goto-programs/show_properties.cpp
@@ -19,9 +19,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_model.h"
 
-optionalt<source_locationt> find_property(
-    const irep_idt &property,
-    const goto_functionst & goto_functions)
+optionalt<std::pair<irep_idt, source_locationt>>
+find_property(const irep_idt &property, const goto_functionst &goto_functions)
 {
   for(const auto &fct : goto_functions.function_map)
   {
@@ -33,7 +32,7 @@ optionalt<source_locationt> find_property(
       {
         if(ins.source_location().get_property_id() == property)
         {
-          return ins.source_location();
+          return std::make_pair(fct.first, ins.source_location());
         }
       }
     }

--- a/src/goto-programs/show_properties.h
+++ b/src/goto-programs/show_properties.h
@@ -45,11 +45,14 @@ void show_properties(
 /// \param property: irep_idt that identifies property
 /// \param goto_functions: program in which to search for
 ///   the property
-/// \return optional<source_locationt> the location of the
-///   property, if found.
-optionalt<source_locationt> find_property(
-    const irep_idt &property,
-    const goto_functionst &goto_functions);
+/// \return A pair of function identifier and source location, where the
+///   function identifier is that of the GOTO function that contains the ASSERT
+///   instruction labelled by \p property, if any such property label exists.
+///   The source location is that of the ASSERT instruction matching the
+///   property. The function identifier and source location's function attribute
+///   are not necessarily equal.
+optionalt<std::pair<irep_idt, source_locationt>>
+find_property(const irep_idt &property, const goto_functionst &goto_functions);
 
 /// \brief Collects the properties in the goto program into a `json_arrayt`
 /// \param json_properties: JSON array to hold the properties

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -940,8 +940,7 @@ void goto_symext::loop_bound_exceeded(
   {
     // Generate VCC for unwinding assertion.
     const std::string property_id =
-      id2string(state.source.pc->source_location().get_function()) +
-      ".unwind." + loop_number;
+      id2string(state.source.function_id) + ".unwind." + loop_number;
     vcc(
       negated_cond,
       property_id,


### PR DESCRIPTION
A source location is a place in a text file, and the function information stored
in there need not coincide with the name we use in the goto model.

Part 1: label_properties should use the actual function name so that properties
in different instantiations of a function (as may happen when linking static
functions) get unique names.

This is in parts an RFC: it may actually be the _right thing_ to use `source_locationt::get_function` for this purpose and no change should be made.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
