### PR TITLE
fresh symbols: Only use source_locationt's get_function() for user output

### DIFF
--- a/src/ansi-c/c_nondet_symbol_factory.cpp
+++ b/src/ansi-c/c_nondet_symbol_factory.cpp
@@ -206,7 +206,12 @@ symbol_exprt c_nondet_symbol_factory(
   bool moving_symbol_failed=symbol_table.move(main_symbol, main_symbol_ptr);
   CHECK_RETURN(!moving_symbol_failed);
 
-  symbol_factoryt state(symbol_table, loc, object_factory_parameters, lifetime);
+  symbol_factoryt state(
+    symbol_table,
+    loc,
+    goto_functionst::entry_point(),
+    object_factory_parameters,
+    lifetime);
 
   code_blockt assignments;
   state.gen_nondet_init(assignments, main_symbol_expr);

--- a/src/ansi-c/c_nondet_symbol_factory.h
+++ b/src/ansi-c/c_nondet_symbol_factory.h
@@ -38,13 +38,14 @@ public:
   symbol_factoryt(
     symbol_tablet &_symbol_table,
     const source_locationt &loc,
+    const irep_idt &name_prefix,
     const c_object_factory_parameterst &object_factory_params,
     const lifetimet lifetime)
     : symbol_table(_symbol_table),
       loc(loc),
       ns(_symbol_table),
       object_factory_params(object_factory_params),
-      allocate_objects(ID_C, loc, loc.get_function(), symbol_table),
+      allocate_objects(ID_C, loc, name_prefix, symbol_table),
       lifetime(lifetime)
   {
   }

--- a/src/goto-instrument/generate_function_bodies.cpp
+++ b/src/goto-instrument/generate_function_bodies.cpp
@@ -169,12 +169,14 @@ private:
     const exprt &lhs,
     const std::size_t initial_depth,
     const source_locationt &source_location,
+    const irep_idt &function_id,
     symbol_tablet &symbol_table,
     goto_programt &dest) const
   {
     symbol_factoryt symbol_factory(
       symbol_table,
       source_location,
+      function_id,
       object_factory_parameters,
       lifetimet::DYNAMIC);
 
@@ -235,6 +237,7 @@ protected:
           dereference_expr,
           1, // depth 1 since we pass the dereferenced pointer
           function_symbol.location,
+          function_name,
           symbol_table,
           dest);
 
@@ -260,6 +263,7 @@ protected:
         symbol_exprt(global_sym.name, global_sym.type),
         0,
         function_symbol.location,
+        irep_idt(),
         symbol_table,
         dest);
 
@@ -291,6 +295,7 @@ protected:
         aux_symbol.symbol_expr(),
         0,
         function_symbol.location,
+        function_name,
         symbol_table,
         dest);
 

--- a/src/goto-instrument/wmm/abstract_event.h
+++ b/src/goto-instrument/wmm/abstract_event.h
@@ -34,6 +34,7 @@ public:
   irep_idt variable;
   unsigned id;
   source_locationt source_location;
+  irep_idt function_id;
   bool local;
 
   // for ASMfence
@@ -61,10 +62,20 @@ public:
   }
 
   abstract_eventt(
-    operationt _op, unsigned _th, irep_idt _var,
-    unsigned _id, source_locationt _loc, bool _local)
-    :operation(_op), thread(_th), variable(_var), id(_id),
-    source_location(_loc), local(_local)
+    operationt _op,
+    unsigned _th,
+    irep_idt _var,
+    unsigned _id,
+    source_locationt _loc,
+    irep_idt _function_id,
+    bool _local)
+    : operation(_op),
+      thread(_th),
+      variable(_var),
+      id(_id),
+      source_location(_loc),
+      function_id(_function_id),
+      local(_local)
   {
   }
 
@@ -74,6 +85,7 @@ public:
     irep_idt _var,
     unsigned _id,
     source_locationt _loc,
+    irep_idt _function_id,
     bool _local,
     bool WRf,
     bool WWf,
@@ -81,20 +93,21 @@ public:
     bool RWf,
     bool WWc,
     bool RWc,
-    bool RRc):
-    operation(_op),
-    thread(_th),
-    variable(_var),
-    id(_id),
-    source_location(_loc),
-    local(_local),
-    WRfence(RWf),
-    WWfence(WWf),
-    RRfence(RRf),
-    RWfence(WRf),
-    WWcumul(WWc),
-    RWcumul(RWc),
-    RRcumul(RRc)
+    bool RRc)
+    : operation(_op),
+      thread(_th),
+      variable(_var),
+      id(_id),
+      source_location(_loc),
+      function_id(_function_id),
+      local(_local),
+      WRfence(RWf),
+      WWfence(WWf),
+      RRfence(RRf),
+      RWfence(WRf),
+      WWcumul(WWc),
+      RWcumul(RWc),
+      RRcumul(RRc)
   {
   }
 
@@ -106,6 +119,7 @@ public:
     variable=other.variable;
     id=other.id;
     source_location=other.source_location;
+    function_id = other.function_id;
     local=other.local;
   }
 

--- a/src/goto-instrument/wmm/event_graph.cpp
+++ b/src/goto-instrument/wmm/event_graph.cpp
@@ -94,10 +94,10 @@ event_idt event_grapht::copy_segment(event_idt begin, event_idt end)
   const abstract_eventt &end_event=operator[](end);
 
   /* not sure -- we should allow cross function cycles */
-  if(begin_event.source_location.get_file()!=end_event.source_location
-    .get_file()
-    || begin_event.source_location.get_function()!=end_event.source_location
-    .get_function())
+  if(
+    begin_event.source_location.get_file() !=
+      end_event.source_location.get_file() ||
+    begin_event.function_id != end_event.function_id)
     return end;
 
   if(duplicated_bodies.find(std::make_pair(begin_event, end_event))

--- a/src/goto-instrument/wmm/goto2graph.cpp
+++ b/src/goto-instrument/wmm/goto2graph.cpp
@@ -199,11 +199,11 @@ void instrumentert::cfg_visitort::visit_cfg_function(
       #ifdef ATOMIC_BREAK
       visit_cfg_thread();
       #elif defined ATOMIC_FENCE
-      visit_cfg_fence(i_it);
-      #else
+      visit_cfg_fence(i_it, function_id);
+#else
       /* propagates */
       visit_cfg_propagate(i_it);
-      #endif
+#endif
     }
     /* a:=b -o-> Rb -po-> Wa */
     else if(instruction.is_assign())
@@ -222,11 +222,11 @@ void instrumentert::cfg_visitort::visit_cfg_function(
     else if(is_fence(instruction, instrumenter.ns))
     {
       instrumenter.message.debug() << "Constructing a fence" << messaget::eom;
-      visit_cfg_fence(i_it);
+      visit_cfg_fence(i_it, function_id);
     }
     else if(model!=TSO && is_lwfence(instruction, instrumenter.ns))
     {
-      visit_cfg_lwfence(i_it);
+      visit_cfg_lwfence(i_it, function_id);
     }
     else if(model==TSO && is_lwfence(instruction, instrumenter.ns))
     {
@@ -236,7 +236,7 @@ void instrumentert::cfg_visitort::visit_cfg_function(
     else if(instruction.is_other()
       && instruction.code.get_statement()==ID_fence)
     {
-      visit_cfg_asm_fence(i_it);
+      visit_cfg_asm_fence(i_it, function_id);
     }
     else if(instruction.is_function_call())
     {
@@ -742,11 +742,18 @@ void instrumentert::cfg_visitort::visit_cfg_function_call(
 }
 
 void instrumentert::cfg_visitort::visit_cfg_lwfence(
-  goto_programt::instructionst::iterator i_it)
+  goto_programt::instructionst::iterator i_it,
+  const irep_idt &function_id)
 {
   const goto_programt::instructiont &instruction=*i_it;
-  const abstract_eventt new_fence_event(abstract_eventt::operationt::Lwfence,
-    thread, "f", instrumenter.unique_id++, instruction.source_location, false);
+  const abstract_eventt new_fence_event(
+    abstract_eventt::operationt::Lwfence,
+    thread,
+    "f",
+    instrumenter.unique_id++,
+    instruction.source_location,
+    function_id,
+    false);
   const event_idt new_fence_node=egraph.add_node();
   egraph[new_fence_node](new_fence_event);
   const event_idt new_fence_gnode=egraph_alt.add_node();
@@ -774,7 +781,8 @@ void instrumentert::cfg_visitort::visit_cfg_lwfence(
 }
 
 void instrumentert::cfg_visitort::visit_cfg_asm_fence(
-  goto_programt::instructionst::iterator i_it)
+  goto_programt::instructionst::iterator i_it,
+  const irep_idt &function_id)
 {
   const goto_programt::instructiont &instruction=*i_it;
   bool WRfence=instruction.code.get_bool(ID_WRfence);
@@ -784,9 +792,21 @@ void instrumentert::cfg_visitort::visit_cfg_asm_fence(
   bool WWcumul=instruction.code.get_bool(ID_WWcumul);
   bool RRcumul=instruction.code.get_bool(ID_RRcumul);
   bool RWcumul=instruction.code.get_bool(ID_RWcumul);
-  const abstract_eventt new_fence_event(abstract_eventt::operationt::ASMfence,
-    thread, "asm", instrumenter.unique_id++, instruction.source_location,
-    false, WRfence, WWfence, RRfence, RWfence, WWcumul, RWcumul, RRcumul);
+  const abstract_eventt new_fence_event(
+    abstract_eventt::operationt::ASMfence,
+    thread,
+    "asm",
+    instrumenter.unique_id++,
+    instruction.source_location,
+    function_id,
+    false,
+    WRfence,
+    WWfence,
+    RRfence,
+    RWfence,
+    WWcumul,
+    RWcumul,
+    RRcumul);
   const event_idt new_fence_node=egraph.add_node();
   egraph[new_fence_node](new_fence_event);
   const event_idt new_fence_gnode=egraph_alt.add_node();
@@ -867,9 +887,14 @@ void instrumentert::cfg_visitort::visit_cfg_assign(
     assert(read_expr);
 #endif
 
-    const abstract_eventt new_read_event(abstract_eventt::operationt::Read,
-      thread, id2string(read), instrumenter.unique_id++,
-      instruction.source_location, local(read));
+    const abstract_eventt new_read_event(
+      abstract_eventt::operationt::Read,
+      thread,
+      id2string(read),
+      instrumenter.unique_id++,
+      instruction.source_location,
+      function_id,
+      local(read));
 
     const event_idt new_read_node=egraph.add_node();
     egraph[new_read_node]=new_read_event;
@@ -965,9 +990,14 @@ void instrumentert::cfg_visitort::visit_cfg_assign(
     // assert(write_expr);
 
     /* creates Write */
-    const abstract_eventt new_write_event(abstract_eventt::operationt::Write,
-      thread, id2string(write), instrumenter.unique_id++,
-      instruction.source_location, local(write));
+    const abstract_eventt new_write_event(
+      abstract_eventt::operationt::Write,
+      thread,
+      id2string(write),
+      instrumenter.unique_id++,
+      instruction.source_location,
+      function_id,
+      local(write));
 
     const event_idt new_write_node=egraph.add_node();
     egraph[new_write_node](new_write_event);
@@ -1137,11 +1167,18 @@ void instrumentert::cfg_visitort::visit_cfg_assign(
 }
 
 void instrumentert::cfg_visitort::visit_cfg_fence(
-  goto_programt::instructionst::iterator i_it)
+  goto_programt::instructionst::iterator i_it,
+  const irep_idt &function_id)
 {
   const goto_programt::instructiont &instruction=*i_it;
-  const abstract_eventt new_fence_event(abstract_eventt::operationt::Fence,
-    thread, "F", instrumenter.unique_id++, instruction.source_location, false);
+  const abstract_eventt new_fence_event(
+    abstract_eventt::operationt::Fence,
+    thread,
+    "F",
+    instrumenter.unique_id++,
+    instruction.source_location,
+    function_id,
+    false);
   const event_idt new_fence_node=egraph.add_node();
   egraph[new_fence_node](new_fence_event);
   const event_idt new_fence_gnode=egraph_alt.add_node();
@@ -1440,7 +1477,7 @@ void inline instrumentert::print_outputs_local(
       if(render_po_aligned)
         same_po[ev.thread].insert(*it_e);
       if(render_by_function)
-        same_file[ev.source_location.get_function()].insert(*it_e);
+        same_file[ev.function_id].insert(*it_e);
       else if(render_by_file)
         same_file[ev.source_location.get_file()].insert(*it_e);
       if(ev.thread>max_thread)

--- a/src/goto-instrument/wmm/goto2graph.h
+++ b/src/goto-instrument/wmm/goto2graph.h
@@ -142,10 +142,16 @@ protected:
       local_may_aliast &local_may
 #endif
     ); // NOLINT(whitespace/parens)
-    void visit_cfg_fence(goto_programt::instructionst::iterator i_it);
+    void visit_cfg_fence(
+      goto_programt::instructionst::iterator i_it,
+      const irep_idt &function_id);
     void visit_cfg_skip(goto_programt::instructionst::iterator i_it);
-    void visit_cfg_lwfence(goto_programt::instructionst::iterator i_it);
-    void visit_cfg_asm_fence(goto_programt::instructionst::iterator i_it);
+    void visit_cfg_lwfence(
+      goto_programt::instructionst::iterator i_it,
+      const irep_idt &function_id);
+    void visit_cfg_asm_fence(
+      goto_programt::instructionst::iterator i_it,
+      const irep_idt &function_id);
     void visit_cfg_function_call(value_setst &value_sets,
       goto_programt::instructionst::iterator i_it,
       memory_modelt model,

--- a/src/goto-programs/remove_function_pointers.h
+++ b/src/goto-programs/remove_function_pointers.h
@@ -14,6 +14,8 @@ Date: June 2003
 #ifndef CPROVER_GOTO_PROGRAMS_REMOVE_FUNCTION_POINTERS_H
 #define CPROVER_GOTO_PROGRAMS_REMOVE_FUNCTION_POINTERS_H
 
+#include <util/irep.h>
+
 class goto_functionst;
 class goto_programt;
 class goto_modelt;
@@ -40,7 +42,8 @@ bool remove_function_pointers(
   symbol_tablet &symbol_table,
   const goto_functionst &goto_functions,
   goto_programt &goto_program,
+  const irep_idt &function_id,
   bool add_safety_assertion,
-  bool only_remove_const_fps=false);
+  bool only_remove_const_fps = false);
 
 #endif // CPROVER_GOTO_PROGRAMS_REMOVE_FUNCTION_POINTERS_H


### PR DESCRIPTION
A source location is a place in a text file, and the function information stored
in there need not coincide with the name we use in the goto model.

Part 2: Wherever we generate fresh symbols or function-specific objects we
should use the actual function name to ensure fewer name collisions (for fresh
symbols) or actually unique objects.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
