### PR TITLE
GraphML witness: consistently use function_id

### DIFF
--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -290,7 +290,7 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
 
           xmlt &val_s=edge.new_element("data");
           val_s.set_attribute("key", "assumption.scope");
-          val_s.data=id2string(it->pc->source_location.get_function());
+          val_s.data = id2string(it->function_id);
         }
         else if(it->type==goto_trace_stept::typet::GOTO &&
                 it->pc->is_goto())
@@ -475,8 +475,7 @@ void graphml_witnesst::operator()(const symex_target_equationt &equation)
           graphml[to].has_invariant=true;
           code_assignt assign(it->ssa_full_lhs, it->ssa_rhs);
           graphml[to].invariant=convert_assign_rec(identifier, assign);
-          graphml[to].invariant_scope=
-            id2string(it->source.pc->source_location.get_function());
+          graphml[to].invariant_scope = id2string(it->source.function_id);
         }
         else if(it->is_goto() &&
                 it->source.pc->is_goto())


### PR DESCRIPTION
Don't sometimes (and unecessarily) fall back to source_locationt::get_function.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
