### PR TITLE
Use type information to detect implicit function declaration

### DIFF
--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -728,8 +728,9 @@ void goto_convertt::do_function_call_symbol(
     a->source_location=function.source_location();
     a->source_location.set("user-provided", true);
   }
-  else if(identifier=="assert" &&
-          !ns.lookup(identifier).location.get_function().empty())
+  else if(
+    identifier == "assert" && symbol->type.get_bool(ID_C_incomplete) &&
+    to_code_type(symbol->type).return_type() == signed_int_type())
   {
     if(arguments.size()!=1)
     {

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -461,8 +461,7 @@ void linkingt::duplicate_code_symbol(
     // return type are an error as we would end up with assignments with
     // mismatching types; as we currently do not patch these by inserting type
     // casts we need to fail hard
-    if(!old_symbol.location.get_function().empty() &&
-       old_symbol.value.is_nil())
+    if(old_symbol.type.get_bool(ID_C_incomplete) && old_symbol.value.is_nil())
     {
       if(base_type_eq(old_t.return_type(), new_t.return_type(), ns))
          link_warning(
@@ -479,8 +478,8 @@ void linkingt::duplicate_code_symbol(
       old_symbol.location=new_symbol.location;
       old_symbol.is_weak=new_symbol.is_weak;
     }
-    else if(!new_symbol.location.get_function().empty() &&
-            new_symbol.value.is_nil())
+    else if(
+      new_symbol.type.get_bool(ID_C_incomplete) && new_symbol.value.is_nil())
     {
       if(base_type_eq(old_t.return_type(), new_t.return_type(), ns))
         link_warning(


### PR DESCRIPTION
Do not rely on source_locationt::get_function to provide this information.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
