### PR TITLE
Remove symbolt::is_procedure_local

### DIFF
--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -478,8 +478,9 @@ void constant_propagator_domaint::valuest::set_dirty_to_top(
 
     const symbolt &symbol=ns.lookup(id);
 
-    if((!symbol.is_procedure_local() || dirty(id)) &&
-       !symbol.type.get_bool(ID_C_constant))
+    if(
+      (symbol.is_static_lifetime || dirty(id)) &&
+      !symbol.type.get_bool(ID_C_constant))
     {
       it = replace_const.erase(it);
     }

--- a/src/util/symbol.h
+++ b/src/util/symbol.h
@@ -97,11 +97,6 @@ public:
     return !is_thread_local;
   }
 
-  bool is_procedure_local() const
-  {
-    return !is_static_lifetime;
-  }
-
   bool is_function() const
   {
     return !is_type && !is_macro && type.id()==ID_code;


### PR DESCRIPTION
It had a single user and wasn't actually a reliable indicator of whether a
symbol is procedure-local (in C/C++, a procedure-scoped variable may still have
static lifetime).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
