### PR TITLE
use instructiont::make_goto variant that takes a guard

### DIFF
--- a/jbmc/src/java_bytecode/remove_exceptions.cpp
+++ b/jbmc/src/java_bytecode/remove_exceptions.cpp
@@ -350,7 +350,7 @@ void remove_exceptionst::add_exception_dispatch_sequence(
       {
         // Normal exception handler, make an instanceof check.
         goto_programt::targett t_exc=goto_program.insert_after(instr_it);
-        t_exc->make_goto(new_state_pc);
+        t_exc->make_goto(new_state_pc, true_exprt());
         t_exc->source_location=instr_it->source_location;
 
         // use instanceof to check that this is the correct handler
@@ -374,7 +374,7 @@ void remove_exceptionst::add_exception_dispatch_sequence(
     }
   }
 
-  default_dispatch->make_goto(default_target);
+  default_dispatch->make_goto(default_target, true_exprt());
   default_dispatch->source_location=instr_it->source_location;
 
   // add dead instructions
@@ -461,9 +461,8 @@ bool remove_exceptionst::instrument_function_call(
 
       // add a null check (so that instanceof can be applied)
       goto_programt::targett t_null=goto_program.insert_after(instr_it);
-      t_null->make_goto(next_it);
+      t_null->make_goto(next_it, no_exception_currently_in_flight);
       t_null->source_location=instr_it->source_location;
-      t_null->guard=no_exception_currently_in_flight;
     }
 
     return true;

--- a/src/goto-analyzer/taint_analysis.cpp
+++ b/src/goto-analyzer/taint_analysis.cpp
@@ -288,7 +288,8 @@ bool taint_analysist::operator()(
           goto_programt::targett t=calls.add_instruction();
           const code_function_callt call(symbol.symbol_expr());
           t->make_function_call(call);
-          calls.add_instruction()->make_goto(end.instructions.begin());
+          calls.add_instruction()->make_goto(
+            end.instructions.begin(), true_exprt());
           goto_programt::targett g=gotos.add_instruction();
           g->make_goto(
             t, side_effect_expr_nondett(bool_typet(), symbol.location));

--- a/src/goto-instrument/branch.cpp
+++ b/src/goto-instrument/branch.cpp
@@ -56,7 +56,7 @@ void branch(
           function_to_call(goto_model.symbol_table, id, "taken"));
 
         goto_programt::targett t2=body.insert_after(t1);
-        t2->make_goto(i_it->get_target());
+        t2->make_goto(i_it->get_target(), true_exprt());
 
         goto_programt::targett t3=body.insert_after(t2);
         t3->make_function_call(

--- a/src/goto-instrument/interrupt.cpp
+++ b/src/goto-instrument/interrupt.cpp
@@ -107,9 +107,9 @@ static void interrupt(
       goto_programt::targett t_call=goto_program.insert_after(t_goto);
       goto_programt::targett t_orig=goto_program.insert_after(t_call);
 
-      t_goto->make_goto(t_orig);
+      t_goto->make_goto(
+        t_orig, side_effect_expr_nondett(bool_typet(), source_location));
       t_goto->source_location=source_location;
-      t_goto->guard = side_effect_expr_nondett(bool_typet(), source_location);
 
       t_call->make_function_call(isr_call);
       t_call->source_location=source_location;
@@ -133,9 +133,9 @@ static void interrupt(
       code_function_callt isr_call(interrupt_handler);
       isr_call.add_source_location()=source_location;
 
-      t_goto->make_goto(t_orig);
+      t_goto->make_goto(
+        t_orig, side_effect_expr_nondett(bool_typet(), source_location));
       t_goto->source_location=source_location;
-      t_goto->guard = side_effect_expr_nondett(bool_typet(), source_location);
 
       t_call->make_function_call(isr_call);
       t_call->source_location=source_location;

--- a/src/goto-instrument/unwind.cpp
+++ b/src/goto-instrument/unwind.cpp
@@ -177,9 +177,9 @@ void goto_unwindt::unwind(
       goto_programt::targett t_goto=goto_program.insert_before(loop_exit);
       unwind_log.insert(t_goto, loop_exit->location_number);
 
-      t_goto->make_goto(goto_program.const_cast_target(loop_exit));
+      t_goto->make_goto(
+        goto_program.const_cast_target(loop_exit), true_exprt());
       t_goto->source_location=loop_exit->source_location;
-      t_goto->guard=true_exprt();
       t_goto->location_number=loop_exit->location_number;
     }
 

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -214,9 +214,8 @@ void goto_convertt::finish_computed_gotos(goto_programt &goto_program)
       goto_programt::targett t=
         goto_program.insert_after(g_it);
 
-      t->make_goto(label.second.first);
+      t->make_goto(label.second.first, guard);
       t->source_location=i.source_location;
-      t->guard=guard;
     }
   }
 
@@ -965,8 +964,7 @@ void goto_convertt::convert_for(
   targets.set_continue(tmp_x.instructions.begin());
 
   // v: if(!c) goto z;
-  v->make_goto(z);
-  v->guard = boolean_negate(cond);
+  v->make_goto(z, boolean_negate(cond));
   v->source_location=cond.source_location();
 
   // do the w label
@@ -976,8 +974,7 @@ void goto_convertt::convert_for(
   // y: goto u;
   goto_programt tmp_y;
   goto_programt::targett y=tmp_y.add_instruction();
-  y->make_goto(u);
-  y->guard=true_exprt();
+  y->make_goto(u, true_exprt());
   y->source_location=code.source_location();
 
   // loop invariant
@@ -1038,8 +1035,7 @@ void goto_convertt::convert_while(
   convert(code.body(), tmp_x, mode);
 
   // y: if(c) goto v;
-  y->make_goto(v);
-  y->guard=true_exprt();
+  y->make_goto(v, true_exprt());
   y->source_location=code.source_location();
 
   // loop invariant
@@ -1108,8 +1104,7 @@ void goto_convertt::convert_dowhile(
   goto_programt::targett w=tmp_w.instructions.begin();
 
   // y: if(c) goto w;
-  y->make_goto(w);
-  y->guard=cond;
+  y->make_goto(w, cond);
   y->source_location=condition_location;
 
   // loop invariant
@@ -1611,7 +1606,7 @@ void goto_convertt::generate_ifthenelse(
   tmp_w.swap(true_case);
 
   // x: goto z;
-  x->make_goto(z);
+  x->make_goto(z, true_exprt());
   CHECK_RETURN(!tmp_w.instructions.empty());
   x->source_location=tmp_w.instructions.back().source_location;
 

--- a/src/goto-programs/goto_convert_function_call.cpp
+++ b/src/goto-programs/goto_convert_function_call.cpp
@@ -135,8 +135,7 @@ void goto_convertt::do_function_call_if(
     y=tmp_y.instructions.begin();
 
   // v: if(!c) goto y;
-  v->make_goto(y);
-  v->guard = boolean_negate(function.cond());
+  v->make_goto(y, boolean_negate(function.cond()));
   v->source_location=function.cond().source_location();
 
   // w: f();
@@ -148,7 +147,7 @@ void goto_convertt::do_function_call_if(
     tmp_w.add_instruction(SKIP);
 
   // x: goto z;
-  x->make_goto(z);
+  x->make_goto(z, true_exprt());
 
   dest.destructive_append(tmp_v);
   dest.destructive_append(tmp_w);

--- a/src/goto-programs/string_instrumentation.cpp
+++ b/src/goto-programs/string_instrumentation.cpp
@@ -888,8 +888,7 @@ void string_instrumentationt::invalidate_buffer(
 
   goto_programt::targett back=dest.add_instruction();
   back->source_location=target->source_location;
-  back->make_goto(check);
-  back->guard=true_exprt();
+  back->make_goto(check, true_exprt());
 
   goto_programt::targett exit=dest.add_instruction();
   exit->source_location=target->source_location;
@@ -909,22 +908,19 @@ void string_instrumentationt::invalidate_buffer(
   const plus_exprt b_plus_i(bufp, cntr_sym.symbol_expr());
   const dereference_exprt deref(b_plus_i, buf_type.subtype());
 
-  check->make_goto(exit);
+  exprt condition;
 
   if(limit==0)
-    check->guard=
-      binary_relation_exprt(
-        cntr_sym.symbol_expr(),
-        ID_ge,
-        buffer_size(bufp));
+    condition =
+      binary_relation_exprt(cntr_sym.symbol_expr(), ID_ge, buffer_size(bufp));
   else
-    check->guard=
-      binary_relation_exprt(
-        cntr_sym.symbol_expr(),
-        ID_gt,
-        from_integer(limit, unsigned_int_type()));
+    condition = binary_relation_exprt(
+      cntr_sym.symbol_expr(), ID_gt, from_integer(limit, unsigned_int_type()));
+
+  check->make_goto(exit, condition);
 
   const side_effect_expr_nondett nondet(
     buf_type.subtype(), target->source_location);
+
   invalidate->code=code_assignt(deref, nondet);
 }

--- a/unit/goto-programs/goto_program_goto_target.cpp
+++ b/unit/goto-programs/goto_program_goto_target.cpp
@@ -37,7 +37,7 @@ SCENARIO(
     instructions.back().make_assertion(x_le_10);
 
     instructions.emplace_back(goto_program_instruction_typet::GOTO);
-    instructions.back().make_goto(instructions.begin());
+    instructions.back().make_goto(instructions.begin(), true_exprt());
 
     symbol.type = type1;
     symbol_table.insert(symbol);


### PR DESCRIPTION
This prevents partial construction.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
