### PR TITLE
from_integer can no longer return nil_exprt

### DIFF
--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -241,11 +241,7 @@ void goto_checkt::div_by_zero_check(
   // add divison by zero subgoal
 
   exprt zero=from_integer(0, expr.op1().type());
-
-  if(zero.is_nil())
-    throw "no zero of argument type of operator "+expr.id_string();
-
-  const notequal_exprt inequality(expr.op1(), zero);
+  const notequal_exprt inequality(expr.op1(), std::move(zero));
 
   add_guarded_claim(
     inequality,
@@ -289,11 +285,8 @@ void goto_checkt::undefined_shift_check(
     exprt width_expr=
       from_integer(to_bitvector_type(op_type).get_width(), distance_type);
 
-    if(width_expr.is_nil())
-      throw "no number for width for operator "+expr.id_string();
-
     add_guarded_claim(
-      binary_relation_exprt(expr.distance(), ID_lt, width_expr),
+      binary_relation_exprt(expr.distance(), ID_lt, std::move(width_expr)),
       "shift distance too large",
       "undefined-shift",
       expr.find_source_location(),
@@ -336,11 +329,7 @@ void goto_checkt::mod_by_zero_check(
   // add divison by zero subgoal
 
   exprt zero=from_integer(0, expr.op1().type());
-
-  if(zero.is_nil())
-    throw "no zero of argument type of operator "+expr.id_string();
-
-  const notequal_exprt inequality(expr.op1(), zero);
+  const notequal_exprt inequality(expr.op1(), std::move(zero));
 
   add_guarded_claim(
     inequality,
@@ -1270,10 +1259,10 @@ void goto_checkt::bounds_check(
         }
 
         exprt zero=from_integer(0, ode.offset().type());
-        assert(zero.is_not_nil());
 
         // the final offset must not be negative
-        binary_relation_exprt inequality(effective_offset, ID_ge, zero);
+        binary_relation_exprt inequality(
+          effective_offset, ID_ge, std::move(zero));
 
         add_guarded_claim(
           inequality,

--- a/src/solvers/flattening/boolbv_index.cpp
+++ b/src/solvers/flattening/boolbv_index.cpp
@@ -105,13 +105,12 @@ bvt boolbvt::convert_index(const index_exprt &expr)
 
       binary_relation_exprt lower_bound(
         from_integer(0, index.type()), ID_le, index);
-      CHECK_RETURN(lower_bound.lhs().is_not_nil());
       binary_relation_exprt upper_bound(
         index, ID_lt, from_integer(array_size, index.type()));
-      CHECK_RETURN(upper_bound.rhs().is_not_nil());
 
-      and_exprt range_condition(lower_bound, upper_bound);
-      implies_exprt implication(range_condition, value_equality);
+      and_exprt range_condition(std::move(lower_bound), std::move(upper_bound));
+      implies_exprt implication(
+        std::move(range_condition), std::move(value_equality));
 
       // Simplify may remove the lower bound if the type
       // is correct.

--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -115,9 +115,8 @@ exprt is_not_zero(
     src_type.id()==ID_floatbv?ID_ieee_float_notequal:ID_notequal;
 
   exprt zero=from_integer(0, src_type);
-  CHECK_RETURN(zero.is_not_nil());
 
-  binary_exprt comparison(src, id, zero, bool_typet());
+  binary_relation_exprt comparison(src, id, std::move(zero));
   comparison.add_source_location()=src.source_location();
 
   return std::move(comparison);

--- a/src/util/pointer_predicates.cpp
+++ b/src/util/pointer_predicates.cpp
@@ -214,7 +214,6 @@ exprt object_lower_bound(
   exprt p_offset=pointer_offset(pointer);
 
   exprt zero=from_integer(0, p_offset.type());
-  CHECK_RETURN(zero.is_not_nil());
 
   if(offset.is_not_nil())
   {
@@ -222,5 +221,5 @@ exprt object_lower_bound(
       p_offset, typecast_exprt::conditional_cast(offset, p_offset.type()));
   }
 
-  return binary_relation_exprt(p_offset, ID_lt, zero);
+  return binary_relation_exprt(std::move(p_offset), ID_lt, std::move(zero));
 }

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -333,7 +333,6 @@ bool simplify_exprt::simplify_typecast(exprt &expr)
       op_type.id() == ID_floatbv ? ID_ieee_float_notequal : ID_notequal,
       from_integer(0, op_type));
     inequality.add_source_location()=expr.source_location();
-    CHECK_RETURN(inequality.rhs().is_not_nil());
     simplify_node(inequality);
     expr.swap(inequality);
     return false;
@@ -592,13 +591,11 @@ bool simplify_exprt::simplify_typecast(exprt &expr)
         if(operand.is_true())
         {
           expr=from_integer(1, expr_type);
-          CHECK_RETURN(expr.is_not_nil());
           return false;
         }
         else if(operand.is_false())
         {
           expr=from_integer(0, expr_type);
-          CHECK_RETURN(expr.is_not_nil());
           return false;
         }
       }

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -316,13 +316,8 @@ bool simplify_exprt::simplify_div(exprt &expr)
     if(int_value0.has_value() && int_value1.has_value())
     {
       mp_integer result = *int_value0 / *int_value1;
-      exprt tmp=from_integer(result, expr_type);
-
-      if(tmp.is_not_nil())
-      {
-        expr.swap(tmp);
-        return false;
-      }
+      expr = from_integer(result, expr_type);
+      return false;
     }
   }
   else if(expr_type.id()==ID_rational)
@@ -419,13 +414,8 @@ bool simplify_exprt::simplify_mod(exprt &expr)
       if(int_value0.has_value() && int_value1.has_value())
       {
         mp_integer result = *int_value0 % *int_value1;
-        exprt tmp=from_integer(result, expr.type());
-
-        if(tmp.is_not_nil())
-        {
-          expr.swap(tmp);
-          return false;
-        }
+        expr = from_integer(result, expr.type());
+        return false;
       }
     }
   }
@@ -517,7 +507,6 @@ bool simplify_exprt::simplify_plus(exprt &expr)
                          to_constant_expr(*it)))
             {
               *it=from_integer(0, it->type());
-              CHECK_RETURN(it->is_not_nil());
               result=false;
             }
           }
@@ -550,7 +539,6 @@ bool simplify_exprt::simplify_plus(exprt &expr)
       {
         *(itm->second)=from_integer(0, expr.type());
         *it=from_integer(0, expr.type());
-        CHECK_RETURN(it->is_not_nil());
         expr_map.erase(itm);
         result=false;
       }
@@ -577,7 +565,6 @@ bool simplify_exprt::simplify_plus(exprt &expr)
   if(operands.empty())
   {
     expr = from_integer(0, plus_expr.type());
-    CHECK_RETURN(expr.is_not_nil());
     return false;
   }
   else if(operands.size()==1)
@@ -637,9 +624,7 @@ bool simplify_exprt::simplify_minus(exprt &expr)
 
     if(operands[0]==operands[1])
     {
-      exprt zero = from_integer(0, minus_expr.type());
-      CHECK_RETURN(zero.is_not_nil());
-      expr=zero;
+      expr = from_integer(0, minus_expr.type());
       return false;
     }
   }
@@ -1230,12 +1215,7 @@ bool simplify_exprt::simplify_unary_minus(exprt &expr)
       if(!int_value.has_value())
         return true;
 
-      exprt tmp = from_integer(-*int_value, expr.type());
-
-      if(tmp.is_nil())
-        return true;
-
-      expr.swap(tmp);
+      expr = from_integer(-*int_value, expr.type());
 
       return false;
     }
@@ -1776,7 +1756,6 @@ bool simplify_exprt::simplify_inequality_constant(exprt &expr)
           {
             constant+=i;
             *it=from_integer(0, it->type());
-            CHECK_RETURN(it->is_not_nil());
             changed=true;
           }
         }


### PR DESCRIPTION
It is nowadays guarded by a PRECONDITION. Thus any use of .is_nil on the result
is trivially false and can safely be removed.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
