### PR TITLE
use goto_progamt::make_X API

### DIFF
--- a/jbmc/src/java_bytecode/convert_java_nondet.cpp
+++ b/jbmc/src/java_bytecode/convert_java_nondet.cpp
@@ -124,9 +124,8 @@ static std::pair<goto_programt::targett, bool> insert_nondet_init_code(
 
     // Insert an instruction declaring `aux_symbol` before `target`, being
     // careful to preserve jumps to `target`
-    goto_programt::instructiont decl_aux_symbol;
-    decl_aux_symbol.make_decl(code_declt(aux_symbol_expr));
-    decl_aux_symbol.source_location = source_loc;
+    goto_programt::instructiont decl_aux_symbol =
+      goto_programt::make_decl(code_declt(aux_symbol_expr), source_loc);
     goto_program.insert_before_swap(target, decl_aux_symbol);
 
     // Keep track of the new location of the instruction containing op.
@@ -142,10 +141,8 @@ static std::pair<goto_programt::targett, bool> insert_nondet_init_code(
         mode);
     goto_program.destructive_insert(target2, gen_nondet_init_instructions);
 
-    goto_programt::targett dead_aux_symbol = goto_program.insert_after(target2);
-    dead_aux_symbol->make_dead();
-    dead_aux_symbol->code = code_deadt(aux_symbol_expr);
-    dead_aux_symbol->source_location = source_loc;
+    goto_program.insert_after(
+      target2, goto_programt::make_dead(aux_symbol_expr, source_loc));
 
     // In theory target could have more than one operand which should be
     // replaced by convert_nondet, so we return target2 so that it

--- a/jbmc/src/java_bytecode/remove_instanceof.cpp
+++ b/jbmc/src/java_bytecode/remove_instanceof.cpp
@@ -211,7 +211,7 @@ bool remove_instanceoft::lower_instanceof(
     // GOTO programs before the target instruction without inserting into the
     // wrong basic block.
     goto_program.insert_before_swap(target);
-    target->make_skip();
+    *target = goto_programt::make_skip();
     // Actually alter the now-moved instruction:
     ++target;
   }

--- a/jbmc/src/java_bytecode/replace_java_nondet.cpp
+++ b/jbmc/src/java_bytecode/replace_java_nondet.cpp
@@ -271,7 +271,7 @@ static goto_programt::targett check_and_replace_target(
 
   std::for_each(
     target, target_instruction, [](goto_programt::instructiont &instr) {
-      instr.make_skip();
+      instr.turn_into_skip();
     });
 
   if(target_instruction->is_return())

--- a/src/analyses/escape_analysis.cpp
+++ b/src/analyses/escape_analysis.cpp
@@ -427,8 +427,7 @@ void escape_analysist::insert_cleanup(
       code.arguments().push_back(arg);
     }
 
-    location->make_function_call(code);
-    location->source_location=source_location;
+    *location = goto_programt::make_function_call(code, source_location);
   }
 }
 

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1801,7 +1801,7 @@ void goto_checkt::goto_check(
           i.source_location.get_property_class()!="error label") ||
          (!is_user_provided && !enable_built_in_assertions))
       {
-        i.make_skip();
+        i.turn_into_skip();
         did_something = true;
       }
     }
@@ -1809,7 +1809,7 @@ void goto_checkt::goto_check(
     {
       if(!enable_assumptions)
       {
-        i.make_skip();
+        i.turn_into_skip();
         did_something = true;
       }
     }

--- a/src/analyses/interval_analysis.cpp
+++ b/src/analyses/interval_analysis.cpp
@@ -79,7 +79,7 @@ void instrument_intervals(
     {
       goto_programt::targett t=i_it;
       goto_function.body.insert_before_swap(i_it);
-      t->make_assumption(conjunction(assertion));
+      *t = goto_programt::make_assumption(conjunction(assertion));
       i_it++; // goes to original instruction
       t->source_location=i_it->source_location;
     }

--- a/src/assembler/remove_asm.cpp
+++ b/src/assembler/remove_asm.cpp
@@ -495,7 +495,7 @@ void remove_asmt::process_function(
     {
       goto_programt tmp_dest;
       process_instruction(*it, tmp_dest);
-      it->make_skip();
+      it->turn_into_skip();
       did_something = true;
 
       goto_programt::targett next = it;

--- a/src/goto-analyzer/taint_analysis.cpp
+++ b/src/goto-analyzer/taint_analysis.cpp
@@ -166,21 +166,20 @@ void taint_analysist::instrument(
                   code_set_may.op0()=where;
                   code_set_may.op1()=
                     address_of_exprt(string_constantt(rule.taint));
-                  goto_programt::targett t=insert_after.add_instruction();
-                  t->make_other(code_set_may);
-                  t->source_location=instruction.source_location;
+                  insert_after.add(goto_programt::make_other(
+                    code_set_may, instruction.source_location));
                 }
                 break;
 
               case taint_parse_treet::rulet::SINK:
                 {
-                  goto_programt::targett t=insert_before.add_instruction();
                   binary_predicate_exprt get_may(
                     where,
                     "get_may",
                     address_of_exprt(string_constantt(rule.taint)));
-                  t->make_assertion(not_exprt(get_may));
-                  t->source_location=instruction.source_location;
+                  goto_programt::targett t =
+                    insert_before.add(goto_programt::make_assertion(
+                      not_exprt(get_may), instruction.source_location));
                   t->source_location.set_property_class(
                     "taint rule "+id2string(rule.id));
                   t->source_location.set_comment(rule.message);
@@ -194,9 +193,8 @@ void taint_analysist::instrument(
                   code_clear_may.op0()=where;
                   code_clear_may.op1()=
                     address_of_exprt(string_constantt(rule.taint));
-                  goto_programt::targett t=insert_after.add_instruction();
-                  t->make_other(code_clear_may);
-                  t->source_location=instruction.source_location;
+                  insert_after.add(goto_programt::make_other(
+                    code_clear_may, instruction.source_location));
                 }
                 break;
               }
@@ -285,14 +283,13 @@ bool taint_analysist::operator()(
            f_it->first!=goto_functionst::entry_point())
         {
           const symbolt &symbol = ns.lookup(f_it->first);
-          goto_programt::targett t=calls.add_instruction();
           const code_function_callt call(symbol.symbol_expr());
-          t->make_function_call(call);
-          calls.add_instruction()->make_goto(
-            end.instructions.begin(), true_exprt());
-          goto_programt::targett g=gotos.add_instruction();
-          g->make_goto(
-            t, side_effect_expr_nondett(bool_typet(), symbol.location));
+          goto_programt::targett t =
+            calls.add(goto_programt::make_function_call(call));
+          calls.add(
+            goto_programt::make_goto(end.instructions.begin(), true_exprt()));
+          gotos.add(goto_programt::make_goto(
+            t, side_effect_expr_nondett(bool_typet(), symbol.location)));
         }
 
       goto_functionst::goto_functiont &entry=

--- a/src/goto-cc/linker_script_merge.cpp
+++ b/src/goto-cc/linker_script_merge.cpp
@@ -469,9 +469,8 @@ int linker_script_merget::ls_data2instructions(
     // Instruction for start-address pointer in __CPROVER_initialize
     code_assignt start_assign(start_sym, array_start);
     start_assign.add_source_location()=start_loc;
-    goto_programt::instructiont start_assign_i;
-    start_assign_i.make_assignment(start_assign);
-    start_assign_i.source_location=start_loc;
+    goto_programt::instructiont start_assign_i =
+      goto_programt::make_assignment(start_assign, start_loc);
     initialize_instructions.push_front(start_assign_i);
 
     if(has_end) // Same for pointer to end of array
@@ -505,9 +504,8 @@ int linker_script_merget::ls_data2instructions(
 
       code_assignt end_assign(end_sym, array_end);
       end_assign.add_source_location()=end_loc;
-      goto_programt::instructiont end_assign_i;
-      end_assign_i.make_assignment(end_assign);
-      end_assign_i.source_location=end_loc;
+      goto_programt::instructiont end_assign_i =
+        goto_programt::make_assignment(end_assign, end_loc);
       initialize_instructions.push_front(end_assign_i);
     }
 
@@ -530,9 +528,8 @@ int linker_script_merget::ls_data2instructions(
     CHECK_RETURN(zi.has_value());
     code_assignt array_assign(array_expr, *zi);
     array_assign.add_source_location()=array_loc;
-    goto_programt::instructiont array_assign_i;
-    array_assign_i.make_assignment(array_assign);
-    array_assign_i.source_location=array_loc;
+    goto_programt::instructiont array_assign_i =
+      goto_programt::make_assignment(array_assign, array_loc);
     initialize_instructions.push_front(array_assign_i);
   }
 
@@ -583,9 +580,8 @@ int linker_script_merget::ls_data2instructions(
 
     code_assignt assign(lhs, rhs_tc);
     assign.add_source_location()=loc;
-    goto_programt::instructiont assign_i;
-    assign_i.make_assignment(assign);
-    assign_i.source_location=loc;
+    goto_programt::instructiont assign_i =
+      goto_programt::make_assignment(assign, loc);
     initialize_instructions.push_front(assign_i);
   }
   return 0;

--- a/src/goto-instrument/accelerate/overflow_instrumenter.cpp
+++ b/src/goto-instrument/accelerate/overflow_instrumenter.cpp
@@ -29,10 +29,9 @@ Author: Matt Lewis
 
 void overflow_instrumentert::add_overflow_checks()
 {
-  goto_programt::targett init_overflow=program.insert_before(
-      program.instructions.begin());
-  init_overflow->make_assignment();
-  init_overflow->code=code_assignt(overflow_var, false_exprt());
+  program.insert_before(
+    program.instructions.begin(),
+    goto_programt::make_assignment(code_assignt(overflow_var, false_exprt())));
 
   program.compute_location_numbers();
   checked.clear();

--- a/src/goto-instrument/accelerate/sat_path_enumerator.cpp
+++ b/src/goto-instrument/accelerate/sat_path_enumerator.cpp
@@ -252,9 +252,9 @@ void sat_path_enumeratort::build_fixed()
     exprt shadow=shadow_sym.symbol_expr();
     shadow_distinguishers[distinguisher]=shadow;
 
-    goto_programt::targett assign=fixed.insert_before(fixedt);
-    assign->make_assignment();
-    assign->code=code_assignt(shadow, false_exprt());
+    fixed.insert_before(
+      fixedt,
+      goto_programt::make_assignment(code_assignt(shadow, false_exprt())));
   }
 
   // We're going to iterate over the 2 programs in lockstep, which allows
@@ -269,7 +269,7 @@ void sat_path_enumeratort::build_fixed()
     if(loop.find(t)==loop.end())
     {
       // This instruction isn't part of the loop...  Just remove it.
-      fixedt->make_skip();
+      *fixedt = goto_programt::make_skip(fixedt->source_location);
       continue;
     }
 
@@ -280,9 +280,9 @@ void sat_path_enumeratort::build_fixed()
       exprt &distinguisher=d->second;
       exprt &shadow=shadow_distinguishers[distinguisher];
 
-      goto_programt::targett assign=fixed.insert_after(fixedt);
-      assign->make_assignment();
-      assign->code=code_assignt(shadow, true_exprt());
+      goto_programt::targett assign = fixed.insert_after(
+        fixedt,
+        goto_programt::make_assignment(code_assignt(shadow, true_exprt())));
 
       assign->swap(*fixedt);
       fixedt=assign;
@@ -346,7 +346,8 @@ void sat_path_enumeratort::build_fixed()
   {
     const exprt &shadow=shadow_distinguishers[expr];
 
-    fixed.insert_after(end)->make_assumption(equal_exprt(expr, shadow));
+    fixed.insert_after(
+      end, goto_programt::make_assumption(equal_exprt(expr, shadow)));
   }
 
   // Finally, let's remove all the skips we introduced and fix the

--- a/src/goto-instrument/branch.cpp
+++ b/src/goto-instrument/branch.cpp
@@ -50,16 +50,18 @@ void branch(
         // negate condition
         i_it->set_condition(boolean_negate(i_it->get_condition()));
 
-        goto_programt::targett t1=body.insert_after(i_it);
-        t1->make_function_call(
-          function_to_call(goto_model.symbol_table, id, "taken"));
+        goto_programt::targett t1 = body.insert_after(
+          i_it,
+          goto_programt::make_function_call(
+            function_to_call(goto_model.symbol_table, id, "taken")));
 
-        goto_programt::targett t2=body.insert_after(t1);
-        t2->make_goto(i_it->get_target(), true_exprt());
+        goto_programt::targett t2 = body.insert_after(
+          t1, goto_programt::make_goto(i_it->get_target(), true_exprt()));
 
-        goto_programt::targett t3=body.insert_after(t2);
-        t3->make_function_call(
-          function_to_call(goto_model.symbol_table, id, "not-taken"));
+        goto_programt::targett t3 = body.insert_after(
+          t2,
+          goto_programt::make_function_call(
+            function_to_call(goto_model.symbol_table, id, "not-taken")));
         i_it->targets.clear();
         i_it->targets.push_back(t3);
       }

--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -274,8 +274,9 @@ static void instrument_cover_goals(
            successor->is_assume() &&
            successor->guard == i_it->guard)
         {
-          successor->make_skip();
+          successor->turn_into_skip();
         }
+
         i_it->type = goto_program_instruction_typet::ASSUME;
       }
     }

--- a/src/goto-instrument/cover_instrument_branch.cpp
+++ b/src/goto-instrument/cover_instrument_branch.cpp
@@ -19,7 +19,7 @@ void cover_branch_instrumentert::instrument(
   const cover_blocks_baset &basic_blocks) const
 {
   if(is_non_cover_assertion(i_it))
-    i_it->make_skip();
+    i_it->turn_into_skip();
 
   if(i_it == goto_program.instructions.begin())
   {
@@ -29,9 +29,8 @@ void cover_branch_instrumentert::instrument(
 
     source_locationt source_location = i_it->source_location;
 
-    goto_programt::targett t = goto_program.insert_before(i_it);
-    t->make_assertion(false_exprt());
-    t->source_location = source_location;
+    goto_programt::targett t = goto_program.insert_before(
+      i_it, goto_programt::make_assertion(false_exprt(), source_location));
     initialize_source_location(t, comment, function_id);
   }
 
@@ -48,13 +47,11 @@ void cover_branch_instrumentert::instrument(
     source_locationt source_location = i_it->source_location;
 
     goto_program.insert_before_swap(i_it);
-    i_it->make_assertion(not_exprt(guard));
-    i_it->source_location = source_location;
+    *i_it = goto_programt::make_assertion(not_exprt(guard), source_location);
     initialize_source_location(i_it, true_comment, function_id);
 
     goto_program.insert_before_swap(i_it);
-    i_it->make_assertion(guard);
-    i_it->source_location = source_location;
+    *i_it = goto_programt::make_assertion(guard, source_location);
     initialize_source_location(i_it, false_comment, function_id);
 
     std::advance(i_it, 2);

--- a/src/goto-instrument/cover_instrument_condition.cpp
+++ b/src/goto-instrument/cover_instrument_condition.cpp
@@ -23,7 +23,7 @@ void cover_condition_instrumentert::instrument(
   const cover_blocks_baset &) const
 {
   if(is_non_cover_assertion(i_it))
-    i_it->make_skip();
+    i_it->turn_into_skip();
 
   // Conditions are all atomic predicates in the programs.
   if(!i_it->source_location.is_built_in())
@@ -38,14 +38,12 @@ void cover_condition_instrumentert::instrument(
 
       const std::string comment_t = "condition `" + c_string + "' true";
       goto_program.insert_before_swap(i_it);
-      i_it->make_assertion(c);
-      i_it->source_location = source_location;
+      *i_it = goto_programt::make_assertion(c, source_location);
       initialize_source_location(i_it, comment_t, function_id);
 
       const std::string comment_f = "condition `" + c_string + "' false";
       goto_program.insert_before_swap(i_it);
-      i_it->make_assertion(not_exprt(c));
-      i_it->source_location = source_location;
+      *i_it = goto_programt::make_assertion(not_exprt(c), source_location);
       initialize_source_location(i_it, comment_f, function_id);
     }
 

--- a/src/goto-instrument/cover_instrument_decision.cpp
+++ b/src/goto-instrument/cover_instrument_decision.cpp
@@ -22,7 +22,7 @@ void cover_decision_instrumentert::instrument(
   const cover_blocks_baset &) const
 {
   if(is_non_cover_assertion(i_it))
-    i_it->make_skip();
+    i_it->turn_into_skip();
 
   // Decisions are maximal Boolean combinations of conditions.
   if(!i_it->source_location.is_built_in())
@@ -37,14 +37,12 @@ void cover_decision_instrumentert::instrument(
 
       const std::string comment_t = "decision `" + d_string + "' true";
       goto_program.insert_before_swap(i_it);
-      i_it->make_assertion(d);
-      i_it->source_location = source_location;
+      *i_it = goto_programt::make_assertion(d, source_location);
       initialize_source_location(i_it, comment_t, function_id);
 
       const std::string comment_f = "decision `" + d_string + "' false";
       goto_program.insert_before_swap(i_it);
-      i_it->make_assertion(not_exprt(d));
-      i_it->source_location = source_location;
+      *i_it = goto_programt::make_assertion(not_exprt(d), source_location);
       initialize_source_location(i_it, comment_f, function_id);
     }
 

--- a/src/goto-instrument/cover_instrument_location.cpp
+++ b/src/goto-instrument/cover_instrument_location.cpp
@@ -21,7 +21,7 @@ void cover_location_instrumentert::instrument(
   const cover_blocks_baset &basic_blocks) const
 {
   if(is_non_cover_assertion(i_it))
-    i_it->make_skip();
+    i_it->turn_into_skip();
 
   const std::size_t block_nr = basic_blocks.block_of(i_it);
   const auto representative_instruction = basic_blocks.instruction_of(block_nr);
@@ -40,8 +40,7 @@ void cover_location_instrumentert::instrument(
       const std::string comment =
         "block " + b + " (lines " + source_lines + ")";
       goto_program.insert_before_swap(i_it);
-      i_it->make_assertion(false_exprt());
-      i_it->source_location = source_location;
+      *i_it = goto_programt::make_assertion(false_exprt(), source_location);
       initialize_source_location(i_it, comment, function_id);
       i_it++;
     }

--- a/src/goto-instrument/cover_instrument_mcdc.cpp
+++ b/src/goto-instrument/cover_instrument_mcdc.cpp
@@ -626,7 +626,7 @@ void cover_mcdc_instrumentert::instrument(
   const cover_blocks_baset &) const
 {
   if(is_non_cover_assertion(i_it))
-    i_it->make_skip();
+    i_it->turn_into_skip();
 
   // 1. Each entry and exit point is invoked
   // 2. Each decision takes every possible outcome
@@ -661,8 +661,7 @@ void cover_mcdc_instrumentert::instrument(
 
       std::string comment_t = description + " `" + p_string + "' true";
       goto_program.insert_before_swap(i_it);
-      i_it->make_assertion(not_exprt(p));
-      i_it->source_location = source_location;
+      *i_it = goto_programt::make_assertion(not_exprt(p), source_location);
       i_it->source_location.set_comment(comment_t);
       i_it->source_location.set(ID_coverage_criterion, coverage_criterion);
       i_it->source_location.set_property_class(property_class);
@@ -670,8 +669,7 @@ void cover_mcdc_instrumentert::instrument(
 
       std::string comment_f = description + " `" + p_string + "' false";
       goto_program.insert_before_swap(i_it);
-      i_it->make_assertion(p);
-      i_it->source_location = source_location;
+      *i_it = goto_programt::make_assertion(p, source_location);
       i_it->source_location.set_comment(comment_f);
       i_it->source_location.set(ID_coverage_criterion, coverage_criterion);
       i_it->source_location.set_property_class(property_class);
@@ -696,8 +694,7 @@ void cover_mcdc_instrumentert::instrument(
         "MC/DC independence condition `" + p_string + "'";
 
       goto_program.insert_before_swap(i_it);
-      i_it->make_assertion(not_exprt(p));
-      i_it->source_location = source_location;
+      *i_it = goto_programt::make_assertion(not_exprt(p), source_location);
       i_it->source_location.set_comment(description);
       i_it->source_location.set(ID_coverage_criterion, coverage_criterion);
       i_it->source_location.set_property_class(property_class);

--- a/src/goto-instrument/cover_instrument_other.cpp
+++ b/src/goto-instrument/cover_instrument_other.cpp
@@ -22,7 +22,7 @@ void cover_path_instrumentert::instrument(
   const cover_blocks_baset &) const
 {
   if(is_non_cover_assertion(i_it))
-    i_it->make_skip();
+    i_it->turn_into_skip();
 
   // TODO: implement
 }
@@ -68,7 +68,7 @@ void cover_cover_instrumentert::instrument(
     }
   }
   else if(is_non_cover_assertion(i_it))
-    i_it->make_skip();
+    i_it->turn_into_skip();
 }
 
 void cover_instrument_end_of_function(
@@ -82,7 +82,7 @@ void cover_instrument_end_of_function(
   const std::string &comment =
     "additional goal to ensure reachability of end of function";
   goto_program.insert_before_swap(if_it);
-  if_it->make_assertion(false_exprt());
+  *if_it = goto_programt::make_assertion(false_exprt());
   if_it->source_location.set_comment(comment);
   if_it->source_location.set_property_class("reachability_constraint");
   if_it->source_location.set_function(function_id);

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -590,16 +590,12 @@ void dump_ct::cleanup_decl(
   }
 
   goto_programt tmp;
-  goto_programt::targett t=tmp.add_instruction(DECL);
-  t->code=decl;
+  tmp.add(goto_programt::make_decl(decl.symbol()));
 
   if(value.is_not_nil())
-  {
-    t=tmp.add_instruction(ASSIGN);
-    t->code=code_assignt(decl.op0(), value);
-  }
+    tmp.add(goto_programt::make_assignment(code_assignt(decl.op0(), value)));
 
-  tmp.add_instruction(END_FUNCTION);
+  tmp.add(goto_programt::make_end_function());
 
   std::unordered_set<irep_idt> typedef_names;
   for(const auto &td : typedef_map)

--- a/src/goto-instrument/full_slicer.cpp
+++ b/src/goto-instrument/full_slicer.cpp
@@ -343,7 +343,9 @@ void full_slicert::operator()(
         const cfgt::entryt &e=cfg.entry_map[i_it];
         if(!i_it->is_end_function() && // always retained
            !cfg[e].node_required)
-          i_it->make_skip();
+        {
+          i_it->turn_into_skip();
+        }
 #ifdef DEBUG_FULL_SLICERT
         else
         {

--- a/src/goto-instrument/function.cpp
+++ b/src/goto-instrument/function.cpp
@@ -87,10 +87,10 @@ void function_enter(
     // patch in a call to `id' at the entry point
     goto_programt &body=f_it->second.body;
 
-    goto_programt::targett t=
-      body.insert_before(body.instructions.begin());
-    t->make_function_call(
-      function_to_call(goto_model.symbol_table, id, f_it->first));
+    body.insert_before(
+      body.instructions.begin(),
+      goto_programt::make_function_call(
+        function_to_call(goto_model.symbol_table, id, f_it->first)));
   }
 }
 
@@ -115,14 +115,15 @@ void function_exit(
     // make sure we have END_OF_FUNCTION
     if(body.instructions.empty() ||
        !body.instructions.back().is_end_function())
-      body.add_instruction(END_FUNCTION);
+    {
+      body.add(goto_programt::make_end_function());
+    }
 
     Forall_goto_program_instructions(i_it, body)
     {
       if(i_it->is_return())
       {
-        goto_programt::instructiont call;
-        call.make_function_call(
+        goto_programt::instructiont call = goto_programt::make_function_call(
           function_to_call(goto_model.symbol_table, id, f_it->first));
         body.insert_before_swap(i_it, call);
 
@@ -149,8 +150,7 @@ void function_exit(
 
     if(!has_return)
     {
-      goto_programt::instructiont call;
-      call.make_function_call(
+      goto_programt::instructiont call = goto_programt::make_function_call(
         function_to_call(goto_model.symbol_table, id, f_it->first));
       body.insert_before_swap(last, call);
     }

--- a/src/goto-instrument/interrupt.cpp
+++ b/src/goto-instrument/interrupt.cpp
@@ -107,12 +107,12 @@ static void interrupt(
       goto_programt::targett t_call=goto_program.insert_after(t_goto);
       goto_programt::targett t_orig=goto_program.insert_after(t_call);
 
-      t_goto->make_goto(
-        t_orig, side_effect_expr_nondett(bool_typet(), source_location));
-      t_goto->source_location=source_location;
+      *t_goto = goto_programt::make_goto(
+        t_orig,
+        side_effect_expr_nondett(bool_typet(), source_location),
+        source_location);
 
-      t_call->make_function_call(isr_call);
-      t_call->source_location=source_location;
+      *t_call = goto_programt::make_function_call(isr_call, source_location);
 
       t_orig->swap(original_instruction);
 
@@ -125,20 +125,20 @@ static void interrupt(
       goto_programt::targett t_orig=i_it;
       t_orig++;
 
-      goto_programt::targett t_goto=goto_program.insert_after(i_it);
-      goto_programt::targett t_call=goto_program.insert_after(t_goto);
-
       const source_locationt &source_location=i_it->source_location;
 
       code_function_callt isr_call(interrupt_handler);
       isr_call.add_source_location()=source_location;
 
-      t_goto->make_goto(
-        t_orig, side_effect_expr_nondett(bool_typet(), source_location));
-      t_goto->source_location=source_location;
+      goto_programt::targett t_goto = goto_program.insert_after(
+        i_it,
+        goto_programt::make_goto(
+          t_orig,
+          side_effect_expr_nondett(bool_typet(), source_location),
+          source_location));
 
-      t_call->make_function_call(isr_call);
-      t_call->source_location=source_location;
+      goto_programt::targett t_call = goto_program.insert_after(
+        t_goto, goto_programt::make_function_call(isr_call, source_location));
 
       i_it=t_call; // the for loop already counts us up
     }

--- a/src/goto-instrument/k_induction.cpp
+++ b/src/goto-instrument/k_induction.cpp
@@ -118,7 +118,7 @@ void k_inductiont::process_loop(
     {
       if(t->is_assert())
         break;
-      t->make_skip();
+      t->turn_into_skip();
     }
 
     // now turn any assertions in iterations 0..k-1 into assumptions

--- a/src/goto-instrument/nondet_static.cpp
+++ b/src/goto-instrument/nondet_static.cpp
@@ -91,12 +91,12 @@ void nondet_static(
       if(is_nondet_initializable_static(sym, ns))
       {
         const goto_programt::instructiont original_instruction = instruction;
-        i_it->make_assignment();
-        i_it->code = code_assignt(
-          sym,
-          side_effect_expr_nondett(
-            sym.type(), original_instruction.source_location));
-        i_it->source_location = original_instruction.source_location;
+        *i_it = goto_programt::make_assignment(
+          code_assignt(
+            sym,
+            side_effect_expr_nondett(
+              sym.type(), original_instruction.source_location)),
+          original_instruction.source_location);
       }
     }
     else if(instruction.is_function_call())

--- a/src/goto-instrument/race_check.cpp
+++ b/src/goto-instrument/race_check.cpp
@@ -187,7 +187,8 @@ static void race_check(
       goto_programt::instructiont original_instruction;
       original_instruction.swap(instruction);
 
-      instruction.make_skip();
+      instruction =
+        goto_programt::make_skip(original_instruction.source_location);
       i_it++;
 
       // now add assignments for what is written -- set
@@ -237,10 +238,11 @@ static void race_check(
         if(!is_shared(ns, e_it->second.symbol_expr))
           continue;
 
-        goto_programt::targett t=goto_program.insert_before(i_it);
-
-        t->make_assertion(w_guards.get_assertion(e_it->second));
-        t->source_location=original_instruction.source_location;
+        goto_programt::targett t = goto_program.insert_before(
+          i_it,
+          goto_programt::make_assertion(
+            w_guards.get_assertion(e_it->second),
+            original_instruction.source_location));
         t->source_location.set_comment(comment(e_it->second, false));
         i_it=++t;
       }
@@ -250,10 +252,11 @@ static void race_check(
         if(!is_shared(ns, e_it->second.symbol_expr))
           continue;
 
-        goto_programt::targett t=goto_program.insert_before(i_it);
-
-        t->make_assertion(w_guards.get_assertion(e_it->second));
-        t->source_location=original_instruction.source_location;
+        goto_programt::targett t = goto_program.insert_before(
+          i_it,
+          goto_programt::make_assertion(
+            w_guards.get_assertion(e_it->second),
+            original_instruction.source_location));
         t->source_location.set_comment(comment(e_it->second, true));
         i_it=++t;
       }

--- a/src/goto-instrument/reachability_slicer.cpp
+++ b/src/goto-instrument/reachability_slicer.cpp
@@ -338,7 +338,10 @@ void reachability_slicert::slice(goto_functionst &goto_functions)
         if(
           !e.reaches_assertion && !e.reachable_from_assertion &&
           !i_it->is_end_function())
-          i_it->make_assumption(false_exprt());
+        {
+          *i_it = goto_programt::make_assumption(
+            false_exprt(), i_it->source_location);
+        }
       }
 
       // replace unreachable code by skip

--- a/src/goto-instrument/skip_loops.cpp
+++ b/src/goto-instrument/skip_loops.cpp
@@ -45,9 +45,9 @@ static bool skip_loops(
     ++next;
     assert(next!=goto_program.instructions.end());
 
-    goto_programt::targett g=goto_program.insert_before(loop_head);
-    g->make_goto(next, true_exprt());
-    g->source_location=loop_head->source_location;
+    goto_program.insert_before(
+      loop_head,
+      goto_programt::make_goto(next, true_exprt(), loop_head->source_location));
 
     ++l_it;
   }

--- a/src/goto-instrument/splice_call.cpp
+++ b/src/goto-instrument/splice_call.cpp
@@ -71,11 +71,10 @@ bool splice_call(
   }
   goto_programt::const_targett start=
     caller_fun->second.body.instructions.begin();
-  goto_programt::targett g=
-    caller_fun->second.body.insert_before(start);
   const code_function_callt splice_call(
     ns.lookup(callee_fun->first).symbol_expr());
-  g->make_function_call(splice_call);
+  caller_fun->second.body.insert_before(
+    start, goto_programt::make_function_call(splice_call));
 
   // update counters etc.
   goto_functions.update();

--- a/src/goto-instrument/stack_depth.cpp
+++ b/src/goto-instrument/stack_depth.cpp
@@ -51,28 +51,25 @@ void stack_depth(
   goto_programt::targett first=goto_program.instructions.begin();
 
   binary_relation_exprt guard(symbol, ID_le, max_depth);
-  goto_programt::targett assert_ins=goto_program.insert_before(first);
-  assert_ins->make_assertion(guard);
-  assert_ins->source_location=first->source_location;
+  goto_programt::targett assert_ins = goto_program.insert_before(
+    first, goto_programt::make_assertion(guard, first->source_location));
 
   assert_ins->source_location.set_comment(
     "Stack depth exceeds "+std::to_string(i_depth));
   assert_ins->source_location.set_property_class("stack-depth");
 
-  goto_programt::targett plus_ins=goto_program.insert_before(first);
-  plus_ins->make_assignment();
-  plus_ins->code=code_assignt(symbol,
-      plus_exprt(symbol, from_integer(1, symbol.type())));
-  plus_ins->source_location=first->source_location;
+  goto_program.insert_before(
+    first,
+    goto_programt::make_assignment(
+      code_assignt(symbol, plus_exprt(symbol, from_integer(1, symbol.type()))),
+      first->source_location));
 
   goto_programt::targett last=--goto_program.instructions.end();
   assert(last->is_end_function());
 
-  goto_programt::instructiont minus_ins;
-  minus_ins.make_assignment();
-  minus_ins.code=code_assignt(symbol,
-      minus_exprt(symbol, from_integer(1, symbol.type())));
-  minus_ins.source_location=last->source_location;
+  goto_programt::instructiont minus_ins = goto_programt::make_assignment(
+    code_assignt(symbol, minus_exprt(symbol, from_integer(1, symbol.type()))),
+    last->source_location);
 
   goto_program.insert_before_swap(last, minus_ins);
 }
@@ -101,9 +98,10 @@ void stack_depth(
 
   goto_programt &init=i_it->second.body;
   goto_programt::targett first=init.instructions.begin();
-  goto_programt::targett it=init.insert_before(first);
-  it->make_assignment();
-  it->code=code_assignt(sym, from_integer(0, sym.type()));
+  init.insert_before(
+    first,
+    goto_programt::make_assignment(
+      code_assignt(sym, from_integer(0, sym.type()))));
   // no suitable value for source location -- omitted
 
   // update counters etc.

--- a/src/goto-instrument/thread_instrumentation.cpp
+++ b/src/goto-instrument/thread_instrumentation.cpp
@@ -46,9 +46,8 @@ void thread_exit_instrumentation(goto_programt &goto_program)
     "get_may",
     address_of_exprt(mutex_locked_string));
 
-  end->make_assertion(not_exprt(get_may));
+  *end = goto_programt::make_assertion(not_exprt(get_may), source_location);
 
-  end->source_location=source_location;
   end->source_location.set_comment("mutexes must not be locked on thread exit");
 }
 
@@ -100,15 +99,13 @@ void mutex_init_instrumentation(
 
       if(code_assign.lhs().type()==lock_type)
       {
-        goto_programt::targett t=goto_program.insert_after(it);
-
         const code_function_callt call(
           f_it->second.symbol_expr(),
           {address_of_exprt(code_assign.lhs()),
            address_of_exprt(string_constantt("mutex-init"))});
 
-        t->make_function_call(call);
-        t->source_location=it->source_location;
+        goto_program.insert_after(
+          it, goto_programt::make_function_call(call, it->source_location));
       }
     }
   }

--- a/src/goto-instrument/undefined_functions.cpp
+++ b/src/goto-instrument/undefined_functions.cpp
@@ -58,7 +58,7 @@ void undefined_function_abort_path(goto_modelt &goto_model)
       if(entry->second.body_available())
         continue;
 
-      ins.make_assumption(false_exprt());
+      ins = goto_programt::make_assumption(false_exprt(), ins.source_location);
       ins.source_location.set_comment(
         "`"+id2string(function)+"' is undefined");
     }

--- a/src/goto-instrument/wmm/goto2graph.cpp
+++ b/src/goto-instrument/wmm/goto2graph.cpp
@@ -1358,7 +1358,8 @@ bool instrumentert::is_cfg_spurious(const event_grapht::critical_cyclet &cyc)
 
         if(!target_in_cycle)
         {
-          int_it->make_assertion(false_exprt());
+          *int_it = goto_programt::make_assertion(
+            false_exprt(), int_it->source_location);
           break;
         }
       }

--- a/src/goto-instrument/wmm/shared_buffers.cpp
+++ b/src/goto-instrument/wmm/shared_buffers.cpp
@@ -1126,8 +1126,7 @@ void shared_bufferst::cfg_visitort::weak_memory(
           original_instruction.source_location;
 
         // ATOMIC_BEGIN: we make the whole thing atomic
-        instruction.make_atomic_begin();
-        instruction.source_location=source_location;
+        instruction = goto_programt::make_atomic_begin(source_location);
         i_it++;
 
         // we first perform (non-deterministically) up to 2 writes for
@@ -1261,9 +1260,8 @@ void shared_bufferst::cfg_visitort::weak_memory(
           }
 
         // ATOMIC_END
-        i_it=goto_program.insert_before(i_it);
-        i_it->make_atomic_end();
-        i_it->source_location=source_location;
+        i_it = goto_program.insert_before(
+          i_it, goto_programt::make_atomic_end(source_location));
         i_it++;
 
         i_it--; // the for loop already counts us up
@@ -1288,8 +1286,7 @@ void shared_bufferst::cfg_visitort::weak_memory(
         original_instruction.source_location;
 
       // ATOMIC_BEGIN
-      instruction.make_atomic_begin();
-      instruction.source_location=source_location;
+      instruction = goto_programt::make_atomic_begin(source_location);
       i_it++;
 
       // does it for all the previous statements
@@ -1302,9 +1299,8 @@ void shared_bufferst::cfg_visitort::weak_memory(
       }
 
       // ATOMIC_END
-      i_it=goto_program.insert_before(i_it);
-      i_it->make_atomic_end();
-      i_it->source_location=source_location;
+      i_it = goto_program.insert_before(
+        i_it, goto_programt::make_atomic_end(source_location));
       i_it++;
 
       i_it--; // the for loop already counts us up
@@ -1312,7 +1308,7 @@ void shared_bufferst::cfg_visitort::weak_memory(
     else if(is_lwfence(instruction, ns))
     {
       // po -- remove the lwfence
-      i_it->make_skip();
+      *i_it = goto_programt::make_skip(i_it->source_location);
     }
     else if(instruction.is_function_call())
     {

--- a/src/goto-instrument/wmm/weak_memory.cpp
+++ b/src/goto-instrument/wmm/weak_memory.cpp
@@ -87,10 +87,9 @@ void introduce_temporaries(
 
       symbol_exprt symbol_expr=new_symbol.symbol_expr();
 
-      goto_programt::instructiont new_i;
-      new_i.make_assignment();
-      new_i.code=code_assignt(symbol_expr, instruction.guard);
-      new_i.source_location=instruction.source_location;
+      goto_programt::instructiont new_i = goto_programt::make_assignment(
+        code_assignt(symbol_expr, instruction.guard),
+        instruction.source_location);
 
       // replace guard
       instruction.guard=symbol_expr;

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -683,13 +683,12 @@ void goto_convertt::do_function_call_symbol(
       throw 0;
     }
 
-    goto_programt::targett t=dest.add_instruction(ASSUME);
-    t->guard=arguments.front();
-    t->source_location=function.source_location();
-    t->source_location.set("user-provided", true);
-
     // let's double-check the type of the argument
-    t->guard = typecast_exprt::conditional_cast(t->guard, bool_typet());
+    goto_programt::targett t = dest.add(goto_programt::make_assumption(
+      typecast_exprt::conditional_cast(arguments.front(), bool_typet()),
+      function.source_location()));
+
+    t->source_location.set("user-provided", true);
 
     if(lhs.is_not_nil())
     {
@@ -708,9 +707,9 @@ void goto_convertt::do_function_call_symbol(
       throw 0;
     }
 
-    goto_programt::targett t=dest.add_instruction(ASSERT);
-    t->guard=false_exprt();
-    t->source_location=function.source_location();
+    goto_programt::targett t = dest.add(
+      goto_programt::make_assertion(false_exprt(), function.source_location()));
+
     t->source_location.set("user-provided", true);
     t->source_location.set_property_class(ID_assertion);
 
@@ -723,9 +722,8 @@ void goto_convertt::do_function_call_symbol(
 
     // __VERIFIER_error has abort() semantics, even if no assertions
     // are being checked
-    goto_programt::targett a=dest.add_instruction(ASSUME);
-    a->guard=false_exprt();
-    a->source_location=function.source_location();
+    goto_programt::targett a = dest.add(goto_programt::make_assumption(
+      false_exprt(), function.source_location()));
     a->source_location.set("user-provided", true);
   }
   else if(
@@ -740,16 +738,14 @@ void goto_convertt::do_function_call_symbol(
       throw 0;
     }
 
-    goto_programt::targett t=dest.add_instruction(ASSERT);
-    t->guard=arguments.front();
-    t->source_location=function.source_location();
+    // let's double-check the type of the argument
+    goto_programt::targett t = dest.add(goto_programt::make_assertion(
+      typecast_exprt::conditional_cast(arguments.front(), bool_typet()),
+      function.source_location()));
     t->source_location.set("user-provided", true);
     t->source_location.set_property_class(ID_assertion);
     t->source_location.set_comment(
-      "assertion " + id2string(from_expr(ns, identifier, t->guard)));
-
-    // let's double-check the type of the argument
-    t->guard = typecast_exprt::conditional_cast(t->guard, bool_typet());
+      "assertion " + from_expr(ns, identifier, arguments.front()));
 
     if(lhs.is_not_nil())
     {
@@ -775,9 +771,10 @@ void goto_convertt::do_function_call_symbol(
     const irep_idt description=
       get_string_constant(arguments[1]);
 
-    goto_programt::targett t=dest.add_instruction(ASSERT);
-    t->guard=arguments[0];
-    t->source_location=function.source_location();
+    // let's double-check the type of the argument
+    goto_programt::targett t = dest.add(goto_programt::make_assertion(
+      typecast_exprt::conditional_cast(arguments[0], bool_typet()),
+      function.source_location()));
 
     if(is_precondition)
     {
@@ -792,9 +789,6 @@ void goto_convertt::do_function_call_symbol(
     }
 
     t->source_location.set_comment(description);
-
-    // let's double-check the type of the argument
-    t->guard = typecast_exprt::conditional_cast(t->guard, bool_typet());
 
     if(lhs.is_not_nil())
     {
@@ -980,9 +974,9 @@ void goto_convertt::do_function_call_symbol(
     const irep_idt description=
       "assertion "+id2string(get_string_constant(arguments[0]));
 
-    goto_programt::targett t=dest.add_instruction(ASSERT);
-    t->guard=false_exprt();
-    t->source_location=function.source_location();
+    goto_programt::targett t = dest.add(
+      goto_programt::make_assertion(false_exprt(), function.source_location()));
+
     t->source_location.set("user-provided", true);
     t->source_location.set_property_class(ID_assertion);
     t->source_location.set_comment(description);
@@ -1018,9 +1012,9 @@ void goto_convertt::do_function_call_symbol(
       throw 0;
     }
 
-    goto_programt::targett t=dest.add_instruction(ASSERT);
-    t->guard=false_exprt();
-    t->source_location=function.source_location();
+    goto_programt::targett t = dest.add(
+      goto_programt::make_assertion(false_exprt(), function.source_location()));
+
     t->source_location.set("user-provided", true);
     t->source_location.set_property_class(ID_assertion);
     t->source_location.set_comment(description);
@@ -1052,9 +1046,9 @@ void goto_convertt::do_function_call_symbol(
       description="assertion";
     }
 
-    goto_programt::targett t=dest.add_instruction(ASSERT);
-    t->guard=false_exprt();
-    t->source_location=function.source_location();
+    goto_programt::targett t = dest.add(
+      goto_programt::make_assertion(false_exprt(), function.source_location()));
+
     t->source_location.set("user-provided", true);
     t->source_location.set_property_class(ID_assertion);
     t->source_location.set_comment(description);

--- a/src/goto-programs/goto_convert_exceptions.cpp
+++ b/src/goto-programs/goto_convert_exceptions.cpp
@@ -93,9 +93,8 @@ void goto_convertt::convert_try_catch(
     code.find_source_location());
 
   // add the CATCH-push instruction to 'dest'
-  goto_programt::targett catch_push_instruction=dest.add_instruction();
-  catch_push_instruction->make_catch();
-  catch_push_instruction->source_location=code.source_location();
+  goto_programt::targett catch_push_instruction =
+    dest.add(goto_programt::make_catch(code.source_location()));
 
   code_push_catcht push_catch_code;
 
@@ -112,9 +111,9 @@ void goto_convertt::convert_try_catch(
   convert(to_code(code.op0()), dest, mode);
 
   // add the CATCH-pop to the end of the 'try' block
-  goto_programt::targett catch_pop_instruction=dest.add_instruction();
-  catch_pop_instruction->make_catch();
-  catch_pop_instruction->code=code_pop_catcht();
+  goto_programt::targett catch_pop_instruction =
+    dest.add(goto_programt::make_catch());
+  catch_pop_instruction->code = code_pop_catcht();
 
   // add a goto to the end of the 'try' block
   dest.add(goto_programt::make_goto(end_target));

--- a/src/goto-programs/goto_convert_function_call.cpp
+++ b/src/goto-programs/goto_convert_function_call.cpp
@@ -120,8 +120,7 @@ void goto_convertt::do_function_call_if(
 
   // do the z label
   goto_programt tmp_z;
-  goto_programt::targett z=tmp_z.add_instruction();
-  z->make_skip();
+  goto_programt::targett z = tmp_z.add(goto_programt::make_skip());
 
   // y: g();
   goto_programt tmp_y;
@@ -135,8 +134,8 @@ void goto_convertt::do_function_call_if(
     y=tmp_y.instructions.begin();
 
   // v: if(!c) goto y;
-  v->make_goto(y, boolean_negate(function.cond()));
-  v->source_location=function.cond().source_location();
+  *v = goto_programt::make_goto(
+    y, boolean_negate(function.cond()), function.cond().source_location());
 
   // w: f();
   goto_programt tmp_w;
@@ -147,7 +146,7 @@ void goto_convertt::do_function_call_if(
     tmp_w.add_instruction(SKIP);
 
   // x: goto z;
-  x->make_goto(z, true_exprt());
+  *x = goto_programt::make_goto(z, true_exprt());
 
   dest.destructive_append(tmp_v);
   dest.destructive_append(tmp_w);

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -132,12 +132,10 @@ void goto_convert_functionst::add_return(
 
   #endif
 
-  const side_effect_expr_nondett rhs(f.type.return_type(), source_location);
+  side_effect_expr_nondett rhs(f.type.return_type(), source_location);
 
-  goto_programt::targett t=f.body.add_instruction();
-  t->make_return();
-  t->code=code_returnt(rhs);
-  t->source_location=source_location;
+  f.body.add(
+    goto_programt::make_return(code_returnt(std::move(rhs)), source_location));
 }
 
 void goto_convert_functionst::convert_function(
@@ -195,13 +193,12 @@ void goto_convert_functionst::convert_function(
       has_prefix(id2string(identifier), "__VERIFIER_atomic_"))
   {
     goto_programt::instructiont a_begin;
-    a_begin.make_atomic_begin();
+    a_begin = goto_programt::make_atomic_begin();
     a_begin.source_location=f.body.instructions.front().source_location;
     f.body.insert_before_swap(f.body.instructions.begin(), a_begin);
 
-    goto_programt::targett a_end=f.body.add_instruction();
-    a_end->make_atomic_end();
-    a_end->source_location=end_location;
+    goto_programt::targett a_end =
+      f.body.add(goto_programt::make_atomic_end(end_location));
 
     Forall_goto_program_instructions(i_it, f.body)
     {

--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -376,7 +376,7 @@ void goto_inlinet::expand_function_call(
               << eom;
 
     if(force_full)
-      target->make_skip();
+      target->turn_into_skip();
 
     return;
   }
@@ -390,7 +390,7 @@ void goto_inlinet::expand_function_call(
     warning() << "missing function `" << identifier << "' is ignored" << eom;
 
     if(force_full)
-      target->make_skip();
+      target->turn_into_skip();
 
     return;
   }

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -389,6 +389,7 @@ public:
     void complete_goto(targett _target)
     {
       PRECONDITION(type == INCOMPLETE_GOTO);
+      code.make_nil();
       targets.push_back(_target);
       type = GOTO;
     }
@@ -914,10 +915,23 @@ public:
   }
 
   static instructiont make_incomplete_goto(
+    const exprt &_cond,
+    const source_locationt &l = source_locationt::nil())
+  {
+    PRECONDITION(_cond.type().id() == ID_bool);
+    return instructiont(
+      static_cast<const codet &>(get_nil_irep()),
+      l,
+      INCOMPLETE_GOTO,
+      _cond,
+      {});
+  }
+
+  static instructiont make_incomplete_goto(
     const code_gotot &_code,
     const source_locationt &l = source_locationt::nil())
   {
-    return instructiont(_code, l, INCOMPLETE_GOTO, nil_exprt(), {});
+    return instructiont(_code, l, INCOMPLETE_GOTO, true_exprt(), {});
   }
 
   static instructiont make_goto(

--- a/src/goto-programs/instrument_preconditions.cpp
+++ b/src/goto-programs/instrument_preconditions.cpp
@@ -119,8 +119,7 @@ void instrument_preconditions(
           goto_program.insert_before_swap(it);
           exprt instance = p->get_condition();
           r(instance);
-          it->make_assertion(instance);
-          it->source_location=source_location;
+          *it = goto_programt::make_assertion(instance, source_location);
           it->source_location.set_property_class(ID_precondition_instance);
           it->source_location.set_comment(p->source_location.get_comment());
           it++;

--- a/src/goto-programs/mm_io.cpp
+++ b/src/goto-programs/mm_io.cpp
@@ -69,8 +69,7 @@ void mm_io(
             mm_io_r,
             {typecast_exprt(d.pointer(), pt), typecast_exprt(size, st)});
           goto_function.body.insert_before_swap(it);
-          it->make_function_call(fc);
-          it->source_location=source_location;
+          *it = goto_programt::make_function_call(fc, source_location);
           it++;
         }
       }
@@ -92,8 +91,7 @@ void mm_io(
              typecast_exprt(size, st),
              typecast_exprt(a.rhs(), vt)});
           goto_function.body.insert_before_swap(it);
-          it->make_function_call(fc);
-          it->source_location=source_location;
+          *it = goto_programt::make_function_call(fc, source_location);
           it++;
         }
       }

--- a/src/goto-programs/parameter_assignments.cpp
+++ b/src/goto-programs/parameter_assignments.cpp
@@ -67,14 +67,12 @@ void parameter_assignmentst::do_function_calls(
 
         if(nr<function_call.arguments().size())
         {
-          goto_programt::targett t=tmp.add_instruction();
-          t->make_assignment();
-          t->source_location=i_it->source_location;
           const symbolt &lhs_symbol=ns.lookup(p_identifier);
           symbol_exprt lhs=lhs_symbol.symbol_expr();
           exprt rhs = typecast_exprt::conditional_cast(
             function_call.arguments()[nr], lhs.type());
-          t->code=code_assignt(lhs, rhs);
+          tmp.add(goto_programt::make_assignment(
+            code_assignt(lhs, rhs), i_it->source_location));
         }
       }
 

--- a/src/goto-programs/remove_calls_no_body.cpp
+++ b/src/goto-programs/remove_calls_no_body.cpp
@@ -35,9 +35,8 @@ void remove_calls_no_bodyt::remove_call_no_body(
   // pointer dereferencing or the like
   for(const exprt &argument : arguments)
   {
-    goto_programt::targett t = tmp.add_instruction();
-    t->make_other(code_expressiont(argument));
-    t->source_location = target->source_location;
+    tmp.add(goto_programt::make_other(
+      code_expressiont(argument), target->source_location));
   }
 
   // return value

--- a/src/goto-programs/remove_returns.cpp
+++ b/src/goto-programs/remove_returns.cpp
@@ -129,10 +129,11 @@ void remove_returnst::replace_returns(
         code_assignt assignment(*return_symbol, i_it->code.op0());
 
         // now turn the `return' into `assignment'
-        i_it->make_assignment(assignment);
+        *i_it =
+          goto_programt::make_assignment(assignment, i_it->source_location);
       }
       else
-        i_it->make_skip();
+        i_it->turn_into_skip();
     }
   }
 }
@@ -361,8 +362,8 @@ bool remove_returnst::restore_returns(
 
       // replace "fkt#return_value=x;" by "return x;"
       const exprt rhs = assign.rhs();
-      i_it->make_return();
-      i_it->code = code_returnt(rhs);
+      *i_it =
+        goto_programt::make_return(code_returnt(rhs), i_it->source_location);
       did_something = true;
     }
   }

--- a/src/goto-programs/remove_unreachable.cpp
+++ b/src/goto-programs/remove_unreachable.cpp
@@ -48,7 +48,7 @@ void remove_unreachable(goto_programt &goto_program)
     if(reachable.find(it)==reachable.end() &&
        !it->is_end_function())
     {
-      it->make_skip();
+      it->turn_into_skip();
       did_something = true;
     }
   }

--- a/src/goto-programs/set_properties.cpp
+++ b/src/goto-programs/set_properties.cpp
@@ -34,7 +34,7 @@ void set_properties(
       property_set.find(property_id);
 
     if(c_it==property_set.end())
-      it->make_skip();
+      it->turn_into_skip();
     else
       property_set.erase(c_it);
   }

--- a/src/goto-programs/slice_global_inits.cpp
+++ b/src/goto-programs/slice_global_inits.cpp
@@ -92,7 +92,9 @@ void slice_global_inits(goto_modelt &goto_model)
 
       if(!has_prefix(id2string(id), CPROVER_PREFIX) &&
          symbols.find(id)==symbols.end())
-        i_it->make_skip();
+      {
+        i_it->turn_into_skip();
+      }
     }
   }
 

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -298,10 +298,9 @@ void string_abstractiont::make_decl_and_def(goto_programt &dest,
   // may still be nil (structs, then assignments have been done already)
   if(val.is_not_nil())
   {
-    goto_programt::targett assignment1=dest.add_instruction();
-    assignment1->make_assignment();
-    assignment1->source_location=ref_instr->source_location;
-    assignment1->code=code_assignt(sym_expr, val);
+    goto_programt::targett assignment1 =
+      dest.add(goto_programt::make_assignment(
+        code_assignt(sym_expr, val), ref_instr->source_location));
     assignment1->code.add_source_location()=ref_instr->source_location;
   }
 }
@@ -357,10 +356,9 @@ exprt string_abstractiont::make_val_or_dummy_rec(goto_programt &dest,
 
         member_exprt member(symbol.symbol_expr(), it2->get_name(), it2->type());
 
-        goto_programt::targett assignment1=dest.add_instruction();
-        assignment1->make_assignment();
-        assignment1->source_location=ref_instr->source_location;
-        assignment1->code=code_assignt(member, sym_expr);
+        goto_programt::targett assignment1 =
+          dest.add(goto_programt::make_assignment(
+            code_assignt(member, sym_expr), ref_instr->source_location));
         assignment1->code.add_source_location()=ref_instr->source_location;
       }
 
@@ -404,10 +402,8 @@ symbol_exprt string_abstractiont::add_dummy_symbol_and_value(
   symbol_exprt sym_expr=new_symbol.symbol_expr();
 
   // make sure it is declared before the recursive call
-  goto_programt::targett decl=dest.add_instruction();
-  decl->make_decl();
-  decl->source_location=ref_instr->source_location;
-  decl->code=code_declt(sym_expr);
+  goto_programt::targett decl =
+    dest.add(goto_programt::make_decl(sym_expr, ref_instr->source_location));
   decl->code.add_source_location()=ref_instr->source_location;
 
   // set the value - may be nil
@@ -429,10 +425,9 @@ symbol_exprt string_abstractiont::add_dummy_symbol_and_value(
 
   if(new_symbol.value.is_not_nil())
   {
-    goto_programt::targett assignment1=dest.add_instruction();
-    assignment1->make_assignment();
-    assignment1->source_location=ref_instr->source_location;
-    assignment1->code=code_assignt(sym_expr, new_symbol.value);
+    goto_programt::targett assignment1 =
+      dest.add(goto_programt::make_assignment(
+        code_assignt(sym_expr, new_symbol.value), ref_instr->source_location));
     assignment1->code.add_source_location()=ref_instr->source_location;
   }
 
@@ -1025,9 +1020,8 @@ bool string_abstractiont::build_symbol_constant(
         string_struct);
 
       // initialization
-      goto_programt::targett assignment1=initialization.add_instruction();
-      assignment1->make_assignment();
-      assignment1->code=code_assignt(new_symbol.symbol_expr(), value);
+      initialization.add(goto_programt::make_assignment(
+        code_assignt(new_symbol.symbol_expr(), value)));
     }
 
     symbol_table.insert(std::move(new_symbol));
@@ -1079,9 +1073,8 @@ goto_programt::targett string_abstractiont::abstract_pointer_assign(
   if(lhs.type().id()==ID_pointer && !unknown)
   {
     goto_programt::instructiont assignment;
-    assignment.make_assignment();
-    assignment.source_location=target->source_location;
-    assignment.code=code_assignt(new_lhs, new_rhs);
+    assignment = goto_programt::make_assignment(
+      code_assignt(new_lhs, new_rhs), target->source_location);
     assignment.code.add_source_location()=target->source_location;
     dest.insert_before_swap(target, assignment);
     ++target;
@@ -1173,16 +1166,12 @@ goto_programt::targett string_abstractiont::char_assign(
     i1.is_not_nil(),
     "failed to create is_zero-component for the left-hand-side");
 
-  goto_programt::targett assignment1=tmp.add_instruction();
-  assignment1->make_assignment();
-  assignment1->source_location=target->source_location;
-  assignment1->code=code_assignt(i1, true_exprt());
+  goto_programt::targett assignment1 = tmp.add(goto_programt::make_assignment(
+    code_assignt(i1, true_exprt()), target->source_location));
   assignment1->code.add_source_location()=target->source_location;
 
-  goto_programt::targett assignment2=tmp.add_instruction();
-  assignment2->make_assignment();
-  assignment2->source_location=target->source_location;
-  assignment2->code=code_assignt(lhs, rhs);
+  goto_programt::targett assignment2 = tmp.add(goto_programt::make_assignment(
+    code_assignt(lhs, rhs), target->source_location));
   assignment2->code.add_source_location()=target->source_location;
 
   move_lhs_arithmetic(
@@ -1256,11 +1245,11 @@ goto_programt::targett string_abstractiont::value_assignments_if(
   goto_programt::targett else_target=tmp.add_instruction(SKIP);
   goto_programt::targett out_target=tmp.add_instruction(SKIP);
 
-  goto_else->source_location=target->source_location;
-  goto_else->make_goto(else_target, boolean_negate(rhs.cond()));
+  *goto_else = goto_programt::make_goto(
+    else_target, boolean_negate(rhs.cond()), target->source_location);
 
-  goto_out->source_location=target->source_location;
-  goto_out->make_goto(out_target, true_exprt());
+  *goto_out =
+    goto_programt::make_goto(out_target, true_exprt(), target->source_location);
 
   else_target->source_location=target->source_location;
 

--- a/unit/goto-programs/goto_program_assume.cpp
+++ b/unit/goto-programs/goto_program_assume.cpp
@@ -38,7 +38,7 @@ SCENARIO(
     symbol_table.insert(symbol);
     symbol_table.insert(fun_symbol);
     namespacet ns(symbol_table);
-    instructions.back().make_assertion(x_le_10);
+    instructions.back() = goto_programt::make_assertion(x_le_10);
 
     WHEN("Instruction has no targets")
     {

--- a/unit/goto-programs/goto_program_dead.cpp
+++ b/unit/goto-programs/goto_program_dead.cpp
@@ -33,10 +33,7 @@ SCENARIO(
 
     goto_functiont goto_function;
     auto &instructions = goto_function.body.instructions;
-    instructions.emplace_back(goto_program_instruction_typet::DEAD);
-    code_deadt removal(var_a);
-    instructions.back().make_dead();
-    instructions.back().code = removal;
+    instructions.emplace_back(goto_programt::make_dead(var_a));
     symbol_table.insert(fun_symbol);
 
     WHEN("Removing known symbol")

--- a/unit/goto-programs/goto_program_declaration.cpp
+++ b/unit/goto-programs/goto_program_declaration.cpp
@@ -33,9 +33,7 @@ SCENARIO(
 
     goto_functiont goto_function;
     auto &instructions = goto_function.body.instructions;
-    instructions.emplace_back(goto_program_instruction_typet::DECL);
-    code_declt declaration(var_a);
-    instructions.back().make_decl(declaration);
+    instructions.emplace_back(goto_programt::make_decl(var_a));
     symbol_table.insert(fun_symbol);
 
     WHEN("Declaring known symbol")

--- a/unit/goto-programs/goto_program_function_call.cpp
+++ b/unit/goto-programs/goto_program_function_call.cpp
@@ -53,7 +53,7 @@ SCENARIO(
     WHEN("Return type matches")
     {
       code_function_callt function_call(var_a, fun_foo, {});
-      instructions.back().make_function_call(function_call);
+      instructions.back() = goto_programt::make_function_call(function_call);
       REQUIRE(instructions.back().code.get_statement() == ID_function_call);
 
       THEN("The consistency check succeeds")
@@ -66,7 +66,7 @@ SCENARIO(
     WHEN("Return type differs from function type")
     {
       code_function_callt function_call(var_b, fun_foo, {});
-      instructions.back().make_function_call(function_call);
+      instructions.back() = goto_programt::make_function_call(function_call);
 
       THEN("The consistency check fails")
       {

--- a/unit/goto-programs/goto_program_goto_target.cpp
+++ b/unit/goto-programs/goto_program_goto_target.cpp
@@ -33,11 +33,10 @@ SCENARIO(
 
     goto_functiont goto_function;
     auto &instructions = goto_function.body.instructions;
-    instructions.emplace_back(goto_program_instruction_typet::ASSERT);
-    instructions.back().make_assertion(x_le_10);
+    instructions.emplace_back(goto_programt::make_assertion(x_le_10));
 
-    instructions.emplace_back(goto_program_instruction_typet::GOTO);
-    instructions.back().make_goto(instructions.begin(), true_exprt());
+    instructions.emplace_back(
+      goto_programt::make_goto(instructions.begin(), true_exprt()));
 
     symbol.type = type1;
     symbol_table.insert(symbol);

--- a/unit/goto-programs/goto_program_symbol_type_table_consistency.cpp
+++ b/unit/goto-programs/goto_program_symbol_type_table_consistency.cpp
@@ -34,8 +34,7 @@ SCENARIO(
 
     goto_functiont goto_function;
     auto &instructions = goto_function.body.instructions;
-    instructions.emplace_back(goto_program_instruction_typet::ASSERT);
-    instructions.back().make_assertion(x_le_10);
+    instructions.emplace_back(goto_programt::make_assertion(x_le_10));
 
     symbol_table.insert(function_symbol);
     WHEN("Symbol table has the right symbol type")

--- a/unit/goto-programs/goto_program_table_consistency.cpp
+++ b/unit/goto-programs/goto_program_table_consistency.cpp
@@ -33,8 +33,7 @@ SCENARIO(
 
     goto_functiont goto_function;
     auto &instructions = goto_function.body.instructions;
-    instructions.emplace_back(goto_program_instruction_typet::ASSERT);
-    instructions.back().make_assertion(x_le_10);
+    instructions.emplace_back(goto_programt::make_assertion(x_le_10));
 
     symbol_table.insert(function_symbol);
     WHEN("Symbol table has the right symbol")


### PR DESCRIPTION
This prevents partial construction of `instructiont`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
