### PR TITLE
initialize three members of instructiont

### DIFF
--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -423,10 +423,7 @@ public:
       : code(static_cast<const codet &>(get_nil_irep())),
         source_location(static_cast<const source_locationt &>(get_nil_irep())),
         type(_type),
-        guard(true_exprt()),
-        location_number(0),
-        loop_number(0),
-        target_number(nil_target)
+        guard(true_exprt())
     {
     }
 
@@ -463,14 +460,14 @@ public:
     /// A globally unique number to identify a program location.
     /// It's guaranteed to be ordered in program order within
     /// one goto_program.
-    unsigned location_number;
+    unsigned location_number = 0;
 
     /// Number unique per function to identify loops
-    unsigned loop_number;
+    unsigned loop_number = 0;
 
     /// A number to identify branch targets.
     /// This is \ref nil_target if it's not a target.
-    unsigned target_number;
+    unsigned target_number = nil_target;
 
     /// Returns true if the instruction is a backwards branch.
     bool is_backwards_goto() const


### PR DESCRIPTION
This prevents that we rely on the undefined values of uninitialized memory.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [X] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
