### PR TITLE
introduce gcc_asm_gcct

### DIFF
--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -124,7 +124,7 @@ protected:
   virtual void typecheck_code(codet &code);
 
   virtual void typecheck_assign(codet &expr);
-  virtual void typecheck_asm(codet &code);
+  virtual void typecheck_asm(code_asmt &code);
   virtual void typecheck_block(code_blockt &code);
   virtual void typecheck_break(codet &code);
   virtual void typecheck_continue(codet &code);

--- a/src/ansi-c/c_typecheck_code.cpp
+++ b/src/ansi-c/c_typecheck_code.cpp
@@ -76,7 +76,7 @@ void c_typecheck_baset::typecheck_code(codet &code)
   {
   }
   else if(statement==ID_asm)
-    typecheck_asm(code);
+    typecheck_asm(to_code_asm(code));
   else if(statement==ID_start_thread)
     typecheck_start_thread(code);
   else if(statement==ID_gcc_local_label)
@@ -133,28 +133,28 @@ void c_typecheck_baset::typecheck_code(codet &code)
   }
 }
 
-void c_typecheck_baset::typecheck_asm(codet &code)
+void c_typecheck_baset::typecheck_asm(code_asmt &code)
 {
-  const irep_idt flavor=to_code_asm(code).get_flavor();
+  const irep_idt flavor = code.get_flavor();
 
   if(flavor==ID_gcc)
   {
     // These have 5 operands.
-    // The first parameter is a string.
-    // Parameters 1, 2, 3, 4 are lists of expressions.
+    // The first operand is a string.
+    // Operands 1, 2, 3, 4 are lists of expressions.
 
-    // Parameter 1: OutputOperands
-    // Parameter 2: InputOperands
-    // Parameter 3: Clobbers
-    // Parameter 4: GotoLabels
+    // Operand 1: OutputOperands
+    // Operand 2: InputOperands
+    // Operand 3: Clobbers
+    // Operand 4: GotoLabels
 
-    assert(code.operands().size()==5);
+    auto &code_asm_gcc = to_code_asm_gcc(code);
 
-    typecheck_expr(code.op0());
+    typecheck_expr(code_asm_gcc.asm_text());
 
-    for(std::size_t i=1; i<code.operands().size(); i++)
+    for(std::size_t i = 1; i < code_asm_gcc.operands().size(); i++)
     {
-      exprt &list=code.operands()[i];
+      exprt &list = code_asm_gcc.operands()[i];
       Forall_operands(it, list)
         typecheck_expr(*it);
     }

--- a/src/assembler/remove_asm.cpp
+++ b/src/assembler/remove_asm.cpp
@@ -47,13 +47,13 @@ protected:
     goto_programt::instructiont &instruction,
     goto_programt &dest);
 
-  void process_instruction_gcc(const code_asmt &, goto_programt &dest);
+  void process_instruction_gcc(const code_asm_gcct &, goto_programt &dest);
 
   void process_instruction_msc(const code_asmt &, goto_programt &dest);
 
   void gcc_asm_function_call(
     const irep_idt &function_base_name,
-    const code_asmt &code,
+    const code_asm_gcct &code,
     goto_programt &dest);
 
   void msc_asm_function_call(
@@ -71,7 +71,7 @@ protected:
 /// \param dest: Goto program to append the function call to
 void remove_asmt::gcc_asm_function_call(
   const irep_idt &function_base_name,
-  const code_asmt &code,
+  const code_asm_gcct &code,
   goto_programt &dest)
 {
   irep_idt function_identifier = function_base_name;
@@ -81,7 +81,7 @@ void remove_asmt::gcc_asm_function_call(
   const typet void_pointer = pointer_type(empty_typet());
 
   // outputs
-  forall_operands(it, code.op1())
+  forall_operands(it, code.outputs())
   {
     if(it->operands().size() == 2)
     {
@@ -91,7 +91,7 @@ void remove_asmt::gcc_asm_function_call(
   }
 
   // inputs
-  forall_operands(it, code.op2())
+  forall_operands(it, code.inputs())
   {
     if(it->operands().size() == 2)
     {
@@ -197,7 +197,7 @@ void remove_asmt::process_instruction(
   const irep_idt &flavor = code.get_flavor();
 
   if(flavor == ID_gcc)
-    process_instruction_gcc(code, dest);
+    process_instruction_gcc(to_code_asm_gcc(code), dest);
   else if(flavor == ID_msc)
     process_instruction_msc(code, dest);
   else
@@ -210,10 +210,10 @@ void remove_asmt::process_instruction(
 /// \param code: The inline assembly code statement to translate
 /// \param dest: The goto program to append the new instructions to
 void remove_asmt::process_instruction_gcc(
-  const code_asmt &code,
+  const code_asm_gcct &code,
   goto_programt &dest)
 {
-  const irep_idt &i_str = to_string_constant(code.op0()).get_value();
+  const irep_idt &i_str = to_string_constant(code.asm_text()).get_value();
 
   std::istringstream str(id2string(i_str));
   assembler_parser.clear();

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -7922,9 +7922,7 @@ bool Parser::rGCCAsmStatement(codet &statement)
   if(lex.get_token(tk)!=TOK_GCC_ASM)
     return false;
 
-  statement=codet(ID_asm);
-  statement.set(ID_flavor, ID_gcc);
-  statement.operands().resize(5); // always has 5 operands
+  statement = code_asm_gcct();
   set_location(statement, tk);
 
   if(lex.LookAhead(0)==TOK_VOLATILE)

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -1589,6 +1589,101 @@ inline const code_asmt &to_code_asm(const codet &code)
   return static_cast<const code_asmt &>(code);
 }
 
+/// \ref codet representation of an inline assembler statement,
+/// for the gcc flavor.
+class code_asm_gcct : public code_asmt
+{
+public:
+  code_asm_gcct()
+  {
+    set_flavor(ID_gcc);
+    operands().resize(5);
+  }
+
+  exprt &asm_text()
+  {
+    return op0();
+  }
+
+  const exprt &asm_text() const
+  {
+    return op0();
+  }
+
+  exprt &outputs()
+  {
+    return op1();
+  }
+
+  const exprt &outputs() const
+  {
+    return op1();
+  }
+
+  exprt &inputs()
+  {
+    return op2();
+  }
+
+  const exprt &inputs() const
+  {
+    return op2();
+  }
+
+  exprt &clobbers()
+  {
+    return op3();
+  }
+
+  const exprt &clobbers() const
+  {
+    return op3();
+  }
+
+  exprt &labels()
+  {
+    return operands()[4];
+  }
+
+  const exprt &labels() const
+  {
+    return operands()[4];
+  }
+
+protected:
+  using code_asmt::op0;
+  using code_asmt::op1;
+  using code_asmt::op2;
+  using code_asmt::op3;
+};
+
+template <>
+inline bool can_cast_expr<code_asm_gcct>(const exprt &base)
+{
+  return detail::can_cast_code_impl(base, ID_asm);
+}
+
+// to_code_asm_gcc only checks the code statement, so no validate_expr is
+// provided for code_asmt
+
+inline code_asm_gcct &to_code_asm_gcc(codet &code)
+{
+  PRECONDITION(code.get_statement() == ID_asm);
+  PRECONDITION(to_code_asm(code).get_flavor() == ID_gcc);
+  DATA_INVARIANT(
+    code.operands().size() == 5, "code_asm_gcc must have give operands");
+  return static_cast<code_asm_gcct &>(code);
+}
+
+inline const code_asm_gcct &to_code_asm_gcc(const codet &code)
+{
+  PRECONDITION(code.get_statement() == ID_asm);
+  PRECONDITION(to_code_asm(code).get_flavor() == ID_gcc);
+  DATA_INVARIANT(
+    code.operands().size() == 5, "code_asm_gcc must have give operands");
+  return static_cast<const code_asm_gcct &>(code);
+}
+
 /// \ref codet representation of an expression statement.
 /// It has one operand, which is the expression it stores.
 class code_expressiont:public codet


### PR DESCRIPTION
This will prevent direct accesses to operands of `codet`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
