### PR TITLE
Use $1 rather than \1 to refer to regex matching group

### DIFF
--- a/regression/test.pl
+++ b/regression/test.pl
@@ -74,7 +74,7 @@ sub test($$$$$$$$$$) {
   foreach my $key (@keys) {
     my $value = $defines->{$key};
     $options =~ s/(\$$key$|\$$key )/$value /g;
-    $options =~ s/\$$key([:;])/$value\1/g; # Variables in --classpath are separated by (semi)colons
+    $options =~ s/\$$key([:;])/$value$1/g; # Variables in --classpath are separated by (semi)colons
   }
   if (scalar @keys) {
     foreach my $word (split(/\s/, $options)) {


### PR DESCRIPTION
At least Perl 5.26 prints a warning each time; some quick Googling suggests that \n should be used
on the *left* of a match-and-replace to refer to an earlier match, and $n should be used on the right,
though \n is acceptable for historical reasons.