### PR TITLE
Same field in both goto_statet and goto_symex_statet

### DIFF
--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -141,7 +141,6 @@ public:
   /// for error traces even after symbolic execution has finished.
   symbol_tablet symbol_table;
 
-  symex_targett::sourcet source;
   symex_target_equationt *symex_target;
 
   // we remember all L1 renamings


### PR DESCRIPTION
In a recent refactor 'source' got moved to a parent class and as I couldn't see any immediate reason for it to shadow the field I guess it was left here accidentally.

If there is a reason, just say and I'll close the PR.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
