### PR TITLE
Clearly separate sharing and non-sharing implementation of irept 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -174,6 +174,33 @@ jobs:
         - CCACHE_CPP2=yes
       script: echo "Not running any tests for a debug build."
 
+    # cmake build using g++-7, enable NAMED_SUB_IS_FORWARD_LIST
+    - stage: Test different OS/CXX/Flags
+      os: linux
+      sudo: false
+      compiler: gcc
+      cache: ccache
+      env:
+        - BUILD_SYSTEM=cmake
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+            - jq
+      before_install:
+        - mkdir bin
+        - ln -s /usr/bin/gcc-7 bin/gcc
+        - ln -s /usr/bin/g++-7 bin/g++
+      install:
+        - ccache -z
+        - ccache --max-size=1G
+        - cmake -H. -Bbuild '-DCMAKE_BUILD_TYPE=Release' '-DCMAKE_CXX_COMPILER=/usr/bin/g++-7' '-DCMAKE_CXX_FLAGS=-DNAMED_SUB_IS_FORWARD_LIST'
+        - git submodule update --init --recursive
+        - cmake --build build -- -j4
+      script: (cd build; bin/unit "[core][irept]")
+
     # cmake build using g++-7, enable CMAKE_USE_CUDD
     - stage: Test different OS/CXX/Flags
       os: linux

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -303,19 +303,13 @@ public:
   /// Used to refer to this class from derived classes
   using tree_implementationt = non_sharing_treet;
 
-  explicit non_sharing_treet(const irep_idt &_id)
+  explicit non_sharing_treet(irep_idt _id) : data(std::move(_id))
   {
-    write().data = _id;
   }
 
-  non_sharing_treet(
-    const irep_idt &_id,
-    const named_subt &_named_sub,
-    const subt &_sub)
+  non_sharing_treet(irep_idt _id, named_subt _named_sub, subt _sub)
+    : data(std::move(_id), std::move(_named_sub), std::move(_sub))
   {
-    write().data = _id;
-    write().named_sub = _named_sub;
-    write().sub = _sub;
   }
 
   non_sharing_treet() = default;


### PR DESCRIPTION
The current implementation of irept contains preprocessor instructions which makes it difficult to read, in particular with regards to SHARING.
This pull request clearly separates the sharing and non-sharing implementation, and inheritance is used for easily switching between the two and not duplicate code.
This results in more structured code, and I think much easier to read, understand.
Ultimately this could allow having sharing and none sharing structures in the same compiled binary (for instance we could experiment with using sharing for exprt but not typet, which is impossible for now).  

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
