### PR TITLE
Correctly truncate error traces

### DIFF
--- a/regression/cbmc/multiple-goto-traces/main.c
+++ b/regression/cbmc/multiple-goto-traces/main.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+
+int main(int argc, char **argv)
+{
+  assert(4 != argc);
+  argc++;
+  argc--;
+  assert(argc >= 1);
+  assert(argc != 4);
+  argc++;
+  argc--;
+  assert(argc + 1 != 5);
+  return 0;
+}

--- a/regression/cbmc/multiple-goto-traces/test.desc
+++ b/regression/cbmc/multiple-goto-traces/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--trace
+activate-multi-line-match
+EXIT=10
+SIGNAL=0
+VERIFICATION FAILED
+Trace for main\.assertion\.1:(\n.*){16}  assertion 4 \!= argc(\n.*){5}Trace for main\.assertion\.3:(\n.*){30}  assertion argc != 4(\n.*){5}Trace for main\.assertion\.4:(\n.*){44}  assertion argc \+ 1 != 5
+\*\* 3 of 4 failed
+--
+^warning: ignoring
+--
+We have one counterexample violating multiple properties.
+Make sure the traces are correctly truncated.

--- a/src/goto-checker/bmc_util.cpp
+++ b/src/goto-checker/bmc_util.cpp
@@ -50,6 +50,17 @@ void build_error_trace(
   build_goto_trace(symex_target_equation, prop_conv, ns, goto_trace);
 }
 
+ssa_step_predicatet
+ssa_step_matches_failing_property(const irep_idt &property_id)
+{
+  return [property_id](
+           symex_target_equationt::SSA_stepst::const_iterator step,
+           const prop_convt &prop_conv) {
+    return step->is_assert() && step->get_property_id() == property_id &&
+           prop_conv.l_get(step->cond_literal).is_false();
+  };
+}
+
 void output_error_trace(
   const goto_tracet &goto_trace,
   const namespacet &ns,

--- a/src/goto-checker/bmc_util.cpp
+++ b/src/goto-checker/bmc_util.cpp
@@ -32,6 +32,11 @@ Author: Daniel Kroening, Peter Schrammel
 
 #include "symex_bmc.h"
 
+void message_building_error_trace(messaget &log)
+{
+  log.status() << "Building error trace" << messaget::eom;
+}
+
 void build_error_trace(
   goto_tracet &goto_trace,
   const namespacet &ns,
@@ -39,8 +44,8 @@ void build_error_trace(
   const prop_convt &prop_conv,
   ui_message_handlert &ui_message_handler)
 {
-  messaget msg(ui_message_handler);
-  msg.status() << "Building error trace" << messaget::eom;
+  messaget log(ui_message_handler);
+  message_building_error_trace(log);
 
   build_goto_trace(symex_target_equation, prop_conv, ns, goto_trace);
 }

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -15,6 +15,7 @@ Author: Daniel Kroening, Peter Schrammel
 #include <memory>
 
 #include <goto-programs/safety_checker.h>
+#include <goto-symex/build_goto_trace.h>
 #include <goto-symex/path_storage.h>
 
 #include "properties.h"
@@ -34,6 +35,11 @@ void convert_symex_target_equation(
   symex_target_equationt &,
   prop_convt &,
   message_handlert &);
+
+/// Returns a function that checks whether an SSA step is an assertion
+/// with \p property_id. Usually used for `build_goto_trace`.
+ssa_step_predicatet
+ssa_step_matches_failing_property(const irep_idt &property_id);
 
 /// Outputs a message that an error trace is being built
 void message_building_error_trace(messaget &);

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -35,6 +35,9 @@ void convert_symex_target_equation(
   prop_convt &,
   message_handlert &);
 
+/// Outputs a message that an error trace is being built
+void message_building_error_trace(messaget &);
+
 void build_error_trace(
   goto_tracet &,
   const namespacet &,

--- a/src/goto-checker/cover_goals_verifier_with_trace_storage.h
+++ b/src/goto-checker/cover_goals_verifier_with_trace_storage.h
@@ -14,6 +14,7 @@ Author: Daniel Kroening, Peter Schrammel
 
 #include "goto_verifier.h"
 
+#include "bmc_util.h"
 #include "cover_goals_report_util.h"
 #include "goto_trace_storage.h"
 #include "incremental_goto_checker.h"
@@ -41,7 +42,8 @@ public:
           incremental_goto_checkert::resultt::progresst::DONE)
     {
       // we've got a trace; store it and link it to the covered goals
-      (void)traces.insert_all(incremental_goto_checker.build_trace());
+      message_building_error_trace(log);
+      (void)traces.insert_all(incremental_goto_checker.build_full_trace());
 
       ++iterations;
     }

--- a/src/goto-checker/goto_trace_provider.h
+++ b/src/goto-checker/goto_trace_provider.h
@@ -12,6 +12,8 @@ Author: Daniel Kroening, Peter Schrammel
 #ifndef CPROVER_GOTO_CHECKER_GOTO_TRACE_PROVIDER_H
 #define CPROVER_GOTO_CHECKER_GOTO_TRACE_PROVIDER_H
 
+#include <util/irep.h>
+
 class goto_tracet;
 class namespacet;
 
@@ -20,8 +22,15 @@ class namespacet;
 class goto_trace_providert
 {
 public:
-  /// Builds and returns a trace
-  virtual goto_tracet build_trace() const = 0;
+  /// Builds and returns the complete trace
+  virtual goto_tracet build_full_trace() const = 0;
+
+  /// Builds and returns the trace up to the first failed property
+  virtual goto_tracet build_shortest_trace() const = 0;
+
+  /// Builds and returns the trace for the FAILed property
+  /// with the given \p property_id
+  virtual goto_tracet build_trace(const irep_idt &property_id) const = 0;
 
   /// Returns the namespace associated with the traces
   virtual const namespacet &get_namespace() const = 0;

--- a/src/goto-checker/multi_path_symex_checker.cpp
+++ b/src/goto-checker/multi_path_symex_checker.cpp
@@ -109,20 +109,44 @@ operator()(propertiest &properties)
   return result;
 }
 
-goto_tracet multi_path_symex_checkert::build_trace() const
+goto_tracet multi_path_symex_checkert::build_full_trace() const
+{
+  goto_tracet goto_trace;
+  build_goto_trace(
+    equation,
+    equation.SSA_steps.end(),
+    property_decider.get_solver(),
+    ns,
+    goto_trace);
+
+  return goto_trace;
+}
+
+goto_tracet multi_path_symex_checkert::build_shortest_trace() const
 {
   if(options.get_bool_option("beautify"))
   {
     counterexample_beautificationt()(
       dynamic_cast<boolbvt &>(property_decider.get_solver()), equation);
   }
+
   goto_tracet goto_trace;
-  ::build_error_trace(
-    goto_trace,
-    ns,
+  build_goto_trace(equation, property_decider.get_solver(), ns, goto_trace);
+
+  return goto_trace;
+}
+
+goto_tracet
+multi_path_symex_checkert::build_trace(const irep_idt &property_id) const
+{
+  goto_tracet goto_trace;
+  build_goto_trace(
     equation,
+    ssa_step_matches_failing_property(property_id),
     property_decider.get_solver(),
-    ui_message_handler);
+    ns,
+    goto_trace);
+
   return goto_trace;
 }
 

--- a/src/goto-checker/multi_path_symex_checker.h
+++ b/src/goto-checker/multi_path_symex_checker.h
@@ -39,7 +39,9 @@ public:
   ///   in P_i. Such additional properties will be ignored.
   resultt operator()(propertiest &) override;
 
-  goto_tracet build_trace() const override;
+  goto_tracet build_full_trace() const override;
+  goto_tracet build_shortest_trace() const override;
+  goto_tracet build_trace(const irep_idt &) const override;
   const namespacet &get_namespace() const override;
 
   void output_error_witness(const goto_tracet &) override;

--- a/src/goto-checker/single_path_symex_checker.cpp
+++ b/src/goto-checker/single_path_symex_checker.cpp
@@ -110,7 +110,20 @@ operator()(propertiest &properties)
   return result;
 }
 
-goto_tracet single_path_symex_checkert::build_trace() const
+goto_tracet single_path_symex_checkert::build_full_trace() const
+{
+  goto_tracet goto_trace;
+  build_goto_trace(
+    property_decider->get_equation(),
+    property_decider->get_equation().SSA_steps.end(),
+    property_decider->get_solver(),
+    ns,
+    goto_trace);
+
+  return goto_trace;
+}
+
+goto_tracet single_path_symex_checkert::build_shortest_trace() const
 {
   if(options.get_bool_option("beautify"))
   {
@@ -118,13 +131,28 @@ goto_tracet single_path_symex_checkert::build_trace() const
       dynamic_cast<boolbvt &>(property_decider->get_solver()),
       property_decider->get_equation());
   }
+
   goto_tracet goto_trace;
-  ::build_error_trace(
-    goto_trace,
-    ns,
+  build_goto_trace(
     property_decider->get_equation(),
     property_decider->get_solver(),
-    ui_message_handler);
+    ns,
+    goto_trace);
+
+  return goto_trace;
+}
+
+goto_tracet
+single_path_symex_checkert::build_trace(const irep_idt &property_id) const
+{
+  goto_tracet goto_trace;
+  build_goto_trace(
+    property_decider->get_equation(),
+    ssa_step_matches_failing_property(property_id),
+    property_decider->get_solver(),
+    ns,
+    goto_trace);
+
   return goto_trace;
 }
 

--- a/src/goto-checker/single_path_symex_checker.h
+++ b/src/goto-checker/single_path_symex_checker.h
@@ -34,7 +34,9 @@ public:
 
   resultt operator()(propertiest &) override;
 
-  goto_tracet build_trace() const override;
+  goto_tracet build_full_trace() const override;
+  goto_tracet build_shortest_trace() const override;
+  goto_tracet build_trace(const irep_idt &) const override;
   const namespacet &get_namespace() const override;
 
   void output_error_witness(const goto_tracet &) override;

--- a/src/goto-checker/stop_on_fail_verifier.h
+++ b/src/goto-checker/stop_on_fail_verifier.h
@@ -50,7 +50,8 @@ public:
 
     case resultt::FAIL:
     {
-      goto_tracet goto_trace = incremental_goto_checker.build_trace();
+      message_building_error_trace(log);
+      goto_tracet goto_trace = incremental_goto_checker.build_shortest_trace();
       output_error_trace(
         goto_trace,
         incremental_goto_checker.get_namespace(),


### PR DESCRIPTION
Fixes a regression introduced in #3795:
If a single counterexample violates several properties then the traces need to be correctly truncated for each property and printed in the same order as the properties are reported.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
