### PR TITLE
irept deserialisation: avoid unnecessary construct/destruct

### DIFF
--- a/src/goto-programs/read_bin_goto_object.cpp
+++ b/src/goto-programs/read_bin_goto_object.cpp
@@ -35,9 +35,10 @@ static bool read_bin_goto_object_v5(
   {
     symbolt sym;
 
-    irepconverter.reference_convert(in, sym.type);
-    irepconverter.reference_convert(in, sym.value);
-    irepconverter.reference_convert(in, sym.location);
+    sym.type = static_cast<const typet &>(irepconverter.reference_convert(in));
+    sym.value = static_cast<const exprt &>(irepconverter.reference_convert(in));
+    sym.location = static_cast<const source_locationt &>(
+      irepconverter.reference_convert(in));
 
     sym.name = irepconverter.read_string_ref(in);
     sym.module = irepconverter.read_string_ref(in);
@@ -99,12 +100,14 @@ static bool read_bin_goto_object_v5(
       goto_programt::targett itarget = f.body.add_instruction();
       goto_programt::instructiont &instruction=*itarget;
 
-      irepconverter.reference_convert(in, instruction.code);
-      irepconverter.reference_convert(in, instruction.source_location);
+      instruction.code =
+        static_cast<const codet &>(irepconverter.reference_convert(in));
+      instruction.source_location = static_cast<const source_locationt &>(
+        irepconverter.reference_convert(in));
       instruction.type = (goto_program_instruction_typet)
                               irepconverter.read_gb_word(in);
-      instruction.guard.make_nil();
-      irepconverter.reference_convert(in, instruction.guard);
+      instruction.guard =
+        static_cast<const exprt &>(irepconverter.reference_convert(in));
       instruction.target_number = irepconverter.read_gb_word(in);
       if(instruction.is_target() &&
          rev_target_map.insert(

--- a/src/util/irep_serialization.h
+++ b/src/util/irep_serialization.h
@@ -61,7 +61,7 @@ public:
     clear();
   };
 
-  void reference_convert(std::istream &, irept &irep);
+  const irept &reference_convert(std::istream &);
   void reference_convert(const irept &irep, std::ostream &);
 
   irep_idt read_string_ref(std::istream &);
@@ -77,7 +77,7 @@ private:
   std::vector<char> read_buffer;
 
   void write_irep(std::ostream &, const irept &irep);
-  void read_irep(std::istream &, irept &irep);
+  irept read_irep(std::istream &);
 };
 
 #endif // CPROVER_UTIL_IREP_SERIALIZATION_H


### PR DESCRIPTION
Do not allocate empty irept elements to incrementally replace them, but instead
construct them bottom-up. When running on SV-COMP's ReachSafety-ECA, these
changes avoid 805,690,478 calls to irept::detach and 554,309,582 calls to
irept::remove_ref in read_irep. In reference_convert, the number of
irept::remove_ref calls is approximately halved (from 1,209,156,897 down to
637,698,242), and the number of irept copy constructor calls reduces from
302,984,665 to 56,124.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
