### PR TITLE
Use type equality, not base_type_eq in local safe pointers

### DIFF
--- a/jbmc/unit/java_bytecode/java_bytecode_instrument/virtual_call_null_checks.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_instrument/virtual_call_null_checks.cpp
@@ -74,7 +74,7 @@ SCENARIO(
         // This analysis checks that any usage of a pointer is preceded by an
         // assumption that it is non-null
         // (e.g. assume(x != nullptr); y = x->...)
-        local_safe_pointerst safe_pointers(ns);
+        local_safe_pointerst safe_pointers;
         safe_pointers(main_function.body);
 
         for(auto instrit = main_function.body.instructions.begin(),

--- a/src/analyses/local_safe_pointers.cpp
+++ b/src/analyses/local_safe_pointers.cpp
@@ -271,17 +271,6 @@ bool local_safe_pointerst::is_non_null_at_program_point(
   auto findit = non_null_expressions.find(program_point->location_number);
   if(findit == non_null_expressions.end())
     return false;
-  const exprt *tocheck = &expr;
-  while(tocheck->id() == ID_typecast)
-    tocheck = &tocheck->op0();
-  return findit->second.count(*tocheck) != 0;
-}
 
-bool local_safe_pointerst::type_comparet::
-operator()(const exprt &e1, const exprt &e2) const
-{
-  if(e1.type() == e2.type())
-    return false;
-  else
-    return e1 < e2;
+  return findit->second.count(skip_typecast(expr)) != 0;
 }

--- a/src/analyses/local_safe_pointers.cpp
+++ b/src/analyses/local_safe_pointers.cpp
@@ -11,7 +11,6 @@ Author: Diffblue Ltd
 
 #include "local_safe_pointers.h"
 
-#include <util/base_type.h>
 #include <util/expr_iterator.h>
 #include <util/expr_util.h>
 #include <util/format_expr.h>
@@ -82,8 +81,7 @@ static optionalt<goto_null_checkt> get_null_checked_expr(const exprt &expr)
 /// \param goto_program: program to analyse
 void local_safe_pointerst::operator()(const goto_programt &goto_program)
 {
-  std::set<exprt, base_type_comparet> checked_expressions(
-    base_type_comparet{ns});
+  std::set<exprt, type_comparet> checked_expressions(type_comparet{});
 
   for(const auto &instruction : goto_program.instructions)
   {
@@ -98,8 +96,7 @@ void local_safe_pointerst::operator()(const goto_programt &goto_program)
         checked_expressions = findit->second;
       else
       {
-        checked_expressions =
-          std::set<exprt, base_type_comparet>(base_type_comparet{ns});
+        checked_expressions = std::set<exprt, type_comparet>(type_comparet{});
       }
     }
 
@@ -179,8 +176,11 @@ void local_safe_pointerst::operator()(const goto_programt &goto_program)
 /// \param out: stream to write output to
 /// \param goto_program: GOTO program analysed (the same one passed to
 ///   operator())
+/// \param ns: namespace
 void local_safe_pointerst::output(
-  std::ostream &out, const goto_programt &goto_program)
+  std::ostream &out,
+  const goto_programt &goto_program,
+  const namespacet &ns)
 {
   forall_goto_program_instructions(i_it, goto_program)
   {
@@ -220,8 +220,11 @@ void local_safe_pointerst::output(
 /// \param out: stream to write output to
 /// \param goto_program: GOTO program analysed (the same one passed to
 ///   operator())
+/// \param ns: namespace
 void local_safe_pointerst::output_safe_dereferences(
-  std::ostream &out, const goto_programt &goto_program)
+  std::ostream &out,
+  const goto_programt &goto_program,
+  const namespacet &ns)
 {
   forall_goto_program_instructions(i_it, goto_program)
   {
@@ -274,10 +277,10 @@ bool local_safe_pointerst::is_non_null_at_program_point(
   return findit->second.count(*tocheck) != 0;
 }
 
-bool local_safe_pointerst::base_type_comparet::operator()(
-  const exprt &e1, const exprt &e2) const
+bool local_safe_pointerst::type_comparet::
+operator()(const exprt &e1, const exprt &e2) const
 {
-  if(base_type_eq(e1, e2, ns))
+  if(e1.type() == e2.type())
     return false;
   else
     return e1 < e2;

--- a/src/analyses/local_safe_pointers.h
+++ b/src/analyses/local_safe_pointers.h
@@ -25,10 +25,12 @@ class local_safe_pointerst
 {
   /// Comparator that regards type-equal expressions as equal, and otherwise
   /// uses the natural (operator<) ordering on irept.
-  class type_comparet
+  struct type_comparet
   {
-  public:
-    bool operator()(const exprt &e1, const exprt &e2) const;
+    bool operator()(const exprt &e1, const exprt &e2) const
+    {
+      return e1.type() != e2.type() && e1 < e2;
+    }
   };
 
   std::map<unsigned, std::set<exprt, type_comparet>> non_null_expressions;

--- a/src/analyses/local_safe_pointers.h
+++ b/src/analyses/local_safe_pointers.h
@@ -23,45 +23,17 @@ Author: Diffblue Ltd
 /// possibly-aliasing operations are handled pessimistically.
 class local_safe_pointerst
 {
-  /// Comparator that regards base_type_eq expressions as equal, and otherwise
+  /// Comparator that regards type-equal expressions as equal, and otherwise
   /// uses the natural (operator<) ordering on irept.
-  /// An expression is base_type_eq another one if their types, and types of
-  /// their subexpressions, are identical except that one may use a symbol_typet
-  /// while the other uses that type's expanded (namespacet::follow'd) form.
-  class base_type_comparet
+  class type_comparet
   {
-    const namespacet &ns;
-
   public:
-    explicit base_type_comparet(const namespacet &ns)
-      : ns(ns)
-    {
-    }
-
-    base_type_comparet(const base_type_comparet &other)
-      : ns(other.ns)
-    {
-    }
-
-    base_type_comparet &operator=(const base_type_comparet &other)
-    {
-      INVARIANT(&ns == &other.ns, "base_type_comparet: clashing namespaces");
-      return *this;
-    }
-
     bool operator()(const exprt &e1, const exprt &e2) const;
   };
 
-  std::map<unsigned, std::set<exprt, base_type_comparet>> non_null_expressions;
-
-  const namespacet &ns;
+  std::map<unsigned, std::set<exprt, type_comparet>> non_null_expressions;
 
 public:
-  local_safe_pointerst(const namespacet &ns)
-    : ns(ns)
-  {
-  }
-
   void operator()(const goto_programt &goto_program);
 
   bool is_non_null_at_program_point(
@@ -74,10 +46,15 @@ public:
     return is_non_null_at_program_point(deref.op(), program_point);
   }
 
-  void output(std::ostream &stream, const goto_programt &program);
+  void output(
+    std::ostream &stream,
+    const goto_programt &program,
+    const namespacet &ns);
 
   void output_safe_dereferences(
-    std::ostream &stream, const goto_programt &program);
+    std::ostream &stream,
+    const goto_programt &program,
+    const namespacet &ns);
 };
 
 #endif // CPROVER_ANALYSES_LOCAL_SAFE_POINTERS_H

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -319,17 +319,17 @@ int goto_instrument_parse_optionst::doit()
 
       forall_goto_functions(it, goto_model.goto_functions)
       {
-        local_safe_pointerst local_safe_pointers(ns);
+        local_safe_pointerst local_safe_pointers;
         local_safe_pointers(it->second.body);
         std::cout << ">>>>\n";
         std::cout << ">>>> " << it->first << '\n';
         std::cout << ">>>>\n";
         if(cmdline.isset("show-local-safe-pointers"))
-          local_safe_pointers.output(std::cout, it->second.body);
+          local_safe_pointers.output(std::cout, it->second.body, ns);
         else
         {
           local_safe_pointers.output_safe_dereferences(
-            std::cout, it->second.body);
+            std::cout, it->second.body, ns);
         }
         std::cout << '\n';
       }

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -17,9 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <goto-programs/abstract_goto_model.h>
 
-#include "goto_symex_state.h"
 #include "path_storage.h"
-#include "symex_target_equation.h"
 
 class byte_extract_exprt;
 class typet;

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -16,7 +16,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <unordered_set>
 
 #include <analyses/dirty.h>
-#include <analyses/local_safe_pointers.h>
 
 #include <util/invariant.h>
 #include <util/guard.h>
@@ -68,7 +67,6 @@ public:
   /// Threads
   unsigned atomic_section_id = 0;
 
-  std::unordered_map<irep_idt, local_safe_pointerst> safe_pointers;
   unsigned total_vccs = 0;
   unsigned remaining_vccs = 0;
 
@@ -320,7 +318,6 @@ inline goto_statet::goto_statet(const class goto_symex_statet &s)
     source(s.source),
     propagation(s.propagation),
     atomic_section_id(s.atomic_section_id),
-    safe_pointers(s.safe_pointers),
     total_vccs(s.total_vccs),
     remaining_vccs(s.remaining_vccs)
 {

--- a/src/goto-symex/path_storage.h
+++ b/src/goto-symex/path_storage.h
@@ -5,15 +5,17 @@
 #ifndef CPROVER_GOTO_SYMEX_PATH_STORAGE_H
 #define CPROVER_GOTO_SYMEX_PATH_STORAGE_H
 
-#include "goto_symex_state.h"
-#include "symex_target_equation.h"
-
-#include <util/options.h>
 #include <util/cmdline.h>
-#include <util/ui_message.h>
 #include <util/invariant.h>
+#include <util/message.h>
+#include <util/options.h>
+
+#include <analyses/local_safe_pointers.h>
 
 #include <memory>
+
+#include "goto_symex_state.h"
+#include "symex_target_equation.h"
 
 /// Functor generating fresh nondet symbols
 class symex_nondet_generatort
@@ -89,6 +91,12 @@ public:
 
   /// Counter for nondet objects, which require unique names
   symex_nondet_generatort build_symex_nondet;
+
+  /// Map function identifiers to \ref local_safe_pointerst instances. This is
+  /// to identify derferences that are guaranteed to be safe in a given
+  /// execution context, thus helping to avoid symex to follow spurious
+  /// error-handling paths.
+  std::unordered_map<irep_idt, local_safe_pointerst> safe_pointers;
 
 private:
   // Derived classes should override these methods, allowing the base class to

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -211,9 +211,8 @@ void goto_symext::dereference_rec(exprt &expr, statet &state)
       {
         get_original_name(to_check);
 
-        expr_is_not_null =
-          state.safe_pointers.at(expr_function).is_safe_dereference(
-            to_check, state.source.pc);
+        expr_is_not_null = path_storage.safe_pointers.at(expr_function)
+                             .is_safe_dereference(to_check, state.source.pc);
       }
     }
 

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -240,7 +240,7 @@ void goto_symext::symex_function_call_code(
   state.dirty.populate_dirty_for_function(identifier, goto_function);
 
   auto emplace_safe_pointers_result =
-    state.safe_pointers.emplace(identifier, local_safe_pointerst{});
+    path_storage.safe_pointers.emplace(identifier, local_safe_pointerst{});
   if(emplace_safe_pointers_result.second)
     emplace_safe_pointers_result.first->second(goto_function.body);
 

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -240,7 +240,7 @@ void goto_symext::symex_function_call_code(
   state.dirty.populate_dirty_for_function(identifier, goto_function);
 
   auto emplace_safe_pointers_result =
-    state.safe_pointers.emplace(identifier, local_safe_pointerst{ns});
+    state.safe_pointers.emplace(identifier, local_safe_pointerst{});
   if(emplace_safe_pointers_result.second)
     emplace_safe_pointers_result.first->second(goto_function.body);
 

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -310,7 +310,7 @@ std::unique_ptr<goto_symext::statet> goto_symext::initialize_entry_point_state(
 
   // initialize support analyses
   auto emplace_safe_pointers_result =
-    state->safe_pointers.emplace(entry_point_id, local_safe_pointerst{});
+    path_storage.safe_pointers.emplace(entry_point_id, local_safe_pointerst{});
   if(emplace_safe_pointers_result.second)
     emplace_safe_pointers_result.first->second(start_function->body);
 

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -310,7 +310,7 @@ std::unique_ptr<goto_symext::statet> goto_symext::initialize_entry_point_state(
 
   // initialize support analyses
   auto emplace_safe_pointers_result =
-    state->safe_pointers.emplace(entry_point_id, local_safe_pointerst{ns});
+    state->safe_pointers.emplace(entry_point_id, local_safe_pointerst{});
   if(emplace_safe_pointers_result.second)
     emplace_safe_pointers_result.first->second(start_function->body);
 


### PR DESCRIPTION
We no longer need to resort to tag/symbol type resolution. This enables partial
revert of 959c7a5f7f653a7 (Bugfix: Maintain safe_pointers per-path) as we no
longer need to maintain a namespacet in local_safe_pointerst. On SV-COMP's
ReachSafety-ECA, copying safe_pointers accounted for 14% of the time spent in
goto_symext::symex_goto (715 of 5119 seconds).

~Requires #3966 to be merged for Java tests to pass.~

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
