### PR TITLE
Use modern API to access parametert's identifier and base name

### DIFF
--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -639,7 +639,7 @@ void cpp_typecheckt::typecheck_compound_declarator(
           arg_symb.location=func_symb.location;
           arg_symb.type=arg.type();
 
-          arg.set(ID_C_identifier, arg_symb.name);
+          arg.set_identifier(arg_symb.name);
 
           // add the parameter to the symbol table
           const bool failed=!symbol_table.insert(std::move(arg_symb)).second;
@@ -648,7 +648,7 @@ void cpp_typecheckt::typecheck_compound_declarator(
 
         // do the body of the function
         typecast_exprt late_cast(
-          lookup(args[0].get(ID_C_identifier)).symbol_expr(),
+          lookup(args[0].get_identifier()).symbol_expr(),
           to_code_type(component.type()).parameters()[0].type());
 
         side_effect_expr_function_callt expr_call(
@@ -661,7 +661,7 @@ void cpp_typecheckt::typecheck_compound_declarator(
         for(const auto &arg : args)
         {
           expr_call.arguments().push_back(
-            lookup(arg.get(ID_C_identifier)).symbol_expr());
+            lookup(arg.get_identifier()).symbol_expr());
         }
 
         if(code_type.return_type().id()!=ID_empty &&

--- a/src/cpp/cpp_typecheck_conversions.cpp
+++ b/src/cpp/cpp_typecheck_conversions.cpp
@@ -576,13 +576,15 @@ bool cpp_typecheckt::standard_conversion_pointer_to_member(
       code_typet code1=to_code_type(expr.type().subtype());
       assert(!code1.parameters().empty());
       code_typet::parametert this1=code1.parameters()[0];
-      assert(this1.get(ID_C_base_name)==ID_this);
+      INVARIANT(
+        this1.get_base_name() == ID_this, "first parameter should be `this'");
       code1.parameters().erase(code1.parameters().begin());
 
       code_typet code2=to_code_type(type.subtype());
       assert(!code2.parameters().empty());
       code_typet::parametert this2=code2.parameters()[0];
-      assert(this2.get(ID_C_base_name)==ID_this);
+      INVARIANT(
+        this2.get_base_name() == ID_this, "first parameter should be `this'");
       code2.parameters().erase(code2.parameters().begin());
 
       if(this2.type().subtype().get_bool(ID_C_constant) &&

--- a/src/cpp/cpp_typecheck_fargs.cpp
+++ b/src/cpp/cpp_typecheck_fargs.cpp
@@ -97,7 +97,7 @@ bool cpp_typecheck_fargst::match(
 
     // "this" is a special case -- we turn the pointer type
     // into a reference type to do the type matching
-    if(it==ops.begin() && parameter.get(ID_C_base_name)==ID_this)
+    if(it == ops.begin() && parameter.get_base_name() == ID_this)
     {
       type.set(ID_C_reference, true);
       type.set(ID_C_this, true);

--- a/src/cpp/cpp_typecheck_function.cpp
+++ b/src/cpp/cpp_typecheck_function.cpp
@@ -127,7 +127,7 @@ void cpp_typecheckt::convert_function(symbolt &symbol)
     code_typet::parametert &this_parameter_expr=parameters.front();
     function_scope.this_expr=exprt(ID_symbol, this_parameter_expr.type());
     function_scope.this_expr.set(
-      ID_identifier, this_parameter_expr.get(ID_C_identifier));
+      ID_identifier, this_parameter_expr.get_identifier());
   }
   else
     function_scope.this_expr.make_nil();

--- a/src/cpp/cpp_typecheck_initializer.cpp
+++ b/src/cpp/cpp_typecheck_initializer.cpp
@@ -89,18 +89,15 @@ void cpp_typecheckt::convert_initializer(symbolt &symbol)
 
       const code_typet &code_type=to_code_type(symbol.type.subtype());
 
-      for(code_typet::parameterst::const_iterator
-          ait=code_type.parameters().begin();
-          ait!=code_type.parameters().end();
-          ait++)
+      for(const auto &parameter : code_type.parameters())
       {
-        exprt new_object(ID_new_object, ait->type());
+        exprt new_object(ID_new_object, parameter.type());
         new_object.set(ID_C_lvalue, true);
 
-        if(ait->get(ID_C_base_name)==ID_this)
+        if(parameter.get_base_name() == ID_this)
         {
           fargs.has_object = true;
-          new_object.type() = ait->type().subtype();
+          new_object.type() = parameter.type().subtype();
         }
 
         fargs.operands.push_back(new_object);

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -2073,8 +2073,9 @@ void cpp_typecheck_resolvet::apply_template_args(
     // check if it is a method
     const code_typet &code_type=to_code_type(new_symbol.type);
 
-    if(!code_type.parameters().empty() &&
-        code_type.parameters()[0].get(ID_C_base_name)==ID_this)
+    if(
+      !code_type.parameters().empty() &&
+      code_type.parameters()[0].get_base_name() == ID_this)
     {
       // do we have an object?
       if(fargs.has_object)
@@ -2128,7 +2129,9 @@ bool cpp_typecheck_resolvet::disambiguate_functions(
       const code_typet::parameterst &parameters=type.parameters();
       const code_typet::parametert &parameter=parameters.front();
 
-      assert(parameter.get(ID_C_base_name)==ID_this);
+      INVARIANT(
+        parameter.get_base_name() == ID_this,
+        "first parameter should be `this'");
 
       if(type.return_type().id() == ID_constructor)
       {

--- a/src/cpp/cpp_typecheck_type.cpp
+++ b/src/cpp/cpp_typecheck_type.cpp
@@ -103,15 +103,14 @@ void cpp_typecheckt::typecheck_type(typet &type)
       // there may be parameters if this is a pointer to member function
       if(type.subtype().id()==ID_code)
       {
-        irept::subt &parameters=type.subtype().add(ID_parameters).get_sub();
+        code_typet::parameterst &parameters =
+          to_code_type(type.subtype()).parameters();
 
-        if(parameters.empty() ||
-           parameters.front().get(ID_C_base_name)!=ID_this)
+        if(parameters.empty() || parameters.front().get_base_name() != ID_this)
         {
           // Add 'this' to the parameters
-          exprt a0(ID_parameter);
-          a0.set(ID_C_base_name, ID_this);
-          a0.type()=pointer_type(class_object);
+          code_typet::parametert a0(pointer_type(class_object));
+          a0.set_base_name(ID_this);
           parameters.insert(parameters.begin(), a0);
         }
       }


### PR DESCRIPTION
Whether we store the values at ID_C_identifier/ID_C_base_name or elsewhere is an
implementation detail. Includes code cleanup to use a ranged for, and a bugfix
where ID_arguments was still being used when it should be parameters.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
