### PR TITLE
merge_value_sets: Avoid assignment when actually values can be moved

### DIFF
--- a/src/goto-checker/symex_bmc.cpp
+++ b/src/goto-checker/symex_bmc.cpp
@@ -86,12 +86,12 @@ void symex_bmct::symex_step(
   }
 }
 
-void symex_bmct::merge_goto(const goto_statet &goto_state, statet &state)
+void symex_bmct::merge_goto(goto_statet &&goto_state, statet &state)
 {
   const goto_programt::const_targett prev_pc = goto_state.source.pc;
   const guardt prev_guard = goto_state.guard;
 
-  goto_symext::merge_goto(goto_state, state);
+  goto_symext::merge_goto(std::move(goto_state), state);
 
   PRECONDITION(prev_pc->is_goto());
   if(

--- a/src/goto-checker/symex_bmc.h
+++ b/src/goto-checker/symex_bmc.h
@@ -94,7 +94,7 @@ protected:
   void symex_step(const get_goto_functiont &get_goto_function, statet &state)
     override;
 
-  void merge_goto(const goto_statet &goto_state, statet &state) override;
+  void merge_goto(goto_statet &&goto_state, statet &state) override;
 
   bool should_stop_unwind(
     const symex_targett::sourcet &source,

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -232,12 +232,15 @@ protected:
 
   virtual void symex_assume(statet &, const exprt &cond);
 
-  // gotos
+  /// Merge all branches joining at the current program point. Applies
+  /// \ref merge_goto for each goto state (each of which corresponds to previous
+  /// branch).
   void merge_gotos(statet &);
 
-  virtual void merge_goto(const goto_statet &goto_state, statet &);
-
-  void merge_value_sets(const goto_statet &goto_state, statet &dest);
+  /// Merge a single branch, the symbolic state of which is held in \p
+  /// goto_state, into the current overall symbolic state. \p goto_state is no
+  /// longer expected to be valid afterwards.
+  virtual void merge_goto(goto_statet &&goto_state, statet &);
 
   void phi_function(const goto_statet &goto_state, statet &);
 

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -47,6 +47,14 @@ public:
 
   virtual ~value_sett() = default;
 
+  value_sett(const value_sett &other) = default;
+
+  value_sett &operator=(value_sett &&other)
+  {
+    values = std::move(other.values);
+    return *this;
+  }
+
   static bool field_sensitive(const irep_idt &id, const typet &type);
 
   /// Matches the location_number field of the instruction that corresponds


### PR DESCRIPTION
We don't need the contents of the source anymore. Running on SV-COMP's
ReachSafety-ECA, this saves 741s, which is approximately 9% of the runtime of merge_goto.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
