### PR TITLE
Return statements always have one operand

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
@@ -415,12 +415,10 @@ void java_bytecode_instrumentt::instrument_code(codet &code)
   }
   else if(statement==ID_return)
   {
-    if(code.operands().size()==1)
-    {
-      code_blockt block;
-      add_expr_instrumentation(block, code.op0());
-      prepend_instrumentation(code, block);
-    }
+    code_blockt block;
+    code_returnt &code_return = to_code_return(code);
+    add_expr_instrumentation(block, code_return.return_value());
+    prepend_instrumentation(code, block);
   }
   else if(statement==ID_function_call)
   {

--- a/jbmc/src/java_bytecode/java_bytecode_typecheck_code.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_typecheck_code.cpp
@@ -52,8 +52,8 @@ void java_bytecode_typecheckt::typecheck_code(codet &code)
   }
   else if(statement==ID_return)
   {
-    if(code.operands().size()==1)
-      typecheck_expr(code.op0());
+    code_returnt &code_return = to_code_return(code);
+    typecheck_expr(code_return.return_value());
   }
   else if(statement==ID_function_call)
   {

--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -138,7 +138,7 @@ protected:
   virtual void typecheck_gcc_computed_goto(codet &code);
   virtual void typecheck_gcc_switch_case_range(code_gcc_switch_case_ranget &);
   virtual void typecheck_gcc_local_label(codet &code);
-  virtual void typecheck_return(codet &code);
+  virtual void typecheck_return(code_returnt &code);
   virtual void typecheck_switch(code_switcht &code);
   virtual void typecheck_while(code_whilet &code);
   virtual void typecheck_dowhile(code_dowhilet &code);

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -2587,8 +2587,7 @@ std::string expr2ct::convert_code_return(
   const codet &src,
   unsigned indent)
 {
-  if(!src.operands().empty() &&
-     src.operands().size()!=1)
+  if(src.operands().size() != 1)
   {
     unsigned precedence;
     return convert_norep(src, precedence);

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -2426,7 +2426,11 @@ jump_statement:
         | TOK_BREAK ';'
         { $$=$1; statement($$, ID_break); }
         | TOK_RETURN ';'
-        { $$=$1; statement($$, ID_return); }
+        {
+          $$=$1;
+          statement($$, ID_return);
+          stack($$).operands().push_back(nil_exprt());
+        }
         | TOK_RETURN comma_expression ';'
         { $$=$1; statement($$, ID_return); mto($$, $2); }
         ;

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -7344,7 +7344,7 @@ bool Parser::rStatement(codet &statement)
 
     lex.get_token(tk1);
 
-    statement=codet(ID_return);
+    statement = code_returnt();
     set_location(statement, tk1);
 
     if(lex.LookAhead(0)==';')
@@ -7375,7 +7375,7 @@ bool Parser::rStatement(codet &statement)
       if(lex.get_token(tk2)!=';')
         return false;
 
-      statement.add_to_operands(std::move(exp));
+      to_code_return(statement).return_value() = std::move(exp);
     }
 
     return true;

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1510,11 +1510,13 @@ void value_sett::apply_code_rec(
   }
   else if(statement==ID_return)
   {
+    const code_returnt &code_return = to_code_return(code);
     // this is turned into an assignment
-    if(code.operands().size()==1)
+    if(code_return.has_return_value())
     {
-      symbol_exprt lhs("value_set::return_value", code.op0().type());
-      assign(lhs, code.op0(), ns, false, false);
+      symbol_exprt lhs(
+        "value_set::return_value", code_return.return_value().type());
+      assign(lhs, code_return.return_value(), ns, false, false);
     }
   }
   else if(statement==ID_array_set)

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -1310,16 +1310,14 @@ void value_set_fit::do_end_function(
   assign(lhs, rhs, ns);
 }
 
-void value_set_fit::apply_code(
-  const exprt &code,
-  const namespacet &ns)
+void value_set_fit::apply_code(const codet &code, const namespacet &ns)
 {
   const irep_idt &statement=code.get(ID_statement);
 
   if(statement==ID_block)
   {
-    forall_operands(it, code)
-      apply_code(*it, ns);
+    for(const auto &stmt : to_code_block(code).statements())
+      apply_code(stmt, ns);
   }
   else if(statement==ID_function_call)
   {
@@ -1372,12 +1370,13 @@ void value_set_fit::apply_code(
   }
   else if(statement==ID_return)
   {
+    const code_returnt &code_return = to_code_return(code);
     // this is turned into an assignment
-    if(code.operands().size()==1)
+    if(code_return.has_return_value())
     {
       std::string rvs="value_set::return_value"+std::to_string(from_function);
-      symbol_exprt lhs(rvs, code.op0().type());
-      assign(lhs, code.op0(), ns);
+      symbol_exprt lhs(rvs, code_return.return_value().type());
+      assign(lhs, code_return.return_value(), ns);
     }
   }
   else if(statement==ID_fence)

--- a/src/pointer-analysis/value_set_fi.h
+++ b/src/pointer-analysis/value_set_fi.h
@@ -24,6 +24,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "object_numbering.h"
 
+class codet;
+
 class value_set_fit
 {
 public:
@@ -271,9 +273,7 @@ public:
     return make_union(new_values.values);
   }
 
-  void apply_code(
-    const exprt &code,
-    const namespacet &ns);
+  void apply_code(const codet &code, const namespacet &ns);
 
   void assign(
     const exprt &lhs,

--- a/src/pointer-analysis/value_set_fivr.cpp
+++ b/src/pointer-analysis/value_set_fivr.cpp
@@ -1460,16 +1460,14 @@ void value_set_fivrt::do_end_function(
   assign(lhs, rhs, ns);
 }
 
-void value_set_fivrt::apply_code(
-  const exprt &code,
-  const namespacet &ns)
+void value_set_fivrt::apply_code(const codet &code, const namespacet &ns)
 {
   const irep_idt &statement=code.get(ID_statement);
 
   if(statement==ID_block)
   {
-    forall_operands(it, code)
-      apply_code(*it, ns);
+    for(const auto &stmt : to_code_block(code).statements())
+      apply_code(stmt, ns);
   }
   else if(statement==ID_function_call)
   {
@@ -1522,12 +1520,14 @@ void value_set_fivrt::apply_code(
   }
   else if(statement==ID_return)
   {
+    const code_returnt &code_return = to_code_return(code);
     // this is turned into an assignment
-    if(code.operands().size()==1)
+    if(code_return.has_return_value())
     {
-      std::string rvs="value_set::return_value" + std::to_string(from_function);
-      symbol_exprt lhs(rvs, code.op0().type());
-      assign(lhs, code.op0(), ns);
+      std::string rvs =
+        "value_set::return_value" + std::to_string(from_function);
+      symbol_exprt lhs(rvs, code_return.return_value().type());
+      assign(lhs, code_return.return_value(), ns);
     }
   }
   else if(statement==ID_input || statement==ID_output)

--- a/src/pointer-analysis/value_set_fivr.h
+++ b/src/pointer-analysis/value_set_fivr.h
@@ -24,6 +24,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "object_numbering.h"
 
+class codet;
+
 class value_set_fivrt
 {
 public:
@@ -307,9 +309,7 @@ public:
     object_mapt &dest,
     const object_mapt &src) const;
 
-  void apply_code(
-    const exprt &code,
-    const namespacet &ns);
+  void apply_code(const codet &code, const namespacet &ns);
 
   bool handover();
 

--- a/src/pointer-analysis/value_set_fivrns.cpp
+++ b/src/pointer-analysis/value_set_fivrns.cpp
@@ -1123,16 +1123,14 @@ void value_set_fivrnst::do_end_function(
   assign(lhs, rhs, ns);
 }
 
-void value_set_fivrnst::apply_code(
-  const exprt &code,
-  const namespacet &ns)
+void value_set_fivrnst::apply_code(const codet &code, const namespacet &ns)
 {
   const irep_idt &statement=code.get(ID_statement);
 
   if(statement==ID_block)
   {
-    forall_operands(it, code)
-      apply_code(*it, ns);
+    for(const auto &stmt : to_code_block(code).statements())
+      apply_code(stmt, ns);
   }
   else if(statement==ID_function_call)
   {
@@ -1185,14 +1183,15 @@ void value_set_fivrnst::apply_code(
   }
   else if(statement==ID_return)
   {
+    const code_returnt &code_return = to_code_return(code);
     // this is turned into an assignment
-    if(code.operands().size()==1)
+    if(code_return.has_return_value())
     {
-      irep_idt rvs = std::string("value_set::return_value") +
-                     std::to_string(from_function);
+      std::string rvs =
+        "value_set::return_value" + std::to_string(from_function);
       add_var(rvs);
-      symbol_exprt lhs(rvs, code.op0().type());
-      assign(lhs, code.op0(), ns);
+      symbol_exprt lhs(rvs, code_return.return_value().type());
+      assign(lhs, code_return.return_value(), ns);
     }
   }
   else if(statement==ID_input || statement==ID_output)

--- a/src/pointer-analysis/value_set_fivrns.h
+++ b/src/pointer-analysis/value_set_fivrns.h
@@ -25,6 +25,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "object_numbering.h"
 
+class codet;
+
 class value_set_fivrnst
 {
 public:
@@ -304,9 +306,7 @@ public:
     object_mapt &dest,
     const object_mapt &src) const;
 
-  void apply_code(
-    const exprt &code,
-    const namespacet &ns);
+  void apply_code(const codet &code, const namespacet &ns);
 
   bool handover();
 

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -1255,10 +1255,8 @@ inline void validate_expr(const code_function_callt &x)
 class code_returnt:public codet
 {
 public:
-  code_returnt():codet(ID_return)
+  code_returnt() : codet(ID_return, {nil_exprt()})
   {
-    operands().resize(1);
-    op0().make_nil();
   }
 
   explicit code_returnt(const exprt &_op) : codet(ID_return, {_op})
@@ -1277,8 +1275,6 @@ public:
 
   bool has_return_value() const
   {
-    if(operands().empty())
-      return false; // backwards compatibility
     return return_value().is_not_nil();
   }
 


### PR DESCRIPTION
We already enforced this when creating a code_returnt, but still permitted
codet(ID_return) that did not have the same. Make sure the C parser always
creates irepts with an operand, and make use of that throughout the code base.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
