### PR TITLE
Cleanup expression/code cast validation

### DIFF
--- a/src/util/mathematical_expr.h
+++ b/src/util/mathematical_expr.h
@@ -61,6 +61,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<transt>(const exprt &base)
+{
+  return base.id() == ID_trans;
+}
+
+inline void validate_expr(const transt &value)
+{
+  validate_operands(value, 3, "Transition systems must have three operands");
+}
+
 /// Cast an exprt to a \ref transt
 /// \a expr must be known to be \ref transt.
 /// \param expr: Source expression
@@ -82,16 +93,6 @@ inline transt &to_trans_expr(exprt &expr)
   return static_cast<transt &>(expr);
 }
 
-template <>
-inline bool can_cast_expr<transt>(const exprt &base)
-{
-  return base.id() == ID_trans;
-}
-inline void validate_expr(const transt &value)
-{
-  validate_operands(value, 3, "Transition systems must have three operands");
-}
-
 /// \brief Exponentiation
 class power_exprt : public binary_exprt
 {
@@ -106,6 +107,17 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<power_exprt>(const exprt &base)
+{
+  return base.id() == ID_power;
+}
+
+inline void validate_expr(const power_exprt &value)
+{
+  validate_operands(value, 2, "Power must have two operands");
+}
 
 /// \brief Cast an exprt to a \ref power_exprt
 ///
@@ -128,16 +140,6 @@ inline power_exprt &to_power_expr(exprt &expr)
   return static_cast<power_exprt &>(expr);
 }
 
-template <>
-inline bool can_cast_expr<power_exprt>(const exprt &base)
-{
-  return base.id() == ID_power;
-}
-inline void validate_expr(const power_exprt &value)
-{
-  validate_operands(value, 2, "Power must have two operands");
-}
-
 /// \brief Falling factorial power
 class factorial_power_exprt : public binary_exprt
 {
@@ -152,6 +154,17 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<factorial_power_exprt>(const exprt &base)
+{
+  return base.id() == ID_factorial_power;
+}
+
+inline void validate_expr(const factorial_power_exprt &value)
+{
+  validate_operands(value, 2, "Factorial power must have two operands");
+}
 
 /// \brief Cast an exprt to a \ref factorial_power_exprt
 ///
@@ -174,16 +187,6 @@ inline factorial_power_exprt &to_factorial_expr(exprt &expr)
   DATA_INVARIANT(
     expr.operands().size() == 2, "Factorial power must have two operands");
   return static_cast<factorial_power_exprt &>(expr);
-}
-
-template <>
-inline bool can_cast_expr<factorial_power_exprt>(const exprt &base)
-{
-  return base.id() == ID_factorial_power;
-}
-inline void validate_expr(const factorial_power_exprt &value)
-{
-  validate_operands(value, 2, "Factorial power must have two operands");
 }
 
 class tuple_exprt : public multi_ary_exprt
@@ -239,6 +242,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<function_application_exprt>(const exprt &base)
+{
+  return base.id() == ID_function_application;
+}
+
+inline void validate_expr(const function_application_exprt &value)
+{
+  validate_operands(value, 2, "Function application must have two operands");
+}
+
 /// \brief Cast an exprt to a \ref function_application_exprt
 ///
 /// \a expr must be known to be \ref function_application_exprt.
@@ -261,16 +275,6 @@ inline function_application_exprt &to_function_application_expr(exprt &expr)
   DATA_INVARIANT(
     expr.operands().size() == 2, "Function application must have two operands");
   return static_cast<function_application_exprt &>(expr);
-}
-
-template <>
-inline bool can_cast_expr<function_application_exprt>(const exprt &base)
-{
-  return base.id() == ID_function_application;
-}
-inline void validate_expr(const function_application_exprt &value)
-{
-  validate_operands(value, 2, "Function application must have two operands");
 }
 
 /// \brief A base class for quantifier expressions
@@ -306,6 +310,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<quantifier_exprt>(const exprt &base)
+{
+  return base.id() == ID_forall || base.id() == ID_exists;
+}
+
+inline void validate_expr(const quantifier_exprt &value)
+{
+  validate_operands(value, 2, "quantifier expressions must have two operands");
+}
+
 /// \brief Cast an exprt to a \ref quantifier_exprt
 ///
 /// \a expr must be known to be \ref quantifier_exprt.
@@ -331,17 +346,6 @@ inline quantifier_exprt &to_quantifier_expr(exprt &expr)
   DATA_INVARIANT(
     expr.op0().id() == ID_symbol, "quantified variable shall be a symbol");
   return static_cast<quantifier_exprt &>(expr);
-}
-
-template <>
-inline bool can_cast_expr<quantifier_exprt>(const exprt &base)
-{
-  return base.id() == ID_forall || base.id() == ID_exists;
-}
-
-inline void validate_expr(const quantifier_exprt &value)
-{
-  validate_operands(value, 2, "quantifier expressions must have two operands");
 }
 
 /// \brief A forall expression

--- a/src/util/mathematical_expr.h
+++ b/src/util/mathematical_expr.h
@@ -79,18 +79,18 @@ inline void validate_expr(const transt &value)
 inline const transt &to_trans_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_trans);
-  DATA_INVARIANT(
-    expr.operands().size() == 3, "Transition systems must have three operands");
-  return static_cast<const transt &>(expr);
+  const transt &ret = static_cast<const transt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_trans_expr(const exprt &)
 inline transt &to_trans_expr(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_trans);
-  DATA_INVARIANT(
-    expr.operands().size() == 3, "Transition systems must have three operands");
-  return static_cast<transt &>(expr);
+  transt &ret = static_cast<transt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \brief Exponentiation
@@ -128,16 +128,18 @@ inline void validate_expr(const power_exprt &value)
 inline const power_exprt &to_power_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_power);
-  DATA_INVARIANT(expr.operands().size() == 2, "Power must have two operands");
-  return static_cast<const power_exprt &>(expr);
+  const power_exprt &ret = static_cast<const power_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_power_expr(const exprt &)
 inline power_exprt &to_power_expr(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_power);
-  DATA_INVARIANT(expr.operands().size() == 2, "Power must have two operands");
-  return static_cast<power_exprt &>(expr);
+  power_exprt &ret = static_cast<power_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \brief Falling factorial power
@@ -175,18 +177,19 @@ inline void validate_expr(const factorial_power_exprt &value)
 inline const factorial_power_exprt &to_factorial_power_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_factorial_power);
-  DATA_INVARIANT(
-    expr.operands().size() == 2, "Factorial power must have two operands");
-  return static_cast<const factorial_power_exprt &>(expr);
+  const factorial_power_exprt &ret =
+    static_cast<const factorial_power_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_factorial_power_expr(const exprt &)
 inline factorial_power_exprt &to_factorial_expr(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_factorial_power);
-  DATA_INVARIANT(
-    expr.operands().size() == 2, "Factorial power must have two operands");
-  return static_cast<factorial_power_exprt &>(expr);
+  factorial_power_exprt &ret = static_cast<factorial_power_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 class tuple_exprt : public multi_ary_exprt
@@ -263,18 +266,20 @@ inline const function_application_exprt &
 to_function_application_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_function_application);
-  DATA_INVARIANT(
-    expr.operands().size() == 2, "Function application must have two operands");
-  return static_cast<const function_application_exprt &>(expr);
+  const function_application_exprt &ret =
+    static_cast<const function_application_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_function_application_expr(const exprt &)
 inline function_application_exprt &to_function_application_expr(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_function_application);
-  DATA_INVARIANT(
-    expr.operands().size() == 2, "Function application must have two operands");
-  return static_cast<function_application_exprt &>(expr);
+  function_application_exprt &ret =
+    static_cast<function_application_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \brief A base class for quantifier expressions
@@ -319,6 +324,8 @@ inline bool can_cast_expr<quantifier_exprt>(const exprt &base)
 inline void validate_expr(const quantifier_exprt &value)
 {
   validate_operands(value, 2, "quantifier expressions must have two operands");
+  DATA_INVARIANT(
+    value.op0().id() == ID_symbol, "quantified variable shall be a symbol");
 }
 
 /// \brief Cast an exprt to a \ref quantifier_exprt
@@ -329,23 +336,19 @@ inline void validate_expr(const quantifier_exprt &value)
 /// \return Object of type \ref quantifier_exprt
 inline const quantifier_exprt &to_quantifier_expr(const exprt &expr)
 {
-  DATA_INVARIANT(
-    expr.operands().size() == 2,
-    "quantifier expressions must have two operands");
-  DATA_INVARIANT(
-    expr.op0().id() == ID_symbol, "quantified variable shall be a symbol");
-  return static_cast<const quantifier_exprt &>(expr);
+  PRECONDITION(can_cast_expr<quantifier_exprt>(expr));
+  const quantifier_exprt &ret = static_cast<const quantifier_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_quantifier_expr(const exprt &)
 inline quantifier_exprt &to_quantifier_expr(exprt &expr)
 {
-  DATA_INVARIANT(
-    expr.operands().size() == 2,
-    "quantifier expressions must have two operands");
-  DATA_INVARIANT(
-    expr.op0().id() == ID_symbol, "quantified variable shall be a symbol");
-  return static_cast<quantifier_exprt &>(expr);
+  PRECONDITION(can_cast_expr<quantifier_exprt>(expr));
+  quantifier_exprt &ret = static_cast<quantifier_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \brief A forall expression
@@ -361,19 +364,17 @@ public:
 inline const forall_exprt &to_forall_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_forall);
-  DATA_INVARIANT(
-    expr.operands().size() == 2,
-    "forall expressions have exactly two operands");
-  return static_cast<const forall_exprt &>(expr);
+  const forall_exprt &ret = static_cast<const forall_exprt &>(expr);
+  validate_expr(static_cast<const quantifier_exprt &>(ret));
+  return ret;
 }
 
 inline forall_exprt &to_forall_expr(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_forall);
-  DATA_INVARIANT(
-    expr.operands().size() == 2,
-    "forall expressions have exactly two operands");
-  return static_cast<forall_exprt &>(expr);
+  forall_exprt &ret = static_cast<forall_exprt &>(expr);
+  validate_expr(static_cast<const quantifier_exprt &>(ret));
+  return ret;
 }
 
 /// \brief An exists expression
@@ -389,19 +390,17 @@ public:
 inline const exists_exprt &to_exists_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_exists);
-  DATA_INVARIANT(
-    expr.operands().size() == 2,
-    "exists expressions have exactly two operands");
-  return static_cast<const exists_exprt &>(expr);
+  const exists_exprt &ret = static_cast<const exists_exprt &>(expr);
+  validate_expr(static_cast<const quantifier_exprt &>(ret));
+  return ret;
 }
 
 inline exists_exprt &to_exists_expr(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_exists);
-  DATA_INVARIANT(
-    expr.operands().size() == 2,
-    "exists expressions have exactly two operands");
-  return static_cast<exists_exprt &>(expr);
+  exists_exprt &ret = static_cast<exists_exprt &>(expr);
+  validate_expr(static_cast<const quantifier_exprt &>(ret));
+  return ret;
 }
 
 #endif // CPROVER_UTIL_MATHEMATICAL_EXPR_H

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -412,8 +412,11 @@ public:
     const codet &code,
     const validation_modet vm = validation_modet::INVARIANT)
   {
+    // will be size()==1 in the future
     DATA_CHECK(
-      vm, code.operands().size() == 1, "declaration must have one operand");
+      vm,
+      code.operands().size() >= 1,
+      "declaration must have one or more operands");
     DATA_CHECK(
       vm,
       code.op0().id() == ID_symbol,

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -493,8 +493,7 @@ public:
     DATA_CHECK(
       vm,
       code.op0().id() == ID_symbol,
-      "removing a non-symbol: " +
-        id2string(to_symbol_expr(code.op0()).get_identifier()) + "from scope");
+      "removing a non-symbol: " + id2string(code.op0().id()) + "from scope");
   }
 
 protected:

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -562,13 +562,17 @@ inline void validate_expr(const code_assumet &x)
 inline const code_assumet &to_code_assume(const codet &code)
 {
   PRECONDITION(code.get_statement() == ID_assume);
-  return static_cast<const code_assumet &>(code);
+  const code_assumet &ret = static_cast<const code_assumet &>(code);
+  validate_expr(ret);
+  return ret;
 }
 
 inline code_assumet &to_code_assume(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_assume);
-  return static_cast<code_assumet &>(code);
+  code_assumet &ret = static_cast<code_assumet &>(code);
+  validate_expr(ret);
+  return ret;
 }
 
 /// A non-fatal assertion, which checks a condition then permits execution to
@@ -616,13 +620,17 @@ inline void validate_expr(const code_assertt &x)
 inline const code_assertt &to_code_assert(const codet &code)
 {
   PRECONDITION(code.get_statement() == ID_assert);
-  return static_cast<const code_assertt &>(code);
+  const code_assertt &ret = static_cast<const code_assertt &>(code);
+  validate_expr(ret);
+  return ret;
 }
 
 inline code_assertt &to_code_assert(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_assert);
-  return static_cast<code_assertt &>(code);
+  code_assertt &ret = static_cast<code_assertt &>(code);
+  validate_expr(ret);
+  return ret;
 }
 
 /// Create a fatal assertion, which checks a condition and then halts if it does
@@ -722,17 +730,17 @@ inline void validate_expr(const code_ifthenelset &x)
 inline const code_ifthenelset &to_code_ifthenelse(const codet &code)
 {
   PRECONDITION(code.get_statement() == ID_ifthenelse);
-  DATA_INVARIANT(
-    code.operands().size() == 3, "if-then-else must have three operands");
-  return static_cast<const code_ifthenelset &>(code);
+  const code_ifthenelset &ret = static_cast<const code_ifthenelset &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 inline code_ifthenelset &to_code_ifthenelse(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_ifthenelse);
-  DATA_INVARIANT(
-    code.operands().size() == 3, "if-then-else must have three operands");
-  return static_cast<code_ifthenelset &>(code);
+  code_ifthenelset &ret = static_cast<code_ifthenelset &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 /// \ref codet representing a `switch` statement.
@@ -790,15 +798,17 @@ inline void validate_expr(const code_switcht &x)
 inline const code_switcht &to_code_switch(const codet &code)
 {
   PRECONDITION(code.get_statement() == ID_switch);
-  DATA_INVARIANT(code.operands().size() == 2, "switch must have two operands");
-  return static_cast<const code_switcht &>(code);
+  const code_switcht &ret = static_cast<const code_switcht &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 inline code_switcht &to_code_switch(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_switch);
-  DATA_INVARIANT(code.operands().size() == 2, "switch must have two operands");
-  return static_cast<code_switcht &>(code);
+  code_switcht &ret = static_cast<code_switcht &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 /// \ref codet representing a `while` statement.
@@ -856,15 +866,17 @@ inline void validate_expr(const code_whilet &x)
 inline const code_whilet &to_code_while(const codet &code)
 {
   PRECONDITION(code.get_statement() == ID_while);
-  DATA_INVARIANT(code.operands().size() == 2, "while must have two operands");
-  return static_cast<const code_whilet &>(code);
+  const code_whilet &ret = static_cast<const code_whilet &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 inline code_whilet &to_code_while(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_while);
-  DATA_INVARIANT(code.operands().size() == 2, "while must have two operands");
-  return static_cast<code_whilet &>(code);
+  code_whilet &ret = static_cast<code_whilet &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 /// \ref codet representation of a `do while` statement.
@@ -922,17 +934,17 @@ inline void validate_expr(const code_dowhilet &x)
 inline const code_dowhilet &to_code_dowhile(const codet &code)
 {
   PRECONDITION(code.get_statement() == ID_dowhile);
-  DATA_INVARIANT(
-    code.operands().size() == 2, "do-while must have two operands");
-  return static_cast<const code_dowhilet &>(code);
+  const code_dowhilet &ret = static_cast<const code_dowhilet &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 inline code_dowhilet &to_code_dowhile(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_dowhile);
-  DATA_INVARIANT(
-    code.operands().size() == 2, "do-while must have two operands");
-  return static_cast<code_dowhilet &>(code);
+  code_dowhilet &ret = static_cast<code_dowhilet &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 /// \ref codet representation of a `for` statement.
@@ -1017,15 +1029,17 @@ inline void validate_expr(const code_fort &x)
 inline const code_fort &to_code_for(const codet &code)
 {
   PRECONDITION(code.get_statement() == ID_for);
-  DATA_INVARIANT(code.operands().size() == 4, "for must have four operands");
-  return static_cast<const code_fort &>(code);
+  const code_fort &ret = static_cast<const code_fort &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 inline code_fort &to_code_for(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_for);
-  DATA_INVARIANT(code.operands().size() == 4, "for must have four operands");
-  return static_cast<code_fort &>(code);
+  code_fort &ret = static_cast<code_fort &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 /// \ref codet representation of a `goto` statement.
@@ -1072,15 +1086,17 @@ inline void validate_expr(const code_gotot &x)
 inline const code_gotot &to_code_goto(const codet &code)
 {
   PRECONDITION(code.get_statement() == ID_goto);
-  DATA_INVARIANT(code.operands().empty(), "goto must not have operands");
-  return static_cast<const code_gotot &>(code);
+  const code_gotot &ret = static_cast<const code_gotot &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 inline code_gotot &to_code_goto(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_goto);
-  DATA_INVARIANT(code.operands().empty(), "goto must not have operands");
-  return static_cast<code_gotot &>(code);
+  code_gotot &ret = static_cast<code_gotot &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 /// \ref codet representation of a function call statement.
@@ -1370,15 +1386,17 @@ inline void validate_expr(const code_labelt &x)
 inline const code_labelt &to_code_label(const codet &code)
 {
   PRECONDITION(code.get_statement() == ID_label);
-  DATA_INVARIANT(code.operands().size() == 1, "label must have one operand");
-  return static_cast<const code_labelt &>(code);
+  const code_labelt &ret = static_cast<const code_labelt &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 inline code_labelt &to_code_label(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_label);
-  DATA_INVARIANT(code.operands().size() == 1, "label must have one operand");
-  return static_cast<code_labelt &>(code);
+  code_labelt &ret = static_cast<code_labelt &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 /// \ref codet representation of a switch-case, i.e.\ a `case` statement within
@@ -1447,17 +1465,17 @@ inline void validate_expr(const code_switch_caset &x)
 inline const code_switch_caset &to_code_switch_case(const codet &code)
 {
   PRECONDITION(code.get_statement() == ID_switch_case);
-  DATA_INVARIANT(
-    code.operands().size() == 2, "switch-case must have two operands");
-  return static_cast<const code_switch_caset &>(code);
+  const code_switch_caset &ret = static_cast<const code_switch_caset &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 inline code_switch_caset &to_code_switch_case(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_switch_case);
-  DATA_INVARIANT(
-    code.operands().size() == 2, "switch-case must have two operands");
-  return static_cast<code_switch_caset &>(code);
+  code_switch_caset &ret = static_cast<code_switch_caset &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 /// \ref codet representation of a switch-case, i.e.\ a `case` statement
@@ -1531,19 +1549,19 @@ inline const code_gcc_switch_case_ranget &
 to_code_gcc_switch_case_range(const codet &code)
 {
   PRECONDITION(code.get_statement() == ID_gcc_switch_case_range);
-  DATA_INVARIANT(
-    code.operands().size() == 3,
-    "gcc-switch-case-range must have three operands");
-  return static_cast<const code_gcc_switch_case_ranget &>(code);
+  const code_gcc_switch_case_ranget &ret =
+    static_cast<const code_gcc_switch_case_ranget &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 inline code_gcc_switch_case_ranget &to_code_gcc_switch_case_range(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_gcc_switch_case_range);
-  DATA_INVARIANT(
-    code.operands().size() == 3,
-    "gcc-switch-case-range must have three operands");
-  return static_cast<code_gcc_switch_case_ranget &>(code);
+  code_gcc_switch_case_ranget &ret =
+    static_cast<code_gcc_switch_case_ranget &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 /// \ref codet representation of a `break` statement (within a `for` or `while`
@@ -1744,18 +1762,18 @@ inline code_asm_gcct &to_code_asm_gcc(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_asm);
   PRECONDITION(to_code_asm(code).get_flavor() == ID_gcc);
-  DATA_INVARIANT(
-    code.operands().size() == 5, "code_asm_gcc must have give operands");
-  return static_cast<code_asm_gcct &>(code);
+  code_asm_gcct &ret = static_cast<code_asm_gcct &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 inline const code_asm_gcct &to_code_asm_gcc(const codet &code)
 {
   PRECONDITION(code.get_statement() == ID_asm);
   PRECONDITION(to_code_asm(code).get_flavor() == ID_gcc);
-  DATA_INVARIANT(
-    code.operands().size() == 5, "code_asm_gcc must have give operands");
-  return static_cast<const code_asm_gcct &>(code);
+  const code_asm_gcct &ret = static_cast<const code_asm_gcct &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 /// \ref codet representation of an expression statement.
@@ -1803,17 +1821,17 @@ inline void validate_expr(const code_expressiont &x)
 inline code_expressiont &to_code_expression(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_expression);
-  DATA_INVARIANT(
-    code.operands().size() == 1, "expression statement must have one operand");
-  return static_cast<code_expressiont &>(code);
+  code_expressiont &ret = static_cast<code_expressiont &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 inline const code_expressiont &to_code_expression(const codet &code)
 {
   PRECONDITION(code.get_statement() == ID_expression);
-  DATA_INVARIANT(
-    code.operands().size() == 1, "expression statement must have one operand");
-  return static_cast<const code_expressiont &>(code);
+  const code_expressiont &ret = static_cast<const code_expressiont &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 /// An expression containing a side effect.
@@ -2456,17 +2474,17 @@ inline void validate_expr(const code_try_catcht &x)
 inline const code_try_catcht &to_code_try_catch(const codet &code)
 {
   PRECONDITION(code.get_statement() == ID_try_catch);
-  DATA_INVARIANT(
-    code.operands().size() >= 3, "try-catch must have three or more operands");
-  return static_cast<const code_try_catcht &>(code);
+  const code_try_catcht &ret = static_cast<const code_try_catcht &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 inline code_try_catcht &to_code_try_catch(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_try_catch);
-  DATA_INVARIANT(
-    code.operands().size() >= 3, "try-catch must have three or more operands");
-  return static_cast<code_try_catcht &>(code);
+  code_try_catcht &ret = static_cast<code_try_catcht &>(code);
+  validate_expr(code);
+  return ret;
 }
 
 /// This class is used to interface between a language frontend

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -571,8 +571,10 @@ template<> inline bool can_cast_expr<code_assumet>(const exprt &base)
   return detail::can_cast_code_impl(base, ID_assume);
 }
 
-// to_code_assume only checks the code statement, so no validate_expr is
-// provided for code_assumet
+inline void validate_expr(const code_assumet &x)
+{
+  validate_operands(x, 1, "assume must have one operand");
+}
 
 inline const code_assumet &to_code_assume(const codet &code)
 {
@@ -584,11 +586,6 @@ inline code_assumet &to_code_assume(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_assume);
   return static_cast<code_assumet &>(code);
-}
-
-inline void validate_expr(const code_assumet &x)
-{
-  validate_operands(x, 1, "assume must have one operand");
 }
 
 /// A non-fatal assertion, which checks a condition then permits execution to
@@ -628,8 +625,10 @@ template<> inline bool can_cast_expr<code_assertt>(const exprt &base)
   return detail::can_cast_code_impl(base, ID_assert);
 }
 
-// to_code_assert only checks the code statement, so no validate_expr is
-// provided for code_assertt
+inline void validate_expr(const code_assertt &x)
+{
+  validate_operands(x, 1, "assert must have one operand");
+}
 
 inline const code_assertt &to_code_assert(const codet &code)
 {
@@ -641,11 +640,6 @@ inline code_assertt &to_code_assert(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_assert);
   return static_cast<code_assertt &>(code);
-}
-
-inline void validate_expr(const code_assertt &x)
-{
-  validate_operands(x, 1, "assert must have one operand");
 }
 
 /// Create a fatal assertion, which checks a condition and then halts if it does
@@ -1246,8 +1240,10 @@ template<> inline bool can_cast_expr<code_function_callt>(const exprt &base)
   return detail::can_cast_code_impl(base, ID_function_call);
 }
 
-// to_code_function_call only checks the code statement, so no validate_expr is
-// provided for code_function_callt
+inline void validate_expr(const code_function_callt &x)
+{
+  validate_operands(x, 3, "function calls must have three operands");
+}
 
 inline const code_function_callt &to_code_function_call(const codet &code)
 {
@@ -1259,11 +1255,6 @@ inline code_function_callt &to_code_function_call(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_function_call);
   return static_cast<code_function_callt &>(code);
-}
-
-inline void validate_expr(const code_function_callt &x)
-{
-  validate_operands(x, 3, "function calls must have three operands");
 }
 
 /// \ref codet representation of a "return from a function" statement.
@@ -1312,8 +1303,10 @@ template<> inline bool can_cast_expr<code_returnt>(const exprt &base)
   return detail::can_cast_code_impl(base, ID_return);
 }
 
-// to_code_return only checks the code statement, so no validate_expr is
-// provided for code_returnt
+inline void validate_expr(const code_returnt &x)
+{
+  validate_operands(x, 1, "return must have one operand");
+}
 
 inline const code_returnt &to_code_return(const codet &code)
 {
@@ -1325,11 +1318,6 @@ inline code_returnt &to_code_return(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_return);
   return static_cast<code_returnt &>(code);
-}
-
-inline void validate_expr(const code_returnt &x)
-{
-  validate_operands(x, 1, "return must have one operand");
 }
 
 /// \ref codet representation of a label for branch targets.
@@ -1760,8 +1748,10 @@ inline bool can_cast_expr<code_asm_gcct>(const exprt &base)
   return detail::can_cast_code_impl(base, ID_asm);
 }
 
-// to_code_asm_gcc only checks the code statement, so no validate_expr is
-// provided for code_asmt
+inline void validate_expr(const code_asm_gcct &x)
+{
+  validate_operands(x, 5, "code_asm_gcc must have five operands");
+}
 
 inline code_asm_gcct &to_code_asm_gcc(codet &code)
 {

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -364,7 +364,7 @@ template<> inline bool can_cast_expr<code_assignt>(const exprt &base)
 
 inline void validate_expr(const code_assignt & x)
 {
-  validate_operands(x, 2, "assignment must have two operands");
+  code_assignt::check(x);
 }
 
 inline const code_assignt &to_code_assign(const codet &code)
@@ -432,29 +432,20 @@ template<> inline bool can_cast_expr<code_declt>(const exprt &base)
 
 inline void validate_expr(const code_declt &x)
 {
-  validate_operands(x, 1, "decls must have one or more operands", true);
+  code_declt::check(x);
 }
 
 inline const code_declt &to_code_decl(const codet &code)
 {
   PRECONDITION(code.get_statement() == ID_decl);
-
-  // will be size()==1 in the future
-  DATA_INVARIANT(
-    code.operands().size() >= 1, "decls must have one or more operands");
-  DATA_INVARIANT(
-    code.op0().id() == ID_symbol, "decls symbols must be a \"symbol\"");
-
+  code_declt::check(code);
   return static_cast<const code_declt &>(code);
 }
 
 inline code_declt &to_code_decl(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_decl);
-
-  // will be size()==1 in the future
-  DATA_INVARIANT(
-    code.operands().size() >= 1, "decls must have one or more operands");
+  code_declt::check(code);
   return static_cast<code_declt &>(code);
 }
 
@@ -510,28 +501,20 @@ template<> inline bool can_cast_expr<code_deadt>(const exprt &base)
 
 inline void validate_expr(const code_deadt &x)
 {
-  validate_operands(x, 1, "dead statement must have one operand");
+  code_deadt::check(x);
 }
 
 inline const code_deadt &to_code_dead(const codet &code)
 {
   PRECONDITION(code.get_statement() == ID_dead);
-  DATA_INVARIANT(
-    code.operands().size() == 1, "dead statement must have one operand");
-  DATA_INVARIANT(
-    to_unary_expr(code).op().id() == ID_symbol,
-    "dead statement must take symbol operand");
+  code_deadt::check(code);
   return static_cast<const code_deadt &>(code);
 }
 
 inline code_deadt &to_code_dead(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_dead);
-  DATA_INVARIANT(
-    code.operands().size() == 1, "dead statement must have one operand");
-  DATA_INVARIANT(
-    to_unary_expr(code).op().id() == ID_symbol,
-    "dead statement must take symbol operand");
+  code_deadt::check(code);
   return static_cast<code_deadt &>(code);
 }
 
@@ -1242,18 +1225,20 @@ template<> inline bool can_cast_expr<code_function_callt>(const exprt &base)
 
 inline void validate_expr(const code_function_callt &x)
 {
-  validate_operands(x, 3, "function calls must have three operands");
+  code_function_callt::check(x);
 }
 
 inline const code_function_callt &to_code_function_call(const codet &code)
 {
   PRECONDITION(code.get_statement() == ID_function_call);
+  code_function_callt::check(code);
   return static_cast<const code_function_callt &>(code);
 }
 
 inline code_function_callt &to_code_function_call(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_function_call);
+  code_function_callt::check(code);
   return static_cast<code_function_callt &>(code);
 }
 
@@ -1305,18 +1290,20 @@ template<> inline bool can_cast_expr<code_returnt>(const exprt &base)
 
 inline void validate_expr(const code_returnt &x)
 {
-  validate_operands(x, 1, "return must have one operand");
+  code_returnt::check(x);
 }
 
 inline const code_returnt &to_code_return(const codet &code)
 {
   PRECONDITION(code.get_statement() == ID_return);
+  code_returnt::check(code);
   return static_cast<const code_returnt &>(code);
 }
 
 inline code_returnt &to_code_return(codet &code)
 {
   PRECONDITION(code.get_statement() == ID_return);
+  code_returnt::check(code);
   return static_cast<code_returnt &>(code);
 }
 

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -206,6 +206,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<symbol_exprt>(const exprt &base)
+{
+  return base.id() == ID_symbol;
+}
+
+inline void validate_expr(const symbol_exprt &value)
+{
+  validate_operands(value, 0, "Symbols must not have operands");
+}
+
 /// \brief Cast an exprt to a \ref symbol_exprt
 ///
 /// \a expr must be known to be \ref symbol_exprt.
@@ -225,15 +236,6 @@ inline symbol_exprt &to_symbol_expr(exprt &expr)
   PRECONDITION(expr.id()==ID_symbol);
   DATA_INVARIANT(!expr.has_operands(), "Symbols must not have operands");
   return static_cast<symbol_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<symbol_exprt>(const exprt &base)
-{
-  return base.id()==ID_symbol;
-}
-inline void validate_expr(const symbol_exprt &value)
-{
-  validate_operands(value, 0, "Symbols must not have operands");
 }
 
 
@@ -260,6 +262,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<nondet_symbol_exprt>(const exprt &base)
+{
+  return base.id() == ID_nondet_symbol;
+}
+
+inline void validate_expr(const nondet_symbol_exprt &value)
+{
+  validate_operands(value, 0, "Symbols must not have operands");
+}
+
 /// \brief Cast an exprt to a \ref nondet_symbol_exprt
 ///
 /// \a expr must be known to be \ref nondet_symbol_exprt.
@@ -279,15 +292,6 @@ inline nondet_symbol_exprt &to_nondet_symbol_expr(exprt &expr)
   PRECONDITION(expr.id()==ID_symbol);
   DATA_INVARIANT(!expr.has_operands(), "Symbols must not have operands");
   return static_cast<nondet_symbol_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<nondet_symbol_exprt>(const exprt &base)
-{
-  return base.id()==ID_nondet_symbol;
-}
-inline void validate_expr(const nondet_symbol_exprt &value)
-{
-  validate_operands(value, 0, "Symbols must not have operands");
 }
 
 
@@ -344,6 +348,12 @@ public:
   exprt &op3() = delete;
 };
 
+template <>
+inline bool can_cast_expr<unary_exprt>(const exprt &base)
+{
+  return base.operands().size() == 1;
+}
+
 /// \brief Cast an exprt to a \ref unary_exprt
 ///
 /// \a expr must be known to be \ref unary_exprt.
@@ -367,11 +377,6 @@ inline unary_exprt &to_unary_expr(exprt &expr)
   return static_cast<unary_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<unary_exprt>(const exprt &base)
-{
-  return base.operands().size()==1;
-}
-
 
 /// \brief Absolute value
 class abs_exprt:public unary_exprt
@@ -387,6 +392,17 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<abs_exprt>(const exprt &base)
+{
+  return base.id() == ID_abs;
+}
+
+inline void validate_expr(const abs_exprt &value)
+{
+  validate_operands(value, 1, "Absolute value must have one operand");
+}
 
 /// \brief Cast an exprt to a \ref abs_exprt
 ///
@@ -413,15 +429,6 @@ inline abs_exprt &to_abs_expr(exprt &expr)
   return static_cast<abs_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<abs_exprt>(const exprt &base)
-{
-  return base.id()==ID_abs;
-}
-inline void validate_expr(const abs_exprt &value)
-{
-  validate_operands(value, 1, "Absolute value must have one operand");
-}
-
 
 /// \brief The unary minus expression
 class unary_minus_exprt:public unary_exprt
@@ -444,6 +451,17 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<unary_minus_exprt>(const exprt &base)
+{
+  return base.id() == ID_unary_minus;
+}
+
+inline void validate_expr(const unary_minus_exprt &value)
+{
+  validate_operands(value, 1, "Unary minus must have one operand");
+}
 
 /// \brief Cast an exprt to a \ref unary_minus_exprt
 ///
@@ -470,15 +488,6 @@ inline unary_minus_exprt &to_unary_minus_expr(exprt &expr)
   return static_cast<unary_minus_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<unary_minus_exprt>(const exprt &base)
-{
-  return base.id()==ID_unary_minus;
-}
-inline void validate_expr(const unary_minus_exprt &value)
-{
-  validate_operands(value, 1, "Unary minus must have one operand");
-}
-
 /// \brief The unary plus expression
 class unary_plus_exprt : public unary_exprt
 {
@@ -488,6 +497,17 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<unary_plus_exprt>(const exprt &base)
+{
+  return base.id() == ID_unary_plus;
+}
+
+inline void validate_expr(const unary_plus_exprt &value)
+{
+  validate_operands(value, 1, "unary plus must have one operand");
+}
 
 /// \brief Cast an exprt to a \ref unary_plus_exprt
 ///
@@ -510,16 +530,6 @@ inline unary_plus_exprt &to_unary_plus_expr(exprt &expr)
   DATA_INVARIANT(
     expr.operands().size() == 1, "unary plus must have one operand");
   return static_cast<unary_plus_exprt &>(expr);
-}
-
-template <>
-inline bool can_cast_expr<unary_plus_exprt>(const exprt &base)
-{
-  return base.id() == ID_unary_plus;
-}
-inline void validate_expr(const unary_plus_exprt &value)
-{
-  validate_operands(value, 1, "unary plus must have one operand");
 }
 
 /// \brief The byte swap expression
@@ -549,6 +559,19 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<bswap_exprt>(const exprt &base)
+{
+  return base.id() == ID_bswap;
+}
+
+inline void validate_expr(const bswap_exprt &value)
+{
+  validate_operands(value, 1, "bswap must have one operand");
+  DATA_INVARIANT(
+    value.op().type() == value.type(), "bswap type must match operand type");
+}
+
 /// \brief Cast an exprt to a \ref bswap_exprt
 ///
 /// \a expr must be known to be \ref bswap_exprt.
@@ -572,18 +595,6 @@ inline bswap_exprt &to_bswap_expr(exprt &expr)
   DATA_INVARIANT(
     expr.op0().type() == expr.type(), "bswap type must match operand type");
   return static_cast<bswap_exprt &>(expr);
-}
-
-template <>
-inline bool can_cast_expr<bswap_exprt>(const exprt &base)
-{
-  return base.id() == ID_bswap;
-}
-inline void validate_expr(const bswap_exprt &value)
-{
-  validate_operands(value, 1, "bswap must have one operand");
-  DATA_INVARIANT(
-    value.op().type() == value.type(), "bswap type must match operand type");
 }
 
 /// \brief A base class for expressions that are predicates,
@@ -656,6 +667,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<sign_exprt>(const exprt &base)
+{
+  return base.id() == ID_sign;
+}
+
+inline void validate_expr(const sign_exprt &expr)
+{
+  validate_operands(expr, 1, "sign expression must have one operand");
+}
+
 /// \brief Cast an exprt to a \ref sign_exprt
 ///
 /// \a expr must be known to be a \ref sign_exprt.
@@ -677,16 +699,6 @@ inline sign_exprt &to_sign_expr(exprt &expr)
   DATA_INVARIANT(
     expr.operands().size() == 1, "sign expression must have one operand");
   return static_cast<sign_exprt &>(expr);
-}
-
-template <>
-inline bool can_cast_expr<sign_exprt>(const exprt &base)
-{
-  return base.id() == ID_sign;
-}
-inline void validate_expr(const sign_exprt &expr)
-{
-  validate_operands(expr, 1, "sign expression must have one operand");
 }
 
 /// \brief A base class for binary expressions
@@ -756,6 +768,12 @@ public:
   exprt &op3() = delete;
 };
 
+template <>
+inline bool can_cast_expr<binary_exprt>(const exprt &base)
+{
+  return base.operands().size() == 2;
+}
+
 /// \brief Cast an exprt to a \ref binary_exprt
 ///
 /// \a expr must be known to be \ref binary_exprt.
@@ -777,11 +795,6 @@ inline binary_exprt &to_binary_expr(exprt &expr)
     expr.operands().size()==2,
     "Binary expressions must have two operands");
   return static_cast<binary_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<binary_exprt>(const exprt &base)
-{
-  return base.operands().size()==2;
 }
 
 /// \brief A base class for expressions that are predicates,
@@ -893,6 +906,12 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<binary_relation_exprt>(const exprt &base)
+{
+  return can_cast_expr<binary_exprt>(base);
+}
+
 /// \brief Cast an exprt to a \ref binary_relation_exprt
 ///
 /// \a expr must be known to be \ref binary_relation_exprt.
@@ -914,11 +933,6 @@ inline binary_relation_exprt &to_binary_relation_expr(exprt &expr)
     expr.operands().size()==2,
     "Binary relations must have two operands");
   return static_cast<binary_relation_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<binary_relation_exprt>(const exprt &base)
-{
-  return can_cast_expr<binary_exprt>(base);
 }
 
 
@@ -1073,6 +1087,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<plus_exprt>(const exprt &base)
+{
+  return base.id() == ID_plus;
+}
+
+inline void validate_expr(const plus_exprt &value)
+{
+  validate_operands(value, 2, "Plus must have two or more operands", true);
+}
+
 /// \brief Cast an exprt to a \ref plus_exprt
 ///
 /// \a expr must be known to be \ref plus_exprt.
@@ -1098,15 +1123,6 @@ inline plus_exprt &to_plus_expr(exprt &expr)
   return static_cast<plus_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<plus_exprt>(const exprt &base)
-{
-  return base.id()==ID_plus;
-}
-inline void validate_expr(const plus_exprt &value)
-{
-  validate_operands(value, 2, "Plus must have two or more operands", true);
-}
-
 
 /// \brief Binary minus
 class minus_exprt:public binary_exprt
@@ -1124,6 +1140,17 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<minus_exprt>(const exprt &base)
+{
+  return base.id() == ID_minus;
+}
+
+inline void validate_expr(const minus_exprt &value)
+{
+  validate_operands(value, 2, "Minus must have two or more operands", true);
+}
 
 /// \brief Cast an exprt to a \ref minus_exprt
 ///
@@ -1150,15 +1177,6 @@ inline minus_exprt &to_minus_expr(exprt &expr)
   return static_cast<minus_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<minus_exprt>(const exprt &base)
-{
-  return base.id()==ID_minus;
-}
-inline void validate_expr(const minus_exprt &value)
-{
-  validate_operands(value, 2, "Minus must have two or more operands", true);
-}
-
 
 /// \brief Binary multiplication
 /// Associativity is not specified.
@@ -1177,6 +1195,17 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<mult_exprt>(const exprt &base)
+{
+  return base.id() == ID_mult;
+}
+
+inline void validate_expr(const mult_exprt &value)
+{
+  validate_operands(value, 2, "Multiply must have two or more operands", true);
+}
 
 /// \brief Cast an exprt to a \ref mult_exprt
 ///
@@ -1201,15 +1230,6 @@ inline mult_exprt &to_mult_expr(exprt &expr)
     expr.operands().size()>=2,
     "Multiply must have two or more operands");
   return static_cast<mult_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<mult_exprt>(const exprt &base)
-{
-  return base.id()==ID_mult;
-}
-inline void validate_expr(const mult_exprt &value)
-{
-  validate_operands(value, 2, "Multiply must have two or more operands", true);
 }
 
 
@@ -1254,6 +1274,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<div_exprt>(const exprt &base)
+{
+  return base.id() == ID_div;
+}
+
+inline void validate_expr(const div_exprt &value)
+{
+  validate_operands(value, 2, "Divide must have two operands");
+}
+
 /// \brief Cast an exprt to a \ref div_exprt
 ///
 /// \a expr must be known to be \ref div_exprt.
@@ -1279,15 +1310,6 @@ inline div_exprt &to_div_expr(exprt &expr)
   return static_cast<div_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<div_exprt>(const exprt &base)
-{
-  return base.id()==ID_div;
-}
-inline void validate_expr(const div_exprt &value)
-{
-  validate_operands(value, 2, "Divide must have two operands");
-}
-
 
 /// \brief Modulo
 class mod_exprt:public binary_exprt
@@ -1305,6 +1327,17 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<mod_exprt>(const exprt &base)
+{
+  return base.id() == ID_mod;
+}
+
+inline void validate_expr(const mod_exprt &value)
+{
+  validate_operands(value, 2, "Modulo must have two operands");
+}
 
 /// \brief Cast an exprt to a \ref mod_exprt
 ///
@@ -1327,15 +1360,6 @@ inline mod_exprt &to_mod_expr(exprt &expr)
   return static_cast<mod_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<mod_exprt>(const exprt &base)
-{
-  return base.id()==ID_mod;
-}
-inline void validate_expr(const mod_exprt &value)
-{
-  validate_operands(value, 2, "Modulo must have two operands");
-}
-
 
 /// \brief Remainder of division
 class rem_exprt:public binary_exprt
@@ -1353,6 +1377,17 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<rem_exprt>(const exprt &base)
+{
+  return base.id() == ID_rem;
+}
+
+inline void validate_expr(const rem_exprt &value)
+{
+  validate_operands(value, 2, "Remainder must have two operands");
+}
 
 /// \brief Cast an exprt to a \ref rem_exprt
 ///
@@ -1373,15 +1408,6 @@ inline rem_exprt &to_rem_expr(exprt &expr)
   PRECONDITION(expr.id()==ID_rem);
   DATA_INVARIANT(expr.operands().size()==2, "Remainder must have two operands");
   return static_cast<rem_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<rem_exprt>(const exprt &base)
-{
-  return base.id()==ID_rem;
-}
-inline void validate_expr(const rem_exprt &value)
-{
-  validate_operands(value, 2, "Remainder must have two operands");
 }
 
 
@@ -1415,6 +1441,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<equal_exprt>(const exprt &base)
+{
+  return base.id() == ID_equal;
+}
+
+inline void validate_expr(const equal_exprt &value)
+{
+  validate_operands(value, 2, "Equality must have two operands");
+}
+
 /// \brief Cast an exprt to an \ref equal_exprt
 ///
 /// \a expr must be known to be \ref equal_exprt.
@@ -1436,15 +1473,6 @@ inline equal_exprt &to_equal_expr(exprt &expr)
   return static_cast<equal_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<equal_exprt>(const exprt &base)
-{
-  return base.id()==ID_equal;
-}
-inline void validate_expr(const equal_exprt &value)
-{
-  validate_operands(value, 2, "Equality must have two operands");
-}
-
 
 /// \brief Disequality
 class notequal_exprt:public binary_relation_exprt
@@ -1460,6 +1488,17 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<notequal_exprt>(const exprt &base)
+{
+  return base.id() == ID_notequal;
+}
+
+inline void validate_expr(const notequal_exprt &value)
+{
+  validate_operands(value, 2, "Inequality must have two operands");
+}
 
 /// \brief Cast an exprt to an \ref notequal_exprt
 ///
@@ -1484,15 +1523,6 @@ inline notequal_exprt &to_notequal_expr(exprt &expr)
     expr.operands().size()==2,
     "Inequality must have two operands");
   return static_cast<notequal_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<notequal_exprt>(const exprt &base)
-{
-  return base.id()==ID_notequal;
-}
-inline void validate_expr(const notequal_exprt &value)
-{
-  validate_operands(value, 2, "Inequality must have two operands");
 }
 
 
@@ -1544,6 +1574,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<index_exprt>(const exprt &base)
+{
+  return base.id() == ID_index;
+}
+
+inline void validate_expr(const index_exprt &value)
+{
+  validate_operands(value, 2, "Array index must have two operands");
+}
+
 /// \brief Cast an exprt to an \ref index_exprt
 ///
 /// \a expr must be known to be \ref index_exprt.
@@ -1567,15 +1608,6 @@ inline index_exprt &to_index_expr(exprt &expr)
     expr.operands().size()==2,
     "Array index must have two operands");
   return static_cast<index_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<index_exprt>(const exprt &base)
-{
-  return base.id()==ID_index;
-}
-inline void validate_expr(const index_exprt &value)
-{
-  validate_operands(value, 2, "Array index must have two operands");
 }
 
 
@@ -1605,6 +1637,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<array_of_exprt>(const exprt &base)
+{
+  return base.id() == ID_array_of;
+}
+
+inline void validate_expr(const array_of_exprt &value)
+{
+  validate_operands(value, 1, "'Array of' must have one operand");
+}
+
 /// \brief Cast an exprt to an \ref array_of_exprt
 ///
 /// \a expr must be known to be \ref array_of_exprt.
@@ -1630,15 +1673,6 @@ inline array_of_exprt &to_array_of_expr(exprt &expr)
   return static_cast<array_of_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<array_of_exprt>(const exprt &base)
-{
-  return base.id()==ID_array_of;
-}
-inline void validate_expr(const array_of_exprt &value)
-{
-  validate_operands(value, 1, "'Array of' must have one operand");
-}
-
 
 /// \brief Array constructor from list of elements
 class array_exprt : public multi_ary_exprt
@@ -1661,6 +1695,12 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<array_exprt>(const exprt &base)
+{
+  return base.id() == ID_array;
+}
+
 /// \brief Cast an exprt to an \ref array_exprt
 ///
 /// \a expr must be known to be \ref array_exprt.
@@ -1678,11 +1718,6 @@ inline array_exprt &to_array_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_array);
   return static_cast<array_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<array_exprt>(const exprt &base)
-{
-  return base.id()==ID_array;
 }
 
 /// Array constructor from a list of index-element pairs
@@ -1734,6 +1769,12 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<vector_exprt>(const exprt &base)
+{
+  return base.id() == ID_vector;
+}
+
 /// \brief Cast an exprt to an \ref vector_exprt
 ///
 /// \a expr must be known to be \ref vector_exprt.
@@ -1751,11 +1792,6 @@ inline vector_exprt &to_vector_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_vector);
   return static_cast<vector_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<vector_exprt>(const exprt &base)
-{
-  return base.id()==ID_vector;
 }
 
 
@@ -1804,6 +1840,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<union_exprt>(const exprt &base)
+{
+  return base.id() == ID_union;
+}
+
+inline void validate_expr(const union_exprt &value)
+{
+  validate_operands(value, 1, "Union constructor must have one operand");
+}
+
 /// \brief Cast an exprt to a \ref union_exprt
 ///
 /// \a expr must be known to be \ref union_exprt.
@@ -1827,15 +1874,6 @@ inline union_exprt &to_union_expr(exprt &expr)
     expr.operands().size()==1,
     "Union constructor must have one operand");
   return static_cast<union_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<union_exprt>(const exprt &base)
-{
-  return base.id()==ID_union;
-}
-inline void validate_expr(const union_exprt &value)
-{
-  validate_operands(value, 1, "Union constructor must have one operand");
 }
 
 
@@ -1862,6 +1900,12 @@ public:
   const exprt &component(const irep_idt &name, const namespacet &ns) const;
 };
 
+template <>
+inline bool can_cast_expr<struct_exprt>(const exprt &base)
+{
+  return base.id() == ID_struct;
+}
+
 /// \brief Cast an exprt to a \ref struct_exprt
 ///
 /// \a expr must be known to be \ref struct_exprt.
@@ -1879,11 +1923,6 @@ inline struct_exprt &to_struct_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_struct);
   return static_cast<struct_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<struct_exprt>(const exprt &base)
-{
-  return base.id()==ID_struct;
 }
 
 
@@ -1931,6 +1970,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<complex_exprt>(const exprt &base)
+{
+  return base.id() == ID_complex;
+}
+
+inline void validate_expr(const complex_exprt &value)
+{
+  validate_operands(value, 2, "Complex constructor must have two operands");
+}
+
 /// \brief Cast an exprt to a \ref complex_exprt
 ///
 /// \a expr must be known to be \ref complex_exprt.
@@ -1956,15 +2006,6 @@ inline complex_exprt &to_complex_expr(exprt &expr)
   return static_cast<complex_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<complex_exprt>(const exprt &base)
-{
-  return base.id()==ID_complex;
-}
-inline void validate_expr(const complex_exprt &value)
-{
-  validate_operands(value, 2, "Complex constructor must have two operands");
-}
-
 /// \brief Real part of the expression describing a complex number.
 class complex_real_exprt : public unary_exprt
 {
@@ -1974,6 +2015,18 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<complex_real_exprt>(const exprt &base)
+{
+  return base.id() == ID_complex_real;
+}
+
+inline void validate_expr(const complex_real_exprt &expr)
+{
+  validate_operands(
+    expr, 1, "real part retrieval operation must have one operand");
+}
 
 /// \brief Cast an exprt to a \ref complex_real_exprt
 ///
@@ -2000,18 +2053,6 @@ inline complex_real_exprt &to_complex_real_expr(exprt &expr)
   return static_cast<complex_real_exprt &>(expr);
 }
 
-template <>
-inline bool can_cast_expr<complex_real_exprt>(const exprt &base)
-{
-  return base.id() == ID_complex_real;
-}
-
-inline void validate_expr(const complex_real_exprt &expr)
-{
-  validate_operands(
-    expr, 1, "real part retrieval operation must have one operand");
-}
-
 /// \brief Imaginary part of the expression describing a complex number.
 class complex_imag_exprt : public unary_exprt
 {
@@ -2021,6 +2062,18 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<complex_imag_exprt>(const exprt &base)
+{
+  return base.id() == ID_complex_imag;
+}
+
+inline void validate_expr(const complex_imag_exprt &expr)
+{
+  validate_operands(
+    expr, 1, "imaginary part retrieval operation must have one operand");
+}
 
 /// \brief Cast an exprt to a \ref complex_imag_exprt
 ///
@@ -2045,18 +2098,6 @@ inline complex_imag_exprt &to_complex_imag_expr(exprt &expr)
     expr.operands().size() == 1,
     "imaginary part retrieval operation must have one operand");
   return static_cast<complex_imag_exprt &>(expr);
-}
-
-template <>
-inline bool can_cast_expr<complex_imag_exprt>(const exprt &base)
-{
-  return base.id() == ID_complex_imag;
-}
-
-inline void validate_expr(const complex_imag_exprt &expr)
-{
-  validate_operands(
-    expr, 1, "imaginary part retrieval operation must have one operand");
 }
 
 class namespacet;
@@ -2099,6 +2140,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<object_descriptor_exprt>(const exprt &base)
+{
+  return base.id() == ID_object_descriptor;
+}
+
+inline void validate_expr(const object_descriptor_exprt &value)
+{
+  validate_operands(value, 2, "Object descriptor must have two operands");
+}
+
 /// \brief Cast an exprt to an \ref object_descriptor_exprt
 ///
 /// \a expr must be known to be \ref object_descriptor_exprt.
@@ -2123,16 +2175,6 @@ inline object_descriptor_exprt &to_object_descriptor_expr(exprt &expr)
     expr.operands().size()==2,
     "Object descriptor must have two operands");
   return static_cast<object_descriptor_exprt &>(expr);
-}
-
-template<>
-inline bool can_cast_expr<object_descriptor_exprt>(const exprt &base)
-{
-  return base.id()==ID_object_descriptor;
-}
-inline void validate_expr(const object_descriptor_exprt &value)
-{
-  validate_operands(value, 2, "Object descriptor must have two operands");
 }
 
 
@@ -2169,6 +2211,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<dynamic_object_exprt>(const exprt &base)
+{
+  return base.id() == ID_dynamic_object;
+}
+
+inline void validate_expr(const dynamic_object_exprt &value)
+{
+  validate_operands(value, 2, "Dynamic object must have two operands");
+}
+
 /// \brief Cast an exprt to a \ref dynamic_object_exprt
 ///
 /// \a expr must be known to be \ref dynamic_object_exprt.
@@ -2193,16 +2246,6 @@ inline dynamic_object_exprt &to_dynamic_object_expr(exprt &expr)
     expr.operands().size()==2,
     "Dynamic object must have two operands");
   return static_cast<dynamic_object_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<dynamic_object_exprt>(const exprt &base)
-{
-  return base.id()==ID_dynamic_object;
-}
-
-inline void validate_expr(const dynamic_object_exprt &value)
-{
-  validate_operands(value, 2, "Dynamic object must have two operands");
 }
 
 
@@ -2230,6 +2273,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<typecast_exprt>(const exprt &base)
+{
+  return base.id() == ID_typecast;
+}
+
+inline void validate_expr(const typecast_exprt &value)
+{
+  validate_operands(value, 1, "Typecast must have one operand");
+}
+
 /// \brief Cast an exprt to a \ref typecast_exprt
 ///
 /// \a expr must be known to be \ref typecast_exprt.
@@ -2253,15 +2307,6 @@ inline typecast_exprt &to_typecast_expr(exprt &expr)
     expr.operands().size()==1,
     "Typecast must have one operand");
   return static_cast<typecast_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<typecast_exprt>(const exprt &base)
-{
-  return base.id()==ID_typecast;
-}
-inline void validate_expr(const typecast_exprt &value)
-{
-  validate_operands(value, 1, "Typecast must have one operand");
 }
 
 
@@ -2302,6 +2347,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<floatbv_typecast_exprt>(const exprt &base)
+{
+  return base.id() == ID_floatbv_typecast;
+}
+
+inline void validate_expr(const floatbv_typecast_exprt &value)
+{
+  validate_operands(value, 2, "Float typecast must have two operands");
+}
+
 /// \brief Cast an exprt to a \ref floatbv_typecast_exprt
 ///
 /// \a expr must be known to be \ref floatbv_typecast_exprt.
@@ -2325,16 +2381,6 @@ inline floatbv_typecast_exprt &to_floatbv_typecast_expr(exprt &expr)
     expr.operands().size()==2,
     "Float typecast must have two operands");
   return static_cast<floatbv_typecast_exprt &>(expr);
-}
-
-template<>
-inline bool can_cast_expr<floatbv_typecast_exprt>(const exprt &base)
-{
-  return base.id()==ID_floatbv_typecast;
-}
-inline void validate_expr(const floatbv_typecast_exprt &value)
-{
-  validate_operands(value, 2, "Float typecast must have two operands");
 }
 
 
@@ -2378,6 +2424,17 @@ public:
 
 exprt conjunction(const exprt::operandst &);
 
+template <>
+inline bool can_cast_expr<and_exprt>(const exprt &base)
+{
+  return base.id() == ID_and;
+}
+
+// inline void validate_expr(const and_exprt &value)
+// {
+//   validate_operands(value, 2, "And must have two or more operands", true);
+// }
+
 /// \brief Cast an exprt to a \ref and_exprt
 ///
 /// \a expr must be known to be \ref and_exprt.
@@ -2403,15 +2460,6 @@ inline and_exprt &to_and_expr(exprt &expr)
   return static_cast<and_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<and_exprt>(const exprt &base)
-{
-  return base.id()==ID_and;
-}
-// inline void validate_expr(const and_exprt &value)
-// {
-//   validate_operands(value, 2, "And must have two or more operands", true);
-// }
-
 
 /// \brief Boolean implication
 class implies_exprt:public binary_exprt
@@ -2427,6 +2475,17 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<implies_exprt>(const exprt &base)
+{
+  return base.id() == ID_implies;
+}
+
+inline void validate_expr(const implies_exprt &value)
+{
+  validate_operands(value, 2, "Implies must have two operands");
+}
 
 /// \brief Cast an exprt to a \ref implies_exprt
 ///
@@ -2447,15 +2506,6 @@ inline implies_exprt &to_implies_expr(exprt &expr)
   PRECONDITION(expr.id()==ID_implies);
   DATA_INVARIANT(expr.operands().size()==2, "Implies must have two operands");
   return static_cast<implies_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<implies_exprt>(const exprt &base)
-{
-  return base.id()==ID_implies;
-}
-inline void validate_expr(const implies_exprt &value)
-{
-  validate_operands(value, 2, "Implies must have two operands");
 }
 
 
@@ -2499,6 +2549,17 @@ public:
 
 exprt disjunction(const exprt::operandst &);
 
+template <>
+inline bool can_cast_expr<or_exprt>(const exprt &base)
+{
+  return base.id() == ID_or;
+}
+
+// inline void validate_expr(const or_exprt &value)
+// {
+//   validate_operands(value, 2, "Or must have two or more operands", true);
+// }
+
 /// \brief Cast an exprt to a \ref or_exprt
 ///
 /// \a expr must be known to be \ref or_exprt.
@@ -2524,15 +2585,6 @@ inline or_exprt &to_or_expr(exprt &expr)
   return static_cast<or_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<or_exprt>(const exprt &base)
-{
-  return base.id()==ID_or;
-}
-// inline void validate_expr(const or_exprt &value)
-// {
-//   validate_operands(value, 2, "Or must have two or more operands", true);
-// }
-
 
 /// \brief Boolean XOR
 class xor_exprt:public multi_ary_exprt
@@ -2548,6 +2600,21 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<xor_exprt>(const exprt &base)
+{
+  return base.id() == ID_xor;
+}
+
+// inline void validate_expr(const bitxor_exprt &value)
+// {
+//   validate_operands(
+//     value,
+//     2,
+//     "Bit-wise xor must have two or more operands",
+//     true);
+// }
 
 /// \brief Cast an exprt to a \ref xor_exprt
 ///
@@ -2568,19 +2635,6 @@ inline xor_exprt &to_xor_expr(exprt &expr)
   return static_cast<xor_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<xor_exprt>(const exprt &base)
-{
-  return base.id()==ID_xor;
-}
-// inline void validate_expr(const bitxor_exprt &value)
-// {
-//   validate_operands(
-//     value,
-//     2,
-//     "Bit-wise xor must have two or more operands",
-//     true);
-// }
-
 
 /// \brief Bit-wise negation of bit-vectors
 class bitnot_exprt:public unary_exprt
@@ -2596,6 +2650,17 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<bitnot_exprt>(const exprt &base)
+{
+  return base.id() == ID_bitnot;
+}
+
+// inline void validate_expr(const bitnot_exprt &value)
+// {
+//   validate_operands(value, 1, "Bit-wise not must have one operand");
+// }
 
 /// \brief Cast an exprt to a \ref bitnot_exprt
 ///
@@ -2620,15 +2685,6 @@ inline bitnot_exprt &to_bitnot_expr(exprt &expr)
   return static_cast<bitnot_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<bitnot_exprt>(const exprt &base)
-{
-  return base.id()==ID_bitnot;
-}
-// inline void validate_expr(const bitnot_exprt &value)
-// {
-//   validate_operands(value, 1, "Bit-wise not must have one operand");
-// }
-
 
 /// \brief Bit-wise OR
 class bitor_exprt:public multi_ary_exprt
@@ -2644,6 +2700,21 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<bitor_exprt>(const exprt &base)
+{
+  return base.id() == ID_bitor;
+}
+
+// inline void validate_expr(const bitor_exprt &value)
+// {
+//   validate_operands(
+//     value,
+//     2,
+//     "Bit-wise or must have two or more operands",
+//     true);
+// }
 
 /// \brief Cast an exprt to a \ref bitor_exprt
 ///
@@ -2670,19 +2741,6 @@ inline bitor_exprt &to_bitor_expr(exprt &expr)
   return static_cast<bitor_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<bitor_exprt>(const exprt &base)
-{
-  return base.id()==ID_bitor;
-}
-// inline void validate_expr(const bitor_exprt &value)
-// {
-//   validate_operands(
-//     value,
-//     2,
-//     "Bit-wise or must have two or more operands",
-//     true);
-// }
-
 
 /// \brief Bit-wise XOR
 class bitxor_exprt:public multi_ary_exprt
@@ -2698,6 +2756,21 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<bitxor_exprt>(const exprt &base)
+{
+  return base.id() == ID_bitxor;
+}
+
+// inline void validate_expr(const bitxor_exprt &value)
+// {
+//   validate_operands(
+//     value,
+//     2,
+//     "Bit-wise xor must have two or more operands",
+//     true);
+// }
 
 /// \brief Cast an exprt to a \ref bitxor_exprt
 ///
@@ -2724,19 +2797,6 @@ inline bitxor_exprt &to_bitxor_expr(exprt &expr)
   return static_cast<bitxor_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<bitxor_exprt>(const exprt &base)
-{
-  return base.id()==ID_bitxor;
-}
-// inline void validate_expr(const bitxor_exprt &value)
-// {
-//   validate_operands(
-//     value,
-//     2,
-//     "Bit-wise xor must have two or more operands",
-//     true);
-// }
-
 
 /// \brief Bit-wise AND
 class bitand_exprt:public multi_ary_exprt
@@ -2752,6 +2812,21 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<bitand_exprt>(const exprt &base)
+{
+  return base.id() == ID_bitand;
+}
+
+// inline void validate_expr(const bitand_exprt &value)
+// {
+//   validate_operands(
+//     value,
+//     2,
+//     "Bit-wise and must have two or more operands",
+//     true);
+// }
 
 /// \brief Cast an exprt to a \ref bitand_exprt
 ///
@@ -2777,19 +2852,6 @@ inline bitand_exprt &to_bitand_expr(exprt &expr)
   //   "Bit-wise and must have two or more operands");
   return static_cast<bitand_exprt &>(expr);
 }
-
-template<> inline bool can_cast_expr<bitand_exprt>(const exprt &base)
-{
-  return base.id()==ID_bitand;
-}
-// inline void validate_expr(const bitand_exprt &value)
-// {
-//   validate_operands(
-//     value,
-//     2,
-//     "Bit-wise and must have two or more operands",
-//     true);
-// }
 
 
 /// \brief A base class for shift operators
@@ -2838,6 +2900,14 @@ public:
   }
 };
 
+// The to_*_expr function for this type doesn't do any checks before casting,
+// therefore the implementation is essentially a static_cast.
+// Enabling expr_dynamic_cast would hide this; instead use static_cast directly.
+// inline void validate_expr(const shift_exprt &value)
+// {
+//   validate_operands(value, 2, "Shifts must have two operands");
+// }
+
 /// \brief Cast an exprt to a \ref shift_exprt
 ///
 /// \a expr must be known to be \ref shift_exprt.
@@ -2860,14 +2930,6 @@ inline shift_exprt &to_shift_expr(exprt &expr)
     "Shifts must have two operands");
   return static_cast<shift_exprt &>(expr);
 }
-
-// The to_*_expr function for this type doesn't do any checks before casting,
-// therefore the implementation is essentially a static_cast.
-// Enabling expr_dynamic_cast would hide this; instead use static_cast directly.
-// inline void validate_expr(const shift_exprt &value)
-// {
-//   validate_operands(value, 2, "Shifts must have two operands");
-// }
 
 
 /// \brief Left shift
@@ -2995,6 +3057,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<extractbit_exprt>(const exprt &base)
+{
+  return base.id() == ID_extractbit;
+}
+
+inline void validate_expr(const extractbit_exprt &value)
+{
+  validate_operands(value, 2, "Extract bit must have two operands");
+}
+
 /// \brief Cast an exprt to an \ref extractbit_exprt
 ///
 /// \a expr must be known to be \ref extractbit_exprt.
@@ -3018,15 +3091,6 @@ inline extractbit_exprt &to_extractbit_expr(exprt &expr)
     expr.operands().size()==2,
     "Extract bit must have two operands");
   return static_cast<extractbit_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<extractbit_exprt>(const exprt &base)
-{
-  return base.id()==ID_extractbit;
-}
-inline void validate_expr(const extractbit_exprt &value)
-{
-  validate_operands(value, 2, "Extract bit must have two operands");
 }
 
 
@@ -3094,6 +3158,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<extractbits_exprt>(const exprt &base)
+{
+  return base.id() == ID_extractbits;
+}
+
+inline void validate_expr(const extractbits_exprt &value)
+{
+  validate_operands(value, 3, "Extract bits must have three operands");
+}
+
 /// \brief Cast an exprt to an \ref extractbits_exprt
 ///
 /// \a expr must be known to be \ref extractbits_exprt.
@@ -3119,15 +3194,6 @@ inline extractbits_exprt &to_extractbits_expr(exprt &expr)
   return static_cast<extractbits_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<extractbits_exprt>(const exprt &base)
-{
-  return base.id()==ID_extractbits;
-}
-inline void validate_expr(const extractbits_exprt &value)
-{
-  validate_operands(value, 3, "Extract bits must have three operands");
-}
-
 
 /// \brief Operator to return the address of an object
 class address_of_exprt:public unary_exprt
@@ -3151,6 +3217,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<address_of_exprt>(const exprt &base)
+{
+  return base.id() == ID_address_of;
+}
+
+inline void validate_expr(const address_of_exprt &value)
+{
+  validate_operands(value, 1, "Address of must have one operand");
+}
+
 /// \brief Cast an exprt to an \ref address_of_exprt
 ///
 /// \a expr must be known to be \ref address_of_exprt.
@@ -3172,15 +3249,6 @@ inline address_of_exprt &to_address_of_expr(exprt &expr)
   return static_cast<address_of_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<address_of_exprt>(const exprt &base)
-{
-  return base.id()==ID_address_of;
-}
-inline void validate_expr(const address_of_exprt &value)
-{
-  validate_operands(value, 1, "Address of must have one operand");
-}
-
 
 /// \brief Boolean negation
 class not_exprt:public unary_exprt
@@ -3197,6 +3265,17 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<not_exprt>(const exprt &base)
+{
+  return base.id() == ID_not;
+}
+
+inline void validate_expr(const not_exprt &value)
+{
+  validate_operands(value, 1, "Not must have one operand");
+}
 
 /// \brief Cast an exprt to an \ref not_exprt
 ///
@@ -3217,16 +3296,6 @@ inline not_exprt &to_not_expr(exprt &expr)
   PRECONDITION(expr.id()==ID_not);
   DATA_INVARIANT(expr.operands().size()==1, "Not must have one operand");
   return static_cast<not_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<not_exprt>(const exprt &base)
-{
-  return base.id()==ID_not;
-}
-
-inline void validate_expr(const not_exprt &value)
-{
-  validate_operands(value, 1, "Not must have one operand");
 }
 
 
@@ -3267,6 +3336,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<dereference_exprt>(const exprt &base)
+{
+  return base.id() == ID_dereference;
+}
+
+inline void validate_expr(const dereference_exprt &value)
+{
+  validate_operands(value, 1, "Dereference must have one operand");
+}
+
 /// \brief Cast an exprt to a \ref dereference_exprt
 ///
 /// \a expr must be known to be \ref dereference_exprt.
@@ -3290,15 +3370,6 @@ inline dereference_exprt &to_dereference_expr(exprt &expr)
     expr.operands().size()==1,
     "Dereference must have one operand");
   return static_cast<dereference_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<dereference_exprt>(const exprt &base)
-{
-  return base.id()==ID_dereference;
-}
-inline void validate_expr(const dereference_exprt &value)
-{
-  validate_operands(value, 1, "Dereference must have one operand");
 }
 
 
@@ -3352,6 +3423,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<if_exprt>(const exprt &base)
+{
+  return base.id() == ID_if;
+}
+
+inline void validate_expr(const if_exprt &value)
+{
+  validate_operands(value, 3, "If-then-else must have three operands");
+}
+
 /// \brief Cast an exprt to an \ref if_exprt
 ///
 /// \a expr must be known to be \ref if_exprt.
@@ -3375,15 +3457,6 @@ inline if_exprt &to_if_expr(exprt &expr)
     expr.operands().size()==3,
     "If-then-else must have three operands");
   return static_cast<if_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<if_exprt>(const exprt &base)
-{
-  return base.id()==ID_if;
-}
-inline void validate_expr(const if_exprt &value)
-{
-  validate_operands(value, 3, "If-then-else must have three operands");
 }
 
 /// \brief Operator to update elements in structs and arrays
@@ -3435,6 +3508,19 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<with_exprt>(const exprt &base)
+{
+  return base.id() == ID_with;
+}
+
+inline void validate_expr(const with_exprt &value)
+{
+  DATA_INVARIANT(
+    value.operands().size() % 2 == 1,
+    "array/structure update must have an odd number of operands");
+}
+
 /// \brief Cast an exprt to a \ref with_exprt
 ///
 /// \a expr must be known to be \ref with_exprt.
@@ -3460,17 +3546,6 @@ inline with_exprt &to_with_expr(exprt &expr)
   return static_cast<with_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<with_exprt>(const exprt &base)
-{
-  return base.id()==ID_with;
-}
-inline void validate_expr(const with_exprt &value)
-{
-  DATA_INVARIANT(
-    value.operands().size() % 2 == 1,
-    "array/structure update must have an odd number of operands");
-}
-
 class index_designatort : public expr_protectedt
 {
 public:
@@ -3490,6 +3565,17 @@ public:
     return op0();
   }
 };
+
+template <>
+inline bool can_cast_expr<index_designatort>(const exprt &base)
+{
+  return base.id() == ID_index_designator;
+}
+
+inline void validate_expr(const index_designatort &value)
+{
+  validate_operands(value, 1, "Index designator must have one operand");
+}
 
 /// \brief Cast an exprt to an \ref index_designatort
 ///
@@ -3516,15 +3602,6 @@ inline index_designatort &to_index_designator(exprt &expr)
   return static_cast<index_designatort &>(expr);
 }
 
-template<> inline bool can_cast_expr<index_designatort>(const exprt &base)
-{
-  return base.id()==ID_index_designator;
-}
-inline void validate_expr(const index_designatort &value)
-{
-  validate_operands(value, 1, "Index designator must have one operand");
-}
-
 class member_designatort : public expr_protectedt
 {
 public:
@@ -3539,6 +3616,17 @@ public:
     return get(ID_component_name);
   }
 };
+
+template <>
+inline bool can_cast_expr<member_designatort>(const exprt &base)
+{
+  return base.id() == ID_member_designator;
+}
+
+inline void validate_expr(const member_designatort &value)
+{
+  validate_operands(value, 0, "Member designator must not have operands");
+}
 
 /// \brief Cast an exprt to an \ref member_designatort
 ///
@@ -3563,15 +3651,6 @@ inline member_designatort &to_member_designator(exprt &expr)
     !expr.has_operands(),
     "Member designator must not have operands");
   return static_cast<member_designatort &>(expr);
-}
-
-template<> inline bool can_cast_expr<member_designatort>(const exprt &base)
-{
-  return base.id()==ID_member_designator;
-}
-inline void validate_expr(const member_designatort &value)
-{
-  validate_operands(value, 0, "Member designator must not have operands");
 }
 
 
@@ -3633,6 +3712,18 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<update_exprt>(const exprt &base)
+{
+  return base.id() == ID_update;
+}
+
+inline void validate_expr(const update_exprt &value)
+{
+  validate_operands(
+    value, 3, "Array/structure update must have three operands");
+}
+
 /// \brief Cast an exprt to an \ref update_exprt
 ///
 /// \a expr must be known to be \ref update_exprt.
@@ -3653,21 +3744,9 @@ inline update_exprt &to_update_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_update);
   DATA_INVARIANT(
-    expr.operands().size()==3,
+    expr.operands().size() == 3,
     "Array/structure update must have three operands");
   return static_cast<update_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<update_exprt>(const exprt &base)
-{
-  return base.id()==ID_update;
-}
-inline void validate_expr(const update_exprt &value)
-{
-  validate_operands(
-    value,
-    3,
-    "Array/structure update must have three operands");
 }
 
 
@@ -3721,6 +3800,16 @@ public:
   }
 };
 
+template<> inline bool can_cast_expr<array_update_exprt>(const exprt &base)
+{
+  return base.id()==ID_array_update;
+}
+
+inline void validate_expr(const array_update_exprt &value)
+{
+  validate_operands(value, 3, "Array update must have three operands");
+}
+
 /// \brief Cast an exprt to an \ref array_update_exprt
 ///
 /// \a expr must be known to be \ref array_update_exprt.
@@ -3744,15 +3833,6 @@ inline array_update_exprt &to_array_update_expr(exprt &expr)
     expr.operands().size()==3,
     "Array update must have three operands");
   return static_cast<array_update_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<array_update_exprt>(const exprt &base)
-{
-  return base.id()==ID_array_update;
-}
-inline void validate_expr(const array_update_exprt &value)
-{
-  validate_operands(value, 3, "Array update must have three operands");
 }
 
 #endif
@@ -3822,6 +3902,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<member_exprt>(const exprt &base)
+{
+  return base.id() == ID_member;
+}
+
+inline void validate_expr(const member_exprt &value)
+{
+  validate_operands(value, 1, "Extract member must have one operand");
+}
+
 /// \brief Cast an exprt to a \ref member_exprt
 ///
 /// \a expr must be known to be \ref member_exprt.
@@ -3847,15 +3938,6 @@ inline member_exprt &to_member_expr(exprt &expr)
   return static_cast<member_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<member_exprt>(const exprt &base)
-{
-  return base.id()==ID_member;
-}
-inline void validate_expr(const member_exprt &value)
-{
-  validate_operands(value, 1, "Extract member must have one operand");
-}
-
 
 /// \brief Evaluates to true if the operand is NaN
 class isnan_exprt:public unary_predicate_exprt
@@ -3871,6 +3953,17 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<isnan_exprt>(const exprt &base)
+{
+  return base.id() == ID_isnan;
+}
+
+inline void validate_expr(const isnan_exprt &value)
+{
+  validate_operands(value, 1, "Is NaN must have one operand");
+}
 
 /// \brief Cast an exprt to a \ref isnan_exprt
 ///
@@ -3893,15 +3986,6 @@ inline isnan_exprt &to_isnan_expr(exprt &expr)
   return static_cast<isnan_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<isnan_exprt>(const exprt &base)
-{
-  return base.id()==ID_isnan;
-}
-inline void validate_expr(const isnan_exprt &value)
-{
-  validate_operands(value, 1, "Is NaN must have one operand");
-}
-
 
 /// \brief Evaluates to true if the operand is infinite
 class isinf_exprt:public unary_predicate_exprt
@@ -3917,6 +4001,17 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<isinf_exprt>(const exprt &base)
+{
+  return base.id() == ID_isinf;
+}
+
+inline void validate_expr(const isinf_exprt &value)
+{
+  validate_operands(value, 1, "Is infinite must have one operand");
+}
 
 /// \brief Cast an exprt to a \ref isinf_exprt
 ///
@@ -3943,15 +4038,6 @@ inline isinf_exprt &to_isinf_expr(exprt &expr)
   return static_cast<isinf_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<isinf_exprt>(const exprt &base)
-{
-  return base.id()==ID_isinf;
-}
-inline void validate_expr(const isinf_exprt &value)
-{
-  validate_operands(value, 1, "Is infinite must have one operand");
-}
-
 
 /// \brief Evaluates to true if the operand is finite
 class isfinite_exprt:public unary_predicate_exprt
@@ -3967,6 +4053,17 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<isfinite_exprt>(const exprt &base)
+{
+  return base.id() == ID_isfinite;
+}
+
+inline void validate_expr(const isfinite_exprt &value)
+{
+  validate_operands(value, 1, "Is finite must have one operand");
+}
 
 /// \brief Cast an exprt to a \ref isfinite_exprt
 ///
@@ -3989,15 +4086,6 @@ inline isfinite_exprt &to_isfinite_expr(exprt &expr)
   return static_cast<isfinite_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<isfinite_exprt>(const exprt &base)
-{
-  return base.id()==ID_isfinite;
-}
-inline void validate_expr(const isfinite_exprt &value)
-{
-  validate_operands(value, 1, "Is finite must have one operand");
-}
-
 
 /// \brief Evaluates to true if the operand is a normal number
 class isnormal_exprt:public unary_predicate_exprt
@@ -4013,6 +4101,17 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<isnormal_exprt>(const exprt &base)
+{
+  return base.id() == ID_isnormal;
+}
+
+inline void validate_expr(const isnormal_exprt &value)
+{
+  validate_operands(value, 1, "Is normal must have one operand");
+}
 
 /// \brief Cast an exprt to a \ref isnormal_exprt
 ///
@@ -4035,15 +4134,6 @@ inline isnormal_exprt &to_isnormal_expr(exprt &expr)
   return static_cast<isnormal_exprt &>(expr);
 }
 
-template<> inline bool can_cast_expr<isnormal_exprt>(const exprt &base)
-{
-  return base.id()==ID_isnormal;
-}
-inline void validate_expr(const isnormal_exprt &value)
-{
-  validate_operands(value, 1, "Is normal must have one operand");
-}
-
 
 /// \brief IEEE-floating-point equality
 class ieee_float_equal_exprt:public binary_relation_exprt
@@ -4059,6 +4149,17 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<ieee_float_equal_exprt>(const exprt &base)
+{
+  return base.id() == ID_ieee_float_equal;
+}
+
+inline void validate_expr(const ieee_float_equal_exprt &value)
+{
+  validate_operands(value, 2, "IEEE equality must have two operands");
+}
 
 /// \brief Cast an exprt to an \ref ieee_float_equal_exprt
 ///
@@ -4085,16 +4186,6 @@ inline ieee_float_equal_exprt &to_ieee_float_equal_expr(exprt &expr)
   return static_cast<ieee_float_equal_exprt &>(expr);
 }
 
-template<>
-inline bool can_cast_expr<ieee_float_equal_exprt>(const exprt &base)
-{
-  return base.id()==ID_ieee_float_equal;
-}
-inline void validate_expr(const ieee_float_equal_exprt &value)
-{
-  validate_operands(value, 2, "IEEE equality must have two operands");
-}
-
 
 /// \brief IEEE floating-point disequality
 class ieee_float_notequal_exprt:public binary_relation_exprt
@@ -4111,6 +4202,17 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<ieee_float_notequal_exprt>(const exprt &base)
+{
+  return base.id() == ID_ieee_float_notequal;
+}
+
+inline void validate_expr(const ieee_float_notequal_exprt &value)
+{
+  validate_operands(value, 2, "IEEE inequality must have two operands");
+}
 
 /// \brief Cast an exprt to an \ref ieee_float_notequal_exprt
 ///
@@ -4136,16 +4238,6 @@ inline ieee_float_notequal_exprt &to_ieee_float_notequal_expr(exprt &expr)
     expr.operands().size()==2,
     "IEEE inequality must have two operands");
   return static_cast<ieee_float_notequal_exprt &>(expr);
-}
-
-template<>
-inline bool can_cast_expr<ieee_float_notequal_exprt>(const exprt &base)
-{
-  return base.id()==ID_ieee_float_notequal;
-}
-inline void validate_expr(const ieee_float_notequal_exprt &value)
-{
-  validate_operands(value, 2, "IEEE inequality must have two operands");
 }
 
 /// \brief IEEE floating-point operations
@@ -4194,6 +4286,19 @@ public:
   }
 };
 
+// The to_*_expr function for this type doesn't do any checks before casting,
+// therefore the implementation is essentially a static_cast.
+// Enabling expr_dynamic_cast would hide this; instead use static_cast directly.
+// template<>
+// inline void validate_expr<ieee_float_op_exprt>(
+//   const ieee_float_op_exprt &value)
+// {
+//   validate_operands(
+//     value,
+//     3,
+//     "IEEE float operations must have three arguments");
+// }
+
 /// \brief Cast an exprt to an \ref ieee_float_op_exprt
 ///
 /// \a expr must be known to be \ref ieee_float_op_exprt.
@@ -4216,19 +4321,6 @@ inline ieee_float_op_exprt &to_ieee_float_op_expr(exprt &expr)
     "IEEE float operations must have three arguments");
   return static_cast<ieee_float_op_exprt &>(expr);
 }
-
-// The to_*_expr function for this type doesn't do any checks before casting,
-// therefore the implementation is essentially a static_cast.
-// Enabling expr_dynamic_cast would hide this; instead use static_cast directly.
-// template<>
-// inline void validate_expr<ieee_float_op_exprt>(
-//   const ieee_float_op_exprt &value)
-// {
-//   validate_operands(
-//     value,
-//     3,
-//     "IEEE float operations must have three arguments");
-// }
 
 
 /// \brief An expression denoting a type
@@ -4279,6 +4371,11 @@ public:
   bool value_is_zero_string() const;
 };
 
+template <>
+inline bool can_cast_expr<constant_exprt>(const exprt &base)
+{
+  return base.id() == ID_constant;
+}
 
 /// \brief Cast an exprt to a \ref constant_exprt
 ///
@@ -4297,11 +4394,6 @@ inline constant_exprt &to_constant_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_constant);
   return static_cast<constant_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<constant_exprt>(const exprt &base)
-{
-  return base.id()==ID_constant;
 }
 
 
@@ -4384,6 +4476,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<replication_exprt>(const exprt &base)
+{
+  return base.id() == ID_replication;
+}
+
+inline void validate_expr(const replication_exprt &value)
+{
+  validate_operands(value, 2, "Bit-wise replication must have two operands");
+}
+
 /// \brief Cast an exprt to a \ref replication_exprt
 ///
 /// \a expr must be known to be \ref replication_exprt.
@@ -4405,16 +4508,6 @@ inline replication_exprt &to_replication_expr(exprt &expr)
   DATA_INVARIANT(
     expr.operands().size() == 2, "Bit-wise replication must have two operands");
   return static_cast<replication_exprt &>(expr);
-}
-
-template <>
-inline bool can_cast_expr<replication_exprt>(const exprt &base)
-{
-  return base.id() == ID_replication;
-}
-inline void validate_expr(const replication_exprt &value)
-{
-  validate_operands(value, 2, "Bit-wise replication must have two operands");
 }
 
 /// \brief Concatenation of bit-vector operands
@@ -4447,6 +4540,23 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<concatenation_exprt>(const exprt &base)
+{
+  return base.id() == ID_concatenation;
+}
+
+// template<>
+// inline void validate_expr<concatenation_exprt>(
+//   const concatenation_exprt &value)
+// {
+//   validate_operands(
+//     value,
+//     2,
+//     "Concatenation must have two or more operands",
+//     true);
+// }
+
 /// \brief Cast an exprt to a \ref concatenation_exprt
 ///
 /// \a expr must be known to be \ref concatenation_exprt.
@@ -4471,21 +4581,6 @@ inline concatenation_exprt &to_concatenation_expr(exprt &expr)
   //   "Concatenation must have two or more operands");
   return static_cast<concatenation_exprt &>(expr);
 }
-
-template<> inline bool can_cast_expr<concatenation_exprt>(const exprt &base)
-{
-  return base.id()==ID_concatenation;
-}
-// template<>
-// inline void validate_expr<concatenation_exprt>(
-//   const concatenation_exprt &value)
-// {
-//   validate_operands(
-//     value,
-//     2,
-//     "Concatenation must have two or more operands",
-//     true);
-// }
 
 
 /// \brief An expression denoting infinity
@@ -4541,6 +4636,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<let_exprt>(const exprt &base)
+{
+  return base.id() == ID_let;
+}
+
+inline void validate_expr(const let_exprt &value)
+{
+  validate_operands(value, 3, "Let must have three operands");
+}
+
 /// \brief Cast an exprt to a \ref let_exprt
 ///
 /// \a expr must be known to be \ref let_exprt.
@@ -4560,15 +4666,6 @@ inline let_exprt &to_let_expr(exprt &expr)
   PRECONDITION(expr.id()==ID_let);
   DATA_INVARIANT(expr.operands().size()==3, "Let must have three operands");
   return static_cast<let_exprt &>(expr);
-}
-
-template<> inline bool can_cast_expr<let_exprt>(const exprt &base)
-{
-  return base.id()==ID_let;
-}
-inline void validate_expr(const let_exprt &value)
-{
-  validate_operands(value, 3, "Let must have three operands");
 }
 
 /// \brief The popcount (counting the number of bits set to 1) expression
@@ -4591,6 +4688,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<popcount_exprt>(const exprt &base)
+{
+  return base.id() == ID_popcount;
+}
+
+inline void validate_expr(const popcount_exprt &value)
+{
+  validate_operands(value, 1, "popcount must have one operand");
+}
+
 /// \brief Cast an exprt to a \ref popcount_exprt
 ///
 /// \a expr must be known to be \ref popcount_exprt.
@@ -4610,16 +4718,6 @@ inline popcount_exprt &to_popcount_expr(exprt &expr)
   PRECONDITION(expr.id() == ID_popcount);
   DATA_INVARIANT(expr.operands().size() == 1, "popcount must have one operand");
   return static_cast<popcount_exprt &>(expr);
-}
-
-template <>
-inline bool can_cast_expr<popcount_exprt>(const exprt &base)
-{
-  return base.id() == ID_popcount;
-}
-inline void validate_expr(const popcount_exprt &value)
-{
-  validate_operands(value, 1, "popcount must have one operand");
 }
 
 /// this is a parametric version of an if-expression: it returns

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -2445,11 +2445,6 @@ inline bool can_cast_expr<and_exprt>(const exprt &base)
   return base.id() == ID_and;
 }
 
-// inline void validate_expr(const and_exprt &value)
-// {
-//   validate_operands(value, 2, "And must have two or more operands", true);
-// }
-
 /// \brief Cast an exprt to a \ref and_exprt
 ///
 /// \a expr must be known to be \ref and_exprt.
@@ -2459,9 +2454,6 @@ inline bool can_cast_expr<and_exprt>(const exprt &base)
 inline const and_exprt &to_and_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_and);
-  // DATA_INVARIANT(
-  //   expr.operands().size()>=2,
-  //   "And must have two or more operands");
   return static_cast<const and_exprt &>(expr);
 }
 
@@ -2469,9 +2461,6 @@ inline const and_exprt &to_and_expr(const exprt &expr)
 inline and_exprt &to_and_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_and);
-  // DATA_INVARIANT(
-  //   expr.operands().size()>=2,
-  //   "And must have two or more operands");
   return static_cast<and_exprt &>(expr);
 }
 
@@ -2570,11 +2559,6 @@ inline bool can_cast_expr<or_exprt>(const exprt &base)
   return base.id() == ID_or;
 }
 
-// inline void validate_expr(const or_exprt &value)
-// {
-//   validate_operands(value, 2, "Or must have two or more operands", true);
-// }
-
 /// \brief Cast an exprt to a \ref or_exprt
 ///
 /// \a expr must be known to be \ref or_exprt.
@@ -2584,9 +2568,6 @@ inline bool can_cast_expr<or_exprt>(const exprt &base)
 inline const or_exprt &to_or_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_or);
-  // DATA_INVARIANT(
-  //   expr.operands().size()>=2,
-  //   "Or must have two or more operands");
   return static_cast<const or_exprt &>(expr);
 }
 
@@ -2594,9 +2575,6 @@ inline const or_exprt &to_or_expr(const exprt &expr)
 inline or_exprt &to_or_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_or);
-  // DATA_INVARIANT(
-  //   expr.operands().size()>=2,
-  //   "Or must have two or more operands");
   return static_cast<or_exprt &>(expr);
 }
 
@@ -2621,15 +2599,6 @@ inline bool can_cast_expr<xor_exprt>(const exprt &base)
 {
   return base.id() == ID_xor;
 }
-
-// inline void validate_expr(const bitxor_exprt &value)
-// {
-//   validate_operands(
-//     value,
-//     2,
-//     "Bit-wise xor must have two or more operands",
-//     true);
-// }
 
 /// \brief Cast an exprt to a \ref xor_exprt
 ///
@@ -2722,15 +2691,6 @@ inline bool can_cast_expr<bitor_exprt>(const exprt &base)
   return base.id() == ID_bitor;
 }
 
-// inline void validate_expr(const bitor_exprt &value)
-// {
-//   validate_operands(
-//     value,
-//     2,
-//     "Bit-wise or must have two or more operands",
-//     true);
-// }
-
 /// \brief Cast an exprt to a \ref bitor_exprt
 ///
 /// \a expr must be known to be \ref bitor_exprt.
@@ -2740,9 +2700,6 @@ inline bool can_cast_expr<bitor_exprt>(const exprt &base)
 inline const bitor_exprt &to_bitor_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_bitor);
-  // DATA_INVARIANT(
-  //   expr.operands().size()>=2,
-  //   "Bit-wise or must have two or more operands");
   return static_cast<const bitor_exprt &>(expr);
 }
 
@@ -2750,9 +2707,6 @@ inline const bitor_exprt &to_bitor_expr(const exprt &expr)
 inline bitor_exprt &to_bitor_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_bitor);
-  // DATA_INVARIANT(
-  //   expr.operands().size()>=2,
-  //   "Bit-wise or must have two or more operands");
   return static_cast<bitor_exprt &>(expr);
 }
 
@@ -2778,15 +2732,6 @@ inline bool can_cast_expr<bitxor_exprt>(const exprt &base)
   return base.id() == ID_bitxor;
 }
 
-// inline void validate_expr(const bitxor_exprt &value)
-// {
-//   validate_operands(
-//     value,
-//     2,
-//     "Bit-wise xor must have two or more operands",
-//     true);
-// }
-
 /// \brief Cast an exprt to a \ref bitxor_exprt
 ///
 /// \a expr must be known to be \ref bitxor_exprt.
@@ -2796,9 +2741,6 @@ inline bool can_cast_expr<bitxor_exprt>(const exprt &base)
 inline const bitxor_exprt &to_bitxor_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_bitxor);
-  // DATA_INVARIANT(
-  //   expr.operands().size()>=2,
-  //   "Bit-wise xor must have two or more operands");
   return static_cast<const bitxor_exprt &>(expr);
 }
 
@@ -2806,9 +2748,6 @@ inline const bitxor_exprt &to_bitxor_expr(const exprt &expr)
 inline bitxor_exprt &to_bitxor_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_bitxor);
-  // DATA_INVARIANT(
-  //   expr.operands().size()>=2,
-  //   "Bit-wise xor must have two or more operands");
   return static_cast<bitxor_exprt &>(expr);
 }
 
@@ -2834,15 +2773,6 @@ inline bool can_cast_expr<bitand_exprt>(const exprt &base)
   return base.id() == ID_bitand;
 }
 
-// inline void validate_expr(const bitand_exprt &value)
-// {
-//   validate_operands(
-//     value,
-//     2,
-//     "Bit-wise and must have two or more operands",
-//     true);
-// }
-
 /// \brief Cast an exprt to a \ref bitand_exprt
 ///
 /// \a expr must be known to be \ref bitand_exprt.
@@ -2852,9 +2782,6 @@ inline bool can_cast_expr<bitand_exprt>(const exprt &base)
 inline const bitand_exprt &to_bitand_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_bitand);
-  // DATA_INVARIANT(
-  //   expr.operands().size()>=2,
-  //   "Bit-wise and must have two or more operands");
   return static_cast<const bitand_exprt &>(expr);
 }
 
@@ -2862,9 +2789,6 @@ inline const bitand_exprt &to_bitand_expr(const exprt &expr)
 inline bitand_exprt &to_bitand_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_bitand);
-  // DATA_INVARIANT(
-  //   expr.operands().size()>=2,
-  //   "Bit-wise and must have two or more operands");
   return static_cast<bitand_exprt &>(expr);
 }
 
@@ -4566,17 +4490,6 @@ inline bool can_cast_expr<concatenation_exprt>(const exprt &base)
   return base.id() == ID_concatenation;
 }
 
-// template<>
-// inline void validate_expr<concatenation_exprt>(
-//   const concatenation_exprt &value)
-// {
-//   validate_operands(
-//     value,
-//     2,
-//     "Concatenation must have two or more operands",
-//     true);
-// }
-
 /// \brief Cast an exprt to a \ref concatenation_exprt
 ///
 /// \a expr must be known to be \ref concatenation_exprt.
@@ -4586,9 +4499,6 @@ inline bool can_cast_expr<concatenation_exprt>(const exprt &base)
 inline const concatenation_exprt &to_concatenation_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_concatenation);
-  // DATA_INVARIANT(
-  //   expr.operands().size()>=2,
-  //   "Concatenation must have two or more operands");
   return static_cast<const concatenation_exprt &>(expr);
 }
 
@@ -4596,9 +4506,6 @@ inline const concatenation_exprt &to_concatenation_expr(const exprt &expr)
 inline concatenation_exprt &to_concatenation_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_concatenation);
-  // DATA_INVARIANT(
-  //   expr.operands().size()>=2,
-  //   "Concatenation must have two or more operands");
   return static_cast<concatenation_exprt &>(expr);
 }
 

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -226,16 +226,18 @@ inline void validate_expr(const symbol_exprt &value)
 inline const symbol_exprt &to_symbol_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_symbol);
-  DATA_INVARIANT(!expr.has_operands(), "Symbols must not have operands");
-  return static_cast<const symbol_exprt &>(expr);
+  const symbol_exprt &ret = static_cast<const symbol_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_symbol_expr(const exprt &)
 inline symbol_exprt &to_symbol_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_symbol);
-  DATA_INVARIANT(!expr.has_operands(), "Symbols must not have operands");
-  return static_cast<symbol_exprt &>(expr);
+  symbol_exprt &ret = static_cast<symbol_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -282,16 +284,19 @@ inline void validate_expr(const nondet_symbol_exprt &value)
 inline const nondet_symbol_exprt &to_nondet_symbol_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_nondet_symbol);
-  DATA_INVARIANT(!expr.has_operands(), "Symbols must not have operands");
-  return static_cast<const nondet_symbol_exprt &>(expr);
+  const nondet_symbol_exprt &ret =
+    static_cast<const nondet_symbol_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_nondet_symbol_expr(const exprt &)
 inline nondet_symbol_exprt &to_nondet_symbol_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_symbol);
-  DATA_INVARIANT(!expr.has_operands(), "Symbols must not have operands");
-  return static_cast<nondet_symbol_exprt &>(expr);
+  nondet_symbol_exprt &ret = static_cast<nondet_symbol_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -367,19 +372,17 @@ inline void validate_expr(const unary_exprt &value)
 /// \return Object of type \ref unary_exprt
 inline const unary_exprt &to_unary_expr(const exprt &expr)
 {
-  DATA_INVARIANT(
-    expr.operands().size()==1,
-    "Unary expressions must have one operand");
-  return static_cast<const unary_exprt &>(expr);
+  const unary_exprt &ret = static_cast<const unary_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_unary_expr(const exprt &)
 inline unary_exprt &to_unary_expr(exprt &expr)
 {
-  DATA_INVARIANT(
-    expr.operands().size()==1,
-    "Unary expressions must have one operand");
-  return static_cast<unary_exprt &>(expr);
+  unary_exprt &ret = static_cast<unary_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -418,20 +421,18 @@ inline void validate_expr(const abs_exprt &value)
 inline const abs_exprt &to_abs_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_abs);
-  DATA_INVARIANT(
-    expr.operands().size()==1,
-    "Absolute value must have one operand");
-  return static_cast<const abs_exprt &>(expr);
+  const abs_exprt &ret = static_cast<const abs_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_abs_expr(const exprt &)
 inline abs_exprt &to_abs_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_abs);
-  DATA_INVARIANT(
-    expr.operands().size()==1,
-    "Absolute value must have one operand");
-  return static_cast<abs_exprt &>(expr);
+  abs_exprt &ret = static_cast<abs_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -477,20 +478,18 @@ inline void validate_expr(const unary_minus_exprt &value)
 inline const unary_minus_exprt &to_unary_minus_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_unary_minus);
-  DATA_INVARIANT(
-    expr.operands().size()==1,
-    "Unary minus must have one operand");
-  return static_cast<const unary_minus_exprt &>(expr);
+  const unary_minus_exprt &ret = static_cast<const unary_minus_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_unary_minus_expr(const exprt &)
 inline unary_minus_exprt &to_unary_minus_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_unary_minus);
-  DATA_INVARIANT(
-    expr.operands().size()==1,
-    "Unary minus must have one operand");
-  return static_cast<unary_minus_exprt &>(expr);
+  unary_minus_exprt &ret = static_cast<unary_minus_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \brief The unary plus expression
@@ -523,18 +522,18 @@ inline void validate_expr(const unary_plus_exprt &value)
 inline const unary_plus_exprt &to_unary_plus_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_unary_plus);
-  DATA_INVARIANT(
-    expr.operands().size() == 1, "unary plus must have one operand");
-  return static_cast<const unary_plus_exprt &>(expr);
+  const unary_plus_exprt &ret = static_cast<const unary_plus_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_unary_minus_expr(const exprt &)
 inline unary_plus_exprt &to_unary_plus_expr(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_unary_plus);
-  DATA_INVARIANT(
-    expr.operands().size() == 1, "unary plus must have one operand");
-  return static_cast<unary_plus_exprt &>(expr);
+  unary_plus_exprt &ret = static_cast<unary_plus_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \brief The byte swap expression
@@ -586,20 +585,18 @@ inline void validate_expr(const bswap_exprt &value)
 inline const bswap_exprt &to_bswap_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_bswap);
-  DATA_INVARIANT(expr.operands().size() == 1, "bswap must have one operand");
-  DATA_INVARIANT(
-    expr.op0().type() == expr.type(), "bswap type must match operand type");
-  return static_cast<const bswap_exprt &>(expr);
+  const bswap_exprt &ret = static_cast<const bswap_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_bswap_expr(const exprt &)
 inline bswap_exprt &to_bswap_expr(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_bswap);
-  DATA_INVARIANT(expr.operands().size() == 1, "bswap must have one operand");
-  DATA_INVARIANT(
-    expr.op0().type() == expr.type(), "bswap type must match operand type");
-  return static_cast<bswap_exprt &>(expr);
+  bswap_exprt &ret = static_cast<bswap_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \brief A base class for expressions that are predicates,
@@ -692,18 +689,18 @@ inline void validate_expr(const sign_exprt &expr)
 inline const sign_exprt &to_sign_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_sign);
-  DATA_INVARIANT(
-    expr.operands().size() == 1, "sign expression must have one operand");
-  return static_cast<const sign_exprt &>(expr);
+  const sign_exprt &ret = static_cast<const sign_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_sign_expr(const exprt &)
 inline sign_exprt &to_sign_expr(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_sign);
-  DATA_INVARIANT(
-    expr.operands().size() == 1, "sign expression must have one operand");
-  return static_cast<sign_exprt &>(expr);
+  sign_exprt &ret = static_cast<sign_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \brief A base class for binary expressions
@@ -1122,20 +1119,18 @@ inline void validate_expr(const plus_exprt &value)
 inline const plus_exprt &to_plus_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_plus);
-  DATA_INVARIANT(
-    expr.operands().size()>=2,
-    "Plus must have two or more operands");
-  return static_cast<const plus_exprt &>(expr);
+  const plus_exprt &ret = static_cast<const plus_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_plus_expr(const exprt &)
 inline plus_exprt &to_plus_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_plus);
-  DATA_INVARIANT(
-    expr.operands().size()>=2,
-    "Plus must have two or more operands");
-  return static_cast<plus_exprt &>(expr);
+  plus_exprt &ret = static_cast<plus_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -1176,20 +1171,18 @@ inline void validate_expr(const minus_exprt &value)
 inline const minus_exprt &to_minus_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_minus);
-  DATA_INVARIANT(
-    expr.operands().size()>=2,
-    "Minus must have two or more operands");
-  return static_cast<const minus_exprt &>(expr);
+  const minus_exprt &ret = static_cast<const minus_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_minus_expr(const exprt &)
 inline minus_exprt &to_minus_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_minus);
-  DATA_INVARIANT(
-    expr.operands().size()>=2,
-    "Minus must have two or more operands");
-  return static_cast<minus_exprt &>(expr);
+  minus_exprt &ret = static_cast<minus_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -1231,20 +1224,18 @@ inline void validate_expr(const mult_exprt &value)
 inline const mult_exprt &to_mult_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_mult);
-  DATA_INVARIANT(
-    expr.operands().size()>=2,
-    "Multiply must have two or more operands");
-  return static_cast<const mult_exprt &>(expr);
+  const mult_exprt &ret = static_cast<const mult_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_mult_expr(const exprt &)
 inline mult_exprt &to_mult_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_mult);
-  DATA_INVARIANT(
-    expr.operands().size()>=2,
-    "Multiply must have two or more operands");
-  return static_cast<mult_exprt &>(expr);
+  mult_exprt &ret = static_cast<mult_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -1309,20 +1300,18 @@ inline void validate_expr(const div_exprt &value)
 inline const div_exprt &to_div_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_div);
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Divide must have two operands");
-  return static_cast<const div_exprt &>(expr);
+  const div_exprt &ret = static_cast<const div_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_div_expr(const exprt &)
 inline div_exprt &to_div_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_div);
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Divide must have two operands");
-  return static_cast<div_exprt &>(expr);
+  div_exprt &ret = static_cast<div_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -1363,16 +1352,18 @@ inline void validate_expr(const mod_exprt &value)
 inline const mod_exprt &to_mod_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_mod);
-  DATA_INVARIANT(expr.operands().size()==2, "Modulo must have two operands");
-  return static_cast<const mod_exprt &>(expr);
+  const mod_exprt &ret = static_cast<const mod_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_mod_expr(const exprt &)
 inline mod_exprt &to_mod_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_mod);
-  DATA_INVARIANT(expr.operands().size()==2, "Modulo must have two operands");
-  return static_cast<mod_exprt &>(expr);
+  mod_exprt &ret = static_cast<mod_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -1413,16 +1404,18 @@ inline void validate_expr(const rem_exprt &value)
 inline const rem_exprt &to_rem_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_rem);
-  DATA_INVARIANT(expr.operands().size()==2, "Remainder must have two operands");
-  return static_cast<const rem_exprt &>(expr);
+  const rem_exprt &ret = static_cast<const rem_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_rem_expr(const exprt &)
 inline rem_exprt &to_rem_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_rem);
-  DATA_INVARIANT(expr.operands().size()==2, "Remainder must have two operands");
-  return static_cast<rem_exprt &>(expr);
+  rem_exprt &ret = static_cast<rem_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -1524,20 +1517,18 @@ inline void validate_expr(const notequal_exprt &value)
 inline const notequal_exprt &to_notequal_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_notequal);
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Inequality must have two operands");
-  return static_cast<const notequal_exprt &>(expr);
+  const notequal_exprt &ret = static_cast<const notequal_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_notequal_expr(const exprt &)
 inline notequal_exprt &to_notequal_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_notequal);
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Inequality must have two operands");
-  return static_cast<notequal_exprt &>(expr);
+  notequal_exprt &ret = static_cast<notequal_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -1609,20 +1600,18 @@ inline void validate_expr(const index_exprt &value)
 inline const index_exprt &to_index_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_index);
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Array index must have two operands");
-  return static_cast<const index_exprt &>(expr);
+  const index_exprt &ret = static_cast<const index_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_index_expr(const exprt &)
 inline index_exprt &to_index_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_index);
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Array index must have two operands");
-  return static_cast<index_exprt &>(expr);
+  index_exprt &ret = static_cast<index_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -1672,20 +1661,18 @@ inline void validate_expr(const array_of_exprt &value)
 inline const array_of_exprt &to_array_of_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_array_of);
-  DATA_INVARIANT(
-    expr.operands().size()==1,
-    "'Array of' must have one operand");
-  return static_cast<const array_of_exprt &>(expr);
+  const array_of_exprt &ret = static_cast<const array_of_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_array_of_expr(const exprt &)
 inline array_of_exprt &to_array_of_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_array_of);
-  DATA_INVARIANT(
-    expr.operands().size()==1,
-    "'Array of' must have one operand");
-  return static_cast<array_of_exprt &>(expr);
+  array_of_exprt &ret = static_cast<array_of_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -1875,20 +1862,18 @@ inline void validate_expr(const union_exprt &value)
 inline const union_exprt &to_union_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_union);
-  DATA_INVARIANT(
-    expr.operands().size()==1,
-    "Union constructor must have one operand");
-  return static_cast<const union_exprt &>(expr);
+  const union_exprt &ret = static_cast<const union_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_union_expr(const exprt &)
 inline union_exprt &to_union_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_union);
-  DATA_INVARIANT(
-    expr.operands().size()==1,
-    "Union constructor must have one operand");
-  return static_cast<union_exprt &>(expr);
+  union_exprt &ret = static_cast<union_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -2005,20 +1990,18 @@ inline void validate_expr(const complex_exprt &value)
 inline const complex_exprt &to_complex_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_complex);
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Complex constructor must have two operands");
-  return static_cast<const complex_exprt &>(expr);
+  const complex_exprt &ret = static_cast<const complex_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_complex_expr(const exprt &)
 inline complex_exprt &to_complex_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_complex);
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Complex constructor must have two operands");
-  return static_cast<complex_exprt &>(expr);
+  complex_exprt &ret = static_cast<complex_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \brief Real part of the expression describing a complex number.
@@ -2052,20 +2035,18 @@ inline void validate_expr(const complex_real_exprt &expr)
 inline const complex_real_exprt &to_complex_real_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_complex_real);
-  DATA_INVARIANT(
-    expr.operands().size() == 1,
-    "real part retrieval operation must have one operand");
-  return static_cast<const complex_real_exprt &>(expr);
+  const complex_real_exprt &ret = static_cast<const complex_real_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_complex_real_expr(const exprt &)
 inline complex_real_exprt &to_complex_real_expr(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_complex_real);
-  DATA_INVARIANT(
-    expr.operands().size() == 1,
-    "real part retrieval operation must have one operand");
-  return static_cast<complex_real_exprt &>(expr);
+  complex_real_exprt &ret = static_cast<complex_real_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \brief Imaginary part of the expression describing a complex number.
@@ -2099,20 +2080,18 @@ inline void validate_expr(const complex_imag_exprt &expr)
 inline const complex_imag_exprt &to_complex_imag_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_complex_imag);
-  DATA_INVARIANT(
-    expr.operands().size() == 1,
-    "imaginary part retrieval operation must have one operand");
-  return static_cast<const complex_imag_exprt &>(expr);
+  const complex_imag_exprt &ret = static_cast<const complex_imag_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_complex_imag_expr(const exprt &)
 inline complex_imag_exprt &to_complex_imag_expr(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_complex_imag);
-  DATA_INVARIANT(
-    expr.operands().size() == 1,
-    "imaginary part retrieval operation must have one operand");
-  return static_cast<complex_imag_exprt &>(expr);
+  complex_imag_exprt &ret = static_cast<complex_imag_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 class namespacet;
@@ -2176,20 +2155,19 @@ inline const object_descriptor_exprt &to_object_descriptor_expr(
   const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_object_descriptor);
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Object descriptor must have two operands");
-  return static_cast<const object_descriptor_exprt &>(expr);
+  const object_descriptor_exprt &ret =
+    static_cast<const object_descriptor_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_object_descriptor_expr(const exprt &)
 inline object_descriptor_exprt &to_object_descriptor_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_object_descriptor);
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Object descriptor must have two operands");
-  return static_cast<object_descriptor_exprt &>(expr);
+  object_descriptor_exprt &ret = static_cast<object_descriptor_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -2247,20 +2225,19 @@ inline const dynamic_object_exprt &to_dynamic_object_expr(
   const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_dynamic_object);
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Dynamic object must have two operands");
-  return static_cast<const dynamic_object_exprt &>(expr);
+  const dynamic_object_exprt &ret =
+    static_cast<const dynamic_object_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_dynamic_object_expr(const exprt &)
 inline dynamic_object_exprt &to_dynamic_object_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_dynamic_object);
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Dynamic object must have two operands");
-  return static_cast<dynamic_object_exprt &>(expr);
+  dynamic_object_exprt &ret = static_cast<dynamic_object_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -2308,20 +2285,18 @@ inline void validate_expr(const typecast_exprt &value)
 inline const typecast_exprt &to_typecast_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_typecast);
-  DATA_INVARIANT(
-    expr.operands().size()==1,
-    "Typecast must have one operand");
-  return static_cast<const typecast_exprt &>(expr);
+  const typecast_exprt &ret = static_cast<const typecast_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_typecast_expr(const exprt &)
 inline typecast_exprt &to_typecast_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_typecast);
-  DATA_INVARIANT(
-    expr.operands().size()==1,
-    "Typecast must have one operand");
-  return static_cast<typecast_exprt &>(expr);
+  typecast_exprt &ret = static_cast<typecast_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -2382,20 +2357,19 @@ inline void validate_expr(const floatbv_typecast_exprt &value)
 inline const floatbv_typecast_exprt &to_floatbv_typecast_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_floatbv_typecast);
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Float typecast must have two operands");
-  return static_cast<const floatbv_typecast_exprt &>(expr);
+  const floatbv_typecast_exprt &ret =
+    static_cast<const floatbv_typecast_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_floatbv_typecast_expr(const exprt &)
 inline floatbv_typecast_exprt &to_floatbv_typecast_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_floatbv_typecast);
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Float typecast must have two operands");
-  return static_cast<floatbv_typecast_exprt &>(expr);
+  floatbv_typecast_exprt &ret = static_cast<floatbv_typecast_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -2500,16 +2474,18 @@ inline void validate_expr(const implies_exprt &value)
 inline const implies_exprt &to_implies_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_implies);
-  DATA_INVARIANT(expr.operands().size()==2, "Implies must have two operands");
-  return static_cast<const implies_exprt &>(expr);
+  const implies_exprt &ret = static_cast<const implies_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_implies_expr(const exprt &)
 inline implies_exprt &to_implies_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_implies);
-  DATA_INVARIANT(expr.operands().size()==2, "Implies must have two operands");
-  return static_cast<implies_exprt &>(expr);
+  implies_exprt &ret = static_cast<implies_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -2655,18 +2631,18 @@ inline void validate_expr(const bitnot_exprt &value)
 inline const bitnot_exprt &to_bitnot_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_bitnot);
-  DATA_INVARIANT(
-    expr.operands().size() == 1, "Bit-wise not must have one operand");
-  return static_cast<const bitnot_exprt &>(expr);
+  const bitnot_exprt &ret = static_cast<const bitnot_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_bitnot_expr(const exprt &)
 inline bitnot_exprt &to_bitnot_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_bitnot);
-  DATA_INVARIANT(
-    expr.operands().size() == 1, "Bit-wise not must have one operand");
-  return static_cast<bitnot_exprt &>(expr);
+  bitnot_exprt &ret = static_cast<bitnot_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -2858,19 +2834,17 @@ inline void validate_expr(const shift_exprt &value)
 /// \return Object of type \ref shift_exprt
 inline const shift_exprt &to_shift_expr(const exprt &expr)
 {
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Shifts must have two operands");
-  return static_cast<const shift_exprt &>(expr);
+  const shift_exprt &ret = static_cast<const shift_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_shift_expr(const exprt &)
 inline shift_exprt &to_shift_expr(exprt &expr)
 {
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Shifts must have two operands");
-  return static_cast<shift_exprt &>(expr);
+  shift_exprt &ret = static_cast<shift_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -2903,18 +2877,18 @@ public:
 inline const shl_exprt &to_shl_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_shl);
-  DATA_INVARIANT(
-    expr.operands().size() == 2, "Bit-wise shl must have two operands");
-  return static_cast<const shl_exprt &>(expr);
+  const shl_exprt &ret = static_cast<const shl_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_shl_expr(const exprt &)
 inline shl_exprt &to_shl_expr(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_shl);
-  DATA_INVARIANT(
-    expr.operands().size() == 2, "Bit-wise shl must have two operands");
-  return static_cast<shl_exprt &>(expr);
+  shl_exprt &ret = static_cast<shl_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \brief Arithmetic right shift
@@ -3019,20 +2993,18 @@ inline void validate_expr(const extractbit_exprt &value)
 inline const extractbit_exprt &to_extractbit_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_extractbit);
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Extract bit must have two operands");
-  return static_cast<const extractbit_exprt &>(expr);
+  const extractbit_exprt &ret = static_cast<const extractbit_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_extractbit_expr(const exprt &)
 inline extractbit_exprt &to_extractbit_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_extractbit);
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Extract bit must have two operands");
-  return static_cast<extractbit_exprt &>(expr);
+  extractbit_exprt &ret = static_cast<extractbit_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -3120,20 +3092,18 @@ inline void validate_expr(const extractbits_exprt &value)
 inline const extractbits_exprt &to_extractbits_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_extractbits);
-  DATA_INVARIANT(
-    expr.operands().size()==3,
-    "Extract bits must have three operands");
-  return static_cast<const extractbits_exprt &>(expr);
+  const extractbits_exprt &ret = static_cast<const extractbits_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_extractbits_expr(const exprt &)
 inline extractbits_exprt &to_extractbits_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_extractbits);
-  DATA_INVARIANT(
-    expr.operands().size()==3,
-    "Extract bits must have three operands");
-  return static_cast<extractbits_exprt &>(expr);
+  extractbits_exprt &ret = static_cast<extractbits_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -3179,16 +3149,18 @@ inline void validate_expr(const address_of_exprt &value)
 inline const address_of_exprt &to_address_of_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_address_of);
-  DATA_INVARIANT(expr.operands().size()==1, "Address of must have one operand");
-  return static_cast<const address_of_exprt &>(expr);
+  const address_of_exprt &ret = static_cast<const address_of_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_address_of_expr(const exprt &)
 inline address_of_exprt &to_address_of_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_address_of);
-  DATA_INVARIANT(expr.operands().size()==1, "Address of must have one operand");
-  return static_cast<address_of_exprt &>(expr);
+  address_of_exprt &ret = static_cast<address_of_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -3228,16 +3200,18 @@ inline void validate_expr(const not_exprt &value)
 inline const not_exprt &to_not_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_not);
-  DATA_INVARIANT(expr.operands().size()==1, "Not must have one operand");
-  return static_cast<const not_exprt &>(expr);
+  const not_exprt &ret = static_cast<const not_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_not_expr(const exprt &)
 inline not_exprt &to_not_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_not);
-  DATA_INVARIANT(expr.operands().size()==1, "Not must have one operand");
-  return static_cast<not_exprt &>(expr);
+  not_exprt &ret = static_cast<not_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -3298,20 +3272,18 @@ inline void validate_expr(const dereference_exprt &value)
 inline const dereference_exprt &to_dereference_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_dereference);
-  DATA_INVARIANT(
-    expr.operands().size()==1,
-    "Dereference must have one operand");
-  return static_cast<const dereference_exprt &>(expr);
+  const dereference_exprt &ret = static_cast<const dereference_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_dereference_expr(const exprt &)
 inline dereference_exprt &to_dereference_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_dereference);
-  DATA_INVARIANT(
-    expr.operands().size()==1,
-    "Dereference must have one operand");
-  return static_cast<dereference_exprt &>(expr);
+  dereference_exprt &ret = static_cast<dereference_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -3385,20 +3357,18 @@ inline void validate_expr(const if_exprt &value)
 inline const if_exprt &to_if_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_if);
-  DATA_INVARIANT(
-    expr.operands().size()==3,
-    "If-then-else must have three operands");
-  return static_cast<const if_exprt &>(expr);
+  const if_exprt &ret = static_cast<const if_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_if_expr(const exprt &)
 inline if_exprt &to_if_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_if);
-  DATA_INVARIANT(
-    expr.operands().size()==3,
-    "If-then-else must have three operands");
-  return static_cast<if_exprt &>(expr);
+  if_exprt &ret = static_cast<if_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \brief Operator to update elements in structs and arrays
@@ -3474,20 +3444,18 @@ inline void validate_expr(const with_exprt &value)
 inline const with_exprt &to_with_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_with);
-  DATA_INVARIANT(
-    expr.operands().size() >= 3 && expr.operands().size() % 2 == 1,
-    "array/structure update must have at least three operands");
-  return static_cast<const with_exprt &>(expr);
+  const with_exprt &ret = static_cast<const with_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_with_expr(const exprt &)
 inline with_exprt &to_with_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_with);
-  DATA_INVARIANT(
-    expr.operands().size() >= 3 && expr.operands().size() % 2 == 1,
-    "array/structure update must have at least three operands");
-  return static_cast<with_exprt &>(expr);
+  with_exprt &ret = static_cast<with_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 class index_designatort : public expr_protectedt
@@ -3530,20 +3498,18 @@ inline void validate_expr(const index_designatort &value)
 inline const index_designatort &to_index_designator(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_index_designator);
-  DATA_INVARIANT(
-    expr.operands().size()==1,
-    "Index designator must have one operand");
-  return static_cast<const index_designatort &>(expr);
+  const index_designatort &ret = static_cast<const index_designatort &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_index_designator(const exprt &)
 inline index_designatort &to_index_designator(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_index_designator);
-  DATA_INVARIANT(
-    expr.operands().size()==1,
-    "Index designator must have one operand");
-  return static_cast<index_designatort &>(expr);
+  index_designatort &ret = static_cast<index_designatort &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 class member_designatort : public expr_protectedt
@@ -3581,20 +3547,18 @@ inline void validate_expr(const member_designatort &value)
 inline const member_designatort &to_member_designator(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_member_designator);
-  DATA_INVARIANT(
-    !expr.has_operands(),
-    "Member designator must not have operands");
-  return static_cast<const member_designatort &>(expr);
+  const member_designatort &ret = static_cast<const member_designatort &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_member_designator(const exprt &)
 inline member_designatort &to_member_designator(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_member_designator);
-  DATA_INVARIANT(
-    !expr.has_operands(),
-    "Member designator must not have operands");
-  return static_cast<member_designatort &>(expr);
+  member_designatort &ret = static_cast<member_designatort &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -3677,20 +3641,18 @@ inline void validate_expr(const update_exprt &value)
 inline const update_exprt &to_update_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_update);
-  DATA_INVARIANT(
-    expr.operands().size()==3,
-    "Array/structure update must have three operands");
-  return static_cast<const update_exprt &>(expr);
+  const update_exprt &ret = static_cast<const update_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_update_expr(const exprt &)
 inline update_exprt &to_update_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_update);
-  DATA_INVARIANT(
-    expr.operands().size() == 3,
-    "Array/structure update must have three operands");
-  return static_cast<update_exprt &>(expr);
+  update_exprt &ret = static_cast<update_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -3763,20 +3725,18 @@ inline void validate_expr(const array_update_exprt &value)
 inline const array_update_exprt &to_array_update_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_array_update);
-  DATA_INVARIANT(
-    expr.operands().size()==3,
-    "Array update must have three operands");
-  return static_cast<const array_update_exprt &>(expr);
+  const array_update_exprt &ret = static_cast<const array_update_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_array_update_expr(const exprt &)
 inline array_update_exprt &to_array_update_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_array_update);
-  DATA_INVARIANT(
-    expr.operands().size()==3,
-    "Array update must have three operands");
-  return static_cast<array_update_exprt &>(expr);
+  array_update_exprt &ret = static_cast<array_update_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 #endif
@@ -3866,20 +3826,18 @@ inline void validate_expr(const member_exprt &value)
 inline const member_exprt &to_member_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_member);
-  DATA_INVARIANT(
-    expr.operands().size()==1,
-    "Extract member must have one operand");
-  return static_cast<const member_exprt &>(expr);
+  const member_exprt &ret = static_cast<const member_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_member_expr(const exprt &)
 inline member_exprt &to_member_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_member);
-  DATA_INVARIANT(
-    expr.operands().size()==1,
-    "Extract member must have one operand");
-  return static_cast<member_exprt &>(expr);
+  member_exprt &ret = static_cast<member_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -3918,16 +3876,18 @@ inline void validate_expr(const isnan_exprt &value)
 inline const isnan_exprt &to_isnan_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_isnan);
-  DATA_INVARIANT(expr.operands().size()==1, "Is NaN must have one operand");
-  return static_cast<const isnan_exprt &>(expr);
+  const isnan_exprt &ret = static_cast<const isnan_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_isnan_expr(const exprt &)
 inline isnan_exprt &to_isnan_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_isnan);
-  DATA_INVARIANT(expr.operands().size()==1, "Is NaN must have one operand");
-  return static_cast<isnan_exprt &>(expr);
+  isnan_exprt &ret = static_cast<isnan_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -3966,20 +3926,18 @@ inline void validate_expr(const isinf_exprt &value)
 inline const isinf_exprt &to_isinf_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_isinf);
-  DATA_INVARIANT(
-    expr.operands().size()==1,
-    "Is infinite must have one operand");
-  return static_cast<const isinf_exprt &>(expr);
+  const isinf_exprt &ret = static_cast<const isinf_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_isinf_expr(const exprt &)
 inline isinf_exprt &to_isinf_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_isinf);
-  DATA_INVARIANT(
-    expr.operands().size()==1,
-    "Is infinite must have one operand");
-  return static_cast<isinf_exprt &>(expr);
+  isinf_exprt &ret = static_cast<isinf_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -4018,16 +3976,18 @@ inline void validate_expr(const isfinite_exprt &value)
 inline const isfinite_exprt &to_isfinite_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_isfinite);
-  DATA_INVARIANT(expr.operands().size()==1, "Is finite must have one operand");
-  return static_cast<const isfinite_exprt &>(expr);
+  const isfinite_exprt &ret = static_cast<const isfinite_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_isfinite_expr(const exprt &)
 inline isfinite_exprt &to_isfinite_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_isfinite);
-  DATA_INVARIANT(expr.operands().size()==1, "Is finite must have one operand");
-  return static_cast<isfinite_exprt &>(expr);
+  isfinite_exprt &ret = static_cast<isfinite_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -4066,16 +4026,18 @@ inline void validate_expr(const isnormal_exprt &value)
 inline const isnormal_exprt &to_isnormal_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_isnormal);
-  DATA_INVARIANT(expr.operands().size()==1, "Is normal must have one operand");
-  return static_cast<const isnormal_exprt &>(expr);
+  const isnormal_exprt &ret = static_cast<const isnormal_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_isnormal_expr(const exprt &)
 inline isnormal_exprt &to_isnormal_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_isnormal);
-  DATA_INVARIANT(expr.operands().size()==1, "Is normal must have one operand");
-  return static_cast<isnormal_exprt &>(expr);
+  isnormal_exprt &ret = static_cast<isnormal_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -4114,20 +4076,19 @@ inline void validate_expr(const ieee_float_equal_exprt &value)
 inline const ieee_float_equal_exprt &to_ieee_float_equal_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_ieee_float_equal);
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "IEEE equality must have two operands");
-  return static_cast<const ieee_float_equal_exprt &>(expr);
+  const ieee_float_equal_exprt &ret =
+    static_cast<const ieee_float_equal_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_ieee_float_equal_expr(const exprt &)
 inline ieee_float_equal_exprt &to_ieee_float_equal_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_ieee_float_equal);
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "IEEE equality must have two operands");
-  return static_cast<ieee_float_equal_exprt &>(expr);
+  ieee_float_equal_exprt &ret = static_cast<ieee_float_equal_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -4168,20 +4129,20 @@ inline const ieee_float_notequal_exprt &to_ieee_float_notequal_expr(
   const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_ieee_float_notequal);
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "IEEE inequality must have two operands");
-  return static_cast<const ieee_float_notequal_exprt &>(expr);
+  const ieee_float_notequal_exprt &ret =
+    static_cast<const ieee_float_notequal_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_ieee_float_notequal_expr(const exprt &)
 inline ieee_float_notequal_exprt &to_ieee_float_notequal_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_ieee_float_notequal);
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "IEEE inequality must have two operands");
-  return static_cast<ieee_float_notequal_exprt &>(expr);
+  ieee_float_notequal_exprt &ret =
+    static_cast<ieee_float_notequal_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \brief IEEE floating-point operations
@@ -4251,19 +4212,18 @@ inline void validate_expr(const ieee_float_op_exprt &value)
 /// \return Object of type \ref ieee_float_op_exprt
 inline const ieee_float_op_exprt &to_ieee_float_op_expr(const exprt &expr)
 {
-  DATA_INVARIANT(
-    expr.operands().size()==3,
-    "IEEE float operations must have three arguments");
-  return static_cast<const ieee_float_op_exprt &>(expr);
+  const ieee_float_op_exprt &ret =
+    static_cast<const ieee_float_op_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_ieee_float_op_expr(const exprt &)
 inline ieee_float_op_exprt &to_ieee_float_op_expr(exprt &expr)
 {
-  DATA_INVARIANT(
-    expr.operands().size()==3,
-    "IEEE float operations must have three arguments");
-  return static_cast<ieee_float_op_exprt &>(expr);
+  ieee_float_op_exprt &ret = static_cast<ieee_float_op_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 
@@ -4440,18 +4400,18 @@ inline void validate_expr(const replication_exprt &value)
 inline const replication_exprt &to_replication_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_replication);
-  DATA_INVARIANT(
-    expr.operands().size() == 2, "Bit-wise replication must have two operands");
-  return static_cast<const replication_exprt &>(expr);
+  const replication_exprt &ret = static_cast<const replication_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_replication_expr(const exprt &)
 inline replication_exprt &to_replication_expr(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_replication);
-  DATA_INVARIANT(
-    expr.operands().size() == 2, "Bit-wise replication must have two operands");
-  return static_cast<replication_exprt &>(expr);
+  replication_exprt &ret = static_cast<replication_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \brief Concatenation of bit-vector operands
@@ -4583,16 +4543,18 @@ inline void validate_expr(const let_exprt &value)
 inline const let_exprt &to_let_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_let);
-  DATA_INVARIANT(expr.operands().size()==3, "Let must have three operands");
-  return static_cast<const let_exprt &>(expr);
+  const let_exprt &ret = static_cast<const let_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_let_expr(const exprt &)
 inline let_exprt &to_let_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_let);
-  DATA_INVARIANT(expr.operands().size()==3, "Let must have three operands");
-  return static_cast<let_exprt &>(expr);
+  let_exprt &ret = static_cast<let_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \brief The popcount (counting the number of bits set to 1) expression
@@ -4635,16 +4597,18 @@ inline void validate_expr(const popcount_exprt &value)
 inline const popcount_exprt &to_popcount_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_popcount);
-  DATA_INVARIANT(expr.operands().size() == 1, "popcount must have one operand");
-  return static_cast<const popcount_exprt &>(expr);
+  const popcount_exprt &ret = static_cast<const popcount_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_popcount_expr(const exprt &)
 inline popcount_exprt &to_popcount_expr(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_popcount);
-  DATA_INVARIANT(expr.operands().size() == 1, "popcount must have one operand");
-  return static_cast<popcount_exprt &>(expr);
+  popcount_exprt &ret = static_cast<popcount_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// this is a parametric version of an if-expression: it returns
@@ -4696,18 +4660,18 @@ inline void validate_expr(const cond_exprt &value)
 inline const cond_exprt &to_cond_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_cond);
-  DATA_INVARIANT(
-    expr.operands().size() % 2 == 0, "cond must have even number of operands");
-  return static_cast<const cond_exprt &>(expr);
+  const cond_exprt &ret = static_cast<const cond_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 /// \copydoc to_popcount_expr(const exprt &)
 inline cond_exprt &to_cond_expr(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_cond);
-  DATA_INVARIANT(
-    expr.operands().size() % 2 != 0, "cond must have even number of operands");
-  return static_cast<cond_exprt &>(expr);
+  cond_exprt &ret = static_cast<cond_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
 }
 
 #endif // CPROVER_UTIL_STD_EXPR_H

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -778,7 +778,7 @@ inline bool can_cast_expr<binary_exprt>(const exprt &base)
 
 inline void validate_expr(const binary_exprt &value)
 {
-  validate_operands(value, 2, "Binary expressions must have two operands");
+  binary_exprt::check(value);
 }
 
 /// \brief Cast an exprt to a \ref binary_exprt
@@ -789,18 +789,14 @@ inline void validate_expr(const binary_exprt &value)
 /// \return Object of type \ref binary_exprt
 inline const binary_exprt &to_binary_expr(const exprt &expr)
 {
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Binary expressions must have two operands");
+  binary_exprt::check(expr);
   return static_cast<const binary_exprt &>(expr);
 }
 
 /// \copydoc to_binary_expr(const exprt &)
 inline binary_exprt &to_binary_expr(exprt &expr)
 {
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Binary expressions must have two operands");
+  binary_exprt::check(expr);
   return static_cast<binary_exprt &>(expr);
 }
 
@@ -921,7 +917,7 @@ inline bool can_cast_expr<binary_relation_exprt>(const exprt &base)
 
 inline void validate_expr(const binary_relation_exprt &value)
 {
-  validate_operands(value, 2, "Binary relations must have two operands");
+  binary_relation_exprt::check(value);
 }
 
 /// \brief Cast an exprt to a \ref binary_relation_exprt
@@ -932,18 +928,14 @@ inline void validate_expr(const binary_relation_exprt &value)
 /// \return Object of type \ref binary_relation_exprt
 inline const binary_relation_exprt &to_binary_relation_expr(const exprt &expr)
 {
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Binary relations must have two operands");
+  binary_relation_exprt::check(expr);
   return static_cast<const binary_relation_exprt &>(expr);
 }
 
 /// \copydoc to_binary_relation_expr(const exprt &)
 inline binary_relation_exprt &to_binary_relation_expr(exprt &expr)
 {
-  DATA_INVARIANT(
-    expr.operands().size()==2,
-    "Binary relations must have two operands");
+  binary_relation_exprt::check(expr);
   return static_cast<binary_relation_exprt &>(expr);
 }
 
@@ -1457,7 +1449,7 @@ inline bool can_cast_expr<equal_exprt>(const exprt &base)
 
 inline void validate_expr(const equal_exprt &value)
 {
-  validate_operands(value, 2, "Equality must have two operands");
+  equal_exprt::check(value);
 }
 
 /// \brief Cast an exprt to an \ref equal_exprt

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -354,6 +354,11 @@ inline bool can_cast_expr<unary_exprt>(const exprt &base)
   return base.operands().size() == 1;
 }
 
+inline void validate_expr(const unary_exprt &value)
+{
+  validate_operands(value, 1, "Unary expressions must have one operand");
+}
+
 /// \brief Cast an exprt to a \ref unary_exprt
 ///
 /// \a expr must be known to be \ref unary_exprt.
@@ -774,6 +779,11 @@ inline bool can_cast_expr<binary_exprt>(const exprt &base)
   return base.operands().size() == 2;
 }
 
+inline void validate_expr(const binary_exprt &value)
+{
+  validate_operands(value, 2, "Binary expressions must have two operands");
+}
+
 /// \brief Cast an exprt to a \ref binary_exprt
 ///
 /// \a expr must be known to be \ref binary_exprt.
@@ -910,6 +920,11 @@ template <>
 inline bool can_cast_expr<binary_relation_exprt>(const exprt &base)
 {
   return can_cast_expr<binary_exprt>(base);
+}
+
+inline void validate_expr(const binary_relation_exprt &value)
+{
+  validate_operands(value, 2, "Binary relations must have two operands");
 }
 
 /// \brief Cast an exprt to a \ref binary_relation_exprt
@@ -2657,10 +2672,10 @@ inline bool can_cast_expr<bitnot_exprt>(const exprt &base)
   return base.id() == ID_bitnot;
 }
 
-// inline void validate_expr(const bitnot_exprt &value)
-// {
-//   validate_operands(value, 1, "Bit-wise not must have one operand");
-// }
+inline void validate_expr(const bitnot_exprt &value)
+{
+  validate_operands(value, 1, "Bit-wise not must have one operand");
+}
 
 /// \brief Cast an exprt to a \ref bitnot_exprt
 ///
@@ -2671,8 +2686,8 @@ inline bool can_cast_expr<bitnot_exprt>(const exprt &base)
 inline const bitnot_exprt &to_bitnot_expr(const exprt &expr)
 {
   PRECONDITION(expr.id()==ID_bitnot);
-  // DATA_INVARIANT(expr.operands().size()==1,
-  //                "Bit-wise not must have one operand");
+  DATA_INVARIANT(
+    expr.operands().size() == 1, "Bit-wise not must have one operand");
   return static_cast<const bitnot_exprt &>(expr);
 }
 
@@ -2680,8 +2695,8 @@ inline const bitnot_exprt &to_bitnot_expr(const exprt &expr)
 inline bitnot_exprt &to_bitnot_expr(exprt &expr)
 {
   PRECONDITION(expr.id()==ID_bitnot);
-  // DATA_INVARIANT(expr.operands().size()==1,
-  //                "Bit-wise not must have one operand");
+  DATA_INVARIANT(
+    expr.operands().size() == 1, "Bit-wise not must have one operand");
   return static_cast<bitnot_exprt &>(expr);
 }
 
@@ -2900,13 +2915,16 @@ public:
   }
 };
 
-// The to_*_expr function for this type doesn't do any checks before casting,
-// therefore the implementation is essentially a static_cast.
-// Enabling expr_dynamic_cast would hide this; instead use static_cast directly.
-// inline void validate_expr(const shift_exprt &value)
-// {
-//   validate_operands(value, 2, "Shifts must have two operands");
-// }
+template <>
+inline bool can_cast_expr<shift_exprt>(const exprt &base)
+{
+  return base.id() == ID_shl || base.id() == ID_ashr || base.id() == ID_lshr;
+}
+
+inline void validate_expr(const shift_exprt &value)
+{
+  validate_operands(value, 2, "Shifts must have two operands");
+}
 
 /// \brief Cast an exprt to a \ref shift_exprt
 ///
@@ -3516,6 +3534,8 @@ inline bool can_cast_expr<with_exprt>(const exprt &base)
 
 inline void validate_expr(const with_exprt &value)
 {
+  validate_operands(
+    value, 3, "array/structure update must have at least 3 operands", true);
   DATA_INVARIANT(
     value.operands().size() % 2 == 1,
     "array/structure update must have an odd number of operands");
@@ -4286,18 +4306,18 @@ public:
   }
 };
 
-// The to_*_expr function for this type doesn't do any checks before casting,
-// therefore the implementation is essentially a static_cast.
-// Enabling expr_dynamic_cast would hide this; instead use static_cast directly.
-// template<>
-// inline void validate_expr<ieee_float_op_exprt>(
-//   const ieee_float_op_exprt &value)
-// {
-//   validate_operands(
-//     value,
-//     3,
-//     "IEEE float operations must have three arguments");
-// }
+template <>
+inline bool can_cast_expr<ieee_float_op_exprt>(const exprt &base)
+{
+  return base.id() == ID_floatbv_plus || base.id() == ID_floatbv_minus ||
+         base.id() == ID_floatbv_div || base.id() == ID_floatbv_mult;
+}
+
+inline void validate_expr(const ieee_float_op_exprt &value)
+{
+  validate_operands(
+    value, 3, "IEEE float operations must have three arguments");
+}
 
 /// \brief Cast an exprt to an \ref ieee_float_op_exprt
 ///
@@ -4747,6 +4767,18 @@ public:
     operands().push_back(value);
   }
 };
+
+template <>
+inline bool can_cast_expr<cond_exprt>(const exprt &base)
+{
+  return base.id() == ID_cond;
+}
+
+inline void validate_expr(const cond_exprt &value)
+{
+  DATA_INVARIANT(
+    value.operands().size() % 2 == 0, "cond must have even number of operands");
+}
 
 /// \brief Cast an exprt to a \ref cond_exprt
 ///

--- a/unit/util/expr_cast/expr_undefined_casts.cpp
+++ b/unit/util/expr_cast/expr_undefined_casts.cpp
@@ -26,17 +26,6 @@ SCENARIO("expr_dynamic_cast",
   {
     const exprt &expr=symbol_expr;
 
-    THEN("Casting from exprt reference to ieee_float_op_exprt "
-         "should not compile")
-    {
-      // This shouldn't compile
-      expr_dynamic_cast<const ieee_float_op_exprt &>(expr);
-    }
-    THEN("Casting from exprt reference to shift_exprt should not compile")
-    {
-      // This shouldn't compile
-      expr_dynamic_cast<const shift_exprt &>(expr);
-    }
     THEN(
       "Casting from exprt reference to non-reference should not compile")
     {


### PR DESCRIPTION
Please review commit-by-commit; several commits are text-motion only and others are automated text replacement - both indicated in the respective commit messages. ~This requires/includes #4175 ("Return statements always have one operand"), so please skip that while reviewing.~

The original aim was to get rid of all the sharing-breaking side effects in `to_*exprt` procedures, but when starting on this I noticed that really a lot more cleanup was indicated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
