### PR TITLE
extend make_assignment and make_function_call APIs

### DIFF
--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -945,11 +945,22 @@ public:
       {_target});
   }
 
+  /// Create an assignment instruction
   static instructiont make_assignment(
     const code_assignt &_code,
     const source_locationt &l = source_locationt::nil())
   {
     return instructiont(_code, l, ASSIGN, nil_exprt(), {});
+  }
+
+  /// Create an assignment instruction
+  static instructiont make_assignment(
+    exprt lhs,
+    exprt rhs,
+    const source_locationt &l = source_locationt::nil())
+  {
+    return instructiont(
+      code_assignt(std::move(lhs), std::move(rhs)), l, ASSIGN, nil_exprt(), {});
   }
 
   static instructiont make_decl(
@@ -959,11 +970,26 @@ public:
     return instructiont(_code, l, DECL, nil_exprt(), {});
   }
 
+  /// Create a function call instruction
   static instructiont make_function_call(
     const code_function_callt &_code,
     const source_locationt &l = source_locationt::nil())
   {
     return instructiont(_code, l, FUNCTION_CALL, nil_exprt(), {});
+  }
+
+  /// Create a function call instruction
+  static instructiont make_function_call(
+    exprt function,
+    code_function_callt::argumentst arguments,
+    const source_locationt &l = source_locationt::nil())
+  {
+    return instructiont(
+      code_function_callt(std::move(function), std::move(arguments)),
+      l,
+      FUNCTION_CALL,
+      nil_exprt(),
+      {});
   }
 };
 


### PR DESCRIPTION
This permits constructing assignments and function calls without
code_assignt and code_function_callt, respectively, in the same style as the
existing API for declarations, returns etc.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
