### PR TITLE
Extend the options for coverage instrumentation

### DIFF
--- a/jbmc/src/jdiff/jdiff_parse_options.cpp
+++ b/jbmc/src/jdiff/jdiff_parse_options.cpp
@@ -324,7 +324,7 @@ bool jdiff_parse_optionst::process_goto_program(
       const auto cover_config = get_cover_config(
         options, goto_model.symbol_table, get_message_handler());
       if(instrument_cover_goals(
-           options, cover_config, goto_model, get_message_handler()))
+           cover_config, goto_model, get_message_handler()))
         return true;
     }
 

--- a/jbmc/src/jdiff/jdiff_parse_options.cpp
+++ b/jbmc/src/jdiff/jdiff_parse_options.cpp
@@ -323,10 +323,8 @@ bool jdiff_parse_optionst::process_goto_program(
     {
       const auto cover_config = get_cover_config(
         options, goto_model.symbol_table, get_message_handler());
-      if(!cover_config)
-        return true;
       if(instrument_cover_goals(
-           options, *cover_config, goto_model, get_message_handler()))
+           options, cover_config, goto_model, get_message_handler()))
         return true;
     }
 

--- a/jbmc/src/jdiff/jdiff_parse_options.cpp
+++ b/jbmc/src/jdiff/jdiff_parse_options.cpp
@@ -321,7 +321,12 @@ bool jdiff_parse_optionst::process_goto_program(
     // instrument cover goals
     if(cmdline.isset("cover"))
     {
-      if(instrument_cover_goals(options, goto_model, get_message_handler()))
+      const auto cover_config = get_cover_config(
+        options, goto_model.symbol_table, get_message_handler());
+      if(!cover_config)
+        return true;
+      if(instrument_cover_goals(
+           options, *cover_config, goto_model, get_message_handler()))
         return true;
     }
 

--- a/jbmc/unit/java_bytecode/java_virtual_functions/virtual_functions.cpp
+++ b/jbmc/unit/java_bytecode/java_virtual_functions/virtual_functions.cpp
@@ -130,11 +130,7 @@ SCENARIO(
         const auto cover_config =
           get_cover_config(options, new_table, null_message_handler);
         REQUIRE_FALSE(instrument_cover_goals(
-          options,
-          cover_config,
-          new_table,
-          new_goto_functions,
-          null_message_handler));
+          cover_config, new_table, new_goto_functions, null_message_handler));
 
         auto function = new_goto_functions.function_map.find(function_name);
         REQUIRE(function != new_goto_functions.function_map.end());

--- a/jbmc/unit/java_bytecode/java_virtual_functions/virtual_functions.cpp
+++ b/jbmc/unit/java_bytecode/java_virtual_functions/virtual_functions.cpp
@@ -129,10 +129,9 @@ SCENARIO(
         options.set_option("cover", "location");
         const auto cover_config =
           get_cover_config(options, new_table, null_message_handler);
-        REQUIRE(cover_config);
         REQUIRE_FALSE(instrument_cover_goals(
           options,
-          *cover_config,
+          cover_config,
           new_table,
           new_goto_functions,
           null_message_handler));

--- a/jbmc/unit/java_bytecode/java_virtual_functions/virtual_functions.cpp
+++ b/jbmc/unit/java_bytecode/java_virtual_functions/virtual_functions.cpp
@@ -127,9 +127,15 @@ SCENARIO(
       {
         optionst options;
         options.set_option("cover", "location");
-        REQUIRE_FALSE(
-          instrument_cover_goals(
-            options, new_table, new_goto_functions, null_message_handler));
+        const auto cover_config =
+          get_cover_config(options, new_table, null_message_handler);
+        REQUIRE(cover_config);
+        REQUIRE_FALSE(instrument_cover_goals(
+          options,
+          *cover_config,
+          new_table,
+          new_goto_functions,
+          null_message_handler));
 
         auto function = new_goto_functions.function_map.find(function_name);
         REQUIRE(function != new_goto_functions.function_map.end());

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -862,10 +862,8 @@ bool cbmc_parse_optionst::process_goto_program(
     {
       const auto cover_config = get_cover_config(
         options, goto_model.symbol_table, log.get_message_handler());
-      if(!cover_config)
-        return true;
       if(instrument_cover_goals(
-           options, *cover_config, goto_model, log.get_message_handler()))
+           options, cover_config, goto_model, log.get_message_handler()))
         return true;
     }
 

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -863,7 +863,7 @@ bool cbmc_parse_optionst::process_goto_program(
       const auto cover_config = get_cover_config(
         options, goto_model.symbol_table, log.get_message_handler());
       if(instrument_cover_goals(
-           options, cover_config, goto_model, log.get_message_handler()))
+           cover_config, goto_model, log.get_message_handler()))
         return true;
     }
 

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -860,7 +860,12 @@ bool cbmc_parse_optionst::process_goto_program(
     // instrument cover goals
     if(options.is_set("cover"))
     {
-      if(instrument_cover_goals(options, goto_model, log.get_message_handler()))
+      const auto cover_config = get_cover_config(
+        options, goto_model.symbol_table, log.get_message_handler());
+      if(!cover_config)
+        return true;
+      if(instrument_cover_goals(
+           options, *cover_config, goto_model, log.get_message_handler()))
         return true;
     }
 

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -365,10 +365,8 @@ bool goto_diff_parse_optionst::process_goto_program(
 
       const auto cover_config = get_cover_config(
         options, goto_model.symbol_table, get_message_handler());
-      if(!cover_config)
-        return true;
       if(instrument_cover_goals(
-           options, *cover_config, goto_model, get_message_handler()))
+           options, cover_config, goto_model, get_message_handler()))
         return true;
     }
 

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -363,7 +363,12 @@ bool goto_diff_parse_optionst::process_goto_program(
       // for coverage annotation:
       remove_skip(goto_model);
 
-      if(instrument_cover_goals(options, goto_model, get_message_handler()))
+      const auto cover_config = get_cover_config(
+        options, goto_model.symbol_table, get_message_handler());
+      if(!cover_config)
+        return true;
+      if(instrument_cover_goals(
+           options, *cover_config, goto_model, get_message_handler()))
         return true;
     }
 

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -366,7 +366,7 @@ bool goto_diff_parse_optionst::process_goto_program(
       const auto cover_config = get_cover_config(
         options, goto_model.symbol_table, get_message_handler());
       if(instrument_cover_goals(
-           options, cover_config, goto_model, get_message_handler()))
+           cover_config, goto_model, get_message_handler()))
         return true;
     }
 

--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -329,11 +329,13 @@ void instrument_cover_goals(
 
 /// Instruments goto functions based on given command line options
 /// \param options: the options
+/// \param cover_config: configuration, produced using get_cover_config
 /// \param symbol_table: the symbol table
 /// \param goto_functions: the goto functions
 /// \param message_handler: a message handler
 bool instrument_cover_goals(
   const optionst &options,
+  const cover_configt &cover_config,
   const symbol_tablet &symbol_table,
   goto_functionst &goto_functions,
   message_handlert &message_handler)
@@ -342,13 +344,8 @@ bool instrument_cover_goals(
   msg.status() << "Rewriting existing assertions as assumptions"
                << messaget::eom;
 
-  std::unique_ptr<cover_configt> cover_config =
-    get_cover_config(options, symbol_table, message_handler);
-  if(!cover_config)
-    return true;
-
   if(
-    cover_config->traces_must_terminate &&
+    cover_config.traces_must_terminate &&
     !goto_functions.function_map.count(goto_functions.entry_point()))
   {
     msg.error() << "cover-traces-must-terminate: invalid entry point ["
@@ -359,29 +356,31 @@ bool instrument_cover_goals(
   Forall_goto_functions(f_it, goto_functions)
   {
     const symbolt function_symbol = symbol_table.lookup_ref(f_it->first);
-    cover_config->mode = function_symbol.mode;
     instrument_cover_goals(
-      *cover_config, function_symbol, f_it->second, message_handler);
+      cover_config, function_symbol, f_it->second, message_handler);
   }
   goto_functions.compute_location_numbers();
 
-  cover_config->function_filters.report_anomalies();
-  cover_config->goal_filters.report_anomalies();
+  cover_config.function_filters.report_anomalies();
+  cover_config.goal_filters.report_anomalies();
 
   return false;
 }
 
 /// Instruments a goto model based on given command line options
 /// \param options: the options
+/// \param cover_config: configuration, produced using get_cover_config
 /// \param goto_model: the goto model
 /// \param message_handler: a message handler
 bool instrument_cover_goals(
   const optionst &options,
+  const cover_configt &cover_config,
   goto_modelt &goto_model,
   message_handlert &message_handler)
 {
   return instrument_cover_goals(
     options,
+    cover_config,
     goto_model.symbol_table,
     goto_model.goto_functions,
     message_handler);

--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -369,13 +369,11 @@ void instrument_cover_goals(
 }
 
 /// Instruments goto functions based on given command line options
-/// \param options: the options
 /// \param cover_config: configuration, produced using get_cover_config
 /// \param symbol_table: the symbol table
 /// \param goto_functions: the goto functions
 /// \param message_handler: a message handler
 bool instrument_cover_goals(
-  const optionst &options,
   const cover_configt &cover_config,
   const symbol_tablet &symbol_table,
   goto_functionst &goto_functions,
@@ -409,18 +407,15 @@ bool instrument_cover_goals(
 }
 
 /// Instruments a goto model based on given command line options
-/// \param options: the options
 /// \param cover_config: configuration, produced using get_cover_config
 /// \param goto_model: the goto model
 /// \param message_handler: a message handler
 bool instrument_cover_goals(
-  const optionst &options,
   const cover_configt &cover_config,
   goto_modelt &goto_model,
   message_handlert &message_handler)
 {
   return instrument_cover_goals(
-    options,
     cover_config,
     goto_model.symbol_table,
     goto_model.goto_functions,

--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -251,13 +251,13 @@ cover_configt get_cover_config(
 /// Build data structures controlling coverage from command-line options.
 /// Include options that depend on the main function specified by the user.
 /// \param options: command-line options
-/// \param main_id: symbol of the user-specified main program function
+/// \param main_function_id: symbol of the user-specified main program function
 /// \param symbol_table: global symbol table
 /// \param message_handler: used to log incorrect option specifications
 /// \return a cover_configt on success, or null otherwise.
 cover_configt get_cover_config(
   const optionst &options,
-  const irep_idt &main_id,
+  const irep_idt &main_function_id,
   const symbol_tablet &symbol_table,
   message_handlert &message_handler)
 {
@@ -269,13 +269,13 @@ cover_configt get_cover_config(
   // cover entry point function only
   if(cover_only == "function")
   {
-    const symbolt &main_symbol = symbol_table.lookup_ref(main_id);
+    const symbolt &main_symbol = symbol_table.lookup_ref(main_function_id);
     cover_config.function_filters.add(util_make_unique<single_function_filtert>(
       message_handler, main_symbol.name));
   }
   else if(cover_only == "file")
   {
-    const symbolt &main_symbol = symbol_table.lookup_ref(main_id);
+    const symbolt &main_symbol = symbol_table.lookup_ref(main_function_id);
     cover_config.function_filters.add(util_make_unique<file_filtert>(
       message_handler, main_symbol.location.get_file()));
   }

--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -200,13 +200,13 @@ cover_configt get_cover_config(
   cover_configt cover_config;
   function_filterst &function_filters =
     cover_config.cover_configt::function_filters;
-  goal_filterst &goal_filters = cover_config.goal_filters;
+  std::unique_ptr<goal_filterst> &goal_filters = cover_config.goal_filters;
   cover_instrumenterst &instrumenters = cover_config.cover_instrumenters;
 
   function_filters.add(
     util_make_unique<internal_functions_filtert>(message_handler));
 
-  goal_filters.add(util_make_unique<internal_goals_filtert>(message_handler));
+  goal_filters->add(util_make_unique<internal_goals_filtert>(message_handler));
 
   optionst::value_listt criteria_strings = options.get_list_option("cover");
 
@@ -218,7 +218,7 @@ cover_configt get_cover_config(
     if(c == coverage_criteriont::ASSERTION)
       cover_config.keep_assertions = true;
 
-    instrumenters.add_from_criterion(c, symbol_table, goal_filters);
+    instrumenters.add_from_criterion(c, symbol_table, *goal_filters);
   }
 
   if(cover_config.keep_assertions && criteria_strings.size() > 1)
@@ -401,7 +401,7 @@ bool instrument_cover_goals(
   goto_functions.compute_location_numbers();
 
   cover_config.function_filters.report_anomalies();
-  cover_config.goal_filters.report_anomalies();
+  cover_config.goal_filters->report_anomalies();
 
   return false;
 }

--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -265,16 +265,17 @@ cover_configt get_cover_config(
     get_cover_config(options, symbol_table, message_handler);
 
   std::string cover_only = options.get_option("cover-only");
-  const symbolt main_symbol = symbol_table.lookup_ref(main_id);
 
   // cover entry point function only
   if(cover_only == "function")
   {
+    const symbolt &main_symbol = symbol_table.lookup_ref(main_id);
     cover_config.function_filters.add(util_make_unique<single_function_filtert>(
       message_handler, main_symbol.name));
   }
   else if(cover_only == "file")
   {
+    const symbolt &main_symbol = symbol_table.lookup_ref(main_id);
     cover_config.function_filters.add(util_make_unique<file_filtert>(
       message_handler, main_symbol.location.get_file()));
   }

--- a/src/goto-instrument/cover.h
+++ b/src/goto-instrument/cover.h
@@ -57,10 +57,10 @@ void instrument_cover_goals(
   coverage_criteriont,
   message_handlert &message_handler);
 
-std::unique_ptr<cover_configt>
+cover_configt
 get_cover_config(const optionst &, const symbol_tablet &, message_handlert &);
 
-std::unique_ptr<cover_configt> get_cover_config(
+cover_configt get_cover_config(
   const optionst &,
   const irep_idt &main_id,
   const symbol_tablet &,

--- a/src/goto-instrument/cover.h
+++ b/src/goto-instrument/cover.h
@@ -16,6 +16,7 @@ Date: May 2016
 
 #include "cover_filter.h"
 #include "cover_instrument.h"
+#include "util/make_unique.h"
 
 class message_handlert;
 class cmdlinet;
@@ -39,7 +40,9 @@ struct cover_configt
   bool traces_must_terminate;
   irep_idt mode;
   function_filterst function_filters;
-  goal_filterst goal_filters;
+  // cover instruments point to goal_filters, so they must be stored on the heap
+  std::unique_ptr<goal_filterst> goal_filters =
+    util_make_unique<goal_filterst>();
   cover_instrumenterst cover_instrumenters;
 };
 

--- a/src/goto-instrument/cover.h
+++ b/src/goto-instrument/cover.h
@@ -14,7 +14,6 @@ Date: May 2016
 #ifndef CPROVER_GOTO_INSTRUMENT_COVER_H
 #define CPROVER_GOTO_INSTRUMENT_COVER_H
 
-#include <goto-programs/goto_model.h>
 #include "cover_filter.h"
 #include "cover_instrument.h"
 
@@ -46,12 +45,14 @@ struct cover_configt
 
 void instrument_cover_goals(
   const symbol_tablet &,
+  const cover_configt &,
   goto_functionst &,
   coverage_criteriont,
   message_handlert &message_handler);
 
 void instrument_cover_goals(
   const symbol_tablet &,
+  const cover_configt &,
   goto_programt &,
   coverage_criteriont,
   message_handlert &message_handler);
@@ -68,12 +69,14 @@ void parse_cover_options(const cmdlinet &, optionst &);
 
 bool instrument_cover_goals(
   const optionst &,
+  const cover_configt &,
   const symbol_tablet &,
   goto_functionst &,
   message_handlert &);
 
 bool instrument_cover_goals(
   const optionst &,
+  const cover_configt &,
   goto_modelt &,
   message_handlert &);
 

--- a/src/goto-instrument/cover.h
+++ b/src/goto-instrument/cover.h
@@ -62,7 +62,7 @@ get_cover_config(const optionst &, const symbol_tablet &, message_handlert &);
 
 cover_configt get_cover_config(
   const optionst &,
-  const irep_idt &main_id,
+  const irep_idt &main_function_id,
   const symbol_tablet &,
   message_handlert &);
 

--- a/src/goto-instrument/cover.h
+++ b/src/goto-instrument/cover.h
@@ -74,14 +74,12 @@ void instrument_cover_goals(
 void parse_cover_options(const cmdlinet &, optionst &);
 
 bool instrument_cover_goals(
-  const optionst &,
   const cover_configt &,
   const symbol_tablet &,
   goto_functionst &,
   message_handlert &);
 
 bool instrument_cover_goals(
-  const optionst &,
   const cover_configt &,
   goto_modelt &,
   message_handlert &);

--- a/src/goto-instrument/cover.h
+++ b/src/goto-instrument/cover.h
@@ -57,8 +57,14 @@ void instrument_cover_goals(
   coverage_criteriont,
   message_handlert &message_handler);
 
+std::unique_ptr<cover_configt>
+get_cover_config(const optionst &, const symbol_tablet &, message_handlert &);
+
 std::unique_ptr<cover_configt> get_cover_config(
-  const optionst &, const symbol_tablet &, message_handlert &);
+  const optionst &,
+  const irep_idt &main_id,
+  const symbol_tablet &,
+  message_handlert &);
 
 void instrument_cover_goals(
   const cover_configt &,

--- a/src/goto-instrument/cover_filter.cpp
+++ b/src/goto-instrument/cover_filter.cpp
@@ -45,6 +45,34 @@ bool internal_functions_filtert::operator()(
   return true;
 }
 
+/// Filter out all functions except those defined in the file that is given
+/// in the constructor.
+/// \param function: the function under consideration
+/// \param goto_function: a goto function
+/// \return returns true if `function` is defined in the file
+/// given in the constructor
+bool file_filtert::operator()(
+  const symbolt &function,
+  const goto_functionst::goto_functiont &goto_function) const
+{
+  (void)goto_function; // unused parameter
+  return function.location.get_file() == file_id;
+}
+
+/// Filter out all functions except for one particular function given
+/// in the constructor.
+/// \param function: the function under consideration
+/// \param goto_function: a goto function
+/// \return returns true if `function` is different from the
+/// function given in the constructor
+bool single_function_filtert::operator()(
+  const symbolt &function,
+  const goto_functionst::goto_functiont &goto_function) const
+{
+  (void)goto_function; // unused parameter
+  return function.name == function_id;
+}
+
 /// Filter functions whose name matches the regex
 /// \param function: the function under consideration
 /// \param goto_function: a goto function

--- a/src/goto-instrument/cover_filter.cpp
+++ b/src/goto-instrument/cover_filter.cpp
@@ -16,24 +16,24 @@ Author: Peter Schrammel
 #include <linking/static_lifetime_init.h>
 
 /// Filter out functions that are not considered provided by the user
-/// \param function_id: a function name
+/// \param function: the function under consideration
 /// \param goto_function: a goto function
 /// \return returns true if function is considered user-provided
 bool internal_functions_filtert::operator()(
-  const irep_idt &function_id,
+  const symbolt &function,
   const goto_functionst::goto_functiont &goto_function) const
 {
-  if(function_id == goto_functionst::entry_point())
+  if(function.name == goto_functionst::entry_point())
     return false;
 
-  if(function_id == INITIALIZE_FUNCTION)
+  if(function.name == INITIALIZE_FUNCTION)
     return false;
 
   if(goto_function.is_hidden())
     return false;
 
   // ignore Java built-ins (synthetic functions)
-  if(has_prefix(id2string(function_id), "java::array["))
+  if(has_prefix(id2string(function.name), "java::array["))
     return false;
 
   // ignore if built-in library
@@ -45,18 +45,18 @@ bool internal_functions_filtert::operator()(
   return true;
 }
 
-/// Filter functions whose name match the regex
-/// \param function_id: a function name
+/// Filter functions whose name matches the regex
+/// \param function: the function under consideration
 /// \param goto_function: a goto function
 /// \return returns true if the function name matches
 bool include_pattern_filtert::operator()(
-  const irep_idt &function_id,
+  const symbolt &function,
   const goto_functionst::goto_functiont &goto_function) const
 {
   (void)goto_function; // unused parameter
   std::smatch string_matcher;
   return std::regex_match(
-    id2string(function_id), string_matcher, regex_matcher);
+    id2string(function.name), string_matcher, regex_matcher);
 }
 
 /// Call a goto_program non-trivial if it has:
@@ -64,14 +64,15 @@ bool include_pattern_filtert::operator()(
 ///  * At least 2 branches
 ///  * At least 5 assignments
 /// These criteria are arbitrarily chosen.
-/// \param function_id: name of \p goto_function
+/// \param function: function symbol for function corresponding
+/// to \p goto_function
 /// \param goto_function: a goto function
 /// \return returns true if non-trivial
 bool trivial_functions_filtert::operator()(
-  const irep_idt &function_id,
+  const symbolt &function,
   const goto_functionst::goto_functiont &goto_function) const
 {
-  (void)function_id; // unused parameter
+  (void)function; // unused parameter
   unsigned long count_assignments = 0, count_goto = 0;
   forall_goto_program_instructions(i_it, goto_function.body)
   {

--- a/src/goto-instrument/cover_filter.h
+++ b/src/goto-instrument/cover_filter.h
@@ -156,6 +156,42 @@ public:
     const goto_functionst::goto_functiont &goto_function) const override;
 };
 
+class file_filtert : public function_filter_baset
+{
+public:
+  explicit file_filtert(
+    message_handlert &message_handler,
+    const irep_idt &file_id)
+    : function_filter_baset(message_handler), file_id(file_id)
+  {
+  }
+
+  bool operator()(
+    const symbolt &identifier,
+    const goto_functionst::goto_functiont &goto_function) const override;
+
+private:
+  irep_idt file_id;
+};
+
+class single_function_filtert : public function_filter_baset
+{
+public:
+  explicit single_function_filtert(
+    message_handlert &message_handler,
+    const irep_idt &function_id)
+    : function_filter_baset(message_handler), function_id(function_id)
+  {
+  }
+
+  bool operator()(
+    const symbolt &identifier,
+    const goto_functionst::goto_functiont &goto_function) const override;
+
+private:
+  irep_idt function_id;
+};
+
 /// Filters functions that match the provided pattern
 class include_pattern_filtert : public function_filter_baset
 {

--- a/src/goto-instrument/cover_filter.h
+++ b/src/goto-instrument/cover_filter.h
@@ -15,8 +15,9 @@ Author: Daniel Kroening
 #include <regex>
 #include <memory>
 
-#include <util/message.h>
 #include <util/invariant.h>
+#include <util/message.h>
+#include <util/symbol.h>
 
 #include <goto-programs/goto_model.h>
 
@@ -35,7 +36,7 @@ public:
 
   /// Returns true if the function passes the filter criteria
   virtual bool operator()(
-    const irep_idt &identifier,
+    const symbolt &identifier,
     const goto_functionst::goto_functiont &goto_function) const = 0;
 
   /// Can be called after final filter application to report
@@ -85,7 +86,7 @@ public:
   /// \param identifier: function name
   /// \param goto_function: goto function
   bool operator()(
-    const irep_idt &identifier,
+    const symbolt &identifier,
     const goto_functionst::goto_functiont &goto_function) const
   {
     for(const auto &filter : filters)
@@ -151,7 +152,7 @@ public:
   }
 
   bool operator()(
-    const irep_idt &identifier,
+    const symbolt &identifier,
     const goto_functionst::goto_functiont &goto_function) const override;
 };
 
@@ -168,7 +169,7 @@ public:
   }
 
   bool operator()(
-    const irep_idt &identifier,
+    const symbolt &identifier,
     const goto_functionst::goto_functiont &goto_function) const override;
 
 private:
@@ -185,7 +186,7 @@ public:
   }
 
   bool operator()(
-    const irep_idt &identifier,
+    const symbolt &identifier,
     const goto_functionst::goto_functiont &goto_function) const override;
 };
 

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -16,6 +16,7 @@ SRC += analyses/ai/ai.cpp \
        analyses/does_remove_const/is_type_at_least_as_const_as.cpp \
        big-int/big-int.cpp \
        compound_block_locations.cpp \
+       goto-instrument/cover/cover_only.cpp \
        goto-programs/goto_model_function_type_consistency.cpp \
        goto-programs/goto_program_assume.cpp \
        goto-programs/goto_program_dead.cpp \

--- a/unit/goto-instrument/cover/cover_only.cpp
+++ b/unit/goto-instrument/cover/cover_only.cpp
@@ -1,0 +1,160 @@
+/*******************************************************************\
+
+Module: Tests for coverage instrumentation config object and filters
+
+Author: Diffblue Ltd
+
+\*******************************************************************/
+
+#include <goto-instrument/cover.h>
+#include <testing-utils/message.h>
+#include <testing-utils/use_catch.h>
+#include <util/options.h>
+#include <util/symbol_table.h>
+#include <util/ui_message.h>
+
+namespace
+{
+symbolt create_new_symbol(const irep_idt &name, const irep_idt &file_name)
+{
+  symbolt symbol;
+  symbol.name = name;
+  source_locationt location;
+  location.set_file(file_name);
+  symbol.location = location;
+
+  return symbol;
+}
+} // namespace
+
+SCENARIO("get_cover_config is called", "[core]")
+{
+  symbol_tablet symbol_table;
+  irep_idt id_Afoo = "java::A.foo";
+  symbolt symbol_Afoo = create_new_symbol(id_Afoo, "A.java");
+
+  symbolt symbol_Afoolish = create_new_symbol("java::A.foolish", "A.java");
+
+  symbolt symbol_Bbar = create_new_symbol("java::B.bar", "B.java");
+
+  symbolt symbol_Bbarbaric = create_new_symbol("java::B.barbaric", "B.java");
+
+  symbolt symbol_A_Innerfoo = create_new_symbol("java::A$Inner.foo", "A.java");
+
+  symbolt symbol_another_package_Afoo =
+    create_new_symbol("java::another.package.A.foo", "another/package/A.java");
+
+  symbol_table.insert(symbol_Afoo);
+  symbol_table.insert(symbol_Afoolish);
+  symbol_table.insert(symbol_Bbar);
+  symbol_table.insert(symbol_Bbarbaric);
+
+  goto_functiont dummy_function;
+
+  ui_message_handlert message_handler(null_message_handler);
+
+  GIVEN("cover-only set to an unrecognised value")
+  {
+    optionst options;
+    options.set_option("cover-only", "diplodocus-with-a-duvet");
+
+    WHEN("We give a valid main_symbol")
+    {
+      THEN("A config is not obtained")
+      {
+        try
+        {
+          get_cover_config(options, id_Afoo, symbol_table, message_handler);
+          REQUIRE_FALSE(false);
+        }
+        catch(...)
+        {
+        }
+      }
+    }
+  }
+
+  GIVEN("cover-only set to 'file'")
+  {
+    optionst options;
+    options.set_option("cover-only", "file");
+
+    WHEN("We give a valid main_symbol")
+    {
+      auto ret =
+        get_cover_config(options, id_Afoo, symbol_table, message_handler);
+
+      THEN("A config is obtained that matches functions from the same file")
+      {
+        REQUIRE(ret.function_filters(symbol_Afoo, dummy_function));
+        REQUIRE(ret.function_filters(symbol_Afoolish, dummy_function));
+        REQUIRE_FALSE(ret.function_filters(symbol_Bbar, dummy_function));
+        REQUIRE_FALSE(ret.function_filters(symbol_Bbarbaric, dummy_function));
+        REQUIRE(ret.function_filters(symbol_A_Innerfoo, dummy_function));
+        REQUIRE_FALSE(
+          ret.function_filters(symbol_another_package_Afoo, dummy_function));
+      }
+    }
+  }
+
+  GIVEN("cover-only set to 'function'")
+  {
+    optionst options;
+    options.set_option("cover-only", "function");
+
+    WHEN("We give a valid main_symbol")
+    {
+      auto ret =
+        get_cover_config(options, id_Afoo, symbol_table, message_handler);
+
+      THEN("A config is obtained that matches the single function")
+      {
+        REQUIRE(ret.function_filters(symbol_Afoo, dummy_function));
+        REQUIRE_FALSE(ret.function_filters(symbol_Afoolish, dummy_function));
+        REQUIRE_FALSE(ret.function_filters(symbol_Bbar, dummy_function));
+        REQUIRE_FALSE(ret.function_filters(symbol_Bbarbaric, dummy_function));
+        REQUIRE_FALSE(ret.function_filters(symbol_A_Innerfoo, dummy_function));
+        REQUIRE_FALSE(
+          ret.function_filters(symbol_another_package_Afoo, dummy_function));
+      }
+    }
+  }
+
+  GIVEN("cover-only is not set")
+  {
+    optionst options;
+
+    WHEN("We give a valid main_symbol")
+    {
+      auto ret =
+        get_cover_config(options, id_Afoo, symbol_table, message_handler);
+
+      THEN("A config is obtained that matches all the symbols")
+      {
+        REQUIRE(ret.function_filters(symbol_Afoo, dummy_function));
+        REQUIRE(ret.function_filters(symbol_Afoolish, dummy_function));
+        REQUIRE(ret.function_filters(symbol_Bbar, dummy_function));
+        REQUIRE(ret.function_filters(symbol_Bbarbaric, dummy_function));
+        REQUIRE(ret.function_filters(symbol_A_Innerfoo, dummy_function));
+        REQUIRE(
+          ret.function_filters(symbol_another_package_Afoo, dummy_function));
+      }
+    }
+
+    WHEN("We give no main_symbol")
+    {
+      auto ret = get_cover_config(options, symbol_table, message_handler);
+
+      THEN("A config is obtained that matches all the symbols")
+      {
+        REQUIRE(ret.function_filters(symbol_Afoo, dummy_function));
+        REQUIRE(ret.function_filters(symbol_Afoolish, dummy_function));
+        REQUIRE(ret.function_filters(symbol_Bbar, dummy_function));
+        REQUIRE(ret.function_filters(symbol_Bbarbaric, dummy_function));
+        REQUIRE(ret.function_filters(symbol_A_Innerfoo, dummy_function));
+        REQUIRE(
+          ret.function_filters(symbol_another_package_Afoo, dummy_function));
+      }
+    }
+  }
+}

--- a/unit/goto-instrument/cover/module_dependencies.txt
+++ b/unit/goto-instrument/cover/module_dependencies.txt
@@ -1,0 +1,3 @@
+goto-instrument
+testing-utils
+util


### PR DESCRIPTION
This PR adds a `cover-only` option that mirrors what `cover-function-only` is doing, but allows the user to specify that a single file can be instrumented, rather than just a single function. As a side-effect of the changes, I fixed a bug in `cover-function-only`: before, we were matching function name as substring, so for the main function `Foo.foo` we'd also have instrumented `Foo.foolish` when `cover-function-only` was used, which was incorrect.

~There are no tests with this PR because the command-line option `cover-only` or `cover-function-only` is not enabled in any of the opensource binaries.~