### PR TITLE
byte_update against a pointer shouldn't be fatal

### DIFF
--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -451,16 +451,6 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
   {
     return SUB::convert_byte_extract(to_byte_extract_expr(expr));
   }
-  else
-  {
-    INVARIANT(
-      expr.id() != ID_byte_update_little_endian,
-      "byte-wise pointer updates are unsupported");
-
-    INVARIANT(
-      expr.id() != ID_byte_update_big_endian,
-      "byte-wise pointer updates are unsupported");
-  }
 
   return conversion_failed(expr);
 }


### PR DESCRIPTION
This can happen in inaccessible code, so it doesn't seem necessary to kill the whole process.

For example, a program might do something like

```
f(bool unknown) {
  int i = 0;
  void *ptr = nullptr;
  void *i_or_ptr = unknown ? &i : &ptr;
  if(unknown)
    ((int*)i_or_ptr) = 1;
}
```

This doesn't do anything unsafe, but symex might produce a byte-update against `ptr` regardless based on the incorrect assumption that `unknown` may have changed between lines 4 and 5. Therefore I argue we shouldn't unconditionally reject such an expression.

I raise this now because with #3725 applied we get byte-update expressions against pointers which were previously hidden as byte-extract + with. The meaning of the expression is the same, but it trips this path, indicating the invariant also fails to find all cases where pointers are updated byte-wise.