### PR TITLE
Clean-up use of guards

### DIFF
--- a/src/goto-instrument/rw_set.h
+++ b/src/goto-instrument/rw_set.h
@@ -18,7 +18,6 @@ Date: February 2006
 #include <vector>
 #include <set>
 
-#include <util/guard.h>
 #include <util/std_expr.h>
 
 #include <goto-programs/goto_model.h>
@@ -158,17 +157,17 @@ protected:
 
   void read(const exprt &expr)
   {
-    read_write_rec(expr, true, false, "", guardt(true_exprt()));
+    read_write_rec(expr, true, false, "", exprt::operandst());
   }
 
-  void read(const exprt &expr, const guardt &guard)
+  void read(const exprt &expr, const exprt::operandst &guard_conjuncts)
   {
-    read_write_rec(expr, true, false, "", guard);
+    read_write_rec(expr, true, false, "", guard_conjuncts);
   }
 
   void write(const exprt &expr)
   {
-    read_write_rec(expr, false, true, "", guardt(true_exprt()));
+    read_write_rec(expr, false, true, "", exprt::operandst());
   }
 
   void compute();
@@ -177,9 +176,10 @@ protected:
 
   void read_write_rec(
     const exprt &expr,
-    bool r, bool w,
+    bool r,
+    bool w,
     const std::string &suffix,
-    const guardt &guard);
+    const exprt::operandst &guard_conjuncts);
 };
 
 class rw_set_loct:public _rw_set_loct

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -17,7 +17,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <unordered_set>
 
 #include <util/allocate_objects.h>
-#include <util/guard.h>
 #include <util/message.h>
 #include <util/namespace.h>
 #include <util/replace_expr.h>

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -125,7 +125,7 @@ void goto_symext::process_array_expr(statet &state, exprt &expr)
   value_set_dereferencet dereference(
     ns, state.symbol_table, symex_dereference_state, language_mode, false);
 
-  expr = dereference.dereference(expr, guardt{true_exprt()});
+  expr = dereference.dereference(expr);
 
   ::process_array_expr(expr, symex_config.simplify_opt, ns);
 }

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -234,7 +234,7 @@ void goto_symext::dereference_rec(exprt &expr, statet &state)
       expr_is_not_null);
 
     // std::cout << "**** " << format(tmp1) << '\n';
-    exprt tmp2 = dereference.dereference(tmp1, guardt(true_exprt()));
+    exprt tmp2 = dereference.dereference(tmp1);
     // std::cout << "**** " << format(tmp2) << '\n';
 
     expr.swap(tmp2);

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -188,7 +188,7 @@ void goto_program_dereferencet::dereference_rec(exprt &expr, guardt &guard)
 
     dereference_location=expr.find_source_location();
 
-    exprt tmp = dereference.dereference(expr.op0(), guard);
+    exprt tmp = dereference.dereference(expr.op0());
 
     expr.swap(tmp);
   }
@@ -206,7 +206,7 @@ void goto_program_dereferencet::dereference_rec(exprt &expr, guardt &guard)
       exprt tmp1(ID_plus, expr.op0().type());
       tmp1.operands().swap(expr.operands());
 
-      exprt tmp2 = dereference.dereference(tmp1, guard);
+      exprt tmp2 = dereference.dereference(tmp1);
       tmp2.swap(expr);
     }
   }

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -44,56 +44,6 @@ goto_program_dereferencet::get_or_create_failed_symbol(const exprt &expr)
   return nullptr;
 }
 
-/// \deprecated
-bool goto_program_dereferencet::is_valid_object(
-  const irep_idt &identifier)
-{
-  const symbolt &symbol=ns.lookup(identifier);
-
-  if(symbol.type.id()==ID_code)
-    return true;
-
-  if(symbol.is_static_lifetime)
-    return true; // global/static
-
-  #if 0
-  return valid_local_variables->find(symbol.name)!=
-     valid_local_variables->end(); // valid local
-  #else
-  return true;
-  #endif
-}
-
-/// \deprecated
-void goto_program_dereferencet::dereference_failure(
-  const std::string &property,
-  const std::string &msg,
-  const guardt &guard)
-{
-  exprt guard_expr=guard.as_expr();
-
-  if(assertions.insert(guard_expr).second)
-  {
-    guard_expr = boolean_negate(guard_expr);
-
-    // first try simplifier on it
-    if(options.get_bool_option("simplify"))
-      simplify(guard_expr, ns);
-
-    if(!guard_expr.is_true())
-    {
-      goto_program_instruction_typet type=
-        options.get_bool_option("assert-to-assume")?ASSUME:ASSERT;
-
-      goto_programt::targett t=new_code.add_instruction(type);
-      t->guard.swap(guard_expr);
-      t->source_location=dereference_location;
-      t->source_location.set_property_class(property);
-      t->source_location.set_comment("dereference failure: "+msg);
-    }
-  }
-}
-
 /// Turn subexpression of `expr` of the form `&*p` into p
 /// and use `dereference` on subexpressions of the form `*p`
 /// \param expr: expression in which to remove dereferences
@@ -166,8 +116,6 @@ void goto_program_dereferencet::dereference_rec(exprt &expr)
     if(expr.operands().size()!=1)
       throw "dereference expects one operand";
 
-    dereference_location=expr.find_source_location();
-
     exprt tmp = dereference.dereference(expr.op0());
 
     expr.swap(tmp);
@@ -181,8 +129,6 @@ void goto_program_dereferencet::dereference_rec(exprt &expr)
 
     if(expr.op0().type().id()==ID_pointer)
     {
-      dereference_location=expr.find_source_location();
-
       exprt tmp1(ID_plus, expr.op0().type());
       tmp1.operands().swap(expr.operands());
 
@@ -231,8 +177,6 @@ void goto_program_dereferencet::dereference_program(
       it++)
   {
     new_code.clear();
-    assertions.clear();
-
     dereference_instruction(it, checks_only);
 
     // insert new instructions
@@ -265,9 +209,6 @@ void goto_program_dereferencet::dereference_instruction(
   bool checks_only)
 {
   current_target=target;
-  #if 0
-  valid_local_variables=&target->local_variables;
-  #endif
   goto_programt::instructiont &i=*target;
 
   if(i.has_condition())
@@ -329,43 +270,7 @@ void goto_program_dereferencet::dereference_expression(
 {
   current_function = function_id;
   current_target=target;
-  #if 0
-  valid_local_variables=&target->local_variables;
-  #endif
-
   dereference_expr(expr, false);
-}
-
-/// Throw an exception in case removing dereferences from the program would
-/// throw an exception.
-void goto_program_dereferencet::pointer_checks(
-  goto_programt &goto_program)
-{
-  dereference_program(goto_program, true);
-}
-
-/// Throw an exception in case removing dereferences from the program would
-/// throw an exception.
-void goto_program_dereferencet::pointer_checks(
-  goto_functionst &goto_functions)
-{
-  dereference_program(goto_functions, true);
-}
-
-/// \deprecated
-void remove_pointers(
-  goto_programt &goto_program,
-  symbol_tablet &symbol_table,
-  value_setst &value_sets)
-{
-  namespacet ns(symbol_table);
-
-  optionst options;
-
-  goto_program_dereferencet
-    goto_program_dereference(ns, symbol_table, options, value_sets);
-
-  goto_program_dereference.dereference_program(goto_program);
 }
 
 /// Remove dereferences in all expressions contained in the program
@@ -385,32 +290,6 @@ void remove_pointers(
 
   Forall_goto_functions(it, goto_model.goto_functions)
     goto_program_dereference.dereference_program(it->second.body);
-}
-
-/// \deprecated
-void pointer_checks(
-  goto_programt &goto_program,
-  symbol_tablet &symbol_table,
-  const optionst &options,
-  value_setst &value_sets)
-{
-  namespacet ns(symbol_table);
-  goto_program_dereferencet
-    goto_program_dereference(ns, symbol_table, options, value_sets);
-  goto_program_dereference.pointer_checks(goto_program);
-}
-
-/// \deprecated
-void pointer_checks(
-  goto_functionst &goto_functions,
-  symbol_tablet &symbol_table,
-  const optionst &options,
-  value_setst &value_sets)
-{
-  namespacet ns(symbol_table);
-  goto_program_dereferencet
-    goto_program_dereference(ns, symbol_table, options, value_sets);
-  goto_program_dereference.pointer_checks(goto_functions);
 }
 
 /// Remove dereferences in `expr` using `value_sets` to determine to what

--- a/src/pointer-analysis/goto_program_dereference.h
+++ b/src/pointer-analysis/goto_program_dereference.h
@@ -19,6 +19,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "value_sets.h"
 #include "value_set_dereference.h"
 
+class guardt;
+
 /// Wrapper for functions removing dereferences in expressions contained in
 /// a goto program.
 class goto_program_dereferencet:protected dereference_callbackt

--- a/src/pointer-analysis/goto_program_dereference.h
+++ b/src/pointer-analysis/goto_program_dereference.h
@@ -19,8 +19,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "value_sets.h"
 #include "value_set_dereference.h"
 
-class guardt;
-
 /// Wrapper for functions removing dereferences in expressions contained in
 /// a goto program.
 class goto_program_dereferencet:protected dereference_callbackt
@@ -50,9 +48,6 @@ public:
     goto_functionst &goto_functions,
     bool checks_only=false);
 
-  void pointer_checks(goto_programt &goto_program);
-  void pointer_checks(goto_functionst &goto_functions);
-
   void dereference_expression(
     const irep_idt &function_id,
     goto_programt::const_targett target,
@@ -68,16 +63,7 @@ protected:
   value_setst &value_sets;
   value_set_dereferencet dereference;
 
-  DEPRECATED("Unused")
-  virtual bool is_valid_object(const irep_idt &identifier);
-
   const symbolt *get_or_create_failed_symbol(const exprt &expr) override;
-
-  DEPRECATED("Unused")
-  virtual void dereference_failure(
-    const std::string &property,
-    const std::string &msg,
-    const guardt &guard);
 
   void
   get_value_set(const exprt &expr, value_setst::valuest &dest) const override;
@@ -90,19 +76,8 @@ protected:
   void dereference_rec(exprt &expr);
   void dereference_expr(exprt &expr, const bool checks_only);
 
-#if 0
-  const std::set<irep_idt> *valid_local_variables;
-#endif
   irep_idt current_function;
   goto_programt::const_targett current_target;
-
-  /// Unused
-  source_locationt dereference_location;
-
-  /// Unused
-  std::set<exprt> assertions;
-
-  /// Unused
   goto_programt new_code;
 };
 
@@ -115,26 +90,6 @@ void dereference(
 
 void remove_pointers(
   goto_modelt &,
-  value_setst &);
-
-DEPRECATED("Unused")
-void remove_pointers(
-  goto_functionst &,
-  symbol_tablet &,
-  value_setst &);
-
-DEPRECATED("Unused")
-void pointer_checks(
-  goto_programt &,
-  symbol_tablet &,
-  const optionst &,
-  value_setst &);
-
-DEPRECATED("Unused")
-void pointer_checks(
-  goto_functionst &,
-  symbol_tablet &,
-  const optionst &,
   value_setst &);
 
 #endif // CPROVER_POINTER_ANALYSIS_GOTO_PROGRAM_DEREFERENCE_H

--- a/src/pointer-analysis/goto_program_dereference.h
+++ b/src/pointer-analysis/goto_program_dereference.h
@@ -87,7 +87,7 @@ protected:
     bool checks_only=false);
 
 protected:
-  void dereference_rec(exprt &expr, guardt &guard);
+  void dereference_rec(exprt &expr);
   void dereference_expr(exprt &expr, const bool checks_only);
 
 #if 0

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -32,9 +32,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/simplify_expr.h>
 #include <util/ssa_expr.h>
 
-exprt value_set_dereferencet::dereference(
-  const exprt &pointer,
-  const guardt &guard)
+exprt value_set_dereferencet::dereference(const exprt &pointer)
 {
   if(pointer.type().id()!=ID_pointer)
     throw "dereference expected pointer type, but got "+
@@ -44,16 +42,8 @@ exprt value_set_dereferencet::dereference(
   if(pointer.id()==ID_if)
   {
     const if_exprt &if_expr=to_if_expr(pointer);
-    // push down the if
-    guardt true_guard=guard;
-    guardt false_guard=guard;
-
-    true_guard.add(if_expr.cond());
-    false_guard.add(not_exprt(if_expr.cond()));
-
-    exprt true_case = dereference(if_expr.true_case(), true_guard);
-    exprt false_case = dereference(if_expr.false_case(), false_guard);
-
+    exprt true_case = dereference(if_expr.true_case());
+    exprt false_case = dereference(if_expr.false_case());
     return if_exprt(if_expr.cond(), true_case, false_case);
   }
 

--- a/src/pointer-analysis/value_set_dereference.h
+++ b/src/pointer-analysis/value_set_dereference.h
@@ -24,7 +24,7 @@ class optionst;
 class symbolt;
 
 /// Wrapper for a function dereferencing pointer expressions using a value set.
-class value_set_dereferencet
+class value_set_dereferencet final
 {
 public:
   /// \param _ns: Namespace
@@ -55,7 +55,7 @@ public:
   /// \param pointer: A pointer-typed expression, to
   ///        be dereferenced.
   /// \param guard: A guard, which is assumed to hold when dereferencing.
-  virtual exprt dereference(const exprt &pointer, const guardt &guard);
+  exprt dereference(const exprt &pointer, const guardt &guard);
 
 private:
   const namespacet &ns;

--- a/src/pointer-analysis/value_set_dereference.h
+++ b/src/pointer-analysis/value_set_dereference.h
@@ -19,7 +19,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "dereference_callback.h"
 
 class symbol_tablet;
-class guardt;
 class optionst;
 class symbolt;
 
@@ -52,10 +51,8 @@ public:
 
   /// Dereference the given pointer-expression. Any errors are
   /// reported to the callback method given in the constructor.
-  /// \param pointer: A pointer-typed expression, to
-  ///        be dereferenced.
-  /// \param guard: A guard, which is assumed to hold when dereferencing.
-  exprt dereference(const exprt &pointer, const guardt &guard);
+  /// \param pointer: A pointer-typed expression, to be dereferenced.
+  exprt dereference(const exprt &pointer);
 
 private:
   const namespacet &ns;


### PR DESCRIPTION
In some places, guards are passed around but never really used, in other places they can be replaced by expressions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
