### PR TITLE
use instructiont::make_X in remove_virtual_functions

### DIFF
--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -247,24 +247,31 @@ goto_programt::targett remove_virtual_functionst::remove_virtual_function(
     // Only create one call sequence per possible target:
     if(insertit.second)
     {
-      goto_programt::targett t1=new_code_calls.add_instruction();
       if(fun.symbol_expr.has_value())
       {
         // call function
-        *t1 = goto_programt::make_function_call(code, vcall_source_loc);
+        goto_programt::targett t1 = new_code_calls.add(
+          goto_programt::make_function_call(code, vcall_source_loc));
+
         create_static_function_call(
           t1->get_function_call(), *fun.symbol_expr, ns);
+
+        insertit.first->second = t1;
       }
       else
       {
+        goto_programt::targett t1 = new_code_calls.add(
+          goto_programt::make_assertion(false_exprt(), vcall_source_loc));
+
         // No definition for this type; shouldn't be possible...
-        *t1 = goto_programt::make_assertion(false_exprt(), vcall_source_loc);
         t1->source_location.set_comment(
           "cannot find calls for " +
           id2string(code.function().get(ID_identifier)) + " dispatching " +
           id2string(fun.class_id));
+
+        insertit.first->second = t1;
       }
-      insertit.first->second=t1;
+
       // goto final
       new_code_calls.add(
         goto_programt::make_goto(t_final, true_exprt(), vcall_source_loc));


### PR DESCRIPTION
This prevents duplicate initialization of instructions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
