### PR TITLE
Array logic: support with_exprt with multiple updates [blocks: #2068]

### DIFF
--- a/src/solvers/flattening/arrays.cpp
+++ b/src/solvers/flattening/arrays.cpp
@@ -123,8 +123,11 @@ void arrayst::collect_arrays(const exprt &a)
     collect_arrays(with_expr.old());
 
     // make sure this shows as an application
-    index_exprt index_expr(with_expr.old(), with_expr.where());
-    record_array_index(index_expr);
+    for(std::size_t i = 1; i < with_expr.operands().size(); i += 2)
+    {
+      index_exprt index_expr(with_expr.old(), with_expr.operands()[i]);
+      record_array_index(index_expr);
+    }
   }
   else if(a.id()==ID_update)
   {
@@ -502,11 +505,19 @@ void arrayst::add_array_constraints_with(
   const index_sett &index_set,
   const with_exprt &expr)
 {
+  const exprt::operandst &operands = expr.operands();
+  for(std::size_t i = 1; i + 1 < operands.size(); i += 2)
+    add_array_constraints_with(index_set, expr, operands[i], operands[i + 1]);
+}
+
+void arrayst::add_array_constraints_with(
+  const index_sett &index_set,
+  const with_exprt &expr,
+  const exprt &index,
+  const exprt &value)
+{
   // we got x=(y with [i:=v])
   // add constraint x[i]=v
-
-  const exprt &index=expr.where();
-  const exprt &value=expr.new_value();
 
   {
     index_exprt index_expr(expr, index, expr.type().subtype());

--- a/src/solvers/flattening/arrays.h
+++ b/src/solvers/flattening/arrays.h
@@ -111,6 +111,11 @@ protected:
     const index_sett &index_set, const if_exprt &exprt);
   void add_array_constraints_with(
     const index_sett &index_set, const with_exprt &expr);
+  void add_array_constraints_with(
+    const index_sett &index_set,
+    const with_exprt &expr,
+    const exprt &index,
+    const exprt &value);
   void add_array_constraints_update(
     const index_sett &index_set, const update_exprt &expr);
   void add_array_constraints_array_of(


### PR DESCRIPTION
A with_exprt can hold any odd number (>=3) of operands, where each pair after
the first operand is an (index, value) entry.

This will be exercised once #2068 is merged.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
