### PR TITLE
byte_extract lowering of pointers [blocks: #2068]

### DIFF
--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -264,6 +264,17 @@ static exprt unpack_rec(
         member, little_endian, offset_bytes, max_bytes, ns, true);
     }
   }
+  else if(src.type().id() == ID_pointer)
+  {
+    return unpack_rec(
+      typecast_exprt(
+        src, unsignedbv_typet(to_pointer_type(src.type()).get_width())),
+      little_endian,
+      offset_bytes,
+      max_bytes,
+      ns,
+      unpack_byte_array);
+  }
   else if(src.type().id()!=ID_empty)
   {
     // a basic type; we turn that into extractbits while considering

--- a/unit/solvers/lowering/byte_operators.cpp
+++ b/unit/solvers/lowering/byte_operators.cpp
@@ -124,6 +124,7 @@ SCENARIO("byte_extract_lowering", "[core][solvers][lowering][byte_extract]")
       signedbv_typet(24),
       signedbv_typet(128),
       // ieee_float_spect::single_precision().to_type(),
+      // generates the correct value, but remains wrapped in a typecast
       // pointer_typet(u64, 64),
       vector_typet(u8, size),
       vector_typet(u64, size),


### PR DESCRIPTION
Bit operations cannot be performed on pointers, thus type cast them to unsigned
bitvectors first and then convert back the result.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
