### PR TITLE
Add string2optional conversion functions

### DIFF
--- a/src/util/narrow.h
+++ b/src/util/narrow.h
@@ -38,4 +38,17 @@ output_type narrow(input_type input)
   return output;
 }
 
+/// Run-time checked narrow cast. Throws a std::out_of_range error
+/// if the input cannot be converted to the output_type without data lass
+template <typename output_type, typename input_type>
+output_type narrow_or_throw_out_of_range(input_type input)
+{
+  auto const result = narrow_cast<input_type>(input);
+  if(result != input)
+  {
+    throw std::out_of_range{"narrowing gave a different value than expected"};
+  }
+  return result;
+}
+
 #endif // CPROVER_UTIL_NARROW_H

--- a/src/util/string2int.cpp
+++ b/src/util/string2int.cpp
@@ -10,82 +10,66 @@ Author: Michael Tautschnig, michael.tautschnig@cs.ox.ac.uk
 
 #include <cerrno>
 #include <cstdlib>
+#include <cstring>
 #include <limits>
+#include <stdexcept>
 
 #include "invariant.h"
 
-template <typename T>
-inline T str2number(const char *str, int base, bool safe)
-{
-  int errno_bak=errno;
-  errno=0;
-  char *endptr;
-// _strtoi64 is available in Visual Studio, but not yet in MINGW
-#ifdef _MSC_VER
-  const __int64 val=_strtoi64(str, &endptr, base);
-#else
-  const long long val=strtoll(str, &endptr, base);
-#endif
-
-  if(safe)
-  {
-    CHECK_RETURN(0==errno);
-    errno=errno_bak;
-    CHECK_RETURN(endptr!=str);
-    if(std::numeric_limits<T>::min()==0)
-    {
-      // unsigned
-      CHECK_RETURN(val>=0);
-      CHECK_RETURN(
-        (unsigned long long)(T)val<=
-        (unsigned long long)std::numeric_limits<T>::max());
-    }
-    else
-    {
-      // signed
-      CHECK_RETURN(val<=(long long)std::numeric_limits<T>::max());
-      CHECK_RETURN(val>=(long long)std::numeric_limits<T>::min());
-    }
-  }
-
-  return (T)val;
-}
-
 unsigned safe_string2unsigned(const std::string &str, int base)
 {
-  return str2number<unsigned>(str.c_str(), base, true);
+  auto converted = string2optional<unsigned>(str, base);
+  CHECK_RETURN(converted != nullopt);
+  return *converted;
 }
 
 std::size_t safe_string2size_t(const std::string &str, int base)
 {
-  return str2number<std::size_t>(str.c_str(), base, true);
+  auto converted = string2optional<std::size_t>(str, base);
+  CHECK_RETURN(converted != nullopt);
+  return *converted;
 }
 
 int unsafe_string2int(const std::string &str, int base)
 {
-  return str2number<int>(str.c_str(), base, false);
+  return narrow_cast<int>(std::strtoll(str.c_str(), nullptr, base));
 }
 
 unsigned unsafe_string2unsigned(const std::string &str, int base)
 {
-  return str2number<unsigned>(str.c_str(), base, false);
+  return narrow_cast<unsigned>(std::strtoul(str.c_str(), nullptr, base));
 }
 
 std::size_t unsafe_string2size_t(const std::string &str, int base)
 {
-  return str2number<std::size_t>(str.c_str(), base, false);
+  return narrow_cast<std::size_t>(std::strtoull(str.c_str(), nullptr, base));
 }
 
 signed long long int unsafe_string2signedlonglong(
   const std::string &str,
   int base)
 {
-  return str2number<signed long long int>(str.c_str(), base, false);
+  return std::strtoll(str.c_str(), nullptr, false);
 }
 
 unsigned long long int unsafe_string2unsignedlonglong(
   const std::string &str,
   int base)
 {
-  return str2number<unsigned long long int>(str.c_str(), base, false);
+  return *string2optional<unsigned long long>(str, base);
+}
+
+optionalt<int> string2optional_int(const std::string &str, int base)
+{
+  return string2optional<int>(str, base);
+}
+
+optionalt<unsigned> string2optional_unsigned(const std::string &str, int base)
+{
+  return string2optional<unsigned>(str, base);
+}
+
+optionalt<std::size_t> string2optional_size_t(const std::string &str, int base)
+{
+  return string2optional<std::size_t>(str, base);
 }

--- a/src/util/string2int.h
+++ b/src/util/string2int.h
@@ -10,7 +10,10 @@ Author: Michael Tautschnig, michael.tautschnig@cs.ox.ac.uk
 #ifndef CPROVER_UTIL_STRING2INT_H
 #define CPROVER_UTIL_STRING2INT_H
 
+#include "narrow.h"
+#include "optional.h"
 #include <string>
+#include <type_traits>
 
 // These check that the string is indeed a valid number,
 // and fail an assertion otherwise.
@@ -29,5 +32,86 @@ std::size_t unsafe_string2size_t(const std::string &str, int base=10);
 long long int unsafe_string2signedlonglong(const std::string &str, int base=10);
 long long unsigned int unsafe_string2unsignedlonglong(
   const std::string &str, int base=10);
+
+// if we had a `resultt` á la Boost.Outcome (https://ned14.github.io/outcome/)
+// we could also return the reason why the conversion failed
+
+/// Convert string to integer as per stoi, but return nullopt when
+/// stoi would throw
+optionalt<int> string2optional_int(const std::string &, int base = 10);
+
+/// Convert string to unsigned similar to the stoul or stoull functions,
+/// return nullopt when the conversion fails.
+/// Note: Unlike stoul or stoull negative inputs are disallowed
+optionalt<unsigned>
+string2optional_unsigned(const std::string &, int base = 10);
+
+/// Convert string to size_t similar to the stoul or stoull functions,
+/// return nullopt when the conversion fails.
+/// Note: Unlike stoul or stoull negative inputs are disallowed
+optionalt<std::size_t>
+string2optional_size_t(const std::string &, int base = 10);
+
+/// convert string to signed long long if T is signed
+template <typename T>
+auto string2optional_base(const std::string &str, int base) ->
+  typename std::enable_if<std::is_signed<T>::value, long long>::type
+{
+  static_assert(
+    sizeof(T) <= sizeof(long long),
+    "this works under the assumption that long long is the largest type we try "
+    "to convert");
+  return std::stoll(str, nullptr, base);
+}
+
+/// convert string to unsigned long long if T is unsigned
+template <typename T>
+auto string2optional_base(const std::string &str, int base) ->
+  typename std::enable_if<std::is_unsigned<T>::value, unsigned long long>::type
+{
+  static_assert(
+    sizeof(T) <= sizeof(unsigned long long),
+    "this works under the assumption that long long is the largest type we try "
+    "to convert");
+  if(str.find('-') != std::string::npos)
+  {
+    throw std::out_of_range{
+      "unsigned conversion behaves a bit strangely with negative values, "
+      "therefore we disable it"};
+  }
+  return std::stoull(str, nullptr, base);
+}
+
+/// attempt a given conversion, return nullopt if the conversion fails
+/// with out_of_range or invalid_argument
+template <typename do_conversiont>
+auto wrap_string_conversion(do_conversiont do_conversion)
+  -> optionalt<decltype(do_conversion())>
+{
+  try
+  {
+    return do_conversion();
+  }
+  catch(const std::invalid_argument &)
+  {
+    return nullopt;
+  }
+  catch(const std::out_of_range &)
+  {
+    return nullopt;
+  }
+}
+
+/// convert a string to an integer, given the base of the representation
+/// works with signed and unsigned integer types smaller than
+///   (unsigned) long long
+/// does not accept negative inputs when the result type is unsigned
+template <typename T>
+optionalt<T> string2optional(const std::string &str, int base)
+{
+  return wrap_string_conversion([&]() {
+    return narrow_or_throw_out_of_range<T>(string2optional_base<T>(str, base));
+  });
+}
 
 #endif // CPROVER_UTIL_STRING2INT_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -69,7 +69,8 @@ SRC += analyses/ai/ai.cpp \
        util/simplify_expr.cpp \
        util/small_map.cpp \
        util/small_shared_two_way_ptr.cpp \
-	util/std_expr.cpp \
+       util/std_expr.cpp \
+       util/string2int.cpp \
        util/string_utils/join_string.cpp \
        util/string_utils/split_string.cpp \
        util/string_utils/strip_string.cpp \

--- a/unit/util/string2int.cpp
+++ b/unit/util/string2int.cpp
@@ -1,0 +1,88 @@
+/*******************************************************************\
+
+Module: Unit tests for string2int.h
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include <testing-utils/use_catch.h>
+#include <util/string2int.h>
+
+TEST_CASE(
+  "converting optionally to a valid integer should succeed",
+  "[core][util][string2int]")
+{
+  REQUIRE(string2optional_int("13") == 13);
+  REQUIRE(string2optional_int("-5") == -5);
+  REQUIRE(string2optional_int("c0fefe", 16) == 0xc0fefe);
+}
+
+TEST_CASE(
+  "optionally converting invalid string to integer should return nullopt",
+  "[core][util][string2int]")
+{
+  REQUIRE(string2optional_int("thirteen") == nullopt);
+  REQUIRE(string2optional_int("c0fefe") == nullopt);
+}
+
+TEST_CASE(
+  "optionally converting string out of range to integer should return nullopt",
+  "[core][util][string2int]")
+{
+  REQUIRE(
+    string2optional_int("0xfffffffffffffffffffffffffffffffffffffffffff", 16) ==
+    nullopt);
+}
+
+TEST_CASE(
+  "converting optionally to a valid unsigned should succeed",
+  "[core][util][string2int]")
+{
+  REQUIRE(string2optional_unsigned("13") == 13u);
+  REQUIRE(string2optional_unsigned("c0fefe", 16) == 0xc0fefeu);
+}
+
+TEST_CASE(
+  "optionally converting invalid string to unsigned should return nullopt",
+  "[core][util][string2int]")
+{
+  REQUIRE(string2optional_unsigned("thirteen") == nullopt);
+  REQUIRE(string2optional_unsigned("c0fefe") == nullopt);
+}
+
+TEST_CASE(
+  "optionally converting string out of range to unsigned should return nullopt",
+  "[core][util][string2int]")
+{
+  REQUIRE(
+    string2optional_unsigned(
+      "0xfffffffffffffffffffffffffffffffffffffffffff", 16) == nullopt);
+  REQUIRE(string2optional_unsigned("-5") == nullopt);
+}
+
+TEST_CASE(
+  "converting optionally to a valid size_t should succeed",
+  "[core][util][string2int]")
+{
+  REQUIRE(string2optional_size_t("13") == std::size_t{13});
+  REQUIRE(string2optional_size_t("c0fefe", 16) == std::size_t{0xc0fefe});
+}
+
+TEST_CASE(
+  "optionally converting invalid string to size_t should return nullopt",
+  "[core][util][string2int]")
+{
+  REQUIRE(string2optional_size_t("thirteen") == nullopt);
+  REQUIRE(string2optional_size_t("c0fefe") == nullopt);
+}
+
+TEST_CASE(
+  "optionally converting string out of range to size_t should return nullopt",
+  "[core][util][string2int]")
+{
+  REQUIRE(
+    string2optional_size_t(
+      "0xfffffffffffffffffffffffffffffffffffffffffff", 16) == nullopt);
+  REQUIRE(string2optional_size_t("-5") == nullopt);
+}


### PR DESCRIPTION
These are intended as helpers for when you want to convert a string to
and integer, but don't want to assert the result (e.g. when dealing with
user input there's usually something better you can do than outright
crashing if the conversion fails), but also don't want to deal with
exceptions (which involve more code to write and read and it's easy to
handle the wrong set of exceptions, whether it is too many or too few).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
