### PR TITLE
ssa_exprt::get_object_name: add fast path

### DIFF
--- a/src/util/ssa_expr.h
+++ b/src/util/ssa_expr.h
@@ -37,8 +37,13 @@ public:
 
   irep_idt get_object_name() const
   {
+    const exprt &original_expr = get_original_expr();
+
+    if(original_expr.id() == ID_symbol)
+      return to_symbol_expr(original_expr).get_identifier();
+
     object_descriptor_exprt ode;
-    ode.object()=get_original_expr();
+    ode.object() = original_expr;
     return to_symbol_expr(ode.root_object()).get_identifier();
   }
 


### PR DESCRIPTION
In many cases (without field sensitivity actually: always) the object will just
be the original expression, no further processing is required. Thus add a fast
path that handles this case directly, which reduces the cost from 967 seconds
across all of SV-COMP's ReachSafety-ECA down to 143 seconds.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
