### PR TITLE
Better goto-instrument error reporting for missing files

### DIFF
--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <memory>
 
 #include <util/config.h>
+#include <util/exception_utils.h>
 #include <util/exit_codes.h>
 #include <util/json.h>
 #include <util/string2int.h>
@@ -823,6 +824,14 @@ int goto_instrument_parse_optionst::doit()
         return CPROVER_EXIT_CONVERSION_FAILED;
       else
         return CPROVER_EXIT_SUCCESS;
+    }
+    else if(cmdline.args.size() < 2)
+    {
+      throw invalid_command_line_argument_exceptiont(
+        "Invalid number of positional arguments passed",
+        "[in] [out]",
+        "goto-instrument needs one input and one output file, aside from other "
+        "flags");
     }
 
     help();


### PR DESCRIPTION
In the past, goto-instrument was failing with the default `--help` error message if it didn't get the correct number of positional arguments, making it unnecessarily hard to understand what was failing and why (since the help message is long and it also didn't have any particular signalling for what went wrong). This makes it so that it reports it as an invalid user input exception. Fixes #2861.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
