### PR TITLE
Update version of clang format in CODING_STANDARDs

### DIFF
--- a/CODING_STANDARD.md
+++ b/CODING_STANDARD.md
@@ -315,13 +315,13 @@ To avoid waiting until you've made a PR to find formatting issues, you can
 install clang-format locally and run it against your code as you are working.
 
 Different versions of clang-format have slightly different behaviors. CBMC uses
-clang-format-3.8 as it is available the repositories for Ubuntu 16.04 and
+clang-format-7 as it is available the repositories for Ubuntu 18.04 and
 Homebrew.
 To install on a Unix-like system, try installing using the system package
 manager:
 ```
-apt-get install clang-format-3.8  # Run this on Ubuntu, Debian etc.
-brew install clang-format@3.8     # Run this on a Mac with Homebrew installed
+apt-get install clang-format-7  # Run this on Ubuntu, Debian etc.
+brew install clang-format@7     # Run this on a Mac with Homebrew installed
 ```
 
 If your platform doesn't have a package for clang-format, you can download a
@@ -333,17 +333,22 @@ the [LLVM Snapshot Builds page](http://llvm.org/builds/).
 
 ### FORMATTING A RANGE OF COMMITS
 
-Clang-format is distributed with a driver script called git-clang-format-3.8.
+Clang-format is distributed with a driver script called git-clang-format-7.
 This script can be used to format git diffs (rather than entire files).
 
 After committing some code, it is recommended to run:
 ```
-git-clang-format-3.8 upstream/develop
+git-clang-format-7 upstream/develop
 ```
 *Important:* If your branch is based on a branch other than `upstream/develop`,
 use the name or checksum of that branch instead. It is strongly recommended to
 rebase your work onto the tip of the branch it's based on before running
 `git-clang-format` in this way.
+
+Note: By default, git-clang-format uses the git config variable
+`clangformat.binary`. If you have multiple versions of clang-format installed,
+you might need to update this, or explicitly specify the binary to use via
+`--binary clang-format-7`.
 
 ### RETROACTIVELY FORMATTING INDIVIDUAL COMMITS
 
@@ -355,7 +360,7 @@ The following command will stop at each commit in the range and run
 clang-format on the diff at that point.  This rewrites git history, so it's
 *unsafe*, and you should back up your branch before running this command:
 ```
-git filter-branch --tree-filter 'git-clang-format-3.8 upstream/develop' \
+git filter-branch --tree-filter 'git-clang-format-7 upstream/develop' \
   -- upstream/develop..HEAD
 ```
 *Important*: `upstream/develop` should be changed in *both* places in the


### PR DESCRIPTION
Was saying 3.8, but CBMC moved to version 7 in #3245

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [n/a] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [n/a] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

Spotted whilst looking for something else. 