### PR TITLE
Store identifiers of parameters in goto_functiont::parameter_identifiers [blocks: #4167]

### DIFF
--- a/src/goto-instrument/generate_function_bodies.cpp
+++ b/src/goto-instrument/generate_function_bodies.cpp
@@ -35,9 +35,11 @@ void generate_function_bodiest::generate_parameter_names(
   symbol_tablet &symbol_table,
   const irep_idt &function_name) const
 {
-  const namespacet ns(symbol_table);
+  auto &function_symbol = symbol_table.get_writeable_ref(function_name);
+  auto &parameters = to_code_type(function_symbol.type).parameters();
+
   int param_counter = 0;
-  for(auto &parameter : function.type.parameters())
+  for(auto &parameter : parameters)
   {
     if(parameter.get_identifier().empty())
     {
@@ -53,15 +55,14 @@ void generate_function_bodiest::generate_parameter_names(
       new_param_sym.name = new_param_identifier;
       new_param_sym.type = parameter.type();
       new_param_sym.base_name = param_base_name;
-      auto const &function_symbol = symbol_table.lookup_ref(function_name);
       new_param_sym.mode = function_symbol.mode;
       new_param_sym.module = function_symbol.module;
       new_param_sym.location = function_symbol.location;
       symbol_table.add(new_param_sym);
     }
   }
-  auto &function_symbol = symbol_table.get_writeable_ref(function_name);
-  function_symbol.type = function.type;
+  function.type = to_code_type(function_symbol.type);
+  function.set_parameter_identifiers(to_code_type(function_symbol.type));
 }
 
 class assume_false_generate_function_bodiest : public generate_function_bodiest

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -151,7 +151,10 @@ void goto_convert_functionst::convert_function(
   // make tmp variables local to function
   tmp_symbol_prefix=id2string(symbol.name)+"::$tmp";
 
-  f.type=to_code_type(symbol.type);
+  // store the parameter identifiers in the goto functions
+  const code_typet &code_type = to_code_type(symbol.type);
+  f.type = code_type;
+  f.set_parameter_identifiers(code_type);
 
   if(symbol.value.is_nil() ||
      symbol.is_compiled()) /* goto_inline may have removed the body */

--- a/src/goto-programs/goto_function.h
+++ b/src/goto-programs/goto_function.h
@@ -16,6 +16,7 @@ Date: May 2018
 
 #include <iosfwd>
 
+#include <util/deprecate.h>
 #include <util/find_symbols.h>
 #include <util/std_types.h>
 
@@ -29,16 +30,15 @@ public:
   goto_programt body;
 
   /// The type of the function, indicating the return type and parameter types
+  DEPRECATED("Get the type from the symbol table instead")
   code_typet type;
 
   typedef std::vector<irep_idt> parameter_identifierst;
 
   /// The identifiers of the parameters of this function
   ///
-  /// Note: This variable is currently unused and the vector is thus always
-  /// empty. In the future the code base may be refactored to fill in the
-  /// parameter identifiers here when creating a `goto_functiont`. For now the
-  /// parameter identifiers should be retrieved from the type (`code_typet`).
+  /// Note: This is now the preferred way of getting the identifiers of the
+  /// parameters. The identifiers in the type will go away.
   parameter_identifierst parameter_identifiers;
 
   bool body_available() const
@@ -46,16 +46,27 @@ public:
     return !body.instructions.empty();
   }
 
+  void set_parameter_identifiers(const code_typet &code_type)
+  {
+    parameter_identifiers.clear();
+    parameter_identifiers.reserve(code_type.parameters().size());
+    for(const auto &parameter : code_type.parameters())
+      parameter_identifiers.push_back(parameter.get_identifier());
+  }
+
+  DEPRECATED("Get the type from the symbol table instead")
   bool is_inlined() const
   {
     return type.get_bool(ID_C_inlined);
   }
 
+  DEPRECATED("Get the type from the symbol table instead")
   bool is_hidden() const
   {
     return type.get_bool(ID_C_hide);
   }
 
+  DEPRECATED("Get the type from the symbol table instead")
   void make_hidden()
   {
     type.set(ID_C_hide, true);

--- a/src/goto-programs/goto_functions.h
+++ b/src/goto-programs/goto_functions.h
@@ -117,6 +117,9 @@ public:
     {
       const goto_functiont &goto_function = entry.second;
       const auto &function_name = entry.first;
+      const symbolt &function_symbol = ns.lookup(function_name);
+      const code_typet::parameterst &parameters =
+        to_code_type(function_symbol.type).parameters();
 
       DATA_CHECK(
         vm,
@@ -124,6 +127,26 @@ public:
         id2string(function_name) + " type inconsistency\ngoto program type: " +
           goto_function.type.id_string() +
           "\nsymbol table type: " + ns.lookup(function_name).type.id_string());
+
+      DATA_CHECK(
+        vm,
+        goto_function.parameter_identifiers.size() == parameters.size(),
+        id2string(function_name) + " parameter count inconsistency\n" +
+          "goto program: " +
+          std::to_string(goto_function.parameter_identifiers.size()) +
+          "\nsymbol table: " + std::to_string(parameters.size()));
+
+      auto it = goto_function.parameter_identifiers.begin();
+      for(const auto &parameter : parameters)
+      {
+        DATA_CHECK(
+          vm,
+          it->empty() || ns.lookup(*it).type == parameter.type(),
+          id2string(function_name) + " parameter type inconsistency\n" +
+            "goto program: " + ns.lookup(*it).type.id_string() +
+            "\nsymbol table: " + parameter.type().id_string());
+        ++it;
+      }
 
       goto_function.validate(ns, vm);
     }

--- a/src/goto-programs/link_goto_model.cpp
+++ b/src/goto-programs/link_goto_model.cpp
@@ -27,6 +27,13 @@ static void rename_symbols_in_function(
   irep_idt &new_function_name,
   const rename_symbolt &rename_symbol)
 {
+  for(auto &identifier : function.parameter_identifiers)
+  {
+    auto entry = rename_symbol.expr_map.find(identifier);
+    if(entry != rename_symbol.expr_map.end())
+      identifier = entry->second;
+  }
+
   goto_programt &program=function.body;
   rename_symbol(function.type);
 

--- a/src/goto-programs/read_bin_goto_object.cpp
+++ b/src/goto-programs/read_bin_goto_object.cpp
@@ -72,10 +72,12 @@ static bool read_bin_goto_object(
 
     if(!sym.is_type && sym.type.id()==ID_code)
     {
-      // makes sure there is an empty function
-      // for every function symbol and fixes
-      // the function types.
-      functions.function_map[sym.name].type=to_code_type(sym.type);
+      // makes sure there is an empty function for every function symbol
+      auto entry = functions.function_map.emplace(sym.name, goto_functiont());
+
+      const code_typet &code_type = to_code_type(sym.type);
+      entry.first->second.type = code_type;
+      entry.first->second.set_parameter_identifiers(code_type);
     }
 
     symbol_table.add(sym);

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -166,31 +166,30 @@ void string_abstractiont::add_str_arguments(
 {
   symbolt &fct_symbol=*symbol_table.get_writeable(name);
 
-  code_typet::parameterst &parameters=
-    to_code_type(fct.type).parameters();
   code_typet::parameterst str_args;
 
-  for(code_typet::parameterst::iterator
-      it=parameters.begin();
-      it!=parameters.end();
-      ++it)
+  for(const auto &identifier : fct.parameter_identifiers)
   {
-    const typet &abstract_type=build_abstraction_type(it->type());
-    if(abstract_type.is_nil())
-      continue;
-
-    const irep_idt &identifier=it->get_identifier();
     if(identifier=="")
       continue; // ignore
 
-    add_argument(str_args, fct_symbol, abstract_type,
-        id2string(it->get_base_name())+arg_suffix,
-        id2string(identifier)+arg_suffix);
+    const symbolt &param_symbol = ns.lookup(identifier);
+    const typet &abstract_type = build_abstraction_type(param_symbol.type);
+    if(abstract_type.is_nil())
+      continue;
+
+    add_argument(
+      str_args,
+      fct_symbol,
+      abstract_type,
+      id2string(param_symbol.base_name) + arg_suffix,
+      id2string(identifier) + arg_suffix);
 
     current_args.insert(identifier);
   }
 
-  parameters.insert(parameters.end(), str_args.begin(), str_args.end());
+  for(const auto &new_param : str_args)
+    fct.parameter_identifiers.push_back(new_param.get_identifier());
   code_typet::parameterst &symb_parameters=
     to_code_type(fct_symbol.type).parameters();
   symb_parameters.insert(


### PR DESCRIPTION
This is to enable a transition towards #4167.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
