### PR TITLE
Add tests for overflows

### DIFF
--- a/regression/cbmc/Overflow_Addition2/main.c
+++ b/regression/cbmc/Overflow_Addition2/main.c
@@ -1,0 +1,6 @@
+void main()
+{
+  signed char i, j;
+  i = j;
+  i++;
+}

--- a/regression/cbmc/Overflow_Addition2/test.desc
+++ b/regression/cbmc/Overflow_Addition2/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--signed-overflow-check
+^EXIT=10$
+^SIGNAL=0$
+^\[.*\] .* arithmetic overflow on signed \+ in .*: FAILURE$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/cbmc/Overflow_Addition3/main.c
+++ b/regression/cbmc/Overflow_Addition3/main.c
@@ -1,0 +1,6 @@
+void main()
+{
+  signed char i, j;
+  i = j;
+  i += 1;
+}

--- a/regression/cbmc/Overflow_Addition3/test.desc
+++ b/regression/cbmc/Overflow_Addition3/test.desc
@@ -1,0 +1,15 @@
+KNOWNBUG
+main.c
+--signed-overflow-check --conversion-check
+^EXIT=10$
+^SIGNAL=0$
+^\[.*\] .* arithmetic overflow on signed \+ in .*: SUCCESS
+^\[.*\] .* arithmetic overflow on signed type conversion in .*: FAILURE$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+--
+The addition is done in signed int; hence, the overflow is only detected
+on conversion.
+
+See #4208.

--- a/regression/cbmc/Overflow_Addition4/main.c
+++ b/regression/cbmc/Overflow_Addition4/main.c
@@ -1,0 +1,6 @@
+void main()
+{
+  signed char i, j;
+  i = j;
+  i = i + 1;
+}

--- a/regression/cbmc/Overflow_Addition4/test.desc
+++ b/regression/cbmc/Overflow_Addition4/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--signed-overflow-check --conversion-check
+^EXIT=10$
+^SIGNAL=0$
+^\[.*\] .* arithmetic overflow on signed \+ in .*: SUCCESS
+^\[.*\] .* arithmetic overflow on signed type conversion in .*: FAILURE$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+--
+The addition is done in signed int; hence, the overflow is only detected
+on conversion.


### PR DESCRIPTION
There is an interaction between type promotion and overflow detection. In the case of compound assignments type promotion is broken, see #4208.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
