### PR TITLE
simplify_exprt::bits2expr now returns optionalt<exprt>

### DIFF
--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -153,8 +153,8 @@ public:
   }
 
   // bit-level conversions
-  exprt bits2expr(
-    const std::string &bits, const typet &type, bool little_endian);
+  optionalt<exprt>
+  bits2expr(const std::string &bits, const typet &type, bool little_endian);
 
   optionalt<std::string> expr2bits(const exprt &, bool little_endian);
 

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -1127,11 +1127,11 @@ bool simplify_exprt::simplify_extractbits(extractbits_exprt &expr)
       numeric_cast_v<std::size_t>(*end),
       numeric_cast_v<std::size_t>(*start - *end + 1));
 
-    exprt result = bits2expr(extracted_value, expr.type(), true);
-    if(result.is_nil())
+    auto result = bits2expr(extracted_value, expr.type(), true);
+    if(!result.has_value())
       return true;
 
-    expr.swap(result);
+    expr.swap(*result);
 
     return false;
   }

--- a/src/util/simplify_expr_struct.cpp
+++ b/src/util/simplify_expr_struct.cpp
@@ -228,11 +228,11 @@ bool simplify_exprt::simplify_member(exprt &expr)
         std::string bits_cut =
           std::string(*bits, 0, numeric_cast_v<std::size_t>(target_bits));
 
-        exprt tmp=bits2expr(bits_cut, expr.type(), true);
+        auto tmp = bits2expr(bits_cut, expr.type(), true);
 
-        if(tmp.is_not_nil())
+        if(tmp.has_value())
         {
-          expr=tmp;
+          expr = *tmp;
           return false;
         }
       }

--- a/unit/solvers/lowering/byte_operators.cpp
+++ b/unit/solvers/lowering/byte_operators.cpp
@@ -183,11 +183,11 @@ SCENARIO("byte_extract_lowering", "[core][solvers][lowering][byte_extract]")
           REQUIRE(type_bits);
           const auto type_bits_int = numeric_cast_v<std::size_t>(*type_bits);
           REQUIRE(type_bits_int <= oss.str().size());
-          const exprt s = simp.bits2expr(
+          const auto s = simp.bits2expr(
             oss.str().substr(0, type_bits_int),
             t1,
             endianness == ID_byte_extract_little_endian);
-          REQUIRE(s.is_not_nil());
+          REQUIRE(s.has_value());
 
           for(const auto &t2 : types)
           {
@@ -209,14 +209,14 @@ SCENARIO("byte_extract_lowering", "[core][solvers][lowering][byte_extract]")
             const auto type_bits_2_int =
               numeric_cast_v<std::size_t>(*type_bits_2);
             REQUIRE(type_bits_2_int <= oss.str().size());
-            const exprt r = simp.bits2expr(
+            const auto r = simp.bits2expr(
               oss.str().substr(0, type_bits_2_int),
               t2,
               endianness == ID_byte_extract_little_endian);
-            REQUIRE(r.is_not_nil());
+            REQUIRE(r.has_value());
 
             const byte_extract_exprt be(
-              endianness, s, from_integer(2, index_type()), t2);
+              endianness, *s, from_integer(2, index_type()), t2);
 
             const exprt lower_be = lower_byte_extract(be, ns);
             const exprt lower_be_s = simplify_expr(lower_be, ns);
@@ -343,9 +343,9 @@ SCENARIO("byte_update_lowering", "[core][solvers][lowering][byte_update]")
           const auto type_bits_int = numeric_cast_v<std::size_t>(*type_bits);
           REQUIRE(type_bits_int <= oss.str().size());
           const std::string s_string = oss.str().substr(0, type_bits_int);
-          const exprt s = simp.bits2expr(
+          const auto s = simp.bits2expr(
             s_string, t1, endianness == ID_byte_update_little_endian);
-          REQUIRE(s.is_not_nil());
+          REQUIRE(s.has_value());
 
           for(const auto &t2 : types)
           {
@@ -368,18 +368,18 @@ SCENARIO("byte_update_lowering", "[core][solvers][lowering][byte_update]")
               numeric_cast_v<std::size_t>(*type_bits_2);
             REQUIRE(type_bits_2_int <= oss.str().size());
             const std::string u_string = oss.str().substr(0, type_bits_2_int);
-            const exprt u = simp.bits2expr(
+            const auto u = simp.bits2expr(
               u_string, t2, endianness == ID_byte_update_little_endian);
-            REQUIRE(u.is_not_nil());
+            REQUIRE(u.has_value());
 
             std::string r_string = s_string;
             r_string.replace(16, u_string.size(), u_string);
-            const exprt r = simp.bits2expr(
+            const auto r = simp.bits2expr(
               r_string, t1, endianness == ID_byte_update_little_endian);
-            REQUIRE(r.is_not_nil());
+            REQUIRE(r.has_value());
 
             const byte_update_exprt bu(
-              endianness, s, from_integer(2, index_type()), u);
+              endianness, *s, from_integer(2, index_type()), *u);
 
             const exprt lower_bu = lower_byte_operators(bu, ns);
             const exprt lower_bu_s = simplify_expr(lower_bu, ns);

--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -94,17 +94,17 @@ TEST_CASE("expr2bits and bits2expr respect bit order")
   REQUIRE(le.has_value());
   REQUIRE(le->size() == 32);
 
-  const exprt should_be_deadbeef1 =
+  const auto should_be_deadbeef1 =
     simp.bits2expr(*le, unsignedbv_typet(32), true);
-  REQUIRE(deadbeef == should_be_deadbeef1);
+  REQUIRE(deadbeef == *should_be_deadbeef1);
 
   const auto be = simp.expr2bits(deadbeef, false);
   REQUIRE(be.has_value());
   REQUIRE(be->size() == 32);
 
-  const exprt should_be_deadbeef2 =
+  const auto should_be_deadbeef2 =
     simp.bits2expr(*be, unsignedbv_typet(32), false);
-  REQUIRE(deadbeef == should_be_deadbeef2);
+  REQUIRE(deadbeef == *should_be_deadbeef2);
 }
 
 TEST_CASE("Simplify extractbit")


### PR DESCRIPTION
This prevents accidental modifications of a `nil_exprt`, say by adding a `type()` to it.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
