### PR TITLE
Add counting number of solver calls

### DIFF
--- a/src/solvers/prop/prop.cpp
+++ b/src/solvers/prop/prop.cpp
@@ -28,5 +28,11 @@ bvt propt::new_variables(std::size_t width)
 
 propt::resultt propt::prop_solve()
 {
+  ++number_of_solver_calls;
   return do_prop_solve();
+}
+
+std::size_t propt::get_number_of_solver_calls() const
+{
+  return number_of_solver_calls;
 }

--- a/src/solvers/prop/prop.cpp
+++ b/src/solvers/prop/prop.cpp
@@ -25,3 +25,8 @@ bvt propt::new_variables(std::size_t width)
     result[i]=new_variable();
   return result;
 }
+
+propt::resultt propt::prop_solve()
+{
+  return do_prop_solve();
+}

--- a/src/solvers/prop/prop.h
+++ b/src/solvers/prop/prop.h
@@ -97,7 +97,7 @@ public:
   // solving
   virtual const std::string solver_text()=0;
   enum class resultt { P_SATISFIABLE, P_UNSATISFIABLE, P_ERROR };
-  virtual resultt prop_solve()=0;
+  resultt prop_solve();
 
   // satisfying assignment
   virtual tvt l_get(literalt a) const=0;
@@ -120,6 +120,8 @@ public:
   }
 
 protected:
+  virtual resultt do_prop_solve() = 0;
+
   // to avoid a temporary for lcnf(...)
   bvt lcnf_bv;
 

--- a/src/solvers/prop/prop.h
+++ b/src/solvers/prop/prop.h
@@ -119,6 +119,8 @@ public:
     log.warning() << "CPU limit ignored (not implemented)" << messaget::eom;
   }
 
+  std::size_t get_number_of_solver_calls() const;
+
 protected:
   virtual resultt do_prop_solve() = 0;
 
@@ -126,6 +128,7 @@ protected:
   bvt lcnf_bv;
 
   messaget log;
+  std::size_t number_of_solver_calls = 0;
 };
 
 #endif // CPROVER_SOLVERS_PROP_PROP_H

--- a/src/solvers/prop/prop_conv.cpp
+++ b/src/solvers/prop/prop_conv.cpp
@@ -512,3 +512,8 @@ void prop_conv_solvert::print_assignment(std::ostream &out) const
   for(const auto &symbol : symbols)
     out << symbol.first << " = " << prop.l_get(symbol.second) << '\n';
 }
+
+std::size_t prop_conv_solvert::get_number_of_solver_calls() const
+{
+  return prop.get_number_of_solver_calls();
+}

--- a/src/solvers/prop/prop_conv.h
+++ b/src/solvers/prop/prop_conv.h
@@ -55,6 +55,9 @@ public:
 
   // Resource limits:
   virtual void set_time_limit_seconds(uint32_t) {}
+
+  /// Returns the number of incremental solver calls
+  virtual std::size_t get_number_of_solver_calls() const = 0;
 };
 
 //
@@ -121,6 +124,8 @@ public:
   {
     prop.set_time_limit_seconds(lim);
   }
+
+  std::size_t get_number_of_solver_calls() const override;
 
 protected:
   virtual void post_process();

--- a/src/solvers/sat/cnf_clause_list.h
+++ b/src/solvers/sat/cnf_clause_list.h
@@ -39,11 +39,6 @@ public:
     return tvt::unknown();
   }
 
-  resultt prop_solve() override
-  {
-    return resultt::P_ERROR;
-  }
-
   size_t no_clauses() const override
   {
     return clauses.size();
@@ -82,6 +77,11 @@ public:
   }
 
 protected:
+  resultt do_prop_solve() override
+  {
+    return resultt::P_ERROR;
+  }
+
   clausest clauses;
 };
 

--- a/src/solvers/sat/cnf_clause_list.h
+++ b/src/solvers/sat/cnf_clause_list.h
@@ -29,19 +29,25 @@ public:
   }
   virtual ~cnf_clause_listt() { }
 
-  virtual void lcnf(const bvt &bv);
+  void lcnf(const bvt &bv) override;
 
-  virtual const std::string solver_text()
+  const std::string solver_text() override
   { return "CNF clause list"; }
 
-  virtual tvt l_get(literalt) const
+  tvt l_get(literalt) const override
   {
     return tvt::unknown();
   }
 
-  virtual resultt prop_solve() { return resultt::P_ERROR; }
+  resultt prop_solve() override
+  {
+    return resultt::P_ERROR;
+  }
 
-  virtual size_t no_clauses() const { return clauses.size(); }
+  size_t no_clauses() const override
+  {
+    return clauses.size();
+  }
 
   typedef std::list<bvt> clausest;
 
@@ -97,7 +103,7 @@ public:
     return assignment;
   }
 
-  virtual tvt l_get(literalt literal) const
+  tvt l_get(literalt literal) const override
   {
     if(literal.is_true())
       return tvt(true);

--- a/src/solvers/sat/dimacs_cnf.h
+++ b/src/solvers/sat/dimacs_cnf.h
@@ -45,24 +45,24 @@ public:
   dimacs_cnf_dumpt(std::ostream &_out, message_handlert &message_handler);
   virtual ~dimacs_cnf_dumpt() { }
 
-  virtual const std::string solver_text()
+  const std::string solver_text() override
   {
     return "DIMACS CNF Dumper";
   }
 
-  virtual void lcnf(const bvt &bv);
+  void lcnf(const bvt &bv) override;
 
-  virtual resultt prop_solve()
+  resultt prop_solve() override
   {
     return resultt::P_ERROR;
   }
 
-  virtual tvt l_get(literalt) const
+  tvt l_get(literalt) const override
   {
     return tvt::unknown();
   }
 
-  virtual size_t no_clauses() const
+  size_t no_clauses() const override
   {
     return 0;
   }

--- a/src/solvers/sat/dimacs_cnf.h
+++ b/src/solvers/sat/dimacs_cnf.h
@@ -52,11 +52,6 @@ public:
 
   void lcnf(const bvt &bv) override;
 
-  resultt prop_solve() override
-  {
-    return resultt::P_ERROR;
-  }
-
   tvt l_get(literalt) const override
   {
     return tvt::unknown();
@@ -68,6 +63,11 @@ public:
   }
 
 protected:
+  resultt do_prop_solve() override
+  {
+    return resultt::P_ERROR;
+  }
+
   std::ostream &out;
 };
 

--- a/src/solvers/sat/pbs_dimacs_cnf.cpp
+++ b/src/solvers/sat/pbs_dimacs_cnf.cpp
@@ -205,7 +205,7 @@ bool pbs_dimacs_cnft::pbs_solve()
   return satisfied;
 }
 
-propt::resultt pbs_dimacs_cnft::prop_solve()
+propt::resultt pbs_dimacs_cnft::do_prop_solve()
 {
   std::ofstream file("temp.cnf");
 

--- a/src/solvers/sat/pbs_dimacs_cnf.h
+++ b/src/solvers/sat/pbs_dimacs_cnf.h
@@ -48,13 +48,13 @@ public:
 
   bool pbs_solve();
 
-  virtual resultt prop_solve();
+  resultt prop_solve() override;
 
-  virtual tvt l_get(literalt a) const;
+  tvt l_get(literalt a) const override;
 
   // dummy functions
 
-  virtual const std::string solver_text()
+  const std::string solver_text() override
   {
     return "PBS - Pseudo Boolean/CNF Solver and Optimizer";
   }

--- a/src/solvers/sat/pbs_dimacs_cnf.h
+++ b/src/solvers/sat/pbs_dimacs_cnf.h
@@ -48,8 +48,6 @@ public:
 
   bool pbs_solve();
 
-  resultt prop_solve() override;
-
   tvt l_get(literalt a) const override;
 
   // dummy functions
@@ -60,6 +58,8 @@ public:
   }
 
 protected:
+  resultt do_prop_solve() override;
+
   std::set<int> assigned;
 };
 

--- a/src/solvers/sat/satcheck_booleforce.cpp
+++ b/src/solvers/sat/satcheck_booleforce.cpp
@@ -79,7 +79,7 @@ void satcheck_booleforce_baset::lcnf(const bvt &bv)
   clause_counter++;
 }
 
-propt::resultt satcheck_booleforce_baset::prop_solve()
+propt::resultt satcheck_booleforce_baset::do_prop_solve()
 {
   PRECONDITION(status == SAT || status == INIT);
 

--- a/src/solvers/sat/satcheck_booleforce.h
+++ b/src/solvers/sat/satcheck_booleforce.h
@@ -20,11 +20,11 @@ class satcheck_booleforce_baset:public cnf_solvert
 public:
   virtual ~satcheck_booleforce_baset();
 
-  virtual const std::string solver_text();
-  virtual resultt prop_solve();
-  virtual tvt l_get(literalt a) const;
+  const std::string solver_text() override;
+  resultt prop_solve() override;
+  tvt l_get(literalt a) const override;
 
-  virtual void lcnf(const bvt &bv);
+  void lcnf(const bvt &bv) override;
 };
 
 class satcheck_booleforcet:public satcheck_booleforce_baset

--- a/src/solvers/sat/satcheck_booleforce.h
+++ b/src/solvers/sat/satcheck_booleforce.h
@@ -21,10 +21,12 @@ public:
   virtual ~satcheck_booleforce_baset();
 
   const std::string solver_text() override;
-  resultt prop_solve() override;
   tvt l_get(literalt a) const override;
 
   void lcnf(const bvt &bv) override;
+
+protected:
+  resultt do_prop_solve() override;
 };
 
 class satcheck_booleforcet:public satcheck_booleforce_baset

--- a/src/solvers/sat/satcheck_cadical.cpp
+++ b/src/solvers/sat/satcheck_cadical.cpp
@@ -65,7 +65,7 @@ void satcheck_cadicalt::lcnf(const bvt &bv)
   clause_counter++;
 }
 
-propt::resultt satcheck_cadicalt::prop_solve()
+propt::resultt satcheck_cadicalt::do_prop_solve()
 {
   INVARIANT(status != statust::ERROR, "there cannot be an error");
 

--- a/src/solvers/sat/satcheck_cadical.h
+++ b/src/solvers/sat/satcheck_cadical.h
@@ -24,7 +24,6 @@ public:
   virtual ~satcheck_cadicalt();
 
   const std::string solver_text() override;
-  resultt prop_solve() override;
   tvt l_get(literalt a) const override;
 
   void lcnf(const bvt &bv) override;
@@ -42,6 +41,8 @@ public:
   bool is_in_conflict(literalt a) const override;
 
 protected:
+  resultt do_prop_solve() override;
+
   // NOLINTNEXTLINE(readability/identifiers)
   CaDiCaL::Solver * solver;
 };

--- a/src/solvers/sat/satcheck_cadical.h
+++ b/src/solvers/sat/satcheck_cadical.h
@@ -23,17 +23,23 @@ public:
   satcheck_cadicalt();
   virtual ~satcheck_cadicalt();
 
-  virtual const std::string solver_text() override;
-  virtual resultt prop_solve() override;
-  virtual tvt l_get(literalt a) const override;
+  const std::string solver_text() override;
+  resultt prop_solve() override;
+  tvt l_get(literalt a) const override;
 
-  virtual void lcnf(const bvt &bv) override;
-  virtual void set_assignment(literalt a, bool value) override;
+  void lcnf(const bvt &bv) override;
+  void set_assignment(literalt a, bool value) override;
 
-  virtual void set_assumptions(const bvt &_assumptions) override;
-  virtual bool has_set_assumptions() const override { return false; }
-  virtual bool has_is_in_conflict() const override { return false; }
-  virtual bool is_in_conflict(literalt a) const override;
+  void set_assumptions(const bvt &_assumptions) override;
+  bool has_set_assumptions() const override
+  {
+    return false;
+  }
+  bool has_is_in_conflict() const override
+  {
+    return false;
+  }
+  bool is_in_conflict(literalt a) const override;
 
 protected:
   // NOLINTNEXTLINE(readability/identifiers)

--- a/src/solvers/sat/satcheck_glucose.cpp
+++ b/src/solvers/sat/satcheck_glucose.cpp
@@ -131,8 +131,8 @@ void satcheck_glucose_baset<T>::lcnf(const bvt &bv)
   }
 }
 
-template<typename T>
-propt::resultt satcheck_glucose_baset<T>::prop_solve()
+template <typename T>
+propt::resultt satcheck_glucose_baset<T>::do_prop_solve()
 {
   PRECONDITION(status != statust::ERROR);
 

--- a/src/solvers/sat/satcheck_glucose.h
+++ b/src/solvers/sat/satcheck_glucose.h
@@ -30,21 +30,27 @@ public:
   satcheck_glucose_baset(T *, message_handlert &message_handler);
   virtual ~satcheck_glucose_baset();
 
-  virtual resultt prop_solve();
-  virtual tvt l_get(literalt a) const;
+  resultt prop_solve() override;
+  tvt l_get(literalt a) const override;
 
-  virtual void lcnf(const bvt &bv);
-  virtual void set_assignment(literalt a, bool value);
+  void lcnf(const bvt &bv) override;
+  void set_assignment(literalt a, bool value) override;
 
   // extra MiniSat feature: solve with assumptions
-  virtual void set_assumptions(const bvt &_assumptions);
+  void set_assumptions(const bvt &_assumptions) override;
 
   // extra MiniSat feature: default branching decision
   void set_polarity(literalt a, bool value);
 
-  virtual bool is_in_conflict(literalt a) const;
-  virtual bool has_set_assumptions() const { return true; }
-  virtual bool has_is_in_conflict() const { return true; }
+  bool is_in_conflict(literalt a) const override;
+  bool has_set_assumptions() const override
+  {
+    return true;
+  }
+  bool has_is_in_conflict() const override
+  {
+    return true;
+  }
 
 protected:
   T *solver;
@@ -58,7 +64,7 @@ class satcheck_glucose_no_simplifiert:
 {
 public:
   explicit satcheck_glucose_no_simplifiert(message_handlert &message_handler);
-  virtual const std::string solver_text();
+  const std::string solver_text() override;
 };
 
 class satcheck_glucose_simplifiert:
@@ -66,8 +72,8 @@ class satcheck_glucose_simplifiert:
 {
 public:
   explicit satcheck_glucose_simplifiert(message_handlert &message_handler);
-  virtual const std::string solver_text();
-  virtual void set_frozen(literalt a);
+  const std::string solver_text() override;
+  void set_frozen(literalt a) override;
   bool is_eliminated(literalt a) const;
 };
 

--- a/src/solvers/sat/satcheck_glucose.h
+++ b/src/solvers/sat/satcheck_glucose.h
@@ -30,7 +30,6 @@ public:
   satcheck_glucose_baset(T *, message_handlert &message_handler);
   virtual ~satcheck_glucose_baset();
 
-  resultt prop_solve() override;
   tvt l_get(literalt a) const override;
 
   void lcnf(const bvt &bv) override;
@@ -53,6 +52,8 @@ public:
   }
 
 protected:
+  resultt do_prop_solve() override;
+
   T *solver;
 
   void add_variables();

--- a/src/solvers/sat/satcheck_ipasir.cpp
+++ b/src/solvers/sat/satcheck_ipasir.cpp
@@ -93,7 +93,7 @@ void satcheck_ipasirt::lcnf(const bvt &bv)
   clause_counter++;
 }
 
-propt::resultt satcheck_ipasirt::prop_solve()
+propt::resultt satcheck_ipasirt::do_prop_solve()
 {
   INVARIANT(status!=statust::ERROR, "there cannot be an error");
 

--- a/src/solvers/sat/satcheck_ipasir.h
+++ b/src/solvers/sat/satcheck_ipasir.h
@@ -24,8 +24,6 @@ public:
   /// This method returns the description produced by the linked SAT solver
   const std::string solver_text() override;
 
-  resultt prop_solve() override;
-
   /// This method returns the truth value for a literal of the current SAT model
   tvt l_get(literalt a) const override final;
 
@@ -47,6 +45,8 @@ public:
   }
 
 protected:
+  resultt do_prop_solve() override;
+
   void *solver;
 
   bvt assumptions;

--- a/src/solvers/sat/satcheck_ipasir.h
+++ b/src/solvers/sat/satcheck_ipasir.h
@@ -22,23 +22,29 @@ public:
   virtual ~satcheck_ipasirt() override;
 
   /// This method returns the description produced by the linked SAT solver
-  virtual const std::string solver_text() override;
+  const std::string solver_text() override;
 
-  virtual resultt prop_solve() override;
+  resultt prop_solve() override;
 
   /// This method returns the truth value for a literal of the current SAT model
-  virtual tvt l_get(literalt a) const override final;
+  tvt l_get(literalt a) const override final;
 
-  virtual void lcnf(const bvt &bv) override final;
+  void lcnf(const bvt &bv) override final;
 
   /* This method is not supported, and currently not called anywhere in CBMC */
-  virtual void set_assignment(literalt a, bool value) override;
+  void set_assignment(literalt a, bool value) override;
 
-  virtual void set_assumptions(const bvt &_assumptions) override;
+  void set_assumptions(const bvt &_assumptions) override;
 
-  virtual bool is_in_conflict(literalt a) const override;
-  virtual bool has_set_assumptions() const override final { return true; }
-  virtual bool has_is_in_conflict() const override final { return true; }
+  bool is_in_conflict(literalt a) const override;
+  bool has_set_assumptions() const override final
+  {
+    return true;
+  }
+  bool has_is_in_conflict() const override final
+  {
+    return true;
+  }
 
 protected:
   void *solver;

--- a/src/solvers/sat/satcheck_lingeling.cpp
+++ b/src/solvers/sat/satcheck_lingeling.cpp
@@ -63,7 +63,7 @@ void satcheck_lingelingt::lcnf(const bvt &bv)
   clause_counter++;
 }
 
-propt::resultt satcheck_lingelingt::prop_solve()
+propt::resultt satcheck_lingelingt::do_prop_solve()
 {
   PRECONDITION(status != ERROR);
 

--- a/src/solvers/sat/satcheck_lingeling.h
+++ b/src/solvers/sat/satcheck_lingeling.h
@@ -22,7 +22,6 @@ public:
   virtual ~satcheck_lingelingt();
 
   const std::string solver_text() override;
-  resultt prop_solve() override;
   tvt l_get(literalt a) const override;
 
   void lcnf(const bvt &bv) override;
@@ -41,6 +40,8 @@ public:
   void set_frozen(literalt a) override;
 
 protected:
+  resultt do_prop_solve() override;
+
   // NOLINTNEXTLINE(readability/identifiers)
   struct LGL * solver;
   bvt assumptions;

--- a/src/solvers/sat/satcheck_lingeling.h
+++ b/src/solvers/sat/satcheck_lingeling.h
@@ -21,18 +21,24 @@ public:
   satcheck_lingelingt();
   virtual ~satcheck_lingelingt();
 
-  virtual const std::string solver_text();
-  virtual resultt prop_solve();
-  virtual tvt l_get(literalt a) const;
+  const std::string solver_text() override;
+  resultt prop_solve() override;
+  tvt l_get(literalt a) const override;
 
-  virtual void lcnf(const bvt &bv);
-  virtual void set_assignment(literalt a, bool value);
+  void lcnf(const bvt &bv) override;
+  void set_assignment(literalt a, bool value) override;
 
-  virtual void set_assumptions(const bvt &_assumptions);
-  virtual bool has_set_assumptions() const { return true; }
-  virtual bool has_is_in_conflict() const { return true; }
-  virtual bool is_in_conflict(literalt a) const;
-  virtual void set_frozen(literalt a);
+  void set_assumptions(const bvt &_assumptions) override;
+  bool has_set_assumptions() const override
+  {
+    return true;
+  }
+  bool has_is_in_conflict() const override
+  {
+    return true;
+  }
+  bool is_in_conflict(literalt a) const override;
+  void set_frozen(literalt a) override;
 
 protected:
   // NOLINTNEXTLINE(readability/identifiers)

--- a/src/solvers/sat/satcheck_minisat.cpp
+++ b/src/solvers/sat/satcheck_minisat.cpp
@@ -150,7 +150,7 @@ void satcheck_minisat1_baset::lcnf(const bvt &bv)
   clause_counter++;
 }
 
-propt::resultt satcheck_minisat1_baset::prop_solve()
+propt::resultt satcheck_minisat1_baset::do_prop_solve()
 {
   PRECONDITION(status != ERROR);
 
@@ -262,11 +262,11 @@ const std::string satcheck_minisat1_prooft::solver_text()
   return "MiniSAT + Proof";
 }
 
-propt::resultt satcheck_minisat1_coret::prop_solve()
+propt::resultt satcheck_minisat1_coret::do_prop_solve()
 {
   propt::resultt r;
 
-  r=satcheck_minisat1_prooft::prop_solve();
+  r = satcheck_minisat1_prooft::do_prop_solve();
 
   if(status==UNSAT)
   {

--- a/src/solvers/sat/satcheck_minisat.h
+++ b/src/solvers/sat/satcheck_minisat.h
@@ -25,7 +25,6 @@ public:
   virtual ~satcheck_minisat1_baset();
 
   const std::string solver_text() override;
-  resultt prop_solve() override;
   tvt l_get(literalt a) const override;
 
   void lcnf(const bvt &bv) final;
@@ -48,6 +47,8 @@ public:
   bool is_in_conflict(literalt l) const override;
 
 protected:
+  resultt do_prop_solve() override;
+
   // NOLINTNEXTLINE(readability/identifiers)
   class Solver *solver;
   void add_variables();
@@ -84,7 +85,6 @@ public:
   ~satcheck_minisat1_coret();
 
   const std::string solver_text() override;
-  resultt prop_solve() override;
 
   bool has_in_core() const
   {
@@ -99,5 +99,7 @@ public:
 
 protected:
   std::vector<bool> in_core;
+
+  resultt do_prop_solve() override;
 };
 #endif // CPROVER_SOLVERS_SAT_SATCHECK_MINISAT_H

--- a/src/solvers/sat/satcheck_minisat.h
+++ b/src/solvers/sat/satcheck_minisat.h
@@ -24,22 +24,28 @@ public:
 
   virtual ~satcheck_minisat1_baset();
 
-  virtual const std::string solver_text() override;
-  virtual resultt prop_solve() override;
-  virtual tvt l_get(literalt a) const override;
+  const std::string solver_text() override;
+  resultt prop_solve() override;
+  tvt l_get(literalt a) const override;
 
-  virtual void lcnf(const bvt &bv) final;
+  void lcnf(const bvt &bv) final;
 
-  virtual void set_assignment(literalt a, bool value) override;
+  void set_assignment(literalt a, bool value) override;
 
   // extra MiniSat feature: solve with assumptions
-  virtual void set_assumptions(const bvt &_assumptions) override;
+  void set_assumptions(const bvt &_assumptions) override;
 
   // features
-  virtual bool has_set_assumptions() const override { return true; }
-  virtual bool has_is_in_conflict() const override { return true; }
+  bool has_set_assumptions() const override
+  {
+    return true;
+  }
+  bool has_is_in_conflict() const override
+  {
+    return true;
+  }
 
-  virtual bool is_in_conflict(literalt l) const override;
+  bool is_in_conflict(literalt l) const override;
 
 protected:
   // NOLINTNEXTLINE(readability/identifiers)
@@ -61,7 +67,7 @@ public:
   satcheck_minisat1_prooft();
   ~satcheck_minisat1_prooft();
 
-  virtual const std::string solver_text() override;
+  const std::string solver_text() override;
   simple_prooft &get_resolution_proof();
   // void set_partition_id(unsigned p_id);
 
@@ -77,12 +83,15 @@ public:
   satcheck_minisat1_coret();
   ~satcheck_minisat1_coret();
 
-  virtual const std::string solver_text() override;
-  virtual resultt prop_solve() override;
+  const std::string solver_text() override;
+  resultt prop_solve() override;
 
-  virtual bool has_in_core() const { return true; }
+  bool has_in_core() const
+  {
+    return true;
+  }
 
-  virtual bool is_in_core(literalt l) const
+  bool is_in_core(literalt l) const
   {
     PRECONDITION(l.var_no() < in_core.size());
     return in_core[l.var_no()];

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -162,8 +162,8 @@ static void interrupt_solver(int signum)
 
 #endif
 
-template<typename T>
-propt::resultt satcheck_minisat2_baset<T>::prop_solve()
+template <typename T>
+propt::resultt satcheck_minisat2_baset<T>::do_prop_solve()
 {
   PRECONDITION(status != statust::ERROR);
 

--- a/src/solvers/sat/satcheck_minisat2.h
+++ b/src/solvers/sat/satcheck_minisat2.h
@@ -30,7 +30,6 @@ public:
   satcheck_minisat2_baset(T *, message_handlert &message_handler);
   virtual ~satcheck_minisat2_baset();
 
-  resultt prop_solve() override;
   tvt l_get(literalt a) const override final;
 
   void lcnf(const bvt &bv) override final;
@@ -64,6 +63,8 @@ public:
   }
 
 protected:
+  resultt do_prop_solve() override;
+
   T *solver;
   uint32_t time_limit_seconds;
 

--- a/src/solvers/sat/satcheck_minisat2.h
+++ b/src/solvers/sat/satcheck_minisat2.h
@@ -30,14 +30,14 @@ public:
   satcheck_minisat2_baset(T *, message_handlert &message_handler);
   virtual ~satcheck_minisat2_baset();
 
-  virtual resultt prop_solve() override;
-  virtual tvt l_get(literalt a) const final;
+  resultt prop_solve() override;
+  tvt l_get(literalt a) const override final;
 
-  virtual void lcnf(const bvt &bv) final;
-  virtual void set_assignment(literalt a, bool value) override;
+  void lcnf(const bvt &bv) override final;
+  void set_assignment(literalt a, bool value) override;
 
   // extra MiniSat feature: solve with assumptions
-  virtual void set_assumptions(const bvt &_assumptions) override;
+  void set_assumptions(const bvt &_assumptions) override;
 
   // extra MiniSat feature: default branching decision
   void set_polarity(literalt a, bool value);
@@ -48,9 +48,15 @@ public:
   // extra MiniSat feature: permit previously interrupted SAT query to continue
   void clear_interrupt();
 
-  virtual bool is_in_conflict(literalt a) const override;
-  virtual bool has_set_assumptions() const final { return true; }
-  virtual bool has_is_in_conflict() const final { return true; }
+  bool is_in_conflict(literalt a) const override;
+  bool has_set_assumptions() const override final
+  {
+    return true;
+  }
+  bool has_is_in_conflict() const override final
+  {
+    return true;
+  }
 
   void set_time_limit_seconds(uint32_t lim) override
   {
@@ -70,7 +76,7 @@ class satcheck_minisat_no_simplifiert:
 {
 public:
   explicit satcheck_minisat_no_simplifiert(message_handlert &message_handler);
-  virtual const std::string solver_text();
+  const std::string solver_text() override;
 };
 
 class satcheck_minisat_simplifiert:
@@ -78,8 +84,8 @@ class satcheck_minisat_simplifiert:
 {
 public:
   explicit satcheck_minisat_simplifiert(message_handlert &message_handler);
-  virtual const std::string solver_text() final;
-  virtual void set_frozen(literalt a) final;
+  const std::string solver_text() override final;
+  void set_frozen(literalt a) override final;
   bool is_eliminated(literalt a) const;
 };
 

--- a/src/solvers/sat/satcheck_picosat.cpp
+++ b/src/solvers/sat/satcheck_picosat.cpp
@@ -65,7 +65,7 @@ void satcheck_picosatt::lcnf(const bvt &bv)
   clause_counter++;
 }
 
-propt::resultt satcheck_picosatt::prop_solve()
+propt::resultt satcheck_picosatt::do_prop_solve()
 {
   PRECONDITION(status != ERROR);
 

--- a/src/solvers/sat/satcheck_picosat.h
+++ b/src/solvers/sat/satcheck_picosat.h
@@ -22,7 +22,6 @@ public:
   ~satcheck_picosatt();
 
   const std::string solver_text() override;
-  resultt prop_solve() override;
   tvt l_get(literalt a) const override;
 
   void lcnf(const bvt &bv) override;
@@ -40,6 +39,8 @@ public:
   }
 
 protected:
+  resultt do_prop_solve() override;
+
   bvt assumptions;
 
 private:

--- a/src/solvers/sat/satcheck_picosat.h
+++ b/src/solvers/sat/satcheck_picosat.h
@@ -21,17 +21,23 @@ public:
   satcheck_picosatt();
   ~satcheck_picosatt();
 
-  virtual const std::string solver_text();
-  virtual resultt prop_solve();
-  virtual tvt l_get(literalt a) const;
+  const std::string solver_text() override;
+  resultt prop_solve() override;
+  tvt l_get(literalt a) const override;
 
-  virtual void lcnf(const bvt &bv);
-  virtual void set_assignment(literalt a, bool value);
+  void lcnf(const bvt &bv) override;
+  void set_assignment(literalt a, bool value) override;
 
-  virtual bool is_in_conflict(literalt a) const;
-  virtual void set_assumptions(const bvt &_assumptions);
-  virtual bool has_set_assumptions() const { return true; }
-  virtual bool has_is_in_conflict() const { return true; }
+  bool is_in_conflict(literalt a) const override;
+  void set_assumptions(const bvt &_assumptions) override;
+  bool has_set_assumptions() const override
+  {
+    return true;
+  }
+  bool has_is_in_conflict() const override
+  {
+    return true;
+  }
 
 protected:
   bvt assumptions;

--- a/src/solvers/sat/satcheck_zchaff.cpp
+++ b/src/solvers/sat/satcheck_zchaff.cpp
@@ -70,7 +70,7 @@ void satcheck_zchaff_baset::copy_cnf()
       reinterpret_cast<int*>(&((*it)[0])), it->size());
 }
 
-propt::resultt satcheck_zchaff_baset::prop_solve()
+propt::resultt satcheck_zchaff_baset::do_prop_solve()
 {
   // this is *not* incremental
   PRECONDITION(status == INIT);

--- a/src/solvers/sat/satcheck_zchaff.h
+++ b/src/solvers/sat/satcheck_zchaff.h
@@ -25,7 +25,6 @@ public:
   virtual ~satcheck_zchaff_baset();
 
   const std::string solver_text() override;
-  resultt prop_solve() override;
   tvt l_get(literalt a) const override;
   void set_assignment(literalt a, bool value) override;
   virtual void copy_cnf();
@@ -36,6 +35,8 @@ public:
   }
 
 protected:
+  resultt do_prop_solve() override;
+
   CSolver *solver;
 
   enum statust { INIT, SAT, UNSAT, ERROR };

--- a/src/solvers/sat/satcheck_zchaff.h
+++ b/src/solvers/sat/satcheck_zchaff.h
@@ -24,10 +24,10 @@ public:
   explicit satcheck_zchaff_baset(CSolver *_solver);
   virtual ~satcheck_zchaff_baset();
 
-  virtual const std::string solver_text();
-  virtual resultt prop_solve();
-  virtual tvt l_get(literalt a) const;
-  virtual void set_assignment(literalt a, bool value);
+  const std::string solver_text() override;
+  resultt prop_solve() override;
+  tvt l_get(literalt a) const override;
+  void set_assignment(literalt a, bool value) override;
   virtual void copy_cnf();
 
   CSolver *zchaff_solver()

--- a/src/solvers/sat/satcheck_zcore.cpp
+++ b/src/solvers/sat/satcheck_zcore.cpp
@@ -34,7 +34,7 @@ const std::string satcheck_zcoret::solver_text()
   return "ZCore";
 }
 
-propt::resultt satcheck_zcoret::prop_solve()
+propt::resultt satcheck_zcoret::do_prop_solve()
 {
   // We start counting at 1, thus there is one variable fewer.
   {

--- a/src/solvers/sat/satcheck_zcore.h
+++ b/src/solvers/sat/satcheck_zcore.h
@@ -20,9 +20,9 @@ public:
   satcheck_zcoret();
   virtual ~satcheck_zcoret();
 
-  virtual const std::string solver_text();
-  virtual resultt prop_solve();
-  virtual tvt l_get(literalt a) const;
+  const std::string solver_text() override;
+  resultt prop_solve() override;
+  tvt l_get(literalt a) const override;
 
   bool is_in_core(literalt l) const
   {

--- a/src/solvers/sat/satcheck_zcore.h
+++ b/src/solvers/sat/satcheck_zcore.h
@@ -21,7 +21,6 @@ public:
   virtual ~satcheck_zcoret();
 
   const std::string solver_text() override;
-  resultt prop_solve() override;
   tvt l_get(literalt a) const override;
 
   bool is_in_core(literalt l) const
@@ -30,6 +29,8 @@ public:
   }
 
 protected:
+  resultt do_prop_solve() override;
+
   std::set<unsigned> in_core;
 };
 

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -4859,3 +4859,8 @@ exprt smt2_convt::substitute_let(
 
   return expr;
 }
+
+std::size_t smt2_convt::get_number_of_solver_calls() const
+{
+  return number_of_solver_calls;
+}

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -133,6 +133,8 @@ public:
   void convert_type(const typet &);
   void convert_literal(const literalt);
 
+  std::size_t get_number_of_solver_calls() const override;
+
 protected:
   const namespacet &ns;
   std::ostream &out;
@@ -141,6 +143,8 @@ protected:
 
   bvt assumptions;
   boolbv_widtht boolbv_width;
+
+  std::size_t number_of_solver_calls = 0;
 
   void write_header();
   void write_footer(std::ostream &);

--- a/src/solvers/smt2/smt2_dec.cpp
+++ b/src/solvers/smt2/smt2_dec.cpp
@@ -36,6 +36,8 @@ std::string smt2_dect::decision_procedure_text() const
 
 decision_proceduret::resultt smt2_dect::dec_solve()
 {
+  ++number_of_solver_calls;
+
   temporary_filet temp_file_problem("smt2_dec_problem_", ""),
     temp_file_stdout("smt2_dec_stdout_", ""),
     temp_file_stderr("smt2_dec_stderr_", "");

--- a/src/solvers/smt2/smt2_dec.h
+++ b/src/solvers/smt2/smt2_dec.h
@@ -35,11 +35,14 @@ public:
   {
   }
 
-  virtual resultt dec_solve();
-  virtual std::string decision_procedure_text() const;
+  resultt dec_solve() override;
+  std::string decision_procedure_text() const override;
 
   // yes, we are incremental!
-  virtual bool has_set_assumptions() const { return true; }
+  bool has_set_assumptions() const override
+  {
+    return true;
+  }
 
 protected:
   resultt read_result(std::istream &in);

--- a/unit/solvers/bdd/miniBDD/miniBDD.cpp
+++ b/unit/solvers/bdd/miniBDD/miniBDD.cpp
@@ -149,7 +149,7 @@ public:
     return "BDDs";
   }
 
-  resultt prop_solve() override
+  resultt do_prop_solve() override
   {
     UNREACHABLE;
     return {};


### PR DESCRIPTION
The uncontroversial part of #4054.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
