### PR TITLE
Fix revert-slice bug

### DIFF
--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -266,7 +266,7 @@ void simple_slice(symex_target_equationt &equation)
 void revert_slice(symex_target_equationt &equation)
 {
   // set ignore to false
-  for(auto step : equation.SSA_steps)
+  for(auto &step : equation.SSA_steps)
   {
     step.ignore = false;
   }


### PR DESCRIPTION
A reference is needed.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
