### PR TITLE
Do not copy on initialization

### DIFF
--- a/src/goto-checker/single_path_symex_checker.cpp
+++ b/src/goto-checker/single_path_symex_checker.cpp
@@ -155,7 +155,7 @@ void single_path_symex_checkert::prepare(
     properties, result.updated_properties, equation);
 
   property_decider = util_make_unique<goto_symex_property_decidert>(
-    goto_symex_property_decidert(options, ui_message_handler, equation, ns));
+    options, ui_message_handler, equation, ns);
 
   log.status() << "Passing problem to "
                << property_decider->get_solver().decision_procedure_text()


### PR DESCRIPTION
util_make_unique creates the instance.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
