### PR TITLE
Fix JSON goals output

### DIFF
--- a/regression/cbmc-cover/json-goals1/main.c
+++ b/regression/cbmc-cover/json-goals1/main.c
@@ -1,0 +1,6 @@
+int main(int argc, char **argv)
+{
+  if(argc == 42)
+    return 0;
+  return 1;
+}

--- a/regression/cbmc-cover/json-goals1/test.desc
+++ b/regression/cbmc-cover/json-goals1/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--json-ui --cover location
+activate-multi-line-match
+^EXIT=0$
+^SIGNAL=0$
+\{\n\s*"goals": \[\n\s*\{\n\s*"description": ".*",\n\s*"goal": "main\.coverage\.[1-4]",\n\s*"sourceLocation": \{(\n.+){5}\},\n\s*"status": "satisfied"\n\s*\},\n\s*\{\n\s*"description": ".*",\n\s*"goal": "main\.coverage\.[1-4]",\n\s*"sourceLocation": \{(\n.+){5}\},\n\s*"status": "satisfied"\n\s*\},\n\s*\{\n\s*"description": ".*",\n\s*"goal": "main\.coverage\.[1-4]",\n\s*"sourceLocation": \{(\n.+){5}\},\n\s*"status": "satisfied"\n\s*\},\n\s*\{\n\s*"description": ".*",\n\s*"goal": "main\.coverage\.[1-4]",\n\s*"sourceLocation": \{(\n.+){5}\},\n\s*"status": "satisfied"\n\s*\}\n\s*\],\n\s*"goalsCovered": 4,\n\s*"totalGoals": 4\n\s*\}
+--
+^warning: ignoring

--- a/src/goto-checker/cover_goals_report_util.cpp
+++ b/src/goto-checker/cover_goals_report_util.cpp
@@ -90,22 +90,28 @@ static void output_goals_json(
     log.status() << messaget::eom; // force end of previous message
   json_stream_objectt &json_result =
     ui_message_handler.get_json_stream().push_back_stream_object();
+  json_stream_arrayt &goals_array = json_result.push_back_stream_array("goals");
   for(const auto &property_pair : properties)
   {
     const property_infot &property_info = property_pair.second;
 
-    json_result["status"] = json_stringt(
+    json_objectt json_goal;
+    json_goal["status"] = json_stringt(
       property_info.status == property_statust::FAIL ? "satisfied" : "failed");
-    json_result["goal"] = json_stringt(property_pair.first);
-    json_result["description"] = json_stringt(property_info.description);
+    json_goal["goal"] = json_stringt(property_pair.first);
+    json_goal["description"] = json_stringt(property_info.description);
 
     if(property_info.pc->source_location.is_not_nil())
-      json_result["sourceLocation"] = json(property_info.pc->source_location);
+      json_goal["sourceLocation"] = json(property_info.pc->source_location);
+
+    goals_array.push_back(std::move(json_goal));
   }
-  json_result["totalGoals"] = json_numbert(std::to_string(properties.size()));
   const std::size_t goals_covered =
     count_properties(properties, property_statust::FAIL);
-  json_result["goalsCovered"] = json_numbert(std::to_string(goals_covered));
+  json_result.push_back(
+    "goalsCovered", json_numbert(std::to_string(goals_covered)));
+  json_result.push_back(
+    "totalGoals", json_numbert(std::to_string(properties.size())));
 }
 
 void output_goals(


### PR DESCRIPTION
This was already broken in bmc_cover.

~Test coming...~ Added

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
