### PR TITLE
Add missing JSON trace output to the C test input generator

### DIFF
--- a/src/cbmc/c_test_input_generator.cpp
+++ b/src/cbmc/c_test_input_generator.cpp
@@ -76,6 +76,13 @@ json_objectt test_inputst::to_json(
     goal_refs.push_back(json_stringt(goal_id));
   }
   json_result["coveredGoals"] = std::move(goal_refs);
+
+  if(print_trace)
+  {
+    json_arrayt json_trace;
+    convert(ns, goto_trace, json_trace);
+    json_result["trace"] = std::move(json_trace);
+  }
   return json_result;
 }
 


### PR DESCRIPTION
Traces should be printed if requested.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
