### PR TITLE
Clarify trace storage property ID mapping

### DIFF
--- a/src/goto-checker/goto_trace_storage.h
+++ b/src/goto-checker/goto_trace_storage.h
@@ -24,6 +24,8 @@ public:
   const goto_tracet &insert(goto_tracet &&);
 
   /// Store trace that contains multiple violated assertions
+  /// \note Only property IDs that are not part of any already stored trace
+  ///   are mapped to the given trace.
   const goto_tracet &insert_all(goto_tracet &&);
 
   const std::vector<goto_tracet> &all() const;


### PR DESCRIPTION
Currently, the trace storage does not maintain an M:N mapping
between property IDs and traces.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
