### PR TITLE
Use correct function ID for return from function without body

### DIFF
--- a/regression/cbmc/function-return-no-body1/main.c
+++ b/regression/cbmc/function-return-no-body1/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+
+void no_body();
+
+void main()
+{
+  no_body();
+  assert(0);
+}

--- a/regression/cbmc/function-return-no-body1/test.desc
+++ b/regression/cbmc/function-return-no-body1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--xml-ui
+activate-multi-line-match
+EXIT=10
+SIGNAL=0
+VERIFICATION FAILED
+<function_call hidden="false" step_nr="18" thread="0">\n\s*<function display_name="no_body" identifier="no_body">
+<function_return hidden="false" step_nr="19" thread="0">\n\s*<function display_name="no_body" identifier="no_body">
+--
+^warning: ignoring

--- a/src/goto-programs/json_goto_trace.cpp
+++ b/src/goto-programs/json_goto_trace.cpp
@@ -263,9 +263,7 @@ void convert_return(
   json_call_return["internal"] = jsont::json_boolean(step.internal);
   json_call_return["thread"] = json_numbert(std::to_string(step.thread_nr));
 
-  const irep_idt &function_identifier =
-    (step.type == goto_trace_stept::typet::FUNCTION_CALL) ? step.called_function
-                                                          : step.function_id;
+  const irep_idt &function_identifier = step.called_function;
 
   const symbolt &symbol = ns.lookup(function_identifier);
   json_call_return["function"] =

--- a/src/goto-programs/xml_goto_trace.cpp
+++ b/src/goto-programs/xml_goto_trace.cpp
@@ -186,11 +186,11 @@ void convert(
         xml_call_return.set_attribute("thread", std::to_string(step.thread_nr));
         xml_call_return.set_attribute("step_nr", std::to_string(step.step_nr));
 
-        const symbolt &symbol = ns.lookup(step.function_id);
+        const symbolt &symbol = ns.lookup(step.called_function);
         xmlt &xml_function=xml_call_return.new_element("function");
         xml_function.set_attribute(
           "display_name", id2string(symbol.display_name()));
-        xml_function.set_attribute("identifier", id2string(step.function_id));
+        xml_function.set_attribute("identifier", id2string(symbol.name));
         xml_function.new_element()=xml(symbol.location);
 
         if(xml_location.name!="")

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -286,7 +286,8 @@ void goto_symext::symex_function_call_code(
     no_body(identifier);
 
     // record the return
-    target.function_return(state.guard.as_expr(), state.source, hidden);
+    target.function_return(
+      state.guard.as_expr(), identifier, state.source, hidden);
 
     if(call.lhs().is_not_nil())
     {
@@ -374,7 +375,8 @@ void goto_symext::symex_end_of_function(statet &state)
   const bool hidden = state.top().hidden_function;
 
   // first record the return
-  target.function_return(state.guard.as_expr(), state.source, hidden);
+  target.function_return(
+    state.guard.as_expr(), state.source.function_id, state.source, hidden);
 
   // then get rid of the frame
   pop_frame(state);

--- a/src/goto-symex/symex_target.h
+++ b/src/goto-symex/symex_target.h
@@ -152,11 +152,15 @@ public:
 
   /// Record return from a function.
   /// \param guard: Precondition for returning from a function
+  /// \param function_id: Name of the function from which we return
   /// \param source: Pointer to location in the input GOTO program of this
   /// \param hidden: Should this step be recorded as hidden?
   ///  function return
-  virtual void
-  function_return(const exprt &guard, const sourcet &source, bool hidden) = 0;
+  virtual void function_return(
+    const exprt &guard,
+    const irep_idt &function_id,
+    const sourcet &source,
+    bool hidden) = 0;
 
   /// Record a location.
   /// \param guard: Precondition for reaching this location

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -204,6 +204,7 @@ void symex_target_equationt::function_call(
 
 void symex_target_equationt::function_return(
   const exprt &guard,
+  const irep_idt &function_id,
   const sourcet &source,
   const bool hidden)
 {
@@ -211,6 +212,7 @@ void symex_target_equationt::function_return(
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard = guard;
+  SSA_step.called_function = function_id;
   SSA_step.hidden = hidden;
 
   merge_ireps(SSA_step);

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -85,8 +85,11 @@ public:
     bool hidden);
 
   /// \copydoc symex_targett::function_return()
-  virtual void
-  function_return(const exprt &guard, const sourcet &source, bool hidden);
+  virtual void function_return(
+    const exprt &guard,
+    const irep_idt &function_id,
+    const sourcet &source,
+    bool hidden);
 
   /// \copydoc symex_targett::location()
   virtual void location(


### PR DESCRIPTION
There is no source location for bodyless functions. Thus, using `source` is incorrect (it's the caller's source).

~Test coming...~ Added

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
