### PR TITLE
Fix C enum output

### DIFF
--- a/regression/cbmc/enum-trace1/main.c
+++ b/regression/cbmc/enum-trace1/main.c
@@ -1,0 +1,23 @@
+#include <assert.h>
+
+enum ENUM
+{
+  E1,
+  E2,
+  E3
+};
+
+typedef enum ENUMT
+{
+  T1,
+  T2,
+  T3
+} enum_t;
+
+void test(enum ENUM e, enum_t t)
+{
+  enum ENUM ee = e;
+  enum_t tt = t;
+
+  assert(ee != tt);
+}

--- a/regression/cbmc/enum-trace1/test_json.desc
+++ b/regression/cbmc/enum-trace1/test_json.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--json-ui --function test --trace
+activate-multi-line-match
+EXIT=10
+SIGNAL=0
+VERIFICATION FAILED
+\{\n\s*"hidden": false,\n\s*"inputID": "e",\n\s*"internal": true,\n\s*"mode": "C",\n\s*"sourceLocation": \{(\n.*)*\},\n\s*"stepType": "input",\n\s*"thread": 0,\n\s*"values": \[\n\s*\{\n\s*"binary": "000000000000000000000000000000(0|1){2}",\n\s*"data": ".*E(1|2|3)",\n\s*"name": "integer",\n\s*"type": "enum",\n\s*"width": 32\n\s*\}\n\s*\]\n\s*\},
+\{\n\s*"hidden": false,\n\s*"inputID": "t",\n\s*"internal": true,\n\s*"mode": "C",\n\s*"sourceLocation": \{(\n.*)*\},\n\s*"stepType": "input",\n\s*"thread": 0,\n\s*"values": \[\n\s*\{\n\s*"binary": "000000000000000000000000000000(0|1){2}",\n\s*"data": ".*T(1|2|3)",\n\s*"name": "integer",\n\s*"type": "enum",\n\s*"width": 32\n\s*\}\n\s*\]\n\s*\},
+--
+^warning: ignoring

--- a/regression/cbmc/enum-trace1/test_xml.desc
+++ b/regression/cbmc/enum-trace1/test_xml.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--xml-ui --function test --trace
+activate-multi-line-match
+EXIT=10
+SIGNAL=0
+VERIFICATION FAILED
+<input hidden="false" step_nr="\d+" thread="0">\n\s*<input_id>e</input_id>\n\s*<value>.*E(1|2|3)</value>\n\s*<value_expression>\n\s*<integer binary="000000000000000000000000000000(0|1){2}" c_type="enum" width="32">(0|1|2)</integer>\n\s*</value_expression>
+<input hidden="false" step_nr="\d+" thread="0">\n\s*<input_id>t</input_id>\n\s*<value>.*T(1|2|3)</value>\n\s*<value_expression>\n\s*<integer binary="000000000000000000000000000000(0|1){2}" c_type="enum" width="32">(0|1|2)</integer>\n\s*</value_expression>
+--
+^warning: ignoring

--- a/src/goto-programs/json_expr.cpp
+++ b/src/goto-programs/json_expr.cpp
@@ -206,7 +206,11 @@ json_objectt json(const typet &type, const namespacet &ns, const irep_idt &mode)
 
 static std::string binary(const constant_exprt &src)
 {
-  const auto width = to_bitvector_type(src.type()).get_width();
+  std::size_t width;
+  if(src.type().id() == ID_c_enum)
+    width = to_bitvector_type(to_c_enum_type(src.type()).subtype()).get_width();
+  else
+    width = to_bitvector_type(src.type()).get_width();
   const auto int_val = bvrep2integer(src.get_value(), width, false);
   return integer2binary(int_val, width);
 }

--- a/src/goto-programs/xml_expr.cpp
+++ b/src/goto-programs/xml_expr.cpp
@@ -179,16 +179,13 @@ xmlt xml(const exprt &expr, const namespacet &ns)
       const auto width =
         to_bitvector_type(to_c_enum_type(type).subtype()).get_width();
 
+      const auto integer_value = bvrep2integer(value, width, false);
       result.name = "integer";
-      result.set_attribute(
-        "binary",
-        integer2binary(numeric_cast_v<mp_integer>(constant_expr), width));
+      result.set_attribute("binary", integer2binary(integer_value, width));
       result.set_attribute("width", width);
       result.set_attribute("c_type", "enum");
 
-      mp_integer i;
-      if(!to_integer(constant_expr, i))
-        result.data = integer2string(i);
+      result.data = integer2string(integer_value);
     }
     else if(type.id() == ID_c_enum_tag)
     {


### PR DESCRIPTION
This fixes the basic bugs that cause crashes at the moment.
Going forward this to-string-conversion code needs a complete overhaul as we are currently fixing the same bugs in three different places.

Tests coming...

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
