### PR TITLE
byte_extract lowering for complex_typet [blocks: #2068]

### DIFF
--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2303,6 +2303,32 @@ bool simplify_exprt::simplify_byte_update(byte_update_exprt &expr)
   return true;
 }
 
+bool simplify_exprt::simplify_complex(exprt &expr)
+{
+  if(expr.id() == ID_complex_real)
+  {
+    complex_real_exprt &complex_real_expr = to_complex_real_expr(expr);
+
+    if(complex_real_expr.op().id() == ID_complex)
+    {
+      expr = to_complex_expr(complex_real_expr.op()).real();
+      return false;
+    }
+  }
+  else if(expr.id() == ID_complex_imag)
+  {
+    complex_imag_exprt &complex_imag_expr = to_complex_imag_expr(expr);
+
+    if(complex_imag_expr.op().id() == ID_complex)
+    {
+      expr = to_complex_expr(complex_imag_expr.op()).imag();
+      return false;
+    }
+  }
+
+  return true;
+}
+
 bool simplify_exprt::simplify_node_preorder(exprt &expr)
 {
   bool result=true;
@@ -2445,6 +2471,8 @@ bool simplify_exprt::simplify_node(exprt &expr)
     result = simplify_popcount(to_popcount_expr(expr)) && result;
   else if(expr.id() == ID_function_application)
     result = simplify_function_application(expr) && result;
+  else if(expr.id() == ID_complex_real || expr.id() == ID_complex_imag)
+    result = simplify_complex(expr) && result;
 
   #ifdef DEBUGX
   if(!result

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2474,17 +2474,18 @@ bool simplify_exprt::simplify_node(exprt &expr)
   else if(expr.id() == ID_complex_real || expr.id() == ID_complex_imag)
     result = simplify_complex(expr) && result;
 
-  #ifdef DEBUGX
-  if(!result
-     #ifdef DEBUG_ON_DEMAND
-     && debug_on
-     #endif
-     )
+#ifdef DEBUGX
+  if(
+    !result
+#ifdef DEBUG_ON_DEMAND
+    && debug_on
+#endif
+  )
   {
     std::cout << "===== " << old.id() << ": " << format(old) << '\n'
               << " ---> " << format(expr) << '\n';
   }
-  #endif
+#endif
 
   return result;
 }

--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -113,6 +113,7 @@ public:
   bool simplify_abs(exprt &expr);
   bool simplify_sign(exprt &expr);
   bool simplify_popcount(popcount_exprt &expr);
+  bool simplify_complex(exprt &expr);
 
   /// Attempt to simplify mathematical function applications if we have
   /// enough information to do so. Currently focused on constant comparisons.

--- a/unit/solvers/lowering/byte_operators.cpp
+++ b/unit/solvers/lowering/byte_operators.cpp
@@ -158,8 +158,8 @@ SCENARIO("byte_extract_lowering", "[core][solvers][lowering][byte_extract]")
       // pointer_typet(u64, 64),
       vector_typet(u8, size),
       vector_typet(u64, size),
-      // complex_typet(s16),
-      // complex_typet(u64)
+      complex_typet(s16),
+      complex_typet(u64)
     };
 
     simplify_exprt simp(ns);


### PR DESCRIPTION
It may have worked before via the fallback to flattening of the entire
expression to a bitvector, but let's be on the safe side and construct
appropriate expressions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
