### PR TITLE
requires_renaming must not recurse into array subtypes in structs

### DIFF
--- a/regression/cbmc/struct13/main.c
+++ b/regression/cbmc/struct13/main.c
@@ -1,0 +1,12 @@
+struct S
+{
+  struct S *s;
+  struct S *a[2];
+};
+
+int main()
+{
+  struct S s;
+  s.s = 0;
+  return 0;
+}

--- a/regression/cbmc/struct13/test.desc
+++ b/regression/cbmc/struct13/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/struct13/test.desc
+++ b/regression/cbmc/struct13/test.desc
@@ -1,0 +1,12 @@
+KNOWNBUG
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Just like pointers, array members may have subtypes of the same type as the
+containing struct. requires_renaming fails to catch this case, which results in
+unbounded recursion.

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -621,7 +621,12 @@ static bool requires_renaming(const typet &type, const namespacet &ns)
     for(auto &component : components)
     {
       // be careful, or it might get cyclic
-      if(
+      if(component.type().id() == ID_array)
+      {
+        if(!to_array_type(component.type()).size().is_constant())
+          return true;
+      }
+      else if(
         component.type().id() != ID_pointer &&
         requires_renaming(component.type(), ns))
       {

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -612,8 +612,7 @@ static bool requires_renaming(const typet &type, const namespacet &ns)
     return requires_renaming(array_type.subtype(), ns) ||
            !array_type.size().is_constant();
   }
-  else if(
-    type.id() == ID_struct || type.id() == ID_union || type.id() == ID_class)
+  else if(type.id() == ID_struct || type.id() == ID_union)
   {
     const struct_union_typet &s_u_type = to_struct_union_type(type);
     const struct_union_typet::componentst &components = s_u_type.components();


### PR DESCRIPTION
Just like pointers, array members may have subtypes of the same type as the
containing struct. The behaviour/check now matches what the actual renaming
function uses.

Also clean up the unnecessary ID_class, which does not actually exist.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
