### PR TITLE
remove two unused includes from util/mp_arith.h

### DIFF
--- a/jbmc/src/java_bytecode/expr2java.h
+++ b/jbmc/src/java_bytecode/expr2java.h
@@ -11,9 +11,11 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #define CPROVER_JAVA_BYTECODE_EXPR2JAVA_H
 
 #include <cmath>
+#include <limits>
 #include <numeric>
 #include <sstream>
 #include <string>
+
 #include <ansi-c/expr2c_class.h>
 
 class expr2javat:public expr2ct

--- a/src/util/arith_tools.h
+++ b/src/util/arith_tools.h
@@ -10,12 +10,13 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_ARITH_TOOLS_H
 #define CPROVER_UTIL_ARITH_TOOLS_H
 
+#include "deprecate.h"
 #include "invariant.h"
 #include "mp_arith.h"
 #include "optional.h"
 #include "std_expr.h"
 
-#include "deprecate.h"
+#include <limits>
 
 class typet;
 

--- a/src/util/mp_arith.h
+++ b/src/util/mp_arith.h
@@ -10,12 +10,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_MP_ARITH_H
 #define CPROVER_UTIL_MP_ARITH_H
 
-#include <string>
 #include <iosfwd>
-#include <limits>
+#include <string>
 
 #include "big-int/bigint.hh"
-#include "optional.h"
 #include "deprecate.h"
 
 // NOLINTNEXTLINE(readability/identifiers)


### PR DESCRIPTION
util/mp_arith.h is widely used, so this improves compile times.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
