### PR TITLE
adding instructiont::transform(f)

### DIFF
--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -555,6 +555,10 @@ public:
     /// The validation mode indicates whether well-formedness check failures are
     /// reported via DATA_INVARIANT violations or exceptions.
     void validate(const namespacet &ns, const validation_modet vm) const;
+
+    /// Apply given transformer to all expressions; no return value
+    /// means no change needed.
+    void transform(std::function<optionalt<exprt>(exprt)>);
   };
 
   // Never try to change this to vector-we mutate the list while iterating


### PR DESCRIPTION
This avoids duplicating the idiom of iterating over the expressions in an
instruction.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
