### PR TITLE
Move printf to C library and support return values

### DIFF
--- a/doc/cprover-manual/api.md
+++ b/doc/cprover-manual/api.md
@@ -62,6 +62,16 @@ using nondeterminism, as described [here](../modeling/nondeterminism/)). The
 string constant is followed by an arbitrary number of values of
 arbitrary types.
 
+#### \_\_CPROVER\_printf
+
+```C
+void __CPROVER_printf(const char *format, ...);
+```
+
+The function **\_\_CPROVER\_printf** implements the C `printf` function (without
+any return value). The observable effect is that its output is shown within a
+counterexample trace.
+
 #### \_\_CPROVER\_cover
 
 ```C

--- a/regression/cbmc-library/printf-01/main.c
+++ b/regression/cbmc-library/printf-01/main.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+#include <stdio.h>
+
+int main()
+{
+  int x;
+  x = printf("x");
+  assert(x < 0);
+  return 0;
+}

--- a/regression/cbmc-library/printf-01/test.desc
+++ b/regression/cbmc-library/printf-01/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--pointer-check --bounds-check
+^EXIT=10$
+^SIGNAL=0$
+^\*\* 1 of \d+ failed
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/cbmc/printf1/test.desc
+++ b/regression/cbmc/printf1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 main.c
 --trace
 ^EXIT=10$

--- a/src/ansi-c/cprover_builtin_headers.h
+++ b/src/ansi-c/cprover_builtin_headers.h
@@ -22,6 +22,7 @@ void __CPROVER_cleanup(const void *, const void *);
 __CPROVER_bool __CPROVER_get_must(const void *, const char *);
 __CPROVER_bool __CPROVER_get_may(const void *, const char *);
 
+void __CPROVER_printf(const char *format, ...);
 void __CPROVER_input(const char *id, ...);
 void __CPROVER_output(const char *id, ...);
 void __CPROVER_cover(__CPROVER_bool condition);

--- a/src/ansi-c/library/cprover.h
+++ b/src/ansi-c/library/cprover.h
@@ -38,6 +38,8 @@ void __CPROVER_initialize(void);
 void __CPROVER_cover(__CPROVER_bool condition);
 #endif
 
+// NOLINTNEXTLINE(build/deprecated)
+void __CPROVER_printf(const char *format, ...);
 void __CPROVER_input(const char *id, ...);
 void __CPROVER_output(const char *id, ...);
 

--- a/src/ansi-c/library/stdio.c
+++ b/src/ansi-c/library/stdio.c
@@ -22,7 +22,7 @@ inline int putchar(int c)
 {
   __CPROVER_HIDE:;
   __CPROVER_bool error=__VERIFIER_nondet___CPROVER_bool();
-  printf("%c", c);
+  __CPROVER_printf("%c", c);
   return (error?-1:c);
 }
 
@@ -41,7 +41,7 @@ inline int puts(const char *s)
   __CPROVER_HIDE:;
   __CPROVER_bool error=__VERIFIER_nondet___CPROVER_bool();
   int ret=__VERIFIER_nondet_int();
-  printf("%s\n", s);
+  __CPROVER_printf("%s\n", s);
   if(error) ret=-1; else __CPROVER_assume(ret>=0);
   return ret;
 }
@@ -768,7 +768,7 @@ void perror(const char *s)
     #endif
     // should go to stderr
     if(s[0]!=0)
-      printf("%s: ", s);
+      __CPROVER_printf("%s: ", s);
   }
 
   // TODO: print errno error
@@ -918,6 +918,31 @@ inline int vsscanf(const char *restrict s, const char *restrict format, va_list 
   (void)*s;
   (void)*format;
   (void)arg;
+  return result;
+}
+
+/* FUNCTION: printf */
+
+#ifndef __CPROVER_STDIO_H_INCLUDED
+#  include <stdio.h>
+#  define __CPROVER_STDIO_H_INCLUDED
+#endif
+
+#ifndef __CPROVER_STDARG_H_INCLUDED
+#  include <stdarg.h>
+#  define __CPROVER_STDARG_H_INCLUDED
+#endif
+
+int __VERIFIER_nondet_int();
+
+inline int printf(const char *format, ...)
+{
+__CPROVER_HIDE:;
+  int result = __VERIFIER_nondet_int();
+  va_list list;
+  va_start(list, format);
+  __CPROVER_printf(format, list);
+  va_end(list);
   return result;
 }
 

--- a/src/ansi-c/library/stdio.c
+++ b/src/ansi-c/library/stdio.c
@@ -1026,3 +1026,64 @@ inline int vasprintf(char **ptr, const char *fmt, va_list ap)
 
   return i;
 }
+
+/* FUNCTION: __acrt_iob_func */
+
+#ifdef _WIN32
+
+#  ifndef __CPROVER_STDIO_H_INCLUDED
+#    include <stdio.h>
+#    define __CPROVER_STDIO_H_INCLUDED
+#  endif
+
+inline FILE *__acrt_iob_func(unsigned fd)
+{
+  static FILE stdin_file;
+  static FILE stdout_file;
+  static FILE stderr_file;
+
+  switch(fd)
+  {
+  case 0:
+    return &stdin_file;
+  case 1:
+    return &stdout_file;
+  case 2:
+    return &stderr_file;
+  default:
+    return (FILE *)0;
+  }
+}
+
+#endif
+
+/* FUNCTION: __stdio_common_vfprintf */
+
+#ifdef _WIN32
+
+#  ifndef __CPROVER_STDIO_H_INCLUDED
+#    include <stdio.h>
+#    define __CPROVER_STDIO_H_INCLUDED
+#  endif
+
+#  ifndef __CPROVER_STDARG_H_INCLUDED
+#    include <stdarg.h>
+#    define __CPROVER_STDARG_H_INCLUDED
+#  endif
+
+inline int __stdio_common_vfprintf(
+  unsigned __int64 options,
+  FILE *stream,
+  char const *format,
+  _locale_t locale,
+  va_list args)
+{
+  (void)options;
+  (void)locale;
+
+  if(stream == __acrt_iob_func(1))
+    __CPROVER_printf(format, args);
+  return 0;
+}
+
+#endif

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -203,33 +203,10 @@ void goto_convertt::do_printf(
 {
   const irep_idt &f_id = function.get_identifier();
 
-  if(f_id==CPROVER_PREFIX "printf" ||
-     f_id=="printf")
-  {
-    const typet &return_type = to_code_type(function.type()).return_type();
-    side_effect_exprt printf_code(
-      ID_printf, return_type, function.source_location());
+  PRECONDITION(f_id == CPROVER_PREFIX "printf");
 
-    printf_code.operands()=arguments;
-    printf_code.add_source_location()=function.source_location();
-
-    if(lhs.is_not_nil())
-    {
-      code_assignt assignment(lhs, printf_code);
-      assignment.add_source_location()=function.source_location();
-      copy(assignment, ASSIGN, dest);
-    }
-    else
-    {
-      printf_code.id(ID_code);
-      printf_code.type() = code_typet(
-        code_typet::parameterst(to_code_type(function.type()).parameters()),
-        empty_typet());
-      copy(to_code(printf_code), OTHER, dest);
-    }
-  }
-  else
-    UNREACHABLE;
+  codet printf_code(ID_printf, arguments, function.source_location());
+  copy(printf_code, OTHER, dest);
 }
 
 void goto_convertt::do_scanf(
@@ -926,15 +903,6 @@ void goto_convertt::do_function_call_symbol(
   else if(identifier==CPROVER_PREFIX "array_replace")
   {
     do_array_op(ID_array_replace, lhs, function, arguments, dest);
-  }
-  else if(identifier=="printf")
-  /*
-          identifier=="fprintf" ||
-          identifier=="sprintf" ||
-          identifier=="snprintf")
-  */
-  {
-    do_printf(lhs, function, arguments, dest);
   }
   else if(identifier=="__assert_fail" ||
           identifier=="_assert" ||

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -47,11 +47,6 @@ void goto_symext::symex_assign(statet &state, const code_assignt &code)
       symex_cpp_new(state, lhs, side_effect_expr);
     else if(statement==ID_allocate)
       symex_allocate(state, lhs, side_effect_expr);
-    else if(statement==ID_printf)
-    {
-      PRECONDITION(lhs.is_nil());
-      symex_printf(state, side_effect_expr);
-    }
     else if(statement == ID_va_start)
       symex_va_start(state, lhs, side_effect_expr);
     else


### PR DESCRIPTION
Code using var = printf(...); (printf does return a value!) previously resulted
in a failing invariant as the symex_assign code assumed the lhs always was nil.
Since symex does not know how to generate a proper return value, make
__CPROVER_printf a void-typed built-in and model printf around it. Clean up the
corresponding goto-convert code.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
