### PR TITLE
Counterexamples: show strings, not address-of-character

### DIFF
--- a/regression/cbmc/trace-strings/main.c
+++ b/regression/cbmc/trace-strings/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  char *c = "abc";
+  ++c;
+  assert(0);
+}

--- a/regression/cbmc/trace-strings/test.desc
+++ b/regression/cbmc/trace-strings/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--trace
+^EXIT=10$
+^SIGNAL=0$
+c="abc"
+c=\{ 'b', 'c', 0 \}
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/src/solvers/flattening/pointer_logic.cpp
+++ b/src/solvers/flattening/pointer_logic.cpp
@@ -104,6 +104,20 @@ exprt pointer_logict::pointer_expr(
   // https://gcc.gnu.org/onlinedocs/gcc-4.8.0/gcc/Pointer-Arith.html
   if(subtype.id() == ID_empty)
     subtype = char_type();
+  if(object_expr.id() == ID_string_constant)
+  {
+    subtype = object_expr.type();
+
+    // a string constant must be array-typed with fixed size
+    const array_typet &array_type = to_array_type(object_expr.type());
+    mp_integer array_size =
+      numeric_cast_v<mp_integer>(to_constant_expr(array_type.size()));
+    if(array_size > pointer.offset)
+    {
+      to_array_type(subtype).size() =
+        from_integer(array_size - pointer.offset, array_type.size().type());
+    }
+  }
   exprt deep_object =
     get_subexpression_at_offset(object_expr, pointer.offset, subtype, ns);
   CHECK_RETURN(deep_object.is_not_nil());

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -26,6 +26,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "rational_tools.h"
 #include "simplify_utils.h"
 #include "std_expr.h"
+#include "string_constant.h"
 #include "string_expr.h"
 #include "symbol.h"
 #include "type_eq.h"
@@ -1794,6 +1795,10 @@ optionalt<std::string> simplify_exprt::expr2bits(
       return expr2bits(
         constant_exprt(value, to_c_enum_type(type).subtype()), little_endian);
     }
+  }
+  else if(expr.id() == ID_string_constant)
+  {
+    return expr2bits(to_string_constant(expr).to_array_expr(), little_endian);
   }
   else if(expr.id()==ID_union)
   {


### PR DESCRIPTION
Pointers to strings (or into strings) should not be printed as
address-of-character. This was an undesired side-effect of d4296f167 ("Use
get_subexpression_at_offset in pointer_logict").

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
