### PR TITLE
symex_allocate: only use alloc_size when set

### DIFF
--- a/regression/cbmc/Malloc25/main.c
+++ b/regression/cbmc/Malloc25/main.c
@@ -1,0 +1,7 @@
+#include <stdlib.h>
+
+int main(int argc, char *argv[])
+{
+  int *p = malloc((size_t)argc * (size_t)argc * sizeof(int));
+  return 0;
+}

--- a/regression/cbmc/Malloc25/test.desc
+++ b/regression/cbmc/Malloc25/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -102,7 +102,7 @@ void goto_symext::symex_allocate(
 
           object_type = array_typet(*tmp_type, s);
         }
-        else
+        else if(alloc_size.has_value())
         {
           if(*alloc_size == *elem_size)
             object_type = *tmp_type;


### PR DESCRIPTION
When alloc_size isn't set but the other conditions in the earlier branch are not
satisfied we must not use alloc_size. Fall back to building an array of
characters instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
