### PR TITLE
Remove deprecated irept::get_unsigned_int

### DIFF
--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -9,6 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_EXPR_H
 #define CPROVER_UTIL_EXPR_H
 
+#include "deprecate.h"
 #include "type.h"
 #include "validate_expressions.h"
 #include "validate_types.h"

--- a/src/util/irep.cpp
+++ b/src/util/irep.cpp
@@ -109,11 +109,6 @@ int irept::get_int(const irep_namet &name) const
   return unsafe_string2int(get_string(name));
 }
 
-unsigned int irept::get_unsigned_int(const irep_namet &name) const
-{
-  return unsafe_string2unsigned(get_string(name));
-}
-
 std::size_t irept::get_size_t(const irep_namet &name) const
 {
   return unsafe_string2size_t(get_string(name));

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -13,7 +13,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <string>
 #include <vector>
 
-#include "deprecate.h"
 #include "invariant.h"
 #include "irep_ids.h"
 
@@ -208,7 +207,6 @@ public:
   {
     if(data!=&empty_d)
     {
-      // NOLINTNEXTLINE(build/deprecated)
       PRECONDITION(data->ref_count != 0);
       data->ref_count++;
 #ifdef IREP_DEBUG
@@ -433,9 +431,6 @@ public:
   const irep_idt &get(const irep_namet &name) const;
   bool get_bool(const irep_namet &name) const;
   signed int get_int(const irep_namet &name) const;
-  /// \deprecated use get_size_t instead
-  DEPRECATED("Use get_size_t instead")
-  unsigned int get_unsigned_int(const irep_namet &name) const;
   std::size_t get_size_t(const irep_namet &name) const;
   long long get_long_long(const irep_namet &name) const;
 

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <sstream>
 #include <string>
 
+#include "deprecate.h"
 #include "invariant.h"
 #include "json.h"
 #include "source_location.h"

--- a/src/util/type.h
+++ b/src/util/type.h
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 class namespacet;
 
+#include "deprecate.h"
 #include "source_location.h"
 #include "validate_types.h"
 #include "validation_mode.h"


### PR DESCRIPTION
It has been deprecated since 06/2018 and has no users. This enables removing the
deprecate.h include. Also clean up an outdated NOLINT.

(Of course inspired by #4236.)

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
