### PR TITLE
Remove unused includes list, functional from expr.h

### DIFF
--- a/src/ansi-c/ansi_c_convert_type.h
+++ b/src/ansi-c/ansi_c_convert_type.h
@@ -12,6 +12,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_ANSI_C_ANSI_C_CONVERT_TYPE_H
 #define CPROVER_ANSI_C_ANSI_C_CONVERT_TYPE_H
 
+#include <list>
+
 #include <util/message.h>
 
 #include "c_qualifiers.h"

--- a/src/assembler/assembler_parser.cpp
+++ b/src/assembler/assembler_parser.cpp
@@ -8,8 +8,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "assembler_parser.h"
 
-#include <iostream>
-
 assembler_parsert assembler_parser;
 
 extern char *yyassemblertext;

--- a/src/assembler/assembler_parser.h
+++ b/src/assembler/assembler_parser.h
@@ -11,7 +11,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_ASSEMBLER_ASSEMBLER_PARSER_H
 
 #include <util/parser.h>
-#include <util/expr.h>
+
+#include <list>
 
 int yyassemblerlex();
 int yyassemblererror(const std::string &error);

--- a/src/cbmc/all_properties.cpp
+++ b/src/cbmc/all_properties.cpp
@@ -20,8 +20,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/xml.h>
 #include <util/json.h>
 
+#include <solvers/prop/prop_conv.h>
 #include <solvers/sat/satcheck.h>
-#include <solvers/prop/literal_expr.h>
 
 #include <goto-symex/build_goto_trace.h>
 #include <goto-programs/xml_goto_trace.h>

--- a/src/cbmc/all_properties_class.h
+++ b/src/cbmc/all_properties_class.h
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_CBMC_ALL_PROPERTIES_CLASS_H
 
 #include <solvers/prop/cover_goals.h>
+#include <solvers/prop/literal_expr.h>
 
 #include "bmc.h"
 

--- a/src/cbmc/bmc_cover.cpp
+++ b/src/cbmc/bmc_cover.cpp
@@ -21,7 +21,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/xml_irep.h>
 
 #include <solvers/prop/cover_goals.h>
-#include <solvers/prop/literal_expr.h>
+#include <solvers/prop/prop_conv.h>
 
 #include <goto-symex/build_goto_trace.h>
 

--- a/src/solvers/flattening/arrays.h
+++ b/src/solvers/flattening/arrays.h
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_SOLVERS_FLATTENING_ARRAYS_H
 #define CPROVER_SOLVERS_FLATTENING_ARRAYS_H
 
+#include <list>
 #include <set>
 
 #include <util/union_find.h>

--- a/src/solvers/prop/cover_goals.cpp
+++ b/src/solvers/prop/cover_goals.cpp
@@ -11,9 +11,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "cover_goals.h"
 
-#include <util/threeval.h>
-
 #include "literal_expr.h"
+#include "prop_conv.h"
 
 cover_goalst::~cover_goalst()
 {

--- a/src/solvers/prop/cover_goals.h
+++ b/src/solvers/prop/cover_goals.h
@@ -12,9 +12,14 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_SOLVERS_PROP_COVER_GOALS_H
 #define CPROVER_SOLVERS_PROP_COVER_GOALS_H
 
+#include <list>
+
+#include <util/decision_procedure.h>
 #include <util/message.h>
 
-#include "prop_conv.h"
+#include "literal.h"
+
+class prop_convt;
 
 /// Try to cover some given set of goals incrementally. This can be seen as a
 /// heuristic variant of SAT-based set-cover. No minimality guarantee.

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -15,9 +15,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "validate_types.h"
 #include "validation_mode.h"
 
-#include <functional>
-#include <list>
-
 #define forall_operands(it, expr) \
   if((expr).has_operands()) /* NOLINT(readability/braces) */ \
     for(exprt::operandst::const_iterator it=(expr).operands().begin(), \


### PR DESCRIPTION
This header file is widely used, and dragging in useless includes unnecessarily
slows down compilation.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
