### PR TITLE
Do not use has_prefix in source_location.h

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_language.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_language.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/invariant.h>
 #include <util/journalling_symbol_table.h>
 #include <util/options.h>
+#include <util/prefix.h>
 #include <util/string2int.h>
 #include <util/suffix.h>
 #include <util/symbol_table.h>

--- a/jbmc/src/java_bytecode/java_bytecode_typecheck_expr.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_typecheck_expr.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/arith_tools.h>
 #include <util/expr_initializer.h>
+#include <util/prefix.h>
 #include <util/unicode.h>
 
 #include "java_pointer_casts.h"

--- a/jbmc/src/java_bytecode/java_class_loader_base.cpp
+++ b/jbmc/src/java_bytecode/java_class_loader_base.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "java_bytecode_parser.h"
 
 #include <util/file_util.h>
+#include <util/prefix.h>
 #include <util/suffix.h>
 
 #include <fstream>

--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -9,9 +9,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "java_object_factory.h"
 
 #include <util/expr_initializer.h>
-#include <util/nondet_bool.h>
 #include <util/nondet.h>
+#include <util/nondet_bool.h>
 #include <util/pointer_offset_size.h>
+#include <util/prefix.h>
 
 #include <goto-programs/class_identifier.h>
 #include <goto-programs/goto_functions.h>

--- a/jbmc/src/java_bytecode/load_method_by_regex.cpp
+++ b/jbmc/src/java_bytecode/load_method_by_regex.cpp
@@ -11,6 +11,7 @@ Author: Diffblue Ltd.
 
 #include <regex>
 
+#include <util/prefix.h>
 #include <util/symbol_table.h>
 
 /// For a given user provided pattern, return a regex, having dealt with the

--- a/src/ansi-c/builtin_factory.cpp
+++ b/src/ansi-c/builtin_factory.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "ansi_c_typecheck.h"
 
 #include <util/config.h>
+#include <util/prefix.h>
 #include <util/string_utils.h>
 
 #include <ostream>

--- a/src/ansi-c/c_preprocess.cpp
+++ b/src/ansi-c/c_preprocess.cpp
@@ -10,6 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/c_types.h>
 #include <util/config.h>
+#include <util/prefix.h>
 #include <util/run.h>
 #include <util/suffix.h>
 #include <util/tempfile.h>

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -22,6 +22,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/mathematical_types.h>
 #include <util/pointer_offset_size.h>
 #include <util/pointer_predicates.h>
+#include <util/prefix.h>
 #include <util/simplify_expr.h>
 #include <util/string_constant.h>
 

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -24,6 +24,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/lispirep.h>
 #include <util/namespace.h>
 #include <util/pointer_offset_size.h>
+#include <util/prefix.h>
 #include <util/string_constant.h>
 #include <util/suffix.h>
 #include <util/symbol.h>

--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -21,6 +21,7 @@ Date: June 2006
 #include <util/config.h>
 #include <util/file_util.h>
 #include <util/get_base_name.h>
+#include <util/prefix.h>
 #include <util/run.h>
 #include <util/suffix.h>
 #include <util/symbol_table_builder.h>

--- a/src/goto-harness/function_call_harness_generator.cpp
+++ b/src/goto-harness/function_call_harness_generator.cpp
@@ -8,15 +8,17 @@ Author: Diffblue Ltd.
 
 #include "function_call_harness_generator.h"
 
-#include <goto-programs/goto_convert.h>
-#include <goto-programs/goto_model.h>
 #include <util/allocate_objects.h>
 #include <util/arith_tools.h>
 #include <util/exception_utils.h>
+#include <util/prefix.h>
 #include <util/std_code.h>
 #include <util/std_expr.h>
 #include <util/string2int.h>
 #include <util/ui_message.h>
+
+#include <goto-programs/goto_convert.h>
+#include <goto-programs/goto_model.h>
 
 #include "function_harness_generator_options.h"
 #include "goto_harness_parse_options.h"

--- a/src/goto-instrument/cover_filter.cpp
+++ b/src/goto-instrument/cover_filter.cpp
@@ -11,6 +11,8 @@ Author: Peter Schrammel
 
 #include "cover_filter.h"
 
+#include <util/prefix.h>
+
 #include <linking/static_lifetime_init.h>
 
 /// Filter out functions that are not considered provided by the user

--- a/src/goto-instrument/nondet_static.cpp
+++ b/src/goto-instrument/nondet_static.cpp
@@ -19,6 +19,8 @@ Date: November 2011
 
 #include "nondet_static.h"
 
+#include <util/prefix.h>
+
 #include <goto-programs/goto_model.h>
 
 #include <linking/static_lifetime_init.h>

--- a/src/goto-instrument/race_check.cpp
+++ b/src/goto-instrument/race_check.cpp
@@ -13,6 +13,8 @@ Date: February 2006
 
 #include "race_check.h"
 
+#include <util/prefix.h>
+
 #include <goto-programs/remove_skip.h>
 
 #include <linking/static_lifetime_init.h>

--- a/src/goto-instrument/wmm/goto2graph.cpp
+++ b/src/goto-instrument/wmm/goto2graph.cpp
@@ -18,6 +18,7 @@ Date: 2012
 #include <fstream>
 
 #include <util/options.h>
+#include <util/prefix.h>
 
 #include <linking/static_lifetime_init.h>
 

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -20,6 +20,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/expr_util.h>
 #include <util/mathematical_expr.h>
 #include <util/pointer_offset_size.h>
+#include <util/prefix.h>
 #include <util/rational.h>
 #include <util/rational_tools.h>
 

--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <algorithm>
 
+#include <util/prefix.h>
 #include <util/type_eq.h>
 
 #include "class_identifier.h"

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -17,6 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/invariant_utils.h>
 #include <util/optional.h>
 #include <util/pointer_offset_size.h>
+#include <util/prefix.h>
 #include <util/simplify_expr.h>
 #include <util/string2int.h>
 #include <util/string_constant.h>

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -17,6 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/c_types.h>
 #include <util/exception_utils.h>
 #include <util/invariant.h>
+#include <util/prefix.h>
 
 static void locality(
   const irep_idt &function_identifier,

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -18,6 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/base_type.h>
 #include <util/c_types.h>
 #include <util/pointer_offset_size.h>
+#include <util/prefix.h>
 #include <util/simplify_expr.h>
 
 #include <langapi/language_util.h>

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/ieee_float.h>
 #include <util/invariant.h>
 #include <util/mathematical_expr.h>
+#include <util/prefix.h>
 #include <util/range.h>
 
 #include <numeric>

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -17,6 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "namespace.h"
 #include "pointer_offset_size.h"
 #include "pointer_predicates.h"
+#include "prefix.h"
 #include "std_expr.h"
 #include "string_constant.h"
 #include "threeval.h"

--- a/src/util/source_location.cpp
+++ b/src/util/source_location.cpp
@@ -11,6 +11,14 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <ostream>
 
 #include "file_util.h"
+#include "prefix.h"
+
+bool source_locationt::is_built_in(const std::string &s)
+{
+  std::string built_in1 = "<built-in-"; // "<built-in-additions>";
+  std::string built_in2 = "<builtin-";  // "<builtin-architecture-strings>";
+  return has_prefix(s, built_in1) || has_prefix(s, built_in2);
+}
 
 /// \par parameters: print_cwd, print the absolute path to the file
 std::string source_locationt::as_string(bool print_cwd) const

--- a/src/util/source_location.h
+++ b/src/util/source_location.h
@@ -13,7 +13,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "invariant.h"
 #include "irep.h"
 #include "optional.h"
-#include "prefix.h"
 
 #include <string>
 
@@ -175,12 +174,7 @@ public:
     return get_bool(ID_hide);
   }
 
-  static bool is_built_in(const std::string &s)
-  {
-    std::string built_in1="<built-in-"; // "<built-in-additions>";
-    std::string built_in2="<builtin-"; // "<builtin-architecture-strings>";
-    return has_prefix(s, built_in1) || has_prefix(s, built_in2);
-  }
+  static bool is_built_in(const std::string &s);
 
   bool is_built_in() const
   {

--- a/unit/analyses/constant_propagator.cpp
+++ b/unit/analyses/constant_propagator.cpp
@@ -15,7 +15,7 @@ Author: Diffblue Ltd
 
 #include <util/arith_tools.h>
 #include <util/mathematical_types.h>
-#include <util/message.h>
+#include <util/prefix.h>
 
 static bool starts_with_x(const exprt &e, const namespacet &)
 {


### PR DESCRIPTION
source_location.h is transitivly included in almost every translation unit.
Avoid the prefix.h include by moving the a method definition to the cpp file.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
