### PR TITLE
Avoid json.h include in message.h

### DIFF
--- a/src/util/message.cpp
+++ b/src/util/message.cpp
@@ -9,6 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "message.h"
 
+#include "json.h"
 #include "string2int.h"
 
 void message_handlert::print(
@@ -139,4 +140,15 @@ void messaget::conditional_output(
   {
     output_generator(mstream);
   }
+}
+
+messaget::mstreamt &messaget::mstreamt::operator<<(const json_objectt &data)
+{
+  if(this->tellp() > 0)
+    *this << eom; // force end of previous message
+  if(message.message_handler)
+  {
+    message.message_handler->print(message_level, data);
+  }
+  return *this;
 }

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -17,9 +17,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "deprecate.h"
 #include "invariant.h"
-#include "json.h"
 #include "source_location.h"
 
+class json_objectt;
+class jsont;
 class xmlt;
 
 class message_handlert
@@ -248,16 +249,7 @@ public:
       return *this;
     }
 
-    mstreamt &operator << (const json_objectt &data)
-    {
-      if(this->tellp() > 0)
-        *this << eom; // force end of previous message
-      if(message.message_handler)
-      {
-        message.message_handler->print(message_level, data);
-      }
-      return *this;
-    }
+    mstreamt &operator<<(const json_objectt &data);
 
     template <class T>
     mstreamt &operator << (const T &x)


### PR DESCRIPTION
message.h is frequently used, and not all users need to know about the jsont
type hierarchy. Move the only function that requires knowing that a json_objectt
is-a jsont to the cpp file.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
