### PR TITLE
Removed deprecated and unused to_unsigned_integer

### DIFF
--- a/src/util/arith_tools.cpp
+++ b/src/util/arith_tools.cpp
@@ -96,23 +96,6 @@ bool to_integer(const constant_exprt &expr, mp_integer &int_value)
   return true;
 }
 
-/// convert a positive integer expression to an unsigned int
-/// \par parameters: a constant expression and a reference to an unsigned int
-/// \return an error flag
-bool to_unsigned_integer(const constant_exprt &expr, unsigned &uint_value)
-{
-  mp_integer i;
-  if(to_integer(expr, i))
-    return true;
-  if(i<0)
-    return true;
-  else
-  {
-    uint_value = numeric_cast_v<unsigned>(i);
-    return false;
-  }
-}
-
 constant_exprt from_integer(
   const mp_integer &int_value,
   const typet &type)

--- a/src/util/arith_tools.h
+++ b/src/util/arith_tools.h
@@ -10,7 +10,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_ARITH_TOOLS_H
 #define CPROVER_UTIL_ARITH_TOOLS_H
 
-#include "deprecate.h"
 #include "invariant.h"
 #include "mp_arith.h"
 #include "optional.h"
@@ -25,10 +24,6 @@ class typet;
 /// \param [out] int_value: Integer value (only modified if conversion succeeds)
 /// \return False if, and only if, the conversion was successful.
 bool to_integer(const constant_exprt &expr, mp_integer &int_value);
-
-// returns 'true' on error
-DEPRECATED(SINCE(2018, 9, 29, "Use numeric_cast<unsigned>(e) instead"))
-bool to_unsigned_integer(const constant_exprt &expr, unsigned &uint_value);
 
 /// Numerical cast provides a unified way of converting from one numerical type
 /// to another.


### PR DESCRIPTION
It has been deprecated since 9/2018.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
