### PR TITLE
cover_goalst isn't a messaget [blocks: #3800]

### DIFF
--- a/src/cbmc/all_properties.cpp
+++ b/src/cbmc/all_properties.cpp
@@ -97,7 +97,6 @@ safety_checkert::resultt bmc_all_propertiest::operator()()
 
   cover_goalst cover_goals(solver);
 
-  cover_goals.set_message_handler(get_message_handler());
   cover_goals.register_observer(*this);
 
   for(const auto &g : goal_map)
@@ -112,7 +111,8 @@ safety_checkert::resultt bmc_all_propertiest::operator()()
 
   bool error=false;
 
-  decision_proceduret::resultt result=cover_goals();
+  const decision_proceduret::resultt result =
+    cover_goals(get_message_handler());
 
   if(result==decision_proceduret::resultt::D_ERROR)
   {

--- a/src/cbmc/bmc_cover.cpp
+++ b/src/cbmc/bmc_cover.cpp
@@ -250,7 +250,7 @@ bool bmc_covert::operator()()
 
   status() << "Running " << solver.decision_procedure_text() << eom;
 
-  cover_goals();
+  cover_goals(get_message_handler());
 
   {
     auto solver_stop=std::chrono::steady_clock::now();

--- a/src/solvers/prop/cover_goals.cpp
+++ b/src/solvers/prop/cover_goals.cpp
@@ -11,6 +11,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "cover_goals.h"
 
+#include <util/message.h>
+
 #include "literal_expr.h"
 #include "prop_conv.h"
 
@@ -69,7 +71,8 @@ void cover_goalst::freeze_goal_variables()
 }
 
 /// Try to cover all goals
-decision_proceduret::resultt cover_goalst::operator()()
+decision_proceduret::resultt cover_goalst::
+operator()(message_handlert &message_handler)
 {
   _iterations=_number_covered=0;
 
@@ -98,8 +101,11 @@ decision_proceduret::resultt cover_goalst::operator()()
       break;
 
     default:
-      error() << "decision procedure has failed" << eom;
+    {
+      messaget log(message_handler);
+      log.error() << "decision procedure has failed" << messaget::eom;
       return dec_result;
+    }
     }
   }
   while(dec_result==decision_proceduret::resultt::D_SATISFIABLE &&

--- a/src/solvers/prop/cover_goals.h
+++ b/src/solvers/prop/cover_goals.h
@@ -15,15 +15,15 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <list>
 
 #include <util/decision_procedure.h>
-#include <util/message.h>
 
 #include "literal.h"
 
+class message_handlert;
 class prop_convt;
 
 /// Try to cover some given set of goals incrementally. This can be seen as a
 /// heuristic variant of SAT-based set-cover. No minimality guarantee.
-class cover_goalst:public messaget
+class cover_goalst
 {
 public:
   explicit cover_goalst(prop_convt &_prop_conv):
@@ -36,7 +36,7 @@ public:
   virtual ~cover_goalst();
 
   // returns result of last run on success
-  decision_proceduret::resultt operator()();
+  decision_proceduret::resultt operator()(message_handlert &);
 
   // the goals
 


### PR DESCRIPTION
There is a single use of message output - pass a message handler to operator()
instead. This avoids deprecated object construction (as messaget ought to be
constructed using a message handler), and also removes an unnecessary include
from the header file. One of the two call sites actually didn't set the message
handler, which is now impossible.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
