### PR TITLE
Fix exit/signal specifications in enum-trace1 [blocks: #4253]

### DIFF
--- a/regression/cbmc-cover/branch-loop1/test.desc
+++ b/regression/cbmc-cover/branch-loop1/test.desc
@@ -2,8 +2,8 @@ CORE
 main.c
 --xml-ui --cover branch
 activate-multi-line-match
-EXIT=0
-SIGNAL=0
+^EXIT=0$
+^SIGNAL=0$
 </inputs>\n\s*<goal id="main\.coverage\.1"/>\n\s*<goal id="main\.coverage\.2"/>\n\s*<goal id="main\.coverage\.3"/>\n\s*<goal id="main\.coverage\.5"/>\n\s*</test>
 --
 ^warning: ignoring

--- a/regression/cbmc/enum-trace1/test_json.desc
+++ b/regression/cbmc/enum-trace1/test_json.desc
@@ -2,8 +2,8 @@ CORE
 main.c
 --json-ui --function test --trace
 activate-multi-line-match
-EXIT=10
-SIGNAL=0
+^EXIT=10$
+^SIGNAL=0$
 VERIFICATION FAILED
 \{\n\s*"hidden": false,\n\s*"inputID": "e",\n\s*"internal": true,\n\s*"mode": "C",\n\s*"sourceLocation": \{(\n.*)*\},\n\s*"stepType": "input",\n\s*"thread": 0,\n\s*"values": \[\n\s*\{\n\s*"binary": "000000000000000000000000000000(0|1){2}",\n\s*"data": ".*E(1|2|3)",\n\s*"name": "integer",\n\s*"type": "enum",\n\s*"width": 32\n\s*\}\n\s*\]\n\s*\},
 \{\n\s*"hidden": false,\n\s*"inputID": "t",\n\s*"internal": true,\n\s*"mode": "C",\n\s*"sourceLocation": \{(\n.*)*\},\n\s*"stepType": "input",\n\s*"thread": 0,\n\s*"values": \[\n\s*\{\n\s*"binary": "000000000000000000000000000000(0|1){2}",\n\s*"data": ".*T(1|2|3)",\n\s*"name": "integer",\n\s*"type": "enum",\n\s*"width": 32\n\s*\}\n\s*\]\n\s*\},

--- a/regression/cbmc/enum-trace1/test_xml.desc
+++ b/regression/cbmc/enum-trace1/test_xml.desc
@@ -2,8 +2,8 @@ CORE
 main.c
 --xml-ui --function test --trace
 activate-multi-line-match
-EXIT=10
-SIGNAL=0
+^EXIT=10$
+^SIGNAL=0$
 VERIFICATION FAILED
 <input hidden="false" step_nr="\d+" thread="0">\n\s*<input_id>e</input_id>\n\s*<value>.*E(1|2|3)</value>\n\s*<value_expression>\n\s*<integer binary="000000000000000000000000000000(0|1){2}" c_type="enum" width="32">(0|1|2)</integer>\n\s*</value_expression>
 <input hidden="false" step_nr="\d+" thread="0">\n\s*<input_id>t</input_id>\n\s*<value>.*T(1|2|3)</value>\n\s*<value_expression>\n\s*<integer binary="000000000000000000000000000000(0|1){2}" c_type="enum" width="32">(0|1|2)</integer>\n\s*</value_expression>

--- a/regression/cbmc/function-return-no-body1/test.desc
+++ b/regression/cbmc/function-return-no-body1/test.desc
@@ -2,8 +2,8 @@ CORE
 main.c
 --xml-ui
 activate-multi-line-match
-EXIT=10
-SIGNAL=0
+^EXIT=10$
+^SIGNAL=0$
 VERIFICATION FAILED
 <function_call hidden="false" step_nr="18" thread="0">\n\s*<function display_name="no_body" identifier="no_body">
 <function_return hidden="false" step_nr="19" thread="0">\n\s*<function display_name="no_body" identifier="no_body">


### PR DESCRIPTION
The patterns were being used without anchoring to the beginning or end of the
line.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
