### PR TITLE
Take __CPROVER_allocated_memory regions into account for --bounds-check

### DIFF
--- a/regression/cbmc/memory_allocation2/main.c
+++ b/regression/cbmc/memory_allocation2/main.c
@@ -1,0 +1,39 @@
+#define _cbmc_printf2(str, var)                                                \
+  {                                                                            \
+    unsigned int ValueOf_##str = (unsigned int)var;                            \
+  }
+
+#define BUFFER_SIZE 100
+typedef struct
+{
+  int buffer[BUFFER_SIZE];
+} buffert;
+
+#define BUF_BASE 0x1000
+#define BUF0_BASE (BUF_BASE + 0x00000)
+#define BUF1_BASE (BUF_BASE + 0x10000)
+#define BUF2_BASE (BUF_BASE + 0x20000)
+#define BUF3_BASE (BUF_BASE + 0x30000)
+
+#define BUF0 ((buffert *)BUF0_BASE)
+#define BUF1 ((buffert *)BUF1_BASE)
+#define BUF2 ((buffert *)BUF2_BASE)
+#define BUF3 ((buffert *)BUF3_BASE)
+
+static buffert(*const buffers[4]) = {BUF0, BUF1, BUF2, BUF3};
+
+main()
+{
+  __CPROVER_allocated_memory(BUF0_BASE, sizeof(buffert));
+  __CPROVER_allocated_memory(BUF1_BASE, sizeof(buffert));
+  __CPROVER_allocated_memory(BUF2_BASE, sizeof(buffert));
+  __CPROVER_allocated_memory(BUF3_BASE, sizeof(buffert));
+
+  _cbmc_printf2(sizeof_buffers, sizeof(buffers));
+  _cbmc_printf2(sizeof_buffers_0, sizeof(buffers[0]));
+  _cbmc_printf2(sizeof_buffer, sizeof(buffers[0]->buffer));
+
+  buffers[0]->buffer[0];
+  buffers[0]->buffer[BUFFER_SIZE - 1];
+  buffers[0]->buffer[BUFFER_SIZE]; // should be out-of-bounds
+}

--- a/regression/cbmc/memory_allocation2/test.desc
+++ b/regression/cbmc/memory_allocation2/test.desc
@@ -1,0 +1,11 @@
+CORE broken-smt-backend
+main.c
+--bounds-check
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.array_bounds\.[1-5]\] .*: SUCCESS$
+^\[main\.array_bounds\.[67]\] line 38 array.buffer (dynamic object )?upper bound in buffers\[\(signed long (long )?int\)0\]->buffer\[\(signed long (long )?int\)100\]: FAILURE$
+^\*\* 2 of 7 failed
+^VERIFICATION FAILED$
+--
+^warning: ignoring


### PR DESCRIPTION
We already took these into account for --pointer-check. Do the same for
--bounds-check.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
