### PR TITLE
 Define an add_const utility function

### DIFF
--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <cstdlib>
 #include <iostream>
 
+#include <util/as_const.h>
 #include <util/base_exceptions.h>
 #include <util/exception_utils.h>
 #include <util/expr_util.h>
@@ -315,7 +316,7 @@ void goto_symex_statet::rename(
   else if(expr.id()==ID_symbol)
   {
     // we never rename function symbols
-    if(expr.type().id() == ID_code)
+    if(as_const(expr).type().id() == ID_code)
     {
       rename(
         expr.type(),
@@ -333,7 +334,8 @@ void goto_symex_statet::rename(
   {
     auto &address_of_expr = to_address_of_expr(expr);
     rename_address(address_of_expr.object(), ns, level);
-    to_pointer_type(expr.type()).subtype() = address_of_expr.object().type();
+    to_pointer_type(expr.type()).subtype() =
+      as_const(address_of_expr).object().type();
   }
   else
   {
@@ -343,12 +345,13 @@ void goto_symex_statet::rename(
     Forall_operands(it, expr)
       rename(*it, ns, level);
 
+    const exprt &c_expr = as_const(expr);
     INVARIANT(
       (expr.id() != ID_with ||
-       expr.type() == to_with_expr(expr).old().type()) &&
+       c_expr.type() == to_with_expr(c_expr).old().type()) &&
         (expr.id() != ID_if ||
-         (expr.type() == to_if_expr(expr).true_case().type() &&
-          expr.type() == to_if_expr(expr).false_case().type())),
+         (c_expr.type() == to_if_expr(c_expr).true_case().type() &&
+          c_expr.type() == to_if_expr(c_expr).false_case().type())),
       "Type of renamed expr should be the same as operands for with_exprt and "
       "if_exprt");
   }

--- a/src/util/as_const.h
+++ b/src/util/as_const.h
@@ -1,0 +1,19 @@
+/*******************************************************************\
+
+Module: Util
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_AS_CONST_H
+#define CPROVER_UTIL_AS_CONST_H
+
+/// Return a reference to the same object but ensures the type is const
+template <typename T>
+const T &as_const(T &value)
+{
+  return static_cast<const T &>(value);
+}
+
+#endif // CPROVER_UTIL_AS_CONST_H


### PR DESCRIPTION
This is useful in particular when we want to force the const version of
a method to be called.
For `exprt` there can be differences in performance between const and
non-const.

This is applied to `goto_symex_statet::rename` as an example, and trying of the example in `jbmc/regression/jbmc-strings/StringConcat/test_buffer_nondet_loop5` it reduced the number of calls to detach from 744638 to 736844.



<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
