### PR TITLE
Consider properties of inline functions

### DIFF
--- a/regression/cbmc/set-property-inline1/main.c
+++ b/regression/cbmc/set-property-inline1/main.c
@@ -1,0 +1,10 @@
+static inline short inc(short x)
+{
+  return x + 1;
+}
+
+void main()
+{
+  short z;
+  inc(z);
+}

--- a/regression/cbmc/set-property-inline1/test.desc
+++ b/regression/cbmc/set-property-inline1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--property inc.overflow.1 --property inc.overflow.2 --slice-formula --signed-overflow-check --conversion-check
+^EXIT=10$
+^SIGNAL=0$
+VERIFICATION FAILED
+\[inc\.overflow\.2\] line 3 arithmetic overflow on signed type conversion in \(signed short int\)\(\(signed int\)x \+ 1\): FAILURE
+\[inc\.overflow\.1\] line 3 arithmetic overflow on signed \+ in \(signed int\)x \+ 1: SUCCESS
+--
+^warning: ignoring

--- a/src/goto-programs/set_properties.cpp
+++ b/src/goto-programs/set_properties.cpp
@@ -109,8 +109,7 @@ void set_properties(
   property_set.insert(properties.begin(), properties.end());
 
   Forall_goto_functions(it, goto_functions)
-    if(!it->second.is_inlined())
-      set_properties(it->second.body, property_set);
+    set_properties(it->second.body, property_set);
 
   if(!property_set.empty())
     throw invalid_command_line_argument_exceptiont(


### PR DESCRIPTION
Properties in inline functions used to be discarded because we ran partial_inline. However, since we do not run partial_inline anymore, properties in inline functions would be completely ignored without this fix.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
