### PR TITLE
use instructiont::transform

### DIFF
--- a/src/goto-programs/adjust_float_expressions.cpp
+++ b/src/goto-programs/adjust_float_expressions.cpp
@@ -197,17 +197,16 @@ void adjust_float_expressions(
   goto_functionst::goto_functiont &goto_function,
   const namespacet &ns)
 {
-  Forall_goto_program_instructions(it, goto_function.body)
-  {
-    adjust_float_expressions(it->code, ns);
-
-    if(it->has_condition())
-    {
-      exprt c = it->get_condition();
-      adjust_float_expressions(c, ns);
-      it->set_condition(c);
-    }
-  }
+  for(auto &i : goto_function.body.instructions)
+    i.transform([&ns](exprt expr) -> optionalt<exprt> {
+      if(have_to_adjust_float_expressions(expr))
+      {
+        adjust_float_expressions(expr, ns);
+        return expr;
+      }
+      else
+        return {};
+    });
 }
 
 void adjust_float_expressions(

--- a/src/goto-programs/remove_complex.cpp
+++ b/src/goto-programs/remove_complex.cpp
@@ -285,17 +285,16 @@ static void remove_complex(
 {
   remove_complex(goto_function.type);
 
-  Forall_goto_program_instructions(it, goto_function.body)
-  {
-    remove_complex(it->code);
-
-    if(it->has_condition())
-    {
-      exprt c = it->get_condition();
-      remove_complex(c);
-      it->set_condition(c);
-    }
-  }
+  for(auto &i : goto_function.body.instructions)
+    i.transform([](exprt e) -> optionalt<exprt> {
+      if(have_to_remove_complex(e))
+      {
+        remove_complex(e);
+        return e;
+      }
+      else
+        return {};
+    });
 }
 
 /// removes complex data type

--- a/src/goto-programs/remove_vector.cpp
+++ b/src/goto-programs/remove_vector.cpp
@@ -219,17 +219,16 @@ void remove_vector(goto_functionst::goto_functiont &goto_function)
 {
   remove_vector(goto_function.type);
 
-  Forall_goto_program_instructions(it, goto_function.body)
-  {
-    remove_vector(it->code);
-
-    if(it->has_condition())
-    {
-      exprt c = it->get_condition();
-      remove_vector(c);
-      it->set_condition(c);
-    }
-  }
+  for(auto &i : goto_function.body.instructions)
+    i.transform([](exprt e) -> optionalt<exprt> {
+      if(have_to_remove_vector(e))
+      {
+        remove_vector(e);
+        return e;
+      }
+      else
+        return {};
+    });
 }
 
 /// removes vector data type


### PR DESCRIPTION
This avoids direct access to data in instructiont.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
