### PR TITLE
function identifier in trace is wrong when function has no body

### DIFF
--- a/regression/cbmc/trace_show_function_calls/main.c
+++ b/regression/cbmc/trace_show_function_calls/main.c
@@ -4,6 +4,8 @@ int function_to_call(int a)
   return a + local;
 }
 
+int function_without_body(int p);
+
 int main()
 {
   int a;
@@ -15,6 +17,7 @@ int main()
   a = -2147483647;
   a = function_to_call(a);
   b = function_to_call(b);
+  a = function_without_body(123);
 
   __CPROVER_assert(0, "");
 }

--- a/regression/cbmc/trace_show_function_calls/main.c
+++ b/regression/cbmc/trace_show_function_calls/main.c
@@ -1,22 +1,20 @@
 int function_to_call(int a)
 {
-	int local = 1;
-	return a+local;
+  int local = 1;
+  return a + local;
 }
-
 
 int main()
 {
-	int a;
-	unsigned int b;
-	a = 0;
-	a = -100;
-	a = 2147483647;
-	b = a*2;
-	a = -2147483647;
-	a = function_to_call(a);
-	b = function_to_call(b);
-	
-	__CPROVER_assert(0,"");
+  int a;
+  unsigned int b;
+  a = 0;
+  a = -100;
+  a = 2147483647;
+  b = a * 2;
+  a = -2147483647;
+  a = function_to_call(a);
+  b = function_to_call(b);
 
+  __CPROVER_assert(0, "");
 }

--- a/regression/cbmc/trace_show_function_calls/test.desc
+++ b/regression/cbmc/trace_show_function_calls/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+KNOWNBUG broken-smt-backend
 main.c
 --trace --trace-show-function-calls
 ^EXIT=10$
@@ -6,6 +6,8 @@ main.c
 Function call: function_to_call\(-2147483647\) \(depth 2\)
 Function return from function_to_call \(depth 1\)
 Function call: function_to_call\(-2\) \(depth 2\)
+Function call: function_without_body\(123\) \(depth 2\)
+Function return from function_without_body \(depth 1\)
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
