### PR TITLE
remove_returns now preserves signature

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -2089,16 +2089,14 @@ void java_bytecode_convert_methodt::convert_invoke(
   // less accurate.
   if(method_symbol != symbol_table.symbols.end())
   {
-    const auto &restored_type =
-      original_return_type(symbol_table, invoked_method_id);
     // Note the number of parameters might change here due to constructors using
     // invokespecial will have zero arguments (the `this` is added below)
     // but the symbol for the <init> will have the this parameter.
     INVARIANT(
       to_java_method_type(arg0.type()).return_type().id() ==
-        restored_type.return_type().id(),
+        to_code_type(method_symbol->second.type).return_type().id(),
       "Function return type must not change in kind");
-    arg0.type() = restored_type;
+    arg0.type() = method_symbol->second.type;
   }
 
   // Note arg0 and arg0.type() are subject to many side-effects in this method,

--- a/src/goto-checker/symex_coverage.cpp
+++ b/src/goto-checker/symex_coverage.cpp
@@ -160,9 +160,8 @@ goto_program_coverage_recordt::goto_program_coverage_recordt(
   // </method>
   xml.set_attribute("name", id2string(gf_it->first));
 
-  code_typet sig_type =
-    original_return_type(ns.get_symbol_table(), gf_it->first);
-  xml.set_attribute("signature", from_type(ns, gf_it->first, sig_type));
+  xml.set_attribute(
+    "signature", from_type(ns, gf_it->first, gf_it->second.type));
 
   xml.set_attribute("line-rate", rate_detailed(lines_covered, lines_total));
   xml.set_attribute("branch-rate", rate(branches_covered, branches_total));

--- a/src/goto-programs/remove_returns.h
+++ b/src/goto-programs/remove_returns.h
@@ -66,18 +66,7 @@ Date:   September 2009
 /// r = func#return_value;
 ///
 /// ```
-///
-/// As `return` instructions are removed, the return types of the function types
-/// are set to void as well (represented by the type `empty_typet`). This
-/// applies both to the functions (i.e., the member `type` of `goto_functiont`)
-/// and to the call sites (i.e., the type
-/// `to_code_function_call(code).function().type()` with `code` being the code
-/// member of the `instructiont` instance that represents the function call).
-///
-/// The types of function pointer expressions in the goto program are however
-/// not changed. For example, in an assignment where `func` is assigned to a
-/// function pointer, such as `int (*f)(void) = func`, the function types
-/// appearing in the lhs and rhs both retain the integer return type.
+/// `remove_returns()` does not change the signature of the function.
 
 #ifndef CPROVER_GOTO_PROGRAMS_REMOVE_RETURNS_H
 #define CPROVER_GOTO_PROGRAMS_REMOVE_RETURNS_H
@@ -105,9 +94,5 @@ void remove_returns(goto_modelt &);
 void restore_returns(symbol_table_baset &, goto_functionst &);
 
 void restore_returns(goto_modelt &);
-
-code_typet original_return_type(
-  const symbol_table_baset &symbol_table,
-  const irep_idt &function_id);
 
 #endif // CPROVER_GOTO_PROGRAMS_REMOVE_RETURNS_H

--- a/src/goto-programs/validate_goto_model.cpp
+++ b/src/goto-programs/validate_goto_model.cpp
@@ -133,13 +133,7 @@ void validate_goto_modelt::check_returns_removed()
         DATA_CHECK(
           vm,
           function_call.lhs().is_nil(),
-          "function call return should be nil");
-
-        const auto &callee = to_code_type(function_call.function().type());
-        DATA_CHECK(
-          vm,
-          callee.return_type().id() == ID_empty,
-          "called function must have empty return type");
+          "function call lhs return should be nil");
       }
     }
   }


### PR DESCRIPTION
This simplifies removal, and removes the need to query the 'original' return
type.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
