### PR TITLE
pthread_cond_wait may return spuriously

### DIFF
--- a/regression/cbmc-library/CMakeLists.txt
+++ b/regression/cbmc-library/CMakeLists.txt
@@ -1,3 +1,13 @@
+if(NOT WIN32)
 add_test_pl_tests(
     "$<TARGET_FILE:cbmc>"
 )
+else()
+add_test_pl_tests(
+    "$<TARGET_FILE:cbmc>"
+    "cbmc-library"
+    "$<TARGET_FILE:cbmc>"
+    "-C;-X;pthread"
+    "CORE"
+)
+endif()

--- a/regression/cbmc-library/Makefile
+++ b/regression/cbmc-library/Makefile
@@ -1,10 +1,17 @@
 default: tests.log
 
+include ../../src/config.inc
+include ../../src/common
+
+ifeq ($(BUILD_ENV_),MSVC)
+	no_pthread = -X pthread
+endif
+
 test:
-	@../test.pl -e -p -c ../../../src/cbmc/cbmc
+	@../test.pl -e -p -c ../../../src/cbmc/cbmc $(no_pthread)
 
 tests.log: ../test.pl
-	@../test.pl -e -p -c ../../../src/cbmc/cbmc
+	@../test.pl -e -p -c ../../../src/cbmc/cbmc $(no_pthread)
 
 show:
 	@for dir in *; do \

--- a/regression/cbmc-library/pthread_barrier_destroy-01/test.desc
+++ b/regression/cbmc-library/pthread_barrier_destroy-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_barrier_init-01/test.desc
+++ b/regression/cbmc-library/pthread_barrier_init-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_barrier_wait-01/test.desc
+++ b/regression/cbmc-library/pthread_barrier_wait-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_cancel-01/test.desc
+++ b/regression/cbmc-library/pthread_cancel-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_cond_broadcast-01/test.desc
+++ b/regression/cbmc-library/pthread_cond_broadcast-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_cond_init-01/test.desc
+++ b/regression/cbmc-library/pthread_cond_init-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_cond_signal-01/test.desc
+++ b/regression/cbmc-library/pthread_cond_signal-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_cond_wait-01/main.c
+++ b/regression/cbmc-library/pthread_cond_wait-01/main.c
@@ -1,9 +1,32 @@
 #include <assert.h>
-#include <pthread_lib.h>
+#include <pthread.h>
+
+pthread_mutex_t lock;
+pthread_cond_t cond;
+
+// only accessed in critical section guarded by mutex, so there is no need to
+// make this variable atomic or volatile
+int x;
+
+void *thread(void *arg)
+{
+  (void)arg;
+  pthread_mutex_lock(&lock);
+  pthread_cond_wait(&cond, &lock);
+  // may fail: pthread_cond_wait can be waken up spuriously (see man
+  // pthread_cond_wait)
+  assert(x == 1);
+  pthread_mutex_unlock(&lock);
+  return NULL;
+}
 
 int main()
 {
-  pthread_cond_wait();
-  assert(0);
-  return 0;
+  pthread_t t;
+  pthread_mutex_init(&lock, 0);
+  pthread_cond_init(&cond, 0);
+  pthread_create(&t, NULL, thread, NULL);
+  x = 1;
+  pthread_cond_broadcast(&cond);
+  pthread_join(t, NULL);
 }

--- a/regression/cbmc-library/pthread_cond_wait-01/test.desc
+++ b/regression/cbmc-library/pthread_cond_wait-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_cond_wait-01/test.desc
+++ b/regression/cbmc-library/pthread_cond_wait-01/test.desc
@@ -1,8 +1,9 @@
-KNOWNBUG pthread
+CORE pthread
 main.c
---pointer-check --bounds-check
-^EXIT=0$
+--bounds-check
+^EXIT=10$
 ^SIGNAL=0$
-^VERIFICATION SUCCESSFUL$
+^\*\* 1 of 2 failed
+^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/cbmc-library/pthread_create-01/test.desc
+++ b/regression/cbmc-library/pthread_create-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_exit-01/test.desc
+++ b/regression/cbmc-library/pthread_exit-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_join-01/test.desc
+++ b/regression/cbmc-library/pthread_join-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_mutex_destroy-01/test.desc
+++ b/regression/cbmc-library/pthread_mutex_destroy-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_mutex_init-01/test.desc
+++ b/regression/cbmc-library/pthread_mutex_init-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_mutex_lock-01/test.desc
+++ b/regression/cbmc-library/pthread_mutex_lock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_mutex_trylock-01/test.desc
+++ b/regression/cbmc-library/pthread_mutex_trylock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_mutex_unlock-01/test.desc
+++ b/regression/cbmc-library/pthread_mutex_unlock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_mutexattr_settype-01/test.desc
+++ b/regression/cbmc-library/pthread_mutexattr_settype-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_rwlock_destroy-01/test.desc
+++ b/regression/cbmc-library/pthread_rwlock_destroy-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_rwlock_init-01/test.desc
+++ b/regression/cbmc-library/pthread_rwlock_init-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_rwlock_rdlock-01/test.desc
+++ b/regression/cbmc-library/pthread_rwlock_rdlock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_rwlock_tryrdlock-01/test.desc
+++ b/regression/cbmc-library/pthread_rwlock_tryrdlock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_rwlock_trywrlock-01/test.desc
+++ b/regression/cbmc-library/pthread_rwlock_trywrlock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_rwlock_unlock-01/test.desc
+++ b/regression/cbmc-library/pthread_rwlock_unlock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_rwlock_wrlock-01/test.desc
+++ b/regression/cbmc-library/pthread_rwlock_wrlock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_spin_lock-01/test.desc
+++ b/regression/cbmc-library/pthread_spin_lock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_spin_trylock-01/test.desc
+++ b/regression/cbmc-library/pthread_spin_trylock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_spin_unlock-01/test.desc
+++ b/regression/cbmc-library/pthread_spin_unlock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+KNOWNBUG pthread
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/src/ansi-c/library/pthread_lib.c
+++ b/src/ansi-c/library/pthread_lib.c
@@ -636,8 +636,8 @@ inline int pthread_cond_wait(
   #endif
 
   __CPROVER_atomic_begin();
-  __CPROVER_assume(*((unsigned *)cond));
-  (*((unsigned *)cond))--;
+  if(*((unsigned *)cond))
+    (*((unsigned *)cond))--;
   __CPROVER_atomic_end();
 
   return 0; // we never fail


### PR DESCRIPTION
The man page states: "In general, whenever a condition wait returns, the thread
has to re-evaluate the predicate associated with the condition wait to determine
whether it can safely proceed, should wait again, or should declare a timeout. A
return from the wait does not imply that the associated predicate is either true
or false."

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
