### PR TITLE
Remove replace_all string utility

### DIFF
--- a/src/util/string_utils.cpp
+++ b/src/util/string_utils.cpp
@@ -159,28 +159,3 @@ std::string escape(const std::string &s)
 
   return result;
 }
-
-/// Replace all occurrences of a string inside a string
-/// \param [out] str: string to search
-/// \param from: string to replace; must be non-empty
-/// \param to: string to replace with
-/// Copyright notice:
-/// Attributed to Gauthier Boaglio
-/// Source: https://stackoverflow.com/a/24315631/7501486
-/// Used under MIT license
-/// Note that this is quadratic in str.size() if from.size() != to.size().
-/// There is no guarantee that it is linear in str.size() if
-/// from.size() == to.size().
-void replace_all(
-  std::string &str,
-  const std::string &from,
-  const std::string &to)
-{
-  PRECONDITION(!from.empty());
-  size_t start_pos = 0;
-  while((start_pos = str.find(from, start_pos)) != std::string::npos)
-  {
-    str.replace(start_pos, from.length(), to);
-    start_pos += to.length();
-  }
-}

--- a/src/util/string_utils.h
+++ b/src/util/string_utils.h
@@ -96,6 +96,4 @@ join_strings(Stream &&os, const It b, const It e, const Delimiter &delimiter)
 /// programming language.
 std::string escape(const std::string &);
 
-void replace_all(std::string &, const std::string &, const std::string &);
-
 #endif


### PR DESCRIPTION
There are several reasons why we should not maintain this here:
* We do not have a single use in the code base.
* It's completely unrelated to program analysis or any other CBMC matter.
* If anyone else uses it, they are more than welcome to copy the implementation.
* It was based on MIT-licensed code copyrighted by an external author. Mixing
  licenses within individual files is questionable practice.

I believe this is still used by TG, and I would thus suggest to copy the implementation into that repository.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
