### PR TITLE
Use ranged-for to iterate over value_sett:valuest

### DIFF
--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -99,14 +99,11 @@ void value_sett::output(
   const namespacet &ns,
   std::ostream &out) const
 {
-  for(valuest::const_iterator
-      v_it=values.begin();
-      v_it!=values.end();
-      v_it++)
+  for(const auto &values_entry : values)
   {
     irep_idt identifier, display_name;
 
-    const entryt &e=v_it->second;
+    const entryt &e = values_entry.second;
 
     if(has_prefix(id2string(e.identifier), "value_set::dynamic_object"))
     {

--- a/src/pointer-analysis/value_set_analysis.cpp
+++ b/src/pointer-analysis/value_set_analysis.cpp
@@ -46,7 +46,7 @@ void value_sets_to_xml(
       xmlt &var=i.new_element("variable");
       var.new_element("identifier").data = id2string(values_entry.first);
 
-      #if 0
+#if 0
       const value_sett::expr_sett &expr_set=
         v_it->second.expr_set();
 
@@ -61,7 +61,7 @@ void value_sets_to_xml(
         var.new_element("value").data=
           xmlt::escape(value_str);
       }
-      #endif
+#endif
     }
   }
 }

--- a/src/pointer-analysis/value_set_analysis.cpp
+++ b/src/pointer-analysis/value_set_analysis.cpp
@@ -41,14 +41,10 @@ void value_sets_to_xml(
     xmlt &i=dest.new_element("instruction");
     i.new_element()=::xml(location);
 
-    for(value_sett::valuest::const_iterator
-        v_it=value_set.values.begin();
-        v_it!=value_set.values.end();
-        v_it++)
+    for(const auto &values_entry : value_set.values)
     {
       xmlt &var=i.new_element("variable");
-      var.new_element("identifier").data=
-        id2string(v_it->first);
+      var.new_element("identifier").data = id2string(values_entry.first);
 
       #if 0
       const value_sett::expr_sett &expr_set=


### PR DESCRIPTION
This is easier to read and simplifies switching between representations.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
