### PR TITLE
Fix: Do not nondet functions and fix scoping issue

### DIFF
--- a/regression/goto-harness/chain.sh
+++ b/regression/goto-harness/chain.sh
@@ -24,4 +24,4 @@ if [ -e "${name}-mod.gb" ] ; then
 fi
 
 $goto_harness "${name}.gb" "${name}-mod.gb" --harness-function-name $entry_point ${args} 
-$cbmc --function $entry_point "${name}-mod.gb"
+$cbmc --function $entry_point "${name}-mod.gb" --unwind 20 --unwinding-assertions

--- a/regression/goto-harness/nondet_elements_longer_lists/main.c
+++ b/regression/goto-harness/nondet_elements_longer_lists/main.c
@@ -1,0 +1,25 @@
+#include <assert.h>
+
+typedef struct list
+{
+  int datum;
+  struct list *next;
+} list_nodet;
+
+void test_function(list_nodet *node)
+{
+  int i = 0;
+  list_nodet *list_walker = node;
+  while(list_walker)
+  {
+    list_walker->datum = ++i;
+    list_walker = list_walker->next;
+  }
+  list_walker = node;
+  i = 0;
+  while(list_walker)
+  {
+    assert(list_walker->datum == ++i);
+    list_walker = list_walker->next;
+  }
+}

--- a/regression/goto-harness/nondet_elements_longer_lists/test.desc
+++ b/regression/goto-harness/nondet_elements_longer_lists/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--harness-type call-function --max-nondet-tree-depth 4 --min-null-tree-depth 1 --function test_function
+\[test_function.unwind.\d+\] line \d+ unwinding assertion loop 0: SUCCESS
+\[test_function.unwind.\d+\] line \d+ unwinding assertion loop 1: SUCCESS
+\[test_function.assertion.\d+\] line \d+ assertion list_walker->datum == \+\+i: SUCCESS
+^EXIT=0$
+^SIGNAL=0$
+VERIFICATION SUCCESSFUL
+--

--- a/regression/goto-harness/nondet_elements_longer_lists_global/main.c
+++ b/regression/goto-harness/nondet_elements_longer_lists_global/main.c
@@ -1,0 +1,26 @@
+#include <assert.h>
+
+typedef struct list
+{
+  int datum;
+  struct list *next;
+} list_nodet;
+
+list_nodet *global_list;
+void test_function(void)
+{
+  int i = 0;
+  list_nodet *list_walker = global_list;
+  while(list_walker)
+  {
+    list_walker->datum = ++i;
+    list_walker = list_walker->next;
+  }
+  list_walker = global_list;
+  i = 0;
+  while(list_walker)
+  {
+    assert(list_walker->datum == ++i);
+    list_walker = list_walker->next;
+  }
+}

--- a/regression/goto-harness/nondet_elements_longer_lists_global/test.desc
+++ b/regression/goto-harness/nondet_elements_longer_lists_global/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--harness-type call-function --max-nondet-tree-depth 4 --min-null-tree-depth 1 --function test_function --nondet-globals
+\[test_function.unwind.\d+\] line \d+ unwinding assertion loop 0: SUCCESS
+\[test_function.unwind.\d+\] line \d+ unwinding assertion loop 1: SUCCESS
+\[test_function.assertion.\d+\] line \d+ assertion list_walker->datum == \+\+i: SUCCESS
+^EXIT=0$
+^SIGNAL=0$
+VERIFICATION SUCCESSFUL
+--

--- a/src/goto-harness/recursive_initialization.cpp
+++ b/src/goto-harness/recursive_initialization.cpp
@@ -93,8 +93,17 @@ void recursive_initializationt::initialize_pointer(
                                      goto_model.symbol_table};
   exprt choice =
     allocate_objects.allocate_automatic_local_object(bool_typet{}, "choice");
-  auto pointee =
-    allocate_objects.allocate_automatic_local_object(type.subtype(), "pointee");
+  symbolt &pointee_symbol = get_fresh_aux_symbol(
+    type.subtype(),
+    "__goto_harness",
+    "pointee",
+    lhs.source_location(),
+    initialization_config.mode,
+    goto_model.symbol_table);
+  pointee_symbol.is_static_lifetime = true;
+  pointee_symbol.is_lvalue = true;
+
+  auto pointee = pointee_symbol.symbol_expr();
   allocate_objects.declare_created_symbols(body);
   body.add(code_assignt{lhs, null_pointer_exprt{type}});
   bool is_unknown_struct_tag =


### PR DESCRIPTION
In goto-harness:
- we used is_static && is_lvalue to determine something was global.
  Turns out that this also applies to extern functions for some reason,
  so we ended up accidentally creating nondet assignments to those.
  We now check type.id() != ID_code as well.
- we declared pointers to local variables. In if blocks. Which went
  out of scope before using them. This meant we had a bunch of
  dangling references. We solve this by creating global variables
  for our pointer-pointees instead of local ones.

Co-authored-by: Fotis Koutoulakis <fotis.koutoulakis@diffblue.com>
Co-authored-by: Hannes Steffenhagen <hannes.steffenhagen@diffblue.com>

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
