### PR TITLE
Bugfix in bdd::as_expr

### DIFF
--- a/src/solvers/prop/bdd_expr.cpp
+++ b/src/solvers/prop/bdd_expr.cpp
@@ -119,11 +119,14 @@ exprt bdd_exprt::as_expr(const bdd_nodet &r, bool complement) const
       if(r.else_branch().is_complement() != complement)
       {
         return and_exprt(
-          n_expr, as_expr(r.then_branch(), complement != r.is_complement()));
+          n_expr,
+          as_expr(
+            r.then_branch(), complement != r.then_branch().is_complement()));
       }
       return or_exprt(
         not_exprt(n_expr),
-        as_expr(r.then_branch(), complement != r.is_complement()));
+        as_expr(
+          r.then_branch(), complement != r.then_branch().is_complement()));
     }
   }
   else if(r.then_branch().is_constant())

--- a/unit/solvers/prop/bdd_expr.cpp
+++ b/unit/solvers/prop/bdd_expr.cpp
@@ -44,4 +44,25 @@ SCENARIO("bdd_expr", "[core][solver][prop][bdd_expr]")
       REQUIRE(bdd.as_expr() == bdd2.as_expr());
     }
   }
+
+  GIVEN("A bdd for (a&!b)")
+  {
+    const symbol_exprt a("a", bool_typet());
+    const symbol_exprt b("b", bool_typet());
+
+    bdd_exprt bdd{ns};
+    bdd.from_expr(and_exprt(a, not_exprt(b)));
+
+    WHEN("It is converted to an exprt")
+    {
+      const exprt result = bdd.as_expr();
+      THEN("It is equal to the expression (a & !b) or (!b & a)")
+      {
+        REQUIRE(result.id() == ID_and);
+        REQUIRE(result.operands().size() == 2);
+        REQUIRE((result.op0() == a || result.op1() == a));
+        REQUIRE((result.op0() == not_exprt(b) || result.op1() == not_exprt(b)));
+      }
+    }
+  }
 }


### PR DESCRIPTION
There was a bug in the as_expr method. I also added a unit test that should fail without the fix.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
