### PR TITLE
Refactor: simplify an if statement

### DIFF
--- a/src/solvers/flattening/pointer_logic.cpp
+++ b/src/solvers/flattening/pointer_logic.cpp
@@ -23,16 +23,11 @@ Author: Daniel Kroening, kroening@kroening.com
 
 bool pointer_logict::is_dynamic_object(const exprt &expr) const
 {
-  if(expr.type().get_bool(ID_C_dynamic))
-    return true;
-
-  if(expr.id()==ID_symbol)
-    if(has_prefix(
-         id2string(to_symbol_expr(expr).get_identifier()),
-         SYMEX_DYNAMIC_PREFIX))
-      return true;
-
-  return false;
+  return expr.type().get_bool(ID_C_dynamic) ||
+         (expr.id() == ID_symbol &&
+          has_prefix(
+            id2string(to_symbol_expr(expr).get_identifier()),
+            SYMEX_DYNAMIC_PREFIX));
 }
 
 void pointer_logict::get_dynamic_objects(std::vector<std::size_t> &o) const


### PR DESCRIPTION
Spotted this doing #3481 - if anyone doesn't like this, I'll simply drop it. 

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [n/a] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [n/a] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [n/a] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
