### PR TITLE
Add coding standard line on member functions

### DIFF
--- a/CODING_STANDARD.md
+++ b/CODING_STANDARD.md
@@ -215,6 +215,8 @@ Formatting is enforced using clang-format. For more information about this, see
   constructors, and `delete` in destructors. Never use `malloc` or `free`.
 - Prefer brace style initialisation (i.e. `type_name{arguments...}`) over
   parentheses for constructor calls
+- Make a function a member only if it needs direct access to the representation
+  of a class
 
 # CProver conventions
 - Avoid if at all possible using irept methods like `get(ID_name)`, instead cast


### PR DESCRIPTION
This is open for discussion. I think several people agree that non-member functions are clearer. 

See for example
https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c4-make-a-function-a-member-only-if-it-needs-direct-access-to-the-representation-of-a-class

"Less coupling than with member functions, fewer functions that can
cause trouble by modifying object state, reduces the number of functions
that needs to be modified after a change in representation."

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [na] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
