### PR TITLE
Add nondet initialisation of strings in goto-harness.

### DIFF
--- a/doc/cprover-manual/goto-harness.md
+++ b/doc/cprover-manual/goto-harness.md
@@ -261,3 +261,52 @@ options.
 If you have a function that takes an array parameter, but without an associated
 size parameter, you can also use the `--treat-pointer-as-array <parameter-name>`
 option.
+
+---
+
+If you want to non-deterministically initialise a pointer
+as a C string (character array with last element `'\0'`)
+then you can do that like this:
+
+``` C
+// nondet_string.c
+
+#include <assert.h>
+
+void function(char *pointer, int size)
+{
+  assert(pointer[size-1] == '\0');
+}
+```
+
+Then call the following:
+
+```
+$ goto-cc -o nondet_string.gb nondet_string.c
+$ goto-harness \
+  --harness-function-name harness \
+  --harness-type call-function \
+  --function function \
+  --treat-pointer-as-cstring pointer \
+  --associated-array-size pointer:size \
+  nondet_string.gb nondet_string-mod.gb
+$ cbmc --function harness nondet_string-mod.gb
+```
+
+Note that C strings are supported by the same mechanism
+behind the non-deterministic initialisation of pointers
+and arrays, so the same command line arguments apply, in
+particular `--associated-array-size`.
+
+This will result in:
+
+```
+[...]
+
+** Results:
+main.c function function
+[function.assertion.1] line 5 assertion pointer[size-1] == '\0': SUCCESS
+
+** 0 of 1 failed (1 iterations)
+VERIFICATION SUCCESSFUL
+```

--- a/regression/goto-harness/nondet_strings/main.c
+++ b/regression/goto-harness/nondet_strings/main.c
@@ -1,0 +1,6 @@
+#include <assert.h>
+
+void function(char *pointer, int size)
+{
+  assert(pointer[size - 1] == '\0');
+}

--- a/regression/goto-harness/nondet_strings/test.desc
+++ b/regression/goto-harness/nondet_strings/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--harness-type call-function --function function --treat-pointer-as-cstring pointer --associated-array-size pointer:size
+\[function.assertion.\d+\] line \d+ assertion pointer\[size - 1\] == \'\\0\': SUCCESS
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/goto-harness/nondet_strings_failing_assertion/main.c
+++ b/regression/goto-harness/nondet_strings_failing_assertion/main.c
@@ -1,0 +1,17 @@
+#include <assert.h>
+
+int stringlength(char *s)
+{
+  int counter = 0;
+  while(*s++ != 0)
+    counter++;
+  return counter;
+}
+
+void calling_func(char *s, int length)
+{
+  // WRONG: This should be stringlength(s)
+  // +1 because length is going to be length
+  // of the array, not the string
+  assert(stringlength(s) == length);
+}

--- a/regression/goto-harness/nondet_strings_failing_assertion/test.desc
+++ b/regression/goto-harness/nondet_strings_failing_assertion/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--harness-type call-function --function calling_func --treat-pointer-as-cstring s --associated-array-size s:length
+\[calling_func.assertion.\d+\] line \d+ assertion stringlength\(s\) == length: FAILURE
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/regression/goto-harness/nondet_strings_should_only_have_zero_at_end/main.c
+++ b/regression/goto-harness/nondet_strings_should_only_have_zero_at_end/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+int stringlength(char *s)
+{
+  int counter = 0;
+  while(*s++ != 0)
+    counter++;
+  return counter;
+}
+
+void calling_func(char *s, int length)
+{
+  // +1 because length is going to be length
+  // of the array, not the string
+  assert(stringlength(s) + 1 == length);
+}

--- a/regression/goto-harness/nondet_strings_should_only_have_zero_at_end/test.desc
+++ b/regression/goto-harness/nondet_strings_should_only_have_zero_at_end/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--harness-type call-function --function calling_func --treat-pointer-as-cstring s --associated-array-size s:length
+\[calling_func.assertion.\d+\] line \d+ assertion stringlength\(s\) \+ 1 == length: SUCCESS
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/src/goto-harness/function_call_harness_generator.cpp
+++ b/src/goto-harness/function_call_harness_generator.cpp
@@ -48,6 +48,9 @@ struct function_call_harness_generatort::implt
   std::set<irep_idt> function_parameters_to_treat_as_arrays;
   std::set<irep_idt> function_arguments_to_treat_as_arrays;
 
+  std::set<irep_idt> function_parameters_to_treat_as_cstrings;
+  std::set<irep_idt> function_arguments_to_treat_as_cstrings;
+
   std::map<irep_idt, irep_idt> function_argument_to_associated_array_size;
   std::map<irep_idt, irep_idt> function_parameter_to_associated_array_size;
 
@@ -178,6 +181,11 @@ void function_call_harness_generatort::handle_option(
       }
     }
   }
+  else if(option == FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_CSTRING)
+  {
+    p_impl->function_parameters_to_treat_as_cstrings.insert(
+      values.begin(), values.end());
+  }
   else
   {
     throw invalid_command_line_argument_exceptiont{
@@ -217,6 +225,8 @@ void function_call_harness_generatort::implt::generate(
     recursive_initialization_config.variables_that_hold_array_sizes.insert(
       pair.second);
   }
+  recursive_initialization_config.pointers_to_treat_as_cstrings =
+    function_arguments_to_treat_as_cstrings;
   recursive_initialization = util_make_unique<recursive_initializationt>(
     recursive_initialization_config, goto_model);
 
@@ -385,6 +395,12 @@ function_call_harness_generatort::implt::declare_arguments(
     {
       function_arguments_to_treat_as_arrays.insert(argument_name);
     }
+
+    if(function_parameters_to_treat_as_cstrings.count(parameter_name) != 0)
+    {
+      function_arguments_to_treat_as_cstrings.insert(argument_name);
+    }
+
     auto it = function_parameter_to_associated_array_size.find(parameter_name);
     if(it != function_parameter_to_associated_array_size.end())
     {

--- a/src/goto-harness/function_harness_generator_options.h
+++ b/src/goto-harness/function_harness_generator_options.h
@@ -20,6 +20,8 @@ Author: Diffblue Ltd.
   "treat-pointer-as-array"
 #define FUNCTION_HARNESS_GENERATOR_ASSOCIATED_ARRAY_SIZE_OPT                   \
   "associated-array-size"
+#define FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_CSTRING                    \
+  "treat-pointer-as-cstring"
 
 // clang-format off
 #define FUNCTION_HARNESS_GENERATOR_OPTIONS                                     \
@@ -31,6 +33,7 @@ Author: Diffblue Ltd.
   "(" FUNCTION_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT "):"                       \
   "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT "):"               \
   "(" FUNCTION_HARNESS_GENERATOR_ASSOCIATED_ARRAY_SIZE_OPT "):"                \
+  "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_CSTRING "):"                 \
 // FUNCTION_HARNESS_GENERATOR_OPTIONS
 
 // clang-format on

--- a/src/goto-harness/recursive_initialization.h
+++ b/src/goto-harness/recursive_initialization.h
@@ -32,6 +32,8 @@ struct recursive_initialization_configt
   std::set<irep_idt> variables_that_hold_array_sizes;
   std::map<irep_idt, irep_idt> array_name_to_associated_array_size_variable;
 
+  std::set<irep_idt> pointers_to_treat_as_cstrings;
+
   std::string to_string() const; // for debugging purposes
 };
 
@@ -81,12 +83,31 @@ private:
     std::size_t depth,
     const recursion_sett &known_tags,
     code_blockt &body);
+
+  using array_convertert = std::function<void(
+    const exprt &pointer,
+    std::size_t length,
+    std::size_t current_index,
+    std::size_t depth,
+    const recursion_sett &known_tags,
+    code_blockt &body)>;
+  array_convertert default_array_member_initialization();
+  array_convertert cstring_member_initialization();
+
   void initialize_array(
     const exprt &array,
     std::size_t depth,
     const recursion_sett &known_tags,
-    code_blockt &body);
+    code_blockt &body,
+    array_convertert array_member_initialization);
   void initialize_dynamic_array(
+    const exprt &pointer,
+    std::size_t depth,
+    const recursion_sett &known_tags,
+    code_blockt &body,
+    array_convertert array_member_initialization);
+
+  void initialize_cstring(
     const exprt &pointer,
     std::size_t depth,
     const recursion_sett &known_tags,
@@ -96,6 +117,7 @@ private:
   bool is_array_size_parameter(const irep_idt &cmdline_arg) const;
   optionalt<irep_idt>
   get_associated_size_variable(const irep_idt &array_name) const;
+  bool should_be_treated_as_cstring(const irep_idt &pointer_name) const;
 };
 
 #endif // CPROVER_GOTO_HARNESS_RECURSIVE_INITIALIZATION_H


### PR DESCRIPTION
Add the capability to non-deterministically initialise strings in `goto-harness` `call-function` harness generator.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
