### PR TITLE
Do not unnecessarily break sharing during renaming

### DIFF
--- a/regression/cbmc/struct13/main.c
+++ b/regression/cbmc/struct13/main.c
@@ -1,0 +1,12 @@
+struct S
+{
+  struct S *s;
+  struct S *a[2];
+};
+
+int main()
+{
+  struct S s;
+  s.s = 0;
+  return 0;
+}

--- a/regression/cbmc/struct13/test.desc
+++ b/regression/cbmc/struct13/test.desc
@@ -1,0 +1,12 @@
+KNOWNBUG
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Just like pointers, array members may have subtypes of the same type as the
+containing struct. requires_renaming fails to catch this case, which results in
+unbounded recursion.

--- a/regression/cbmc/struct13/test.desc
+++ b/regression/cbmc/struct13/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=0$
@@ -8,5 +8,4 @@ main.c
 ^warning: ignoring
 --
 Just like pointers, array members may have subtypes of the same type as the
-containing struct. requires_renaming fails to catch this case, which results in
-unbounded recursion.
+containing struct.

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -115,6 +115,8 @@ protected:
   template <levelt>
   optionalt<exprt> rename_address(const exprt &expr, const namespacet &ns);
   template <levelt>
+  optionalt<exprt> rename_expr(const exprt &expr, const namespacet &ns);
+  template <levelt>
   optionalt<typet> rename_type(
     const typet &type,
     const irep_idt &l1_identifier,

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -98,6 +98,8 @@ public:
   template <levelt level>
   ssa_exprt rename_ssa(ssa_exprt ssa, const namespacet &ns);
 
+  /// Perform renaming of expressions contained in types, which is necessary for
+  /// arrays of non-constant size.
   template <levelt level = L2>
   void rename(typet &type, const irep_idt &l1_identifier, const namespacet &ns);
 
@@ -112,6 +114,11 @@ public:
 protected:
   template <levelt>
   void rename_address(exprt &expr, const namespacet &ns);
+  template <levelt>
+  optionalt<typet> rename_type(
+    const typet &type,
+    const irep_idt &l1_identifier,
+    const namespacet &ns);
 
   /// Update values up to \c level.
   template <levelt level>

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -113,7 +113,7 @@ public:
 
 protected:
   template <levelt>
-  void rename_address(exprt &expr, const namespacet &ns);
+  optionalt<exprt> rename_address(const exprt &expr, const namespacet &ns);
   template <levelt>
   optionalt<typet> rename_type(
     const typet &type,


### PR DESCRIPTION
Not all subexpressions (or types) change during renaming. Only actually write to
the result when there was a change. This preserves sharing. On SV-COMP's
ReachSafety-ECA benchmarks the time spent in goto_symex_state::rename(exprt &,
...) is now 1944 seconds, when previously it was 2326 seconds. On the other
hand, the time spent in merge_ireps did not improve, the number of recursive
operator== calls in fact was higher (6930718243 rising to from 5710509892).

The time spent in goto_symex_statet::rename(typet &, ...) increases from 530
seconds to 568 seconds, which suggests there is room for improvement.

~I will keep this PR in Draft status to make sure #3996 won't need a rebase.~

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
