### PR TITLE
Remove redundant lines in ID_dynamic_object branch in value_set_dereferencet

### DIFF
--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -293,15 +293,6 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
   }
   else if(root_object.id()==ID_dynamic_object)
   {
-    // const dynamic_object_exprt &dynamic_object=
-    //  to_dynamic_object_expr(root_object);
-
-    // the object produced by malloc
-    exprt malloc_object=
-      ns.lookup(CPROVER_PREFIX "malloc_object").symbol_expr();
-
-    exprt is_malloc_object=same_object(pointer_expr, malloc_object);
-
     // constraint that it actually is a dynamic object
     // this is also our guard
     result.pointer_guard = dynamic_object(pointer_expr);


### PR DESCRIPTION
This branch is not taken any more, at least in symex. The code in it
doesn't make much sense, which makes me think it isn't taken at all.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
