### PR TITLE
Do not store ref to goto_symext in symex_dereference_statet

### DIFF
--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -122,7 +122,7 @@ process_array_expr(exprt &expr, bool do_simplify, const namespacet &ns)
 
 void goto_symext::process_array_expr(statet &state, exprt &expr)
 {
-  symex_dereference_statet symex_dereference_state(*this, state);
+  symex_dereference_statet symex_dereference_state(state, ns);
 
   value_set_dereferencet dereference(
     ns, state.symbol_table, symex_dereference_state, language_mode, false);

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -224,7 +224,7 @@ void goto_symext::dereference_rec(exprt &expr, statet &state)
     dereference_rec(tmp1, state);
 
     // we need to set up some elaborate call-backs
-    symex_dereference_statet symex_dereference_state(*this, state);
+    symex_dereference_statet symex_dereference_state(state, ns);
 
     value_set_dereferencet dereference(
       ns,

--- a/src/goto-symex/symex_dereference_state.cpp
+++ b/src/goto-symex/symex_dereference_state.cpp
@@ -86,22 +86,22 @@ void symex_dereference_statet::get_value_set(
 {
   state.value_set.get_value_set(expr, value_set, ns);
 
-  #if 0
+#if 0
   std::cout << "**************************\n";
   state.value_set.output(goto_symex.ns, std::cout);
   std::cout << "**************************\n";
-  #endif
+#endif
 
-  #if 0
+#if 0
   std::cout << "E: " << from_expr(goto_symex.ns, "", expr) << '\n';
-  #endif
+#endif
 
-  #if 0
+#if 0
   std::cout << "**************************\n";
   for(value_setst::valuest::const_iterator it=value_set.begin();
       it!=value_set.end();
       it++)
     std::cout << from_expr(goto_symex.ns, "", *it) << '\n';
   std::cout << "**************************\n";
-  #endif
+#endif
 }

--- a/src/goto-symex/symex_dereference_state.cpp
+++ b/src/goto-symex/symex_dereference_state.cpp
@@ -30,8 +30,6 @@ Author: Daniel Kroening, kroening@kroening.com
 const symbolt *
 symex_dereference_statet::get_or_create_failed_symbol(const exprt &expr)
 {
-  const namespacet &ns=goto_symex.ns;
-
   if(expr.id()==ID_symbol &&
      expr.get_bool(ID_C_SSA_symbol))
   {
@@ -86,7 +84,7 @@ void symex_dereference_statet::get_value_set(
   const exprt &expr,
   value_setst::valuest &value_set) const
 {
-  state.value_set.get_value_set(expr, value_set, goto_symex.ns);
+  state.value_set.get_value_set(expr, value_set, ns);
 
   #if 0
   std::cout << "**************************\n";

--- a/src/goto-symex/symex_dereference_state.h
+++ b/src/goto-symex/symex_dereference_state.h
@@ -25,16 +25,14 @@ class symex_dereference_statet:
   public dereference_callbackt
 {
 public:
-  symex_dereference_statet(
-    const goto_symext &_goto_symex,
-    goto_symext::statet &_state)
-    : goto_symex(_goto_symex), state(_state)
+  symex_dereference_statet(goto_symext::statet &_state, const namespacet &ns)
+    : state(_state), ns(ns)
   {
   }
 
 protected:
-  const goto_symext &goto_symex;
   goto_symext::statet &state;
+  const namespacet &ns;
 
   void get_value_set(const exprt &expr, value_setst::valuest &value_set)
     const override;


### PR DESCRIPTION
The `goto_symext &` was only used to access a namespace. Just store
a `namespacet &` instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
