### PR TITLE
Minor refactoring in symex_goto

### DIFF
--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -34,10 +34,10 @@ void goto_symext::symex_goto(statet &state)
     return; // nothing to do
   }
 
-  exprt old_guard = instruction.get_condition();
-  clean_expr(old_guard, state, false);
+  exprt new_guard = instruction.get_condition();
+  clean_expr(new_guard, state, false);
 
-  exprt new_guard = state.rename(old_guard, ns);
+  new_guard = state.rename(std::move(new_guard), ns);
   do_simplify(new_guard);
 
   if(new_guard.is_false())


### PR DESCRIPTION
Create one fewer exprt - old_guard isn't used later

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
