### PR TITLE
Move goto_statet and framet to their own files [blocks: #4302]

### DIFF
--- a/src/goto-symex/Makefile
+++ b/src/goto-symex/Makefile
@@ -1,5 +1,6 @@
 SRC = auto_objects.cpp \
       build_goto_trace.cpp \
+      goto_state.cpp \
       goto_symex.cpp \
       goto_symex_state.cpp \
       memory_model.cpp \

--- a/src/goto-symex/frame.h
+++ b/src/goto-symex/frame.h
@@ -1,0 +1,54 @@
+/*******************************************************************\
+
+Module: Symbolic Execution
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+/// \file
+/// Class for stack frames
+
+#ifndef CPROVER_GOTO_SYMEX_FRAME_H
+#define CPROVER_GOTO_SYMEX_FRAME_H
+
+#include "goto_state.h"
+
+/// Stack frames -- these are used for function calls and for exceptions
+struct framet
+{
+  // gotos
+  using goto_state_listt = std::list<goto_statet>;
+
+  // function calls
+  irep_idt function_identifier;
+  std::map<goto_programt::const_targett, goto_state_listt> goto_state_map;
+  symex_targett::sourcet calling_location;
+
+  goto_programt::const_targett end_of_function;
+  exprt return_value = nil_exprt();
+  bool hidden_function = false;
+
+  symex_renaming_levelt::current_namest old_level1;
+
+  std::set<irep_idt> local_objects;
+
+  // exceptions
+  std::map<irep_idt, goto_programt::targett> catch_map;
+
+  // loop and recursion unwinding
+  struct loop_infot
+  {
+    unsigned count = 0;
+    bool is_recursion = false;
+  };
+
+  std::unordered_map<irep_idt, loop_infot> loop_iterations;
+
+  explicit framet(symex_targett::sourcet _calling_location)
+    : calling_location(std::move(_calling_location))
+  {
+  }
+};
+
+#endif // CPROVER_GOTO_SYMEX_FRAME_H

--- a/src/goto-symex/goto_state.cpp
+++ b/src/goto-symex/goto_state.cpp
@@ -1,0 +1,22 @@
+/*******************************************************************\
+
+Module: Symbolic Execution
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+#include "goto_state.h"
+
+#include <util/format_expr.h>
+
+/// Print the constant propagation map in a human-friendly format.
+/// This is primarily for use from the debugger; please don't delete me just
+/// because there aren't any current callers.
+void goto_statet::output_propagation_map(std::ostream &out)
+{
+  for(const auto &name_value : propagation)
+  {
+    out << name_value.first << " <- " << format(name_value.second) << "\n";
+  }
+}

--- a/src/goto-symex/goto_state.h
+++ b/src/goto-symex/goto_state.h
@@ -1,0 +1,70 @@
+/*******************************************************************\
+
+Module: Symbolic Execution
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+/// \file
+/// goto_statet class definition
+
+#ifndef CPROVER_GOTO_SYMEX_GOTO_STATE_H
+#define CPROVER_GOTO_SYMEX_GOTO_STATE_H
+
+#include <analyses/local_safe_pointers.h>
+#include <pointer-analysis/value_set.h>
+#include <util/guard.h>
+
+#include "renaming_level.h"
+#include "symex_target_equation.h"
+
+/// Container for data that varies per program point, e.g. the constant
+/// propagator state, when state needs to branch. This is copied out of
+/// goto_symex_statet at a control-flow fork and then back into it at a
+/// control-flow merge.
+class goto_statet
+{
+public:
+  /// Distance from entry
+  unsigned depth = 0;
+
+  symex_level2t level2;
+
+  /// Uses level 1 names, and is used to do dereferencing
+  value_sett value_set;
+
+  // A guard is a particular condition that has to pass for an instruction
+  // to be executed. The easiest example is an if/else: each instruction along
+  // the if branch will be guarded by the condition of the if (and if there
+  // is an else branch then instructions on it will be guarded by the negation
+  // of the condition of the if).
+  guardt guard{true_exprt{}};
+
+  symex_targett::sourcet source;
+
+  // Map L1 names to (L2) constants. Values will be evicted from this map
+  // when they become non-constant. This is used to propagate values that have
+  // been worked out to only have one possible value.
+  //
+  // "constants" can include symbols, but only in the context of an address-of
+  // op (i.e. &x can be propagated), and an address-taken thing should only be
+  // L1.
+  std::map<irep_idt, exprt> propagation;
+
+  void output_propagation_map(std::ostream &);
+
+  /// Threads
+  unsigned atomic_section_id = 0;
+
+  unsigned total_vccs = 0;
+  unsigned remaining_vccs = 0;
+
+  /// Constructors
+  explicit goto_statet(const class goto_symex_statet &s);
+  explicit goto_statet(const symex_targett::sourcet &_source) : source(_source)
+  {
+  }
+};
+
+#endif // CPROVER_GOTO_SYMEX_GOTO_STATE_H

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -785,14 +785,3 @@ void goto_symex_statet::print_backtrace(std::ostream &out) const
         << frame.calling_location.pc->location_number << "\n";
   }
 }
-
-/// Print the constant propagation map in a human-friendly format.
-/// This is primarily for use from the debugger; please don't delete me just
-/// because there aren't any current callers.
-void goto_statet::output_propagation_map(std::ostream &out)
-{
-  for(const auto &name_value : propagation)
-  {
-    out << name_value.first << " <- " << format(name_value.second) << "\n";
-  }
-}

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -22,60 +22,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/std_expr.h>
 #include <util/ssa_expr.h>
 #include <util/make_unique.h>
-
-#include <pointer-analysis/value_set.h>
 #include <goto-programs/goto_function.h>
 
+#include "goto_state.h"
 #include "renaming_level.h"
 #include "symex_target_equation.h"
-
-/// Container for data that varies per program point, e.g. the constant
-/// propagator state, when state needs to branch. This is copied out of
-/// goto_symex_statet at a control-flow fork and then back into it at a
-/// control-flow merge.
-class goto_statet
-{
-public:
-  /// Distance from entry
-  unsigned depth = 0;
-
-  symex_level2t level2;
-
-  /// Uses level 1 names, and is used to do dereferencing
-  value_sett value_set;
-
-  // A guard is a particular condition that has to pass for an instruction
-  // to be executed. The easiest example is an if/else: each instruction along
-  // the if branch will be guarded by the condition of the if (and if there
-  // is an else branch then instructions on it will be guarded by the negation
-  // of the condition of the if).
-  guardt guard{true_exprt{}};
-
-  symex_targett::sourcet source;
-
-  // Map L1 names to (L2) constants. Values will be evicted from this map
-  // when they become non-constant. This is used to propagate values that have
-  // been worked out to only have one possible value.
-  //
-  // "constants" can include symbols, but only in the context of an address-of
-  // op (i.e. &x can be propagated), and an address-taken thing should only be
-  // L1.
-  std::map<irep_idt, exprt> propagation;
-
-  void output_propagation_map(std::ostream &);
-
-  /// Threads
-  unsigned atomic_section_id = 0;
-
-  unsigned total_vccs = 0;
-  unsigned remaining_vccs = 0;
-
-  /// Constructors
-  explicit goto_statet(const class goto_symex_statet &s);
-  explicit goto_statet(const symex_targett::sourcet &_source) : source(_source)
-  {
-  }
-};
 
 // stack frames -- these are used for function calls and
 // for exceptions

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -24,46 +24,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/make_unique.h>
 #include <goto-programs/goto_function.h>
 
+#include "frame.h"
 #include "goto_state.h"
 #include "renaming_level.h"
 #include "symex_target_equation.h"
-
-// stack frames -- these are used for function calls and
-// for exceptions
-struct framet
-{
-  // gotos
-  using goto_state_listt = std::list<goto_statet>;
-
-  // function calls
-  irep_idt function_identifier;
-  std::map<goto_programt::const_targett, goto_state_listt> goto_state_map;
-  symex_targett::sourcet calling_location;
-
-  goto_programt::const_targett end_of_function;
-  exprt return_value = nil_exprt();
-  bool hidden_function = false;
-
-  symex_renaming_levelt::current_namest old_level1;
-
-  std::set<irep_idt> local_objects;
-
-  // exceptions
-  std::map<irep_idt, goto_programt::targett> catch_map;
-
-  // loop and recursion unwinding
-  struct loop_infot
-  {
-    unsigned count = 0;
-    bool is_recursion = false;
-  };
-  std::unordered_map<irep_idt, loop_infot> loop_iterations;
-
-  explicit framet(symex_targett::sourcet _calling_location)
-    : calling_location(std::move(_calling_location))
-  {
-  }
-};
 
 /// \brief Central data structure: state.
 ///


### PR DESCRIPTION
No functional changes.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [na] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
