### PR TITLE
MSVC build fixes

### DIFF
--- a/src/ansi-c/CMakeLists.txt
+++ b/src/ansi-c/CMakeLists.txt
@@ -50,9 +50,11 @@ add_custom_command(
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-add_custom_target(c_library_check
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/library-check.stamp
+if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    add_custom_target(c_library_check
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/library-check.stamp
 )
+endif()
 
 ################################################################################
 
@@ -101,6 +103,12 @@ set(extra_dependencies
     ${CMAKE_CURRENT_BINARY_DIR}/windows_builtin_headers.inc
     ${CMAKE_CURRENT_BINARY_DIR}/library-check.stamp
 )
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    list(REMOVE_ITEM
+         extra_dependencies
+         ${CMAKE_CURRENT_BINARY_DIR}/library-check.stamp)
+endif()
 
 file(GLOB_RECURSE sources "*.cpp" "*.h")
 

--- a/src/ansi-c/library_check.sh
+++ b/src/ansi-c/library_check.sh
@@ -10,8 +10,8 @@ for f in "$@"; do
     perl -p -i -e 's/(_mm_.fence)/s$1/' __libcheck.c
     perl -p -i -e 's/(__sync_)/s$1/' __libcheck.c
     perl -p -i -e 's/(__noop)/s$1/' __libcheck.c
-    $CC -std=gnu99 -E -include library/cprover.h -D__CPROVER_bool=_Bool -D__CPROVER_thread_local=__thread -DLIBRARY_CHECK -o __libcheck.i __libcheck.c
-    $CC -S -Wall -Werror -pedantic -Wextra -std=gnu99 __libcheck.i -o __libcheck.s -Wno-unused-label
+    "$CC" -std=gnu99 -E -include library/cprover.h -D__CPROVER_bool=_Bool -D__CPROVER_thread_local=__thread -DLIBRARY_CHECK -o __libcheck.i __libcheck.c
+    "$CC" -S -Wall -Werror -pedantic -Wextra -std=gnu99 __libcheck.i -o __libcheck.s -Wno-unused-label
     ec="${?}"
     rm __libcheck.s __libcheck.i __libcheck.c
     [ "${ec}" -eq 0 ] || exit "${ec}"

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -22,9 +22,11 @@ add_custom_command(
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
+if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 add_custom_target(cpp_library_check
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/library-check.stamp
 )
+endif()
 
 ################################################################################
 

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -23,8 +23,8 @@ add_custom_command(
 )
 
 if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-add_custom_target(cpp_library_check
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/library-check.stamp
+    add_custom_target(cpp_library_check
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/library-check.stamp
 )
 endif()
 


### PR DESCRIPTION
These patches enable CBMC to be built using the MSVC compiler, under the Visual Studio developer console, using CMake---no cygwin or mingw. There are warnings galore, but it does build.

I don't know whether we're actually intending to support this particular build configuration; if so, it's probably a good idea to add it to CI. I don't have time to do this right now, but if there's interest, I'll add it as the ωth item on my backlog...