### PR TITLE
 Make simplify_expr take copy instead of reference

### DIFF
--- a/src/analyses/ai_domain.cpp
+++ b/src/analyses/ai_domain.cpp
@@ -48,7 +48,7 @@ bool ai_domain_baset::ai_simplify_lhs(exprt &condition, const namespacet &ns)
     index_exprt ie = to_index_expr(condition);
     bool no_simplification = ai_simplify(ie.index(), ns);
     if(!no_simplification)
-      condition = simplify_expr(ie, ns);
+      condition = simplify_expr(std::move(ie), ns);
 
     return no_simplification;
   }
@@ -57,7 +57,7 @@ bool ai_domain_baset::ai_simplify_lhs(exprt &condition, const namespacet &ns)
     dereference_exprt de = to_dereference_expr(condition);
     bool no_simplification = ai_simplify(de.pointer(), ns);
     if(!no_simplification)
-      condition = simplify_expr(de, ns); // So *(&x) -> x
+      condition = simplify_expr(std::move(de), ns); // So *(&x) -> x
 
     return no_simplification;
   }
@@ -70,7 +70,7 @@ bool ai_domain_baset::ai_simplify_lhs(exprt &condition, const namespacet &ns)
     // must also be addressable
     bool no_simplification = ai_simplify_lhs(me.compound(), ns);
     if(!no_simplification)
-      condition = simplify_expr(me, ns);
+      condition = simplify_expr(std::move(me), ns);
 
     return no_simplification;
   }

--- a/src/analyses/custom_bitvector_analysis.cpp
+++ b/src/analyses/custom_bitvector_analysis.cpp
@@ -529,8 +529,7 @@ void custom_bitvector_domaint::transform(
       if(to!=from->get_target())
         guard = boolean_negate(guard);
 
-      exprt result=eval(guard, cba);
-      exprt result2=simplify_expr(result, ns);
+      const exprt result2 = simplify_expr(eval(guard, cba), ns);
 
       if(result2.is_false())
         make_bottom();
@@ -787,7 +786,7 @@ void custom_bitvector_analysist::check(
 
         exprt tmp = eval(i_it->get_condition(), i_it);
         const namespacet ns(goto_model.symbol_table);
-        result=simplify_expr(tmp, ns);
+        result = simplify_expr(std::move(tmp), ns);
 
         description=i_it->source_location.get_comment();
       }

--- a/src/goto-analyzer/taint_analysis.cpp
+++ b/src/goto-analyzer/taint_analysis.cpp
@@ -343,9 +343,7 @@ bool taint_analysist::operator()(
 
         exprt result =
           custom_bitvector_analysis.eval(i_it->get_condition(), i_it);
-        exprt result2=simplify_expr(result, ns);
-
-        if(result2.is_true())
+        if(simplify_expr(std::move(result), ns).is_true())
           continue;
 
         if(first)

--- a/src/goto-instrument/accelerate/acceleration_utils.cpp
+++ b/src/goto-instrument/accelerate/acceleration_utils.cpp
@@ -1120,13 +1120,13 @@ bool acceleration_utilst::assign_array(
   {
     replace_expr(
       loop_counter, from_integer(0, loop_counter.type()), lower_bound);
-    simplify_expr(lower_bound, ns);
+    lower_bound = simplify_expr(std::move(lower_bound), ns);
   }
   else
   {
     replace_expr(
       loop_counter, from_integer(0, loop_counter.type()), upper_bound);
-    simplify_expr(upper_bound, ns);
+    upper_bound = simplify_expr(std::move(upper_bound), ns);
   }
 
   if(stride==0)

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -1012,7 +1012,7 @@ exprt lower_byte_extract(const byte_extract_exprt &src, const namespacet &ns)
     }
 
     if(!failed)
-      return simplify_expr(s, ns);
+      return simplify_expr(std::move(s), ns);
   }
   else if(src.type().id() == ID_union || src.type().id() == ID_union_tag)
   {
@@ -1183,7 +1183,7 @@ static exprt lower_byte_update_byte_array_vector(
       result.add_to_operands(where, update_value);
   }
 
-  return simplify_expr(result, ns);
+  return simplify_expr(std::move(result), ns);
 }
 
 /// Apply a byte update \p src to an array/vector typed operand, using the byte
@@ -1328,7 +1328,7 @@ static exprt lower_byte_update_array_vector_non_const(
     result.add_to_operands(std::move(where), std::move(element));
   }
 
-  return simplify_expr(result, ns);
+  return simplify_expr(std::move(result), ns);
 }
 
 /// Apply a byte update \p src to an array/vector typed operand using the byte

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2574,9 +2574,8 @@ bool simplify(exprt &expr, const namespacet &ns)
   return simplify_exprt(ns).simplify(expr);
 }
 
-exprt simplify_expr(const exprt &src, const namespacet &ns)
+exprt simplify_expr(exprt src, const namespacet &ns)
 {
-  exprt tmp=src;
-  simplify_exprt(ns).simplify(tmp);
-  return tmp;
+  simplify_exprt(ns).simplify(src);
+  return src;
 }

--- a/src/util/simplify_expr.h
+++ b/src/util/simplify_expr.h
@@ -25,6 +25,6 @@ bool simplify(
   const namespacet &ns);
 
 // this is the preferred interface
-exprt simplify_expr(const exprt &src, const namespacet &ns);
+exprt simplify_expr(exprt src, const namespacet &ns);
 
 #endif // CPROVER_UTIL_SIMPLIFY_EXPR_H

--- a/unit/solvers/strings/string_constraint_generator_valueof/is_digit_with_radix.cpp
+++ b/unit/solvers/strings/string_constraint_generator_valueof/is_digit_with_radix.cpp
@@ -29,7 +29,9 @@ static exprt actual(
   const namespacet ns(symtab);
 
   return simplify_expr(
-    is_digit_with_radix(chr, strict_formatting, radix_as_char, radix_ul), ns);
+    is_digit_with_radix(
+      std::move(chr), strict_formatting, radix_as_char, radix_ul),
+    ns);
 }
 
 /// Get the simplified return value of is_digit_with_radix called with a radix


### PR DESCRIPTION
The implementation would make a copy of the argument anyway.
This makes it explicit in the type and allow the use of move by the
caller which avoids a copy.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
