### PR TITLE
Extract call_stackt class from goto_symex_statet [depends-on: #4294]

### DIFF
--- a/jbmc/src/java_bytecode/java_bmc_util.cpp
+++ b/jbmc/src/java_bytecode/java_bmc_util.cpp
@@ -28,7 +28,7 @@ void java_setup_symex(
     //  for some reason)
     symex.add_loop_unwind_handler(
       [&goto_model](
-        const goto_symex_statet::call_stackt &context,
+        const call_stackt &context,
         unsigned loop_num,
         unsigned unwind,
         unsigned &max_unwind)

--- a/jbmc/src/java_bytecode/java_enum_static_init_unwind_handler.cpp
+++ b/jbmc/src/java_bytecode/java_enum_static_init_unwind_handler.cpp
@@ -24,8 +24,7 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 /// \param context: the current call stack
 /// \return the name of an enclosing function that may be defined on the
 ///   relevant enum type, or an empty string if we don't find one.
-static irep_idt
-find_enum_function_on_stack(const goto_symex_statet::call_stackt &context)
+static irep_idt find_enum_function_on_stack(const call_stackt &context)
 {
   static irep_idt reference_array_clone_id =
     "java::array[reference].clone:()Ljava/lang/Object;";
@@ -64,7 +63,7 @@ find_enum_function_on_stack(const goto_symex_statet::call_stackt &context)
 ///   unwind_count is <= the enumeration size, or unknown (defer / no decision)
 ///   otherwise.
 tvt java_enum_static_init_unwind_handler(
-  const goto_symex_statet::call_stackt &context,
+  const call_stackt &context,
   unsigned loop_number,
   unsigned unwind_count,
   unsigned &unwind_max,

--- a/jbmc/src/java_bytecode/java_enum_static_init_unwind_handler.h
+++ b/jbmc/src/java_bytecode/java_enum_static_init_unwind_handler.h
@@ -18,7 +18,7 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 #include <util/threeval.h>
 
 tvt java_enum_static_init_unwind_handler(
-  const goto_symex_statet::call_stackt &context,
+  const call_stackt &context,
   unsigned loop_number,
   unsigned unwind_count,
   unsigned &unwind_max,

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -514,7 +514,7 @@ int jbmc_parse_optionst::doit()
     configure_bmc = [](bmct &bmc, const symbol_tablet &symbol_table) {
       bmc.add_loop_unwind_handler(
         [&symbol_table](
-          const goto_symex_statet::call_stackt &context,
+          const call_stackt &context,
           unsigned loop_number,
           unsigned unwind,
           unsigned &max_unwind) {

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -511,17 +511,17 @@ int jbmc_parse_optionst::doit()
   std::function<void(bmct &, const symbol_tablet &)> configure_bmc = nullptr;
   if(options.get_bool_option("java-unwind-enum-static"))
   {
-    configure_bmc = [](bmct &bmc, const symbol_tablet &symbol_table) {
-      bmc.add_loop_unwind_handler(
-        [&symbol_table](
-          const call_stackt &context,
-          unsigned loop_number,
-          unsigned unwind,
-          unsigned &max_unwind) {
+    configure_bmc =
+      [](bmct &bmc, const symbol_tablet &symbol_table) {
+        bmc.add_loop_unwind_handler([&symbol_table](
+                                      const call_stackt &context,
+                                      unsigned loop_number,
+                                      unsigned unwind,
+                                      unsigned &max_unwind) {
           return java_enum_static_init_unwind_handler(
             context, loop_number, unwind, max_unwind, symbol_table);
         });
-    };
+      };
   }
 
   object_factory_params.set(options);

--- a/src/goto-checker/symex_bmc.cpp
+++ b/src/goto-checker/symex_bmc.cpp
@@ -105,7 +105,7 @@ void symex_bmct::merge_goto(goto_statet &&goto_state, statet &state)
 
 bool symex_bmct::should_stop_unwind(
   const symex_targett::sourcet &source,
-  const goto_symex_statet::call_stackt &context,
+  const call_stackt &context,
   unsigned unwind)
 {
   const irep_idt id = goto_programt::loop_id(source.function_id, *source.pc);

--- a/src/goto-checker/symex_bmc.h
+++ b/src/goto-checker/symex_bmc.h
@@ -42,7 +42,7 @@ public:
   /// enforced. They return true to halt unwinding, false to authorise
   /// unwinding, or Unknown to indicate they have no opinion.
   typedef std::function<
-    tvt(const goto_symex_statet::call_stackt &, unsigned, unsigned, unsigned &)>
+    tvt(const call_stackt &, unsigned, unsigned, unsigned &)>
     loop_unwind_handlert;
 
   /// Recursion unwind handlers take the function ID, the unwind count so far,
@@ -98,7 +98,7 @@ protected:
 
   bool should_stop_unwind(
     const symex_targett::sourcet &source,
-    const goto_symex_statet::call_stackt &context,
+    const call_stackt &context,
     unsigned unwind) override;
 
   bool get_unwind_recursion(

--- a/src/goto-symex/Makefile
+++ b/src/goto-symex/Makefile
@@ -1,5 +1,6 @@
 SRC = auto_objects.cpp \
       build_goto_trace.cpp \
+      goto_state.cpp \
       goto_symex.cpp \
       goto_symex_state.cpp \
       memory_model.cpp \

--- a/src/goto-symex/call_stack.h
+++ b/src/goto-symex/call_stack.h
@@ -1,0 +1,46 @@
+/*******************************************************************\
+
+Module: Symbolic Execution
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_GOTO_SYMEX_CALL_STACK_H
+#define CPROVER_GOTO_SYMEX_CALL_STACK_H
+
+#include "frame.h"
+
+class call_stackt : public std::vector<framet>
+{
+public:
+  framet &top()
+  {
+    PRECONDITION(!empty());
+    return back();
+  }
+
+  const framet &top() const
+  {
+    PRECONDITION(!empty());
+    return back();
+  }
+
+  framet &new_frame(symex_targett::sourcet calling_location)
+  {
+    emplace_back(calling_location);
+    return back();
+  }
+
+  void pop()
+  {
+    pop_back();
+  }
+
+  const framet &previous_frame()
+  {
+    return *(--(--end()));
+  }
+};
+
+#endif // CPROVER_GOTO_SYMEX_CALL_STACK_H

--- a/src/goto-symex/call_stack.h
+++ b/src/goto-symex/call_stack.h
@@ -34,6 +34,7 @@ public:
 
   void pop()
   {
+    PRECONDITION(!empty());
     pop_back();
   }
 

--- a/src/goto-symex/frame.h
+++ b/src/goto-symex/frame.h
@@ -1,0 +1,54 @@
+/*******************************************************************\
+
+Module: Symbolic Execution
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+/// \file
+/// Class for stack frames
+
+#ifndef CPROVER_GOTO_SYMEX_FRAME_H
+#define CPROVER_GOTO_SYMEX_FRAME_H
+
+#include "goto_state.h"
+
+/// Stack frames -- these are used for function calls and for exceptions
+struct framet
+{
+  // gotos
+  using goto_state_listt = std::list<goto_statet>;
+
+  // function calls
+  irep_idt function_identifier;
+  std::map<goto_programt::const_targett, goto_state_listt> goto_state_map;
+  symex_targett::sourcet calling_location;
+
+  goto_programt::const_targett end_of_function;
+  exprt return_value = nil_exprt();
+  bool hidden_function = false;
+
+  symex_renaming_levelt::current_namest old_level1;
+
+  std::set<irep_idt> local_objects;
+
+  // exceptions
+  std::map<irep_idt, goto_programt::targett> catch_map;
+
+  // loop and recursion unwinding
+  struct loop_infot
+  {
+    unsigned count = 0;
+    bool is_recursion = false;
+  };
+
+  std::unordered_map<irep_idt, loop_infot> loop_iterations;
+
+  explicit framet(symex_targett::sourcet _calling_location)
+    : calling_location(std::move(_calling_location))
+  {
+  }
+};
+
+#endif // CPROVER_GOTO_SYMEX_FRAME_H

--- a/src/goto-symex/goto_state.cpp
+++ b/src/goto-symex/goto_state.cpp
@@ -1,0 +1,22 @@
+/*******************************************************************\
+
+Module: Symbolic Execution
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+#include "goto_state.h"
+
+#include <util/format_expr.h>
+
+/// Print the constant propagation map in a human-friendly format.
+/// This is primarily for use from the debugger; please don't delete me just
+/// because there aren't any current callers.
+void goto_statet::output_propagation_map(std::ostream &out)
+{
+  for(const auto &name_value : propagation)
+  {
+    out << name_value.first << " <- " << format(name_value.second) << "\n";
+  }
+}

--- a/src/goto-symex/goto_state.h
+++ b/src/goto-symex/goto_state.h
@@ -1,0 +1,70 @@
+/*******************************************************************\
+
+Module: Symbolic Execution
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+/// \file
+/// goto_statet class definition
+
+#ifndef CPROVER_GOTO_SYMEX_GOTO_STATE_H
+#define CPROVER_GOTO_SYMEX_GOTO_STATE_H
+
+#include <analyses/local_safe_pointers.h>
+#include <pointer-analysis/value_set.h>
+#include <util/guard.h>
+
+#include "renaming_level.h"
+#include "symex_target_equation.h"
+
+/// Container for data that varies per program point, e.g. the constant
+/// propagator state, when state needs to branch. This is copied out of
+/// goto_symex_statet at a control-flow fork and then back into it at a
+/// control-flow merge.
+class goto_statet
+{
+public:
+  /// Distance from entry
+  unsigned depth = 0;
+
+  symex_level2t level2;
+
+  /// Uses level 1 names, and is used to do dereferencing
+  value_sett value_set;
+
+  // A guard is a particular condition that has to pass for an instruction
+  // to be executed. The easiest example is an if/else: each instruction along
+  // the if branch will be guarded by the condition of the if (and if there
+  // is an else branch then instructions on it will be guarded by the negation
+  // of the condition of the if).
+  guardt guard{true_exprt{}};
+
+  symex_targett::sourcet source;
+
+  // Map L1 names to (L2) constants. Values will be evicted from this map
+  // when they become non-constant. This is used to propagate values that have
+  // been worked out to only have one possible value.
+  //
+  // "constants" can include symbols, but only in the context of an address-of
+  // op (i.e. &x can be propagated), and an address-taken thing should only be
+  // L1.
+  std::map<irep_idt, exprt> propagation;
+
+  void output_propagation_map(std::ostream &);
+
+  /// Threads
+  unsigned atomic_section_id = 0;
+
+  unsigned total_vccs = 0;
+  unsigned remaining_vccs = 0;
+
+  /// Constructors
+  explicit goto_statet(const class goto_symex_statet &s);
+  explicit goto_statet(const symex_targett::sourcet &_source) : source(_source)
+  {
+  }
+};
+
+#endif // CPROVER_GOTO_SYMEX_GOTO_STATE_H

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -345,7 +345,7 @@ protected:
   /// \return true indicates abort, with false we continue
   virtual bool should_stop_unwind(
     const symex_targett::sourcet &source,
-    const goto_symex_statet::call_stackt &context,
+    const call_stackt &context,
     unsigned unwind);
 
   virtual void loop_bound_exceeded(statet &state, const exprt &guard);

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -785,14 +785,3 @@ void goto_symex_statet::print_backtrace(std::ostream &out) const
         << frame.calling_location.pc->location_number << "\n";
   }
 }
-
-/// Print the constant propagation map in a human-friendly format.
-/// This is primarily for use from the debugger; please don't delete me just
-/// because there aren't any current callers.
-void goto_statet::output_propagation_map(std::ostream &out)
-{
-  for(const auto &name_value : propagation)
-  {
-    out << name_value.first << " <- " << format(name_value.second) << "\n";
-  }
-}

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -33,7 +33,7 @@ goto_symex_statet::goto_symex_statet(const symex_targett::sourcet &_source)
   : goto_statet(_source), symex_target(nullptr), record_events(true), dirty()
 {
   threads.resize(1);
-  new_frame();
+  call_stack().new_frame(source);
 }
 
 goto_symex_statet::~goto_symex_statet()=default;

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -22,60 +22,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/std_expr.h>
 #include <util/ssa_expr.h>
 #include <util/make_unique.h>
-
-#include <pointer-analysis/value_set.h>
 #include <goto-programs/goto_function.h>
 
+#include "goto_state.h"
 #include "renaming_level.h"
 #include "symex_target_equation.h"
-
-/// Container for data that varies per program point, e.g. the constant
-/// propagator state, when state needs to branch. This is copied out of
-/// goto_symex_statet at a control-flow fork and then back into it at a
-/// control-flow merge.
-class goto_statet
-{
-public:
-  /// Distance from entry
-  unsigned depth = 0;
-
-  symex_level2t level2;
-
-  /// Uses level 1 names, and is used to do dereferencing
-  value_sett value_set;
-
-  // A guard is a particular condition that has to pass for an instruction
-  // to be executed. The easiest example is an if/else: each instruction along
-  // the if branch will be guarded by the condition of the if (and if there
-  // is an else branch then instructions on it will be guarded by the negation
-  // of the condition of the if).
-  guardt guard{true_exprt{}};
-
-  symex_targett::sourcet source;
-
-  // Map L1 names to (L2) constants. Values will be evicted from this map
-  // when they become non-constant. This is used to propagate values that have
-  // been worked out to only have one possible value.
-  //
-  // "constants" can include symbols, but only in the context of an address-of
-  // op (i.e. &x can be propagated), and an address-taken thing should only be
-  // L1.
-  std::map<irep_idt, exprt> propagation;
-
-  void output_propagation_map(std::ostream &);
-
-  /// Threads
-  unsigned atomic_section_id = 0;
-
-  unsigned total_vccs = 0;
-  unsigned remaining_vccs = 0;
-
-  /// Constructors
-  explicit goto_statet(const class goto_symex_statet &s);
-  explicit goto_statet(const symex_targett::sourcet &_source) : source(_source)
-  {
-  }
-};
 
 // stack frames -- these are used for function calls and
 // for exceptions

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -127,9 +127,6 @@ protected:
   l1_typest l1_types;
 
 public:
-  // gotos
-  typedef std::list<goto_statet> goto_state_listt;
-
   // guards
   static irep_idt guard_identifier()
   {

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -24,6 +24,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/make_unique.h>
 #include <goto-programs/goto_function.h>
 
+#include "call_stack.h"
 #include "frame.h"
 #include "goto_state.h"
 #include "renaming_level.h"
@@ -136,8 +137,6 @@ public:
     return id;
   }
 
-  typedef std::vector<framet> call_stackt;
-
   call_stackt &call_stack()
   {
     PRECONDITION(source.thread_nr < threads.size());
@@ -149,28 +148,6 @@ public:
     PRECONDITION(source.thread_nr < threads.size());
     return threads[source.thread_nr].call_stack;
   }
-
-  framet &top()
-  {
-    PRECONDITION(!call_stack().empty());
-    return call_stack().back();
-  }
-
-  const framet &top() const
-  {
-    PRECONDITION(!call_stack().empty());
-    return call_stack().back();
-  }
-
-  framet &new_frame()
-  {
-    call_stack().emplace_back(source);
-    return top();
-  }
-
-  void pop_frame() { call_stack().pop_back(); }
-
-  const framet &previous_frame() { return *(--(--call_stack().end())); }
 
   void print_backtrace(std::ostream &) const;
 

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -24,46 +24,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/make_unique.h>
 #include <goto-programs/goto_function.h>
 
+#include "frame.h"
 #include "goto_state.h"
 #include "renaming_level.h"
 #include "symex_target_equation.h"
-
-// stack frames -- these are used for function calls and
-// for exceptions
-struct framet
-{
-  // gotos
-  using goto_state_listt = std::list<goto_statet>;
-
-  // function calls
-  irep_idt function_identifier;
-  std::map<goto_programt::const_targett, goto_state_listt> goto_state_map;
-  symex_targett::sourcet calling_location;
-
-  goto_programt::const_targett end_of_function;
-  exprt return_value = nil_exprt();
-  bool hidden_function = false;
-
-  symex_renaming_levelt::current_namest old_level1;
-
-  std::set<irep_idt> local_objects;
-
-  // exceptions
-  std::map<irep_idt, goto_programt::targett> catch_map;
-
-  // loop and recursion unwinding
-  struct loop_infot
-  {
-    unsigned count = 0;
-    bool is_recursion = false;
-  };
-  std::unordered_map<irep_idt, loop_infot> loop_iterations;
-
-  explicit framet(symex_targett::sourcet _calling_location)
-    : calling_location(std::move(_calling_location))
-  {
-  }
-};
 
 /// \brief Central data structure: state.
 ///

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -65,7 +65,7 @@ void goto_symext::symex_assign(statet &state, const code_assignt &code)
       assignment_type=symex_targett::assignment_typet::HIDDEN;
 
     // We hide if we are in a hidden function.
-    if(state.top().hidden_function)
+    if(state.call_stack().top().hidden_function)
       assignment_type=symex_targett::assignment_typet::HIDDEN;
 
     // We hide if we are executing a hidden instruction.

--- a/src/goto-symex/symex_decl.cpp
+++ b/src/goto-symex/symex_decl.cpp
@@ -78,10 +78,9 @@ void goto_symext::symex_decl(statet &state, const symbol_exprt &expr)
 
   // we hide the declaration of auxiliary variables
   // and if the statement itself is hidden
-  bool hidden=
-    ns.lookup(expr.get_identifier()).is_auxiliary ||
-    state.top().hidden_function ||
-    state.source.pc->source_location.get_hide();
+  bool hidden = ns.lookup(expr.get_identifier()).is_auxiliary ||
+                state.call_stack().top().hidden_function ||
+                state.source.pc->source_location.get_hide();
 
   target.decl(
     state.guard.as_expr(),

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -53,7 +53,7 @@ void symex_transition(
     // 1. the transition from state.source.pc to "to" is not a backwards goto
     // or
     // 2. we are arriving from an outer loop
-    framet &frame = state.top();
+    framet &frame = state.call_stack().top();
     const goto_programt::instructiont &instruction=*to;
     for(const auto &i_e : instruction.incoming_edges)
       if(i_e->is_goto() && i_e->is_backwards_goto() &&
@@ -257,7 +257,7 @@ void goto_symext::symex_with_state(
   // as state.symbol_table might go out of scope
   reset_namespacet reset_ns(ns);
 
-  PRECONDITION(state.top().end_of_function->is_end_function());
+  PRECONDITION(state.call_stack().top().end_of_function->is_end_function());
 
   symex_threaded_step(state, get_goto_function);
   if(should_pause_symex)
@@ -323,9 +323,10 @@ std::unique_ptr<goto_symext::statet> goto_symext::initialize_entry_point_state(
 
   goto_programt::const_targett limit =
     std::prev(start_function->body.instructions.end());
-  state->top().end_of_function = limit;
-  state->top().calling_location.pc = state->top().end_of_function;
-  state->top().hidden_function = start_function->is_hidden();
+  state->call_stack().top().end_of_function = limit;
+  state->call_stack().top().calling_location.pc =
+    state->call_stack().top().end_of_function;
+  state->call_stack().top().hidden_function = start_function->is_hidden();
 
   state->symex_target = &target;
 

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -42,7 +42,7 @@ void goto_symext::symex_start_thread(statet &state)
   statet::threadt &new_thread=state.threads.back();
   new_thread.pc=thread_target;
   new_thread.guard=state.guard;
-  new_thread.call_stack.push_back(state.top());
+  new_thread.call_stack.push_back(state.call_stack().top());
   new_thread.call_stack.back().local_objects.clear();
   new_thread.call_stack.back().goto_state_map.clear();
   #if 0
@@ -50,7 +50,7 @@ void goto_symext::symex_start_thread(statet &state)
   #endif
 
   // create a copy of the local variables for the new thread
-  framet &frame = state.top();
+  framet &frame = state.call_stack().top();
 
   for(auto c_it = state.level2.current_names.begin();
       c_it != state.level2.current_names.end();


### PR DESCRIPTION
No functional changes.

This is based on  https://github.com/diffblue/cbmc/pull/4294

Extract a `call_stackt` class from `goto_symex_statet` to declutter the
class definition.
This makes some calls a bit more verbose, but can be clearer.
For instance, it is not obvious what `top()` represent in the context of
goto_symex_state, whereas `call_stack().top()` is more explicit.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
