### PR TITLE
Deprecate link_to_library(goto_functions, symbol_table, ...) [blocks: #4296]

### DIFF
--- a/src/goto-programs/link_to_library.h
+++ b/src/goto-programs/link_to_library.h
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <functional>
 #include <set>
 
+#include <util/deprecate.h>
 #include <util/irep.h>
 
 class goto_functionst;
@@ -22,6 +23,7 @@ class goto_modelt;
 class message_handlert;
 class symbol_tablet;
 
+DEPRECATED("Use link_to_library(goto_model, ...) instead")
 void link_to_library(
   symbol_tablet &,
   goto_functionst &,


### PR DESCRIPTION
There are no in-tree uses of this function. External users should use
link_to_library(goto_model, ...). This is in preparation of further changes that
will only support the goto_modelt-variant.

This is the more consumer-friendly variant of #4296, which works equally well until the dependencies of #4296 come into effect.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
