### PR TITLE
Introduce a renamedt type for renamed expressions in symex

### DIFF
--- a/src/goto-instrument/accelerate/scratch_program.cpp
+++ b/src/goto-instrument/accelerate/scratch_program.cpp
@@ -69,7 +69,7 @@ bool scratch_programt::check_sat(bool do_slice)
 
 exprt scratch_programt::eval(const exprt &e)
 {
-  return checker->get(symex_state->rename<goto_symex_statet::L2>(e, ns));
+  return checker->get(symex_state->rename<L2>(e, ns));
 }
 
 void scratch_programt::append(goto_programt::instructionst &new_instructions)

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -250,9 +250,9 @@ void goto_symex_statet::set_l1_indices(
     return;
   if(!ssa_expr.get_level_1().empty())
     return;
-  renamedt<ssa_exprt, L0> l0 =
-    level0(std::move(ssa_expr), ns, source.thread_nr);
-  ssa_expr = level1(l0.get());
+  renamedt<ssa_exprt, L1> l1 =
+    level1(level0(std::move(ssa_expr), ns, source.thread_nr));
+  ssa_expr = l1.get();
 }
 
 void goto_symex_statet::set_l2_indices(
@@ -261,10 +261,9 @@ void goto_symex_statet::set_l2_indices(
 {
   if(!ssa_expr.get_level_2().empty())
     return;
-  renamedt<ssa_exprt, L0> l0 =
-    level0(std::move(ssa_expr), ns, source.thread_nr);
-  ssa_exprt l1 = level1(l0.get());
-  ssa_expr = level2(std::move(l1));
+  renamedt<ssa_exprt, L1> l1 =
+    level1(level0(std::move(ssa_expr), ns, source.thread_nr);
+  ssa_expr = level2(l1.get());
 }
 
 template <levelt level>

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -261,9 +261,9 @@ void goto_symex_statet::set_l2_indices(
 {
   if(!ssa_expr.get_level_2().empty())
     return;
-  renamedt<ssa_exprt, L1> l1 =
-    level1(level0(std::move(ssa_expr), ns, source.thread_nr);
-  ssa_expr = level2(l1.get());
+  renamedt<ssa_exprt, L2> l2 =
+    level2(level1(level0(std::move(ssa_expr), ns, source.thread_nr)));
+  ssa_expr = l2.get();
 }
 
 template <levelt level>
@@ -287,6 +287,8 @@ ssa_exprt goto_symex_statet::rename_ssa(ssa_exprt ssa, const namespacet &ns)
 /// Ensure `rename_ssa` gets compiled for L0
 template ssa_exprt
 goto_symex_statet::rename_ssa<L0>(ssa_exprt ssa, const namespacet &ns);
+template ssa_exprt
+goto_symex_statet::rename_ssa<L1>(ssa_exprt ssa, const namespacet &ns);
 
 template <levelt level>
 exprt goto_symex_statet::rename(exprt expr, const namespacet &ns)
@@ -368,6 +370,8 @@ exprt goto_symex_statet::rename(exprt expr, const namespacet &ns)
   }
   return expr;
 }
+
+template exprt goto_symex_statet::rename<L1>(exprt expr, const namespacet &ns);
 
 /// thread encoding
 bool goto_symex_statet::l2_thread_read_encoding(

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -260,7 +260,7 @@ void goto_symex_statet::set_l2_indices(
     return;
   level0(ssa_expr, ns, source.thread_nr);
   level1(ssa_expr);
-  ssa_expr.set_level_2(level2.current_count(ssa_expr.get_identifier()));
+  level2(ssa_expr);
 }
 
 template <goto_symex_statet::levelt level>

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -237,7 +237,9 @@ void goto_symex_statet::set_l0_indices(
   ssa_exprt &ssa_expr,
   const namespacet &ns)
 {
-  ssa_expr = level0(std::move(ssa_expr), ns, source.thread_nr);
+  renamedt<ssa_exprt, L0> renamed =
+    level0(std::move(ssa_expr), ns, source.thread_nr);
+  ssa_expr = renamed.get();
 }
 
 void goto_symex_statet::set_l1_indices(
@@ -248,8 +250,9 @@ void goto_symex_statet::set_l1_indices(
     return;
   if(!ssa_expr.get_level_1().empty())
     return;
-  ssa_exprt l0 = level0(std::move(ssa_expr), ns, source.thread_nr);
-  ssa_expr = level1(std::move(l0));
+  renamedt<ssa_exprt, L0> l0 =
+    level0(std::move(ssa_expr), ns, source.thread_nr);
+  ssa_expr = level1(l0.get());
 }
 
 void goto_symex_statet::set_l2_indices(
@@ -258,8 +261,9 @@ void goto_symex_statet::set_l2_indices(
 {
   if(!ssa_expr.get_level_2().empty())
     return;
-  ssa_exprt l0 = level0(std::move(ssa_expr), ns, source.thread_nr);
-  ssa_exprt l1 = level1(std::move(l0));
+  renamedt<ssa_exprt, L0> l0 =
+    level0(std::move(ssa_expr), ns, source.thread_nr);
+  ssa_exprt l1 = level1(l0.get());
   ssa_expr = level2(std::move(l1));
 }
 

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -237,7 +237,7 @@ void goto_symex_statet::set_l0_indices(
   ssa_exprt &ssa_expr,
   const namespacet &ns)
 {
-  level0(ssa_expr, ns, source.thread_nr);
+  ssa_expr = level0(std::move(ssa_expr), ns, source.thread_nr);
 }
 
 void goto_symex_statet::set_l1_indices(
@@ -248,8 +248,8 @@ void goto_symex_statet::set_l1_indices(
     return;
   if(!ssa_expr.get_level_1().empty())
     return;
-  level0(ssa_expr, ns, source.thread_nr);
-  level1(ssa_expr);
+  ssa_exprt l0 = level0(std::move(ssa_expr), ns, source.thread_nr);
+  ssa_expr = level1(std::move(l0));
 }
 
 void goto_symex_statet::set_l2_indices(
@@ -258,9 +258,9 @@ void goto_symex_statet::set_l2_indices(
 {
   if(!ssa_expr.get_level_2().empty())
     return;
-  level0(ssa_expr, ns, source.thread_nr);
-  level1(ssa_expr);
-  level2(ssa_expr);
+  ssa_exprt l0 = level0(std::move(ssa_expr), ns, source.thread_nr);
+  ssa_exprt l1 = level1(std::move(l0));
+  ssa_expr = level2(std::move(l1));
 }
 
 template <goto_symex_statet::levelt level>

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -263,7 +263,7 @@ void goto_symex_statet::set_l2_indices(
   ssa_expr = level2(std::move(l1));
 }
 
-template <goto_symex_statet::levelt level>
+template <levelt level>
 ssa_exprt goto_symex_statet::rename_ssa(ssa_exprt ssa, const namespacet &ns)
 {
   static_assert(
@@ -282,11 +282,10 @@ ssa_exprt goto_symex_statet::rename_ssa(ssa_exprt ssa, const namespacet &ns)
 }
 
 /// Ensure `rename_ssa` gets compiled for L0
-template ssa_exprt goto_symex_statet::rename_ssa<goto_symex_statet::L0>(
-  ssa_exprt ssa,
-  const namespacet &ns);
+template ssa_exprt
+goto_symex_statet::rename_ssa<L0>(ssa_exprt ssa, const namespacet &ns);
 
-template <goto_symex_statet::levelt level>
+template <levelt level>
 exprt goto_symex_statet::rename(exprt expr, const namespacet &ns)
 {
   // rename all the symbols with their last known value
@@ -544,7 +543,7 @@ bool goto_symex_statet::l2_thread_write_encoding(
   return threads.size()>1;
 }
 
-template <goto_symex_statet::levelt level>
+template <levelt level>
 void goto_symex_statet::rename_address(exprt &expr, const namespacet &ns)
 {
   if(expr.id()==ID_symbol &&
@@ -669,7 +668,7 @@ static bool requires_renaming(const typet &type, const namespacet &ns)
   return false;
 }
 
-template <goto_symex_statet::levelt level>
+template <levelt level>
 void goto_symex_statet::rename(
   typet &type,
   const irep_idt &l1_identifier,

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -150,9 +150,6 @@ public:
   symex_level0t level0;
   symex_level1t level1;
 
-  // Symex renaming levels.
-  enum levelt { L0=0, L1=1, L2=2 };
-
   /// Rewrites symbol expressions in \ref exprt, applying a suffix to each
   /// symbol reflecting its most recent version, which differs depending on
   /// which level you requested. Each level also updates its predecessors, so

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -60,10 +60,11 @@ operator()(renamedt<ssa_exprt, L0> l0_expr) const
   return renamedt<ssa_exprt, L1>{std::move(l0_expr.value)};
 }
 
-ssa_exprt symex_level2t::operator()(ssa_exprt ssa_expr) const
+renamedt<ssa_exprt, L2> symex_level2t::
+operator()(renamedt<ssa_exprt, L1> l1_expr) const
 {
-  ssa_expr.set_level_2(current_count(ssa_expr.get_identifier()));
-  return ssa_expr;
+  l1_expr.value.set_level_2(current_count(l1_expr.get().get_identifier()));
+  return renamedt<ssa_exprt, L2>{std::move(l1_expr.value)};
 }
 
 void symex_level1t::restore_from(

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -43,21 +43,21 @@ operator()(ssa_exprt ssa_expr, const namespacet &ns, unsigned thread_nr) const
   return renamedt<ssa_exprt, L0>{ssa_expr};
 }
 
-ssa_exprt symex_level1t::operator()(ssa_exprt ssa_expr) const
+renamedt<ssa_exprt, L1> symex_level1t::
+operator()(renamedt<ssa_exprt, L0> l0_expr) const
 {
-  // already renamed?
-  if(!ssa_expr.get_level_1().empty())
-    return ssa_expr;
+  if(!l0_expr.get().get_level_1().empty())
+    return renamedt<ssa_exprt, L1>{std::move(l0_expr.value)};
 
-  const irep_idt l0_name = ssa_expr.get_l1_object_identifier();
+  const irep_idt l0_name = l0_expr.get().get_l1_object_identifier();
 
   const auto it = current_names.find(l0_name);
   if(it == current_names.end())
-    return ssa_expr;
+    return renamedt<ssa_exprt, L1>{std::move(l0_expr.value)};
 
   // rename!
-  ssa_expr.set_level_1(it->second.second);
-  return ssa_expr;
+  l0_expr.value.set_level_1(it->second.second);
+  return renamedt<ssa_exprt, L1>{std::move(l0_expr.value)};
 }
 
 ssa_exprt symex_level2t::operator()(ssa_exprt ssa_expr) const

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -17,18 +17,18 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 
 #include "goto_symex_state.h"
 
-ssa_exprt symex_level0t::
+renamedt<ssa_exprt, L0> symex_level0t::
 operator()(ssa_exprt ssa_expr, const namespacet &ns, unsigned thread_nr) const
 {
   // already renamed?
   if(!ssa_expr.get_level_0().empty())
-    return ssa_expr;
+    return renamedt<ssa_exprt, L0>{std::move(ssa_expr)};
 
   const irep_idt &obj_identifier = ssa_expr.get_object_name();
 
   // guards are not L0-renamed
   if(obj_identifier == goto_symex_statet::guard_identifier())
-    return ssa_expr;
+    return renamedt<ssa_exprt, L0>{std::move(ssa_expr)};
 
   const symbolt *s;
   const bool found_l0 = !ns.lookup(obj_identifier, s);
@@ -36,11 +36,11 @@ operator()(ssa_exprt ssa_expr, const namespacet &ns, unsigned thread_nr) const
 
   // don't rename shared variables or functions
   if(s->type.id() == ID_code || s->is_shared())
-    return ssa_expr;
+    return renamedt<ssa_exprt, L0>{std::move(ssa_expr)};
 
   // rename!
   ssa_expr.set_level_0(thread_nr);
-  return ssa_expr;
+  return renamedt<ssa_exprt, L0>{ssa_expr};
 }
 
 ssa_exprt symex_level1t::operator()(ssa_exprt ssa_expr) const

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -17,18 +17,18 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 
 #include "goto_symex_state.h"
 
-void symex_level0t::
-operator()(ssa_exprt &ssa_expr, const namespacet &ns, unsigned thread_nr) const
+ssa_exprt symex_level0t::
+operator()(ssa_exprt ssa_expr, const namespacet &ns, unsigned thread_nr) const
 {
   // already renamed?
   if(!ssa_expr.get_level_0().empty())
-    return;
+    return ssa_expr;
 
   const irep_idt &obj_identifier = ssa_expr.get_object_name();
 
   // guards are not L0-renamed
   if(obj_identifier == goto_symex_statet::guard_identifier())
-    return;
+    return ssa_expr;
 
   const symbolt *s;
   const bool found_l0 = !ns.lookup(obj_identifier, s);
@@ -36,31 +36,34 @@ operator()(ssa_exprt &ssa_expr, const namespacet &ns, unsigned thread_nr) const
 
   // don't rename shared variables or functions
   if(s->type.id() == ID_code || s->is_shared())
-    return;
+    return ssa_expr;
 
   // rename!
   ssa_expr.set_level_0(thread_nr);
+  return ssa_expr;
 }
 
-void symex_level1t::operator()(ssa_exprt &ssa_expr) const
+ssa_exprt symex_level1t::operator()(ssa_exprt ssa_expr) const
 {
   // already renamed?
   if(!ssa_expr.get_level_1().empty())
-    return;
+    return ssa_expr;
 
   const irep_idt l0_name = ssa_expr.get_l1_object_identifier();
 
   const auto it = current_names.find(l0_name);
   if(it == current_names.end())
-    return;
+    return ssa_expr;
 
   // rename!
   ssa_expr.set_level_1(it->second.second);
+  return ssa_expr;
 }
 
-void symex_level2t::operator()(ssa_exprt &ssa_expr) const
+ssa_exprt symex_level2t::operator()(ssa_exprt ssa_expr) const
 {
   ssa_expr.set_level_2(current_count(ssa_expr.get_identifier()));
+  return ssa_expr;
 }
 
 void symex_level1t::restore_from(

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -58,6 +58,11 @@ void symex_level1t::operator()(ssa_exprt &ssa_expr) const
   ssa_expr.set_level_1(it->second.second);
 }
 
+void symex_level2t::operator()(ssa_exprt &ssa_expr) const
+{
+  ssa_expr.set_level_2(current_count(ssa_expr.get_identifier()));
+}
+
 void symex_level1t::restore_from(
   const symex_renaming_levelt::current_namest &other)
 {

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -59,6 +59,35 @@ struct symex_renaming_levelt
   }
 };
 
+/// Wrapper for expressions or types which have been renamed up to a given
+/// \p level
+template <typename underlyingt, levelt level>
+class renamedt
+{
+public:
+  static_assert(
+    std::is_base_of<exprt, underlyingt>::value ||
+      std::is_base_of<typet, underlyingt>::value,
+    "underlyingt should inherit from exprt or typet");
+
+  const underlyingt &get() const
+  {
+    return value;
+  }
+
+private:
+  underlyingt value;
+
+  friend struct symex_level0t;
+  friend struct symex_level1t;
+  friend struct symex_level2t;
+
+  /// Only symex_levelXt classes can create renamedt objects
+  explicit renamedt(underlyingt value) : value(std::move(value))
+  {
+  }
+};
+
 /// Functor to set the level 0 renaming of SSA expressions.
 /// Level 0 corresponds to threads.
 /// The renaming is built for one particular interleaving.

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -82,6 +82,8 @@ struct symex_level1t : public symex_renaming_levelt
 /// This is to ensure each variable is only assigned once.
 struct symex_level2t : public symex_renaming_levelt
 {
+  void operator()(ssa_exprt &ssa_expr) const;
+
   symex_level2t() = default;
   ~symex_level2t() override = default;
 };

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -93,7 +93,7 @@ private:
 /// The renaming is built for one particular interleaving.
 struct symex_level0t : public symex_renaming_levelt
 {
-  ssa_exprt operator()(
+  renamedt<ssa_exprt, L0> operator()(
     ssa_exprt ssa_expr,
     const namespacet &ns,
     unsigned thread_nr) const;

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -18,6 +18,14 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include <util/irep.h>
 #include <util/ssa_expr.h>
 
+/// Symex renaming level names.
+enum levelt
+{
+  L0 = 0,
+  L1 = 1,
+  L2 = 2
+};
+
 /// Wrapper for a \c current_names map, which maps each identifier to an SSA
 /// expression and a counter.
 /// This is extended by the different symex_level structures which are used

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -121,7 +121,7 @@ struct symex_level1t : public symex_renaming_levelt
 /// This is to ensure each variable is only assigned once.
 struct symex_level2t : public symex_renaming_levelt
 {
-  ssa_exprt operator()(ssa_exprt ssa_expr) const;
+  renamedt<ssa_exprt, L2> operator()(renamedt<ssa_exprt, L1> l1_expr) const;
 
   symex_level2t() = default;
   ~symex_level2t() override = default;

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -56,8 +56,10 @@ struct symex_renaming_levelt
 /// The renaming is built for one particular interleaving.
 struct symex_level0t : public symex_renaming_levelt
 {
-  void operator()(ssa_exprt &ssa_expr, const namespacet &ns, unsigned thread_nr)
-    const;
+  ssa_exprt operator()(
+    ssa_exprt ssa_expr,
+    const namespacet &ns,
+    unsigned thread_nr) const;
 
   symex_level0t() = default;
   ~symex_level0t() override = default;
@@ -68,7 +70,7 @@ struct symex_level0t : public symex_renaming_levelt
 /// This is to preserve locality in case of recursion
 struct symex_level1t : public symex_renaming_levelt
 {
-  void operator()(ssa_exprt &ssa_expr) const;
+  ssa_exprt operator()(ssa_exprt ssa_expr) const;
 
   /// Insert the content of \p other into this renaming
   void restore_from(const current_namest &other);
@@ -82,7 +84,7 @@ struct symex_level1t : public symex_renaming_levelt
 /// This is to ensure each variable is only assigned once.
 struct symex_level2t : public symex_renaming_levelt
 {
-  void operator()(ssa_exprt &ssa_expr) const;
+  ssa_exprt operator()(ssa_exprt ssa_expr) const;
 
   symex_level2t() = default;
   ~symex_level2t() override = default;

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -107,7 +107,7 @@ struct symex_level0t : public symex_renaming_levelt
 /// This is to preserve locality in case of recursion
 struct symex_level1t : public symex_renaming_levelt
 {
-  ssa_exprt operator()(ssa_exprt ssa_expr) const;
+  renamedt<ssa_exprt, L1> operator()(renamedt<ssa_exprt, L0> l0_expr) const;
 
   /// Insert the content of \p other into this renaming
   void restore_from(const current_namest &other);

--- a/src/goto-symex/symex_dead.cpp
+++ b/src/goto-symex/symex_dead.cpp
@@ -26,7 +26,7 @@ void goto_symext::symex_dead(statet &state)
   // We increase the L2 renaming to make these non-deterministic.
   // We also prevent propagation of old values.
 
-  ssa_exprt ssa = state.rename_ssa<statet::L1>(ssa_exprt{code.symbol()}, ns);
+  ssa_exprt ssa = state.rename_ssa<L1>(ssa_exprt{code.symbol()}, ns);
 
   // in case of pointers, put something into the value set
   if(code.symbol().type().id() == ID_pointer)
@@ -37,8 +37,7 @@ void goto_symext::symex_dead(statet &state)
     else
       rhs=exprt(ID_invalid);
 
-    const exprt l1_rhs =
-      state.rename<goto_symex_statet::L1>(std::move(rhs), ns);
+    const exprt l1_rhs = state.rename<L1>(std::move(rhs), ns);
     state.value_set.assign(ssa, l1_rhs, ns, true, false);
   }
 

--- a/src/goto-symex/symex_decl.cpp
+++ b/src/goto-symex/symex_decl.cpp
@@ -37,7 +37,7 @@ void goto_symext::symex_decl(statet &state, const symbol_exprt &expr)
   // We increase the L2 renaming to make these non-deterministic.
   // We also prevent propagation of old values.
 
-  ssa_exprt ssa = state.rename_ssa<statet::L1>(ssa_exprt{expr}, ns);
+  ssa_exprt ssa = state.rename_ssa<L1>(ssa_exprt{expr}, ns);
   const irep_idt &l1_identifier = ssa.get_identifier();
 
   // rename type to L2
@@ -53,7 +53,7 @@ void goto_symext::symex_decl(statet &state, const symbol_exprt &expr)
     else
       rhs=exprt(ID_invalid);
 
-    exprt l1_rhs = state.rename<goto_symex_statet::L1>(std::move(rhs), ns);
+    exprt l1_rhs = state.rename<L1>(std::move(rhs), ns);
     state.value_set.assign(ssa, l1_rhs, ns, true, false);
   }
 

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -356,11 +356,11 @@ void goto_symext::dereference(exprt &expr, statet &state)
   // from different frames. Would be enough to rename
   // symbols whose address is taken.
   PRECONDITION(!state.call_stack().empty());
-  exprt l1_expr = state.rename<goto_symex_statet::L1>(expr, ns);
+  exprt l1_expr = state.rename<L1>(expr, ns);
 
   // start the recursion!
   dereference_rec(l1_expr, state);
   // dereferencing may introduce new symbol_exprt
   // (like __CPROVER_memory)
-  expr = state.rename<goto_symex_statet::L1>(std::move(l1_expr), ns);
+  expr = state.rename<L1>(std::move(l1_expr), ns);
 }

--- a/src/goto-symex/symex_dereference_state.cpp
+++ b/src/goto-symex/symex_dereference_state.cpp
@@ -48,8 +48,8 @@ symex_dereference_statet::get_or_create_failed_symbol(const exprt &expr)
     {
       symbolt sym=*symbol;
       symbolt *sym_ptr=nullptr;
-      const ssa_exprt sym_expr = state.rename_ssa<goto_symex_statet::L1>(
-        ssa_exprt{sym.symbol_expr()}, ns);
+      const ssa_exprt sym_expr =
+        state.rename_ssa<L1>(ssa_exprt{sym.symbol_expr()}, ns);
       sym.name = sym_expr.get_identifier();
       state.symbol_table.move(sym, sym_ptr);
       return sym_ptr;
@@ -68,8 +68,8 @@ symex_dereference_statet::get_or_create_failed_symbol(const exprt &expr)
     {
       symbolt sym=*symbol;
       symbolt *sym_ptr=nullptr;
-      const ssa_exprt sym_expr = state.rename_ssa<goto_symex_statet::L1>(
-        ssa_exprt{sym.symbol_expr()}, ns);
+      const ssa_exprt sym_expr =
+        state.rename_ssa<L1>(ssa_exprt{sym.symbol_expr()}, ns);
       sym.name = sym_expr.get_identifier();
       state.symbol_table.move(sym, sym_ptr);
       return sym_ptr;

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -395,8 +395,8 @@ static void locality(
       it++)
   {
     // get L0 name
-    ssa_exprt ssa = state.rename_ssa<goto_symex_statet::L0>(
-      ssa_exprt{ns.lookup(*it).symbol_expr()}, ns);
+    ssa_exprt ssa =
+      state.rename_ssa<L0>(ssa_exprt{ns.lookup(*it).symbol_expr()}, ns);
     const irep_idt l0_name=ssa.get_identifier();
 
     // save old L1 name for popping the frame
@@ -418,8 +418,7 @@ static void locality(
     // identifiers may be shared among functions
     // (e.g., due to inlining or other code restructuring)
 
-    ssa_exprt ssa_l1 =
-      state.rename_ssa<goto_symex_statet::L1>(std::move(ssa), ns);
+    ssa_exprt ssa_l1 = state.rename_ssa<L1>(std::move(ssa), ns);
 
     irep_idt l1_name = ssa_l1.get_identifier();
     unsigned offset=0;

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -246,7 +246,7 @@ void goto_symext::symex_goto(statet &state)
       exprt new_rhs = boolean_negate(new_guard);
 
       ssa_exprt new_lhs =
-        state.rename_ssa<statet::L1>(ssa_exprt{guard_symbol_expr}, ns);
+        state.rename_ssa<L1>(ssa_exprt{guard_symbol_expr}, ns);
       state.assignment(new_lhs, new_rhs, ns, true, false);
 
       guardt guard{true_exprt{}};

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -73,7 +73,7 @@ void goto_symext::symex_start_thread(statet &state)
       std::forward_as_tuple(lhs.get_l1_object_identifier()),
       std::forward_as_tuple(lhs, 0));
     CHECK_RETURN(emplace_result.second);
-    const ssa_exprt lhs_l1 = state.rename_ssa<statet::L1>(std::move(lhs), ns);
+    const ssa_exprt lhs_l1 = state.rename_ssa<L1>(std::move(lhs), ns);
     const irep_idt l1_name = lhs_l1.get_l1_object_identifier();
     // store it
     state.l1_history.insert(l1_name);


### PR DESCRIPTION
This is a wrapper that will be used to signal that an expression or type
has been renamed to a given level.
It makes it possible to define functions which only accept expression
which have been through renaming.

This is preliminary to https://github.com/diffblue/cbmc/pull/3986 but some of its part becomes redundant, and it needs to be reworked on afterwards.

Eventually expressions of this type will be propagated everywhere renamed expressions are used and `.get()` should only be used when constructing the target equations.


<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
