### PR TITLE
Add a --total option to benchmark_to_spreadsheet.js

### DIFF
--- a/scripts/benchmark/benchmark_to_spreadsheet.js
+++ b/scripts/benchmark/benchmark_to_spreadsheet.js
@@ -3,14 +3,21 @@ let program = require('commander');
 
 program
     .arguments('<jsonFile>')
+    .option('-t, --total', 'Only print the total time')
     .action(function (jsonFile) {
         let lineReader = require('readline').createInterface({
             input: require('fs').createReadStream(jsonFile)
         });
-        console.log("class file; function name; execution time (ms);"
-        + "success; goals covered; total number of goals");
+        const printTotalTime = typeof program.total != 'undefined';
+        let totalTime = 0.0;
+        if (!printTotalTime)
+            console.log("class file; function name; execution time (ms);"
+                        + "success; goals covered; total number of goals");
         lineReader.on('line', function (data) {
             let json = JSON.parse(data.toString());
+            totalTime += parseFloat(json.execTime);
+            if (printTotalTime)
+                return;
             console.log(
                 json.classFile +";" +
                 json['function'].replace(/;/g, "_") + "; " +
@@ -19,5 +26,10 @@ program
                 ((typeof json.goals != 'undefined')? json.goals.goalsCovered : "0") + ";" +
                 ((typeof json.goals != 'undefined')? json.goals.totalGoals : ""));
         });
+        if (printTotalTime) {
+            lineReader.on('close', function () {
+                console.log(jsonFile + "; " + totalTime)
+            });
+        }
     })
     .parse(process.argv);


### PR DESCRIPTION
This adds an option to the script to take the total of the time taken by
the benchmarks instead of the results for each individual functions

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
