### PR TITLE
Don't simplify guard to skip instructions

### DIFF
--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -106,15 +106,13 @@ void goto_symext::symex_goto(statet &state)
     }
   }
 
-  exprt simpl_state_guard = state.guard.as_expr();
-  do_simplify(simpl_state_guard);
-
   // No point executing both branches of an unconditional goto.
   if(
     new_guard.is_true() && // We have an unconditional goto, AND
-    // either there are no blocks between us and the target in the
-    // surrounding scope
-    (simpl_state_guard.is_true() ||
+    // either there are no reachable blocks between us and the target in the
+    // surrounding scope (because state.guard == true implies there is no path
+    // around this GOTO instruction)
+    (state.guard.is_true() ||
      // or there is another block, but we're doing path exploration so
      // we're going to skip over it for now and return to it later.
      symex_config.doing_path_exploration))


### PR DESCRIPTION
This still applies even with the guards-are-BDDs branch, since it retains the option to use expr-guards. Needs data, of course, but anecdotally this reduces symex time on one large Java example from about 20 to about 15 minutes.

Underlying theory: forward-GOTOs on a must-execute path (i.e. one that post-dominates the entry point) are rarer than forward-GOTOs that don't post-dominate, and the cost of figuring out that the guard must be effectively TRUE by checking `goto_state_map` for each intervening instruction is quite low (each instruction does a single map lookup to determine there is no incoming state to merge, checks state.guard.is_false() and continues). This is especially true for short GOTOs, which are also common. This simplify-and-jump code could only make a big saving when (a) the GOTO post-doms the entry point, (b) the state guard simplifies to true, and (c) the GOTO is long enough that the cost of a quick check-and-skip for each intervening instruction is high.