### PR TITLE
Regularise the style and division of responsibilities in symex dispatch

### DIFF
--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -223,12 +223,14 @@ protected:
   virtual void symex_dead(statet &);
   virtual void symex_other(statet &);
 
+  void symex_assert(const goto_programt::instructiont &, statet &);
   virtual void vcc(
     const exprt &,
     const std::string &msg,
     statet &);
 
   virtual void symex_assume(statet &, const exprt &cond);
+  void symex_assume_l2(statet &, const exprt &cond);
 
   // gotos
   void merge_gotos(statet &);

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -194,8 +194,18 @@ void goto_symext::symex_function_call(
 void goto_symext::symex_function_call_symbol(
   const get_goto_functiont &get_goto_function,
   statet &state,
-  const code_function_callt &code)
+  const code_function_callt &original_code)
 {
+  code_function_callt code = original_code;
+
+  if(code.lhs().is_not_nil())
+    clean_expr(code.lhs(), state, true);
+
+  clean_expr(code.function(), state, false);
+
+  Forall_expr(it, code.arguments())
+    clean_expr(*it, state, false);
+
   target.location(state.guard.as_expr(), state.source);
 
   PRECONDITION(code.function().id() == ID_symbol);
@@ -437,4 +447,3 @@ static void locality(
     state.l1_history.insert(l1_name);
   }
 }
-

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -27,13 +27,6 @@ void goto_symext::symex_goto(statet &state)
   const goto_programt::instructiont &instruction=*state.source.pc;
   framet &frame = state.top();
 
-  if(state.guard.is_false())
-  {
-    // next instruction
-    symex_transition(state);
-    return; // nothing to do
-  }
-
   exprt new_guard = instruction.get_condition();
   clean_expr(new_guard, state, false);
 
@@ -75,9 +68,9 @@ void goto_symext::symex_goto(statet &state)
       // generate assume(false) or a suitable negation if this
       // instruction is a conditional goto
       if(new_guard.is_true())
-        symex_assume(state, false_exprt());
+        symex_assume_l2(state, false_exprt());
       else
-        symex_assume(state, not_exprt(new_guard));
+        symex_assume_l2(state, not_exprt(new_guard));
 
       // next instruction
       symex_transition(state);
@@ -559,9 +552,10 @@ void goto_symext::loop_bound_exceeded(
     if(symex_config.unwinding_assertions)
     {
       // Generate VCC for unwinding assertion.
-      vcc(negated_cond,
-          "unwinding assertion loop "+std::to_string(loop_number),
-          state);
+      vcc(
+        negated_cond,
+        "unwinding assertion loop " + std::to_string(loop_number),
+        state);
 
       // add to state guard to prevent further assignments
       state.guard.add(negated_cond);
@@ -569,7 +563,7 @@ void goto_symext::loop_bound_exceeded(
     else
     {
       // generate unwinding assumption, unless we permit partial loops
-      symex_assume(state, negated_cond);
+      symex_assume_l2(state, negated_cond);
     }
   }
 }

--- a/src/goto-symex/symex_throw.cpp
+++ b/src/goto-symex/symex_throw.cpp
@@ -49,5 +49,5 @@ void goto_symext::symex_throw(statet &state)
   #endif
 
   // An un-caught exception. Behaves like assume(0);
-  symex_assume(state, false_exprt());
+  symex_assume_l2(state, false_exprt());
 }


### PR DESCRIPTION
Specifically: symex_step always dispatches without running either clean_expr or renaming, symex_step
always takes care of the if-unreachable case (usually means skip instruction, but end-of-function has
work to do regardless), symex_step takes care of advancing to the successor instruction after a simple
instruction executes.

No behavioural changes intended here except avoiding a little bit of redundant renaming / simplification
when functions other than symex_step call symex_assume or vcc.