### PR TITLE
Read "is inlined" attribute of goto functions from the symbol table [blocks: #4167]

### DIFF
--- a/src/ansi-c/ansi_c_declaration.cpp
+++ b/src/ansi-c/ansi_c_declaration.cpp
@@ -150,7 +150,7 @@ void ansi_c_declarationt::to_symbol(
     symbol.is_file_local=get_is_static();
 
     if(get_is_inline())
-      symbol.type.set(ID_C_inlined, true);
+      to_code_type(symbol.type).set_inlined(true);
 
     if(
       config.ansi_c.mode == configt::ansi_ct::flavourt::GCC ||

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -309,10 +309,6 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
 
   if(final_new.id()==ID_code)
   {
-    bool inlined=
-       (new_symbol.type.get_bool(ID_C_inlined) ||
-        old_symbol.type.get_bool(ID_C_inlined));
-
     if(final_old.id()!=ID_code)
     {
       error().source_location=new_symbol.location;
@@ -327,6 +323,8 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
     code_typet &old_ct=to_code_type(old_symbol.type);
     code_typet &new_ct=to_code_type(new_symbol.type);
 
+    const bool inlined = old_ct.get_inlined() || new_ct.get_inlined();
+
     if(old_ct.has_ellipsis() && !new_ct.has_ellipsis())
       old_ct=new_ct;
     else if(!old_ct.has_ellipsis() && new_ct.has_ellipsis())
@@ -334,8 +332,8 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
 
     if(inlined)
     {
-      old_symbol.type.set(ID_C_inlined, true);
-      new_symbol.type.set(ID_C_inlined, true);
+      old_ct.set_inlined(true);
+      new_ct.set_inlined(true);
     }
 
     // do body
@@ -348,7 +346,7 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
         // definition is marked as "extern inline"
 
         if(
-          old_symbol.type.get_bool(ID_C_inlined) &&
+          old_ct.get_inlined() &&
           (config.ansi_c.mode == configt::ansi_ct::flavourt::GCC ||
            config.ansi_c.mode == configt::ansi_ct::flavourt::CLANG ||
            config.ansi_c.mode == configt::ansi_ct::flavourt::ARM ||

--- a/src/cpp/cpp_declarator_converter.cpp
+++ b/src/cpp/cpp_declarator_converter.cpp
@@ -459,7 +459,7 @@ symbolt &cpp_declarator_convertert::convert_new_symbol(
     symbol.is_macro=true;
 
   if(member_spec.is_inline())
-    symbol.type.set(ID_C_inlined, true);
+    to_code_type(symbol.type).set_inlined(true);
 
   if(!symbol.is_type)
   {

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -1293,7 +1293,7 @@ void cpp_typecheckt::typecheck_member_function(
   component.set(ID_prefix, id2string(identifier) + "::");
 
   if(value.is_not_nil())
-    type.set(ID_C_inlined, true);
+    to_code_type(type).set_inlined(true);
 
   symbol.name=identifier;
   symbol.base_name=component.get_base_name();

--- a/src/goto-analyzer/unreachable_instructions.cpp
+++ b/src/goto-analyzer/unreachable_instructions.cpp
@@ -173,9 +173,12 @@ void unreachable_instructions(
 
     // f_it->first may be a link-time renamed version, use the
     // base_name instead; do not list inlined functions
-    if(called.find(decl.base_name)!=called.end() ||
-       f_it->second.is_inlined())
+    if(
+      called.find(decl.base_name) != called.end() ||
+      to_code_type(decl.type).get_inlined())
+    {
       unreachable_instructions(goto_program, dead_map);
+    }
     else
       all_unreachable(goto_program, dead_map);
 
@@ -295,10 +298,12 @@ static void list_functions(
 
     // f_it->first may be a link-time renamed version, use the
     // base_name instead; do not list inlined functions
-    if(unreachable ==
-       (called.find(decl.base_name)!=called.end() ||
-        f_it->second.is_inlined()))
+    if(
+      unreachable == (called.find(decl.base_name) != called.end() ||
+                      to_code_type(decl.type).get_inlined()))
+    {
       continue;
+    }
 
     source_locationt first_location=decl.location;
 

--- a/src/goto-instrument/aggressive_slicer.cpp
+++ b/src/goto-instrument/aggressive_slicer.cpp
@@ -39,9 +39,11 @@ void aggressive_slicert::note_functions_to_keep(
 
 void aggressive_slicert::get_all_functions_containing_properties()
 {
+  const namespacet ns(goto_model.symbol_table);
+
   for(const auto &fct : goto_model.goto_functions.function_map)
   {
-    if(!fct.second.is_inlined())
+    if(!to_code_type(ns.lookup(fct.first).type).get_inlined())
     {
       for(const auto &ins : fct.second.body.instructions)
         if(ins.is_assert())

--- a/src/goto-instrument/remove_function.cpp
+++ b/src/goto-instrument/remove_function.cpp
@@ -39,7 +39,8 @@ void remove_function(
                     << " in goto program" << messaget::eom;
     return;
   }
-  else if(entry->second.is_inlined())
+  else if(to_code_type(goto_model.symbol_table.lookup_ref(identifier).type)
+            .get_inlined())
   {
     message.warning() << "Function " << identifier << " is inlined, "
                       << "instantiations will not be removed"

--- a/src/goto-programs/goto_inline.cpp
+++ b/src/goto-programs/goto_inline.cpp
@@ -194,7 +194,7 @@ void goto_partial_inline(
         continue;
 
       if(
-        called_function.is_inlined() ||
+        to_code_type(ns.lookup(id).type).get_inlined() ||
         called_function.body.instructions.size() <= smallfunc_limit)
       {
         PRECONDITION(i_it->is_function_call());

--- a/src/goto-programs/link_goto_model.cpp
+++ b/src/goto-programs/link_goto_model.cpp
@@ -104,7 +104,7 @@ static bool link_functions(
       {
         // just keep the old one in dest
       }
-      else if(in_dest_symbol_table.type.get_bool(ID_C_inlined))
+      else if(to_code_type(ns.lookup(final_id).type).get_inlined())
       {
         // ok, we silently ignore
       }

--- a/src/goto-programs/property_checker.cpp
+++ b/src/goto-programs/property_checker.cpp
@@ -30,12 +30,15 @@ property_checkert::property_checkert(
 {
 }
 
-void property_checkert::initialize_property_map(
-  const goto_functionst &goto_functions)
+void property_checkert::initialize_property_map(const goto_modelt &goto_model)
 {
-  forall_goto_functions(it, goto_functions)
-    if(!it->second.is_inlined() ||
-       it->first==goto_functions.entry_point())
+  const namespacet ns(goto_model.symbol_table);
+
+  forall_goto_functions(it, goto_model.goto_functions)
+  {
+    if(
+      !to_code_type(ns.lookup(it->first).type).get_inlined() ||
+      it->first == goto_functionst::entry_point())
     {
       const goto_programt &goto_program=it->second.body;
 
@@ -53,4 +56,5 @@ void property_checkert::initialize_property_map(
         property_status.location=i_it;
       }
     }
+  }
 }

--- a/src/goto-programs/property_checker.h
+++ b/src/goto-programs/property_checker.h
@@ -49,7 +49,7 @@ public:
   property_mapt property_map;
 
 protected:
-  void initialize_property_map(const goto_functionst &);
+  void initialize_property_map(const goto_modelt &);
 };
 
 #endif // CPROVER_GOTO_PROGRAMS_PROPERTY_CHECKER_H


### PR DESCRIPTION
There should only be a single place to hold type information, including
attributes, to ensure consistency. Future changes will remove the "type" member
of goto_functiont, making the type information stored in the symbol table the
single, authoritative source of information.

The "is inlined" information should already be consistent/redundant. This commit
makes all read accesses use the information stored in the symbol table, and also
uses a modern API for doing so.

This is a further, meant-to-be-non-breaking step towards removing `goto_functiont::type`, which #4167 tries to achieve.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
