### PR TITLE
mark return_value symbols as auxiliary

### DIFF
--- a/src/goto-programs/remove_returns.cpp
+++ b/src/goto-programs/remove_returns.cpp
@@ -74,6 +74,7 @@ remove_returnst::get_or_create_return_value_symbol(const irep_idt &function_id)
 
   auxiliary_symbolt new_symbol;
   new_symbol.is_static_lifetime = true;
+  new_symbol.is_auxiliary = true;
   new_symbol.module = function_symbol.module;
   new_symbol.base_name =
     id2string(function_symbol.base_name) + RETURN_VALUE_SUFFIX;


### PR DESCRIPTION
Symbols that aren't part of the original program should be marked as
'auxiliary'.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
