### PR TITLE
new constructor for function_application_exprt

### DIFF
--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -818,10 +818,7 @@ exprt smt2_parsert::function_application()
           if(id_it->second.type.id()==ID_mathematical_function)
           {
             return function_application_exprt(
-              symbol_exprt(final_id, id_it->second.type),
-              op,
-              to_mathematical_function_type(
-                id_it->second.type).codomain());
+              symbol_exprt(final_id, id_it->second.type), op);
           }
           else
             return symbol_exprt(final_id, id_it->second.type);

--- a/src/util/mathematical_expr.cpp
+++ b/src/util/mathematical_expr.cpp
@@ -7,3 +7,17 @@ Author: Daniel Kroening, kroening@kroening.com
 \*******************************************************************/
 
 #include "mathematical_expr.h"
+#include "mathematical_types.h"
+
+function_application_exprt::function_application_exprt(
+  const symbol_exprt &_function,
+  argumentst _arguments)
+  : binary_exprt(
+      _function,
+      ID_function_application,
+      multi_ary_exprt(irep_idt(), std::move(_arguments), typet()),
+      to_mathematical_function_type(_function.type()).codomain())
+{
+  const auto &domain = to_mathematical_function_type(_function.type()).domain();
+  PRECONDITION(domain.size() == arguments().size());
+}

--- a/src/util/mathematical_expr.h
+++ b/src/util/mathematical_expr.h
@@ -192,6 +192,7 @@ class function_application_exprt : public binary_exprt
 public:
   using argumentst = exprt::operandst;
 
+  DEPRECATED("use function_application_exprt(fkt, arg) instead")
   function_application_exprt(
     const symbol_exprt &_function,
     const argumentst &_arguments,
@@ -200,6 +201,10 @@ public:
   {
     arguments() = _arguments;
   }
+
+  function_application_exprt(
+    const symbol_exprt &_function,
+    argumentst _arguments);
 
   symbol_exprt &function()
   {


### PR DESCRIPTION
The new constructor
1) moves the arguments
2) enforces the type of the function to be mathematical_function
3) automatically sets the type of the application to be the codomain of the
function.
4) checks that the right number of arguments is given.

Note that the function symbol can't be moved during construction as its type
is needed.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
