### PR TITLE
deprecate parametert::get/set_identifier

### DIFF
--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -801,6 +801,7 @@ public:
     // The following for methods will go away;
     // these should not be part of the signature of a function,
     // but rather part of the body.
+    DEPRECATED("Use goto_functiont::parameter_identifiers instead")
     void set_identifier(const irep_idt &identifier)
     {
       set(ID_C_identifier, identifier);
@@ -811,6 +812,7 @@ public:
       set(ID_C_base_name, name);
     }
 
+    DEPRECATED("Use goto_functiont::parameter_identifiers instead")
     const irep_idt &get_identifier() const
     {
       return get(ID_C_identifier);


### PR DESCRIPTION
This deprecates both `parametert::get_identifier()` and
`parametert::set_identifier()`.  There has been a comment announcing this
since 2013.

Users of goto programs are meant to use
`goto_functiont::parameter_identifiers`.  It remains to resolve the interface
that is used to pass these identifiers into goto_convert.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
