### PR TITLE
store parameter identifiers in goto binary

### DIFF
--- a/src/goto-programs/read_bin_goto_object.cpp
+++ b/src/goto-programs/read_bin_goto_object.cpp
@@ -87,9 +87,17 @@ static bool read_bin_goto_object(
 
   for(std::size_t fct_index = 0; fct_index < count; ++fct_index)
   {
+    // read the function identifier
     irep_idt fname=irepconverter.read_gb_string(in);
     goto_functionst::goto_functiont &f = functions.function_map[fname];
 
+    // read the parameter idenntifiers
+    const std::size_t param_count = irepconverter.read_gb_word(in); // # parameters
+    f.parameter_identifiers.reserve(param_count);
+    for(std::size_t param_index = 0; param_index < param_count; param_index++)
+      f.parameter_identifiers.push_back(irepconverter.read_string_ref(in));
+
+    // now read the instructions
     typedef std::map<goto_programt::targett, std::list<unsigned> > target_mapt;
     target_mapt target_map;
     typedef std::map<unsigned, goto_programt::targett> rev_target_mapt;

--- a/src/goto-programs/write_goto_binary.cpp
+++ b/src/goto-programs/write_goto_binary.cpp
@@ -90,6 +90,11 @@ bool write_goto_binary(
       // instead they are saved in a custom binary format
 
       write_gb_string(out, id2string(fct.first)); // name
+
+      write_gb_word(out, fct.second.parameter_identifiers.size()); // # parameters
+      for(const auto &id : fct.second.parameter_identifiers)
+        irepconverter.write_string_ref(out, id);
+
       write_gb_word(out, fct.second.body.instructions.size()); // # instructions
 
       forall_goto_program_instructions(i_it, fct.second.body)

--- a/src/goto-programs/write_goto_binary.h
+++ b/src/goto-programs/write_goto_binary.h
@@ -12,7 +12,7 @@ Author: CM Wintersteiger
 #ifndef CPROVER_GOTO_PROGRAMS_WRITE_GOTO_BINARY_H
 #define CPROVER_GOTO_PROGRAMS_WRITE_GOTO_BINARY_H
 
-#define GOTO_BINARY_VERSION 5
+#define GOTO_BINARY_VERSION 6
 
 #include <iosfwd>
 #include <string>


### PR DESCRIPTION
Parameter identifiers are now stored explicitly as part of the function body
in the goto binary.

The version number of the goto binary is increased.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
