### PR TITLE
use a tuple for function arguments

### DIFF
--- a/src/util/irep_ids.def
+++ b/src/util/irep_ids.def
@@ -720,6 +720,7 @@ IREP_ID_ONE(typeid)
 IREP_ID_TWO(C_quoted, #quoted)
 IREP_ID_ONE(to_member)
 IREP_ID_ONE(pointer_to_member)
+IREP_ID_ONE(tuple)
 
 // Projects depending on this code base that wish to extend the list of
 // available ids should provide a file local_irep_ids.def in their source tree

--- a/src/util/mathematical_expr.cpp
+++ b/src/util/mathematical_expr.cpp
@@ -15,7 +15,7 @@ function_application_exprt::function_application_exprt(
   : binary_exprt(
       _function,
       ID_function_application,
-      multi_ary_exprt(irep_idt(), std::move(_arguments), typet()),
+      tuple_exprt(std::move(_arguments)),
       to_mathematical_function_type(_function.type()).codomain())
 {
   const auto &domain = to_mathematical_function_type(_function.type()).domain();

--- a/src/util/mathematical_expr.h
+++ b/src/util/mathematical_expr.h
@@ -186,6 +186,15 @@ inline void validate_expr(const factorial_power_exprt &value)
   validate_operands(value, 2, "Factorial power must have two operands");
 }
 
+class tuple_exprt : public multi_ary_exprt
+{
+public:
+  explicit tuple_exprt(exprt::operandst operands)
+    : multi_ary_exprt(ID_tuple, std::move(operands), typet())
+  {
+  }
+};
+
 /// \brief Application of (mathematical) function
 class function_application_exprt : public binary_exprt
 {
@@ -197,9 +206,12 @@ public:
     const symbol_exprt &_function,
     const argumentst &_arguments,
     const typet &_type)
-    : binary_exprt(_function, ID_function_application, exprt(), _type)
+    : binary_exprt(
+        _function,
+        ID_function_application,
+        tuple_exprt(_arguments),
+        _type)
   {
-    arguments() = _arguments;
   }
 
   function_application_exprt(


### PR DESCRIPTION
This is follow-up from PR #4317.

This introduces `tuple_exprt`.

`function_application_exprt` now uses `tuple_exprt` for the argument operand,
instead of an expression with empty ID.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
