### PR TITLE
introduce code_bodyt

### DIFF
--- a/src/util/irep_ids.def
+++ b/src/util/irep_ids.def
@@ -721,6 +721,7 @@ IREP_ID_TWO(C_quoted, #quoted)
 IREP_ID_ONE(to_member)
 IREP_ID_ONE(pointer_to_member)
 IREP_ID_ONE(tuple)
+IREP_ID_ONE(function_body)
 
 // Projects depending on this code base that wish to extend the list of
 // available ids should provide a file local_irep_ids.def in their source tree

--- a/src/util/std_code.cpp
+++ b/src/util/std_code.cpp
@@ -145,3 +145,25 @@ code_blockt create_fatal_assertion(
 
   return result;
 }
+
+std::vector<irep_idt> code_function_bodyt::get_parameter_identifiers() const
+{
+  const auto &sub = find(ID_parameters).get_sub();
+  std::vector<irep_idt> result;
+  result.reserve(sub.size());
+  for(const auto &s : sub)
+    result.push_back(s.get(ID_identifier));
+  return result;
+}
+
+void code_function_bodyt::set_parameter_identifiers(
+  const std::vector<irep_idt> &parameter_identifiers)
+{
+  auto &sub = add(ID_parameters).get_sub();
+  sub.reserve(parameter_identifiers.size());
+  for(const auto &id : parameter_identifiers)
+  {
+    sub.push_back(irept(ID_parameter));
+    sub.back().set(ID_identifier, id);
+  }
+}

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -2490,4 +2490,54 @@ inline code_try_catcht &to_code_try_catch(codet &code)
   return static_cast<code_try_catcht &>(code);
 }
 
+/// This class is used to interface between a language frontend
+/// and goto-convert -- it communicates the identifiers of the parameters
+/// of a function or method
+class code_function_bodyt : public codet
+{
+public:
+  explicit code_function_bodyt(
+    const std::vector<irep_idt> &parameter_identifiers,
+    code_blockt _block)
+    : codet(ID_function_body, {std::move(_block)})
+  {
+    set_parameter_identifiers(parameter_identifiers);
+  }
+
+  code_blockt &block()
+  {
+    return to_code_block(to_code(op0()));
+  }
+
+  const code_blockt &block() const
+  {
+    return to_code_block(to_code(op0()));
+  }
+
+  std::vector<irep_idt> get_parameter_identifiers() const;
+  void set_parameter_identifiers(const std::vector<irep_idt> &);
+
+protected:
+  using codet::op0;
+  using codet::op1;
+  using codet::op2;
+  using codet::op3;
+};
+
+inline const code_function_bodyt &to_code_function_body(const codet &code)
+{
+  PRECONDITION(code.get_statement() == ID_function_body);
+  DATA_INVARIANT(
+    code.operands().size() == 1, "code_function_body must have one operand");
+  return static_cast<const code_function_bodyt &>(code);
+}
+
+inline code_function_bodyt &to_code_function_body(codet &code)
+{
+  PRECONDITION(code.get_statement() == ID_function_body);
+  DATA_INVARIANT(
+    code.operands().size() == 1, "code_function_body must have one operand");
+  return static_cast<code_function_bodyt &>(code);
+}
+
 #endif // CPROVER_UTIL_STD_CODE_H


### PR DESCRIPTION
This is a class that supports a new interface to pass parameter identifiers
from a language frontend to goto_convert.  At the moment, parameter
identifiers are passed as part of the function signature.  The new class
enables passing these as part of the body.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ X Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
