### PR TITLE
Fix bounds checking for structs with flexible array members

### DIFF
--- a/regression/cbmc/struct12/main.c
+++ b/regression/cbmc/struct12/main.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+#include <stdlib.h>
+
+struct S
+{
+  int a;
+  char b[];
+};
+
+int main()
+{
+  struct S *s = malloc(sizeof(struct S) + 1);
+  // allocate an object that matches the fixed size of the struct, without the
+  // flexible member
+  int *p = malloc(sizeof(int));
+  s->b[0] = 0;
+  assert(s->b[0] == 0);
+}

--- a/regression/cbmc/struct12/test.desc
+++ b/regression/cbmc/struct12/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--pointer-check --bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Our logic for constructing assertion over structs with flexible array members
+was wrong, because it could conflate dynamic allocation sizes across different
+objects.


### PR DESCRIPTION
The constraints did not make sure that the dynamic size (__CPROVER_malloc_size)
actually referred to the object we are looking at (__CPROVER_malloc_object).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
