### PR TITLE
Fix typet::check usage to work with latest API

### DIFF
--- a/src/util/expr_cast.h
+++ b/src/util/expr_cast.h
@@ -170,8 +170,8 @@ optionalt<T> type_try_dynamic_cast(TType &&base)
   static_assert(!std::is_const<TType>::value, "Attempted to move from const.");
   if(!can_cast_type<T>(base))
     return {};
+  TType::check(base);
   optionalt<T> ret{static_cast<T &&>(base)};
-  validate_type(*ret);
   return ret;
 }
 

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -1130,7 +1130,8 @@ public:
     const typet &type,
     const validation_modet vm = validation_modet::INVARIANT)
   {
-    DATA_CHECK(!type.get(ID_width).empty(), "bitvector type must have width");
+    DATA_CHECK(
+      vm, !type.get(ID_width).empty(), "bitvector type must have width");
   }
 };
 
@@ -1241,7 +1242,7 @@ public:
     const validation_modet vm = validation_modet::INVARIANT)
   {
     DATA_CHECK(
-      !type.get(ID_width).empty(), "signed bitvector type must have width");
+      vm, !type.get(ID_width).empty(), "signed bitvector type must have width");
   }
 };
 
@@ -1305,7 +1306,7 @@ public:
     const validation_modet vm = validation_modet::INVARIANT)
   {
     DATA_CHECK(
-      !type.get(ID_width).empty(), "fixed bitvector type must have width");
+      vm, !type.get(ID_width).empty(), "fixed bitvector type must have width");
   }
 };
 
@@ -1367,7 +1368,7 @@ public:
     const validation_modet vm = validation_modet::INVARIANT)
   {
     DATA_CHECK(
-      !type.get(ID_width).empty(), "float bitvector type must have width");
+      vm, !type.get(ID_width).empty(), "float bitvector type must have width");
   }
 };
 
@@ -1469,7 +1470,7 @@ public:
     const typet &type,
     const validation_modet vm = validation_modet::INVARIANT)
   {
-    DATA_CHECK(!type.get(ID_width).empty(), "pointer must have width");
+    DATA_CHECK(vm, !type.get(ID_width).empty(), "pointer must have width");
   }
 };
 
@@ -1567,7 +1568,7 @@ public:
     const typet &type,
     const validation_modet vm = validation_modet::INVARIANT)
   {
-    DATA_CHECK(!type.get(ID_width).empty(), "C bool type must have width");
+    DATA_CHECK(vm, !type.get(ID_width).empty(), "C bool type must have width");
   }
 };
 

--- a/src/util/type.h
+++ b/src/util/type.h
@@ -88,7 +88,8 @@ public:
   ///
   /// The validation mode indicates whether well-formedness check failures are
   /// reported via DATA_INVARIANT violations or exceptions.
-  static void check(const typet &, const validation_modet)
+  static void
+  check(const typet &, const validation_modet = validation_modet::INVARIANT)
   {
   }
 


### PR DESCRIPTION
Fixes the build breakage caused by merging an old PR. We nowadays require a
validation mode.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
