### PR TITLE
Add back two declarations needed for test-gen

### DIFF
--- a/src/cbmc/bmc.h
+++ b/src/cbmc/bmc.h
@@ -193,6 +193,10 @@ protected:
 
   friend class bmc_all_propertiest;
 
+  // \todo remove these two declarations once test-gen dependency is fixed
+  bool cover(const goto_functionst &goto_functions);
+  friend class bmc_covert;
+
 private:
   /// \brief Class-specific symbolic execution
   ///


### PR DESCRIPTION
These were removed in #4216.

This is temporary and these two declarations will be removed once https://github.com/diffblue/test-gen/tree/svorenova/goto-checker is merged (PR currently being prepared).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
