### PR TITLE
optimize encoding of dcmgl

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -2637,13 +2637,16 @@ exprt::operandst &java_bytecode_convert_methodt::convert_cmp2(
   isnan_exprt nan_op1(op[1]);
   exprt one = from_integer(1, result_type);
   exprt minus_one = from_integer(-1, result_type);
+
   results[0] = if_exprt(
     or_exprt(nan_op0, nan_op1),
     nan_result,
     if_exprt(
-      ieee_float_equal_exprt(op[0], op[1]),
+      // no need to use ieee_float_equal since NaN is already ruled out
+      equal_exprt(op[0], op[1]),
       from_integer(0, result_type),
       if_exprt(binary_relation_exprt(op[0], ID_lt, op[1]), minus_one, one)));
+
   return results;
 }
 


### PR DESCRIPTION
The encoding of the dcmpg and dcmpl bytecode instructions first checks for
the NaN case. When neither operand is NaN, then ieee_float_equal is used.

This commit uses equal since equal is cheaper and coincides with
ieee_float_equal when both operands are not NaN.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
