### PR TITLE
Make set_indices a template

### DIFF
--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -262,13 +262,7 @@ ssa_exprt goto_symex_statet::rename_ssa(ssa_exprt ssa, const namespacet &ns)
   static_assert(
     level == L0 || level == L1,
     "rename_ssa can only be used for levels L0 and L1");
-  if(level == L0)
-    ssa = set_indices<L0>(std::move(ssa), ns).get();
-  else if(level == L1)
-    ssa = set_indices<L1>(std::move(ssa), ns).get();
-  else
-    UNREACHABLE;
-
+  ssa = set_indices<level>(std::move(ssa), ns).get();
   rename<level>(ssa.type(), ssa.get_identifier(), ns);
   ssa.update_type();
   return ssa;

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -156,6 +156,24 @@ protected:
   }
 };
 
+renamedt<ssa_exprt, L0>
+goto_symex_statet::set_l0_indices(ssa_exprt ssa_expr, const namespacet &ns)
+{
+  return level0(std::move(ssa_expr), ns, source.thread_nr);
+}
+
+renamedt<ssa_exprt, L1>
+goto_symex_statet::set_l1_indices(ssa_exprt ssa_expr, const namespacet &ns)
+{
+  return level1(level0(std::move(ssa_expr), ns, source.thread_nr));
+}
+
+renamedt<ssa_exprt, L2>
+goto_symex_statet::set_l2_indices(ssa_exprt ssa_expr, const namespacet &ns)
+{
+  return level2(level1(level0(std::move(ssa_expr), ns, source.thread_nr)));
+}
+
 void goto_symex_statet::assignment(
   ssa_exprt &lhs, // L0/L1
   const exprt &rhs,  // L2
@@ -233,24 +251,6 @@ void goto_symex_statet::assignment(
   value_set.output(ns, std::cout);
   std::cout << "**********************\n";
   #endif
-}
-
-renamedt<ssa_exprt, L0>
-goto_symex_statet::set_l0_indices(ssa_exprt ssa_expr, const namespacet &ns)
-{
-  return level0(std::move(ssa_expr), ns, source.thread_nr);
-}
-
-renamedt<ssa_exprt, L1>
-goto_symex_statet::set_l1_indices(ssa_exprt ssa_expr, const namespacet &ns)
-{
-  return level1(level0(std::move(ssa_expr), ns, source.thread_nr));
-}
-
-renamedt<ssa_exprt, L2>
-goto_symex_statet::set_l2_indices(ssa_exprt ssa_expr, const namespacet &ns)
-{
-  return level2(level1(level0(std::move(ssa_expr), ns, source.thread_nr)));
 }
 
 template <levelt level>

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -113,14 +113,9 @@ protected:
   template <levelt>
   void rename_address(exprt &expr, const namespacet &ns);
 
-  /// Update level 0 values.
-  renamedt<ssa_exprt, L0> set_l0_indices(ssa_exprt expr, const namespacet &ns);
-
-  /// Update level 0 and 1 values.
-  renamedt<ssa_exprt, L1> set_l1_indices(ssa_exprt expr, const namespacet &ns);
-
-  /// Update level 0, 1 and 2 values.
-  renamedt<ssa_exprt, L2> set_l2_indices(ssa_exprt expr, const namespacet &ns);
+  /// Update values up to \c level.
+  template <levelt level>
+  renamedt<ssa_exprt, level> set_indices(ssa_exprt expr, const namespacet &ns);
 
   // this maps L1 names to (L2) types
   typedef std::unordered_map<irep_idt, typet> l1_typest;


### PR DESCRIPTION
This makes the interface of `goto_symex_statet` simpler and can simplify
code of function templates using set_indices

~This is based on #3986~ (merged)

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
