### PR TITLE
Add an is_global() predicate to symbolt.

### DIFF
--- a/src/util/symbol.h
+++ b/src/util/symbol.h
@@ -123,6 +123,12 @@ public:
     return is_auxiliary;
   }
 
+  /// Returns true iff the symbol belongs to the global scope.
+  bool is_global() const
+  {
+    return is_static_lifetime && is_lvalue;
+  }
+
   /// Mark a symbol for internal use. This is advisory and may be utilized,
   /// e.g., to filter output.
   void set_hidden()


### PR DESCRIPTION
This is a convenience predicate. Before that we had to remember to check a couple of properties. This makes it easier to handle by raising the abstraction level, and centralising the property checking. The properties checked have been reverse engineered from the properties that global symbols in the symbol table hold.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
