### PR TITLE
Delete as_const on rvalue

### DIFF
--- a/src/util/as_const.h
+++ b/src/util/as_const.h
@@ -16,4 +16,8 @@ const T &as_const(T &value)
   return static_cast<const T &>(value);
 }
 
+/// Deleted to avoid calling as_const on an xvalue
+template <typename T>
+void as_const(T &&) = delete;
+
 #endif // CPROVER_UTIL_AS_CONST_H


### PR DESCRIPTION
This is done similarly to the standard library (C++17) to avoid
returning a reference to a temporary value which may have been
destroyed.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
