### PR TITLE
Fix Xen integration test

### DIFF
--- a/integration/xen/Dockerfile
+++ b/integration/xen/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get --no-install-recommends -y install \
 
 ADD integration/xen/docker_compile_xen.sh docker_compile_xen.sh
 ADD src /tmp/cbmc/src
+ADD scripts /tmp/cbmc/scripts
 RUN ./docker_compile_xen.sh
 VOLUME /tmp/cbmc
 VOLUME /tmp/xen_compilation

--- a/integration/xen/Makefile
+++ b/integration/xen/Makefile
@@ -2,7 +2,7 @@ CONTAINER_ID = xen_build_container
 IMAGE_ID = xen_image
 
 all:
-	if docker ps | grep -q ^$(CONTAINER_ID) ; then \
+	if docker ps -a | grep -wq $(CONTAINER_ID) ; then \
 		docker rm xen_build_container ; \
 	fi
 	cd ../../ && docker build -t $(IMAGE_ID) -f integration/xen/Dockerfile .


### PR DESCRIPTION
1) We need the scripts/ directory inside the container to patch MiniSat.
2) Use -a with `docker ps` to also list containers that aren't running, and
don't expect the container name at the beginning of the line.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
