### PR TITLE
Pass a message handler to is_goto_binary [blocks: #3867]

### DIFF
--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -485,8 +485,9 @@ int cbmc_parse_optionst::doit()
 
   if(cmdline.isset("show-parse-tree"))
   {
-    if(cmdline.args.size()!=1 ||
-       is_goto_binary(cmdline.args[0]))
+    if(
+      cmdline.args.size() != 1 ||
+      is_goto_binary(cmdline.args[0], ui_message_handler))
     {
       error() << "Please give exactly one source file" << eom;
       return CPROVER_EXIT_INCORRECT_TASK;

--- a/src/goto-programs/initialize_goto_model.cpp
+++ b/src/goto-programs/initialize_goto_model.cpp
@@ -75,7 +75,7 @@ goto_modelt initialize_goto_model(
 
   for(const auto &file : files)
   {
-    if(is_goto_binary(file))
+    if(is_goto_binary(file, message_handler))
       binaries.push_back(file);
     else
       sources.push_back(file);

--- a/src/goto-programs/lazy_goto_model.cpp
+++ b/src/goto-programs/lazy_goto_model.cpp
@@ -128,7 +128,7 @@ void lazy_goto_modelt::initialize(
 
   for(const auto &file : files)
   {
-    if(is_goto_binary(file))
+    if(is_goto_binary(file, message_handler))
       binaries.push_back(file);
     else
       sources.push_back(file);

--- a/src/goto-programs/read_goto_binary.cpp
+++ b/src/goto-programs/read_goto_binary.cpp
@@ -155,7 +155,7 @@ static bool read_goto_binary(
   return true;
 }
 
-bool is_goto_binary(const std::string &filename)
+bool is_goto_binary(const std::string &filename, message_handlert &)
 {
   #ifdef _MSC_VER
   std::ifstream in(widen(filename), std::ios::binary);

--- a/src/goto-programs/read_goto_binary.h
+++ b/src/goto-programs/read_goto_binary.h
@@ -25,7 +25,7 @@ class symbol_tablet;
 optionalt<goto_modelt>
 read_goto_binary(const std::string &filename, message_handlert &);
 
-bool is_goto_binary(const std::string &filename);
+bool is_goto_binary(const std::string &filename, message_handlert &);
 
 bool read_object_and_link(
   const std::string &file_name,


### PR DESCRIPTION
This is in preparation of support for goto-cc sections in OS X Mach-O
files (#3867), where we will want to report problems while attempting to read a
file.

I believe this will break TG, but @allredj had already prepared a bump for #3867 at https://github.com/diffblue/test-gen/pull/2857. Presumably that would still do the trick.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
