### PR TITLE
Variant submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "jbmc/lib/java-models-library"]
 	path = jbmc/lib/java-models-library
 	url = https://github.com/diffblue/java-models-library.git
+[submodule "lib/variant"]
+	path = lib/variant
+	url = https://github.com/mpark/variant.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -326,6 +326,7 @@ install:
   - make -C src/cpp library_check
   - make -C src "CXX=${COMPILER} ${EXTRA_CXXFLAGS}" -j3
   - make -C jbmc/src "CXX=${COMPILER} ${EXTRA_CXXFLAGS}" -j3
+  - ./scripts/run_variant_tests.sh -j3
 
 script:
   - if [ -e bin/gcc ] ; then export PATH=$PWD/bin:$PATH ; fi ;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,8 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
     endif()
 endif()
 
+add_subdirectory(lib/variant)
+
 add_subdirectory(src)
 add_subdirectory(regression)
 add_subdirectory(unit)

--- a/scripts/run_variant_tests.sh
+++ b/scripts/run_variant_tests.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd lib/variant
+mkdir -p build
+cd build
+cmake -DMPARK_VARIANT_INCLUDE_TESTS="mpark" -DCMAKE_CXX_FLAGS="-std=c++11" ..
+cmake --build . -- $@
+ctest --output-on-failure

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -47,4 +47,4 @@ add_dependencies(util generate_version_cpp)
 
 generic_includes(util)
 
-target_link_libraries(util big-int langapi)
+target_link_libraries(util big-int langapi mpark_variant)

--- a/src/util/module_dependencies.txt
+++ b/src/util/module_dependencies.txt
@@ -1,6 +1,8 @@
 big-int
 mach # system
 malloc # system
+mpark
 nonstd
 sys # system
 util
+

--- a/src/util/variant.h
+++ b/src/util/variant.h
@@ -1,0 +1,18 @@
+/*******************************************************************\
+
+Module: typedef for variant class template. To be replaced with
+        std::variant once C++17 support is enabled
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_VARIANT_H
+#define CPROVER_UTIL_VARIANT_H
+
+#include <mpark/variant.hpp>
+
+template <typename... Ts>
+using variantt = mpark::variant<Ts...>;
+
+#endif // CPROVER_UTIL_VARIANT_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -78,6 +78,7 @@ SRC += analyses/ai/ai.cpp \
        util/symbol_table.cpp \
        util/symbol.cpp \
        util/unicode.cpp \
+       util/variant.cpp \
        # Empty last line
 
 INCLUDES= -I ../src/ -I.

--- a/unit/util/variant.cpp
+++ b/unit/util/variant.cpp
@@ -1,0 +1,12 @@
+// Copyright 2016-2019 Diffblue Limited. All Rights Reserved.
+
+#include <testing-utils/use_catch.h>
+#include <util/variant.h>
+
+TEST_CASE("Ensure variant has been included", "[core][util][variant]")
+{
+  variantt<int, float> some_type = 1;
+  REQUIRE(some_type.index() == 0);
+  some_type = 1.0f;
+  REQUIRE(some_type.index() == 1);
+}


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

This is a proposed replacement for  #3962 that I hope might be less controversial. It provides the following advantages:
 -  tests provided by the original repo are run in our CI
 - easy to find the source of variation

I didn't spend much time on this, so if people don't like it, no harm no fowl, but would quite like to be able to use variant.
