### PR TITLE
Add ranget drop and skip methods

### DIFF
--- a/src/util/range.h
+++ b/src/util/range.h
@@ -341,6 +341,24 @@ public:
     return begin_value == end_value;
   }
 
+  /// Return an new range containing the same elements except for the first
+  /// \p count elements.
+  /// If the range has fewer elements, returns an empty range.
+  ranget<iteratort> drop(std::size_t count) &&
+  {
+    for(; count > 0 && begin_value != end_value; --count)
+      ++begin_value;
+    return ranget<iteratort>{std::move(begin_value), std::move(end_value)};
+  }
+
+  /// Return an new range containing the same elements except for the first
+  /// \p count elements.
+  /// If the range has fewer elements, returns an empty range.
+  ranget<iteratort> drop(std::size_t count) const &
+  {
+    return ranget<iteratort>{begin(), end()}.drop(count);
+  }
+
   iteratort begin() const
   {
     return begin_value;

--- a/src/util/range.h
+++ b/src/util/range.h
@@ -289,7 +289,8 @@ struct ranget final
 public:
   using value_type = typename iteratort::value_type;
 
-  ranget(iteratort begin, iteratort end) : begin_value(begin), end_value(end)
+  ranget(iteratort begin, iteratort end)
+    : begin_value(std::move(begin)), end_value(std::move(end))
   {
   }
 

--- a/unit/util/range.cpp
+++ b/unit/util/range.cpp
@@ -57,6 +57,45 @@ SCENARIO("range tests", "[core][util][range]")
       ++it;
       REQUIRE(it == filtered_range.end());
     }
+
+    THEN("Drop first 2 elements")
+    {
+      auto range = make_range(list);
+      auto drop_range = range.drop(2);
+      auto it = drop_range.begin();
+      REQUIRE(*it == "acdef");
+      drop_range = std::move(drop_range).drop(1);
+      REQUIRE(drop_range.empty());
+      // Check the original is unmodified
+      REQUIRE(!range.empty());
+      REQUIRE(*range.begin() == "abc");
+    }
+    THEN("Drop first 5 elements")
+    {
+      auto range = make_range(list);
+      auto skip_range = range.drop(5);
+      REQUIRE(skip_range.empty());
+      // Check the original is unmodified
+      REQUIRE(!range.empty());
+      REQUIRE(*range.begin() == "abc");
+    }
+    THEN("Drop first 2 elements, move version")
+    {
+      auto range = make_range(list);
+      range = std::move(range).drop(2);
+      REQUIRE(!range.empty());
+      auto it = range.begin();
+      REQUIRE(*it == "acdef");
+      range = std::move(range).drop(1);
+      REQUIRE(range.empty());
+    }
+    THEN("Drop first 5 elements, move version")
+    {
+      auto range = make_range(list);
+      range = std::move(range).drop(5);
+      REQUIRE(range.empty());
+    }
+
     THEN(
       "A const instance of a `filter_iteratort` can mutate the input "
       "collection.")


### PR DESCRIPTION
This adds two utility methods to ranget which I would find useful. 
For instance we could iterate on a ranget with a while loop instead of a range-for: `while(!range.empty()) { ....; range.drop(1); ...}`

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
