### PR TITLE
Fix type of bddVar argument

### DIFF
--- a/src/solvers/bdd/bdd_cudd.h
+++ b/src/solvers/bdd/bdd_cudd.h
@@ -35,8 +35,11 @@ public:
     return Cudd_IsComplement(node) != 0;
   }
 
+  /// Type of indexes of Boolean variables
+  using indext = int;
+
   /// Label on the node, corresponds to the index of a Boolean variable
-  std::size_t index() const
+  indext index() const
   {
     return Cudd_NodeReadIndex(node);
   }
@@ -147,7 +150,7 @@ public:
     return bddt(cudd.bddZero());
   }
 
-  bddt bdd_variable(std::size_t index)
+  bddt bdd_variable(bdd_nodet::indext index)
   {
     return bddt(cudd.bddVar(index));
   }

--- a/src/solvers/bdd/bdd_miniBDD.h
+++ b/src/solvers/bdd/bdd_miniBDD.h
@@ -39,8 +39,11 @@ public:
     return node->node_number == 0;
   }
 
+  /// Type of indexes of Boolean variables
+  using indext = std::size_t;
+
   /// Label on the node, corresponds to the index of a Boolean variable
-  std::size_t index() const
+  indext index() const
   {
     return bdd_var_to_index.at(node->var);
   }
@@ -158,7 +161,7 @@ public:
     return bddt(False());
   }
 
-  bddt bdd_variable(std::size_t index)
+  bddt bdd_variable(bdd_nodet::indext index)
   {
     auto it = index_to_bdd.find(index);
     if(it != index_to_bdd.end())

--- a/src/solvers/prop/bdd_expr.cpp
+++ b/src/solvers/prop/bdd_expr.cpp
@@ -11,6 +11,7 @@ Author: Michael Tautschnig, michael.tautschnig@qmul.ac.uk
 
 #include "bdd_expr.h"
 
+#include <util/arith_tools.h>
 #include <util/expr_util.h>
 #include <util/format_expr.h>
 #include <util/invariant.h>
@@ -111,8 +112,9 @@ exprt bdd_exprt::as_expr(
       return true_exprt();
   }
 
-  INVARIANT(r.index() < node_map.size(), "Index should be in node_map");
-  const exprt &n_expr = node_map[r.index()];
+  auto index = numeric_cast_v<std::size_t>(r.index());
+  INVARIANT(index < node_map.size(), "Index should be in node_map");
+  const exprt &n_expr = node_map[index];
 
   // Look-up cache for already computed value
   auto insert_result = cache.emplace(r.id(), nil_exprt());


### PR DESCRIPTION
The function bdd_variable takes a size_t while cudd.bddVar takes an int,
we need a conversion between the two.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
