### PR TITLE
Memory snapshot harness havoc

### DIFF
--- a/regression/goto-harness/havoc-global-int-01/main.c
+++ b/regression/goto-harness/havoc-global-int-01/main.c
@@ -1,0 +1,8 @@
+int x = 1;
+
+int main()
+{
+  assert(x == 1);
+
+  return 0;
+}

--- a/regression/goto-harness/havoc-global-int-01/test.desc
+++ b/regression/goto-harness/havoc-global-int-01/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-location main:0 --havoc-variables x
+^EXIT=10$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion x == 1: FAILURE
+--
+^warning: ignoring

--- a/regression/goto-harness/havoc-global-int-02/main.c
+++ b/regression/goto-harness/havoc-global-int-02/main.c
@@ -1,0 +1,53 @@
+#include <assert.h>
+
+unsigned int x;
+unsigned int y;
+
+unsigned int nondet_int()
+{
+  unsigned int z;
+  return z;
+}
+
+void checkpoint()
+{
+}
+
+unsigned int complex_function_which_returns_one()
+{
+  unsigned int i = 0;
+  while(++i < 1000001)
+  {
+    if(nondet_int() && ((i & 1) == 1))
+      break;
+  }
+  return i & 1;
+}
+
+void fill_array(unsigned int *arr, unsigned int size)
+{
+  for(unsigned int i = 0; i < size; i++)
+    arr[i] = nondet_int();
+}
+
+unsigned int array_sum(unsigned int *arr, unsigned int size)
+{
+  unsigned int sum = 0;
+  for(unsigned int i = 0; i < size; i++)
+    sum += arr[i];
+  return sum;
+}
+
+const unsigned int array_size = 100000;
+
+int main()
+{
+  x = complex_function_which_returns_one();
+  unsigned int large_array[array_size];
+  fill_array(large_array, array_size);
+  y = array_sum(large_array, array_size);
+  checkpoint();
+  assert(y + 2 > y); //y is nondet -- may overflow
+  assert(0);
+  return 0;
+}

--- a/regression/goto-harness/havoc-global-int-02/test.desc
+++ b/regression/goto-harness/havoc-global-int-02/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-y-snapshot.json --initial-location main:9 --havoc-variables y
+^\[main.assertion.1\] line \d+ assertion y \+ 2 > y: FAILURE$
+^\[main.assertion.2\] line \d+ assertion 0: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/goto-harness/havoc-global-struct/main.c
+++ b/regression/goto-harness/havoc-global-struct/main.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+
+struct simple_str
+{
+  int i;
+  int j;
+} simple;
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  simple.i = 1;
+  simple.j = 2;
+
+  checkpoint();
+  assert(simple.j > simple.i);
+  return 0;
+}

--- a/regression/goto-harness/havoc-global-struct/test.desc
+++ b/regression/goto-harness/havoc-global-struct/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-struct-snapshot.json --initial-location main:3 --havoc-variables simple
+^EXIT=10$
+^SIGNAL=0$
+^\[main.assertion.1\] line \d+ assertion simple.j > simple.i: FAILURE$
+--
+^warning: ignoring

--- a/regression/goto-harness/load-snapshot-json-snapshots/global-int-x-y-snapshot.json
+++ b/regression/goto-harness/load-snapshot-json-snapshots/global-int-x-y-snapshot.json
@@ -1,0 +1,212 @@
+  {
+    "symbolTable": {
+      "__CPROVER_size_t": {
+        "baseName": "__CPROVER_size_t",
+        "isAuxiliary": false,
+        "isExported": false,
+        "isExtern": false,
+        "isFileLocal": true,
+        "isInput": false,
+        "isLvalue": false,
+        "isMacro": true,
+        "isOutput": false,
+        "isParameter": false,
+        "isProperty": false,
+        "isStateVar": false,
+        "isStaticLifetime": false,
+        "isThreadLocal": true,
+        "isType": true,
+        "isVolatile": false,
+        "isWeak": false,
+        "location": {
+          "id": "",
+          "namedSub": {
+            "file": {
+              "id": "<built-in-additions>"
+            },
+            "line": {
+              "id": "1"
+            },
+            "working_directory": {
+              "id": "/home/diffblue/petr.bauch/code/cbmc/regression/memory-analyzer"
+            }
+          }
+        },
+        "mode": "C",
+        "module": "main",
+        "name": "__CPROVER_size_t",
+        "prettyName": "__CPROVER_size_t",
+        "prettyType": "__CPROVER_size_t",
+        "prettyValue": "",
+        "type": {
+          "id": "unsignedbv",
+          "namedSub": {
+            "#c_type": {
+              "id": "unsigned_long_int"
+            },
+            "#source_location": {
+              "id": "",
+              "namedSub": {
+                "file": {
+                  "id": "<built-in-additions>"
+                },
+                "line": {
+                  "id": "1"
+                },
+                "working_directory": {
+                  "id": "/home/diffblue/petr.bauch/code/cbmc/regression/memory-analyzer"
+                }
+              }
+            },
+            "#typedef": {
+              "id": "__CPROVER_size_t"
+            },
+            "width": {
+              "id": "64"
+            }
+          }
+        },
+        "value": {
+          "id": "nil"
+        }
+      },
+      "x": {
+        "baseName": "x",
+        "isAuxiliary": false,
+        "isExported": false,
+        "isExtern": false,
+        "isFileLocal": false,
+        "isInput": false,
+        "isLvalue": true,
+        "isMacro": false,
+        "isOutput": false,
+        "isParameter": false,
+        "isProperty": false,
+        "isStateVar": false,
+        "isStaticLifetime": true,
+        "isThreadLocal": false,
+        "isType": false,
+        "isVolatile": false,
+        "isWeak": false,
+        "location": {
+          "id": "",
+          "namedSub": {
+            "file": {
+              "id": "main.c"
+            },
+            "line": {
+              "id": "3"
+            },
+            "working_directory": {
+              "id": "/home/diffblue/petr.bauch/code/cbmc/regression/memory-analyzer"
+            }
+          }
+        },
+        "mode": "C",
+        "module": "main",
+        "name": "x",
+        "prettyName": "x",
+        "prettyType": "unsigned int",
+        "prettyValue": "1u",
+        "type": {
+          "id": "unsignedbv",
+          "namedSub": {
+            "#c_type": {
+              "id": "unsigned_int"
+            },
+            "width": {
+              "id": "32"
+            }
+          }
+        },
+        "value": {
+          "id": "constant",
+          "namedSub": {
+            "type": {
+              "id": "unsignedbv",
+              "namedSub": {
+                "#c_type": {
+                  "id": "unsigned_int"
+                },
+                "width": {
+                  "id": "32"
+                }
+              }
+            },
+            "value": {
+              "id": "1"
+            }
+          }
+        }
+      },
+      "y": {
+        "baseName": "y",
+        "isAuxiliary": false,
+        "isExported": false,
+        "isExtern": false,
+        "isFileLocal": false,
+        "isInput": false,
+        "isLvalue": true,
+        "isMacro": false,
+        "isOutput": false,
+        "isParameter": false,
+        "isProperty": false,
+        "isStateVar": false,
+        "isStaticLifetime": true,
+        "isThreadLocal": false,
+        "isType": false,
+        "isVolatile": false,
+        "isWeak": false,
+        "location": {
+          "id": "",
+          "namedSub": {
+            "file": {
+              "id": "main.c"
+            },
+            "line": {
+              "id": "4"
+            },
+            "working_directory": {
+              "id": "/home/diffblue/petr.bauch/code/cbmc/regression/memory-analyzer"
+            }
+          }
+        },
+        "mode": "C",
+        "module": "main",
+        "name": "y",
+        "prettyName": "y",
+        "prettyType": "unsigned int",
+        "prettyValue": "0u",
+        "type": {
+          "id": "unsignedbv",
+          "namedSub": {
+            "#c_type": {
+              "id": "unsigned_int"
+            },
+            "width": {
+              "id": "32"
+            }
+          }
+        },
+        "value": {
+          "id": "constant",
+          "namedSub": {
+            "type": {
+              "id": "unsignedbv",
+              "namedSub": {
+                "#c_type": {
+                  "id": "unsigned_int"
+                },
+                "width": {
+                  "id": "32"
+                }
+              }
+            },
+            "value": {
+              "id": "0"
+            }
+          }
+        }
+      }
+    }
+  }

--- a/regression/goto-harness/load-snapshot-json-snapshots/global-struct-snapshot.json
+++ b/regression/goto-harness/load-snapshot-json-snapshots/global-struct-snapshot.json
@@ -1,0 +1,357 @@
+  {
+    "symbolTable": {
+      "__CPROVER_size_t": {
+        "baseName": "__CPROVER_size_t",
+        "isAuxiliary": false,
+        "isExported": false,
+        "isExtern": false,
+        "isFileLocal": true,
+        "isInput": false,
+        "isLvalue": false,
+        "isMacro": true,
+        "isOutput": false,
+        "isParameter": false,
+        "isProperty": false,
+        "isStateVar": false,
+        "isStaticLifetime": false,
+        "isThreadLocal": true,
+        "isType": true,
+        "isVolatile": false,
+        "isWeak": false,
+        "location": {
+          "id": "",
+          "namedSub": {
+            "file": {
+              "id": "<built-in-additions>"
+            },
+            "line": {
+              "id": "1"
+            },
+            "working_directory": {
+              "id": "/home/diffblue/petr.bauch/code/cbmc/regression/memory-analyzer"
+            }
+          }
+        },
+        "mode": "C",
+        "module": "main",
+        "name": "__CPROVER_size_t",
+        "prettyName": "__CPROVER_size_t",
+        "prettyType": "__CPROVER_size_t",
+        "prettyValue": "",
+        "type": {
+          "id": "unsignedbv",
+          "namedSub": {
+            "#c_type": {
+              "id": "unsigned_long_int"
+            },
+            "#source_location": {
+              "id": "",
+              "namedSub": {
+                "file": {
+                  "id": "<built-in-additions>"
+                },
+                "line": {
+                  "id": "1"
+                },
+                "working_directory": {
+                  "id": "/home/diffblue/petr.bauch/code/cbmc/regression/memory-analyzer"
+                }
+              }
+            },
+            "#typedef": {
+              "id": "__CPROVER_size_t"
+            },
+            "width": {
+              "id": "64"
+            }
+          }
+        },
+        "value": {
+          "id": "nil"
+        }
+      },
+      "simple": {
+        "baseName": "simple",
+        "isAuxiliary": false,
+        "isExported": false,
+        "isExtern": false,
+        "isFileLocal": false,
+        "isInput": false,
+        "isLvalue": true,
+        "isMacro": false,
+        "isOutput": false,
+        "isParameter": false,
+        "isProperty": false,
+        "isStateVar": false,
+        "isStaticLifetime": true,
+        "isThreadLocal": false,
+        "isType": false,
+        "isVolatile": false,
+        "isWeak": false,
+        "location": {
+          "id": "",
+          "namedSub": {
+            "file": {
+              "id": "main.c"
+            },
+            "line": {
+              "id": "6"
+            },
+            "working_directory": {
+              "id": "/home/diffblue/petr.bauch/code/cbmc/regression/memory-analyzer"
+            }
+          }
+        },
+        "mode": "C",
+        "module": "main",
+        "name": "simple",
+        "prettyName": "simple",
+        "prettyType": "struct simple_str",
+        "prettyValue": "{ .i=1, .j=2 }",
+        "type": {
+          "id": "struct_tag",
+          "namedSub": {
+            "#source_location": {
+              "id": "",
+              "namedSub": {
+                "file": {
+                  "id": "main.c"
+                },
+                "line": {
+                  "id": "3"
+                },
+                "working_directory": {
+                  "id": "/home/diffblue/petr.bauch/code/cbmc/regression/memory-analyzer"
+                }
+              }
+            },
+            "identifier": {
+              "id": "tag-simple_str"
+            }
+          }
+        },
+        "value": {
+          "id": "struct",
+          "namedSub": {
+            "#source_location": {
+              "id": "",
+              "namedSub": {
+                "file": {
+                  "id": "main.c"
+                },
+                "line": {
+                  "id": "6"
+                },
+                "working_directory": {
+                  "id": "/home/diffblue/petr.bauch/code/cbmc/regression/memory-analyzer"
+                }
+              }
+            },
+            "type": {
+              "id": "struct_tag",
+              "namedSub": {
+                "#source_location": {
+                  "id": "",
+                  "namedSub": {
+                    "file": {
+                      "id": "main.c"
+                    },
+                    "line": {
+                      "id": "3"
+                    },
+                    "working_directory": {
+                      "id": "/home/diffblue/petr.bauch/code/cbmc/regression/memory-analyzer"
+                    }
+                  }
+                },
+                "identifier": {
+                  "id": "tag-simple_str"
+                }
+              }
+            }
+          },
+          "sub": [
+            {
+              "id": "constant",
+              "namedSub": {
+                "type": {
+                  "id": "signedbv",
+                  "namedSub": {
+                    "#c_type": {
+                      "id": "signed_int"
+                    },
+                    "width": {
+                      "id": "32"
+                    }
+                  }
+                },
+                "value": {
+                  "id": "1"
+                }
+              }
+            },
+            {
+              "id": "constant",
+              "namedSub": {
+                "type": {
+                  "id": "signedbv",
+                  "namedSub": {
+                    "#c_type": {
+                      "id": "signed_int"
+                    },
+                    "width": {
+                      "id": "32"
+                    }
+                  }
+                },
+                "value": {
+                  "id": "2"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "tag-simple_str": {
+        "baseName": "simple_str",
+        "isAuxiliary": false,
+        "isExported": false,
+        "isExtern": false,
+        "isFileLocal": false,
+        "isInput": false,
+        "isLvalue": false,
+        "isMacro": false,
+        "isOutput": false,
+        "isParameter": false,
+        "isProperty": false,
+        "isStateVar": false,
+        "isStaticLifetime": false,
+        "isThreadLocal": false,
+        "isType": true,
+        "isVolatile": false,
+        "isWeak": false,
+        "location": {
+          "id": "",
+          "namedSub": {
+            "file": {
+              "id": "main.c"
+            },
+            "line": {
+              "id": "3"
+            },
+            "working_directory": {
+              "id": "/home/diffblue/petr.bauch/code/cbmc/regression/memory-analyzer"
+            }
+          }
+        },
+        "mode": "C",
+        "module": "main",
+        "name": "tag-simple_str",
+        "prettyName": "struct simple_str",
+        "prettyType": "struct simple_str { signed int i; signed int j; }",
+        "prettyValue": "",
+        "type": {
+          "id": "struct",
+          "namedSub": {
+            "#source_location": {
+              "id": "",
+              "namedSub": {
+                "file": {
+                  "id": "main.c"
+                },
+                "line": {
+                  "id": "3"
+                },
+                "working_directory": {
+                  "id": "/home/diffblue/petr.bauch/code/cbmc/regression/memory-analyzer"
+                }
+              }
+            },
+            "components": {
+              "id": "",
+              "sub": [
+                {
+                  "id": "",
+                  "namedSub": {
+                    "#source_location": {
+                      "id": "",
+                      "namedSub": {
+                        "file": {
+                          "id": "main.c"
+                        },
+                        "line": {
+                          "id": "4"
+                        },
+                        "working_directory": {
+                          "id": "/home/diffblue/petr.bauch/code/cbmc/regression/memory-analyzer"
+                        }
+                      }
+                    },
+                    "name": {
+                      "id": "i"
+                    },
+                    "pretty_name": {
+                      "id": "i"
+                    },
+                    "type": {
+                      "id": "signedbv",
+                      "namedSub": {
+                        "#c_type": {
+                          "id": "signed_int"
+                        },
+                        "width": {
+                          "id": "32"
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "id": "",
+                  "namedSub": {
+                    "#source_location": {
+                      "id": "",
+                      "namedSub": {
+                        "file": {
+                          "id": "main.c"
+                        },
+                        "line": {
+                          "id": "5"
+                        },
+                        "working_directory": {
+                          "id": "/home/diffblue/petr.bauch/code/cbmc/regression/memory-analyzer"
+                        }
+                      }
+                    },
+                    "name": {
+                      "id": "j"
+                    },
+                    "pretty_name": {
+                      "id": "j"
+                    },
+                    "type": {
+                      "id": "signedbv",
+                      "namedSub": {
+                        "#c_type": {
+                          "id": "signed_int"
+                        },
+                        "width": {
+                          "id": "32"
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "tag": {
+              "id": "simple_str"
+            }
+          }
+        },
+        "value": {
+          "id": "nil"
+        }
+      }
+    }
+  }

--- a/src/goto-harness/memory_snapshot_harness_generator.h
+++ b/src/goto-harness/memory_snapshot_harness_generator.h
@@ -51,28 +51,97 @@ public:
   {
   }
 
+  /// The main function of this harness, consists of the following:
+  /// 1. Load memory table from the snapshot.
+  /// 2. Add initial section to the user-specified initial location.
+  /// 3. Assign global variables their snapshot values (via the harness
+  ///    function).
+  /// 4. Insert call of the initial location (with nondet values) into the
+  ///    harness function.
+  /// 5. Build symbol for the harness functions.
+  /// 6. Insert harness function into \p goto_model.
+  /// \param goto_model: goto model to be modified
+  /// \param harness_function_name: name of the resulting harness function
   void generate(goto_modelt &goto_model, const irep_idt &harness_function_name)
     override;
 
 protected:
+  /// Collect the memory-snapshot specific cmdline options (one at a time)
+  /// \param option: memory-snapshot | initial-location | havoc-variables
+  /// \param values: list of arguments related to a given option
   void handle_option(
     const std::string &option,
     const std::list<std::string> &values) override;
 
+  /// Check that user options make sense:
+  /// On their own, e.g. location number cannot be specified without a function.
+  /// In relation to the input program, e.g. function name must be known via
+  ///   the symbol table.
+  /// \param goto_model: the model containing the symbol table, goto functions,
+  ///   etc.
   void validate_options(const goto_modelt &goto_model) override;
 
+  /// Parse the snapshot JSON file and initialise the symbol table
+  /// \param file: the snapshot JSON file
+  /// \param snapshot: the resulting symbol table built from the snapshot
   void
   get_memory_snapshot(const std::string &file, symbol_tablet &snapshot) const;
 
+  /// Modify the entry-point function to start from the user-specified initial
+  ///   location.
+  /// Turn this:
+  ///
+  ///    int foo() {
+  ///      ..first_part..
+  /// i:   //location_number=i
+  ///      ..second_part..
+  ///    }
+  ///
+  /// Into this:
+  ///
+  ///   func_init_done;
+  ///   __CPROVER_initialize() {
+  ///     ...
+  ///     func_init_done = false;
+  ///   }
+  ///   int foo() {
+  ///     if (func_init_done) goto 1;
+  ///     func_init_done = true;
+  ///     goto i;
+  /// 1:  ;
+  ///     ..first_part..
+  /// i:  //location_number=i
+  ///     ..second_part..
+  ///   }
+  ///
+  /// \param goto_model: Model where the modification takes place
   void add_init_section(goto_modelt &goto_model) const;
 
+  /// For each global symbol in the \p snapshot symbol table either:
+  /// 1) add \ref code_assignt assigning a value from the \p snapshot to the
+  ///    symbol
+  /// or
+  /// 2) recursively initialise the symbol to a non-deterministic value of the
+  ///    right type
+  /// \param snapshot: snapshot to load the symbols and their values from
+  /// \param goto_model: model to initialise the havoc-ing
+  /// \return the block of code where the assignments are added
   code_blockt add_assignments_to_globals(
     const symbol_tablet &snapshot,
     goto_modelt &goto_model) const;
+
+  /// Create as many non-deterministic arguments as there are arguments of the
+  /// \p called_function_symbol and add a function call with those arguments
+  /// \param called_function_symbol: the function to be called
+  /// \param code: the block of code where the function call is added
   void add_call_with_nondet_arguments(
     const symbolt &called_function_symbol,
     code_blockt &code) const;
 
+  /// Insert the \p function into the symbol table (and the goto functions map)
+  /// of the \p goto_model
+  /// \param goto_model: goto model where the insertion is to take place
+  /// \param function: symbol of the function to be inserted
   void insert_harness_function_into_goto_model(
     goto_modelt &goto_model,
     const symbolt &function) const;

--- a/src/goto-harness/memory_snapshot_harness_generator.h
+++ b/src/goto-harness/memory_snapshot_harness_generator.h
@@ -19,9 +19,12 @@ Author: Daniel Poetzl
 #include <util/message.h>
 #include <util/optional.h>
 
+// clang-format off
 #define MEMORY_SNAPSHOT_HARNESS_GENERATOR_OPTIONS                              \
   "(memory-snapshot):"                                                         \
-  "(initial-location):" // MEMORY_SNAPSHOT_HARNESS_GENERATOR_OPTIONS
+  "(initial-location):"                                                        \
+  "(havoc-variables):" // MEMORY_SNAPSHOT_HARNESS_GENERATOR_OPTIONS
+// clang-format on
 
 // clang-format off
 #define MEMORY_SNAPSHOT_HARNESS_GENERATOR_HELP                                 \
@@ -31,6 +34,8 @@ Author: Daniel Poetzl
   "--initial-location <func[:<n>]>\n"                                          \
   "                              use given function and location number as "   \
   "entry\n                              point\n"                               \
+  "--havoc-variables vars        initialise variables from vars to\n"          \
+  "                              non-deterministic values"                     \
   // MEMORY_SNAPSHOT_HARNESS_GENERATOR_HELP
 // clang-format on
 
@@ -61,8 +66,9 @@ protected:
 
   void add_init_section(goto_modelt &goto_model) const;
 
-  code_blockt add_assignments_to_globals(const symbol_tablet &snapshot) const;
-
+  code_blockt add_assignments_to_globals(
+    const symbol_tablet &snapshot,
+    goto_modelt &goto_model) const;
   void add_call_with_nondet_arguments(
     const symbolt &called_function_symbol,
     code_blockt &code) const;
@@ -75,6 +81,7 @@ protected:
 
   irep_idt entry_function_name;
   optionalt<unsigned> location_number;
+  std::unordered_set<irep_idt> variables_to_havoc;
 
   message_handlert &message_handler;
 };


### PR DESCRIPTION
This PR adds the option to selectively initialise global variables from a snapshot to a non-deterministic value rather than the value they had in the snapshot.

The scope of this PR are global variables of primitive types but since we use the `recursive_initialization` for the havoc-ing, the scope is inherited from the goto-harness general. At this moment, `struct_tag`, `pointer`, and `array` have dedicated treatment. On the other hand it is not within the scope of this PR to modify the configuration of the recursive initialization, i.e. the default values are used.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
