### PR TITLE
Use narrow instead of numeric_cast on std::size_t

### DIFF
--- a/src/solvers/prop/bdd_expr.cpp
+++ b/src/solvers/prop/bdd_expr.cpp
@@ -11,13 +11,10 @@ Author: Michael Tautschnig, michael.tautschnig@qmul.ac.uk
 
 #include "bdd_expr.h"
 
-#include <util/arith_tools.h>
 #include <util/expr_util.h>
 #include <util/format_expr.h>
 #include <util/invariant.h>
 #include <util/std_expr.h>
-
-#include <sstream>
 
 bddt bdd_exprt::from_expr_rec(const exprt &expr)
 {

--- a/src/solvers/prop/bdd_expr.cpp
+++ b/src/solvers/prop/bdd_expr.cpp
@@ -112,7 +112,7 @@ exprt bdd_exprt::as_expr(
       return true_exprt();
   }
 
-  auto index = numeric_cast_v<std::size_t>(r.index());
+  auto index = narrow<std::size_t>(r.index());
   INVARIANT(index < node_map.size(), "Index should be in node_map");
   const exprt &n_expr = node_map[index];
 


### PR DESCRIPTION
numeric_cast implicitely converts the std::size_t to an mp_integer,
before converting it back to an integral value and checking for bound
which is less efficient than narrow.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
