### PR TITLE
Move get_null_assignment out of object factory

### DIFF
--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -8,6 +8,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "java_object_factory.h"
 
+#include <util/code_util.h>
 #include <util/expr_initializer.h>
 #include <util/nondet.h>
 #include <util/nondet_bool.h>
@@ -58,10 +59,6 @@ class java_object_factoryt
   const select_pointer_typet &pointer_type_selector;
 
   allocate_objectst allocate_objects;
-
-  code_assignt get_null_assignment(
-    const exprt &expr,
-    const pointer_typet &ptr_type);
 
   void gen_pointer_target_init(
     code_blockt &assignments,
@@ -184,17 +181,6 @@ private:
     update_in_placet update_in_place,
     const source_locationt &location);
 };
-
-/// Returns a codet that assigns \p expr, of type \p ptr_type, a NULL value.
-code_assignt java_object_factoryt::get_null_assignment(
-  const exprt &expr,
-  const pointer_typet &ptr_type)
-{
-  null_pointer_exprt null_pointer_expr(ptr_type);
-  code_assignt code(expr, null_pointer_expr);
-  code.add_source_location()=loc;
-  return code;
-}
 
 /// Initializes the pointer-typed lvalue expression `expr` to point to an object
 /// of type `target_type`, recursively nondet-initializing the members of that
@@ -571,7 +557,7 @@ void java_object_factoryt::gen_nondet_pointer_init(
     {
       if(update_in_place==update_in_placet::NO_UPDATE_IN_PLACE)
       {
-        assignments.add(get_null_assignment(expr, pointer_type));
+        assignments.add(get_null_assignment(expr, pointer_type, loc));
       }
       // Otherwise leave it as it is.
       return;
@@ -650,7 +636,7 @@ void java_object_factoryt::gen_nondet_pointer_init(
     update_in_placet::NO_UPDATE_IN_PLACE,
     location);
 
-  auto set_null_inst=get_null_assignment(expr, pointer_type);
+  auto set_null_inst = get_null_assignment(expr, pointer_type, loc);
 
   const bool allow_null = depth > object_factory_parameters.min_null_tree_depth;
 

--- a/src/ansi-c/c_nondet_symbol_factory.cpp
+++ b/src/ansi-c/c_nondet_symbol_factory.cpp
@@ -16,6 +16,7 @@ Author: Diffblue Ltd.
 #include <util/allocate_objects.h>
 #include <util/arith_tools.h>
 #include <util/c_types.h>
+#include <util/code_util.h>
 #include <util/fresh_symbol.h>
 #include <util/namespace.h>
 #include <util/nondet_bool.h>
@@ -62,8 +63,7 @@ void symbol_factoryt::gen_nondet_init(
         recursion_set.find(struct_tag) != recursion_set.end() &&
         depth >= object_factory_params.max_nondet_tree_depth)
       {
-        assignments.add(code_assignt(expr, null_pointer_exprt(pointer_type)));
-
+        assignments.add(get_null_assignment(expr, pointer_type, loc));
         return;
       }
     }
@@ -91,9 +91,7 @@ void symbol_factoryt::gen_nondet_init(
       //           <code from recursive call to gen_nondet_init() with
       //             tmp$<temporary_counter>>
       // And the next line is labelled label2
-      auto set_null_inst=code_assignt(expr, null_pointer_exprt(pointer_type));
-      set_null_inst.add_source_location()=loc;
-
+      auto set_null_inst = get_null_assignment(expr, pointer_type, loc);
       code_ifthenelset null_check(
         side_effect_expr_nondett(bool_typet(), loc),
         std::move(set_null_inst),

--- a/src/goto-harness/recursive_initialization.cpp
+++ b/src/goto-harness/recursive_initialization.cpp
@@ -11,6 +11,7 @@ Author: Diffblue Ltd.
 #include <util/allocate_objects.h>
 #include <util/arith_tools.h>
 #include <util/c_types.h>
+#include <util/code_util.h>
 #include <util/fresh_symbol.h>
 #include <util/irep.h>
 #include <util/optional_utils.h>
@@ -129,7 +130,7 @@ void recursive_initializationt::initialize_pointer(
 
   auto pointee = pointee_symbol.symbol_expr();
   allocate_objects.declare_created_symbols(body);
-  body.add(code_assignt{lhs, null_pointer_exprt{type}});
+  body.add(get_null_assignment(lhs, type, type.source_location()));
   bool is_unknown_struct_tag =
     can_cast_type<tag_typet>(type.subtype()) &&
     known_tags.find(to_tag_type(type.subtype()).get_identifier()) ==

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -6,6 +6,7 @@ SRC = allocate_objects.cpp \
       byte_operators.cpp \
       c_types.cpp \
       cmdline.cpp \
+      code_util.cpp \
       config.cpp \
       cout_message.cpp \
       decision_procedure.cpp \

--- a/src/util/allocate_objects.cpp
+++ b/src/util/allocate_objects.cpp
@@ -10,6 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "arith_tools.h"
 #include "c_types.h"
+#include "code_util.h"
 #include "fresh_symbol.h"
 #include "pointer_offset_size.h"
 #include "string_constant.h"
@@ -147,11 +148,8 @@ exprt allocate_objectst::allocate_dynamic_object(
   if(allocate_type.id() == ID_empty)
   {
     // make null
-    null_pointer_exprt null_pointer_expr(to_pointer_type(target_expr.type()));
-    code_assignt code(target_expr, null_pointer_expr);
-    code.add_source_location() = source_location;
-    output_code.add(code);
-
+    output_code.add(get_null_assignment(
+      target_expr, to_pointer_type(target_expr.type()), source_location));
     return exprt();
   }
 

--- a/src/util/code_util.cpp
+++ b/src/util/code_util.cpp
@@ -13,8 +13,7 @@ code_assignt get_null_assignment(
   const pointer_typet &ptr_type,
   const source_locationt &loc)
 {
-  null_pointer_exprt null_pointer_expr(ptr_type);
-  code_assignt code(expr, null_pointer_expr);
+  code_assignt code{expr, null_pointer_exprt{ptr_type}};
   code.add_source_location() = loc;
   return code;
 }

--- a/src/util/code_util.cpp
+++ b/src/util/code_util.cpp
@@ -1,0 +1,20 @@
+/*******************************************************************\
+
+Module: codet utilities
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include "code_util.h"
+
+code_assignt get_null_assignment(
+  const exprt &expr,
+  const pointer_typet &ptr_type,
+  const source_locationt &loc)
+{
+  null_pointer_exprt null_pointer_expr(ptr_type);
+  code_assignt code(expr, null_pointer_expr);
+  code.add_source_location() = loc;
+  return code;
+}

--- a/src/util/code_util.h
+++ b/src/util/code_util.h
@@ -1,0 +1,21 @@
+/*******************************************************************\
+
+Module: codet utilities
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_CODE_UTIL_H
+#define CPROVER_UTIL_CODE_UTIL_H
+
+#include "std_code.h"
+
+/// Returns a codet that assigns \p expr, of type \p ptr_type, a NULL value, and
+/// has source location \p loc.
+code_assignt get_null_assignment(
+  const exprt &expr,
+  const pointer_typet &ptr_type,
+  const source_locationt &loc);
+
+#endif // CPROVER_UTIL_CODE_UTIL_H


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->
My goal is to tidy up the Java object factory a bit as I'm hoping to be able to re-use some of its functionality and it currently has a few helper functions that should probably live somewhere else.
The target of this PR is the simple `get_null_assignment`. My suggestion with this PR is to move it to a new util file `util/code_util.h`, mirroring the already existing `util/expr_util.h`. I couldn't find a better place to put it. However, if reviewers can think of a better place for it, or if they think I should just inline it because it's so simple, let me know and I'm happy to change it. All I want is for it to go out of the object factory. :slightly_smiling_face: 

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
