### PR TITLE
Synchronise file extensions between C++ language and C/C++ preprocessor

### DIFF
--- a/src/ansi-c/c_preprocess.cpp
+++ b/src/ansi-c/c_preprocess.cpp
@@ -585,7 +585,8 @@ bool c_preprocess_gcc_clang(
      has_suffix(file, ".C") ||
   #endif
      has_suffix(file, ".c++") || has_suffix(file, ".C++") ||
-     has_suffix(file, ".cp") || has_suffix(file, ".CP"))
+     has_suffix(file, ".cp") || has_suffix(file, ".CP") ||
+     has_suffix(file, ".cc") || has_suffix(file, ".cxx"))
   {
     switch(config.cpp.cpp_standard)
     {

--- a/src/ansi-c/c_preprocess.cpp
+++ b/src/ansi-c/c_preprocess.cpp
@@ -580,13 +580,14 @@ bool c_preprocess_gcc_clang(
     argv.push_back("-nostdinc");
 
   // Set the standard
-  if(has_suffix(file, ".cpp") || has_suffix(file, ".CPP") ||
-  #ifndef _WIN32
-     has_suffix(file, ".C") ||
-  #endif
-     has_suffix(file, ".c++") || has_suffix(file, ".C++") ||
-     has_suffix(file, ".cp") || has_suffix(file, ".CP") ||
-     has_suffix(file, ".cc") || has_suffix(file, ".cxx"))
+  if(
+    has_suffix(file, ".cpp") || has_suffix(file, ".CPP") ||
+#ifndef _WIN32
+    has_suffix(file, ".C") ||
+#endif
+    has_suffix(file, ".c++") || has_suffix(file, ".C++") ||
+    has_suffix(file, ".cp") || has_suffix(file, ".CP") ||
+    has_suffix(file, ".cc") || has_suffix(file, ".cxx"))
   {
     switch(config.cpp.cpp_standard)
     {

--- a/src/cpp/cpp_language.cpp
+++ b/src/cpp/cpp_language.cpp
@@ -37,6 +37,7 @@ std::set<std::string> cpp_languaget::extensions() const
   s.insert("cpp");
   s.insert("CPP");
   s.insert("cc");
+  s.insert("cp");
   s.insert("c++");
   s.insert("ii");
   s.insert("cxx");


### PR DESCRIPTION
Largely follows GCC's documentation at
https://gcc.gnu.org/onlinedocs/gcc/Overall-Options.html#index-file-name-suffix-71,
with the extension that we accept some uppercase variants in C/C++
pre-processing.

Fixes: #4358

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
