### PR TITLE
Split out goto_statet::source

### DIFF
--- a/src/goto-checker/symex_bmc.cpp
+++ b/src/goto-checker/symex_bmc.cpp
@@ -93,12 +93,15 @@ void symex_bmct::symex_step(
   }
 }
 
-void symex_bmct::merge_goto(goto_statet &&goto_state, statet &state)
+void symex_bmct::merge_goto(
+  const symex_targett::sourcet &prev_source,
+  goto_statet &&goto_state,
+  statet &state)
 {
-  const goto_programt::const_targett prev_pc = goto_state.source.pc;
+  const goto_programt::const_targett prev_pc = prev_source.pc;
   const guardt prev_guard = goto_state.guard;
 
-  goto_symext::merge_goto(std::move(goto_state), state);
+  goto_symext::merge_goto(prev_source, std::move(goto_state), state);
 
   PRECONDITION(prev_pc->is_goto());
   if(

--- a/src/goto-checker/symex_bmc.h
+++ b/src/goto-checker/symex_bmc.h
@@ -95,7 +95,10 @@ protected:
   void symex_step(const get_goto_functiont &get_goto_function, statet &state)
     override;
 
-  void merge_goto(goto_statet &&goto_state, statet &state) override;
+  void merge_goto(
+    const symex_targett::sourcet &source,
+    goto_statet &&goto_state,
+    statet &state) override;
 
   bool should_stop_unwind(
     const symex_targett::sourcet &source,

--- a/src/goto-symex/frame.h
+++ b/src/goto-symex/frame.h
@@ -13,12 +13,14 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #define CPROVER_GOTO_SYMEX_FRAME_H
 
 #include "goto_state.h"
+#include "symex_target.h"
 
 /// Stack frames -- these are used for function calls and for exceptions
 struct framet
 {
   // gotos
-  using goto_state_listt = std::list<goto_statet>;
+  using goto_state_listt =
+    std::list<std::pair<symex_targett::sourcet, goto_statet>>;
 
   // function calls
   irep_idt function_identifier;

--- a/src/goto-symex/goto_state.h
+++ b/src/goto-symex/goto_state.h
@@ -17,7 +17,6 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include <pointer-analysis/value_set.h>
 
 #include "renaming_level.h"
-#include "symex_target_equation.h"
 
 /// Container for data that varies per program point, e.g. the constant
 /// propagator state, when state needs to branch. This is copied out of
@@ -41,8 +40,6 @@ public:
   // of the condition of the if).
   guardt guard;
 
-  symex_targett::sourcet source;
-
   // Map L1 names to (L2) constants. Values will be evicted from this map
   // when they become non-constant. This is used to propagate values that have
   // been worked out to only have one possible value.
@@ -60,10 +57,8 @@ public:
   /// Constructors
   explicit goto_statet(const class goto_symex_statet &s);
 
-  goto_statet(
-    const symex_targett::sourcet &_source,
-    guard_managert &guard_manager)
-    : guard(true_exprt(), guard_manager), source(_source)
+  explicit goto_statet(guard_managert &guard_manager)
+    : guard(true_exprt(), guard_manager)
   {
   }
 };

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -336,9 +336,13 @@ protected:
   /// Merge a single branch, the symbolic state of which is held in \p
   /// goto_state, into the current overall symbolic state. \p goto_state is no
   /// longer expected to be valid afterwards.
+  /// \param source: source associated with the incoming \p goto_state
   /// \param goto_state: A state to be merged into this location
   /// \param state: Symbolic execution state to be updated
-  virtual void merge_goto(goto_statet &&goto_state, statet &state);
+  virtual void merge_goto(
+    const symex_targett::sourcet &source,
+    goto_statet &&goto_state,
+    statet &state);
 
   /// Merge the SSA assignments from goto_state into dest_state
   /// \param goto_state: A state to be merged into this location

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -32,7 +32,8 @@ static void get_l1_name(exprt &expr);
 goto_symex_statet::goto_symex_statet(
   const symex_targett::sourcet &_source,
   guard_managert &manager)
-  : goto_statet(_source, manager),
+  : goto_statet(manager),
+    source(_source),
     guard_manager(manager),
     symex_target(nullptr),
     record_events(true),

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -54,6 +54,8 @@ public:
     symex_target = target;
   }
 
+  symex_targett::sourcet source;
+
   /// contains symbols that are minted during symbolic execution, such as
   /// dynamically created objects etc. The names in this table are needed
   /// for error traces even after symbolic execution has finished.
@@ -219,7 +221,6 @@ inline goto_statet::goto_statet(const class goto_symex_statet &s)
     level2(s.level2),
     value_set(s.value_set),
     guard(s.guard),
-    source(s.source),
     propagation(s.propagation),
     atomic_section_id(s.atomic_section_id)
 {


### PR DESCRIPTION
This is the one member of goto_statet which is not trivially moved when it is combined
with an existing goto_symex_statet -- rather it labels the incoming state and is discarded
after perhaps being inspected by the merge_goto routine. By splitting these we prepare
goto_statet to use a trivial move-constructor when merging into a goto_symex_statet with
a false state guard.

There should be no behavioural change caused by this commit.