### PR TITLE
Fix Makefile-based build for with CUDD

### DIFF
--- a/jbmc/src/janalyzer/Makefile
+++ b/jbmc/src/janalyzer/Makefile
@@ -11,6 +11,7 @@ OBJ += ../$(CPROVER_DIR)/src/ansi-c/ansi-c$(LIBEXT) \
       ../$(CPROVER_DIR)/src/pointer-analysis/pointer-analysis$(LIBEXT) \
       ../$(CPROVER_DIR)/src/langapi/langapi$(LIBEXT) \
       ../$(CPROVER_DIR)/src/json/json$(LIBEXT) \
+      ../$(CPROVER_DIR)/src/solvers/solvers$(LIBEXT) \
       ../$(CPROVER_DIR)/src/util/util$(LIBEXT) \
       ..//miniz/miniz$(OBJEXT) \
       ../$(CPROVER_DIR)/src/goto-analyzer/static_show_domain$(OBJEXT) \

--- a/jbmc/src/jdiff/Makefile
+++ b/jbmc/src/jdiff/Makefile
@@ -28,6 +28,7 @@ OBJ += ../$(CPROVER_DIR)/src/ansi-c/ansi-c$(LIBEXT) \
       ../$(CPROVER_DIR)/src/analyses/analyses$(LIBEXT) \
       ../$(CPROVER_DIR)/src/langapi/langapi$(LIBEXT) \
       ../$(CPROVER_DIR)/src/xmllang/xmllang$(LIBEXT) \
+      ../$(CPROVER_DIR)/src/solvers/solvers$(LIBEXT) \
       ../$(CPROVER_DIR)/src/util/util$(LIBEXT) \
       ../miniz/miniz$(OBJEXT) \
       ../$(CPROVER_DIR)/src/json/json$(LIBEXT) \

--- a/src/analyses/Makefile
+++ b/src/analyses/Makefile
@@ -41,6 +41,10 @@ CLEANFILES = analyses$(LIBEXT)
 
 all: analyses$(LIBEXT)
 
+ifneq ($(CUDD),)
+  OBJ += $(CUDD)/cudd/.libs/libcudd$(LIBEXT) $(CUDD)/cplusplus/.libs/libobj$(LIBEXT)
+endif
+
 ###############################################################################
 
 analyses$(LIBEXT): $(OBJ)

--- a/src/common
+++ b/src/common
@@ -195,6 +195,16 @@ ifneq ($(CADICAL),)
 endif
 
 
+ifneq ($(CUDD),)
+  CP_CXXFLAGS += -DHAVE_CUDD
+ifeq ($(CPROVER_DIR),)
+  INCLUDES += -I $(CUDD) -I $(CUDD)/cudd
+else
+  INCLUDES += -I ../$(CPROVER_DIR)/src/solvers/$(CUDD)
+  INCLUDES += -I ../$(CPROVER_DIR)/src/solvers/$(CUDD)/cudd
+endif
+endif
+
 
 first_target: all
 

--- a/src/goto-analyzer/Makefile
+++ b/src/goto-analyzer/Makefile
@@ -19,6 +19,7 @@ OBJ += ../ansi-c/ansi-c$(LIBEXT) \
       ../langapi/langapi$(LIBEXT) \
       ../json/json$(LIBEXT) \
       ../assembler/assembler$(LIBEXT) \
+      ../solvers/solvers$(LIBEXT) \
       ../util/util$(LIBEXT) \
       # Empty last line
 

--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -44,9 +44,7 @@ ifneq ($(SQUOLEM2),)
 endif
 
 ifneq ($(CUDD),)
-  CUDD_INCLUDE=-I $(CUDD)
   CUDD_LIB=$(CUDD)/cudd/.libs/libcudd$(LIBEXT) $(CUDD)/cplusplus/.libs/libobj$(LIBEXT)
-  CP_CXXFLAGS += -DHAVE_CUDD
 endif
 
 ifneq ($(PICOSAT),)

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -84,6 +84,7 @@ SRC += analyses/ai/ai.cpp \
 
 INCLUDES= -I ../src/ -I.
 
+CPROVER_DIR = .
 include ../src/config.inc
 include ../src/common
 


### PR DESCRIPTION
The previous set-up failed to compile (as cudd.h was not found), and
first fixes to make it compile and link resulted in persistent
segmentation faults. These were caused by inconsistent includes as
HAVE_CUDD was only set in selected directories (unlike the CMake
configuration).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
