### PR TITLE
Define constructors that take a source location argument

### DIFF
--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -62,10 +62,6 @@ class java_object_factoryt
   /// Log for reporting warnings and errors in object creation
   messaget log;
 
-  code_assignt get_null_assignment(
-    const exprt &expr,
-    const pointer_typet &ptr_type);
-
   void gen_pointer_target_init(
     code_blockt &assignments,
     const exprt &expr,
@@ -189,17 +185,6 @@ private:
     update_in_placet update_in_place,
     const source_locationt &location);
 };
-
-/// Returns a codet that assigns \p expr, of type \p ptr_type, a NULL value.
-code_assignt java_object_factoryt::get_null_assignment(
-  const exprt &expr,
-  const pointer_typet &ptr_type)
-{
-  null_pointer_exprt null_pointer_expr(ptr_type);
-  code_assignt code(expr, null_pointer_expr);
-  code.add_source_location()=loc;
-  return code;
-}
 
 /// Initializes the pointer-typed lvalue expression `expr` to point to an object
 /// of type `target_type`, recursively nondet-initializing the members of that
@@ -576,7 +561,8 @@ void java_object_factoryt::gen_nondet_pointer_init(
     {
       if(update_in_place==update_in_placet::NO_UPDATE_IN_PLACE)
       {
-        assignments.add(get_null_assignment(expr, pointer_type));
+        assignments.add(
+          code_assignt{expr, null_pointer_exprt{pointer_type}, loc});
       }
       // Otherwise leave it as it is.
       return;
@@ -655,7 +641,7 @@ void java_object_factoryt::gen_nondet_pointer_init(
     update_in_placet::NO_UPDATE_IN_PLACE,
     location);
 
-  auto set_null_inst=get_null_assignment(expr, pointer_type);
+  const code_assignt set_null_inst{expr, null_pointer_exprt{pointer_type}, loc};
 
   const bool allow_null = depth > object_factory_parameters.min_null_tree_depth;
 

--- a/src/ansi-c/c_nondet_symbol_factory.cpp
+++ b/src/ansi-c/c_nondet_symbol_factory.cpp
@@ -62,7 +62,8 @@ void symbol_factoryt::gen_nondet_init(
         recursion_set.find(struct_tag) != recursion_set.end() &&
         depth >= object_factory_params.max_nondet_tree_depth)
       {
-        assignments.add(code_assignt(expr, null_pointer_exprt(pointer_type)));
+        assignments.add(
+          code_assignt{expr, null_pointer_exprt{pointer_type}, loc});
 
         return;
       }
@@ -91,8 +92,8 @@ void symbol_factoryt::gen_nondet_init(
       //           <code from recursive call to gen_nondet_init() with
       //             tmp$<temporary_counter>>
       // And the next line is labelled label2
-      auto set_null_inst=code_assignt(expr, null_pointer_exprt(pointer_type));
-      set_null_inst.add_source_location()=loc;
+      const code_assignt set_null_inst{
+        expr, null_pointer_exprt{pointer_type}, loc};
 
       code_ifthenelset null_check(
         side_effect_expr_nondett(bool_typet(), loc),

--- a/src/goto-harness/recursive_initialization.cpp
+++ b/src/goto-harness/recursive_initialization.cpp
@@ -129,7 +129,7 @@ void recursive_initializationt::initialize_pointer(
 
   auto pointee = pointee_symbol.symbol_expr();
   allocate_objects.declare_created_symbols(body);
-  body.add(code_assignt{lhs, null_pointer_exprt{type}});
+  body.add(code_assignt{lhs, null_pointer_exprt{type}, type.source_location()});
   bool is_unknown_struct_tag =
     can_cast_type<tag_typet>(type.subtype()) &&
     known_tags.find(to_tag_type(type.subtype()).get_identifier()) ==

--- a/src/util/allocate_objects.cpp
+++ b/src/util/allocate_objects.cpp
@@ -147,10 +147,10 @@ exprt allocate_objectst::allocate_dynamic_object(
   if(allocate_type.id() == ID_empty)
   {
     // make null
-    null_pointer_exprt null_pointer_expr(to_pointer_type(target_expr.type()));
-    code_assignt code(target_expr, null_pointer_expr);
-    code.add_source_location() = source_location;
-    output_code.add(code);
+    code_assignt code{target_expr,
+                      null_pointer_exprt{to_pointer_type(target_expr.type())},
+                      source_location};
+    output_code.add(std::move(code));
 
     return exprt();
   }

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -71,6 +71,12 @@ public:
   {
   }
 
+  exprt(const irep_idt &id, typet type, source_locationt loc)
+    : exprt(id, std::move(type))
+  {
+    add_source_location() = std::move(loc);
+  }
+
   /// Return the type of the expression
   typet &type() { return static_cast<typet &>(add(ID_type)); }
   const typet &type() const

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -47,6 +47,12 @@ public:
     set_statement(statement);
   }
 
+  codet(const irep_idt &statement, source_locationt loc)
+    : exprt(ID_code, empty_typet(), std::move(loc))
+  {
+    set_statement(statement);
+  }
+
   /// \param statement: Specifies the type of the `codet` to be constructed,
   ///   e.g. `ID_block` for a \ref code_blockt or `ID_assign` for a
   ///   \ref code_assignt.
@@ -54,6 +60,12 @@ public:
   explicit codet(const irep_idt &statement, operandst _op) : codet(statement)
   {
     operands() = std::move(_op);
+  }
+
+  codet(const irep_idt &statement, operandst op, source_locationt loc)
+    : codet(statement, std::move(loc))
+  {
+    operands() = std::move(op);
   }
 
   void set_statement(const irep_idt &statement)
@@ -292,6 +304,11 @@ public:
 
   code_assignt(exprt lhs, exprt rhs)
     : codet(ID_assign, {std::move(lhs), std::move(rhs)})
+  {
+  }
+
+  code_assignt(exprt lhs, exprt rhs, source_locationt loc)
+    : codet(ID_assign, {std::move(lhs), std::move(rhs)}, std::move(loc))
   {
   }
 
@@ -1842,21 +1859,19 @@ public:
     operandst _operands,
     typet _type,
     source_locationt loc)
-    : exprt(ID_side_effect, std::move(_type))
+    : exprt(ID_side_effect, std::move(_type), std::move(loc))
   {
     set_statement(statement);
     operands() = std::move(_operands);
-    add_source_location().swap(loc);
   }
 
   side_effect_exprt(
     const irep_idt &statement,
     typet _type,
     source_locationt loc)
-    : exprt(ID_side_effect, std::move(_type))
+    : exprt(ID_side_effect, std::move(_type), std::move(loc))
   {
     set_statement(statement);
-    add_source_location().swap(loc);
   }
 
   const irep_idt &get_statement() const


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->
This is an alternative approach to https://github.com/diffblue/cbmc/pull/4355 for getting rid of the `get_null_assignment` helper function in the Java object factory, following @romainbrenguier 's suggestion.
I'm not sure if documentation is required on the new constructors as they are exactly the same as existing constructor except for the new source location parameter.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
