### PR TITLE
avoid access to instructiont::guard

### DIFF
--- a/src/analyses/interval_analysis.cpp
+++ b/src/analyses/interval_analysis.cpp
@@ -43,9 +43,9 @@ void instrument_intervals(
     }
     else
     {
-      goto_programt::const_targett previous=i_it;
-      previous--;
-      if(previous->is_goto() && !previous->guard.is_true())
+      goto_programt::const_targett previous = std::prev(i_it);
+
+      if(previous->is_goto() && !previous->get_condition().is_true())
       {
         // we follow a branch, instrument
       }

--- a/src/analyses/invariant_propagation.cpp
+++ b/src/analyses/invariant_propagation.cpp
@@ -256,6 +256,6 @@ void invariant_propagationt::simplify(goto_programt &goto_program)
     ::simplify(simplified_guard, ns);
 
     if(invariant_set.implies(simplified_guard).is_true())
-      i_it->guard=true_exprt();
+      i_it->set_condition(true_exprt());
   }
 }

--- a/src/goto-analyzer/static_simplifier.cpp
+++ b/src/goto-analyzer/static_simplifier.cpp
@@ -65,33 +65,45 @@ bool static_simplifier(
 
       if(i_it->is_assert())
       {
-        bool unchanged =
-          ai.abstract_state_before(i_it)->ai_simplify(i_it->guard, ns);
+        exprt cond = i_it->get_condition();
+
+        bool unchanged = ai.abstract_state_before(i_it)->ai_simplify(cond, ns);
 
         if(unchanged)
           unmodified.asserts++;
         else
+        {
           simplified.asserts++;
+          i_it->set_condition(cond);
+        }
       }
       else if(i_it->is_assume())
       {
-        bool unchanged =
-          ai.abstract_state_before(i_it)->ai_simplify(i_it->guard, ns);
+        exprt cond = i_it->get_condition();
+
+        bool unchanged = ai.abstract_state_before(i_it)->ai_simplify(cond, ns);
 
         if(unchanged)
           unmodified.assumes++;
         else
+        {
           simplified.assumes++;
+          i_it->set_condition(cond);
+        }
       }
       else if(i_it->is_goto())
       {
-        bool unchanged =
-          ai.abstract_state_before(i_it)->ai_simplify(i_it->guard, ns);
+        exprt cond = i_it->get_condition();
+
+        bool unchanged = ai.abstract_state_before(i_it)->ai_simplify(cond, ns);
 
         if(unchanged)
           unmodified.gotos++;
         else
+        {
           simplified.gotos++;
+          i_it->set_condition(cond);
+        }
       }
       else if(i_it->is_assign())
       {

--- a/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
+++ b/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
@@ -828,7 +828,7 @@ void disjunctive_polynomial_accelerationt::build_path(
       // If this was a conditional branch (it probably was), figure out
       // if we hit the "taken" or "not taken" branch & accumulate the
       // appropriate guard.
-      cond=not_exprt(t->guard);
+      cond = not_exprt(t->get_condition());
 
       for(goto_programt::targetst::iterator it=t->targets.begin();
           it!=t->targets.end();
@@ -836,7 +836,7 @@ void disjunctive_polynomial_accelerationt::build_path(
       {
         if(next==*it)
         {
-          cond=t->guard;
+          cond = t->get_condition();
           break;
         }
       }

--- a/src/goto-instrument/accelerate/overflow_instrumenter.cpp
+++ b/src/goto-instrument/accelerate/overflow_instrumenter.cpp
@@ -64,7 +64,8 @@ void overflow_instrumentert::add_overflow_checks(
     add_overflow_checks(t, assignment.rhs(), added);
   }
 
-  add_overflow_checks(t, t->guard, added);
+  if(t->has_condition())
+    add_overflow_checks(t, t->get_condition(), added);
 
   checked.insert(t->location_number);
 }

--- a/src/goto-instrument/accelerate/polynomial_accelerator.cpp
+++ b/src/goto-instrument/accelerate/polynomial_accelerator.cpp
@@ -816,7 +816,7 @@ exprt polynomial_acceleratort::precondition(patht &path)
     }
     else if(t->is_assume() || t->is_assert())
     {
-      ret=implies_exprt(t->guard, ret);
+      ret = implies_exprt(t->get_condition(), ret);
     }
     else
     {

--- a/src/goto-instrument/accelerate/sat_path_enumerator.cpp
+++ b/src/goto-instrument/accelerate/sat_path_enumerator.cpp
@@ -184,7 +184,7 @@ void sat_path_enumeratort::build_path(
       // If this was a conditional branch (it probably was), figure out
       // if we hit the "taken" or "not taken" branch & accumulate the
       // appropriate guard.
-      cond=not_exprt(t->guard);
+      cond = not_exprt(t->get_condition());
 
       for(goto_programt::targetst::iterator it=t->targets.begin();
           it!=t->targets.end();
@@ -192,7 +192,7 @@ void sat_path_enumeratort::build_path(
       {
         if(next==*it)
         {
-          cond=t->guard;
+          cond = t->get_condition();
           break;
         }
       }

--- a/src/goto-instrument/accelerate/scratch_program.cpp
+++ b/src/goto-instrument/accelerate/scratch_program.cpp
@@ -95,7 +95,7 @@ goto_programt::targett scratch_programt::assign(
 goto_programt::targett scratch_programt::assume(const exprt &guard)
 {
   targett instruction=add_instruction(ASSUME);
-  instruction->guard=guard;
+  instruction->set_condition(guard);
 
   return instruction;
 }
@@ -143,7 +143,9 @@ void scratch_programt::fix_types()
     }
     else if(it->is_assume() || it->is_assert())
     {
-      ::fix_types(it->guard);
+      exprt cond = it->get_condition();
+      ::fix_types(cond);
+      it->set_condition(cond);
     }
   }
 }
@@ -162,12 +164,12 @@ void scratch_programt::append_path(patht &path)
     {
       if(it->guard.id()!=ID_nil)
       {
-        add_instruction(ASSUME)->guard=it->guard;
+        add_instruction(ASSUME)->set_condition(it->guard);
       }
     }
     else if(it->loc->is_assert())
     {
-      add_instruction(ASSUME)->guard=it->loc->guard;
+      add_instruction(ASSUME)->set_condition(it->loc->get_condition());
     }
   }
 }

--- a/src/goto-instrument/accelerate/scratch_program.cpp
+++ b/src/goto-instrument/accelerate/scratch_program.cpp
@@ -26,7 +26,7 @@ bool scratch_programt::check_sat(bool do_slice, guard_managert &guard_manager)
 {
   fix_types();
 
-  add_instruction(END_FUNCTION);
+  add(goto_programt::make_end_function());
 
   remove_skip(*this);
 
@@ -85,19 +85,12 @@ goto_programt::targett scratch_programt::assign(
   const exprt &lhs,
   const exprt &rhs)
 {
-  code_assignt assignment(lhs, rhs);
-  targett instruction=add_instruction(ASSIGN);
-  instruction->code=assignment;
-
-  return instruction;
+  return add(goto_programt::make_assignment(lhs, rhs));
 }
 
 goto_programt::targett scratch_programt::assume(const exprt &guard)
 {
-  targett instruction=add_instruction(ASSUME);
-  instruction->set_condition(guard);
-
-  return instruction;
+  return add(goto_programt::make_assumption(guard));
 }
 
 static void fix_types(exprt &expr)
@@ -164,12 +157,12 @@ void scratch_programt::append_path(patht &path)
     {
       if(it->guard.id()!=ID_nil)
       {
-        add_instruction(ASSUME)->set_condition(it->guard);
+        add(goto_programt::make_assumption(it->guard));
       }
     }
     else if(it->loc->is_assert())
     {
-      add_instruction(ASSUME)->set_condition(it->loc->get_condition());
+      add(goto_programt::make_assumption(it->loc->get_condition()));
     }
   }
 }
@@ -192,7 +185,7 @@ void scratch_programt::append_loop(
   (void)loop_header; // unused parameter
   assume(false_exprt());
 
-  goto_programt::targett end=add_instruction(SKIP);
+  goto_programt::targett end = add(goto_programt::make_skip());
 
   update();
 

--- a/src/goto-instrument/call_sequences.cpp
+++ b/src/goto-instrument/call_sequences.cpp
@@ -231,7 +231,7 @@ void check_call_sequencet::operator()()
     {
       goto_programt::const_targett t=e.pc->get_target();
 
-      if(e.pc->guard.is_true())
+      if(e.pc->get_condition().is_true())
         e.pc=t;
       else
       {

--- a/src/goto-instrument/concurrency.cpp
+++ b/src/goto-instrument/concurrency.cpp
@@ -124,7 +124,11 @@ void concurrency_instrumentationt::instrument(
       instrument(code.rhs());
     }
     else if(it->is_assume() || it->is_assert() || it->is_goto())
-      instrument(it->guard);
+    {
+      exprt cond = it->get_condition();
+      instrument(cond);
+      it->set_condition(cond);
+    }
     else if(it->is_function_call())
     {
       code_function_callt &code=to_code_function_call(it->code);

--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -312,9 +312,10 @@ static void instrument_cover_goals(
       if(i_it->is_assert())
       {
         auto successor = std::next(i_it);
-        if(successor != function.body.instructions.end() &&
-           successor->is_assume() &&
-           successor->guard == i_it->guard)
+        if(
+          successor != function.body.instructions.end() &&
+          successor->is_assume() &&
+          successor->get_condition() == i_it->get_condition())
         {
           successor->turn_into_skip();
         }

--- a/src/goto-instrument/dot.cpp
+++ b/src/goto-instrument/dot.cpp
@@ -107,11 +107,11 @@ void dott::write_dot_subgraph(
       std::stringstream tmp("");
       if(it->is_goto())
       {
-        if(it->guard.is_true())
+        if(it->get_condition().is_true())
           tmp.str("Goto");
         else
         {
-          std::string t = from_expr(ns, function_id, it->guard);
+          std::string t = from_expr(ns, function_id, it->get_condition());
           while(t[ t.size()-1 ]=='\n')
             t = t.substr(0, t.size()-1);
           tmp << escape(t) << "?";
@@ -119,14 +119,14 @@ void dott::write_dot_subgraph(
       }
       else if(it->is_assume())
       {
-        std::string t = from_expr(ns, function_id, it->guard);
+        std::string t = from_expr(ns, function_id, it->get_condition());
         while(t[ t.size()-1 ]=='\n')
           t = t.substr(0, t.size()-1);
         tmp << "Assume\\n(" << escape(t) << ")";
       }
       else if(it->is_assert())
       {
-        std::string t = from_expr(ns, function_id, it->guard);
+        std::string t = from_expr(ns, function_id, it->get_condition());
         while(t[ t.size()-1 ]=='\n')
           t = t.substr(0, t.size()-1);
         tmp << "Assert\\n(" << escape(t) << ")";
@@ -180,7 +180,7 @@ void dott::write_dot_subgraph(
 
       out << "Node_" << subgraphscount << "_" << it->location_number;
       out << " [shape=";
-      if(it->is_goto() && !it->guard.is_true() && !it->guard.is_false())
+      if(it->is_goto() && !it->get_condition().is_constant())
         out << "diamond";
       else
         out <<"Mrecord";
@@ -311,13 +311,13 @@ void dott::find_next(
   std::set<goto_programt::const_targett> &tres,
   std::set<goto_programt::const_targett> &fres)
 {
-  if(it->is_goto() && !it->guard.is_false())
+  if(it->is_goto() && !it->get_condition().is_false())
   {
     for(const auto &target : it->targets)
       tres.insert(target);
   }
 
-  if(it->is_goto() && it->guard.is_true())
+  if(it->is_goto() && it->get_condition().is_true())
     return;
 
   goto_programt::const_targett next = it; next++;

--- a/src/goto-instrument/full_slicer.cpp
+++ b/src/goto-instrument/full_slicer.cpp
@@ -310,8 +310,9 @@ void full_slicert::operator()(
       add_to_queue(queue, e_it->second, e_it->first);
     else if(implicit(e_it->first))
       add_to_queue(queue, e_it->second, e_it->first);
-    else if((e_it->first->is_goto() && e_it->first->guard.is_true()) ||
-            e_it->first->is_throw())
+    else if(
+      (e_it->first->is_goto() && e_it->first->get_condition().is_true()) ||
+      e_it->first->is_throw())
       jumps.push_back(e_it->second);
     else if(e_it->first->is_decl())
     {

--- a/src/goto-instrument/generate_function_bodies.cpp
+++ b/src/goto-instrument/generate_function_bodies.cpp
@@ -106,7 +106,7 @@ protected:
     const namespacet ns(symbol_table);
     std::ostringstream comment_stream;
     comment_stream << id2string(ID_assertion) << " "
-                   << format(assert_instruction->guard);
+                   << format(assert_instruction->get_condition());
     assert_instruction->source_location.set_comment(comment_stream.str());
     assert_instruction->source_location.set_property_class(ID_assertion);
     add_instruction(goto_programt::make_end_function());
@@ -135,7 +135,7 @@ protected:
     const namespacet ns(symbol_table);
     std::ostringstream comment_stream;
     comment_stream << id2string(ID_assertion) << " "
-                   << format(assert_instruction->guard);
+                   << format(assert_instruction->get_condition());
     assert_instruction->source_location.set_comment(comment_stream.str());
     assert_instruction->source_location.set_property_class(ID_assertion);
     add_instruction(goto_programt::make_assumption(false_exprt()));

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -601,8 +601,8 @@ int goto_instrument_parse_optionst::doit()
         {
           if(ins.code.is_not_nil())
             status() << ins.code.pretty() << eom;
-          if(ins.guard.is_not_nil())
-            status() << "[guard] " << ins.guard.pretty() << eom;
+          if(ins.has_condition())
+            status() << "[guard] " << ins.get_condition().pretty() << eom;
         }
       return CPROVER_EXIT_SUCCESS;
     }

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -198,7 +198,7 @@ goto_programt::const_targett goto_program2codet::convert_instruction(
 
     case ASSERT:
       system_headers.insert("assert.h");
-      dest.add(code_assertt(target->guard));
+      dest.add(code_assertt(target->get_condition()));
       dest.statements().back().add_source_location().set_comment(
         target->source_location.get_comment());
       return target;
@@ -847,11 +847,12 @@ bool goto_program2codet::remove_default(
           break;
       }
 
-      if(next_case!=goto_program.instructions.end() &&
-         next_case==default_target &&
-         (!it->case_last->is_goto() ||
-          (it->case_last->guard.is_true() &&
-           it->case_last->get_target()==default_target)))
+      if(
+        next_case != goto_program.instructions.end() &&
+        next_case == default_target &&
+        (!it->case_last->is_goto() ||
+         (it->case_last->get_condition().is_true() &&
+          it->case_last->get_target() == default_target)))
       {
         // if there is no goto here, yet we got here, all others would
         // branch to this - we don't need default

--- a/src/goto-instrument/k_induction.cpp
+++ b/src/goto-instrument/k_induction.cpp
@@ -83,8 +83,8 @@ void k_inductiont::process_loop(
       goto_unwindt::unwind_strategyt::PARTIAL);
 
     // assume the loop condition has become false
-    goto_programt::instructiont assume(ASSUME);
-    assume.guard=loop_guard;
+    goto_programt::instructiont assume =
+      goto_programt::make_assumption(loop_guard);
     goto_function.body.insert_before_swap(loop_exit, assume);
   }
 
@@ -135,8 +135,8 @@ void k_inductiont::process_loop(
     }
 
     // assume the loop condition has become false
-    goto_programt::instructiont assume(ASSUME);
-    assume.guard=loop_guard;
+    goto_programt::instructiont assume =
+      goto_programt::make_assumption(loop_guard);
     goto_function.body.insert_before_swap(loop_exit, assume);
 
     // Now havoc at the loop head. Use insert_swap to

--- a/src/goto-instrument/nondet_volatile.cpp
+++ b/src/goto-instrument/nondet_volatile.cpp
@@ -107,12 +107,12 @@ void nondet_volatile(
       // do return value
       nondet_volatile_lhs(symbol_table, code_function_call.lhs());
     }
-    else if(instruction.is_assert() ||
-            instruction.is_assume() ||
-            instruction.is_goto())
+    else if(instruction.has_condition())
     {
-      // do guard
-      nondet_volatile_rhs(symbol_table, instruction.guard);
+      // do condition
+      exprt cond = instruction.get_condition();
+      nondet_volatile_rhs(symbol_table, cond);
+      instruction.set_condition(cond);
     }
   }
 }

--- a/src/goto-instrument/rw_set.cpp
+++ b/src/goto-instrument/rw_set.cpp
@@ -55,7 +55,7 @@ void _rw_set_loct::compute()
           target->is_assume() ||
           target->is_assert())
   {
-    read(target->guard);
+    read(target->get_condition());
   }
   else if(target->is_function_call())
   {

--- a/src/goto-instrument/uninitialized.cpp
+++ b/src/goto-instrument/uninitialized.cpp
@@ -156,10 +156,10 @@ void uninitializedt::add_assertions(
             const irep_idt new_identifier=id2string(identifier)+"#initialized";
 
             // insert assertion
-            goto_programt::instructiont assertion;
-            assertion.type=ASSERT;
-            assertion.guard=symbol_exprt(new_identifier, bool_typet());
-            assertion.source_location=instruction.source_location;
+            goto_programt::instructiont assertion =
+              goto_programt::make_assertion(
+                symbol_exprt(new_identifier, bool_typet()),
+                instruction.source_location);
             assertion.source_location.set_comment(
               "use of uninitialized local variable");
             assertion.source_location.set_property_class("uninitialized local");

--- a/src/goto-instrument/unwind.cpp
+++ b/src/goto-instrument/unwind.cpp
@@ -134,14 +134,14 @@ void goto_unwindt::unwind(
 
     exprt exit_cond = false_exprt(); // default is false
 
-    if(!t->guard.is_true()) // cond in backedge
+    if(!t->get_condition().is_true()) // cond in backedge
     {
-      exit_cond = boolean_negate(t->guard);
+      exit_cond = boolean_negate(t->get_condition());
     }
     else if(loop_head->is_goto())
     {
       if(loop_head->get_target()==loop_exit) // cond in forward edge
-        exit_cond=loop_head->guard;
+        exit_cond = loop_head->get_condition();
     }
 
     goto_programt::targett new_t;
@@ -176,7 +176,7 @@ void goto_unwindt::unwind(
     goto_programt::const_targett t_before=loop_exit;
     t_before--;
 
-    if(!t_before->is_goto() || !t_before->guard.is_true())
+    if(!t_before->is_goto() || !t_before->get_condition().is_true())
     {
       goto_programt::targett t_goto = goto_program.insert_before(
         loop_exit,

--- a/src/goto-instrument/wmm/shared_buffers.cpp
+++ b/src/goto-instrument/wmm/shared_buffers.cpp
@@ -319,12 +319,8 @@ void shared_bufferst::write(
   const exprt cond_expr=
     not_exprt(and_exprt(buff1_used_expr, buff0_used_expr));
 
-  target=goto_program.insert_before(target);
-  target->guard=cond_expr;
-  target->type=ASSERT;
-  target->code = code_assertt(cond_expr);
-  target->code.add_source_location()=source_location;
-  target->source_location=source_location;
+  target = goto_program.insert_before(
+    target, goto_programt::make_assertion(cond_expr, source_location));
   target++;
 
   // We update writers ownership of the values in the buffer

--- a/src/goto-instrument/wmm/weak_memory.cpp
+++ b/src/goto-instrument/wmm/weak_memory.cpp
@@ -88,11 +88,11 @@ void introduce_temporaries(
       symbol_exprt symbol_expr=new_symbol.symbol_expr();
 
       goto_programt::instructiont new_i = goto_programt::make_assignment(
-        code_assignt(symbol_expr, instruction.guard),
+        code_assignt(symbol_expr, instruction.get_condition()),
         instruction.source_location);
 
       // replace guard
-      instruction.guard=symbol_expr;
+      instruction.set_condition(symbol_expr);
       goto_program.insert_before_swap(i_it, new_i);
 
       i_it++; // step forward

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1472,7 +1472,7 @@ void goto_convertt::generate_ifthenelse(
   {
     // The above conjunction deliberately excludes the instance
     // if(some) { label: assert(false); }
-    true_case.instructions.back().guard=boolean_negate(guard);
+    true_case.instructions.back().set_condition(boolean_negate(guard));
     dest.destructive_append(true_case);
     true_case.instructions.clear();
     if(
@@ -1490,7 +1490,7 @@ void goto_convertt::generate_ifthenelse(
   {
     // The above conjunction deliberately excludes the instance
     // if(some) ... else { label: assert(false); }
-    false_case.instructions.back().guard=guard;
+    false_case.instructions.back().set_condition(guard);
     dest.destructive_append(false_case);
     false_case.instructions.clear();
     if(
@@ -1509,7 +1509,7 @@ void goto_convertt::generate_ifthenelse(
     true_case.instructions.front().labels.empty() &&
     true_case.instructions.back().labels.empty())
   {
-    true_case.instructions.front().guard = boolean_negate(guard);
+    true_case.instructions.front().set_condition(boolean_negate(guard));
     true_case.instructions.erase(--true_case.instructions.end());
     dest.destructive_append(true_case);
     true_case.instructions.clear();

--- a/src/goto-programs/link_goto_model.cpp
+++ b/src/goto-programs/link_goto_model.cpp
@@ -156,10 +156,10 @@ static bool link_functions(
     Forall_goto_functions(dest_it, dest_functions)
       Forall_goto_program_instructions(iit, dest_it->second.body)
       {
-        object_type_updates(iit->code);
-
-        if(iit->has_condition())
-          object_type_updates(iit->guard);
+        iit->transform([&object_type_updates](exprt expr) {
+          object_type_updates(expr);
+          return expr;
+        });
       }
   }
 

--- a/src/goto-programs/set_properties.cpp
+++ b/src/goto-programs/set_properties.cpp
@@ -136,21 +136,12 @@ void make_assertions_false(goto_modelt &goto_model)
 void make_assertions_false(
   goto_functionst &goto_functions)
 {
-  for(goto_functionst::function_mapt::iterator
-      f_it=goto_functions.function_map.begin();
-      f_it!=goto_functions.function_map.end();
-      f_it++)
+  for(auto &f : goto_functions.function_map)
   {
-    goto_programt &goto_program=f_it->second.body;
-
-    for(goto_programt::instructionst::iterator
-        i_it=goto_program.instructions.begin();
-        i_it!=goto_program.instructions.end();
-        i_it++)
+    for(auto &i : f.second.body.instructions)
     {
-      if(!i_it->is_assert())
-        continue;
-      i_it->guard=false_exprt();
+      if(i.is_assert())
+        i.set_condition(false_exprt());
     }
   }
 }

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -450,7 +450,11 @@ goto_programt::targett string_abstractiont::abstract(
   case ASSERT:
   case ASSUME:
     if(has_string_macros(it->get_condition()))
-      replace_string_macros(it->guard, false, it->source_location);
+    {
+      exprt tmp = it->get_condition();
+      replace_string_macros(tmp, false, it->source_location);
+      it->set_condition(tmp);
+    }
     break;
 
   case FUNCTION_CALL:


### PR DESCRIPTION
This will eventually enable us to protect `instructiont::guard`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
