### PR TITLE
Single path symex only while there are properties to check

### DIFF
--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -279,7 +279,10 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
 
   // generate unwinding assertions
   if(cmdline.isset("unwinding-assertions"))
+  {
     options.set_option("unwinding-assertions", true);
+    options.set_option("paths-symex-explore-all", true);
+  }
 
   if(cmdline.isset("partial-loops"))
     options.set_option("partial-loops", true);
@@ -416,9 +419,12 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
   }
 
   if(cmdline.isset("symex-coverage-report"))
+  {
     options.set_option(
       "symex-coverage-report",
       cmdline.get_value("symex-coverage-report"));
+    options.set_option("paths-symex-explore-all", true);
+  }
 
   if(cmdline.isset("validate-ssa-equation"))
   {

--- a/src/goto-checker/single_path_symex_checker.cpp
+++ b/src/goto-checker/single_path_symex_checker.cpp
@@ -70,7 +70,9 @@ operator()(propertiest &properties)
       goto_symext::get_goto_function(goto_model), symex_symbol_table);
   }
 
-  while(!worklist->empty())
+  while(!worklist->empty() &&
+        (options.get_bool_option("paths-symex-explore-all") ||
+         has_properties_to_check(properties)))
   {
     path_storaget::patht &resume = worklist->peek();
     symex_bmct symex(

--- a/src/goto-checker/single_path_symex_only_checker.cpp
+++ b/src/goto-checker/single_path_symex_only_checker.cpp
@@ -53,7 +53,9 @@ operator()(propertiest &properties)
       goto_symext::get_goto_function(goto_model), symex_symbol_table);
   }
 
-  while(!worklist->empty())
+  while(!worklist->empty() &&
+        (options.get_bool_option("paths-symex-explore-all") ||
+         has_properties_to_check(properties)))
   {
     path_storaget::patht &resume = worklist->peek();
     symex_bmct symex(


### PR DESCRIPTION
This makes the exploration finish as soon as there are no goals left that could be covered, instead of exploring all paths exhaustively.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
