### PR TITLE
Symex filter value sets using clean expr

### DIFF
--- a/regression/cbmc/CMakeLists.txt
+++ b/regression/cbmc/CMakeLists.txt
@@ -5,7 +5,7 @@ add_test_pl_tests(
 add_test_pl_profile(
     "cbmc-paths-lifo"
     "$<TARGET_FILE:cbmc> --paths lifo"
-    "-C;-X;thorough-paths;-X;smt-backend;-s;paths-lifo"
+    "-C;-X;thorough-paths;-X;smt-backend;-X;paths-lifo-expected-failure;-s;paths-lifo"
     "CORE"
 )
 

--- a/regression/cbmc/Makefile
+++ b/regression/cbmc/Makefile
@@ -7,7 +7,7 @@ test-cprover-smt2:
 	@../test.pl -e -p -c "../../../src/cbmc/cbmc --cprover-smt2" -X broken-smt-backend
 
 test-paths-lifo:
-	@../test.pl -e -p -c "../../../src/cbmc/cbmc --paths lifo" -X thorough-paths -X smt-backend
+	@../test.pl -e -p -c "../../../src/cbmc/cbmc --paths lifo" -X thorough-paths -X smt-backend -X paths-lifo-expected-failure
 
 tests.log: ../test.pl test
 

--- a/regression/cbmc/symex_should_exclude_null_pointers/test.desc
+++ b/regression/cbmc/symex_should_exclude_null_pointers/test.desc
@@ -3,15 +3,14 @@ main.c
 --show-vcc
 ^EXIT=0$
 ^SIGNAL=0$
-ptr4\$object
-ptr5\$object
-ptr6\$object
-ptr7\$object
-ptr8\$object
+ptr10\$object
 --
-ptr[1-3]\$object
+ptr[1-9]\$object
 ^warning: ignoring
 --
 ptrX\$object appearing in the VCCs indicates symex was unsure whether the pointer had a valid
 target, and uses the $object symbol as a referred object of last resort. ptr1-3 should be judged
-not-null by symex, so their $object symbols do not occur.
+not-null by local safe pointer analysis, so their $object symbols do not occur. ptr4-7 are
+not caught by local safe pointer analysis but they are judged safe by value-set filtering, i.e.
+goto_symext::try_filter_value_sets(). ptr8-9 are judged safe by local safe pointer analysis but
+not value-set filtering. ptr10 is not judged safe by either because it is not safe.

--- a/regression/cbmc/symex_should_filter_value_sets/main.c
+++ b/regression/cbmc/symex_should_filter_value_sets/main.c
@@ -1,0 +1,146 @@
+#include <assert.h>
+
+static void noop()
+{
+}
+
+int main(int argc, char **argv)
+{
+  __CPROVER_assume(argc == 5);
+
+  int a = 2;
+  int b = 1;
+  int *ptr_to_a_or_b = argv[0][0] == '0' ? &a : &b;
+
+  // Should work (value-set filtered by assume):
+  int *p1 = ptr_to_a_or_b;
+  __CPROVER_assume(p1 != &a);
+  int c1 = *p1;
+
+  int *p2 = ptr_to_a_or_b;
+  __CPROVER_assume(*p2 != 2);
+  int c2 = *p2;
+
+  // Should work (value-set filtered by else):
+  int c3 = 0;
+  int *p3 = ptr_to_a_or_b;
+  if(p3 == &a)
+  {
+  }
+  else
+  {
+    c3 = *p3;
+  }
+
+  int c4 = 0;
+  int *p4 = ptr_to_a_or_b;
+  if(*p4 == 2)
+  {
+  }
+  else
+  {
+    c4 = *p4;
+  }
+
+  // Should work (value-set filtered by if):
+  int c5 = 0;
+  int *p5 = ptr_to_a_or_b;
+  if(p5 != &a)
+  {
+    c5 = *p5;
+  }
+
+  int c6 = 0;
+  int *p6 = ptr_to_a_or_b;
+  if(*p6 != 2)
+  {
+    c6 = *p6;
+  }
+
+  // Should work (value-set filtered by assume before a backward goto):
+  int *p7 = ptr_to_a_or_b;
+  goto check7;
+
+divide7:
+  int c7 = *p7;
+  goto end_test7;
+
+check7:
+  __CPROVER_assume(p7 != &a);
+  goto divide7;
+
+end_test7:
+
+  int *p8 = ptr_to_a_or_b;
+  goto check8;
+
+divide8:
+  int c8 = *p8;
+  goto end_test8;
+
+check8:
+  __CPROVER_assume(*p8 != 2);
+  goto divide8;
+
+end_test8:
+
+  // Should work (value-set filtered by confluence of if and else):
+  int *p9 = ptr_to_a_or_b;
+  if(argv[1][0] == '0')
+    __CPROVER_assume(p9 != &a);
+  else
+    __CPROVER_assume(p9 != &a);
+  int c9 = *p9;
+
+  int *p10 = ptr_to_a_or_b;
+  if(argv[2][0] == '0')
+    __CPROVER_assume(*p10 != 2);
+  else
+    __CPROVER_assume(*p10 != 2);
+  int c10 = *p10;
+
+  // Should work (value-set filtered by assume, write through an unrelated
+  // pointer has no effect):
+  int c = 0;
+  int *ptr_to_c = &c;
+
+  int *p11 = ptr_to_a_or_b;
+  __CPROVER_assume(p11 != &a);
+  *ptr_to_c = 3;
+  int c11 = *p11;
+
+  int *p12 = ptr_to_a_or_b;
+  __CPROVER_assume(*p12 != 2);
+  *ptr_to_c = 4;
+  int c12 = *p12;
+
+  // Should work (value-set filtered by assume, function call has no effect):
+  int *p13 = ptr_to_a_or_b;
+  __CPROVER_assume(p13 != &a);
+  noop();
+  int c13 = *p13;
+
+  int *p14 = ptr_to_a_or_b;
+  __CPROVER_assume(*p14 != 2);
+  noop();
+  int c14 = *p14;
+
+  // Shouldn't work (unsafe as value-set only filtered by if on one branch):
+  int *p15 = ptr_to_a_or_b;
+  if(argv[3][0] == '0')
+    __CPROVER_assume(p15 != &a);
+  else
+  {
+  }
+  int c15 = *p15;
+
+  int *p16 = ptr_to_a_or_b;
+  if(argv[4][0] == '0')
+    __CPROVER_assume(*p16 != 2);
+  else
+  {
+  }
+  int c16 = *p16;
+
+  assert(0);
+}

--- a/regression/cbmc/symex_should_filter_value_sets/test.desc
+++ b/regression/cbmc/symex_should_filter_value_sets/test.desc
@@ -1,0 +1,30 @@
+CORE paths-lifo-expected-failure
+main.c
+--show-vcc
+^EXIT=0$
+^SIGNAL=0$
+main::1::c1!0@1#. = 1
+main::1::c2!0@1#. = 1
+main::1::c3!0@1#. = 1
+main::1::c4!0@1#. = 1
+main::1::c5!0@1#. = 1
+main::1::c6!0@1#. = 1
+main::1::c7!0@1#. = 1
+main::1::c8!0@1#. = 1
+main::1::c9!0@1#. = 1
+main::1::c10!0@1#. = 1
+main::1::c11!0@1#. = 1
+main::1::c12!0@1#. = 1
+main::1::c13!0@1#. = 1
+main::1::c14!0@1#. = 1
+--
+^warning: ignoring
+main::1::c15!0@1#. = 1
+main::1::c16!0@1#. = 1
+--
+This test does not work in single-path mode as it relies on convergence
+behaviour: c15 and c16 should not be assigned 1 because p15 and p16 are
+restricted on ony one branch of an if-else diamond.
+
+See comments in main.c for explanations on why each of the assignments
+is or isn't expected to appear in the output.

--- a/src/goto-symex/CMakeLists.txt
+++ b/src/goto-symex/CMakeLists.txt
@@ -1,5 +1,5 @@
 file(GLOB_RECURSE sources "*.cpp" "*.h")
-add_library(goto-symex ${sources})
+add_library(goto-symex ${sources} single_value_set_dereference_callback.h single_value_set_dereference_callback.cpp)
 
 generic_includes(goto-symex)
 

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -25,6 +25,7 @@ class code_typet;
 class symbol_tablet;
 class code_assignt;
 class code_function_callt;
+class dereference_callbackt;
 class exprt;
 class goto_symex_statet;
 class guardt;
@@ -267,18 +268,24 @@ protected:
   /// \param state
   /// \param write
   void clean_expr(exprt &expr, statet &state, bool write);
+  void clean_expr(
+    exprt &expr,
+    statet &state,
+    bool write,
+    dereference_callbackt &dereference_callback);
 
   void trigger_auto_object(const exprt &, statet &);
   void initialize_auto_object(const exprt &, statet &);
   void process_array_expr(statet &, exprt &);
   exprt make_auto_object(const typet &, statet &);
-  virtual void dereference(exprt &, statet &);
+  virtual void dereference(exprt &, statet &, dereference_callbackt &);
 
-  void dereference_rec(exprt &, statet &);
+  void dereference_rec(exprt &, statet &, dereference_callbackt &);
   exprt address_arithmetic(
     const exprt &,
     statet &,
-    bool keep_array);
+    bool keep_array,
+    dereference_callbackt &dereference_callback);
 
   /// Symbolically execute a GOTO instruction
   /// \param state: Symbolic execution state for current instruction

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -308,6 +308,28 @@ protected:
   virtual void symex_other(statet &state);
 
   void symex_assert(const goto_programt::instructiont &, statet &);
+
+  /// Try to filter value sets based on whether possible values of a
+  /// pointer-typed symbol make the condition true or false. We only do this
+  /// when there is only one pointer-typed symbol in \p condition.
+  /// \param state: The current state
+  /// \param condition: The condition which is being evaluated, which it expects
+  ///   will not have been cleaned or renamed. In practice, it's fine if it has
+  ///   been cleaned and renamed up to level L1.
+  /// \param value_set_for_true_case: A pointer to the value set that possible
+  ///   values should be removed from if they make the condition false, or
+  ///   nullptr if this shouldn't be done
+  /// \param value_set_for_false_case: A pointer to the value set that possible
+  ///   values should be removed from if they make the condition true, or
+  ///   nullptr if this shouldn't be done
+  /// \param ns: A namespace
+  void try_filter_value_sets(
+    goto_symex_statet &state,
+    exprt condition,
+    value_sett *value_set_for_true_case,
+    value_sett *value_set_for_false_case,
+    const namespacet &ns);
+
   virtual void vcc(
     const exprt &,
     const std::string &msg,

--- a/src/goto-symex/single_value_set_dereference_callback.cpp
+++ b/src/goto-symex/single_value_set_dereference_callback.cpp
@@ -1,0 +1,44 @@
+/*******************************************************************\
+
+Module: Callback object for dereference_rec
+
+Author: Owen Jones, owen.jones@diffblue.com
+
+\*******************************************************************/
+
+/// \file
+/// Callback object for dereference_rec
+
+#include "single_value_set_dereference_callback.h"
+
+#include <util/symbol_table.h>
+
+const symbolt *
+single_value_set_dereference_callbackt::get_or_create_failed_symbol(
+  const exprt &expr)
+{
+  get_or_create_failed_symbol_called = true;
+  return nullptr;
+}
+
+void single_value_set_dereference_callbackt::get_value_set(
+  const exprt &expr,
+  value_setst::valuest &value_set) const
+{
+  if(expr == query_expr)
+  {
+    get_value_set_called_with_right_query_expr = true;
+    value_set = return_values;
+  }
+  else
+  {
+    get_value_set_called_with_wrong_query_expr = true;
+    value_set = value_setst::valuest();
+  }
+}
+
+bool single_value_set_dereference_callbackt::used_correctly()
+{
+  return !get_or_create_failed_symbol_called &&
+         !get_value_set_called_with_wrong_query_expr;
+}

--- a/src/goto-symex/single_value_set_dereference_callback.h
+++ b/src/goto-symex/single_value_set_dereference_callback.h
@@ -1,0 +1,47 @@
+/*******************************************************************\
+
+Module: Callback object for dereference_rec
+
+Author: Owen Jones, owen.jones@diffblue.com
+
+\*******************************************************************/
+
+/// \file
+/// Callback object for dereference_rec
+
+#ifndef CPROVER_GOTO_SYMEX_SINGLE_VALUE_SET_DEREFERENCE_CALLBACK_H
+#define CPROVER_GOTO_SYMEX_SINGLE_VALUE_SET_DEREFERENCE_CALLBACK_H
+
+#include <pointer-analysis/dereference_callback.h>
+
+/// Callback object that \ref goto_symext::dereference_rec provides to
+/// \ref value_set_dereferencet to provide value sets (from goto-symex's
+/// working value set) and retrieve or create failed symbols on demand.
+/// For details of symex-dereference's operation see
+/// \ref goto_symext::dereference
+class single_value_set_dereference_callbackt : public dereference_callbackt
+{
+public:
+  single_value_set_dereference_callbackt(
+    const exprt &query_expr,
+    const value_setst::valuest &return_values)
+    : query_expr(query_expr), return_values(return_values)
+  {
+  }
+
+  bool used_correctly();
+
+protected:
+  const exprt &query_expr;
+  const value_setst::valuest &return_values;
+  bool get_or_create_failed_symbol_called = false;
+  mutable bool get_value_set_called_with_right_query_expr = false;
+  mutable bool get_value_set_called_with_wrong_query_expr = false;
+
+  void get_value_set(const exprt &expr, value_setst::valuest &value_set)
+    const override;
+
+  const symbolt *get_or_create_failed_symbol(const exprt &expr) override;
+};
+
+#endif // CPROVER_GOTO_SYMEX_SINGLE_VALUE_SET_DEREFERENCE_CALLBACK_H

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -175,8 +175,18 @@ void goto_symext::clean_expr(
   statet &state,
   const bool write)
 {
+  symex_dereference_statet symex_dereference_state(state, ns);
+  clean_expr(expr, state, write, symex_dereference_state);
+}
+
+void goto_symext::clean_expr(
+  exprt &expr,
+  statet &state,
+  const bool write,
+  dereference_callbackt &dereference_callback)
+{
   replace_nondet(expr, path_storage.build_symex_nondet);
-  dereference(expr, state);
+  dereference(expr, state, dereference_callback);
 
   // make sure all remaining byte extract operations use the root
   // object to avoid nesting of with/update and byte_update when on

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -367,6 +367,54 @@ static std::string strip_first_field_from_suffix(
   return suffix.substr(field.length() + 1);
 }
 
+const value_sett::entryt *value_sett::get_entry_for_symbol(
+  const irep_idt identifier,
+  const typet &type,
+  const std::string &suffix,
+  const namespacet &ns) const
+{
+  if(
+    type.id() != ID_pointer && type.id() != ID_signedbv &&
+    type.id() != ID_unsignedbv && type.id() != ID_array &&
+    type.id() != ID_struct && type.id() != ID_struct_tag &&
+    type.id() != ID_union && type.id() != ID_union_tag)
+  {
+    return nullptr;
+  }
+
+  const typet &followed_type = type.id() == ID_struct_tag
+                                 ? ns.follow_tag(to_struct_tag_type(type))
+                                 : type.id() == ID_union_tag
+                                     ? ns.follow_tag(to_union_tag_type(type))
+                                     : type;
+
+  // look it up
+  const value_sett::entryt *entry = find_entry(id2string(identifier) + suffix);
+
+  // try first component name as suffix if not yet found
+  if(
+    !entry &&
+    (followed_type.id() == ID_struct || followed_type.id() == ID_union))
+  {
+    const struct_union_typet &struct_union_type =
+      to_struct_union_type(followed_type);
+
+    const irep_idt &first_component_name =
+      struct_union_type.components().front().get_name();
+
+    entry = find_entry(
+      id2string(identifier) + "." + id2string(first_component_name) + suffix);
+  }
+
+  if(!entry)
+  {
+    // not found? try without suffix
+    entry = find_entry(identifier);
+  }
+
+  return entry;
+}
+
 void value_sett::get_value_set_rec(
   const exprt &expr,
   object_mapt &dest,
@@ -414,43 +462,11 @@ void value_sett::get_value_set_rec(
   }
   else if(expr.id()==ID_symbol)
   {
-    irep_idt identifier=to_symbol_expr(expr).get_identifier();
+    const entryt *entry = get_entry_for_symbol(
+      to_symbol_expr(expr).get_identifier(), expr_type, suffix, ns);
 
-    // is it a pointer, integer, array or struct?
-    if(expr_type.id()==ID_pointer ||
-       expr_type.id()==ID_signedbv ||
-       expr_type.id()==ID_unsignedbv ||
-       expr_type.id()==ID_struct ||
-       expr_type.id()==ID_union ||
-       expr_type.id()==ID_array)
-    {
-      // look it up
-      const entryt *entry =
-        find_entry(id2string(identifier) + suffix);
-
-      // try first component name as suffix if not yet found
-      if(!entry && (expr_type.id() == ID_struct || expr_type.id() == ID_union))
-      {
-        const struct_union_typet &struct_union_type=
-          to_struct_union_type(expr_type);
-
-        const irep_idt &first_component_name =
-          struct_union_type.components().front().get_name();
-
-        entry = find_entry(
-          id2string(identifier) + "." + id2string(first_component_name) +
-          suffix);
-      }
-
-      // not found? try without suffix
-      if(!entry)
-        entry = find_entry(identifier);
-
-      if(entry)
-        make_union(dest, entry->object_map);
-      else
-        insert(dest, exprt(ID_unknown, original_type));
-    }
+    if(entry)
+      make_union(dest, entry->object_map);
     else
       insert(dest, exprt(ID_unknown, original_type));
   }

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1616,3 +1616,25 @@ exprt value_sett::make_member(
 
   return member_expr;
 }
+
+void value_sett::erase_value_from_entry(
+  entryt &entry,
+  const exprt &value_to_erase)
+{
+  std::vector<object_map_dt::key_type> keys_to_erase;
+
+  for(const auto &key_value : entry.object_map.read())
+  {
+    const auto &rhs_object = to_expr(key_value);
+    if(rhs_object == value_to_erase)
+    {
+      keys_to_erase.emplace_back(key_value.first);
+    }
+  }
+
+  DATA_INVARIANT(
+    keys_to_erase.size() == 1,
+    "value_sett::erase_value_from_entry() should erase exactly one value");
+
+  entry.object_map.write().erase(keys_to_erase[0]);
+}

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -468,6 +468,8 @@ public:
     const std::string &suffix,
     const namespacet &ns) const;
 
+  void erase_value_from_entry(entryt &entry, const exprt &value_to_erase);
+
 protected:
   /// Reads the set of objects pointed to by `expr`, including making
   /// recursive lookups for dereference operations etc.

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -455,6 +455,19 @@ public:
     exprt &expr,
     const namespacet &ns) const;
 
+  /// Get the entry for the symbol and suffix
+  /// \param identifier: The identifier for the symbol
+  /// \param type: The type of the symbol
+  /// \param suffix: The suffix for the entry
+  /// \param ns: The global namespace, for following \p type if it is a
+  ///   struct tag type or a union tag type
+  /// \return The entry for the symbol and suffix
+  const value_sett::entryt *get_entry_for_symbol(
+    const irep_idt identifier,
+    const typet &type,
+    const std::string &suffix,
+    const namespacet &ns) const;
+
 protected:
   /// Reads the set of objects pointed to by `expr`, including making
   /// recursive lookups for dereference operations etc.


### PR DESCRIPTION
This is an alternative to #4288 which uses `clean_expr` and hence `dereference_rec` to do the work. This means it can't cope with conditions like `p == &a` or `p == null`, because `clean_expr` only cares about removing dereferences. That is probably why CI is failing (though I don't know why Travis didn't even start).

Only the last commit is new, all the others are from #4288 .


- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
