### PR TITLE
SMT2 backend: remove byte operators before calling find_symbols

### DIFF
--- a/regression/cbmc/assigning_nullpointers_should_not_crash_symex/test.desc
+++ b/regression/cbmc/assigning_nullpointers_should_not_crash_symex/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/byte_update10/main.c
+++ b/regression/cbmc/byte_update10/main.c
@@ -1,0 +1,35 @@
+#include <assert.h>
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+  unsigned long long x[2];
+  x[0] = 0x0102030405060708;
+  x[1] = 0x1112131415161718;
+
+  unsigned char *alias = (unsigned short *)(((char *)x) + 5);
+  *alias = 0xed;
+
+  unsigned char *alias2 = (unsigned char *)x;
+  /*
+  for(int i = 0; i < 16; ++i)
+    printf("%02hhx\n",alias2[i]);
+  */
+
+  assert(alias2[0] == 0x08);
+  assert(alias2[1] == 0x07);
+  assert(alias2[2] == 0x06);
+  assert(alias2[3] == 0x05);
+  assert(alias2[4] == 0x04);
+  assert(alias2[5] == 0xed);
+  assert(alias2[6] == 0x02);
+  assert(alias2[7] == 0x01);
+  assert(alias2[8] == 0x18);
+  assert(alias2[9] == 0x17);
+  assert(alias2[10] == 0x16);
+  assert(alias2[11] == 0x15);
+  assert(alias2[12] == 0x14);
+  assert(alias2[13] == 0x13);
+  assert(alias2[14] == 0x12);
+  assert(alias2[15] == 0x11);
+}

--- a/regression/cbmc/byte_update10/test.desc
+++ b/regression/cbmc/byte_update10/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--little-endian
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Note this is identical to test byte_update2, except that the array 'x' has
+constant size.

--- a/regression/cbmc/gcc_c99-bool-1/test.desc
+++ b/regression/cbmc/gcc_c99-bool-1/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 c99-bool-1.c
 
 ^EXIT=0$

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -1041,7 +1041,7 @@ exprt lower_byte_extract(const byte_extract_exprt &src, const namespacet &ns)
       tmp.type() = max_comp_type;
 
       return union_exprt(
-        max_comp_name, lower_byte_extract(tmp, ns), union_type);
+        max_comp_name, lower_byte_extract(tmp, ns), src.type());
     }
   }
 

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -154,8 +154,6 @@ protected:
   void flatten_array(const exprt &);
 
   // specific expressions go here
-  void convert_byte_update(const byte_update_exprt &expr);
-  void convert_byte_extract(const byte_extract_exprt &expr);
   void convert_typecast(const typecast_exprt &expr);
   void convert_floatbv_typecast(const floatbv_typecast_exprt &expr);
   void convert_struct(const struct_exprt &expr);
@@ -182,6 +180,8 @@ protected:
   std::string convert_identifier(const irep_idt &identifier);
 
   // auxiliary methods
+  exprt prepare_for_convert_expr(const exprt &expr);
+  exprt lower_byte_operators(const exprt &expr);
   void find_symbols(const exprt &expr);
   void find_symbols(const typet &type);
   void find_symbols_rec(const typet &type, std::set<irep_idt> &recstack);


### PR DESCRIPTION
`convert_expr` assumes that `find_symbols` has already made an entry for every `array_exprt`, but byte operator lowering can introduce new ones. Therefore run it up front.

The particular construction (depth-iterator plus recursion) is a bit ugly -- this is required because (a) we must keep the post-order strategy or we expose other bugs (see https://github.com/diffblue/cbmc/issues/4380) and (b) `expr_iterator.h` is broken when expressions are mutated and then the iterator is permitted to visit those mutated parts, despite the design intending this feature. I suggest we get this fix in and then tackle those two individually, particularly as this blocks other PRs.