### PR TITLE
There is no need for argc and argv to be new

### DIFF
--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -268,10 +268,12 @@ bool generate_ansi_c_start_function(
         argc_symbol.is_lvalue = true;
         argc_symbol.mode = ID_C;
 
-        if(!symbol_table.insert(std::move(argc_symbol)).second)
+        auto r = symbol_table.insert(argc_symbol);
+        if(!r.second && r.first != argc_symbol)
         {
           messaget message(message_handler);
-          message.error() << "failed to insert argc symbol" << messaget::eom;
+          message.error() << "argc already exists but is not usable"
+                          << messaget::eom;
           return true;
         }
       }
@@ -295,10 +297,12 @@ bool generate_ansi_c_start_function(
         argv_symbol.is_lvalue = true;
         argv_symbol.mode = ID_C;
 
-        if(!symbol_table.insert(std::move(argv_symbol)).second)
+        auto r = symbol_table.insert(argv_symbol);
+        if(!r.second && r.first != argv_symbol)
         {
           messaget message(message_handler);
-          message.error() << "failed to insert argv symbol" << messaget::eom;
+          message.error() << "argv already exists but is not usable"
+                          << messaget::eom;
           return true;
         }
       }


### PR DESCRIPTION
With thanks to @natasha-jeppu who found this the hard way.  Consider the following unlikely sequence of events:

```
$ cat ~/tmp/can-delete/main.c
int main (int argc, char **argv) {
  return 0;
}
$ goto-cc main.c -o main.goto
$ cbmc main.goto --function main
CBMC version 5.11 (cbmc-5.11-881-gd52cd0d1e-dirty) 64-bit x86_64 linux
Reading GOTO program from file
Reading: /home/martin/tmp/can-delete/main.goto
failed to insert argc symbol
SUPPORT FUNCTION GENERATION ERROR
```

`argc` and `argv` both exist and it is fine to re-use them.  If the
addition fails it will throw an exception, the `.second` bool is only
false in the case they already exist which is harmless.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
