### PR TITLE
Fix segmentation fault when failing to lookup parameter names [depends-on: #4434]

### DIFF
--- a/jbmc/regression/jbmc/nondet_propagation1/lazy-loading-bug.desc
+++ b/jbmc/regression/jbmc/nondet_propagation1/lazy-loading-bug.desc
@@ -1,0 +1,13 @@
+CORE
+andNot_Bug.class
+--depth 1600 --java-unwind-enum-static --java-max-vla-length 48 --unwind 4 --max-nondet-string-length 100 andNot_Pass.class --function andNot_Pass.main
+^\*\* 1 of \d+ failed
+VERIFICATION FAILED
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+This somewhat bogus test (both andNot_Pass.class and andNot_Bug.class are
+specified on the command line) resulted in a segmentation fault when used with
+symex-driven-lazy-loading. Even though that's a bogus command line, user input
+should never trigger a segmentation fault.

--- a/jbmc/src/java_bytecode/java_entry_point.cpp
+++ b/jbmc/src/java_bytecode/java_entry_point.cpp
@@ -492,16 +492,16 @@ static code_blockt record_pointer_parameters(
   for(std::size_t param_number = 0; param_number < parameters.size();
       param_number++)
   {
-    const symbolt &p_symbol =
-      *symbol_table.lookup(parameters[param_number].get_identifier());
+    const symbolt *p_symbol =
+      symbol_table.lookup(parameters[param_number].get_identifier());
 
-    if(!can_cast_type<pointer_typet>(p_symbol.type))
+    if(!p_symbol || !can_cast_type<pointer_typet>(p_symbol->type))
       continue;
 
     codet output(ID_output);
     output.operands().resize(2);
     output.op0() = address_of_exprt(index_exprt(
-      string_constantt(p_symbol.base_name), from_integer(0, index_type())));
+      string_constantt(p_symbol->base_name), from_integer(0, index_type())));
     output.op1() = arguments[param_number];
     output.add_source_location() = function.location;
 


### PR DESCRIPTION
Users should not be able to trigger segmentation faults.

Only the second commit is new, the first one is #4374. It is likely possible to also trigger the same problem with other tests and we might thus be able to get rid of the dependency on that PR. It was just that test where I bumped into this problem.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
