### PR TITLE
Fix use of as_const in std_expr

### DIFF
--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -3168,7 +3168,7 @@ class not_exprt:public unary_exprt
 public:
   explicit not_exprt(exprt _op) : unary_exprt(ID_not, std::move(_op))
   {
-    PRECONDITION(as_const(op()).type().id() == ID_bool);
+    PRECONDITION(as_const(*this).op().type().id() == ID_bool);
   }
 
   DEPRECATED("use not_exprt(op) instead")


### PR DESCRIPTION
Using as_const() on op() is too late, as op() itself would already
perform non-const operations. This is a fix-up to c2674213.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
