### PR TITLE
Fix lower_byte_{extract,update}'s documentation

### DIFF
--- a/src/solvers/lowering/expr_lowering.h
+++ b/src/solvers/lowering/expr_lowering.h
@@ -19,15 +19,19 @@ class popcount_exprt;
 /// Rewrite a byte extract expression to more fundamental operations.
 /// \param src: Byte extract expression
 /// \param ns: Namespace
-/// \return Semantically equivalent expression that does not contain any \ref
-///   byte_extract_exprt or \ref byte_update_exprt.
+/// \return Semantically equivalent expression such that the top-level
+///   expression no longer is a \ref byte_extract_exprt or
+///   \ref byte_update_exprt. Use \ref lower_byte_operators to also remove all
+///   byte operators from any operands of \p src.
 exprt lower_byte_extract(const byte_extract_exprt &src, const namespacet &ns);
 
 /// Rewrite a byte update expression to more fundamental operations.
 /// \param src: Byte update expression
 /// \param ns: Namespace
-/// \return Semantically equivalent expression that does not contain any \ref
-///   byte_extract_exprt or \ref byte_update_exprt.
+/// \return Semantically equivalent expression such that the top-level
+///   expression no longer is a \ref byte_extract_exprt or
+///   \ref byte_update_exprt. Use \ref lower_byte_operators to also remove all
+///   byte operators from any operands of \p src.
 exprt lower_byte_update(const byte_update_exprt &src, const namespacet &ns);
 
 /// Rewrite an expression possibly containing byte-extract or -update


### PR DESCRIPTION
The documentation previously claimed that the full expression was being
rewritten, which is not the case. Only lower_byte_operators takes care
of this. Make sure the documentation clearly states this.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
