### PR TITLE
Add a note on compiling Cudd with Ninja

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -314,6 +314,10 @@ If compiling with cmake:
    cmake --build build
    ```
 
+If compiling with cmake Ninja generator (`cmake -G Ninja`), the extra step
+`cmake --build build --target cudd-make` may be necessary between step 1 and 2
+because of a problem in the tracking of dependencies.
+
 ## Use BDDs for guards
 
 There are two implementation for symex guards. The default one uses the


### PR DESCRIPTION
There seems to be a problem, where Cudd is not build when using Ninja,
and explicitly triggering the build solves that prolbem.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [na] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
