### PR TITLE
Make rename return a renamedt<exprt, level> 

### DIFF
--- a/src/goto-instrument/accelerate/scratch_program.cpp
+++ b/src/goto-instrument/accelerate/scratch_program.cpp
@@ -74,7 +74,7 @@ bool scratch_programt::check_sat(bool do_slice, guard_managert &guard_manager)
 
 exprt scratch_programt::eval(const exprt &e)
 {
-  return checker->get(symex_state->rename<L2>(e, ns));
+  return checker->get(symex_state->rename<L2>(e, ns).get());
 }
 
 void scratch_programt::append(goto_programt::instructionst &new_instructions)

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -96,12 +96,12 @@ public:
   /// A full explanation of SSA (which is why we do this renaming) is in
   /// the SSA section of background-concepts.md.
   template <levelt level = L2>
-  exprt rename(exprt expr, const namespacet &ns);
+  renamedt<exprt, level> rename(exprt expr, const namespacet &ns);
 
   /// Version of rename which is specialized for SSA exprt.
   /// Implementation only exists for level L0 and L1.
   template <levelt level>
-  ssa_exprt rename_ssa(ssa_exprt ssa, const namespacet &ns);
+  renamedt<ssa_exprt, level> rename_ssa(ssa_exprt ssa, const namespacet &ns);
 
   template <levelt level = L2>
   void rename(typet &type, const irep_idt &l1_identifier, const namespacet &ns);

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -16,6 +16,7 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include <unordered_set>
 
 #include <util/irep.h>
+#include <util/simplify_expr.h>
 #include <util/ssa_expr.h>
 
 /// Symex renaming level names.
@@ -79,6 +80,11 @@ public:
   const underlyingt &get() const
   {
     return value;
+  }
+
+  void simplify(const namespacet &ns)
+  {
+    (void)::simplify(value, ns);
   }
 
 private:

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -87,8 +87,9 @@ private:
   friend struct symex_level0t;
   friend struct symex_level1t;
   friend struct symex_level2t;
+  friend class goto_symex_statet;
 
-  /// Only symex_levelXt classes can create renamedt objects
+  /// Only the friend classes can create renamedt objects
   explicit renamedt(underlyingt value) : value(std::move(value))
   {
   }

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -215,7 +215,7 @@ void goto_symext::symex_assign_symbol(
     tmp_ssa_rhs.swap(ssa_rhs);
   }
 
-  exprt l2_rhs = state.rename(std::move(ssa_rhs), ns);
+  exprt l2_rhs = state.rename(std::move(ssa_rhs), ns).get();
   do_simplify(l2_rhs);
 
   ssa_exprt ssa_lhs=lhs;
@@ -231,7 +231,7 @@ void goto_symext::symex_assign_symbol(
   ssa_full_lhs=add_to_lhs(ssa_full_lhs, ssa_lhs);
   const bool record_events=state.record_events;
   state.record_events=false;
-  exprt l2_full_lhs = state.rename(std::move(ssa_full_lhs), ns);
+  exprt l2_full_lhs = state.rename(std::move(ssa_full_lhs), ns).get();
   state.record_events=record_events;
 
   // do the assignment
@@ -410,7 +410,7 @@ void goto_symext::symex_assign_if(
   assignment_typet assignment_type)
 {
   // we have (c?a:b)=e;
-  exprt renamed_guard = state.rename(lhs.cond(), ns);
+  exprt renamed_guard = state.rename(lhs.cond(), ns).get();
   do_simplify(renamed_guard);
 
   if(!renamed_guard.is_false())

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -358,13 +358,14 @@ void goto_symext::symex_output(
   PRECONDITION(code.operands().size() >= 2);
   exprt id_arg = state.rename(code.op0(), ns).get();
 
-  std::list<exprt> args;
+  std::list<renamedt<exprt, L2>> args;
 
   for(std::size_t i=1; i<code.operands().size(); i++)
   {
-    exprt l2_arg = state.rename(code.operands()[i], ns).get();
-    do_simplify(l2_arg);
-    args.emplace_back(std::move(l2_arg));
+    renamedt<exprt, L2> l2_arg = state.rename(code.operands()[i], ns);
+    if(symex_config.simplify_opt)
+      l2_arg.simplify(ns);
+    args.emplace_back(l2_arg);
   }
 
   const irep_idt output_id=get_string_argument(id_arg, ns);
@@ -470,12 +471,12 @@ void goto_symext::symex_trace(
 
   if(symex_config.debug_level >= debug_lvl)
   {
-    std::list<exprt> vars;
+    std::list<renamedt<exprt, L2>> vars;
 
     irep_idt event = to_string_constant(code.arguments()[1].op0()).get_value();
 
     for(std::size_t j=2; j<code.arguments().size(); j++)
-      vars.push_back(state.rename(code.arguments()[j], ns).get());
+      vars.push_back(state.rename(code.arguments()[j], ns));
 
     target.output(state.guard.as_expr(), state.source, event, vars);
   }

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -72,7 +72,7 @@ void goto_symext::symex_allocate(
   else
   {
     // to allow constant propagation
-    exprt tmp_size = state.rename(size, ns);
+    exprt tmp_size = state.rename(size, ns).get();
     simplify(tmp_size, ns);
 
     // special treatment for sizeof(T)*x
@@ -165,7 +165,7 @@ void goto_symext::symex_allocate(
   state.symbol_table.add(value_symbol);
 
   // to allow constant propagation
-  exprt zero_init = state.rename(code.op1(), ns);
+  exprt zero_init = state.rename(code.op1(), ns).get();
   simplify(zero_init, ns);
 
   INVARIANT(
@@ -234,7 +234,7 @@ void goto_symext::symex_gcc_builtin_va_arg_next(
     return; // ignore
 
   // to allow constant propagation
-  exprt tmp = state.rename(code.op0(), ns);
+  exprt tmp = state.rename(code.op0(), ns).get();
   do_simplify(tmp);
   irep_idt id=get_symbol(tmp);
 
@@ -311,7 +311,7 @@ void goto_symext::symex_printf(
 {
   PRECONDITION(!rhs.operands().empty());
 
-  exprt tmp_rhs = state.rename(rhs, ns);
+  exprt tmp_rhs = state.rename(rhs, ns).get();
   do_simplify(tmp_rhs);
 
   const exprt::operandst &operands=tmp_rhs.operands();
@@ -335,13 +335,13 @@ void goto_symext::symex_input(
 {
   PRECONDITION(code.operands().size() >= 2);
 
-  exprt id_arg = state.rename(code.op0(), ns);
+  exprt id_arg = state.rename(code.op0(), ns).get();
 
   std::list<exprt> args;
 
   for(std::size_t i=1; i<code.operands().size(); i++)
   {
-    exprt l2_arg = state.rename(code.operands()[i], ns);
+    exprt l2_arg = state.rename(code.operands()[i], ns).get();
     do_simplify(l2_arg);
     args.emplace_back(std::move(l2_arg));
   }
@@ -356,13 +356,13 @@ void goto_symext::symex_output(
   const codet &code)
 {
   PRECONDITION(code.operands().size() >= 2);
-  exprt id_arg = state.rename(code.op0(), ns);
+  exprt id_arg = state.rename(code.op0(), ns).get();
 
   std::list<exprt> args;
 
   for(std::size_t i=1; i<code.operands().size(); i++)
   {
-    exprt l2_arg = state.rename(code.operands()[i], ns);
+    exprt l2_arg = state.rename(code.operands()[i], ns).get();
     do_simplify(l2_arg);
     args.emplace_back(std::move(l2_arg));
   }
@@ -475,7 +475,7 @@ void goto_symext::symex_trace(
     irep_idt event = to_string_constant(code.arguments()[1].op0()).get_value();
 
     for(std::size_t j=2; j<code.arguments().size(); j++)
-      vars.push_back(state.rename(code.arguments()[j], ns));
+      vars.push_back(state.rename(code.arguments()[j], ns).get());
 
     target.output(state.guard.as_expr(), state.source, event, vars);
   }

--- a/src/goto-symex/symex_dead.cpp
+++ b/src/goto-symex/symex_dead.cpp
@@ -21,7 +21,7 @@ void goto_symext::symex_dead(statet &state)
 
   const code_deadt &code = instruction.get_dead();
 
-  ssa_exprt ssa = state.rename_ssa<L1>(ssa_exprt{code.symbol()}, ns);
+  ssa_exprt ssa = state.rename_ssa<L1>(ssa_exprt{code.symbol()}, ns).get();
   const irep_idt &l1_identifier = ssa.get_identifier();
 
   // we cannot remove the object from the L1 renaming map, because L1 renaming

--- a/src/goto-symex/symex_decl.cpp
+++ b/src/goto-symex/symex_decl.cpp
@@ -61,7 +61,7 @@ void goto_symext::symex_decl(statet &state, const symbol_exprt &expr)
     else
       rhs=exprt(ID_invalid);
 
-    exprt l1_rhs = state.rename<L1>(std::move(rhs), ns);
+    exprt l1_rhs = state.rename<L1>(std::move(rhs), ns).get();
     state.value_set.assign(ssa, l1_rhs, ns, true, false);
   }
 
@@ -71,7 +71,7 @@ void goto_symext::symex_decl(statet &state, const symbol_exprt &expr)
 
   const bool record_events=state.record_events;
   state.record_events=false;
-  exprt expr_l2 = state.rename(std::move(ssa), ns);
+  exprt expr_l2 = state.rename(std::move(ssa), ns).get();
   INVARIANT(
     expr_l2.id() == ID_symbol && expr_l2.get_bool(ID_C_SSA_symbol),
     "symbol to declare should not be replaced by constant propagation");

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -356,13 +356,13 @@ void goto_symext::dereference(exprt &expr, statet &state)
   // from different frames. Would be enough to rename
   // symbols whose address is taken.
   PRECONDITION(!state.call_stack().empty());
-  exprt l1_expr = state.rename<L1>(expr, ns);
+  exprt l1_expr = state.rename<L1>(expr, ns).get();
 
   // start the recursion!
   dereference_rec(l1_expr, state);
   // dereferencing may introduce new symbol_exprt
   // (like __CPROVER_memory)
-  expr = state.rename<L1>(std::move(l1_expr), ns);
+  expr = state.rename<L1>(std::move(l1_expr), ns).get();
 
   // Dereferencing is likely to introduce new member-of-if constructs --
   // for example, "x->field" may have become "(x == &o1 ? o1 : o2).field."

--- a/src/goto-symex/symex_dereference_state.cpp
+++ b/src/goto-symex/symex_dereference_state.cpp
@@ -49,7 +49,7 @@ symex_dereference_statet::get_or_create_failed_symbol(const exprt &expr)
       symbolt sym=*symbol;
       symbolt *sym_ptr=nullptr;
       const ssa_exprt sym_expr =
-        state.rename_ssa<L1>(ssa_exprt{sym.symbol_expr()}, ns);
+        state.rename_ssa<L1>(ssa_exprt{sym.symbol_expr()}, ns).get();
       sym.name = sym_expr.get_identifier();
       state.symbol_table.move(sym, sym_ptr);
       return sym_ptr;
@@ -69,7 +69,7 @@ symex_dereference_statet::get_or_create_failed_symbol(const exprt &expr)
       symbolt sym=*symbol;
       symbolt *sym_ptr=nullptr;
       const ssa_exprt sym_expr =
-        state.rename_ssa<L1>(ssa_exprt{sym.symbol_expr()}, ns);
+        state.rename_ssa<L1>(ssa_exprt{sym.symbol_expr()}, ns).get();
       sym.name = sym_expr.get_identifier();
       state.symbol_table.move(sym, sym_ptr);
       return sym_ptr;

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -272,7 +272,7 @@ void goto_symext::symex_function_call_code(
   // read the arguments -- before the locality renaming
   exprt::operandst arguments = call.arguments();
   for(auto &a : arguments)
-    a = state.rename(std::move(a), ns);
+    a = state.rename(std::move(a), ns).get();
 
   // we hide the call if the caller and callee are both hidden
   const bool callee_is_hidden = ns.lookup(identifier).is_hidden();

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -59,8 +59,10 @@ void goto_symext::symex_goto(statet &state)
   exprt new_guard = instruction.get_condition();
   clean_expr(new_guard, state, false);
 
-  new_guard = state.rename(std::move(new_guard), ns).get();
-  do_simplify(new_guard);
+  renamedt<exprt, L2> renamed_guard = state.rename(std::move(new_guard), ns);
+  if(symex_config.simplify_opt)
+    renamed_guard.simplify(ns);
+  new_guard = renamed_guard.get();
 
   if(new_guard.is_false())
   {
@@ -71,7 +73,7 @@ void goto_symext::symex_goto(statet &state)
     return; // nothing to do
   }
 
-  target.goto_instruction(state.guard.as_expr(), new_guard, state.source);
+  target.goto_instruction(state.guard.as_expr(), renamed_guard, state.source);
 
   DATA_INVARIANT(
     !instruction.targets.empty(), "goto should have at least one target");

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -59,7 +59,7 @@ void goto_symext::symex_goto(statet &state)
   exprt new_guard = instruction.get_condition();
   clean_expr(new_guard, state, false);
 
-  new_guard = state.rename(std::move(new_guard), ns);
+  new_guard = state.rename(std::move(new_guard), ns).get();
   do_simplify(new_guard);
 
   if(new_guard.is_false())
@@ -288,7 +288,7 @@ void goto_symext::symex_goto(statet &state)
       exprt new_rhs = boolean_negate(new_guard);
 
       ssa_exprt new_lhs =
-        state.rename_ssa<L1>(ssa_exprt{guard_symbol_expr}, ns);
+        state.rename_ssa<L1>(ssa_exprt{guard_symbol_expr}, ns).get();
       state.assignment(new_lhs, new_rhs, ns, true, false);
 
       guardt guard{true_exprt{}, guard_manager};
@@ -308,7 +308,7 @@ void goto_symext::symex_goto(statet &state)
         original_source,
         symex_targett::assignment_typet::GUARD);
 
-      guard_expr = state.rename(boolean_negate(guard_symbol_expr), ns);
+      guard_expr = state.rename(boolean_negate(guard_symbol_expr), ns).get();
     }
 
     if(state.has_saved_jump_target)

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -93,7 +93,7 @@ void goto_symext::symex_assert(
     rewrite_quantifiers(condition, state);
 
   // now rename, enables propagation
-  exprt l2_condition = state.rename(std::move(condition), ns);
+  exprt l2_condition = state.rename(std::move(condition), ns).get();
 
   // now try simplifier on it
   do_simplify(l2_condition);
@@ -127,7 +127,7 @@ void goto_symext::symex_assume(statet &state, const exprt &cond)
   exprt simplified_cond=cond;
 
   clean_expr(simplified_cond, state, false);
-  simplified_cond = state.rename(std::move(simplified_cond), ns);
+  simplified_cond = state.rename(std::move(simplified_cond), ns).get();
   do_simplify(simplified_cond);
 
   symex_assume_l2(state, simplified_cond);

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -76,7 +76,7 @@ void goto_symext::symex_start_thread(statet &state)
       std::forward_as_tuple(lhs.get_l1_object_identifier()),
       std::forward_as_tuple(lhs, 0));
     CHECK_RETURN(emplace_result.second);
-    const ssa_exprt lhs_l1 = state.rename_ssa<L1>(std::move(lhs), ns);
+    const ssa_exprt lhs_l1 = state.rename_ssa<L1>(std::move(lhs), ns).get();
     const irep_idt l1_name = lhs_l1.get_l1_object_identifier();
     // store it
     new_thread.call_stack.back().local_objects.insert(l1_name);

--- a/src/goto-symex/symex_target.h
+++ b/src/goto-symex/symex_target.h
@@ -248,8 +248,8 @@ public:
   ///  goto instruction
   virtual void goto_instruction(
     const exprt &guard,
-    const exprt &cond,
-    const sourcet &source)=0;
+    const renamedt<exprt, L2> &cond,
+    const sourcet &source) = 0;
 
   /// Record a _global_ constraint: there is no guard limiting its scope.
   /// \param cond: Condition represented by this constraint

--- a/src/goto-symex/symex_target.h
+++ b/src/goto-symex/symex_target.h
@@ -191,7 +191,7 @@ public:
     const exprt &guard,
     const sourcet &source,
     const irep_idt &output_id,
-    const std::list<exprt> &args)=0;
+    const std::list<renamedt<exprt, L2>> &args) = 0;
 
   /// Record formatted output.
   /// \param guard: Precondition for writing to the output

--- a/src/goto-symex/symex_target.h
+++ b/src/goto-symex/symex_target.h
@@ -14,6 +14,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <goto-programs/goto_program.h>
 
+#include "renaming_level.h"
+
 class ssa_exprt;
 class symbol_exprt;
 
@@ -155,7 +157,7 @@ public:
   virtual void function_call(
     const exprt &guard,
     const irep_idt &function_id,
-    const std::vector<exprt> &ssa_function_arguments,
+    const std::vector<renamedt<exprt, L2>> &ssa_function_arguments,
     const sourcet &source,
     bool hidden) = 0;
 

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -188,7 +188,7 @@ void symex_target_equationt::location(
 void symex_target_equationt::function_call(
   const exprt &guard,
   const irep_idt &function_id,
-  const std::vector<exprt> &ssa_function_arguments,
+  const std::vector<renamedt<exprt, L2>> &function_arguments,
   const sourcet &source,
   const bool hidden)
 {
@@ -197,7 +197,8 @@ void symex_target_equationt::function_call(
 
   SSA_step.guard = guard;
   SSA_step.called_function = function_id;
-  SSA_step.ssa_function_arguments = ssa_function_arguments;
+  for(const auto &arg : function_arguments)
+    SSA_step.ssa_function_arguments.emplace_back(arg.get());
   SSA_step.hidden = hidden;
 
   merge_ireps(SSA_step);

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -224,13 +224,14 @@ void symex_target_equationt::output(
   const exprt &guard,
   const sourcet &source,
   const irep_idt &output_id,
-  const std::list<exprt> &args)
+  const std::list<renamedt<exprt, L2>> &args)
 {
   SSA_steps.emplace_back(source, goto_trace_stept::typet::OUTPUT);
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
-  SSA_step.io_args=args;
+  for(const auto &arg : args)
+    SSA_step.io_args.emplace_back(arg.get());
   SSA_step.io_id=output_id;
 
   merge_ireps(SSA_step);

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -304,14 +304,14 @@ void symex_target_equationt::assertion(
 
 void symex_target_equationt::goto_instruction(
   const exprt &guard,
-  const exprt &cond,
+  const renamedt<exprt, L2> &cond,
   const sourcet &source)
 {
   SSA_steps.emplace_back(source, goto_trace_stept::typet::GOTO);
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
-  SSA_step.cond_expr=cond;
+  SSA_step.cond_expr = cond.get();
 
   merge_ireps(SSA_step);
 }

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -109,7 +109,7 @@ public:
     const exprt &guard,
     const sourcet &source,
     const irep_idt &output_id,
-    const std::list<exprt> &args);
+    const std::list<renamedt<exprt, L2>> &args);
 
   /// \copydoc symex_targett::output_fmt()
   virtual void output_fmt(

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -26,6 +26,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <solvers/prop/literal.h>
 
+#include "renaming_level.h"
 #include "ssa_step.h"
 #include "symex_target.h"
 
@@ -87,7 +88,7 @@ public:
   virtual void function_call(
     const exprt &guard,
     const irep_idt &function_id,
-    const std::vector<exprt> &ssa_function_arguments,
+    const std::vector<renamedt<exprt, L2>> &ssa_function_arguments,
     const sourcet &source,
     bool hidden);
 

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -142,7 +142,7 @@ public:
   /// \copydoc symex_targett::goto_instruction()
   virtual void goto_instruction(
     const exprt &guard,
-    const exprt &cond,
+    const renamedt<exprt, L2> &cond,
     const sourcet &source);
 
   /// \copydoc symex_targett::constraint()


### PR DESCRIPTION
This is to reflect in the type that an expression as been renamed and we
can then make some functions only accept expressions of that type.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
