### PR TITLE
exprt::visit now accepts a lambda

### DIFF
--- a/src/goto-programs/validate_goto_model.cpp
+++ b/src/goto-programs/validate_goto_model.cpp
@@ -141,18 +141,8 @@ void validate_goto_modelt::check_returns_removed()
 
 void validate_goto_modelt::check_called_functions()
 {
-  class test_for_function_addresst : public const_expr_visitort
-  {
-  public:
-    test_for_function_addresst(
-      const function_mapt &function_map,
-      const validation_modet &vm)
-      : function_map{function_map}, vm{vm}
-    {
-    }
-
-    void operator()(const exprt &expr) override
-    {
+  auto test_for_function_address =
+    [this](const exprt &expr) {
       if(expr.id() == ID_address_of)
       {
         const auto &pointee = to_address_of_expr(expr).object();
@@ -168,13 +158,7 @@ void validate_goto_modelt::check_called_functions()
             "function map");
         }
       }
-    }
-
-  private:
-    const function_mapt &function_map;
-    const validation_modet &vm;
-  };
-  test_for_function_addresst test_for_function_address(function_map, vm);
+    };
 
   for(const auto &fun : function_map)
   {

--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -243,7 +243,7 @@ const source_locationt &exprt::find_source_location() const
   return static_cast<const source_locationt &>(get_nil_irep());
 }
 
-void exprt::visit(expr_visitort &visitor)
+void exprt::visit(std::function<void(exprt &)> visitor)
 {
   std::stack<exprt *> stack;
 
@@ -256,12 +256,12 @@ void exprt::visit(expr_visitort &visitor)
 
     visitor(expr);
 
-    Forall_operands(it, expr)
-      stack.push(&(*it));
+    for(auto &op : expr.operands())
+      stack.push(&op);
   }
 }
 
-void exprt::visit(const_expr_visitort &visitor) const
+void exprt::visit(std::function<void(const exprt &)> visitor) const
 {
   std::stack<const exprt *> stack;
 
@@ -274,9 +274,19 @@ void exprt::visit(const_expr_visitort &visitor) const
 
     visitor(expr);
 
-    forall_operands(it, expr)
-      stack.push(&(*it));
+    for(auto &op : expr.operands())
+      stack.push(&op);
   }
+}
+
+void exprt::visit(expr_visitort &visitor)
+{
+  visit([&visitor](exprt &e) { visitor(e); });
+}
+
+void exprt::visit(const_expr_visitort &visitor) const
+{
+  visit([&visitor](const exprt &e) { visitor(e); });
 }
 
 depth_iteratort exprt::depth_begin()

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -312,6 +312,8 @@ protected:
 public:
   void visit(class expr_visitort &visitor);
   void visit(class const_expr_visitort &visitor) const;
+  void visit(std::function<void(exprt &)>);
+  void visit(std::function<void(const exprt &)>) const;
 
   depth_iteratort depth_begin();
   depth_iteratort depth_end();


### PR DESCRIPTION
This is more modern than the current visitor base class.
Also adds two ranged for statements.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
