### PR TITLE
Satcheck doesn't inherit from messaget anymore

### DIFF
--- a/src/solvers/sat/satcheck_booleforce.cpp
+++ b/src/solvers/sat/satcheck_booleforce.cpp
@@ -103,7 +103,7 @@ propt::resultt satcheck_booleforce_baset::do_prop_solve()
       break;
     }
 
-    messaget::status() << msg << messaget::eom;
+    log.status() << msg << messaget::eom;
   }
 
   if(result==BOOLEFORCE_UNSATISFIABLE)

--- a/src/solvers/sat/satcheck_cadical.cpp
+++ b/src/solvers/sat/satcheck_cadical.cpp
@@ -69,28 +69,29 @@ propt::resultt satcheck_cadicalt::do_prop_solve()
 {
   INVARIANT(status != statust::ERROR, "there cannot be an error");
 
-  messaget::statistics() << (no_variables() - 1) << " variables, "
-                         << clause_counter << " clauses" << eom;
+  log.statistics() << (no_variables() - 1) << " variables, " << clause_counter
+                   << " clauses" << messaget::eom;
 
   if(status == statust::UNSAT)
   {
-    messaget::status() << "SAT checker inconsistent: instance is UNSATISFIABLE"
-                       << eom;
+    log.status() << "SAT checker inconsistent: instance is UNSATISFIABLE"
+                 << messaget::eom;
   }
   else
   {
     switch(solver->solve())
     {
       case 10:
-        messaget::status() << "SAT checker: instance is SATISFIABLE" << eom;
+        log.status() << "SAT checker: instance is SATISFIABLE" << messaget::eom;
         status = statust::SAT;
         return resultt::P_SATISFIABLE;
       case 20:
-        messaget::status() << "SAT checker: instance is UNSATISFIABLE" << eom;
+        log.status() << "SAT checker: instance is UNSATISFIABLE"
+                     << messaget::eom;
         break;
       default:
-        messaget::status() << "SAT checker: solving returned without solution"
-                           << eom;
+        log.status() << "SAT checker: solving returned without solution"
+                     << messaget::eom;
         throw analysis_exceptiont(
           "solving inside CaDiCaL SAT solver has been interrupted");
     }

--- a/src/solvers/sat/satcheck_glucose.cpp
+++ b/src/solvers/sat/satcheck_glucose.cpp
@@ -73,7 +73,7 @@ void satcheck_glucose_baset<T>::set_polarity(literalt a, bool value)
   }
   catch(Glucose::OutOfMemoryException)
   {
-    messaget::error() << "SAT checker ran out of memory" << eom;
+    log.error() << "SAT checker ran out of memory" << messaget::eom;
     status = statust::ERROR;
     throw std::bad_alloc();
   }
@@ -125,7 +125,7 @@ void satcheck_glucose_baset<T>::lcnf(const bvt &bv)
   }
   catch(Glucose::OutOfMemoryException)
   {
-    messaget::error() << "SAT checker ran out of memory" << eom;
+    log.error() << "SAT checker ran out of memory" << messaget::eom;
     status = statust::ERROR;
     throw std::bad_alloc();
   }
@@ -137,8 +137,8 @@ propt::resultt satcheck_glucose_baset<T>::do_prop_solve()
   PRECONDITION(status != statust::ERROR);
 
   // We start counting at 1, thus there is one variable fewer.
-  messaget::statistics() << (no_variables() - 1) << " variables, "
-                         << solver->nClauses() << " clauses" << eom;
+  log.statistics() << (no_variables() - 1) << " variables, "
+                   << solver->nClauses() << " clauses" << messaget::eom;
 
   try
   {
@@ -146,8 +146,8 @@ propt::resultt satcheck_glucose_baset<T>::do_prop_solve()
 
     if(!solver->okay())
     {
-      messaget::status()
-        << "SAT checker inconsistent: instance is UNSATISFIABLE" << eom;
+      log.status() << "SAT checker inconsistent: instance is UNSATISFIABLE"
+                   << messaget::eom;
     }
     else
     {
@@ -160,8 +160,8 @@ propt::resultt satcheck_glucose_baset<T>::do_prop_solve()
 
       if(has_false)
       {
-        messaget::status()
-          << "got FALSE as assumption: instance is UNSATISFIABLE" << eom;
+        log.status() << "got FALSE as assumption: instance is UNSATISFIABLE"
+                     << messaget::eom;
       }
       else
       {
@@ -170,13 +170,15 @@ propt::resultt satcheck_glucose_baset<T>::do_prop_solve()
 
         if(solver->solve(solver_assumptions))
         {
-          messaget::status() << "SAT checker: instance is SATISFIABLE" << eom;
+          log.status() << "SAT checker: instance is SATISFIABLE"
+                       << messaget::eom;
           status = statust::SAT;
           return resultt::P_SATISFIABLE;
         }
         else
         {
-          messaget::status() << "SAT checker: instance is UNSATISFIABLE" << eom;
+          log.status() << "SAT checker: instance is UNSATISFIABLE"
+                       << messaget::eom;
         }
       }
     }
@@ -186,7 +188,7 @@ propt::resultt satcheck_glucose_baset<T>::do_prop_solve()
   }
   catch(Glucose::OutOfMemoryException)
   {
-    messaget::error() << "SAT checker ran out of memory" << eom;
+    log.error() << "SAT checker ran out of memory" << messaget::eom;
     status = statust::ERROR;
     throw std::bad_alloc();
   }
@@ -209,7 +211,7 @@ void satcheck_glucose_baset<T>::set_assignment(literalt a, bool value)
   }
   catch(Glucose::OutOfMemoryException)
   {
-    messaget::error() << "SAT checker ran out of memory" << eom;
+    log.error() << "SAT checker ran out of memory" << messaget::eom;
     status = statust::ERROR;
     throw std::bad_alloc();
   }
@@ -284,7 +286,7 @@ void satcheck_glucose_simplifiert::set_frozen(literalt a)
   }
   catch(Glucose::OutOfMemoryException)
   {
-    messaget::error() << "SAT checker ran out of memory" << eom;
+    log.error() << "SAT checker ran out of memory" << messaget::eom;
     status = statust::ERROR;
     throw std::bad_alloc();
   }

--- a/src/solvers/sat/satcheck_ipasir.cpp
+++ b/src/solvers/sat/satcheck_ipasir.cpp
@@ -97,15 +97,15 @@ propt::resultt satcheck_ipasirt::do_prop_solve()
 {
   INVARIANT(status!=statust::ERROR, "there cannot be an error");
 
-  messaget::statistics() << (no_variables() - 1) << " variables, "
-                         << clause_counter << " clauses" << eom;
+  log.statistics() << (no_variables() - 1) << " variables, " << clause_counter
+                   << " clauses" << messaget::eom;
 
   // use the internal representation, as ipasir does not support reporting the
   // status
   if(status==statust::UNSAT)
   {
-    messaget::status() <<
-      "SAT checker inconsistent: instance is UNSATISFIABLE" << eom;
+    log.status() << "SAT checker inconsistent: instance is UNSATISFIABLE"
+                 << messaget::eom;
   }
   else
   {
@@ -116,8 +116,8 @@ propt::resultt satcheck_ipasirt::do_prop_solve()
 
     if(has_false)
     {
-      messaget::status() <<
-        "got FALSE as assumption: instance is UNSATISFIABLE" << eom;
+      log.status() << "got FALSE as assumption: instance is UNSATISFIABLE"
+                   << messaget::eom;
     }
     else
     {
@@ -129,20 +129,19 @@ propt::resultt satcheck_ipasirt::do_prop_solve()
       int solver_state=ipasir_solve(solver);
       if(10==solver_state)
       {
-        messaget::status() <<
-          "SAT checker: instance is SATISFIABLE" << eom;
+        log.status() << "SAT checker: instance is SATISFIABLE" << messaget::eom;
         status=statust::SAT;
         return resultt::P_SATISFIABLE;
       }
       else if(20==solver_state)
       {
-        messaget::status() <<
-          "SAT checker: instance is UNSATISFIABLE" << eom;
+        log.status() << "SAT checker: instance is UNSATISFIABLE"
+                     << messaget::eom;
       }
       else
       {
-        messaget::status() <<
-          "SAT checker: solving returned without solution" << eom;
+        log.status() << "SAT checker: solving returned without solution"
+                     << messaget::eom;
         throw analysis_exceptiont(
           "solving inside IPASIR SAT solver has been interrupted");
       }

--- a/src/solvers/sat/satcheck_lingeling.cpp
+++ b/src/solvers/sat/satcheck_lingeling.cpp
@@ -72,7 +72,7 @@ propt::resultt satcheck_lingelingt::do_prop_solve()
     std::string msg=
       std::to_string(no_variables()-1)+" variables, "+
       std::to_string(clause_counter)+" clauses";
-    messaget::statistics() << msg << messaget::eom;
+    log.statistics() << msg << messaget::eom;
   }
 
   std::string msg;
@@ -86,7 +86,7 @@ propt::resultt satcheck_lingelingt::do_prop_solve()
   if(res==10)
   {
     msg="SAT checker: instance is SATISFIABLE";
-    messaget::status() << msg << messaget::eom;
+    log.status() << msg << messaget::eom;
     status=SAT;
     return P_SATISFIABLE;
   }
@@ -94,7 +94,7 @@ propt::resultt satcheck_lingelingt::do_prop_solve()
   {
     INVARIANT(res == 20, "result value is either 10 or 20");
     msg="SAT checker: instance is UNSATISFIABLE";
-    messaget::status() << msg << messaget::eom;
+    log.status() << msg << messaget::eom;
   }
 
   status=UNSAT;

--- a/src/solvers/sat/satcheck_minisat.cpp
+++ b/src/solvers/sat/satcheck_minisat.cpp
@@ -154,8 +154,8 @@ propt::resultt satcheck_minisat1_baset::do_prop_solve()
 {
   PRECONDITION(status != ERROR);
 
-  messaget::statistics() << (_no_variables - 1) << " variables, "
-                         << solver->nClauses() << " clauses" << messaget::eom;
+  log.statistics() << (_no_variables - 1) << " variables, "
+                   << solver->nClauses() << " clauses" << messaget::eom;
 
   add_variables();
 
@@ -179,7 +179,7 @@ propt::resultt satcheck_minisat1_baset::do_prop_solve()
     if(solver->solve(MiniSat_assumptions))
     {
       msg="SAT checker: instance is SATISFIABLE";
-      messaget::status() << msg << messaget::eom;
+      log.status() << msg << messaget::eom;
       status=SAT;
       return P_SATISFIABLE;
     }
@@ -187,7 +187,7 @@ propt::resultt satcheck_minisat1_baset::do_prop_solve()
       msg="SAT checker: instance is UNSATISFIABLE";
   }
 
-  messaget::status() << msg << messaget::eom;
+  log.status() << msg << messaget::eom;
   status=UNSAT;
   return P_UNSATISFIABLE;
 }

--- a/src/solvers/sat/satcheck_picosat.cpp
+++ b/src/solvers/sat/satcheck_picosat.cpp
@@ -73,7 +73,7 @@ propt::resultt satcheck_picosatt::do_prop_solve()
     std::string msg=
       std::to_string(_no_variables-1)+" variables, "+
       std::to_string(picosat_added_original_clauses(picosat))+" clauses";
-    messaget::statistics() << msg << messaget::eom;
+    log.statistics() << msg << messaget::eom;
   }
 
   std::string msg;
@@ -85,7 +85,7 @@ propt::resultt satcheck_picosatt::do_prop_solve()
   if(res==PICOSAT_SATISFIABLE)
   {
     msg="SAT checker: instance is SATISFIABLE";
-    messaget::status() << msg << messaget::eom;
+    log.status() << msg << messaget::eom;
     status=SAT;
     return P_SATISFIABLE;
   }
@@ -95,7 +95,7 @@ propt::resultt satcheck_picosatt::do_prop_solve()
       res == PICOSAT_UNSATISFIABLE,
       "picosat result should report either sat or unsat");
     msg="SAT checker: instance is UNSATISFIABLE";
-    messaget::status() << msg << messaget::eom;
+    log.status() << msg << messaget::eom;
   }
 
   status=UNSAT;

--- a/src/solvers/sat/satcheck_zchaff.cpp
+++ b/src/solvers/sat/satcheck_zchaff.cpp
@@ -81,7 +81,7 @@ propt::resultt satcheck_zchaff_baset::do_prop_solve()
     std::string msg=
       std::to_string(solver->num_variables())+" variables, "+
       std::to_string(solver->clauses().size())+" clauses";
-    messaget::statistics() << msg << messaget::eom;
+    log.statistics() << msg << messaget::eom;
   }
 
   SAT_StatusT result=(SAT_StatusT)solver->solve();
@@ -120,7 +120,7 @@ propt::resultt satcheck_zchaff_baset::do_prop_solve()
       break;
     }
 
-    messaget::status() << msg << messaget::eom;
+    log.status() << msg << messaget::eom;
   }
 
   if(result==SATISFIABLE)

--- a/src/solvers/sat/satcheck_zcore.cpp
+++ b/src/solvers/sat/satcheck_zcore.cpp
@@ -41,7 +41,7 @@ propt::resultt satcheck_zcoret::do_prop_solve()
     std::string msg=
       std::to_string(no_variables()-1)+" variables, "+
       std::to_string(no_clauses())+" clauses";
-    messaget::statistics() << msg << messaget::eom;
+    log.statistics() << msg << messaget::eom;
   }
 
   // get the core


### PR DESCRIPTION
Fixup of 756b003 for non-default solvers.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
