### PR TITLE
replace recursion in letify_rec by loop [blocks: #4395]

### DIFF
--- a/src/solvers/smt2/letify.cpp
+++ b/src/solvers/smt2/letify.cpp
@@ -19,6 +19,10 @@ void letifyt::collect_bindings(
   seen_expressionst &map,
   std::vector<exprt> &let_order)
 {
+  // do not letify things with no children
+  if(expr.operands().empty())
+    return;
+
   // did we already see the expression?
   seen_expressionst::iterator entry = map.find(expr);
 
@@ -29,10 +33,6 @@ void letifyt::collect_bindings(
     ++(count_id.count);
     return;
   }
-
-  // do not letify things with no children
-  if(expr.operands().empty())
-    return;
 
   // not seen before
   for(auto &op : expr.operands())

--- a/src/solvers/smt2/letify.cpp
+++ b/src/solvers/smt2/letify.cpp
@@ -46,26 +46,29 @@ void letifyt::collect_bindings(
   let_order.push_back(expr);
 }
 
-exprt letifyt::letify_rec(
+exprt letifyt::letify(
   const exprt &expr,
-  std::vector<exprt> &let_order,
-  const seen_expressionst &map,
-  std::size_t i)
+  const std::vector<exprt> &let_order,
+  const seen_expressionst &map)
 {
-  if(i >= let_order.size())
-    return substitute_let(expr, map);
+  exprt result = substitute_let(expr, map);
 
-  exprt current = let_order[i];
-  INVARIANT(
-    map.find(current) != map.end(), "expression should have been seen already");
+  // go backwards in let order
+  for(auto r_it = let_order.rbegin(); r_it != let_order.rend(); r_it++)
+  {
+    const exprt &current = *r_it;
 
-  if(map.find(current)->second.count < LET_COUNT)
-    return letify_rec(expr, let_order, map, i + 1);
+    auto m_it = map.find(current);
+    INVARIANT(m_it != map.end(), "expression should have been seen already");
 
-  return let_exprt(
-    map.find(current)->second.let_symbol,
-    substitute_let(current, map),
-    letify_rec(expr, let_order, map, i + 1));
+    if(m_it->second.count >= LET_COUNT)
+    {
+      result = let_exprt(
+        m_it->second.let_symbol, substitute_let(current, map), result);
+    }
+  }
+
+  return result;
 }
 
 exprt letifyt::operator()(const exprt &expr)
@@ -75,7 +78,7 @@ exprt letifyt::operator()(const exprt &expr)
 
   collect_bindings(expr, map, let_order);
 
-  return letify_rec(expr, let_order, map, 0);
+  return letify(expr, let_order, map);
 }
 
 exprt letifyt::substitute_let(const exprt &expr, const seen_expressionst &map)

--- a/src/solvers/smt2/letify.h
+++ b/src/solvers/smt2/letify.h
@@ -22,8 +22,6 @@ protected:
   // to produce a fresh ID for each new let
   std::size_t let_id_count = 0;
 
-  static const std::size_t LET_COUNT = 2;
-
   struct let_count_idt
   {
     let_count_idt(std::size_t _count, const symbol_exprt &_let_symbol)

--- a/src/solvers/smt2/letify.h
+++ b/src/solvers/smt2/letify.h
@@ -46,11 +46,10 @@ protected:
     seen_expressionst &map,
     std::vector<exprt> &let_order);
 
-  static exprt letify_rec(
+  static exprt letify(
     const exprt &expr,
-    std::vector<exprt> &let_order,
-    const seen_expressionst &map,
-    std::size_t i);
+    const std::vector<exprt> &let_order,
+    const seen_expressionst &map);
 
   static exprt substitute_let(const exprt &expr, const seen_expressionst &map);
 };


### PR DESCRIPTION
This avoids stack overflow in the case of expressions with many unique subexpressions. PR #4395 is an exemplar.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
