### PR TITLE
Break down steps of goto checker operator

### DIFF
--- a/src/goto-checker/multi_path_symex_checker.cpp
+++ b/src/goto-checker/multi_path_symex_checker.cpp
@@ -42,9 +42,7 @@ operator()(propertiest &properties)
   // we haven't got an equation yet
   if(!equation_generated)
   {
-    symex.symex_from_entry_point_of(
-      goto_symext::get_goto_function(goto_model), symex_symbol_table);
-    postprocess_equation(symex, equation, options, ns, ui_message_handler);
+    generate_equation();
 
     output_coverage_report(
       options.get_option("symex-coverage-report"),
@@ -52,14 +50,7 @@ operator()(propertiest &properties)
       symex,
       ui_message_handler);
 
-    // This might add new properties such as unwinding assertions, for instance.
-    update_properties_status_from_symex_target_equation(
-      properties, result.updated_properties, equation);
-    // Since we will not symex any further we can decide the status
-    // of all properties that do not occur in the equation now.
-    // The current behavior is PASS.
-    update_status_of_not_checked_properties(
-      properties, result.updated_properties);
+    update_properties(properties, result.updated_properties);
 
     // Have we got anything to check? Otherwise we return DONE.
     if(!has_properties_to_check(properties))

--- a/src/goto-checker/multi_path_symex_checker.cpp
+++ b/src/goto-checker/multi_path_symex_checker.cpp
@@ -56,19 +56,35 @@ operator()(propertiest &properties)
     if(!has_properties_to_check(properties))
       return result;
 
-    solver_runtime += prepare_property_decider(
-      properties, equation, property_decider, ui_message_handler);
-
-    if(options.get_bool_option("localize-faults"))
-      freeze_guards(equation, property_decider.get_solver());
+    solver_runtime += prepare_property_decider(properties);
 
     equation_generated = true;
   }
 
-  run_property_decider(
-    result, properties, property_decider, ui_message_handler, solver_runtime);
+  run_property_decider(result, properties, solver_runtime);
 
   return result;
+}
+
+std::chrono::duration<double>
+multi_path_symex_checkert::prepare_property_decider(propertiest &properties)
+{
+  std::chrono::duration<double> solver_runtime = ::prepare_property_decider(
+    properties, equation, property_decider, ui_message_handler);
+
+  if(options.get_bool_option("localize-faults"))
+    freeze_guards(equation, property_decider.get_solver());
+
+  return solver_runtime;
+}
+
+void multi_path_symex_checkert::run_property_decider(
+  incremental_goto_checkert::resultt &result,
+  propertiest &properties,
+  std::chrono::duration<double> solver_runtime)
+{
+  ::run_property_decider(
+    result, properties, property_decider, ui_message_handler, solver_runtime);
 }
 
 goto_tracet multi_path_symex_checkert::build_full_trace() const

--- a/src/goto-checker/multi_path_symex_checker.h
+++ b/src/goto-checker/multi_path_symex_checker.h
@@ -12,6 +12,8 @@ Author: Daniel Kroening, Peter Schrammel
 #ifndef CPROVER_GOTO_CHECKER_MULTI_PATH_SYMEX_CHECKER_H
 #define CPROVER_GOTO_CHECKER_MULTI_PATH_SYMEX_CHECKER_H
 
+#include <chrono>
+
 #include "fault_localization_provider.h"
 #include "goto_symex_property_decider.h"
 #include "goto_trace_provider.h"
@@ -55,6 +57,23 @@ public:
 protected:
   bool equation_generated;
   goto_symex_property_decidert property_decider;
+
+  /// Prepare the property decider for solving. This sets up the data structures
+  /// for tracking goal literals, sets the status of \p properties to be checked
+  /// to UNKNOWN and pushes the equation into the solver.
+  /// \return the time taken (pushing into the solver is a costly operation)
+  virtual std::chrono::duration<double>
+  prepare_property_decider(propertiest &properties);
+
+  /// Run the property decider, which calls the SAT solver, and set the status
+  /// of checked \p properties accordingly. The property IDs of updated
+  /// properties are added to the `result.updated_properties` and the goto
+  /// checker's progress (DONE, FOUND_FAIL) is set in \p result.
+  /// The \p solver_runtime will be logged.
+  virtual void run_property_decider(
+    incremental_goto_checkert::resultt &result,
+    propertiest &properties,
+    std::chrono::duration<double> solver_runtime);
 };
 
 #endif // CPROVER_GOTO_CHECKER_MULTI_PATH_SYMEX_CHECKER_H

--- a/src/goto-checker/multi_path_symex_only_checker.cpp
+++ b/src/goto-checker/multi_path_symex_only_checker.cpp
@@ -41,9 +41,7 @@ multi_path_symex_only_checkert::multi_path_symex_only_checkert(
 incremental_goto_checkert::resultt multi_path_symex_only_checkert::
 operator()(propertiest &properties)
 {
-  symex.symex_from_entry_point_of(
-    goto_symext::get_goto_function(goto_model), symex_symbol_table);
-  postprocess_equation(symex, equation, options, ns, ui_message_handler);
+  generate_equation();
 
   output_coverage_report(
     options.get_option("symex-coverage-report"),
@@ -62,12 +60,25 @@ operator()(propertiest &properties)
   }
 
   resultt result(resultt::progresst::DONE);
+  update_properties(properties, result.updated_properties);
+  return result;
+}
+
+void multi_path_symex_only_checkert::generate_equation()
+{
+  symex.symex_from_entry_point_of(
+    goto_symext::get_goto_function(goto_model), symex_symbol_table);
+  postprocess_equation(symex, equation, options, ns, ui_message_handler);
+}
+
+void multi_path_symex_only_checkert::update_properties(
+  propertiest &properties,
+  std::unordered_set<irep_idt> &updated_properties)
+{
   update_properties_status_from_symex_target_equation(
-    properties, result.updated_properties, equation);
+    properties, updated_properties, equation);
   // Since we will not symex any further we can decide the status
   // of all properties that do not occur in the equation now.
   // The current behavior is PASS.
-  update_status_of_not_checked_properties(
-    properties, result.updated_properties);
-  return result;
+  update_status_of_not_checked_properties(properties, updated_properties);
 }

--- a/src/goto-checker/multi_path_symex_only_checker.h
+++ b/src/goto-checker/multi_path_symex_only_checker.h
@@ -34,6 +34,15 @@ protected:
   guard_managert guard_manager;
   path_fifot path_storage; // should go away
   symex_bmct symex;
+
+  /// Generates the equation by running goto-symex
+  virtual void generate_equation();
+
+  /// Updates the \p properties from the `equation` and
+  /// adds their property IDs to \p updated_properties.
+  virtual void update_properties(
+    propertiest &properties,
+    std::unordered_set<irep_idt> &updated_properties);
 };
 
 #endif // CPROVER_GOTO_CHECKER_MULTI_PATH_SYMEX_ONLY_CHECKER_H

--- a/src/goto-checker/single_path_symex_checker.h
+++ b/src/goto-checker/single_path_symex_checker.h
@@ -47,6 +47,9 @@ public:
 protected:
   bool symex_initialized = false;
   std::unique_ptr<goto_symex_property_decidert> property_decider;
+
+  bool
+  is_ready_to_decide(const symex_bmct &, const path_storaget::patht &) override;
 };
 
 #endif // CPROVER_GOTO_CHECKER_SINGLE_PATH_SYMEX_CHECKER_H

--- a/src/goto-checker/single_path_symex_checker.h
+++ b/src/goto-checker/single_path_symex_checker.h
@@ -12,6 +12,8 @@ Author: Daniel Kroening, Peter Schrammel
 #ifndef CPROVER_GOTO_CHECKER_SINGLE_PATH_SYMEX_CHECKER_H
 #define CPROVER_GOTO_CHECKER_SINGLE_PATH_SYMEX_CHECKER_H
 
+#include <chrono>
+
 #include <util/optional.h>
 
 #include "goto_symex_property_decider.h"
@@ -50,6 +52,26 @@ protected:
 
   bool
   is_ready_to_decide(const symex_bmct &, const path_storaget::patht &) override;
+
+  /// Prepare the \p property_decider for solving. This sets up the data
+  /// structures for tracking goal literals, sets the status of \p properties to
+  /// be checked to UNKNOWN and pushes the equation into the solver.
+  /// \return the time taken (pushing into the solver is a costly operation)
+  virtual std::chrono::duration<double> prepare_property_decider(
+    propertiest &properties,
+    symex_target_equationt &equation,
+    goto_symex_property_decidert &property_decider);
+
+  /// Run the \p property_decider, which calls the SAT solver, and set the
+  /// status of checked \p properties accordingly. The property IDs of updated
+  /// properties are added to the `result.updated_properties` and the goto
+  /// checker's progress (DONE, FOUND_FAIL) is set in \p result.
+  /// The \p solver_runtime will be logged.
+  virtual void run_property_decider(
+    incremental_goto_checkert::resultt &result,
+    propertiest &properties,
+    goto_symex_property_decidert &property_decider,
+    std::chrono::duration<double> solver_runtime);
 };
 
 #endif // CPROVER_GOTO_CHECKER_SINGLE_PATH_SYMEX_CHECKER_H

--- a/src/goto-checker/single_path_symex_only_checker.h
+++ b/src/goto-checker/single_path_symex_only_checker.h
@@ -43,6 +43,34 @@ protected:
     const symex_target_equationt &equation);
 
   virtual void setup_symex(symex_bmct &symex);
+
+  /// Adds the initial goto-symex state as a path to the worklist
+  virtual void initialize_worklist();
+
+  /// Continues exploring the given \p path using goto-symex
+  /// \return whether the path is ready to be checked
+  virtual bool resume_path(path_storaget::patht &path);
+
+  /// Returns whether the given \p path produced by \p symex is ready to be
+  /// checked
+  virtual bool
+  is_ready_to_decide(const symex_bmct &symex, const path_storaget::patht &path);
+
+  /// Returns whether we should stop exploring paths
+  virtual bool has_finished_exploration(const propertiest &);
+
+  /// Updates the \p properties from the \p equation and
+  /// adds their property IDs to \p updated_properties.
+  virtual void update_properties(
+    propertiest &properties,
+    std::unordered_set<irep_idt> &updated_properties,
+    const symex_target_equationt &equation);
+
+  /// Updates the \p properties after having finished exploration and
+  /// adds their property IDs to \p updated_properties.
+  virtual void final_update_properties(
+    propertiest &properties,
+    std::unordered_set<irep_idt> &updated_properties);
 };
 
 #endif // CPROVER_GOTO_CHECKER_SINGLE_PATH_SYMEX_ONLY_CHECKER_H

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -597,7 +597,7 @@ protected:
   ///@}
 
 public:
-  unsigned get_total_vccs()
+  unsigned get_total_vccs() const
   {
     INVARIANT(
       _total_vccs != std::numeric_limits<unsigned>::max(),
@@ -606,7 +606,7 @@ public:
     return _total_vccs;
   }
 
-  unsigned get_remaining_vccs()
+  unsigned get_remaining_vccs() const
   {
     INVARIANT(
       _remaining_vccs != std::numeric_limits<unsigned>::max(),


### PR DESCRIPTION
Break down into smaller class methods to enable better code reuse in derived classes. 

Does not change behaviour.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
