### PR TITLE
Memory snapshot harness lines

### DIFF
--- a/regression/goto-harness/havoc-global-int-01/test.desc
+++ b/regression/goto-harness/havoc-global-int-01/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-location main:0 --havoc-variables x
+--harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-goto-location main:0 --havoc-variables x
 ^EXIT=10$
 ^SIGNAL=0$
 \[main.assertion.1\] line [0-9]+ assertion x == 1: FAILURE

--- a/regression/goto-harness/havoc-global-int-02/test.desc
+++ b/regression/goto-harness/havoc-global-int-02/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-y-snapshot.json --initial-location main:9 --havoc-variables y
+--harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-y-snapshot.json --initial-goto-location main:7 --havoc-variables y
 ^\[main.assertion.1\] line \d+ assertion y \+ 2 > y: FAILURE$
 ^\[main.assertion.2\] line \d+ assertion 0: FAILURE$
 ^EXIT=10$

--- a/regression/goto-harness/havoc-global-int-03/main.c
+++ b/regression/goto-harness/havoc-global-int-03/main.c
@@ -1,0 +1,10 @@
+int x = 1;
+
+int main()
+{
+  assert(x == 1); //unreachable, hence success
+  assert(x == 2);
+  assert(x == 3);
+
+  return 0;
+}

--- a/regression/goto-harness/havoc-global-int-03/test.desc
+++ b/regression/goto-harness/havoc-global-int-03/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-source-location main.c:6 --havoc-variables x
+^EXIT=10$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion x == 1: SUCCESS
+\[main.assertion.2\] line [0-9]+ assertion x == 2: FAILURE
+\[main.assertion.3\] line [0-9]+ assertion x == 3: FAILURE
+--
+^warning: ignoring

--- a/regression/goto-harness/havoc-global-struct/test.desc
+++ b/regression/goto-harness/havoc-global-struct/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-struct-snapshot.json --initial-location main:3 --havoc-variables simple
+--harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-struct-snapshot.json --initial-goto-location main:3 --havoc-variables simple
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[main.assertion.1\] line \d+ assertion simple.j > simple.i: FAILURE$

--- a/regression/goto-harness/load-snapshot-recursive-static-global-int-01/test.desc
+++ b/regression/goto-harness/load-snapshot-recursive-static-global-int-01/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-location main:1
+--harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-goto-location main:1
 ^EXIT=0$
 ^SIGNAL=0$
 VERIFICATION SUCCESSFUL

--- a/regression/goto-harness/load-snapshot-static-global-array-01/test.desc
+++ b/regression/goto-harness/load-snapshot-static-global-array-01/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---harness-type initialise-with-memory-snapshot --memory-snapshot snapshot.json --initial-location main:0
+--harness-type initialise-with-memory-snapshot --memory-snapshot snapshot.json --initial-goto-location main:0
 ^EXIT=0$
 ^SIGNAL=0$
 VERIFICATION SUCCESSFUL

--- a/regression/goto-harness/load-snapshot-static-global-int-01/test.desc
+++ b/regression/goto-harness/load-snapshot-static-global-int-01/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-location main:0
+--harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-goto-location main:0
 ^EXIT=0$
 ^SIGNAL=0$
 VERIFICATION SUCCESSFUL

--- a/regression/goto-harness/load-snapshot-static-global-int-02/test.desc
+++ b/regression/goto-harness/load-snapshot-static-global-int-02/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-location main:0
+--harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-goto-location main:0
 ^EXIT=10$
 ^SIGNAL=0$
 \[main.assertion.1\] line [0-9]+ assertion x == 1: SUCCESS

--- a/regression/goto-harness/load-snapshot-static-global-int-03/test.desc
+++ b/regression/goto-harness/load-snapshot-static-global-int-03/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-location main:0
+--harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-goto-location main:0
 ^EXIT=0$
 ^SIGNAL=0$
 VERIFICATION SUCCESSFUL

--- a/regression/goto-harness/load-snapshot-static-global-int-04/test.desc
+++ b/regression/goto-harness/load-snapshot-static-global-int-04/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-location main:1
+--harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-goto-location main:1
 ^EXIT=0$
 ^SIGNAL=0$
 VERIFICATION SUCCESSFUL

--- a/regression/goto-harness/load-snapshot-static-global-pointer-01/test.desc
+++ b/regression/goto-harness/load-snapshot-static-global-pointer-01/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---harness-type initialise-with-memory-snapshot --memory-snapshot snapshot.json --initial-location main:0
+--harness-type initialise-with-memory-snapshot --memory-snapshot snapshot.json --initial-goto-location main:0
 ^EXIT=0$
 ^SIGNAL=0$
 VERIFICATION SUCCESSFUL

--- a/src/goto-harness/memory_snapshot_harness_generator.cpp
+++ b/src/goto-harness/memory_snapshot_harness_generator.cpp
@@ -36,32 +36,17 @@ void memory_snapshot_harness_generatort::handle_option(
   {
     memory_snapshot_file = require_exactly_one_value(option, values);
   }
-  else if(option == "initial-location")
+  else if(option == "initial-goto-location")
   {
-    const std::string initial_location =
-      require_exactly_one_value(option, values);
-
-    std::vector<std::string> start;
-    split_string(initial_location, ':', start, true);
-
-    if(
-      start.empty() || start.front().empty() ||
-      (start.size() == 2 && start.back().empty()) || start.size() > 2)
-    {
-      throw invalid_command_line_argument_exceptiont(
-        "invalid initial location specification", "--initial-location");
-    }
-
-    entry_function_name = start.front();
-
-    if(start.size() == 2)
-    {
-      location_number = optionalt<unsigned>(safe_string2unsigned(start.back()));
-    }
+    initial_goto_location_line = require_exactly_one_value(option, values);
   }
   else if(option == "havoc-variables")
   {
     variables_to_havoc.insert(values.begin(), values.end());
+  }
+  else if(option == "initial-source-location")
+  {
+    initial_source_location_line = require_exactly_one_value(option, values);
   }
   else
   {

--- a/src/goto-harness/memory_snapshot_harness_generator.cpp
+++ b/src/goto-harness/memory_snapshot_harness_generator.cpp
@@ -66,105 +66,50 @@ void memory_snapshot_harness_generatort::validate_options(
       "--harness-type initialise-from-memory-snapshot");
   }
 
-  if(entry_function_name.empty())
-  {
-    INVARIANT(
-      !location_number.has_value(),
-      "when `function` is empty then the option --initial-location was not "
-      "given and thus `location_number` was not set");
-
-    throw invalid_command_line_argument_exceptiont(
-      "option --initial-location is required",
-      "--harness-type initialise-from-memory-snapshot");
-  }
-
-  const auto &goto_functions = goto_model.goto_functions;
-  const auto &goto_function =
-    goto_functions.function_map.find(entry_function_name);
-  if(goto_function == goto_functions.function_map.end())
+  if(initial_source_location_line.empty() == initial_goto_location_line.empty())
   {
     throw invalid_command_line_argument_exceptiont(
-      "unknown initial location specification", "--initial-location");
+      "choose either source or goto location to specify the entry point",
+      "--initial-source/goto-location");
   }
 
-  if(!goto_function->second.body_available())
+  if(!initial_source_location_line.empty())
   {
-    throw invalid_command_line_argument_exceptiont(
-      "given function `" + id2string(entry_function_name) +
-        "` does not have a body",
-      "--initial-location");
+    entry_location = initialize_entry_via_source(
+      parse_source_location(initial_source_location_line),
+      goto_model.goto_functions);
   }
-
-  if(location_number.has_value())
+  else
   {
-    const auto &goto_program = goto_function->second.body;
-    const auto opt_it = goto_program.get_target(*location_number);
-
-    if(!opt_it.has_value())
-    {
-      throw invalid_command_line_argument_exceptiont(
-        "no instruction with location number " +
-          std::to_string(*location_number) + " in function " +
-          id2string(entry_function_name),
-        "--initial-location");
-    }
-  }
-
-  if(goto_functions.function_map.count(INITIALIZE_FUNCTION) == 0)
-  {
-    throw invalid_command_line_argument_exceptiont(
-      "invalid input program: " + std::string(INITIALIZE_FUNCTION) +
-        " not found",
-      "<in>");
+    entry_location = initialize_entry_via_goto(
+      parse_goto_location(initial_goto_location_line),
+      goto_model.goto_functions);
   }
 
   const symbol_tablet &symbol_table = goto_model.symbol_table;
+
   const symbolt *called_function_symbol =
-    symbol_table.lookup(entry_function_name);
+    symbol_table.lookup(entry_location.function_name);
 
   if(called_function_symbol == nullptr)
   {
     throw invalid_command_line_argument_exceptiont(
-      "function `" + id2string(entry_function_name) +
+      "function `" + id2string(entry_location.function_name) +
         "` not found in the symbol table",
       "--initial-location");
   }
 }
 
 void memory_snapshot_harness_generatort::add_init_section(
+  const symbol_exprt &func_init_done_var,
   goto_modelt &goto_model) const
 {
   goto_functionst &goto_functions = goto_model.goto_functions;
-  symbol_tablet &symbol_table = goto_model.symbol_table;
 
   goto_functiont &goto_function =
-    goto_functions.function_map[entry_function_name];
-  const symbolt &function_symbol = symbol_table.lookup_ref(entry_function_name);
+    goto_functions.function_map[entry_location.function_name];
 
   goto_programt &goto_program = goto_function.body;
-
-  // introduce a symbol for a Boolean variable to indicate the point at which
-  // the function initialisation is completed
-  symbolt &func_init_done_symbol = get_fresh_aux_symbol(
-    bool_typet(),
-    id2string(entry_function_name),
-    "func_init_done",
-    function_symbol.location,
-    function_symbol.mode,
-    symbol_table);
-  func_init_done_symbol.is_static_lifetime = true;
-  func_init_done_symbol.value = false_exprt();
-
-  const symbol_exprt func_init_done_var = func_init_done_symbol.symbol_expr();
-
-  // initialise func_init_done_var in __CPROVER_initialize if it is present
-  // so that it's FALSE value is visible before the harnessed function is called
-  goto_programt &cprover_initialize =
-    goto_functions.function_map.find(INITIALIZE_FUNCTION)->second.body;
-  cprover_initialize.insert_before(
-    std::prev(cprover_initialize.instructions.end()),
-    goto_programt::make_assignment(
-      code_assignt(func_init_done_var, false_exprt())));
 
   const goto_programt::const_targett start_it =
     goto_program.instructions.begin();
@@ -182,9 +127,8 @@ void memory_snapshot_harness_generatort::add_init_section(
   goto_program.compute_location_numbers();
   goto_program.insert_after(
     ins_it2,
-    goto_programt::make_goto(goto_program.const_cast_target(
-      location_number.has_value() ? *goto_program.get_target(*location_number)
-                                  : start_it)));
+    goto_programt::make_goto(
+      goto_program.const_cast_target(entry_location.start_instruction)));
 }
 
 code_blockt memory_snapshot_harness_generatort::add_assignments_to_globals(
@@ -310,12 +254,27 @@ void memory_snapshot_harness_generatort::generate(
   goto_functionst &goto_functions = goto_model.goto_functions;
 
   const symbolt *called_function_symbol =
-    symbol_table.lookup(entry_function_name);
+    symbol_table.lookup(entry_location.function_name);
 
-  add_init_section(goto_model);
+  // introduce a symbol for a Boolean variable to indicate the point at which
+  // the function initialisation is completed
+  auto &func_init_done_symbol = get_fresh_aux_symbol(
+    bool_typet(),
+    id2string(entry_location.function_name),
+    "func_init_done",
+    source_locationt::nil(),
+    called_function_symbol->mode,
+    symbol_table);
+  func_init_done_symbol.is_static_lifetime = true;
+  func_init_done_symbol.value = false_exprt();
+  symbol_exprt func_init_done_var = func_init_done_symbol.symbol_expr();
+
+  add_init_section(func_init_done_var, goto_model);
 
   code_blockt harness_function_body =
     add_assignments_to_globals(snapshot, goto_model);
+
+  harness_function_body.add(code_assignt{func_init_done_var, false_exprt{}});
 
   add_call_with_nondet_arguments(
     *called_function_symbol, harness_function_body);

--- a/src/goto-harness/memory_snapshot_harness_generator.h
+++ b/src/goto-harness/memory_snapshot_harness_generator.h
@@ -99,7 +99,7 @@ protected:
 
   /// Parse a command line option to extract the user specified entry goto
   ///   location
-  /// \param cmdl_option: a string of the format <func[:<n>]>
+  /// \param cmdl_option: a string of the format `name:number`
   /// \return correctly constructed entry goto location
   entry_goto_locationt parse_goto_location(const std::string &cmdl_option);
 
@@ -126,7 +126,7 @@ protected:
 
   /// Parse a command line option to extract the user specified entry source
   ///   location
-  /// \param cmdl_option: a string of the format <file:n>
+  /// \param cmdl_option: a string of the format `name:number`
   /// \return correctly constructed entry source location
   entry_source_locationt parse_source_location(const std::string &cmdl_option);
 
@@ -214,8 +214,12 @@ protected:
   ///     ..second_part..
   ///   }
   ///
+  /// \param func_init_done_var: symbol expression for the `func_init_done`
+  ///   variable
   /// \param goto_model: Model where the modification takes place
-  void add_init_section(goto_modelt &goto_model) const;
+  void add_init_section(
+    const symbol_exprt &func_init_done_var,
+    goto_modelt &goto_model) const;
 
   /// For each global symbol in the \p snapshot symbol table either:
   /// 1) add \ref code_assignt assigning a value from the \p snapshot to the

--- a/src/goto-harness/memory_snapshot_harness_generator.h
+++ b/src/goto-harness/memory_snapshot_harness_generator.h
@@ -22,7 +22,8 @@ Author: Daniel Poetzl
 // clang-format off
 #define MEMORY_SNAPSHOT_HARNESS_GENERATOR_OPTIONS                              \
   "(memory-snapshot):"                                                         \
-  "(initial-location):"                                                        \
+  "(initial-goto-location):"                                                   \
+  "(initial-source-location):"                                                 \
   "(havoc-variables):" // MEMORY_SNAPSHOT_HARNESS_GENERATOR_OPTIONS
 // clang-format on
 
@@ -31,9 +32,11 @@ Author: Daniel Poetzl
   "memory snapshot harness generator (--harness-type\n"                        \
   "  initialise-from-memory-snapshot)\n\n"                                     \
   "--memory-snapshot <file>      initialise memory from JSON memory snapshot\n"\
-  "--initial-location <func[:<n>]>\n"                                          \
+  "--initial-goto-location <func[:<n>]>\n"                                     \
   "                              use given function and location number as "   \
   "entry\n                              point\n"                               \
+  "--initial-source-location <file:n>\n"                                       \
+  "                              use given file and line as entry point\n"     \
   "--havoc-variables vars        initialise variables from vars to\n"          \
   "                              non-deterministic values"                     \
   // MEMORY_SNAPSHOT_HARNESS_GENERATOR_HELP

--- a/src/goto-harness/memory_snapshot_harness_generator.h
+++ b/src/goto-harness/memory_snapshot_harness_generator.h
@@ -246,10 +246,10 @@ protected:
     goto_modelt &goto_model,
     const symbolt &function) const;
 
+  /// data to store the command-line options
   std::string memory_snapshot_file;
-
-  irep_idt entry_function_name;
-  optionalt<unsigned> location_number;
+  std::string initial_goto_location_line;
+  std::string initial_source_location_line;
   std::unordered_set<irep_idt> variables_to_havoc;
 
   /// data to initialize the entry function

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -588,28 +588,6 @@ public:
     return t;
   }
 
-  optionalt<const_targett> get_target(const unsigned location_number) const
-  {
-    PRECONDITION(!instructions.empty());
-
-    const unsigned start_location_number = instructions.front().location_number;
-
-    if(
-      location_number < start_location_number ||
-      location_number > instructions.back().location_number)
-    {
-      return nullopt;
-    }
-
-    auto location_target =
-      std::next(instructions.begin(), location_number - start_location_number);
-
-    // location numbers are contiguous unless new instructions are inserted
-    // here we check that nobody inserted any instruction into our function
-    CHECK_RETURN(location_target->location_number == location_number);
-    return location_target;
-  }
-
   template <typename Target>
   std::list<Target> get_successors(Target target) const;
 


### PR DESCRIPTION
Before the user had to run the CBMC first to find out the location where they wanted to start their snaphot. This PR adds to option to specify the code line.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
