### PR TITLE
Fix type consistency in dereference expressions

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -641,7 +641,7 @@ static member_exprt to_member(
 
   const irep_idt &component_name = field_reference.component_name();
 
-  exprt accessed_object = checked_dereference(typed_pointer, class_type);
+  exprt accessed_object = checked_dereference(typed_pointer);
   const auto type_of = [&ns](const exprt &object) {
     return to_struct_type(ns.follow(object.type()));
   };

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -831,16 +831,8 @@ void java_string_library_preprocesst::code_assign_java_string_to_string_expr(
 {
   PRECONDITION(implements_java_char_sequence_pointer(rhs.type()));
 
-  typet deref_type;
-  if(rhs.type().subtype().id() == ID_struct_tag)
-    deref_type =
-      symbol_table
-        .lookup_ref(to_struct_tag_type(rhs.type().subtype()).get_identifier())
-        .type;
-  else
-    deref_type=rhs.type().subtype();
-
-  const dereference_exprt deref = checked_dereference(rhs, deref_type);
+  const dereference_exprt deref =
+    checked_dereference(rhs, rhs.type().subtype());
 
   // Although we should not reach this code if rhs is null, the association
   // `pointer -> length` is added to the solver anyway, so we have to make sure

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -401,8 +401,7 @@ refined_string_exprt java_string_library_preprocesst::replace_char_array(
   code_blockt &code)
 {
   // array is *array_pointer
-  const dereference_exprt array =
-    checked_dereference(array_pointer, array_pointer.type().subtype());
+  const dereference_exprt array = checked_dereference(array_pointer);
   // array_data is array_pointer-> data
   const exprt array_data = get_data(array, symbol_table);
   const symbolt &sym_char_array = fresh_java_symbol(
@@ -769,7 +768,7 @@ codet java_string_library_preprocesst::code_assign_components_to_java_string(
   bool is_constructor)
 {
   PRECONDITION(implements_java_char_sequence_pointer(lhs.type()));
-  dereference_exprt deref=checked_dereference(lhs, lhs.type().subtype());
+  dereference_exprt deref = checked_dereference(lhs);
 
   if(is_constructor)
   {
@@ -781,8 +780,7 @@ codet java_string_library_preprocesst::code_assign_components_to_java_string(
     java_root_class_init(jlo_init, ns.follow_tag(jlo_tag), clsid);
 
     struct_exprt struct_rhs({jlo_init, rhs_length, rhs_array}, deref.type());
-    return code_assignt(
-      checked_dereference(lhs, lhs.type().subtype()), struct_rhs);
+    return code_assignt(checked_dereference(lhs), struct_rhs);
   }
   else
   {
@@ -831,8 +829,7 @@ void java_string_library_preprocesst::code_assign_java_string_to_string_expr(
 {
   PRECONDITION(implements_java_char_sequence_pointer(rhs.type()));
 
-  const dereference_exprt deref =
-    checked_dereference(rhs, rhs.type().subtype());
+  const dereference_exprt deref = checked_dereference(rhs);
 
   // Although we should not reach this code if rhs is null, the association
   // `pointer -> length` is added to the solver anyway, so we have to make sure
@@ -1454,9 +1451,7 @@ code_blockt java_string_library_preprocesst::make_object_get_class_code(
 
   // class_identifier is this->@class_identifier
   const member_exprt class_identifier(
-    checked_dereference(this_obj, this_obj.type().subtype()),
-    "@class_identifier",
-    string_typet());
+    checked_dereference(this_obj), "@class_identifier", string_typet());
 
   // string_expr = cprover_string_literal(this->@class_identifier)
   const refined_string_exprt string_expr = string_expr_of_function(
@@ -1685,8 +1680,7 @@ code_returnt java_string_library_preprocesst::make_string_length_code(
   const java_method_typet::parameterst &params = type.parameters();
   PRECONDITION(!params[0].get_identifier().empty());
   const symbol_exprt arg_this{params[0].get_identifier(), params[0].type()};
-  const dereference_exprt deref =
-    checked_dereference(arg_this, arg_this.type().subtype());
+  const dereference_exprt deref = checked_dereference(arg_this);
 
   code_returnt ret(get_length(deref, symbol_table));
   ret.add_source_location() = loc;

--- a/jbmc/src/java_bytecode/java_utils.cpp
+++ b/jbmc/src/java_bytecode/java_utils.cpp
@@ -174,9 +174,9 @@ irep_idt resolve_friendly_method_name(
   }
 }
 
-dereference_exprt checked_dereference(const exprt &expr, const typet &type)
+dereference_exprt checked_dereference(const exprt &expr)
 {
-  dereference_exprt result(expr, type);
+  dereference_exprt result(expr);
   // tag it so it's easy to identify during instrumentation
   result.set(ID_java_member_access, true);
   return result;

--- a/jbmc/src/java_bytecode/java_utils.h
+++ b/jbmc/src/java_bytecode/java_utils.h
@@ -70,8 +70,7 @@ irep_idt resolve_friendly_method_name(
 
 /// Dereference an expression and flag it for a null-pointer check
 /// \param expr: expression to dereference and check
-/// \param type: expected result type (typically expr.type().subtype())
-dereference_exprt checked_dereference(const exprt &expr, const typet &type);
+dereference_exprt checked_dereference(const exprt &expr);
 
 /// Add the components in components_to_add to the class denoted
 /// by class symbol.

--- a/jbmc/src/java_bytecode/simple_method_stubbing.cpp
+++ b/jbmc/src/java_bytecode/simple_method_stubbing.cpp
@@ -108,7 +108,7 @@ void java_simple_method_stubst::create_method_stub_at(
   // If it's a constructor the thing we're constructing has already
   // been allocated by this point.
   if(is_constructor)
-    to_init = dereference_exprt(to_init, expected_base);
+    to_init = dereference_exprt(to_init);
 
   java_object_factory_parameterst parameters = object_factory_parameters;
   if(assume_non_null)

--- a/src/util/std_expr.cpp
+++ b/src/util/std_expr.cpp
@@ -267,3 +267,36 @@ void member_exprt::validate(
     "member expression's type must match the addressed struct or union "
     "component");
 }
+
+/// Check that the dereference expression has the right number of operands,
+/// refers to something with a pointer type, and that its type is the subtype
+/// of that pointer type. Throws or raises an invariant if not, according to
+/// validation mode.
+/// \param expr: expression to validate
+/// \param ns: global namespace
+/// \param vm: validation mode (see \ref exprt::validate)
+void dereference_exprt::validate(
+  const exprt &expr,
+  const namespacet &ns,
+  const validation_modet vm)
+{
+  check(expr, vm);
+
+  const auto &dereference_expr = to_dereference_expr(expr);
+
+  const typet &type_of_operand = dereference_expr.pointer().type();
+
+  const pointer_typet *pointer_type =
+    type_try_dynamic_cast<pointer_typet>(type_of_operand);
+
+  DATA_CHECK(
+    vm,
+    pointer_type,
+    "dereference expression's operand must have a pointer type");
+
+  DATA_CHECK(
+    vm,
+    dereference_expr.type() == pointer_type->subtype(),
+    "dereference expression's type must match the subtype of the type of its "
+    "operand");
+}

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -3247,6 +3247,21 @@ public:
   {
     return op0();
   }
+
+  static void check(
+    const exprt &expr,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    DATA_CHECK(
+      vm,
+      expr.operands().size() == 1,
+      "dereference expression must have one operand");
+  }
+
+  static void validate(
+    const exprt &expr,
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT);
 };
 
 template <>

--- a/src/util/validate_expressions.cpp
+++ b/src/util/validate_expressions.cpp
@@ -41,6 +41,10 @@ void call_on_expr(const exprt &expr, Args &&... args)
   {
     CALL_ON_EXPR(member_exprt);
   }
+  else if(expr.id() == ID_dereference)
+  {
+    CALL_ON_EXPR(dereference_exprt);
+  }
   else
   {
 #ifdef REPORT_UNIMPLEMENTED_EXPRESSION_CHECKS


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->
The first two commits each fix a source of type inconsistent dereference expressions, where the dereference expression had the struct type obtained by following the subtype of the struct-tag type of its operand.

The third commit adds validation that this problem doesn't occur. This validation fails without either of the first two commits.

The fourth commit changes `checked_dereference` to use the single-argument constructor for `dereference_exprt`, which will always get the right type. This eliminates a possible source of future type inconsistency.


- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
