### PR TITLE
Sharing map refactorings

### DIFF
--- a/src/util/sharing_node.h
+++ b/src/util/sharing_node.h
@@ -105,6 +105,9 @@ class sharing_node_baset
 SN_TYPE_PAR_DEF class sharing_node_innert : public sharing_node_baset
 {
 public:
+  typedef small_shared_two_way_ptrt<SN_PTR_TYPE_ARGS> datat;
+  typedef typename datat::use_countt use_countt;
+
   typedef d_internalt<SN_TYPE_ARGS> d_it;
   typedef d_containert<SN_TYPE_ARGS> d_ct;
 
@@ -134,6 +137,11 @@ public:
     return data == other.data;
   }
 
+  use_countt use_count() const
+  {
+    return data.use_count();
+  }
+
   void swap(sharing_node_innert &other)
   {
     data.swap(other.data);
@@ -151,43 +159,11 @@ public:
     return data.is_derived_v();
   }
 
-  d_it &write_internal()
-  {
-    if(!data)
-    {
-      data = make_shared_derived_u<SN_PTR_TYPE_ARGS>();
-    }
-    else if(data.use_count() > 1)
-    {
-      data = make_shared_derived_u<SN_PTR_TYPE_ARGS>(*data.get_derived_u());
-    }
-
-    SN_ASSERT(data.use_count() == 1);
-
-    return *data.get_derived_u();
-  }
-
   const d_it &read_internal() const
   {
     SN_ASSERT(!empty());
 
     return *data.get_derived_u();
-  }
-
-  d_ct &write_container()
-  {
-    if(!data)
-    {
-      data = make_shared_derived_v<SN_PTR_TYPE_ARGS>();
-    }
-    else if(data.use_count() > 1)
-    {
-      data = make_shared_derived_v<SN_PTR_TYPE_ARGS>(*data.get_derived_v());
-    }
-
-    SN_ASSERT(data.use_count() == 1);
-
-    return *data.get_derived_v();
   }
 
   const d_ct &read_container() const
@@ -338,7 +314,40 @@ public:
     SN_ASSERT_USE(r, r == 1);
   }
 
-  small_shared_two_way_ptrt<SN_PTR_TYPE_ARGS> data;
+protected:
+  d_it &write_internal()
+  {
+    if(!data)
+    {
+      data = make_shared_derived_u<SN_PTR_TYPE_ARGS>();
+    }
+    else if(data.use_count() > 1)
+    {
+      data = make_shared_derived_u<SN_PTR_TYPE_ARGS>(*data.get_derived_u());
+    }
+
+    SN_ASSERT(data.use_count() == 1);
+
+    return *data.get_derived_u();
+  }
+
+  d_ct &write_container()
+  {
+    if(!data)
+    {
+      data = make_shared_derived_v<SN_PTR_TYPE_ARGS>();
+    }
+    else if(data.use_count() > 1)
+    {
+      data = make_shared_derived_v<SN_PTR_TYPE_ARGS>(*data.get_derived_v());
+    }
+
+    SN_ASSERT(data.use_count() == 1);
+
+    return *data.get_derived_v();
+  }
+
+  datat data;
 };
 
 // Leafs
@@ -357,6 +366,9 @@ public:
 SN_TYPE_PAR_DEF class sharing_node_leaft : public sharing_node_baset
 {
 public:
+  typedef small_shared_ptrt<SN_PTR_TYPE_ARG> datat;
+  typedef decltype(datat().use_count()) use_countt;
+
   typedef d_leaft<SN_TYPE_ARGS> d_lt;
 
   sharing_node_leaft(const keyT &k, const valueT &v)
@@ -392,30 +404,14 @@ public:
     return data == other.data;
   }
 
+  use_countt use_count() const
+  {
+    return data.use_count();
+  }
+
   void swap(sharing_node_leaft &other)
   {
     data.swap(other.data);
-  }
-
-  d_lt &write()
-  {
-    if(!data)
-    {
-      data = make_small_shared_ptr<d_lt>();
-    }
-    else if(data.use_count() > 1)
-    {
-      data = make_small_shared_ptr<d_lt>(*data);
-    }
-
-    SN_ASSERT(data.use_count() == 1);
-
-    return *data;
-  }
-
-  const d_lt &read() const
-  {
-    return *data;
   }
 
   // Accessors
@@ -445,7 +441,29 @@ public:
     return write().v;
   }
 
-  small_shared_ptrt<SN_PTR_TYPE_ARG> data;
+  const d_lt &read() const
+  {
+    return *data;
+  }
+
+protected:
+  d_lt &write()
+  {
+    if(!data)
+    {
+      data = make_small_shared_ptr<d_lt>();
+    }
+    else if(data.use_count() > 1)
+    {
+      data = make_small_shared_ptr<d_lt>(*data);
+    }
+
+    SN_ASSERT(data.use_count() == 1);
+
+    return *data;
+  }
+
+  datat data;
 };
 
 #endif

--- a/src/util/sharing_node.h
+++ b/src/util/sharing_node.h
@@ -113,18 +113,18 @@ public:
   typedef typename d_ct::leaft leaft;
   typedef typename d_ct::leaf_listt leaf_listt;
 
-  sharing_node_innert() : data(empty_data)
+  sharing_node_innert()
   {
   }
 
   bool empty() const
   {
-    return data == empty_data;
+    return !data;
   }
 
   void clear()
   {
-    data = empty_data;
+    data.reset();
   }
 
   bool shares_with(const sharing_node_innert &other) const
@@ -153,7 +153,7 @@ public:
 
   d_it &write_internal()
   {
-    if(data == empty_data)
+    if(!data)
     {
       data = make_shared_derived_u<SN_PTR_TYPE_ARGS>();
     }
@@ -176,7 +176,7 @@ public:
 
   d_ct &write_container()
   {
-    if(data == empty_data)
+    if(!data)
     {
       data = make_shared_derived_v<SN_PTR_TYPE_ARGS>();
     }
@@ -339,12 +339,7 @@ public:
   }
 
   small_shared_two_way_ptrt<SN_PTR_TYPE_ARGS> data;
-  static small_shared_two_way_ptrt<SN_PTR_TYPE_ARGS> empty_data;
 };
-
-SN_TYPE_PAR_DEF small_shared_two_way_ptrt<SN_PTR_TYPE_ARGS>
-  sharing_node_innert<SN_TYPE_ARGS>::empty_data =
-    small_shared_two_way_ptrt<SN_PTR_TYPE_ARGS>();
 
 // Leafs
 
@@ -364,7 +359,7 @@ SN_TYPE_PAR_DEF class sharing_node_leaft : public sharing_node_baset
 public:
   typedef d_leaft<SN_TYPE_ARGS> d_lt;
 
-  sharing_node_leaft(const keyT &k, const valueT &v) : data(empty_data)
+  sharing_node_leaft(const keyT &k, const valueT &v)
   {
     SN_ASSERT(empty());
 
@@ -384,12 +379,12 @@ public:
 
   bool empty() const
   {
-    return data == empty_data;
+    return !data;
   }
 
   void clear()
   {
-    data = empty_data;
+    data.reset();
   }
 
   bool shares_with(const sharing_node_leaft &other) const
@@ -404,9 +399,7 @@ public:
 
   d_lt &write()
   {
-    SN_ASSERT(data.use_count() > 0);
-
-    if(data == empty_data)
+    if(!data)
     {
       data = make_small_shared_ptr<d_lt>();
     }
@@ -453,11 +446,6 @@ public:
   }
 
   small_shared_ptrt<SN_PTR_TYPE_ARG> data;
-  static small_shared_ptrt<SN_PTR_TYPE_ARG> empty_data;
 };
-
-SN_TYPE_PAR_DEF small_shared_ptrt<SN_PTR_TYPE_ARG>
-  sharing_node_leaft<SN_TYPE_ARGS>::empty_data =
-    make_small_shared_ptr<SN_PTR_TYPE_ARG>();
 
 #endif

--- a/src/util/small_shared_two_way_ptr.h
+++ b/src/util/small_shared_two_way_ptr.h
@@ -101,30 +101,13 @@ public:
 
   ~small_shared_two_way_ptrt()
   {
-    if(!p)
-    {
-      return;
-    }
+    destruct();
+  }
 
-    auto use_count = p->use_count();
-
-    if(use_count == 1)
-    {
-      if(p->is_derived_u())
-      {
-        U *u = static_cast<U *>(p);
-        delete u;
-      }
-      else
-      {
-        V *v = static_cast<V *>(p);
-        delete v;
-      }
-    }
-    else
-    {
-      p->decrement_use_count();
-    }
+  void reset()
+  {
+    destruct();
+    p = nullptr;
   }
 
   void swap(small_shared_two_way_ptrt &rhs)
@@ -186,6 +169,34 @@ public:
   }
 
 private:
+  void destruct()
+  {
+    if(!p)
+    {
+      return;
+    }
+
+    auto use_count = p->use_count();
+
+    if(use_count == 1)
+    {
+      if(p->is_derived_u())
+      {
+        U *u = static_cast<U *>(p);
+        delete u;
+      }
+      else
+      {
+        V *v = static_cast<V *>(p);
+        delete v;
+      }
+    }
+    else
+    {
+      p->decrement_use_count();
+    }
+  }
+
   pointeet *p = nullptr;
 };
 

--- a/unit/util/sharing_map.cpp
+++ b/unit/util/sharing_map.cpp
@@ -385,7 +385,7 @@ void sharing_map_sharing_stats_test()
 {
   SECTION("count nodes")
   {
-    std::set<void *> marked;
+    std::set<const void *> marked;
     smt sm;
     int count = 0;
 
@@ -410,7 +410,7 @@ void sharing_map_sharing_stats_test()
 
   SECTION("marking")
   {
-    std::set<void *> marked;
+    std::set<const void *> marked;
     smt sm;
 
     fill(sm);

--- a/unit/util/sharing_node.cpp
+++ b/unit/util/sharing_node.cpp
@@ -7,7 +7,37 @@
 #include <testing-utils/use_catch.h>
 #include <util/sharing_node.h>
 
-void sharing_node_test()
+class leaft : public sharing_node_leaft<int, int>
+{
+public:
+  leaft(const int &a, const int &b) : sharing_node_leaft<int, int>(a, b)
+  {
+  }
+  friend void sharing_node_internals_test();
+};
+
+void sharing_node_internals_test()
+{
+  SECTION("Leaf test")
+  {
+    // Detaching
+    {
+      leaft leaf(1, 2);
+
+      auto p = leaf.data.get();
+      leaf.write();
+
+      REQUIRE(leaf.data.get() == p);
+    }
+  }
+}
+
+TEST_CASE("Sharing node internals", "[core][util]")
+{
+  sharing_node_internals_test();
+}
+
+TEST_CASE("Sharing node", "[core][util]")
 {
   SECTION("Leaf test")
   {
@@ -44,16 +74,6 @@ void sharing_node_test()
       v = 3;
       REQUIRE(leaf2.get_value() == 3);
       REQUIRE(!leaf2.shares_with(leaf1));
-    }
-
-    // Detaching
-    {
-      leaft leaf(1, 2);
-
-      auto p = leaf.data.get();
-      leaf.write();
-
-      REQUIRE(leaf.data.get() == p);
     }
   }
 
@@ -200,9 +220,4 @@ void sharing_node_test()
 
     REQUIRE(map2.shares_with(map));
   }
-}
-
-TEST_CASE("Sharing node")
-{
-  sharing_node_test();
 }

--- a/unit/util/small_shared_two_way_ptr.cpp
+++ b/unit/util/small_shared_two_way_ptr.cpp
@@ -61,6 +61,7 @@ TEST_CASE("Small shared two-way pointer")
   SECTION("Basic")
   {
     spt sp1;
+    REQUIRE(!sp1);
     REQUIRE(sp1.use_count() == 0);
 
     const d1t *p;
@@ -86,6 +87,10 @@ TEST_CASE("Small shared two-way pointer")
     REQUIRE(sp1.use_count() == 3);
     REQUIRE(sp2.use_count() == 3);
     REQUIRE(sp3.use_count() == 3);
+
+    sp1.reset();
+    REQUIRE(!sp1);
+    REQUIRE(sp1.use_count() == 0);
   }
 
   SECTION("Creation")


### PR DESCRIPTION
This removes the `empty_data` static field to represent an empty sharing node (now an empty sharing node is distinguished by containing and empty shared pointer), and makes the `write_*` methods of the sharing nodes protected.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
