### PR TITLE
Add the deprecation date to each deprecated entity [blocks: #3768, #4248, #4368, #4371]

### DIFF
--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -58,7 +58,7 @@ void instrument_cover_goals(
 /// \deprecated use instrument_cover_goals(goto_programt &goto_program,
 /// const cover_instrumenterst &instrumenters,
 /// message_handlert &message_handler, const irep_idt mode) instead
-DEPRECATED("use instrument_cover_goals(goto_programt &...) instead")
+DEPRECATED(SINCE(2018, 2, 9, "use instrument_cover_goals goto_programt &..."))
 void instrument_cover_goals(
   const symbol_tablet &symbol_table,
   const irep_idt &function_id,

--- a/src/goto-programs/goto_function.h
+++ b/src/goto-programs/goto_function.h
@@ -30,7 +30,7 @@ public:
   goto_programt body;
 
   /// The type of the function, indicating the return type and parameter types
-  DEPRECATED("Get the type from the symbol table instead")
+  DEPRECATED(SINCE(2019, 2, 16, "Get the type from the symbol table instead"))
   code_typet type;
 
   typedef std::vector<irep_idt> parameter_identifierst;
@@ -54,19 +54,19 @@ public:
       parameter_identifiers.push_back(parameter.get_identifier());
   }
 
-  DEPRECATED("Get the type from the symbol table instead")
+  DEPRECATED(SINCE(2019, 2, 16, "Get the type from the symbol table instead"))
   bool is_inlined() const
   {
     return type.get_bool(ID_C_inlined);
   }
 
-  DEPRECATED("Get the type from the symbol table instead")
+  DEPRECATED(SINCE(2019, 2, 16, "Get the type from the symbol table instead"))
   bool is_hidden() const
   {
     return type.get_bool(ID_C_hide);
   }
 
-  DEPRECATED("Get the type from the symbol table instead")
+  DEPRECATED(SINCE(2019, 2, 16, "Get the type from the symbol table instead"))
   void make_hidden()
   {
     type.set(ID_C_hide, true);

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -353,64 +353,71 @@ public:
       clear(SKIP);
     }
 
-    DEPRECATED("use goto_programt::make_return() instead")
+    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_return() instead"))
     void make_return() { clear(RETURN); }
 
-    DEPRECATED("use goto_programt::make_skip() instead")
+    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_skip() instead"))
     void make_skip() { clear(SKIP); }
 
-    DEPRECATED("use goto_programt::make_location() instead")
+    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_location() instead"))
     void make_location(const source_locationt &l)
     { clear(LOCATION); source_location=l; }
 
-    DEPRECATED("use goto_programt::make_throw() instead")
+    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_throw() instead"))
     void make_throw() { clear(THROW); }
 
-    DEPRECATED("use goto_programt::make_catch() instead")
+    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_catch() instead"))
     void make_catch() { clear(CATCH); }
 
-    DEPRECATED("use goto_programt::make_assertion() instead")
+    DEPRECATED(
+      SINCE(2019, 2, 13, "use goto_programt::make_assertion() instead"))
     void make_assertion(const exprt &g) { clear(ASSERT); guard=g; }
 
-    DEPRECATED("use goto_programt::make_assumption() instead")
+    DEPRECATED(
+      SINCE(2019, 2, 13, "use goto_programt::make_assumption() instead"))
     void make_assumption(const exprt &g) { clear(ASSUME); guard=g; }
 
-    DEPRECATED("use goto_programt::make_assignment() instead")
+    DEPRECATED(
+      SINCE(2019, 2, 13, "use goto_programt::make_assignment() instead"))
     void make_assignment() { clear(ASSIGN); }
 
-    DEPRECATED("use goto_programt::make_other() instead")
+    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_other() instead"))
     void make_other(const codet &_code) { clear(OTHER); code=_code; }
 
-    DEPRECATED("use goto_programt::make_decl() instead")
+    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_decl() instead"))
     void make_decl() { clear(DECL); }
 
-    DEPRECATED("use goto_programt::make_dead() instead")
+    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_dead() instead"))
     void make_dead() { clear(DEAD); }
 
-    DEPRECATED("use goto_programt::make_atomic_begin() instead")
+    DEPRECATED(
+      SINCE(2019, 2, 13, "use goto_programt::make_atomic_begin() instead"))
     void make_atomic_begin() { clear(ATOMIC_BEGIN); }
 
-    DEPRECATED("use goto_programt::make_atomic_end() instead")
+    DEPRECATED(
+      SINCE(2019, 2, 13, "use goto_programt::make_atomic_end() instead"))
     void make_atomic_end() { clear(ATOMIC_END); }
 
-    DEPRECATED("use goto_programt::make_end_function() instead")
+    DEPRECATED(
+      SINCE(2019, 2, 13, "use goto_programt::make_end_function() instead"))
     void make_end_function() { clear(END_FUNCTION); }
 
-    DEPRECATED("use goto_programt::make_incomplete_goto() instead")
+    DEPRECATED(
+      SINCE(2019, 2, 13, "use goto_programt::make_incomplete_goto() instead"))
     void make_incomplete_goto(const code_gotot &_code)
     {
       clear(INCOMPLETE_GOTO);
       code = _code;
     }
 
-    DEPRECATED("use goto_programt::make_goto() instead")
+    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_goto() instead"))
     void make_goto(targett _target)
     {
       clear(GOTO);
       targets.push_back(_target);
     }
 
-    DEPRECATED("use goto_programt::make_goto() instead")
+    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_goto() instead"))
     void make_goto(targett _target, const exprt &g)
     {
       make_goto(_target);
@@ -425,21 +432,23 @@ public:
       type = GOTO;
     }
 
-    DEPRECATED("use goto_programt::make_assignment() instead")
+    DEPRECATED(
+      SINCE(2019, 2, 13, "use goto_programt::make_assignment() instead"))
     void make_assignment(const code_assignt &_code)
     {
       clear(ASSIGN);
       code=_code;
     }
 
-    DEPRECATED("use goto_programt::make_decl() instead")
+    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_decl() instead"))
     void make_decl(const code_declt &_code)
     {
       clear(DECL);
       code=_code;
     }
 
-    DEPRECATED("use goto_programt::make_function_call() instead")
+    DEPRECATED(
+      SINCE(2019, 2, 13, "use goto_programt::make_function_call() instead"))
     void make_function_call(const code_function_callt &_code)
     {
       clear(FUNCTION_CALL);

--- a/src/goto-programs/link_to_library.h
+++ b/src/goto-programs/link_to_library.h
@@ -23,7 +23,7 @@ class goto_modelt;
 class message_handlert;
 class symbol_tablet;
 
-DEPRECATED("Use link_to_library(goto_model, ...) instead")
+DEPRECATED(SINCE(2019, 2, 28, "Use link_to_library(goto_model, ...) instead"))
 void link_to_library(
   symbol_tablet &,
   goto_functionst &,

--- a/src/goto-symex/ssa_step.h
+++ b/src/goto-symex/ssa_step.h
@@ -191,7 +191,7 @@ public:
   {
   }
 
-  DEPRECATED("Use output without ns param")
+  DEPRECATED(SINCE(2018, 4, 23, "Use output without ns param"))
   void output(const namespacet &ns, std::ostream &out) const;
 
   void output(std::ostream &out) const;

--- a/src/solvers/strings/string_constraint_generator.h
+++ b/src/solvers/strings/string_constraint_generator.h
@@ -482,7 +482,7 @@ add_axioms_for_char_literal(const function_application_exprt &f);
 /// \todo This function is underspecified, we do not compute the exact value
 /// but over approximate it.
 /// \deprecated This is Java specific and should be implemented in Java.
-DEPRECATED("This is Java specific and should be implemented in Java")
+DEPRECATED(SINCE(2017, 10, 5, "Java specific, should be implemented in Java"))
 std::pair<exprt, string_constraintst> add_axioms_for_code_point_count(
   symbol_generatort &fresh_symbol,
   const function_application_exprt &f,
@@ -494,6 +494,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_code_point_count(
 /// argument code points and we approximate this by saying the result is
 /// between index + offset and index + 2 * offset.
 /// \deprecated This is Java specific and should be implemented in Java.
+DEPRECATED(SINCE(2017, 10, 5, "Java specific, should be implemented in Java"))
 std::pair<exprt, string_constraintst> add_axioms_for_offset_by_code_point(
   symbol_generatort &fresh_symbol,
   const function_application_exprt &f);

--- a/src/solvers/strings/string_constraint_generator_comparison.cpp
+++ b/src/solvers/strings/string_constraint_generator_comparison.cpp
@@ -303,7 +303,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_compare_to(
 /// \deprecated never tested
 /// \param f: function application with one string argument
 /// \return a string expression
-DEPRECATED("never tested")
+DEPRECATED(SINCE(2017, 10, 5, "never tested"))
 std::pair<symbol_exprt, string_constraintst>
 string_constraint_generatort::add_axioms_for_intern(
   const function_application_exprt &f)

--- a/src/solvers/strings/string_constraint_generator_insert.cpp
+++ b/src/solvers/strings/string_constraint_generator_insert.cpp
@@ -140,7 +140,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_insert(
 /// \param array_pool: pool of arrays representing strings
 /// \param ns: namespace
 /// \return an expression
-DEPRECATED("should convert the value to string and call insert")
+DEPRECATED(SINCE(2017, 10, 5, "convert the value to string and call insert"))
 std::pair<exprt, string_constraintst> add_axioms_for_insert_int(
   symbol_generatort &fresh_symbol,
   const function_application_exprt &f,
@@ -167,7 +167,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_insert_int(
 ///   integer offset, and a Boolean
 /// \param array_pool: pool of arrays representing strings
 /// \return a new string expression
-DEPRECATED("should convert the value to string and call insert")
+DEPRECATED(SINCE(2017, 10, 5, "convert the value to string and call insert"))
 std::pair<exprt, string_constraintst> add_axioms_for_insert_bool(
   symbol_generatort &fresh_symbol,
   const function_application_exprt &f,
@@ -219,7 +219,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_insert_char(
 /// \param array_pool: pool of arrays representing strings
 /// \param ns: namespace
 /// \return a string expression
-DEPRECATED("should convert the value to string and call insert")
+DEPRECATED(SINCE(2017, 10, 5, "convert the value to string and call insert"))
 std::pair<exprt, string_constraintst> add_axioms_for_insert_double(
   symbol_generatort &fresh_symbol,
   const function_application_exprt &f,
@@ -248,7 +248,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_insert_double(
 /// \param array_pool: pool of arrays representing strings
 /// \param ns: namespace
 /// \return a new string expression
-DEPRECATED("should convert the value to string and call insert")
+DEPRECATED(SINCE(2017, 10, 5, "convert the value to string and call insert"))
 std::pair<exprt, string_constraintst> add_axioms_for_insert_float(
   symbol_generatort &fresh_symbol,
   const function_application_exprt &f,

--- a/src/solvers/strings/string_constraint_generator_main.cpp
+++ b/src/solvers/strings/string_constraint_generator_main.cpp
@@ -487,7 +487,7 @@ string_constraint_generatort::add_axioms_for_function_application(
 ///   or three arguments: string, integer offset and count
 /// \param array_pool: pool of arrays representing strings
 /// \return a new string expression
-DEPRECATED("should use substring instead")
+DEPRECATED(SINCE(2017, 10, 5, "should use substring instead"))
 std::pair<exprt, string_constraintst> add_axioms_for_copy(
   symbol_generatort &fresh_symbol,
   const function_application_exprt &f,

--- a/src/solvers/strings/string_constraint_generator_testing.cpp
+++ b/src/solvers/strings/string_constraint_generator_testing.cpp
@@ -123,7 +123,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_is_prefix(
 /// \param f: function application with a string argument
 /// \param array_pool: pool of arrays representing strings
 /// \return a Boolean expression
-DEPRECATED("should use `string_length(s)==0` instead")
+DEPRECATED(SINCE(2017, 10, 5, "should use `string_length s == 0` instead"))
 std::pair<exprt, string_constraintst> add_axioms_for_is_empty(
   symbol_generatort &fresh_symbol,
   const function_application_exprt &f,
@@ -165,7 +165,8 @@ std::pair<exprt, string_constraintst> add_axioms_for_is_empty(
 ///   argument or the first argument
 /// \param array_pool: pool of arrays representing strings
 /// \return Boolean expression `issuffix`
-DEPRECATED("should use `strings_startwith(s0, s1, s1.length - s0.length)`")
+/// \deprecated Should use `strings_startwith(s0, s1, s1.length - s0.length)`.
+DEPRECATED(SINCE(2018, 6, 6, "should use strings_startwith"))
 std::pair<exprt, string_constraintst> add_axioms_for_is_suffix(
   symbol_generatort &fresh_symbol,
   const function_application_exprt &f,

--- a/src/solvers/strings/string_constraint_generator_valueof.cpp
+++ b/src/solvers/strings/string_constraint_generator_valueof.cpp
@@ -42,7 +42,7 @@ static unsigned long to_integer_or_default(
 /// \param array_pool: pool of arrays representing strings
 /// \param ns: namespace
 /// \return a new string expression
-DEPRECATED("should use add_axioms_for_string_of_int instead")
+DEPRECATED(SINCE(2017, 10, 5, "use add_axioms_for_string_of_int instead"))
 std::pair<exprt, string_constraintst> add_axioms_from_long(
   const function_application_exprt &f,
   array_poolt &array_pool,
@@ -63,7 +63,7 @@ std::pair<exprt, string_constraintst> add_axioms_from_long(
 /// \param f: function application with a Boolean argument
 /// \param array_pool: pool of arrays representing strings
 /// \return a new string expression
-DEPRECATED("This is Java specific and should be implemented in Java instead")
+DEPRECATED(SINCE(2017, 10, 5, "Java specific, should be implemented in Java"))
 std::pair<exprt, string_constraintst> add_axioms_from_bool(
   const function_application_exprt &f,
   array_poolt &array_pool)
@@ -80,7 +80,7 @@ std::pair<exprt, string_constraintst> add_axioms_from_bool(
 /// \param res: string expression for the result
 /// \param b: Boolean expression
 /// \return code 0 on success
-DEPRECATED("This is Java specific and should be implemented in Java instead")
+DEPRECATED(SINCE(2017, 10, 5, "Java specific, should be implemented in Java"))
 std::pair<exprt, string_constraintst>
 add_axioms_from_bool(const array_string_exprt &res, const exprt &b)
 {
@@ -212,7 +212,7 @@ static exprt int_of_hex_char(const exprt &chr)
 /// \param res: string expression for the result
 /// \param i: an integer argument
 /// \return code 0 on success
-DEPRECATED("use add_axioms_for_string_of_int_with_radix instead")
+DEPRECATED(SINCE(2017, 10, 5, "use add_axioms_for_string_of_int_with_radix"))
 std::pair<exprt, string_constraintst>
 add_axioms_from_int_hex(const array_string_exprt &res, const exprt &i)
 {

--- a/src/util/arith_tools.h
+++ b/src/util/arith_tools.h
@@ -27,7 +27,7 @@ class typet;
 bool to_integer(const constant_exprt &expr, mp_integer &int_value);
 
 // returns 'true' on error
-DEPRECATED("Use numeric_cast<unsigned>(e) instead")
+DEPRECATED(SINCE(2018, 9, 29, "Use numeric_cast<unsigned>(e) instead"))
 bool to_unsigned_integer(const constant_exprt &expr, unsigned &uint_value);
 
 /// Numerical cast provides a unified way of converting from one numerical type

--- a/src/util/base_type.h
+++ b/src/util/base_type.h
@@ -18,13 +18,13 @@ class exprt;
 class typet;
 class namespacet;
 
-DEPRECATED("Use == instead")
+DEPRECATED(SINCE(2019, 1, 22, "Use == instead"))
 bool base_type_eq(
   const typet &type1,
   const typet &type2,
   const namespacet &ns);
 
-DEPRECATED("Use == instead")
+DEPRECATED(SINCE(2019, 1, 22, "Use == instead"))
 bool base_type_eq(
   const exprt &expr1,
   const exprt &expr2,

--- a/src/util/byte_operators.h
+++ b/src/util/byte_operators.h
@@ -25,12 +25,14 @@ Author: Daniel Kroening, kroening@kroening.com
 class byte_extract_exprt:public binary_exprt
 {
 public:
-  DEPRECATED("use byte_extract_exprt(id, op, offset, type) instead")
+  DEPRECATED(
+    SINCE(2019, 1, 12, "use byte_extract_exprt(id, op, offset, type) instead"))
   explicit byte_extract_exprt(irep_idt _id):binary_exprt(_id)
   {
   }
 
-  DEPRECATED("use byte_extract_exprt(id, op, offset, type) instead")
+  DEPRECATED(
+    SINCE(2019, 1, 12, "use byte_extract_exprt(id, op, offset, type) instead"))
   explicit byte_extract_exprt(irep_idt _id, const typet &_type):
     binary_exprt(_id, _type)
   {

--- a/src/util/deprecate.h
+++ b/src/util/deprecate.h
@@ -23,4 +23,7 @@ Author: Diffblue Ltd.
 #define DEPRECATED(msg)
 #endif
 
+#define SINCE(year, month, day, msg)                                           \
+  "deprecated since " #year "-" #month "-" #day "; " msg
+
 #endif // CPROVER_UTIL_DEPRECATE_H

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -121,14 +121,22 @@ public:
   void reserve_operands(operandst::size_type n)
   { operands().reserve(n) ; }
 
-  DEPRECATED("use add_to_operands(std::move(expr)) instead")
+  DEPRECATED(SINCE(2018, 10, 1, "use add_to_operands(std::move(expr)) instead"))
   void move_to_operands(exprt &expr);
 
-  DEPRECATED("use add_to_operands(std::move(e1), std::move(e2)) instead")
+  DEPRECATED(SINCE(
+    2018,
+    10,
+    1,
+    "use add_to_operands(std::move(e1), std::move(e2)) instead"))
   void move_to_operands(exprt &e1, exprt &e2);
 
-  DEPRECATED(
-    "use add_to_operands(std::move(e1), std::move(e2), std::move(e3)) instead")
+  DEPRECATED(SINCE(
+    2018,
+    10,
+    1,
+    "use add_to_operands(std::move(e1), std::move(e2), std::move(e3))"
+    "instead"))
   void move_to_operands(exprt &e1, exprt &e2, exprt &e3);
 
   /// Copy the given argument to the end of `exprt`'s operands.
@@ -225,7 +233,7 @@ public:
     op.push_back(std::move(e3));
   }
 
-  DEPRECATED("use typecast_exprt() instead")
+  DEPRECATED(SINCE(2019, 1, 19, "use typecast_exprt() instead"))
   void make_typecast(const typet &_type);
 
   void make_bool(bool value);

--- a/src/util/lispexpr.h
+++ b/src/util/lispexpr.h
@@ -6,8 +6,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-
-// THIS HEADER IS DEPRECATED AND WILL GO AWAY
+// THIS HEADER IS DEPRECATED (since 2015-06-30) AND WILL GO AWAY
 
 #ifndef CPROVER_UTIL_LISPEXPR_H
 #define CPROVER_UTIL_LISPEXPR_H

--- a/src/util/mathematical_expr.h
+++ b/src/util/mathematical_expr.h
@@ -19,7 +19,7 @@ Author: Daniel Kroening, kroening@kroening.com
 class transt : public ternary_exprt
 {
 public:
-  DEPRECATED("use transt(op0, op1, op2) instead")
+  DEPRECATED(SINCE(2019, 1, 12, "use transt(op0, op1, op2) instead"))
   transt() : ternary_exprt(ID_trans)
   {
   }
@@ -97,7 +97,7 @@ inline transt &to_trans_expr(exprt &expr)
 class power_exprt : public binary_exprt
 {
 public:
-  DEPRECATED("use power_exprt(lhs, rhs) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use power_exprt(lhs, rhs) instead"))
   power_exprt() : binary_exprt(ID_power)
   {
   }
@@ -146,7 +146,7 @@ inline power_exprt &to_power_expr(exprt &expr)
 class factorial_power_exprt : public binary_exprt
 {
 public:
-  DEPRECATED("use factorial_power_exprt(lhs, rhs) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use factorial_power_exprt(lhs, rhs) instead"))
   factorial_power_exprt() : binary_exprt(ID_factorial_power)
   {
   }
@@ -207,7 +207,8 @@ class function_application_exprt : public binary_exprt
 public:
   using argumentst = exprt::operandst;
 
-  DEPRECATED("use function_application_exprt(fkt, arg) instead")
+  DEPRECATED(
+    SINCE(2019, 3, 3, "use function_application_exprt(fkt, arg) instead"))
   function_application_exprt(
     const symbol_exprt &_function,
     const argumentst &_arguments,

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -183,7 +183,7 @@ public:
 
   // constructors, destructor
 
-  DEPRECATED("use messaget(message_handler) instead")
+  DEPRECATED(SINCE(2019, 1, 7, "use messaget(message_handler) instead"))
   messaget():
     message_handler(nullptr),
     mstream(M_DEBUG, *this)

--- a/src/util/mp_arith.h
+++ b/src/util/mp_arith.h
@@ -50,15 +50,16 @@ const std::string integer2binary(const mp_integer &, std::size_t width);
 const mp_integer binary2integer(const std::string &, bool is_signed);
 
 /// \deprecated use numeric_cast_v<unsigned long long> instead
-DEPRECATED("Use numeric_cast_v<unsigned long long> instead")
+DEPRECATED(
+  SINCE(2017, 11, 13, "Use numeric_cast_v<unsigned long long> instead"))
 mp_integer::ullong_t integer2ulong(const mp_integer &);
 
 /// \deprecated use numeric_cast_v<std::size_t> instead
-DEPRECATED("Use numeric_cast_v<std::size_t> instead")
+DEPRECATED(SINCE(2017, 11, 13, "Use numeric_cast_v<std::size_t> instead"))
 std::size_t integer2size_t(const mp_integer &);
 
 /// \deprecated use numeric_cast_v<unsigned> instead
-DEPRECATED("Use numeric_cast_v<unsigned> instead")
+DEPRECATED(SINCE(2017, 11, 13, "Use numeric_cast_v<unsigned> instead"))
 unsigned integer2unsigned(const mp_integer &);
 
 #endif // CPROVER_UTIL_MP_ARITH_H

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -34,7 +34,7 @@ Author: Daniel Kroening, kroening@kroening.com
 class codet:public exprt
 {
 public:
-  DEPRECATED("use codet(statement) instead")
+  DEPRECATED(SINCE(2018, 6, 28, "use codet(statement) instead"))
   codet() : exprt(ID_code, empty_typet())
   {
   }
@@ -83,7 +83,7 @@ public:
   codet &last_statement();
   const codet &last_statement() const;
 
-  DEPRECATED("use code_blockt(...) instead")
+  DEPRECATED(SINCE(2019, 2, 6, "use code_blockt(...) instead"))
   class code_blockt &make_block();
 
   /// Check that the code statement is well-formed (shallow checks only, i.e.,
@@ -537,7 +537,7 @@ inline code_deadt &to_code_dead(codet &code)
 class code_assumet:public codet
 {
 public:
-  DEPRECATED("use code_assumet(expr) instead")
+  DEPRECATED(SINCE(2018, 6, 28, "use code_assumet(expr) instead"))
   code_assumet():codet(ID_assume)
   {
     operands().resize(1);
@@ -595,7 +595,7 @@ inline code_assumet &to_code_assume(codet &code)
 class code_assertt:public codet
 {
 public:
-  DEPRECATED("use code_assertt(expr) instead")
+  DEPRECATED(SINCE(2018, 6, 28, "use code_assertt(expr) instead"))
   code_assertt():codet(ID_assert)
   {
     operands().resize(1);
@@ -667,7 +667,11 @@ code_blockt create_fatal_assertion(
 class code_ifthenelset:public codet
 {
 public:
-  DEPRECATED("use code_ifthenelset(condition, then_code[, else_code]) instead")
+  DEPRECATED(SINCE(
+    2018,
+    12,
+    2,
+    "use code_ifthenelset(condition, then_code[, else_code]) instead"))
   code_ifthenelset():codet(ID_ifthenelse)
   {
     operands().resize(3);
@@ -763,7 +767,7 @@ inline code_ifthenelset &to_code_ifthenelse(codet &code)
 class code_switcht:public codet
 {
 public:
-  DEPRECATED("use code_switcht(value, body) instead")
+  DEPRECATED(SINCE(2018, 6, 28, "use code_switcht(value, body) instead"))
   code_switcht():codet(ID_switch)
   {
     operands().resize(2);
@@ -831,7 +835,7 @@ inline code_switcht &to_code_switch(codet &code)
 class code_whilet:public codet
 {
 public:
-  DEPRECATED("use code_whilet(cond, body) instead")
+  DEPRECATED(SINCE(2018, 6, 28, "use code_whilet(cond, body) instead"))
   code_whilet():codet(ID_while)
   {
     operands().resize(2);
@@ -899,7 +903,7 @@ inline code_whilet &to_code_while(codet &code)
 class code_dowhilet:public codet
 {
 public:
-  DEPRECATED("use code_dowhilet(cond, body) instead")
+  DEPRECATED(SINCE(2018, 6, 28, "use code_dowhilet(cond, body) instead"))
   code_dowhilet():codet(ID_dowhile)
   {
     operands().resize(2);
@@ -967,7 +971,8 @@ inline code_dowhilet &to_code_dowhile(codet &code)
 class code_fort:public codet
 {
 public:
-  DEPRECATED("use code_fort(init, cond, iter, body) instead")
+  DEPRECATED(
+    SINCE(2018, 12, 2, "use code_fort(init, cond, iter, body) instead"))
   code_fort():codet(ID_for)
   {
     operands().resize(4);
@@ -1063,7 +1068,7 @@ inline code_fort &to_code_for(codet &code)
 class code_gotot:public codet
 {
 public:
-  DEPRECATED("use code_gotot(label) instead")
+  DEPRECATED(SINCE(2018, 6, 28, "use code_gotot(label) instead"))
   code_gotot():codet(ID_goto)
   {
   }
@@ -1124,7 +1129,7 @@ inline code_gotot &to_code_goto(codet &code)
 class code_function_callt:public codet
 {
 public:
-  DEPRECATED("Use code_function_callt(...) instead")
+  DEPRECATED(SINCE(2018, 8, 26, "Use code_function_callt(...) instead"))
   code_function_callt():codet(ID_function_call)
   {
     operands().resize(3);
@@ -1324,13 +1329,13 @@ inline code_returnt &to_code_return(codet &code)
 class code_labelt:public codet
 {
 public:
-  DEPRECATED("use code_labelt(label, _code) instead")
+  DEPRECATED(SINCE(2018, 6, 28, "use code_labelt(label, _code) instead"))
   code_labelt():codet(ID_label)
   {
     operands().resize(1);
   }
 
-  DEPRECATED("use code_labelt(label, _code) instead")
+  DEPRECATED(SINCE(2019, 2, 6, "use code_labelt(label, _code) instead"))
   explicit code_labelt(const irep_idt &_label):codet(ID_label)
   {
     operands().resize(1);
@@ -1401,7 +1406,7 @@ inline code_labelt &to_code_label(codet &code)
 class code_switch_caset:public codet
 {
 public:
-  DEPRECATED("use code_switch_caset(case_op, code) instead")
+  DEPRECATED(SINCE(2018, 6, 28, "use code_switch_caset(case_op, code) instead"))
   code_switch_caset():codet(ID_switch_case)
   {
     operands().resize(2);
@@ -1778,7 +1783,7 @@ inline const code_asm_gcct &to_code_asm_gcc(const codet &code)
 class code_expressiont:public codet
 {
 public:
-  DEPRECATED("use code_expressiont(expr) instead")
+  DEPRECATED(SINCE(2018, 6, 28, "use code_expressiont(expr) instead"))
   code_expressiont():codet(ID_expression)
   {
     operands().resize(1);
@@ -1840,13 +1845,15 @@ inline const code_expressiont &to_code_expression(const codet &code)
 class side_effect_exprt : public exprt
 {
 public:
-  DEPRECATED("use side_effect_exprt(statement, type, loc) instead")
+  DEPRECATED(
+    SINCE(2018, 6, 28, "use side_effect_exprt(statement, type, loc) instead"))
   explicit side_effect_exprt(const irep_idt &statement) : exprt(ID_side_effect)
   {
     set_statement(statement);
   }
 
-  DEPRECATED("use side_effect_exprt(statement, type, loc) instead")
+  DEPRECATED(
+    SINCE(2018, 8, 9, "use side_effect_exprt(statement, type, loc) instead"))
   side_effect_exprt(const irep_idt &statement, const typet &_type)
     : exprt(ID_side_effect, _type)
   {
@@ -1924,13 +1931,21 @@ inline const side_effect_exprt &to_side_effect_expr(const exprt &expr)
 class side_effect_expr_nondett:public side_effect_exprt
 {
 public:
-  DEPRECATED("use side_effect_expr_nondett(statement, type, loc) instead")
+  DEPRECATED(SINCE(
+    2018,
+    6,
+    28,
+    "use side_effect_expr_nondett(statement, type, loc) instead"))
   side_effect_expr_nondett():side_effect_exprt(ID_nondet)
   {
     set_nullable(true);
   }
 
-  DEPRECATED("use side_effect_expr_nondett(statement, type, loc) instead")
+  DEPRECATED(SINCE(
+    2018,
+    8,
+    9,
+    "use side_effect_expr_nondett(statement, type, loc) instead"))
   explicit side_effect_expr_nondett(const typet &_type):
     side_effect_exprt(ID_nondet, _type)
   {
@@ -2052,9 +2067,12 @@ to_side_effect_expr_assign(const exprt &expr)
 class side_effect_expr_function_callt:public side_effect_exprt
 {
 public:
-  DEPRECATED(
+  DEPRECATED(SINCE(
+    2018,
+    6,
+    28,
     "use side_effect_expr_function_callt("
-    "function, arguments, type, loc) instead")
+    "function, arguments, type, loc) instead"))
   side_effect_expr_function_callt()
     : side_effect_exprt(ID_function_call, typet(), source_locationt())
   {
@@ -2062,9 +2080,12 @@ public:
     op1().id(ID_arguments);
   }
 
-  DEPRECATED(
+  DEPRECATED(SINCE(
+    2018,
+    8,
+    9,
     "use side_effect_expr_function_callt("
-    "function, arguments, type, loc) instead")
+    "function, arguments, type, loc) instead"))
   side_effect_expr_function_callt(
     const exprt &_function,
     const exprt::operandst &_arguments)
@@ -2076,9 +2097,12 @@ public:
     arguments() = _arguments;
   }
 
-  DEPRECATED(
+  DEPRECATED(SINCE(
+    2018,
+    8,
+    9,
     "use side_effect_expr_function_callt("
-    "function, arguments, type, loc) instead")
+    "function, arguments, type, loc) instead"))
   side_effect_expr_function_callt(
     const exprt &_function,
     const exprt::operandst &_arguments,
@@ -2156,7 +2180,8 @@ inline const side_effect_expr_function_callt
 class side_effect_expr_throwt:public side_effect_exprt
 {
 public:
-  DEPRECATED("use side_effect_expr_throwt(exception_list) instead")
+  DEPRECATED(
+    SINCE(2018, 6, 28, "use side_effect_expr_throwt(exception_list) instead"))
   side_effect_expr_throwt():side_effect_exprt(ID_throw)
   {
   }
@@ -2390,7 +2415,7 @@ static inline const code_landingpadt &to_code_landingpad(const codet &code)
 class code_try_catcht:public codet
 {
 public:
-  DEPRECATED("use code_try_catcht(try_code) instead")
+  DEPRECATED(SINCE(2018, 12, 2, "use code_try_catcht(try_code) instead"))
   code_try_catcht():codet(ID_try_catch)
   {
     operands().resize(1);

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -24,7 +24,7 @@ class nullary_exprt : public expr_protectedt
 {
 public:
   // constructors
-  DEPRECATED("use nullary_exprt(id, type) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use nullary_exprt(id, type) instead"))
   explicit nullary_exprt(const irep_idt &_id) : expr_protectedt(_id, typet())
   {
   }
@@ -61,13 +61,15 @@ class ternary_exprt : public expr_protectedt
 {
 public:
   // constructors
-  DEPRECATED("use ternary_exprt(id, op0, op1, op2, type) instead")
+  DEPRECATED(
+    SINCE(2018, 9, 21, "use ternary_exprt(id, op0, op1, op2, type) instead"))
   explicit ternary_exprt(const irep_idt &_id) : expr_protectedt(_id, type())
   {
     operands().resize(3);
   }
 
-  DEPRECATED("use ternary_exprt(id, op0, op1, op2, type) instead")
+  DEPRECATED(
+    SINCE(2018, 9, 21, "use ternary_exprt(id, op0, op1, op2, type) instead"))
   explicit ternary_exprt(const irep_idt &_id, const typet &_type)
     : expr_protectedt(_id, _type)
   {
@@ -100,13 +102,13 @@ public:
 class symbol_exprt : public nullary_exprt
 {
 public:
-  DEPRECATED("use symbol_exprt(identifier, type) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use symbol_exprt(identifier, type) instead"))
   symbol_exprt() : nullary_exprt(ID_symbol)
   {
   }
 
   /// \param identifier: Name of symbol
-  DEPRECATED("use symbol_exprt(identifier, type) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use symbol_exprt(identifier, type) instead"))
   explicit symbol_exprt(const irep_idt &identifier) : nullary_exprt(ID_symbol)
   {
     set_identifier(identifier);
@@ -150,20 +152,23 @@ public:
 class decorated_symbol_exprt:public symbol_exprt
 {
 public:
-  DEPRECATED("use decorated_symbol_exprt(identifier, type) instead")
+  DEPRECATED(
+    SINCE(2018, 9, 21, "use decorated_symbol_exprt(identifier, type) instead"))
   decorated_symbol_exprt()
   {
   }
 
   /// \param identifier: Name of symbol
-  DEPRECATED("use decorated_symbol_exprt(identifier, type) instead")
+  DEPRECATED(
+    SINCE(2018, 9, 21, "use decorated_symbol_exprt(identifier, type) instead"))
   explicit decorated_symbol_exprt(const irep_idt &identifier):
     symbol_exprt(identifier)
   {
   }
 
   /// \param type: Type of symbol
-  DEPRECATED("use decorated_symbol_exprt(identifier, type) instead")
+  DEPRECATED(
+    SINCE(2018, 9, 21, "use decorated_symbol_exprt(identifier, type) instead"))
   explicit decorated_symbol_exprt(const typet &type):
     symbol_exprt(type)
   {
@@ -305,13 +310,13 @@ inline nondet_symbol_exprt &to_nondet_symbol_expr(exprt &expr)
 class unary_exprt : public expr_protectedt
 {
 public:
-  DEPRECATED("use unary_exprt(id, op) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use unary_exprt(id, op) instead"))
   unary_exprt() : expr_protectedt(irep_idt(), typet())
   {
     operands().resize(1);
   }
 
-  DEPRECATED("use unary_exprt(id, op) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use unary_exprt(id, op) instead"))
   explicit unary_exprt(const irep_idt &_id) : expr_protectedt(_id, typet())
   {
     operands().resize(1);
@@ -322,7 +327,7 @@ public:
   {
   }
 
-  DEPRECATED("use unary_exprt(id, op, type) instead")
+  DEPRECATED(SINCE(2018, 12, 2, "use unary_exprt(id, op, type) instead"))
   unary_exprt(const irep_idt &_id, const typet &_type)
     : expr_protectedt(_id, _type)
   {
@@ -389,7 +394,7 @@ inline unary_exprt &to_unary_expr(exprt &expr)
 class abs_exprt:public unary_exprt
 {
 public:
-  DEPRECATED("use abs_exprt(op) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use abs_exprt(op) instead"))
   abs_exprt()
   {
   }
@@ -438,7 +443,7 @@ inline abs_exprt &to_abs_expr(exprt &expr)
 class unary_minus_exprt:public unary_exprt
 {
 public:
-  DEPRECATED("use unary_minus_exprt(op) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use unary_minus_exprt(op) instead"))
   unary_minus_exprt():unary_exprt(ID_unary_minus)
   {
   }
@@ -600,7 +605,7 @@ inline bswap_exprt &to_bswap_expr(exprt &expr)
 class predicate_exprt : public expr_protectedt
 {
 public:
-  DEPRECATED("use predicate_exprt(id) instead")
+  DEPRECATED(SINCE(2018, 12, 2, "use predicate_exprt(id) instead"))
   predicate_exprt() : expr_protectedt(irep_idt(), bool_typet())
   {
   }
@@ -610,14 +615,15 @@ public:
   {
   }
 
-  DEPRECATED("use unary_predicate_exprt(id, op) instead")
+  DEPRECATED(SINCE(2018, 12, 2, "use unary_predicate_exprt(id, op) instead"))
   predicate_exprt(const irep_idt &_id, const exprt &_op)
     : expr_protectedt(_id, bool_typet())
   {
     add_to_operands(_op);
   }
 
-  DEPRECATED("use binary_predicate_exprt(op1, id, op2) instead")
+  DEPRECATED(
+    SINCE(2018, 12, 2, "use binary_predicate_exprt(op1, id, op2) instead"))
   predicate_exprt(const irep_idt &_id, const exprt &_op0, const exprt &_op1)
     : expr_protectedt(_id, bool_typet())
   {
@@ -630,12 +636,12 @@ public:
 class unary_predicate_exprt:public unary_exprt
 {
 public:
-  DEPRECATED("use unary_predicate_exprt(id, op) instead")
+  DEPRECATED(SINCE(2018, 12, 2, "use unary_predicate_exprt(id, op) instead"))
   unary_predicate_exprt():unary_exprt(irep_idt(), bool_typet())
   {
   }
 
-  DEPRECATED("use unary_predicate_exprt(id, op) instead")
+  DEPRECATED(SINCE(2018, 12, 2, "use unary_predicate_exprt(id, op) instead"))
   explicit unary_predicate_exprt(const irep_idt &_id):
     unary_exprt(_id, bool_typet())
   {
@@ -652,7 +658,7 @@ public:
 class sign_exprt:public unary_predicate_exprt
 {
 public:
-  DEPRECATED("use sign_exprt(op) instead")
+  DEPRECATED(SINCE(2018, 12, 2, "use sign_exprt(op) instead"))
   sign_exprt()
   {
   }
@@ -701,19 +707,19 @@ inline sign_exprt &to_sign_expr(exprt &expr)
 class binary_exprt : public expr_protectedt
 {
 public:
-  DEPRECATED("use binary_exprt(lhs, id, rhs) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use binary_exprt(lhs, id, rhs) instead"))
   binary_exprt() : expr_protectedt(irep_idt(), typet())
   {
     operands().resize(2);
   }
 
-  DEPRECATED("use binary_exprt(lhs, id, rhs) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use binary_exprt(lhs, id, rhs) instead"))
   explicit binary_exprt(const irep_idt &_id) : expr_protectedt(_id, typet())
   {
     operands().resize(2);
   }
 
-  DEPRECATED("use binary_exprt(lhs, id, rhs, type) instead")
+  DEPRECATED(SINCE(2018, 12, 2, "use binary_exprt(lhs, id, rhs, type) instead"))
   binary_exprt(const irep_idt &_id, const typet &_type)
     : expr_protectedt(_id, _type)
   {
@@ -793,12 +799,14 @@ inline binary_exprt &to_binary_expr(exprt &expr)
 class binary_predicate_exprt:public binary_exprt
 {
 public:
-  DEPRECATED("use binary_predicate_exprt(lhs, id, rhs) instead")
+  DEPRECATED(
+    SINCE(2018, 12, 2, "use binary_predicate_exprt(lhs, id, rhs) instead"))
   binary_predicate_exprt():binary_exprt(irep_idt(), bool_typet())
   {
   }
 
-  DEPRECATED("use binary_predicate_exprt(lhs, id, rhs) instead")
+  DEPRECATED(
+    SINCE(2018, 12, 2, "use binary_predicate_exprt(lhs, id, rhs) instead"))
   explicit binary_predicate_exprt(const irep_idt &_id):
     binary_exprt(_id, bool_typet())
   {
@@ -834,12 +842,14 @@ public:
 class binary_relation_exprt:public binary_predicate_exprt
 {
 public:
-  DEPRECATED("use binary_relation_exprt(lhs, id, rhs) instead")
+  DEPRECATED(
+    SINCE(2018, 12, 2, "use binary_relation_exprt(lhs, id, rhs) instead"))
   binary_relation_exprt()
   {
   }
 
-  DEPRECATED("use binary_relation_exprt(lhs, id, rhs) instead")
+  DEPRECATED(
+    SINCE(2018, 12, 2, "use binary_relation_exprt(lhs, id, rhs) instead"))
   explicit binary_relation_exprt(const irep_idt &id):
     binary_predicate_exprt(id)
   {
@@ -928,17 +938,17 @@ inline binary_relation_exprt &to_binary_relation_expr(exprt &expr)
 class multi_ary_exprt : public expr_protectedt
 {
 public:
-  DEPRECATED("use multi_ary_exprt(id, op, type) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use multi_ary_exprt(id, op, type) instead"))
   multi_ary_exprt() : expr_protectedt(irep_idt(), typet())
   {
   }
 
-  DEPRECATED("use multi_ary_exprt(id, op, type) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use multi_ary_exprt(id, op, type) instead"))
   explicit multi_ary_exprt(const irep_idt &_id) : expr_protectedt(_id, typet())
   {
   }
 
-  DEPRECATED("use multi_ary_exprt(id, op, type) instead")
+  DEPRECATED(SINCE(2018, 12, 7, "use multi_ary_exprt(id, op, type) instead"))
   multi_ary_exprt(const irep_idt &_id, const typet &_type)
     : expr_protectedt(_id, _type)
   {
@@ -1034,12 +1044,12 @@ inline multi_ary_exprt &to_multi_ary_expr(exprt &expr)
 class plus_exprt:public multi_ary_exprt
 {
 public:
-  DEPRECATED("use plus_exprt(lhs, rhs) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use plus_exprt(lhs, rhs) instead"))
   plus_exprt():multi_ary_exprt(ID_plus)
   {
   }
 
-  DEPRECATED("use plus_exprt(lhs, rhs, type) instead")
+  DEPRECATED(SINCE(2019, 1, 12, "use plus_exprt(lhs, rhs, type) instead"))
   plus_exprt(const typet &type) : multi_ary_exprt(ID_plus, type)
   {
   }
@@ -1103,7 +1113,7 @@ inline plus_exprt &to_plus_expr(exprt &expr)
 class minus_exprt:public binary_exprt
 {
 public:
-  DEPRECATED("use minus_exprt(lhs, rhs) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use minus_exprt(lhs, rhs) instead"))
   minus_exprt():binary_exprt(ID_minus)
   {
   }
@@ -1154,7 +1164,7 @@ inline minus_exprt &to_minus_expr(exprt &expr)
 class mult_exprt:public multi_ary_exprt
 {
 public:
-  DEPRECATED("use mult_exprt(lhs, rhs) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use mult_exprt(lhs, rhs) instead"))
   mult_exprt():multi_ary_exprt(ID_mult)
   {
   }
@@ -1204,7 +1214,7 @@ inline mult_exprt &to_mult_expr(exprt &expr)
 class div_exprt:public binary_exprt
 {
 public:
-  DEPRECATED("use div_exprt(lhs, rhs) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use div_exprt(lhs, rhs) instead"))
   div_exprt():binary_exprt(ID_div)
   {
   }
@@ -1278,7 +1288,7 @@ inline div_exprt &to_div_expr(exprt &expr)
 class mod_exprt:public binary_exprt
 {
 public:
-  DEPRECATED("use mod_exprt(lhs, rhs) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use mod_exprt(lhs, rhs) instead"))
   mod_exprt():binary_exprt(ID_mod)
   {
   }
@@ -1328,7 +1338,7 @@ inline mod_exprt &to_mod_expr(exprt &expr)
 class rem_exprt:public binary_exprt
 {
 public:
-  DEPRECATED("use rem_exprt(lhs, rhs) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use rem_exprt(lhs, rhs) instead"))
   rem_exprt():binary_exprt(ID_rem)
   {
   }
@@ -1378,7 +1388,7 @@ inline rem_exprt &to_rem_expr(exprt &expr)
 class equal_exprt:public binary_relation_exprt
 {
 public:
-  DEPRECATED("use equal_exprt(lhs, rhs) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use equal_exprt(lhs, rhs) instead"))
   equal_exprt():binary_relation_exprt(ID_equal)
   {
   }
@@ -1441,7 +1451,7 @@ inline equal_exprt &to_equal_expr(exprt &expr)
 class notequal_exprt:public binary_relation_exprt
 {
 public:
-  DEPRECATED("use notequal_exprt(lhs, rhs) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use notequal_exprt(lhs, rhs) instead"))
   notequal_exprt():binary_relation_exprt(ID_notequal)
   {
   }
@@ -1491,12 +1501,12 @@ inline notequal_exprt &to_notequal_expr(exprt &expr)
 class index_exprt:public binary_exprt
 {
 public:
-  DEPRECATED("use index_exprt(array, index) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use index_exprt(array, index) instead"))
   index_exprt():binary_exprt(ID_index)
   {
   }
 
-  DEPRECATED("use index_exprt(array, index) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use index_exprt(array, index) instead"))
   explicit index_exprt(const typet &_type):binary_exprt(ID_index, _type)
   {
   }
@@ -1575,7 +1585,7 @@ inline index_exprt &to_index_expr(exprt &expr)
 class array_of_exprt:public unary_exprt
 {
 public:
-  DEPRECATED("use array_of_exprt(what, type) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use array_of_exprt(what, type) instead"))
   array_of_exprt():unary_exprt(ID_array_of)
   {
   }
@@ -1635,7 +1645,7 @@ inline array_of_exprt &to_array_of_expr(exprt &expr)
 class array_exprt : public multi_ary_exprt
 {
 public:
-  DEPRECATED("use array_exprt(operands, type) instead")
+  DEPRECATED(SINCE(2019, 1, 12, "use array_exprt(operands, type) instead"))
   explicit array_exprt(const array_typet &_type)
     : multi_ary_exprt(ID_array, _type)
   {
@@ -1687,7 +1697,7 @@ inline array_exprt &to_array_expr(exprt &expr)
 class array_list_exprt : public multi_ary_exprt
 {
 public:
-  DEPRECATED("use array_list_exprt(operands, type) instead")
+  DEPRECATED(SINCE(2019, 1, 12, "use array_list_exprt(operands, type) instead"))
   explicit array_list_exprt(const array_typet &_type)
     : multi_ary_exprt(ID_array_list, _type)
   {
@@ -1746,12 +1756,12 @@ inline array_list_exprt &to_array_list_expr(exprt &expr)
 class vector_exprt : public multi_ary_exprt
 {
 public:
-  DEPRECATED("use vector_exprt(type) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use vector_exprt(type) instead"))
   vector_exprt() : multi_ary_exprt(ID_vector)
   {
   }
 
-  DEPRECATED("use vector_exprt(operands, type) instead")
+  DEPRECATED(SINCE(2019, 1, 12, "use vector_exprt(operands, type) instead"))
   explicit vector_exprt(const vector_typet &_type)
     : multi_ary_exprt(ID_vector, _type)
   {
@@ -1793,12 +1803,14 @@ inline vector_exprt &to_vector_expr(exprt &expr)
 class union_exprt:public unary_exprt
 {
 public:
-  DEPRECATED("use union_exprt(component_name, value, type) instead")
+  DEPRECATED(
+    SINCE(2018, 9, 21, "use union_exprt(component_name, value, type) instead"))
   union_exprt():unary_exprt(ID_union)
   {
   }
 
-  DEPRECATED("use union_exprt(component_name, value, type) instead")
+  DEPRECATED(
+    SINCE(2018, 9, 21, "use union_exprt(component_name, value, type) instead"))
   explicit union_exprt(const typet &_type):
     unary_exprt(ID_union, _type)
   {
@@ -1870,12 +1882,14 @@ inline union_exprt &to_union_expr(exprt &expr)
 class struct_exprt : public multi_ary_exprt
 {
 public:
-  DEPRECATED("use struct_exprt(component_name, value, type) instead")
+  DEPRECATED(
+    SINCE(2018, 9, 21, "use struct_exprt(component_name, value, type) instead"))
   struct_exprt() : multi_ary_exprt(ID_struct)
   {
   }
 
-  DEPRECATED("use struct_exprt(component_name, value, type) instead")
+  DEPRECATED(
+    SINCE(2019, 1, 12, "use struct_exprt(component_name, value, type) instead"))
   explicit struct_exprt(const typet &_type) : multi_ary_exprt(ID_struct, _type)
   {
   }
@@ -1919,12 +1933,12 @@ inline struct_exprt &to_struct_expr(exprt &expr)
 class complex_exprt:public binary_exprt
 {
 public:
-  DEPRECATED("use complex_exprt(r, i, type) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use complex_exprt(r, i, type) instead"))
   complex_exprt():binary_exprt(ID_complex)
   {
   }
 
-  DEPRECATED("use complex_exprt(r, i, type) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use complex_exprt(r, i, type) instead"))
   explicit complex_exprt(const complex_typet &_type):
     binary_exprt(ID_complex, _type)
   {
@@ -2178,7 +2192,7 @@ inline object_descriptor_exprt &to_object_descriptor_expr(exprt &expr)
 class dynamic_object_exprt:public binary_exprt
 {
 public:
-  DEPRECATED("use dynamic_object_exprt(type) instead")
+  DEPRECATED(SINCE(2019, 2, 11, "use dynamic_object_exprt(type) instead"))
   dynamic_object_exprt()
     : binary_exprt(exprt(ID_unknown), ID_dynamic_object, exprt(ID_unknown))
   {
@@ -2249,7 +2263,7 @@ inline dynamic_object_exprt &to_dynamic_object_expr(exprt &expr)
 class typecast_exprt:public unary_exprt
 {
 public:
-  DEPRECATED("use typecast_exprt(op, type) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use typecast_exprt(op, type) instead"))
   explicit typecast_exprt(const typet &_type):unary_exprt(ID_typecast, _type)
   {
   }
@@ -2308,7 +2322,8 @@ inline typecast_exprt &to_typecast_expr(exprt &expr)
 class floatbv_typecast_exprt:public binary_exprt
 {
 public:
-  DEPRECATED("use floatbv_typecast_exprt(op, r, type) instead")
+  DEPRECATED(
+    SINCE(2018, 9, 21, "use floatbv_typecast_exprt(op, r, type) instead"))
   floatbv_typecast_exprt():binary_exprt(ID_floatbv_typecast)
   {
   }
@@ -2383,7 +2398,7 @@ inline floatbv_typecast_exprt &to_floatbv_typecast_expr(exprt &expr)
 class and_exprt:public multi_ary_exprt
 {
 public:
-  DEPRECATED("use and_exprt(op, op) instead")
+  DEPRECATED(SINCE(2019, 1, 12, "use and_exprt(op, op) instead"))
   and_exprt():multi_ary_exprt(ID_and, bool_typet())
   {
   }
@@ -2451,7 +2466,7 @@ inline and_exprt &to_and_expr(exprt &expr)
 class implies_exprt:public binary_exprt
 {
 public:
-  DEPRECATED("use implies_exprt(a, b) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use implies_exprt(a, b) instead"))
   implies_exprt():binary_exprt(ID_implies, bool_typet())
   {
   }
@@ -2501,7 +2516,7 @@ inline implies_exprt &to_implies_expr(exprt &expr)
 class or_exprt:public multi_ary_exprt
 {
 public:
-  DEPRECATED("use or_exprt(op, op) instead")
+  DEPRECATED(SINCE(2019, 1, 12, "use or_exprt(op, op) instead"))
   or_exprt():multi_ary_exprt(ID_or, bool_typet())
   {
   }
@@ -2569,7 +2584,7 @@ inline or_exprt &to_or_expr(exprt &expr)
 class xor_exprt:public multi_ary_exprt
 {
 public:
-  DEPRECATED("use xor_exprt(op, op) instead")
+  DEPRECATED(SINCE(2019, 1, 12, "use xor_exprt(op, op) instead"))
   xor_exprt():multi_ary_exprt(ID_bitxor, bool_typet())
   {
   }
@@ -2610,7 +2625,7 @@ inline xor_exprt &to_xor_expr(exprt &expr)
 class bitnot_exprt:public unary_exprt
 {
 public:
-  DEPRECATED("use bitnot_exprt(op) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use bitnot_exprt(op) instead"))
   bitnot_exprt():unary_exprt(ID_bitnot)
   {
   }
@@ -2659,7 +2674,7 @@ inline bitnot_exprt &to_bitnot_expr(exprt &expr)
 class bitor_exprt:public multi_ary_exprt
 {
 public:
-  DEPRECATED("use bitor_exprt(op0, op1) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use bitor_exprt(op0, op1) instead"))
   bitor_exprt():multi_ary_exprt(ID_bitor)
   {
   }
@@ -2700,7 +2715,7 @@ inline bitor_exprt &to_bitor_expr(exprt &expr)
 class bitxor_exprt:public multi_ary_exprt
 {
 public:
-  DEPRECATED("use bitxor_exprt(op0, op1) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use bitxor_exprt(op0, op1) instead"))
   bitxor_exprt():multi_ary_exprt(ID_bitxor)
   {
   }
@@ -2741,7 +2756,7 @@ inline bitxor_exprt &to_bitxor_expr(exprt &expr)
 class bitand_exprt:public multi_ary_exprt
 {
 public:
-  DEPRECATED("use bitand_exprt(op0, op1) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use bitand_exprt(op0, op1) instead"))
   bitand_exprt():multi_ary_exprt(ID_bitand)
   {
   }
@@ -2782,12 +2797,12 @@ inline bitand_exprt &to_bitand_expr(exprt &expr)
 class shift_exprt:public binary_exprt
 {
 public:
-  DEPRECATED("use shift_exprt(value, id, distance) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use shift_exprt(value, id, distance) instead"))
   explicit shift_exprt(const irep_idt &_id):binary_exprt(_id)
   {
   }
 
-  DEPRECATED("use shift_exprt(value, id, distance) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use shift_exprt(value, id, distance) instead"))
   shift_exprt(const irep_idt &_id, const typet &_type):
     binary_exprt(_id, _type)
   {
@@ -2858,7 +2873,7 @@ inline shift_exprt &to_shift_expr(exprt &expr)
 class shl_exprt:public shift_exprt
 {
 public:
-  DEPRECATED("use shl_exprt(value, distance) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use shl_exprt(value, distance) instead"))
   shl_exprt():shift_exprt(ID_shl)
   {
   }
@@ -2901,7 +2916,7 @@ inline shl_exprt &to_shl_expr(exprt &expr)
 class ashr_exprt:public shift_exprt
 {
 public:
-  DEPRECATED("use ashl_exprt(value, distance) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use ashl_exprt(value, distance) instead"))
   ashr_exprt():shift_exprt(ID_ashr)
   {
   }
@@ -2921,7 +2936,7 @@ public:
 class lshr_exprt:public shift_exprt
 {
 public:
-  DEPRECATED("use lshl_exprt(value, distance) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use lshl_exprt(value, distance) instead"))
   lshr_exprt():shift_exprt(ID_lshr)
   {
   }
@@ -2941,7 +2956,7 @@ public:
 class extractbit_exprt:public binary_predicate_exprt
 {
 public:
-  DEPRECATED("use extractbit_exprt(value, index) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use extractbit_exprt(value, index) instead"))
   extractbit_exprt():binary_predicate_exprt(ID_extractbit)
   {
   }
@@ -3014,7 +3029,8 @@ inline extractbit_exprt &to_extractbit_expr(exprt &expr)
 class extractbits_exprt : public expr_protectedt
 {
 public:
-  DEPRECATED("use extractbits_exprt(value, upper, lower) instead")
+  DEPRECATED(
+    SINCE(2018, 9, 21, "use extractbits_exprt(value, upper, lower) instead"))
   extractbits_exprt() : expr_protectedt(ID_extractbits, typet())
   {
     operands().resize(3);
@@ -3171,7 +3187,7 @@ public:
     PRECONDITION(as_const(*this).op().type().id() == ID_bool);
   }
 
-  DEPRECATED("use not_exprt(op) instead")
+  DEPRECATED(SINCE(2019, 1, 12, "use not_exprt(op) instead"))
   not_exprt():unary_exprt(ID_not, bool_typet())
   {
   }
@@ -3216,12 +3232,12 @@ inline not_exprt &to_not_expr(exprt &expr)
 class dereference_exprt:public unary_exprt
 {
 public:
-  DEPRECATED("use dereference_exprt(pointer) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use dereference_exprt(pointer) instead"))
   dereference_exprt():unary_exprt(ID_dereference)
   {
   }
 
-  DEPRECATED("use dereference_exprt(pointer) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use dereference_exprt(pointer) instead"))
   explicit dereference_exprt(const typet &type):
     unary_exprt(ID_dereference, type)
   {
@@ -3318,7 +3334,7 @@ public:
   {
   }
 
-  DEPRECATED("use if_exprt(cond, t, f) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use if_exprt(cond, t, f) instead"))
   if_exprt() : ternary_exprt(ID_if)
   {
   }
@@ -3402,7 +3418,8 @@ public:
   {
   }
 
-  DEPRECATED("use with_exprt(old, where, new_value) instead")
+  DEPRECATED(
+    SINCE(2018, 9, 21, "use with_exprt(old, where, new_value) instead"))
   with_exprt() : expr_protectedt(ID_with, typet())
   {
     operands().resize(3);
@@ -3594,12 +3611,14 @@ public:
   {
   }
 
-  DEPRECATED("use update_exprt(old, where, new_value) instead")
+  DEPRECATED(
+    SINCE(2018, 9, 21, "use update_exprt(old, where, new_value) instead"))
   explicit update_exprt(const typet &_type) : ternary_exprt(ID_update, _type)
   {
   }
 
-  DEPRECATED("use update_exprt(old, where, new_value) instead")
+  DEPRECATED(
+    SINCE(2018, 9, 21, "use update_exprt(old, where, new_value) instead"))
   update_exprt() : ternary_exprt(ID_update)
   {
     op1().id(ID_designator);
@@ -3778,7 +3797,7 @@ public:
     set_component_name(c.get_name());
   }
 
-  DEPRECATED("use member_exprt(op, c) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use member_exprt(op, c) instead"))
   member_exprt():unary_exprt(ID_member)
   {
   }
@@ -3880,7 +3899,7 @@ public:
   {
   }
 
-  DEPRECATED("use isnan_exprt(op) instead")
+  DEPRECATED(SINCE(2018, 12, 2, "use isnan_exprt(op) instead"))
   isnan_exprt():unary_predicate_exprt(ID_isnan)
   {
   }
@@ -3930,7 +3949,7 @@ public:
   {
   }
 
-  DEPRECATED("use isinf_exprt(op) instead")
+  DEPRECATED(SINCE(2018, 12, 2, "use isinf_exprt(op) instead"))
   isinf_exprt():unary_predicate_exprt(ID_isinf)
   {
   }
@@ -3980,7 +3999,7 @@ public:
   {
   }
 
-  DEPRECATED("use isfinite_exprt(op) instead")
+  DEPRECATED(SINCE(2018, 12, 2, "use isfinite_exprt(op) instead"))
   isfinite_exprt():unary_predicate_exprt(ID_isfinite)
   {
   }
@@ -4030,7 +4049,7 @@ public:
   {
   }
 
-  DEPRECATED("use isnormal_exprt(op) instead")
+  DEPRECATED(SINCE(2018, 12, 2, "use isnormal_exprt(op) instead"))
   isnormal_exprt():unary_predicate_exprt(ID_isnormal)
   {
   }
@@ -4075,7 +4094,7 @@ inline isnormal_exprt &to_isnormal_expr(exprt &expr)
 class ieee_float_equal_exprt:public binary_relation_exprt
 {
 public:
-  DEPRECATED("use ieee_float_equal_exprt(lhs, rhs) instead")
+  DEPRECATED(SINCE(2018, 12, 2, "use ieee_float_equal_exprt(lhs, rhs) instead"))
   ieee_float_equal_exprt():binary_relation_exprt(ID_ieee_float_equal)
   {
   }
@@ -4129,7 +4148,8 @@ inline ieee_float_equal_exprt &to_ieee_float_equal_expr(exprt &expr)
 class ieee_float_notequal_exprt:public binary_relation_exprt
 {
 public:
-  DEPRECATED("use ieee_float_notequal_exprt(lhs, rhs) instead")
+  DEPRECATED(
+    SINCE(2018, 12, 2, "use ieee_float_notequal_exprt(lhs, rhs) instead"))
   ieee_float_notequal_exprt():
     binary_relation_exprt(ID_ieee_float_notequal)
   {
@@ -4267,7 +4287,7 @@ inline ieee_float_op_exprt &to_ieee_float_op_expr(exprt &expr)
 class type_exprt : public nullary_exprt
 {
 public:
-  DEPRECATED("use type_exprt(type) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use type_exprt(type) instead"))
   type_exprt() : nullary_exprt(ID_type)
   {
   }
@@ -4281,12 +4301,12 @@ public:
 class constant_exprt : public expr_protectedt
 {
 public:
-  DEPRECATED("use constant_exprt(value, type) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use constant_exprt(value, type) instead"))
   constant_exprt() : expr_protectedt(ID_constant, typet())
   {
   }
 
-  DEPRECATED("use constant_exprt(value, type) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use constant_exprt(value, type) instead"))
   explicit constant_exprt(const typet &type)
     : expr_protectedt(ID_constant, type)
   {
@@ -4379,12 +4399,12 @@ public:
 class replication_exprt : public binary_exprt
 {
 public:
-  DEPRECATED("use replication_exprt(times, value) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use replication_exprt(times, value) instead"))
   replication_exprt() : binary_exprt(ID_replication)
   {
   }
 
-  DEPRECATED("use replication_exprt(times, value) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use replication_exprt(times, value) instead"))
   explicit replication_exprt(const typet &_type)
     : binary_exprt(ID_replication, _type)
   {
@@ -4458,12 +4478,12 @@ inline replication_exprt &to_replication_expr(exprt &expr)
 class concatenation_exprt : public multi_ary_exprt
 {
 public:
-  DEPRECATED("use concatenation_exprt(op, type) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use concatenation_exprt(op, type) instead"))
   concatenation_exprt() : multi_ary_exprt(ID_concatenation)
   {
   }
 
-  DEPRECATED("use concatenation_exprt(op, type) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use concatenation_exprt(op, type) instead"))
   explicit concatenation_exprt(const typet &_type)
     : multi_ary_exprt(ID_concatenation, _type)
   {
@@ -4602,7 +4622,7 @@ inline let_exprt &to_let_expr(exprt &expr)
 class popcount_exprt: public unary_exprt
 {
 public:
-  DEPRECATED("use popcount_exprt(op, type) instead")
+  DEPRECATED(SINCE(2018, 9, 21, "use popcount_exprt(op, type) instead"))
   popcount_exprt(): unary_exprt(ID_popcount)
   {
   }
@@ -4658,7 +4678,7 @@ inline popcount_exprt &to_popcount_expr(exprt &expr)
 class cond_exprt : public multi_ary_exprt
 {
 public:
-  DEPRECATED("use cond_exprt(operands, type) instead")
+  DEPRECATED(SINCE(2019, 1, 12, "use cond_exprt(operands, type) instead"))
   explicit cond_exprt(const typet &_type) : multi_ary_exprt(ID_cond, _type)
   {
   }

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -37,7 +37,8 @@ public:
 /// The NIL type, i.e., an invalid type, no value.
 /// \deprecated Use `optional<typet>` instead.
 // NOLINTNEXTLINE
-class DEPRECATED("Use `optional<typet>` instead.") nil_typet : public typet
+class DEPRECATED(SINCE(2018, 8, 22, "Use `optional<typet>` instead.")) nil_typet
+  : public typet
 {
 public:
   nil_typet():typet(static_cast<const typet &>(get_nil_irep()))
@@ -749,7 +750,7 @@ public:
   }
 
   /// \deprecated
-  DEPRECATED("Use the two argument constructor instead")
+  DEPRECATED(SINCE(2018, 6, 4, "Use the two argument constructor instead"))
   code_typet():typet(ID_code)
   {
     // make sure these properties are always there to avoid problems
@@ -763,7 +764,7 @@ public:
   class parametert:public exprt
   {
   public:
-    DEPRECATED("use parametert(type) instead")
+    DEPRECATED(SINCE(2018, 9, 21, "use parametert(type) instead"))
     parametert():exprt(ID_parameter)
     {
     }
@@ -1781,7 +1782,7 @@ inline vector_typet &to_vector_type(typet &type)
 class complex_typet:public type_with_subtypet
 {
 public:
-  DEPRECATED("use complex_typet(type) instead")
+  DEPRECATED(SINCE(2018, 12, 2, "use complex_typet(type) instead"))
   complex_typet():type_with_subtypet(ID_complex)
   {
   }

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -114,7 +114,11 @@ inline const array_string_exprt &to_array_string_expr(const exprt &expr)
 class refined_string_exprt : public struct_exprt
 {
 public:
-  DEPRECATED("use refined_string_exprt(length, content, type) instead")
+  DEPRECATED(SINCE(
+    2019,
+    1,
+    12,
+    "use refined_string_exprt(length, content, type) instead"))
   refined_string_exprt() : struct_exprt()
   {
   }

--- a/src/util/type.h
+++ b/src/util/type.h
@@ -138,7 +138,7 @@ public:
 class type_with_subtypet:public typet
 {
 public:
-  DEPRECATED("use type_with_subtypet(id, subtype) instead")
+  DEPRECATED(SINCE(2018, 12, 2, "use type_with_subtypet(id, subtype) instead"))
   explicit type_with_subtypet(const irep_idt &_id):typet(_id) { }
 
   type_with_subtypet(irep_idt _id, typet _subtype)
@@ -173,10 +173,12 @@ class type_with_subtypest:public typet
 public:
   typedef std::vector<typet> subtypest;
 
-  DEPRECATED("use type_with_subtypest(id, subtypes) instead")
+  DEPRECATED(
+    SINCE(2018, 12, 2, "use type_with_subtypest(id, subtypes) instead"))
   type_with_subtypest() { }
 
-  DEPRECATED("use type_with_subtypest(id, subtypes) instead")
+  DEPRECATED(
+    SINCE(2018, 12, 2, "use type_with_subtypest(id, subtypes) instead"))
   explicit type_with_subtypest(const irep_idt &_id):typet(_id) { }
 
   type_with_subtypest(const irep_idt &_id, const subtypest &_subtypes)


### PR DESCRIPTION
This makes the date of deprecation visible in warning messages and also
makes tracking much easier: git grep DEPRECATED or any code review will
yield immediate insight on how long an entity has been deprecated
already.

The date is taken from the commit that first marked the entity as
deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
