### PR TITLE
Move dirtyt from goto_symex_state to path_storaget

### DIFF
--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -39,7 +39,6 @@ goto_symex_statet::goto_symex_statet(
     guard_manager(manager),
     symex_target(nullptr),
     record_events(true),
-    dirty(),
     fresh_l2_name_provider(fresh_l2_name_provider)
 {
   threads.emplace_back(guard_manager);
@@ -352,10 +351,11 @@ bool goto_symex_statet::l2_thread_read_encoding(
     return false;
 
   // is it a shared object?
+  PRECONDITION(dirty != nullptr);
   const irep_idt &obj_identifier=expr.get_object_name();
   if(
     obj_identifier == guard_identifier() ||
-    (!ns.lookup(obj_identifier).is_shared() && !(dirty)(obj_identifier)))
+    (!ns.lookup(obj_identifier).is_shared() && !(*dirty)(obj_identifier)))
   {
     return false;
   }
@@ -476,10 +476,11 @@ goto_symex_statet::write_is_shared_resultt goto_symex_statet::write_is_shared(
   if(!record_events)
     return write_is_shared_resultt::NOT_SHARED;
 
+  PRECONDITION(dirty != nullptr);
   const irep_idt &obj_identifier = expr.get_object_name();
   if(
     obj_identifier == guard_identifier() ||
-    (!ns.lookup(obj_identifier).is_shared() && !(dirty)(obj_identifier)))
+    (!ns.lookup(obj_identifier).is_shared() && !(*dirty)(obj_identifier)))
   {
     return write_is_shared_resultt::NOT_SHARED;
   }

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -16,7 +16,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <memory>
 #include <unordered_set>
 
-#include <analyses/dirty.h>
 #include <analyses/guard.h>
 
 #include <util/invariant.h>
@@ -30,6 +29,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "goto_state.h"
 #include "renaming_level.h"
 #include "symex_target_equation.h"
+
+class incremental_dirtyt;
 
 /// \brief Central data structure: state.
 ///
@@ -195,9 +196,7 @@ public:
 
   bool record_events;
 
-  // Local variables are considered 'dirty' if they've had an address taken and
-  // therefore may be referred to by a pointer.
-  incremental_dirtyt dirty;
+  const incremental_dirtyt *dirty = nullptr;
 
   goto_programt::const_targett saved_target;
 

--- a/src/goto-symex/path_storage.h
+++ b/src/goto-symex/path_storage.h
@@ -10,6 +10,7 @@
 #include <util/message.h>
 #include <util/options.h>
 
+#include <analyses/dirty.h>
 #include <analyses/local_safe_pointers.h>
 
 #include <memory>
@@ -109,6 +110,10 @@ public:
   {
     return get_unique_index(l2_indices, id, 1);
   }
+
+  /// Local variables are considered 'dirty' if they've had an address taken and
+  /// therefore may be referred to by a pointer.
+  incremental_dirtyt dirty;
 
 private:
   // Derived classes should override these methods, allowing the base class to

--- a/src/goto-symex/symex_decl.cpp
+++ b/src/goto-symex/symex_decl.cpp
@@ -17,8 +17,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <pointer-analysis/add_failed_symbols.h>
 
-#include <analyses/dirty.h>
-
 void goto_symext::symex_decl(statet &state)
 {
   const goto_programt::instructiont &instruction=*state.source.pc;
@@ -92,7 +90,7 @@ void goto_symext::symex_decl(statet &state, const symbol_exprt &expr)
       symex_targett::assignment_typet::HIDDEN:
       symex_targett::assignment_typet::STATE);
 
-  if(state.dirty(ssa.get_object_name()) && state.atomic_section_id == 0)
+  if(path_storage.dirty(ssa.get_object_name()) && state.atomic_section_id == 0)
     target.shared_write(
       state.guard.as_expr(),
       ssa,

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -238,7 +238,7 @@ void goto_symext::symex_function_call_code(
   const goto_functionst::goto_functiont &goto_function =
     get_goto_function(identifier);
 
-  state.dirty.populate_dirty_for_function(identifier, goto_function);
+  path_storage.dirty.populate_dirty_for_function(identifier, goto_function);
 
   auto emplace_safe_pointers_result =
     path_storage.safe_pointers.emplace(identifier, local_safe_pointerst{});
@@ -336,7 +336,8 @@ void goto_symext::symex_function_call_code(
 }
 
 /// pop one call frame
-static void pop_frame(goto_symext::statet &state)
+static void
+pop_frame(goto_symext::statet &state, const path_storaget &path_storage)
 {
   PRECONDITION(!state.call_stack().empty());
 
@@ -359,7 +360,7 @@ static void pop_frame(goto_symext::statet &state)
       if(
         frame.local_objects.find(l1_o_id) == frame.local_objects.end() ||
         (state.threads.size() > 1 &&
-         state.dirty(c_it->second.first.get_object_name())))
+         path_storage.dirty(c_it->second.first.get_object_name())))
       {
         ++c_it;
         continue;
@@ -383,7 +384,7 @@ void goto_symext::symex_end_of_function(statet &state)
     state.guard.as_expr(), state.source.function_id, state.source, hidden);
 
   // then get rid of the frame
-  pop_frame(state);
+  pop_frame(state, path_storage);
 }
 
 /// Preserves locality of parameters of a given function by applying L1

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -19,7 +19,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/pointer_offset_size.h>
 #include <util/std_expr.h>
 
-#include <analyses/dirty.h>
 #include <util/simplify_expr.h>
 
 /// Propagate constants and points-to information implied by a GOTO condition.
@@ -438,6 +437,7 @@ static void for_each2(
 /// \param do_simplify: should the right-hand-side of the assignment that is
 ///   added to the target be simplified
 /// \param [out] target: equation that will receive the resulting assignment
+/// \param dirty: dirty-object analysis
 /// \param ssa: SSA expression to merge
 /// \param goto_count: current level 2 count in \p goto_state of
 ///   \p l1_identifier
@@ -450,6 +450,7 @@ static void merge_names(
   messaget &log,
   const bool do_simplify,
   symex_target_equationt &target,
+  const incremental_dirtyt &dirty,
   const ssa_exprt &ssa,
   const unsigned goto_count,
   const unsigned dest_count)
@@ -479,8 +480,10 @@ static void merge_names(
   // shared?
   if(
     dest_state.atomic_section_id == 0 && dest_state.threads.size() >= 2 &&
-    (symbol.is_shared() || (dest_state.dirty)(symbol.name)))
+    (symbol.is_shared() || dirty(symbol.name)))
+  {
     return; // no phi nodes for shared stuff
+  }
 
   // don't merge (thread-)locals across different threads, which
   // may have been introduced by symex_start_thread (and will
@@ -581,6 +584,7 @@ void goto_symext::phi_function(
         log,
         symex_config.simplify_opt,
         target,
+        path_storage.dirty,
         ssa,
         goto_count,
         dest_count);

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -23,8 +23,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/string2int.h>
 #include <util/symbol_table.h>
 
-#include <analyses/dirty.h>
-
 symex_configt::symex_configt(const optionst &options)
   : max_depth(options.get_unsigned_int_option("depth")),
     doing_path_exploration(options.is_set("paths")),
@@ -357,7 +355,9 @@ std::unique_ptr<goto_symext::statet> goto_symext::initialize_entry_point_state(
   if(emplace_safe_pointers_result.second)
     emplace_safe_pointers_result.first->second(start_function->body);
 
-  state->dirty.populate_dirty_for_function(entry_point_id, *start_function);
+  path_storage.dirty.populate_dirty_for_function(
+    entry_point_id, *start_function);
+  state->dirty = &path_storage.dirty;
 
   // make the first step onto the instruction pointed to by the initial program
   // counter


### PR DESCRIPTION
This is a per-symex object, unrelated to the symbolic program state.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
