### PR TITLE
Inline make_member and fix up is_simplified passing

### DIFF
--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1150,6 +1150,9 @@ void value_sett::assign(
       if(rhs.id()==ID_unknown ||
          rhs.id()==ID_invalid)
       {
+        // this branch is deemed dead as otherwise we'd be missing assignments
+        // that never happened in this branch
+        UNREACHABLE;
         rhs_member=exprt(rhs.id(), subtype);
       }
       else
@@ -1159,9 +1162,13 @@ void value_sett::assign(
                 "rhs.type():\n"+rhs.type().pretty()+"\n"+
                 "lhs.type():\n"+lhs.type().pretty();
 
-        rhs_member=make_member(rhs, name, ns);
+        const struct_union_typet &rhs_struct_union_type =
+          to_struct_union_type(ns.follow(rhs.type()));
 
-        assign(lhs_member, rhs_member, ns, false, add_to_sets);
+        const typet &rhs_subtype = rhs_struct_union_type.component_type(name);
+        rhs_member = simplify_expr(member_exprt{rhs, name, rhs_subtype}, ns);
+
+        assign(lhs_member, rhs_member, ns, true, add_to_sets);
       }
     }
   }
@@ -1582,20 +1589,4 @@ void value_sett::guard(
 
     assign(expr.op0(), address_of, ns, false, false);
   }
-}
-
-exprt value_sett::make_member(
-  const exprt &src,
-  const irep_idt &component_name,
-  const namespacet &ns)
-{
-  const struct_union_typet &struct_union_type=
-    to_struct_union_type(ns.follow(src.type()));
-
-  const typet &subtype = struct_union_type.component_type(component_name);
-  exprt member_expr = member_exprt(src, component_name, subtype);
-
-  simplify(member_expr, ns);
-
-  return member_expr;
 }

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1157,10 +1157,11 @@ void value_sett::assign(
       }
       else
       {
-        if(rhs.type() != lhs.type())
-          throw "value_sett::assign type mismatch: "
-                "rhs.type():\n"+rhs.type().pretty()+"\n"+
-                "lhs.type():\n"+lhs.type().pretty();
+        DATA_INVARIANT(
+          rhs.type() == lhs.type(),
+          "value_sett::assign types should match, got: "
+          "rhs.type():\n" +
+            rhs.type().pretty() + "\n" + "lhs.type():\n" + lhs.type().pretty());
 
         const struct_union_typet &rhs_struct_union_type =
           to_struct_union_type(ns.follow(rhs.type()));
@@ -1189,10 +1190,11 @@ void value_sett::assign(
     }
     else
     {
-      if(rhs.type() != type)
-        throw "value_sett::assign type mismatch: "
-          "rhs.type():\n"+rhs.type().pretty()+"\n"+
-          "type:\n"+type.pretty();
+      DATA_INVARIANT(
+        rhs.type() == type,
+        "value_sett::assign types should match, got: "
+        "rhs.type():\n" +
+          rhs.type().pretty() + "\n" + "type:\n" + type.pretty());
 
       if(rhs.id()==ID_array_of)
       {

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -494,17 +494,6 @@ protected:
     const exprt &src,
     exprt &dest) const;
 
-  /// Extracts a member from a struct- or union-typed expression.
-  /// Usually that means making a `member_exprt`, but this can shortcut
-  /// extracting members from constants or with-expressions.
-  /// \param src: base struct-or-union-typed expression
-  /// \param component_name: member to extract
-  /// \param ns: global namespace
-  exprt make_member(
-    const exprt &src,
-    const irep_idt &component_name,
-    const namespacet &ns);
-
   // Subclass customisation points:
 
 protected:


### PR DESCRIPTION
make_member always took care of simplifying, there was no need to pass "false"
afterwards. Make that more clear by inlining it.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
