### PR TITLE
[WIP] Treat symex guard symbols as constants

### DIFF
--- a/jbmc/regression/jbmc/throwing-function-return-value/test.desc
+++ b/jbmc/regression/jbmc/throwing-function-return-value/test.desc
@@ -2,7 +2,7 @@ CORE
 Test.class
 --function Test.main --show-vcc
 java::Test\.main:\(Z\)V::14::t1!0@1#\d+ = address_of\(symex_dynamic::dynamic_object\d+\)
-java::Test\.main:\(Z\)V::9::x!0@1#\d+ = 5 \+ java::Test\.main:\(Z\)V::9::x!0@1#\d+
+java::Test\.main:\(Z\)V::9::x!0@1#\d+ = 5 \+ \(goto_symex::\\guard#\d+ \? 0 : 5\)
 java::Test\.g:\(\)I#return_value!0#[0-9]+ = 5
 ^EXIT=0$
 ^SIGNAL=0$

--- a/src/goto-symex/goto_symex_is_constant.h
+++ b/src/goto-symex/goto_symex_is_constant.h
@@ -15,6 +15,8 @@ Author: Michael Tautschig, tautschn@amazon.com
 #include <util/expr.h>
 #include <util/expr_util.h>
 
+#include "goto_symex_state.h"
+
 class goto_symex_is_constantt : public is_constantt
 {
 protected:
@@ -44,6 +46,12 @@ protected:
       return true;
       */
       return false;
+    }
+    else if(expr.id() == ID_symbol)
+    {
+      // we only ever assign to a single guard once, we can treat it as constant
+      return to_ssa_expr(expr).get_object_name() ==
+             goto_symex_statet::guard_identifier();
     }
 
     return is_constantt::is_constant(expr);


### PR DESCRIPTION
We only ever assign a single value to them.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
