### PR TITLE
Remove two unnecessary fields from the Java object factory

### DIFF
--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -45,9 +45,6 @@ class java_object_factoryt
   /// The symbol table.
   symbol_table_baset &symbol_table;
 
-  /// A namespace built from exclusively one symbol table - the one above.
-  namespacet ns;
-
   /// Resolves pointer types potentially using some heuristics, for example
   /// to replace pointers to interface types with pointers to concrete
   /// implementations.
@@ -83,7 +80,6 @@ public:
     message_handlert &log)
     : object_factory_parameters(_object_factory_parameters),
       symbol_table(_symbol_table),
-      ns(_symbol_table),
       pointer_type_selector(pointer_type_selector),
       allocate_objects(
         ID_java,
@@ -228,6 +224,7 @@ void java_object_factoryt::gen_pointer_target_init(
   PRECONDITION(expr.type().id() == ID_pointer);
   PRECONDITION(update_in_place != update_in_placet::MAY_UPDATE_IN_PLACE);
 
+  const namespacet ns(symbol_table);
   const typet &followed_target_type = ns.follow(target_type);
 
   if(followed_target_type.id() == ID_struct)
@@ -490,6 +487,7 @@ void java_object_factoryt::gen_nondet_pointer_init(
   const source_locationt &location)
 {
   PRECONDITION(expr.type().id()==ID_pointer);
+  const namespacet ns(symbol_table);
   const pointer_typet &replacement_pointer_type =
     pointer_type_selector.convert_pointer_type(
       pointer_type, generic_parameter_specialization_map, ns);
@@ -800,6 +798,7 @@ void java_object_factoryt::gen_nondet_struct_init(
   const update_in_placet &update_in_place,
   const source_locationt &location)
 {
+  const namespacet ns(symbol_table);
   PRECONDITION(ns.follow(expr.type()).id()==ID_struct);
   PRECONDITION(struct_type.id()==ID_struct);
 
@@ -1000,6 +999,7 @@ void java_object_factoryt::gen_nondet_init(
   const source_locationt &location)
 {
   const typet &type = override_type.has_value() ? *override_type : expr.type();
+  const namespacet ns(symbol_table);
   const typet &followed_type = ns.follow(type);
 
   if(type.id()==ID_pointer)
@@ -1304,6 +1304,7 @@ void java_object_factoryt::gen_nondet_array_init(
   PRECONDITION(expr.type().subtype().id() == ID_struct_tag);
   PRECONDITION(update_in_place != update_in_placet::MAY_UPDATE_IN_PLACE);
 
+  const namespacet ns(symbol_table);
   const typet &type = ns.follow(expr.type().subtype());
   const struct_typet &struct_type = to_struct_type(type);
   const typet &element_type =
@@ -1386,7 +1387,7 @@ bool java_object_factoryt::gen_nondet_enum_init(
 {
   const irep_idt &class_name = java_class_type.get_name();
   const irep_idt values_name = id2string(class_name) + ".$VALUES";
-  if(!ns.get_symbol_table().has_symbol(values_name))
+  if(!symbol_table.has_symbol(values_name))
   {
     log.warning() << values_name
                   << " is missing, so the corresponding Enum "
@@ -1395,6 +1396,7 @@ bool java_object_factoryt::gen_nondet_enum_init(
     return false;
   }
 
+  const namespacet ns(symbol_table);
   const symbolt &values = ns.lookup(values_name);
 
   // Access members (length and data) of $VALUES array


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->
No functional change.
The first commit is a follow-up PR to https://github.com/diffblue/cbmc/pull/4416, where it was requested in reviews. The second commit seemed related enough to include it in the same PR.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
