### PR TITLE
Use symbol_tablet::lookup_ref and ::get_writeable_ref

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_typecheck.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_typecheck.cpp
@@ -52,14 +52,14 @@ void java_bytecode_typecheckt::typecheck(
   // recursively doing base classes first.
   for(const irep_idt &id : identifiers)
   {
-    symbolt &symbol=*symbol_table.get_writeable(id);
+    symbolt &symbol = symbol_table.get_writeable_ref(id);
     if(symbol.is_type)
       typecheck_type_symbol(symbol);
   }
   // We now check all non-type symbols
   for(const irep_idt &id : identifiers)
   {
-    symbolt &symbol=*symbol_table.get_writeable(id);
+    symbolt &symbol = symbol_table.get_writeable_ref(id);
     if(!symbol.is_type)
       typecheck_non_type_symbol(symbol);
   }

--- a/jbmc/src/java_bytecode/java_entry_point.cpp
+++ b/jbmc/src/java_bytecode/java_entry_point.cpp
@@ -125,7 +125,8 @@ static void java_static_lifetime_init(
   bool string_refinement_enabled,
   message_handlert &message_handler)
 {
-  symbolt &initialize_symbol=*symbol_table.get_writeable(INITIALIZE_FUNCTION);
+  symbolt &initialize_symbol =
+    symbol_table.get_writeable_ref(INITIALIZE_FUNCTION);
   code_blockt &code_block=to_code_block(to_code(initialize_symbol.value));
   object_factory_parameters.function_id = initialize_symbol.name;
 
@@ -160,7 +161,7 @@ static void java_static_lifetime_init(
     ++symbol_it)
   {
     const auto &symname = *symbol_it;
-    const symbolt &sym=*symbol_table.lookup(symname);
+    const symbolt &sym = symbol_table.lookup_ref(symname);
     if(should_init_symbol(sym))
     {
       if(const symbolt *class_literal_init_method =
@@ -468,7 +469,7 @@ static optionalt<codet> record_return_value(
     return {};
 
   const symbolt &return_symbol =
-    *symbol_table.lookup(JAVA_ENTRY_POINT_RETURN_SYMBOL);
+    symbol_table.lookup_ref(JAVA_ENTRY_POINT_RETURN_SYMBOL);
 
   codet output(ID_output);
   output.operands().resize(2);
@@ -493,7 +494,7 @@ static code_blockt record_pointer_parameters(
       param_number++)
   {
     const symbolt &p_symbol =
-      *symbol_table.lookup(parameters[param_number].get_identifier());
+      symbol_table.lookup_ref(parameters[param_number].get_identifier());
 
     if(!can_cast_type<pointer_typet>(p_symbol.type))
       continue;

--- a/jbmc/src/java_bytecode/java_utils.cpp
+++ b/jbmc/src/java_bytecode/java_utils.cpp
@@ -365,8 +365,8 @@ get_inherited_component(
       return *resolved_component;
 
     // No, may be inherited from some parent class; check it is visible:
-    const symbolt &component_symbol =
-      *symbol_table.lookup(resolved_component->get_full_component_identifier());
+    const symbolt &component_symbol = symbol_table.lookup_ref(
+      resolved_component->get_full_component_identifier());
 
     irep_idt access = component_symbol.type.get(ID_access);
     if(access.empty())

--- a/jbmc/src/java_bytecode/simple_method_stubbing.cpp
+++ b/jbmc/src/java_bytecode/simple_method_stubbing.cpp
@@ -235,7 +235,7 @@ void java_simple_method_stubst::create_method_stub(symbolt &symbol)
 /// \param symname: Symbol name to consider stubbing
 void java_simple_method_stubst::check_method_stub(const irep_idt &symname)
 {
-  const symbolt &sym = *symbol_table.lookup(symname);
+  const symbolt &sym = symbol_table.lookup_ref(symname);
   if(!sym.is_type && sym.value.id() == ID_nil &&
     sym.type.id() == ID_code &&
     // do not stub internal locking calls as 'create_method_stub' does not
@@ -248,7 +248,7 @@ void java_simple_method_stubst::check_method_stub(const irep_idt &symname)
     sym.name !=
       "java::java.lang.Object.monitorexit:(Ljava/lang/Object;)V")
   {
-    create_method_stub(*symbol_table.get_writeable(symname));
+    create_method_stub(symbol_table.get_writeable_ref(symname));
   }
 }
 

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -63,7 +63,7 @@ void record_function_outputs(
     codet output(ID_output);
     output.operands().resize(2);
 
-    const symbolt &return_symbol=*symbol_table.lookup("return'");
+    const symbolt &return_symbol = symbol_table.lookup_ref("return'");
 
     output.op0()=
       address_of_exprt(

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -125,7 +125,7 @@ void c_typecheck_baset::typecheck_symbol(symbolt &symbol)
       throw 0;
     }
 
-    symbolt & existing_symbol=*symbol_table.get_writeable(symbol.name);
+    symbolt &existing_symbol = symbol_table.get_writeable_ref(symbol.name);
     if(symbol.is_type)
       typecheck_redefinition_type(existing_symbol, symbol);
     else
@@ -735,7 +735,7 @@ void c_typecheck_baset::typecheck_declaration(
       // add code contract (if any); we typecheck this after the
       // function body done above, so as to have parameter symbols
       // available
-      symbolt &new_symbol=*symbol_table.get_writeable(identifier);
+      symbolt &new_symbol = symbol_table.get_writeable_ref(identifier);
 
       typecheck_spec_expr(static_cast<codet &>(contract), ID_C_spec_requires);
 

--- a/src/cpp/cpp_instantiate_template.cpp
+++ b/src/cpp/cpp_instantiate_template.cpp
@@ -369,7 +369,7 @@ const symbolt &cpp_typecheckt::instantiate_template(
   // been instantiated using these arguments
   {
     // need non-const handle on template symbol
-    symbolt &s=*symbol_table.get_writeable(template_symbol.name);
+    symbolt &s = symbol_table.get_writeable_ref(template_symbol.name);
     irept &instantiated_with = s.value.add(ID_instantiated_with);
     instantiated_with.get_sub().push_back(specialization_template_args);
   }
@@ -461,7 +461,7 @@ const symbolt &cpp_typecheckt::instantiate_template(
 
   if(is_template_method)
   {
-    symbolt &symb=*symbol_table.get_writeable(class_name);
+    symbolt &symb = symbol_table.get_writeable_ref(class_name);
 
     assert(new_decl.declarators().size() == 1);
 

--- a/src/cpp/cpp_typecheck.cpp
+++ b/src/cpp/cpp_typecheck.cpp
@@ -156,7 +156,7 @@ void cpp_typecheckt::static_and_dynamic_initialization()
 
   for(const irep_idt &d_it : dynamic_initializations)
   {
-    const symbolt &symbol=*symbol_table.lookup(d_it);
+    const symbolt &symbol = symbol_table.lookup_ref(d_it);
 
     if(symbol.is_extern)
       continue;
@@ -250,7 +250,7 @@ void cpp_typecheckt::do_not_typechecked()
           UNREACHABLE; // Don't know what to do!
 
         symbolt &writable_symbol =
-          *symbol_table.get_writeable(named_symbol.first);
+          symbol_table.get_writeable_ref(named_symbol.first);
         writable_symbol.value.swap(value);
         convert_function(writable_symbol);
       }

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -194,7 +194,7 @@ void cpp_typecheckt::typecheck_compound_type(
         to_struct_union_type(symbol.type).is_incomplete())
       {
         // a previously incomplete struct/union becomes complete
-        symbolt &writeable_symbol = *symbol_table.get_writeable(symbol_name);
+        symbolt &writeable_symbol = symbol_table.get_writeable_ref(symbol_name);
         writeable_symbol.type.swap(type);
         typecheck_compound_body(writeable_symbol);
       }
@@ -1426,8 +1426,8 @@ void cpp_typecheckt::convert_anon_struct_union_member(
   const irep_idt &access,
   struct_typet::componentst &components)
 {
-  symbolt &struct_union_symbol=
-    *symbol_table.get_writeable(follow(declaration.type()).get(ID_name));
+  symbolt &struct_union_symbol =
+    symbol_table.get_writeable_ref(follow(declaration.type()).get(ID_name));
 
   if(declaration.storage_spec().is_static() ||
      declaration.storage_spec().is_mutable())

--- a/src/cpp/cpp_typecheck_declaration.cpp
+++ b/src/cpp/cpp_typecheck_declaration.cpp
@@ -58,8 +58,8 @@ codet cpp_typecheckt::convert_anonymous_union(cpp_declarationt &declaration)
   new_code.add_to_operands(code_declt(cpp_symbol_expr(symbol)));
 
   // do scoping
-  symbolt union_symbol=
-    *symbol_table.get_writeable(follow(symbol.type).get(ID_name));
+  symbolt union_symbol =
+    symbol_table.get_writeable_ref(follow(symbol.type).get(ID_name));
 
   for(const auto &c : to_union_type(union_symbol.type).components())
   {

--- a/src/cpp/cpp_typecheck_template.cpp
+++ b/src/cpp/cpp_typecheck_template.cpp
@@ -377,8 +377,7 @@ void cpp_typecheckt::typecheck_class_template_member(
   }
 
   const cpp_idt &cpp_id=**(id_set.begin());
-  symbolt &template_symbol=
-    *symbol_table.get_writeable(cpp_id.identifier);
+  symbolt &template_symbol = symbol_table.get_writeable_ref(cpp_id.identifier);
 
   exprt &template_methods =
     static_cast<exprt &>(template_symbol.value.add(ID_template_methods));

--- a/src/goto-instrument/accelerate/accelerate.cpp
+++ b/src/goto-instrument/accelerate/accelerate.cpp
@@ -427,7 +427,7 @@ bool acceleratet::is_underapproximate(path_acceleratort &accelerator)
     if(it->id()==ID_symbol && it->type() == bool_typet())
     {
       const irep_idt &id=to_symbol_expr(*it).get_identifier();
-      const symbolt &sym=*symbol_table.lookup(id);
+      const symbolt &sym = symbol_table.lookup_ref(id);
 
       if(sym.module=="scratch")
       {

--- a/src/goto-instrument/accelerate/acceleration_utils.cpp
+++ b/src/goto-instrument/accelerate/acceleration_utils.cpp
@@ -227,7 +227,7 @@ void acceleration_utilst::stash_variables(
       it!=vars.end();
       ++it)
   {
-    symbolt orig=*symbol_table.lookup(*it);
+    symbolt orig = symbol_table.lookup_ref(*it);
     symbolt stashed_sym=fresh_symbol("polynomial::stash", orig.type);
     substitution[orig.symbol_expr()]=stashed_sym.symbol_expr();
     program.assign(stashed_sym.symbol_expr(), orig.symbol_expr());

--- a/src/goto-instrument/accelerate/acceleration_utils.cpp
+++ b/src/goto-instrument/accelerate/acceleration_utils.cpp
@@ -227,7 +227,7 @@ void acceleration_utilst::stash_variables(
       it!=vars.end();
       ++it)
   {
-    symbolt orig = symbol_table.lookup_ref(*it);
+    const symbolt &orig = symbol_table.lookup_ref(*it);
     symbolt stashed_sym=fresh_symbol("polynomial::stash", orig.type);
     substitution[orig.symbol_expr()]=stashed_sym.symbol_expr();
     program.assign(stashed_sym.symbol_expr(), orig.symbol_expr());

--- a/src/goto-instrument/accelerate/polynomial_accelerator.cpp
+++ b/src/goto-instrument/accelerate/polynomial_accelerator.cpp
@@ -768,7 +768,7 @@ void polynomial_acceleratort::stash_variables(
       it!=vars.end();
       ++it)
   {
-    symbolt orig=*symbol_table.lookup(*it);
+    symbolt orig = symbol_table.lookup_ref(*it);
     symbolt stashed_sym=utils.fresh_symbol("polynomial::stash", orig.type);
     substitution[orig.symbol_expr()]=stashed_sym.symbol_expr();
     program.assign(stashed_sym.symbol_expr(), orig.symbol_expr());

--- a/src/goto-instrument/accelerate/polynomial_accelerator.cpp
+++ b/src/goto-instrument/accelerate/polynomial_accelerator.cpp
@@ -768,7 +768,7 @@ void polynomial_acceleratort::stash_variables(
       it!=vars.end();
       ++it)
   {
-    symbolt orig = symbol_table.lookup_ref(*it);
+    const symbolt &orig = symbol_table.lookup_ref(*it);
     symbolt stashed_sym=utils.fresh_symbol("polynomial::stash", orig.type);
     substitution[orig.symbol_expr()]=stashed_sym.symbol_expr();
     program.assign(stashed_sym.symbol_expr(), orig.symbol_expr());

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -89,7 +89,7 @@ void dump_ct::operator()(std::ostream &os)
   std::set<std::string> symbols_sorted;
   for(const auto &named_symbol : copied_symbol_table.symbols)
   {
-    symbolt &symbol=*copied_symbol_table.get_writeable(named_symbol.first);
+    symbolt &symbol = copied_symbol_table.get_writeable_ref(named_symbol.first);
     bool tag_added=false;
 
     // TODO we could get rid of some of the ID_anonymous by looking up

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -1630,7 +1630,7 @@ void goto_program2codet::remove_const(typet &type)
     if(!const_removed.insert(identifier).second)
       return;
 
-    symbolt &symbol=*symbol_table.get_writeable(identifier);
+    symbolt &symbol = symbol_table.get_writeable_ref(identifier);
     INVARIANT(
       symbol.is_type,
       "Symbol "+id2string(identifier)+" should be a type");

--- a/src/goto-programs/rebuild_goto_start_function.cpp
+++ b/src/goto-programs/rebuild_goto_start_function.cpp
@@ -76,8 +76,8 @@ template<typename maybe_lazy_goto_modelt>
 irep_idt rebuild_goto_start_function_baset<maybe_lazy_goto_modelt>::
 get_entry_point_mode() const
 {
-  const symbolt &current_entry_point=
-    *goto_model.symbol_table.lookup(goto_functionst::entry_point());
+  const symbolt &current_entry_point =
+    goto_model.symbol_table.lookup_ref(goto_functionst::entry_point());
   return current_entry_point.mode;
 }
 

--- a/src/goto-programs/remove_complex.cpp
+++ b/src/goto-programs/remove_complex.cpp
@@ -276,7 +276,7 @@ static void remove_complex(symbolt &symbol)
 void remove_complex(symbol_tablet &symbol_table)
 {
   for(const auto &named_symbol : symbol_table.symbols)
-    remove_complex(*symbol_table.get_writeable(named_symbol.first));
+    remove_complex(symbol_table.get_writeable_ref(named_symbol.first));
 }
 
 /// removes complex data type

--- a/src/goto-programs/remove_const_function_pointers.cpp
+++ b/src/goto-programs/remove_const_function_pointers.cpp
@@ -75,7 +75,7 @@ exprt remove_const_function_pointerst::replace_const_symbols(
     if(is_const_expression(expression))
     {
       const symbolt &symbol =
-        *symbol_table.lookup(to_symbol_expr(expression).get_identifier());
+        symbol_table.lookup_ref(to_symbol_expr(expression).get_identifier());
       if(symbol.type.id()!=ID_code)
       {
         const exprt &symbol_value=symbol.value;
@@ -111,8 +111,7 @@ exprt remove_const_function_pointerst::replace_const_symbols(
 exprt remove_const_function_pointerst::resolve_symbol(
   const symbol_exprt &symbol_expr) const
 {
-  const symbolt &symbol=
-    *symbol_table.lookup(symbol_expr.get_identifier());
+  const symbolt &symbol = symbol_table.lookup_ref(symbol_expr.get_identifier());
   return symbol.value;
 }
 

--- a/src/goto-programs/remove_vector.cpp
+++ b/src/goto-programs/remove_vector.cpp
@@ -211,7 +211,7 @@ static void remove_vector(symbolt &symbol)
 static void remove_vector(symbol_tablet &symbol_table)
 {
   for(const auto &named_symbol : symbol_table.symbols)
-    remove_vector(*symbol_table.get_writeable(named_symbol.first));
+    remove_vector(symbol_table.get_writeable_ref(named_symbol.first));
 }
 
 /// removes vector data type

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -163,7 +163,7 @@ void string_abstractiont::add_str_arguments(
     const irep_idt &name,
     goto_functionst::goto_functiont &fct)
 {
-  symbolt &fct_symbol=*symbol_table.get_writeable(name);
+  symbolt &fct_symbol = symbol_table.get_writeable_ref(name);
 
   code_typet::parameterst str_args;
 

--- a/src/jsil/jsil_typecheck.cpp
+++ b/src/jsil/jsil_typecheck.cpp
@@ -897,7 +897,7 @@ void jsil_typecheckt::typecheck()
   // recursively doing base classes first.
   for(const irep_idt &id : identifiers)
   {
-    symbolt &symbol=*symbol_table.get_writeable(id);
+    symbolt &symbol = symbol_table.get_writeable_ref(id);
     if(symbol.is_type)
       typecheck_type_symbol(symbol);
   }
@@ -905,7 +905,7 @@ void jsil_typecheckt::typecheck()
   // We now check all non-type symbols
   for(const irep_idt &id : identifiers)
   {
-    symbolt &symbol=*symbol_table.get_writeable(id);
+    symbolt &symbol = symbol_table.get_writeable_ref(id);
     if(!symbol.is_type)
       typecheck_non_type_symbol(symbol);
   }

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -1309,7 +1309,7 @@ void linkingt::rename_symbols(
 
   for(const irep_idt &id : needs_to_be_renamed)
   {
-    symbolt &new_symbol=*src_symbol_table.get_writeable(id);
+    symbolt &new_symbol = src_symbol_table.get_writeable_ref(id);
 
     irep_idt new_identifier;
 
@@ -1372,7 +1372,7 @@ void linkingt::copy_symbols()
   // Now do the collisions
   for(const irep_idt &collision : collisions)
   {
-    symbolt &old_symbol=*main_symbol_table.get_writeable(collision);
+    symbolt &old_symbol = main_symbol_table.get_writeable_ref(collision);
     symbolt &new_symbol=src_symbols.at(collision);
 
     if(new_symbol.is_type)

--- a/src/linking/static_lifetime_init.cpp
+++ b/src/linking/static_lifetime_init.cpp
@@ -57,7 +57,7 @@ static_lifetime_init(const irep_idt &identifier, symbol_tablet &symbol_table)
   {
     // C standard 6.9.2, paragraph 5
     // adjust the type to an array of size 1
-    symbolt &writable_symbol = *symbol_table.get_writeable(identifier);
+    symbolt &writable_symbol = symbol_table.get_writeable_ref(identifier);
     writable_symbol.type = type;
     writable_symbol.type.set(ID_size, from_integer(1, size_type()));
   }

--- a/src/pointer-analysis/add_failed_symbols.cpp
+++ b/src/pointer-analysis/add_failed_symbols.cpp
@@ -67,7 +67,7 @@ void add_failed_symbol_if_needed(
   if(symbol.type.get(ID_C_failed_symbol)!="")
     return;
 
-  add_failed_symbol(*symbol_table.get_writeable(symbol.name), symbol_table);
+  add_failed_symbol(symbol_table.get_writeable_ref(symbol.name), symbol_table);
 }
 
 /// Create a failed-dereference symbol for all symbols in the given table that


### PR DESCRIPTION
These all replace uses of lookup and get_writeable that were immediately dereferenced without
being checked, thereby replacing any possible failure due to reading through a null pointer with
an invariant failure.