### PR TITLE
Memory snapshot support for pointers and structs [blocks: #4482]

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -55,5 +55,6 @@ add_subdirectory(linking-goto-binaries)
 add_subdirectory(symtab2gb)
 
 if(WITH_MEMORY_ANALYZER)
-add_subdirectory(memory-analyzer)
+  add_subdirectory(snapshot-harness)
+  add_subdirectory(memory-analyzer)
 endif()

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -44,7 +44,8 @@ ifeq ($(detected_OS),Linux)
 endif
 
 ifeq ($(WITH_MEMORY_ANALYZER),1)
-  DIRS += memory-analyzer
+  DIRS += snapshot-harness \
+          memory-analyzer
 endif
 
 # Run all test directories in sequence

--- a/regression/memory-analyzer/pointer_to_struct_01/test.desc
+++ b/regression/memory-analyzer/pointer_to_struct_01/test.desc
@@ -2,8 +2,7 @@ CORE
 main.gb
 --breakpoint checkpoint --symbols p
 struct S tmp;
-tmp = \{ \.next=\(\(struct S \*\)(NULL|0)\) \};
-p = &tmp;
-p->next = &tmp;
+tmp = \{ \.next=\(\(struct S \*\)0\) \};
+p = \&tmp;
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/snapshot-harness/CMakeLists.txt
+++ b/regression/snapshot-harness/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_test_pl_tests(
+  "../chain.sh \
+   $<TARGET_FILE:goto-cc> \
+   $<TARGET_FILE:goto-harness> \
+   $<TARGET_FILE:memory-analyzer> \
+   $<TARGET_FILE:cbmc> \
+   ../../../build/bin/goto-gcc")

--- a/regression/snapshot-harness/Makefile
+++ b/regression/snapshot-harness/Makefile
@@ -1,0 +1,26 @@
+default: tests.log
+
+MEMORY_ANALYZER_EXE=../../../src/memory-analyzer/memory-analyzer
+GOTO_HARNESS_EXE=../../../src/goto-harness/goto-harness
+CBMC_EXE=../../../src/cbmc/cbmc
+GOTO_CC_EXE=../../../src/goto-cc/goto-cc
+GOTO_GCC_EXE=../../../src/goto-cc/goto-gcc
+
+test:
+	@../test.pl -e -p -c "../chain.sh $(GOTO_CC_EXE) $(GOTO_HARNESS_EXE) $(MEMORY_ANALYZER_EXE) $(CBMC_EXE) $(GOTO_GCC_EXE)"
+
+tests.log: ../test.pl
+	@../test.pl -e -p -c "../chain.sh $(GOTO_CC_EXE) $(GOTO_HARNESS_EXE) $(MEMORY_ANALYZER_EXE) $(CBMC_EXE) $(GOTO_GCC_EXE)"
+
+show:
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			vim -o "$$dir/*.c" "$$dir/*.out"; \
+		fi; \
+	done;
+
+clean:
+	find -name '*.out' -execdir $(RM) '{}' \;
+	find -name '*.gb' -execdir $(RM) '{}' \;
+	find -name '*.json' -execdir $(RM) '{}' \;
+	$(RM) tests.log

--- a/regression/snapshot-harness/arrays_01/main.c
+++ b/regression/snapshot-harness/arrays_01/main.c
@@ -1,0 +1,29 @@
+#include <assert.h>
+
+int array[] = {1, 2, 3};
+int *p;
+int *q;
+
+void initialize()
+{
+  p = &(array[1]);
+  q = array + 1;
+  array[0] = 4;
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(p == &(array[1]));
+  assert(p == q);
+  assert(*p == *q);
+  assert(array[0] != *p);
+  *p = 4;
+  assert(array[0] == *p);
+}

--- a/regression/snapshot-harness/arrays_01/test.desc
+++ b/regression/snapshot-harness/arrays_01/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+array,p,q --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^EXIT=0$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion p == \&\(array\[1\]\): SUCCESS
+\[main.assertion.2\] line [0-9]+ assertion p == q: SUCCESS
+\[main.assertion.3\] line [0-9]+ assertion \*p == \*q: SUCCESS
+\[main.assertion.4\] line [0-9]+ assertion array\[0\] != \*p: SUCCESS
+\[main.assertion.5\] line [0-9]+ assertion array\[0\] == \*p: SUCCESS
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/regression/snapshot-harness/chain.sh
+++ b/regression/snapshot-harness/chain.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+goto_cc=$1
+goto_harness=$2
+memory_analyzer=$3
+cbmc=$4
+goto_gcc=$5
+entry_point='generated_entry_function'
+break_point='checkpoint'
+
+name=${*:$#}
+name=${name%.c}
+memory_analyzer_symbols=$6
+goto_harness_args=${*:7:$#-7}
+
+$goto_cc -o "${name}_cc.gb" "${name}.c"
+$goto_gcc -g -std=c11 -o "${name}_gcc.gb" "${name}.c"
+
+$memory_analyzer --symtab-snapshot --json-ui --breakpoint $break_point --symbols ${memory_analyzer_symbols} "${name}_gcc.gb" > "${name}.json"
+
+if [ -e "${name}-mod.gb" ] ; then
+  rm -f "${name}-mod.gb"
+fi
+
+$goto_harness "${name}_cc.gb" "${name}-mod.gb" --harness-function-name $entry_point --memory-snapshot "${name}.json" ${goto_harness_args}
+$cbmc --function $entry_point "${name}-mod.gb" \
+  --pointer-check `# because we want to see out of bounds errors` \
+  --unwind 11 `# with the way we set up arrays symex can't figure out loop bounds automatically` \
+  --unwinding-assertions `# we want to make sure we don't accidentally pass tests because we didn't unwind enough` \
+  # cbmc args end

--- a/regression/snapshot-harness/pointer_01/main.c
+++ b/regression/snapshot-harness/pointer_01/main.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+
+int x;
+int *p;
+
+void initialize()
+{
+  x = 3;
+  p = &x;
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(*p == x);
+}

--- a/regression/snapshot-harness/pointer_01/test.desc
+++ b/regression/snapshot-harness/pointer_01/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+x,p --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^EXIT=0$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion \*p == x: SUCCESS
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/regression/snapshot-harness/pointer_02/main.c
+++ b/regression/snapshot-harness/pointer_02/main.c
@@ -1,0 +1,32 @@
+#include <assert.h>
+#include <malloc.h>
+
+int x;
+int *p1;
+int *p2;
+int *p3;
+
+void initialize()
+{
+  x = 3;
+  p1 = malloc(sizeof(int));
+  p3 = malloc(sizeof(int));
+  p2 = &x;
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(*p2 == x);
+  assert(p1 != p2);
+  assert(p1 != p3);
+  assert(*p1 == x);
+  *p1 = x;
+  assert(*p1 == x);
+}

--- a/regression/snapshot-harness/pointer_02/test.desc
+++ b/regression/snapshot-harness/pointer_02/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+x,p1,p2,p3 --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^EXIT=10$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion \*p2 == x: SUCCESS
+\[main.assertion.2\] line [0-9]+ assertion p1 != p2: SUCCESS
+\[main.assertion.3\] line [0-9]+ assertion p1 != p3: SUCCESS
+\[main.assertion.4\] line [0-9]+ assertion \*p1 == x: FAILURE
+\[main.assertion.5\] line [0-9]+ assertion \*p1 == x: SUCCESS
+--
+^warning: ignoring

--- a/regression/snapshot-harness/pointer_03/main.c
+++ b/regression/snapshot-harness/pointer_03/main.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+
+int x;
+void *p;
+
+void initialize()
+{
+  x = 3;
+  p = (void *)&x;
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(*(int *)p == 3);
+
+  return 0;
+}

--- a/regression/snapshot-harness/pointer_03/test.desc
+++ b/regression/snapshot-harness/pointer_03/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+x,p --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^EXIT=0$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion \*\(int \*\)p == 3: SUCCESS
+--
+^warning: ignoring

--- a/regression/snapshot-harness/pointer_04/main.c
+++ b/regression/snapshot-harness/pointer_04/main.c
@@ -1,0 +1,30 @@
+#include <assert.h>
+
+int x;
+int *p1;
+int **p2;
+
+void initialize()
+{
+  x = 3;
+  p1 = &x;
+  p2 = &p1;
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(&p1 == *p2);
+  assert(*p2 == p1);
+  assert(*p1 == 3);
+  assert(*p2 == &x);
+  assert(**p2 == x);
+
+  return 0;
+}

--- a/regression/snapshot-harness/pointer_04/test.desc
+++ b/regression/snapshot-harness/pointer_04/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+x,p1,p2 --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^EXIT=0$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion \&p1 == \*p2: SUCCESS
+\[main.assertion.2\] line [0-9]+ assertion \*p2 == p1: SUCCESS
+\[main.assertion.3\] line [0-9]+ assertion \*p1 == 3: SUCCESS
+\[main.assertion.4\] line [0-9]+ assertion \*p2 == \&x: SUCCESS
+\[main.assertion.5\] line [0-9]+ assertion \*\*p2 == x: SUCCESS
+--
+^warning: ignoring

--- a/regression/snapshot-harness/pointer_05/main.c
+++ b/regression/snapshot-harness/pointer_05/main.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+
+int x;
+int *p1;
+int *p2;
+
+void initialize()
+{
+  x = 3;
+  p1 = &x;
+  p2 = &x;
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(*p1 == *p2);
+}

--- a/regression/snapshot-harness/pointer_05/test.desc
+++ b/regression/snapshot-harness/pointer_05/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+x,p1,p2 --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^EXIT=0$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion \*p1 == \*p2: SUCCESS
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/regression/snapshot-harness/pointer_06/main.c
+++ b/regression/snapshot-harness/pointer_06/main.c
@@ -1,0 +1,23 @@
+#include <assert.h>
+#include <malloc.h>
+
+int *p;
+int *q;
+
+void initialize()
+{
+  p = malloc(sizeof(int));
+  q = p;
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(p == q);
+}

--- a/regression/snapshot-harness/pointer_06/test.desc
+++ b/regression/snapshot-harness/pointer_06/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+p,q --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^EXIT=0$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion p == q: SUCCESS
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/regression/snapshot-harness/pointer_to_struct_01/main.c
+++ b/regression/snapshot-harness/pointer_to_struct_01/main.c
@@ -1,0 +1,34 @@
+#include <assert.h>
+#include <malloc.h>
+
+struct S
+{
+  struct S *next;
+};
+
+struct S st;
+struct S *p;
+struct S *q;
+
+void initialize()
+{
+  st.next = &st;
+  p = &st;
+  q = malloc(sizeof(struct S));
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(p == &st);
+  assert(p->next == &st);
+  assert(p != q);
+  q->next = &st;
+  assert(p == q->next);
+}

--- a/regression/snapshot-harness/pointer_to_struct_01/test.desc
+++ b/regression/snapshot-harness/pointer_to_struct_01/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+st,p,q --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^EXIT=0$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion p == \&st: SUCCESS
+\[main.assertion.2\] line [0-9]+ assertion p-\>next == \&st: SUCCESS
+\[main.assertion.3\] line [0-9]+ assertion p \!= q: SUCCESS
+\[main.assertion.4\] line [0-9]+ assertion p == q-\>next: SUCCESS
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/regression/snapshot-harness/structs_01/main.c
+++ b/regression/snapshot-harness/structs_01/main.c
@@ -1,0 +1,32 @@
+#include <assert.h>
+
+struct S
+{
+  int c1;
+  int c2;
+} st;
+
+int *p;
+
+void initialize()
+{
+  st.c1 = 1;
+  st.c2 = 3;
+  p = &(st.c2);
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(st.c1 + 2 == st.c2);
+  assert(st.c1 + 2 == *p);
+  assert(*p == st.c2);
+  *p = st.c2 + 1;
+  assert(*p == st.c2);
+}

--- a/regression/snapshot-harness/structs_01/test.desc
+++ b/regression/snapshot-harness/structs_01/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+st,p --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^EXIT=0$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion st.c1 \+ 2 == st.c2: SUCCESS
+\[main.assertion.2\] line [0-9]+ assertion st.c1 \+ 2 == \*p: SUCCESS
+\[main.assertion.3\] line [0-9]+ assertion \*p == st.c2: SUCCESS
+\[main.assertion.4\] line [0-9]+ assertion \*p == st.c2: SUCCESS
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/regression/snapshot-harness/union_01/main.c
+++ b/regression/snapshot-harness/union_01/main.c
@@ -1,0 +1,31 @@
+#include <assert.h>
+
+union Un {
+  int i;
+  float f;
+} un;
+
+int *ip;
+float *fp;
+
+void initialize()
+{
+  un.i = 1;
+  ip = &un.i;
+  fp = &un.f;
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(ip == &un.i);
+  assert(*ip == un.i);
+  *fp = 2.0f;
+  assert(un.f == 2.0f);
+}

--- a/regression/snapshot-harness/union_01/test.desc
+++ b/regression/snapshot-harness/union_01/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+un,ip,fp --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^EXIT=0$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion ip == \&un.i: SUCCESS
+\[main.assertion.2\] line [0-9]+ assertion \*ip == un.i: SUCCESS
+\[main.assertion.3\] line [0-9]+ assertion un.f == 2.0f: SUCCESS
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/src/goto-harness/memory_snapshot_harness_generator.h
+++ b/src/goto-harness/memory_snapshot_harness_generator.h
@@ -221,12 +221,23 @@ protected:
     const symbol_exprt &func_init_done_var,
     goto_modelt &goto_model) const;
 
+  /// Introduce a new symbol into \p symbol_table with the same name and type as
+  ///   \p snapshot_symbol
+  /// \param snapshot_symbol: the unknown symbol to be introduced
+  /// \param symbol_table: the symbol table to be updated
+  /// \return the new symbol
+  const symbolt &fresh_symbol_copy(
+    const symbolt &snapshot_symbol,
+    symbol_tablet &symbol_table) const;
+
   /// For each global symbol in the \p snapshot symbol table either:
   /// 1) add \ref code_assignt assigning a value from the \p snapshot to the
   ///    symbol
   /// or
   /// 2) recursively initialise the symbol to a non-deterministic value of the
-  ///    right type
+  ///    right type.
+  /// Malloc(ed) pointers point to temporaries which do not exists in the symbol
+  ///   table: for these we introduce fresh symbols.
   /// \param snapshot: snapshot to load the symbols and their values from
   /// \param goto_model: model to initialise the havoc-ing
   /// \return the block of code where the assignments are added

--- a/src/memory-analyzer/analyze_symbol.cpp
+++ b/src/memory-analyzer/analyze_symbol.cpp
@@ -287,7 +287,14 @@ exprt gdb_value_extractort::get_non_char_pointer_value(
   }
   else
   {
-    return it->second;
+    const auto &known_value = it->second;
+    const auto &expected_type = expr.type().subtype();
+    if(known_value.is_not_nil() && known_value.type() != expected_type)
+    {
+      return symbol_exprt{to_symbol_expr(known_value).get_identifier(),
+                          expected_type};
+    }
+    return known_value;
   }
 }
 
@@ -340,7 +347,9 @@ exprt gdb_value_extractort::get_pointer_value(
       }
       else
       {
-        return address_of_exprt(target_expr);
+        const auto result_expr = address_of_exprt(target_expr);
+        CHECK_RETURN(result_expr.type() == zero_expr.type());
+        return result_expr;
       }
     }
   }

--- a/src/memory-analyzer/analyze_symbol.cpp
+++ b/src/memory-analyzer/analyze_symbol.cpp
@@ -421,7 +421,11 @@ exprt gdb_value_extractort::get_expr_value(
 
     return get_pointer_value(expr, zero_expr, location);
   }
-  UNIMPLEMENTED;
+  else if(type.id() == ID_union_tag)
+  {
+    return get_union_value(expr, zero_expr, location);
+  }
+  UNREACHABLE;
 }
 
 exprt gdb_value_extractort::get_struct_value(
@@ -454,6 +458,28 @@ exprt gdb_value_extractort::get_struct_value(
     operand = get_expr_value(member_expr, operand, location);
   }
 
+  return new_expr;
+}
+
+exprt gdb_value_extractort::get_union_value(
+  const exprt &expr,
+  const exprt &zero_expr,
+  const source_locationt &location)
+{
+  PRECONDITION(zero_expr.id() == ID_union);
+
+  PRECONDITION(expr.type().id() == ID_union_tag);
+  PRECONDITION(expr.type() == zero_expr.type());
+
+  exprt new_expr(zero_expr);
+
+  const union_tag_typet &union_tag_type = to_union_tag_type(expr.type());
+  const union_typet &union_type = ns.follow_tag(union_tag_type);
+
+  CHECK_RETURN(new_expr.operands().size() == 1);
+  const union_typet::componentt &component = union_type.components()[0];
+  auto &operand = new_expr.operands()[0];
+  operand = get_expr_value(member_exprt{expr, component}, operand, location);
   return new_expr;
 }
 

--- a/src/memory-analyzer/analyze_symbol.h
+++ b/src/memory-analyzer/analyze_symbol.h
@@ -150,6 +150,18 @@ private:
     const exprt &zero_expr,
     const source_locationt &location);
 
+  /// Call \ref get_subexpression_at_offset to get the correct member
+  ///   expression.
+  /// \param expr: the input pointer expression (needed to get the right type)
+  /// \param pointer_value: pointer value with structure name and offset as the
+  ///   pointee member
+  /// \param location: the source location
+  /// \return \ref member_exprt that the \p pointer_value points to
+  exprt get_pointer_to_member_value(
+    const exprt &expr,
+    const pointer_valuet &pointer_value,
+    const source_locationt &location);
+
   /// Similar to \ref get_char_pointer_value. Doesn't re-call
   ///   \ref gdb_apit::get_memory, calls \ref get_expr_value on _dereferenced_
   ///   \p expr (the result of which is assigned to a new symbol).
@@ -184,6 +196,12 @@ private:
   /// \param expr: expression to be extracted
   /// \return the value as a string
   std::string get_gdb_value(const exprt &expr);
+
+  /// Analyzes the \p pointer_value to decide if it point to a struct or a
+  ///   union (or array)
+  /// \param pointer_value: pointer value to be analyzed
+  /// \return true if pointing to a member
+  bool points_to_member(const pointer_valuet &pointer_value) const;
 };
 
 #endif // CPROVER_MEMORY_ANALYZER_ANALYZE_SYMBOL_H

--- a/src/memory-analyzer/analyze_symbol.h
+++ b/src/memory-analyzer/analyze_symbol.h
@@ -138,6 +138,16 @@ private:
     const exprt &zero_expr,
     const source_locationt &location);
 
+  /// For each of the members of the struct: call \ref get_expr_value
+  /// \param expr: struct expression to be analysed
+  /// \param zero_expr: struct with zero-initialised members
+  /// \param location: the source location
+  /// \return the value of the struct from \ref gdb_apit
+  exprt get_union_value(
+    const exprt &expr,
+    const exprt &zero_expr,
+    const source_locationt &location);
+
   /// Call \ref gdb_apit::get_memory on \p expr then split based on the
   ///   points-to type being `char` type or not. These have dedicated functions.
   /// \param expr: the input pointer expression

--- a/src/memory-analyzer/gdb_api.h
+++ b/src/memory-analyzer/gdb_api.h
@@ -19,6 +19,7 @@ Author: Malte Mues <mail.mues@gmail.com>
 #define CPROVER_MEMORY_ANALYZER_GDB_API_H
 #include <unistd.h>
 
+#include <algorithm>
 #include <exception>
 #include <forward_list>
 
@@ -81,6 +82,12 @@ public:
     const std::string pointee;
     const std::string character;
     const optionalt<std::string> string;
+
+    bool has_known_offset() const
+    {
+      return std::any_of(
+        pointee.begin(), pointee.end(), [](char c) { return c == '+'; });
+    }
   };
 
   /// Create a new gdb process for analysing the binary indicated by the member


### PR DESCRIPTION
This PR extends the memory snapshot harness to correctly work with pointers and structs (and unions). This requires two functionalities to cooperate: 1) the `memory-analyzer` should produce a JSON file containing all information needed for; 2) the `goto-harness` should be able to read the pointer/struct symbols and correctly instantiate them. Regression tests automate the generation of JSON symbol tables for the harness so that they do not have to be included. The first commit is a squash of the prerequisite PR #4261 (no need to review it here).

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
