### PR TITLE
Remove unnecessary helper function that adds a function call to a code block

### DIFF
--- a/jbmc/src/java_bytecode/java_static_initializers.cpp
+++ b/jbmc/src/java_bytecode/java_static_initializers.cpp
@@ -210,21 +210,13 @@ static void clinit_wrapper_do_recursive_calls(
   {
     const auto base_name = base.type().get_identifier();
     irep_idt base_init_routine = clinit_wrapper_name(base_name);
-    auto findit = symbol_table.symbols.find(base_init_routine);
-    if(findit == symbol_table.symbols.end())
-      continue;
-
-    const code_function_callt call_base(findit->second.symbol_expr());
-    init_body.add(call_base);
+    if(const auto base_init_func = symbol_table.lookup(base_init_routine))
+      init_body.add(code_function_callt{base_init_func->symbol_expr()});
   }
 
   const irep_idt &real_clinit_name = clinit_function_name(class_name);
-  auto find_sym_it = symbol_table.symbols.find(real_clinit_name);
-  if(find_sym_it != symbol_table.symbols.end())
-  {
-    const code_function_callt call_real_init(find_sym_it->second.symbol_expr());
-    init_body.add(call_real_init);
-  }
+  if(const auto clinit_func = symbol_table.lookup(real_clinit_name))
+    init_body.add(code_function_callt{clinit_func->symbol_expr()});
 
   // If nondet-static option is given, add a standard nondet initialization for
   // each non-final static field of this class. Note this is the same invocation


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->
No functional change, only refactoring.
~The helper function is not directly related to nondet object creation and can be used in another function outside of the object factory.~ The function has now been removed entirely as it can be simplified and inlined.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
