### PR TITLE
prop_conv_solvert is not a messaget

### DIFF
--- a/jbmc/src/jbmc/bmc.cpp
+++ b/jbmc/src/jbmc/bmc.cpp
@@ -204,8 +204,11 @@ safety_checkert::resultt bmct::stop_on_fail()
     if(options.get_bool_option("trace"))
     {
       if(options.get_bool_option("beautify"))
-        counterexample_beautificationt()(
+      {
+        // NOLINTNEXTLINE(whitespace/braces)
+        counterexample_beautificationt{ui_message_handler}(
           dynamic_cast<boolbvt &>(prop_conv), equation);
+      }
 
       build_error_trace(
         error_trace, ns, equation, prop_conv, ui_message_handler);

--- a/src/goto-checker/counterexample_beautification.cpp
+++ b/src/goto-checker/counterexample_beautification.cpp
@@ -19,6 +19,12 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <solvers/prop/literal_expr.h>
 #include <solvers/prop/minimize.h>
 
+counterexample_beautificationt::counterexample_beautificationt(
+  message_handlert &message_handler)
+  : log(message_handler)
+{
+}
+
 void counterexample_beautificationt::get_minimization_list(
   prop_convt &prop_conv,
   const symex_target_equationt &equation,
@@ -92,7 +98,7 @@ operator()(boolbvt &boolbv, const symex_target_equationt &equation)
   boolbv.set_to(literal_exprt(failed->cond_literal), false);
 
   {
-    boolbv.status() << "Beautifying counterexample (guards)" << messaget::eom;
+    log.status() << "Beautifying counterexample (guards)" << messaget::eom;
 
     // compute weights for guards
     typedef std::map<literalt, unsigned> guard_countt;
@@ -117,8 +123,7 @@ operator()(boolbvt &boolbv, const symex_target_equationt &equation)
     }
 
     // give to propositional minimizer
-    prop_minimizet prop_minimize(boolbv);
-    prop_minimize.set_message_handler(boolbv.get_message_handler());
+    prop_minimizet prop_minimize{boolbv, log.get_message_handler()};
 
     for(const auto &g : guard_count)
       prop_minimize.objective(g.first, g.second);
@@ -128,7 +133,7 @@ operator()(boolbvt &boolbv, const symex_target_equationt &equation)
   }
 
   {
-    boolbv.status() << "Beautifying counterexample (values)" << messaget::eom;
+    log.status() << "Beautifying counterexample (values)" << messaget::eom;
 
     // get symbols we care about
     minimization_listt minimization_list;
@@ -136,8 +141,7 @@ operator()(boolbvt &boolbv, const symex_target_equationt &equation)
     get_minimization_list(boolbv, equation, minimization_list);
 
     // minimize
-    bv_minimizet bv_minimize(boolbv);
-    bv_minimize.set_message_handler(boolbv.get_message_handler());
+    bv_minimizet bv_minimize(boolbv, log.get_message_handler());
     bv_minimize(minimization_list);
   }
 }

--- a/src/goto-checker/counterexample_beautification.h
+++ b/src/goto-checker/counterexample_beautification.h
@@ -21,9 +21,8 @@ Author: Daniel Kroening, kroening@kroening.com
 class counterexample_beautificationt
 {
 public:
-  virtual ~counterexample_beautificationt()
-  {
-  }
+  explicit counterexample_beautificationt(message_handlert &message_handler);
+  virtual ~counterexample_beautificationt() = default;
 
   void operator()(boolbvt &boolbv, const symex_target_equationt &equation);
 
@@ -41,6 +40,8 @@ protected:
 
   // the failed property
   symex_target_equationt::SSA_stepst::const_iterator failed;
+
+  messaget log;
 };
 
 #endif // CPROVER_GOTO_CHECKER_COUNTEREXAMPLE_BEAUTIFICATION_H

--- a/src/goto-checker/multi_path_symex_checker.cpp
+++ b/src/goto-checker/multi_path_symex_checker.cpp
@@ -104,7 +104,8 @@ goto_tracet multi_path_symex_checkert::build_shortest_trace() const
 {
   if(options.get_bool_option("beautify"))
   {
-    counterexample_beautificationt()(
+    // NOLINTNEXTLINE(whitespace/braces)
+    counterexample_beautificationt{ui_message_handler}(
       dynamic_cast<boolbvt &>(property_decider.get_solver()), equation);
   }
 

--- a/src/goto-checker/single_path_symex_checker.cpp
+++ b/src/goto-checker/single_path_symex_checker.cpp
@@ -133,7 +133,8 @@ goto_tracet single_path_symex_checkert::build_shortest_trace() const
 {
   if(options.get_bool_option("beautify"))
   {
-    counterexample_beautificationt()(
+    // NOLINTNEXTLINE(whitespace/braces)
+    counterexample_beautificationt{ui_message_handler}(
       dynamic_cast<boolbvt &>(property_decider->get_solver()),
       property_decider->get_equation());
   }

--- a/src/goto-checker/solver_factory.cpp
+++ b/src/goto-checker/solver_factory.cpp
@@ -157,8 +157,8 @@ std::unique_ptr<solver_factoryt::solvert> solver_factoryt::get_default()
     solver->set_prop(util_make_unique<satcheckt>(message_handler));
   }
 
-  auto bv_pointers = util_make_unique<bv_pointerst>(ns, solver->prop());
-  bv_pointers->set_message_handler(message_handler);
+  auto bv_pointers =
+    util_make_unique<bv_pointerst>(ns, solver->prop(), message_handler);
 
   if(options.get_option("arrays-uf") == "never")
     bv_pointers->unbounded_array = bv_pointerst::unbounded_arrayt::U_NONE;
@@ -180,8 +180,8 @@ std::unique_ptr<solver_factoryt::solvert> solver_factoryt::get_dimacs()
 
   std::string filename = options.get_option("outfile");
 
-  auto bv_dimacs = util_make_unique<bv_dimacst>(ns, *prop, filename);
-  bv_dimacs->set_message_handler(message_handler);
+  auto bv_dimacs =
+    util_make_unique<bv_dimacst>(ns, *prop, message_handler, filename);
   return util_make_unique<solvert>(std::move(bv_dimacs), std::move(prop));
 }
 
@@ -209,9 +209,9 @@ std::unique_ptr<solver_factoryt::solvert> solver_factoryt::get_bv_refinement()
 
   info.refine_arrays = options.get_bool_option("refine-arrays");
   info.refine_arithmetic = options.get_bool_option("refine-arithmetic");
+  info.message_handler = &message_handler;
 
   auto prop_conv = util_make_unique<bv_refinementt>(info);
-  prop_conv->set_message_handler(message_handler);
   set_prop_conv_time_limit(*prop_conv);
   return util_make_unique<solvert>(std::move(prop_conv), std::move(prop));
 }
@@ -233,9 +233,9 @@ solver_factoryt::get_string_refinement()
       options.get_unsigned_int_option("max-node-refinement");
   info.refine_arrays = options.get_bool_option("refine-arrays");
   info.refine_arithmetic = options.get_bool_option("refine-arithmetic");
+  info.message_handler = &message_handler;
 
   auto prop_conv = util_make_unique<string_refinementt>(info);
-  prop_conv->set_message_handler(message_handler);
   set_prop_conv_time_limit(*prop_conv);
   return util_make_unique<solvert>(std::move(prop_conv), std::move(prop));
 }

--- a/src/goto-instrument/accelerate/scratch_program.h
+++ b/src/goto-instrument/accelerate/scratch_program.h
@@ -49,7 +49,7 @@ public:
       options(get_default_options()),
       symex(mh, symbol_table, equation, options, path_storage, guard_manager),
       satcheck(util_make_unique<satcheckt>(mh)),
-      satchecker(ns, *satcheck),
+      satchecker(ns, *satcheck, mh),
       z3(ns, "accelerate", "", "", smt2_dect::solvert::Z3),
       checker(&z3) // checker(&satchecker)
   {

--- a/src/solvers/flattening/arrays.cpp
+++ b/src/solvers/flattening/arrays.cpp
@@ -22,8 +22,11 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <unordered_set>
 
-arrayst::arrayst(const namespacet &_ns, propt &_prop)
-  : equalityt(_prop), ns(_ns)
+arrayst::arrayst(
+  const namespacet &_ns,
+  propt &_prop,
+  message_handlert &message_handler)
+  : equalityt(_prop, message_handler), ns(_ns)
 {
   lazy_arrays = false;        // will be set to true when --refine is used
   incremental_cache = false;  // for incremental solving
@@ -48,7 +51,7 @@ literalt arrayst::record_array_equality(
   // check types
   if(op0.type() != op1.type())
   {
-    error() << equality.pretty() << messaget::eom;
+    log.error() << equality.pretty() << messaget::eom;
     DATA_INVARIANT(
       false,
       "record_array_equality got equality without matching types");
@@ -116,7 +119,7 @@ void arrayst::collect_arrays(const exprt &a)
     // check types
     if(array_type != with_expr.old().type())
     {
-      error() << a.pretty() << messaget::eom;
+      log.error() << a.pretty() << messaget::eom;
       DATA_INVARIANT(false, "collect_arrays got 'with' without matching types");
     }
 
@@ -137,7 +140,7 @@ void arrayst::collect_arrays(const exprt &a)
     // check types
     if(array_type != update_expr.old().type())
     {
-      error() << a.pretty() << messaget::eom;
+      log.error() << a.pretty() << messaget::eom;
       DATA_INVARIANT(
         false,
         "collect_arrays got 'update' without matching types");
@@ -159,14 +162,14 @@ void arrayst::collect_arrays(const exprt &a)
     // check types
     if(array_type != if_expr.true_case().type())
     {
-      error() << a.pretty() << messaget::eom;
+      log.error() << a.pretty() << messaget::eom;
       DATA_INVARIANT(false, "collect_arrays got if without matching types");
     }
 
     // check types
     if(array_type != if_expr.false_case().type())
     {
-      error() << a.pretty() << messaget::eom;
+      log.error() << a.pretty() << messaget::eom;
       DATA_INVARIANT(false, "collect_arrays got if without matching types");
     }
 
@@ -520,7 +523,7 @@ void arrayst::add_array_constraints_with(
 
     if(index_expr.type()!=value.type())
     {
-      error() << expr.pretty() << messaget::eom;
+      log.error() << expr.pretty() << messaget::eom;
       DATA_INVARIANT(
         false,
         "with-expression operand should match array element type");
@@ -596,7 +599,7 @@ void arrayst::add_array_constraints_update(
 
     if(index_expr.type()!=value.type())
     {
-      prop.message.error() << expr.pretty() << messaget::eom;
+      prop.message.log.error() << expr.pretty() << messaget::eom;
       DATA_INVARIANT(
         false,
         "update operand should match array element type");

--- a/src/solvers/flattening/arrays.cpp
+++ b/src/solvers/flattening/arrays.cpp
@@ -48,14 +48,10 @@ literalt arrayst::record_array_equality(
   const exprt &op0=equality.op0();
   const exprt &op1=equality.op1();
 
-  // check types
-  if(op0.type() != op1.type())
-  {
-    log.error() << equality.pretty() << messaget::eom;
-    DATA_INVARIANT(
-      false,
-      "record_array_equality got equality without matching types");
-  }
+  DATA_INVARIANT_WITH_DIAGNOSTICS(
+    op0.type() == op1.type(),
+    "record_array_equality got equality without matching types",
+    irep_pretty_diagnosticst{equality});
 
   DATA_INVARIANT(
     op0.type().id() == ID_array,
@@ -116,12 +112,10 @@ void arrayst::collect_arrays(const exprt &a)
   {
     const with_exprt &with_expr=to_with_expr(a);
 
-    // check types
-    if(array_type != with_expr.old().type())
-    {
-      log.error() << a.pretty() << messaget::eom;
-      DATA_INVARIANT(false, "collect_arrays got 'with' without matching types");
-    }
+    DATA_INVARIANT_WITH_DIAGNOSTICS(
+      array_type == with_expr.old().type(),
+      "collect_arrays got 'with' without matching types",
+      irep_pretty_diagnosticst{a});
 
     arrays.make_union(a, with_expr.old());
     collect_arrays(with_expr.old());
@@ -137,14 +131,10 @@ void arrayst::collect_arrays(const exprt &a)
   {
     const update_exprt &update_expr=to_update_expr(a);
 
-    // check types
-    if(array_type != update_expr.old().type())
-    {
-      log.error() << a.pretty() << messaget::eom;
-      DATA_INVARIANT(
-        false,
-        "collect_arrays got 'update' without matching types");
-    }
+    DATA_INVARIANT_WITH_DIAGNOSTICS(
+      array_type == update_expr.old().type(),
+      "collect_arrays got 'update' without matching types",
+      irep_pretty_diagnosticst{a});
 
     arrays.make_union(a, update_expr.old());
     collect_arrays(update_expr.old());
@@ -159,19 +149,15 @@ void arrayst::collect_arrays(const exprt &a)
   {
     const if_exprt &if_expr=to_if_expr(a);
 
-    // check types
-    if(array_type != if_expr.true_case().type())
-    {
-      log.error() << a.pretty() << messaget::eom;
-      DATA_INVARIANT(false, "collect_arrays got if without matching types");
-    }
+    DATA_INVARIANT_WITH_DIAGNOSTICS(
+      array_type == if_expr.true_case().type(),
+      "collect_arrays got if without matching types",
+      irep_pretty_diagnosticst{a});
 
-    // check types
-    if(array_type != if_expr.false_case().type())
-    {
-      log.error() << a.pretty() << messaget::eom;
-      DATA_INVARIANT(false, "collect_arrays got if without matching types");
-    }
+    DATA_INVARIANT_WITH_DIAGNOSTICS(
+      array_type == if_expr.false_case().type(),
+      "collect_arrays got if without matching types",
+      irep_pretty_diagnosticst{a});
 
     arrays.make_union(a, if_expr.true_case());
     arrays.make_union(a, if_expr.false_case());
@@ -521,13 +507,10 @@ void arrayst::add_array_constraints_with(
 
     index_exprt index_expr(expr, index, expr.type().subtype());
 
-    if(index_expr.type()!=value.type())
-    {
-      log.error() << expr.pretty() << messaget::eom;
-      DATA_INVARIANT(
-        false,
-        "with-expression operand should match array element type");
-    }
+    DATA_INVARIANT_WITH_DIAGNOSTICS(
+      index_expr.type() == value.type(),
+      "with-expression operand should match array element type",
+      irep_pretty_diagnosticst{expr});
 
     lazy_constraintt lazy(
       lazy_typet::ARRAY_WITH, equal_exprt(index_expr, value));
@@ -597,13 +580,10 @@ void arrayst::add_array_constraints_update(
   {
     index_exprt index_expr(expr, index, expr.type().subtype());
 
-    if(index_expr.type()!=value.type())
-    {
-      prop.message.log.error() << expr.pretty() << messaget::eom;
-      DATA_INVARIANT(
-        false,
-        "update operand should match array element type");
-    }
+    DATA_INVARIANT_WITH_DIAGNOSTICS(
+      index_expr.type()==value.type(),
+      "update operand should match array element type",
+      irep_pretty_diagnosticst{expr});
 
     set_to_true(equal_exprt(index_expr, value));
   }

--- a/src/solvers/flattening/arrays.h
+++ b/src/solvers/flattening/arrays.h
@@ -29,7 +29,10 @@ class update_exprt;
 class arrayst:public equalityt
 {
 public:
-  arrayst(const namespacet &_ns, propt &_prop);
+  arrayst(
+    const namespacet &_ns,
+    propt &_prop,
+    message_handlert &message_handler);
 
   void post_process() override
   {

--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -191,7 +191,7 @@ bvt boolbvt::convert_bitvector(const exprt &expr)
   else if(expr.id()==ID_member)
     return convert_member(to_member_expr(expr));
   else if(expr.id()==ID_with)
-    return convert_with(expr);
+    return convert_with(to_with_expr(expr));
   else if(expr.id()==ID_update)
     return convert_update(expr);
   else if(expr.id()==ID_width)

--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -32,8 +32,11 @@ class member_exprt;
 class boolbvt:public arrayst
 {
 public:
-  boolbvt(const namespacet &_ns, propt &_prop)
-    : arrayst(_ns, _prop),
+  boolbvt(
+    const namespacet &_ns,
+    propt &_prop,
+    message_handlert &message_handler)
+    : arrayst(_ns, _prop, message_handler),
       unbounded_array(unbounded_arrayt::U_NONE),
       boolbv_width(_ns),
       bv_utils(_prop),

--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -159,7 +159,7 @@ protected:
   virtual bvt convert_floatbv_op(const exprt &expr);
   virtual bvt convert_floatbv_typecast(const floatbv_typecast_exprt &expr);
   virtual bvt convert_member(const member_exprt &expr);
-  virtual bvt convert_with(const exprt &expr);
+  virtual bvt convert_with(const with_exprt &expr);
   virtual bvt convert_update(const exprt &expr);
   virtual bvt convert_case(const exprt &expr);
   virtual bvt convert_cond(const cond_exprt &);

--- a/src/solvers/flattening/boolbv_constant.cpp
+++ b/src/solvers/flattening/boolbv_constant.cpp
@@ -33,8 +33,9 @@ bvt boolbvt::convert_constant(const constant_exprt &expr)
 
       if(tmp.size()!=op_width)
       {
-        error().source_location=expr.find_source_location();
-        error() << "convert_constant: unexpected operand width" << eom;
+        log.error().source_location = expr.find_source_location();
+        log.error() << "convert_constant: unexpected operand width"
+                    << messaget::eom;
         throw 0;
       }
 
@@ -101,9 +102,9 @@ bvt boolbvt::convert_constant(const constant_exprt &expr)
 
     if(binary.size()*2!=width)
     {
-      error().source_location=expr.find_source_location();
-      error() << "wrong value length in constant: "
-              << expr.pretty() << eom;
+      log.error().source_location = expr.find_source_location();
+      log.error() << "wrong value length in constant: " << expr.pretty()
+                  << messaget::eom;
       throw 0;
     }
 
@@ -135,9 +136,9 @@ bvt boolbvt::convert_constant(const constant_exprt &expr)
         break;
 
       default:
-        error().source_location=expr.find_source_location();
-        error() << "unknown character in Verilog constant:"
-                << expr.pretty() << eom;
+        log.error().source_location = expr.find_source_location();
+        log.error() << "unknown character in Verilog constant:" << expr.pretty()
+                    << messaget::eom;
         throw 0;
       }
     }

--- a/src/solvers/flattening/boolbv_constant.cpp
+++ b/src/solvers/flattening/boolbv_constant.cpp
@@ -31,13 +31,10 @@ bvt boolbvt::convert_constant(const constant_exprt &expr)
     {
       const bvt &tmp=convert_bv(*it);
 
-      if(tmp.size()!=op_width)
-      {
-        log.error().source_location = expr.find_source_location();
-        log.error() << "convert_constant: unexpected operand width"
-                    << messaget::eom;
-        throw 0;
-      }
+      DATA_INVARIANT_WITH_DIAGNOSTICS(
+        tmp.size() == op_width,
+        "convert_constant: unexpected operand width",
+        irep_pretty_diagnosticst{expr});
 
       for(std::size_t j=0; j<op_width; j++)
         bv[offset+j]=tmp[j];
@@ -100,13 +97,10 @@ bvt boolbvt::convert_constant(const constant_exprt &expr)
   {
     const std::string &binary=id2string(expr.get_value());
 
-    if(binary.size()*2!=width)
-    {
-      log.error().source_location = expr.find_source_location();
-      log.error() << "wrong value length in constant: " << expr.pretty()
-                  << messaget::eom;
-      throw 0;
-    }
+    DATA_INVARIANT_WITH_DIAGNOSTICS(
+      binary.size() * 2 == width,
+      "wrong value length in constant",
+      irep_pretty_diagnosticst{expr});
 
     for(std::size_t i=0; i<binary.size(); i++)
     {
@@ -136,10 +130,10 @@ bvt boolbvt::convert_constant(const constant_exprt &expr)
         break;
 
       default:
-        log.error().source_location = expr.find_source_location();
-        log.error() << "unknown character in Verilog constant:" << expr.pretty()
-                    << messaget::eom;
-        throw 0;
+        DATA_INVARIANT_WITH_DIAGNOSTICS(
+          false,
+          "unknown character in Verilog constant",
+          irep_pretty_diagnosticst{expr});
       }
     }
 

--- a/src/solvers/flattening/boolbv_with.cpp
+++ b/src/solvers/flattening/boolbv_with.cpp
@@ -19,15 +19,15 @@ bvt boolbvt::convert_with(const exprt &expr)
 {
   if(expr.operands().size()<3)
   {
-    error().source_location=expr.find_source_location();
-    error() << "with takes at least three operands" << eom;
+    log.error().source_location = expr.find_source_location();
+    log.error() << "with takes at least three operands" << messaget::eom;
     throw 0;
   }
 
   if((expr.operands().size()%2)!=1)
   {
-    error().source_location=expr.find_source_location();
-    error() << "with takes an odd number of operands" << eom;
+    log.error().source_location = expr.find_source_location();
+    log.error() << "with takes an odd number of operands" << messaget::eom;
     throw 0;
   }
 
@@ -46,8 +46,8 @@ bvt boolbvt::convert_with(const exprt &expr)
 
   if(bv.size()!=width)
   {
-    error().source_location=expr.find_source_location();
-    error() << "unexpected operand 0 width" << eom;
+    log.error().source_location = expr.find_source_location();
+    log.error() << "unexpected operand 0 width" << messaget::eom;
     throw 0;
   }
 
@@ -100,8 +100,8 @@ void boolbvt::convert_with(
     return convert_with(
       ns.follow_tag(to_union_tag_type(type)), op1, op2, prev_bv, next_bv);
 
-  error().source_location=type.source_location();
-  error() << "unexpected with type: " << type.id() << eom;
+  log.error().source_location = type.source_location();
+  log.error() << "unexpected with type: " << type.id() << messaget::eom;
   throw 0;
 }
 
@@ -115,8 +115,9 @@ void boolbvt::convert_with_array(
   if(is_unbounded_array(type))
   {
     // can't do this
-    error().source_location=type.source_location();
-    error() << "convert_with_array called for unbounded array" << eom;
+    log.error().source_location = type.source_location();
+    log.error() << "convert_with_array called for unbounded array"
+                << messaget::eom;
     throw 0;
   }
 
@@ -126,8 +127,9 @@ void boolbvt::convert_with_array(
 
   if(!size.has_value())
   {
-    error().source_location=type.source_location();
-    error() << "convert_with_array expects constant array size" << eom;
+    log.error().source_location = type.source_location();
+    log.error() << "convert_with_array expects constant array size"
+                << messaget::eom;
     throw 0;
   }
 
@@ -135,8 +137,9 @@ void boolbvt::convert_with_array(
 
   if(*size * op2_bv.size() != prev_bv.size())
   {
-    error().source_location=type.source_location();
-    error() << "convert_with_array: unexpected operand 2 width" << eom;
+    log.error().source_location = type.source_location();
+    log.error() << "convert_with_array: unexpected operand 2 width"
+                << messaget::eom;
     throw 0;
   }
 
@@ -231,19 +234,18 @@ void boolbvt::convert_with_struct(
     {
       if(subtype != op2.type())
       {
-        error().source_location=type.source_location();
-        error() << "with/struct: component `" << component_name
-                << "' type does not match: "
-                << subtype.pretty() << " vs. "
-                << op2.type().pretty() << eom;
+        log.error().source_location = type.source_location();
+        log.error() << "with/struct: component `" << component_name
+                    << "' type does not match: " << subtype.pretty() << " vs. "
+                    << op2.type().pretty() << messaget::eom;
         throw 0;
       }
 
       if(sub_width!=op2_bv.size())
       {
-        error().source_location=type.source_location();
-        error() << "convert_with_struct: unexpected operand op2 width"
-                << eom;
+        log.error().source_location = type.source_location();
+        log.error() << "convert_with_struct: unexpected operand op2 width"
+                    << messaget::eom;
         throw 0;
       }
 
@@ -269,8 +271,9 @@ void boolbvt::convert_with_union(
 
   if(next_bv.size()<op2_bv.size())
   {
-    error().source_location=type.source_location();
-    error() << "convert_with_union: unexpected operand op2 width" << eom;
+    log.error().source_location = type.source_location();
+    log.error() << "convert_with_union: unexpected operand op2 width"
+                << messaget::eom;
     throw 0;
   }
 

--- a/src/solvers/flattening/bv_dimacs.cpp
+++ b/src/solvers/flattening/bv_dimacs.cpp
@@ -25,7 +25,7 @@ bool bv_dimacst::write_dimacs()
 
   if(!out)
   {
-    error() << "failed to open " << filename << eom;
+    log.error() << "failed to open " << filename << messaget::eom;
     return false;
   }
 

--- a/src/solvers/flattening/bv_dimacs.h
+++ b/src/solvers/flattening/bv_dimacs.h
@@ -17,8 +17,12 @@ Author: Daniel Kroening, kroening@kroening.com
 class bv_dimacst : public bv_pointerst
 {
 public:
-  bv_dimacst(const namespacet &_ns, propt &_prop, const std::string &_filename)
-    : bv_pointerst(_ns, _prop), filename(_filename)
+  bv_dimacst(
+    const namespacet &_ns,
+    propt &_prop,
+    message_handlert &message_handler,
+    const std::string &_filename)
+    : bv_pointerst(_ns, _prop, message_handler), filename(_filename)
   {
   }
 

--- a/src/solvers/flattening/bv_minimize.cpp
+++ b/src/solvers/flattening/bv_minimize.cpp
@@ -56,8 +56,7 @@ void bv_minimizet::operator()(const minimization_listt &symbols)
 {
   // build bit-wise objective function
 
-  prop_minimizet prop_minimize(boolbv);
-  prop_minimize.set_message_handler(get_message_handler());
+  prop_minimizet prop_minimize(boolbv, log.get_message_handler());
 
   for(minimization_listt::const_iterator
       l_it=symbols.begin();

--- a/src/solvers/flattening/bv_minimize.h
+++ b/src/solvers/flattening/bv_minimize.h
@@ -22,11 +22,11 @@ Purpose: Find a satisfying assignment that minimizes a given set
 
 typedef std::set<exprt> minimization_listt;
 
-class bv_minimizet:public messaget
+class bv_minimizet
 {
 public:
-  explicit bv_minimizet(boolbvt &_boolbv):
-    boolbv(_boolbv)
+  bv_minimizet(boolbvt &_boolbv, message_handlert &message_handler)
+    : boolbv(_boolbv), log(message_handler)
   {
   }
 
@@ -34,6 +34,7 @@ public:
 
 protected:
   boolbvt &boolbv;
+  messaget log;
 
   void add_objective(
     class prop_minimizet &prop_minimize,
@@ -49,18 +50,20 @@ public:
   }
 
   bv_minimizing_dect(const namespacet &_ns, message_handlert &message_handler)
-    : bv_pointerst(_ns, satcheck), satcheck(message_handler)
+    : bv_pointerst(_ns, satcheck, message_handler),
+      satcheck(message_handler),
+      log(message_handler)
   {
   }
 
   void minimize(const minimization_listt &objectives)
   {
-    bv_minimizet bv_minimize(*this);
-    bv_minimize.set_message_handler(get_message_handler());
+    bv_minimizet bv_minimize{*this, log.get_message_handler()};
     bv_minimize(objectives);
   }
 
   satcheckt satcheck;
+  messaget log;
 };
 
 #endif // CPROVER_SOLVERS_FLATTENING_BV_MINIMIZE_H

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -81,9 +81,9 @@ literalt bv_pointerst::convert_rest(const exprt &expr)
 
 bv_pointerst::bv_pointerst(
   const namespacet &_ns,
-  propt &_prop):
-  boolbvt(_ns, _prop),
-  pointer_logic(_ns)
+  propt &_prop,
+  message_handlert &message_handler)
+  : boolbvt(_ns, _prop, message_handler), pointer_logic(_ns)
 {
   object_bits=config.bv_encoding.object_bits;
   std::size_t pointer_width = boolbv_width(pointer_type(empty_typet()));

--- a/src/solvers/flattening/bv_pointers.h
+++ b/src/solvers/flattening/bv_pointers.h
@@ -17,7 +17,10 @@ Author: Daniel Kroening, kroening@kroening.com
 class bv_pointerst:public boolbvt
 {
 public:
-  bv_pointerst(const namespacet &_ns, propt &_prop);
+  bv_pointerst(
+    const namespacet &_ns,
+    propt &_prop,
+    message_handlert &message_handler);
 
   void post_process() override;
 

--- a/src/solvers/flattening/equality.h
+++ b/src/solvers/flattening/equality.h
@@ -19,7 +19,8 @@ Author: Daniel Kroening, kroening@kroening.com
 class equalityt:public prop_conv_solvert
 {
 public:
-  explicit equalityt(propt &_prop) : prop_conv_solvert(_prop)
+  equalityt(propt &_prop, message_handlert &message_handler)
+    : prop_conv_solvert(_prop, message_handler)
   {
   }
 

--- a/src/solvers/prop/minimize.cpp
+++ b/src/solvers/prop/minimize.cpp
@@ -15,6 +15,18 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "literal_expr.h"
 
+prop_minimizet::prop_minimizet(
+  prop_convt &_prop_conv,
+  message_handlert &message_handler)
+  : _iterations(0),
+    _number_satisfied(0),
+    _number_objectives(0),
+    _value(0),
+    prop_conv(_prop_conv),
+    log(message_handler)
+{
+}
+
 /// Add an objective
 void prop_minimizet::objective(
   const literalt condition,
@@ -106,7 +118,7 @@ void prop_minimizet::operator()()
       current!=objectives.rend();
       current++)
   {
-    status() << "weight " << current->first << eom;
+    log.status() << "weight " << current->first << messaget::eom;
 
     decision_proceduret::resultt dec_result;
     do
@@ -137,7 +149,7 @@ void prop_minimizet::operator()()
           break;
 
         default:
-          error() << "decision procedure failed" << eom;
+          log.error() << "decision procedure failed" << messaget::eom;
           last_was_SAT=false;
           return;
         }

--- a/src/solvers/prop/minimize.cpp
+++ b/src/solvers/prop/minimize.cpp
@@ -18,12 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 prop_minimizet::prop_minimizet(
   prop_convt &_prop_conv,
   message_handlert &message_handler)
-  : _iterations(0),
-    _number_satisfied(0),
-    _number_objectives(0),
-    _value(0),
-    prop_conv(_prop_conv),
-    log(message_handler)
+  : prop_conv(_prop_conv), log(message_handler)
 {
 }
 

--- a/src/solvers/prop/minimize.h
+++ b/src/solvers/prop/minimize.h
@@ -20,17 +20,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 /// Computes a satisfying assignment of minimal cost according to a const
 /// function using incremental SAT
-class prop_minimizet:public messaget
+class prop_minimizet
 {
 public:
-  explicit prop_minimizet(prop_convt &_prop_conv):
-    _iterations(0),
-    _number_satisfied(0),
-    _number_objectives(0),
-    _value(0),
-    prop_conv(_prop_conv)
-  {
-  }
+  prop_minimizet(prop_convt &_prop_conv, message_handlert &message_handler);
 
   void operator()();
 
@@ -77,9 +70,11 @@ public:
 
 protected:
   unsigned _iterations;
-  std::size_t _number_satisfied, _number_objectives;
+  std::size_t _number_satisfied;
+  std::size_t _number_objectives;
   weightt _value;
   prop_convt &prop_conv;
+  messaget log;
 
   literalt constraint();
   void fix_objectives();

--- a/src/solvers/prop/minimize.h
+++ b/src/solvers/prop/minimize.h
@@ -69,10 +69,10 @@ public:
   objectivest objectives;
 
 protected:
-  unsigned _iterations;
-  std::size_t _number_satisfied;
-  std::size_t _number_objectives;
-  weightt _value;
+  unsigned _iterations = 0;
+  std::size_t _number_satisfied = 0;
+  std::size_t _number_objectives = 0;
+  weightt _value = 0;
   prop_convt &prop_conv;
   messaget log;
 

--- a/src/solvers/prop/prop_conv.cpp
+++ b/src/solvers/prop/prop_conv.cpp
@@ -454,7 +454,7 @@ void prop_conv_solvert::ignoring(const exprt &expr)
 {
   // fall through
 
-  warning() << "warning: ignoring " << expr.pretty() << eom;
+  log.warning() << "warning: ignoring " << expr.pretty() << messaget::eom;
 }
 
 void prop_conv_solvert::post_process()
@@ -466,12 +466,12 @@ decision_proceduret::resultt prop_conv_solvert::dec_solve()
   // post-processing isn't incremental yet
   if(!post_processing_done)
   {
-    statistics() << "Post-processing" << eom;
+    log.statistics() << "Post-processing" << messaget::eom;
     post_process();
     post_processing_done=true;
   }
 
-  statistics() << "Solving with " << prop.solver_text() << eom;
+  log.statistics() << "Solving with " << prop.solver_text() << messaget::eom;
 
   switch(prop.prop_solve())
   {

--- a/src/solvers/prop/prop_conv.h
+++ b/src/solvers/prop/prop_conv.h
@@ -54,10 +54,11 @@ public:
 
 /*! \brief TO_BE_DOCUMENTED
 */
-class prop_conv_solvert : public prop_convt, public messaget
+class prop_conv_solvert : public prop_convt
 {
 public:
-  explicit prop_conv_solvert(propt &_prop) : prop(_prop)
+  prop_conv_solvert(propt &_prop, message_handlert &message_handler)
+    : prop(_prop), log(message_handler)
   {
   }
 
@@ -139,6 +140,8 @@ protected:
 
   // deliberately protected now to protect lower-level API
   propt &prop;
+
+  messaget log;
 };
 
 #endif // CPROVER_SOLVERS_PROP_PROP_CONV_H

--- a/src/solvers/refinement/bv_refinement.h
+++ b/src/solvers/refinement/bv_refinement.h
@@ -34,6 +34,7 @@ public:
   {
     const namespacet *ns=nullptr;
     propt *prop=nullptr;
+    message_handlert *message_handler = nullptr;
   };
 
   explicit bv_refinementt(const infot &info);

--- a/src/solvers/refinement/bv_refinement_loop.cpp
+++ b/src/solvers/refinement/bv_refinement_loop.cpp
@@ -10,10 +10,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/xml.h>
 
-bv_refinementt::bv_refinementt(const infot &info):
-  bv_pointerst(*info.ns, *info.prop),
-  progress(false),
-  config_(info)
+bv_refinementt::bv_refinementt(const infot &info)
+  : bv_pointerst(*info.ns, *info.prop, *info.message_handler),
+    progress(false),
+    config_(info)
 {
   // check features we need
   PRECONDITION(prop.has_set_assumptions());
@@ -24,10 +24,10 @@ bv_refinementt::bv_refinementt(const infot &info):
 decision_proceduret::resultt bv_refinementt::dec_solve()
 {
   // do the usual post-processing
-  status() << "BV-Refinement: post-processing" << eom;
+  log.status() << "BV-Refinement: post-processing" << messaget::eom;
   post_process();
 
-  debug() << "Solving with " << prop.solver_text() << eom;
+  log.debug() << "Solving with " << prop.solver_text() << messaget::eom;
 
   unsigned iteration=0;
 
@@ -36,14 +36,14 @@ decision_proceduret::resultt bv_refinementt::dec_solve()
   {
     iteration++;
 
-    status() << "BV-Refinement: iteration " << iteration << eom;
+    log.status() << "BV-Refinement: iteration " << iteration << messaget::eom;
 
     // output the very same information in a structured fashion
     if(config_.output_xml)
     {
       xmlt xml("refinement-iteration");
       xml.data=std::to_string(iteration);
-      status() << xml << '\n';
+      log.status() << xml << '\n';
     }
 
     switch(prop_solve())
@@ -52,27 +52,30 @@ decision_proceduret::resultt bv_refinementt::dec_solve()
       check_SAT();
       if(!progress)
       {
-        status() << "BV-Refinement: got SAT, and it simulates => SAT" << eom;
-        status() << "Total iterations: " << iteration << eom;
+        log.status() << "BV-Refinement: got SAT, and it simulates => SAT"
+                     << messaget::eom;
+        log.status() << "Total iterations: " << iteration << messaget::eom;
         return resultt::D_SATISFIABLE;
       }
       else
-        status() << "BV-Refinement: got SAT, and it is spurious, refining"
-                 << eom;
+        log.status() << "BV-Refinement: got SAT, and it is spurious, refining"
+                     << messaget::eom;
       break;
 
     case resultt::D_UNSATISFIABLE:
       check_UNSAT();
       if(!progress)
       {
-        status() << "BV-Refinement: got UNSAT, and the proof passes => UNSAT"
-                 << eom;
-        status() << "Total iterations: " << iteration << eom;
+        log.status()
+          << "BV-Refinement: got UNSAT, and the proof passes => UNSAT"
+          << messaget::eom;
+        log.status() << "Total iterations: " << iteration << messaget::eom;
         return resultt::D_UNSATISFIABLE;
       }
       else
-        status() << "BV-Refinement: got UNSAT, and the proof fails, refining"
-                 << eom;
+        log.status()
+          << "BV-Refinement: got UNSAT, and the proof fails, refining"
+          << messaget::eom;
       break;
 
     default:

--- a/src/solvers/refinement/refine_arithmetic.cpp
+++ b/src/solvers/refinement/refine_arithmetic.cpp
@@ -204,21 +204,23 @@ void bv_refinementt::check_SAT(approximationt &a)
     if(result.pack()==a.result_value) // ok
       return;
 
-    #ifdef DEBUG
+#ifdef DEBUG
     ieee_floatt rr(spec);
     rr.unpack(a.result_value);
 
-    debug() << "S1: " << o0 << " " << a.expr.id() << " " << o1
-              << " != " << rr << eom;
-    debug() << "S2: " << integer2binary(a.op0_value, spec.width())
-                        << " " << a.expr.id() << " " <<
-                           integer2binary(a.op1_value, spec.width())
-              << "!=" << integer2binary(a.result_value, spec.width()) << eom;
-    debug() << "S3: " << integer2binary(a.op0_value, spec.width())
-                        << " " << a.expr.id() << " " <<
-                           integer2binary(a.op1_value, spec.width())
-              << "==" << integer2binary(result.pack(), spec.width()) << eom;
-    #endif
+    log.debug() << "S1: " << o0 << " " << a.expr.id() << " " << o1
+                << " != " << rr << messaget::eom;
+    log.debug() << "S2: " << integer2binary(a.op0_value, spec.width()) << " "
+                << a.expr.id() << " "
+                << integer2binary(a.op1_value, spec.width())
+                << "!=" << integer2binary(a.result_value, spec.width())
+                << messaget::eom;
+    log.debug() << "S3: " << integer2binary(a.op0_value, spec.width()) << " "
+                << a.expr.id() << " "
+                << integer2binary(a.op1_value, spec.width())
+                << "==" << integer2binary(result.pack(), spec.width())
+                << messaget::eom;
+#endif
 
     if(a.over_state<config_.max_node_refinement)
     {
@@ -351,8 +353,8 @@ void bv_refinementt::check_SAT(approximationt &a)
     UNREACHABLE;
   }
 
-  status() << "Found spurious `" << a.as_string()
-           << "' (state " << a.over_state << ")" << eom;
+  log.status() << "Found spurious `" << a.as_string() << "' (state "
+               << a.over_state << ")" << messaget::eom;
 
   progress=true;
   if(a.over_state<MAX_STATE)
@@ -367,8 +369,8 @@ void bv_refinementt::check_UNSAT(approximationt &a)
   if(!this->conflicts_with(a))
     return;
 
-  status() << "Found assumption for `" << a.as_string()
-           << "' in proof (state " << a.under_state << ")" << eom;
+  log.status() << "Found assumption for `" << a.as_string()
+               << "' in proof (state " << a.under_state << ")" << messaget::eom;
 
   PRECONDITION(!a.under_assumptions.empty());
 

--- a/src/solvers/refinement/refine_arrays.cpp
+++ b/src/solvers/refinement/refine_arrays.cpp
@@ -43,8 +43,8 @@ void bv_refinementt::arrays_overapproximated()
   std::list<lazy_constraintt>::iterator it=lazy_array_constraints.begin();
   while(it!=lazy_array_constraints.end())
   {
-    satcheck_no_simplifiert sat_check(get_message_handler());
-    bv_pointerst solver(ns, sat_check);
+    satcheck_no_simplifiert sat_check{log.get_message_handler()};
+    bv_pointerst solver{ns, sat_check, log.get_message_handler()};
     solver.unbounded_array=bv_pointerst::unbounded_arrayt::U_ALL;
 
     exprt current=(*it).lazy;
@@ -94,10 +94,10 @@ void bv_refinementt::arrays_overapproximated()
     }
   }
 
-  debug() << "BV-Refinement: " << nb_active
-          << " array expressions become active" << eom;
-  debug() << "BV-Refinement: " << lazy_array_constraints.size()
-          << " inactive array expressions" << eom;
+  log.debug() << "BV-Refinement: " << nb_active
+              << " array expressions become active" << messaget::eom;
+  log.debug() << "BV-Refinement: " << lazy_array_constraints.size()
+              << " inactive array expressions" << messaget::eom;
   if(nb_active > 0)
     progress=true;
 }

--- a/src/solvers/smt2/smt2_solver.cpp
+++ b/src/solvers/smt2/smt2_solver.cpp
@@ -373,11 +373,10 @@ int solver(std::istream &in)
   // this is our default verbosity
   message_handler.set_verbosity(messaget::M_STATISTICS);
 
-  satcheckt satcheck(message_handler);
-  boolbvt boolbv(ns, satcheck);
-  boolbv.set_message_handler(message_handler);
+  satcheckt satcheck{message_handler};
+  boolbvt boolbv{ns, satcheck, message_handler};
 
-  smt2_solvert smt2_solver(in, boolbv);
+  smt2_solvert smt2_solver{in, boolbv};
   bool error_found = false;
 
   while(!smt2_solver.exit)

--- a/src/solvers/strings/string_constraint.cpp
+++ b/src/solvers/strings/string_constraint.cpp
@@ -22,7 +22,7 @@ static bool cannot_be_neg(const exprt &expr)
   satcheck_no_simplifiert sat_check(null_message_handler);
   symbol_tablet symbol_table;
   namespacet ns(symbol_table);
-  boolbvt solver(ns, sat_check);
+  boolbvt solver{ns, sat_check, null_message_handler};
   const exprt zero = from_integer(0, expr.type());
   const binary_relation_exprt non_neg(expr, ID_lt, zero);
   solver << non_neg;

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -180,13 +180,12 @@ string_refinementt::string_refinementt(const infot &info)
 static void
 display_index_set(messaget::mstreamt &stream, const index_set_pairt &index_set)
 {
-  const auto eom = messaget::eom;
   std::size_t count = 0;
   std::size_t count_current = 0;
   for(const auto &i : index_set.cumulative)
   {
     const exprt &s = i.first;
-    stream << "IS(" << format(s) << ")=={" << eom;
+    stream << "IS(" << format(s) << ")=={" << messaget::eom;
 
     for(const auto &j : i.second)
     {
@@ -197,13 +196,13 @@ display_index_set(messaget::mstreamt &stream, const index_set_pairt &index_set)
         count_current++;
         stream << "**";
       }
-      stream << "  " << format(j) << ";" << eom;
+      stream << "  " << format(j) << ";" << messaget::eom;
       count++;
     }
-    stream << "}" << eom;
+    stream << "}" << messaget::eom;
   }
   stream << count << " elements in index set (" << count_current
-         << " newly added)" << eom;
+         << " newly added)" << messaget::eom;
 }
 
 /// Instantiation of all constraints
@@ -316,7 +315,6 @@ static void add_equations_for_symbol_resolution(
   const namespacet &ns,
   messaget::mstreamt &stream)
 {
-  const auto eom = messaget::eom;
   const std::string log_message =
     "WARNING string_refinement.cpp generate_symbol_resolution_from_equations:";
   for(const equal_exprt &eq : equations)
@@ -326,14 +324,15 @@ static void add_equations_for_symbol_resolution(
     if(lhs.id() != ID_symbol)
     {
       stream << log_message << "non symbol lhs: " << format(lhs)
-             << " with rhs: " << format(rhs) << eom;
+             << " with rhs: " << format(rhs) << messaget::eom;
       continue;
     }
 
     if(lhs.type() != rhs.type())
     {
       stream << log_message << "non equal types lhs: " << format(lhs)
-             << "\n####################### rhs: " << format(rhs) << eom;
+             << "\n####################### rhs: " << format(rhs)
+             << messaget::eom;
       continue;
     }
 
@@ -366,7 +365,8 @@ static void add_equations_for_symbol_resolution(
       else
       {
         stream << log_message << "non struct with char pointer subexpr "
-               << format(rhs) << "\n  * of type " << format(rhs.type()) << eom;
+               << format(rhs) << "\n  * of type " << format(rhs.type())
+               << messaget::eom;
       }
     }
   }
@@ -473,7 +473,6 @@ union_find_replacet string_identifiers_resolution_from_equations(
   const namespacet &ns,
   messaget::mstreamt &stream)
 {
-  const auto eom = messaget::eom;
   const std::string log_message =
     "WARNING string_refinement.cpp "
     "string_identifiers_resolution_from_equations:";
@@ -509,7 +508,7 @@ union_find_replacet string_identifiers_resolution_from_equations(
       {
         stream << log_message << "non struct with string subtype "
                << format(eq.lhs()) << "\n  * of type "
-               << format(eq.lhs().type()) << eom;
+               << format(eq.lhs().type()) << messaget::eom;
       }
 
       for(const exprt &expr : extract_strings(eq.rhs(), ns))
@@ -618,31 +617,36 @@ static void output_equations(
 decision_proceduret::resultt string_refinementt::dec_solve()
 {
 #ifdef DEBUG
-  debug() << "dec_solve: Initial set of equations" << eom;
-  output_equations(debug(), equations);
+  log.debug() << "dec_solve: Initial set of equations" << messaget::eom;
+  output_equations(log.debug(), equations);
 #endif
 
-  debug() << "dec_solve: Build symbol solver from equations" << eom;
+  log.debug() << "dec_solve: Build symbol solver from equations"
+              << messaget::eom;
   // symbol_resolve is used by get and is kept between calls to dec_solve,
   // that's why we use a class member here
-  add_equations_for_symbol_resolution(symbol_resolve, equations, ns, debug());
+  add_equations_for_symbol_resolution(
+    symbol_resolve, equations, ns, log.debug());
 #ifdef DEBUG
-  debug() << "symbol resolve:" << eom;
+  log.debug() << "symbol resolve:" << messaget::eom;
   for(const auto &pair : symbol_resolve.to_vector())
-    debug() << format(pair.first) << " --> " << format(pair.second) << eom;
+    log.debug() << format(pair.first) << " --> " << format(pair.second)
+                << messaget::eom;
 #endif
 
   const union_find_replacet string_id_symbol_resolve =
-    string_identifiers_resolution_from_equations(equations, ns, debug());
+    string_identifiers_resolution_from_equations(equations, ns, log.debug());
 #ifdef DEBUG
-  debug() << "symbol resolve string:" << eom;
+  log.debug() << "symbol resolve string:" << messaget::eom;
   for(const auto &pair : string_id_symbol_resolve.to_vector())
   {
-    debug() << format(pair.first) << " --> " << format(pair.second) << eom;
+    log.debug() << format(pair.first) << " --> " << format(pair.second)
+                << messaget::eom;
   }
 #endif
 
-  debug() << "dec_solve: Replacing string ids in function applications" << eom;
+  log.debug() << "dec_solve: Replacing string ids in function applications"
+              << messaget::eom;
   for(equal_exprt &eq : equations)
   {
     if(can_cast_expr<function_application_exprt>(eq.rhs()))
@@ -658,11 +662,11 @@ decision_proceduret::resultt string_refinementt::dec_solve()
   make_char_array_pointer_associations(generator, equations);
 
 #ifdef DEBUG
-  output_equations(debug(), equations);
+  output_equations(log.debug(), equations);
 #endif
 
-  debug() << "dec_solve: compute dependency graph and remove function "
-          << "applications captured by the dependencies:" << eom;
+  log.debug() << "dec_solve: compute dependency graph and remove function "
+              << "applications captured by the dependencies:" << messaget::eom;
   std::vector<equal_exprt> local_equations;
   for(const equal_exprt &eq : equations)
   {
@@ -680,29 +684,30 @@ decision_proceduret::resultt string_refinementt::dec_solve()
   equations.clear();
 
 #ifdef DEBUG
-  dependencies.output_dot(debug());
+  dependencies.output_dot(log.debug());
 #endif
 
-  debug() << "dec_solve: add constraints" << eom;
+  log.debug() << "dec_solve: add constraints" << messaget::eom;
   dependencies.add_constraints(generator);
 
 #ifdef DEBUG
-  output_equations(debug(), equations);
+  output_equations(log.debug(), equations);
 #endif
 
 #ifdef DEBUG
-  debug() << "dec_solve: arrays_of_pointers:" << eom;
+  log.debug() << "dec_solve: arrays_of_pointers:" << messaget::eom;
   for(auto pair : generator.array_pool.get_arrays_of_pointers())
   {
-    debug() << "  * " << format(pair.first) << "\t--> " << format(pair.second)
-            << " : " << format(pair.second.type()) << eom;
+    log.debug() << "  * " << format(pair.first) << "\t--> "
+                << format(pair.second) << " : " << format(pair.second.type())
+                << messaget::eom;
   }
 #endif
 
   for(const auto &eq : local_equations)
   {
 #ifdef DEBUG
-    debug() << "dec_solve: set_to " << format(eq) << eom;
+    log.debug() << "dec_solve: set_to " << format(eq) << messaget::eom;
 #endif
     supert::set_to(eq, true);
   }
@@ -714,7 +719,7 @@ decision_proceduret::resultt string_refinementt::dec_solve()
     [&](string_constraintt constraint) {
       constraint.replace_expr(symbol_resolve);
       DATA_INVARIANT(
-        is_valid_string_constraint(error(), ns, constraint),
+        is_valid_string_constraint(log.error(), ns, constraint),
         string_refinement_invariantt(
           "string constraints satisfy their invariant"));
       return constraint;
@@ -758,21 +763,22 @@ decision_proceduret::resultt string_refinementt::dec_solve()
       axioms,
       generator,
       get,
-      debug(),
+      log.debug(),
       ns,
       config_.use_counter_example,
       symbol_resolve,
       not_contain_witnesses);
     if(satisfied)
     {
-      debug() << "check_SAT: the model is correct" << eom;
+      log.debug() << "check_SAT: the model is correct" << messaget::eom;
       return resultt::D_SATISFIABLE;
     }
-    debug() << "check_SAT: got SAT but the model is not correct" << eom;
+    log.debug() << "check_SAT: got SAT but the model is not correct"
+                << messaget::eom;
   }
   else
   {
-    debug() << "check_SAT: got UNSAT or ERROR" << eom;
+    log.debug() << "check_SAT: got UNSAT or ERROR" << messaget::eom;
     return initial_result;
   }
 
@@ -797,19 +803,20 @@ decision_proceduret::resultt string_refinementt::dec_solve()
         axioms,
         generator,
         get,
-        debug(),
+        log.debug(),
         ns,
         config_.use_counter_example,
         symbol_resolve,
         not_contain_witnesses);
       if(satisfied)
       {
-        debug() << "check_SAT: the model is correct" << eom;
+        log.debug() << "check_SAT: the model is correct" << messaget::eom;
         return resultt::D_SATISFIABLE;
       }
 
-      debug() << "check_SAT: got SAT but the model is not correct, refining..."
-              << eom;
+      log.debug()
+        << "check_SAT: got SAT but the model is not correct, refining..."
+        << messaget::eom;
 
       // Since the model is not correct although we got SAT, we need to refine
       // the property we are checking by adding more indices to the index set,
@@ -818,20 +825,20 @@ decision_proceduret::resultt string_refinementt::dec_solve()
       index_sets.current.clear();
       update_index_set(index_sets, ns, current_constraints);
 
-      display_index_set(debug(), index_sets);
+      display_index_set(log.debug(), index_sets);
 
       if(index_sets.current.empty())
       {
         if(axioms.not_contains.empty())
         {
-          error() << "dec_solve: current index set is empty, "
-                  << "this should not happen" << eom;
+          log.error() << "dec_solve: current index set is empty, "
+                      << "this should not happen" << messaget::eom;
           return resultt::D_ERROR;
         }
         else
         {
-          debug() << "dec_solve: current index set is empty, "
-                  << "adding counter examples" << eom;
+          log.debug() << "dec_solve: current index set is empty, "
+                      << "adding counter examples" << messaget::eom;
           for(const auto &counter : counter_examples)
             add_lemma(counter);
         }
@@ -844,13 +851,13 @@ decision_proceduret::resultt string_refinementt::dec_solve()
     }
     else
     {
-      debug() << "check_SAT: default return "
-              << static_cast<int>(refined_result) << eom;
+      log.debug() << "check_SAT: default return "
+                  << static_cast<int>(refined_result) << messaget::eom;
       return refined_result;
     }
   }
-  debug() << "string_refinementt::dec_solve reached the maximum number"
-          << "of steps allowed" << eom;
+  log.debug() << "string_refinementt::dec_solve reached the maximum number"
+              << "of steps allowed" << messaget::eom;
   return resultt::D_ERROR;
 }
 
@@ -920,7 +927,7 @@ void string_refinementt::add_lemma(
   if(simple_lemma.is_true())
   {
 #if 0
-    debug() << "string_refinementt::add_lemma : tautology" << eom;
+    log.debug() << "string_refinementt::add_lemma : tautology" << messaget::eom;
 #endif
     return;
   }
@@ -942,7 +949,7 @@ void string_refinementt::add_lemma(
       ++it;
   }
 
-  debug() << "adding lemma " << format(simple_lemma) << eom;
+  log.debug() << "adding lemma " << format(simple_lemma) << messaget::eom;
 
   prop.l_set_to_true(convert(simple_lemma));
 }
@@ -961,7 +968,6 @@ static optionalt<exprt> get_array(
   messaget::mstreamt &stream,
   const array_string_exprt &arr)
 {
-  const auto eom = messaget::eom;
   const exprt &size = arr.length();
   exprt arr_val = simplify_expr(adjust_if_recursive(super_get(arr), ns), ns);
   exprt size_val = super_get(size);
@@ -974,14 +980,14 @@ static optionalt<exprt> get_array(
   if(size_val.id() != ID_constant)
   {
     stream << "(sr::get_array) string of unknown size: " << format(size_val)
-           << eom;
+           << messaget::eom;
     return {};
   }
 
   auto n_opt = numeric_cast<std::size_t>(size_val);
   if(!n_opt)
   {
-    stream << "(sr::get_array) size is not valid" << eom;
+    stream << "(sr::get_array) size is not valid" << messaget::eom;
     return {};
   }
   std::size_t n = *n_opt;
@@ -989,15 +995,15 @@ static optionalt<exprt> get_array(
   if(n > MAX_CONCRETE_STRING_SIZE)
   {
     stream << "(sr::get_array) long string (size " << format(arr.length())
-           << " = " << n << ") " << format(arr) << eom;
+           << " = " << n << ") " << format(arr) << messaget::eom;
     stream << "(sr::get_array) consider reducing max-nondet-string-length so "
               "that no string exceeds "
            << MAX_CONCRETE_STRING_SIZE
            << " in length and "
               "make sure all functions returning strings are loaded"
-           << eom;
+           << messaget::eom;
     stream << "(sr::get_array) this can also happen on invalid object access"
-           << eom;
+           << messaget::eom;
     return nil_exprt();
   }
 
@@ -1035,26 +1041,26 @@ static exprt get_char_array_and_concretize(
   messaget::mstreamt &stream,
   const array_string_exprt &arr)
 {
-  const auto &eom = messaget::eom;
   stream << "- " << format(arr) << ":\n";
-  stream << std::string(4, ' ') << "- type: " << format(arr.type()) << eom;
+  stream << std::string(4, ' ') << "- type: " << format(arr.type())
+         << messaget::eom;
   const auto arr_model_opt = get_array(super_get, ns, stream, arr);
   if(arr_model_opt)
   {
     stream << std::string(4, ' ') << "- char_array: " << format(*arr_model_opt)
            << '\n';
     stream << std::string(4, ' ')
-           << "- type : " << format(arr_model_opt->type()) << eom;
+           << "- type : " << format(arr_model_opt->type()) << messaget::eom;
     const exprt simple = simplify_expr(*arr_model_opt, ns);
     stream << std::string(4, ' ')
-           << "- simplified_char_array: " << format(simple) << eom;
+           << "- simplified_char_array: " << format(simple) << messaget::eom;
     if(
       const auto concretized_array =
         get_array(super_get, ns, stream, to_array_string_expr(simple)))
     {
       stream << std::string(4, ' ')
              << "- concretized_char_array: " << format(*concretized_array)
-             << eom;
+             << messaget::eom;
 
       if(
         const auto array_expr =
@@ -1064,12 +1070,13 @@ static exprt get_char_array_and_concretize(
                << string_of_array(*array_expr) << "\"\n";
       }
       else
-        stream << std::string(2, ' ') << "- warning: not an array" << eom;
+        stream << std::string(2, ' ') << "- warning: not an array"
+               << messaget::eom;
       return *concretized_array;
     }
     return simple;
   }
-  stream << std::string(4, ' ') << "- incomplete model" << eom;
+  stream << std::string(4, ' ') << "- incomplete model" << messaget::eom;
   return arr;
 }
 
@@ -1315,7 +1322,6 @@ static std::pair<bool, std::vector<exprt>> check_axioms(
   const std::unordered_map<string_not_contains_constraintt, symbol_exprt>
     &not_contain_witnesses)
 {
-  const auto eom = messaget::eom;
   // clang-format off
   const auto gen_symbol = [&](const irep_idt &id, const typet &type)
   {
@@ -1323,13 +1329,13 @@ static std::pair<bool, std::vector<exprt>> check_axioms(
   };
   // clang-format on
 
-  stream << "string_refinementt::check_axioms:" << eom;
+  stream << "string_refinementt::check_axioms:" << messaget::eom;
 
-  stream << "symbol_resolve:" << eom;
+  stream << "symbol_resolve:" << messaget::eom;
   auto pairs = symbol_resolve.to_vector();
   for(const auto &pair : pairs)
     stream << "  - " << format(pair.first) << " --> " << format(pair.second)
-           << eom;
+           << messaget::eom;
 
 #ifdef DEBUG
   debug_model(
@@ -1340,7 +1346,7 @@ static std::pair<bool, std::vector<exprt>> check_axioms(
   std::map<size_t, exprt> violated;
 
   stream << "string_refinement::check_axioms: " << axioms.universal.size()
-         << " universal axioms:" << eom;
+         << " universal axioms:" << messaget::eom;
   for(size_t i = 0; i < axioms.universal.size(); i++)
   {
     const string_constraintt &axiom = axioms.universal[i];
@@ -1368,18 +1374,18 @@ static std::pair<bool, std::vector<exprt>> check_axioms(
     {
       stream << std::string(4, ' ')
              << "- violated_for: " << format(axiom.univ_var) << "="
-             << format(*witness) << eom;
+             << format(*witness) << messaget::eom;
       violated[i] = *witness;
     }
     else
-      stream << std::string(4, ' ') << "- correct" << eom;
+      stream << std::string(4, ' ') << "- correct" << messaget::eom;
   }
 
   // Maps from indexes of violated not_contains axiom to a witness of violation
   std::map<std::size_t, exprt> violated_not_contains;
 
   stream << "there are " << axioms.not_contains.size() << " not_contains axioms"
-         << eom;
+         << messaget::eom;
   for(std::size_t i = 0; i < axioms.not_contains.size(); i++)
   {
     const string_not_contains_constraintt &nc_axiom = axioms.not_contains[i];
@@ -1400,22 +1406,22 @@ static std::pair<bool, std::vector<exprt>> check_axioms(
     {
       stream << std::string(4, ' ')
              << "- violated_for: " << univ_var.get_identifier() << "="
-             << format(*witness) << eom;
+             << format(*witness) << messaget::eom;
       violated_not_contains[i] = *witness;
     }
   }
 
   if(violated.empty() && violated_not_contains.empty())
   {
-    stream << "no violated property" << eom;
+    stream << "no violated property" << messaget::eom;
     return {true, std::vector<exprt>()};
   }
   else
   {
     stream << violated.size() << " universal string axioms can be violated"
-           << eom;
+           << messaget::eom;
     stream << violated_not_contains.size()
-           << " not_contains string axioms can be violated" << eom;
+           << " not_contains string axioms can be violated" << messaget::eom;
 
     if(use_counter_example)
     {
@@ -2083,7 +2089,7 @@ exprt string_refinementt::get(const exprt &expr) const
         dependencies.eval(arr, [&](const exprt &expr) { return get(expr); }))
       return *from_dependencies;
 
-    if(const auto arr_model_opt = get_array(super_get, ns, debug(), arr))
+    if(const auto arr_model_opt = get_array(super_get, ns, log.debug(), arr))
       return *arr_model_opt;
 
     if(generator.array_pool.created_strings().count(arr))
@@ -2117,7 +2123,7 @@ static optionalt<exprt> find_counter_example(
   message_handlert &message_handler)
 {
   satcheck_no_simplifiert sat_check(message_handler);
-  boolbvt solver(ns, sat_check);
+  boolbvt solver(ns, sat_check, message_handler);
   solver << axiom;
 
   if(solver() == decision_proceduret::resultt::D_SATISFIABLE)
@@ -2204,7 +2210,6 @@ static bool is_valid_string_constraint(
   const namespacet &ns,
   const string_constraintt &constraint)
 {
-  const auto eom = messaget::eom;
   const array_index_mapt body_indices = gather_indices(constraint.body);
   // Must validate for each string. Note that we have an invariant that the
   // second value in the pair is non-empty.
@@ -2220,7 +2225,7 @@ static bool is_valid_string_constraint(
       if(result.is_false())
       {
         stream << "Indices not equal: " << to_string(constraint)
-               << ", str: " << format(pair.first) << eom;
+               << ", str: " << format(pair.first) << messaget::eom;
         return false;
       }
     }
@@ -2229,7 +2234,7 @@ static bool is_valid_string_constraint(
     if(!is_linear_arithmetic_expr(rep, constraint.univ_var))
     {
       stream << "f is not linear: " << to_string(constraint)
-             << ", str: " << format(pair.first) << eom;
+             << ", str: " << format(pair.first) << messaget::eom;
       return false;
     }
 
@@ -2238,7 +2243,7 @@ static bool is_valid_string_constraint(
     if(!universal_only_in_index(constraint))
     {
       stream << "Universal variable outside of index:" << to_string(constraint)
-             << eom;
+             << messaget::eom;
       return false;
     }
   }

--- a/unit/solvers/bdd/miniBDD/miniBDD.cpp
+++ b/unit/solvers/bdd/miniBDD/miniBDD.cpp
@@ -190,7 +190,7 @@ SCENARIO("miniBDD", "[core][solver][miniBDD]")
   {
     mini_bdd_mgrt bdd_mgr;
     bdd_propt bdd_prop(bdd_mgr);
-    prop_conv_solvert solver(bdd_prop);
+    prop_conv_solvert solver(bdd_prop, null_message_handler);
 
     symbol_exprt var("x", bool_typet());
     literalt result = solver.convert(and_exprt(var, not_exprt(var)));
@@ -204,7 +204,7 @@ SCENARIO("miniBDD", "[core][solver][miniBDD]")
     namespacet ns(symbol_table);
     mini_bdd_mgrt bdd_mgr;
     bdd_propt bdd_prop(bdd_mgr);
-    boolbvt boolbv(ns, bdd_prop);
+    boolbvt boolbv(ns, bdd_prop, null_message_handler);
 
     unsignedbv_typet type(2);
     symbol_exprt var("x", type);
@@ -222,7 +222,7 @@ SCENARIO("miniBDD", "[core][solver][miniBDD]")
     namespacet ns(symbol_table);
     mini_bdd_mgrt bdd_mgr;
     bdd_propt bdd_prop(bdd_mgr);
-    boolbvt boolbv(ns, bdd_prop);
+    boolbvt boolbv(ns, bdd_prop, null_message_handler);
 
     unsignedbv_typet type(32);
     symbol_exprt var("x", type);
@@ -239,7 +239,7 @@ SCENARIO("miniBDD", "[core][solver][miniBDD]")
     namespacet ns(symbol_table);
     mini_bdd_mgrt bdd_mgr;
     bdd_propt bdd_prop(bdd_mgr);
-    boolbvt boolbv(ns, bdd_prop);
+    boolbvt boolbv(ns, bdd_prop, null_message_handler);
 
     unsignedbv_typet type(4);
     symbol_exprt var_x("x", type);
@@ -257,7 +257,7 @@ SCENARIO("miniBDD", "[core][solver][miniBDD]")
     namespacet ns(symbol_table);
     mini_bdd_mgrt bdd_mgr;
     bdd_propt bdd_prop(bdd_mgr);
-    boolbvt boolbv(ns, bdd_prop);
+    boolbvt boolbv(ns, bdd_prop, null_message_handler);
 
     unsignedbv_typet type(8);
     symbol_exprt var_x("x", type);
@@ -274,7 +274,7 @@ SCENARIO("miniBDD", "[core][solver][miniBDD]")
     namespacet ns(symbol_table);
     mini_bdd_mgrt bdd_mgr;
     bdd_propt bdd_prop(bdd_mgr);
-    boolbvt boolbv(ns, bdd_prop);
+    boolbvt boolbv(ns, bdd_prop, null_message_handler);
 
     unsignedbv_typet type(8);
     symbol_exprt var_x("x", type);


### PR DESCRIPTION
Gets a log member instead.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
