### PR TITLE
Do not build a counterexample trace unless requested

### DIFF
--- a/jbmc/regression/jbmc-strings/string-non-empty-option/test_non_empty.desc
+++ b/jbmc/regression/jbmc-strings/string-non-empty-option/test_non_empty.desc
@@ -7,3 +7,5 @@ assertion.* line 11 function java::Test.checkMinLength.*: SUCCESS
 assertion.* line 13 function java::Test.checkMinLength.*: SUCCESS
 assertion.* line 17 function java::Test.checkMinLength.*: FAILURE
 assertion.* line 19 function java::Test.checkMinLength.*: FAILURE
+--
+^Building error trace

--- a/jbmc/src/jbmc/all_properties.cpp
+++ b/jbmc/src/jbmc/all_properties.cpp
@@ -43,7 +43,11 @@ void bmc_all_propertiest::goal_covered(const cover_goalst::goalt &)
       if(solver.l_get(cond).is_false())
       {
         g.second.status = goalt::statust::FAILURE;
-        build_goto_trace(bmc.equation, c, solver, bmc.ns, g.second.goto_trace);
+        if(bmc.options.get_bool_option("trace"))
+        {
+          build_goto_trace(
+            bmc.equation, c, solver, bmc.ns, g.second.goto_trace);
+        }
         break;
       }
     }

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -158,9 +158,13 @@ void jbmc_parse_optionst::get_command_line_options(optionst &options)
     options.set_option("stop-on-fail", true);
 
   if(
-    cmdline.isset("trace") || cmdline.isset("stack-trace") ||
-    cmdline.isset("stop-on-fail"))
+    cmdline.isset("trace") || cmdline.isset("compact-trace") ||
+    cmdline.isset("stack-trace") || cmdline.isset("stop-on-fail") ||
+    (ui_message_handler.get_ui() != ui_message_handlert::uit::PLAIN &&
+     !cmdline.isset("cover")))
+  {
     options.set_option("trace", true);
+  }
 
   if(cmdline.isset("localize-faults"))
     options.set_option("localize-faults", true);

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -227,7 +227,9 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
 
   if(
     cmdline.isset("trace") || cmdline.isset("compact-trace") ||
-    cmdline.isset("stack-trace") || cmdline.isset("stop-on-fail"))
+    cmdline.isset("stack-trace") || cmdline.isset("stop-on-fail") ||
+    (ui_message_handler.get_ui() != ui_message_handlert::uit::PLAIN &&
+     !cmdline.isset("cover")))
   {
     options.set_option("trace", true);
   }

--- a/src/goto-checker/all_properties_verifier_with_trace_storage.h
+++ b/src/goto-checker/all_properties_verifier_with_trace_storage.h
@@ -45,14 +45,17 @@ public:
         break;
 
       // we've got an error trace
-      message_building_error_trace(log);
-      for(const auto &property_id : result.updated_properties)
+      if(options.get_bool_option("trace"))
       {
-        if(properties.at(property_id).status == property_statust::FAIL)
+        message_building_error_trace(log);
+        for(const auto &property_id : result.updated_properties)
         {
-          // get correctly truncated error trace for property and store it
-          (void)traces.insert(
-            incremental_goto_checker.build_trace(property_id));
+          if(properties.at(property_id).status == property_statust::FAIL)
+          {
+            // get correctly truncated error trace for property and store it
+            (void)traces.insert(
+              incremental_goto_checker.build_trace(property_id));
+          }
         }
       }
 
@@ -64,10 +67,7 @@ public:
 
   void report() override
   {
-    if(
-      options.get_bool_option("trace") ||
-      // currently --trace only affects plain text output
-      ui_message_handler.get_ui() != ui_message_handlert::uit::PLAIN)
+    if(options.get_bool_option("trace"))
     {
       const trace_optionst trace_options(options);
       output_properties_with_traces(


### PR DESCRIPTION
On the specific test that now checks that the error trace is not being
built, this reduces the memory footprint from 3GB to 14MB. (This is due
to the size of the string being constructed, which cannot be limited
here as numeric overflow is being tested.)

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
