### PR TITLE
Add codecov

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,10 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
             COMMAND ${CODE_COVERAGE_LCOV} ${LCOV_FLAGS} --remove ${CODE_COVERAGE_INFO_FILE} '/usr/*' --output-file ${CODE_COVERAGE_INFO_FILE}
             COMMAND ${CODE_COVERAGE_GENHTML} ${CODE_COVERAGE_INFO_FILE} --output-directory ${CODE_COVERAGE_OUTPUT_DIR}
             DEPENDS
-              java-models-library java-unit unit
+              java-models-library
+              "$<TARGET_FILE:java-unit>"
+              "$<TARGET_FILE:unit>"
+              "$<TARGET_FILE:goto-harness>"
               "$<TARGET_FILE:cbmc>"
               "$<TARGET_FILE:driver>"
               "$<TARGET_FILE:goto-analyzer>"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ![Build Status][codebuild_img]
 ![Build Status][codebuild_windows_img]
 [![Build Status][coverity_img]][coverity]
+[![Build Status][codecov_img]][codecov]
 
 [CProver Wiki](http://www.cprover.org/wiki)
 
@@ -59,3 +60,5 @@ License
 [codebuild_windows_img]: https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiTFQ4Q0lCSEc1Rk5NcmlzaFZDdU44Vk8zY0c1VCtIVWMwWnJMRitmVFI5bE94Q3dhekVPMWRobFU2Q0xTTlpDSWZUQ3J1eksrWW1rSll1OExXdll2bExZPSIsIml2UGFyYW1ldGVyU3BlYyI6InpqcloyaEdxbjBiQUtvNysiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=develop
 [coverity]: https://scan.coverity.com/projects/diffblue-cbmc
 [coverity_img]: https://scan.coverity.com/projects/13552/badge.svg
+[codecov]: https://codecov.io/gh/diffblue/cbmc
+[codecov_img]: https://codecov.io/gh/diffblue/cbmc/branch/develop/graphs/badge.svg

--- a/buildspec-linux-cmake-gcc-cov.yml
+++ b/buildspec-linux-cmake-gcc-cov.yml
@@ -1,0 +1,37 @@
+version: 0.2
+
+env:
+  variables:
+    # CodeBuild console doesn't display color codes correctly
+    TESTPL_COLOR_OUTPUT: 0
+
+phases:
+  install:
+    runtime-versions:
+      java: openjdk8    
+    commands:
+      - sed -i 's#/archive.ubuntu.com#/us-east-1.ec2.archive.ubuntu.com#g' /etc/apt/sources.list
+      - add-apt-repository ppa:ubuntu-toolchain-r/test
+      - apt-get update -y
+      - apt-get install -y flex bison make git libwww-perl patch ccache libc6-dev-i386 jq lcov cmake curl gdb python-pip
+      - pip install codecov
+  build:
+    commands:
+      - echo Build started on `date`
+      - git submodule update --init --recursive
+      - cmake -H. -Bbuild '-Denable_coverage=1' '-Dparallel_tests=2' '-DCMAKE_CXX_COMPILER=/usr/bin/g++'
+      - cmake --build build --target coverage -- -j2
+  post_build:
+    commands:
+      - lcov --capture --directory build --output-file ./lcov.info
+      - VCS_PULL_REQUEST=$(echo $CODEBUILD_SOURCE_VERSION | sed 's/pr\///g')
+      - COV_SCRIPT=/root/.cache/codecov.sh
+      - if [ ! -f "$COV_SCRIPT" ]; then curl -s https://codecov.io/bash > "$COV_SCRIPT"; fi
+      - echo "$CODEBUILD_INITIATOR" | grep GitHub && bash "$COV_SCRIPT" -t "$CODECOV_TOKEN" || true
+      - echo Build completed on `date`
+cache:
+  paths:
+    - '/var/cache/apt/**/*'
+    - '/var/lib/apt/lists/**/*'
+    - '/root/.ccache/**/*'
+    - '/root/.cache/codecov.sh'

--- a/buildspec-linux-make-gcc-cov.yml
+++ b/buildspec-linux-make-gcc-cov.yml
@@ -1,0 +1,46 @@
+version: 0.2
+
+env:
+  variables:
+    # CodeBuild console doesn't display color codes correctly
+    TESTPL_COLOR_OUTPUT: 0
+
+phases:
+  install:
+    runtime-versions:
+      java: openjdk8
+    commands:
+      - sed -i 's#/archive.ubuntu.com#/us-east-1.ec2.archive.ubuntu.com#g' /etc/apt/sources.list
+      - apt-get update -y
+      - apt-get install -y flex bison make git libwww-perl patch ccache libc6-dev-i386 jq gdb lcov curl python-pip
+      - pip install codecov
+  build:
+    commands:
+      - echo Build started on `date`
+      - make -C src minisat2-download
+      - make -C jbmc/src setup-submodules
+      - make -C src CXX="ccache g++" -j2 CPROVER_WITH_PROFILING=1
+      - make -C unit CXX="ccache g++" -j2 CPROVER_WITH_PROFILING=1
+      - make -C jbmc/src CXX="ccache g++" -j2 CPROVER_WITH_PROFILING=1
+      - make -C jbmc/unit CXX="ccache g++" -j2 CPROVER_WITH_PROFILING=1
+  post_build:
+    commands:
+      - make -C unit test 
+      - make -C regression test CPROVER_WITH_PROFILING=1
+      - make -C regression/cbmc test-paths-lifo
+      - env PATH=$PATH:`pwd`/src/solvers make -C regression/cbmc test-cprover-smt2
+      - make -C jbmc/unit test
+      - make -C jbmc/regression test
+      - lcov --capture --directory . --output-file ./lcov.info
+      - VCS_PULL_REQUEST=$(echo $CODEBUILD_SOURCE_VERSION | sed 's/pr\///g')
+      - COV_SCRIPT=/root/.cache/codecov.sh
+      - if [ ! -f "$COV_SCRIPT" ]; then curl -s https://codecov.io/bash > "$COV_SCRIPT"; fi
+      - echo "$CODEBUILD_INITIATOR" | grep GitHub && bash "$COV_SCRIPT" -t "$CODECOV_TOKEN" || true      
+      - echo Build completed on `date`
+cache:
+  paths:
+    - '/var/cache/apt/**/*'
+    - '/var/lib/apt/lists/**/*'
+    - '/root/.ccache/**/*'
+    - '/root/.cache/codecov.sh'
+  

--- a/buildspec-linux-make-gcc-cov.yml
+++ b/buildspec-linux-make-gcc-cov.yml
@@ -43,4 +43,3 @@ cache:
     - '/var/lib/apt/lists/**/*'
     - '/root/.ccache/**/*'
     - '/root/.cache/codecov.sh'
-  

--- a/src/config.inc
+++ b/src/config.inc
@@ -8,6 +8,11 @@ else
   CXXFLAGS += -Wall -pedantic -Werror -Wno-deprecated-declarations -Wswitch-enum
 endif
 
+ifeq ($(CPROVER_WITH_PROFILING),1)
+  CXXFLAGS += -fprofile-arcs -ftest-coverage
+  LINKFLAGS += -lgcov -fprofile-arcs
+endif
+
 # Select optimisation or debug info
 #CXXFLAGS += -O2 -DNDEBUG
 #CXXFLAGS += -O0 -g


### PR DESCRIPTION
The purpose of this PR is to understand current CBMC coverage.

Below are justification of why I created `buildspec-linux-make-gcc-cov.yml` and modified `config.inc`

`travis` vs. `CodeBuild`
:cry: `travis` has timeout = `50min` and maximum log length `10k`

:cry: codecov does not support CodeBuild
:hammer: Therefore `CODECOV_TOKEN` needs to be set as a environment variable in Build detail (not in buildspec.xml)
:hammer: In order to coverage reporting available, needed to install `lcov`, `curl`, `python-pip`, then `pip install codecov` (This is to hope `codecov.sh` find all `gcda` files)

`cmake` vs. `make`

:disappointed: `make` with `CXXFLAGS` in the same line causes compile error
:hammer: to mitigate this, in `config.inc`, a new environment variable `CPROVER_WITH_PROFILING` with `CXXFLAGS` and `LINKFLAGS` are added
:hammer: append `CPROVER_WITH_PROFILING=1` is added for each `make` and also `make -C regression test` as it's calling `driver` which also require coverage instrumentation
:grey_question: `cmake` and `make` shows different statistics 
:grey_question: it is unclear why it's reported failure when build is complete for `cmake`

`codecov script`
:disappointed: `bash` does not work on `CodeBuild`
:hammer: use the 4 line shell scripts

`lcov`
:disappointed: `codecov.sh` does not find `gcda` files for some reasons, so had to generate coverage info file using `lcov`

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
