### PR TITLE
Factor out solver resource limits capability

### DIFF
--- a/src/goto-checker/solver_factory.cpp
+++ b/src/goto-checker/solver_factory.cpp
@@ -27,6 +27,7 @@ Author: Daniel Kroening, Peter Schrammel
 #include <solvers/flattening/bv_dimacs.h>
 #include <solvers/prop/prop.h>
 #include <solvers/prop/prop_conv.h>
+#include <solvers/prop/solver_resource_limits.h>
 #include <solvers/refinement/bv_refinement.h>
 #include <solvers/sat/dimacs_cnf.h>
 #include <solvers/sat/satcheck.h>
@@ -79,8 +80,21 @@ void solver_factoryt::set_prop_conv_time_limit(prop_convt &prop_conv)
 {
   const int timeout_seconds =
     options.get_signed_int_option("solver-time-limit");
+
   if(timeout_seconds > 0)
-    prop_conv.set_time_limit_seconds(timeout_seconds);
+  {
+    solver_resource_limitst *solver =
+      dynamic_cast<solver_resource_limitst *>(&prop_conv);
+    if(solver == nullptr)
+    {
+      messaget log(message_handler);
+      log.warning() << "cannot set solver time limit on "
+                    << prop_conv.decision_procedure_text() << messaget::eom;
+      return;
+    }
+
+    solver->set_time_limit_seconds(timeout_seconds);
+  }
 }
 
 void solver_factoryt::solvert::set_prop_conv(std::unique_ptr<prop_convt> p)

--- a/src/solvers/prop/prop_conv.h
+++ b/src/solvers/prop/prop_conv.h
@@ -42,9 +42,6 @@ public:
   // returns true if an assumption is in the final conflict
   virtual bool is_in_conflict(literalt l) const;
   virtual bool has_is_in_conflict() const { return false; }
-
-  // Resource limits:
-  virtual void set_time_limit_seconds(uint32_t) {}
 };
 
 //

--- a/src/solvers/prop/prop_conv_solver.h
+++ b/src/solvers/prop/prop_conv_solver.h
@@ -21,8 +21,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "literal_expr.h"
 #include "prop.h"
 #include "prop_conv.h"
+#include "solver_resource_limits.h"
 
-class prop_conv_solvert : public prop_convt
+class prop_conv_solvert : public prop_convt, public solver_resource_limitst
 {
 public:
   prop_conv_solvert(propt &_prop, message_handlert &message_handler)

--- a/src/solvers/prop/solver_resource_limits.h
+++ b/src/solvers/prop/solver_resource_limits.h
@@ -1,0 +1,24 @@
+/*******************************************************************\
+
+Module: Solver capability to set resource limits
+
+Author: Peter Schrammel
+
+\*******************************************************************/
+
+/// \file
+/// Solver capability to set resource limits
+
+#ifndef CPROVER_SOLVERS_PROP_SOLVER_RESOURCE_LIMITS_H
+#define CPROVER_SOLVERS_PROP_SOLVER_RESOURCE_LIMITS_H
+
+class solver_resource_limitst
+{
+public:
+  /// Set the limit for the solver to time out in seconds
+  virtual void set_time_limit_seconds(uint32_t) = 0;
+
+  virtual ~solver_resource_limitst() = default;
+};
+
+#endif // CPROVER_SOLVERS_PROP_SOLVER_RESOURCE_LIMITS_H


### PR DESCRIPTION
That need not be a part of prop_convt.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
