### PR TITLE
Make renamedt inherit from underlyingt

### DIFF
--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -261,12 +261,12 @@ goto_symex_statet::rename(exprt expr, const namespacet &ns)
     if(level == L0)
     {
       return renamedt<exprt, level>{
-        std::move(rename_ssa<L0>(std::move(ssa), ns).value)};
+        std::move(rename_ssa<L0>(std::move(ssa), ns).value())};
     }
     else if(level == L1)
     {
       return renamedt<exprt, level>{
-        std::move(rename_ssa<L1>(std::move(ssa), ns).value)};
+        std::move(rename_ssa<L1>(std::move(ssa), ns).value())};
     }
     else if(level==L2)
     {

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -50,27 +50,27 @@ operator()(renamedt<ssa_exprt, L0> l0_expr) const
     !l0_expr.get().get_level_1().empty() ||
     !l0_expr.get().get_level_2().empty())
   {
-    return renamedt<ssa_exprt, L1>{std::move(l0_expr.value)};
+    return renamedt<ssa_exprt, L1>{std::move(l0_expr.value())};
   }
 
   const irep_idt l0_name = l0_expr.get().get_l1_object_identifier();
 
   const auto it = current_names.find(l0_name);
   if(it == current_names.end())
-    return renamedt<ssa_exprt, L1>{std::move(l0_expr.value)};
+    return renamedt<ssa_exprt, L1>{std::move(l0_expr.value())};
 
   // rename!
-  l0_expr.value.set_level_1(it->second.second);
-  return renamedt<ssa_exprt, L1>{std::move(l0_expr.value)};
+  l0_expr.value().set_level_1(it->second.second);
+  return renamedt<ssa_exprt, L1>{std::move(l0_expr.value())};
 }
 
 renamedt<ssa_exprt, L2> symex_level2t::
 operator()(renamedt<ssa_exprt, L1> l1_expr) const
 {
   if(!l1_expr.get().get_level_2().empty())
-    return renamedt<ssa_exprt, L2>{std::move(l1_expr.value)};
-  l1_expr.value.set_level_2(current_count(l1_expr.get().get_identifier()));
-  return renamedt<ssa_exprt, L2>{std::move(l1_expr.value)};
+    return renamedt<ssa_exprt, L2>{std::move(l1_expr.value())};
+  l1_expr.value().set_level_2(current_count(l1_expr.get().get_identifier()));
+  return renamedt<ssa_exprt, L2>{std::move(l1_expr.value())};
 }
 
 void symex_level1t::restore_from(const current_namest &other)

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -69,7 +69,7 @@ struct symex_renaming_levelt
 /// Wrapper for expressions or types which have been renamed up to a given
 /// \p level
 template <typename underlyingt, levelt level>
-class renamedt
+class renamedt : private underlyingt
 {
 public:
   static_assert(
@@ -79,16 +79,19 @@ public:
 
   const underlyingt &get() const
   {
-    return value;
+    return static_cast<const underlyingt &>(*this);
   }
 
   void simplify(const namespacet &ns)
   {
-    (void)::simplify(value, ns);
+    (void)::simplify(value(), ns);
   }
 
 private:
-  underlyingt value;
+  underlyingt &value()
+  {
+    return static_cast<underlyingt &>(*this);
+  };
 
   friend struct symex_level0t;
   friend struct symex_level1t;
@@ -96,7 +99,7 @@ private:
   friend class goto_symex_statet;
 
   /// Only the friend classes can create renamedt objects
-  explicit renamedt(underlyingt value) : value(std::move(value))
+  explicit renamedt(underlyingt value) : underlyingt(std::move(value))
   {
   }
 };


### PR DESCRIPTION
This is so that we can easily convert from an exprt to a renamedt using
static_cast.
The potential use case, is to be able to look at all the operands of a
renamedt, as renamedt themselves without having to construct new
objects.
For instanc, we could declare a renamedt method:
```
void renamedt::apply_to_operands(std::function<void(renamedt&)> f)
{
  for(exprt &op : operands())
    f(static_cast<renamedt&>(op));
}
```
The idea for correctness is that if an expression is renamed then all its operands also are, by construction.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
