### PR TITLE
Ensure typet constructor is always compatible with GCC 5's STL [blocks: #4458]

### DIFF
--- a/src/util/type.h
+++ b/src/util/type.h
@@ -32,10 +32,17 @@ public:
 
   explicit typet(const irep_idt &_id):irept(_id) { }
 
+#if defined(__clang__) || !defined(__GNUC__) || __GNUC__ >= 6
   typet(irep_idt _id, typet _subtype)
     : irept(std::move(_id), {}, {std::move(_subtype)})
   {
   }
+#else
+  typet(irep_idt _id, typet _subtype) : irept(std::move(_id))
+  {
+    subtype() = std::move(_subtype);
+  }
+#endif
 
   const typet &subtype() const
   {


### PR DESCRIPTION
When enabling NAMED_SUB_IS_FORWARD_LIST, compilation failed as the
std::forward_list constructors shipped with GCC 5 do not support an
empty initializer list. GCC 6 and later do not have any such problem.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
