### PR TITLE
Remove value_sett::idt [blocks: #4463]

### DIFF
--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -48,14 +48,13 @@ bool value_sett::field_sensitive(const irep_idt &id, const typet &type)
   return type.id() == ID_struct || type.id() == ID_struct_tag;
 }
 
-value_sett::entryt *value_sett::find_entry(const value_sett::idt &id)
+value_sett::entryt *value_sett::find_entry(const irep_idt &id)
 {
   auto found = values.find(id);
   return found == values.end() ? nullptr : &found->second;
 }
 
-const value_sett::entryt *
-value_sett::find_entry(const value_sett::idt &id) const
+const value_sett::entryt *value_sett::find_entry(const irep_idt &id) const
 {
   auto found = values.find(id);
   return found == values.end() ? nullptr : &found->second;
@@ -70,8 +69,8 @@ value_sett::entryt &value_sett::get_entry(const entryt &e, const typet &type)
   else
     index=e.identifier;
 
-  std::pair<valuest::iterator, bool> r=
-    values.insert(std::pair<idt, entryt>(index, e));
+  std::pair<valuest::iterator, bool> r =
+    values.insert(std::pair<irep_idt, entryt>(index, e));
 
   return r.first->second;
 }

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -72,8 +72,6 @@ public:
   /// in value sets.
   static object_numberingt object_numbering;
 
-  typedef irep_idt idt;
-
   /// Represents the offset into an object: either a unique integer offset,
   /// or an unknown value, represented by `!offset`.
   typedef optionalt<mp_integer> offsett;
@@ -249,16 +247,15 @@ public:
   struct entryt
   {
     object_mapt object_map;
-    idt identifier;
+    irep_idt identifier;
     std::string suffix;
 
     entryt()
     {
     }
 
-    entryt(const idt &_identifier, const std::string &_suffix):
-      identifier(_identifier),
-      suffix(_suffix)
+    entryt(const irep_idt &_identifier, const std::string &_suffix)
+      : identifier(_identifier), suffix(_suffix)
     {
     }
 
@@ -297,11 +294,11 @@ public:
   ///
   /// The components of the ID are thus duplicated in the `valuest` key and in
   /// `entryt` fields.
-  #ifdef USE_DSTRING
-  typedef std::map<idt, entryt> valuest;
-  #else
-  typedef std::unordered_map<idt, entryt, string_hash> valuest;
-  #endif
+#ifdef USE_DSTRING
+  typedef std::map<irep_idt, entryt> valuest;
+#else
+  typedef std::unordered_map<irep_idt, entryt, string_hash> valuest;
+#endif
 
   /// Gets values pointed to by `expr`, including following dereference
   /// operators (i.e. this is not a simple lookup in `valuest`).
@@ -314,9 +311,7 @@ public:
     const namespacet &ns) const;
 
   /// Appears to be unimplemented.
-  expr_sett &get(
-    const idt &identifier,
-    const std::string &suffix);
+  expr_sett &get(const irep_idt &identifier, const std::string &suffix);
 
   void clear()
   {
@@ -330,10 +325,10 @@ public:
   /// \return a constant pointer to an entry if found, or null otherwise.
   ///   Note the pointer may be invalidated by insert operations, including
   ///   get_entry.
-  entryt *find_entry(const idt &id);
+  entryt *find_entry(const irep_idt &id);
 
   /// Const version of \ref find_entry
-  const entryt *find_entry(const idt &id) const;
+  const entryt *find_entry(const irep_idt &id) const;
 
   /// Gets or inserts an entry in this value-set.
   /// \param e: entry to find. Its `id` and `suffix` fields will be used


### PR DESCRIPTION
We weren't using it consistently anyway, so just use irep_idt
everywhere.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
