### PR TITLE
Use sharing_mapt as container in value_sett

### DIFF
--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -676,16 +676,16 @@ void goto_symext::try_filter_value_sets(
   }
   if(jump_taken_value_set && !erase_from_jump_taken_value_set.empty())
   {
-    value_sett::entryt *entry = jump_taken_value_set->get_entry_for_symbol(
+    auto entry_index = jump_taken_value_set->get_index_of_symbol(
       symbol_expr->get_identifier(), symbol_type, "", ns);
     jump_taken_value_set->erase_values_from_entry(
-      *entry, erase_from_jump_taken_value_set);
+      *entry_index, erase_from_jump_taken_value_set);
   }
   if(jump_not_taken_value_set && !erase_from_jump_not_taken_value_set.empty())
   {
-    value_sett::entryt *entry = jump_not_taken_value_set->get_entry_for_symbol(
+    auto entry_index = jump_not_taken_value_set->get_index_of_symbol(
       symbol_expr->get_identifier(), symbol_type, "", ns);
     jump_not_taken_value_set->erase_values_from_entry(
-      *entry, erase_from_jump_not_taken_value_set);
+      *entry_index, erase_from_jump_not_taken_value_set);
   }
 }

--- a/src/pointer-analysis/value_set_analysis.cpp
+++ b/src/pointer-analysis/value_set_analysis.cpp
@@ -41,7 +41,10 @@ void value_sets_to_xml(
     xmlt &i=dest.new_element("instruction");
     i.new_element()=::xml(location);
 
-    for(const auto &values_entry : value_set.values)
+    value_sett::valuest::viewt view;
+    value_set.values.get_view(view);
+
+    for(const auto &values_entry : view)
     {
       xmlt &var=i.new_element("variable");
       var.new_element("identifier").data = id2string(values_entry.first);


### PR DESCRIPTION
goto-symex copies a state, which contains a value set, at each branching
point. The paths originating at that branch point typically share most
of the points-to information. Thus the copy is unnecessarily expensive,
and so is the merge at the next join point, which will also result in
one of the value sets to be destroyed. With sharing_mapt, the copy has
constant cost, merging can make use of the delta view, and the cost of
destruction only depends on the size of the delta.

Includes the cleanup-commit from #4462.

Performance evaluation to be done.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
