### PR TITLE
Constify collect_virtual_function_callees

### DIFF
--- a/src/goto-programs/remove_virtual_functions.h
+++ b/src/goto-programs/remove_virtual_functions.h
@@ -114,7 +114,7 @@ goto_programt::targett remove_virtual_function(
 ///   overridden functions will be stored.
 void collect_virtual_function_callees(
   const exprt &function,
-  symbol_tablet &symbol_table,
+  const symbol_table_baset &symbol_table,
   const class_hierarchyt &class_hierarchy,
   dispatch_table_entriest &overridden_functions);
 


### PR DESCRIPTION
This was always a const operation in spirit, as it retrieves a set of potential virtual function
overrides without making any changes to the GOTO program, but was recently changed to take a non-
const symbol table because it shares code with remove_virtual_function(s), which indeed add new
symbols to the symbol table.

To once again allow calling collect_virtual_function_callees in a const context, this splits the
implementation of remove_virtual_functions into those parts that require a non-const reference and
those for which a const symbol table will suffice.