### PR TITLE
fix compilation with cygwin

### DIFF
--- a/src/goto-cc/cl_message_handler.cpp
+++ b/src/goto-cc/cl_message_handler.cpp
@@ -42,7 +42,7 @@ void cl_message_handlert::print(
 
   if(full_path.has_value() && !line.empty())
   {
-#ifdef _WIN32
+#ifdef _MSC_VER
     std::ifstream in(widen(full_path.value()));
 #else
     std::ifstream in(full_path.value());

--- a/src/goto-cc/gcc_message_handler.cpp
+++ b/src/goto-cc/gcc_message_handler.cpp
@@ -66,7 +66,7 @@ void gcc_message_handlert::print(
     const auto file_name = location.full_path();
     if(file_name.has_value() && !line.empty())
     {
-#ifdef _WIN32
+#ifdef _MSC_VER
       std::ifstream in(widen(file_name.value()));
 #else
       std::ifstream in(file_name.value());

--- a/unit/util/file_util.cpp
+++ b/unit/util/file_util.cpp
@@ -40,7 +40,7 @@ TEST_CASE("is_directory functionality", "[core][util][file_util]")
 {
   temp_dirt temp_dir("testXXXXXX");
 
-#ifdef _WIN32
+#ifdef _MSC_VER
   std::ofstream outfile(widen(temp_dir("file")));
 #else
   std::ofstream outfile(temp_dir("file"));


### PR DESCRIPTION
The variant of `std::ifstream` with a wide character file name is only
available when using Visual Studio but not when using Cygwin.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
