### PR TITLE
C++: Add support for indexed access to bitvectors

### DIFF
--- a/regression/systemc/BitvectorCpp2/main.cpp
+++ b/regression/systemc/BitvectorCpp2/main.cpp
@@ -5,7 +5,7 @@ int main(int argc, char** argv)
   __CPROVER::signedbv<4> x(15);
   __CPROVER::signedbv<4> y;
   y = 13;
-  x[1] = 0; //TODO: currently not supported
+  x[1] = 0;
   assert(x == y);
 
   return 0;

--- a/regression/systemc/BitvectorCpp2/test.desc
+++ b/regression/systemc/BitvectorCpp2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 
 ^EXIT=0$


### PR DESCRIPTION
As a non-standard extension, we permit indexed access to bitvectors.
This translates to bit-level updates, which the typechecker now
generates.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
