### PR TITLE
C++ front-end: parameter symbols are file- and thread-local

### DIFF
--- a/src/cpp/cpp_typecheck_function.cpp
+++ b/src/cpp/cpp_typecheck_function.cpp
@@ -41,7 +41,7 @@ void cpp_typecheckt::convert_parameter(
   if(!lookup(identifier, check_symbol))
     return;
 
-  symbolt symbol;
+  parameter_symbolt symbol;
 
   symbol.name=identifier;
   symbol.base_name=parameter.get_base_name();
@@ -49,9 +49,7 @@ void cpp_typecheckt::convert_parameter(
   symbol.mode = current_mode;
   symbol.module=module;
   symbol.type=parameter.type();
-  symbol.is_state_var=true;
   symbol.is_lvalue=!is_reference(symbol.type);
-  symbol.is_parameter=true;
 
   INVARIANT(!symbol.base_name.empty(), "parameter has base name");
 


### PR DESCRIPTION
As global symbols they wouldn't be amenable to constant propagation in
multi-threaded contexts.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
