### PR TITLE
Handle ID_cpp_name in expr2cppt

### DIFF
--- a/src/cpp/expr2cpp.cpp
+++ b/src/cpp/expr2cpp.cpp
@@ -21,6 +21,8 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <ansi-c/c_qualifiers.h>
 #include <ansi-c/expr2c_class.h>
 
+#include "cpp_name.h"
+
 class expr2cppt:public expr2ct
 {
 public:
@@ -166,6 +168,51 @@ std::string expr2cppt::convert_rec(
       dest+="struct";
 
     dest+=d;
+
+    return dest;
+  }
+  else if(src.id() == ID_struct_tag)
+  {
+    const struct_typet &struct_type = ns.follow_tag(to_struct_tag_type(src));
+
+    std::string dest = q;
+
+    if(src.get_bool(ID_C_class))
+      dest += "class";
+    else if(src.get_bool(ID_C_interface))
+      dest += "__interface"; // MS-specific
+    else
+      dest += "struct";
+
+    const irept &tag = struct_type.find(ID_tag);
+    if(!tag.id().empty())
+    {
+      if(tag.id() == ID_cpp_name)
+        dest += " " + to_cpp_name(tag).to_string();
+      else
+        dest += id2string(tag.id());
+    }
+
+    dest += d;
+
+    return dest;
+  }
+  else if(src.id() == ID_union_tag)
+  {
+    const union_typet &union_type = ns.follow_tag(to_union_tag_type(src));
+
+    std::string dest = q + "union";
+
+    const irept &tag = union_type.find(ID_tag);
+    if(!tag.id().empty())
+    {
+      if(tag.id() == ID_cpp_name)
+        dest += " " + to_cpp_name(tag).to_string();
+      else
+        dest += id2string(tag.id());
+    }
+
+    dest += d;
 
     return dest;
   }


### PR DESCRIPTION
While typechecking is still in progress, tags may still be cpp names.
For debugging purposes it's useful to print their underlying names.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
