### PR TITLE
User controlled havoc(ing) for memory-snapshot harness

### DIFF
--- a/regression/snapshot-harness/nondet_initialize_static_arrays/main.c
+++ b/regression/snapshot-harness/nondet_initialize_static_arrays/main.c
@@ -1,0 +1,51 @@
+#include <assert.h>
+#include <stdlib.h>
+
+typedef struct st1
+{
+  struct st2 *to_st2;
+  int data;
+} st1_t;
+
+typedef struct st2
+{
+  struct st1 *to_st1;
+  int data;
+} st2_t;
+
+typedef struct st3
+{
+  st1_t *array[3];
+} st3_t;
+
+st3_t *p;
+
+void initialize()
+{
+  p = malloc(sizeof(st3_t));
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(p != NULL);
+  for(int index = 0; index < 3; index++)
+  {
+    // check that the arrays in structs (and structs in those arrays) were
+    // initialized up-to the input depth
+    assert(p->array[index]->to_st2 != NULL);
+    assert(p->array[index]->to_st2->to_st1 != NULL);
+    assert(p->array[index]->to_st2->to_st1->to_st2 == NULL);
+  }
+
+  // non-deterministically initializated objects should not be equal
+  assert(p->array[0] != p->array[1]);
+  assert(p->array[1] != p->array[2]);
+  assert(p->array[0] != p->array[2]);
+}

--- a/regression/snapshot-harness/nondet_initialize_static_arrays/test.desc
+++ b/regression/snapshot-harness/nondet_initialize_static_arrays/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+p --harness-type initialise-with-memory-snapshot --initial-goto-location main:4 --min-null-tree-depth 10 --max-nondet-tree-depth 4 --havoc-variables p
+^EXIT=0$
+^SIGNAL=0$
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/regression/snapshot-harness/pointer-function-parameters-struct-mutual-recursion/main.c
+++ b/regression/snapshot-harness/pointer-function-parameters-struct-mutual-recursion/main.c
@@ -1,0 +1,42 @@
+#include <assert.h>
+#include <stdlib.h>
+
+typedef struct st1
+{
+  struct st2 *to_st2;
+  int data;
+} st1_t;
+
+typedef struct st2
+{
+  struct st1 *to_st1;
+  int data;
+} st2_t;
+
+st1_t dummy1;
+st2_t dummy2;
+
+st1_t *p;
+
+void initialize()
+{
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(p != NULL);
+  assert(p->to_st2 != NULL);
+  assert(p->to_st2->to_st1 != NULL);
+  assert(p->to_st2->to_st1->to_st2 == NULL);
+
+  assert(p != &dummy1);
+  assert(p->to_st2 != &dummy2);
+  assert(p->to_st2->to_st1 != &dummy1);
+}

--- a/regression/snapshot-harness/pointer-function-parameters-struct-mutual-recursion/test.desc
+++ b/regression/snapshot-harness/pointer-function-parameters-struct-mutual-recursion/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+p --harness-type initialise-with-memory-snapshot --initial-goto-location main:4 --havoc-variables p --min-null-tree-depth 10 --max-nondet-tree-depth 3
+^SIGNAL=0$
+^EXIT=0$
+VERIFICATION SUCCESSFUL
+--
+unwinding assertion loop \d+: FAILURE

--- a/regression/snapshot-harness/pointer-to-array-char/main.c
+++ b/regression/snapshot-harness/pointer-to-array-char/main.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+#include <malloc.h>
+
+char *first;
+char *second;
+int array_size;
+
+void initialize()
+{
+  first = malloc(sizeof(char) * 12);
+  first = "1234567890a";
+  second = first;
+  array_size = 11;
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(first == second);
+  assert(second[array_size - 1] == 'a');
+  return 0;
+}

--- a/regression/snapshot-harness/pointer-to-array-char/test.desc
+++ b/regression/snapshot-harness/pointer-to-array-char/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+first,second,array_size --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^SIGNAL=0$
+^EXIT=0$
+VERIFICATION SUCCESSFUL
+--
+unwinding assertion loop \d+: FAILURE

--- a/regression/snapshot-harness/pointer-to-array-function-parameters-multi-arg-right/main.c
+++ b/regression/snapshot-harness/pointer-to-array-function-parameters-multi-arg-right/main.c
@@ -1,0 +1,41 @@
+#include <assert.h>
+
+char *first = "12345678901";
+char *second;
+int string_size;
+const char *prefix;
+int prefix_size;
+
+void initialize()
+{
+  second = first;
+  string_size = 11;
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(first == second);
+  if(prefix_size > 0)
+    assert(second[prefix_size - 1] != 'a');
+
+  if(string_size < prefix_size)
+  {
+    return 0;
+  }
+
+  for(int ix = 0; ix < prefix_size; ++ix)
+  {
+    if(second[ix] != prefix[ix])
+    {
+      return 0;
+    }
+  }
+  return 1;
+}

--- a/regression/snapshot-harness/pointer-to-array-function-parameters-multi-arg-right/test.desc
+++ b/regression/snapshot-harness/pointer-to-array-function-parameters-multi-arg-right/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+first,second,string_size,prefix,prefix_size --harness-type initialise-with-memory-snapshot --initial-goto-location main:4 --havoc-variables prefix,prefix_size --size-of-array prefix:prefix_size --max-array-size 5
+^SIGNAL=0$
+^EXIT=0$
+VERIFICATION SUCCESSFUL
+--
+unwinding assertion loop \d+: FAILURE

--- a/regression/snapshot-harness/pointer-to-array-int/main.c
+++ b/regression/snapshot-harness/pointer-to-array-int/main.c
@@ -1,0 +1,44 @@
+#include <assert.h>
+#include <malloc.h>
+
+int *first;
+int *second;
+int *third;
+int array_size;
+const int *prefix;
+int prefix_size;
+
+void initialize()
+{
+  first = (int *)malloc(sizeof(int) * 5);
+  first[0] = 0;
+  first[1] = 1;
+  first[2] = 2;
+  first[3] = 3;
+  first[4] = 4;
+  second = first;
+  array_size = 5;
+  third = &array_size;
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(first == second);
+  // The following assertions will be check in the following PR once
+  // dynamically allocated snapshots are properly implemented.
+  /* assert(array_size >= prefix_size); */
+  /* assert(prefix_size >= 0); */
+  /* assert(second[prefix_size] != 6); */
+  /* assert(second[4] == 4); */
+
+  /* for(int i = 0; i < prefix_size; i++) */
+  /*   assert(second[i] != prefix[i]); */
+  return 0;
+}

--- a/regression/snapshot-harness/pointer-to-array-int/test.desc
+++ b/regression/snapshot-harness/pointer-to-array-int/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+first,second,array_size,prefix,prefix_size --harness-type initialise-with-memory-snapshot --initial-goto-location main:4 --havoc-variables prefix --size-of-array prefix:prefix_size --max-array-size 4
+^SIGNAL=0$
+^EXIT=0$
+VERIFICATION SUCCESSFUL
+--
+unwinding assertion loop \d+: FAILURE

--- a/regression/snapshot-harness/pointer_07/main.c
+++ b/regression/snapshot-harness/pointer_07/main.c
@@ -1,0 +1,26 @@
+#include <assert.h>
+#include <malloc.h>
+
+int *p1;
+
+void initialize()
+{
+  p1 = malloc(sizeof(int));
+  *p1 = 1;
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(p1[0] == 1);
+  assert(*p1 == 1);
+  p1[0] = 2;
+  assert(*p1 == 1);
+  assert(*p1 != 1);
+}

--- a/regression/snapshot-harness/pointer_07/test.desc
+++ b/regression/snapshot-harness/pointer_07/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+p1 --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^EXIT=10$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion p1\[0\] == 1: SUCCESS
+\[main.assertion.2\] line [0-9]+ assertion \*p1 == 1: SUCCESS
+\[main.assertion.3\] line [0-9]+ assertion \*p1 == 1: FAILURE
+\[main.assertion.4\] line [0-9]+ assertion \*p1 != 1: SUCCESS
+--
+^warning: ignoring

--- a/regression/snapshot-harness/static-array-char/main.c
+++ b/regression/snapshot-harness/static-array-char/main.c
@@ -1,0 +1,32 @@
+#include <assert.h>
+
+char tmp[12];
+char *first;
+char *second;
+int array_size;
+
+void initialize()
+{
+  tmp[0] = '1';
+  tmp[9] = '0';
+  tmp[10] = 'a';
+  first = (char *)tmp;
+  second = first;
+  array_size = 11;
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(first == second);
+  assert(second[array_size - 1] == 'a');
+  assert(first[0] == '1');
+  assert(second[9] == '0');
+  return 0;
+}

--- a/regression/snapshot-harness/static-array-char/test.desc
+++ b/regression/snapshot-harness/static-array-char/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+tmp,first,second,array_size --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^SIGNAL=0$
+^EXIT=0$
+VERIFICATION SUCCESSFUL
+--
+unwinding assertion loop \d+: FAILURE

--- a/src/goto-harness/common_harness_generator_options.h
+++ b/src/goto-harness/common_harness_generator_options.h
@@ -1,0 +1,46 @@
+/******************************************************************\
+
+Module: common_harness_generator_options
+
+Author: Diffblue Ltd.
+
+\******************************************************************/
+
+#ifndef CPROVER_GOTO_HARNESS_COMMON_HARNESS_GENERATOR_OPTIONS_H
+#define CPROVER_GOTO_HARNESS_COMMON_HARNESS_GENERATOR_OPTIONS_H
+
+#define COMMON_HARNESS_GENERATOR_MIN_NULL_TREE_DEPTH_OPT "min-null-tree-depth"
+#define COMMON_HARNESS_GENERATOR_MAX_NONDET_TREE_DEPTH_OPT                     \
+  "max-nondet-tree-depth"
+#define COMMON_HARNESS_GENERATOR_MIN_ARRAY_SIZE_OPT "min-array-size"
+#define COMMON_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT "max-array-size"
+
+// clang-format off
+#define COMMON_HARNESS_GENERATOR_OPTIONS                                       \
+  "(" COMMON_HARNESS_GENERATOR_MIN_NULL_TREE_DEPTH_OPT "):"                    \
+  "(" COMMON_HARNESS_GENERATOR_MAX_NONDET_TREE_DEPTH_OPT "):"                  \
+  "(" COMMON_HARNESS_GENERATOR_MIN_ARRAY_SIZE_OPT "):"                         \
+  "(" COMMON_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT "):"                         \
+// COMMON_HARNESS_GENERATOR_OPTIONS
+
+// clang-format on
+
+// clang-format off
+#define COMMON_HARNESS_GENERATOR_HELP                                          \
+  "--" COMMON_HARNESS_GENERATOR_MIN_NULL_TREE_DEPTH_OPT                        \
+  " N       minimum level at which a pointer can first be NULL\n"              \
+  "                              in a recursively nondet initialized struct\n" \
+  "--" COMMON_HARNESS_GENERATOR_MAX_NONDET_TREE_DEPTH_OPT                      \
+  " N     limit size of nondet (e.g. input) object tree;\n"                    \
+  "                              at level N pointers are set to null\n"        \
+  "--" COMMON_HARNESS_GENERATOR_MIN_ARRAY_SIZE_OPT                             \
+  " N            minimum size of dynamically created arrays\n"                 \
+  "                              (default: 1)\n"                               \
+  "--" COMMON_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT                             \
+  " N            maximum size of dynamically created arrays\n"                 \
+  "                              (default: 2)\n"                               \
+  // COMMON_HARNESS_GENERATOR_HELP
+
+// clang-format on
+
+#endif // CPROVER_GOTO_HARNESS_COMMON_HARNESS_GENERATOR_OPTIONS_H

--- a/src/goto-harness/function_call_harness_generator.cpp
+++ b/src/goto-harness/function_call_harness_generator.cpp
@@ -90,57 +90,20 @@ void function_call_harness_generatort::handle_option(
   const std::string &option,
   const std::list<std::string> &values)
 {
-  if(option == FUNCTION_HARNESS_GENERATOR_FUNCTION_OPT)
+  auto &require_exactly_one_value =
+    harness_options_parsert::require_exactly_one_value;
+
+  if(p_impl->recursive_initialization_config.handle_option(option, values))
+  {
+    // the option belongs to recursive initialization
+  }
+  else if(option == FUNCTION_HARNESS_GENERATOR_FUNCTION_OPT)
   {
     p_impl->function = require_exactly_one_value(option, values);
   }
-  else if(option == FUNCTION_HARNESS_GENERATOR_NONDET_GLOBALS_OPT)
+  else if(option == COMMON_HARNESS_GENERATOR_NONDET_GLOBALS_OPT)
   {
     p_impl->nondet_globals = true;
-  }
-  else if(option == FUNCTION_HARNESS_GENERATOR_MIN_NULL_TREE_DEPTH_OPT)
-  {
-    auto const value = require_exactly_one_value(option, values);
-    auto const min_null_tree_depth = string2optional<std::size_t>(value, 10);
-    if(min_null_tree_depth.has_value())
-    {
-      p_impl->recursive_initialization_config.min_null_tree_depth =
-        min_null_tree_depth.value();
-    }
-    else
-    {
-      throw invalid_command_line_argument_exceptiont{
-        "failed to convert `" + value + "' to integer",
-        "--" FUNCTION_HARNESS_GENERATOR_MIN_NULL_TREE_DEPTH_OPT};
-    }
-  }
-  else if(option == FUNCTION_HARNESS_GENERATOR_MAX_NONDET_TREE_DEPTH_OPT)
-  {
-    auto const value = require_exactly_one_value(option, values);
-    auto const max_nondet_tree_depth = string2optional<std::size_t>(value, 10);
-    if(max_nondet_tree_depth.has_value())
-    {
-      p_impl->recursive_initialization_config.max_nondet_tree_depth =
-        max_nondet_tree_depth.value();
-    }
-    else
-    {
-      throw invalid_command_line_argument_exceptiont{
-        "failed to convert `" + value + "' to integer",
-        "--" FUNCTION_HARNESS_GENERATOR_MAX_NONDET_TREE_DEPTH_OPT};
-    }
-  }
-  else if(option == FUNCTION_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT)
-  {
-    p_impl->recursive_initialization_config.max_dynamic_array_size =
-      require_one_size_value(
-        FUNCTION_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT, values);
-  }
-  else if(option == FUNCTION_HARNESS_GENERATOR_MIN_ARRAY_SIZE_OPT)
-  {
-    p_impl->recursive_initialization_config.min_dynamic_array_size =
-      require_one_size_value(
-        FUNCTION_HARNESS_GENERATOR_MIN_ARRAY_SIZE_OPT, values);
   }
   else if(option == FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT)
   {
@@ -285,25 +248,8 @@ void function_call_harness_generatort::validate_options(
   {
     throw invalid_command_line_argument_exceptiont{
       "min dynamic array size cannot be greater than max dynamic array size",
-      "--" FUNCTION_HARNESS_GENERATOR_MIN_ARRAY_SIZE_OPT
-      " --" FUNCTION_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT};
-  }
-}
-
-std::size_t function_call_harness_generatort::require_one_size_value(
-  const std::string &option,
-  const std::list<std::string> &values)
-{
-  auto const string_value = require_exactly_one_value(option, values);
-  auto value = string2optional<std::size_t>(string_value, 10);
-  if(value.has_value())
-  {
-    return value.value();
-  }
-  else
-  {
-    throw invalid_command_line_argument_exceptiont{
-      "failed to parse `" + string_value + "' as integer", "--" + option};
+      "--" COMMON_HARNESS_GENERATOR_MIN_ARRAY_SIZE_OPT
+      " --" COMMON_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT};
   }
 }
 

--- a/src/goto-harness/function_call_harness_generator.cpp
+++ b/src/goto-harness/function_call_harness_generator.cpp
@@ -91,7 +91,7 @@ void function_call_harness_generatort::handle_option(
   const std::list<std::string> &values)
 {
   auto &require_exactly_one_value =
-    harness_options_parsert::require_exactly_one_value;
+    harness_options_parser::require_exactly_one_value;
 
   if(p_impl->recursive_initialization_config.handle_option(option, values))
   {
@@ -101,7 +101,7 @@ void function_call_harness_generatort::handle_option(
   {
     p_impl->function = require_exactly_one_value(option, values);
   }
-  else if(option == COMMON_HARNESS_GENERATOR_NONDET_GLOBALS_OPT)
+  else if(option == FUNCTION_HARNESS_GENERATOR_NONDET_GLOBALS_OPT)
   {
     p_impl->nondet_globals = true;
   }

--- a/src/goto-harness/function_harness_generator_options.h
+++ b/src/goto-harness/function_harness_generator_options.h
@@ -12,7 +12,7 @@ Author: Diffblue Ltd.
 #include "common_harness_generator_options.h"
 
 #define FUNCTION_HARNESS_GENERATOR_FUNCTION_OPT "function"
-#define COMMON_HARNESS_GENERATOR_NONDET_GLOBALS_OPT "nondet-globals"
+#define FUNCTION_HARNESS_GENERATOR_NONDET_GLOBALS_OPT "nondet-globals"
 #define FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT                  \
   "treat-pointer-as-array"
 #define FUNCTION_HARNESS_GENERATOR_ASSOCIATED_ARRAY_SIZE_OPT                   \
@@ -23,7 +23,7 @@ Author: Diffblue Ltd.
 // clang-format off
 #define FUNCTION_HARNESS_GENERATOR_OPTIONS                                     \
   "(" FUNCTION_HARNESS_GENERATOR_FUNCTION_OPT "):"                             \
-  "(" COMMON_HARNESS_GENERATOR_NONDET_GLOBALS_OPT ")"                          \
+  "(" FUNCTION_HARNESS_GENERATOR_NONDET_GLOBALS_OPT ")"                        \
   "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT "):"               \
   "(" FUNCTION_HARNESS_GENERATOR_ASSOCIATED_ARRAY_SIZE_OPT "):"                \
   "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_CSTRING "):"                 \
@@ -36,7 +36,7 @@ Author: Diffblue Ltd.
   "function harness generator (--harness-type call-function)\n\n"              \
   "--" FUNCTION_HARNESS_GENERATOR_FUNCTION_OPT                                 \
   "                    the function the harness should call\n"                 \
-  "--" COMMON_HARNESS_GENERATOR_NONDET_GLOBALS_OPT                             \
+  "--" FUNCTION_HARNESS_GENERATOR_NONDET_GLOBALS_OPT                           \
   "              set global variables to non-deterministic values\n"           \
   "                              in harness\n"                                 \
   COMMON_HARNESS_GENERATOR_HELP                                                \

--- a/src/goto-harness/function_harness_generator_options.h
+++ b/src/goto-harness/function_harness_generator_options.h
@@ -9,13 +9,10 @@ Author: Diffblue Ltd.
 #ifndef CPROVER_GOTO_HARNESS_FUNCTION_HARNESS_GENERATOR_OPTIONS_H
 #define CPROVER_GOTO_HARNESS_FUNCTION_HARNESS_GENERATOR_OPTIONS_H
 
+#include "common_harness_generator_options.h"
+
 #define FUNCTION_HARNESS_GENERATOR_FUNCTION_OPT "function"
-#define FUNCTION_HARNESS_GENERATOR_NONDET_GLOBALS_OPT "nondet-globals"
-#define FUNCTION_HARNESS_GENERATOR_MIN_NULL_TREE_DEPTH_OPT "min-null-tree-depth"
-#define FUNCTION_HARNESS_GENERATOR_MAX_NONDET_TREE_DEPTH_OPT                   \
-  "max-nondet-tree-depth"
-#define FUNCTION_HARNESS_GENERATOR_MIN_ARRAY_SIZE_OPT "min-array-size"
-#define FUNCTION_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT "max-array-size"
+#define COMMON_HARNESS_GENERATOR_NONDET_GLOBALS_OPT "nondet-globals"
 #define FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT                  \
   "treat-pointer-as-array"
 #define FUNCTION_HARNESS_GENERATOR_ASSOCIATED_ARRAY_SIZE_OPT                   \
@@ -26,11 +23,7 @@ Author: Diffblue Ltd.
 // clang-format off
 #define FUNCTION_HARNESS_GENERATOR_OPTIONS                                     \
   "(" FUNCTION_HARNESS_GENERATOR_FUNCTION_OPT "):"                             \
-  "(" FUNCTION_HARNESS_GENERATOR_NONDET_GLOBALS_OPT ")"                        \
-  "(" FUNCTION_HARNESS_GENERATOR_MIN_NULL_TREE_DEPTH_OPT "):"                  \
-  "(" FUNCTION_HARNESS_GENERATOR_MAX_NONDET_TREE_DEPTH_OPT "):"                \
-  "(" FUNCTION_HARNESS_GENERATOR_MIN_ARRAY_SIZE_OPT "):"                       \
-  "(" FUNCTION_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT "):"                       \
+  "(" COMMON_HARNESS_GENERATOR_NONDET_GLOBALS_OPT ")"                          \
   "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT "):"               \
   "(" FUNCTION_HARNESS_GENERATOR_ASSOCIATED_ARRAY_SIZE_OPT "):"                \
   "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_CSTRING "):"                 \
@@ -42,29 +35,24 @@ Author: Diffblue Ltd.
 #define FUNCTION_HARNESS_GENERATOR_HELP                                        \
   "function harness generator (--harness-type call-function)\n\n"              \
   "--" FUNCTION_HARNESS_GENERATOR_FUNCTION_OPT                                 \
-  "      the function the harness should call\n"                               \
-  "--" FUNCTION_HARNESS_GENERATOR_NONDET_GLOBALS_OPT                           \
-  "      set global variables to non-deterministic values in harness\n"        \
-  "--" FUNCTION_HARNESS_GENERATOR_MIN_NULL_TREE_DEPTH_OPT                      \
-  " N      minimum level at which a pointer can first be\n"                    \
-  "        NULL in a recursively nondet initialized struct\n"                  \
-  "--" FUNCTION_HARNESS_GENERATOR_MAX_NONDET_TREE_DEPTH_OPT                    \
-  " N    limit size of nondet (e.g. input) object tree;\n"                     \
-  "      at level N pointers are set to null\n"                                \
-  "--" FUNCTION_HARNESS_GENERATOR_MIN_ARRAY_SIZE_OPT                           \
-  " N    minimum size of dynamically created arrays (default: 1)\n"            \
-  "--" FUNCTION_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT                           \
-  " N    maximum size of dynamically created arrays (default: 2)\n"            \
+  "                    the function the harness should call\n"                 \
+  "--" COMMON_HARNESS_GENERATOR_NONDET_GLOBALS_OPT                             \
+  "              set global variables to non-deterministic values\n"           \
+  "                              in harness\n"                                 \
+  COMMON_HARNESS_GENERATOR_HELP                                                \
   "--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT                   \
-  " parameter    treat the function parameter with the name `parameter'\n"     \
-  "                   as an array\n"                                           \
+  " p    treat the function parameter with the name `p' as\n"                  \
+  "                              an array\n"                                   \
   "--" FUNCTION_HARNESS_GENERATOR_ASSOCIATED_ARRAY_SIZE_OPT                    \
   " array_name:size_name\n"                                                    \
-  "                                set the parameter <size_name> to the size\n"\
-  "                                of the array <array_name>\n"                \
-  "                                (implies "                                  \
-  "-- " FUNCTION_HARNESS_GENERATOR_ASSOCIATED_ARRAY_SIZE_OPT                   \
+  "                              set the parameter <size_name> to the size"    \
+  " of\n                              the array <array_name>\n"                \
+  "                              (implies "                                    \
+  "-- " FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT                  \
   " <array_name>)\n"                                                           \
+  "--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_CSTRING                     \
+  " p    treat the function parameter with the name `p' as\n"                  \
+  "                              a string of characters\n"                     \
   // FUNCTION_HARNESS_GENERATOR_HELP
 
 // clang-format on

--- a/src/goto-harness/goto_harness_generator.cpp
+++ b/src/goto-harness/goto_harness_generator.cpp
@@ -13,8 +13,9 @@ Author: Diffblue Ltd.
 
 #include <util/exception_utils.h>
 #include <util/invariant.h>
+#include <util/string2int.h>
 
-std::string goto_harness_generatort::require_exactly_one_value(
+std::string harness_options_parsert::require_exactly_one_value(
   const std::string &option,
   const std::list<std::string> &values)
 {
@@ -27,9 +28,26 @@ std::string goto_harness_generatort::require_exactly_one_value(
   return values.front();
 }
 
-void goto_harness_generatort::assert_no_values(
+void harness_options_parsert::assert_no_values(
   const std::string &option,
   const std::list<std::string> &values)
 {
   PRECONDITION_WITH_DIAGNOSTICS(values.empty(), option);
+}
+
+std::size_t harness_options_parsert::require_one_size_value(
+  const std::string &option,
+  const std::list<std::string> &values)
+{
+  auto const string_value = require_exactly_one_value(option, values);
+  auto value = string2optional<std::size_t>(string_value, 10);
+  if(value.has_value())
+  {
+    return value.value();
+  }
+  else
+  {
+    throw invalid_command_line_argument_exceptiont{
+      "failed to parse `" + string_value + "' as integer", "--" + option};
+  }
 }

--- a/src/goto-harness/goto_harness_generator.cpp
+++ b/src/goto-harness/goto_harness_generator.cpp
@@ -15,7 +15,10 @@ Author: Diffblue Ltd.
 #include <util/invariant.h>
 #include <util/string2int.h>
 
-std::string harness_options_parsert::require_exactly_one_value(
+// NOLINTNEXTLINE(readability/namespace)
+namespace harness_options_parser
+{
+std::string require_exactly_one_value(
   const std::string &option,
   const std::list<std::string> &values)
 {
@@ -28,14 +31,14 @@ std::string harness_options_parsert::require_exactly_one_value(
   return values.front();
 }
 
-void harness_options_parsert::assert_no_values(
+void assert_no_values(
   const std::string &option,
   const std::list<std::string> &values)
 {
   PRECONDITION_WITH_DIAGNOSTICS(values.empty(), option);
 }
 
-std::size_t harness_options_parsert::require_one_size_value(
+std::size_t require_one_size_value(
   const std::string &option,
   const std::list<std::string> &values)
 {
@@ -51,3 +54,5 @@ std::size_t harness_options_parsert::require_one_size_value(
       "failed to parse `" + string_value + "' as integer", "--" + option};
   }
 }
+// NOLINTNEXTLINE(readability/namespace)
+} // namespace harness_options_parser

--- a/src/goto-harness/goto_harness_generator.h
+++ b/src/goto-harness/goto_harness_generator.h
@@ -16,26 +16,27 @@ Author: Diffblue Ltd.
 
 class goto_modelt;
 
-class harness_options_parsert
+// NOLINTNEXTLINE(readability/namespace)
+namespace harness_options_parser
 {
-public:
-  /// Returns the only value of a single element list,
-  /// throws an exception if not passed a single element list
-  static std::string require_exactly_one_value(
-    const std::string &option,
-    const std::list<std::string> &values);
+/// Returns the only value of a single element list,
+/// throws an exception if not passed a single element list
+std::string require_exactly_one_value(
+  const std::string &option,
+  const std::list<std::string> &values);
 
-  /// Asserts that the list of values to an option passed is empty
-  static void assert_no_values(
-    const std::string &option,
-    const std::list<std::string> &values);
+/// Asserts that the list of values to an option passed is empty
+void assert_no_values(
+  const std::string &option,
+  const std::list<std::string> &values);
 
-  /// Returns the only Nat value of a single element list,
-  /// throws an exception if not passed a single element list (or not Nat)
-  static std::size_t require_one_size_value(
-    const std::string &option,
-    const std::list<std::string> &values);
-};
+/// Returns the only Nat value of a single element list,
+/// throws an exception if not passed a single element list (or not Nat)
+std::size_t require_one_size_value(
+  const std::string &option,
+  const std::list<std::string> &values);
+// NOLINTNEXTLINE(readability/namespace)
+} // namespace harness_options_parser
 
 class goto_harness_generatort
 {

--- a/src/goto-harness/goto_harness_generator.h
+++ b/src/goto-harness/goto_harness_generator.h
@@ -16,6 +16,27 @@ Author: Diffblue Ltd.
 
 class goto_modelt;
 
+class harness_options_parsert
+{
+public:
+  /// Returns the only value of a single element list,
+  /// throws an exception if not passed a single element list
+  static std::string require_exactly_one_value(
+    const std::string &option,
+    const std::list<std::string> &values);
+
+  /// Asserts that the list of values to an option passed is empty
+  static void assert_no_values(
+    const std::string &option,
+    const std::list<std::string> &values);
+
+  /// Returns the only Nat value of a single element list,
+  /// throws an exception if not passed a single element list (or not Nat)
+  static std::size_t require_one_size_value(
+    const std::string &option,
+    const std::list<std::string> &values);
+};
+
 class goto_harness_generatort
 {
 public:
@@ -36,17 +57,6 @@ protected:
 
   /// Check if options are in a sane state, throw otherwise
   virtual void validate_options(const goto_modelt &goto_model) = 0;
-
-  /// Returns the only value of a single element list,
-  /// throws an exception if not passed a single element list
-  static std::string require_exactly_one_value(
-    const std::string &option,
-    const std::list<std::string> &values);
-
-  /// Asserts that the list of values to an option passed is empty
-  static void assert_no_values(
-    const std::string &option,
-    const std::list<std::string> &values);
 };
 
 #endif // CPROVER_GOTO_HARNESS_GOTO_HARNESS_GENERATOR_H

--- a/src/goto-harness/goto_harness_parse_options.h
+++ b/src/goto-harness/goto_harness_parse_options.h
@@ -17,11 +17,13 @@ Author: Diffblue Ltd.
 
 #include "function_harness_generator_options.h"
 #include "goto_harness_generator_factory.h"
+#include "memory_snapshot_harness_generator_options.h"
 
 // clang-format off
 #define GOTO_HARNESS_OPTIONS                                                   \
   "(version)"                                                                  \
   GOTO_HARNESS_FACTORY_OPTIONS                                                 \
+  COMMON_HARNESS_GENERATOR_OPTIONS                                             \
   FUNCTION_HARNESS_GENERATOR_OPTIONS                                           \
   MEMORY_SNAPSHOT_HARNESS_GENERATOR_OPTIONS                                    \
 // end GOTO_HARNESS_OPTIONS

--- a/src/goto-harness/memory_snapshot_harness_generator.cpp
+++ b/src/goto-harness/memory_snapshot_harness_generator.cpp
@@ -9,6 +9,7 @@ Author: Daniel Poetzl
 #include <algorithm>
 
 #include "memory_snapshot_harness_generator.h"
+#include "memory_snapshot_harness_generator_options.h"
 
 #include <goto-programs/goto_convert.h>
 
@@ -26,25 +27,75 @@ Author: Daniel Poetzl
 #include <linking/static_lifetime_init.h>
 
 #include "goto_harness_generator_factory.h"
-#include "recursive_initialization.h"
 
 void memory_snapshot_harness_generatort::handle_option(
   const std::string &option,
   const std::list<std::string> &values)
 {
-  if(option == "memory-snapshot")
+  auto &require_exactly_one_value =
+    harness_options_parsert::require_exactly_one_value;
+  if(recursive_initialization_config.handle_option(option, values))
+  {
+    // the option belongs to recursive initialization
+  }
+  else if(option == MEMORY_SNAPSHOT_HARNESS_TREAT_POINTER_AS_ARRAY_OPT)
+  {
+    recursive_initialization_config.pointers_to_treat_as_arrays.insert(
+      values.begin(), values.end());
+  }
+  else if(option == MEMORY_SNAPSHOT_HARNESS_ASSOCIATED_ARRAY_SIZE_OPT)
+  {
+    for(auto const &array_size_pair : values)
+    {
+      try
+      {
+        std::string array;
+        std::string size;
+        split_string(array_size_pair, ':', array, size);
+        // --associated-array-size implies --treat-pointer-as-array
+        // but it is not an error to specify both, so we don't check
+        // for duplicates here
+        recursive_initialization_config.pointers_to_treat_as_arrays.insert(
+          array);
+        auto const inserted =
+          recursive_initialization_config
+            .array_name_to_associated_array_size_variable.emplace(array, size);
+        if(!inserted.second)
+        {
+          throw invalid_command_line_argument_exceptiont{
+            "can not have two associated array sizes for one array",
+            "--" MEMORY_SNAPSHOT_HARNESS_ASSOCIATED_ARRAY_SIZE_OPT};
+        }
+      }
+      catch(const deserialization_exceptiont &)
+      {
+        throw invalid_command_line_argument_exceptiont{
+          "`" + array_size_pair +
+            "' is in an invalid format for array size pair",
+          "--" MEMORY_SNAPSHOT_HARNESS_ASSOCIATED_ARRAY_SIZE_OPT,
+          "array_name:size_name, where both are the names of global "
+          "variables"};
+      }
+    }
+  }
+  else if(option == MEMORY_SNAPSHOT_HARNESS_SNAPSHOT_OPT)
   {
     memory_snapshot_file = require_exactly_one_value(option, values);
   }
-  else if(option == "initial-goto-location")
+  else if(option == MEMORY_SNAPSHOT_HARNESS_INITIAL_GOTO_LOC_OPT)
   {
     initial_goto_location_line = require_exactly_one_value(option, values);
   }
-  else if(option == "havoc-variables")
+  else if(option == MEMORY_SNAPSHOT_HARNESS_HAVOC_VARIABLES_OPT)
   {
-    variables_to_havoc.insert(values.begin(), values.end());
+    std::vector<std::string> havoc_candidates;
+    split_string(values.front(), ',', havoc_candidates, true);
+    for(const auto &candidate : havoc_candidates)
+    {
+      variables_to_havoc.insert(candidate);
+    }
   }
-  else if(option == "initial-source-location")
+  else if(option == MEMORY_SNAPSHOT_HARNESS_INITIAL_SOURCE_LOC_OPT)
   {
     initial_source_location_line = require_exactly_one_value(option, values);
   }
@@ -153,7 +204,7 @@ code_blockt memory_snapshot_harness_generatort::add_assignments_to_globals(
   goto_modelt &goto_model) const
 {
   recursive_initializationt recursive_initialization{
-    recursive_initialization_configt{}, goto_model};
+    recursive_initialization_config, goto_model};
 
   code_blockt code;
   for(const auto &pair : snapshot)

--- a/src/goto-harness/memory_snapshot_harness_generator.cpp
+++ b/src/goto-harness/memory_snapshot_harness_generator.cpp
@@ -33,7 +33,7 @@ void memory_snapshot_harness_generatort::handle_option(
   const std::list<std::string> &values)
 {
   auto &require_exactly_one_value =
-    harness_options_parsert::require_exactly_one_value;
+    harness_options_parser::require_exactly_one_value;
   if(recursive_initialization_config.handle_option(option, values))
   {
     // the option belongs to recursive initialization

--- a/src/goto-harness/memory_snapshot_harness_generator.h
+++ b/src/goto-harness/memory_snapshot_harness_generator.h
@@ -239,6 +239,11 @@ protected:
     goto_modelt &goto_model,
     const symbolt &function) const;
 
+  /// Recursively compute the pointer depth
+  /// \param t: input type
+  /// \return pointer depth of type \p t
+  size_t pointer_depth(const typet &t) const;
+
   /// data to store the command-line options
   std::string memory_snapshot_file;
   std::string initial_goto_location_line;

--- a/src/goto-harness/memory_snapshot_harness_generator.h
+++ b/src/goto-harness/memory_snapshot_harness_generator.h
@@ -13,34 +13,12 @@ Author: Daniel Poetzl
 #include <string>
 
 #include "goto_harness_generator.h"
+#include "recursive_initialization.h"
 
 #include <goto-programs/goto_model.h>
 
 #include <util/message.h>
 #include <util/optional.h>
-
-// clang-format off
-#define MEMORY_SNAPSHOT_HARNESS_GENERATOR_OPTIONS                              \
-  "(memory-snapshot):"                                                         \
-  "(initial-goto-location):"                                                   \
-  "(initial-source-location):"                                                 \
-  "(havoc-variables):" // MEMORY_SNAPSHOT_HARNESS_GENERATOR_OPTIONS
-// clang-format on
-
-// clang-format off
-#define MEMORY_SNAPSHOT_HARNESS_GENERATOR_HELP                                 \
-  "memory snapshot harness generator (--harness-type\n"                        \
-  "  initialise-from-memory-snapshot)\n\n"                                     \
-  "--memory-snapshot <file>      initialise memory from JSON memory snapshot\n"\
-  "--initial-goto-location <func[:<n>]>\n"                                     \
-  "                              use given function and location number as "   \
-  "entry\n                              point\n"                               \
-  "--initial-source-location <file:n>\n"                                       \
-  "                              use given file and line as entry point\n"     \
-  "--havoc-variables vars        initialise variables from vars to\n"          \
-  "                              non-deterministic values"                     \
-  // MEMORY_SNAPSHOT_HARNESS_GENERATOR_HELP
-// clang-format on
 
 /// Generates a harness which first assigns global variables with values from
 /// a given memory snapshot and then calls a specified function. The called
@@ -271,6 +249,8 @@ protected:
   entry_locationt entry_location;
 
   message_handlert &message_handler;
+
+  recursive_initialization_configt recursive_initialization_config;
 };
 
 #endif // CPROVER_GOTO_HARNESS_MEMORY_SNAPSHOT_HARNESS_GENERATOR_H

--- a/src/goto-harness/memory_snapshot_harness_generator_options.h
+++ b/src/goto-harness/memory_snapshot_harness_generator_options.h
@@ -1,0 +1,63 @@
+/******************************************************************\
+
+Module: memory_snapshot_harness_generator_options
+
+Author: Diffblue Ltd.
+
+\******************************************************************/
+
+#ifndef CPROVER_GOTO_HARNESS_MEMORY_SNAPSHOT_HARNESS_GENERATOR_OPTIONS_H
+#define CPROVER_GOTO_HARNESS_MEMORY_SNAPSHOT_HARNESS_GENERATOR_OPTIONS_H
+
+#include "common_harness_generator_options.h"
+
+#define MEMORY_SNAPSHOT_HARNESS_SNAPSHOT_OPT "memory-snapshot"
+#define MEMORY_SNAPSHOT_HARNESS_INITIAL_GOTO_LOC_OPT "initial-goto-location"
+#define MEMORY_SNAPSHOT_HARNESS_INITIAL_SOURCE_LOC_OPT "initial-source-location"
+#define MEMORY_SNAPSHOT_HARNESS_HAVOC_VARIABLES_OPT "havoc-variables"
+#define MEMORY_SNAPSHOT_HARNESS_TREAT_POINTER_AS_ARRAY_OPT "pointer-as-array"
+#define MEMORY_SNAPSHOT_HARNESS_ASSOCIATED_ARRAY_SIZE_OPT "size-of-array"
+
+// clang-format off
+#define MEMORY_SNAPSHOT_HARNESS_GENERATOR_OPTIONS                              \
+  "(" MEMORY_SNAPSHOT_HARNESS_SNAPSHOT_OPT "):"                                \
+  "(" MEMORY_SNAPSHOT_HARNESS_INITIAL_GOTO_LOC_OPT "):"                        \
+  "(" MEMORY_SNAPSHOT_HARNESS_INITIAL_SOURCE_LOC_OPT "):"                      \
+  "(" MEMORY_SNAPSHOT_HARNESS_HAVOC_VARIABLES_OPT "):"                         \
+  "(" MEMORY_SNAPSHOT_HARNESS_TREAT_POINTER_AS_ARRAY_OPT "):"                  \
+  "(" MEMORY_SNAPSHOT_HARNESS_ASSOCIATED_ARRAY_SIZE_OPT "):"                   \
+// MEMORY_SNAPSHOT_HARNESS_GENERATOR_OPTIONS
+
+// clang-format on
+
+// clang-format off
+#define MEMORY_SNAPSHOT_HARNESS_GENERATOR_HELP                                 \
+  "memory snapshot harness generator (--harness-type\n"                        \
+  "  initialise-from-memory-snapshot)\n\n"                                     \
+  "--" MEMORY_SNAPSHOT_HARNESS_SNAPSHOT_OPT " <file>      initialise memory "  \
+  "from JSON memory snapshot\n"                                                \
+  "--" MEMORY_SNAPSHOT_HARNESS_INITIAL_GOTO_LOC_OPT " <func[:<n>]>\n"          \
+  "                              use given function and location number as "   \
+  "entry\n                              point\n"                               \
+  "--" MEMORY_SNAPSHOT_HARNESS_INITIAL_SOURCE_LOC_OPT " <file:<n>>\n"          \
+  "                              use given file name and line number as "      \
+  "entry\n                              point\n"                               \
+  "--" MEMORY_SNAPSHOT_HARNESS_HAVOC_VARIABLES_OPT " vars        initialise"   \
+  " variables from `vars' to\n"                                                \
+  "                              non-deterministic values\n"                   \
+  COMMON_HARNESS_GENERATOR_HELP                                                \
+  "--" MEMORY_SNAPSHOT_HARNESS_TREAT_POINTER_AS_ARRAY_OPT                      \
+  " p    treat the global pointer with the name `p' as\n"                      \
+  "                              an array\n"                                   \
+  "--" MEMORY_SNAPSHOT_HARNESS_ASSOCIATED_ARRAY_SIZE_OPT                       \
+  " array_name:size_name\n"                                                    \
+  "                              set the parameter <size_name> to the size"    \
+  " of\n                              the array <array_name>\n"                \
+  "                              (implies "                                    \
+  "-- " MEMORY_SNAPSHOT_HARNESS_TREAT_POINTER_AS_ARRAY_OPT                     \
+  " <array_name>)\n"                                                           \
+// MEMORY_SNAPSHOT_HARNESS_GENERATOR_HELP
+
+// clang-format on
+
+#endif // CPROVER_GOTO_HARNESS_MEMORY_SNAPSHOT_HARNESS_GENERATOR_OPTIONS_H

--- a/src/goto-harness/recursive_initialization.cpp
+++ b/src/goto-harness/recursive_initialization.cpp
@@ -16,8 +16,62 @@ Author: Diffblue Ltd.
 #include <util/optional_utils.h>
 #include <util/std_code.h>
 #include <util/std_expr.h>
+#include <util/string2int.h>
 
 #include <functional>
+
+bool recursive_initialization_configt::handle_option(
+  const std::string &option,
+  const std::list<std::string> &values)
+{
+  if(option == COMMON_HARNESS_GENERATOR_MIN_NULL_TREE_DEPTH_OPT)
+  {
+    auto const value = require_exactly_one_value(option, values);
+    auto const user_min_null_tree_depth =
+      string2optional<std::size_t>(value, 10);
+    if(user_min_null_tree_depth.has_value())
+    {
+      min_null_tree_depth = user_min_null_tree_depth.value();
+    }
+    else
+    {
+      throw invalid_command_line_argument_exceptiont{
+        "failed to convert `" + value + "' to integer",
+        "--" COMMON_HARNESS_GENERATOR_MIN_NULL_TREE_DEPTH_OPT};
+    }
+    return true;
+  }
+  else if(option == COMMON_HARNESS_GENERATOR_MAX_NONDET_TREE_DEPTH_OPT)
+  {
+    auto const value = require_exactly_one_value(option, values);
+    auto const user_max_nondet_tree_depth =
+      string2optional<std::size_t>(value, 10);
+    if(user_max_nondet_tree_depth.has_value())
+    {
+      max_nondet_tree_depth = user_max_nondet_tree_depth.value();
+    }
+    else
+    {
+      throw invalid_command_line_argument_exceptiont{
+        "failed to convert `" + value + "' to integer",
+        "--" COMMON_HARNESS_GENERATOR_MAX_NONDET_TREE_DEPTH_OPT};
+    }
+    return true;
+  }
+  else if(option == COMMON_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT)
+  {
+    max_dynamic_array_size = require_one_size_value(
+      COMMON_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT, values);
+    return true;
+  }
+  else if(option == COMMON_HARNESS_GENERATOR_MIN_ARRAY_SIZE_OPT)
+  {
+    min_dynamic_array_size = require_one_size_value(
+      COMMON_HARNESS_GENERATOR_MIN_ARRAY_SIZE_OPT, values);
+    return true;
+  }
+  return false;
+}
 
 recursive_initializationt::recursive_initializationt(
   recursive_initialization_configt initialization_config,

--- a/src/goto-harness/recursive_initialization.cpp
+++ b/src/goto-harness/recursive_initialization.cpp
@@ -26,7 +26,8 @@ bool recursive_initialization_configt::handle_option(
 {
   if(option == COMMON_HARNESS_GENERATOR_MIN_NULL_TREE_DEPTH_OPT)
   {
-    auto const value = require_exactly_one_value(option, values);
+    auto const value =
+      harness_options_parser::require_exactly_one_value(option, values);
     auto const user_min_null_tree_depth =
       string2optional<std::size_t>(value, 10);
     if(user_min_null_tree_depth.has_value())
@@ -43,7 +44,8 @@ bool recursive_initialization_configt::handle_option(
   }
   else if(option == COMMON_HARNESS_GENERATOR_MAX_NONDET_TREE_DEPTH_OPT)
   {
-    auto const value = require_exactly_one_value(option, values);
+    auto const value =
+      harness_options_parser::require_exactly_one_value(option, values);
     auto const user_max_nondet_tree_depth =
       string2optional<std::size_t>(value, 10);
     if(user_max_nondet_tree_depth.has_value())
@@ -60,13 +62,13 @@ bool recursive_initialization_configt::handle_option(
   }
   else if(option == COMMON_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT)
   {
-    max_dynamic_array_size = require_one_size_value(
+    max_dynamic_array_size = harness_options_parser::require_one_size_value(
       COMMON_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT, values);
     return true;
   }
   else if(option == COMMON_HARNESS_GENERATOR_MIN_ARRAY_SIZE_OPT)
   {
-    min_dynamic_array_size = require_one_size_value(
+    min_dynamic_array_size = harness_options_parser::require_one_size_value(
       COMMON_HARNESS_GENERATOR_MIN_ARRAY_SIZE_OPT, values);
     return true;
   }

--- a/src/goto-harness/recursive_initialization.h
+++ b/src/goto-harness/recursive_initialization.h
@@ -21,7 +21,7 @@ Author: Diffblue Ltd.
 #include "function_harness_generator_options.h"
 #include "goto_harness_generator.h"
 
-struct recursive_initialization_configt : harness_options_parsert
+struct recursive_initialization_configt
 {
   std::size_t min_null_tree_depth = 1;
   std::size_t max_nondet_tree_depth = 2;
@@ -43,7 +43,7 @@ struct recursive_initialization_configt : harness_options_parsert
   /// \param option: the user option name
   /// \param values: the (one-or-more) values for this option
   /// \return true if the option belonged to recursive initialisation and was
-  /// successfully parsed here
+  ///   successfully parsed here
   bool handle_option(
     const std::string &option,
     const std::list<std::string> &values);

--- a/src/goto-harness/recursive_initialization.h
+++ b/src/goto-harness/recursive_initialization.h
@@ -18,7 +18,10 @@ Author: Diffblue Ltd.
 #include <util/optional.h>
 #include <util/std_types.h>
 
-struct recursive_initialization_configt
+#include "function_harness_generator_options.h"
+#include "goto_harness_generator.h"
+
+struct recursive_initialization_configt : harness_options_parsert
 {
   std::size_t min_null_tree_depth = 1;
   std::size_t max_nondet_tree_depth = 2;
@@ -35,6 +38,15 @@ struct recursive_initialization_configt
   std::set<irep_idt> pointers_to_treat_as_cstrings;
 
   std::string to_string() const; // for debugging purposes
+
+  /// Parse the options specific for recursive initialisation
+  /// \param option: the user option name
+  /// \param values: the (one-or-more) values for this option
+  /// \return true if the option belonged to recursive initialisation and was
+  /// successfully parsed here
+  bool handle_option(
+    const std::string &option,
+    const std::list<std::string> &values);
 };
 
 /// Class for generating initialisation code

--- a/src/memory-analyzer/analyze_symbol.cpp
+++ b/src/memory-analyzer/analyze_symbol.cpp
@@ -160,10 +160,13 @@ exprt gdb_value_extractort::get_char_pointer_value(
 
     values.insert(std::make_pair(memory_location, new_symbol));
 
+    // check that we are returning objects of the right type
+    CHECK_RETURN(new_symbol.type().subtype() == expr.type().subtype());
     return new_symbol;
   }
   else
   {
+    CHECK_RETURN(it->second.type().subtype() == expr.type().subtype());
     return it->second;
   }
 }
@@ -174,7 +177,6 @@ exprt gdb_value_extractort::get_pointer_to_member_value(
   const source_locationt &location)
 {
   PRECONDITION(expr.type().id() == ID_pointer);
-  PRECONDITION(!is_c_char_type(expr.type().subtype()));
   const auto &memory_location = pointer_value.address;
   std::string memory_location_string = memory_location.string();
   PRECONDITION(memory_location_string != "0x0");
@@ -242,7 +244,11 @@ exprt gdb_value_extractort::get_pointer_to_member_value(
 
   const auto maybe_member_expr = get_subexpression_at_offset(
     struct_symbol->symbol_expr(), member_offset, expr.type().subtype(), ns);
-  CHECK_RETURN(maybe_member_expr.has_value());
+  DATA_INVARIANT(
+    maybe_member_expr.has_value(), "structure doesn't have member");
+
+  // check that we return the right type
+  CHECK_RETURN(maybe_member_expr->type() == expr.type().subtype());
   return *maybe_member_expr;
 }
 

--- a/src/memory-analyzer/gdb_api.cpp
+++ b/src/memory-analyzer/gdb_api.cpp
@@ -377,14 +377,23 @@ gdb_apit::pointer_valuet gdb_apit::get_memory(const std::string &expr)
 {
   PRECONDITION(gdb_state == gdb_statet::STOPPED);
 
-  std::string value = eval_expr(expr);
+  std::string value;
+  try
+  {
+    value = eval_expr(expr);
+  }
+  catch(gdb_interaction_exceptiont &e)
+  {
+    return pointer_valuet{};
+  }
 
   std::regex regex(
     r_hex_addr + r_opt(' ' + r_id) + r_opt(' ' + r_or(r_char, r_string)));
 
   std::smatch result;
   const bool b = regex_match(value, result, regex);
-  CHECK_RETURN(b);
+  if(!b)
+    return pointer_valuet{};
 
   optionalt<std::string> opt_string;
   const std::string string = result[4];
@@ -412,14 +421,22 @@ gdb_apit::pointer_valuet gdb_apit::get_memory(const std::string &expr)
     opt_string = string.substr(2, len - 4);
   }
 
-  return pointer_valuet(result[1], result[2], result[3], opt_string);
+  return pointer_valuet(result[1], result[2], result[3], opt_string, true);
 }
 
-std::string gdb_apit::get_value(const std::string &expr)
+optionalt<std::string> gdb_apit::get_value(const std::string &expr)
 {
   PRECONDITION(gdb_state == gdb_statet::STOPPED);
 
-  const std::string value = eval_expr(expr);
+  std::string value;
+  try
+  {
+    value = eval_expr(expr);
+  }
+  catch(gdb_interaction_exceptiont &e)
+  {
+    return {};
+  }
 
   // Get char value
   {
@@ -431,7 +448,7 @@ std::string gdb_apit::get_value(const std::string &expr)
 
     if(b)
     {
-      return result[1];
+      return std::string{result[1]};
     }
   }
 

--- a/src/memory-analyzer/gdb_api.h
+++ b/src/memory-analyzer/gdb_api.h
@@ -90,6 +90,17 @@ public:
     }
   };
 
+  /// Get the allocated size estimate for a pointer by evaluating
+  /// `malloc_usable_size'. The function returns the number of usable bytes in
+  /// the block pointed to by the pointer to a block of memory allocated by
+  /// `malloc' or a related function. The value may be greater than the
+  /// requested size of the allocation because of alignment and minimum size
+  /// constraints.
+  /// \param pointer_expr: expression with a pointer name
+  /// \return 1 if the pointer was not allocated with malloc otherwise return
+  ///   the result of calling `malloc_usable_size'
+  size_t query_malloc_size(const std::string &pointer_expr);
+
   /// Create a new gdb process for analysing the binary indicated by the member
   /// variable `binary`
   void create_gdb_process();

--- a/src/memory-analyzer/gdb_api.h
+++ b/src/memory-analyzer/gdb_api.h
@@ -68,13 +68,17 @@ public:
 
   struct pointer_valuet
   {
-    pointer_valuet() = delete;
     pointer_valuet(
-      const std::string &address,
-      const std::string &pointee,
-      const std::string &character,
-      const optionalt<std::string> &string)
-      : address(address), pointee(pointee), character(character), string(string)
+      const std::string &address = "",
+      const std::string &pointee = "",
+      const std::string &character = "",
+      const optionalt<std::string> &string = nullopt,
+      const bool valid = false)
+      : address(address),
+        pointee(pointee),
+        character(character),
+        string(string),
+        valid(valid)
     {
     }
 
@@ -88,6 +92,8 @@ public:
       return std::any_of(
         pointee.begin(), pointee.end(), [](char c) { return c == '+'; });
     }
+
+    bool valid;
   };
 
   /// Get the allocated size estimate for a pointer by evaluating
@@ -115,17 +121,12 @@ public:
   /// \param corefile: core dump
   void run_gdb_from_core(const std::string &corefile);
 
-  /// Get value of the given value expression
-  /// \param expr: an expression of non-pointer type or pointer to char
-  /// \return value of the expression; if the expression is of type pointer to
-  ///   char and represents a string, the string value is returned; otherwise
-  ///   the value is returned just as it is printed by gdb
-  std::string get_value(const std::string &expr);
-
   /// Get the memory address pointed to by the given pointer expression
   /// \param expr: an expression of pointer type (e.g., `&x` with `x` being of
   ///   type `int` or `p` with `p` being of type `int *`)
   /// \return memory address in hex format
+  optionalt<std::string> get_value(const std::string &expr);
+
   pointer_valuet get_memory(const std::string &expr);
 
   /// Return the vector of commands that have been written to gdb so far

--- a/src/util/c_types_util.h
+++ b/src/util/c_types_util.h
@@ -100,9 +100,9 @@ constant_exprt convert_member_name_to_enum_value(
 /// Convert id to a Boolean value
 /// \param bool_value: A string that is compared to "true" ignoring case.
 /// \return a constant of type Boolean
-bool id2boolean(const irep_idt &bool_value)
+bool id2boolean(const std::string &bool_value)
 {
-  std::string string_value = id2string(bool_value);
+  std::string string_value = bool_value;
   std::transform(
     string_value.begin(), string_value.end(), string_value.begin(), ::tolower);
   if(string_value == "true")

--- a/unit/memory-analyzer/gdb_api.cpp
+++ b/unit/memory-analyzer/gdb_api.cpp
@@ -167,9 +167,16 @@ TEST_CASE("gdb api test", "[core][memory-analyzer]")
     const bool r = gdb_api.run_gdb_to_breakpoint("checkpoint");
     REQUIRE(r);
 
-    REQUIRE(gdb_api.get_value("x") == "8");
-    REQUIRE(gdb_api.get_value("y") == "2.5");
-    REQUIRE(gdb_api.get_value("z") == "c");
+    const auto &x_value = gdb_api.get_value("x");
+    const auto &y_value = gdb_api.get_value("y");
+    const auto &z_value = gdb_api.get_value("z");
+
+    REQUIRE(x_value.has_value());
+    REQUIRE(*x_value == "8");
+    REQUIRE(y_value.has_value());
+    REQUIRE(*y_value == "2.5");
+    REQUIRE(z_value.has_value());
+    REQUIRE(*z_value == "c");
   }
 
   SECTION("query pointers")


### PR DESCRIPTION
In #4438 we build support for recovering structs and pointers in goto-harness from a memory snapshot. The havocing there was by default: the user couldn't change how deeply will the structs and array-pointers initialised. This PR unifies the control over non-deterministic initialisation between function-call and memory-snapshot harnesses, consequently allowing the user to control the initialisation in memory-snapshot harness as well.

Pointers to arrays are initialised in a similar fashion to function-call harness, i.e. the user has to declare which variable contains the size of the array.

Also dynamically allocated pointers in the source-program and changed into statically allocated arrays in the memory snapshot, so that it would be legal to query about their content in the harness-program.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
