### PR TITLE
Change erase() method of the sharing map to require that key exists

### DIFF
--- a/src/goto-symex/symex_dead.cpp
+++ b/src/goto-symex/symex_dead.cpp
@@ -28,7 +28,12 @@ void goto_symext::symex_dead(statet &state)
   // information is not local to a path, but removing it from the propagation
   // map and value-set is safe as 1) it is local to a path and 2) this instance
   // can no longer appear
-  state.value_set.values.erase(l1_identifier);
+
+  if(state.value_set.values.has_key(l1_identifier))
+  {
+    state.value_set.values.erase(l1_identifier);
+  }
+
   state.propagation.erase(l1_identifier);
   // Remove from the local L2 renaming map; this means any reads from the dead
   // identifier will use generation 0 (e.g. x!N@M#0, where N and M are positive

--- a/unit/util/sharing_map.cpp
+++ b/unit/util/sharing_map.cpp
@@ -193,13 +193,12 @@ TEST_CASE("Sharing map interface", "[core][util]")
     sm.insert("i", "0");
     sm.insert("j", "1");
 
-    REQUIRE(sm.erase("k") == 0);
     REQUIRE(sm.size() == 2);
 
-    REQUIRE(sm.erase("i") == 1);
+    sm.erase("i");
     REQUIRE(!sm.has_key("i"));
 
-    REQUIRE(sm.erase("j") == 1);
+    sm.erase("j");
     REQUIRE(!sm.has_key("j"));
 
     sm.insert("i", "0");
@@ -232,7 +231,7 @@ TEST_CASE("Sharing map copying", "[core][util]")
 
   sharing_map_standardt sm2(sm1);
 
-  REQUIRE(sm2.erase("i") == 1);
+  sm2.erase("i");
   REQUIRE(!sm2.has_key("i"));
   REQUIRE(sm1.has_key("i"));
 
@@ -509,4 +508,12 @@ TEST_CASE("Sharing map insert existing", "[.]")
   fill(sm);
 
   sm.insert("i", "4");
+}
+
+TEST_CASE("Sharing map erase non-existing", "[.]")
+{
+  sharing_map_standardt sm;
+  fill(sm);
+
+  sm.erase("x");
 }


### PR DESCRIPTION
Previously when `sharing_map.erase(key)` was called, two traversals of the path to the leaf to erase were done. One to check whether the key was in the map, and if it was, a second one to copy and detach the nodes on the path to the leaf. This commit changes `erase()` to require that the given key exists in the map. This simplifies the implementation and avoids two traversals of the path to the leaf when it is known that the key exists. If it is not known whether the key exists, `sharing_map.has_key(key)` should be explicitely called first.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
