### PR TITLE
fix sorting in symbol_table_baset::show

### DIFF
--- a/src/goto-programs/show_symbol_table.cpp
+++ b/src/goto-programs/show_symbol_table.cpp
@@ -70,17 +70,10 @@ void show_symbol_table_plain(
 {
   out << '\n' << "Symbols:" << '\n' << '\n';
 
-  // we want to sort alphabetically
-  std::vector<std::string> symbols;
-  symbols.reserve(symbol_table.symbols.size());
-
-  for(const auto &symbol_pair : symbol_table.symbols)
-    symbols.push_back(id2string(symbol_pair.first));
-  std::sort(symbols.begin(), symbols.end());
-
   const namespacet ns(symbol_table);
 
-  for(const irep_idt &id : symbols)
+  // we want to sort alphabetically
+  for(const irep_idt &id : symbol_table.sorted_symbol_names())
   {
     const symbolt &symbol=ns.lookup(id);
 

--- a/src/util/symbol_table_base.cpp
+++ b/src/util/symbol_table_base.cpp
@@ -33,22 +33,30 @@ bool symbol_table_baset::remove(const irep_idt &name)
   return false;
 }
 
+std::vector<irep_idt> symbol_table_baset::sorted_symbol_names() const
+{
+  std::vector<irep_idt> sorted_names;
+  sorted_names.reserve(symbols.size());
+
+  for(const auto &elem : symbols)
+    sorted_names.push_back(elem.first);
+
+  std::sort(
+    sorted_names.begin(),
+    sorted_names.end(),
+    [](const irep_idt &a, const irep_idt &b) { return a.compare(b) < 0; });
+
+  return sorted_names;
+}
+
 /// Print the contents of the symbol table.
 /// \param out: The ostream to direct output to.
 void symbol_table_baset::show(std::ostream &out) const
 {
-  std::vector<irep_idt> sorted_names;
-  sorted_names.reserve(symbols.size());
-  for(const auto &elem : symbols)
-    sorted_names.push_back(elem.first);
-  std::sort(
-    sorted_names.begin(),
-    sorted_names.end(),
-    [](const irep_idt &a, const irep_idt &b) { return a.compare(b); });
   out << "\n"
       << "Symbols:"
       << "\n";
-  for(const auto &name : sorted_names)
+  for(const auto &name : sorted_symbol_names())
     out << symbols.at(name);
 }
 

--- a/src/util/symbol_table_base.h
+++ b/src/util/symbol_table_base.h
@@ -136,6 +136,10 @@ public:
 
   void show(std::ostream &out) const;
 
+  /// Build and return a lexicographically sorted vector of symbol names from
+  /// all symbols stored in this symbol table.
+  std::vector<irep_idt> sorted_symbol_names() const;
+
   class iteratort
   {
   private:


### PR DESCRIPTION
This is a fix for 25ffad4199; `std::string::compare` returns an integer <0,
==0 or >0, but `std::sort` wants a boolean when <0.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
