### PR TITLE
decision_proceduret interface

### DIFF
--- a/src/solvers/prop/decision_procedure.h
+++ b/src/solvers/prop/decision_procedure.h
@@ -34,7 +34,13 @@ public:
   void set_to_false(const exprt &expr);
 
   /// Convert a Boolean expression and return the corresponding literal
+  /// This will go away, use handle(expr) instead
   virtual literalt convert(const exprt &expr) = 0;
+
+  /// Generate a handle for an expression; this offers an efficient way
+  /// to refer to the expression in subsequent calls to \ref get or
+  /// \ref set_to
+  virtual exprt handle(const exprt &expr) = 0;
 
   /// Result of running the decision procedure
   enum class resultt
@@ -54,6 +60,7 @@ public:
 
   /// Return value of literal \p l from satisfying assignment.
   /// Return tvt::UNKNOWN if not available
+  /// This will go away, use get instead.
   virtual tvt l_get(literalt l) const = 0;
 
   /// Print satisfying assignment to \p out

--- a/src/solvers/prop/prop_conv.cpp
+++ b/src/solvers/prop/prop_conv.cpp
@@ -7,7 +7,15 @@ Author: Daniel Kroening, kroening@kroening.com
 \*******************************************************************/
 
 #include "prop_conv.h"
+
+#include "literal_expr.h"
+
 #include <algorithm>
+
+exprt prop_convt::handle(const exprt &expr)
+{
+  return literal_exprt(convert(expr));
+}
 
 /// determine whether a variable is in the final conflict
 bool prop_convt::is_in_conflict(literalt) const

--- a/src/solvers/prop/prop_conv.h
+++ b/src/solvers/prop/prop_conv.h
@@ -22,6 +22,13 @@ public:
 
   using decision_proceduret::operator();
 
+  /// returns a 'handle', which is an expression that
+  /// has the same value as the argument in any model
+  /// that is generated.
+  /// This may be the expression itself or a more compact
+  /// but solver-specific representation.
+  exprt handle(const exprt &expr) override;
+
   // incremental solving
   virtual void set_frozen(literalt a);
   virtual void set_frozen(const bvt &);


### PR DESCRIPTION
This re-establishes a simpler interface for solvers. In particular, the concept of 'literal' is not exposed, which is specific to DPLL-style SAT solvers.

The new interface is in particular a much better fit for SMT2 solvers, which right now need to emulate a CNF-style interface.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
