### PR TITLE
Ensure Java stubbing names parameters [blocks: #4485]

### DIFF
--- a/jbmc/src/java_bytecode/simple_method_stubbing.cpp
+++ b/jbmc/src/java_bytecode/simple_method_stubbing.cpp
@@ -148,11 +148,28 @@ void java_simple_method_stubst::create_method_stub_at(
 void java_simple_method_stubst::create_method_stub(symbolt &symbol)
 {
   code_blockt new_instructions;
-  const java_method_typet &required_type = to_java_method_type(symbol.type);
+  java_method_typet &required_type = to_java_method_type(symbol.type);
 
   // synthetic source location that contains the opaque function name only
   source_locationt synthesized_source_location;
   synthesized_source_location.set_function(symbol.name);
+
+  // make sure all parameters are named
+  for(auto &parameter : required_type.parameters())
+  {
+    if(parameter.get_identifier().empty())
+    {
+      symbolt &parameter_symbol = fresh_java_symbol(
+        parameter.type(),
+        "#anon",
+        synthesized_source_location,
+        symbol.name,
+        symbol_table);
+      parameter_symbol.is_parameter = true;
+      parameter.set_base_name(parameter_symbol.base_name);
+      parameter.set_identifier(parameter_symbol.name);
+    }
+  }
 
   // Initialize the return value or `this` parameter under construction.
   // Note symbol.type is required_type, but with write access

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -159,6 +159,15 @@ void goto_convert_functionst::convert_function(
      symbol.is_compiled()) /* goto_inline may have removed the body */
     return;
 
+  // we have a body, make sure all parameter names are valid
+  for(const auto &p : f.parameter_identifiers)
+  {
+    DATA_INVARIANT(!p.empty(), "parameter identifier should not be empty");
+    DATA_INVARIANT(
+      symbol_table.has_symbol(p),
+      "parameter identifier must be a known symbol");
+  }
+
   lifetimet parent_lifetime = lifetime;
   lifetime = identifier == INITIALIZE_FUNCTION ? lifetimet::STATIC_GLOBAL
                                                : lifetimet::AUTOMATIC_LOCAL;


### PR DESCRIPTION
For functions with a body we require that parameters are named so that
we can generate assignments to them (even when the body may not read the
value). Also guard against future regressions by sanity checking
parameter names for any converted function.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
