### PR TITLE
Use the sharing map for the renaming level maps

### DIFF
--- a/src/goto-symex/auto_objects.cpp
+++ b/src/goto-symex/auto_objects.cpp
@@ -90,9 +90,8 @@ void goto_symext::trigger_auto_object(const exprt &expr, statet &state)
         if(has_prefix(id2string(symbol.base_name), "auto_object"))
         {
           // done already?
-          if(
-            state.get_level2().current_names.find(ssa_expr.get_identifier()) ==
-            state.get_level2().current_names.end())
+          if(!state.get_level2().current_names.has_key(
+               ssa_expr.get_identifier()))
           {
             initialize_auto_object(e, state);
           }

--- a/src/goto-symex/goto_state.cpp
+++ b/src/goto-symex/goto_state.cpp
@@ -31,13 +31,22 @@ std::size_t goto_statet::increase_generation(
   const ssa_exprt &lhs,
   std::function<std::size_t(const irep_idt &)> fresh_l2_name_provider)
 {
-  auto current_emplace_res =
-    level2.current_names.emplace(l1_identifier, std::make_pair(lhs, 0));
+  std::size_t n = fresh_l2_name_provider(l1_identifier);
 
-  current_emplace_res.first->second.second =
-    fresh_l2_name_provider(l1_identifier);
+  const auto r_opt = level2.current_names.find(l1_identifier);
 
-  return current_emplace_res.first->second.second;
+  if(!r_opt)
+  {
+    level2.current_names.insert(l1_identifier, std::make_pair(lhs, n));
+  }
+  else
+  {
+    std::pair<ssa_exprt, unsigned> copy = r_opt->get();
+    copy.second = n;
+    level2.current_names.replace(l1_identifier, std::move(copy));
+  }
+
+  return n;
 }
 
 /// Given a condition that must hold on this path, propagate as much knowledge

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -795,16 +795,21 @@ ssa_exprt goto_symex_statet::add_object(
   const irep_idt l0_name = ssa.get_identifier();
   const std::size_t l1_index = index_generator(l0_name);
 
-  // save old L1 name, if any
-  auto existing_or_new_entry = level1.current_names.emplace(
-    std::piecewise_construct,
-    std::forward_as_tuple(l0_name),
-    std::forward_as_tuple(ssa, l1_index));
+  const auto r_opt = level1.current_names.find(l0_name);
 
-  if(!existing_or_new_entry.second)
+  if(!r_opt)
   {
-    frame.old_level1.emplace(l0_name, existing_or_new_entry.first->second);
-    existing_or_new_entry.first->second = std::make_pair(ssa, l1_index);
+    level1.current_names.insert(l0_name, std::make_pair(ssa, l1_index));
+  }
+  else
+  {
+    // save old L1 name
+    if(!frame.old_level1.has_key(l0_name))
+    {
+      frame.old_level1.insert(l0_name, r_opt->get());
+    }
+
+    level1.current_names.replace(l0_name, std::make_pair(ssa, l1_index));
   }
 
   ssa = rename_ssa<L1>(std::move(ssa), ns).get();

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -226,15 +226,15 @@ public:
   }
 
   /// Drops an L1 name from the local L2 map
-  void drop_l1_name(symex_renaming_levelt::current_namest::const_iterator it)
+  void drop_existing_l1_name(const irep_idt &l1_identifier)
   {
-    level2.current_names.erase(it);
+    level2.current_names.erase(l1_identifier);
   }
 
   /// Drops an L1 name from the local L2 map
   void drop_l1_name(const irep_idt &l1_identifier)
   {
-    level2.current_names.erase(l1_identifier);
+    level2.current_names.erase_if_exists(l1_identifier);
   }
 
   std::function<std::size_t(const irep_idt &)> get_l2_name_provider() const


### PR DESCRIPTION
Use the sharing map for the renaming level maps `current_names` in `symex_renaming_levelt`. The code in this PR has a few issues which I'll fix once we've decided whether to merge it.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
