### PR TITLE
Remove message_handler field of ui_message_handler

### DIFF
--- a/src/util/ui_message.h
+++ b/src/util/ui_message.h
@@ -26,7 +26,7 @@ public:
     ui_message_handlert(make(cmdline, program))
   { }
 
-  explicit ui_message_handlert(message_handlert &);
+  explicit ui_message_handlert(std::unique_ptr<message_handlert>);
   ui_message_handlert(ui_message_handlert &&) = default;
 
   virtual ~ui_message_handlert();
@@ -46,7 +46,6 @@ public:
 
 protected:
   std::unique_ptr<console_message_handlert> console_message_handler;
-  message_handlert *message_handler;
   uit _ui;
   const bool always_flush;
   std::unique_ptr<const timestampert> time;
@@ -54,7 +53,7 @@ protected:
   std::unique_ptr<json_stream_arrayt> json_stream;
 
   ui_message_handlert(
-    message_handlert *,
+    std::unique_ptr<message_handlert>,
     uit,
     const std::string &program,
     const bool always_flush,
@@ -93,14 +92,6 @@ protected:
     const source_locationt &location);
 
   const char *level_string(unsigned level);
-
-  std::string command(unsigned c) const override
-  {
-    if(message_handler)
-      return message_handler->command(c);
-    else
-      return std::string();
-  }
 
   static ui_message_handlert
   make(const class cmdlinet &, const std::string &program);

--- a/src/util/ui_message.h
+++ b/src/util/ui_message.h
@@ -21,7 +21,10 @@ class ui_message_handlert : public message_handlert
 public:
   enum class uit { PLAIN, XML_UI, JSON_UI };
 
-  ui_message_handlert(const class cmdlinet &, const std::string &program);
+  ui_message_handlert(
+    const class cmdlinet &cmdline, const std::string &program):
+    ui_message_handlert(make(cmdline, program))
+  { }
 
   explicit ui_message_handlert(message_handlert &);
   ui_message_handlert(ui_message_handlert &&) = default;
@@ -98,6 +101,9 @@ protected:
     else
       return std::string();
   }
+
+  static ui_message_handlert
+  make(const class cmdlinet &, const std::string &program);
 };
 
 #define OPT_FLUSH "(flush)"

--- a/unit/analyses/ai/ai_simplify_lhs.cpp
+++ b/unit/analyses/ai/ai_simplify_lhs.cpp
@@ -71,7 +71,8 @@ bool constant_simplification_mockt::ai_simplify(
 SCENARIO("ai_domain_baset::ai_simplify_lhs",
   "[core][analyses][ai][ai_simplify_lhs]")
 {
-  ui_message_handlert message_handler(null_message_handler);
+  ui_message_handlert message_handler{
+    util_make_unique<null_message_handlert>()};
   ansi_c_languaget language;
   language.set_message_handler(message_handler);
 

--- a/unit/goto-instrument/cover/cover_only.cpp
+++ b/unit/goto-instrument/cover/cover_only.cpp
@@ -52,7 +52,8 @@ SCENARIO("get_cover_config is called", "[core]")
 
   goto_functiont dummy_function;
 
-  ui_message_handlert message_handler(null_message_handler);
+  ui_message_handlert message_handler{
+    util_make_unique<null_message_handlert>()};
 
   GIVEN("cover-only set to an unrecognised value")
   {


### PR DESCRIPTION
Having ui_message_handlert both inherit from message_handler and have a
message handler pointer field is confusing.
We remove the field and keep inheritance. Because one of the constructor
becomes too complicated we make it into a static make function.
This in particular solves the problem of verbosity not being correct
because it is inherited and not fetched from the pointer field.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
