### PR TITLE
Clean up usage of messaget in *_parse_options classes

### DIFF
--- a/jbmc/src/janalyzer/janalyzer_parse_options.h
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.h
@@ -150,7 +150,7 @@ class optionst;
   JAVA_BYTECODE_LANGUAGE_OPTIONS
 // clang-format on
 
-class janalyzer_parse_optionst : public parse_options_baset, public messaget
+class janalyzer_parse_optionst : public parse_options_baset
 {
 public:
   virtual int doit() override;

--- a/jbmc/src/jdiff/jdiff_parse_options.cpp
+++ b/jbmc/src/jdiff/jdiff_parse_options.cpp
@@ -63,7 +63,6 @@ Author: Peter Schrammel
 
 jdiff_parse_optionst::jdiff_parse_optionst(int argc, const char **argv)
   : parse_options_baset(JDIFF_OPTIONS, argc, argv, ui_message_handler),
-    messaget(ui_message_handler),
     ui_message_handler(cmdline, std::string("JDIFF ") + CBMC_VERSION)
 {
 }
@@ -186,19 +185,19 @@ int jdiff_parse_optionst::doit()
 
   optionst options;
   get_command_line_options(options);
-  eval_verbosity(
+  messaget::eval_verbosity(
     cmdline.get_value("verbosity"), messaget::M_STATISTICS, ui_message_handler);
 
   //
   // Print a banner
   //
-  status() << "JDIFF version " << CBMC_VERSION << " " << sizeof(void *) * 8
-           << "-bit " << config.this_architecture() << " "
-           << config.this_operating_system() << eom;
+  log.status() << "JDIFF version " << CBMC_VERSION << " " << sizeof(void *) * 8
+               << "-bit " << config.this_architecture() << " "
+               << config.this_operating_system() << messaget::eom;
 
   if(cmdline.args.size() != 2)
   {
-    error() << "Please provide two programs to compare" << eom;
+    log.error() << "Please provide two programs to compare" << messaget::eom;
     return CPROVER_EXIT_INCORRECT_TASK;
   }
 
@@ -226,12 +225,12 @@ int jdiff_parse_optionst::doit()
   {
     show_goto_functions(
       goto_model1,
-      get_message_handler(),
+      log.get_message_handler(),
       ui_message_handler.get_ui(),
       cmdline.isset("list-goto-functions"));
     show_goto_functions(
       goto_model2,
-      get_message_handler(),
+      log.get_message_handler(),
       ui_message_handler.get_ui(),
       cmdline.isset("list-goto-functions"));
     return CPROVER_EXIT_SUCCESS;
@@ -275,20 +274,21 @@ bool jdiff_parse_optionst::process_goto_program(
 {
   {
     // remove function pointers
-    status() << "Removing function pointers and virtual functions" << eom;
+    log.status() << "Removing function pointers and virtual functions"
+                 << messaget::eom;
     remove_function_pointers(
-      get_message_handler(), goto_model, cmdline.isset("pointer-check"));
+      log.get_message_handler(), goto_model, cmdline.isset("pointer-check"));
 
     // Java virtual functions -> explicit dispatch tables:
     remove_virtual_functions(goto_model);
 
     // remove Java throw and catch
     // This introduces instanceof, so order is important:
-    remove_exceptions_using_instanceof(goto_model, get_message_handler());
+    remove_exceptions_using_instanceof(goto_model, log.get_message_handler());
 
     // Java instanceof -> clsid comparison:
     class_hierarchyt class_hierarchy(goto_model.symbol_table);
-    remove_instanceof(goto_model, class_hierarchy, get_message_handler());
+    remove_instanceof(goto_model, class_hierarchy, log.get_message_handler());
 
     mm_io(goto_model);
 
@@ -302,7 +302,7 @@ bool jdiff_parse_optionst::process_goto_program(
     rewrite_union(goto_model);
 
     // add generic checks
-    status() << "Generic Property Instrumentation" << eom;
+    log.status() << "Generic Property Instrumentation" << messaget::eom;
     goto_check(options, goto_model);
 
     // checks don't know about adjusted float expressions
@@ -322,9 +322,9 @@ bool jdiff_parse_optionst::process_goto_program(
     if(cmdline.isset("cover"))
     {
       const auto cover_config = get_cover_config(
-        options, goto_model.symbol_table, get_message_handler());
+        options, goto_model.symbol_table, log.get_message_handler());
       if(instrument_cover_goals(
-           cover_config, goto_model, get_message_handler()))
+           cover_config, goto_model, log.get_message_handler()))
         return true;
     }
 

--- a/jbmc/src/jdiff/jdiff_parse_options.h
+++ b/jbmc/src/jdiff/jdiff_parse_options.h
@@ -40,7 +40,7 @@ class goto_modelt;
   "(compact-output)"
 // clang-format on
 
-class jdiff_parse_optionst : public parse_options_baset, public messaget
+class jdiff_parse_optionst : public parse_options_baset
 {
 public:
   virtual int doit();

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -65,7 +65,6 @@ Author: Peter Schrammel
 
 goto_diff_parse_optionst::goto_diff_parse_optionst(int argc, const char **argv)
   : parse_options_baset(GOTO_DIFF_OPTIONS, argc, argv, ui_message_handler),
-    messaget(ui_message_handler),
     ui_message_handler(cmdline, std::string("GOTO-DIFF ") + CBMC_VERSION)
 {
 }
@@ -201,8 +200,8 @@ void goto_diff_parse_optionst::get_command_line_options(optionst &options)
   if(options.get_bool_option("partial-loops") &&
      options.get_bool_option("unwinding-assertions"))
   {
-    error() << "--partial-loops and --unwinding-assertions"
-            << " must not be given together" << eom;
+    log.error() << "--partial-loops and --unwinding-assertions"
+                << " must not be given together" << messaget::eom;
     exit(1);
   }
 
@@ -224,19 +223,19 @@ int goto_diff_parse_optionst::doit()
 
   optionst options;
   get_command_line_options(options);
-  eval_verbosity(
+  messaget::eval_verbosity(
     cmdline.get_value("verbosity"), messaget::M_STATISTICS, ui_message_handler);
 
   //
   // Print a banner
   //
-  status() << "GOTO-DIFF version " << CBMC_VERSION << " " << sizeof(void *) * 8
-           << "-bit " << config.this_architecture() << " "
-           << config.this_operating_system() << eom;
+  log.status() << "GOTO-DIFF version " << CBMC_VERSION << " "
+               << sizeof(void *) * 8 << "-bit " << config.this_architecture()
+               << " " << config.this_operating_system() << messaget::eom;
 
   if(cmdline.args.size()!=2)
   {
-    error() << "Please provide two programs to compare" << eom;
+    log.error() << "Please provide two programs to compare" << messaget::eom;
     return CPROVER_EXIT_INCORRECT_TASK;
   }
 
@@ -264,12 +263,12 @@ int goto_diff_parse_optionst::doit()
   {
     show_goto_functions(
       goto_model1,
-      get_message_handler(),
+      log.get_message_handler(),
       ui_message_handler.get_ui(),
       cmdline.isset("list-goto-functions"));
     show_goto_functions(
       goto_model2,
-      get_message_handler(),
+      log.get_message_handler(),
       ui_message_handler.get_ui(),
       cmdline.isset("list-goto-functions"));
     return CPROVER_EXIT_SUCCESS;
@@ -321,16 +320,18 @@ bool goto_diff_parse_optionst::process_goto_program(
     remove_asm(goto_model);
 
     // add the library
-    status() << "Adding CPROVER library (" << config.ansi_c.arch << ")" << eom;
+    log.status() << "Adding CPROVER library (" << config.ansi_c.arch << ")"
+                 << messaget::eom;
     link_to_library(
-      goto_model, get_message_handler(), cprover_cpp_library_factory);
+      goto_model, log.get_message_handler(), cprover_cpp_library_factory);
     link_to_library(
-      goto_model, get_message_handler(), cprover_c_library_factory);
+      goto_model, log.get_message_handler(), cprover_c_library_factory);
 
     // remove function pointers
-    status() << "Removal of function pointers and virtual functions" << eom;
+    log.status() << "Removal of function pointers and virtual functions"
+                 << messaget::eom;
     remove_function_pointers(
-      get_message_handler(), goto_model, cmdline.isset("pointer-check"));
+      log.get_message_handler(), goto_model, cmdline.isset("pointer-check"));
 
     mm_io(goto_model);
 
@@ -344,7 +345,7 @@ bool goto_diff_parse_optionst::process_goto_program(
     rewrite_union(goto_model);
 
     // add generic checks
-    status() << "Generic Property Instrumentation" << eom;
+    log.status() << "Generic Property Instrumentation" << messaget::eom;
     goto_check(options, goto_model);
 
     // checks don't know about adjusted float expressions
@@ -364,9 +365,9 @@ bool goto_diff_parse_optionst::process_goto_program(
       remove_skip(goto_model);
 
       const auto cover_config = get_cover_config(
-        options, goto_model.symbol_table, get_message_handler());
+        options, goto_model.symbol_table, log.get_message_handler());
       if(instrument_cover_goals(
-           cover_config, goto_model, get_message_handler()))
+           cover_config, goto_model, log.get_message_handler()))
         return true;
     }
 

--- a/src/goto-diff/goto_diff_parse_options.h
+++ b/src/goto-diff/goto_diff_parse_options.h
@@ -39,7 +39,7 @@ class optionst;
   "(compact-output)"
 // clang-format on
 
-class goto_diff_parse_optionst : public parse_options_baset, public messaget
+class goto_diff_parse_optionst : public parse_options_baset
 {
 public:
   virtual int doit();

--- a/src/goto-harness/goto_harness_parse_options.cpp
+++ b/src/goto-harness/goto_harness_parse_options.cpp
@@ -41,7 +41,7 @@ int goto_harness_parse_optionst::doit()
 {
   if(cmdline.isset("version"))
   {
-    logger.status() << CBMC_VERSION << '\n';
+    log.status() << CBMC_VERSION << '\n';
     return CPROVER_EXIT_SUCCESS;
   }
 
@@ -55,7 +55,7 @@ int goto_harness_parse_optionst::doit()
 
   // Read goto binary into goto-model
   auto read_goto_binary_result =
-    read_goto_binary(got_harness_config.in_file, logger.get_message_handler());
+    read_goto_binary(got_harness_config.in_file, log.get_message_handler());
   if(!read_goto_binary_result.has_value())
   {
     throw deserialization_exceptiont{"failed to read goto program from file `" +
@@ -89,7 +89,7 @@ int goto_harness_parse_optionst::doit()
 
   // Write end result to new goto-binary
   if(write_goto_binary(
-       got_harness_config.out_file, goto_model, logger.get_message_handler()))
+       got_harness_config.out_file, goto_model, log.get_message_handler()))
   {
     throw system_exceptiont{"failed to write goto program from file `" +
                             got_harness_config.out_file + "'"};
@@ -100,7 +100,7 @@ int goto_harness_parse_optionst::doit()
 
 void goto_harness_parse_optionst::help()
 {
-  logger.status()
+  log.status()
     << '\n'
     << banner_string("Goto-Harness", CBMC_VERSION) << '\n'
     << align_center_with_border("Copyright (C) 2019") << '\n'
@@ -127,8 +127,7 @@ goto_harness_parse_optionst::goto_harness_parse_optionst(
   int argc,
   const char *argv[])
   : parse_options_baset{GOTO_HARNESS_OPTIONS, argc, argv, ui_message_handler},
-    ui_message_handler(cmdline, std::string("GOTO-HARNESS ") + CBMC_VERSION),
-    logger(ui_message_handler)
+    ui_message_handler(cmdline, std::string("GOTO-HARNESS ") + CBMC_VERSION)
 {
 }
 

--- a/src/goto-harness/goto_harness_parse_options.h
+++ b/src/goto-harness/goto_harness_parse_options.h
@@ -46,7 +46,6 @@ private:
   };
 
   ui_message_handlert ui_message_handler;
-  messaget logger;
 
   /// Handle command line arguments that are common to all
   /// harness generators.


### PR DESCRIPTION
Several classes inherits from messaget when they are not meant to be used as messaget.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
