### PR TITLE
Use bv_typet to fix type consistency in byte-operator lowering

### DIFF
--- a/regression/cbmc/Bitfields3/paths.desc
+++ b/regression/cbmc/Bitfields3/paths.desc
@@ -6,3 +6,6 @@ main.c
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
+--
+This test is marked broken-smt-backend for performance reasons only: it passes,
+but takes 5 seconds to do so.

--- a/regression/cbmc/Bitfields3/test.desc
+++ b/regression/cbmc/Bitfields3/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc/Malloc23/test.desc
+++ b/regression/cbmc/Malloc23/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --pointer-check
 ^EXIT=10$

--- a/regression/cbmc/Pointer_Arithmetic11/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic11/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --pointer-check --little-endian
 ^EXIT=0$

--- a/regression/cbmc/Pointer_byte_extract2/test.desc
+++ b/regression/cbmc/Pointer_byte_extract2/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --little-endian
 ^EXIT=10$

--- a/regression/cbmc/Pointer_byte_extract9/test.desc
+++ b/regression/cbmc/Pointer_byte_extract9/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/Quantifiers-assignment/test.desc
+++ b/regression/cbmc/Quantifiers-assignment/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 
 ^\*\* Results:$

--- a/regression/cbmc/byte_update3/test.desc
+++ b/regression/cbmc/byte_update3/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --little-endian
 ^EXIT=0$

--- a/regression/cbmc/byte_update5/test.desc
+++ b/regression/cbmc/byte_update5/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --little-endian
 ^EXIT=0$

--- a/regression/cbmc/memory_allocation2/test.desc
+++ b/regression/cbmc/memory_allocation2/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --bounds-check
 ^EXIT=10$

--- a/src/solvers/flattening/boolbv_typecast.cpp
+++ b/src/solvers/flattening/boolbv_typecast.cpp
@@ -260,7 +260,7 @@ bool boolbvt::type_conversion(
     {
       INVARIANT(
         src_width == dest_width,
-        "source bitvector with shall equal the destination bitvector width");
+        "source bitvector width shall equal the destination bitvector width");
       dest=src;
       return false;
     }
@@ -418,7 +418,7 @@ bool boolbvt::type_conversion(
       case bvtypet::IS_BV:
         INVARIANT(
           src_width == dest_width,
-          "source bitvector with shall equal the destination bitvector width");
+          "source bitvector width shall equal the destination bitvector width");
         dest = src;
         return false;
 

--- a/src/solvers/flattening/boolbv_typecast.cpp
+++ b/src/solvers/flattening/boolbv_typecast.cpp
@@ -415,31 +415,31 @@ bool boolbvt::type_conversion(
       }
       break;
 
-    case bvtypet::IS_BV:
-      INVARIANT(
-        src_width == dest_width,
-        "source bitvector with shall equal the destination bitvector width");
-      dest=src;
-      return false;
-
-    default:
-      if(src_type.id()==ID_bool)
-      {
-        // bool to integer
-
+      case bvtypet::IS_BV:
         INVARIANT(
-          src_width == 1, "bitvector of type boolean shall have width one");
-
-        for(std::size_t i=0; i<dest_width; i++)
-        {
-          if(i==0)
-            dest.push_back(src[0]);
-          else
-            dest.push_back(const_literal(false));
-        }
-
+          src_width == dest_width,
+          "source bitvector with shall equal the destination bitvector width");
+        dest = src;
         return false;
-      }
+
+      default:
+        if(src_type.id() == ID_bool)
+        {
+          // bool to integer
+
+          INVARIANT(
+            src_width == 1, "bitvector of type boolean shall have width one");
+
+          for(std::size_t i = 0; i < dest_width; i++)
+          {
+            if(i == 0)
+              dest.push_back(src[0]);
+            else
+              dest.push_back(const_literal(false));
+          }
+
+          return false;
+        }
     }
     break;
 

--- a/src/solvers/flattening/boolbv_typecast.cpp
+++ b/src/solvers/flattening/boolbv_typecast.cpp
@@ -415,6 +415,13 @@ bool boolbvt::type_conversion(
       }
       break;
 
+    case bvtypet::IS_BV:
+      INVARIANT(
+        src_width == dest_width,
+        "source bitvector with shall equal the destination bitvector width");
+      dest=src;
+      return false;
+
     default:
       if(src_type.id()==ID_bool)
       {

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -2243,8 +2243,9 @@ void smt2_convt::convert_typecast(const typecast_exprt &expr)
       // this just passes through
       convert_expr(src);
     }
-    else if(src_type.id()==ID_unsignedbv ||
-            src_type.id()==ID_signedbv)
+    else if(
+      src_type.id() == ID_unsignedbv || src_type.id() == ID_signedbv ||
+      src_type.id() == ID_bv)
     {
       // integer to pointer
 

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -951,7 +951,7 @@ bool simplify_exprt::simplify_concatenation(exprt &expr)
 
 bool simplify_exprt::simplify_shifts(exprt &expr)
 {
-  if(!is_number(expr.type()))
+  if(!is_bitvector_type(expr.type()))
     return true;
 
   if(expr.operands().size()!=2)
@@ -972,11 +972,21 @@ bool simplify_exprt::simplify_shifts(exprt &expr)
 
   auto value = numeric_cast<mp_integer>(expr.op0());
 
+  if(
+    !value.has_value() && expr.op0().type().id() == ID_bv &&
+    expr.op0().id() == ID_constant)
+  {
+    const std::size_t width = to_bitvector_type(expr.op0().type()).get_width();
+    value =
+      bvrep2integer(to_constant_expr(expr.op0()).get_value(), width, false);
+  }
+
   if(!value.has_value())
     return true;
 
-  if(expr.op0().type().id()==ID_unsignedbv ||
-     expr.op0().type().id()==ID_signedbv)
+  if(
+    expr.op0().type().id() == ID_unsignedbv ||
+    expr.op0().type().id() == ID_signedbv || expr.op0().type().id() == ID_bv)
   {
     const std::size_t width = to_bitvector_type(expr.op0().type()).get_width();
 

--- a/unit/solvers/lowering/byte_operators.cpp
+++ b/unit/solvers/lowering/byte_operators.cpp
@@ -150,14 +150,13 @@ SCENARIO("byte_extract_lowering", "[core][solvers][lowering][byte_extract]")
       unsignedbv_typet(128),
       signedbv_typet(24),
       signedbv_typet(128),
-      // ieee_float_spect::single_precision().to_type(),
+      ieee_float_spect::single_precision().to_type(),
       // generates the correct value, but remains wrapped in a typecast
       // pointer_typet(u64, 64),
       vector_typet(u8, size),
       vector_typet(u64, size),
       complex_typet(s16),
-      complex_typet(u64)
-    };
+      complex_typet(u64)};
 
     simplify_exprt simp(ns);
 
@@ -301,7 +300,7 @@ SCENARIO("byte_update_lowering", "[core][solvers][lowering][byte_update]")
       unsignedbv_typet(128),
       signedbv_typet(24),
       signedbv_typet(128),
-      // ieee_float_spect::single_precision().to_type(),
+      ieee_float_spect::single_precision().to_type(),
       // generates the correct value, but remains wrapped in a typecast
       // pointer_typet(u64, 64),
       vector_typet(u8, size),


### PR DESCRIPTION
Previously we fixed the extracted bytes to be unsigned bitvectors, but
we should not actually imposed (un)signedness as we do not actually
interpret the bytes as numeric values. This fixes byte operators over
floating-point values, and makes various SMT-solver tests pass as the
SMT back-end is more strict about typing.

To make all this work it was also necessary to extend and fix the
simplifier's handling of bv_typet expressions, and also cover one more
case of type casts in the bitvector back-end.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
