### PR TITLE
Clean-up message_handler of parse_options_baset

### DIFF
--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -58,8 +58,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-analyzer/unreachable_instructions.h>
 
 janalyzer_parse_optionst::janalyzer_parse_optionst(int argc, const char **argv)
-  : parse_options_baset(JANALYZER_OPTIONS, argc, argv, ui_message_handler),
-    ui_message_handler(cmdline, std::string("JANALYZER ") + CBMC_VERSION)
+  : parse_options_baset(
+      JANALYZER_OPTIONS,
+      argc,
+      argv,
+      std::string("JANALYZER ") + CBMC_VERSION)
 {
 }
 

--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -371,8 +371,7 @@ int janalyzer_parse_optionst::doit()
     return CPROVER_EXIT_USAGE_ERROR;
   }
 
-  goto_model =
-    initialize_goto_model(cmdline.args, log.get_message_handler(), options);
+  goto_model = initialize_goto_model(cmdline.args, ui_message_handler, options);
 
   if(process_goto_program(options))
     return CPROVER_EXIT_INTERNAL_ERROR;
@@ -391,7 +390,7 @@ int janalyzer_parse_optionst::doit()
   {
     show_goto_functions(
       goto_model,
-      log.get_message_handler(),
+      ui_message_handler,
       ui_message_handler.get_ui(),
       cmdline.isset("list-goto-functions"));
     return CPROVER_EXIT_SUCCESS;
@@ -409,15 +408,14 @@ int janalyzer_parse_optionst::perform_analysis(const optionst &options)
 
     if(cmdline.isset("show-taint"))
     {
-      taint_analysis(
-        goto_model, taint_file, log.get_message_handler(), true, "");
+      taint_analysis(goto_model, taint_file, ui_message_handler, true, "");
       return CPROVER_EXIT_SUCCESS;
     }
     else
     {
       std::string json_file = cmdline.get_value("json");
       bool result = taint_analysis(
-        goto_model, taint_file, log.get_message_handler(), false, json_file);
+        goto_model, taint_file, ui_message_handler, false, json_file);
       return result ? CPROVER_EXIT_VERIFICATION_UNSAFE : CPROVER_EXIT_SUCCESS;
     }
   }
@@ -523,7 +521,7 @@ int janalyzer_parse_optionst::perform_analysis(const optionst &options)
   if(cmdline.isset("show-properties"))
   {
     show_properties(
-      goto_model, log.get_message_handler(), ui_message_handler.get_ui());
+      goto_model, ui_message_handler, ui_message_handler.get_ui());
     return CPROVER_EXIT_SUCCESS;
   }
 
@@ -574,12 +572,12 @@ int janalyzer_parse_optionst::perform_analysis(const optionst &options)
     else if(options.get_bool_option("verify"))
     {
       result = static_verifier(
-        goto_model, *analyzer, options, log.get_message_handler(), out);
+        goto_model, *analyzer, options, ui_message_handler, out);
     }
     else if(options.get_bool_option("simplify"))
     {
       result = static_simplifier(
-        goto_model, *analyzer, options, log.get_message_handler(), out);
+        goto_model, *analyzer, options, ui_message_handler, out);
     }
     else if(options.get_bool_option("unreachable-instructions"))
     {
@@ -620,18 +618,18 @@ bool janalyzer_parse_optionst::process_goto_program(const optionst &options)
     log.status() << "Removing function pointers and virtual functions"
                  << messaget::eom;
     remove_function_pointers(
-      log.get_message_handler(), goto_model, cmdline.isset("pointer-check"));
+      ui_message_handler, goto_model, cmdline.isset("pointer-check"));
 
     // Java virtual functions -> explicit dispatch tables:
     remove_virtual_functions(goto_model);
 
     // remove Java throw and catch
     // This introduces instanceof, so order is important:
-    remove_exceptions_using_instanceof(goto_model, log.get_message_handler());
+    remove_exceptions_using_instanceof(goto_model, ui_message_handler);
 
     // Java instanceof -> clsid comparison:
     class_hierarchyt class_hierarchy(goto_model.symbol_table);
-    remove_instanceof(goto_model, class_hierarchy, log.get_message_handler());
+    remove_instanceof(goto_model, class_hierarchy, ui_message_handler);
 
     // do partial inlining
     log.status() << "Partial Inlining" << messaget::eom;

--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -520,8 +520,7 @@ int janalyzer_parse_optionst::perform_analysis(const optionst &options)
 
   if(cmdline.isset("show-properties"))
   {
-    show_properties(
-      goto_model, ui_message_handler, ui_message_handler.get_ui());
+    show_properties(goto_model, ui_message_handler);
     return CPROVER_EXIT_SUCCESS;
   }
 

--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -389,7 +389,7 @@ int janalyzer_parse_optionst::doit()
     show_goto_functions(
       goto_model,
       log.get_message_handler(),
-      get_ui(),
+      ui_message_handler.get_ui(),
       cmdline.isset("list-goto-functions"));
     return CPROVER_EXIT_SUCCESS;
   }
@@ -519,7 +519,8 @@ int janalyzer_parse_optionst::perform_analysis(const optionst &options)
 
   if(cmdline.isset("show-properties"))
   {
-    show_properties(goto_model, log.get_message_handler(), get_ui());
+    show_properties(
+      goto_model, log.get_message_handler(), ui_message_handler.get_ui());
     return CPROVER_EXIT_SUCCESS;
   }
 

--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -389,10 +389,7 @@ int janalyzer_parse_optionst::doit()
     cmdline.isset("list-goto-functions"))
   {
     show_goto_functions(
-      goto_model,
-      ui_message_handler,
-      ui_message_handler.get_ui(),
-      cmdline.isset("list-goto-functions"));
+      goto_model, ui_message_handler, cmdline.isset("list-goto-functions"));
     return CPROVER_EXIT_SUCCESS;
   }
 

--- a/jbmc/src/janalyzer/janalyzer_parse_options.h
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.h
@@ -159,7 +159,6 @@ public:
   janalyzer_parse_optionst(int argc, const char **argv);
 
 protected:
-  ui_message_handlert ui_message_handler;
   goto_modelt goto_model;
 
   void register_languages();

--- a/jbmc/src/janalyzer/janalyzer_parse_options.h
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.h
@@ -171,11 +171,6 @@ protected:
   virtual int perform_analysis(const optionst &options);
 
   ai_baset *build_analyzer(const optionst &, const namespacet &ns);
-
-  ui_message_handlert::uit get_ui()
-  {
-    return ui_message_handler.get_ui();
-  }
 };
 
 #endif // CPROVER_JANALYZER_JANALYZER_PARSE_OPTIONS_H

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -75,8 +75,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <java_bytecode/simple_method_stubbing.h>
 
 jbmc_parse_optionst::jbmc_parse_optionst(int argc, const char **argv)
-  : parse_options_baset(JBMC_OPTIONS, argc, argv, ui_message_handler),
-    ui_message_handler(cmdline, std::string("JBMC ") + CBMC_VERSION)
+  : parse_options_baset(
+      JBMC_OPTIONS,
+      argc,
+      argv,
+      std::string("JBMC ") + CBMC_VERSION)
 {
 }
 
@@ -88,8 +91,7 @@ jbmc_parse_optionst::jbmc_parse_optionst(int argc, const char **argv)
       JBMC_OPTIONS + extra_options,
       argc,
       argv,
-      ui_message_handler),
-    ui_message_handler(cmdline, std::string("JBMC ") + CBMC_VERSION)
+      std::string("JBMC ") + CBMC_VERSION)
 {
 }
 

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -136,7 +136,7 @@ void jbmc_parse_optionst::get_command_line_options(optionst &options)
     exit(CPROVER_EXIT_SUCCESS);
   }
 
-  parse_path_strategy_options(cmdline, options, log.get_message_handler());
+  parse_path_strategy_options(cmdline, options, ui_message_handler);
 
   if(cmdline.isset("program-only"))
     options.set_option("program-only", true);
@@ -423,9 +423,7 @@ int jbmc_parse_optionst::doit()
   }
 
   messaget::eval_verbosity(
-    cmdline.get_value("verbosity"),
-    messaget::M_STATISTICS,
-    log.get_message_handler());
+    cmdline.get_value("verbosity"), messaget::M_STATISTICS, ui_message_handler);
 
   //
   // command line options
@@ -500,7 +498,7 @@ int jbmc_parse_optionst::doit()
     }
 
     language->set_language_options(options);
-    language->set_message_handler(log.get_message_handler());
+    language->set_message_handler(ui_message_handler);
 
     log.status() << "Parsing " << filename << messaget::eom;
 
@@ -749,7 +747,7 @@ void jbmc_parse_optionst::process_goto_function(
     goto_function,
     symbol_table,
     *class_hierarchy,
-    log.get_message_handler());
+    ui_message_handler);
   // Java virtual functions -> explicit dispatch tables:
   remove_virtual_functions(function);
 
@@ -864,7 +862,7 @@ bool jbmc_parse_optionst::show_loaded_functions(
     namespacet ns(goto_model.get_symbol_table());
     show_properties(
       ns,
-      log.get_message_handler(),
+      ui_message_handler,
       ui_message_handler.get_ui(),
       goto_model.get_goto_functions());
     return true;
@@ -889,8 +887,7 @@ bool jbmc_parse_optionst::process_goto_functions(
     return false;
 
   // remove catch and throw
-  remove_exceptions(
-    goto_model, *class_hierarchy.get(), log.get_message_handler());
+  remove_exceptions(goto_model, *class_hierarchy.get(), ui_message_handler);
 
   // instrument library preconditions
   instrument_preconditions(goto_model);
@@ -912,7 +909,7 @@ bool jbmc_parse_optionst::process_goto_functions(
   {
     // Entry point will have been set before and function pointers removed
     log.status() << "Removing unused functions" << messaget::eom;
-    remove_unused_functions(goto_model, log.get_message_handler());
+    remove_unused_functions(goto_model, ui_message_handler);
   }
 
   // remove skips such that trivial GOTOs are deleted

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -851,7 +851,6 @@ bool jbmc_parse_optionst::show_loaded_functions(
     show_goto_functions(
       ns,
       ui_message_handler,
-      ui_message_handler.get_ui(),
       goto_model.get_goto_functions(),
       cmdline.isset("list-goto-functions"));
     return true;

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -860,11 +860,7 @@ bool jbmc_parse_optionst::show_loaded_functions(
   if(cmdline.isset("show-properties"))
   {
     namespacet ns(goto_model.get_symbol_table());
-    show_properties(
-      ns,
-      ui_message_handler,
-      ui_message_handler.get_ui(),
-      goto_model.get_goto_functions());
+    show_properties(ns, ui_message_handler, goto_model.get_goto_functions());
     return true;
   }
 

--- a/jbmc/src/jbmc/jbmc_parse_options.h
+++ b/jbmc/src/jbmc/jbmc_parse_options.h
@@ -117,7 +117,6 @@ public:
     bool body_available);
 
 protected:
-  ui_message_handlert ui_message_handler;
   java_object_factory_parameterst object_factory_params;
   bool stub_objects_are_not_null;
 

--- a/jbmc/src/jdiff/jdiff_parse_options.cpp
+++ b/jbmc/src/jdiff/jdiff_parse_options.cpp
@@ -62,8 +62,11 @@ Author: Peter Schrammel
 #include <goto-diff/unified_diff.h>
 
 jdiff_parse_optionst::jdiff_parse_optionst(int argc, const char **argv)
-  : parse_options_baset(JDIFF_OPTIONS, argc, argv, ui_message_handler),
-    ui_message_handler(cmdline, std::string("JDIFF ") + CBMC_VERSION)
+  : parse_options_baset(
+      JDIFF_OPTIONS,
+      argc,
+      argv,
+      std::string("JDIFF ") + CBMC_VERSION)
 {
 }
 

--- a/jbmc/src/jdiff/jdiff_parse_options.cpp
+++ b/jbmc/src/jdiff/jdiff_parse_options.cpp
@@ -227,15 +227,9 @@ int jdiff_parse_optionst::doit()
     cmdline.isset("list-goto-functions"))
   {
     show_goto_functions(
-      goto_model1,
-      ui_message_handler,
-      ui_message_handler.get_ui(),
-      cmdline.isset("list-goto-functions"));
+      goto_model1, ui_message_handler, cmdline.isset("list-goto-functions"));
     show_goto_functions(
-      goto_model2,
-      ui_message_handler,
-      ui_message_handler.get_ui(),
-      cmdline.isset("list-goto-functions"));
+      goto_model2, ui_message_handler, cmdline.isset("list-goto-functions"));
     return CPROVER_EXIT_SUCCESS;
   }
 

--- a/jbmc/src/jdiff/jdiff_parse_options.cpp
+++ b/jbmc/src/jdiff/jdiff_parse_options.cpp
@@ -228,12 +228,12 @@ int jdiff_parse_optionst::doit()
   {
     show_goto_functions(
       goto_model1,
-      log.get_message_handler(),
+      ui_message_handler,
       ui_message_handler.get_ui(),
       cmdline.isset("list-goto-functions"));
     show_goto_functions(
       goto_model2,
-      log.get_message_handler(),
+      ui_message_handler,
       ui_message_handler.get_ui(),
       cmdline.isset("list-goto-functions"));
     return CPROVER_EXIT_SUCCESS;
@@ -280,18 +280,18 @@ bool jdiff_parse_optionst::process_goto_program(
     log.status() << "Removing function pointers and virtual functions"
                  << messaget::eom;
     remove_function_pointers(
-      log.get_message_handler(), goto_model, cmdline.isset("pointer-check"));
+      ui_message_handler, goto_model, cmdline.isset("pointer-check"));
 
     // Java virtual functions -> explicit dispatch tables:
     remove_virtual_functions(goto_model);
 
     // remove Java throw and catch
     // This introduces instanceof, so order is important:
-    remove_exceptions_using_instanceof(goto_model, log.get_message_handler());
+    remove_exceptions_using_instanceof(goto_model, ui_message_handler);
 
     // Java instanceof -> clsid comparison:
     class_hierarchyt class_hierarchy(goto_model.symbol_table);
-    remove_instanceof(goto_model, class_hierarchy, log.get_message_handler());
+    remove_instanceof(goto_model, class_hierarchy, ui_message_handler);
 
     mm_io(goto_model);
 
@@ -324,10 +324,9 @@ bool jdiff_parse_optionst::process_goto_program(
     // instrument cover goals
     if(cmdline.isset("cover"))
     {
-      const auto cover_config = get_cover_config(
-        options, goto_model.symbol_table, log.get_message_handler());
-      if(instrument_cover_goals(
-           cover_config, goto_model, log.get_message_handler()))
+      const auto cover_config =
+        get_cover_config(options, goto_model.symbol_table, ui_message_handler);
+      if(instrument_cover_goals(cover_config, goto_model, ui_message_handler))
         return true;
     }
 

--- a/jbmc/src/jdiff/jdiff_parse_options.h
+++ b/jbmc/src/jdiff/jdiff_parse_options.h
@@ -49,7 +49,6 @@ public:
   jdiff_parse_optionst(int argc, const char **argv);
 
 protected:
-  ui_message_handlert ui_message_handler;
   void register_languages();
 
   void get_command_line_options(optionst &options);

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -733,7 +733,6 @@ int cbmc_parse_optionst::get_goto_program(
       show_goto_functions(
         goto_model,
         ui_message_handler,
-        ui_message_handler.get_ui(),
         cmdline.isset("list-goto-functions"));
       return CPROVER_EXIT_SUCCESS;
     }

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -486,7 +486,7 @@ int cbmc_parse_optionst::doit()
   register_languages();
 
   if(cmdline.isset("test-preprocessor"))
-    return test_c_preprocessor(log.get_message_handler())
+    return test_c_preprocessor(ui_message_handler)
              ? CPROVER_EXIT_PREPROCESSOR_TEST_FAILED
              : CPROVER_EXIT_SUCCESS;
 
@@ -532,7 +532,7 @@ int cbmc_parse_optionst::doit()
     }
 
     language->set_language_options(options);
-    language->set_message_handler(log.get_message_handler());
+    language->set_message_handler(ui_message_handler);
 
     log.status() << "Parsing " << filename << messaget::eom;
 
@@ -556,7 +556,7 @@ int cbmc_parse_optionst::doit()
      cmdline.isset("show-properties")) // use this one
   {
     show_properties(
-      goto_model, log.get_message_handler(), ui_message_handler.get_ui());
+      goto_model, ui_message_handler, ui_message_handler.get_ui());
     return CPROVER_EXIT_SUCCESS;
   }
 
@@ -774,7 +774,7 @@ void cbmc_parse_optionst::preprocessing(const optionst &options)
       return;
     }
 
-    language->set_message_handler(log.get_message_handler());
+    language->set_message_handler(ui_message_handler);
 
     if(language->preprocess(infile, filename, std::cout))
       log.error() << "PREPROCESSING ERROR" << messaget::eom;

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -83,9 +83,12 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "xml_interface.h"
 
 cbmc_parse_optionst::cbmc_parse_optionst(int argc, const char **argv)
-  : parse_options_baset(CBMC_OPTIONS, argc, argv, ui_message_handler),
-    xml_interfacet(cmdline),
-    ui_message_handler(cmdline, std::string("CBMC ") + CBMC_VERSION)
+  : parse_options_baset(
+      CBMC_OPTIONS,
+      argc,
+      argv,
+      std::string("CBMC ") + CBMC_VERSION),
+    xml_interfacet(cmdline)
 {
 }
 
@@ -97,9 +100,8 @@ cbmc_parse_optionst::cbmc_parse_optionst(int argc, const char **argv)
       CBMC_OPTIONS + extra_options,
       argc,
       argv,
-      ui_message_handler),
-    xml_interfacet(cmdline),
-    ui_message_handler(cmdline, std::string("CBMC ") + CBMC_VERSION)
+      std::string("CBMC ") + CBMC_VERSION),
+    xml_interfacet(cmdline)
 {
 }
 

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -555,8 +555,7 @@ int cbmc_parse_optionst::doit()
   if(cmdline.isset("show-claims") || // will go away
      cmdline.isset("show-properties")) // use this one
   {
-    show_properties(
-      goto_model, ui_message_handler, ui_message_handler.get_ui());
+    show_properties(goto_model, ui_message_handler);
     return CPROVER_EXIT_SUCCESS;
   }
 

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -547,7 +547,7 @@ int cbmc_parse_optionst::doit()
   }
 
   int get_goto_program_ret =
-    get_goto_program(goto_model, options, cmdline, log, ui_message_handler);
+    get_goto_program(goto_model, options, cmdline, ui_message_handler);
 
   if(get_goto_program_ret!=-1)
     return get_goto_program_ret;
@@ -692,12 +692,12 @@ int cbmc_parse_optionst::get_goto_program(
   goto_modelt &goto_model,
   const optionst &options,
   const cmdlinet &cmdline,
-  messaget &log,
   ui_message_handlert &ui_message_handler)
 {
+  messaget log{ui_message_handler};
   if(cmdline.args.empty())
   {
-    log.error() << "Please provide a program to verify" << log.eom;
+    log.error() << "Please provide a program to verify" << messaget::eom;
     return CPROVER_EXIT_INCORRECT_TASK;
   }
 
@@ -739,7 +739,7 @@ int cbmc_parse_optionst::get_goto_program(
       return CPROVER_EXIT_SUCCESS;
     }
 
-    log.status() << config.object_bits_info() << log.eom;
+    log.status() << config.object_bits_info() << messaget::eom;
   }
 
   return -1; // no error, continue

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -111,7 +111,6 @@ public:
 
 protected:
   goto_modelt goto_model;
-  ui_message_handlert ui_message_handler;
 
   void register_languages();
   void get_command_line_options(optionst &);

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -106,7 +106,6 @@ public:
     goto_modelt &,
     const optionst &,
     const cmdlinet &,
-    messaget &,
     ui_message_handlert &);
 
 protected:

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -401,8 +401,7 @@ int goto_analyzer_parse_optionst::doit()
 
   register_languages();
 
-  goto_model =
-    initialize_goto_model(cmdline.args, log.get_message_handler(), options);
+  goto_model = initialize_goto_model(cmdline.args, ui_message_handler, options);
 
   if(process_goto_program(options))
     return CPROVER_EXIT_INTERNAL_ERROR;
@@ -426,7 +425,7 @@ int goto_analyzer_parse_optionst::doit()
   {
     show_goto_functions(
       goto_model,
-      log.get_message_handler(),
+      ui_message_handler,
       ui_message_handler.get_ui(),
       cmdline.isset("list-goto-functions"));
     return CPROVER_EXIT_SUCCESS;
@@ -446,15 +445,14 @@ int goto_analyzer_parse_optionst::perform_analysis(const optionst &options)
 
     if(cmdline.isset("show-taint"))
     {
-      taint_analysis(
-        goto_model, taint_file, log.get_message_handler(), true, "");
+      taint_analysis(goto_model, taint_file, ui_message_handler, true, "");
       return CPROVER_EXIT_SUCCESS;
     }
     else
     {
       std::string json_file=cmdline.get_value("json");
       bool result = taint_analysis(
-        goto_model, taint_file, log.get_message_handler(), false, json_file);
+        goto_model, taint_file, ui_message_handler, false, json_file);
       return result ? CPROVER_EXIT_VERIFICATION_UNSAFE : CPROVER_EXIT_SUCCESS;
     }
   }
@@ -557,7 +555,7 @@ int goto_analyzer_parse_optionst::perform_analysis(const optionst &options)
   if(cmdline.isset("show-properties"))
   {
     show_properties(
-      goto_model, log.get_message_handler(), ui_message_handler.get_ui());
+      goto_model, ui_message_handler, ui_message_handler.get_ui());
     return CPROVER_EXIT_SUCCESS;
   }
 
@@ -611,13 +609,13 @@ int goto_analyzer_parse_optionst::perform_analysis(const optionst &options)
     }
     else if(options.get_bool_option("show-on-source"))
     {
-      show_on_source(goto_model, *analyzer, log.get_message_handler());
+      show_on_source(goto_model, *analyzer, ui_message_handler);
       return CPROVER_EXIT_SUCCESS;
     }
     else if(options.get_bool_option("verify"))
     {
       result = static_verifier(
-        goto_model, *analyzer, options, log.get_message_handler(), out);
+        goto_model, *analyzer, options, ui_message_handler, out);
     }
     else if(options.get_bool_option("simplify"))
     {
@@ -625,7 +623,7 @@ int goto_analyzer_parse_optionst::perform_analysis(const optionst &options)
       output_stream.close();
       output_stream.open(outfile, std::ios::binary);
       result = static_simplifier(
-        goto_model, *analyzer, options, log.get_message_handler(), out);
+        goto_model, *analyzer, options, ui_message_handler, out);
     }
     else if(options.get_bool_option("unreachable-instructions"))
     {
@@ -685,7 +683,7 @@ bool goto_analyzer_parse_optionst::process_goto_program(
     log.status() << "Removing function pointers and virtual functions"
                  << messaget::eom;
     remove_function_pointers(
-      log.get_message_handler(), goto_model, cmdline.isset("pointer-check"));
+      ui_message_handler, goto_model, cmdline.isset("pointer-check"));
 
     // do partial inlining
     log.status() << "Partial Inlining" << messaget::eom;

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -424,10 +424,7 @@ int goto_analyzer_parse_optionst::doit()
     cmdline.isset("list-goto-functions"))
   {
     show_goto_functions(
-      goto_model,
-      ui_message_handler,
-      ui_message_handler.get_ui(),
-      cmdline.isset("list-goto-functions"));
+      goto_model, ui_message_handler, cmdline.isset("list-goto-functions"));
     return CPROVER_EXIT_SUCCESS;
   }
 

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -554,8 +554,7 @@ int goto_analyzer_parse_optionst::perform_analysis(const optionst &options)
 
   if(cmdline.isset("show-properties"))
   {
-    show_properties(
-      goto_model, ui_message_handler, ui_message_handler.get_ui());
+    show_properties(goto_model, ui_message_handler);
     return CPROVER_EXIT_SUCCESS;
   }
 

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -424,7 +424,7 @@ int goto_analyzer_parse_optionst::doit()
     show_goto_functions(
       goto_model,
       log.get_message_handler(),
-      get_ui(),
+      ui_message_handler.get_ui(),
       cmdline.isset("list-goto-functions"));
     return CPROVER_EXIT_SUCCESS;
   }
@@ -553,7 +553,8 @@ int goto_analyzer_parse_optionst::perform_analysis(const optionst &options)
 
   if(cmdline.isset("show-properties"))
   {
-    show_properties(goto_model, log.get_message_handler(), get_ui());
+    show_properties(
+      goto_model, log.get_message_handler(), ui_message_handler.get_ui());
     return CPROVER_EXIT_SUCCESS;
   }
 

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -69,8 +69,11 @@ Author: Daniel Kroening, kroening@kroening.com
 goto_analyzer_parse_optionst::goto_analyzer_parse_optionst(
   int argc,
   const char **argv)
-  : parse_options_baset(GOTO_ANALYSER_OPTIONS, argc, argv, ui_message_handler),
-    ui_message_handler(cmdline, std::string("GOTO-ANALYZER ") + CBMC_VERSION)
+  : parse_options_baset(
+      GOTO_ANALYSER_OPTIONS,
+      argc,
+      argv,
+      std::string("GOTO-ANALYZER "))
 {
 }
 

--- a/src/goto-analyzer/goto_analyzer_parse_options.h
+++ b/src/goto-analyzer/goto_analyzer_parse_options.h
@@ -162,7 +162,6 @@ public:
   goto_analyzer_parse_optionst(int argc, const char **argv);
 
 protected:
-  ui_message_handlert ui_message_handler;
   goto_modelt goto_model;
 
   virtual void register_languages();

--- a/src/goto-analyzer/goto_analyzer_parse_options.h
+++ b/src/goto-analyzer/goto_analyzer_parse_options.h
@@ -174,11 +174,6 @@ protected:
   virtual int perform_analysis(const optionst &options);
 
   ai_baset *build_analyzer(const optionst &, const namespacet &ns);
-
-  ui_message_handlert::uit get_ui()
-  {
-    return ui_message_handler.get_ui();
-  }
 };
 
 #endif // CPROVER_GOTO_ANALYZER_GOTO_ANALYZER_PARSE_OPTIONS_H

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -64,8 +64,11 @@ Author: Peter Schrammel
 #include "change_impact.h"
 
 goto_diff_parse_optionst::goto_diff_parse_optionst(int argc, const char **argv)
-  : parse_options_baset(GOTO_DIFF_OPTIONS, argc, argv, ui_message_handler),
-    ui_message_handler(cmdline, std::string("GOTO-DIFF ") + CBMC_VERSION)
+  : parse_options_baset(
+      GOTO_DIFF_OPTIONS,
+      argc,
+      argv,
+      std::string("GOTO-DIFF ") + CBMC_VERSION)
 {
 }
 

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -265,15 +265,9 @@ int goto_diff_parse_optionst::doit()
     cmdline.isset("list-goto-functions"))
   {
     show_goto_functions(
-      goto_model1,
-      ui_message_handler,
-      ui_message_handler.get_ui(),
-      cmdline.isset("list-goto-functions"));
+      goto_model1, ui_message_handler, cmdline.isset("list-goto-functions"));
     show_goto_functions(
-      goto_model2,
-      ui_message_handler,
-      ui_message_handler.get_ui(),
-      cmdline.isset("list-goto-functions"));
+      goto_model2, ui_message_handler, cmdline.isset("list-goto-functions"));
     return CPROVER_EXIT_SUCCESS;
   }
 

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -266,12 +266,12 @@ int goto_diff_parse_optionst::doit()
   {
     show_goto_functions(
       goto_model1,
-      log.get_message_handler(),
+      ui_message_handler,
       ui_message_handler.get_ui(),
       cmdline.isset("list-goto-functions"));
     show_goto_functions(
       goto_model2,
-      log.get_message_handler(),
+      ui_message_handler,
       ui_message_handler.get_ui(),
       cmdline.isset("list-goto-functions"));
     return CPROVER_EXIT_SUCCESS;
@@ -326,15 +326,14 @@ bool goto_diff_parse_optionst::process_goto_program(
     log.status() << "Adding CPROVER library (" << config.ansi_c.arch << ")"
                  << messaget::eom;
     link_to_library(
-      goto_model, log.get_message_handler(), cprover_cpp_library_factory);
-    link_to_library(
-      goto_model, log.get_message_handler(), cprover_c_library_factory);
+      goto_model, ui_message_handler, cprover_cpp_library_factory);
+    link_to_library(goto_model, ui_message_handler, cprover_c_library_factory);
 
     // remove function pointers
     log.status() << "Removal of function pointers and virtual functions"
                  << messaget::eom;
     remove_function_pointers(
-      log.get_message_handler(), goto_model, cmdline.isset("pointer-check"));
+      ui_message_handler, goto_model, cmdline.isset("pointer-check"));
 
     mm_io(goto_model);
 
@@ -367,10 +366,9 @@ bool goto_diff_parse_optionst::process_goto_program(
       // for coverage annotation:
       remove_skip(goto_model);
 
-      const auto cover_config = get_cover_config(
-        options, goto_model.symbol_table, log.get_message_handler());
-      if(instrument_cover_goals(
-           cover_config, goto_model, log.get_message_handler()))
+      const auto cover_config =
+        get_cover_config(options, goto_model.symbol_table, ui_message_handler);
+      if(instrument_cover_goals(cover_config, goto_model, ui_message_handler))
         return true;
     }
 

--- a/src/goto-diff/goto_diff_parse_options.h
+++ b/src/goto-diff/goto_diff_parse_options.h
@@ -48,7 +48,6 @@ public:
   goto_diff_parse_optionst(int argc, const char **argv);
 
 protected:
-  ui_message_handlert ui_message_handler;
   void register_languages();
 
   void get_command_line_options(optionst &options);

--- a/src/goto-harness/goto_harness_main.cpp
+++ b/src/goto-harness/goto_harness_main.cpp
@@ -10,6 +10,5 @@ Author: Diffblue Ltd.
 
 int main(int argc, const char *argv[])
 {
-  auto parse_options = goto_harness_parse_optionst(argc, argv);
-  return parse_options.main();
+  return goto_harness_parse_optionst{argc, argv}.main();
 }

--- a/src/goto-harness/goto_harness_parse_options.cpp
+++ b/src/goto-harness/goto_harness_parse_options.cpp
@@ -55,7 +55,7 @@ int goto_harness_parse_optionst::doit()
 
   // Read goto binary into goto-model
   auto read_goto_binary_result =
-    read_goto_binary(got_harness_config.in_file, log.get_message_handler());
+    read_goto_binary(got_harness_config.in_file, ui_message_handler);
   if(!read_goto_binary_result.has_value())
   {
     throw deserialization_exceptiont{"failed to read goto program from file `" +
@@ -89,7 +89,7 @@ int goto_harness_parse_optionst::doit()
 
   // Write end result to new goto-binary
   if(write_goto_binary(
-       got_harness_config.out_file, goto_model, log.get_message_handler()))
+       got_harness_config.out_file, goto_model, ui_message_handler))
   {
     throw system_exceptiont{"failed to write goto program from file `" +
                             got_harness_config.out_file + "'"};

--- a/src/goto-harness/goto_harness_parse_options.cpp
+++ b/src/goto-harness/goto_harness_parse_options.cpp
@@ -126,8 +126,10 @@ void goto_harness_parse_optionst::help()
 goto_harness_parse_optionst::goto_harness_parse_optionst(
   int argc,
   const char *argv[])
-  : parse_options_baset{GOTO_HARNESS_OPTIONS, argc, argv, ui_message_handler},
-    ui_message_handler(cmdline, std::string("GOTO-HARNESS ") + CBMC_VERSION)
+  : parse_options_baset{GOTO_HARNESS_OPTIONS,
+                        argc,
+                        argv,
+                        std::string("GOTO-HARNESS ") + CBMC_VERSION}
 {
 }
 

--- a/src/goto-harness/goto_harness_parse_options.h
+++ b/src/goto-harness/goto_harness_parse_options.h
@@ -45,8 +45,6 @@ private:
     irep_idt harness_function_name;
   };
 
-  ui_message_handlert ui_message_handler;
-
   /// Handle command line arguments that are common to all
   /// harness generators.
   goto_harness_configt handle_common_options();

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -809,8 +809,7 @@ int goto_instrument_parse_optionst::doit()
       do_indirect_call_and_rtti_removal();
 
       log.status() << "Removing unused functions" << messaget::eom;
-      remove_unused_functions(
-        goto_model.goto_functions, log.get_message_handler());
+      remove_unused_functions(goto_model.goto_functions, ui_message_handler);
     }
 
     if(cmdline.isset("undefined-function-is-assume-false"))

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -616,10 +616,7 @@ int goto_instrument_parse_optionst::doit()
       cmdline.isset("list-goto-functions"))
     {
       show_goto_functions(
-        goto_model,
-        ui_message_handler,
-        ui_message_handler.get_ui(),
-        cmdline.isset("list-goto-functions"));
+        goto_model, ui_message_handler, cmdline.isset("list-goto-functions"));
       return CPROVER_EXIT_SUCCESS;
     }
 

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -268,7 +268,7 @@ int goto_instrument_parse_optionst::doit()
       namespacet ns(goto_model.symbol_table);
       value_set_analysist value_set_analysis(ns);
       value_set_analysis(goto_model.goto_functions);
-      show_value_sets(get_ui(), goto_model, value_set_analysis);
+      show_value_sets(ui_message_handler.get_ui(), goto_model, value_set_analysis);
       return CPROVER_EXIT_SUCCESS;
     }
 
@@ -564,7 +564,8 @@ int goto_instrument_parse_optionst::doit()
        cmdline.isset("show-properties"))
     {
       const namespacet ns(goto_model.symbol_table);
-      show_properties(goto_model, log.get_message_handler(), get_ui());
+      show_properties(
+        goto_model, log.get_message_handler(), ui_message_handler.get_ui());
       return CPROVER_EXIT_SUCCESS;
     }
 
@@ -584,7 +585,7 @@ int goto_instrument_parse_optionst::doit()
 
     if(cmdline.isset("show-loops"))
     {
-      show_loop_ids(get_ui(), goto_model);
+      show_loop_ids(ui_message_handler.get_ui(), goto_model);
       return CPROVER_EXIT_SUCCESS;
     }
 
@@ -637,7 +638,7 @@ int goto_instrument_parse_optionst::doit()
 
     if(cmdline.isset("show-locations"))
     {
-      show_locations(get_ui(), goto_model);
+      show_locations(ui_message_handler.get_ui(), goto_model);
       return CPROVER_EXIT_SUCCESS;
     }
 

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -565,8 +565,7 @@ int goto_instrument_parse_optionst::doit()
        cmdline.isset("show-properties"))
     {
       const namespacet ns(goto_model.symbol_table);
-      show_properties(
-        goto_model, ui_message_handler, ui_message_handler.get_ui());
+      show_properties(goto_model, ui_message_handler);
       return CPROVER_EXIT_SUCCESS;
     }
 

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -122,8 +122,7 @@ public:
         GOTO_INSTRUMENT_OPTIONS,
         argc,
         argv,
-        ui_message_handler),
-      ui_message_handler(cmdline, "goto-instrument"),
+        "goto-instrument"),
       function_pointer_removal_done(false),
       partial_inlining_done(false),
       remove_returns_done(false)
@@ -131,7 +130,6 @@ public:
   }
 
 protected:
-  ui_message_handlert ui_message_handler;
   void register_languages();
 
   void get_goto_program();

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -147,11 +147,6 @@ protected:
   bool remove_returns_done;
 
   goto_modelt goto_model;
-
-  ui_message_handlert::uit get_ui()
-  {
-    return ui_message_handler.get_ui();
-  }
 };
 
 #endif // CPROVER_GOTO_INSTRUMENT_GOTO_INSTRUMENT_PARSE_OPTIONS_H

--- a/src/goto-programs/show_goto_functions.cpp
+++ b/src/goto-programs/show_goto_functions.cpp
@@ -25,12 +25,12 @@ Author: Peter Schrammel
 
 void show_goto_functions(
   const namespacet &ns,
-  message_handlert &message_handler,
-  ui_message_handlert::uit ui,
+  ui_message_handlert &ui_message_handler,
   const goto_functionst &goto_functions,
   bool list_only)
 {
-  messaget msg(message_handler);
+  ui_message_handlert::uit ui = ui_message_handler.get_ui();
+  messaget msg(ui_message_handler);
   switch(ui)
   {
   case ui_message_handlert::uit::XML_UI:
@@ -82,11 +82,10 @@ void show_goto_functions(
 
 void show_goto_functions(
   const goto_modelt &goto_model,
-  message_handlert &message_handler,
-  ui_message_handlert::uit ui,
+  ui_message_handlert &ui_message_handler,
   bool list_only)
 {
   const namespacet ns(goto_model.symbol_table);
   show_goto_functions(
-    ns, message_handler, ui, goto_model.goto_functions, list_only);
+    ns, ui_message_handler, goto_model.goto_functions, list_only);
 }

--- a/src/goto-programs/show_goto_functions.h
+++ b/src/goto-programs/show_goto_functions.h
@@ -30,15 +30,13 @@ class goto_functionst;
 
 void show_goto_functions(
   const namespacet &ns,
-  message_handlert &message_handler,
-  ui_message_handlert::uit ui,
+  ui_message_handlert &ui_message_handler,
   const goto_functionst &goto_functions,
-  bool list_only = false);
+  bool list_only);
 
 void show_goto_functions(
   const goto_modelt &,
-  message_handlert &message_handler,
-  ui_message_handlert::uit ui,
-  bool list_only = false);
+  ui_message_handlert &ui_message_handler,
+  bool list_only);
 
 #endif // CPROVER_GOTO_PROGRAMS_SHOW_GOTO_FUNCTIONS_H

--- a/src/goto-programs/show_properties.cpp
+++ b/src/goto-programs/show_properties.cpp
@@ -163,25 +163,25 @@ void show_properties_json(
 
 void show_properties(
   const namespacet &ns,
-  message_handlert &message_handler,
-  ui_message_handlert::uit ui,
+  ui_message_handlert &ui_message_handler,
   const goto_functionst &goto_functions)
 {
+  ui_message_handlert::uit ui = ui_message_handler.get_ui();
   if(ui == ui_message_handlert::uit::JSON_UI)
-    show_properties_json(ns, message_handler, goto_functions);
+    show_properties_json(ns, ui_message_handler, goto_functions);
   else
     for(const auto &fct : goto_functions.function_map)
-      show_properties(ns, fct.first, message_handler, ui, fct.second.body);
+      show_properties(ns, fct.first, ui_message_handler, ui, fct.second.body);
 }
 
 void show_properties(
   const goto_modelt &goto_model,
-  message_handlert &message_handler,
-  ui_message_handlert::uit ui)
+  ui_message_handlert &ui_message_handler)
 {
+  ui_message_handlert::uit ui = ui_message_handler.get_ui();
   const namespacet ns(goto_model.symbol_table);
   if(ui == ui_message_handlert::uit::JSON_UI)
-    show_properties_json(ns, message_handler, goto_model.goto_functions);
+    show_properties_json(ns, ui_message_handler, goto_model.goto_functions);
   else
-    show_properties(ns, message_handler, ui, goto_model.goto_functions);
+    show_properties(ns, ui_message_handler, goto_model.goto_functions);
 }

--- a/src/goto-programs/show_properties.h
+++ b/src/goto-programs/show_properties.h
@@ -32,13 +32,11 @@ class message_handlert;
 
 void show_properties(
   const goto_modelt &,
-  message_handlert &message_handler,
-  ui_message_handlert::uit ui);
+  ui_message_handlert &ui_message_handler);
 
 void show_properties(
   const namespacet &ns,
-  message_handlert &message_handler,
-  ui_message_handlert::uit ui,
+  ui_message_handlert &ui_message_handler,
   const goto_functionst &goto_functions);
 
 /// \brief Returns a source_locationt that corresponds

--- a/src/util/parse_options.cpp
+++ b/src/util/parse_options.cpp
@@ -28,11 +28,14 @@ parse_options_baset::parse_options_baset(
   const std::string &_optstring,
   int argc,
   const char **argv,
-  message_handlert &mh)
-  : log(mh)
+  const std::string &program)
+  : parse_result(cmdline.parse(
+      argc,
+      argv,
+      (std::string("?h(help)") + _optstring).c_str())),
+    ui_message_handler(cmdline, program),
+    log(ui_message_handler)
 {
-  std::string optstring=std::string("?h(help)")+_optstring;
-  parse_result=cmdline.parse(argc, argv, optstring.c_str());
 
   // DO NOT USE log HERE!
   //

--- a/src/util/parse_options.cpp
+++ b/src/util/parse_options.cpp
@@ -36,18 +36,6 @@ parse_options_baset::parse_options_baset(
     ui_message_handler(cmdline, program),
     log(ui_message_handler)
 {
-
-  // DO NOT USE log HERE!
-  //
-  // The usual pattern of use is that the application class inherits from
-  // messaget and parse_options_baset using a member variable of type
-  // message_handlert to construct the messaget part.
-  //
-  // C++'s rules of initialisation mean that the constructors for
-  // messaget and then parse_options_base run before those of message_handlert.
-  // This means that the message_handlert object is uninitialised.
-  // Using it here will likely cause a hard to debug failure somewhere in
-  // the messaget code.
 }
 
 void parse_options_baset::help()

--- a/src/util/parse_options.h
+++ b/src/util/parse_options.h
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "cmdline.h"
 #include "message.h"
+#include "ui_message.h"
 
 class parse_options_baset
 {
@@ -22,7 +23,7 @@ public:
     const std::string &optstring,
     int argc,
     const char **argv,
-    message_handlert &mh);
+    const std::string &program);
 
   cmdlinet cmdline;
 
@@ -34,12 +35,15 @@ public:
   virtual int main();
   virtual ~parse_options_baset() { }
 
+private:
+  bool parse_result;
+
 protected:
+  ui_message_handlert ui_message_handler;
   messaget log;
 
 private:
   void unknown_option_msg();
-  bool parse_result;
 };
 
 std::string

--- a/unit/compound_block_locations.cpp
+++ b/unit/compound_block_locations.cpp
@@ -289,7 +289,7 @@ void compound_block_locationst::check_compound_block_locations(
 
   goto_modelt gm;
   int ret;
-  ret = cbmc_parse_optionst::get_goto_program(gm, opts, cmdline, log, mh);
+  ret = cbmc_parse_optionst::get_goto_program(gm, opts, cmdline, mh);
   REQUIRE(ret == -1);
 
   const auto found = gm.goto_functions.function_map.find("main");

--- a/unit/path_strategies.cpp
+++ b/unit/path_strategies.cpp
@@ -398,7 +398,7 @@ void _check_with_strategy(
   goto_modelt goto_model;
   int ret;
   ret = cbmc_parse_optionst::get_goto_program(
-    goto_model, options, cmdline, log, ui_message_handler);
+    goto_model, options, cmdline, ui_message_handler);
   REQUIRE(ret == -1);
 
   symbol_tablet symex_symbol_table;


### PR DESCRIPTION
~Based on https://github.com/diffblue/cbmc/pull/4520~

The message handler field was owned by the classes inheriting from
parse_options_baset which lead to strange patterns where the handler
reference was initialized using a reference to a field which was not
constructed yet.
This is cleaner and avoid some reference duplication.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
