### PR TITLE
Avoid crash in linking conflict report by providing correct type for …

### DIFF
--- a/regression/ansi-c/linking_conflicts2/main.c
+++ b/regression/ansi-c/linking_conflicts2/main.c
@@ -1,0 +1,4 @@
+int foo(int *i)
+{
+  return *i;
+}

--- a/regression/ansi-c/linking_conflicts2/other.c
+++ b/regression/ansi-c/linking_conflicts2/other.c
@@ -1,0 +1,4 @@
+int foo(char *i)
+{
+  return *i;
+}

--- a/regression/ansi-c/linking_conflicts2/test.desc
+++ b/regression/ansi-c/linking_conflicts2/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+other.c
+^EXIT=(64|1)$
+^SIGNAL=0$
+^CONVERSION ERROR$
+error: conflicting function declarations `foo'
+--
+^warning: ignoring

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -143,7 +143,8 @@ void linkingt::detailed_conflict_report_rec(
     if(depth>0 &&
        !base_type_eq(t1.subtype(), t2.subtype(), ns))
     {
-      conflict_path=dereference_exprt(conflict_path);
+      if(conflict_path.type().id() == ID_pointer)
+        conflict_path = dereference_exprt(conflict_path);
 
       detailed_conflict_report_rec(
         old_symbol,


### PR DESCRIPTION
…dereference expression

CBMC currently crashes with an invariant check failure if there is a conflict discovered during linking.
Test case:
file one.c:
```
int f(char *i) { return  *i; }
```
file two.c:
```
int f(int *i) { return  *i; }
```
cbmc command:
```
cbmc one.c two.c
```
cbmc message without this commit:
```
--- begin invariant violation report ---
Invariant check failed
File: ../util/std_expr.h:3041 function: dereference_exprt
Condition: op.type().id()==ID_pointer
Reason: Precondition
```
cbmc message with this commit:
```
file two.c line 1: 
reason for conflict at *#this: conflict on POD

char
signed int
error: conflicting function declarations f
old definition in module one file one.c line 1
signed int (char *i)
new definition in module two file two.c line 1
signed int (signed int *i$link1)
CONVERSION ERROR
```
