### PR TITLE
NULL compares equal to 0

### DIFF
--- a/regression/cbmc/union13/main.c
+++ b/regression/cbmc/union13/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <stdint.h>
+
+int main()
+{
+  union {
+    intptr_t i;
+    int *p;
+  } u;
+  u.i = 0;
+  assert(u.p == 0);
+}

--- a/regression/cbmc/union13/no-arch.desc
+++ b/regression/cbmc/union13/no-arch.desc
@@ -1,0 +1,9 @@
+CORE broken-smt-backend
+main.c
+--arch none --little-endian
+(Starting CEGAR Loop|^Generated 1 VCC\(s\), 1 remaining after simplification$)
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc/union13/test.desc
+++ b/regression/cbmc/union13/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -1357,8 +1357,23 @@ bool simplify_exprt::simplify_inequality(exprt &expr)
   {
     if(expr.id() == ID_equal || expr.id() == ID_notequal)
     {
-
+      // two constants compare equal when there values (as strings) are the same
+      // or both of them are pointers and both represent NULL in some way
       bool equal = (tmp0_const->get_value() == tmp1_const->get_value());
+      if(
+        !equal && tmp0_const->type().id() == ID_pointer &&
+        tmp1_const->type().id() == ID_pointer)
+      {
+        if(
+          !config.ansi_c.NULL_is_zero && (tmp0_const->get_value() == ID_NULL ||
+                                          tmp1_const->get_value() == ID_NULL))
+        {
+          // if NULL is not zero on this platform, we really don't know what it
+          // is and therefore cannot simplify
+          return true;
+        }
+        equal = tmp0_const->is_zero() && tmp1_const->is_zero();
+      }
       expr.make_bool(expr.id() == ID_equal ? equal : !equal);
       return false;
     }


### PR DESCRIPTION
When comparing constants, we just compared their string representations.
This fails when one side of the (in)equality was NULL while the other
side was 0, which is wrong when config.ansi_c.NULL_is_zero is set. Thus
actually test both sides for being zero in this configuration.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
