### PR TITLE
Support typecast from bv_typet to pointer_typet

### DIFF
--- a/regression/cbmc/Typecast3/main.c
+++ b/regression/cbmc/Typecast3/main.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int main()
+{
+  int **s = malloc(sizeof(int *));
+  for(int i = 0; i < sizeof(int *); ++i)
+  {
+    // A correct program would use (char *)s, but updating the pointer allows us
+    // to reproduce a bug in CBMC (missing support for typecasts from bv_typet
+    // to pointers).
+    *((char *)&s + i) = 0;
+  }
+  assert(s[0] == 0);
+}

--- a/regression/cbmc/Typecast3/test.desc
+++ b/regression/cbmc/Typecast3/test.desc
@@ -1,0 +1,21 @@
+CORE
+main.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+--
+This test makes sure we support bv_typet -> pointer type casts, avoiding
+warnings like:
+
+warning: ignoring typecast
+  * type: pointer
+      * width: 64
+      0: signedbv
+          * width: 32
+          * #c_type: signed_int
+  0: typecast
+      * type: bv
+          * width: 64

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -253,11 +253,10 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
 
     if(op_type.id()==ID_pointer)
       return convert_bv(op);
-    else if(op_type.id()==ID_signedbv ||
-            op_type.id()==ID_unsignedbv ||
-            op_type.id()==ID_bool ||
-            op_type.id()==ID_c_enum ||
-            op_type.id()==ID_c_enum_tag)
+    else if(
+      op_type.id() == ID_signedbv || op_type.id() == ID_unsignedbv ||
+      op_type.id() == ID_bool || op_type.id() == ID_c_enum ||
+      op_type.id() == ID_c_enum_tag || op_type.id() == ID_bv)
     {
       // Cast from integer to pointer.
       // We just do a zero extension.


### PR DESCRIPTION
The fixes in 848e633b67 result in type casts from bv_typet to various
other bitvector types being generated. Most cases were addressed in that
commit, but support for casting to pointers was omitted. This follow-up
commit fixes this, and adds a test specifically covering this case.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
