### PR TITLE
Java bytecode conversion: inline or move temporaries

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_class.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_class.cpp
@@ -859,7 +859,7 @@ void java_bytecode_convert_classt::add_array_types(symbol_tablet &symbol_table)
     local_symbol.type = java_reference_type(struct_tag_type);
     local_symbol.mode=ID_java;
     symbol_table.add(local_symbol);
-    const auto &local_symexpr=local_symbol.symbol_expr();
+    const auto local_symexpr = local_symbol.symbol_expr();
 
     code_declt declare_cloned(local_symexpr);
 

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1949,10 +1949,9 @@ code_switcht java_bytecode_convert_methodt::convert_switch(
       if(a_it == args.begin())
       {
         code_switch_caset code_case(nil_exprt(), std::move(code));
-        code_case.add_source_location() = location;
         code_case.set_default();
 
-        code_block.add(std::move(code_case));
+        code_block.add(std::move(code_case), location);
       }
       else
       {
@@ -1961,9 +1960,7 @@ code_switcht java_bytecode_convert_methodt::convert_switch(
         case_op.add_source_location() = location;
 
         code_switch_caset code_case(std::move(case_op), std::move(code));
-        code_case.add_source_location() = location;
-
-        code_block.add(std::move(code_case));
+        code_block.add(std::move(code_case), location);
       }
     }
   }
@@ -2853,15 +2850,15 @@ code_blockt java_bytecode_convert_methodt::convert_store(
     toassign = typecast_exprt::conditional_cast(toassign, var.type());
 
   code_blockt block;
+  block.add_source_location() = location;
 
   save_stack_entries(
     "stack_store",
     block,
     bytecode_write_typet::VARIABLE,
     var_name);
-  code_assignt assign(var, toassign);
-  assign.add_source_location() = location;
-  block.add(assign);
+
+  block.add(code_assignt{var, toassign}, location);
   return block;
 }
 
@@ -2886,9 +2883,8 @@ code_blockt java_bytecode_convert_methodt::convert_astore(
   save_stack_entries(
     "stack_astore", block, bytecode_write_typet::ARRAY_REF, "");
 
-  code_assignt array_put(element, op[2]);
-  array_put.add_source_location() = location;
-  block.add(array_put);
+  code_assignt array_put{dereference_exprt{data_plus_offset}, op[2]};
+  block.add(std::move(array_put), location);
   return block;
 }
 


### PR DESCRIPTION
This is a cleanup follow-up to #4524 of various minor bits that I spotted while doing the review thereof.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
