### PR TITLE
Interface for collecting function pointer targets

### DIFF
--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -634,7 +634,7 @@ bool janalyzer_parse_optionst::process_goto_program(const optionst &options)
     goto_partial_inline(goto_model, ui_message_handler);
 
     // remove returns, gcc vectors, complex
-    remove_returns(goto_model);
+    remove_returns(log.get_message_handler(), goto_model);
     remove_vector(goto_model);
     remove_complex(goto_model);
 

--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -634,7 +634,7 @@ bool janalyzer_parse_optionst::process_goto_program(const optionst &options)
     goto_partial_inline(goto_model, ui_message_handler);
 
     // remove returns, gcc vectors, complex
-    remove_returns(log.get_message_handler(), goto_model);
+    remove_returns(goto_model, log.get_message_handler());
     remove_vector(goto_model);
     remove_complex(goto_model);
 

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -764,7 +764,7 @@ void jbmc_parse_optionst::process_goto_function(
            !model.can_produce_function(id);
   };
 
-  remove_returns(function, function_is_stub);
+  remove_returns(log.get_message_handler(), function, function_is_stub);
 
   replace_java_nondet(function);
 

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -764,7 +764,7 @@ void jbmc_parse_optionst::process_goto_function(
            !model.can_produce_function(id);
   };
 
-  remove_returns(log.get_message_handler(), function, function_is_stub);
+  remove_returns(function, log.get_message_handler(), function_is_stub);
 
   replace_java_nondet(function);
 

--- a/jbmc/src/jdiff/jdiff_parse_options.cpp
+++ b/jbmc/src/jdiff/jdiff_parse_options.cpp
@@ -293,7 +293,7 @@ bool jdiff_parse_optionst::process_goto_program(
     instrument_preconditions(goto_model);
 
     // remove returns, gcc vectors, complex
-    remove_returns(log.get_message_handler(), goto_model);
+    remove_returns(goto_model, log.get_message_handler());
     remove_vector(goto_model);
     remove_complex(goto_model);
     rewrite_union(goto_model);

--- a/jbmc/src/jdiff/jdiff_parse_options.cpp
+++ b/jbmc/src/jdiff/jdiff_parse_options.cpp
@@ -293,7 +293,7 @@ bool jdiff_parse_optionst::process_goto_program(
     instrument_preconditions(goto_model);
 
     // remove returns, gcc vectors, complex
-    remove_returns(goto_model);
+    remove_returns(log.get_message_handler(), goto_model);
     remove_vector(goto_model);
     remove_complex(goto_model);
     rewrite_union(goto_model);

--- a/jbmc/unit/java_bytecode/java_replace_nondet/replace_nondet.cpp
+++ b/jbmc/unit/java_bytecode/java_replace_nondet/replace_nondet.cpp
@@ -154,7 +154,9 @@ void load_and_test_method(
   // Then test both situations.
   THEN("Replace nondet should work after remove returns has been called.")
   {
-    remove_returns(model_function, [](const irep_idt &) { return false; });
+    remove_returns(null_message_handler, model_function, [](const irep_idt &) {
+      return false;
+    });
 
     replace_java_nondet(model_function);
 
@@ -165,7 +167,9 @@ void load_and_test_method(
   {
     replace_java_nondet(model_function);
 
-    remove_returns(model_function, [](const irep_idt &) { return false; });
+    remove_returns(null_message_handler, model_function, [](const irep_idt &) {
+      return false;
+    });
 
     validate_nondet_method_removed(goto_function.body.instructions);
   }
@@ -176,7 +180,9 @@ void load_and_test_method(
     "Replace and convert nondet should work after remove returns has been "
     "called.")
   {
-    remove_returns(model_function, [](const irep_idt &) { return false; });
+    remove_returns(null_message_handler, model_function, [](const irep_idt &) {
+      return false;
+    });
 
     replace_java_nondet(model_function);
 
@@ -193,7 +199,9 @@ void load_and_test_method(
 
     convert_nondet(model_function, null_message_handler, params, ID_java);
 
-    remove_returns(model_function, [](const irep_idt &) { return false; });
+    remove_returns(null_message_handler, model_function, [](const irep_idt &) {
+      return false;
+    });
 
     validate_nondets_converted(goto_function.body.instructions);
   }

--- a/jbmc/unit/java_bytecode/java_replace_nondet/replace_nondet.cpp
+++ b/jbmc/unit/java_bytecode/java_replace_nondet/replace_nondet.cpp
@@ -154,7 +154,7 @@ void load_and_test_method(
   // Then test both situations.
   THEN("Replace nondet should work after remove returns has been called.")
   {
-    remove_returns(null_message_handler, model_function, [](const irep_idt &) {
+    remove_returns(model_function, null_message_handler, [](const irep_idt &) {
       return false;
     });
 
@@ -167,7 +167,7 @@ void load_and_test_method(
   {
     replace_java_nondet(model_function);
 
-    remove_returns(null_message_handler, model_function, [](const irep_idt &) {
+    remove_returns(model_function, null_message_handler, [](const irep_idt &) {
       return false;
     });
 
@@ -180,7 +180,7 @@ void load_and_test_method(
     "Replace and convert nondet should work after remove returns has been "
     "called.")
   {
-    remove_returns(null_message_handler, model_function, [](const irep_idt &) {
+    remove_returns(model_function, null_message_handler, [](const irep_idt &) {
       return false;
     });
 
@@ -199,7 +199,7 @@ void load_and_test_method(
 
     convert_nondet(model_function, null_message_handler, params, ID_java);
 
-    remove_returns(null_message_handler, model_function, [](const irep_idt &) {
+    remove_returns(model_function, null_message_handler, [](const irep_idt &) {
       return false;
     });
 

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -810,7 +810,7 @@ bool cbmc_parse_optionst::process_goto_program(
   instrument_preconditions(goto_model);
 
   // remove returns, gcc vectors, complex
-  remove_returns(log.get_message_handler(), goto_model);
+  remove_returns(goto_model, log.get_message_handler());
   remove_vector(goto_model);
   remove_complex(goto_model);
   rewrite_union(goto_model);

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -810,7 +810,7 @@ bool cbmc_parse_optionst::process_goto_program(
   instrument_preconditions(goto_model);
 
   // remove returns, gcc vectors, complex
-  remove_returns(goto_model);
+  remove_returns(log.get_message_handler(), goto_model);
   remove_vector(goto_model);
   remove_complex(goto_model);
   rewrite_union(goto_model);

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -686,7 +686,7 @@ bool goto_analyzer_parse_optionst::process_goto_program(
     goto_partial_inline(goto_model, ui_message_handler);
 
     // remove returns, gcc vectors, complex
-    remove_returns(goto_model);
+    remove_returns(log.get_message_handler(), goto_model);
     remove_vector(goto_model);
     remove_complex(goto_model);
 

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -686,7 +686,7 @@ bool goto_analyzer_parse_optionst::process_goto_program(
     goto_partial_inline(goto_model, ui_message_handler);
 
     // remove returns, gcc vectors, complex
-    remove_returns(log.get_message_handler(), goto_model);
+    remove_returns(goto_model, log.get_message_handler());
     remove_vector(goto_model);
     remove_complex(goto_model);
 

--- a/src/goto-analyzer/static_simplifier.cpp
+++ b/src/goto-analyzer/static_simplifier.cpp
@@ -186,7 +186,7 @@ bool static_simplifier(
   }
 
   // restore return types before writing the binary
-  restore_returns(goto_model);
+  restore_returns(m.get_message_handler(), goto_model);
   goto_model.goto_functions.update();
 
   m.status() << "Writing goto binary" << messaget::eom;

--- a/src/goto-analyzer/static_simplifier.cpp
+++ b/src/goto-analyzer/static_simplifier.cpp
@@ -186,7 +186,7 @@ bool static_simplifier(
   }
 
   // restore return types before writing the binary
-  restore_returns(m.get_message_handler(), goto_model);
+  restore_returns(goto_model, m.get_message_handler());
   goto_model.goto_functions.update();
 
   m.status() << "Writing goto binary" << messaget::eom;

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -335,7 +335,7 @@ bool goto_diff_parse_optionst::process_goto_program(
     instrument_preconditions(goto_model);
 
     // remove returns, gcc vectors, complex
-    remove_returns(log.get_message_handler(), goto_model);
+    remove_returns(goto_model, log.get_message_handler());
     remove_vector(goto_model);
     remove_complex(goto_model);
     rewrite_union(goto_model);

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -335,7 +335,7 @@ bool goto_diff_parse_optionst::process_goto_program(
     instrument_preconditions(goto_model);
 
     // remove returns, gcc vectors, complex
-    remove_returns(goto_model);
+    remove_returns(log.get_message_handler(), goto_model);
     remove_vector(goto_model);
     remove_complex(goto_model);
     rewrite_union(goto_model);

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -649,7 +649,7 @@ int goto_instrument_parse_optionst::doit()
 
       // restore RETURN instructions in case remove_returns had been
       // applied
-      restore_returns(log.get_message_handler(), goto_model);
+      restore_returns(goto_model, log.get_message_handler());
 
       if(cmdline.args.size()==2)
       {
@@ -899,7 +899,7 @@ void goto_instrument_parse_optionst::do_remove_returns()
   remove_returns_done=true;
 
   log.status() << "Removing returns" << messaget::eom;
-  remove_returns(log.get_message_handler(), goto_model);
+  remove_returns(goto_model, log.get_message_handler());
 }
 
 void goto_instrument_parse_optionst::get_goto_program()

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -649,7 +649,7 @@ int goto_instrument_parse_optionst::doit()
 
       // restore RETURN instructions in case remove_returns had been
       // applied
-      restore_returns(goto_model);
+      restore_returns(log.get_message_handler(), goto_model);
 
       if(cmdline.args.size()==2)
       {
@@ -899,7 +899,7 @@ void goto_instrument_parse_optionst::do_remove_returns()
   remove_returns_done=true;
 
   log.status() << "Removing returns" << messaget::eom;
-  remove_returns(goto_model);
+  remove_returns(log.get_message_handler(), goto_model);
 }
 
 void goto_instrument_parse_optionst::get_goto_program()

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -543,6 +543,8 @@ void remove_function_pointerst::remove_function_pointer_non_const(
   const code_function_callt &code = target->get_function_call();
   const exprt &function = code.function();
 
+  auto new_code = build_new_code(functions, code, function_id, target);
+
   goto_programt::targett next_target=target;
   next_target++;
 

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -150,9 +150,12 @@ protected:
   /// if (fp=&f1) then goto loc1
   /// if (fp=&f2) then goto loc2
   /// ..
-  /// loc1: f1(); goto N+1;
-  /// loc2: f2(); goto N+1;
+  /// if (fp=&fn) then goto locN
+  /// loc1:  f1(); goto N+1;
+  /// loc2:  f2(); goto N+1;
   /// ..
+  /// locN:  fn(); goto N+1;
+  /// locN+1:
   ///
   /// \param functions: set of function candidates
   /// \param code: the original function call

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -230,7 +230,7 @@ protected:
     const functionst &functions) const;
 
   /// Extract function name from \p called_functions
-  /// \param: called_function: the function call expression
+  /// \param called_function: the function call expression
   /// \return function identifier
   irep_idt get_callee_id(const exprt &called_function) const;
 };

--- a/src/goto-programs/remove_function_pointers.h
+++ b/src/goto-programs/remove_function_pointers.h
@@ -16,11 +16,22 @@ Date: June 2003
 
 #include <util/irep.h>
 
+#include <map>
+
+#include "remove_const_function_pointers.h"
+
 class goto_functionst;
 class goto_programt;
 class goto_modelt;
 class message_handlert;
 class symbol_tablet;
+
+using possible_fp_targetst = remove_const_function_pointerst::functionst;
+using possible_fp_targets_mapt = std::map<irep_idt, possible_fp_targetst>;
+
+possible_fp_targets_mapt get_function_pointer_targets(
+  message_handlert &message_handler,
+  goto_modelt &goto_model);
 
 // remove indirect function calls
 // and replace by case-split

--- a/src/goto-programs/remove_function_pointers.h
+++ b/src/goto-programs/remove_function_pointers.h
@@ -29,6 +29,11 @@ class symbol_tablet;
 using possible_fp_targetst = remove_const_function_pointerst::functionst;
 using possible_fp_targets_mapt = std::map<irep_idt, possible_fp_targetst>;
 
+/// Go through the whole model and find all potential function the pointer at
+///   all call sites
+/// \param message_handler: a message handler for reporting
+/// \param goto_model: model to search for potential functions
+/// \return a map from ids to sets of function candidates
 possible_fp_targets_mapt get_function_pointer_targets(
   message_handlert &message_handler,
   goto_modelt &goto_model);
@@ -40,6 +45,20 @@ void remove_function_pointers(
   goto_modelt &goto_model,
   bool add_safety_assertion,
   bool only_remove_const_fps=false);
+
+/// Replace all calls to a dynamic function by a case-split over a given set of
+///   candidate functions
+/// \param _message_handler: a message handler for reporting
+/// \param goto_model: model to search for potential functions
+/// \param target_map: candidate functions
+/// \param add_safety_assertion: check that at least one function matches
+/// \param only_remove_const_fps: restrict the pointer remove to const
+void remove_function_pointers(
+  message_handlert &_message_handler,
+  goto_modelt &goto_model,
+  const possible_fp_targets_mapt &target_map,
+  bool add_safety_assertion,
+  bool only_remove_const_fps = false);
 
 void remove_function_pointers(
   message_handlert &_message_handler,

--- a/src/goto-programs/remove_returns.cpp
+++ b/src/goto-programs/remove_returns.cpp
@@ -196,8 +196,8 @@ bool remove_returnst::do_function_calls(
     INVARIANT(
       function_call.function().id() == ID_symbol ||
         function_call.function().id() == ID_dereference,
-      "indirect function calls should have been removed prior to running "
-      "remove-returns");
+      "only direct function calls (via a symbol) or indirect function calls "
+      "(via a dereference) are supported");
 
     bool is_function_pointer = function_call.function().id() == ID_dereference;
 

--- a/src/goto-programs/remove_returns.cpp
+++ b/src/goto-programs/remove_returns.cpp
@@ -60,10 +60,10 @@ protected:
   optionalt<symbol_exprt>
   get_or_create_return_value_symbol(const irep_idt &function_id);
 
-  bool do_function_call(
+  void do_function_call(
     goto_programt::targett i_it,
     goto_programt &goto_program,
-    function_is_stubt function_is_stub);
+    bool is_stub);
 };
 
 optionalt<symbol_exprt>
@@ -154,12 +154,27 @@ bool remove_returnst::do_function_calls(
 
   Forall_goto_program_instructions(i_it, goto_program)
   {
+    if(!i_it->is_function_call())
+      continue;
+
+    const auto &function_call = i_it->get_function_call();
+    INVARIANT(
+      function_call.function().id() == ID_symbol,
+      "indirect function calls should have been removed prior to running "
+      "remove-returns");
+    // Do we return anything?
     if(
-      i_it->is_function_call() &&
-      do_function_call(i_it, goto_program, function_is_stub))
-    {
-      requires_update = true;
-    }
+      to_code_type(function_call.function().type()).return_type() ==
+        empty_typet() ||
+      !function_call.lhs().is_not_nil())
+      continue;
+
+    const auto &function_id =
+      to_symbol_expr(function_call.function()).get_identifier();
+    bool is_stub = function_is_stub(function_id);
+
+    do_function_call(i_it, goto_program, is_stub);
+    requires_update = true;
   }
   return requires_update;
 }
@@ -377,70 +392,53 @@ bool is_return_value_symbol(const symbol_exprt &symbol_expr)
   return is_return_value_identifier(symbol_expr.get_identifier());
 }
 
-bool remove_returnst::do_function_call(
+void remove_returnst::do_function_call(
   goto_programt::targett i_it,
   goto_programt &goto_program,
-  function_is_stubt function_is_stub)
+  bool is_stub)
 {
   code_function_callt function_call = i_it->get_function_call();
-
-  INVARIANT(
-    function_call.function().id() == ID_symbol,
-    "indirect function calls should have been removed prior to running "
-    "remove-returns");
 
   const irep_idt function_id =
     to_symbol_expr(function_call.function()).get_identifier();
 
-  // Do we return anything?
-  if(
-    to_code_type(function_call.function().type()).return_type() !=
-      empty_typet() &&
-    function_call.lhs().is_not_nil())
+  // replace "lhs=f(...)" by
+  // "f(...); lhs=f#return_value; DEAD f#return_value;"
+  exprt rhs;
+
+  optionalt<symbol_exprt> return_value;
+
+  if(!is_stub)
   {
-    // replace "lhs=f(...)" by
-    // "f(...); lhs=f#return_value; DEAD f#return_value;"
+    return_value = get_or_create_return_value_symbol(function_id);
+    CHECK_RETURN(return_value.has_value());
 
-    exprt rhs;
-
-    bool is_stub = function_is_stub(function_id);
-    optionalt<symbol_exprt> return_value;
-
-    if(!is_stub)
-    {
-      return_value = get_or_create_return_value_symbol(function_id);
-      CHECK_RETURN(return_value.has_value());
-
-      // The return type in the definition of the function may differ
-      // from the return type in the declaration.  We therefore do a
-      // cast.
-      rhs = typecast_exprt::conditional_cast(
-        *return_value, function_call.lhs().type());
-    }
-    else
-    {
-      rhs = side_effect_expr_nondett(
-        function_call.lhs().type(), i_it->source_location);
-    }
-
-    goto_programt::targett t_a = goto_program.insert_after(
-      i_it,
-      goto_programt::make_assignment(
-        code_assignt(function_call.lhs(), rhs), i_it->source_location));
-
-    // fry the previous assignment
-    function_call.lhs().make_nil();
-
-    if(!is_stub)
-    {
-      goto_program.insert_after(
-        t_a, goto_programt::make_dead(*return_value, i_it->source_location));
-    }
-
-    // update the call
-    i_it->set_function_call(function_call);
-
-    return true;
+    // The return type in the definition of the function may differ
+    // from the return type in the declaration.  We therefore do a
+    // cast.
+    rhs = typecast_exprt::conditional_cast(
+      *return_value, function_call.lhs().type());
   }
-  return false;
+  else
+  {
+    rhs = side_effect_expr_nondett(
+      function_call.lhs().type(), i_it->source_location);
+  }
+
+  goto_programt::targett t_a = goto_program.insert_after(
+    i_it,
+    goto_programt::make_assignment(
+      code_assignt(function_call.lhs(), rhs), i_it->source_location));
+
+  // fry the previous assignment
+  function_call.lhs().make_nil();
+
+  if(!is_stub)
+  {
+    goto_program.insert_after(
+      t_a, goto_programt::make_dead(*return_value, i_it->source_location));
+  }
+
+  // update the call
+  i_it->set_function_call(function_call);
 }

--- a/src/goto-programs/remove_returns.cpp
+++ b/src/goto-programs/remove_returns.cpp
@@ -30,8 +30,8 @@ class remove_returnst
 {
 public:
   explicit remove_returnst(
-    message_handlert &m,
-    symbol_table_baset &_symbol_table)
+    symbol_table_baset &_symbol_table,
+    message_handlert &m)
     : log(m), symbol_table(_symbol_table)
   {
   }
@@ -282,27 +282,27 @@ void remove_returnst::operator()(
 
 /// removes returns
 void remove_returns(
-  message_handlert &m,
   symbol_table_baset &symbol_table,
+  message_handlert &m,
   goto_functionst &goto_functions)
 {
-  remove_returnst rr(m, symbol_table);
+  remove_returnst rr(symbol_table, m);
   rr(goto_functions);
 }
 
 void remove_returns(
-  message_handlert &m,
   goto_model_functiont &goto_model_function,
+  message_handlert &m,
   function_is_stubt function_is_stub)
 {
-  remove_returnst rr(m, goto_model_function.get_symbol_table());
+  remove_returnst rr(goto_model_function.get_symbol_table(), m);
   rr(goto_model_function, function_is_stub);
 }
 
 /// removes returns
-void remove_returns(message_handlert &m, goto_modelt &goto_model)
+void remove_returns(goto_modelt &goto_model, message_handlert &m)
 {
-  remove_returnst rr(m, goto_model.symbol_table);
+  remove_returnst rr(goto_model.symbol_table, m);
   rr.build_fp_targets(goto_model);
   rr(goto_model.goto_functions);
 }
@@ -420,12 +420,11 @@ void remove_returnst::restore(goto_functionst &goto_functions)
 }
 
 /// restores return statements
-void restore_returns(message_handlert &m, goto_modelt &goto_model)
+void restore_returns(goto_modelt &goto_model, message_handlert &m)
 {
-  remove_returnst rr(m, goto_model.symbol_table);
+  remove_returnst rr(goto_model.symbol_table, m);
   rr.restore(goto_model.goto_functions);
 }
-
 
 irep_idt return_value_identifier(const irep_idt &identifier)
 {

--- a/src/goto-programs/remove_returns.h
+++ b/src/goto-programs/remove_returns.h
@@ -84,8 +84,8 @@ class symbol_table_baset;
 class symbol_exprt;
 
 void remove_returns(
+  symbol_table_baset &symbol_table,
   message_handlert &m,
-  symbol_table_baset &,
   goto_functionst &);
 
 typedef std::function<bool(const irep_idt &)> function_is_stubt;
@@ -103,16 +103,16 @@ typedef std::function<bool(const irep_idt &)> function_is_stubt;
 ///   callee has been or will be given a body. It should return true if so, or
 ///   false if the function will remain a bodyless stub.
 void remove_returns(
-  message_handlert &m,
   goto_model_functiont &goto_model_function,
+  message_handlert &m,
   function_is_stubt function_is_stub);
 
-void remove_returns(message_handlert &m, goto_modelt &);
+void remove_returns(goto_modelt &goto_model, message_handlert &m);
 
 // reverse the above operations
 void restore_returns(symbol_table_baset &, goto_functionst &);
 
-void restore_returns(message_handlert &m, goto_modelt &);
+void restore_returns(goto_modelt &goto_model, message_handlert &m);
 
 /// produces the identifier that is used to store the return
 /// value of the function with the given identifier

--- a/src/goto-programs/remove_returns.h
+++ b/src/goto-programs/remove_returns.h
@@ -73,6 +73,7 @@ Date:   September 2009
 
 #include <functional>
 
+#include <util/message.h>
 #include <util/std_types.h>
 
 class goto_functionst;
@@ -82,18 +83,36 @@ class namespacet;
 class symbol_table_baset;
 class symbol_exprt;
 
-void remove_returns(symbol_table_baset &, goto_functionst &);
+void remove_returns(
+  message_handlert &m,
+  symbol_table_baset &,
+  goto_functionst &);
 
 typedef std::function<bool(const irep_idt &)> function_is_stubt;
 
-void remove_returns(goto_model_functiont &, function_is_stubt);
+/// Removes returns from a single function. Only usable with Java programs at
+/// the moment; to use it with other languages, they must annotate their stub
+/// functions with ID_C_incomplete as currently done in
+/// java_bytecode_convert_method.cpp.
+///
+/// This will generate \#return_value variables, if not already present, for
+/// both the function being altered *and* any callees.
+/// \param m: message to initialise remove_function_pointers with
+/// \param goto_model_function: function to transform
+/// \param function_is_stub: function that will be used to test whether a given
+///   callee has been or will be given a body. It should return true if so, or
+///   false if the function will remain a bodyless stub.
+void remove_returns(
+  message_handlert &m,
+  goto_model_functiont &goto_model_function,
+  function_is_stubt function_is_stub);
 
-void remove_returns(goto_modelt &);
+void remove_returns(message_handlert &m, goto_modelt &);
 
 // reverse the above operations
 void restore_returns(symbol_table_baset &, goto_functionst &);
 
-void restore_returns(goto_modelt &);
+void restore_returns(message_handlert &m, goto_modelt &);
 
 /// produces the identifier that is used to store the return
 /// value of the function with the given identifier

--- a/src/util/type.h
+++ b/src/util/type.h
@@ -139,6 +139,16 @@ public:
 
     validate_type(type, ns, vm);
   }
+
+  void visit(std::function<void(const typet &)> f) const
+  {
+    f(*this);
+    for(const auto &sub_irep : get_sub())
+    {
+      const typet &subtype = static_cast<const typet &>(sub_irep);
+      subtype.visit(f);
+    }
+  }
 };
 
 /// Type with a single subtype.

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -14,6 +14,8 @@ SRC += analyses/ai/ai.cpp \
        analyses/does_remove_const/does_expr_lose_const.cpp \
        analyses/does_remove_const/does_type_preserve_const_correctness.cpp \
        analyses/does_remove_const/is_type_at_least_as_const_as.cpp \
+       analyses/remove_function_pointers.cpp \
+       analyses/remove_returns.cpp \
        big-int/big-int.cpp \
        compound_block_locations.cpp \
        goto-instrument/cover/cover_only.cpp \

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -15,6 +15,7 @@ SRC += analyses/ai/ai.cpp \
        analyses/does_remove_const/does_type_preserve_const_correctness.cpp \
        analyses/does_remove_const/is_type_at_least_as_const_as.cpp \
        analyses/remove_function_pointers.cpp \
+       analyses/remove_function_pointers_refine.cpp \
        analyses/remove_returns.cpp \
        big-int/big-int.cpp \
        compound_block_locations.cpp \

--- a/unit/analyses/remove_function_pointers.cpp
+++ b/unit/analyses/remove_function_pointers.cpp
@@ -1,0 +1,129 @@
+/*******************************************************************\
+ Module: Unit tests for module remove_function_pointers
+
+ Author: Diffblue Ltd.
+
+ Date: Apr 2019
+
+\*******************************************************************/
+
+/// \file
+/// Unit tests for module remove_function_pointers
+
+#include <testing-utils/message.h>
+#include <testing-utils/use_catch.h>
+
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/std_code.h>
+
+#include <goto-programs/goto_convert_functions.h>
+#include <goto-programs/goto_model.h>
+#include <goto-programs/remove_function_pointers.h>
+
+SCENARIO(
+  "List potential targets works reliable",
+  "[core][goto-programs][list_potential_targets]")
+{
+  goto_modelt goto_model;
+  // create one instance of the function type, they are all
+  // going to have the same signature
+  typet func_type = code_typet{{}, empty_typet{}};
+  // create an empty code block, to act as the functions' body
+  code_blockt func_body = code_blockt{};
+
+  // void f(){};
+  symbolt f;
+  f.name = "f";
+  f.mode = ID_C;
+  f.type = func_type; // void, takes no params
+  f.value = func_body;
+  goto_model.symbol_table.add(f);
+
+  // void g(){};
+  symbolt g;
+  g.name = "g";
+  g.mode = ID_C;
+  g.type = func_type; // void, takes no params
+  g.value = func_body;
+  goto_model.symbol_table.add(g);
+
+  // void h(){};
+  symbolt h;
+  h.name = "h";
+  h.mode = ID_C;
+  h.type = func_type; // void, takes no params
+  h.value = func_body;
+  goto_model.symbol_table.add(h);
+
+  // void l(){};
+  symbolt l;
+  l.name = "l";
+  l.mode = ID_C;
+  l.type = func_type; // void, takes no params
+  l.value = func_body;
+  goto_model.symbol_table.add(l);
+
+  // create array with function pointer elements
+  array_typet fp_array_type(
+    pointer_typet{func_type, 64}, from_integer(4, signed_int_type()));
+  array_exprt fp_array{{}, fp_array_type};
+
+  fp_array.copy_to_operands(address_of_exprt{f.symbol_expr()});
+  fp_array.copy_to_operands(address_of_exprt{g.symbol_expr()});
+  fp_array.copy_to_operands(address_of_exprt{h.symbol_expr()});
+  fp_array.copy_to_operands(address_of_exprt{l.symbol_expr()});
+
+  // f = fparray {f1, f2, f3, f4};
+  symbolt fpa;
+  fpa.name = "f";
+  fpa.mode = ID_C;
+  fpa.type = fp_array_type;
+  fpa.value = fp_array;
+
+  goto_model.symbol_table.add(fpa);
+
+  // pointer to fn call
+  symbolt fn_ptr;
+  fn_ptr.name = "fn_ptr";
+  fn_ptr.mode = ID_C;
+  fn_ptr.type = pointer_typet{func_type, 64};
+  goto_model.symbol_table.add(fn_ptr);
+
+  // symbol for indexing the array
+  symbolt z;
+  z.name = "z";
+  z.mode = ID_C;
+  z.type = signed_int_type();
+  goto_model.symbol_table.add(z);
+
+  // create function with pointer function call instruction
+
+  // void entry(){z; array; fn_ptr = array[z]; *fn_ptr()};
+  symbolt entry;
+  entry.name = "entry";
+  entry.mode = ID_C;
+  entry.type = func_type; // void, takes no params
+
+  code_blockt entry_body{
+    {// fn_ptr = array[z];
+     code_assignt{
+       fn_ptr.symbol_expr(),
+       index_exprt{fp_array, z.symbol_expr(), pointer_type(func_type)}},
+     // *fn_ptr();
+     code_function_callt{dereference_exprt{fn_ptr.symbol_expr()}}}};
+  entry.value = entry_body;
+  goto_model.symbol_table.add(entry);
+
+  WHEN("list_potential_targets is run")
+  {
+    goto_convert(goto_model, null_message_handler);
+    auto target_map =
+      get_function_pointer_targets(null_message_handler, goto_model);
+    THEN("there should be 4 targets recognised")
+    {
+      REQUIRE(target_map.size() == 1);
+      REQUIRE(target_map.begin()->second.size() == 4);
+    }
+  }
+}

--- a/unit/analyses/remove_function_pointers_refine.cpp
+++ b/unit/analyses/remove_function_pointers_refine.cpp
@@ -1,0 +1,157 @@
+/*******************************************************************\
+ Module: Unit tests for module remove_function_pointers.refine_call_type
+
+ Author: Diffblue Ltd.
+
+ Date: May 2019
+
+\*******************************************************************/
+
+/// \file
+/// Unit tests for module remove_function_pointers
+
+#include <testing-utils/message.h>
+#include <testing-utils/use_catch.h>
+
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/std_code.h>
+
+#include <goto-programs/goto_convert_functions.h>
+#include <goto-programs/goto_model.h>
+#include <goto-programs/remove_function_pointers.h>
+
+SCENARIO(
+  "List potential targets works for ellipsis",
+  "[core][goto-programs][list_potential_targets]")
+{
+  goto_modelt goto_model;
+  // create one instance of the function type, they are all
+  // going to have the same signature
+
+  symbolt int_param;
+  int_param.name = "int_param";
+  int_param.mode = ID_C;
+  int_param.type = signedbv_typet{32};
+  goto_model.symbol_table.add(int_param);
+
+  code_typet::parameterst parameters;
+  parameters.emplace_back(signedbv_typet{32});
+  parameters.back().set_identifier("int_param");
+  auto func_empty_type = code_typet{{}, empty_typet{}};
+  auto func_ellipsis_type = code_typet{{}, empty_typet{}};
+  func_ellipsis_type.make_ellipsis();
+  auto func_one_arg_type = code_typet{parameters, empty_typet{}};
+  // create an empty code block, to act as the functions' body
+  code_blockt func_body = code_blockt{};
+
+  irep_idt f_name{"f"};
+
+  // void f(...){};
+  symbolt f;
+  f.name = f_name;
+  f.mode = ID_C;
+  f.type = func_ellipsis_type; // takes anything
+  f.value = func_body;
+  goto_model.symbol_table.add(f);
+
+  // void g(int){};
+  symbolt g;
+  g.name = "g";
+  g.mode = ID_C;
+  g.type = func_one_arg_type; // takes one int
+  g.value = func_body;
+  goto_model.symbol_table.add(g);
+
+  // create array with function pointer elements
+  array_typet fp_array_type(
+    pointer_typet{func_ellipsis_type, 64}, from_integer(2, index_type()));
+  array_exprt fp_array{{}, fp_array_type};
+
+  fp_array.copy_to_operands(address_of_exprt{f.symbol_expr()});
+  fp_array.copy_to_operands(address_of_exprt{g.symbol_expr()});
+
+  // fpa = fparray {f1, f2};
+  symbolt fpa;
+  fpa.name = "fpa";
+  fpa.mode = ID_C;
+  fpa.type = fp_array_type;
+  fpa.value = fp_array;
+
+  goto_model.symbol_table.add(fpa);
+
+  irep_idt fn_ptr_name{"fn_ptr"};
+
+  // pointer to fn call
+  symbolt fn_ptr;
+  fn_ptr.name = fn_ptr_name;
+  fn_ptr.mode = ID_C;
+  fn_ptr.type = pointer_typet{func_ellipsis_type, 64};
+  goto_model.symbol_table.add(fn_ptr);
+
+  // symbol for indexing the array
+  symbolt z;
+  z.name = "z";
+  z.mode = ID_C;
+  z.type = index_type();
+  goto_model.symbol_table.add(z);
+
+  // create function with pointer function call instruction
+
+  // void entry(){z; array; fn_ptr = array[z]; *fn_ptr(z)};
+  symbolt entry;
+  entry.name = "entry";
+  entry.mode = ID_C;
+  entry.type = func_empty_type;
+
+  code_function_callt::argumentst arguments;
+  arguments.emplace_back(z.symbol_expr());
+
+  code_blockt entry_body{
+    {// fn_ptr = array[z];
+     code_assignt{fn_ptr.symbol_expr(),
+                  index_exprt{fp_array,
+                              z.symbol_expr(),
+                              pointer_type(func_ellipsis_type)}},
+     // *fn_ptr();
+     code_function_callt{dereference_exprt{fn_ptr.symbol_expr()}, arguments}}};
+  entry.value = entry_body;
+  goto_model.symbol_table.add(entry);
+
+  WHEN("list_potential_targets is run")
+  {
+    goto_convert(goto_model, null_message_handler);
+
+    // goto convert removes ellipsis so we need to re-insert them
+    auto &f_symbol = goto_model.symbol_table.get_writeable_ref(f_name);
+    to_code_type(f_symbol.type).make_ellipsis();
+    auto &fn_ptr_symbol =
+      goto_model.symbol_table.get_writeable_ref(fn_ptr_name);
+    to_code_type(fn_ptr_symbol.type.subtype()).make_ellipsis();
+
+    auto &goto_functions = goto_model.goto_functions;
+    for(auto &goto_function_pair : goto_functions.function_map)
+    {
+      auto &goto_function = goto_function_pair.second;
+      auto &goto_program = goto_function.body;
+      for(auto &instruction : goto_program.instructions)
+      {
+        if(instruction.is_function_call())
+        {
+          code_function_callt function_call = instruction.get_function_call();
+          auto &function = to_dereference_expr(function_call.function());
+          to_code_type(function.type()).make_ellipsis();
+          instruction.set_function_call(function_call);
+        }
+      }
+    }
+
+    auto target_map =
+      get_function_pointer_targets(null_message_handler, goto_model);
+    THEN("there should be 4 targets recognised")
+    {
+      REQUIRE(target_map.size() == 1);
+      REQUIRE(target_map.begin()->second.size() == 2);
+    }
+  }
+}

--- a/unit/analyses/remove_returns.cpp
+++ b/unit/analyses/remove_returns.cpp
@@ -43,7 +43,7 @@ SCENARIO(
   WHEN("remove_returns is invoked")
   {
     remove_returns(
-      null_message_handler, goto_model.symbol_table, goto_model.goto_functions);
+      goto_model.symbol_table, null_message_handler, goto_model.goto_functions);
     THEN("function f should not contain any return instructions")
     {
       const auto &goto_functions = goto_model.goto_functions;
@@ -65,7 +65,7 @@ SCENARIO(
 
   WHEN("restore_returns is invoked")
   {
-    restore_returns(null_message_handler, goto_model);
+    restore_returns(goto_model, null_message_handler);
     THEN("function f should have a skip instruction")
     {
       int number_of_returns = 0;

--- a/unit/analyses/remove_returns.cpp
+++ b/unit/analyses/remove_returns.cpp
@@ -1,0 +1,93 @@
+/*******************************************************************\
+ Module: Unit tests for module remove_returns
+
+ Author: Diffblue Ltd.
+
+ Date: Apr 2019
+
+\*******************************************************************/
+
+/// \file
+/// Unit tests for module remove_returns
+/// This is testing the top level interfaces for now.
+
+#include <testing-utils/message.h>
+#include <testing-utils/use_catch.h>
+
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/std_code.h>
+
+#include <goto-programs/goto_convert_functions.h>
+#include <goto-programs/goto_model.h>
+#include <goto-programs/remove_returns.h>
+
+// scenario for testing remove returns
+
+SCENARIO(
+  "Remove returns is working reliably",
+  "[core][goto-programs][remove_returns]")
+{
+  goto_modelt goto_model;
+
+  // int f() { return 5; }
+  symbolt f;
+  f.name = "f";
+  f.mode = ID_C;
+  f.type = code_typet{{}, signed_int_type()};
+  f.value = code_blockt{{code_returnt(from_integer(5, signed_int_type()))}};
+  goto_model.symbol_table.add(f);
+
+  goto_convert(goto_model, null_message_handler);
+
+  WHEN("remove_returns is invoked")
+  {
+    remove_returns(
+      null_message_handler, goto_model.symbol_table, goto_model.goto_functions);
+    THEN("function f should not contain any return instructions")
+    {
+      const auto &goto_functions = goto_model.goto_functions;
+      for(const auto &function_pair : goto_functions.function_map)
+      {
+        if(function_pair.first == "f")
+        {
+          const auto &instructions = function_pair.second.body.instructions;
+          for(auto target = instructions.begin(); target != instructions.end();
+              target++)
+          {
+            // make sure there are no return instructions.
+            REQUIRE(!target->is_return());
+          }
+        }
+      }
+    }
+  }
+
+  WHEN("restore_returns is invoked")
+  {
+    restore_returns(null_message_handler, goto_model);
+    THEN("function f should have a skip instruction")
+    {
+      int number_of_returns = 0;
+      const auto &goto_functions = goto_model.goto_functions;
+      for(const auto &function_pair : goto_functions.function_map)
+      {
+        if(function_pair.first == "f")
+        {
+          const auto &instructions = function_pair.second.body.instructions;
+          for(auto target = instructions.begin(); target != instructions.end();
+              target++)
+          {
+            if(target->is_return())
+              number_of_returns++;
+          }
+        }
+      }
+
+      // ensure that there were only 1 return instructions in f
+      REQUIRE(number_of_returns == 1);
+    }
+  }
+}
+
+// scenario for testing restore returns


### PR DESCRIPTION
Motivation: we want `remove_returns` to work even if not preceded by `remove_function_pointers`. For example:

```
int (* const fptbl2[])(void) = {g1, g2};

int func(int id1)
{
  t = fptbl2[id1];  // for this instruction the set is {"g1", "g2"}
  return t;
}
```

This PR exposes the function-pointer-target-collecting part of `remove_function_pointers` to be used in other analyses and the does so in `remove_returns`.

In `remove_returns` use the `possible_fp_targets_map` to be able to remove returns for calls to function pointers. `CALL x=*fp()` should become `CALL *fp(); ASSIGN x = (fp == &f00) ? return_value_f00 : (fp == &f01) ?` ....

The first 3 commits are refactoring/preparation. The fourth introduces the interface. The fifth implements the new `do_function_call` for function pointers.

Then we refactor the `remove_function_pointers` to extract the collect-candidate-functions part and separate the modify-function-call part.

Finally -- now that the file is open -- we also refactor the internal `remove_function_pointers` without any functional change.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
