### PR TITLE
Minor sharing-map improvements, used to avoid copying in value_sett

### DIFF
--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -232,6 +232,24 @@ public:
     object_numberingt::number_type n,
     const offsett &offset) const;
 
+  enum class insert_actiont
+  {
+    INSERT,
+    RESET_OFFSET,
+    NONE
+  };
+
+  /// Determines what would happen if object number \p n was inserted into map
+  /// \p dest with offset \p offset -- the possibilities being, nothing (the
+  /// entry is already present), a new entry would be inserted (no existing
+  /// entry with number \p n was found), or an existing entry's offset would be
+  /// reset (indicating there is already an entry with number \p n, but with
+  /// differing offset).
+  insert_actiont get_insert_action(
+    const object_mapt &dest,
+    object_numberingt::number_type n,
+    const offsett &offset) const;
+
   /// Adds an expression and offset to an object map. If the
   /// destination map has an existing element for the same expression
   /// with a differing offset its offset is marked unknown.
@@ -359,6 +377,13 @@ public:
   /// \param src: set to merge in
   /// \return true if anything changed.
   bool make_union(object_mapt &dest, const object_mapt &src) const;
+
+  /// Determines whether merging two RHS expression sets would cause any change
+  /// \param dest: set that would be merged into
+  /// \param src: set that would be merged in
+  /// \return true if anything changed.
+  bool make_union_would_change(const object_mapt &dest, const object_mapt &src)
+    const;
 
   /// Merges an entire existing value_sett's data into this one
   /// \param new_values: new values to merge in

--- a/src/util/invariant.cpp
+++ b/src/util/invariant.cpp
@@ -16,6 +16,8 @@ Author: Martin Brain, martin.brain@diffblue.com
 
 #include <iostream>
 
+bool cbmc_invariants_should_throw = false;
+
 // Backtraces compiler and C library specific
 // So we should include something explicitly from the C library
 // to check if the C library is glibc.
@@ -25,7 +27,6 @@ Author: Martin Brain, martin.brain@diffblue.com
 // GCC needs LINKFLAGS="-rdynamic" to give function names in the backtrace
 #include <execinfo.h>
 #include <cxxabi.h>
-
 
 /// Attempts to demangle the function name assuming the glibc
 /// format of stack entry:

--- a/src/util/sharing_map.h
+++ b/src/util/sharing_map.h
@@ -222,6 +222,19 @@ public:
   /// \param k: The key of the element to erase
   void erase(const key_type &k);
 
+  /// Erase element if it exists
+  ///
+  /// Complexity:
+  /// - Worst case: O(H * S + M)
+  /// - Best case: O(H)
+  ///
+  /// \param k: The key of the element to erase
+  void erase_if_exists(const key_type &k)
+  {
+    if(has_key(k))
+      erase(k);
+  }
+
   /// Insert element, element must not exist in map
   ///
   /// Complexity:

--- a/src/util/sharing_map.h
+++ b/src/util/sharing_map.h
@@ -444,6 +444,18 @@ public:
     delta_viewt &delta_view,
     const bool only_common = true) const;
 
+  /// Call a function for every key-value pair in the map.
+  ///
+  /// Complexity: as \ref sharing_mapt::get_view
+  void
+  iterate(std::function<void(const key_type &k, const mapped_type &m)> f) const
+  {
+    if(empty())
+      return;
+
+    iterate(map, 0, f);
+  }
+
 #if !defined(_MSC_VER)
   /// Stats about sharing between several sharing map instances. An instance of
   /// this class is returned by the get_sharing_map_stats_* functions.

--- a/src/util/sharing_node.h
+++ b/src/util/sharing_node.h
@@ -511,6 +511,16 @@ public:
     SN_ASSERT(data.use_count() == 1);
   }
 
+  void mutate_value(std::function<void(valueT &)> mutator)
+  {
+    SN_ASSERT(data);
+
+    if(data.use_count() > 1)
+      data = make_small_shared_ptr<d_lt>(data->k, data->v);
+
+    mutator(data->v);
+  }
+
 protected:
   datat data;
 };

--- a/unit/util/sharing_map.cpp
+++ b/unit/util/sharing_map.cpp
@@ -297,7 +297,7 @@ TEST_CASE("Sharing map collisions", "[core][util]")
   REQUIRE(!sm.has_key(some_keyt(8)));
 }
 
-TEST_CASE("Sharing map views", "[core][util]")
+TEST_CASE("Sharing map views and iteration", "[core][util]")
 {
   SECTION("View of empty map")
   {
@@ -347,6 +347,25 @@ TEST_CASE("Sharing map views", "[core][util]")
     sort_view();
 
     REQUIRE((pairs[3] == pt("l", "3")));
+  }
+
+  SECTION("Iterate")
+  {
+    sharing_map_standardt sm;
+    fill(sm);
+
+    typedef std::pair<dstringt, std::string> pt;
+    std::vector<pt> pairs;
+
+    sm.iterate([&pairs](const irep_idt &key, const std::string &value) {
+      pairs.push_back({key, value});
+    });
+
+    std::sort(pairs.begin(), pairs.end());
+    REQUIRE(pairs.size() == 3);
+    REQUIRE((pairs[0] == pt("i", "0")));
+    REQUIRE((pairs[1] == pt("j", "1")));
+    REQUIRE((pairs[2] == pt("k", "2")));
   }
 
   SECTION("Delta view (no sharing, same keys)")

--- a/unit/util/sharing_map.cpp
+++ b/unit/util/sharing_map.cpp
@@ -201,6 +201,12 @@ TEST_CASE("Sharing map interface", "[core][util]")
     sm.erase("j");
     REQUIRE(!sm.has_key("j"));
 
+    sm.erase_if_exists("j");
+    REQUIRE(!sm.has_key("j"));
+    sm.insert("j", "1");
+    sm.erase_if_exists("j");
+    REQUIRE(!sm.has_key("j"));
+
     sm.insert("i", "0");
     sm.insert("j", "1");
 


### PR DESCRIPTION
This adds `sharing_mapt::erase_if_exists`, `::iterate` and `::update`, and uses them to avoid copying entries in `value_sett`. The `value_sett` changes are much easier to review if you diff without whitespace sensitivity.

Note `erase_if_exists` isn't used in this PR (it's used out-of-tree), but is also the most simple of the additions.