### PR TITLE
Clean up in string solver

### DIFF
--- a/src/solvers/strings/array_pool.cpp
+++ b/src/solvers/strings/array_pool.cpp
@@ -123,14 +123,6 @@ array_poolt::find(const exprt &pointer, const exprt &length)
   return *created_strings_value.insert(array).first;
 }
 
-const array_string_exprt &char_array_of_pointer(
-  array_poolt &pool,
-  const exprt &pointer,
-  const exprt &length)
-{
-  return pool.find(pointer, length);
-}
-
 array_string_exprt of_argument(array_poolt &array_pool, const exprt &arg)
 {
   const auto string_argument = expr_checked_cast<struct_exprt>(arg);
@@ -141,5 +133,5 @@ array_string_exprt get_string_expr(array_poolt &pool, const exprt &expr)
 {
   PRECONDITION(is_refined_string_type(expr.type()));
   const refined_string_exprt &str = to_string_expr(expr);
-  return char_array_of_pointer(pool, str.content(), str.length());
+  return pool.find(str.content(), str.length());
 }

--- a/src/solvers/strings/array_pool.h
+++ b/src/solvers/strings/array_pool.h
@@ -97,13 +97,6 @@ private:
 /// are given as a struct containing a length and pointer to an array.
 array_string_exprt of_argument(array_poolt &array_pool, const exprt &arg);
 
-/// Return the array associated to the given pointer or creates a new one
-DEPRECATED("use pool.find(pointer, length) instead")
-const array_string_exprt &char_array_of_pointer(
-  array_poolt &pool,
-  const exprt &pointer,
-  const exprt &length);
-
 /// Fetch the string_exprt corresponding to the given refined_string_exprt
 /// \param pool: pool of arrays representing strings
 /// \param expr: an expression of refined string type

--- a/src/solvers/strings/string_constraint_generator_code_points.cpp
+++ b/src/solvers/strings/string_constraint_generator_code_points.cpp
@@ -196,7 +196,6 @@ std::pair<exprt, string_constraintst> add_axioms_for_code_point_count(
 {
   PRECONDITION(f.arguments().size() == 3);
   string_constraintst constraints;
-  const array_string_exprt str = get_string_expr(array_pool, f.arguments()[0]);
   const exprt &begin = f.arguments()[1];
   const exprt &end = f.arguments()[2];
   const typet &return_type = f.type();

--- a/src/solvers/strings/string_constraint_generator_concat.cpp
+++ b/src/solvers/strings/string_constraint_generator_concat.cpp
@@ -147,7 +147,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_concat_code_point(
 {
   PRECONDITION(f.arguments().size() == 4);
   const array_string_exprt res =
-    char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
+    array_pool.find(f.arguments()[1], f.arguments()[0]);
   const array_string_exprt s1 = get_string_expr(array_pool, f.arguments()[2]);
   const typet &char_type = s1.content().type().subtype();
   const typet &index_type = s1.length().type();

--- a/src/solvers/strings/string_constraint_generator_constants.cpp
+++ b/src/solvers/strings/string_constraint_generator_constants.cpp
@@ -117,8 +117,7 @@ std::pair<exprt, string_constraintst> add_axioms_from_literal(
 {
   const function_application_exprt::argumentst &args = f.arguments();
   PRECONDITION(args.size() == 3); // Bad args to string literal?
-  const array_string_exprt res =
-    char_array_of_pointer(array_pool, args[1], args[0]);
+  const array_string_exprt res = array_pool.find(args[1], args[0]);
   return add_axioms_for_cprover_string(
     fresh_symbol, res, args[2], true_exprt());
 }

--- a/src/solvers/strings/string_constraint_generator_float.cpp
+++ b/src/solvers/strings/string_constraint_generator_float.cpp
@@ -165,8 +165,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_string_of_float(
   const namespacet &ns)
 {
   PRECONDITION(f.arguments().size() == 3);
-  array_string_exprt res =
-    char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
+  array_string_exprt res = array_pool.find(f.arguments()[1], f.arguments()[0]);
   return add_axioms_for_string_of_float(
     fresh_symbol, res, f.arguments()[2], array_pool, ns);
 }
@@ -551,7 +550,7 @@ std::pair<exprt, string_constraintst> add_axioms_from_float_scientific_notation(
 {
   PRECONDITION(f.arguments().size() == 3);
   const array_string_exprt res =
-    char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
+    array_pool.find(f.arguments()[1], f.arguments()[0]);
   const exprt &arg = f.arguments()[2];
   return add_axioms_from_float_scientific_notation(
     fresh_symbol, res, arg, array_pool, ns);

--- a/src/solvers/strings/string_constraint_generator_format.cpp
+++ b/src/solvers/strings/string_constraint_generator_format.cpp
@@ -603,7 +603,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_format(
 {
   PRECONDITION(f.arguments().size() >= 3);
   const array_string_exprt res =
-    char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
+    array_pool.find(f.arguments()[1], f.arguments()[0]);
   const array_string_exprt s1 = get_string_expr(array_pool, f.arguments()[2]);
 
   if(s1.length().id() == ID_constant && s1.content().id() == ID_array)

--- a/src/solvers/strings/string_constraint_generator_insert.cpp
+++ b/src/solvers/strings/string_constraint_generator_insert.cpp
@@ -111,8 +111,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_insert(
   PRECONDITION(f.arguments().size() == 5 || f.arguments().size() == 7);
   array_string_exprt s1 = get_string_expr(pool, f.arguments()[2]);
   array_string_exprt s2 = get_string_expr(pool, f.arguments()[4]);
-  array_string_exprt res =
-    char_array_of_pointer(pool, f.arguments()[1], f.arguments()[0]);
+  array_string_exprt res = pool.find(f.arguments()[1], f.arguments()[0]);
   const exprt &offset = f.arguments()[3];
   if(f.arguments().size() == 7)
   {
@@ -150,7 +149,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_insert_int(
   PRECONDITION(f.arguments().size() == 5);
   const array_string_exprt s1 = get_string_expr(array_pool, f.arguments()[2]);
   const array_string_exprt res =
-    char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
+    array_pool.find(f.arguments()[1], f.arguments()[0]);
   const exprt &offset = f.arguments()[3];
   const typet &index_type = s1.length().type();
   const typet &char_type = s1.content().type().subtype();
@@ -176,7 +175,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_insert_bool(
   PRECONDITION(f.arguments().size() == 5);
   const array_string_exprt s1 = get_string_expr(array_pool, f.arguments()[0]);
   const array_string_exprt res =
-    char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
+    array_pool.find(f.arguments()[1], f.arguments()[0]);
   const exprt &offset = f.arguments()[3];
   const typet &index_type = s1.length().type();
   const typet &char_type = s1.content().type().subtype();
@@ -200,7 +199,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_insert_char(
 {
   PRECONDITION(f.arguments().size() == 5);
   const array_string_exprt res =
-    char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
+    array_pool.find(f.arguments()[1], f.arguments()[0]);
   const array_string_exprt s1 = get_string_expr(array_pool, f.arguments()[2]);
   const exprt &offset = f.arguments()[3];
   const typet &index_type = s1.length().type();
@@ -228,7 +227,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_insert_double(
 {
   PRECONDITION(f.arguments().size() == 5);
   const array_string_exprt res =
-    char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
+    array_pool.find(f.arguments()[1], f.arguments()[0]);
   const array_string_exprt s1 = get_string_expr(array_pool, f.arguments()[2]);
   const exprt &offset = f.arguments()[3];
   const typet &index_type = s1.length().type();

--- a/src/solvers/strings/string_constraint_generator_main.cpp
+++ b/src/solvers/strings/string_constraint_generator_main.cpp
@@ -173,8 +173,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_constrain_characters(
   PRECONDITION(args[2].type().id() == ID_string);
   PRECONDITION(args[2].id() == ID_constant);
 
-  const array_string_exprt s =
-    char_array_of_pointer(array_pool, args[1], args[0]);
+  const array_string_exprt s = array_pool.find(args[1], args[0]);
   const irep_idt &char_set_string = to_constant_expr(args[2]).get_value();
   const exprt &start =
     args.size() >= 4 ? args[3] : from_integer(0, s.length().type());
@@ -340,8 +339,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_copy(
 {
   const auto &args = f.arguments();
   PRECONDITION(args.size() == 3 || args.size() == 5);
-  const array_string_exprt res =
-    char_array_of_pointer(array_pool, args[1], args[0]);
+  const array_string_exprt res = array_pool.find(args[1], args[0]);
   const array_string_exprt str = get_string_expr(array_pool, args[2]);
   const typet &index_type = str.length().type();
   const exprt offset = args.size() == 3 ? from_integer(0, index_type) : args[3];

--- a/src/solvers/strings/string_constraint_generator_transformation.cpp
+++ b/src/solvers/strings/string_constraint_generator_transformation.cpp
@@ -43,7 +43,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_set_length(
   PRECONDITION(f.arguments().size() == 4);
   string_constraintst constraints;
   const array_string_exprt res =
-    char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
+    array_pool.find(f.arguments()[1], f.arguments()[0]);
   const array_string_exprt s1 = get_string_expr(array_pool, f.arguments()[2]);
   const exprt &k = f.arguments()[3];
   const typet &index_type = s1.length().type();
@@ -100,8 +100,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_substring(
   const function_application_exprt::argumentst &args = f.arguments();
   PRECONDITION(args.size() == 4 || args.size() == 5);
   const array_string_exprt str = get_string_expr(array_pool, args[2]);
-  const array_string_exprt res =
-    char_array_of_pointer(array_pool, args[1], args[0]);
+  const array_string_exprt res = array_pool.find(args[1], args[0]);
   const exprt &i = args[3];
   const exprt j = args.size() == 5 ? args[4] : str.length();
   return add_axioms_for_substring(fresh_symbol, res, str, i, j);
@@ -190,7 +189,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_trim(
   string_constraintst constraints;
   const array_string_exprt &str = get_string_expr(array_pool, f.arguments()[2]);
   const array_string_exprt &res =
-    char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
+    array_pool.find(f.arguments()[1], f.arguments()[0]);
   const typet &index_type = str.length().type();
   const typet &char_type = str.content().type().subtype();
   const symbol_exprt idx = fresh_symbol("index_trim", index_type);
@@ -302,8 +301,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_replace(
   PRECONDITION(f.arguments().size() == 5);
   string_constraintst constraints;
   array_string_exprt str = get_string_expr(array_pool, f.arguments()[2]);
-  array_string_exprt res =
-    char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
+  array_string_exprt res = array_pool.find(f.arguments()[1], f.arguments()[0]);
   if(
     const auto maybe_chars =
       to_char_pair(f.arguments()[3], f.arguments()[4], [&](const exprt &e) {
@@ -342,7 +340,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_delete_char_at(
 {
   PRECONDITION(f.arguments().size() == 4);
   const array_string_exprt res =
-    char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
+    array_pool.find(f.arguments()[1], f.arguments()[0]);
   const array_string_exprt str = get_string_expr(array_pool, f.arguments()[2]);
   exprt index_one = from_integer(1, str.length().type());
   return add_axioms_for_delete(
@@ -414,7 +412,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_delete(
 {
   PRECONDITION(f.arguments().size() == 5);
   const array_string_exprt res =
-    char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
+    array_pool.find(f.arguments()[1], f.arguments()[0]);
   const array_string_exprt arg = get_string_expr(array_pool, f.arguments()[2]);
   return add_axioms_for_delete(
     fresh_symbol, res, arg, f.arguments()[3], f.arguments()[4], array_pool);

--- a/src/solvers/strings/string_constraint_generator_valueof.cpp
+++ b/src/solvers/strings/string_constraint_generator_valueof.cpp
@@ -50,7 +50,7 @@ std::pair<exprt, string_constraintst> add_axioms_from_long(
 {
   PRECONDITION(f.arguments().size() == 3 || f.arguments().size() == 4);
   const array_string_exprt res =
-    char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
+    array_pool.find(f.arguments()[1], f.arguments()[0]);
   if(f.arguments().size() == 4)
     return add_axioms_for_string_of_int_with_radix(
       res, f.arguments()[2], f.arguments()[3], 0, ns);
@@ -70,7 +70,7 @@ std::pair<exprt, string_constraintst> add_axioms_from_bool(
 {
   PRECONDITION(f.arguments().size() == 3);
   const array_string_exprt res =
-    char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
+    array_pool.find(f.arguments()[1], f.arguments()[0]);
   return add_axioms_from_bool(res, f.arguments()[2]);
 }
 
@@ -275,7 +275,7 @@ std::pair<exprt, string_constraintst> add_axioms_from_int_hex(
 {
   PRECONDITION(f.arguments().size() == 3);
   const array_string_exprt res =
-    char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
+    array_pool.find(f.arguments()[1], f.arguments()[0]);
   return add_axioms_from_int_hex(res, f.arguments()[2]);
 }
 
@@ -296,7 +296,7 @@ std::pair<exprt, string_constraintst> add_axioms_from_char(
 {
   PRECONDITION(f.arguments().size() == 3);
   const array_string_exprt res =
-    char_array_of_pointer(array_pool, f.arguments()[1], f.arguments()[0]);
+    array_pool.find(f.arguments()[1], f.arguments()[0]);
   return add_axioms_from_char(res, f.arguments()[2]);
 }
 

--- a/src/solvers/strings/string_constraint_instantiation.cpp
+++ b/src/solvers/strings/string_constraint_instantiation.cpp
@@ -14,10 +14,8 @@ Author: Jesse Sigal, jesse.sigal@diffblue.com
 #include <unordered_set>
 #include <util/expr_iterator.h>
 
-/// look for the symbol and return true if it is found
-/// \param index: an index expression
-/// \param qvar: a symbol expression
-/// \return a Boolean
+/// Look for symbol \p qvar in the expression \p index and return true if found
+/// \return True, iff \p qvar appears in \p index.
 static bool contains(const exprt &index, const symbol_exprt &qvar)
 {
   return std::find(index.depth_begin(), index.depth_end(), qvar) !=

--- a/src/solvers/strings/string_constraint_instantiation.cpp
+++ b/src/solvers/strings/string_constraint_instantiation.cpp
@@ -131,8 +131,9 @@ exprt sum_over_map(std::map<exprt, int> &m, const typet &type, bool negated)
           if(sum.is_nil())
             sum = t;
           else
-            plus_exprt(sum, t);
-          for(int i = 1; i < factor; i++)             sum = plus_exprt(sum, t);
+            sum = plus_exprt(sum, t);
+          for(int i = 1; i < factor; i++)
+            sum = plus_exprt(sum, t);
         }
         else if(factor < -1)
         {

--- a/src/solvers/strings/string_constraint_instantiation.cpp
+++ b/src/solvers/strings/string_constraint_instantiation.cpp
@@ -126,24 +126,13 @@ exprt sum_over_map(std::map<exprt, int> &m, const typet &type, bool negated)
         break;
 
       default:
-        if(factor > 1)
-        {
-          if(sum.is_nil())
-            sum = t;
-          else
-            sum = plus_exprt(sum, t);
-          for(int i = 1; i < factor; i++)
-            sum = plus_exprt(sum, t);
-        }
-        else if(factor < -1)
-        {
-          if(sum.is_nil())
-            sum = unary_minus_exprt(t);
-          else
-            sum = minus_exprt(sum, t);
-          for(int i = -1; i > factor; i--)
-            sum = minus_exprt(sum, t);
-        }
+      {
+        const mult_exprt to_add{t, from_integer(factor, t.type())};
+        if(sum.is_nil())
+          sum = to_add;
+        else
+          sum = plus_exprt(sum, to_add);
+      }
       }
     }
   }

--- a/src/solvers/strings/string_constraint_instantiation.cpp
+++ b/src/solvers/strings/string_constraint_instantiation.cpp
@@ -203,8 +203,10 @@ compute_inverse_function(const exprt &qvar, const exprt &val, const exprt &f)
 /// \param str: an array of characters
 /// \param val: an index expression
 /// \return instantiated formula
-exprt
-instantiate(const string_constraintt &axiom, const exprt &str, const exprt &val)
+exprt instantiate(
+  const string_constraintt &axiom,
+  const exprt &str,
+  const exprt &val)
 {
   exprt::operandst conjuncts;
   for(const auto &index : find_indexes(axiom.body, str, axiom.univ_var))
@@ -213,9 +215,9 @@ instantiate(const string_constraintt &axiom, const exprt &str, const exprt &val)
       compute_inverse_function(axiom.univ_var, val, index);
     implies_exprt instance(
       and_exprt(
-    binary_relation_exprt(axiom.univ_var, ID_ge, axiom.lower_bound),
-    binary_relation_exprt(axiom.univ_var, ID_lt, axiom.upper_bound)),
-    axiom.body);
+        binary_relation_exprt(axiom.univ_var, ID_ge, axiom.lower_bound),
+        binary_relation_exprt(axiom.univ_var, ID_lt, axiom.upper_bound)),
+      axiom.body);
     replace_expr(axiom.univ_var, univ_var_value, instance);
     conjuncts.push_back(instance);
   }

--- a/src/solvers/strings/string_constraint_instantiation.cpp
+++ b/src/solvers/strings/string_constraint_instantiation.cpp
@@ -157,7 +157,7 @@ static exprt
 compute_inverse_function(const exprt &qvar, const exprt &val, const exprt &f)
 {
   exprt positive, negative;
-  // number of time the element should be added (can be negative)
+  // number of times the element should be added (can be negative)
   // qvar has to be equal to val - f(0) if it appears positively in f
   // (i.e. if f(qvar)=f(0) + qvar) and f(0) - val if it appears negatively
   // in f. So we start by computing val - f(0).
@@ -180,7 +180,7 @@ compute_inverse_function(const exprt &qvar, const exprt &val, const exprt &f)
       it->second == 0,
       string_refinement_invariantt(
         "a proper function must have exactly one "
-        "occurrences after reduction, or it cancelled out, and it does not"
+        "occurrence after reduction, or it cancelled out, and it does not"
         " have one"));
   }
 

--- a/src/solvers/strings/string_constraint_instantiation.cpp
+++ b/src/solvers/strings/string_constraint_instantiation.cpp
@@ -91,6 +91,14 @@ linear_functiont::linear_functiont(const exprt &f)
   }
 }
 
+void linear_functiont::add(const linear_functiont &other)
+{
+  PRECONDITION(type == other.type);
+  constant_coefficient += other.constant_coefficient;
+  for(auto pair : other.coefficients)
+    coefficients[pair.first] += pair.second;
+}
+
 exprt linear_functiont::to_expr(bool negated) const
 {
   exprt sum = nil_exprt{};

--- a/src/solvers/strings/string_constraint_instantiation.cpp
+++ b/src/solvers/strings/string_constraint_instantiation.cpp
@@ -156,6 +156,15 @@ exprt linear_functiont::solve(
   return f.to_expr(positive);
 }
 
+std::string linear_functiont::format()
+{
+  std::ostringstream stream;
+  stream << constant_coefficient;
+  for(const auto &pair : coefficients)
+    stream << " + " << pair.second << " * " << ::format(pair.first);
+  return stream.str();
+}
+
 /// Instantiates a string constraint by substituting the quantifiers.
 /// For a string constraint of the form `forall q. P(x)`,
 /// substitute `q` the universally quantified variable of `axiom`, by

--- a/src/solvers/strings/string_constraint_instantiation.cpp
+++ b/src/solvers/strings/string_constraint_instantiation.cpp
@@ -52,7 +52,7 @@ find_indexes(const exprt &expr, const exprt &str, const symbol_exprt &qvar)
 
 std::map<exprt, int> map_representation_of_sum(const exprt &f)
 {
-  // number of time the leaf should be added (can be negative)
+  // number of times the leaf should be added (can be negative)
   std::map<exprt, int> elems;
 
   std::list<std::pair<exprt, bool>> to_process;
@@ -80,9 +80,9 @@ std::map<exprt, int> map_representation_of_sum(const exprt &f)
     else
     {
       if(positive)
-        elems[cur] = elems[cur] + 1;
+        ++elems[cur];
       else
-        elems[cur] = elems[cur] - 1;
+        --elems[cur];
     }
   }
   return elems;

--- a/src/solvers/strings/string_constraint_instantiation.cpp
+++ b/src/solvers/strings/string_constraint_instantiation.cpp
@@ -10,6 +10,232 @@ Author: Jesse Sigal, jesse.sigal@diffblue.com
 /// Defines related function for string constraints.
 
 #include "string_constraint_instantiation.h"
+#include <algorithm>
+#include <unordered_set>
+#include <util/expr_iterator.h>
+
+/// look for the symbol and return true if it is found
+/// \param index: an index expression
+/// \param qvar: a symbol expression
+/// \return a Boolean
+static bool contains(const exprt &index, const symbol_exprt &qvar)
+{
+  return std::find(index.depth_begin(), index.depth_end(), qvar) !=
+         index.depth_end();
+}
+
+/// Find indexes of `str` used in `expr` that contains `qvar`, for instance
+/// with arguments ``(str[k+1]=='a')``, `str`, and `k`, the function should
+/// return `k+1`.
+/// \param [in] expr: the expression to search
+/// \param [in] str: the string which must be indexed
+/// \param [in] qvar: the universal variable that must be in the index
+/// \return index expressions in `expr` on `str` containing `qvar`.
+static std::unordered_set<exprt, irep_hash>
+find_indexes(const exprt &expr, const exprt &str, const symbol_exprt &qvar)
+{
+  decltype(find_indexes(expr, str, qvar)) result;
+  auto index_str_containing_qvar = [&](const exprt &e) {
+    if(auto index_expr = expr_try_dynamic_cast<index_exprt>(e))
+    {
+      const auto &arr = index_expr->array();
+      const auto str_it = std::find(arr.depth_begin(), arr.depth_end(), str);
+      return str_it != arr.depth_end() && contains(index_expr->index(), qvar);
+    }
+    return false;
+  };
+
+  std::for_each(expr.depth_begin(), expr.depth_end(), [&](const exprt &e) {
+    if(index_str_containing_qvar(e))
+      result.insert(to_index_expr(e).index());
+  });
+  return result;
+}
+
+std::map<exprt, int> map_representation_of_sum(const exprt &f)
+{
+  // number of time the leaf should be added (can be negative)
+  std::map<exprt, int> elems;
+
+  std::list<std::pair<exprt, bool>> to_process;
+  to_process.emplace_back(f, true);
+
+  while(!to_process.empty())
+  {
+    exprt cur = to_process.back().first;
+    bool positive = to_process.back().second;
+    to_process.pop_back();
+    if(cur.id() == ID_plus)
+    {
+      for(const auto &op : cur.operands())
+        to_process.emplace_back(op, positive);
+    }
+    else if(cur.id() == ID_minus)
+    {
+      to_process.emplace_back(cur.op1(), !positive);
+      to_process.emplace_back(cur.op0(), positive);
+    }
+    else if(cur.id() == ID_unary_minus)
+    {
+      to_process.emplace_back(cur.op0(), !positive);
+    }
+    else
+    {
+      if(positive)
+        elems[cur] = elems[cur] + 1;
+      else
+        elems[cur] = elems[cur] - 1;
+    }
+  }
+  return elems;
+}
+
+exprt
+sum_over_map(std::map<exprt, int> &m, const typet &type, bool negated)
+{
+  exprt sum = nil_exprt();
+  mp_integer constants = 0;
+  typet index_type;
+  if(m.empty())
+    return from_integer(0, type);
+  else
+    index_type = m.begin()->first.type();
+
+  for(const auto &term : m)
+  {
+    // We should group constants together...
+    const exprt &t = term.first;
+    int second = negated ? (-term.second) : term.second;
+    if(t.id() == ID_constant)
+    {
+      const auto int_value = numeric_cast_v<mp_integer>(to_constant_expr(t));
+      constants += int_value * second;
+    }
+    else
+    {
+      switch(second)
+      {
+        case -1:
+          if(sum.is_nil())
+            sum = unary_minus_exprt(t);
+          else
+            sum = minus_exprt(sum, t);
+          break;
+
+        case 1:
+          if(sum.is_nil())
+            sum = t;
+          else
+            sum = plus_exprt(sum, t);
+          break;
+
+        default:
+          if(second > 1)
+          {
+            if(sum.is_nil())
+              sum = t;
+            else
+              plus_exprt(sum, t);
+            for(int i = 1; i < second; i++)
+              sum = plus_exprt(sum, t);
+          }
+          else if(second < -1)
+          {
+            if(sum.is_nil())
+              sum = unary_minus_exprt(t);
+            else
+              sum = minus_exprt(sum, t);
+            for(int i = -1; i > second; i--)
+              sum = minus_exprt(sum, t);
+          }
+      }
+    }
+  }
+
+  exprt index_const = from_integer(constants, index_type);
+  if(sum.is_not_nil())
+    return plus_exprt(sum, index_const);
+  else
+    return index_const;
+}
+
+/// \param qvar: a symbol representing a universally quantified variable
+/// \param val: an expression
+/// \param f: an expression containing `+` and `-`
+///   operations in which `qvar` should appear exactly once.
+/// \return an expression corresponding of $f^{-1}(val)$ where $f$ is seen as
+///   a function of $qvar$, i.e. the value that is necessary for `qvar` for `f`
+///   to be equal to `val`. For instance, if `f` corresponds to the expression
+///   $q + x$, `compute_inverse_function(q,v,f)` returns an expression
+///   for $v - x$.
+static exprt
+compute_inverse_function(const exprt &qvar, const exprt &val, const exprt &f)
+{
+  exprt positive, negative;
+  // number of time the element should be added (can be negative)
+  // qvar has to be equal to val - f(0) if it appears positively in f
+  // (i.e. if f(qvar)=f(0) + qvar) and f(0) - val if it appears negatively
+  // in f. So we start by computing val - f(0).
+  std::map<exprt, int> elems = map_representation_of_sum(minus_exprt(val, f));
+
+  // true if qvar appears negatively in f (positively in elems):
+  bool neg = false;
+
+  auto it = elems.find(qvar);
+  INVARIANT(
+    it != elems.end(),
+    string_refinement_invariantt("a function must have an occurrence of qvar"));
+  if(it->second == 1 || it->second == -1)
+  {
+    neg = (it->second == 1);
+  }
+  else
+  {
+    INVARIANT(
+      it->second == 0,
+      string_refinement_invariantt(
+        "a proper function must have exactly one "
+        "occurrences after reduction, or it cancelled out, and it does not"
+        " have one"));
+  }
+
+  elems.erase(it);
+  return sum_over_map(elems, f.type(), neg);
+}
+
+/// Instantiates a string constraint by substituting the quantifiers.
+/// For a string constraint of the form `forall q. P(x)`,
+/// substitute `q` the universally quantified variable of `axiom`, by
+/// an `index`, in `axiom`, so that the index used for `str` equals `val`.
+/// For instance, if `axiom` is `forall q. s[q+x] = 'a' && t[q] = 'b'`,
+/// `instantiate(axiom,s,v)` would return the expression
+/// `s[v] = 'a' && t[v-x] = 'b'`.
+/// If there are several such indexes, the conjunction of the instantiations is
+/// returned, for instance for a formula:
+/// `forall q. s[q+x]='a' && s[q]=c` we would get
+/// `s[v] = 'a' && s[v-x] = c && s[v+x] = 'a' && s[v] = c`.
+/// \param axiom: a universally quantified formula
+/// \param str: an array of characters
+/// \param val: an index expression
+/// \return instantiated formula
+exprt
+instantiate(const string_constraintt &axiom, const exprt &str, const exprt &val)
+{
+  exprt::operandst conjuncts;
+  for(const auto &index : find_indexes(axiom.body, str, axiom.univ_var))
+  {
+    const exprt univ_var_value =
+      compute_inverse_function(axiom.univ_var, val, index);
+    implies_exprt instance(
+      and_exprt(
+    binary_relation_exprt(axiom.univ_var, ID_ge, axiom.lower_bound),
+    binary_relation_exprt(axiom.univ_var, ID_lt, axiom.upper_bound)),
+    axiom.body);
+    replace_expr(axiom.univ_var, univ_var_value, instance);
+    conjuncts.push_back(instance);
+  }
+  return conjunction(conjuncts);
+}
 
 /// Instantiates a quantified formula representing `not_contains` by
 /// substituting the quantifiers and generating axioms.

--- a/src/solvers/strings/string_constraint_instantiation.h
+++ b/src/solvers/strings/string_constraint_instantiation.h
@@ -48,6 +48,9 @@ struct linear_functiont
   /// its cannonical representation
   explicit linear_functiont(const exprt &f);
 
+  /// Make this function the sum of the current function with \p other
+  void add(const linear_functiont &other);
+
   /// \param negated: optional Boolean asking to negate the function
   /// \return an expression corresponding to the linear function
   exprt to_expr(bool negated = false) const;

--- a/src/solvers/strings/string_constraint_instantiation.h
+++ b/src/solvers/strings/string_constraint_instantiation.h
@@ -54,6 +54,12 @@ struct linear_functiont
   /// \param negated: optional Boolean asking to negate the function
   /// \return an expression corresponding to the linear function
   exprt to_expr(bool negated = false) const;
+
+  /// Return an expression `y` such that `f(var <- y) = val`.
+  /// The coefficient of \p var in the linear function must be 1 or -1.
+  /// For instance, if `f` corresponds to the expression `q + x`, `solve(q,v,f)`
+  /// returns the expression `v - x`.
+  static exprt solve(linear_functiont f, const exprt &var, const exprt &val);
 };
 
 #endif // CPROVER_SOLVERS_REFINEMENT_STRING_CONSTRAINT_INSTANTIATION_H

--- a/src/solvers/strings/string_constraint_instantiation.h
+++ b/src/solvers/strings/string_constraint_instantiation.h
@@ -15,10 +15,39 @@ Author: Jesse Sigal, jesse.sigal@diffblue.com
 #include "string_constraint.h"
 #include "string_constraint_generator.h"
 
+/// Substitute `qvar` the universally quantified variable of `axiom`, by
+/// an index `val`, in `axiom`, so that the index used for `str` equals `val`.
+/// For instance, if `axiom` corresponds to \f$\forall q.\ s[q+x]='a' \land
+/// t[q]='b'\f$, `instantiate(axiom,s,v)` would return an expression for
+/// \f$s[v]='a' \land t[v-x]='b'\f$.
+/// \param axiom: a universally quantified formula
+/// \param str: an array of char variable
+/// \param val: an index expression
+/// \return `axiom` with substitued `qvar`
+exprt instantiate(
+  const string_constraintt &axiom,
+  const exprt &str,
+  const exprt &val);
+
 std::vector<exprt> instantiate_not_contains(
   const string_not_contains_constraintt &axiom,
   const std::set<std::pair<exprt, exprt>> &index_pairs,
   const std::unordered_map<string_not_contains_constraintt, symbol_exprt>
     &witnesses);
+
+/// \param f: an expression with only addition and subtraction
+/// \return a map where each leaf of the input is mapped to the number of times
+///   it is added. For instance, expression $x + x - y$ would give the map x ->
+///   2, y -> -1.
+std::map<exprt, int> map_representation_of_sum(const exprt &f);
+
+/// \param m: a map from expressions to integers
+/// \param type: type for the returned expression
+/// \param negated: optinal Boolean asking to negates the sum
+/// \return a expression for the sum of each element in the map a number of
+///   times given by the corresponding integer in the map. For a map x -> 2, y
+///   -> -1 would give an expression $x + x - y$.
+exprt
+sum_over_map(std::map<exprt, int> &m, const typet &type, bool negated = false);
 
 #endif // CPROVER_SOLVERS_REFINEMENT_STRING_CONSTRAINT_INSTANTIATION_H

--- a/src/solvers/strings/string_constraint_instantiation.h
+++ b/src/solvers/strings/string_constraint_instantiation.h
@@ -37,8 +37,8 @@ std::vector<exprt> instantiate_not_contains(
 
 /// \param f: an expression with only addition and subtraction
 /// \return a map where each leaf of the input is mapped to the number of times
-///   it is added. For instance, expression $x + x - y$ would give the map x ->
-///   2, y -> -1.
+///   it is added. For instance, expression $x + x - y + 3 - 5$ would give the
+///   map x -> 2, y -> -1, 3 -> 1, 5 -> -1.
 std::map<exprt, int> map_representation_of_sum(const exprt &f);
 
 /// \param m: a map from expressions to integers

--- a/src/solvers/strings/string_constraint_instantiation.h
+++ b/src/solvers/strings/string_constraint_instantiation.h
@@ -35,21 +35,22 @@ std::vector<exprt> instantiate_not_contains(
   const std::unordered_map<string_not_contains_constraintt, symbol_exprt>
     &witnesses);
 
-/// \param f: an expression with only addition and subtraction
-/// \return a map where each leaf of the input is mapped to the number of times
-///   it is added. For instance, expression $x + x - y + 3 - 5$ would give the
-///   map x -> 2, y -> -1, 3 -> 1, 5 -> -1.
-std::map<exprt, int> map_representation_of_sum(const exprt &f);
+/// Canonical representation of linear function, for instance, expression
+/// $x + x - y + 5 - 3$ would given by \c constant_coefficient 2 and
+/// \p coefficients: x -> 2, y -> -1
+struct linear_functiont
+{
+  mp_integer constant_coefficient;
+  std::unordered_map<exprt, mp_integer, irep_hash> coefficients;
+  typet type;
 
-/// \param m: a map from expressions to integers
-/// \param type: type for the returned expression
-/// \param negated: optinal Boolean asking to negates the sum
-/// \return a expression for the sum of each element in the map a number of
-///   times given by the corresponding integer in the map. For a map x -> 2, y
-///   -> -1 would give an expression $x + x - y$.
-exprt sum_over_map(
-  std::map<exprt, int> &m,
-  const typet &type,
-  bool negated = false);
+  /// Put an expression \p f composed of additions and subtractions into
+  /// its cannonical representation
+  explicit linear_functiont(const exprt &f);
+
+  /// \param negated: optional Boolean asking to negate the function
+  /// \return an expression corresponding to the linear function
+  exprt to_expr(bool negated = false) const;
+};
 
 #endif // CPROVER_SOLVERS_REFINEMENT_STRING_CONSTRAINT_INSTANTIATION_H

--- a/src/solvers/strings/string_constraint_instantiation.h
+++ b/src/solvers/strings/string_constraint_instantiation.h
@@ -58,6 +58,9 @@ public:
   /// returns the expression `v - x`.
   static exprt solve(linear_functiont f, const exprt &var, const exprt &val);
 
+  /// Format the linear function as a string, can be used for debugging
+  std::string format();
+
 private:
   mp_integer constant_coefficient;
   std::unordered_map<exprt, mp_integer, irep_hash> coefficients;

--- a/src/solvers/strings/string_constraint_instantiation.h
+++ b/src/solvers/strings/string_constraint_instantiation.h
@@ -47,7 +47,9 @@ std::map<exprt, int> map_representation_of_sum(const exprt &f);
 /// \return a expression for the sum of each element in the map a number of
 ///   times given by the corresponding integer in the map. For a map x -> 2, y
 ///   -> -1 would give an expression $x + x - y$.
-exprt
-sum_over_map(std::map<exprt, int> &m, const typet &type, bool negated = false);
+exprt sum_over_map(
+  std::map<exprt, int> &m,
+  const typet &type,
+  bool negated = false);
 
 #endif // CPROVER_SOLVERS_REFINEMENT_STRING_CONSTRAINT_INSTANTIATION_H

--- a/src/solvers/strings/string_constraint_instantiation.h
+++ b/src/solvers/strings/string_constraint_instantiation.h
@@ -38,12 +38,9 @@ std::vector<exprt> instantiate_not_contains(
 /// Canonical representation of linear function, for instance, expression
 /// $x + x - y + 5 - 3$ would given by \c constant_coefficient 2 and
 /// \p coefficients: x -> 2, y -> -1
-struct linear_functiont
+class linear_functiont
 {
-  mp_integer constant_coefficient;
-  std::unordered_map<exprt, mp_integer, irep_hash> coefficients;
-  typet type;
-
+public:
   /// Put an expression \p f composed of additions and subtractions into
   /// its cannonical representation
   explicit linear_functiont(const exprt &f);
@@ -60,6 +57,11 @@ struct linear_functiont
   /// For instance, if `f` corresponds to the expression `q + x`, `solve(q,v,f)`
   /// returns the expression `v - x`.
   static exprt solve(linear_functiont f, const exprt &var, const exprt &val);
+
+private:
+  mp_integer constant_coefficient;
+  std::unordered_map<exprt, mp_integer, irep_hash> coefficients;
+  typet type;
 };
 
 #endif // CPROVER_SOLVERS_REFINEMENT_STRING_CONSTRAINT_INSTANTIATION_H

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -1462,8 +1462,7 @@ static std::pair<bool, std::vector<exprt>> check_axioms(
 /// \return an equivalent expression in a canonical form
 exprt simplify_sum(const exprt &f)
 {
-  std::map<exprt, int> map = map_representation_of_sum(f);
-  return sum_over_map(map, f.type());
+  return linear_functiont{f}.to_expr();
 }
 
 /// Add to the index set all the indices that appear in the formulas and the

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -1645,7 +1645,7 @@ compute_inverse_function(const exprt &qvar, const exprt &val, const exprt &f)
 /// \param index: an index expression
 /// \param qvar: a symbol expression
 /// \return a Boolean
-static bool find_qvar(const exprt &index, const symbol_exprt &qvar)
+static bool contains(const exprt &index, const symbol_exprt &qvar)
 {
   return std::find(index.depth_begin(), index.depth_end(), qvar) !=
          index.depth_end();
@@ -1877,7 +1877,7 @@ find_indexes(const exprt &expr, const exprt &str, const symbol_exprt &qvar)
     {
       const auto &arr = index_expr->array();
       const auto str_it = std::find(arr.depth_begin(), arr.depth_end(), str);
-      return str_it != arr.depth_end() && find_qvar(index_expr->index(), qvar);
+      return str_it != arr.depth_end() && contains(index_expr->index(), qvar);
     }
     return false;
   };
@@ -2157,7 +2157,7 @@ is_linear_arithmetic_expr(const exprt &expr, const symbol_exprt &var)
       it->id() != ID_plus && it->id() != ID_minus &&
       it->id() != ID_unary_minus && *it != var)
     {
-      if(find_qvar(*it, var))
+      if(contains(*it, var))
         return false;
       else
         it.next_sibling_or_parent();


### PR DESCRIPTION
This deduplicate the use of `array_pool.find` and `char_array_of_pointer` and move the code for instantiation. This is preparation to make coming changes to the solver easier.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
