### PR TITLE
Create SSA-level 2 names for individual fields

### DIFF
--- a/regression/cbmc/struct14/main.c
+++ b/regression/cbmc/struct14/main.c
@@ -1,0 +1,14 @@
+struct S
+{
+  int x;
+};
+
+int main(int argc, char *argv[])
+{
+  struct S s;
+
+  if(argc > 3)
+    s.x = 42;
+
+  __CPROVER_assert(s.x == 42, "should fail");
+}

--- a/regression/cbmc/struct14/test.desc
+++ b/regression/cbmc/struct14/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+--
+With field-sensitive SSA encoding we need to make sure that each struct member
+is treated as non-deterministic unless initialised.

--- a/src/goto-symex/symex_decl.cpp
+++ b/src/goto-symex/symex_decl.cpp
@@ -64,8 +64,17 @@ void goto_symext::symex_decl(statet &state, const symbol_exprt &expr)
   }
 
   // L2 renaming
-  std::size_t generation = state.increase_generation(l1_identifier, ssa);
-  CHECK_RETURN(generation == 1);
+  const exprt fields = state.field_sensitivity.get_fields(ns, state, ssa);
+  std::set<symbol_exprt> fields_set;
+  find_symbols(fields, fields_set);
+
+  for(const auto &l1_symbol : fields_set)
+  {
+    ssa_exprt field_ssa = to_ssa_expr(l1_symbol);
+    std::size_t field_generation =
+      state.increase_generation(l1_symbol.get_identifier(), field_ssa);
+    CHECK_RETURN(field_generation == 1);
+  }
 
   const bool record_events=state.record_events;
   state.record_events=false;


### PR DESCRIPTION
During symex, a declaration introduces non-deterministic values for the
declared symbol by creating a fresh L2 name without assigning any value
to it. With field-sensitive SSA, the same must be done for each field
(just like we already did the inverse for objects going out of scope via
a DEAD instruction).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
