### PR TITLE
avoid access to exprt::opX

### DIFF
--- a/src/goto-programs/adjust_float_expressions.cpp
+++ b/src/goto-programs/adjust_float_expressions.cpp
@@ -118,7 +118,7 @@ void adjust_float_expressions(exprt &expr, const exprt &rounding_mode)
                                 irep_idt());
 
       expr.operands().resize(3);
-      expr.op2()=rounding_mode;
+      to_ieee_float_op_expr(expr).rounding_mode() = rounding_mode;
     }
   }
 
@@ -138,7 +138,7 @@ void adjust_float_expressions(exprt &expr, const exprt &rounding_mode)
       // the representation.
       expr.id(ID_floatbv_typecast);
       expr.operands().resize(2);
-      expr.op1()=rounding_mode;
+      to_floatbv_typecast_expr(expr).rounding_mode() = rounding_mode;
     }
     else if(
       dest_type.id() == ID_floatbv &&
@@ -148,7 +148,7 @@ void adjust_float_expressions(exprt &expr, const exprt &rounding_mode)
       // casts from integer to float-type might round
       expr.id(ID_floatbv_typecast);
       expr.operands().resize(2);
-      expr.op1()=rounding_mode;
+      to_floatbv_typecast_expr(expr).rounding_mode() = rounding_mode;
     }
     else if(
       dest_type.id() == ID_floatbv &&
@@ -174,7 +174,7 @@ void adjust_float_expressions(exprt &expr, const exprt &rounding_mode)
        */
       expr.id(ID_floatbv_typecast);
       expr.operands().resize(2);
-      expr.op1()=
+      to_floatbv_typecast_expr(expr).rounding_mode() =
         from_integer(ieee_floatt::ROUND_TO_ZERO, rounding_mode.type());
     }
   }

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -119,7 +119,7 @@ protected:
     const irep_idt &mode,
     bool result_is_used);
   void remove_function_call(
-    side_effect_exprt &expr,
+    side_effect_expr_function_callt &expr,
     goto_programt &dest,
     const irep_idt &mode,
     bool result_is_used);

--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -165,9 +165,11 @@ void goto_inlinet::replace_return(
   {
     if(it->is_return())
     {
+      const auto &code_return = it->get_return();
+
       if(lhs.is_not_nil())
       {
-        if(it->code.operands().size()!=1)
+        if(!code_return.has_return_value())
         {
           warning().source_location=it->code.find_source_location();
           warning() << "return expects one operand!\n"
@@ -178,14 +180,16 @@ void goto_inlinet::replace_return(
         // a typecast may be necessary if the declared return type at the call
         // site differs from the defined return type
         it->code = code_assignt(
-          lhs, typecast_exprt::conditional_cast(it->code.op0(), lhs.type()));
+          lhs,
+          typecast_exprt::conditional_cast(
+            code_return.return_value(), lhs.type()));
         it->type=ASSIGN;
 
         it++;
       }
-      else if(!it->code.operands().empty())
+      else if(code_return.has_return_value())
       {
-        it->code=code_expressiont(it->code.op0());
+        it->code = code_expressiont(code_return.return_value());
         it->type=OTHER;
         it++;
       }


### PR DESCRIPTION
This avoids out-of-bounds accesses to the operands() vector.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
