### PR TITLE
C++ front-end: store typedef names

### DIFF
--- a/regression/cbmc-cpp/typedef1/main.cpp
+++ b/regression/cbmc-cpp/typedef1/main.cpp
@@ -1,0 +1,7 @@
+typedef int XYZ;
+
+int main(int argc, char *argv[])
+{
+  XYZ a;
+  return a;
+}

--- a/regression/cbmc-cpp/typedef1/test.desc
+++ b/regression/cbmc-cpp/typedef1/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.cpp
+--show-symbol-table
+activate-multi-line-match
+Symbol......: main::1::a\nPretty name.: main::1::a\nModule......: main\nBase name...: a\nMode........: cpp\nType........: XYZ\n
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/cpp/cpp_declarator_converter.cpp
+++ b/src/cpp/cpp_declarator_converter.cpp
@@ -90,6 +90,9 @@ symbolt &cpp_declarator_convertert::convert(
 
   get_final_identifier();
 
+  if(is_typedef)
+    final_type.set(ID_C_typedef, final_identifier);
+
   // first see if it is a member
   if(scope->id_class == cpp_idt::id_classt::CLASS)
   {


### PR DESCRIPTION
This is already supported in the C front-end, and we should not
unnecessarily deviate in behaviour between the C and C++ front-ends.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
