### PR TITLE
avoid access to exprt::opX

### DIFF
--- a/src/goto-instrument/accelerate/acceleration_utils.cpp
+++ b/src/goto-instrument/accelerate/acceleration_utils.cpp
@@ -992,10 +992,10 @@ bool acceleration_utilst::do_nonrecursive(
     }
   }
 
-  for(auto it = array_writes.begin(); it != array_writes.end(); ++it)
+  for(const auto &write : array_writes)
   {
-    const auto &lhs = *it;
-    const auto &rhs = state[*it];
+    const auto &lhs = write;
+    const auto &rhs = state[write];
 
     if(!assign_array(lhs, rhs, program))
     {

--- a/src/goto-instrument/accelerate/acceleration_utils.h
+++ b/src/goto-instrument/accelerate/acceleration_utils.h
@@ -128,7 +128,7 @@ public:
     expr_sett &nonrecursive,
     scratch_programt &program);
   bool assign_array(
-    const exprt &lhs,
+    const index_exprt &lhs,
     const exprt &rhs,
     scratch_programt &program);
 

--- a/src/goto-instrument/accelerate/overflow_instrumenter.h
+++ b/src/goto-instrument/accelerate/overflow_instrumenter.h
@@ -51,7 +51,7 @@ class overflow_instrumentert
   void accumulate_overflow(goto_programt::targett t, const exprt &expr,
       goto_programt::targetst &added);
 
-  void fix_types(exprt &overflow);
+  void fix_types(binary_exprt &overflow);
 
   goto_programt &program;
   symbol_tablet &symbol_table;

--- a/src/goto-instrument/accelerate/scratch_program.cpp
+++ b/src/goto-instrument/accelerate/scratch_program.cpp
@@ -112,13 +112,14 @@ static void fix_types(exprt &expr)
      expr.id()==ID_ge ||
      expr.id()==ID_le)
   {
-    exprt &lhs=expr.op0();
-    exprt &rhs=expr.op1();
+    auto &rel_expr = to_binary_relation_expr(expr);
+    exprt &lhs = rel_expr.lhs();
+    exprt &rhs = rel_expr.rhs();
 
     if(lhs.type()!=rhs.type())
     {
       typecast_exprt typecast(rhs, lhs.type());
-      expr.op1().swap(typecast);
+      rel_expr.rhs().swap(typecast);
     }
   }
 }

--- a/src/goto-instrument/cover_instrument_mcdc.cpp
+++ b/src/goto-instrument/cover_instrument_mcdc.cpp
@@ -208,7 +208,7 @@ collect_mcdc_controlling_nested(const std::set<exprt> &decisions)
           // expansion of such an operand is stored in ''res''.
           if(operands[i].id() == ID_not)
           {
-            exprt no = operands[i].op0();
+            exprt no = to_not_expr(operands[i]).op();
             if(!is_condition(no))
             {
               changed = true;
@@ -271,7 +271,7 @@ std::set<signed> sign_of_expr(const exprt &e, const exprt &E)
   // or, ''E'' is the negation of ''e''?
   if(E.id() == ID_not)
   {
-    if(e == E.op0())
+    if(e == to_not_expr(E).op())
     {
       signs.insert(-1);
       return signs;

--- a/src/goto-instrument/cover_util.cpp
+++ b/src/goto-instrument/cover_util.cpp
@@ -92,7 +92,7 @@ void collect_decisions_rec(const exprt &src, std::set<exprt> &dest)
     }
     else if(src.id() == ID_not)
     {
-      collect_decisions_rec(src.op0(), dest);
+      collect_decisions_rec(to_not_expr(src).op(), dest);
     }
     else
     {

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -1277,10 +1277,11 @@ void dump_ct::cleanup_expr(exprt &expr)
     }
   }
   else if(
-    expr.id() == ID_typecast && expr.op0().id() == ID_typecast &&
-    expr.type() == expr.op0().type())
+    expr.id() == ID_typecast &&
+    to_typecast_expr(expr).op().id() == ID_typecast &&
+    expr.type() == to_typecast_expr(expr).op().type())
   {
-    exprt tmp=expr.op0();
+    exprt tmp = to_typecast_expr(expr).op();
     expr.swap(tmp);
   }
   else if(expr.id()==ID_code &&


### PR DESCRIPTION
This prevents out-of-bounds accesses to the operands() vector.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
