### PR TITLE
Value-set dereference: use cond_exprt to avoid quadratic guards

### DIFF
--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -534,6 +534,13 @@ protected:
     const exprt &rhs,
     exprt::operandst &,
     assignment_typet);
+  void symex_assign_cond(
+    statet &,
+    const cond_exprt &lhs,
+    const exprt &full_lhs,
+    const exprt &rhs,
+    exprt::operandst &,
+    assignment_typet);
   void symex_assign_byte_extract(
     statet &,
     const byte_extract_exprt &lhs,

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -579,6 +579,16 @@ void goto_symex_statet::rename_address(exprt &expr, const namespacet &ns)
 
       if_expr.type()=if_expr.true_case().type();
     }
+    else if(expr.id() == ID_cond)
+    {
+      cond_exprt &cond_expr = to_cond_expr(expr);
+      for(std::size_t i = 0; i < cond_expr.get_n_cases(); ++i)
+      {
+        cond_expr.condition(i) =
+          rename<level>(std::move(cond_expr.condition(i)), ns).get();
+        rename_address<level>(cond_expr.value(i), ns);
+      }
+    }
     else if(expr.id()==ID_member)
     {
       member_exprt &member_expr=to_member_expr(expr);

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -50,6 +50,27 @@ process_array_expr(exprt &expr, bool do_simplify, const namespacet &ns)
 
     if_expr.type()=if_expr.true_case().type();
   }
+  else if(expr.id() == ID_cond)
+  {
+    cond_exprt &cond_expr = to_cond_expr(expr);
+    typet result_type;
+    for(std::size_t i = 0; i < cond_expr.get_n_cases(); ++i)
+    {
+      process_array_expr(cond_expr.value(i), do_simplify, ns);
+      if(i == 0)
+        result_type = cond_expr.value(i).type();
+      else if(cond_expr.value(i).type() != result_type)
+      {
+        cond_expr.value(i) = byte_extract_exprt(
+          byte_extract_id(),
+          cond_expr.value(i),
+          from_integer(0, index_type()),
+          result_type);
+      }
+    }
+
+    cond_expr.type() = result_type;
+  }
   else if(expr.id()==ID_address_of)
   {
     // strip

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -123,6 +123,18 @@ exprt goto_symext::address_arithmetic(
 
     result=if_expr;
   }
+  else if(expr.id() == ID_cond)
+  {
+    cond_exprt cond_expr = to_cond_expr(expr);
+    for(std::size_t i = 0; i < cond_expr.get_n_cases(); ++i)
+    {
+      dereference_rec(cond_expr.condition(i), state, false);
+      cond_expr.value(i) =
+        address_arithmetic(cond_expr.value(i), state, keep_array);
+    }
+
+    result = std::move(cond_expr);
+  }
   else if(expr.id()==ID_symbol ||
           expr.id()==ID_string_constant ||
           expr.id()==ID_label ||

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -55,6 +55,21 @@ void goto_symext::havoc_rec(
     guard_f.add(not_exprt(if_expr.cond()));
     havoc_rec(state, guard_f, if_expr.false_case());
   }
+  else if(dest.id() == ID_cond)
+  {
+    const auto &cond_expr = to_cond_expr(dest);
+    for(std::size_t i = 0; i < cond_expr.get_n_cases(); ++i)
+    {
+      guardt guard = state.guard;
+      if(!cond_expr.is_exclusive())
+      {
+        for(std::size_t j = 0; j < i; ++j)
+          guard.add(not_exprt(cond_expr.condition(j)));
+      }
+      guard.add(cond_expr.condition(i));
+      havoc_rec(state, guard, cond_expr.value(i));
+    }
+  }
   else if(dest.id()==ID_typecast)
   {
     havoc_rec(state, guard, to_typecast_expr(dest).op());

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -521,6 +521,12 @@ void value_sett::get_value_set_rec(
     get_value_set_rec(expr.op1(), dest, suffix, original_type, ns);
     get_value_set_rec(expr.op2(), dest, suffix, original_type, ns);
   }
+  else if(expr.id() == ID_cond)
+  {
+    const auto &cond_expr = to_cond_expr(expr);
+    for(std::size_t i = 0; i < cond_expr.get_n_cases(); ++i)
+      get_value_set_rec(cond_expr.value(i), dest, suffix, original_type, ns);
+  }
   else if(expr.id()==ID_address_of)
   {
     if(expr.operands().size()!=1)

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1175,6 +1175,12 @@ void value_sett::get_reference_set_rec(
     get_reference_set_rec(expr.op2(), dest, ns);
     return;
   }
+  else if(expr.id() == ID_cond)
+  {
+    const auto &cond_expr = to_cond_expr(expr);
+    for(std::size_t i = 0; i < cond_expr.get_n_cases(); ++i)
+      get_reference_set_rec(cond_expr.value(i), dest, ns);
+  }
 
   insert(dest, exprt(ID_unknown, expr.type()));
 }

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -36,13 +36,20 @@ exprt value_set_dereferencet::dereference(const exprt &pointer)
     throw "dereference expected pointer type, but got "+
           pointer.type().pretty();
 
-  // we may get ifs due to recursive calls
+  // we may get ifs or conds due to recursive calls
   if(pointer.id()==ID_if)
   {
     const if_exprt &if_expr=to_if_expr(pointer);
     exprt true_case = dereference(if_expr.true_case());
     exprt false_case = dereference(if_expr.false_case());
     return if_exprt(if_expr.cond(), true_case, false_case);
+  }
+  else if(pointer.id() == ID_cond)
+  {
+    cond_exprt result = to_cond_expr(pointer);
+    for(std::size_t i = 0; i < result.get_n_cases(); ++i)
+      result.value(i) = dereference(result.value(i));
+    return std::move(result);
   }
 
   // type of the object

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -270,6 +270,10 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
   {
     return SUB::convert_if(to_if_expr(expr));
   }
+  else if(expr.id() == ID_cond)
+  {
+    return SUB::convert_cond(to_cond_expr(expr));
+  }
   else if(expr.id()==ID_index)
   {
     return SUB::convert_index(to_index_expr(expr));

--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -216,6 +216,24 @@ if_exprt lift_if(const exprt &src, std::size_t operand_number)
   return result;
 }
 
+cond_exprt lift_cond(const exprt &src, std::size_t operand_number)
+{
+  PRECONDITION(operand_number < src.operands().size());
+  PRECONDITION(src.operands()[operand_number].id() == ID_cond);
+
+  const cond_exprt cond_expr = to_cond_expr(src.operands()[operand_number]);
+  cond_exprt result({}, src.type(), cond_expr.is_exclusive());
+
+  for(std::size_t i = 0; i < cond_expr.get_n_cases(); ++i)
+  {
+    exprt new_value = src;
+    new_value.operands()[operand_number] = cond_expr.value(i);
+    result.add_case(cond_expr.condition(i), new_value);
+  }
+
+  return result;
+}
+
 const exprt &skip_typecast(const exprt &expr)
 {
   if(expr.id()!=ID_typecast)

--- a/src/util/expr_util.h
+++ b/src/util/expr_util.h
@@ -26,6 +26,7 @@ class symbol_exprt;
 class update_exprt;
 class with_exprt;
 class if_exprt;
+class cond_exprt;
 class symbolt;
 class typet;
 class namespacet;
@@ -73,6 +74,9 @@ bool has_subtype(const typet &, const irep_idt &id, const namespacet &);
 
 /// lift up an if_exprt one level
 if_exprt lift_if(const exprt &, std::size_t operand_number);
+
+/// lift up an cond_exprt one level
+cond_exprt lift_cond(const exprt &, std::size_t operand_number);
 
 /// find the expression nested inside typecasts, if any
 const exprt &skip_typecast(const exprt &expr);

--- a/src/util/irep_ids.def
+++ b/src/util/irep_ids.def
@@ -723,6 +723,7 @@ IREP_ID_ONE(to_member)
 IREP_ID_ONE(pointer_to_member)
 IREP_ID_ONE(tuple)
 IREP_ID_ONE(function_body)
+IREP_ID_ONE(exclusive)
 
 // Projects depending on this code base that wish to extend the list of
 // available ids should provide a file local_irep_ids.def in their source tree

--- a/src/util/simplify_expr_array.cpp
+++ b/src/util/simplify_expr_array.cpp
@@ -9,6 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "simplify_expr_class.h"
 
 #include "arith_tools.h"
+#include "expr_util.h"
 #include "namespace.h"
 #include "pointer_offset_size.h"
 #include "replace_expr.h"
@@ -213,15 +214,7 @@ bool simplify_exprt::simplify_index(exprt &expr)
   }
   else if(array.id()==ID_if)
   {
-    const if_exprt &if_expr=to_if_expr(array);
-    exprt cond=if_expr.cond();
-
-    index_exprt idx_false=to_index_expr(expr);
-    idx_false.array()=if_expr.false_case();
-
-    to_index_expr(expr).array()=if_expr.true_case();
-
-    expr=if_exprt(cond, expr, idx_false, expr.type());
+    expr = lift_if(expr, 0);
     simplify_rec(expr);
 
     return false;

--- a/src/util/simplify_expr_array.cpp
+++ b/src/util/simplify_expr_array.cpp
@@ -219,6 +219,13 @@ bool simplify_exprt::simplify_index(exprt &expr)
 
     return false;
   }
+  else if(array.id() == ID_cond)
+  {
+    expr = lift_cond(expr, 0);
+    simplify_rec(expr);
+
+    return false;
+  }
 
   return result;
 }

--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -27,6 +27,7 @@ Author: Daniel Kroening, kroening@kroening.com
 class bswap_exprt;
 class byte_extract_exprt;
 class byte_update_exprt;
+class cond_exprt;
 class exprt;
 class extractbits_exprt;
 class if_exprt;
@@ -81,6 +82,8 @@ public:
   bool simplify_bitwise(exprt &expr);
   bool simplify_if_preorder(if_exprt &expr);
   bool simplify_if(if_exprt &expr);
+  bool simplify_cond_preorder(cond_exprt &expr);
+  bool simplify_cond(cond_exprt &expr);
   bool simplify_bitnot(exprt &expr);
   bool simplify_not(exprt &expr);
   bool simplify_boolean(exprt &expr);

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -498,16 +498,11 @@ bool simplify_exprt::simplify_pointer_object(exprt &expr)
 
   if(op.id()==ID_if)
   {
-    const if_exprt &if_expr=to_if_expr(op);
-    exprt cond=if_expr.cond();
-
-    exprt p_o_false=expr;
-    p_o_false.op0()=if_expr.false_case();
-
-    expr.op0()=if_expr.true_case();
-
-    expr=if_exprt(cond, expr, p_o_false, expr.type());
-    simplify_rec(expr);
+    if_exprt if_expr = lift_if(expr, 0);
+    simplify_pointer_object(if_expr.true_case());
+    simplify_pointer_object(if_expr.false_case());
+    simplify_if(if_expr);
+    expr.swap(if_expr);
 
     return false;
   }

--- a/src/util/simplify_expr_struct.cpp
+++ b/src/util/simplify_expr_struct.cpp
@@ -282,6 +282,13 @@ bool simplify_exprt::simplify_member(exprt &expr)
 
     return false;
   }
+  else if(op.id() == ID_cond)
+  {
+    expr = lift_cond(expr, 0);
+    simplify_rec(expr);
+
+    return false;
+  }
 
   return true;
 }

--- a/src/util/simplify_expr_struct.cpp
+++ b/src/util/simplify_expr_struct.cpp
@@ -10,6 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "arith_tools.h"
 #include "byte_operators.h"
+#include "expr_util.h"
 #include "invariant.h"
 #include "namespace.h"
 #include "pointer_offset_size.h"
@@ -276,15 +277,7 @@ bool simplify_exprt::simplify_member(exprt &expr)
   }
   else if(op.id()==ID_if)
   {
-    const if_exprt &if_expr=to_if_expr(op);
-    exprt cond=if_expr.cond();
-
-    member_exprt member_false=to_member_expr(expr);
-    member_false.compound()=if_expr.false_case();
-
-    to_member_expr(expr).compound()=if_expr.true_case();
-
-    expr=if_exprt(cond, expr, member_false, expr.type());
+    expr = lift_if(expr, 0);
     simplify_rec(expr);
 
     return false;

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -4421,6 +4421,36 @@ public:
     operands().push_back(condition);
     operands().push_back(value);
   }
+
+  std::size_t get_n_cases() const
+  {
+    return operands().size() / 2;
+  }
+
+  const exprt &condition(std::size_t case_index) const
+  {
+    return operands().at(case_index * 2);
+  }
+
+  const exprt &value(std::size_t case_index) const
+  {
+    return operands().at((case_index * 2) + 1);
+  }
+
+  exprt &condition(std::size_t case_index)
+  {
+    return operands().at(case_index * 2);
+  }
+
+  exprt &value(std::size_t case_index)
+  {
+    return operands().at((case_index * 2) + 1);
+  }
+
+  bool is_exclusive() const
+  {
+    return get_bool(ID_exclusive);
+  }
 };
 
 template <>

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -4394,6 +4394,8 @@ inline popcount_exprt &to_popcount_expr(exprt &expr)
 /// this is a parametric version of an if-expression: it returns
 /// the value of the first case (using the ordering of the operands)
 /// whose condition evaluates to true.
+/// It can be exclusive, in which case the creator asserts that the conditions
+/// are mutually exclusive (i.e. they may be processed in any order).
 class cond_exprt : public multi_ary_exprt
 {
 public:
@@ -4402,9 +4404,11 @@ public:
   {
   }
 
-  cond_exprt(operandst _operands, typet _type)
+  cond_exprt(operandst _operands, typet _type, bool exclusive = false)
     : multi_ary_exprt(ID_cond, std::move(_operands), std::move(_type))
   {
+    if(exclusive)
+      set(ID_exclusive, true);
   }
 
   /// adds a case to a cond expression


### PR DESCRIPTION
### The problem

When we have a moderately complicated pointer expression, `p`, with a large-ish alias set (size `n`) named `o1`, `o2` ... `on`, then `value_set_dereferencet` would create an expression of the form:
`p == &o1 ? o1 : p == &o2 ? o2 : p == &o3 : ...`

So far so good -- the expression `p` has been duplicated `n` times, but irep sharing means that's not actually very costly.

However, if the deref occurs on the LHS, then `symex_assign_if` expands this into a series of assignments:
```
o1#2 = p == &o1 ? new_value : o1#1
o2#2 = p != &o1 && p == &o2 ? new_value : o2#1
o3#2 = p != &o1 && p != &o2 && p == &o3 ? new_value : o3#1
...
```

There are now n^2 copies of `p`, and thanks to renaming they are no longer shared. The simplifier then proceeds to spend quite a long time on this assignment sequence if n is large-ish and so n^2 is very large.

### The solution

The conditions `p != &o1 && p != &o2 && p == &o3` are actually redundant, but our nested `if_exprt` chain doesn't actually make that clear. Therefore I add a flag `is_exclusive` to the already-existing `cond_exprt`, which expresses an if-elseif-elseif-... chain in one instruction. This means that we now get
```
o1#2 = p == &o1 ? new_value : o1#1
o2#2 = p == &o2 ? new_value : o2#1
o3#2 = p == &o3 ? new_value : o3#1
```
Back to linear complexity on the number of aliases. Much better. 90% of the diff in the PR is teaching various passes how to deal with `cond_exprt`, which presumably we'd want to do sooner or later; review commit-by-commit.

Note this doesn't implement cond-expr *everywhere*; particularly the string solver doesn't understand it yet. For now the expression is turned back into nested-ifs before it gets to that module.

### Rejected solutions

**Use a let-expression**: Rather than try to avoid quadratic conditionals we could just surround the whole thing in `let p2 = p in ...`. I think this would work: `symex_assign` would need to learn to evaluate let-around-if, presumably leading to `let p2 = p in p2 != &o1 && p2 != &o2 && p2 == &o3 ...`, and the simplifier would have a linear number of `p` instances to attack and a quadratic number of shallow `==` nodes. I thought it was better to avoid the quadratic syntax tree node problem at its root.

**Use caching in the simplifier**: While a quadratic number of comparisons would still occur, the simplifier can check before simplifying if it has seen an identical node before and avoid the repeated work. However this doesn't really deal with the case where `p` is complicated and doesn't simplify much or at all -- in this case renaming and subsequent passes still have a huge expression to deal with.

**Avoid quadratic guards by analysis**: when symex comes to add `p == &o3` to its stack of guards, it could also remove any that are incompatible with it. This feels brittle to me -- the tests generated by `value_set_dereferencet` are not always that simple, so we'd have to at least cover the various expressions it creates, and would rely on the guard elimination remaining clever enough if/when value-set-deref produces different expressions. We could try doing this as well, but I'd prefer if value-set-deref was explicit that it intends to produce a disjoint switch.
