### PR TITLE
RFC Upstream cnf dumper

### DIFF
--- a/src/solvers/sat/cnf.h
+++ b/src/solvers/sat/cnf.h
@@ -14,6 +14,13 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <solvers/prop/prop.h>
 
+#include <cstdlib>
+#include <vector>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <unistd.h>
+
 class cnft:public propt
 {
 public:
@@ -66,6 +73,89 @@ protected:
   }
 };
 
+/** simple container for CNF formula to easily dump it */
+class cnf_dumpert
+{
+  bool active = false;
+  std::vector< std::vector<int> > formula;
+  std::size_t dumps = 0;
+  std::size_t writer = 0;
+  std::size_t maxV;
+  std::string file_prefix;
+
+  public:
+  cnf_dumpert()
+  {
+    static std::size_t created_writer = 0;
+    created_writer++;
+    const char *prefix = getenv("CBMC_CNF_DUMP_FILE_PREFIX");
+    if(!prefix)
+      return;
+    active = true;
+    file_prefix = prefix;
+    writer = created_writer;
+  }
+
+  /** add the given clause to the formula */
+  void add_clause(const bvt &bv)
+  {
+    if(!active)
+      return;
+
+    formula.emplace_back(std::vector<int>());
+    forall_literals(it, bv)
+      if(!it->is_false()) {
+        maxV = maxV > it->var_no() ? maxV : it->var_no();
+        formula.back().push_back(it->sign() ? (-it->var_no()) : (it->var_no()));
+      }
+  }
+
+  /** dump the CNF to the specified location*/
+  void dump_formula(std::string hint = "")
+  {
+    // make sure different calls get different names
+    dumps++;
+
+    std::stringstream filename;
+    filename << file_prefix;
+    filename << "_" << writer << "_" << dumps << "_" << getpid() << ".cnf";
+
+    std::ofstream out(filename.str());
+
+    if(!out) {
+      std::cout << "warn: failed to open file " << filename.str()
+                << " for writing" << std::endl;
+      return;
+    }
+
+    // write header
+    out << "c CNF created with CBMC CNF streamer of writer " << writer
+        << ", dump " << dumps << std::endl
+        << "p cnf " << maxV << " " << formula.size() << std::endl;
+
+    // write formula
+    std::size_t count = 0;
+    std::stringstream output_block;
+    for(const auto &clause : formula)
+    {
+      // dump clause into string stream (faster than file IO)
+      for(const int &l : clause)
+        output_block << l << " ";
+      output_block << "0" << std::endl;
+
+      // print the block once in a while
+      if(++count % CNF_DUMP_BLOCK_SIZE == 0)
+      {
+        out << output_block.str();
+        output_block.str("");
+      }
+    }
+
+    // make sure the final block is dumped as well
+    out << output_block.str();
+  }
+};
+
 class cnf_solvert:public cnft
 {
 public:
@@ -83,6 +173,8 @@ protected:
   enum class statust { INIT, SAT, UNSAT, ERROR };
   statust status;
   size_t clause_counter;
+
+  cnf_dumpert cnf_dumper;
 };
 
 #endif // CPROVER_SOLVERS_SAT_CNF_H

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -133,6 +133,8 @@ void satcheck_minisat2_baset<T>::lcnf(const bvt &bv)
 
     Minisat::vec<Minisat::Lit> c;
 
+    cnf_dumper.add_clause(bv);
+
     convert(bv, c);
 
     // Note the underscore.
@@ -214,6 +216,7 @@ propt::resultt satcheck_minisat2_baset<T>::do_prop_solve()
             alarm(time_limit_seconds);
         }
 
+        cnf_dumper.dump_formula();
         lbool solver_result=solver->solveLimited(solver_assumptions);
 
         if(old_handler!=SIG_ERR)


### PR DESCRIPTION
In this first iteration, I just want to share this code so that the performance of SAT solvers can be investigated outside of CBMC. This modification might be used to create coverage based CNFs that can be used for this years SAT competition.

Note, that actually only the first produced file is equivalent to what your internal SAT solver is doing, as follow up calls already build on top of internal state.

I might extend this class to produce incremental CNFs instead of plain CNFs, to close this gap.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
