### PR TITLE
Regression tests: Ensure __LINE__ is expanded

### DIFF
--- a/regression/ansi-c/Struct_Bitfields1/main.c
+++ b/regression/ansi-c/Struct_Bitfields1/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1];
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 struct S1
 {

--- a/regression/ansi-c/Struct_Enum_Padding1/main.c
+++ b/regression/ansi-c/Struct_Enum_Padding1/main.c
@@ -2,8 +2,11 @@
 
 #include <inttypes.h>
 
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1]
+#  define CONCAT(a, b) a##b
+#  define CONCAT2(a, b) CONCAT(a, b)
+
+#  define STATIC_ASSERT(condition)                                             \
+    int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 // Debian package openvswitch
 enum __attribute__((__packed__)) ofpact_type {

--- a/regression/ansi-c/Struct_Initialization1/main.c
+++ b/regression/ansi-c/Struct_Initialization1/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1]
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 struct A {
   int x;

--- a/regression/ansi-c/Struct_Initialization2/main.c
+++ b/regression/ansi-c/Struct_Initialization2/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1]
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 struct A {
   int x;

--- a/regression/ansi-c/Struct_Padding2/main.c
+++ b/regression/ansi-c/Struct_Padding2/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1]
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 enum {
  RTAX_UNSPEC,

--- a/regression/ansi-c/Struct_Padding3/main.c
+++ b/regression/ansi-c/Struct_Padding3/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1]
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 #ifndef __GNUC__
 #define __builtin_offsetof(a, b) ((unsigned long long)&(((a *)0)->b))

--- a/regression/ansi-c/Struct_Padding4/main.c
+++ b/regression/ansi-c/Struct_Padding4/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1]
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 struct Z1
 {

--- a/regression/ansi-c/Struct_Padding5/main.c
+++ b/regression/ansi-c/Struct_Padding5/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1]
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 #ifdef _MSC_VER
 

--- a/regression/ansi-c/Struct_Padding6/main.c
+++ b/regression/ansi-c/Struct_Padding6/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1]
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 #pragma pack(4)
 

--- a/regression/ansi-c/Union_Padding1/main.c
+++ b/regression/ansi-c/Union_Padding1/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1]
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 #ifdef _MSC_VER
 

--- a/regression/ansi-c/Universal_characters1/main.c
+++ b/regression/ansi-c/Universal_characters1/main.c
@@ -1,8 +1,11 @@
 int identifier_\u0201_;
 int \u0201_abc;
 
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1];
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 char my_string[]="\u0201";
 STATIC_ASSERT(sizeof(my_string)==3);

--- a/regression/ansi-c/_Alignof1/main.c
+++ b/regression/ansi-c/_Alignof1/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1];
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 // C11: _Alignof
 // 6.5.3.4

--- a/regression/ansi-c/_Bool1/main.c
+++ b/regression/ansi-c/_Bool1/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1];
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 // C11:
 // 6.3.1.2 Boolean type

--- a/regression/ansi-c/_Generic1/main.c
+++ b/regression/ansi-c/_Generic1/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1];
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 #define G(X) _Generic((X), \
                 long double: 1, \

--- a/regression/ansi-c/array_initialization1/main.c
+++ b/regression/ansi-c/array_initialization1/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1]
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 // 6.7.9, 14: An array of character type may be initialized by a character
 // string literal or UTF−8 string literal, optionally enclosed in braces.

--- a/regression/ansi-c/array_initialization3/main.c
+++ b/regression/ansi-c/array_initialization3/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT_sizeof(condition) \
-  int[(condition) ? 1 : -1]
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 int A[];
 int B[];

--- a/regression/ansi-c/bitfields1/main.c
+++ b/regression/ansi-c/bitfields1/main.c
@@ -1,6 +1,10 @@
 #include <limits.h>
 
-#define STATIC_ASSERT(condition) int some_array##__LINE__[(condition) ? 1 : -1]
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 #if CHAR_BIT == 8
 struct bits

--- a/regression/ansi-c/character_literals1/main.c
+++ b/regression/ansi-c/character_literals1/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1];
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 // character literals such as are of type int in C
 STATIC_ASSERT(sizeof('a')==sizeof(int));

--- a/regression/ansi-c/cprover_bool1/main.c
+++ b/regression/ansi-c/cprover_bool1/main.c
@@ -1,4 +1,8 @@
-#define STATIC_ASSERT(condition) int some_array##__LINE__[(condition) ? 1 : -1]
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 struct bits
 {

--- a/regression/ansi-c/enum3/main.c
+++ b/regression/ansi-c/enum3/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1]
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 #if defined(__GNUC__)
 

--- a/regression/ansi-c/float_constant1/main.c
+++ b/regression/ansi-c/float_constant1/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1];
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 // hex-based constants
 STATIC_ASSERT(0x1.0p-95f == 2.524355e-29f);

--- a/regression/ansi-c/gcc_attributes10/main.c
+++ b/regression/ansi-c/gcc_attributes10/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int array##__LINE__[(condition) ? 1 : -1]
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 #ifdef __GNUC__
 #ifndef __clang__

--- a/regression/ansi-c/gcc_attributes3/main.c
+++ b/regression/ansi-c/gcc_attributes3/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1];
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 #ifdef __GNUC__
 

--- a/regression/ansi-c/gcc_attributes4/main.c
+++ b/regression/ansi-c/gcc_attributes4/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array[(condition) ? 1 : -1];
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 #ifdef __GNUC__
 

--- a/regression/ansi-c/gcc_attributes5/main.c
+++ b/regression/ansi-c/gcc_attributes5/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1];
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 #ifdef __GNUC__
 

--- a/regression/ansi-c/gcc_attributes6/main.c
+++ b/regression/ansi-c/gcc_attributes6/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array[(condition) ? 1 : -1];
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 #ifdef __GNUC__
 

--- a/regression/ansi-c/gcc_attributes8/main.c
+++ b/regression/ansi-c/gcc_attributes8/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array[(condition) ? 1 : -1];
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 #ifdef __GNUC__
 

--- a/regression/ansi-c/gcc_builtins2/main.c
+++ b/regression/ansi-c/gcc_builtins2/main.c
@@ -8,7 +8,11 @@ extern double cabs (double _Complex __z);
 extern double fabs (double __x);
 extern long double cabsl (long double _Complex __z);
 
-#define STATIC_ASSERT(a) int __dummy__[(a)?1:-1]
+#  define CONCAT(a, b) a##b
+#  define CONCAT2(a, b) CONCAT(a, b)
+
+#  define STATIC_ASSERT(condition)                                             \
+    int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 #endif
 
 int main()

--- a/regression/ansi-c/gcc_builtins4/main.c
+++ b/regression/ansi-c/gcc_builtins4/main.c
@@ -1,6 +1,10 @@
 #ifdef __GNUC__
 
-#define STATIC_ASSERT(a) int __dummy__[(a)?1:-1]
+#  define CONCAT(a, b) a##b
+#  define CONCAT2(a, b) CONCAT(a, b)
+
+#  define STATIC_ASSERT(condition)                                             \
+    int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 struct { int i; _Bool bit_field : 1; } s;
 union { int i; } u;

--- a/regression/ansi-c/gcc_builtins5/main.c
+++ b/regression/ansi-c/gcc_builtins5/main.c
@@ -17,7 +17,11 @@ struct pthread
   };
 };
 
-#define STATIC_ASSERT(a) int __dummy__[(a)?1:-1]
+#  define CONCAT(a, b) a##b
+#  define CONCAT2(a, b) CONCAT(a, b)
+
+#  define STATIC_ASSERT(condition)                                             \
+    int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 int main()
 {

--- a/regression/ansi-c/gcc_types_compatible_p1/main.c
+++ b/regression/ansi-c/gcc_types_compatible_p1/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array[(condition) ? 1 : -1];
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 int i;
 double d;

--- a/regression/ansi-c/gcc_types_compatible_p2/main.c
+++ b/regression/ansi-c/gcc_types_compatible_p2/main.c
@@ -1,7 +1,10 @@
 #ifdef __GNUC__
 
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1]
+#  define CONCAT(a, b) a##b
+#  define CONCAT2(a, b) CONCAT(a, b)
+
+#  define STATIC_ASSERT(condition)                                             \
+    int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 int getopt_long(int i, char * const* s);
 int getopt_long_nn(int, char * const*);

--- a/regression/ansi-c/gcc_types_compatible_p3/main.c
+++ b/regression/ansi-c/gcc_types_compatible_p3/main.c
@@ -1,7 +1,10 @@
 #ifdef __GNUC__
 
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1]
+#  define CONCAT(a, b) a##b
+#  define CONCAT2(a, b) CONCAT(a, b)
+
+#  define STATIC_ASSERT(condition)                                             \
+    int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 // Debian package linux-tools
 enum help_format {

--- a/regression/ansi-c/gcc_types_compatible_p4/main.c
+++ b/regression/ansi-c/gcc_types_compatible_p4/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array[(condition) ? 1 : -1];
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 typedef struct struct_tag
 {

--- a/regression/ansi-c/integer_constant1/main.c
+++ b/regression/ansi-c/integer_constant1/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1];
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 STATIC_ASSERT('\''==39);
 STATIC_ASSERT(L'\''==39);

--- a/regression/ansi-c/integer_constant2/main.c
+++ b/regression/ansi-c/integer_constant2/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1]
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 STATIC_ASSERT(((long int)0x7FFFFFFFL)>0);
 

--- a/regression/ansi-c/pragma_pack1/main.c
+++ b/regression/ansi-c/pragma_pack1/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1]
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 #ifdef _WIN32
 typedef unsigned __int64 uint64_t;

--- a/regression/ansi-c/pragma_pack2/main.c
+++ b/regression/ansi-c/pragma_pack2/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1]
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 // see http://msdn.microsoft.com/en-us/library/2e70t5y1%28v=vs.80%29.aspx
 

--- a/regression/ansi-c/pragma_pack3/main.c
+++ b/regression/ansi-c/pragma_pack3/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1]
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 // see http://msdn.microsoft.com/en-us/library/2e70t5y1%28v=vs.80%29.aspx
 

--- a/regression/ansi-c/sizeof1/main.c
+++ b/regression/ansi-c/sizeof1/main.c
@@ -1,8 +1,11 @@
 #include <wchar.h>
 #include <stdlib.h> // for size_t
 
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1];
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 // check size_t
 STATIC_ASSERT(sizeof(void *)==sizeof(size_t));

--- a/regression/ansi-c/sizeof3/main.c
+++ b/regression/ansi-c/sizeof3/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1];
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 struct empty_struct { };
 union empty_union { };

--- a/regression/ansi-c/sizeof4/main.c
+++ b/regression/ansi-c/sizeof4/main.c
@@ -1,6 +1,8 @@
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
 
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1];
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 // The result of boolean operators is always an int
 STATIC_ASSERT(sizeof(1.0 && 1.0)==sizeof(int));

--- a/regression/ansi-c/sizeof5/main.c
+++ b/regression/ansi-c/sizeof5/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1];
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 struct S
 {

--- a/regression/ansi-c/struct3/main.c
+++ b/regression/ansi-c/struct3/main.c
@@ -1,5 +1,3 @@
-//#define STATIC_ASSERT(condition) \
-//  int some_array##__LINE__[(condition) ? 1 : -1];
 #define STATIC_ASSERT(condition) \
   _Static_assert((condition), "assertion");
 

--- a/regression/cbmc-with-incr/Struct_Padding1/main.c
+++ b/regression/cbmc-with-incr/Struct_Padding1/main.c
@@ -1,7 +1,10 @@
 #include <assert.h>
 
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1]
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 struct my_struct1
 {

--- a/regression/cbmc-with-incr/null1/main.c
+++ b/regression/cbmc-with-incr/null1/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1];
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 STATIC_ASSERT((void*)0==(void*)(1-1));
 

--- a/regression/cbmc/null1/main.c
+++ b/regression/cbmc/null1/main.c
@@ -1,5 +1,8 @@
-#define STATIC_ASSERT(condition) \
-  int some_array##__LINE__[(condition) ? 1 : -1];
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
 STATIC_ASSERT((void*)0==(void*)(1-1));
 


### PR DESCRIPTION
We previously generated several declarations with the same name, because
the C preprocessor does not expand __LINE__ after a concatenation
operator. Add two levels of indirection to achieve this. Using
declarations with the same name was kind of ok for the C front-end, but
is a bug with any C++ front-end.

This is in preparation of running a subset of the C test against the C++ front-end.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
