### PR TITLE
Re-use C tests to exercise C++ front-end [blocks: #4558]

### DIFF
--- a/regression/ansi-c/CMakeLists.txt
+++ b/regression/ansi-c/CMakeLists.txt
@@ -6,4 +6,10 @@ else()
 add_test_pl_tests(
     "$<TARGET_FILE:goto-cc>"
 )
+add_test_pl_profile(
+    "ansi-c-c++-front-end"
+    "$<TARGET_FILE:goto-cc> -xc++ -D_Bool=bool"
+    "-C;-I;test-c++-front-end;-s;c++-front-end"
+    "CORE"
+)
 endif()

--- a/regression/ansi-c/Defines1/test.desc
+++ b/regression/ansi-c/Defines1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
  -D NEW_DEFINE
 ^EXIT=0$

--- a/regression/ansi-c/Empty_Declaration1/test.desc
+++ b/regression/ansi-c/Empty_Declaration1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^SIGNAL=0$

--- a/regression/ansi-c/Forward_Declaration1/test.desc
+++ b/regression/ansi-c/Forward_Declaration1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^SIGNAL=0$

--- a/regression/ansi-c/Function_pointer1/test.desc
+++ b/regression/ansi-c/Function_pointer1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/Header_files1/test.desc
+++ b/regression/ansi-c/Header_files1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/Initializer_cast2/test.desc
+++ b/regression/ansi-c/Initializer_cast2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/MMX1/test.desc
+++ b/regression/ansi-c/MMX1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/MMX2/test.desc
+++ b/regression/ansi-c/MMX2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/Makefile
+++ b/regression/ansi-c/Makefile
@@ -11,9 +11,15 @@ endif
 
 test:
 	@../test.pl -e -p -c $(exe)
+ifneq ($(BUILD_ENV_),MSVC)
+	@../test.pl -e -p -c "$(exe) -xc++ -D_Bool=bool" -I test-c++-front-end -s c++-front-end
+endif
 
 tests.log: ../test.pl
 	@../test.pl -e -p -c $(exe)
+ifneq ($(BUILD_ENV_),MSVC)
+	@../test.pl -e -p -c "$(exe) -xc++ -D_Bool=bool" -I test-c++-front-end -s c++-front-end
+endif
 
 show:
 	@for dir in *; do \

--- a/regression/ansi-c/Recursive_Structure1/test.desc
+++ b/regression/ansi-c/Recursive_Structure1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^SIGNAL=0$

--- a/regression/ansi-c/Recursive_Structure2/test.desc
+++ b/regression/ansi-c/Recursive_Structure2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^SIGNAL=0$

--- a/regression/ansi-c/Struct_Enum_Padding1/test.desc
+++ b/regression/ansi-c/Struct_Enum_Padding1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/Struct_Hierarchy1/test.desc
+++ b/regression/ansi-c/Struct_Hierarchy1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/Struct_Padding2/test.desc
+++ b/regression/ansi-c/Struct_Padding2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/Struct_Padding3/test.desc
+++ b/regression/ansi-c/Struct_Padding3/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/Struct_Padding5/test.desc
+++ b/regression/ansi-c/Struct_Padding5/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/Struct_Padding6/test.desc
+++ b/regression/ansi-c/Struct_Padding6/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/Struct_ptrmember1/test.desc
+++ b/regression/ansi-c/Struct_ptrmember1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/Typecast_to_array_ptr1/test.desc
+++ b/regression/ansi-c/Typecast_to_array_ptr1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/VS_extensions1/test.desc
+++ b/regression/ansi-c/VS_extensions1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/Zero_Initialization1/test.desc
+++ b/regression/ansi-c/Zero_Initialization1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^SIGNAL=0$

--- a/regression/ansi-c/always_inline2/test.desc
+++ b/regression/ansi-c/always_inline2/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/always_inline5/test.desc
+++ b/regression/ansi-c/always_inline5/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/always_inline6/test.desc
+++ b/regression/ansi-c/always_inline6/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/always_inline7/test.desc
+++ b/regression/ansi-c/always_inline7/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/always_inline8/test.desc
+++ b/regression/ansi-c/always_inline8/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/always_inline9/test.desc
+++ b/regression/ansi-c/always_inline9/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/anonymous_union1/test.desc
+++ b/regression/ansi-c/anonymous_union1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/arch_flags_mcpu_bad/test.desc
+++ b/regression/ansi-c/arch_flags_mcpu_bad/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only test-c++-front-end
 preproc.i
 -mcpu=cortex-a15 -o linked-object.gb object.intel
 ^EXIT=(64|1)$

--- a/regression/ansi-c/arch_flags_mthumb_bad/test.desc
+++ b/regression/ansi-c/arch_flags_mthumb_bad/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only test-c++-front-end
 preproc.i
 -mthumb -o linked-object.gb object.intel
 ^EXIT=(64|1)$

--- a/regression/ansi-c/array_initialization2/test.desc
+++ b/regression/ansi-c/array_initialization2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/asm2/test.desc
+++ b/regression/ansi-c/asm2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/asm3/test.desc
+++ b/regression/ansi-c/asm3/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 other.c
 ^EXIT=0$

--- a/regression/ansi-c/bitfields1/test.desc
+++ b/regression/ansi-c/bitfields1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/builtin_ia32_undef/test.desc
+++ b/regression/ansi-c/builtin_ia32_undef/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/builtin_nontemporal_load_store/test.desc
+++ b/regression/ansi-c/builtin_nontemporal_load_store/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/const2/test0.desc
+++ b/regression/ansi-c/const2/test0.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 -DTEST=0
 ^EXIT=0$

--- a/regression/ansi-c/const2/test1.desc
+++ b/regression/ansi-c/const2/test1.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 -DTEST=1
 ^EXIT=0$

--- a/regression/ansi-c/const2/test2.desc
+++ b/regression/ansi-c/const2/test2.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 -DTEST=2
 ^EXIT=0$

--- a/regression/ansi-c/decl_initialization1/test.desc
+++ b/regression/ansi-c/decl_initialization1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/decl_initialization2/test.desc
+++ b/regression/ansi-c/decl_initialization2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/enum1/test.desc
+++ b/regression/ansi-c/enum1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/enum2/test.desc
+++ b/regression/ansi-c/enum2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/enum5/test.desc
+++ b/regression/ansi-c/enum5/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/enum8/test.desc
+++ b/regression/ansi-c/enum8/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/envp1/test.desc
+++ b/regression/ansi-c/envp1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/extern1/test.desc
+++ b/regression/ansi-c/extern1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/extern2/test.desc
+++ b/regression/ansi-c/extern2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/float_constant1/test.desc
+++ b/regression/ansi-c/float_constant1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/float_constant2/test.desc
+++ b/regression/ansi-c/float_constant2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/gcc_attributes10/test.desc
+++ b/regression/ansi-c/gcc_attributes10/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/gcc_attributes14/test.desc
+++ b/regression/ansi-c/gcc_attributes14/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/gcc_attributes3/test.desc
+++ b/regression/ansi-c/gcc_attributes3/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/gcc_attributes4/test.desc
+++ b/regression/ansi-c/gcc_attributes4/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/gcc_attributes7/test.desc
+++ b/regression/ansi-c/gcc_attributes7/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only broken-test-c++-front-end
 main.i
 
 ^EXIT=0$

--- a/regression/ansi-c/gcc_attributes8/test.desc
+++ b/regression/ansi-c/gcc_attributes8/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/gcc_builtin_constant_p1/test.desc
+++ b/regression/ansi-c/gcc_builtin_constant_p1/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/gcc_builtins3/test.desc
+++ b/regression/ansi-c/gcc_builtins3/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/gcc_builtins6/test.desc
+++ b/regression/ansi-c/gcc_builtins6/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/gcc_float_types1/test.desc
+++ b/regression/ansi-c/gcc_float_types1/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/goto_convert_break/test.desc
+++ b/regression/ansi-c/goto_convert_break/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=(1|64)$

--- a/regression/ansi-c/goto_convert_continue/test.desc
+++ b/regression/ansi-c/goto_convert_continue/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=(1|64)$

--- a/regression/ansi-c/goto_convert_invalid_goto_label/test.desc
+++ b/regression/ansi-c/goto_convert_invalid_goto_label/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 
 ^CONVERSION ERROR$

--- a/regression/ansi-c/goto_convert_switch_range_bounds/test.desc
+++ b/regression/ansi-c/goto_convert_switch_range_bounds/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^CONVERSION ERROR$

--- a/regression/ansi-c/goto_convert_switch_range_case_valid/test.desc
+++ b/regression/ansi-c/goto_convert_switch_range_case_valid/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/goto_convert_switch_range_empty/test.desc
+++ b/regression/ansi-c/goto_convert_switch_range_empty/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/goto_convert_switch_range_empty_nodefault/test.desc
+++ b/regression/ansi-c/goto_convert_switch_range_empty_nodefault/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/goto_convert_switch_range_operands_count/test.desc
+++ b/regression/ansi-c/goto_convert_switch_range_operands_count/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=(1|64)$

--- a/regression/ansi-c/integer_constant2/test.desc
+++ b/regression/ansi-c/integer_constant2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/linking_conflicts2/test.desc
+++ b/regression/ansi-c/linking_conflicts2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 other.c
 ^EXIT=(64|1)$

--- a/regression/ansi-c/message_handling1/test.desc
+++ b/regression/ansi-c/message_handling1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 --verbosity 2
 ^EXIT=0$

--- a/regression/ansi-c/pointer_arithmetic1/test.desc
+++ b/regression/ansi-c/pointer_arithmetic1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/pragma_pack1/test.desc
+++ b/regression/ansi-c/pragma_pack1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/pragma_pack2/test.desc
+++ b/regression/ansi-c/pragma_pack2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/pragma_pack3/test.desc
+++ b/regression/ansi-c/pragma_pack3/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/return_void/test.desc
+++ b/regression/ansi-c/return_void/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/sizeof1/test.desc
+++ b/regression/ansi-c/sizeof1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/static1/test.desc
+++ b/regression/ansi-c/static1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 --function fun
 ^EXIT=0$

--- a/regression/ansi-c/static2/test.desc
+++ b/regression/ansi-c/static2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 main2.c --function foo
 ^main symbol `foo' is ambiguous$

--- a/regression/ansi-c/static3/test.desc
+++ b/regression/ansi-c/static3/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 main2.c --function foo
 ^main symbol `foo' is ambiguous$

--- a/regression/ansi-c/static_inline1/test.desc
+++ b/regression/ansi-c/static_inline1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/struct2/test.desc
+++ b/regression/ansi-c/struct2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/struct6/test.desc
+++ b/regression/ansi-c/struct6/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-test-c++-front-end
 main.c
 
 ^EXIT=(64|1)$

--- a/regression/ansi-c/struct7/test.desc
+++ b/regression/ansi-c/struct7/test.desc
@@ -1,8 +1,8 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=(64|1)$
 ^SIGNAL=0$
-: duplicate member .*$
+(: duplicate member .*|already in compound scope)$
 ^CONVERSION ERROR$
 --

--- a/regression/ansi-c/typedef1/test.desc
+++ b/regression/ansi-c/typedef1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/typedef2/test.desc
+++ b/regression/ansi-c/typedef2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/typedef_code/test.desc
+++ b/regression/ansi-c/typedef_code/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$


### PR DESCRIPTION
Several C tests should also pass when using the C++ front-end. Use them
to exercise it more and find and fix more bugs. Those that should pass,
but currently don't, are tagged broken-test-c++-front-end.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
