### PR TITLE
Re-use C type conversion in C++ front-end [blocks: #4560]

### DIFF
--- a/regression/ansi-c/builtin_ia32_undef/test.desc
+++ b/regression/ansi-c/builtin_ia32_undef/test.desc
@@ -1,4 +1,4 @@
-CORE test-c++-front-end
+CORE broken-test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/gcc_attributes3/test.desc
+++ b/regression/ansi-c/gcc_attributes3/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only broken-test-c++-front-end
+CORE gcc-only test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/cpp/CMakeLists.txt
+++ b/regression/cpp/CMakeLists.txt
@@ -1,3 +1,9 @@
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+add_test_pl_tests(
+    "$<TARGET_FILE:goto-cc>" -X gcc-only
+)
+else()
 add_test_pl_tests(
     "$<TARGET_FILE:goto-cc>"
 )
+endif()

--- a/regression/cpp/Makefile
+++ b/regression/cpp/Makefile
@@ -4,7 +4,7 @@ include ../../src/config.inc
 include ../../src/common
 
 ifeq ($(BUILD_ENV_),MSVC)
-	exe=../../../src/goto-cc/goto-cl
+	exe=../../../src/goto-cc/goto-cl -X gcc-only
 else
 	exe=../../../src/goto-cc/goto-cc
 endif

--- a/regression/cpp/gcc_attributes1/main.cpp
+++ b/regression/cpp/gcc_attributes1/main.cpp
@@ -1,0 +1,12 @@
+#ifdef __GNUC__
+const char *__attribute__((weak)) bar();
+#endif
+
+int main()
+{
+#ifdef __GNUC__
+  return bar() != 0;
+#else
+  return 0
+#endif
+}

--- a/regression/cpp/gcc_attributes1/test.desc
+++ b/regression/cpp/gcc_attributes1/test.desc
@@ -1,5 +1,5 @@
-CORE gcc-only test-c++-front-end
-main.c
+CORE gcc-only
+main.cpp
 
 ^EXIT=0$
 ^SIGNAL=0$

--- a/src/ansi-c/ansi_c_convert_type.cpp
+++ b/src/ansi-c/ansi_c_convert_type.cpp
@@ -589,6 +589,13 @@ void ansi_c_convert_typet::write(typet &type)
     }
   }
 
+  build_type_with_subtype(type);
+  set_attributes(type);
+}
+
+/// Build a vector or complex type with \p type as subtype.
+void ansi_c_convert_typet::build_type_with_subtype(typet &type) const
+{
   if(vector_size.is_not_nil())
   {
     type_with_subtypet new_type(ID_frontend_vector, type);
@@ -604,7 +611,11 @@ void ansi_c_convert_typet::write(typet &type)
     new_type.add_source_location()=source_location;
     type.swap(new_type);
   }
+}
 
+/// Add qualifiers and GCC attributes onto \p type.
+void ansi_c_convert_typet::set_attributes(typet &type) const
+{
   if(gcc_attribute_mode.is_not_nil())
   {
     typet new_type=gcc_attribute_mode;

--- a/src/ansi-c/ansi_c_convert_type.h
+++ b/src/ansi-c/ansi_c_convert_type.h
@@ -51,8 +51,8 @@ public:
   // qualifiers
   c_qualifierst c_qualifiers;
 
-  void read(const typet &type);
-  void write(typet &type);
+  virtual void read(const typet &type);
+  virtual void write(typet &type);
 
   source_locationt source_location;
 
@@ -64,7 +64,7 @@ public:
   {
   }
 
-  void clear()
+  virtual void clear()
   {
     unsigned_cnt=signed_cnt=char_cnt=int_cnt=short_cnt=
     long_cnt=double_cnt=float_cnt=c_bool_cnt=proper_bool_cnt=complex_cnt=
@@ -90,7 +90,9 @@ public:
   }
 
 protected:
-  void read_rec(const typet &type);
+  virtual void read_rec(const typet &type);
+  virtual void build_type_with_subtype(typet &type) const;
+  virtual void set_attributes(typet &type) const;
 };
 
 #endif // CPROVER_ANSI_C_ANSI_C_CONVERT_TYPE_H

--- a/src/cpp/cpp_convert_type.h
+++ b/src/cpp/cpp_convert_type.h
@@ -12,10 +12,11 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #ifndef CPROVER_CPP_CPP_CONVERT_TYPE_H
 #define CPROVER_CPP_CPP_CONVERT_TYPE_H
 
-#include <util/type.h>
+class message_handlert;
+class typet;
 
-void cpp_convert_plain_type(typet &);
+void cpp_convert_plain_type(typet &, message_handlert &);
 
-void cpp_convert_auto(typet &dest, const typet &src);
+void cpp_convert_auto(typet &dest, const typet &src, message_handlert &);
 
 #endif // CPROVER_CPP_CPP_CONVERT_TYPE_H

--- a/src/cpp/cpp_typecheck_initializer.cpp
+++ b/src/cpp/cpp_typecheck_initializer.cpp
@@ -66,7 +66,7 @@ void cpp_typecheckt::convert_initializer(symbolt &symbol)
 
     if(has_auto(symbol.type))
     {
-      cpp_convert_auto(symbol.type, symbol.value.type());
+      cpp_convert_auto(symbol.type, symbol.value.type(), get_message_handler());
       typecheck_type(symbol.type);
       implicit_typecast(symbol.value, symbol.type);
     }
@@ -152,7 +152,7 @@ void cpp_typecheckt::convert_initializer(symbolt &symbol)
     }
     else if(has_auto(symbol.type))
     {
-      cpp_convert_auto(symbol.type, symbol.value.type());
+      cpp_convert_auto(symbol.type, symbol.value.type(), get_message_handler());
       typecheck_type(symbol.type);
       implicit_typecast(symbol.value, symbol.type);
     }

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -1954,7 +1954,7 @@ exprt cpp_typecheck_resolvet::guess_function_template_args(
       // We only convert the arg_type,
       // and don't typecheck it -- that could cause all
       // sorts of trouble.
-      cpp_convert_plain_type(arg_type);
+      cpp_convert_plain_type(arg_type, cpp_typecheck.get_message_handler());
 
       guess_template_args(arg_type, it->type());
     }

--- a/src/cpp/cpp_typecheck_template.cpp
+++ b/src/cpp/cpp_typecheck_template.cpp
@@ -233,7 +233,7 @@ void cpp_typecheckt::typecheck_function_template(
   typet function_type=
     declarator.merge_type(declaration.type());
 
-  cpp_convert_plain_type(function_type);
+  cpp_convert_plain_type(function_type, get_message_handler());
 
   irep_idt symbol_name=
     function_template_identifier(

--- a/src/cpp/cpp_typecheck_type.cpp
+++ b/src/cpp/cpp_typecheck_type.cpp
@@ -27,7 +27,7 @@ void cpp_typecheckt::typecheck_type(typet &type)
 
   try
   {
-    cpp_convert_plain_type(type);
+    cpp_convert_plain_type(type, get_message_handler());
   }
 
   catch(const char *err)


### PR DESCRIPTION
This avoids duplicating code and the need to update code in two places to add new features.

~Only the last commit is new, the other two are #4557 and #4558, respectively.~

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
