### PR TITLE
C++ front-end: default constructed PODs are constants

### DIFF
--- a/regression/cpp/enum3/test.desc
+++ b/regression/cpp/enum3/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 -std=c++11
 ^EXIT=0$

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -1919,21 +1919,13 @@ void cpp_typecheckt::typecheck_side_effect_function_call(
 
     // These aren't really function calls, but either conversions or
     // initializations.
-    if(expr.arguments().empty())
-    {
-      // create temporary object
-      side_effect_exprt tmp_object_expr(
-        ID_temporary_object, pod, expr.source_location());
-      tmp_object_expr.set(ID_C_lvalue, true);
-      tmp_object_expr.set(ID_mode, ID_cpp);
-      expr.swap(tmp_object_expr);
-    }
-    else if(expr.arguments().size()==1)
+    if(expr.arguments().size() <= 1)
     {
       exprt typecast("explicit-typecast");
       typecast.type()=pod;
       typecast.add_source_location()=expr.source_location();
-      typecast.copy_to_operands(expr.arguments().front());
+      if(!expr.arguments().empty())
+        typecast.copy_to_operands(expr.arguments().front());
       typecheck_expr_explicit_typecast(typecast);
       expr.swap(typecast);
     }


### PR DESCRIPTION
We already supported single-argument construction, and explicit casts
already took care of zero-initialisation, so really all we needed was to
remove some code.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
