### PR TITLE
Export-function-local-symbols name mangling: rename initial values

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -25,6 +25,7 @@ DIRS = cbmc \
        goto-cc-goto-analyzer \
        systemc \
        contracts \
+       goto-cc-file-local \
        # Empty last line
 
 # Run all test directories in sequence

--- a/regression/goto-cc-file-local/Makefile
+++ b/regression/goto-cc-file-local/Makefile
@@ -1,0 +1,35 @@
+default: tests.log
+
+include ../../src/config.inc
+include ../../src/common
+
+ifeq ($(BUILD_ENV_),MSVC)
+	exe=../../../src/goto-cc/goto-cl
+	is_windows=true
+else
+	exe=../../../src/goto-cc/goto-cc
+	is_windows=false
+endif
+
+test:
+	@../test.pl -e -p -c '../chain.sh $(exe) ../../../src/goto-instrument/goto-instrument ../../../src/cbmc/cbmc $(is_windows)'
+
+tests.log:
+	@../test.pl -e -p -c '../chain.sh $(exe) ../../../src/goto-instrument/goto-instrument ../../../src/cbmc/cbmc $(is_windows)'
+
+show:
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			vim -o "$$dir/*.c" "$$dir/*.out"; \
+		fi; \
+	done;
+
+clean:
+	@for dir in *; do \
+		$(RM) tests.log; \
+		if [ -d "$$dir" ]; then \
+			cd "$$dir"; \
+			$(RM) *.out *.gb; \
+			cd ..; \
+		fi \
+	done

--- a/regression/goto-cc-file-local/chain.sh
+++ b/regression/goto-cc-file-local/chain.sh
@@ -4,6 +4,8 @@
 #
 # Author: Kareem Khazem <karkhaz@karkhaz.com>
 
+set -e
+
 is_in()
 {
   [[ "$2" =~ $1 ]] && return 0 || return 1
@@ -81,6 +83,7 @@ done
 
 if is_in final-link "$ALL_ARGS"; then
   OUT_FILE=final-link.gb
+  rm -f ${OUT_FILE}
   if [[ "${is_windows}" == "true" ]]; then
     "${goto_cc}"                        \
         --export-function-local-symbols \

--- a/regression/goto-cc-file-local/function-pointer/main.c
+++ b/regression/goto-cc-file-local/function-pointer/main.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+
+static int foo()
+{
+  return 3;
+}
+
+int (*fptrs[])(void) = {foo};
+
+int main()
+{
+  int x = fptrs[0]();
+  assert(x == 3);
+}

--- a/regression/goto-cc-file-local/function-pointer/test.desc
+++ b/regression/goto-cc-file-local/function-pointer/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+final-link assertion-check
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^\*\*\*\* WARNING: no body for function

--- a/src/goto-programs/name_mangler.h
+++ b/src/goto-programs/name_mangler.h
@@ -84,6 +84,20 @@ public:
     for(const auto &sym : old_syms)
       model.symbol_table.erase(sym);
 
+    for(const auto &sym_pair : model.symbol_table)
+    {
+      const symbolt &sym = sym_pair.second;
+
+      exprt e = sym.value;
+      typet t = sym.type;
+      if(rename(e) && rename(t))
+        continue;
+
+      symbolt &new_sym = model.symbol_table.get_writeable_ref(sym.name);
+      new_sym.value = e;
+      new_sym.type = t;
+    }
+
     for(auto &fun : model.goto_functions.function_map)
     {
       if(!fun.second.body_available())

--- a/src/util/rename_symbol.h
+++ b/src/util/rename_symbol.h
@@ -43,14 +43,18 @@ public:
     type_map.insert(std::pair<irep_idt, irep_idt>(old_id, new_id));
   }
 
-  void operator()(exprt &dest) const
+  /// Rename symbols in \p dest.
+  /// \return True if, and only if, the expression was not modified.
+  bool operator()(exprt &dest) const
   {
-    rename(dest);
+    return rename(dest);
   }
 
-  void operator()(typet &dest) const
+  /// Rename symbols in \p dest.
+  /// \return True if, and only if, the type was not modified.
+  bool operator()(typet &dest) const
   {
-    rename(dest);
+    return rename(dest);
   }
 
   rename_symbolt();


### PR DESCRIPTION
We previously renamed all occurrences in goto functions, but did not
consider the initial values of symbols with static lifetime, which are
stored in the symbol table. To make this reasonably efficient, make
rename_symbolt::operator() expose the return value (and document the
methods).

To test this, include the test suite in Makefile-based test set-ups
(CMake was already done), and fix the chain.sh file.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
