### PR TITLE
Fix L2 renaming after shift-to-rhs and enable validation

### DIFF
--- a/regression/cbmc-concurrency/CMakeLists.txt
+++ b/regression/cbmc-concurrency/CMakeLists.txt
@@ -1,12 +1,11 @@
 if((NOT WIN32) AND (NOT APPLE))
 add_test_pl_tests(
-    "$<TARGET_FILE:cbmc>"
+    "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation"
 )
 else()
-add_test_pl_tests(
-    "$<TARGET_FILE:cbmc>"
+add_test_pl_profile(
     "cbmc-concurrency"
-    "$<TARGET_FILE:cbmc>"
+    "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation"
     "-C;-X;pthread"
     "CORE"
 )

--- a/regression/cbmc-concurrency/Makefile
+++ b/regression/cbmc-concurrency/Makefile
@@ -10,10 +10,10 @@ ifeq ($(filter-out OSX MSVC,$(BUILD_ENV_)),)
 endif
 
 test:
-	@../test.pl -e -p -c ../../../src/cbmc/cbmc $(no_pthread)
+	@../test.pl -e -p -c "../../../src/cbmc/cbmc --validate-goto-model --validate-ssa-equation" $(no_pthread)
 
 tests.log: ../test.pl
-	@../test.pl -e -p -c ../../../src/cbmc/cbmc $(no_pthread)
+	@../test.pl -e -p -c "../../../src/cbmc/cbmc --validate-goto-model --validate-ssa-equation" $(no_pthread)
 
 show:
 	@for dir in *; do \

--- a/regression/cbmc/CMakeLists.txt
+++ b/regression/cbmc/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_test_pl_tests(
-    "$<TARGET_FILE:cbmc> --validate-goto-model" -X smt-backend
+    "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation" -X smt-backend
 )
 
 add_test_pl_profile(

--- a/regression/cbmc/Makefile
+++ b/regression/cbmc/Makefile
@@ -1,7 +1,7 @@
 default: test
 
 test:
-	@../test.pl -e -p -c "../../../src/cbmc/cbmc --validate-goto-model" -X smt-backend
+	@../test.pl -e -p -c "../../../src/cbmc/cbmc --validate-goto-model --validate-ssa-equation" -X smt-backend
 
 test-cprover-smt2:
 	@../test.pl -e -p -c "../../../src/cbmc/cbmc --cprover-smt2" -X broken-smt-backend


### PR DESCRIPTION
When rewriting the RHS to enable field-sensitive LHS-names, we may
introduce the LHS into the RHS, and thus need to re-rename the RHS
expression to ensure all of it is L2. We could have caught this earlier
if we had always enabled SSA validation in regression tests, which is
now done (except for C++ tests, which require a different set of fixes).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
