### PR TITLE
Symex: shortcut the common case of whole-struct initialisation

### DIFF
--- a/jbmc/regression/jbmc-generics/constant_propagation/test.desc
+++ b/jbmc/regression/jbmc-generics/constant_propagation/test.desc
@@ -3,7 +3,6 @@ Test.class
 --function Test.main --show-vcc
 ^EXIT=0$
 ^SIGNAL=0$
-^\{-\d+\} symex_dynamic::dynamic_object1#2 = \{ \{ \{ "java::GenericSub" \}, NULL, 0 \} \}$
 ^\{-\d+\} symex_dynamic::dynamic_object1#2\.\.@Generic\.\.@java.lang.Object\.\.@class_identifier = "java::GenericSub"$
 ^\{-\d+\} symex_dynamic::dynamic_object1#2\.\.@Generic\.\.key = NULL$
 ^\{-\d+\} symex_dynamic::dynamic_object1#3\.\.@Generic\.\.x = 5$

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -499,6 +499,13 @@ protected:
     const exprt &rhs,
     exprt::operandst &,
     assignment_typet);
+  void symex_assign_from_struct(
+    statet &,
+    const ssa_exprt &lhs,
+    const exprt &full_lhs,
+    const struct_exprt &rhs,
+    exprt::operandst &,
+    assignment_typet);
   void symex_assign_symbol(
     statet &,
     const ssa_exprt &lhs,


### PR DESCRIPTION
Rather than assign a temporary symbol and then expand it, directly extract the fields
and assign them. This cuts the time taken on one initialisation-heavy benchmark to symex and print VCCs from 3.6s to 3.2s.