### PR TITLE
value-set-dereference: factor out should_ignore_value

### DIFF
--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -623,18 +623,15 @@ void goto_symext::try_filter_value_sets(
     }
 
     const bool exclude_null_derefs = false;
-    value_set_dereferencet::valuet possible_value =
-      value_set_dereferencet::build_reference_to(
-        value_set_element,
-        *symbol_expr,
-        exclude_null_derefs,
-        language_mode,
-        ns);
-
-    if(possible_value.ignore)
+    if(value_set_dereferencet::should_ignore_value(
+         value_set_element, exclude_null_derefs, language_mode))
     {
       continue;
     }
+
+    value_set_dereferencet::valuet possible_value =
+      value_set_dereferencet::build_reference_to(
+        value_set_element, *symbol_expr, ns);
 
     exprt replacement_expr =
       possible_value.value.is_nil()

--- a/src/pointer-analysis/value_set_dereference.h
+++ b/src/pointer-analysis/value_set_dereference.h
@@ -60,18 +60,20 @@ public:
   public:
     exprt value;
     exprt pointer_guard;
-    bool ignore;
 
-    valuet():value(nil_exprt()), pointer_guard(false_exprt()), ignore(false)
+    valuet() : value(nil_exprt()), pointer_guard(false_exprt())
     {
     }
   };
 
+  static bool should_ignore_value(
+    const exprt &what,
+    bool exclude_null_derefs,
+    const irep_idt &language_mode);
+
   static valuet build_reference_to(
     const exprt &what,
     const exprt &pointer,
-    bool exclude_null_derefs,
-    irep_idt language_mode,
     const namespacet &ns);
 
   static bool dereference_type_compare(


### PR DESCRIPTION
Rather than build_reference_to returning a tuple which may indicate a value is ignored,
seperately test whether it ought to be ignored beforehand and then build references to those
values which are not ignored.