### PR TITLE
Use let-expression for dereferenced pointers

### DIFF
--- a/regression/cbmc/double_deref/README
+++ b/regression/cbmc/double_deref/README
@@ -8,7 +8,7 @@ operator, such as **p, *(int*)*p, p->field1->field2, etc. At present a directly 
 (p == &o1 ? (o1 == &o3 ? o3 : o4) : (o2 == &o5 ? o5 : o6))
 
 This deref operator push-in is performed (implicitly) by value_set_dereferencet::dereference, which special-cases
-the ternary conditional expression.
+the ternary conditional expression and typecasts of ternary conditionals.
 More complicated expressions are handled using a let-expression. Example:
 
 p->field1->field2 ==>
@@ -21,7 +21,7 @@ result = (derefd_pointer == &o3 ? o3 : derefd_pointer == &o4 ? o4 : derefd_point
 
 The tests in this directory check that auxiliary let-expressions like this are only used when appropriate by inspecting formula VCCs:
 double_deref.desc -- a directly nested double-dereference, should not use a let-expression
-double_deref_with_cast.desc -- a double-deref with an intervening cast (*(int*)*p for example), should use a let-expression
+double_deref_with_cast.desc -- a double-deref with an intervening cast (*(int*)*p for example), should not use a let-expression
 double_deref_with_member.desc -- a double-deref with an intervening member expression (p->field1->field2), should use a let-expression
 double_deref_with_pointer_arithmetic.desc -- a double-deref with intervening pointer arithmetic (p[idx1][idx2]), should use a let-expression
 *_single_alias.desc -- variants of the above where the first dereference points to a single possible object, so no let-expression is necessary

--- a/regression/cbmc/double_deref/README
+++ b/regression/cbmc/double_deref/README
@@ -1,0 +1,27 @@
+This is a batch of tests checking cbmc's behaviour against expressions with more than one deref
+operator, such as **p, *(int*)*p, p->field1->field2, etc. At present a directly nested dereference
+(**p) is handled by pushing the second deref inside the result of the first. Example:
+
+**p ==>
+*(p == &o1 ? o1 : o2) ==>
+(p == &o1 ? *o1 : *o2) ==>
+(p == &o1 ? (o1 == &o3 ? o3 : o4) : (o2 == &o5 ? o5 : o6))
+
+This deref operator push-in is performed (implicitly) by value_set_dereferencet::dereference, which special-cases
+the ternary conditional expression.
+More complicated expressions are handled using a let-expression. Example:
+
+p->field1->field2 ==>
+((p == &o1 ? o1 : o2).field1)->field2 ==>
+let derefd_pointer = ((p == &o1 ? o1 : o2).field1) in (derefd_pointer == &o3 ? o3 : derefd_pointer == &o4 ? o4 : derefd_pointer == &o5 ? o5 : o6)
+
+Symex executes this let-expression as an auxiliary assignment, such as
+derefd_pointer = ((p == &o1 ? o1 : o2).field1)
+result = (derefd_pointer == &o3 ? o3 : derefd_pointer == &o4 ? o4 : derefd_pointer == &o5 ? o5 : o6)
+
+The tests in this directory check that auxiliary let-expressions like this are only used when appropriate by inspecting formula VCCs:
+double_deref.desc -- a directly nested double-dereference, should not use a let-expression
+double_deref_with_cast.desc -- a double-deref with an intervening cast (*(int*)*p for example), should use a let-expression
+double_deref_with_member.desc -- a double-deref with an intervening member expression (p->field1->field2), should use a let-expression
+double_deref_with_pointer_arithmetic.desc -- a double-deref with intervening pointer arithmetic (p[idx1][idx2]), should use a let-expression
+*_single_alias.desc -- variants of the above where the first dereference points to a single possible object, so no let-expression is necessary

--- a/regression/cbmc/double_deref/double_deref.c
+++ b/regression/cbmc/double_deref/double_deref.c
@@ -1,0 +1,16 @@
+
+#include <assert.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv)
+{
+  int **pptr;
+  int *ptr1 = (int *)malloc(sizeof(int));
+  *ptr1 = 1;
+  int *ptr2 = (int *)malloc(sizeof(int));
+  *ptr2 = 2;
+
+  pptr = (argc == 5 ? &ptr1 : &ptr2);
+
+  assert(**pptr == argc);
+}

--- a/regression/cbmc/double_deref/double_deref.desc
+++ b/regression/cbmc/double_deref/double_deref.desc
@@ -1,0 +1,10 @@
+CORE
+double_deref.c
+--show-vcc
+\{1\} \(main::1::pptr!0@1#2 = address_of\(main::1::ptr[12]!0@1\) \? main::argc!0@1#1 = [12] : main::argc!0@1#1 = [12]\)
+^EXIT=0$
+^SIGNAL=0$
+--
+derefd_pointer::derefd_pointer
+--
+See README for details about these tests

--- a/regression/cbmc/double_deref/double_deref_single_alias.c
+++ b/regression/cbmc/double_deref/double_deref_single_alias.c
@@ -1,0 +1,14 @@
+
+#include <assert.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv)
+{
+  int **pptr;
+  int *ptr1 = (int *)malloc(sizeof(int));
+  *ptr1 = 1;
+
+  pptr = &ptr1;
+
+  assert(**pptr == argc);
+}

--- a/regression/cbmc/double_deref/double_deref_single_alias.desc
+++ b/regression/cbmc/double_deref/double_deref_single_alias.desc
@@ -1,0 +1,10 @@
+CORE
+double_deref_single_alias.c
+--show-vcc
+\{1\} main::argc!0@1#1 = 1
+^EXIT=0$
+^SIGNAL=0$
+--
+derefd_pointer::derefd_pointer
+--
+See README for details about these tests

--- a/regression/cbmc/double_deref/double_deref_with_cast.c
+++ b/regression/cbmc/double_deref/double_deref_with_cast.c
@@ -1,0 +1,16 @@
+
+#include <assert.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv)
+{
+  void **pptr;
+  int *ptr1 = (int *)malloc(sizeof(int));
+  *ptr1 = 1;
+  int *ptr2 = (int *)malloc(sizeof(int));
+  *ptr2 = 2;
+
+  pptr = (argc == 1 ? &ptr1 : &ptr2);
+
+  assert(*(int *)*pptr == argc);
+}

--- a/regression/cbmc/double_deref/double_deref_with_cast.desc
+++ b/regression/cbmc/double_deref/double_deref_with_cast.desc
@@ -1,0 +1,10 @@
+CORE
+double_deref_with_cast.c
+--show-vcc
+^\{-[0-9]+\} derefd_pointer::derefd_pointer!0#1 =
+^\{1\} \(derefd_pointer::derefd_pointer!0#1 = address_of\(symex_dynamic::dynamic_object[1-9]+\) \? main::argc!0@1#1 = [12] : main::argc!0@1#1 = [12]
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+See README for details about these tests

--- a/regression/cbmc/double_deref/double_deref_with_cast.desc
+++ b/regression/cbmc/double_deref/double_deref_with_cast.desc
@@ -1,10 +1,10 @@
 CORE
 double_deref_with_cast.c
 --show-vcc
-^\{-[0-9]+\} derefd_pointer::derefd_pointer!0#1 =
-^\{1\} \(derefd_pointer::derefd_pointer!0#1 = address_of\(symex_dynamic::dynamic_object[1-9]+\) \? main::argc!0@1#1 = [12] : main::argc!0@1#1 = [12]
+\{1\} \(cast\(main::1::pptr!0@1#2, signedbv\[32\]\*\*\) = address_of\(main::1::ptr2!0@1\) \? main::argc!0@1#1 = 2 \: main::argc!0@1#1 = 1\)
 ^EXIT=0$
 ^SIGNAL=0$
 --
+derefd_pointer::derefd_pointer
 --
 See README for details about these tests

--- a/regression/cbmc/double_deref/double_deref_with_cast_single_alias.c
+++ b/regression/cbmc/double_deref/double_deref_with_cast_single_alias.c
@@ -1,0 +1,14 @@
+
+#include <assert.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv)
+{
+  void **pptr;
+  int *ptr1 = (int *)malloc(sizeof(int));
+  *ptr1 = 1;
+
+  pptr = &ptr1;
+
+  assert(*(int *)*pptr == argc);
+}

--- a/regression/cbmc/double_deref/double_deref_with_cast_single_alias.desc
+++ b/regression/cbmc/double_deref/double_deref_with_cast_single_alias.desc
@@ -1,0 +1,10 @@
+CORE
+double_deref_with_cast_single_alias.c
+--show-vcc
+\{1\} main::argc!0@1#1 = 1
+^EXIT=0$
+^SIGNAL=0$
+--
+derefd_pointer::derefd_pointer
+--
+See README for details about these tests

--- a/regression/cbmc/double_deref/double_deref_with_member.c
+++ b/regression/cbmc/double_deref/double_deref_with_member.c
@@ -1,0 +1,22 @@
+
+#include <assert.h>
+#include <stdlib.h>
+
+struct container
+{
+  int *iptr;
+};
+
+int main(int argc, char **argv)
+{
+  struct container *cptr;
+  struct container container1, container2;
+  container1.iptr = (int *)malloc(sizeof(int));
+  *container1.iptr = 1;
+  container2.iptr = (int *)malloc(sizeof(int));
+  *container2.iptr = 2;
+
+  cptr = (argc == 1 ? &container1 : &container2);
+
+  assert(*(cptr->iptr) == argc);
+}

--- a/regression/cbmc/double_deref/double_deref_with_member.desc
+++ b/regression/cbmc/double_deref/double_deref_with_member.desc
@@ -1,0 +1,10 @@
+CORE
+double_deref_with_member.c
+--show-vcc
+^\{-[0-9]+\} derefd_pointer::derefd_pointer!0#1 = \(main::1::cptr!0@1#2 = address_of\(main::1::container[12]!0@1\) \? address_of\(symex_dynamic::dynamic_object[12]\) : address_of\(symex_dynamic::dynamic_object[12]\)\)
+^\{1\} \(derefd_pointer::derefd_pointer!0#1 = address_of\(symex_dynamic::dynamic_object[12]\) \? main::argc!0@1#1 = 2 : main::argc!0@1#1 = 1\)
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+See README for details about these tests

--- a/regression/cbmc/double_deref/double_deref_with_member_single_alias.c
+++ b/regression/cbmc/double_deref/double_deref_with_member_single_alias.c
@@ -1,0 +1,20 @@
+
+#include <assert.h>
+#include <stdlib.h>
+
+struct container
+{
+  int *iptr;
+};
+
+int main(int argc, char **argv)
+{
+  struct container *cptr;
+  struct container container1;
+  container1.iptr = (int *)malloc(sizeof(int));
+  *container1.iptr = 1;
+
+  cptr = &container1;
+
+  assert(*(cptr->iptr) == argc);
+}

--- a/regression/cbmc/double_deref/double_deref_with_member_single_alias.desc
+++ b/regression/cbmc/double_deref/double_deref_with_member_single_alias.desc
@@ -1,0 +1,10 @@
+CORE
+double_deref_with_member_single_alias.c
+--show-vcc
+\{1\} main::argc!0@1#1 = 1
+^EXIT=0$
+^SIGNAL=0$
+--
+derefd_pointer::derefd_pointer
+--
+See README for details about these tests

--- a/regression/cbmc/double_deref/double_deref_with_pointer_arithmetic.c
+++ b/regression/cbmc/double_deref/double_deref_with_pointer_arithmetic.c
@@ -1,0 +1,22 @@
+
+#include <assert.h>
+#include <stdlib.h>
+
+struct container
+{
+  int *iptr;
+};
+
+int main(int argc, char **argv)
+{
+  int **new_ptrs = malloc(2 * sizeof(int *));
+  int *iptr1 = (int *)malloc(sizeof(int));
+  *iptr1 = 1;
+  int *iptr2 = (int *)malloc(sizeof(int));
+  *iptr2 = 2;
+
+  new_ptrs[argc % 2] = iptr1;
+  new_ptrs[1 - (argc % 2)] = iptr2;
+
+  assert(*(new_ptrs[argc % 2]) == argc);
+}

--- a/regression/cbmc/double_deref/double_deref_with_pointer_arithmetic.desc
+++ b/regression/cbmc/double_deref/double_deref_with_pointer_arithmetic.desc
@@ -1,0 +1,10 @@
+CORE
+double_deref_with_pointer_arithmetic.c
+--show-vcc
+^\{-[0-9]+\} derefd_pointer::derefd_pointer!0#1 = symex_dynamic::dynamic_object1#3\[cast\(mod #source_location=""\(main::argc!0@1#1, 2\), signedbv\[64\]\)\]
+^\{1\} \(derefd_pointer::derefd_pointer!0#1 = address_of\(symex_dynamic::dynamic_object[23]\) \? main::argc!0@1#1 = 2 : main::argc!0@1#1 = 1\)
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+See README for details about these tests

--- a/regression/cbmc/double_deref/double_deref_with_pointer_arithmetic_single_alias.c
+++ b/regression/cbmc/double_deref/double_deref_with_pointer_arithmetic_single_alias.c
@@ -1,0 +1,19 @@
+
+#include <assert.h>
+#include <stdlib.h>
+
+struct container
+{
+  int *iptr;
+};
+
+int main(int argc, char **argv)
+{
+  int **new_ptrs = malloc(2 * sizeof(int *));
+  int *iptr1 = (int *)malloc(sizeof(int));
+  *iptr1 = 1;
+
+  new_ptrs[argc % 2] = iptr1;
+
+  assert(*(new_ptrs[argc % 2]) == argc);
+}

--- a/regression/cbmc/double_deref/double_deref_with_pointer_arithmetic_single_alias.desc
+++ b/regression/cbmc/double_deref/double_deref_with_pointer_arithmetic_single_alias.desc
@@ -1,0 +1,10 @@
+CORE
+double_deref_with_pointer_arithmetic_single_alias.c
+--show-vcc
+\{1\} main::argc!0@1#1 = 1
+^EXIT=0$
+^SIGNAL=0$
+--
+derefd_pointer::derefd_pointer
+--
+See README for details about these tests

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -288,6 +288,11 @@ protected:
 
   void trigger_auto_object(const exprt &, statet &);
   void initialize_auto_object(const exprt &, statet &);
+
+  /// Given an expression, find the root object and the offset into it.
+  ///
+  /// The extra complication to be considered here is that the expression may
+  /// have any number of ternary expressions mixed with type casts.
   void process_array_expr(statet &, exprt &);
   exprt make_auto_object(const typet &, statet &);
   virtual void dereference(exprt &, statet &, bool write);
@@ -507,7 +512,16 @@ protected:
 
   typedef symex_targett::assignment_typet assignment_typet;
 
+  /// Execute any let expressions in \p expr using \ref symex_assign_symbol.
+  /// The assignments will be made in bottom-up topological but otherwise
+  /// arbitrary order (i.e. in `(let x = let y = 0 in x + y) + (let z = 0 in z)
+  /// we will define `y` before `x`, but `z` and `x` could come in either order)
   void lift_lets(statet &, exprt &);
+
+  /// Execute a single let expression, which should not have any nested let
+  /// expressions (use \ref lift_lets instead if there might be).
+  /// The caller is responsible for killing the newly-defined variable when
+  /// appropriate.
   void lift_let(statet &state, const let_exprt &let_expr);
 
   void symex_assign_rec(

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -218,6 +218,16 @@ protected:
     const get_goto_functiont &get_goto_function);
 
   /// \brief Called for each step in the symbolic execution
+  /// This calls \ref print_symex_step to print symex's current instruction if
+  /// required, then \ref execute_instruction to execute the actual instruction
+  /// body.
+  /// \param get_goto_function: The delegate to retrieve function bodies (see
+  ///   \ref get_goto_functiont)
+  /// \param state: Symbolic execution state for current instruction
+  virtual void
+  symex_step(const get_goto_functiont &get_goto_function, statet &state);
+
+  /// \brief Executes the instruction `state.source.pc`
   /// Case-switches over the type of the instruction being executed and calls
   /// another function appropriate to the instruction type, for example
   /// \ref symex_function_call if the current instruction is a function call,
@@ -225,8 +235,9 @@ protected:
   /// \param get_goto_function: The delegate to retrieve function bodies (see
   ///   \ref get_goto_functiont)
   /// \param state: Symbolic execution state for current instruction
-  virtual void
-  symex_step(const get_goto_functiont &get_goto_function, statet &state);
+  void execute_next_instruction(
+    const get_goto_functiont &get_goto_function,
+    statet &state);
 
   /// Prints the route of symex as it walks through the code. Used for
   /// debugging.

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -321,6 +321,10 @@ protected:
   /// Symbolically execute a DEAD instruction
   /// \param state: Symbolic execution state for current instruction
   virtual void symex_dead(statet &state);
+  /// Kill a symbol, as if it had been the subject of a DEAD instruction
+  /// \param state: Symbolic execution state
+  /// \param symbol_expr: Symbol to kill
+  void symex_dead(statet &state, const symbol_exprt &symbol_expr);
   /// Symbolically execute an OTHER instruction
   /// \param state: Symbolic execution state for current instruction
   virtual void symex_other(statet &state);

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -503,6 +503,12 @@ protected:
 
   typedef symex_targett::assignment_typet assignment_typet;
 
+  void lift_lets(statet &, exprt &, assignment_typet);
+  void lift_let(
+    statet &state,
+    const let_exprt &let_expr,
+    assignment_typet assignment_type);
+
   void symex_assign_rec(
     statet &,
     const exprt &lhs,

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -507,11 +507,8 @@ protected:
 
   typedef symex_targett::assignment_typet assignment_typet;
 
-  void lift_lets(statet &, exprt &, assignment_typet);
-  void lift_let(
-    statet &state,
-    const let_exprt &let_expr,
-    assignment_typet assignment_type);
+  void lift_lets(statet &, exprt &);
+  void lift_let(statet &state, const let_exprt &let_expr);
 
   void symex_assign_rec(
     statet &,

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -186,6 +186,9 @@ void goto_symext::lift_let(statet &state, const let_exprt &let_expr)
     let_value,
     value_assignment_guard,
     symex_targett::assignment_typet::HIDDEN);
+
+  // Schedule the bound variable to be cleaned up at the end of symex_step:
+  instruction_local_symbols.push_back(let_expr.symbol());
 }
 
 void goto_symext::lift_lets(statet &state, exprt &rhs)

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -128,6 +128,7 @@ void goto_symext::process_array_expr(statet &state, exprt &expr)
     ns, state.symbol_table, symex_dereference_state, language_mode, false);
 
   expr = dereference.dereference(expr);
+  lift_lets(state, expr, symex_targett::assignment_typet::STATE);
 
   ::process_array_expr(expr, symex_config.simplify_opt, ns);
 }
@@ -222,6 +223,7 @@ void goto_symext::clean_expr(
 {
   replace_nondet(expr, path_storage.build_symex_nondet);
   dereference(expr, state, write);
+  lift_lets(state, expr, symex_targett::assignment_typet::STATE);
 
   // make sure all remaining byte extract operations use the root
   // object to avoid nesting of with/update and byte_update when on

--- a/src/goto-symex/symex_dead.cpp
+++ b/src/goto-symex/symex_dead.cpp
@@ -21,8 +21,14 @@ void goto_symext::symex_dead(statet &state)
   const goto_programt::instructiont &instruction=*state.source.pc;
 
   const code_deadt &code = instruction.get_dead();
+  symex_dead(state, code.symbol());
+}
 
-  ssa_exprt ssa = state.rename_ssa<L1>(ssa_exprt{code.symbol()}, ns).get();
+void goto_symext::symex_dead(statet &state, const symbol_exprt &symbol_expr)
+{
+  ssa_exprt to_rename = is_ssa_expr(symbol_expr) ? to_ssa_expr(symbol_expr)
+                                                 : ssa_exprt{symbol_expr};
+  ssa_exprt ssa = state.rename_ssa<L1>(to_rename, ns).get();
 
   const exprt fields = state.field_sensitivity.get_fields(ns, state, ssa);
   find_symbols_sett fields_set;

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -513,6 +513,7 @@ void goto_symext::symex_step(
   // Print debug statements if they've been enabled.
   print_symex_step(state);
   execute_next_instruction(get_goto_function, state);
+  kill_instruction_local_symbols(state);
 }
 
 void goto_symext::execute_next_instruction(
@@ -650,6 +651,13 @@ void goto_symext::execute_next_instruction(
   case INCOMPLETE_GOTO:
     DATA_INVARIANT(false, "symex got unexpected instruction type");
   }
+}
+
+void goto_symext::kill_instruction_local_symbols(statet &state)
+{
+  for(const auto &symbol_expr : instruction_local_symbols)
+    symex_dead(state, symbol_expr);
+  instruction_local_symbols.clear();
 }
 
 /// Check if an expression only contains one unique symbol (possibly repeated

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -512,7 +512,13 @@ void goto_symext::symex_step(
 {
   // Print debug statements if they've been enabled.
   print_symex_step(state);
+  execute_next_instruction(get_goto_function, state);
+}
 
+void goto_symext::execute_next_instruction(
+  const get_goto_functiont &get_goto_function,
+  statet &state)
+{
   PRECONDITION(!state.threads.empty());
   PRECONDITION(!state.call_stack().empty());
 

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -962,6 +962,18 @@ void value_sett::get_value_set_rec(
 
     // we could have checked object size to be more precise
   }
+  else if(expr.id() == ID_let)
+  {
+    const auto &let_expr = to_let_expr(expr);
+    // This depends on copying `value_sett` being cheap -- which it is, because
+    // our backing store is sharing_mapt.
+    value_sett value_set_with_local_definition = *this;
+    value_set_with_local_definition.assign(
+      let_expr.symbol(), let_expr.value(), ns, false, false);
+
+    value_set_with_local_definition.get_value_set_rec(
+      let_expr.where(), dest, suffix, original_type, ns);
+  }
   else
   {
     #if 0

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -76,9 +76,24 @@ exprt value_set_dereferencet::dereference(const exprt &pointer)
 
   std::list<valuet> values;
 
+  exprt compare_against_pointer = pointer;
+
+  if(pointer.id() != ID_symbol && retained_values.size() >= 2)
+  {
+    symbolt fresh_binder = get_fresh_aux_symbol(
+      pointer.type(),
+      "derefd_pointer",
+      "derefd_pointer",
+      source_locationt(),
+      language_mode,
+      new_symbol_table);
+
+    compare_against_pointer = fresh_binder.symbol_expr();
+  }
+
   for(const auto &value : retained_values)
   {
-    values.push_back(build_reference_to(value, pointer, ns));
+    values.push_back(build_reference_to(value, compare_against_pointer, ns));
 #if 0
     std::cout << "V: " << format(value.pointer_guard) << " --> ";
     std::cout << format(value.value);
@@ -160,9 +175,12 @@ exprt value_set_dereferencet::dereference(const exprt &pointer)
     }
   }
 
-  #if 0
+  if(compare_against_pointer != pointer)
+    value = let_exprt(to_symbol_expr(compare_against_pointer), pointer, value);
+
+#if 0
   std::cout << "R: " << format(value) << "\n\n";
-  #endif
+#endif
 
   return value;
 }


### PR DESCRIPTION
~Depends on #4574 and #4575.~ Since #4555 didn't really work out, here's my second stab at avoiding producing comically large expressions during nested dereferencing. 

In brief, if we have `**p` where `p` is the root of a binary tree with nodes L, R, LL, LR, RL, RR, then instead of `*p` -> `p == &L ? L : R` and then `**p` -> `(p == &L ? L : R) == LL ? LL : (p == &L ? L : R) == LR ? LR : ...` instead we get `let derefd = (p == &L ? L : R) in derefd == LL ? LL : derefd = LR ? LR : ...`. When we have a large alias set this avoids creating many duplicates of the inner dereference result.

Anecdotally this speeds up a nested deref due to a two-dimensional array from "practically forever" to "around a second".

~Putting up now for early review, but known TODOs:~
* ~Data~
* ~Check whether the assignments associated with a let expression's temporary variable ought to be `STATE` or `HIDDEN` assignments.~ (gone for HIDDEN, given that `#return_value` assignments use the same scheme)
* ~Forgo a `let` in more cases when the existing pointer expression is small / simple (e.g. if `pointer` is `(T*)p` there's not really any point in creating a temporary for it)~ (allowed expressions only involving one `symbol_exprt` to be used directly, such as `(type *)p` and `p[some_constant]`)
* ~Kill the temporaries created for `let` bound variables when they go out of scope, to avoid pointlessly carrying them around in `value_sett`, the constant propagator, etc for the rest of time~ ~(added an owning object returned by `clean_expr` that kills the binders after the instruction is done executing)~ (added a tracking vector of instruction-local bound variables, which are killed at the end of `symex_step`)