### PR TITLE
Dynamic memory snapshot

### DIFF
--- a/regression/memory-analyzer/pointer_03/test.desc
+++ b/regression/memory-analyzer/pointer_03/test.desc
@@ -2,6 +2,6 @@ CORE
 main.gb
 --breakpoint checkpoint --symbols x,p
 x = 3;
-p = &x;
+p = \(void \*\)\&x;
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/memory-analyzer/pointer_to_struct_01/test.desc
+++ b/regression/memory-analyzer/pointer_to_struct_01/test.desc
@@ -1,8 +1,7 @@
 CORE
 main.gb
 --breakpoint checkpoint --symbols p
-struct S tmp;
-tmp = \{ \.next=\(\(struct S \*\)0\) \};
-p = \&tmp;
+st = \{ .next=\&st \};
+p = \&st;
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/memory-analyzer/structs_02/test.desc
+++ b/regression/memory-analyzer/structs_02/test.desc
@@ -1,8 +1,7 @@
 CORE
 main.gb
 --breakpoint checkpoint --symbols st
-signed int tmp;
-tmp = 3;
-st = \{ .c1=1, .c2=&tmp \};
+i = 3;
+st = \{ .c1=1, .c2=\&i \};
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/snapshot-harness/arrays_02/main.c
+++ b/regression/snapshot-harness/arrays_02/main.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+
+int array[] = {1, 2, 3};
+int *p;
+int *q;
+
+void initialize()
+{
+  p = &(array[1]);
+  q = array + 1;
+  array[0] = 4;
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(p == q);
+  assert(*p == *q);
+  *p = 4;
+  q = q - 1;
+  assert(*q == *p);
+}

--- a/regression/snapshot-harness/arrays_02/test.desc
+++ b/regression/snapshot-harness/arrays_02/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+p,q --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^EXIT=0$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion p == q: SUCCESS
+\[main.assertion.2\] line [0-9]+ assertion \*p == \*q: SUCCESS
+\[main.assertion.3\] line [0-9]+ assertion \*q == \*p: SUCCESS
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/regression/snapshot-harness/dynamic-array-int/main.c
+++ b/regression/snapshot-harness/dynamic-array-int/main.c
@@ -1,0 +1,47 @@
+#include <assert.h>
+#include <malloc.h>
+
+int *array;
+int *iterator1;
+int *iterator2;
+int *iterator3;
+
+void initialize()
+{
+  array = (int *)malloc(sizeof(int) * 10);
+  array[0] = 1;
+  array[1] = 2;
+  array[2] = 3;
+  array[3] = 4;
+  array[4] = 5;
+  array[5] = 6;
+  array[6] = 7;
+  array[7] = 8;
+  array[8] = 9;
+  array[9] = 10;
+  iterator1 = (int *)array;
+  iterator2 = &array[1];
+  iterator3 = array + 1;
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(*iterator1 == 1);
+  assert(iterator1 != iterator2);
+  assert(iterator2 == iterator3);
+  assert(iterator2 == &array[1]);
+  assert(*iterator3 == array[1]);
+  assert(*iterator3 == 2);
+  iterator3 = &array[9];
+  iterator3++;
+  assert(*iterator3 == 0);
+
+  return 0;
+}

--- a/regression/snapshot-harness/dynamic-array-int/test.desc
+++ b/regression/snapshot-harness/dynamic-array-int/test.desc
@@ -1,0 +1,16 @@
+CORE
+main.c
+array,iterator1,iterator2,iterator3 --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^EXIT=10$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion \*iterator1 == 1: SUCCESS
+\[main.assertion.2\] line [0-9]+ assertion iterator1 != iterator2: SUCCESS
+\[main.assertion.3\] line [0-9]+ assertion iterator2 == iterator3: SUCCESS
+\[main.assertion.4\] line [0-9]+ assertion iterator2 == \&array\[1\]: SUCCESS
+\[main.assertion.5\] line [0-9]+ assertion \*iterator3 == array\[1\]: SUCCESS
+\[main.assertion.6\] line [0-9]+ assertion \*iterator3 == 2: SUCCESS
+\[main.pointer_dereference.27\] line [0-9]+ dereference failure: pointer outside object bounds in \*iterator3: FAILURE
+\[main.assertion.7\] line [0-9]+ assertion \*iterator3 == 0: FAILURE
+VERIFICATION FAILED
+--
+unwinding assertion loop \d+: FAILURE

--- a/regression/snapshot-harness/pointer-to-array-int/main.c
+++ b/regression/snapshot-harness/pointer-to-array-int/main.c
@@ -31,14 +31,10 @@ int main()
   checkpoint();
 
   assert(first == second);
-  // The following assertions will be check in the following PR once
-  // dynamically allocated snapshots are properly implemented.
-  /* assert(array_size >= prefix_size); */
-  /* assert(prefix_size >= 0); */
-  /* assert(second[prefix_size] != 6); */
-  /* assert(second[4] == 4); */
+  assert(array_size >= prefix_size);
+  assert(prefix_size >= 0);
+  assert(second[prefix_size] != 6);
+  assert(second[4] == 4);
 
-  /* for(int i = 0; i < prefix_size; i++) */
-  /*   assert(second[i] != prefix[i]); */
   return 0;
 }

--- a/regression/snapshot-harness/static-array-float/main.c
+++ b/regression/snapshot-harness/static-array-float/main.c
@@ -1,0 +1,32 @@
+#include <assert.h>
+
+float array[10];
+float *iterator1;
+float *iterator2;
+
+void initialize()
+{
+  array[0] = 1.11;
+  array[8] = 9.999;
+  array[9] = 10.0;
+  iterator1 = (float *)array;
+  iterator2 = &array[9];
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(*iterator1 >= 1.10 && *iterator1 <= 1.12);
+  assert(iterator1 != iterator2);
+  assert(iterator2 == &array[9]);
+  iterator2++;
+  assert(*iterator2 == 0.0);
+
+  return 0;
+}

--- a/regression/snapshot-harness/static-array-float/test.desc
+++ b/regression/snapshot-harness/static-array-float/test.desc
@@ -1,0 +1,15 @@
+FUTURE
+main.c
+array,iterator1,iterator2 --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^EXIT=10$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion \*iterator1 \>= 1.10 \&\& \*iterator1 \<= 1.12: SUCCESS
+\[main.assertion.2\] line [0-9]+ assertion iterator1 != iterator2: SUCCESS
+\[main.assertion.3\] line [0-9]+ assertion iterator2 == \&array\[9\]: SUCCESS
+\[main.pointer_dereference.13\] line [0-9]+ dereference failure: pointer outside object bounds in \*iterator2: FAILURE
+\[main.assertion.4\] line [0-9]+ assertion \*iterator2 == 0: FAILURE
+VERIFICATION FAILED
+--
+unwinding assertion loop \d+: FAILURE
+--
+memory analyzer does not yet allow extract floating point values

--- a/regression/snapshot-harness/static-array-int/main.c
+++ b/regression/snapshot-harness/static-array-int/main.c
@@ -1,0 +1,32 @@
+#include <assert.h>
+
+int array[10];
+int *iterator1;
+int *iterator2;
+
+void initialize()
+{
+  array[0] = 1;
+  array[8] = 9;
+  array[9] = 10;
+  iterator1 = (int *)array;
+  iterator2 = &array[9];
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(*iterator1 == 1);
+  assert(iterator1 != iterator2);
+  assert(iterator2 == &array[9]);
+  iterator2++;
+  assert(*iterator2 == 0);
+
+  return 0;
+}

--- a/regression/snapshot-harness/static-array-int/test.desc
+++ b/regression/snapshot-harness/static-array-int/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+array,iterator1,iterator2 --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^EXIT=10$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion \*iterator1 == 1: SUCCESS
+\[main.assertion.2\] line [0-9]+ assertion iterator1 != iterator2: SUCCESS
+\[main.assertion.3\] line [0-9]+ assertion iterator2 == \&array\[9\]: SUCCESS
+\[main.pointer_dereference.13\] line [0-9]+ dereference failure: pointer outside object bounds in \*iterator2: FAILURE
+\[main.assertion.4\] line [0-9]+ assertion \*iterator2 == 0: FAILURE
+VERIFICATION FAILED
+--
+unwinding assertion loop \d+: FAILURE

--- a/src/goto-cc/Makefile
+++ b/src/goto-cc/Makefile
@@ -40,15 +40,16 @@ INCLUDES= -I ..
 
 LIBS =
 
-CLEANFILES = goto-cc$(EXEEXT) goto-cl$(EXEEXT)
+CLEANFILES = goto-cc$(EXEEXT) goto-gcc$(EXEEXT) goto-cl$(EXEEXT)
 
 include ../config.inc
 include ../common
 
 ifeq ($(BUILD_ENV_),MSVC)
 all: goto-cl$(EXEEXT)
+else
+all: goto-gcc$(EXEEXT)
 endif
-all: goto-cc$(EXEEXT)
 
 ifneq ($(wildcard ../jsil/Makefile),)
   OBJ += ../jsil/jsil$(LIBEXT)
@@ -56,6 +57,9 @@ ifneq ($(wildcard ../jsil/Makefile),)
 endif
 
 ###############################################################################
+
+goto-gcc$(EXEEXT): goto-cc$(EXEEXT)
+	ln -sf goto-cc$(EXEEXT) goto-gcc$(EXEEXT)
 
 goto-cc$(EXEEXT): $(OBJ)
 	$(LINKBIN)

--- a/src/goto-harness/memory_snapshot_harness_generator.h
+++ b/src/goto-harness/memory_snapshot_harness_generator.h
@@ -244,6 +244,12 @@ protected:
   /// \return pointer depth of type \p t
   size_t pointer_depth(const typet &t) const;
 
+  /// Recursively test pointer reference
+  /// \param expr: expression to be tested
+  /// \param name: name to be located
+  /// \return true if \p expr refers to an object named \p name
+  bool refers_to(const exprt &expr, const irep_idt &name) const;
+
   /// data to store the command-line options
   std::string memory_snapshot_file;
   std::string initial_goto_location_line;

--- a/src/memory-analyzer/analyze_symbol.cpp
+++ b/src/memory-analyzer/analyze_symbol.cpp
@@ -217,7 +217,8 @@ symbol_tablet gdb_value_extractort::get_snapshot_as_symbol_table()
 
 void gdb_value_extractort::add_assignment(const exprt &lhs, const exprt &value)
 {
-  assignments.push_back(std::make_pair(lhs, value));
+  if(assignments.count(lhs) == 0)
+    assignments.emplace(std::make_pair(lhs, value));
 }
 
 exprt gdb_value_extractort::get_char_pointer_value(

--- a/src/memory-analyzer/analyze_symbol.cpp
+++ b/src/memory-analyzer/analyze_symbol.cpp
@@ -98,6 +98,13 @@ optionalt<std::string> gdb_value_extractort::get_malloc_pointee(
          (pointer_distance > 0 ? "+" + integer2string(pointer_distance) : "");
 }
 
+mp_integer gdb_value_extractort::get_type_size(const typet &type) const
+{
+  const auto maybe_size = pointer_offset_bits(type, ns);
+  CHECK_RETURN(maybe_size.has_value());
+  return *maybe_size / 8;
+}
+
 void gdb_value_extractort::analyze_symbols(const std::vector<irep_idt> &symbols)
 {
   // record addresses of given symbols

--- a/src/memory-analyzer/analyze_symbol.h
+++ b/src/memory-analyzer/analyze_symbol.h
@@ -278,12 +278,12 @@ private:
   ///   \ref gdb_apit::get_memory, calls \ref get_expr_value on _dereferenced_
   ///   \p expr (the result of which is assigned to a new symbol).
   /// \param expr: the pointer expression to be analysed
-  /// \param memory_location: pointer value from \ref gdb_apit::get_memory
+  /// \param value: pointer value from \ref gdb_apit::get_memory
   /// \param location: the source location
   /// \return symbol expression associated with \p memory_location
   exprt get_non_char_pointer_value(
     const exprt &expr,
-    const memory_addresst &memory_location,
+    const pointer_valuet &value,
     const source_locationt &location);
 
   /// If \p memory_location is found among \ref values then return the symbol

--- a/src/memory-analyzer/analyze_symbol.h
+++ b/src/memory-analyzer/analyze_symbol.h
@@ -188,6 +188,11 @@ private:
   optionalt<std::string>
   get_malloc_pointee(const memory_addresst &point, mp_integer member_size);
 
+  /// Wrapper for call get_offset_pointer_bits
+  /// \param type: type to get the size of
+  /// \return the size of the type in bytes
+  mp_integer get_type_size(const typet &type) const;
+
   /// Assign the gdb-extracted value for \p symbol_name to its symbol
   ///   expression and then process outstanding assignments that this
   ///   extraction introduced.

--- a/src/memory-analyzer/analyze_symbol.h
+++ b/src/memory-analyzer/analyze_symbol.h
@@ -81,7 +81,7 @@ private:
   allocate_objectst allocate_objects;
 
   /// Sequence of assignments collected during \ref analyze_symbols
-  std::vector<std::pair<exprt, exprt>> assignments;
+  std::map<exprt, exprt> assignments;
 
   /// Mapping pointer expression for which \ref get_non_char_pointer_value
   ///   returned nil expression to memory location (from \ref gdb_apit).

--- a/src/memory-analyzer/analyze_symbol.h
+++ b/src/memory-analyzer/analyze_symbol.h
@@ -307,8 +307,10 @@ private:
   /// Analyzes the \p pointer_value to decide if it point to a struct or a
   ///   union (or array)
   /// \param pointer_value: pointer value to be analyzed
+  /// \param expected_type: type of the potential member
   /// \return true if pointing to a member
-  bool points_to_member(const pointer_valuet &pointer_value) const;
+  bool
+  points_to_member(pointer_valuet &pointer_value, const typet &expected_type);
 };
 
 #endif // CPROVER_MEMORY_ANALYZER_ANALYZE_SYMBOL_H

--- a/src/memory-analyzer/gdb_api.cpp
+++ b/src/memory-analyzer/gdb_api.cpp
@@ -9,7 +9,8 @@ Author: Malte Mues <mail.mues@gmail.com>
 
 /// \file
 /// Low-level interface to gdb
-
+///
+/// Implementation of the GDB/MI API for extracting values of expressions.
 
 #include <cctype>
 #include <cerrno>

--- a/src/memory-analyzer/gdb_api.cpp
+++ b/src/memory-analyzer/gdb_api.cpp
@@ -300,9 +300,57 @@ void gdb_apit::run_gdb_from_core(const std::string &corefile)
   gdb_state = gdb_statet::STOPPED;
 }
 
+void gdb_apit::collect_malloc_calls()
+{
+  // this is what the registers look like at the function call entry:
+  //
+  // reg. name         hex. value   dec. value
+  // 0: rax            0xffffffff   4294967295
+  // 1: rbx            0x20000000   536870912
+  // 2: rcx            0x591        1425
+  // 3: rdx            0x591        1425
+  // 4: rsi            0x1          1
+  // 5: rdi            0x591        1425
+  // ...
+  // rax will eventually contain the return value and
+  // rdi now stores the first (integer) argument
+  // in the machine interface they are referred to by numbers, hence:
+  write_to_gdb("-data-list-register-values d 5");
+  auto record = get_most_recent_record("^done", true);
+  auto allocated_size = safe_string2size_t(get_register_value(record));
+
+  write_to_gdb("-exec-finish");
+  if(!most_recent_line_has_tag("*running"))
+  {
+    throw gdb_interaction_exceptiont("could not run program");
+  }
+  record = get_most_recent_record("*stopped");
+  auto frame_content = get_value_from_record(record, "frame");
+
+  // the malloc breakpoint may be inside another malloc function
+  if(frame_content.find("func=\"malloc\"") != std::string::npos)
+  {
+    // so we need to finish the outer malloc as well
+    write_to_gdb("-exec-finish");
+    if(!most_recent_line_has_tag("*running"))
+    {
+      throw gdb_interaction_exceptiont("could not run program");
+    }
+    record = get_most_recent_record("*stopped");
+  }
+
+  // now we can read the rax register to the the allocated memory address
+  write_to_gdb("-data-list-register-values x 0");
+  record = get_most_recent_record("^done", true);
+  allocated_memory[get_register_value(record)] = allocated_size;
+}
+
 bool gdb_apit::run_gdb_to_breakpoint(const std::string &breakpoint)
 {
   PRECONDITION(gdb_state == gdb_statet::CREATED);
+
+  write_to_gdb("-break-insert " + malloc_name);
+  bool malloc_is_known = was_command_accepted();
 
   std::string command("-break-insert");
   command += " " + breakpoint;
@@ -321,6 +369,30 @@ bool gdb_apit::run_gdb_to_breakpoint(const std::string &breakpoint)
   }
 
   gdb_output_recordt record = get_most_recent_record("*stopped");
+
+  // malloc function is known, i.e. present among the symbols
+  if(malloc_is_known)
+  {
+    // stop at every entry into malloc call
+    while(hit_malloc_breakpoint(record))
+    {
+      // and store the information about the allocated memory
+      collect_malloc_calls();
+      write_to_gdb("-exec-continue");
+      if(!most_recent_line_has_tag("*running"))
+      {
+        throw gdb_interaction_exceptiont("could not run program");
+      }
+      record = get_most_recent_record("*stopped");
+    }
+
+    write_to_gdb("-break-delete 1");
+    if(!was_command_accepted())
+    {
+      throw gdb_interaction_exceptiont("could not delete breakpoint at malloc");
+    }
+  }
+
   const auto it = record.find("reason");
   CHECK_RETURN(it != record.end());
 
@@ -557,6 +629,18 @@ std::string gdb_apit::get_value_from_record(
   INVARIANT(value.back() != '\n', "value should not end in a newline");
 
   return value;
+}
+
+bool gdb_apit::hit_malloc_breakpoint(const gdb_output_recordt &stopped_record)
+{
+  const auto it = stopped_record.find("reason");
+  CHECK_RETURN(it != stopped_record.end());
+
+  if(it->second != "breakpoint-hit")
+    return false;
+
+  return safe_string2size_t(get_value_from_record(stopped_record, "bkptno")) ==
+         1;
 }
 
 std::string gdb_apit::get_register_value(const gdb_output_recordt &record)

--- a/src/memory-analyzer/gdb_api.h
+++ b/src/memory-analyzer/gdb_api.h
@@ -31,6 +31,9 @@ class gdb_apit
 {
 public:
   using commandst = std::forward_list<std::string>;
+
+  /// Memory address imbued with the explicit boolean data indicating if the
+  /// address is null or not.
   struct memory_addresst
   {
     bool null_address;
@@ -67,6 +70,8 @@ public:
   /// writing to gdb)
   ~gdb_apit();
 
+  /// Data associated with the value of a pointer, i.e. not only the address but
+  /// also the pointee (if known), string (in the case of char*), etc.
   struct pointer_valuet
   {
     pointer_valuet(
@@ -128,6 +133,9 @@ public:
   /// \return memory address in hex format
   optionalt<std::string> get_value(const std::string &expr);
 
+  /// Get the value of a pointer associated with \p expr
+  /// \param expr: the expression to be analyzed
+  /// \return the \p pointer_valuet filled with data gdb produced for \p expr
   pointer_valuet get_memory(const std::string &expr);
 
   /// Return the vector of commands that have been written to gdb so far

--- a/src/memory-analyzer/gdb_api.h
+++ b/src/memory-analyzer/gdb_api.h
@@ -177,6 +177,19 @@ protected:
   bool was_command_accepted();
   void check_command_accepted();
 
+  /// Locate and return the value for a given name
+  /// \param record: gdb record to search
+  /// \param value_name: name of the value to be extracted
+  /// \return the value associated with \p value_name
+  std::string get_value_from_record(
+    const gdb_output_recordt &record,
+    const std::string &value_name);
+
+  /// Parse the record produced by listing register value
+  /// \param record: gdb record for one register value
+  /// \return get the value associated with some register value
+  std::string get_register_value(const gdb_output_recordt &record);
+
   static std::string r_opt(const std::string &regex);
 
   static std::string

--- a/src/memory-analyzer/gdb_api.h
+++ b/src/memory-analyzer/gdb_api.h
@@ -102,15 +102,10 @@ public:
     bool valid;
   };
 
-  /// Get the allocated size estimate for a pointer by evaluating
-  /// `malloc_usable_size'. The function returns the number of usable bytes in
-  /// the block pointed to by the pointer to a block of memory allocated by
-  /// `malloc' or a related function. The value may be greater than the
-  /// requested size of the allocation because of alignment and minimum size
-  /// constraints.
+  /// Get the exact allocated size for a pointer \p pointer_expr.
   /// \param pointer_expr: expression with a pointer name
   /// \return 1 if the pointer was not allocated with malloc otherwise return
-  ///   the result of calling `malloc_usable_size'
+  ///   the number of allocated bytes
   size_t query_malloc_size(const std::string &pointer_expr);
 
   /// Create a new gdb process for analysing the binary indicated by the member

--- a/src/memory-analyzer/gdb_api.h
+++ b/src/memory-analyzer/gdb_api.h
@@ -88,10 +88,10 @@ public:
     {
     }
 
-    const memory_addresst address;
-    const std::string pointee;
-    const std::string character;
-    const optionalt<std::string> string;
+    memory_addresst address;
+    std::string pointee;
+    std::string character;
+    optionalt<std::string> string;
 
     bool has_known_offset() const
     {


### PR DESCRIPTION
Enable tracking information about dynamically allocated memory from `memory-analyzer` across to `goto-harness` via memory snapshots. The knowledge about what addresses have been allocated dynamically (and the scope of these allocation in byte size) is collected by breaking the execution at `malloc` call-sites and inspecting the registers of these function calls.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
