### PR TITLE
stack_decision_proceduret for solving under assumptions/contexts

### DIFF
--- a/src/goto-checker/goto_symex_fault_localizer.cpp
+++ b/src/goto-checker/goto_symex_fault_localizer.cpp
@@ -11,13 +11,11 @@ Author: Peter Schrammel
 
 #include "goto_symex_fault_localizer.h"
 
-#include <solvers/prop/prop_conv.h>
-
 goto_symex_fault_localizert::goto_symex_fault_localizert(
   const optionst &options,
   ui_message_handlert &ui_message_handler,
   const symex_target_equationt &equation,
-  prop_convt &solver)
+  stack_decision_proceduret &solver)
   : options(options),
     ui_message_handler(ui_message_handler),
     equation(equation),
@@ -58,7 +56,7 @@ const SSA_stept &goto_symex_fault_localizert::collect_guards(
       step.assignment_type == symex_targett::assignment_typet::STATE &&
       !step.ignore)
     {
-      literalt l = solver.convert(step.guard_handle);
+      exprt l = solver.handle(step.guard_handle);
       if(!l.is_constant())
       {
         auto emplace_result = fault_location.scores.emplace(step.source.pc, 0);
@@ -79,21 +77,21 @@ bool goto_symex_fault_localizert::check(
   const localization_points_valuet &value)
 {
   PRECONDITION(value.size() == localization_points.size());
-  bvt assumptions;
+  std::vector<exprt> assumptions;
   localization_points_valuet::const_iterator v_it = value.begin();
   for(const auto &l : localization_points)
   {
     if(v_it->is_true())
       assumptions.push_back(l.first);
     else if(v_it->is_false())
-      assumptions.push_back(!l.first);
+      assumptions.push_back(solver.handle(not_exprt(l.first)));
     ++v_it;
   }
 
   // lock the failed assertion
-  assumptions.push_back(!solver.convert(failed_step.cond_handle));
+  assumptions.push_back(solver.handle(not_exprt(failed_step.cond_handle)));
 
-  solver.set_assumptions(assumptions);
+  solver.push(assumptions);
 
   return solver() != decision_proceduret::resultt::D_SATISFIABLE;
 }
@@ -104,11 +102,11 @@ void goto_symex_fault_localizert::update_scores(
   for(auto &l : localization_points)
   {
     auto &score = l.second->second;
-    if(solver.l_get(l.first).is_true())
+    if(solver.get(l.first).is_true())
     {
       score++;
     }
-    else if(solver.l_get(l.first).is_false() && score > 0)
+    else if(solver.get(l.first).is_false() && score > 0)
     {
       score--;
     }
@@ -135,6 +133,5 @@ void goto_symex_fault_localizert::localize_linear(
   }
 
   // clear assumptions
-  bvt assumptions;
-  solver.set_assumptions(assumptions);
+  solver.pop();
 }

--- a/src/goto-checker/goto_symex_fault_localizer.h
+++ b/src/goto-checker/goto_symex_fault_localizer.h
@@ -18,7 +18,7 @@ Author: Peter Schrammel
 
 #include <goto-symex/symex_target_equation.h>
 
-#include <solvers/prop/prop_conv.h>
+#include <solvers/stack_decision_procedure.h>
 
 #include "fault_localization_provider.h"
 
@@ -29,7 +29,7 @@ public:
     const optionst &options,
     ui_message_handlert &ui_message_handler,
     const symex_target_equationt &equation,
-    prop_convt &solver);
+    stack_decision_proceduret &solver);
 
   fault_location_infot operator()(const irep_idt &failed_property_id);
 
@@ -37,10 +37,10 @@ protected:
   const optionst &options;
   ui_message_handlert &ui_message_handler;
   const symex_target_equationt &equation;
-  prop_convt &solver;
+  stack_decision_proceduret &solver;
 
   /// A localization point is a goto instruction that is potentially at fault
-  typedef std::map<literalt, fault_location_infot::score_mapt::iterator>
+  typedef std::map<exprt, fault_location_infot::score_mapt::iterator>
     localization_pointst;
 
   /// Collects the guards as \p localization_points up to \p failed_property_id

--- a/src/goto-checker/goto_symex_property_decider.h
+++ b/src/goto-checker/goto_symex_property_decider.h
@@ -37,10 +37,6 @@ public:
   /// Convert the instances of a property into a goal variable
   void convert_goals();
 
-  /// Prevent the solver to optimize-away the goal variables
-  /// (necessary for incremental solving)
-  void freeze_goal_variables();
-
   /// Add disjunction of negated selected properties to the equation
   void add_constraint_from_goals(
     std::function<bool(const irep_idt &property_id)> select_property);

--- a/src/solvers/prop/prop_conv.cpp
+++ b/src/solvers/prop/prop_conv.cpp
@@ -7,14 +7,3 @@ Author: Daniel Kroening, kroening@kroening.com
 \*******************************************************************/
 
 #include "prop_conv.h"
-
-#include "literal_expr.h"
-
-#include <util/std_expr.h>
-
-#include <algorithm>
-
-void prop_convt::set_assumptions(const bvt &)
-{
-  UNREACHABLE;
-}

--- a/src/solvers/prop/prop_conv.h
+++ b/src/solvers/prop/prop_conv.h
@@ -10,21 +10,18 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_SOLVERS_PROP_PROP_CONV_H
 #define CPROVER_SOLVERS_PROP_PROP_CONV_H
 
-#include <solvers/decision_procedure.h>
+#include <solvers/stack_decision_procedure.h>
 
-#include "literal.h"
-
+class literalt;
 class tvt;
 
 // API that provides a "handle" in the form of a literalt
 // for expressions.
 
-class prop_convt:public decision_proceduret
+class prop_convt : public stack_decision_proceduret
 {
 public:
   virtual ~prop_convt() { }
-
-  using decision_proceduret::operator();
 
   /// Convert a Boolean expression and return the corresponding literal
   virtual literalt convert(const exprt &expr) = 0;
@@ -32,10 +29,6 @@ public:
   /// Return value of literal \p l from satisfying assignment.
   /// Return tvt::UNKNOWN if not available
   virtual tvt l_get(literalt l) const = 0;
-
-  // incremental solving
-  virtual void set_assumptions(const bvt &_assumptions);
-  virtual bool has_set_assumptions() const { return false; }
 };
 
 #endif // CPROVER_SOLVERS_PROP_PROP_CONV_H

--- a/src/solvers/prop/prop_minimize.cpp
+++ b/src/solvers/prop/prop_minimize.cpp
@@ -95,9 +95,6 @@ literalt prop_minimizet::constraint()
 /// Try to cover all objectives
 void prop_minimizet::operator()()
 {
-  // we need to use assumptions
-  PRECONDITION(prop_conv.has_set_assumptions());
-
   _iterations = 0;
   _number_satisfied = 0;
   _value = 0;
@@ -120,9 +117,7 @@ void prop_minimizet::operator()()
       {
         _iterations++;
 
-        bvt assumptions;
-        assumptions.push_back(c);
-        prop_conv.set_assumptions(assumptions);
+        prop_conv.push({literal_exprt{c}});
         dec_result = prop_conv();
 
         switch(dec_result)
@@ -150,8 +145,7 @@ void prop_minimizet::operator()()
     // We don't have a satisfying assignment to work with.
     // Run solver again to get one.
 
-    bvt assumptions; // no assumptions
-    prop_conv.set_assumptions(assumptions);
+    prop_conv.pop();
     (void)prop_conv();
   }
 }

--- a/src/solvers/prop/prop_minimize.h
+++ b/src/solvers/prop/prop_minimize.h
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/message.h>
 
+#include "literal.h"
 #include "prop_conv.h"
 
 /// Computes a satisfying assignment of minimal cost according to a const

--- a/src/solvers/refinement/bv_refinement.h
+++ b/src/solvers/refinement/bv_refinement.h
@@ -57,8 +57,6 @@ protected:
   bvt convert_mod(const mod_exprt &expr) override;
   bvt convert_floatbv_op(const exprt &expr) override;
 
-  void set_assumptions(const bvt &_assumptions) override;
-
 private:
   // the list of operator approximations
   struct approximationt final
@@ -78,8 +76,8 @@ private:
     bvt op0_bv, op1_bv, op2_bv, result_bv;
     mp_integer op0_value, op1_value, op2_value, result_value;
 
-    bvt under_assumptions;
-    bvt over_assumptions;
+    std::vector<exprt> under_assumptions;
+    std::vector<exprt> over_assumptions;
 
     // the kind of under- or over-approximation
     unsigned under_state, over_state;
@@ -108,7 +106,7 @@ private:
 
   bool progress;
   std::list<approximationt> approximations;
-  bvt parent_assumptions;
+
 protected:
   // use gui format
   configt config_;

--- a/src/solvers/refinement/bv_refinement_loop.cpp
+++ b/src/solvers/refinement/bv_refinement_loop.cpp
@@ -87,7 +87,7 @@ decision_proceduret::resultt bv_refinementt::dec_solve()
 decision_proceduret::resultt bv_refinementt::prop_solve()
 {
   // this puts the underapproximations into effect
-  bvt assumptions=parent_assumptions;
+  std::vector<exprt> assumptions;
 
   for(const approximationt &approximation : approximations)
   {
@@ -101,9 +101,9 @@ decision_proceduret::resultt bv_refinementt::prop_solve()
       approximation.under_assumptions.end());
   }
 
-  prop.set_assumptions(assumptions);
+  push(assumptions);
   propt::resultt result=prop.prop_solve();
-  prop.set_assumptions(parent_assumptions);
+  pop();
 
   switch(result)
   {
@@ -131,10 +131,4 @@ void bv_refinementt::check_UNSAT()
 
   for(approximationt &approximation : this->approximations)
     check_UNSAT(approximation);
-}
-
-void bv_refinementt::set_assumptions(const bvt &_assumptions)
-{
-  parent_assumptions=_assumptions;
-  prop.set_assumptions(_assumptions);
 }

--- a/src/solvers/refinement/refine_arithmetic.cpp
+++ b/src/solvers/refinement/refine_arithmetic.cpp
@@ -23,14 +23,14 @@ void bv_refinementt::approximationt::add_over_assumption(literalt l)
 {
   // if it's a constant already, give up
   if(!l.is_constant())
-    over_assumptions.push_back(l);
+    over_assumptions.push_back(literal_exprt(l));
 }
 
 void bv_refinementt::approximationt::add_under_assumption(literalt l)
 {
   // if it's a constant already, give up
   if(!l.is_constant())
-    under_assumptions.push_back(l);
+    under_assumptions.push_back(literal_exprt(l));
 }
 
 bvt bv_refinementt::convert_floatbv_op(const exprt &expr)
@@ -454,8 +454,13 @@ void bv_refinementt::check_UNSAT(approximationt &a)
 bool bv_refinementt::conflicts_with(approximationt &a)
 {
   for(std::size_t i=0; i<a.under_assumptions.size(); i++)
-    if(prop.is_in_conflict(a.under_assumptions[i]))
+  {
+    if(prop.is_in_conflict(
+         to_literal_expr(a.under_assumptions[i]).get_literal()))
+    {
       return true;
+    }
+  }
 
   return false;
 }

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -104,10 +104,10 @@ void smt2_convt::write_footer(std::ostream &os)
   {
     os << "; assumptions\n";
 
-    forall_literals(it, assumptions)
+    for(const auto &assumption : assumptions)
     {
       os << "(assert ";
-      convert_literal(*it);
+      convert_literal(to_literal_expr(assumption).get_literal());
       os << ")"
          << "\n";
     }
@@ -688,6 +688,23 @@ void smt2_convt::convert_literal(const literalt l)
 
     smt2_identifiers.insert("B"+std::to_string(l.var_no()));
   }
+}
+
+void smt2_convt::push()
+{
+  UNIMPLEMENTED;
+}
+
+void smt2_convt::push(const std::vector<exprt> &_assumptions)
+{
+  INVARIANT(assumptions.empty(), "nested contexts are not supported");
+
+  assumptions = _assumptions;
+}
+
+void smt2_convt::pop()
+{
+  assumptions.clear();
 }
 
 std::string smt2_convt::convert_identifier(const irep_idt &identifier)

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -123,10 +123,15 @@ public:
   }
   void print_assignment(std::ostream &out) const override;
   tvt l_get(literalt l) const override;
-  void set_assumptions(const bvt &bv) override
-  {
-    assumptions = bv;
-  }
+
+  /// Unimplemented
+  void push() override;
+
+  /// Currently, only implements a single stack element (no nested contexts)
+  void push(const std::vector<exprt> &_assumptions) override;
+
+  /// Currently, only implements a single stack element (no nested contexts)
+  void pop() override;
 
   void convert_expr(const exprt &);
   void convert_type(const typet &);
@@ -140,7 +145,7 @@ protected:
   std::string benchmark, notes, logic;
   solvert solver;
 
-  bvt assumptions;
+  std::vector<exprt> assumptions;
   boolbv_widtht boolbv_width;
 
   std::size_t number_of_solver_calls = 0;

--- a/src/solvers/smt2/smt2_dec.h
+++ b/src/solvers/smt2/smt2_dec.h
@@ -42,12 +42,6 @@ public:
   resultt dec_solve() override;
   std::string decision_procedure_text() const override;
 
-  // yes, we are incremental!
-  bool has_set_assumptions() const override
-  {
-    return true;
-  }
-
 protected:
   resultt read_result(std::istream &in);
 };

--- a/src/solvers/stack_decision_procedure.h
+++ b/src/solvers/stack_decision_procedure.h
@@ -1,0 +1,81 @@
+/*******************************************************************\
+
+Module: Decision procedure with incremental solving with contexts
+        and assumptions
+
+Author: Peter Schrammel
+
+\*******************************************************************/
+
+/// \file
+/// Decision procedure with incremental solving with contexts
+/// and assumptions
+///
+/// Normally, solvers allow you only to add new conjuncts to the
+/// formula, but not to remove parts of the formula once added.
+///
+/// Solvers that offer pushing/popping of contexts or
+/// 'solving under assumptions' offer some ways to emulate
+/// removing parts of the formula.
+///
+/// Example 1: push/pop contexts:
+/// \code{.cpp}
+/// dp.set_to_true(a);     // added permanently
+/// resultt result = dp(); // solves formula 'a'
+/// stack_decision_procedure.set_to_true(b); // added permanently
+/// resultt result = dp(); // solves 'a && b'
+/// dp.push();
+/// dp.set_to_true(c);     // added inside a context: we can remove it later
+/// resultt result = dp(); // solves 'a && b && c'
+/// dp.pop();              // 'removes' c
+/// dp.push();
+/// dp.set_to_true(d);     // added inside a context: we can remove it later
+/// resultt result = dp(); // solves 'a && b && d'
+/// \endcode
+///
+/// Example 2: solving under assumptions:
+/// \code{.cpp}
+/// dp.set_to_true(a);     // added permanently
+/// resultt result = dp(); // solves formula 'a'
+/// h1 = dp.handle(c);
+/// h2 = dp.handle(d)
+/// dp.push({h1, h2});
+/// resultt result = dp(); // solves formula 'a && c && d'
+/// dp.pop();              // clear assumptions h1, h2
+/// h1 = dp.handle(not_exprt(c)); // get negated handle for 'c'
+/// dp.push({h1, h2});
+/// resultt result = dp(); // solves formula 'a && !c && d'
+/// \endcode
+
+#ifndef CPROVER_SOLVERS_STACK_DECISION_PROCEDURE_H
+#define CPROVER_SOLVERS_STACK_DECISION_PROCEDURE_H
+
+#include <vector>
+
+#include "decision_procedure.h"
+
+class stack_decision_proceduret : public decision_proceduret
+{
+public:
+  /// Pushes a new context on the stack that consists of the given
+  /// (possibly empty vector of) \p assumptions.
+  /// This context becomes a child context nested in the current context.
+  /// An assumption is usually obtained by calling
+  /// `decision_proceduret::handle`. Thus it can be a Boolean expression or
+  /// something more solver-specific such as `literal_exprt`.
+  /// An empty vector of assumptions counts as an element on the stack
+  /// (and therefore needs to be popped), but has no effect beyond that.
+  virtual void push(const std::vector<exprt> &assumptions) = 0;
+
+  /// Push a new context on the stack
+  /// This context becomes a child context nested in the current context.
+  virtual void push() = 0;
+
+  /// Pop whatever is on top of the stack.
+  /// Popping from the empty stack results in an invariant violation.
+  virtual void pop() = 0;
+
+  virtual ~stack_decision_proceduret() = default;
+};
+
+#endif // CPROVER_SOLVERS_STACK_DECISION_PROCEDURE_H


### PR DESCRIPTION
Replaces #4451 and #4054 

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
