### PR TITLE
Make sharing map iteration independent of tree depth

### DIFF
--- a/src/util/sharing_map.h
+++ b/src/util/sharing_map.h
@@ -530,6 +530,11 @@ protected:
 
   void gather_all(const innert &n, delta_viewt &delta_view) const;
 
+  bool is_singular(const leaf_listt &ll) const
+  {
+    return !ll.empty() && std::next(ll.begin()) == ll.end();
+  }
+
   std::size_t count_unmarked_nodes(
     bool leafs_only,
     std::set<const void *> &marked,
@@ -787,7 +792,7 @@ SHARING_MAPT(void)
     return;
   }
 
-  typedef std::tuple<unsigned, const baset *, const baset *> stack_itemt;
+  typedef std::pair<const innert *, const innert *> stack_itemt;
   std::stack<stack_itemt> stack;
 
   // We do a DFS "in lockstep" simultaneously on both maps. For
@@ -797,70 +802,105 @@ SHARING_MAPT(void)
   // The stack contains the children of already visited nodes that we
   // still have to visit during the traversal.
 
-  stack.push(stack_itemt(0, &map, &other.map));
+  if(map.shares_with(other.map))
+    return;
+
+  stack.push(stack_itemt(&map, &other.map));
 
   do
   {
     const stack_itemt &si = stack.top();
 
-    const unsigned depth = std::get<0>(si);
-    const baset *bp1 = std::get<1>(si);
-    const baset *bp2 = std::get<2>(si);
+    const innert *ip1 = si.first;
+    const innert *ip2 = si.second;
 
     stack.pop();
 
-    if(depth < steps) // internal
+    SM_ASSERT(!ip1->empty());
+    SM_ASSERT(!ip2->empty());
+
+    if(ip1->is_internal() && ip2->is_container())
     {
-      const innert *ip1 = static_cast<const innert *>(bp1);
-      const innert *ip2 = static_cast<const innert *>(bp2);
+      // The container *ip2 contains one element as only containers at the
+      // bottom of the tree can have more than one element. This happens when
+      // two different keys have the same hash code. It is known here that *ip2
+      // is not at the bottom of the tree, as *ip1 (the corresponding node in
+      // the other map) is an internal node, and internal nodes cannot be at the
+      // bottom of the map.
+      SM_ASSERT(is_singular(ip2->get_container()));
 
-      const to_mapt &m = ip1->get_to_map();
-
-      for(const auto &item : m)
+      for(const auto &item : ip1->get_to_map())
       {
-        const innert *p;
+        const innert &child = item.second;
+        SM_ASSERT(!child.shares_with(*ip2));
+        stack.push(stack_itemt(&child, ip2));
+      }
 
+      continue;
+    }
+
+    if(ip1->is_internal())
+    {
+      SM_ASSERT(ip2->is_internal());
+
+      for(const auto &item : ip1->get_to_map())
+      {
+        const innert &child = item.second;
+
+        const innert *p;
         p = ip2->find_child(item.first);
-        if(p==nullptr)
+
+        if(p == nullptr)
         {
           if(!only_common)
           {
-            gather_all(item.second, delta_view);
+            gather_all(child, delta_view);
           }
         }
-        else if(!item.second.shares_with(*p))
+        else if(!child.shares_with(*p))
         {
-          stack.push(stack_itemt(depth + 1, &item.second, p));
+          stack.push(stack_itemt(&child, p));
         }
       }
+
+      continue;
     }
-    else // container
+
+    SM_ASSERT(ip1->is_container());
+
+    if(ip2->is_internal())
     {
-      SM_ASSERT(depth == steps);
+      SM_ASSERT(is_singular(ip1->get_container()));
 
-      const innert *cp1 = static_cast<const innert *>(bp1);
-      const innert *cp2 = static_cast<const innert *>(bp2);
-
-      const leaf_listt &ll1 = cp1->get_container();
-
-      for(const auto &l1 : ll1)
+      for(const auto &item : ip2->get_to_map())
       {
-        const key_type &k1=l1.get_key();
-        const leaft *p;
+        const innert &child = item.second;
+        SM_ASSERT(!ip1->shares_with(child));
+        stack.push(stack_itemt(ip1, &child));
+      }
 
-        p = cp2->find_leaf(k1);
+      continue;
+    }
 
-        if(p != nullptr)
+    SM_ASSERT(ip2->is_container());
+
+    for(const auto &l1 : ip1->get_container())
+    {
+      const key_type &k1 = l1.get_key();
+      const leaft *p;
+
+      p = ip2->find_leaf(k1);
+
+      if(p != nullptr)
+      {
+        if(!l1.shares_with(*p))
         {
-          if(!l1.shares_with(*p))
-          {
-            delta_view.push_back({true, k1, l1.get_value(), p->get_value()});
-          }
+          delta_view.push_back({true, k1, l1.get_value(), p->get_value()});
         }
-        else if(!only_common)
-        {
-          delta_view.push_back({false, l1.get_key(), l1.get_value(), dummy});
-        }
+      }
+      else if(!only_common)
+      {
+        delta_view.push_back({false, l1.get_key(), l1.get_value(), dummy});
       }
     }
   }

--- a/src/util/sharing_map.h
+++ b/src/util/sharing_map.h
@@ -894,6 +894,8 @@ SHARING_MAPT2(, innert *)::get_container_node(const key_type &k)
     key >>= chunk;
   }
 
+  SM_ASSERT(ip->is_container());
+
   return ip;
 }
 
@@ -915,6 +917,8 @@ SHARING_MAPT2(const, innert *)::get_container_node(const key_type &k) const
 
     key >>= chunk;
   }
+
+  SM_ASSERT(ip->is_defined_container());
 
   return ip;
 }

--- a/src/util/sharing_map.h
+++ b/src/util/sharing_map.h
@@ -610,23 +610,15 @@ SHARING_MAPT(std::size_t)
 
   unsigned count = 0;
 
-  // depth, node pointer
-  typedef std::pair<unsigned, const baset *> stack_itemt;
-
-  std::stack<stack_itemt> stack;
-  stack.push({0, &map});
+  std::stack<const innert *> stack;
+  stack.push(&map);
 
   do
   {
-    const stack_itemt &si = stack.top();
-
-    const unsigned depth = si.first;
-    const baset *bp = si.second;
-
+    const innert *ip = stack.top();
     stack.pop();
 
     // internal node or container node
-    const innert *ip = static_cast<const innert *>(bp);
     const unsigned use_count = ip->use_count();
     const void *raw_ptr = ip->is_internal()
                             ? (const void *)&ip->read_internal()
@@ -650,20 +642,22 @@ SHARING_MAPT(std::size_t)
       count++;
     }
 
-    if(depth < steps) // internal
+    if(ip->is_internal())
     {
+      SM_ASSERT(!ip->empty());
+
       const to_mapt &m = ip->get_to_map();
       SM_ASSERT(!m.empty());
 
       for(const auto &item : m)
       {
         const innert *i = &item.second;
-        stack.push({depth + 1, i});
+        stack.push(i);
       }
     }
-    else // container
+    else
     {
-      SM_ASSERT(depth == steps);
+      SM_ASSERT(ip->is_defined_container());
 
       const leaf_listt &ll = ip->get_container();
       SM_ASSERT(!ll.empty());

--- a/src/util/sharing_node.h
+++ b/src/util/sharing_node.h
@@ -163,6 +163,16 @@ public:
     return data.is_derived_v();
   }
 
+  bool is_defined_internal() const
+  {
+    return !empty() && is_internal();
+  }
+
+  bool is_defined_container() const
+  {
+    return !empty() && is_container();
+  }
+
   const d_it &read_internal() const
   {
     SN_ASSERT(!empty());

--- a/unit/util/sharing_map.cpp
+++ b/unit/util/sharing_map.cpp
@@ -378,6 +378,9 @@ TEST_CASE("Sharing map views and iteration", "[core][util]")
   SECTION("Iterate")
   {
     sharing_map_standardt sm;
+
+    sm.iterate([](const irep_idt &key, const std::string &value) {});
+
     fill(sm);
 
     typedef std::pair<std::string, std::string> pt;
@@ -392,6 +395,23 @@ TEST_CASE("Sharing map views and iteration", "[core][util]")
     REQUIRE((pairs[0] == pt("i", "0")));
     REQUIRE((pairs[1] == pt("j", "1")));
     REQUIRE((pairs[2] == pt("k", "2")));
+  }
+
+  SECTION("Delta view (one empty)")
+  {
+    sharing_map_standardt sm1;
+    fill(sm1);
+
+    sharing_map_standardt sm2;
+
+    sharing_map_standardt::delta_viewt delta_view;
+
+    sm1.get_delta_view(sm2, delta_view, false);
+    REQUIRE(delta_view.size() == 3);
+
+    delta_view.clear();
+    sm2.get_delta_view(sm1, delta_view, false);
+    REQUIRE(delta_view.empty());
   }
 
   SECTION("Delta view (no sharing, same keys)")


### PR DESCRIPTION
This makes the various methods that iterate over a sharing map independent of the depth of the nodes in the tree. This is in preparation to support variable height trees.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
