### PR TITLE
remove -y bison option

### DIFF
--- a/src/common
+++ b/src/common
@@ -85,7 +85,7 @@ else
   endif
 endif
 ifeq ($(origin YACC),default)
-  YACC   = bison -y
+  YACC   = bison
 endif
   YFLAGS ?= -v
 ifeq ($(origin LEX),default)


### PR DESCRIPTION
We use a lot of non-POSIX commands in all our .y files (say %expect); the -y
option triggers a lot of warnings about these.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
