### PR TITLE
Clean up smt2_conv

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -42,6 +42,70 @@ Author: Daniel Kroening, kroening@kroening.com
 // General todos
 #define SMT2_TODO(S) PRECONDITION_WITH_DIAGNOSTICS(false, "TODO: " S)
 
+smt2_convt::smt2_convt(
+  const namespacet &_ns,
+  const std::string &_benchmark,
+  const std::string &_notes,
+  const std::string &_logic,
+  solvert _solver,
+  std::ostream &_out)
+  : use_FPA_theory(false),
+    use_datatypes(false),
+    use_array_of_bool(false),
+    emit_set_logic(true),
+    ns(_ns),
+    out(_out),
+    benchmark(_benchmark),
+    notes(_notes),
+    logic(_logic),
+    solver(_solver),
+    boolbv_width(_ns),
+    pointer_logic(_ns),
+    no_boolean_variables(0)
+{
+  // We set some defaults differently
+  // for some solvers.
+
+  switch(solver)
+  {
+  case solvert::GENERIC:
+    break;
+
+  case solvert::BOOLECTOR:
+    break;
+
+  case solvert::CPROVER_SMT2:
+    use_array_of_bool = true;
+    emit_set_logic = false;
+    break;
+
+  case solvert::CVC3:
+    break;
+
+  case solvert::CVC4:
+    break;
+
+  case solvert::MATHSAT:
+    break;
+
+  case solvert::YICES:
+    break;
+
+  case solvert::Z3:
+    use_array_of_bool = true;
+    emit_set_logic = false;
+    use_datatypes = true;
+    break;
+  }
+
+  write_header();
+}
+
+std::string smt2_convt::decision_procedure_text() const
+{
+  return "SMT2";
+}
+
 void smt2_convt::print_assignment(std::ostream &os) const
 {
   // Boolean stuff

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -52,61 +52,9 @@ public:
     const std::string &_notes,
     const std::string &_logic,
     solvert _solver,
-    std::ostream &_out)
-    : use_FPA_theory(false),
-      use_datatypes(false),
-      use_array_of_bool(false),
-      emit_set_logic(true),
-      ns(_ns),
-      out(_out),
-      benchmark(_benchmark),
-      notes(_notes),
-      logic(_logic),
-      solver(_solver),
-      boolbv_width(_ns),
-      pointer_logic(_ns),
-      no_boolean_variables(0)
-  {
-    // We set some defaults differently
-    // for some solvers.
-
-    switch(solver)
-    {
-    case solvert::GENERIC:
-      break;
-
-    case solvert::BOOLECTOR:
-      break;
-
-    case solvert::CPROVER_SMT2:
-      use_array_of_bool = true;
-      emit_set_logic = false;
-      break;
-
-    case solvert::CVC3:
-      break;
-
-    case solvert::CVC4:
-      break;
-
-    case solvert::MATHSAT:
-      break;
-
-    case solvert::YICES:
-      break;
-
-    case solvert::Z3:
-      use_array_of_bool=true;
-      emit_set_logic=false;
-      use_datatypes=true;
-      break;
-    }
-
-    write_header();
-  }
+    std::ostream &_out);
 
   ~smt2_convt() override = default;
-  resultt dec_solve() override;
 
   bool use_FPA_theory;
   bool use_datatypes;
@@ -116,10 +64,7 @@ public:
   exprt handle(const exprt &expr) override;
   void set_to(const exprt &expr, bool value) override;
   exprt get(const exprt &expr) const override;
-  std::string decision_procedure_text() const override
-  {
-    return "SMT2";
-  }
+  std::string decision_procedure_text() const override;
   void print_assignment(std::ostream &out) const override;
 
   /// Unimplemented
@@ -130,10 +75,6 @@ public:
 
   /// Currently, only implements a single stack element (no nested contexts)
   void pop() override;
-
-  void convert_expr(const exprt &);
-  void convert_type(const typet &);
-  void convert_literal(const literalt);
 
   std::size_t get_number_of_solver_calls() const override;
 
@@ -147,6 +88,8 @@ protected:
   boolbv_widtht boolbv_width;
 
   std::size_t number_of_solver_calls = 0;
+
+  resultt dec_solve() override;
 
   void write_header();
   void write_footer(std::ostream &);
@@ -180,6 +123,10 @@ protected:
   void convert_update(const exprt &expr);
 
   std::string convert_identifier(const irep_idt &identifier);
+
+  void convert_expr(const exprt &);
+  void convert_type(const typet &);
+  void convert_literal(const literalt);
 
   literalt convert(const exprt &expr);
   tvt l_get(literalt l) const;

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -31,7 +31,7 @@ class constant_exprt;
 class index_exprt;
 class member_exprt;
 
-class smt2_convt:public prop_convt
+class smt2_convt : public stack_decision_proceduret
 {
 public:
   enum class solvert
@@ -114,7 +114,6 @@ public:
   bool emit_set_logic;
 
   exprt handle(const exprt &expr) override;
-  literalt convert(const exprt &expr) override;
   void set_to(const exprt &expr, bool value) override;
   exprt get(const exprt &expr) const override;
   std::string decision_procedure_text() const override
@@ -122,7 +121,6 @@ public:
     return "SMT2";
   }
   void print_assignment(std::ostream &out) const override;
-  tvt l_get(literalt l) const override;
 
   /// Unimplemented
   void push() override;
@@ -182,6 +180,9 @@ protected:
   void convert_update(const exprt &expr);
 
   std::string convert_identifier(const irep_idt &identifier);
+
+  literalt convert(const exprt &expr);
+  tvt l_get(literalt l) const;
 
   // auxiliary methods
   exprt prepare_for_convert_expr(const exprt &expr);


### PR DESCRIPTION
- inherit directly from `stack_decision_proceduret` instead of `prop_convt`
- make methods protected that need not be public

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
