### PR TITLE
Implement parsing of hexadecimal Unicode characters from JSON

### DIFF
--- a/src/json/parser.y
+++ b/src/json/parser.y
@@ -46,8 +46,15 @@ static std::string convert_TOK_STRING()
       case 'r':  result+='\r'; break;
       case 't':  result+='\t'; break;
       case 'u':
+      {
+        // Character in hexadecimal Unicode representation, in the format
+        // \uABCD, i.e. the following four digits are part of this character.
+        assert(p + 4 < yyjsontext + len - 1);
+        std::string hex(++p, 4);
+        result += std::stoi(hex, nullptr, 16);
+        p += 3;
         break;
-        
+      }
       default:; /* an error */
       }
     }

--- a/unit/json/json_parser.cpp
+++ b/unit/json/json_parser.cpp
@@ -84,4 +84,31 @@ SCENARIO("Loading JSON files")
       }
     }
   }
+  GIVEN("A JSON file containing a hexadecimal Unicode character")
+  {
+    temporary_filet unicode_json_file("cbmc_unit_json_parser_unicode", ".json");
+    const std::string unicode_json_path = unicode_json_file();
+    {
+      std::ofstream unicode_json_out(unicode_json_path);
+      unicode_json_out << "{\n"
+                       << "  \"special character\": \"\\u0001\"\n"
+                       << "}\n";
+    }
+    WHEN("Loading the JSON file with the special character")
+    {
+      jsont unicode_json;
+      const auto unicode_parse_error =
+        parse_json(unicode_json_path, null_message_handler, unicode_json);
+      THEN("The JSON file should be parsed correctly")
+      {
+        REQUIRE_FALSE(unicode_parse_error);
+        REQUIRE(unicode_json.is_object());
+
+        const json_objectt &json_object = to_json_object(unicode_json);
+        REQUIRE(json_object.find("special character") != json_object.end());
+        REQUIRE(json_object["special character"].value.size() == 1);
+        REQUIRE(json_object["special character"].value == "\u0001");
+      }
+    }
+  }
 }


### PR DESCRIPTION
Previously, if a JSON file contained a string in hexadecimal Unicode representation, e.g. "\u0001", the JSON parser would discard the "\u" part and store the string as (the four-character string) "0001". This PR fixes this so the resulting string is equal to (the one-character string) "\u0001".

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
