### PR TITLE
Add symex debugging print-out

### DIFF
--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -113,6 +113,7 @@ void jbmc_parse_optionst::set_default_options(optionst &options)
   options.set_option("simple-slice", true);
   options.set_option("simplify", true);
   options.set_option("simplify-if", true);
+  options.set_option("show-goto-symex-steps", false);
 
   // Other default
   options.set_option("arrays-uf", "auto");
@@ -415,6 +416,9 @@ void jbmc_parse_optionst::get_command_line_options(optionst &options)
   // code.
   if(cmdline.isset("java-threading"))
     options.set_option("allow-pointer-unsoundness", true);
+
+  if(cmdline.isset("show-goto-symex-steps"))
+    options.set_option("show-goto-symex-steps", true);
 }
 
 /// invoke main modules

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -118,6 +118,7 @@ void cbmc_parse_optionst::set_default_options(optionst &options)
   options.set_option("simple-slice", true);
   options.set_option("simplify", true);
   options.set_option("simplify-if", true);
+  options.set_option("show-goto-symex-steps", false);
 
   // Other default
   options.set_option("arrays-uf", "auto");
@@ -441,6 +442,9 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
   {
     options.set_option("validate-goto-model", true);
   }
+
+  if(cmdline.isset("show-goto-symex-steps"))
+    options.set_option("show-goto-symex-steps", true);
 
   PARSE_OPTIONS_GOTO_TRACE(cmdline, options);
 }

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -175,6 +175,7 @@ void run_property_decider(
   "(program-only)" \
   "(show-loops)" \
   "(show-vcc)" \
+  "(show-goto-symex-steps)" \
   "(slice-formula)" \
   "(unwinding-assertions)" \
   "(no-unwinding-assertions)" \
@@ -192,6 +193,8 @@ void run_property_decider(
 #define HELP_BMC \
   " --paths [strategy]           explore paths one at a time\n" \
   " --show-symex-strategies      list strategies for use with --paths\n" \
+  " --show-goto-symex-steps      show which steps symex travels, includes " \
+  "                              diagnostic information\n" \
   " --program-only               only show program expression\n" \
   " --show-loops                 show the loops in the program\n" \
   " --depth nr                   limit search depth\n" \

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -64,6 +64,10 @@ struct symex_configt final
   /// executed in the goto_symex_statet (in the assignment method).
   bool run_validation_checks;
 
+  /// \brief Prints out the path that symex is actively taking during execution,
+  /// includes diagnostic information about call stack and guard size.
+  bool show_symex_steps;
+
   /// \brief Construct a symex_configt using options specified in an
   /// \ref optionst
   explicit symex_configt(const optionst &options);
@@ -223,6 +227,13 @@ protected:
   /// \param state: Symbolic execution state for current instruction
   virtual void
   symex_step(const get_goto_functiont &get_goto_function, statet &state);
+
+  /// Prints the route of symex as it walks through the code. Used for
+  /// debugging.
+  void print_symex_step(statet &state);
+
+  messaget::mstreamt &
+  print_callstack_entry(const symex_targett::sourcet &target);
 
 public:
 

--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -324,6 +324,31 @@ std::ostream &format_rec(std::ostream &os, const exprt &expr)
         os << ' ' << format(s);
       return os << " }";
     }
+    else if(statement == ID_dead)
+    {
+      return os << "dead " << format(to_code_dead(code).symbol()) << ";";
+    }
+    else if(statement == ID_decl)
+    {
+      const auto &declaration_symb = to_code_decl(code).symbol();
+      return os << "decl " << format(declaration_symb.type()) << " "
+                << format(declaration_symb) << ";";
+    }
+    else if(statement == ID_function_call)
+    {
+      const auto &func_call = to_code_function_call(code);
+      os << to_symbol_expr(func_call.function()).get_identifier() << "(";
+
+      // Join all our arguments together.
+      join_strings(
+        os,
+        func_call.arguments().begin(),
+        func_call.arguments().end(),
+        ", ",
+        [](const exprt &expr) { return format(expr); });
+
+      return os << ");";
+    }
     else
       return fallback_format_rec(os, expr);
   }


### PR DESCRIPTION
Adds in debug output for symex to assist in seeing what instructions it's executing and path it's taking. Prints only instructions that get executed, call stack on method call (and partially on a return) and guard size.

The output looks like this:

```
[Guard Size: 1] __CPROVER_initialize();

Call stack:
__CPROVER__start location number: 31
__CPROVER__start location number: 22
__CPROVER_initialize

[Guard Size: 1] __CPROVER_alloca_object = NULL;
[Guard Size: 1] __CPROVER_dead_object = NULL;
[Guard Size: 1] __CPROVER_deallocated = NULL;
[Guard Size: 1] __CPROVER_malloc_is_new_array = 0 ≠ 0;
[Guard Size: 1] __CPROVER_malloc_object = NULL;
[Guard Size: 1] __CPROVER_malloc_size = 0;
[Guard Size: 1] __CPROVER_memory_leak = NULL;
[Guard Size: 1] __CPROVER_next_thread_id = cast(0, unsignedbv[64]);
[Guard Size: 1] __CPROVER_next_thread_key = cast(0, unsignedbv[64]);
[Guard Size: 1] __CPROVER_pipe_count = cast(0, unsignedbv[32]);
[Guard Size: 1] __CPROVER_rounding_mode = 0;
[Guard Size: 1] __CPROVER_thread_id = cast(0, unsignedbv[64]);
[Guard Size: 1] __CPROVER_thread_key_dtors = array_of #source_location=""(NULL);
[Guard Size: 1] __CPROVER_thread_keys = array_of #source_location=""(NULL);
[Guard Size: 1] __CPROVER_threads_exited = array_of #source_location=""(false);
[Guard Size: 1] x = side_effect #source_location="" statement="nondet" is_nondet_nullable="1";

Returning to: __CPROVER__start location number: 22

[Guard Size: 1] code statement="input"(address_of(string_constant value="argc"[0]), argc')
[Guard Size: 1] argv'[argc'] = NULL;
[Guard Size: 1] main(argc', address_of(argv'[0]));

Call stack:
__CPROVER__start location number: 31
__CPROVER__start location number: 27
main

[Guard Size: 1] x = 42;
[Guard Size: 1] main#return_value = side_effect #source_location="" statement="nondet" is_nondet_nullable="1";

Returning to: __CPROVER__start location number: 27

[Guard Size: 1] return' = main#return_value;
[Guard Size: 1] code #source_location="" statement="output"(address_of(string_constant value="return'"[0]), return')

Returning to: __CPROVER__start location number: 31
```

There are some expressions that don't have a nice formatting output but those can be added later as it's still readable, even if not very pretty.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.