### PR TITLE
Add support for all Unicode codepoints of the BMP in the JSON parser [TG-7634]

### DIFF
--- a/src/json/parser.y
+++ b/src/json/parser.y
@@ -51,10 +51,11 @@ static std::string convert_TOK_STRING()
       {
         // Character in hexadecimal Unicode representation, in the format
         // \uABCD, i.e. the following four digits are part of this character.
-        assert(p + 4 < yyjsontext + len - 1);
+        char *last_hex_digit = p + 4;
+        assert(last_hex_digit < yyjsontext + len - 1);
         std::string hex(++p, 4);
         result += codepoint_hex_to_utf8(hex);
-        p += 3;
+        p = last_hex_digit;
         break;
       }
       default:; /* an error */

--- a/src/json/parser.y
+++ b/src/json/parser.y
@@ -18,6 +18,8 @@
 %{
 #include "json_parser.h"
 
+#include <util/unicode.h>
+
 int yyjsonlex();
 extern char *yyjsontext;
 extern int yyjsonleng; // really an int, not a size_t
@@ -51,7 +53,7 @@ static std::string convert_TOK_STRING()
         // \uABCD, i.e. the following four digits are part of this character.
         assert(p + 4 < yyjsontext + len - 1);
         std::string hex(++p, 4);
-        result += std::stoi(hex, nullptr, 16);
+        result += codepoint_hex_to_utf8(hex);
         p += 3;
         break;
       }

--- a/src/util/unicode.h
+++ b/src/util/unicode.h
@@ -31,6 +31,26 @@ std::string utf16_native_endian_to_java(const std::wstring &in);
 
 std::vector<std::string> narrow_argv(int argc, const wchar_t **argv_wide);
 
+/// \param utf16_char: UTF-16 character in architecture-native endianness
+///   encoding
+/// \return UTF-8 encoding of the same codepoint
+std::string utf16_native_endian_to_utf8(char16_t utf16_char);
+
+/// \param utf16_str: UTF-16 string in architecture-native endianness encoding
+/// \return UTF-8 encoding of the string
+std::string utf16_native_endian_to_utf8(const std::u16string &utf16_str);
+
+/// \param hex: representation of a BMP codepoint as a four-digit string
+///   (e.g.\ "0041" for \\u0041)
+/// \return encoding of the codepoint as a single UTF-16 character in
+///   architecture-native endianness encoding
+char16_t codepoint_hex_to_utf16_native_endian(const std::string &hex);
+
+/// \param hex: representation of a BMP codepoint as a four-digit string
+///   (e.g.\ "0041" for \\u0041)
+/// \return UTF-8 encoding of the codepoint
+std::string codepoint_hex_to_utf8(const std::string &hex);
+
 template <typename It>
 std::vector<const char *> to_c_str_array(It b, It e)
 {

--- a/unit/json/json_parser.cpp
+++ b/unit/json/json_parser.cpp
@@ -84,17 +84,22 @@ SCENARIO("Loading JSON files")
       }
     }
   }
-  GIVEN("A JSON file containing a hexadecimal Unicode character")
+  GIVEN("A JSON file containing hexadecimal Unicode symbols")
   {
     temporary_filet unicode_json_file("cbmc_unit_json_parser_unicode", ".json");
     const std::string unicode_json_path = unicode_json_file();
     {
       std::ofstream unicode_json_out(unicode_json_path);
       unicode_json_out << "{\n"
-                       << "  \"special character\": \"\\u0001\"\n"
+                       << "  \"one\": \"\\u0001\",\n"
+                       << "  \"latin\": \"\\u0042\",\n"
+                       << "  \"grave\": \"\\u00E0\",\n"
+                       << "  \"trema\": \"\\u00FF\",\n"
+                       << "  \"high\": \"\\uFFFF\",\n"
+                       << "  \"several\": \"a\\u0041b\\u2FC3\\uFFFF\"\n"
                        << "}\n";
     }
-    WHEN("Loading the JSON file with the special character")
+    WHEN("Loading the JSON file with the Unicode symbols")
     {
       jsont unicode_json;
       const auto unicode_parse_error =
@@ -105,9 +110,25 @@ SCENARIO("Loading JSON files")
         REQUIRE(unicode_json.is_object());
 
         const json_objectt &json_object = to_json_object(unicode_json);
-        REQUIRE(json_object.find("special character") != json_object.end());
-        REQUIRE(json_object["special character"].value.size() == 1);
-        REQUIRE(json_object["special character"].value == "\u0001");
+
+        REQUIRE(json_object.find("one") != json_object.end());
+        REQUIRE(json_object["one"].value.size() == 1);
+        REQUIRE(json_object["one"].value == u8"\u0001");
+
+        REQUIRE(json_object.find("latin") != json_object.end());
+        REQUIRE(json_object["latin"].value == "B");
+
+        REQUIRE(json_object.find("grave") != json_object.end());
+        REQUIRE(json_object["grave"].value == "à");
+
+        REQUIRE(json_object.find("trema") != json_object.end());
+        REQUIRE(json_object["trema"].value == "ÿ");
+
+        REQUIRE(json_object.find("high") != json_object.end());
+        REQUIRE(json_object["high"].value == u8"\uFFFF");
+
+        REQUIRE(json_object.find("several") != json_object.end());
+        REQUIRE(json_object["several"].value == u8"aAb\u2FC3\uFFFF");
       }
     }
   }


### PR DESCRIPTION
This is a follow-up PR to https://github.com/diffblue/cbmc/pull/4590, which implemented support in the JSON parser for hexadecimal Unicode representations (`\uABCD`) but was limited to codepoints <= `0x7f` (with values from `0x80` to `0xff` also sort of working, representing them as integers rather than characters).
This improved implementation supports all values from `\u0000` to `\uFFFF`, i.e. all codepoints in the BMP.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
