### PR TITLE
field_sensitivityt::apply does not take a reference

### DIFF
--- a/src/goto-symex/field_sensitivity.h
+++ b/src/goto-symex/field_sensitivity.h
@@ -45,11 +45,11 @@ public:
   /// existing member or index expressions into symbols are performed.
   /// \param ns: a namespace to resolve type symbols/tag types
   /// \param [in,out] state: symbolic execution state
-  /// \param [in,out] expr: an expression to be (recursively) transformed - this
-  ///   parameter is both input and output.
+  /// \param expr: an expression to be (recursively) transformed.
   /// \param write: set to true if the expression is to be used as an lvalue.
-  void
-  apply(const namespacet &ns, goto_symex_statet &state, exprt &expr, bool write)
+  /// \return the transformed expression
+  exprt
+  apply(const namespacet &ns, goto_symex_statet &state, exprt expr, bool write)
     const;
 
   /// Compute an expression representing the individual components of a

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -337,7 +337,7 @@ goto_symex_statet::rename(exprt expr, const namespacet &ns)
       "if_exprt");
 
     if(level == L2)
-      field_sensitivity.apply(ns, *this, expr, false);
+      expr = field_sensitivity.apply(ns, *this, std::move(expr), false);
 
     return renamedt<exprt, level>{std::move(expr)};
   }

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -271,7 +271,8 @@ static void rewrite_with_to_field_symbols(
         with_expr.new_value().type());
     }
 
-    state.field_sensitivity.apply(ns, state, field_sensitive_lhs, true);
+    field_sensitive_lhs = state.field_sensitivity.apply(
+      ns, state, std::move(field_sensitive_lhs), true);
 
     if(field_sensitive_lhs.id() != ID_symbol)
       break;
@@ -392,8 +393,8 @@ void goto_symext::symex_assign_from_struct(
   for(std::size_t i = 0; i < components.size(); ++i)
   {
     const auto &comp = components[i];
-    exprt lhs_field = member_exprt(lhs, comp.get_name(), comp.type());
-    state.field_sensitivity.apply(ns, state, lhs_field, true);
+    const exprt lhs_field = state.field_sensitivity.apply(
+      ns, state, member_exprt{lhs, comp.get_name(), comp.type()}, true);
     INVARIANT(
       lhs_field.id() == ID_symbol,
       "member of symbol should be susceptible to field-sensitivity");

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -244,7 +244,7 @@ void goto_symext::dereference_rec(exprt &expr, statet &state, bool write)
 
     // ...and may have introduced a member-of-symbol construct with a
     // corresponding SSA symbol:
-    state.field_sensitivity.apply(ns, state, expr, write);
+    expr = state.field_sensitivity.apply(ns, state, std::move(expr), write);
   }
   else if(
     expr.id() == ID_index && to_index_expr(expr).array().id() == ID_member &&
@@ -359,8 +359,8 @@ void goto_symext::dereference(exprt &expr, statet &state, bool write)
   // from different frames. Would be enough to rename
   // symbols whose address is taken.
   PRECONDITION(!state.call_stack().empty());
-  exprt l1_expr = state.rename<L1>(expr, ns).get();
-  state.field_sensitivity.apply(ns, state, l1_expr, write);
+  exprt l1_expr = state.field_sensitivity.apply(
+    ns, state, state.rename<L1>(expr, ns).get(), write);
 
   // start the recursion!
   dereference_rec(l1_expr, state, write);
@@ -394,5 +394,5 @@ void goto_symext::dereference(exprt &expr, statet &state, bool write)
       "simplify re-introduced dereferencing");
   }
 
-  state.field_sensitivity.apply(ns, state, expr, write);
+  expr = state.field_sensitivity.apply(ns, state, std::move(expr), write);
 }


### PR DESCRIPTION
We make `apply` take the expression by copy and return a transformed one.
This makes it more intuitive to use and avoid problems of the kind:

          index_exprt i;
          apply(ns, s, i, true);
          f_of_index_expr(i);

where in the call to `f_of_index_expr`, `i` is of type `index_exprt` but may not have
`ID_index` thus breaking an invariant which we should intuitively have.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
