### PR TITLE
languaget now needs message_handler during construction

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_language.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_language.cpp
@@ -1183,9 +1183,9 @@ void java_bytecode_languaget::show_parse(std::ostream &out)
   }
 }
 
-std::unique_ptr<languaget> new_java_bytecode_language()
+std::unique_ptr<languaget> new_java_bytecode_language(message_handlert &mh)
 {
-  return util_make_unique<java_bytecode_languaget>();
+  return util_make_unique<java_bytecode_languaget>(mh);
 }
 
 bool java_bytecode_languaget::from_expr(

--- a/jbmc/src/java_bytecode/java_bytecode_language.h
+++ b/jbmc/src/java_bytecode/java_bytecode_language.h
@@ -111,9 +111,12 @@ public:
   void show_parse(std::ostream &out) override;
 
   virtual ~java_bytecode_languaget();
+
   java_bytecode_languaget(
-    std::unique_ptr<select_pointer_typet> pointer_type_selector)
-    : language_options_initialized(false),
+    std::unique_ptr<select_pointer_typet> pointer_type_selector,
+    message_handlert &mh)
+    : languaget(mh),
+      language_options_initialized(false),
       threading_support(false),
       assume_inputs_non_null(false),
       object_factory_parameters(),
@@ -128,9 +131,10 @@ public:
   {
   }
 
-  java_bytecode_languaget():
-    java_bytecode_languaget(
-      std::unique_ptr<select_pointer_typet>(new select_pointer_typet()))
+  explicit java_bytecode_languaget(message_handlert &mh)
+    : java_bytecode_languaget(
+        std::unique_ptr<select_pointer_typet>(new select_pointer_typet()),
+        mh)
   {
   }
 
@@ -151,7 +155,9 @@ public:
     const namespacet &ns) override;
 
   std::unique_ptr<languaget> new_language() override
-  { return util_make_unique<java_bytecode_languaget>(); }
+  {
+    return util_make_unique<java_bytecode_languaget>(get_message_handler());
+  }
 
   std::string id() const override { return "java"; }
   std::string description() const override { return "Java Bytecode"; }
@@ -218,7 +224,7 @@ private:
   std::vector<load_extra_methodst> extra_methods;
 };
 
-std::unique_ptr<languaget> new_java_bytecode_language();
+std::unique_ptr<languaget> new_java_bytecode_language(message_handlert &);
 
 void parse_java_language_options(const cmdlinet &cmd, optionst &options);
 

--- a/src/ansi-c/ansi_c_language.cpp
+++ b/src/ansi-c/ansi_c_language.cpp
@@ -141,9 +141,9 @@ void ansi_c_languaget::show_parse(std::ostream &out)
   parse_tree.output(out);
 }
 
-std::unique_ptr<languaget> new_ansi_c_language()
+std::unique_ptr<languaget> new_ansi_c_language(message_handlert &mh)
 {
-  return util_make_unique<ansi_c_languaget>();
+  return util_make_unique<ansi_c_languaget>(mh);
 }
 
 bool ansi_c_languaget::from_expr(

--- a/src/ansi-c/ansi_c_language.h
+++ b/src/ansi-c/ansi_c_language.h
@@ -70,7 +70,9 @@ public:
   void show_parse(std::ostream &out) override;
 
   ~ansi_c_languaget() override;
-  ansi_c_languaget() { }
+  explicit ansi_c_languaget(message_handlert &mh) : languaget(mh)
+  {
+  }
 
   bool from_expr(
     const exprt &expr,
@@ -94,7 +96,9 @@ public:
     const namespacet &ns) override;
 
   std::unique_ptr<languaget> new_language() override
-  { return util_make_unique<ansi_c_languaget>(); }
+  {
+    return util_make_unique<ansi_c_languaget>(get_message_handler());
+  }
 
   std::string id() const override { return "C"; }
   std::string description() const override { return "ANSI-C 99"; }
@@ -109,6 +113,6 @@ protected:
   c_object_factory_parameterst object_factory_params;
 };
 
-std::unique_ptr<languaget> new_ansi_c_language();
+std::unique_ptr<languaget> new_ansi_c_language(message_handlert &);
 
 #endif // CPROVER_ANSI_C_ANSI_C_LANGUAGE_H

--- a/src/ansi-c/cprover_library.cpp
+++ b/src/ansi-c/cprover_library.cpp
@@ -99,8 +99,7 @@ void add_library(
 
   std::istringstream in(src);
 
-  ansi_c_languaget ansi_c_language;
-  ansi_c_language.set_message_handler(message_handler);
+  ansi_c_languaget ansi_c_language(message_handler);
   ansi_c_language.parse(in, "");
 
   ansi_c_language.typecheck(symbol_table, "<built-in-library>");

--- a/src/cpp/cpp_language.cpp
+++ b/src/cpp/cpp_language.cpp
@@ -195,9 +195,9 @@ void cpp_languaget::show_parse(
     out << "UNKNOWN: " << item.pretty() << '\n';
 }
 
-std::unique_ptr<languaget> new_cpp_language()
+std::unique_ptr<languaget> new_cpp_language(message_handlert &mh)
 {
-  return util_make_unique<cpp_languaget>();
+  return util_make_unique<cpp_languaget>(mh);
 }
 
 bool cpp_languaget::from_expr(

--- a/src/cpp/cpp_language.h
+++ b/src/cpp/cpp_language.h
@@ -55,7 +55,9 @@ public:
 
   // constructor, destructor
   ~cpp_languaget() override;
-  cpp_languaget() { }
+  cpp_languaget(message_handlert &mh) : languaget(mh)
+  {
+  }
 
   // conversion from expression into string
   bool from_expr(
@@ -82,7 +84,9 @@ public:
     const namespacet &ns) override;
 
   std::unique_ptr<languaget> new_language() override
-  { return util_make_unique<cpp_languaget>(); }
+  {
+    return util_make_unique<cpp_languaget>(get_message_handler());
+  }
 
   std::string id() const override { return "cpp"; }
   std::string description() const override { return "C++"; }
@@ -104,6 +108,6 @@ protected:
   }
 };
 
-std::unique_ptr<languaget> new_cpp_language();
+std::unique_ptr<languaget> new_cpp_language(message_handlert &);
 
 #endif // CPROVER_CPP_CPP_LANGUAGE_H

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -1405,13 +1405,17 @@ void dump_c(
   const namespacet &ns,
   std::ostream &out)
 {
+  null_message_handlert mh;
+
   dump_ct goto2c(
     src,
     use_system_headers,
     use_all_headers,
     include_harness,
     ns,
-    new_ansi_c_language);
+    new_ansi_c_language,
+    mh);
+
   out << goto2c;
 }
 
@@ -1423,12 +1427,16 @@ void dump_cpp(
   const namespacet &ns,
   std::ostream &out)
 {
+  null_message_handlert mh;
+
   dump_ct goto2cpp(
     src,
     use_system_headers,
     use_all_headers,
     include_harness,
     ns,
-    new_cpp_language);
+    new_cpp_language,
+    mh);
+
   out << goto2cpp;
 }

--- a/src/goto-instrument/dump_c_class.h
+++ b/src/goto-instrument/dump_c_class.h
@@ -30,13 +30,14 @@ public:
     const bool use_all_headers,
     const bool include_harness,
     const namespacet &_ns,
-    language_factoryt factory):
-    goto_functions(_goto_functions),
-    copied_symbol_table(_ns.get_symbol_table()),
-    ns(copied_symbol_table),
-    language(factory()),
-    harness(include_harness),
-    system_symbols(use_system_headers)
+    language_factoryt factory,
+    message_handlert &mh)
+    : goto_functions(_goto_functions),
+      copied_symbol_table(_ns.get_symbol_table()),
+      ns(copied_symbol_table),
+      language(factory(mh)),
+      harness(include_harness),
+      system_symbols(use_system_headers)
   {
     system_symbols.set_use_all_headers(use_all_headers);
   }

--- a/src/goto-instrument/model_argc_argv.cpp
+++ b/src/goto-instrument/model_argc_argv.cpp
@@ -104,8 +104,7 @@ bool model_argc_argv(
       << "}";
   std::istringstream iss(oss.str());
 
-  ansi_c_languaget ansi_c_language;
-  ansi_c_language.set_message_handler(message_handler);
+  ansi_c_languaget ansi_c_language(message_handler);
   configt::ansi_ct::preprocessort pp=config.ansi_c.preprocessor;
   config.ansi_c.preprocessor=configt::ansi_ct::preprocessort::NONE;
   ansi_c_language.parse(iss, "");

--- a/src/goto-programs/show_symbol_table.cpp
+++ b/src/goto-programs/show_symbol_table.cpp
@@ -250,11 +250,11 @@ static void show_symbol_table_brief_json_ui(
 
     if(symbol.mode.empty())
     {
-      ptr=get_default_language();
+      ptr = get_default_language(message_handler);
     }
     else
     {
-      ptr=get_language_from_mode(symbol.mode);
+      ptr = get_language_from_mode(symbol.mode, message_handler);
     }
 
     if(!ptr)

--- a/src/jsil/jsil_language.cpp
+++ b/src/jsil/jsil_language.cpp
@@ -99,9 +99,9 @@ void jsil_languaget::show_parse(std::ostream &out)
   parse_tree.output(out);
 }
 
-std::unique_ptr<languaget> new_jsil_language()
+std::unique_ptr<languaget> new_jsil_language(message_handlert &mh)
 {
-  return util_make_unique<jsil_languaget>();
+  return util_make_unique<jsil_languaget>(mh);
 }
 
 bool jsil_languaget::from_expr(

--- a/src/jsil/jsil_language.h
+++ b/src/jsil/jsil_language.h
@@ -42,7 +42,9 @@ public:
   virtual void show_parse(std::ostream &out) override;
 
   virtual ~jsil_languaget();
-  jsil_languaget() { }
+  jsil_languaget(message_handlert &mh) : languaget(mh)
+  {
+  }
 
   virtual bool from_expr(
     const exprt &expr,
@@ -61,7 +63,9 @@ public:
     const namespacet &ns) override;
 
   virtual std::unique_ptr<languaget> new_language() override
-  { return util_make_unique<jsil_languaget>(); }
+  {
+    return util_make_unique<jsil_languaget>(get_message_handler());
+  }
 
   virtual std::string id() const override { return "jsil"; }
   virtual std::string description() const override
@@ -76,6 +80,6 @@ protected:
   std::string parse_path;
 };
 
-std::unique_ptr<languaget> new_jsil_language();
+std::unique_ptr<languaget> new_jsil_language(message_handlert &);
 
 #endif // CPROVER_JSIL_JSIL_LANGUAGE_H

--- a/src/json-symtab-language/json_symtab_language.h
+++ b/src/json-symtab-language/json_symtab_language.h
@@ -52,7 +52,7 @@ public:
 
   std::unique_ptr<languaget> new_language() override
   {
-    return util_make_unique<json_symtab_languaget>();
+    return util_make_unique<json_symtab_languaget>(get_message_handler());
   }
 
   bool generate_support_functions(symbol_tablet &symbol_table) override
@@ -65,14 +65,17 @@ public:
   }
 
   ~json_symtab_languaget() override = default;
+  json_symtab_languaget(message_handlert &mh) : languaget(mh)
+  {
+  }
 
 protected:
   jsont parsed_json_file;
 };
 
-inline std::unique_ptr<languaget> new_json_symtab_language()
+inline std::unique_ptr<languaget> new_json_symtab_language(message_handlert &mh)
 {
-  return util_make_unique<json_symtab_languaget>();
+  return util_make_unique<json_symtab_languaget>(mh);
 }
 
 #endif

--- a/src/langapi/language.cpp
+++ b/src/langapi/language.cpp
@@ -18,6 +18,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/cprover_prefix.h>
 #include <util/std_types.h>
 
+languaget::languaget(message_handlert &message_handler)
+  : messaget(message_handler)
+{
+}
+
 bool languaget::final(symbol_table_baset &)
 {
   return false;

--- a/src/langapi/language.h
+++ b/src/langapi/language.h
@@ -207,8 +207,7 @@ public:
   virtual std::unique_ptr<languaget> new_language()=0;
 
   // constructor / destructor
-
-  languaget() { }
+  explicit languaget(message_handlert &);
   virtual ~languaget() { }
 };
 

--- a/src/langapi/mode.h
+++ b/src/langapi/mode.h
@@ -16,17 +16,27 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 class languaget;
 class namespacet;
+class message_handlert;
 
 std::unique_ptr<languaget> get_language_from_mode(const irep_idt &mode);
-const irep_idt &
-get_mode_from_identifier(const namespacet &ns, const irep_idt &identifier);
 std::unique_ptr<languaget>
-get_language_from_identifier(const namespacet &ns, const irep_idt &identifier);
+get_language_from_mode(const irep_idt &mode, message_handlert &);
+const irep_idt &
+get_mode_from_identifier(const namespacet &, const irep_idt &identifier);
+std::unique_ptr<languaget>
+get_language_from_identifier(const namespacet &, const irep_idt &identifier);
+std::unique_ptr<languaget> get_language_from_identifier(
+  const namespacet &,
+  const irep_idt &identifier,
+  message_handlert &);
 std::unique_ptr<languaget> get_language_from_filename(
   const std::string &filename);
+std::unique_ptr<languaget>
+get_language_from_filename(const std::string &filename, message_handlert &);
 std::unique_ptr<languaget> get_default_language();
+std::unique_ptr<languaget> get_default_language(message_handlert &);
 
-typedef std::unique_ptr<languaget> (*language_factoryt)();
+typedef std::unique_ptr<languaget> (*language_factoryt)(message_handlert &);
 void register_language(language_factoryt factory);
 
 #endif // CPROVER_LANGAPI_MODE_H


### PR DESCRIPTION
This avoids usage of the deprecated `messaget` constructor without message
handler; it is follow-up for #4050.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
