### PR TITLE
Clean-up string solver: refactor binary relations [TG-7439]

### DIFF
--- a/src/solvers/strings/string_constraint_generator_code_points.cpp
+++ b/src/solvers/strings/string_constraint_generator_code_points.cpp
@@ -41,10 +41,10 @@ std::pair<exprt, string_constraintst> add_axioms_for_code_point(
   exprt hex0400 = from_integer(0x0400, type);
 
   binary_relation_exprt small(code_point, ID_lt, hex010000);
-  implies_exprt a1(small, length_eq(res, 1));
+  implies_exprt a1(small, equal_to(res.length(), 1));
   constraints.existential.push_back(a1);
 
-  implies_exprt a2(not_exprt(small), length_eq(res, 2));
+  implies_exprt a2(not_exprt(small), equal_to(res.length(), 2));
   constraints.existential.push_back(a2);
 
   typecast_exprt code_point_as_char(code_point, char_type);

--- a/src/solvers/strings/string_constraint_generator_comparison.cpp
+++ b/src/solvers/strings/string_constraint_generator_comparison.cpp
@@ -208,7 +208,7 @@ string_constraint_generatort::add_axioms_for_hash_code(
       equal_exprt(it.first.length(), str.length()),
       and_exprt(
         notequal_exprt(str[i], it.first[i]),
-        and_exprt(length_gt(str, i), is_positive(i))));
+        and_exprt(greater_than(str.length(), i), is_positive(i))));
     hash_constraints.existential.push_back(or_exprt(c1, or_exprt(c2, c3)));
   }
   return {hash, std::move(hash_constraints)};
@@ -271,12 +271,13 @@ std::pair<exprt, string_constraintst> add_axioms_for_compare_to(
       typecast_exprt(s1.length(), return_type),
       typecast_exprt(s2.length(), return_type)));
   const or_exprt guard1(
-    and_exprt(length_le(s1, s2.length()), length_gt(s1, x)),
-    and_exprt(length_ge(s1, s2.length()), length_gt(s2, x)));
+    and_exprt(length_le(s1, s2.length()), greater_than(s1.length(), x)),
+    and_exprt(length_ge(s1, s2.length()), greater_than(s2.length(), x)));
   const and_exprt cond1(ret_char_diff, guard1);
   const or_exprt guard2(
-    and_exprt(length_gt(s2, s1.length()), length_eq(s1, x)),
-    and_exprt(length_gt(s1, s2.length()), length_eq(s2, x)));
+    and_exprt(greater_than(s2.length(), s1.length()), equal_to(s1.length(), x)),
+    and_exprt(
+      greater_than(s1.length(), s2.length()), equal_to(s2.length(), x)));
   const and_exprt cond2(ret_length_diff, guard2);
 
   const implies_exprt a3(

--- a/src/solvers/strings/string_constraint_generator_comparison.cpp
+++ b/src/solvers/strings/string_constraint_generator_comparison.cpp
@@ -272,7 +272,9 @@ std::pair<exprt, string_constraintst> add_axioms_for_compare_to(
       typecast_exprt(s2.length(), return_type)));
   const or_exprt guard1(
     and_exprt(length_le(s1, s2.length()), greater_than(s1.length(), x)),
-    and_exprt(length_ge(s1, s2.length()), greater_than(s2.length(), x)));
+    and_exprt(
+      greater_or_equal_to(s1.length(), s2.length()),
+      greater_than(s2.length(), x)));
   const and_exprt cond1(ret_char_diff, guard1);
   const or_exprt guard2(
     and_exprt(greater_than(s2.length(), s1.length()), equal_to(s1.length(), x)),

--- a/src/solvers/strings/string_constraint_generator_comparison.cpp
+++ b/src/solvers/strings/string_constraint_generator_comparison.cpp
@@ -271,7 +271,9 @@ std::pair<exprt, string_constraintst> add_axioms_for_compare_to(
       typecast_exprt(s1.length(), return_type),
       typecast_exprt(s2.length(), return_type)));
   const or_exprt guard1(
-    and_exprt(length_le(s1, s2.length()), greater_than(s1.length(), x)),
+    and_exprt(
+      less_than_or_equal_to(s1.length(), s2.length()),
+      greater_than(s1.length(), x)),
     and_exprt(
       greater_or_equal_to(s1.length(), s2.length()),
       greater_than(s2.length(), x)));

--- a/src/solvers/strings/string_constraint_generator_float.cpp
+++ b/src/solvers/strings/string_constraint_generator_float.cpp
@@ -278,7 +278,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_fractional_part(
   // no_trailing_zero: forall j:[2, max_size[. !(|res| = j+1 && res[j] = '0')
   // a3 : int_expr = sum_j 10^j (j < |res| ? res[j] - '0' : 0)
 
-  const and_exprt a1(length_gt(res, 1), length_le(res, max));
+  const and_exprt a1(greater_than(res.length(), 1), length_le(res, max));
   constraints.existential.push_back(a1);
 
   equal_exprt starts_with_dot(res[0], from_integer('.', char_type));

--- a/src/solvers/strings/string_constraint_generator_float.cpp
+++ b/src/solvers/strings/string_constraint_generator_float.cpp
@@ -278,7 +278,8 @@ std::pair<exprt, string_constraintst> add_axioms_for_fractional_part(
   // no_trailing_zero: forall j:[2, max_size[. !(|res| = j+1 && res[j] = '0')
   // a3 : int_expr = sum_j 10^j (j < |res| ? res[j] - '0' : 0)
 
-  const and_exprt a1(greater_than(res.length(), 1), length_le(res, max));
+  const and_exprt a1(
+    greater_than(res.length(), 1), less_than_or_equal_to(res.length(), max));
   constraints.existential.push_back(a1);
 
   equal_exprt starts_with_dot(res[0], from_integer('.', char_type));

--- a/src/solvers/strings/string_constraint_generator_testing.cpp
+++ b/src/solvers/strings/string_constraint_generator_testing.cpp
@@ -72,7 +72,8 @@ std::pair<exprt, string_constraintst> add_axioms_for_is_prefix(
       notequal_exprt(str[plus_exprt(witness, offset)], prefix[witness]));
     const exprt s1_does_not_start_with_s0 = or_exprt(
       not_exprt(offset_within_bounds),
-      not_exprt(length_ge(str, plus_exprt(prefix.length(), offset))),
+      not_exprt(
+        greater_or_equal_to(str.length(), plus_exprt(prefix.length(), offset))),
       strings_differ_at_witness);
     return implies_exprt(not_exprt(isprefix), s1_does_not_start_with_s0);
   }());
@@ -186,7 +187,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_is_suffix(
     get_string_expr(array_pool, args[swap_arguments ? 0u : 1u]);
   const typet &index_type = s0.length().type();
 
-  implies_exprt a1(issuffix, length_ge(s1, s0.length()));
+  implies_exprt a1(issuffix, greater_or_equal_to(s1.length(), s0.length()));
   constraints.existential.push_back(a1);
 
   symbol_exprt qvar = fresh_symbol("QA_suffix", index_type);
@@ -246,7 +247,8 @@ std::pair<exprt, string_constraintst> add_axioms_for_contains(
   const symbol_exprt contains = fresh_symbol("contains");
   const symbol_exprt startpos = fresh_symbol("startpos_contains", index_type);
 
-  const implies_exprt a1(contains, length_ge(s0, s1.length()));
+  const implies_exprt a1(
+    contains, greater_or_equal_to(s0.length(), s1.length()));
   constraints.existential.push_back(a1);
 
   minus_exprt length_diff(s0.length(), s1.length());
@@ -270,7 +272,8 @@ std::pair<exprt, string_constraintst> add_axioms_for_contains(
   const string_not_contains_constraintt a5 = {
     from_integer(0, index_type),
     plus_exprt(from_integer(1, index_type), length_diff),
-    and_exprt(not_exprt(contains), length_ge(s0, s1.length())),
+    and_exprt(
+      not_exprt(contains), greater_or_equal_to(s0.length(), s1.length())),
     from_integer(0, index_type),
     s1.length(),
     s0,

--- a/src/solvers/strings/string_constraint_generator_testing.cpp
+++ b/src/solvers/strings/string_constraint_generator_testing.cpp
@@ -68,7 +68,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_is_prefix(
     const exprt witness = fresh_symbol("witness_not_isprefix", index_type);
     const exprt strings_differ_at_witness = and_exprt(
       is_positive(witness),
-      length_gt(prefix, witness),
+      greater_than(prefix.length(), witness),
       notequal_exprt(str[plus_exprt(witness, offset)], prefix[witness]));
     const exprt s1_does_not_start_with_s0 = or_exprt(
       not_exprt(offset_within_bounds),
@@ -201,11 +201,11 @@ std::pair<exprt, string_constraintst> add_axioms_for_is_suffix(
   const plus_exprt shifted(witness, minus_exprt(s1.length(), s0.length()));
   or_exprt constr3(
     and_exprt(
-      length_gt(s0, s1.length()),
+      greater_than(s0.length(), s1.length()),
       equal_exprt(witness, from_integer(-1, index_type))),
     and_exprt(
       notequal_exprt(s0[witness], s1[shifted]),
-      and_exprt(length_gt(s0, witness), is_positive(witness))));
+      and_exprt(greater_than(s0.length(), witness), is_positive(witness))));
   implies_exprt a3(not_exprt(issuffix), constr3);
 
   constraints.existential.push_back(a3);

--- a/src/solvers/strings/string_constraint_generator_testing.cpp
+++ b/src/solvers/strings/string_constraint_generator_testing.cpp
@@ -138,8 +138,8 @@ std::pair<exprt, string_constraintst> add_axioms_for_is_empty(
   symbol_exprt is_empty = fresh_symbol("is_empty");
   array_string_exprt s0 = get_string_expr(array_pool, f.arguments()[0]);
   string_constraintst constraints;
-  constraints.existential = {implies_exprt(is_empty, length_eq(s0, 0)),
-                             implies_exprt(length_eq(s0, 0), is_empty)};
+  constraints.existential = {implies_exprt(is_empty, equal_to(s0.length(), 0)),
+                             implies_exprt(equal_to(s0.length(), 0), is_empty)};
   return {typecast_exprt(is_empty, f.type()), std::move(constraints)};
 }
 

--- a/src/solvers/strings/string_constraint_generator_transformation.cpp
+++ b/src/solvers/strings/string_constraint_generator_transformation.cpp
@@ -209,7 +209,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_trim(
     greater_or_equal_to(res.length(), from_integer(0, index_type));
   constraints.existential.push_back(a4);
 
-  const exprt a5 = length_le(res, str.length());
+  const exprt a5 = less_than_or_equal_to(res.length(), str.length());
   constraints.existential.push_back(a5);
 
   symbol_exprt n = fresh_symbol("QA_index_trim", index_type);

--- a/src/solvers/strings/string_constraint_generator_transformation.cpp
+++ b/src/solvers/strings/string_constraint_generator_transformation.cpp
@@ -54,7 +54,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_set_length(
   // a2 : forall i< min(|s1|, k) .res[i] = s1[i]
   // a3 : forall |s1| <= i < |res|. res[i] = 0
 
-  constraints.existential.push_back(length_eq(res, k));
+  constraints.existential.push_back(equal_to(res.length(), k));
 
   const symbol_exprt idx = fresh_symbol("QA_index_set_length", index_type);
   const string_constraintt a2(

--- a/src/solvers/strings/string_constraint_generator_transformation.cpp
+++ b/src/solvers/strings/string_constraint_generator_transformation.cpp
@@ -197,15 +197,16 @@ std::pair<exprt, string_constraintst> add_axioms_for_trim(
 
   // Axiom 1.
   constraints.existential.push_back(
-    length_ge(str, plus_exprt(idx, res.length())));
+    greater_or_equal_to(str.length(), plus_exprt(idx, res.length())));
 
   binary_relation_exprt a2(idx, ID_ge, from_integer(0, index_type));
   constraints.existential.push_back(a2);
 
-  const exprt a3 = length_ge(str, idx);
+  const exprt a3 = greater_or_equal_to(str.length(), idx);
   constraints.existential.push_back(a3);
 
-  const exprt a4 = length_ge(res, from_integer(0, index_type));
+  const exprt a4 =
+    greater_or_equal_to(res.length(), from_integer(0, index_type));
   constraints.existential.push_back(a4);
 
   const exprt a5 = length_le(res, str.length());

--- a/src/solvers/strings/string_constraint_generator_valueof.cpp
+++ b/src/solvers/strings/string_constraint_generator_valueof.cpp
@@ -230,8 +230,9 @@ add_axioms_from_int_hex(const array_string_exprt &res, const exprt &i)
   exprt f_char = from_integer('f', char_type);
 
   size_t max_size = 8;
-  constraints.existential.push_back(
-    and_exprt(greater_than(res.length(), 0), length_le(res, max_size)));
+  constraints.existential.push_back(and_exprt(
+    greater_than(res.length(), 0),
+    less_than_or_equal_to(res.length(), max_size)));
 
   for(size_t size = 1; size <= max_size; size++)
   {
@@ -370,7 +371,8 @@ string_constraintst add_axioms_for_correct_number_format(
   constraints.existential.push_back(contains_digit);
 
   // |str| <= max_size
-  constraints.existential.push_back(length_le(str, max_size));
+  constraints.existential.push_back(
+    less_than_or_equal_to(str.length(), max_size));
 
   // forall 1 <= i < |str| . is_digit_with_radix(str[i], radix)
   // We unfold the above because we know that it will be used for all i up to

--- a/src/solvers/strings/string_constraint_generator_valueof.cpp
+++ b/src/solvers/strings/string_constraint_generator_valueof.cpp
@@ -345,7 +345,8 @@ string_constraintst add_axioms_for_correct_number_format(
     is_digit_with_radix(chr, strict_formatting, radix_as_char, radix_ul);
 
   // |str| > 0
-  const exprt non_empty = length_ge(str, from_integer(1, index_type));
+  const exprt non_empty =
+    greater_or_equal_to(str.length(), from_integer(1, index_type));
   constraints.existential.push_back(non_empty);
 
   if(strict_formatting)
@@ -365,7 +366,7 @@ string_constraintst add_axioms_for_correct_number_format(
   // str[0]='+' or '-' ==> |str| > 1
   const implies_exprt contains_digit(
     or_exprt(starts_with_minus, starts_with_plus),
-    length_ge(str, from_integer(2, index_type)));
+    greater_or_equal_to(str.length(), from_integer(2, index_type)));
   constraints.existential.push_back(contains_digit);
 
   // |str| <= max_size
@@ -378,7 +379,7 @@ string_constraintst add_axioms_for_correct_number_format(
   {
     /// index < length => is_digit_with_radix(str[index], radix)
     const implies_exprt character_at_index_is_digit(
-      length_ge(str, from_integer(index + 1, index_type)),
+      greater_or_equal_to(str.length(), from_integer(index + 1, index_type)),
       is_digit_with_radix(
         str[index], strict_formatting, radix_as_char, radix_ul));
     constraints.existential.push_back(character_at_index_is_digit);

--- a/src/solvers/strings/string_constraint_generator_valueof.cpp
+++ b/src/solvers/strings/string_constraint_generator_valueof.cpp
@@ -231,7 +231,7 @@ add_axioms_from_int_hex(const array_string_exprt &res, const exprt &i)
 
   size_t max_size = 8;
   constraints.existential.push_back(
-    and_exprt(length_gt(res, 0), length_le(res, max_size)));
+    and_exprt(greater_than(res.length(), 0), length_le(res, max_size)));
 
   for(size_t size = 1; size <= max_size; size++)
   {

--- a/src/solvers/strings/string_constraint_generator_valueof.cpp
+++ b/src/solvers/strings/string_constraint_generator_valueof.cpp
@@ -96,7 +96,7 @@ add_axioms_from_bool(const array_string_exprt &res, const exprt &b)
   // a4 : forall i < |"false"|. !eq => res[i]="false"[i]
 
   std::string str_true = "true";
-  const implies_exprt a1(eq, length_eq(res, str_true.length()));
+  const implies_exprt a1(eq, equal_to(res.length(), str_true.length()));
   constraints.existential.push_back(a1);
 
   for(std::size_t i = 0; i < str_true.length(); i++)
@@ -107,7 +107,8 @@ add_axioms_from_bool(const array_string_exprt &res, const exprt &b)
   }
 
   std::string str_false = "false";
-  const implies_exprt a3(not_exprt(eq), length_eq(res, str_false.length()));
+  const implies_exprt a3(
+    not_exprt(eq), equal_to(res.length(), str_false.length()));
   constraints.existential.push_back(a3);
 
   for(std::size_t i = 0; i < str_false.length(); i++)
@@ -253,7 +254,7 @@ add_axioms_from_int_hex(const array_string_exprt &res, const exprt &i)
       all_numbers = and_exprt(all_numbers, is_number);
     }
 
-    const equal_exprt premise = length_eq(res, size);
+    const equal_exprt premise = equal_to(res.length(), size);
     constraints.existential.push_back(
       implies_exprt(premise, and_exprt(equal_exprt(i, sum), all_numbers)));
 
@@ -312,7 +313,7 @@ add_axioms_from_char(const array_string_exprt &res, const exprt &c)
 {
   string_constraintst constraints;
   constraints.existential = {
-    and_exprt(equal_exprt(res[0], c), length_eq(res, 1))};
+    and_exprt(equal_exprt(res[0], c), equal_to(res.length(), 1))};
   return {from_integer(0, get_return_code_type()), std::move(constraints)};
 }
 
@@ -389,7 +390,8 @@ string_constraintst add_axioms_for_correct_number_format(
 
     // no_leading_zero : str[0] = '0' => |str| = 1
     const implies_exprt no_leading_zero(
-      equal_exprt(chr, zero_char), length_eq(str, from_integer(1, index_type)));
+      equal_exprt(chr, zero_char),
+      equal_to(str.length(), from_integer(1, index_type)));
     constraints.existential.push_back(no_leading_zero);
 
     // no_leading_zero_after_minus : str[0]='-' => str[1]!='0'
@@ -435,7 +437,7 @@ string_constraintst add_axioms_for_characters_in_integer_string(
   /// add_axioms_for_correct_number_format which say that the string must
   /// contain at least one digit, so we don't have to worry about "+" or "-".
   constraints.existential.push_back(
-    implies_exprt(length_eq(str, 1), equal_exprt(input_int, sum)));
+    implies_exprt(equal_to(str.length(), 1), equal_exprt(input_int, sum)));
 
   for(size_t size = 2; size <= max_string_length; size++)
   {
@@ -473,7 +475,7 @@ string_constraintst add_axioms_for_characters_in_integer_string(
     }
     sum = new_sum;
 
-    const equal_exprt premise = length_eq(str, size);
+    const equal_exprt premise = equal_to(str.length(), size);
 
     if(!digit_constraints.empty())
     {

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -24,17 +24,15 @@ binary_relation_exprt length_ge(const T &lhs, const exprt &rhs)
   return binary_relation_exprt(lhs.length(), ID_ge, rhs);
 }
 
-template <typename T>
-binary_relation_exprt length_gt(const T &lhs, const exprt &rhs)
+inline binary_relation_exprt greater_than(const exprt &lhs, const exprt &rhs)
 {
-  PRECONDITION(rhs.type() == lhs.length().type());
-  return binary_relation_exprt(rhs, ID_lt, lhs.length());
+  PRECONDITION(rhs.type() == lhs.type());
+  return binary_relation_exprt(rhs, ID_lt, lhs);
 }
 
-template <typename T>
-binary_relation_exprt length_gt(const T &lhs, mp_integer i)
+inline binary_relation_exprt greater_than(const exprt &lhs, mp_integer i)
 {
-  return length_gt(lhs, from_integer(i, lhs.length().type()));
+  return greater_than(lhs, from_integer(i, lhs.type()));
 }
 
 template <typename T>

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -16,17 +16,16 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include "refined_string_type.h"
 #include "std_expr.h"
 
-inline binary_relation_exprt
-greater_or_equal_to(const exprt &lhs, const exprt &rhs)
+inline binary_relation_exprt greater_or_equal_to(exprt lhs, exprt rhs)
 {
   PRECONDITION(rhs.type() == lhs.type());
-  return binary_relation_exprt(lhs, ID_ge, rhs);
+  return binary_relation_exprt(std::move(lhs), ID_ge, std::move(rhs));
 }
 
-inline binary_relation_exprt greater_than(const exprt &lhs, const exprt &rhs)
+inline binary_relation_exprt greater_than(exprt lhs, exprt rhs)
 {
   PRECONDITION(rhs.type() == lhs.type());
-  return binary_relation_exprt(rhs, ID_lt, lhs);
+  return binary_relation_exprt(std::move(rhs), ID_lt, std::move(lhs));
 }
 
 inline binary_relation_exprt greater_than(const exprt &lhs, mp_integer i)
@@ -34,11 +33,10 @@ inline binary_relation_exprt greater_than(const exprt &lhs, mp_integer i)
   return binary_relation_exprt(from_integer(i, lhs.type()), ID_lt, lhs);
 }
 
-inline binary_relation_exprt
-less_than_or_equal_to(const exprt &lhs, const exprt &rhs)
+inline binary_relation_exprt less_than_or_equal_to(exprt lhs, exprt rhs)
 {
   PRECONDITION(rhs.type() == lhs.type());
-  return binary_relation_exprt(lhs, ID_le, rhs);
+  return binary_relation_exprt(std::move(lhs), ID_le, std::move(rhs));
 }
 
 inline binary_relation_exprt
@@ -47,10 +45,10 @@ less_than_or_equal_to(const exprt &lhs, mp_integer i)
   return binary_relation_exprt(lhs, ID_le, from_integer(i, lhs.type()));
 }
 
-inline equal_exprt equal_to(const exprt &lhs, const exprt &rhs)
+inline equal_exprt equal_to(exprt lhs, exprt rhs)
 {
   PRECONDITION(rhs.type() == lhs.type());
-  return equal_exprt(lhs, rhs);
+  return equal_exprt(std::move(lhs), std::move(rhs));
 }
 
 inline equal_exprt equal_to(const exprt &lhs, mp_integer i)

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -31,7 +31,7 @@ inline binary_relation_exprt greater_than(const exprt &lhs, const exprt &rhs)
 
 inline binary_relation_exprt greater_than(const exprt &lhs, mp_integer i)
 {
-  return greater_than(lhs, from_integer(i, lhs.type()));
+  return binary_relation_exprt(from_integer(i, lhs.type()), ID_lt, lhs);
 }
 
 inline binary_relation_exprt
@@ -44,7 +44,7 @@ less_than_or_equal_to(const exprt &lhs, const exprt &rhs)
 inline binary_relation_exprt
 less_than_or_equal_to(const exprt &lhs, mp_integer i)
 {
-  return less_than_or_equal_to(lhs, from_integer(i, lhs.type()));
+  return binary_relation_exprt(lhs, ID_le, from_integer(i, lhs.type()));
 }
 
 inline equal_exprt equal_to(const exprt &lhs, const exprt &rhs)
@@ -55,7 +55,7 @@ inline equal_exprt equal_to(const exprt &lhs, const exprt &rhs)
 
 inline equal_exprt equal_to(const exprt &lhs, mp_integer i)
 {
-  return equal_to(lhs, from_integer(i, lhs.type()));
+  return equal_exprt(lhs, from_integer(i, lhs.type()));
 }
 
 // Representation of strings as arrays

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -34,17 +34,17 @@ inline binary_relation_exprt greater_than(const exprt &lhs, mp_integer i)
   return greater_than(lhs, from_integer(i, lhs.type()));
 }
 
-template <typename T>
-binary_relation_exprt length_le(const T &lhs, const exprt &rhs)
+inline binary_relation_exprt
+less_than_or_equal_to(const exprt &lhs, const exprt &rhs)
 {
-  PRECONDITION(rhs.type() == lhs.length().type());
-  return binary_relation_exprt(lhs.length(), ID_le, rhs);
+  PRECONDITION(rhs.type() == lhs.type());
+  return binary_relation_exprt(lhs, ID_le, rhs);
 }
 
-template <typename T>
-binary_relation_exprt length_le(const T &lhs, mp_integer i)
+inline binary_relation_exprt
+less_than_or_equal_to(const exprt &lhs, mp_integer i)
 {
-  return length_le(lhs, from_integer(i, lhs.length().type()));
+  return less_than_or_equal_to(lhs, from_integer(i, lhs.type()));
 }
 
 inline equal_exprt equal_to(const exprt &lhs, const exprt &rhs)

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -16,12 +16,11 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include "refined_string_type.h"
 #include "std_expr.h"
 
-// Comparison on the length of the strings
-template <typename T>
-binary_relation_exprt length_ge(const T &lhs, const exprt &rhs)
+inline binary_relation_exprt
+greater_or_equal_to(const exprt &lhs, const exprt &rhs)
 {
-  PRECONDITION(rhs.type() == lhs.length().type());
-  return binary_relation_exprt(lhs.length(), ID_ge, rhs);
+  PRECONDITION(rhs.type() == lhs.type());
+  return binary_relation_exprt(lhs, ID_ge, rhs);
 }
 
 inline binary_relation_exprt greater_than(const exprt &lhs, const exprt &rhs)

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -50,17 +50,15 @@ binary_relation_exprt length_le(const T &lhs, mp_integer i)
   return length_le(lhs, from_integer(i, lhs.length().type()));
 }
 
-template <typename T>
-equal_exprt length_eq(const T &lhs, const exprt &rhs)
+inline equal_exprt equal_to(const exprt &lhs, const exprt &rhs)
 {
-  PRECONDITION(rhs.type() == lhs.length().type());
-  return equal_exprt(lhs.length(), rhs);
+  PRECONDITION(rhs.type() == lhs.type());
+  return equal_exprt(lhs, rhs);
 }
 
-template <typename T>
-equal_exprt length_eq(const T &lhs, mp_integer i)
+inline equal_exprt equal_to(const exprt &lhs, mp_integer i)
 {
-  return length_eq(lhs, from_integer(i, lhs.length().type()));
+  return equal_to(lhs, from_integer(i, lhs.type()));
 }
 
 // Representation of strings as arrays


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

Rename and refactor binary constraining functions to take two integers rather than a string and an integer. I.e. let the caller dereference the length of the string.

N.B. These relations are no longer string-specific. They should be moved to a more general location in a later PR.

Only review 4 last commits.

Based on:
* https://github.com/diffblue/cbmc/pull/4601
* https://github.com/diffblue/cbmc/pull/4607

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
