### PR TITLE
Refactor: Introduce array_string_exprt.length_type() [TG-7439]

### DIFF
--- a/src/solvers/strings/string_builtin_function.cpp
+++ b/src/solvers/strings/string_builtin_function.cpp
@@ -182,7 +182,7 @@ optionalt<exprt> string_concat_char_builtin_functiont::eval(
   }();
   input_opt.value().push_back(char_val);
   const auto length =
-    from_integer(input_opt.value().size(), result.length().type());
+    from_integer(input_opt.value().size(), result.length_type());
   const array_typet type(result.type().subtype(), length);
   return make_string(input_opt.value(), type);
 }
@@ -200,7 +200,7 @@ string_constraintst string_concat_char_builtin_functiont::constraints(
   constraints.existential.push_back(length_constraint());
   constraints.universal.push_back([&] {
     const symbol_exprt idx =
-      generator.fresh_symbol("QA_index_concat_char", result.length().type());
+      generator.fresh_symbol("QA_index_concat_char", result.length_type());
     const exprt upper_bound = zero_if_negative(input.length());
     return string_constraintt(
       idx, upper_bound, equal_exprt(input[idx], result[idx]));
@@ -228,7 +228,7 @@ optionalt<exprt> string_set_char_builtin_functiont::eval(
   if(0 <= *position_opt && *position_opt < input_opt.value().size())
     input_opt.value()[numeric_cast_v<std::size_t>(*position_opt)] = *char_opt;
   const auto length =
-    from_integer(input_opt.value().size(), result.length().type());
+    from_integer(input_opt.value().size(), result.length_type());
   const array_typet type(result.type().subtype(), length);
   return make_string(input_opt.value(), type);
 }
@@ -275,7 +275,7 @@ exprt string_set_char_builtin_functiont::length_constraint() const
   const exprt out_of_bounds = or_exprt(
     binary_relation_exprt(position, ID_ge, input.length()),
     binary_relation_exprt(
-      position, ID_lt, from_integer(0, input.length().type())));
+      position, ID_lt, from_integer(0, input.length_type())));
   const exprt return_value = if_exprt(
     out_of_bounds,
     from_integer(1, return_code.type()),
@@ -308,7 +308,7 @@ optionalt<exprt> string_to_lower_case_builtin_functiont::eval(
       c += 0x20;
   }
   const auto length =
-    from_integer(input_opt.value().size(), result.length().type());
+    from_integer(input_opt.value().size(), result.length_type());
   const array_typet type(result.type().subtype(), length);
   return make_string(input_opt.value(), type);
 }
@@ -371,7 +371,7 @@ string_constraintst string_to_lower_case_builtin_functiont::constraints(
   constraints.existential.push_back(length_constraint());
   constraints.universal.push_back([&] {
     const symbol_exprt idx =
-      generator.fresh_symbol("QA_lower_case", result.length().type());
+      generator.fresh_symbol("QA_lower_case", result.length_type());
     const exprt conditional_convert = [&] {
       // The difference between upper-case and lower-case for the basic
       // latin and latin-1 supplement is 0x20.
@@ -400,7 +400,7 @@ optionalt<exprt> string_to_upper_case_builtin_functiont::eval(
       c -= 0x20;
   }
   const auto length =
-    from_integer(input_opt.value().size(), result.length().type());
+    from_integer(input_opt.value().size(), result.length_type());
   const array_typet type(result.type().subtype(), length);
   return make_string(input_opt.value(), type);
 }
@@ -421,7 +421,7 @@ string_constraintst string_to_upper_case_builtin_functiont::constraints(
   constraints.existential.push_back(length_constraint());
   constraints.universal.push_back([&] {
     const symbol_exprt idx =
-      fresh_symbol("QA_upper_case", result.length().type());
+      fresh_symbol("QA_upper_case", result.length_type());
     const typet &char_type = input.content().type().subtype();
     const exprt converted =
       minus_exprt(input[idx], from_integer(0x20, char_type));
@@ -480,7 +480,7 @@ optionalt<exprt> string_insertion_builtin_functiont::eval(
     });
 
   const auto result_value = eval(*input1_value, *input2_value, arg_values);
-  const auto length = from_integer(result_value.size(), result.length().type());
+  const auto length = from_integer(result_value.size(), result.length_type());
   const array_typet type(result.type().subtype(), length);
   return make_string(result_value, type);
 }
@@ -552,7 +552,7 @@ optionalt<exprt> string_of_int_builtin_functiont::eval(
     right_to_left_characters.emplace_back('-');
 
   const auto length = right_to_left_characters.size();
-  const auto length_expr = from_integer(length, result.length().type());
+  const auto length_expr = from_integer(length, result.length_type());
   const array_typet type(result.type().subtype(), length_expr);
   return make_string(
     right_to_left_characters.rbegin(), right_to_left_characters.rend(), type);
@@ -569,7 +569,7 @@ string_constraintst string_of_int_builtin_functiont::constraints(
 
 exprt string_of_int_builtin_functiont::length_constraint() const
 {
-  const typet &type = result.length().type();
+  const typet &type = result.length_type();
   const auto radix_opt = numeric_cast<std::size_t>(radix);
   const auto radix_value = radix_opt.has_value() ? radix_opt.value() : 2;
   const std::size_t upper_bound =

--- a/src/solvers/strings/string_constraint_generator_code_points.cpp
+++ b/src/solvers/strings/string_constraint_generator_code_points.cpp
@@ -131,7 +131,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_code_point_at(
   const exprt &pos = f.arguments()[1];
 
   const symbol_exprt result = fresh_symbol("char", return_type);
-  const exprt index1 = from_integer(1, str.length().type());
+  const exprt index1 = from_integer(1, str.length_type());
   const exprt &char1 = str[pos];
   const exprt &char2 = str[plus_exprt(pos, index1)];
   const typecast_exprt char1_as_int(char1, return_type);

--- a/src/solvers/strings/string_constraint_generator_comparison.cpp
+++ b/src/solvers/strings/string_constraint_generator_comparison.cpp
@@ -43,7 +43,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_equals(
   symbol_exprt eq = fresh_symbol("equal");
   typecast_exprt tc_eq(eq, f.type());
 
-  typet index_type = s1.length().type();
+  typet index_type = s1.length_type();
 
   // Axiom 1.
   constraints.existential.push_back(
@@ -145,7 +145,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_equals_ignore_case(
   const exprt char_a = from_integer('a', char_type);
   const exprt char_A = from_integer('A', char_type);
   const exprt char_Z = from_integer('Z', char_type);
-  const typet index_type = s1.length().type();
+  const typet index_type = s1.length_type();
 
   const implies_exprt a1(eq, equal_exprt(s1.length(), s2.length()));
   constraints.existential.push_back(a1);
@@ -193,7 +193,7 @@ string_constraint_generatort::add_axioms_for_hash_code(
   string_constraintst hash_constraints;
   const array_string_exprt str = get_string_expr(array_pool, f.arguments()[0]);
   const typet &return_type = f.type();
-  const typet &index_type = str.length().type();
+  const typet &index_type = str.length_type();
 
   auto pair = hash_code_of_string.insert(
     std::make_pair(str, fresh_symbol("hash", return_type)));
@@ -247,7 +247,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_compare_to(
   const array_string_exprt &s1 = get_string_expr(array_pool, f.arguments()[0]);
   const array_string_exprt &s2 = get_string_expr(array_pool, f.arguments()[1]);
   const symbol_exprt res = fresh_symbol("compare_to", return_type);
-  const typet &index_type = s1.length().type();
+  const typet &index_type = s1.length_type();
 
   const equal_exprt res_null(res, from_integer(0, return_type));
   const implies_exprt a1(res_null, equal_exprt(s1.length(), s2.length()));

--- a/src/solvers/strings/string_constraint_generator_concat.cpp
+++ b/src/solvers/strings/string_constraint_generator_concat.cpp
@@ -54,8 +54,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_concat_substr(
 
   // Axiom 2.
   constraints.universal.push_back([&] {
-    const symbol_exprt idx =
-      fresh_symbol("QA_index_concat", res.length().type());
+    const symbol_exprt idx = fresh_symbol("QA_index_concat", res.length_type());
     return string_constraintt(
       idx, zero_if_negative(s1.length()), equal_exprt(s1[idx], res[idx]));
   }());
@@ -63,7 +62,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_concat_substr(
   // Axiom 3.
   constraints.universal.push_back([&] {
     const symbol_exprt idx2 =
-      fresh_symbol("QA_index_concat2", res.length().type());
+      fresh_symbol("QA_index_concat2", res.length_type());
     const equal_exprt res_eq(
       res[plus_exprt(idx2, s1.length())], s2[plus_exprt(start1, idx2)]);
     const minus_exprt upper_bound(res.length(), s1.length());
@@ -85,12 +84,12 @@ exprt length_constraint_for_concat_substr(
   const exprt &start,
   const exprt &end)
 {
-  PRECONDITION(res.length().type().id() == ID_signedbv);
+  PRECONDITION(res.length_type().id() == ID_signedbv);
   const exprt start1 = maximum(start, from_integer(0, start.type()));
   const exprt end1 = maximum(minimum(end, s2.length()), start1);
   const plus_exprt res_length(s1.length(), minus_exprt(end1, start1));
   const exprt overflow = sum_overflows(res_length);
-  const exprt max_int = to_signedbv_type(res.length().type()).largest_expr();
+  const exprt max_int = to_signedbv_type(res.length_type()).largest_expr();
   return equal_exprt(res.length(), if_exprt(overflow, max_int, res_length));
 }
 
@@ -111,7 +110,7 @@ exprt length_constraint_for_concat_char(
   const array_string_exprt &s1)
 {
   return equal_exprt(
-    res.length(), plus_exprt(s1.length(), from_integer(1, s1.length().type())));
+    res.length(), plus_exprt(s1.length(), from_integer(1, s1.length_type())));
 }
 
 /// Add axioms enforcing that `res` is equal to the concatenation of `s1` and
@@ -129,7 +128,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_concat(
   const array_string_exprt &s1,
   const array_string_exprt &s2)
 {
-  exprt index_zero = from_integer(0, s2.length().type());
+  exprt index_zero = from_integer(0, s2.length_type());
   return add_axioms_for_concat_substr(
     fresh_symbol, res, s1, s2, index_zero, s2.length());
 }
@@ -150,7 +149,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_concat_code_point(
     array_pool.find(f.arguments()[1], f.arguments()[0]);
   const array_string_exprt s1 = get_string_expr(array_pool, f.arguments()[2]);
   const typet &char_type = s1.content().type().subtype();
-  const typet &index_type = s1.length().type();
+  const typet &index_type = s1.length_type();
   const array_string_exprt code_point =
     array_pool.fresh_string(index_type, char_type);
   return combine_results(

--- a/src/solvers/strings/string_constraint_generator_float.cpp
+++ b/src/solvers/strings/string_constraint_generator_float.cpp
@@ -210,7 +210,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_string_of_float(
   const floatbv_typet &type = to_floatbv_type(f.type());
   const ieee_float_spect float_spec(type);
   const typet &char_type = res.content().type().subtype();
-  const typet &index_type = res.length().type();
+  const typet &index_type = res.length_type();
 
   // We will look at the first 5 digits of the fractional part.
   // shifted is floor(f * 1e5)
@@ -264,7 +264,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_fractional_part(
   string_constraintst constraints;
   const typet &type = int_expr.type();
   const typet &char_type = res.content().type().subtype();
-  const typet &index_type = res.length().type();
+  const typet &index_type = res.length_type();
   const exprt ten = from_integer(10, type);
   const exprt zero_char = from_integer('0', char_type);
   const exprt nine_char = from_integer('9', char_type);
@@ -292,7 +292,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_fractional_part(
   {
     // after_end is |res| <= j
     binary_relation_exprt after_end(
-      res.length(), ID_le, from_integer(j, res.length().type()));
+      res.length(), ID_le, from_integer(j, res.length_type()));
     mult_exprt ten_sum(sum, ten);
 
     // sum = 10 * sum + after_end ? 0 : (res[j]-'0')
@@ -311,7 +311,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_fractional_part(
     if(j > 1)
     {
       not_exprt no_trailing_zero(and_exprt(
-        equal_exprt(res.length(), from_integer(j + 1, res.length().type())),
+        equal_exprt(res.length(), from_integer(j + 1, res.length_type())),
         equal_exprt(res[j], zero_char)));
       digit_constraints.push_back(no_trailing_zero);
     }
@@ -355,7 +355,7 @@ std::pair<exprt, string_constraintst> add_axioms_from_float_scientific_notation(
   const ieee_float_spect float_spec = ieee_float_spect::single_precision();
   const typet float_type = float_spec.to_type();
   const signedbv_typet int_type(32);
-  const typet &index_type = res.length().type();
+  const typet &index_type = res.length_type();
   const typet &char_type = res.content().type().subtype();
 
   // This is used for rounding float to integers.

--- a/src/solvers/strings/string_constraint_generator_format.cpp
+++ b/src/solvers/strings/string_constraint_generator_format.cpp
@@ -245,12 +245,11 @@ static std::vector<format_elementt> parse_format_string(std::string s)
 static exprt is_null(const array_string_exprt &string)
 {
   return and_exprt{
-    equal_exprt{string.length(), from_integer(4, string.length().type())},
-    and_exprt{
-      equal_exprt{string[0], from_integer('n', string[0].type())},
-      equal_exprt{string[1], from_integer('u', string[0].type())},
-      equal_exprt{string[2], from_integer('l', string[0].type())},
-      equal_exprt{string[3], from_integer('l', string[0].type())}}};
+    equal_exprt{string.length(), from_integer(4, string.length_type())},
+    and_exprt{equal_exprt{string[0], from_integer('n', string[0].type())},
+              equal_exprt{string[1], from_integer('u', string[0].type())},
+              equal_exprt{string[2], from_integer('l', string[0].type())},
+              equal_exprt{string[3], from_integer('l', string[0].type())}}};
 }
 
 /// Parse `s` and add axioms ensuring the output corresponds to the output of
@@ -457,7 +456,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_format(
   std::vector<array_string_exprt> intermediary_strings;
   std::size_t arg_count = 0;
   const typet &char_type = res.content().type().subtype();
-  const typet &index_type = res.length().type();
+  const typet &index_type = res.length_type();
 
   for(const format_elementt &fe : format_strings)
   {

--- a/src/solvers/strings/string_constraint_generator_indexof.cpp
+++ b/src/solvers/strings/string_constraint_generator_indexof.cpp
@@ -42,7 +42,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_index_of(
   const exprt &from_index)
 {
   string_constraintst constraints;
-  const typet &index_type = str.length().type();
+  const typet &index_type = str.length_type();
   symbol_exprt index = fresh_symbol("index_of", index_type);
   symbol_exprt contains = fresh_symbol("contains_in_index_of");
 
@@ -115,7 +115,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_index_of_string(
   const exprt &from_index)
 {
   string_constraintst constraints;
-  const typet &index_type = haystack.length().type();
+  const typet &index_type = haystack.length_type();
   symbol_exprt offset = fresh_symbol("index_of", index_type);
   symbol_exprt contains = fresh_symbol("contains_substring");
 
@@ -208,7 +208,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_last_index_of_string(
   const exprt &from_index)
 {
   string_constraintst constraints;
-  const typet &index_type = haystack.length().type();
+  const typet &index_type = haystack.length_type();
   symbol_exprt offset = fresh_symbol("index_of", index_type);
   symbol_exprt contains = fresh_symbol("contains_substring");
 
@@ -295,7 +295,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_index_of(
   PRECONDITION(args.size() == 2 || args.size() == 3);
   const array_string_exprt str = get_string_expr(array_pool, args[0]);
   const exprt &c = args[1];
-  const typet &index_type = str.length().type();
+  const typet &index_type = str.length_type();
   const typet &char_type = str.content().type().subtype();
   PRECONDITION(f.type() == index_type);
   const exprt from_index =
@@ -349,7 +349,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_last_index_of(
   const exprt &from_index)
 {
   string_constraintst constraints;
-  const typet &index_type = str.length().type();
+  const typet &index_type = str.length_type();
   const symbol_exprt index = fresh_symbol("last_index_of", index_type);
   const symbol_exprt contains = fresh_symbol("contains_in_last_index_of");
 
@@ -420,7 +420,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_last_index_of(
   PRECONDITION(args.size() == 2 || args.size() == 3);
   const array_string_exprt str = get_string_expr(array_pool, args[0]);
   const exprt c = args[1];
-  const typet &index_type = str.length().type();
+  const typet &index_type = str.length_type();
   const typet &char_type = str.content().type().subtype();
   PRECONDITION(f.type() == index_type);
 

--- a/src/solvers/strings/string_constraint_generator_insert.cpp
+++ b/src/solvers/strings/string_constraint_generator_insert.cpp
@@ -38,10 +38,10 @@ std::pair<exprt, string_constraintst> add_axioms_for_insert(
   const array_string_exprt &s2,
   const exprt &offset)
 {
-  PRECONDITION(offset.type() == s1.length().type());
+  PRECONDITION(offset.type() == s1.length_type());
 
   string_constraintst constraints;
-  const typet &index_type = s1.length().type();
+  const typet &index_type = s1.length_type();
   const exprt offset1 =
     maximum(from_integer(0, index_type), minimum(s1.length(), offset));
 
@@ -118,7 +118,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_insert(
     const exprt &start = f.arguments()[5];
     const exprt &end = f.arguments()[6];
     const typet &char_type = s1.content().type().subtype();
-    const typet &index_type = s1.length().type();
+    const typet &index_type = s1.length_type();
     const array_string_exprt substring =
       array_pool.fresh_string(index_type, char_type);
     return combine_results(
@@ -151,7 +151,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_insert_int(
   const array_string_exprt res =
     array_pool.find(f.arguments()[1], f.arguments()[0]);
   const exprt &offset = f.arguments()[3];
-  const typet &index_type = s1.length().type();
+  const typet &index_type = s1.length_type();
   const typet &char_type = s1.content().type().subtype();
   const array_string_exprt s2 = array_pool.fresh_string(index_type, char_type);
   return combine_results(
@@ -177,7 +177,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_insert_bool(
   const array_string_exprt res =
     array_pool.find(f.arguments()[1], f.arguments()[0]);
   const exprt &offset = f.arguments()[3];
-  const typet &index_type = s1.length().type();
+  const typet &index_type = s1.length_type();
   const typet &char_type = s1.content().type().subtype();
   const array_string_exprt s2 = array_pool.fresh_string(index_type, char_type);
   return combine_results(
@@ -202,7 +202,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_insert_char(
     array_pool.find(f.arguments()[1], f.arguments()[0]);
   const array_string_exprt s1 = get_string_expr(array_pool, f.arguments()[2]);
   const exprt &offset = f.arguments()[3];
-  const typet &index_type = s1.length().type();
+  const typet &index_type = s1.length_type();
   const typet &char_type = s1.content().type().subtype();
   const array_string_exprt s2 = array_pool.fresh_string(index_type, char_type);
   return combine_results(
@@ -230,7 +230,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_insert_double(
     array_pool.find(f.arguments()[1], f.arguments()[0]);
   const array_string_exprt s1 = get_string_expr(array_pool, f.arguments()[2]);
   const exprt &offset = f.arguments()[3];
-  const typet &index_type = s1.length().type();
+  const typet &index_type = s1.length_type();
   const typet &char_type = s1.content().type().subtype();
   const array_string_exprt s2 = array_pool.fresh_string(index_type, char_type);
   return combine_results(

--- a/src/solvers/strings/string_constraint_generator_main.cpp
+++ b/src/solvers/strings/string_constraint_generator_main.cpp
@@ -141,7 +141,7 @@ string_constraintst add_constraint_on_characters(
   const char &high_char = char_set[2];
 
   // Add constraint
-  const symbol_exprt qvar = fresh_symbol("char_constr", s.length().type());
+  const symbol_exprt qvar = fresh_symbol("char_constr", s.length_type());
   const exprt chr = s[qvar];
   const and_exprt char_in_set(
     binary_relation_exprt(chr, ID_ge, from_integer(low_char, chr.type())),
@@ -176,7 +176,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_constrain_characters(
   const array_string_exprt s = array_pool.find(args[1], args[0]);
   const irep_idt &char_set_string = to_constant_expr(args[2]).get_value();
   const exprt &start =
-    args.size() >= 4 ? args[3] : from_integer(0, s.length().type());
+    args.size() >= 4 ? args[3] : from_integer(0, s.length_type());
   const exprt &end = args.size() >= 5 ? args[4] : s.length();
   auto constraints = add_constraint_on_characters(
     fresh_symbol, s, start, end, char_set_string.c_str());
@@ -339,7 +339,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_copy(
   PRECONDITION(args.size() == 3 || args.size() == 5);
   const array_string_exprt res = array_pool.find(args[1], args[0]);
   const array_string_exprt str = get_string_expr(array_pool, args[2]);
-  const typet &index_type = str.length().type();
+  const typet &index_type = str.length_type();
   const exprt offset = args.size() == 3 ? from_integer(0, index_type) : args[3];
   const exprt count = args.size() == 3 ? str.length() : args[4];
   return add_axioms_for_substring(

--- a/src/solvers/strings/string_constraint_generator_testing.cpp
+++ b/src/solvers/strings/string_constraint_generator_testing.cpp
@@ -43,7 +43,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_is_prefix(
 {
   string_constraintst constraints;
   const symbol_exprt isprefix = fresh_symbol("isprefix");
-  const typet &index_type = str.length().type();
+  const typet &index_type = str.length_type();
   const exprt offset_within_bounds = and_exprt(
     binary_relation_exprt(offset, ID_ge, from_integer(0, offset.type())),
     binary_relation_exprt(offset, ID_le, str.length()),
@@ -112,7 +112,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_is_prefix(
   const array_string_exprt &s1 =
     get_string_expr(array_pool, args[swap_arguments ? 0u : 1u]);
   const exprt offset =
-    args.size() == 2 ? from_integer(0, s0.length().type()) : args[2];
+    args.size() == 2 ? from_integer(0, s0.length_type()) : args[2];
   auto pair = add_axioms_for_is_prefix(fresh_symbol, s0, s1, offset);
   return {typecast_exprt(pair.first, f.type()), std::move(pair.second)};
 }
@@ -185,7 +185,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_is_suffix(
     get_string_expr(array_pool, args[swap_arguments ? 1u : 0u]);
   const array_string_exprt &s1 =
     get_string_expr(array_pool, args[swap_arguments ? 0u : 1u]);
-  const typet &index_type = s0.length().type();
+  const typet &index_type = s0.length_type();
 
   implies_exprt a1(issuffix, greater_or_equal_to(s1.length(), s0.length()));
   constraints.existential.push_back(a1);
@@ -243,7 +243,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_contains(
   string_constraintst constraints;
   const array_string_exprt s0 = get_string_expr(array_pool, f.arguments()[0]);
   const array_string_exprt s1 = get_string_expr(array_pool, f.arguments()[1]);
-  const typet &index_type = s0.length().type();
+  const typet &index_type = s0.length_type();
   const symbol_exprt contains = fresh_symbol("contains");
   const symbol_exprt startpos = fresh_symbol("startpos_contains", index_type);
 

--- a/src/solvers/strings/string_constraint_generator_transformation.cpp
+++ b/src/solvers/strings/string_constraint_generator_transformation.cpp
@@ -46,7 +46,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_set_length(
     array_pool.find(f.arguments()[1], f.arguments()[0]);
   const array_string_exprt s1 = get_string_expr(array_pool, f.arguments()[2]);
   const exprt &k = f.arguments()[3];
-  const typet &index_type = s1.length().type();
+  const typet &index_type = s1.length_type();
   const typet &char_type = s1.content().type().subtype();
 
   // We add axioms:
@@ -128,7 +128,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_substring(
   const exprt &start,
   const exprt &end)
 {
-  const typet &index_type = str.length().type();
+  const typet &index_type = str.length_type();
   PRECONDITION(start.type() == index_type);
   PRECONDITION(end.type() == index_type);
 
@@ -190,7 +190,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_trim(
   const array_string_exprt &str = get_string_expr(array_pool, f.arguments()[2]);
   const array_string_exprt &res =
     array_pool.find(f.arguments()[1], f.arguments()[0]);
-  const typet &index_type = str.length().type();
+  const typet &index_type = str.length_type();
   const typet &char_type = str.content().type().subtype();
   const symbol_exprt idx = fresh_symbol("index_trim", index_type);
   const exprt space_char = from_integer(' ', char_type);
@@ -314,7 +314,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_replace(
 
     constraints.existential.push_back(equal_exprt(res.length(), str.length()));
 
-    symbol_exprt qvar = fresh_symbol("QA_replace", str.length().type());
+    symbol_exprt qvar = fresh_symbol("QA_replace", str.length_type());
     implies_exprt case1(
       equal_exprt(str[qvar], old_char), equal_exprt(res[qvar], new_char));
     implies_exprt case2(
@@ -343,7 +343,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_delete_char_at(
   const array_string_exprt res =
     array_pool.find(f.arguments()[1], f.arguments()[0]);
   const array_string_exprt str = get_string_expr(array_pool, f.arguments()[2]);
-  exprt index_one = from_integer(1, str.length().type());
+  exprt index_one = from_integer(1, str.length_type());
   return add_axioms_for_delete(
     fresh_symbol,
     res,
@@ -377,9 +377,9 @@ std::pair<exprt, string_constraintst> add_axioms_for_delete(
   const exprt &end,
   array_poolt &array_pool)
 {
-  PRECONDITION(start.type() == str.length().type());
-  PRECONDITION(end.type() == str.length().type());
-  const typet &index_type = str.length().type();
+  PRECONDITION(start.type() == str.length_type());
+  PRECONDITION(end.type() == str.length_type());
+  const typet &index_type = str.length_type();
   const typet &char_type = str.content().type().subtype();
   const array_string_exprt sub1 =
     array_pool.fresh_string(index_type, char_type);
@@ -387,7 +387,7 @@ std::pair<exprt, string_constraintst> add_axioms_for_delete(
     array_pool.fresh_string(index_type, char_type);
   return combine_results(
     add_axioms_for_substring(
-      fresh_symbol, sub1, str, from_integer(0, str.length().type()), start),
+      fresh_symbol, sub1, str, from_integer(0, str.length_type()), start),
     combine_results(
       add_axioms_for_substring(fresh_symbol, sub2, str, end, str.length()),
       add_axioms_for_concat(fresh_symbol, res, sub1, sub2)));

--- a/src/solvers/strings/string_constraint_generator_valueof.cpp
+++ b/src/solvers/strings/string_constraint_generator_valueof.cpp
@@ -220,7 +220,7 @@ add_axioms_from_int_hex(const array_string_exprt &res, const exprt &i)
   const typet &type = i.type();
   PRECONDITION(type.id() == ID_signedbv);
   string_constraintst constraints;
-  const typet &index_type = res.length().type();
+  const typet &index_type = res.length_type();
   const typet &char_type = res.content().type().subtype();
   exprt sixteen = from_integer(16, index_type);
   exprt minus_char = from_integer('-', char_type);
@@ -337,7 +337,7 @@ string_constraintst add_axioms_for_correct_number_format(
 {
   string_constraintst constraints;
   const typet &char_type = str.content().type().subtype();
-  const typet &index_type = str.length().type();
+  const typet &index_type = str.length_type();
 
   const exprt &chr = str[0];
   const equal_exprt starts_with_minus(chr, from_integer('-', char_type));

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -780,7 +780,7 @@ decision_proceduret::resultt string_refinementt::dec_solve()
   for(const auto &string : generator.array_pool.created_strings())
   {
     add_lemma(binary_relation_exprt{
-      string.length(), ID_ge, from_integer(0, string.length().type())});
+      string.length(), ID_ge, from_integer(0, string.length_type())});
   }
 
   while((loop_bound_--) > 0)
@@ -1383,7 +1383,7 @@ static std::pair<bool, std::vector<exprt>> check_axioms(
   {
     const string_not_contains_constraintt &nc_axiom = axioms.not_contains[i];
     const symbol_exprt univ_var = generator.fresh_symbol(
-      "not_contains_univ_var", nc_axiom.s0.length().type());
+      "not_contains_univ_var", nc_axiom.s0.length_type());
     const exprt negated_axiom = negation_of_not_contains_constraint(
       nc_axiom, univ_var, [&](const exprt &expr) {
         return simplify_expr(get(expr), ns);

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -70,6 +70,11 @@ public:
     return to_array_type(type()).size();
   }
 
+  const typet &length_type() const
+  {
+    return to_array_type(type()).size().type();
+  }
+
   exprt &content()
   {
     return *this;

--- a/src/util/string_expr.h
+++ b/src/util/string_expr.h
@@ -92,7 +92,7 @@ public:
 
   index_exprt operator[](int i) const
   {
-    return index_exprt(content(), from_integer(i, length().type()));
+    return index_exprt(content(), from_integer(i, length_type()));
   }
 };
 


### PR DESCRIPTION
Directly accessing the size of the string backing arrays will soon no longer be allowed, as the length of the string needs to be stored separately and the size of the backing array will no longer be relied upon.

We introduce a functionality to keep accessing the type of the array size, as this is widely used and we don't need to query the array_pool for that.

Based on https://github.com/diffblue/cbmc/pull/4608. Only review last 2 commits.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
