### PR TITLE
String solver: add non-negative length constraint before solving [TG-7439]

### DIFF
--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -740,8 +740,8 @@ decision_proceduret::resultt string_refinementt::dec_solve()
   // All generated strings should have non-negative length
   for(const auto &string : generator.array_pool.created_strings())
   {
-    add_lemma(binary_relation_exprt{
-      string.length(), ID_ge, from_integer(0, string.length_type())});
+    add_lemma(greater_or_equal_to(
+      string.length(), from_integer(0, string.length_type())));
   }
 
   // Initial try without index set

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -737,6 +737,13 @@ decision_proceduret::resultt string_refinementt::dec_solve()
   for(const exprt &lemma : generator.constraints.existential)
     add_lemma(lemma);
 
+  // All generated strings should have non-negative length
+  for(const auto &string : generator.array_pool.created_strings())
+  {
+    add_lemma(binary_relation_exprt{
+      string.length(), ID_ge, from_integer(0, string.length_type())});
+  }
+
   // Initial try without index set
   const auto get = [this](const exprt &expr) { return this->get(expr); };
   dependencies.clean_cache();
@@ -775,13 +782,6 @@ decision_proceduret::resultt string_refinementt::dec_solve()
     generate_instantiations(index_sets, axioms, not_contain_witnesses);
   for(const auto &instance : initial_instances)
     add_lemma(instance);
-
-  // All generated strings should have non-negative length
-  for(const auto &string : generator.array_pool.created_strings())
-  {
-    add_lemma(binary_relation_exprt{
-      string.length(), ID_ge, from_integer(0, string.length_type())});
-  }
 
   while((loop_bound_--) > 0)
   {


### PR DESCRIPTION
Add non-negativeness constraint on string lengths before doing the first iteration over the index set.
    
These constraints used to be added after that step, and some of the length variables were missing these constraints.
    
I don't have a failing example at hand, but this issue is made very visible by the upcoming changes to the way we deal with string lengths.

Based on https://github.com/diffblue/cbmc/pull/4609
**Only review last commit.**

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
