### PR TITLE
change return_value_identifier() to return_value_symbol

### DIFF
--- a/src/goto-programs/mm_io.cpp
+++ b/src/goto-programs/mm_io.cpp
@@ -56,8 +56,7 @@ void mm_io(
           const code_typet &ct=to_code_type(mm_io_r.type());
 
           irep_idt identifier=to_symbol_expr(mm_io_r).get_identifier();
-          irep_idt r_identifier = return_value_identifier(identifier, ns);
-          symbol_exprt return_value(r_identifier, ct.return_type());
+          auto return_value = return_value_symbol(identifier, ns);
           if_exprt if_expr(integer_address(d.pointer()), return_value, d);
           if(!replace_expr(d, if_expr, a.rhs()))
             it->set_assign(a);

--- a/src/goto-programs/remove_returns.h
+++ b/src/goto-programs/remove_returns.h
@@ -78,8 +78,9 @@ Date:   September 2009
 class goto_functionst;
 class goto_model_functiont;
 class goto_modelt;
-class symbol_table_baset;
 class namespacet;
+class symbol_table_baset;
+class symbol_exprt;
 
 void remove_returns(symbol_table_baset &, goto_functionst &);
 
@@ -94,8 +95,8 @@ void restore_returns(symbol_table_baset &, goto_functionst &);
 
 void restore_returns(goto_modelt &);
 
-/// produces the identifier that is used to store the return
+/// produces the symbol that is used to store the return
 /// value of the function with the given identifier
-irep_idt return_value_identifier(const irep_idt &, const namespacet &);
+symbol_exprt return_value_symbol(const irep_idt &, const namespacet &);
 
 #endif // CPROVER_GOTO_PROGRAMS_REMOVE_RETURNS_H

--- a/src/goto-programs/replace_calls.cpp
+++ b/src/goto-programs/replace_calls.cpp
@@ -97,16 +97,18 @@ void replace_callst::operator()(
     PRECONDITION(base_type_eq(f_it1->second.type, f_it2->second.type, ns));
 
     // check that returns have not been removed
-    goto_programt::const_targett next_it = std::next(it);
-    if(next_it != goto_program.instructions.end() && next_it->is_assign())
+    if(to_code_type(f_it1->second.type).return_type().id() != ID_empty)
     {
-      const code_assignt &ca = next_it->get_assign();
-      const exprt &rhs = ca.rhs();
+      goto_programt::const_targett next_it = std::next(it);
+      if(next_it != goto_program.instructions.end() && next_it->is_assign())
+      {
+        const code_assignt &ca = next_it->get_assign();
+        const exprt &rhs = ca.rhs();
 
-      INVARIANT(
-        rhs.id() != ID_symbol || to_symbol_expr(rhs).get_identifier() !=
-                                   return_value_identifier(id, ns),
-        "returns must not be removed before replacing calls");
+        INVARIANT(
+          rhs != return_value_symbol(id, ns),
+          "returns must not be removed before replacing calls");
+      }
     }
 
     // Finally modify the call


### PR DESCRIPTION
All users of this function either compare the result with a `symbol_exprt` or
build a `symbol_exprt`.  This change makes the function return a `symbol_exprt`
instead of the identifier, which reduces effort at the call site.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
