### PR TITLE
expr2java: use .name in case there is no pretty name

### DIFF
--- a/jbmc/src/java_bytecode/expr2java.cpp
+++ b/jbmc/src/java_bytecode/expr2java.cpp
@@ -150,7 +150,10 @@ std::string expr2javat::convert_struct(
 
       dest+=sep;
       dest+='.';
-      dest += id2string(c.get_pretty_name());
+      irep_idt field_name = c.get_pretty_name();
+      if(field_name.empty())
+        field_name = c.get_name();
+      dest += id2string(field_name);
       dest+='=';
       dest+=tmp;
     }


### PR DESCRIPTION
This now matches the behavior of expr2c and the convention used in symbolt::display_name()

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
