### PR TITLE
C front-end: Do not lose comments in type checking

### DIFF
--- a/regression/cbmc/pragma_cprover2/main.c
+++ b/regression/cbmc/pragma_cprover2/main.c
@@ -1,0 +1,24 @@
+int foo(int x)
+{
+  return x;
+}
+
+int main()
+{
+  int n;
+
+#pragma CPROVER check push
+#pragma CPROVER check disable "signed-overflow"
+  // do not generate assertions for the following statements
+  int x = n + n;
+  ++n;
+  n++;
+  n += 1;
+  foo(x + n);
+  // pop all annotations
+#pragma CPROVER check pop
+  // but do generate assertions for these
+  x = n + n;
+  foo(x + n);
+  return x;
+}

--- a/regression/cbmc/pragma_cprover2/test.desc
+++ b/regression/cbmc/pragma_cprover2/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--signed-overflow-check
+^\[main.overflow\.1\] line 21 arithmetic overflow on signed \+ in n \+ n: FAILURE$
+^\[main.overflow\.2\] line 22 arithmetic overflow on signed \+ in x \+ n: FAILURE$
+^\*\* 2 of 2 failed
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/ansi-c/c_typecheck_code.cpp
+++ b/src/ansi-c/c_typecheck_code.cpp
@@ -243,7 +243,16 @@ void c_typecheck_baset::typecheck_decl(codet &code)
   }
 
   ansi_c_declarationt declaration;
+  irep_idt comment = code.source_location().get_comment();
   declaration.swap(code.op0());
+  if(!comment.empty())
+  {
+    for(auto &d : declaration.declarators())
+    {
+      if(d.source_location().get_comment().empty())
+        d.add_source_location().set_comment(comment);
+    }
+  }
 
   if(declaration.get_is_static_assert())
   {

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2019,6 +2019,10 @@ void c_typecheck_baset::typecheck_side_effect_function_call(
     throw 0;
   }
 
+  irep_idt comment = expr.source_location().get_comment();
+  if(!comment.empty() && f_op.source_location().get_comment().empty())
+    f_op.add_source_location().set_comment(comment);
+
   const code_typet &code_type=to_code_type(f_op.type());
 
   expr.type()=code_type.return_type();


### PR DESCRIPTION
In case of declarations and function calls we need to carry over
comments from the statement's source location into individual
subexpressions as the source location of those subexpressions will be
used when generating the goto program instruction.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
