### PR TITLE
bugfix: pointer check failure in fgets

### DIFF
--- a/regression/cbmc-library/fgets-01/test.desc
+++ b/regression/cbmc-library/fgets-01/test.desc
@@ -5,6 +5,6 @@ main.c
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
 \[main.assertion.3\] line 16 assertion p\[1\] == 'b': FAILURE
-\*\* 2 of \d+ failed
+\*\* 1 of \d+ failed
 --
 ^warning: ignoring

--- a/src/ansi-c/library/stdio.c
+++ b/src/ansi-c/library/stdio.c
@@ -259,10 +259,10 @@ char *fgets(char *str, int size, FILE *stream)
   if(size>0)
   {
     int str_length=__VERIFIER_nondet_int();
-    __CPROVER_assume(str_length>0 && str_length<size);
+    __CPROVER_assume(str_length >= 0 && str_length < size);
     // check that the memory is accessible
-    (void)*(char *)str;
-    (void)*(((const char *)str) + str_length - 1);
+    __CPROVER_precondition(
+      __CPROVER_w_ok(str, str_length + 1), "fgets buffer writeable");
     char contents_nondet[str_length];
     __CPROVER_array_replace(str, contents_nondet);
     if(!error)

--- a/src/ansi-c/library/stdio.c
+++ b/src/ansi-c/library/stdio.c
@@ -259,7 +259,7 @@ char *fgets(char *str, int size, FILE *stream)
   if(size>0)
   {
     int str_length=__VERIFIER_nondet_int();
-    __CPROVER_assume(str_length>=0 && str_length<size);
+    __CPROVER_assume(str_length>0 && str_length<size);
     // check that the memory is accessible
     (void)*(char *)str;
     (void)*(((const char *)str) + str_length - 1);

--- a/src/ansi-c/library/stdio.c
+++ b/src/ansi-c/library/stdio.c
@@ -260,9 +260,7 @@ char *fgets(char *str, int size, FILE *stream)
   {
     int str_length=__VERIFIER_nondet_int();
     __CPROVER_assume(str_length >= 0 && str_length < size);
-    // check that the memory is accessible
-    __CPROVER_precondition(
-      __CPROVER_w_ok(str, str_length + 1), "fgets buffer writeable");
+    __CPROVER_precondition(__CPROVER_w_ok(str, size), "fgets buffer writable");
     char contents_nondet[str_length];
     __CPROVER_array_replace(str, contents_nondet);
     if(!error)


### PR DESCRIPTION
Now we assume str_length greater than 0, since no dereference should take place when str_length equals 0.
Updated cbmc-library/fgets-01 regression test.

Fixes: #4621

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.
