### PR TITLE
rename add_throws_exceptions

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -561,7 +561,7 @@ void java_bytecode_convert_methodt::convert(
   method_symbol.location.set_function(method_identifier);
 
   for(const auto &exception_name : m.throws_exception_table)
-    method_type.add_throws_exceptions(exception_name);
+    method_type.add_throws_exception(exception_name);
 
   const std::string signature_string = pretty_signature(method_type);
 

--- a/jbmc/src/java_bytecode/java_types.h
+++ b/jbmc/src/java_bytecode/java_types.h
@@ -131,7 +131,7 @@ public:
     return exceptions;
   }
 
-  void add_throws_exceptions(irep_idt exception)
+  void add_throws_exception(irep_idt exception)
   {
     add(ID_exceptions_thrown_list).get_sub().push_back(irept(exception));
   }


### PR DESCRIPTION
This is follow up for #4618, and a addresses a comment by Chris.  The method
only adds one exception, not multiple.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
