### PR TITLE
fix up __float128 and _Float128 support

### DIFF
--- a/regression/ansi-c/gcc_version1/gcc-5.c
+++ b/regression/ansi-c/gcc_version1/gcc-5.c
@@ -3,7 +3,8 @@ typedef float _Float32;
 typedef double _Float32x;
 typedef double _Float64;
 typedef long double _Float64x;
+typedef long double _Float128;
 typedef long double _Float128x;
 
 // But this type should:
-_Float128 f128;
+__float128 f128;

--- a/regression/ansi-c/gcc_version1/gcc-7.c
+++ b/regression/ansi-c/gcc_version1/gcc-7.c
@@ -5,3 +5,5 @@ _Float64 f64;
 _Float64x f64x;
 _Float128 f128;
 _Float128x f128x;
+
+__float128 gcc_f128;

--- a/regression/cbmc/ts18661_typedefs/main.c
+++ b/regression/cbmc/ts18661_typedefs/main.c
@@ -1,31 +1,51 @@
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__)
 
-#include <features.h> // For __GNUC_PREREQ
+#  ifdef __clang__
 
-#ifdef __x86_64__
-#define FLOAT128_MINOR_VERSION 3
+#    define HAS_FLOAT128
+
+#  else
+
+#    include <features.h> // For __GNUC_PREREQ
+
+#    ifdef __x86_64__
+#      define FLOAT128_MINOR_VERSION 3
+#    else
+#      define FLOAT128_MINOR_VERSION 5
+#    endif
+
+#    if __GNUC__ >= 7
+#      define HAS_FLOATN
+#    endif
+
+#    if __GNUC_PREREQ(4, FLOAT128_MINOR_VERSION)
+#      define HAS_FLOAT128
+#    endif
+
+#  endif
+
+#endif
+
+#ifdef HAS_FLOATN
+typedef _Float32 f1;
+typedef _Float32x f2;
+typedef _Float64 f3;
+typedef _Float64x f4;
+typedef _Float128 f5;
+typedef _Float128x f6;
 #else
-#define FLOAT128_MINOR_VERSION 5
-#endif
-
-#if __GNUC__ >= 7
-#define HAS_FLOATN
-#elif __GNUC_PREREQ(4, FLOAT128_MINOR_VERSION)
-#define HAS_FLOAT128
-#endif
-
-#endif
-
-#ifndef HAS_FLOATN
 typedef float _Float32;
 typedef double _Float32x;
 typedef double _Float64;
 typedef long double _Float64x;
+typedef long double _Float128;
 typedef long double _Float128x;
 #endif
 
-#if !defined(HAS_FLOATN) && !defined(HAS_FLOAT128)
-typedef long double _Float128;
+#if defined(HAS_FLOAT128)
+typedef __float128 f7;
+#else
+typedef long double __float128;
 #endif
 
 int main(int argc, char** argv) {

--- a/src/ansi-c/ansi_c_internal_additions.cpp
+++ b/src/ansi-c/ansi_c_internal_additions.cpp
@@ -208,8 +208,12 @@ void ansi_c_internal_additions(std::string &code)
       // https://gcc.gnu.org/onlinedocs/gcc/Floating-Types.html
       // For clang, __float128 is a keyword.
       // For gcc, this is a typedef and not a keyword.
-      if(config.ansi_c.mode != configt::ansi_ct::flavourt::CLANG)
+      if(
+        config.ansi_c.mode != configt::ansi_ct::flavourt::CLANG &&
+        config.ansi_c.gcc__float128_type)
+      {
         code += "typedef " CPROVER_PREFIX "Float128 __float128;\n";
+      }
     }
     else if(config.ansi_c.arch == "ppc64le")
     {
@@ -222,8 +226,12 @@ void ansi_c_internal_additions(std::string &code)
       // https://gcc.gnu.org/onlinedocs/gcc/Floating-Types.html
       // For clang, __float128 is a keyword.
       // For gcc, this is a typedef and not a keyword.
-      if(config.ansi_c.mode != configt::ansi_ct::flavourt::CLANG)
+      if(
+        config.ansi_c.mode != configt::ansi_ct::flavourt::CLANG &&
+        config.ansi_c.gcc__float128_type)
+      {
         code+="typedef long double __float128;\n";
+      }
     }
 
     if(

--- a/src/ansi-c/ansi_c_language.cpp
+++ b/src/ansi-c/ansi_c_language.cpp
@@ -76,7 +76,6 @@ bool ansi_c_languaget::parse(
   ansi_c_parser.set_message_handler(get_message_handler());
   ansi_c_parser.for_has_scope=config.ansi_c.for_has_scope;
   ansi_c_parser.ts_18661_3_Floatn_types=config.ansi_c.ts_18661_3_Floatn_types;
-  ansi_c_parser.Float128_type = config.ansi_c.Float128_type;
   ansi_c_parser.cpp98=false; // it's not C++
   ansi_c_parser.cpp11=false; // it's not C++
   ansi_c_parser.mode=config.ansi_c.mode;

--- a/src/ansi-c/ansi_c_parser.h
+++ b/src/ansi-c/ansi_c_parser.h
@@ -28,16 +28,15 @@ class ansi_c_parsert:public parsert
 public:
   ansi_c_parse_treet parse_tree;
 
-  ansi_c_parsert():
-    tag_following(false),
-    asm_block_following(false),
-    parenthesis_counter(0),
-    mode(modet::NONE),
-    cpp98(false),
-    cpp11(false),
-    for_has_scope(false),
-    ts_18661_3_Floatn_types(false),
-    Float128_type(false)
+  ansi_c_parsert()
+    : tag_following(false),
+      asm_block_following(false),
+      parenthesis_counter(0),
+      mode(modet::NONE),
+      cpp98(false),
+      cpp11(false),
+      for_has_scope(false),
+      ts_18661_3_Floatn_types(false)
   {
   }
 
@@ -83,9 +82,6 @@ public:
 
   // ISO/IEC TS 18661-3:2015
   bool ts_18661_3_Floatn_types;
-
-  // Does the compiler version emulated provide _Float128?
-  bool Float128_type;
 
   typedef ansi_c_identifiert identifiert;
   typedef ansi_c_scopet scopet;

--- a/src/ansi-c/gcc_version.cpp
+++ b/src/ansi-c/gcc_version.cpp
@@ -142,3 +142,23 @@ std::ostream &operator<<(std::ostream &out, const gcc_versiont &v)
 {
   return out << v.v_major << '.' << v.v_minor << '.' << v.v_patchlevel;
 }
+
+void configure_gcc(const gcc_versiont &gcc_version)
+{
+  // ISO/IEC TS 18661-3:2015 support was introduced with gcc 7.0
+  if(
+    gcc_version.flavor == gcc_versiont::flavort::GCC &&
+    gcc_version.is_at_least(7u))
+  {
+    config.ansi_c.ts_18661_3_Floatn_types = true;
+  }
+
+  const auto gcc_float128_minor_version =
+    config.ansi_c.arch == "x86_64" ? 3u : 5u;
+
+  // __float128 exists (as a typedef) since gcc 4.5 everywhere,
+  // and since 4.3 on x86_64
+  config.ansi_c.gcc__float128_type =
+    gcc_version.flavor == gcc_versiont::flavort::GCC &&
+    gcc_version.is_at_least(4u, gcc_float128_minor_version);
+}

--- a/src/ansi-c/gcc_version.h
+++ b/src/ansi-c/gcc_version.h
@@ -50,6 +50,8 @@ public:
   }
 };
 
+void configure_gcc(const gcc_versiont &);
+
 std::ostream &operator<<(std::ostream &, const gcc_versiont &);
 
 #endif

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -565,7 +565,7 @@ void ansi_c_scanner_init()
                     return make_identifier();
                 }
 
-"_Float128"     { if(PARSER.Float128_type)
+"_Float128"     { if(PARSER.ts_18661_3_Floatn_types)
                   { loc(); return TOK_GCC_FLOAT128; }
                   else
                     return make_identifier();

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -28,6 +28,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <ansi-c/c_preprocess.h>
 #include <ansi-c/cprover_library.h>
+#include <ansi-c/gcc_version.h>
 
 #include <assembler/remove_asm.h>
 
@@ -489,6 +490,14 @@ int cbmc_parse_optionst::doit()
   }
 
   register_languages();
+
+  // configure gcc, if required
+  if(config.ansi_c.preprocessor == configt::ansi_ct::preprocessort::GCC)
+  {
+    gcc_versiont gcc_version;
+    gcc_version.get("gcc");
+    configure_gcc(gcc_version);
+  }
 
   if(cmdline.isset("test-preprocessor"))
     return test_c_preprocessor(ui_message_handler)

--- a/src/cpp/cpp_parser.cpp
+++ b/src/cpp/cpp_parser.cpp
@@ -25,7 +25,6 @@ bool cpp_parsert::parse()
     config.cpp.cpp_standard==configt::cppt::cpp_standardt::CPP11 ||
     config.cpp.cpp_standard==configt::cppt::cpp_standardt::CPP14;
   ansi_c_parser.ts_18661_3_Floatn_types=false;
-  ansi_c_parser.Float128_type = false;
   ansi_c_parser.in=in;
   ansi_c_parser.mode=mode;
   ansi_c_parser.set_file(get_file());

--- a/src/goto-cc/gcc_mode.cpp
+++ b/src/goto-cc/gcc_mode.cpp
@@ -539,7 +539,9 @@ int gcc_modet::doit()
   const auto gcc_float128_minor_version =
     config.ansi_c.arch == "x86_64" ? 3u : 5u;
 
-  config.ansi_c.Float128_type =
+  // __float128 exists (as a typedef) since gcc 4.5 everywhere,
+  // and since 4.3 on x86_64
+  config.ansi_c.gcc__float128_type =
     gcc_version.flavor == gcc_versiont::flavort::GCC &&
     gcc_version.is_at_least(4u, gcc_float128_minor_version);
 

--- a/src/goto-cc/gcc_mode.cpp
+++ b/src/goto-cc/gcc_mode.cpp
@@ -531,23 +531,12 @@ int gcc_modet::doit()
   if(cmdline.isset("-fsingle-precision-constant"))
     config.ansi_c.single_precision_constant=true;
 
-  // ISO/IEC TS 18661-3:2015 support was introduced with gcc 7.0
-  if(gcc_version.flavor==gcc_versiont::flavort::GCC &&
-     gcc_version.is_at_least(7))
-    config.ansi_c.ts_18661_3_Floatn_types=true;
-
-  const auto gcc_float128_minor_version =
-    config.ansi_c.arch == "x86_64" ? 3u : 5u;
-
-  // __float128 exists (as a typedef) since gcc 4.5 everywhere,
-  // and since 4.3 on x86_64
-  config.ansi_c.gcc__float128_type =
-    gcc_version.flavor == gcc_versiont::flavort::GCC &&
-    gcc_version.is_at_least(4u, gcc_float128_minor_version);
-
   // -fshort-double makes double the same as float
   if(cmdline.isset("fshort-double"))
     config.ansi_c.double_width=config.ansi_c.single_width;
+
+  // configure version-specific gcc settings
+  configure_gcc(gcc_version);
 
   switch(compiler.mode)
   {

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -948,7 +948,7 @@ bool configt::set(const cmdlinet &cmdline)
   }
 
   if(ansi_c.preprocessor == ansi_ct::preprocessort::GCC)
-    ansi_c.Float128_type = true;
+    ansi_c.gcc__float128_type = true;
 
   set_arch(arch);
 

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -44,7 +44,7 @@ public:
     bool char_is_unsigned, wchar_t_is_unsigned;
     bool for_has_scope;
     bool ts_18661_3_Floatn_types; // ISO/IEC TS 18661-3:2015
-    bool Float128_type;
+    bool gcc__float128_type;      // __float128, a gcc extension since 4.3/4.5
     bool single_precision_constant;
     enum class c_standardt { C89, C99, C11 } c_standard;
     static c_standardt default_c_standard();


### PR DESCRIPTION
`_Float128` is a keyword, defined in ISO/IEC TS 18661-3:2015, and exists since
gcc 7.0. clang does not offer it.

`__float128` is a typedef in gcc since 4.3/4.5, depending on architecture.

`__float128` is a keyword in clang.

This PR attempts to clean this up.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
