### PR TITLE
 Make inverse_memory_map of interpreter store symbols instead of identifier

### DIFF
--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -621,19 +621,17 @@ exprt interpretert::get_value(
     {
       // We want the symbol pointed to
       mp_integer address = rhs[numeric_cast_v<std::size_t>(offset)];
-      irep_idt identifier=address_to_identifier(address);
+      const symbol_exprt &symbol_expr = address_to_symbol(address);
       mp_integer offset_from_address = address_to_offset(address);
-      const typet type_from_identifier = get_type(identifier);
-      const symbol_exprt symbol_expr(identifier, type_from_identifier);
 
       if(offset_from_address == 0)
         return address_of_exprt(symbol_expr);
 
       if(
-        type_from_identifier.id() == ID_struct ||
-        type_from_identifier.id() == ID_struct_tag)
+        symbol_expr.type().id() == ID_struct ||
+        symbol_expr.type().id() == ID_struct_tag)
       {
-        const auto c = get_component(identifier, offset_from_address);
+        const auto c = get_component(symbol_expr.type(), offset_from_address);
         member_exprt member_expr(symbol_expr, c);
         return address_of_exprt(member_expr);
       }
@@ -722,7 +720,7 @@ void interpretert::assign(
       if(show)
       {
         status() << total_steps << " ** assigning "
-                 << address_to_identifier(address_val) << "["
+                 << address_to_symbol(address_val).get_identifier() << "["
                  << address_to_offset(address_val)
                  << "]:=" << rhs[numeric_cast_v<std::size_t>(i)] << "\n"
                  << eom;
@@ -770,7 +768,7 @@ void interpretert::execute_function_call()
 #if 0
   const memory_cellt &cell=memory[address];
 #endif
-  const irep_idt &identifier = address_to_identifier(address);
+  const irep_idt &identifier = address_to_symbol(address).get_identifier();
   trace_step.called_function = identifier;
 
   const goto_functionst::function_mapt::const_iterator f_it=
@@ -815,7 +813,7 @@ void interpretert::execute_function_call()
     for(const auto &id : locals)
     {
       const symbolt &symbol=ns.lookup(id);
-      frame.local_map[id]=build_memory_map(id, symbol.type);
+      frame.local_map[id] = build_memory_map(symbol.symbol_expr());
     }
 
     // assign the arguments
@@ -863,7 +861,7 @@ void interpretert::build_memory_map()
 {
   // put in a dummy for NULL
   memory.resize(1);
-  inverse_memory_map[0] = ID_null_object;
+  inverse_memory_map[0] = {};
 
   num_dynamic_objects=0;
   dynamic_types.clear();
@@ -894,7 +892,7 @@ void interpretert::build_memory_map(const symbolt &symbol)
     mp_integer address=memory.size();
     memory.resize(numeric_cast_v<std::size_t>(address + size));
     memory_map[symbol.name]=address;
-    inverse_memory_map[address]=symbol.name;
+    inverse_memory_map[address] = symbol.symbol_expr();
   }
 }
 
@@ -926,21 +924,19 @@ typet interpretert::concretize_type(const typet &type)
 
 /// Populates dynamic entries of the memory map
 /// \return Updates the memory map to include variable id if it does not exist
-mp_integer interpretert::build_memory_map(
-  const irep_idt &id,
-  const typet &type)
+mp_integer interpretert::build_memory_map(const symbol_exprt &symbol_expr)
 {
-  typet alloc_type=concretize_type(type);
+  typet alloc_type = concretize_type(symbol_expr.type());
   mp_integer size=get_size(alloc_type);
-  auto it=dynamic_types.find(id);
+  auto it = dynamic_types.find(symbol_expr.get_identifier());
 
   if(it!=dynamic_types.end())
   {
-    mp_integer address=memory_map[id];
+    mp_integer address = memory_map[symbol_expr.get_identifier()];
     mp_integer current_size=base_address_to_alloc_size(address);
     // current size <= size already recorded
     if(size<=current_size)
-      return memory_map[id];
+      return memory_map[symbol_expr.get_identifier()];
   }
 
   // The current size is bigger then the one previously recorded
@@ -951,9 +947,10 @@ mp_integer interpretert::build_memory_map(
 
   mp_integer address=memory.size();
   memory.resize(numeric_cast_v<std::size_t>(address + size));
-  memory_map[id]=address;
-  inverse_memory_map[address]=id;
-  dynamic_types.insert(std::pair<const irep_idt, typet>(id, alloc_type));
+  memory_map[symbol_expr.get_identifier()] = address;
+  inverse_memory_map[address] = symbol_expr;
+  dynamic_types.insert(
+    std::pair<const irep_idt, typet>(symbol_expr.get_identifier(), alloc_type));
 
   return address;
 }
@@ -1072,7 +1069,7 @@ void interpretert::print_memory(bool input_flags)
   {
     mp_integer i=cell_address.first;
     const memory_cellt &cell=cell_address.second;
-    const auto identifier=address_to_identifier(i);
+    const auto identifier = address_to_symbol(i).get_identifier();
     const auto offset=address_to_offset(i);
     debug() << identifier << "[" << offset << "]"
             << "=" << cell.value << eom;

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -427,8 +427,15 @@ struct_typet::componentt interpretert::get_component(
   const irep_idt &object,
   const mp_integer &offset)
 {
-  const symbolt &symbol=ns.lookup(object);
-  const typet real_type=ns.follow(symbol.type);
+  const symbolt &symbol = ns.lookup(object);
+  return get_component(symbol.type, offset);
+}
+
+/// Retrieves the member at \p offset of an object of type \p object_type.
+struct_typet::componentt
+interpretert::get_component(const typet &object_type, const mp_integer &offset)
+{
+  const typet real_type = ns.follow(object_type);
   if(real_type.id()!=ID_struct)
     throw "request for member of non-struct";
 

--- a/src/goto-programs/interpreter_class.h
+++ b/src/goto-programs/interpreter_class.h
@@ -197,9 +197,13 @@ protected:
   bool unbounded_size(const typet &);
   mp_integer get_size(const typet &type);
 
+  DEPRECATED("use the object_type version instead")
   struct_typet::componentt get_component(
     const irep_idt &object,
     const mp_integer &offset);
+
+  struct_typet::componentt
+  get_component(const typet &object_type, const mp_integer &offset);
 
   typet get_type(const irep_idt &id) const;
 

--- a/src/goto-programs/interpreter_class.h
+++ b/src/goto-programs/interpreter_class.h
@@ -106,7 +106,7 @@ protected:
   const goto_functionst &goto_functions;
 
   typedef std::unordered_map<irep_idt, mp_integer> memory_mapt;
-  typedef std::map<mp_integer, irep_idt> inverse_memory_mapt;
+  using inverse_memory_mapt = std::map<mp_integer, optionalt<symbol_exprt>>;
   memory_mapt memory_map;
   inverse_memory_mapt inverse_memory_map;
 
@@ -122,9 +122,9 @@ protected:
     return *lower_bound;
   }
 
-  irep_idt address_to_identifier(const mp_integer &address) const
+  symbol_exprt address_to_symbol(const mp_integer &address) const
   {
-    return address_to_object_record(address).second;
+    return *address_to_object_record(address).second;
   }
 
   mp_integer address_to_offset(const mp_integer &address) const
@@ -192,7 +192,7 @@ protected:
 
   void build_memory_map();
   void build_memory_map(const symbolt &symbol);
-  mp_integer build_memory_map(const irep_idt &id, const typet &type);
+  mp_integer build_memory_map(const symbol_exprt &symbol_expr);
   typet concretize_type(const typet &type);
   bool unbounded_size(const typet &);
   mp_integer get_size(const typet &type);

--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -469,7 +469,8 @@ void interpretert::evaluate(
       num_dynamic_objects++;
       buffer << "interpreter::dynamic_object" << num_dynamic_objects;
       irep_idt id(buffer.str().c_str());
-      mp_integer address=build_memory_map(id, expr.type().subtype());
+      mp_integer address =
+        build_memory_map(symbol_exprt{id, expr.type().subtype()});
       // TODO: check array of type
       // TODO: interpret zero-initialization argument
       dest.push_back(address);
@@ -875,7 +876,7 @@ void interpretert::evaluate(
       mp_integer address=result[0];
       if(address>0 && address<memory.size())
       {
-        auto obj_type=get_type(address_to_identifier(address));
+        auto obj_type = address_to_symbol(address).type();
 
         mp_integer offset=address_to_offset(address);
         mp_integer byte_offset;
@@ -1107,7 +1108,7 @@ mp_integer interpretert::evaluate_address(
         return m_it2->second;
     }
     mp_integer address=memory.size();
-    build_memory_map(to_symbol_expr(expr).get_identifier(), expr.type());
+    build_memory_map(to_symbol_expr(expr));
     return address;
   }
   else if(expr.id()==ID_dereference)


### PR DESCRIPTION
By storing only identifiers, some information is lost (for instance the type) that needs to be retrieved later. It is particularly bad for SSA symbols because to retrieve the SSA with have to parse the identifier. 

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
