### PR TITLE
Add string solver axioms for StringBuffer.append(I)

### DIFF
--- a/src/solvers/strings/string_constraint_generator.h
+++ b/src/solvers/strings/string_constraint_generator.h
@@ -204,6 +204,11 @@ std::pair<exprt, string_constraintst> add_axioms_for_concat_code_point(
   symbol_generatort &fresh_symbol,
   const function_application_exprt &f,
   array_poolt &array_pool);
+std::pair<exprt, string_constraintst> add_axioms_for_concat_integer(
+  symbol_generatort &fresh_symbol,
+  const function_application_exprt &f,
+  array_poolt &array_pool,
+  const namespacet &ns);
 std::pair<exprt, string_constraintst> add_axioms_for_constant(
   const array_string_exprt &res,
   irep_idt sval,

--- a/src/solvers/strings/string_constraint_generator_concat.cpp
+++ b/src/solvers/strings/string_constraint_generator_concat.cpp
@@ -157,3 +157,27 @@ std::pair<exprt, string_constraintst> add_axioms_for_concat_code_point(
     add_axioms_for_code_point(code_point, f.arguments()[3]),
     add_axioms_for_concat(fresh_symbol, res, s1, code_point));
 }
+
+/// Add axioms corresponding to the StringBuilder.append(I) function
+/// \param fresh_symbol: generator of fresh symbols
+/// \param f: function application with two arguments: a string and an integer
+/// \param array_pool: pool of arrays representing strings
+/// \param ns: namespace
+/// \return an expression
+std::pair<exprt, string_constraintst> add_axioms_for_concat_integer(
+  symbol_generatort &fresh_symbol,
+  const function_application_exprt &f,
+  array_poolt &array_pool,
+  const namespacet &ns)
+{
+  PRECONDITION(f.arguments().size() == 4);
+  const array_string_exprt res =
+    array_pool.find(f.arguments()[1], f.arguments()[0]);
+  const array_string_exprt s1 = get_string_expr(array_pool, f.arguments()[2]);
+  const typet &char_type = s1.content().type().subtype();
+  const typet &index_type = s1.length().type();
+  const array_string_exprt s2 = array_pool.fresh_string(index_type, char_type);
+  return combine_results(
+    add_axioms_for_string_of_int(s2, f.arguments()[3], 0, ns),
+    add_axioms_for_concat(fresh_symbol, res, s1, s2));
+}

--- a/src/solvers/strings/string_constraint_generator_main.cpp
+++ b/src/solvers/strings/string_constraint_generator_main.cpp
@@ -313,6 +313,8 @@ string_constraint_generatort::add_axioms_for_function_application(
     return add_axioms_for_format(fresh_symbol, expr, array_pool, message, ns);
   else if(id == ID_cprover_string_constrain_characters_func)
     return add_axioms_for_constrain_characters(fresh_symbol, expr, array_pool);
+  else if(id == ID_cprover_string_concat_int_func)
+    return add_axioms_for_concat_integer(fresh_symbol, expr, array_pool, ns);
   else
   {
     std::string msg(


### PR DESCRIPTION
Came up against the string solver throwing an exception while trying to analyse a StringBuffer.append call. I put together something that might do the job but have no idea how to test it properly or if it's correct.

Can someone with more know-how about this area help out. 

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.