### PR TITLE
Add return_value_identifier function

### DIFF
--- a/src/goto-programs/remove_returns.cpp
+++ b/src/goto-programs/remove_returns.cpp
@@ -295,13 +295,9 @@ bool remove_returnst::restore_returns(
   const irep_idt function_id=f_it->first;
 
   // do we have X#return_value?
-  const namespacet ns(symbol_table);
-  auto rv_symbol = return_value_symbol(function_id, ns);
-  auto rv_name = rv_symbol.get_identifier();
-
+  auto rv_name = return_value_identifier(function_id);
   symbol_tablet::symbolst::const_iterator rv_it=
     symbol_table.symbols.find(rv_name);
-
   if(rv_it==symbol_table.symbols.end())
     return true;
 
@@ -411,10 +407,15 @@ void restore_returns(goto_modelt &goto_model)
   rr.restore(goto_model.goto_functions);
 }
 
+irep_idt return_value_identifier(const irep_idt &identifier)
+{
+  return id2string(identifier) + RETURN_VALUE_SUFFIX;
+}
+
 symbol_exprt
 return_value_symbol(const irep_idt &identifier, const namespacet &ns)
 {
   const symbolt &function_symbol = ns.lookup(identifier);
   const typet &return_type = to_code_type(function_symbol.type).return_type();
-  return symbol_exprt(id2string(identifier) + RETURN_VALUE_SUFFIX, return_type);
+  return symbol_exprt(return_value_identifier(identifier), return_type);
 }

--- a/src/goto-programs/remove_returns.h
+++ b/src/goto-programs/remove_returns.h
@@ -95,6 +95,10 @@ void restore_returns(symbol_table_baset &, goto_functionst &);
 
 void restore_returns(goto_modelt &);
 
+/// produces the identifier that is used to store the return
+/// value of the function with the given identifier
+irep_idt return_value_identifier(const irep_idt &);
+
 /// produces the symbol that is used to store the return
 /// value of the function with the given identifier
 symbol_exprt return_value_symbol(const irep_idt &, const namespacet &);


### PR DESCRIPTION
This function was removed in https://github.com/diffblue/cbmc/pull/4616, I would like to bring it back - it makes `return_value_symbol` more abstract (no need to work with the `RETURN_VALUE_SUFFIX` string directly), there is at least one place where creating the whole symbol is not necessary and last but not least, the function was quite widely used in test-gen (so in order to update the cbmc pointer, this needs to be resolved).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
