### PR TITLE
Update coding standard for function brief documentation

### DIFF
--- a/CODING_STANDARD.md
+++ b/CODING_STANDARD.md
@@ -121,6 +121,8 @@ Formatting is enforced using clang-format. For more information about this, see
   functionality should remain in place for at least six months from the date of
   deprecation. Before deprecating code, all in-tree uses should be replaced or
   marked as deprecated.
+- In the brief of function descriptions, prefer imperatives such as
+  `Remove first element...` over `Removes first element...`.
 
 # Naming
 - Identifiers should make clear the purpose of the thing they are naming. 


### PR DESCRIPTION
Seems to be generally applied around the code, but is still the subject of questions.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
