### PR TITLE
Sharing map variable-height trees

### DIFF
--- a/src/util/sharing_map.h
+++ b/src/util/sharing_map.h
@@ -564,7 +564,6 @@ protected:
     std::set<const void *> &marked,
     bool mark = true) const;
 
-  static const std::string not_found_msg;
   static const std::size_t dummy_level;
 
   // config
@@ -1291,7 +1290,6 @@ SHARING_MAPT2(optionalt<std::reference_wrapper<const, mapped_type>>)::find(
 
 // static constants
 
-SHARING_MAPT(const std::string)::not_found_msg="key not found";
 SHARING_MAPT(const std::size_t)::dummy_level = 0xff;
 
 SHARING_MAPT(const std::size_t)::bits = 30;

--- a/src/util/sharing_map.h
+++ b/src/util/sharing_map.h
@@ -1284,7 +1284,7 @@ SHARING_MAPT2(optionalt<std::reference_wrapper<const, mapped_type>>)::find(
 
 SHARING_MAPT(const std::string)::not_found_msg="key not found";
 
-SHARING_MAPT(const std::size_t)::bits = 18;
+SHARING_MAPT(const std::size_t)::bits = 30;
 SHARING_MAPT(const std::size_t)::chunk = 3;
 
 SHARING_MAPT(const std::size_t)::mask = 0xffff >> (16 - chunk);

--- a/src/util/sharing_map.h
+++ b/src/util/sharing_map.h
@@ -535,9 +535,21 @@ protected:
     return lp;
   }
 
+  innert *migrate(
+    const std::size_t i,
+    const std::size_t key_suffix,
+    const std::size_t bit_last,
+    innert &inner);
+
   void iterate(
     const innert &n,
     std::function<void(const key_type &k, const mapped_type &m)> f) const;
+
+  void add_item_if_not_shared(
+    const innert &container,
+    const innert &inner,
+    delta_viewt &delta_view,
+    const bool only_common) const;
 
   void gather_all(const innert &n, delta_viewt &delta_view) const;
 
@@ -592,8 +604,7 @@ SHARING_MAPT(void)
 
       for(const auto &item : m)
       {
-        const innert *i = &item.second;
-        stack.push(i);
+        stack.push(&item.second);
       }
     }
     else
@@ -664,8 +675,7 @@ SHARING_MAPT(std::size_t)
 
       for(const auto &item : m)
       {
-        const innert *i = &item.second;
-        stack.push(i);
+        stack.push(&item.second);
       }
     }
     else
@@ -779,6 +789,73 @@ SHARING_MAPT(void)
   iterate(n, f);
 }
 
+SHARING_MAPT(void)::add_item_if_not_shared(
+  const innert &container,
+  const innert &inner,
+  delta_viewt &delta_view,
+  const bool only_common) const
+{
+  SM_ASSERT(!container.empty());
+  SM_ASSERT(!inner.empty());
+
+  std::stack<const innert *> stack;
+  stack.push(&inner);
+
+  do
+  {
+    const innert *ip = stack.top();
+    stack.pop();
+
+    SM_ASSERT(!ip->empty());
+
+    if(ip->is_internal())
+    {
+      const to_mapt &m = ip->get_to_map();
+      SM_ASSERT(!m.empty());
+
+      for(const auto &item : m)
+      {
+        const innert *i = &item.second;
+        stack.push(i);
+      }
+    }
+    else
+    {
+      SM_ASSERT(ip->is_container());
+
+      if(ip->shares_with(container))
+        return;
+
+      const leaft &l1 = container.get_container().front();
+
+      const leaf_listt &ll = ip->get_container();
+      SM_ASSERT(!ll.empty());
+
+      for(const auto &l : ll)
+      {
+        if(l1.shares_with(l))
+          return;
+
+        if(l1.get_key() == l.get_key())
+        {
+          // element is in both maps and not shared
+          delta_view.push_back(
+            {true, l1.get_key(), l1.get_value(), l.get_value()});
+          return;
+        }
+      }
+    }
+  }
+  while(!stack.empty());
+
+  // element is only in first map
+  if(!only_common)
+  {
+    const leaft &l1 = container.get_container().front();
+    delta_view.push_back({false, l1.get_key(), l1.get_value(), dummy});
+  }
+}
+
 SHARING_MAPT(void)
 ::get_delta_view(
   const sharing_mapt &other,
@@ -840,8 +917,10 @@ SHARING_MAPT(void)
       for(const auto &item : ip1->get_to_map())
       {
         const innert &child = item.second;
-        SM_ASSERT(!child.shares_with(*ip2));
-        stack.push(stack_itemt(&child, ip2));
+        if(!child.shares_with(*ip2))
+        {
+          stack.push(stack_itemt(&child, ip2));
+        }
       }
 
       continue;
@@ -880,12 +959,7 @@ SHARING_MAPT(void)
     {
       SM_ASSERT(is_singular(ip1->get_container()));
 
-      for(const auto &item : ip2->get_to_map())
-      {
-        const innert &child = item.second;
-        SM_ASSERT(!ip1->shares_with(child));
-        stack.push(stack_itemt(ip1, &child));
-      }
+      add_item_if_not_shared(*ip1, *ip2, delta_view, only_common);
 
       continue;
     }
@@ -903,11 +977,13 @@ SHARING_MAPT(void)
       {
         if(!l1.shares_with(*p))
         {
+          SM_ASSERT(other.has_key(k1));
           delta_view.push_back({k1, l1.get_value(), p->get_value()});
         }
       }
       else if(!only_common)
       {
+        SM_ASSERT(!other.has_key(k1));
         delta_view.push_back({k1, l1.get_value()});
       }
     }
@@ -917,21 +993,28 @@ SHARING_MAPT(void)
 
 SHARING_MAPT2(, innert *)::get_container_node(const key_type &k)
 {
+  SM_ASSERT(has_key(k));
+
   std::size_t key = hash()(k);
   innert *ip = &map;
+  SM_ASSERT(ip->is_internal());
 
   for(std::size_t i = 0; i < steps; i++)
   {
     std::size_t bit = key & mask;
 
     ip = ip->add_child(bit);
+    SM_ASSERT(ip != nullptr);
+    SM_ASSERT(!ip->empty());
+
+    if(ip->is_container())
+      return ip;
 
     key >>= chunk;
   }
 
-  SM_ASSERT(ip->is_container());
-
-  return ip;
+  UNREACHABLE;
+  return nullptr;
 }
 
 SHARING_MAPT2(const, innert *)::get_container_node(const key_type &k) const
@@ -942,24 +1025,33 @@ SHARING_MAPT2(const, innert *)::get_container_node(const key_type &k) const
   std::size_t key = hash()(k);
   const innert *ip = &map;
 
+  SM_ASSERT(ip->is_defined_internal());
+
   for(std::size_t i = 0; i < steps; i++)
   {
     std::size_t bit = key & mask;
 
     ip = ip->find_child(bit);
+
     if(ip == nullptr)
       return nullptr;
+
+    SM_ASSERT(!ip->empty());
+
+    if(ip->is_container())
+      return ip;
 
     key >>= chunk;
   }
 
-  SM_ASSERT(ip->is_defined_container());
-
-  return ip;
+  UNREACHABLE;
+  return nullptr;
 }
 
 SHARING_MAPT(void)::erase(const key_type &k)
 {
+  SM_ASSERT(has_key(k));
+
   innert *del = nullptr;
   std::size_t del_bit = 0;
 
@@ -979,6 +1071,9 @@ SHARING_MAPT(void)::erase(const key_type &k)
     }
 
     ip = ip->add_child(bit);
+
+    if(ip->is_defined_container())
+      break;
 
     key >>= chunk;
   }
@@ -1001,13 +1096,136 @@ SHARING_MAPT(void)::erase(const key_type &k)
   num--;
 }
 
+SHARING_MAPT2(, innert *)::migrate(
+  const std::size_t step,
+  const std::size_t key_suffix,
+  const std::size_t bit_last,
+  innert &inner)
+{
+  SM_ASSERT(step < steps - 1);
+  SM_ASSERT(inner.is_defined_internal());
+
+  const innert &child = *inner.find_child(bit_last);
+  SM_ASSERT(child.is_defined_container());
+
+  const leaf_listt &ll = child.get_container();
+
+  // Only containers at the bottom can contain more than two elements
+  SM_ASSERT(is_singular(ll));
+
+  const leaft &leaf = ll.front();
+  std::size_t key_existing = hash()(leaf.get_key());
+
+  key_existing >>= chunk * step;
+
+  // Copy the container
+  innert container_copy(child);
+
+  // Delete existing container
+  inner.remove_child(bit_last);
+
+  // Add internal node
+  innert *ip = inner.add_child(bit_last);
+  SM_ASSERT(ip->empty());
+
+  // Find place for both elements
+
+  std::size_t i = step + 1;
+  std::size_t key = key_suffix;
+
+  key_existing >>= chunk;
+  key >>= chunk;
+
+  SM_ASSERT(i < steps);
+
+  do
+  {
+    std::size_t bit_existing = key_existing & mask;
+    std::size_t bit = key & mask;
+
+    if(bit != bit_existing)
+    {
+      // Place found
+
+      innert *cp2 = ip->add_child(bit_existing);
+      cp2->swap(container_copy);
+
+      innert *cp1 = ip->add_child(bit);
+      return cp1;
+    }
+
+    SM_ASSERT(bit == bit_existing);
+    ip = ip->add_child(bit);
+
+    key >>= chunk;
+    key_existing >>= chunk;
+
+    i++;
+  } while(i < steps);
+
+  leaft leaf_copy(as_const(&container_copy)->get_container().front());
+  ip->get_container().push_front(leaf_copy);
+
+  return ip;
+}
+
 SHARING_MAPT4(valueU, void)
 ::insert(const key_type &k, valueU &&m)
 {
-  innert *cp = get_container_node(k);
-  SM_ASSERT(cp != nullptr);
+  SM_ASSERT(!has_key(k));
 
-  cp->place_leaf(k, std::forward<valueU>(m));
+  std::size_t key = hash()(k);
+  innert *ip = &map;
+
+  // The root cannot be a container node
+  SM_ASSERT(ip->is_internal());
+
+  for(std::size_t i = 0; i < steps; i++)
+  {
+    std::size_t bit = key & mask;
+
+    SM_ASSERT(ip != nullptr);
+    SM_ASSERT(ip->is_internal());
+    SM_ASSERT(i == 0 || !ip->empty());
+
+    innert *child = ip->add_child(bit);
+
+    // Place is unoccupied
+    if(child->empty())
+    {
+      // Create container and insert leaf
+      child->place_leaf(k, std::forward<valueU>(m));
+
+      SM_ASSERT(child->is_defined_container());
+
+      num++;
+
+      return;
+    }
+
+    if(child->is_container() && i < steps - 1)
+    {
+      // Migrate the elements downwards
+      innert *cp = migrate(i, key, bit, *ip);
+
+      cp->place_leaf(k, std::forward<valueU>(m));
+
+      num++;
+
+      return;
+    }
+
+    SM_ASSERT(i == steps - 1 || child->is_defined_internal());
+
+    ip = child;
+    key >>= chunk;
+  }
+
+  SM_ASSERT(ip->is_defined_container());
+
+  // Add to the bottom container
+  ip->place_leaf(k, std::forward<valueU>(m));
+
   num++;
 }
 


### PR DESCRIPTION
This changes the sharing map such that not all leafs are stored at the same depth (which was depth 6 previously), but that the tree grows dynamically as elements are inserted.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
