### PR TITLE
Refactoring of symex_assign_symbol

### DIFF
--- a/src/goto-symex/field_sensitivity.cpp
+++ b/src/goto-symex/field_sensitivity.cpp
@@ -222,9 +222,15 @@ void field_sensitivityt::field_assignments_rec(
     exprt ssa_rhs = state.rename(lhs, ns).get();
     simplify(ssa_rhs, ns);
 
-    ssa_exprt ssa_lhs = to_ssa_expr(lhs_fs);
-    state.assignment(
-      ssa_lhs, ssa_rhs, ns, true, true, allow_pointer_unsoundness);
+    const ssa_exprt ssa_lhs = state
+                                .assignment(
+                                  to_ssa_expr(lhs_fs),
+                                  ssa_rhs,
+                                  ns,
+                                  true,
+                                  true,
+                                  allow_pointer_unsoundness)
+                                .get();
 
     // do the assignment
     target.assignment(

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -47,7 +47,8 @@ goto_symex_statet::goto_symex_statet(
 
 goto_symex_statet::~goto_symex_statet()=default;
 
-/// write to a variable
+/// Check that \p expr is correctly renamed to level 2 and return true in case
+/// an error is detected.
 static bool check_renaming(const exprt &expr);
 
 static bool check_renaming(const typet &type)
@@ -458,8 +459,8 @@ bool goto_symex_statet::l2_thread_read_encoding(
       source,
       symex_targett::assignment_typet::PHI);
 
-    // TODO: are we setting l2 indices of something that is already l2?
-    expr = set_indices<L2>(std::move(ssa_l2), ns).get();
+    INVARIANT(!check_renaming(ssa_l2), "expr should be renamed to L2");
+    expr = std::move(ssa_l2);
 
     a_s_read.second.push_back(guard);
     if(!no_write.op().is_false())

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -198,7 +198,7 @@ public:
   write_is_shared_resultt
   write_is_shared(const ssa_exprt &expr, const namespacet &ns) const;
 
-  bool record_events;
+  std::stack<bool> record_events;
 
   const incremental_dirtyt *dirty = nullptr;
 

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -108,13 +108,14 @@ public:
   template <levelt level = L2>
   void rename(typet &type, const irep_idt &l1_identifier, const namespacet &ns);
 
-  void assignment(
-    ssa_exprt &lhs, // L0/L1
-    const exprt &rhs,  // L2
+  /// \return lhs renamed to level 2
+  renamedt<ssa_exprt, L2> assignment(
+    ssa_exprt lhs,    // L0/L1
+    const exprt &rhs, // L2
     const namespacet &ns,
     bool rhs_is_simplified,
     bool record_value,
-    bool allow_pointer_unsoundness=false);
+    bool allow_pointer_unsoundness = false);
 
   field_sensitivityt field_sensitivity;
 

--- a/src/goto-symex/postcondition.cpp
+++ b/src/goto-symex/postcondition.cpp
@@ -130,8 +130,8 @@ void postconditiont::strengthen(exprt &dest)
        SSA_step.ssa_lhs.type().id()==ID_struct)
       return;
 
-    equal_exprt equality(SSA_step.ssa_lhs, SSA_step.ssa_rhs);
-    get_original_name(equality);
+    exprt equality =
+      get_original_name(equal_exprt{SSA_step.ssa_lhs, SSA_step.ssa_rhs});
 
     if(dest.is_true())
       dest.swap(equality);
@@ -169,8 +169,7 @@ bool postconditiont::is_used(
         it!=expr_set.end();
         it++)
     {
-      exprt tmp(*it);
-      get_original_name(tmp);
+      const exprt tmp = get_original_name(*it);
       find_symbols(tmp, symbols);
     }
 

--- a/src/goto-symex/precondition.cpp
+++ b/src/goto-symex/precondition.cpp
@@ -140,8 +140,7 @@ void preconditiont::compute_rec(exprt &dest)
   }
   else if(dest==SSA_step.ssa_lhs.get_original_expr())
   {
-    dest=SSA_step.ssa_rhs;
-    get_original_name(dest);
+    dest = get_original_name(SSA_step.ssa_rhs);
   }
   else
     Forall_operands(it, dest)

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -97,26 +97,29 @@ void symex_level1t::restore_from(const current_namest &other)
   }
 }
 
-void get_original_name(exprt &expr)
+exprt get_original_name(exprt expr)
 {
-  get_original_name(expr.type());
+  expr.type() = get_original_name(std::move(expr.type()));
 
   if(expr.id() == ID_symbol && expr.get_bool(ID_C_SSA_symbol))
-    expr = to_ssa_expr(expr).get_original_expr();
+    return to_ssa_expr(expr).get_original_expr();
   else
+  {
     Forall_operands(it, expr)
-      get_original_name(*it);
+      *it = get_original_name(std::move(*it));
+    return expr;
+  }
 }
 
-void get_original_name(typet &type)
+typet get_original_name(typet type)
 {
   // rename all the symbols with their last known value
 
   if(type.id() == ID_array)
   {
     auto &array_type = to_array_type(type);
-    get_original_name(array_type.subtype());
-    get_original_name(array_type.size());
+    array_type.subtype() = get_original_name(std::move(array_type.subtype()));
+    array_type.size() = get_original_name(std::move(array_type.size()));
   }
   else if(type.id() == ID_struct || type.id() == ID_union)
   {
@@ -124,10 +127,12 @@ void get_original_name(typet &type)
     struct_union_typet::componentst &components = s_u_type.components();
 
     for(auto &component : components)
-      get_original_name(component.type());
+      component.type() = get_original_name(std::move(component.type()));
   }
   else if(type.id() == ID_pointer)
   {
-    get_original_name(to_pointer_type(type).subtype());
+    type.subtype() =
+      get_original_name(std::move(to_pointer_type(type).subtype()));
   }
+  return type;
 }

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -148,9 +148,9 @@ struct symex_level2t : public symex_renaming_levelt
 };
 
 /// Undo all levels of renaming
-void get_original_name(exprt &expr);
+exprt get_original_name(exprt expr);
 
 /// Undo all levels of renaming
-void get_original_name(typet &type);
+typet get_original_name(typet type);
 
 #endif // CPROVER_GOTO_SYMEX_RENAMING_LEVEL_H

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -491,8 +491,7 @@ void goto_symext::symex_assign_symbol(
   // Temporarily add the state guard
   guard.emplace_back(state.guard.as_expr());
 
-  exprt original_lhs = l2_full_lhs;
-  get_original_name(original_lhs);
+  const exprt original_lhs = get_original_name(l2_full_lhs);
   target.assignment(
     conjunction(guard),
     l2_lhs,

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -298,18 +298,18 @@ static assignmentt rewrite_with_to_field_symbols(
 /// "update") expressions, which \ref rewrite_with_to_field_symbols will then
 /// take care of.
 /// \param [in, out] state: symbolic execution state to perform renaming
-/// \param ssa_rhs: right-hand side
-/// \param lhs_mod: left-hand side
+/// \param assignment: assignment to transform
 /// \param ns: namespace
 /// \param do_simplify: set to true if, and only if, simplification is enabled
 /// \return updated assignment
 static assignmentt shift_indexed_access_to_lhs(
   goto_symext::statet &state,
-  exprt ssa_rhs,
-  ssa_exprt lhs_mod,
+  assignmentt assignment,
   const namespacet &ns,
   bool do_simplify)
 {
+  exprt &ssa_rhs = assignment.rhs;
+  ssa_exprt &lhs_mod = assignment.lhs;
   if(
     ssa_rhs.id() == ID_byte_update_little_endian ||
     ssa_rhs.id() == ID_byte_update_big_endian)
@@ -373,7 +373,7 @@ static assignmentt shift_indexed_access_to_lhs(
                          state.rename(std::move(ssa_rhs), ns).get()};
     }
   }
-  return assignmentt{std::move(lhs_mod), std::move(ssa_rhs)};
+  return assignment;
 }
 
 /// Assign a struct expression to a symbol. If \ref symex_assign_symbol was used
@@ -454,7 +454,7 @@ void goto_symext::symex_assign_symbol(
   // expressions on the LHS. If we add an option to disable field-sensitivity
   // in the future these should be omitted.
   auto assignment = shift_indexed_access_to_lhs(
-    state, std::move(l2_rhs), lhs, ns, symex_config.simplify_opt);
+    state, assignmentt{lhs, std::move(l2_rhs)}, ns, symex_config.simplify_opt);
   assignment = rewrite_with_to_field_symbols(state, std::move(assignment), ns);
 
   do_simplify(assignment.rhs);

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -472,7 +472,7 @@ void goto_symext::symex_assign_symbol(
 
   exprt ssa_full_lhs = add_to_lhs(full_lhs, l2_lhs);
   state.record_events.push(false);
-  exprt l2_full_lhs = state.rename(std::move(ssa_full_lhs), ns).get();
+  const exprt l2_full_lhs = state.rename(std::move(ssa_full_lhs), ns).get();
   state.record_events.pop();
 
   // do the assignment

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -459,15 +459,16 @@ void goto_symext::symex_assign_symbol(
 
   do_simplify(assignment.rhs);
 
-  ssa_exprt l2_lhs = std::move(assignment.lhs);
-  ssa_exprt l1_lhs = l2_lhs; // l2_lhs will be renamed to L2 by the following:
-  state.assignment(
-    l2_lhs,
-    assignment.rhs,
-    ns,
-    symex_config.simplify_opt,
-    symex_config.constant_propagation,
-    symex_config.allow_pointer_unsoundness);
+  ssa_exprt &l1_lhs = assignment.lhs;
+  ssa_exprt l2_lhs = state
+                       .assignment(
+                         assignment.lhs,
+                         assignment.rhs,
+                         ns,
+                         symex_config.simplify_opt,
+                         symex_config.constant_propagation,
+                         symex_config.allow_pointer_unsoundness)
+                       .get();
 
   exprt ssa_full_lhs=full_lhs;
   ssa_full_lhs = add_to_lhs(ssa_full_lhs, l2_lhs);

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -288,13 +288,14 @@ static void rewrite_with_to_field_symbols(
 /// "update") expressions, which \ref rewrite_with_to_field_symbols will then
 /// take care of.
 /// \param [in, out] state: symbolic execution state to perform renaming
-/// \param [in,out] ssa_rhs: right-hand side
+/// \param ssa_rhs: right-hand side
 /// \param [in,out] lhs_mod: left-hand side
 /// \param ns: namespace
 /// \param do_simplify: set to true if, and only if, simplification is enabled
-static void shift_indexed_access_to_lhs(
+/// \return updated right-hand side
+static exprt shift_indexed_access_to_lhs(
   goto_symext::statet &state,
-  exprt &ssa_rhs,
+  exprt ssa_rhs,
   ssa_exprt &lhs_mod,
   const namespacet &ns,
   bool do_simplify)
@@ -303,7 +304,7 @@ static void shift_indexed_access_to_lhs(
     ssa_rhs.id() == ID_byte_update_little_endian ||
     ssa_rhs.id() == ID_byte_update_big_endian)
   {
-    byte_update_exprt &byte_update = to_byte_update_expr(ssa_rhs);
+    const byte_update_exprt &byte_update = to_byte_update_expr(ssa_rhs);
     exprt byte_extract = byte_extract_exprt(
       byte_update.id() == ID_byte_update_big_endian
         ? ID_byte_extract_big_endian
@@ -316,8 +317,8 @@ static void shift_indexed_access_to_lhs(
 
     if(byte_extract.id() == ID_symbol)
     {
-      ssa_rhs = byte_update.value();
       lhs_mod = to_ssa_expr(byte_extract);
+      return byte_update.value();
     }
     else if(byte_extract.id() == ID_index || byte_extract.id() == ID_member)
     {
@@ -359,10 +360,11 @@ static void shift_indexed_access_to_lhs(
 
       // We may have shifted the previous lhs into the rhs; as the lhs is only
       // L1-renamed, we need to rename again.
-      ssa_rhs = state.rename(ssa_rhs, ns).get();
       lhs_mod = to_ssa_expr(byte_extract);
+      return state.rename(std::move(ssa_rhs), ns).get();
     }
   }
+  return ssa_rhs;
 }
 
 /// Assign a struct expression to a symbol. If \ref symex_assign_symbol was used
@@ -444,8 +446,8 @@ void goto_symext::symex_assign_symbol(
   // introduced by symex_assign_struct_member, are transformed into member
   // expressions on the LHS. If we add an option to disable field-sensitivity
   // in the future these should be omitted.
-  shift_indexed_access_to_lhs(
-    state, l2_rhs, lhs_mod, ns, symex_config.simplify_opt);
+  l2_rhs = shift_indexed_access_to_lhs(
+    state, std::move(l2_rhs), lhs_mod, ns, symex_config.simplify_opt);
   rewrite_with_to_field_symbols(state, l2_rhs, lhs_mod, ns);
 
   do_simplify(l2_rhs);

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -426,16 +426,16 @@ void goto_symext::symex_assign_symbol(
     return;
   }
 
-  exprt ssa_rhs=rhs;
+  exprt guarded_rhs = rhs;
 
   // put assignment guard into the rhs
   if(!guard.empty())
   {
-    if_exprt tmp_ssa_rhs(conjunction(guard), ssa_rhs, lhs, ssa_rhs.type());
-    tmp_ssa_rhs.swap(ssa_rhs);
+    guarded_rhs =
+      if_exprt{conjunction(guard), std::move(guarded_rhs), lhs, rhs.type()};
   }
 
-  exprt l2_rhs = state.rename(std::move(ssa_rhs), ns).get();
+  exprt l2_rhs = state.rename(std::move(guarded_rhs), ns).get();
 
   ssa_exprt lhs_mod = lhs;
 

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -472,10 +472,9 @@ void goto_symext::symex_assign_symbol(
 
   exprt ssa_full_lhs=full_lhs;
   ssa_full_lhs = add_to_lhs(ssa_full_lhs, l2_lhs);
-  const bool record_events=state.record_events;
-  state.record_events=false;
+  state.record_events.push(false);
   exprt l2_full_lhs = state.rename(std::move(ssa_full_lhs), ns).get();
-  state.record_events=record_events;
+  state.record_events.pop();
 
   // do the assignment
   const symbolt &symbol = ns.lookup(l2_lhs.get_object_name());

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -470,8 +470,7 @@ void goto_symext::symex_assign_symbol(
                          symex_config.allow_pointer_unsoundness)
                        .get();
 
-  exprt ssa_full_lhs=full_lhs;
-  ssa_full_lhs = add_to_lhs(ssa_full_lhs, l2_lhs);
+  exprt ssa_full_lhs = add_to_lhs(full_lhs, l2_lhs);
   state.record_events.push(false);
   exprt l2_full_lhs = state.rename(std::move(ssa_full_lhs), ns).get();
   state.record_events.pop();

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -426,16 +426,16 @@ void goto_symext::symex_assign_symbol(
     return;
   }
 
-  exprt guarded_rhs = rhs;
-
-  // put assignment guard into the rhs
-  if(!guard.empty())
-  {
-    guarded_rhs =
-      if_exprt{conjunction(guard), std::move(guarded_rhs), lhs, rhs.type()};
-  }
-
-  exprt l2_rhs = state.rename(std::move(guarded_rhs), ns).get();
+  exprt l2_rhs = [&]() {
+    exprt guarded_rhs = rhs;
+    // put assignment guard into the rhs
+    if(!guard.empty())
+    {
+      guarded_rhs =
+        if_exprt{conjunction(guard), std::move(guarded_rhs), lhs, rhs.type()};
+    }
+    return state.rename(std::move(guarded_rhs), ns).get();
+  }();
 
   ssa_exprt lhs_mod = lhs;
 

--- a/src/goto-symex/symex_decl.cpp
+++ b/src/goto-symex/symex_decl.cpp
@@ -76,14 +76,13 @@ void goto_symext::symex_decl(statet &state, const symbol_exprt &expr)
     CHECK_RETURN(field_generation == 1);
   }
 
-  const bool record_events=state.record_events;
-  state.record_events=false;
+  state.record_events.push(false);
   exprt expr_l2 = state.rename(std::move(ssa), ns).get();
   INVARIANT(
     expr_l2.id() == ID_symbol && expr_l2.get_bool(ID_C_SSA_symbol),
     "symbol to declare should not be replaced by constant propagation");
   ssa = to_ssa_expr(expr_l2);
-  state.record_events=record_events;
+  state.record_events.pop();
 
   // we hide the declaration of auxiliary variables
   // and if the statement itself is hidden

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -202,7 +202,6 @@ void goto_symext::dereference_rec(exprt &expr, statet &state, bool write)
 {
   if(expr.id()==ID_dereference)
   {
-    dereference_exprt to_check = to_dereference_expr(expr);
     bool expr_is_not_null = false;
 
     if(state.threads.size() == 1)
@@ -210,7 +209,8 @@ void goto_symext::dereference_rec(exprt &expr, statet &state, bool write)
       const irep_idt &expr_function = state.source.function_id;
       if(!expr_function.empty())
       {
-        get_original_name(to_check);
+        const dereference_exprt to_check =
+          to_dereference_expr(get_original_name(expr));
 
         expr_is_not_null = path_storage.safe_pointers.at(expr_function)
                              .is_safe_dereference(to_check, state.source.pc);

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -310,7 +310,8 @@ void goto_symext::symex_goto(statet &state)
 
       ssa_exprt new_lhs =
         state.rename_ssa<L1>(ssa_exprt{guard_symbol_expr}, ns).get();
-      state.assignment(new_lhs, new_rhs, ns, true, false);
+      new_lhs =
+        state.assignment(std::move(new_lhs), new_rhs, ns, true, false).get();
 
       guardt guard{true_exprt{}, guard_manager};
 
@@ -527,10 +528,10 @@ static void merge_names(
       simplify(rhs, ns);
   }
 
-  ssa_exprt new_lhs = ssa;
   const bool record_events = dest_state.record_events;
   dest_state.record_events = false;
-  dest_state.assignment(new_lhs, rhs, ns, true, true);
+  const ssa_exprt new_lhs =
+    dest_state.assignment(ssa, rhs, ns, true, true).get();
   dest_state.record_events = record_events;
 
   log.conditional_output(

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -528,11 +528,10 @@ static void merge_names(
       simplify(rhs, ns);
   }
 
-  const bool record_events = dest_state.record_events;
-  dest_state.record_events = false;
+  dest_state.record_events.push(false);
   const ssa_exprt new_lhs =
     dest_state.assignment(ssa, rhs, ns, true, true).get();
-  dest_state.record_events = record_events;
+  dest_state.record_events.pop();
 
   log.conditional_output(
     log.debug(), [ns, &new_lhs](messaget::mstreamt &mstream) {

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -747,10 +747,9 @@ void goto_symext::try_filter_value_sets(
     // something that just replaces `*&x` with `x` whenever it finds it.
     do_simplify(modified_condition);
 
-    const bool record_events = state.record_events;
-    state.record_events = false;
+    state.record_events.push(false);
     modified_condition = state.rename(std::move(modified_condition), ns).get();
-    state.record_events = record_events;
+    state.record_events.pop();
 
     do_simplify(modified_condition);
 

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -85,8 +85,7 @@ void goto_symext::symex_start_thread(statet &state)
     ssa_exprt rhs = pair.second.first;
 
     exprt::operandst lhs_conditions;
-    const bool record_events=state.record_events;
-    state.record_events=false;
+    state.record_events.push(false);
     symex_assign_symbol(
       state,
       lhs_l1,
@@ -94,7 +93,7 @@ void goto_symext::symex_start_thread(statet &state)
       rhs,
       lhs_conditions,
       symex_targett::assignment_typet::HIDDEN);
-    state.record_events=record_events;
+    state.record_events.pop();
   }
 
   // initialize all variables marked thread-local


### PR DESCRIPTION
Having to debug some changes related to `symex_assign` I found it difficult to understand what variable represents what in the execution of `symex_assign_symbol` because of several functions which have parameters that are also output. This pull request is an attempt to get rid of these.


<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
