### PR TITLE
Default fall-through for function pointer removal

### DIFF
--- a/regression/cbmc/Function_Pointer18/main.c
+++ b/regression/cbmc/Function_Pointer18/main.c
@@ -1,0 +1,34 @@
+// f is set to 0 -> does not point to either f1 or f2
+#include <assert.h>
+
+typedef int (*f_ptr)(int);
+
+extern f_ptr f;
+
+int f1(int j);
+int f2(int i);
+
+int f1(int j)
+{
+  f = &f2;
+  return 1;
+}
+int f2(int i)
+{
+  assert(0);
+  return 2;
+}
+
+f_ptr f = 0;
+
+int main()
+{
+  int x = 0;
+
+  x = f(x);
+  assert(x == 1);
+  x = f(x);
+  assert(x == 2);
+
+  return 0;
+}

--- a/regression/cbmc/Function_Pointer18/test.desc
+++ b/regression/cbmc/Function_Pointer18/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+\[f2.assertion.1\] line [0-9]+ assertion 0: SUCCESS
+\[main.assertion.1\] line [0-9]+ assertion x == 1: SUCCESS
+\[main.assertion.2\] line [0-9]+ assertion x == 2: SUCCESS
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -416,6 +416,7 @@ void remove_function_pointerst::remove_function_pointer(
     t->source_location.set_property_class("pointer dereference");
     t->source_location.set_comment("invalid function pointer");
   }
+  new_code_gotos.add(goto_programt::make_assumption(false_exprt()));
 
   goto_programt new_code;
 


### PR DESCRIPTION
When the pointer points to neither of the candidates we shouldn't just call the
first one (which does happen if the user does not request pointer-check). This
PR inserts an ASSUME (false) which makes all subsequent assertions
unreachable (and thus reported as not being violated).

A small regression test is included.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
