### PR TITLE
Suppress color output on aws

### DIFF
--- a/buildspec-linux-clang.yml
+++ b/buildspec-linux-clang.yml
@@ -1,5 +1,10 @@
 version: 0.2
 
+env:
+  variables:
+    # CodeBuild console doesn't display color codes correctly
+    TESTPL_COLOR_OUTPUT: 0
+
 phases:
   install:
     runtime-versions:

--- a/buildspec-linux-cmake-gcc.yml
+++ b/buildspec-linux-cmake-gcc.yml
@@ -1,5 +1,10 @@
 version: 0.2
 
+env:
+  variables:
+    # CodeBuild console doesn't display color codes correctly
+    TESTPL_COLOR_OUTPUT: 0
+
 phases:
   install:
     runtime-versions:

--- a/buildspec-windows.yml
+++ b/buildspec-windows.yml
@@ -1,5 +1,10 @@
 version: 0.2
 
+env:
+  variables:
+    # CodeBuild console doesn't display color codes correctly
+    TESTPL_COLOR_OUTPUT: 0
+
 phases:
   install:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,5 +1,10 @@
 version: 0.2
 
+env:
+  variables:
+    # CodeBuild console doesn't display color codes correctly
+    TESTPL_COLOR_OUTPUT: 0
+
 phases:
   install:
     runtime-versions:


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

Color codes don't show up correctly on AWS CodeBuild console, so we're disabling them to make the output more legible (they're still on by default!). Having the ability to turn color codes off can be useful in other situations (like scripts) as well.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
