### PR TITLE
Refactor forward_list use in irept

### DIFF
--- a/src/util/forward_list_as_map.h
+++ b/src/util/forward_list_as_map.h
@@ -1,0 +1,119 @@
+/*******************************************************************\
+
+Module: util
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_FORWARD_LIST_AS_MAP_H
+#define CPROVER_UTIL_FORWARD_LIST_AS_MAP_H
+
+#include <algorithm>
+#include <forward_list>
+
+#include "as_const.h"
+#include "narrow.h"
+
+/// Implementation of map-like interface using a forward list
+template <typename keyt, typename mappedt>
+//  requires DefaultConstructible<mappedt>
+class forward_list_as_mapt : public std::forward_list<std::pair<keyt, mappedt>>
+{
+public:
+  using implementationt = typename std::forward_list<std::pair<keyt, mappedt>>;
+  using const_iterator = typename implementationt::const_iterator;
+  using iterator = typename implementationt::iterator;
+
+  forward_list_as_mapt() : implementationt()
+  {
+  }
+
+  forward_list_as_mapt(std::initializer_list<std::pair<keyt, mappedt>> list)
+    : implementationt(std::move(list))
+  {
+  }
+
+  void remove(const keyt &name)
+  {
+    const_iterator it = this->lower_bound(name);
+
+    if(it != this->end() && it->first == name)
+    {
+      iterator before = this->before_begin();
+      while(std::next(before) != it)
+        ++before;
+      this->erase_after(before);
+    }
+  }
+
+  const const_iterator find(const keyt &name) const
+  {
+    const_iterator it = lower_bound(name);
+
+    if(it == this->end() || it->first != name)
+      return this->end();
+
+    return it;
+  }
+
+  iterator add(const keyt &name)
+  {
+    iterator it = mutable_lower_bound(name);
+
+    if(it == this->end() || it->first != name)
+    {
+      iterator before = this->before_begin();
+      while(std::next(before) != it)
+        ++before;
+      it = this->emplace_after(before, name, mappedt());
+    }
+
+    return it;
+  }
+
+  mappedt &operator[](const keyt &name)
+  {
+    return add(name)->second;
+  }
+
+  mappedt &add(const keyt &name, mappedt irep)
+  {
+    iterator it = mutable_lower_bound(name);
+
+    if(it == this->end() || it->first != name)
+    {
+      iterator before = this->before_begin();
+      while(std::next(before) != it)
+        ++before;
+      it = this->emplace_after(before, name, std::move(irep));
+    }
+    else
+      it->second = std::move(irep);
+
+    return it->second;
+  }
+
+  std::size_t size() const
+  {
+    return narrow<std::size_t>(std::distance(this->begin(), this->end()));
+  }
+
+private:
+  static bool order(const std::pair<keyt, mappedt> &a, const keyt &b)
+  {
+    return a.first < b;
+  }
+
+  const_iterator lower_bound(const keyt &id) const
+  {
+    return std::lower_bound(this->begin(), this->end(), id, order);
+  }
+
+  iterator mutable_lower_bound(const keyt &id)
+  {
+    return std::lower_bound(this->begin(), this->end(), id, order);
+  }
+};
+
+#endif // CPROVER_UTIL_FORWARD_LIST_AS_MAP_H

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -23,7 +23,7 @@ Author: Daniel Kroening, kroening@kroening.com
 // #define NAMED_SUB_IS_FORWARD_LIST
 
 #ifdef NAMED_SUB_IS_FORWARD_LIST
-#include <forward_list>
+#  include "forward_list_as_map.h"
 #else
 #include <map>
 #endif
@@ -387,7 +387,7 @@ class irept
       irept,
 #endif
 #ifdef NAMED_SUB_IS_FORWARD_LIST
-      std::forward_list<std::pair<irep_namet, irept>>
+      forward_list_as_mapt<irep_namet, irept>>
 #else
       std::map<irep_namet, irept>>
 #endif

--- a/src/util/merge_irep.cpp
+++ b/src/util/merge_irep.cpp
@@ -28,12 +28,7 @@ std::size_t to_be_merged_irept::hash() const
         result, static_cast<const merged_irept &>(it->second).hash());
   }
 
-#ifdef NAMED_SUB_IS_FORWARD_LIST
-  const std::size_t named_sub_size =
-    std::distance(named_sub.begin(), named_sub.end());
-#else
   const std::size_t named_sub_size = named_sub.size();
-#endif
   result = hash_finalize(result, named_sub_size + sub.size());
 
   return result;


### PR DESCRIPTION
This introduce a class for using forward list as maps, which makes switching between maps and forward lists as an implementation for the subtrees of irept more natural and clearer.


<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
