### PR TITLE
Remove adjust_if_recursive

### DIFF
--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -862,50 +862,6 @@ decision_proceduret::resultt string_refinementt::dec_solve()
               << "of steps allowed" << messaget::eom;
   return resultt::D_ERROR;
 }
-
-/// In a best-effort manner, try to clean up the type inconsistencies introduced
-/// by \ref array_poolt::make_char_array_for_char_pointer, which creates
-/// conditional expressions for the size of arrays. The cleanup is achieved by
-/// removing branches that are found to be infeasible, and by simplifying the
-/// conditional size expressions previously generated.
-/// \param expr: Expression to be cleaned
-/// \param ns: Namespace
-/// \return Cleaned expression
-static exprt adjust_if_recursive(exprt expr, const namespacet &ns)
-{
-  for(auto it = expr.depth_begin(); it != expr.depth_end();)
-  {
-    if(it->id() == ID_if)
-    {
-      if_exprt if_expr = to_if_expr(*it);
-      const exprt simp_cond = simplify_expr(if_expr.cond(), ns);
-      if(simp_cond.is_true())
-      {
-        it.mutate() = adjust_if_recursive(if_expr.true_case(), ns);
-        it.next_sibling_or_parent();
-      }
-      else if(simp_cond.is_false())
-      {
-        it.mutate() = adjust_if_recursive(if_expr.false_case(), ns);
-        it.next_sibling_or_parent();
-      }
-      else if(
-        it->type().id() == ID_array &&
-        to_array_type(it->type()).size().id() == ID_if)
-      {
-        simplify(to_array_type(it.mutate().type()).size(), ns);
-        ++it;
-      }
-      else
-        ++it;
-    }
-    else
-      ++it;
-  }
-
-  return expr;
-}
-
 /// Add the given lemma to the solver.
 /// \param lemma: a Boolean expression
 /// \param simplify_lemma: whether the lemma should be simplified before being
@@ -922,7 +878,6 @@ void string_refinementt::add_lemma(
   exprt simple_lemma = lemma;
   if(simplify_lemma)
   {
-    simple_lemma = adjust_if_recursive(std::move(simple_lemma), ns);
     simplify(simple_lemma, ns);
   }
 
@@ -1047,8 +1002,7 @@ static optionalt<exprt> get_array(
     return nil_exprt();
   }
 
-  const exprt arr_val =
-    simplify_expr(adjust_if_recursive(super_get(arr), ns), ns);
+  const exprt arr_val = simplify_expr(super_get(arr), ns);
   const typet char_type = arr.type().subtype();
   const typet &index_type = size.value().type();
 

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -848,7 +848,8 @@ decision_proceduret::resultt string_refinementt::dec_solve()
       const auto instances =
         generate_instantiations(index_sets, axioms, not_contain_witnesses);
       for(const auto &instance : instances)
-        add_lemma(instance);
+        add_lemma(
+          substitute_array_access(instance, generator.fresh_symbol, true));
     }
     else
     {


### PR DESCRIPTION
Remove unneeded call to `adjust_if_recursive`.

As requested in https://github.com/diffblue/cbmc/pull/4626.
~Based on https://github.com/diffblue/cbmc/pull/4626.~
~Only review last commit.~

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
