### PR TITLE
smt2 frontend: check the number of types of function arguments

### DIFF
--- a/regression/smt2_solver/function-applications/function-application3.desc
+++ b/regression/smt2_solver/function-applications/function-application3.desc
@@ -1,0 +1,7 @@
+CORE
+function-application3.smt2
+
+^EXIT=20$
+^SIGNAL=0$
+^\(error "line 4: wrong number of arguments for function"\)$
+--

--- a/regression/smt2_solver/function-applications/function-application3.smt2
+++ b/regression/smt2_solver/function-applications/function-application3.smt2
@@ -1,0 +1,6 @@
+(set-logic LIA)
+
+(define-fun next ((x Int)) Int x )
+(assert (= (next ) 243))
+
+(check-sat)

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -291,26 +291,22 @@ exprt smt2_parsert::quantifier_expression(irep_idt id)
 }
 
 exprt smt2_parsert::function_application(
-  const irep_idt &,
-  const exprt::operandst &)
+  const symbol_exprt &function,
+  const exprt::operandst &op)
 {
-  #if 0
-  const auto &f = id_map[identifier];
+  const auto &function_type = to_mathematical_function_type(function.type());
 
   // check the arguments
-  if(op.size()!=f.type.variables().size())
+  if(op.size() != function_type.domain().size())
     throw error("wrong number of arguments for function");
 
   for(std::size_t i=0; i<op.size(); i++)
   {
-    if(op[i].type() != f.type.variables()[i].type())
+    if(op[i].type() != function_type.domain()[i])
       throw error("wrong type for arguments for function");
   }
 
-  return function_application_exprt(
-    symbol_exprt(identifier, f.type), op, f.type.range());
-  #endif
-  return nil_exprt();
+  return function_application_exprt(function, op);
 }
 
 exprt::operandst smt2_parsert::cast_bv_to_signed(const exprt::operandst &op)
@@ -826,7 +822,7 @@ exprt smt2_parsert::function_application()
         {
           if(id_it->second.type.id()==ID_mathematical_function)
           {
-            return function_application_exprt(
+            return function_application(
               symbol_exprt(final_id, id_it->second.type), op);
           }
           else

--- a/src/solvers/smt2/smt2_parser.h
+++ b/src/solvers/smt2/smt2_parser.h
@@ -136,7 +136,7 @@ protected:
   exprt let_expression();
   exprt quantifier_expression(irep_idt);
   exprt function_application(
-    const irep_idt &identifier,
+    const symbol_exprt &function,
     const exprt::operandst &op);
 
   /// Apply typecast to signedbv to expressions in vector


### PR DESCRIPTION
This means that a proper error message is generated instead of failing an
assertion.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
