### PR TITLE
Fix bug where an item was not added to the delta view of the sharing map

### DIFF
--- a/src/util/sharing_map.h
+++ b/src/util/sharing_map.h
@@ -844,6 +844,8 @@ SHARING_MAPT(void)::add_item_if_not_shared(
         }
       }
 
+      delta_view.push_back({k, l1.get_value()});
+
       return;
     }
 

--- a/unit/util/sharing_map.cpp
+++ b/unit/util/sharing_map.cpp
@@ -49,33 +49,12 @@ void fill2(some_sharing_mapt &sm)
   sm.insert("n", "5");
 }
 
-// tests
-
-class some_keyt
+class key_hasht
 {
 public:
-  some_keyt() : s(0)
+  std::size_t operator()(const std::size_t &k) const
   {
-  }
-
-  explicit some_keyt(size_t s) : s(s)
-  {
-  }
-
-  size_t s;
-
-  bool operator==(const some_keyt &other) const
-  {
-    return s == other.s;
-  }
-};
-
-class some_key_hasht
-{
-public:
-  size_t operator()(const some_keyt &k) const
-  {
-    return k.s & 0x3;
+    return k & 0x3;
   }
 };
 
@@ -494,46 +473,46 @@ TEST_CASE("Sharing map copying", "[core][util]")
 
 TEST_CASE("Sharing map collisions", "[core][util]")
 {
-  typedef sharing_mapt<some_keyt, std::string, false, some_key_hasht>
+  typedef sharing_mapt<std::size_t, std::string, false, key_hasht>
     sharing_map_collisionst;
 
   sharing_map_collisionst sm;
 
   SECTION("Basic")
   {
-    sm.insert(some_keyt(0), "a");
-    sm.insert(some_keyt(8), "b");
-    sm.insert(some_keyt(16), "c");
+    sm.insert(0, "a");
+    sm.insert(8, "b");
+    sm.insert(16, "c");
 
-    sm.insert(some_keyt(1), "d");
-    sm.insert(some_keyt(2), "e");
+    sm.insert(1, "d");
+    sm.insert(2, "e");
 
-    sm.erase(some_keyt(8));
+    sm.erase(8);
 
-    REQUIRE(sm.has_key(some_keyt(0)));
-    REQUIRE(sm.has_key(some_keyt(16)));
+    REQUIRE(sm.has_key(0));
+    REQUIRE(sm.has_key(16));
 
-    REQUIRE(sm.has_key(some_keyt(1)));
-    REQUIRE(sm.has_key(some_keyt(2)));
+    REQUIRE(sm.has_key(1));
+    REQUIRE(sm.has_key(2));
 
-    REQUIRE(!sm.has_key(some_keyt(8)));
+    REQUIRE(!sm.has_key(8));
   }
 
   SECTION("Delta view")
   {
-    sm.insert(some_keyt(0), "a");
+    sm.insert(0, "a");
 
     sharing_map_collisionst sm2;
 
-    sm2.insert(some_keyt(8), "b");
-    sm2.insert(some_keyt(16), "c");
+    sm2.insert(8, "b");
+    sm2.insert(16, "c");
 
     sharing_map_collisionst::delta_viewt delta_view;
 
     sm.get_delta_view(sm2, delta_view, false);
 
     REQUIRE(delta_view.size() == 1);
-    REQUIRE(delta_view[0].k == some_keyt(0));
+    REQUIRE(delta_view[0].k == 0);
     REQUIRE(!delta_view[0].is_in_both_maps());
   }
 }

--- a/unit/util/sharing_map.cpp
+++ b/unit/util/sharing_map.cpp
@@ -499,22 +499,43 @@ TEST_CASE("Sharing map collisions", "[core][util]")
 
   sharing_map_collisionst sm;
 
-  sm.insert(some_keyt(0), "a");
-  sm.insert(some_keyt(8), "b");
-  sm.insert(some_keyt(16), "c");
+  SECTION("Basic")
+  {
+    sm.insert(some_keyt(0), "a");
+    sm.insert(some_keyt(8), "b");
+    sm.insert(some_keyt(16), "c");
 
-  sm.insert(some_keyt(1), "d");
-  sm.insert(some_keyt(2), "e");
+    sm.insert(some_keyt(1), "d");
+    sm.insert(some_keyt(2), "e");
 
-  sm.erase(some_keyt(8));
+    sm.erase(some_keyt(8));
 
-  REQUIRE(sm.has_key(some_keyt(0)));
-  REQUIRE(sm.has_key(some_keyt(16)));
+    REQUIRE(sm.has_key(some_keyt(0)));
+    REQUIRE(sm.has_key(some_keyt(16)));
 
-  REQUIRE(sm.has_key(some_keyt(1)));
-  REQUIRE(sm.has_key(some_keyt(2)));
+    REQUIRE(sm.has_key(some_keyt(1)));
+    REQUIRE(sm.has_key(some_keyt(2)));
 
-  REQUIRE(!sm.has_key(some_keyt(8)));
+    REQUIRE(!sm.has_key(some_keyt(8)));
+  }
+
+  SECTION("Delta view")
+  {
+    sm.insert(some_keyt(0), "a");
+
+    sharing_map_collisionst sm2;
+
+    sm2.insert(some_keyt(8), "b");
+    sm2.insert(some_keyt(16), "c");
+
+    sharing_map_collisionst::delta_viewt delta_view;
+
+    sm.get_delta_view(sm2, delta_view, false);
+
+    REQUIRE(delta_view.size() == 1);
+    REQUIRE(delta_view[0].k == some_keyt(0));
+    REQUIRE(!delta_view[0].is_in_both_maps());
+  }
 }
 
 TEST_CASE("Sharing map views and iteration", "[core][util]")


### PR DESCRIPTION
The bug could appear when there are hash collisions between the keys stored in the sharing map.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
