### PR TITLE
Allocation size computation in calloc must not overflow

### DIFF
--- a/doc/cprover-manual/api.md
+++ b/doc/cprover-manual/api.md
@@ -112,6 +112,22 @@ float __CPROVER_fabsf(float x);
 
 These functions return the absolute value of the given argument.
 
+#### \_\_CPROVER\_overflow\_minus, \_\_CPROVER\_overflow\_mult, \_\_CPROVER\_overflow\_plus, \_\_CPROVER\_overflow\_shl, \_\_CPROVER\_overflow\_unary\_minus
+
+```C
+__CPROVER_bool __CPROVER_overflow_minus();
+__CPROVER_bool __CPROVER_overflow_mult();
+__CPROVER_bool __CPROVER_overflow_plus();
+__CPROVER_bool __CPROVER_overflow_shl();
+__CPROVER_bool __CPROVER_overflow_unary_minus();
+```
+
+These functions take two (`__CPROVER_overflow_unary_minus` only takes one)
+arguments of any numeric type. They return true, if, and only if, the named
+operation would overflow when applied to the arguments. For example,
+`__CPROVER_overflow_plus(x, y)` returns true if `x + y` would result in an
+arithmetic overflow.
+
 #### \_\_CPROVER\_array\_equal, \_\_CPROVER\_array\_copy, \_\_CPROVER\_array\_set
 
 ```C

--- a/regression/cbmc-library/calloc-02/main.c
+++ b/regression/cbmc-library/calloc-02/main.c
@@ -6,4 +6,10 @@ int main()
   char *p = calloc(-1, -1);
   if(p)
     assert(p[0] == 0);
+
+  size_t size;
+  size_t num;
+  p = calloc(size, num);
+  if(p && size > 0 && num > 0)
+    assert(p[0] == 0);
 }

--- a/regression/cbmc-library/calloc-02/main.c
+++ b/regression/cbmc-library/calloc-02/main.c
@@ -1,9 +1,14 @@
 #include <assert.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 int main()
 {
   char *p = calloc(-1, -1);
+  if(p)
+    assert(p[0] == 0);
+
+  p = calloc(SIZE_MAX, 1);
   if(p)
     assert(p[0] == 0);
 

--- a/regression/cbmc-library/calloc-02/main.c
+++ b/regression/cbmc-library/calloc-02/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int main()
+{
+  char *p = calloc(-1, -1);
+  if(p)
+    assert(p[0] == 0);
+}

--- a/regression/cbmc-library/calloc-02/test.desc
+++ b/regression/cbmc-library/calloc-02/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--unsigned-overflow-check --pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc-library/calloc-02/test.desc
+++ b/regression/cbmc-library/calloc-02/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---unsigned-overflow-check --pointer-check
+--unsigned-overflow-check --pointer-check --arrays-uf-always
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2811,6 +2811,46 @@ exprt c_typecheck_baset::do_special_functions(
 
     return expr;
   }
+  else if(
+    identifier == CPROVER_PREFIX "overflow_minus" ||
+    identifier == CPROVER_PREFIX "overflow_mult" ||
+    identifier == CPROVER_PREFIX "overflow_plus" ||
+    identifier == CPROVER_PREFIX "overflow_shl" ||
+    identifier == CPROVER_PREFIX "overflow_unary_minus")
+  {
+    exprt overflow{identifier, typet{}, exprt::operandst{expr.arguments()}};
+    overflow.add_source_location() = f_op.source_location();
+
+    if(identifier == CPROVER_PREFIX "overflow_minus")
+    {
+      overflow.id(ID_minus);
+      typecheck_expr_binary_arithmetic(overflow);
+    }
+    else if(identifier == CPROVER_PREFIX "overflow_mult")
+    {
+      overflow.id(ID_mult);
+      typecheck_expr_binary_arithmetic(overflow);
+    }
+    else if(identifier == CPROVER_PREFIX "overflow_plus")
+    {
+      overflow.id(ID_plus);
+      typecheck_expr_binary_arithmetic(overflow);
+    }
+    else if(identifier == CPROVER_PREFIX "overflow_shl")
+    {
+      overflow.id(ID_shl);
+      typecheck_expr_shifts(to_shift_expr(overflow));
+    }
+    else if(identifier == CPROVER_PREFIX "overflow_unary_minus")
+    {
+      overflow.id(ID_unary_minus);
+      typecheck_expr_unary_arithmetic(overflow);
+    }
+
+    overflow.id("overflow-" + overflow.id_string());
+    overflow.type() = bool_typet{};
+    return overflow;
+  }
   else
     return nil_exprt();
 }

--- a/src/ansi-c/cprover_builtin_headers.h
+++ b/src/ansi-c/cprover_builtin_headers.h
@@ -98,3 +98,9 @@ void __CPROVER_k_induction_hint(unsigned min, unsigned max,
 // format string-related
 int __CPROVER_scanf(const char *, ...);
 
+// detect overflow
+__CPROVER_bool __CPROVER_overflow_minus();
+__CPROVER_bool __CPROVER_overflow_mult();
+__CPROVER_bool __CPROVER_overflow_plus();
+__CPROVER_bool __CPROVER_overflow_shl();
+__CPROVER_bool __CPROVER_overflow_unary_minus();

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -3793,11 +3793,13 @@ std::string expr2ct::convert_with_precedence(
   else if(src.id()==ID_cond)
     return convert_cond(src, precedence);
 
-  else if(src.id()==ID_overflow_unary_minus ||
-      src.id()==ID_overflow_minus ||
-      src.id()==ID_overflow_mult ||
-      src.id()==ID_overflow_plus)
+  else if(
+    src.id() == ID_overflow_unary_minus || src.id() == ID_overflow_minus ||
+    src.id() == ID_overflow_mult || src.id() == ID_overflow_plus ||
+    src.id() == ID_overflow_shl)
+  {
     return convert_overflow(src, precedence);
+  }
 
   else if(src.id()==ID_unknown)
     return "*";

--- a/src/ansi-c/library/cprover.h
+++ b/src/ansi-c/library/cprover.h
@@ -150,4 +150,16 @@ __CPROVER_bool __CPROVER_get_may(const void *, const char *);
 #define __CPROVER_danger_number_of_vars 1
 #define __CPROVER_danger_number_of_consts 1
 
+// detect overflow
+// NOLINTNEXTLINE(build/deprecated)
+__CPROVER_bool __CPROVER_overflow_minus();
+// NOLINTNEXTLINE(build/deprecated)
+__CPROVER_bool __CPROVER_overflow_mult();
+// NOLINTNEXTLINE(build/deprecated)
+__CPROVER_bool __CPROVER_overflow_plus();
+// NOLINTNEXTLINE(build/deprecated)
+__CPROVER_bool __CPROVER_overflow_shl();
+// NOLINTNEXTLINE(build/deprecated)
+__CPROVER_bool __CPROVER_overflow_unary_minus();
+
 #endif // CPROVER_ANSI_C_LIBRARY_CPROVER_H

--- a/src/ansi-c/library/stdlib.c
+++ b/src/ansi-c/library/stdlib.c
@@ -65,11 +65,20 @@ __CPROVER_bool __VERIFIER_nondet___CPROVER_bool();
 
 inline void *calloc(__CPROVER_size_t nmemb, __CPROVER_size_t size)
 {
+__CPROVER_HIDE:;
+#pragma CPROVER check push
+#pragma CPROVER check disable "unsigned-overflow"
+  if(__CPROVER_overflow_mult(nmemb, size))
+    return (void *)0;
+  // This is now safe; still do it within the scope of the pragma to avoid an
+  // unnecessary assertion to be generated.
+  __CPROVER_size_t alloc_size = nmemb * size;
+#pragma CPROVER check pop
+
+  void *malloc_res;
   // realistically, calloc may return NULL,
   // and __CPROVER_allocate doesn't, but no one cares
-  __CPROVER_HIDE:;
-  void *malloc_res;
-  malloc_res = __CPROVER_allocate(nmemb * size, 1);
+  malloc_res = __CPROVER_allocate(alloc_size, 1);
 
   // make sure it's not recorded as deallocated
   __CPROVER_deallocated =
@@ -79,7 +88,7 @@ inline void *calloc(__CPROVER_size_t nmemb, __CPROVER_size_t size)
   __CPROVER_bool record_malloc = __VERIFIER_nondet___CPROVER_bool();
   __CPROVER_malloc_object =
     record_malloc ? malloc_res : __CPROVER_malloc_object;
-  __CPROVER_malloc_size = record_malloc ? nmemb * size : __CPROVER_malloc_size;
+  __CPROVER_malloc_size = record_malloc ? alloc_size : __CPROVER_malloc_size;
   __CPROVER_malloc_is_new_array =
     record_malloc ? 0 : __CPROVER_malloc_is_new_array;
 

--- a/src/ansi-c/library_check.sh
+++ b/src/ansi-c/library_check.sh
@@ -11,7 +11,8 @@ for f in "$@"; do
     perl -p -i -e 's/(__sync_)/s$1/' __libcheck.c
     perl -p -i -e 's/(__noop)/s$1/' __libcheck.c
     "$CC" -std=gnu99 -E -include library/cprover.h -D__CPROVER_bool=_Bool -D__CPROVER_thread_local=__thread -DLIBRARY_CHECK -o __libcheck.i __libcheck.c
-    "$CC" -S -Wall -Werror -pedantic -Wextra -std=gnu99 __libcheck.i -o __libcheck.s -Wno-unused-label
+    "$CC" -S -Wall -Werror -pedantic -Wextra -std=gnu99 __libcheck.i \
+      -o __libcheck.s -Wno-unused-label -Wno-unknown-pragmas
     ec="${?}"
     rm __libcheck.s __libcheck.i __libcheck.c
     [ "${ec}" -eq 0 ] || exit "${ec}"

--- a/src/util/expr_initializer.cpp
+++ b/src/util/expr_initializer.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "arith_tools.h"
 #include "c_types.h"
+#include "magic.h"
 #include "namespace.h"
 #include "pointer_offset_size.h"
 #include "std_code.h"
@@ -133,7 +134,9 @@ optionalt<exprt> expr_initializert<nondet>::expr_initializer_rec(
         return {};
 
       const auto array_size = numeric_cast<mp_integer>(array_type.size());
-      if(array_type.size().id() == ID_infinity || !array_size.has_value())
+      if(
+        array_type.size().id() == ID_infinity || !array_size.has_value() ||
+        *array_size > MAX_FLATTENED_ARRAY_SIZE)
       {
         if(nondet)
           return side_effect_expr_nondett(type, source_location);

--- a/src/util/expr_initializer.cpp
+++ b/src/util/expr_initializer.cpp
@@ -132,7 +132,8 @@ optionalt<exprt> expr_initializert<nondet>::expr_initializer_rec(
       if(!tmpval.has_value())
         return {};
 
-      if(array_type.size().id()==ID_infinity)
+      const auto array_size = numeric_cast<mp_integer>(array_type.size());
+      if(array_type.size().id() == ID_infinity || !array_size.has_value())
       {
         if(nondet)
           return side_effect_expr_nondett(type, source_location);
@@ -140,15 +141,6 @@ optionalt<exprt> expr_initializert<nondet>::expr_initializer_rec(
         array_of_exprt value(*tmpval, array_type);
         value.add_source_location()=source_location;
         return std::move(value);
-      }
-
-      const auto array_size = numeric_cast<mp_integer>(array_type.size());
-      if(!array_size.has_value())
-      {
-        if(nondet)
-          return side_effect_expr_nondett(type, source_location);
-        else
-          return {};
       }
 
       if(*array_size < 0)


### PR DESCRIPTION
calloc guarantees that the requested number of bytes is allocated, or
else NULL is returned. Since an overflowing multiplication would imply
that the requested size can never be allocated, NULL must be returned
(and we should not report an arithmetic overflow error).

Fixes: #4606

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
