### PR TITLE
Print a more helpful message in Java bytecode parsing invariant violation

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_language.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_language.cpp
@@ -345,10 +345,11 @@ static void infer_opaque_type_fields(
             // Not present here: check the superclass.
             INVARIANT(
               !class_type->bases().empty(),
-              "class '" + id2string(class_symbol->name)
-                + "' (which was missing a field '" + id2string(component_name)
-                + "' referenced from method '" + id2string(method.name)
-                + "') should have an opaque superclass");
+              "class '" + id2string(class_symbol->name) +
+                "' (which was missing a field '" + id2string(component_name) +
+                "' referenced from method '" + id2string(method.name) +
+                "' of class '" + id2string(parse_tree.parsed_class.name) +
+                "') should have an opaque superclass");
             const auto &superclass_type = class_type->bases().front().type();
             class_symbol_id = superclass_type.get_identifier();
             class_type = &to_java_class_type(ns.follow(superclass_type));


### PR DESCRIPTION
In Java bytecode parsing, we throw an invariant violation when we cannot find and opaque class for which we could infer a field referenced in another method `X.m`. To make debugging easier, we should be printing not only the field, its class, and referencing method `m`, but also the referencing class `X`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
