### PR TITLE
add further == operators for patternt

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1007,14 +1007,16 @@ code_blockt java_bytecode_convert_methodt::convert_instructions(
     // a new maximal key
     assert(a_entry.first==--address_map.end());
 
-    if(i_it->statement!="goto" &&
-       i_it->statement!="return" &&
-       !(i_it->statement==patternt("?return")) &&
-       i_it->statement!="athrow" &&
-       i_it->statement!="jsr" &&
-       i_it->statement!="jsr_w" &&
-       i_it->statement!="ret")
+    // clang-format off
+    if(i_it->statement != "goto" &&
+       i_it->statement != "return" &&
+       i_it->statement != patternt("?return") &&
+       i_it->statement != "athrow" &&
+       i_it->statement != "jsr" &&
+       i_it->statement != "jsr_w" &&
+       i_it->statement != "ret")
     {
+      // clang-format on
       instructionst::const_iterator next=i_it;
       if(++next!=instructions.end())
         a_entry.first->second.successors.push_back(next->address);

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -94,11 +94,6 @@ static void assign_parameter_names(
   }
 }
 
-static bool operator==(const irep_idt &what, const patternt &pattern)
-{
-  return pattern==what;
-}
-
 static bool is_constructor(const irep_idt &method_name)
 {
   return id2string(method_name).find("<init>") != std::string::npos;

--- a/jbmc/src/java_bytecode/pattern.h
+++ b/jbmc/src/java_bytecode/pattern.h
@@ -25,7 +25,7 @@ public:
   }
 
   // match with '?'
-  bool operator==(const irep_idt &what) const
+  bool operator==(const std::string &what) const
   {
     for(std::size_t i = 0; i < what.size(); i++)
       if(p[i] == 0)
@@ -35,6 +35,25 @@ public:
 
     return p[what.size()] == 0;
   }
+
+#ifndef USE_STD_STRING
+  bool operator==(const irep_idt &what) const
+  {
+    return (*this) == id2string(what);
+  }
+#endif
+
+  friend bool operator==(const std::string &what, const patternt &p)
+  {
+    return p == what;
+  }
+
+#ifndef USE_STD_STRING
+  friend bool operator==(const irep_idt &what, const patternt &p)
+  {
+    return p == what;
+  }
+#endif
 
 protected:
   const char *p;

--- a/jbmc/src/java_bytecode/pattern.h
+++ b/jbmc/src/java_bytecode/pattern.h
@@ -55,6 +55,18 @@ public:
   }
 #endif
 
+  friend bool operator!=(const std::string &what, const patternt &p)
+  {
+    return !(p == what);
+  }
+
+#ifndef USE_STD_STRING
+  friend bool operator!=(const irep_idt &what, const patternt &p)
+  {
+    return !(p == what);
+  }
+#endif
+
 protected:
   const char *p;
 };


### PR DESCRIPTION
1.  A variant for comparing with std::string is added.  This avoids hashing
the string to produce the irep_idt.

2.  The variants with the pattern on the rhs are added.  This is already
used in one place.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
