### PR TITLE
Record constraints of indexed access to array constants [blocks: #2108]

### DIFF
--- a/regression/cbmc/array-tests/uf-always.c
+++ b/regression/cbmc/array-tests/uf-always.c
@@ -1,0 +1,33 @@
+#include <assert.h>
+
+// C semantics are that these will be zero
+int uninitializedGlobalArray1[2];
+int uninitializedGlobalArray2[2];
+
+int main(void)
+{
+  // Variable access
+  long directUseReadLocation; // Non-det
+
+  long x = directUseReadLocation;
+  if(0 <= directUseReadLocation && directUseReadLocation < 2)
+    assert(uninitializedGlobalArray1[directUseReadLocation] == 0);
+
+  /*** Variable non-redundant update ***/
+  // No obvious simplifications to writes
+
+  long nonRedundantWriteLocation;
+
+  if(
+    0 <= nonRedundantWriteLocation && nonRedundantWriteLocation < 2 &&
+    nonRedundantWriteLocation != 1)
+  {
+    uninitializedGlobalArray2[nonRedundantWriteLocation] = 1;
+  }
+
+  // Constant access
+  // Again, constant index into a fully known but non-constant array
+  assert(uninitializedGlobalArray2[1] == 0);
+
+  return 0;
+}

--- a/regression/cbmc/array-tests/uf-always.desc
+++ b/regression/cbmc/array-tests/uf-always.desc
@@ -1,0 +1,10 @@
+CORE
+uf-always.c
+--arrays-uf-always
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+This test is extracted from main.c to showcase a bug in the array encoding.

--- a/src/solvers/flattening/arrays.h
+++ b/src/solvers/flattening/arrays.h
@@ -83,7 +83,8 @@ protected:
     ARRAY_WITH,
     ARRAY_IF,
     ARRAY_OF,
-    ARRAY_TYPECAST
+    ARRAY_TYPECAST,
+    ARRAY_CONSTANT
   };
 
   struct lazy_constraintt
@@ -119,6 +120,9 @@ protected:
     const index_sett &index_set, const update_exprt &expr);
   void add_array_constraints_array_of(
     const index_sett &index_set, const array_of_exprt &exprt);
+  void add_array_constraints_array_constant(
+    const index_sett &index_set,
+    const array_exprt &exprt);
 
   void update_index_map(bool update_all);
   void update_index_map(std::size_t i);


### PR DESCRIPTION
When even constant arrays are left to be handled by the array theory,
expressions such as { 3, 4 }[1] were actually unconstrained as we never
recorded the fact that this expression evaluates to 4. To reduce the
number of constraints to be generated for non-constant indices, ranges
of equal values just yield a single constraint, optimising the case of
large zero-initialised arrays.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
