### PR TITLE
Document byte_update_exprt and rename non-const functions

### DIFF
--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -1497,7 +1497,7 @@ static exprt lower_byte_update_struct(
         array_typet{bv_typet{8}, src_size_opt.value()}};
 
       byte_update_exprt bu = src;
-      bu.op() = lower_byte_extract(byte_extract_expr, ns);
+      bu.set_op() = lower_byte_extract(byte_extract_expr, ns);
 
       return lower_byte_extract(
         byte_extract_exprt{
@@ -1615,7 +1615,7 @@ static exprt lower_byte_update_union(
     "lower_byte_update of union of unknown size is not supported");
 
   byte_update_exprt bu = src;
-  bu.op() = member_exprt{src.op(), max_comp_name, max_comp_type};
+  bu.set_op() = member_exprt{src.op(), max_comp_name, max_comp_type};
   bu.type() = max_comp_type;
 
   return union_exprt{

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -1497,7 +1497,7 @@ static exprt lower_byte_update_struct(
         array_typet{bv_typet{8}, src_size_opt.value()}};
 
       byte_update_exprt bu = src;
-      bu.set_op() = lower_byte_extract(byte_extract_expr, ns);
+      bu.set_op(lower_byte_extract(byte_extract_expr, ns));
 
       return lower_byte_extract(
         byte_extract_exprt{
@@ -1615,7 +1615,7 @@ static exprt lower_byte_update_union(
     "lower_byte_update of union of unknown size is not supported");
 
   byte_update_exprt bu = src;
-  bu.set_op() = member_exprt{src.op(), max_comp_name, max_comp_type};
+  bu.set_op(member_exprt{src.op(), max_comp_name, max_comp_type});
   bu.type() = max_comp_type;
 
   return union_exprt{

--- a/src/util/byte_operators.h
+++ b/src/util/byte_operators.h
@@ -90,6 +90,18 @@ public:
   exprt &op() { return op0(); }
   exprt &offset() { return op1(); }
   exprt &value() { return op2(); }
+  void set_op(exprt e)
+  {
+    op0() = std::move(e);
+  }
+  void set_offset(exprt e)
+  {
+    op1() = std::move(e);
+  }
+  void set_value(exprt e)
+  {
+    op2() = std::move(e);
+  }
 
   const exprt &op() const { return op0(); }
   const exprt &offset() const { return op1(); }

--- a/src/util/byte_operators.h
+++ b/src/util/byte_operators.h
@@ -87,9 +87,13 @@ public:
   {
   }
 
+  DEPRECATED(SINCE(2019, 5, 21, "use set_op or as_const instead"))
   exprt &op() { return op0(); }
+  DEPRECATED(SINCE(2019, 5, 21, "use set_offset or as_const instead"))
   exprt &offset() { return op1(); }
+  DEPRECATED(SINCE(2019, 5, 21, "use set_value or as_const instead"))
   exprt &value() { return op2(); }
+
   void set_op(exprt e)
   {
     op0() = std::move(e);

--- a/src/util/byte_operators.h
+++ b/src/util/byte_operators.h
@@ -20,8 +20,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "invariant.h"
 #include "std_expr.h"
 
-/*! \brief TO_BE_DOCUMENTED
-*/
+/// Expression of type \c type extracted from some object \c op starting at
+/// position \c offset (given in number of bytes).
+/// The object can either be interpreted in big endian or little endian, which
+/// is reflected by the \c id of the expression which is either
+/// \c ID_byte_extract_big_endian or \c ID_byte_extract_little_endian
 class byte_extract_exprt:public binary_exprt
 {
 public:

--- a/src/util/byte_operators.h
+++ b/src/util/byte_operators.h
@@ -72,8 +72,9 @@ inline byte_extract_exprt &to_byte_extract_expr(exprt &expr)
 irep_idt byte_extract_id();
 irep_idt byte_update_id();
 
-/*! \brief TO_BE_DOCUMENTED
-*/
+/// Expression corresponding to \c op() where the bytes starting at
+/// position \c offset (given in number of bytes) have been updated with
+/// \c value.
 class byte_update_exprt : public ternary_exprt
 {
 public:

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2064,7 +2064,7 @@ bool simplify_exprt::simplify_byte_update(byte_update_exprt &expr)
     expr.offset() == to_byte_update_expr(expr.op()).offset() &&
     expr.value().type() == to_byte_update_expr(expr.op()).value().type())
   {
-    expr.op()=expr.op().op0();
+    expr.set_op()=expr.op().op0();
     return false;
   }
 
@@ -2140,8 +2140,8 @@ bool simplify_exprt::simplify_byte_update(byte_update_exprt &expr)
             plus_exprt new_offset(offset, compo_offset);
             simplify_node(new_offset);
             exprt new_value(with.new_value());
-            expr.offset().swap(new_offset);
-            expr.value().swap(new_value);
+            expr.set_offset().swap(new_offset);
+            expr.set_value().swap(new_value);
             simplify_byte_update(expr); // do this recursively
             return false;
           }
@@ -2167,8 +2167,8 @@ bool simplify_exprt::simplify_byte_update(byte_update_exprt &expr)
           plus_exprt new_offset(offset, index_offset);
           simplify_node(new_offset);
           exprt new_value(with.new_value());
-          expr.offset().swap(new_offset);
-          expr.value().swap(new_value);
+          expr.set_offset().swap(new_offset);
+          expr.set_value().swap(new_value);
           simplify_byte_update(expr); // do this recursively
           return false;
         }


### PR DESCRIPTION
In some cases the non-const version was unnecessarily called because it
has the same name as the const version.
This pull requests avoids that from happening in 9 cases for op, 2 for value and 3 for
offset.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
