### PR TITLE
Add --nondet-static-except flag to CBMC

### DIFF
--- a/regression/goto-instrument/chain.sh
+++ b/regression/goto-instrument/chain.sh
@@ -8,13 +8,24 @@ cbmc=$3
 is_windows=$4
 
 name=${*:$#}
-name=${name%.c}
+
+if [[ x$name == x ]];  then
+  name=${name%.c}
+fi
 
 args=${*:5:$#-5}
 
-if [[ "${is_windows}" == "true" ]]; then
+if [[ "${is_windows}" == "true" && x$name != x ]]; then
+  $goto_cc "main.gb" ${name}
+  name="main"
+  mv "${name}.exe" "${name}.gb"
+elif [[ "${is_windows}" == "true" ]]; then
   $goto_cc "${name}.c"
   mv "${name}.exe" "${name}.gb"
+elif [[ x$name != x ]]; then
+  $goto_cc -o "main.gb" ${name}
+  echo "name: ${name}"
+  name="main"
 else
   $goto_cc -o "${name}.gb" "${name}.c"
 fi

--- a/regression/goto-instrument/nondet-static-exclude_subfolder/main.c
+++ b/regression/goto-instrument/nondet-static-exclude_subfolder/main.c
@@ -1,0 +1,9 @@
+#include "package1/file.c"
+#include "package2/file.c"
+
+void main()
+{
+  method1();
+  method2();
+  return 0;
+}

--- a/regression/goto-instrument/nondet-static-exclude_subfolder/package1/file.c
+++ b/regression/goto-instrument/nondet-static-exclude_subfolder/package1/file.c
@@ -1,0 +1,8 @@
+static int myVal = 3;
+static int myVal2 = 4;
+
+void method2()
+{
+  __CPROVER_assert(myVal == 3, "method2 myVal");
+  __CPROVER_assert(myVal2 == 4, "method2 myVal2");
+}

--- a/regression/goto-instrument/nondet-static-exclude_subfolder/package2/file.c
+++ b/regression/goto-instrument/nondet-static-exclude_subfolder/package2/file.c
@@ -1,0 +1,8 @@
+static int myVal = 3;
+static int myVal2 = 4;
+
+void method1()
+{
+  __CPROVER_assert(myVal == 3, "method1 myVal");
+  __CPROVER_assert(myVal2 == 4, "method1 myVal2");
+}

--- a/regression/goto-instrument/nondet-static-exclude_subfolder/test.desc
+++ b/regression/goto-instrument/nondet-static-exclude_subfolder/test.desc
@@ -1,0 +1,12 @@
+CORE
+package1/file.c package2/file.c main.c
+--nondet-static-exclude package1/file.c:myVal --nondet-static-exclude package2/file.c:myVal2
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+method2 myVal: SUCCESS
+method2 myVal2: FAILURE
+method1 myVal: FAILURE
+method1 myVal2: SUCCESS
+--
+--

--- a/regression/goto-instrument/nondet_static_exclude/main.c
+++ b/regression/goto-instrument/nondet_static_exclude/main.c
@@ -1,0 +1,38 @@
+#define NULL 0
+
+struct aStruct
+{
+  int a;
+  int b;
+};
+
+struct aStruct *test1 = NULL;
+
+struct aStruct test2 = {.a = 5, .b = 2};
+struct aStruct test3 = {.a = 1, .b = 4};
+struct aStruct *test4 = &test3;
+struct aStruct *test5 = &test2;
+
+static int value = 7;
+
+#include "main_1.h"
+#include <assert.h>
+
+int main(int argc, char **argv)
+{
+  assert(test1 == NULL);
+  assert(test2.a == 5);
+  assert(test3.a == 1);
+  assert(test3.b == 4);
+  assert(test4->a == 1);
+  assert(test4->b == 4);
+
+  assert(test5->a == 5);
+  assert(test5->b == 2);
+
+  assert(value == 7);
+
+  setup();
+
+  return 0;
+}

--- a/regression/goto-instrument/nondet_static_exclude/main_1.c
+++ b/regression/goto-instrument/nondet_static_exclude/main_1.c
@@ -1,0 +1,9 @@
+static int value = 5;
+
+#include <assert.h>
+
+void setup()
+{
+  assert(value == 5);
+  return 0;
+}

--- a/regression/goto-instrument/nondet_static_exclude/main_1.h
+++ b/regression/goto-instrument/nondet_static_exclude/main_1.h
@@ -1,0 +1,1 @@
+void setup();

--- a/regression/goto-instrument/nondet_static_exclude/test.desc
+++ b/regression/goto-instrument/nondet_static_exclude/test.desc
@@ -1,0 +1,18 @@
+CORE
+main_1.c main.c 
+--nondet-static --nondet-static-exclude test1 --nondet-static-exclude test3 --nondet-static-exclude test4 --nondet-static-exclude main_1.c:value
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+assertion test1 == (NULL|0): SUCCESS
+assertion test2.a == 5: FAILURE
+assertion test3.a == 1: SUCCESS
+assertion test3.b == 4: SUCCESS
+assertion test4->a == 1: SUCCESS
+assertion test4->b == 4: SUCCESS
+assertion test5->a == 5: FAILURE
+assertion test5->b == 2: FAILURE
+assertion value == 7: FAILURE
+assertion value == 5: SUCCESS
+--
+--

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1205,10 +1205,19 @@ void goto_instrument_parse_optionst::instrument_goto_program()
 
   // ignore default/user-specified initialization of variables with static
   // lifetime
-  if(cmdline.isset("nondet-static"))
+  if(cmdline.isset("nondet-static-exclude"))
   {
-    log.status() << "Adding nondeterministic initialization of static/global "
-                    "variables"
+    log.status() << "Adding nondeterministic initialization "
+                    "of static/global variables except for "
+                    "the specified ones."
+                 << messaget::eom;
+
+    nondet_static(goto_model, cmdline.get_values("nondet-static-exclude"));
+  }
+  else if(cmdline.isset("nondet-static"))
+  {
+    log.status() << "Adding nondeterministic initialization "
+                    "of static/global variables"
                  << messaget::eom;
     nondet_static(goto_model);
   }
@@ -1607,6 +1616,8 @@ void goto_instrument_parse_optionst::help()
     " --isr <function>             instruments an interrupt service routine\n"
     " --mmio                       instruments memory-mapped I/O\n"
     " --nondet-static              add nondeterministic initialization of variables with static lifetime\n" // NOLINT(*)
+    " --nondet-static-exclude e    same as nondet-static except for the variable e\n" //NOLINT(*)
+    "                              (use multiple times if required)\n"
     " --check-invariant function   instruments invariant checking function\n"
     " --remove-pointers            converts pointer arithmetic to base+offset expressions\n" // NOLINT(*)
     " --splice-call caller,callee  prepends a call to callee in the body of caller\n"  // NOLINT(*)

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -62,6 +62,7 @@ Author: Daniel Kroening, kroening@kroening.com
   "(no-po-rendering)(render-cluster-file)(render-cluster-function)" \
   "(nondet-volatile)(isr):" \
   "(stack-depth):(nondet-static)" \
+  "(nondet-static-exclude):" \
   "(function-enter):(function-exit):(branch):" \
   OPT_SHOW_GOTO_FUNCTIONS \
   OPT_SHOW_PROPERTIES \

--- a/src/goto-instrument/nondet_static.h
+++ b/src/goto-instrument/nondet_static.h
@@ -20,6 +20,8 @@ Date: November 2011
 #ifndef CPROVER_GOTO_INSTRUMENT_NONDET_STATIC_H
 #define CPROVER_GOTO_INSTRUMENT_NONDET_STATIC_H
 
+#include <util/options.h>
+
 class goto_modelt;
 class namespacet;
 class goto_functionst;
@@ -34,5 +36,7 @@ void nondet_static(
   goto_functionst &goto_functions);
 
 void nondet_static(goto_modelt &);
+
+void nondet_static(goto_modelt &, const optionst::value_listt &);
 
 #endif // CPROVER_GOTO_INSTRUMENT_NONDET_STATIC_H


### PR DESCRIPTION
--nondet-static-except behaves as --nondet-static but allows to filter
the symbols which are effected by --nondet-static. Every symbol
that is effected by nondet-static and is not in the comma separated
symbol list passed to --nondet-static-except will be nondet when
using this flag. All symbols in the list keep their concret initalization.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
