### PR TITLE
Update generate_vcxproj to work with current source tree

### DIFF
--- a/buildspec-windows.yml
+++ b/buildspec-windows.yml
@@ -33,6 +33,14 @@ phases:
         cmd /c 'call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64 && bash -c "make CXX=clcache.exe -j4 -C jbmc/unit all BUILD_ENV=MSVC" '
 
       - |
+        $env:Path = "C:\tools\cygwin\bin;c:\tools\clcache\clcache-4.1.0;$env:Path"
+        $env:CLCACHE_DIR = "C:\clcache"
+        $env:CLCACHE_BASEDIR = (Get-Item -Path ".\").FullName
+        cmd /c 'bash -c "cd scripts ; ./generate_vcxproj"'
+        $env:Path = "C:\Program Files (x86)\MSBuild\14.0\Bin;$env:Path"
+        msbuild /p:CLToolExe=clcache.exe /m:4 cbmc.vcxproj
+
+      - |
         # display cache stats
         $env:Path = "C:\tools\cygwin\bin;c:\tools\clcache\clcache-4.1.0;$env:Path"
         $env:CLCACHE_DIR = "C:\clcache"

--- a/scripts/generate_vcxproj
+++ b/scripts/generate_vcxproj
@@ -16,6 +16,9 @@ function doit {
   for dir in $dirs ; do
     sources="`(cd $dest/src/$dir; make sources)`"
     for s in $sources ; do
+      if [ "$s" = "goto_instrument_main.cpp" ] && [ "$1" != "goto-instrument" ] ; then
+        continue
+      fi
       echo "    <ClCompile Include=\"src\\${dir}\\${s}\"/>" >> $dest/$1.vcxproj
     done
   done
@@ -50,11 +53,11 @@ function doit {
   echo "</Project>" >> $dest/$1.vcxproj.filters
 }
 
-dirs="big-int langapi util ansi-c assembler cpp java_bytecode xmllang solvers goto-symex analyses pointer-analysis goto-programs linking cbmc"
+dirs="big-int langapi util ansi-c assembler cpp json json-symtab-language xmllang solvers goto-symex analyses pointer-analysis goto-programs linking goto-checker goto-instrument cbmc"
 doit cbmc
 
-dirs="big-int langapi util ansi-c assembler cpp java_bytecode xmllang solvers goto-symex analyses pointer-analysis goto-programs linking jsil goto-cc"
+dirs="big-int langapi util ansi-c assembler cpp json xmllang goto-programs linking goto-cc"
 doit goto-cc
 
-dirs="big-int langapi util ansi-c assembler cpp java_bytecode xmllang solvers goto-symex analyses pointer-analysis goto-programs linking goto-instrument"
+dirs="big-int langapi util ansi-c assembler cpp json xmllang solvers goto-symex analyses pointer-analysis goto-programs linking goto-instrument"
 doit goto-instrument

--- a/scripts/vcxproj.1
+++ b/scripts/vcxproj.1
@@ -20,12 +20,14 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -50,6 +52,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions);STL_HASH_TR1;HAVE_MINISAT2</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)/src;$(ProjectDir)/minisat-2.2.1</AdditionalIncludeDirectories>
+      <ObjectFileName>$(IntDir)/%(RelativeDir)/</ObjectFileName>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -65,6 +68,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions);STL_HASH_TR1;HAVE_MINISAT2</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)/src;$(ProjectDir)/minisat-2.2.1</AdditionalIncludeDirectories>
+      <ObjectFileName>$(IntDir)/%(RelativeDir)/</ObjectFileName>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
1) We have multiple source files with the same basename, and thus need
to instruct Visual Studio not to put build artefacts into a single
directory.
2) Directory dependencies have changed.
3) Specifically, cbmc now also depends on (parts of) goto-instrument;
yet we must not include goto_instrument_main.cpp in the CBMC build as it
would cause duplicate main functions.
4) Cleanup: While reviewing 2) I noticed that we had a duplicate
json$(LIBEXT) entry in CBMC's Makefile.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
