### PR TITLE
Make check in XML output function a precondition

### DIFF
--- a/src/goto-analyzer/static_verifier.cpp
+++ b/src/goto-analyzer/static_verifier.cpp
@@ -66,7 +66,7 @@ static void static_verifier_xml(
 {
   m.status() << "Writing XML report" << messaget::eom;
 
-  xmlt xml_result;
+  xmlt xml_result{"cprover"};
 
   for(const auto &result : results)
   {

--- a/src/util/xml.cpp
+++ b/src/util/xml.cpp
@@ -34,8 +34,7 @@ void xmlt::output(std::ostream &out, unsigned indent) const
   // 'name' needs to be set, or we produce mal-formed
   // XML.
 
-  if(name.empty())
-    return;
+  PRECONDITION(!name.empty());
 
   do_indent(out, indent);
 


### PR DESCRIPTION
Previously this check would just lead to a silent return when
trying to output an empty XML document. As per the comment this is
actually an error.

Also fixes one instance where this function was used incorrectly in
goto-analyzer.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
