### PR TITLE
Rename lambda_exprt to array_comprehension_exprt

### DIFF
--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -294,7 +294,7 @@ bvt boolbvt::convert_bitvector(const exprt &expr)
   else if(expr.id()==ID_complex_imag)
     return convert_complex_imag(to_complex_imag_expr(expr));
   else if(expr.id()==ID_lambda)
-    return convert_lambda(to_lambda_expr(expr));
+    return convert_lambda(to_array_comprehension_expr(expr));
   else if(expr.id()==ID_array_of)
     return convert_array_of(to_array_of_expr(expr));
   else if(expr.id()==ID_let)
@@ -316,7 +316,7 @@ bvt boolbvt::convert_bitvector(const exprt &expr)
   return conversion_failed(expr);
 }
 
-bvt boolbvt::convert_lambda(const lambda_exprt &expr)
+bvt boolbvt::convert_lambda(const array_comprehension_exprt &expr)
 {
   std::size_t width=boolbv_width(expr.type());
 

--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -28,7 +28,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 class extractbit_exprt;
 class extractbits_exprt;
-class lambda_exprt;
+class array_comprehension_exprt;
 class member_exprt;
 
 class boolbvt:public arrayst
@@ -149,7 +149,7 @@ protected:
   virtual bvt convert_complex(const complex_exprt &expr);
   virtual bvt convert_complex_real(const complex_real_exprt &expr);
   virtual bvt convert_complex_imag(const complex_imag_exprt &expr);
-  virtual bvt convert_lambda(const lambda_exprt &expr);
+  virtual bvt convert_lambda(const array_comprehension_exprt &expr);
   virtual bvt convert_let(const let_exprt &);
   virtual bvt convert_array_of(const array_of_exprt &expr);
   virtual bvt convert_union(const union_exprt &expr);

--- a/src/util/simplify_expr_array.cpp
+++ b/src/util/simplify_expr_array.cpp
@@ -48,12 +48,12 @@ bool simplify_exprt::simplify_index(exprt &expr)
   {
     // simplify (lambda i: e)(x) to e[i/x]
 
-    const lambda_exprt &lambda_expr = to_lambda_expr(array);
+    const auto &comprehension = to_array_comprehension_expr(array);
 
-    if(expr.op1().type() == lambda_expr.arg().type())
+    if(expr.op1().type() == comprehension.arg().type())
     {
-      exprt tmp = lambda_expr.body();
-      replace_expr(lambda_expr.arg(), expr.op1(), tmp);
+      exprt tmp = comprehension.body();
+      replace_expr(comprehension.arg(), expr.op1(), tmp);
       expr.swap(tmp);
       simplify_rec(expr);
       return false;

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -4462,6 +4462,14 @@ inline cond_exprt &to_cond_expr(exprt &expr)
 
 /// \brief Expression to define a mapping from an argument (index) to elements.
 /// This enables constructing an array via an anonymous function.
+/// Not all kinds of array comprehension can be expressed, only those of the
+/// form `[f(x) | x in {0, 1, ... array_size-1}]`.
+/// The LHS and RHS are the argument (`x`) and body (`f(x)`) of the anonymous
+/// function, respectively. The range is given by the type of the expression,
+/// which has to be an \ref array_typet (which includes a value for
+/// `array_size`).
+/// For legacy reasons, the ID of an array_comprehension_exprt is ID_lambda,
+/// even though it cannot be used to represent arbitrary lambda functions.
 class array_comprehension_exprt : public binary_exprt
 {
 public:

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -4462,10 +4462,13 @@ inline cond_exprt &to_cond_expr(exprt &expr)
 
 /// \brief Expression to define a mapping from an argument (index) to elements.
 /// This enables constructing an array via an anonymous function.
-class lambda_exprt : public binary_exprt
+class array_comprehension_exprt : public binary_exprt
 {
 public:
-  explicit lambda_exprt(symbol_exprt arg, exprt body, array_typet _type)
+  explicit array_comprehension_exprt(
+    symbol_exprt arg,
+    exprt body,
+    array_typet _type)
     : binary_exprt(std::move(arg), ID_lambda, std::move(body), std::move(_type))
   {
   }
@@ -4502,35 +4505,38 @@ public:
 };
 
 template <>
-inline bool can_cast_expr<lambda_exprt>(const exprt &base)
+inline bool can_cast_expr<array_comprehension_exprt>(const exprt &base)
 {
   return base.id() == ID_lambda;
 }
 
-inline void validate_expr(const lambda_exprt &value)
+inline void validate_expr(const array_comprehension_exprt &value)
 {
-  validate_operands(value, 2, "'Lambda' must have two operands");
+  validate_operands(value, 2, "'Array comprehension' must have two operands");
 }
 
-/// \brief Cast an exprt to a \ref lambda_exprt
+/// \brief Cast an exprt to a \ref array_comprehension_exprt
 ///
-/// \a expr must be known to be \ref lambda_exprt.
+/// \a expr must be known to be \ref array_comprehension_exprt.
 ///
 /// \param expr: Source expression
-/// \return Object of type \ref lambda_exprt
-inline const lambda_exprt &to_lambda_expr(const exprt &expr)
+/// \return Object of type \ref array_comprehension_exprt
+inline const array_comprehension_exprt &
+to_array_comprehension_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_lambda);
-  const lambda_exprt &ret = static_cast<const lambda_exprt &>(expr);
+  const array_comprehension_exprt &ret =
+    static_cast<const array_comprehension_exprt &>(expr);
   validate_expr(ret);
   return ret;
 }
 
-/// \copydoc to_lambda_expr(const exprt &)
-inline lambda_exprt &to_lambda_expr(exprt &expr)
+/// \copydoc to_array_comprehension_expr(const exprt &)
+inline array_comprehension_exprt &to_array_comprehension_expr(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_lambda);
-  lambda_exprt &ret = static_cast<lambda_exprt &>(expr);
+  array_comprehension_exprt &ret =
+    static_cast<array_comprehension_exprt &>(expr);
   validate_expr(ret);
   return ret;
 }


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->
As mentioned in a comment on https://github.com/diffblue/cbmc/pull/4672, this is a suggestion to rename the newly introduced type `lambda_exprt` to `array_comprehension_exprt`, which I find more intuitive. Some more documentation is also added.
If there is a good reason to keep the old name, or if another name would be more suitable, let me know and I'll change the first commit accordingly.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
