### PR TITLE
Clean up in the value set API

### DIFF
--- a/src/doxyfile
+++ b/src/doxyfile
@@ -2041,7 +2041,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = "DEPRECATED(msg)= /// \deprecated msg"
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/src/goto-symex/postcondition.cpp
+++ b/src/goto-symex/postcondition.cpp
@@ -160,16 +160,13 @@ bool postconditiont::is_used(
   else if(expr.id()==ID_dereference)
   {
     // aliasing may happen here
-    value_setst::valuest expr_set =
+    std::vector<exprt> expr_set =
       value_set.get_value_set(to_dereference_expr(expr).pointer(), ns);
     std::unordered_set<irep_idt> symbols;
 
-    for(value_setst::valuest::const_iterator
-        it=expr_set.begin();
-        it!=expr_set.end();
-        it++)
+    for(const exprt &e : expr_set)
     {
-      const exprt tmp = get_original_name(*it);
+      const exprt tmp = get_original_name(e);
       find_symbols(tmp, symbols);
     }
 

--- a/src/goto-symex/postcondition.cpp
+++ b/src/goto-symex/postcondition.cpp
@@ -160,8 +160,8 @@ bool postconditiont::is_used(
   else if(expr.id()==ID_dereference)
   {
     // aliasing may happen here
-    value_setst::valuest expr_set;
-    value_set.get_value_set(to_dereference_expr(expr).pointer(), expr_set, ns);
+    value_setst::valuest expr_set =
+      value_set.get_value_set(to_dereference_expr(expr).pointer(), ns);
     std::unordered_set<irep_idt> symbols;
 
     for(value_setst::valuest::const_iterator

--- a/src/goto-symex/precondition.cpp
+++ b/src/goto-symex/precondition.cpp
@@ -112,15 +112,12 @@ void preconditiont::compute_rec(exprt &dest)
 
     // aliasing may happen here
 
-    value_setst::valuest expr_set = value_sets.get_values(
+    const std::vector<exprt> expr_set = value_sets.get_values(
       SSA_step.source.function_id, target, deref_expr.pointer());
     std::unordered_set<irep_idt> symbols;
 
-    for(value_setst::valuest::const_iterator
-        it=expr_set.begin();
-        it!=expr_set.end();
-        it++)
-      find_symbols(*it, symbols);
+    for(const exprt &e : expr_set)
+      find_symbols(e, symbols);
 
     if(symbols.find(lhs_identifier)!=symbols.end())
     {

--- a/src/goto-symex/precondition.cpp
+++ b/src/goto-symex/precondition.cpp
@@ -112,9 +112,8 @@ void preconditiont::compute_rec(exprt &dest)
 
     // aliasing may happen here
 
-    value_setst::valuest expr_set;
-    value_sets.get_values(
-      SSA_step.source.function_id, target, deref_expr.pointer(), expr_set);
+    value_setst::valuest expr_set = value_sets.get_values(
+      SSA_step.source.function_id, target, deref_expr.pointer());
     std::unordered_set<irep_idt> symbols;
 
     for(value_setst::valuest::const_iterator

--- a/src/goto-symex/symex_dereference_state.cpp
+++ b/src/goto-symex/symex_dereference_state.cpp
@@ -107,3 +107,10 @@ void symex_dereference_statet::get_value_set(
   std::cout << "**************************\n";
 #endif
 }
+
+/// Just forwards a value-set query to `state.value_set`
+value_setst::valuest
+symex_dereference_statet::get_value_set(const exprt &expr) const
+{
+  return state.value_set.get_value_set(expr, ns);
+}

--- a/src/goto-symex/symex_dereference_state.cpp
+++ b/src/goto-symex/symex_dereference_state.cpp
@@ -109,7 +109,7 @@ void symex_dereference_statet::get_value_set(
 }
 
 /// Just forwards a value-set query to `state.value_set`
-value_setst::valuest
+std::vector<exprt>
 symex_dereference_statet::get_value_set(const exprt &expr) const
 {
   return state.value_set.get_value_set(expr, ns);

--- a/src/goto-symex/symex_dereference_state.h
+++ b/src/goto-symex/symex_dereference_state.h
@@ -34,11 +34,11 @@ protected:
   goto_symext::statet &state;
   const namespacet &ns;
 
-  DEPRECATED(SINCE(2019, 05, 22, "use list returning version instead"))
+  DEPRECATED(SINCE(2019, 05, 22, "use vector returning version instead"))
   void get_value_set(const exprt &expr, value_setst::valuest &value_set)
     const override;
 
-  value_setst::valuest get_value_set(const exprt &expr) const override;
+  std::vector<exprt> get_value_set(const exprt &expr) const override;
 
   const symbolt *get_or_create_failed_symbol(const exprt &expr) override;
 };

--- a/src/goto-symex/symex_dereference_state.h
+++ b/src/goto-symex/symex_dereference_state.h
@@ -34,8 +34,11 @@ protected:
   goto_symext::statet &state;
   const namespacet &ns;
 
+  DEPRECATED(SINCE(2019, 05, 22, "use list returning version instead"))
   void get_value_set(const exprt &expr, value_setst::valuest &value_set)
     const override;
+
+  value_setst::valuest get_value_set(const exprt &expr) const override;
 
   const symbolt *get_or_create_failed_symbol(const exprt &expr) override;
 };

--- a/src/pointer-analysis/dereference_callback.h
+++ b/src/pointer-analysis/dereference_callback.h
@@ -29,8 +29,11 @@ class dereference_callbackt
 public:
   virtual ~dereference_callbackt() = default;
 
+  DEPRECATED(SINCE(2019, 05, 22, "use list returning version instead"))
   virtual void
   get_value_set(const exprt &expr, value_setst::valuest &value_set) const = 0;
+
+  virtual value_setst::valuest get_value_set(const exprt &expr) const = 0;
 
   virtual const symbolt *get_or_create_failed_symbol(const exprt &expr) = 0;
 };

--- a/src/pointer-analysis/dereference_callback.h
+++ b/src/pointer-analysis/dereference_callback.h
@@ -29,11 +29,11 @@ class dereference_callbackt
 public:
   virtual ~dereference_callbackt() = default;
 
-  DEPRECATED(SINCE(2019, 05, 22, "use list returning version instead"))
+  DEPRECATED(SINCE(2019, 05, 22, "use vector returning version instead"))
   virtual void
   get_value_set(const exprt &expr, value_setst::valuest &value_set) const = 0;
 
-  virtual value_setst::valuest get_value_set(const exprt &expr) const = 0;
+  virtual std::vector<exprt> get_value_set(const exprt &expr) const = 0;
 
   virtual const symbolt *get_or_create_failed_symbol(const exprt &expr) = 0;
 };

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -147,6 +147,16 @@ void goto_program_dereferencet::get_value_set(
   value_sets.get_values(current_function, current_target, expr, dest);
 }
 
+/// Gets the value set corresponding to the current target and
+/// expression \p expr.
+/// \param expr: an expression
+/// \return the value set
+std::list<exprt>
+goto_program_dereferencet::get_value_set(const exprt &expr) const
+{
+  return value_sets.get_values(current_function, current_target, expr);
+}
+
 /// Remove dereference expressions contained in `expr`.
 /// \param expr: an expression
 /// \param checks_only: when true, execute the substitution on a copy of expr

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -151,7 +151,7 @@ void goto_program_dereferencet::get_value_set(
 /// expression \p expr.
 /// \param expr: an expression
 /// \return the value set
-std::list<exprt>
+std::vector<exprt>
 goto_program_dereferencet::get_value_set(const exprt &expr) const
 {
   return value_sets.get_values(current_function, current_target, expr);

--- a/src/pointer-analysis/goto_program_dereference.h
+++ b/src/pointer-analysis/goto_program_dereference.h
@@ -65,11 +65,11 @@ protected:
 
   const symbolt *get_or_create_failed_symbol(const exprt &expr) override;
 
-  DEPRECATED(SINCE(2019, 05, 22, "use list returning version instead"))
+  DEPRECATED(SINCE(2019, 05, 22, "use vector returning version instead"))
   void
   get_value_set(const exprt &expr, value_setst::valuest &dest) const override;
 
-  std::list<exprt> get_value_set(const exprt &expr) const override;
+  std::vector<exprt> get_value_set(const exprt &expr) const override;
 
   void dereference_instruction(
     goto_programt::targett target,

--- a/src/pointer-analysis/goto_program_dereference.h
+++ b/src/pointer-analysis/goto_program_dereference.h
@@ -65,8 +65,11 @@ protected:
 
   const symbolt *get_or_create_failed_symbol(const exprt &expr) override;
 
+  DEPRECATED(SINCE(2019, 05, 22, "use list returning version instead"))
   void
   get_value_set(const exprt &expr, value_setst::valuest &dest) const override;
+
+  std::list<exprt> get_value_set(const exprt &expr) const override;
 
   void dereference_instruction(
     goto_programt::targett target,

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -371,7 +371,7 @@ void value_sett::get_value_set(
   #endif
 }
 
-std::list<exprt>
+std::vector<exprt>
 value_sett::get_value_set(exprt expr, const namespacet &ns) const
 {
   const object_mapt object_map = get_value_set(std::move(expr), ns, false);

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -21,6 +21,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/simplify_expr.h>
 
 #include <langapi/language_util.h>
+#include <util/range.h>
 
 #ifdef DEBUG
 #include <iostream>
@@ -308,8 +309,7 @@ bool value_sett::eval_pointer_offset(
   {
     assert(expr.operands().size()==1);
 
-    object_mapt reference_set;
-    get_value_set(expr.op0(), reference_set, ns, true);
+    const object_mapt reference_set = get_value_set(expr.op0(), ns, true);
 
     exprt new_expr;
     mp_integer previous_offset=0;
@@ -356,8 +356,7 @@ void value_sett::get_value_set(
   value_setst::valuest &dest,
   const namespacet &ns) const
 {
-  object_mapt object_map;
-  get_value_set(std::move(expr), object_map, ns, false);
+  object_mapt object_map = get_value_set(std::move(expr), ns, false);
 
   for(object_map_dt::const_iterator
       it=object_map.read().begin();
@@ -372,6 +371,14 @@ void value_sett::get_value_set(
   #endif
 }
 
+std::list<exprt>
+value_sett::get_value_set(exprt expr, const namespacet &ns) const
+{
+  const object_mapt object_map = get_value_set(std::move(expr), ns, false);
+  return make_range(object_map.read())
+    .map([&](const object_map_dt::value_type &pair) { return to_expr(pair); });
+}
+
 void value_sett::get_value_set(
   exprt expr,
   object_mapt &dest,
@@ -382,6 +389,19 @@ void value_sett::get_value_set(
     simplify(expr, ns);
 
   get_value_set_rec(expr, dest, "", expr.type(), ns);
+}
+
+value_sett::object_mapt value_sett::get_value_set(
+  exprt expr,
+  const namespacet &ns,
+  bool is_simplified) const
+{
+  if(!is_simplified)
+    simplify(expr, ns);
+
+  object_mapt dest;
+  get_value_set_rec(expr, dest, "", expr.type(), ns);
+  return dest;
 }
 
 /// Check if 'suffix' starts with 'field'.
@@ -1303,8 +1323,7 @@ void value_sett::assign(
   else
   {
     // basic type
-    object_mapt values_rhs;
-    get_value_set(rhs, values_rhs, ns, is_simplified);
+    object_mapt values_rhs = get_value_set(rhs, ns, is_simplified);
 
     // Permit custom subclass to alter the read values prior to write:
     adjust_assign_rhs_values(rhs, ns, values_rhs);

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -352,12 +352,12 @@ bool value_sett::eval_pointer_offset(
 }
 
 void value_sett::get_value_set(
-  const exprt &expr,
+  exprt expr,
   value_setst::valuest &dest,
   const namespacet &ns) const
 {
   object_mapt object_map;
-  get_value_set(expr, object_map, ns, false);
+  get_value_set(std::move(expr), object_map, ns, false);
 
   for(object_map_dt::const_iterator
       it=object_map.read().begin();
@@ -373,16 +373,15 @@ void value_sett::get_value_set(
 }
 
 void value_sett::get_value_set(
-  const exprt &expr,
+  exprt expr,
   object_mapt &dest,
   const namespacet &ns,
   bool is_simplified) const
 {
-  exprt tmp(expr);
   if(!is_simplified)
-    simplify(tmp, ns);
+    simplify(expr, ns);
 
-  get_value_set_rec(tmp, dest, "", tmp.type(), ns);
+  get_value_set_rec(expr, dest, "", expr.type(), ns);
 }
 
 /// Check if 'suffix' starts with 'field'.

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -264,7 +264,7 @@ public:
   /// \param [out] dest: assigned a set of expressions that `expr` may point to
   /// \param ns: global namespace
   void get_value_set(
-    const exprt &expr,
+    exprt expr,
     value_setst::valuest &dest,
     const namespacet &ns) const;
 
@@ -461,7 +461,7 @@ protected:
   /// \param ns: global namespace
   /// \param is_simplified: if false, simplify `expr` before reading.
   void get_value_set(
-    const exprt &expr,
+    exprt expr,
     object_mapt &dest,
     const namespacet &ns,
     bool is_simplified) const;

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -275,7 +275,7 @@ public:
   /// \param expr: query expression
   /// \param ns: global namespace
   /// \return list of expressions that `expr` may point to
-  std::list<exprt> get_value_set(exprt expr, const namespacet &ns) const;
+  std::vector<exprt> get_value_set(exprt expr, const namespacet &ns) const;
 
   /// Appears to be unimplemented.
   DEPRECATED(SINCE(2019, 05, 22, "Unimplemented"))

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -237,6 +237,7 @@ public:
 
   /// Set of expressions; only used for the `get` API, not for internal
   /// data representation.
+  DEPRECATED(SINCE(2019, 05, 22, "Only used in deprecated function"))
   typedef std::set<exprt> expr_sett;
 
   /// Set of dynamic object numbers, equivalent to a set of
@@ -270,6 +271,7 @@ public:
     const namespacet &ns) const;
 
   /// Appears to be unimplemented.
+  DEPRECATED(SINCE(2019, 05, 22, "Unimplemented"))
   expr_sett &get(const irep_idt &identifier, const std::string &suffix);
 
   void clear()

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -80,6 +80,7 @@ public:
   /// Represents the offset into an object: either a unique integer offset,
   /// or an unknown value, represented by `!offset`.
   typedef optionalt<mp_integer> offsett;
+  DEPRECATED(SINCE(2019, 05, 22, "Unused"))
   bool offset_is_zero(const offsett &offset) const
   {
     return offset && offset->is_zero();

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -261,15 +261,21 @@ public:
   /// `entryt` fields.
   typedef sharing_mapt<irep_idt, entryt> valuest;
 
-  /// Gets values pointed to by `expr`, including following dereference
+  /// Gets values pointed to by \p expr, including following dereference
   /// operators (i.e. this is not a simple lookup in `valuest`).
-  /// \param expr: query expression
-  /// \param [out] dest: assigned a set of expressions that `expr` may point to
-  /// \param ns: global namespace
+  DEPRECATED(
+    SINCE(2019, 05, 22, "Use get_value_set(exprt, const namespacet &) instead"))
   void get_value_set(
     exprt expr,
     value_setst::valuest &dest,
     const namespacet &ns) const;
+
+  /// Gets values pointed to by `expr`, including following dereference
+  /// operators (i.e. this is not a simple lookup in `valuest`).
+  /// \param expr: query expression
+  /// \param ns: global namespace
+  /// \return list of expressions that `expr` may point to
+  std::list<exprt> get_value_set(exprt expr, const namespacet &ns) const;
 
   /// Appears to be unimplemented.
   DEPRECATED(SINCE(2019, 05, 22, "Unimplemented"))
@@ -458,17 +464,24 @@ public:
   void erase_symbol(const symbol_exprt &symbol_expr, const namespacet &ns);
 
 protected:
-  /// Reads the set of objects pointed to by `expr`, including making
+  /// Reads the set of objects pointed to by \p expr, including making
   /// recursive lookups for dereference operations etc.
-  /// \param expr: query expression
-  /// \param [out] dest: overwritten by the set of object numbers pointed to
-  /// \param ns: global namespace
-  /// \param is_simplified: if false, simplify `expr` before reading.
+  DEPRECATED(
+    SINCE(2019, 05, 22, "Use the version returning object_mapt instead"))
   void get_value_set(
     exprt expr,
     object_mapt &dest,
     const namespacet &ns,
     bool is_simplified) const;
+
+  /// Reads the set of objects pointed to by `expr`, including making
+  /// recursive lookups for dereference operations etc.
+  /// \param expr: query expression
+  /// \param ns: global namespace
+  /// \param is_simplified: if false, simplify `expr` before reading.
+  /// \return the set of object numbers pointed to
+  object_mapt
+  get_value_set(exprt expr, const namespacet &ns, bool is_simplified) const;
 
   /// See the other overload of `get_reference_set`. This one returns object
   /// numbers and offsets instead of expressions.

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -243,6 +243,7 @@ public:
   /// Set of dynamic object numbers, equivalent to a set of
   /// `dynamic_object_exprt`s with corresponding IDs. Used only in internal
   /// implementation details.
+  DEPRECATED(SINCE(2019, 05, 22, "Unused"))
   typedef std::set<unsigned int> dynamic_object_id_sett;
 
   /// Map representing the entire value set, mapping from string LHS IDs

--- a/src/pointer-analysis/value_set_analysis.h
+++ b/src/pointer-analysis/value_set_analysis.h
@@ -76,7 +76,7 @@ public:
   }
 
   // interface value_sets
-  std::list<exprt>
+  std::vector<exprt>
   get_values(const irep_idt &, locationt l, const exprt &expr) override
   {
     return (*this)[l].value_set.get_value_set(expr, baset::ns);

--- a/src/pointer-analysis/value_set_analysis.h
+++ b/src/pointer-analysis/value_set_analysis.h
@@ -65,6 +65,7 @@ public:
 
 public:
   // interface value_sets
+  DEPRECATED(SINCE(2019, 05, 22, "use list returning version instead"))
   void get_values(
     const irep_idt &,
     locationt l,
@@ -72,6 +73,13 @@ public:
     value_setst::valuest &dest) override
   {
     (*this)[l].value_set.get_value_set(expr, dest, baset::ns);
+  }
+
+  // interface value_sets
+  std::list<exprt>
+  get_values(const irep_idt &, locationt l, const exprt &expr) override
+  {
+    return (*this)[l].value_set.get_value_set(expr, baset::ns);
   }
 };
 

--- a/src/pointer-analysis/value_set_analysis_fi.cpp
+++ b/src/pointer-analysis/value_set_analysis_fi.cpp
@@ -195,3 +195,17 @@ bool value_set_analysis_fit::check_type(const typet &type)
 
   return false;
 }
+
+std::list<exprt> value_set_analysis_fit::get_values(
+  const irep_idt &function_id,
+  flow_insensitive_analysis_baset::locationt l,
+  const exprt &expr)
+{
+  state.value_set.from_function =
+    state.value_set.function_numbering.number(function_id);
+  state.value_set.to_function =
+    state.value_set.function_numbering.number(function_id);
+  state.value_set.from_target_index = l->location_number;
+  state.value_set.to_target_index = l->location_number;
+  return state.value_set.get_value_set(expr, ns);
+}

--- a/src/pointer-analysis/value_set_analysis_fi.cpp
+++ b/src/pointer-analysis/value_set_analysis_fi.cpp
@@ -196,7 +196,7 @@ bool value_set_analysis_fit::check_type(const typet &type)
   return false;
 }
 
-std::list<exprt> value_set_analysis_fit::get_values(
+std::vector<exprt> value_set_analysis_fit::get_values(
   const irep_idt &function_id,
   flow_insensitive_analysis_baset::locationt l,
   const exprt &expr)

--- a/src/pointer-analysis/value_set_analysis_fi.h
+++ b/src/pointer-analysis/value_set_analysis_fi.h
@@ -58,6 +58,7 @@ protected:
 
 public:
   // interface value_sets
+  DEPRECATED(SINCE(2019, 05, 22, "Use the version returning list instead"))
   void get_values(
     const irep_idt &function_id,
     locationt l,
@@ -72,6 +73,11 @@ public:
     state.value_set.to_target_index = l->location_number;
     state.value_set.get_value_set(expr, dest, ns);
   }
+
+  std::list<exprt> get_values(
+    const irep_idt &function_id,
+    locationt l,
+    const exprt &expr) override;
 };
 
 #endif // CPROVER_POINTER_ANALYSIS_VALUE_SET_ANALYSIS_FI_H

--- a/src/pointer-analysis/value_set_analysis_fi.h
+++ b/src/pointer-analysis/value_set_analysis_fi.h
@@ -74,7 +74,7 @@ public:
     state.value_set.get_value_set(expr, dest, ns);
   }
 
-  std::list<exprt> get_values(
+  std::vector<exprt> get_values(
     const irep_idt &function_id,
     locationt l,
     const exprt &expr) override;

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "value_set_fi.h"
 
 #include <cassert>
+#include <iterator>
 #include <ostream>
 
 #include <util/symbol_table.h>
@@ -297,6 +298,12 @@ void value_set_fit::get_value_set(
   std::list<exprt> &value_set,
   const namespacet &ns) const
 {
+  value_set = get_value_set(expr, ns);
+}
+
+std::list<exprt>
+value_set_fit::get_value_set(const exprt &expr, const namespacet &ns) const
+{
   object_mapt object_map;
   get_value_set(expr, object_map, ns);
 
@@ -336,21 +343,24 @@ void value_set_fit::get_value_set(
       flat_map.write()[it->first]=it->second;
   }
 
+  std::list<exprt> result;
   forall_objects(fit, flat_map.read())
-    value_set.push_back(to_expr(*fit));
+    result.push_back(to_expr(*fit));
 
-  #if 0
+#if 0
   // Sanity check!
   for(std::list<exprt>::const_iterator it=value_set.begin();
       it!=value_set.end();
       it++)
     assert(it->type().id()!="#REF");
-  #endif
+#endif
 
-  #if 0
+#if 0
   for(expr_sett::const_iterator it=value_set.begin(); it!=value_set.end(); it++)
     std::cout << "GET_VALUE_SET: " << format(*it) << '\n';
-  #endif
+#endif
+
+  return result;
 }
 
 void value_set_fit::get_value_set(

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -298,10 +298,14 @@ void value_set_fit::get_value_set(
   std::list<exprt> &value_set,
   const namespacet &ns) const
 {
-  value_set = get_value_set(expr, ns);
+  std::vector<exprt> result_as_vector = get_value_set(expr, ns);
+  std::move(
+    result_as_vector.begin(),
+    result_as_vector.end(),
+    std::back_inserter(value_set));
 }
 
-std::list<exprt>
+std::vector<exprt>
 value_set_fit::get_value_set(const exprt &expr, const namespacet &ns) const
 {
   object_mapt object_map;
@@ -343,7 +347,7 @@ value_set_fit::get_value_set(const exprt &expr, const namespacet &ns) const
       flat_map.write()[it->first]=it->second;
   }
 
-  std::list<exprt> result;
+  std::vector<exprt> result;
   forall_objects(fit, flat_map.read())
     result.push_back(to_expr(*fit));
 

--- a/src/pointer-analysis/value_set_fi.h
+++ b/src/pointer-analysis/value_set_fi.h
@@ -205,10 +205,13 @@ public:
   typedef std::unordered_set<idt, string_hash> assign_recursion_sett;
   #endif
 
+  DEPRECATED(SINCE(2019, 05, 22, "Use the version returning object_mapt instead"))
   void get_value_set(
     const exprt &expr,
     std::list<exprt> &dest,
     const namespacet &ns) const;
+
+  std::list<exprt> get_value_set(const exprt &expr, const namespacet &ns) const;
 
   expr_sett &get(
     const idt &identifier,

--- a/src/pointer-analysis/value_set_fi.h
+++ b/src/pointer-analysis/value_set_fi.h
@@ -205,13 +205,14 @@ public:
   typedef std::unordered_set<idt, string_hash> assign_recursion_sett;
   #endif
 
-  DEPRECATED(SINCE(2019, 05, 22, "Use the version returning object_mapt instead"))
+  DEPRECATED(SINCE(2019, 05, 22, "Use the version returning vector instead"))
   void get_value_set(
     const exprt &expr,
     std::list<exprt> &dest,
     const namespacet &ns) const;
 
-  std::list<exprt> get_value_set(const exprt &expr, const namespacet &ns) const;
+  std::vector<exprt>
+  get_value_set(const exprt &expr, const namespacet &ns) const;
 
   expr_sett &get(
     const idt &identifier,

--- a/src/pointer-analysis/value_sets.h
+++ b/src/pointer-analysis/value_sets.h
@@ -28,7 +28,7 @@ public:
   typedef std::list<exprt> valuest;
 
   // this is not const to allow a lazy evaluation
-  DEPRECATED(SINCE(2019, 05, 22, "use list returning version instead"))
+  DEPRECATED(SINCE(2019, 05, 22, "use vector returning version instead"))
   virtual void get_values(
     const irep_idt &function_id,
     goto_programt::const_targett l,
@@ -36,7 +36,7 @@ public:
     valuest &dest) = 0;
 
   // this is not const to allow a lazy evaluation
-  virtual valuest get_values(
+  virtual std::vector<exprt> get_values(
     const irep_idt &function_id,
     goto_programt::const_targett l,
     const exprt &expr) = 0;

--- a/src/pointer-analysis/value_sets.h
+++ b/src/pointer-analysis/value_sets.h
@@ -28,11 +28,18 @@ public:
   typedef std::list<exprt> valuest;
 
   // this is not const to allow a lazy evaluation
+  DEPRECATED(SINCE(2019, 05, 22, "use list returning version instead"))
   virtual void get_values(
     const irep_idt &function_id,
     goto_programt::const_targett l,
     const exprt &expr,
     valuest &dest) = 0;
+
+  // this is not const to allow a lazy evaluation
+  virtual valuest get_values(
+    const irep_idt &function_id,
+    goto_programt::const_targett l,
+    const exprt &expr) = 0;
 
   virtual ~value_setst()
   {


### PR DESCRIPTION
Several methods/members of value set are actually not used and should be deprecated to simplify the API. 
The `get_value_set` interface in which the result has to be given as argument is also not clear and it is better to return the result.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
