### PR TITLE
Value-set filtering: gracefully handle pointer arithmetic

### DIFF
--- a/regression/cbmc/Pointer_Arithmetic16/main.c
+++ b/regression/cbmc/Pointer_Arithmetic16/main.c
@@ -1,0 +1,10 @@
+#include <stdlib.h>
+
+int main()
+{
+  int *ptr = malloc(sizeof(int) * 2);
+  int *other_ptr;
+  if(ptr + 1 == other_ptr)
+    return 0;
+  __CPROVER_assert(0, "");
+}

--- a/regression/cbmc/Pointer_Arithmetic16/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic16/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+--
+Value-set filtering did not take into account arithemetic over pointers and thus
+spuriously failed an invariant.


### PR DESCRIPTION
Pointer arithmetic can yield expressions that are deemed constant for
the purpose of constant propagation (such as &x + 1), even though they
aren't actually constant_exprt.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
