### PR TITLE
Refactor in value_set

### DIFF
--- a/src/goto-symex/symex_dereference_state.cpp
+++ b/src/goto-symex/symex_dereference_state.cpp
@@ -13,6 +13,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/symbol_table.h>
 
+#ifdef DEBUG
+#  include <iostream>
+#endif
+
 /// Get or create a failed symbol for the given pointer-typed expression. These
 /// are used as placeholders when dereferencing expressions that are illegal to
 /// dereference, such as null pointers. The \ref add_failed_symbols pass must
@@ -84,10 +88,10 @@ void symex_dereference_statet::get_value_set(
 {
   state.value_set.get_value_set(expr, value_set, ns);
 
-#if 0
-  std::cout << "**************************\n";
-  state.value_set.output(goto_symex.ns, std::cout);
-  std::cout << "**************************\n";
+#ifdef DEBUG
+  std::cout << "symex_dereference_statet state.value_set={\n";
+  state.value_set.output(ns, std::cout, "  - ");
+  std::cout << "}" << std::endl;
 #endif
 
 #if 0

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -131,7 +131,10 @@ bool value_sett::insert(
   return true;
 }
 
-void value_sett::output(const namespacet &ns, std::ostream &out) const
+void value_sett::output(
+  const namespacet &ns,
+  std::ostream &out,
+  const std::string &indent) const
 {
   values.iterate([&](const irep_idt &, const entryt &e) {
     irep_idt identifier, display_name;
@@ -158,9 +161,7 @@ void value_sett::output(const namespacet &ns, std::ostream &out) const
 #endif
     }
 
-    out << display_name;
-
-    out << " = { ";
+    out << indent << display_name << " = { ";
 
     const object_map_dt &object_map = e.object_map.read();
 
@@ -204,7 +205,7 @@ void value_sett::output(const namespacet &ns, std::ostream &out) const
       {
         out << ", ";
         if(width >= 40)
-          out << "\n      ";
+          out << "\n" << std::string(' ', indent.size()) << "      ";
       }
     }
 

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -305,9 +305,11 @@ public:
   /// Pretty-print this value-set
   /// \param ns: global namespace
   /// \param [out] out: stream to write to
+  /// \param indent: string to use for indentation of the output
   void output(
     const namespacet &ns,
-    std::ostream &out) const;
+    std::ostream &out,
+    const std::string &indent = "") const;
 
   /// Stores the LHS ID -> RHS expression set map. See `valuest` documentation
   /// for more detail.

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -116,13 +116,10 @@ exprt value_set_dereferencet::dereference(const exprt &pointer)
 #endif
 
   // get the values of these
-
-  std::vector<exprt> retained_values;
-  for(const auto &value : points_to_set)
-  {
-    if(!should_ignore_value(value, exclude_null_derefs, language_mode))
-      retained_values.push_back(value);
-  }
+  const std::vector<exprt> retained_values =
+    make_range(points_to_set).filter([&](const exprt &value) {
+      return !should_ignore_value(value, exclude_null_derefs, language_mode);
+    });
 
   exprt compare_against_pointer = pointer;
 

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -29,6 +29,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/options.h>
 #include <util/pointer_offset_size.h>
 #include <util/pointer_predicates.h>
+#include <util/range.h>
 #include <util/simplify_expr.h>
 #include <util/ssa_expr.h>
 
@@ -123,8 +124,6 @@ exprt value_set_dereferencet::dereference(const exprt &pointer)
       retained_values.push_back(value);
   }
 
-  std::list<valuet> values;
-
   exprt compare_against_pointer = pointer;
 
   if(retained_values.size() >= 2 && should_use_local_definition_for(pointer))
@@ -147,8 +146,10 @@ exprt value_set_dereferencet::dereference(const exprt &pointer)
   std::cout << "}\n" << std::flush;
 #endif
 
-  for(const auto &value : retained_values)
-    values.push_back(build_reference_to(value, compare_against_pointer, ns));
+  std::list<valuet> values =
+    make_range(retained_values).map([&](const exprt &value) {
+      return build_reference_to(value, compare_against_pointer, ns);
+    });
 
   // can this fail?
   bool may_fail;

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -97,8 +97,9 @@ exprt value_set_dereferencet::dereference(const exprt &pointer)
   // type of the object
   const typet &type=pointer.type().subtype();
 
-#if 0
-  std::cout << "DEREF: " << format(pointer) << '\n';
+#ifdef DEBUG
+  std::cout << "value_set_dereferencet::dereference pointer=" << format(pointer)
+            << '\n';
 #endif
 
   // collect objects the pointer may point to
@@ -106,12 +107,11 @@ exprt value_set_dereferencet::dereference(const exprt &pointer)
 
   dereference_callback.get_value_set(pointer, points_to_set);
 
-#if 0
-  for(value_setst::valuest::const_iterator
-      it=points_to_set.begin();
-      it!=points_to_set.end();
-      it++)
-    std::cout << "P: " << format(*it) << '\n';
+#ifdef DEBUG
+  std::cout << "value_set_dereferencet::dereference points_to_set={";
+  for(auto p : points_to_set)
+    std::cout << format(p) << "; ";
+  std::cout << "}\n" << std::flush;
 #endif
 
   // get the values of these
@@ -140,15 +140,15 @@ exprt value_set_dereferencet::dereference(const exprt &pointer)
     compare_against_pointer = fresh_binder.symbol_expr();
   }
 
+#ifdef DEBUG
+  std::cout << "value_set_dereferencet::dereference retained_values={";
   for(const auto &value : retained_values)
-  {
-    values.push_back(build_reference_to(value, compare_against_pointer, ns));
-#if 0
-    std::cout << "V: " << format(value.pointer_guard) << " --> ";
-    std::cout << format(value.value);
-    std::cout << '\n';
+    std::cout << format(value) << "; ";
+  std::cout << "}\n" << std::flush;
 #endif
-  }
+
+  for(const auto &value : retained_values)
+    values.push_back(build_reference_to(value, compare_against_pointer, ns));
 
   // can this fail?
   bool may_fail;
@@ -227,8 +227,10 @@ exprt value_set_dereferencet::dereference(const exprt &pointer)
   if(compare_against_pointer != pointer)
     value = let_exprt(to_symbol_expr(compare_against_pointer), pointer, value);
 
-#if 0
-  std::cout << "R: " << format(value) << "\n\n";
+#ifdef DEBUG
+  std::cout << "value_set_derefencet::dereference value=" << format(value)
+            << '\n'
+            << std::flush;
 #endif
 
   return value;


### PR DESCRIPTION
This improves logging of debug information and clarifies the definition of `values` and `retained_values`

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
