### PR TITLE
Preparation to make goto-analyzer work with the goto_verifiert framework

### DIFF
--- a/src/analyses/ai.h
+++ b/src/analyses/ai.h
@@ -68,12 +68,12 @@ public:
   }
 
   /// Run abstract interpretation on a whole program
-  void operator()(const goto_modelt &goto_model)
+  void operator()(const abstract_goto_modelt &goto_model)
   {
-    const namespacet ns(goto_model.symbol_table);
-    initialize(goto_model.goto_functions);
-    entry_state(goto_model.goto_functions);
-    fixedpoint(goto_model.goto_functions, ns);
+    const namespacet ns(goto_model.get_symbol_table());
+    initialize(goto_model.get_goto_functions());
+    entry_state(goto_model.get_goto_functions());
+    fixedpoint(goto_model.get_goto_functions(), ns);
     finalize();
   }
 
@@ -374,7 +374,7 @@ protected:
 ///    \ref ai_baset#operator()(const irep_idt&,const goto_programt&, <!--
 ///    --> const namespacet&),
 ///    \ref ai_baset#operator()(const goto_functionst&,const namespacet&)
-///    and \ref ai_baset#operator()(const goto_modelt&)
+///    and \ref ai_baset#operator()(const abstract_goto_modelt&)
 /// 2. Accessing the results of an analysis, by looking up the result
 ///    for a given location \p l using
 ///    \ref ait#operator[](goto_programt::const_targett).

--- a/src/goto-analyzer/CMakeLists.txt
+++ b/src/goto-analyzer/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(goto-analyzer-lib
     cpp
     linking
     big-int
+    goto-checker
     goto-programs
     analyses
     pointer-analysis

--- a/src/goto-analyzer/Makefile
+++ b/src/goto-analyzer/Makefile
@@ -13,6 +13,7 @@ OBJ += ../ansi-c/ansi-c$(LIBEXT) \
       ../cpp/cpp$(LIBEXT) \
       ../linking/linking$(LIBEXT) \
       ../big-int/big-int$(LIBEXT) \
+      ../goto-checker/goto-checker$(LIBEXT) \
       ../goto-programs/goto-programs$(LIBEXT) \
       ../analyses/analyses$(LIBEXT) \
       ../pointer-analysis/pointer-analysis$(LIBEXT) \

--- a/src/goto-analyzer/module_dependencies.txt
+++ b/src/goto-analyzer/module_dependencies.txt
@@ -3,6 +3,7 @@ analyses
 assembler
 cpp
 goto-analyzer
+goto-checker
 goto-programs
 java_bytecode # will go away
 langapi # should go away

--- a/src/goto-analyzer/static_verifier.h
+++ b/src/goto-analyzer/static_verifier.h
@@ -9,8 +9,10 @@ Author: Martin Brain, martin.brain@cs.ox.ac.uk
 #ifndef CPROVER_GOTO_ANALYZER_STATIC_VERIFIER_H
 #define CPROVER_GOTO_ANALYZER_STATIC_VERIFIER_H
 
+#include <goto-checker/properties.h>
 #include <iosfwd>
 
+class abstract_goto_modelt;
 class ai_baset;
 class goto_modelt;
 class message_handlert;
@@ -22,5 +24,16 @@ bool static_verifier(
   const optionst &,
   message_handlert &,
   std::ostream &);
+
+/// Use the information from the abstract interpreter to fill out the statuses
+/// of the passed properties
+/// \param abstract_goto_model The goto program to verify
+/// \param ai The abstract interpreter (should be run to fixpoint
+///           before calling this function)
+/// \param properties The properties to fill out
+void static_verifier(
+  const abstract_goto_modelt &abstract_goto_model,
+  const ai_baset &ai,
+  propertiest &properties);
 
 #endif // CPROVER_GOTO_ANALYZER_STATIC_VERIFIER_H


### PR DESCRIPTION
* Make ai_baset work with `abstract_goto_modelt` rather than `goto_modelt`
* Add a version of `static_verifier` that works with `abstract_goto_modelt` and `propertiest`

This will (eventually) allow us to use the goto-checker stuff in `goto-analyzer`, which will be useful to make reporting of results and things like that more consistent with the rest of CPROVER.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
