### PR TITLE
Fix use of equality of value_sett::object_mapt

### DIFF
--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -221,10 +221,12 @@ public:
 
     bool operator==(const entryt &other) const
     {
-      return
-        identifier==other.identifier &&
-        suffix==other.suffix &&
-        object_map==other.object_map;
+      // Note that the object_map comparison below is duplicating the code of
+      // operator== defined in reference_counting.h because old versions of
+      // clang (3.7 and 3.8) do not resolve the template instantiation correctly
+      return identifier == other.identifier && suffix == other.suffix &&
+             (object_map.get_d() == other.object_map.get_d() ||
+              object_map.read() == other.object_map.read());
     }
     bool operator!=(const entryt &other) const
     {


### PR DESCRIPTION
This was removed recently in pull request diffblue/cbmc#4694 but it
seems necessary when compiling with clang which would complain about it
not being defined.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
