### PR TITLE
User-provided function definitions take precedence over built-ins

### DIFF
--- a/regression/cbmc/Function14/main.c
+++ b/regression/cbmc/Function14/main.c
@@ -1,0 +1,10 @@
+int nondet_foo()
+{
+  return 42;
+}
+
+int main()
+{
+  int x = nondet_foo();
+  __CPROVER_assert(x == 42, "nondet_foo returns a constant");
+}

--- a/regression/cbmc/Function14/test.desc
+++ b/regression/cbmc/Function14/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring


### PR DESCRIPTION
We should not replace calls to functions that have a body provided by
the user by our built-in definitions. While function names starting with
"\_" are reserved in C and thus users shouldn't be using them, it is
certainly not true that anything named "nondet_*" is exclusively to be
captured by our built-ins.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
