### PR TITLE
fix result type of aaload

### DIFF
--- a/jbmc/src/java_bytecode/bytecode_info.cpp
+++ b/jbmc/src/java_bytecode/bytecode_info.cpp
@@ -15,7 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 // clang-format off
 struct bytecode_infot const bytecode_info[]=
 {
-{ "aaload",         0x32, ' ', 2, 1, ' ' }, // arrayref, index → value; load onto the stack a reference from an array  NOLINT(*)
+{ "aaload",         0x32, ' ', 2, 1, 'a' }, // arrayref, index → value; load onto the stack a reference from an array  NOLINT(*)
 { "aastore",        0x53, ' ', 3, 0, ' ' }, // arrayref, index, value →; store into a reference in an array  NOLINT(*)
 { "aconst_null",    0x01, ' ', 0, 1, 'a' }, // → null; push a null reference onto the stack  NOLINT(*)
 { "aload",          0x19, 'v', 0, 1, 'a' }, // → objectref; load a reference onto the stack from a local variable #index  NOLINT(*)


### PR DESCRIPTION
`aaload` does return a reference (`'a'`), as opposed to nothing (`' '`).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
