### PR TITLE
Test of dereferencing without an explicit temporary

### DIFF
--- a/regression/cbmc/Pointer_Arithmetic17/main.c
+++ b/regression/cbmc/Pointer_Arithmetic17/main.c
@@ -1,0 +1,28 @@
+struct dummy
+{
+  int *array;
+};
+
+struct cont
+{
+  struct dummy **array;
+};
+
+int main()
+{
+  struct cont cont;
+  struct dummy dummy;
+  struct dummy *dummies[10];
+  int a[10];
+  int i = 4;
+  a[i] = i;
+  dummy.array = &a[i - 1];
+  dummies[i + 1] = &dummy;
+  cont.array = &dummies[1];
+  struct dummy *tmp = cont.array[i];
+  int *pa = &(cont.array[i]->array[1]);
+  int *pb = &(tmp->array[1]);
+  __CPROVER_assert(pa == pb, "temporary should not matter");
+  __CPROVER_assert(*pa == 4, "value must be 4");
+  return 0;
+}

--- a/regression/cbmc/Pointer_Arithmetic17/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic17/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Field-sensitivity caused a regression such that dereferencing results in an
+invalid object even though the pointer should point into an allocated object.
+Test derived from SV-COMP's ldv-regression/test_27-1.c. The problem was resolved
+in 8ff892778d (Simplify and apply field sensitivity before value-set-deref).


### PR DESCRIPTION
This is a regression introduced by field sensitivity, fixed in 8ff892778d (Simplify and apply field sensitivity before value-set-deref).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
