### PR TITLE
build_reference_to must consider the offset when returning a null object

### DIFF
--- a/regression/cbmc/null6/main.c
+++ b/regression/cbmc/null6/main.c
@@ -1,0 +1,17 @@
+void *guard_malloc_counter = 0;
+
+void *my_malloc(int size)
+{
+  _Bool nondet;
+  guard_malloc_counter++;
+  if(nondet)
+    return 0;
+  return (void *)guard_malloc_counter;
+}
+
+int main()
+{
+  int *ptr = my_malloc(sizeof(int));
+  if(ptr != 0)
+    __CPROVER_assert(0, "reached");
+}

--- a/regression/cbmc/null6/test.desc
+++ b/regression/cbmc/null6/test.desc
@@ -1,0 +1,12 @@
+CORE broken-smt-backend
+main.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+--
+When building a reference to a null object we need to consider the offset;
+build_reference_to had failed to do so, which confused value-set based
+filtering.

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -388,7 +388,10 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
 
   if(root_object.id() == ID_null_object)
   {
-    result.pointer = null_pointer_exprt{pointer_type};
+    if(o.offset().is_zero())
+      result.pointer = null_pointer_exprt{pointer_type};
+    else
+      return valuet{};
   }
   else if(root_object.id()==ID_dynamic_object)
   {


### PR DESCRIPTION
This has been buggy for a long time, but is now used more extensively
with value-set based filtering. The included regression test shows an
example where filtering would wrongly conclude that a condition is
always false.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
