### PR TITLE
Fix segmentation fault with empty array

### DIFF
--- a/regression/cbmc/array-tests/zero-sized.c
+++ b/regression/cbmc/array-tests/zero-sized.c
@@ -1,0 +1,7 @@
+int main()
+{
+  int A[0] = {};
+  int i;
+  if(A[i] == 1)
+    __CPROVER_assert(0, "");
+}

--- a/regression/cbmc/array-tests/zero-sized.desc
+++ b/regression/cbmc/array-tests/zero-sized.desc
@@ -1,0 +1,8 @@
+CORE
+zero-sized.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/src/solvers/flattening/boolbv_index.cpp
+++ b/src/solvers/flattening/boolbv_index.cpp
@@ -124,6 +124,11 @@ bvt boolbvt::convert_index(const index_exprt &expr)
       symbol_exprt result(identifier, expr.type());
       bv = convert_bv(result);
 
+      // return an unconstrained value in case of an empty array (the access is
+      // necessarily out-of-bounds)
+      if(!array.has_operands())
+        return bv;
+
       equal_exprt value_equality(result, array.op0());
 
       binary_relation_exprt lower_bound(


### PR DESCRIPTION
We must not attempt to access the first operand of an array expression
when the array is empty. This case is explicitly considered earlier in
this method (an empty array is considered uniform), but value equality
constraints were attempted nevertheless.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
