### PR TITLE
Fix unbounded recursion in byte-update lowering of structs

### DIFF
--- a/regression/cbmc/byte_update11/main.c
+++ b/regression/cbmc/byte_update11/main.c
@@ -1,0 +1,13 @@
+struct S
+{
+  int i;
+};
+
+int main()
+{
+  unsigned x;
+  __CPROVER_assume(x % sizeof(int) == 0);
+  struct S A[x];
+  ((char *)A)[x] = 42;
+  __CPROVER_assert((A[x / sizeof(int)].i & 0xFF) == 42, "lowest byte is 42");
+}

--- a/regression/cbmc/byte_update11/test.desc
+++ b/regression/cbmc/byte_update11/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--little-endian
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -1787,6 +1787,10 @@ static exprt lower_byte_update_struct(
     }
     else if(!offset_bytes.has_value())
     {
+      // The offset to update is not constant; abort the attempt to update
+      // indiviual struct members and instead turn the operand-to-be-updated
+      // into a byte array, which we know how to update even if the offset is
+      // non-constant.
       const irep_idt extract_opcode = src.id() == ID_byte_update_little_endian
                                         ? ID_byte_extract_little_endian
                                         : ID_byte_extract_big_endian;
@@ -1802,6 +1806,7 @@ static exprt lower_byte_update_struct(
 
       byte_update_exprt bu = src;
       bu.set_op(lower_byte_extract(byte_extract_expr, ns));
+      bu.type() = bu.op().type();
 
       return lower_byte_extract(
         byte_extract_exprt{


### PR DESCRIPTION
The missing update of the type of the byte-update expression caused the
very same procedure to be invoked recursively. Instead we should use
byte-update-of-array.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
