### PR TITLE
Byte-update lowering: fixup invariant for array-comprehension

### DIFF
--- a/regression/cbmc/byte_update12/main.c
+++ b/regression/cbmc/byte_update12/main.c
@@ -13,6 +13,8 @@ int main()
   __CPROVER_assume(x == sizeof(int));
   A[0] = 42;
   struct S s;
+  s.j = 1;
   memcpy(&s, A, x);
   __CPROVER_assert((s.i & 0xFF) == 42, "lowest byte is 42");
+  __CPROVER_assert(s.j == 1, "s.j is unaffected by upate");
 }

--- a/regression/cbmc/byte_update12/main.c
+++ b/regression/cbmc/byte_update12/main.c
@@ -1,0 +1,18 @@
+#include <string.h>
+
+struct S
+{
+  int i;
+  int j;
+};
+
+int main()
+{
+  unsigned x;
+  char A[x];
+  __CPROVER_assume(x == sizeof(int));
+  A[0] = 42;
+  struct S s;
+  memcpy(&s, A, x);
+  __CPROVER_assert((s.i & 0xFF) == 42, "lowest byte is 42");
+}

--- a/regression/cbmc/byte_update12/test.desc
+++ b/regression/cbmc/byte_update12/test.desc
@@ -1,0 +1,8 @@
+CORE broken-smt-backend
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -1822,7 +1822,8 @@ static exprt lower_byte_update_struct(
     {
       offset = from_integer(0, src.offset().type());
       INVARIANT(
-        value_as_byte_array.operands().size() > -*offset_bytes,
+        value_as_byte_array.id() != ID_array ||
+          value_as_byte_array.operands().size() > -*offset_bytes,
         "members past the update should be handled above");
       first = numeric_cast_v<std::size_t>(-*offset_bytes);
     }


### PR DESCRIPTION
In case of an array comprehension the number of operands must not be
used to sanity check the update offset (any update offset would be
valid). This was observed on several device driver benchmarks in
SV-COMP. One example (with --unwind 2):
ldv-consumption/32_7a_cilled_linux-3.8-rc1-32_7a-drivers--net--wireless--rndis_wlan.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
