### PR TITLE
process_array_expr: abort upon reaching a failed_symbol

### DIFF
--- a/regression/cbmc/void_pointer5/main.c
+++ b/regression/cbmc/void_pointer5/main.c
@@ -1,0 +1,9 @@
+int main(int argc, char *argv[])
+{
+  void *p;
+  if(argc > 0)
+    p = argv[0];
+  char A[1];
+  __CPROVER_array_copy(A, p + 1);
+  __CPROVER_assert(0, "");
+}

--- a/regression/cbmc/void_pointer5/test.desc
+++ b/regression/cbmc/void_pointer5/test.desc
@@ -1,0 +1,8 @@
+CORE broken-smt-backend
+main.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -76,6 +76,12 @@ process_array_expr(exprt &expr, bool do_simplify, const namespacet &ns)
 
     expr = ode.root_object();
 
+    // If we arrive at a void-typed object (typically the result of failing to
+    // dereference a void* pointer) there is nothing else to be done - it has
+    // void-type and the caller needs to handle this case gracefully.
+    if(expr.type().id() == ID_empty)
+      return;
+
     if(!ode.offset().is_zero())
     {
       if(expr.type().id() != ID_array)

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -18,10 +18,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/expr_util.h>
 #include <util/invariant.h>
 #include <util/pointer_offset_size.h>
+#include <util/simplify_expr.h>
 #include <util/std_expr.h>
 
+#include <pointer-analysis/add_failed_symbols.h>
 #include <pointer-analysis/value_set_dereference.h>
-#include <util/simplify_expr.h>
 
 void goto_symext::apply_goto_condition(
   goto_symex_statet &current_state,
@@ -110,11 +111,8 @@ static optionalt<renamedt<exprt, L2>> try_evaluate_pointer_comparison(
     if(
       value_set_element.id() == ID_unknown ||
       value_set_element.id() == ID_invalid ||
-      !to_object_descriptor_expr(value_set_element)
-         .root_object()
-         .type()
-         .get(ID_C_is_failed_symbol)
-         .empty())
+      is_failed_symbol(
+        to_object_descriptor_expr(value_set_element).root_object()))
     {
       // We can't conclude anything about the value-set
       return {};

--- a/src/pointer-analysis/add_failed_symbols.h
+++ b/src/pointer-analysis/add_failed_symbols.h
@@ -12,12 +12,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_POINTER_ANALYSIS_ADD_FAILED_SYMBOLS_H
 #define CPROVER_POINTER_ANALYSIS_ADD_FAILED_SYMBOLS_H
 
-#include <util/irep.h>
+#include <util/expr.h>
 #include <util/optional.h>
 
 class symbol_table_baset;
 class symbolt;
-class exprt;
 class namespacet;
 class symbol_exprt;
 
@@ -30,5 +29,11 @@ irep_idt failed_symbol_id(const irep_idt &identifier);
 
 optionalt<symbol_exprt>
 get_failed_symbol(const symbol_exprt &expr, const namespacet &ns);
+
+/// Return true if, and only if, \p expr is the result of failed dereferencing.
+inline bool is_failed_symbol(const exprt &expr)
+{
+  return expr.type().get_bool(ID_C_is_failed_symbol);
+}
 
 #endif // CPROVER_POINTER_ANALYSIS_ADD_FAILED_SYMBOLS_H


### PR DESCRIPTION
We previously attempted to compute the size of the expression, which is
undefined as a failed_symbol is void-typed. There is nothing else to be
done once we hit a failed_symbol, and thus we just return. Encountered
in several of SV-COMP's device driver benchmarks (yes, they might not be
memory safe, but this is not an excuse to fail an invariant). For
example (with --unwind 2):
ldv-linux-3.16-rc1/205_9a_array_unsafes_linux-3.16-rc1.tar.xz-205_9a-drivers--net--ethernet--atheros--atlx--atl1.ko-entry_point.cil.out.i

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
