### PR TITLE
Support va_list types defined via one-element arrays

### DIFF
--- a/regression/cbmc/va_list4/main.c
+++ b/regression/cbmc/va_list4/main.c
@@ -1,0 +1,47 @@
+#ifdef __GNUC__
+
+struct __va_list_tag;
+typedef struct __va_list_tag __va_list_tag;
+typedef __builtin_va_list __gnuc_va_list[1U];
+typedef __gnuc_va_list va_list[1U];
+
+void foo(int n, ...);
+
+int main()
+{
+  foo(1, 1u);
+  foo(2, 2l);
+  foo(3, 3.0);
+  return 0;
+}
+
+void foo(int n, ...)
+{
+  va_list args;
+  __builtin_va_start((__va_list_tag *)(&args), n);
+
+  switch(n)
+  {
+  case 1:
+    __CPROVER_assert(__builtin_va_arg(&args, unsigned) == 1, "1");
+    break;
+  case 2:
+    __CPROVER_assert(__builtin_va_arg(&args, long) == 2, "2");
+    break;
+  case 3:
+    __CPROVER_assert(__builtin_va_arg(&args, double) == 3.0, "3");
+    break;
+  }
+
+  __builtin_va_end((__va_list_tag *)(&args));
+}
+
+#else
+
+// __builtin_va_list is GCC/Clang-only
+
+int main()
+{
+}
+
+#endif

--- a/regression/cbmc/va_list4/test.desc
+++ b/regression/cbmc/va_list4/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -602,19 +602,23 @@ void goto_convertt::do_array_op(
 
 exprt make_va_list(const exprt &expr)
 {
-  // we first strip any typecast
-  if(expr.id()==ID_typecast)
-    return make_va_list(to_typecast_expr(expr).op());
+  exprt result = skip_typecast(expr);
 
   // if it's an address of an lvalue, we take that
-  if(expr.id() == ID_address_of)
+  if(result.id() == ID_address_of)
   {
-    const auto &address_of_expr = to_address_of_expr(expr);
+    const auto &address_of_expr = to_address_of_expr(result);
     if(is_lvalue(address_of_expr.object()))
-      return address_of_expr.object();
+      result = address_of_expr.object();
   }
 
-  return expr;
+  while(result.type().id() == ID_array &&
+        to_array_type(result.type()).size().is_one())
+  {
+    result = index_exprt{result, from_integer(0, index_type())};
+  }
+
+  return result;
 }
 
 /// add function calls to function queue for later processing


### PR DESCRIPTION
Some SV-COMP device driver benchmarks define a va_list type as in the
included regression test. As one-element arrays shouldn't make a
substantial difference we can easily support this case.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
