### PR TITLE
Byte-operator lowering: Add support for byte-extracting unions

### DIFF
--- a/regression/cbmc/union17/main.c
+++ b/regression/cbmc/union17/main.c
@@ -1,0 +1,19 @@
+int main()
+{
+  // create a union type of non-constant, non-zero size
+  unsigned x;
+  __CPROVER_assume(x > 0);
+  union U
+  {
+    unsigned A[x];
+  };
+  // create an integer of arbitrary value
+  int i, i_before;
+  i_before = i;
+  // initialize a union of non-zero size from the integer
+  unsigned u = ((union U *)&i)->A[0];
+  // reading back an integer out of the union should yield the same value for
+  // the integer as it had before
+  i = u;
+  __CPROVER_assert(i == i_before, "going through union works");
+}

--- a/regression/cbmc/union17/test.desc
+++ b/regression/cbmc/union17/test.desc
@@ -1,0 +1,13 @@
+CORE broken-smt-backend
+main.c
+--no-simplify
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+This test passes when simplification is enabled (which gets rid of
+byte-extracting a union of non-constant size), but yielded a wrong verification
+outcome with both the SAT back-end before. The SMT back-end fails for it would
+like to flatten an array of non-constant size.

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -940,6 +940,18 @@ static exprt unpack_rec(
         ns,
         true);
     }
+    else if(!union_type.components().empty())
+    {
+      member_exprt member{src, union_type.components().front()};
+      return unpack_rec(
+        member,
+        little_endian,
+        offset_bytes,
+        max_bytes,
+        bits_per_byte,
+        ns,
+        true);
+    }
   }
   else if(src.type().id() == ID_pointer)
   {


### PR DESCRIPTION
We already had support for structs, arrays, vectors in place; add unions
following the same approach. This is required for some SV-COMP device
driver benchmarks, including
ldv-linux-3.16-rc1/43_2a_consumption_linux-3.16-rc1.tar.xz-43_2a-drivers--scsi--qla2xxx--tcm_qla2xxx.ko-entry_point.cil.out.i

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
