### PR TITLE
Add CI compilation with clang++-3.8

### DIFF
--- a/buildspec-linux-clang-3.8.yml
+++ b/buildspec-linux-clang-3.8.yml
@@ -1,0 +1,29 @@
+version: 0.2
+
+env:
+  variables:
+    # CodeBuild console doesn't display color codes correctly
+    TESTPL_COLOR_OUTPUT: 0
+
+phases:
+  install:
+    commands:
+      - sed -i 's#/archive.ubuntu.com#/us-east-1.ec2.archive.ubuntu.com#g' /etc/apt/sources.list
+      - apt-get update -y
+      - apt-get install -y clang-3.8 flex bison make git libwww-perl patch ccache libc6-dev-i386 jq openjdk-8-jdk maven
+  build:
+    commands:
+      - echo Build started on `date`
+      - git submodule update --init --recursive
+      - make -C src minisat2-download
+      - make -C jbmc/src setup-submodules
+      - make -C src CXX='ccache /usr/bin/clang++-3.8' CXX_FLAGS='-Qunused-arguments -DDEBUG'
+      - make -C jbmc/src CXX='ccache /usr/bin/clang++-3.8' CXX_FLAGS='-Qunused-arguments -DDEBUG'
+  post_build:
+    commands:
+      - echo Build completed on `date`
+cache:
+  paths:
+    - '/var/cache/apt/**/*'
+    - '/var/lib/apt/lists/**/*'
+    - '/root/.ccache/**/*'


### PR DESCRIPTION
This is to check that changes do not break compilation using
clang++-3.8, as happened with
https://github.com/diffblue/cbmc/issues/4699

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [na] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
