### PR TITLE
rename simplify_inequality_* methods

### DIFF
--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -131,8 +131,8 @@ public:
   static tvt objects_equal(const exprt &a, const exprt &b);
   static tvt objects_equal_address_of(const exprt &a, const exprt &b);
   bool simplify_address_of_arg(exprt &expr);
-  bool simplify_inequality_constant(exprt &expr);
-  bool simplify_inequality_not_constant(exprt &expr);
+  bool simplify_inequality_no_constant(exprt &);
+  bool simplify_inequality_rhs_is_constant(exprt &);
   bool simplify_inequality_address_of(exprt &expr);
   bool simplify_inequality_pointer_object(exprt &expr);
 

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -1478,19 +1478,19 @@ bool simplify_exprt::simplify_inequality(exprt &expr)
 
     expr.op0().swap(expr.op1());
 
-    // one is constant
-    simplify_inequality_constant(expr);
+    // RHS is constant, LHS is not
+    simplify_inequality_rhs_is_constant(expr);
     return false;
   }
   else if(tmp1_const)
   {
-    // one is constant
-    return simplify_inequality_constant(expr);
+    // RHS is constant, LHS is not
+    return simplify_inequality_rhs_is_constant(expr);
   }
   else
   {
     // both are not constant
-    return simplify_inequality_not_constant(expr);
+    return simplify_inequality_no_constant(expr);
   }
 }
 
@@ -1542,7 +1542,7 @@ bool simplify_exprt::eliminate_common_addends(
   return true;
 }
 
-bool simplify_exprt::simplify_inequality_not_constant(exprt &expr)
+bool simplify_exprt::simplify_inequality_no_constant(exprt &expr)
 {
   exprt::operandst &operands=expr.operands();
 
@@ -1556,7 +1556,7 @@ bool simplify_exprt::simplify_inequality_not_constant(exprt &expr)
   if(expr.id()==ID_notequal)
   {
     expr.id(ID_equal);
-    simplify_inequality_not_constant(expr);
+    simplify_inequality_no_constant(expr);
     expr = boolean_negate(expr);
     simplify_node(expr);
     return false;
@@ -1566,7 +1566,7 @@ bool simplify_exprt::simplify_inequality_not_constant(exprt &expr)
     expr.id(ID_ge);
     // swap operands
     expr.op0().swap(expr.op1());
-    simplify_inequality_not_constant(expr);
+    simplify_inequality_no_constant(expr);
     expr = boolean_negate(expr);
     simplify_node(expr);
     return false;
@@ -1574,7 +1574,7 @@ bool simplify_exprt::simplify_inequality_not_constant(exprt &expr)
   else if(expr.id()==ID_lt)
   {
     expr.id(ID_ge);
-    simplify_inequality_not_constant(expr);
+    simplify_inequality_no_constant(expr);
     expr = boolean_negate(expr);
     simplify_node(expr);
     return false;
@@ -1584,7 +1584,7 @@ bool simplify_exprt::simplify_inequality_not_constant(exprt &expr)
     expr.id(ID_ge);
     // swap operands
     expr.op0().swap(expr.op1());
-    simplify_inequality_not_constant(expr);
+    simplify_inequality_no_constant(expr);
     return false;
   }
 
@@ -1670,8 +1670,9 @@ bool simplify_exprt::simplify_inequality_not_constant(exprt &expr)
   return true;
 }
 
-/// \par parameters: an inequality with a constant on the RHS
-bool simplify_exprt::simplify_inequality_constant(exprt &expr)
+/// \par expr: an inequality where the RHS is a constant
+/// and the LHS is not
+bool simplify_exprt::simplify_inequality_rhs_is_constant(exprt &expr)
 {
   // the constant is always on the RHS
   PRECONDITION(expr.op1().is_constant());
@@ -1679,8 +1680,8 @@ bool simplify_exprt::simplify_inequality_constant(exprt &expr)
   if(expr.op0().id()==ID_if && expr.op0().operands().size()==3)
   {
     if_exprt if_expr=lift_if(expr, 0);
-    simplify_inequality_constant(if_expr.true_case());
-    simplify_inequality_constant(if_expr.false_case());
+    simplify_inequality_rhs_is_constant(if_expr.true_case());
+    simplify_inequality_rhs_is_constant(if_expr.false_case());
     simplify_if(if_expr);
     expr.swap(if_expr);
 
@@ -1693,7 +1694,7 @@ bool simplify_exprt::simplify_inequality_constant(exprt &expr)
     if(expr.id()==ID_notequal)
     {
       expr.id(ID_equal);
-      simplify_inequality_constant(expr);
+      simplify_inequality_rhs_is_constant(expr);
       expr = boolean_negate(expr);
       simplify_node(expr);
       return false;
@@ -1909,7 +1910,7 @@ bool simplify_exprt::simplify_inequality_constant(exprt &expr)
     if(expr.id()==ID_notequal)
     {
       expr.id(ID_equal);
-      simplify_inequality_constant(expr);
+      simplify_inequality_rhs_is_constant(expr);
       expr = boolean_negate(expr);
       simplify_node(expr);
       return false;
@@ -1927,13 +1928,13 @@ bool simplify_exprt::simplify_inequality_constant(exprt &expr)
       expr.id(ID_ge);
       ++i;
       expr.op1()=from_integer(i, expr.op1().type());
-      simplify_inequality_constant(expr);
+      simplify_inequality_rhs_is_constant(expr);
       return false;
     }
     else if(expr.id()==ID_lt)
     {
       expr.id(ID_ge);
-      simplify_inequality_constant(expr);
+      simplify_inequality_rhs_is_constant(expr);
       expr = boolean_negate(expr);
       simplify_node(expr);
       return false;
@@ -1951,7 +1952,7 @@ bool simplify_exprt::simplify_inequality_constant(exprt &expr)
       expr.id(ID_ge);
       ++i;
       expr.op1()=from_integer(i, expr.op1().type());
-      simplify_inequality_constant(expr);
+      simplify_inequality_rhs_is_constant(expr);
       expr = boolean_negate(expr);
       simplify_node(expr);
       return false;


### PR DESCRIPTION
This attempts to make the names of the simplify_inequality_* methods more
intuitive.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
