### PR TITLE
Out-of-line prop_conv_solvert::decision_procedure_text to work around g++-5 bug

### DIFF
--- a/src/solvers/prop/prop_conv_solver.cpp
+++ b/src/solvers/prop/prop_conv_solver.cpp
@@ -574,3 +574,13 @@ void prop_conv_solvert::pop()
 
   prop.set_assumptions(assumption_stack);
 }
+
+// This method out-of-line because gcc-5.5.0-12ubuntu1 20171010 miscompiles it
+// when inline (in certain build configurations, notably -O2 -g0) by producing
+// a non-virtual thunk with c++03 ABI but a function body with c++11 ABI, the
+// mismatch leading to a missing vtable entry and consequent null-pointer deref
+// whenever this function is called.
+std::string prop_conv_solvert::decision_procedure_text() const
+{
+  return "propositional reduction";
+}

--- a/src/solvers/prop/prop_conv_solver.h
+++ b/src/solvers/prop/prop_conv_solver.h
@@ -39,10 +39,7 @@ public:
   // overloading from decision_proceduret
   decision_proceduret::resultt dec_solve() override;
   void print_assignment(std::ostream &out) const override;
-  std::string decision_procedure_text() const override
-  {
-    return "propositional reduction";
-  }
+  std::string decision_procedure_text() const override;
   exprt get(const exprt &expr) const override;
 
   tvt l_get(literalt a) const override


### PR DESCRIPTION
As elaborated in the comment in prop_conv_solver.cpp, under some configurations g++-5 would
miscompile the inline version.

This can't be tested without adding yet another CI profile, but anyone with compiler `gcc-5.5.0-12ubuntu1 20171010` should be able to reproduce with build `-O2 -g0`, aka cmake's build type `Release`. In particular  `objdump -t cbmc` shows a definition for `non-virtual thunk to prop_conv_solvert::decision_procedure_text() const` not `non-virtual thunk to prop_conv_solvert::decision_procedure_text[abi:cxx11]() const` as it ought to (and does with `g++-7`, or `g++-5 -g`).