### PR TITLE
Move LIBCXX_DEBUG flag from Travis to AWS codebuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,6 @@ jobs:
       # env: COMPILER=g++-5 SAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover -fno-omit-frame-pointer"
       env:
         - COMPILER="ccache /usr/bin/g++-5"
-        - EXTRA_CXXFLAGS="-D_GLIBCXX_DEBUG"
         - WITH_MEMORY_ANALYZER=1
 
     # OS X using clang++

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,6 +4,7 @@ env:
   variables:
     # CodeBuild console doesn't display color codes correctly
     TESTPL_COLOR_OUTPUT: 0
+    CP_EXTRA_CXXFLAGS: -D_GLIBCXX_DEBUG
 
 phases:
   install:

--- a/src/common
+++ b/src/common
@@ -210,8 +210,8 @@ first_target: all
 
 HOSTCXX ?= $(CXX)
 
-CP_CFLAGS += $(CFLAGS) $(INCLUDES)
-CP_CXXFLAGS += $(CXXFLAGS) $(INCLUDES)
+CP_CFLAGS += $(CFLAGS) $(CP_EXTRA_CFLAGS) $(INCLUDES)
+CP_CXXFLAGS += $(CXXFLAGS) $(CP_EXTRA_CXXFLAGS) $(INCLUDES)
 
 OBJ += $(patsubst %.cpp, %$(OBJEXT), $(filter %.cpp, $(SRC)))
 OBJ += $(patsubst %.cc, %$(OBJEXT), $(filter %.cc, $(SRC)))


### PR DESCRIPTION
The Travis build takes too long to complete with this flag set; moving it to AWS CodeBuild
means we can take advantage of AWS' longer timeout and even the load between Travis and AWS.
