### PR TITLE
Do not assign a non-ssa expression to object accessed via an ssa_exprt reference

### DIFF
--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -285,13 +285,10 @@ goto_symex_statet::rename(exprt expr, const namespacet &ns)
       rename<level>(expr.type(), ssa.get_identifier(), ns);
       ssa.update_type();
 
-      if(l2_thread_read_encoding(ssa, ns))
+      // renaming taken care of by l2_thread_encoding, or already at L2
+      if(l2_thread_read_encoding(ssa, ns) || !ssa.get_level_2().empty())
       {
-        // renaming taken care of by l2_thread_encoding
-      }
-      else if(!ssa.get_level_2().empty())
-      {
-        // already at L2
+        return renamedt<exprt, level>(std::move(ssa));
       }
       else
       {
@@ -300,11 +297,15 @@ goto_symex_statet::rename(exprt expr, const namespacet &ns)
         auto p_it = propagation.find(ssa.get_identifier());
 
         if(p_it.has_value())
-          expr = *p_it; // already L2
+        {
+          return renamedt<exprt, level>(*p_it); // already L2
+        }
         else
+        {
           ssa = set_indices<L2>(std::move(ssa), ns).get();
+          return renamedt<exprt, level>(std::move(ssa));
+        }
       }
-      return renamedt<exprt, level>(std::move(ssa));
     }
   }
   else if(expr.id()==ID_symbol)


### PR DESCRIPTION
Previously a variable `expr` of type `exprt &` was cast to `ssa_exprt &` and assigned to variable `ssa`. Later the object was modified via assigning a non-ssa expression to `expr`, violating the invariants of `ssa_exprt`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
