### PR TITLE
Remove duplicate __builtin_isgreater condition

### DIFF
--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -1439,13 +1439,12 @@ void goto_convertt::do_function_call_symbol(
 
     // void __sync_lock_release (type *ptr, ...)
   }
-  else if(identifier=="__builtin_isgreater" ||
-          identifier=="__builtin_isgreater" ||
-          identifier=="__builtin_isgreaterequal" ||
-          identifier=="__builtin_isless" ||
-          identifier=="__builtin_islessequal" ||
-          identifier=="__builtin_islessgreater" ||
-          identifier=="__builtin_isunordered")
+  else if(
+    identifier == "__builtin_isgreater" ||
+    identifier == "__builtin_isgreaterequal" ||
+    identifier == "__builtin_isless" || identifier == "__builtin_islessequal" ||
+    identifier == "__builtin_islessgreater" ||
+    identifier == "__builtin_isunordered")
   {
     // these support two double or two float arguments; we call the
     // appropriate internal version


### PR DESCRIPTION
This is just cleanup of a copy&paste mistake following a warning emitted
by Visual Studio. Also clang-format the entire decision.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
