### PR TITLE
Revert "Use std::forward_list instead of std::map in irept by default"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -182,7 +182,7 @@ jobs:
         - WITH_MEMORY_ANALYZER=1
       script: echo "Not running any tests for a debug build."
 
-    # cmake build using g++-7, disable NAMED_SUB_IS_FORWARD_LIST
+    # cmake build using g++-7, enable NAMED_SUB_IS_FORWARD_LIST
     - stage: Test different OS/CXX/Flags
       os: linux
       sudo: false
@@ -205,7 +205,7 @@ jobs:
       install:
         - ccache -z
         - ccache --max-size=1G
-        - cmake -H. -Bbuild '-DCMAKE_BUILD_TYPE=Release' '-DCMAKE_CXX_COMPILER=/usr/bin/g++-7' '-DCMAKE_CXX_FLAGS=-DNAMED_SUB_IS_FORWARD_LIST=0' '-DWITH_MEMORY_ANALYZER=On'
+        - cmake -H. -Bbuild '-DCMAKE_BUILD_TYPE=Release' '-DCMAKE_CXX_COMPILER=/usr/bin/g++-7' '-DCMAKE_CXX_FLAGS=-DNAMED_SUB_IS_FORWARD_LIST' '-DWITH_MEMORY_ANALYZER=On'
         - git submodule update --init --recursive
         - cmake --build build -- -j4
       script: (cd build; bin/unit "[core][irept]")

--- a/src/util/irep.cpp
+++ b/src/util/irep.cpp
@@ -92,7 +92,7 @@ void irept::set(const irep_namet &name, const long long value)
 
 void irept::remove(const irep_namet &name)
 {
-#if NAMED_SUB_IS_FORWARD_LIST
+#ifdef NAMED_SUB_IS_FORWARD_LIST
   return get_named_sub().remove(name);
 #else
   named_subt &s = get_named_sub();
@@ -120,7 +120,7 @@ irept &irept::add(const irep_namet &name, irept irep)
 {
   named_subt &s = get_named_sub();
 
-#if NAMED_SUB_IS_FORWARD_LIST
+#ifdef NAMED_SUB_IS_FORWARD_LIST
   return s.add(name, std::move(irep));
 #else
   std::pair<named_subt::iterator, bool> entry = s.emplace(

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -20,11 +20,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef HASH_CODE
 #  define HASH_CODE 1
 #endif
-#ifndef NAMED_SUB_IS_FORWARD_LIST
-#  define NAMED_SUB_IS_FORWARD_LIST 1
-#endif
+// #define NAMED_SUB_IS_FORWARD_LIST
 
-#if NAMED_SUB_IS_FORWARD_LIST
+#ifdef NAMED_SUB_IS_FORWARD_LIST
 #  include "forward_list_as_map.h"
 #else
 #include <map>
@@ -388,7 +386,7 @@ class irept
   : public non_sharing_treet<
       irept,
 #endif
-#if NAMED_SUB_IS_FORWARD_LIST
+#ifdef NAMED_SUB_IS_FORWARD_LIST
       forward_list_as_mapt<irep_namet, irept>>
 #else
       std::map<irep_namet, irept>>

--- a/src/util/irep_hash_container.cpp
+++ b/src/util/irep_hash_container.cpp
@@ -55,7 +55,7 @@ void irep_hash_container_baset::pack(
   {
     // we pack: the irep id, the sub size, the subs, the named-sub size, and
     // each of the named subs with their ids
-#if NAMED_SUB_IS_FORWARD_LIST
+#ifdef NAMED_SUB_IS_FORWARD_LIST
     const std::size_t named_sub_size =
       std::distance(named_sub.begin(), named_sub.end());
 #else

--- a/src/util/irep_serialization.cpp
+++ b/src/util/irep_serialization.cpp
@@ -76,14 +76,14 @@ irept irep_serializationt::read_irep(std::istream &in)
     sub.push_back(reference_convert(in));
   }
 
-#if NAMED_SUB_IS_FORWARD_LIST
+#ifdef NAMED_SUB_IS_FORWARD_LIST
   irept::named_subt::iterator before = named_sub.before_begin();
 #endif
   while(in.peek()=='N')
   {
     in.get();
     irep_idt id = read_string_ref(in);
-#if NAMED_SUB_IS_FORWARD_LIST
+#ifdef NAMED_SUB_IS_FORWARD_LIST
     named_sub.emplace_after(before, id, reference_convert(in));
     ++before;
 #else
@@ -95,7 +95,7 @@ irept irep_serializationt::read_irep(std::istream &in)
   {
     in.get();
     irep_idt id = read_string_ref(in);
-#if NAMED_SUB_IS_FORWARD_LIST
+#ifdef NAMED_SUB_IS_FORWARD_LIST
     named_sub.emplace_after(before, id, reference_convert(in));
     ++before;
 #else

--- a/src/util/lispirep.cpp
+++ b/src/util/lispirep.cpp
@@ -46,7 +46,7 @@ void irep2lisp(const irept &src, lispexprt &dest)
   dest.value.clear();
   dest.type=lispexprt::List;
 
-#if NAMED_SUB_IS_FORWARD_LIST
+#ifdef NAMED_SUB_IS_FORWARD_LIST
   const std::size_t named_sub_size =
     std::distance(src.get_named_sub().begin(), src.get_named_sub().end());
 #else

--- a/src/util/merge_irep.cpp
+++ b/src/util/merge_irep.cpp
@@ -46,7 +46,7 @@ bool to_be_merged_irept::operator == (const to_be_merged_irept &other) const
 
   if(sub.size()!=o_sub.size())
     return false;
-#if NAMED_SUB_IS_FORWARD_LIST
+#ifdef NAMED_SUB_IS_FORWARD_LIST
   if(
     std::distance(named_sub.begin(), named_sub.end()) !=
     std::distance(o_named_sub.begin(), o_named_sub.end()))
@@ -105,12 +105,12 @@ const merged_irept &merged_irepst::merged(const irept &irep)
   const irept::named_subt &src_named_sub=irep.get_named_sub();
   irept::named_subt &dest_named_sub=new_irep.get_named_sub();
 
-#if NAMED_SUB_IS_FORWARD_LIST
+#ifdef NAMED_SUB_IS_FORWARD_LIST
   irept::named_subt::iterator before = dest_named_sub.before_begin();
 #endif
   forall_named_irep(it, src_named_sub)
   {
-#if NAMED_SUB_IS_FORWARD_LIST
+#ifdef NAMED_SUB_IS_FORWARD_LIST
     dest_named_sub.emplace_after(
       before, it->first, merged(it->second)); // recursive call
     ++before;
@@ -209,12 +209,12 @@ const irept &merge_full_irept::merged(const irept &irep)
   const irept::named_subt &src_named_sub=irep.get_named_sub();
   irept::named_subt &dest_named_sub=new_irep.get_named_sub();
 
-#if NAMED_SUB_IS_FORWARD_LIST
+#ifdef NAMED_SUB_IS_FORWARD_LIST
   irept::named_subt::iterator before = dest_named_sub.before_begin();
 #endif
   forall_named_irep(it, src_named_sub)
   {
-#if NAMED_SUB_IS_FORWARD_LIST
+#ifdef NAMED_SUB_IS_FORWARD_LIST
     dest_named_sub.emplace_after(
       before, it->first, merged(it->second)); // recursive call
     ++before;

--- a/src/util/type.h
+++ b/src/util/type.h
@@ -32,8 +32,7 @@ public:
 
   explicit typet(const irep_idt &_id):irept(_id) { }
 
-  // the STL implementation shipped with GCC 5 is broken
-#if !defined(__GLIBCXX__) || __GLIBCXX__ >= 20181026
+#if defined(__clang__) || !defined(__GNUC__) || __GNUC__ >= 6
   typet(irep_idt _id, typet _subtype)
     : irept(std::move(_id), {}, {std::move(_subtype)})
   {

--- a/unit/util/irep.cpp
+++ b/unit/util/irep.cpp
@@ -35,7 +35,7 @@ SCENARIO("irept_memory", "[core][utils][irept]")
       REQUIRE(sizeof(std::vector<int>) == 3 * sizeof(void *));
 #endif
 
-#if !NAMED_SUB_IS_FORWARD_LIST
+#ifndef NAMED_SUB_IS_FORWARD_LIST
       const std::size_t named_size = sizeof(std::map<int, int>);
 #  ifndef _GLIBCXX_DEBUG
 #    ifdef __APPLE__


### PR DESCRIPTION
This is an experiment to see whether NAMED_SUB_IS_FORWARD_LIST=1 is the
root cause of builds and tests taking >70 minutes on Travis when
previously they would only take 26 minutes. (confirmed)

This is now a clean revert of the second commit in #4458.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
