### PR TITLE
Extract function pointers using memory analyzer

### DIFF
--- a/regression/snapshot-harness/function_pointer_01/main.c
+++ b/regression/snapshot-harness/function_pointer_01/main.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+
+int foo(int i)
+{
+  return i + 1;
+}
+
+int (*fun_ptr)(int);
+
+void initialize()
+{
+  fun_ptr = &foo;
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(fun_ptr == &foo);
+  assert((*fun_ptr)(5) == 6);
+  assert((*fun_ptr)(5) == foo(5));
+  return 0;
+}

--- a/regression/snapshot-harness/function_pointer_01/test.desc
+++ b/regression/snapshot-harness/function_pointer_01/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+fun_ptr --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^EXIT=0$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion fun_ptr == \&foo: SUCCESS
+\[main.assertion.2\] line [0-9]+ assertion \(\*fun_ptr\)\(5\) == 6: SUCCESS
+\[main.assertion.3\] line [0-9]+ assertion \(\*fun_ptr\)\(5\) == foo\(5\): SUCCESS
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/regression/snapshot-harness/function_pointer_02/main.c
+++ b/regression/snapshot-harness/function_pointer_02/main.c
@@ -1,0 +1,37 @@
+#include <assert.h>
+
+int plus(int i)
+{
+  return i + 1;
+}
+
+int minus(int i)
+{
+  return i - 1;
+}
+
+int (*fun_ptr1)(int);
+int (*fun_ptr2)(int);
+
+void initialize()
+{
+  fun_ptr1 = &plus;
+  fun_ptr2 = &minus;
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(fun_ptr1 == &plus);
+  assert((*fun_ptr1)(5) == 6);
+  assert((*fun_ptr1)(5) == plus(5));
+  assert(fun_ptr2 != fun_ptr1);
+  assert((*fun_ptr2)(5) == 4);
+  return 0;
+}

--- a/regression/snapshot-harness/function_pointer_02/test.desc
+++ b/regression/snapshot-harness/function_pointer_02/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+fun_ptr1,fun_ptr2 --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^EXIT=0$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion fun_ptr1 == \&plus: SUCCESS
+\[main.assertion.2\] line [0-9]+ assertion \(\*fun_ptr1\)\(5\) == 6: SUCCESS
+\[main.assertion.3\] line [0-9]+ assertion \(\*fun_ptr1\)\(5\) == plus\(5\): SUCCESS
+\[main.assertion.4\] line [0-9]+ assertion fun_ptr2 \!= fun_ptr1: SUCCESS
+\[main.assertion.5\] line [0-9]+ assertion \(\*fun_ptr2\)\(5\) == 4: SUCCESS
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/regression/snapshot-harness/function_pointer_03/main.c
+++ b/regression/snapshot-harness/function_pointer_03/main.c
@@ -1,0 +1,42 @@
+#include <assert.h>
+
+int plus(int i)
+{
+  return i + 1;
+}
+
+int minus(int i)
+{
+  return i - 1;
+}
+
+typedef int (*fun_ptrt)(int);
+fun_ptrt fun_array[2];
+
+fun_ptrt fun_ptr1;
+fun_ptrt fun_ptr2;
+
+void initialize()
+{
+  fun_array[0] = &plus;
+  fun_array[1] = &minus;
+  fun_ptr1 = *fun_array;
+  fun_ptr2 = fun_array[1];
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(fun_ptr1 == &plus);
+  assert((*fun_ptr1)(5) == 6);
+  assert((*fun_ptr1)(5) == plus(5));
+  assert(fun_ptr2 != fun_ptr1);
+  assert((*fun_ptr2)(5) == 4);
+  return 0;
+}

--- a/regression/snapshot-harness/function_pointer_03/test.desc
+++ b/regression/snapshot-harness/function_pointer_03/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+fun_array,fun_ptr1,fun_ptr2 --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^EXIT=0$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion fun_ptr1 == \&plus: SUCCESS
+\[main.assertion.2\] line [0-9]+ assertion \(\*fun_ptr1\)\(5\) == 6: SUCCESS
+\[main.assertion.3\] line [0-9]+ assertion \(\*fun_ptr1\)\(5\) == plus\(5\): SUCCESS
+\[main.assertion.4\] line [0-9]+ assertion fun_ptr2 \!= fun_ptr1: SUCCESS
+\[main.assertion.5\] line [0-9]+ assertion \(\*fun_ptr2\)\(5\) == 4: SUCCESS
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/src/memory-analyzer/analyze_symbol.h
+++ b/src/memory-analyzer/analyze_symbol.h
@@ -286,6 +286,18 @@ private:
     const pointer_valuet &value,
     const source_locationt &location);
 
+  /// Extract the function name from \p pointer_value, check it has a symbol and
+  ///   return the associated symbol expression
+  /// \param expr: the pointer-to-function expression
+  /// \param pointer_value: pointer value with the function name as the pointee
+  ///   member
+  /// \param location: the source location
+  /// \return symbol expression for the function pointed at by \p pointer_value
+  exprt get_pointer_to_function_value(
+    const exprt &expr,
+    const pointer_valuet &pointer_value,
+    const source_locationt &location);
+
   /// If \p memory_location is found among \ref values then return the symbol
   ///   expression associated with it.
   /// Otherwise we add the appropriate \ref values mapping:


### PR DESCRIPTION
This PR adds the facilities to query GDB via `memory-analyzer` to obtain information about function pointers. The values of function pointers can then be extracted into a symbol table and reused, e.g. by `goto-harness`.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
