### PR TITLE
Travis clang-format, cpplint: Use the merge base

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ jobs:
         clang-format-7 --version
         # build a pathspec that excludes the files in .clang-format-ignore
         while read file ; do echo EXCLUDES+="':(top,exclude)$file' " ; done < .clang-format-ignore
-        git-clang-format-7 --binary clang-format-7 "${TRAVIS_BRANCH}" -- $EXCLUDES
+        MERGE_BASE=$(git merge-base ${TRAVIS_COMMIT_RANGE%...*} ${TRAVIS_COMMIT_RANGE#*...})
+        echo "Checking for formatting errors introduced since $MERGE_BASE"
+        git-clang-format-7 --binary clang-format-7 $MERGE_BASE -- $EXCLUDES
         git diff > formatted.diff
         if [[ -s formatted.diff ]] ; then
           echo 'Formatting error! The following diff shows the required changes'

--- a/scripts/travis_lint.sh
+++ b/scripts/travis_lint.sh
@@ -12,5 +12,6 @@ else
   git config remote.origin.fetch +refs/heads/$TRAVIS_BRANCH:refs/remotes/origin/$TRAVIS_BRANCH
   git fetch --unshallow
   git checkout $TMP_HEAD
-  $script_folder/run_diff.sh CPPLINT origin/$TRAVIS_BRANCH # Check for errors compared to merge target
+  MERGE_BASE=$(git merge-base ${TRAVIS_COMMIT_RANGE%...*} ${TRAVIS_COMMIT_RANGE#*...})
+  $script_folder/run_diff.sh CPPLINT $MERGE_BASE
 fi


### PR DESCRIPTION
We previously looked at the diff to the current head of the target
branch, which may have moved in comparison to the merge base of a pull
request. Thus we sometimes ended up with spurious clang-format errors,
talking about changes introduced in another PR.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
