### PR TITLE
C front-end: Typecheck bitnand

### DIFF
--- a/regression/cbmc/atomic_fetch_X-1/main.c
+++ b/regression/cbmc/atomic_fetch_X-1/main.c
@@ -10,5 +10,10 @@ int main()
   assert(result == x_before);
   assert(x == x_before + v);
 
+  x_before = x;
+  result = __atomic_fetch_nand(p, x, 0);
+  assert(result == x_before);
+  assert(x == ~x_before);
+
   return 0;
 }

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -207,11 +207,13 @@ void c_typecheck_baset::typecheck_expr_main(exprt &expr)
     typecheck_expr_sizeof(expr);
   else if(expr.id()==ID_alignof)
     typecheck_expr_alignof(expr);
-  else if(expr.id()==ID_plus || expr.id()==ID_minus ||
-          expr.id()==ID_mult || expr.id()==ID_div ||
-          expr.id()==ID_mod ||
-          expr.id()==ID_bitand || expr.id()==ID_bitxor || expr.id()==ID_bitor)
+  else if(
+    expr.id() == ID_plus || expr.id() == ID_minus || expr.id() == ID_mult ||
+    expr.id() == ID_div || expr.id() == ID_mod || expr.id() == ID_bitand ||
+    expr.id() == ID_bitxor || expr.id() == ID_bitor || expr.id() == ID_bitnand)
+  {
     typecheck_expr_binary_arithmetic(expr);
+  }
   else if(expr.id()==ID_shl || expr.id()==ID_shr)
     typecheck_expr_shifts(to_shift_expr(expr));
   else if(expr.id()==ID_comma)
@@ -3136,9 +3138,9 @@ void c_typecheck_baset::typecheck_expr_binary_arithmetic(exprt &expr)
       }
     }
   }
-  else if(expr.id()==ID_bitand ||
-          expr.id()==ID_bitxor ||
-          expr.id()==ID_bitor)
+  else if(
+    expr.id() == ID_bitand || expr.id() == ID_bitnand ||
+    expr.id() == ID_bitxor || expr.id() == ID_bitor)
   {
     if(type0==type1)
     {
@@ -3151,6 +3153,8 @@ void c_typecheck_baset::typecheck_expr_binary_arithmetic(exprt &expr)
       {
         if(expr.id()==ID_bitand)
           expr.id(ID_and);
+        else if(expr.id() == ID_bitnand)
+          expr.id(ID_nand);
         else if(expr.id()==ID_bitor)
           expr.id(ID_or);
         else if(expr.id()==ID_bitxor)


### PR DESCRIPTION
The front-end can generate bitnand expressions when expanding atomic
built-ins, and thus also needs to be able to typecheck those.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
