### PR TITLE
fix constructor of string_builtin_functiont

### DIFF
--- a/src/solvers/strings/string_builtin_function.h
+++ b/src/solvers/strings/string_builtin_function.h
@@ -19,6 +19,7 @@ class string_constraint_generatort;
 class string_builtin_functiont
 {
 public:
+  string_builtin_functiont() = delete;
   string_builtin_functiont(const string_builtin_functiont &) = delete;
   virtual ~string_builtin_functiont() = default;
 
@@ -59,9 +60,6 @@ public:
   {
     return true;
   }
-
-private:
-  string_builtin_functiont() = default;
 
 protected:
   array_poolt &array_pool;


### PR DESCRIPTION
The default constructor cannot exist; marking it as `delete` re-enables
compilation with clang.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- na Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
