### PR TITLE
Regularise the AWS CodeBuild Clang buildspecs

### DIFF
--- a/buildspec-linux-clang-3.8.yml
+++ b/buildspec-linux-clang-3.8.yml
@@ -14,7 +14,6 @@ phases:
   build:
     commands:
       - echo Build started on `date`
-      - git submodule update --init --recursive
       - make -C src minisat2-download
       - make -C jbmc/src setup-submodules
       - make -C src CXX='ccache /usr/bin/clang++-3.8' CXX_FLAGS='-Qunused-arguments -DDEBUG'


### PR DESCRIPTION
Check out the diff vs. buildspec.yml and you'll see these are now much more regular.
This duplication and drift is a vindication of Travis' "matrix" approach if you ask me ;)