### PR TITLE
Update .gitignore for Eclipse project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,9 @@ src/goto-analyzer/taint_driver_scripts/.idea/*
 /*.idea
 /*.includes
 # Eclipse
-src/.cproject
-src/.project
-src/.settings/*
+.cproject
+.project
+.settings
 # Visual Studio
 Debug/*
 Release/*

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -286,6 +286,13 @@ To work with Eclipse, do the following:
 5. Click "Finish"
 6. Select Project -> Build All
 
+You can also select the repository's root folder as the "Existing Code 
+Location". This has the advantage that you can build both CBMC and JBMC without
+the need to integrate JBMC as a separate project. Be aware that you need to 
+change the build location (Select project in Eclipse -> Properties -> C/C++ 
+Build) to one of the src directories.
+
+
 # OPTIONS AND VARIABLES
 
 ## Compiling with CUDD


### PR DESCRIPTION
Suppress Eclipse project files globally, making it more convenient to integrate CBMC into Eclipse as the repository can directly be used as the project's root folder. This also eliminates the need to integrate JBMC and CBMC as separate projects.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] My PR is restricted to a single feature or bugfix.