### PR TITLE
Clean-up and unit test the renaming level classes

### DIFF
--- a/src/goto-symex/frame.h
+++ b/src/goto-symex/frame.h
@@ -32,7 +32,7 @@ struct framet
   exprt return_value = nil_exprt();
   bool hidden_function = false;
 
-  symex_renaming_levelt old_level1;
+  symex_level1t old_level1;
 
   std::set<irep_idt> local_objects;
 

--- a/src/goto-symex/frame.h
+++ b/src/goto-symex/frame.h
@@ -32,7 +32,7 @@ struct framet
   exprt return_value = nil_exprt();
   bool hidden_function = false;
 
-  symex_renaming_levelt::current_namest old_level1;
+  symex_renaming_levelt old_level1;
 
   std::set<irep_idt> local_objects;
 

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -798,23 +798,13 @@ ssa_exprt goto_symex_statet::add_object(
 
   ssa_exprt ssa = rename_ssa<L0>(ssa_exprt{expr}, ns).get();
   const irep_idt l0_name = ssa.get_identifier();
-  const std::size_t l1_index = index_generator(l0_name);
+  const auto l1_index = narrow_cast<unsigned>(index_generator(l0_name));
 
-  const auto r_opt = level1.current_names.find(l0_name);
-
-  if(!r_opt)
-  {
-    level1.current_names.insert(l0_name, std::make_pair(ssa, l1_index));
-  }
-  else
+  if(const auto old_value = level1.insert_or_replace(ssa, l1_index))
   {
     // save old L1 name
     if(!frame.old_level1.has_key(l0_name))
-    {
-      frame.old_level1.insert(l0_name, r_opt->get());
-    }
-
-    level1.current_names.replace(l0_name, std::make_pair(ssa, l1_index));
+      frame.old_level1.insert(l0_name, *old_value);
   }
 
   ssa = rename_ssa<L1>(std::move(ssa), ns).get();

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -135,21 +135,22 @@ template <>
 renamedt<ssa_exprt, L0>
 goto_symex_statet::set_indices<L0>(ssa_exprt ssa_expr, const namespacet &ns)
 {
-  return level0(std::move(ssa_expr), ns, source.thread_nr);
+  return symex_level0(std::move(ssa_expr), ns, source.thread_nr);
 }
 
 template <>
 renamedt<ssa_exprt, L1>
 goto_symex_statet::set_indices<L1>(ssa_exprt ssa_expr, const namespacet &ns)
 {
-  return level1(level0(std::move(ssa_expr), ns, source.thread_nr));
+  return level1(symex_level0(std::move(ssa_expr), ns, source.thread_nr));
 }
 
 template <>
 renamedt<ssa_exprt, L2>
 goto_symex_statet::set_indices<L2>(ssa_exprt ssa_expr, const namespacet &ns)
 {
-  return level2(level1(level0(std::move(ssa_expr), ns, source.thread_nr)));
+  return level2(
+    level1(symex_level0(std::move(ssa_expr), ns, source.thread_nr)));
 }
 
 renamedt<ssa_exprt, L2> goto_symex_statet::assignment(

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -803,8 +803,8 @@ ssa_exprt goto_symex_statet::add_object(
   if(const auto old_value = level1.insert_or_replace(renamed, l1_index))
   {
     // save old L1 name
-    if(!frame.old_level1.has_key(l0_name))
-      frame.old_level1.insert(l0_name, *old_value);
+    if(!frame.old_level1.has(renamed))
+      frame.old_level1.insert(renamed, old_value->second);
   }
 
   const ssa_exprt ssa = rename_ssa<L1>(renamed.get(), ns).get();

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -437,7 +437,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
     if(a_s_read.second.empty())
     {
       increase_generation(l1_identifier, ssa_l1);
-      a_s_read.first=level2.current_count(l1_identifier);
+      a_s_read.first = level2.latest_index(l1_identifier);
     }
     const renamedt<ssa_exprt, L2> l2_false_case = set_indices<L2>(ssa_l1, ns);
 

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -796,18 +796,18 @@ ssa_exprt goto_symex_statet::add_object(
 {
   framet &frame = call_stack().top();
 
-  ssa_exprt ssa = rename_ssa<L0>(ssa_exprt{expr}, ns).get();
-  const irep_idt l0_name = ssa.get_identifier();
+  const renamedt<ssa_exprt, L0> renamed = rename_ssa<L0>(ssa_exprt{expr}, ns);
+  const irep_idt l0_name = renamed.get_identifier();
   const auto l1_index = narrow_cast<unsigned>(index_generator(l0_name));
 
-  if(const auto old_value = level1.insert_or_replace(ssa, l1_index))
+  if(const auto old_value = level1.insert_or_replace(renamed, l1_index))
   {
     // save old L1 name
     if(!frame.old_level1.has_key(l0_name))
       frame.old_level1.insert(l0_name, *old_value);
   }
 
-  ssa = rename_ssa<L1>(std::move(ssa), ns).get();
+  const ssa_exprt ssa = rename_ssa<L1>(renamed.get(), ns).get();
   const bool inserted = frame.local_objects.insert(ssa.get_identifier()).second;
   INVARIANT(inserted, "l1_name expected to be unique by construction");
 

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -70,7 +70,6 @@ public:
   guard_managert &guard_manager;
   symex_target_equationt *symex_target;
 
-  symex_level0t level0;
   symex_level1t level1;
 
   /// Rewrites symbol expressions in \ref exprt, applying a suffix to each

--- a/src/goto-symex/renamed.h
+++ b/src/goto-symex/renamed.h
@@ -27,7 +27,7 @@ class renamedt : private underlyingt
 public:
   static_assert(
     std::is_base_of<exprt, underlyingt>::value ||
-    std::is_base_of<typet, underlyingt>::value,
+      std::is_base_of<typet, underlyingt>::value,
     "underlyingt should inherit from exprt or typet");
 
   const underlyingt &get() const
@@ -41,7 +41,7 @@ public:
   }
 
   using mutator_functiont =
-  std::function<optionalt<renamedt>(const renamedt &)>;
+    std::function<optionalt<renamedt>(const renamedt &)>;
 
 private:
   underlyingt &value()
@@ -62,7 +62,7 @@ private:
   friend void selectively_mutate(
     renamedt<exprt, selectively_mutate_level> &renamed,
     typename renamedt<exprt, selectively_mutate_level>::mutator_functiont
-    get_mutated_expr);
+      get_mutated_expr);
 
   /// Only the friend classes can create renamedt objects
   explicit renamedt(underlyingt value) : underlyingt(std::move(value))

--- a/src/goto-symex/renamed.h
+++ b/src/goto-symex/renamed.h
@@ -1,0 +1,102 @@
+/*******************************************************************\
+
+Module: Symbolic Execution
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+/// \file
+/// Class for expressions or types renamed up to a given level
+
+#ifndef CPROVER_GOTO_SYMEX_RENAMED_H
+#define CPROVER_GOTO_SYMEX_RENAMED_H
+
+/// Symex renaming level names.
+enum levelt
+{
+  L0 = 0,
+  L1 = 1,
+  L2 = 2
+};
+
+/// Wrapper for expressions or types which have been renamed up to a given
+/// \p level
+template <typename underlyingt, levelt level>
+class renamedt : private underlyingt
+{
+public:
+  static_assert(
+    std::is_base_of<exprt, underlyingt>::value ||
+    std::is_base_of<typet, underlyingt>::value,
+    "underlyingt should inherit from exprt or typet");
+
+  const underlyingt &get() const
+  {
+    return static_cast<const underlyingt &>(*this);
+  }
+
+  void simplify(const namespacet &ns)
+  {
+    (void)::simplify(value(), ns);
+  }
+
+  using mutator_functiont =
+  std::function<optionalt<renamedt>(const renamedt &)>;
+
+private:
+  underlyingt &value()
+  {
+    return static_cast<underlyingt &>(*this);
+  };
+
+  friend struct symex_level0t;
+  friend struct symex_level1t;
+  friend struct symex_level2t;
+  friend class goto_symex_statet;
+
+  template <levelt make_renamed_level>
+  friend renamedt<exprt, make_renamed_level>
+  make_renamed(constant_exprt constant);
+
+  template <levelt selectively_mutate_level>
+  friend void selectively_mutate(
+    renamedt<exprt, selectively_mutate_level> &renamed,
+    typename renamedt<exprt, selectively_mutate_level>::mutator_functiont
+    get_mutated_expr);
+
+  /// Only the friend classes can create renamedt objects
+  explicit renamedt(underlyingt value) : underlyingt(std::move(value))
+  {
+  }
+};
+
+template <levelt level>
+renamedt<exprt, level> make_renamed(constant_exprt constant)
+{
+  return renamedt<exprt, level>(std::move(constant));
+}
+
+/// This permits replacing subexpressions of the renamed value, so long as
+/// each replacement is consistent with our current renaming level (for
+/// example, replacing subexpressions of L2 expressions with ones which are
+/// themselves L2 renamed).
+/// The passed function will be called with each expression node in preorder
+/// (i.e. parent expressions before children), and should return an empty
+/// optional to make no change or a renamed expression to make a change.
+template <levelt level>
+void selectively_mutate(
+  renamedt<exprt, level> &renamed,
+  typename renamedt<exprt, level>::mutator_functiont get_mutated_expr)
+{
+  for(auto it = renamed.depth_begin(), itend = renamed.depth_end(); it != itend;
+      ++it)
+  {
+    optionalt<renamedt<exprt, level>> replacement =
+      get_mutated_expr(static_cast<const renamedt<exprt, level> &>(*it));
+
+    if(replacement)
+      it.mutate() = std::move(replacement->value());
+  }
+}
+
+#endif // CPROVER_GOTO_SYMEX_RENAMED_H

--- a/src/goto-symex/renamed.h
+++ b/src/goto-symex/renamed.h
@@ -49,7 +49,8 @@ private:
     return static_cast<underlyingt &>(*this);
   };
 
-  friend struct symex_level0t;
+  friend renamedt<ssa_exprt, L0>
+  symex_level0(ssa_exprt, const namespacet &, unsigned);
   friend struct symex_level1t;
   friend struct symex_level2t;
   friend class goto_symex_statet;

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -116,10 +116,10 @@ operator()(renamedt<ssa_exprt, L1> l1_expr) const
   return renamedt<ssa_exprt, L2>{std::move(l1_expr.value())};
 }
 
-void symex_level1t::restore_from(const symex_renaming_levelt &other)
+void symex_level1t::restore_from(const symex_level1t &other)
 {
   symex_renaming_levelt::delta_viewt delta_view;
-  other.get_delta_view(current_names, delta_view, false);
+  other.current_names.get_delta_view(current_names, delta_view, false);
 
   for(const auto &delta_item : delta_view)
   {

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -56,25 +56,25 @@ operator()(ssa_exprt ssa_expr, const namespacet &ns, unsigned thread_nr) const
   return renamedt<ssa_exprt, L0>{ssa_expr};
 }
 
-void symex_level1t::insert(ssa_exprt ssa, unsigned index)
+void symex_level1t::insert(const renamedt<ssa_exprt, L0> &ssa, unsigned index)
 {
-  const irep_idt identifier = ssa.get_identifier();
-  current_names.insert(identifier, std::make_pair(std::move(ssa), index));
+  current_names.insert(
+    ssa.get().get_identifier(), std::make_pair(ssa.get(), index));
 }
 
 optionalt<std::pair<ssa_exprt, unsigned>> symex_level1t::insert_or_replace(
-  ssa_exprt ssa, 
+  const renamedt<ssa_exprt, L0> &ssa,
   unsigned index)
 {
-  const irep_idt identifier = ssa.get_identifier();
+  const irep_idt &identifier = ssa.get().get_identifier();
   const auto old_value = current_names.find(identifier);
   if(old_value)
   {
     std::pair<ssa_exprt, unsigned> result = *old_value;
-    current_names.replace(identifier, std::make_pair(std::move(ssa), index));
+    current_names.replace(identifier, std::make_pair(ssa.get(), index));
     return result;
   }
-  current_names.insert(identifier, std::make_pair(std::move(ssa), index));
+  current_names.insert(identifier, std::make_pair(ssa.get(), index));
   return {};
 }
 

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -30,8 +30,8 @@ void get_variables(
   }
 }
 
-renamedt<ssa_exprt, L0> symex_level0t::
-operator()(ssa_exprt ssa_expr, const namespacet &ns, unsigned thread_nr) const
+renamedt<ssa_exprt, L0>
+symex_level0(ssa_exprt ssa_expr, const namespacet &ns, unsigned thread_nr)
 {
   // already renamed?
   if(!ssa_expr.get_level_0().empty())

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -56,6 +56,28 @@ operator()(ssa_exprt ssa_expr, const namespacet &ns, unsigned thread_nr) const
   return renamedt<ssa_exprt, L0>{ssa_expr};
 }
 
+void symex_level1t::insert(ssa_exprt ssa, unsigned index)
+{
+  const irep_idt identifier = ssa.get_identifier();
+  current_names.insert(identifier, std::make_pair(std::move(ssa), index));
+}
+
+optionalt<std::pair<ssa_exprt, unsigned>> symex_level1t::insert_or_replace(
+  ssa_exprt ssa, 
+  unsigned index)
+{
+  const irep_idt identifier = ssa.get_identifier();
+  const auto old_value = current_names.find(identifier);
+  if(old_value)
+  {
+    std::pair<ssa_exprt, unsigned> result = *old_value;
+    current_names.replace(identifier, std::make_pair(std::move(ssa), index));
+    return result;
+  }
+  current_names.insert(identifier, std::make_pair(std::move(ssa), index));
+  return {};
+}
+
 renamedt<ssa_exprt, L1> symex_level1t::
 operator()(renamedt<ssa_exprt, L0> l0_expr) const
 {

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -78,6 +78,11 @@ optionalt<std::pair<ssa_exprt, unsigned>> symex_level1t::insert_or_replace(
   return {};
 }
 
+bool symex_level1t::has(const renamedt<ssa_exprt, L0> &ssa) const
+{
+  return current_names.has_key(ssa.get().get_identifier());
+}
+
 renamedt<ssa_exprt, L1> symex_level1t::
 operator()(renamedt<ssa_exprt, L0> l0_expr) const
 {

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -112,7 +112,7 @@ operator()(renamedt<ssa_exprt, L1> l1_expr) const
 {
   if(!l1_expr.get().get_level_2().empty())
     return renamedt<ssa_exprt, L2>{std::move(l1_expr.value())};
-  l1_expr.value().set_level_2(current_count(l1_expr.get().get_identifier()));
+  l1_expr.value().set_level_2(latest_index(l1_expr.get().get_identifier()));
   return renamedt<ssa_exprt, L2>{std::move(l1_expr.value())};
 }
 
@@ -137,7 +137,7 @@ void symex_level1t::restore_from(const symex_level1t &other)
   }
 }
 
-unsigned symex_level2t::current_count(const irep_idt &identifier) const
+unsigned symex_level2t::latest_index(const irep_idt &identifier) const
 {
   const auto r_opt = current_names.find(identifier);
   return !r_opt ? 0 : r_opt->get().second;

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -17,6 +17,19 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 
 #include "goto_symex_state.h"
 
+void get_variables(
+  const symex_renaming_levelt &current_names,
+  std::unordered_set<ssa_exprt, irep_hash> &vars)
+{
+  symex_renaming_levelt::viewt view;
+  current_names.get_view(view);
+
+  for(const auto &pair : view)
+  {
+    vars.insert(pair.second.first);
+  }
+}
+
 renamedt<ssa_exprt, L0> symex_level0t::
 operator()(ssa_exprt ssa_expr, const namespacet &ns, unsigned thread_nr) const
 {
@@ -76,9 +89,9 @@ operator()(renamedt<ssa_exprt, L1> l1_expr) const
   return renamedt<ssa_exprt, L2>{std::move(l1_expr.value())};
 }
 
-void symex_level1t::restore_from(const current_namest &other)
+void symex_level1t::restore_from(const symex_renaming_levelt &other)
 {
-  current_namest::delta_viewt delta_view;
+  symex_renaming_levelt::delta_viewt delta_view;
   other.get_delta_view(current_names, delta_view, false);
 
   for(const auto &delta_item : delta_view)
@@ -95,6 +108,12 @@ void symex_level1t::restore_from(const current_namest &other)
       }
     }
   }
+}
+
+unsigned symex_level2t::current_count(const irep_idt &identifier) const
+{
+  const auto r_opt = current_names.find(identifier);
+  return !r_opt ? 0 : r_opt->get().second;
 }
 
 exprt get_original_name(exprt expr)

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -56,8 +56,6 @@ struct symex_level0t
 /// This is to preserve locality in case of recursion
 struct symex_level1t
 {
-  symex_renaming_levelt current_names;
-
   /// Assume \p ssa is not already known
   void insert(ssa_exprt ssa, unsigned index);
 
@@ -74,6 +72,9 @@ struct symex_level1t
 
   /// Insert the content of \p other into this renaming
   void restore_from(const symex_renaming_levelt &other);
+
+private:
+  symex_renaming_levelt current_names;
 };
 
 /// Functor to set the level 2 renaming of SSA expressions.

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -50,6 +50,7 @@ struct symex_renaming_levelt
   }
 
   /// Add the \c ssa_exprt of current_names to vars
+  DEPRECATED(SINCE(2019, 6, 5, "Unused"))
   void get_variables(std::unordered_set<ssa_exprt, irep_hash> &vars) const
   {
     current_namest::viewt view;

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -37,19 +37,14 @@ void get_variables(
   const symex_renaming_levelt &current_names,
   std::unordered_set<ssa_exprt, irep_hash> &vars);
 
-/// Functor to set the level 0 renaming of SSA expressions.
+/// Set the level 0 renaming of SSA expressions.
 /// Level 0 corresponds to threads.
 /// The renaming is built for one particular interleaving.
-struct symex_level0t
-{
-  /// Rename \p ssa_expr using \p thread_nr as L0 tag, unless \p ssa_expr is
-  /// a guard, a shared variable or a function. \p ns is queried to decide
-  /// whether we are in one of these cases.
-  renamedt<ssa_exprt, L0> operator()(
-    ssa_exprt ssa_expr,
-    const namespacet &ns,
-    unsigned thread_nr) const;
-};
+/// Rename \p ssa_expr using \p thread_nr as L0 tag, unless \p ssa_expr is
+/// a guard, a shared variable or a function. \p ns is queried to decide
+/// whether we are in one of these cases.
+renamedt<ssa_exprt, L0>
+symex_level0(ssa_exprt ssa_expr, const namespacet &ns, unsigned thread_nr);
 
 /// Functor to set the level 1 renaming of SSA expressions.
 /// Level 1 corresponds to function frames.

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -42,6 +42,9 @@ void get_variables(
 /// The renaming is built for one particular interleaving.
 struct symex_level0t
 {
+  /// Rename \p ssa_expr using \p thread_nr as L0 tag, unless \p ssa_expr is
+  /// a guard, a shared variable or a function. \p ns is queried to decide
+  /// whether we are in one of these cases.
   renamedt<ssa_exprt, L0> operator()(
     ssa_exprt ssa_expr,
     const namespacet &ns,

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -74,6 +74,8 @@ struct symex_level2t
 {
   symex_renaming_levelt current_names;
 
+  /// Set L2 tag to correspond to the current count of the identifier of
+  /// \p l1_expr's
   renamedt<ssa_exprt, L2> operator()(renamedt<ssa_exprt, L1> l1_expr) const;
 
   /// Counter corresponding to an identifier

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -74,7 +74,7 @@ struct symex_level1t
   renamedt<ssa_exprt, L1> operator()(renamedt<ssa_exprt, L0> l0_expr) const;
 
   /// Insert the content of \p other into this renaming
-  void restore_from(const symex_renaming_levelt &other);
+  void restore_from(const symex_level1t &other);
 
 private:
   symex_renaming_levelt current_names;

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -58,6 +58,15 @@ struct symex_level1t
 {
   symex_renaming_levelt current_names;
 
+  /// Assume \p ssa is not already known
+  void insert(ssa_exprt ssa, unsigned index);
+
+  /// Set the index for \p ssa to index.
+  /// \return if an index for \p ssa was already know, returns it's previous
+  ///   value.
+  optionalt<std::pair<ssa_exprt, unsigned>>
+  insert_or_replace(ssa_exprt ssa, unsigned index);
+
   /// \return an SSA expression similar to \p l0_expr where the L1 tag has been
   ///   set to the value in \ref current_names of the l1 object identifier of
   ///   \p l0_expr

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -65,6 +65,9 @@ struct symex_level1t
   optionalt<std::pair<ssa_exprt, unsigned>>
   insert_or_replace(const renamedt<ssa_exprt, L0> &ssa, unsigned index);
 
+  /// \return true if \p ssa has an associated index
+  bool has(const renamedt<ssa_exprt, L0> &ssa) const;
+
   /// \return an SSA expression similar to \p l0_expr where the L1 tag has been
   ///   set to the value in \ref current_names of the l1 object identifier of
   ///   \p l0_expr

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -58,6 +58,9 @@ struct symex_level1t
 {
   symex_renaming_levelt current_names;
 
+  /// \return an SSA expression similar to \p l0_expr where the L1 tag has been
+  ///   set to the value in \ref current_names of the l1 object identifier of
+  ///   \p l0_expr
   renamedt<ssa_exprt, L1> operator()(renamedt<ssa_exprt, L0> l0_expr) const;
 
   /// Insert the content of \p other into this renaming

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -22,13 +22,7 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include <util/simplify_expr.h>
 #include <util/ssa_expr.h>
 
-/// Symex renaming level names.
-enum levelt
-{
-  L0 = 0,
-  L1 = 1,
-  L2 = 2
-};
+#include "renamed.h"
 
 /// Wrapper for a \c current_names map, which maps each identifier to an SSA
 /// expression and a counter.
@@ -67,86 +61,6 @@ struct symex_renaming_levelt
     }
   }
 };
-
-/// Wrapper for expressions or types which have been renamed up to a given
-/// \p level
-template <typename underlyingt, levelt level>
-class renamedt : private underlyingt
-{
-public:
-  static_assert(
-    std::is_base_of<exprt, underlyingt>::value ||
-      std::is_base_of<typet, underlyingt>::value,
-    "underlyingt should inherit from exprt or typet");
-
-  const underlyingt &get() const
-  {
-    return static_cast<const underlyingt &>(*this);
-  }
-
-  void simplify(const namespacet &ns)
-  {
-    (void)::simplify(value(), ns);
-  }
-
-  using mutator_functiont =
-    std::function<optionalt<renamedt>(const renamedt &)>;
-
-private:
-  underlyingt &value()
-  {
-    return static_cast<underlyingt &>(*this);
-  };
-
-  friend struct symex_level0t;
-  friend struct symex_level1t;
-  friend struct symex_level2t;
-  friend class goto_symex_statet;
-
-  template <levelt make_renamed_level>
-  friend renamedt<exprt, make_renamed_level>
-  make_renamed(constant_exprt constant);
-
-  template <levelt selectively_mutate_level>
-  friend void selectively_mutate(
-    renamedt<exprt, selectively_mutate_level> &renamed,
-    typename renamedt<exprt, selectively_mutate_level>::mutator_functiont
-      get_mutated_expr);
-
-  /// Only the friend classes can create renamedt objects
-  explicit renamedt(underlyingt value) : underlyingt(std::move(value))
-  {
-  }
-};
-
-template <levelt level>
-renamedt<exprt, level> make_renamed(constant_exprt constant)
-{
-  return renamedt<exprt, level>(std::move(constant));
-}
-
-/// This permits replacing subexpressions of the renamed value, so long as
-/// each replacement is consistent with our current renaming level (for
-/// example, replacing subexpressions of L2 expressions with ones which are
-/// themselves L2 renamed).
-/// The passed function will be called with each expression node in preorder
-/// (i.e. parent expressions before children), and should return an empty
-/// optional to make no change or a renamed expression to make a change.
-template <levelt level>
-void selectively_mutate(
-  renamedt<exprt, level> &renamed,
-  typename renamedt<exprt, level>::mutator_functiont get_mutated_expr)
-{
-  for(auto it = renamed.depth_begin(), itend = renamed.depth_end(); it != itend;
-      ++it)
-  {
-    optionalt<renamedt<exprt, level>> replacement =
-      get_mutated_expr(static_cast<const renamedt<exprt, level> &>(*it));
-
-    if(replacement)
-      it.mutate() = std::move(replacement->value());
-  }
-}
 
 /// Functor to set the level 0 renaming of SSA expressions.
 /// Level 0 corresponds to threads.

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -57,13 +57,13 @@ struct symex_level0t
 struct symex_level1t
 {
   /// Assume \p ssa is not already known
-  void insert(ssa_exprt ssa, unsigned index);
+  void insert(const renamedt<ssa_exprt, L0> &ssa, unsigned index);
 
   /// Set the index for \p ssa to index.
   /// \return if an index for \p ssa was already know, returns it's previous
   ///   value.
   optionalt<std::pair<ssa_exprt, unsigned>>
-  insert_or_replace(ssa_exprt ssa, unsigned index);
+  insert_or_replace(const renamedt<ssa_exprt, L0> &ssa, unsigned index);
 
   /// \return an SSA expression similar to \p l0_expr where the L1 tag has been
   ///   set to the value in \ref current_names of the l1 object identifier of

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -92,7 +92,7 @@ struct symex_level2t
   renamedt<ssa_exprt, L2> operator()(renamedt<ssa_exprt, L1> l1_expr) const;
 
   /// Counter corresponding to an identifier
-  unsigned current_count(const irep_idt &identifier) const;
+  unsigned latest_index(const irep_idt &identifier) const;
 };
 
 /// Undo all levels of renaming

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -28,82 +28,50 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 /// expression and a counter.
 /// This is extended by the different symex_level structures which are used
 /// during symex to ensure static single assignment (SSA) form.
-struct symex_renaming_levelt
-{
-  symex_renaming_levelt() = default;
-  virtual ~symex_renaming_levelt() = default;
-  symex_renaming_levelt &
-  operator=(const symex_renaming_levelt &other) = default;
-  symex_renaming_levelt &operator=(symex_renaming_levelt &&other) = default;
-  symex_renaming_levelt(const symex_renaming_levelt &other) = default;
-  symex_renaming_levelt(symex_renaming_levelt &&other) = default;
+using symex_renaming_levelt =
+  sharing_mapt<irep_idt, std::pair<ssa_exprt, unsigned>>;
 
-  /// Map identifier to ssa_exprt and counter
-  typedef sharing_mapt<irep_idt, std::pair<ssa_exprt, unsigned>> current_namest;
-  current_namest current_names;
-
-  /// Counter corresponding to an identifier
-  unsigned current_count(const irep_idt &identifier) const
-  {
-    const auto r_opt = current_names.find(identifier);
-    return !r_opt ? 0 : r_opt->get().second;
-  }
-
-  /// Add the \c ssa_exprt of current_names to vars
-  DEPRECATED(SINCE(2019, 6, 5, "Unused"))
-  void get_variables(std::unordered_set<ssa_exprt, irep_hash> &vars) const
-  {
-    current_namest::viewt view;
-    current_names.get_view(view);
-
-    for(const auto &pair : view)
-    {
-      vars.insert(pair.second.first);
-    }
-  }
-};
+/// Add the \c ssa_exprt of current_names to vars
+DEPRECATED(SINCE(2019, 6, 5, "Unused"))
+void get_variables(
+  const symex_renaming_levelt &current_names,
+  std::unordered_set<ssa_exprt, irep_hash> &vars);
 
 /// Functor to set the level 0 renaming of SSA expressions.
 /// Level 0 corresponds to threads.
 /// The renaming is built for one particular interleaving.
-struct symex_level0t : public symex_renaming_levelt
+struct symex_level0t
 {
   renamedt<ssa_exprt, L0> operator()(
     ssa_exprt ssa_expr,
     const namespacet &ns,
     unsigned thread_nr) const;
-
-  symex_level0t() = default;
-  ~symex_level0t() override = default;
 };
 
 /// Functor to set the level 1 renaming of SSA expressions.
 /// Level 1 corresponds to function frames.
 /// This is to preserve locality in case of recursion
-struct symex_level1t : public symex_renaming_levelt
+struct symex_level1t
 {
+  symex_renaming_levelt current_names;
+
   renamedt<ssa_exprt, L1> operator()(renamedt<ssa_exprt, L0> l0_expr) const;
 
   /// Insert the content of \p other into this renaming
-  void restore_from(const current_namest &other);
-
-  symex_level1t() = default;
-  ~symex_level1t() override = default;
+  void restore_from(const symex_renaming_levelt &other);
 };
 
 /// Functor to set the level 2 renaming of SSA expressions.
 /// Level 2 corresponds to SSA.
 /// This is to ensure each variable is only assigned once.
-struct symex_level2t : public symex_renaming_levelt
+struct symex_level2t
 {
+  symex_renaming_levelt current_names;
+
   renamedt<ssa_exprt, L2> operator()(renamedt<ssa_exprt, L1> l1_expr) const;
 
-  symex_level2t() = default;
-  ~symex_level2t() override = default;
-  symex_level2t &operator=(const symex_level2t &other) = default;
-  symex_level2t &operator=(symex_level2t &&other) = default;
-  symex_level2t(const symex_level2t &other) = default;
-  symex_level2t(symex_level2t &&other) = default;
+  /// Counter corresponding to an identifier
+  unsigned current_count(const irep_idt &identifier) const;
 };
 
 /// Undo all levels of renaming

--- a/src/goto-symex/symex_atomic_section.cpp
+++ b/src/goto-symex/symex_atomic_section.cpp
@@ -70,7 +70,7 @@ void goto_symext::symex_atomic_end(statet &state)
   for(const auto &pair : state.written_in_atomic_section)
   {
     ssa_exprt w = pair.first;
-    w.set_level_2(state.get_level2().current_count(w.get_identifier()));
+    w.set_level_2(state.get_level2().latest_index(w.get_identifier()));
 
     // guard is the disjunction over writes
     PRECONDITION(!pair.second.empty());

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -343,7 +343,7 @@ pop_frame(goto_symext::statet &state, const path_storaget &path_storage)
     // restore L1 renaming
     state.level1.restore_from(frame.old_level1);
 
-    symex_renaming_levelt::current_namest::viewt view;
+    symex_renaming_levelt::viewt view;
     state.get_level2().current_names.get_view(view);
 
     std::vector<irep_idt> keys_to_erase;

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -722,7 +722,7 @@ void goto_symext::phi_function(
   // this gets the diff between the guards
   diff_guard -= dest_state.guard;
 
-  symex_renaming_levelt::current_namest::delta_viewt delta_view;
+  symex_renaming_levelt::delta_viewt delta_view;
   goto_state.get_level2().current_names.get_delta_view(
     dest_state.get_level2().current_names, delta_view, false);
 

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -67,13 +67,14 @@ void goto_symext::symex_start_thread(statet &state)
     ssa_exprt lhs(pair.second.first.get_original_expr());
 
     // get L0 name for current thread
-    renamedt<ssa_exprt, L0> l0_lhs = symex_level0t{}(std::move(lhs), ns , t);
+    const renamedt<ssa_exprt, L0> l0_lhs =
+      symex_level0t{}(std::move(lhs), ns, t);
     const irep_idt &l0_name = l0_lhs.get().get_identifier();
     std::size_t l1_index = path_storage.get_unique_l1_index(l0_name, 0);
     CHECK_RETURN(l1_index == 0);
 
     // set up L1 name
-    state.level1.insert(l0_lhs.get(), 0);
+    state.level1.insert(l0_lhs, 0);
 
     const ssa_exprt lhs_l1 = state.rename_ssa<L1>(l0_lhs.get(), ns).get();
     const irep_idt l1_name = lhs_l1.get_l1_object_identifier();

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -52,7 +52,7 @@ void goto_symext::symex_start_thread(statet &state)
   // create a copy of the local variables for the new thread
   framet &frame = state.call_stack().top();
 
-  symex_renaming_levelt::current_namest::viewt view;
+  symex_renaming_levelt::viewt view;
   state.get_level2().current_names.get_view(view);
 
   for(const auto &pair : view)

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -67,8 +67,7 @@ void goto_symext::symex_start_thread(statet &state)
     ssa_exprt lhs(pair.second.first.get_original_expr());
 
     // get L0 name for current thread
-    const renamedt<ssa_exprt, L0> l0_lhs =
-      symex_level0t{}(std::move(lhs), ns, t);
+    const renamedt<ssa_exprt, L0> l0_lhs = symex_level0(std::move(lhs), ns, t);
     const irep_idt &l0_name = l0_lhs.get().get_identifier();
     std::size_t l1_index = path_storage.get_unique_l1_index(l0_name, 0);
     CHECK_RETURN(l1_index == 0);

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -67,15 +67,15 @@ void goto_symext::symex_start_thread(statet &state)
     ssa_exprt lhs(pair.second.first.get_original_expr());
 
     // get L0 name for current thread
-    lhs.set_level_0(t);
-    const irep_idt &l0_name = lhs.get_identifier();
+    renamedt<ssa_exprt, L0> l0_lhs = symex_level0t{}(std::move(lhs), ns , t);
+    const irep_idt &l0_name = l0_lhs.get().get_identifier();
     std::size_t l1_index = path_storage.get_unique_l1_index(l0_name, 0);
     CHECK_RETURN(l1_index == 0);
 
     // set up L1 name
-    state.level1.insert(lhs, 0);
+    state.level1.insert(l0_lhs.get(), 0);
 
-    const ssa_exprt lhs_l1 = state.rename_ssa<L1>(std::move(lhs), ns).get();
+    const ssa_exprt lhs_l1 = state.rename_ssa<L1>(l0_lhs.get(), ns).get();
     const irep_idt l1_name = lhs_l1.get_l1_object_identifier();
     // store it
     new_thread.call_stack.back().local_objects.insert(l1_name);

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -73,8 +73,7 @@ void goto_symext::symex_start_thread(statet &state)
     CHECK_RETURN(l1_index == 0);
 
     // set up L1 name
-    state.level1.current_names.insert(
-      lhs.get_l1_object_identifier(), std::make_pair(lhs, 0));
+    state.level1.insert(lhs, 0);
 
     const ssa_exprt lhs_l1 = state.rename_ssa<L1>(std::move(lhs), ns).get();
     const irep_idt l1_name = lhs_l1.get_l1_object_identifier();

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -33,6 +33,7 @@ SRC += analyses/ai/ai.cpp \
        goto-symex/ssa_equation.cpp \
        goto-symex/is_constant.cpp \
        goto-symex/symex_level0.cpp \
+       goto-symex/symex_level1.cpp \
        interpreter/interpreter.cpp \
        json/json_parser.cpp \
        json_symbol_table.cpp \

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -32,6 +32,7 @@ SRC += analyses/ai/ai.cpp \
        goto-programs/xml_expr.cpp \
        goto-symex/ssa_equation.cpp \
        goto-symex/is_constant.cpp \
+       goto-symex/symex_level0.cpp \
        interpreter/interpreter.cpp \
        json/json_parser.cpp \
        json_symbol_table.cpp \

--- a/unit/goto-symex/symex_level0.cpp
+++ b/unit/goto-symex/symex_level0.cpp
@@ -1,0 +1,115 @@
+/*******************************************************************\
+
+Module: Unit tests for symex_target_equation::validate
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include <testing-utils/message.h>
+#include <testing-utils/use_catch.h>
+
+#include <goto-symex/goto_symex_state.h>
+#include <goto-symex/renaming_level.h>
+#include <util/namespace.h>
+#include <util/symbol_table.h>
+
+SCENARIO("Level 0 renaming", "[core][goto-symex][symex-level0]")
+{
+  GIVEN(
+    "A symbol table with a thread local variable, a shared variable, "
+    "a guard, and a function")
+  {
+    symbol_tablet symbol_table;
+    namespacet ns{symbol_table};
+    const signedbv_typet int_type{32};
+
+    const symbol_exprt symbol_nonshared{"nonShared", int_type};
+    const ssa_exprt ssa_nonshared{symbol_nonshared};
+    symbol_table.insert([&] {
+      symbolt symbol;
+      symbol.name = symbol_nonshared.get_identifier();
+      symbol.type = symbol_nonshared.type();
+      symbol.value = symbol_nonshared;
+      symbol.is_thread_local = true;
+      return symbol;
+    }());
+
+    const symbol_exprt symbol_shared{"shared", int_type};
+    const ssa_exprt ssa_shared{symbol_shared};
+    symbol_table.insert([&] {
+      symbolt symbol;
+      symbol.name = symbol_shared.get_identifier();
+      symbol.type = symbol_shared.type();
+      symbol.value = symbol_shared;
+      symbol.is_thread_local = false;
+      return symbol;
+    }());
+
+    const symbol_exprt symbol_guard{goto_symex_statet::guard_identifier(),
+                                    bool_typet{}};
+    const ssa_exprt ssa_guard{symbol_guard};
+    symbol_table.insert([&] {
+      symbolt symbol;
+      symbol.name = symbol_guard.get_identifier();
+      symbol.type = symbol_guard.type();
+      symbol.value = symbol_guard;
+      symbol.is_thread_local = false;
+      return symbol;
+    }());
+
+    const code_typet code_type({}, int_type);
+    const symbol_exprt symbol_fun{"fun", code_type};
+    const ssa_exprt ssa_fun{symbol_fun};
+    symbol_table.insert([&] {
+      symbolt fun_symbol;
+      fun_symbol.name = symbol_fun.get_identifier();
+      fun_symbol.type = symbol_fun.type();
+      fun_symbol.value = symbol_fun;
+      fun_symbol.is_thread_local = true;
+      return fun_symbol;
+    }());
+
+    WHEN("The non-shared symbol is renamed")
+    {
+      auto renamed = symex_level0t{}(ssa_nonshared, ns, 423);
+
+      THEN("Its L0 tag is set to the thread index")
+      {
+        REQUIRE(renamed.get().get_identifier() == "nonShared!423");
+      }
+    }
+
+    WHEN("The shared symbol is renamed")
+    {
+      auto renamed = symex_level0t{}(ssa_shared, ns, 423);
+
+      THEN("Its L0 tag is unchanged")
+      {
+        REQUIRE(renamed.get().get_identifier() == "shared");
+      }
+    }
+
+    WHEN("The guard is renamed")
+    {
+      auto renamed = symex_level0t{}(ssa_guard, ns, 423);
+
+      THEN("Its L0 tag is unchanged")
+      {
+        REQUIRE(
+          renamed.get().get_identifier() ==
+          goto_symex_statet::guard_identifier());
+      }
+    }
+
+    WHEN("The function is renamed")
+    {
+      auto renamed = symex_level0t{}(ssa_fun, ns, 423);
+
+      THEN("Its L0 tag is unchanged")
+      {
+        REQUIRE(renamed.get().get_identifier() == "fun");
+      }
+    }
+  }
+}

--- a/unit/goto-symex/symex_level0.cpp
+++ b/unit/goto-symex/symex_level0.cpp
@@ -72,7 +72,7 @@ SCENARIO("Level 0 renaming", "[core][goto-symex][symex-level0]")
 
     WHEN("The non-shared symbol is renamed")
     {
-      auto renamed = symex_level0t{}(ssa_nonshared, ns, 423);
+      auto renamed = symex_level0(ssa_nonshared, ns, 423);
 
       THEN("Its L0 tag is set to the thread index")
       {
@@ -82,7 +82,7 @@ SCENARIO("Level 0 renaming", "[core][goto-symex][symex-level0]")
 
     WHEN("The shared symbol is renamed")
     {
-      auto renamed = symex_level0t{}(ssa_shared, ns, 423);
+      auto renamed = symex_level0(ssa_shared, ns, 423);
 
       THEN("Its L0 tag is unchanged")
       {
@@ -92,7 +92,7 @@ SCENARIO("Level 0 renaming", "[core][goto-symex][symex-level0]")
 
     WHEN("The guard is renamed")
     {
-      auto renamed = symex_level0t{}(ssa_guard, ns, 423);
+      auto renamed = symex_level0(ssa_guard, ns, 423);
 
       THEN("Its L0 tag is unchanged")
       {
@@ -104,7 +104,7 @@ SCENARIO("Level 0 renaming", "[core][goto-symex][symex-level0]")
 
     WHEN("The function is renamed")
     {
-      auto renamed = symex_level0t{}(ssa_fun, ns, 423);
+      auto renamed = symex_level0(ssa_fun, ns, 423);
 
       THEN("Its L0 tag is unchanged")
       {

--- a/unit/goto-symex/symex_level1.cpp
+++ b/unit/goto-symex/symex_level1.cpp
@@ -1,0 +1,82 @@
+/*******************************************************************\
+
+Module: Unit tests for symex_target_equation::validate
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include <testing-utils/message.h>
+#include <testing-utils/use_catch.h>
+
+#include <goto-symex/goto_symex_state.h>
+#include <goto-symex/renaming_level.h>
+#include <util/namespace.h>
+#include <util/symbol_table.h>
+
+SCENARIO("Level 1 renaming", "[core][goto-symex][symex-level1]")
+{
+  GIVEN("A symbol renamed to level 0, and a symex_level1t functor")
+  {
+    symbol_tablet symbol_table;
+    namespacet ns{symbol_table};
+    const signedbv_typet int_type{32};
+    const symbol_exprt symbol_nonshared{"foo", int_type};
+    ssa_exprt ssa{symbol_nonshared};
+    symbol_table.insert([&] {
+      symbolt symbol;
+      symbol.name = symbol_nonshared.get_identifier();
+      symbol.type = symbol_nonshared.type();
+      symbol.value = symbol_nonshared;
+      symbol.is_thread_local = true;
+      return symbol;
+    }());
+    auto l0_symbol = symex_level0(ssa, ns, 50);
+    symex_level1t symex_level1;
+
+    WHEN("The symbol is not yet inserted in symex_level1")
+    {
+      THEN("Renaming leaves it unchanged")
+      {
+        auto renamed = symex_level1(l0_symbol);
+        REQUIRE(renamed.get().get_identifier() == "foo!50");
+      }
+    }
+
+    WHEN("The symbol is inserted in symex_level1 several times")
+    {
+      symex_level1.insert(l0_symbol, 12134);
+      THEN("The symbol is renamed to the index inserted")
+      {
+        auto renamed = symex_level1(l0_symbol);
+        REQUIRE(renamed.get().get_identifier() == "foo!50@12134");
+      }
+
+      auto old = symex_level1.insert_or_replace(l0_symbol, 43950);
+      THEN("insert_or_replace return the old value")
+      {
+        REQUIRE(old.has_value());
+        REQUIRE(old->second == 12134);
+      }
+      THEN("The symbol is renamed to the new value")
+      {
+        auto renamed2 = symex_level1(l0_symbol);
+        REQUIRE(renamed2.get().get_identifier() == "foo!50@43950");
+      }
+    }
+
+    WHEN("insert_or_replace is called with a symbol not already inserted")
+    {
+      auto old = symex_level1.insert_or_replace(l0_symbol, 20051);
+      THEN("insert_or_replace return an empty optional")
+      {
+        REQUIRE(!old.has_value());
+      }
+      THEN("The symbol is renamed to the index inserted")
+      {
+        auto renamed = symex_level1(l0_symbol);
+        REQUIRE(renamed.get().get_identifier() == "foo!50@20051");
+      }
+    }
+  }
+}

--- a/unit/goto-symex/symex_level1.cpp
+++ b/unit/goto-symex/symex_level1.cpp
@@ -38,6 +38,7 @@ SCENARIO("Level 1 renaming", "[core][goto-symex][symex-level1]")
     {
       THEN("Renaming leaves it unchanged")
       {
+        REQUIRE(!symex_level1.has(l0_symbol));
         auto renamed = symex_level1(l0_symbol);
         REQUIRE(renamed.get().get_identifier() == "foo!50");
       }
@@ -48,6 +49,7 @@ SCENARIO("Level 1 renaming", "[core][goto-symex][symex-level1]")
       symex_level1.insert(l0_symbol, 12134);
       THEN("The symbol is renamed to the index inserted")
       {
+        REQUIRE(symex_level1.has(l0_symbol));
         auto renamed = symex_level1(l0_symbol);
         REQUIRE(renamed.get().get_identifier() == "foo!50@12134");
       }
@@ -63,6 +65,7 @@ SCENARIO("Level 1 renaming", "[core][goto-symex][symex-level1]")
         auto renamed2 = symex_level1(l0_symbol);
         REQUIRE(renamed2.get().get_identifier() == "foo!50@43950");
       }
+      REQUIRE(symex_level1.has(l0_symbol));
     }
 
     WHEN("insert_or_replace is called with a symbol not already inserted")
@@ -74,6 +77,7 @@ SCENARIO("Level 1 renaming", "[core][goto-symex][symex-level1]")
       }
       THEN("The symbol is renamed to the index inserted")
       {
+        REQUIRE(symex_level1.has(l0_symbol));
         auto renamed = symex_level1(l0_symbol);
         REQUIRE(renamed.get().get_identifier() == "foo!50@20051");
       }


### PR DESCRIPTION
This removes unnecessary inheritance, and makes the public interface of symex_level1t smaller so that it can be more significantly unit-tested. In particular we ensure that it is only used to map identifiers which come from L0 renamed ssa_exprt.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
