### PR TITLE
introduce code_havoc_objectt

### DIFF
--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -793,9 +793,8 @@ void goto_convertt::do_function_call_symbol(
       throw 0;
     }
 
-    codet havoc(ID_havoc_object);
+    code_havoc_objectt havoc(arguments[0]);
     havoc.add_source_location() = function.source_location();
-    havoc.copy_to_operands(arguments[0]);
 
     dest.add(goto_programt::make_other(havoc, function.source_location()));
   }

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -256,11 +256,9 @@ void goto_symext::symex_other(
   }
   else if(statement==ID_havoc_object)
   {
-    DATA_INVARIANT(
-      code.operands().size() == 1,
-      "expected havoc_object statement to have one operand");
+    const auto &havoc_object_statement = to_code_havoc_object(code);
 
-    exprt object = clean_expr(code.op0(), state, false);
+    exprt object = clean_expr(havoc_object_statement.object(), state, false);
 
     process_array_expr(state, object);
     havoc_rec(state, guardt(true_exprt(), guard_manager), object);

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -2473,6 +2473,59 @@ inline code_try_catcht &to_code_try_catch(codet &code)
   return ret;
 }
 
+/// \ref codet representation of a 'havoc_object' statement.
+class code_havoc_objectt : public codet
+{
+public:
+  explicit code_havoc_objectt(exprt op)
+    : codet(ID_havoc_object, {std::move(op)})
+  {
+  }
+
+  const exprt &object() const
+  {
+    return op0();
+  }
+
+  exprt &object()
+  {
+    return op0();
+  }
+
+protected:
+  using codet::op0;
+  using codet::op1;
+  using codet::op2;
+  using codet::op3;
+};
+
+template <>
+inline bool can_cast_expr<code_havoc_objectt>(const exprt &base)
+{
+  return detail::can_cast_code_impl(base, ID_havoc_object);
+}
+
+inline void validate_expr(const code_havoc_objectt &x)
+{
+  validate_operands(x, 1, "havoc_object must have one operand", true);
+}
+
+inline const code_havoc_objectt &to_code_havoc_object(const codet &code)
+{
+  PRECONDITION(code.get_statement() == ID_havoc_object);
+  const code_havoc_objectt &ret = static_cast<const code_havoc_objectt &>(code);
+  validate_expr(ret);
+  return ret;
+}
+
+inline code_havoc_objectt &to_code_havoc_object(codet &code)
+{
+  PRECONDITION(code.get_statement() == ID_try_catch);
+  code_havoc_objectt &ret = static_cast<code_havoc_objectt &>(code);
+  validate_expr(ret);
+  return ret;
+}
+
 /// This class is used to interface between a language frontend
 /// and goto-convert -- it communicates the identifiers of the parameters
 /// of a function or method


### PR DESCRIPTION
This documents an existing `codet` variant.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
