### PR TITLE
avoid access to exprt::opX()

### DIFF
--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -334,17 +334,18 @@ bool constant_propagator_domaint::two_way_propagate_rec(
   }
   else if(expr.id() == ID_not)
   {
-    if(expr.op0().id() == ID_equal || expr.op0().id() == ID_notequal)
+    const auto &op = to_not_expr(expr).op();
+
+    if(op.id() == ID_equal || op.id() == ID_notequal)
     {
-      exprt subexpr = expr.op0();
+      exprt subexpr = op;
       subexpr.id(subexpr.id() == ID_equal ? ID_notequal : ID_equal);
       change = two_way_propagate_rec(subexpr, ns, cp);
     }
-    else if(expr.op0().id() == ID_symbol && expr.type() == bool_typet())
+    else if(op.id() == ID_symbol && expr.type() == bool_typet())
     {
       // Treat `IF !x` like `IF x == FALSE`:
-      change =
-        two_way_propagate_rec(equal_exprt(expr.op0(), false_exprt()), ns, cp);
+      change = two_way_propagate_rec(equal_exprt(op, false_exprt()), ns, cp);
     }
   }
   else if(expr.id() == ID_symbol)
@@ -359,8 +360,8 @@ bool constant_propagator_domaint::two_way_propagate_rec(
   {
     // Treat "symbol != constant" like "symbol == !constant" when the constant
     // is a boolean.
-    exprt lhs = expr.op0();
-    exprt rhs = expr.op1();
+    exprt lhs = to_notequal_expr(expr).lhs();
+    exprt rhs = to_notequal_expr(expr).rhs();
 
     if(lhs.is_constant() && !rhs.is_constant())
       std::swap(lhs, rhs);
@@ -384,8 +385,8 @@ bool constant_propagator_domaint::two_way_propagate_rec(
   }
   else if(expr.id() == ID_equal)
   {
-    exprt lhs = expr.op0();
-    exprt rhs = expr.op1();
+    exprt lhs = to_equal_expr(expr).lhs();
+    exprt rhs = to_equal_expr(expr).rhs();
 
     replace_typecast_of_bool(lhs, rhs, ns);
 

--- a/src/goto-symex/goto_state.cpp
+++ b/src/goto-symex/goto_state.cpp
@@ -51,8 +51,8 @@ void goto_statet::apply_condition(
   }
   else if(condition.id() == ID_equal)
   {
-    exprt lhs = condition.op0();
-    exprt rhs = condition.op1();
+    exprt lhs = to_equal_expr(condition).lhs();
+    exprt rhs = to_equal_expr(condition).rhs();
     if(is_ssa_expr(rhs))
       std::swap(lhs, rhs);
 


### PR DESCRIPTION
This improves memory safety.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
