### PR TITLE
Function and test for identifier of user specified clinit [TG-7981]

### DIFF
--- a/jbmc/src/java_bytecode/java_static_initializers.cpp
+++ b/jbmc/src/java_bytecode/java_static_initializers.cpp
@@ -88,6 +88,14 @@ bool is_clinit_function(const irep_idt &function_id)
   return has_suffix(id2string(function_id), clinit_function_suffix);
 }
 
+/// Check if function_id is a user-specified clinit
+/// \param function_id: some function identifier
+/// \return true if the passed identifier is a clinit
+bool is_user_specified_clinit_function(const irep_idt &function_id)
+{
+  return has_suffix(id2string(function_id), user_specified_clinit_suffix);
+}
+
 /// Add a new symbol to the symbol table.
 /// Note: assumes that a symbol with this name does not exist.
 /// /param name: name of the symbol to be generated

--- a/jbmc/src/java_bytecode/java_static_initializers.h
+++ b/jbmc/src/java_bytecode/java_static_initializers.h
@@ -26,6 +26,7 @@ irep_idt user_specified_clinit_name(const irep_idt &class_name);
 
 bool is_clinit_wrapper_function(const irep_idt &function_id);
 bool is_clinit_function(const irep_idt &function_id);
+bool is_user_specified_clinit_function(const irep_idt &function_id);
 
 void create_static_initializer_symbols(
   symbol_tablet &symbol_table,

--- a/jbmc/unit/java_bytecode/java_static_initializers/java_static_initializers.cpp
+++ b/jbmc/unit/java_bytecode/java_static_initializers/java_static_initializers.cpp
@@ -12,16 +12,21 @@ Author: Diffblue Ltd.
 SCENARIO("is_clinit_function", "[core][java_static_initializers]")
 {
   GIVEN("A function id that represents a clinit")
-  THEN("is_clinit_function should return true.")
   {
-    const std::string input = "com.something.package.TestClass.<clinit>:()V";
-    REQUIRE(is_clinit_function(input));
+    THEN("is_clinit_function should return true.")
+    {
+      const std::string input = "com.something.package.TestClass.<clinit>:()V";
+      REQUIRE(is_clinit_function(input));
+    }
   }
   GIVEN("A function id that does not represent a clinit")
-  THEN("is_clinit_function should return false.")
   {
-    const std::string input = "com.something.package.TestClass.<notclinit>:()V";
-    REQUIRE_FALSE(is_clinit_function(input));
+    THEN("is_clinit_function should return false.")
+    {
+      const std::string input =
+        "com.something.package.TestClass.<notclinit>:()V";
+      REQUIRE_FALSE(is_clinit_function(input));
+    }
   }
 }
 
@@ -30,16 +35,20 @@ SCENARIO(
   "[core][java_static_initializers]")
 {
   GIVEN("A function id that represents a user-specified clinit")
-  THEN("is_user_specified_clinit_function should return true.")
   {
-    const std::string input =
-      "com.something.package.TestClass::user_specified_clinit";
-    REQUIRE(is_user_specified_clinit_function(input));
+    THEN("is_user_specified_clinit_function should return true.")
+    {
+      const std::string input =
+        "com.something.package.TestClass::user_specified_clinit";
+      REQUIRE(is_user_specified_clinit_function(input));
+    }
   }
   GIVEN("A function id that does not represent a user-specified clinit")
-  THEN("is_clinit_function should return false.")
   {
-    const std::string input = "com.something.package.TestClass::not_it";
-    REQUIRE_FALSE(is_user_specified_clinit_function(input));
+    THEN("is_clinit_function should return false.")
+    {
+      const std::string input = "com.something.package.TestClass::not_it";
+      REQUIRE_FALSE(is_user_specified_clinit_function(input));
+    }
   }
 }

--- a/jbmc/unit/java_bytecode/java_static_initializers/java_static_initializers.cpp
+++ b/jbmc/unit/java_bytecode/java_static_initializers/java_static_initializers.cpp
@@ -24,3 +24,22 @@ SCENARIO("is_clinit_function", "[core][java_static_initializers]")
     REQUIRE_FALSE(is_clinit_function(input));
   }
 }
+
+SCENARIO(
+  "is_user_specified_clinit_function",
+  "[core][java_static_initializers]")
+{
+  GIVEN("A function id that represents a user-specified clinit")
+  THEN("is_user_specified_clinit_function should return true.")
+  {
+    const std::string input =
+      "com.something.package.TestClass::user_specified_clinit";
+    REQUIRE(is_user_specified_clinit_function(input));
+  }
+  GIVEN("A function id that does not represent a user-specified clinit")
+  THEN("is_clinit_function should return false.")
+  {
+    const std::string input = "com.something.package.TestClass::not_it";
+    REQUIRE_FALSE(is_user_specified_clinit_function(input));
+  }
+}

--- a/jbmc/unit/java_bytecode/java_static_initializers/java_static_initializers.cpp
+++ b/jbmc/unit/java_bytecode/java_static_initializers/java_static_initializers.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************\
 
-Module: Unit tests for java_types
+Module: Unit tests for java_static_initializers
 
 Author: Diffblue Ltd.
 


### PR DESCRIPTION
For detecting when an identifier represented a user-specified clinit.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
