### PR TITLE
C library/free: distinguish invalid pointer from invalid free

### DIFF
--- a/regression/cbmc-library/free-01/main.c
+++ b/regression/cbmc-library/free-01/main.c
@@ -1,9 +1,8 @@
-#include <assert.h>
 #include <stdlib.h>
 
 int main()
 {
-  free();
-  assert(0);
+  int *ptr;
+  free(ptr);
   return 0;
 }

--- a/regression/cbmc-library/free-01/test.desc
+++ b/regression/cbmc-library/free-01/test.desc
@@ -1,8 +1,9 @@
-KNOWNBUG
+CORE
 main.c
---pointer-check --bounds-check
-^EXIT=0$
+--pointer-check --bounds-check --stop-on-fail
+free argument must be NULL or valid pointer
+^EXIT=10$
 ^SIGNAL=0$
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/cbmc/alloca1/test.desc
+++ b/regression/cbmc/alloca1/test.desc
@@ -5,6 +5,6 @@ main.c
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
 free called for stack-allocated object: FAILURE$
-^\*\* 1 of 12 failed
+^\*\* 1 of 13 failed
 --
 ^warning: ignoring

--- a/src/ansi-c/library/stdlib.c
+++ b/src/ansi-c/library/stdlib.c
@@ -184,6 +184,9 @@ inline void free(void *ptr)
 {
   __CPROVER_HIDE:;
   // If ptr is NULL, no operation is performed.
+  __CPROVER_precondition(
+    ptr == 0 || __CPROVER_r_ok(ptr, 0),
+    "free argument must be NULL or valid pointer");
   __CPROVER_precondition(ptr==0 || __CPROVER_DYNAMIC_OBJECT(ptr),
                          "free argument must be dynamic object");
   __CPROVER_precondition(ptr==0 || __CPROVER_POINTER_OFFSET(ptr)==0,


### PR DESCRIPTION
This makes counterexamples easier to understand when an invalid pointer
is being passed to free(), and also supports SV-COMP, where we
previously only distinguished these cases via a hack in the wrapper
script.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
