### PR TITLE
Unit-test try_evaluate_pointer_comparison and bugfix

### DIFF
--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -726,4 +726,20 @@ void symex_transition(
   goto_programt::const_targett to,
   bool is_backwards_goto);
 
+/// Try to evaluate pointer comparisons where they can be trivially determined
+/// using the value-set. This is optional as all it does is allow symex to
+/// resolve some comparisons itself and therefore create a simpler formula for
+/// the SAT solver.
+/// \param [in,out] condition: An L2-renamed expression with boolean type
+/// \param value_set: The value-set for determining what pointer-typed symbols
+///   might possibly point to
+/// \param language_mode: The language mode
+/// \param ns: A namespace
+/// \return The possibly modified condition
+renamedt<exprt, L2> try_evaluate_pointer_comparisons(
+  renamedt<exprt, L2> condition,
+  const value_sett &value_set,
+  const irep_idt &language_mode,
+  const namespacet &ns);
+
 #endif // CPROVER_GOTO_SYMEX_GOTO_SYMEX_H

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -196,17 +196,7 @@ static optionalt<renamedt<exprt, L2>> try_evaluate_pointer_comparison(
     expr.id(), *symbol_expr_lhs, rhs, value_set, language_mode, ns);
 }
 
-/// Try to evaluate pointer comparisons where they can be trivially determined
-/// using the value-set. This is optional as all it does is allow symex to
-/// resolve some comparisons itself and therefore create a simpler formula for
-/// the SAT solver.
-/// \param [in,out] condition: An L2-renamed expression with boolean type
-/// \param value_set: The value-set for determining what pointer-typed symbols
-///   might possibly point to
-/// \param language_mode: The language mode
-/// \param ns: A namespace
-/// \return The possibly modified condition
-static renamedt<exprt, L2> try_evaluate_pointer_comparisons(
+renamedt<exprt, L2> try_evaluate_pointer_comparisons(
   renamedt<exprt, L2> condition,
   const value_sett &value_set,
   const irep_idt &language_mode,

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -100,8 +100,10 @@ static optionalt<renamedt<exprt, L2>> try_evaluate_pointer_comparison(
   const ssa_exprt *ssa_symbol_expr =
     expr_try_dynamic_cast<ssa_exprt>(symbol_expr);
 
+  ssa_exprt l1_expr{*ssa_symbol_expr};
+  l1_expr.remove_level_2();
   const std::vector<exprt> value_set_elements =
-    value_set.get_value_set(ssa_symbol_expr->get_l1_object(), ns);
+    value_set.get_value_set(l1_expr, ns);
 
   bool constant_found = false;
 

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -35,6 +35,7 @@ SRC += analyses/ai/ai.cpp \
        goto-symex/is_constant.cpp \
        goto-symex/symex_level0.cpp \
        goto-symex/symex_level1.cpp \
+       goto-symex/try_evaluate_pointer_comparisons.cpp \
        interpreter/interpreter.cpp \
        json/json_parser.cpp \
        json_symbol_table.cpp \

--- a/unit/goto-symex/try_evaluate_pointer_comparisons.cpp
+++ b/unit/goto-symex/try_evaluate_pointer_comparisons.cpp
@@ -1,0 +1,130 @@
+/*******************************************************************\
+
+Module: Unit tests for try_evaluate_pointer_comparisons
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+#include <testing-utils/message.h>
+#include <testing-utils/use_catch.h>
+
+#include <goto-symex/goto_symex.h>
+#include <util/c_types.h>
+
+static void add_to_symbol_table(
+  symbol_tablet &symbol_table,
+  const symbol_exprt &symbol_expr)
+{
+  symbolt symbol;
+  symbol.name = symbol_expr.get_identifier();
+  symbol.type = symbol_expr.type();
+  symbol.value = symbol_expr;
+  symbol.is_thread_local = true;
+  symbol_table.insert(symbol);
+}
+
+SCENARIO(
+  "Try to evaluate pointer comparisons",
+  "[core][goto-symex][try_evaluate_pointer_comparisons]")
+{
+  const unsignedbv_typet int_type{32};
+  const pointer_typet ptr_type = pointer_type(int_type);
+  const symbol_exprt ptr1{"ptr1", ptr_type};
+  const symbol_exprt ptr2{"ptr2", ptr_type};
+  const symbol_exprt value1{"value1", int_type};
+  const address_of_exprt address1{value1};
+  const symbol_exprt value2{"value2", int_type};
+  const address_of_exprt address2{value2};
+  const symbol_exprt b{"b", bool_typet{}};
+
+  // Add symbols to symbol table
+  symbol_tablet symbol_table;
+  namespacet ns{symbol_table};
+  add_to_symbol_table(symbol_table, ptr1);
+  add_to_symbol_table(symbol_table, ptr2);
+  add_to_symbol_table(symbol_table, value1);
+  add_to_symbol_table(symbol_table, value2);
+  add_to_symbol_table(symbol_table, b);
+
+  // Initialize goto state
+  std::list<goto_programt::instructiont> target;
+  symex_targett::sourcet source{"fun", target.begin()};
+  guard_managert guard_manager;
+  std::size_t count = 0;
+  auto fresh_name = [&count](const irep_idt &) { return count++; };
+  goto_symex_statet state{source, guard_manager, fresh_name};
+
+  GIVEN("A value set in which pointer symbol `ptr1` only points to `&value1`")
+  {
+    value_sett value_set;
+    const renamedt<exprt, L1> ptr1_l1 = state.rename<L1>(ptr1, ns);
+    const renamedt<exprt, L1> address1_l1 = state.rename<L1>(address1, ns);
+    // ptr1 <- &value1
+    value_set.assign(ptr1_l1.get(), address1_l1.get(), ns, false, false);
+
+    WHEN("Evaluating ptr1 == &value1")
+    {
+      const equal_exprt comparison{ptr1, address1};
+      const renamedt<exprt, L2> renamed_comparison =
+        state.rename(comparison, ns);
+      auto result = try_evaluate_pointer_comparisons(
+        renamed_comparison, value_set, ID_java, ns);
+      THEN("Evaluation succeeds")
+      {
+        REQUIRE(result.get() == true_exprt{});
+      }
+    }
+
+    WHEN("Evaluating ptr1 != &value1")
+    {
+      const notequal_exprt comparison{ptr1, address1};
+      const renamedt<exprt, L2> renamed_comparison =
+        state.rename(comparison, ns);
+      auto result = try_evaluate_pointer_comparisons(
+        renamed_comparison, value_set, ID_java, ns);
+      THEN("Evaluation succeeds")
+      {
+        REQUIRE(result.get() == false_exprt{});
+      }
+    }
+
+    WHEN("Evaluating ptr1 == ptr2")
+    {
+      const equal_exprt comparison{ptr1, ptr2};
+      const renamedt<exprt, L2> renamed_comparison =
+        state.rename(comparison, ns);
+      auto result = try_evaluate_pointer_comparisons(
+        renamed_comparison, value_set, ID_java, ns);
+      THEN("Evaluation leaves the expression unchanged")
+      {
+        REQUIRE(result.get() == renamed_comparison.get());
+      }
+    }
+  }
+
+  GIVEN(
+    "A value set in which pointer symbol `ptr1` can point to `&value1` or "
+    "`&value2`")
+  {
+    value_sett value_set;
+    const if_exprt if_expr{b, address1, address2};
+    const renamedt<exprt, L1> ptr1_l1 = state.rename<L1>(ptr1, ns);
+    const renamedt<exprt, L1> if_expr_l1 = state.rename<L1>(if_expr, ns);
+    // ptr1 <- b ? &value1 : &value2
+    value_set.assign(ptr1_l1.get(), if_expr_l1.get(), ns, false, false);
+
+    WHEN("Evaluating ptr1 == &value1")
+    {
+      const equal_exprt comparison{ptr1, address1};
+      const renamedt<exprt, L2> renamed_comparison =
+        state.rename(comparison, ns);
+      auto result = try_evaluate_pointer_comparisons(
+        renamed_comparison, value_set, ID_java, ns);
+      THEN("Evaluation leaves the expression unchanged")
+      {
+        REQUIRE(result.get() == renamed_comparison.get());
+      }
+    }
+  }
+}

--- a/unit/goto-symex/try_evaluate_pointer_comparisons.cpp
+++ b/unit/goto-symex/try_evaluate_pointer_comparisons.cpp
@@ -156,6 +156,58 @@ SCENARIO(
     }
   }
 
+  GIVEN(
+    "A value set in which pointer symbol `ptr1` can point to `&value1` or "
+    "`unknown`")
+  {
+    value_sett value_set;
+    const exprt unknown_expr{ID_unknown, ptr_type};
+    const if_exprt if_expr{b, address1, unknown_expr};
+    const renamedt<exprt, L1> ptr1_l1 = state.rename<L1>(ptr1, ns);
+    const renamedt<exprt, L1> if_expr_l1 = state.rename<L1>(if_expr, ns);
+    // ptr1 <- b ? &value1 : unknown
+    value_set.assign(ptr1_l1.get(), if_expr_l1.get(), ns, false, false);
+
+    WHEN("Evaluating ptr1 == &value1")
+    {
+      const equal_exprt comparison{ptr1, address1};
+      const renamedt<exprt, L2> renamed_comparison =
+        state.rename(comparison, ns);
+      auto result = try_evaluate_pointer_comparisons(
+        renamed_comparison, value_set, ID_java, ns);
+      THEN("Evaluation leaves the expression unchanged")
+      {
+        REQUIRE(result.get() == renamed_comparison.get());
+      }
+    }
+
+    WHEN("Evaluating ptr1 != &value1")
+    {
+      const notequal_exprt comparison{ptr1, address1};
+      const renamedt<exprt, L2> renamed_comparison =
+        state.rename(comparison, ns);
+      auto result = try_evaluate_pointer_comparisons(
+        renamed_comparison, value_set, ID_java, ns);
+      THEN("Evaluation leaves the expression unchanged")
+      {
+        REQUIRE(result.get() == renamed_comparison.get());
+      }
+    }
+
+    WHEN("Evaluating ptr1 != nullptr")
+    {
+      const notequal_exprt comparison{ptr1, null_ptr};
+      const renamedt<exprt, L2> renamed_comparison =
+        state.rename(comparison, ns);
+      auto result = try_evaluate_pointer_comparisons(
+        renamed_comparison, value_set, ID_java, ns);
+      THEN("Evaluation leaves the expression unchanged")
+      {
+        REQUIRE(result.get() == renamed_comparison.get());
+      }
+    }
+  }
+
   GIVEN("A struct whose first element can only point to `&value1`")
   {
     // member is `struct_symbol.pointer_field`

--- a/unit/goto-symex/try_evaluate_pointer_comparisons.cpp
+++ b/unit/goto-symex/try_evaluate_pointer_comparisons.cpp
@@ -38,6 +38,7 @@ SCENARIO(
   const symbol_exprt value2{"value2", int_type};
   const address_of_exprt address2{value2};
   const symbol_exprt b{"b", bool_typet{}};
+  const null_pointer_exprt null_ptr{ptr_type};
 
   // Add symbols to symbol table
   symbol_tablet symbol_table;
@@ -138,6 +139,19 @@ SCENARIO(
       THEN("Evaluation leaves the expression unchanged")
       {
         REQUIRE(result.get() == renamed_comparison.get());
+      }
+    }
+
+    WHEN("Evaluating ptr1 != nullptr")
+    {
+      const notequal_exprt comparison{ptr1, null_ptr};
+      const renamedt<exprt, L2> renamed_comparison =
+        state.rename(comparison, ns);
+      auto result = try_evaluate_pointer_comparisons(
+        renamed_comparison, value_set, ID_java, ns);
+      THEN("Evaluation succeeds")
+      {
+        REQUIRE(result.get() == true_exprt{});
       }
     }
   }

--- a/unit/goto-symex/try_evaluate_pointer_comparisons.cpp
+++ b/unit/goto-symex/try_evaluate_pointer_comparisons.cpp
@@ -127,6 +127,19 @@ SCENARIO(
         REQUIRE(result.get() == renamed_comparison.get());
       }
     }
+
+    WHEN("Evaluating ptr1 != &value1")
+    {
+      const notequal_exprt comparison{ptr1, address1};
+      const renamedt<exprt, L2> renamed_comparison =
+        state.rename(comparison, ns);
+      auto result = try_evaluate_pointer_comparisons(
+        renamed_comparison, value_set, ID_java, ns);
+      THEN("Evaluation leaves the expression unchanged")
+      {
+        REQUIRE(result.get() == renamed_comparison.get());
+      }
+    }
   }
 
   GIVEN("A struct whose first element can only point to `&value1`")


### PR DESCRIPTION
This adds some unit test for `try_evaluate_pointer_comparison`, then fix a small bug, and add an unit-test for the case that was buggy, then add some checks for an implicit invariant that I noticed while unit testing, and make value_sett::output more usable in particular for debugging unit tests. 

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
