### PR TITLE
Remove use of deprecated get_value_set function

### DIFF
--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -104,9 +104,8 @@ exprt value_set_dereferencet::dereference(const exprt &pointer)
 #endif
 
   // collect objects the pointer may point to
-  value_setst::valuest points_to_set;
-
-  dereference_callback.get_value_set(pointer, points_to_set);
+  const std::vector<exprt> points_to_set =
+    dereference_callback.get_value_set(pointer);
 
 #ifdef DEBUG
   std::cout << "value_set_dereferencet::dereference points_to_set={";


### PR DESCRIPTION
Use the version of get_value_set which returns the values.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
