### PR TITLE
Document field sensitivity class

### DIFF
--- a/doc/architectural/background-concepts.md
+++ b/doc/architectural/background-concepts.md
@@ -646,6 +646,10 @@ technique from an SSA compared to a CFG (or, even worse, an AST). That
 being said, the CPROVER framework takes a different route, opting to convert to
 intermediate representation known as GOTO programs instead.
 
+\subsection field_sensitivity_section Field Sensitivity
+
+\copydoc field_sensitivityt
+
 \section analysis_techniques_section Analysis techniques
 
 \subsection BMC_section Bounded model checking

--- a/src/goto-symex/field_sensitivity.h
+++ b/src/goto-symex/field_sensitivity.h
@@ -15,7 +15,36 @@ class namespacet;
 class goto_symex_statet;
 class symex_targett;
 
-/// \brief Control granularity of object accesses
+/// Control granularity of object accesses
+///
+/// [Field sensitivity](\ref field_sensitivityt) is a transformation of the
+/// instructions goto-program which mainly replaces some expressions by symbols
+/// but can also add assignments to the target equations produced by symbolic
+/// execution.
+/// The main goal of this transformation is to allow more constants to be
+/// propagated during symbolic execution.
+/// Note that field sensitivity is not applied as a single pass over the
+/// whole goto program but instead applied as the symbolic execution unfolds.
+///
+/// ### Member access
+/// A member expression `struct_expr.field_name` is replaced by the
+/// symbol `struct_expr..field_name`; note the use of `..` to visually
+/// distinguish the symbol from the member expression. This is valid for
+/// both lvalues and rvalues. See \ref field_sensitivityt::apply.
+///
+/// ### Symbols representing structs
+/// In an rvalue, a symbol struct_expr which has a struct type with fields
+/// field1, field2, etc, will be replaced by
+/// `{struct_expr..field_name1; struct_expr..field_name2; …}`.
+/// See \ref field_sensitivityt::get_fields.
+///
+/// ### Assignment to a struct
+/// When the symbol is on the left-hand-side, for instance for an assignment
+/// `struct_expr = other_struct`, the assignment is replaced by a sequence
+/// of assignments:
+/// `struct_expr..field_name1 = other_struct..field_name1;`
+/// `struct_expr..field_name2 = other_struct..field_name2;` etc.
+/// See \ref field_sensitivityt::field_assignments.
 class field_sensitivityt
 {
 public:

--- a/src/goto-symex/field_sensitivity.h
+++ b/src/goto-symex/field_sensitivity.h
@@ -26,6 +26,11 @@ class symex_targett;
 /// Note that field sensitivity is not applied as a single pass over the
 /// whole goto program but instead applied as the symbolic execution unfolds.
 ///
+/// On a high level, field sensitivity replaces member operators with atomic
+/// symbols representing a field when possible. In cases where this is not
+/// immediately possible, like struct assignments, some things need to be added.
+/// The possible cases are described below.
+///
 /// ### Member access
 /// A member expression `struct_expr.field_name` is replaced by the
 /// symbol `struct_expr..field_name`; note the use of `..` to visually


### PR DESCRIPTION
This gives an overview of how expressions are transformed by functions
from this class.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [na] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
