### PR TITLE
Make goto-gcc generate executables with execute permissions set on OSX

### DIFF
--- a/src/goto-cc/module_dependencies.txt
+++ b/src/goto-cc/module_dependencies.txt
@@ -6,4 +6,5 @@ jsil
 json
 langapi # should go away
 linking
+sys # system
 util


### PR DESCRIPTION
At the moment, if I just compile a simple hello world C program with goto-gcc on OSX, the resulting file is an executable, but can't actually be run until I chmod +x it. This is because the OSX `lipo` command doesn't set the permissions on its output file. One situation where this shows up is doing something like `./configure CC=goto-gcc` for a project on OSX will fail because goto-gcc (without this patch) will not produce a file that can be executed. This issue is specific to the production of hybrid goto/executable binaries on OSX - it works fine on linux.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
