### PR TITLE
Remove unused local variable

### DIFF
--- a/jbmc/src/java_bytecode/java_entry_point.cpp
+++ b/jbmc/src/java_bytecode/java_entry_point.cpp
@@ -510,9 +510,6 @@ main_function_resultt get_main_symbol(
   // find main symbol
   if(config.main.has_value())
   {
-    // Add java:: prefix
-    std::string main_identifier = "java::" + config.main.value();
-
     std::string error_message;
     irep_idt main_symbol_id = resolve_friendly_method_name(
       config.main.value(), symbol_table, error_message);


### PR DESCRIPTION
Unused legacy `main_identifier` can be removed.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.