### PR TITLE
Doc improvements to format_specifer

### DIFF
--- a/src/solvers/strings/format_specifier.cpp
+++ b/src/solvers/strings/format_specifier.cpp
@@ -27,8 +27,10 @@ static format_specifiert format_specifier_of_match(std::smatch &m)
   std::string flag = m[2].str();
   int width = m[3].str().empty() ? -1 : std::stoi(m[3].str());
   int precision = m[4].str().empty() ? -1 : std::stoi(m[4].str());
+  // `tT` values:  "t" = date/time, "T" = uppercase date/time
   std::string tT = m[5].str();
 
+  // date/time
   bool dt = !tT.empty();
   if(tT == "T")
     flag.push_back(format_specifiert::DATE_TIME_UPPER);
@@ -40,6 +42,8 @@ static format_specifiert format_specifier_of_match(std::smatch &m)
   return format_specifiert(index, flag, width, precision, dt, conversion);
 }
 
+/// Regexp is taken directly from openJDK implementation:
+///  http://hg.openjdk.java.net/jdk7/jdk7/jdk/file/9b8c96f96a0f/src/share/classes/java/util/Formatter.java#l2506
 std::vector<format_elementt> parse_format_string(std::string s)
 {
   const std::string format_specifier =

--- a/src/solvers/strings/format_specifier.cpp
+++ b/src/solvers/strings/format_specifier.cpp
@@ -23,6 +23,7 @@ Date:   June 2019
 ///   conversion type.
 static format_specifiert format_specifier_of_match(std::smatch &m)
 {
+  PRECONDITION(m.size() == 7);
   int index = m[1].str().empty() ? -1 : std::stoi(m[1].str());
   std::string flag = m[2].str();
   int width = m[3].str().empty() ? -1 : std::stoi(m[3].str());

--- a/src/solvers/strings/format_specifier.h
+++ b/src/solvers/strings/format_specifier.h
@@ -58,13 +58,13 @@ public:
     int _width,
     int _precision,
     bool _dt,
-    char c)
+    char conversion)
     : index(_index),
       flag(_flag),
       width(_width),
       precision(_precision),
       dt(_dt),
-      conversion(c)
+      conversion(conversion)
   {
   }
 };

--- a/src/solvers/strings/format_specifier.h
+++ b/src/solvers/strings/format_specifier.h
@@ -17,6 +17,8 @@ Author: Romain Brenguier, Joel Allred
 #include <vector>
 
 // Format specifier describes how a value should be printed.
+/// Field names follow the OpenJDK implementation:
+/// http://hg.openjdk.java.net/jdk7/jdk7/jdk/file/9b8c96f96a0f/src/share/classes/java/util/Formatter.java#l2569
 class format_specifiert
 {
 public:
@@ -49,6 +51,7 @@ public:
   std::string flag;
   int width;
   int precision;
+  // date/time
   bool dt = false;
   char conversion;
 


### PR DESCRIPTION
As requested in #4760.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
