### PR TITLE
Parse number ranges utility

### DIFF
--- a/src/util/format_number_range.cpp
+++ b/src/util/format_number_range.cpp
@@ -13,7 +13,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <sstream>
 #include <string>
 
+#include "exception_utils.h"
 #include "invariant.h"
+#include "optional.h"
 
 #include "format_number_range.h"
 
@@ -68,4 +70,80 @@ std::string format_number_range(const std::vector<unsigned> &input_numbers)
 
   POSTCONDITION(!number_range.str().empty());
   return number_range.str();
+}
+
+/// Appends \p number resp. numbers \p begin_range ... \p number to \p numbers
+static void append_numbers_and_reset(
+  const std::string &number_range,
+  std::vector<unsigned> &numbers,
+  optionalt<unsigned> &begin_range,
+  optionalt<unsigned> &number)
+{
+  if(!number.has_value() && begin_range.has_value())
+  {
+    throw deserialization_exceptiont(
+      "unterminated number range '" + std::to_string(*begin_range) + "-'");
+  }
+
+  if(!number.has_value())
+  {
+    throw deserialization_exceptiont(
+      "invalid number range '" + number_range + "'");
+  }
+
+  if(number.has_value() && begin_range.has_value())
+  {
+    if(*begin_range > *number)
+    {
+      throw deserialization_exceptiont(
+        "lower bound must not be larger than upper bound '" +
+        std::to_string(*begin_range) + "-" + std::to_string(*number) + "'");
+    }
+    for(unsigned i = *begin_range; i < *number; ++i)
+      numbers.push_back(i);
+    // add upper bound separately to avoid
+    // potential overflow issues in the loop above
+    numbers.push_back(*number);
+    begin_range = {};
+    number = {};
+  }
+  else if(number.has_value() && !begin_range.has_value())
+  {
+    numbers.push_back(*number);
+    number = {};
+  }
+}
+
+std::vector<unsigned> parse_number_range(const std::string &number_range)
+{
+  std::vector<unsigned> numbers;
+
+  optionalt<unsigned> begin_range;
+  optionalt<unsigned> number;
+  for(char c : number_range)
+  {
+    if('0' <= c && c <= '9')
+    {
+      if(!number.has_value())
+        number = 0;
+      *number = 10 * *number + (c - '0');
+    }
+    else if(c == ',')
+    {
+      append_numbers_and_reset(number_range, numbers, begin_range, number);
+    }
+    else if(c == '-')
+    {
+      begin_range = number;
+      number = {};
+    }
+    else
+    {
+      throw deserialization_exceptiont(
+        std::string("character '") + c + "' not allowed in number range");
+    }
+  }
+  append_numbers_and_reset(number_range, numbers, begin_range, number);
+
+  return numbers;
 }

--- a/src/util/format_number_range.h
+++ b/src/util/format_number_range.h
@@ -17,4 +17,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 std::string format_number_range(const std::vector<unsigned> &);
 
+/// Parse a compressed range into a vector of numbers,
+/// e.g. "2,4-6" -> [2,4,5,6]
+std::vector<unsigned> parse_number_range(const std::string &);
+
 #endif // CPROVER_UTIL_FORMAT_NUMBER_RANGE_H

--- a/unit/util/format_number_range.cpp
+++ b/unit/util/format_number_range.cpp
@@ -8,6 +8,7 @@ Author: Michael Tautschnig
 
 #include <testing-utils/use_catch.h>
 
+#include <util/exception_utils.h>
 #include <util/format_number_range.h>
 
 TEST_CASE(
@@ -34,4 +35,37 @@ TEST_CASE(
 
   const std::vector<unsigned> r6 = {1u, 10u, 11u, 12u, 42u, 43u, 44u};
   REQUIRE(format_number_range(r6) == "1,10-12,42-44");
+}
+
+TEST_CASE(
+  "Parse a range of unsigned numbers",
+  "[core][util][format_number_range]")
+{
+  const std::vector<unsigned> singleton = {1u};
+  REQUIRE(parse_number_range("1") == singleton);
+
+  const std::vector<unsigned> r1 = {0u, 42u};
+  REQUIRE(parse_number_range("0,42") == r1);
+
+  const std::vector<unsigned> r2 = {0u, 1u};
+  REQUIRE(parse_number_range("0,1") == r2);
+
+  const std::vector<unsigned> r3 = {1u, 2u, 3u};
+  REQUIRE(parse_number_range("1-3") == r3);
+
+  const std::vector<unsigned> r4 = {1u, 3u, 4u, 5u};
+  REQUIRE(parse_number_range("1,3-5") == r4);
+
+  const std::vector<unsigned> r5 = {1u, 10u, 11u, 12u, 42u};
+  REQUIRE(parse_number_range("1,10-12,42") == r5);
+
+  const std::vector<unsigned> r6 = {1u, 10u, 11u, 12u, 42u, 43u, 44u};
+  REQUIRE(parse_number_range("1,10-12,42-44") == r6);
+
+  REQUIRE_THROWS_AS(parse_number_range(""), deserialization_exceptiont);
+  REQUIRE_THROWS_AS(parse_number_range(","), deserialization_exceptiont);
+  REQUIRE_THROWS_AS(parse_number_range("1,"), deserialization_exceptiont);
+  REQUIRE_THROWS_AS(parse_number_range("0,1-"), deserialization_exceptiont);
+  REQUIRE_THROWS_AS(parse_number_range("1, 2"), deserialization_exceptiont);
+  REQUIRE_THROWS_AS(parse_number_range("4-2"), deserialization_exceptiont);
 }


### PR DESCRIPTION
As inverse to format_number_range

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
