### PR TITLE
Define remove_level_2 function and use it

### DIFF
--- a/src/goto-symex/goto_state.cpp
+++ b/src/goto-symex/goto_state.cpp
@@ -91,8 +91,7 @@ void goto_statet::apply_condition(
         previous_state.write_is_shared(ssa_lhs, ns) !=
           goto_symex_statet::write_is_shared_resultt::SHARED)
       {
-        ssa_exprt l1_lhs = ssa_lhs;
-        l1_lhs.remove_level_2();
+        const ssa_exprt l1_lhs = remove_level_2(ssa_lhs);
         const irep_idt &l1_identifier = l1_lhs.get_identifier();
 
         increase_generation(

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -219,9 +219,7 @@ renamedt<ssa_exprt, L2> goto_symex_statet::assignment(
     exprt l1_rhs(rhs);
     get_l1_name(l1_rhs);
 
-    ssa_exprt l1_lhs(lhs);
-    l1_lhs.remove_level_2();
-
+    const ssa_exprt l1_lhs = remove_level_2(lhs);
     if(run_validation_checks)
     {
       DATA_INVARIANT(!check_renaming_l1(l1_lhs), "lhs renaming failed on l1");
@@ -381,8 +379,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
   if(field_sensitivityt::is_divisible(expr))
     return false;
 
-  ssa_exprt ssa_l1=expr;
-  ssa_l1.remove_level_2();
+  const ssa_exprt ssa_l1 = remove_level_2(expr);
   const irep_idt &l1_identifier=ssa_l1.get_identifier();
   const exprt guard_as_expr = guard.as_expr();
 
@@ -527,10 +524,7 @@ bool goto_symex_statet::l2_thread_write_encoding(
     return false;
   case write_is_shared_resultt::IN_ATOMIC_SECTION:
   {
-    ssa_exprt ssa_l1 = expr;
-    ssa_l1.remove_level_2();
-
-    written_in_atomic_section[ssa_l1].push_back(guard);
+    written_in_atomic_section[remove_level_2(expr)].push_back(guard);
     return false;
   }
   case write_is_shared_resultt::SHARED:

--- a/src/goto-symex/partial_order_concurrency.cpp
+++ b/src/goto-symex/partial_order_concurrency.cpp
@@ -62,8 +62,7 @@ void partial_order_concurrencyt::add_init_writes(
 
       SSA_step.guard=true_exprt();
       // no SSA L2 index, thus nondet value
-      SSA_step.ssa_lhs=e_it->ssa_lhs;
-      SSA_step.ssa_lhs.remove_level_2();
+      SSA_step.ssa_lhs = remove_level_2(e_it->ssa_lhs);
       SSA_step.atomic_section_id=0;
     }
 

--- a/src/goto-symex/partial_order_concurrency.h
+++ b/src/goto-symex/partial_order_concurrency.h
@@ -92,9 +92,7 @@ protected:
   /// \return L1-renamed identifier
   irep_idt address(event_it event) const
   {
-    ssa_exprt tmp=event->ssa_lhs;
-    tmp.remove_level_2();
-    return tmp.get_identifier();
+    return remove_level_2(event->ssa_lhs).get_identifier();
   }
 
   typet clock_type;

--- a/src/util/ssa_expr.cpp
+++ b/src/util/ssa_expr.cpp
@@ -220,3 +220,9 @@ void ssa_exprt::update_identifier()
 {
   ::update_identifier(*this);
 }
+
+ssa_exprt remove_level_2(ssa_exprt ssa)
+{
+  ssa.remove_level_2();
+  return ssa;
+}

--- a/src/util/ssa_expr.h
+++ b/src/util/ssa_expr.h
@@ -138,4 +138,7 @@ inline ssa_exprt &to_ssa_expr(exprt &expr)
   return static_cast<ssa_exprt &>(expr);
 }
 
+/// \return \p ssa where level2 identifiers have been removed
+ssa_exprt remove_level_2(ssa_exprt ssa);
+
 #endif // CPROVER_UTIL_SSA_EXPR_H

--- a/src/util/ssa_expr.h
+++ b/src/util/ssa_expr.h
@@ -138,7 +138,7 @@ inline ssa_exprt &to_ssa_expr(exprt &expr)
   return static_cast<ssa_exprt &>(expr);
 }
 
-/// \return \p ssa where level2 identifiers have been removed
+/// \return copy of \p ssa where level2 identifiers have been removed
 ssa_exprt remove_level_2(ssa_exprt ssa);
 
 #endif // CPROVER_UTIL_SSA_EXPR_H


### PR DESCRIPTION
In several cases we make explicit copies in the code to be able to be
apply the mutating method. Having a function returning the new value
allows to simplify the code. std::move can be used on the argument to
get the same behaviour as the method.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
