### PR TITLE
Use format instead of from_expr in value_sett::output

### DIFF
--- a/src/pointer-analysis/module_dependencies.txt
+++ b/src/pointer-analysis/module_dependencies.txt
@@ -1,5 +1,4 @@
 analyses
 goto-programs
-langapi # should go away
 pointer-analysis
 util

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -16,12 +16,12 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/arith_tools.h>
 #include <util/c_types.h>
+#include <util/format_expr.h>
+#include <util/format_type.h>
 #include <util/pointer_offset_size.h>
 #include <util/prefix.h>
-#include <util/simplify_expr.h>
-
-#include <langapi/language_util.h>
 #include <util/range.h>
+#include <util/simplify_expr.h>
 
 #ifdef DEBUG
 #include <iostream>
@@ -133,7 +133,7 @@ bool value_sett::insert(
 }
 
 void value_sett::output(
-  const namespacet &ns,
+  const namespacet &,
   std::ostream &out,
   const std::string &indent) const
 {
@@ -174,29 +174,29 @@ void value_sett::output(
     {
       const exprt &o = object_numbering[o_it->first];
 
-      std::string result;
+      std::ostringstream stream;
 
       if(o.id() == ID_invalid || o.id() == ID_unknown)
-        result = from_expr(ns, identifier, o);
+        stream << format(o);
       else
       {
-        result = "<" + from_expr(ns, identifier, o) + ", ";
+        stream << "<" << format(o) << ", ";
 
         if(o_it->second)
-          result += integer2string(*o_it->second);
+          stream << *o_it->second;
         else
-          result += '*';
+          stream << '*';
 
         if(o.type().is_nil())
-          result += ", ?";
+          stream << ", ?";
         else
-          result += ", " + from_type(ns, identifier, o.type());
+          stream << ", " << format(o.type());
 
-        result += '>';
+        stream << '>';
       }
 
+      const std::string result = stream.str();
       out << result;
-
       width += result.size();
 
       object_map_dt::const_iterator next(o_it);

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -137,6 +137,11 @@ void value_sett::output(
   std::ostream &out,
   const std::string &indent) const
 {
+  output(out, indent);
+}
+
+void value_sett::output(std::ostream &out, const std::string &indent) const
+{
   values.iterate([&](const irep_idt &, const entryt &e) {
     irep_idt identifier, display_name;
 

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -313,9 +313,11 @@ public:
     bool add_to_sets);
 
   /// Pretty-print this value-set
-  /// \param ns: global namespace
   /// \param [out] out: stream to write to
   /// \param indent: string to use for indentation of the output
+  void output(std::ostream &out, const std::string &indent = "") const;
+
+  DEPRECATED(SINCE(2019, 06, 11, "Use the version without ns argument"))
   void output(
     const namespacet &ns,
     std::ostream &out,


### PR DESCRIPTION
This allow to get rid of some module dependency and avoid having to give a namespace argument.


<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
