### PR TITLE
Refactor building goto traces

### DIFF
--- a/src/goto-symex/build_goto_trace.h
+++ b/src/goto-symex/build_goto_trace.h
@@ -17,6 +17,41 @@ Date: July 2005
 #include "symex_target_equation.h"
 #include "goto_symex_state.h"
 
+typedef std::function<bool(
+  symex_target_equationt::SSA_stepst::const_iterator,
+  const decision_proceduret &)>
+  ssa_step_predicatet;
+
+struct goto_tracert
+{
+  goto_tracert(
+    const symex_target_equationt &target,
+    const decision_proceduret &decision_procedure,
+    const namespacet &ns)
+    : target(target), decision_procedure(decision_procedure), ns(ns)
+  {
+  }
+
+  goto_tracet build_trace(const ssa_step_predicatet &is_last_step_to_keep);
+
+private:
+  const symex_target_equationt &target;
+  const decision_proceduret &decision_procedure;
+  const namespacet &ns;
+
+  typedef symex_target_equationt::SSA_stepst::const_iterator ssa_step_iteratort;
+  typedef std::map<mp_integer, std::vector<ssa_step_iteratort>> time_mapt;
+  time_mapt time_map;
+  ssa_step_iteratort last_step_to_keep = target.SSA_steps.end();
+  bool last_step_was_kept = false;
+
+  void
+  fill_trace_step(const SSA_stept &SSA_step, goto_trace_stept &goto_trace_step);
+  void sort_steps(const ssa_step_predicatet &is_last_step_to_keep);
+
+  void step_shared(mp_integer &current_time, const ssa_step_iteratort &it);
+};
+
 /// Build a trace by going through the steps of \p target and stopping at the
 /// first failing assertion
 /// \param target: SSA form of the program
@@ -42,11 +77,6 @@ void build_goto_trace(
   const decision_proceduret &decision_procedure,
   const namespacet &ns,
   goto_tracet &goto_trace);
-
-typedef std::function<bool(
-  symex_target_equationt::SSA_stepst::const_iterator,
-  const decision_proceduret &)>
-  ssa_step_predicatet;
 
 /// Build a trace by going through the steps of \p target and stopping after
 /// the step matching a given condition


### PR DESCRIPTION
PR proposal for refactoring the construction of goto traces. Introduces a new structure `goto_tracert` that encapsulates the trace construction. The build-trace function is split into two screen-sized parts
1: sort SSA-steps (using the clock predicates)
2: fill trace-steps using SSA-steps.
If people think this refactor is worth the trouble, I would split it into commits to make it more clear that no functional change was introduced and add appropriate documentation.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
