### PR TITLE
Specify linux distribution trusty in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,7 @@ jobs:
     # Ubuntu Linux with glibc using g++-5
     - stage: Linter + Doxygen + non-debug Ubuntu/gcc-5 test
       os: linux
+      dist: trusty
       sudo: false
       compiler: gcc
       cache: ccache
@@ -127,6 +128,7 @@ jobs:
     # Ubuntu Linux with glibc using g++-5, debug mode
     - stage: Test different OS/CXX/Flags
       os: linux
+      dist: trusty
       sudo: false
       compiler: gcc
       cache: ccache
@@ -154,6 +156,7 @@ jobs:
     # Ubuntu Linux with glibc using clang++-7, debug mode, disable USE_DSTRING
     - stage: Test different OS/CXX/Flags
       os: linux
+      dist: trusty
       sudo: false
       compiler: clang
       cache: ccache
@@ -186,6 +189,7 @@ jobs:
     # cmake build using g++-7, enable NAMED_SUB_IS_FORWARD_LIST
     - stage: Test different OS/CXX/Flags
       os: linux
+      dist: trusty
       sudo: false
       compiler: gcc
       cache: ccache
@@ -214,6 +218,7 @@ jobs:
     # cmake build using g++-7, enable CMAKE_USE_CUDD and BDD_GUARDS
     - stage: Test different OS/CXX/Flags
       os: linux
+      dist: trusty
       sudo: false
       compiler: gcc
       cache: ccache
@@ -242,6 +247,7 @@ jobs:
     # cmake build using clang++-6
     - stage: Test different OS/CXX/Flags
       os: linux
+      dist: trusty
       sudo: false
       compiler: clang
       cache: ccache
@@ -300,6 +306,7 @@ jobs:
     - stage: Test different OS/CXX/Flags
       if: type = cron
       os: linux
+      dist: trusty
       sudo: false
       compiler: gcc
       cache: ccache


### PR DESCRIPTION
Currently no dist is specified and it defaults to trusty. Soon the
default will change to xenial. Specify it as trusty now so it doesn't
break when that happens.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
