### PR TITLE
Replace array if-exprts before giving to solver

### DIFF
--- a/src/solvers/strings/array_pool.cpp
+++ b/src/solvers/strings/array_pool.cpp
@@ -93,7 +93,9 @@ array_string_exprt array_poolt::make_char_array_for_char_pointer(
         to_array_type(t.type()).size(),
         to_array_type(f.type()).size()));
     // BEWARE: this expression is possibly type-inconsistent and must not be
-    // used for any purposes other than passing it to concretisation
+    // used for any purposes other than passing it to concretization.
+    // Array if-exprts must be replaced (using substitute_array_access) before
+    // passing the lemmas to the solver.
     return to_array_string_expr(if_exprt(if_expr.cond(), t, f, array_type));
   }
   const bool is_constant_array =

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -738,7 +738,9 @@ decision_proceduret::resultt string_refinementt::dec_solve()
   }
 
   for(const exprt &lemma : generator.constraints.existential)
-    add_lemma(lemma);
+  {
+    add_lemma(substitute_array_access(lemma, generator.fresh_symbol, true));
+  }
 
   // All generated strings should have non-negative length
   for(const auto &pair : generator.array_pool.created_strings())
@@ -785,7 +787,9 @@ decision_proceduret::resultt string_refinementt::dec_solve()
   const auto initial_instances =
     generate_instantiations(index_sets, axioms, not_contain_witnesses);
   for(const auto &instance : initial_instances)
-    add_lemma(instance);
+  {
+    add_lemma(substitute_array_access(instance, generator.fresh_symbol, true));
+  }
 
   while((loop_bound_--) > 0)
   {


### PR DESCRIPTION
This should allow us to remove all the `adjust_if_recursive` calls (https://github.com/diffblue/cbmc/pull/4653).

~Now based on #4805. Only review 2 last commits.~

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
