### PR TITLE
Extract string_concatenation_builtin_function in own file [TG-8152]

### DIFF
--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -164,13 +164,13 @@ SRC = $(BOOLEFORCE_SRC) \
       strings/format_specifier.cpp \
       strings/string_builtin_function.cpp \
       strings/string_dependencies.cpp \
+      strings/string_concatenation_builtin_function.cpp \
       strings/string_format_builtin_function.cpp \
       strings/string_refinement.cpp \
       strings/string_refinement_util.cpp \
       strings/string_constraint.cpp \
       strings/string_constraint_generator_code_points.cpp \
       strings/string_constraint_generator_comparison.cpp \
-      strings/string_constraint_generator_concat.cpp \
       strings/string_constraint_generator_constants.cpp \
       strings/string_constraint_generator_indexof.cpp \
       strings/string_constraint_generator_insert.cpp \

--- a/src/solvers/strings/string_builtin_function.cpp
+++ b/src/solvers/strings/string_builtin_function.cpp
@@ -37,21 +37,6 @@ string_insertion_builtin_functiont::string_insertion_builtin_functiont(
   args.insert(args.end(), fun_args.begin() + 5, fun_args.end());
 }
 
-string_concatenation_builtin_functiont::string_concatenation_builtin_functiont(
-  const exprt &return_code,
-  const std::vector<exprt> &fun_args,
-  array_poolt &array_pool)
-  : string_insertion_builtin_functiont(return_code, array_pool)
-{
-  PRECONDITION(fun_args.size() >= 4 && fun_args.size() <= 6);
-  const auto arg1 = expr_checked_cast<struct_exprt>(fun_args[2]);
-  input1 = array_pool.find(arg1.op1(), arg1.op0());
-  const auto arg2 = expr_checked_cast<struct_exprt>(fun_args[3]);
-  input2 = array_pool.find(arg2.op1(), arg2.op0());
-  result = array_pool.find(fun_args[1], fun_args[0]);
-  args.insert(args.end(), fun_args.begin() + 4, fun_args.end());
-}
-
 optionalt<std::vector<mp_integer>> eval_string(
   const array_string_exprt &a,
   const std::function<exprt(const exprt &)> &get_value)
@@ -102,62 +87,6 @@ array_string_exprt
 make_string(const std::vector<mp_integer> &array, const array_typet &array_type)
 {
   return make_string(array.begin(), array.end(), array_type);
-}
-
-std::vector<mp_integer> string_concatenation_builtin_functiont::eval(
-  const std::vector<mp_integer> &input1_value,
-  const std::vector<mp_integer> &input2_value,
-  const std::vector<mp_integer> &args_value) const
-{
-  const auto start_index =
-    args_value.size() > 0 && args_value[0] > 0 ? args_value[0] : mp_integer(0);
-  const mp_integer input2_size(input2_value.size());
-  const auto end_index =
-    args_value.size() > 1
-      ? std::max(std::min(args_value[1], input2_size), start_index)
-      : input2_size;
-
-  std::vector<mp_integer> eval_result(input1_value);
-  eval_result.insert(
-    eval_result.end(),
-    input2_value.begin() + numeric_cast_v<std::size_t>(start_index),
-    input2_value.begin() + numeric_cast_v<std::size_t>(end_index));
-  return eval_result;
-}
-
-string_constraintst string_concatenation_builtin_functiont::constraints(
-  string_constraint_generatort &generator) const
-
-{
-  auto pair = [&]() -> std::pair<exprt, string_constraintst> {
-    if(args.size() == 0)
-      return add_axioms_for_concat(
-        generator.fresh_symbol, result, input1, input2, array_pool);
-    if(args.size() == 2)
-    {
-      return add_axioms_for_concat_substr(
-        generator.fresh_symbol,
-        result,
-        input1,
-        input2,
-        args[0],
-        args[1],
-        array_pool);
-    }
-    UNREACHABLE;
-  }();
-  pair.second.existential.push_back(equal_exprt(pair.first, return_code));
-  return pair.second;
-}
-
-exprt string_concatenation_builtin_functiont::length_constraint() const
-{
-  if(args.size() == 0)
-    return length_constraint_for_concat(result, input1, input2, array_pool);
-  if(args.size() == 2)
-    return length_constraint_for_concat_substr(
-      result, input1, input2, args[0], args[1], array_pool);
-  UNREACHABLE;
 }
 
 optionalt<exprt> string_concat_char_builtin_functiont::eval(

--- a/src/solvers/strings/string_builtin_function.h
+++ b/src/solvers/strings/string_builtin_function.h
@@ -340,36 +340,6 @@ protected:
   }
 };
 
-class string_concatenation_builtin_functiont final
-  : public string_insertion_builtin_functiont
-{
-public:
-  /// Constructor from arguments of a function application.
-  /// The arguments in `fun_args` should be in order:
-  /// an integer `result.length`, a character pointer `&result[0]`,
-  /// a string `arg1` of type refined_string_typet,
-  /// a string `arg2` of type refined_string_typet,
-  /// optionally followed by an integer `start` and an integer `end`.
-  string_concatenation_builtin_functiont(
-    const exprt &return_code,
-    const std::vector<exprt> &fun_args,
-    array_poolt &array_pool);
-
-  std::vector<mp_integer> eval(
-    const std::vector<mp_integer> &input1_value,
-    const std::vector<mp_integer> &input2_value,
-    const std::vector<mp_integer> &args_value) const override;
-
-  std::string name() const override
-  {
-    return "concat";
-  }
-
-  string_constraintst
-  constraints(string_constraint_generatort &generator) const override;
-
-  exprt length_constraint() const override;
-};
 
 /// String creation from other types
 class string_creation_builtin_functiont : public string_builtin_functiont

--- a/src/solvers/strings/string_concatenation_builtin_function.h
+++ b/src/solvers/strings/string_concatenation_builtin_function.h
@@ -1,0 +1,48 @@
+/*******************************************************************\
+
+Module: Builtin functions for string concatenations
+
+Author: Romain Brenguier, Joel Allred
+
+\*******************************************************************/
+
+/// \file
+/// Builtin functions for string concatenations
+
+#ifndef CPROVER_SOLVERS_STRINGS_STRING_CONCATENATION_BUILTIN_FUNCTION_H
+#define CPROVER_SOLVERS_STRINGS_STRING_CONCATENATION_BUILTIN_FUNCTION_H
+
+#include "string_builtin_function.h"
+
+class string_concatenation_builtin_functiont final
+  : public string_insertion_builtin_functiont
+{
+public:
+  /// Constructor from arguments of a function application.
+  /// The arguments in `fun_args` should be in order:
+  /// an integer `result.length`, a character pointer `&result[0]`,
+  /// a string `arg1` of type refined_string_typet,
+  /// a string `arg2` of type refined_string_typet,
+  /// optionally followed by an integer `start` and an integer `end`.
+  string_concatenation_builtin_functiont(
+    const exprt &return_code,
+    const std::vector<exprt> &fun_args,
+    array_poolt &array_pool);
+
+  std::vector<mp_integer> eval(
+    const std::vector<mp_integer> &input1_value,
+    const std::vector<mp_integer> &input2_value,
+    const std::vector<mp_integer> &args_value) const override;
+
+  std::string name() const override
+  {
+    return "concat";
+  }
+
+  string_constraintst
+  constraints(string_constraint_generatort &generator) const override;
+
+  exprt length_constraint() const override;
+};
+
+#endif // CPROVER_SOLVERS_STRINGS_STRING_CONCATENATION_BUILTIN_FUNCTION_H

--- a/src/solvers/strings/string_dependencies.cpp
+++ b/src/solvers/strings/string_dependencies.cpp
@@ -7,6 +7,7 @@ Author: Diffblue Ltd.
 \*******************************************************************/
 
 #include "string_dependencies.h"
+#include "string_concatenation_builtin_function.h"
 #include "string_format_builtin_function.h"
 #include <unordered_set>
 #include <util/expr_iterator.h>


### PR DESCRIPTION
`string_builtin_function.cpp` is too large.

Concatenation functions can live directly in the `string_concatenation_builtin_function` file, which avoids having dependencies

Progressively doing this for all string functions to get rid of all the `string_constraint_generator_*` files and have a clear entry point for string constraints, namely the string builtin functions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
