### PR TITLE
fix result type of instanceof

### DIFF
--- a/jbmc/src/java_bytecode/bytecode_info.cpp
+++ b/jbmc/src/java_bytecode/bytecode_info.cpp
@@ -208,7 +208,7 @@ struct bytecode_infot const bytecode_info[]=
 { "arraylength",    0xbe, ' ', 1, 1, 'i' }, // arrayref → length; get the length of an array  NOLINT(*)
 { "athrow",         0xbf, ' ', 1, 1, ' ' }, // objectref → [empty], objectref; throws an error or exception (notice that the rest of the stack is cleared, leaving only a reference to the Throwable)  NOLINT(*)
 { "checkcast",      0xc0, 'C', 1, 1, 'a' }, // objectref → objectref; checks whether an objectref is of a certain type, the class reference of which is in the constant pool at index (indexbyte1 << 8 + indexbyte2)  NOLINT(*)
-{ "instanceof",     0xc1, 'C', 1, 1, ' ' }, // objectref → result; determines if an object objectref is of a given type, identified by class reference index in constant pool (indexbyte1 << 8 + indexbyte2)  NOLINT(*)
+{ "instanceof",     0xc1, 'C', 1, 1, 'i' }, // objectref → result; determines if an object objectref is of a given type, identified by class reference index in constant pool (indexbyte1 << 8 + indexbyte2)  NOLINT(*)
 { "monitorenter",   0xc2, ' ', 1, 0, ' ' }, // objectref →; enter monitor for object ("grab the lock" - start of synchronized() section)  NOLINT(*)
 { "monitorexit",    0xc3, ' ', 1, 0, ' ' }, // objectref →; exit monitor for object ("release the lock" - end of synchronized() section)  NOLINT(*)
 { "wide",           0xc4, ' ', 0, 0, ' ' }, // modifier for others  NOLINT(*)


### PR DESCRIPTION
`instanceof` pushes an integer onto the stack,
which is result type `'i'`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
