### PR TITLE
Use global symbol generator in substitute_array_access

### DIFF
--- a/src/solvers/strings/string_refinement.h
+++ b/src/solvers/strings/string_refinement.h
@@ -129,8 +129,7 @@ union_find_replacet string_identifiers_resolution_from_equations(
 // Declaration required for unit-test:
 exprt substitute_array_access(
   exprt expr,
-  const std::function<symbol_exprt(const irep_idt &, const typet &)>
-    &symbol_generator,
+  symbol_generatort &symbol_generator,
   const bool left_propagate);
 
 #endif


### PR DESCRIPTION
Using a const symbol generator doesn't make sense and results in several symbols having the same name, thus messing up the bool_bv map.

There are no regression tests as the problem is not visible at the moment, but this fix prevents issues with more extensive usage of `substitute_array_access`, as experienced in https://github.com/diffblue/cbmc/pull/4798.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
