### PR TITLE
Allow zipped ranges to have different sizes

### DIFF
--- a/src/util/range.h
+++ b/src/util/range.h
@@ -267,9 +267,14 @@ private:
 
 /// Zip two ranges to make a range of pairs.
 /// On increment, both iterators are incremented.
-/// Ends when the two ranges reach their ends.
-/// Invariants are checking that one does not end before the other.
-template <typename first_iteratort, typename second_iteratort>
+/// Ends when both of the two ranges reach their end if \p same_size is true,
+/// when one of the two ranges ends otherwise.
+/// \tparam same_size: if true invariants are checking that one range does not
+///     end before the other
+template <
+  typename first_iteratort,
+  typename second_iteratort,
+  bool same_size = true>
 struct zip_iteratort
 {
 public:
@@ -283,6 +288,9 @@ public:
 
   bool operator==(const zip_iteratort &other) const
   {
+    if(!same_size && end_reached() && other.end_reached())
+      return true;
+
     return first_begin == other.first_begin && first_end == other.first_end &&
            second_begin == other.second_begin && second_end == other.second_end;
   }
@@ -299,9 +307,10 @@ public:
     ++first_begin;
     ++second_begin;
     INVARIANT(
-      (first_begin == first_end) == (second_begin == second_end),
+      !same_size ||
+        ((first_begin == first_end) == (second_begin == second_end)),
       "Zipped ranges should have the same size");
-    current = first_begin != first_end
+    current = !end_reached()
                 ? std::make_shared<value_type>(*first_begin, *second_begin)
                 : nullptr;
     return *this;
@@ -336,7 +345,9 @@ public:
       second_begin(std::move(_second_begin)),
       second_end(std::move(_second_end))
   {
-    PRECONDITION((first_begin == first_end) == (second_begin == second_end));
+    PRECONDITION(
+      !same_size ||
+      ((first_begin == first_end) == (second_begin == second_end)));
     if(first_begin != first_end)
       current = util_make_unique<value_type>(*first_begin, *second_begin);
   }
@@ -347,6 +358,19 @@ private:
   second_iteratort second_begin;
   second_iteratort second_end;
   std::shared_ptr<value_type> current = nullptr;
+
+  bool end_reached() const
+  {
+    if(same_size)
+    {
+      INVARIANT(
+        (first_begin == first_end) == (second_begin == second_end),
+        "Zip ranges should have same size");
+      return first_begin == first_end;
+    }
+    else
+      return first_begin == first_end || second_begin == second_end;
+  }
 };
 
 /// A range is a pair of a begin and an end iterators.
@@ -421,23 +445,23 @@ public:
       concat_begin, concat_end);
   }
 
-  template <typename other_iteratort>
-  ranget<zip_iteratort<iteratort, other_iteratort>>
+  template <bool same_size = true, typename other_iteratort>
+  ranget<zip_iteratort<iteratort, other_iteratort, same_size>>
   zip(ranget<other_iteratort> other)
   {
-    auto zip_begin = zip_iteratort<iteratort, other_iteratort>(
+    auto zip_begin = zip_iteratort<iteratort, other_iteratort, same_size>(
       begin(), end(), other.begin(), other.end());
-    auto zip_end = zip_iteratort<iteratort, other_iteratort>(
+    auto zip_end = zip_iteratort<iteratort, other_iteratort, same_size>(
       end(), end(), other.end(), other.end());
-    return ranget<zip_iteratort<iteratort, other_iteratort>>(
+    return ranget<zip_iteratort<iteratort, other_iteratort, same_size>>(
       zip_begin, zip_end);
   }
 
-  template <typename containert>
+  template <bool same_size = true, typename containert>
   auto zip(containert &container)
-    -> ranget<zip_iteratort<iteratort, decltype(container.begin())>>
+    -> ranget<zip_iteratort<iteratort, decltype(container.begin()), same_size>>
   {
-    return zip(
+    return zip<same_size>(
       ranget<decltype(container.begin())>{container.begin(), container.end()});
   }
 

--- a/src/util/range.h
+++ b/src/util/range.h
@@ -303,7 +303,7 @@ public:
   /// Preincrement operator
   zip_iteratort &operator++()
   {
-    PRECONDITION(first_begin != first_end && second_begin != second_end);
+    PRECONDITION(!end_reached());
     ++first_begin;
     ++second_begin;
     INVARIANT(

--- a/src/util/range.h
+++ b/src/util/range.h
@@ -445,6 +445,9 @@ public:
       concat_begin, concat_end);
   }
 
+  /// Combine two ranges to make a range over pairs
+  /// \tparam same_size: if true, cause an invariant violation in case the end
+  ///   is not reached simultaneously for both ranges
   template <bool same_size = true, typename other_iteratort>
   ranget<zip_iteratort<iteratort, other_iteratort, same_size>>
   zip(ranget<other_iteratort> other)

--- a/unit/util/range.cpp
+++ b/unit/util/range.cpp
@@ -189,7 +189,7 @@ SCENARIO("range tests", "[core][util][range]")
       REQUIRE(input2 == expected_result2);
     }
   }
-  GIVEN("A vectors of int and a list of strings.")
+  GIVEN("A vectors of int and a list of strings of same sizes.")
   {
     std::vector<int> int_vector{1, 2};
     std::list<std::string> string_list{"foo", "bar"};
@@ -217,7 +217,7 @@ SCENARIO("range tests", "[core][util][range]")
       }
     }
   }
-  GIVEN("A constant vectors of int and a list of strings.")
+  GIVEN("A constant vectors of int and a list of strings of same sizes.")
   {
     const std::vector<int> int_vector{41, 27};
     const std::list<std::string> string_list{"boo", "far"};
@@ -245,11 +245,11 @@ SCENARIO("range tests", "[core][util][range]")
       }
     }
   }
-  GIVEN("Two vectors of different sizes.")
+  GIVEN("Two vectors, where the first is shorter.")
   {
     const std::vector<int> int_vector{814, 51};
     const std::vector<std::string> string_vector{"foo", "bar", "baz", "bay"};
-    WHEN("We zip the vectors")
+    WHEN("We zip the vectors with same_size=false")
     {
       auto range = make_range(int_vector).zip<false>(string_vector);
       REQUIRE(!range.empty());
@@ -275,6 +275,93 @@ SCENARIO("range tests", "[core][util][range]")
       {
         REQUIRE(third_range.begin() != second_range.begin());
         REQUIRE(third_range.empty());
+      }
+    }
+    WHEN("We zip the vectors with same_size=true")
+    {
+      auto range = make_range(int_vector).zip<true>(string_vector);
+      REQUIRE(!range.empty());
+      THEN("First pair is (814, foo)")
+      {
+        const std::pair<int, std::string> first_pair = *range.begin();
+        REQUIRE(first_pair.first == 814);
+        REQUIRE(first_pair.second == "foo");
+      }
+      auto second_range = range.drop(1);
+      THEN("Begin iterator when first element is dropped is different")
+      {
+        REQUIRE(second_range.begin() != range.begin());
+      }
+      THEN("Second pair is (51, bar)")
+      {
+        const std::pair<int, std::string> second_pair = *second_range.begin();
+        REQUIRE(second_pair.first == 51);
+        REQUIRE(second_pair.second == "bar");
+      }
+      THEN("An invariant throw as we reach the end of the first range")
+      {
+        cbmc_invariants_should_throwt invariants_throw;
+        REQUIRE_THROWS_AS(second_range.drop(1), invariant_failedt);
+      }
+    }
+  }
+  GIVEN("Two vectors, where the second is shorter.")
+  {
+    const std::vector<std::string> string_vector{"foo", "bar", "baz", "bay"};
+    const std::vector<int> int_vector{814, 51};
+    WHEN("We zip the vectors with same_size=false")
+    {
+      auto range = make_range(string_vector).zip<false>(int_vector);
+      REQUIRE(!range.empty());
+      THEN("First pair is (foo, 814)")
+      {
+        const std::pair<std::string, int> first_pair = *range.begin();
+        REQUIRE(first_pair.first == "foo");
+        REQUIRE(first_pair.second == 814);
+      }
+      auto second_range = range.drop(1);
+      THEN("Begin iterator when first element is dropped is different")
+      {
+        REQUIRE(second_range.begin() != range.begin());
+      }
+      THEN("Second pair is (51, bar)")
+      {
+        const std::pair<std::string, int> second_pair = *second_range.begin();
+        REQUIRE(second_pair.first == "bar");
+        REQUIRE(second_pair.second == 51);
+      }
+      auto third_range = second_range.drop(1);
+      THEN("Range is empty")
+      {
+        REQUIRE(third_range.begin() != second_range.begin());
+        REQUIRE(third_range.empty());
+      }
+    }
+    WHEN("We zip the vectors with same_size=true")
+    {
+      auto range = make_range(string_vector).zip<true>(int_vector);
+      REQUIRE(!range.empty());
+      THEN("First pair is (foo, 814)")
+      {
+        const std::pair<std::string, int> first_pair = *range.begin();
+        REQUIRE(first_pair.first == "foo");
+        REQUIRE(first_pair.second == 814);
+      }
+      auto second_range = range.drop(1);
+      THEN("Begin iterator when first element is dropped is different")
+      {
+        REQUIRE(second_range.begin() != range.begin());
+      }
+      THEN("Second pair is (bar, 51)")
+      {
+        const std::pair<std::string, int> second_pair = *second_range.begin();
+        REQUIRE(second_pair.first == "bar");
+        REQUIRE(second_pair.second == 51);
+      }
+      THEN("An invariant throw as we reach the end of the first range")
+      {
+        cbmc_invariants_should_throwt invariants_throw;
+        REQUIRE_THROWS_AS(second_range.drop(1), invariant_failedt);
       }
     }
   }

--- a/unit/util/range.cpp
+++ b/unit/util/range.cpp
@@ -245,6 +245,39 @@ SCENARIO("range tests", "[core][util][range]")
       }
     }
   }
+  GIVEN("Two vectors of different sizes.")
+  {
+    const std::vector<int> int_vector{814, 51};
+    const std::vector<std::string> string_vector{"foo", "bar", "baz", "bay"};
+    WHEN("We zip the vectors")
+    {
+      auto range = make_range(int_vector).zip<false>(string_vector);
+      REQUIRE(!range.empty());
+      THEN("First pair is (814, foo)")
+      {
+        const std::pair<int, std::string> first_pair = *range.begin();
+        REQUIRE(first_pair.first == 814);
+        REQUIRE(first_pair.second == "foo");
+      }
+      auto second_range = range.drop(1);
+      THEN("Begin iterator when first element is dropped is different")
+      {
+        REQUIRE(second_range.begin() != range.begin());
+      }
+      THEN("Second pair is (51, bar)")
+      {
+        const std::pair<int, std::string> second_pair = *second_range.begin();
+        REQUIRE(second_pair.first == 51);
+        REQUIRE(second_pair.second == "bar");
+      }
+      auto third_range = second_range.drop(1);
+      THEN("Range is empty")
+      {
+        REQUIRE(third_range.begin() != second_range.begin());
+        REQUIRE(third_range.empty());
+      }
+    }
+  }
 }
 
 class move_onlyt


### PR DESCRIPTION
This adds a template argument with which we can allow ranges to have different sizes, in which case the end of the zip result is defined by the first of the two ranges ending.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
