### PR TITLE
Fix missing base report in codecov

### DIFF
--- a/buildspec-linux-make-gcc-cov.yml
+++ b/buildspec-linux-make-gcc-cov.yml
@@ -32,7 +32,8 @@ phases:
       - make -C jbmc/unit test
       - make -C jbmc/regression test
       - lcov --capture --directory . --output-file ./lcov.info
-      - VCS_PULL_REQUEST=$(echo $CODEBUILD_SOURCE_VERSION | sed 's/pr\///g')
+      # If $CODEBUILD_SOURCE_VERSION starts with 'pr/', filter out pr number, if not, return empty
+      - VCS_PULL_REQUEST=$(echo $CODEBUILD_SOURCE_VERSION | sed '/^pr\//!d;s/^pr\///')
       - COV_SCRIPT=/root/.cache/codecov.sh
       - if [ ! -f "$COV_SCRIPT" ]; then curl -s https://codecov.io/bash > "$COV_SCRIPT"; fi
       - echo "$CODEBUILD_INITIATOR" | grep GitHub && bash "$COV_SCRIPT" -t "$CODECOV_TOKEN" || true      


### PR DESCRIPTION
Currently codecov is missing base report, because merge PR uses commit not PR.
So the regex for sed is modified to choose only PR. I'd like to credit that improved regex is by @LAJW. 

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- N/A Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- N/A The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- N/A Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- N/A My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
