### PR TITLE
Fixed out of link for pages that used to be in modeling folder

### DIFF
--- a/doc/cprover-manual/api.md
+++ b/doc/cprover-manual/api.md
@@ -18,7 +18,7 @@ void assert(_Bool assertion);
 The function **\_\_CPROVER\_assume** adds an expression as a constraint
 to the program. If the expression evaluates to false, the execution
 aborts without failure. More detail on the use of assumptions is in the
-section on [Assumptions](../modeling/assumptions/).
+section on [Assumptions](./modeling-assumptions.md).
 
 #### \_\_CPROVER\_r_ok, \_\_CPROVER\_w_ok
 
@@ -58,7 +58,7 @@ The functions **\_\_CPROVER\_input** and **\_\_CPROVER\_output** are
 used to report an input or output value. Note that they do not generate
 input or output values. The first argument is a string constant to
 distinguish multiple inputs and outputs (inputs are typically generated
-using nondeterminism, as described [here](../modeling/nondeterminism/)). The
+using nondeterminism, as described [here](./modeling-nondeterminism.md)). The
 string constant is followed by an arbitrary number of values of
 arbitrary types.
 
@@ -154,7 +154,7 @@ the array **dest** with the given value.
 
 #### Uninterpreted Functions
 
-Uninterpreted functions are documented [here](../modeling/nondeterminism/)).
+Uninterpreted functions are documented [here](./modeling-nondeterminism.md)).
 
 ### Predefined Types and Symbols
 

--- a/doc/cprover-manual/cbmc-assertions.md
+++ b/doc/cprover-manual/cbmc-assertions.md
@@ -33,7 +33,7 @@ properties together with the condition.
 
 The assertion language of the CPROVER tools is identical to the language
 used for expressions.  Note that
-[nondeterminism](../../modeling-nondeterminism/) can be exploited in order
+[nondeterminism](./modeling-nondeterminism.md) can be exploited in order
 to check a range of choices.  As an example, the following code fragment
 asserts that **all** elements of the array are zero:
 


### PR DESCRIPTION
Fixed links as follow:
modeling/assumptions -> modeling-assumptions.md
modeling/nondeterminism -> modeling-nondeterminism.md

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- N/A Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- N/A The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- N/A Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- N/A My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- N/A White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
