### PR TITLE
satcheck_minisat2 assumptions bug fix and unit tests

### DIFF
--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -328,14 +328,16 @@ bool satcheck_minisat2_baset<T>::is_in_conflict(literalt a) const
 template<typename T>
 void satcheck_minisat2_baset<T>::set_assumptions(const bvt &bv)
 {
-  assumptions=bv;
-
-  forall_literals(it, assumptions)
-    if(it->is_true())
+  // We filter out 'true' assumptions which cause an assertion violation
+  // in Minisat2.
+  assumptions.clear();
+  for(const auto &assumption : bv)
+  {
+    if(!assumption.is_true())
     {
-      assumptions.clear();
-      break;
+      assumptions.push_back(assumption);
     }
+  }
 }
 
 satcheck_minisat_no_simplifiert::satcheck_minisat_no_simplifiert(

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -185,8 +185,13 @@ propt::resultt satcheck_minisat2_baset<T>::do_prop_solve()
       bool has_false=false;
 
       forall_literals(it, assumptions)
+      {
         if(it->is_false())
-          has_false=true;
+        {
+          has_false = true;
+          break;
+        }
+      }
 
       if(has_false)
       {

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -45,6 +45,7 @@ SRC += analyses/ai/ai.cpp \
        solvers/floatbv/float_utils.cpp \
        solvers/lowering/byte_operators.cpp \
        solvers/prop/bdd_expr.cpp \
+       solvers/sat/satcheck_minisat2.cpp \
        solvers/strings/array_pool/array_pool.cpp \
        solvers/strings/string_constraint_generator_valueof/calculate_max_string_length.cpp \
        solvers/strings/string_constraint_generator_valueof/get_numeric_value_from_character.cpp \

--- a/unit/solvers/sat/module_dependencies.txt
+++ b/unit/solvers/sat/module_dependencies.txt
@@ -1,0 +1,4 @@
+solvers/prop
+solvers/sat
+testing-utils
+util

--- a/unit/solvers/sat/satcheck_minisat2.cpp
+++ b/unit/solvers/sat/satcheck_minisat2.cpp
@@ -1,0 +1,86 @@
+/*******************************************************************\
+
+Module: Unit tests for satcheck_minisat2
+
+Author: Peter Schrammel
+
+\*******************************************************************/
+
+/// \file
+/// Unit tests for satcheck_minisat2
+
+#ifdef HAVE_MINISAT2
+
+#  include <testing-utils/use_catch.h>
+
+#  include <solvers/prop/literal.h>
+#  include <solvers/sat/satcheck_minisat2.h>
+#  include <util/cout_message.h>
+
+SCENARIO("satcheck_minisat2", "[core][solvers][sat][satcheck_minisat2]")
+{
+  console_message_handlert message_handler;
+
+  GIVEN("A satisfiable formula f")
+  {
+    satcheck_minisat_no_simplifiert satcheck(message_handler);
+    literalt f = satcheck.new_variable();
+    satcheck.l_set_to_true(f);
+
+    THEN("is indeed satisfiable")
+    {
+      REQUIRE(satcheck.prop_solve() == propt::resultt::P_SATISFIABLE);
+    }
+    THEN("is unsatisfiable under a false assumption")
+    {
+      bvt assumptions;
+      assumptions.push_back(const_literal(false));
+      satcheck.set_assumptions(assumptions);
+      REQUIRE(satcheck.prop_solve() == propt::resultt::P_UNSATISFIABLE);
+    }
+  }
+
+  GIVEN("An unsatisfiable formula f && !f")
+  {
+    satcheck_minisat_no_simplifiert satcheck(message_handler);
+    literalt f = satcheck.new_variable();
+    satcheck.l_set_to_true(satcheck.land(f, !f));
+
+    THEN("is indeed unsatisfiable")
+    {
+      REQUIRE(satcheck.prop_solve() == propt::resultt::P_UNSATISFIABLE);
+    }
+  }
+
+  GIVEN("An unsatisfiable formula false implied by a")
+  {
+    satcheck_minisat_no_simplifiert satcheck(message_handler);
+    literalt a = satcheck.new_variable();
+    literalt a_implies_false = satcheck.lor(!a, const_literal(false));
+    satcheck.l_set_to_true(a_implies_false);
+
+    THEN("is indeed unsatisfiable under assumption a")
+    {
+      bvt assumptions;
+      assumptions.push_back(a);
+      satcheck.set_assumptions(assumptions);
+      REQUIRE(satcheck.prop_solve() == propt::resultt::P_UNSATISFIABLE);
+    }
+    THEN("is still unsatisfiable under assumption a and true")
+    {
+      bvt assumptions;
+      assumptions.push_back(const_literal(true));
+      assumptions.push_back(a);
+      satcheck.set_assumptions(assumptions);
+      REQUIRE(satcheck.prop_solve() == propt::resultt::P_UNSATISFIABLE);
+    }
+    THEN("becomes satisfiable when assumption a is lifted")
+    {
+      bvt assumptions;
+      satcheck.set_assumptions(assumptions);
+      REQUIRE(satcheck.prop_solve() == propt::resultt::P_SATISFIABLE);
+    }
+  }
+}
+
+#endif


### PR DESCRIPTION
Fix an assumption bug and adds unit tests to verify some basic behaviours w/wo assumptions

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
