### PR TITLE
Make increase generation a method of symex_level2t

### DIFF
--- a/src/goto-symex/goto_state.cpp
+++ b/src/goto-symex/goto_state.cpp
@@ -26,27 +26,6 @@ void goto_statet::output_propagation_map(std::ostream &out)
   }
 }
 
-std::size_t goto_statet::increase_generation(
-  const irep_idt l1_identifier,
-  const ssa_exprt &lhs,
-  std::function<std::size_t(const irep_idt &)> fresh_l2_name_provider)
-{
-  const std::size_t n = fresh_l2_name_provider(l1_identifier);
-
-  if(const auto r_opt = level2.current_names.find(l1_identifier))
-  {
-    std::pair<ssa_exprt, std::size_t> copy = r_opt->get();
-    copy.second = n;
-    level2.current_names.replace(l1_identifier, std::move(copy));
-  }
-  else
-  {
-    level2.current_names.insert(l1_identifier, std::make_pair(lhs, n));
-  }
-
-  return n;
-}
-
 /// Given a condition that must hold on this path, propagate as much knowledge
 /// as possible. For example, if the condition is (x == 5), whether that's an
 /// assumption or a GOTO condition that we just passed through, we can propagate
@@ -92,7 +71,7 @@ void goto_statet::apply_condition(
         const ssa_exprt l1_lhs = remove_level_2(ssa_lhs);
         const irep_idt &l1_identifier = l1_lhs.get_identifier();
 
-        increase_generation(
+        level2.increase_generation(
           l1_identifier, l1_lhs, previous_state.get_l2_name_provider());
 
         const auto propagation_entry = propagation.find(l1_identifier);

--- a/src/goto-symex/goto_state.h
+++ b/src/goto-symex/goto_state.h
@@ -81,11 +81,6 @@ public:
     const exprt &condition, // L2
     const goto_symex_statet &previous_state,
     const namespacet &ns);
-
-  std::size_t increase_generation(
-    const irep_idt l1_identifier,
-    const ssa_exprt &lhs,
-    std::function<std::size_t(const irep_idt &)> fresh_l2_name_provider);
 };
 
 #endif // CPROVER_GOTO_SYMEX_GOTO_STATE_H

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -184,7 +184,7 @@ renamedt<ssa_exprt, L2> goto_symex_statet::assignment(
 #endif
 
   // do the l2 renaming
-  increase_generation(l1_identifier, lhs);
+  level2.increase_generation(l1_identifier, lhs, fresh_l2_name_provider);
   renamedt<ssa_exprt, L2> l2_lhs = set_indices<L2>(std::move(lhs), ns);
   lhs = l2_lhs.get();
 
@@ -435,7 +435,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
 
     if(a_s_read.second.empty())
     {
-      increase_generation(l1_identifier, ssa_l1);
+      level2.increase_generation(l1_identifier, ssa_l1, fresh_l2_name_provider);
       a_s_read.first = level2.latest_index(l1_identifier);
     }
     const renamedt<ssa_exprt, L2> l2_false_case = set_indices<L2>(ssa_l1, ns);
@@ -477,7 +477,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
   }
 
   // produce a fresh L2 name
-  increase_generation(l1_identifier, ssa_l1);
+  level2.increase_generation(l1_identifier, ssa_l1, fresh_l2_name_provider);
   expr = set_indices<L2>(std::move(ssa_l1), ns).get();
 
   // and record that
@@ -839,8 +839,8 @@ ssa_exprt goto_symex_statet::declare(ssa_exprt ssa, const namespacet &ns)
   for(const auto &l1_symbol : find_symbols(fields))
   {
     const ssa_exprt &field_ssa = to_ssa_expr(l1_symbol);
-    std::size_t field_generation =
-      increase_generation(l1_symbol.get_identifier(), field_ssa);
+    const std::size_t field_generation = level2.increase_generation(
+      l1_symbol.get_identifier(), field_ssa, fresh_l2_name_provider);
     CHECK_RETURN(field_generation == 1);
   }
 

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -161,6 +161,12 @@ public:
     std::function<std::size_t(const irep_idt &)> index_generator,
     const namespacet &ns);
 
+  /// Add `invalid` (or a failed symbol) to the value_set if ssa is a pointer,
+  /// ensure that level2 index of symbols in fields of ssa are at 1,
+  /// and rename ssa to level 2
+  /// \return ssa renamed to level 2
+  ssa_exprt declare(ssa_exprt ssa, const namespacet &ns);
+
   void print_backtrace(std::ostream &) const;
 
   // threads

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -222,15 +222,6 @@ public:
   unsigned total_vccs = 0;
   unsigned remaining_vccs = 0;
 
-  /// Allocates a fresh L2 name for the given L1 identifier, and makes it the
-  /// latest generation on this path.
-  std::size_t
-  increase_generation(const irep_idt l1_identifier, const ssa_exprt &lhs)
-  {
-    return goto_statet::increase_generation(
-      l1_identifier, lhs, fresh_l2_name_provider);
-  }
-
   /// Drops an L1 name from the local L2 map
   void drop_existing_l1_name(const irep_idt &l1_identifier)
   {

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -145,6 +145,27 @@ unsigned symex_level2t::latest_index(const irep_idt &identifier) const
   return !r_opt ? 0 : r_opt->get().second;
 }
 
+std::size_t symex_level2t::increase_generation(
+  const irep_idt &l1_identifier,
+  const ssa_exprt &lhs,
+  std::function<std::size_t(const irep_idt &)> fresh_l2_name_provider)
+{
+  const std::size_t n = fresh_l2_name_provider(l1_identifier);
+
+  if(const auto r_opt = current_names.find(l1_identifier))
+  {
+    std::pair<ssa_exprt, std::size_t> copy = r_opt->get();
+    copy.second = n;
+    current_names.replace(l1_identifier, std::move(copy));
+  }
+  else
+  {
+    current_names.insert(l1_identifier, std::make_pair(lhs, n));
+  }
+
+  return n;
+}
+
 exprt get_original_name(exprt expr)
 {
   expr.type() = get_original_name(std::move(expr.type()));

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -88,6 +88,13 @@ struct symex_level2t
 
   /// Counter corresponding to an identifier
   unsigned latest_index(const irep_idt &identifier) const;
+
+  /// Allocates a fresh L2 name for the given L1 identifier, and makes it the
+  ///  latest generation on this path.
+  std::size_t increase_generation(
+    const irep_idt &l1_identifier,
+    const ssa_exprt &lhs,
+    std::function<std::size_t(const irep_idt &)> fresh_l2_name_provider);
 };
 
 /// Undo all levels of renaming

--- a/src/pointer-analysis/add_failed_symbols.cpp
+++ b/src/pointer-analysis/add_failed_symbols.cpp
@@ -86,11 +86,6 @@ void add_failed_symbols(symbol_table_baset &symbol_table)
     add_failed_symbol_if_needed(*symbol, symbol_table);
 }
 
-/// Get the failed-dereference symbol for the given symbol
-/// \param expr: symbol expression to get a failed symbol for
-/// \param ns: global namespace
-/// \return symbol expression for the failed-dereference symbol, or an empty
-///   optional if none exists.
 optionalt<symbol_exprt>
 get_failed_symbol(const symbol_exprt &expr, const namespacet &ns)
 {

--- a/src/pointer-analysis/add_failed_symbols.h
+++ b/src/pointer-analysis/add_failed_symbols.h
@@ -27,6 +27,11 @@ void add_failed_symbol_if_needed(
 
 irep_idt failed_symbol_id(const irep_idt &identifier);
 
+/// Get the failed-dereference symbol for the given symbol
+/// \param expr: symbol expression to get a failed symbol for
+/// \param ns: global namespace
+/// \return symbol expression for the failed-dereference symbol, or an empty
+///   optional if none exists.
 optionalt<symbol_exprt>
 get_failed_symbol(const symbol_exprt &expr, const namespacet &ns);
 


### PR DESCRIPTION
This  is based on https://github.com/diffblue/cbmc/pull/4806.
The goal is to make `increase_generation` a method of `symex_level2t` instead of `goto_symext` and `goto_symex_statet` because it only affect their `level2` field.
This requires moving some code from `goto_symext` to `goto_symex_statet` so that it can access the level2 component.
This would make it easier to test the method.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
