### PR TITLE
Refactor branch coverage filtering

### DIFF
--- a/src/goto-instrument/cover_instrument_branch.cpp
+++ b/src/goto-instrument/cover_instrument_branch.cpp
@@ -9,8 +9,9 @@ Author: Daniel Kroening
 /// \file
 /// Coverage Instrumentation for Branches
 
-#include "cover_instrument.h"
 #include "cover_basic_blocks.h"
+#include "cover_filter.h"
+#include "cover_instrument.h"
 
 void cover_branch_instrumentert::instrument(
   const irep_idt &function_id,
@@ -23,9 +24,11 @@ void cover_branch_instrumentert::instrument(
 
   const bool is_function_entry_point =
     i_it == goto_program.instructions.begin();
-  const bool is_conditional_goto = i_it->is_goto() && !i_it->guard.is_true() &&
-                                   !i_it->source_location.is_built_in();
+  const bool is_conditional_goto = i_it->is_goto() && !i_it->guard.is_true();
   if(!is_function_entry_point && !is_conditional_goto)
+    return;
+
+  if(!goal_filters(i_it->source_location))
     return;
 
   if(is_function_entry_point)

--- a/src/goto-instrument/cover_instrument_branch.cpp
+++ b/src/goto-instrument/cover_instrument_branch.cpp
@@ -21,7 +21,14 @@ void cover_branch_instrumentert::instrument(
   if(is_non_cover_assertion(i_it))
     i_it->turn_into_skip();
 
-  if(i_it == goto_program.instructions.begin())
+  const bool is_function_entry_point =
+    i_it == goto_program.instructions.begin();
+  const bool is_conditional_goto = i_it->is_goto() && !i_it->guard.is_true() &&
+                                   !i_it->source_location.is_built_in();
+  if(!is_function_entry_point && !is_conditional_goto)
+    return;
+
+  if(is_function_entry_point)
   {
     // we want branch coverage to imply 'entry point of function'
     // coverage
@@ -34,9 +41,7 @@ void cover_branch_instrumentert::instrument(
     initialize_source_location(t, comment, function_id);
   }
 
-  if(
-    i_it->is_goto() && !i_it->guard.is_true() &&
-    !i_it->source_location.is_built_in())
+  if(is_conditional_goto)
   {
     std::string b =
       std::to_string(basic_blocks.block_of(i_it) + 1); // start with 1


### PR DESCRIPTION
Use the internal_goals_filter to check whether source_location is built-in, which has the benefit that it allows us to apply custom goal filters in addition.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
