### PR TITLE
Make nondet_symbol_exprt constructor take location

### DIFF
--- a/src/goto-symex/path_storage.cpp
+++ b/src/goto-symex/path_storage.cpp
@@ -13,10 +13,12 @@ Author: Kareem Khazem <karkhaz@karkhaz.com>
 #include <util/exit_codes.h>
 #include <util/make_unique.h>
 
-nondet_symbol_exprt symex_nondet_generatort::operator()(const typet &type)
+nondet_symbol_exprt symex_nondet_generatort::
+operator()(typet type, source_locationt location)
 {
-  irep_idt identifier = "symex::nondet" + std::to_string(nondet_count++);
-  return nondet_symbol_exprt(identifier, type);
+  return nondet_symbol_exprt{"symex::nondet" + std::to_string(nondet_count++),
+                             std::move(type),
+                             std::move(location)};
 }
 
 // _____________________________________________________________________________

--- a/src/goto-symex/path_storage.h
+++ b/src/goto-symex/path_storage.h
@@ -22,7 +22,7 @@
 class symex_nondet_generatort
 {
 public:
-  nondet_symbol_exprt operator()(const typet &type);
+  nondet_symbol_exprt operator()(typet type, source_locationt location);
 
 private:
   std::size_t nondet_count = 0;

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -183,8 +183,9 @@ void goto_symext::symex_allocate(
   }
   else
   {
-    const exprt nondet = path_storage.build_symex_nondet(*object_type);
-    const code_assignt assignment(value_symbol.symbol_expr(), nondet);
+    const code_assignt assignment{
+      value_symbol.symbol_expr(),
+      path_storage.build_symex_nondet(*object_type, code.source_location())};
     symex_assign(state, assignment);
   }
 

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -167,9 +167,7 @@ replace_nondet(exprt &expr, symex_nondet_generatort &build_symex_nondet)
 {
   if(expr.id() == ID_side_effect && expr.get(ID_statement) == ID_nondet)
   {
-    nondet_symbol_exprt new_expr = build_symex_nondet(expr.type());
-    new_expr.add_source_location() = expr.source_location();
-    expr.swap(new_expr);
+    expr = build_symex_nondet(expr.type(), expr.source_location());
   }
   else
   {

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -211,6 +211,19 @@ public:
     set_identifier(identifier);
   }
 
+  /// \param identifier: name of symbol
+  /// \param type: type of symbol
+  /// \param location: location from which the symbol originate
+  nondet_symbol_exprt(
+    irep_idt identifier,
+    typet type,
+    source_locationt location)
+    : nullary_exprt(ID_nondet_symbol, std::move(type))
+  {
+    set_identifier(std::move(identifier));
+    add_source_location() = std::move(location);
+  }
+
   void set_identifier(const irep_idt &identifier)
   {
     set(ID_identifier, identifier);


### PR DESCRIPTION
This is how it is used in practice so this makes the constructor calls
clearer.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
