### PR TITLE
Fix indentation in value_sett output

### DIFF
--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -211,7 +211,7 @@ void value_sett::output(std::ostream &out, const std::string &indent) const
       {
         out << ", ";
         if(width >= 40)
-          out << "\n" << std::string(' ', indent.size()) << "      ";
+          out << "\n" << std::string(indent.size(), ' ') << "      ";
       }
     }
 


### PR DESCRIPTION
The character and size arguments where inverted.
The constructor used is `string (size_t n, char c);` the order can be
confusing because there is also a `string (const char* s, size_t n);`
constructor.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
