### PR TITLE
Bugfix in get_subexpression_at_offset 

### DIFF
--- a/src/util/pointer_offset_size.cpp
+++ b/src/util/pointer_offset_size.cpp
@@ -694,12 +694,18 @@ optionalt<exprt> get_subexpression_at_offset(
     if(*target_size_bits <= *elem_size_bits)
     {
       const mp_integer elem_size_bytes = *elem_size_bits / 8;
-      return get_subexpression_at_offset(
-        index_exprt(
-          expr, from_integer(offset_bytes / elem_size_bytes, index_type())),
-        offset_bytes % elem_size_bytes,
-        target_type_raw,
-        ns);
+      const auto offset_inside_elem = offset_bytes % elem_size_bytes;
+      const auto target_size_bytes = *target_size_bits / 8;
+      // only recurse if the cell completely contains the target
+      if(offset_inside_elem + target_size_bytes <= elem_size_bytes)
+      {
+        return get_subexpression_at_offset(
+          index_exprt(
+            expr, from_integer(offset_bytes / elem_size_bytes, index_type())),
+          offset_inside_elem,
+          target_type_raw,
+          ns);
+      }
     }
   }
 

--- a/unit/util/pointer_offset_size.cpp
+++ b/unit/util/pointer_offset_size.cpp
@@ -65,6 +65,18 @@ TEST_CASE("Build subexpression to access element at offset into array")
                           from_integer(1, index_type()),
                           small_t));
   }
+
+  {
+    const signedbv_typet int16_t(16);
+    const auto result = get_subexpression_at_offset(a, 3, int16_t, ns);
+    // At offset 3 there are only 8 bits remaining in an element of type t so
+    // not enough to fill a 16 bit int, so this cannot be transformed in an
+    // index_exprt.
+    REQUIRE(
+      result.value() ==
+      byte_extract_exprt(
+        byte_extract_id(), a, from_integer(3, index_type()), int16_t));
+  }
 }
 
 TEST_CASE("Build subexpression to access element at offset into struct")


### PR DESCRIPTION
This fixes the case where the value we want to extract would require more bits than what can be found at the given offset.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
