### PR TITLE
Don't add trailing dot if printing in scientific exponent

### DIFF
--- a/jbmc/src/java_bytecode/expr2java.h
+++ b/jbmc/src/java_bytecode/expr2java.h
@@ -75,8 +75,13 @@ std::string floating_point_to_java_string(float_type value)
     std::ostringstream raw_stream;
     raw_stream << value;
     const auto raw_decimal = raw_stream.str();
-    if(raw_decimal.find('.') == std::string::npos)
+    const bool is_scientific = raw_decimal.find('e') != std::string::npos;
+    if(
+      raw_decimal.find('.') == std::string::npos &&
+      !is_scientific) // don't add trailing .0 if in scientific notation
+    {
       return raw_decimal + ".0";
+    }
     return raw_decimal;
   }();
   const bool is_lossless = [&] {

--- a/jbmc/unit/java_bytecode/expr2java.cpp
+++ b/jbmc/unit/java_bytecode/expr2java.cpp
@@ -129,4 +129,10 @@ TEST_CASE(
     REQUIRE(floating_point_to_java_string(-5.56268e-309) == "-5.56268e-309");
 #endif
   }
+
+  SECTION("Precise exponent")
+  {
+    REQUIRE(floating_point_to_java_string(3e+06) == "3e+06");
+    REQUIRE(floating_point_to_java_string(3e+06f) == "3e+06f");
+  }
 }


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [n/a] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
