### PR TITLE
Add unit-test for goto symex state assignments

### DIFF
--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -173,7 +173,6 @@ renamedt<ssa_exprt, L2> goto_symex_statet::assignment(
   {
     DATA_INVARIANT(!check_renaming_l1(lhs), "lhs renaming failed on l1");
   }
-  const ssa_exprt l1_lhs = lhs;
 
 #if 0
   PRECONDITION(l1_identifier != get_original_name(l1_identifier)

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -174,14 +174,6 @@ renamedt<ssa_exprt, L2> goto_symex_statet::assignment(
     DATA_INVARIANT(!check_renaming_l1(lhs), "lhs renaming failed on l1");
   }
 
-#if 0
-  PRECONDITION(l1_identifier != get_original_name(l1_identifier)
-      || l1_identifier == guard_identifier()
-      || ns.lookup(l1_identifier).is_shared()
-      || has_prefix(id2string(l1_identifier), "symex::invalid_object")
-      || has_prefix(id2string(l1_identifier), SYMEX_DYNAMIC_PREFIX "dynamic_object"));
-#endif
-
   // do the l2 renaming
   level2.increase_generation(l1_identifier, lhs, fresh_l2_name_provider);
   renamedt<ssa_exprt, L2> l2_lhs = set_indices<L2>(std::move(lhs), ns);

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -221,7 +221,7 @@ renamedt<ssa_exprt, L2> goto_symex_statet::assignment(
     value_set.assign(l1_lhs, l1_rhs, ns, rhs_is_simplified, is_shared);
   }
 
-#if 0
+#ifdef DEBUG
   std::cout << "Assigning " << l1_identifier << '\n';
   value_set.output(std::cout);
   std::cout << "**********************\n";

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -193,8 +193,7 @@ renamedt<ssa_exprt, L2> goto_symex_statet::assignment(
     throw unsupported_operation_exceptiont(
       "pointer handling for concurrency is unsound");
 
-  // for value propagation -- the RHS is L2
-
+  // Update constant propagation map -- the RHS is L2
   if(!is_shared && record_value && goto_symex_is_constantt()(rhs))
   {
     const auto propagation_entry = propagation.find(l1_identifier);

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -202,8 +202,8 @@ renamedt<ssa_exprt, L2> goto_symex_statet::assignment(
     else if(propagation_entry->get() != rhs)
       propagation.replace(l1_identifier, rhs);
   }
-  else if(propagation.has_key(l1_identifier))
-    propagation.erase(l1_identifier);
+  else
+    propagation.erase_if_exists(l1_identifier);
 
   {
     // update value sets

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -223,7 +223,7 @@ renamedt<ssa_exprt, L2> goto_symex_statet::assignment(
 
 #if 0
   std::cout << "Assigning " << l1_identifier << '\n';
-  value_set.output(ns, std::cout);
+  value_set.output(std::cout);
   std::cout << "**********************\n";
 #endif
 

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -274,7 +274,8 @@ public:
   /// operators (i.e. this is not a simple lookup in `valuest`).
   /// \param expr: query expression
   /// \param ns: global namespace
-  /// \return list of expressions that `expr` may point to
+  /// \return list of expressions that `expr` may point to. These expressions
+  ///   are object_descriptor_exprt or have id ID_invalid or ID_unknown.
   std::vector<exprt> get_value_set(exprt expr, const namespacet &ns) const;
 
   /// Appears to be unimplemented.

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -31,6 +31,7 @@ SRC += analyses/ai/ai.cpp \
        goto-programs/osx_fat_reader.cpp \
        goto-programs/remove_returns.cpp \
        goto-programs/xml_expr.cpp \
+       goto-symex/goto_symex_state.cpp \
        goto-symex/ssa_equation.cpp \
        goto-symex/is_constant.cpp \
        goto-symex/symex_level0.cpp \

--- a/unit/goto-symex/goto_symex_state.cpp
+++ b/unit/goto-symex/goto_symex_state.cpp
@@ -1,0 +1,102 @@
+/*******************************************************************\
+
+Module: Unit tests for goto_symex_statet
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include <testing-utils/message.h>
+#include <testing-utils/use_catch.h>
+
+#include <analyses/dirty.h>
+#include <goto-symex/goto_symex_state.h>
+#include <util/arith_tools.h>
+#include <util/namespace.h>
+#include <util/symbol_table.h>
+
+static void add_to_symbol_table(
+  symbol_tablet &symbol_table,
+  const symbol_exprt &symbol_expr)
+{
+  symbolt symbol;
+  symbol.name = symbol_expr.get_identifier();
+  symbol.type = symbol_expr.type();
+  symbol.value = symbol_expr;
+  symbol.is_thread_local = true;
+  symbol_table.insert(symbol);
+}
+
+SCENARIO(
+  "Goto symex state assignment",
+  "[core][goto-symex][goto-symex-state][assignment]")
+{
+  // Initialize goto state
+  std::list<goto_programt::instructiont> target;
+  symex_targett::sourcet source{"fun", target.begin()};
+  guard_managert manager;
+  std::size_t fresh_name_count = 1;
+  auto fresh_name = [&fresh_name_count](const irep_idt &) {
+    return fresh_name_count++;
+  };
+  goto_symex_statet state{source, manager, fresh_name};
+
+  // Initialize dirty field of state
+  incremental_dirtyt dirty;
+  goto_functiont function;
+  dirty.populate_dirty_for_function("fun", function);
+  state.dirty = &dirty;
+
+  GIVEN("An L1 lhs and an L2 rhs of type int")
+  {
+    // Initialize symbol table with an integer symbol `foo`
+    symbol_tablet symbol_table;
+    namespacet ns{symbol_table};
+    const signedbv_typet int_type{32};
+    const symbol_exprt foo{"foo", int_type};
+    add_to_symbol_table(symbol_table, foo);
+    const ssa_exprt ssa_foo{foo};
+
+    WHEN("Symbol `foo` is assigned constant integer `475`")
+    {
+      const exprt rhs1 = from_integer(475, int_type);
+      const auto result =
+        state.assignment(ssa_foo, rhs1, ns, true, true, false);
+      THEN("The result is `foo` renamed to L2")
+      {
+        REQUIRE(result.get().get_identifier() == "foo!0#1");
+      }
+      THEN("The propagation map contains an entry for `foo`")
+      {
+        const auto l1_foo = state.rename_ssa<L1>(ssa_foo, ns);
+        const auto foo_propagated =
+          state.propagation.find(l1_foo.get().get_identifier());
+        REQUIRE(foo_propagated.has_value());
+        const auto foo_value =
+          numeric_cast_v<mp_integer>(to_constant_expr(foo_propagated->get()));
+        REQUIRE(foo_value == 475);
+      }
+      THEN("Symbol `foo` is assigned another integer 1834")
+      {
+        const exprt rhs2 = from_integer(1834, int_type);
+        const auto result2 =
+          state.assignment(ssa_foo, rhs2, ns, true, true, false);
+
+        THEN("The level 2 index of `foo` is incremented")
+        {
+          REQUIRE(result2.get().get_identifier() == "foo!0#2");
+        }
+        THEN("The propagation map entry for `foo` is updated")
+        {
+          const auto l1_foo = state.rename_ssa<L1>(ssa_foo, ns);
+          const auto foo_propagated =
+            state.propagation.find(l1_foo.get().get_identifier());
+          REQUIRE(foo_propagated.has_value());
+          const auto foo_value =
+            numeric_cast_v<mp_integer>(to_constant_expr(foo_propagated->get()));
+          REQUIRE(foo_value == 1834);
+        }
+      }
+    }
+  }
+}

--- a/unit/goto-symex/goto_symex_state.cpp
+++ b/unit/goto-symex/goto_symex_state.cpp
@@ -12,6 +12,7 @@ Author: Diffblue Ltd.
 #include <analyses/dirty.h>
 #include <goto-symex/goto_symex_state.h>
 #include <util/arith_tools.h>
+#include <util/c_types.h>
 #include <util/namespace.h>
 #include <util/symbol_table.h>
 
@@ -95,6 +96,69 @@ SCENARIO(
           const auto foo_value =
             numeric_cast_v<mp_integer>(to_constant_expr(foo_propagated->get()));
           REQUIRE(foo_value == 1834);
+        }
+      }
+    }
+  }
+
+  GIVEN("An L1 lhs and an L2 rhs of pointer type")
+  {
+    // Initialize symbol table with a pointer symbol `foo`
+    symbol_tablet symbol_table;
+    namespacet ns{symbol_table};
+    const signedbv_typet int_type{32};
+    const pointer_typet int_pointer_type = pointer_type(int_type);
+    const symbol_exprt foo{"foo", int_pointer_type};
+    add_to_symbol_table(symbol_table, foo);
+    const ssa_exprt ssa_foo{foo};
+
+    WHEN("Symbol `foo` is assigned a null pointer")
+    {
+      const null_pointer_exprt null_pointer{int_pointer_type};
+      const auto result =
+        state.assignment(ssa_foo, null_pointer, ns, true, true, false);
+      THEN("The result is `foo` renamed to L2")
+      {
+        REQUIRE(result.get().get_identifier() == "foo!0#1");
+      }
+      THEN("The value set contains an entry for `foo`")
+      {
+        const auto l1_foo = state.rename_ssa<L1>(ssa_foo, ns);
+        const std::vector<exprt> value_set =
+          state.value_set.get_value_set(l1_foo.get(), ns);
+        REQUIRE(value_set.size() == 1);
+        const auto object_descriptor =
+          expr_try_dynamic_cast<object_descriptor_exprt>(value_set[0]);
+        REQUIRE(object_descriptor != nullptr);
+        REQUIRE(object_descriptor->object().id() == ID_null_object);
+      }
+      THEN("Symbol `foo` is assigned `&int_value`")
+      {
+        const symbol_exprt int_value{"int_value", int_type};
+        add_to_symbol_table(symbol_table, int_value);
+        const address_of_exprt rhs2{int_value};
+        const renamedt<exprt, L2> l2_rhs2 = state.rename(rhs2, ns);
+        const auto result2 =
+          state.assignment(ssa_foo, l2_rhs2.get(), ns, true, true, false);
+
+        THEN("The level 2 index of `foo` is incremented")
+        {
+          REQUIRE(result2.get().get_identifier() == "foo!0#2");
+        }
+        THEN("The value set for `foo` is updated to contain int_value!0")
+        {
+          const auto l1_foo = state.rename_ssa<L1>(ssa_foo, ns);
+          const std::vector<exprt> value_set =
+            state.value_set.get_value_set(l1_foo.get(), ns);
+          REQUIRE(value_set.size() == 1);
+          const auto object_descriptor =
+            expr_try_dynamic_cast<object_descriptor_exprt>(value_set[0]);
+          REQUIRE(object_descriptor != nullptr);
+          const symbol_exprt object_symbol =
+            to_symbol_expr(object_descriptor->object());
+          REQUIRE(object_symbol.get_identifier() == "int_value!0");
+          REQUIRE(to_constant_expr(object_descriptor->offset())
+                    .value_is_zero_string());
         }
       }
     }

--- a/unit/goto-symex/goto_symex_state.cpp
+++ b/unit/goto-symex/goto_symex_state.cpp
@@ -77,6 +77,10 @@ SCENARIO(
           numeric_cast_v<mp_integer>(to_constant_expr(foo_propagated->get()));
         REQUIRE(foo_value == 475);
       }
+      THEN("The target equations are unchanged")
+      {
+        REQUIRE(state.symex_target == nullptr);
+      }
       THEN("Symbol `foo` is assigned another integer 1834")
       {
         const exprt rhs2 = from_integer(1834, int_type);
@@ -96,6 +100,10 @@ SCENARIO(
           const auto foo_value =
             numeric_cast_v<mp_integer>(to_constant_expr(foo_propagated->get()));
           REQUIRE(foo_value == 1834);
+        }
+        THEN("The target equations are unchanged")
+        {
+          REQUIRE(state.symex_target == nullptr);
         }
       }
     }
@@ -132,6 +140,10 @@ SCENARIO(
         REQUIRE(object_descriptor != nullptr);
         REQUIRE(object_descriptor->object().id() == ID_null_object);
       }
+      THEN("The target equations are unchanged")
+      {
+        REQUIRE(state.symex_target == nullptr);
+      }
       THEN("Symbol `foo` is assigned `&int_value`")
       {
         const symbol_exprt int_value{"int_value", int_type};
@@ -159,6 +171,10 @@ SCENARIO(
           REQUIRE(object_symbol.get_identifier() == "int_value!0");
           REQUIRE(to_constant_expr(object_descriptor->offset())
                     .value_is_zero_string());
+        }
+        THEN("The target equations are unchanged")
+        {
+          REQUIRE(state.symex_target == nullptr);
         }
       }
     }

--- a/unit/goto-symex/module_dependencies.txt
+++ b/unit/goto-symex/module_dependencies.txt
@@ -1,3 +1,4 @@
+analyses
 goto-symex
 testing-utils
 util


### PR DESCRIPTION
This adds unit test for state.assignment, and a couple of clean-up for things I noticed while looking at the function.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
