### PR TITLE
Refactor array object factory to allow customising the element construction

### DIFF
--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -162,6 +162,13 @@ private:
     size_t depth,
     update_in_placet update_in_place,
     const source_locationt &location);
+
+  code_blockt assign_element(
+    const exprt &element_at_counter,
+    update_in_placet update_in_place,
+    const typet &element_type,
+    size_t depth,
+    const source_locationt &location);
 };
 
 /// Initializes the pointer-typed lvalue expression `expr` to point to an object
@@ -1133,6 +1140,66 @@ void java_object_factoryt::array_primitive_init_code(
   assignments.statements().back().add_source_location() = location;
 }
 
+/// Generate codet for assigning an individual element inside the array
+code_blockt java_object_factoryt::assign_element(
+  const exprt &element_at_counter,
+  const update_in_placet update_in_place,
+  const typet &element_type,
+  const size_t depth,
+  const source_locationt &location)
+{
+  code_blockt assignments;
+  bool new_item_is_primitive = element_at_counter.type().id() != ID_pointer;
+
+  // Use a temporary to initialise a new, or update an existing, non-primitive.
+  // This makes it clearer that in a sequence like
+  // `new_array_item->x = y; new_array_item->z = w;` that all the
+  // `new_array_item` references must alias, cf. the harder-to-analyse
+  // `some_expr[idx]->x = y; some_expr[idx]->z = w;`
+  exprt init_expr;
+  if(new_item_is_primitive)
+  {
+    init_expr = element_at_counter;
+  }
+  else
+  {
+    init_expr = allocate_objects.allocate_automatic_local_object(
+      element_at_counter.type(), "new_array_item");
+
+    // If we're updating an existing array item, read the existing object that
+    // we (may) alter:
+    if(update_in_place != update_in_placet::NO_UPDATE_IN_PLACE)
+      assignments.add(code_assignt(init_expr, element_at_counter));
+  }
+
+  // MUST_UPDATE_IN_PLACE only applies to this object.
+  // If this is a pointer to another object, offer the chance
+  // to leave it alone by setting MAY_UPDATE_IN_PLACE instead.
+  update_in_placet child_update_in_place=
+    update_in_place==update_in_placet::MUST_UPDATE_IN_PLACE ?
+    update_in_placet::MAY_UPDATE_IN_PLACE :
+    update_in_place;
+  gen_nondet_init(
+    assignments,
+    init_expr,
+    false, // is_sub
+    false, // skip_classid
+    // These are variable in number, so use dynamic allocator:
+    lifetimet::DYNAMIC,
+    element_type, // override
+    depth,
+    child_update_in_place,
+    location);
+
+  if(!new_item_is_primitive)
+  {
+    // We used a temporary variable to update or initialise an array item;
+    // now write it into the array:
+    assignments.add(code_assignt(element_at_counter, init_expr));
+  }
+  return assignments;
+}
+
 /// Create code to nondeterministically initialize each element of an array in a
 /// loop.
 /// The code produced is of the form (supposing an array of type OBJ):
@@ -1223,56 +1290,9 @@ void java_object_factoryt::array_loop_init_code(
   const dereference_exprt element_at_counter =
     array_element_from_pointer(array_init_symexpr, counter_expr);
 
-  bool new_item_is_primitive = element_at_counter.type().id() != ID_pointer;
-
-  // Use a temporary to initialise a new, or update an existing, non-primitive.
-  // This makes it clearer that in a sequence like
-  // `new_array_item->x = y; new_array_item->z = w;` that all the
-  // `new_array_item` references must alias, cf. the harder-to-analyse
-  // `some_expr[idx]->x = y; some_expr[idx]->z = w;`
-  exprt init_expr;
-  if(new_item_is_primitive)
-  {
-    init_expr = element_at_counter;
-  }
-  else
-  {
-    init_expr = allocate_objects.allocate_automatic_local_object(
-      element_at_counter.type(), "new_array_item");
-
-    // If we're updating an existing array item, read the existing object that
-    // we (may) alter:
-    if(update_in_place != update_in_placet::NO_UPDATE_IN_PLACE)
-      assignments.add(code_assignt(init_expr, element_at_counter));
-  }
-
-  // MUST_UPDATE_IN_PLACE only applies to this object.
-  // If this is a pointer to another object, offer the chance
-  // to leave it alone by setting MAY_UPDATE_IN_PLACE instead.
-  update_in_placet child_update_in_place=
-    update_in_place==update_in_placet::MUST_UPDATE_IN_PLACE ?
-    update_in_placet::MAY_UPDATE_IN_PLACE :
-    update_in_place;
-  gen_nondet_init(
-    assignments,
-    init_expr,
-    false, // is_sub
-    false, // skip_classid
-    // These are variable in number, so use dynamic allocator:
-    lifetimet::DYNAMIC,
-    element_type, // override
-    depth,
-    child_update_in_place,
-    location);
-
-  if(!new_item_is_primitive)
-  {
-    // We used a temporary variable to update or initialise an array item;
-    // now write it into the array:
-    assignments.add(code_assignt(element_at_counter, init_expr));
-  }
-
-  exprt java_one=from_integer(1, java_int_type());
+  assignments.append(assign_element(
+    element_at_counter, update_in_place, element_type, depth, location));
+  exprt java_one = from_integer(1, java_int_type());
   code_assignt incr(counter_expr, plus_exprt(counter_expr, java_one));
 
   assignments.add(std::move(incr));

--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -202,7 +202,6 @@ void java_object_factoryt::gen_pointer_target_init(
   {
     assignments.append(gen_nondet_array_init(
       expr,
-      depth + 1,
       update_in_place,
       location,
       [this, update_in_place, depth, location](
@@ -1228,8 +1227,6 @@ code_blockt java_object_factoryt::assign_element(
 /// \param length_expr : array length
 /// \param element_type: type of array elements
 /// \param max_length_expr : max length, as specified by max-nondet-array-length
-/// \param depth: Number of times that a pointer has been dereferenced from the
-///   root of the object tree that we are initializing.
 /// \param update_in_place:
 ///   NO_UPDATE_IN_PLACE: initialize `expr` from scratch
 ///   MAY_UPDATE_IN_PLACE: generate a runtime nondet branch between the NO_
@@ -1249,7 +1246,6 @@ static void array_loop_init_code(
   const exprt &length_expr,
   const typet &element_type,
   const exprt &max_length_expr,
-  size_t depth,
   update_in_placet update_in_place,
   const source_locationt &location,
   const array_element_generatort &element_generator,
@@ -1312,7 +1308,6 @@ static void array_loop_init_code(
 
 code_blockt gen_nondet_array_init(
   const exprt &expr,
-  size_t depth,
   update_in_placet update_in_place,
   const source_locationt &location,
   const array_element_generatort &element_generator,
@@ -1374,7 +1369,6 @@ code_blockt gen_nondet_array_init(
       length_expr,
       element_type,
       max_length_expr,
-      depth,
       update_in_place,
       location,
       element_generator,

--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -153,12 +153,8 @@ private:
     const exprt &max_length_expr,
     const source_locationt &location);
 
-  using element_generatort = std::function<code_blockt(
-    const exprt &element_at_counter,
-    const update_in_placet &update_in_place,
-    const typet &element_type,
-    const size_t depth,
-    const source_locationt &location)>;
+  using element_generatort = std::function<
+    code_blockt(const exprt &element_at_counter, const typet &element_type)>;
 
   void array_loop_init_code(
     code_blockt &assignments,
@@ -1299,8 +1295,7 @@ void java_object_factoryt::array_loop_init_code(
   const dereference_exprt element_at_counter =
     array_element_from_pointer(array_init_symexpr, counter_expr);
 
-  assignments.append(element_generator(
-    element_at_counter, update_in_place, element_type, depth, location));
+  assignments.append(element_generator(element_at_counter, element_type));
   exprt java_one = from_integer(1, java_int_type());
   code_assignt incr(counter_expr, plus_exprt(counter_expr, java_one));
 
@@ -1372,12 +1367,9 @@ void java_object_factoryt::gen_nondet_array_init(
       depth,
       update_in_place,
       location,
-      [this](
+      [this, update_in_place, depth, location](
         const exprt &element_at_counter,
-        const update_in_placet &update_in_place,
-        const typet &element_type,
-        const size_t depth,
-        const source_locationt &location) -> code_blockt {
+        const typet &element_type) -> code_blockt {
         return assign_element(
           element_at_counter, update_in_place, element_type, depth, location);
       });

--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -1051,6 +1051,8 @@ void java_object_factoryt::declare_created_symbols(code_blockt &init_code)
 /// \param element_type:
 ///   Actual element type of the array (the array for all reference types will
 ///   have void* type, but this will be annotated as the true member type).
+/// \param create_local_symbol:
+///   A function to generate a new local symbol and add it to the symbol table
 /// \param location:
 ///   Source location associated with nondet-initialization.
 /// \return Appends instructions to `assignments`
@@ -1094,6 +1096,8 @@ static void allocate_nondet_length_array(
 /// \param element_type: type of array elements
 /// \param max_length_expr : the (constant) size to which initialise the array
 /// \param location: Source location associated with nondet-initialization.
+/// \param allocate_local_symbol:
+///   A function to generate a new local symbol and add it to the symbol table
 static void array_primitive_init_code(
   code_blockt &assignments,
   const exprt &init_array_expr,
@@ -1224,6 +1228,13 @@ code_blockt java_object_factoryt::assign_element(
 ///   and MUST_ cases.
 ///   MUST_UPDATE_IN_PLACE: reinitialize an existing object
 /// \param location: Source location associated with nondet-initialization.
+/// \param element_generator:
+///   A function for generating the body of the loop which creates and assigns
+///   the element at the position.
+/// \param allocate_local_symbol:
+///   A function to generate a new local symbol and add it to the symbol table
+/// \param symbol_table:
+///   The symbol table.
 static void array_loop_init_code(
   code_blockt &assignments,
   const exprt &init_array_expr,

--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -1051,7 +1051,7 @@ void java_object_factoryt::declare_created_symbols(code_blockt &init_code)
 /// \param element_type:
 ///   Actual element type of the array (the array for all reference types will
 ///   have void* type, but this will be annotated as the true member type).
-/// \param create_local_symbol:
+/// \param allocate_local_symbol:
 ///   A function to generate a new local symbol and add it to the symbol table
 /// \param location:
 ///   Source location associated with nondet-initialization.
@@ -1061,7 +1061,7 @@ static void allocate_nondet_length_array(
   const exprt &lhs,
   const exprt &max_length_expr,
   const typet &element_type,
-  const allocate_localt &create_local_symbol,
+  const allocate_local_symbolt &allocate_local_symbol,
   const source_locationt &location)
 {
   const auto &length_sym_expr = generate_nondet_int(
@@ -1069,7 +1069,7 @@ static void allocate_nondet_length_array(
     max_length_expr,
     "nondet_array_length",
     location,
-    create_local_symbol,
+    allocate_local_symbol,
     assignments);
 
   side_effect_exprt java_new_array(ID_java_new_array, lhs.type(), location);
@@ -1104,7 +1104,7 @@ static void array_primitive_init_code(
   const typet &element_type,
   const exprt &max_length_expr,
   const source_locationt &location,
-  const allocate_localt &allocate_local_symbol)
+  const allocate_local_symbolt &allocate_local_symbol)
 {
   const array_typet array_type(element_type, max_length_expr);
 
@@ -1245,7 +1245,7 @@ static void array_loop_init_code(
   update_in_placet update_in_place,
   const source_locationt &location,
   const array_element_generatort &element_generator,
-  const allocate_localt &allocate_local_symbol,
+  const allocate_local_symbolt &allocate_local_symbol,
   const symbol_tablet &symbol_table)
 {
   const symbol_exprt &array_init_symexpr =
@@ -1314,7 +1314,7 @@ code_blockt gen_nondet_array_init(
   update_in_placet update_in_place,
   const source_locationt &location,
   const array_element_generatort &element_generator,
-  const allocate_localt &create_local_symbol,
+  const allocate_local_symbolt &allocate_local_symbol,
   const symbol_tablet &symbol_table,
   const size_t max_nondet_array_length)
 {
@@ -1342,7 +1342,7 @@ code_blockt gen_nondet_array_init(
       expr,
       max_length_expr,
       element_type,
-      create_local_symbol,
+      allocate_local_symbol,
       location);
   }
 
@@ -1376,7 +1376,7 @@ code_blockt gen_nondet_array_init(
       update_in_place,
       location,
       element_generator,
-      create_local_symbol,
+      allocate_local_symbol,
       symbol_table);
   }
   else
@@ -1391,7 +1391,7 @@ code_blockt gen_nondet_array_init(
       element_type,
       max_length_expr,
       location,
-      create_local_symbol);
+      allocate_local_symbol);
   }
   return statements;
 }

--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -23,16 +23,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "java_string_literals.h"
 #include "java_utils.h"
 
-static code_blockt gen_nondet_array_init(
-  const exprt &expr,
-  size_t depth,
-  update_in_placet update_in_place,
-  const source_locationt &location,
-  const array_element_generatort &element_generator,
-  const allocate_localt &create_local_symbol,
-  const symbol_tablet &symbol_table,
-  const size_t max_nondet_array_length);
-
 class java_object_factoryt
 {
   const java_object_factory_parameterst object_factory_parameters;
@@ -1307,7 +1297,7 @@ static void array_loop_init_code(
 /// 1. non-deterministically choose a length for the array
 /// 2. assume that such length is >=0 and <= max_length
 /// 3. loop through all elements of the array and initialize them
-static code_blockt gen_nondet_array_init(
+code_blockt gen_nondet_array_init(
   const exprt &expr,
   size_t depth,
   update_in_placet update_in_place,
@@ -1647,25 +1637,4 @@ void gen_nondet_init(
     pointer_type_selector,
     update_in_place,
     log);
-}
-std::pair<code_blockt, symbol_exprt> nondet_array(
-  const typet &array_type,
-  const symbol_exprt &array_symbol,
-  const array_element_generatort &element_generator,
-  size_t max_array_size,
-  symbol_table_baset &symbol_table,
-  const std::function<symbol_exprt(const typet &type, std::string)> &create_local_symbol)
-{
-  source_locationt loc;
-
-  code_blockt assignments = gen_nondet_array_init(
-    array_symbol,
-    0,
-    update_in_placet::NO_UPDATE_IN_PLACE,
-    loc,
-    element_generator,
-    create_local_symbol,
-    symbol_table,
-    max_array_size);
-  return std::make_pair(assignments, array_symbol);
 }

--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -1302,12 +1302,6 @@ static void array_loop_init_code(
   assignments.add(std::move(init_done_label));
 }
 
-/// Create code to initialize a Java array whose size will be at most
-/// `max_nondet_array_length`. The code is emitted to \p assignments does as
-/// follows:
-/// 1. non-deterministically choose a length for the array
-/// 2. assume that such length is >=0 and <= max_length
-/// 3. loop through all elements of the array and initialize them
 code_blockt gen_nondet_array_init(
   const exprt &expr,
   size_t depth,

--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -89,8 +89,6 @@ public:
         symbol_table),
       log(log)
   {}
-  using element_generatort = std::function<
-    code_blockt(const exprt &element_at_counter, const typet &element_type)>;
 
   void gen_nondet_array_init(
     code_blockt &assignments,
@@ -98,7 +96,7 @@ public:
     size_t depth,
     update_in_placet update_in_place,
     const source_locationt &location,
-    const element_generatort &element_generator);
+    const array_element_generatort &element_generator);
 
   bool gen_nondet_enum_init(
     code_blockt &assignments,
@@ -166,7 +164,7 @@ private:
     size_t depth,
     update_in_placet update_in_place,
     const source_locationt &location,
-    const element_generatort &element_generator);
+    const array_element_generatort &element_generator);
 
   code_blockt assign_element(
     const exprt &element_at_counter,
@@ -1263,7 +1261,7 @@ void java_object_factoryt::array_loop_init_code(
   size_t depth,
   update_in_placet update_in_place,
   const source_locationt &location,
-  const element_generatort &element_generator)
+  const array_element_generatort &element_generator)
 {
   const symbol_exprt &array_init_symexpr =
     allocate_objects.allocate_automatic_local_object(
@@ -1331,7 +1329,7 @@ void java_object_factoryt::gen_nondet_array_init(
   size_t depth,
   update_in_placet update_in_place,
   const source_locationt &location,
-  const element_generatort &element_generator)
+  const array_element_generatort &element_generator)
 {
   PRECONDITION(expr.type().id() == ID_pointer);
   PRECONDITION(expr.type().subtype().id() == ID_struct_tag);
@@ -1652,4 +1650,30 @@ void gen_nondet_init(
     pointer_type_selector,
     update_in_place,
     log);
+}
+std::pair<code_blockt, symbol_exprt> nondet_array(
+  const typet &array_type,
+  const symbol_exprt &array_symbol,
+  const array_element_generatort &element_generator,
+  size_t max_array_size,
+  symbol_table_baset &symbol_table)
+{
+  source_locationt loc;
+
+  java_object_factory_parameterst parameters;
+  parameters.max_nondet_array_length = max_array_size;
+
+  select_pointer_typet spt;
+  null_message_handlert nmh;
+
+  java_object_factoryt factory{loc, parameters, symbol_table, spt, nmh};
+  code_blockt assignments;
+  factory.gen_nondet_array_init(
+    assignments,
+    array_symbol,
+    0,
+    update_in_placet::NO_UPDATE_IN_PLACE,
+    loc,
+    element_generator);
+  return std::make_pair(assignments, array_symbol);
 }

--- a/jbmc/src/java_bytecode/java_object_factory.h
+++ b/jbmc/src/java_bytecode/java_object_factory.h
@@ -137,7 +137,6 @@ using array_element_generatort = std::function<
 /// Synthesize GOTO for generating a array of nondet length to be stored in the
 /// \p expr.
 /// \param expr: The array expression to initialize.
-/// \param depth: The depth of the expression from a root object being created.
 /// \param update_in_place: Should the code allow the solver the freedom to
 /// leave the array as is.
 /// \param location: Source location to use for all synthesized code.
@@ -159,7 +158,6 @@ using array_element_generatort = std::function<
 /// ```
 code_blockt gen_nondet_array_init(
   const exprt &expr,
-  size_t depth,
   update_in_placet update_in_place,
   const source_locationt &location,
   const array_element_generatort &element_generator,

--- a/jbmc/src/java_bytecode/java_object_factory.h
+++ b/jbmc/src/java_bytecode/java_object_factory.h
@@ -76,6 +76,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/allocate_objects.h>
 #include <util/message.h>
+#include <util/nondet.h>
 #include <util/std_code.h>
 #include <util/symbol_table.h>
 
@@ -138,6 +139,7 @@ std::pair<code_blockt, symbol_exprt> nondet_array(
   const symbol_exprt &array_symbol,
   const array_element_generatort &element_generator,
   size_t max_array_size,
-  symbol_table_baset &symbol_table);
+  symbol_table_baset &symbol_table,
+  const std::function<symbol_exprt(const typet &type, std::string)> &create_local_symbol);
 
 #endif // CPROVER_JAVA_BYTECODE_JAVA_OBJECT_FACTORY_H

--- a/jbmc/src/java_bytecode/java_object_factory.h
+++ b/jbmc/src/java_bytecode/java_object_factory.h
@@ -130,4 +130,14 @@ void gen_nondet_init(
   update_in_placet update_in_place,
   message_handlert &log);
 
+using array_element_generatort = std::function<
+  code_blockt(const exprt &element_at_counter, const typet &element_type)>;
+
+std::pair<code_blockt, symbol_exprt> nondet_array(
+  const typet &array_type,
+  const symbol_exprt &array_symbol,
+  const array_element_generatort &element_generator,
+  size_t max_array_size,
+  symbol_table_baset &symbol_table);
+
 #endif // CPROVER_JAVA_BYTECODE_JAVA_OBJECT_FACTORY_H

--- a/jbmc/src/java_bytecode/java_object_factory.h
+++ b/jbmc/src/java_bytecode/java_object_factory.h
@@ -144,7 +144,8 @@ using array_element_generatort = std::function<
 /// \param element_generator: A function that creates a new element and assigns
 /// it to the provided expression.
 /// \param allocate_local_symbol: A function that creates a local symbol in the
-/// symbol table
+/// symbol table. See \ref java_object_factoryt::assign_element for an example
+/// implementation.
 /// \param symbol_table: The symbol table.
 /// \param max_nondet_array_length: The maximum size the array can be.
 /// \return The GOTO that approximates:

--- a/jbmc/src/java_bytecode/java_object_factory.h
+++ b/jbmc/src/java_bytecode/java_object_factory.h
@@ -143,7 +143,7 @@ using array_element_generatort = std::function<
 /// \param location: Source location to use for all synthesized code.
 /// \param element_generator: A function that creates a new element and assigns
 /// it to the provided expression.
-/// \param create_local_symbol: A function that creates a local symbol in the
+/// \param allocate_local_symbol: A function that creates a local symbol in the
 /// symbol table
 /// \param symbol_table: The symbol table.
 /// \param max_nondet_array_length: The maximum size the array can be.
@@ -162,7 +162,7 @@ code_blockt gen_nondet_array_init(
   update_in_placet update_in_place,
   const source_locationt &location,
   const array_element_generatort &element_generator,
-  const allocate_localt &create_local_symbol,
+  const allocate_local_symbolt &allocate_local_symbol,
   const symbol_tablet &symbol_table,
   size_t max_nondet_array_length);
 

--- a/jbmc/src/java_bytecode/java_object_factory.h
+++ b/jbmc/src/java_bytecode/java_object_factory.h
@@ -134,12 +134,36 @@ void gen_nondet_init(
 using array_element_generatort = std::function<
   code_blockt(const exprt &element_at_counter, const typet &element_type)>;
 
-std::pair<code_blockt, symbol_exprt> nondet_array(
-  const typet &array_type,
-  const symbol_exprt &array_symbol,
+/// Synthesize GOTO for generating a array of nondet length to be stored in the
+/// \p expr.
+/// \param expr: The array expression to initialize.
+/// \param depth: The depth of the expression from a root object being created.
+/// \param update_in_place: Should the code allow the solver the freedom to
+/// leave the array as is.
+/// \param location: Source location to use for all synthesized code.
+/// \param element_generator: A function that creates a new element and assigns
+/// it to the provided expression.
+/// \param create_local_symbol: A function that creates a local symbol in the
+/// symbol table
+/// \param symbol_table: The symbol table.
+/// \param max_nondet_array_length: The maximum size the array can be.
+/// \return The GOTO that approximates:
+/// ```
+/// array_length = NONDET(int)
+/// ASSUME(array_length < max_nondet_array_length)
+/// expr = java_new_array(max_nondet_array_length)
+/// expr->length = array_length
+/// for (int i = 0; i < array_length; ++i)
+///   `element_generator()`
+/// ```
+code_blockt gen_nondet_array_init(
+  const exprt &expr,
+  size_t depth,
+  update_in_placet update_in_place,
+  const source_locationt &location,
   const array_element_generatort &element_generator,
-  size_t max_array_size,
-  symbol_table_baset &symbol_table,
-  const std::function<symbol_exprt(const typet &type, std::string)> &create_local_symbol);
+  const allocate_localt &create_local_symbol,
+  const symbol_tablet &symbol_table,
+  size_t max_nondet_array_length);
 
 #endif // CPROVER_JAVA_BYTECODE_JAVA_OBJECT_FACTORY_H

--- a/src/util/nondet.cpp
+++ b/src/util/nondet.cpp
@@ -22,12 +22,35 @@ symbol_exprt generate_nondet_int(
   allocate_objectst &allocate_objects,
   code_blockt &instructions)
 {
+  const allocate_localt cls =
+    [&allocate_objects](
+      const typet &type, std::string basename_prefix) -> symbol_exprt {
+    return allocate_objects.allocate_automatic_local_object(
+      type, basename_prefix);
+  };
+  return generate_nondet_int(
+    min_value_expr,
+    max_value_expr,
+    basename_prefix,
+    source_location,
+    cls,
+    instructions);
+}
+
+symbol_exprt generate_nondet_int(
+  const exprt &min_value_expr,
+  const exprt &max_value_expr,
+  const std::string &basename_prefix,
+  const source_locationt &source_location,
+  const allocate_localt &create_local_symbol,
+  code_blockt &instructions)
+{
   PRECONDITION(min_value_expr.type() == max_value_expr.type());
   const typet &int_type = min_value_expr.type();
 
   // Declare a symbol for the non deterministic integer.
   const symbol_exprt &nondet_symbol =
-    allocate_objects.allocate_automatic_local_object(int_type, basename_prefix);
+    create_local_symbol(int_type, basename_prefix);
   instructions.add(code_declt(nondet_symbol));
 
   // Assign the symbol any non deterministic integer value.

--- a/src/util/nondet.cpp
+++ b/src/util/nondet.cpp
@@ -22,7 +22,7 @@ symbol_exprt generate_nondet_int(
   allocate_objectst &allocate_objects,
   code_blockt &instructions)
 {
-  const allocate_localt cls =
+  const allocate_local_symbolt allocate_local_symbol =
     [&allocate_objects](
       const typet &type, std::string basename_prefix) -> symbol_exprt {
     return allocate_objects.allocate_automatic_local_object(
@@ -33,7 +33,7 @@ symbol_exprt generate_nondet_int(
     max_value_expr,
     basename_prefix,
     source_location,
-    cls,
+    allocate_local_symbol,
     instructions);
 }
 
@@ -42,7 +42,7 @@ symbol_exprt generate_nondet_int(
   const exprt &max_value_expr,
   const std::string &basename_prefix,
   const source_locationt &source_location,
-  const allocate_localt &create_local_symbol,
+  const allocate_local_symbolt &alocate_local_symbol,
   code_blockt &instructions)
 {
   PRECONDITION(min_value_expr.type() == max_value_expr.type());
@@ -50,7 +50,7 @@ symbol_exprt generate_nondet_int(
 
   // Declare a symbol for the non deterministic integer.
   const symbol_exprt &nondet_symbol =
-    create_local_symbol(int_type, basename_prefix);
+    alocate_local_symbol(int_type, basename_prefix);
   instructions.add(code_declt(nondet_symbol));
 
   // Assign the symbol any non deterministic integer value.

--- a/src/util/nondet.h
+++ b/src/util/nondet.h
@@ -15,6 +15,9 @@ Author: Diffblue Ltd.
 class allocate_objectst;
 class symbol_table_baset;
 
+using allocate_localt =
+  std::function<symbol_exprt(const typet &type, std::string)>;
+
 /// Same as \ref generate_nondet_int(
 ///   const mp_integer &min_value,
 ///   const mp_integer &max_value,
@@ -31,6 +34,14 @@ symbol_exprt generate_nondet_int(
   const std::string &basename_prefix,
   const source_locationt &source_location,
   allocate_objectst &allocate_objects,
+  code_blockt &instructions);
+
+symbol_exprt generate_nondet_int(
+  const exprt &min_value_expr,
+  const exprt &max_value_expr,
+  const std::string &basename_prefix,
+  const source_locationt &source_location,
+  const allocate_localt &create_local_symbol,
   code_blockt &instructions);
 
 /// Gets a fresh nondet choice in range (min_value, max_value). GOTO generated

--- a/src/util/nondet.h
+++ b/src/util/nondet.h
@@ -15,7 +15,7 @@ Author: Diffblue Ltd.
 class allocate_objectst;
 class symbol_table_baset;
 
-using allocate_localt =
+using allocate_local_symbolt =
   std::function<symbol_exprt(const typet &type, std::string)>;
 
 /// Same as \ref generate_nondet_int(
@@ -41,7 +41,7 @@ symbol_exprt generate_nondet_int(
   const exprt &max_value_expr,
   const std::string &basename_prefix,
   const source_locationt &source_location,
-  const allocate_localt &create_local_symbol,
+  const allocate_local_symbolt &alocate_local_symbol,
   code_blockt &instructions);
 
 /// Gets a fresh nondet choice in range (min_value, max_value). GOTO generated


### PR DESCRIPTION
- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [na] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

In TG need a way to initalise an array but to not use the object factory for its elements. This refactors the array loop init code to allow customizing on this point. I also intend to upstream a refactor to make it use a `code_fort` which makes intent clearer and code simpler. 

I would also like to refactor it to take a function that deals with adding symbols - would this be a reasonable change? 

Suggest reviewing commit by commit

The interface for the free function can be simplified a bit:
 - No need to take the array_element expression, instead let the object factory add the assignment inside the loop
 - No need to return the symbol for the array, since it is passed in. 

