### PR TITLE
Refactor and unit test symex_assign_symbol

### DIFF
--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -10,6 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 /// Symbolic Execution
 
 #include "goto_symex.h"
+#include "symex_assign.h"
 
 #include <util/format_expr.h>
 #include <util/pointer_offset_size.h>

--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -79,15 +79,7 @@ void goto_symext::symex_assign(statet &state, const code_assignt &code)
       assignment_type = symex_targett::assignment_typet::HIDDEN;
 
     exprt::operandst lhs_if_then_else_conditions;
-    symex_assign_rec(
-      state,
-      lhs,
-      nil_exprt(),
-      rhs,
-      lhs_if_then_else_conditions,
-      assignment_type,
-      ns,
-      symex_config,
-      target);
+    symex_assignt{state, assignment_type, ns, symex_config, target}
+      .symex_assign_rec(lhs, nil_exprt(), rhs, lhs_if_then_else_conditions);
   }
 }

--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -79,7 +79,7 @@ void goto_symext::symex_assign(statet &state, const code_assignt &code)
       assignment_type = symex_targett::assignment_typet::HIDDEN;
 
     exprt::operandst lhs_if_then_else_conditions;
-    symex_assignt{state, assignment_type, ns, symex_config, target}
-      .symex_assign_rec(lhs, nil_exprt(), rhs, lhs_if_then_else_conditions);
+    symex_assignt{state, assignment_type, ns, symex_config, target}.assign_rec(
+      lhs, nil_exprt(), rhs, lhs_if_then_else_conditions);
   }
 }

--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -11,6 +11,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_symex.h"
 
+#include <util/format_expr.h>
+#include <util/pointer_offset_size.h>
 #include <util/simplify_expr.h>
 
 unsigned goto_symext::dynamic_counter=0;
@@ -19,4 +21,72 @@ void goto_symext::do_simplify(exprt &expr)
 {
   if(symex_config.simplify_opt)
     simplify(expr, ns);
+}
+
+void goto_symext::symex_assign(statet &state, const code_assignt &code)
+{
+  exprt lhs = clean_expr(code.lhs(), state, true);
+  exprt rhs = clean_expr(code.rhs(), state, false);
+
+  DATA_INVARIANT(
+    lhs.type() == rhs.type(), "assignments must be type consistent");
+
+  log.conditional_output(
+    log.debug(), [this, &lhs](messaget::mstreamt &mstream) {
+      mstream << "Assignment to " << format(lhs) << " ["
+              << pointer_offset_bits(lhs.type(), ns).value_or(0) << " bits]"
+              << messaget::eom;
+    });
+
+  if(rhs.id() == ID_side_effect)
+  {
+    const side_effect_exprt &side_effect_expr = to_side_effect_expr(rhs);
+    const irep_idt &statement = side_effect_expr.get_statement();
+
+    if(
+      statement == ID_cpp_new || statement == ID_cpp_new_array ||
+      statement == ID_java_new_array_data)
+    {
+      symex_cpp_new(state, lhs, side_effect_expr);
+    }
+    else if(statement == ID_allocate)
+      symex_allocate(state, lhs, side_effect_expr);
+    else if(statement == ID_va_start)
+      symex_va_start(state, lhs, side_effect_expr);
+    else
+      UNREACHABLE;
+  }
+  else
+  {
+    assignment_typet assignment_type = symex_targett::assignment_typet::STATE;
+
+    // Let's hide return value assignments.
+    if(
+      lhs.id() == ID_symbol &&
+      id2string(to_symbol_expr(lhs).get_identifier()).find("#return_value!") !=
+        std::string::npos)
+    {
+      assignment_type = symex_targett::assignment_typet::HIDDEN;
+    }
+
+    // We hide if we are in a hidden function.
+    if(state.call_stack().top().hidden_function)
+      assignment_type = symex_targett::assignment_typet::HIDDEN;
+
+    // We hide if we are executing a hidden instruction.
+    if(state.source.pc->source_location.get_hide())
+      assignment_type = symex_targett::assignment_typet::HIDDEN;
+
+    exprt::operandst lhs_if_then_else_conditions;
+    symex_assign_rec(
+      state,
+      lhs,
+      nil_exprt(),
+      rhs,
+      lhs_if_then_else_conditions,
+      assignment_type,
+      ns,
+      symex_config,
+      target);
+  }
 }

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -552,13 +552,6 @@ protected:
     const exprt &rhs,
     exprt::operandst &,
     assignment_typet);
-  void symex_assign_from_struct(
-    statet &,
-    const ssa_exprt &lhs,
-    const exprt &full_lhs,
-    const struct_exprt &rhs,
-    const exprt::operandst &,
-    assignment_typet);
   void symex_assign_symbol(
     statet &,
     const ssa_exprt &lhs,

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -685,26 +685,4 @@ renamedt<exprt, L2> try_evaluate_pointer_comparisons(
   const irep_idt &language_mode,
   const namespacet &ns);
 
-void symex_assign_symbol(
-  goto_symex_statet &state,
-  const ssa_exprt &lhs, // L1
-  const exprt &full_lhs,
-  const exprt &rhs,
-  const exprt::operandst &guard,
-  symex_targett::assignment_typet assignment_type,
-  const namespacet &ns,
-  const symex_configt &symex_config,
-  symex_targett &target);
-
-void symex_assign_rec(
-  goto_symex_statet &state,
-  const exprt &lhs,
-  const exprt &full_lhs,
-  const exprt &rhs,
-  exprt::operandst &guard,
-  symex_targett::assignment_typet assignment_type,
-  const namespacet &ns,
-  const symex_configt &symex_config,
-  symex_targett &target);
-
 #endif // CPROVER_GOTO_SYMEX_GOTO_SYMEX_H

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -545,56 +545,6 @@ protected:
   /// meaning it will be killed when \ref symex_step concludes.
   void lift_let(statet &state, const let_exprt &let_expr);
 
-  void symex_assign_rec(
-    statet &,
-    const exprt &lhs,
-    const exprt &full_lhs,
-    const exprt &rhs,
-    exprt::operandst &,
-    assignment_typet);
-  void symex_assign_symbol(
-    statet &,
-    const ssa_exprt &lhs,
-    const exprt &full_lhs,
-    const exprt &rhs,
-    const exprt::operandst &,
-    assignment_typet);
-  void symex_assign_typecast(
-    statet &,
-    const typecast_exprt &lhs,
-    const exprt &full_lhs,
-    const exprt &rhs,
-    exprt::operandst &,
-    assignment_typet);
-  void symex_assign_array(
-    statet &,
-    const index_exprt &lhs,
-    const exprt &full_lhs,
-    const exprt &rhs,
-    exprt::operandst &,
-    assignment_typet);
-  void symex_assign_struct_member(
-    statet &,
-    const member_exprt &lhs,
-    const exprt &full_lhs,
-    const exprt &rhs,
-    exprt::operandst &,
-    assignment_typet);
-  void symex_assign_if(
-    statet &,
-    const if_exprt &lhs,
-    const exprt &full_lhs,
-    const exprt &rhs,
-    exprt::operandst &,
-    assignment_typet);
-  void symex_assign_byte_extract(
-    statet &,
-    const byte_extract_exprt &lhs,
-    const exprt &full_lhs,
-    const exprt &rhs,
-    exprt::operandst &,
-    assignment_typet);
-
   virtual void
   symex_va_start(statet &, const exprt &lhs, const side_effect_exprt &);
 
@@ -734,5 +684,27 @@ renamedt<exprt, L2> try_evaluate_pointer_comparisons(
   const value_sett &value_set,
   const irep_idt &language_mode,
   const namespacet &ns);
+
+void symex_assign_symbol(
+  goto_symex_statet &state,
+  const ssa_exprt &lhs, // L1
+  const exprt &full_lhs,
+  const exprt &rhs,
+  const exprt::operandst &guard,
+  symex_targett::assignment_typet assignment_type,
+  const namespacet &ns,
+  const symex_configt &symex_config,
+  symex_targett &target);
+
+void symex_assign_rec(
+  goto_symex_statet &state,
+  const exprt &lhs,
+  const exprt &full_lhs,
+  const exprt &rhs,
+  exprt::operandst &guard,
+  symex_targett::assignment_typet assignment_type,
+  const namespacet &ns,
+  const symex_configt &symex_config,
+  symex_targett &target);
 
 #endif // CPROVER_GOTO_SYMEX_GOTO_SYMEX_H

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -533,7 +533,8 @@ protected:
 
   typedef symex_targett::assignment_typet assignment_typet;
 
-  /// Execute any let expressions in \p expr using \ref symex_assign_symbol.
+  /// Execute any let expressions in \p expr using
+  /// \ref symex_assignt::assign_symbol.
   /// The assignments will be made in bottom-up topological but otherwise
   /// arbitrary order (i.e. in `(let x = let y = 0 in x + y) + (let z = 0 in z)
   /// we will define `y` before `x`, but `z` and `x` could come in either order)

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -9,6 +9,8 @@ Author: Daniel Kroening, kroening@kroening.com
 /// \file
 /// Symbolic Execution
 
+#include "symex_assign.h"
+
 #include "goto_symex.h"
 #include "goto_symex_state.h"
 #include <util/byte_operators.h>

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -22,72 +22,6 @@ Author: Daniel Kroening, kroening@kroening.com
 // update_exprt.
 // #define USE_UPDATE
 
-static void assign_non_struct_symbol(
-  goto_symex_statet &state,
-  const ssa_exprt &lhs, // L1
-  const exprt &full_lhs,
-  const exprt &rhs,
-  const exprt::operandst &guard,
-  symex_targett::assignment_typet assignment_type,
-  const namespacet &ns,
-  const symex_configt &symex_config,
-  symex_targett &target);
-
-static void symex_assign_array(
-  goto_symex_statet &state,
-  const index_exprt &lhs,
-  const exprt &full_lhs,
-  const exprt &rhs,
-  exprt::operandst &guard,
-  symex_targett::assignment_typet assignment_type,
-  const namespacet &ns,
-  const symex_configt &symex_config,
-  symex_targett &target);
-
-static void symex_assign_struct_member(
-  goto_symex_statet &state,
-  const member_exprt &lhs,
-  const exprt &full_lhs,
-  const exprt &rhs,
-  exprt::operandst &guard,
-  symex_targett::assignment_typet assignment_type,
-  const namespacet &ns,
-  const symex_configt &symex_config,
-  symex_targett &target);
-
-static void symex_assign_if(
-  goto_symex_statet &state,
-  const if_exprt &lhs,
-  const exprt &full_lhs,
-  const exprt &rhs,
-  exprt::operandst &guard,
-  symex_targett::assignment_typet assignment_type,
-  const namespacet &ns,
-  const symex_configt &symex_config,
-  symex_targett &target);
-
-static void symex_assign_typecast(
-  goto_symex_statet &state,
-  const typecast_exprt &lhs,
-  const exprt &full_lhs,
-  const exprt &rhs,
-  exprt::operandst &guard,
-  symex_targett::assignment_typet assignment_type,
-  const namespacet &ns,
-  const symex_configt &symex_config,
-  symex_targett &target);
-
-static void symex_assign_byte_extract(
-  goto_symex_statet &state,
-  const byte_extract_exprt &lhs,
-  const exprt &full_lhs,
-  const exprt &rhs,
-  exprt::operandst &guard,
-  symex_targett::assignment_typet assignment_type,
-  const namespacet &ns,
-  const symex_configt &symex_config,
-  symex_targett &target);
-
 /// Store the \p what expression by recursively descending into the operands
 /// of \p lhs until the first operand \c op0 is _nil_: this _nil_ operand
 /// is then replaced with \p what.
@@ -126,55 +60,23 @@ static exprt add_to_lhs(const exprt &lhs, const exprt &what)
   return new_lhs;
 }
 
-void symex_assign_rec(
-  goto_symex_statet &state,
+void symex_assignt::symex_assign_rec(
   const exprt &lhs,
   const exprt &full_lhs,
   const exprt &rhs,
-  exprt::operandst &guard,
-  symex_targett::assignment_typet assignment_type,
-  const namespacet &ns,
-  const symex_configt &symex_config,
-  symex_targett &target)
+  exprt::operandst &guard)
 {
   if(lhs.id() == ID_symbol && lhs.get_bool(ID_C_SSA_symbol))
   {
-    symex_assign_symbol(
-      state,
-      to_ssa_expr(lhs),
-      full_lhs,
-      rhs,
-      guard,
-      assignment_type,
-      ns,
-      symex_config,
-      target);
+    symex_assign_symbol(to_ssa_expr(lhs), full_lhs, rhs, guard);
   }
   else if(lhs.id() == ID_index)
-    symex_assign_array(
-      state,
-      to_index_expr(lhs),
-      full_lhs,
-      rhs,
-      guard,
-      assignment_type,
-      ns,
-      symex_config,
-      target);
+    symex_assign_array(to_index_expr(lhs), full_lhs, rhs, guard);
   else if(lhs.id()==ID_member)
   {
     const typet &type = to_member_expr(lhs).struct_op().type();
     if(type.id() == ID_struct || type.id() == ID_struct_tag)
-      symex_assign_struct_member(
-        state,
-        to_member_expr(lhs),
-        full_lhs,
-        rhs,
-        guard,
-        assignment_type,
-        ns,
-        symex_config,
-        target);
+      symex_assign_struct_member(to_member_expr(lhs), full_lhs, rhs, guard);
     else if(type.id() == ID_union || type.id() == ID_union_tag)
     {
       // should have been replaced by byte_extract
@@ -187,27 +89,9 @@ void symex_assign_rec(
         type.id_string() + "'");
   }
   else if(lhs.id()==ID_if)
-    symex_assign_if(
-      state,
-      to_if_expr(lhs),
-      full_lhs,
-      rhs,
-      guard,
-      assignment_type,
-      ns,
-      symex_config,
-      target);
+    symex_assign_if(to_if_expr(lhs), full_lhs, rhs, guard);
   else if(lhs.id()==ID_typecast)
-    symex_assign_typecast(
-      state,
-      to_typecast_expr(lhs),
-      full_lhs,
-      rhs,
-      guard,
-      assignment_type,
-      ns,
-      symex_config,
-      target);
+    symex_assign_typecast(to_typecast_expr(lhs), full_lhs, rhs, guard);
   else if(lhs.id() == ID_string_constant ||
           lhs.id() == ID_null_object ||
           lhs.id() == "zero_string" ||
@@ -219,16 +103,7 @@ void symex_assign_rec(
   else if(lhs.id()==ID_byte_extract_little_endian ||
           lhs.id()==ID_byte_extract_big_endian)
   {
-    symex_assign_byte_extract(
-      state,
-      to_byte_extract_expr(lhs),
-      full_lhs,
-      rhs,
-      guard,
-      assignment_type,
-      ns,
-      symex_config,
-      target);
+    symex_assign_byte_extract(to_byte_extract_expr(lhs), full_lhs, rhs, guard);
   }
   else if(lhs.id() == ID_complex_real)
   {
@@ -240,16 +115,7 @@ void symex_assign_rec(
     complex_exprt new_rhs(
       rhs, complex_imag_expr, to_complex_type(complex_real_expr.op().type()));
 
-    symex_assign_rec(
-      state,
-      complex_real_expr.op(),
-      full_lhs,
-      new_rhs,
-      guard,
-      assignment_type,
-      ns,
-      symex_config,
-      target);
+    symex_assign_rec(complex_real_expr.op(), full_lhs, new_rhs, guard);
   }
   else if(lhs.id() == ID_complex_imag)
   {
@@ -260,16 +126,7 @@ void symex_assign_rec(
     complex_exprt new_rhs(
       complex_real_expr, rhs, to_complex_type(complex_imag_expr.op().type()));
 
-    symex_assign_rec(
-      state,
-      complex_imag_expr.op(),
-      full_lhs,
-      new_rhs,
-      guard,
-      assignment_type,
-      ns,
-      symex_config,
-      target);
+    symex_assign_rec(complex_imag_expr.op(), full_lhs, new_rhs, guard);
   }
   else
     throw unsupported_operation_exceptiont(
@@ -455,24 +312,16 @@ static assignmentt shift_indexed_access_to_lhs(
 /// with results like `x = {1, 2}; x..field1 = x.field1; x..field2 = x.field2;`
 /// This abbreviates the process, directly producing
 /// `x..field1 = 1; x..field2 = 2;`
-/// \param state: goto-symex state
 /// \param lhs: symbol to assign (already renamed to L1)
 /// \param full_lhs: expression skeleton corresponding to \p lhs, to be included
 ///   in the result trace
 /// \param rhs: struct expression to assign to \p lhs
 /// \param guard: guard conjuncts that must hold for this assignment to be made
-/// \param assignment_type: assignment type (see
-///   \ref symex_targett::assignment_typet)
-static void symex_assign_from_struct(
-  goto_symex_statet &state,
+void symex_assignt::symex_assign_from_struct(
   const ssa_exprt &lhs, // L1
   const exprt &full_lhs,
   const struct_exprt &rhs,
-  const exprt::operandst &guard,
-  symex_targett::assignment_typet assignment_type,
-  const namespacet &ns,
-  const symex_configt &symex_config,
-  symex_targett &target)
+  const exprt::operandst &guard)
 {
   const auto &components = to_struct_type(ns.follow(lhs.type())).components();
   PRECONDITION(rhs.operands().size() == components.size());
@@ -489,43 +338,24 @@ static void symex_assign_from_struct(
     if(comp_rhs.second.id() == ID_struct)
     {
       symex_assign_from_struct(
-        state,
         to_ssa_expr(lhs_field),
         full_lhs,
         to_struct_expr(comp_rhs.second),
-        guard,
-        assignment_type,
-        ns,
-        symex_config,
-        target);
+        guard);
     }
     else
     {
       assign_non_struct_symbol(
-        state,
-        to_ssa_expr(lhs_field),
-        full_lhs,
-        comp_rhs.second,
-        guard,
-        assignment_type,
-        ns,
-        symex_config,
-        target);
+        to_ssa_expr(lhs_field), full_lhs, comp_rhs.second, guard);
     }
   }
 }
 
-/// \return l2_lhs
-static void assign_non_struct_symbol(
-  goto_symex_statet &state,
+void symex_assignt::assign_non_struct_symbol(
   const ssa_exprt &lhs, // L1
   const exprt &full_lhs,
   const exprt &rhs,
-  const exprt::operandst &guard,
-  symex_targett::assignment_typet assignment_type,
-  const namespacet &ns,
-  const symex_configt &symex_config,
-  symex_targett &target)
+  const exprt::operandst &guard)
 {
   exprt l2_rhs =
     state
@@ -564,8 +394,10 @@ static void assign_non_struct_symbol(
     state.rename(add_to_lhs(full_lhs, l2_lhs), ns).get();
   state.record_events.pop();
 
-  if(ns.lookup(l2_lhs.get_object_name()).is_auxiliary)
-    assignment_type=symex_targett::assignment_typet::HIDDEN;
+  auto current_assignment_type =
+    ns.lookup(l2_lhs.get_object_name()).is_auxiliary
+      ? symex_targett::assignment_typet::HIDDEN
+      : assignment_type;
 
   target.assignment(
     make_and(state.guard.as_expr(), conjunction(guard)),
@@ -574,7 +406,7 @@ static void assign_non_struct_symbol(
     get_original_name(l2_full_lhs),
     assignment.rhs,
     state.source,
-    assignment_type);
+    current_assignment_type);
 
   const ssa_exprt &l1_lhs = assignment.lhs;
   if(field_sensitivityt::is_divisible(l1_lhs))
@@ -590,84 +422,37 @@ static void assign_non_struct_symbol(
   }
 }
 
-void symex_assign_symbol(
-  goto_symex_statet &state,
+void symex_assignt::symex_assign_symbol(
   const ssa_exprt &lhs, // L1
   const exprt &full_lhs,
   const exprt &rhs,
-  const exprt::operandst &guard,
-  symex_targett::assignment_typet assignment_type,
-  const namespacet &ns,
-  const symex_configt &symex_config,
-  symex_targett &target)
+  const exprt::operandst &guard)
 {
   // Shortcut the common case of a whole-struct initializer:
   if(rhs.id() == ID_struct)
-  {
-    symex_assign_from_struct(
-      state,
-      lhs,
-      full_lhs,
-      to_struct_expr(rhs),
-      guard,
-      assignment_type,
-      ns,
-      symex_config,
-      target);
-  }
+    symex_assign_from_struct(lhs, full_lhs, to_struct_expr(rhs), guard);
   else
-  {
-    assign_non_struct_symbol(
-      state,
-      lhs,
-      full_lhs,
-      rhs,
-      guard,
-      assignment_type,
-      ns,
-      symex_config,
-      target);
-  }
+    assign_non_struct_symbol(lhs, full_lhs, rhs, guard);
 }
 
-static void symex_assign_typecast(
-  goto_symex_statet &state,
+void symex_assignt::symex_assign_typecast(
   const typecast_exprt &lhs,
   const exprt &full_lhs,
   const exprt &rhs,
-  exprt::operandst &guard,
-  symex_targett::assignment_typet assignment_type,
-  const namespacet &ns,
-  const symex_configt &symex_config,
-  symex_targett &target)
+  exprt::operandst &guard)
 {
   // these may come from dereferencing on the lhs
   exprt rhs_typecasted = typecast_exprt::conditional_cast(rhs, lhs.op().type());
 
   exprt new_full_lhs=add_to_lhs(full_lhs, lhs);
-
-  symex_assign_rec(
-    state,
-    lhs.op(),
-    new_full_lhs,
-    rhs_typecasted,
-    guard,
-    assignment_type,
-    ns,
-    symex_config,
-    target);
+  symex_assign_rec(lhs.op(), new_full_lhs, rhs_typecasted, guard);
 }
 
-static void symex_assign_array(
-  goto_symex_statet &state,
+void symex_assignt::symex_assign_array(
   const index_exprt &lhs,
   const exprt &full_lhs,
   const exprt &rhs,
-  exprt::operandst &guard,
-  symex_targett::assignment_typet assignment_type,
-  const namespacet &ns,
-  const symex_configt &symex_config,
-  symex_targett &target)
+  exprt::operandst &guard)
 {
   const exprt &lhs_array=lhs.array();
   const exprt &lhs_index=lhs.index();
@@ -701,29 +486,15 @@ static void symex_assign_array(
   const with_exprt new_rhs{lhs_array, lhs_index, rhs};
   const exprt new_full_lhs = add_to_lhs(full_lhs, lhs);
 
-  symex_assign_rec(
-    state,
-    lhs_array,
-    new_full_lhs,
-    new_rhs,
-    guard,
-    assignment_type,
-    ns,
-    symex_config,
-    target);
+  symex_assign_rec(lhs_array, new_full_lhs, new_rhs, guard);
 #endif
 }
 
-static void symex_assign_struct_member(
-  goto_symex_statet &state,
+void symex_assignt::symex_assign_struct_member(
   const member_exprt &lhs,
   const exprt &full_lhs,
   const exprt &rhs,
-  exprt::operandst &guard,
-  symex_targett::assignment_typet assignment_type,
-  const namespacet &ns,
-  const symex_configt &symex_config,
-  symex_targett &target)
+  exprt::operandst &guard)
 {
   // Symbolic execution of a struct member assignment.
 
@@ -781,30 +552,15 @@ static void symex_assign_struct_member(
   new_rhs.where().set(ID_component_name, component_name);
 
   exprt new_full_lhs=add_to_lhs(full_lhs, lhs);
-
-  symex_assign_rec(
-    state,
-    lhs_struct,
-    new_full_lhs,
-    new_rhs,
-    guard,
-    assignment_type,
-    ns,
-    symex_config,
-    target);
+  symex_assign_rec(lhs_struct, new_full_lhs, new_rhs, guard);
 #endif
 }
 
-static void symex_assign_if(
-  goto_symex_statet &state,
+void symex_assignt::symex_assign_if(
   const if_exprt &lhs,
   const exprt &full_lhs,
   const exprt &rhs,
-  exprt::operandst &guard,
-  symex_targett::assignment_typet assignment_type,
-  const namespacet &ns,
-  const symex_configt &symex_config,
-  symex_targett &target)
+  exprt::operandst &guard)
 {
   // we have (c?a:b)=e;
   exprt renamed_guard = state.rename(lhs.cond(), ns).get();
@@ -814,46 +570,23 @@ static void symex_assign_if(
   if(!renamed_guard.is_false())
   {
     guard.push_back(renamed_guard);
-    symex_assign_rec(
-      state,
-      lhs.true_case(),
-      full_lhs,
-      rhs,
-      guard,
-      assignment_type,
-      ns,
-      symex_config,
-      target);
+    symex_assign_rec(lhs.true_case(), full_lhs, rhs, guard);
     guard.pop_back();
   }
 
   if(!renamed_guard.is_true())
   {
     guard.push_back(not_exprt(renamed_guard));
-    symex_assign_rec(
-      state,
-      lhs.false_case(),
-      full_lhs,
-      rhs,
-      guard,
-      assignment_type,
-      ns,
-      symex_config,
-      target);
+    symex_assign_rec(lhs.false_case(), full_lhs, rhs, guard);
     guard.pop_back();
   }
 }
 
-static void symex_assign_byte_extract(
-  goto_symex_statet &state,
+void symex_assignt::symex_assign_byte_extract(
   const byte_extract_exprt &lhs,
   const exprt &full_lhs,
   const exprt &rhs,
-  exprt::operandst &guard,
-  symex_targett::assignment_typet assignment_type,
-  const namespacet &ns,
-  const symex_configt &symex_config,
-  symex_targett &target)
+  exprt::operandst &guard)
 {
   // we have byte_extract_X(object, offset)=value
   // turn into object=byte_update_X(object, offset, value)
@@ -868,15 +601,5 @@ static void symex_assign_byte_extract(
 
   const byte_update_exprt new_rhs{byte_update_id, lhs.op(), lhs.offset(), rhs};
   exprt new_full_lhs=add_to_lhs(full_lhs, lhs);
-
-  symex_assign_rec(
-    state,
-    lhs.op(),
-    new_full_lhs,
-    new_rhs,
-    guard,
-    assignment_type,
-    ns,
-    symex_config,
-    target);
+  symex_assign_rec(lhs.op(), new_full_lhs, new_rhs, guard);
 }

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -335,19 +335,8 @@ void symex_assignt::symex_assign_from_struct(
       lhs_field.id() == ID_symbol,
       "member of symbol should be susceptible to field-sensitivity");
 
-    if(comp_rhs.second.id() == ID_struct)
-    {
-      symex_assign_from_struct(
-        to_ssa_expr(lhs_field),
-        full_lhs,
-        to_struct_expr(comp_rhs.second),
-        guard);
-    }
-    else
-    {
-      assign_non_struct_symbol(
-        to_ssa_expr(lhs_field), full_lhs, comp_rhs.second, guard);
-    }
+    symex_assign_symbol(
+      to_ssa_expr(lhs_field), full_lhs, comp_rhs.second, guard);
   }
 }
 

--- a/src/goto-symex/symex_assign.h
+++ b/src/goto-symex/symex_assign.h
@@ -19,6 +19,9 @@ class goto_symex_statet;
 class ssa_exprt;
 struct symex_configt;
 
+/// Record the assignment of value \p rhs to variable \p lhs in \p state and add
+/// the equation to target: `lhs#{n+1} == guard ? rhs#{m} : lhs#{n}`
+/// where {n} and {m} denote the current L2 indexes of lhs and rhs respectively.
 void symex_assign_symbol(
   goto_symex_statet &state,
   const ssa_exprt &lhs, // L1

--- a/src/goto-symex/symex_assign.h
+++ b/src/goto-symex/symex_assign.h
@@ -42,13 +42,13 @@ public:
   /// add the equation to target: `lhs#{n+1} == guard ? rhs#{m} : lhs#{n}`
   /// where {n} and {m} denote the current L2 indexes of lhs and rhs
   /// respectively.
-  void symex_assign_symbol(
+  void assign_symbol(
     const ssa_exprt &lhs, // L1
     const exprt &full_lhs,
     const exprt &rhs,
     const exprt::operandst &guard);
 
-  void symex_assign_rec(
+  void assign_rec(
     const exprt &lhs,
     const exprt &full_lhs,
     const exprt &rhs,
@@ -61,7 +61,7 @@ private:
   const symex_configt &symex_config;
   symex_targett &target;
 
-  void symex_assign_from_struct(
+  void assign_from_struct(
     const ssa_exprt &lhs, // L1
     const exprt &full_lhs,
     const struct_exprt &rhs,
@@ -73,31 +73,31 @@ private:
     const exprt &rhs,
     const exprt::operandst &guard);
 
-  void symex_assign_array(
+  void assign_array(
     const index_exprt &lhs,
     const exprt &full_lhs,
     const exprt &rhs,
     exprt::operandst &guard);
 
-  void symex_assign_struct_member(
+  void assign_struct_member(
     const member_exprt &lhs,
     const exprt &full_lhs,
     const exprt &rhs,
     exprt::operandst &guard);
 
-  void symex_assign_if(
+  void assign_if(
     const if_exprt &lhs,
     const exprt &full_lhs,
     const exprt &rhs,
     exprt::operandst &guard);
 
-  void symex_assign_typecast(
+  void assign_typecast(
     const typecast_exprt &lhs,
     const exprt &full_lhs,
     const exprt &rhs,
     exprt::operandst &guard);
 
-  void symex_assign_byte_extract(
+  void assign_byte_extract(
     const byte_extract_exprt &lhs,
     const exprt &full_lhs,
     const exprt &rhs,

--- a/src/goto-symex/symex_assign.h
+++ b/src/goto-symex/symex_assign.h
@@ -16,32 +16,92 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include <util/expr.h>
 
 class goto_symex_statet;
+class byte_extract_exprt;
 class ssa_exprt;
 struct symex_configt;
 
-/// Record the assignment of value \p rhs to variable \p lhs in \p state and add
-/// the equation to target: `lhs#{n+1} == guard ? rhs#{m} : lhs#{n}`
-/// where {n} and {m} denote the current L2 indexes of lhs and rhs respectively.
-void symex_assign_symbol(
-  goto_symex_statet &state,
-  const ssa_exprt &lhs, // L1
-  const exprt &full_lhs,
-  const exprt &rhs,
-  const exprt::operandst &guard,
-  symex_targett::assignment_typet assignment_type,
-  const namespacet &ns,
-  const symex_configt &symex_config,
-  symex_targett &target);
+/// Functor for symex assignment
+class symex_assignt
+{
+public:
+  symex_assignt(
+    goto_symex_statet &state,
+    symex_targett::assignment_typet assignment_type,
+    const namespacet &ns,
+    const symex_configt &symex_config,
+    symex_targett &target)
+    : state(state),
+      assignment_type(assignment_type),
+      ns(ns),
+      symex_config(symex_config),
+      target(target)
+  {
+  }
 
-void symex_assign_rec(
-  goto_symex_statet &state,
-  const exprt &lhs,
-  const exprt &full_lhs,
-  const exprt &rhs,
-  exprt::operandst &guard,
-  symex_targett::assignment_typet assignment_type,
-  const namespacet &ns,
-  const symex_configt &symex_config,
-  symex_targett &target);
+  /// Record the assignment of value \p rhs to variable \p lhs in \p state and
+  /// add the equation to target: `lhs#{n+1} == guard ? rhs#{m} : lhs#{n}`
+  /// where {n} and {m} denote the current L2 indexes of lhs and rhs
+  /// respectively.
+  void symex_assign_symbol(
+    const ssa_exprt &lhs, // L1
+    const exprt &full_lhs,
+    const exprt &rhs,
+    const exprt::operandst &guard);
+
+  void symex_assign_rec(
+    const exprt &lhs,
+    const exprt &full_lhs,
+    const exprt &rhs,
+    exprt::operandst &guard);
+
+private:
+  goto_symex_statet &state;
+  symex_targett::assignment_typet assignment_type;
+  const namespacet &ns;
+  const symex_configt &symex_config;
+  symex_targett &target;
+
+  void symex_assign_from_struct(
+    const ssa_exprt &lhs, // L1
+    const exprt &full_lhs,
+    const struct_exprt &rhs,
+    const exprt::operandst &guard);
+
+  void assign_non_struct_symbol(
+    const ssa_exprt &lhs, // L1
+    const exprt &full_lhs,
+    const exprt &rhs,
+    const exprt::operandst &guard);
+
+  void symex_assign_array(
+    const index_exprt &lhs,
+    const exprt &full_lhs,
+    const exprt &rhs,
+    exprt::operandst &guard);
+
+  void symex_assign_struct_member(
+    const member_exprt &lhs,
+    const exprt &full_lhs,
+    const exprt &rhs,
+    exprt::operandst &guard);
+
+  void symex_assign_if(
+    const if_exprt &lhs,
+    const exprt &full_lhs,
+    const exprt &rhs,
+    exprt::operandst &guard);
+
+  void symex_assign_typecast(
+    const typecast_exprt &lhs,
+    const exprt &full_lhs,
+    const exprt &rhs,
+    exprt::operandst &guard);
+
+  void symex_assign_byte_extract(
+    const byte_extract_exprt &lhs,
+    const exprt &full_lhs,
+    const exprt &rhs,
+    exprt::operandst &guard);
+};
 
 #endif // CPROVER_GOTO_SYMEX_SYMEX_ASSIGN_H

--- a/src/goto-symex/symex_assign.h
+++ b/src/goto-symex/symex_assign.h
@@ -1,0 +1,44 @@
+/*******************************************************************\
+
+Module: Symbolic Execution
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+/// \file
+/// Symbolic Execution of assignments
+
+#ifndef CPROVER_GOTO_SYMEX_SYMEX_ASSIGN_H
+#define CPROVER_GOTO_SYMEX_SYMEX_ASSIGN_H
+
+#include "symex_target.h"
+#include <util/expr.h>
+
+class goto_symex_statet;
+class ssa_exprt;
+struct symex_configt;
+
+void symex_assign_symbol(
+  goto_symex_statet &state,
+  const ssa_exprt &lhs, // L1
+  const exprt &full_lhs,
+  const exprt &rhs,
+  const exprt::operandst &guard,
+  symex_targett::assignment_typet assignment_type,
+  const namespacet &ns,
+  const symex_configt &symex_config,
+  symex_targett &target);
+
+void symex_assign_rec(
+  goto_symex_statet &state,
+  const exprt &lhs,
+  const exprt &full_lhs,
+  const exprt &rhs,
+  exprt::operandst &guard,
+  symex_targett::assignment_typet assignment_type,
+  const namespacet &ns,
+  const symex_configt &symex_config,
+  symex_targett &target);
+
+#endif // CPROVER_GOTO_SYMEX_SYMEX_ASSIGN_H

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -19,6 +19,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/pointer_offset_size.h>
 #include <util/simplify_expr.h>
 
+#include "symex_assign.h"
 #include "symex_dereference_state.h"
 
 #include <pointer-analysis/value_set_dereference.h>

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -189,7 +189,10 @@ void goto_symext::lift_let(statet &state, const let_exprt &let_expr)
     nil_exprt(),
     let_value,
     value_assignment_guard,
-    symex_targett::assignment_typet::HIDDEN);
+    symex_targett::assignment_typet::HIDDEN,
+    ns,
+    symex_config,
+    target);
 
   // Schedule the bound variable to be cleaned up at the end of symex_step:
   instruction_local_symbols.push_back(let_expr.symbol());

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -186,7 +186,7 @@ void goto_symext::lift_let(statet &state, const let_exprt &let_expr)
   exprt::operandst value_assignment_guard;
   symex_assignt{
     state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
-    .symex_assign_symbol(
+    .assign_symbol(
       to_ssa_expr(state.rename<L1>(let_expr.symbol(), ns).get()),
       nil_exprt(),
       let_value,

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -184,16 +184,13 @@ void goto_symext::lift_let(statet &state, const let_exprt &let_expr)
   do_simplify(let_value);
 
   exprt::operandst value_assignment_guard;
-  symex_assign_symbol(
-    state,
-    to_ssa_expr(state.rename<L1>(let_expr.symbol(), ns).get()),
-    nil_exprt(),
-    let_value,
-    value_assignment_guard,
-    symex_targett::assignment_typet::HIDDEN,
-    ns,
-    symex_config,
-    target);
+  symex_assignt{
+    state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
+    .symex_assign_symbol(
+      to_ssa_expr(state.rename<L1>(let_expr.symbol(), ns).get()),
+      nil_exprt(),
+      let_value,
+      value_assignment_guard);
 
   // Schedule the bound variable to be cleaned up at the end of symex_step:
   instruction_local_symbols.push_back(let_expr.symbol());

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -20,6 +20,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/prefix.h>
 #include <util/range.h>
 
+#include "symex_assign.h"
+
 static void locality(
   const irep_idt &function_identifier,
   goto_symext::statet &state,

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -141,7 +141,7 @@ void goto_symext::parameter_assignments(
 
       exprt::operandst lhs_conditions;
       symex_assignt{state, assignment_type, ns, symex_config, target}
-        .symex_assign_rec(lhs, nil_exprt(), rhs, lhs_conditions);
+        .assign_rec(lhs, nil_exprt(), rhs, lhs_conditions);
     }
 
     if(it1!=arguments.end())

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -139,7 +139,15 @@ void goto_symext::parameter_assignments(
 
       exprt::operandst lhs_conditions;
       symex_assign_rec(
-        state, lhs, nil_exprt(), rhs, lhs_conditions, assignment_type);
+        state,
+        lhs,
+        nil_exprt(),
+        rhs,
+        lhs_conditions,
+        assignment_type,
+        ns,
+        symex_config,
+        target);
     }
 
     if(it1!=arguments.end())

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -140,16 +140,8 @@ void goto_symext::parameter_assignments(
       rhs = clean_expr(std::move(rhs), state, false);
 
       exprt::operandst lhs_conditions;
-      symex_assign_rec(
-        state,
-        lhs,
-        nil_exprt(),
-        rhs,
-        lhs_conditions,
-        assignment_type,
-        ns,
-        symex_config,
-        target);
+      symex_assignt{state, assignment_type, ns, symex_config, target}
+        .symex_assign_rec(lhs, nil_exprt(), rhs, lhs_conditions);
     }
 
     if(it1!=arguments.end())

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -14,6 +14,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/exception_utils.h>
 #include <util/expr_initializer.h>
 
+#include "symex_assign.h"
+
 void goto_symext::symex_start_thread(statet &state)
 {
   if(state.guard.is_false())

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -87,16 +87,9 @@ void goto_symext::symex_start_thread(statet &state)
 
     exprt::operandst lhs_conditions;
     state.record_events.push(false);
-    symex_assign_symbol(
-      state,
-      lhs_l1,
-      nil_exprt(),
-      rhs,
-      lhs_conditions,
-      symex_targett::assignment_typet::HIDDEN,
-      ns,
-      symex_config,
-      target);
+    symex_assignt{
+      state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
+      .symex_assign_symbol(lhs_l1, nil_exprt(), rhs, lhs_conditions);
     state.record_events.pop();
   }
 
@@ -127,15 +120,8 @@ void goto_symext::symex_start_thread(statet &state)
     }
 
     exprt::operandst lhs_conditions;
-    symex_assign_symbol(
-      state,
-      lhs,
-      nil_exprt(),
-      rhs,
-      lhs_conditions,
-      symex_targett::assignment_typet::HIDDEN,
-      ns,
-      symex_config,
-      target);
+    symex_assignt{
+      state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
+      .symex_assign_symbol(lhs, nil_exprt(), rhs, lhs_conditions);
   }
 }

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -89,7 +89,7 @@ void goto_symext::symex_start_thread(statet &state)
     state.record_events.push(false);
     symex_assignt{
       state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
-      .symex_assign_symbol(lhs_l1, nil_exprt(), rhs, lhs_conditions);
+      .assign_symbol(lhs_l1, nil_exprt(), rhs, lhs_conditions);
     state.record_events.pop();
   }
 
@@ -122,6 +122,6 @@ void goto_symext::symex_start_thread(statet &state)
     exprt::operandst lhs_conditions;
     symex_assignt{
       state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
-      .symex_assign_symbol(lhs, nil_exprt(), rhs, lhs_conditions);
+      .assign_symbol(lhs, nil_exprt(), rhs, lhs_conditions);
   }
 }

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -91,7 +91,10 @@ void goto_symext::symex_start_thread(statet &state)
       nil_exprt(),
       rhs,
       lhs_conditions,
-      symex_targett::assignment_typet::HIDDEN);
+      symex_targett::assignment_typet::HIDDEN,
+      ns,
+      symex_config,
+      target);
     state.record_events.pop();
   }
 
@@ -128,6 +131,9 @@ void goto_symext::symex_start_thread(statet &state)
       nil_exprt(),
       rhs,
       lhs_conditions,
-      symex_targett::assignment_typet::HIDDEN);
+      symex_targett::assignment_typet::HIDDEN,
+      ns,
+      symex_config,
+      target);
   }
 }

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -34,6 +34,7 @@ SRC += analyses/ai/ai.cpp \
        goto-symex/goto_symex_state.cpp \
        goto-symex/ssa_equation.cpp \
        goto-symex/is_constant.cpp \
+       goto-symex/symex_assign.cpp \
        goto-symex/symex_level0.cpp \
        goto-symex/symex_level1.cpp \
        goto-symex/try_evaluate_pointer_comparisons.cpp \

--- a/unit/goto-symex/symex_assign.cpp
+++ b/unit/goto-symex/symex_assign.cpp
@@ -1,0 +1,121 @@
+/*******************************************************************\
+
+Module: Unit tests for symex_assign
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+#include <testing-utils/message.h>
+#include <testing-utils/use_catch.h>
+
+#include <analyses/dirty.h>
+#include <analyses/guard.h>
+#include <goto-symex/goto_symex.h>
+#include <goto-symex/goto_symex_state.h>
+#include <goto-symex/symex_assign.h>
+#include <goto-symex/symex_target.h>
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/namespace.h>
+#include <util/symbol_table.h>
+
+static void add_to_symbol_table(
+  symbol_tablet &symbol_table,
+  const symbol_exprt &symbol_expr)
+{
+  symbolt symbol;
+  symbol.name = symbol_expr.get_identifier();
+  symbol.type = symbol_expr.type();
+  symbol.value = symbol_expr;
+  symbol.is_thread_local = true;
+  symbol_table.insert(symbol);
+}
+
+SCENARIO(
+  "symex_assign_symbol",
+  "[core][goto-symex][symex-assign][symex-assign-symbol]")
+{
+  // Note that the initialization part of this test is very similar to that of
+  // goto_symex_state.cpp
+
+  // Initialize goto state
+  std::list<goto_programt::instructiont> target;
+  symex_targett::sourcet source{"fun", target.begin()};
+  guard_managert manager;
+  std::size_t fresh_name_count = 1;
+  auto fresh_name = [&fresh_name_count](const irep_idt &) {
+    return fresh_name_count++;
+  };
+  goto_symex_statet state{source, manager, fresh_name};
+
+  // Initialize dirty field of state
+  incremental_dirtyt dirty;
+  goto_functiont function;
+  dirty.populate_dirty_for_function("fun", function);
+  state.dirty = &dirty;
+
+  GIVEN("An L1 lhs and an L2 rhs of type int, and a guard g")
+  {
+    // Initialize symbol table with an integer symbol `foo`
+    symbol_tablet symbol_table;
+    namespacet ns{symbol_table};
+    const signedbv_typet int_type{32};
+    const symbol_exprt foo{"foo", int_type};
+    add_to_symbol_table(symbol_table, foo);
+    const ssa_exprt ssa_foo{foo};
+
+    const symbol_exprt g{"g", bool_typet{}};
+    add_to_symbol_table(symbol_table, g);
+    exprt::operandst guard;
+    guard.push_back(g);
+
+    null_message_handlert log;
+    optionst options;
+    symex_configt symex_config{options};
+
+    WHEN("Symbol `foo` is assigned constant integer `475`")
+    {
+      const exprt rhs1 = from_integer(475, int_type);
+      symex_target_equationt target{log};
+      exprt full_lhs = nil_exprt{};
+      full_lhs.type() = int_type;
+      symex_assign_symbol(
+        state,
+        ssa_foo,
+        full_lhs,
+        rhs1,
+        guard,
+        symex_targett::assignment_typet::STATE,
+        ns,
+        symex_config,
+        target);
+      THEN("An equation is added to the target")
+      {
+        REQUIRE(target.SSA_steps.size() == 1);
+        SSA_stept step = target.SSA_steps.back();
+        REQUIRE(step.type == goto_trace_stept::typet::ASSIGNMENT);
+        REQUIRE(step.assignment_type == symex_targett::assignment_typet::STATE);
+        REQUIRE(step.cond_expr == equal_exprt{step.ssa_lhs, step.ssa_rhs});
+        REQUIRE(step.guard == g);
+
+        THEN("The left-hand-side of the equation is foo!0#1")
+        {
+          REQUIRE(to_symbol_expr(step.ssa_lhs).get_identifier() == "foo!0#1");
+        }
+        THEN("The right-hand-side of the equation is g!0#0 ? 475 : foo!0#0")
+        {
+          const if_exprt *rhs_if =
+            expr_try_dynamic_cast<if_exprt>(step.ssa_rhs);
+          REQUIRE(rhs_if != nullptr);
+          REQUIRE(to_symbol_expr(rhs_if->cond()).get_identifier() == "g!0#0");
+          const auto then_value =
+            numeric_cast_v<mp_integer>(to_constant_expr(rhs_if->true_case()));
+          REQUIRE(then_value == 475);
+          const symbol_exprt rhs_symbol = to_symbol_expr(rhs_if->false_case());
+          REQUIRE(rhs_symbol.get_identifier() == "foo!0#0");
+        }
+      }
+    }
+  }
+}

--- a/unit/goto-symex/symex_assign.cpp
+++ b/unit/goto-symex/symex_assign.cpp
@@ -55,38 +55,40 @@ SCENARIO(
   dirty.populate_dirty_for_function("fun", function);
   state.dirty = &dirty;
 
+  // Initialize symbol table with an integer symbol `foo`, and a boolean g
+  symbol_tablet symbol_table;
+  namespacet ns{symbol_table};
+  const signedbv_typet int_type{32};
+  const symbol_exprt foo{"foo", int_type};
+  add_to_symbol_table(symbol_table, foo);
+  const ssa_exprt ssa_foo{foo};
+  const symbol_exprt g{"g", bool_typet{}};
+  add_to_symbol_table(symbol_table, g);
+
+  optionst options;
+  symex_configt symex_config{options};
+
   GIVEN("An L1 lhs and an L2 rhs of type int, and a guard g")
   {
-    // Initialize symbol table with an integer symbol `foo`
-    symbol_tablet symbol_table;
-    namespacet ns{symbol_table};
-    const signedbv_typet int_type{32};
-    const symbol_exprt foo{"foo", int_type};
-    add_to_symbol_table(symbol_table, foo);
-    const ssa_exprt ssa_foo{foo};
-
-    const symbol_exprt g{"g", bool_typet{}};
-    add_to_symbol_table(symbol_table, g);
     exprt::operandst guard;
     guard.push_back(g);
-
-    null_message_handlert log;
-    optionst options;
-    symex_configt symex_config{options};
+    symex_target_equationt target_equation{null_message_handler};
 
     WHEN("Symbol `foo` is assigned constant integer `475`")
     {
       const exprt rhs1 = from_integer(475, int_type);
-      symex_target_equationt target{log};
       exprt full_lhs = nil_exprt{};
       full_lhs.type() = int_type;
-      symex_assignt{
-        state, symex_targett::assignment_typet::STATE, ns, symex_config, target}
+      symex_assignt{state,
+                    symex_targett::assignment_typet::STATE,
+                    ns,
+                    symex_config,
+                    target_equation}
         .symex_assign_symbol(ssa_foo, full_lhs, rhs1, guard);
       THEN("An equation is added to the target")
       {
-        REQUIRE(target.SSA_steps.size() == 1);
-        SSA_stept step = target.SSA_steps.back();
+        REQUIRE(target_equation.SSA_steps.size() == 1);
+        SSA_stept step = target_equation.SSA_steps.back();
         REQUIRE(step.type == goto_trace_stept::typet::ASSIGNMENT);
         REQUIRE(step.assignment_type == symex_targett::assignment_typet::STATE);
         REQUIRE(step.cond_expr == equal_exprt{step.ssa_lhs, step.ssa_rhs});
@@ -117,6 +119,81 @@ SCENARIO(
         {
           REQUIRE(
             to_symbol_expr(step.original_full_lhs).get_identifier() == "foo");
+        }
+      }
+    }
+  }
+  GIVEN(
+    "A lhs and rhs of type int, an empty guard, and constant propagation "
+    "activated")
+  {
+    exprt::operandst guard;
+    symex_config.constant_propagation = true;
+    WHEN("foo is assigned without a guard")
+    {
+      const exprt rhs1 = from_integer(5721, int_type);
+      symex_target_equationt target_equation{null_message_handler};
+      exprt full_lhs = nil_exprt{};
+      full_lhs.type() = int_type;
+      symex_assignt symex_assign{state,
+                                 symex_targett::assignment_typet::STATE,
+                                 ns,
+                                 symex_config,
+                                 target_equation};
+      symex_assign.symex_assign_symbol(ssa_foo, full_lhs, rhs1, guard);
+      THEN("An equation with an empty guard is added to the target")
+      {
+        REQUIRE(target_equation.SSA_steps.size() == 1);
+        SSA_stept step = target_equation.SSA_steps.back();
+        REQUIRE(step.guard == true_exprt{});
+      }
+      THEN("The propagation map maps 'foo' to 5721")
+      {
+        const auto propagated = state.rename(ssa_foo, ns);
+        const mp_integer value =
+          numeric_cast_v<mp_integer>(to_constant_expr(propagated.get()));
+        REQUIRE(value == 5721);
+        WHEN("foo is assigned a second time")
+        {
+          const exprt rhs2 = from_integer(1841, int_type);
+          exprt full_lhs2 = nil_exprt{};
+          full_lhs.type() = int_type;
+          symex_assign.symex_assign_symbol(ssa_foo, full_lhs2, rhs2, guard);
+          THEN("A second equation is added to the target")
+          {
+            REQUIRE(target_equation.SSA_steps.size() == 2);
+            SSA_stept step = target_equation.SSA_steps.back();
+            REQUIRE(step.type == goto_trace_stept::typet::ASSIGNMENT);
+            REQUIRE(
+              step.assignment_type == symex_targett::assignment_typet::STATE);
+            REQUIRE(step.cond_expr.id() == ID_equal);
+            REQUIRE(step.cond_expr == equal_exprt{step.ssa_lhs, step.ssa_rhs});
+            REQUIRE(step.guard == true_exprt{});
+
+            THEN("The left-hand-side of the equation is foo!0#2")
+            {
+              REQUIRE(
+                to_symbol_expr(step.ssa_lhs).get_identifier() == "foo!0#2");
+            }
+            THEN("The right-hand-side of the equation is 1841")
+            {
+              const auto rhs_value =
+                numeric_cast_v<mp_integer>(to_constant_expr(step.ssa_rhs));
+              REQUIRE(rhs_value == 1841);
+            }
+            THEN("ssa_full_lhs is foo!0#1")
+            {
+              REQUIRE(
+                to_symbol_expr(step.ssa_full_lhs).get_identifier() ==
+                "foo!0#2");
+            }
+            THEN("original_full_lhs is foo")
+            {
+              REQUIRE(
+                to_symbol_expr(step.original_full_lhs).get_identifier() ==
+                "foo");
+            }
+          }
         }
       }
     }

--- a/unit/goto-symex/symex_assign.cpp
+++ b/unit/goto-symex/symex_assign.cpp
@@ -80,16 +80,9 @@ SCENARIO(
       symex_target_equationt target{log};
       exprt full_lhs = nil_exprt{};
       full_lhs.type() = int_type;
-      symex_assign_symbol(
-        state,
-        ssa_foo,
-        full_lhs,
-        rhs1,
-        guard,
-        symex_targett::assignment_typet::STATE,
-        ns,
-        symex_config,
-        target);
+      symex_assignt{
+        state, symex_targett::assignment_typet::STATE, ns, symex_config, target}
+        .symex_assign_symbol(ssa_foo, full_lhs, rhs1, guard);
       THEN("An equation is added to the target")
       {
         REQUIRE(target.SSA_steps.size() == 1);

--- a/unit/goto-symex/symex_assign.cpp
+++ b/unit/goto-symex/symex_assign.cpp
@@ -33,7 +33,7 @@ static void add_to_symbol_table(
 }
 
 SCENARIO(
-  "symex_assign_symbol",
+  "symex_assignt::assign_symbol",
   "[core][goto-symex][symex-assign][symex-assign-symbol]")
 {
   // Note that the initialization part of this test is very similar to that of
@@ -84,7 +84,7 @@ SCENARIO(
                     ns,
                     symex_config,
                     target_equation}
-        .symex_assign_symbol(ssa_foo, full_lhs, rhs1, guard);
+        .assign_symbol(ssa_foo, full_lhs, rhs1, guard);
       THEN("An equation is added to the target")
       {
         REQUIRE(target_equation.SSA_steps.size() == 1);
@@ -140,7 +140,7 @@ SCENARIO(
                                  ns,
                                  symex_config,
                                  target_equation};
-      symex_assign.symex_assign_symbol(ssa_foo, full_lhs, rhs1, guard);
+      symex_assign.assign_symbol(ssa_foo, full_lhs, rhs1, guard);
       THEN("An equation with an empty guard is added to the target")
       {
         REQUIRE(target_equation.SSA_steps.size() == 1);
@@ -158,7 +158,7 @@ SCENARIO(
           const exprt rhs2 = from_integer(1841, int_type);
           exprt full_lhs2 = nil_exprt{};
           full_lhs.type() = int_type;
-          symex_assign.symex_assign_symbol(ssa_foo, full_lhs2, rhs2, guard);
+          symex_assign.assign_symbol(ssa_foo, full_lhs2, rhs2, guard);
           THEN("A second equation is added to the target")
           {
             REQUIRE(target_equation.SSA_steps.size() == 2);

--- a/unit/goto-symex/symex_assign.cpp
+++ b/unit/goto-symex/symex_assign.cpp
@@ -108,6 +108,16 @@ SCENARIO(
           const symbol_exprt rhs_symbol = to_symbol_expr(rhs_if->false_case());
           REQUIRE(rhs_symbol.get_identifier() == "foo!0#0");
         }
+        THEN("ssa_full_lhs is foo!0#1")
+        {
+          REQUIRE(
+            to_symbol_expr(step.ssa_full_lhs).get_identifier() == "foo!0#1");
+        }
+        THEN("original_full_lhs is foo")
+        {
+          REQUIRE(
+            to_symbol_expr(step.original_full_lhs).get_identifier() == "foo");
+        }
       }
     }
   }


### PR DESCRIPTION
~This is based on https://github.com/diffblue/cbmc/pull/4825 (first 10 commits).~ (merged and rebased)
The goal was to add unit test for symex_assign_symbol, to make that easier we make `symex_assign_rec` and the functions it calls static, and add a header `symex_assign.h` which corresponds to `symex_assign.cpp`.



<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
