### PR TITLE
Handle missing lower bound in number range

### DIFF
--- a/src/util/format_number_range.cpp
+++ b/src/util/format_number_range.cpp
@@ -134,6 +134,11 @@ std::vector<unsigned> parse_number_range(const std::string &number_range)
     }
     else if(c == '-')
     {
+      if(!number.has_value())
+      {
+        throw deserialization_exceptiont(
+          "lower bound missing in number range '" + number_range + "'");
+      }
       begin_range = number;
       number = {};
     }

--- a/unit/util/format_number_range.cpp
+++ b/unit/util/format_number_range.cpp
@@ -65,6 +65,7 @@ TEST_CASE(
   REQUIRE_THROWS_AS(parse_number_range(""), deserialization_exceptiont);
   REQUIRE_THROWS_AS(parse_number_range(","), deserialization_exceptiont);
   REQUIRE_THROWS_AS(parse_number_range("1,"), deserialization_exceptiont);
+  REQUIRE_THROWS_AS(parse_number_range("-5"), deserialization_exceptiont);
   REQUIRE_THROWS_AS(parse_number_range("0,1-"), deserialization_exceptiont);
   REQUIRE_THROWS_AS(parse_number_range("1, 2"), deserialization_exceptiont);
   REQUIRE_THROWS_AS(parse_number_range("4-2"), deserialization_exceptiont);


### PR DESCRIPTION
Previously, the upper bound was added instead of throwing an error.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
