### PR TITLE
added NODISCARD to simplifier results

### DIFF
--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -19,6 +19,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "expr.h"
 #include "mp_arith.h"
+#include "nodiscard.h"
 #include "type.h"
 // #define USE_LOCAL_REPLACE_MAP
 #ifdef USE_LOCAL_REPLACE_MAP
@@ -104,12 +105,12 @@ public:
     }
   };
 
-  static resultt<> unchanged(exprt expr)
+  NODISCARD static resultt<> unchanged(exprt expr)
   {
     return resultt<>(resultt<>::UNCHANGED, std::move(expr));
   }
 
-  static resultt<> changed(resultt<> result)
+  NODISCARD static resultt<> changed(resultt<> result)
   {
     result.expr_changed = resultt<>::CHANGED;
     return result;
@@ -117,7 +118,7 @@ public:
 
   // These below all return 'true' if the simplification wasn't applicable.
   // If false is returned, the expression has changed.
-  resultt<> simplify_typecast(const typecast_exprt &);
+  NODISCARD resultt<> simplify_typecast(const typecast_exprt &);
   bool simplify_extractbit(exprt &expr);
   bool simplify_extractbits(extractbits_exprt &expr);
   bool simplify_concatenation(exprt &expr);
@@ -143,8 +144,8 @@ public:
   bool simplify_update(exprt &expr);
   bool simplify_index(exprt &expr);
   bool simplify_member(exprt &expr);
-  resultt<> simplify_byte_update(const byte_update_exprt &);
-  resultt<> simplify_byte_extract(const byte_extract_exprt &);
+  NODISCARD resultt<> simplify_byte_update(const byte_update_exprt &);
+  NODISCARD resultt<> simplify_byte_extract(const byte_extract_exprt &);
   bool simplify_pointer_object(exprt &expr);
   bool simplify_object_size(exprt &expr);
   bool simplify_dynamic_size(exprt &expr);
@@ -155,21 +156,22 @@ public:
   bool simplify_object(exprt &expr);
   bool simplify_unary_minus(exprt &expr);
   bool simplify_unary_plus(exprt &expr);
-  resultt<> simplify_dereference(const dereference_exprt &);
+  NODISCARD resultt<> simplify_dereference(const dereference_exprt &);
   bool simplify_address_of(exprt &expr);
   bool simplify_pointer_offset(exprt &expr);
   bool simplify_bswap(bswap_exprt &expr);
   bool simplify_isinf(exprt &expr);
   bool simplify_isnan(exprt &expr);
   bool simplify_isnormal(exprt &expr);
-  resultt<> simplify_abs(const abs_exprt &);
+  NODISCARD resultt<> simplify_abs(const abs_exprt &);
   bool simplify_sign(exprt &expr);
-  resultt<> simplify_popcount(const popcount_exprt &);
+  NODISCARD resultt<> simplify_popcount(const popcount_exprt &);
   bool simplify_complex(exprt &expr);
 
   /// Attempt to simplify mathematical function applications if we have
   /// enough information to do so. Currently focused on constant comparisons.
-  resultt<> simplify_function_application(const function_application_exprt &);
+  NODISCARD resultt<>
+  simplify_function_application(const function_application_exprt &);
 
   // auxiliary
   bool simplify_if_implies(


### PR DESCRIPTION
The call to these methods is meaningless unless the result is used.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
