### PR TITLE
Document string_abstractiont

### DIFF
--- a/src/goto-programs/string_abstraction.h
+++ b/src/goto-programs/string_abstraction.h
@@ -19,6 +19,11 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_model.h"
 
+/// Replace all uses of `char *` by a struct that carries that string, and also
+/// the underlying allocation and the C string length.
+/// This will become useful (with some modifications) for supporting strings in
+/// the C frontend, as the string solver expects a struct that bundles the
+/// string length and the underlying character array.
 class string_abstractiont:public messaget
 {
 public:


### PR DESCRIPTION
Some initial documentation for `string_abstractiont`, as a result of discussion in https://github.com/diffblue/cbmc/pull/4638.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
