### PR TITLE
Define assignmentt struct for symex_assignt functions

### DIFF
--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -80,6 +80,7 @@ void goto_symext::symex_assign(statet &state, const code_assignt &code)
 
     exprt::operandst lhs_if_then_else_conditions;
     symex_assignt{state, assignment_type, ns, symex_config, target}.assign_rec(
-      assignmentt<exprt>{nil_exprt(), lhs, rhs}, lhs_if_then_else_conditions);
+      assignmentt<exprt>{expr_skeletont{}, lhs, rhs},
+      lhs_if_then_else_conditions);
   }
 }

--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -80,6 +80,6 @@ void goto_symext::symex_assign(statet &state, const code_assignt &code)
 
     exprt::operandst lhs_if_then_else_conditions;
     symex_assignt{state, assignment_type, ns, symex_config, target}.assign_rec(
-      lhs, nil_exprt(), rhs, lhs_if_then_else_conditions);
+      assignmentt<exprt>{nil_exprt(), lhs, rhs}, lhs_if_then_else_conditions);
   }
 }

--- a/src/goto-symex/symex_assign.h
+++ b/src/goto-symex/symex_assign.h
@@ -20,6 +20,37 @@ class byte_extract_exprt;
 class ssa_exprt;
 struct symex_configt;
 
+/// Represents a assignment that has been transformed so that the lhs
+/// represents the whole object that is modified, rather than a given subpart.
+/// For instance an assignment `array#2[i] = value` maybe transformed to
+/// `array#2 = array#1 with [i = value]` which will be represented by
+/// `lhs = array#2`, `rhs = array#1 with [i = value]`, and
+/// `original_lhs_skeleton = nil[i]`. This way we can substitute `lhs` in the
+/// skeleton to find the original lhs of the assignment.
+template <typename lhst>
+struct assignmentt final
+{
+  static_assert(
+    std::is_base_of<exprt, lhst>::value,
+    "LHS type should inherit from exprt");
+
+  exprt original_lhs_skeleton;
+  /// Left-hand-side, should be renamed to L1
+  lhst lhs;
+  /// Right-hand-side, should be renamed to L2
+  exprt rhs;
+};
+
+/// Replace the lhs of an assignment by a new value
+template <typename input_lhst, typename output_lhst>
+assignmentt<output_lhst>
+replace_lhs(assignmentt<input_lhst> assignment, output_lhst new_lhs)
+{
+  return assignmentt<output_lhst>{std::move(assignment.original_lhs_skeleton),
+                                  std::move(new_lhs),
+                                  std::move(assignment.rhs)};
+}
+
 /// Functor for symex assignment
 class symex_assignt
 {
@@ -43,16 +74,11 @@ public:
   /// where {n} and {m} denote the current L2 indexes of lhs and rhs
   /// respectively.
   void assign_symbol(
-    const ssa_exprt &lhs, // L1
-    const exprt &full_lhs,
-    const exprt &rhs,
+    const assignmentt<ssa_exprt> &assignment,
     const exprt::operandst &guard);
 
-  void assign_rec(
-    const exprt &lhs,
-    const exprt &full_lhs,
-    const exprt &rhs,
-    exprt::operandst &guard);
+  void
+  assign_rec(const assignmentt<exprt> &assignment, exprt::operandst &guard);
 
 private:
   goto_symex_statet &state;
@@ -68,39 +94,26 @@ private:
     const exprt::operandst &guard);
 
   void assign_non_struct_symbol(
-    const ssa_exprt &lhs, // L1
-    const exprt &full_lhs,
-    const exprt &rhs,
+    assignmentt<ssa_exprt> assignment,
     const exprt::operandst &guard);
 
   void assign_array(
-    const index_exprt &lhs,
-    const exprt &full_lhs,
-    const exprt &rhs,
+    const assignmentt<index_exprt> &assignment,
     exprt::operandst &guard);
 
   void assign_struct_member(
-    const member_exprt &lhs,
-    const exprt &full_lhs,
-    const exprt &rhs,
+    const assignmentt<member_exprt> &assignment,
     exprt::operandst &guard);
 
-  void assign_if(
-    const if_exprt &lhs,
-    const exprt &full_lhs,
-    const exprt &rhs,
-    exprt::operandst &guard);
+  void
+  assign_if(const assignmentt<if_exprt> &assignment, exprt::operandst &guard);
 
   void assign_typecast(
-    const typecast_exprt &lhs,
-    const exprt &full_lhs,
-    const exprt &rhs,
+    const assignmentt<typecast_exprt> &assignment,
     exprt::operandst &guard);
 
   void assign_byte_extract(
-    const byte_extract_exprt &lhs,
-    const exprt &full_lhs,
-    const exprt &rhs,
+    const assignmentt<byte_extract_exprt> &assignment,
     exprt::operandst &guard);
 };
 

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -187,9 +187,10 @@ void goto_symext::lift_let(statet &state, const let_exprt &let_expr)
   symex_assignt{
     state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
     .assign_symbol(
-      to_ssa_expr(state.rename<L1>(let_expr.symbol(), ns).get()),
-      nil_exprt(),
-      let_value,
+      assignmentt<ssa_exprt>{
+        nil_exprt(),
+        to_ssa_expr(state.rename<L1>(let_expr.symbol(), ns).get()),
+        let_value},
       value_assignment_guard);
 
   // Schedule the bound variable to be cleaned up at the end of symex_step:

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -188,7 +188,7 @@ void goto_symext::lift_let(statet &state, const let_exprt &let_expr)
     state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
     .assign_symbol(
       assignmentt<ssa_exprt>{
-        nil_exprt(),
+        expr_skeletont{},
         to_ssa_expr(state.rename<L1>(let_expr.symbol(), ns).get()),
         let_value},
       value_assignment_guard);

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -141,7 +141,8 @@ void goto_symext::parameter_assignments(
 
       exprt::operandst lhs_conditions;
       symex_assignt{state, assignment_type, ns, symex_config, target}
-        .assign_rec(assignmentt<exprt>{nil_exprt(), lhs, rhs}, lhs_conditions);
+        .assign_rec(
+          assignmentt<exprt>{expr_skeletont{}, lhs, rhs}, lhs_conditions);
     }
 
     if(it1!=arguments.end())

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -141,7 +141,7 @@ void goto_symext::parameter_assignments(
 
       exprt::operandst lhs_conditions;
       symex_assignt{state, assignment_type, ns, symex_config, target}
-        .assign_rec(lhs, nil_exprt(), rhs, lhs_conditions);
+        .assign_rec(assignmentt<exprt>{nil_exprt(), lhs, rhs}, lhs_conditions);
     }
 
     if(it1!=arguments.end())

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -90,7 +90,7 @@ void goto_symext::symex_start_thread(statet &state)
     symex_assignt{
       state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
       .assign_symbol(
-        assignmentt<ssa_exprt>{nil_exprt(), lhs_l1, rhs}, lhs_conditions);
+        assignmentt<ssa_exprt>{expr_skeletont{}, lhs_l1, rhs}, lhs_conditions);
     state.record_events.pop();
   }
 
@@ -124,6 +124,6 @@ void goto_symext::symex_start_thread(statet &state)
     symex_assignt{
       state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
       .assign_symbol(
-        assignmentt<ssa_exprt>{nil_exprt(), lhs, rhs}, lhs_conditions);
+        assignmentt<ssa_exprt>{expr_skeletont{}, lhs, rhs}, lhs_conditions);
   }
 }

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -89,7 +89,8 @@ void goto_symext::symex_start_thread(statet &state)
     state.record_events.push(false);
     symex_assignt{
       state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
-      .assign_symbol(lhs_l1, nil_exprt(), rhs, lhs_conditions);
+      .assign_symbol(
+        assignmentt<ssa_exprt>{nil_exprt(), lhs_l1, rhs}, lhs_conditions);
     state.record_events.pop();
   }
 
@@ -122,6 +123,7 @@ void goto_symext::symex_start_thread(statet &state)
     exprt::operandst lhs_conditions;
     symex_assignt{
       state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
-      .assign_symbol(lhs, nil_exprt(), rhs, lhs_conditions);
+      .assign_symbol(
+        assignmentt<ssa_exprt>{nil_exprt(), lhs, rhs}, lhs_conditions);
   }
 }

--- a/unit/goto-symex/symex_assign.cpp
+++ b/unit/goto-symex/symex_assign.cpp
@@ -77,14 +77,14 @@ SCENARIO(
     WHEN("Symbol `foo` is assigned constant integer `475`")
     {
       const exprt rhs1 = from_integer(475, int_type);
-      exprt full_lhs = nil_exprt{};
-      full_lhs.type() = int_type;
+      // full_lhs.type() = int_type;
       symex_assignt{state,
                     symex_targett::assignment_typet::STATE,
                     ns,
                     symex_config,
                     target_equation}
-        .assign_symbol(ssa_foo, full_lhs, rhs1, guard);
+        .assign_symbol(
+          assignmentt<ssa_exprt>{expr_skeletont{}, ssa_foo, rhs1}, guard);
       THEN("An equation is added to the target")
       {
         REQUIRE(target_equation.SSA_steps.size() == 1);
@@ -133,14 +133,14 @@ SCENARIO(
     {
       const exprt rhs1 = from_integer(5721, int_type);
       symex_target_equationt target_equation{null_message_handler};
-      exprt full_lhs = nil_exprt{};
-      full_lhs.type() = int_type;
+      // full_lhs.type() = int_type;
       symex_assignt symex_assign{state,
                                  symex_targett::assignment_typet::STATE,
                                  ns,
                                  symex_config,
                                  target_equation};
-      symex_assign.assign_symbol(ssa_foo, full_lhs, rhs1, guard);
+      symex_assign.assign_symbol(
+        assignmentt<ssa_exprt>{expr_skeletont{}, ssa_foo, rhs1}, guard);
       THEN("An equation with an empty guard is added to the target")
       {
         REQUIRE(target_equation.SSA_steps.size() == 1);
@@ -156,9 +156,9 @@ SCENARIO(
         WHEN("foo is assigned a second time")
         {
           const exprt rhs2 = from_integer(1841, int_type);
-          exprt full_lhs2 = nil_exprt{};
-          full_lhs.type() = int_type;
-          symex_assign.assign_symbol(ssa_foo, full_lhs2, rhs2, guard);
+          // full_lhs.type() = int_type;
+          symex_assign.assign_symbol(
+            assignmentt<ssa_exprt>{expr_skeletont{}, ssa_foo, rhs2}, guard);
           THEN("A second equation is added to the target")
           {
             REQUIRE(target_equation.SSA_steps.size() == 2);


### PR DESCRIPTION
~Based on https://github.com/diffblue/cbmc/pull/4827, only the three last commits are relevant.~ (merged and rebased)

This introduce an `assignmentt` structure to clarify which argument is which in the symex_assignt functions, and a `expr_skeletont` class to clarify how what was called `full_lhs` is supposed to be used. 

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
