### PR TITLE
Define and use an expr_skeletont class

### DIFF
--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -80,6 +80,6 @@ void goto_symext::symex_assign(statet &state, const code_assignt &code)
 
     exprt::operandst lhs_if_then_else_conditions;
     symex_assignt{state, assignment_type, ns, symex_config, target}.assign_rec(
-      lhs, nil_exprt(), rhs, lhs_if_then_else_conditions);
+      lhs, expr_skeletont{}, rhs, lhs_if_then_else_conditions);
   }
 }

--- a/src/goto-symex/symex_assign.h
+++ b/src/goto-symex/symex_assign.h
@@ -20,6 +20,49 @@ class byte_extract_exprt;
 class ssa_exprt;
 struct symex_configt;
 
+/// Expression in which some part is missing and can be substituted for another
+/// expression.
+///
+/// For instance, a skeleton `☐[index]` where `☐` is the missing part, can be
+/// applied to an expression `x` to get `x[index]` (see
+/// \ref expr_skeletont::apply). It can also be composed with another skeleton,
+/// let say `☐.some_field` which would give the skeleton `☐.some_field[index]`
+/// (see \ref expr_skeletont::compose).
+class expr_skeletont final
+{
+public:
+  /// Empty skeleton. Applying it to an expression would give the same
+  /// expression unchanged
+  expr_skeletont() : skeleton(nil_exprt{})
+  {
+  }
+
+  /// Replace the missing part of the current skeleton by another skeleton,
+  /// ending in a bigger skeleton corresponding to the two combined.
+  expr_skeletont compose(expr_skeletont other) const;
+
+  /// Replace the missing part by the given expression, to end-up with a
+  /// complete expression
+  exprt apply(exprt expr) const;
+
+  /// Create a skeleton by removing the first operand of \p e. For instance,
+  /// remove_op0 on `array[index]` would give a skeleton in which `array` is
+  /// missing, and applying that skeleton to `array2` would give
+  /// `array2[index]`.
+  static expr_skeletont remove_op0(exprt e);
+
+private:
+  /// In \c skeleton, nil_exprt is used to mark the sub expression to be
+  /// substituted. The nil_exprt always appears recursively following the first
+  /// operands because the only way to get a skeleton is by removing the first
+  /// operand.
+  exprt skeleton;
+
+  explicit expr_skeletont(exprt e) : skeleton(std::move(e))
+  {
+  }
+};
+
 /// Functor for symex assignment
 class symex_assignt
 {
@@ -44,13 +87,13 @@ public:
   /// respectively.
   void assign_symbol(
     const ssa_exprt &lhs, // L1
-    const exprt &full_lhs,
+    const expr_skeletont &full_lhs,
     const exprt &rhs,
     const exprt::operandst &guard);
 
   void assign_rec(
     const exprt &lhs,
-    const exprt &full_lhs,
+    const expr_skeletont &full_lhs,
     const exprt &rhs,
     exprt::operandst &guard);
 
@@ -63,13 +106,13 @@ private:
 
   void assign_from_struct(
     const ssa_exprt &lhs, // L1
-    const exprt &full_lhs,
+    const expr_skeletont &full_lhs,
     const struct_exprt &rhs,
     const exprt::operandst &guard);
 
   void assign_non_struct_symbol(
     const ssa_exprt &lhs, // L1
-    const exprt &full_lhs,
+    const expr_skeletont &full_lhs,
     const exprt &rhs,
     const exprt::operandst &guard);
 
@@ -78,7 +121,7 @@ private:
   template <bool use_update>
   void assign_array(
     const index_exprt &lhs,
-    const exprt &full_lhs,
+    const expr_skeletont &full_lhs,
     const exprt &rhs,
     exprt::operandst &guard);
 
@@ -87,25 +130,25 @@ private:
   template <bool use_update>
   void assign_struct_member(
     const member_exprt &lhs,
-    const exprt &full_lhs,
+    const expr_skeletont &full_lhs,
     const exprt &rhs,
     exprt::operandst &guard);
 
   void assign_if(
     const if_exprt &lhs,
-    const exprt &full_lhs,
+    const expr_skeletont &full_lhs,
     const exprt &rhs,
     exprt::operandst &guard);
 
   void assign_typecast(
     const typecast_exprt &lhs,
-    const exprt &full_lhs,
+    const expr_skeletont &full_lhs,
     const exprt &rhs,
     exprt::operandst &guard);
 
   void assign_byte_extract(
     const byte_extract_exprt &lhs,
-    const exprt &full_lhs,
+    const expr_skeletont &full_lhs,
     const exprt &rhs,
     exprt::operandst &guard);
 };

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -188,7 +188,7 @@ void goto_symext::lift_let(statet &state, const let_exprt &let_expr)
     state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
     .assign_symbol(
       to_ssa_expr(state.rename<L1>(let_expr.symbol(), ns).get()),
-      nil_exprt(),
+      expr_skeletont{},
       let_value,
       value_assignment_guard);
 

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -141,7 +141,7 @@ void goto_symext::parameter_assignments(
 
       exprt::operandst lhs_conditions;
       symex_assignt{state, assignment_type, ns, symex_config, target}
-        .assign_rec(lhs, nil_exprt(), rhs, lhs_conditions);
+        .assign_rec(lhs, expr_skeletont{}, rhs, lhs_conditions);
     }
 
     if(it1!=arguments.end())

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -89,7 +89,7 @@ void goto_symext::symex_start_thread(statet &state)
     state.record_events.push(false);
     symex_assignt{
       state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
-      .assign_symbol(lhs_l1, nil_exprt(), rhs, lhs_conditions);
+      .assign_symbol(lhs_l1, expr_skeletont{}, rhs, lhs_conditions);
     state.record_events.pop();
   }
 
@@ -122,6 +122,6 @@ void goto_symext::symex_start_thread(statet &state)
     exprt::operandst lhs_conditions;
     symex_assignt{
       state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
-      .assign_symbol(lhs, nil_exprt(), rhs, lhs_conditions);
+      .assign_symbol(lhs, expr_skeletont{}, rhs, lhs_conditions);
   }
 }

--- a/unit/goto-symex/symex_assign.cpp
+++ b/unit/goto-symex/symex_assign.cpp
@@ -77,14 +77,12 @@ SCENARIO(
     WHEN("Symbol `foo` is assigned constant integer `475`")
     {
       const exprt rhs1 = from_integer(475, int_type);
-      exprt full_lhs = nil_exprt{};
-      full_lhs.type() = int_type;
       symex_assignt{state,
                     symex_targett::assignment_typet::STATE,
                     ns,
                     symex_config,
                     target_equation}
-        .assign_symbol(ssa_foo, full_lhs, rhs1, guard);
+        .assign_symbol(ssa_foo, expr_skeletont{}, rhs1, guard);
       THEN("An equation is added to the target")
       {
         REQUIRE(target_equation.SSA_steps.size() == 1);
@@ -133,14 +131,12 @@ SCENARIO(
     {
       const exprt rhs1 = from_integer(5721, int_type);
       symex_target_equationt target_equation{null_message_handler};
-      exprt full_lhs = nil_exprt{};
-      full_lhs.type() = int_type;
       symex_assignt symex_assign{state,
                                  symex_targett::assignment_typet::STATE,
                                  ns,
                                  symex_config,
                                  target_equation};
-      symex_assign.assign_symbol(ssa_foo, full_lhs, rhs1, guard);
+      symex_assign.assign_symbol(ssa_foo, expr_skeletont{}, rhs1, guard);
       THEN("An equation with an empty guard is added to the target")
       {
         REQUIRE(target_equation.SSA_steps.size() == 1);
@@ -156,9 +152,7 @@ SCENARIO(
         WHEN("foo is assigned a second time")
         {
           const exprt rhs2 = from_integer(1841, int_type);
-          exprt full_lhs2 = nil_exprt{};
-          full_lhs.type() = int_type;
-          symex_assign.assign_symbol(ssa_foo, full_lhs2, rhs2, guard);
+          symex_assign.assign_symbol(ssa_foo, expr_skeletont{}, rhs2, guard);
           THEN("A second equation is added to the target")
           {
             REQUIRE(target_equation.SSA_steps.size() == 2);


### PR DESCRIPTION
This clarifies the meaning of skeletons, which we use in assignmentt.
This makes sure the skeleton field is always of the correct form for a
skeleton.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
