### PR TITLE
Unit test expr_skeleton and move it to its own file

### DIFF
--- a/src/goto-symex/Makefile
+++ b/src/goto-symex/Makefile
@@ -1,5 +1,6 @@
 SRC = auto_objects.cpp \
       build_goto_trace.cpp \
+      expr_skeleton.cpp \
       field_sensitivity.cpp \
       goto_state.cpp \
       goto_symex.cpp \

--- a/src/goto-symex/expr_skeleton.cpp
+++ b/src/goto-symex/expr_skeleton.cpp
@@ -1,0 +1,102 @@
+/*******************************************************************\
+
+Module: Symbolic Execution
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+/// \file
+/// Expression skeleton
+
+#include "expr_skeleton.h"
+
+#include <util/std_expr.h>
+
+expr_skeletont::expr_skeletont() : skeleton(nil_exprt{})
+{
+}
+
+expr_skeletont expr_skeletont::remove_op0(exprt e)
+{
+  PRECONDITION(e.id() != ID_symbol);
+  PRECONDITION(e.operands().size() >= 1);
+  e.op0().make_nil();
+  return expr_skeletont{std::move(e)};
+}
+
+exprt expr_skeletont::apply(exprt expr) const
+{
+  PRECONDITION(skeleton.id() != ID_symbol);
+  exprt result = skeleton;
+  exprt *p = &result;
+
+  while(p->is_not_nil())
+  {
+    INVARIANT(
+      p->id() != ID_symbol,
+      "expected pointed-to expression not to be a symbol");
+    INVARIANT(
+      p->operands().size() >= 1,
+      "expected pointed-to expression to have at least one operand");
+    p = &p->op0();
+  }
+
+  INVARIANT(p->is_nil(), "expected pointed-to expression to be nil");
+
+  *p = std::move(expr);
+  return result;
+}
+
+expr_skeletont expr_skeletont::compose(expr_skeletont other) const
+{
+  return expr_skeletont(apply(other.skeleton));
+}
+
+/// In the expression corresponding to a skeleton returns a pointer to the
+/// deepest subexpression before we encounter nil.
+static exprt *deepest_not_nil(exprt &e)
+{
+  exprt *ptr = &e;
+  while(!ptr->op0().is_nil())
+    ptr = &ptr->op0();
+  return ptr;
+}
+
+optionalt<expr_skeletont>
+expr_skeletont::clear_innermost_index_expr(expr_skeletont skeleton)
+{
+  exprt *to_update = deepest_not_nil(skeleton.skeleton);
+  if(index_exprt *index_expr = expr_try_dynamic_cast<index_exprt>(*to_update))
+  {
+    index_expr->make_nil();
+    return expr_skeletont{std::move(skeleton)};
+  }
+  return {};
+}
+
+optionalt<expr_skeletont>
+expr_skeletont::clear_innermost_member_expr(expr_skeletont skeleton)
+{
+  exprt *to_update = deepest_not_nil(skeleton.skeleton);
+  if(member_exprt *member = expr_try_dynamic_cast<member_exprt>(*to_update))
+  {
+    member->make_nil();
+    return expr_skeletont{std::move(skeleton)};
+  }
+  return {};
+}
+
+optionalt<expr_skeletont>
+expr_skeletont::clear_innermost_byte_extract_expr(expr_skeletont skeleton)
+{
+  exprt *to_update = deepest_not_nil(skeleton.skeleton);
+  if(
+    to_update->id() != ID_byte_extract_big_endian &&
+    to_update->id() != ID_byte_extract_little_endian)
+  {
+    return {};
+  }
+  to_update->make_nil();
+  return expr_skeletont{std::move(skeleton.skeleton)};
+}

--- a/src/goto-symex/expr_skeleton.h
+++ b/src/goto-symex/expr_skeleton.h
@@ -1,0 +1,76 @@
+/*******************************************************************\
+
+Module: Symbolic Execution
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+/// \file
+/// Expression skeleton
+
+#ifndef CPROVER_GOTO_SYMEX_EXPR_SKELETON_H
+#define CPROVER_GOTO_SYMEX_EXPR_SKELETON_H
+
+#include <util/expr.h>
+
+/// Expression in which some part is missing and can be substituted for another
+/// expression.
+///
+/// For instance, a skeleton `☐[index]` where `☐` is the missing part, can be
+/// applied to an expression `x` to get `x[index]` (see
+/// \ref expr_skeletont::apply). It can also be composed with another skeleton,
+/// let say `☐.some_field` which would give the skeleton `☐.some_field[index]`
+/// (see \ref expr_skeletont::compose).
+class expr_skeletont final
+{
+public:
+  /// Empty skeleton. Applying it to an expression would give the same
+  /// expression unchanged
+  expr_skeletont();
+
+  /// Replace the missing part of the current skeleton by another skeleton,
+  /// ending in a bigger skeleton corresponding to the two combined.
+  expr_skeletont compose(expr_skeletont other) const;
+
+  /// Replace the missing part by the given expression, to end-up with a
+  /// complete expression
+  exprt apply(exprt expr) const;
+
+  /// Create a skeleton by removing the first operand of \p e. For instance,
+  /// remove_op0 on `array[index]` would give a skeleton in which `array` is
+  /// missing, and applying that skeleton to `array2` would give
+  /// `array2[index]`.
+  static expr_skeletont remove_op0(exprt e);
+
+  /// If the deepest subexpression in the skeleton is a member expression,
+  /// replace it with a nil expression and return the obtained skeleton.
+  static optionalt<expr_skeletont>
+  clear_innermost_index_expr(expr_skeletont skeleton);
+
+  /// If the deepest subexpression in the skeleton is a member expression,
+  /// replace it with a nil expression and return the obtained skeleton.
+  static optionalt<expr_skeletont>
+  clear_innermost_member_expr(expr_skeletont skeleton);
+
+  /// If the deepest subexpression in the skeleton is a byte-extract expression,
+  /// replace it with a nil expression and return the obtained skeleton.
+  /// For instance, for `(byte_extract(☐, 2, int)).field[index]`
+  /// `☐.field[index]` is returned, while for `byte_extract(☐.field, 2, int)`
+  /// an empty optional is returned.
+  static optionalt<expr_skeletont>
+  clear_innermost_byte_extract_expr(expr_skeletont skeleton);
+
+private:
+  /// In \c skeleton, nil_exprt is used to mark the sub expression to be
+  /// substituted. The nil_exprt always appears recursively following the first
+  /// operands because the only way to get a skeleton is by removing the first
+  /// operand.
+  exprt skeleton;
+
+  explicit expr_skeletont(exprt e) : skeleton(std::move(e))
+  {
+  }
+};
+
+#endif // CPROVER_GOTO_SYMEX_EXPR_SKELETON_H

--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -10,6 +10,8 @@ Author: Daniel Kroening, kroening@kroening.com
 /// Symbolic Execution
 
 #include "goto_symex.h"
+
+#include "expr_skeleton.h"
 #include "symex_assign.h"
 
 #include <util/format_expr.h>

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "symex_assign.h"
 
+#include "expr_skeleton.h"
 #include "goto_symex.h"
 #include "goto_symex_state.h"
 #include <util/byte_operators.h>
@@ -29,90 +30,6 @@ constexpr bool use_update()
 #else
   return false;
 #endif
-}
-
-expr_skeletont expr_skeletont::remove_op0(exprt e)
-{
-  PRECONDITION(e.id() != ID_symbol);
-  PRECONDITION(e.operands().size() >= 1);
-  e.op0().make_nil();
-  return expr_skeletont{std::move(e)};
-}
-
-exprt expr_skeletont::apply(exprt expr) const
-{
-  PRECONDITION(skeleton.id() != ID_symbol);
-  exprt result = skeleton;
-  exprt *p = &result;
-
-  while(p->is_not_nil())
-  {
-    INVARIANT(
-      p->id() != ID_symbol,
-      "expected pointed-to expression not to be a symbol");
-    INVARIANT(
-      p->operands().size() >= 1,
-      "expected pointed-to expression to have at least one operand");
-    p = &p->op0();
-  }
-
-  INVARIANT(p->is_nil(), "expected pointed-to expression to be nil");
-
-  *p = std::move(expr);
-  return result;
-}
-
-expr_skeletont expr_skeletont::compose(expr_skeletont other) const
-{
-  return expr_skeletont(apply(other.skeleton));
-}
-
-/// In the expression corresponding to a skeleton returns a pointer to the
-/// deepest subexpression before we encounter nil.
-static exprt *deepest_not_nil(exprt &e)
-{
-  exprt *ptr = &e;
-  while(!ptr->op0().is_nil())
-    ptr = &ptr->op0();
-  return ptr;
-}
-
-optionalt<expr_skeletont>
-expr_skeletont::clear_innermost_index_expr(expr_skeletont skeleton)
-{
-  exprt *to_update = deepest_not_nil(skeleton.skeleton);
-  if(index_exprt *index_expr = expr_try_dynamic_cast<index_exprt>(*to_update))
-  {
-    index_expr->make_nil();
-    return expr_skeletont{std::move(skeleton)};
-  }
-  return {};
-}
-
-optionalt<expr_skeletont>
-expr_skeletont::clear_innermost_member_expr(expr_skeletont skeleton)
-{
-  exprt *to_update = deepest_not_nil(skeleton.skeleton);
-  if(member_exprt *member = expr_try_dynamic_cast<member_exprt>(*to_update))
-  {
-    member->make_nil();
-    return expr_skeletont{std::move(skeleton)};
-  }
-  return {};
-}
-
-optionalt<expr_skeletont>
-expr_skeletont::clear_innermost_byte_extract_expr(expr_skeletont skeleton)
-{
-  exprt *to_update = deepest_not_nil(skeleton.skeleton);
-  if(
-    to_update->id() != ID_byte_extract_big_endian &&
-    to_update->id() != ID_byte_extract_little_endian)
-  {
-    return {};
-  }
-  to_update->make_nil();
-  return expr_skeletont{std::move(skeleton.skeleton)};
 }
 
 void symex_assignt::assign_rec(

--- a/src/goto-symex/symex_assign.h
+++ b/src/goto-symex/symex_assign.h
@@ -15,71 +15,11 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include "symex_target.h"
 #include <util/expr.h>
 
-class goto_symex_statet;
 class byte_extract_exprt;
+class expr_skeletont;
+class goto_symex_statet;
 class ssa_exprt;
 struct symex_configt;
-
-/// Expression in which some part is missing and can be substituted for another
-/// expression.
-///
-/// For instance, a skeleton `☐[index]` where `☐` is the missing part, can be
-/// applied to an expression `x` to get `x[index]` (see
-/// \ref expr_skeletont::apply). It can also be composed with another skeleton,
-/// let say `☐.some_field` which would give the skeleton `☐.some_field[index]`
-/// (see \ref expr_skeletont::compose).
-class expr_skeletont final
-{
-public:
-  /// Empty skeleton. Applying it to an expression would give the same
-  /// expression unchanged
-  expr_skeletont() : skeleton(nil_exprt{})
-  {
-  }
-
-  /// Replace the missing part of the current skeleton by another skeleton,
-  /// ending in a bigger skeleton corresponding to the two combined.
-  expr_skeletont compose(expr_skeletont other) const;
-
-  /// Replace the missing part by the given expression, to end-up with a
-  /// complete expression
-  exprt apply(exprt expr) const;
-
-  /// Create a skeleton by removing the first operand of \p e. For instance,
-  /// remove_op0 on `array[index]` would give a skeleton in which `array` is
-  /// missing, and applying that skeleton to `array2` would give
-  /// `array2[index]`.
-  static expr_skeletont remove_op0(exprt e);
-
-  /// If the deepest subexpression in the skeleton is a member expression,
-  /// replace it with a nil expression and return the obtained skeleton.
-  static optionalt<expr_skeletont>
-  clear_innermost_index_expr(expr_skeletont skeleton);
-
-  /// If the deepest subexpression in the skeleton is a member expression,
-  /// replace it with a nil expression and return the obtained skeleton.
-  static optionalt<expr_skeletont>
-  clear_innermost_member_expr(expr_skeletont skeleton);
-
-  /// If the deepest subexpression in the skeleton is a byte-extract expression,
-  /// replace it with a nil expression and return the obtained skeleton.
-  /// For instance, for `(byte_extract(☐, 2, int)).field[index]`
-  /// `☐.field[index]` is returned, while for `byte_extract(☐.field, 2, int)`
-  /// an empty optional is returned.
-  static optionalt<expr_skeletont>
-  clear_innermost_byte_extract_expr(expr_skeletont skeleton);
-
-private:
-  /// In \c skeleton, nil_exprt is used to mark the sub expression to be
-  /// substituted. The nil_exprt always appears recursively following the first
-  /// operands because the only way to get a skeleton is by removing the first
-  /// operand.
-  exprt skeleton;
-
-  explicit expr_skeletont(exprt e) : skeleton(std::move(e))
-  {
-  }
-};
 
 /// Functor for symex assignment
 class symex_assignt

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -19,6 +19,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/pointer_offset_size.h>
 #include <util/simplify_expr.h>
 
+#include "expr_skeleton.h"
 #include "symex_assign.h"
 #include "symex_dereference_state.h"
 

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -20,6 +20,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/prefix.h>
 #include <util/range.h>
 
+#include "expr_skeleton.h"
 #include "symex_assign.h"
 
 static void locality(

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/exception_utils.h>
 #include <util/expr_initializer.h>
 
+#include "expr_skeleton.h"
 #include "symex_assign.h"
 
 void goto_symext::symex_start_thread(statet &state)

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -31,6 +31,7 @@ SRC += analyses/ai/ai.cpp \
        goto-programs/osx_fat_reader.cpp \
        goto-programs/remove_returns.cpp \
        goto-programs/xml_expr.cpp \
+       goto-symex/expr_skeleton.cpp \
        goto-symex/goto_symex_state.cpp \
        goto-symex/ssa_equation.cpp \
        goto-symex/is_constant.cpp \

--- a/unit/goto-symex/expr_skeleton.cpp
+++ b/unit/goto-symex/expr_skeleton.cpp
@@ -1,0 +1,63 @@
+/*******************************************************************\
+
+Module: Unit tests for expr_skeleton
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+#include <testing-utils/message.h>
+#include <testing-utils/use_catch.h>
+
+#include <goto-symex/expr_skeleton.h>
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/std_expr.h>
+
+SCENARIO("expr skeleton", "[core][goto-symex][symex-assign][expr-skeleton]")
+{
+  const symbol_exprt foo{"foo", typet{}};
+  GIVEN("Skeletons `☐`, `☐[index]` and `☐.field1`")
+  {
+    const expr_skeletont empty_skeleton;
+    const signedbv_typet int_type{32};
+    const expr_skeletont index_skeleton =
+      expr_skeletont::remove_op0(index_exprt{
+        array_exprt{array_typet{int_type, from_integer(2, size_type())}},
+        from_integer(1, size_type())});
+    const expr_skeletont member_skeleton = expr_skeletont::remove_op0(
+      member_exprt{symbol_exprt{"struct1", typet{}}, "field1", int_type});
+    THEN(
+      "Applying the skeletons to `foo` gives `foo`, `foo[index]` and "
+      "`foo.field1` respectively")
+    {
+      REQUIRE(empty_skeleton.apply(foo) == foo);
+      REQUIRE(
+        index_skeleton.apply(foo) ==
+        index_exprt{foo, from_integer(1, size_type()), int_type});
+      REQUIRE(
+        member_skeleton.apply(foo) == member_exprt{foo, "field1", int_type});
+    }
+    THEN(
+      "The composition of `☐[index]` with `☐.field1` applied to `foo` gives "
+      "`foo.field1[index]`")
+    {
+      const expr_skeletont composition =
+        index_skeleton.compose(member_skeleton);
+      REQUIRE(
+        composition.apply(foo) ==
+        index_exprt{member_exprt{foo, "field1", int_type},
+                    from_integer(1, size_type()),
+                    int_type});
+    }
+    THEN(
+      "The composition of `☐[index]` with `☐` applied to `foo` gives "
+      "`foo[index]`")
+    {
+      const expr_skeletont composition = index_skeleton.compose(empty_skeleton);
+      REQUIRE(
+        composition.apply(foo) ==
+        index_exprt{foo, from_integer(1, size_type()), int_type});
+    }
+  }
+}

--- a/unit/goto-symex/symex_assign.cpp
+++ b/unit/goto-symex/symex_assign.cpp
@@ -11,6 +11,7 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 
 #include <analyses/dirty.h>
 #include <analyses/guard.h>
+#include <goto-symex/expr_skeleton.h>
 #include <goto-symex/goto_symex.h>
 #include <goto-symex/goto_symex_state.h>
 #include <goto-symex/symex_assign.h>


### PR DESCRIPTION
Move the class to its own files and unit test it.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
