### PR TITLE
Fix full_lhs not being updated in symex_assignt::assign_symbol after rewrite_with_to_field_symbols

### DIFF
--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -474,7 +474,8 @@ void symex_assignt::assign_non_struct_symbol(
                              .get();
 
   state.record_events.push(false);
-  const exprt l2_full_lhs = state.rename(full_lhs.apply(l2_lhs), ns).get();
+  const exprt l2_full_lhs =
+    state.rename(assignment.original_lhs_skeleton.apply(l2_lhs), ns).get();
   state.record_events.pop();
 
   auto current_assignment_type =

--- a/src/goto-symex/symex_assign.h
+++ b/src/goto-symex/symex_assign.h
@@ -51,6 +51,24 @@ public:
   /// `array2[index]`.
   static expr_skeletont remove_op0(exprt e);
 
+  /// If the deepest subexpression in the skeleton is a member expression,
+  /// replace it with a nil expression and return the obtained skeleton.
+  static optionalt<expr_skeletont>
+  clear_innermost_index_expr(expr_skeletont skeleton);
+
+  /// If the deepest subexpression in the skeleton is a member expression,
+  /// replace it with a nil expression and return the obtained skeleton.
+  static optionalt<expr_skeletont>
+  clear_innermost_member_expr(expr_skeletont skeleton);
+
+  /// If the deepest subexpression in the skeleton is a byte-extract expression,
+  /// replace it with a nil expression and return the obtained skeleton.
+  /// For instance, for `(byte_extract(☐, 2, int)).field[index]`
+  /// `☐.field[index]` is returned, while for `byte_extract(☐.field, 2, int)`
+  /// an empty optional is returned.
+  static optionalt<expr_skeletont>
+  clear_innermost_byte_extract_expr(expr_skeletont skeleton);
+
 private:
   /// In \c skeleton, nil_exprt is used to mark the sub expression to be
   /// substituted. The nil_exprt always appears recursively following the first

--- a/src/util/optional.h
+++ b/src/util/optional.h
@@ -38,4 +38,21 @@ typedef nonstd::bad_optional_access bad_optional_accesst;
 
 using nonstd::nullopt;
 
+/// Similar to optionalt::value but in case of empty optional, generates an
+/// invariant failure instead of throwing an exception.
+template <typename T>
+T &get_value_or_abort(optionalt<T> &opt)
+{
+  PRECONDITION(opt.has_value());
+  return opt.value();
+}
+
+/// \copydoc get_value_or_abort(optionalt<T> &)
+template <typename T>
+const T &get_value_or_abort(const optionalt<T> &opt)
+{
+  PRECONDITION(opt.has_value());
+  return opt.value();
+}
+
 #endif // CPROVER_UTIL_OPTIONAL_H


### PR DESCRIPTION
The function rewrite_with_two_field_symbols can transform the assignment and in particular lhs without the inverse transformation being reported on full_lhs leading the two to be desynchronized. The problem is illustrated in a unit test, in which the previous version of assign_symbol would have caused `original_full_lhs` to be `struct1.field1.field1` instead of `struct1.field1`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
