### PR TITLE
Add `code_inputt` and `code_outputt` for `ID_input` and `ID_output`

### DIFF
--- a/jbmc/src/java_bytecode/java_entry_point.cpp
+++ b/jbmc/src/java_bytecode/java_entry_point.cpp
@@ -311,7 +311,7 @@ std::pair<code_blockt, std::vector<exprt>> java_build_arguments(
 
   // we iterate through all the parameters of the function under test, allocate
   // an object for that parameter (recursively allocating other objects
-  // necessary to initialize it), and declare such object as an ID_input
+  // necessary to initialize it), and mark such object using `code_inputt`.
   for(std::size_t param_number=0;
       param_number<parameters.size();
       param_number++)
@@ -420,17 +420,8 @@ std::pair<code_blockt, std::vector<exprt>> java_build_arguments(
     }
 
     // record as an input
-    codet input(ID_input);
-    input.operands().resize(2);
-    input.op0()=
-      address_of_exprt(
-        index_exprt(
-          string_constantt(base_name),
-          from_integer(0, index_type())));
-    input.op1()=main_arguments[param_number];
-    input.add_source_location()=function.location;
-
-    init_code.add(std::move(input));
+    init_code.add(
+      code_inputt{base_name, main_arguments[param_number], function.location});
   }
 
   return make_pair(init_code, main_arguments);

--- a/jbmc/src/java_bytecode/java_entry_point.cpp
+++ b/jbmc/src/java_bytecode/java_entry_point.cpp
@@ -458,13 +458,8 @@ static optionalt<codet> record_return_value(
   const symbolt &return_symbol =
     symbol_table.lookup_ref(JAVA_ENTRY_POINT_RETURN_SYMBOL);
 
-  codet output(ID_output);
-  output.operands().resize(2);
-  output.op0() = address_of_exprt(index_exprt(
-    string_constantt(return_symbol.base_name), from_integer(0, index_type())));
-  output.op1() = return_symbol.symbol_expr();
-  output.add_source_location() = function.location;
-  return output;
+  return code_outputt{
+    return_symbol.base_name, return_symbol.symbol_expr(), function.location};
 }
 
 static code_blockt record_pointer_parameters(
@@ -486,14 +481,8 @@ static code_blockt record_pointer_parameters(
     if(!can_cast_type<pointer_typet>(p_symbol.type))
       continue;
 
-    codet output(ID_output);
-    output.operands().resize(2);
-    output.op0() = address_of_exprt(index_exprt(
-      string_constantt(p_symbol.base_name), from_integer(0, index_type())));
-    output.op1() = arguments[param_number];
-    output.add_source_location() = function.location;
-
-    init_code.add(std::move(output));
+    init_code.add(code_outputt{
+      p_symbol.base_name, arguments[param_number], function.location});
   }
   return init_code;
 }
@@ -502,20 +491,13 @@ static codet record_exception(
   const symbolt &function,
   const symbol_table_baset &symbol_table)
 {
-  // record exceptional return variable as output
-  codet output(ID_output);
-  output.operands().resize(2);
-
   // retrieve the exception variable
   const symbolt &exc_symbol =
     symbol_table.lookup_ref(JAVA_ENTRY_POINT_EXCEPTION_SYMBOL);
 
-  output.op0()=address_of_exprt(
-    index_exprt(string_constantt(exc_symbol.base_name),
-                from_integer(0, index_type())));
-  output.op1()=exc_symbol.symbol_expr();
-  output.add_source_location()=function.location;
-  return output;
+  // record exceptional return variable as output
+  return code_outputt{
+    exc_symbol.base_name, exc_symbol.symbol_expr(), function.location};
 }
 
 main_function_resultt get_main_symbol(

--- a/jbmc/src/java_bytecode/java_entry_point.h
+++ b/jbmc/src/java_bytecode/java_entry_point.h
@@ -33,8 +33,8 @@ using build_argumentst =
 ///
 /// 1. Allocates and initializes the parameters of the method under test.
 /// 2. Call it and save its return variable in the variable 'return'.
-/// 3. Declare variable 'return' as an output variable (codet with id
-///    ID_output), together with other objects possibly altered by the execution
+/// 3. Declare variable 'return' as an output variable using a `code_outputt`,
+///    together with other objects possibly altered by the execution of
 ///    the method under test (in `java_record_outputs`)
 ///
 /// When \p assume_init_pointers_not_null is false, the generated parameter

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -333,15 +333,8 @@ bool generate_ansi_c_start_function(
         init_code.add(code_assumet(std::move(le)));
       }
 
-      {
-        // record argc as an input
-        codet input(ID_input);
-        input.operands().resize(2);
-        input.op0()=address_of_exprt(
-          index_exprt(string_constantt("argc"), from_integer(0, index_type())));
-        input.op1()=argc_symbol.symbol_expr();
-        init_code.add(std::move(input));
-      }
+      // record argc as an input
+      init_code.add(code_inputt{"argc", argc_symbol.symbol_expr()});
 
       if(parameters.size()==3)
       {

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -59,22 +59,11 @@ void record_function_outputs(
 
   if(has_return_value)
   {
-    // record return value
-    codet output(ID_output);
-    output.operands().resize(2);
-
     const symbolt &return_symbol = symbol_table.lookup_ref("return'");
 
-    output.op0()=
-      address_of_exprt(
-        index_exprt(
-          string_constantt(return_symbol.base_name),
-          from_integer(0, index_type())));
-
-    output.op1()=return_symbol.symbol_expr();
-    output.add_source_location()=function.location;
-
-    init_code.add(std::move(output));
+    // record return value
+    init_code.add(code_outputt{
+      return_symbol.base_name, return_symbol.symbol_expr(), function.location});
   }
 
   #if 0

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -2867,7 +2867,7 @@ std::string expr2ct::convert_code(
   if(statement==ID_fence)
     return convert_code_fence(src, indent);
 
-  if(statement==ID_input)
+  if(can_cast_expr<code_inputt>(src))
     return convert_code_input(src, indent);
 
   if(statement==ID_output)

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -2870,7 +2870,7 @@ std::string expr2ct::convert_code(
   if(can_cast_expr<code_inputt>(src))
     return convert_code_input(src, indent);
 
-  if(statement==ID_output)
+  if(can_cast_expr<code_outputt>(src))
     return convert_code_output(src, indent);
 
   if(statement==ID_assume)

--- a/src/cpp/library/cprover.h
+++ b/src/cpp/library/cprover.h
@@ -24,7 +24,8 @@ void __CPROVER_precondition(__CPROVER_bool assertion, const char *description);
 
 // NOLINTNEXTLINE(build/deprecated)
 void __CPROVER_input(const char *description, ...);
-void __CPROVER_output(const char *id, ...);
+// NOLINTNEXTLINE(build/deprecated)
+void __CPROVER_output(const char *description, ...);
 
 // concurrency-related
 void __CPROVER_atomic_begin();

--- a/src/cpp/library/cprover.h
+++ b/src/cpp/library/cprover.h
@@ -22,7 +22,8 @@ void __CPROVER_assume(__CPROVER_bool assumption) __attribute__((__noreturn__));
 void __CPROVER_assert(__CPROVER_bool assertion, const char *description);
 void __CPROVER_precondition(__CPROVER_bool assertion, const char *description);
 
-void __CPROVER_input(const char *id, ...);
+// NOLINTNEXTLINE(build/deprecated)
+void __CPROVER_input(const char *description, ...);
 void __CPROVER_output(const char *id, ...);
 
 // concurrency-related

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -331,10 +331,6 @@ void goto_convertt::do_output(
   const exprt::operandst &arguments,
   goto_programt &dest)
 {
-  codet output_code(ID_output);
-  output_code.operands()=arguments;
-  output_code.add_source_location()=function.source_location();
-
   if(arguments.size()<2)
   {
     error().source_location=function.find_source_location();
@@ -342,7 +338,7 @@ void goto_convertt::do_output(
     throw 0;
   }
 
-  copy(output_code, OTHER, dest);
+  copy(code_outputt{arguments, function.source_location()}, OTHER, dest);
 }
 
 void goto_convertt::do_atomic_begin(

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -316,10 +316,6 @@ void goto_convertt::do_input(
   const exprt::operandst &arguments,
   goto_programt &dest)
 {
-  codet input_code(ID_input);
-  input_code.operands()=arguments;
-  input_code.add_source_location()=function.source_location();
-
   if(arguments.size()<2)
   {
     error().source_location=function.find_source_location();
@@ -327,7 +323,7 @@ void goto_convertt::do_input(
     throw 0;
   }
 
-  copy(input_code, OTHER, dest);
+  copy(code_inputt{arguments, function.source_location()}, OTHER, dest);
 }
 
 void goto_convertt::do_output(

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -408,7 +408,7 @@ void interpretert::execute_other()
       assign(address, rhs);
     }
   }
-  else if(statement==ID_output)
+  else if(can_cast_expr<code_outputt>(pc->get_other()))
   {
     return;
   }

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -102,7 +102,7 @@ void goto_symext::symex_other(
     const codet clean_code = to_code(clean_expr(code, state, false));
     symex_input(state, clean_code);
   }
-  else if(statement==ID_output)
+  else if(can_cast_expr<code_outputt>(code))
   {
     const codet clean_code = to_code(clean_expr(code, state, false));
     symex_output(state, clean_code);

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -97,7 +97,7 @@ void goto_symext::symex_other(
     const codet clean_code = to_code(clean_expr(code, state, false));
     symex_printf(state, clean_code);
   }
-  else if(statement==ID_input)
+  else if(can_cast_expr<code_inputt>(code))
   {
     const codet clean_code = to_code(clean_expr(code, state, false));
     symex_input(state, clean_code);

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1634,7 +1634,7 @@ void value_sett::apply_code_rec(
   else if(statement==ID_fence)
   {
   }
-  else if(statement==ID_input || statement==ID_output)
+  else if(can_cast_expr<code_inputt>(code) || statement == ID_output)
   {
     // doesn't do anything
   }

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1634,7 +1634,7 @@ void value_sett::apply_code_rec(
   else if(statement==ID_fence)
   {
   }
-  else if(can_cast_expr<code_inputt>(code) || statement == ID_output)
+  else if(can_cast_expr<code_inputt>(code) || can_cast_expr<code_outputt>(code))
   {
     // doesn't do anything
   }

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -1400,7 +1400,7 @@ void value_set_fit::apply_code(const codet &code, const namespacet &ns)
           statement==ID_array_set)
   {
   }
-  else if(can_cast_expr<code_inputt>(code) || statement == ID_output)
+  else if(can_cast_expr<code_inputt>(code) || can_cast_expr<code_outputt>(code))
   {
     // doesn't do anything
   }

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -1400,7 +1400,7 @@ void value_set_fit::apply_code(const codet &code, const namespacet &ns)
           statement==ID_array_set)
   {
   }
-  else if(statement==ID_input || statement==ID_output)
+  else if(can_cast_expr<code_inputt>(code) || statement == ID_output)
   {
     // doesn't do anything
   }

--- a/src/pointer-analysis/value_set_fivr.cpp
+++ b/src/pointer-analysis/value_set_fivr.cpp
@@ -1528,7 +1528,7 @@ void value_set_fivrt::apply_code(const codet &code, const namespacet &ns)
       assign(lhs, code_return.return_value(), ns);
     }
   }
-  else if(can_cast_expr<code_inputt>(code) || statement == ID_output)
+  else if(can_cast_expr<code_inputt>(code) || can_cast_expr<code_outputt>(code))
   {
     // doesn't do anything
   }

--- a/src/pointer-analysis/value_set_fivr.cpp
+++ b/src/pointer-analysis/value_set_fivr.cpp
@@ -1528,7 +1528,7 @@ void value_set_fivrt::apply_code(const codet &code, const namespacet &ns)
       assign(lhs, code_return.return_value(), ns);
     }
   }
-  else if(statement==ID_input || statement==ID_output)
+  else if(can_cast_expr<code_inputt>(code) || statement == ID_output)
   {
     // doesn't do anything
   }

--- a/src/pointer-analysis/value_set_fivrns.cpp
+++ b/src/pointer-analysis/value_set_fivrns.cpp
@@ -1192,7 +1192,7 @@ void value_set_fivrnst::apply_code(const codet &code, const namespacet &ns)
       assign(lhs, code_return.return_value(), ns);
     }
   }
-  else if(can_cast_expr<code_inputt>(code) || statement == ID_output)
+  else if(can_cast_expr<code_inputt>(code) || can_cast_expr<code_outputt>(code))
   {
     // doesn't do anything
   }

--- a/src/pointer-analysis/value_set_fivrns.cpp
+++ b/src/pointer-analysis/value_set_fivrns.cpp
@@ -1192,7 +1192,7 @@ void value_set_fivrnst::apply_code(const codet &code, const namespacet &ns)
       assign(lhs, code_return.return_value(), ns);
     }
   }
-  else if(statement==ID_input || statement==ID_output)
+  else if(can_cast_expr<code_inputt>(code) || statement == ID_output)
   {
     // doesn't do anything
   }

--- a/src/util/allocate_objects.cpp
+++ b/src/util/allocate_objects.cpp
@@ -247,13 +247,8 @@ void allocate_objectst::mark_created_symbols_as_input(code_blockt &init_code)
   //   INPUT("<identifier>", <identifier>);
   for(symbolt const *symbol_ptr : symbols_created)
   {
-    codet input_code(ID_input);
-    input_code.operands().resize(2);
-    input_code.op0() = address_of_exprt(index_exprt(
-      string_constantt(symbol_ptr->base_name), from_integer(0, index_type())));
-    input_code.op1() = symbol_ptr->symbol_expr();
-    input_code.add_source_location() = source_location;
-    init_code.add(std::move(input_code));
+    init_code.add(code_inputt{
+      symbol_ptr->base_name, symbol_ptr->symbol_expr(), source_location});
   }
 }
 

--- a/src/util/std_code.cpp
+++ b/src/util/std_code.cpp
@@ -198,3 +198,31 @@ void code_inputt::check(const codet &code, const validation_modet vm)
   DATA_CHECK(
     vm, code.operands().size() >= 2, "input must have at least two operands");
 }
+
+code_outputt::code_outputt(
+  std::vector<exprt> arguments,
+  optionalt<source_locationt> location)
+  : codet{ID_output, std::move(arguments)}
+{
+  if(location)
+    add_source_location() = std::move(*location);
+  check(*this, validation_modet::INVARIANT);
+}
+
+code_outputt::code_outputt(
+  const irep_idt &description,
+  exprt expression,
+  optionalt<source_locationt> location)
+  : code_outputt{{address_of_exprt(index_exprt(
+                    string_constantt(description),
+                    from_integer(0, index_type()))),
+                  std::move(expression)},
+                 std::move(location)}
+{
+}
+
+void code_outputt::check(const codet &code, const validation_modet vm)
+{
+  DATA_CHECK(
+    vm, code.operands().size() >= 2, "output must have at least two operands");
+}

--- a/src/util/std_code.cpp
+++ b/src/util/std_code.cpp
@@ -11,7 +11,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "std_code.h"
 
+#include "arith_tools.h"
+#include "c_types.h"
 #include "std_expr.h"
+#include "string_constant.h"
 
 /// If this `codet` is a \ref code_blockt (i.e.\ it represents a block of
 /// statements), return the unmodified input. Otherwise (i.e.\ the `codet`
@@ -166,4 +169,32 @@ void code_function_bodyt::set_parameter_identifiers(
     sub.push_back(irept(ID_parameter));
     sub.back().set(ID_identifier, id);
   }
+}
+
+code_inputt::code_inputt(
+  std::vector<exprt> arguments,
+  optionalt<source_locationt> location)
+  : codet{ID_input, std::move(arguments)}
+{
+  if(location)
+    add_source_location() = std::move(*location);
+  check(*this, validation_modet::INVARIANT);
+}
+
+code_inputt::code_inputt(
+  const irep_idt &description,
+  exprt expression,
+  optionalt<source_locationt> location)
+  : code_inputt{{address_of_exprt(index_exprt(
+                   string_constantt(description),
+                   from_integer(0, index_type()))),
+                 std::move(expression)},
+                std::move(location)}
+{
+}
+
+void code_inputt::check(const codet &code, const validation_modet vm)
+{
+  DATA_CHECK(
+    vm, code.operands().size() >= 2, "input must have at least two operands");
 }

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -631,6 +631,53 @@ inline code_assertt &to_code_assert(codet &code)
   return ret;
 }
 
+/// A `codet` representing the declaration that an input of a particular
+/// description has a value which corresponds to the value of a given expression
+/// (or expressions).
+/// When working with the C front end, calls to the `__CPROVER_input` intrinsic
+/// can be added to the input code in order add instructions of this type to the
+/// goto program.
+/// The first argument is expected to be a C string denoting the input
+/// identifier. The second argument is the expression for the input value.
+class code_inputt : public codet
+{
+public:
+  /// This constructor is for support of calls to `__CPROVER_input` in user
+  /// code. Where the first first argument is a description which may be any
+  /// `const char *` and one or more corresponding expression arguments follow.
+  explicit code_inputt(
+    std::vector<exprt> arguments,
+    optionalt<source_locationt> location = {});
+
+  /// This constructor is intended for generating input instructions as part of
+  /// synthetic entry point code, rather than as part of user code.
+  /// \param description: This is used to construct an expression for a pointer
+  ///   to a string constant containing the description text. This expression
+  ///   is then used as the first argument.
+  /// \param expression: This expression corresponds to a value which should be
+  ///   recorded as an input.
+  /// \param location: A location to associate with this instruction.
+  code_inputt(
+    const irep_idt &description,
+    exprt expression,
+    optionalt<source_locationt> location = {});
+
+  static void check(
+    const codet &code,
+    const validation_modet vm = validation_modet::INVARIANT);
+};
+
+template <>
+inline bool can_cast_expr<code_inputt>(const exprt &base)
+{
+  return detail::can_cast_code_impl(base, ID_input);
+}
+
+inline void validate_expr(const code_inputt &input)
+{
+  code_inputt::check(input);
+}
+
 /// Create a fatal assertion, which checks a condition and then halts if it does
 /// not hold. Equivalent to `ASSERT(condition); ASSUME(condition)`.
 ///

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -678,6 +678,52 @@ inline void validate_expr(const code_inputt &input)
   code_inputt::check(input);
 }
 
+/// A `codet` representing the declaration that an output of a particular
+/// description has a value which corresponds to the value of a given expression
+/// (or expressions).
+/// When working with the C front end, calls to the `__CPROVER_output` intrinsic
+/// can be added to the input code in order add instructions of this type to the
+/// goto program.
+/// The first argument is expected to be a C string denoting the output
+/// identifier. The second argument is the expression for the output value.
+class code_outputt : public codet
+{
+public:
+  /// This constructor is for support of calls to `__CPROVER_output` in user
+  /// code. Where the first first argument is a description which may be any
+  /// `const char *` and one or more corresponding expression arguments follow.
+  explicit code_outputt(
+    std::vector<exprt> arguments,
+    optionalt<source_locationt> location = {});
+
+  /// This constructor is intended for generating output instructions as part of
+  /// synthetic entry point code, rather than as part of user code.
+  /// \param description: This is used to construct an expression for a pointer
+  ///   to a string constant containing the description text.
+  /// \param expression: This expression corresponds to a value which should be
+  ///   recorded as an output.
+  /// \param location: A location to associate with this instruction.
+  code_outputt(
+    const irep_idt &description,
+    exprt expression,
+    optionalt<source_locationt> location = {});
+
+  static void check(
+    const codet &code,
+    const validation_modet vm = validation_modet::INVARIANT);
+};
+
+template <>
+inline bool can_cast_expr<code_outputt>(const exprt &base)
+{
+  return detail::can_cast_code_impl(base, ID_output);
+}
+
+inline void validate_expr(const code_outputt &output)
+{
+  code_outputt::check(output);
+}
+
 /// Create a fatal assertion, which checks a condition and then halts if it does
 /// not hold. Equivalent to `ASSERT(condition); ASSUME(condition)`.
 ///


### PR DESCRIPTION
Whilst working on entry point code, I noticed the construction of `codet`s based on `ID_input` and `ID_output` using direct manipulation of the `.operands()`. I also found an absence of documentation as to what these were. This PR adds a higher level interface and documentation for these.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~ N/A - No feature or user visible behaviour changes.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
