### PR TITLE
Clean up/simplify expr nitpicks

### DIFF
--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -161,7 +161,7 @@ simplify_exprt::simplify_popcount(const popcount_exprt &expr)
 /// Simplify String.endsWith function when arguments are constant
 /// \param expr: the expression to simplify
 /// \param ns: namespace
-/// \return: the modified expression or an unchanged expression
+/// \return the modified expression or an unchanged expression
 static simplify_exprt::resultt<> simplify_string_endswith(
   const function_application_exprt &expr,
   const namespacet &ns)
@@ -192,7 +192,7 @@ static simplify_exprt::resultt<> simplify_string_endswith(
 /// Simplify String.isEmpty function when arguments are constant
 /// \param expr: the expression to simplify
 /// \param ns: namespace
-/// \return: the modified expression or an unchanged expression
+/// \return the modified expression or an unchanged expression
 static simplify_exprt::resultt<> simplify_string_is_empty(
   const function_application_exprt &expr,
   const namespacet &ns)
@@ -217,7 +217,7 @@ static simplify_exprt::resultt<> simplify_string_is_empty(
 /// http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/lang/String.java#l1140
 /// \param expr: the expression to simplify
 /// \param ns: namespace
-/// \return: the modified expression or an unchanged expression
+/// \return the modified expression or an unchanged expression
 static simplify_exprt::resultt<> simplify_string_compare_to(
   const function_application_exprt &expr,
   const namespacet &ns)

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -162,7 +162,7 @@ simplify_exprt::simplify_popcount(const popcount_exprt &expr)
 /// \param expr: the expression to simplify
 /// \param ns: namespace
 /// \return: the modified expression or an unchanged expression
-static simplify_exprt::resultt<> simplify_string_endswith_func(
+static simplify_exprt::resultt<> simplify_string_endswith(
   const function_application_exprt &expr,
   const namespacet &ns)
 {
@@ -334,7 +334,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_function_application(
   }
   else if(func_id == ID_cprover_string_endswith_func)
   {
-    return simplify_string_endswith_func(expr, ns);
+    return simplify_string_endswith(expr, ns);
   }
   else if(func_id == ID_cprover_string_is_empty_func)
   {


### PR DESCRIPTION
One renaming and some small documentation corrections.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
