### PR TITLE
Do not store duplicates of inherited static fields in tests for --static-values

### DIFF
--- a/jbmc/regression/jbmc/deterministic_assignments_json/clinit-state.json
+++ b/jbmc/regression/jbmc/deterministic_assignments_json/clinit-state.json
@@ -313,10 +313,6 @@
       "@type":"java.lang.Long",
       "value":"9223372036854775807"
     },
-    "inheritedStatic":{
-      "@type":"java.lang.Integer",
-      "value":10
-    },
     "interfaceContainerFirst":{
       "@type":"MyInterfaceContainerA",
       "field":{

--- a/jbmc/regression/jbmc/deterministic_assignments_json/src/main/java/org/cprover/JsonGenerator.java
+++ b/jbmc/regression/jbmc/deterministic_assignments_json/src/main/java/org/cprover/JsonGenerator.java
@@ -73,7 +73,7 @@ public class JsonGenerator {
 
   public static StaticFieldMap<Object> staticFieldMap(Class<?> clazz) {
     StaticFieldMap<Object> staticFields = new StaticFieldMap<>();
-    for (Field field : getAllStaticFields(clazz)) {
+    for (Field field : getDeclaredStaticFields(clazz)) {
       field.setAccessible(true);
       try {
         if (!field.getName().equals("$assertionsDisabled")) {
@@ -88,19 +88,12 @@ public class JsonGenerator {
     return staticFields;
   }
 
-  public static List<Field> getAllStaticFields(Class<?> clazz) {
+  public static List<Field> getDeclaredStaticFields(Class<?> clazz) {
     List<Field> fields = new ArrayList<>();
-    if (clazz == null) {
-      return fields;
-    }
     for (Field field : clazz.getDeclaredFields()) {
       if ((field.getModifiers() & Modifier.STATIC) == Modifier.STATIC) {
         fields.add(field);
       }
-    }
-    fields.addAll(getAllStaticFields(clazz.getSuperclass()));
-    for (Class<?> interfaze : clazz.getInterfaces()) {
-      fields.addAll(getAllStaticFields(interfaze));
     }
     return fields;
   }


### PR DESCRIPTION
In the tests for the --static-values option, we previously stored the value for an inherited static field twice, when it fact it is only needed in its declaring class.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
