### PR TITLE
Fix type of data_ptr in convert_aload/astore and useless typecasts

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1340,7 +1340,7 @@ code_blockt java_bytecode_convert_methodt::convert_instructions(
     }
     else if(bytecode == patternt("?aload"))
     {
-      PRECONDITION(op.size() == 2 && results.size() == 1);
+      PRECONDITION(results.size() == 1);
       results[0] = convert_aload(statement, op);
     }
     else if(bytecode == patternt("?load") || bytecode == patternt("?load_?"))
@@ -2872,6 +2872,7 @@ exprt java_bytecode_convert_methodt::convert_aload(
   const irep_idt &statement,
   const exprt::operandst &op)
 {
+  PRECONDITION(op.size() == 2);
   const char type_char = statement[0];
   const exprt op_with_right_type = conditional_array_cast(op[0], type_char);
   dereference_exprt deref{op_with_right_type};

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -2877,7 +2877,10 @@ exprt java_bytecode_convert_methodt::convert_aload(
   dereference_exprt deref{op_with_right_type};
   deref.set(ID_java_member_access, true);
 
-  member_exprt data_ptr(deref, "data", pointer_type(op_with_right_type.type()));
+  auto java_array_type = type_try_dynamic_cast<struct_tag_typet>(deref.type());
+  INVARIANT(java_array_type, "Java array type should be a struct_tag_typet");
+  member_exprt data_ptr{
+    deref, "data", pointer_type(java_array_element_type(*java_array_type))};
   plus_exprt data_plus_offset{std::move(data_ptr), op[1]};
   // tag it so it's easy to identify during instrumentation
   data_plus_offset.set(ID_java_array_access, true);
@@ -2921,7 +2924,10 @@ code_blockt java_bytecode_convert_methodt::convert_astore(
   dereference_exprt deref{op_with_right_type};
   deref.set(ID_java_member_access, true);
 
-  member_exprt data_ptr(deref, "data", pointer_type(op_with_right_type.type()));
+  auto java_array_type = type_try_dynamic_cast<struct_tag_typet>(deref.type());
+  INVARIANT(java_array_type, "Java array type should be a struct_tag_typet");
+  member_exprt data_ptr{
+    deref, "data", pointer_type(java_array_element_type(*java_array_type))};
   plus_exprt data_plus_offset{std::move(data_ptr), op[1]};
   // tag it so it's easy to identify during instrumentation
   data_plus_offset.set(ID_java_array_access, true);

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1328,7 +1328,7 @@ code_blockt java_bytecode_convert_methodt::convert_instructions(
     }
     else if(bytecode == patternt("?astore"))
     {
-      assert(op.size()==3 && results.empty());
+      PRECONDITION(results.empty());
       c = convert_astore(statement, op, i_it->source_location);
     }
     else if(bytecode == patternt("?store") || bytecode == patternt("?store_?"))
@@ -2920,6 +2920,7 @@ code_blockt java_bytecode_convert_methodt::convert_astore(
   const exprt::operandst &op,
   const source_locationt &location)
 {
+  PRECONDITION(op.size() == 3);
   const char type_char = statement[0];
   const exprt op_with_right_type = conditional_array_cast(op[0], type_char);
   dereference_exprt deref{op_with_right_type};

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -2870,7 +2870,7 @@ static exprt conditional_array_cast(const exprt &expr, char type_char)
 
 exprt java_bytecode_convert_methodt::convert_aload(
   const irep_idt &statement,
-  const exprt::operandst &op) const
+  const exprt::operandst &op)
 {
   const char type_char = statement[0];
   const exprt op_with_right_type = conditional_array_cast(op[0], type_char);

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -504,5 +504,7 @@ protected:
     const source_locationt &location);
 
   codet convert_pop(const irep_idt &statement, const exprt::operandst &op);
+
+  friend class java_bytecode_convert_method_unit_testt;
 };
 #endif

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -366,8 +366,8 @@ protected:
     const method_offsett address,
     const source_locationt &location);
 
-  exprt
-  convert_aload(const irep_idt &statement, const exprt::operandst &op) const;
+  static exprt
+  convert_aload(const irep_idt &statement, const exprt::operandst &op);
 
   code_blockt convert_ret(
     const std::vector<method_offsett> &jsr_ret_targets,

--- a/unit/testing-utils/expr_query.h
+++ b/unit/testing-utils/expr_query.h
@@ -1,0 +1,62 @@
+/*******************************************************************\
+
+Module: Unit test utilities
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+/// \file
+/// Helper class for querying expressions
+/// Throw CATCH exceptions when the query fails.
+
+#ifndef CPROVER_TESTING_UTILS_EXPR_QUERY_H
+#define CPROVER_TESTING_UTILS_EXPR_QUERY_H
+
+#include <testing-utils/use_catch.h>
+#include <util/expr.h>
+#include <util/expr_cast.h>
+
+/// Wrapper for optionalt<exprt> with useful method for queries to be used in
+/// unit tests.
+template <typename T = exprt>
+class expr_queryt
+{
+  static_assert(
+    std::is_base_of<exprt, T>::value,
+    "T should inherit from exprt");
+
+public:
+  explicit expr_queryt(T e) : value(std::move(e))
+  {
+  }
+
+  template <typename targett>
+  expr_queryt<targett> as() const
+  {
+    auto result = expr_try_dynamic_cast<targett>(static_cast<exprt>(value));
+    REQUIRE(result);
+    return expr_queryt<targett>(*result);
+  }
+
+  expr_queryt<exprt> operator[](const std::size_t i) const
+  {
+    REQUIRE(value.operands().size() > i);
+    return expr_queryt<exprt>(value.operands()[i]);
+  }
+
+  T get() const
+  {
+    return value;
+  }
+
+private:
+  T value;
+};
+
+expr_queryt<exprt> make_query(exprt e)
+{
+  return expr_queryt<exprt>(std::move(e));
+}
+
+#endif // CPROVER_TESTING_UTILS_EXPR_QUERY_H


### PR DESCRIPTION
This remove unnecessary typecasts in the case of baload and bastore of boolean arrays and fixes the type of the of the data pointer, and adds some unit test for convert_aload.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
