### PR TITLE
Avoid unnecessary typecast in java_bytecode_convert_methodt::variable

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -2886,8 +2886,20 @@ exprt java_bytecode_convert_methodt::convert_load(
   char type_char,
   size_t address)
 {
-  return typecast_exprt::conditional_cast(
-    variable(index, type_char, address), java_type_from_char(type_char));
+  const exprt var = variable(index, type_char, address);
+  if(type_char == 'i')
+  {
+    INVARIANT(
+      can_cast_type<bitvector_typet>(var.type()) &&
+        type_try_dynamic_cast<bitvector_typet>(var.type())->get_width() <= 32,
+      "iload can be used for boolean, byte, short, int and char");
+    return typecast_exprt::conditional_cast(var, java_int_type());
+  }
+  INVARIANT(
+    (type_char == 'a' && can_cast_type<reference_typet>(var.type())) ||
+      var.type() == java_type_from_char(type_char),
+    "Variable type must match [adflv]load return type");
+  return var;
 }
 
 code_blockt java_bytecode_convert_methodt::convert_store(

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -2911,10 +2911,6 @@ code_blockt java_bytecode_convert_methodt::convert_store(
   const exprt var = variable(arg0, statement[0], address);
   const irep_idt &var_name = to_symbol_expr(var).get_identifier();
 
-  exprt toassign = op[0];
-  if('a' == statement[0])
-    toassign = typecast_exprt::conditional_cast(toassign, var.type());
-
   code_blockt block;
   block.add_source_location() = location;
 
@@ -2924,7 +2920,9 @@ code_blockt java_bytecode_convert_methodt::convert_store(
     bytecode_write_typet::VARIABLE,
     var_name);
 
-  block.add(code_assignt{var, toassign}, location);
+  block.add(
+    code_assignt{var, typecast_exprt::conditional_cast(op[0], var.type())},
+    location);
   return block;
 }
 

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -176,7 +176,6 @@ exprt java_bytecode_convert_methodt::variable(
   char type_char,
   size_t address)
 {
-  typet t=java_type_from_char(type_char);
   const std::size_t number_int =
     numeric_cast_v<std::size_t>(to_constant_expr(arg));
   variablest &var_list=variables[number_int];
@@ -192,7 +191,7 @@ exprt java_bytecode_convert_methodt::variable(
   irep_idt base_name = "anonlocal::" + std::to_string(number_int) + type_char;
   irep_idt identifier = id2string(current_method) + "::" + id2string(base_name);
 
-  symbol_exprt result(identifier, t);
+  symbol_exprt result(identifier, java_type_from_char(type_char));
   result.set(ID_C_base_name, base_name);
   used_local_names.insert(result);
   return std::move(result);

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -365,6 +365,17 @@ protected:
   static exprt
   convert_aload(const irep_idt &statement, const exprt::operandst &op);
 
+  /// Load reference from local variable.
+  /// \p index must be an unsigned byte and an index in the local variable array
+  /// of the current frame. The type of the local variable at index \p index
+  /// must:
+  ///   - be a reference type if \p type_char is 'a'
+  ///   - be either boolean, byte, short, int, or char if \p type_char is 'i', a
+  ///     typecast to `int` is added if needed
+  ///   - match \c java_type_of_char(type_char) otherwise
+  /// \return the local variable at \p index
+  exprt convert_load(const exprt &index, char type_char, size_t address);
+
   code_blockt convert_ret(
     const std::vector<method_offsett> &jsr_ret_targets,
     const exprt &arg0,

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -183,11 +183,7 @@ protected:
     NO_CAST
   };
 
-  exprt variable(
-    const exprt &arg,
-    char type_char,
-    size_t address,
-    variable_cast_argumentt do_cast);
+  exprt variable(const exprt &arg, char type_char, size_t address);
 
   // temporary variables
   std::list<symbol_exprt> tmp_vars;

--- a/jbmc/unit/java_bytecode/java_bytecode_convert_method/convert_method.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_convert_method/convert_method.cpp
@@ -330,6 +330,15 @@ public:
     converter.variables[index].emplace_back(
       std::move(symbol_expr), start_pc, length, is_parameter, std::move(holes));
   }
+
+  static exprt convert_load(
+    java_bytecode_convert_methodt &converter,
+    const exprt &index,
+    char type_char,
+    size_t address)
+  {
+    return converter.convert_load(index, type_char, address);
+  }
 };
 
 SCENARIO(
@@ -642,6 +651,147 @@ SCENARIO(
       THEN("the result is long_var")
       {
         REQUIRE(result == long_var);
+      }
+    }
+  }
+}
+
+SCENARIO(
+  "java convert load",
+  "[core][java_bytecode][java_bytecode_convert_method][convert_load]")
+{
+  symbol_tablet symbol_table;
+  java_string_library_preprocesst string_preprocess;
+  const class_hierarchyt class_hierarchy{};
+  const std::size_t max_array_length = 10;
+  const bool throw_assertion_error = true;
+  const bool threading_support = false;
+  java_bytecode_convert_methodt converter{symbol_table,
+                                          null_message_handler,
+                                          max_array_length,
+                                          throw_assertion_error,
+                                          {},
+                                          string_preprocess,
+                                          class_hierarchy,
+                                          threading_support};
+
+  GIVEN("An int_array variable")
+  {
+    const source_locationt location;
+    const typet int_array_type = java_array_type('i');
+    const symbol_exprt int_array{"int_array", int_array_type};
+    const std::size_t variable_index = 0;
+    const std::size_t start_pc = 0;
+    const std::size_t length = 1;
+    const bool is_parameter = false;
+    java_bytecode_convert_method_unit_testt::add_variable(
+      converter, variable_index, int_array, start_pc, length, is_parameter, {});
+    const std::size_t address = 0;
+    WHEN("The variable is loaded with aload")
+    {
+      const constant_exprt index_expr =
+        from_integer(variable_index, java_int_type());
+      const exprt result =
+        java_bytecode_convert_method_unit_testt::convert_load(
+          converter, index_expr, 'a', address);
+      THEN("the result is int_array")
+      {
+        REQUIRE(result == int_array);
+      }
+    }
+    WHEN("There is no variable at the given index")
+    {
+      const constant_exprt index_expr =
+        from_integer(variable_index + 1, java_int_type());
+      const exprt result = java_bytecode_convert_method_unit_testt::variable(
+        converter, index_expr, 'a', address);
+      THEN("A new reference variable is created")
+      {
+        REQUIRE(result != int_array);
+        REQUIRE(can_cast_expr<symbol_exprt>(result));
+        REQUIRE(result.type() == java_type_from_char('a'));
+      }
+    }
+  }
+  GIVEN("An Object variable")
+  {
+    const source_locationt location;
+    const typet object_type = java_lang_object_type();
+    const symbol_exprt obj{"obj", object_type};
+    const std::size_t variable_index = 0;
+    const std::size_t start_pc = 0;
+    const std::size_t length = 1;
+    const bool is_parameter = false;
+    java_bytecode_convert_method_unit_testt::add_variable(
+      converter, variable_index, obj, start_pc, length, is_parameter, {});
+    const std::size_t address = 0;
+    WHEN("The variable is loaded with aload")
+    {
+      const constant_exprt index_expr =
+        from_integer(variable_index, java_int_type());
+      const exprt result =
+        java_bytecode_convert_method_unit_testt::convert_load(
+          converter, index_expr, 'a', address);
+      THEN("the result is obj")
+      {
+        REQUIRE(result == obj);
+      }
+    }
+  }
+  GIVEN("A long variable")
+  {
+    const source_locationt location;
+    const typet long_type = java_long_type();
+    const symbol_exprt long_var{"long_var", long_type};
+    const std::size_t variable_index = 0;
+    const std::size_t start_pc = 0;
+    const std::size_t length = 1;
+    const bool is_parameter = false;
+    java_bytecode_convert_method_unit_testt::add_variable(
+      converter, variable_index, long_var, start_pc, length, is_parameter, {});
+    const std::size_t address = 0;
+    WHEN("The variable is loaded with lload")
+    {
+      const constant_exprt index_expr =
+        from_integer(variable_index, java_int_type());
+      const exprt result =
+        java_bytecode_convert_method_unit_testt::convert_load(
+          converter, index_expr, 'l', address);
+      THEN("the result is long_var")
+      {
+        REQUIRE(result == long_var);
+      }
+    }
+  }
+  GIVEN("A boolean variable")
+  {
+    const source_locationt location;
+    const symbol_exprt boolean_var{"boolean_var", java_boolean_type()};
+    const std::size_t variable_index = 0;
+    const std::size_t start_pc = 0;
+    const std::size_t length = 1;
+    const bool is_parameter = false;
+    java_bytecode_convert_method_unit_testt::add_variable(
+      converter,
+      variable_index,
+      boolean_var,
+      start_pc,
+      length,
+      is_parameter,
+      {});
+    const std::size_t address = 0;
+    WHEN("The variable is loaded with iload")
+    {
+      const constant_exprt index_expr =
+        from_integer(variable_index, java_int_type());
+      const exprt result =
+        java_bytecode_convert_method_unit_testt::convert_load(
+          converter, index_expr, 'i', address);
+      THEN("the result is (int)boolean_var")
+      {
+        REQUIRE(result.type() == java_int_type());
+        REQUIRE(
+          make_query(result).as<typecast_exprt>()[0].get() == boolean_var);
       }
     }
   }

--- a/jbmc/unit/java_bytecode/java_bytecode_convert_method/convert_method.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_convert_method/convert_method.cpp
@@ -308,6 +308,28 @@ public:
   {
     return converter.convert_astore(statement, op, location);
   }
+
+  static exprt variable(
+    java_bytecode_convert_methodt &converter,
+    const exprt &arg,
+    char type_char,
+    size_t address)
+  {
+    return converter.variable(arg, type_char, address);
+  }
+
+  static void add_variable(
+    java_bytecode_convert_methodt &converter,
+    std::size_t index,
+    symbol_exprt symbol_expr,
+    std::size_t start_pc,
+    std::size_t length,
+    bool is_parameter,
+    std::vector<java_bytecode_convert_methodt::holet> holes)
+  {
+    converter.variables[index].emplace_back(
+      std::move(symbol_expr), start_pc, length, is_parameter, std::move(holes));
+  }
 };
 
 SCENARIO(
@@ -514,6 +536,112 @@ SCENARIO(
             .as<typecast_exprt>()
             .get()
             .type() == java_array_type('i'));
+      }
+    }
+  }
+}
+
+SCENARIO(
+  "java convert method variable",
+  "[core][java_bytecode][java_bytecode_convert_method][variable]")
+{
+  symbol_tablet symbol_table;
+  java_string_library_preprocesst string_preprocess;
+  const class_hierarchyt class_hierarchy{};
+  const std::size_t max_array_length = 10;
+  const bool throw_assertion_error = true;
+  const bool threading_support = false;
+  java_bytecode_convert_methodt converter{symbol_table,
+                                          null_message_handler,
+                                          max_array_length,
+                                          throw_assertion_error,
+                                          {},
+                                          string_preprocess,
+                                          class_hierarchy,
+                                          threading_support};
+
+  GIVEN("An int_array variable")
+  {
+    const source_locationt location;
+    const typet int_array_type = java_array_type('i');
+    const symbol_exprt int_array{"int_array", int_array_type};
+    const std::size_t variable_index = 0;
+    const std::size_t start_pc = 0;
+    const std::size_t length = 1;
+    const bool is_parameter = false;
+    java_bytecode_convert_method_unit_testt::add_variable(
+      converter, variable_index, int_array, start_pc, length, is_parameter, {});
+    const std::size_t address = 0;
+    WHEN("The variable is retrieved via its index with type_char a")
+    {
+      const constant_exprt index_expr =
+        from_integer(variable_index, java_int_type());
+      const exprt result = java_bytecode_convert_method_unit_testt::variable(
+        converter, index_expr, 'a', address);
+      THEN("the result is int_array")
+      {
+        REQUIRE(result == int_array);
+      }
+    }
+    WHEN("There is no variable at the given index")
+    {
+      const constant_exprt index_expr =
+        from_integer(variable_index + 1, java_int_type());
+      const exprt result = java_bytecode_convert_method_unit_testt::variable(
+        converter, index_expr, 'a', address);
+      THEN("A new reference variable is created")
+      {
+        REQUIRE(result != int_array);
+        REQUIRE(can_cast_expr<symbol_exprt>(result));
+        REQUIRE(result.type() == java_type_from_char('a'));
+      }
+    }
+  }
+  GIVEN("An Object variable")
+  {
+    const source_locationt location;
+    const typet object_type = java_lang_object_type();
+    const symbol_exprt obj{"obj", object_type};
+    const std::size_t variable_index = 0;
+    const std::size_t start_pc = 0;
+    const std::size_t length = 1;
+    const bool is_parameter = false;
+    java_bytecode_convert_method_unit_testt::add_variable(
+      converter, variable_index, obj, start_pc, length, is_parameter, {});
+    const std::size_t address = 0;
+    WHEN("The variable is retrieved via its index with type_char a")
+    {
+      const constant_exprt index_expr =
+        from_integer(variable_index, java_int_type());
+      const exprt result = java_bytecode_convert_method_unit_testt::variable(
+        converter, index_expr, 'a', address);
+      THEN("the result is obj")
+      {
+        REQUIRE(result == obj);
+      }
+    }
+  }
+  GIVEN("An long variable")
+  {
+    const source_locationt location;
+    const typet long_type = java_long_type();
+    const symbol_exprt long_var{"long_var", long_type};
+    const std::size_t variable_index = 0;
+    const std::size_t start_pc = 0;
+    const std::size_t length = 1;
+    const bool is_parameter = false;
+    java_bytecode_convert_method_unit_testt::add_variable(
+      converter, variable_index, long_var, start_pc, length, is_parameter, {});
+    const std::size_t address = 0;
+    WHEN("The variable is retrieved via its index with type_char l")
+    {
+      const constant_exprt index_expr =
+        from_integer(variable_index, java_int_type());
+      const exprt result = java_bytecode_convert_method_unit_testt::variable(
+        converter, index_expr, 'l', address);
+      THEN("the result is long_var")
+      {
+        REQUIRE(result == long_var);
       }
     }
   }


### PR DESCRIPTION
~Based on https://github.com/diffblue/cbmc/pull/4870~
When the variable is a reference and the type_char is 'a' then typecast is not required.

This change is to prevent unnecessary typecast which can lead to byte_extract operations later down the line and are more difficult to deal with.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
