### PR TITLE
(un)reachable functions: valid JSON even without source locations

### DIFF
--- a/regression/goto-analyzer/unreachable-functions-basic-json/test.desc
+++ b/regression/goto-analyzer/unreachable-functions-basic-json/test.desc
@@ -1,12 +1,12 @@
 CORE
 ../unreachable-instructions-basic-text/unreachable.c
 --unreachable-functions --json -
-"file name": ".*unreachable.c",
-"first line": 3,
+"file": ".*unreachable.c",
+"firstLine": 3,
 "function": "not_called",
-"last line": 6
+"lastLine": 6
 ^EXIT=0$
 ^SIGNAL=0$
 --
-"last line":[[:space:]]*$
+"lastLine":[[:space:]]*$
 ^warning: ignoring

--- a/src/goto-analyzer/unreachable_instructions.cpp
+++ b/src/goto-analyzer/unreachable_instructions.cpp
@@ -127,7 +127,7 @@ static void add_to_json(
 
   json_objectt entry{{"function", json_stringt(function_identifier)}};
   if(auto file_name_opt = file_name_string_opt(end_function->source_location))
-    entry["fileName"] = json_stringt{*file_name_opt};
+    entry["file"] = json_stringt{*file_name_opt};
 
   json_arrayt &dead_ins=entry["unreachableInstructions"].make_array();
 
@@ -270,11 +270,11 @@ static void json_output_function(
 {
   json_objectt entry{{"function", json_stringt(function)}};
   if(auto file_name_opt = file_name_string_opt(first_location))
-    entry["file name"] = json_stringt{*file_name_opt};
+    entry["file"] = json_stringt{*file_name_opt};
   if(auto line_opt = line_string_opt(first_location))
-    entry["first line"] = json_numbert{*line_opt};
+    entry["firstLine"] = json_numbert{*line_opt};
   if(auto line_opt = line_string_opt(last_location))
-    entry["last line"] = json_numbert{*line_opt};
+    entry["lastLine"] = json_numbert{*line_opt};
 
   dest.push_back(std::move(entry));
 }
@@ -289,11 +289,11 @@ static void xml_output_function(
 
   x.set_attribute("name", id2string(function));
   if(auto file_name_opt = file_name_string_opt(first_location))
-    x.set_attribute("file name", *file_name_opt);
+    x.set_attribute("file", *file_name_opt);
   if(auto line_opt = line_string_opt(first_location))
-    x.set_attribute("first line", *line_opt);
+    x.set_attribute("first_line", *line_opt);
   if(auto line_opt = line_string_opt(last_location))
-    x.set_attribute("last line", *line_opt);
+    x.set_attribute("last_line", *line_opt);
 }
 
 static void list_functions(


### PR DESCRIPTION
We may lack source locations for generated functions such as C atomics,
and must not generate invalid JSON in such cases. Previously we would
generate output such as

```
{
  "file name": "/",
  "first line": ,
  "function": "__atomic_store_*{V}$V$",
  "last line": 0
}
```

which will now be

```
{
  "file name": "",
  "first line": 0,
  "function": "__atomic_store_*{V}$V$",
  "last line": 0
},
```

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
