### PR TITLE
Add test demonstrating bug in field sensitivity

### DIFF
--- a/regression/cbmc/field-sensitivity-trace-wrong-counterexample-1/test.c
+++ b/regression/cbmc/field-sensitivity-trace-wrong-counterexample-1/test.c
@@ -1,0 +1,14 @@
+struct SomeStruct
+{
+  int x;
+};
+
+int main(void)
+{
+  struct SomeStruct x;
+  // this should cause
+  // visible initialization of
+  // x to value other than 0
+  // if assertion fails
+  assert(x.x == 0);
+}

--- a/regression/cbmc/field-sensitivity-trace-wrong-counterexample-1/test.desc
+++ b/regression/cbmc/field-sensitivity-trace-wrong-counterexample-1/test.desc
@@ -1,0 +1,13 @@
+KNOWNBUG
+test.c
+--trace
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+x=\{ \.x=-?[123456789]\d* \}
+--
+^warning: ignoring
+--
+This tests for the counterexample shown in the trace having sensible values.
+In this case, we are asserting that x.x == 0, so x.x should have a value other
+than 0 if the assertion fails.


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

This adds a KNOWNBUG test demonstrating an issue where struct fields in counterexamples seem to have nonsensical values (apparently always 0). See also #4882

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
