### PR TITLE
better typing in object_descriptor_exprt::root_object()

### DIFF
--- a/src/util/std_expr.cpp
+++ b/src/util/std_expr.cpp
@@ -218,11 +218,14 @@ const exprt &object_descriptor_exprt::root_object() const
 {
   const exprt *p = &object();
 
-  while(p->id() == ID_member || p->id() == ID_index)
+  while(true)
   {
-    DATA_INVARIANT(
-      p->has_operands(), "member and index expressions have operands");
-    p = &p->op0();
+    if(p->id() == ID_member)
+      p = &to_member_expr(*p).compound();
+    else if(p->id() == ID_index)
+      p = &to_index_expr(*p).array();
+    else
+      break;
   }
 
   return *p;


### PR DESCRIPTION
This improves memory safety.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
