### PR TITLE
applying functions that aren't symbols

### DIFF
--- a/src/solvers/strings/string_builtin_function.h
+++ b/src/solvers/strings/string_builtin_function.h
@@ -484,7 +484,9 @@ public:
 
   std::string name() const override
   {
-    return id2string(function_application.function().get_identifier());
+    PRECONDITION(function_application.function().id() == ID_symbol);
+    return id2string(
+      to_symbol_expr(function_application.function()).get_identifier());
   }
   std::vector<array_string_exprt> string_arguments() const override
   {

--- a/src/util/mathematical_expr.cpp
+++ b/src/util/mathematical_expr.cpp
@@ -10,7 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "mathematical_types.h"
 
 function_application_exprt::function_application_exprt(
-  const symbol_exprt &_function,
+  const exprt &_function,
   argumentst _arguments)
   : binary_exprt(
       _function,

--- a/src/util/mathematical_expr.h
+++ b/src/util/mathematical_expr.h
@@ -211,18 +211,16 @@ public:
   {
   }
 
-  function_application_exprt(
-    const symbol_exprt &_function,
-    argumentst _arguments);
+  function_application_exprt(const exprt &_function, argumentst _arguments);
 
-  symbol_exprt &function()
+  exprt &function()
   {
-    return static_cast<symbol_exprt &>(op0());
+    return op0();
   }
 
-  const symbol_exprt &function() const
+  const exprt &function() const
   {
-    return static_cast<const symbol_exprt &>(op0());
+    return op0();
   }
 
   argumentst &arguments()


### PR DESCRIPTION
SMT-LIB 3 will bring function applications for terms that aren't symbols
(e.g., lamba, choice).

This commit removes the restriction that the function in a function
application has to be a symbol.  The expression is still required to have
function type.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
