### PR TITLE
pre/post traversal expression transformers

### DIFF
--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -287,6 +287,63 @@ void exprt::visit_post(std::function<void(const exprt &)> visitor) const
   visit_post_template(visitor, this);
 }
 
+optionalt<exprt>
+exprt::transform_pre(std::function<optionalt<exprt>(exprt)> visitor) const
+{
+  auto visitor_result = visitor(*this);
+
+  // make a copy
+  exprt tmp = visitor_result.value_or(*this);
+
+  bool op_changed = false;
+
+  for(auto &op : tmp.operands()) // this breaks sharing of the copy
+  {
+    auto op_result = op.transform_pre(visitor);
+    if(op_result.has_value())
+    {
+      op = std::move(op_result.value());
+      op_changed = true;
+    }
+  }
+
+  if(op_changed)
+    return std::move(tmp);
+  else
+    return visitor_result;
+}
+
+optionalt<exprt>
+exprt::transform_post(std::function<optionalt<exprt>(exprt)> visitor) const
+{
+  // make a copy
+  exprt tmp = *this;
+
+  bool op_changed = false;
+
+  for(auto &op : tmp.operands()) // this breaks sharing of the copy
+  {
+    auto op_result = op.transform_post(visitor);
+    if(op_result.has_value())
+    {
+      op = std::move(op_result.value());
+      op_changed = true;
+    }
+  }
+
+  if(op_changed)
+  {
+    auto visitor_result = visitor(tmp);
+
+    if(visitor_result.has_value())
+      return std::move(visitor_result.value());
+    else
+      return std::move(tmp);
+  }
+  else
+    return visitor(*this);
+}
+
 template <typename T>
 static void visit_pre_template(std::function<void(T &)> visitor, T *_expr)
 {

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -332,12 +332,14 @@ public:
   void visit(class const_expr_visitort &visitor) const;
   void visit_pre(std::function<void(exprt &)>);
   void visit_pre(std::function<void(const exprt &)>) const;
+  optionalt<exprt> transform_pre(std::function<optionalt<exprt>(exprt)>) const;
 
   /// These are post-order traversal visitors, i.e.,
   /// the visitor is executed on a node _after_ its children
   /// have been visited.
   void visit_post(std::function<void(exprt &)>);
   void visit_post(std::function<void(const exprt &)>) const;
+  optionalt<exprt> transform_post(std::function<optionalt<exprt>(exprt)>) const;
 
   depth_iteratort depth_begin();
   depth_iteratort depth_end();


### PR DESCRIPTION
Transformers for expressions that offer an interface similar to that offered
by the goto-program API. Both pre- and post-traversal options are available.

The key benefit over the non-const `visit` method is that sharing is only
broken up when required.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
