### PR TITLE
Fix skeleton in shift_indexed_access_to_lhs

### DIFF
--- a/src/goto-symex/expr_skeleton.cpp
+++ b/src/goto-symex/expr_skeleton.cpp
@@ -55,8 +55,11 @@ expr_skeletont expr_skeletont::compose(expr_skeletont other) const
 
 /// In the expression corresponding to a skeleton returns a pointer to the
 /// deepest subexpression before we encounter nil.
+/// Returns nullptr if \p e is nil
 static exprt *deepest_not_nil(exprt &e)
 {
+  if(e.is_nil())
+    return nullptr;
   exprt *ptr = &e;
   while(!ptr->op0().is_nil())
     ptr = &ptr->op0();
@@ -67,6 +70,8 @@ optionalt<expr_skeletont>
 expr_skeletont::clear_innermost_index_expr(expr_skeletont skeleton)
 {
   exprt *to_update = deepest_not_nil(skeleton.skeleton);
+  if(to_update == nullptr)
+    return {};
   if(index_exprt *index_expr = expr_try_dynamic_cast<index_exprt>(*to_update))
   {
     index_expr->make_nil();
@@ -79,6 +84,8 @@ optionalt<expr_skeletont>
 expr_skeletont::clear_innermost_member_expr(expr_skeletont skeleton)
 {
   exprt *to_update = deepest_not_nil(skeleton.skeleton);
+  if(to_update == nullptr)
+    return {};
   if(member_exprt *member = expr_try_dynamic_cast<member_exprt>(*to_update))
   {
     member->make_nil();
@@ -91,6 +98,8 @@ optionalt<expr_skeletont>
 expr_skeletont::clear_innermost_byte_extract_expr(expr_skeletont skeleton)
 {
   exprt *to_update = deepest_not_nil(skeleton.skeleton);
+  if(to_update == nullptr)
+    return {};
   if(
     to_update->id() != ID_byte_extract_big_endian &&
     to_update->id() != ID_byte_extract_little_endian)

--- a/src/goto-symex/expr_skeleton.cpp
+++ b/src/goto-symex/expr_skeleton.cpp
@@ -13,7 +13,8 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 
 #include <util/std_expr.h>
 
-expr_skeletont::expr_skeletont() : skeleton(nil_exprt{})
+expr_skeletont::expr_skeletont(typet missing_type)
+  : skeleton(nil_exprt{}), type_of_missing_part(std::move(missing_type))
 {
 }
 
@@ -21,13 +22,15 @@ expr_skeletont expr_skeletont::remove_op0(exprt e)
 {
   PRECONDITION(e.id() != ID_symbol);
   PRECONDITION(e.operands().size() >= 1);
+  typet missing = std::move(e.op0().type());
   e.op0().make_nil();
-  return expr_skeletont{std::move(e)};
+  return expr_skeletont{std::move(e), std::move(missing)};
 }
 
 exprt expr_skeletont::apply(exprt expr) const
 {
   PRECONDITION(skeleton.id() != ID_symbol);
+  PRECONDITION(expr.type() == type_of_missing_part);
   exprt result = skeleton;
   exprt *p = &result;
 
@@ -50,7 +53,9 @@ exprt expr_skeletont::apply(exprt expr) const
 
 expr_skeletont expr_skeletont::compose(expr_skeletont other) const
 {
-  return expr_skeletont(apply(other.skeleton));
+  typet missing_type = other.type_of_missing_part;
+  return expr_skeletont{apply(std::move(other.skeleton)),
+                        std::move(missing_type)};
 }
 
 /// In the expression corresponding to a skeleton returns a pointer to the
@@ -74,8 +79,10 @@ expr_skeletont::clear_innermost_index_expr(expr_skeletont skeleton)
     return {};
   if(index_exprt *index_expr = expr_try_dynamic_cast<index_exprt>(*to_update))
   {
+    typet new_missing_type = index_expr->type();
     index_expr->make_nil();
-    return expr_skeletont{std::move(skeleton)};
+    return expr_skeletont{std::move(skeleton.skeleton),
+                          std::move(new_missing_type)};
   }
   return {};
 }
@@ -88,8 +95,10 @@ expr_skeletont::clear_innermost_member_expr(expr_skeletont skeleton)
     return {};
   if(member_exprt *member = expr_try_dynamic_cast<member_exprt>(*to_update))
   {
+    typet new_missing_type = member->type();
     member->make_nil();
-    return expr_skeletont{std::move(skeleton)};
+    return expr_skeletont{std::move(skeleton.skeleton),
+                          std::move(new_missing_type)};
   }
   return {};
 }
@@ -106,6 +115,8 @@ expr_skeletont::clear_innermost_byte_extract_expr(expr_skeletont skeleton)
   {
     return {};
   }
+  typet new_missing_type = to_update->type();
   to_update->make_nil();
-  return expr_skeletont{std::move(skeleton.skeleton)};
+  return expr_skeletont{std::move(skeleton.skeleton),
+                        std::move(new_missing_type)};
 }

--- a/src/goto-symex/expr_skeleton.cpp
+++ b/src/goto-symex/expr_skeleton.cpp
@@ -11,6 +11,11 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 
 #include "expr_skeleton.h"
 
+#include <util/arith_tools.h>
+#include <util/byte_operators.h>
+#include <util/mp_arith.h>
+#include <util/pointer_offset_size.h>
+#include <util/simplify_expr.h>
 #include <util/std_expr.h>
 
 expr_skeletont::expr_skeletont(typet missing_type)
@@ -119,4 +124,84 @@ expr_skeletont::clear_innermost_byte_extract_expr(expr_skeletont skeleton)
   to_update->make_nil();
   return expr_skeletont{std::move(skeleton.skeleton),
                         std::move(new_missing_type)};
+}
+
+expr_skeletont expr_skeletont::revert_byte_extract_aux(
+  expr_skeletont skeleton,
+  exprt offset,
+  const typet &type,
+  const namespacet &ns,
+  exprt offset_already_removed)
+{
+  offset = simplify_expr(std::move(offset), ns);
+  const exprt offset_reached =
+    simplify_expr(equal_exprt{offset_already_removed, offset}, ns);
+  if(offset_reached.is_true() && type == skeleton.type_of_missing_part)
+    return expr_skeletont{std::move(skeleton)};
+  const exprt offset_exceeded = simplify_expr(
+    binary_relation_exprt{offset_already_removed, ID_gt, offset}, ns);
+  exprt *deepest = deepest_not_nil(skeleton.skeleton);
+  if(deepest == nullptr || offset_exceeded.is_true())
+  {
+    // In case of empty skeleton or if the offset has been exceeded, compose
+    // with `byte_extract(☐, offset_already_removed - offset)`
+    const minus_exprt offset_diff{std::move(offset_already_removed), offset};
+    const auto simplified = simplify_expr(offset_diff, ns);
+    return skeleton.compose(expr_skeletont{
+      byte_extract_exprt{byte_extract_id(), nil_exprt{}, simplified, type},
+      skeleton.type_of_missing_part});
+  }
+  const auto offset_resulting_from_deepest_operation = [&]() -> exprt {
+    if(auto byte_extract = expr_try_dynamic_cast<byte_extract_exprt>(*deepest))
+      return byte_extract->offset();
+    if(auto index_expr = expr_try_dynamic_cast<index_exprt>(*deepest))
+    {
+      auto element_size_in_bits = pointer_offset_bits(index_expr->type(), ns);
+      CHECK_RETURN(element_size_in_bits);
+      mult_exprt offset_in_bits{
+        index_expr->index(),
+        from_integer(*element_size_in_bits, index_expr->index().type())};
+      return div_exprt{offset_in_bits, from_integer(8, offset_in_bits.type())};
+    }
+    auto member_expr = expr_try_dynamic_cast<member_exprt>(*deepest);
+    INVARIANT(
+      member_expr,
+      "Skeleton should only be composed of byte_extract, index and member "
+      "exprts");
+    auto struct_type =
+      type_try_dynamic_cast<struct_typet>(skeleton.type_of_missing_part);
+    INVARIANT(
+      struct_type,
+      "In member_exprt skeleton the missing part should have struct type");
+    auto member_offset =
+      member_offset_expr(*struct_type, member_expr->get_component_name(), ns);
+    CHECK_RETURN(member_offset);
+    return *member_offset;
+  }();
+
+  typet new_missing_type = deepest->type();
+  deepest->make_nil();
+  skeleton.type_of_missing_part = new_missing_type;
+  return revert_byte_extract_aux(
+    skeleton,
+    offset,
+    type,
+    ns,
+    plus_exprt{std::move(offset_already_removed),
+               offset_resulting_from_deepest_operation});
+}
+
+expr_skeletont expr_skeletont::revert_byte_extract(
+  expr_skeletont skeleton,
+  exprt offset,
+  const typet &type,
+  const namespacet &ns)
+{
+  exprt init_already_removed = from_integer(0, offset.type());
+  return revert_byte_extract_aux(
+    std::move(skeleton),
+    std::move(offset),
+    type,
+    ns,
+    std::move(init_already_removed));
 }

--- a/src/goto-symex/expr_skeleton.h
+++ b/src/goto-symex/expr_skeleton.h
@@ -27,7 +27,7 @@ class expr_skeletont final
 public:
   /// Empty skeleton. Applying it to an expression would give the same
   /// expression unchanged
-  expr_skeletont();
+  explicit expr_skeletont(typet missing_type);
 
   /// Replace the missing part of the current skeleton by another skeleton,
   /// ending in a bigger skeleton corresponding to the two combined.
@@ -67,8 +67,10 @@ private:
   /// operands because the only way to get a skeleton is by removing the first
   /// operand.
   exprt skeleton;
+  typet type_of_missing_part;
 
-  explicit expr_skeletont(exprt e) : skeleton(std::move(e))
+  expr_skeletont(exprt e, typet missing)
+    : skeleton(std::move(e)), type_of_missing_part(std::move(missing))
   {
   }
 };

--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -82,6 +82,6 @@ void goto_symext::symex_assign(statet &state, const code_assignt &code)
 
     exprt::operandst lhs_if_then_else_conditions;
     symex_assignt{state, assignment_type, ns, symex_config, target}.assign_rec(
-      lhs, expr_skeletont{}, rhs, lhs_if_then_else_conditions);
+      lhs, expr_skeletont{lhs.type()}, rhs, lhs_if_then_else_conditions);
   }
 }

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -182,7 +182,7 @@ static assignmentt rewrite_with_to_field_symbols(
        lhs_mod.type().id() == ID_struct_tag))
     {
       exprt field_sensitive_lhs;
-      expr_skeletont lhs_skeleton;
+      expr_skeletont lhs_skeleton{lhs_mod.type()};
       const with_exprt &with_expr = to_with_expr(ssa_rhs);
 
       if(lhs_mod.type().id() == ID_array)

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -344,7 +344,10 @@ void symex_assignt::assign_from_struct(
       lhs_field.id() == ID_symbol,
       "member of symbol should be susceptible to field-sensitivity");
 
-    assign_symbol(to_ssa_expr(lhs_field), full_lhs, comp_rhs.second, guard);
+    assign_symbol(
+      to_ssa_expr(lhs_field),
+      expr_skeletont{lhs_field.type()},
+      comp_rhs.second, guard);
   }
 }
 

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -241,14 +241,13 @@ static assignmentt shift_indexed_access_to_lhs(
   if(!can_cast_expr<byte_update_exprt>(assignment.rhs))
     return assignment;
   exprt &ssa_rhs = assignment.rhs;
-  ssa_exprt &lhs_mod = assignment.lhs;
   const byte_update_exprt &byte_update = to_byte_update_expr(ssa_rhs);
   exprt byte_extract = simplify_exprt{ns}
                          .simplify_byte_extract(byte_extract_exprt{
                            byte_update.id() == ID_byte_update_big_endian
                              ? ID_byte_extract_big_endian
                              : ID_byte_extract_little_endian,
-                           lhs_mod,
+                           assignment.lhs,
                            byte_update.offset(),
                            byte_update.value().type()})
                          .expr;

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -252,11 +252,15 @@ static assignmentt shift_indexed_access_to_lhs(
                            byte_update.value().type()})
                          .expr;
 
+  expr_skeletont new_skeleton = expr_skeletont::revert_byte_extract(
+    assignment.original_lhs_skeleton,
+    byte_update.offset(),
+    byte_update.value().type(),
+    ns);
   if(byte_extract.id() == ID_symbol)
   {
-    return assignmentt{to_ssa_expr(byte_extract),
-                       std::move(assignment.original_lhs_skeleton),
-                       byte_update.value()};
+    return assignmentt{
+      to_ssa_expr(byte_extract), std::move(new_skeleton), byte_update.value()};
   }
   else if(byte_extract.id() == ID_index || byte_extract.id() == ID_member)
   {
@@ -305,7 +309,7 @@ static assignmentt shift_indexed_access_to_lhs(
     // We may have shifted the previous lhs into the rhs; as the lhs is only
     // L1-renamed, we need to rename again.
     return assignmentt{to_ssa_expr(byte_extract),
-                       std::move(assignment.original_lhs_skeleton),
+                       std::move(new_skeleton),
                        state.rename(std::move(ssa_rhs), ns).get()};
   }
   return assignment;

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -185,11 +185,13 @@ void goto_symext::lift_let(statet &state, const let_exprt &let_expr)
   do_simplify(let_value);
 
   exprt::operandst value_assignment_guard;
+  const ssa_exprt l1_symbol =
+    to_ssa_expr(state.rename<L1>(let_expr.symbol(), ns).get());
   symex_assignt{
     state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
     .assign_symbol(
-      to_ssa_expr(state.rename<L1>(let_expr.symbol(), ns).get()),
-      expr_skeletont{},
+      l1_symbol,
+      expr_skeletont{l1_symbol.type()},
       let_value,
       value_assignment_guard);
 

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -142,7 +142,7 @@ void goto_symext::parameter_assignments(
 
       exprt::operandst lhs_conditions;
       symex_assignt{state, assignment_type, ns, symex_config, target}
-        .assign_rec(lhs, expr_skeletont{}, rhs, lhs_conditions);
+        .assign_rec(lhs, expr_skeletont{lhs.type()}, rhs, lhs_conditions);
     }
 
     if(it1!=arguments.end())

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -90,7 +90,8 @@ void goto_symext::symex_start_thread(statet &state)
     state.record_events.push(false);
     symex_assignt{
       state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
-      .assign_symbol(lhs_l1, expr_skeletont{}, rhs, lhs_conditions);
+      .assign_symbol(
+        lhs_l1, expr_skeletont{lhs_l1.type()}, rhs, lhs_conditions);
     state.record_events.pop();
   }
 
@@ -123,6 +124,6 @@ void goto_symext::symex_start_thread(statet &state)
     exprt::operandst lhs_conditions;
     symex_assignt{
       state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
-      .assign_symbol(lhs, expr_skeletont{}, rhs, lhs_conditions);
+      .assign_symbol(lhs, expr_skeletont{lhs.type()}, rhs, lhs_conditions);
   }
 }

--- a/src/util/byte_operators.h
+++ b/src/util/byte_operators.h
@@ -136,4 +136,11 @@ inline byte_update_exprt &to_byte_update_expr(exprt &expr)
   return static_cast<byte_update_exprt &>(expr);
 }
 
+template <>
+inline bool can_cast_expr<byte_update_exprt>(const exprt &base)
+{
+  return base.id() == ID_byte_update_little_endian ||
+         base.id() == ID_byte_update_big_endian;
+}
+
 #endif // CPROVER_UTIL_BYTE_OPERATORS_H

--- a/unit/goto-symex/expr_skeleton.cpp
+++ b/unit/goto-symex/expr_skeleton.cpp
@@ -19,7 +19,7 @@ SCENARIO("expr skeleton", "[core][goto-symex][symex-assign][expr-skeleton]")
   const symbol_exprt foo{"foo", typet{}};
   GIVEN("Skeletons `☐`, `☐[index]` and `☐.field1`")
   {
-    const expr_skeletont empty_skeleton;
+    const expr_skeletont empty_skeleton{foo.type()};
     const signedbv_typet int_type{32};
     const expr_skeletont index_skeleton =
       expr_skeletont::remove_op0(index_exprt{

--- a/unit/goto-symex/symex_assign.cpp
+++ b/unit/goto-symex/symex_assign.cpp
@@ -83,7 +83,7 @@ SCENARIO(
                     ns,
                     symex_config,
                     target_equation}
-        .assign_symbol(ssa_foo, expr_skeletont{}, rhs1, guard);
+        .assign_symbol(ssa_foo, expr_skeletont{ssa_foo.type()}, rhs1, guard);
       THEN("An equation is added to the target")
       {
         REQUIRE(target_equation.SSA_steps.size() == 1);
@@ -137,7 +137,8 @@ SCENARIO(
                                  ns,
                                  symex_config,
                                  target_equation};
-      symex_assign.assign_symbol(ssa_foo, expr_skeletont{}, rhs1, guard);
+      symex_assign.assign_symbol(
+        ssa_foo, expr_skeletont{ssa_foo.type()}, rhs1, guard);
       THEN("An equation with an empty guard is added to the target")
       {
         REQUIRE(target_equation.SSA_steps.size() == 1);
@@ -153,7 +154,8 @@ SCENARIO(
         WHEN("foo is assigned a second time")
         {
           const exprt rhs2 = from_integer(1841, int_type);
-          symex_assign.assign_symbol(ssa_foo, expr_skeletont{}, rhs2, guard);
+          symex_assign.assign_symbol(
+            ssa_foo, expr_skeletont{ssa_foo.type()}, rhs2, guard);
           THEN("A second equation is added to the target")
           {
             REQUIRE(target_equation.SSA_steps.size() == 2);

--- a/unit/testing-utils/expr_query.h
+++ b/unit/testing-utils/expr_query.h
@@ -54,7 +54,7 @@ private:
   T value;
 };
 
-expr_queryt<exprt> make_query(exprt e)
+inline expr_queryt<exprt> make_query(exprt e)
 {
   return expr_queryt<exprt>(std::move(e));
 }


### PR DESCRIPTION
If a byte_extract operation is added to the lhs, then the invert
operation must be performed on the skeleton so that
new_skeleton[new_lhs] is equivalent to skeleton[lhs].

This requires adding a method `revert_byte_extract` on skeletont.
Unit tests are added for this method and for convert assign symbol.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
