### PR TITLE
Cleanup generic_parameter_specialization_map_keys

### DIFF
--- a/jbmc/src/java_bytecode/generic_parameter_specialization_map_keys.cpp
+++ b/jbmc/src/java_bytecode/generic_parameter_specialization_map_keys.cpp
@@ -4,6 +4,8 @@
 
 #include <iterator>
 
+#include <util/range.h>
+
 /// \param type: Source type
 /// \return The vector of implicitly generic and (explicitly) generic type
 ///   parameters of the given type.
@@ -44,22 +46,8 @@ void generic_parameter_specialization_map_keyst::insert_pairs(
   const std::vector<reference_typet> &types)
 {
   INVARIANT(erase_keys.empty(), "insert_pairs should only be called once");
-  PRECONDITION(parameters.size() == types.size());
 
-  // Pair up the parameters and types for easier manipulation later
-  std::vector<std::pair<java_generic_parametert, reference_typet>> pairs;
-  pairs.reserve(parameters.size());
-  std::transform(
-    parameters.begin(),
-    parameters.end(),
-    types.begin(),
-    std::back_inserter(pairs),
-    [&](java_generic_parametert param, reference_typet type)
-    {
-      return std::make_pair(param, type);
-    });
-
-  for(const auto &pair : pairs)
+  for(const auto &pair : make_range(parameters).zip(types))
   {
     // Only add the pair if the type is not the parameter itself, e.g.,
     // pair.first = pair.second = java::A::T. This can happen for example

--- a/jbmc/src/java_bytecode/generic_parameter_specialization_map_keys.cpp
+++ b/jbmc/src/java_bytecode/generic_parameter_specialization_map_keys.cpp
@@ -2,8 +2,6 @@
 
 #include "generic_parameter_specialization_map_keys.h"
 
-#include <iterator>
-
 #include <util/range.h>
 
 /// \param type: Source type

--- a/jbmc/src/java_bytecode/generic_parameter_specialization_map_keys.cpp
+++ b/jbmc/src/java_bytecode/generic_parameter_specialization_map_keys.cpp
@@ -49,7 +49,7 @@ void generic_parameter_specialization_map_keyst::insert_pairs(
   {
     // Only add the pair if the type is not the parameter itself, e.g.,
     // pair.first = pair.second = java::A::T. This can happen for example
-    // when initiating a pointer to an implicitly java generic class type
+    // when initializing a pointer to an implicitly generic Java class type
     // in gen_nondet_init and would result in a loop when the map is used
     // to look up the type of the parameter.
     if(
@@ -58,13 +58,13 @@ void generic_parameter_specialization_map_keyst::insert_pairs(
           pair.first.get_name()))
     {
       const irep_idt &key = pair.first.get_name();
-      if(generic_parameter_specialization_map.count(key) == 0)
-        generic_parameter_specialization_map.emplace(
-          key, std::vector<reference_typet>());
-      (*generic_parameter_specialization_map.find(key))
-        .second.push_back(pair.second);
+      const auto map_it = generic_parameter_specialization_map
+                            .emplace(key, std::vector<reference_typet>{})
+                            .first;
+      map_it->second.push_back(pair.second);
 
-      // We added something, so pop it when this is destroyed:
+      // We added something; pop it when this
+      // generic_parameter_specialization_map_keyst is destroyed
       erase_keys.push_back(key);
     }
   }

--- a/jbmc/src/java_bytecode/generic_parameter_specialization_map_keys.h
+++ b/jbmc/src/java_bytecode/generic_parameter_specialization_map_keys.h
@@ -33,11 +33,12 @@ public:
   {
     for(const auto key : erase_keys)
     {
-      PRECONDITION(generic_parameter_specialization_map.count(key) != 0);
-      auto &val = generic_parameter_specialization_map.find(key)->second;
+      const auto map_it = generic_parameter_specialization_map.find(key);
+      PRECONDITION(map_it != generic_parameter_specialization_map.end());
+      std::vector<reference_typet> &val = map_it->second;
       val.pop_back();
       if(val.empty())
-        generic_parameter_specialization_map.erase(key);
+        generic_parameter_specialization_map.erase(map_it);
     }
   }
 

--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -487,8 +487,8 @@ void java_object_factoryt::gen_nondet_pointer_init(
   // If we are changing the pointer, we generate code for creating a pointer
   // to the substituted type instead
   // TODO if we are comparing array types we need to compare their element
-  // types. this is for now done by implementing equality function especially
-  // for java types, technical debt TG-2707
+  //   types. this is for now done by implementing equality function especially
+  //   for java types, technical debt TG-2707
   if(!equal_java_types(replacement_pointer_type, pointer_type))
   {
     // update generic_parameter_specialization_map for the new pointer

--- a/jbmc/src/java_bytecode/select_pointer_type.cpp
+++ b/jbmc/src/java_bytecode/select_pointer_type.cpp
@@ -58,7 +58,9 @@ pointer_typet select_pointer_typet::specialize_generics(
       return result.has_value() ? result.value() : pointer_type;
     }
 
-    if(generic_parameter_specialization_map.count(parameter_name) == 0)
+    const auto specialization =
+      generic_parameter_specialization_map.find(parameter_name);
+    if(specialization == generic_parameter_specialization_map.end())
     {
       // this means that the generic pointer_type has not been specialized
       // in the current context (e.g., the method under test is generic);
@@ -66,8 +68,7 @@ pointer_typet select_pointer_typet::specialize_generics(
       // its upper bound
       return pointer_type;
     }
-    const pointer_typet &type =
-      generic_parameter_specialization_map.find(parameter_name)->second.back();
+    const pointer_typet &type = specialization->second.back();
 
     // generic parameters can be adopted from outer classes or superclasses so
     // we may need to search for the concrete type recursively

--- a/jbmc/src/java_bytecode/select_pointer_type.cpp
+++ b/jbmc/src/java_bytecode/select_pointer_type.cpp
@@ -18,9 +18,8 @@ pointer_typet select_pointer_typet::convert_pointer_type(
   const pointer_typet &pointer_type,
   const generic_parameter_specialization_mapt
     &generic_parameter_specialization_map,
-  const namespacet &ns) const
+  const namespacet &) const
 {
-  (void)ns; // unused parameter
   // if we have a map of generic parameters -> types and the pointer is
   // a generic parameter, specialize it with concrete types
   if(!generic_parameter_specialization_map.empty())
@@ -51,7 +50,7 @@ pointer_typet select_pointer_typet::specialize_generics(
 
     // avoid infinite recursion by looking at each generic argument from
     // previous assignments
-    if(visited_nodes.find(parameter_name) != visited_nodes.end())
+    if(visited_nodes.count(parameter_name) != 0)
     {
       const optionalt<pointer_typet> result = get_recursively_instantiated_type(
         parameter_name, generic_parameter_specialization_map);
@@ -112,7 +111,7 @@ pointer_typet select_pointer_typet::specialize_generics(
 ///
 /// Example:
 /// `class MyGeneric<T,U> { MyGeneric<U,T> gen; T t;}`
-/// When instantiating `MyGeneric<Integer,String> my` we need to for example
+/// For example, when instantiating `MyGeneric<Integer,String> my` we need to
 /// resolve the type of `my.gen.t`. The map would in this context contain
 /// - T -> (Integer, U)
 /// - U -> (String, T)


### PR DESCRIPTION
- [x] Each commit message has a non-empty body, explaining why the change was made.
- N/A Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- N/A The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- N/A My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.