### PR TITLE
Null-pointer filtering must handle unknown offsets

### DIFF
--- a/regression/cbmc/null7/main.c
+++ b/regression/cbmc/null7/main.c
@@ -1,0 +1,28 @@
+#include <stdlib.h>
+
+_Bool nondet_bool();
+
+int main()
+{
+  char *s = NULL;
+  char A[3];
+  _Bool s_is_set = 0;
+
+  if(nondet_bool())
+  {
+    s = A;
+    s_is_set = 1;
+  }
+
+  if(s_is_set)
+  {
+    unsigned len;
+    __CPROVER_assume(len < 3);
+    s += len;
+  }
+
+  if(s)
+    *s = 42;
+
+  return 0;
+}

--- a/regression/cbmc/null7/test.desc
+++ b/regression/cbmc/null7/test.desc
@@ -1,0 +1,11 @@
+CORE broken-smt-backend
+main.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+The value set may contain the constants with unknown offsets. Such cases cannot
+be conclusively filtered out as the offset may be zero.

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -114,7 +114,8 @@ static optionalt<renamedt<exprt, L2>> try_evaluate_pointer_comparison(
       value_set_element.id() == ID_unknown ||
       value_set_element.id() == ID_invalid ||
       is_failed_symbol(
-        to_object_descriptor_expr(value_set_element).root_object()))
+        to_object_descriptor_expr(value_set_element).root_object()) ||
+      to_object_descriptor_expr(value_set_element).offset().id() == ID_unknown)
     {
       // We can't conclude anything about the value-set
       return {};


### PR DESCRIPTION
A non-constant offset is stored as "unknown," which does include an
offset of zero. As constant + zero == constant we should not conclude
that the constant is not contained in the set.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
