### PR TITLE
C front-end: Permit array_of as array initializer

### DIFF
--- a/regression/ansi-c/array_initialization5/main.c
+++ b/regression/ansi-c/array_initialization5/main.c
@@ -1,0 +1,7 @@
+// array size greater than MAX_FLATTENED_ARRAY_SIZE
+static unsigned char buffer[10000] = {0};
+
+int main()
+{
+  __CPROVER_assert(buffer[0] == 0, "");
+}

--- a/regression/ansi-c/array_initialization5/test.desc
+++ b/regression/ansi-c/array_initialization5/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -37,7 +37,7 @@ void c_typecheck_baset::do_initializer(
                    "any array must have a size");
 
     // we don't allow initialisation with symbols of array type
-    if(result.id()!=ID_array)
+    if(result.id() != ID_array && result.id() != ID_array_of)
     {
       error().source_location = result.source_location();
       error() << "invalid array initializer " << to_string(result)


### PR DESCRIPTION
Since 375e9a8cfd93 we generate array_of expressions for large arrays.
The C front-end must also be made aware of this.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
