### PR TITLE
Value sets: Support bitand/bitor over pointers

### DIFF
--- a/regression/cbmc/Pointer_Arithmetic14/main.c
+++ b/regression/cbmc/Pointer_Arithmetic14/main.c
@@ -1,0 +1,16 @@
+#include <stdlib.h>
+
+int main()
+{
+  int a = 42;
+  size_t mask = ~(size_t)0;
+  // applying bitmasks to pointers is used to defend against speculative
+  // execution side channels, hence we need to support this
+  __CPROVER_assert(*(int *)(mask & (size_t)&a) == 42, "");
+
+  // the following bitmasks are for completeness of the test only, they aren't
+  // necessarily as useful in practice
+  size_t mask_zero = 0;
+  __CPROVER_assert(*(int *)(mask_zero | (size_t)&a) == 42, "");
+  __CPROVER_assert(*(int *)(mask_zero ^ (size_t)&a) == 42, "");
+}

--- a/regression/cbmc/Pointer_Arithmetic14/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic14/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -642,8 +642,11 @@ void value_sett::get_value_set_rec(
     else
       insert(dest, exprt(ID_unknown, original_type));
   }
-  else if(expr.id()==ID_plus ||
-          expr.id()==ID_minus)
+  else if(
+    expr.id() == ID_plus || expr.id() == ID_minus || expr.id() == ID_bitor ||
+    expr.id() == ID_bitand || expr.id() == ID_bitxor ||
+    expr.id() == ID_bitnand || expr.id() == ID_bitnor ||
+    expr.id() == ID_bitxnor)
   {
     if(expr.operands().size()<2)
       throw expr.id_string()+" expected to have at least two operands";
@@ -653,8 +656,9 @@ void value_sett::get_value_set_rec(
 
     // special case for pointer+integer
 
-    if(expr.operands().size()==2 &&
-       expr_type.id()==ID_pointer)
+    if(
+      expr.operands().size() == 2 && expr_type.id() == ID_pointer &&
+      (expr.id() == ID_plus || expr.id() == ID_minus))
     {
       exprt ptr_operand;
 


### PR DESCRIPTION
Bit operations on pointers are used to defend against side channels
resulting from speculative execution. Hence we need to support these.
Without the support in value sets we silently just returned "unknown"
and thus subsequent dereferencing would fail.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
