### PR TITLE
Support OBJECT_SIZE over string constants

### DIFF
--- a/regression/cbmc/String8/main.c
+++ b/regression/cbmc/String8/main.c
@@ -1,0 +1,19 @@
+int main()
+{
+  _Bool branch;
+  const char *str = 0;
+
+  if(branch)
+  {
+    str = "foo";
+  }
+  else
+  {
+    str = "bar";
+  }
+
+  char a = str[2];
+  __CPROVER_assert(a == 'o' || a == 'r', "");
+
+  return 0;
+}

--- a/regression/cbmc/String8/test.desc
+++ b/regression/cbmc/String8/test.desc
@@ -1,0 +1,8 @@
+CORE broken-smt-backend
+main.c
+--pointer-check --bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -768,7 +768,7 @@ void bv_pointerst::do_postponed(
     {
       const exprt &expr=*it;
 
-      if(expr.id() != ID_symbol)
+      if(expr.id() != ID_symbol && expr.id() != ID_string_constant)
         continue;
 
       const auto size_expr = size_of_expr(expr.type(), ns);

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -220,7 +220,8 @@ void smt2_convt::define_object_size(
       numeric_cast<mp_integer>(size_expr.value_or(nil_exprt()));
 
     if(
-      o.id() != ID_symbol || !size_expr.has_value() || !object_size.has_value())
+      (o.id() != ID_symbol && o.id() != ID_string_constant) ||
+      !size_expr.has_value() || !object_size.has_value())
     {
       ++number;
       continue;


### PR DESCRIPTION
Pointer checks (including __CPROVER_{r,w}_ok) over string constants
should succeed when the access is within bounds. To do so, we must no
return non-deterministic values for the object size of string constants.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
