### PR TITLE
simplifier: eliminate casts from bool to number

### DIFF
--- a/jbmc/unit/util/simplify_expr.cpp
+++ b/jbmc/unit/util/simplify_expr.cpp
@@ -47,6 +47,17 @@ void test_unnecessary_cast(const typet &type)
       REQUIRE(simplified.type()==java_int_type());
     }
 
+    // casts from boolean get rewritten to ?:
+    if(type == java_boolean_type())
+    {
+      const exprt simplified = simplify_expr(
+        typecast_exprt(symbol_exprt("foo", java_int_type()), type),
+        namespacet(symbol_tablet()));
+
+      REQUIRE(simplified.id() == ID_if);
+      REQUIRE(simplified.type() == type);
+    }
+    else
     {
       const exprt simplified=simplify_expr(
         typecast_exprt(symbol_exprt("foo", java_int_type()), type),

--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -244,3 +244,57 @@ TEST_CASE("Simplify pointer_object equality", "[core][util]")
 
   REQUIRE(simp.is_true());
 }
+
+TEST_CASE("Simplify cast from bool", "[core][util]")
+{
+  symbol_tablet symbol_table;
+  namespacet ns(symbol_table);
+
+  {
+    // this checks that ((int)B)==1 turns into B
+    exprt B = symbol_exprt("B", bool_typet());
+    exprt comparison = equal_exprt(
+      typecast_exprt(B, signedbv_typet(32)),
+      from_integer(1, signedbv_typet(32)));
+
+    exprt simp = simplify_expr(comparison, ns);
+
+    REQUIRE(simp == B);
+  }
+
+  {
+    // this checks that ((int)B)==0 turns into !B
+    exprt B = symbol_exprt("B", bool_typet());
+    exprt comparison = equal_exprt(
+      typecast_exprt(B, signedbv_typet(32)),
+      from_integer(0, signedbv_typet(32)));
+
+    exprt simp = simplify_expr(comparison, ns);
+
+    REQUIRE(simp == not_exprt(B));
+  }
+
+  {
+    // this checks that ((int)B)!=1 turns into !B
+    exprt B = symbol_exprt("B", bool_typet());
+    exprt comparison = notequal_exprt(
+      typecast_exprt(B, signedbv_typet(32)),
+      from_integer(1, signedbv_typet(32)));
+
+    exprt simp = simplify_expr(comparison, ns);
+
+    REQUIRE(simp == not_exprt(B));
+  }
+
+  {
+    // this checks that ((int)B)!=0 turns into B
+    exprt B = symbol_exprt("B", bool_typet());
+    exprt comparison = notequal_exprt(
+      typecast_exprt(B, signedbv_typet(32)),
+      from_integer(0, signedbv_typet(32)));
+
+    exprt simp = simplify_expr(comparison, ns);
+
+    REQUIRE(simp == B);
+  }
+}


### PR DESCRIPTION
This usually enables subsequent simplification, e.g.,

`((int)B) != 0`

turns into

`(B?1:0) != 0`

and then into

`B?1!=0:0!=0`

and then into

`B?true:false`

which then turns into

`B`

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
