### PR TITLE
Removed const from return types where they return by value

### DIFF
--- a/src/util/range.h
+++ b/src/util/range.h
@@ -53,7 +53,7 @@ public:
   }
 
   /// Postincrement operator
-  const map_iteratort operator++(int)
+  map_iteratort operator++(int)
   {
     map_iteratort tmp(*this);
     this->operator++();
@@ -136,7 +136,7 @@ public:
   }
 
   /// Postincrement operator
-  const filter_iteratort operator++(int)
+  filter_iteratort operator++(int)
   {
     filter_iteratort tmp(*this);
     this->operator++();
@@ -228,7 +228,7 @@ public:
   }
 
   /// Postincrement operator
-  const concat_iteratort operator++(int)
+  concat_iteratort operator++(int)
   {
     concat_iteratort tmp(first_begin, first_end, second_begin);
     this->operator++();
@@ -317,7 +317,7 @@ public:
   }
 
   /// Postincrement operator
-  const zip_iteratort operator++(int)
+  zip_iteratort operator++(int)
   {
     zip_iteratort tmp(first_begin, first_end, second_begin, second_end);
     this->operator++();


### PR DESCRIPTION
This must have been added by mistake as it has no effect at all.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- N/A Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- N/A The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- N/A Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- N/A My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.