### PR TITLE
[TG-7815] Fix bug in get_recursively_instantiated_type

### DIFF
--- a/jbmc/src/java_bytecode/java_types.h
+++ b/jbmc/src/java_bytecode/java_types.h
@@ -735,13 +735,23 @@ public:
   }
 };
 
+/// Check whether a reference to a typet is a java generic parameter/variable,
+/// e.g., `T` in `List<T>`.
+/// \param type: Source type.
+/// \return True if \p type is a generic Java parameter type
+template <>
+inline bool can_cast_type<java_generic_parametert>(const typet &base)
+{
+  return is_reference(base) && is_java_generic_parameter_tag(base.subtype());
+}
+
 /// Checks whether the type is a java generic parameter/variable, e.g., `T` in
 /// `List<T>`.
 /// \param type: the type to check
 /// \return true if type is a generic Java parameter type
 inline bool is_java_generic_parameter(const typet &type)
 {
-  return is_reference(type) && is_java_generic_parameter_tag(type.subtype());
+  return can_cast_type<java_generic_parametert>(type);
 }
 
 /// \param type: source type

--- a/jbmc/src/java_bytecode/select_pointer_type.cpp
+++ b/jbmc/src/java_bytecode/select_pointer_type.cpp
@@ -21,17 +21,8 @@ pointer_typet select_pointer_typet::convert_pointer_type(
   const namespacet &ns) const
 {
   (void)ns; // unused parameter
-  // if we have a map of generic parameters -> types and the pointer is
-  // a generic parameter, specialize it with concrete types
-  if(!generic_parameter_specialization_map.empty())
-  {
-    return specialize_generics(
-      pointer_type, generic_parameter_specialization_map);
-  }
-  else
-  {
-    return pointer_type;
-  }
+  return specialize_generics(
+    pointer_type, generic_parameter_specialization_map);
 }
 
 /// Return the first concrete type instantiation if any such exists.

--- a/jbmc/src/java_bytecode/select_pointer_type.cpp
+++ b/jbmc/src/java_bytecode/select_pointer_type.cpp
@@ -43,11 +43,10 @@ pointer_typet select_pointer_typet::specialize_generics(
     &generic_parameter_specialization_map,
   generic_parameter_recursion_trackingt &visited_nodes) const
 {
-  if(is_java_generic_parameter(pointer_type))
+  auto parameter = type_try_dynamic_cast<java_generic_parametert>(pointer_type);
+  if(parameter != nullptr)
   {
-    const java_generic_parametert &parameter =
-      to_java_generic_parameter(pointer_type);
-    const irep_idt &parameter_name = parameter.get_name();
+    const irep_idt &parameter_name = parameter->get_name();
 
     // avoid infinite recursion by looking at each generic argument from
     // previous assignments
@@ -82,26 +81,27 @@ pointer_typet select_pointer_typet::specialize_generics(
     visited_nodes.erase(parameter_name);
     return returned_type;
   }
-  else if(pointer_type.subtype().id() == ID_struct_tag)
+
+  auto subtype =
+    type_try_dynamic_cast<struct_tag_typet>(pointer_type.subtype());
+  if(subtype != nullptr && is_java_array_tag(subtype->get_identifier()))
   {
     // if the pointer is an array, recursively specialize its element type
-    const auto &array_subtype = to_struct_tag_type(pointer_type.subtype());
-    if(is_java_array_tag(array_subtype.get_identifier()))
-    {
-      const typet &array_element_type = java_array_element_type(array_subtype);
-      if(array_element_type.id() == ID_pointer)
-      {
-        const pointer_typet &new_array_type = specialize_generics(
-          to_pointer_type(array_element_type),
-          generic_parameter_specialization_map,
-          visited_nodes);
+    auto array_element_type =
+      type_try_dynamic_cast<pointer_typet>(java_array_element_type(*subtype));
+    if(array_element_type == nullptr)
+      return pointer_type;
 
-        pointer_typet replacement_array_type = java_array_type('a');
-        replacement_array_type.subtype().set(ID_element_type, new_array_type);
-        return replacement_array_type;
-      }
-    }
+    const pointer_typet &new_array_type = specialize_generics(
+      *array_element_type,
+      generic_parameter_specialization_map,
+      visited_nodes);
+
+    pointer_typet replacement_array_type = java_array_type('a');
+    replacement_array_type.subtype().set(ID_element_type, new_array_type);
+    return replacement_array_type;
   }
+
   return pointer_type;
 }
 

--- a/jbmc/src/java_bytecode/select_pointer_type.h
+++ b/jbmc/src/java_bytecode/select_pointer_type.h
@@ -55,13 +55,9 @@ class namespacet;
 class select_pointer_typet
 {
   optionalt<pointer_typet> get_recursively_instantiated_type(
-    const irep_idt &,
-    const generic_parameter_specialization_mapt &,
-    generic_parameter_recursion_trackingt &,
-    const size_t) const;
-  optionalt<pointer_typet> get_recursively_instantiated_type(
-    const irep_idt &parameter_name,
-    const generic_parameter_specialization_mapt &visited) const;
+    irep_idt parameter_name,
+    generic_parameter_specialization_mapt
+      generic_parameter_specialization_map) const;
 
 public:
   virtual ~select_pointer_typet() = default;

--- a/jbmc/src/java_bytecode/select_pointer_type.h
+++ b/jbmc/src/java_bytecode/select_pointer_type.h
@@ -22,7 +22,6 @@ Author: Diffblue Ltd.
 
 typedef std::unordered_map<irep_idt, std::vector<reference_typet>>
   generic_parameter_specialization_mapt;
-typedef std::set<irep_idt> generic_parameter_recursion_trackingt;
 
 struct print_generic_parameter_specialization_map
 {
@@ -54,11 +53,6 @@ class namespacet;
 
 class select_pointer_typet
 {
-  optionalt<pointer_typet> get_recursively_instantiated_type(
-    irep_idt parameter_name,
-    generic_parameter_specialization_mapt
-      generic_parameter_specialization_map) const;
-
 public:
   virtual ~select_pointer_typet() = default;
 
@@ -111,8 +105,7 @@ public:
   pointer_typet specialize_generics(
     const pointer_typet &pointer_type,
     const generic_parameter_specialization_mapt
-      &generic_parameter_specialization_map,
-    generic_parameter_recursion_trackingt &visited_nodes) const;
+      &generic_parameter_specialization_map) const;
 };
 
 #endif // CPROVER_JAVA_BYTECODE_SELECT_POINTER_TYPE_H

--- a/jbmc/src/java_bytecode/select_pointer_type.h
+++ b/jbmc/src/java_bytecode/select_pointer_type.h
@@ -15,6 +15,7 @@ Author: Diffblue Ltd.
 
 #include <vector>
 
+#include "expr2java.h"
 #include "java_types.h"
 #include <util/optional.h>
 #include <util/std_types.h>
@@ -22,6 +23,32 @@ Author: Diffblue Ltd.
 typedef std::unordered_map<irep_idt, std::vector<reference_typet>>
   generic_parameter_specialization_mapt;
 typedef std::set<irep_idt> generic_parameter_recursion_trackingt;
+
+struct print_generic_parameter_specialization_map
+{
+  const generic_parameter_specialization_mapt &map;
+  const namespacet &ns;
+};
+
+template <typename ostream>
+ostream &
+operator<<(ostream &stm, const print_generic_parameter_specialization_map &map)
+{
+  stm << "Size: " << map.map.size() << "\n";
+  for(const auto &elt : map.map)
+  {
+    stm << elt.first << ": { ";
+    for(const auto &pointer_type : elt.second)
+    {
+      if(is_java_generic_parameter(pointer_type))
+        stm << to_java_generic_parameter(pointer_type).get_name() << "; ";
+      else
+        stm << type2java(pointer_type, map.ns) << "; ";
+    }
+    stm << "}\n";
+  }
+  return stm;
+}
 
 class namespacet;
 


### PR DESCRIPTION
This reduces the amount of code and in so doing fixes the implementation of specialization of generics.

Previously the following invariant was being triggered in non-symmetric mutual generic specialization:
```
Invariant check failed
File: .../lib/cbmc/jbmc/src/java_bytecode/select_pointer_type.cpp:187 function: get_recursively_instantiated_type
Condition: depth < replacements.size()
Reason: cannot access elements outside stack
```

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- N/A The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included in a downstream PR.
- N/A My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.