### PR TITLE
Include SSA lhs and rhs in extended JSON trace

### DIFF
--- a/regression/cbmc/trace_options_json_extended/extended.desc
+++ b/regression/cbmc/trace_options_json_extended/extended.desc
@@ -4,4 +4,6 @@ test.c
 ^EXIT=10$
 ^SIGNAL=0$
 rawLhs
+"ssaLhs": "main::argc!0@1#1",
+"ssaRhs": "argc'#0",
 --

--- a/src/goto-programs/goto_trace.h
+++ b/src/goto-programs/goto_trace.h
@@ -118,6 +118,9 @@ public:
   bool cond_value;
   exprt cond_expr;
 
+  // for assignments and declarations (ssa_lhs only)
+  exprt ssa_lhs, ssa_rhs;
+
   // for assert
   irep_idt property_id;
   std::string comment;
@@ -161,6 +164,8 @@ public:
     full_lhs.make_nil();
     full_lhs_value.make_nil();
     cond_expr.make_nil();
+    ssa_lhs.make_nil();
+    ssa_rhs.make_nil();
   }
 };
 

--- a/src/goto-programs/json_goto_trace.cpp
+++ b/src/goto-programs/json_goto_trace.cpp
@@ -14,8 +14,10 @@ Author: Daniel Kroening
 #include "json_goto_trace.h"
 
 #include <langapi/language_util.h>
+
 #include <util/arith_tools.h>
 #include <util/config.h>
+#include <util/format_expr.h>
 #include <util/invariant.h>
 #include <util/simplify_expr.h>
 
@@ -154,6 +156,19 @@ void convert_decl(
     step.assignment_type == goto_trace_stept::assignment_typet::ACTUAL_PARAMETER
       ? "actual-parameter"
       : "variable");
+
+  if(trace_options.json_full_lhs)
+  {
+    std::ostringstream oss;
+    oss << format(step.ssa_lhs);
+    json_assignment["ssaLhs"] = json_stringt(oss.str());
+  }
+  if(trace_options.json_full_lhs && step.ssa_rhs.is_not_nil())
+  {
+    std::ostringstream oss;
+    oss << format(step.ssa_rhs);
+    json_assignment["ssaRhs"] = json_stringt(oss.str());
+  }
 }
 
 /// Convert an OUTPUT goto_trace step.

--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -407,6 +407,15 @@ void build_goto_trace(
         goto_trace_step.cond_value =
           decision_procedure.get(SSA_step.cond_handle).is_true();
       }
+      else if(SSA_step.is_assignment())
+      {
+        goto_trace_step.ssa_lhs = SSA_step.ssa_lhs;
+        goto_trace_step.ssa_rhs = SSA_step.ssa_rhs;
+      }
+      else if(SSA_step.is_decl())
+      {
+        goto_trace_step.ssa_lhs = SSA_step.ssa_lhs;
+      }
 
       if(ssa_step_it == last_step_to_keep)
         return;


### PR DESCRIPTION
The full SSA identifiers will permit building tools that trace
assigned values back to inputs.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
