### PR TITLE
Make goto_rw less conservative

### DIFF
--- a/regression/goto-instrument/goto_rw_pointer_handling-2/main.c
+++ b/regression/goto-instrument/goto_rw_pointer_handling-2/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  char a = 'a';
+  char *b = &a;
+  *b = 'c';
+}

--- a/regression/goto-instrument/goto_rw_pointer_handling-2/test.desc
+++ b/regression/goto-instrument/goto_rw_pointer_handling-2/test.desc
@@ -1,0 +1,16 @@
+CORE
+main.c
+--show-dependence-graph
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+^Data dependencies: \d+$
+--
+^warning: ignoring
+^Data dependencies: \d+,\s*\d+$
+--
+This tests that the write-set of a pointer contains only the pointed-to
+object when the pointer is dereferenced and written to.
+
+There should therefore be no data dependence between the pointer itself
+and the write to the pointed-to object.

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -429,17 +429,13 @@ void rw_range_sett::get_objects_typecast(
 
 void rw_range_sett::get_objects_address_of(const exprt &object)
 {
-  if(object.id() == ID_string_constant ||
-     object.id() == ID_label ||
-     object.id() == ID_array ||
-     object.id() == ID_null_object)
+  if(
+    object.id() == ID_string_constant || object.id() == ID_label ||
+    object.id() == ID_array || object.id() == ID_null_object ||
+    object.id() == ID_symbol)
   {
     // constant, nothing to do
     return;
-  }
-  else if(object.id()==ID_symbol)
-  {
-    get_objects_rec(get_modet::READ, object);
   }
   else if(object.id()==ID_dereference)
   {


### PR DESCRIPTION
When handling the case of pointers, goto_rw would mark both the object pointed
to and the pointer itself as written. For example, if x = &i, the line `*x = 1'
would yield a write set containing both x and i, instead of just i.

This resolves that issue by ensuring that value_set_dereference always gives at
least one object that the dereference can refer to.

This also resolves a bug wherein &a is marked as reading from a by removing the
ID_symbol special case from get_objects_address_of.