### PR TITLE
Statement List: Language additions for boolean instructions

### DIFF
--- a/regression/statement-list/Bool5/main.awl
+++ b/regression/statement-list/Bool5/main.awl
@@ -1,0 +1,24 @@
+﻿FUNCTION_BLOCK "Bool5"
+VERSION : 0.1
+   VAR_INPUT 
+      in1 : Bool;
+   END_VAR
+
+   VAR_OUTPUT 
+      out1 : Bool;
+   END_VAR
+
+
+BEGIN
+NETWORK
+TITLE =
+      CLR;
+      X #in1;
+      XN #in1;
+      = #out1;
+      CALL "__CPROVER_assert"
+      (  condition := #out1
+      );
+
+END_FUNCTION_BLOCK
+

--- a/regression/statement-list/Bool5/test.desc
+++ b/regression/statement-list/Bool5/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.awl
+--function \"Bool5\"
+^EXIT=0$
+^SIGNAL=0$
+^\*\* 0 of 1 failed \(1 iterations\)$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/statement-list/Function_Call1/main.awl
+++ b/regression/statement-list/Function_Call1/main.awl
@@ -1,4 +1,4 @@
-﻿FUNCTION_BLOCK "Function_Call"
+﻿FUNCTION_BLOCK "Function_Call1"
 VERSION : 0.1
    VAR_INPUT 
       In1 : Bool;

--- a/regression/statement-list/Function_Call1/test.desc
+++ b/regression/statement-list/Function_Call1/test.desc
@@ -3,7 +3,7 @@ main.awl
 --show-parse-tree
 ^EXIT=0$
 ^SIGNAL=0$
-^Name: "Function_Call"$
+^Name: "Function_Call1"$
 ^Version: 0[.]1$
 ^statement_list_call	"__Function"$
 ^	param := In1$

--- a/regression/statement-list/Function_Call2/main.awl
+++ b/regression/statement-list/Function_Call2/main.awl
@@ -1,0 +1,40 @@
+﻿﻿FUNCTION "Called_Function" : Void
+VERSION : 0.1
+   VAR_INPUT 
+      Input : Bool;
+   END_VAR
+
+BEGIN
+NETWORK
+TITLE = 
+
+END_FUNCTION
+
+
+FUNCTION_BLOCK "Function_Call2"
+VERSION : 0.1
+   VAR_INPUT 
+      In1 : Bool;
+   END_VAR
+
+BEGIN
+NETWORK
+TITLE = 
+      CALL "__CPROVER_assert"
+      (  condition             := TRUE
+      );
+
+      CALL "__CPROVER_assume"
+      (  condition             := #In1
+      );
+
+      CALL "__CPROVER_assert"
+      (  condition             := #In1
+      );
+
+      CALL "Called_Function"
+      (  Input                 := #In1
+      );
+
+END_FUNCTION_BLOCK
+

--- a/regression/statement-list/Function_Call2/test.desc
+++ b/regression/statement-list/Function_Call2/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.awl
+--function \"Function_Call2\"
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/statement-list/parser.y
+++ b/src/statement-list/parser.y
@@ -1080,7 +1080,7 @@ Oom_Param_Assignment:
     ;
     
 Param_Assignment:
-    Variable_Name TOK_ASSIGNMENT Variable_Access
+    Variable_Name TOK_ASSIGNMENT IL_Operand
     {
       newstack($$);
       parser_stack($$) = equal_exprt{std::move(parser_stack($1)), 

--- a/src/statement-list/statement_list_parse_tree_io.cpp
+++ b/src/statement-list/statement_list_parse_tree_io.cpp
@@ -19,36 +19,36 @@ Author: Matthias Weiss, matthias.weiss@diffblue.com
 #define NO_VALUE "(none)"
 
 /// Prints a constant to the given output stream.
-/// \param [out] out: Stream that should receive the result.
+/// \param [out] os: Stream that should receive the result.
 /// \param constant: Constant that shall be printed.
-static void output_constant(std::ostream &out, const constant_exprt &constant)
+static void output_constant(std::ostream &os, const constant_exprt &constant)
 {
   mp_integer ivalue;
   if(!to_integer(constant, ivalue))
-    out << ivalue;
+    os << ivalue;
   else if(can_cast_type<floatbv_typet>(constant.type()))
   {
     ieee_floatt real{get_real_type()};
     real.from_expr(constant);
-    out << real.to_float();
+    os << real.to_float();
   }
   else
-    out << constant.get_value();
+    os << constant.get_value();
 }
 
 /// Prints the assignment of a module parameter to the given output stream.
-/// \param [out] out: Stream that should receive the result.
+/// \param [out] os: Stream that should receive the result.
 /// \param assignment: Assignment that shall be printed.
 static void
-output_parameter_assignment(std::ostream &out, const equal_exprt &assignment)
+output_parameter_assignment(std::ostream &os, const equal_exprt &assignment)
 {
-  out << assignment.lhs().get(ID_identifier) << " := ";
+  os << assignment.lhs().get(ID_identifier) << " := ";
   const constant_exprt *const constant =
     expr_try_dynamic_cast<constant_exprt>(assignment.rhs());
   if(constant)
-    output_constant(out, *constant);
+    output_constant(os, *constant);
   else
-    out << assignment.rhs().get(ID_identifier);
+    os << assignment.rhs().get(ID_identifier);
 }
 
 void output_parse_tree(
@@ -81,178 +81,178 @@ void output_parse_tree(
 }
 
 void output_function_block(
-  std::ostream &out,
+  std::ostream &os,
   const statement_list_parse_treet::function_blockt &function_block)
 {
-  output_tia_module_properties(function_block, out);
-  output_common_var_declarations(out, function_block);
-  output_static_var_declarations(out, function_block);
-  output_network_list(out, function_block.networks);
+  output_tia_module_properties(function_block, os);
+  output_common_var_declarations(os, function_block);
+  output_static_var_declarations(os, function_block);
+  output_network_list(os, function_block.networks);
 }
 
 void output_function(
-  std::ostream &out,
+  std::ostream &os,
   const statement_list_parse_treet::functiont &function)
 {
-  output_tia_module_properties(function, out);
-  output_return_value(function, out);
-  output_common_var_declarations(out, function);
-  output_network_list(out, function.networks);
+  output_tia_module_properties(function, os);
+  output_return_value(function, os);
+  output_common_var_declarations(os, function);
+  output_network_list(os, function.networks);
 }
 
 void output_tia_module_properties(
   const statement_list_parse_treet::tia_modulet &module,
-  std::ostream &out)
+  std::ostream &os)
 {
-  out << "Name: " << module.name << '\n';
-  out << "Version: " << module.version << "\n\n";
+  os << "Name: " << module.name << '\n';
+  os << "Version: " << module.version << "\n\n";
 }
 
 void output_return_value(
   const statement_list_parse_treet::functiont &function,
-  std::ostream &out)
+  std::ostream &os)
 {
-  out << "Return type: ";
+  os << "Return type: ";
   if(function.return_type.is_nil())
-    out << "Void";
+    os << "Void";
   else
-    out << function.return_type.id();
-  out << "\n\n";
+    os << function.return_type.id();
+  os << "\n\n";
 }
 
 void output_common_var_declarations(
-  std::ostream &out,
+  std::ostream &os,
   const statement_list_parse_treet::tia_modulet &module)
 {
   if(!module.var_input.empty())
   {
-    out << "--------- Input Variables ----------\n\n";
-    output_var_declaration_list(out, module.var_input);
+    os << "--------- Input Variables ----------\n\n";
+    output_var_declaration_list(os, module.var_input);
   }
 
   if(!module.var_inout.empty())
   {
-    out << "--------- In/Out Variables ---------\n\n";
-    output_var_declaration_list(out, module.var_inout);
+    os << "--------- In/Out Variables ---------\n\n";
+    output_var_declaration_list(os, module.var_inout);
   }
 
   if(!module.var_output.empty())
   {
-    out << "--------- Output Variables ---------\n\n";
-    output_var_declaration_list(out, module.var_output);
+    os << "--------- Output Variables ---------\n\n";
+    output_var_declaration_list(os, module.var_output);
   }
 
   if(!module.var_constant.empty())
   {
-    out << "-------- Constant Variables --------\n\n";
-    output_var_declaration_list(out, module.var_constant);
+    os << "-------- Constant Variables --------\n\n";
+    output_var_declaration_list(os, module.var_constant);
   }
 
   if(!module.var_temp.empty())
   {
-    out << "---------- Temp Variables ----------\n\n";
-    output_var_declaration_list(out, module.var_temp);
+    os << "---------- Temp Variables ----------\n\n";
+    output_var_declaration_list(os, module.var_temp);
   }
 }
 
 void output_static_var_declarations(
-  std::ostream &out,
+  std::ostream &os,
   const statement_list_parse_treet::function_blockt &block)
 {
   if(!block.var_static.empty())
   {
-    out << "--------- Static Variables ---------\n\n";
-    output_var_declaration_list(out, block.var_static);
+    os << "--------- Static Variables ---------\n\n";
+    output_var_declaration_list(os, block.var_static);
   }
 }
 
 void output_var_declaration_list(
-  std::ostream &out,
+  std::ostream &os,
   const statement_list_parse_treet::var_declarationst &declarations)
 {
   for(const auto &declaration : declarations)
   {
-    output_var_declaration(out, declaration);
-    out << "\n\n";
+    output_var_declaration(os, declaration);
+    os << "\n\n";
   }
 }
 
 void output_var_declaration(
-  std::ostream &out,
+  std::ostream &os,
   const statement_list_parse_treet::var_declarationt &declaration)
 {
-  out << declaration.variable.pretty() << '\n';
-  out << "  * default_value: ";
+  os << declaration.variable.pretty() << '\n';
+  os << "  * default_value: ";
   if(declaration.default_value)
   {
     const constant_exprt &constant =
       to_constant_expr(declaration.default_value.value());
-    output_constant(out, constant);
+    output_constant(os, constant);
   }
   else
-    out << NO_VALUE;
+    os << NO_VALUE;
 }
 
 void output_network_list(
-  std::ostream &out,
+  std::ostream &os,
   const statement_list_parse_treet::networkst &networks)
 {
-  out << "-------------- Networks --------------\n\n";
+  os << "-------------- Networks --------------\n\n";
   for(const auto &network : networks)
   {
-    output_network(out, network);
-    out << '\n';
+    output_network(os, network);
+    os << '\n';
   }
 }
 
 void output_network(
-  std::ostream &out,
+  std::ostream &os,
   const statement_list_parse_treet::networkt &network)
 {
-  out << "Title: " << network.title.value_or(NO_VALUE) << '\n';
-  out << "Instructions: ";
+  os << "Title: " << network.title.value_or(NO_VALUE) << '\n';
+  os << "Instructions: ";
   if(network.instructions.empty())
-    out << NO_VALUE;
-  out << '\n';
+    os << NO_VALUE;
+  os << '\n';
   for(const auto &instruction : network.instructions)
   {
-    output_instruction(out, instruction);
-    out << '\n';
+    output_instruction(os, instruction);
+    os << '\n';
   }
 }
 
 void output_instruction(
-  std::ostream &out,
+  std::ostream &os,
   const statement_list_parse_treet::instructiont &instruction)
 {
   for(const codet &token : instruction.tokens)
   {
-    out << token.get_statement();
+    os << token.get_statement();
     for(const auto &expr : token.operands())
     {
       const symbol_exprt *const symbol =
         expr_try_dynamic_cast<symbol_exprt>(expr);
       if(symbol)
       {
-        out << '\t' << symbol->get_identifier();
+        os << '\t' << symbol->get_identifier();
         continue;
       }
       const constant_exprt *const constant =
         expr_try_dynamic_cast<constant_exprt>(expr);
       if(constant)
       {
-        out << '\t';
-        output_constant(out, *constant);
+        os << '\t';
+        output_constant(os, *constant);
         continue;
       }
       const equal_exprt *const equal = expr_try_dynamic_cast<equal_exprt>(expr);
       if(equal)
       {
-        out << "\n\t";
-        output_parameter_assignment(out, *equal);
+        os << "\n\t";
+        output_parameter_assignment(os, *equal);
         continue;
       }
-      out << '\t' << expr.id();
+      os << '\t' << expr.id();
     }
   }
 }

--- a/src/statement-list/statement_list_parse_tree_io.h
+++ b/src/statement-list/statement_list_parse_tree_io.h
@@ -16,97 +16,97 @@ Author: Matthias Weiss, matthias.weiss@diffblue.com
 
 /// Prints the given Statement List parse tree in a human-readable form to the
 /// given output stream.
-/// \param out: Stream that should receive the result.
+/// \param os: Stream that should receive the result.
 /// \param tree: Parse Tree whose contents should be printed.
 void output_parse_tree(
-  std::ostream &out,
+  std::ostream &os,
   const statement_list_parse_treet &tree);
 
 /// Prints the given Statement List function block in a human-readable form to
 /// the given output stream.
-/// \param out: Stream that should receive the result.
+/// \param os: Stream that should receive the result.
 /// \param block: Function block whose contents should be printed.
 void output_function_block(
-  std::ostream &out,
+  std::ostream &os,
   const statement_list_parse_treet::function_blockt &block);
 
 /// Prints the given Statement List function in a human-readable form to
 /// the given output stream.
-/// \param out: Stream that should receive the result.
+/// \param os: Stream that should receive the result.
 /// \param function: Function whose contents should be printed.
 void output_function(
-  std::ostream &out,
+  std::ostream &os,
   const statement_list_parse_treet::functiont &function);
 
 /// Prints the basic information about a TIA module to the given output stream.
 /// \param module: TIA module whose contents should be printed.
-/// \param out: Stream that should receive the result.
+/// \param os: Stream that should receive the result.
 void output_tia_module_properties(
   const statement_list_parse_treet::tia_modulet &module,
-  std::ostream &out);
+  std::ostream &os);
 
 /// Prints the return value of a function to the given output stream.
 /// \param function: Function whose return value should be printed.
-/// \param out: Stream that should receive the result.
+/// \param os: Stream that should receive the result.
 void output_return_value(
   const statement_list_parse_treet::functiont &function,
-  std::ostream &out);
+  std::ostream &os);
 
 /// Prints all variable declarations functions and function blocks have in
 /// common to the given output stream.
-/// \param out: Stream that should receive the result.
+/// \param os: Stream that should receive the result.
 /// \param module: TIA module whose variable declarations should be printed.
 void output_common_var_declarations(
-  std::ostream &out,
+  std::ostream &os,
   const statement_list_parse_treet::tia_modulet &module);
 
 /// Prints the static variable declarations of a function block to the given
 /// output stream.
-/// \param out: Stream that should receive the result.
+/// \param os: Stream that should receive the result.
 /// \param block: Function block whose static variables should be
 ///   printed.
 void output_static_var_declarations(
-  std::ostream &out,
+  std::ostream &os,
   const statement_list_parse_treet::function_blockt &block);
 
 /// Prints all variable declarations of the given list to the given output
 /// stream.
-/// \param out: Stream that should receive the result.
+/// \param os: Stream that should receive the result.
 /// \param declarations: List whose contents should be printed.
 void output_var_declaration_list(
-  std::ostream &out,
+  std::ostream &os,
   const statement_list_parse_treet::var_declarationst &declarations);
 
 /// Prints the given Statement List variable declaration in a human-readable
 /// form to the given output stream.
-/// \param out: Stream that should receive the result.
+/// \param os: Stream that should receive the result.
 /// \param declaration: Declaration that should be printed.
 void output_var_declaration(
-  std::ostream &out,
+  std::ostream &os,
   const statement_list_parse_treet::var_declarationt &declaration);
 
 /// Prints the given network list in a human-readable form to the given output
 /// stream.
-/// \param out: Stream that should receive the result.
+/// \param os: Stream that should receive the result.
 /// \param networks: List whose contents should be printed.
 void output_network_list(
-  std::ostream &out,
+  std::ostream &os,
   const statement_list_parse_treet::networkst &networks);
 
 /// Prints the given Statement List network in a human-readable form to the
 /// given output stream.
-/// \param out: Stream that should receive the result.
+/// \param os: Stream that should receive the result.
 /// \param network: Network that should be printed.
 void output_network(
-  std::ostream &out,
+  std::ostream &os,
   const statement_list_parse_treet::networkt &network);
 
 /// Prints the given Statement List instruction in a human-readable form to the
 /// given output stream.
-/// \param out: Stream that should receive the result.
+/// \param os: Stream that should receive the result.
 /// \param instruction: Instruction that should be printed.
 void output_instruction(
-  std::ostream &out,
+  std::ostream &os,
   const statement_list_parse_treet::instructiont &instruction);
 
 #endif // CPROVER_STATEMENT_LIST_STATEMENT_LIST_PARSE_TREE_IO_H

--- a/src/statement-list/statement_list_typecheck.h
+++ b/src/statement-list/statement_list_typecheck.h
@@ -592,6 +592,15 @@ private:
     const code_typet::parametert &param,
     const symbolt &tia_element);
 
+  /// Checks if the given assigned expression is a variable or a constant and
+  /// returns the typechecked version.
+  /// \param tia_element: Symbol representation of the TIA element.
+  /// \param rhs: Expression that the function parameter got assigned to.
+  /// \return: Expression of either a symbol or a constant.
+  exprt typecheck_function_call_argument_rhs(
+    const symbolt &tia_element,
+    const exprt &rhs);
+
   /// Checks if there is a return value assignment inside of the assignment
   /// list of a function call and returns the expression of the assigned
   /// variable.

--- a/src/statement-list/statement_list_typecheck.h
+++ b/src/statement-list/statement_list_typecheck.h
@@ -368,15 +368,23 @@ private:
     const codet &op_code,
     const symbolt &tia_element);
 
-  /// Performs a typecheck on a STL boolean And Not instruction. Reads and
+  /// Performs a typecheck on a STL boolean Or instruction. Reads and
   /// modifies the RLO, OR and FC bit.
   /// \param op_code: OP code of the instruction.
   /// \param tia_element: Symbol representation of the TIA element.
   void
   typecheck_statement_list_or(const codet &op_code, const symbolt &tia_element);
 
-  /// Performs a typecheck on a STL boolean Or instruction. Reads and modifies
-  /// the RLO, OR and FC bit.
+  /// Performs a typecheck on a STL boolean XOR instruction. Reads and
+  /// modifies the RLO, OR and FC bit.
+  /// \param op_code: OP code of the instruction.
+  /// \param tia_element: Symbol representation of the TIA element.
+  void typecheck_statement_list_xor(
+    const codet &op_code,
+    const symbolt &tia_element);
+
+  /// Performs a typecheck on a STL boolean And Not instruction. Reads and
+  /// modifies the RLO, OR and FC bit.
   /// \param op_code: OP code of the instruction.
   /// \param tia_element: Symbol representation of the TIA element.
   void typecheck_statement_list_and_not(
@@ -388,6 +396,14 @@ private:
   /// \param op_code: OP code of the instruction.
   /// \param tia_element: Symbol representation of the TIA element.
   void typecheck_statement_list_or_not(
+    const codet &op_code,
+    const symbolt &tia_element);
+
+  /// Performs a typecheck on a STL boolean XOR Not instruction. Reads and
+  /// modifies the RLO, OR and FC bit.
+  /// \param op_code: OP code of the instruction.
+  /// \param tia_element: Symbol representation of the TIA element.
+  void typecheck_statement_list_xor_not(
     const codet &op_code,
     const symbolt &tia_element);
 
@@ -405,6 +421,11 @@ private:
   /// \param op_code: OP code of the instruction.
   void typecheck_statement_list_nested_or(const codet &op_code);
 
+  /// Performs a typecheck on a nested XOR instruction. Pushes the current
+  /// program state to the nesting stack and cleans the RLO, OR and FC bit.
+  /// \param op_code: OP code of the instruction.
+  void typecheck_statement_list_nested_xor(const codet &op_code);
+
   /// Performs a typecheck on a nested And Not instruction. Pushes the current
   /// program state to the nesting stack and cleans the RLO, OR and FC bit.
   /// \param op_code: OP code of the instruction.
@@ -414,6 +435,11 @@ private:
   /// program state to the nesting stack and cleans the RLO, OR and FC bit.
   /// \param op_code: OP code of the instruction.
   void typecheck_statement_list_nested_or_not(const codet &op_code);
+
+  /// Performs a typecheck on a nested XOR Not instruction. Pushes the current
+  /// program state to the nesting stack and cleans the RLO, OR and FC bit.
+  /// \param op_code: OP code of the instruction.
+  void typecheck_statement_list_nested_xor_not(const codet &op_code);
 
   /// Performs a typecheck on a Nesting Closed instruction. Uses the latest
   /// entry on the nesting stack and modifies the RLO, OR and FC bit according
@@ -478,7 +504,7 @@ private:
   /// Performs a typecheck on a STL instruction with an additional operand that
   /// should be no constant.
   /// \param op_code: OP code of the instruction.
-  /// \return Reference to the operand.
+  /// \return: Reference to the operand.
   const symbol_exprt &
   typecheck_instruction_with_non_const_operand(const codet &op_code);
 
@@ -486,10 +512,31 @@ private:
   /// \param op_code: OP code of the instruction.
   void typecheck_instruction_without_operand(const codet &op_code);
 
-  /// Performs a typecheck on an STL instruction that uses two accumulator
+  /// Performs a typecheck on a STL instruction that uses two accumulator
   /// entries.
   /// \param op_code: OP code of the instruction.
   void typecheck_binary_accumulator_instruction(const codet &op_code);
+
+  /// Performs a typecheck on a STL instruction that initializes a new boolean
+  /// nesting.
+  /// \param op_code: OP code of the instruction.
+  /// \param rlo_value: Value of the RLO that is pushed on the nesting stack
+  ///   for the case that this is the first instruction of a new bit string.
+  void typecheck_nested_boolean_instruction(
+    const codet &op_code,
+    const exprt &rlo_value);
+
+  /// Performs a typecheck on the operand of a not nested boolean instruction
+  /// and returns the result.
+  /// \param op_code: OP code of the instruction.
+  /// \param tia_element: Symbol representation of the TIA element.
+  /// \param negate: Whether the operand should be negated (e.g. for the
+  ///   `AND NOT` expression).
+  /// \return: Typechecked operand.
+  exprt typecheck_simple_boolean_instruction_operand(
+    const codet &op_code,
+    const symbolt &tia_element,
+    bool negate);
 
   /// Performs a typecheck on an STL comparison instruction. Modifies the RLO.
   /// \param comparison: ID of the compare expression that should be pushed to

--- a/src/statement-list/statement_list_typecheck.h
+++ b/src/statement-list/statement_list_typecheck.h
@@ -129,6 +129,10 @@ private:
   /// adds symbols for its contents to the symbol table.
   void typecheck_tag_list();
 
+  /// Adds a symbol for the RLO to the symbol table. This symbol is used by
+  /// other operations to save intermediate results of the rlo expression.
+  void add_temp_rlo();
+
   /// Creates a data block type for the given function block.
   /// \param function_block: Function block with an interface that should be
   /// converted to a data block.
@@ -624,6 +628,11 @@ private:
   /// instruction was encontered.
   /// \param op: Operand of the encountered instruction.
   void initialize_bit_expression(const exprt &op);
+
+  /// Saves the current RLO bit to a temporary variable to prevent false
+  /// overrides when modifying boolean variables.
+  /// \param tia_element: Symbol representation of the TIA element.
+  void save_rlo_state(symbolt &tia_element);
 };
 
 #endif // CPROVER_STATEMENT_LIST_STATEMENT_LIST_TYPECHECK_H


### PR DESCRIPTION
This PR expands the language subset of STL. 
1. Adds support for STL `X`, `XN`, `X(` and `XN(` instructions (XOR and XOR NOT).
2. Enables the use of constants as function parameters.
3. Fixes an issue that modified the RLO in a wrong way when a variable that contributed to the RLO was modified.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.