### PR TITLE
Create auxiliary symbols with a different name than symbols in namespace [blocks: #4885]

### DIFF
--- a/src/util/fresh_symbol.cpp
+++ b/src/util/fresh_symbol.cpp
@@ -17,7 +17,8 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 #include "symbol.h"
 #include "symbol_table_base.h"
 
-/// Installs a fresh-named symbol with the requested name pattern.
+/// Installs a fresh-named symbol with respect to the given namespace `ns` with
+/// the requested name pattern in the given symbol table
 /// \param type: The type of the new symbol.
 /// \param name_prefix: The new symbol will be named
 ///   `name_prefix::basename_prefix$num` unless name_prefix is empty, in which
@@ -25,6 +26,7 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 /// \param basename_prefix: See `name_prefix`.
 /// \param source_location: The source location for the new symbol.
 /// \param symbol_mode: The mode for the new symbol, e.g. ID_C, ID_java.
+/// \param ns: the new symbol has a different name than any symbols in `ns`
 /// \param symbol_table: The symbol table to add the new symbol to.
 /// \return The new symbol.
 symbolt &get_fresh_aux_symbol(
@@ -33,9 +35,9 @@ symbolt &get_fresh_aux_symbol(
   const std::string &basename_prefix,
   const source_locationt &source_location,
   const irep_idt &symbol_mode,
+  const namespacet &ns,
   symbol_table_baset &symbol_table)
 {
-  namespacet ns(symbol_table);
   irep_idt identifier = basename_prefix;
   std::size_t prefix_size = 0;
   if(!name_prefix.empty())
@@ -54,4 +56,33 @@ symbolt &get_fresh_aux_symbol(
   CHECK_RETURN(res.second);
 
   return res.first;
+}
+
+/// Installs a fresh-named symbol with the requested name pattern in the given
+/// symbol table
+/// \param type: The type of the new symbol.
+/// \param name_prefix: The new symbol will be named
+///   `name_prefix::basename_prefix$num` unless name_prefix is empty, in which
+///   case the :: prefix is omitted.
+/// \param basename_prefix: See `name_prefix`.
+/// \param source_location: The source location for the new symbol.
+/// \param symbol_mode: The mode for the new symbol, e.g. ID_C, ID_java.
+/// \param symbol_table: The symbol table to add the new symbol to.
+/// \return The new symbol.
+symbolt &get_fresh_aux_symbol(
+  const typet &type,
+  const std::string &name_prefix,
+  const std::string &basename_prefix,
+  const source_locationt &source_location,
+  const irep_idt &symbol_mode,
+  symbol_table_baset &symbol_table)
+{
+  return get_fresh_aux_symbol(
+    type,
+    name_prefix,
+    basename_prefix,
+    source_location,
+    symbol_mode,
+    namespacet(symbol_table),
+    symbol_table);
 }

--- a/src/util/fresh_symbol.h
+++ b/src/util/fresh_symbol.h
@@ -16,6 +16,7 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 
 #include "irep.h"
 
+class namespacet;
 class source_locationt;
 class symbolt;
 class symbol_table_baset;
@@ -27,6 +28,15 @@ symbolt &get_fresh_aux_symbol(
   const std::string &basename_prefix,
   const source_locationt &source_location,
   const irep_idt &symbol_mode,
+  symbol_table_baset &symbol_table);
+
+symbolt &get_fresh_aux_symbol(
+  const typet &type,
+  const std::string &name_prefix,
+  const std::string &basename_prefix,
+  const source_locationt &source_location,
+  const irep_idt &symbol_mode,
+  const namespacet &ns,
   symbol_table_baset &symbol_table);
 
 #endif // CPROVER_UTIL_FRESH_SYMBOL_H


### PR DESCRIPTION
This adds another version of get_fresh_aux_symbol which takes a namespace and
produces symbol names that are different from any of the symbols in the
namespace. This can be used to e.g. generate fresh symbols during symex that
don't clash with any of the existing symbols.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
