### PR TITLE
Stop asserting positive array size

### DIFF
--- a/regression/cbmc/Struct_Hack_Initialization/main.c
+++ b/regression/cbmc/Struct_Hack_Initialization/main.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+
+typedef struct stritem
+{
+  unsigned nkey;
+  unsigned cas[];
+} item;
+
+int foo(item *it)
+{
+  assert(it->cas[0] == 0);
+  return 0;
+}

--- a/regression/cbmc/Struct_Hack_Initialization/test.desc
+++ b/regression/cbmc/Struct_Hack_Initialization/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--function foo --bounds-check --pointer-check
+^\[foo.assertion.1\] line \d+ assertion it->cas\[0\] == 0: FAILURE$
+^\[foo.array_bounds.3\] line \d+ array.cas upper bound in it->cas\[\(.*\)0\]: FAILURE$
+^\[foo.array_bounds.2\] line \d+ array.cas dynamic object upper bound in it->cas\[\(.*\)0\]: FAILURE$
+^\[foo.pointer_dereference.2\] line \d+ dereference failure: pointer invalid in it->cas: SUCCESS$
+^\[foo.pointer_dereference.6\] line \d+ dereference failure: pointer outside object bounds in it->cas: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/src/ansi-c/c_nondet_symbol_factory.cpp
+++ b/src/ansi-c/c_nondet_symbol_factory.cpp
@@ -163,7 +163,6 @@ void symbol_factoryt::gen_nondet_array_init(
   const auto &size = array_type.size();
   PRECONDITION(size.id() == ID_constant);
   auto const array_size = numeric_cast_v<size_t>(to_constant_expr(size));
-  DATA_INVARIANT(array_size > 0, "Arrays should have positive size");
   for(size_t index = 0; index < array_size; ++index)
   {
     gen_nondet_init(

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -2672,7 +2672,14 @@ void smt2_convt::convert_struct(const struct_exprt &expr)
 
         // may need to flatten array-theory arrays in there
         if(op.type().id() == ID_array)
-          flatten_array(op);
+        {
+          const array_typet &array_type = to_array_type(op.type());
+          const auto &size_expr = array_type.size();
+          CHECK_RETURN(size_expr.id() == ID_constant);
+
+          if(numeric_cast_v<mp_integer>(to_constant_expr(size_expr)) != 0)
+            flatten_array(op);
+        }
         else
           convert_expr(op);
 
@@ -4526,7 +4533,11 @@ void smt2_convt::convert_type(const typet &type)
   {
     if(use_datatypes)
     {
-      out << datatype_map.at(type);
+      const typet &struct_type = type.id() == ID_struct_tag
+                                   ? ns.follow_tag(to_struct_tag_type(type))
+                                   : type;
+      CHECK_RETURN(datatype_map.count(struct_type) > 0);
+      out << datatype_map.at(struct_type);
     }
     else
     {


### PR DESCRIPTION
when generating non-deterministic arrays. Zero-sized arrays are (unfortunately)
legal C construct (as for example the regression test shows).

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
