### PR TITLE
Stop assertion size-of-expr for pointer-checks

### DIFF
--- a/regression/cbmc/Void_Pointer_Init/main.c
+++ b/regression/cbmc/Void_Pointer_Init/main.c
@@ -1,0 +1,6 @@
+#include <assert.h>
+
+void foo(void *arg)
+{
+  assert(*(unsigned *)(arg) == 5);
+}

--- a/regression/cbmc/Void_Pointer_Init/test.desc
+++ b/regression/cbmc/Void_Pointer_Init/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--function foo --pointer-check
+^\[foo.assertion.1\] line \d+ assertion \*\(unsigned \*\)\(arg\) == 5: FAILURE$
+^\[foo.pointer_dereference.4\] line \d+ dereference failure: dead object in \*\(\(unsigned int \*\)arg\): FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1113,7 +1113,8 @@ void goto_checkt::pointer_validity_check(
   const exprt &pointer=expr.pointer();
 
   auto size_of_expr_opt = size_of_expr(expr.type(), ns);
-  CHECK_RETURN(size_of_expr_opt.has_value());
+  if(!size_of_expr_opt.has_value())
+    return; // in the case of `void*`
 
   auto conditions = address_check(pointer, size_of_expr_opt.value());
 

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -2214,6 +2214,10 @@ void smt2_convt::convert_typecast(const typecast_exprt &expr)
         convert_typecast(tmp);
       }
     }
+    else if(src_type.id() == ID_empty)
+    {
+      convert_expr(src);
+    }
     else
     {
       std::ostringstream e_str;
@@ -4625,6 +4629,11 @@ void smt2_convt::convert_type(const typet &type)
   else if(type.id()==ID_c_bit_field)
   {
     convert_type(c_bit_field_replacement_type(to_c_bit_field_type(type), ns));
+  }
+  else if(type.id() == ID_empty)
+  {
+    // the NONDET(void) is in fact of type char
+    out << "(_ BitVec " << boolbv_width(char_type()) << " )";
   }
   else
   {


### PR DESCRIPTION
Since these can be void-pointers. In this case we simply skip introducing the
address-check altogether. See https://github.com/diffblue/cbmc/issues/4930.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
