### PR TITLE
Error message when entry function body cannot be produced [TG-8299]

### DIFF
--- a/jbmc/regression/jbmc/context-include-exclude/test_excluded_entry_point.desc
+++ b/jbmc/regression/jbmc/context-include-exclude/test_excluded_entry_point.desc
@@ -1,0 +1,11 @@
+CORE
+Main.class
+--context-exclude 'org.cprover.MyClass$Inner.' --function 'org.cprover.MyClass$Inner.doIt:(I)I'
+^EXIT=1$
+^SIGNAL=0$
+the program has no entry point
+--
+_Map_base::at
+unordered_map::at: key not found
+--
+Tests that a proper error message is printed.

--- a/jbmc/src/java_bytecode/java_bytecode_language.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_language.cpp
@@ -899,6 +899,17 @@ bool java_bytecode_languaget::generate_support_functions(
   // parameter names
   convert_lazy_method(res.main_function.name, symbol_table_builder);
 
+  const symbolt &symbol =
+    symbol_table_builder.lookup_ref(res.main_function.name);
+  if(symbol.value.is_nil())
+  {
+    throw invalid_command_line_argument_exceptiont(
+      "the program has no entry point",
+      "function",
+      "Check that the specified entry point is included by your "
+      "--context-include or --context-exclude options");
+  }
+
   // generate the test harness in __CPROVER__start and a call the entry point
   return java_entry_point(
     symbol_table_builder,


### PR DESCRIPTION
Previously crashed on a failed map.at

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
