### PR TITLE
Generation of function contracts from preconditions

### DIFF
--- a/regression/preconditions-to-contracts/CMakeLists.txt
+++ b/regression/preconditions-to-contracts/CMakeLists.txt
@@ -1,0 +1,9 @@
+if(WIN32)
+    set(is_windows true)
+else()
+    set(is_windows false)
+endif()
+
+add_test_pl_tests(
+    "${CMAKE_CURRENT_SOURCE_DIR}/chain.sh $<TARGET_FILE:goto-cc> $<TARGET_FILE:goto-instrument> $<TARGET_FILE:cbmc> ${is_windows}"
+)

--- a/regression/preconditions-to-contracts/Makefile
+++ b/regression/preconditions-to-contracts/Makefile
@@ -1,0 +1,35 @@
+default: tests.log
+
+include ../../src/config.inc
+include ../../src/common
+
+ifeq ($(BUILD_ENV_),MSVC)
+	exe=../../../src/goto-cc/goto-cl
+	is_windows=true
+else
+	exe=../../../src/goto-cc/goto-cc
+	is_windows=false
+endif
+
+test:
+	@../test.pl -e -p -c '../chain.sh $(exe) ../../../src/goto-instrument/goto-instrument ../../../src/cbmc/cbmc $(is_windows)'
+
+tests.log:
+	@../test.pl -e -p -c '../chain.sh $(exe) ../../../src/goto-instrument/goto-instrument ../../../src/cbmc/cbmc $(is_windows)'
+
+show:
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			vim -o "$$dir/*.c" "$$dir/*.out"; \
+		fi; \
+	done;
+
+clean:
+	@for dir in *; do \
+		$(RM) tests.log; \
+		if [ -d "$$dir" ]; then \
+			cd "$$dir"; \
+			$(RM) *.out *.gb; \
+			cd ..; \
+		fi \
+	done

--- a/regression/preconditions-to-contracts/chain.sh
+++ b/regression/preconditions-to-contracts/chain.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+goto_cc=$1
+goto_instrument=$2
+cbmc=$3
+is_windows=$4
+
+name=${*:$#}
+name=${name%.c}
+
+args=${*:5:$#-5}
+
+if [[ "${is_windows}" == "true" ]]; then
+  $goto_cc --turn-preconditions-to-contracts "${name}.c"
+  mv "${name}.exe" "${name}.gb"
+else
+  $goto_cc --turn-preconditions-to-contracts -o "${name}.gb" "${name}.c"
+fi
+
+rm -f "${name}-mod.gb"
+$goto_instrument ${args} "${name}.gb" "${name}-mod.gb"
+if [ ! -e "${name}-mod.gb" ] ; then
+  cp "$name.gb" "${name}-mod.gb"
+elif echo $args | grep -q -- "--dump-c" ; then
+  mv "${name}-mod.gb" "${name}-mod.c"
+
+  if [[ "${is_windows}" == "true" ]]; then
+    $goto_cc "${name}-mod.c"
+    mv "${name}-mod.exe" "${name}-mod.gb"
+  else
+    $goto_cc -o "${name}-mod.gb" "${name}-mod.c"
+  fi
+
+  rm "${name}-mod.c"
+fi
+$goto_instrument --show-goto-functions "${name}-mod.gb"
+$cbmc "${name}-mod.gb"

--- a/regression/preconditions-to-contracts/precondition_check_01/main.c
+++ b/regression/preconditions-to-contracts/precondition_check_01/main.c
@@ -1,0 +1,28 @@
+// This tests whether preconditions are correctly turned to contracts
+// by checking whether the contract holds
+
+#include <assert.h>
+
+int min(int a, int b) __CPROVER_ensures(
+  __CPROVER_return_value <= a && __CPROVER_return_value <= b &&
+  (__CPROVER_return_value == a || __CPROVER_return_value == b))
+{
+  __CPROVER_precondition(a >= 0, "");
+  __CPROVER_precondition(b >= 0, "");
+  if(a <= b)
+  {
+    return a;
+  }
+  else
+  {
+    return b;
+  }
+}
+
+int main()
+{
+  int x, y, z;
+  __CPROVER_assume(x >= 0 && y >= 0);
+  z = min(x, y);
+  assert(z <= x);
+}

--- a/regression/preconditions-to-contracts/precondition_check_01/test.desc
+++ b/regression/preconditions-to-contracts/precondition_check_01/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--apply-code-contracts
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+--check-code-contracts not implemented yet.
+--apply-code-contracts is the current name for the flag. This should be
+updated as the flag changes.

--- a/regression/preconditions-to-contracts/precondition_check_02/main.c
+++ b/regression/preconditions-to-contracts/precondition_check_02/main.c
@@ -1,0 +1,18 @@
+// Note that this test is supposed to have a false precondition, and
+// we check whether CBMC can detect this failure
+
+#include <assert.h>
+
+int foo(int x) __CPROVER_ensures(__CPROVER_return_value == 1)
+{
+  __CPROVER_precondition(x == 0, "");
+  return 1;
+}
+
+int main()
+{
+  int in;
+  int x = foo(in);
+  assert(x == 1);
+  return 0;
+}

--- a/regression/preconditions-to-contracts/precondition_check_02/test.desc
+++ b/regression/preconditions-to-contracts/precondition_check_02/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--apply-code-contracts
+^EXIT=10$
+^SIGNAL=0$
+^\[main.1\] .* assertion: FAILURE
+^VERIFICATION FAILED$
+--
+--
+--check-code-contracts not implemented yet.
+--apply-code-contracts is the current name for the flag. This should be
+updated as the flag changes.

--- a/src/ansi-c/ansi_c_language.cpp
+++ b/src/ansi-c/ansi_c_language.cpp
@@ -11,8 +11,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <cstring>
 #include <sstream>
 #include <fstream>
+#include <iostream>
 
 #include <util/config.h>
+#include <util/expr_iterator.h>
+#include <util/expr_util.h>
 #include <util/get_base_name.h>
 
 #include <linking/linking.h>
@@ -133,6 +136,158 @@ bool ansi_c_languaget::generate_support_functions(
   // This creates __CPROVER_start and __CPROVER_initialize:
   return ansi_c_entry_point(
     symbol_table, get_message_handler(), object_factory_params);
+}
+
+// Question: Are those [is_*] functions correct? Are they sound/complete?
+bool is_call_to_function(irep_idt function_name, exprt expr) {
+  if(can_cast_expr<side_effect_expr_function_callt>(expr))
+  {
+    const side_effect_expr_function_callt function_call = to_side_effect_expr_function_call(expr);
+    const exprt function = function_call.function();
+    
+    if(can_cast_expr<symbol_exprt>(function))
+    {
+      const symbol_exprt function_symbol = to_symbol_expr(function);
+      return function_symbol.get_identifier() == function_name;
+    }
+  }
+  return false;
+}
+
+
+exprt::operandst filter_preconditions(irep_idt target_function_name, code_blockt function_body) {
+  // TODO: I probably have to add some check that inside the
+  // code in the precondition there is nothing funky going on?
+  exprt::operandst conditions;
+  for (depth_iteratort it = function_body.depth_begin(); it != function_body.depth_end(); ++it) {
+    // std::cout << it->id() << " -- " << it->find(ID_statement).id() << "\n";
+    if (is_call_to_function(target_function_name, *it)) {
+      const side_effect_expr_function_callt function_call = to_side_effect_expr_function_call(*it);
+      exprt condition = function_call.arguments().front();
+      // std::cout << "Precondition:\n" << precondition.pretty() << "\n";
+      // std::cout << "Precondition type:\n" << precondition.type().id() << "\n";
+      
+      conditions.push_back(condition);
+
+      // TODO: I should probably go to the next sibling or parent
+      // after finding a function call to the target name and not just
+      // iterate it once
+    }
+  }
+  return conditions;
+}
+
+// Question: Is there a way to optimize this (Returning a balanced
+// tree instead of a chain tree)? Is there a standard function that I
+// can call for this?
+//
+// If this function returns nil expression, it means that no (pre/post)condition was aggregated.
+exprt condition_conjunction(const exprt::operandst &nil_op)
+{
+  exprt::operandst op;
+  
+  // filter non nil expressions
+  std::copy_if (nil_op.begin(), nil_op.end(), std::back_inserter(op), [](exprt e){return e.is_not_nil();} );
+  
+  if(op.empty()) {
+    // Question: What is a better way to do this?
+    exprt expr = exprt(ID_nil);
+    INVARIANT(expr.is_nil(), "Postcondition conjunction should be nil if no postcondition group was found.");
+    return expr;
+    // return make_boolean_expr(true);
+  }
+  else if(op.size()==1) {
+    return op.front();
+  }
+  else
+  {
+    // If the first op is trivially true recurse for free
+    auto it = op.begin();
+    exprt op0 = *it;
+    ++it;
+    exprt op1 = *it;
+    ++it;
+    exprt acc = and_exprt(op0, op1);
+
+    for ( ; it != op.end(); ++it) {
+      // Is this invariant correct?
+      INVARIANT(it->is_not_nil(), "Conjunction of conditions should never be called with nil arguments");
+      acc = and_exprt(acc, *it);
+    }
+
+    // This means that we didn't see any non-nil postcondition group
+    INVARIANT(!acc.is_true(), "Assuming that the invariant in the loop holds this should never be the case.");
+
+    return acc;
+  }
+}
+
+// TODO: Remove the filter_pre_post_conditions, as it is only used for
+// preconditions and add its code here.
+//
+// QUESTION: Should I make that static or define it somewhere else?
+exprt aggregate_function_preconditions(ansi_c_declaratort function) {
+  code_blockt function_body = to_code_block(to_code(function.value()));
+  
+  exprt::operandst preconditions = filter_preconditions("__CPROVER_precondition", function_body);
+  
+  // WARNING: In order for it to make sense to return the conjunction
+  // of the preconditions, they have to be in the beginning of the
+  // function body before anythinf else.
+  //
+  // TODO: Maybe I should add a check to ensure that
+  
+  return condition_conjunction(preconditions);
+}
+
+// Extends the specified contract (requires/ensures) of the function declaration with the given condition.
+//
+// TODO: What is a way to add as a precondition to [extend_contract]
+// that [declaration] should be a function definition, and that
+// [condition] should be boolean, etc...
+void extend_contract(const irep_namet &contract_name,
+                     const exprt condition,
+                     ansi_c_declarationt* declaration) {
+  exprt old_contract = static_cast<const exprt&>(declaration->find(contract_name));
+  exprt new_contract;
+  if (old_contract.is_nil()) {
+    new_contract = condition;
+  } else {
+    new_contract = and_exprt(old_contract, condition);
+  }
+  declaration->add(contract_name, new_contract);
+}
+
+bool ansi_c_languaget::preconditions_to_contracts() {
+
+  // QUESTION: What is the canonical way to find function definitions?  
+  for (std::list<ansi_c_declarationt>::iterator it = parse_tree.items.begin(); it != parse_tree.items.end(); ++it){
+    std::cout << "Declaration:\n";
+
+    // Question: Does it always hold that a declaration either has 0 or 1 declarator?
+    if (!it->declarators().empty()) {
+      ansi_c_declaratort decl = it->declarator();
+      std::cout << "  " << decl.get_name() << "\n";
+      
+      exprt precondition = aggregate_function_preconditions(decl);
+
+      // std::cout << "Folded precondition:\n" << precondition.pretty() << "\n";
+      if (precondition.is_not_nil()) {
+        std::cout << "  -- Successfully turned precondition into contract\n";
+        // std::cout << "Previous declaration\n" << it->pretty() << "\n";
+        // Question: Is there any better way of passing a pointer to that declaration?
+        extend_contract(ID_C_spec_requires, precondition, &(*it));
+        // std::cout << "New declaration\n" << it->pretty() << "\n";
+      }
+    }
+  }
+
+  // TODO: Make a check for preconditions and ensure that they happen
+  // before anything else in the code. Should this check just be that
+  // the preconditions are a prefix of the function body?
+  
+  // show_parse(std::cout);
+  return false;
 }
 
 void ansi_c_languaget::show_parse(std::ostream &out)

--- a/src/ansi-c/ansi_c_language.cpp
+++ b/src/ansi-c/ansi_c_language.cpp
@@ -138,7 +138,10 @@ bool ansi_c_languaget::generate_support_functions(
     symbol_table, get_message_handler(), object_factory_params);
 }
 
-bool is_call_to_function(irep_idt function_name, exprt expr)
+// This returns true if the expression [expr] is a call to the
+// function with name [function_name]. Note that this doesn't handle
+// function pointers.
+bool is_call_to_function_with_name(irep_idt function_name, exprt expr)
 {
   if(can_cast_expr<side_effect_expr_function_callt>(expr))
   {
@@ -222,13 +225,11 @@ exprt aggregate_function_preconditions(code_blockt function_body)
       it != function_body.depth_end();
       ++it)
   {
-    if(is_call_to_function(CPROVER_PREFIX "precondition", *it))
+    if(is_call_to_function_with_name(CPROVER_PREFIX "precondition", *it))
     {
       const side_effect_expr_function_callt function_call =
         to_side_effect_expr_function_call(*it);
       exprt condition = function_call.arguments().front();
-      // std::cout << "Precondition:\n" << precondition.pretty() << "\n";
-
       preconditions.push_back(condition);
     }
   }

--- a/src/ansi-c/ansi_c_language.h
+++ b/src/ansi-c/ansi_c_language.h
@@ -66,7 +66,9 @@ public:
   {
     return typecheck(symbol_table, module, true);
   }
-
+  
+  bool preconditions_to_contracts() override;
+    
   void show_parse(std::ostream &out) override;
 
   ~ansi_c_languaget() override;

--- a/src/ansi-c/ansi_c_language.h
+++ b/src/ansi-c/ansi_c_language.h
@@ -66,9 +66,9 @@ public:
   {
     return typecheck(symbol_table, module, true);
   }
-  
+
   bool preconditions_to_contracts() override;
-    
+
   void show_parse(std::ostream &out) override;
 
   ~ansi_c_languaget() override;

--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -504,8 +504,23 @@ bool compilet::parse(
       error() << "PARSING ERROR" << eom;
       return true;
     }
+    // Question: Should this move after a typecheck. I don't think so,
+    // because typecheck should also typecheck the contracts in
+    // theory, so it is actually even better to let typecheck happen
+    // after this transformation so that we make sure that the
+    // transformed contracts are correct
+    if(cmdline.isset("turn-preconditions-to-contracts"))
+    {
+      statistics() << "Turning pre and postconditions to function contracts" << eom;
+      
+      if (lf.language->preconditions_to_contracts())
+      {
+        error() << "ERROR WHEN TURNING PRE AND POSTCONDITIONS TO CONTRACTS" << eom;
+        return true;
+      }
+    }
   }
-
+  
   lf.get_modules();
   return false;
 }

--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -504,11 +504,10 @@ bool compilet::parse(
       error() << "PARSING ERROR" << eom;
       return true;
     }
-    // Question: Should this move after a typecheck. I don't think so,
-    // because typecheck should also typecheck the contracts in
-    // theory, so it is actually even better to let typecheck happen
-    // after this transformation so that we make sure that the
-    // transformed contracts are correct
+
+    // Contracts are populated in the parsing step, so it is
+    // reasonable to extend them with preconditions right after
+    // parsing.
     if(cmdline.isset("turn-preconditions-to-contracts"))
     {
       statistics() << "Turning pre and postconditions to function contracts"

--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -511,16 +511,18 @@ bool compilet::parse(
     // transformed contracts are correct
     if(cmdline.isset("turn-preconditions-to-contracts"))
     {
-      statistics() << "Turning pre and postconditions to function contracts" << eom;
-      
-      if (lf.language->preconditions_to_contracts())
+      statistics() << "Turning pre and postconditions to function contracts"
+                   << eom;
+
+      if(lf.language->preconditions_to_contracts())
       {
-        error() << "ERROR WHEN TURNING PRE AND POSTCONDITIONS TO CONTRACTS" << eom;
+        error() << "ERROR WHEN TURNING PRE AND POSTCONDITIONS TO CONTRACTS"
+                << eom;
         return true;
       }
     }
   }
-  
+
   lf.get_modules();
   return false;
 }

--- a/src/goto-cc/gcc_cmdline.cpp
+++ b/src/goto-cc/gcc_cmdline.cpp
@@ -52,6 +52,7 @@ const char *goto_cc_options_without_argument[]=
   "--partial-inlining",
   "--validate-goto-model",
   "-?",
+  "--turn-preconditions-to-contracts",
   "--export-function-local-symbols",
   nullptr
 };

--- a/src/langapi/language.h
+++ b/src/langapi/language.h
@@ -158,6 +158,15 @@ public:
 
   // show parse tree
 
+  virtual bool preconditions_to_contracts()
+    {
+      INVARIANT(
+      false,
+      "preconditions_to_contracts should only be called for files written in C");
+    }
+  
+  // show parse tree
+
   virtual void show_parse(std::ostream &out)=0;
 
   // conversion of expressions

--- a/src/langapi/language.h
+++ b/src/langapi/language.h
@@ -159,12 +159,13 @@ public:
   // show parse tree
 
   virtual bool preconditions_to_contracts()
-    {
-      INVARIANT(
+  {
+    INVARIANT(
       false,
-      "preconditions_to_contracts should only be called for files written in C");
-    }
-  
+      "preconditions_to_contracts should only be called for files written in "
+      "C");
+  }
+
   // show parse tree
 
   virtual void show_parse(std::ostream &out)=0;


### PR DESCRIPTION
The goal of this PR is to extend the function contracts using preconditions.

An overview of the code changes follows:

I have added a flag `turn-preconditions-to-contracts` in goto-cc that collects preconditions from all function bodies and extends the function contract with their conjunction. The code for this functionality is in  `src/ansi-c/ansi_c_language.cpp`.  This analysis is done on the AST and not in the goto-binary because it is much cleaner to extract the condition in the preconditions from the AST (as in the goto-binary function calls are flattened, and some transformations happen so it becomes difficult to reconstruct the conditions). It is assumed that calls to `__CPROVER_precondition` are in the beginning of the function body and consecutive.
