### PR TITLE
Fix snapshot harness source location initialisation

### DIFF
--- a/regression/snapshot-harness/simple-source-location/main.c
+++ b/regression/snapshot-harness/simple-source-location/main.c
@@ -1,0 +1,31 @@
+#include <assert.h>
+
+int global_var;
+
+void initialize()
+{
+  global_var = 1;
+}
+
+void checkpoint()
+{
+}
+
+int foo()
+{
+  initialize();
+  checkpoint();
+
+  assert(global_var == 0);
+  //line to be used for init (20)
+  assert(global_var == 0);
+
+  return 0;
+}
+
+int main()
+{
+  foo();
+
+  return 0;
+}

--- a/regression/snapshot-harness/simple-source-location/test.desc
+++ b/regression/snapshot-harness/simple-source-location/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+global_var --harness-type initialise-with-memory-snapshot --initial-source-location main.c:20
+^EXIT=10$
+^SIGNAL=0$
+^\[foo.assertion.1\] line [0-9]+ assertion global_var == 0: SUCCESS$
+^\[foo.assertion.2\] line [0-9]+ assertion global_var == 0: FAILURE$
+VERIFICATION FAILED
+--
+^warning: ignoring
+--
+The first assertion is succeeding because unreachable.

--- a/regression/snapshot-harness/structs_02/main.c
+++ b/regression/snapshot-harness/structs_02/main.c
@@ -1,0 +1,41 @@
+#include <assert.h>
+
+struct S
+{
+  int c1;
+  int c2;
+} st;
+
+int *p;
+
+void initialize()
+{
+  st.c1 = 1;
+  st.c2 = 3;
+  p = &(st.c2);
+}
+
+void checkpoint()
+{
+}
+
+int foo()
+{
+  initialize();
+  checkpoint();
+
+  assert(st.c1 + 2 == st.c2);
+  assert(st.c1 + 2 == *p);
+  assert(*p == st.c2);
+  *p = st.c2 + 1;
+  assert(*p == st.c2);
+
+  return 0;
+}
+
+int main()
+{
+  foo();
+
+  return 0;
+}

--- a/regression/snapshot-harness/structs_02/test.desc
+++ b/regression/snapshot-harness/structs_02/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+st,p --harness-type initialise-with-memory-snapshot --initial-source-location main.c:27
+^EXIT=0$
+^SIGNAL=0$
+\[foo.assertion.1\] line [0-9]+ assertion st.c1 \+ 2 == st.c2: SUCCESS
+\[foo.assertion.2\] line [0-9]+ assertion st.c1 \+ 2 == \*p: SUCCESS
+\[foo.assertion.3\] line [0-9]+ assertion \*p == st.c2: SUCCESS
+\[foo.assertion.4\] line [0-9]+ assertion \*p == st.c2: SUCCESS
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/src/goto-harness/memory_snapshot_harness_generator.h
+++ b/src/goto-harness/memory_snapshot_harness_generator.h
@@ -97,8 +97,10 @@ protected:
     /// Returns the first \ref goto_programt::instructiont represented by this
     ///   source location, i.e. one with the same file name and line number
     /// \param instructions: list of instructions to be searched
-    /// \return iterator to the right instruction (or `end()`)
-    goto_programt::const_targett find_first_corresponding_instruction(
+    /// \return <iterator to the right instruction (or `end()`), distance to
+    ///   `line_number`>
+    std::pair<goto_programt::const_targett, size_t>
+    find_first_corresponding_instruction(
       const goto_programt::instructionst &instructions) const;
   };
 
@@ -121,6 +123,35 @@ protected:
       goto_programt::const_targett start_instruction)
       : function_name(function_name), start_instruction(start_instruction)
     {
+    }
+  };
+
+  /// Wraps the information for source location match candidates. Keeps track of
+  /// the distance between user specified source code line and goto-program
+  /// instruction line.
+  struct source_location_matcht
+  {
+    size_t distance;
+    irep_idt function_name;
+    goto_programt::const_targett instruction;
+    bool match_found;
+
+    source_location_matcht() : distance(0), match_found(false)
+    {
+    }
+
+    void match_up(
+      const size_t &candidate_distance,
+      const irep_idt &candidate_function_name,
+      const goto_programt::const_targett &candidate_instruction)
+    {
+      if(match_found && distance <= candidate_distance)
+        return;
+
+      match_found = true;
+      distance = candidate_distance;
+      function_name = candidate_function_name;
+      instruction = candidate_instruction;
     }
   };
 


### PR DESCRIPTION
Before we simply took the first instruction with the line number geq to the one
specified. Now we go through all instructions and take the one closest.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
