### PR TITLE
Patch goto-analyzer reachable-functions json and xml output.

### DIFF
--- a/src/goto-analyzer/unreachable_instructions.cpp
+++ b/src/goto-analyzer/unreachable_instructions.cpp
@@ -249,14 +249,21 @@ static void json_output_function(
   const source_locationt &last_location,
   json_arrayt &dest)
 {
+  // source locations occassionally omit line numbers
+  // an empty string makes json unparsable
+  std::string first_line = id2string(first_location.get_line());
+  std::string last_line = id2string(last_location.get_line());
+  first_line = first_line.empty() ? "0" : first_line;
+  last_line = last_line.empty() ? "0" : last_line;
+
   json_objectt entry{
     {"function", json_stringt(function)},
     {"file name",
      json_stringt(concat_dir_file(
        id2string(first_location.get_working_directory()),
        id2string(first_location.get_file())))},
-    {"first line", json_numbert(id2string(first_location.get_line()))},
-    {"last line", json_numbert(id2string(last_location.get_line()))}};
+    {"first line", json_numbert(first_line)},
+    {"last line", json_numbert(last_line)}};
 
   dest.push_back(std::move(entry));
 }
@@ -269,13 +276,20 @@ static void xml_output_function(
 {
   xmlt &x=dest.new_element("function");
 
+  // source locations occassionally omit line numbers
+  // an empty string makes xml unparsable
+  std::string first_line = id2string(first_location.get_line());
+  std::string last_line = id2string(last_location.get_line());
+  first_line = first_line.empty() ? "0" : first_line;
+  last_line = last_line.empty() ? "0" : last_line;
+
   x.set_attribute("name", id2string(function));
   x.set_attribute("file name",
                   concat_dir_file(
                     id2string(first_location.get_working_directory()),
                     id2string(first_location.get_file())));
-  x.set_attribute("first line", id2string(first_location.get_line()));
-  x.set_attribute("last line", id2string(last_location.get_line()));
+  x.set_attribute("first line", first_line);
+  x.set_attribute("last line", last_line);
 }
 
 static void list_functions(

--- a/src/goto-analyzer/unreachable_instructions.cpp
+++ b/src/goto-analyzer/unreachable_instructions.cpp
@@ -256,14 +256,13 @@ static void json_output_function(
   first_line = first_line.empty() ? "0" : first_line;
   last_line = last_line.empty() ? "0" : last_line;
 
-  json_objectt entry{
-    {"function", json_stringt(function)},
-    {"file name",
-     json_stringt(concat_dir_file(
-       id2string(first_location.get_working_directory()),
-       id2string(first_location.get_file())))},
-    {"first line", json_numbert(first_line)},
-    {"last line", json_numbert(last_line)}};
+  json_objectt entry{{"function", json_stringt(function)},
+                     {"file name",
+                      json_stringt(concat_dir_file(
+                        id2string(first_location.get_working_directory()),
+                        id2string(first_location.get_file())))},
+                     {"first line", json_numbert(first_line)},
+                     {"last line", json_numbert(last_line)}};
 
   dest.push_back(std::move(entry));
 }


### PR DESCRIPTION
Source locations occassionally omit a line number, and printing
an empty string in the json and xml output renders the output
unparsable.  This patch uses "0" in place of the empty string
in the output.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ x] Each commit message has a non-empty body, explaining why the change was made.
- [ x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ x] My PR is restricted to a single feature or bugfix.
- [ x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
