### PR TITLE
Take into account no existing .gdbinit file

### DIFF
--- a/scripts/pretty-printers/gdb/install.py
+++ b/scripts/pretty-printers/gdb/install.py
@@ -30,33 +30,33 @@ def create_gdbinit_file():
 
     gdbinit_file = os.path.join(home_folder, ".gdbinit")
     lines = []
+    imports = { "os", "sys" }
     if os.path.exists(gdbinit_file):
         with open(gdbinit_file, 'r') as file:
             lines = [ line.rstrip() for line in file ]
-    line_no = 0
-    imports = { "os", "sys" }
-    while line_no < len(lines):
-        if lines[line_no].startswith('import '):
-            imports.add(lines[line_no][len("import "):].strip())
-            lines.pop(line_no)
-        else:
-            if lines[line_no].startswith(code_block_start):
-                print(".gdbinit already contains our pretty printers, not changing it")
+        line_no = 0
+        while line_no < len(lines):
+            if lines[line_no].startswith('import '):
+                imports.add(lines[line_no][len("import "):].strip())
+                lines.pop(line_no)
+            else:
+                if lines[line_no].startswith(code_block_start):
+                    print(".gdbinit already contains our pretty printers, not changing it")
+                    return
+                line_no += 1
+        while len(lines) != 0 and (lines[0] == "" or lines[0] == "python"):
+            lines.pop(0)
+
+        backup_file = os.path.join(home_folder, "backup.gdbinit")
+        if os.path.exists(backup_file):
+            print("backup.gdbinit file already exists. Type 'y' if you would like to overwrite it or any other key to exit.")
+            choice = input().lower()
+            if choice != 'y':
                 return
-            line_no += 1
-    while len(lines) != 0 and (lines[0] == "" or lines[0] == "python"):
-        lines.pop(0)
+        print("Backing up {0}".format(gdbinit_file))
+        copyfile(gdbinit_file, backup_file)
 
     lines = [ "python" ] + list(map("import {}".format, sorted(imports))) + [ "", "" ] + code_block + [ "", "" ] + lines + [ "" ]
-
-    backup_file = os.path.join(home_folder, "backup.gdbinit")
-    if os.path.exists(backup_file):
-        print("backup.gdbinit file already exists. Type 'y' if you would like to overwrite it or any other key to exit.")
-        choice = input().lower()
-        if choice != 'y':
-            return
-    print("Backing up {0}".format(gdbinit_file))
-    copyfile(gdbinit_file, backup_file)
     print("Adding pretty-print commands to {0}.".format(gdbinit_file))
     try:
         with open(gdbinit_file, 'w+') as file:


### PR DESCRIPTION
Allows there to be no .gbdinit file to begin with when doing first set-up.

The only functional change is wrapping everything to do with a .gdbinit file already existing inside the condition that asserts that's true, and the one statement that should be run regardless outside of it.   

Hide whitespace to see the actual changes.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
