### PR TITLE
Simplify and apply field sensitivity before value-set-deref

### DIFF
--- a/regression/cbmc/double_deref/double_deref_with_member.desc
+++ b/regression/cbmc/double_deref/double_deref_with_member.desc
@@ -1,10 +1,10 @@
 CORE
 double_deref_with_member.c
 --show-vcc
-^\{-[0-9]+\} derefd_pointer::derefd_pointer!0#1 = \(main::1::cptr!0@1#2 = address_of\(main::1::container[12]!0@1\) \? address_of\(symex_dynamic::dynamic_object[12]\) : address_of\(symex_dynamic::dynamic_object[12]\)\)
-^\{1\} \(derefd_pointer::derefd_pointer!0#1 = address_of\(symex_dynamic::dynamic_object[12]\) \? main::argc!0@1#1 = 2 : main::argc!0@1#1 = 1\)
+^\{1\} \(main::1::cptr!0@1#2 = address_of\(main::1::container2!0@1\) \? main::argc!0@1#1 = 2 : main::argc!0@1#1 = 1\)
 ^EXIT=0$
 ^SIGNAL=0$
 --
+derefd_pointer
 --
 See README for details about these tests


### PR DESCRIPTION
This means that any member-of-symbol constructs introduced by a nested dereference,
such as `x->y ==> (x == &o1 ? o1 : o2).y`, can be simplified to produce e.g.
`(x == &o1 ? o1.y : o2.y) ==> (x == &o1 ? o1..y : o2..y)`. value_set_dereferencet will
then special-case the if-expression, dereferencing the inner `o1..y` and `o2..y` individually.
In the best case where each has a single possible alias, `&o3` and `&o4` respectively, we
end up with `(x == &o1 ? &o3 : &o4)`, rather than the current result:
`let p = (x == &o1 ? o1 : o2).y in (p == &o3 ? o3 : o4)`.

The net benefit: smaller expressions, and thanks to simpler expressions a higher chance that future simplification will succeed.