### PR TITLE
fix exprt::opX accesses in goto-symex

### DIFF
--- a/src/goto-symex/expr_skeleton.cpp
+++ b/src/goto-symex/expr_skeleton.cpp
@@ -21,7 +21,7 @@ expr_skeletont expr_skeletont::remove_op0(exprt e)
 {
   PRECONDITION(e.id() != ID_symbol);
   PRECONDITION(e.operands().size() >= 1);
-  e.op0().make_nil();
+  to_multi_ary_expr(e).op0().make_nil();
   return expr_skeletont{std::move(e)};
 }
 
@@ -39,7 +39,7 @@ exprt expr_skeletont::apply(exprt expr) const
     INVARIANT(
       p->operands().size() >= 1,
       "expected pointed-to expression to have at least one operand");
-    p = &p->op0();
+    p = &to_multi_ary_expr(*p).op0();
   }
 
   INVARIANT(p->is_nil(), "expected pointed-to expression to be nil");

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -60,11 +60,15 @@ void goto_symext::apply_goto_condition(
   // Could use not_exprt + simplify, but let's avoid paying that cost on quite
   // a hot path:
   if(new_guard.id() == ID_not)
-    jump_not_taken_state.apply_condition(new_guard.op0(), current_state, ns);
+    jump_not_taken_state.apply_condition(
+      to_not_expr(new_guard).op(), current_state, ns);
   else if(new_guard.id() == ID_notequal)
   {
+    auto &not_equal_expr = to_notequal_expr(new_guard);
     jump_not_taken_state.apply_condition(
-      equal_exprt(new_guard.op0(), new_guard.op1()), current_state, ns);
+      equal_exprt(not_equal_expr.lhs(), not_equal_expr.rhs()),
+      current_state,
+      ns);
   }
 }
 
@@ -180,10 +184,10 @@ static optionalt<renamedt<exprt, L2>> try_evaluate_pointer_comparison(
   if(expr.id() != ID_equal && expr.id() != ID_notequal)
     return {};
 
-  if(!can_cast_type<pointer_typet>(expr.op0().type()))
+  if(!can_cast_type<pointer_typet>(to_binary_expr(expr).op0().type()))
     return {};
 
-  exprt lhs = expr.op0(), rhs = expr.op1();
+  exprt lhs = to_binary_expr(expr).op0(), rhs = to_binary_expr(expr).op1();
   if(can_cast_expr<symbol_exprt>(rhs))
     std::swap(lhs, rhs);
 


### PR DESCRIPTION
This improves type safety.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
