### PR TITLE
fix exprt::opX accesses in analyses

### DIFF
--- a/src/analyses/custom_bitvector_analysis.cpp
+++ b/src/analyses/custom_bitvector_analysis.cpp
@@ -704,10 +704,10 @@ exprt custom_bitvector_domaint::eval(
   {
     if(src.operands().size()==2)
     {
-      unsigned bit_nr=
-        custom_bitvector_analysis.get_bit_nr(src.op1());
+      unsigned bit_nr =
+        custom_bitvector_analysis.get_bit_nr(to_binary_expr(src).op1());
 
-      exprt pointer=src.op0();
+      exprt pointer = to_binary_expr(src).op0();
 
       if(pointer.type().id()!=ID_pointer)
         return src;

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -790,7 +790,7 @@ void goto_checkt::integer_overflow_check(
       exprt tmp;
 
       if(i==1)
-        tmp=expr.op0();
+        tmp = to_multi_ary_expr(expr).op0();
       else
       {
         tmp=expr;
@@ -1732,7 +1732,8 @@ optionalt<exprt> goto_checkt::rw_ok_check(exprt expr)
     DATA_INVARIANT(
       expr.operands().size() == 2, "r/w_ok must have two operands");
 
-    const auto conditions = address_check(expr.op0(), expr.op1());
+    const auto conditions =
+      address_check(to_binary_expr(expr).op0(), to_binary_expr(expr).op1());
 
     exprt::operandst conjuncts;
 
@@ -1964,7 +1965,7 @@ void goto_checkt::goto_check(
       {
         // must not throw NULL
 
-        exprt pointer=i.code.op0().op0();
+        exprt pointer = to_unary_expr(i.code.op0()).op();
 
         const notequal_exprt not_eq_null(
           pointer, null_pointer_exprt(to_pointer_type(pointer.type())));

--- a/src/analyses/local_bitvector_analysis.cpp
+++ b/src/analyses/local_bitvector_analysis.cpp
@@ -176,23 +176,26 @@ local_bitvector_analysist::flagst local_bitvector_analysist::get_rec(
   }
   else if(rhs.id()==ID_plus)
   {
-    if(rhs.operands().size()>=3)
+    const auto &plus_expr = to_plus_expr(rhs);
+
+    if(plus_expr.operands().size() >= 3)
     {
-      assert(rhs.op0().type().id()==ID_pointer);
-      return get_rec(rhs.op0(), loc_info_src) |
-             flagst::mk_uses_offset();
+      DATA_INVARIANT(
+        plus_expr.op0().type().id() == ID_pointer,
+        "pointer in pointer-typed sum must be op0");
+      return get_rec(plus_expr.op0(), loc_info_src) | flagst::mk_uses_offset();
     }
-    else if(rhs.operands().size()==2)
+    else if(plus_expr.operands().size() == 2)
     {
       // one must be pointer, one an integer
-      if(rhs.op0().type().id()==ID_pointer)
+      if(plus_expr.op0().type().id() == ID_pointer)
       {
-        return get_rec(rhs.op0(), loc_info_src) |
+        return get_rec(plus_expr.op0(), loc_info_src) |
                flagst::mk_uses_offset();
       }
-      else if(rhs.op1().type().id()==ID_pointer)
+      else if(plus_expr.op1().type().id() == ID_pointer)
       {
-        return get_rec(rhs.op1(), loc_info_src) |
+        return get_rec(plus_expr.op1(), loc_info_src) |
                flagst::mk_uses_offset();
       }
       else
@@ -203,10 +206,11 @@ local_bitvector_analysist::flagst local_bitvector_analysist::get_rec(
   }
   else if(rhs.id()==ID_minus)
   {
-    if(rhs.op0().type().id()==ID_pointer)
+    const auto &op0 = to_minus_expr(rhs).op0();
+
+    if(op0.type().id() == ID_pointer)
     {
-      return get_rec(rhs.op0(), loc_info_src) |
-             flagst::mk_uses_offset();
+      return get_rec(op0, loc_info_src) | flagst::mk_uses_offset();
     }
     else
       return flagst::mk_unknown();

--- a/src/analyses/local_may_alias.cpp
+++ b/src/analyses/local_may_alias.cpp
@@ -278,7 +278,7 @@ void local_may_aliast::get_rec(
   }
   else if(rhs.id()==ID_minus)
   {
-    const auto &op0 = to_minus_expr(rhs);
+    const auto &op0 = to_minus_expr(rhs).op0();
 
     if(op0.type().id() == ID_pointer)
     {

--- a/src/analyses/local_may_alias.cpp
+++ b/src/analyses/local_may_alias.cpp
@@ -250,21 +250,25 @@ void local_may_aliast::get_rec(
   }
   else if(rhs.id()==ID_plus)
   {
-    if(rhs.operands().size()>=3)
+    const auto &plus_expr = to_plus_expr(rhs);
+
+    if(plus_expr.operands().size() >= 3)
     {
-      assert(rhs.op0().type().id()==ID_pointer);
-      get_rec(dest, rhs.op0(), loc_info_src);
+      DATA_INVARIANT(
+        plus_expr.op0().type().id() == ID_pointer,
+        "pointer in pointer-typed sum must be op0");
+      get_rec(dest, plus_expr.op0(), loc_info_src);
     }
-    else if(rhs.operands().size()==2)
+    else if(plus_expr.operands().size() == 2)
     {
       // one must be pointer, one an integer
-      if(rhs.op0().type().id()==ID_pointer)
+      if(plus_expr.op0().type().id() == ID_pointer)
       {
-        get_rec(dest, rhs.op0(), loc_info_src);
+        get_rec(dest, plus_expr.op0(), loc_info_src);
       }
-      else if(rhs.op1().type().id()==ID_pointer)
+      else if(plus_expr.op1().type().id() == ID_pointer)
       {
-        get_rec(dest, rhs.op1(), loc_info_src);
+        get_rec(dest, plus_expr.op1(), loc_info_src);
       }
       else
         dest.insert(unknown_object);
@@ -274,9 +278,11 @@ void local_may_aliast::get_rec(
   }
   else if(rhs.id()==ID_minus)
   {
-    if(rhs.op0().type().id()==ID_pointer)
+    const auto &op0 = to_minus_expr(rhs);
+
+    if(op0.type().id() == ID_pointer)
     {
-      get_rec(dest, rhs.op0(), loc_info_src);
+      get_rec(dest, op0, loc_info_src);
     }
     else
       dest.insert(unknown_object);

--- a/src/analyses/local_safe_pointers.cpp
+++ b/src/analyses/local_safe_pointers.cpp
@@ -43,7 +43,7 @@ static optionalt<goto_null_checkt> get_null_checked_expr(const exprt &expr)
   // Reduce some roundabout ways of saying "x != null", e.g. "!(x == null)".
   while(normalized_expr.id() == ID_not)
   {
-    normalized_expr = normalized_expr.op0();
+    normalized_expr = to_not_expr(normalized_expr).op();
     checked_when_taken = !checked_when_taken;
   }
 
@@ -55,8 +55,8 @@ static optionalt<goto_null_checkt> get_null_checked_expr(const exprt &expr)
 
   if(normalized_expr.id() == ID_notequal)
   {
-    const exprt &op0 = skip_typecast(normalized_expr.op0());
-    const exprt &op1 = skip_typecast(normalized_expr.op1());
+    const exprt &op0 = skip_typecast(to_notequal_expr(normalized_expr).op0());
+    const exprt &op1 = skip_typecast(to_notequal_expr(normalized_expr).op1());
 
     if(op0.type().id() == ID_pointer &&
        op0 == null_pointer_exprt(to_pointer_type(op0.type())))

--- a/src/analyses/static_analysis.cpp
+++ b/src/analyses/static_analysis.cpp
@@ -370,7 +370,7 @@ void static_analysis_baset::do_function_call_rec(
       calling_function,
       l_call,
       l_return,
-      function.op1(),
+      to_if_expr(function).true_case(),
       arguments,
       new_state,
       goto_functions);
@@ -379,7 +379,7 @@ void static_analysis_baset::do_function_call_rec(
       calling_function,
       l_call,
       l_return,
-      function.op2(),
+      to_if_expr(function).false_case(),
       arguments,
       *n2,
       goto_functions);

--- a/src/analyses/uncaught_exceptions_analysis.cpp
+++ b/src/analyses/uncaught_exceptions_analysis.cpp
@@ -28,8 +28,8 @@ irep_idt uncaught_exceptions_domaint::get_exception_type(const typet &type)
 /// Returns the symbol corresponding to an exception
 exprt uncaught_exceptions_domaint::get_exception_symbol(const exprt &expr)
 {
-  if(expr.id()!=ID_symbol && expr.has_operands())
-    return get_exception_symbol(expr.op0());
+  if(expr.id() != ID_symbol && expr.operands().size() >= 1)
+    return get_exception_symbol(to_multi_ary_expr(expr).op0());
 
   return expr;
 }


### PR DESCRIPTION
This improves type safety.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
