### PR TITLE
Symex trace: show implicit value associated with composite declarations

### DIFF
--- a/regression/cbmc/field-sensitivity-trace-wrong-counterexample-1/test.c
+++ b/regression/cbmc/field-sensitivity-trace-wrong-counterexample-1/test.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+struct SomeStruct
+{
+  int x;
+};
+
+int main(void)
+{
+  struct SomeStruct x;
+  // this should cause
+  // visible initialization of
+  // x to value other than 0
+  // if assertion fails
+  assert(x.x == 0);
+}

--- a/regression/cbmc/field-sensitivity-trace-wrong-counterexample-1/test.desc
+++ b/regression/cbmc/field-sensitivity-trace-wrong-counterexample-1/test.desc
@@ -1,0 +1,13 @@
+CORE
+test.c
+--trace
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+x=\{ \.x=0 \}
+^warning: ignoring
+--
+This tests for the counterexample shown in the trace having sensible values.
+In this case, we are asserting that x.x == 0, so x.x should have a value other
+than 0 if the assertion fails.

--- a/src/goto-symex/symex_decl.cpp
+++ b/src/goto-symex/symex_decl.cpp
@@ -54,10 +54,10 @@ void goto_symext::symex_decl(statet &state, const symbol_exprt &expr)
   target.decl(
     state.guard.as_expr(),
     ssa,
+    state.field_sensitivity.apply(ns, state, ssa, false),
     state.source,
-    hidden?
-      symex_targett::assignment_typet::HIDDEN:
-      symex_targett::assignment_typet::STATE);
+    hidden ? symex_targett::assignment_typet::HIDDEN
+           : symex_targett::assignment_typet::STATE);
 
   if(path_storage.dirty(ssa.get_object_name()) && state.atomic_section_id == 0)
     target.shared_write(

--- a/src/goto-symex/symex_target.h
+++ b/src/goto-symex/symex_target.h
@@ -127,6 +127,7 @@ public:
   /// Declare a fresh variable. The `cond_expr` is _lhs==lhs_.
   /// \param guard: Precondition for a declaration of this variable
   /// \param ssa_lhs: Variable to be declared, must be symbol (and not nil)
+  /// \param initializer: Initial value
   /// \param source: Pointer to location in the input GOTO program of this
   ///  declaration
   /// \param assignment_type: To distinguish between different types of
@@ -134,8 +135,9 @@ public:
   virtual void decl(
     const exprt &guard,
     const ssa_exprt &ssa_lhs,
+    const exprt &initializer,
     const sourcet &source,
-    assignment_typet assignment_type)=0;
+    assignment_typet assignment_type) = 0;
 
   /// Remove a variable from the scope.
   /// \param guard: Precondition for removal of this variable

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -128,6 +128,7 @@ void symex_target_equationt::assignment(
 void symex_target_equationt::decl(
   const exprt &guard,
   const ssa_exprt &ssa_lhs,
+  const exprt &initializer,
   const sourcet &source,
   assignment_typet assignment_type)
 {
@@ -138,7 +139,7 @@ void symex_target_equationt::decl(
 
   SSA_step.guard=guard;
   SSA_step.ssa_lhs=ssa_lhs;
-  SSA_step.ssa_full_lhs=ssa_lhs;
+  SSA_step.ssa_full_lhs = initializer;
   SSA_step.original_full_lhs=ssa_lhs.get_original_expr();
   SSA_step.hidden=(assignment_type!=assignment_typet::STATE);
 

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -73,6 +73,7 @@ public:
   virtual void decl(
     const exprt &guard,
     const ssa_exprt &ssa_lhs,
+    const exprt &initializer,
     const sourcet &source,
     assignment_typet assignment_type);
 


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

Previously when a struct- or other composite-typed variable was declared, symex_decl
would initialize its individual fields, then return an L2-renamed symbol relating to
the whole object. With field-sensitivity enabled, the returned symbol is e.g. my_struct!0@1#0,
while anybody reading from it will read my_struct!0@1#1..field, a different symbol which
to the solver is unrelated. The result was that in the trace, the declaration would show
up with the value of the free symbol my_struct!0@1#0 (most likely zero, since it can't be
referred to), while the rest of the trace may make it obvious that it actually had some other
non-zero value.

With this change we expand the struct into its constituent field symbols before recording an
SSA_stept for the trace. This restores the correspondence between what the trace reads and what
code reading from the struct reads.

Argument for the reviewers to have: should the goto_symex_statet::rename in symex_decl already be expanding like this? That function has an invariant insisting that it should return a single symbol, not a struct-exprt of field symbols, but that may not really be necessary. Note that if we change ::rename to always perform struct expansion then we will probably break any user that is applying this to an lvalue.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
