### PR TITLE
Stop unneccessary copy of lbva location info

### DIFF
--- a/src/analyses/local_bitvector_analysis.cpp
+++ b/src/analyses/local_bitvector_analysis.cpp
@@ -264,7 +264,7 @@ void local_bitvector_analysist::build()
     work_queue.pop();
 
     auto &loc_info_src=loc_infos[loc_nr];
-    auto loc_info_dest=loc_infos[loc_nr];
+    auto loc_info_dest=points_tot();
 
     switch(instruction.type)
     {


### PR DESCRIPTION
This now holds only the changes, so will look like this:

Changes array: [0,0,0,x,0,y]
Original array: [a,b,c,d,e,f]

Where previously it would've been a direct copy we now just have a zero in any place that has no changes, so when it merges instead of b | b, it's b | 0. In a changed scenario nothing it does the same thing.

Saw an instance where the location info was big enough that the local bit vector analysis was taking minutes to do due to the copies. 

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.