### PR TITLE
Do not generate initializations for struct padding in goto-harness

### DIFF
--- a/src/goto-harness/recursive_initialization.cpp
+++ b/src/goto-harness/recursive_initialization.cpp
@@ -155,7 +155,10 @@ void recursive_initializationt::initialize_struct_tag(
   auto const &ns = namespacet{goto_model.symbol_table};
   for(auto const &component : ns.follow_tag(type).components())
   {
-    initialize(member_exprt{lhs, component}, depth, new_known_tags, body);
+    if(!component.get_is_padding())
+    {
+      initialize(member_exprt{lhs, component}, depth, new_known_tags, body);
+    }
   }
 }
 


### PR DESCRIPTION
Previously the generated code for struct fields included assignments to
struct padding. This is not necessary, makes the generated code harder
to read and makes --dump-c generated code based on it not compile, so we
shouldn't do this.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
