### PR TITLE
goto-symex must not lift lets with bound variables

### DIFF
--- a/regression/cbmc/Quantifiers-expr-cleaning/main.c
+++ b/regression/cbmc/Quantifiers-expr-cleaning/main.c
@@ -1,0 +1,20 @@
+int main()
+{
+  unsigned x, y;
+
+  // assume x and y are zero, but make sure this can't be constant propagated
+  __CPROVER_assume(x < 1);
+  __CPROVER_assume(y < 1);
+
+  // make value sets produce a derefd_pointer object for ((const char*)p)[i]
+  // below
+  _Bool nondet;
+  int *p = nondet ? &x : &y;
+
+  // clang-format off
+  __CPROVER_assert(
+    __CPROVER_forall{
+      unsigned i; i < sizeof(unsigned) ==> ((const char*)p)[i] == 0},
+    "");
+  // clang-format on
+}

--- a/regression/cbmc/Quantifiers-expr-cleaning/test.desc
+++ b/regression/cbmc/Quantifiers-expr-cleaning/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -214,6 +214,12 @@ void goto_symext::lift_lets(statet &state, exprt &rhs)
 
       it.next_sibling_or_parent();
     }
+    else if(it->id() == ID_exists || it->id() == ID_forall)
+    {
+      // expressions within exists/forall may depend on bound variables, we
+      // cannot safely lift let expressions out of those, just skip
+      it.next_sibling_or_parent();
+    }
     else
       ++it;
   }

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -192,6 +192,7 @@ void goto_symext::rewrite_quantifiers(exprt &expr, statet &state)
     symbol_exprt tmp0 =
       to_symbol_expr(to_ssa_expr(quant_expr.symbol()).get_original_expr());
     symex_decl(state, tmp0);
+    instruction_local_symbols.push_back(tmp0);
     exprt tmp = quant_expr.where();
     rewrite_quantifiers(tmp, state);
     quant_expr.swap(tmp);


### PR DESCRIPTION
Lifting lets may add equations to the formula, which would then use
symbols before they had been declared. Thus do not lift lets occurring
within exits/forall expressions.

While at it, also make sure declarations introduced by resolved
quantifiers yield a corresponding "dead" statement to be symbolically
executed.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
