### PR TITLE
Fix catch stringification of ireps in failure messages

### DIFF
--- a/unit/testing-utils/use_catch.h
+++ b/unit/testing-utils/use_catch.h
@@ -1,6 +1,7 @@
 /*******************************************************************\
 
 Module: Wrapper around CATCH to disable selected compiler warnings
+        and add pretty printing for failure messages involving ireps.
 
 Author: Michael Tautschnig
 
@@ -27,6 +28,52 @@ Author: Michael Tautschnig
 #pragma warning(disable : 4365)
 // signed/unsigned mismatch
 #endif
+
+#include <string>
+#include <type_traits>
+#include <util/irep.h>
+
+/// Returns true if `potential_irept` is an `irept`.
+template <typename potential_irept>
+constexpr bool is_irep()
+{
+  return std::is_convertible<potential_irept, irept>::value;
+}
+
+/// Default case for stringify fallback printing.
+template <typename unknownt, typename = void>
+struct catch_fallback_stringifyt
+{
+  template <typename anyt>
+  std::string operator()(anyt &&any)
+  {
+    return "{?}";
+  }
+};
+
+/// Stringify fallback printing specialization for irept.
+template <typename potentially_an_irept>
+struct catch_fallback_stringifyt<
+  potentially_an_irept,
+  typename std::enable_if<is_irep<potentially_an_irept>()>::type>
+{
+  template <typename any_irept>
+  std::string operator()(any_irept &&any_irep)
+  {
+    return any_irep.pretty(0, 0);
+  }
+};
+
+template <typename unknownt>
+std::string catch_fallback_stringify(unknownt &&unknown)
+{
+  return catch_fallback_stringifyt<typename std::decay<unknownt>::type>{}(
+    std::forward<unknownt>(unknown));
+}
+
+// Replace catch's original stringify fallback with a custom version which
+// pretty prints ireps.
+#define CATCH_CONFIG_FALLBACK_STRINGIFIER(x) catch_fallback_stringify(x);
 
 #define INCLUDED_VIA_USE_CATCH_H
 

--- a/unit/unit_tests.cpp
+++ b/unit/unit_tests.cpp
@@ -8,11 +8,3 @@ Author: Diffblue Ltd.
 
 #define CATCH_CONFIG_MAIN
 #include <testing-utils/use_catch.h>
-#include <util/irep.h>
-
-// Debug printer for irept
-std::ostream &operator<<(std::ostream &os, const irept &value)
-{
-  os << value.pretty();
-  return os;
-}


### PR DESCRIPTION
The existing debug printing of ireps in `unit_tests.cpp` was not being
called by catch for some reason. This pr adds a more thorough
implementation of the pretty printing configuration/specializtion in
`use_catch.h` instead. This implementation works for any type which can
be converted to `irept`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
