### PR TITLE
Make prefix filter operator const [TG-8603]

### DIFF
--- a/src/util/prefix_filter.cpp
+++ b/src/util/prefix_filter.cpp
@@ -23,7 +23,7 @@ prefix_filtert::prefix_filtert(
 {
 }
 
-bool prefix_filtert::operator()(const std::string &value)
+bool prefix_filtert::operator()(const std::string &value) const
 {
   if(!included_prefixes.empty())
   {

--- a/src/util/prefix_filter.h
+++ b/src/util/prefix_filter.h
@@ -27,7 +27,7 @@ public:
   /// but doesn't match a prefix in `excluded_prefixes`.
   /// An empty vector of `included_prefixes` is treated as 'match all'.
   /// An empty vector of `excluded_prefixes` is treated as 'match nothing'.
-  bool operator()(const std::string &value);
+  bool operator()(const std::string &value) const;
 
 protected:
   std::vector<std::string> included_prefixes;


### PR DESCRIPTION

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
