### PR TITLE
[TG-8996] Avoid redundant expressions when dereferencing

### DIFF
--- a/regression/cbmc/double_deref/double_deref_with_pointer_arithmetic_single_alias.desc
+++ b/regression/cbmc/double_deref/double_deref_with_pointer_arithmetic_single_alias.desc
@@ -1,7 +1,7 @@
 CORE
 double_deref_with_pointer_arithmetic_single_alias.c
 --show-vcc
-\{1\} \(derefd_pointer::derefd_pointer!0#1 = address_of\(symex_dynamic::dynamic_object2\) \? main::argc!0@1#1 = 1 : symex::invalid_object!0#0 = main::argc!0@1#1\)
+\{1\} \(symex_dynamic::dynamic_object1#2\[cast\(mod #source_location=""\(main::argc!0@1#1, 2\), signedbv\[64\]\)\] = address_of\(symex_dynamic::dynamic_object2\) \? main::argc!0@1#1 = 1 : symex::invalid_object!0#0 = main::argc!0@1#1\)
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/pointer-analysis/value_set_dereference.h
+++ b/src/pointer-analysis/value_set_dereference.h
@@ -68,6 +68,31 @@ public:
     }
   };
 
+  /// Descriptor for the possible values to may be reached by dereferencing
+  /// a pointer
+  struct value_set_resultt
+  {
+    /// Pointer expression that produced this value-set
+    exprt pointer;
+    /// Set of values that may result from dereferencing pointer_expr
+    std::vector<valuet> values;
+    /// Can dereferencing pointer_expr fail (for example, could it be null,
+    /// or could it point to unallocated memory)?
+    bool may_fail;
+  };
+
+  /// Mapping from a placeholder symbol to a value-set. These are created by
+  /// gather_value_sets, which replaces expressions to be dereferenced with
+  /// placeholder symbols and records the corresponding value set an instance
+  /// of this struct.
+  struct value_set_mappingt
+  {
+    /// Placeholder symbol corresponding to this value-set
+    symbol_exprt placeholder;
+    /// Value-set
+    value_set_resultt values;
+  };
+
   static bool should_ignore_value(
     const exprt &what,
     bool exclude_null_derefs,
@@ -105,6 +130,34 @@ private:
   /// Flag indicating whether `value_set_dereferencet::dereference` should
   /// disregard an apparent attempt to dereference NULL
   const bool exclude_null_derefs;
+
+  /// Find the subexpressions of \p pointer that can be independently
+  /// dereferenced, replace each one with a placeholder symbol, and accumulate
+  /// the mapping from placeholders to value-sets in \p value_set_accumulator.
+  /// For example, if \p pointer was 'x ? y : z' then we might independently
+  /// dereference 'y' and 'z' and return `x ? placeholder1 : placeholder2`, with
+  /// value_set_accumulator containing "placeholder1 -> y, {a, b}" and
+  /// "placeholder2 -> z, {c, d}", where y and z are the original pointers and
+  /// {a, b, c, d} possible objects the pointer subexpressions may point to.
+  /// Note in the simplest case this will just return "placeholder1" and
+  /// populate \p value_set_accumulator with a single entry.
+  exprt gather_value_sets(
+    const exprt &pointer,
+    std::vector<value_set_mappingt> &value_set_accumulator) const;
+
+  /// Find the objects that \p pointer may point to. The result is effectively a
+  /// tuple, <pointer, value-set, may-fail>, where may-fail indicates whether
+  /// pointer may point to anything other than an allocated object, such as an
+  /// integer cast to a pointer or a null pointer.
+  value_set_resultt get_value_set(const exprt &pointer) const;
+
+  /// Converts a value-set into a conditional expression -- for example, if the
+  /// input \p value_set has values {a, b, c} we might return
+  /// `(p == &a ? a : p == &b ? b : c)`, where `p` is the dereferenced pointer
+  /// given in `value_set.pointer`. If `value_set.may_fail` is set then the
+  /// result expression will contain a fall-back catch-all symbol, such as
+  /// `p == &o1 ? o1 : symex::invalid_object$1`
+  exprt value_set_to_conditional_expr(const value_set_resultt &value_set) const;
 };
 
 #endif // CPROVER_POINTER_ANALYSIS_VALUE_SET_DEREFERENCE_H


### PR DESCRIPTION
Our dereferencing code currently special-cases nested dereferences, allowing us to turn
`**x` directly into something like `(x == &o1 ? 1 : 2)` in the best case where 'x' has two
possible aliases, rather than going via an intermediary like `*(x == &o1 ? o1 : o2)`
==> `((x == &o1 ? o1 : o2) == &o3 ? 1 : 2)`.

However, this can lead to redundnacy when o1 and o2 have overlapping alias sets, such as
`(x == &o1 ? (o1 == &o3 ? o3 : o4) : (o2 == &o3 ? o3 : o4))`

In this case it is better to use a temporary:
```
derefd_pointer = x == &o1 ? o1 : o2
result = derefd_pointer == &o3 ? o3 : o4
```

This restructuring of `value_set_dereferencet::dereference` attempts to keep the best of both
worlds by dividing the algorithm into two stages: one which determines the alias sets that
would be created, using placeholder symbols to mark where they occur in the overall expression,
followed by a commit stage which decides whether to commit the tentative result or to combine
the alias sets and use an intermediate temporary symbol instead.

The result should be that when alias sets overlap we use an intermediate variable, but when they
are disjoint we apply the double-dereference in-place.