### PR TITLE
Disable test snapshot-harness/dynamic-array-int

### DIFF
--- a/regression/snapshot-harness/dynamic-array-int/test.desc
+++ b/regression/snapshot-harness/dynamic-array-int/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.c
 array,iterator1,iterator2,iterator3 --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
 ^EXIT=10$
@@ -14,3 +14,5 @@ array,iterator1,iterator2,iterator3 --harness-type initialise-with-memory-snapsh
 VERIFICATION FAILED
 --
 unwinding assertion loop \d+: FAILURE
+--
+Broken by https://github.com/diffblue/cbmc/issues/4978


### PR DESCRIPTION
This test is known to pass or fail depending on compiler / library version
due to variations in unordered_map/set ordering.

See https://github.com/diffblue/cbmc/issues/4978