### PR TITLE
Made get_all_generic_parameters a non-private function

### DIFF
--- a/jbmc/src/java_bytecode/generic_parameter_specialization_map_keys.cpp
+++ b/jbmc/src/java_bytecode/generic_parameter_specialization_map_keys.cpp
@@ -4,37 +4,6 @@
 
 #include <util/range.h>
 
-/// \param type: Source type
-/// \return The vector of implicitly generic and (explicitly) generic type
-///   parameters of the given type.
-const std::vector<java_generic_parametert>
-get_all_generic_parameters(const typet &type)
-{
-  PRECONDITION(
-    is_java_generic_class_type(type) ||
-    is_java_implicitly_generic_class_type(type));
-  std::vector<java_generic_parametert> generic_parameters;
-  if(is_java_implicitly_generic_class_type(type))
-  {
-    const java_implicitly_generic_class_typet &implicitly_generic_class =
-      to_java_implicitly_generic_class_type(to_java_class_type(type));
-    generic_parameters.insert(
-      generic_parameters.end(),
-      implicitly_generic_class.implicit_generic_types().begin(),
-      implicitly_generic_class.implicit_generic_types().end());
-  }
-  if(is_java_generic_class_type(type))
-  {
-    const java_generic_class_typet &generic_class =
-      to_java_generic_class_type(to_java_class_type(type));
-    generic_parameters.insert(
-      generic_parameters.end(),
-      generic_class.generic_types().begin(),
-      generic_class.generic_types().end());
-  }
-  return generic_parameters;
-}
-
 /// Add the parameters and their types for each generic parameter of the
 /// given generic pointer type to the map.
 /// Own the keys and pop from their stack on destruction.

--- a/jbmc/src/java_bytecode/java_types.cpp
+++ b/jbmc/src/java_bytecode/java_types.cpp
@@ -839,6 +839,31 @@ bool equal_java_types(const typet &type1, const typet &type2)
   return (type1 == type2 && arrays_with_same_element_type);
 }
 
+std::vector<java_generic_parametert>
+get_all_generic_parameters(const typet &type)
+{
+  std::vector<java_generic_parametert> generic_parameters;
+  if(is_java_implicitly_generic_class_type(type))
+  {
+    const java_implicitly_generic_class_typet &implicitly_generic_class =
+      to_java_implicitly_generic_class_type(to_java_class_type(type));
+    generic_parameters.insert(
+      generic_parameters.end(),
+      implicitly_generic_class.implicit_generic_types().begin(),
+      implicitly_generic_class.implicit_generic_types().end());
+  }
+  if(is_java_generic_class_type(type))
+  {
+    const java_generic_class_typet &generic_class =
+      to_java_generic_class_type(to_java_class_type(type));
+    generic_parameters.insert(
+      generic_parameters.end(),
+      generic_class.generic_types().begin(),
+      generic_class.generic_types().end());
+  }
+  return generic_parameters;
+}
+
 void get_dependencies_from_generic_parameters_rec(
   const typet &t,
   std::set<irep_idt> &refs)

--- a/jbmc/src/java_bytecode/java_types.h
+++ b/jbmc/src/java_bytecode/java_types.h
@@ -1051,6 +1051,12 @@ to_java_implicitly_generic_class_type(java_class_typet &type)
   return static_cast<java_implicitly_generic_class_typet &>(type);
 }
 
+/// \param type: Source type
+/// \return The vector of implicitly generic and (explicitly) generic type
+///   parameters of the given type.
+std::vector<java_generic_parametert>
+get_all_generic_parameters(const typet &type);
+
 /// An exception that is raised for unsupported class signature.
 /// Currently we do not parse multiple bounds.
 class unsupported_java_class_signature_exceptiont:public std::logic_error


### PR DESCRIPTION
This moves a piece of code to a place where it can be made publicly visible.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- N/A The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- N/A Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- N/A My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- N/A White-space or formatting changes outside the feature-related changed lines are in commits of their own.
