### PR TITLE
fix exprt::opX accesses in simplifier

### DIFF
--- a/src/util/simplify_expr_boolean.cpp
+++ b/src/util/simplify_expr_boolean.cpp
@@ -136,10 +136,9 @@ simplify_exprt::resultt<> simplify_exprt::simplify_boolean(const exprt &expr)
 
     // search for a and !a
     for(const exprt &op : new_operands)
-      if(op.id()==ID_not &&
-         op.operands().size()==1 &&
-         op.type().id()==ID_bool &&
-         expr_set.find(op.op0())!=expr_set.end())
+      if(
+        op.id() == ID_not && op.type().id() == ID_bool &&
+        expr_set.find(to_not_expr(op).op()) != expr_set.end())
       {
         return make_boolean_expr(expr.id() == ID_or);
       }

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -313,7 +313,8 @@ simplify_exprt::simplify_pointer_offset(const unary_exprt &expr)
              tmp.op0().operands().size()==1 &&
              tmp.op0().op0().id()==ID_address_of)
           {
-            auto new_expr = typecast_exprt::conditional_cast(tmp.op1(), type);
+            auto new_expr =
+              typecast_exprt::conditional_cast(to_plus_expr(tmp).op1(), type);
 
             simplify_node(new_expr);
             return new_expr;


### PR DESCRIPTION
This improves type safety.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
