### PR TITLE
simplifier: new interface for simplify_node

### DIFF
--- a/src/util/simplify_expr_array.cpp
+++ b/src/util/simplify_expr_array.cpp
@@ -184,8 +184,8 @@ simplify_exprt::simplify_index(const index_exprt &expr)
       // add offset to index
       mult_exprt offset(
         from_integer(*sub_size, byte_extract_expr.offset().type()), index);
-      plus_exprt final_offset(byte_extract_expr.offset(), offset);
-      simplify_node(final_offset);
+      exprt final_offset =
+        simplify_node(plus_exprt(byte_extract_expr.offset(), offset));
 
       exprt result_expr(array.id(), expr.type());
       result_expr.add_to_operands(byte_extract_expr.op(), final_offset);

--- a/src/util/simplify_expr_boolean.cpp
+++ b/src/util/simplify_expr_boolean.cpp
@@ -41,8 +41,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_boolean(const exprt &expr)
     binary_exprt new_expr = implies_expr;
     new_expr.id(ID_or);
     new_expr.op0() = boolean_negate(new_expr.op0());
-    simplify_node(new_expr);
-    return std::move(new_expr);
+    return changed(simplify_node(new_expr));
   }
   else if(expr.id()==ID_xor)
   {
@@ -192,8 +191,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_not(const not_exprt &expr)
 
     Forall_operands(it, tmp)
     {
-      *it = boolean_negate(*it);
-      simplify_node(*it);
+      *it = simplify_node(boolean_negate(*it));
     }
 
     tmp.id(tmp.id() == ID_and ? ID_or : ID_and);
@@ -211,7 +209,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_not(const not_exprt &expr)
     auto const &op_as_exists = to_exists_expr(op);
     forall_exprt rewritten_op(
       op_as_exists.symbol(), not_exprt(op_as_exists.where()));
-    simplify_node(rewritten_op.where());
+    rewritten_op.where() = simplify_node(rewritten_op.where());
     return std::move(rewritten_op);
   }
   else if(op.id() == ID_forall) // !(forall: a) <-> exists: not a
@@ -219,7 +217,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_not(const not_exprt &expr)
     auto const &op_as_forall = to_forall_expr(op);
     exists_exprt rewritten_op(
       op_as_forall.symbol(), not_exprt(op_as_forall.where()));
-    simplify_node(rewritten_op.where());
+    rewritten_op.where() = simplify_node(rewritten_op.where());
     return std::move(rewritten_op);
   }
 

--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -210,7 +210,7 @@ public:
   NODISCARD resultt<> simplify_inequality_pointer_object(const exprt &);
 
   // main recursion
-  bool simplify_node(exprt &expr);
+  NODISCARD resultt<> simplify_node(exprt);
   bool simplify_node_preorder(exprt &expr);
   NODISCARD resultt<> simplify_rec(const exprt &);
 

--- a/src/util/simplify_expr_if.cpp
+++ b/src/util/simplify_expr_if.cpp
@@ -350,41 +350,29 @@ simplify_exprt::resultt<> simplify_exprt::simplify_if(const if_exprt &expr)
       else if(truevalue.is_false() && falsevalue.is_true())
       {
         // a?0:1 <-> !a
-        exprt tmp = boolean_negate(cond);
-        simplify_node(tmp);
-        return std::move(tmp);
+        return changed(simplify_node(boolean_negate(cond)));
       }
       else if(falsevalue.is_false())
       {
         // a?b:0 <-> a AND b
-        and_exprt tmp(cond, truevalue);
-        simplify_node(tmp);
-        return std::move(tmp);
+        return changed(simplify_node(and_exprt(cond, truevalue)));
       }
       else if(falsevalue.is_true())
       {
         // a?b:1 <-> !a OR b
-        exprt tmp_not_cond = boolean_negate(cond);
-        simplify_node(tmp_not_cond);
-        or_exprt tmp(tmp_not_cond, truevalue);
-        simplify_node(tmp);
-        return std::move(tmp);
+        return changed(simplify_node(
+          or_exprt(simplify_node(boolean_negate(cond)), truevalue)));
       }
       else if(truevalue.is_true())
       {
         // a?1:b <-> a||(!a && b) <-> a OR b
-        or_exprt tmp(cond, falsevalue);
-        simplify_node(tmp);
-        return std::move(tmp);
+        return changed(simplify_node(or_exprt(cond, falsevalue)));
       }
       else if(truevalue.is_false())
       {
         // a?0:b <-> !a && b
-        exprt tmp_not_cond = boolean_negate(cond);
-        simplify_node(tmp_not_cond);
-        and_exprt tmp(tmp_not_cond, falsevalue);
-        simplify_node(tmp);
-        return std::move(tmp);
+        return changed(simplify_node(
+          and_exprt(simplify_node(boolean_negate(cond)), falsevalue)));
       }
     }
   }

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -568,9 +568,7 @@ simplify_exprt::simplify_minus(const minus_exprt &expr)
     // rewrite "a-b" to "a+(-b)"
     unary_minus_exprt rhs_negated(operands[1]);
     plus_exprt plus_expr(operands[0], simplify_unary_minus(rhs_negated));
-    simplify_node(plus_expr);
-
-    return std::move(plus_expr);
+    return changed(simplify_node(plus_expr));
   }
   else if(
     minus_expr.type().id() == ID_pointer &&
@@ -649,12 +647,10 @@ simplify_exprt::resultt<> simplify_exprt::simplify_bitwise(const exprt &expr)
       }
 
       new_expr.type()=bool_typet();
-      simplify_node(new_expr);
+      new_expr = simplify_node(new_expr);
 
       new_expr = typecast_exprt(new_expr, expr.type());
-      simplify_node(new_expr);
-
-      return std::move(new_expr);
+      return changed(simplify_node(new_expr));
     }
   }
 
@@ -1486,8 +1482,7 @@ simplify_exprt::simplify_inequality_no_constant(const exprt &expr)
     new_expr.id(ID_equal);
     new_expr = simplify_inequality_no_constant(new_expr);
     new_expr = boolean_negate(new_expr);
-    simplify_node(new_expr);
-    return std::move(new_expr);
+    return changed(simplify_node(new_expr));
   }
   else if(expr.id()==ID_gt)
   {
@@ -1497,8 +1492,7 @@ simplify_exprt::simplify_inequality_no_constant(const exprt &expr)
     new_expr.op0().swap(new_expr.op1());
     new_expr = simplify_inequality_no_constant(new_expr);
     new_expr = boolean_negate(new_expr);
-    simplify_node(new_expr);
-    return std::move(new_expr);
+    return changed(simplify_node(new_expr));
   }
   else if(expr.id()==ID_lt)
   {
@@ -1506,8 +1500,7 @@ simplify_exprt::simplify_inequality_no_constant(const exprt &expr)
     new_expr.id(ID_ge);
     new_expr = simplify_inequality_no_constant(new_expr);
     new_expr = boolean_negate(new_expr);
-    simplify_node(new_expr);
-    return std::move(new_expr);
+    return changed(simplify_node(new_expr));
   }
   else if(expr.id()==ID_le)
   {
@@ -1588,10 +1581,9 @@ simplify_exprt::simplify_inequality_no_constant(const exprt &expr)
     if(!eliminate_common_addends(new_expr.op0(), new_expr.op1()))
     {
       // remove zeros
-      simplify_node(new_expr.op0());
-      simplify_node(new_expr.op1());
-      new_expr = simplify_inequality(new_expr); // recursive call
-      return std::move(new_expr);
+      new_expr.op0() = simplify_node(new_expr.op0());
+      new_expr.op1() = simplify_node(new_expr.op1());
+      return changed(simplify_inequality(new_expr)); // recursive call
     }
   }
 
@@ -1625,8 +1617,7 @@ simplify_exprt::simplify_inequality_rhs_is_constant(const exprt &expr)
       new_expr.id(ID_equal);
       new_expr = simplify_inequality_rhs_is_constant(new_expr);
       new_expr = boolean_negate(new_expr);
-      simplify_node(new_expr);
-      return std::move(new_expr);
+      return changed(simplify_node(new_expr));
     }
 
     // very special case for pointers
@@ -1839,8 +1830,7 @@ simplify_exprt::simplify_inequality_rhs_is_constant(const exprt &expr)
       new_expr.id(ID_equal);
       new_expr = simplify_inequality_rhs_is_constant(new_expr);
       new_expr = boolean_negate(new_expr);
-      simplify_node(new_expr);
-      return std::move(new_expr);
+      return changed(simplify_node(new_expr));
     }
     else if(expr.id()==ID_gt)
     {
@@ -1863,8 +1853,7 @@ simplify_exprt::simplify_inequality_rhs_is_constant(const exprt &expr)
       new_expr.id(ID_ge);
       new_expr = simplify_inequality_rhs_is_constant(new_expr);
       new_expr = boolean_negate(new_expr);
-      simplify_node(new_expr);
-      return std::move(new_expr);
+      return changed(simplify_node(new_expr));
     }
     else if(expr.id()==ID_le)
     {
@@ -1881,8 +1870,7 @@ simplify_exprt::simplify_inequality_rhs_is_constant(const exprt &expr)
       new_expr.op1() = from_integer(i, new_expr.op1().type());
       new_expr = simplify_inequality_rhs_is_constant(new_expr);
       new_expr = boolean_negate(new_expr);
-      simplify_node(new_expr);
-      return std::move(new_expr);
+      return changed(simplify_node(new_expr));
     }
   }
 #endif

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -285,8 +285,7 @@ simplify_exprt::simplify_pointer_offset(const unary_exprt &expr)
       auto new_expr = expr;
       new_expr.op() = ptr.op0();
 
-      simplify_node(new_expr); // recursive call
-      return new_expr;
+      return changed(simplify_node(new_expr)); // recursive call
     }
     else if(op_type.id()==ID_signedbv ||
             op_type.id()==ID_unsignedbv)
@@ -297,8 +296,7 @@ simplify_exprt::simplify_pointer_offset(const unary_exprt &expr)
       {
         // (T *)0x1234 -> 0x1234
         exprt tmp = typecast_exprt(ptr.op0(), expr.type());
-        simplify_node(tmp);
-        return tmp;
+        return changed(simplify_node(tmp));
       }
       else
       {
@@ -316,8 +314,7 @@ simplify_exprt::simplify_pointer_offset(const unary_exprt &expr)
             auto new_expr =
               typecast_exprt::conditional_cast(to_plus_expr(tmp).op1(), type);
 
-            simplify_node(new_expr);
-            return new_expr;
+            return changed(simplify_node(new_expr));
           }
           else if(tmp.op1().id()==ID_typecast &&
                   tmp.op1().operands().size()==1 &&
@@ -325,8 +322,7 @@ simplify_exprt::simplify_pointer_offset(const unary_exprt &expr)
           {
             auto new_expr = typecast_exprt::conditional_cast(tmp.op0(), type);
 
-            simplify_node(new_expr);
-            return new_expr;
+            return changed(simplify_node(new_expr));
           }
         }
       }
@@ -345,10 +341,7 @@ simplify_exprt::simplify_pointer_offset(const unary_exprt &expr)
       {
         exprt tmp=op;
         if(tmp.type()!=expr.type())
-        {
-          tmp = typecast_exprt(tmp, expr.type());
-          simplify_node(tmp);
-        }
+          tmp = simplify_node(typecast_exprt(tmp, expr.type()));
 
         int_expr.push_back(tmp);
       }
@@ -367,8 +360,7 @@ simplify_exprt::simplify_pointer_offset(const unary_exprt &expr)
       return unchanged(expr);
 
     // this might change the type of the pointer!
-    exprt pointer_offset_expr=pointer_offset(ptr_expr.front());
-    simplify_node(pointer_offset_expr);
+    exprt pointer_offset_expr = simplify_node(pointer_offset(ptr_expr.front()));
 
     exprt sum;
 
@@ -380,20 +372,18 @@ simplify_exprt::simplify_pointer_offset(const unary_exprt &expr)
       sum.operands()=int_expr;
     }
 
-    simplify_node(sum);
+    sum = simplify_node(sum);
 
     exprt size_expr = from_integer(*element_size, expr.type());
 
-    binary_exprt product(sum, ID_mult, size_expr, expr.type());
+    exprt product = binary_exprt(sum, ID_mult, size_expr, expr.type());
 
-    simplify_node(product);
+    product = simplify_node(product);
 
     auto new_expr =
       binary_exprt(pointer_offset_expr, ID_plus, product, expr.type());
 
-    simplify_node(new_expr);
-
-    return new_expr;
+    return changed(simplify_node(new_expr));
   }
   else if(ptr.id()==ID_constant)
   {
@@ -403,10 +393,7 @@ simplify_exprt::simplify_pointer_offset(const unary_exprt &expr)
        c_ptr.value_is_zero_string())
     {
       auto new_expr = from_integer(0, expr.type());
-
-      simplify_node(new_expr);
-
-      return new_expr;
+      return changed(simplify_node(new_expr));
     }
     else
     {
@@ -425,9 +412,7 @@ simplify_exprt::simplify_pointer_offset(const unary_exprt &expr)
 
       auto new_expr = from_integer(number, expr.type());
 
-      simplify_node(new_expr);
-
-      return new_expr;
+      return changed(simplify_node(new_expr));
     }
   }
 
@@ -523,9 +508,9 @@ simplify_exprt::simplify_inequality_pointer_object(const exprt &expr)
       new_inequality_ops.push_back(op);
     else
     {
-      new_inequality_ops.push_back(typecast_exprt::conditional_cast(
-        op, new_inequality_ops.front().type()));
-      simplify_node(new_inequality_ops.back());
+      new_inequality_ops.push_back(
+        simplify_node(typecast_exprt::conditional_cast(
+          op, new_inequality_ops.front().type())));
     }
   }
 
@@ -739,7 +724,7 @@ simplify_exprt::simplify_object_size(const unary_exprt &expr)
         if(size.type() != expr_type)
         {
           size = typecast_exprt(size, expr_type);
-          simplify_node(size);
+          size = simplify_node(size);
         }
 
         return size;
@@ -766,7 +751,5 @@ simplify_exprt::simplify_good_pointer(const unary_exprt &expr)
   exprt def = good_pointer_def(expr.op(), ns);
 
   // recursive call
-  simplify_node(def);
-
-  return std::move(def);
+  return changed(simplify_node(def));
 }

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -376,12 +376,11 @@ simplify_exprt::simplify_pointer_offset(const unary_exprt &expr)
 
     exprt size_expr = from_integer(*element_size, expr.type());
 
-    exprt product = binary_exprt(sum, ID_mult, size_expr, expr.type());
+    exprt product = mult_exprt(sum, size_expr);
 
     product = simplify_node(product);
 
-    auto new_expr =
-      binary_exprt(pointer_offset_expr, ID_plus, product, expr.type());
+    auto new_expr = plus_exprt(pointer_offset_expr, product);
 
     return changed(simplify_node(new_expr));
   }

--- a/src/util/simplify_expr_struct.cpp
+++ b/src/util/simplify_expr_struct.cpp
@@ -155,8 +155,8 @@ simplify_exprt::simplify_member(const member_exprt &expr)
 
       const exprt &struct_offset = byte_extract_expr.offset();
       exprt member_offset = from_integer(*offset_int, struct_offset.type());
-      plus_exprt final_offset(struct_offset, member_offset);
-      simplify_node(final_offset);
+      exprt final_offset =
+        simplify_node(plus_exprt(struct_offset, member_offset));
 
       byte_extract_exprt result(
         op.id(), byte_extract_expr.op(), final_offset, expr.type());


### PR DESCRIPTION
This improves type safety. It's the final major interface in the simplifier to use the new API style.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
