### PR TITLE
fix accesses to exprt::opX() in ansi-c/

### DIFF
--- a/src/ansi-c/ansi_c_convert_type.cpp
+++ b/src/ansi-c/ansi_c_convert_type.cpp
@@ -107,8 +107,7 @@ void ansi_c_convert_typet::read_rec(const typet &type)
   {
     const exprt &as_expr=
       static_cast<const exprt &>(static_cast<const irept &>(type));
-    assert(as_expr.operands().size()==1);
-    msc_based=as_expr.op0();
+    msc_based = to_unary_expr(as_expr).op();
   }
   else if(type.id()==ID_custom_bv)
   {
@@ -215,9 +214,8 @@ void ansi_c_convert_typet::read_rec(const typet &type)
         c_storage_spec.is_thread_local=true;
       else if(id=="align")
       {
-        assert(it->operands().size()==1);
         aligned=true;
-        alignment=it->op0();
+        alignment = to_unary_expr(*it).op();
       }
     }
   }

--- a/src/ansi-c/ansi_c_language.cpp
+++ b/src/ansi-c/ansi_c_language.cpp
@@ -214,7 +214,9 @@ bool ansi_c_languaget::to_expr(
   if(expr.id()==ID_typecast &&
      expr.type().id()==ID_empty &&
      expr.operands().size()==1)
-    expr=expr.op0();
+  {
+    expr = to_typecast_expr(expr).op();
+  }
 
   return result;
 }

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -627,9 +627,9 @@ void c_typecheck_baset::typecheck_declaration(
 {
   if(declaration.get_is_static_assert())
   {
-    assert(declaration.operands().size()==2);
-    typecheck_expr(declaration.op0());
-    typecheck_expr(declaration.op1());
+    auto &static_assert_expr = to_binary_expr(declaration);
+    typecheck_expr(static_assert_expr.op0());
+    typecheck_expr(static_assert_expr.op1());
   }
   else
   {

--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -177,7 +177,7 @@ protected:
   virtual void typecheck_expr_ptrmember(exprt &expr);
   virtual void typecheck_expr_rel(binary_relation_exprt &expr);
   virtual void typecheck_expr_rel_vector(binary_relation_exprt &expr);
-  virtual void adjust_float_rel(exprt &expr);
+  virtual void adjust_float_rel(binary_relation_exprt &);
   static void add_rounding_mode(exprt &);
   virtual void typecheck_expr_index(exprt &expr);
   virtual void typecheck_expr_typecast(exprt &expr);

--- a/src/ansi-c/c_typecheck_code.cpp
+++ b/src/ansi-c/c_typecheck_code.cpp
@@ -567,9 +567,7 @@ void c_typecheck_baset::typecheck_gcc_computed_goto(codet &code)
     throw 0;
   }
 
-  assert(dest.operands().size()==1);
-
-  typecheck_expr(dest.op0());
+  typecheck_expr(to_unary_expr(dest).op());
   dest.type() = void_type();
 }
 

--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <unordered_map>
 #include <unordered_set>
 
+#include <util/byte_operators.h>
 #include <util/mathematical_expr.h>
 #include <util/std_code.h>
 #include <util/std_expr.h>
@@ -133,8 +134,7 @@ protected:
   std::string convert_with(
     const exprt &src, unsigned precedence);
 
-  std::string convert_update(
-    const exprt &src, unsigned precedence);
+  std::string convert_update(const update_exprt &, unsigned precedence);
 
   std::string convert_member_designator(
     const exprt &src);
@@ -145,9 +145,8 @@ protected:
   std::string convert_index(
     const exprt &src, unsigned precedence);
 
-  std::string convert_byte_extract(
-    const exprt &src,
-    unsigned precedence);
+  std::string
+  convert_byte_extract(const byte_extract_exprt &, unsigned precedence);
 
   std::string convert_byte_update(
     const exprt &src,
@@ -161,7 +160,8 @@ protected:
   convert_extractbits(const extractbits_exprt &src, unsigned precedence);
 
   std::string convert_unary(
-    const exprt &src, const std::string &symbol,
+    const unary_exprt &,
+    const std::string &symbol,
     unsigned precedence);
 
   std::string convert_unary_post(

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -433,9 +433,10 @@ offsetof_member_designator:
         {
           init($$, ID_designated_initializer);
           parser_stack($$).operands().resize(1);
-          parser_stack($$).op0().id(ID_member);
-          parser_stack($$).op0().add_source_location()=parser_stack($1).source_location();
-          parser_stack($$).op0().set(ID_component_name, parser_stack($1).get(ID_C_base_name));
+          auto &op = to_unary_expr(parser_stack($$)).op();
+          op.id(ID_member);
+          op.add_source_location()=parser_stack($1).source_location();
+          op.set(ID_component_name, parser_stack($1).get(ID_C_base_name));
         }
         | offsetof_member_designator '.' member_name
         {
@@ -519,20 +520,22 @@ postfix_expression:
         | postfix_expression '(' ')'
         { $$=$2;
           set($$, ID_side_effect);
-          parser_stack($$).set(ID_statement, ID_function_call);
-          parser_stack($$).operands().resize(2);
-          parser_stack($$).op0().swap(parser_stack($1));
-          parser_stack($$).op1().clear();
-          parser_stack($$).op1().id(ID_arguments);
+          auto &side_effect = to_side_effect_expr(parser_stack($$));
+          side_effect.set_statement(ID_function_call);
+          side_effect.operands().resize(2);
+          to_binary_expr(side_effect).op0().swap(parser_stack($1));
+          to_binary_expr(side_effect).op1().clear();
+          to_binary_expr(side_effect).op1().id(ID_arguments);
         }
         | postfix_expression '(' argument_expression_list ')'
         { $$=$2;
           set($$, ID_side_effect);
-          parser_stack($$).set(ID_statement, ID_function_call);
-          parser_stack($$).operands().resize(2);
-          parser_stack($$).op0().swap(parser_stack($1));
-          parser_stack($$).op1().swap(parser_stack($3));
-          parser_stack($$).op1().id(ID_arguments);
+          auto &side_effect = to_side_effect_expr(parser_stack($$));
+          side_effect.set_statement(ID_function_call);
+          side_effect.operands().resize(2);
+          to_binary_expr(side_effect).op0().swap(parser_stack($1));
+          to_binary_expr(side_effect).op1().swap(parser_stack($3));
+          to_binary_expr(side_effect).op1().id(ID_arguments);
         }
         | postfix_expression '.' member_name
         { $$=$2;
@@ -625,9 +628,10 @@ unary_expression:
           irep_idt identifier=PARSER.lookup_label(parser_stack($2).get(ID_C_base_name));
           set($$, ID_address_of);
           parser_stack($$).operands().resize(1);
-          parser_stack($$).op0()=parser_stack($2);
-          parser_stack($$).op0().id(ID_label);
-          parser_stack($$).op0().set(ID_identifier, identifier);
+          auto &op = to_unary_expr(parser_stack($$)).op();
+          op=parser_stack($2);
+          op.id(ID_label);
+          op.set(ID_identifier, identifier);
         }
         | '*' cast_expression
         { $$=$1;
@@ -2500,7 +2504,7 @@ gcc_asm_statement:
           statement($$, ID_asm);
           parser_stack($$).set(ID_flavor, ID_gcc);
           parser_stack($$).operands().resize(5);
-          parser_stack($$).op0()=parser_stack($4);
+          to_multi_ary_expr(parser_stack($$)).op0()=parser_stack($4);
         }
         ;
 

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -125,6 +125,11 @@ public:
   {
     check_code(code, vm);
   }
+
+  using exprt::op0;
+  using exprt::op1;
+  using exprt::op2;
+  using exprt::op3;
 };
 
 namespace detail // NOLINT

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -2073,6 +2073,63 @@ to_side_effect_expr_assign(const exprt &expr)
   return static_cast<const side_effect_expr_assignt &>(side_effect_expr_assign);
 }
 
+/// A \ref side_effect_exprt that contains a statement
+class side_effect_expr_statement_expressiont : public side_effect_exprt
+{
+public:
+  /// construct an assignment side-effect, given lhs, rhs and the type
+  side_effect_expr_statement_expressiont(
+    codet _code,
+    typet _type,
+    source_locationt loc)
+    : side_effect_exprt(
+        ID_statement_expression,
+        {std::move(_code)},
+        std::move(_type),
+        std::move(loc))
+  {
+  }
+
+  codet &statement()
+  {
+    return to_code(op0());
+  }
+
+  const codet &statement() const
+  {
+    return to_code(op0());
+  }
+};
+
+template <>
+inline bool
+can_cast_expr<side_effect_expr_statement_expressiont>(const exprt &base)
+{
+  return detail::can_cast_side_effect_expr_impl(base, ID_statement_expression);
+}
+
+inline side_effect_expr_statement_expressiont &
+to_side_effect_expr_statement_expression(exprt &expr)
+{
+  auto &side_effect_expr_statement_expression = to_side_effect_expr(expr);
+  PRECONDITION(
+    side_effect_expr_statement_expression.get_statement() ==
+    ID_statement_expression);
+  return static_cast<side_effect_expr_statement_expressiont &>(
+    side_effect_expr_statement_expression);
+}
+
+inline const side_effect_expr_statement_expressiont &
+to_side_effect_expr_statement_expression(const exprt &expr)
+{
+  const auto &side_effect_expr_statement_expression = to_side_effect_expr(expr);
+  PRECONDITION(
+    side_effect_expr_statement_expression.get_statement() ==
+    ID_statement_expression);
+  return static_cast<const side_effect_expr_statement_expressiont &>(
+    side_effect_expr_statement_expression);
+}
+
 /// A \ref side_effect_exprt representation of a function call side effect.
 class side_effect_expr_function_callt:public side_effect_exprt
 {


### PR DESCRIPTION
This improves type safety.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
