### PR TITLE
fix exprt::opX() accesses in cpp/

### DIFF
--- a/src/cpp/cpp_constructor.cpp
+++ b/src/cpp/cpp_constructor.cpp
@@ -235,8 +235,10 @@ optionalt<codet> cpp_typecheckt::cpp_constructor(
     assert(initializer.id()==ID_code &&
            initializer.get(ID_statement)==ID_expression);
 
-    side_effect_expr_function_callt &func_ini=
-      to_side_effect_expr_function_call(initializer.op0());
+    auto &statement_expr = to_code_expression(to_code(initializer));
+
+    side_effect_expr_function_callt &func_ini =
+      to_side_effect_expr_function_call(statement_expr.expression());
 
     exprt &tmp_this=func_ini.arguments().front();
     DATA_INVARIANT(

--- a/src/cpp/cpp_static_assert.h
+++ b/src/cpp/cpp_static_assert.h
@@ -12,14 +12,13 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #ifndef CPROVER_CPP_CPP_STATIC_ASSERT_H
 #define CPROVER_CPP_CPP_STATIC_ASSERT_H
 
-#include <util/expr.h>
+#include <util/std_expr.h>
 
-class cpp_static_assertt:public exprt
+class cpp_static_assertt : public binary_exprt
 {
 public:
-  cpp_static_assertt():exprt(ID_cpp_static_assert)
+  cpp_static_assertt() : binary_exprt(ID_cpp_static_assert)
   {
-    operands().resize(2);
   }
 
   exprt &cond()

--- a/src/cpp/cpp_typecheck.cpp
+++ b/src/cpp/cpp_typecheck.cpp
@@ -243,7 +243,7 @@ void cpp_typecheckt::do_not_typechecked()
         }
         else if(symbol.value.operands().size()==1)
         {
-          value = symbol.value.op0();
+          value = to_unary_expr(symbol.value).op();
           cont=true;
         }
         else

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -1278,7 +1278,10 @@ void cpp_typecheckt::typecheck_member_function(
   }
 
   if(value.id() == ID_cpp_not_typechecked && value.has_operands())
-    move_member_initializers(initializers, type, value.op0());
+  {
+    move_member_initializers(
+      initializers, type, to_multi_ary_expr(value).op0());
+  }
   else
     move_member_initializers(initializers, type, value);
 

--- a/src/cpp/cpp_typecheck_constructor.cpp
+++ b/src/cpp/cpp_typecheck_constructor.cpp
@@ -68,10 +68,8 @@ static void copy_member(
   op1.copy_to_operands(cpp_namet(arg_name, source_location).as_expr());
   op1.add_source_location()=source_location;
 
-  side_effect_exprt assign(ID_assign, typet(), source_location);
-  assign.copy_to_operands(op0.as_expr());
-  assign.op0().add_source_location() = source_location;
-  assign.copy_to_operands(op1);
+  side_effect_expr_assignt assign(op0.as_expr(), op1, typet(), source_location);
+  assign.lhs().add_source_location() = source_location;
 
   code_expressiont code(assign);
   code.add_source_location() = source_location;
@@ -102,13 +100,14 @@ static void copy_array(
     ID_component_cpp_name, cpp_namet(member_base_name, source_location));
   member.copy_to_operands(cpp_namet(arg_name, source_location).as_expr());
 
-  side_effect_exprt assign(ID_assign, typet(), source_location);
+  side_effect_expr_assignt assign(
+    index_exprt(array.as_expr(), constant),
+    index_exprt(member, constant),
+    typet(),
+    source_location);
 
-  assign.copy_to_operands(index_exprt(array.as_expr(), constant));
-  assign.op0().add_source_location() = source_location;
-
-  assign.copy_to_operands(index_exprt(member, constant));
-  assign.op1().add_source_location() = source_location;
+  assign.lhs().add_source_location() = source_location;
+  assign.rhs().add_source_location() = source_location;
 
   code_expressiont code(assign);
   code.add_source_location() = source_location;
@@ -186,7 +185,8 @@ void cpp_typecheckt::default_cpctor(
   irept &initializers=decl0.add(ID_member_initializers);
   initializers.id(ID_member_initializers);
 
-  cpp_declaratort &declarator=static_cast<cpp_declaratort &>(cpctor.op0());
+  cpp_declaratort &declarator =
+    static_cast<cpp_declaratort &>(to_multi_ary_expr(cpctor).op0());
   exprt &block=declarator.value();
 
   // First, we need to call the parent copy constructors
@@ -295,7 +295,8 @@ void cpp_typecheckt::default_assignop(
   cpctor.operands().push_back(exprt(ID_cpp_declarator));
   cpctor.add_source_location()=source_location;
 
-  cpp_declaratort &declarator=(cpp_declaratort&) cpctor.op0();
+  cpp_declaratort &declarator =
+    static_cast<cpp_declaratort &>(to_multi_ary_expr(cpctor).op0());
   declarator.add_source_location()=source_location;
 
   cpp_namet &declarator_name=declarator.name();

--- a/src/cpp/cpp_typecheck_conversions.cpp
+++ b/src/cpp/cpp_typecheck_conversions.cpp
@@ -894,7 +894,7 @@ bool cpp_typecheckt::user_defined_conversion_sequence(
 
           // simplify address
           if(expr.id()==ID_dereference)
-            address=expr.op0();
+            address = to_dereference_expr(expr).pointer();
 
           pointer_typet ptr_sub=pointer_type(type);
           c_qualifierst qual_from;
@@ -1333,10 +1333,11 @@ bool cpp_typecheckt::reference_binding(
            reference_compatible(returned_value, type, rank))
         {
           // returned values are lvalues in case of references only
-          assert(returned_value.id()==ID_dereference &&
-                 is_reference(returned_value.op0().type()));
+          DATA_INVARIANT(
+            is_reference(to_dereference_expr(returned_value).op().type()),
+            "the returned value must be pointer to reference");
 
-          new_expr=returned_value.op0();
+          new_expr = to_multi_ary_expr(returned_value).op0();
 
           if(returned_value.type() != type.subtype())
           {
@@ -1484,7 +1485,7 @@ void cpp_typecheckt::implicit_typecast(exprt &expr, const typet &type)
     e.id() == ID_initializer_list && cpp_is_pod(type) &&
     e.operands().size() == 1)
   {
-    e = expr.op0();
+    e = to_unary_expr(expr).op();
   }
 
   if(!implicit_conversion_sequence(e, type, expr))
@@ -1696,7 +1697,7 @@ bool cpp_typecheckt::dynamic_typecast(
   if(type.id()==ID_pointer)
   {
     if(e.id()==ID_dereference && e.get_bool(ID_C_implicit))
-      e=expr.op0();
+      e = to_dereference_expr(expr).pointer();
 
     if(e.type().id()==ID_pointer &&
        cast_away_constness(e.type(), type))
@@ -1749,7 +1750,7 @@ bool cpp_typecheckt::reinterpret_typecast(
   if(check_constantness && type.id()==ID_pointer)
   {
     if(e.id()==ID_dereference && e.get_bool(ID_C_implicit))
-      e=expr.op0();
+      e = to_dereference_expr(expr).pointer();
 
     if(e.type().id()==ID_pointer &&
        cast_away_constness(e.type(), type))
@@ -1845,7 +1846,7 @@ bool cpp_typecheckt::static_typecast(
   if(check_constantness && type.id()==ID_pointer)
   {
     if(e.id()==ID_dereference && e.get_bool(ID_C_implicit))
-      e=expr.op0();
+      e = to_dereference_expr(expr).pointer();
 
     if(e.type().id()==ID_pointer &&
        cast_away_constness(e.type(), type))
@@ -1884,8 +1885,8 @@ bool cpp_typecheckt::static_typecast(
       {
         if(e.id()==ID_dereference)
         {
-          make_ptr_typecast(e.op0(), type);
-          new_expr.swap(e.op0());
+          make_ptr_typecast(to_dereference_expr(e).pointer(), type);
+          new_expr.swap(to_dereference_expr(e).pointer());
           return true;
         }
 

--- a/src/cpp/cpp_typecheck_fargs.cpp
+++ b/src/cpp/cpp_typecheck_fargs.cpp
@@ -34,7 +34,7 @@ void cpp_typecheck_fargst::build(
   const side_effect_expr_function_callt &function_call)
 {
   in_use=true;
-  operands = function_call.op1().operands();
+  operands = function_call.arguments();
 }
 
 bool cpp_typecheck_fargst::match(
@@ -126,7 +126,7 @@ bool cpp_typecheck_fargst::match(
       operand.id() == ID_initializer_list && cpp_typecheck.cpp_is_pod(type) &&
       operand.operands().size() == 1 &&
       cpp_typecheck.implicit_conversion_sequence(
-        operand.op0(), type, new_expr, rank))
+        to_unary_expr(operand).op(), type, new_expr, rank))
     {
       distance += rank;
     }

--- a/src/cpp/cpp_typecheck_function.cpp
+++ b/src/cpp/cpp_typecheck_function.cpp
@@ -123,8 +123,10 @@ void cpp_typecheckt::convert_function(symbolt &symbol)
     PRECONDITION(symbol.value.get(ID_statement) == ID_block);
 
     if(
-      !symbol.value.has_operands() || !symbol.value.op0().has_operands() ||
-      symbol.value.op0().op0().id() != ID_already_typechecked)
+      !symbol.value.has_operands() ||
+      !to_multi_ary_expr(symbol.value).op0().has_operands() ||
+      to_multi_ary_expr(to_multi_ary_expr(symbol.value).op0()).op0().id() !=
+        ID_already_typechecked)
     {
       symbol.value.copy_to_operands(
         dtor(msymb, to_symbol_expr(function_scope.this_expr)));

--- a/src/cpp/cpp_typecheck_initializer.cpp
+++ b/src/cpp/cpp_typecheck_initializer.cpp
@@ -74,10 +74,10 @@ void cpp_typecheckt::convert_initializer(symbolt &symbol)
   }
   else if(cpp_is_pod(symbol.type))
   {
-    if(symbol.type.id() == ID_pointer &&
-       symbol.type.subtype().id() == ID_code &&
-       symbol.value.id() == ID_address_of &&
-       symbol.value.op0().id() == ID_cpp_name)
+    if(
+      symbol.type.id() == ID_pointer && symbol.type.subtype().id() == ID_code &&
+      symbol.value.id() == ID_address_of &&
+      to_address_of_expr(symbol.value).object().id() == ID_cpp_name)
     {
       // initialization of a function pointer with
       // the address of a function: use pointer type information
@@ -102,9 +102,11 @@ void cpp_typecheckt::convert_initializer(symbolt &symbol)
         fargs.operands.push_back(new_object);
       }
 
-      exprt resolved_expr=resolve(
-        to_cpp_name(static_cast<irept &>(symbol.value.op0())),
-        cpp_typecheck_resolvet::wantt::BOTH, fargs);
+      exprt resolved_expr = resolve(
+        to_cpp_name(
+          static_cast<irept &>(to_address_of_expr(symbol.value).object())),
+        cpp_typecheck_resolvet::wantt::BOTH,
+        fargs);
 
       assert(symbol.type.subtype() == resolved_expr.type());
 
@@ -119,7 +121,8 @@ void cpp_typecheckt::convert_initializer(symbolt &symbol)
           address_of_exprt(
             lookup(resolved_expr.get(ID_component_name)).symbol_expr());
 
-        symbol.value.type().add(ID_to_member) = resolved_expr.op0().type();
+        symbol.value.type().add(ID_to_member) =
+          to_member_expr(resolved_expr).compound().type();
       }
       else
         UNREACHABLE;

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -2154,7 +2154,7 @@ bool cpp_typecheck_resolvet::disambiguate_functions(
         }
 
         cpp_typecheck_fargst new_fargs(fargs);
-        new_fargs.add_object(expr.op0());
+        new_fargs.add_object(to_member_expr(expr).compound());
 
         return new_fargs.match(type, args_distance, cpp_typecheck);
       }

--- a/src/cpp/expr2cpp.cpp
+++ b/src/cpp/expr2cpp.cpp
@@ -404,7 +404,7 @@ std::string expr2cppt::convert_code_cpp_delete(
     return convert_norep(src, precedence);
   }
 
-  std::string tmp=convert(src.op0());
+  std::string tmp = convert(to_unary_expr(src).op());
 
   dest+=tmp+";\n";
 
@@ -476,16 +476,17 @@ std::string expr2cppt::convert_code(
 
 std::string expr2cppt::convert_extractbit(const exprt &src)
 {
-  assert(src.operands().size()==2);
-  return convert(src.op0())+"["+convert(src.op1())+"]";
+  const auto &extractbit_expr = to_extractbit_expr(src);
+  return convert(extractbit_expr.op0()) + "[" + convert(extractbit_expr.op1()) +
+         "]";
 }
 
 std::string expr2cppt::convert_extractbits(const exprt &src)
 {
-  assert(src.operands().size()==3);
-  return
-    convert(src.op0())+".range("+convert(src.op1())+ ","+
-    convert(src.op2())+")";
+  const auto &extractbits_expr = to_extractbits_expr(src);
+  return convert(extractbits_expr.src()) + ".range(" +
+         convert(extractbits_expr.upper()) + "," +
+         convert(extractbits_expr.lower()) + ")";
 }
 
 std::string expr2cpp(const exprt &expr, const namespacet &ns)


### PR DESCRIPTION
This improves type safety.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
