### PR TITLE
Slicing global inits must not drop depended-on globals

### DIFF
--- a/regression/goto-instrument/slice-global-inits4/main.c
+++ b/regression/goto-instrument/slice-global-inits4/main.c
@@ -1,0 +1,16 @@
+struct S
+{
+  int x;
+};
+
+struct T
+{
+  struct S *s;
+};
+
+int main()
+{
+  static struct S s = {42};
+  static struct T t = {.s = &s};
+  __CPROVER_assert(t.s->x == 42, "must be 42");
+}

--- a/regression/goto-instrument/slice-global-inits4/test.desc
+++ b/regression/goto-instrument/slice-global-inits4/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--slice-global-inits
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/goto-programs/slice_global_inits.cpp
+++ b/src/goto-programs/slice_global_inits.cpp
@@ -48,7 +48,7 @@ void slice_global_inits(goto_modelt &goto_model)
 
   // gather all symbols used by reachable functions
 
-  find_symbols_sett symbols;
+  find_symbols_sett symbols_to_keep;
 
   for(std::size_t node_idx = 0; node_idx < directed_graph.size(); ++node_idx)
   {
@@ -63,8 +63,8 @@ void slice_global_inits(goto_modelt &goto_model)
 
     for(const auto &i : it->second.body.instructions)
     {
-      i.apply([&symbols](const exprt &expr) {
-        find_symbols(expr, symbols, true, false);
+      i.apply([&symbols_to_keep](const exprt &expr) {
+        find_symbols(expr, symbols_to_keep, true, false);
       });
     }
   }
@@ -87,8 +87,9 @@ void slice_global_inits(goto_modelt &goto_model)
       const symbol_exprt &symbol_expr=to_symbol_expr(code_assign.lhs());
       const irep_idt id=symbol_expr.get_identifier();
 
-      if(!has_prefix(id2string(id), CPROVER_PREFIX) &&
-         symbols.find(id)==symbols.end())
+      if(
+        !has_prefix(id2string(id), CPROVER_PREFIX) &&
+        symbols_to_keep.find(id) == symbols_to_keep.end())
       {
         i_it->turn_into_skip();
       }

--- a/src/goto-programs/slice_global_inits.cpp
+++ b/src/goto-programs/slice_global_inits.cpp
@@ -69,8 +69,6 @@ void slice_global_inits(goto_modelt &goto_model)
     }
   }
 
-  // now remove unnecessary initializations
-
   goto_functionst::function_mapt::iterator f_it;
   f_it=goto_functions.function_map.find(INITIALIZE_FUNCTION);
 
@@ -79,6 +77,44 @@ void slice_global_inits(goto_modelt &goto_model)
 
   goto_programt &goto_program=f_it->second.body;
 
+  // add all symbols from right-hand sides of required symbols
+  bool fixed_point_reached = false;
+  // markers for each instruction to avoid repeatedly searching the same
+  // instruction for new symbols; initialized to false, and set to true whenever
+  // an instruction is determined to be irrelevant (not an assignment) or
+  // symbols have been collected from it
+  std::vector<bool> seen(goto_program.instructions.size(), false);
+  while(!fixed_point_reached)
+  {
+    fixed_point_reached = true;
+
+    std::vector<bool>::iterator seen_it = seen.begin();
+    forall_goto_program_instructions(i_it, goto_program)
+    {
+      if(!*seen_it && i_it->is_assign())
+      {
+        const code_assignt &code_assign = i_it->get_assign();
+        const irep_idt id = to_symbol_expr(code_assign.lhs()).get_identifier();
+
+        // if we are to keep the left-hand side, then we also need to keep all
+        // symbols occurring in the right-hand side
+        if(
+          has_prefix(id2string(id), CPROVER_PREFIX) ||
+          symbols_to_keep.find(id) != symbols_to_keep.end())
+        {
+          fixed_point_reached = false;
+          find_symbols(code_assign.rhs(), symbols_to_keep, true, false);
+          *seen_it = true;
+        }
+      }
+      else if(!*seen_it)
+        *seen_it = true;
+
+      ++seen_it;
+    }
+  }
+
+  // now remove unnecessary initializations
   Forall_goto_program_instructions(i_it, goto_program)
   {
     if(i_it->is_assign())


### PR DESCRIPTION
An initializer of an object of static lifetime may use the address of
another object with static lifetime as initial value. Such depended-on
globals must not be sliced away.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
