### PR TITLE
goto-symex: Reformat parameter conversion error message

### DIFF
--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -116,15 +116,16 @@ void goto_symext::parameter_assignments(
               from_integer(0, index_type()),
               parameter_type);
         }
+        // clang-format on
         else
         {
           std::ostringstream error;
-          error << "function call: parameter \"" << identifier
-                << "\" type mismatch: got " << rhs.type().pretty()
-                << ", expected " << parameter_type.pretty();
+          error << state.source.pc->source_location.as_string() << ": "
+                << "function call: parameter \"" << identifier
+                << "\" type mismatch:\ngot " << rhs.type().pretty()
+                << "\nexpected " << parameter_type.pretty();
           throw unsupported_operation_exceptiont(error.str());
         }
-        // clang-format on
       }
 
       assignment_typet assignment_type;


### PR DESCRIPTION
Language front-ends cannot always type check parameter conversions, for
example in case of incomplete forward declaration there isn't sufficient
information available. Thus some of that work is left to be done during
symbolic execution. In such cases, late type checking can fail and the
problem needs to be reported back to the users. We previously did not
include the source location of the problem in the output, and did not
make generous use of newlines, making diagnosing the problem difficult.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
