### PR TITLE
Fix header include

### DIFF
--- a/jbmc/src/java_bytecode/ci_lazy_methods_needed.cpp
+++ b/jbmc/src/java_bytecode/ci_lazy_methods_needed.cpp
@@ -9,7 +9,7 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 /// \file
 /// Context-insensitive lazy methods container
 
-#include "ci_lazy_methods.h"
+#include "ci_lazy_methods_needed.h"
 #include "java_static_initializers.h"
 
 #include <java_bytecode/select_pointer_type.h>

--- a/jbmc/src/java_bytecode/ci_lazy_methods_needed.cpp
+++ b/jbmc/src/java_bytecode/ci_lazy_methods_needed.cpp
@@ -10,12 +10,14 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 /// Context-insensitive lazy methods container
 
 #include "ci_lazy_methods_needed.h"
-#include "java_static_initializers.h"
 
-#include <java_bytecode/select_pointer_type.h>
-#include <string>
 #include <util/namespace.h>
 #include <util/std_types.h>
+
+#include <string>
+
+#include "java_static_initializers.h"
+#include "select_pointer_type.h"
 
 /// Notes `method_symbol_name` is referenced from some reachable function, and
 /// should therefore be elaborated.


### PR DESCRIPTION
It seems that the header include wasn't updated when this file was extracted from a larger file.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
