### PR TITLE
Clean up string constraint generator class

### DIFF
--- a/src/solvers/strings/string_constraint_generator.h
+++ b/src/solvers/strings/string_constraint_generator.h
@@ -60,20 +60,23 @@ public:
 
   array_poolt array_pool;
 
-  string_constraintst constraints;
-
   const namespacet ns;
 
   /// Associate array to pointer, and array to length
   /// \return an expression if the given function application is one of
   ///   associate pointer and associate length
-  optionalt<exprt>
-  make_array_pointer_association(const function_application_exprt &expr);
+  optionalt<exprt> make_array_pointer_association(
+    const exprt &return_code,
+    const function_application_exprt &expr);
 
 private:
-  exprt associate_array_to_pointer(const function_application_exprt &f);
+  exprt associate_array_to_pointer(
+    const exprt &return_code,
+    const function_application_exprt &f);
 
-  exprt associate_length_to_array(const function_application_exprt &f);
+  exprt associate_length_to_array(
+    const exprt &return_code,
+    const function_application_exprt &f);
 };
 
 // Type used by primitives to signal errors

--- a/src/solvers/strings/string_constraint_generator.h
+++ b/src/solvers/strings/string_constraint_generator.h
@@ -74,9 +74,6 @@ private:
   exprt associate_array_to_pointer(const function_application_exprt &f);
 
   exprt associate_length_to_array(const function_application_exprt &f);
-
-  // MEMBERS
-  const messaget message;
 };
 
 // Type used by primitives to signal errors

--- a/src/solvers/strings/string_constraint_generator.h
+++ b/src/solvers/strings/string_constraint_generator.h
@@ -37,9 +37,6 @@ struct string_constraintst final
   std::vector<exprt> existential;
   std::vector<string_constraintt> universal;
   std::vector<string_not_contains_constraintt> not_contains;
-
-  /// Clear all constraints
-  void clear();
 };
 
 void merge(string_constraintst &result, string_constraintst other);

--- a/src/solvers/strings/string_constraint_generator_main.cpp
+++ b/src/solvers/strings/string_constraint_generator_main.cpp
@@ -96,13 +96,6 @@ exprt string_constraint_generatort::associate_length_to_array(
                    equal_exprt(length, new_length)};
 }
 
-void string_constraintst::clear()
-{
-  existential.clear();
-  universal.clear();
-  not_contains.clear();
-}
-
 /// Merge two sets of constraints by appending to the first one
 void merge(string_constraintst &result, string_constraintst other)
 {

--- a/src/solvers/strings/string_dependencies.cpp
+++ b/src/solvers/strings/string_dependencies.cpp
@@ -328,8 +328,8 @@ void string_dependenciest::output_dot(std::ostream &stream) const
   stream << '}' << std::endl;
 }
 
-void string_dependenciest::add_constraints(
-  string_constraint_generatort &generator)
+string_constraintst
+string_dependenciest::add_constraints(string_constraint_generatort &generator)
 {
   std::unordered_set<nodet, node_hash> test_dependencies;
   for(const auto &builtin : builtin_function_nodes)
@@ -346,16 +346,16 @@ void string_dependenciest::add_constraints(
       for_each_successor(n, f);
     });
 
+  string_constraintst constraints;
   for(const auto &node : builtin_function_nodes)
   {
     if(test_dependencies.count(nodet(node)))
     {
       const auto &builtin = builtin_function_nodes[node.index];
-      string_constraintst constraints = builtin.data->constraints(generator);
-      merge(generator.constraints, std::move(constraints));
+      merge(constraints, builtin.data->constraints(generator));
     }
     else
-      generator.constraints.existential.push_back(
-        node.data->length_constraint());
+      constraints.existential.push_back(node.data->length_constraint());
   }
+  return constraints;
 }

--- a/src/solvers/strings/string_dependencies.h
+++ b/src/solvers/strings/string_dependencies.h
@@ -14,6 +14,8 @@ Author: Diffblue Ltd.
 
 #include <memory>
 
+#include <util/nodiscard.h>
+
 #include "string_builtin_function.h"
 
 /// Keep track of dependencies between strings.
@@ -114,7 +116,8 @@ public:
   /// For all builtin call on which a test (or an unsupported buitin)
   /// result depends, add the corresponding constraints. For the other builtin
   /// only add constraints on the length.
-  void add_constraints(string_constraint_generatort &generatort);
+  NODISCARD string_constraintst
+  add_constraints(string_constraint_generatort &generatort);
 
   /// Clear the content of the dependency graph
   void clear();


### PR DESCRIPTION
The message field was unused, and the `constraints` field does not belong here since it is rather the return value of constraint generation than a field.
This was triggered by this discussion https://github.com/diffblue/cbmc/pull/4957#discussion_r311393622


<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
