### PR TITLE
Fix clang-format excludes in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,11 @@ jobs:
       script: |
         clang-format-7 --version
         # build a pathspec that excludes the files in .clang-format-ignore
-        while read file ; do echo EXCLUDES+="':(top,exclude)$file' " ; done < .clang-format-ignore
+        while read file ; do EXCLUDES+="':(top,exclude)$file' " ; done < .clang-format-ignore
         MERGE_BASE=$(git merge-base ${TRAVIS_COMMIT_RANGE%...*} ${TRAVIS_COMMIT_RANGE#*...})
         echo "Checking for formatting errors introduced since $MERGE_BASE"
-        git-clang-format-7 --binary clang-format-7 $MERGE_BASE -- $EXCLUDES
+        # use eval so that quotes (as inserted into $EXCLUDES above) are not interpreted as parts of file names
+        eval git-clang-format-7 --binary clang-format-7 $MERGE_BASE -- $EXCLUDES
         git diff > formatted.diff
         if [[ -s formatted.diff ]] ; then
           echo 'Formatting error! The following diff shows the required changes'


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->
I noticed that the clang-format excludes where not actually working on Travis. This PR should fix that.
I tested this with clang-format breaking changes in both a regular `.cpp` file and one from the excludes. Before the change in this PR, clang-format complained about both changes. After the change, it only complained about the one that is not in the excludes.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
