### PR TITLE
Refine CPPLINT script to not report __CPROVER_ usage outside of strings

### DIFF
--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -4605,7 +4605,7 @@ def CheckAssert(filename, clean_lines, linenum, error):
 
 
 def Check__CPROVER_(filename, clean_lines, linenum, error):
-  """Check for uses of __CPROVER_.
+  """Check for uses of __CPROVER_ in strings.
 
   Args:
     filename: The name of the current file.
@@ -4614,7 +4614,7 @@ def Check__CPROVER_(filename, clean_lines, linenum, error):
     error: The function to call with any errors found.
   """
   line = clean_lines.lines[linenum]
-  match = Match(r'.*__CPROVER_.*', line)
+  match = Match(r'.*"([^"\\]|\\.)*__CPROVER_([^"\\]|\\.)*".*', line)
   if match:
     error(filename, linenum, 'build/deprecated', 4,
           'use CPROVER_PREFIX instead of __CPROVER_')

--- a/src/ansi-c/library/cprover.h
+++ b/src/ansi-c/library/cprover.h
@@ -38,7 +38,6 @@ void __CPROVER_initialize(void);
 void __CPROVER_cover(__CPROVER_bool condition);
 #endif
 
-// NOLINTNEXTLINE(build/deprecated)
 void __CPROVER_printf(const char *format, ...);
 void __CPROVER_input(const char *id, ...);
 void __CPROVER_output(const char *id, ...);
@@ -153,15 +152,10 @@ __CPROVER_bool __CPROVER_get_may(const void *, const char *);
 #define __CPROVER_danger_number_of_consts 1
 
 // detect overflow
-// NOLINTNEXTLINE(build/deprecated)
 __CPROVER_bool __CPROVER_overflow_minus();
-// NOLINTNEXTLINE(build/deprecated)
 __CPROVER_bool __CPROVER_overflow_mult();
-// NOLINTNEXTLINE(build/deprecated)
 __CPROVER_bool __CPROVER_overflow_plus();
-// NOLINTNEXTLINE(build/deprecated)
 __CPROVER_bool __CPROVER_overflow_shl();
-// NOLINTNEXTLINE(build/deprecated)
 __CPROVER_bool __CPROVER_overflow_unary_minus();
 
 #endif // CPROVER_ANSI_C_LIBRARY_CPROVER_H

--- a/src/cpp/library/cprover.h
+++ b/src/cpp/library/cprover.h
@@ -22,9 +22,7 @@ void __CPROVER_assume(__CPROVER_bool assumption) __attribute__((__noreturn__));
 void __CPROVER_assert(__CPROVER_bool assertion, const char *description);
 void __CPROVER_precondition(__CPROVER_bool assertion, const char *description);
 
-// NOLINTNEXTLINE(build/deprecated)
 void __CPROVER_input(const char *description, ...);
-// NOLINTNEXTLINE(build/deprecated)
 void __CPROVER_output(const char *description, ...);
 
 // concurrency-related


### PR DESCRIPTION
This commit refines the CPPLINT script to only report `__CPROVER_` usages in strings (and not in function names for example).

I also removed several unnecessary NOLINT comments. 