### PR TITLE
Make copy of not_exprt private

### DIFF
--- a/jbmc/src/java_bytecode/character_refine_preprocess.cpp
+++ b/jbmc/src/java_bytecode/character_refine_preprocess.cpp
@@ -443,7 +443,7 @@ exprt character_refine_preprocesst::expr_of_is_defined(
   intervals.push_back(
     binary_relation_exprt(chr, ID_ge, from_integer(0x1D800, chr.type())));
 
-  return not_exprt(disjunction(intervals));
+  return not_expr(disjunction(intervals));
 }
 
 /// Converts function call to an assignment of an expression corresponding to

--- a/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
@@ -180,9 +180,7 @@ codet java_bytecode_instrumentt::check_array_access(
 
   if(throw_runtime_exceptions)
     return throw_exception(
-      not_exprt(cond),
-      original_loc,
-      "java.lang.ArrayIndexOutOfBoundsException");
+      not_expr(cond), original_loc, "java.lang.ArrayIndexOutOfBoundsException");
 
   code_blockt bounds_checks;
 
@@ -223,11 +221,8 @@ code_ifthenelset java_bytecode_instrumentt::check_class_cast(
   optionalt<codet> check_code;
   if(throw_runtime_exceptions)
   {
-    check_code=
-      throw_exception(
-        not_exprt(class_cast_check),
-        original_loc,
-        "java.lang.ClassCastException");
+    check_code = throw_exception(
+      not_expr(class_cast_check), original_loc, "java.lang.ClassCastException");
   }
   else
   {
@@ -271,7 +266,7 @@ codet java_bytecode_instrumentt::check_null_dereference(
   check_loc.set_comment("Null pointer check");
   check_loc.set_property_class("null-pointer-exception");
 
-  return create_fatal_assertion(not_exprt(equal_expr), check_loc);
+  return create_fatal_assertion(not_expr(equal_expr), check_loc);
 }
 
 /// Checks whether \p length >= 0 and throws NegativeArraySizeException/
@@ -292,9 +287,7 @@ codet java_bytecode_instrumentt::check_array_length(
 
   if(throw_runtime_exceptions)
     return throw_exception(
-      not_exprt(ge_zero),
-      original_loc,
-      "java.lang.NegativeArraySizeException");
+      not_expr(ge_zero), original_loc, "java.lang.NegativeArraySizeException");
 
   source_locationt check_loc;
   check_loc.set_comment("Array size should be >= 0");

--- a/jbmc/src/java_bytecode/java_static_initializers.cpp
+++ b/jbmc/src/java_bytecode/java_static_initializers.cpp
@@ -604,7 +604,7 @@ code_blockt get_thread_safe_clinit_wrapper_body(
   {
     exprt assumption = gen_clinit_eqexpr(
       clinit_state_sym.symbol_expr(), clinit_statest::IN_PROGRESS);
-    assumption = not_exprt(assumption);
+    assumption = not_expr(assumption);
     code_assumet assume(assumption);
     function_body.add(assume);
   }

--- a/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
+++ b/jbmc/src/java_bytecode/java_string_library_preprocess.cpp
@@ -940,7 +940,7 @@ code_blockt java_string_library_preprocesst::make_float_to_string_code(
 
   // Case of Infinity
   extractbit_exprt is_neg(arg, float_spec.width()-1);
-  condition_list.push_back(and_exprt(isinf_exprt(arg), not_exprt(is_neg)));
+  condition_list.push_back(and_exprt(isinf_exprt(arg), not_expr(is_neg)));
   const refined_string_exprt infinity =
     string_literal_to_string_expr("Infinity", loc, symbol_table, code);
   string_expr_list.push_back(infinity);

--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -179,7 +179,7 @@ void constant_propagator_domaint::transform(
     if(from->get_target()==to)
       g = from->get_condition();
     else
-      g = not_exprt(from->get_condition());
+      g = not_expr(from->get_condition());
     partial_evaluate(values, g, ns);
     if(g.is_false())
      values.set_to_bottom();

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -676,7 +676,7 @@ void goto_checkt::integer_overflow_check(
       equal_exprt minus_one_eq(div_expr.divisor(), from_integer(-1, type));
 
       add_guarded_property(
-        not_exprt(and_exprt(int_min_eq, minus_one_eq)),
+        not_expr(and_exprt(int_min_eq, minus_one_eq)),
         "arithmetic overflow on signed division",
         "overflow",
         expr.find_source_location(),
@@ -697,7 +697,7 @@ void goto_checkt::integer_overflow_check(
         to_unary_minus_expr(expr).op(), to_signedbv_type(type).smallest_expr());
 
       add_guarded_property(
-        not_exprt(int_min_eq),
+        not_expr(int_min_eq),
         "arithmetic overflow on signed unary minus",
         "overflow",
         expr.find_source_location(),
@@ -839,7 +839,7 @@ void goto_checkt::integer_overflow_check(
         type.id()==ID_unsignedbv?"unsigned":"signed";
 
       add_guarded_property(
-        not_exprt(overflow),
+        not_expr(overflow),
         "arithmetic overflow on " + kind + " " + expr.id_string(),
         "overflow",
         expr.find_source_location(),
@@ -853,7 +853,7 @@ void goto_checkt::integer_overflow_check(
       type.id()==ID_unsignedbv?"unsigned":"signed";
 
     add_guarded_property(
-      not_exprt(overflow),
+      not_expr(overflow),
       "arithmetic overflow on " + kind + " " + expr.id_string(),
       "overflow",
       expr.find_source_location(),
@@ -885,7 +885,7 @@ void goto_checkt::float_overflow_check(
     if(op.type().id() == ID_floatbv)
     {
       // float-to-float
-      or_exprt overflow_check{isinf_exprt(op), not_exprt(isinf_exprt(expr))};
+      or_exprt overflow_check{isinf_exprt(op), not_expr(isinf_exprt(expr))};
 
       add_guarded_property(
         std::move(overflow_check),
@@ -899,7 +899,7 @@ void goto_checkt::float_overflow_check(
     {
       // non-float-to-float
       add_guarded_property(
-        not_exprt(isinf_exprt(expr)),
+        not_expr(isinf_exprt(expr)),
         "arithmetic overflow on floating-point typecast",
         "overflow",
         expr.find_source_location(),
@@ -913,7 +913,7 @@ void goto_checkt::float_overflow_check(
   {
     // Can overflow if dividing by something small
     or_exprt overflow_check(
-      isinf_exprt(to_div_expr(expr).dividend()), not_exprt(isinf_exprt(expr)));
+      isinf_exprt(to_div_expr(expr).dividend()), not_expr(isinf_exprt(expr)));
 
     add_guarded_property(
       std::move(overflow_check),
@@ -944,7 +944,7 @@ void goto_checkt::float_overflow_check(
       or_exprt overflow_check(
         isinf_exprt(to_binary_expr(expr).op0()),
         isinf_exprt(to_binary_expr(expr).op1()),
-        not_exprt(isinf_exprt(expr)));
+        not_expr(isinf_exprt(expr)));
 
       std::string kind=
         expr.id()==ID_plus?"addition":
@@ -1128,7 +1128,7 @@ void goto_checkt::pointer_overflow_check(
   overflow.operands() = expr.operands();
 
   add_guarded_property(
-    not_exprt(overflow),
+    not_expr(overflow),
     "pointer arithmetic overflow on " + expr.id_string(),
     "overflow",
     expr.find_source_location(),
@@ -1211,21 +1211,21 @@ goto_checkt::address_check(const exprt &address, const exprt &size)
       conditions.push_back(conditiont(
         or_exprt(
           in_bounds_of_some_explicit_allocation,
-          not_exprt(null_pointer(address))),
+          not_expr(null_pointer(address))),
         "pointer NULL"));
     }
 
     if(flags.is_unknown())
     {
       conditions.push_back(conditiont{
-        not_exprt{is_invalid_pointer_exprt{address}}, "pointer invalid"});
+        not_expr(is_invalid_pointer_exprt{address}), "pointer invalid"});
     }
 
     if(flags.is_uninitialized())
     {
       conditions.push_back(
         conditiont{or_exprt{in_bounds_of_some_explicit_allocation,
-                            not_exprt{is_invalid_pointer_exprt{address}}},
+                            not_expr(is_invalid_pointer_exprt{address})},
                    "pointer uninitialized"});
     }
 
@@ -1234,7 +1234,7 @@ goto_checkt::address_check(const exprt &address, const exprt &size)
       conditions.push_back(conditiont(
         or_exprt(
           in_bounds_of_some_explicit_allocation,
-          not_exprt(deallocated(address, ns))),
+          not_expr(deallocated(address, ns))),
         "deallocated dynamic object"));
     }
 
@@ -1243,7 +1243,7 @@ goto_checkt::address_check(const exprt &address, const exprt &size)
       conditions.push_back(conditiont(
         or_exprt(
           in_bounds_of_some_explicit_allocation,
-          not_exprt(dead_object(address, ns))),
+          not_expr(dead_object(address, ns))),
         "dead object"));
     }
 
@@ -1257,7 +1257,7 @@ goto_checkt::address_check(const exprt &address, const exprt &size)
         or_exprt(
           in_bounds_of_some_explicit_allocation,
           implies_exprt(
-            malloc_object(address, ns), not_exprt(dynamic_bounds_violation))),
+            malloc_object(address, ns), not_expr(dynamic_bounds_violation))),
         "pointer outside dynamic object bounds"));
     }
 
@@ -1273,8 +1273,8 @@ goto_checkt::address_check(const exprt &address, const exprt &size)
         or_exprt(
           in_bounds_of_some_explicit_allocation,
           implies_exprt(
-            not_exprt(dynamic_object(address)),
-            not_exprt(object_bounds_violation))),
+            not_expr(dynamic_object(address)),
+            not_expr(object_bounds_violation))),
         "pointer outside object bounds"));
     }
 
@@ -1406,7 +1406,7 @@ void goto_checkt::bounds_check(
 
     or_exprt precond(
       std::move(in_bounds_of_some_explicit_allocation),
-      and_exprt(dynamic_object(pointer), not_exprt(malloc_object(pointer, ns))),
+      and_exprt(dynamic_object(pointer), not_expr(malloc_object(pointer, ns))),
       inequality);
 
     add_guarded_property(
@@ -1596,7 +1596,7 @@ void goto_checkt::check_rec_if(const if_exprt &if_expr, guardt &guard)
 
   {
     guardt old_guard = guard;
-    guard.add(not_exprt{if_expr.cond()});
+    guard.add(not_expr(if_expr.cond()));
     check_rec(if_expr.false_case(), guard);
     guard = std::move(old_guard);
   }

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -692,7 +692,7 @@ void rw_guarded_range_set_value_sett::get_objects_if(
 
     guardt copy = guard;
 
-    guard.add(not_exprt(if_expr.cond()));
+    guard.add(not_expr(if_expr.cond()));
     get_objects_rec(mode, if_expr.false_case(), range_start, size);
     guard = copy;
 

--- a/src/analyses/interval_domain.cpp
+++ b/src/analyses/interval_domain.cpp
@@ -88,7 +88,7 @@ void interval_domaint::transform(
     if(from->get_target() != next) // If equal then a skip
     {
       if(next == to)
-        assume(not_exprt(instruction.get_condition()), ns);
+        assume(not_expr(instruction.get_condition()), ns);
       else
         assume(instruction.get_condition(), ns);
     }
@@ -505,7 +505,7 @@ bool interval_domaint::ai_simplify(
   }
   else                                    // Less likely to be representable
   {
-    d.assume(not_exprt(condition), ns);   // Restrict to when condition is false
+    d.assume(not_expr(condition), ns);    // Restrict to when condition is false
     if(d.is_bottom())                     // If there there are none...
     {                                     // Then the condition is always true
       unchanged=condition.is_true();

--- a/src/goto-analyzer/taint_analysis.cpp
+++ b/src/goto-analyzer/taint_analysis.cpp
@@ -180,7 +180,7 @@ void taint_analysist::instrument(
                 address_of_exprt(string_constantt(rule.taint))};
               goto_programt::targett t =
                 insert_before.add(goto_programt::make_assertion(
-                  not_exprt(get_may), instruction.source_location));
+                  not_expr(get_may), instruction.source_location));
               t->source_location.set_property_class(
                 "taint rule " + id2string(rule.id));
               t->source_location.set_comment(rule.message);

--- a/src/goto-checker/goto_symex_fault_localizer.cpp
+++ b/src/goto-checker/goto_symex_fault_localizer.cpp
@@ -84,12 +84,12 @@ bool goto_symex_fault_localizert::check(
     if(v_it->is_true())
       assumptions.push_back(l.first);
     else if(v_it->is_false())
-      assumptions.push_back(solver.handle(not_exprt(l.first)));
+      assumptions.push_back(solver.handle(not_expr(l.first)));
     ++v_it;
   }
 
   // lock the failed assertion
-  assumptions.push_back(solver.handle(not_exprt(failed_step.cond_handle)));
+  assumptions.push_back(solver.handle(not_expr(failed_step.cond_handle)));
 
   solver.push(assumptions);
 

--- a/src/goto-checker/goto_symex_property_decider.cpp
+++ b/src/goto-checker/goto_symex_property_decider.cpp
@@ -73,8 +73,8 @@ void goto_symex_property_decidert::convert_goals()
   {
     // Our goal is to falsify a property, i.e., we will
     // add the negation of the property as goal.
-    goal_pair.second.condition = solver->decision_procedure().handle(
-      not_exprt(goal_pair.second.as_expr()));
+    goal_pair.second.condition =
+      solver->decision_procedure().handle(not_expr(goal_pair.second.as_expr()));
   }
 }
 

--- a/src/goto-instrument/accelerate/accelerate.cpp
+++ b/src/goto-instrument/accelerate/accelerate.cpp
@@ -261,7 +261,7 @@ void acceleratet::make_overflow_loc(
   loop.insert_instruction(overflow_loc);
 
   goto_programt::targett t2 = program.insert_after(
-    loop_end, goto_programt::make_goto(overflow_loc, not_exprt(overflow_var)));
+    loop_end, goto_programt::make_goto(overflow_loc, not_expr(overflow_var)));
   t2->swap(*loop_end);
   overflow_locs[overflow_loc].push_back(t2);
   loop.insert_instruction(t2);
@@ -403,7 +403,7 @@ void acceleratet::add_dirty_checks()
       }
 
       goto_programt::instructiont not_dirty =
-        goto_programt::make_assumption(not_exprt(dirty_var->second));
+        goto_programt::make_assumption(not_expr(dirty_var->second));
       program.insert_before_swap(it, not_dirty);
     }
   }
@@ -603,7 +603,7 @@ void acceleratet::build_state_machine(
       ++it)
   {
     state_machine.assume(
-      not_exprt(equal_exprt(state, from_integer(*it, state.type()))));
+      not_expr(equal_exprt(state, from_integer(*it, state.type()))));
   }
 }
 

--- a/src/goto-instrument/accelerate/acceleration_utils.cpp
+++ b/src/goto-instrument/accelerate/acceleration_utils.cpp
@@ -398,7 +398,7 @@ bool acceleration_utilst::do_assumptions(
     program.assume(*it);
   }
 
-  program.assume(not_exprt(condition));
+  program.assume(not_expr(condition));
 
   program.assign(
     loop_counter,
@@ -427,7 +427,7 @@ bool acceleration_utilst::do_assumptions(
 
   program.add(goto_programt::make_assertion(condition));
 
-  guard=not_exprt(condition);
+  guard = not_expr(condition);
   simplify(guard, ns);
 
 #ifdef DEBUG
@@ -485,7 +485,7 @@ void acceleration_utilst::ensure_no_overflows(scratch_programt &program)
 #endif
 
   instrumenter.add_overflow_checks();
-  program.add(goto_programt::make_assumption(not_exprt(overflow_var)));
+  program.add(goto_programt::make_assumption(not_expr(overflow_var)));
 
   // goto_functionst::goto_functiont fn;
   // fn.body.instructions.swap(program.instructions);
@@ -728,7 +728,7 @@ bool acceleration_utilst::do_arrays(
           ++it)
       {
         idx_touched_operands.push_back(
-          not_exprt(equal_exprt(idx, it->to_expr())));
+          not_expr(equal_exprt(idx, it->to_expr())));
       }
 
       exprt idx_not_touched=conjunction(idx_touched_operands);

--- a/src/goto-instrument/accelerate/all_paths_enumerator.cpp
+++ b/src/goto-instrument/accelerate/all_paths_enumerator.cpp
@@ -136,7 +136,7 @@ void all_paths_enumeratort::extend_path(
 
   if(t->is_goto())
   {
-    guard = not_exprt(t->get_condition());
+    guard = not_expr(t->get_condition());
 
     for(goto_programt::targetst::iterator it=t->targets.begin();
         it != t->targets.end();

--- a/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
+++ b/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
@@ -359,7 +359,7 @@ bool disjunctive_polynomial_accelerationt::find_path(patht &path)
 
       if(taken)
       {
-        not_exprt negated(distinguisher);
+        exprt negated = not_expr(distinguisher);
         distinguisher.swap(negated);
       }
 
@@ -600,7 +600,7 @@ bool disjunctive_polynomial_accelerationt::fit_polynomial(
 
       if(taken)
       {
-        not_exprt negated(distinguisher);
+        exprt negated = not_expr(distinguisher);
         distinguisher.swap(negated);
       }
 
@@ -826,7 +826,7 @@ void disjunctive_polynomial_accelerationt::build_path(
       // If this was a conditional branch (it probably was), figure out
       // if we hit the "taken" or "not taken" branch & accumulate the
       // appropriate guard.
-      cond = not_exprt(t->get_condition());
+      cond = not_expr(t->get_condition());
 
       for(goto_programt::targetst::iterator it=t->targets.begin();
           it!=t->targets.end();

--- a/src/goto-instrument/accelerate/polynomial_accelerator.cpp
+++ b/src/goto-instrument/accelerate/polynomial_accelerator.cpp
@@ -459,7 +459,7 @@ bool polynomial_acceleratort::fit_const(
   scratch_programt program(symbol_table, message_handler);
 
   program.append(body);
-  program.add_instruction(ASSERT)->guard=equal_exprt(target, not_exprt(target));
+  program.add_instruction(ASSERT)->guard=equal_exprt(target, not_expr(target));
 
   try
   {
@@ -599,7 +599,7 @@ void polynomial_acceleratort::assert_for_values(
   exprt overflow_expr;
   overflow.overflow_expr(rhs, overflow_expr);
 
-  program.add(goto_programt::make_assumption(not_exprt(overflow_expr)));
+  program.add(goto_programt::make_assumption(not_expr(overflow_expr)));
 
   rhs=typecast_exprt(rhs, target.type());
 

--- a/src/goto-instrument/accelerate/sat_path_enumerator.cpp
+++ b/src/goto-instrument/accelerate/sat_path_enumerator.cpp
@@ -68,7 +68,7 @@ bool sat_path_enumeratort::next(patht &path)
 
       if(taken)
       {
-        not_exprt negated(distinguisher);
+        exprt negated = not_expr(distinguisher);
         distinguisher.swap(negated);
       }
 
@@ -184,7 +184,7 @@ void sat_path_enumeratort::build_path(
       // If this was a conditional branch (it probably was), figure out
       // if we hit the "taken" or "not taken" branch & accumulate the
       // appropriate guard.
-      cond = not_exprt(t->get_condition());
+      cond = not_expr(t->get_condition());
 
       for(goto_programt::targetst::iterator it=t->targets.begin();
           it!=t->targets.end();

--- a/src/goto-instrument/cover_instrument_branch.cpp
+++ b/src/goto-instrument/cover_instrument_branch.cpp
@@ -55,7 +55,7 @@ void cover_branch_instrumentert::instrument(
     source_locationt source_location = i_it->source_location;
 
     goto_program.insert_before_swap(i_it);
-    *i_it = goto_programt::make_assertion(not_exprt(guard), source_location);
+    *i_it = goto_programt::make_assertion(not_expr(guard), source_location);
     initialize_source_location(i_it, true_comment, function_id);
 
     goto_program.insert_before_swap(i_it);

--- a/src/goto-instrument/cover_instrument_condition.cpp
+++ b/src/goto-instrument/cover_instrument_condition.cpp
@@ -43,7 +43,7 @@ void cover_condition_instrumentert::instrument(
 
       const std::string comment_f = "condition '" + c_string + "' false";
       goto_program.insert_before_swap(i_it);
-      *i_it = goto_programt::make_assertion(not_exprt(c), source_location);
+      *i_it = goto_programt::make_assertion(not_expr(c), source_location);
       initialize_source_location(i_it, comment_f, function_id);
     }
 

--- a/src/goto-instrument/cover_instrument_decision.cpp
+++ b/src/goto-instrument/cover_instrument_decision.cpp
@@ -42,7 +42,7 @@ void cover_decision_instrumentert::instrument(
 
       const std::string comment_f = "decision '" + d_string + "' false";
       goto_program.insert_before_swap(i_it);
-      *i_it = goto_programt::make_assertion(not_exprt(d), source_location);
+      *i_it = goto_programt::make_assertion(not_expr(d), source_location);
       initialize_source_location(i_it, comment_f, function_id);
     }
 

--- a/src/goto-instrument/cover_instrument_mcdc.cpp
+++ b/src/goto-instrument/cover_instrument_mcdc.cpp
@@ -56,9 +56,9 @@ void collect_mcdc_controlling_rec(
 
             for(std::size_t j = 0; j < operands.size(); j++)
             {
-              others1.push_back(not_exprt(operands[j]));
+              others1.push_back(not_expr(operands[j]));
               if(i != j)
-                others2.push_back(not_exprt(operands[j]));
+                others2.push_back(not_expr(operands[j]));
               else
                 others2.push_back((operands[j]));
             }
@@ -88,7 +88,7 @@ void collect_mcdc_controlling_rec(
             if(i != j)
             {
               if(src.id() == ID_or)
-                others.push_back(not_exprt(operands[j]));
+                others.push_back(not_expr(operands[j]));
               else
                 others.push_back(operands[j]);
             }
@@ -661,7 +661,7 @@ void cover_mcdc_instrumentert::instrument(
 
       std::string comment_t = description + " '" + p_string + "' true";
       goto_program.insert_before_swap(i_it);
-      *i_it = goto_programt::make_assertion(not_exprt(p), source_location);
+      *i_it = goto_programt::make_assertion(not_expr(p), source_location);
       i_it->source_location.set_comment(comment_t);
       i_it->source_location.set(ID_coverage_criterion, coverage_criterion);
       i_it->source_location.set_property_class(property_class);
@@ -694,7 +694,7 @@ void cover_mcdc_instrumentert::instrument(
         "MC/DC independence condition '" + p_string + "'";
 
       goto_program.insert_before_swap(i_it);
-      *i_it = goto_programt::make_assertion(not_exprt(p), source_location);
+      *i_it = goto_programt::make_assertion(not_expr(p), source_location);
       i_it->source_location.set_comment(description);
       i_it->source_location.set(ID_coverage_criterion, coverage_criterion);
       i_it->source_location.set_property_class(property_class);

--- a/src/goto-instrument/cover_instrument_other.cpp
+++ b/src/goto-instrument/cover_instrument_other.cpp
@@ -61,7 +61,7 @@ void cover_cover_instrumentert::instrument(
     {
       const exprt c = code_function_call.arguments()[0];
       std::string comment = "condition '" + from_expr(ns, function_id, c) + "'";
-      i_it->guard = not_exprt(c);
+      i_it->guard = not_expr(c);
       i_it->type = ASSERT;
       i_it->code.clear();
       initialize_source_location(i_it, comment, function_id);

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -566,7 +566,7 @@ goto_programt::const_targett goto_program2codet::convert_goto_while(
 
   if(target->get_target()==after_loop)
   {
-    w.cond()=not_exprt(target->guard);
+    w.cond() = not_expr(target->guard);
     simplify(w.cond(), ns);
   }
   else if(target->guard.is_true())
@@ -592,7 +592,7 @@ goto_programt::const_targett goto_program2codet::convert_goto_while(
   }
   else if(!loop_end->guard.is_true())
   {
-    code_ifthenelset i(not_exprt(loop_end->guard), code_breakt());
+    code_ifthenelset i(not_expr(loop_end->guard), code_breakt());
     simplify(i.cond(), ns);
 
     copy_source_location(target, i);
@@ -1064,7 +1064,7 @@ goto_programt::const_targett goto_program2codet::convert_goto_if(
       return convert_goto_goto(target, dest);
   }
 
-  code_ifthenelset i(not_exprt(target->guard), code_blockt());
+  code_ifthenelset i(not_expr(target->guard), code_blockt());
   copy_source_location(target, i);
   simplify(i.cond(), ns);
 
@@ -1706,7 +1706,7 @@ void goto_program2codet::cleanup_code_ifthenelse(
     code.get_statement() == ID_ifthenelse &&
     i_t_e.then_case().get_statement() == ID_skip)
   {
-    not_exprt tmp(i_t_e.cond());
+    exprt tmp = not_expr(i_t_e.cond());
     simplify(tmp, ns);
     // simplification might have removed essential type casts
     cleanup_expr(tmp, false);

--- a/src/goto-instrument/race_check.cpp
+++ b/src/goto-instrument/race_check.cpp
@@ -54,7 +54,7 @@ public:
 
   const exprt get_assertion(const rw_set_baset::entryt &entry)
   {
-    return not_exprt(get_guard_symbol_expr(entry.object));
+    return not_expr(get_guard_symbol_expr(entry.object));
   }
 
   void add_initialization(goto_programt &goto_program) const;

--- a/src/goto-instrument/rw_set.cpp
+++ b/src/goto-instrument/rw_set.cpp
@@ -186,7 +186,7 @@ void _rw_set_loct::read_write_rec(
     read_write_rec(if_expr.true_case(), r, w, suffix, true_guard);
 
     exprt::operandst false_guard = guard_conjuncts;
-    false_guard.push_back(not_exprt(if_expr.cond()));
+    false_guard.push_back(not_expr(if_expr.cond()));
     read_write_rec(if_expr.false_case(), r, w, suffix, false_guard);
   }
   else

--- a/src/goto-instrument/thread_instrumentation.cpp
+++ b/src/goto-instrument/thread_instrumentation.cpp
@@ -46,7 +46,7 @@ void thread_exit_instrumentation(goto_programt &goto_program)
     ID_get_may,
     address_of_exprt(mutex_locked_string)};
 
-  *end = goto_programt::make_assertion(not_exprt(get_may), source_location);
+  *end = goto_programt::make_assertion(not_expr(get_may), source_location);
 
   end->source_location.set_comment("mutexes must not be locked on thread exit");
 }

--- a/src/goto-instrument/wmm/shared_buffers.cpp
+++ b/src/goto-instrument/wmm/shared_buffers.cpp
@@ -316,8 +316,7 @@ void shared_bufferst::write(
   // checking this
   const exprt buff0_used_expr=symbol_exprt(vars.w_buff0_used, bool_typet());
   const exprt buff1_used_expr=symbol_exprt(vars.w_buff1_used, bool_typet());
-  const exprt cond_expr=
-    not_exprt(and_exprt(buff1_used_expr, buff0_used_expr));
+  const exprt cond_expr = not_expr(and_exprt(buff1_used_expr, buff0_used_expr));
 
   target = goto_program.insert_before(
     target, goto_programt::make_assertion(cond_expr, source_location));
@@ -526,16 +525,11 @@ void shared_bufferst::nondet_flush(
     // or buff0 not mine and buff1 unused
     // or buff0 not mine and buff1 not mine
     // -> read from memory (and does not modify the buffer in any aspect)
-    const exprt cond_134_expr=
+    const exprt cond_134_expr = or_exprt(
+      not_expr(buff0_used_expr),
       or_exprt(
-        not_exprt(buff0_used_expr),
-        or_exprt(
-          and_exprt(
-            not_exprt(buff0_thd_expr),
-            not_exprt(buff1_used_expr)),
-          and_exprt(
-            not_exprt(buff0_thd_expr),
-            not_exprt(buff1_thd_expr))));
+        and_exprt(not_expr(buff0_thd_expr), not_expr(buff1_used_expr)),
+        and_exprt(not_expr(buff0_thd_expr), not_expr(buff1_thd_expr))));
     const exprt val_134_expr=lhs;
     const exprt buff0_used_134_expr=buff0_used_expr;
     const exprt buff1_used_134_expr=buff1_used_expr;
@@ -559,12 +553,10 @@ void shared_bufferst::nondet_flush(
     // (5)
     // buff0 and buff1 are used, buff0 is not mine, buff1 is mine
     // -> read from buff1
-    const exprt cond_5_expr=
+    const exprt cond_5_expr = and_exprt(
+      buff0_used_expr,
       and_exprt(
-        buff0_used_expr,
-        and_exprt(
-          buff1_used_expr,
-          and_exprt(not_exprt(buff0_thd_expr), buff1_thd_expr)));
+        buff1_used_expr, and_exprt(not_expr(buff0_thd_expr), buff1_thd_expr)));
     const exprt val_5_expr=buff1_expr;
     const exprt buff0_used_5_expr=buff0_used_expr;
     const exprt buff1_used_5_expr=false_exprt();
@@ -701,7 +693,7 @@ void shared_bufferst::nondet_flush(
     // (1)
     // if buff0 unused
     // -> read from memory (and does not modify the buffer in any aspect)
-    const exprt cond_1_expr=not_exprt(buff0_used_expr);
+    const exprt cond_1_expr = not_expr(buff0_used_expr);
     const exprt val_1_expr=lhs;
     const exprt buff0_used_1_expr=buff0_used_expr;
     const exprt buff1_used_1_expr=buff1_used_expr;
@@ -726,12 +718,9 @@ void shared_bufferst::nondet_flush(
     // (3)
     // if buff0 used and not mine, and buff1 not used
     // -> read from buff0 or memory
-    const exprt cond_3_expr=
-      and_exprt(
-        buff0_used_expr,
-        and_exprt(
-          not_exprt(buff0_thd_expr),
-          not_exprt(buff1_used_expr)));
+    const exprt cond_3_expr = and_exprt(
+      buff0_used_expr,
+      and_exprt(not_expr(buff0_thd_expr), not_expr(buff1_used_expr)));
     const exprt val_3_expr=if_exprt(choice0_expr, buff0_expr, lhs);
     const exprt buff0_used_3_expr=choice0_expr;
     const exprt buff1_used_3_expr=false_exprt();
@@ -743,10 +732,9 @@ void shared_bufferst::nondet_flush(
     // (4)
     // buff0 and buff1 are both used, and both not mine
     // -> read from memory or buff0 or buff1
-    const exprt cond_4_expr=
-      and_exprt(
-        and_exprt(buff0_used_expr, not_exprt(buff1_thd_expr)),
-        and_exprt(buff1_used_expr, not_exprt(buff0_thd_expr)));
+    const exprt cond_4_expr = and_exprt(
+      and_exprt(buff0_used_expr, not_expr(buff1_thd_expr)),
+      and_exprt(buff1_used_expr, not_expr(buff0_thd_expr)));
     const exprt val_4_expr=
       if_exprt(
         choice0_expr,
@@ -755,8 +743,8 @@ void shared_bufferst::nondet_flush(
           choice1_expr,
           buff0_expr,
           buff1_expr));
-    const exprt buff0_used_4_expr=
-      or_exprt(choice0_expr, not_exprt(choice1_expr));
+    const exprt buff0_used_4_expr =
+      or_exprt(choice0_expr, not_expr(choice1_expr));
     const exprt buff1_used_4_expr=choice0_expr;
     const exprt buff0_4_expr=buff0_expr;
     const exprt buff1_4_expr=buff1_expr;
@@ -767,10 +755,9 @@ void shared_bufferst::nondet_flush(
     // (5)
     // buff0 and buff1 are both used, and buff0 not mine, and buff1 mine
     // -> read buff1 or buff0
-    const exprt cond_5_expr=
-      and_exprt(
-        and_exprt(buff0_used_expr, buff1_thd_expr),
-        and_exprt(buff1_used_expr, not_exprt(buff0_thd_expr)));
+    const exprt cond_5_expr = and_exprt(
+      and_exprt(buff0_used_expr, buff1_thd_expr),
+      and_exprt(buff1_used_expr, not_expr(buff0_thd_expr)));
     const exprt val_5_expr=
       if_exprt(
         choice0_expr,

--- a/src/goto-programs/ensure_one_backedge_per_target.cpp
+++ b/src/goto-programs/ensure_one_backedge_per_target.cpp
@@ -57,7 +57,7 @@ bool ensure_one_backedge_per_target(
       goto_program.insert_after(last_backedge, goto_programt::make_goto(it));
     // Turn the existing `if(x) goto head; succ: ...`
     // into `if(!x) goto succ; goto head; succ: ...`
-    last_backedge->guard = not_exprt(last_backedge->guard);
+    last_backedge->guard = not_expr(last_backedge->guard);
     last_backedge->set_target(std::next(new_goto));
     // Use the new backedge as the one true way to the header:
     last_backedge = new_goto;

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -401,7 +401,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
       }
     }
 
-    not_exprt no_write(write_guard.as_expr());
+    not_exprt no_write = not_expr(write_guard.as_expr());
 
     // we cannot determine for sure that there has been a write already
     // so generate a read even if l1_identifier has been written on

--- a/src/goto-symex/memory_model_sc.cpp
+++ b/src/goto-symex/memory_model_sc.cpp
@@ -237,7 +237,7 @@ void memory_model_sct::write_serialization_external(
 
         add_constraint(
           equation,
-          implies_exprt(not_exprt(s), before(*w_it2, *w_it1)),
+          implies_exprt(not_expr(s), before(*w_it2, *w_it1)),
           "ws-ext",
           (*w_it1)->source);
       }

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -355,7 +355,7 @@ void symex_assignt::assign_if(
   assign_rec(lhs.true_case(), full_lhs, rhs, guard);
   guard.pop_back();
 
-  guard.push_back(not_exprt(lhs.cond()));
+  guard.push_back(not_expr(lhs.cond()));
   assign_rec(lhs.false_case(), full_lhs, rhs, guard);
   guard.pop_back();
 }

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -259,7 +259,7 @@ void goto_symext::symex_goto(statet &state)
       if(new_guard.is_true())
         symex_assume_l2(state, false_exprt());
       else
-        symex_assume_l2(state, not_exprt(new_guard));
+        symex_assume_l2(state, not_expr(new_guard));
 
       // next instruction
       symex_transition(state);
@@ -773,7 +773,7 @@ void goto_symext::loop_bound_exceeded(
   if(guard.is_true())
     negated_cond=false_exprt();
   else
-    negated_cond=not_exprt(guard);
+    negated_cond = not_expr(guard);
 
   if(!symex_config.partial_loops)
   {

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -52,7 +52,7 @@ void goto_symext::havoc_rec(
     havoc_rec(state, guard_t, if_expr.true_case());
 
     guardt guard_f=state.guard;
-    guard_f.add(not_exprt(if_expr.cond()));
+    guard_f.add(not_expr(if_expr.cond()));
     havoc_rec(state, guard_f, if_expr.false_case());
   }
   else if(dest.id()==ID_typecast)

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -510,7 +510,7 @@ void symex_target_equationt::convert_assertions(
       step.cond_handle = decision_procedure.handle(implication);
 
       // store disjunct
-      disjuncts.push_back(not_exprt(step.cond_handle));
+      disjuncts.push_back(not_expr(step.cond_handle));
     }
     else if(step.is_assume())
     {

--- a/src/solvers/prop/bdd_expr.cpp
+++ b/src/solvers/prop/bdd_expr.cpp
@@ -133,7 +133,7 @@ exprt bdd_exprt::as_expr(
         {
           if(r.else_branch().is_complement()) // else is false
             return n_expr;
-          return not_exprt(n_expr); // else is true
+          return not_expr(n_expr); // else is true
         }
         else
         {
@@ -143,7 +143,7 @@ exprt bdd_exprt::as_expr(
             return make_and(n_expr, then_case);
           }
           exprt then_case = as_expr(r.then_branch(), cache);
-          return make_or(not_exprt(n_expr), then_case);
+          return make_or(not_expr(n_expr), then_case);
         }
       }
       else if(r.then_branch().is_constant())
@@ -151,7 +151,7 @@ exprt bdd_exprt::as_expr(
         if(r.then_branch().is_complement()) // then is false
         {
           exprt else_case = as_expr(r.else_branch(), cache);
-          return make_and(not_exprt(n_expr), else_case);
+          return make_and(not_expr(n_expr), else_case);
         }
         exprt else_case = as_expr(r.else_branch(), cache);
         return make_or(n_expr, else_case);

--- a/src/solvers/qbf/qbf_bdd_core.cpp
+++ b/src/solvers/qbf/qbf_bdd_core.cpp
@@ -305,7 +305,7 @@ const exprt qbf_bdd_certificatet::f_get(literalt l)
       #endif
 
       if(l.sign())
-        return not_exprt(it->second);
+        return not_expr(it->second);
       else
         return it->second;
     }
@@ -379,7 +379,7 @@ const exprt qbf_bdd_certificatet::f_get(literalt l)
     function_cache[l.var_no()]=final;
 
     if(l.sign())
-      return not_exprt(final);
+      return not_expr(final);
     else
       return final;
   }

--- a/src/solvers/qbf/qbf_squolem_core.cpp
+++ b/src/solvers/qbf/qbf_squolem_core.cpp
@@ -215,7 +215,7 @@ const exprt qbf_squolem_coret::f_get(literalt l)
     #endif
 
     if(l.sign())
-      return not_exprt(it->second);
+      return not_expr(it->second);
     else
       return it->second;
   }
@@ -237,7 +237,7 @@ const exprt qbf_squolem_coret::f_get(literalt l)
     function_cache[l.var_no()]=res;
 
     if(l.sign())
-      return not_exprt(res);
+      return not_expr(res);
     else
       return res;
   }

--- a/src/solvers/strings/string_constraint.h
+++ b/src/solvers/strings/string_constraint.h
@@ -100,7 +100,7 @@ public:
 
   exprt negation() const
   {
-    return and_exprt(univ_within_bounds(), not_exprt(body));
+    return and_exprt(univ_within_bounds(), not_expr(body));
   }
 };
 

--- a/src/solvers/strings/string_constraint_generator_code_points.cpp
+++ b/src/solvers/strings/string_constraint_generator_code_points.cpp
@@ -46,7 +46,7 @@ string_constraint_generatort::add_axioms_for_code_point(
   constraints.existential.push_back(a1);
 
   implies_exprt a2(
-    not_exprt(small), equal_to(array_pool.get_or_create_length(res), 2));
+    not_expr(small), equal_to(array_pool.get_or_create_length(res), 2));
   constraints.existential.push_back(a2);
 
   typecast_exprt code_point_as_char(code_point, char_type);
@@ -56,13 +56,13 @@ string_constraint_generatort::add_axioms_for_code_point(
   plus_exprt first_char(
     hexD800, div_exprt(minus_exprt(code_point, hex010000), hex0400));
   implies_exprt a4(
-    not_exprt(small),
+    not_expr(small),
     equal_exprt(res[0], typecast_exprt(first_char, char_type)));
   constraints.existential.push_back(a4);
 
   plus_exprt second_char(hexDC00, mod_exprt(code_point, hex0400));
   implies_exprt a5(
-    not_exprt(small),
+    not_expr(small),
     equal_exprt(res[1], typecast_exprt(second_char, char_type)));
   constraints.existential.push_back(a5);
 
@@ -142,7 +142,7 @@ string_constraint_generatort::add_axioms_for_code_point_at(
   constraints.existential.push_back(
     implies_exprt(return_pair, equal_exprt(result, pair)));
   constraints.existential.push_back(
-    implies_exprt(not_exprt(return_pair), equal_exprt(result, char1_as_int)));
+    implies_exprt(not_expr(return_pair), equal_exprt(result, char1_as_int)));
   return {result, constraints};
 }
 
@@ -176,7 +176,7 @@ string_constraint_generatort::add_axioms_for_code_point_before(
   constraints.existential.push_back(
     implies_exprt(return_pair, equal_exprt(result, pair)));
   constraints.existential.push_back(
-    implies_exprt(not_exprt(return_pair), equal_exprt(result, char2_as_int)));
+    implies_exprt(not_expr(return_pair), equal_exprt(result, char2_as_int)));
   return {result, constraints};
 }
 

--- a/src/solvers/strings/string_constraint_generator_comparison.cpp
+++ b/src/solvers/strings/string_constraint_generator_comparison.cpp
@@ -73,7 +73,7 @@ string_constraint_generatort::add_axioms_for_equals(
         array_pool.get_or_create_length(s1),
         array_pool.get_or_create_length(s2)),
       equal_exprt(witness, from_integer(-1, index_type)));
-    return implies_exprt(not_exprt(eq), or_exprt(diff_length, witnessing));
+    return implies_exprt(not_expr(eq), or_exprt(diff_length, witnessing));
   }());
 
   return {tc_eq, std::move(constraints)};
@@ -171,9 +171,9 @@ string_constraint_generatort::add_axioms_for_equals_ignore_case(
     binary_relation_exprt(witness, ID_ge, zero));
   const exprt witness_eq = character_equals_ignore_case(
     s1[witness], s2[witness], char_a, char_A, char_Z);
-  const not_exprt witness_diff(witness_eq);
+  const exprt witness_diff = not_expr(witness_eq);
   const implies_exprt a3(
-    not_exprt(eq),
+    not_expr(eq),
     or_exprt(
       notequal_exprt(
         array_pool.get_or_create_length(s1),
@@ -267,7 +267,7 @@ string_constraint_generatort::add_axioms_for_compare_to(
   const and_exprt cond2(ret_length_diff, guard2);
 
   const implies_exprt a3(
-    not_exprt(res_null),
+    not_expr(res_null),
     and_exprt(
       binary_relation_exprt(x, ID_ge, from_integer(0, return_type)),
       or_exprt(cond1, cond2)));
@@ -277,7 +277,7 @@ string_constraint_generatort::add_axioms_for_compare_to(
   const string_constraintt a4(
     i2,
     zero_if_negative(x),
-    implies_exprt(not_exprt(res_null), equal_exprt(s1[i2], s2[i2])));
+    implies_exprt(not_expr(res_null), equal_exprt(s1[i2], s2[i2])));
   constraints.universal.push_back(a4);
 
   return {res, std::move(constraints)};

--- a/src/solvers/strings/string_constraint_generator_constants.cpp
+++ b/src/solvers/strings/string_constraint_generator_constants.cpp
@@ -88,7 +88,7 @@ string_constraint_generatort::add_axioms_for_cprover_string(
   if(const auto if_expr = expr_try_dynamic_cast<if_exprt>(arg))
   {
     const and_exprt guard_true(guard, if_expr->cond());
-    const and_exprt guard_false(guard, not_exprt(if_expr->cond()));
+    const and_exprt guard_false(guard, not_expr(if_expr->cond()));
     return combine_results(
       add_axioms_for_cprover_string(res, if_expr->true_case(), guard_true),
       add_axioms_for_cprover_string(res, if_expr->false_case(), guard_false));

--- a/src/solvers/strings/string_constraint_generator_float.cpp
+++ b/src/solvers/strings/string_constraint_generator_float.cpp
@@ -298,7 +298,7 @@ string_constraint_generatort::add_axioms_for_fractional_part(
     // There are no trailing zeros except for ".0" (i.e j=2)
     if(j > 1)
     {
-      not_exprt no_trailing_zero(and_exprt(
+      exprt no_trailing_zero = not_expr(and_exprt(
         equal_exprt(
           array_pool.get_or_create_length(res),
           from_integer(j + 1, res.length_type())),

--- a/src/solvers/strings/string_constraint_generator_indexof.cpp
+++ b/src/solvers/strings/string_constraint_generator_indexof.cpp
@@ -51,7 +51,7 @@ string_constraint_generatort::add_axioms_for_index_of(
     binary_relation_exprt(index, ID_lt, array_pool.get_or_create_length(str)));
   constraints.existential.push_back(a1);
 
-  equal_exprt a2(not_exprt(contains), equal_exprt(index, minus1));
+  equal_exprt a2(not_expr(contains), equal_exprt(index, minus1));
   constraints.existential.push_back(a2);
 
   implies_exprt a3(
@@ -76,7 +76,7 @@ string_constraint_generatort::add_axioms_for_index_of(
     m,
     lower_bound,
     zero_if_negative(array_pool.get_or_create_length(str)),
-    implies_exprt(not_exprt(contains), not_exprt(equal_exprt(str[m], c))));
+    implies_exprt(not_expr(contains), not_expr(equal_exprt(str[m], c))));
   constraints.universal.push_back(a5);
 
   return {index, std::move(constraints)};
@@ -130,7 +130,7 @@ string_constraint_generatort::add_axioms_for_index_of_string(
   constraints.existential.push_back(a1);
 
   equal_exprt a2(
-    not_exprt(contains), equal_exprt(offset, from_integer(-1, index_type)));
+    not_expr(contains), equal_exprt(offset, from_integer(-1, index_type)));
   constraints.existential.push_back(a2);
 
   symbol_exprt qvar = fresh_symbol("QA_index_of_string", index_type);
@@ -160,7 +160,7 @@ string_constraint_generatort::add_axioms_for_index_of_string(
         array_pool.get_or_create_length(haystack),
         array_pool.get_or_create_length(needle)),
       from_integer(1, index_type)),
-    not_exprt(contains),
+    not_expr(contains),
     from_integer(0, index_type),
     array_pool.get_or_create_length(needle),
     haystack,
@@ -231,7 +231,7 @@ string_constraint_generatort::add_axioms_for_last_index_of_string(
   constraints.existential.push_back(a1);
 
   equal_exprt a2(
-    not_exprt(contains), equal_exprt(offset, from_integer(-1, index_type)));
+    not_expr(contains), equal_exprt(offset, from_integer(-1, index_type)));
   constraints.existential.push_back(a2);
 
   symbol_exprt qvar = fresh_symbol("QA_index_of_string", index_type);
@@ -264,7 +264,7 @@ string_constraint_generatort::add_axioms_for_last_index_of_string(
   string_not_contains_constraintt a5 = {
     from_integer(0, index_type),
     plus_exprt(end_index, from_integer(1, index_type)),
-    not_exprt(contains),
+    not_expr(contains),
     from_integer(0, index_type),
     array_pool.get_or_create_length(needle),
     haystack,
@@ -396,7 +396,7 @@ string_constraint_generatort::add_axioms_for_last_index_of(
   const string_constraintt a5(
     m,
     zero_if_negative(end_index),
-    implies_exprt(not_exprt(contains), notequal_exprt(str[m], c)));
+    implies_exprt(not_expr(contains), notequal_exprt(str[m], c)));
   constraints.universal.push_back(a5);
 
   return {index, std::move(constraints)};

--- a/src/solvers/strings/string_constraint_generator_testing.cpp
+++ b/src/solvers/strings/string_constraint_generator_testing.cpp
@@ -75,12 +75,12 @@ string_constraint_generatort::add_axioms_for_is_prefix(
       greater_than(array_pool.get_or_create_length(prefix), witness),
       notequal_exprt(str[plus_exprt(witness, offset)], prefix[witness]));
     const exprt s1_does_not_start_with_s0 = or_exprt(
-      not_exprt(offset_within_bounds),
-      not_exprt(greater_or_equal_to(
+      not_expr(offset_within_bounds),
+      not_expr(greater_or_equal_to(
         array_pool.get_or_create_length(str),
         plus_exprt(array_pool.get_or_create_length(prefix), offset))),
       strings_differ_at_witness);
-    return implies_exprt(not_exprt(isprefix), s1_does_not_start_with_s0);
+    return implies_exprt(not_expr(isprefix), s1_does_not_start_with_s0);
   }());
 
   return {isprefix, std::move(constraints)};
@@ -220,7 +220,7 @@ string_constraint_generatort::add_axioms_for_is_suffix(
       and_exprt(
         greater_than(array_pool.get_or_create_length(s0), witness),
         is_positive(witness))));
-  implies_exprt a3(not_exprt(issuffix), constr3);
+  implies_exprt a3(not_expr(issuffix), constr3);
 
   constraints.existential.push_back(a3);
   return {tc_issuffix, std::move(constraints)};
@@ -272,7 +272,7 @@ string_constraint_generatort::add_axioms_for_contains(
   constraints.existential.push_back(a2);
 
   implies_exprt a3(
-    not_exprt(contains), equal_exprt(startpos, from_integer(-1, index_type)));
+    not_expr(contains), equal_exprt(startpos, from_integer(-1, index_type)));
   constraints.existential.push_back(a3);
 
   symbol_exprt qvar = fresh_symbol("QA_contains", index_type);
@@ -287,7 +287,7 @@ string_constraint_generatort::add_axioms_for_contains(
     from_integer(0, index_type),
     plus_exprt(from_integer(1, index_type), length_diff),
     and_exprt(
-      not_exprt(contains),
+      not_expr(contains),
       greater_or_equal_to(
         array_pool.get_or_create_length(s0),
         array_pool.get_or_create_length(s1))),

--- a/src/solvers/strings/string_constraint_generator_transformation.cpp
+++ b/src/solvers/strings/string_constraint_generator_transformation.cpp
@@ -326,7 +326,7 @@ string_constraint_generatort::add_axioms_for_replace(
     implies_exprt case1(
       equal_exprt(str[qvar], old_char), equal_exprt(res[qvar], new_char));
     implies_exprt case2(
-      not_exprt(equal_exprt(str[qvar], old_char)),
+      not_expr(equal_exprt(str[qvar], old_char)),
       equal_exprt(res[qvar], str[qvar]));
     string_constraintt a2(
       qvar,

--- a/src/solvers/strings/string_constraint_generator_valueof.cpp
+++ b/src/solvers/strings/string_constraint_generator_valueof.cpp
@@ -92,14 +92,14 @@ string_constraint_generatort::add_axioms_from_bool(
 
   std::string str_false = "false";
   const implies_exprt a3(
-    not_exprt(eq),
+    not_expr(eq),
     equal_to(array_pool.get_or_create_length(res), str_false.length()));
   constraints.existential.push_back(a3);
 
   for(std::size_t i = 0; i < str_false.length(); i++)
   {
     exprt chr = from_integer(str_false[i], char_type);
-    implies_exprt a4(not_exprt(eq), equal_exprt(res[i], chr));
+    implies_exprt a4(not_expr(eq), equal_exprt(res[i], chr));
     constraints.existential.push_back(a4);
   }
 
@@ -248,7 +248,7 @@ string_constraint_generatort::add_axioms_from_int_hex(
     // disallow 0s at the beginning
     if(size > 1)
       constraints.existential.push_back(
-        implies_exprt(premise, not_exprt(equal_exprt(res[0], zero_char))));
+        implies_exprt(premise, not_expr(equal_exprt(res[0], zero_char))));
   }
   return {from_integer(0, get_return_code_type()), std::move(constraints)};
 }
@@ -352,7 +352,7 @@ string_constraint_generatort::add_axioms_for_correct_number_format(
 
     // no_leading_zero_after_minus : str[0]='-' => str[1]!='0'
     implies_exprt no_leading_zero_after_minus(
-      starts_with_minus, not_exprt(equal_exprt(str[1], zero_char)));
+      starts_with_minus, not_expr(equal_exprt(str[1], zero_char)));
     constraints.existential.push_back(no_leading_zero_after_minus);
   }
   return constraints;
@@ -443,7 +443,7 @@ string_constraint_generatort::add_axioms_for_characters_in_integer_string(
     }
 
     const implies_exprt a6(
-      and_exprt(premise, not_exprt(starts_with_minus)),
+      and_exprt(premise, not_expr(starts_with_minus)),
       equal_exprt(input_int, sum));
     constraints.existential.push_back(a6);
 

--- a/src/solvers/strings/string_format_builtin_function.cpp
+++ b/src/solvers/strings/string_format_builtin_function.cpp
@@ -166,7 +166,7 @@ add_axioms_for_format_specifier(
                 equal_exprt{res[2], from_integer('l', char_type)},
                 equal_exprt{res[3], from_integer('l', char_type)}}});
     constraints.existential.push_back(implies_exprt{
-      not_exprt{is_null_literal},
+      not_expr(is_null_literal),
       equal_exprt{res[0], typecast_exprt{string_expr[3], char_type}}});
     return {res, constraints};
   }

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -284,7 +284,7 @@ void string_refinementt::set_to(const exprt &expr, bool value)
   PRECONDITION(expr.type().id() == ID_bool);
   PRECONDITION(equality_propagation);
   if(!value)
-    equations.push_back(not_exprt{expr});
+    equations.push_back(not_expr(expr));
   else
     equations.push_back(expr);
 }

--- a/src/statement-list/converters/expr2statement_list.cpp
+++ b/src/statement-list/converters/expr2statement_list.cpp
@@ -67,7 +67,7 @@ instrument_equal_operands(const exprt &lhs, const exprt &rhs)
   {
     // lhs == rhs is equivalent to X lhs; XN rhs;
     result.push_back(lhs);
-    result.push_back(not_exprt{rhs});
+    result.push_back(not_expr(rhs));
   }
   else if(ID_not != lhs.id() && ID_not == rhs.id())
   {

--- a/src/statement-list/statement_list_typecheck.cpp
+++ b/src/statement-list/statement_list_typecheck.cpp
@@ -761,7 +761,7 @@ void statement_list_typecheckt::typecheck_statement_list_not(
   typecheck_instruction_without_operand(op_code);
   if(fc_bit)
   {
-    const not_exprt unsimplified{rlo_bit};
+    const exprt unsimplified = not_expr(rlo_bit);
     rlo_bit = simplify_expr(unsimplified, namespacet(symbol_table));
     or_bit = false;
   }
@@ -845,7 +845,7 @@ void statement_list_typecheckt::typecheck_statement_list_or_not(
   const symbol_exprt &sym{
     typecheck_instruction_with_non_const_operand(op_code)};
   const exprt op{typecheck_identifier(tia_element, sym.get_identifier())};
-  const not_exprt not_op{op};
+  const exprt not_op = not_expr(op);
 
   // If inside of a bit string, create an 'or' expression with the operand and
   // the current contents of the rlo bit.
@@ -886,7 +886,7 @@ void statement_list_typecheckt::typecheck_statement_list_xor_not(
   const symbol_exprt &sym{
     typecheck_instruction_with_non_const_operand(op_code)};
   const exprt op{typecheck_identifier(tia_element, sym.get_identifier())};
-  const not_exprt not_op{op};
+  const exprt not_op = not_expr(op);
 
   // If inside of a bit string, create an 'xor not' expression with the
   // operand and the current contents of the rlo bit.
@@ -988,12 +988,12 @@ void statement_list_typecheckt::typecheck_statement_list_nesting_closed(
   {
     if(or_bit)
     {
-      const not_exprt op{rlo_bit};
+      const exprt op = not_expr(rlo_bit);
       rlo_bit = nesting_stack.back().rlo_bit;
       add_to_or_rlo_wrapper(op);
     }
     else
-      rlo_bit = and_exprt{nesting_stack.back().rlo_bit, not_exprt{rlo_bit}};
+      rlo_bit = and_exprt{nesting_stack.back().rlo_bit, not_expr(rlo_bit)};
   }
   else if(ID_statement_list_or_nested == statement)
   {
@@ -1003,7 +1003,7 @@ void statement_list_typecheckt::typecheck_statement_list_nesting_closed(
   else if(ID_statement_list_or_not_nested == statement)
   {
     or_bit = false;
-    rlo_bit = or_exprt{nesting_stack.back().rlo_bit, not_exprt{rlo_bit}};
+    rlo_bit = or_exprt{nesting_stack.back().rlo_bit, not_expr(rlo_bit)};
   }
   else if(ID_statement_list_xor_nested == statement)
   {
@@ -1013,7 +1013,7 @@ void statement_list_typecheckt::typecheck_statement_list_nesting_closed(
   else if(ID_statement_list_xor_not_nested == statement)
   {
     or_bit = false;
-    rlo_bit = xor_exprt{nesting_stack.back().rlo_bit, not_exprt{rlo_bit}};
+    rlo_bit = xor_exprt{nesting_stack.back().rlo_bit, not_expr(rlo_bit)};
   }
   nesting_stack.pop_back();
 }
@@ -1240,7 +1240,7 @@ exprt statement_list_typecheckt::typecheck_simple_boolean_instruction_operand(
   const symbol_exprt &sym{
     typecheck_instruction_with_non_const_operand(op_code)};
   const exprt op{typecheck_identifier(tia_element, sym.get_identifier())};
-  const not_exprt not_op{op};
+  const exprt not_op = not_expr(op);
   return negate ? not_op : op;
 }
 

--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -133,7 +133,7 @@ exprt boolean_negate(const exprt &src)
   else if(src.is_false())
     return true_exprt();
   else
-    return not_exprt(src);
+    return not_expr(src);
 }
 
 bool has_subexpr(

--- a/src/util/pointer_predicates.cpp
+++ b/src/util/pointer_predicates.cpp
@@ -91,27 +91,27 @@ exprt good_pointer_def(
   CHECK_RETURN(size_of_expr_opt.has_value());
 
   const or_exprt good_dynamic_tmp1(
-    not_exprt(malloc_object(pointer, ns)),
+    not_expr(malloc_object(pointer, ns)),
     and_exprt(
-      not_exprt(dynamic_object_lower_bound(pointer, nil_exprt())),
-      not_exprt(
+      not_expr(dynamic_object_lower_bound(pointer, nil_exprt())),
+      not_expr(
         dynamic_object_upper_bound(pointer, ns, size_of_expr_opt.value()))));
 
   const and_exprt good_dynamic_tmp2(
-    not_exprt(deallocated(pointer, ns)), good_dynamic_tmp1);
+    not_expr(deallocated(pointer, ns)), good_dynamic_tmp1);
 
   const or_exprt good_dynamic(
-    not_exprt(dynamic_object(pointer)), good_dynamic_tmp2);
+    not_expr(dynamic_object(pointer)), good_dynamic_tmp2);
 
-  const not_exprt not_null(null_pointer(pointer));
+  const exprt not_null = not_expr(null_pointer(pointer));
 
-  const not_exprt not_invalid{is_invalid_pointer_exprt{pointer}};
+  const exprt not_invalid = not_expr(is_invalid_pointer_exprt{pointer});
 
   const or_exprt bad_other(
     object_lower_bound(pointer, nil_exprt()),
     object_upper_bound(pointer, size_of_expr_opt.value()));
 
-  const or_exprt good_other(dynamic_object(pointer), not_exprt(bad_other));
+  const or_exprt good_other(dynamic_object(pointer), not_expr(bad_other));
 
   return and_exprt(
     not_null,

--- a/src/util/simplify_expr_boolean.cpp
+++ b/src/util/simplify_expr_boolean.cpp
@@ -40,7 +40,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_boolean(const exprt &expr)
 
     binary_exprt new_expr = implies_expr;
     new_expr.id(ID_or);
-    new_expr.op0() = simplify_not(not_exprt(new_expr.op0()));
+    new_expr.op0() = simplify_not(not_expr(new_expr.op0()));
     return changed(simplify_node(new_expr));
   }
   else if(expr.id()==ID_xor)
@@ -82,7 +82,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_boolean(const exprt &expr)
     else if(new_operands.size() == 1)
     {
       if(negate)
-        return changed(simplify_not(not_exprt(new_operands.front())));
+        return changed(simplify_not(not_expr(new_operands.front())));
       else
         return std::move(new_operands.front());
     }
@@ -191,7 +191,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_not(const not_exprt &expr)
 
     Forall_operands(it, tmp)
     {
-      *it = simplify_not(not_exprt(*it));
+      *it = simplify_not(not_expr(*it));
     }
 
     tmp.id(tmp.id() == ID_and ? ID_or : ID_and);
@@ -208,7 +208,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_not(const not_exprt &expr)
   {
     auto const &op_as_exists = to_exists_expr(op);
     forall_exprt rewritten_op(
-      op_as_exists.symbol(), not_exprt(op_as_exists.where()));
+      op_as_exists.symbol(), not_expr(op_as_exists.where()));
     rewritten_op.where() = simplify_node(rewritten_op.where());
     return std::move(rewritten_op);
   }
@@ -216,7 +216,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_not(const not_exprt &expr)
   {
     auto const &op_as_forall = to_forall_expr(op);
     exists_exprt rewritten_op(
-      op_as_forall.symbol(), not_exprt(op_as_forall.where()));
+      op_as_forall.symbol(), not_expr(op_as_forall.where()));
     rewritten_op.where() = simplify_node(rewritten_op.where());
     return std::move(rewritten_op);
   }

--- a/src/util/simplify_expr_floatbv.cpp
+++ b/src/util/simplify_expr_floatbv.cpp
@@ -366,7 +366,7 @@ simplify_exprt::simplify_ieee_float_relation(const binary_relation_exprt &expr)
     {
     }
     else if(expr.id()==ID_ieee_float_equal)
-      isnan = not_exprt(isnan);
+      isnan = not_expr(isnan);
     else
       UNREACHABLE;
 

--- a/src/util/simplify_expr_if.cpp
+++ b/src/util/simplify_expr_if.cpp
@@ -353,7 +353,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_if(const if_exprt &expr)
       else if(truevalue.is_false() && falsevalue.is_true())
       {
         // a?0:1 <-> !a
-        return changed(simplify_not(not_exprt(cond)));
+        return changed(simplify_not(not_expr(cond)));
       }
       else if(falsevalue.is_false())
       {
@@ -364,7 +364,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_if(const if_exprt &expr)
       {
         // a?b:1 <-> !a OR b
         return changed(
-          simplify_node(or_exprt(simplify_not(not_exprt(cond)), truevalue)));
+          simplify_node(or_exprt(simplify_not(not_expr(cond)), truevalue)));
       }
       else if(truevalue.is_true())
       {
@@ -375,7 +375,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_if(const if_exprt &expr)
       {
         // a?0:b <-> !a && b
         return changed(
-          simplify_node(and_exprt(simplify_not(not_exprt(cond)), falsevalue)));
+          simplify_node(and_exprt(simplify_not(not_expr(cond)), falsevalue)));
       }
     }
   }

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -1477,7 +1477,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_no_constant(
     auto new_rel_expr = expr;
     new_rel_expr.id(ID_equal);
     auto new_expr = simplify_inequality_no_constant(new_rel_expr);
-    return changed(simplify_not(not_exprt(new_expr)));
+    return changed(simplify_not(not_expr(new_expr)));
   }
   else if(expr.id()==ID_gt)
   {
@@ -1486,14 +1486,14 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_no_constant(
     // swap operands
     new_rel_expr.lhs().swap(new_rel_expr.rhs());
     auto new_expr = simplify_inequality_no_constant(new_rel_expr);
-    return changed(simplify_not(not_exprt(new_expr)));
+    return changed(simplify_not(not_expr(new_expr)));
   }
   else if(expr.id()==ID_lt)
   {
     auto new_rel_expr = expr;
     new_rel_expr.id(ID_ge);
     auto new_expr = simplify_inequality_no_constant(new_rel_expr);
-    return changed(simplify_not(not_exprt(new_expr)));
+    return changed(simplify_not(not_expr(new_expr)));
   }
   else if(expr.id()==ID_le)
   {
@@ -1608,7 +1608,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_rhs_is_constant(
       auto new_rel_expr = expr;
       new_rel_expr.id(ID_equal);
       auto new_expr = simplify_inequality_rhs_is_constant(new_rel_expr);
-      return changed(simplify_not(not_exprt(new_expr)));
+      return changed(simplify_not(not_expr(new_expr)));
     }
 
     // very special case for pointers
@@ -1790,7 +1790,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_rhs_is_constant(
     // we re-write (TYPE)boolean == 0 -> !boolean
     if(expr.op1().is_zero() && expr.id()==ID_equal)
     {
-      return changed(simplify_not(not_exprt(lhs_typecast_op)));
+      return changed(simplify_not(not_expr(lhs_typecast_op)));
     }
 
     // we re-write (TYPE)boolean != 0 -> boolean
@@ -1813,7 +1813,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_rhs_is_constant(
       auto new_rel_expr = expr;
       new_rel_expr.id(ID_equal);
       auto new_expr = simplify_inequality_rhs_is_constant(new_rel_expr);
-      return changed(simplify_not(not_exprt(new_expr)));
+      return changed(simplify_not(not_expr(new_expr)));
     }
     else if(expr.id()==ID_gt)
     {
@@ -1835,7 +1835,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_rhs_is_constant(
       auto new_rel_expr = expr;
       new_rel_expr.id(ID_ge);
       auto new_expr = simplify_inequality_rhs_is_constant(new_rel_expr);
-      return changed(simplify_not(not_exprt(new_expr)));
+      return changed(simplify_not(not_expr(new_expr)));
     }
     else if(expr.id()==ID_le)
     {
@@ -1851,7 +1851,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_rhs_is_constant(
       ++i;
       new_rel_expr.op1() = from_integer(i, new_rel_expr.op1().type());
       auto new_expr = simplify_inequality_rhs_is_constant(new_rel_expr);
-      return changed(simplify_not(not_exprt(new_expr)));
+      return changed(simplify_not(not_expr(new_expr)));
     }
   }
 #endif

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -2994,12 +2994,22 @@ inline address_of_exprt &to_address_of_expr(exprt &expr)
 /// \brief Boolean negation
 class not_exprt:public unary_exprt
 {
-public:
-  explicit not_exprt(exprt _op) : unary_exprt(ID_not, std::move(_op))
+private:
+  /// This constructor is private to avoid ambiguity with the copy constructor.
+  /// Use \ref not_expr to construct a \c not_exprt object.
+  explicit not_exprt(exprt op) : unary_exprt{ID_not, std::move(op)}
   {
-    PRECONDITION(as_const(*this).op().type().id() == ID_bool);
   }
+
+  friend not_exprt not_expr(exprt e);
 };
+
+/// Constructor for \ref not_exprt objects.
+inline not_exprt not_expr(exprt e)
+{
+  PRECONDITION(as_const(e).type().id() == ID_bool);
+  return not_exprt{std::move(e)};
+}
 
 template <>
 inline bool can_cast_expr<not_exprt>(const exprt &base)

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -2999,11 +2999,6 @@ public:
   {
     PRECONDITION(as_const(*this).op().type().id() == ID_bool);
   }
-
-  DEPRECATED(SINCE(2019, 1, 12, "use not_exprt(op) instead"))
-  not_exprt():unary_exprt(ID_not, bool_typet())
-  {
-  }
 };
 
 template <>

--- a/unit/analyses/constant_propagator.cpp
+++ b/unit/analyses/constant_propagator.cpp
@@ -133,7 +133,7 @@ SCENARIO("constant_propagator", "[core][analyses][constant_propagator]")
                       code_declt(c_bool_local.symbol_expr())});
 
     code_ifthenelset bool_cond_block(
-      not_exprt(bool_local.symbol_expr()),
+      not_expr(bool_local.symbol_expr()),
       code_assignt(bool_local.symbol_expr(), true_exprt()));
 
     const exprt c_bool_true = from_integer(1, c_bool_typet(8));
@@ -233,7 +233,7 @@ SCENARIO("constant_propagator", "[core][analyses][constant_propagator]")
 
     const exprt bool_tests[] = {
       bool_locals.at(0).symbol_expr(),
-      not_exprt(bool_locals.at(1).symbol_expr()),
+      not_expr(bool_locals.at(1).symbol_expr()),
       and_exprt(
         bool_locals.at(2).symbol_expr(), bool_locals.at(3).symbol_expr()),
       equal_exprt(bool_locals.at(4).symbol_expr(), true_exprt()),

--- a/unit/goto-symex/apply_condition.cpp
+++ b/unit/goto-symex/apply_condition.cpp
@@ -67,7 +67,7 @@ SCENARIO(
 
   WHEN("Applying the condition '!b'")
   {
-    const exprt condition = not_exprt{renamed_b};
+    const exprt condition = not_expr(renamed_b);
     goto_state.apply_condition(condition, state, ns);
 
     THEN("b should be in the constant propagator with value 'false'")
@@ -109,7 +109,7 @@ SCENARIO(
 
   WHEN("Applying the condition '!(b == true)'")
   {
-    const exprt condition = not_exprt{equal_exprt{renamed_b, true_exprt{}}};
+    const exprt condition = not_expr(equal_exprt{renamed_b, true_exprt{}});
     goto_state.apply_condition(condition, state, ns);
 
     THEN("b should be in the constant propagator with value 'false'")
@@ -123,7 +123,7 @@ SCENARIO(
 
   WHEN("Applying the condition '!(b == false)'")
   {
-    const exprt condition = not_exprt{equal_exprt{renamed_b, false_exprt{}}};
+    const exprt condition = not_expr(equal_exprt{renamed_b, false_exprt{}});
     goto_state.apply_condition(condition, state, ns);
 
     THEN("b should be in the constant propagator with value 'true'")
@@ -165,7 +165,7 @@ SCENARIO(
 
   WHEN("Applying the condition '!(b != true)'")
   {
-    const exprt condition = not_exprt{notequal_exprt{renamed_b, true_exprt{}}};
+    const exprt condition = not_expr(notequal_exprt{renamed_b, true_exprt{}});
     goto_state.apply_condition(condition, state, ns);
 
     THEN("b should be in the constant propagator with value 'true'")
@@ -179,7 +179,7 @@ SCENARIO(
 
   WHEN("Applying the condition '!(b != false)'")
   {
-    const exprt condition = not_exprt{notequal_exprt{renamed_b, false_exprt{}}};
+    const exprt condition = not_expr(notequal_exprt{renamed_b, false_exprt{}});
     goto_state.apply_condition(condition, state, ns);
 
     THEN("b should be in the constant propagator with value 'false'")

--- a/unit/solvers/bdd/miniBDD/miniBDD.cpp
+++ b/unit/solvers/bdd/miniBDD/miniBDD.cpp
@@ -193,7 +193,7 @@ SCENARIO("miniBDD", "[core][solver][miniBDD]")
     prop_conv_solvert solver(bdd_prop, null_message_handler);
 
     symbol_exprt var("x", bool_typet());
-    literalt result = solver.convert(and_exprt(var, not_exprt(var)));
+    literalt result = solver.convert(and_exprt(var, not_expr(var)));
 
     REQUIRE(result.is_false());
   }
@@ -330,7 +330,7 @@ SCENARIO("miniBDD", "[core][solver][miniBDD]")
     symbol_exprt a("a", bool_typet());
     symbol_exprt b("b", bool_typet());
 
-    or_exprt o(and_exprt(a, b), not_exprt(a));
+    or_exprt o(and_exprt(a, b), not_expr(a));
 
     symbol_tablet symbol_table;
     namespacet ns(symbol_table);

--- a/unit/solvers/prop/bdd_expr.cpp
+++ b/unit/solvers/prop/bdd_expr.cpp
@@ -26,7 +26,7 @@ SCENARIO("bdd_expr", "[core][solver][prop][bdd_expr]")
   {
     const symbol_exprt var("x", bool_typet());
     const bddt bdd =
-      bdd_expr_converter.from_expr(and_exprt(var, not_exprt(var)));
+      bdd_expr_converter.from_expr(and_exprt(var, not_expr(var)));
     REQUIRE(bdd_expr_converter.as_expr(bdd) == false_exprt());
   }
 
@@ -36,11 +36,11 @@ SCENARIO("bdd_expr", "[core][solver][prop][bdd_expr]")
     const symbol_exprt b("b", bool_typet());
 
     const bddt bdd =
-      bdd_expr_converter.from_expr(or_exprt(and_exprt(a, b), not_exprt(a)));
+      bdd_expr_converter.from_expr(or_exprt(and_exprt(a, b), not_expr(a)));
 
     THEN("It is equal to the BDD for (!a|b)")
     {
-      const bddt bdd2 = bdd_expr_converter.from_expr(or_exprt(not_exprt(a), b));
+      const bddt bdd2 = bdd_expr_converter.from_expr(or_exprt(not_expr(a), b));
       REQUIRE(
         bdd_expr_converter.as_expr(bdd) == bdd_expr_converter.as_expr(bdd2));
     }
@@ -51,7 +51,7 @@ SCENARIO("bdd_expr", "[core][solver][prop][bdd_expr]")
     const symbol_exprt a("a", bool_typet());
     const symbol_exprt b("b", bool_typet());
 
-    const bddt bdd = bdd_expr_converter.from_expr(and_exprt(a, not_exprt(b)));
+    const bddt bdd = bdd_expr_converter.from_expr(and_exprt(a, not_expr(b)));
 
     WHEN("It is converted to an exprt")
     {
@@ -59,7 +59,7 @@ SCENARIO("bdd_expr", "[core][solver][prop][bdd_expr]")
       THEN("It is equivalent to the expression !(!a || b)")
       {
         const bddt to_compare =
-          bdd_expr_converter.from_expr(not_exprt{or_exprt{not_exprt{a}, b}});
+          bdd_expr_converter.from_expr(not_expr(or_exprt{not_expr(a), b}));
         REQUIRE(bdd.bdd_xor(to_compare).is_false());
         REQUIRE(bdd.bdd_xor(to_compare.bdd_not()).is_true());
       }
@@ -71,7 +71,7 @@ SCENARIO("bdd_expr", "[core][solver][prop][bdd_expr]")
     const symbol_exprt a("a", bool_typet());
     const symbol_exprt b("b", bool_typet());
     const bddt bdd = bdd_expr_converter.from_expr(
-      xor_exprt{or_exprt{not_exprt{a}, b}, implies_exprt{a, b}});
+      xor_exprt{or_exprt{not_expr(a), b}, implies_exprt{a, b}});
     THEN("It reduces to false")
     {
       REQUIRE(bdd.is_false());
@@ -96,7 +96,7 @@ SCENARIO("bdd_expr", "[core][solver][prop][bdd_expr]")
     THEN("e xor !e is true")
     {
       REQUIRE(
-        bdd.bdd_xor(bdd_expr_converter.from_expr(not_exprt{expr})).is_true());
+        bdd.bdd_xor(bdd_expr_converter.from_expr(not_expr(expr))).is_true());
     }
 
     THEN("Converting to expr and back to BDD gives the same BDD")

--- a/unit/solvers/strings/string_refinement/string_refinement.cpp
+++ b/unit/solvers/strings/string_refinement/string_refinement.cpp
@@ -227,7 +227,7 @@ SCENARIO("string refinement", "[core][solvers][strings][string_refinement]")
 
       solver.set_to(
         and_exprt{
-          equal_exprt{length1, from_integer(10, int_type)}, not_exprt{g1}, g2},
+          equal_exprt{length1, from_integer(10, int_type)}, not_expr(g1), g2},
         true);
       THEN("The model for array1 has length 10 and contains 'c' at position 9")
       {

--- a/unit/util/expr_iterator.cpp
+++ b/unit/util/expr_iterator.cpp
@@ -52,7 +52,7 @@ SCENARIO("expr_iterator", "[core][utils][expr_iterator]")
           ++it)
       {
         if(it->id() == ID_notequal)
-          it.mutate() = not_exprt(equal_exprt(symbol, symbol));
+          it.mutate() = not_expr(equal_exprt(symbol, symbol));
 
         ids.push_back(it->id());
       }
@@ -82,7 +82,7 @@ SCENARIO("expr_iterator", "[core][utils][expr_iterator]")
         bool replace_here = it->id() == ID_notequal;
 
         if(replace_here)
-          it.mutate() = not_exprt(equal_exprt(symbol, symbol));
+          it.mutate() = not_expr(equal_exprt(symbol, symbol));
 
         ids.push_back(it->id());
 

--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -271,7 +271,7 @@ TEST_CASE("Simplify cast from bool", "[core][util]")
 
     exprt simp = simplify_expr(comparison, ns);
 
-    REQUIRE(simp == not_exprt(B));
+    REQUIRE(simp == not_expr(B));
   }
 
   {
@@ -283,7 +283,7 @@ TEST_CASE("Simplify cast from bool", "[core][util]")
 
     exprt simp = simplify_expr(comparison, ns);
 
-    REQUIRE(simp == not_exprt(B));
+    REQUIRE(simp == not_expr(B));
   }
 
   {


### PR DESCRIPTION
With this copy constructor, we can accidentaly make a copy of the
expression instead of negating it, for instance:

```
not_exprt a{b}; // a = not b
not_exprt c{(expr)a}; // c = not (not b)
not_exprt d{a}; // d = not b !!!
```

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
