### PR TITLE
Fix a bug with the cache in the BDD to exprt conversion

### DIFF
--- a/src/solvers/prop/bdd_expr.h
+++ b/src/solvers/prop/bdd_expr.h
@@ -50,7 +50,6 @@ protected:
   bddt from_expr_rec(const exprt &expr);
   exprt as_expr(
     const bdd_nodet &r,
-    bool complement,
     std::unordered_map<bdd_nodet::idt, exprt> &cache) const;
 };
 

--- a/unit/solvers/prop/bdd_expr.cpp
+++ b/unit/solvers/prop/bdd_expr.cpp
@@ -56,12 +56,12 @@ SCENARIO("bdd_expr", "[core][solver][prop][bdd_expr]")
     WHEN("It is converted to an exprt")
     {
       const exprt result = bdd_expr_converter.as_expr(bdd);
-      THEN("It is equal to the expression (a & !b) or (!b & a)")
+      THEN("It is equivalent to the expression !(!a || b)")
       {
-        REQUIRE(result.id() == ID_and);
-        REQUIRE(result.operands().size() == 2);
-        REQUIRE((result.op0() == a || result.op1() == a));
-        REQUIRE((result.op0() == not_exprt(b) || result.op1() == not_exprt(b)));
+        const bddt to_compare =
+          bdd_expr_converter.from_expr(not_exprt{or_exprt{not_exprt{a}, b}});
+        REQUIRE(bdd.bdd_xor(to_compare).is_false());
+        REQUIRE(bdd.bdd_xor(to_compare.bdd_not()).is_true());
       }
     }
   }

--- a/unit/solvers/prop/bdd_expr.cpp
+++ b/unit/solvers/prop/bdd_expr.cpp
@@ -65,4 +65,45 @@ SCENARIO("bdd_expr", "[core][solver][prop][bdd_expr]")
       }
     }
   }
+
+  GIVEN("(!a | b) xor (a => b) ")
+  {
+    const symbol_exprt a("a", bool_typet());
+    const symbol_exprt b("b", bool_typet());
+    const bddt bdd = bdd_expr_converter.from_expr(
+      xor_exprt{or_exprt{not_exprt{a}, b}, implies_exprt{a, b}});
+    THEN("It reduces to false")
+    {
+      REQUIRE(bdd.is_false());
+    }
+  }
+
+  GIVEN("e = (a | b) xor (c | d)")
+  {
+    const symbol_exprt a("a", bool_typet());
+    const symbol_exprt b("b", bool_typet());
+    const symbol_exprt c("c", bool_typet());
+    const symbol_exprt d("d", bool_typet());
+
+    const xor_exprt expr{or_exprt{a, b}, or_exprt{c, d}};
+    const bddt bdd = bdd_expr_converter.from_expr(expr);
+
+    THEN("e xor e is false")
+    {
+      REQUIRE(bdd.bdd_xor(bdd_expr_converter.from_expr(expr)).is_false());
+    }
+
+    THEN("e xor !e is true")
+    {
+      REQUIRE(
+        bdd.bdd_xor(bdd_expr_converter.from_expr(not_exprt{expr})).is_true());
+    }
+
+    THEN("Converting to expr and back to BDD gives the same BDD")
+    {
+      const exprt expr_of_bdd = bdd_expr_converter.as_expr(bdd);
+      const bddt bdd_of_expr = bdd_expr_converter.from_expr(expr_of_bdd);
+      REQUIRE(bdd_of_expr.equals(bdd));
+    }
+  }
 }


### PR DESCRIPTION
There was a bug in which the result for a node and for it's complement would have been stored in the same map entry, this happens with the Cudd library which uses complemented nodes (a node and it's negation are stored at the same address).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
