### PR TITLE
Add codecov flags, specify codecov file to upload, and remove unit test folder from coverage

### DIFF
--- a/buildspec-linux-make-gcc-cov.yml
+++ b/buildspec-linux-make-gcc-cov.yml
@@ -25,53 +25,20 @@ phases:
       - echo Build completed on `date`
   post_build:
     commands:
-      # Run unit test
-      - make -C unit test
-      - lcov --capture --directory . --output-file lcov.info
-      - lcov --remove lcov.info '/usr/*' '*/unit/*' --output-file lcov.info
+      # codecov script creation
       # If $CODEBUILD_SOURCE_VERSION starts with 'pr/', filter out pr number, if not, return empty
       - VCS_PULL_REQUEST=$(echo $CODEBUILD_SOURCE_VERSION | sed '/^pr\//!d;s/^pr\///')
       # If $CODEBUILD_SOURCE_VERSION is commit id, set $VCS_COMMIT_ID
       - VCS_COMMIT_ID=$(echo $CODEBUILD_SOURCE_VERSION | sed -r '/^[a-z0-9]{40}$/!d') 
       - COV_SCRIPT=/root/.cache/codecov.sh
       - if [ ! -f "$COV_SCRIPT" ]; then curl -s https://codecov.io/bash > "$COV_SCRIPT"; fi
-      # -f lcov.info is needed to avoid codecov.sh deleting gcno files includeing word 'coverage'. 
-      # -F is flag associate with the coverage report.
-      - bash $COV_SCRIPT -t "$CODECOV_TOKEN" -f lcov.info -c -F reg || true
-      # reset all execution counts to
-      - lcov --zerocounters --directory . 
+      # Run unit test
+      - scripts/run_test_upload_cov_report.sh unit
       # Run regression tests
-      # Also enable compilation with coverage/profiling flags when running the
-      # regression tests, to also get results for the driver program in
-      # regression/invariants
-      - make -C regression test CPROVER_WITH_PROFILING=1
-      - lcov --capture --directory . --output-file lcov.info
-      - lcov --remove lcov.info '/usr/*' '*/unit/*' --output-file lcov.info
-      - bash $COV_SCRIPT -t "$CODECOV_TOKEN" -f lcov.info -c -F unit || true
-      # Run regression/cbmc tests with test-paths lifo option
-      - lcov --zerocounters --directory .
-      - make -C regression/cbmc test-paths-lifo
-      - lcov --capture --directory . --output-file lcov.info
-      - lcov --remove lcov.info '/usr/*' '*/unit/*' --output-file lcov.info
-      - bash $COV_SCRIPT -t "$CODECOV_TOKEN" -f lcov.info -c -F cbmcreglifo || true
+      - scripts/run_test_upload_cov_report.sh regression
       # Run regression/cbmc tests with test-cprover-smt2
-      - lcov --zerocounters --directory .
-      - env PATH=$PATH:`pwd`/src/solvers make -C regression/cbmc test-cprover-smt2
-      - lcov --capture --directory . --output-file lcov.info
-      - lcov --remove lcov.info '/usr/*' '*/unit/*' --output-file lcov.info
-      - bash $COV_SCRIPT -t "$CODECOV_TOKEN" -f lcov.info -c -F cbmcregsmt2 || true
-      # Run jbmc unit tests
-      - lcov --zerocounters --directory .
-      - make -C jbmc/unit test
-      - lcov --capture --directory . --output-file lcov.info
-      - lcov --remove lcov.info '/usr/*' '*/unit/*' --output-file lcov.info
-      - bash $COV_SCRIPT -t "$CODECOV_TOKEN" -f lcov.info -c -F jbmcunit || true
-      # Run jbmc regression tests
-      - lcov --zerocounters --directory .
-      - make -C jbmc/regression test
-      - lcov --capture --directory . --output-file lcov.info
-      - lcov --remove lcov.info '/usr/*' '*/unit/*' --output-file lcov.info
-      - bash $COV_SCRIPT -t "$CODECOV_TOKEN" -f lcov.info -c -F jbmcreg|| true
+      - scripts/run_test_upload_cov_report.sh cproversmt2
+
 cache:
   paths:
     - '/var/cache/apt/**/*'

--- a/buildspec-linux-make-gcc-cov.yml
+++ b/buildspec-linux-make-gcc-cov.yml
@@ -22,17 +22,11 @@ phases:
       - make -C unit CXX="ccache g++" -j2 CPROVER_WITH_PROFILING=1
       - make -C jbmc/src CXX="ccache g++" -j2 CPROVER_WITH_PROFILING=1
       - make -C jbmc/unit CXX="ccache g++" -j2 CPROVER_WITH_PROFILING=1
+      - echo Build completed on `date`
   post_build:
     commands:
-      - make -C unit test 
-      # Also enable compilation with coverage/profiling flags when running the
-      # regression tests, to also get results for the driver program in
-      # regression/invariants
-      - make -C regression test CPROVER_WITH_PROFILING=1
-      - make -C regression/cbmc test-paths-lifo
-      - env PATH=$PATH:`pwd`/src/solvers make -C regression/cbmc test-cprover-smt2
-      - make -C jbmc/unit test
-      - make -C jbmc/regression test
+      # Run unit test
+      - make -C unit test
       - lcov --capture --directory . --output-file lcov.info
       - lcov --remove lcov.info '/usr/*' --output-file lcov.info
       # If $CODEBUILD_SOURCE_VERSION starts with 'pr/', filter out pr number, if not, return empty
@@ -41,8 +35,43 @@ phases:
       - VCS_COMMIT_ID=$(echo $CODEBUILD_SOURCE_VERSION | sed -r '/^[a-z0-9]{40}$/!d') 
       - COV_SCRIPT=/root/.cache/codecov.sh
       - if [ ! -f "$COV_SCRIPT" ]; then curl -s https://codecov.io/bash > "$COV_SCRIPT"; fi
-      - bash $COV_SCRIPT -t "$CODECOV_TOKEN" || true
-      - echo Build completed on `date`
+      # -f lcov.info is needed to avoid codecov.sh deleting gcno files includeing word 'coverage'. 
+      # -F is flag associate with the coverage report.
+      - bash $COV_SCRIPT -t "$CODECOV_TOKEN" -f lcov.info -c -F reg || true
+      # reset all execution counts to
+      - lcov --zerocounters --directory . 
+      # Run regression tests
+      # Also enable compilation with coverage/profiling flags when running the
+      # regression tests, to also get results for the driver program in
+      # regression/invariants
+      - make -C regression test CPROVER_WITH_PROFILING=1
+      - lcov --capture --directory . --output-file lcov.info
+      - lcov --remove lcov.info '/usr/*' --output-file lcov.info
+      - bash $COV_SCRIPT -t "$CODECOV_TOKEN" -f lcov.info -c -F unit || true
+      # Run regression/cbmc tests with test-paths lifo option
+      - lcov --zerocounters --directory .
+      - make -C regression/cbmc test-paths-lifo
+      - lcov --capture --directory . --output-file lcov.info
+      - lcov --remove lcov.info '/usr/*' --output-file lcov.info
+      - bash $COV_SCRIPT -t "$CODECOV_TOKEN" -f lcov.info -c -F cbmcreglifo || true
+      # Run regression/cbmc tests with test-cprover-smt2
+      - lcov --zerocounters
+      - env PATH=$PATH:`pwd`/src/solvers make -C regression/cbmc test-cprover-smt2
+      - lcov --capture --directory . --output-file lcov.info
+      - lcov --remove lcov.info '/usr/*' --output-file lcov.info
+      - bash $COV_SCRIPT -t "$CODECOV_TOKEN" -f lcov.info -c -F cbmcregsmt2 || true
+      # Run jbmc unit tests
+      - lcov --zerocounters --directory .
+      - make -C jbmc/unit test
+      - lcov --capture --directory . --output-file lcov.info
+      - lcov --remove lcov.info '/usr/*' --output-file lcov.info
+      - bash $COV_SCRIPT -t "$CODECOV_TOKEN" -f lcov.info -c -F jbmcunit || true
+      # Run jbmc regression tests
+      - lcov --zerocounters --directory .
+      - make -C jbmc/regression test
+      - lcov --capture --directory . --output-file lcov.info
+      - lcov --remove lcov.info '/usr/*' --output-file lcov.info
+      - bash $COV_SCRIPT -t "$CODECOV_TOKEN" -f lcov.info -c -F jbmcreg|| true
 cache:
   paths:
     - '/var/cache/apt/**/*'

--- a/buildspec-linux-make-gcc-cov.yml
+++ b/buildspec-linux-make-gcc-cov.yml
@@ -28,7 +28,7 @@ phases:
       # Run unit test
       - make -C unit test
       - lcov --capture --directory . --output-file lcov.info
-      - lcov --remove lcov.info '/usr/*' --output-file lcov.info
+      - lcov --remove lcov.info '/usr/*' '*/unit/*' --output-file lcov.info
       # If $CODEBUILD_SOURCE_VERSION starts with 'pr/', filter out pr number, if not, return empty
       - VCS_PULL_REQUEST=$(echo $CODEBUILD_SOURCE_VERSION | sed '/^pr\//!d;s/^pr\///')
       # If $CODEBUILD_SOURCE_VERSION is commit id, set $VCS_COMMIT_ID
@@ -46,31 +46,31 @@ phases:
       # regression/invariants
       - make -C regression test CPROVER_WITH_PROFILING=1
       - lcov --capture --directory . --output-file lcov.info
-      - lcov --remove lcov.info '/usr/*' --output-file lcov.info
+      - lcov --remove lcov.info '/usr/*' '*/unit/*' --output-file lcov.info
       - bash $COV_SCRIPT -t "$CODECOV_TOKEN" -f lcov.info -c -F unit || true
       # Run regression/cbmc tests with test-paths lifo option
       - lcov --zerocounters --directory .
       - make -C regression/cbmc test-paths-lifo
       - lcov --capture --directory . --output-file lcov.info
-      - lcov --remove lcov.info '/usr/*' --output-file lcov.info
+      - lcov --remove lcov.info '/usr/*' '*/unit/*' --output-file lcov.info
       - bash $COV_SCRIPT -t "$CODECOV_TOKEN" -f lcov.info -c -F cbmcreglifo || true
       # Run regression/cbmc tests with test-cprover-smt2
-      - lcov --zerocounters
+      - lcov --zerocounters --directory .
       - env PATH=$PATH:`pwd`/src/solvers make -C regression/cbmc test-cprover-smt2
       - lcov --capture --directory . --output-file lcov.info
-      - lcov --remove lcov.info '/usr/*' --output-file lcov.info
+      - lcov --remove lcov.info '/usr/*' '*/unit/*' --output-file lcov.info
       - bash $COV_SCRIPT -t "$CODECOV_TOKEN" -f lcov.info -c -F cbmcregsmt2 || true
       # Run jbmc unit tests
       - lcov --zerocounters --directory .
       - make -C jbmc/unit test
       - lcov --capture --directory . --output-file lcov.info
-      - lcov --remove lcov.info '/usr/*' --output-file lcov.info
+      - lcov --remove lcov.info '/usr/*' '*/unit/*' --output-file lcov.info
       - bash $COV_SCRIPT -t "$CODECOV_TOKEN" -f lcov.info -c -F jbmcunit || true
       # Run jbmc regression tests
       - lcov --zerocounters --directory .
       - make -C jbmc/regression test
       - lcov --capture --directory . --output-file lcov.info
-      - lcov --remove lcov.info '/usr/*' --output-file lcov.info
+      - lcov --remove lcov.info '/usr/*' '*/unit/*' --output-file lcov.info
       - bash $COV_SCRIPT -t "$CODECOV_TOKEN" -f lcov.info -c -F jbmcreg|| true
 cache:
   paths:

--- a/scripts/run_test_upload_cov_report.sh
+++ b/scripts/run_test_upload_cov_report.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -eou pipefail
+FLAG=$1
+
+if [[ "$FLAG" == "unit" ]]
+then
+  echo "Run $FLAG Tests"
+  make -C unit test
+  make -C jbmc/unit test
+fi
+
+if [[ "$FLAG" == "regression" ]]
+then
+  echo "Run $FLAG Tests"
+  # Also enable compilation with coverage/profiling flags when running the
+  # regression tests, to also get results for the driver program in
+  # regression/invariants
+  make -C regression test CPROVER_WITH_PROFILING=1
+  make -C regression/cbmc test-paths-lifo
+  make -C jbmc/regression test
+fi
+
+if [[ "$FLAG" == "cproversmt2" ]]
+then
+  echo "Run $FLAG Tests"
+  env PATH=$PATH:`pwd`/src/solvers make -C regression/cbmc test-cprover-smt2
+fi
+
+lcov --capture --directory . --output-file lcov.info
+lcov --remove lcov.info '/usr/*' '*/unit/*' --output-file lcov.info
+# -f lcov.info is needed to avoid codecov.sh deleting gcno files including word 'coverage'. 
+# -F is flag associate with the coverage report.
+bash $COV_SCRIPT -t "$CODECOV_TOKEN" -f lcov.info -c -F $FLAG || true
+# reset all execution counts to
+lcov --zerocounters --directory .   


### PR DESCRIPTION
This PR contains adding [flags](https://docs.codecov.io/docs/flags) work for codecov. 
In order to create separate coverage report
- lcov counter reset is set for new coverage report.
- coverage file (lcov.file) to upload codecov is specified, otherwise, `codecov.sh` scripts delete coverage files that its filename contains `coverage`.
- flags are for `unit` test, `regression` test for cbmc and jbmc. 

Also, remove `unit` folder from coverage source. This will cause coverage "drop".
 
- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.