### PR TITLE
fix exprt::opX accesses in goto-instrument

### DIFF
--- a/src/goto-instrument/accelerate/overflow_instrumenter.cpp
+++ b/src/goto-instrument/accelerate/overflow_instrumenter.cpp
@@ -211,7 +211,7 @@ void overflow_instrumentert::overflow_expr(
           expr.id()==ID_mult)
   {
     // A generic arithmetic operation.
-    exprt overflow("overflow-" + expr.id_string(), bool_typet());
+    multi_ary_exprt overflow("overflow-" + expr.id_string(), bool_typet());
     overflow.operands()=expr.operands();
 
     if(expr.operands().size()>=3)
@@ -223,7 +223,7 @@ void overflow_instrumentert::overflow_expr(
 
         if(i==1)
         {
-          tmp=expr.op0();
+          tmp = to_multi_ary_expr(expr).op0();
         }
         else
         {

--- a/src/goto-instrument/accelerate/polynomial.cpp
+++ b/src/goto-instrument/accelerate/polynomial.cpp
@@ -117,10 +117,11 @@ void polynomialt::from_expr(const exprt &expr)
           expr.id()==ID_minus ||
           expr.id()==ID_mult)
   {
+    const auto &multi_ary_expr = to_multi_ary_expr(expr);
     polynomialt poly2;
 
-    from_expr(expr.op0());
-    poly2.from_expr(expr.op1());
+    from_expr(multi_ary_expr.op0());
+    poly2.from_expr(multi_ary_expr.op1());
 
     if(expr.id()==ID_minus)
     {
@@ -148,7 +149,7 @@ void polynomialt::from_expr(const exprt &expr)
     // Pretty shady...  We just throw away the typecast...  Pretty sure this
     // isn't sound.
     // XXX - probably not sound.
-    from_expr(expr.op0());
+    from_expr(to_typecast_expr(expr).op());
   }
   else
   {

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -109,8 +109,7 @@ void goto_program2codet::scan_for_varargs()
         r.id() == ID_side_effect &&
         to_side_effect_expr(r).get_statement() == ID_va_start)
       {
-        assert(r.has_operands());
-        va_list_expr.insert(r.op0());
+        va_list_expr.insert(to_unary_expr(r).op());
       }
       // try our modelling of va_start
       else if(l.type().id()==ID_pointer &&
@@ -315,7 +314,8 @@ goto_programt::const_targett goto_program2codet::convert_assign_varargs(
   {
     code_function_callt f(
       symbol_exprt(ID_va_start, code_typet({}, empty_typet())),
-      {this_va_list_expr, to_address_of_expr(skip_typecast(r.op0())).object()});
+      {this_va_list_expr,
+       to_address_of_expr(skip_typecast(to_unary_expr(r).op())).object()});
 
     dest.add(std::move(f));
   }
@@ -865,7 +865,7 @@ goto_programt::const_targett goto_program2codet::convert_goto_switch(
   // try to figure out whether this was a switch/case
   exprt eq_cand=target->guard;
   if(eq_cand.id()==ID_or)
-    eq_cand=eq_cand.op0();
+    eq_cand = to_or_expr(eq_cand).op0();
 
   if(target->is_backwards_goto() ||
      eq_cand.id()!=ID_equal ||


### PR DESCRIPTION
This improves type safety.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
