### PR TITLE
fix exprt::opX accesses in linker_script_merge

### DIFF
--- a/src/goto-cc/linker_script_merge.cpp
+++ b/src/goto-cc/linker_script_merge.cpp
@@ -126,45 +126,58 @@ linker_script_merget::linker_script_merget(
       {replacement_predicatet(
          "address of array's first member",
          [](const exprt &expr) -> const symbol_exprt & {
-           return to_symbol_expr(expr.op0().op0());
+           return to_symbol_expr(
+             to_index_expr(to_address_of_expr(expr).object()).index());
          },
          [](const exprt &expr) {
            return expr.id() == ID_address_of &&
                   expr.type().id() == ID_pointer &&
 
-                  expr.op0().id() == ID_index &&
-                  expr.op0().type().id() == ID_unsignedbv &&
+                  to_address_of_expr(expr).object().id() == ID_index &&
+                  to_address_of_expr(expr).object().type().id() ==
+                    ID_unsignedbv &&
 
-                  expr.op0().op0().id() == ID_symbol &&
-                  expr.op0().op0().type().id() == ID_array &&
+                  to_index_expr(to_address_of_expr(expr).object())
+                      .array()
+                      .id() == ID_symbol &&
+                  to_index_expr(to_address_of_expr(expr).object())
+                      .array()
+                      .type()
+                      .id() == ID_array &&
 
-                  expr.op0().op1().id() == ID_constant &&
-                  expr.op0().op1().type().id() == ID_signedbv;
+                  to_index_expr(to_address_of_expr(expr).object())
+                      .index()
+                      .id() == ID_constant &&
+                  to_index_expr(to_address_of_expr(expr).object())
+                      .index()
+                      .type()
+                      .id() == ID_signedbv;
          }),
        replacement_predicatet(
          "address of array",
          [](const exprt &expr) -> const symbol_exprt & {
-           return to_symbol_expr(expr.op0());
+           return to_symbol_expr(to_address_of_expr(expr).object());
          },
          [](const exprt &expr) {
            return expr.id() == ID_address_of &&
                   expr.type().id() == ID_pointer &&
 
-                  expr.op0().id() == ID_symbol &&
-                  expr.op0().type().id() == ID_array;
+                  to_address_of_expr(expr).object().id() == ID_symbol &&
+                  to_address_of_expr(expr).object().type().id() == ID_array;
          }),
        replacement_predicatet(
          "address of struct",
          [](const exprt &expr) -> const symbol_exprt & {
-           return to_symbol_expr(expr.op0());
+           return to_symbol_expr(to_address_of_expr(expr).object());
          },
          [](const exprt &expr) {
            return expr.id() == ID_address_of &&
                   expr.type().id() == ID_pointer &&
 
-                  expr.op0().id() == ID_symbol &&
-                  (expr.op0().type().id() == ID_struct ||
-                   expr.op0().type().id() == ID_struct_tag);
+                  to_address_of_expr(expr).object().id() == ID_symbol &&
+                  (to_address_of_expr(expr).object().type().id() == ID_struct ||
+                   to_address_of_expr(expr).object().type().id() ==
+                     ID_struct_tag);
          }),
        replacement_predicatet(
          "array variable",


### PR DESCRIPTION
This improves type safety.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
