### PR TITLE
Improve error message when functional method is inherited

### DIFF
--- a/jbmc/src/java_bytecode/lambda_synthesis.cpp
+++ b/jbmc/src/java_bytecode/lambda_synthesis.cpp
@@ -121,7 +121,9 @@ static optionalt<irep_idt> interface_method_id(
       << functional_interface_tag.get_identifier()
       << " which should have exactly one abstract method but actually has "
       << implemented_interface_type.methods().size()
-      << ". Note default methods are not supported yet." << messaget::eom;
+      << ". Note default methods are not supported yet."
+      << "Also note methods declared in an inherited interface are not "
+      << "supported either." << messaget::eom;
     return {};
   }
   return implemented_interface_type.methods().at(0).get_name();


### PR DESCRIPTION
This error can be erroneously triggered both when there are default methods on the interface (meaning >1 methods) or when the method is actually defined in an inherited interface (meaning 0 methods). Extend the warning message to explain both cases.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [n.a] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
