### PR TITLE
type simplify_inequality and auxiliary methods

### DIFF
--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2225,7 +2225,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_node(exprt node)
           expr.id()==ID_gt    || expr.id()==ID_lt ||
           expr.id()==ID_ge    || expr.id()==ID_le)
   {
-    r = simplify_inequality(expr);
+    r = simplify_inequality(to_binary_relation_expr(expr));
   }
   else if(expr.id()==ID_if)
   {

--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -154,7 +154,7 @@ public:
   NODISCARD resultt<> simplify_bitnot(const bitnot_exprt &);
   NODISCARD resultt<> simplify_not(const not_exprt &);
   NODISCARD resultt<> simplify_boolean(const exprt &);
-  NODISCARD resultt<> simplify_inequality(const exprt &);
+  NODISCARD resultt<> simplify_inequality(const binary_relation_exprt &);
   NODISCARD resultt<>
   simplify_ieee_float_relation(const binary_relation_exprt &);
   NODISCARD resultt<> simplify_lambda(const exprt &);
@@ -203,11 +203,16 @@ public:
   static tvt objects_equal(const exprt &a, const exprt &b);
   static tvt objects_equal_address_of(const exprt &a, const exprt &b);
   NODISCARD resultt<> simplify_address_of_arg(const exprt &);
-  NODISCARD resultt<> simplify_inequality_both_constant(const exprt &);
-  NODISCARD resultt<> simplify_inequality_no_constant(const exprt &);
-  NODISCARD resultt<> simplify_inequality_rhs_is_constant(const exprt &);
-  NODISCARD resultt<> simplify_inequality_address_of(const exprt &);
-  NODISCARD resultt<> simplify_inequality_pointer_object(const exprt &);
+  NODISCARD resultt<>
+  simplify_inequality_both_constant(const binary_relation_exprt &);
+  NODISCARD resultt<>
+  simplify_inequality_no_constant(const binary_relation_exprt &);
+  NODISCARD resultt<>
+  simplify_inequality_rhs_is_constant(const binary_relation_exprt &);
+  NODISCARD resultt<>
+  simplify_inequality_address_of(const binary_relation_exprt &);
+  NODISCARD resultt<>
+  simplify_inequality_pointer_object(const binary_relation_exprt &);
 
   // main recursion
   NODISCARD resultt<> simplify_node(exprt);

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -418,13 +418,10 @@ simplify_exprt::simplify_pointer_offset(const unary_exprt &expr)
   return unchanged(expr);
 }
 
-simplify_exprt::resultt<>
-simplify_exprt::simplify_inequality_address_of(const exprt &expr)
+simplify_exprt::resultt<> simplify_exprt::simplify_inequality_address_of(
+  const binary_relation_exprt &expr)
 {
   PRECONDITION(expr.id() == ID_equal || expr.id() == ID_notequal);
-  PRECONDITION(expr.type().id() == ID_bool);
-  DATA_INVARIANT(
-    expr.operands().size() == 2, "(in)equalities have two operands");
 
   exprt tmp0=expr.op0();
   if(tmp0.id()==ID_typecast)
@@ -473,13 +470,11 @@ simplify_exprt::simplify_inequality_address_of(const exprt &expr)
   return unchanged(expr);
 }
 
-simplify_exprt::resultt<>
-simplify_exprt::simplify_inequality_pointer_object(const exprt &expr)
+simplify_exprt::resultt<> simplify_exprt::simplify_inequality_pointer_object(
+  const binary_relation_exprt &expr)
 {
   PRECONDITION(expr.id() == ID_equal || expr.id() == ID_notequal);
   PRECONDITION(expr.type().id() == ID_bool);
-  DATA_INVARIANT(
-    expr.operands().size() == 2, "(in)equalities have two operands");
 
   exprt::operandst new_inequality_ops;
   forall_operands(it, expr)


### PR DESCRIPTION
This improves type safety.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
