### PR TITLE
Handle more formulas than just equations in string solver

### DIFF
--- a/jbmc/unit/solvers/strings/string_refinement/dependency_graph.cpp
+++ b/jbmc/unit/solvers/strings/string_refinement/dependency_graph.cpp
@@ -89,12 +89,15 @@ SCENARIO("dependency_graph", "[core][solvers][refinement][string_refinement]")
       symbol_generatort generator;
       array_poolt array_pool(generator);
 
-      bool success = add_node(dependencies, equation1, array_pool);
-      REQUIRE(success);
-      success = add_node(dependencies, equation2, array_pool);
-      REQUIRE(success);
-      success = add_node(dependencies, equation3, array_pool);
-      REQUIRE(success);
+      optionalt<exprt> new_equation1 =
+        add_node(dependencies, equation1, array_pool, generator);
+      REQUIRE(new_equation1.has_value());
+      optionalt<exprt> new_equation2 =
+        add_node(dependencies, equation2, array_pool, generator);
+      REQUIRE(new_equation2.has_value());
+      optionalt<exprt> new_equation3 =
+        add_node(dependencies, equation3, array_pool, generator);
+      REQUIRE(new_equation3.has_value());
 
 #ifdef DEBUG // useful output for visualizing the graph
       {

--- a/src/solvers/strings/string_dependencies.cpp
+++ b/src/solvers/strings/string_dependencies.cpp
@@ -195,18 +195,35 @@ void string_dependenciest::clean_cache()
     e.reset();
 }
 
-bool add_node(
+optionalt<exprt> add_node(
   string_dependenciest &dependencies,
-  const equal_exprt &equation,
-  array_poolt &array_pool)
+  const exprt &expr,
+  array_poolt &array_pool,
+  symbol_generatort &fresh_symbol)
 {
-  const auto fun_app =
-    expr_try_dynamic_cast<function_application_exprt>(equation.rhs());
+  const auto fun_app = expr_try_dynamic_cast<function_application_exprt>(expr);
   if(!fun_app)
-    return false;
+  {
+    exprt copy = expr;
+    bool copy_differs_from_expr = false;
+    for(std::size_t i = 0; i < expr.operands().size(); ++i)
+    {
+      auto new_op =
+        add_node(dependencies, expr.operands()[i], array_pool, fresh_symbol);
+      if(new_op)
+      {
+        copy.operands()[i] = *new_op;
+        copy_differs_from_expr = true;
+      }
+    }
+    if(copy_differs_from_expr)
+      return copy;
+    return {};
+  }
 
+  const exprt return_code = fresh_symbol("string_builtin_return", expr.type());
   auto builtin_function =
-    to_string_builtin_function(*fun_app, equation.lhs(), array_pool);
+    to_string_builtin_function(*fun_app, return_code, array_pool);
 
   CHECK_RETURN(builtin_function != nullptr);
   const auto &builtin_function_node =
@@ -233,7 +250,7 @@ bool add_node(
     add_dependency_to_string_subexprs(
       dependencies, *fun_app, builtin_function_node, array_pool);
 
-  return true;
+  return return_code;
 }
 
 void string_dependenciest::for_each_dependency(

--- a/src/solvers/strings/string_dependencies.cpp
+++ b/src/solvers/strings/string_dependencies.cpp
@@ -90,7 +90,7 @@ string_dependenciest::node_at(const array_string_exprt &e) const
 }
 
 string_dependenciest::builtin_function_nodet &string_dependenciest::make_node(
-  std::unique_ptr<string_builtin_functiont> &builtin_function)
+  std::unique_ptr<string_builtin_functiont> builtin_function)
 {
   builtin_function_nodes.emplace_back(
     std::move(builtin_function), builtin_function_nodes.size());
@@ -209,8 +209,8 @@ bool add_node(
     to_string_builtin_function(*fun_app, equation.lhs(), array_pool);
 
   CHECK_RETURN(builtin_function != nullptr);
-  const auto &builtin_function_node = dependencies.make_node(builtin_function);
-  // Warning: `builtin_function` has been emptied and should not be used anymore
+  const auto &builtin_function_node =
+    dependencies.make_node(std::move(builtin_function));
 
   if(
     const auto &string_result =

--- a/src/solvers/strings/string_dependencies.h
+++ b/src/solvers/strings/string_dependencies.h
@@ -182,22 +182,27 @@ private:
     const std::function<void(const nodet &)> &f) const;
 };
 
-/// When right hand side of equation is a builtin_function add
+/// When a sub-expression of \p expr is a builtin_function, add
 /// a "string_builtin_function" node to the graph and connect it to the strings
 /// on which it depends and which depends on it.
 /// If the string builtin_function is not a supported one, mark all the string
 /// arguments as depending on an unknown builtin_function.
 /// \param dependencies: graph to which we add the node
-/// \param equation: an equation whose right hand side is possibly a call to a
+/// \param expr: an expression which may contain a call to a
 ///   string builtin_function.
 /// \param array_pool: array pool containing arrays corresponding to the string
 ///   exprt arguments of the builtin_function call
-/// \return true if a node was added, if false is returned it either means that
-///   the right hand side is not a function application
+/// \param fresh_symbol: used to create new symbols for the return values of
+///   builtin functions
+/// \return An expression in which function applications have been replaced
+///   by symbols corresponding to the `return_value` field of the associated
+///   builtin function. Or an empty optional when no function applications has
+///   been encountered
 /// \todo there should be a class with just the three functions we require here
-bool add_node(
+optionalt<exprt> add_node(
   string_dependenciest &dependencies,
-  const equal_exprt &equation,
-  array_poolt &array_pool);
+  const exprt &expr,
+  array_poolt &array_pool,
+  symbol_generatort &fresh_symbol);
 
 #endif // CPROVER_SOLVERS_STRINGS_STRING_DEPENDENCIES_H

--- a/src/solvers/strings/string_dependencies.h
+++ b/src/solvers/strings/string_dependencies.h
@@ -79,9 +79,8 @@ public:
   std::unique_ptr<const string_nodet>
   node_at(const array_string_exprt &e) const;
 
-  /// `builtin_function` is reset to an empty pointer after the node is created
   builtin_function_nodet &
-  make_node(std::unique_ptr<string_builtin_functiont> &builtin_function);
+  make_node(std::unique_ptr<string_builtin_functiont> builtin_function);
   const string_builtin_functiont &
   get_builtin_function(const builtin_function_nodet &node) const;
 

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -283,18 +283,10 @@ void string_refinementt::set_to(const exprt &expr, bool value)
 {
   PRECONDITION(expr.type().id() == ID_bool);
   PRECONDITION(equality_propagation);
-
-  if(expr.id() == ID_equal && value)
-  {
-    const equal_exprt &eq_expr = to_equal_expr(expr);
-    equations.push_back(eq_expr);
-  }
+  if(!value)
+    equations.push_back(not_exprt{expr});
   else
-  {
-    INVARIANT(
-      !has_char_array_subexpr(expr, ns), "char array only appear in equations");
-    supert::set_to(expr, value);
-  }
+    equations.push_back(expr);
 }
 
 /// Add association for each char pointer in the equation

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -660,18 +660,21 @@ decision_proceduret::resultt string_refinementt::dec_solve()
 
   log.debug() << "dec_solve: compute dependency graph and remove function "
               << "applications captured by the dependencies:" << messaget::eom;
-  std::vector<equal_exprt> local_equations;
+  std::vector<exprt> local_equations;
   for(const equal_exprt &eq : equations)
   {
     // Ensures that arrays that are equal, are associated to the same nodes
     // in the graph.
     const equal_exprt eq_with_char_array_replaced_with_representative_elements =
       to_equal_expr(replace_expr_copy(symbol_resolve, eq));
-    const bool node_added = add_node(
+    const optionalt<exprt> new_equation = add_node(
       dependencies,
       eq_with_char_array_replaced_with_representative_elements,
-      generator.array_pool);
-    if(!node_added)
+      generator.array_pool,
+      generator.fresh_symbol);
+    if(new_equation)
+      local_equations.push_back(*new_equation);
+    else
       local_equations.push_back(eq);
   }
   equations.clear();

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -464,7 +464,7 @@ static void add_string_equation_to_symbol_resolution(
 /// \param stream: output stream
 /// \return union_find_replacet structure containing the correspondences.
 union_find_replacet string_identifiers_resolution_from_equations(
-  std::vector<equal_exprt> &equations,
+  const std::vector<equal_exprt> &equations,
   const namespacet &ns,
   messaget::mstreamt &stream)
 {

--- a/src/solvers/strings/string_refinement.h
+++ b/src/solvers/strings/string_refinement.h
@@ -122,7 +122,7 @@ exprt substitute_array_lists(exprt expr, std::size_t string_max_length);
 
 // Declaration required for unit-test:
 union_find_replacet string_identifiers_resolution_from_equations(
-  std::vector<equal_exprt> &equations,
+  const std::vector<equal_exprt> &equations,
   const namespacet &ns,
   messaget::mstreamt &stream);
 

--- a/src/solvers/strings/string_refinement.h
+++ b/src/solvers/strings/string_refinement.h
@@ -111,7 +111,7 @@ private:
   index_set_pairt index_sets;
   union_find_replacet symbol_resolve;
 
-  std::vector<equal_exprt> equations;
+  std::vector<exprt> equations;
 
   string_dependenciest dependencies;
 

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -57,6 +57,7 @@ SRC += analyses/ai/ai.cpp \
        solvers/strings/string_format_builtin_function/length_of_decimal_int.cpp \
        solvers/strings/string_refinement/concretize_array.cpp \
        solvers/strings/string_refinement/sparse_array.cpp \
+       solvers/strings/string_refinement/string_refinement.cpp \
        solvers/strings/string_refinement/substitute_array_list.cpp \
        solvers/strings/string_refinement/union_find_replace.cpp \
        util/allocate_objects.cpp \

--- a/unit/solvers/strings/string_refinement/module_dependencies.txt
+++ b/unit/solvers/strings/string_refinement/module_dependencies.txt
@@ -1,4 +1,5 @@
 solvers/refinement
+solvers/sat
 solvers/strings
 string_refinement
 testing-utils

--- a/unit/solvers/strings/string_refinement/string_refinement.cpp
+++ b/unit/solvers/strings/string_refinement/string_refinement.cpp
@@ -1,0 +1,246 @@
+/*******************************************************************\
+
+Module: Unit tests for sparse arrays in
+        solvers/refinement/string_refinement.cpp
+
+Author: Romain Brenguier, romain.brenguier@diffblue.com
+
+\*******************************************************************/
+
+#include <testing-utils/use_catch.h>
+
+#include <solvers/sat/satcheck.h>
+#include <solvers/strings/string_refinement.h>
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/config.h>
+#include <util/mathematical_types.h>
+#include <util/std_expr.h>
+#include <util/std_types.h>
+#include <util/symbol_table.h>
+
+SCENARIO("string refinement", "[core][solvers][strings][string_refinement]")
+{
+  config.set_arch("none");
+
+  string_refinementt::infot info;
+
+  null_message_handlert log{};
+  info.message_handler = &log;
+
+  symbol_tablet symbol_table;
+  namespacet ns{symbol_table};
+  info.ns = &ns;
+
+  satcheck_minisat_simplifiert sat_solver{log};
+  info.prop = &sat_solver;
+
+  string_refinementt solver{info};
+
+  GIVEN("An array of characters, with its associated pointer and length")
+  {
+    const signedbv_typet int_type{64};
+    const unsignedbv_typet char_type{16};
+    const array_typet char_array_type{char_type, infinity_exprt{int_type}};
+    const refined_string_typet string_type{int_type, pointer_type(char_type)};
+    const symbol_exprt array1{"array1", char_array_type};
+    const symbol_exprt pointer1{"pointer1", pointer_type(char_type)};
+    const symbol_exprt length1{"length1", int_type};
+    const refined_string_exprt string_expr{length1, pointer1, string_type};
+
+    // associate_array_to_pointer : (char[], *char) -> int
+    const symbol_exprt associate_array_to_pointer{
+      ID_cprover_associate_array_to_pointer_func,
+      mathematical_function_typet{{char_array_type, pointer_type(char_type)},
+                                  int_type}};
+
+    // associate_length_to_array : (int, char[]) -> int
+    const symbol_exprt associate_length_to_array{
+      ID_cprover_associate_length_to_array_func,
+      mathematical_function_typet{{int_type, char_array_type}, int_type}};
+
+    // length_function : (string) -> int
+    const symbol_exprt length_function{
+      ID_cprover_string_length_func,
+      mathematical_function_typet{{string_type}, int_type}};
+
+    // char_at_function : (string, int) -> char
+    const symbol_exprt char_at_function{
+      ID_cprover_string_char_at_func,
+      mathematical_function_typet{{string_type, int_type}, char_type}};
+
+    // return_code1 == associate_array_to_pointer(array1, pointer1)
+    const symbol_exprt return_code1{"return_code1", int_type};
+    solver.set_to(
+      equal_exprt{
+        return_code1,
+        function_application_exprt{associate_array_to_pointer,
+                                   std::vector<exprt>{array1, pointer1}}},
+      true);
+
+    // return_code2 == associate_length_to_array(length1, array1)
+    const symbol_exprt return_code2{"return_code2", int_type};
+    solver.set_to(
+      equal_exprt{
+        return_code1,
+        function_application_exprt{associate_length_to_array,
+                                   std::vector<exprt>{array1, length1}}},
+      true);
+
+    WHEN(
+      "return_length == string_length({length1, pointer1}) "
+      "and return_length == 15")
+    {
+      const symbol_exprt return_length{"return_length", int_type};
+      solver.set_to(
+        equal_exprt{return_length,
+                    function_application_exprt{
+                      length_function, std::vector<exprt>{string_expr}}},
+        true);
+
+      solver.set_to(
+        equal_exprt{return_length, from_integer(15, int_type)}, true);
+
+      auto result = solver.dec_solve();
+      THEN("The formula is satisfiable")
+      {
+        REQUIRE(result == decision_proceduret::resultt::D_SATISFIABLE);
+      }
+      THEN("the model for the result and length1 are `15`")
+      {
+        const exprt return_length_model = solver.get(return_length);
+        REQUIRE(return_length_model == from_integer(15, int_type));
+        const exprt length1_model = solver.get(length1);
+        REQUIRE(return_length_model == from_integer(15, int_type));
+      }
+      THEN("the model of array1 is an array of length 15")
+      {
+        const exprt array_model = solver.get(array1);
+        REQUIRE(can_cast_expr<array_exprt>(array_model));
+        REQUIRE(to_array_expr(array_model).operands().size() == 15);
+      }
+    }
+
+    WHEN("length1 == 10 and 'b' == string_char_at({length1, pointer1}, 9)")
+    {
+      solver.set_to(equal_exprt{length1, from_integer(10, int_type)}, true);
+
+      solver.set_to(
+        equal_exprt{
+          from_integer('b', char_type),
+          function_application_exprt{
+            char_at_function,
+            std::vector<exprt>{string_expr, from_integer(9, int_type)}}},
+        true);
+
+      THEN(
+        "The formula is satisfiable and the model of the array should have"
+        "length 10 and end with 'b'")
+      {
+        auto result = solver.dec_solve();
+        REQUIRE(result == decision_proceduret::resultt::D_SATISFIABLE);
+        const exprt array_model = solver.get(array1);
+        REQUIRE(can_cast_expr<array_exprt>(array_model));
+        const std::vector<exprt> &elements =
+          to_array_expr(array_model).operands();
+        REQUIRE(elements.size() == 10);
+        REQUIRE(elements[9].is_constant());
+        REQUIRE(numeric_cast_v<char>(to_constant_expr(elements[9])) == 'b');
+      }
+    }
+
+    WHEN(
+      "g1 => length1 = 10 && 'b' == string_char_at({length1, pointer1}, 9)"
+      " and g2 => 'c' == string_char_at({length1, pointer1}, 3)"
+      " and g1 && g2")
+    {
+      const symbol_exprt g1{"g1", bool_typet{}};
+      solver.set_to(
+        implies_exprt{
+          g1,
+          and_exprt{equal_exprt{length1, from_integer(10, int_type)},
+                    equal_exprt{from_integer('b', char_type),
+                                function_application_exprt{
+                                  char_at_function,
+                                  std::vector<exprt>{
+                                    string_expr, from_integer(9, int_type)}}}}},
+        true);
+
+      const symbol_exprt g2{"g2", bool_typet{}};
+      solver.set_to(
+        implies_exprt{
+          g2,
+          and_exprt{equal_exprt{length1, from_integer(10, int_type)},
+                    equal_exprt{from_integer('c', char_type),
+                                function_application_exprt{
+                                  char_at_function,
+                                  std::vector<exprt>{
+                                    string_expr, from_integer(3, int_type)}}}}},
+        true);
+
+      solver.set_to(and_exprt{g1, g2}, true);
+
+      THEN(
+        "The model for array1 has length 10 and contains 'c' at "
+        " position 3 and b at position 9")
+      {
+        auto result = solver.dec_solve();
+        REQUIRE(result == decision_proceduret::resultt::D_SATISFIABLE);
+        const exprt array_model = solver.get(array1);
+        REQUIRE(can_cast_expr<array_exprt>(array_model));
+        const std::vector<exprt> &elements =
+          to_array_expr(array_model).operands();
+        REQUIRE(elements.size() == 10);
+        REQUIRE(elements[3].is_constant());
+        REQUIRE(numeric_cast_v<char>(to_constant_expr(elements[3])) == 'c');
+        REQUIRE(elements[9].is_constant());
+        REQUIRE(numeric_cast_v<char>(to_constant_expr(elements[9])) == 'b');
+      }
+    }
+
+    WHEN(
+      "g1 => 'b' == string_char_at({length1, pointer1}, 9)"
+      " and g2 => 'c' == string_char_at({length1, pointer1}, 9) "
+      " and length1 == 10 && !g1 && g2")
+    {
+      const symbol_exprt g1{"g1", bool_typet{}};
+      solver.set_to(
+        implies_exprt{
+          g1,
+          equal_exprt{
+            from_integer('b', char_type),
+            function_application_exprt{
+              char_at_function,
+              std::vector<exprt>{string_expr, from_integer(9, int_type)}}}},
+        true);
+
+      const symbol_exprt g2{"g2", bool_typet{}};
+      solver.set_to(
+        implies_exprt{
+          g2,
+          equal_exprt{
+            from_integer('c', char_type),
+            function_application_exprt{
+              char_at_function,
+              std::vector<exprt>{string_expr, from_integer(9, int_type)}}}},
+        true);
+
+      solver.set_to(
+        and_exprt{
+          equal_exprt{length1, from_integer(10, int_type)}, not_exprt{g1}, g2},
+        true);
+      THEN("The model for array1 has length 10 and contains 'c' at position 9")
+      {
+        auto result = solver.dec_solve();
+        REQUIRE(result == decision_proceduret::resultt::D_SATISFIABLE);
+        const exprt array_model = solver.get(array1);
+        REQUIRE(can_cast_expr<array_exprt>(array_model));
+        const std::vector<exprt> &elements =
+          to_array_expr(array_model).operands();
+        REQUIRE(elements.size() == 10);
+        REQUIRE(elements[9].is_constant());
+        REQUIRE(numeric_cast_v<char>(to_constant_expr(elements[9])) == 'c');
+      }
+    }
+  }
+}


### PR DESCRIPTION
Previously the string-solver was restricting builtin-functions to be the left-hand-side of an equations, so formulas like `g1 => c = char_at(string, 10)` would be forbidden.
This removes this restriction by replacing these function applications by symbols.
The array_to_length and pointer_to_array associations should still only appear on lhs of an equations. Char array equalities should also only appear as an equation.

The changes are tested with unit tests as the current symex is not producing the kind of formulas which were not handled.
The motivation for this feature is that I have seen this kind of equations appear while experimenting with BDD guards https://github.com/diffblue/cbmc/pull/4765
 
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
