### PR TITLE
byte-operators unpack_rec: enforce max-bytes if supplied

### DIFF
--- a/regression/cbmc/byte_update14/test.c
+++ b/regression/cbmc/byte_update14/test.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv)
+{
+  int array[10];
+  char *ptr = argc % 2 ? (char *)&array[0] : (char *)&argc;
+  ptr[argc] = 'a';
+  ptr[1] = (char)argc;
+  assert(ptr[1] == (char)argc);
+  assert(array[1] == (char)argc);
+}

--- a/regression/cbmc/byte_update14/test.desc
+++ b/regression/cbmc/byte_update14/test.desc
@@ -1,0 +1,8 @@
+CORE broken-smt-backend
+test.c
+
+^VERIFICATION FAILED$
+^\[main.assertion\.1\] line 10.*SUCCESS$
+^\[main.assertion\.2\] line 11.*FAILURE$
+^EXIT=10$
+^SIGNAL=0$

--- a/regression/cbmc/dynamic_size1/stack_object.desc
+++ b/regression/cbmc/dynamic_size1/stack_object.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 stack_object.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/pointer-function-parameters-struct-mutual-recursion/test.desc
+++ b/regression/cbmc/pointer-function-parameters-struct-mutual-recursion/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --function func --min-null-tree-depth 10 --max-nondet-tree-depth 3 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/pointer-function-parameters-struct-simple-recursion-2/test.desc
+++ b/regression/cbmc/pointer-function-parameters-struct-simple-recursion-2/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --function func --min-null-tree-depth 10 --max-nondet-tree-depth 2 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/pointer-function-parameters-struct-simple-recursion/test.desc
+++ b/regression/cbmc/pointer-function-parameters-struct-simple-recursion/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --function func --min-null-tree-depth 10 --max-nondet-tree-depth 3 --pointer-check
 ^EXIT=0$

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -1072,7 +1072,7 @@ exprt lower_byte_extract(const byte_extract_exprt &src, const namespacet &ns)
     src.id() == ID_byte_extract_big_endian);
   const bool little_endian = src.id() == ID_byte_extract_little_endian;
 
-  // determine an upper bound of the number of bytes we might need
+  // determine an upper bound of the last byte we might need
   auto upper_bound_opt = size_of_expr(src.type(), ns);
   if(upper_bound_opt.has_value())
   {
@@ -1106,6 +1106,7 @@ exprt lower_byte_extract(const byte_extract_exprt &src, const namespacet &ns)
     if(element_bits.has_value() && *element_bits >= 1 && *element_bits % 8 == 0)
     {
       auto num_elements = numeric_cast<std::size_t>(array_type.size());
+      // XXX: This can't be right -- unpacked is a byte array, whereas array_type may have larger elements
       if(!num_elements.has_value() && unpacked.op().id() == ID_array)
         num_elements = unpacked.op().operands().size();
 
@@ -1286,11 +1287,10 @@ exprt lower_byte_extract(const byte_extract_exprt &src, const namespacet &ns)
     size_bits = op0_bits;
   }
 
-  mp_integer num_elements =
-    (*size_bits) / 8 + (((*size_bits) % 8 == 0) ? 0 : 1);
+  mp_integer num_bytes = (*size_bits) / 8 + (((*size_bits) % 8 == 0) ? 0 : 1);
 
   // get 'width'-many bytes, and concatenate
-  const std::size_t width_bytes = numeric_cast_v<std::size_t>(num_elements);
+  const std::size_t width_bytes = numeric_cast_v<std::size_t>(num_bytes);
   exprt::operandst op;
   op.reserve(width_bytes);
 


### PR DESCRIPTION
Otherwise it may return more bytes than were requested, leading to an invariant violation in lower_byte_update which passes a constant limit and enforces that it is obeyed.

Also remove the broken-smt-backend tag from tests which now pass.