### PR TITLE
fix accesses to exprt::opX() in statement-list/

### DIFF
--- a/src/statement-list/converters/expr2statement_list.cpp
+++ b/src/statement-list/converters/expr2statement_list.cpp
@@ -73,18 +73,18 @@ instrument_equal_operands(const exprt &lhs, const exprt &rhs)
   {
     // lhs == !rhs is equivalent to X lhs; X rhs;
     result.push_back(lhs);
-    result.push_back(rhs.op0());
+    result.push_back(to_not_expr(rhs).op());
   }
   else if(ID_not == lhs.id() && ID_not != rhs.id())
   {
     // !lhs == rhs is equivalent to X lhs; X rhs;
-    result.push_back(lhs.op0());
+    result.push_back(to_not_expr(lhs).op());
     result.push_back(rhs);
   }
   else // ID_not == lhs.id() && ID_not == rhs.id()
   {
     // !lhs == !rhs is equivalent to X lhs; XN rhs;
-    result.push_back(lhs.op0());
+    result.push_back(to_not_expr(lhs).op());
     result.push_back(rhs);
   }
   return result;
@@ -142,7 +142,7 @@ std::string expr2stlt::convert(const exprt &expr)
     convert(to_equal_expr(expr));
   else if(ID_symbol == expr.id())
     convert(to_symbol_expr(expr));
-  else if(ID_not == expr.id() && expr.op0().type().id() == ID_bool)
+  else if(ID_not == expr.id() && to_not_expr(expr).op().type().id() == ID_bool)
     convert(to_not_expr(expr));
   else // TODO: support more instructions in expr2stl.
     return expr2c(expr, ns);
@@ -235,7 +235,7 @@ void expr2stlt::convert_multiary_bool_operands(
     if(ID_not == op.id())
     {
       result << operation << NOT_POSTFIX;
-      convert_bool_operand(op.op0());
+      convert_bool_operand(to_not_expr(op).op());
     }
     else
     {
@@ -270,7 +270,7 @@ void expr2stlt::convert_first_non_trivial_operand(std::vector<exprt> &operands)
   {
     if(
       (ID_symbol == it->id()) ||
-      (ID_not == it->id() && ID_symbol == it->op0().id()))
+      (ID_not == it->id() && ID_symbol == to_not_expr(*it).op().id()))
       continue;
     else
     {


### PR DESCRIPTION
This improves type safety.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
