### PR TITLE
fix accesses to exprt::opX() in solvers/

### DIFF
--- a/src/solvers/flattening/arrays.cpp
+++ b/src/solvers/flattening/arrays.cpp
@@ -190,9 +190,8 @@ void arrayst::collect_arrays(const exprt &a)
 
     DATA_INVARIANT(
       struct_op.id() == ID_symbol || struct_op.id() == ID_nondet_symbol,
-      ("unexpected array expression: member with '" + struct_op.id_string() +
-       "'")
-        .c_str());
+      "unexpected array expression: member with '" + struct_op.id_string() +
+        "'");
   }
   else if(a.id()==ID_constant ||
           a.id()==ID_array ||
@@ -216,8 +215,7 @@ void arrayst::collect_arrays(const exprt &a)
     // cast between array types?
     DATA_INVARIANT(
       typecast_op.type().id() == ID_array,
-      ("unexpected array type cast from " + typecast_op.type().id_string())
-        .c_str());
+      "unexpected array type cast from " + typecast_op.type().id_string());
 
     arrays.make_union(a, typecast_op);
     collect_arrays(typecast_op);
@@ -236,8 +234,7 @@ void arrayst::collect_arrays(const exprt &a)
   {
     DATA_INVARIANT(
       false,
-      ("unexpected array expression (collect_arrays): '" + a.id_string() + "'")
-        .c_str());
+      "unexpected array expression (collect_arrays): '" + a.id_string() + "'");
   }
 }
 
@@ -523,9 +520,8 @@ void arrayst::add_array_constraints(
   {
     DATA_INVARIANT(
       false,
-      ("unexpected array expression (add_array_constraints): '" +
-       expr.id_string() + "'")
-        .c_str());
+      "unexpected array expression (add_array_constraints): '" +
+        expr.id_string() + "'");
   }
 }
 

--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -124,7 +124,7 @@ protected:
     const typet &src_type, const bvt &src,
     const typet &dest_type, bvt &dest);
 
-  virtual literalt convert_bv_rel(const exprt &expr);
+  virtual literalt convert_bv_rel(const binary_relation_exprt &);
   virtual literalt convert_typecast(const typecast_exprt &expr);
   virtual literalt convert_reduction(const unary_exprt &expr);
   virtual literalt convert_onehot(const unary_exprt &expr);
@@ -133,7 +133,7 @@ protected:
   virtual literalt convert_equality(const equal_exprt &expr);
   virtual literalt convert_verilog_case_equality(
     const binary_relation_exprt &expr);
-  virtual literalt convert_ieee_float_rel(const exprt &expr);
+  virtual literalt convert_ieee_float_rel(const binary_relation_exprt &);
   virtual literalt convert_quantifier(const quantifier_exprt &expr);
 
   virtual bvt convert_index(const exprt &array, const mp_integer &index);
@@ -158,11 +158,11 @@ protected:
   virtual bvt convert_mult(const mult_exprt &expr);
   virtual bvt convert_div(const div_exprt &expr);
   virtual bvt convert_mod(const mod_exprt &expr);
-  virtual bvt convert_floatbv_op(const exprt &expr);
+  virtual bvt convert_floatbv_op(const ieee_float_op_exprt &);
   virtual bvt convert_floatbv_typecast(const floatbv_typecast_exprt &expr);
   virtual bvt convert_member(const member_exprt &expr);
   virtual bvt convert_with(const with_exprt &expr);
-  virtual bvt convert_update(const exprt &expr);
+  virtual bvt convert_update(const update_exprt &);
   virtual bvt convert_case(const exprt &expr);
   virtual bvt convert_cond(const cond_exprt &);
   virtual bvt convert_shift(const binary_exprt &expr);

--- a/src/solvers/flattening/boolbv_add_sub.cpp
+++ b/src/solvers/flattening/boolbv_add_sub.cpp
@@ -41,7 +41,7 @@ bvt boolbvt::convert_add_sub(const exprt &expr)
     !operands.empty(),
     "operator " + expr.id_string() + " takes at least one operand");
 
-  const exprt &op0=expr.op0();
+  const exprt &op0 = to_multi_ary_expr(expr).op0();
   DATA_INVARIANT(
     op0.type() == type, "add/sub with mixed types:\n" + expr.pretty());
 

--- a/src/solvers/flattening/boolbv_bitwise.cpp
+++ b/src/solvers/flattening/boolbv_bitwise.cpp
@@ -17,9 +17,8 @@ bvt boolbvt::convert_bitwise(const exprt &expr)
 
   if(expr.id()==ID_bitnot)
   {
-    DATA_INVARIANT(expr.operands().size() == 1, "bitnot takes one operand");
-    const exprt &op0=expr.op0();
-    const bvt &op_bv = convert_bv(op0, width);
+    const exprt &op = to_bitnot_expr(expr).op();
+    const bvt &op_bv = convert_bv(op, width);
     return bv_utils.inverted(op_bv);
   }
   else if(expr.id()==ID_bitand || expr.id()==ID_bitor ||

--- a/src/solvers/flattening/boolbv_bv_rel.cpp
+++ b/src/solvers/flattening/boolbv_bv_rel.cpp
@@ -15,98 +15,95 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <solvers/floatbv/float_utils.h>
 
 /// Flatten <, >, <= and >= expressions.
-literalt boolbvt::convert_bv_rel(const exprt &expr)
+literalt boolbvt::convert_bv_rel(const binary_relation_exprt &expr)
 {
-  const exprt::operandst &operands=expr.operands();
   const irep_idt &rel=expr.id();
 
-  if(operands.size()==2)
+  const exprt &lhs = expr.lhs();
+  const exprt &rhs = expr.rhs();
+
+  const bvt &bv_lhs = convert_bv(lhs);
+  const bvt &bv_rhs = convert_bv(rhs);
+
+  bvtypet bvtype_lhs = get_bvtype(lhs.type());
+  bvtypet bvtype_rhs = get_bvtype(rhs.type());
+
+  if(
+    bv_lhs.size() == bv_rhs.size() && !bv_lhs.empty() &&
+    bvtype_lhs == bvtype_rhs)
   {
-    const exprt &op0=expr.op0();
-    const exprt &op1=expr.op1();
-
-    const bvt &bv0=convert_bv(op0);
-    const bvt &bv1=convert_bv(op1);
-
-    bvtypet bvtype0=get_bvtype(op0.type());
-    bvtypet bvtype1=get_bvtype(op1.type());
-
-    if(bv0.size()==bv1.size() && !bv0.empty() &&
-       bvtype0==bvtype1)
+    if(bvtype_lhs == bvtypet::IS_FLOAT)
     {
-      if(bvtype0==bvtypet::IS_FLOAT)
+      float_utilst float_utils(prop, to_floatbv_type(lhs.type()));
+
+      if(rel == ID_le)
+        return float_utils.relation(bv_lhs, float_utilst::relt::LE, bv_rhs);
+      else if(rel == ID_lt)
+        return float_utils.relation(bv_lhs, float_utilst::relt::LT, bv_rhs);
+      else if(rel == ID_ge)
+        return float_utils.relation(bv_lhs, float_utilst::relt::GE, bv_rhs);
+      else if(rel == ID_gt)
+        return float_utils.relation(bv_lhs, float_utilst::relt::GT, bv_rhs);
+      else
+        return SUB::convert_rest(expr);
+    }
+    else if(
+      (lhs.type().id() == ID_range && rhs.type() == lhs.type()) ||
+      bvtype_lhs == bvtypet::IS_SIGNED || bvtype_lhs == bvtypet::IS_UNSIGNED ||
+      bvtype_lhs == bvtypet::IS_FIXED)
+    {
+      literalt literal;
+
+      bv_utilst::representationt rep = ((bvtype_lhs == bvtypet::IS_SIGNED) ||
+                                        (bvtype_lhs == bvtypet::IS_FIXED))
+                                         ? bv_utilst::representationt::SIGNED
+                                         : bv_utilst::representationt::UNSIGNED;
+
+#if 1
+
+      return bv_utils.rel(bv_lhs, expr.id(), bv_rhs, rep);
+
+#else
+      literalt literal = bv_utils.rel(bv_lhs, expr.id(), bv_rhs, rep);
+
+      if(prop.has_set_to())
       {
-        float_utilst float_utils(prop, to_floatbv_type(op0.type()));
-
-        if(rel==ID_le)
-          return float_utils.relation(bv0, float_utilst::relt::LE, bv1);
-        else if(rel==ID_lt)
-          return float_utils.relation(bv0, float_utilst::relt::LT, bv1);
-        else if(rel==ID_ge)
-          return float_utils.relation(bv0, float_utilst::relt::GE, bv1);
-        else if(rel==ID_gt)
-          return float_utils.relation(bv0, float_utilst::relt::GT, bv1);
-        else
-          return SUB::convert_rest(expr);
-      }
-      else if((op0.type().id()==ID_range &&
-               op1.type()==op0.type()) ||
-               bvtype0==bvtypet::IS_SIGNED ||
-               bvtype0==bvtypet::IS_UNSIGNED ||
-               bvtype0==bvtypet::IS_FIXED)
-      {
-        literalt literal;
-
-        bv_utilst::representationt rep=
-          ((bvtype0==bvtypet::IS_SIGNED) || (bvtype0==bvtypet::IS_FIXED))?
-             bv_utilst::representationt::SIGNED:
-             bv_utilst::representationt::UNSIGNED;
-
-        #if 1
-
-        return bv_utils.rel(bv0, expr.id(), bv1, rep);
-
-        #else
-        literalt literal=bv_utils.rel(bv0, expr.id(), bv1, rep);
-
-        if(prop.has_set_to())
+        // it's unclear if this helps
+        if(bv_lhs.size() > 8)
         {
-          // it's unclear if this helps
-          if(bv0.size()>8)
-          {
-            literalt equal_lit=equality(op0, op1);
+          literalt equal_lit = equality(lhs, rhs);
 
-            if(or_equal)
-              prop.l_set_to_true(prop.limplies(equal_lit, literal));
-            else
-              prop.l_set_to_true(prop.limplies(equal_lit, !literal));
-          }
+          if(or_equal)
+            prop.l_set_to_true(prop.limplies(equal_lit, literal));
+          else
+            prop.l_set_to_true(prop.limplies(equal_lit, !literal));
         }
-
-        return literal;
-        #endif
       }
-      else if((bvtype0==bvtypet::IS_VERILOG_SIGNED ||
-               bvtype0==bvtypet::IS_VERILOG_UNSIGNED) &&
-              op0.type()==op1.type())
-      {
-        // extract number bits
-        bvt extract0, extract1;
 
-        extract0.resize(bv0.size()/2);
-        extract1.resize(bv1.size()/2);
+      return literal;
+#endif
+    }
+    else if(
+      (bvtype_lhs == bvtypet::IS_VERILOG_SIGNED ||
+       bvtype_lhs == bvtypet::IS_VERILOG_UNSIGNED) &&
+      lhs.type() == rhs.type())
+    {
+      // extract number bits
+      bvt extract0, extract1;
 
-        for(std::size_t i=0; i<extract0.size(); i++)
-          extract0[i]=bv0[i*2];
+      extract0.resize(bv_lhs.size() / 2);
+      extract1.resize(bv_rhs.size() / 2);
 
-        for(std::size_t i=0; i<extract1.size(); i++)
-          extract1[i]=bv1[i*2];
+      for(std::size_t i = 0; i < extract0.size(); i++)
+        extract0[i] = bv_lhs[i * 2];
 
-        bv_utilst::representationt rep=bv_utilst::representationt::UNSIGNED;
+      for(std::size_t i = 0; i < extract1.size(); i++)
+        extract1[i] = bv_rhs[i * 2];
 
-        // now compare
-        return bv_utils.rel(extract0, expr.id(), extract1, rep);
-      }
+      bv_utilst::representationt rep = bv_utilst::representationt::UNSIGNED;
+
+      // now compare
+      return bv_utils.rel(extract0, expr.id(), extract1, rep);
     }
   }
 

--- a/src/solvers/flattening/boolbv_constraint_select_one.cpp
+++ b/src/solvers/flattening/boolbv_constraint_select_one.cpp
@@ -17,9 +17,9 @@ bvt boolbvt::convert_constraint_select_one(const exprt &expr)
     throw "expected constraint_select_one expression";
 
   if(operands.empty())
-    throw "constraint_select_one takes at one operand";
+    throw "constraint_select_one takes at least one operand";
 
-  if(expr.type()!=expr.op0().type())
+  if(expr.type() != to_multi_ary_expr(expr).op0().type())
     throw "constraint_select_one expects matching types";
 
   bvt bv;

--- a/src/solvers/flattening/boolbv_floatbv_op.cpp
+++ b/src/solvers/flattening/boolbv_floatbv_op.cpp
@@ -79,16 +79,11 @@ bvt boolbvt::convert_floatbv_typecast(const floatbv_typecast_exprt &expr)
     return conversion_failed(expr);
 }
 
-bvt boolbvt::convert_floatbv_op(const exprt &expr)
+bvt boolbvt::convert_floatbv_op(const ieee_float_op_exprt &expr)
 {
-  const exprt::operandst &operands=expr.operands();
-
-  if(operands.size()!=3)
-    throw "operator "+expr.id_string()+" takes three operands";
-
-  const exprt &lhs = expr.op0();
-  const exprt &rhs = expr.op1();
-  const exprt &rounding_mode = expr.op2();
+  const exprt &lhs = expr.lhs();
+  const exprt &rhs = expr.rhs();
+  const exprt &rounding_mode = expr.rounding_mode();
 
   bvt lhs_as_bv = convert_bv(lhs);
   bvt rhs_as_bv = convert_bv(rhs);

--- a/src/solvers/flattening/boolbv_ieee_float_rel.cpp
+++ b/src/solvers/flattening/boolbv_ieee_float_rel.cpp
@@ -14,7 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <solvers/floatbv/float_utils.h>
 
-literalt boolbvt::convert_ieee_float_rel(const exprt &expr)
+literalt boolbvt::convert_ieee_float_rel(const binary_relation_exprt &expr)
 {
   const exprt::operandst &operands=expr.operands();
   const irep_idt &rel=expr.id();

--- a/src/solvers/flattening/boolbv_index.cpp
+++ b/src/solvers/flattening/boolbv_index.cpp
@@ -106,12 +106,13 @@ bvt boolbvt::convert_index(const index_exprt &expr)
 
     if(array.id() == ID_constant || array.id() == ID_array)
     {
-      is_uniform =
-        array.operands().size() <= 1 ||
-        std::all_of(
-          ++array.operands().begin(),
-          array.operands().end(),
-          [&array](const exprt &expr) { return expr == array.op0(); });
+      is_uniform = array.operands().size() <= 1 ||
+                   std::all_of(
+                     ++array.operands().begin(),
+                     array.operands().end(),
+                     [&array](const exprt &expr) {
+                       return expr == to_multi_ary_expr(array).op0();
+                     });
     }
 
     if(is_uniform && prop.has_set_to())
@@ -129,7 +130,7 @@ bvt boolbvt::convert_index(const index_exprt &expr)
       if(!array.has_operands())
         return bv;
 
-      equal_exprt value_equality(result, array.op0());
+      equal_exprt value_equality(result, to_multi_ary_expr(array).op0());
 
       binary_relation_exprt lower_bound(
         from_integer(0, index.type()), ID_le, index);

--- a/src/solvers/flattening/boolbv_overflow.cpp
+++ b/src/solvers/flattening/boolbv_overflow.cpp
@@ -14,24 +14,21 @@ Author: Daniel Kroening, kroening@kroening.com
 
 literalt boolbvt::convert_overflow(const exprt &expr)
 {
-  const exprt::operandst &operands=expr.operands();
-
   if(expr.id()==ID_overflow_plus ||
      expr.id()==ID_overflow_minus)
   {
-    DATA_INVARIANT(
-      operands.size() == 2,
-      "expression " + expr.id_string() + " should have two operands");
+    const auto &overflow_expr = to_binary_expr(expr);
 
-    const bvt &bv0=convert_bv(operands[0]);
-    const bvt &bv1=convert_bv(operands[1]);
+    const bvt &bv0 = convert_bv(overflow_expr.lhs());
+    const bvt &bv1 = convert_bv(overflow_expr.rhs());
 
     if(bv0.size()!=bv1.size())
       return SUB::convert_rest(expr);
 
-    bv_utilst::representationt rep=
-      expr.op0().type().id()==ID_signedbv?bv_utilst::representationt::SIGNED:
-                                          bv_utilst::representationt::UNSIGNED;
+    bv_utilst::representationt rep =
+      overflow_expr.lhs().type().id() == ID_signedbv
+        ? bv_utilst::representationt::SIGNED
+        : bv_utilst::representationt::UNSIGNED;
 
     return expr.id()==ID_overflow_minus?
       bv_utils.overflow_sub(bv0, bv1, rep):
@@ -39,23 +36,23 @@ literalt boolbvt::convert_overflow(const exprt &expr)
   }
   else if(expr.id()==ID_overflow_mult)
   {
-    DATA_INVARIANT(
-      operands.size() == 2,
-      "overflow_mult expression should have two operands");
+    const auto &overflow_expr = to_binary_expr(expr);
 
-    if(operands[0].type().id()!=ID_unsignedbv &&
-       operands[0].type().id()!=ID_signedbv)
+    if(
+      overflow_expr.lhs().type().id() != ID_unsignedbv &&
+      overflow_expr.lhs().type().id() != ID_signedbv)
       return SUB::convert_rest(expr);
 
-    bvt bv0=convert_bv(operands[0]);
-    bvt bv1 = convert_bv(operands[1], bv0.size());
+    bvt bv0 = convert_bv(overflow_expr.lhs());
+    bvt bv1 = convert_bv(overflow_expr.rhs(), bv0.size());
 
-    bv_utilst::representationt rep=
-      operands[0].type().id()==ID_signedbv?bv_utilst::representationt::SIGNED:
-                                           bv_utilst::representationt::UNSIGNED;
+    bv_utilst::representationt rep =
+      overflow_expr.lhs().type().id() == ID_signedbv
+        ? bv_utilst::representationt::SIGNED
+        : bv_utilst::representationt::UNSIGNED;
 
     DATA_INVARIANT(
-      operands[0].type() == operands[1].type(),
+      overflow_expr.lhs().type() == overflow_expr.rhs().type(),
       "operands of overflow_mult expression shall have same type");
 
     std::size_t old_size=bv0.size();
@@ -96,28 +93,27 @@ literalt boolbvt::convert_overflow(const exprt &expr)
   }
   else if(expr.id() == ID_overflow_shl)
   {
-    DATA_INVARIANT(
-      operands.size() == 2, "overflow_shl expression should have two operands");
+    const auto &overflow_expr = to_binary_expr(expr);
 
-    const bvt &bv0=convert_bv(operands[0]);
-    const bvt &bv1=convert_bv(operands[1]);
+    const bvt &bv0 = convert_bv(overflow_expr.lhs());
+    const bvt &bv1 = convert_bv(overflow_expr.rhs());
 
     std::size_t old_size = bv0.size();
     std::size_t new_size = old_size * 2;
 
-    bv_utilst::representationt rep=
-      operands[0].type().id()==ID_signedbv?bv_utilst::representationt::SIGNED:
-                                           bv_utilst::representationt::UNSIGNED;
+    bv_utilst::representationt rep =
+      overflow_expr.lhs().type().id() == ID_signedbv
+        ? bv_utilst::representationt::SIGNED
+        : bv_utilst::representationt::UNSIGNED;
 
     bvt bv_ext=bv_utils.extension(bv0, new_size, rep);
 
     bvt result=bv_utils.shift(bv_ext, bv_utilst::shiftt::SHIFT_LEFT, bv1);
 
     // a negative shift is undefined; yet this isn't an overflow
-    literalt neg_shift =
-      operands[1].type().id() == ID_unsignedbv ?
-        const_literal(false) :
-        bv1.back(); // sign bit
+    literalt neg_shift = overflow_expr.lhs().type().id() == ID_unsignedbv
+                           ? const_literal(false)
+                           : bv1.back(); // sign bit
 
     // an undefined shift of a non-zero value always results in overflow; the
     // use of unsigned comparision is safe here as we cover the signed negative
@@ -162,11 +158,9 @@ literalt boolbvt::convert_overflow(const exprt &expr)
   }
   else if(expr.id()==ID_overflow_unary_minus)
   {
-    DATA_INVARIANT(
-      operands.size() == 1,
-      "overflow_unary_minus expression should have one operand");
+    const auto &overflow_expr = to_unary_expr(expr);
 
-    const bvt &bv=convert_bv(operands[0]);
+    const bvt &bv = convert_bv(overflow_expr.op());
 
     return bv_utils.overflow_negate(bv);
   }

--- a/src/solvers/flattening/boolbv_quantifier.cpp
+++ b/src/solvers/flattening/boolbv_quantifier.cpp
@@ -37,12 +37,14 @@ get_quantifier_var_min(const exprt &var_expr, const exprt &quantifier_expr)
     {
       if(x.id()!=ID_not)
         continue;
-      exprt y=x.op0();
+      exprt y = to_not_expr(x).op();
       if(y.id()!=ID_ge)
         continue;
-      if(expr_eq(var_expr, y.op0()) && y.op1().id()==ID_constant)
+      const auto &y_binary = to_binary_relation_expr(y);
+      if(
+        expr_eq(var_expr, y_binary.lhs()) && y_binary.rhs().id() == ID_constant)
       {
-        return to_constant_expr(y.op1());
+        return to_constant_expr(y_binary.rhs());
       }
     }
   }
@@ -56,9 +58,11 @@ get_quantifier_var_min(const exprt &var_expr, const exprt &quantifier_expr)
     {
       if(x.id()!=ID_ge)
         continue;
-      if(expr_eq(var_expr, x.op0()) && x.op1().id()==ID_constant)
+      const auto &x_binary = to_binary_relation_expr(x);
+      if(
+        expr_eq(var_expr, x_binary.lhs()) && x_binary.rhs().id() == ID_constant)
       {
-        return to_constant_expr(x.op1());
+        return to_constant_expr(x_binary.rhs());
       }
     }
   }
@@ -81,9 +85,11 @@ get_quantifier_var_max(const exprt &var_expr, const exprt &quantifier_expr)
     {
       if(x.id()!=ID_ge)
         continue;
-      if(expr_eq(var_expr, x.op0()) && x.op1().id()==ID_constant)
+      const auto &x_binary = to_binary_relation_expr(x);
+      if(
+        expr_eq(var_expr, x_binary.lhs()) && x_binary.rhs().id() == ID_constant)
       {
-        const constant_exprt &over_expr = to_constant_expr(x.op1());
+        const constant_exprt &over_expr = to_constant_expr(x_binary.rhs());
 
         mp_integer over_i = numeric_cast_v<mp_integer>(over_expr);
 
@@ -93,7 +99,7 @@ get_quantifier_var_max(const exprt &var_expr, const exprt &quantifier_expr)
          * maximum index as specified in the original code.
          **/
         over_i-=1;
-        return from_integer(over_i, x.op1().type());
+        return from_integer(over_i, x_binary.rhs().type());
       }
     }
   }
@@ -107,15 +113,17 @@ get_quantifier_var_max(const exprt &var_expr, const exprt &quantifier_expr)
     {
       if(x.id()!=ID_not)
         continue;
-      exprt y=x.op0();
+      exprt y = to_not_expr(x).op();
       if(y.id()!=ID_ge)
         continue;
-      if(expr_eq(var_expr, y.op0()) && y.op1().id()==ID_constant)
+      const auto &y_binary = to_binary_relation_expr(y);
+      if(
+        expr_eq(var_expr, y_binary.lhs()) && y_binary.rhs().id() == ID_constant)
       {
-        const constant_exprt &over_expr = to_constant_expr(y.op1());
+        const constant_exprt &over_expr = to_constant_expr(y_binary.rhs());
         mp_integer over_i = numeric_cast_v<mp_integer>(over_expr);
         over_i-=1;
-        return from_integer(over_i, y.op1().type());
+        return from_integer(over_i, y_binary.rhs().type());
       }
     }
   }

--- a/src/solvers/flattening/boolbv_update.cpp
+++ b/src/solvers/flattening/boolbv_update.cpp
@@ -10,12 +10,9 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/arith_tools.h>
 
-bvt boolbvt::convert_update(const exprt &expr)
+bvt boolbvt::convert_update(const update_exprt &expr)
 {
   const exprt::operandst &ops=expr.operands();
-
-  if(ops.size()!=3)
-    throw "update takes at three operands";
 
   std::size_t width=boolbv_width(expr.type());
 
@@ -71,7 +68,7 @@ void boolbvt::convert_update_rec(
     if(designator.operands().size()!=1)
       throw "update: index designator takes one operand";
 
-    bvt index_bv=convert_bv(designator.op0());
+    bvt index_bv = convert_bv(to_index_designator(designator).index());
 
     const array_typet &array_type=to_array_type(type);
     const typet &subtype = array_type.subtype();

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -1900,8 +1900,10 @@ static exprt lower_byte_update_struct(
         typecast_exprt::conditional_cast(member, bv_typet{element_bits_int}),
         from_integer(0, bv_typet{shift}),
         bv_typet{shift + element_bits_int}};
+
       if(!little_endian)
-        member.op0().swap(member.op1());
+        to_concatenation_expr(member).op0().swap(
+          to_concatenation_expr(member).op1());
     }
 
     // Finally construct the updated member.
@@ -2125,7 +2127,9 @@ static exprt lower_byte_update(
                             bv_typet{width}};
 
       if(!is_little_endian)
-        val_before.op0().swap(val_before.op1());
+        to_concatenation_expr(val_before)
+          .op0()
+          .swap(to_concatenation_expr(val_before).op1());
     }
     bitand_exprt bitand_expr{val_before, bitnot_exprt{mask_shifted}};
 
@@ -2143,7 +2147,9 @@ static exprt lower_byte_update(
                             bv_typet{width}};
 
       if(!is_little_endian)
-        zero_extended.op0().swap(zero_extended.op1());
+        to_concatenation_expr(zero_extended)
+          .op0()
+          .swap(to_concatenation_expr(zero_extended).op1());
     }
     else
       zero_extended = value;

--- a/src/solvers/prop/bdd_expr.cpp
+++ b/src/solvers/prop/bdd_expr.cpp
@@ -33,25 +33,24 @@ bddt bdd_exprt::from_expr_rec(const exprt &expr)
       "logical and, or, and xor expressions have at least two operands");
     exprt bin_expr=make_binary(expr);
 
-    bddt op0 = from_expr_rec(bin_expr.op0());
-    bddt op1 = from_expr_rec(bin_expr.op1());
+    bddt lhs = from_expr_rec(to_binary_expr(bin_expr).lhs());
+    bddt rhs = from_expr_rec(to_binary_expr(bin_expr).rhs());
 
     return expr.id() == ID_and
-             ? op0.bdd_and(op1)
-             : (expr.id() == ID_or ? op0.bdd_or(op1) : op0.bdd_xor(op1));
+             ? lhs.bdd_and(rhs)
+             : (expr.id() == ID_or ? lhs.bdd_or(rhs) : lhs.bdd_xor(rhs));
   }
   else if(expr.id()==ID_implies)
   {
     const implies_exprt &imp_expr=to_implies_expr(expr);
 
-    bddt n_op0 = from_expr_rec(imp_expr.op0()).bdd_not();
-    bddt op1 = from_expr_rec(imp_expr.op1());
+    bddt n_lhs = from_expr_rec(imp_expr.lhs()).bdd_not();
+    bddt rhs = from_expr_rec(imp_expr.rhs());
 
-    return n_op0.bdd_or(op1);
+    return n_lhs.bdd_or(rhs);
   }
-  else if(expr.id()==ID_equal &&
-          expr.operands().size()==2 &&
-          expr.op0().type().id()==ID_bool)
+  else if(
+    expr.id() == ID_equal && to_equal_expr(expr).lhs().type().id() == ID_bool)
   {
     const equal_exprt &eq_expr=to_equal_expr(expr);
 

--- a/src/solvers/prop/prop_conv_solver.cpp
+++ b/src/solvers/prop/prop_conv_solver.cpp
@@ -392,11 +392,8 @@ void prop_conv_solvert::add_constraints_to_prop(const exprt &expr, bool value)
   {
     if(expr.id() == ID_not)
     {
-      if(expr.operands().size() == 1)
-      {
-        add_constraints_to_prop(expr.op0(), !value);
-        return;
-      }
+      add_constraints_to_prop(to_not_expr(expr).op(), !value);
+      return;
     }
     else
     {
@@ -430,13 +427,11 @@ void prop_conv_solvert::add_constraints_to_prop(const exprt &expr, bool value)
         }
         else if(expr.id() == ID_implies)
         {
-          if(expr.operands().size() == 2)
-          {
-            literalt l0 = convert(expr.op0());
-            literalt l1 = convert(expr.op1());
-            prop.lcnf(!l0, l1);
-            return;
-          }
+          const auto &implies_expr = to_implies_expr(expr);
+          literalt l_lhs = convert(implies_expr.lhs());
+          literalt l_rhs = convert(implies_expr.rhs());
+          prop.lcnf(!l_lhs, l_rhs);
+          return;
         }
         else if(expr.id() == ID_equal)
         {

--- a/src/solvers/qbf/qdimacs_core.cpp
+++ b/src/solvers/qbf/qdimacs_core.cpp
@@ -20,14 +20,17 @@ void qdimacs_coret::simplify_extractbits(exprt &expr) const
 
     forall_operands(it, expr)
     {
-      if(it->id()==ID_extractbit && it->op1().is_constant())
+      if(it->id() == ID_extractbit)
       {
-        used_bits_map[it->op0()].insert(it->op1());
+        const auto &extractbit_expr = to_extractbit_expr(*it);
+        if(extractbit_expr.op1().is_constant())
+          used_bits_map[extractbit_expr.src()].insert(extractbit_expr.index());
       }
-      else if(it->id()==ID_not &&
-              it->op0().id()==ID_extractbit && it->op0().op1().is_constant())
+      else if(it->id() == ID_not && to_not_expr(*it).op().id() == ID_extractbit)
       {
-        used_bits_map[it->op0().op0()].insert(it->op0().op1());
+        const auto &extractbit_expr = to_extractbit_expr(to_not_expr(*it).op());
+        if(extractbit_expr.op1().is_constant())
+          used_bits_map[extractbit_expr.src()].insert(extractbit_expr.index());
       }
     }
 

--- a/src/solvers/refinement/bv_refinement.h
+++ b/src/solvers/refinement/bv_refinement.h
@@ -55,7 +55,7 @@ protected:
   bvt convert_mult(const mult_exprt &expr) override;
   bvt convert_div(const div_exprt &expr) override;
   bvt convert_mod(const mod_exprt &expr) override;
-  bvt convert_floatbv_op(const exprt &expr) override;
+  bvt convert_floatbv_op(const ieee_float_op_exprt &) override;
 
 private:
   // the list of operator approximations

--- a/src/solvers/refinement/refine_arithmetic.cpp
+++ b/src/solvers/refinement/refine_arithmetic.cpp
@@ -33,12 +33,12 @@ void bv_refinementt::approximationt::add_under_assumption(literalt l)
     under_assumptions.push_back(literal_exprt(l));
 }
 
-bvt bv_refinementt::convert_floatbv_op(const exprt &expr)
+bvt bv_refinementt::convert_floatbv_op(const ieee_float_op_exprt &expr)
 {
   if(!config_.refine_arithmetic)
     return SUB::convert_floatbv_op(expr);
 
-  if(expr.type().id() != ID_floatbv || expr.operands().size() != 3)
+  if(expr.type().id() != ID_floatbv)
     return SUB::convert_floatbv_op(expr);
 
   bvt bv;
@@ -497,21 +497,21 @@ bv_refinementt::add_approximation(
 
   if(a.no_operands==1)
   {
-    a.op0_bv=convert_bv(expr.op0());
+    a.op0_bv = convert_bv(to_unary_expr(expr).op());
     set_frozen(a.op0_bv);
   }
   else if(a.no_operands==2)
   {
-    a.op0_bv=convert_bv(expr.op0());
-    a.op1_bv=convert_bv(expr.op1());
+    a.op0_bv = convert_bv(to_binary_expr(expr).op0());
+    a.op1_bv = convert_bv(to_binary_expr(expr).op1());
     set_frozen(a.op0_bv);
     set_frozen(a.op1_bv);
   }
   else if(a.no_operands==3)
   {
-    a.op0_bv=convert_bv(expr.op0());
-    a.op1_bv=convert_bv(expr.op1());
-    a.op2_bv=convert_bv(expr.op2());
+    a.op0_bv = convert_bv(to_multi_ary_expr(expr).op0());
+    a.op1_bv = convert_bv(to_multi_ary_expr(expr).op1());
+    a.op2_bv = convert_bv(to_multi_ary_expr(expr).op2());
     set_frozen(a.op0_bv);
     set_frozen(a.op1_bv);
     set_frozen(a.op2_bv);

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -206,7 +206,7 @@ void smt2_convt::define_object_size(
   const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_object_size);
-  const exprt &ptr = expr.op0();
+  const exprt &ptr = to_unary_expr(expr).op();
   std::size_t size_width = boolbv_width(expr.type());
   std::size_t pointer_width = boolbv_width(ptr.type());
   std::size_t number = 0;
@@ -844,7 +844,8 @@ std::string smt2_convt::type2id(const typet &type) const
 std::string smt2_convt::floatbv_suffix(const exprt &expr) const
 {
   PRECONDITION(!expr.operands().empty());
-  return "_"+type2id(expr.op0().type())+"->"+type2id(expr.type());
+  return "_" + type2id(to_multi_ary_expr(expr).op0().type()) + "->" +
+         type2id(expr.type());
 }
 
 void smt2_convt::convert_floatbv(const exprt &expr)
@@ -1175,9 +1176,9 @@ void smt2_convt::convert_expr(const exprt &expr)
       "operands of equal expression shall have same type");
 
     out << "(= ";
-    convert_expr(expr.op0());
+    convert_expr(equal_expr.op0());
     out << " ";
-    convert_expr(expr.op1());
+    convert_expr(equal_expr.op1());
     out << ")";
   }
   else if(expr.id() == ID_notequal)
@@ -1199,26 +1200,25 @@ void smt2_convt::convert_expr(const exprt &expr)
   {
     // These are not the same as (= A B)
     // because of NaN and negative zero.
+    const auto &rel_expr = to_binary_relation_expr(expr);
+
     DATA_INVARIANT(
-      expr.operands().size() == 2,
-      "float equal and not equal expressions must have two operands");
-    DATA_INVARIANT(
-      expr.op0().type() == expr.op1().type(),
+      rel_expr.lhs().type() == rel_expr.rhs().type(),
       "operands of float equal and not equal expressions shall have same type");
 
     // The FPA theory properly treats NaN and negative zero.
     if(use_FPA_theory)
     {
-      if(expr.id()==ID_ieee_float_notequal)
+      if(rel_expr.id() == ID_ieee_float_notequal)
         out << "(not ";
 
       out << "(fp.eq ";
-      convert_expr(expr.op0());
+      convert_expr(rel_expr.lhs());
       out << " ";
-      convert_expr(expr.op1());
+      convert_expr(rel_expr.rhs());
       out << ")";
 
-      if(expr.id()==ID_ieee_float_notequal)
+      if(rel_expr.id() == ID_ieee_float_notequal)
         out << ")";
     }
     else
@@ -1229,7 +1229,7 @@ void smt2_convt::convert_expr(const exprt &expr)
           expr.id()==ID_ge ||
           expr.id()==ID_gt)
   {
-    convert_relation(expr);
+    convert_relation(to_binary_relation_expr(expr));
   }
   else if(expr.id()==ID_plus)
   {
@@ -1376,15 +1376,14 @@ void smt2_convt::convert_expr(const exprt &expr)
   }
   else if(expr.id()==ID_pointer_offset)
   {
+    const auto &op = to_unary_expr(expr).op();
+
     DATA_INVARIANT(
-      expr.operands().size() == 1,
-      "pointer offset expression shall have one operand");
-    DATA_INVARIANT(
-      expr.op0().type().id() == ID_pointer,
+      op.type().id() == ID_pointer,
       "operand of pointer offset expression shall be of pointer type");
 
-    std::size_t offset_bits=
-      boolbv_width(expr.op0().type())-config.bv_encoding.object_bits;
+    std::size_t offset_bits =
+      boolbv_width(op.type()) - config.bv_encoding.object_bits;
     std::size_t result_width=boolbv_width(expr.type());
 
     // max extract width
@@ -1396,7 +1395,7 @@ void smt2_convt::convert_expr(const exprt &expr)
       out << "((_ zero_extend " << result_width-offset_bits << ") ";
 
     out << "((_ extract " << offset_bits-1 << " 0) ";
-    convert_expr(expr.op0());
+    convert_expr(op);
     out << ")";
 
     if(result_width>offset_bits)
@@ -1404,16 +1403,14 @@ void smt2_convt::convert_expr(const exprt &expr)
   }
   else if(expr.id()==ID_pointer_object)
   {
-    DATA_INVARIANT(
-      expr.operands().size() == 1,
-      "pointer object expressions should have one operand");
+    const auto &op = to_unary_expr(expr).op();
 
     DATA_INVARIANT(
-      expr.op0().type().id() == ID_pointer,
+      op.type().id() == ID_pointer,
       "pointer object expressions should be of pointer type");
 
     std::size_t ext=boolbv_width(expr.type())-config.bv_encoding.object_bits;
-    std::size_t pointer_width=boolbv_width(expr.op0().type());
+    std::size_t pointer_width = boolbv_width(op.type());
 
     if(ext>0)
       out << "((_ zero_extend " << ext << ") ";
@@ -1421,7 +1418,7 @@ void smt2_convt::convert_expr(const exprt &expr)
     out << "((_ extract "
         << pointer_width-1 << " "
         << pointer_width-config.bv_encoding.object_bits << ") ";
-    convert_expr(expr.op0());
+    convert_expr(op);
     out << ")";
 
     if(ext>0)
@@ -1429,19 +1426,16 @@ void smt2_convt::convert_expr(const exprt &expr)
   }
   else if(expr.id() == ID_is_dynamic_object)
   {
-    convert_is_dynamic_object(expr);
+    convert_is_dynamic_object(to_unary_expr(expr));
   }
   else if(expr.id() == ID_is_invalid_pointer)
   {
-    DATA_INVARIANT(
-      expr.operands().size() == 1,
-      "invalid pointer expression shall have one operand");
-
-    std::size_t pointer_width=boolbv_width(expr.op0().type());
+    const auto &op = to_unary_expr(expr).op();
+    std::size_t pointer_width = boolbv_width(op.type());
     out << "(= ((_ extract "
         << pointer_width-1 << " "
         << pointer_width-config.bv_encoding.object_bits << ") ";
-    convert_expr(expr.op0());
+    convert_expr(op);
     out << ") (_ bv" << pointer_logic.get_invalid_object()
         << " " << config.bv_encoding.object_bits << "))";
   }
@@ -1536,13 +1530,10 @@ void smt2_convt::convert_expr(const exprt &expr)
   }
   else if(expr.id()==ID_width)
   {
-    DATA_INVARIANT(
-      expr.operands().size() == 1, "width expression should have one operand");
-
     std::size_t result_width=boolbv_width(expr.type());
     CHECK_RETURN(result_width != 0);
 
-    std::size_t op_width=boolbv_width(expr.op0().type());
+    std::size_t op_width = boolbv_width(to_unary_expr(expr).op().type());
     CHECK_RETURN(op_width != 0);
 
     out << "(_ bv" << op_width/8
@@ -1693,16 +1684,15 @@ void smt2_convt::convert_expr(const exprt &expr)
   else if(expr.id()==ID_overflow_plus ||
           expr.id()==ID_overflow_minus)
   {
-    DATA_INVARIANT(
-      expr.operands().size() == 2,
-      "overflow plus and overflow minus expressions shall have two operands");
+    const auto &op0 = to_binary_expr(expr).op0();
+    const auto &op1 = to_binary_expr(expr).op1();
 
     DATA_INVARIANT(
       expr.type().id() == ID_bool,
       "overflow plus and overflow minus expressions shall be of Boolean type");
 
     bool subtract=expr.id()==ID_overflow_minus;
-    const typet &op_type=expr.op0().type();
+    const typet &op_type = op0.type();
     std::size_t width=boolbv_width(op_type);
 
     if(op_type.id()==ID_signedbv)
@@ -1711,10 +1701,10 @@ void smt2_convt::convert_expr(const exprt &expr)
       out << "(let ((?sum (";
       out << (subtract?"bvsub":"bvadd");
       out << " ((_ sign_extend 1) ";
-      convert_expr(expr.op0());
+      convert_expr(op0);
       out << ")";
       out << " ((_ sign_extend 1) ";
-      convert_expr(expr.op1());
+      convert_expr(op1);
       out << ")))) "; // sign_extend, bvadd/sub let2
       out << "(not (= "
                    "((_ extract " << width << " " << width << ") ?sum) "
@@ -1729,10 +1719,10 @@ void smt2_convt::convert_expr(const exprt &expr)
       out << "((_ extract " << width << " " << width << ") ";
       out << "(" << (subtract?"bvsub":"bvadd");
       out << " ((_ zero_extend 1) ";
-      convert_expr(expr.op0());
+      convert_expr(op0);
       out << ")";
       out << " ((_ zero_extend 1) ";
-      convert_expr(expr.op1());
+      convert_expr(op1);
       out << ")))"; // zero_extend, bvsub/bvadd, extract
       out << " #b1)"; // =
     }
@@ -1744,9 +1734,8 @@ void smt2_convt::convert_expr(const exprt &expr)
   }
   else if(expr.id()==ID_overflow_mult)
   {
-    DATA_INVARIANT(
-      expr.operands().size() == 2,
-      "overflow mult expression shall have two operands");
+    const auto &op0 = to_binary_expr(expr).op0();
+    const auto &op1 = to_binary_expr(expr).op1();
 
     DATA_INVARIANT(
       expr.type().id() == ID_bool,
@@ -1755,15 +1744,15 @@ void smt2_convt::convert_expr(const exprt &expr)
     // No better idea than to multiply with double the bits and then compare
     // with max value.
 
-    const typet &op_type=expr.op0().type();
+    const typet &op_type = op0.type();
     std::size_t width=boolbv_width(op_type);
 
     if(op_type.id()==ID_signedbv)
     {
       out << "(let ( (prod (bvmul ((_ sign_extend " << width << ") ";
-      convert_expr(expr.op0());
+      convert_expr(op0);
       out << ") ((_ sign_extend " << width << ") ";
-      convert_expr(expr.op1());
+      convert_expr(op1);
       out << ")) )) ";
       out << "(or (bvsge prod (_ bv" << power(2, width-1) << " "
           << width*2 << "))";
@@ -1773,9 +1762,9 @@ void smt2_convt::convert_expr(const exprt &expr)
     else if(op_type.id()==ID_unsignedbv)
     {
       out << "(bvuge (bvmul ((_ zero_extend " << width << ") ";
-      convert_expr(expr.op0());
+      convert_expr(op0);
       out << ") ((_ zero_extend " << width << ") ";
-      convert_expr(expr.op1());
+      convert_expr(op1);
       out << ")) (_ bv" << power(2, width) << " " << width*2 << "))";
     }
     else
@@ -2920,25 +2909,21 @@ void smt2_convt::convert_mod(const mod_exprt &expr)
     UNEXPECTEDCASE("unsupported type for mod: "+expr.type().id_string());
 }
 
-void smt2_convt::convert_is_dynamic_object(const exprt &expr)
+void smt2_convt::convert_is_dynamic_object(const unary_exprt &expr)
 {
   std::vector<std::size_t> dynamic_objects;
   pointer_logic.get_dynamic_objects(dynamic_objects);
-
-  DATA_INVARIANT(
-    expr.operands().size() == 1,
-    "is_dynamic_object expression should have one operand");
 
   if(dynamic_objects.empty())
     out << "false";
   else
   {
-    std::size_t pointer_width=boolbv_width(expr.op0().type());
+    std::size_t pointer_width = boolbv_width(expr.op().type());
 
     out << "(let ((?obj ((_ extract "
         << pointer_width-1 << " "
         << pointer_width-config.bv_encoding.object_bits << ") ";
-    convert_expr(expr.op0());
+    convert_expr(expr.op());
     out << "))) ";
 
     if(dynamic_objects.size()==1)
@@ -2961,10 +2946,8 @@ void smt2_convt::convert_is_dynamic_object(const exprt &expr)
   }
 }
 
-void smt2_convt::convert_relation(const exprt &expr)
+void smt2_convt::convert_relation(const binary_relation_exprt &expr)
 {
-  PRECONDITION(expr.operands().size() == 2);
-
   const typet &op_type=expr.op0().type();
 
   if(op_type.id()==ID_unsignedbv ||
@@ -4413,10 +4396,9 @@ void smt2_convt::find_symbols(const exprt &expr)
       defined_expressions[expr]=id;
     }
   }
-  else if(expr.id()==ID_object_size &&
-          expr.operands().size()==1)
+  else if(expr.id() == ID_object_size)
   {
-    const exprt &op = expr.op0();
+    const exprt &op = to_unary_expr(expr).op();
 
     if(op.type().id()==ID_pointer)
     {
@@ -4432,37 +4414,39 @@ void smt2_convt::find_symbols(const exprt &expr)
       }
     }
   }
+  // clang-format off
   else if(!use_FPA_theory &&
-          expr.operands().size()>=1 &&
-          (expr.id()==ID_floatbv_plus ||
-           expr.id()==ID_floatbv_minus ||
-           expr.id()==ID_floatbv_mult ||
-           expr.id()==ID_floatbv_div ||
-           expr.id()==ID_floatbv_typecast ||
-           expr.id()==ID_ieee_float_equal ||
-           expr.id()==ID_ieee_float_notequal ||
-           ((expr.id()==ID_lt ||
-             expr.id()==ID_gt ||
-             expr.id()==ID_le ||
-             expr.id()==ID_ge ||
-             expr.id()==ID_isnan ||
-             expr.id()==ID_isnormal ||
-             expr.id()==ID_isfinite ||
-             expr.id()==ID_isinf ||
-             expr.id()==ID_sign ||
-             expr.id()==ID_unary_minus ||
-             expr.id()==ID_typecast ||
-             expr.id()==ID_abs) &&
-             expr.op0().type().id()==ID_floatbv)))
+          expr.operands().size() >= 1 &&
+          (expr.id() == ID_floatbv_plus ||
+           expr.id() == ID_floatbv_minus ||
+           expr.id() == ID_floatbv_mult ||
+           expr.id() == ID_floatbv_div ||
+           expr.id() == ID_floatbv_typecast ||
+           expr.id() == ID_ieee_float_equal ||
+           expr.id() == ID_ieee_float_notequal ||
+           ((expr.id() == ID_lt ||
+             expr.id() == ID_gt ||
+             expr.id() == ID_le ||
+             expr.id() == ID_ge ||
+             expr.id() == ID_isnan ||
+             expr.id() == ID_isnormal ||
+             expr.id() == ID_isfinite ||
+             expr.id() == ID_isinf ||
+             expr.id() == ID_sign ||
+             expr.id() == ID_unary_minus ||
+             expr.id() == ID_typecast ||
+             expr.id() == ID_abs) &&
+             to_multi_ary_expr(expr).op0().type().id() == ID_floatbv)))
+  // clang-format on
   {
     irep_idt function=
       "|float_bv."+expr.id_string()+floatbv_suffix(expr)+"|";
 
     if(bvfp_set.insert(function).second)
     {
-      out << "; this is a model for " << expr.id()
-          << " : " << type2id(expr.op0().type())
-          << " -> " << type2id(expr.type()) << "\n"
+      out << "; this is a model for " << expr.id() << " : "
+          << type2id(to_multi_ary_expr(expr).op0().type()) << " -> "
+          << type2id(expr.type()) << "\n"
           << "(define-fun " << function << " (";
 
       for(std::size_t i = 0; i < expr.operands().size(); i++)

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -104,8 +104,8 @@ protected:
   void convert_struct(const struct_exprt &expr);
   void convert_union(const union_exprt &expr);
   void convert_constant(const constant_exprt &expr);
-  void convert_relation(const exprt &expr);
-  void convert_is_dynamic_object(const exprt &expr);
+  void convert_relation(const binary_relation_exprt &);
+  void convert_is_dynamic_object(const unary_exprt &);
   void convert_plus(const plus_exprt &expr);
   void convert_minus(const minus_exprt &expr);
   void convert_div(const div_exprt &expr);

--- a/src/solvers/strings/array_pool.cpp
+++ b/src/solvers/strings/array_pool.cpp
@@ -98,10 +98,13 @@ array_string_exprt array_poolt::make_char_array_for_char_pointer(
     // passing the lemmas to the solver.
     return to_array_string_expr(if_exprt(if_expr.cond(), t, f, array_type));
   }
+
   const bool is_constant_array =
     char_pointer.id() == ID_address_of &&
-    (to_address_of_expr(char_pointer).object().id() == ID_index) &&
-    char_pointer.op0().op0().id() == ID_array;
+    to_address_of_expr(char_pointer).object().id() == ID_index &&
+    to_index_expr(to_address_of_expr(char_pointer).object()).array().id() ==
+      ID_array;
+
   if(is_constant_array)
   {
     return to_array_string_expr(

--- a/src/solvers/strings/string_constraint_generator_main.cpp
+++ b/src/solvers/strings/string_constraint_generator_main.cpp
@@ -351,11 +351,14 @@ string_constraint_generatort::add_axioms_for_char_literal(
   // for C programs argument to char literal should be one string constant
   // of size 1.
   if(
-    arg.operands().size() == 1 && arg.op0().operands().size() == 1 &&
-    arg.op0().op0().operands().size() == 2 &&
-    arg.op0().op0().op0().id() == ID_string_constant)
+    arg.operands().size() == 1 &&
+    to_unary_expr(arg).op().operands().size() == 1 &&
+    to_unary_expr(to_unary_expr(arg).op()).op().operands().size() == 2 &&
+    to_binary_expr(to_unary_expr(to_unary_expr(arg).op()).op()).op0().id() ==
+      ID_string_constant)
   {
-    const string_constantt &s = to_string_constant(arg.op0().op0().op0());
+    const string_constantt &s = to_string_constant(
+      to_binary_expr(to_unary_expr(to_unary_expr(arg).op()).op()).op0());
     const std::string &sval = id2string(s.get_value());
     CHECK_RETURN(sval.size() == 1);
     return {from_integer(unsigned(sval[0]), arg.type()), {}};

--- a/src/solvers/strings/string_constraint_instantiation.cpp
+++ b/src/solvers/strings/string_constraint_instantiation.cpp
@@ -74,12 +74,12 @@ linear_functiont::linear_functiont(const exprt &f)
     }
     else if(cur.id() == ID_minus)
     {
-      to_process.emplace_back(cur.op1(), !positive);
-      to_process.emplace_back(cur.op0(), positive);
+      to_process.emplace_back(to_minus_expr(cur).op1(), !positive);
+      to_process.emplace_back(to_minus_expr(cur).op0(), positive);
     }
     else if(cur.id() == ID_unary_minus)
     {
-      to_process.emplace_back(cur.op0(), !positive);
+      to_process.emplace_back(to_unary_minus_expr(cur).op(), !positive);
     }
     else
     {

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -1661,8 +1661,8 @@ static void initial_index_set(
   {
     if(it->id() == ID_index && is_char_type(it->type()))
     {
-      const exprt &s = it->op0();
-      const exprt &i = it->op1();
+      const exprt &s = to_index_expr(*it).array();
+      const exprt &i = to_index_expr(*it).index();
 
       // cur is of the form s[i] and no quantified variable appears in i
       add_to_index_set(index_set, ns, s, i);
@@ -1696,8 +1696,8 @@ static void update_index_set(
     to_process.pop_back();
     if(cur.id() == ID_index && is_char_type(cur.type()))
     {
-      const exprt &s = cur.op0();
-      const exprt &i = cur.op1();
+      const exprt &s = to_index_expr(cur).array();
+      const exprt &i = to_index_expr(cur).index();
       DATA_INVARIANT(
         s.type().id() == ID_array,
         string_refinement_invariantt("index expressions must index on arrays"));


### PR DESCRIPTION
This improves type safety.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
