### PR TITLE
fix accesses to exprt::opX() in goto-programs/

### DIFF
--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -471,7 +471,7 @@ void goto_convertt::do_cpp_new(
     if(new_array)
       new_call.arguments().push_back(count);
     new_call.arguments().push_back(object_size);
-    new_call.arguments().push_back(rhs.op0()); // memory location
+    new_call.arguments().push_back(to_unary_expr(rhs).op()); // memory location
     new_call.set(ID_C_cxx_alloc_type, lhs.type().subtype());
     new_call.lhs()=tmp_symbol_expr;
     new_call.add_source_location()=rhs.source_location();

--- a/src/goto-programs/goto_clean_expr.cpp
+++ b/src/goto-programs/goto_clean_expr.cpp
@@ -505,22 +505,22 @@ void goto_convertt::remove_gcc_conditional_expression(
   goto_programt &dest,
   const irep_idt &mode)
 {
-  DATA_INVARIANT(
-    expr.operands().size() == 2,
-    "gcc conditional expressions must have two operands");
+  {
+    auto &binary_expr = to_binary_expr(expr);
 
-  // first remove side-effects from condition
-  clean_expr(expr.op0(), dest, mode);
+    // first remove side-effects from condition
+    clean_expr(to_binary_expr(expr).op0(), dest, mode);
 
-  // now we can copy op0 safely
-  if_exprt if_expr(
-    typecast_exprt::conditional_cast(expr.op0(), bool_typet()),
-    expr.op0(),
-    expr.op1(),
-    expr.type());
-  if_expr.add_source_location()=expr.source_location();
+    // now we can copy op0 safely
+    if_exprt if_expr(
+      typecast_exprt::conditional_cast(binary_expr.op0(), bool_typet()),
+      binary_expr.op0(),
+      binary_expr.op1(),
+      expr.type());
+    if_expr.add_source_location() = expr.source_location();
 
-  expr.swap(if_expr);
+    expr.swap(if_expr);
+  }
 
   // there might still be junk in expr.op2()
   clean_expr(expr, dest, mode);

--- a/src/goto-programs/goto_trace.cpp
+++ b/src/goto-programs/goto_trace.cpp
@@ -256,8 +256,7 @@ std::string trace_numeric_value(
   }
   else if(expr.id()==ID_union)
   {
-    PRECONDITION(expr.operands().size()==1);
-    return trace_numeric_value(expr.op0(), ns, options);
+    return trace_numeric_value(to_union_expr(expr).op(), ns, options);
   }
 
   return "?";
@@ -351,9 +350,9 @@ void show_state_header(
 bool is_index_member_symbol(const exprt &src)
 {
   if(src.id()==ID_index)
-    return is_index_member_symbol(src.op0());
+    return is_index_member_symbol(to_index_expr(src).array());
   else if(src.id()==ID_member)
-    return is_index_member_symbol(src.op0());
+    return is_index_member_symbol(to_member_expr(src).compound());
   else if(src.id()==ID_symbol)
     return true;
   else

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -456,7 +456,9 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
           (!it->full_lhs_value.is_constant() ||
            !it->full_lhs_value.has_operands() ||
            !has_prefix(
-             id2string(it->full_lhs_value.op0().get(ID_value)), "INVALID-")))
+             id2string(
+               to_multi_ary_expr(it->full_lhs_value).op0().get(ID_value)),
+             "INVALID-")))
         {
           xmlt &val = edge.new_element("data");
           val.set_attribute("key", "assumption");

--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "interpreter_class.h"
 
+#include <util/byte_operators.h>
 #include <util/fixedbv.h>
 #include <util/ieee_float.h>
 #include <util/pointer_offset_size.h>
@@ -350,7 +351,7 @@ void interpretert::evaluate(
     {
       if(expr.has_operands())
       {
-        const exprt &object = skip_typecast(expr.op0());
+        const exprt &object = skip_typecast(to_unary_expr(expr).op());
         if(object.id() == ID_address_of)
         {
           evaluate(object, dest);
@@ -531,13 +532,12 @@ void interpretert::evaluate(
   }
   else if(expr.id()==ID_bitnot)
   {
-    if(expr.operands().size()!=1)
-      throw id2string(expr.id())+" expects one operand";
     mp_vectort tmp;
-    evaluate(expr.op0(), tmp);
+    evaluate(to_bitnot_expr(expr).op(), tmp);
     if(tmp.size()==1)
     {
-      const auto width = to_bitvector_type(expr.op0().type()).get_width();
+      const auto width =
+        to_bitvector_type(to_bitnot_expr(expr).op().type()).get_width();
       const mp_integer mask = power(2, width) - 1;
       dest.push_back(bitwise_xor(tmp.front(), mask));
       return;
@@ -545,88 +545,75 @@ void interpretert::evaluate(
   }
   else if(expr.id()==ID_shl)
   {
-    if(expr.operands().size()!=2)
-      throw id2string(expr.id())+" expects two operands";
-
     mp_vectort tmp0, tmp1;
-    evaluate(expr.op0(), tmp0);
-    evaluate(expr.op1(), tmp1);
+    evaluate(to_shl_expr(expr).op0(), tmp0);
+    evaluate(to_shl_expr(expr).op1(), tmp1);
     if(tmp0.size()==1 && tmp1.size()==1)
     {
-      mp_integer final=arith_left_shift(
+      mp_integer final = arith_left_shift(
         tmp0.front(),
         tmp1.front(),
-        to_bitvector_type(expr.op0().type()).get_width());
+        to_bitvector_type(to_shl_expr(expr).op0().type()).get_width());
       dest.push_back(final);
       return;
     }
   }
-  else if((expr.id()==ID_shr) || (expr.id()==ID_lshr))
+  else if(expr.id() == ID_shr || expr.id() == ID_lshr)
   {
-    if(expr.operands().size()!=2)
-      throw id2string(expr.id())+" expects two operands";
-
     mp_vectort tmp0, tmp1;
-    evaluate(expr.op0(), tmp0);
-    evaluate(expr.op1(), tmp1);
+    evaluate(to_shift_expr(expr).op0(), tmp0);
+    evaluate(to_shift_expr(expr).op1(), tmp1);
     if(tmp0.size()==1 && tmp1.size()==1)
     {
-      mp_integer final=logic_right_shift(
+      mp_integer final = logic_right_shift(
         tmp0.front(),
         tmp1.front(),
-        to_bitvector_type(expr.op0().type()).get_width());
+        to_bitvector_type(to_shift_expr(expr).op0().type()).get_width());
       dest.push_back(final);
       return;
     }
   }
   else if(expr.id()==ID_ashr)
   {
-    if(expr.operands().size()!=2)
-      throw id2string(expr.id())+" expects two operands";
-
     mp_vectort tmp0, tmp1;
-    evaluate(expr.op0(), tmp0);
-    evaluate(expr.op1(), tmp1);
+    evaluate(to_shift_expr(expr).op0(), tmp0);
+    evaluate(to_shift_expr(expr).op1(), tmp1);
     if(tmp0.size()==1 && tmp1.size()==1)
     {
-      mp_integer final=arith_right_shift(
+      mp_integer final = arith_right_shift(
         tmp0.front(),
         tmp1.front(),
-        to_bitvector_type(expr.op0().type()).get_width());
+        to_bitvector_type(to_shift_expr(expr).op0().type()).get_width());
       dest.push_back(final);
       return;
     }
   }
   else if(expr.id()==ID_ror)
   {
-    if(expr.operands().size()!=2)
-      throw id2string(expr.id())+" expects two operands";
-
     mp_vectort tmp0, tmp1;
-    evaluate(expr.op0(), tmp0);
-    evaluate(expr.op1(), tmp1);
+    evaluate(to_binary_expr(expr).op0(), tmp0);
+    evaluate(to_binary_expr(expr).op1(), tmp1);
     if(tmp0.size()==1 && tmp1.size()==1)
     {
-      mp_integer final=rotate_right(tmp0.front(),
+      mp_integer final = rotate_right(
+        tmp0.front(),
         tmp1.front(),
-        to_bitvector_type(expr.op0().type()).get_width());
+        to_bitvector_type(to_binary_expr(expr).op0().type()).get_width());
       dest.push_back(final);
       return;
     }
   }
   else if(expr.id()==ID_rol)
   {
-    if(expr.operands().size()!=2)
-      throw id2string(expr.id())+" expects two operands";
-
     mp_vectort tmp0, tmp1;
-    evaluate(expr.op0(), tmp0);
-    evaluate(expr.op1(), tmp1);
+    evaluate(to_binary_expr(expr).op0(), tmp0);
+    evaluate(to_binary_expr(expr).op1(), tmp1);
     if(tmp0.size()==1 && tmp1.size()==1)
     {
-      mp_integer final=rotate_left(tmp0.front(),
+      mp_integer final = rotate_left(
+        tmp0.front(),
         tmp1.front(),
-        to_bitvector_type(expr.op0().type()).get_width());
+        to_bitvector_type(to_binary_expr(expr).op0().type()).get_width());
       dest.push_back(final);
       return;
     }
@@ -638,12 +625,9 @@ void interpretert::evaluate(
           expr.id()==ID_lt ||
           expr.id()==ID_gt)
   {
-    if(expr.operands().size()!=2)
-      throw id2string(expr.id())+" expects two operands";
-
     mp_vectort tmp0, tmp1;
-    evaluate(expr.op0(), tmp0);
-    evaluate(expr.op1(), tmp1);
+    evaluate(to_binary_expr(expr).op0(), tmp0);
+    evaluate(to_binary_expr(expr).op1(), tmp1);
 
     if(tmp0.size()==1 && tmp1.size()==1)
     {
@@ -691,18 +675,17 @@ void interpretert::evaluate(
   }
   else if(expr.id()==ID_if)
   {
-    if(expr.operands().size()!=3)
-      throw "if expects three operands";
+    const auto &if_expr = to_if_expr(expr);
 
     mp_vectort tmp0, tmp1;
-    evaluate(expr.op0(), tmp0);
+    evaluate(if_expr.cond(), tmp0);
 
     if(tmp0.size()==1)
     {
       if(tmp0.front()!=0)
-        evaluate(expr.op1(), tmp1);
+        evaluate(if_expr.true_case(), tmp1);
       else
-        evaluate(expr.op2(), tmp1);
+        evaluate(if_expr.false_case(), tmp1);
     }
 
     if(tmp1.size()==1)
@@ -735,11 +718,8 @@ void interpretert::evaluate(
   }
   else if(expr.id()==ID_not)
   {
-    if(expr.operands().size()!=1)
-      throw id2string(expr.id())+" expects one operand";
-
     mp_vectort tmp;
-    evaluate(expr.op0(), tmp);
+    evaluate(to_not_expr(expr).op(), tmp);
 
     if(tmp.size()==1)
       dest.push_back(tmp.front()==0);
@@ -817,12 +797,9 @@ void interpretert::evaluate(
   }
   else if(expr.id()==ID_minus)
   {
-    if(expr.operands().size()!=2)
-      throw "- expects two operands";
-
     mp_vectort tmp0, tmp1;
-    evaluate(expr.op0(), tmp0);
-    evaluate(expr.op1(), tmp1);
+    evaluate(to_minus_expr(expr).op0(), tmp0);
+    evaluate(to_minus_expr(expr).op1(), tmp1);
 
     if(tmp0.size()==1 && tmp1.size()==1)
       dest.push_back(tmp0.front()-tmp1.front());
@@ -830,12 +807,9 @@ void interpretert::evaluate(
   }
   else if(expr.id()==ID_div)
   {
-    if(expr.operands().size()!=2)
-      throw "/ expects two operands";
-
     mp_vectort tmp0, tmp1;
-    evaluate(expr.op0(), tmp0);
-    evaluate(expr.op1(), tmp1);
+    evaluate(to_div_expr(expr).op0(), tmp0);
+    evaluate(to_div_expr(expr).op1(), tmp1);
 
     if(tmp0.size()==1 && tmp1.size()==1)
       dest.push_back(tmp0.front()/tmp1.front());
@@ -843,11 +817,8 @@ void interpretert::evaluate(
   }
   else if(expr.id()==ID_unary_minus)
   {
-    if(expr.operands().size()!=1)
-      throw "unary- expects one operand";
-
     mp_vectort tmp0;
-    evaluate(expr.op0(), tmp0);
+    evaluate(to_unary_minus_expr(expr).op(), tmp0);
 
     if(tmp0.size()==1)
       dest.push_back(-tmp0.front());
@@ -855,20 +826,20 @@ void interpretert::evaluate(
   }
   else if(expr.id()==ID_address_of)
   {
-    if(expr.operands().size()!=1)
-      throw "address_of expects one operand";
-
-    dest.push_back(evaluate_address(expr.op0()));
+    dest.push_back(evaluate_address(to_address_of_expr(expr).op()));
     return;
   }
   else if(expr.id()==ID_pointer_offset)
   {
     if(expr.operands().size()!=1)
       throw "pointer_offset expects one operand";
-    if(expr.op0().type().id()!=ID_pointer)
+
+    if(to_unary_expr(expr).op().type().id() != ID_pointer)
       throw "pointer_offset expects a pointer operand";
+
     mp_vectort result;
-    evaluate(expr.op0(), result);
+    evaluate(to_unary_expr(expr).op(), result);
+
     if(result.size()==1)
     {
       // Return the distance, in bytes, between the address returned
@@ -889,12 +860,13 @@ void interpretert::evaluate(
   else if(expr.id()==ID_byte_extract_little_endian ||
           expr.id()==ID_byte_extract_big_endian)
   {
-    if(expr.operands().size()!=2)
-      throw "byte_extract should have two operands";
+    const auto &byte_extract_expr = to_byte_extract_expr(expr);
+
     mp_vectort extract_offset;
-    evaluate(expr.op1(), extract_offset);
+    evaluate(byte_extract_expr.op1(), extract_offset);
     mp_vectort extract_from;
-    evaluate(expr.op0(), extract_from);
+    evaluate(byte_extract_expr.op0(), extract_from);
+
     if(extract_offset.size()==1 && extract_from.size()!=0)
     {
       const typet &target_type=expr.type();
@@ -902,9 +874,7 @@ void interpretert::evaluate(
       // If memory offset is found (which should normally be the case)
       // extract the corresponding data from the appropriate memory location
       if(!byte_offset_to_memory_offset(
-           expr.op0().type(),
-           extract_offset[0],
-           memory_offset))
+           byte_extract_expr.op0().type(), extract_offset[0], memory_offset))
       {
         mp_integer target_type_leaves;
         if(!count_type_leaves(target_type, target_type_leaves) &&
@@ -926,6 +896,7 @@ void interpretert::evaluate(
     mp_integer address=evaluate_address(
       expr,
       true); // fail quietly
+
     if(address.is_zero())
     {
       exprt simplified;
@@ -933,12 +904,13 @@ void interpretert::evaluate(
       // simplify.
       if(expr.id() == ID_index)
       {
-        exprt evaluated_index = expr;
+        index_exprt evaluated_index = to_index_expr(expr);
         mp_vectort idx;
-        evaluate(expr.op1(), idx);
+        evaluate(to_index_expr(expr).index(), idx);
         if(idx.size() == 1)
         {
-          evaluated_index.op1() = from_integer(idx[0], expr.op1().type());
+          evaluated_index.index() =
+            from_integer(idx[0], to_index_expr(expr).index().type());
         }
         simplified = simplify_expr(evaluated_index, ns);
       }
@@ -974,11 +946,8 @@ void interpretert::evaluate(
   }
   else if(expr.id()==ID_typecast)
   {
-    if(expr.operands().size()!=1)
-      throw "typecast expects one operand";
-
     mp_vectort tmp;
-    evaluate(expr.op0(), tmp);
+    evaluate(to_typecast_expr(expr).op(), tmp);
 
     if(tmp.size()==1)
     {
@@ -1031,7 +1000,7 @@ void interpretert::evaluate(
     {
       std::size_t size_int = numeric_cast_v<std::size_t>(size[0]);
       for(std::size_t i=0; i<size_int; ++i)
-        evaluate(expr.op0(), dest);
+        evaluate(to_array_of_expr(expr).op(), dest);
       return;
     }
   }
@@ -1113,37 +1082,28 @@ mp_integer interpretert::evaluate_address(
   }
   else if(expr.id()==ID_dereference)
   {
-    if(expr.operands().size()!=1)
-      throw "dereference expects one operand";
-
     mp_vectort tmp0;
-    evaluate(expr.op0(), tmp0);
+    evaluate(to_dereference_expr(expr).op(), tmp0);
 
     if(tmp0.size()==1)
       return tmp0.front();
   }
   else if(expr.id()==ID_index)
   {
-    if(expr.operands().size()!=2)
-      throw "index expects two operands";
-
     mp_vectort tmp1;
-    evaluate(expr.op1(), tmp1);
+    evaluate(to_index_expr(expr).index(), tmp1);
 
     if(tmp1.size()==1)
     {
-      auto base=evaluate_address(expr.op0(), fail_quietly);
+      auto base = evaluate_address(to_index_expr(expr).array(), fail_quietly);
       if(!base.is_zero())
         return base+tmp1.front();
     }
   }
   else if(expr.id()==ID_member)
   {
-    if(expr.operands().size()!=1)
-      throw "member expects one operand";
-
-    const struct_typet &struct_type=
-      to_struct_type(ns.follow(expr.op0().type()));
+    const struct_typet &struct_type =
+      to_struct_type(ns.follow(to_member_expr(expr).compound().type()));
 
     const irep_idt &component_name=
       to_member_expr(expr).get_component_name();
@@ -1158,45 +1118,44 @@ mp_integer interpretert::evaluate_address(
       offset+=get_size(comp.type());
     }
 
-    auto base=evaluate_address(expr.op0(), fail_quietly);
+    auto base = evaluate_address(to_member_expr(expr).compound(), fail_quietly);
     if(!base.is_zero())
       return base+offset;
   }
   else if(expr.id()==ID_byte_extract_little_endian ||
           expr.id()==ID_byte_extract_big_endian)
   {
-    if(expr.operands().size()!=2)
-      throw "byte_extract should have two operands";
+    const auto &byte_extract_expr = to_byte_extract_expr(expr);
     mp_vectort extract_offset;
-    evaluate(expr.op1(), extract_offset);
+    evaluate(byte_extract_expr.op1(), extract_offset);
     mp_vectort extract_from;
-    evaluate(expr.op0(), extract_from);
+    evaluate(byte_extract_expr.op0(), extract_from);
     if(extract_offset.size()==1 && !extract_from.empty())
     {
       mp_integer memory_offset;
-      if(!byte_offset_to_memory_offset(expr.op0().type(),
-        extract_offset[0], memory_offset))
-        return evaluate_address(expr.op0(), fail_quietly)+memory_offset;
+      if(!byte_offset_to_memory_offset(
+           byte_extract_expr.op0().type(), extract_offset[0], memory_offset))
+        return evaluate_address(byte_extract_expr.op0(), fail_quietly) +
+               memory_offset;
     }
   }
   else if(expr.id()==ID_if)
   {
     mp_vectort result;
+    const auto &if_expr = to_if_expr(expr);
     if_exprt address_cond(
-      expr.op0(),
-      address_of_exprt(expr.op1()),
-      address_of_exprt(expr.op2()));
+      if_expr.cond(),
+      address_of_exprt(if_expr.true_case()),
+      address_of_exprt(if_expr.false_case()));
     evaluate(address_cond, result);
     if(result.size()==1)
       return result[0];
   }
   else if(expr.id()==ID_typecast)
   {
-    if(expr.operands().size()!=1)
-      throw "typecast expects one operand";
-
-    return evaluate_address(expr.op0(), fail_quietly);
+    return evaluate_address(to_typecast_expr(expr).op(), fail_quietly);
   }
+
   if(!fail_quietly)
   {
     error() << "!! failed to evaluate address: "

--- a/src/goto-programs/pointer_arithmetic.cpp
+++ b/src/goto-programs/pointer_arithmetic.cpp
@@ -52,7 +52,7 @@ void pointer_arithmetict::read(const exprt &src)
         add_to_offset(index_expr.index());
         // produce &x[0] + i instead of &x[i]
         auto new_address_of_src = address_of_src;
-        new_address_of_src.op().op1() =
+        to_index_expr(new_address_of_src.op()).index() =
           from_integer(0, index_expr.index().type());
         make_pointer(new_address_of_src);
       }

--- a/src/goto-programs/printf_formatter.cpp
+++ b/src/goto-programs/printf_formatter.cpp
@@ -134,12 +134,15 @@ void printf_formattert::process_format(std::ostream &out)
         break;
       // this is the address of a string
       const exprt &op=*(next_operand++);
-      if(op.id()==ID_address_of &&
-         op.operands().size()==1 &&
-         op.op0().id()==ID_index &&
-         op.op0().operands().size()==2 &&
-         op.op0().op0().id()==ID_string_constant)
-        out << format_constant(op.op0().op0());
+      if(
+        op.id() == ID_address_of &&
+        to_address_of_expr(op).object().id() == ID_index &&
+        to_index_expr(to_address_of_expr(op).object()).array().id() ==
+          ID_string_constant)
+      {
+        out << format_constant(
+          to_index_expr(to_address_of_expr(op).object()).array());
+      }
     }
     break;
 

--- a/src/goto-programs/remove_complex.cpp
+++ b/src/goto-programs/remove_complex.cpp
@@ -24,9 +24,9 @@ static exprt complex_member(const exprt &expr, irep_idt id)
   if(expr.id()==ID_struct && expr.operands().size()==2)
   {
     if(id==ID_real)
-      return expr.op0();
+      return to_binary_expr(expr).op0();
     else if(id==ID_imag)
-      return expr.op1();
+      return to_binary_expr(expr).op1();
     else
       UNREACHABLE;
   }
@@ -138,13 +138,13 @@ static void remove_complex(exprt &expr)
       // x+y -> complex(x.r+y.r,x.i+y.i)
       struct_exprt struct_expr(
         {binary_exprt(
-           complex_member(expr.op0(), ID_real),
+           complex_member(to_binary_expr(expr).op0(), ID_real),
            expr.id(),
-           complex_member(expr.op1(), ID_real)),
+           complex_member(to_binary_expr(expr).op1(), ID_real)),
          binary_exprt(
-           complex_member(expr.op0(), ID_imag),
+           complex_member(to_binary_expr(expr).op0(), ID_imag),
            expr.id(),
-           complex_member(expr.op1(), ID_imag))},
+           complex_member(to_binary_expr(expr).op1(), ID_imag))},
         expr.type());
 
       struct_expr.op0().add_source_location() = expr.source_location();

--- a/src/goto-programs/string_instrumentation.cpp
+++ b/src/goto-programs/string_instrumentation.cpp
@@ -375,12 +375,16 @@ void string_instrumentationt::do_format_string_read(
 {
   const exprt &format_arg=arguments[format_string_inx];
 
-  if(format_arg.id()==ID_address_of &&
-     format_arg.op0().id()==ID_index &&
-     format_arg.op0().op0().id()==ID_string_constant)
+  if(
+    format_arg.id() == ID_address_of &&
+    to_address_of_expr(format_arg).object().id() == ID_index &&
+    to_index_expr(to_address_of_expr(format_arg).object()).array().id() ==
+      ID_string_constant)
   {
-    format_token_listt token_list = parse_format_string(
-      id2string(to_string_constant(format_arg.op0().op0()).get_value()));
+    format_token_listt token_list = parse_format_string(id2string(
+      to_string_constant(
+        to_index_expr(to_address_of_expr(format_arg).object()).array())
+        .get_value()));
 
     std::size_t args=0;
 
@@ -464,12 +468,16 @@ void string_instrumentationt::do_format_string_write(
 {
   const exprt &format_arg=arguments[format_string_inx];
 
-  if(format_arg.id()==ID_address_of &&
-     format_arg.op0().id()==ID_index &&
-     format_arg.op0().op0().id()==ID_string_constant) // constant format
+  if(
+    format_arg.id() == ID_address_of &&
+    to_address_of_expr(format_arg).object().id() == ID_index &&
+    to_index_expr(to_address_of_expr(format_arg).object()).array().id() ==
+      ID_string_constant) // constant format
   {
-    format_token_listt token_list = parse_format_string(
-      id2string(to_string_constant(format_arg.op0().op0()).get_value()));
+    format_token_listt token_list = parse_format_string(id2string(
+      to_string_constant(
+        to_index_expr(to_address_of_expr(format_arg).object()).array())
+        .get_value()));
 
     std::size_t args=0;
 

--- a/src/goto-programs/wp.cpp
+++ b/src/goto-programs/wp.cpp
@@ -65,17 +65,21 @@ aliasingt aliasing(
   const namespacet &ns)
 {
   // deal with some dereferencing
-  if(e1.id()==ID_dereference &&
-     e1.operands().size()==1 &&
-     e1.op0().id()==ID_address_of &&
-     e1.op0().operands().size()==1)
-    return aliasing(e1.op0().op0(), e2, ns);
+  if(
+    e1.id() == ID_dereference &&
+    to_dereference_expr(e1).pointer().id() == ID_address_of)
+  {
+    return aliasing(
+      to_address_of_expr(to_dereference_expr(e1).pointer()).object(), e2, ns);
+  }
 
-  if(e2.id()==ID_dereference &&
-     e2.operands().size()==1 &&
-     e2.op0().id()==ID_address_of &&
-     e2.op0().operands().size()==1)
-    return aliasing(e1, e2.op0().op0(), ns);
+  if(
+    e2.id() == ID_dereference &&
+    to_dereference_expr(e2).pointer().id() == ID_address_of)
+  {
+    return aliasing(
+      e1, to_address_of_expr(to_dereference_expr(e2).pointer()).object(), ns);
+  }
 
   // fairly radical. Ignores struct prefixes and the like.
   if(e1.type() != e2.type())


### PR DESCRIPTION
This improves type safety.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
