### PR TITLE
fix accesses to exprt::opX() in jsil/

### DIFF
--- a/src/jsil/jsil_convert.cpp
+++ b/src/jsil/jsil_convert.cpp
@@ -80,13 +80,13 @@ bool jsil_convertt::convert_code(const symbolt &symbol, codet &code)
 
     if(a.rhs().id()==ID_with)
     {
-      exprt to_try=a.rhs().op0();
+      exprt to_try = to_with_expr(a.rhs()).old();
       codet t(code_assignt(a.lhs(), to_try));
       if(convert_code(symbol, t))
         return true;
 
-      irep_idt c_target=
-        to_symbol_expr(a.rhs().op1()).get_identifier();
+      irep_idt c_target =
+        to_symbol_expr(to_with_expr(a.rhs()).where()).get_identifier();
       code_gotot g(c_target);
 
       code_try_catcht t_c(std::move(t));

--- a/src/jsil/jsil_typecheck.cpp
+++ b/src/jsil/jsil_typecheck.cpp
@@ -294,8 +294,8 @@ void jsil_typecheckt::typecheck_expr_proto_field(exprt &expr)
     throw 0;
   }
 
-  make_type_compatible(expr.op0(), jsil_object_type(), true);
-  make_type_compatible(expr.op1(), string_typet(), true);
+  make_type_compatible(to_binary_expr(expr).op0(), jsil_object_type(), true);
+  make_type_compatible(to_binary_expr(expr).op1(), string_typet(), true);
 
   expr.type()=jsil_value_or_empty_type();
 }
@@ -309,8 +309,8 @@ void jsil_typecheckt::typecheck_expr_proto_obj(exprt &expr)
     throw 0;
   }
 
-  make_type_compatible(expr.op0(), jsil_object_type(), true);
-  make_type_compatible(expr.op1(), jsil_object_type(), true);
+  make_type_compatible(to_binary_expr(expr).op0(), jsil_object_type(), true);
+  make_type_compatible(to_binary_expr(expr).op1(), jsil_object_type(), true);
 
   expr.type()=bool_typet();
 }
@@ -324,8 +324,8 @@ void jsil_typecheckt::typecheck_expr_delete(exprt &expr)
     throw 0;
   }
 
-  make_type_compatible(expr.op0(), jsil_object_type(), true);
-  make_type_compatible(expr.op1(), string_typet(), true);
+  make_type_compatible(to_binary_expr(expr).op0(), jsil_object_type(), true);
+  make_type_compatible(to_binary_expr(expr).op1(), string_typet(), true);
 
   expr.type()=bool_typet();
 }
@@ -339,11 +339,13 @@ void jsil_typecheckt::typecheck_expr_index(exprt &expr)
     throw 0;
   }
 
-  make_type_compatible(expr.op0(), jsil_object_type(), true);
-  make_type_compatible(expr.op1(), string_typet(), true);
+  make_type_compatible(to_binary_expr(expr).op0(), jsil_object_type(), true);
+  make_type_compatible(to_binary_expr(expr).op1(), string_typet(), true);
 
   // special case for function identifiers
-  if(expr.op1().id()=="fid" || expr.op1().id()=="constructid")
+  if(
+    to_binary_expr(expr).op1().id() == "fid" ||
+    to_binary_expr(expr).op1().id() == "constructid")
     expr.type() = code_typet({}, typet());
   else
     expr.type()=jsil_value_type();
@@ -358,8 +360,8 @@ void jsil_typecheckt::typecheck_expr_has_field(exprt &expr)
     throw 0;
   }
 
-  make_type_compatible(expr.op0(), jsil_object_type(), true);
-  make_type_compatible(expr.op1(), string_typet(), true);
+  make_type_compatible(to_binary_expr(expr).op0(), jsil_object_type(), true);
+  make_type_compatible(to_binary_expr(expr).op1(), string_typet(), true);
 
   expr.type()=bool_typet();
 }
@@ -373,7 +375,7 @@ void jsil_typecheckt::typecheck_expr_field(exprt &expr)
     throw 0;
   }
 
-  make_type_compatible(expr.op0(), jsil_reference_type(), true);
+  make_type_compatible(to_unary_expr(expr).op(), jsil_reference_type(), true);
 
   expr.type()=string_typet();
 }
@@ -387,7 +389,7 @@ void jsil_typecheckt::typecheck_expr_base(exprt &expr)
     throw 0;
   }
 
-  make_type_compatible(expr.op0(), jsil_reference_type(), true);
+  make_type_compatible(to_unary_expr(expr).op(), jsil_reference_type(), true);
 
   expr.type()=jsil_value_type();
 }
@@ -401,10 +403,10 @@ void jsil_typecheckt::typecheck_expr_ref(exprt &expr)
     throw 0;
   }
 
-  make_type_compatible(expr.op0(), jsil_value_type(), true);
-  make_type_compatible(expr.op1(), string_typet(), true);
+  make_type_compatible(to_multi_ary_expr(expr).op0(), jsil_value_type(), true);
+  make_type_compatible(to_multi_ary_expr(expr).op1(), string_typet(), true);
 
-  exprt &operand3=expr.op2();
+  exprt &operand3 = to_multi_ary_expr(expr).op2();
   make_type_compatible(operand3, jsil_kind(), true);
 
   if(operand3.id()==ID_member)
@@ -430,8 +432,8 @@ void jsil_typecheckt::typecheck_expr_concatenation(exprt &expr)
     throw 0;
   }
 
-  make_type_compatible(expr.op0(), string_typet(), true);
-  make_type_compatible(expr.op1(), string_typet(), true);
+  make_type_compatible(to_binary_expr(expr).op0(), string_typet(), true);
+  make_type_compatible(to_binary_expr(expr).op1(), string_typet(), true);
 
   expr.type()=string_typet();
 }
@@ -445,8 +447,8 @@ void jsil_typecheckt::typecheck_expr_subtype(exprt &expr)
     throw 0;
   }
 
-  make_type_compatible(expr.op0(), jsil_kind(), true);
-  make_type_compatible(expr.op1(), jsil_kind(), true);
+  make_type_compatible(to_binary_expr(expr).op0(), jsil_kind(), true);
+  make_type_compatible(to_binary_expr(expr).op1(), jsil_kind(), true);
 
   expr.type()=bool_typet();
 }
@@ -460,8 +462,8 @@ void jsil_typecheckt::typecheck_expr_binary_boolean(exprt &expr)
     throw 0;
   }
 
-  make_type_compatible(expr.op0(), bool_typet(), true);
-  make_type_compatible(expr.op1(), bool_typet(), true);
+  make_type_compatible(to_binary_expr(expr).op0(), bool_typet(), true);
+  make_type_compatible(to_binary_expr(expr).op1(), bool_typet(), true);
 
   expr.type()=bool_typet();
 }
@@ -475,9 +477,8 @@ void jsil_typecheckt::typecheck_expr_binary_arith(exprt &expr)
     throw 0;
   }
 
-
-  make_type_compatible(expr.op0(), floatbv_typet(), true);
-  make_type_compatible(expr.op1(), floatbv_typet(), true);
+  make_type_compatible(to_binary_expr(expr).op0(), floatbv_typet(), true);
+  make_type_compatible(to_binary_expr(expr).op1(), floatbv_typet(), true);
 
   expr.type()=floatbv_typet();
 }
@@ -505,8 +506,8 @@ void jsil_typecheckt::typecheck_expr_binary_compare(exprt &expr)
     throw 0;
   }
 
-  make_type_compatible(expr.op0(), floatbv_typet(), true);
-  make_type_compatible(expr.op1(), floatbv_typet(), true);
+  make_type_compatible(to_binary_expr(expr).op0(), floatbv_typet(), true);
+  make_type_compatible(to_binary_expr(expr).op1(), floatbv_typet(), true);
 
   expr.type()=bool_typet();
 }
@@ -520,7 +521,7 @@ void jsil_typecheckt::typecheck_expr_unary_boolean(exprt &expr)
     throw 0;
   }
 
-  make_type_compatible(expr.op0(), bool_typet(), true);
+  make_type_compatible(to_unary_expr(expr).op(), bool_typet(), true);
 
   expr.type()=bool_typet();
 }
@@ -534,7 +535,7 @@ void jsil_typecheckt::typecheck_expr_unary_string(exprt &expr)
     throw 0;
   }
 
-  make_type_compatible(expr.op0(), string_typet(), true);
+  make_type_compatible(to_unary_expr(expr).op(), string_typet(), true);
 
   expr.type()=floatbv_typet();
 }
@@ -548,7 +549,7 @@ void jsil_typecheckt::typecheck_expr_unary_num(exprt &expr)
     throw 0;
   }
 
-  make_type_compatible(expr.op0(), floatbv_typet(), true);
+  make_type_compatible(to_unary_expr(expr).op(), floatbv_typet(), true);
 }
 
 void jsil_typecheckt::typecheck_symbol_expr(symbol_exprt &symbol_expr)


### PR DESCRIPTION
This improves type safety.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
