### PR TITLE
fix accesses to exprt::opX() in unit/

### DIFF
--- a/unit/solvers/strings/string_refinement/substitute_array_list.cpp
+++ b/unit/solvers/strings/string_refinement/substitute_array_list.cpp
@@ -37,19 +37,19 @@ SCENARIO("substitute_array_list", "[core][solvers][strings][string_refinement]")
   // Check that `subst = e1 WITH [1:='y']`
   REQUIRE(subst.id() == ID_with);
   REQUIRE(subst.operands().size() == 3);
-  const exprt &e1 = subst.op0();
-  REQUIRE(subst.op1() == index1);
-  REQUIRE(subst.op2() == chary);
+  const exprt &e1 = to_with_expr(subst).old();
+  REQUIRE(to_with_expr(subst).where() == index1);
+  REQUIRE(to_with_expr(subst).new_value() == chary);
 
   // Check that `e1 = e2 WITH [0:='x']`
   REQUIRE(e1.id() == ID_with);
   REQUIRE(e1.operands().size() == 3);
-  const exprt &e2 = e1.op0();
-  REQUIRE(e1.op1() == index0);
-  REQUIRE(e1.op2() == charx);
+  const exprt &e2 = to_with_expr(e1).old();
+  REQUIRE(to_with_expr(e1).where() == index0);
+  REQUIRE(to_with_expr(e1).new_value() == charx);
 
   // Check that `e1 = ARRAY_OF 0`
   REQUIRE(e2.id() == ID_array_of);
   REQUIRE(e2.operands().size() == 1);
-  REQUIRE(e2.op0() == from_integer(0, char_type));
+  REQUIRE(to_array_of_expr(e2).op() == from_integer(0, char_type));
 }

--- a/unit/util/interval_constraint.cpp
+++ b/unit/util/interval_constraint.cpp
@@ -31,16 +31,20 @@ SCENARIO(
         "expressions representing a <= expr && expr <= z")
       {
         REQUIRE(can_cast_expr<and_exprt>(result));
+        REQUIRE(result.operands().size() == 2);
+        const auto &result_binary = to_binary_expr(result);
 
-        REQUIRE(result.op0().id() == ID_ge);
-        REQUIRE(result.op0().op0().type() == unsignedbv_typet(16));
-        REQUIRE(can_cast_expr<constant_exprt>(result.op0().op1()));
-        REQUIRE(to_constant_expr(result.op0().op1()).get_value() == "61"); // a
+        REQUIRE(result_binary.op0().id() == ID_ge);
+        const auto &op0_binary = to_binary_expr(result_binary.op0());
+        REQUIRE(op0_binary.op0().type() == unsignedbv_typet(16));
+        REQUIRE(can_cast_expr<constant_exprt>(op0_binary.op1()));
+        REQUIRE(to_constant_expr(op0_binary.op1()).get_value() == "61"); // a
 
-        REQUIRE(result.op1().id() == ID_le);
-        REQUIRE(result.op1().op0().type() == unsignedbv_typet(16));
-        REQUIRE(can_cast_expr<constant_exprt>(result.op1().op1()));
-        REQUIRE(to_constant_expr(result.op1().op1()).get_value() == "7A"); // b
+        REQUIRE(result_binary.op1().id() == ID_le);
+        const auto &op1_binary = to_binary_expr(result_binary.op1());
+        REQUIRE(op1_binary.op0().type() == unsignedbv_typet(16));
+        REQUIRE(can_cast_expr<constant_exprt>(op1_binary.op1()));
+        REQUIRE(to_constant_expr(op1_binary.op1()).get_value() == "7A"); // b
       }
     }
   }
@@ -64,16 +68,20 @@ SCENARIO(
         "expressions representing 6 <= expr && expr <= 9")
       {
         REQUIRE(can_cast_expr<and_exprt>(result));
+        REQUIRE(result.operands().size() == 2);
+        const auto &result_binary = to_binary_expr(result);
 
-        REQUIRE(result.op0().id() == ID_ge);
-        REQUIRE(result.op0().op0().type() == unsignedbv_typet(32));
-        REQUIRE(can_cast_expr<constant_exprt>(result.op0().op1()));
-        REQUIRE(to_constant_expr(result.op0().op1()).get_value() == "6");
+        REQUIRE(result_binary.op0().id() == ID_ge);
+        const auto &op0_binary = to_binary_expr(result_binary.op0());
+        REQUIRE(op0_binary.op0().type() == unsignedbv_typet(32));
+        REQUIRE(can_cast_expr<constant_exprt>(op0_binary.op1()));
+        REQUIRE(to_constant_expr(op0_binary.op1()).get_value() == "6");
 
-        REQUIRE(result.op1().id() == ID_le);
-        REQUIRE(result.op1().op0().type() == unsignedbv_typet(32));
-        REQUIRE(can_cast_expr<constant_exprt>(result.op1().op1()));
-        REQUIRE(to_constant_expr(result.op1().op1()).get_value() == "9");
+        REQUIRE(result_binary.op1().id() == ID_le);
+        const auto &op1_binary = to_binary_expr(result_binary.op1());
+        REQUIRE(op1_binary.op0().type() == unsignedbv_typet(32));
+        REQUIRE(can_cast_expr<constant_exprt>(op1_binary.op1()));
+        REQUIRE(to_constant_expr(op1_binary.op1()).get_value() == "9");
       }
     }
   }

--- a/unit/util/irep_sharing.cpp
+++ b/unit/util/irep_sharing.cpp
@@ -3,7 +3,9 @@
 /// \file Tests that irep sharing works correctly
 
 #include <testing-utils/use_catch.h>
+
 #include <util/irep.h>
+#include <util/std_expr.h>
 
 #ifdef SHARING
 
@@ -118,7 +120,7 @@ SCENARIO("exprt_sharing_trade_offs", "[!mayfail][core][utils][exprt]")
 {
   GIVEN("An expression created with add_to_operands(std::move(...))")
   {
-    exprt test_expr(ID_1);
+    multi_ary_exprt test_expr(ID_1);
     exprt test_subexpr(ID_1);
     exprt test_subsubexpr(ID_1);
     test_subexpr.add_to_operands(std::move(test_subsubexpr));
@@ -132,7 +134,7 @@ SCENARIO("exprt_sharing_trade_offs", "[!mayfail][core][utils][exprt]")
       "copying should not change them in the copy")
     {
       exprt &operand = test_expr.op0();
-      exprt expr = test_expr;
+      multi_ary_exprt expr = test_expr;
       operand.id(ID_0);
       REQUIRE(test_expr.op0().id() == ID_0);
       REQUIRE(expr.op0().id() == ID_1);
@@ -140,7 +142,7 @@ SCENARIO("exprt_sharing_trade_offs", "[!mayfail][core][utils][exprt]")
     THEN("Holding a reference to an operand should not prevent sharing")
     {
       exprt &operand = test_expr.op0();
-      exprt expr = test_expr;
+      multi_ary_exprt expr = test_expr;
       REQUIRE(&expr.read() == &test_expr.read());
       operand = exprt(ID_0);
       REQUIRE(expr.op0().id() == test_expr.op0().id());
@@ -152,7 +154,7 @@ SCENARIO("exprt_sharing", "[core][utils][exprt]")
 {
   GIVEN("An expression created with add_to_operands(std::move(...))")
   {
-    exprt test_expr(ID_1);
+    multi_ary_exprt test_expr(ID_1);
     exprt test_subexpr(ID_1);
     exprt test_subsubexpr(ID_1);
     test_subexpr.add_to_operands(std::move(test_subsubexpr));
@@ -165,20 +167,20 @@ SCENARIO("exprt_sharing", "[core][utils][exprt]")
     }
     THEN("Changing operands in the original should not change them in a copy")
     {
-      exprt expr = test_expr;
+      multi_ary_exprt expr = test_expr;
       test_expr.op0().id(ID_0);
       REQUIRE(expr.op0().id() == ID_1);
     }
     THEN("Changing operands in a copy should not change them in the original")
     {
-      exprt expr = test_expr;
+      multi_ary_exprt expr = test_expr;
       expr.op0().id(ID_0);
       REQUIRE(test_expr.op0().id() == ID_1);
       REQUIRE(expr.op0().id() == ID_0);
     }
     THEN("Getting a reference to an operand in a copy should break sharing")
     {
-      exprt expr = test_expr;
+      multi_ary_exprt expr = test_expr;
       exprt &operand = expr.op0();
       REQUIRE(&expr.read() != &test_expr.read());
       operand = exprt(ID_0);
@@ -187,7 +189,7 @@ SCENARIO("exprt_sharing", "[core][utils][exprt]")
     THEN(
       "Getting a reference to an operand in the original should break sharing")
     {
-      exprt expr = test_expr;
+      multi_ary_exprt expr = test_expr;
       exprt &operand = test_expr.op0();
       REQUIRE(&expr.read() != &test_expr.read());
       operand = exprt(ID_0);

--- a/unit/util/replace_symbol.cpp
+++ b/unit/util/replace_symbol.cpp
@@ -16,9 +16,7 @@ TEST_CASE("Replace all symbols in expression", "[core][util][replace_symbol]")
   symbol_exprt s1("a", typet("some_type"));
   symbol_exprt s2("b", typet("some_type"));
 
-  exprt binary("binary", typet("some_type"));
-  binary.copy_to_operands(s1);
-  binary.copy_to_operands(s2);
+  binary_exprt binary(s1, "binary", s2, typet("some_type"));
 
   array_typet array_type(typet("sub-type"), s1);
   REQUIRE(array_type.size() == s1);
@@ -55,9 +53,11 @@ TEST_CASE("Lvalue only", "[core][util][replace_symbol]")
   symbol_exprt array("b", array_type);
   index_exprt index(array, s1);
 
-  exprt binary("binary", typet("some_type"));
-  binary.copy_to_operands(address_of_exprt(s1));
-  binary.copy_to_operands(address_of_exprt(index));
+  binary_exprt binary(
+    address_of_exprt(s1),
+    "binary",
+    address_of_exprt(index),
+    typet("some_type"));
 
   constant_exprt c("some_value", typet("some_type"));
 
@@ -86,9 +86,11 @@ TEST_CASE("Replace always", "[core][util][replace_symbol]")
   symbol_exprt array("b", array_type);
   index_exprt index(array, s1);
 
-  exprt binary("binary", typet("some_type"));
-  binary.copy_to_operands(address_of_exprt(s1));
-  binary.copy_to_operands(address_of_exprt(index));
+  binary_exprt binary(
+    address_of_exprt(s1),
+    "binary",
+    address_of_exprt(index),
+    typet("some_type"));
 
   constant_exprt c("some_value", typet("some_type"));
 


### PR DESCRIPTION
This improves type safety.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
