### PR TITLE
Fix & enable irept pretty-printer

### DIFF
--- a/jbmc/src/java_bytecode/remove_java_new.cpp
+++ b/jbmc/src/java_bytecode/remove_java_new.cpp
@@ -306,7 +306,7 @@ goto_programt::targett remove_java_newt::lower_java_new_array(
     CHECK_RETURN(sub_type.id() == ID_pointer);
     sub_java_new.type() = sub_type;
 
-      plus_exprt(tmp_i, from_integer(1, tmp_i.type()));
+    plus_exprt(tmp_i, from_integer(1, tmp_i.type()));
     dereference_exprt deref_expr(
       plus_exprt(data, tmp_i), data.type().subtype());
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,7 +1,6 @@
 A collection of utility scripts and script applications.
 
-pretty-printers 
-------
+# pretty-printers 
 
 GDB:
 
@@ -25,3 +24,14 @@ scripts, and the code injects the pretty-printers during that.
 
 Nothing else is required to get the pretty-printers to work, beside using 
 GDB to debug the code.
+
+# options
+
+There is an `options.json` file to control any internal options.
+
+List of options.
+
+`clion_pretty_printers`: Some pretty printers work differently if you're
+running them in CLion versus baseline GDB, and aren't very pretty if you 
+look at them in the alternate view. Set to true if you use CLion, false if
+you use commandline GDB. Defaults to true. 

--- a/scripts/pretty-printers/gdb/options.json
+++ b/scripts/pretty-printers/gdb/options.json
@@ -1,0 +1,3 @@
+{
+  "clion_pretty_printers": true
+}


### PR DESCRIPTION
Makes minor changes to the existing irept pretty-printer to make it work in CLion and then enable it. Marked as do-not-merge for now as I start using it locally to make sure there's no obvious problems.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.