### PR TITLE
Do not escape ' in java strings

### DIFF
--- a/src/solvers/strings/string_refinement_util.cpp
+++ b/src/solvers/strings/string_refinement_util.cpp
@@ -63,7 +63,7 @@ utf16_constant_array_to_java(const array_exprt &arr, std::size_t length)
   for(std::size_t i = 0; i < arr.operands().size() && i < length; i++)
     out[i] = numeric_cast_v<unsigned>(to_constant_expr(arr.operands()[i]));
 
-  return utf16_native_endian_to_java(out);
+  return utf16_native_endian_to_java_string(out);
 }
 
 sparse_arrayt::sparse_arrayt(const with_exprt &expr)

--- a/src/util/unicode.cpp
+++ b/src/util/unicode.cpp
@@ -352,17 +352,6 @@ std::string utf16_native_endian_to_java_string(const std::wstring &in)
   return result.str();
 }
 
-/// \param in: String in UTF-16 (native endianness) format
-/// \return String in US-ASCII format, with \\uxxxx escapes for other characters
-std::string utf16_native_endian_to_java(const std::wstring &in)
-{
-  std::ostringstream result;
-  const std::locale loc;
-  for(const auto ch : in)
-    utf16_native_endian_to_java(ch, result, loc);
-  return result.str();
-}
-
 std::string utf16_native_endian_to_utf8(const char16_t utf16_char)
 {
   return utf16_native_endian_to_utf8(std::u16string(1, utf16_char));

--- a/src/util/unicode.h
+++ b/src/util/unicode.h
@@ -28,6 +28,7 @@ utf32_native_endian_to_utf8(const std::basic_string<unsigned int> &s);
 std::wstring utf8_to_utf16_native_endian(const std::string &in);
 std::string utf16_native_endian_to_java(const char16_t ch);
 std::string utf16_native_endian_to_java(const std::wstring &in);
+std::string utf16_native_endian_to_java_string(const std::wstring &in);
 
 std::vector<std::string> narrow_argv(int argc, const wchar_t **argv_wide);
 

--- a/unit/util/unicode.cpp
+++ b/unit/util/unicode.cpp
@@ -93,3 +93,10 @@ TEST_CASE("unicode4", "[core][util][unicode]")
   const std::string s = u8"дȚȨɌṡʒʸͼἨѶݔݺ→⅒⅀▤▞╢◍⛳⻥龍ンㄗㄸ";
   REQUIRE(compare_utf8_to_utf16(s));
 }
+
+TEST_CASE("utf16_native_endian_to_java_string", "[core][util][unicode]")
+{
+  const std::wstring in = L"abc \" ' \\ub374 \\";
+  REQUIRE(
+    utf16_native_endian_to_java_string(in) == "abc \\\" \' \\\\ub374 \\\\");
+}


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

Java strings do not need to escape the ' character (e.g. `"That's cool"` is fine), but java characters do (e.g. `'''` is not fine, it must be `'\''`). This work creates a new conversion function from utf16 to java for characters contained in java strings that does not escape `'`, and then uses that to build a java string from the characters.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
