### PR TITLE
Add java_instanceof_exprt, and use it in place of raw exprts

### DIFF
--- a/jbmc/src/java_bytecode/expr2java.cpp
+++ b/jbmc/src/java_bytecode/expr2java.cpp
@@ -22,6 +22,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <ansi-c/c_misc.h>
 #include <ansi-c/expr2c_class.h>
 
+#include "java_expr.h"
 #include "java_qualifiers.h"
 #include "java_string_literal_expr.h"
 #include "java_types.h"
@@ -320,16 +321,10 @@ std::string expr2javat::convert_java_this()
 
 std::string expr2javat::convert_java_instanceof(const exprt &src)
 {
-  if(src.operands().size()!=2)
-  {
-    unsigned precedence;
-    return convert_norep(src, precedence);
-  }
+  const auto &instanceof_expr = to_java_instanceof_expr(src);
 
-  const auto &binary_expr = to_binary_expr(src);
-
-  return convert(binary_expr.op0()) + " instanceof " +
-         convert(binary_expr.op1().type());
+  return convert(instanceof_expr.tested_expr()) + " instanceof " +
+         convert(instanceof_expr.target_type());
 }
 
 std::string expr2javat::convert_code_java_new(const exprt &src, unsigned indent)

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "bytecode_info.h"
 #include "java_bytecode_convert_method.h"
 #include "java_bytecode_convert_method_class.h"
+#include "java_expr.h"
 #include "java_static_initializers.h"
 #include "java_string_library_preprocess.h"
 #include "java_string_literal_expr.h"
@@ -1687,8 +1688,8 @@ java_bytecode_convert_methodt::convert_instructions(const methodt &method)
     {
       PRECONDITION(op.size() == 1 && results.size() == 1);
 
-      results[0]=
-        binary_predicate_exprt(op[0], ID_java_instanceof, arg0);
+      results[0] =
+        java_instanceof_exprt(op[0], to_struct_tag_type(arg0.type()));
     }
     else if(bytecode == BC_monitorenter || bytecode == BC_monitorexit)
     {
@@ -2326,7 +2327,7 @@ void java_bytecode_convert_methodt::convert_checkcast(
   codet &c,
   exprt::operandst &results) const
 {
-  binary_predicate_exprt check(op[0], ID_java_instanceof, arg0);
+  java_instanceof_exprt check(op[0], to_struct_tag_type(arg0.type()));
   code_assertt assert_class(check);
   assert_class.add_source_location().set_comment("Dynamic cast check");
   assert_class.add_source_location().set_property_class("bad-dynamic-cast");

--- a/jbmc/src/java_bytecode/java_expr.h
+++ b/jbmc/src/java_bytecode/java_expr.h
@@ -1,0 +1,99 @@
+/*******************************************************************\
+
+Module: Java-specific exprt subclasses
+
+Author: Diffblue Ltd
+
+\*******************************************************************/
+
+/// \file
+/// Java-specific exprt subclasses
+
+#ifndef CPROVER_JAVA_BYTECODE_JAVA_EXPR_H
+#define CPROVER_JAVA_BYTECODE_JAVA_EXPR_H
+
+#include <util/std_expr.h>
+
+class java_instanceof_exprt : public binary_predicate_exprt
+{
+public:
+  java_instanceof_exprt(exprt lhs, const struct_tag_typet &target_type)
+    : binary_predicate_exprt(
+        std::move(lhs),
+        ID_java_instanceof,
+        type_exprt(target_type))
+  {
+  }
+
+  const exprt &tested_expr() const
+  {
+    return op0();
+  }
+  exprt &tested_expr()
+  {
+    return op0();
+  }
+
+  const struct_tag_typet &target_type() const
+  {
+    return to_struct_tag_type(op1().type());
+  }
+
+  static void check(
+    const exprt &expr,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    binary_predicate_exprt::check(expr, vm);
+  }
+
+  static void validate(
+    const exprt &expr,
+    const namespacet &ns,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    binary_predicate_exprt::validate(expr, ns, vm);
+
+    DATA_CHECK(
+      vm,
+      can_cast_expr<type_exprt>(expr.op1()),
+      "java_instanceof_exprt rhs should be a type_exprt");
+    DATA_CHECK(
+      vm,
+      can_cast_type<struct_tag_typet>(expr.op1().type()),
+      "java_instanceof_exprt rhs should denote a struct_tag_typet");
+  }
+};
+
+template <>
+inline bool can_cast_expr<java_instanceof_exprt>(const exprt &base)
+{
+  return can_cast_expr<binary_exprt>(base) && base.id() == ID_java_instanceof;
+}
+
+inline void validate_expr(const java_instanceof_exprt &value)
+{
+  java_instanceof_exprt::check(value);
+}
+
+/// \brief Cast an exprt to a \ref java_instanceof_exprt
+///
+/// \a expr must be known to be \ref java_instanceof_exprt.
+///
+/// \param expr: Source expression
+/// \return Object of type \ref java_instanceof_exprt
+inline const java_instanceof_exprt &to_java_instanceof_expr(const exprt &expr)
+{
+  java_instanceof_exprt::check(expr);
+  PRECONDITION(can_cast_expr<java_instanceof_exprt>(expr));
+  return static_cast<const java_instanceof_exprt &>(expr);
+}
+
+/// \copydoc to_java_instanceof_expr(const exprt &)
+inline java_instanceof_exprt &to_java_instanceof_expr(exprt &expr)
+{
+  java_instanceof_exprt::check(expr);
+  PRECONDITION(can_cast_expr<java_instanceof_exprt>(expr));
+  return static_cast<java_instanceof_exprt &>(expr);
+}
+
+#endif // CPROVER_JAVA_BYTECODE_JAVA_EXPR_H

--- a/jbmc/src/java_bytecode/remove_exceptions.cpp
+++ b/jbmc/src/java_bytecode/remove_exceptions.cpp
@@ -32,6 +32,7 @@ Date:   December 2016
 
 #include <linking/static_lifetime_init.h>
 
+#include "java_expr.h"
 #include "java_types.h"
 
 /// Lowers high-level exception descriptions into low-level operations suitable
@@ -366,9 +367,8 @@ void remove_exceptionst::add_exception_dispatch_sequence(
 
         // use instanceof to check that this is the correct handler
         struct_tag_typet type(stack_catch[i][j].first);
-        type_exprt expr(type);
 
-        binary_predicate_exprt check(exc_thrown, ID_java_instanceof, expr);
+        java_instanceof_exprt check(exc_thrown, type);
         t_exc->guard=check;
 
         if(remove_added_instanceof)

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -4071,6 +4071,33 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<type_exprt>(const exprt &base)
+{
+  return base.id() == ID_type;
+}
+
+/// \brief Cast an exprt to an \ref type_exprt
+///
+/// \a expr must be known to be \ref type_exprt.
+///
+/// \param expr: Source expression
+/// \return Object of type \ref type_exprt
+inline const type_exprt &to_type_expr(const exprt &expr)
+{
+  PRECONDITION(can_cast_expr<type_exprt>(expr));
+  const type_exprt &ret = static_cast<const type_exprt &>(expr);
+  return ret;
+}
+
+/// \copydoc to_type_expr(const exprt &)
+inline type_exprt &to_type_expr(exprt &expr)
+{
+  PRECONDITION(can_cast_expr<type_exprt>(expr));
+  type_exprt &ret = static_cast<type_exprt &>(expr);
+  return ret;
+}
+
 /// \brief A constant literal expression
 class constant_exprt : public expr_protectedt
 {


### PR DESCRIPTION
Add java_instanceof_exprt, and use it in place of raw exprts