### PR TITLE
[TG-9189] Value retriever: Allow @nondetLength field to be false.

### DIFF
--- a/jbmc/src/java_bytecode/assignments_from_json.cpp
+++ b/jbmc/src/java_bytecode/assignments_from_json.cpp
@@ -199,9 +199,14 @@ static bool has_nondet_length(const jsont &json)
 /// (typed vs. untyped).
 static jsont get_untyped(const jsont &json, const std::string &object_key)
 {
-  if(get_type(json) || has_nondet_length(json))
-    return json[object_key];
-  return json;
+  if(!json.is_object())
+    return json;
+
+  const auto &json_object = to_json_object(json);
+  PRECONDITION(
+    get_type(json) || json_object.find("@nondetLength") != json_object.end());
+
+  return json[object_key];
 }
 
 /// \ref get_untyped for primitive types.


### PR DESCRIPTION
This can happen with `Arrays$ArrayList`.
get_untyped now no longer calls has_nondet_length, which would fail if `@nondetLength` was false.

There will be a regression test in TG.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
