### PR TITLE
offer .lhs() and .rhs() for all binary expressions

### DIFF
--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1065,11 +1065,11 @@ void goto_checkt::nan_check(
 
     isnan = or_exprt(
       and_exprt(
-        equal_exprt(minus_expr.op0(), plus_inf),
-        equal_exprt(minus_expr.op1(), plus_inf)),
+        equal_exprt(minus_expr.lhs(), plus_inf),
+        equal_exprt(minus_expr.rhs(), plus_inf)),
       and_exprt(
-        equal_exprt(minus_expr.op0(), minus_inf),
-        equal_exprt(minus_expr.op1(), minus_inf)));
+        equal_exprt(minus_expr.lhs(), minus_inf),
+        equal_exprt(minus_expr.rhs(), minus_inf)));
   }
   else
     UNREACHABLE;

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -393,23 +393,23 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
     const minus_exprt &minus_expr = to_minus_expr(expr);
 
     INVARIANT(
-      minus_expr.op0().type().id() == ID_pointer,
+      minus_expr.lhs().type().id() == ID_pointer,
       "first operand should be of pointer type");
 
     if(
-      minus_expr.op1().type().id() != ID_unsignedbv &&
-      minus_expr.op1().type().id() != ID_signedbv)
+      minus_expr.rhs().type().id() != ID_unsignedbv &&
+      minus_expr.rhs().type().id() != ID_signedbv)
     {
       bvt bv;
       conversion_failed(minus_expr, bv);
       return bv;
     }
 
-    const unary_minus_exprt neg_op1(minus_expr.op1());
+    const unary_minus_exprt neg_op1(minus_expr.rhs());
 
-    bvt bv = convert_bv(minus_expr.op0());
+    bvt bv = convert_bv(minus_expr.lhs());
 
-    typet pointer_sub_type = minus_expr.op0().type().subtype();
+    typet pointer_sub_type = minus_expr.rhs().type().subtype();
     mp_integer element_size;
 
     if(pointer_sub_type.id()==ID_empty)

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -691,6 +691,26 @@ public:
     check(expr, vm);
   }
 
+  exprt &lhs()
+  {
+    return exprt::op0();
+  }
+
+  const exprt &lhs() const
+  {
+    return exprt::op0();
+  }
+
+  exprt &rhs()
+  {
+    return exprt::op1();
+  }
+
+  const exprt &rhs() const
+  {
+    return exprt::op1();
+  }
+
   // make op0 and op1 public
   using exprt::op0;
   using exprt::op1;
@@ -820,26 +840,6 @@ public:
       vm,
       expr_binary.op0().type() == expr_binary.op1().type(),
       "lhs and rhs of binary relation expression should have same type");
-  }
-
-  exprt &lhs()
-  {
-    return op0();
-  }
-
-  const exprt &lhs() const
-  {
-    return op0();
-  }
-
-  exprt &rhs()
-  {
-    return op1();
-  }
-
-  const exprt &rhs() const
-  {
-    return op1();
   }
 };
 


### PR DESCRIPTION
This is follow up from #5025.  A clear desire is visible to use `.lhs()` and
`.rhs()` on binary expressions, say `minus_exprt`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
