### PR TITLE
Fix assigning to dynamically allocated structs

### DIFF
--- a/regression/cbmc/dynamic_struct/main.c
+++ b/regression/cbmc/dynamic_struct/main.c
@@ -1,0 +1,58 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#ifndef NULL
+#  define NULL ((void *)0)
+#endif
+
+struct list;
+
+typedef struct list list_nodet;
+
+list_nodet fill_node(signed int depth_tag_list);
+
+struct list
+{
+  int datum;
+  struct list *next;
+};
+
+int max_depth = 4;
+
+list_nodet *build_node(int depth)
+{
+  if(max_depth < depth)
+    return ((list_nodet *)NULL);
+  else
+  {
+    // previous CBMC would work with this line:
+    // list_nodet *result = malloc(sizeof(struct list));
+    // but not this:
+    list_nodet *result = malloc(16);
+    if(result)
+    {
+      *result = fill_node(depth + 1);
+    }
+    return result;
+  }
+}
+
+list_nodet fill_node(int depth)
+{
+  list_nodet result;
+  result.next = build_node(depth);
+  return result;
+}
+
+int main()
+{
+  list_nodet *node = build_node(0);
+  int i = 0;
+  list_nodet *list_walker = node;
+  for(; list_walker; list_walker = list_walker->next)
+  {
+    i = i + 1;
+  }
+  assert(i == 5);
+  return 0;
+}

--- a/regression/cbmc/dynamic_struct/test.desc
+++ b/regression/cbmc/dynamic_struct/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--unwinding-assertions --unwind 11
+^\[main.unwind.0\] line \d+ unwinding assertion loop 0: SUCCESS$
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -936,6 +936,11 @@ void value_sett::get_value_set_rec(
     const typet &op_type = ns.follow(byte_extract_expr.op().type());
     if(op1_offset.has_value() && op_type.id() == ID_struct)
     {
+      if(*op1_offset == 0)
+      {
+        get_value_set_rec(expr.op0(), dest, suffix, original_type, ns);
+        return;
+      }
       const struct_typet &struct_type = to_struct_type(op_type);
 
       for(const auto &c : struct_type.components())


### PR DESCRIPTION
that is when
```
lhs :: [char]
rhs :: byte-extract-expr(struct, 0)
```
before we created a member expression at the offset and, in this case, assigned
to the first member of the struct. Now we assign the whole struct.

A test is included that was previously failing in the unwinding assertion (CBMC
did not see that the next pointer is eventually NULL). Which is issue #5002.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
