### PR TITLE
 cfgt: introduce and use a public interface when interacting with the entry map [blocks: 5049, 5059]

### DIFF
--- a/jbmc/src/java_bytecode/java_local_variable_table.cpp
+++ b/jbmc/src/java_bytecode/java_local_variable_table.cpp
@@ -32,6 +32,10 @@ struct procedure_local_cfg_baset<
   : public grapht<
       cfg_base_nodet<T, java_bytecode_convert_methodt::method_offsett>>
 {
+  typedef grapht<
+    cfg_base_nodet<T, java_bytecode_convert_methodt::method_offsett>>
+    base_grapht;
+  typedef typename base_grapht::nodet nodet;
   typedef java_bytecode_convert_methodt::method_with_amapt method_with_amapt;
   typedef std::map<java_bytecode_convert_methodt::method_offsett,
                    java_bytecode_convert_methodt::method_offsett>
@@ -83,6 +87,23 @@ struct procedure_local_cfg_baset<
         }
       }
     }
+  }
+
+  java_bytecode_convert_methodt::method_offsett get_node_index(
+    const java_bytecode_convert_methodt::method_offsett &instruction) const
+  {
+    return entry_map.at(instruction);
+  }
+
+  nodet &
+  get_node(const java_bytecode_convert_methodt::method_offsett &instruction)
+  {
+    return (*this)[get_node_index(instruction)];
+  }
+  const nodet &get_node(
+    const java_bytecode_convert_methodt::method_offsett &instruction) const
+  {
+    return (*this)[get_node_index(instruction)];
   }
 
   static java_bytecode_convert_methodt::method_offsett

--- a/src/analyses/cfg_dominators.h
+++ b/src/analyses/cfg_dominators.h
@@ -53,14 +53,14 @@ public:
   /// for \p program_point
   const typename cfgt::nodet &get_node(const T &program_point) const
   {
-    return cfg[cfg.entry_map.at(program_point)];
+    return cfg.get_node(program_point);
   }
 
   /// Get the graph node (which gives dominators, predecessors and successors)
   /// for \p program_point
   typename cfgt::nodet &get_node(const T &program_point)
   {
-    return cfg[cfg.entry_map.at(program_point)];
+    return cfg.get_node(program_point);
   }
 
   /// Returns true if the program point corresponding to \p rhs_node is
@@ -149,7 +149,7 @@ void cfg_dominators_templatet<P, T, post_dom>::fixedpoint(P &program)
     entry_node = cfgt::get_last_node(program);
   else
     entry_node = cfgt::get_first_node(program);
-  typename cfgt::nodet &n=cfg[cfg.entry_map[entry_node]];
+  typename cfgt::nodet &n = cfg.get_node(entry_node);
   n.dominators.insert(entry_node);
 
   for(typename cfgt::edgest::const_iterator
@@ -165,7 +165,7 @@ void cfg_dominators_templatet<P, T, post_dom>::fixedpoint(P &program)
     worklist.pop_front();
 
     bool changed=false;
-    typename cfgt::nodet &node=cfg[cfg.entry_map[current]];
+    typename cfgt::nodet &node = cfg.get_node(current);
     if(node.dominators.empty())
     {
       for(const auto &edge : (post_dom ? node.out : node.in))
@@ -248,7 +248,7 @@ inline void dominators_pretty_print_node(
 template <class P, class T, bool post_dom>
 void cfg_dominators_templatet<P, T, post_dom>::output(std::ostream &out) const
 {
-  for(const auto &node : cfg.entry_map)
+  for(const auto &node : cfg.entries())
   {
     auto n=node.first;
 

--- a/src/goto-instrument/count_eloc.cpp
+++ b/src/goto-instrument/count_eloc.cpp
@@ -106,10 +106,10 @@ void print_path_lengths(const goto_modelt &goto_model)
 
   const goto_programt &start_program=start->second.body;
 
-  const cfgt::entryt &start_node=
-    cfg.entry_map[start_program.instructions.begin()];
-  const cfgt::entryt &last_node=
-    cfg.entry_map[--start_program.instructions.end()];
+  const cfgt::entryt &start_node =
+    cfg.get_node_index(start_program.instructions.begin());
+  const cfgt::entryt &last_node =
+    cfg.get_node_index(--start_program.instructions.end());
 
   cfgt::patht shortest_path;
   cfg.shortest_path(start_node, last_node, shortest_path);
@@ -123,7 +123,7 @@ void print_path_lengths(const goto_modelt &goto_model)
       if(i_it->is_backwards_goto() ||
          i_it==gf_it->second.body.instructions.begin())
       {
-        const cfgt::entryt &node=cfg.entry_map[i_it];
+        const cfgt::entryt &node = cfg.get_node_index(i_it);
         cfgt::patht loop;
         cfg.shortest_loop(node, loop);
 

--- a/src/goto-instrument/points_to.cpp
+++ b/src/goto-instrument/points_to.cpp
@@ -21,12 +21,9 @@ void points_tot::fixedpoint()
   {
     added=false;
 
-    for(cfgt::entry_mapt::iterator
-        e_it=cfg.entry_map.begin();
-        e_it!=cfg.entry_map.end();
-        e_it++)
+    for(const auto &instruction_and_entry : cfg.entries())
     {
-      if(transform(cfg[e_it->second]))
+      if(transform(cfg[instruction_and_entry.second]))
         added=true;
     }
   }

--- a/src/goto-programs/cfg.h
+++ b/src/goto-programs/cfg.h
@@ -61,8 +61,11 @@ template<class T,
          typename I=goto_programt::const_targett>
 class cfg_baset:public grapht< cfg_base_nodet<T, I> >
 {
+  typedef grapht<cfg_base_nodet<T, I>> base_grapht;
+
 public:
-  typedef std::size_t entryt;
+  typedef typename base_grapht::node_indext entryt;
+  typedef typename base_grapht::nodet nodet;
 
   class entry_mapt final
   {
@@ -73,9 +76,9 @@ public:
     grapht< cfg_base_nodet<T, I> > &container;
 
     // NOLINTNEXTLINE(readability/identifiers)
-    typedef data_typet::iterator iterator;
+    typedef typename data_typet::iterator iterator;
     // NOLINTNEXTLINE(readability/identifiers)
-    typedef data_typet::const_iterator const_iterator;
+    typedef typename data_typet::const_iterator const_iterator;
 
     template <typename U>
     const_iterator find(U &&u) const { return data.find(std::forward<U>(u)); }
@@ -177,6 +180,36 @@ public:
   {
     goto_functionst goto_functions;
     compute_edges(goto_functions, goto_program);
+  }
+
+  /// Get the graph node index for \p program_point. Use this with operator[]
+  /// to get the related graph node (e.g. `cfg[cfg.get_node_index(i)]`, though
+  /// in that particular case you should just use `cfg.get_node(i)`). Storing
+  /// node indices saves a map lookup, so it can be worthwhile when you expect
+  /// to repeatedly look up the same program point.
+  entryt get_node_index(const I &program_point) const
+  {
+    return entry_map.at(program_point);
+  }
+
+  /// Get the CFG graph node relating to \p program_point.
+  nodet &get_node(const I &program_point)
+  {
+    return (*this)[get_node_index(program_point)];
+  }
+
+  /// Get the CFG graph node relating to \p program_point.
+  const nodet &get_node(const I &program_point) const
+  {
+    return (*this)[get_node_index(program_point)];
+  }
+
+  /// Get a map from program points to their corresponding node indices. Use
+  /// the indices with `operator[]` similar to those returned by
+  /// \ref get_node_index.
+  const entry_mapt &entries() const
+  {
+    return entry_map;
   }
 
   static I get_first_node(P &program)


### PR DESCRIPTION
This eliminates many uses of the `cfg[cfg.entry_map[instruction]]` pattern, and makes it easier to refactor / change the implementation of cfgt. No behavioural changes intended. Depends on #5045 -- don't review the first commit.