### PR TITLE
Use general `satcheckt` instead of explicit MiniSAT version

### DIFF
--- a/unit/solvers/strings/string_refinement/string_refinement.cpp
+++ b/unit/solvers/strings/string_refinement/string_refinement.cpp
@@ -32,7 +32,7 @@ SCENARIO("string refinement", "[core][solvers][strings][string_refinement]")
   namespacet ns{symbol_table};
   info.ns = &ns;
 
-  satcheck_minisat_simplifiert sat_solver{log};
+  satcheckt sat_solver{log};
   info.prop = &sat_solver;
 
   string_refinementt solver{info};


### PR DESCRIPTION
The unit tests for the string solvers used the type
`satcheck_minisat_simplifiert` which does not allow for changing the underlying
solver.

This commit changes this to use the general `satcheckt` type as solver.
