### PR TITLE
Allow user of run_doxygen script to specify path to doxygen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,11 +69,10 @@ jobs:
           then
             scripts/build_doxygen.sh ${DOXYGEN_VERSION}
           fi
-        - export PATH="$PATH:${TRAVIS_BUILD_DIR}/doxygen/build/bin"
       script:
         - echo $PATH
-        - doxygen --version
-        - scripts/run_doxygen.sh
+        - ${TRAVIS_BUILD_DIR}/doxygen/build/bin/doxygen --version
+        - scripts/run_doxygen.sh ${TRAVIS_BUILD_DIR}/doxygen/build/bin/doxygen
       before_cache:
       after_success:
         # Google Cloud Integration

--- a/scripts/run_doxygen.sh
+++ b/scripts/run_doxygen.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 
+doxygen_executable=${1:-doxygen}
+
 # Check doxygen version
 EXPECTED_VERSION="1.8.16"
-doxygen --version | grep ^$EXPECTED_VERSION > /dev/null
+$doxygen_executable --version | grep ^$EXPECTED_VERSION > /dev/null
 if [ $? -ne 0 ]
 then
   echo "WARNING: Using wrong version of doxygen.\
   The list of expected warnings is for version $EXPECTED_VERSION."
+  $doxygen_executable --version
+
 fi
 
 # Run doxygen and filter warnings
 SCRIPT_FOLDER=`dirname $0`
 cd $SCRIPT_FOLDER/../src
-doxygen 2>&1 | ../scripts/filter_expected_warnings.py ../scripts/expected_doxygen_warnings.txt
+$doxygen_executable 2>&1 | ../scripts/filter_expected_warnings.py ../scripts/expected_doxygen_warnings.txt


### PR DESCRIPTION
Modify the `run_doxygen.sh` shell script to optionally take the path to doxygen as an argument. 

This change made it a little easier to test the broken doxygen problem so I'm suggesting it as an improvement.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [na] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
