### PR TITLE
Natural loops: do not insist that loops only have one backedge

### DIFF
--- a/regression/goto-instrument/natural-loops-multiple-backedges/main.c
+++ b/regression/goto-instrument/natural-loops-multiple-backedges/main.c
@@ -1,0 +1,10 @@
+int main(int argc, char **argv)
+{
+loop_header:
+  --argc;
+  if(argc == 1)
+    goto loop_header;
+  else if(argc == 2)
+    goto loop_header;
+  return argc;
+}

--- a/regression/goto-instrument/natural-loops-multiple-backedges/test.desc
+++ b/regression/goto-instrument/natural-loops-multiple-backedges/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--show-natural-loops
+0 is head of \{ 0, 1, 2, 4 \}
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/analyses/natural_loops.h
+++ b/src/analyses/natural_loops.h
@@ -241,7 +241,12 @@ void natural_loops_templatet<P, T>::compute_natural_loop(T m, T n)
   std::stack<T> stack;
 
   auto insert_result = loop_map.emplace(n, natural_loopt{*this});
-  INVARIANT(insert_result.second, "each loop head should only be visited once");
+  // Note the emplace *may* access a loop that already exists: this happens when
+  // a given header has more than one incoming edge, such as
+  // head: if(x) goto head; else goto head;
+  // In this case this compute routine is run twice, one for each backedge, with
+  // each adding whatever instructions can reach this 'm' (the program point
+  // that branches to the loop header, 'n').
   natural_loopt &loop = insert_result.first->second;
 
   loop.insert_instruction(n);


### PR DESCRIPTION
I accidentally added this check when altering the natural loops data structures as it appeared
that each loop head was visited once -- in fact each *backedge* is visited once, and many such
edges may target the same loop header.