### PR TITLE
Disable clang format for java

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -87,4 +87,5 @@ UseTab: Never
 ---
 Language: Java
 ColumnLimit: '80'
+DisableFormat: 'true'
 ...


### PR DESCRIPTION
This PR should disable clang-format for java. I don't think we are particularly prescriptive about our java style, and it's annoying when PRs fail because of a java formatting issue. I've cherry-picked #5068 which is currently failing for this reason to check that it works. I've marked it "Do not merge" until those two commits have been removed.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
