### PR TITLE
Set default max string length below existing max concrete string size

### DIFF
--- a/jbmc/regression/jbmc-strings/long_string/test_abort.desc
+++ b/jbmc/regression/jbmc-strings/long_string/test_abort.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---function Test.checkAbort --trace
+--function Test.checkAbort --trace --max-nondet-string-length 100000000
 ^EXIT=10$
 ^SIGNAL=0$
 dynamic_object[0-9]*=\(assignment removed\)

--- a/jbmc/regression/jbmc-strings/string-non-empty-option/test_non_empty.desc
+++ b/jbmc/regression/jbmc-strings/string-non-empty-option/test_non_empty.desc
@@ -1,6 +1,6 @@
 CORE
 Test.class
---function Test.checkMinLength --string-non-empty
+--function Test.checkMinLength --string-non-empty --max-nondet-string-length 2147483647
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.* line 11 function java::Test.checkMinLength.*: SUCCESS
@@ -9,3 +9,6 @@ assertion.* line 17 function java::Test.checkMinLength.*: FAILURE
 assertion.* line 19 function java::Test.checkMinLength.*: FAILURE
 --
 ^Building error trace
+--
+The max-nondet-string-length permits strings long enough that they might overflow an
+int32, as tested here.

--- a/src/solvers/strings/string_refinement.h
+++ b/src/solvers/strings/string_refinement.h
@@ -21,6 +21,7 @@ Author: Alberto Griggio, alberto.griggio@gmail.com
 #define CPROVER_SOLVERS_REFINEMENT_STRING_REFINEMENT_H
 
 #include <limits>
+#include <util/magic.h>
 #include <util/replace_expr.h>
 #include <util/string_expr.h>
 #include <util/union_find_replace.h>
@@ -46,7 +47,10 @@ Author: Alberto Griggio, alberto.griggio@gmail.com
   " --string-input-value st      restrict non-null strings to a fixed value st;\n" /* NOLINT(*) */ \
   "                              the switch can be used multiple times to give\n" /* NOLINT(*) */ \
   "                              several strings\n" /* NOLINT(*) */ \
-  " --max-nondet-string-length n bound the length of nondet (e.g. input) strings\n" /* NOLINT(*) */
+  " --max-nondet-string-length n bound the length of nondet (e.g. input) strings.\n" /* NOLINT(*) */ \
+  "                              Default is " + std::to_string(MAX_CONCRETE_STRING_SIZE - 1) + "; note that\n" /* NOLINT(*) */ \
+  "                              setting the value higher than this does not work\n" /* NOLINT(*) */ \
+  "                              with --trace or --validate-trace.\n" /* NOLINT(*) */
 
 // The integration of the string solver into CBMC is incomplete. Therefore,
 // it is not turned on by default and not all options are available.

--- a/src/util/object_factory_parameters.h
+++ b/src/util/object_factory_parameters.h
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <list>
 
 #include <util/irep.h>
+#include <util/magic.h>
 #include <util/optional.h>
 
 #include "integer_interval.h"
@@ -39,8 +40,11 @@ struct object_factory_parameterst
   size_t max_nondet_array_length = 5;
 
   /// Maximum value for the non-deterministically-chosen length of a string.
-  size_t max_nondet_string_length =
-    static_cast<std::size_t>(std::numeric_limits<std::int32_t>::max());
+  /// Defaults to MAX_CONCRETE_STRING_SIZE - 1 such that even with a null
+  /// terminator all strings can be rendered concretely by string-refinement's
+  /// `get_array` function, which is used by `--trace` among other C/JBMC
+  /// options.
+  size_t max_nondet_string_length = MAX_CONCRETE_STRING_SIZE - 1;
 
   /// Minimum value for the non-deterministically-chosen length of a string.
   size_t min_nondet_string_length = 0;


### PR DESCRIPTION
Previously by default JBMC could guess at arbitrarily long strings but could not concretise
them (i.e. decision_proceduret::get() could not handle the ensuing very large arrays). This
meant JBMC would crash with --validate-trace (always enabled in regression testing), or
without it client code would encounter an unexpected nil_exprt.

After one too many difficult-to-reproduce regression test failures, I think it's finally time we set this by default...