### PR TITLE
(Calling) context sensitivity in the abstract interpreter

### DIFF
--- a/regression/goto-analyzer/command_line_01/main.c
+++ b/regression/goto-analyzer/command_line_01/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+int f00(int x)
+{
+  assert(x != 0);
+  return 0;
+}
+
+int main(int argc, char **argv)
+{
+  int v = 0;
+  v = f00(v);
+  assert(v != 0);
+
+  return 0;
+}

--- a/regression/goto-analyzer/command_line_01/test.desc
+++ b/regression/goto-analyzer/command_line_01/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--verify --recursive-interprocedural --ahistorical --constants --one-domain-per-history
+\[main.assertion.1\] line 13 assertion v != 0: FAILURE \(if reachable\)
+\[f00.assertion.1\] line 5 assertion x != 0: FAILURE \(if reachable\)
+Summary: 0 pass, 2 fail if reachable, 0 unknown
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Tests the full AI configuration tuple AI/history/domain/storage

--- a/regression/goto-analyzer/command_line_02/main.c
+++ b/regression/goto-analyzer/command_line_02/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+int f00(int x)
+{
+  assert(x != 0);
+  return 0;
+}
+
+int main(int argc, char **argv)
+{
+  int v = 0;
+  v = f00(v);
+  assert(v != 0);
+
+  return 0;
+}

--- a/regression/goto-analyzer/command_line_02/test.desc
+++ b/regression/goto-analyzer/command_line_02/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--verify --recursive-interprocedural --ahistorical --constants --one-domain-per-location
+\[main.assertion.1\] line 13 assertion v != 0: FAILURE \(if reachable\)
+\[f00.assertion.1\] line 5 assertion x != 0: FAILURE \(if reachable\)
+Summary: 0 pass, 2 fail if reachable, 0 unknown
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Tests the full AI configuration tuple AI/history/domain/storage

--- a/regression/goto-analyzer/context_sensitivity_01/main.c
+++ b/regression/goto-analyzer/context_sensitivity_01/main.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+
+unsigned fib(unsigned x)
+{
+  switch(x)
+  {
+  case 0:
+    return 0;
+    break;
+  case 1:
+    return 1;
+    break;
+  default:
+    return fib(x - 1) + fib(x - 2);
+    break;
+  }
+}
+
+int main(int argc, char **argv)
+{
+  unsigned v = fib(7);
+  assert(v == 13); // Requires context sensitivity to handle with constants
+
+  unsigned w = fib(9);
+  assert(w == 24); // Requires location, not just function tracking
+
+  return 0;
+}

--- a/regression/goto-analyzer/context_sensitivity_01/test.desc
+++ b/regression/goto-analyzer/context_sensitivity_01/test.desc
@@ -1,0 +1,12 @@
+FUTURE
+main.c
+--verify --recursive-interprocedural --call-stack 10 --constants --one-domain-per-history
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion v == 13: SUCCESS$
+^\[main.assertion.2\] .* assertion w == 24: SUCCESS$
+--
+^warning: ignoring
+--
+This should be possible just tracking constants and calling stacks.
+At the moment the --constants domain can't do it due to the way it proactively merges to handle recursion.

--- a/regression/goto-analyzer/context_sensitivity_02/main.c
+++ b/regression/goto-analyzer/context_sensitivity_02/main.c
@@ -1,0 +1,17 @@
+#include <assert.h>
+
+int negate(int x)
+{
+  return -x;
+}
+
+int main(int argc, char **argv)
+{
+  int x = 23;
+  int nx = negate(x);
+  int nnx = negate(nx);
+
+  assert(x == nnx);
+
+  return 0;
+}

--- a/regression/goto-analyzer/context_sensitivity_02/test.desc
+++ b/regression/goto-analyzer/context_sensitivity_02/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--verify --recursive-interprocedural --call-stack 0 --constants --one-domain-per-history
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion x == nnx: SUCCESS$
+--
+^warning: ignoring
+--
+A simple test of call stacks and context sensitivity.  Merging calling context with contexts will give a failure.

--- a/regression/goto-analyzer/context_sensitivity_03/main.c
+++ b/regression/goto-analyzer/context_sensitivity_03/main.c
@@ -1,0 +1,23 @@
+#include <assert.h>
+
+int step(int x)
+{
+  if(x <= 0)
+  {
+    return 0;
+  }
+  else
+  {
+    return x + step(x - 1);
+  }
+}
+
+int main(int argc, char **argv)
+{
+  int x = 5;
+  int res = step(x);
+
+  assert(res == 15);
+
+  return 0;
+}

--- a/regression/goto-analyzer/context_sensitivity_03/test.desc
+++ b/regression/goto-analyzer/context_sensitivity_03/test.desc
@@ -1,0 +1,11 @@
+FUTURE
+main.c
+--verify --recursive-interprocedural --call-stack 10 --constants --one-domain-per-history
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion res == 15: SUCCESS$
+--
+^warning: ignoring
+--
+This should be possible just tracking constants and calling stacks.
+At the moment the --constants domain can't do it due to the way it proactively merges to handle recursion.

--- a/regression/goto-analyzer/context_sensitivity_04/main.c
+++ b/regression/goto-analyzer/context_sensitivity_04/main.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+
+int step(int x)
+{
+  if(x == 0)
+  {
+    assert(x == 0);
+    return 0;
+  }
+  else
+  {
+    return step(x - 1);
+  }
+}
+
+int main(int argc, char **argv)
+{
+  int orig = 20;
+  int res = step(orig);
+
+  assert(res == 0);
+
+  return 0;
+}

--- a/regression/goto-analyzer/context_sensitivity_04/test.desc
+++ b/regression/goto-analyzer/context_sensitivity_04/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--verify --recursive-interprocedural --call-stack 10 --constants --one-domain-per-history
+^\[main.assertion.1\] .* assertion res == 0: SUCCESS$
+^\[step.assertion.1\] .* assertion x == 0: SUCCESS$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Tests the interaction of call stacks and recursion.
+

--- a/regression/goto-analyzer/context_sensitivity_05/main.c
+++ b/regression/goto-analyzer/context_sensitivity_05/main.c
@@ -1,0 +1,54 @@
+#include <assert.h>
+
+void f00(int x, int y)
+{
+  if(x < 0)
+  {
+    // Unreachable in all traces if they are considered individually
+    assert(x < 0);
+    assert(1);
+    assert(0);
+  }
+
+  assert(x >= 0); // True in all traces
+  assert(x < 0);  // False in all traces
+  assert(x < 2);  // Split; true in some, false in others
+
+  assert((x <= 0) ? 1 : y);                  // True in some, unknown in others
+  assert((x <= 1) ? 0 : y);                  // False in some, unknown in others
+  assert((x <= 2) ? ((x <= 3) ? 1 : 0) : y); // A mix of all three
+
+  if(x < 5)
+  {
+    // Not reachable in all traces
+    assert((x <= 0) ? 1 : y); // True in some, unknown in others
+    assert((x <= 1) ? 0 : y); // False in some, unknown in others
+    assert((x <= 2) ? ((x <= 3) ? 1 : 0) : y); // A mix of all three
+  }
+
+  if(x < 3)
+  {
+    // Not reachable in all traces
+    assert((x <= 0) ? 1 : y); // True in some, unknown in others
+    assert((x <= 1) ? 0 : y); // False in some, unknown in others
+    assert((x <= 2) ? ((x <= 3) ? 1 : 0) : y); // A mix of all three
+  }
+}
+
+int nondet_int();
+
+int main(int argc, char **argv)
+{
+  int y = nondet_int();
+
+  // Because the history is context sensitive these should be analysed independently
+  // Just showing the domain will merge them giving top for everything interesting
+  f00(0, y);
+  f00(1, y);
+  f00(2, y);
+  f00(3, y);
+  f00(4, y);
+  f00(5, y);
+
+  return 0;
+}

--- a/regression/goto-analyzer/context_sensitivity_05/test.desc
+++ b/regression/goto-analyzer/context_sensitivity_05/test.desc
@@ -1,0 +1,25 @@
+CORE
+main.c
+--verify --recursive-interprocedural --call-stack 0 --constants --one-domain-per-history
+^\[f00.assertion.1\] .* assertion x < 0: SUCCESS \(unreachable\)$
+^\[f00.assertion.2\] .* assertion 1: SUCCESS \(unreachable\)$
+^\[f00.assertion.3\] .* assertion 0: SUCCESS \(unreachable\)$
+^\[f00.assertion.4\] .* assertion x >= 0: SUCCESS$
+^\[f00.assertion.5\] .* assertion x < 0: FAILURE \(if reachable\)$
+^\[f00.assertion.6\] .* assertion x < 2: FAILURE \(if reachable\)$
+^\[f00.assertion.7\] .* assertion \(x <= 0\) \? 1 : y: UNKNOWN$
+^\[f00.assertion.8\] .* assertion \(x <= 1\) \? 0 : y: UNKNOWN$
+^\[f00.assertion.9\] .* assertion \(x <= 2\) \? \(\(x <= 3\) \? 1 : 0\) : y: UNKNOWN$
+^\[f00.assertion.10\] .* assertion \(x <= 0\) \? 1 : y: UNKNOWN$
+^\[f00.assertion.11\] .* assertion \(x <= 1\) \? 0 : y: UNKNOWN$
+^\[f00.assertion.12\] .* assertion \(x <= 2\) \? \(\(x <= 3\) \? 1 : 0\) : y: UNKNOWN$
+^\[f00.assertion.13\] .* assertion \(x <= 0\) \? 1 : y: UNKNOWN$
+^\[f00.assertion.14\] .* assertion \(x <= 1\) \? 0 : y: UNKNOWN$
+^\[f00.assertion.15\] .* assertion \(x <= 2\) \? \(\(x <= 3\) \? 1 : 0\) : y: SUCCESS$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Tests the verify tasks handling of multiple traces for each assertion
+

--- a/regression/goto-analyzer/intervals_01/test.desc
+++ b/regression/goto-analyzer/intervals_01/test.desc
@@ -6,7 +6,7 @@ main.c
 ^\[main.assertion.1\] line 7 assertion i\s*>=\s*10: SUCCESS$
 ^\[main.assertion.2\] line 10 assertion i\s*!=\s*30: SUCCESS$
 ^\[main.assertion.3\] line 13 assertion i\s*!=\s*15: UNKNOWN$
-^\[main.assertion.4\] line 16 assertion 0: SUCCESS$
+^\[main.assertion.4\] line 16 assertion 0: SUCCESS \(unreachable\)$
 ^\[main.assertion.5\] line 19 assertion j\s*>=\s*10: SUCCESS$
 ^\[main.assertion.6\] line 22 assertion i\s*>=\s*j: UNKNOWN$
 ^\[main.assertion.7\] line 25 assertion i\s*>=\s*11: SUCCESS$

--- a/regression/goto-analyzer/intervals_13/test.desc
+++ b/regression/goto-analyzer/intervals_13/test.desc
@@ -6,7 +6,7 @@ main.c
 ^\[main.assertion.1\] line 7 assertion i\s*>=\s*10: SUCCESS$
 ^\[main.assertion.2\] line 10 assertion i\s*!=\s*30: SUCCESS$
 ^\[main.assertion.3\] line 13 assertion i\s*!=\s*15: UNKNOWN$
-^\[main.assertion.4\] line 16 assertion 0: SUCCESS$
+^\[main.assertion.4\] line 16 assertion 0: SUCCESS \(unreachable\)$
 ^\[main.assertion.5\] line 19 assertion j\s*>=\s*10: SUCCESS$
 ^\[main.assertion.6\] line 22 assertion i\s*>=\s*j: UNKNOWN$
 ^\[main.assertion.7\] line 25 assertion i\s*>=\s*11: SUCCESS$

--- a/src/analyses/ai_history.cpp
+++ b/src/analyses/ai_history.cpp
@@ -27,3 +27,169 @@ xmlt ai_history_baset::output_xml(void) const
   xml.data = out.str();
   return xml;
 }
+
+ai_history_baset::step_returnt
+call_stack_historyt::step(locationt to, const trace_sett &others) const
+{
+  DATA_INVARIANT(current_stack != nullptr, "current_stack must exist");
+
+  cse_ptrt next_stack = nullptr;
+
+  // First construct what the new history would be.
+  // This requires special handling if this edge is a function call or return
+  if(current_stack->current_location->is_function_call())
+  {
+    locationt l_return = std::next(current_stack->current_location);
+
+    if(l_return->location_number == to->location_number)
+    {
+      // Is skipping the function call, only update the location
+      next_stack =
+        cse_ptrt(new call_stack_entryt(l_return, current_stack->caller));
+    }
+    else
+    {
+      // An interprocedural (call) edge; add to the current stack
+      next_stack = cse_ptrt(new call_stack_entryt(to, current_stack));
+    }
+  }
+  else if(current_stack->current_location->is_end_function())
+  {
+    if(current_stack->caller == nullptr)
+    {
+      // Trying to return but there was no caller?
+      // Refuse to do the transition outright
+      return std::make_pair(ai_history_baset::step_statust::BLOCKED, nullptr);
+    }
+    else
+    {
+      // The expected call return site...
+      locationt l_caller_return =
+        std::next(current_stack->caller->current_location);
+
+      if(l_caller_return->location_number == to->location_number)
+      {
+        // ... which is where we are going
+        next_stack =
+          cse_ptrt(new call_stack_entryt(to, current_stack->caller->caller));
+      }
+      else
+      {
+        // Not possible to return to somewhere other than the call site
+        return std::make_pair(ai_history_baset::step_statust::BLOCKED, nullptr);
+      }
+    }
+  }
+  else
+  {
+    // Just update the location
+    next_stack = cse_ptrt(new call_stack_entryt(to, current_stack->caller));
+  }
+  INVARIANT(next_stack != nullptr, "All branches should initialise next_stack");
+
+  // Create the potential next history
+  trace_ptrt next(new call_stack_historyt(next_stack));
+
+  // If there is already an equivalent history, merge with that instead
+  auto it = others.find(next);
+
+  if(it == others.end())
+  {
+    return std::make_pair(ai_history_baset::step_statust::NEW, next);
+  }
+  else
+  {
+    return std::make_pair(ai_history_baset::step_statust::MERGED, *it);
+  }
+}
+
+bool call_stack_historyt::operator<(const ai_history_baset &op) const
+{
+  auto other = dynamic_cast<const call_stack_historyt *>(&op);
+  PRECONDITION(other != nullptr);
+
+  return *(this->current_stack) < *(other->current_stack);
+}
+
+bool call_stack_historyt::operator==(const ai_history_baset &op) const
+{
+  auto other = dynamic_cast<const call_stack_historyt *>(&op);
+  PRECONDITION(other != nullptr);
+
+  return *(this->current_stack) == *(other->current_stack);
+}
+
+void call_stack_historyt::output(std::ostream &out) const
+{
+  out << "call_stack_history : stack "
+      << current_stack->current_location->location_number;
+  cse_ptrt working = current_stack->caller;
+  while(working != nullptr)
+  {
+    out << " from " << working->current_location->location_number;
+    working = working->caller;
+  }
+  return;
+}
+
+bool call_stack_historyt::call_stack_entryt::
+operator<(const call_stack_entryt &op) const
+{
+  if(
+    this->current_location->location_number <
+    op.current_location->location_number)
+  {
+    return true;
+  }
+  else if(
+    this->current_location->location_number >
+    op.current_location->location_number)
+  {
+    return false;
+  }
+  else
+  {
+    INVARIANT(
+      this->current_location->location_number ==
+        op.current_location->location_number,
+      "Implied by if-then-else");
+
+    if(this->caller == op.caller)
+    {
+      return false; // Because they are equal
+    }
+    else if(this->caller == nullptr)
+    {
+      return true; // Shorter stacks are 'lower'
+    }
+    else if(op.caller == nullptr)
+    {
+      return false;
+    }
+    else
+    {
+      // Sort by the rest of the stack
+      return *(this->caller) < *(op.caller);
+    }
+  }
+  UNREACHABLE;
+}
+
+bool call_stack_historyt::call_stack_entryt::
+operator==(const call_stack_entryt &op) const
+{
+  if(
+    this->current_location->location_number ==
+    op.current_location->location_number)
+  {
+    if(this->caller == op.caller)
+    {
+      return true;
+    }
+    else if(this->caller != nullptr && op.caller != nullptr)
+    {
+      return *(this->caller) == *(op.caller);
+    }
+  }
+  return false;
+}

--- a/src/analyses/ai_history.cpp
+++ b/src/analyses/ai_history.cpp
@@ -44,8 +44,8 @@ call_stack_historyt::step(locationt to, const trace_sett &others) const
     if(l_return->location_number == to->location_number)
     {
       // Is skipping the function call, only update the location
-      next_stack =
-        cse_ptrt(new call_stack_entryt(l_return, current_stack->caller));
+      next_stack = cse_ptrt(
+        std::make_shared<call_stack_entryt>(l_return, current_stack->caller));
     }
     else
     {
@@ -83,7 +83,7 @@ call_stack_historyt::step(locationt to, const trace_sett &others) const
         }
       }
 
-      next_stack = cse_ptrt(new call_stack_entryt(to, shorten));
+      next_stack = cse_ptrt(std::make_shared<call_stack_entryt>(to, shorten));
     }
   }
   else if(current_stack->current_location->is_end_function())
@@ -103,8 +103,8 @@ call_stack_historyt::step(locationt to, const trace_sett &others) const
       if(l_caller_return->location_number == to->location_number)
       {
         // ... which is where we are going
-        next_stack =
-          cse_ptrt(new call_stack_entryt(to, current_stack->caller->caller));
+        next_stack = cse_ptrt(std::make_shared<call_stack_entryt>(
+          to, current_stack->caller->caller));
       }
       else
       {
@@ -116,12 +116,15 @@ call_stack_historyt::step(locationt to, const trace_sett &others) const
   else
   {
     // Just update the location
-    next_stack = cse_ptrt(new call_stack_entryt(to, current_stack->caller));
+    next_stack =
+      cse_ptrt(std::make_shared<call_stack_entryt>(to, current_stack->caller));
   }
   INVARIANT(next_stack != nullptr, "All branches should initialise next_stack");
 
   // Create the potential next history
   trace_ptrt next(new call_stack_historyt(next_stack, recursion_limit));
+  // It would be nice to use make_shared here but ... that doesn't work with
+  // protected constructors
 
   // If there is already an equivalent history, merge with that instead
   auto it = others.find(next);

--- a/src/analyses/ai_history.h
+++ b/src/analyses/ai_history.h
@@ -255,26 +255,27 @@ protected:
     return recursion_limit != 0;
   }
 
-  call_stack_historyt(cse_ptrt p, unsigned int rl)
-    : ai_history_baset(p->current_location),
-      current_stack(p),
-      recursion_limit(rl)
+  call_stack_historyt(cse_ptrt cur_stack, unsigned int rec_lim)
+    : ai_history_baset(cur_stack->current_location),
+      current_stack(cur_stack),
+      recursion_limit(rec_lim)
   {
-    PRECONDITION(p != nullptr); // A little late by now but worth documenting
+    PRECONDITION(
+      cur_stack != nullptr); // A little late by now but worth documenting
   }
 
 public:
   explicit call_stack_historyt(locationt l)
     : ai_history_baset(l),
-      current_stack(new call_stack_entryt(l, nullptr)),
+      current_stack(std::make_shared<call_stack_entryt>(l, nullptr)),
       recursion_limit(0)
   {
   }
 
-  call_stack_historyt(locationt l, unsigned int rl)
+  call_stack_historyt(locationt l, unsigned int rec_lim)
     : ai_history_baset(l),
-      current_stack(new call_stack_entryt(l, nullptr)),
-      recursion_limit(rl)
+      current_stack(std::make_shared<call_stack_entryt>(l, nullptr)),
+      recursion_limit(rec_lim)
   {
   }
 
@@ -341,13 +342,15 @@ protected:
   unsigned int recursion_limit;
 
 public:
-  explicit call_stack_history_factoryt(unsigned int rl) : recursion_limit(rl)
+  explicit call_stack_history_factoryt(unsigned int rec_lim)
+    : recursion_limit(rec_lim)
   {
   }
 
   ai_history_baset::trace_ptrt epoch(ai_history_baset::locationt l) override
   {
-    ai_history_baset::trace_ptrt p(new call_stack_historyt(l, recursion_limit));
+    ai_history_baset::trace_ptrt p(
+      std::make_shared<call_stack_historyt>(l, recursion_limit));
     return p;
   }
 

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -287,6 +287,13 @@ void goto_analyzer_parse_optionst::get_command_line_options(optionst &options)
       options.set_option("ahistorical", true);
       options.set_option("history set", true);
     }
+    else if(cmdline.isset("call-stack"))
+    {
+      options.set_option("call-stack", true);
+      options.set_option(
+        "call-stack-recursion-limit", cmdline.get_value("call-stack"));
+      options.set_option("history set", true);
+    }
 
     if(!options.get_bool_option("history set"))
     {
@@ -386,6 +393,11 @@ ai_baset *goto_analyzer_parse_optionst::build_analyzer(
     {
       hf = util_make_unique<
         ai_history_factory_default_constructort<ahistoricalt>>();
+    }
+    else if(options.get_bool_option("call-stack"))
+    {
+      hf = util_make_unique<call_stack_history_factoryt>(
+        options.get_unsigned_int_option("call-stack-recursion-limit"));
     }
 
     // Build the domain factory
@@ -838,6 +850,10 @@ void goto_analyzer_parse_optionst::help()
     "History options:\n"
     // NOLINTNEXTLINE(whitespace/line_length)
     " --ahistorical                the most basic history, tracks locations only\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    " --call-stack n               track the calling location stack for each function\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    "                              limiting to at most n recursive loops, 0 to disable\n"
     "\n"
     "Domain options:\n"
     " --constants                  a constant for each variable if possible\n"

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -133,6 +133,10 @@ void goto_analyzer_parse_optionst::get_command_line_options(optionst &options)
     options.set_option("error-label", cmdline.get_values("error-label"));
 #endif
 
+  // The user should either select:
+  //  1. a specific analysis, or
+  //  2. a tuple of task / analyser options / outputs
+
   // Select a specific analysis
   if(cmdline.isset("taint"))
   {
@@ -187,11 +191,6 @@ void goto_analyzer_parse_optionst::get_command_line_options(optionst &options)
     options.set_option("dot", true);
     options.set_option("outfile", cmdline.get_value("dot"));
   }
-
-  // The use should either select:
-  //  1. a specific analysis, or
-  //  2. a triple of task / analyzer / domain, or
-  //  3. one of the general display options
 
   // Task options
   if(cmdline.isset("show"))
@@ -252,15 +251,50 @@ void goto_analyzer_parse_optionst::get_command_line_options(optionst &options)
   if(options.get_bool_option("general-analysis") || reachability_task)
   {
     // Abstract interpreter choice
-    if(cmdline.isset("location-sensitive"))
-      options.set_option("location-sensitive", true);
-    else if(cmdline.isset("concurrent"))
-      options.set_option("concurrent", true);
+    if(cmdline.isset("recursive-interprocedural"))
+      options.set_option("recursive-interprocedural", true);
+    else if(cmdline.isset("legacy-ait") || cmdline.isset("location-sensitive"))
+    {
+      options.set_option("legacy-ait", true);
+      // Fixes a number of other options as well
+      options.set_option("ahistorical", true);
+      options.set_option("history set", true);
+      options.set_option("one-domain-per-location", true);
+      options.set_option("storage set", true);
+    }
+    else if(cmdline.isset("legacy-concurrent") || cmdline.isset("concurrent"))
+    {
+      options.set_option("legacy-concurrent", true);
+      options.set_option("ahistorical", true);
+      options.set_option("history set", true);
+      options.set_option("one-domain-per-location", true);
+      options.set_option("storage set", true);
+    }
     else
     {
-      // Silently default to location-sensitive as it's the "default"
-      // view of abstract interpretation.
-      options.set_option("location-sensitive", true);
+      // Silently default to legacy-ait for backwards compatability
+      options.set_option("legacy-ait", true);
+      // Fixes a number of other options as well
+      options.set_option("ahistorical", true);
+      options.set_option("history set", true);
+      options.set_option("one-domain-per-location", true);
+      options.set_option("storage set", true);
+    }
+
+    // History choice
+    if(cmdline.isset("ahistorical"))
+    {
+      options.set_option("ahistorical", true);
+      options.set_option("history set", true);
+    }
+
+    if(!options.get_bool_option("history set"))
+    {
+      // Default to ahistorical as it is the expected for of analysis
+      log.status() << "History not specified, defaulting to --ahistorical"
+                   << messaget::eom;
+      options.set_option("ahistorical", true);
+      options.set_option("history set", true);
     }
 
     // Domain choice
@@ -307,6 +341,29 @@ void goto_analyzer_parse_optionst::get_command_line_options(optionst &options)
     }
   }
 
+  // Storage choice
+  if(cmdline.isset("one-domain-per-history"))
+  {
+    options.set_option("one-domain-per-history", true);
+    options.set_option("storage set", true);
+  }
+  else if(cmdline.isset("one-domain-per-location"))
+  {
+    options.set_option("one-domain-per-location", true);
+    options.set_option("storage set", true);
+  }
+
+  if(!options.get_bool_option("storage set"))
+  {
+    // one-domain-per-location and one-domain-per-history are effectively
+    // the same when using ahistorical so we default to per-history so that
+    // more sophisticated history objects work as expected
+    log.status() << "Storage not specified,"
+                 << " defaulting to --one-domain-per-history" << messaget::eom;
+    options.set_option("one-domain-per-history", true);
+    options.set_option("storage set", true);
+  }
+
   if(cmdline.isset("validate-goto-model"))
   {
     options.set_option("validate-goto-model", true);
@@ -315,63 +372,98 @@ void goto_analyzer_parse_optionst::get_command_line_options(optionst &options)
 
 /// For the task, build the appropriate kind of analyzer
 /// Ideally this should be a pure function of options.
-/// However at the moment some domains require the goto_model
+/// However at the moment some domains require the goto_model or parts of it
 ai_baset *goto_analyzer_parse_optionst::build_analyzer(
   const optionst &options,
   const namespacet &ns)
 {
-  ai_baset *domain = nullptr;
+  // These support all of the option categories
+  if(options.get_bool_option("recursive-interprocedural"))
+  {
+    // Build the history factory
+    std::unique_ptr<ai_history_factory_baset> hf = nullptr;
+    if(options.get_bool_option("ahistorical"))
+    {
+      hf = util_make_unique<
+        ai_history_factory_default_constructort<ahistoricalt>>();
+    }
 
-  if(options.get_bool_option("location-sensitive"))
+    // Build the domain factory
+    std::unique_ptr<ai_domain_factory_baset> df = nullptr;
+    if(options.get_bool_option("constants"))
+    {
+      df = util_make_unique<
+        ai_domain_factory_default_constructort<constant_propagator_domaint>>();
+    }
+    else if(options.get_bool_option("intervals"))
+    {
+      df = util_make_unique<
+        ai_domain_factory_default_constructort<interval_domaint>>();
+    }
+    // non-null is not fully supported, despite the historical options
+    // dependency-graph is quite heavily tied to the legacy-ait infrastructure
+
+    // Build the storage object
+    std::unique_ptr<ai_storage_baset> st = nullptr;
+    if(options.get_bool_option("one-domain-per-history"))
+    {
+      st = util_make_unique<history_sensitive_storaget>();
+    }
+    else if(options.get_bool_option("one-domain-per-location"))
+    {
+      st = util_make_unique<location_sensitive_storaget>();
+    }
+
+    // Only try to build the abstract interpreter if all the parts have been
+    // correctly specified and configured
+    if(hf != nullptr && df != nullptr && st != nullptr)
+    {
+      if(options.get_bool_option("recursive-interprocedural"))
+      {
+        return new ai_recursive_interproceduralt(
+          std::move(hf), std::move(df), std::move(st));
+      }
+      UNREACHABLE;
+    }
+  }
+  else if(options.get_bool_option("legacy-ait"))
   {
     if(options.get_bool_option("constants"))
     {
       // constant_propagator_ait derives from ait<constant_propagator_domaint>
-      domain=new constant_propagator_ait(goto_model.goto_functions);
+      return new constant_propagator_ait(goto_model.goto_functions);
     }
     else if(options.get_bool_option("dependence-graph"))
     {
-      domain=new dependence_grapht(ns);
+      return new dependence_grapht(ns);
     }
     else if(options.get_bool_option("intervals"))
     {
-      domain=new ait<interval_domaint>();
+      return new ait<interval_domaint>();
     }
 #if 0
     // Not actually implemented, despite the option...
     else if(options.get_bool_option("non-null"))
     {
-      domain=new ait<non_null_domaint>();
+      return new ait<non_null_domaint>();
     }
 #endif
   }
-  else if(options.get_bool_option("concurrent"))
+  else if(options.get_bool_option("legacy-concurrent"))
   {
 #if 0
-    // Disabled until merge_shared is implemented for these
-    if(options.get_bool_option("constants"))
+    // Very few domains can work with this interpreter
+    // as it requires that changes to the domain are
+    // 'non-revertable' and it has merge shared
+    if(options.get_bool_option("dependence-graph"))
     {
-      domain=new concurrency_aware_ait<constant_propagator_domaint>();
+      return new dependence_grapht(ns);
     }
-    else if(options.get_bool_option("dependence-graph"))
-    {
-      domain=new dependence_grapht(ns);
-    }
-    else if(options.get_bool_option("intervals"))
-    {
-      domain=new concurrency_aware_ait<interval_domaint>();
-    }
-#if 0
-    // Not actually implemented, despite the option...
-    else if(options.get_bool_option("non-null"))
-    {
-      domain=new concurrency_aware_ait<non_null_domaint>();
-    }
-#endif
 #endif
   }
 
-  return domain;
+  // Construction failed due to configuration errors
+  return nullptr;
 }
 
 /// invoke main modules
@@ -584,7 +676,7 @@ int goto_analyzer_parse_optionst::perform_analysis(const optionst &options)
 
     if(analyzer == nullptr)
     {
-      log.status() << "Task / Interpreter / Domain combination not supported"
+      log.status() << "Task / Interpreter combination not supported"
                    << messaget::eom;
       return CPROVER_EXIT_INTERNAL_ERROR;
     }
@@ -737,14 +829,26 @@ void goto_analyzer_parse_optionst::help()
     "\n"
     "Abstract interpreter options:\n"
     // NOLINTNEXTLINE(whitespace/line_length)
-    " --location-sensitive         use location-sensitive abstract interpreter\n"
-    " --concurrent                 use concurrency-aware abstract interpreter\n"
+    " --recursive-interprocedural  use recursion to handle interprocedural reasoning\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    " --legacy-ait                 recursion for function and one domain per location\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    " --legacy-concurrent          legacy-ait with an extended fixed-point for concurrency\n"
+    "\n"
+    "History options:\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    " --ahistorical                the most basic history, tracks locations only\n"
     "\n"
     "Domain options:\n"
-    " --constants                  constant domain\n"
-    " --intervals                  interval domain\n"
-    " --non-null                   non-null domain\n"
+    " --constants                  a constant for each variable if possible\n"
+    " --intervals                  an interval for each variable\n"
+    " --non-null                   tracks which pointers are non-null\n"
     " --dependence-graph           data and control dependencies between instructions\n" // NOLINT(*)
+    "\n"
+    "Storage options:\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    " --one-domain-per-history     stores a domain for each history object created\n"
+    " --one-domain-per-location    stores a domain for each location reached\n"
     "\n"
     "Output options:\n"
     " --text file_name             output results in plain text to given file\n"
@@ -786,7 +890,6 @@ void goto_analyzer_parse_optionst::help()
     " --gcc                        use GCC as preprocessor\n"
     #endif
     " --no-library                 disable built-in abstract C library\n"
-    "\n"
     HELP_FUNCTIONS
     "\n"
     "Program representations:\n"

--- a/src/goto-analyzer/goto_analyzer_parse_options.h
+++ b/src/goto-analyzer/goto_analyzer_parse_options.h
@@ -115,7 +115,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <analyses/ai.h>
 #include <analyses/goto_check.h>
 
-class bmct;
 class goto_functionst;
 class optionst;
 

--- a/src/goto-analyzer/goto_analyzer_parse_options.h
+++ b/src/goto-analyzer/goto_analyzer_parse_options.h
@@ -20,18 +20,20 @@ Author: Daniel Kroening, kroening@kroening.com
 /// provide an executable front-end for all of them.
 ///
 /// There are a lot of different analyses and a lot of ways they can be
-/// used.  Goto-analyze has five, largely independent, sets of options:
+/// used.  Goto-analyze has six, largely independent, sets of options:
 ///
 /// 1. Task : What you do once you've computed the domains.
 /// 2. Abstract interpreter : What kind of abstract interpretation you do.
-/// 3. Domain : What domain you use.
-/// 4. Sensitivity : How that domain handles things like arrays, pointers, etc.
-///    (see variable_sensitivity_domain.h)
-/// 5. Output : What you do with the results.
+/// 3. History : What kind of steps and CFG sensitivity the interpreter uses.
+/// 4. Domain : What domain you use to represent the values of the variables.
+///             This includes domain specific configuration.
+/// 5. Storage : How many history steps share domains.
+/// 6. Output : What you do with the results.
 ///
-/// Formally speaking, 2, 3 and 4 are an artificial distinction as they are
-/// all really parts of the "what domain" question.  However they correspond
-/// to parts of our code architecture, so ... they should stay.
+/// Formally speaking, 2, 3, 4 and 5 are somewhat artificial distinction as they
+/// are all really parts of the "what abstraction" question.
+/// However they correspond to parts of our code architecture, so ...
+/// they should stay.
 ///
 /// Ideally, the cross product of options should be supported but ... in
 /// practice there will always be ones that are not meaningful.  Those
@@ -73,22 +75,9 @@ Author: Daniel Kroening, kroening@kroening.com
 /// --------------------
 ///
 /// This option is effectively about how we compute the fix-point(s) /
-/// which child class of ai_baset we use.  I.E.  ait<domainT> or
-/// concurrency_aware_ait<domainT>, etc.   For migrating / refactor /
-/// unifying with the pointer analysis code we might want a
-/// location_insensitive_ait<domainT> or something but this is not urgent.
-/// We will need a context_aware_ait<domainT>.
-///
-///
-/// Domain
-/// ------
-///
-/// Which child of ai_domain_baset we use to represent the abstract state at
-/// each location / implement the transformers.  I expect most of these will
-/// be non-relational (i.e. an abstract object for each variable) due to the
-/// cost of implementing effective non-relational domains in this style vs.
-/// using 2LS.  The exception might be equalities, which we could implement
-/// here.
+/// which child class of ai_baset we use.  This and the other AI related
+/// option categories (history, domain, storage, etc.) are more extensively
+/// documented in analyses/ai.h and analyses/ai_*.h
 ///
 ///
 /// Output
@@ -96,7 +85,6 @@ Author: Daniel Kroening, kroening@kroening.com
 ///
 /// Text, XML, JSON plus some others for specific domains such as dependence
 /// graphs in DOT format.
-
 
 #ifndef CPROVER_GOTO_ANALYZER_GOTO_ANALYZER_PARSE_OPTIONS_H
 #define CPROVER_GOTO_ANALYZER_GOTO_ANALYZER_PARSE_OPTIONS_H
@@ -119,6 +107,38 @@ class goto_functionst;
 class optionst;
 
 // clang-format off
+#define GOTO_ANALYSER_OPTIONS_TASKS \
+  "(show)(verify)(simplify):" \
+  "(show-on-source)" \
+  "(unreachable-instructions)(unreachable-functions)" \
+  "(reachable-functions)"
+
+#define GOTO_ANALYSER_OPTIONS_AI \
+  "(recursive-interprocedural)" \
+  "(legacy-ait)" \
+  "(legacy-concurrent)"
+
+#define GOTO_ANALYSER_OPTIONS_HISTORY \
+  "(ahistorical)"
+
+#define GOTO_ANALYSER_OPTIONS_DOMAIN \
+  "(intervals)" \
+  "(non-null)" \
+  "(constants)" \
+  "(dependence-graph)"
+
+#define GOTO_ANALYSER_OPTIONS_STORAGE \
+  "(one-domain-per-history)" \
+  "(one-domain-per-location)"
+
+#define GOTO_ANALYSER_OPTIONS_OUTPUT \
+  "(json):(xml):" \
+  "(text):(dot):"
+
+#define GOTO_ANALYSER_OPTIONS_SPECIFIC_ANALYSES \
+  "(taint):(show-taint)" \
+  "(show-local-may-alias)"
+
 #define GOTO_ANALYSER_OPTIONS \
   OPT_FUNCTIONS \
   "D:I:(std89)(std99)(std11)" \
@@ -133,23 +153,19 @@ class optionst;
   "(show-reachable-properties)(property):" \
   "(verbosity):(version)" \
   "(gcc)(arch):" \
-  "(taint):(show-taint)" \
-  "(show-local-may-alias)" \
-  "(json):(xml):" \
-  "(text):(dot):" \
   OPT_FLUSH \
   OPT_TIMESTAMP \
-  "(unreachable-instructions)(unreachable-functions)" \
-  "(reachable-functions)" \
-  "(intervals)(show-intervals)" \
-  "(non-null)(show-non-null)" \
-  "(constants)" \
-  "(dependence-graph)" \
-  "(show)(verify)(simplify):" \
-  "(show-on-source)" \
-  "(location-sensitive)(concurrent)" \
-  "(no-simplify-slicing)" \
   OPT_VALIDATE \
+  GOTO_ANALYSER_OPTIONS_TASKS \
+  "(no-simplify-slicing)" \
+  "(show-intervals)(show-non-null)" \
+  GOTO_ANALYSER_OPTIONS_AI \
+  "(location-sensitive)(concurrent)" \
+  GOTO_ANALYSER_OPTIONS_HISTORY \
+  GOTO_ANALYSER_OPTIONS_DOMAIN \
+  GOTO_ANALYSER_OPTIONS_STORAGE \
+  GOTO_ANALYSER_OPTIONS_OUTPUT \
+  GOTO_ANALYSER_OPTIONS_SPECIFIC_ANALYSES \
 // clang-format on
 
 class goto_analyzer_parse_optionst: public parse_options_baset

--- a/src/goto-analyzer/goto_analyzer_parse_options.h
+++ b/src/goto-analyzer/goto_analyzer_parse_options.h
@@ -119,7 +119,8 @@ class optionst;
   "(legacy-concurrent)"
 
 #define GOTO_ANALYSER_OPTIONS_HISTORY \
-  "(ahistorical)"
+  "(ahistorical)" \
+  "(call-stack):"
 
 #define GOTO_ANALYSER_OPTIONS_DOMAIN \
   "(intervals)" \

--- a/src/goto-analyzer/static_verifier.cpp
+++ b/src/goto-analyzer/static_verifier.cpp
@@ -307,7 +307,12 @@ bool static_verifier(
       results.push_back(static_verifier_resultt());
       auto &result = results.back();
 
-      if(e.is_true())
+      if(domain.is_bottom())
+      {
+        result.status = static_verifier_resultt::BOTTOM;
+        ++pass;
+      }
+      else if(e.is_true())
       {
         result.status = static_verifier_resultt::TRUE;
         ++pass;
@@ -316,11 +321,6 @@ bool static_verifier(
       {
         result.status = static_verifier_resultt::FALSE;
         ++fail;
-      }
-      else if(domain.is_bottom())
-      {
-        result.status = static_verifier_resultt::BOTTOM;
-        ++pass;
       }
       else
       {


### PR DESCRIPTION
This patch builds on #5036 and is intended as a demonstration of what the refactored infrastructure can do.  This adds optional context sensitivity to the abstract interpreter by just implementing a new history object.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
