### PR TITLE
Fix accesses to exprt::opX() in jbmc/

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_concurrency_instrumentation.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_concurrency_instrumentation.cpp
@@ -87,7 +87,7 @@ static const std::string get_thread_block_identifier(
   PRECONDITION(f_code.arguments().size() == 1);
   const exprt &expr = f_code.arguments()[0];
   const mp_integer lbl_id =
-    numeric_cast_v<mp_integer>(to_constant_expr(expr.op0()));
+    numeric_cast_v<mp_integer>(to_constant_expr(to_multi_ary_expr(expr).op0()));
   return integer2string(lbl_id);
 }
 

--- a/jbmc/src/java_bytecode/java_expr.h
+++ b/jbmc/src/java_bytecode/java_expr.h
@@ -53,13 +53,15 @@ public:
   {
     binary_predicate_exprt::validate(expr, ns, vm);
 
+    const auto &expr_binary = static_cast<const binary_predicate_exprt &>(expr);
+
     DATA_CHECK(
       vm,
-      can_cast_expr<type_exprt>(expr.op1()),
+      can_cast_expr<type_exprt>(expr_binary.rhs()),
       "java_instanceof_exprt rhs should be a type_exprt");
     DATA_CHECK(
       vm,
-      can_cast_type<struct_tag_typet>(expr.op1().type()),
+      can_cast_type<struct_tag_typet>(expr_binary.rhs().type()),
       "java_instanceof_exprt rhs should denote a struct_tag_typet");
   }
 };

--- a/jbmc/src/java_bytecode/java_trace_validation.cpp
+++ b/jbmc/src/java_bytecode/java_trace_validation.cpp
@@ -39,7 +39,7 @@ optionalt<symbol_exprt> get_inner_symbol_expr(exprt expr)
 {
   while(expr.has_operands())
   {
-    expr = expr.op0();
+    expr = to_multi_ary_expr(expr).op0();
     if(!may_be_lvalue(expr))
       return {};
   }

--- a/jbmc/unit/java-testing-utils/require_goto_statements.cpp
+++ b/jbmc/unit/java-testing-utils/require_goto_statements.cpp
@@ -179,21 +179,25 @@ require_goto_statements::find_this_component_assignment(
         const member_exprt &member_expr = to_member_expr(code_assign.lhs());
         if(
           member_expr.get_component_name() == component_name &&
-          member_expr.op().id() == ID_dereference &&
-          member_expr.op().op0().id() == ID_symbol &&
-          has_suffix(
-            id2string(to_symbol_expr(member_expr.op().op0()).get_identifier()),
-            id2string(ID_this)))
+          member_expr.op().id() == ID_dereference)
         {
+          const auto &pointer = to_dereference_expr(member_expr.op()).pointer();
           if(
-            code_assign.rhs() ==
-            null_pointer_exprt(to_pointer_type(code_assign.lhs().type())))
+            pointer.id() == ID_symbol &&
+            has_suffix(
+              id2string(to_symbol_expr(pointer).get_identifier()),
+              id2string(ID_this)))
           {
-            locations.null_assignment = code_assign;
-          }
-          else
-          {
-            locations.non_null_assignments.push_back(code_assign);
+            if(
+              code_assign.rhs() ==
+              null_pointer_exprt(to_pointer_type(code_assign.lhs().type())))
+            {
+              locations.null_assignment = code_assign;
+            }
+            else
+            {
+              locations.non_null_assignments.push_back(code_assign);
+            }
           }
         }
       }

--- a/jbmc/unit/java_bytecode/goto-programs/remove_virtual_functions_without_fallback.cpp
+++ b/jbmc/unit/java_bytecode/goto-programs/remove_virtual_functions_without_fallback.cpp
@@ -29,22 +29,28 @@ exprt resolve_classid_test(
     return resolved;
   }
 
-  if(expr.op0().id() == ID_constant && expr.op1().id() != ID_constant)
+  const auto &expr_binary = to_binary_expr(expr);
+
+  if(
+    expr_binary.op0().id() == ID_constant &&
+    expr_binary.op1().id() != ID_constant)
   {
-    exprt swapped = expr;
+    binary_exprt swapped = expr_binary;
     std::swap(swapped.op0(), swapped.op1());
     return resolve_classid_test(swapped, actual_class_id, ns);
   }
 
-  if(expr.op0().id() == ID_member &&
-     to_member_expr(expr.op0()).get_component_name() == "@class_identifier" &&
-     expr.op1().id() == ID_constant &&
-     expr.op1().type().id() == ID_string)
+  if(
+    expr_binary.op0().id() == ID_member &&
+    to_member_expr(expr_binary.op0()).get_component_name() ==
+      "@class_identifier" &&
+    expr_binary.op1().id() == ID_constant &&
+    expr_binary.op1().type().id() == ID_string)
   {
-    exprt resolved = expr;
-    resolved.op0() = constant_exprt(actual_class_id, expr.op1().type());
+    binary_exprt resolved = expr_binary;
+    resolved.op0() = constant_exprt(actual_class_id, expr_binary.op1().type());
     simplify(resolved, ns);
-    return resolved;
+    return std::move(resolved);
   }
 
   return expr;

--- a/jbmc/unit/java_bytecode/java_bytecode_instrument/virtual_call_null_checks.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_instrument/virtual_call_null_checks.cpp
@@ -33,7 +33,7 @@ static bool is_expected_virtualmethod_call(
   const auto &this_argument = virtual_call.arguments()[0];
   if(this_argument.id() != ID_member)
     return false;
-  if(this_argument.op0().id() != ID_dereference)
+  if(to_member_expr(this_argument).compound().id() != ID_dereference)
     return false;
 
   return true;

--- a/jbmc/unit/pointer-analysis/custom_value_set_analysis.cpp
+++ b/jbmc/unit/pointer-analysis/custom_value_set_analysis.cpp
@@ -11,12 +11,17 @@ Author: Chris Smowton, chris@smowton.net
 
 #include <goto-programs/goto_inline.h>
 #include <goto-programs/initialize_goto_model.h>
+
 #include <java_bytecode/java_bytecode_language.h>
 #include <java_bytecode/java_types.h>
 #include <java_bytecode/remove_java_new.h>
+
 #include <langapi/mode.h>
+
 #include <pointer-analysis/value_set_analysis.h>
+
 #include <util/config.h>
+#include <util/expr_util.h>
 #include <util/options.h>
 
 /// An example customised value_sett. It makes a series of small changes
@@ -96,9 +101,7 @@ public:
   {
     // Always add an ID_unknown to reads from variables containing
     // "maybe_unknown":
-    exprt read_sym=expr;
-    while(read_sym.id()==ID_typecast)
-      read_sym=read_sym.op0();
+    exprt read_sym = skip_typecast(expr);
     if(read_sym.id()==ID_symbol)
     {
       const irep_idt &id=to_symbol_expr(read_sym).get_identifier();

--- a/jbmc/unit/solvers/strings/string_refinement/dependency_graph.cpp
+++ b/jbmc/unit/solvers/strings/string_refinement/dependency_graph.cpp
@@ -46,12 +46,12 @@ SCENARIO("dependency_graph", "[core][solvers][refinement][string_refinement]")
     string_dependenciest dependencies;
     const typet string_type =
       refined_string_typet(java_int_type(), pointer_type(java_char_type()));
-    const exprt string1 = make_string_argument("string1");
-    const exprt string2 = make_string_argument("string2");
-    const exprt string3 = make_string_argument("string3");
-    const exprt string4 = make_string_argument("string4");
-    const exprt string5 = make_string_argument("string5");
-    const exprt string6 = make_string_argument("string6");
+    const auto string1 = make_string_argument("string1");
+    const auto string2 = make_string_argument("string2");
+    const auto string3 = make_string_argument("string3");
+    const auto string4 = make_string_argument("string4");
+    const auto string5 = make_string_argument("string5");
+    const auto string6 = make_string_argument("string6");
     const symbol_exprt lhs("lhs", unsignedbv_typet(32));
     const symbol_exprt lhs2("lhs2", unsignedbv_typet(32));
     const symbol_exprt lhs3("lhs3", unsignedbv_typet(32));

--- a/jbmc/unit/util/expr_iterator.cpp
+++ b/jbmc/unit/util/expr_iterator.cpp
@@ -3,8 +3,8 @@
 /// \file Tests for depth_iteratort and friends
 
 #include <testing-utils/use_catch.h>
-#include <util/expr.h>
 #include <util/expr_iterator.h>
+#include <util/std_expr.h>
 
 TEST_CASE("Depth iterator over empty exprt")
 {
@@ -190,10 +190,12 @@ SCENARIO("depth_iterator_mutate_root", "[core][utils][depth_iterator]")
       // Create iterator on first operand of expr
       // We don't want to copy-on-write expr, so we get its first operand
       // using a const reference to it
-      const exprt &root = static_cast<const exprt &>(expr).op0();
+      const exprt &root = to_unary_expr(static_cast<const exprt &>(expr)).op();
       // This function gets a mutable version of root but in so doing it
       // copy-on-writes expr
-      auto get_non_const_root = [&expr]() -> exprt & { return expr.op0(); };
+      auto get_non_const_root = [&expr]() -> exprt & {
+        return to_unary_expr(expr).op();
+      };
       // Create the iterator over root
       depth_iteratort it = root.depth_begin(get_non_const_root);
       for(; it != root.depth_cend(); ++it)
@@ -218,10 +220,12 @@ SCENARIO("depth_iterator_mutate_root", "[core][utils][depth_iterator]")
       // Create iterator on first operand of expr
       // We don't want to copy-on-write expr, so we get its first operand
       // using a const reference to it
-      const exprt &root = static_cast<const exprt &>(expr).op0();
+      const exprt &root = to_unary_expr(static_cast<const exprt &>(expr)).op();
       // This function gets a mutable version of root but in so doing it
       // copy-on-writes expr
-      auto get_non_const_root = [&expr]() -> exprt & { return expr.op0(); };
+      auto get_non_const_root = [&expr]() -> exprt & {
+        return to_unary_expr(expr).op();
+      };
       // Create the iterator over root
       depth_iteratort it = root.depth_begin(get_non_const_root);
       for(; it != root.depth_cend(); ++it)


### PR DESCRIPTION
This improves type safety, and will enable restricing the exprt interface.

These are the final ones in jbmc/.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
