### PR TITLE
Fix accesses to exprt::opX() in ansi-c/

### DIFF
--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2672,10 +2672,11 @@ exprt c_typecheck_baset::do_special_functions(
     if(
       tmp1.id() == ID_typecast &&
       to_typecast_expr(tmp1).op().id() == ID_address_of &&
-      to_typecast_expr(tmp1).op().operands().size() == 1 &&
-      to_typecast_expr(tmp1).op().op0().id() == ID_index &&
-      to_typecast_expr(tmp1).op().op0().operands().size() == 2 &&
-      to_typecast_expr(tmp1).op().op0().op0().id() == ID_string_constant)
+      to_address_of_expr(to_typecast_expr(tmp1).op()).object().id() ==
+        ID_index &&
+      to_index_expr(to_address_of_expr(to_typecast_expr(tmp1).op()).object())
+          .array()
+          .id() == ID_string_constant)
     {
       is_constant=true;
     }

--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -97,8 +97,10 @@ protected:
     unsigned &precedence);
 
   std::string convert_binary(
-    const exprt &src, const std::string &symbol,
-    unsigned precedence, bool full_parentheses);
+    const binary_exprt &,
+    const std::string &symbol,
+    unsigned precedence,
+    bool full_parentheses);
 
   std::string convert_multi_ary(
     const exprt &src, const std::string &symbol,
@@ -149,13 +151,10 @@ protected:
   std::string
   convert_byte_extract(const byte_extract_exprt &, unsigned precedence);
 
-  std::string convert_byte_update(
-    const exprt &src,
-    unsigned precedence);
+  std::string
+  convert_byte_update(const byte_update_exprt &, unsigned precedence);
 
-  std::string convert_extractbit(
-    const exprt &src,
-    unsigned precedence);
+  std::string convert_extractbit(const extractbit_exprt &, unsigned precedence);
 
   std::string
   convert_extractbits(const extractbits_exprt &src, unsigned precedence);


### PR DESCRIPTION
This improves type safety, and will enable restricing the exprt interface.

This is the final one in ansi-c/.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
