### PR TITLE
Avoid redundant computations in get_user_specified_clinit

### DIFF
--- a/jbmc/src/java_bytecode/README.md
+++ b/jbmc/src/java_bytecode/README.md
@@ -674,10 +674,11 @@ determine which loading strategy to use.
 If [lazy_methods_mode](\ref java_bytecode_languaget::lazy_methods_mode) is
 \ref java_bytecode_languaget::LAZY_METHODS_MODE_EAGER then eager loading is
 used. Under eager loading
-\ref java_bytecode_languaget::convert_single_method(const irep_idt &, symbol_table_baset &)
+\ref java_bytecode_languaget::convert_single_method(const irep_idt &, symbol_table_baset &, lazy_class_to_declared_symbols_mapt &)
 is called once for each method listed in method_bytecode (described above). This
 then calls
-\ref java_bytecode_languaget::convert_single_method(const irep_idt &, symbol_table_baset &, optionalt<ci_lazy_methods_neededt>)
+\ref java_bytecode_languaget::convert_single_method(const irep_idt &, symbol_table_baset &, optionalt<ci_lazy_methods_neededt>, lazy_class_to_declared_symbols_mapt &);
+
 without a ci_lazy_methods_neededt object, which calls
 \ref java_bytecode_convert_method, passing in the method parse tree. This in
 turn uses \ref java_bytecode_convert_methodt to turn the bytecode into symbols

--- a/jbmc/src/java_bytecode/java_bytecode_language.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_language.cpp
@@ -1218,13 +1218,16 @@ bool java_bytecode_languaget::convert_single_method(
         class_name, "user_specified_clinit must be declared by a class.");
       INVARIANT(
         static_values_json.has_value(), "static-values JSON must be available");
+      const auto class_to_declared_symbols_map =
+        class_to_declared_symbols(symbol_table);
       writable_symbol.value = get_user_specified_clinit_body(
         *class_name,
         *static_values_json,
         symbol_table,
         needed_lazy_methods,
         max_user_array_length,
-        references);
+        references,
+        class_to_declared_symbols_map);
       break;
     }
     case synthetic_method_typet::STUB_CLASS_STATIC_INITIALIZER:

--- a/jbmc/src/java_bytecode/java_bytecode_language.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_language.cpp
@@ -1222,7 +1222,6 @@ bool java_bytecode_languaget::convert_single_method(
         *class_name,
         *static_values_json,
         symbol_table,
-        get_message_handler(),
         needed_lazy_methods,
         max_user_array_length,
         references);

--- a/jbmc/src/java_bytecode/java_bytecode_language.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_language.cpp
@@ -207,8 +207,21 @@ void java_bytecode_languaget::set_language_options(const optionst &options)
   {
     const std::string filename = options.get_option("static-values");
     jsont tmp_json;
-    if(!parse_json(filename, *message_handler, tmp_json))
-      static_values_json = std::move(tmp_json);
+    if(parse_json(filename, *message_handler, tmp_json))
+    {
+      warning() << "Provided JSON file for static-values cannot be parsed; it"
+                << " will be ignored." << messaget::eom;
+    }
+    else
+    {
+      if(!tmp_json.is_object())
+      {
+        warning() << "Provided JSON file for static-values is not a JSON "
+                  << "object; it will be ignored." << messaget::eom;
+      }
+      else
+        static_values_json = std::move(to_json_object(tmp_json));
+    }
   }
 
   ignore_manifest_main_class =

--- a/jbmc/src/java_bytecode/java_bytecode_language.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_language.cpp
@@ -1216,9 +1216,11 @@ bool java_bytecode_languaget::convert_single_method(
         declaring_class(symbol_table.lookup_ref(function_id));
       INVARIANT(
         class_name, "user_specified_clinit must be declared by a class.");
+      INVARIANT(
+        static_values_json.has_value(), "static-values JSON must be available");
       writable_symbol.value = get_user_specified_clinit_body(
         *class_name,
-        static_values_json,
+        *static_values_json,
         symbol_table,
         get_message_handler(),
         needed_lazy_methods,

--- a/jbmc/src/java_bytecode/java_bytecode_language.h
+++ b/jbmc/src/java_bytecode/java_bytecode_language.h
@@ -121,6 +121,31 @@ enum lazy_methods_modet
   LAZY_METHODS_MODE_EXTERNAL_DRIVER
 };
 
+/// Map classes to the symbols they declare but is only computed once it is
+/// needed and the map is then kept.
+/// Note that it only includes function and field symbols (and not for example,
+/// local variables), these are produced in the convert-class phase.
+/// Calling `get` before the symbol table is properly filled with these symbols,
+/// would make later calls return an outdated map. The
+/// lazy_class_to_declared_symbols_mapt would then need to be reinitialized.
+/// Similarly if some transformation creates or deletes function or field
+/// symbols in the symbol table, then the map would get out of date and would
+/// need to be reinitialized.
+class lazy_class_to_declared_symbols_mapt
+{
+public:
+  lazy_class_to_declared_symbols_mapt() = default;
+
+  std::unordered_multimap<irep_idt, symbolt> &
+  get(const symbol_tablet &symbol_table);
+
+  void reinitialize();
+
+private:
+  bool initialized = false;
+  std::unordered_multimap<irep_idt, symbolt> map;
+};
+
 #define JAVA_CLASS_MODEL_SUFFIX "@class_model"
 
 class java_bytecode_languaget:public languaget
@@ -205,15 +230,20 @@ public:
 protected:
   void convert_single_method(
     const irep_idt &function_id,
-    symbol_table_baset &symbol_table)
+    symbol_table_baset &symbol_table,
+    lazy_class_to_declared_symbols_mapt &class_to_declared_symbols)
   {
     convert_single_method(
-      function_id, symbol_table, optionalt<ci_lazy_methods_neededt>());
+      function_id,
+      symbol_table,
+      optionalt<ci_lazy_methods_neededt>(),
+      class_to_declared_symbols);
   }
   bool convert_single_method(
     const irep_idt &function_id,
     symbol_table_baset &symbol_table,
-    optionalt<ci_lazy_methods_neededt> needed_lazy_methods);
+    optionalt<ci_lazy_methods_neededt> needed_lazy_methods,
+    lazy_class_to_declared_symbols_mapt &class_to_declared_symbols);
 
   bool do_ci_lazy_method_conversion(symbol_tablet &);
   const select_pointer_typet &get_pointer_type_selector() const;

--- a/jbmc/src/java_bytecode/java_bytecode_language.h
+++ b/jbmc/src/java_bytecode/java_bytecode_language.h
@@ -239,7 +239,7 @@ protected:
   /// JSON which contains initial values of static fields (right
   /// after the static initializer of the class was run). This is read from the
   /// file specified by the --static-values command-line option.
-  optionalt<jsont> static_values_json;
+  optionalt<json_objectt> static_values_json;
 
   // list of classes to force load even without reference from the entry point
   std::vector<irep_idt> java_load_classes;

--- a/jbmc/src/java_bytecode/java_bytecode_language.h
+++ b/jbmc/src/java_bytecode/java_bytecode_language.h
@@ -236,10 +236,10 @@ protected:
   java_string_library_preprocesst string_preprocess;
   std::string java_cp_include_files;
   bool nondet_static;
-  /// Path to a JSON file which contains initial values of static fields (right
+  /// JSON which contains initial values of static fields (right
   /// after the static initializer of the class was run). This is read from the
-  /// --static-values command-line option.
-  std::string static_values_file;
+  /// file specified by the --static-values command-line option.
+  optionalt<jsont> static_values_json;
 
   // list of classes to force load even without reference from the entry point
   std::vector<irep_idt> java_load_classes;

--- a/jbmc/src/java_bytecode/java_static_initializers.cpp
+++ b/jbmc/src/java_bytecode/java_static_initializers.cpp
@@ -777,6 +777,7 @@ code_blockt get_user_specified_clinit_body(
   std::unordered_map<std::string, object_creation_referencet> &references)
 {
   jsont json;
+  const irep_idt &real_clinit_name = clinit_function_name(class_id);
   if(
     !static_values_file.empty() &&
     !parse_json(static_values_file, message_handler, json) && json.is_object())
@@ -814,7 +815,7 @@ code_blockt get_user_specified_clinit_body(
           assign_from_json(
             value_pair.first,
             value_pair.second,
-            clinit_function_name(class_id),
+            real_clinit_name,
             body,
             symbol_table,
             needed_lazy_methods,
@@ -825,7 +826,6 @@ code_blockt get_user_specified_clinit_body(
       }
     }
   }
-  const irep_idt &real_clinit_name = clinit_function_name(class_id);
   if(const auto clinit_func = symbol_table.lookup(real_clinit_name))
     return code_blockt{{code_function_callt{clinit_func->symbol_expr()}}};
   return code_blockt{};

--- a/jbmc/src/java_bytecode/java_static_initializers.cpp
+++ b/jbmc/src/java_bytecode/java_static_initializers.cpp
@@ -768,7 +768,7 @@ code_ifthenelset get_clinit_wrapper_body(
 }
 
 /// \return map associating classes to the symbols they declare
-static std::unordered_multimap<irep_idt, symbolt>
+std::unordered_multimap<irep_idt, symbolt>
 class_to_declared_symbols(const symbol_tablet &symbol_table)
 {
   std::unordered_multimap<irep_idt, symbolt> result;
@@ -787,7 +787,9 @@ code_blockt get_user_specified_clinit_body(
   symbol_table_baset &symbol_table,
   optionalt<ci_lazy_methods_neededt> needed_lazy_methods,
   size_t max_user_array_length,
-  std::unordered_map<std::string, object_creation_referencet> &references)
+  std::unordered_map<std::string, object_creation_referencet> &references,
+  const std::unordered_multimap<irep_idt, symbolt>
+    &class_to_declared_symbols_map)
 {
   const irep_idt &real_clinit_name = clinit_function_name(class_id);
   const auto class_entry =
@@ -799,8 +801,6 @@ code_blockt get_user_specified_clinit_body(
     {
       const auto &class_json_object = to_json_object(class_json_value);
       std::map<symbol_exprt, jsont> static_field_values;
-      const auto class_to_declared_symbols_map =
-        class_to_declared_symbols(symbol_table);
       for(const auto &class_symbol_pair :
           equal_range(class_to_declared_symbols_map, class_id))
       {

--- a/jbmc/src/java_bytecode/java_static_initializers.cpp
+++ b/jbmc/src/java_bytecode/java_static_initializers.cpp
@@ -769,7 +769,7 @@ code_ifthenelset get_clinit_wrapper_body(
 
 code_blockt get_user_specified_clinit_body(
   const irep_idt &class_id,
-  const optionalt<jsont> &static_values_json,
+  const optionalt<json_objectt> &static_values_json,
   symbol_table_baset &symbol_table,
   message_handlert &message_handler,
   optionalt<ci_lazy_methods_neededt> needed_lazy_methods,
@@ -777,12 +777,11 @@ code_blockt get_user_specified_clinit_body(
   std::unordered_map<std::string, object_creation_referencet> &references)
 {
   const irep_idt &real_clinit_name = clinit_function_name(class_id);
-  if(static_values_json.has_value() && static_values_json->is_object())
+  if(static_values_json.has_value())
   {
-    const auto &json_object = to_json_object(*static_values_json);
-    const auto class_entry =
-      json_object.find(id2string(strip_java_namespace_prefix(class_id)));
-    if(class_entry != json_object.end())
+    const auto class_entry = static_values_json->find(
+      id2string(strip_java_namespace_prefix(class_id)));
+    if(class_entry != static_values_json->end())
     {
       const auto &class_json_value = class_entry->second;
       if(class_json_value.is_object())

--- a/jbmc/src/java_bytecode/java_static_initializers.cpp
+++ b/jbmc/src/java_bytecode/java_static_initializers.cpp
@@ -769,20 +769,17 @@ code_ifthenelset get_clinit_wrapper_body(
 
 code_blockt get_user_specified_clinit_body(
   const irep_idt &class_id,
-  const std::string &static_values_file,
+  const optionalt<jsont> &static_values_json,
   symbol_table_baset &symbol_table,
   message_handlert &message_handler,
   optionalt<ci_lazy_methods_neededt> needed_lazy_methods,
   size_t max_user_array_length,
   std::unordered_map<std::string, object_creation_referencet> &references)
 {
-  jsont json;
   const irep_idt &real_clinit_name = clinit_function_name(class_id);
-  if(
-    !static_values_file.empty() &&
-    !parse_json(static_values_file, message_handler, json) && json.is_object())
+  if(static_values_json.has_value() && static_values_json->is_object())
   {
-    const auto &json_object = to_json_object(json);
+    const auto &json_object = to_json_object(*static_values_json);
     const auto class_entry =
       json_object.find(id2string(strip_java_namespace_prefix(class_id)));
     if(class_entry != json_object.end())

--- a/jbmc/src/java_bytecode/java_static_initializers.cpp
+++ b/jbmc/src/java_bytecode/java_static_initializers.cpp
@@ -771,7 +771,6 @@ code_blockt get_user_specified_clinit_body(
   const irep_idt &class_id,
   const json_objectt &static_values_json,
   symbol_table_baset &symbol_table,
-  message_handlert &message_handler,
   optionalt<ci_lazy_methods_neededt> needed_lazy_methods,
   size_t max_user_array_length,
   std::unordered_map<std::string, object_creation_referencet> &references)

--- a/jbmc/src/java_bytecode/java_static_initializers.cpp
+++ b/jbmc/src/java_bytecode/java_static_initializers.cpp
@@ -988,21 +988,21 @@ code_blockt stub_global_initializer_factoryt::get_stub_initializer_body(
   // class. Note this is the same invocation used in
   // java_static_lifetime_init.
 
-  auto class_globals = stub_globals_by_class.equal_range(*class_id);
+  auto class_globals = equal_range(stub_globals_by_class, *class_id);
   INVARIANT(
-    class_globals.first != class_globals.second,
+    !class_globals.empty(),
     "class with synthetic clinit should have at least one global to init");
 
   java_object_factory_parameterst parameters = object_factory_parameters;
   parameters.function_id = function_id;
 
-  for(auto it = class_globals.first; it != class_globals.second; ++it)
+  for(const auto &pair : class_globals)
   {
     const symbol_exprt new_global_symbol =
-      symbol_table.lookup_ref(it->second).symbol_expr();
+      symbol_table.lookup_ref(pair.second).symbol_expr();
 
     parameters.min_null_tree_depth =
-      is_non_null_library_global(it->second)
+      is_non_null_library_global(pair.second)
         ? object_factory_parameters.min_null_tree_depth + 1
         : object_factory_parameters.min_null_tree_depth;
 

--- a/jbmc/src/java_bytecode/java_static_initializers.h
+++ b/jbmc/src/java_bytecode/java_static_initializers.h
@@ -52,6 +52,10 @@ code_ifthenelset get_clinit_wrapper_body(
   const select_pointer_typet &pointer_type_selector,
   message_handlert &message_handler);
 
+/// \return map associating classes to the symbols they declare
+std::unordered_multimap<irep_idt, symbolt>
+class_to_declared_symbols(const symbol_tablet &symbol_table);
+
 /// Create the body of a user_specified_clinit function for a given class, which
 /// includes assignments for all static fields of the class to values read from
 /// an input file. If the file could not be parsed or an entry for this class
@@ -72,6 +76,8 @@ code_ifthenelset get_clinit_wrapper_body(
 ///   arrays. Any arrays that were specified to be of nondeterministic length in
 ///   the input file will be limited by this value.
 /// \param references: map to keep track of reference-equal objets.
+/// \param class_to_declared_symbols_map: map classes to the symbols that
+///   they declare.
 /// \return the body of the user_specified_clinit function as a code block.
 code_blockt get_user_specified_clinit_body(
   const irep_idt &class_id,
@@ -79,7 +85,9 @@ code_blockt get_user_specified_clinit_body(
   symbol_table_baset &symbol_table,
   optionalt<ci_lazy_methods_neededt> needed_lazy_methods,
   size_t max_user_array_length,
-  std::unordered_map<std::string, object_creation_referencet> &references);
+  std::unordered_map<std::string, object_creation_referencet> &references,
+  const std::unordered_multimap<irep_idt, symbolt>
+    &class_to_declared_symbols_map);
 
 class stub_global_initializer_factoryt
 {

--- a/jbmc/src/java_bytecode/java_static_initializers.h
+++ b/jbmc/src/java_bytecode/java_static_initializers.h
@@ -76,7 +76,7 @@ code_ifthenelset get_clinit_wrapper_body(
 /// \return the body of the user_specified_clinit function as a code block.
 code_blockt get_user_specified_clinit_body(
   const irep_idt &class_id,
-  const optionalt<json_objectt> &static_values_json,
+  const json_objectt &static_values_json,
   symbol_table_baset &symbol_table,
   message_handlert &message_handler,
   optionalt<ci_lazy_methods_neededt> needed_lazy_methods,

--- a/jbmc/src/java_bytecode/java_static_initializers.h
+++ b/jbmc/src/java_bytecode/java_static_initializers.h
@@ -62,10 +62,9 @@ code_ifthenelset get_clinit_wrapper_body(
 /// assigned default values (zero or null).
 /// \param class_id: the id of the class to create a user_specified_clinit
 ///   function body for.
-/// \param static_values_file: input file containing values of static fields.
+/// \param static_values_json: JSON object containing values of static fields.
 ///   The format is expected to be a map whose keys are class names, and whose
-///   values are maps from static field names to values. Currently only JSON
-///   is supported as a file format.
+///   values are maps from static field names to values.
 /// \param symbol_table: used to look up and create new symbols
 /// \param message_handler: used to log any errors with parsing the input file
 /// \param needed_lazy_methods: used to mark any runtime types given in the
@@ -77,7 +76,7 @@ code_ifthenelset get_clinit_wrapper_body(
 /// \return the body of the user_specified_clinit function as a code block.
 code_blockt get_user_specified_clinit_body(
   const irep_idt &class_id,
-  const std::string &static_values_file,
+  const optionalt<jsont> &static_values_json,
   symbol_table_baset &symbol_table,
   message_handlert &message_handler,
   optionalt<ci_lazy_methods_neededt> needed_lazy_methods,

--- a/jbmc/src/java_bytecode/java_static_initializers.h
+++ b/jbmc/src/java_bytecode/java_static_initializers.h
@@ -76,7 +76,7 @@ code_ifthenelset get_clinit_wrapper_body(
 /// \return the body of the user_specified_clinit function as a code block.
 code_blockt get_user_specified_clinit_body(
   const irep_idt &class_id,
-  const optionalt<jsont> &static_values_json,
+  const optionalt<json_objectt> &static_values_json,
   symbol_table_baset &symbol_table,
   message_handlert &message_handler,
   optionalt<ci_lazy_methods_neededt> needed_lazy_methods,

--- a/jbmc/src/java_bytecode/java_static_initializers.h
+++ b/jbmc/src/java_bytecode/java_static_initializers.h
@@ -66,7 +66,6 @@ code_ifthenelset get_clinit_wrapper_body(
 ///   The format is expected to be a map whose keys are class names, and whose
 ///   values are maps from static field names to values.
 /// \param symbol_table: used to look up and create new symbols
-/// \param message_handler: used to log any errors with parsing the input file
 /// \param needed_lazy_methods: used to mark any runtime types given in the
 ///   input file as needed
 /// \param max_user_array_length: maximum value for constant or variable length
@@ -78,7 +77,6 @@ code_blockt get_user_specified_clinit_body(
   const irep_idt &class_id,
   const json_objectt &static_values_json,
   symbol_table_baset &symbol_table,
-  message_handlert &message_handler,
   optionalt<ci_lazy_methods_neededt> needed_lazy_methods,
   size_t max_user_array_length,
   std::unordered_map<std::string, object_creation_referencet> &references);

--- a/src/util/range.h
+++ b/src/util/range.h
@@ -533,4 +533,15 @@ auto make_range(containert &container) -> ranget<decltype(container.begin())>
     container.begin(), container.end());
 }
 
+/// Utility function to make equal_range method of multimap easier to use by
+/// returning a ranget object. For instance, we can write:
+/// `for(auto value : equal_range(map, key).filter(...).map(...)) {...}`.
+template <typename multimapt>
+ranget<typename multimapt::const_iterator>
+equal_range(const multimapt &multimap, const typename multimapt::key_type &key)
+{
+  auto iterator_pair = multimap.equal_range(key);
+  return make_range(iterator_pair.first, iterator_pair.second);
+}
+
 #endif // CPROVER_UTIL_RANGE_H


### PR DESCRIPTION
Some computation like json parsing and iterating through the map were done at each call to `get_user_specified_clinit` which is called a lot of times for projects with large json file for static values.
With this pull request on such an example the execution time went from 10 seconds to 2 seconds (mostly thanks to removing the redundant json parsing).

 
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
