### PR TITLE
Add pass to (try to) ensure a single backedge per loop header

### DIFF
--- a/regression/goto-instrument/ensure-one-backedge-per-target-do-while-loop/test.c
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-do-while-loop/test.c
@@ -1,0 +1,11 @@
+int main(int argc, char **argv)
+{
+  int i = 0;
+  do
+  {
+    ++i;
+    if(i == 5)
+      continue;
+    ++i;
+  } while(i < 10);
+}

--- a/regression/goto-instrument/ensure-one-backedge-per-target-do-while-loop/with-transform.desc
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-do-while-loop/with-transform.desc
@@ -1,0 +1,6 @@
+CORE
+test.c
+--ensure-one-backedge-per-target --show-natural-loops
+^2 is head of \{ 2, 3, 4, 5, 6, 7 \(backedge\) \}$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/ensure-one-backedge-per-target-do-while-loop/without-transform.desc
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-do-while-loop/without-transform.desc
@@ -1,0 +1,6 @@
+CORE
+test.c
+--show-natural-loops
+^2 is head of \{ 2, 3, 4, 5, 6, 7 \(backedge\) \}$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/ensure-one-backedge-per-target-for-loop/test.c
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-for-loop/test.c
@@ -1,0 +1,10 @@
+int main(int argc, char **argv)
+{
+  for(int i = 0; i < 10; ++i)
+  {
+    ++i;
+    if(i == 5)
+      continue;
+    --i;
+  }
+}

--- a/regression/goto-instrument/ensure-one-backedge-per-target-for-loop/with-transform.desc
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-for-loop/with-transform.desc
@@ -1,0 +1,6 @@
+CORE
+test.c
+--ensure-one-backedge-per-target --show-natural-loops
+^2 is head of \{ 2, 3, 4, 5, 6, 7, 8, 9 \(backedge\) \}$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/ensure-one-backedge-per-target-for-loop/without-transform.desc
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-for-loop/without-transform.desc
@@ -1,0 +1,6 @@
+CORE
+test.c
+--show-natural-loops
+^2 is head of \{ 2, 3, 4, 5, 6, 7, 8, 9 \(backedge\) \}$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/ensure-one-backedge-per-target-goto-top-multiple-loops/test.c
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-goto-top-multiple-loops/test.c
@@ -1,0 +1,24 @@
+int main(int argc, char **argv)
+{
+  int i = 0;
+top:
+{
+  ++i;
+  if(i == 5)
+    goto top;
+  ++i;
+}
+  if(i < 10)
+    goto top;
+
+  i = 0;
+top2:
+{
+  ++i;
+  if(i == 5)
+    goto top2;
+  ++i;
+}
+  if(i < 10)
+    goto top2;
+}

--- a/regression/goto-instrument/ensure-one-backedge-per-target-goto-top-multiple-loops/with-transform.desc
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-goto-top-multiple-loops/with-transform.desc
@@ -1,0 +1,7 @@
+CORE
+test.c
+--ensure-one-backedge-per-target --show-natural-loops
+^2 is head of \{ 2, 3, 4, 5, 6, 7, 8 \(backedge\) \}
+^12 is head of \{ 12, 13, 14, 15, 16, 17, 18 \(backedge\) \}
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/ensure-one-backedge-per-target-goto-top-multiple-loops/without-transform.desc
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-goto-top-multiple-loops/without-transform.desc
@@ -1,0 +1,7 @@
+CORE
+test.c
+--show-natural-loops
+^2 is head of \{ 2, 3 \(backedge\), 4, 5, 6, 7 \(backedge\) \}
+^11 is head of \{ 11, 12 \(backedge\), 13, 14, 15, 16 \(backedge\) \}
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/ensure-one-backedge-per-target-goto-top-multiple/test.c
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-goto-top-multiple/test.c
@@ -1,0 +1,19 @@
+int main(int argc, char **argv)
+{
+  int i = 0;
+top:
+{
+  ++i;
+  if(i == 5)
+    goto top;
+  if(i == 6)
+    goto top;
+  if(i == 7)
+    goto top;
+  if(i == 8)
+    goto top;
+  ++i;
+}
+  if(i < 10)
+    goto top;
+}

--- a/regression/goto-instrument/ensure-one-backedge-per-target-goto-top-multiple/with-transform.desc
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-goto-top-multiple/with-transform.desc
@@ -1,0 +1,6 @@
+CORE
+test.c
+--ensure-one-backedge-per-target --show-natural-loops
+^2 is head of \{ 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 \(backedge\) \}$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/ensure-one-backedge-per-target-goto-top-multiple/without-transform.desc
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-goto-top-multiple/without-transform.desc
@@ -1,0 +1,6 @@
+CORE
+test.c
+--show-natural-loops
+^2 is head of \{ 2, 3 \(backedge\), 4, 5, 6 \(backedge\), 7, 8, 9 \(backedge\), 10, 11, 12 \(backedge\), 13, 14, 15, 16 \(backedge\) \}$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/ensure-one-backedge-per-target-goto-top-unconditional/test.c
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-goto-top-unconditional/test.c
@@ -1,0 +1,14 @@
+int main(int argc, char **argv)
+{
+  int i = 0;
+top:
+{
+  ++i;
+  if(i == 5)
+    goto top;
+  if(i > 10)
+    return 0;
+  ++i;
+}
+  goto top;
+}

--- a/regression/goto-instrument/ensure-one-backedge-per-target-goto-top-unconditional/with-transform.desc
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-goto-top-unconditional/with-transform.desc
@@ -1,0 +1,6 @@
+CORE
+test.c
+--ensure-one-backedge-per-target --show-natural-loops
+^2 is head of \{ 2, 3, 4, 5, 6, 10, 11, 12 \(backedge\) \}$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/ensure-one-backedge-per-target-goto-top-unconditional/without-transform.desc
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-goto-top-unconditional/without-transform.desc
@@ -1,0 +1,6 @@
+CORE
+test.c
+--show-natural-loops
+^2 is head of \{ 2, 3 \(backedge\), 4, 5, 6, 10, 11, 12 \(backedge\) \}$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/ensure-one-backedge-per-target-goto-top/test.c
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-goto-top/test.c
@@ -1,0 +1,13 @@
+int main(int argc, char **argv)
+{
+  int i = 0;
+top:
+{
+  ++i;
+  if(i == 5)
+    goto top;
+  ++i;
+}
+  if(i < 10)
+    goto top;
+}

--- a/regression/goto-instrument/ensure-one-backedge-per-target-goto-top/with-transform.desc
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-goto-top/with-transform.desc
@@ -1,0 +1,6 @@
+CORE
+test.c
+--ensure-one-backedge-per-target --show-natural-loops
+^2 is head of \{ 2, 3, 4, 5, 6, 7, 8 \(backedge\) \}$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/ensure-one-backedge-per-target-goto-top/without-transform.desc
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-goto-top/without-transform.desc
@@ -1,0 +1,6 @@
+CORE
+test.c
+--show-natural-loops
+^2 is head of \{ 2, 3 \(backedge\), 4, 5, 6, 7 \(backedge\) \}$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/ensure-one-backedge-per-target-while-loop/test.c
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-while-loop/test.c
@@ -1,0 +1,11 @@
+int main(int argc, char **argv)
+{
+  int i = 0;
+  while(i < 10)
+  {
+    ++i;
+    if(i == 5)
+      continue;
+    ++i;
+  }
+}

--- a/regression/goto-instrument/ensure-one-backedge-per-target-while-loop/with-transform.desc
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-while-loop/with-transform.desc
@@ -1,0 +1,6 @@
+CORE
+test.c
+--ensure-one-backedge-per-target --show-natural-loops
+^2 is head of \{ 2, 3, 4, 5, 6, 7, 8 \(backedge\) \}$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/ensure-one-backedge-per-target-while-loop/without-transform.desc
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-while-loop/without-transform.desc
@@ -1,0 +1,6 @@
+CORE
+test.c
+--show-natural-loops
+^2 is head of \{ 2, 3, 4, 5, 6, 7, 8 \(backedge\) \}$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/natural-loops-multiple-backedges/test.desc
+++ b/regression/goto-instrument/natural-loops-multiple-backedges/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-natural-loops
-0 is head of \{ [0124], [0124], [0124], [0124] \}
+0 is head of \{ 0, 1, 2 \(backedge\), 4 \(backedge\) \}
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/analyses/natural_loops.h
+++ b/src/analyses/natural_loops.h
@@ -281,13 +281,24 @@ void natural_loops_templatet<P, T>::output(std::ostream &out) const
   {
     unsigned n=loop.first->location_number;
 
+    std::unordered_set<std::size_t> backedge_location_numbers;
+    for(const auto &backedge : loop.first->incoming_edges)
+      backedge_location_numbers.insert(backedge->location_number);
+
     out << n << " is head of { ";
-    for(typename natural_loopt::const_iterator l_it=loop.second.begin();
-        l_it!=loop.second.end(); ++l_it)
+
+    std::vector<std::size_t> loop_location_numbers;
+    for(const auto &loop_instruction_it : loop.second)
+      loop_location_numbers.push_back(loop_instruction_it->location_number);
+    std::sort(loop_location_numbers.begin(), loop_location_numbers.end());
+
+    for(const auto location_number : loop_location_numbers)
     {
-      if(l_it!=loop.second.begin())
+      if(location_number != loop_location_numbers.at(0))
         out << ", ";
-      out << (*l_it)->location_number;
+      out << location_number;
+      if(backedge_location_numbers.count(location_number))
+        out << " (backedge)";
     }
     out << " }\n";
   }

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -24,6 +24,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/version.h>
 
 #include <goto-programs/class_hierarchy.h>
+#include <goto-programs/ensure_one_backedge_per_target.h>
 #include <goto-programs/goto_convert_functions.h>
 #include <goto-programs/goto_inline.h>
 #include <goto-programs/interpreter.h>
@@ -1577,6 +1578,12 @@ void goto_instrument_parse_optionst::instrument_goto_program()
       reachability_slicer(goto_model, cmdline.get_values("property"));
     else
       reachability_slicer(goto_model);
+  }
+
+  if(cmdline.isset("ensure-one-backedge-per-target"))
+  {
+    log.status() << "Trying to force one backedge per target" << messaget::eom;
+    ensure_one_backedge_per_target(goto_model);
   }
 
   // recalculate numbers, etc.

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -111,6 +111,7 @@ Author: Daniel Kroening, kroening@kroening.com
   "(validate-goto-binary)" \
   OPT_VALIDATE \
   OPT_ANSI_C_LANGUAGE \
+  "(ensure-one-backedge-per-target)" \
   // empty last line
 
 // clang-format on

--- a/src/goto-programs/Makefile
+++ b/src/goto-programs/Makefile
@@ -6,6 +6,7 @@ SRC = adjust_float_expressions.cpp \
       destructor.cpp \
       destructor_tree.cpp \
       elf_reader.cpp \
+      ensure_one_backedge_per_target.cpp \
       format_strings.cpp \
       goto_asm.cpp \
       goto_clean_expr.cpp \

--- a/src/goto-programs/ensure_one_backedge_per_target.cpp
+++ b/src/goto-programs/ensure_one_backedge_per_target.cpp
@@ -1,0 +1,122 @@
+/*******************************************************************\
+
+Module: Ensure one backedge per target
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+/// \file
+/// Ensure one backedge per target
+
+#include "ensure_one_backedge_per_target.h"
+
+static bool location_number_less_than(
+  const goto_programt::targett &a,
+  const goto_programt::targett &b)
+{
+  return a->location_number < b->location_number;
+}
+
+bool ensure_one_backedge_per_target(
+  goto_programt::targett &it,
+  goto_programt &goto_program)
+{
+  auto &instruction = *it;
+  std::vector<goto_programt::targett> backedges;
+
+  // Check if this instruction has multiple incoming edges from (lexically)
+  // lower down the program. These aren't necessarily loop backedges (in fact
+  // the program might be acyclic), but that's the most common case.
+  for(auto predecessor : instruction.incoming_edges)
+  {
+    if(predecessor->location_number > instruction.location_number)
+      backedges.push_back(predecessor);
+  }
+
+  if(backedges.size() < 2)
+    return false;
+
+  std::sort(backedges.begin(), backedges.end(), location_number_less_than);
+
+  auto last_backedge = backedges.back();
+  backedges.pop_back();
+
+  // Can't transform if the bottom of the (probably) loop is of unexpected
+  // form:
+  if(!last_backedge->is_goto() || last_backedge->targets.size() > 1)
+  {
+    return false;
+  }
+
+  // If the last backedge is a conditional jump, add an extra unconditional
+  // backedge after it:
+  if(!last_backedge->guard.is_true())
+  {
+    auto new_goto =
+      goto_program.insert_after(last_backedge, goto_programt::make_goto(it));
+    // Turn the existing `if(x) goto head; succ: ...`
+    // into `if(!x) goto succ; goto head; succ: ...`
+    last_backedge->guard = not_exprt(last_backedge->guard);
+    last_backedge->set_target(std::next(new_goto));
+    // Use the new backedge as the one true way to the header:
+    last_backedge = new_goto;
+  }
+
+  // Redirect all but one of the backedges to the last one.
+  // For example, transform
+  // "a: if(x) goto a; if(y) goto a;" into
+  // "a: if(x) goto b; if(y) b: goto a;"
+  // In the common case where this is a natural loop this corresponds to
+  // branching to the bottom of the loop on a `continue` statement.
+  for(auto backedge : backedges)
+  {
+    if(backedge->is_goto() && backedge->targets.size() == 1)
+    {
+      backedge->set_target(last_backedge);
+    }
+  }
+
+  return true;
+}
+
+bool ensure_one_backedge_per_target(goto_programt &goto_program)
+{
+  bool any_change = false;
+
+  for(auto it = goto_program.instructions.begin();
+      it != goto_program.instructions.end();
+      ++it)
+  {
+    any_change |= ensure_one_backedge_per_target(it, goto_program);
+  }
+
+  return any_change;
+}
+
+bool ensure_one_backedge_per_target(goto_model_functiont &goto_model_function)
+{
+  auto &goto_function = goto_model_function.get_goto_function();
+
+  if(ensure_one_backedge_per_target(goto_function.body))
+  {
+    goto_function.body.update();
+    goto_model_function.compute_location_numbers();
+    return true;
+  }
+
+  return false;
+}
+
+bool ensure_one_backedge_per_target(goto_modelt &goto_model)
+{
+  bool any_change = false;
+
+  for(auto &id_and_function : goto_model.goto_functions.function_map)
+    any_change |= ensure_one_backedge_per_target(id_and_function.second.body);
+
+  if(any_change)
+    goto_model.goto_functions.update();
+
+  return any_change;
+}

--- a/src/goto-programs/ensure_one_backedge_per_target.h
+++ b/src/goto-programs/ensure_one_backedge_per_target.h
@@ -1,0 +1,48 @@
+/*******************************************************************\
+
+Module: Ensure one backedge per target
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+/// \file
+/// Ensure one backedge per target
+
+#ifndef CPROVER_GOTO_PROGRAMS_ENSURE_ONE_BACKEDGE_PER_TARGET_H
+#define CPROVER_GOTO_PROGRAMS_ENSURE_ONE_BACKEDGE_PER_TARGET_H
+
+#include "goto_model.h"
+#include "goto_program.h"
+
+/// Try to force the given \p goto_program into a form such that each backedge
+/// (branch going backwards in lexical program order) has a unique target. This
+/// is achieved by redirecting backedges or possibly introducing a new one.
+/// Note this may not always succeed; client code must check whether the
+/// condition holds of any backedge target it is interested in.
+/// Note this overload leaves \p goto_program's location numbers and incoming-
+/// edges sets inconsistent; the client should call \ref goto_programt::update.
+/// \return true if any change is made.
+bool ensure_one_backedge_per_target(goto_programt &goto_program);
+
+/// Try to force the given \p goto_program into a form such that each backedge
+/// (branch going backwards in lexical program order) has a unique target. This
+/// is achieved by redirecting backedges or possibly introducing a new one.
+/// Note this may not always succeed; client code must check whether the
+/// condition holds of any backedge target it is interested in.
+/// Note this overload updates \p goto_model_function's location numbers and
+/// incoming-edges sets.
+/// \return true if any change is made.
+bool ensure_one_backedge_per_target(goto_model_functiont &goto_model_function);
+
+/// Try to force the given \p goto_program into a form such that each backedge
+/// (branch going backwards in lexical program order) has a unique target. This
+/// is achieved by redirecting backedges or possibly introducing a new one.
+/// Note this may not always succeed; client code must check whether the
+/// condition holds of any backedge target it is interested in.
+/// Note this overload updates \p goto_model's location numbers and
+/// incoming-edges sets.
+/// \return true if any change is made.
+bool ensure_one_backedge_per_target(goto_modelt &goto_model);
+
+#endif // CPROVER_GOTO_PROGRAMS_ENSURE_ONE_BACKEDGE_PER_TARGET_H


### PR DESCRIPTION
Actually to reduce costs this redirects *any* (lexical) backedge to enforce the rule that each loop header (or block otherwise branched back to, including acyclic code) has a single incoming edge from below.

This pass will be useful for regularising Java `while` and `do-while` loops, which can have `continue` edges directed to the top of the loop. At present goto-symex executes these loops more times than the `--unwind` directive would suggest because it regards the multiple distinct backedges as different loops.