### PR TITLE
Add single-entry, single-exit regions pass

### DIFF
--- a/jbmc/src/java_bytecode/java_local_variable_table.cpp
+++ b/jbmc/src/java_bytecode/java_local_variable_table.cpp
@@ -40,6 +40,7 @@ struct procedure_local_cfg_baset<
   typedef std::map<java_bytecode_convert_methodt::method_offsett,
                    java_bytecode_convert_methodt::method_offsett>
     entry_mapt;
+  typedef std::size_t entryt;
   entry_mapt entry_map;
 
   procedure_local_cfg_baset() {}

--- a/regression/goto-instrument/region-analysis-1/test.c
+++ b/regression/goto-instrument/region-analysis-1/test.c
@@ -1,0 +1,22 @@
+int main(int argc, char **argv)
+{
+  // Function containing two SESE regions,
+  // one per if-block.
+  if(argc % 5)
+  {
+    if(argc % 2)
+    {
+      ++argc;
+    }
+    else
+    {
+      --argc;
+    }
+  }
+  else
+  {
+    ++argc;
+  }
+
+  return argc;
+}

--- a/regression/goto-instrument/region-analysis-1/test.desc
+++ b/regression/goto-instrument/region-analysis-1/test.desc
@@ -1,0 +1,8 @@
+CORE
+test.c
+--show-sese-regions
+^Region starting at \(1, [0-9]+\) IF !\(argc % 2 != 0\) THEN GOTO 1 ends at \(5, [0-9]+\) 2: SKIP$
+^Region starting at \(0, [0-9]+\) IF !\(argc % 5 != 0\) THEN GOTO 3 ends at \(8, [0-9]+\) 4: SKIP$
+^Function contains 2 single-entry, single-exit regions:$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/region-analysis-10/test.c
+++ b/regression/goto-instrument/region-analysis-10/test.c
@@ -1,0 +1,20 @@
+int main(int argc, char **argv)
+{
+  // A function containing 2 SESE regions: one delimiting the outer
+  // if-block, and one delimiting the while-loop.
+
+  if(argc % 5)
+  {
+    int x = 0;
+    while(x < 10)
+    {
+      ++x;
+    }
+  }
+  else
+  {
+    --argc;
+  }
+
+  return argc;
+}

--- a/regression/goto-instrument/region-analysis-10/test.desc
+++ b/regression/goto-instrument/region-analysis-10/test.desc
@@ -1,0 +1,8 @@
+CORE
+test.c
+--show-sese-regions
+^Function contains 2 single-entry, single-exit regions:$
+^Region starting at \(2, [0-9]+\) x = 0; ends at \(6, [0-9]+\) 2: SKIP$
+^Region starting at \(0, [0-9]+\) IF !\(argc % 5 != 0\) THEN GOTO 3 ends at \(10, [0-9]+\) 4: SKIP$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/region-analysis-11/test.c
+++ b/regression/goto-instrument/region-analysis-11/test.c
@@ -1,0 +1,22 @@
+int main(int argc, char **argv)
+{
+  // A function containing 2 SESE regions, one for the outer if-block
+  // and one for the while-loop, despite a break edge
+
+  if(argc % 5)
+  {
+    int x = 0;
+    while(x < 10)
+    {
+      if(x % 7)
+        break;
+      ++x;
+    }
+  }
+  else
+  {
+    --argc;
+  }
+
+  return argc;
+}

--- a/regression/goto-instrument/region-analysis-11/test.desc
+++ b/regression/goto-instrument/region-analysis-11/test.desc
@@ -1,0 +1,8 @@
+CORE
+test.c
+--show-sese-regions
+^Function contains 2 single-entry, single-exit regions:$
+^Region starting at \(2, [0-9]+\) x = 0; ends at \(9, [0-9]+\) 2: SKIP$
+^Region starting at \(0, [0-9]+\) IF !\(argc % 5 != 0\) THEN GOTO 3 ends at \(13, [0-9]+\) 4: SKIP$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/region-analysis-12/test.c
+++ b/regression/goto-instrument/region-analysis-12/test.c
@@ -1,0 +1,26 @@
+int main(int argc, char **argv)
+{
+  // A function containing 3 SESE regions, one for the outer if-block
+  // and one for the while-loop, despite a continue edge, and one for
+  // the conditional inside the loop.
+
+  if(argc % 5)
+  {
+    int x = 0;
+    while(x < 10)
+    {
+      if(x % 7)
+      {
+        ++x;
+        continue;
+      }
+      ++x;
+    }
+  }
+  else
+  {
+    --argc;
+  }
+
+  return argc;
+}

--- a/regression/goto-instrument/region-analysis-12/test.desc
+++ b/regression/goto-instrument/region-analysis-12/test.desc
@@ -1,0 +1,9 @@
+CORE
+test.c
+--show-sese-regions
+^Function contains 3 single-entry, single-exit regions:$
+^Region starting at \(4, [0-9]+\) IF !\(x % 7 != 0\) THEN GOTO 2 ends at \(9, [0-9]+\) 3: GOTO 1$
+^Region starting at \(0, [0-9]+\) IF !\(argc % 5 != 0\) THEN GOTO 5 ends at \(14, [0-9]+\) 6: SKIP$
+^Region starting at \(2, [0-9]+\) x = 0; ends at \(10, [0-9]+\) 4: SKIP$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/region-analysis-13/test.c
+++ b/regression/goto-instrument/region-analysis-13/test.c
@@ -1,0 +1,27 @@
+int main(int argc, char **argv)
+{
+  // A function containing 2 SESE regions, one for the outer if-block
+  // and one for the while-loop, despite a continue edge that branches
+  // directly to the top of the loop.
+
+  if(argc % 5)
+  {
+    int x = 0;
+  top_continue:
+    while(x < 10)
+    {
+      if(x % 7)
+      {
+        ++x;
+        goto top_continue;
+      }
+      ++x;
+    }
+  }
+  else
+  {
+    --argc;
+  }
+
+  return argc;
+}

--- a/regression/goto-instrument/region-analysis-13/test.desc
+++ b/regression/goto-instrument/region-analysis-13/test.desc
@@ -1,0 +1,11 @@
+FUTURE
+test.c
+--show-sese-regions
+^Function contains 2 single-entry, single-exit regions:$
+^Region starting at \(2, [0-9]+\) x = 0; ends at \(10, [0-9]+\) 3: SKIP$
+^Region starting at \(0, [0-9]+\) IF !\(argc % 5 != 0\) THEN GOTO 4 ends at \(14, [0-9]+\) 5: SKIP$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+These regions cannot currently be identified because the function contains a loop with two backedges.

--- a/regression/goto-instrument/region-analysis-14/test.c
+++ b/regression/goto-instrument/region-analysis-14/test.c
@@ -1,0 +1,20 @@
+int main(int argc, char **argv)
+{
+  // A function containing 2 SESE regions: one delimiting the outer
+  // if-block, and one delimiting the do-while loop.
+
+  if(argc % 5)
+  {
+    int x = 0;
+    do
+    {
+      ++x;
+    } while(x < 10);
+  }
+  else
+  {
+    --argc;
+  }
+
+  return argc;
+}

--- a/regression/goto-instrument/region-analysis-14/test.desc
+++ b/regression/goto-instrument/region-analysis-14/test.desc
@@ -1,0 +1,8 @@
+CORE
+test.c
+--show-sese-regions
+^Function contains 2 single-entry, single-exit regions:$
+^Region starting at \(2, [0-9]+\) x = 0; ends at \(5, [0-9]+\) SKIP$
+^Region starting at \(0, [0-9]+\) IF !\(argc % 5 != 0\) THEN GOTO 2 ends at \(9, [0-9]+\) 3: SKIP$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/region-analysis-15/test.c
+++ b/regression/goto-instrument/region-analysis-15/test.c
@@ -1,0 +1,22 @@
+int main(int argc, char **argv)
+{
+  // A function containing 2 SESE regions, one for the outer if-block
+  // and one for the while-loop, despite a break edge
+
+  if(argc % 5)
+  {
+    int x = 0;
+    do
+    {
+      if(x % 7)
+        break;
+      ++x;
+    } while(x < 10);
+  }
+  else
+  {
+    --argc;
+  }
+
+  return argc;
+}

--- a/regression/goto-instrument/region-analysis-15/test.desc
+++ b/regression/goto-instrument/region-analysis-15/test.desc
@@ -1,0 +1,8 @@
+CORE
+test.c
+--show-sese-regions
+^Function contains 2 single-entry, single-exit regions:$
+^Region starting at \(2, [0-9]+\) x = 0; ends at \(8, [0-9]+\) 2: SKIP$
+^Region starting at \(0, [0-9]+\) IF !\(argc % 5 != 0\) THEN GOTO 3 ends at \(12, [0-9]+\) 4: SKIP$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/region-analysis-16/test.c
+++ b/regression/goto-instrument/region-analysis-16/test.c
@@ -1,0 +1,26 @@
+int main(int argc, char **argv)
+{
+  // A function containing 3 SESE regions, one for the outer if-block
+  // and one for the while-loop, despite a continue edge, and one for
+  // the conditional inside the loop.
+
+  if(argc % 5)
+  {
+    int x = 0;
+    do
+    {
+      if(x % 7)
+      {
+        ++x;
+        continue;
+      }
+      ++x;
+    } while(x < 10);
+  }
+  else
+  {
+    --argc;
+  }
+
+  return argc;
+}

--- a/regression/goto-instrument/region-analysis-16/test.desc
+++ b/regression/goto-instrument/region-analysis-16/test.desc
@@ -1,0 +1,9 @@
+CORE
+test.c
+--show-sese-regions
+^Function contains 3 single-entry, single-exit regions:$
+^Region starting at \(3, [0-9]+\) 1: IF !\(x % 7 != 0\) THEN GOTO 2 ends at \(8, [0-9]+\) 3: IF x < 10 THEN GOTO 1$
+^Region starting at \(0, [0-9]+\) IF !\(argc % 5 != 0\) THEN GOTO 4 ends at \(13, [0-9]+\) 5: SKIP$
+^Region starting at \(2, [0-9]+\) x = 0; ends at \(9, [0-9]+\) SKIP$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/region-analysis-17/test.c
+++ b/regression/goto-instrument/region-analysis-17/test.c
@@ -1,0 +1,27 @@
+int main(int argc, char **argv)
+{
+  // A function containing 2 SESE regions, one for the outer if-block
+  // and one for the while-loop, despite a continue edge that branches
+  // directly to the top of the loop.
+
+  if(argc % 5)
+  {
+    int x = 0;
+  top_continue:
+    do
+    {
+      if(x % 7)
+      {
+        ++x;
+        goto top_continue;
+      }
+      ++x;
+    } while(x < 10);
+  }
+  else
+  {
+    --argc;
+  }
+
+  return argc;
+}

--- a/regression/goto-instrument/region-analysis-17/test.desc
+++ b/regression/goto-instrument/region-analysis-17/test.desc
@@ -1,0 +1,14 @@
+FUTURE
+test.c
+--show-sese-regions
+^Function contains 2 single-entry, single-exit regions:$
+^Region starting at \(2, [0-9]+\) x = 0; ends at \(10, [0-9]+\) 3: SKIP$
+^Region starting at \(0, [0-9]+\) IF !\(argc % 5 != 0\) THEN GOTO 4 ends at \(14, [0-9]+\) 5: SKIP$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+The program test.c produces what is effectively two nested loops, but natural-loop
+analysis conflates the two. This would risk identifying a region that straddles the
+boundary between those two loops, and so SESE analysis currently conservatively refrains
+from identifying the regions.

--- a/regression/goto-instrument/region-analysis-2/test.c
+++ b/regression/goto-instrument/region-analysis-2/test.c
@@ -1,0 +1,27 @@
+int main(int argc, char **argv)
+{
+  // Function containing two SESE regions: the inner if-block and the whole
+  // function. The outer if-block is specifically *not* a region due to
+  // a spoiling incoming edge.
+  if(argc % 7)
+    goto target;
+
+  if(argc % 5)
+  {
+    if(argc % 2)
+    {
+      ++argc;
+    }
+    else
+    {
+      --argc;
+    }
+  }
+  else
+  {
+  target:
+    ++argc;
+  }
+
+  return argc;
+}

--- a/regression/goto-instrument/region-analysis-2/test.desc
+++ b/regression/goto-instrument/region-analysis-2/test.desc
@@ -1,0 +1,8 @@
+CORE
+test.c
+--show-sese-regions
+^Function contains 2 single-entry, single-exit regions:$
+^Region starting at \(4, [0-9]+\) IF !\(argc % 2 != 0\) THEN GOTO 1 ends at \(8, [0-9]+\) 2: SKIP$
+^Region starting at \(0, [0-9]+\) IF argc % 7 != 0 THEN GOTO 3 ends at \(11, [0-9]+\) 4: SKIP$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/region-analysis-3/test.c
+++ b/regression/goto-instrument/region-analysis-3/test.c
@@ -1,0 +1,23 @@
+int main(int argc, char **argv)
+{
+  // Function containing two SESE regions: the inner if-block and the whole
+  // function. The outer if-block is specifically *not* a region due to
+  // a spoiling outgoing edge,
+  if(argc % 5)
+  {
+    if(argc % 2)
+    {
+      ++argc;
+    }
+    else
+    {
+      --argc;
+    }
+  }
+  else
+  {
+    return argc - 1;
+  }
+
+  return argc;
+}

--- a/regression/goto-instrument/region-analysis-3/test.desc
+++ b/regression/goto-instrument/region-analysis-3/test.desc
@@ -1,0 +1,8 @@
+CORE
+test.c
+--show-sese-regions
+^Function contains 2 single-entry, single-exit regions:$
+^Region starting at \(1, [0-9]+\) IF !\(argc % 2 != 0\) THEN GOTO 1 ends at \(5, [0-9]+\) 2: SKIP$
+^Region starting at \(0, [0-9]+\) IF !\(argc % 5 != 0\) THEN GOTO 3 ends at \(12, [0-9]+\) 5: END_FUNCTION$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/region-analysis-4/test.c
+++ b/regression/goto-instrument/region-analysis-4/test.c
@@ -1,0 +1,19 @@
+int main(int argc, char **argv)
+{
+  // A function containing 2 SESE regions: one delimiting the outer
+  // if-block, and one delimiting the for-loop.
+
+  if(argc % 5)
+  {
+    for(int x = 0; x < 10; ++x)
+    {
+      ++x;
+    }
+  }
+  else
+  {
+    --argc;
+  }
+
+  return argc;
+}

--- a/regression/goto-instrument/region-analysis-4/test.desc
+++ b/regression/goto-instrument/region-analysis-4/test.desc
@@ -1,0 +1,8 @@
+CORE
+test.c
+--show-sese-regions
+^Function contains 2 single-entry, single-exit regions:$
+^Region starting at \(2, [0-9]+\) x = 0; ends at \(7, [0-9]+\) 2: SKIP$
+^Region starting at \(0, [0-9]+\) IF !\(argc % 5 != 0\) THEN GOTO 3 ends at \(11, [0-9]+\) 4: SKIP$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/region-analysis-5/test.c
+++ b/regression/goto-instrument/region-analysis-5/test.c
@@ -1,0 +1,21 @@
+int main(int argc, char **argv)
+{
+  // A function containing 2 SESE regions: one delimiting the outer
+  // if-block, and one delimiting the for-loop, despite a break edge.
+
+  if(argc % 5)
+  {
+    for(int x = 0; x < 10; ++x)
+    {
+      if(x % 7)
+        break;
+      ++x;
+    }
+  }
+  else
+  {
+    --argc;
+  }
+
+  return argc;
+}

--- a/regression/goto-instrument/region-analysis-5/test.desc
+++ b/regression/goto-instrument/region-analysis-5/test.desc
@@ -1,0 +1,8 @@
+CORE
+test.c
+--show-sese-regions
+^Function contains 2 single-entry, single-exit regions:$
+^Region starting at \(2, [0-9]+\) x = 0; ends at \(10, [0-9]+\) 2: SKIP$
+^Region starting at \(0, [0-9]+\) IF !\(argc % 5 != 0\) THEN GOTO 3 ends at \(14, [0-9]+\) 4: SKIP$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/region-analysis-6/test.c
+++ b/regression/goto-instrument/region-analysis-6/test.c
@@ -1,0 +1,23 @@
+int main(int argc, char **argv)
+{
+  // A function containing 3 SESE regions: one delimiting the outer
+  // if-block, and one delimiting the for-loop, despite a continue edge,
+  // and another delimiting the conditional within the loop (which converges
+  // before the bottom of the loop, to execute the loop increment).
+
+  if(argc % 5)
+  {
+    for(int x = 0; x < 10; ++x)
+    {
+      if(x % 7)
+        continue;
+      ++x;
+    }
+  }
+  else
+  {
+    --argc;
+  }
+
+  return argc;
+}

--- a/regression/goto-instrument/region-analysis-6/test.desc
+++ b/regression/goto-instrument/region-analysis-6/test.desc
@@ -1,0 +1,9 @@
+CORE
+test.c
+--show-sese-regions
+^Function contains 3 single-entry, single-exit regions:$
+^Region starting at \(4, [0-9]+\) IF x % 7 != 0 THEN GOTO 2 ends at \(8, [0-9]+\) 2: x = x \+ 1;$
+^Region starting at \(0, [0-9]+\) IF !\(argc % 5 != 0\) THEN GOTO 4 ends at \(14, [0-9]+\) 5: SKIP$
+^Region starting at \(2, [0-9]+\) x = 0; ends at \(10, [0-9]+\) 3: SKIP$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/region-analysis-7/test.c
+++ b/regression/goto-instrument/region-analysis-7/test.c
@@ -1,0 +1,21 @@
+int main(int argc, char **argv)
+{
+  // A function containing 1 SESE region delimiting the whole function, because
+  // of a spoiling return edge defeating what would otherwise be regions.
+
+  if(argc % 5)
+  {
+    for(int x = 0; x < 10; ++x)
+    {
+      if(x % 7)
+        return;
+      ++x;
+    }
+  }
+  else
+  {
+    --argc;
+  }
+
+  return argc;
+}

--- a/regression/goto-instrument/region-analysis-7/test.desc
+++ b/regression/goto-instrument/region-analysis-7/test.desc
@@ -1,0 +1,7 @@
+CORE
+test.c
+--show-sese-regions
+^Function contains 1 single-entry, single-exit regions:$
+^Region starting at \(0, [0-9]+\) IF !\(argc % 5 != 0\) THEN GOTO 4 ends at \(19, [0-9]+\) 6: END_FUNCTION$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/region-analysis-8/test.c
+++ b/regression/goto-instrument/region-analysis-8/test.c
@@ -1,0 +1,22 @@
+int main(int argc, char **argv)
+{
+  // A function containing 3 SESE regions: one delimiting the outer
+  // if-block, and one delimiting each for-loop.
+
+  if(argc % 5)
+  {
+    for(int x = 0; x < 10; ++x)
+    {
+      for(int y = 0; y < 2; ++y)
+      {
+        ++x;
+      }
+    }
+  }
+  else
+  {
+    --argc;
+  }
+
+  return argc;
+}

--- a/regression/goto-instrument/region-analysis-8/test.desc
+++ b/regression/goto-instrument/region-analysis-8/test.desc
@@ -1,0 +1,9 @@
+CORE
+test.c
+--show-sese-regions
+^Function contains 3 single-entry, single-exit regions:$
+^Region starting at \(5, [0-9]+\) y = 0; ends at \(10, [0-9]+\) 3: SKIP$
+^Region starting at \(0, [0-9]+\) IF !\(argc % 5 != 0\) THEN GOTO 5 ends at \(18, [0-9]+\) 6: SKIP$
+^Region starting at \(2, [0-9]+\) x = 0; ends at \(14, [0-9]+\) 4: SKIP$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/region-analysis-9/test.c
+++ b/regression/goto-instrument/region-analysis-9/test.c
@@ -1,0 +1,27 @@
+int main(int argc, char **argv)
+{
+  // A function containing 2 SESE regions: one delimiting the outer
+  // if-block, and one delimiting the for-loop. The inner loop isn't
+  // a region due to the edge that breaks directly out of both loops.
+
+  if(argc % 5)
+  {
+    for(int x = 0; x < 10; ++x)
+    {
+      for(int y = 0; y < 2; ++y)
+      {
+        ++x;
+        if(y == 1)
+          goto doublebreak;
+      }
+    }
+  doublebreak:
+    ++argc;
+  }
+  else
+  {
+    --argc;
+  }
+
+  return argc;
+}

--- a/regression/goto-instrument/region-analysis-9/test.desc
+++ b/regression/goto-instrument/region-analysis-9/test.desc
@@ -1,0 +1,8 @@
+CORE
+test.c
+--show-sese-regions
+^Function contains 2 single-entry, single-exit regions:$
+^Region starting at \(2, [0-9]+\) x = 0; ends at \(21, [0-9]+\) 6: argc = argc \+ 1;$
+^Region starting at \(0, [0-9]+\) IF !\(argc % 5 != 0\) THEN GOTO 7 ends at \(24, [0-9]+\) 8: SKIP$
+^EXIT=0$
+^SIGNAL=0$

--- a/src/analyses/Makefile
+++ b/src/analyses/Makefile
@@ -27,6 +27,7 @@ SRC = ai.cpp \
       locals.cpp \
       natural_loops.cpp \
       reaching_definitions.cpp \
+      sese_regions.cpp \
       static_analysis.cpp \
       uncaught_exceptions_analysis.cpp \
       uninitialized_domain.cpp \

--- a/src/analyses/cfg_dominators.h
+++ b/src/analyses/cfg_dominators.h
@@ -63,6 +63,12 @@ public:
     return cfg.get_node(program_point);
   }
 
+  /// Get the graph node index for \p program_point
+  typename cfgt::entryt get_node_index(const T &program_point) const
+  {
+    return cfg.get_node_index(program_point);
+  }
+
   /// Returns true if the program point corresponding to \p rhs_node is
   /// dominated by program point \p lhs. Saves node lookup compared to the
   /// dominates overload that takes two program points, so this version is

--- a/src/analyses/sese_regions.cpp
+++ b/src/analyses/sese_regions.cpp
@@ -1,0 +1,261 @@
+/*******************************************************************\
+
+Module: Single-entry, single-exit region analysis
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+/// \file
+/// Single-entry, single-exit region analysis
+
+#include <sstream>
+
+#include "cfg_dominators.h"
+#include "natural_loops.h"
+#include "sese_regions.h"
+
+void sese_region_analysist::operator()(const goto_programt &goto_program)
+{
+  natural_loopst natural_loops;
+  natural_loops(goto_program);
+
+  // A single-entry, single-exit region is one whose entry and exit nodes
+  // are in a dominator-postdominator relationship, and which are
+  // *cycle equivalent*, which means that any cycle in the CFG that includes the
+  // entry must include the exit and vice versa.
+
+  // Because we have a natural-loop analysis but not a general cycle analysis,
+  // we conservatively approximate the latter condition by checking that there
+  // are no loops with multiple backedges (this implies there are effectively
+  // two loops being described as one), and that there are no backedges not
+  // associated with a natural loop (indicating a cycle with multiple entry
+  // edges). Those conditions being met, it suffices to check that the would-be
+  // region has its entry and exit nodes in the same natural loops; without them
+  // we conservatively decline to identify any regions.
+
+  for(auto it = goto_program.instructions.begin();
+      it != goto_program.instructions.end();
+      ++it)
+  {
+    for(auto predecessor : it->incoming_edges)
+    {
+      if(
+        predecessor->location_number > it->location_number &&
+        !natural_loops.is_loop_header(it))
+      {
+        // No loop header associated with this backedge; conservatively decline
+        // to diagnose any SESE regions.
+        return;
+      }
+    }
+  }
+
+  for(const auto &loop : natural_loops.loop_map)
+  {
+    std::size_t backedge_count = std::count_if(
+      loop.first->incoming_edges.begin(),
+      loop.first->incoming_edges.end(),
+      [&](const goto_programt::const_targett &predecessor) {
+        return loop.first->location_number < predecessor->location_number;
+      });
+    if(backedge_count > 1)
+    {
+      // Loop with multiple backedges; conservatively decline to diagnose any
+      // SESE regions.
+      return;
+    }
+  }
+
+  // All checks passed, let's find some regions!
+  compute_sese_regions(goto_program, natural_loops);
+}
+
+typedef std::
+  unordered_map<goto_programt::const_targett, std::size_t, const_target_hash>
+    innermost_loop_mapt;
+
+/// Builds a map from instructions to the smallest (and therefore innermost)
+/// loop they are a member of.
+static innermost_loop_mapt
+compute_innermost_loop_ids(const natural_loopst &natural_loops)
+{
+  innermost_loop_mapt innermost_loop_ids;
+  std::vector<std::size_t> loop_size_by_id;
+
+  std::size_t loop_id = 0;
+  for(const auto &header_and_loop : natural_loops.loop_map)
+  {
+    const auto &loop = header_and_loop.second;
+    loop_size_by_id.push_back(loop.size());
+
+    for(const auto &instruction : loop)
+    {
+      auto emplace_result = innermost_loop_ids.emplace(instruction, loop_id);
+      if(!emplace_result.second)
+      {
+        // Is the existing loop for this instruction larger than this one? If so
+        // this is the inner of the two loops.
+        if(loop_size_by_id.at(emplace_result.first->second) > loop.size())
+          emplace_result.first->second = loop_id;
+      }
+    }
+
+    ++loop_id;
+  }
+
+  return innermost_loop_ids;
+}
+
+static long get_innermost_loop(
+  const innermost_loop_mapt &innermost_loops,
+  const goto_programt::const_targett &target)
+{
+  auto findit = innermost_loops.find(target);
+  if(findit == innermost_loops.end())
+    return -1;
+  else
+    return (long)findit->second;
+}
+
+void sese_region_analysist::compute_sese_regions(
+  const goto_programt &goto_program,
+  const natural_loopst &natural_loops)
+{
+  const auto &dominators = natural_loops.get_dominator_info();
+  cfg_post_dominatorst postdominators;
+  postdominators(goto_program);
+
+  auto innermost_loop_ids = compute_innermost_loop_ids(natural_loops);
+
+  for(auto it = goto_program.instructions.begin();
+      it != goto_program.instructions.end();
+      ++it)
+  {
+    // Only look for regions starting at nontrivial CFG edges:
+
+    auto successors = goto_program.get_successors(it);
+    if(
+      successors.size() == 1 &&
+      (*successors.begin())->incoming_edges.size() == 1)
+      continue;
+
+    const auto &instruction_postdoms = postdominators.get_node(it).dominators;
+
+    // Ideally we would start with the immediate postdominator and walk down,
+    // but our current dominator analysis doesn't make it easy to determine an
+    // immediate dominator.
+
+    // Ideally I would use `optionalt<std::size_t>` here, but it triggers a
+    // GCC-5 bug.
+    std::size_t closest_exit_index = dominators.cfg.size();
+    for(const auto &possible_exit : instruction_postdoms)
+    {
+      const auto possible_exit_index = dominators.get_node_index(possible_exit);
+      const auto &possible_exit_node = dominators.cfg[possible_exit_index];
+      const auto possible_exit_dominators =
+        possible_exit_node.dominators.size();
+
+      if(
+        it != possible_exit && dominators.dominates(it, possible_exit_node) &&
+        get_innermost_loop(innermost_loop_ids, it) ==
+          get_innermost_loop(innermost_loop_ids, possible_exit))
+      {
+        // If there are several candidate region exit nodes, prefer the one with
+        // the least dominators, i.e. the closest to the region entrance.
+        if(
+          closest_exit_index == dominators.cfg.size() ||
+          dominators.cfg[closest_exit_index].dominators.size() >
+            possible_exit_dominators)
+        {
+          closest_exit_index = possible_exit_index;
+        }
+      }
+    }
+
+    if(closest_exit_index < dominators.cfg.size())
+    {
+      auto emplace_result =
+        sese_regions.emplace(it, dominators.cfg[closest_exit_index].PC);
+      INVARIANT(
+        emplace_result.second, "should only visit each region entry once");
+    }
+  }
+}
+
+static std::string trimmed_last_line(const std::string &input)
+{
+  auto rhs_trim_idx = input.size() - 1;
+  while(rhs_trim_idx > 0 && isspace(input[rhs_trim_idx]))
+    --rhs_trim_idx;
+
+  auto lhs_trim_idx = input.rfind('\n', rhs_trim_idx);
+  if(lhs_trim_idx == std::string::npos)
+    lhs_trim_idx = 0;
+
+  while(lhs_trim_idx < input.size() && isspace(input[lhs_trim_idx]))
+    ++lhs_trim_idx;
+
+  return input.substr(lhs_trim_idx, (rhs_trim_idx - lhs_trim_idx) + 1);
+}
+
+typedef std::
+  unordered_map<goto_programt::const_targett, std::size_t, const_target_hash>
+    program_relative_instruction_indicest;
+
+static std::string instruction_ordinals(
+  const goto_programt::const_targett &instruction,
+  const program_relative_instruction_indicest
+    &program_relative_instruction_indices)
+{
+  return "(" +
+         std::to_string(program_relative_instruction_indices.at(instruction)) +
+         ", " + std::to_string(instruction->location_number) + ")";
+}
+
+static std::string brief_instruction_string(
+  const goto_programt &goto_program,
+  const goto_programt::const_targett &instruction,
+  const namespacet &ns,
+  const program_relative_instruction_indicest
+    &program_relative_instruction_indices)
+{
+  std::ostringstream ostr;
+  goto_program.output_instruction(ns, "", ostr, *instruction);
+  return instruction_ordinals(
+           instruction, program_relative_instruction_indices) +
+         " " + trimmed_last_line(ostr.str());
+}
+
+void sese_region_analysist::output(
+  std::ostream &out,
+  const goto_programt &goto_program,
+  const namespacet &ns) const
+{
+  program_relative_instruction_indicest program_relative_instruction_indices;
+  std::size_t next_index = 0;
+  for(auto it = goto_program.instructions.begin();
+      it != goto_program.instructions.end();
+      ++it, ++next_index)
+  {
+    program_relative_instruction_indices.emplace(it, next_index);
+  }
+  out << "Function contains " << sese_regions.size()
+      << " single-entry, single-exit regions:\n";
+  for(const auto &entry_exit : sese_regions)
+  {
+    out << "Region starting at "
+        << brief_instruction_string(
+             goto_program,
+             entry_exit.first,
+             ns,
+             program_relative_instruction_indices)
+        << " ends at "
+        << brief_instruction_string(
+             goto_program,
+             entry_exit.second,
+             ns,
+             program_relative_instruction_indices)
+        << "\n";
+  }
+}

--- a/src/analyses/sese_regions.h
+++ b/src/analyses/sese_regions.h
@@ -1,0 +1,49 @@
+/*******************************************************************\
+
+Module: Single-entry, single-exit region analysis
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+/// \file
+/// Single-entry, single-exit region analysis
+
+#ifndef CPROVER_ANALYSES_SESE_REGIONS_H
+#define CPROVER_ANALYSES_SESE_REGIONS_H
+
+#include <analyses/cfg_dominators.h>
+#include <analyses/natural_loops.h>
+#include <util/optional.h>
+
+class sese_region_analysist
+{
+public:
+  void operator()(const goto_programt &goto_program);
+  optionalt<goto_programt::const_targett>
+  get_region_exit(goto_programt::const_targett entry) const
+  {
+    auto find_result = sese_regions.find(entry);
+    if(find_result == sese_regions.end())
+      return {};
+    else
+      return find_result->second;
+  }
+
+  void output(
+    std::ostream &out,
+    const goto_programt &goto_program,
+    const namespacet &ns) const;
+
+private:
+  std::unordered_map<
+    goto_programt::const_targett,
+    goto_programt::const_targett,
+    const_target_hash>
+    sese_regions;
+  void compute_sese_regions(
+    const goto_programt &goto_program,
+    const natural_loopst &natural_loops);
+};
+
+#endif // CPROVER_ANALYSES_SESE_REGIONS_H

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -64,6 +64,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <analyses/local_safe_pointers.h>
 #include <analyses/natural_loops.h>
 #include <analyses/reaching_definitions.h>
+#include <analyses/sese_regions.h>
 
 #include <ansi-c/ansi_c_language.h>
 #include <ansi-c/c_object_factory_parameters.h>
@@ -349,6 +350,27 @@ int goto_instrument_parse_optionst::doit()
           local_safe_pointers.output_safe_dereferences(
             std::cout, it->second.body, ns);
         }
+        std::cout << '\n';
+      }
+
+      return CPROVER_EXIT_SUCCESS;
+    }
+
+    if(cmdline.isset("show-sese-regions"))
+    {
+      // Ensure location numbering is unique:
+      goto_model.goto_functions.update();
+
+      namespacet ns(goto_model.symbol_table);
+
+      forall_goto_functions(it, goto_model.goto_functions)
+      {
+        sese_region_analysist sese_region_analysis;
+        sese_region_analysis(it->second.body);
+        std::cout << ">>>>\n";
+        std::cout << ">>>> " << it->first << '\n';
+        std::cout << ">>>>\n";
+        sese_region_analysis.output(std::cout, it->second.body, ns);
         std::cout << '\n';
       }
 

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -107,6 +107,7 @@ Author: Daniel Kroening, kroening@kroening.com
   OPT_REPLACE_FUNCTION_BODY \
   OPT_GOTO_PROGRAM_STATS \
   "(show-local-safe-pointers)(show-safe-dereferences)" \
+  "(show-sese-regions)" \
   OPT_REPLACE_CALLS \
   "(validate-goto-binary)" \
   OPT_VALIDATE \


### PR DESCRIPTION
This pass identifies regions with a single entry node and a single exit node, where those nodes exist at the same loop level. In effect these are regions that could trivially be lifted out as their own function; the intent is for goto-symex to use these to simplify its state guard, but this PR just introduces the pass and tests it.