### PR TITLE
Use type_try_dynamic_cast in particular case where it clarifies the code

### DIFF
--- a/jbmc/src/java_bytecode/java_types.cpp
+++ b/jbmc/src/java_bytecode/java_types.cpp
@@ -1072,9 +1072,8 @@ optionalt<size_t> java_generic_struct_tag_typet::generic_type_index(
   const auto &generics = generic_types();
   for(std::size_t i = 0; i < generics.size(); ++i)
   {
-    if(
-      is_java_generic_parameter(generics[i]) &&
-      to_java_generic_parameter(generics[i]).get_name() == type_variable)
+    auto param = type_try_dynamic_cast<java_generic_parametert>(generics[i]);
+    if(param && param->get_name() == type_variable)
       return i;
   }
   return {};


### PR DESCRIPTION
- [x] Each commit message has a non-empty body, explaining why the change was made.
- N/A Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- N/A The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- N/A My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- N/A White-space or formatting changes outside the feature-related changed lines are in commits of their own.
