### PR TITLE
GOTO-symex: propagate notequal conditions for boolean types [TG-9390]

### DIFF
--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -55,21 +55,12 @@ void goto_symext::apply_goto_condition(
 
   jump_taken_state.apply_condition(new_guard, current_state, ns);
 
-  // Try to find a negative condition that implies an equality constraint on
-  // the branch-not-taken path.
   // Could use not_exprt + simplify, but let's avoid paying that cost on quite
   // a hot path:
-  if(new_guard.id() == ID_not)
-    jump_not_taken_state.apply_condition(
-      to_not_expr(new_guard).op(), current_state, ns);
-  else if(new_guard.id() == ID_notequal)
-  {
-    auto &not_equal_expr = to_notequal_expr(new_guard);
-    jump_not_taken_state.apply_condition(
-      equal_exprt(not_equal_expr.lhs(), not_equal_expr.rhs()),
-      current_state,
-      ns);
-  }
+  exprt negated_new_guard = new_guard.id() ==
+    ID_not ? to_not_expr(new_guard).op() : not_exprt(new_guard);
+  jump_not_taken_state.apply_condition(
+    negated_new_guard, current_state, ns);
 }
 
 /// Try to evaluate a simple pointer comparison.


### PR DESCRIPTION
Conditional branches on "x != false", as well as "x" and "!x", can and should lead to constant
propagation just as "x == true" does now. This is particularly beneficial for the
"clinit_already_run" variables that are maintained to determine if a static initialiser should
be run or not -- the current "if(already_run != true) clinit(); already_run = true;" condition
now leaves symex certain that it has been run at the bottom of the function regardless of the
already_run flag's initial value, whereas before it could remain uncertain and so explore the
static initialiser more than is necessary.

Command line to see the benefit of this change on Tika-parsers:

`test-generator --java-max-vla-length 192 --unwind 2 --java-unwind-enum-static --trace --export-imports --java-assume-inputs-non-null --classpath ~/test-gen/lib/models-library/model/target/models.jar tika-all.jar --function 'org.apache.tika.parser.jdbc.JDBCTableReader.handleClob'`

where `tika-all.jar` is a jar containing all of the `org/apache/tika` package from all Tika modules (i.e. tika-core, tika-parsers etc).