### PR TITLE
Add KNOWBUG test for 5093

### DIFF
--- a/regression/cbmc/pointer-to-struct-with-flexible-array-member-as-parameter-to-entry-point/main.c
+++ b/regression/cbmc/pointer-to-struct-with-flexible-array-member-as-parameter-to-entry-point/main.c
@@ -1,0 +1,9 @@
+typedef struct ST
+{
+  int id;
+  int c[];
+} ST;
+
+void testFunc(ST **t)
+{
+}

--- a/regression/cbmc/pointer-to-struct-with-flexible-array-member-as-parameter-to-entry-point/test.desc
+++ b/regression/cbmc/pointer-to-struct-with-flexible-array-member-as-parameter-to-entry-point/test.desc
@@ -1,0 +1,10 @@
+KNOWNBUG
+main.c
+--function testFunc
+--
+^EXIT=0$
+^SIGNAL=0$
+--
+^EXIT=134$
+--
+Github issue #5093: Pointer to struct with flexible array member as parameter to entry point causes invariant violation


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

This PR is to add KNOWBUG for https://github.com/diffblue/cbmc/pull/5093

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
