### PR TITLE
Fix the ordering of variable initialisation in goto-harness

### DIFF
--- a/regression/snapshot-harness/dynamic-array-int-ordering/main.c
+++ b/regression/snapshot-harness/dynamic-array-int-ordering/main.c
@@ -1,0 +1,64 @@
+#include <assert.h>
+#include <malloc.h>
+
+int a;
+int *a1;
+int *iterator1;
+int *a2;
+int *a3;
+int *iterator2;
+int *a4;
+int *a5;
+int *iterator3;
+int *a6;
+int *a7;
+int *array2;
+int *a8;
+
+void initialize()
+{
+  array2 = (int *)malloc(sizeof(int) * 10);
+  array2[0] = 1;
+  array2[1] = 2;
+  array2[2] = 3;
+  array2[3] = 4;
+  array2[4] = 5;
+  array2[5] = 6;
+  array2[6] = 7;
+  array2[7] = 8;
+  array2[8] = 9;
+  array2[9] = 10;
+  iterator1 = (int *)array2;
+  iterator2 = &array2[1];
+  iterator3 = array2 + 1;
+  a1 = &a;
+  a2 = a1;
+  a3 = a2;
+  a4 = a3;
+  a5 = a4;
+  a6 = a5;
+  a7 = a6;
+  a8 = a7;
+}
+
+void checkpoint()
+{
+}
+
+int main()
+{
+  initialize();
+  checkpoint();
+
+  assert(*iterator1 == 1);
+  assert(iterator1 != iterator2);
+  assert(iterator2 == iterator3);
+  assert(iterator2 == &array2[1]);
+  assert(*iterator3 == array2[1]);
+  assert(*iterator3 == 2);
+  iterator3 = &array2[9];
+  iterator3++;
+  assert(*iterator3 == 0);
+
+  return 0;
+}

--- a/regression/snapshot-harness/dynamic-array-int-ordering/test.desc
+++ b/regression/snapshot-harness/dynamic-array-int-ordering/test.desc
@@ -1,0 +1,16 @@
+CORE
+main.c
+a,a1,iterator1,a2,a3,iterator2,a4,a5,iterator3,a6,a7,array2,a8 --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
+^EXIT=10$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion \*iterator1 == 1: SUCCESS
+\[main.assertion.2\] line [0-9]+ assertion iterator1 != iterator2: SUCCESS
+\[main.assertion.3\] line [0-9]+ assertion iterator2 == iterator3: SUCCESS
+\[main.assertion.4\] line [0-9]+ assertion iterator2 == \&array2\[1\]: SUCCESS
+\[main.assertion.5\] line [0-9]+ assertion \*iterator3 == array2\[1\]: SUCCESS
+\[main.assertion.6\] line [0-9]+ assertion \*iterator3 == 2: SUCCESS
+\[main.pointer_dereference.27\] line [0-9]+ dereference failure: pointer outside object bounds in \*iterator3: FAILURE
+\[main.assertion.7\] line [0-9]+ assertion \*iterator3 == 0: FAILURE
+VERIFICATION FAILED
+--
+unwinding assertion loop \d+: FAILURE

--- a/regression/snapshot-harness/dynamic-array-int/test.desc
+++ b/regression/snapshot-harness/dynamic-array-int/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 array,iterator1,iterator2,iterator3 --harness-type initialise-with-memory-snapshot --initial-goto-location main:4
 ^EXIT=10$

--- a/regression/snapshot-harness/pointer-to-array-function-parameters-multi-arg-right/test.desc
+++ b/regression/snapshot-harness/pointer-to-array-function-parameters-multi-arg-right/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
-first,second,string_size,prefix,prefix_size --harness-type initialise-with-memory-snapshot --initial-goto-location main:4 --havoc-variables prefix,prefix_size --size-of-array prefix:prefix_size --max-array-size 5
+first,second,string_size,prefix,prefix_size --harness-type initialise-with-memory-snapshot --initial-goto-location main:4 --havoc-variables prefix --size-of-array prefix:prefix_size --max-array-size 5
 ^SIGNAL=0$
 ^EXIT=0$
 VERIFICATION SUCCESSFUL


### PR DESCRIPTION
When using the `memory-snapshot` harness.

See https://github.com/diffblue/cbmc/issues/4978 for the problem.

Previously we were using the `refers-to` relation (`a` refers to `b` if the value `a` should be initialised with contains -- as a subexpression -- the symbol `b`) as if it was a linear ordering between the snapshot symbols. That is, we called `std::stable_sort` with this relation which is incorrect.

Now we select one linearisation of the partial order (given by `refers-to`) to be the initilisation ordering. Note that we ignore cycles, or more precisely in the presence of a cycle we start from the first visited symbol. This is correct, because for

```
struct A { A*next; };
A a1;
A a2;
a1.next = &a2;
a2.next = &a1;
```
the snapshot is

```
a1 = {.next=&a2}
a2 = {.next=&a1}
```

And the order is irrelevant. There is also a test-case which was failing before.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
