### PR TITLE
Symex: distinguish reachability from the state guard

### DIFF
--- a/jbmc/regression/jbmc/NondetEnumOpaqueReturn/test_indirect_enum_initalization.desc
+++ b/jbmc/regression/jbmc/NondetEnumOpaqueReturn/test_indirect_enum_initalization.desc
@@ -1,7 +1,6 @@
 CORE
 indirect/IndirectVirtualCall.class
 --function indirect.IndirectVirtualCall.main
-function java::indirect\.TestEnum\.<clinit>:\(\)V$
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/cbmc/unreachable-goto1/test-vccs.desc
+++ b/regression/cbmc/unreachable-goto1/test-vccs.desc
@@ -1,0 +1,12 @@
+CORE paths-lifo-expected-failure
+test.c
+--show-vcc
+^Generated 1 VCC\(s\), 1 remaining after simplification$
+^\{1\} false$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Note: disabled for paths-lifo mode, which never merges state guards
+This checks that despite being unreachable due to an assume(false), the state guard
+is returned to TRUE by the time the assertion is executed.

--- a/regression/cbmc/unreachable-goto1/test.c
+++ b/regression/cbmc/unreachable-goto1/test.c
@@ -1,0 +1,12 @@
+int main(int argc, char **argv)
+{
+  if(argc == 1)
+  {
+    do
+    {
+      __CPROVER_assume(0);
+    } while(argc < 2);
+  }
+
+  assert(0);
+}

--- a/regression/cbmc/unreachable-goto1/test.desc
+++ b/regression/cbmc/unreachable-goto1/test.desc
@@ -1,0 +1,10 @@
+CORE
+test.c
+
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+This tests that a __CPROVER_assume(0) prompts symex to assume that a conditional
+backward branch is not taken.

--- a/regression/cbmc/unreachable-goto2/test-vccs.desc
+++ b/regression/cbmc/unreachable-goto2/test-vccs.desc
@@ -1,0 +1,13 @@
+CORE paths-lifo-expected-failure
+test.c
+--show-vcc
+^Generated 1 VCC\(s\), 1 remaining after simplification$
+^\{1\} goto_symex::\\guard#1$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Note: disabled for paths-lifo mode, which never merges state guards
+This checks that the guard from a loop containing an assume(false), and with
+an unconditional backedge, is discarded as expected, resulting in a non-trivial
+guard at the assertion.

--- a/regression/cbmc/unreachable-goto2/test.c
+++ b/regression/cbmc/unreachable-goto2/test.c
@@ -1,0 +1,12 @@
+int main(int argc, char **argv)
+{
+  if(argc == 1)
+  {
+    while(argc < 2)
+    {
+      __CPROVER_assume(0);
+    }
+  }
+
+  assert(0);
+}

--- a/regression/cbmc/unreachable-goto2/test.desc
+++ b/regression/cbmc/unreachable-goto2/test.desc
@@ -1,0 +1,9 @@
+CORE
+test.c
+
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+This tests that a __CPROVER_assume(0) in an infinite loop terminates the loop

--- a/regression/cbmc/unreachable-goto3/test-vccs.desc
+++ b/regression/cbmc/unreachable-goto3/test-vccs.desc
@@ -1,0 +1,13 @@
+CORE paths-lifo-expected-failure
+test.c
+--show-vcc
+^Generated 1 VCC\(s\), 1 remaining after simplification$
+^\{1\} false$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Note: disabled for paths-lifo mode, which never merges state guards
+This checks that an assume(false) prior to a loop correctly results
+in symex stepping around that loop, resulting in the state guard
+returning to true.

--- a/regression/cbmc/unreachable-goto3/test.c
+++ b/regression/cbmc/unreachable-goto3/test.c
@@ -1,0 +1,12 @@
+int main(int argc, char **argv)
+{
+  if(argc == 1)
+  {
+    __CPROVER_assume(0);
+    while(1)
+    {
+    }
+  }
+
+  assert(0);
+}

--- a/regression/cbmc/unreachable-goto3/test.desc
+++ b/regression/cbmc/unreachable-goto3/test.desc
@@ -1,0 +1,10 @@
+CORE
+test.c
+
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+This tests that with a __CPROVER_assume(0) before an infinite loop,
+symex terminates without needing a `--unwind` setting.

--- a/regression/cbmc/unreachable-goto4/test-vccs.desc
+++ b/regression/cbmc/unreachable-goto4/test-vccs.desc
@@ -1,0 +1,13 @@
+CORE paths-lifo-expected-failure
+test.c
+--show-vcc
+^Generated 1 VCC\(s\), 1 remaining after simplification$
+^\{1\} false$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Note: disabled for paths-lifo mode, which never merges state guards
+This checks that an assume(false) prior to a do-while loop correctly results
+in symex stepping into a single iteration of that loop, and then out,
+resulting in the state guard returning to true.

--- a/regression/cbmc/unreachable-goto4/test.c
+++ b/regression/cbmc/unreachable-goto4/test.c
@@ -1,0 +1,12 @@
+int main(int argc, char **argv)
+{
+  if(argc == 1)
+  {
+    __CPROVER_assume(0);
+    do
+    {
+    } while(1);
+  }
+
+  assert(0);
+}

--- a/regression/cbmc/unreachable-goto4/test.desc
+++ b/regression/cbmc/unreachable-goto4/test.desc
@@ -1,0 +1,10 @@
+CORE
+test.c
+
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+This tests that with a __CPROVER_assume(0) before an infinite loop,
+symex terminates without needing a `--unwind` setting.

--- a/regression/cbmc/unreachable-goto5/test-vccs.desc
+++ b/regression/cbmc/unreachable-goto5/test-vccs.desc
@@ -1,0 +1,12 @@
+CORE paths-lifo-expected-failure
+test.c
+--show-vcc
+^Generated 1 VCC\(s\), 1 remaining after simplification$
+^\{1\} false$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Note: disabled for paths-lifo mode, which never merges state guards
+This checks that an assume(false) within a branch correctly results
+in symex returning the state guard to true when control flow converges.

--- a/regression/cbmc/unreachable-goto5/test.c
+++ b/regression/cbmc/unreachable-goto5/test.c
@@ -1,0 +1,12 @@
+int main(int argc, char **argv)
+{
+  if(argc == 1)
+  {
+    __CPROVER_assume(0);
+  }
+  else
+  {
+  }
+
+  assert(0);
+}

--- a/regression/cbmc/unreachable-goto5/test.desc
+++ b/regression/cbmc/unreachable-goto5/test.desc
@@ -1,0 +1,10 @@
+CORE
+test.c
+
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+This tests that with a __CPROVER_assume(0) within conditional control flow,
+symex still executes the assertion as expected.

--- a/regression/cbmc/unreachable-goto6/test-vccs.desc
+++ b/regression/cbmc/unreachable-goto6/test-vccs.desc
@@ -1,0 +1,13 @@
+CORE paths-lifo-expected-failure
+test.c
+--show-vcc
+^Generated 1 VCC\(s\), 1 remaining after simplification$
+^\{1\} false$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Note: disabled for paths-lifo mode, which never merges state guards
+This checks that an assume(false) prior to a branch correctly results
+in symex picking some arbitrary path through the unreachable CFG, and so
+it returns the state guard to true when control flow converges.

--- a/regression/cbmc/unreachable-goto6/test.c
+++ b/regression/cbmc/unreachable-goto6/test.c
@@ -1,0 +1,18 @@
+int main(int argc, char **argv)
+{
+  if(argc > 1)
+  {
+    __CPROVER_assume(0);
+
+    if(argc == 2)
+    {
+      ++argc;
+    }
+    else
+    {
+      --argc;
+    }
+  }
+
+  assert(0);
+}

--- a/regression/cbmc/unreachable-goto6/test.desc
+++ b/regression/cbmc/unreachable-goto6/test.desc
@@ -1,0 +1,10 @@
+CORE
+test.c
+
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+This tests that with a __CPROVER_assume(0) prior to conditional control flow,
+symex executes the final assertion as expected.

--- a/src/analyses/guard_bdd.h
+++ b/src/analyses/guard_bdd.h
@@ -65,6 +65,13 @@ public:
     return guard_bddt(manager, bdd.bdd_not());
   }
 
+  /// Returns true if `operator|=` with \p other_guard may result in a simpler
+  /// expression. For `bdd_exprt` we always simplify maximally.
+  bool disjunction_may_simplify(const guard_bddt &other_guard)
+  {
+    return true;
+  }
+
 private:
   bdd_exprt &manager;
   bddt bdd;

--- a/src/analyses/guard_expr.cpp
+++ b/src/analyses/guard_expr.cpp
@@ -13,7 +13,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <ostream>
 
-#include <util/expr_util.h>
 #include <util/invariant.h>
 #include <util/simplify_utils.h>
 #include <util/std_expr.h>
@@ -89,6 +88,17 @@ guard_exprt &operator-=(guard_exprt &g1, const guard_exprt &g2)
   g1.expr = conjunction(op1);
 
   return g1;
+}
+
+bool guard_exprt::disjunction_may_simplify(const guard_exprt &other_guard)
+{
+  if(is_true() || is_false() || other_guard.is_true() || other_guard.is_false())
+    return true;
+  if(expr.id() == ID_and && other_guard.expr.id() == ID_and)
+    return true;
+  if(other_guard.expr == boolean_negate(expr))
+    return true;
+  return false;
 }
 
 guard_exprt &operator|=(guard_exprt &g1, const guard_exprt &g2)

--- a/src/analyses/guard_expr.h
+++ b/src/analyses/guard_expr.h
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <iosfwd>
 
+#include <util/expr_util.h>
 #include <util/std_expr.h>
 
 /// This is unused by this implementation of guards, but can be used by other
@@ -71,6 +72,11 @@ public:
 
   friend guard_exprt &operator-=(guard_exprt &g1, const guard_exprt &g2);
   friend guard_exprt &operator|=(guard_exprt &g1, const guard_exprt &g2);
+
+  /// Returns true if `operator|=` with \p other_guard may result in a simpler
+  /// expression. For `guard_exprt` in practice this means they're both
+  /// conjunctions, since for other things we just OR them together.
+  bool disjunction_may_simplify(const guard_exprt &other_guard);
 
 private:
   exprt expr;

--- a/src/goto-symex/goto_state.h
+++ b/src/goto-symex/goto_state.h
@@ -49,6 +49,10 @@ public:
   // of the condition of the if).
   guardt guard;
 
+  /// Is this code reachable? If not we can take shortcuts such as not entering
+  /// function calls, but we still conduct guard arithmetic as usual.
+  bool reachable;
+
   // Map L1 names to (L2) constants. Values will be evicted from this map
   // when they become non-constant. This is used to propagate values that have
   // been worked out to only have one possible value.
@@ -73,7 +77,7 @@ public:
   explicit goto_statet(const class goto_symex_statet &s);
 
   explicit goto_statet(guard_managert &guard_manager)
-    : guard(true_exprt(), guard_manager)
+    : guard(true_exprt(), guard_manager), reachable(true)
   {
   }
 

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -332,6 +332,9 @@ protected:
   /// Symbolically execute a GOTO instruction
   /// \param state: Symbolic execution state for current instruction
   virtual void symex_goto(statet &state);
+  /// Symbolically execute a GOTO instruction in the context of unreachable code
+  /// \param state: Symbolic execution state for current instruction
+  void symex_unreachable_goto(statet &state);
   /// Symbolically execute a START_THREAD instruction
   /// \param state: Symbolic execution state for current instruction
   virtual void symex_start_thread(statet &state);

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -277,6 +277,7 @@ inline goto_statet::goto_statet(const class goto_symex_statet &s)
     level2(s.level2),
     value_set(s.value_set),
     guard(s.guard),
+    reachable(s.reachable),
     propagation(s.propagation),
     atomic_section_id(s.atomic_section_id)
 {

--- a/src/goto-symex/symex_atomic_section.cpp
+++ b/src/goto-symex/symex_atomic_section.cpp
@@ -15,7 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 void goto_symext::symex_atomic_begin(statet &state)
 {
-  if(state.guard.is_false())
+  if(!state.reachable)
     return;
 
   if(state.atomic_section_id != 0)
@@ -35,7 +35,7 @@ void goto_symext::symex_atomic_begin(statet &state)
 
 void goto_symext::symex_atomic_end(statet &state)
 {
-  if(state.guard.is_false())
+  if(!state.reachable)
     return;
 
   if(state.atomic_section_id == 0)

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -19,7 +19,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 void goto_symext::symex_start_thread(statet &state)
 {
-  if(state.guard.is_false())
+  if(!state.reachable)
     return;
 
   if(state.atomic_section_id != 0)

--- a/unit/path_strategies.cpp
+++ b/unit/path_strategies.cpp
@@ -202,10 +202,9 @@ SCENARIO("path strategies")
         symex_eventt::resume(symex_eventt::enumt::JUMP, 9),
         symex_eventt::result(symex_eventt::enumt::FAILURE),
 
-        // The path where we enter the loop body twice. Successful because
-        // infeasible.
+        // The path where we enter the loop body twice. No result because
+        // this path hits an unwind bound.
         symex_eventt::resume(symex_eventt::enumt::NEXT, 7),
-        symex_eventt::result(symex_eventt::enumt::SUCCESS),
 
         // Overall we fail.
         symex_eventt::result(symex_eventt::enumt::FAILURE),
@@ -235,9 +234,8 @@ SCENARIO("path strategies")
         symex_eventt::result(symex_eventt::enumt::SUCCESS),
 
         // Pop line 7 that we saved from above, and execute the loop a second
-        // time. Successful, since this path is infeasible.
+        // time. No result, since this path exceeds an unwind bound
         symex_eventt::resume(symex_eventt::enumt::NEXT, 7),
-        symex_eventt::result(symex_eventt::enumt::SUCCESS),
 
         // Pop line 7 that we saved from above and bail out. That corresponds to
         // executing the loop once, decrementing x to 0; assert(x) should fail.


### PR DESCRIPTION
Previously the state guard being false was taken to indicate unreachable code,
and different causes of unreachability were handled inconsistently:

* ASSUME false implied unreachability but had no effect on the guard
* --unwind or --depth being exceeded usually meant setting the guard false

This meant that expensive code downstream of an ASSUME false *was* executed, but the state
guard was maintained as usual including shrinking the guard when branches converge, while
--unwind or --depth limit breaks led to code *not* being executed (vital for these options
to function properly) but the state guard grew ever larger because the part that had gone
missing (been set to false) never got merged back in.

This commit distinguishes the two concepts: the "reachable" flag is set false whenever a
limit break OR and ASSUME false happens, but state guard maintenance continues as normal.
A new symex_unreachable_goto tries to find some way through the CFG back to reachable code;
when it can't due to loops *then* it sets the state guard to false, signifying our not
being able to figure out where the guard ought to be merged back in.

This means that ASSUME false instructions now correctly truncate execution and are
recognised as unreachable code for the purposes of state merging (leading to better
constant propagation downstream), but in some cases we may see more guard growth
because code downstream of an ASSUME false is executed less rigorously that before,
which could result in the guard not being merged or being merged later than it otherwise
would have been.

Depth and unwind limit breaks behave roughly as before, except that there is some chance
the state guard will be merged rather than discarded, reducing costs downstream.