### PR TITLE
Symex: use single-entry, single-exit region analysis to simplify state guards

### DIFF
--- a/src/goto-symex/frame.h
+++ b/src/goto-symex/frame.h
@@ -48,6 +48,9 @@ struct framet
 
   std::unordered_map<irep_idt, loop_infot> loop_iterations;
 
+  std::unordered_map<goto_programt::const_targett, guardt, const_target_hash>
+    instruction_guards;
+
   framet(symex_targett::sourcet _calling_location, const guardt &state_guard)
     : calling_location(std::move(_calling_location)),
       guard_at_function_start(state_guard)

--- a/src/goto-symex/path_storage.h
+++ b/src/goto-symex/path_storage.h
@@ -12,6 +12,7 @@
 
 #include <analyses/dirty.h>
 #include <analyses/local_safe_pointers.h>
+#include <analyses/sese_regions.h>
 
 #include <memory>
 
@@ -114,6 +115,8 @@ public:
   /// Local variables are considered 'dirty' if they've had an address taken and
   /// therefore may be referred to by a pointer.
   incremental_dirtyt dirty;
+
+  std::unordered_map<irep_idt, sese_region_analysist> sese_region_analysis;
 
 private:
   // Derived classes should override these methods, allowing the base class to

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -241,6 +241,11 @@ void goto_symext::symex_function_call_code(
   if(emplace_safe_pointers_result.second)
     emplace_safe_pointers_result.first->second(goto_function.body);
 
+  auto emplace_sese_regions_result =
+    path_storage.sese_region_analysis.emplace(identifier, sese_region_analysist{});
+  if(emplace_sese_regions_result.second)
+    emplace_sese_regions_result.first->second(goto_function.body);
+
   const bool stop_recursing = get_unwind_recursion(
     identifier,
     state.source.thread_nr,


### PR DESCRIPTION
By saving the state guard on entry to an SESE region and the restoring it on exit,
we prevent the guard from growing out of control due to paths being truncated for
breaking unwind or depth limits.