### PR TITLE
Add `lazy` function with auto inferred type

### DIFF
--- a/src/util/lazy.h
+++ b/src/util/lazy.h
@@ -43,4 +43,12 @@ private:
   }
 };
 
+/// Delay the computation of \p fun to the next time the \c force method
+/// is called.
+template <typename funt>
+auto lazy(funt fun) -> lazyt<decltype(fun())>
+{
+  return lazyt<decltype(fun())>::from_fun(std::move(fun));
+}
+
 #endif // CPROVER_UTIL_LAZY_H

--- a/unit/util/lazy.cpp
+++ b/unit/util/lazy.cpp
@@ -9,7 +9,7 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #include <testing-utils/use_catch.h>
 #include <util/lazy.h>
 
-SCENARIO("lazy test", "[core][util][lazy]")
+SCENARIO("lazyt::from_fun test", "[core][util][lazy]")
 {
   std::size_t call_counter = 0;
   auto length_with_counter = [&call_counter](const std::string &s) {
@@ -26,4 +26,23 @@ SCENARIO("lazy test", "[core][util][lazy]")
   result = lazy_length.force();
   REQUIRE(call_counter == 1);
   REQUIRE(result == 3);
+}
+
+SCENARIO("lazy test", "[core][util][lazy]")
+{
+  std::size_t call_counter = 0;
+  auto length_with_counter = [&call_counter](const std::string &s) {
+    ++call_counter;
+    return s.length();
+  };
+  lazyt<std::size_t> lazy_length =
+    lazy([&] { return length_with_counter("foobar"); });
+
+  REQUIRE(call_counter == 0);
+  auto result = lazy_length.force();
+  REQUIRE(call_counter == 1);
+  REQUIRE(result == 6);
+  result = lazy_length.force();
+  REQUIRE(call_counter == 1);
+  REQUIRE(result == 6);
 }


### PR DESCRIPTION
This allow to write `lazy(f)` and get the type of the object
automatically inferred from the type of `f`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [na] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
