### PR TITLE
Cleanups before splitting java_bytecode_parsert

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_parser.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_parser.cpp
@@ -680,8 +680,7 @@ void java_bytecode_parsert::rconstant_pool()
     case CONSTANT_Long:
     case CONSTANT_Double:
       it->number = read<u8>();
-      // Eight-byte constants take up two entries
-      // in the constant_pool table, for annoying this programmer.
+      // Eight-byte constants take up two entries in the constant_pool table.
       if(it==constant_pool.end())
       {
         error() << "invalid double entry" << eom;
@@ -698,7 +697,7 @@ void java_bytecode_parsert::rconstant_pool()
         s.resize(bytes);
         for(auto &ch : s)
           ch = read<u1>();
-        it->s=s; // hashes
+        it->s = s; // Add to string table
       }
       break;
 

--- a/jbmc/unit/java_bytecode/java_trace_validation/java_trace_validation.cpp
+++ b/jbmc/unit/java_bytecode/java_trace_validation/java_trace_validation.cpp
@@ -71,7 +71,7 @@ TEST_CASE("java trace validation", "[core][java_trace_validation]")
   {
     const exprt inner_symbol = exprt(exprt(valid_symbol_expr));
     const exprt inner_nonsymbol = exprt(exprt(exprt()));
-    INFO("expression does not have an inner symbol")
+    INFO("expression has an inner symbol")
     REQUIRE(get_inner_symbol_expr(inner_symbol).has_value());
     INFO("expression does not have an inner symbol")
     REQUIRE_FALSE(get_inner_symbol_expr(inner_nonsymbol).has_value());

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -1565,8 +1565,13 @@ public:
 template <>
 inline bool can_cast_type<reference_typet>(const typet &type)
 {
-  return can_cast_type<pointer_typet>(type) && type.get_bool(ID_C_reference) &&
-         !type.get(ID_width).empty();
+  return can_cast_type<pointer_typet>(type) && type.get_bool(ID_C_reference);
+}
+
+inline void validate_type(const reference_typet &type)
+{
+  DATA_INVARIANT(!type.get(ID_width).empty(), "reference must have width");
+  DATA_INVARIANT(type.get_width() > 0, "reference must have non-zero width");
 }
 
 /// \brief Cast a typet to a \ref reference_typet


### PR DESCRIPTION
Non-behavioural changes in preparation for major refactoring of `java_bytecode_parsert` into separate load and parse stages.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- N/A Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- N/A The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- N/A Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- N/A My commit message includes data points confirming performance improvements (if claimed).
- N/A My PR is restricted to a single feature or bugfix.
- N/A White-space or formatting changes outside the feature-related changed lines are in commits of their own.