### PR TITLE
Minor java loading changes to support alternative loading strategies

### DIFF
--- a/jbmc/src/java_bytecode/ci_lazy_methods_needed.h
+++ b/jbmc/src/java_bytecode/ci_lazy_methods_needed.h
@@ -27,7 +27,7 @@ public:
   ci_lazy_methods_neededt(
     std::unordered_set<irep_idt> &_callable_methods,
     std::unordered_set<irep_idt> &_instantiated_classes,
-    symbol_tablet &_symbol_table,
+    const symbol_tablet &_symbol_table,
     const select_pointer_typet &pointer_type_selector)
     : callable_methods(_callable_methods),
       instantiated_classes(_instantiated_classes),
@@ -52,7 +52,7 @@ private:
   // found so far, so we can use a membership test to avoid
   // repeatedly exploring a class hierarchy.
   std::unordered_set<irep_idt> &instantiated_classes;
-  symbol_tablet &symbol_table;
+  const symbol_tablet &symbol_table;
 
   const select_pointer_typet &pointer_type_selector;
 


### PR DESCRIPTION
These minor changes to loading interfaces in a couple of places support the use of alternative loading strategies in downstream repositories.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
