### PR TITLE
Protect exprt::opX()

### DIFF
--- a/src/assembler/remove_asm.cpp
+++ b/src/assembler/remove_asm.cpp
@@ -85,8 +85,8 @@ void remove_asmt::gcc_asm_function_call(
   {
     if(it->operands().size() == 2)
     {
-      arguments.push_back(
-        typecast_exprt(address_of_exprt(it->op1()), void_pointer));
+      arguments.push_back(typecast_exprt(
+        address_of_exprt(to_binary_expr(*it).op1()), void_pointer));
     }
   }
 
@@ -95,8 +95,8 @@ void remove_asmt::gcc_asm_function_call(
   {
     if(it->operands().size() == 2)
     {
-      arguments.push_back(
-        typecast_exprt(address_of_exprt(it->op1()), void_pointer));
+      arguments.push_back(typecast_exprt(
+        address_of_exprt(to_binary_expr(*it).op1()), void_pointer));
     }
   }
 

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -201,7 +201,14 @@ void linkingt::detailed_conflict_report_rec(
                 e.id()==ID_index)
           {
             parent_types.insert(e.type());
-            e=e.op0();
+            if(e.id() == ID_dereference)
+              e = to_dereference_expr(e).pointer();
+            else if(e.id() == ID_member)
+              e = to_member_expr(e).compound();
+            else if(e.id() == ID_index)
+              e = to_index_expr(e).array();
+            else
+              UNREACHABLE;
           }
 
           conflict_path=conflict_path_before;

--- a/src/statement-list/statement_list_parser.cpp
+++ b/src/statement-list/statement_list_parser.cpp
@@ -260,7 +260,7 @@ static void find_instructions(
   for(const exprt &instruction_expr : instructions.operands())
   {
     statement_list_parse_treet::instructiont instruction;
-    codet code_token(instruction_expr.op0().id());
+    codet code_token(to_multi_ary_expr(instruction_expr).op0().id());
     for(const exprt &operand : instruction_expr.operands())
     {
       if(operand.is_not_nil() && operand.id() != code_token.get_statement())

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -98,6 +98,7 @@ public:
   const operandst &operands() const
   { return (const operandst &)get_sub(); }
 
+protected:
   exprt &op0()
   { return operands().front(); }
 
@@ -122,6 +123,7 @@ public:
   const exprt &op3() const
   { return operands()[3]; }
 
+public:
   void reserve_operands(operandst::size_type n)
   { operands().reserve(n) ; }
 


### PR DESCRIPTION
This is a big change.

The key point is to prevent direct access to `exprt::opX()` -- the expectation is that the relevant specializations are used, which continue to offer these methods.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
