### PR TITLE
Add runtime-check replacing instrumentation pass

### DIFF
--- a/regression/goto-instrument/ada-checks/main.c
+++ b/regression/goto-instrument/ada-checks/main.c
@@ -1,0 +1,10 @@
+void __CPROVER_Ada_Overflow_Check(int condition)
+{
+}
+
+int main()
+{
+  int i = 0;
+  __CPROVER_Ada_Overflow_Check(i > 5);
+  return 0;
+}

--- a/regression/goto-instrument/ada-checks/test.desc
+++ b/regression/goto-instrument/ada-checks/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--replace-runtime-checks assert-then-assume-first-arg --runtime-checks-language Ada
+^EXIT=10$
+^SIGNAL=0$
+^\[main.\d+\] line \d+ Ada Overflow check i > 5: FAILURE$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-instrument/ada-checks2/main.c
+++ b/regression/goto-instrument/ada-checks2/main.c
@@ -1,0 +1,10 @@
+void __CPROVER_Ada_Overflow_Check(int condition)
+{
+}
+
+int main()
+{
+  int i = 0;
+  __CPROVER_Ada_Overflow_Check(i > 5);
+  return 0;
+}

--- a/regression/goto-instrument/ada-checks2/test.desc
+++ b/regression/goto-instrument/ada-checks2/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--generate-function-body __CPROVER_Ada_Overflow_Check --generate-function-body-options assert-then-assume-first-arg
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-instrument/generate-function-body/main.c
+++ b/regression/goto-instrument/generate-function-body/main.c
@@ -1,6 +1,6 @@
 #include <assert.h>
 
-void should_not_be_replaced(void)
+void __should_not_be_replaced(void)
 {
   __CPROVER_assume(0);
 }
@@ -13,7 +13,7 @@ int main(void)
   int does_not_get_reached = 0;
   if(flag)
   {
-    should_not_be_replaced();
+    __should_not_be_replaced();
     assert(does_not_get_reached);
   }
   should_be_generated();

--- a/src/goto-instrument/Makefile
+++ b/src/goto-instrument/Makefile
@@ -54,6 +54,7 @@ SRC = accelerate/accelerate.cpp \
       points_to.cpp \
       race_check.cpp \
       reachability_slicer.cpp \
+      replace_runtime_checks.cpp \
       remove_function.cpp \
       rw_set.cpp \
       show_locations.cpp \

--- a/src/goto-instrument/generate_function_bodies.cpp
+++ b/src/goto-instrument/generate_function_bodies.cpp
@@ -12,6 +12,7 @@ Author: Diffblue Ltd.
 #include <ansi-c/c_object_factory_parameters.h>
 
 #include <goto-programs/goto_convert.h>
+#include <goto-programs/goto_inline.h>
 #include <goto-programs/remove_skip.h>
 
 #include <util/arith_tools.h>
@@ -566,6 +567,15 @@ void generate_function_bodies(
       did_generate_body = true;
       generate_function_body.generate_function_body(
         function.second, model.symbol_table, function.first);
+    }
+  }
+
+  for(auto &function : model.goto_functions.function_map)
+  {
+    if(std::regex_match(id2string(function.first), functions_regex))
+    {
+      goto_function_inline_calls(
+        model, function.first, message_handler, false, false);
     }
   }
   if(!did_generate_body)

--- a/src/goto-instrument/generate_function_bodies.h
+++ b/src/goto-instrument/generate_function_bodies.h
@@ -83,7 +83,9 @@ void generate_function_bodies(
   "                              One of assert-false, assume-false,\n" \
   /* NOLINTNEXTLINE(whitespace/line_length) */ \
   "                              nondet-return, assert-false-assume-false and\n" \
-  "                              havoc[,params:<regex>][,globals:<regex>]\n" \
+  "                              havoc[,params:<regex>][,globals:<regex>],\n" \
+  "                              assert-first-arg, assume-first-arg,\n" \
+  "                              assert-then-assume-first-arg\n" \
   "                              (default: nondet-return)"
 // clang-format on
 

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -100,6 +100,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "race_check.h"
 #include "reachability_slicer.h"
 #include "remove_function.h"
+#include "replace_runtime_checks.h"
 #include "rw_set.h"
 #include "show_locations.h"
 #include "skip_loops.h"
@@ -1459,6 +1460,17 @@ void goto_instrument_parse_optionst::instrument_goto_program()
     havoc_loops(goto_model);
   }
 
+  if(cmdline.isset("replace-runtime-checks"))
+  {
+    std::string replace_option = cmdline.get_value("replace-runtime-checks");
+    log.status() << "Replacing runtime checks" << messaget::eom;
+    if(!cmdline.isset("runtime-checks-language"))
+      throw invalid_command_line_argument_exceptiont{
+        "unspecified language for runtime checks", "--runtime-checks-language"};
+    std::string language_id = cmdline.get_value("runtime-checks-language");
+    replace_runtime_checks(goto_model, replace_option, language_id);
+  }
+
   if(cmdline.isset("k-induction"))
   {
     bool base_case=cmdline.isset("base-case");
@@ -1782,6 +1794,16 @@ void goto_instrument_parse_optionst::help()
     " --xml-ui                     use XML-formatted output\n"
     " --json-ui                    use JSON-formatted output\n"
     HELP_TIMESTAMP
+    " --replace-runtime-checks <rplc-option>\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    "                              replace runtime checks with assume/assert/both\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    "                              <rplc-option> should be \'assert-first-arg\'\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    "                              \'assert-first-arg\' or \'assert-then-assume-first-arg\'\n"
+    " --runtime-checks-language <lang>\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    "                              language identification for the runtime checks\n"
     "\n";
   // clang-format on
 }

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -113,6 +113,7 @@ Author: Daniel Kroening, kroening@kroening.com
   OPT_VALIDATE \
   OPT_ANSI_C_LANGUAGE \
   "(ensure-one-backedge-per-target)" \
+  "(replace-runtime-checks):(runtime-checks-language):" \
   // empty last line
 
 // clang-format on

--- a/src/goto-instrument/replace_runtime_checks.cpp
+++ b/src/goto-instrument/replace_runtime_checks.cpp
@@ -1,0 +1,209 @@
+/*******************************************************************\
+
+Module: Replace Runtime Checks
+
+Author: diffblue
+
+\*******************************************************************/
+
+/// \file
+/// Replace Runtime Checks
+
+#include <util/cprover_prefix.h>
+#include <util/prefix.h>
+#include <util/string_constant.h>
+
+#include <langapi/language.h>
+#include <langapi/mode.h>
+
+#include "replace_runtime_checks.h"
+
+/// A simple pass that replace each call to a function with name:
+/// __CPROVER_X_`check-name` with a user-specified sequence of instructions. The
+/// language X can also by specified by the user via
+/// `--runtime-checks-language`. The function is expected to take one argument
+/// (the condition to be checked) and this condition is either asserted or
+/// assumed (or both). The `check-name` is then included in the assertion
+/// description (via source-location).
+struct runtime_checks_replacert
+{
+public:
+  explicit runtime_checks_replacert(
+    goto_modelt &goto_model,
+    const namespacet &ns,
+    const std::string &language_id)
+    : goto_model(goto_model),
+      ns(ns),
+      language_id(language_id),
+      common_prefix(std::string{CPROVER_PREFIX} + language_id)
+  {
+  }
+
+  void replace_with(const std::string &replace_option);
+
+private:
+  goto_modelt &goto_model;
+  const namespacet &ns;
+  const std::string language_id;
+  const std::string common_prefix;
+  irep_idt mode;
+
+  enum class replace_typet
+  {
+    assert_only,
+    assume_only,
+    assert_then_assume
+  };
+
+  enum class runtime_check_typet
+  {
+    overflow,
+    range,
+    division_by_zero
+  };
+
+  void replace_by_option(
+    const exprt &condition,
+    goto_programt &goto_program,
+    goto_programt::targett instruction,
+    const std::string &function_name,
+    const std::string &replace_option);
+
+  runtime_check_typet get_check_type(const std::string &function_name) const
+  {
+    if(function_name == common_prefix + "_Overflow_Check")
+      return runtime_check_typet::overflow;
+    if(function_name == common_prefix + "_Range_Check")
+      return runtime_check_typet::range;
+    if(function_name == common_prefix + "_Division_Check")
+      return runtime_check_typet::division_by_zero;
+    throw invalid_source_file_exceptiont{"unsupported " + language_id +
+                                         " check: " + function_name};
+  }
+
+  replace_typet get_replace_type(const std::string &replace_option) const
+  {
+    if(replace_option == "assert-first-arg")
+      return replace_typet::assert_only;
+    if(replace_option == "assume-first-arg")
+      return replace_typet::assume_only;
+    if(replace_option == "assert-then-assume-first-arg")
+      return replace_typet::assert_then_assume;
+    throw invalid_command_line_argument_exceptiont{
+      "unknown " + language_id + " check replacement option" + replace_option,
+      "--replace-runtime-checks"};
+  }
+
+  friend std::string to_string(runtime_check_typet type)
+  {
+    switch(type)
+    {
+    case runtime_check_typet::overflow:
+      return "Overflow";
+    case runtime_check_typet::range:
+      return "Range";
+    case runtime_check_typet::division_by_zero:
+      return "Division by zero";
+    }
+    UNREACHABLE;
+  }
+};
+
+void runtime_checks_replacert::replace_with(const std::string &replace_option)
+{
+  auto &goto_functions = goto_model.goto_functions;
+  for(auto &goto_function_pair : goto_functions.function_map)
+  {
+    goto_programt &function_body = goto_function_pair.second.body;
+    for(goto_programt::targett instruction = function_body.instructions.begin();
+        instruction != function_body.instructions.end();
+        ++instruction)
+    {
+      if(instruction->is_function_call())
+      {
+        const auto &function_call = instruction->get_function_call();
+        const auto &function = function_call.function();
+
+        const auto &function_name =
+          id2string(to_symbol_expr(function).get_identifier());
+        const auto &function_symbol = ns.lookup(function_name);
+        mode = function_symbol.mode;
+        if(has_prefix(function_name, common_prefix))
+        {
+          const auto &function_arguments = function_call.arguments();
+          CHECK_RETURN(!function_arguments.empty());
+
+          replace_by_option(
+            *function_arguments.begin(),
+            function_body,
+            instruction,
+            function_name,
+            replace_option);
+        }
+      }
+    }
+  }
+}
+
+void runtime_checks_replacert::replace_by_option(
+  const exprt &condition,
+  goto_programt &goto_program,
+  goto_programt::targett instruction,
+  const std::string &function_name,
+  const std::string &replace_option)
+{
+  exprt boolean_condition = condition;
+  while(boolean_condition.id() == ID_typecast)
+    boolean_condition = to_typecast_expr(boolean_condition).op();
+  CHECK_RETURN(boolean_condition.type().id() == ID_bool);
+
+  source_locationt commented_source_location = instruction->source_location;
+  std::string source_expr_string;
+  get_language_from_mode(mode)->from_expr(
+    boolean_condition, source_expr_string, ns);
+  commented_source_location.set_comment(
+    language_id + " " + to_string(get_check_type(function_name)) + " check " +
+    source_expr_string);
+
+  switch(get_replace_type(replace_option))
+  {
+  case replace_typet::assert_then_assume:
+  {
+    auto after_assert = goto_program.insert_after(
+      instruction,
+      goto_programt::make_assertion(
+        boolean_condition, commented_source_location));
+    goto_program.insert_after(
+      after_assert,
+      goto_programt::make_assumption(
+        boolean_condition, commented_source_location));
+    break;
+  }
+  case replace_typet::assert_only:
+    goto_program.insert_after(
+      instruction,
+      goto_programt::make_assertion(
+        boolean_condition, commented_source_location));
+    break;
+  case replace_typet::assume_only:
+    goto_program.insert_after(
+      instruction,
+      goto_programt::make_assumption(
+        boolean_condition, commented_source_location));
+    break;
+  }
+
+  auto skip_instruction = goto_programt::make_skip();
+  instruction->swap(skip_instruction);
+}
+
+void replace_runtime_checks(
+  goto_modelt &goto_model,
+  const std::string &replace_option,
+  const std::string &language_id)
+{
+  const namespacet ns{goto_model.symbol_table};
+  runtime_checks_replacert runtime_checks{goto_model, ns, language_id};
+  runtime_checks.replace_with(replace_option);
+  goto_model.goto_functions.update();
+}

--- a/src/goto-instrument/replace_runtime_checks.h
+++ b/src/goto-instrument/replace_runtime_checks.h
@@ -1,0 +1,24 @@
+/*******************************************************************\
+
+Module: Replace Runtime Checks
+
+Author: diffblue
+
+\*******************************************************************/
+
+/// \file
+/// Replace Runtime Checks
+
+#ifndef CPROVER_GOTO_INSTRUMENT_REPLACE_RUNTIME_CHECKS_H
+#define CPROVER_GOTO_INSTRUMENT_REPLACE_RUNTIME_CHECKS_H
+
+#include <goto-programs/goto_model.h>
+
+class goto_modelt;
+
+void replace_runtime_checks(
+  goto_modelt &,
+  const std::string &replace_option,
+  const std::string &language_id);
+
+#endif // CPROVER_GOTO_INSTRUMENT_REPLACE_RUNTIME_CHECKS_H

--- a/src/goto-programs/goto_inline.h
+++ b/src/goto-programs/goto_inline.h
@@ -56,6 +56,13 @@ void goto_function_inline(
   bool adjust_function=false,
   bool caching=true);
 
+void goto_function_inline_calls(
+  goto_modelt &goto_model,
+  const irep_idt function,
+  message_handlert &message_handler,
+  bool adjust_function = false,
+  bool caching = true);
+
 void goto_function_inline(
   goto_functionst &goto_functions,
   const irep_idt function,
@@ -63,6 +70,14 @@ void goto_function_inline(
   message_handlert &message_handler,
   bool adjust_function=false,
   bool caching=true);
+
+void goto_function_inline_calls(
+  goto_functionst &goto_functions,
+  const irep_idt function,
+  const namespacet &ns,
+  message_handlert &message_handler,
+  bool adjust_function = false,
+  bool caching = true);
 
 jsont goto_function_inline_and_log(
   goto_modelt &,


### PR DESCRIPTION
replacing calls to `__CPROVER_X_check-name` checks with a user-specified
combination of assume/assert (for a user-defined language X).

For example Ada checks can be generated with `gnat2goto`, and this pass allows
us to have more fine-grained and option-able workflow when verifying them. Also this allows us to customise how `check-name` is reported to the user via the assertion description.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
