### PR TITLE
Remove unneeded class hierarchy from resolve_inherited_componentt

### DIFF
--- a/jbmc/src/java_bytecode/ci_lazy_methods.cpp
+++ b/jbmc/src/java_bytecode/ci_lazy_methods.cpp
@@ -547,7 +547,7 @@ irep_idt ci_lazy_methodst::get_virtual_method_target(
   if(!instantiated_classes.count(classname))
     return irep_idt();
 
-  resolve_inherited_componentt call_resolver(symbol_table, class_hierarchy);
+  resolve_inherited_componentt call_resolver{symbol_table};
   const auto resolved_call = call_resolver(classname, call_basename, false);
 
   if(resolved_call)

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -3209,8 +3209,8 @@ bool java_bytecode_convert_methodt::is_method_inherited(
   const irep_idt &classname,
   const irep_idt &methodid) const
 {
-  const auto inherited_method = get_inherited_component(
-    classname, methodid, symbol_table, class_hierarchy, false);
+  const auto inherited_method =
+    get_inherited_component(classname, methodid, symbol_table, false);
   return inherited_method.has_value();
 }
 
@@ -3224,7 +3224,7 @@ irep_idt java_bytecode_convert_methodt::get_static_field(
   const irep_idt &component_name) const
 {
   const auto inherited_method = get_inherited_component(
-    class_identifier, component_name, symbol_table, class_hierarchy, true);
+    class_identifier, component_name, symbol_table, true);
 
   INVARIANT(
     inherited_method.has_value(), "static field should be in symbol table");

--- a/jbmc/src/java_bytecode/java_bytecode_language.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_language.cpp
@@ -672,8 +672,8 @@ static void create_stub_global_symbols(
 
         // The final 'true' parameter here includes interfaces, as they can
         // define static fields.
-        const auto referred_component = get_inherited_component(
-          class_id, component, symbol_table, class_hierarchy, true);
+        const auto referred_component =
+          get_inherited_component(class_id, component, symbol_table, true);
         if(!referred_component)
         {
           // Create a new stub global on an arbitrary incomplete ancestor of the

--- a/jbmc/src/java_bytecode/java_utils.cpp
+++ b/jbmc/src/java_bytecode/java_utils.cpp
@@ -371,7 +371,6 @@ std::string pretty_print_java_type(const std::string &fqn_java_type)
 /// \param component_name: component basename to search for. If searching for
 ///   A.b, this is "b".
 /// \param symbol_table: global symbol table.
-/// \param class_hierarchy: global class hierarchy.
 /// \param include_interfaces: if true, search for the given component in all
 ///   ancestors including interfaces, rather than just parents.
 /// \return the concrete component referred to if any is found, or an invalid
@@ -381,11 +380,9 @@ get_inherited_component(
   const irep_idt &component_class_id,
   const irep_idt &component_name,
   const symbol_tablet &symbol_table,
-  const class_hierarchyt &class_hierarchy,
   bool include_interfaces)
 {
-  resolve_inherited_componentt component_resolver(
-    symbol_table, class_hierarchy);
+  resolve_inherited_componentt component_resolver{symbol_table};
   const auto resolved_component =
     component_resolver(component_class_id, component_name, include_interfaces);
 

--- a/jbmc/src/java_bytecode/java_utils.h
+++ b/jbmc/src/java_bytecode/java_utils.h
@@ -122,7 +122,6 @@ get_inherited_component(
   const irep_idt &component_class_id,
   const irep_idt &component_name,
   const symbol_tablet &symbol_table,
-  const class_hierarchyt &class_hierarchy,
   bool include_interfaces);
 
 bool is_non_null_library_global(const irep_idt &);

--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -589,8 +589,7 @@ void get_virtual_calleest::get_functions(
   const std::string function_name_string(id2string(function_name));
   INVARIANT(!class_id.empty(), "All virtual functions must have a class");
 
-  resolve_inherited_componentt get_virtual_call_target(
-    symbol_table, class_hierarchy);
+  resolve_inherited_componentt get_virtual_call_target{symbol_table};
   const function_call_resolvert resolve_function_call =
     [&get_virtual_call_target](
       const irep_idt &class_id, const irep_idt &function_name) {

--- a/src/goto-programs/resolve_inherited_component.h
+++ b/src/goto-programs/resolve_inherited_component.h
@@ -21,8 +21,7 @@ Author: Diffblue Ltd.
 class resolve_inherited_componentt
 {
 public:
-  resolve_inherited_componentt(
-    const symbol_tablet &symbol_table, const class_hierarchyt &class_hierarchy);
+  explicit resolve_inherited_componentt(const symbol_tablet &symbol_table);
 
   class inherited_componentt
   {
@@ -54,7 +53,6 @@ public:
     const irep_idt &class_name, const irep_idt &component_name);
 
 private:
-  const class_hierarchyt &class_hierarchy;
   const symbol_tablet &symbol_table;
 };
 


### PR DESCRIPTION
This means it can be used even in settings where a class hierarchy isn't
readily available. The class hierarchy was only being used to find
parents, which are easily available from the class type directly, so it
wasn't providing any benefit. (It would have been different if we needed
to find children.)

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
