### PR TITLE
Java type parser [TG-9756]

### DIFF
--- a/jbmc/src/java_bytecode/Makefile
+++ b/jbmc/src/java_bytecode/Makefile
@@ -41,6 +41,7 @@ SRC = assignments_from_json.cpp \
       java_string_library_preprocess.cpp \
       java_string_literals.cpp \
       java_trace_validation.cpp \
+      java_type_signature_parser.cpp \
       java_types.cpp \
       java_utils.cpp \
       lambda_synthesis.cpp \

--- a/jbmc/src/java_bytecode/java_bytecode_parse_tree.h
+++ b/jbmc/src/java_bytecode/java_bytecode_parse_tree.h
@@ -220,7 +220,6 @@ struct java_bytecode_parse_treet
     bool is_inner_class = false;
     bool is_static_class = false;
     bool is_anonymous_class = false;
-    bool attribute_bootstrapmethods_read = false;
     irep_idt outer_class; // when no outer class is set, there is no outer class
     size_t enum_elements=0;
 

--- a/jbmc/src/java_bytecode/java_bytecode_parse_tree.h
+++ b/jbmc/src/java_bytecode/java_bytecode_parse_tree.h
@@ -18,6 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/std_types.h>
 
 #include "bytecode_info.h"
+#include "java_type_signature_parser.h"
 
 struct java_bytecode_parse_treet
 {
@@ -268,6 +269,7 @@ struct java_bytecode_parse_treet
     typedef std::list<irep_idt> implementst;
     implementst implements;
     optionalt<std::string> signature;
+    optionalt<java_class_type_signaturet> parsed_sig;
     typedef std::list<fieldt> fieldst;
     typedef std::list<methodt> methodst;
     fieldst fields;

--- a/jbmc/src/java_bytecode/java_bytecode_parser.h
+++ b/jbmc/src/java_bytecode/java_bytecode_parser.h
@@ -15,6 +15,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <string>
 #include <util/optional.h>
 
+#include "java_type_signature_parser.h"
+
 struct java_bytecodet;
 struct java_bytecode_parse_treet;
 
@@ -37,6 +39,7 @@ public:
   {
     return *bytecode;
   }
+  optionalt<std::string> get_outer_class_name();
 };
 
 /// Attempt to load the bytecode from the given file.
@@ -63,10 +66,13 @@ java_bytecode_reft java_bytecode_load(
 
 /// Attempt to parse a Java class from the loaded bytecode
 /// \param bytecode: the loaded bytecode
+/// \param outer_generic_parameters The generic paramaters of the outer class,
+///   if any
 /// \param message_handler: handles log messages
 /// \return parse tree, or empty optionalt on failure
 optionalt<java_bytecode_parse_treet> java_bytecode_parse(
   java_bytecode_reft &bytecode,
+  const java_generic_type_parameter_mapt &outer_generic_parameters,
   class message_handlert &message_handler);
 
 #endif // CPROVER_JAVA_BYTECODE_JAVA_BYTECODE_PARSER_H

--- a/jbmc/src/java_bytecode/java_bytecode_parser.h
+++ b/jbmc/src/java_bytecode/java_bytecode_parser.h
@@ -11,33 +11,62 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_JAVA_BYTECODE_JAVA_BYTECODE_PARSER_H
 
 #include <iosfwd>
+#include <memory>
 #include <string>
 #include <util/optional.h>
 
+struct java_bytecodet;
 struct java_bytecode_parse_treet;
 
-/// Attempt to parse a Java class from the given file.
+class java_bytecode_reft
+{
+private:
+  std::unique_ptr<java_bytecodet> bytecode;
+
+public:
+  java_bytecode_reft() noexcept;
+  explicit java_bytecode_reft(java_bytecodet &&bytecode) noexcept;
+  java_bytecode_reft(java_bytecode_reft &&) noexcept;
+  ~java_bytecode_reft();
+
+  bool has_value() const
+  {
+    return bytecode != nullptr;
+  }
+  java_bytecodet &operator*() const
+  {
+    return *bytecode;
+  }
+};
+
+/// Attempt to load the bytecode from the given file.
 /// \param file: file to load from
-/// \param msg: handles log messages
+/// \param message_handler: handles log messages
 /// \param skip_instructions: if true, the loaded class's methods will all be
 ///   empty. Saves time and memory for consumers that only want signature info.
 /// \return parse tree, or empty optionalt on failure
-optionalt<java_bytecode_parse_treet>
-java_bytecode_parse(
+java_bytecode_reft java_bytecode_load(
   const std::string &file,
-  class message_handlert &msg,
+  class message_handlert &message_handler,
   bool skip_instructions = false);
 
-/// Attempt to parse a Java class from the given stream
+/// Attempt to load the bytecode from the given stream
 /// \param stream: stream to load from
-/// \param msg: handles log messages
+/// \param message_handler: handles log messages
 /// \param skip_instructions: if true, the loaded class's methods will all be
 ///   empty. Saves time and memory for consumers that only want signature info.
 /// \return parse tree, or empty optionalt on failure
-optionalt<java_bytecode_parse_treet>
-java_bytecode_parse(
+java_bytecode_reft java_bytecode_load(
   std::istream &stream,
-  class message_handlert &msg,
+  class message_handlert &message_handler,
   bool skip_instructions = false);
+
+/// Attempt to parse a Java class from the loaded bytecode
+/// \param bytecode: the loaded bytecode
+/// \param message_handler: handles log messages
+/// \return parse tree, or empty optionalt on failure
+optionalt<java_bytecode_parse_treet> java_bytecode_parse(
+  java_bytecode_reft &bytecode,
+  class message_handlert &message_handler);
 
 #endif // CPROVER_JAVA_BYTECODE_JAVA_BYTECODE_PARSER_H

--- a/jbmc/src/java_bytecode/java_class_loader.h
+++ b/jbmc/src/java_bytecode/java_class_loader.h
@@ -100,6 +100,8 @@ private:
   parse_tree_with_overridest_mapt class_map;
 
   optionalt<std::vector<irep_idt>> read_jar_file(const std::string &jar_path);
+  optionalt<java_bytecode_parse_treet>
+  get_parse_tree(const irep_idt &class_name, const classpath_entryt &cp_entry);
 };
 
 #endif // CPROVER_JAVA_BYTECODE_JAVA_CLASS_LOADER_H

--- a/jbmc/src/java_bytecode/java_class_loader_base.cpp
+++ b/jbmc/src/java_bytecode/java_class_loader_base.cpp
@@ -146,7 +146,9 @@ java_class_loader_baset::get_class_from_jar(
             << eom;
 
     std::istringstream istream(*data);
-    return java_bytecode_parse(istream, get_message_handler());
+    java_bytecode_reft bytecode =
+      java_bytecode_load(istream, get_message_handler());
+    return java_bytecode_parse(bytecode, get_message_handler());
   }
   catch(const std::runtime_error &)
   {
@@ -172,7 +174,9 @@ java_class_loader_baset::get_class_from_directory(
   {
     debug() << "Getting class '" << class_name << "' from file " << full_path
             << eom;
-    return java_bytecode_parse(full_path, get_message_handler());
+    java_bytecode_reft bytecode =
+      java_bytecode_load(full_path, get_message_handler());
+    return java_bytecode_parse(bytecode, get_message_handler());
   }
   else
     return {};

--- a/jbmc/src/java_bytecode/java_class_loader_base.cpp
+++ b/jbmc/src/java_bytecode/java_class_loader_base.cpp
@@ -9,7 +9,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "java_class_loader_base.h"
 
 #include "jar_file.h"
-#include "java_bytecode_parser.h"
 
 #include <util/file_util.h>
 #include <util/prefix.h>
@@ -109,7 +108,7 @@ java_class_loader_baset::class_name_to_os_file(const irep_idt &class_name)
 }
 
 /// attempt to load a class from a classpath_entry
-optionalt<java_bytecode_parse_treet> java_class_loader_baset::load_class(
+java_bytecode_reft java_class_loader_baset::load_class(
   const irep_idt &class_name,
   const classpath_entryt &cp_entry)
 {
@@ -129,8 +128,7 @@ optionalt<java_bytecode_parse_treet> java_class_loader_baset::load_class(
 /// \param class_name: name of class to load in Java source format
 /// \param jar_file: path of the jar file
 /// \return optional value of parse tree, empty if class cannot be loaded
-optionalt<java_bytecode_parse_treet>
-java_class_loader_baset::get_class_from_jar(
+java_bytecode_reft java_class_loader_baset::get_class_from_jar(
   const irep_idt &class_name,
   const std::string &jar_file)
 {
@@ -146,9 +144,7 @@ java_class_loader_baset::get_class_from_jar(
             << eom;
 
     std::istringstream istream(*data);
-    java_bytecode_reft bytecode =
-      java_bytecode_load(istream, get_message_handler());
-    return java_bytecode_parse(bytecode, get_message_handler());
+    return java_bytecode_load(istream, get_message_handler());
   }
   catch(const std::runtime_error &)
   {
@@ -161,8 +157,7 @@ java_class_loader_baset::get_class_from_jar(
 /// \param class_name: name of class to load in Java source format
 /// \param path: directory to load from
 /// \return optional value of parse tree, empty if class cannot be loaded
-optionalt<java_bytecode_parse_treet>
-java_class_loader_baset::get_class_from_directory(
+java_bytecode_reft java_class_loader_baset::get_class_from_directory(
   const irep_idt &class_name,
   const std::string &path)
 {
@@ -174,9 +169,7 @@ java_class_loader_baset::get_class_from_directory(
   {
     debug() << "Getting class '" << class_name << "' from file " << full_path
             << eom;
-    java_bytecode_reft bytecode =
-      java_bytecode_load(full_path, get_message_handler());
-    return java_bytecode_parse(bytecode, get_message_handler());
+    return java_bytecode_load(full_path, get_message_handler());
   }
   else
     return {};

--- a/jbmc/src/java_bytecode/java_class_loader_base.h
+++ b/jbmc/src/java_bytecode/java_class_loader_base.h
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "jar_pool.h"
 #include "java_bytecode_parse_tree.h"
+#include "java_bytecode_parser.h"
 
 /// Base class for maintaining classpath.
 class java_class_loader_baset : public messaget
@@ -55,15 +56,15 @@ protected:
   std::list<classpath_entryt> classpath_entries;
 
   /// attempt to load a class from a classpath_entry
-  optionalt<java_bytecode_parse_treet>
+  java_bytecode_reft
   load_class(const irep_idt &class_name, const classpath_entryt &);
 
   /// attempt to load a class from a given jar file
-  optionalt<java_bytecode_parse_treet>
+  java_bytecode_reft
   get_class_from_jar(const irep_idt &class_name, const std::string &jar_file);
 
   /// attempt to load a class from a given directory
-  optionalt<java_bytecode_parse_treet>
+  java_bytecode_reft
   get_class_from_directory(const irep_idt &class_name, const std::string &path);
 };
 

--- a/jbmc/src/java_bytecode/java_type_signature_parser.cpp
+++ b/jbmc/src/java_bytecode/java_type_signature_parser.cpp
@@ -461,6 +461,8 @@ java_class_type_signaturet::java_class_type_signaturet(
   while(!type_str.empty());
 }
 
+const java_class_type_signaturet java_class_type_signaturet::object_type;
+
 void java_class_type_signaturet::collect_class_dependencies(
   std::set<irep_idt> &deps) const
 {

--- a/jbmc/src/java_bytecode/java_type_signature_parser.cpp
+++ b/jbmc/src/java_bytecode/java_type_signature_parser.cpp
@@ -1,0 +1,537 @@
+// Copyright 2019 Diffblue Limited.
+
+/// \file
+/// Parser for Java type signatures
+
+#include "java_type_signature_parser.h"
+#include <ostream>
+#include <util/parsable_string.h>
+
+#include "java_types.h"
+
+///////////////////////////////////////////////////////////
+// static parse functions
+
+static std::shared_ptr<java_ref_type_signaturet> parse_class_type(
+  parsable_stringt &type_string,
+  const java_generic_type_parameter_mapt &parameters);
+
+/// Parse a java_value_type_signaturet from a parsable_stringt pointing at an
+/// appropriate part of a type signature
+/// \param type_string A parsable_stringt pointing at an appropriate part of a
+///   type signature
+/// \param parameters A map giving the parameters in scope for this signature
+/// \return The parsed java_value_type_signaturet
+static std::shared_ptr<java_value_type_signaturet> parse_type(
+  parsable_stringt &type_string,
+  const java_generic_type_parameter_mapt &parameters)
+{
+  char first =
+    type_string.get_first("Expected type string at end of signature");
+  switch(first)
+  {
+  case 'B':
+  case 'F':
+  case 'D':
+  case 'I':
+  case 'C':
+  case 'S':
+  case 'Z':
+  case 'V':
+  case 'J':
+    return std::make_shared<java_primitive_type_signaturet>(first);
+  case '[':
+    return std::make_shared<java_array_type_signaturet>(
+      parse_type(type_string, parameters));
+  case 'L': // Class type
+    return parse_class_type(type_string, parameters);
+  case 'T': // Type parameter
+  {
+    parsable_stringt parameter_name = type_string.split_at_first(
+      ';', "Type parameter reference doesn't have closing semicolon");
+    auto parameter = parameters.find(parameter_name);
+    if(parameter == parameters.end())
+      throw parse_exceptiont(
+        "Reference to undefined type parameter: " +
+          std::string(parameter_name));
+    return parameter->second;
+  }
+  case '*':
+  case '+':
+  case '-':
+    throw unsupported_java_class_signature_exceptiont("Wild card generic");
+  default:
+    throw unsupported_java_class_signature_exceptiont(
+      std::string("Unknown type signature starting with ") + first);
+  }
+}
+
+/// Parse the signature of a reference to a class type
+/// \param type_string A parsable_stringt starting at the type signature of a
+///   reference to a class
+/// \param parameters The generic type parameters that may appear in the type
+/// \return The parsed type
+static std::shared_ptr<java_ref_type_signaturet> parse_class_type(
+  parsable_stringt &type_string,
+  const java_generic_type_parameter_mapt &parameters)
+{
+  // Check if a < occurs before a ;
+  std::pair<parsable_stringt, char> class_name_and_next =
+    type_string.split_at_first_of(
+      "<;", "Class type doesn't have closing semicolon");
+  java_type_signature_listt type_arguments;
+  if(class_name_and_next.second == '<')
+  {
+    do
+    {
+      type_arguments.push_back(parse_type(type_string, parameters));
+    } while(!type_string.try_skip('>'));
+    type_string.skip(
+      ';', "Class type with type arguments doesn't have closing semicolon");
+  }
+  return std::make_shared<java_ref_type_signaturet>(
+    class_name_and_next.first, std::move(type_arguments));
+}
+
+/// Parse a reference to a generic type parameter
+/// \param parameter_string A parsable_stringt starting at the type signature
+///   of a type parameter
+/// \return The parsed type parameter
+static std::shared_ptr<java_generic_type_parametert>
+parse_type_parameter(parsable_stringt &parameter_string)
+{
+  std::shared_ptr<java_generic_type_parametert> result =
+    std::make_shared<java_generic_type_parametert>(
+      parameter_string.split_at_first(':', "No colon in type parameter bound"));
+  java_generic_type_parameter_mapt parameter_map;
+  // Allow recursive definitions where the bound refers to the parameter itself
+  parameter_map.emplace(result->name, result);
+  if(!parameter_string.starts_with(':'))
+    result->class_bound = parse_type(parameter_string, parameter_map);
+  while(parameter_string.try_skip(':'))
+  {
+    result->interface_bounds.push_back(
+      parse_type(parameter_string, parameter_map));
+  }
+  INVARIANT(
+    result->class_bound != nullptr || !result->interface_bounds.empty(),
+    "All type parameters have at least one bound");
+  return result;
+}
+
+/// Parse an optional collection of formal type parameters (e.g. on generic
+/// methods of non-generic classes, generic static methods or generic classes).
+/// \param parameters_string A parsable_stringt starting at where the
+///   collection would appear
+/// \return The parsed java_generic_type_parameter_listt
+/// \example
+/// This java method: static void <T, U extends V> foo(T t, U u, int x)
+/// Would have this signature: <T:Ljava/lang/Object;U:LV;>(TT;TU;I)V
+static java_generic_type_parameter_listt
+parse_type_parameters(parsable_stringt &parameters_string)
+{
+  java_generic_type_parameter_listt parameter_map;
+  if(parameters_string.try_skip('<'))
+  {
+    do
+    {
+      parameter_map.push_back(parse_type_parameter(parameters_string));
+    } while(!parameters_string.try_skip('>'));
+  }
+  return parameter_map;
+}
+
+
+///////////////////////////////////////////////////////////
+// java_type_signaturet derivatives
+
+std::shared_ptr<java_value_type_signaturet>
+java_value_type_signaturet::parse_single_value_type(
+  const std::string &type_string,
+  const java_generic_type_parameter_mapt &parameter_map)
+{
+  parsable_stringt type_str = type_string;
+  std::shared_ptr<java_value_type_signaturet> type =
+    parse_type(type_str, parameter_map);
+  if(!type_str.empty())
+    throw parse_exceptiont("Extra content after type signature");
+  return type;
+}
+
+std::ostream &
+operator<<(std::ostream &stm, const java_type_signature_listt &types)
+{
+  bool first = true;
+  for(const std::shared_ptr<java_value_type_signaturet> &type : types)
+  {
+    if(!first)
+      stm << ", ";
+    else
+      first = false;
+    stm << *type;
+  }
+  return stm;
+}
+
+typet java_generic_type_parametert::get_type(
+  const std::string &class_name_prefix) const
+{
+  return java_generic_parametert(
+    class_name_prefix + "::" + name,
+    to_struct_tag_type(
+      // We currently only support one bound per variable, use the first
+      (class_bound != nullptr ? class_bound : interface_bounds[0])
+        ->get_type(class_name_prefix)
+        .subtype()));
+}
+
+void java_generic_type_parametert::full_output(
+  std::ostream &stm,
+  bool show_bounds) const
+{
+  stm << name;
+  if(show_bounds)
+  {
+    stm << " extends ";
+    bool first = true;
+    if(class_bound != nullptr)
+    {
+      stm << *class_bound;
+      first = false;
+    }
+    for(const std::shared_ptr<java_value_type_signaturet> &interface_bound :
+        interface_bounds)
+    {
+      if(!first)
+        stm << " & ";
+      else
+        first = false;
+      stm << *interface_bound;
+    }
+  }
+}
+
+void java_generic_type_parametert::collect_class_dependencies_from_declaration(
+  std::set<irep_idt> &deps) const
+{
+  if(class_bound != nullptr)
+    class_bound->collect_class_dependencies(deps);
+  for(const std::shared_ptr<java_value_type_signaturet> &interface_bound :
+      interface_bounds)
+  {
+    interface_bound->collect_class_dependencies(deps);
+  }
+}
+
+typet java_primitive_type_signaturet::get_type(
+  const std::string &class_name_prefix) const
+{
+  switch(type_character)
+  {
+  case 'B':
+    return java_byte_type();
+  case 'F':
+    return java_float_type();
+  case 'D':
+    return java_double_type();
+  case 'I':
+    return java_int_type();
+  case 'C':
+    return java_char_type();
+  case 'S':
+    return java_short_type();
+  case 'Z':
+    return java_boolean_type();
+  case 'V':
+    return java_void_type();
+  case 'J':
+    return java_long_type();
+  default:
+    UNREACHABLE;
+  }
+}
+
+void java_primitive_type_signaturet::output(std::ostream &stm) const
+{
+  switch(type_character)
+  {
+  case 'B':
+    stm << "byte";
+    break;
+  case 'F':
+    stm << "float";
+    break;
+  case 'D':
+    stm << "double";
+    break;
+  case 'I':
+    stm << "int";
+    break;
+  case 'C':
+    stm << "char";
+    break;
+  case 'S':
+    stm << "short";
+    break;
+  case 'Z':
+    stm << "boolean";
+    break;
+  case 'V':
+    stm << "void";
+    break;
+  case 'J':
+    stm << "long";
+    break;
+  default:
+    UNREACHABLE;
+  }
+}
+
+void java_array_type_signaturet::collect_class_dependencies(
+  std::set<irep_idt> &deps) const
+{
+  element_type->collect_class_dependencies(deps);
+}
+
+typet java_array_type_signaturet::get_type(
+  const std::string &class_name_prefix) const
+{
+  // If this is a reference array, we generate a plain array[reference]
+  // with void* members, but note the real type in ID_C_element_type.
+  std::shared_ptr<java_primitive_type_signaturet> primitive_elt_type =
+    std::dynamic_pointer_cast<java_primitive_type_signaturet>(element_type);
+  typet result = java_array_type(static_cast<char>(std::tolower(
+    primitive_elt_type == nullptr ? 'A' : primitive_elt_type->type_character)));
+  result.subtype().set(
+    ID_element_type, element_type->get_type(class_name_prefix));
+  return result;
+}
+
+void java_array_type_signaturet::output(std::ostream &stm) const
+{
+  stm << *element_type << "[]";
+}
+
+java_ref_type_signaturet::java_ref_type_signaturet(
+  std::string class_name,
+  java_type_signature_listt type_arguments)
+  : type_arguments(std::move(type_arguments))
+{
+  std::replace(class_name.begin(), class_name.end(), '.', '$');
+  std::replace(class_name.begin(), class_name.end(), '/', '.');
+  this->class_name = std::move(class_name);
+}
+
+void java_ref_type_signaturet::collect_class_dependencies(
+  std::set<irep_idt> &deps) const
+{
+  deps.insert(class_name);
+  for(const std::shared_ptr<java_value_type_signaturet> &type_arg :
+      type_arguments)
+  {
+    type_arg->collect_class_dependencies(deps);
+  }
+}
+
+typet java_ref_type_signaturet::get_type(
+  const std::string &class_name_prefix) const
+{
+  std::string identifier = "java::" + class_name;
+  struct_tag_typet struct_tag_type(identifier);
+  struct_tag_type.set(ID_C_base_name, class_name);
+
+  if(type_arguments.empty())
+    return java_reference_type(struct_tag_type);
+
+  java_generic_typet result(struct_tag_type);
+  std::transform(
+    type_arguments.begin(),
+    type_arguments.end(),
+    std::back_inserter(result.generic_type_arguments()),
+    [&class_name_prefix](
+      const std::shared_ptr<java_value_type_signaturet> &type_argument)
+    {
+      const typet type = type_argument->get_type(class_name_prefix);
+      const reference_typet *ref_type =
+        type_try_dynamic_cast<reference_typet>(type);
+      if(ref_type == nullptr)
+        throw unsupported_java_class_signature_exceptiont(
+          "All generic type arguments should be references");
+      return *ref_type;
+    });
+  return std::move(result);
+}
+
+void java_ref_type_signaturet::output(std::ostream &stm) const
+{
+  stm << class_name;
+  if(!type_arguments.empty())
+    stm << "<" << type_arguments << ">";
+}
+
+std::ostream &operator<<(
+  std::ostream &stm,
+  const java_generic_type_parameter_listt &parameters)
+{
+  bool first = true;
+  for(const std::shared_ptr<java_generic_type_parametert> &parameter :
+      parameters)
+  {
+    if(!first)
+      stm << ", ";
+    else
+      first = false;
+    stm << *parameter;
+  }
+  return stm;
+}
+
+
+///////////////////////////////////////////////////////////
+// java_class_type_signaturet
+
+java_class_type_signaturet::java_class_type_signaturet(
+  const std::string &type_string,
+  const java_generic_type_parameter_mapt &outer_parameter_map)
+{
+  parsable_stringt type_str = type_string;
+  explicit_type_parameters = parse_type_parameters(type_str);
+  type_parameter_map = outer_parameter_map;
+  for(const std::shared_ptr<java_generic_type_parametert> &parameter :
+      explicit_type_parameters)
+  {
+    type_parameter_map.emplace(parameter->name, parameter);
+  }
+  do
+    bases.push_back(parse_type(type_str, type_parameter_map));
+  while(!type_str.empty());
+}
+
+void java_class_type_signaturet::collect_class_dependencies(
+  std::set<irep_idt> &deps) const
+{
+  for(const std::shared_ptr<java_generic_type_parametert> &parameter :
+      explicit_type_parameters)
+  {
+    parameter->collect_class_dependencies_from_declaration(deps);
+  }
+  for(const std::shared_ptr<java_value_type_signaturet> &base : bases)
+    base->collect_class_dependencies(deps);
+}
+
+typet java_class_type_signaturet::get_type(
+  const std::string &class_name_prefix) const
+{
+  // TODO: Implement this
+  UNREACHABLE;
+}
+
+void java_class_type_signaturet::output(std::ostream &stm) const
+{
+  stm << "class Foo";
+  if(!explicit_type_parameters.empty())
+  {
+    stm << "<";
+    bool first = true;
+    for(const std::shared_ptr<java_generic_type_parametert> &parameter :
+        explicit_type_parameters)
+    {
+      if(!first)
+        stm << ", ";
+      else
+        first = false;
+      parameter->full_output(stm, true);
+    }
+    stm << ">";
+  }
+  stm << " extends " << *bases[0];
+  if(bases.size() != 1)
+  {
+    stm << " implements ";
+    bool first = true;
+    for(std::size_t i = 1; i < bases.size(); ++i)
+    {
+      if(!first)
+        stm << ", ";
+      else
+        first = false;
+      stm << *bases[i];
+    }
+  }
+}
+
+
+///////////////////////////////////////////////////////////
+// java_method_type_signaturet
+
+java_method_type_signaturet::java_method_type_signaturet(
+  const std::string &type_string,
+  java_generic_type_parameter_mapt class_parameter_map)
+{
+  parsable_stringt type_str = type_string;
+  explicit_type_parameters = parse_type_parameters(type_str);
+  type_parameter_map = class_parameter_map;
+  for(const std::shared_ptr<java_generic_type_parametert> &parameter :
+      explicit_type_parameters)
+  {
+    type_parameter_map.emplace(parameter->name, parameter);
+  }
+  type_str.skip('(', "No '(' at start of method signature");
+  while(!type_str.try_skip(')'))
+    parameters.push_back(parse_type(type_str, type_parameter_map));
+  return_type = parse_type(type_str, type_parameter_map);
+  if(!type_str.empty())
+    throw parse_exceptiont("Extra content after type signature");
+}
+
+void java_method_type_signaturet::collect_class_dependencies(
+  std::set<irep_idt> &deps) const
+{
+  for(const std::shared_ptr<java_generic_type_parametert> &parameter :
+      explicit_type_parameters)
+  {
+    parameter->collect_class_dependencies_from_declaration(deps);
+  }
+  for(const std::shared_ptr<java_value_type_signaturet> &param : parameters)
+    param->collect_class_dependencies(deps);
+  return_type->collect_class_dependencies(deps);
+}
+
+typet java_method_type_signaturet::get_type(
+  const std::string &class_name_prefix) const
+{
+  code_typet::parameterst parameter_types;
+  std::transform(
+    parameters.begin(),
+    parameters.end(),
+    std::back_inserter(parameter_types),
+    [&class_name_prefix](
+      const std::shared_ptr<java_value_type_signaturet> &parameter)
+    {
+      return code_typet::parametert(parameter->get_type(class_name_prefix));
+    });
+  return
+    java_method_typet
+    { std::move(parameter_types), return_type->get_type(class_name_prefix) };
+}
+
+void java_method_type_signaturet::output(std::ostream &stm) const
+{
+  stm << *return_type << " f";
+  if(!explicit_type_parameters.empty())
+  {
+    stm << "<";
+    bool first = true;
+    for(const std::shared_ptr<java_generic_type_parametert> &parameter :
+        explicit_type_parameters)
+    {
+      if(!first)
+        stm << ", ";
+      else
+        first = false;
+      parameter->full_output(stm, true);
+    }
+    stm << ">";
+  }
+  stm << "(" << parameters << ")";
+}

--- a/jbmc/src/java_bytecode/java_type_signature_parser.h
+++ b/jbmc/src/java_bytecode/java_type_signature_parser.h
@@ -272,6 +272,13 @@ public:
   /// Type parameters in scope in the class, including those from outer classes
   java_generic_type_parameter_mapt type_parameter_map;
 
+private:
+  /// Private default constructor used by object_type
+  java_class_type_signaturet()
+  {
+  }
+
+public:
   /// Create a java_class_type_signaturet by parsing a type signature
   /// \param type_string The type signature to parse
   /// \param outer_parameter_map A map giving the parameters in scope for this
@@ -279,6 +286,9 @@ public:
   java_class_type_signaturet(
     const std::string &type_string,
     const java_generic_type_parameter_mapt &outer_parameter_map);
+
+  /// The type signature of java.lang.Object
+  static const java_class_type_signaturet object_type;
 
   /// \copydoc java_type_signaturet::collect_class_dependencies
   void collect_class_dependencies(std::set<irep_idt> &deps) const override;

--- a/jbmc/src/java_bytecode/java_type_signature_parser.h
+++ b/jbmc/src/java_bytecode/java_type_signature_parser.h
@@ -202,13 +202,17 @@ public:
   std::string class_name;
   /// Generic type arguments
   java_type_signature_listt type_arguments;
+  /// If not nullptr then the reference is to this inner class within the
+  /// current class reference
+  std::shared_ptr<java_ref_type_signaturet> inner_class;
 
   java_ref_type_signaturet(const java_ref_type_signaturet &) = delete;
   java_ref_type_signaturet(java_ref_type_signaturet &&) = default;
 
   java_ref_type_signaturet(
     std::string class_name,
-    java_type_signature_listt type_arguments);
+    java_type_signature_listt type_arguments,
+    std::shared_ptr<java_ref_type_signaturet> inner_class);
 
   /// \copydoc java_type_signaturet::collect_class_dependencies
   void collect_class_dependencies(std::set<irep_idt> &deps) const override;

--- a/jbmc/src/java_bytecode/java_type_signature_parser.h
+++ b/jbmc/src/java_bytecode/java_type_signature_parser.h
@@ -1,0 +1,284 @@
+// Copyright 2019 Diffblue Limited.
+
+/// \file
+/// Parser for Java type signatures
+
+#ifndef CPROVER_JAVA_BYTECODE_JAVA_TYPE_SIGNATURE_PARSER_H
+#define CPROVER_JAVA_BYTECODE_JAVA_TYPE_SIGNATURE_PARSER_H
+
+#include <memory>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <util/type.h>
+
+class java_generic_type_parametert;
+typedef
+  std::unordered_map<std::string, std::shared_ptr<java_generic_type_parametert>>
+  java_generic_type_parameter_mapt;
+
+/// Base class for parsed type signatures
+class java_type_signaturet
+{
+public:
+  virtual ~java_type_signaturet() = default;
+
+  /// Gather the names of classes referred to by this type
+  /// \param deps A set into which to gether the names of classes referred to
+  ///   by this type
+  virtual void collect_class_dependencies(std::set<irep_idt> &deps) const = 0;
+
+  /// Get the typet representation of this type
+  /// \param class_name_prefix The prefix to put before the class name to make
+  ///   the full name for a class used in its typet representation
+  /// \return The typet representation of this type
+  /// \remarks This may lose information where typet doesn't currently support
+  ///   all the features of java
+  virtual typet get_type(const std::string &class_name_prefix) const = 0;
+
+  /// Output this type in human readable (Java) format
+  /// \param stm The stream to which to output
+  virtual void output(std::ostream &stm) const = 0;
+};
+
+/// Operator<< overload to output a parsed type signature to a stream
+/// \param stm The stream to which to output
+/// \param me The parsed type signature to output
+/// \return The stream passed as input
+inline std::ostream &
+operator<<(std::ostream &stm, const java_type_signaturet &me)
+{
+  me.output(stm);
+  return stm;
+}
+
+/// Base class for parsed type signatures representing the type of a value
+class java_value_type_signaturet : public java_type_signaturet
+{
+public:
+  /// Static method to parse a java_value_type_signaturet from a type signature
+  /// \param type_string The type signature to parse
+  /// \param parameter_map A map giving the parameters in scope for this
+  ///   signature
+  /// \return The parsed java_value_type_signaturet
+  static std::shared_ptr<java_value_type_signaturet> parse_single_value_type(
+    const std::string &type_string,
+    const java_generic_type_parameter_mapt &parameter_map);
+};
+
+/// A list of type signatures, typically used for the types of type parameter
+/// bounds, generic type arguments or implemented interfaces
+typedef std::vector<std::shared_ptr<java_value_type_signaturet>>
+  java_type_signature_listt;
+
+/// Operator<< overload to output a list of parsed type signatures to a stream
+/// \param stm The stream to which to output
+/// \param types The list of parsed type signatures to output
+/// \return The stream passed as input
+std::ostream &
+operator<<(std::ostream &stm, const java_type_signature_listt &types);
+
+/// A generic type parameter, this class is used to represent both their
+/// declarations and their usages
+class java_generic_type_parametert : public java_value_type_signaturet
+{
+public:
+  /// The name of the parameter
+  const std::string name;
+  /// Bound on the type parameter that is a class
+  /// \remarks
+  /// If there isn't one then there must be at least one interface bound
+  /// If no bound is explicitly specified this this will be java.lang.Object
+  std::shared_ptr<java_value_type_signaturet> class_bound;
+  /// Bounds on the type parameter that are interfaces
+  /// \remarks
+  /// If there aren't any then there must be a class bound
+  java_type_signature_listt interface_bounds;
+
+  // Delete the copy constructor - the declaration and the usage should share
+  // the same object
+  java_generic_type_parametert(const java_generic_type_parametert &) = delete;
+  java_generic_type_parametert(java_generic_type_parametert &&) = default;
+
+  /// Create a named type parameter
+  /// \param name The name of the type parameter to create
+  explicit java_generic_type_parametert(std::string name)
+    : name(std::move(name))
+  {
+  }
+
+  /// Gather the names of classes referred to by this parameter at the point
+  ///   where it is used
+  /// \param deps A set into which to gether the names of classes referred to
+  ///   by this type
+  void collect_class_dependencies(std::set<irep_idt> &deps) const override
+  {
+  }
+  /// Gather the names of classes referred to by this parameter at the point
+  ///   where it is declared
+  /// \param deps A set into which to gether the names of classes referred to
+  ///   by this type
+  void
+  collect_class_dependencies_from_declaration(std::set<irep_idt> &deps) const;
+
+  /// \copydoc java_type_signaturet::get_type
+  typet get_type(const std::string &class_name_prefix) const override;
+
+  /// \copydoc java_type_signaturet::output
+  void output(std::ostream &stm) const override
+  {
+    full_output(stm);
+  }
+  /// Output this type in human readable (Java) format
+  /// \param stm The stream to which to output
+  /// \param show_bounds Whether to include the list of bounds in the output
+  void full_output(std::ostream &stm, bool show_bounds = false) const;
+};
+
+/// A vector of type parameters
+typedef std::vector<std::shared_ptr<java_generic_type_parametert>>
+  java_generic_type_parameter_listt;
+
+/// Operator<< overload to output a list of type parameters to a stream
+/// \param stm The stream to which to output
+/// \param parameters The list of type parameters to output
+/// \return The stream passed as input
+std::ostream &operator<<(
+  std::ostream &stm,
+  const java_generic_type_parameter_listt &parameters);
+
+/// A primitive type, such as int (but not Integer)
+class java_primitive_type_signaturet : public java_value_type_signaturet
+{
+public:
+  const char type_character;
+
+  explicit java_primitive_type_signaturet(char type_character)
+    : type_character(type_character)
+  {
+  }
+
+  /// \copydoc java_type_signaturet::collect_class_dependencies
+  void collect_class_dependencies(std::set<irep_idt> &deps) const override
+  {
+  }
+
+  /// \copydoc java_type_signaturet::get_type
+  typet get_type(const std::string &class_name_prefix) const override;
+
+  /// \copydoc java_type_signaturet::output
+  void output(std::ostream &stm) const override;
+};
+
+/// An array type, specifying the type of the elements
+class java_array_type_signaturet : public java_value_type_signaturet
+{
+public:
+  std::shared_ptr<java_value_type_signaturet> element_type;
+
+  explicit java_array_type_signaturet(
+    std::shared_ptr<java_value_type_signaturet> element_type)
+    : element_type(std::move(element_type))
+  {
+  }
+
+  /// \copydoc java_type_signaturet::collect_class_dependencies
+  void collect_class_dependencies(std::set<irep_idt> &deps) const override;
+
+  /// \copydoc java_type_signaturet::get_type
+  typet get_type(const std::string &class_name_prefix) const override;
+
+  /// \copydoc java_type_signaturet::output
+  void output(std::ostream &stm) const override;
+};
+
+/// A reference to a class type
+class java_ref_type_signaturet : public java_value_type_signaturet
+{
+public:
+  /// The name of the class referred to
+  std::string class_name;
+  /// Generic type arguments
+  java_type_signature_listt type_arguments;
+
+  java_ref_type_signaturet(const java_ref_type_signaturet &) = delete;
+  java_ref_type_signaturet(java_ref_type_signaturet &&) = default;
+
+  java_ref_type_signaturet(
+    std::string class_name,
+    java_type_signature_listt type_arguments);
+
+  /// \copydoc java_type_signaturet::collect_class_dependencies
+  void collect_class_dependencies(std::set<irep_idt> &deps) const override;
+
+  /// \copydoc java_type_signaturet::get_type
+  typet get_type(const std::string &class_name_prefix) const override;
+
+  /// \copydoc java_type_signaturet::output
+  void output(std::ostream &stm) const override;
+};
+
+/// Type signature of a class, does not include its name
+class java_class_type_signaturet : public java_type_signaturet
+{
+public:
+  /// Base classes, including interfaces
+  java_type_signature_listt bases;
+  /// Type parameters specified on the class declaration
+  java_generic_type_parameter_listt explicit_type_parameters;
+  /// Type parameters in scope in the class, including those from outer classes
+  java_generic_type_parameter_mapt type_parameter_map;
+
+  /// Create a java_class_type_signaturet by parsing a type signature
+  /// \param type_string The type signature to parse
+  /// \param outer_parameter_map A map giving the parameters in scope for this
+  ///   signature
+  java_class_type_signaturet(
+    const std::string &type_string,
+    const java_generic_type_parameter_mapt &outer_parameter_map);
+
+  /// \copydoc java_type_signaturet::collect_class_dependencies
+  void collect_class_dependencies(std::set<irep_idt> &deps) const override;
+
+  /// \copydoc java_type_signaturet::get_type
+  typet get_type(const std::string &class_name_prefix) const override;
+
+  /// \copydoc java_type_signaturet::output
+  void output(std::ostream &stm) const override;
+};
+
+/// Type signature of a method, does not include its name
+class java_method_type_signaturet : public java_type_signaturet
+{
+public:
+  /// The types of the parameters to the method
+  java_type_signature_listt parameters;
+  /// The return type of the method
+  std::shared_ptr<java_value_type_signaturet> return_type;
+  /// Type parameters specified on the method declaration
+  java_generic_type_parameter_listt explicit_type_parameters;
+  /// Type parameters in scope in the method, including those from the
+  /// containing classes
+  java_generic_type_parameter_mapt type_parameter_map;
+
+  /// Create a java_method_type_signaturet by parsing a type signature
+  /// \param type_string The type signature to parse
+  /// \param class_parameter_map A map giving the parameters in scope for this
+  ///   signature
+  java_method_type_signaturet(
+    const std::string &type_string,
+    java_generic_type_parameter_mapt class_parameter_map);
+
+  /// \copydoc java_type_signaturet::collect_class_dependencies
+  void collect_class_dependencies(std::set<irep_idt> &deps) const override;
+
+  /// \copydoc java_type_signaturet::get_type
+  typet get_type(const std::string &class_name_prefix) const override;
+
+  /// \copydoc java_type_signaturet::output
+  void output(std::ostream &stm) const override;
+};
+
+#endif // CPROVER_JAVA_BYTECODE_JAVA_TYPE_SIGNATURE_PARSER_H

--- a/jbmc/unit/Makefile
+++ b/jbmc/unit/Makefile
@@ -23,6 +23,7 @@ SRC += java_bytecode/ci_lazy_methods/lazy_load_lambdas.cpp \
        java_bytecode/java_bytecode_instrument/virtual_call_null_checks.cpp \
        java_bytecode/java_bytecode_language/language.cpp \
        java_bytecode/java_bytecode_language/context_excluded.cpp \
+       java_bytecode/java_bytecode_parse_generics/parse_advanced_generics.cpp \
        java_bytecode/java_bytecode_parse_generics/parse_bounded_generic_inner_classes.cpp \
        java_bytecode/java_bytecode_parse_generics/parse_derived_generic_class.cpp \
        java_bytecode/java_bytecode_parse_generics/parse_functions_with_generics.cpp \

--- a/jbmc/unit/java_bytecode/java_bytecode_parse_generics/module_dependencies.txt
+++ b/jbmc/unit/java_bytecode/java_bytecode_parse_generics/module_dependencies.txt
@@ -1,3 +1,3 @@
-java_bytecode_parse_generics
+java_bytecode
 java-testing-utils
 testing-utils

--- a/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_advanced_generics.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parse_generics/parse_advanced_generics.cpp
@@ -1,0 +1,69 @@
+// Copyright 2019 Diffblue Limited.
+
+/// \file
+/// Unit tests for parsing generics using the exact method
+
+#include <java_bytecode/java_type_signature_parser.h>
+#include <testing-utils/use_catch.h>
+
+SCENARIO(
+  "parse_java_type_signature",
+  "[core][java_bytecode][java_bytecode_parse_generics]")
+{
+  WHEN("A complex generic class signature is parsed")
+  {
+    java_class_type_signaturet result(
+      "<TT:LU<Ljava/lang/Integer;Ljava/lang/String;>;:"
+      "LMyInterface<Ljava/lang/String;>;>"
+      "LU<TTT;Ljava/lang/String;>;LMyInterface<Ljava/lang/String;>;",
+      {});
+    THEN("The pretty-printed version is as expected")
+    {
+      std::stringstream output;
+      output << result;
+      REQUIRE(
+        output.str() ==
+        "class Foo<TT extends U<java.lang.Integer, java.lang.String> "
+        "& MyInterface<java.lang.String>> "
+        "extends U<TT, java.lang.String> "
+        "implements MyInterface<java.lang.String>");
+    }
+  }
+  WHEN("A generic method signature is parsed")
+  {
+    java_method_type_signaturet result("<T:LA;>()TT;", {});
+    THEN("The pretty-printed version is as expected")
+    {
+      std::stringstream output;
+      output << result;
+      REQUIRE(output.str() == "T f<T extends A>()");
+    }
+  }
+  WHEN("A generic array signature is parsed")
+  {
+    std::shared_ptr<java_value_type_signaturet> result =
+      java_value_type_signaturet::parse_single_value_type(
+        "[LMyInterface<Ljava/lang/Object;>;", {});
+    THEN("The pretty-printed version is as expected")
+    {
+      std::stringstream output;
+      output << *result;
+      REQUIRE(output.str() == "MyInterface<java.lang.Object>[]");
+    }
+  }
+  WHEN(
+    "The signature of a generic class with a recursive type reference via an "
+    "interface bound on a type parameter is parsed")
+  {
+    java_class_type_signaturet result(
+      "<T::LMyInterface<TT;>;>Ljava/lang/Object;", {});
+    THEN("The pretty-printed version is as expected")
+    {
+      std::stringstream output;
+      output << result;
+      REQUIRE(
+        output.str() ==
+        "class Foo<T extends MyInterface<T>> extends java.lang.Object");
+    }
+  }
+}

--- a/jbmc/unit/java_bytecode/java_bytecode_parse_lambdas/java_bytecode_parse_lambda_method_table.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parse_lambdas/java_bytecode_parse_lambda_method_table.cpp
@@ -37,7 +37,7 @@ SCENARIO(
           compiler + "_classes/StaticLambdas.class",
         null_message_handler);
       optionalt<java_bytecode_parse_treet> parse_tree =
-        java_bytecode_parse(bytecode, null_message_handler);
+        java_bytecode_parse(bytecode, {}, null_message_handler);
       WHEN("Parsing that class")
       {
         REQUIRE(parse_tree);
@@ -348,7 +348,7 @@ SCENARIO(
             compiler + "_classes/LocalLambdas.class",
           null_message_handler);
         optionalt<java_bytecode_parse_treet> parse_tree =
-          java_bytecode_parse(bytecode, null_message_handler);
+          java_bytecode_parse(bytecode, {}, null_message_handler);
         WHEN("Parsing that class")
         {
           REQUIRE(parse_tree);
@@ -657,7 +657,7 @@ SCENARIO(
             compiler + "_classes/MemberLambdas.class",
           null_message_handler);
         optionalt<java_bytecode_parse_treet> parse_tree =
-          java_bytecode_parse(bytecode, null_message_handler);
+          java_bytecode_parse(bytecode, {}, null_message_handler);
         WHEN("Parsing that class")
         {
           REQUIRE(parse_tree);
@@ -992,7 +992,7 @@ SCENARIO(
             compiler + "_classes/OuterMemberLambdas$Inner.class",
           null_message_handler);
         optionalt<java_bytecode_parse_treet> parse_tree =
-          java_bytecode_parse(bytecode, null_message_handler);
+          java_bytecode_parse(bytecode, {}, null_message_handler);
         WHEN("Parsing that class")
         {
           REQUIRE(parse_tree);

--- a/jbmc/unit/java_bytecode/java_bytecode_parse_lambdas/java_bytecode_parse_lambda_method_table.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parse_lambdas/java_bytecode_parse_lambda_method_table.cpp
@@ -32,17 +32,18 @@ SCENARIO(
     GIVEN(
       "A class with a static lambda variables from " + compiler + " compiler.")
     {
-      optionalt<java_bytecode_parse_treet> parse_tree = java_bytecode_parse(
+      java_bytecode_reft bytecode = java_bytecode_load(
         "./java_bytecode/java_bytecode_parse_lambdas/lambda_examples/" +
           compiler + "_classes/StaticLambdas.class",
         null_message_handler);
+      optionalt<java_bytecode_parse_treet> parse_tree =
+        java_bytecode_parse(bytecode, null_message_handler);
       WHEN("Parsing that class")
       {
         REQUIRE(parse_tree);
         REQUIRE(parse_tree->loading_successful);
         const java_bytecode_parse_treet::classt &parsed_class =
           parse_tree->parsed_class;
-        REQUIRE(parsed_class.attribute_bootstrapmethods_read);
         REQUIRE(parsed_class.lambda_method_handle_map.size() == 12);
 
         // Simple lambdas
@@ -342,17 +343,18 @@ SCENARIO(
     [](const std::string &compiler) { // NOLINT(whitespace/braces)
       GIVEN("A method with local lambdas from " + compiler + " compiler.")
       {
-        optionalt<java_bytecode_parse_treet> parse_tree = java_bytecode_parse(
+        java_bytecode_reft bytecode = java_bytecode_load(
           "./java_bytecode/java_bytecode_parse_lambdas/lambda_examples/" +
             compiler + "_classes/LocalLambdas.class",
           null_message_handler);
+        optionalt<java_bytecode_parse_treet> parse_tree =
+          java_bytecode_parse(bytecode, null_message_handler);
         WHEN("Parsing that class")
         {
           REQUIRE(parse_tree);
           REQUIRE(parse_tree->loading_successful);
           const java_bytecode_parse_treet::classt &parsed_class =
             parse_tree->parsed_class;
-          REQUIRE(parsed_class.attribute_bootstrapmethods_read);
           REQUIRE(parsed_class.lambda_method_handle_map.size() == 12);
 
           // Simple lambdas
@@ -650,17 +652,18 @@ SCENARIO(
         "A class that has lambdas as member variables from " + compiler +
         " compiler.")
       {
-        optionalt<java_bytecode_parse_treet> parse_tree = java_bytecode_parse(
+        java_bytecode_reft bytecode = java_bytecode_load(
           "./java_bytecode/java_bytecode_parse_lambdas/lambda_examples/" +
             compiler + "_classes/MemberLambdas.class",
           null_message_handler);
+        optionalt<java_bytecode_parse_treet> parse_tree =
+          java_bytecode_parse(bytecode, null_message_handler);
         WHEN("Parsing that class")
         {
           REQUIRE(parse_tree);
           REQUIRE(parse_tree->loading_successful);
           const java_bytecode_parse_treet::classt &parsed_class =
             parse_tree->parsed_class;
-          REQUIRE(parsed_class.attribute_bootstrapmethods_read);
           REQUIRE(parsed_class.lambda_method_handle_map.size() == 12);
 
           // Simple lambdas
@@ -984,17 +987,18 @@ SCENARIO(
         "variables from " +
         compiler + " compiler.")
       {
-        optionalt<java_bytecode_parse_treet> parse_tree = java_bytecode_parse(
+        java_bytecode_reft bytecode = java_bytecode_load(
           "./java_bytecode/java_bytecode_parse_lambdas/lambda_examples/" +
             compiler + "_classes/OuterMemberLambdas$Inner.class",
           null_message_handler);
+        optionalt<java_bytecode_parse_treet> parse_tree =
+          java_bytecode_parse(bytecode, null_message_handler);
         WHEN("Parsing that class")
         {
           REQUIRE(parse_tree);
           REQUIRE(parse_tree->loading_successful);
           const java_bytecode_parse_treet::classt &parsed_class =
             parse_tree->parsed_class;
-          REQUIRE(parsed_class.attribute_bootstrapmethods_read);
           REQUIRE(parsed_class.lambda_method_handle_map.size() == 3);
 
           // Field ref for getting the outer class

--- a/jbmc/unit/java_bytecode/java_bytecode_parser/parse_class_without_instructions.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parser/parse_class_without_instructions.cpp
@@ -62,7 +62,7 @@ SCENARIO(
       null_message_handler,
       true);
     optionalt<java_bytecode_parse_treet> loaded =
-      java_bytecode_parse(bytecode, null_message_handler);
+      java_bytecode_parse(bytecode, {}, null_message_handler);
     THEN("Loading should succeed")
     {
       REQUIRE(loaded);
@@ -96,7 +96,7 @@ SCENARIO(
       null_message_handler,
       false);
     optionalt<java_bytecode_parse_treet> loaded =
-      java_bytecode_parse(bytecode, null_message_handler);
+      java_bytecode_parse(bytecode, {}, null_message_handler);
     THEN("Loading should succeed")
     {
       REQUIRE(loaded);

--- a/jbmc/unit/java_bytecode/java_bytecode_parser/parse_class_without_instructions.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parser/parse_class_without_instructions.cpp
@@ -57,11 +57,12 @@ SCENARIO(
 {
   WHEN("Loading a class without instructions")
   {
-    auto loaded =
-      java_bytecode_parse(
-        "./java_bytecode/java_bytecode_parser/Trivial$Inner.class",
-        null_message_handler,
-        true);
+    java_bytecode_reft bytecode = java_bytecode_load(
+      "./java_bytecode/java_bytecode_parser/Trivial$Inner.class",
+      null_message_handler,
+      true);
+    optionalt<java_bytecode_parse_treet> loaded =
+      java_bytecode_parse(bytecode, null_message_handler);
     THEN("Loading should succeed")
     {
       REQUIRE(loaded);
@@ -90,11 +91,12 @@ SCENARIO(
 
   WHEN("Loading the same class normally")
   {
-    auto loaded =
-      java_bytecode_parse(
-        "./java_bytecode/java_bytecode_parser/Trivial$Inner.class",
-        null_message_handler,
-        false);
+    java_bytecode_reft bytecode = java_bytecode_load(
+      "./java_bytecode/java_bytecode_parser/Trivial$Inner.class",
+      null_message_handler,
+      false);
+    optionalt<java_bytecode_parse_treet> loaded =
+      java_bytecode_parse(bytecode, null_message_handler);
     THEN("Loading should succeed")
     {
       REQUIRE(loaded);

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -51,6 +51,7 @@ SRC = allocate_objects.cpp \
       nondet.cpp \
       object_factory_parameters.cpp \
       options.cpp \
+      parsable_string.cpp \
       parse_options.cpp \
       parser.cpp \
       pointer_offset_size.cpp \

--- a/src/util/parsable_string.cpp
+++ b/src/util/parsable_string.cpp
@@ -1,0 +1,59 @@
+// Copyright 2019 Diffblue Limited.
+
+/// \file
+/// A wrapper for strings that facilitates parsing
+
+#include "parsable_string.h"
+
+parsable_stringt
+parsable_stringt::split_at_first(char separator, const char *failure_error)
+{
+  std::size_t pos = underlying.find(separator, start_pos);
+  if(pos == std::string::npos)
+    throw parse_exceptiont(failure_error);
+  parsable_stringt result(underlying, start_pos, pos);
+  start_pos = pos + 1;
+  return result;
+}
+
+std::pair<parsable_stringt, char> parsable_stringt::split_at_first_of(
+  const std::string &separators,
+  const char *failure_error)
+{
+  std::size_t pos = underlying.find_first_of(separators, start_pos);
+  if(pos == std::string::npos)
+    throw parse_exceptiont(failure_error);
+  parsable_stringt result(underlying, start_pos, pos);
+  start_pos = pos + 1;
+  return { result, underlying[pos] };
+}
+
+char parsable_stringt::get_first(const char *failure_error)
+{
+  if(empty())
+    throw parse_exceptiont(failure_error);
+  char result = underlying[start_pos];
+  ++start_pos;
+  return result;
+}
+
+bool parsable_stringt::starts_with(char c)
+{
+  return !empty() && underlying[start_pos] == c;
+}
+
+bool parsable_stringt::try_skip(char c)
+{
+  if(starts_with(c))
+  {
+    ++start_pos;
+    return true;
+  }
+  return false;
+}
+
+void parsable_stringt::skip(char c, const char *failure_error)
+{
+  if(!try_skip(c))
+    throw parse_exceptiont(failure_error);
+}

--- a/src/util/parsable_string.h
+++ b/src/util/parsable_string.h
@@ -1,0 +1,100 @@
+// Copyright 2019 Diffblue Limited.
+
+/// \file
+/// A wrapper for strings that facilitates parsing
+
+#ifndef CPROVER_UTIL_PARSABLE_STRING_H
+#define CPROVER_UTIL_PARSABLE_STRING_H
+
+#include <stdexcept>
+#include <string>
+
+class parsable_stringt
+{
+private:
+  const std::string &underlying;
+  std::size_t start_pos;
+  std::size_t after_end_pos;
+
+  parsable_stringt(
+    const std::string &underlying,
+    std::size_t start_pos,
+    std::size_t after_end_pos)
+    : underlying(underlying), start_pos(start_pos), after_end_pos(after_end_pos)
+  {
+  }
+
+public:
+  /// Create an instance containing the whole of the given string
+  /// \param underlying The string to wrap in the input
+  // NOLINTNEXTLINE(runtime/explicit) - loses no information
+  parsable_stringt(const std::string &underlying)
+    : parsable_stringt(underlying, 0, underlying.size())
+  {
+  }
+
+  /// Get the input before the given separator, skip past the separator
+  /// \param separator The separator to look for
+  /// \param failure_error The message of the parse_exceptiont to throw if the
+  ///   separator character is not found
+  /// \return The input before the separator
+  parsable_stringt split_at_first(char separator, const char *failure_error);
+
+  /// Get the input before the first of the given separators is found, skip
+  ///   past the found separator
+  /// \param separators A string consisting of all the separators to look for
+  /// \param failure_error The message of the parse_exceptiont to throw if a
+  ///   separator character is not found
+  /// \return The input before the separator and the separator that was found
+  std::pair<parsable_stringt, char>
+  split_at_first_of(const std::string &separators, const char *failure_error);
+
+  /// Test whether the input is empty
+  /// \return true if the input is empty
+  bool empty() const
+  {
+    return start_pos >= after_end_pos;
+  }
+
+  /// Get the character at the start of the input and move to the next character
+  /// \param failure_error The message of the parse_exceptiont to throw if the
+  ///   input is empty
+  /// \return The character at the start of the input
+  char get_first(const char *failure_error);
+
+  /// Test whether the input starts with the given character without moving
+  ///   forward in the input
+  /// \param c The character to look for at the start of the input
+  /// \return true if the given character is found
+  bool starts_with(char c);
+
+  /// Try to skip the given character at the front of the input
+  /// \param c The character to skip
+  /// \return true if the character was found at the start of the input
+  bool try_skip(char c);
+
+  /// Skip the given character at the front of the input
+  /// \param c The character to skip
+  /// \param failure_error The message of the parse_exceptiont to throw if the
+  ///   character is not found
+  /// \throws parse_exceptiont if the character is not found
+  void skip(char c, const char *failure_error);
+
+  /// Default string extraction
+  /// \return The substring represented by this instance
+  operator std::string() const
+  {
+    return underlying.substr(start_pos, after_end_pos - start_pos);
+  }
+};
+
+/// An exception that is raised for parse errors.
+class parse_exceptiont : public std::logic_error
+{
+public:
+  explicit parse_exceptiont(const std::string &arg) : std::logic_error(arg)
+  {
+  }
+};
+
+#endif // CPROVER_UTIL_PARSABLE_STRING_H


### PR DESCRIPTION
This is a draft PR for the Java type parser.
In order to properly interpret generic parameters from outer classes it is necessary to load the outer class first to find the bounds of the generic parameter. The bytecode parser has thus been split into two phases, one that loads the bytecode just enough to find the outer class and a second phase that uses type information to parse this loaded bytecode after outer classes have been loaded and parsed.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- N/A My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- N/A White-space or formatting changes outside the feature-related changed lines are in commits of their own.