### PR TITLE
GDB pretty-printers v2

### DIFF
--- a/scripts/pretty-printers/gdb/pretty_printers.py
+++ b/scripts/pretty-printers/gdb/pretty_printers.py
@@ -72,12 +72,10 @@ def get_node_value(data_ref):
     if id_value:
         if has_children:
             return "[{0}]".format(id_value)
-        else:
-            return "\"{0}\"".format(id_value)
     elif has_children:
         return "[...]"
 
-    return "\"\""
+    return None
 
 
 def get_id(data_ref):
@@ -148,6 +146,13 @@ class IrepPrettyPrinter:
         we return a single child with the value of the node.
         """
 
+        if has_children_nodes(self.val):
+            if self.clion_representation:
+                yield "ID", self.val["data"]
+            else:
+                yield "ID key", "ID"
+                yield "ID value", self.val["data"]
+
         sub = self.val["sub"]
         sub_count = 0
         item = sub["_M_impl"]["_M_start"]
@@ -158,9 +163,12 @@ class IrepPrettyPrinter:
             iter_item = item.dereference()
 
             if self.clion_representation:
+                item_deref = iter_item["data"].referenced_value()
                 nested_id = get_node_value(iter_item["data"].referenced_value())
                 if nested_id:
                     node_key = "{0}: {1}".format(node_key, nested_id)
+                else:
+                    iter_item = item_deref["data"]
 
                 yield node_key, iter_item
             else:
@@ -188,9 +196,12 @@ class IrepPrettyPrinter:
 
             iter_item = result["second"]
             if self.clion_representation:
-                nested_id = get_node_value(iter_item["data"].referenced_value())
+                item_deref = iter_item["data"].referenced_value()
+                nested_id = get_node_value(item_deref)
                 if nested_id:
                     node_key = "{0}: {1}".format(node_key, nested_id)
+                else:
+                    iter_item = item_deref["data"]
 
                 yield node_key, iter_item
             else:

--- a/scripts/pretty-printers/gdb/pretty_printers.py
+++ b/scripts/pretty-printers/gdb/pretty_printers.py
@@ -16,6 +16,7 @@ except JSONDecodeError as e:
 except Exception as e:
     print("Error attempting to load configuration. Exception: {1}".format(options_path, e))
 
+
 def get_option(value):
     return pretty_printer_options.get(value, None)
 
@@ -59,14 +60,14 @@ def deconstruct_dstring(val):
 
 
 def has_children_nodes(data_ref):
+    """ Does this irept have any children. """
     has_subs = data_ref["sub"]["_M_impl"]["_M_start"] != data_ref["sub"]["_M_impl"]["_M_finish"]
     has_named_subs = data_ref["named_sub"]["_M_t"]["_M_impl"]["_M_node_count"] > 0
     return has_subs or has_named_subs
 
 
 def get_node_value(data_ref):
-    """ If the item has children, wrap it in [...], if it's just a
-        value wrap it in quotes to help differentiate. """
+    """ If the item has children, wrap it in [...]. """
     has_children = has_children_nodes(data_ref)
     id_value = get_id(data_ref)
     if id_value:
@@ -79,6 +80,7 @@ def get_node_value(data_ref):
 
 
 def get_id(data_ref):
+    """ Return the ID of a node as a string. """
     _, nested_value = deconstruct_dstring(data_ref["data"])
     if nested_value:
         return nested_value.replace("\"", "\\\"")
@@ -86,9 +88,21 @@ def get_id(data_ref):
     return ""
 
 
-# Class for pretty-printing dstringt
+def untypedef(type_obj):
+    """ Strip type definitions off type if required. """
+    if (type_obj.code == gdb.TYPE_CODE_REF or
+            type_obj.code == getattr(gdb, 'TYPE_CODE_RVALUE_REF', None)):
+
+        type_obj = type_obj.target()
+
+    if type_obj.code == gdb.TYPE_CODE_TYPEDEF:
+        type_obj = type_obj.strip_typedefs()
+
+    return type_obj
+
+
 class DStringPrettyPrinter:
-    "Print a dstringt"
+    """Class for printing a dstringt"""
 
     def __init__(self, val):
         self.val = val
@@ -119,10 +133,13 @@ def find_type(type, name):
 
 class IrepPrettyPrinter:
     """
-    Print an irept.
+    Print an irept. Has two modes.
 
-    This is an array GDB type as everything in the tree is key->value, so it
-    works better than doing a map type with individual key/value entries.
+    CLion mode: prints like a vector, with each elements IDE-shown index
+    being the name of a named-sub, or the actual index of a normal sub.
+
+    GDB mode: prints like a map, and just prints key/value pairs of both sub
+    and named sub.
     """
 
     def __init__(self, val):
@@ -136,16 +153,11 @@ class IrepPrettyPrinter:
             return "Exception pretty printing irept"
 
     def children(self):
-        """
-        This method tells the pretty-printer what children this object can
-        return. Because we've stated this is a array then we've also stated that
-        irept is a container that holds other values.
+        """ Method that tells GDB what children this object has. """
 
-        This makes things awkward because some ireps are not actually containers
-        of children but values themselves. It's hard to represent that, so instead
-        we return a single child with the value of the node.
-        """
-
+        # Every node should show their ID. Without this the root node
+        # misses any identifier information even if every other child
+        # has [...] to tell you what type it is.
         if has_children_nodes(self.val):
             if self.clion_representation:
                 yield "ID", self.val["data"]
@@ -153,20 +165,24 @@ class IrepPrettyPrinter:
                 yield "ID key", "ID"
                 yield "ID value", self.val["data"]
 
+        # Loop through our subs, print out the index as the key.
         sub = self.val["sub"]
         sub_count = 0
         item = sub["_M_impl"]["_M_start"]
         finish = sub["_M_impl"]["_M_finish"]
         while item != finish:
-            # The original key is just the index, as that's all we have.
+
             node_key = "{}".format(sub_count)
             iter_item = item.dereference()
 
+            # In CLion mode we're considered a vector, which takes one return tuple
+            # of (key, value). In map mode, it expects two return tuples,
+            # (key identifier, key) and (value identifier, value).
             if self.clion_representation:
                 item_deref = iter_item["data"].referenced_value()
                 nested_id = get_node_value(iter_item["data"].referenced_value())
                 if nested_id:
-                    node_key = "{0}: {1}".format(node_key, nested_id)
+                    node_key = "{0} {1}".format(node_key, nested_id)
                 else:
                     iter_item = item_deref["data"]
 
@@ -178,11 +194,14 @@ class IrepPrettyPrinter:
             sub_count += 1
             item += 1
 
+        # Loop through our named subs, using the sub name as the key.
         named_sub = self.val["named_sub"]
         size = named_sub["_M_t"]["_M_impl"]["_M_node_count"]
         node = named_sub["_M_t"]["_M_impl"]["_M_header"]["_M_left"]
         named_sub_count = 0
         while named_sub_count != size:
+
+            # Wind our way through structure internals to get the data.
             rep_type = find_type(named_sub.type, "_Rep_type")
             link_type = find_type(rep_type, "_Link_type")
             node_type = link_type.strip_typedefs()
@@ -194,12 +213,13 @@ class IrepPrettyPrinter:
             _, sub_name = deconstruct_dstring(result["first"])
             node_key = sub_name.replace("\"", "\\\"")
 
+            # Print out {name} {value}
             iter_item = result["second"]
             if self.clion_representation:
                 item_deref = iter_item["data"].referenced_value()
                 nested_id = get_node_value(item_deref)
                 if nested_id:
-                    node_key = "{0}: {1}".format(node_key, nested_id)
+                    node_key = "{0} {1}".format(node_key, nested_id)
                 else:
                     iter_item = item_deref["data"]
 
@@ -233,6 +253,18 @@ class IrepPrettyPrinter:
 
 
 class InstructionPrettyPrinter:
+    """
+        instructiont causes problems with the default STL pretty-printers when
+        they exist within collections. It attempts to perform a normal GDB pretty-print
+        of the object as a 'summary' from a pointer, which then comes up against our
+        exprt's and immediately times out and takes the debugging session with it.
+
+        This pretty-printer fixes that bug, but comes with the unfortunate
+        side-effect that you can't expand an instructiont in the CLion window, and
+        instead have to perform a watch on it to look at internal values.
+
+        It's the best solution out of a bunch of bad ones for now.
+    """
     def __init__(self, val):
         self.val = val
 
@@ -249,16 +281,19 @@ class InstructionPrettyPrinter:
         return "string"
 
 
-def untypedef(type_obj):
-    if (type_obj.code == gdb.TYPE_CODE_REF or
-            type_obj.code == getattr(gdb, 'TYPE_CODE_RVALUE_REF', None)):
+# If you change the name of this make sure to change install.py too.
+def load_cbmc_printers():
+    gdb.printing.register_pretty_printer(None, child_of_irept)
 
-        type_obj = type_obj.target()
+    printers = gdb.printing.RegexpCollectionPrettyPrinter("CBMC")
 
-    if type_obj.code == gdb.TYPE_CODE_TYPEDEF:
-        type_obj = type_obj.strip_typedefs()
+    # First argument is the name of the pretty-printer, second is a regex match for which type
+    # it should be applied too, third is the class that should be called to pretty-print that type.
+    printers.add_printer("dstringt", "^(?:dstringt|irep_idt)", DStringPrettyPrinter)
+    printers.add_printer("instructiont", "^goto_programt::instructiont", InstructionPrettyPrinter)
 
-    return type_obj
+    # We aren't associating with a particular object file, so pass in None instead of gdb.current_objfile()
+    gdb.printing.register_pretty_printer(None, printers, replace=True)
 
 
 def child_of_irept(val):
@@ -271,8 +306,8 @@ def child_of_irept(val):
         return
 
     if type.code == gdb.TYPE_CODE_STRUCT \
-        or type.code == gdb.TYPE_CODE_ENUM \
-        or type.code == gdb.TYPE_CODE_UNION:
+            or type.code == gdb.TYPE_CODE_ENUM \
+            or type.code == gdb.TYPE_CODE_UNION:
 
         hierarchy_types = set()
         while type is not None:
@@ -289,18 +324,3 @@ def child_of_irept(val):
             return IrepPrettyPrinter(val)
 
     return None
-
-
-# If you change the name of this make sure to change install.py too.
-def load_cbmc_printers():
-    gdb.printing.register_pretty_printer(None, child_of_irept)
-
-    printers = gdb.printing.RegexpCollectionPrettyPrinter("CBMC")
-
-    # First argument is the name of the pretty-printer, second is a regex match for which type
-    # it should be applied too, third is the class that should be called to pretty-print that type.
-    printers.add_printer("dstringt", "^(?:dstringt|irep_idt)", DStringPrettyPrinter)
-    printers.add_printer("instructiont", "^goto_programt::instructiont", InstructionPrettyPrinter)
-
-    # We aren't associating with a particular object file, so pass in None instead of gdb.current_objfile()
-    gdb.printing.register_pretty_printer(None, printers, replace=True)

--- a/scripts/pretty-printers/gdb/pretty_printers.py
+++ b/scripts/pretty-printers/gdb/pretty_printers.py
@@ -13,7 +13,8 @@ try:
         pretty_printer_options = json.load(json_file)
 except JSONDecodeError as e:
     print("Options file at {0} failed to load. Exception: {1}".format(options_path, e.msg))
-
+except Exception as e:
+    print("Error attempting to load configuration. Exception: {1}".format(options_path, e))
 
 def get_option(value):
     return pretty_printer_options.get(value, None)


### PR DESCRIPTION
This cleans up the final few bits of the irep pretty-printer that was still outstanding. This is what it now looks like:

![pretty_printer_phase2](https://user-images.githubusercontent.com/37293497/65331333-8399c600-dbb4-11e9-9a02-0177fb63fcab.png)

(That's part of a seal in the background, pay it no mind)

It's a little bit more verbose but far more consistent with how other things look and work in the IDE. Means you can just ctrl-c the value now and it'll work properly, as well as delegating the printing to the dstring pretty-printer, etc. 

Unless bugs crop up this is now considered finished.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.