### PR TITLE
remove deprecated bison option

### DIFF
--- a/src/jsil/parser.y
+++ b/src/jsil/parser.y
@@ -114,7 +114,6 @@ extern char *yyjsiltext;
 
 %start program
 
-%error-verbose
 %expect 0
 
 %%

--- a/src/xmllang/parser.y
+++ b/src/xmllang/parser.y
@@ -26,8 +26,6 @@ int yyxmlerror(const std::string &error)
 #endif
 %}
 
-%error-verbose
-
 %union {char *s;}
 
 %token STARTXMLDECL


### PR DESCRIPTION
%error-verbose is deprecated since bison 3.0; this commit replaces it by
%define parse.error verbose

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
