### PR TITLE
Do not ignore invalid command line options in JSON/XML interface [TG-9049]

### DIFF
--- a/regression/cbmc/json-interface1/test_wrong_flag.desc
+++ b/regression/cbmc/json-interface1/test_wrong_flag.desc
@@ -1,0 +1,6 @@
+CORE broken-smt-backend
+--json-interface
+< test_wrong_flag.json
+^EXIT=6$
+^SIGNAL=0$
+unknown command line option

--- a/regression/cbmc/json-interface1/test_wrong_flag.json
+++ b/regression/cbmc/json-interface1/test_wrong_flag.json
@@ -1,0 +1,15 @@
+{
+  "arguments": [
+    "main.c"
+  ],
+  "options": {
+    "function": "foo",
+    "unwind": 3,
+    "property": [
+      "foo.assertion.1",
+      "foo.assertion.3"
+    ],
+    "unknown-flag": true,
+    "show-properties": false
+  }
+}

--- a/regression/cbmc/json-interface1/test_wrong_option.desc
+++ b/regression/cbmc/json-interface1/test_wrong_option.desc
@@ -1,0 +1,6 @@
+CORE broken-smt-backend
+--json-interface
+< test_wrong_option.json
+^EXIT=6$
+^SIGNAL=0$
+unknown command line option

--- a/regression/cbmc/json-interface1/test_wrong_option.json
+++ b/regression/cbmc/json-interface1/test_wrong_option.json
@@ -1,0 +1,15 @@
+{
+  "arguments": [
+    "main.c"
+  ],
+  "options": {
+    "function": "foo",
+    "unwind": 3,
+    "unknown-option": [
+      "foo.assertion.1",
+      "foo.assertion.3"
+    ],
+    "trace": true,
+    "show-properties": false
+  }	
+}

--- a/regression/cbmc/xml-interface1/test_wrong_flag.desc
+++ b/regression/cbmc/xml-interface1/test_wrong_flag.desc
@@ -1,0 +1,6 @@
+CORE
+--xml-interface
+< test_wrong_flag.xml
+^EXIT=6$
+^SIGNAL=0$
+unknown command line option

--- a/regression/cbmc/xml-interface1/test_wrong_flag.xml
+++ b/regression/cbmc/xml-interface1/test_wrong_flag.xml
@@ -1,0 +1,9 @@
+<options>
+  <valueOption actual="main.c"/>
+  <valueOption name="function" actual="foo"/>
+  <valueOption name="unwind" actual="3"/>
+  <valueOption name="property" actual="foo.assertion.1"/>
+  <valueOption name="property" actual="foo.assertion.3"/>
+  <flagOption name="trace" actual="on"/>
+  <flagOption name="unknown-flag" actual="off"/>
+</options>

--- a/regression/cbmc/xml-interface1/test_wrong_option.desc
+++ b/regression/cbmc/xml-interface1/test_wrong_option.desc
@@ -1,0 +1,6 @@
+CORE
+--xml-interface
+< test_wrong_option.xml
+^EXIT=6$
+^SIGNAL=0$
+unknown command line option

--- a/regression/cbmc/xml-interface1/test_wrong_option.xml
+++ b/regression/cbmc/xml-interface1/test_wrong_option.xml
@@ -1,0 +1,9 @@
+<options>
+  <valueOption actual="main.c"/>
+  <valueOption name="function" actual="foo"/>
+  <valueOption name="unknown-option" actual="3"/>
+  <valueOption name="property" actual="foo.assertion.1"/>
+  <valueOption name="property" actual="foo.assertion.3"/>
+  <flagOption name="trace" actual="on"/>
+  <flagOption name="show-properties" actual="off"/>
+</options>

--- a/src/goto-cc/goto_cc_cmdline.h
+++ b/src/goto-cc/goto_cc_cmdline.h
@@ -34,16 +34,16 @@ public:
   // never fails, will add if not found
   std::size_t get_optnr(const std::string &option);
 
-  void set(const std::string &opt, const std::string &value)
+  void set(const std::string &opt, const std::string &value) override
   {
     std::size_t nr=get_optnr(opt);
     options[nr].isset=true;
     options[nr].values.push_back(value);
   }
 
-  void set(const std::string &opt)
+  void set(const std::string &opt, bool value = true) override
   {
-    options[get_optnr(opt)].isset=true;
+    options[get_optnr(opt)].isset = value;
   }
 
   // This lets you distinguish input file name arguments

--- a/src/util/cmdline.cpp
+++ b/src/util/cmdline.cpp
@@ -52,12 +52,12 @@ std::string cmdlinet::get_value(char option) const
     return "";
 }
 
-void cmdlinet::set(const std::string &option)
+void cmdlinet::set(const std::string &option, bool value)
 {
   auto i=getoptnr(option);
 
   if(i.has_value())
-    options[*i].isset=true;
+    options[*i].isset = value;
 
   // otherwise ignore
 }

--- a/src/util/cmdline.cpp
+++ b/src/util/cmdline.cpp
@@ -8,6 +8,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "cmdline.h"
 
+#include <util/exception_utils.h>
 #include <util/invariant.h>
 
 cmdlinet::cmdlinet()
@@ -58,8 +59,11 @@ void cmdlinet::set(const std::string &option, bool value)
 
   if(i.has_value())
     options[*i].isset = value;
-
-  // otherwise ignore
+  else
+  {
+    throw invalid_command_line_argument_exceptiont(
+      "unknown command line option", option);
+  }
 }
 
 void cmdlinet::set(const std::string &option, const std::string &value)
@@ -71,8 +75,11 @@ void cmdlinet::set(const std::string &option, const std::string &value)
     options[*i].isset=true;
     options[*i].values.push_back(value);
   }
-
-  // otherwise ignore
+  else
+  {
+    throw invalid_command_line_argument_exceptiont(
+      "unknown command line option", option);
+  }
 }
 
 static std::list<std::string> immutable_empty_list;

--- a/src/util/cmdline.h
+++ b/src/util/cmdline.h
@@ -32,7 +32,7 @@ public:
 
   virtual bool isset(char option) const;
   virtual bool isset(const char *option) const;
-  virtual void set(const std::string &option);
+  virtual void set(const std::string &option, bool value = true);
   virtual void set(const std::string &option, const std::string &value);
   virtual void clear();
 

--- a/src/xmllang/xml_interface.cpp
+++ b/src/xmllang/xml_interface.cpp
@@ -39,10 +39,7 @@ static void get_xml_options(const xmlt &xml, cmdlinet &cmdline)
   }
   else if(xml.name == "flagOption")
   {
-    if(xml.get_attribute("actual") == "on")
-    {
-      cmdline.set(xml.get_attribute("name"));
-    }
+    cmdline.set(xml.get_attribute("name"), xml.get_attribute("actual") == "on");
   }
 }
 

--- a/src/xmllang/xml_interface.cpp
+++ b/src/xmllang/xml_interface.cpp
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <iostream>
 
 #include <util/cmdline.h>
+#include <util/exception_utils.h>
 #include <util/message.h>
 
 #include <xmllang/xml_parser.h>
@@ -51,11 +52,24 @@ void xml_interface(cmdlinet &cmdline, message_handlert &message_handler)
 
     parse_xml(std::cin, "", message_handler, xml);
 
-    get_xml_options(xml, cmdline);
+    // We have to catch here because command line options are
+    // parsed in the constructor of parse_optionst and not in main()
+    try
+    {
+      get_xml_options(xml, cmdline);
 
-    // Add this so that it gets propagated into optionst;
-    // the ui_message_handlert::uit has already been set on the basis
-    // of the xml-interface flag.
-    cmdline.set("xml-ui");
+      // Add this so that it gets propagated into optionst;
+      // the ui_message_handlert::uit has already been set on the basis
+      // of the xml-interface flag.
+      cmdline.set("xml-ui");
+    }
+    catch(const invalid_command_line_argument_exceptiont &e)
+    {
+      messaget log(message_handler);
+      log.error() << e.what() << messaget::eom;
+
+      // make sure we fail with a usage error
+      cmdline.clear();
+    }
   }
 }


### PR DESCRIPTION
- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
