### PR TITLE
Fix end iterator dereference

### DIFF
--- a/src/goto-instrument/cover_instrument_other.cpp
+++ b/src/goto-instrument/cover_instrument_other.cpp
@@ -75,10 +75,19 @@ void cover_instrument_end_of_function(
   const irep_idt &function_id,
   goto_programt &goto_program)
 {
-  auto if_it = goto_program.instructions.end();
-  while(!if_it->is_function_call())
-    if_it--;
-  if_it++;
+  const auto last_function_call = std::find_if(
+    goto_program.instructions.rbegin(),
+    goto_program.instructions.rend(),
+    [](const goto_programt::instructiont &instruction) {
+      return instruction.is_function_call();
+    });
+  INVARIANT(
+    last_function_call != goto_program.instructions.rend(),
+    "Goto program should have at least one function call");
+  INVARIANT(
+    last_function_call != goto_program.instructions.rbegin(),
+    "Goto program shouldn't end with a function call");
+  const auto if_it = last_function_call.base();
   const std::string &comment =
     "additional goal to ensure reachability of end of function";
   goto_program.insert_before_swap(if_it);

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -16,6 +16,7 @@ SRC += analyses/ai/ai.cpp \
        analyses/does_remove_const/is_type_at_least_as_const_as.cpp \
        big-int/big-int.cpp \
        compound_block_locations.cpp \
+       goto-instrument/cover_instrument.cpp \
        goto-instrument/cover/cover_only.cpp \
        goto-programs/goto_model_function_type_consistency.cpp \
        goto-programs/goto_program_assume.cpp \

--- a/unit/goto-instrument/cover_instrument.cpp
+++ b/unit/goto-instrument/cover_instrument.cpp
@@ -1,0 +1,28 @@
+/*******************************************************************\
+
+Module: Tests for coverage instrumentation
+
+Author: Diffblue Ltd
+
+\*******************************************************************/
+
+#include <goto-instrument/cover_instrument.h>
+#include <testing-utils/use_catch.h>
+
+TEST_CASE("cover_intrument_end_of_function", "[core]")
+{
+  // Arrange
+  goto_programt goto_program{};
+  goto_program.add(
+    goto_programt::make_function_call(code_function_callt({}, {})));
+  goto_program.add(
+    goto_programt::make_function_call(code_function_callt({}, {})));
+  goto_program.add(goto_programt::make_return());
+  // Act
+  cover_instrument_end_of_function("foo", goto_program);
+  // Assert
+  REQUIRE(goto_program.instructions.size() == 4);
+  const auto newly_inserted = std::next(goto_program.instructions.begin(), 2);
+  REQUIRE(newly_inserted->is_assert());
+  REQUIRE(newly_inserted->source_location.get_function() == "foo");
+}

--- a/unit/goto-instrument/module_dependencies.txt
+++ b/unit/goto-instrument/module_dependencies.txt
@@ -1,0 +1,3 @@
+goto-instrument
+testing-utils
+util


### PR DESCRIPTION
Detected by VS2017 Debug mode
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own. (There are none)

The reason why it worked was that it's unlikely for the end iterator to point to a memory address with the exact required value, so it was skipped over in the while loop.