### PR TITLE
SMT2 parser: use hash tables instead of if() ... else...

### DIFF
--- a/src/solvers/smt2/smt2_parser.h
+++ b/src/solvers/smt2/smt2_parser.h
@@ -10,6 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_SOLVERS_SMT2_SMT2_PARSER_H
 
 #include <map>
+#include <unordered_map>
 
 #include <util/mathematical_types.h>
 #include <util/std_expr.h>
@@ -22,6 +23,7 @@ public:
   explicit smt2_parsert(std::istream &_in)
     : exit(false), smt2_tokenizer(_in), parenthesis_level(0)
   {
+    setup_commands();
   }
 
   virtual ~smt2_parsert() = default;
@@ -82,10 +84,6 @@ protected:
   std::size_t parenthesis_level;
   smt2_tokenizert::tokent next_token();
 
-  void command_sequence();
-
-  virtual void command(const std::string &);
-
   // for let/quantifier bindings, function parameters
   using renaming_mapt=std::map<irep_idt, irep_idt>;
   renaming_mapt renaming_map;
@@ -116,7 +114,6 @@ protected:
     }
   };
 
-  void ignore_command();
   exprt expression();
   exprt function_application();
   exprt function_application_ieee_float_op(
@@ -144,6 +141,14 @@ protected:
 
   /// Apply typecast to unsignedbv to given expression
   exprt cast_bv_to_unsigned(const exprt &);
+
+  // hashtable for all commands
+  std::unordered_map<std::string, std::function<void()>> commands;
+
+  void command_sequence();
+  void command(const std::string &);
+  void ignore_command();
+  void setup_commands();
 };
 
 #endif // CPROVER_SOLVERS_SMT2_SMT2_PARSER_H

--- a/src/solvers/smt2/smt2_parser.h
+++ b/src/solvers/smt2/smt2_parser.h
@@ -24,6 +24,7 @@ public:
     : exit(false), smt2_tokenizer(_in), parenthesis_level(0)
   {
     setup_commands();
+    setup_sorts();
   }
 
   virtual ~smt2_parsert() = default;
@@ -121,7 +122,6 @@ protected:
     const exprt::operandst &);
   exprt function_application_ieee_float_eq(const exprt::operandst &);
   exprt function_application_fp(const exprt::operandst &);
-  typet sort();
   exprt::operandst operands();
   typet function_signature_declaration();
   signature_with_parameter_idst function_signature_definition();
@@ -141,6 +141,11 @@ protected:
 
   /// Apply typecast to unsignedbv to given expression
   exprt cast_bv_to_unsigned(const exprt &);
+
+  // sorts
+  typet sort();
+  std::unordered_map<std::string, std::function<typet()>> sorts;
+  void setup_sorts();
 
   // hashtable for all commands
   std::unordered_map<std::string, std::function<void()>> commands;

--- a/src/solvers/smt2/smt2_parser.h
+++ b/src/solvers/smt2/smt2_parser.h
@@ -25,9 +25,8 @@ public:
   {
     setup_commands();
     setup_sorts();
+    setup_expressions();
   }
-
-  virtual ~smt2_parsert() = default;
 
   void parse()
   {
@@ -115,6 +114,9 @@ protected:
     }
   };
 
+  // expressions
+  std::unordered_map<std::string, std::function<exprt()>> expressions;
+  void setup_expressions();
   exprt expression();
   exprt function_application();
   exprt function_application_ieee_float_op(


### PR DESCRIPTION
This refactors the SMT2 parser to use hash tables instead of chains of `if()...else if()...` for commands, sorts and expressions.

This enables extensions, and may have a performance benefit as the number of commands/expressions/sorts grows.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
