### PR TITLE
Unit tests: remove pointless command-line argument [TG-2708]

### DIFF
--- a/jbmc/unit/java-testing-utils/load_java_class.cpp
+++ b/jbmc/unit/java-testing-utils/load_java_class.cpp
@@ -170,11 +170,6 @@ symbol_tablet load_java_class(
   free_form_cmdlinet command_line;
   command_line.add_flag("no-lazy-methods");
   command_line.add_flag("no-refine-strings");
-  // TODO(tkiley): This doesn't do anything as "java-cp-include-files" is an
-  // TODO(tkiley): unknown argument. This could be changed by using the
-  // TODO(tkiley): free_form_cmdlinet however this causes some tests to fail.
-  // TODO(tkiley): TG-2708 to investigate and fix
-  command_line.set("java-cp-include-files", class_path);
   return load_java_class(
     java_class_name, class_path, main, std::move(java_lang), command_line);
 }


### PR DESCRIPTION
Setting java-cp-include-files requires registering the option properly,
but there's no point in doing so as its only purpose is to limit the classes
explored by java_class_loadert, and limiting it to the entire classpath is
equivalent to not limiting it at all.