### PR TITLE
Remove symbol_module_map from `symbol_tablet`

### DIFF
--- a/src/util/journalling_symbol_table.h
+++ b/src/util/journalling_symbol_table.h
@@ -51,8 +51,7 @@ private:
   explicit journalling_symbol_tablet(symbol_table_baset &base_symbol_table)
     : symbol_table_baset(
         base_symbol_table.symbols,
-        base_symbol_table.symbol_base_map,
-        base_symbol_table.symbol_module_map),
+        base_symbol_table.symbol_base_map),
       base_symbol_table(base_symbol_table)
   {
   }
@@ -61,10 +60,7 @@ public:
   journalling_symbol_tablet(const journalling_symbol_tablet &other) = delete;
 
   journalling_symbol_tablet(journalling_symbol_tablet &&other)
-    : symbol_table_baset(
-        other.symbols,
-        other.symbol_base_map,
-        other.symbol_module_map),
+    : symbol_table_baset(other.symbols, other.symbol_base_map),
       base_symbol_table(other.base_symbol_table),
       inserted(std::move(other.inserted)),
       updated(std::move(other.updated)),

--- a/src/util/symbol_table.h
+++ b/src/util/symbol_table.h
@@ -21,26 +21,18 @@ class symbol_tablet : public symbol_table_baset
 private:
   symbolst internal_symbols;
   symbol_base_mapt internal_symbol_base_map;
-  symbol_module_mapt internal_symbol_module_map;
 
 public:
   symbol_tablet()
-    : symbol_table_baset(
-        internal_symbols,
-        internal_symbol_base_map,
-        internal_symbol_module_map)
+    : symbol_table_baset(internal_symbols, internal_symbol_base_map)
   {
   }
 
   /// Copy constructor.
   symbol_tablet(const symbol_tablet &other)
-    : symbol_table_baset(
-        internal_symbols,
-        internal_symbol_base_map,
-        internal_symbol_module_map),
+    : symbol_table_baset(internal_symbols, internal_symbol_base_map),
       internal_symbols(other.internal_symbols),
-      internal_symbol_base_map(other.internal_symbol_base_map),
-      internal_symbol_module_map(other.internal_symbol_module_map)
+      internal_symbol_base_map(other.internal_symbol_base_map)
   {
   }
 
@@ -53,13 +45,9 @@ public:
 
   /// Move constructor.
   symbol_tablet(symbol_tablet &&other)
-    : symbol_table_baset(
-        internal_symbols,
-        internal_symbol_base_map,
-        internal_symbol_module_map),
+    : symbol_table_baset(internal_symbols, internal_symbol_base_map),
       internal_symbols(std::move(other.internal_symbols)),
-      internal_symbol_base_map(std::move(other.internal_symbol_base_map)),
-      internal_symbol_module_map(std::move(other.internal_symbol_module_map))
+      internal_symbol_base_map(std::move(other.internal_symbol_base_map))
   {
   }
 
@@ -68,7 +56,6 @@ public:
   {
     internal_symbols = std::move(other.internal_symbols);
     internal_symbol_base_map = std::move(other.internal_symbol_base_map);
-    internal_symbol_module_map = std::move(other.internal_symbol_module_map);
     return *this;
   }
 
@@ -78,7 +65,6 @@ public:
   {
     internal_symbols.swap(other.internal_symbols);
     internal_symbol_base_map.swap(other.internal_symbol_base_map);
-    internal_symbol_module_map.swap(other.internal_symbol_module_map);
   }
 
 public:
@@ -105,7 +91,6 @@ public:
   {
     internal_symbols.clear();
     internal_symbol_base_map.clear();
-    internal_symbol_module_map.clear();
   }
 
   virtual iteratort begin() override

--- a/src/util/symbol_table_base.h
+++ b/src/util/symbol_table_base.h
@@ -12,7 +12,6 @@
 #include "symbol.h"
 
 typedef std::multimap<irep_idt, irep_idt> symbol_base_mapt;
-typedef std::multimap<irep_idt, irep_idt> symbol_module_mapt;
 
 class symbol_tablet;
 
@@ -26,16 +25,12 @@ public:
 public:
   const symbolst &symbols;
   const symbol_base_mapt &symbol_base_map;
-  const symbol_module_mapt &symbol_module_map;
 
 public:
   symbol_table_baset(
     const symbolst &symbols,
-    const symbol_base_mapt &symbol_base_map,
-    const symbol_module_mapt &symbol_module_map)
-    : symbols(symbols),
-      symbol_base_map(symbol_base_map),
-      symbol_module_map(symbol_module_map)
+    const symbol_base_mapt &symbol_base_map)
+    : symbols(symbols), symbol_base_map(symbol_base_map)
   {
   }
 

--- a/src/util/symbol_table_builder.h
+++ b/src/util/symbol_table_builder.h
@@ -20,17 +20,13 @@ public:
   explicit symbol_table_buildert(symbol_table_baset &base_symbol_table)
     : symbol_table_baset(
         base_symbol_table.symbols,
-        base_symbol_table.symbol_base_map,
-        base_symbol_table.symbol_module_map),
+        base_symbol_table.symbol_base_map),
       base_symbol_table(base_symbol_table)
   {
   }
 
   symbol_table_buildert(symbol_table_buildert &&other)
-    : symbol_table_baset(
-        other.symbols,
-        other.symbol_base_map,
-        other.symbol_module_map),
+    : symbol_table_baset(other.symbols, other.symbol_base_map),
       base_symbol_table(other.base_symbol_table)
   {
   }

--- a/unit/util/symbol_table.cpp
+++ b/unit/util/symbol_table.cpp
@@ -79,22 +79,6 @@ SCENARIO(
       // Reset symbol to a valid base_name after the previous test
       transformed_symbol.base_name = "TestBase";
     }
-    WHEN(
-      "A symbol module identifier is transformed without updating the module "
-      "mapping")
-    {
-      symbolt &transformed_symbol = symbol_table.get_writeable_ref(symbol_name);
-      transformed_symbol.module = "TransformTestModule";
-
-      THEN("validate() should throw an exception")
-      {
-        REQUIRE_THROWS_AS(
-          symbol_table.validate(validation_modet::EXCEPTION),
-          incorrect_goto_program_exceptiont);
-      }
-      // Reset symbol to a valid module name
-      transformed_symbol.module = "TestModule";
-    }
   }
 }
 


### PR DESCRIPTION
The `symbol_module_map` is not referenced from outside of the symbol
table. It is only read from inside the symbol table for consistency
checking purposes. Therefore the `symbol_module_map` and all code
referring to it can be removed resulting in less code to maintain.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~ No user visible feature or behaviour.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] ~~My commit message includes data points confirming performance improvements (if claimed).~~ Non claimed.
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
