### PR TITLE
ansi-c: explicit casts from structs to structs

### DIFF
--- a/regression/ansi-c/Initializer_cast1/main.c
+++ b/regression/ansi-c/Initializer_cast1/main.c
@@ -27,6 +27,9 @@ int main()
   // struct
   s=(struct S){ 1, 2, 3, 4, 5, 6 };
 
+  // do it twice
+  s = (struct S)(struct S){1, 2, 3, 4, 5, 6};
+
   // union
   u=(union U)s;
 

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1038,10 +1038,10 @@ void c_typecheck_baset::typecheck_expr_typecast(exprt &expr)
     op.swap(comma_expr);
   }
 
-  const typet expr_type=follow(expr.type());
+  const typet expr_type = expr.type();
 
   if(
-    expr_type.id() == ID_union && expr_type != op.type() &&
+    expr_type.id() == ID_union_tag && expr_type != op.type() &&
     op.id() != ID_initializer_list)
   {
     // This is a GCC extension. It's either a 'temporary union',
@@ -1054,7 +1054,8 @@ void c_typecheck_baset::typecheck_expr_typecast(exprt &expr)
       op = typecast_exprt(op, signed_int_type());
 
     // we need to find a member with the right type
-    for(const auto &c : to_union_type(expr_type).components())
+    const auto &union_type = follow_tag(to_union_tag_type(expr_type));
+    for(const auto &c : union_type.components())
     {
       if(c.type() == op.type())
       {


### PR DESCRIPTION
The C frontend should allow casting a struct to itself using a typecast.

Reported as issue #5153.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
