### PR TITLE
Support for an external lazy methods driver to control when the `INITIALIZE_FUNCTION` is generated

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_language.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_language.cpp
@@ -1125,7 +1125,8 @@ void java_bytecode_languaget::convert_lazy_method(
   lazy_class_to_declared_symbols_mapt class_to_declared_symbols;
   convert_single_method(function_id, symbol_table, class_to_declared_symbols);
 
-  // Instrument runtime exceptions (unless symbol is a stub)
+  // Instrument runtime exceptions (unless symbol is a stub or is the
+  // INITIALISE_FUNCTION).
   if(symbol.value.is_not_nil() && function_id != INITIALIZE_FUNCTION)
   {
     java_bytecode_instrument_symbol(

--- a/jbmc/src/java_bytecode/java_entry_point.cpp
+++ b/jbmc/src/java_bytecode/java_entry_point.cpp
@@ -53,7 +53,6 @@ void create_java_initialize(symbol_table_baset &symbol_table)
   initialize.mode=ID_java;
 
   initialize.type = java_method_typet({}, java_void_type());
-
   symbol_table.add(initialize);
 }
 
@@ -104,7 +103,7 @@ static constant_exprt constant_bool(bool val)
   return from_integer(val ? 1 : 0, java_boolean_type());
 }
 
-static void java_static_lifetime_init(
+void java_static_lifetime_init(
   symbol_table_baset &symbol_table,
   const source_locationt &source_location,
   bool assume_init_pointers_not_null,
@@ -115,6 +114,7 @@ static void java_static_lifetime_init(
 {
   symbolt &initialize_symbol =
     symbol_table.get_writeable_ref(INITIALIZE_FUNCTION);
+  PRECONDITION(initialize_symbol.value.is_nil());
   code_blockt code_block;
 
   const symbol_exprt rounding_mode =
@@ -589,17 +589,6 @@ bool java_entry_point(
   symbolt symbol=res.main_function;
 
   assert(symbol.type.id()==ID_code);
-
-  create_java_initialize(symbol_table);
-
-  java_static_lifetime_init(
-    symbol_table,
-    symbol.location,
-    assume_init_pointers_not_null,
-    object_factory_parameters,
-    pointer_type_selector,
-    string_refinement_enabled,
-    message_handler);
 
   return generate_java_start_function(
     symbol,

--- a/jbmc/src/java_bytecode/java_entry_point.h
+++ b/jbmc/src/java_bytecode/java_entry_point.h
@@ -190,4 +190,14 @@ std::pair<code_blockt, std::vector<exprt>> java_build_arguments(
 /// code for it yet.
 void create_java_initialize(symbol_table_baset &symbol_table);
 
+/// Adds the body to __CPROVER_initialize
+void java_static_lifetime_init(
+  symbol_table_baset &symbol_table,
+  const source_locationt &source_location,
+  bool assume_init_pointers_not_null,
+  java_object_factory_parameterst object_factory_parameters,
+  const select_pointer_typet &pointer_type_selector,
+  bool string_refinement_enabled,
+  message_handlert &message_handler);
+
 #endif // CPROVER_JAVA_BYTECODE_JAVA_ENTRY_POINT_H

--- a/jbmc/unit/java_bytecode/java_bytecode_language/language.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_language/language.cpp
@@ -56,7 +56,7 @@ static void use_external_driver(java_bytecode_languaget &language)
   language.set_language_options(options);
 }
 
-TEST_CASE(
+SCENARIO(
   "LAZY_METHODS_MODE_EXTERNAL_DRIVER based generation of cprover_initialise",
   "[core][java_bytecode_language]")
 {
@@ -65,17 +65,29 @@ TEST_CASE(
   language.set_message_handler(null_message_handler);
   use_external_driver(language);
   symbol_tablet symbol_table;
-  language.typecheck(symbol_table, "");
+  GIVEN("java_bytecode_languaget::typecheck is run.")
   {
-    const symbolt *const initialise = symbol_table.lookup(INITIALIZE_FUNCTION);
-    REQUIRE(initialise);
-    REQUIRE(initialise->value.is_nil());
-  }
-  language.convert_lazy_method(INITIALIZE_FUNCTION, symbol_table);
-  {
-    const symbolt *const initialise = symbol_table.lookup(INITIALIZE_FUNCTION);
-    REQUIRE(initialise);
-    REQUIRE(can_cast_expr<codet>(initialise->value));
+    language.typecheck(symbol_table, "");
+    THEN("The " INITIALIZE_FUNCTION " is in the symbol table without code.")
+    {
+      const symbolt *const initialise =
+        symbol_table.lookup(INITIALIZE_FUNCTION);
+      REQUIRE(initialise);
+      REQUIRE(initialise->value.is_nil());
+    }
+    GIVEN(
+      "java_bytecode_languaget::convert_lazy_method is used to "
+      "generate " INITIALIZE_FUNCTION)
+    {
+      language.convert_lazy_method(INITIALIZE_FUNCTION, symbol_table);
+      THEN("The " INITIALIZE_FUNCTION " is in the symbol table with code.")
+      {
+        const symbolt *const initialise =
+          symbol_table.lookup(INITIALIZE_FUNCTION);
+        REQUIRE(initialise);
+        REQUIRE(can_cast_expr<codet>(initialise->value));
+      }
+    }
   }
 }
 
@@ -88,8 +100,16 @@ TEST_CASE(
   language.set_message_handler(null_message_handler);
   language.set_language_options(optionst{});
   symbol_tablet symbol_table;
-  language.typecheck(symbol_table, "");
-  const symbolt *const initialise = symbol_table.lookup(INITIALIZE_FUNCTION);
-  REQUIRE(initialise);
-  REQUIRE(can_cast_expr<codet>(initialise->value));
+  GIVEN("java_bytecode_languaget::typecheck is run.")
+  {
+    language.typecheck(symbol_table, "");
+    THEN("The " INITIALIZE_FUNCTION
+         " function is in the symbol table with code.")
+    {
+      const symbolt *const initialise =
+        symbol_table.lookup(INITIALIZE_FUNCTION);
+      REQUIRE(initialise);
+      REQUIRE(can_cast_expr<codet>(initialise->value));
+    }
+  }
 }

--- a/jbmc/unit/java_bytecode/java_bytecode_language/module_dependencies.txt
+++ b/jbmc/unit/java_bytecode/java_bytecode_language/module_dependencies.txt
@@ -1,3 +1,5 @@
+java_bytecode
 java-testing-utils
+linking
 testing-utils
 util


### PR DESCRIPTION
Support for an external lazy methods driver to control when the `INITIALIZE_FUNCTION` is generated. The `INITIALIZE_FUNCTION` needs to be generated after all needed string literals have been added to the symbol table. The existing implementation tied the generation of the `INITIALIZE_FUNCTION`, to the point where `generate_support_functions` is called. This PR frees an external loading driver to generate the `INITIALIZE_FUNCTION` separately.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~ - N/A
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] ~~My commit message includes data points confirming performance improvements (if claimed).~~ Non claimed
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
