### PR TITLE
SMT-LIB2 parameter/let/quantifier scopes

### DIFF
--- a/regression/smt2_solver/function-applications/function-scoping1.desc
+++ b/regression/smt2_solver/function-applications/function-scoping1.desc
@@ -1,0 +1,8 @@
+CORE
+function-scoping1.smt2
+
+^EXIT=0$
+^SIGNAL=0$
+^unsat$
+--
+^\(error

--- a/regression/smt2_solver/function-applications/function-scoping1.smt2
+++ b/regression/smt2_solver/function-applications/function-scoping1.smt2
@@ -1,0 +1,12 @@
+(set-logic QF_BV)
+
+; the function parameters are in a separate scope
+
+(define-fun min ((a (_ BitVec 8)) (b (_ BitVec 8))) (_ BitVec 8)
+    (ite (bvule a b) a b))
+
+(declare-const a (_ BitVec 32))
+
+(assert (not (= a a)))
+
+(check-sat)

--- a/regression/smt2_solver/let1/let-scoping1.desc
+++ b/regression/smt2_solver/let1/let-scoping1.desc
@@ -1,0 +1,8 @@
+CORE
+let-scoping1.smt2
+
+^EXIT=0$
+^SIGNAL=0$
+^unsat$
+--
+^\(error

--- a/regression/smt2_solver/let1/let-scoping1.smt2
+++ b/regression/smt2_solver/let1/let-scoping1.smt2
@@ -1,0 +1,12 @@
+(set-logic QF_BV)
+
+; the let parameters are in a separate scope
+(define-fun let1 () Bool (let ((a true)) a))
+(declare-const a (_ BitVec 32))
+(assert (not (= a a)))
+
+; declare-const first
+(declare-const b (_ BitVec 32))
+(define-fun let2 () Bool (let ((b true)) b))
+
+(check-sat)

--- a/regression/smt2_solver/quanitfiers/quantifier-scoping.desc
+++ b/regression/smt2_solver/quanitfiers/quantifier-scoping.desc
@@ -1,0 +1,7 @@
+CORE
+quantifier-scoping.smt2
+
+^EXIT=0$
+^SIGNAL=0$
+^unsat$
+--

--- a/regression/smt2_solver/quanitfiers/quantifier-scoping.smt2
+++ b/regression/smt2_solver/quanitfiers/quantifier-scoping.smt2
@@ -1,0 +1,12 @@
+(set-logic QF_BV)
+
+; the quantified identifiers are in a separate scope
+(define-fun q1 () Bool (exists ((a Bool)) a))
+(declare-const a (_ BitVec 32))
+(assert (not (= a a)))
+
+; declare-const first
+(declare-const b (_ BitVec 32))
+(define-fun q2 () Bool (exists ((b Bool)) b))
+
+(check-sat)

--- a/src/solvers/smt2/smt2_parser.h
+++ b/src/solvers/smt2/smt2_parser.h
@@ -90,6 +90,7 @@ protected:
   using renaming_counterst=std::map<irep_idt, unsigned>;
   renaming_counterst renaming_counters;
   irep_idt add_fresh_id(const irep_idt &, const exprt &);
+  void add_unique_id(const irep_idt &, const exprt &);
   irep_idt rename_id(const irep_idt &) const;
 
   struct signature_with_parameter_idst


### PR DESCRIPTION
SMT-LIB2 function definitions have scopes for the identifiers of the parameters.

This was raised in #5143.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
