### PR TITLE
smt2 parser: track a 'kind' for all identifiers

### DIFF
--- a/src/solvers/smt2/smt2_parser.h
+++ b/src/solvers/smt2/smt2_parser.h
@@ -35,10 +35,14 @@ public:
 
   struct idt
   {
-    explicit idt(const exprt &expr) : type(expr.type()), definition(expr)
+    using kindt = enum { VARIABLE, BINDING, PARAMETER };
+
+    idt(kindt _kind, const exprt &expr)
+      : kind(_kind), type(expr.type()), definition(expr)
     {
     }
 
+    kindt kind;
     typet type;
     exprt definition;
     std::vector<irep_idt> parameters;
@@ -89,7 +93,7 @@ protected:
   renaming_mapt renaming_map;
   using renaming_counterst=std::map<irep_idt, unsigned>;
   renaming_counterst renaming_counters;
-  irep_idt add_fresh_id(const irep_idt &, const exprt &);
+  irep_idt add_fresh_id(const irep_idt &, idt::kindt, const exprt &);
   void add_unique_id(const irep_idt &, const exprt &);
   irep_idt rename_id(const irep_idt &) const;
 


### PR DESCRIPTION
This commit adds a field to the idt data structure in the SMT-LIB2 parser.
This enables distinguishing variables, parameters, and bound identifiers,
primarily for the benefit of debugging.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
