### PR TITLE
Make virtual the destructor for symex_complexity_limit_exceeded_actiont.

### DIFF
--- a/src/goto-symex/symex_complexity_limit_exceeded_action.h
+++ b/src/goto-symex/symex_complexity_limit_exceeded_action.h
@@ -18,6 +18,7 @@ public:
   {
     current_state.reachable = false;
   }
+  virtual ~symex_complexity_limit_exceeded_actiont() {}
 };
 
 #endif // CPROVER_GOTO_SYMEX_SYMEX_COMPLEXITY_LIMIT_EXCEEDED_ACTION_H

--- a/src/goto-symex/symex_complexity_limit_exceeded_action.h
+++ b/src/goto-symex/symex_complexity_limit_exceeded_action.h
@@ -18,7 +18,9 @@ public:
   {
     current_state.reachable = false;
   }
-  virtual ~symex_complexity_limit_exceeded_actiont() {}
+  virtual ~symex_complexity_limit_exceeded_actiont()
+  {
+  }
 };
 
 #endif // CPROVER_GOTO_SYMEX_SYMEX_COMPLEXITY_LIMIT_EXCEEDED_ACTION_H


### PR DESCRIPTION
The class symex_complexity_limit_exceeded_actiont has a virtual function transform and no virtual destructor.

On macos, the cmake build with clang fails with

```
[ 60%] Building CXX object src/goto-symex/CMakeFiles/goto-symex.dir/auto_objects.cpp.o
In file included from /Users/mrtuttle/cbmc/src/goto-symex/auto_objects.cpp:12:
In file included from /Users/mrtuttle/cbmc/src/goto-symex/goto_symex.h:15:
In file included from /Users/mrtuttle/cbmc/src/util/options.h:15:
In file included from /Library/Developer/CommandLineTools/usr/include/c++/v1/string:500:
In file included from /Library/Developer/CommandLineTools/usr/include/c++/v1/string_view:176:
In file included from /Library/Developer/CommandLineTools/usr/include/c++/v1/__string:56:
In file included from /Library/Developer/CommandLineTools/usr/include/c++/v1/algorithm:644:
/Library/Developer/CommandLineTools/usr/include/c++/v1/memory:1880:58: error: destructor called on non-final
      'symex_complexity_limit_exceeded_actiont' that has virtual functions but non-virtual destructor
      [-Werror,-Wdelete-non-virtual-dtor]
    _LIBCPP_INLINE_VISIBILITY void destroy(pointer __p) {__p->~_Tp();}
                                                         ^
```