### PR TITLE
Specify working directory for git calls

### DIFF
--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -12,6 +12,7 @@ if(GIT_FOUND)
       COMMAND \"${GIT_EXECUTABLE}\" \"describe\" \"--tags\" \"--always\" \"--dirty\"
       OUTPUT_VARIABLE GIT_INFO
       OUTPUT_STRIP_TRAILING_WHITESPACE
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
     configure_file(\${CUR}/version.cpp.in version.cpp)
     "


### PR DESCRIPTION
This is so that the CMake's `build` directory can be put outside of the repository.

VS CMake puts the build directory in `~/CMakeBuilds/` and so it doesn't work for some targets.
This might also be handy if you're juggling multiple builds yet want to be able to run `git clean -xdf .` and not see the `build` folder in your searches in your IDE.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [n/a] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [n/a] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [n/a] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
