### PR TITLE
Make access to exprt::opN bounds checked

### DIFF
--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -99,28 +99,44 @@ public:
   { return (const operandst &)get_sub(); }
 
   exprt &op0()
-  { return operands().front(); }
+  {
+    return operands().at(0);
+  }
 
   exprt &op1()
-  { return operands()[1]; }
+  {
+    return operands().at(1);
+  }
 
   exprt &op2()
-  { return operands()[2]; }
+  {
+    return operands().at(2);
+  }
 
   exprt &op3()
-  { return operands()[3]; }
+  {
+    return operands().at(3);
+  }
 
   const exprt &op0() const
-  { return operands().front(); }
+  {
+    return operands().at(0);
+  }
 
   const exprt &op1() const
-  { return operands()[1]; }
+  {
+    return operands().at(1);
+  }
 
   const exprt &op2() const
-  { return operands()[2]; }
+  {
+    return operands().at(2);
+  }
 
   const exprt &op3() const
-  { return operands()[3]; }
+  {
+    return operands().at(3);
+  }
 
   void reserve_operands(operandst::size_type n)
   { operands().reserve(n) ; }


### PR DESCRIPTION
These not being bounds checked is a potential source for pretty annoying bugs
where a non-existent operand of a malformed irep is accessed, a reference to it
passed around, causing the program to crash in a potentially quite distant
location when it eventually needs to be actually dereferenced.

Of course ideally we don't want any malformed Ireps at all, but sometimes we do end up getting them anyway because we don't do extensive structure invariant checking everywhere all the time, so it helps to be defensive with these.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
