### PR TITLE
Allow function pointer arguments to be equal

### DIFF
--- a/regression/goto-harness/pointer-function-parameters-equal-maybe/main.c
+++ b/regression/goto-harness/pointer-function-parameters-equal-maybe/main.c
@@ -1,0 +1,27 @@
+#include <assert.h>
+#include <stdlib.h>
+
+typedef struct st1
+{
+  struct st *next;
+  int data;
+} st1_t;
+
+typedef struct st2
+{
+  struct st *next;
+  int data;
+} st2_t;
+
+void func(st1_t *p, st1_t *q, st2_t *r, st2_t *s, st2_t *t)
+{
+  assert(p != NULL);
+  assert(p->next != NULL);
+
+  assert(p == q);
+
+  assert((void *)p != (void *)r);
+
+  assert(r == s);
+  assert(r == t);
+}

--- a/regression/goto-harness/pointer-function-parameters-equal-maybe/test.desc
+++ b/regression/goto-harness/pointer-function-parameters-equal-maybe/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--function func --min-null-tree-depth 10 --max-nondet-tree-depth 3 --harness-type call-function --treat-pointers-equal 'p,q;r,s,t' --treat-pointers-equal-maybe
+^EXIT=10$
+^SIGNAL=0$
+^\[func.assertion.\d+\] line \d+ assertion p == q: FAILURE$
+^\[func.assertion.\d+\] line \d+ assertion \(void \*\)p != \(void \*\)r: SUCCESS$
+^\[func.assertion.\d+\] line \d+ assertion r == s: FAILURE$
+^\[func.assertion.\d+\] line \d+ assertion r == t: FAILURE$
+VERIFICATION FAILED
+--
+^warning: ignoring

--- a/regression/goto-harness/pointer-function-parameters-equal-simple/main.c
+++ b/regression/goto-harness/pointer-function-parameters-equal-simple/main.c
@@ -1,16 +1,27 @@
 #include <assert.h>
 #include <stdlib.h>
 
-typedef struct st
+typedef struct st1
 {
   struct st *next;
   int data;
-} st_t;
+} st1_t;
 
-void func(st_t *p, st_t *q)
+typedef struct st2
+{
+  struct st *next;
+  int data;
+} st2_t;
+
+void func(st1_t *p, st1_t *q, st2_t *r, st2_t *s, st2_t *t)
 {
   assert(p != NULL);
   assert(p->next != NULL);
 
   assert(p == q);
+
+  assert((void *)p != (void *)r);
+
+  assert(r == s);
+  assert(r == t);
 }

--- a/regression/goto-harness/pointer-function-parameters-equal-simple/main.c
+++ b/regression/goto-harness/pointer-function-parameters-equal-simple/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+#include <stdlib.h>
+
+typedef struct st
+{
+  struct st *next;
+  int data;
+} st_t;
+
+void func(st_t *p, st_t *q)
+{
+  assert(p != NULL);
+  assert(p->next != NULL);
+
+  assert(p == q);
+}

--- a/regression/goto-harness/pointer-function-parameters-equal-simple/test.desc
+++ b/regression/goto-harness/pointer-function-parameters-equal-simple/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---function func --min-null-tree-depth 10 --max-nondet-tree-depth 3 --harness-type call-function --treat-pointers-equal p,q
+--function func --min-null-tree-depth 10 --max-nondet-tree-depth 3 --harness-type call-function --treat-pointers-equal 'p,q;r,s,t'
 ^EXIT=0$
 ^SIGNAL=0$
 VERIFICATION SUCCESSFUL

--- a/regression/goto-harness/pointer-function-parameters-equal-simple/test.desc
+++ b/regression/goto-harness/pointer-function-parameters-equal-simple/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--function func --min-null-tree-depth 10 --max-nondet-tree-depth 3 --harness-type call-function --treat-pointers-equal p,q
+^EXIT=0$
+^SIGNAL=0$
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/src/goto-harness/function_call_harness_generator.cpp
+++ b/src/goto-harness/function_call_harness_generator.cpp
@@ -169,6 +169,10 @@ void function_call_harness_generatort::handle_option(
     p_impl->function_parameters_to_treat_as_cstrings.insert(
       values.begin(), values.end());
   }
+  else if(option == FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_MAYBE_OPT)
+  {
+    p_impl->recursive_initialization_config.arguments_may_be_equal = true;
+  }
   else
   {
     throw invalid_command_line_argument_exceptiont{
@@ -219,9 +223,9 @@ void function_call_harness_generatort::implt::generate(
   call_function(arguments, function_body);
   for(const auto &global_pointer : global_pointers)
   {
-    function_body.add(code_function_callt{
-      recursive_initialization->get_free_function(), {global_pointer}});
+    recursive_initialization->free_if_possible(global_pointer, function_body);
   }
+  recursive_initialization->free_cluster_origins(function_body);
   add_harness_function_to_goto_model(std::move(function_body));
 }
 

--- a/src/goto-harness/function_harness_generator_options.h
+++ b/src/goto-harness/function_harness_generator_options.h
@@ -15,6 +15,8 @@ Author: Diffblue Ltd.
 #define FUNCTION_HARNESS_GENERATOR_NONDET_GLOBALS_OPT "nondet-globals"
 #define FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT                  \
   "treat-pointer-as-array"
+#define FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_OPT                    \
+  "treat-pointers-equal"
 #define FUNCTION_HARNESS_GENERATOR_ASSOCIATED_ARRAY_SIZE_OPT                   \
   "associated-array-size"
 #define FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_CSTRING                    \
@@ -25,6 +27,7 @@ Author: Diffblue Ltd.
   "(" FUNCTION_HARNESS_GENERATOR_FUNCTION_OPT "):"                             \
   "(" FUNCTION_HARNESS_GENERATOR_NONDET_GLOBALS_OPT ")"                        \
   "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT "):"               \
+  "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_OPT "):"                 \
   "(" FUNCTION_HARNESS_GENERATOR_ASSOCIATED_ARRAY_SIZE_OPT "):"                \
   "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_CSTRING "):"                 \
 // FUNCTION_HARNESS_GENERATOR_OPTIONS
@@ -43,6 +46,9 @@ Author: Diffblue Ltd.
   "--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT                   \
   " p    treat the function parameter with the name `p' as\n"                  \
   "                              an array\n"                                   \
+  "--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_OPT                     \
+  " p,q    treat the function parameter with the name `q' equal\n"             \
+  "                              to parameter `q'\n"                           \
   "--" FUNCTION_HARNESS_GENERATOR_ASSOCIATED_ARRAY_SIZE_OPT                    \
   " array_name:size_name\n"                                                    \
   "                              set the parameter <size_name> to the size"    \

--- a/src/goto-harness/function_harness_generator_options.h
+++ b/src/goto-harness/function_harness_generator_options.h
@@ -21,6 +21,8 @@ Author: Diffblue Ltd.
   "associated-array-size"
 #define FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_CSTRING                    \
   "treat-pointer-as-cstring"
+#define FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_MAYBE_OPT              \
+  "treat-pointers-equal-maybe"
 
 // clang-format off
 #define FUNCTION_HARNESS_GENERATOR_OPTIONS                                     \
@@ -30,6 +32,7 @@ Author: Diffblue Ltd.
   "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_OPT "):"                 \
   "(" FUNCTION_HARNESS_GENERATOR_ASSOCIATED_ARRAY_SIZE_OPT "):"                \
   "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_CSTRING "):"                 \
+  "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_MAYBE_OPT ")"            \
 // FUNCTION_HARNESS_GENERATOR_OPTIONS
 
 // clang-format on
@@ -49,6 +52,8 @@ Author: Diffblue Ltd.
   "--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_OPT                     \
   " p,q,r[;s,t]    treat the function parameters `q,r' equal\n"                \
   "                              to parameter `p'; `s` to `t` and so on\n"     \
+  "--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_MAYBE_OPT               \
+  "                function parameters equality is non-deterministic\n"        \
   "--" FUNCTION_HARNESS_GENERATOR_ASSOCIATED_ARRAY_SIZE_OPT                    \
   " array_name:size_name\n"                                                    \
   "                              set the parameter <size_name> to the size"    \

--- a/src/goto-harness/function_harness_generator_options.h
+++ b/src/goto-harness/function_harness_generator_options.h
@@ -47,8 +47,8 @@ Author: Diffblue Ltd.
   " p    treat the function parameter with the name `p' as\n"                  \
   "                              an array\n"                                   \
   "--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_OPT                     \
-  " p,q    treat the function parameter with the name `q' equal\n"             \
-  "                              to parameter `q'\n"                           \
+  " p,q,r[;s,t]    treat the function parameters `q,r' equal\n"                \
+  "                              to parameter `p'; `s` to `t` and so on\n"     \
   "--" FUNCTION_HARNESS_GENERATOR_ASSOCIATED_ARRAY_SIZE_OPT                    \
   " array_name:size_name\n"                                                    \
   "                              set the parameter <size_name> to the size"    \

--- a/src/goto-harness/recursive_initialization.h
+++ b/src/goto-harness/recursive_initialization.h
@@ -37,7 +37,7 @@ struct recursive_initialization_configt
   std::map<irep_idt, irep_idt> array_name_to_associated_array_size_variable;
 
   std::set<irep_idt> pointers_to_treat_as_cstrings;
-  std::set<irep_idt> pointers_to_treat_equal;
+  std::vector<std::set<irep_idt>> pointers_to_treat_equal;
 
   std::string to_string() const; // for debugging purposes
 
@@ -90,7 +90,7 @@ private:
   irep_idt max_depth_var_name;
   irep_idt min_depth_var_name;
   type_constructor_namest type_constructor_names;
-  optionalt<exprt> common_arguments_origin;
+  std::vector<optionalt<exprt>> common_arguments_origins;
 
   /// Get the malloc function as symbol exprt,
   /// and inserts it into the goto-model if it doesn't
@@ -98,7 +98,7 @@ private:
   symbol_exprt get_malloc_function();
 
   bool should_be_treated_as_array(const irep_idt &pointer_name) const;
-  bool should_be_treated_equal(const irep_idt &pointer_name) const;
+  optionalt<std::size_t> find_equal_cluster(const irep_idt &name) const;
   bool is_array_size_parameter(const irep_idt &cmdline_arg) const;
   optionalt<irep_idt>
   get_associated_size_variable(const irep_idt &array_name) const;

--- a/src/goto-harness/recursive_initialization.h
+++ b/src/goto-harness/recursive_initialization.h
@@ -37,6 +37,7 @@ struct recursive_initialization_configt
   std::map<irep_idt, irep_idt> array_name_to_associated_array_size_variable;
 
   std::set<irep_idt> pointers_to_treat_as_cstrings;
+  std::set<irep_idt> pointers_to_treat_equal;
 
   std::string to_string() const; // for debugging purposes
 
@@ -81,12 +82,15 @@ public:
       !has_prefix(id2string(symbol.name), CPROVER_PREFIX));
   }
 
+  bool needs_freeing(const exprt &expr) const;
+
 private:
   const recursive_initialization_configt initialization_config;
   goto_modelt &goto_model;
   irep_idt max_depth_var_name;
   irep_idt min_depth_var_name;
   type_constructor_namest type_constructor_names;
+  optionalt<exprt> common_arguments_origin;
 
   /// Get the malloc function as symbol exprt,
   /// and inserts it into the goto-model if it doesn't
@@ -94,6 +98,7 @@ private:
   symbol_exprt get_malloc_function();
 
   bool should_be_treated_as_array(const irep_idt &pointer_name) const;
+  bool should_be_treated_equal(const irep_idt &pointer_name) const;
   bool is_array_size_parameter(const irep_idt &cmdline_arg) const;
   optionalt<irep_idt>
   get_associated_size_variable(const irep_idt &array_name) const;

--- a/src/goto-harness/recursive_initialization.h
+++ b/src/goto-harness/recursive_initialization.h
@@ -39,6 +39,8 @@ struct recursive_initialization_configt
   std::set<irep_idt> pointers_to_treat_as_cstrings;
   std::vector<std::set<irep_idt>> pointers_to_treat_equal;
 
+  bool arguments_may_be_equal = false;
+
   std::string to_string() const; // for debugging purposes
 
   /// Parse the options specific for recursive initialisation
@@ -58,6 +60,7 @@ class recursive_initializationt
 public:
   using recursion_sett = std::set<irep_idt>;
   using type_constructor_namest = std::map<typet, irep_idt>;
+  using equal_cluster_idt = std::size_t;
 
   recursive_initializationt(
     recursive_initialization_configt initialization_config,
@@ -83,6 +86,8 @@ public:
   }
 
   bool needs_freeing(const exprt &expr) const;
+  void free_if_possible(const exprt &expr, code_blockt &body);
+  void free_cluster_origins(code_blockt &body);
 
 private:
   const recursive_initialization_configt initialization_config;
@@ -98,7 +103,7 @@ private:
   symbol_exprt get_malloc_function();
 
   bool should_be_treated_as_array(const irep_idt &pointer_name) const;
-  optionalt<std::size_t> find_equal_cluster(const irep_idt &name) const;
+  optionalt<equal_cluster_idt> find_equal_cluster(const irep_idt &name) const;
   bool is_array_size_parameter(const irep_idt &cmdline_arg) const;
   optionalt<irep_idt>
   get_associated_size_variable(const irep_idt &array_name) const;


### PR DESCRIPTION
for the function-call goto-harness.

We add a new command-line option `treat-pointers-equal` that takes a list of
formal parameter names and results in a harness that only generates constructor
for one of the pointers. The other pointers are simply assigned with the
constructed one.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
