### PR TITLE
Ensure strncmp(a,b,n) compares at most n characters.

### DIFF
--- a/regression/cbmc-library/strncasecmp-01/main.c
+++ b/regression/cbmc-library/strncasecmp-01/main.c
@@ -3,7 +3,20 @@
 
 int main()
 {
-  strncasecmp();
-  assert(0);
+#ifdef _WIN32
+  // strncasecmp is a POSIX call not available on Windows
+  // Can cbmc-library regression be configured to just skip this test
+  // on Windows?
+#else
+  char a[] = "abc";
+  char b[] = "xyz";
+  char A[] = "ABC";
+  char B[] = "XYZ";
+  assert(strncasecmp(a, b, 0) == 0);
+  assert(strncasecmp(A, B, 0) == 0);
+  assert(strncasecmp(A, b, 0) == 0);
+  assert(strncasecmp(A, b, 2) == -1);
+  assert(strncasecmp(B, a, 2) == 1);
+#endif
   return 0;
 }

--- a/regression/cbmc-library/strncasecmp-01/test.desc
+++ b/regression/cbmc-library/strncasecmp-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/strncmp-01/main.c
+++ b/regression/cbmc-library/strncmp-01/main.c
@@ -1,9 +1,15 @@
 #include <assert.h>
 #include <string.h>
 
+#include <assert.h>
+#include <string.h>
+
 int main()
 {
-  strncmp();
-  assert(0);
+  char a[] = "abc";
+  char b[] = "xyz";
+  assert(strncmp(a, b, 0) == 0);
+  assert(strncmp(a, b, 1) == -1);
+  assert(strncmp(b, a, 1) == 1);
   return 0;
 }

--- a/regression/cbmc-library/strncmp-01/test.desc
+++ b/regression/cbmc-library/strncmp-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/src/ansi-c/library/string.c
+++ b/src/ansi-c/library/string.c
@@ -463,6 +463,8 @@ inline int strncmp(const char *s1, const char *s2, size_t n)
   #else
   __CPROVER_size_t i=0;
   unsigned char ch1, ch2;
+  if(n == 0)
+    return 0;
   do
   {
     ch1=s1[i];
@@ -505,6 +507,8 @@ inline int strncasecmp(const char *s1, const char *s2, size_t n)
   #else
   __CPROVER_size_t i=0;
   unsigned char ch1, ch2;
+  if(n == 0)
+    return 0;
   do
   {
     ch1=s1[i];


### PR DESCRIPTION
The built in model of stncmp always compares at least one character even when n==0 because the do while loop does the first comparison before checking the value of n.  Just return 0 when n==0.

Consider the file test.c below.  The command 'cbmc test.c' fails and the command 'gcc test.c; a.out' succeeds.

```
#include <assert.h>
#include <string.h>

int main() {
  char a[] = "abc";
  char b[] = "xyz";
  assert(strncmp(a,b,0) == 0);
  return 0;
}
```