### PR TITLE
jbmc: avoid deprecated constructors

### DIFF
--- a/jbmc/src/java_bytecode/code_with_references.cpp
+++ b/jbmc/src/java_bytecode/code_with_references.cpp
@@ -40,7 +40,7 @@ reference_allocationt::to_code(reference_substitutiont &references) const
   // the file.
   code_blockt code;
   code.add(code_assignt{*reference.array_length,
-                        side_effect_expr_nondett{java_int_type()}});
+                        side_effect_expr_nondett{java_int_type(), loc}});
   code.add(code_assumet{binary_predicate_exprt{
     *reference.array_length, ID_ge, from_integer(0, java_int_type())}});
   code.add(allocate_array(reference.expr, *reference.array_length, loc));

--- a/jbmc/unit/java_bytecode/java_trace_validation/java_trace_validation.cpp
+++ b/jbmc/unit/java_bytecode/java_trace_validation/java_trace_validation.cpp
@@ -28,10 +28,10 @@ TEST_CASE("java trace validation", "[core][java_trace_validation]")
   const index_exprt valid_index =
     index_exprt(valid_symbol_expr, valid_constant);
   const index_exprt index_plain = index_exprt(exprt(), exprt());
-  const byte_extract_exprt byte_little_endian =
-    byte_extract_exprt(ID_byte_extract_little_endian);
+  const byte_extract_exprt byte_little_endian = byte_extract_exprt(
+    ID_byte_extract_little_endian, exprt(), exprt(), typet());
   const byte_extract_exprt byte_big_endian =
-    byte_extract_exprt(ID_byte_extract_big_endian);
+    byte_extract_exprt(ID_byte_extract_big_endian, exprt(), exprt(), typet());
   const address_of_exprt valid_address = address_of_exprt(valid_symbol_expr);
   const address_of_exprt invalid_address = address_of_exprt(exprt());
   const struct_exprt struct_plain =


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
