### PR TITLE
cpp_static_assertt constructor now has operands

### DIFF
--- a/src/cpp/cpp_static_assert.h
+++ b/src/cpp/cpp_static_assert.h
@@ -17,7 +17,12 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 class cpp_static_assertt : public binary_exprt
 {
 public:
-  cpp_static_assertt() : binary_exprt(ID_cpp_static_assert)
+  cpp_static_assertt(exprt _cond, exprt _description)
+    : binary_exprt(
+        std::move(_cond),
+        ID_cpp_static_assert,
+        std::move(_description),
+        typet())
   {
   }
 

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -920,19 +920,20 @@ bool Parser::rStaticAssert(cpp_static_assertt &cpp_static_assert)
   if(lex.get_token(tk)!=TOK_STATIC_ASSERT)
     return false;
 
-  cpp_static_assert=cpp_static_assertt();
-  set_location(cpp_static_assert, tk);
-
   if(lex.get_token(tk)!='(')
     return false;
 
-  if(!rExpression(cpp_static_assert.cond(), false))
+  exprt cond;
+
+  if(!rExpression(cond, false))
     return false;
 
   if(lex.get_token(tk)!=',')
     return false;
 
-  if(!rExpression(cpp_static_assert.description(), false))
+  exprt description;
+
+  if(!rExpression(description, false))
     return false;
 
   if(lex.get_token(tk)!=')')
@@ -940,6 +941,10 @@ bool Parser::rStaticAssert(cpp_static_assertt &cpp_static_assert)
 
   if(lex.get_token(tk)!=';')
     return false;
+
+  cpp_static_assert =
+    cpp_static_assertt(std::move(cond), std::move(description));
+  set_location(cpp_static_assert, tk);
 
   return true;
 }
@@ -7505,7 +7510,7 @@ optionalt<codet> Parser::rStatement()
 
   case TOK_STATIC_ASSERT:
     {
-      cpp_static_assertt cpp_static_assert;
+      cpp_static_assertt cpp_static_assert{nil_exprt(), nil_exprt()};
 
       if(!rStaticAssert(cpp_static_assert))
         return {};


### PR DESCRIPTION
This avoids a deprecated constructor for `binary_exprt`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
