### PR TITLE
unit tests: avoid deprecated constructors

### DIFF
--- a/unit/util/expr_cast/expr_cast.cpp
+++ b/unit/util/expr_cast/expr_cast.cpp
@@ -145,9 +145,11 @@ SCENARIO("expr_dynamic_cast",
 
   GIVEN("A byte extract expression with little endianness")
   {
-    auto byte = byte_extract_exprt(ID_byte_extract_little_endian);
-    byte.op() = symbol_exprt(typet());
-    byte.offset() = constant_exprt("0", typet());
+    auto byte = byte_extract_exprt(
+      ID_byte_extract_little_endian,
+      symbol_exprt(typet()),
+      constant_exprt("0", typet()),
+      typet());
     THEN("try_expr_dynamic_cast<byte_extract_expr> returns non-empty")
     {
       REQUIRE(expr_try_dynamic_cast<byte_extract_exprt>(byte));
@@ -155,9 +157,11 @@ SCENARIO("expr_dynamic_cast",
   }
   GIVEN("A byte extract expression with big endianness")
   {
-    auto byte = byte_extract_exprt(ID_byte_extract_big_endian);
-    byte.op() = symbol_exprt(typet());
-    byte.offset() = constant_exprt("0", typet());
+    auto byte = byte_extract_exprt(
+      ID_byte_extract_big_endian,
+      symbol_exprt(typet()),
+      constant_exprt("0", typet()),
+      typet());
     THEN("try_expr_dynamic_cast<byte_extract_expr> returns non-empty")
     {
       REQUIRE(expr_try_dynamic_cast<byte_extract_exprt>(byte));
@@ -177,9 +181,11 @@ SCENARIO("can_cast_expr", "[core][utils][expr_cast][can_cast_expr]")
 {
   GIVEN("A byte extract expression with little endianness")
   {
-    auto byte = byte_extract_exprt(ID_byte_extract_little_endian);
-    byte.op() = symbol_exprt(typet());
-    byte.offset() = constant_exprt("0", typet());
+    auto byte = byte_extract_exprt(
+      ID_byte_extract_little_endian,
+      symbol_exprt(typet()),
+      constant_exprt("0", typet()),
+      typet());
     THEN("can_expr_expr<byte_extract_expr> returns true")
     {
       REQUIRE(can_cast_expr<byte_extract_exprt>(byte));
@@ -187,9 +193,11 @@ SCENARIO("can_cast_expr", "[core][utils][expr_cast][can_cast_expr]")
   }
   GIVEN("A byte extract expression with big endianness")
   {
-    auto byte = byte_extract_exprt(ID_byte_extract_big_endian);
-    byte.op() = symbol_exprt(typet());
-    byte.offset() = constant_exprt("0", typet());
+    auto byte = byte_extract_exprt(
+      ID_byte_extract_big_endian,
+      symbol_exprt(typet()),
+      constant_exprt("0", typet()),
+      typet());
     THEN("can_expr_expr<byte_extract_expr> returns true")
     {
       REQUIRE(can_cast_expr<byte_extract_exprt>(byte));

--- a/unit/util/irep_sharing.cpp
+++ b/unit/util/irep_sharing.cpp
@@ -120,7 +120,7 @@ SCENARIO("exprt_sharing_trade_offs", "[!mayfail][core][utils][exprt]")
 {
   GIVEN("An expression created with add_to_operands(std::move(...))")
   {
-    multi_ary_exprt test_expr(ID_1);
+    multi_ary_exprt test_expr(ID_1, {}, typet());
     exprt test_subexpr(ID_1);
     exprt test_subsubexpr(ID_1);
     test_subexpr.add_to_operands(std::move(test_subsubexpr));
@@ -154,7 +154,7 @@ SCENARIO("exprt_sharing", "[core][utils][exprt]")
 {
   GIVEN("An expression created with add_to_operands(std::move(...))")
   {
-    multi_ary_exprt test_expr(ID_1);
+    multi_ary_exprt test_expr(ID_1, {}, typet());
     exprt test_subexpr(ID_1);
     exprt test_subsubexpr(ID_1);
     test_subexpr.add_to_operands(std::move(test_subsubexpr));


### PR DESCRIPTION
This will enable removing those deprecated constructors.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
