### PR TITLE
Selective havocing in generated function bodies

### DIFF
--- a/doc/cprover-manual/goto-instrument.md
+++ b/doc/cprover-manual/goto-instrument.md
@@ -1,0 +1,127 @@
+[CPROVER Manual TOC](../../)
+
+## Goto Instrument
+
+This is a tool that implements a variety of instrumentation passes modifying a
+pre-existing GOTO binary, or rather producing the modified binary as output.
+
+```sh
+$ goto-instrument in.gb out.gb <instrumentation-options>
+```
+
+### Diagnosis Options
+
+### Safety Checks
+
+### Semantic Transformations
+
+#### Generate Function Body
+
+This transformation inserts implementation of functions without definition, i.e.
+a body. The user is allowed to choose the behavior to be implemented by those
+functions from a predefined list. The command-line option to select the behavior
+is `--generate-function-body-options <option>`.
+
+- `assert-false`: The body consists of a single command: `assert(0);`
+- `assume-false`: The body consists of a single command: `assume(0);`
+- `nondet-return`: The body only returns a non-deterministic value of it's
+  return type.
+- `assert-false-assume-false`: Two commands as above.
+- `havoc[,params:<p-regex>][,globals:<g-regex>]`: Assign non-deterministic
+  values to the targets of pointer-to-non-constant parameters matching the
+  `p-regex`, and non-constant globals matching the `g-regex` and then (in case
+  of non-void function) returning as with `nondet-return`.
+
+Let's demonstrate using the havoc on a simple example:
+
+```C
+// main.c
+int global;
+const int c_global;
+
+int function(int *param, const int *c_param);
+```
+
+Often we want to avoid overwriting internal symbols, i.e. those with `__`
+prefix, which is done using the pattern `(?!__)`.
+
+```sh
+$ goto-cc main.c -o main.gb
+$ goto-instrument main.gb main-out.gb \
+  --generate-function-body-options 'havoc,params:(?!__).*,globals:(?!__).*' \
+  --generate-funtion-body function
+```
+
+Leads to a binary equivalent to the following C code:
+
+```C
+// main-mod.c
+int function(int *param, const int *c_param) {
+  *param = nondet_int();
+  global = nondet_int();
+  return nondet_int();
+}
+```
+
+Which parameters should be modified can be specified either by a regular
+expression (as above) or by a semicolon-separated list of their numbers. For
+example `havoc,params:0;3;4` will assign non-deterministic values to the 1st,
+4th, and 5th parameter.
+
+Finally, the user can also request different implementation for a number of
+call-sites of a single function. The option `--generate-havocing-body` inserts
+new functions for selected call-sites and replaces the calls to the origin
+function with calls to the respective new functions.
+
+```C
+// main.c
+int function(int *first, int *second, int *third);
+
+int main() {
+  int a = 10;
+  int b = 10;
+  int c = 10;
+
+  function(&a, &b, &c);
+  function(&a, &b, &c);
+}
+```
+
+The user can specify different behavior for each call-site as follows:
+
+```
+$ goto-cc main.c -o main.gb
+$ goto-instrument main.gb  main-mod.gb \
+  --generate-havocing-body 'function,1,params:0;2,2,params:1'
+```
+
+Results in a binary equivalent to:
+
+```C
+// main-mod.c
+int function_1(int *first, int *second, int *third) {
+  *first = nondet_int();
+  *third = nondet_int();
+}
+
+int function_2(int *first, int *second, int *third) {
+  *second = nondet_int();
+}
+
+int main() {
+  int a = 10;
+  int b = 10;
+  int c = 10;
+
+  function_1(&a, &b, &c);
+  function_2(&a, &b, &c);
+}
+```
+
+### Loop Transformations
+
+### Memory Model Instrumentations
+
+### Slicing
+
+### Further Transformations

--- a/doc/cprover-manual/goto-instrument.md
+++ b/doc/cprover-manual/goto-instrument.md
@@ -118,6 +118,11 @@ int main() {
 }
 ```
 
+Note that only parameters of pointer type can be havoc(ed) and CBMC will produce
+an error report if given a parameter number associated with a non-pointer
+parameter. Requesting to havoc a parameter with a number higher than the number
+of parameters a given function takes will also results in an error report.
+
 ### Loop Transformations
 
 ### Memory Model Instrumentations

--- a/regression/goto-instrument/generate-function-body-havoc-params-call-sites/main.c
+++ b/regression/goto-instrument/generate-function-body-havoc-params-call-sites/main.c
@@ -1,0 +1,31 @@
+#include <assert.h>
+
+struct S
+{
+  int i;
+  char *j;
+};
+
+void touches_parameter(int *param, int *const_param, struct S *struct_param);
+
+int main(void)
+{
+  int parameter = 10;
+  int unchanged_parameter = 10;
+  struct S my_struct = {.i = 10, .j = "10"};
+  touches_parameter(&parameter, &unchanged_parameter, &my_struct);
+  assert(parameter == 10);
+  assert(unchanged_parameter == 10);
+  assert(my_struct.i == 10);
+  assert(my_struct.j == "10");
+
+  parameter = 10;
+  unchanged_parameter = 10;
+  my_struct.i = 10;
+  my_struct.j = "10";
+  touches_parameter(&parameter, &unchanged_parameter, &my_struct);
+  assert(parameter == 10);
+  assert(unchanged_parameter == 10);
+  assert(my_struct.i == 10);
+  assert(my_struct.j == "10");
+}

--- a/regression/goto-instrument/generate-function-body-havoc-params-call-sites/main.c
+++ b/regression/goto-instrument/generate-function-body-havoc-params-call-sites/main.c
@@ -6,14 +6,18 @@ struct S
   char *j;
 };
 
-void touches_parameter(int *param, int *const_param, struct S *struct_param);
+void touches_parameter(
+  int *param,
+  int *const_param,
+  struct S *struct_param,
+  int non_pointer_param);
 
 int main(void)
 {
   int parameter = 10;
   int unchanged_parameter = 10;
   struct S my_struct = {.i = 10, .j = "10"};
-  touches_parameter(&parameter, &unchanged_parameter, &my_struct);
+  touches_parameter(&parameter, &unchanged_parameter, &my_struct, 4);
   assert(parameter == 10);
   assert(unchanged_parameter == 10);
   assert(my_struct.i == 10);
@@ -23,7 +27,7 @@ int main(void)
   unchanged_parameter = 10;
   my_struct.i = 10;
   my_struct.j = "10";
-  touches_parameter(&parameter, &unchanged_parameter, &my_struct);
+  touches_parameter(&parameter, &unchanged_parameter, &my_struct, 4);
   assert(parameter == 10);
   assert(unchanged_parameter == 10);
   assert(my_struct.i == 10);

--- a/regression/goto-instrument/generate-function-body-havoc-params-call-sites/non_pointer_param.desc
+++ b/regression/goto-instrument/generate-function-body-havoc-params-call-sites/non_pointer_param.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--generate-havocing-body 'touches_parameter,1,params:0;3,2,params:1'
+^EXIT=1$
+^SIGNAL=0$
+^Reason: argument number 3 of function touches_parameter.1 is not a pointer$
+--
+^warning: ignoring

--- a/regression/goto-instrument/generate-function-body-havoc-params-call-sites/test.desc
+++ b/regression/goto-instrument/generate-function-body-havoc-params-call-sites/test.desc
@@ -1,0 +1,16 @@
+CORE
+main.c
+--generate-havocing-body 'touches_parameter,1,params:0;2,2,params:1'
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+^\[main.assertion.\d+\] line \d+ assertion parameter == 10: FAILURE$
+^\[main.assertion.\d+\] line \d+ assertion unchanged_parameter == 10: SUCCESS$
+^\[main.assertion.\d+\] line \d+ assertion my_struct.i == 10: FAILURE$
+^\[main.assertion.\d+\] line \d+ assertion my_struct.j == "10": FAILURE$
+^\[main.assertion.\d+\] line \d+ assertion parameter == 10: SUCCESS$
+^\[main.assertion.\d+\] line \d+ assertion unchanged_parameter == 10: FAILURE
+^\[main.assertion.\d+\] line \d+ assertion my_struct.i == 10: SUCCESS$
+^\[main.assertion.\d+\] line \d+ assertion my_struct.j == "10": SUCCESS$
+--
+^warning: ignoring

--- a/regression/goto-instrument/generate-function-body-havoc-params-call-sites/too_high_param_number.desc
+++ b/regression/goto-instrument/generate-function-body-havoc-params-call-sites/too_high_param_number.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--generate-havocing-body 'touches_parameter,1,params:0;5,2,params:1'
+^EXIT=1$
+^SIGNAL=0$
+^Reason: function touches_parameter.1 does not take 6 arguments$
+--
+^warning: ignoring

--- a/regression/goto-instrument/generate-function-body-havoc-some-params/main.c
+++ b/regression/goto-instrument/generate-function-body-havoc-some-params/main.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+
+struct S
+{
+  int i;
+  char *j;
+};
+
+void touches_parameter(int *param, int *const_param, struct S *struct_param);
+
+int main(void)
+{
+  int parameter = 10;
+  int unchanged_parameter = 10;
+  struct S my_struct = {.i = 10, .j = "10"};
+  touches_parameter(&parameter, &unchanged_parameter, &my_struct);
+  assert(parameter == 10);
+  assert(unchanged_parameter == 10);
+  assert(my_struct.i == 10);
+  assert(my_struct.j == "10");
+}

--- a/regression/goto-instrument/generate-function-body-havoc-some-params/test.desc
+++ b/regression/goto-instrument/generate-function-body-havoc-some-params/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--generate-function-body touches_parameter --generate-function-body-options 'havoc,params:0;2'
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+^\[main.assertion.\d+\] line \d+ assertion parameter == 10: FAILURE$
+^\[main.assertion.\d+\] line \d+ assertion unchanged_parameter == 10: SUCCESS$
+^\[main.assertion.\d+\] line \d+ assertion my_struct.i == 10: FAILURE$
+^\[main.assertion.\d+\] line \d+ assertion my_struct.j == "10": FAILURE$
+--
+^warning: ignoring

--- a/src/goto-instrument/generate_function_bodies.h
+++ b/src/goto-instrument/generate_function_bodies.h
@@ -70,21 +70,43 @@ void generate_function_bodies(
   goto_modelt &model,
   message_handlert &message_handler);
 
+/// Generate a clone of \p function_name (labelled with \p call_site_id) and
+///   instantiate its body with selective havocing of its parameters.
+/// \param function_name: The function whose body should be generated
+/// \param call_site_id: the number of the call site
+/// \param generate_function_body: the previously constructed body generator
+/// \param model: the goto-model to be modified
+/// \param message_handler: the message-handler
+void generate_function_bodies(
+  const std::string &function_name,
+  const std::string &call_site_id,
+  const generate_function_bodiest &generate_function_body,
+  goto_modelt &model,
+  message_handlert &message_handler);
+
 // clang-format off
 #define OPT_REPLACE_FUNCTION_BODY \
   "(generate-function-body):" \
+  "(generate-havocing-body):" \
   "(generate-function-body-options):"
 
 #define HELP_REPLACE_FUNCTION_BODY \
   " --generate-function-body <regex>\n" \
   /* NOLINTNEXTLINE(whitespace/line_length) */ \
   "                              Generate bodies for functions matching regex\n" \
+  " --generate-havocing-body <option>\n" \
+  /* NOLINTNEXTLINE(whitespace/line_length) */ \
+  "                              <fun_name>,params:<p_n1;p_n2;..>\n" \
+  "                              or\n" \
+  /* NOLINTNEXTLINE(whitespace/line_length) */ \
+  "                              <fun_name>[,<call-site-id>,params:<p_n1;p_n2;..>]+\n" \
   " --generate-function-body-options <option>\n" \
   "                              One of assert-false, assume-false,\n" \
   /* NOLINTNEXTLINE(whitespace/line_length) */ \
   "                              nondet-return, assert-false-assume-false and\n" \
   "                              havoc[,params:<regex>][,globals:<regex>]\n" \
-  "                              (default: nondet-return)"
+  "                                   [,params:<p_n1;p_n2;..>]\n" \
+  "                              (default: nondet-return)\n"
 // clang-format on
 
 #endif // CPROVER_GOTO_PROGRAMS_GENERATE_FUNCTION_BODIES_H

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -20,6 +20,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/exit_codes.h>
 #include <util/json.h>
 #include <util/string2int.h>
+#include <util/string_utils.h>
 #include <util/unicode.h>
 #include <util/version.h>
 
@@ -1252,6 +1253,52 @@ void goto_instrument_parse_optionst::instrument_goto_program()
       *generate_implementation,
       goto_model,
       ui_message_handler);
+  }
+
+  if(cmdline.isset("generate-havocing-body"))
+  {
+    optionst c_object_factory_options;
+    parse_c_object_factory_options(cmdline, c_object_factory_options);
+    c_object_factory_parameterst object_factory_parameters(
+      c_object_factory_options);
+
+    auto options_split =
+      split_string(cmdline.get_value("generate-havocing-body"), ',');
+    if(options_split.size() < 2)
+      throw invalid_command_line_argument_exceptiont{
+        "not enough arguments for this option", "--generate-havocing-body"};
+
+    if(options_split.size() == 2)
+    {
+      auto generate_implementation = generate_function_bodies_factory(
+        std::string{"havoc,"} + options_split.back(),
+        object_factory_parameters,
+        goto_model.symbol_table,
+        ui_message_handler);
+      generate_function_bodies(
+        std::regex(options_split[0]),
+        *generate_implementation,
+        goto_model,
+        ui_message_handler);
+    }
+    else
+    {
+      CHECK_RETURN(options_split.size() % 2 == 1);
+      for(size_t i = 1; i + 1 < options_split.size(); i += 2)
+      {
+        auto generate_implementation = generate_function_bodies_factory(
+          std::string{"havoc,"} + options_split[i + 1],
+          object_factory_parameters,
+          goto_model.symbol_table,
+          ui_message_handler);
+        generate_function_bodies(
+          options_split[0],
+          options_split[i],
+          *generate_implementation,
+          goto_model,
+          ui_message_handler);
+      }
+    }
   }
 
   // add generic checks, if needed


### PR DESCRIPTION
Adds option `--generate-havocing-body 'fun,1,params:0;2,2,params:1` for
body-less function `fun` generates two bodies `fun.1` and `fun.2` and re-names
the respective call-sites. The first body havoc(s) the 0th and 2nd parameter,
the second body havoc(s) the 1st parameter.

The ability to selectively havoc parameter by their numbers was added to the
existing option `generate-function-body`.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
