### PR TITLE
remove type-symbol case in has_subtype()

### DIFF
--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -171,8 +171,6 @@ bool has_subtype(
 
     if(pred(top))
       return true;
-    else if(top.id() == ID_symbol)
-      push_if_not_visited(ns.follow(top));
     else if(top.id() == ID_c_enum_tag)
       push_if_not_visited(ns.follow_tag(to_c_enum_tag_type(top)));
     else if(top.id() == ID_struct_tag)


### PR DESCRIPTION
Type symbols no longer exist, i.e., this removes dead code.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
