### PR TITLE
deprecate a split_string variant

### DIFF
--- a/src/goto-harness/memory_snapshot_harness_generator.cpp
+++ b/src/goto-harness/memory_snapshot_harness_generator.cpp
@@ -90,8 +90,8 @@ void memory_snapshot_harness_generatort::handle_option(
   }
   else if(option == MEMORY_SNAPSHOT_HARNESS_HAVOC_VARIABLES_OPT)
   {
-    std::vector<std::string> havoc_candidates;
-    split_string(values.front(), ',', havoc_candidates, true);
+    std::vector<std::string> havoc_candidates =
+      split_string(values.front(), ',', true);
     for(const auto &candidate : havoc_candidates)
     {
       variables_to_havoc.insert(candidate);
@@ -431,8 +431,7 @@ memory_snapshot_harness_generatort::entry_goto_locationt
 memory_snapshot_harness_generatort::parse_goto_location(
   const std::string &cmdl_option)
 {
-  std::vector<std::string> start;
-  split_string(cmdl_option, ':', start, true);
+  std::vector<std::string> start = split_string(cmdl_option, ':', true);
 
   if(
     start.empty() || start.front().empty() ||

--- a/src/goto-instrument/splice_call.cpp
+++ b/src/goto-instrument/splice_call.cpp
@@ -31,8 +31,8 @@ static bool parse_caller_callee(
   const std::string &callercallee,
   std::vector<std::string> &result)
 {
-  split_string(callercallee, ',', result);
-  return (result.size()!= 2);
+  result = split_string(callercallee, ',');
+  return result.size() != 2;
 }
 
 bool splice_call(

--- a/src/util/string_utils.h
+++ b/src/util/string_utils.h
@@ -10,6 +10,8 @@ Author: Daniel Poetzl
 #ifndef CPROVER_UTIL_STRING_UTILS_H
 #define CPROVER_UTIL_STRING_UTILS_H
 
+#include "deprecate.h"
+
 #include <iosfwd>
 #include <string>
 #include <vector>
@@ -26,6 +28,11 @@ std::string strip_string(const std::string &s);
 /// \param remove_empty: If true, all empty-string elements will be removed.
 ///   This is applied after strip so whitespace only elements will be removed if
 ///   both are set to true.
+DEPRECATED(SINCE(
+  2019,
+  11,
+  14,
+  "use split_string(s, delim, strip, remove_empty) instead"))
 void split_string(
   const std::string &s,
   char delim,


### PR DESCRIPTION
This deprecates the variant of `split_string` that uses a parameter to return
the result.  This is no longer appropriate since C++11's rvalue references.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
