### PR TITLE
C++20 replacements for has_suffix/has_prefix

### DIFF
--- a/src/util/prefix.h
+++ b/src/util/prefix.h
@@ -12,6 +12,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <string>
 
+// C++20 will have std::string::starts_with
+
 inline bool has_prefix(const std::string &s, const std::string &prefix)
 {
   return s.compare(0, prefix.size(), prefix)==0;

--- a/src/util/suffix.h
+++ b/src/util/suffix.h
@@ -12,6 +12,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <string>
 
+// C++20 will have std::string::ends_with
+
 inline bool has_suffix(const std::string &s, const std::string &suffix)
 {
   if(suffix.size()>s.size())


### PR DESCRIPTION
This clarifies the intended meaning of the existing functions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
