### PR TITLE
Fix split_string remove_empty case

### DIFF
--- a/src/util/string_utils.cpp
+++ b/src/util/string_utils.cpp
@@ -50,7 +50,8 @@ void split_string(
 
   if(s.empty())
   {
-    result.push_back("");
+    if(!remove_empty)
+      result.push_back("");
     return;
   }
 
@@ -84,7 +85,7 @@ void split_string(
   if(!remove_empty || !new_s.empty())
     result.push_back(new_s);
 
-  if(result.empty())
+  if(!remove_empty && result.empty())
     result.push_back("");
 }
 

--- a/unit/util/string_utils/split_string.cpp
+++ b/unit/util/string_utils/split_string.cpp
@@ -113,11 +113,8 @@ SCENARIO("split_string", "[core][utils][string_utils][split_string]")
       expected_resultst expected_results;
       expected_results.no_strip_no_remove = {""};
       expected_results.strip_no_remove = {""};
-
-      // TODO(tkiley): This is probably wrong, since I'd expect removing empty
-      // TODO(tkiley): elements to return an empty vector here.
-      expected_results.no_strip_remove_empty = {""};
-      expected_results.strip_remove_empty = {""};
+      expected_results.no_strip_remove_empty = {};
+      expected_results.strip_remove_empty = {};
 
       run_on_all_variants(string, ',', expected_results);
     }
@@ -131,9 +128,7 @@ SCENARIO("split_string", "[core][utils][string_utils][split_string]")
       expected_results.no_strip_no_remove = {"    "};
       expected_results.strip_no_remove = {""};
       expected_results.no_strip_remove_empty = {"    "};
-      // TODO(tkiley): This is probably wrong, since I'd expect removing empty
-      // TODO(tkiley): elements to return an empty vector here.
-      expected_results.strip_remove_empty = {""};
+      expected_results.strip_remove_empty = {};
 
       run_on_all_variants(string, ',', expected_results);
     }


### PR DESCRIPTION
This fixes cases in which `split_string` returns empty strings despite being
given the `remove_empty` option.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
