### PR TITLE
Refactor rebuild entry points [TG-9888] [Blocks: 5195]

### DIFF
--- a/src/goto-programs/lazy_goto_model.cpp
+++ b/src/goto-programs/lazy_goto_model.cpp
@@ -201,6 +201,10 @@ void lazy_goto_modelt::initialize(
 
   if(binaries_provided_start && options.is_set("function"))
   {
+    // The goto binaries provided already contain a __CPROVER_start
+    // function that may be tied to a different entry point `function`.
+    // Hence, we will rebuild the __CPROVER_start function.
+
     // Get the language annotation of the existing __CPROVER_start function.
     std::unique_ptr<languaget> language =
       get_entry_point_language(symbol_table, options, message_handler);

--- a/src/goto-programs/rebuild_goto_start_function.cpp
+++ b/src/goto-programs/rebuild_goto_start_function.cpp
@@ -19,50 +19,9 @@ Author: Thomas Kiley, thomas@diffblue.com
 #include <langapi/mode.h>
 #include <langapi/language.h>
 
+#include <goto-programs/goto_functions.h>
+
 #include <memory>
-
-/// To rebuild the _start function in the event the program was compiled into
-/// GOTO with a different entry function selected.
-/// \param options: Command-line options
-/// \param goto_model: The goto functions (to replace the body of the _start
-///   function) and symbol table (to replace the _start function symbol) of the
-///   program.
-/// \param message_handler: The message handler to report any messages with
-template <typename maybe_lazy_goto_modelt>
-rebuild_goto_start_function_baset<maybe_lazy_goto_modelt>::
-  rebuild_goto_start_function_baset(
-    const optionst &options,
-    maybe_lazy_goto_modelt &goto_model,
-    message_handlert &message_handler)
-  : messaget(message_handler), options(options), goto_model(goto_model)
-{
-}
-
-/// To rebuild the _start function in the event the program was compiled into
-/// GOTO with a different entry function selected. It works by discarding the
-/// _start symbol and GOTO function and calling on the relevant languaget to
-/// generate the _start function again.
-/// \return Returns true if either the symbol is not found, or something went
-///   wrong with generating the start_function. False otherwise.
-template<typename maybe_lazy_goto_modelt>
-bool rebuild_goto_start_function_baset<maybe_lazy_goto_modelt>::operator()()
-{
-  std::unique_ptr<languaget> language = get_entry_point_language(
-    goto_model.symbol_table, options, get_message_handler());
-
-  // To create a new entry point we must first remove the old one
-  remove_existing_entry_point(goto_model.symbol_table);
-
-  bool return_code=
-    language->generate_support_functions(goto_model.symbol_table);
-
-  // Remove the function from the goto functions so it is copied back in
-  // from the symbol table during goto_convert
-  if(!return_code)
-    goto_model.unload(goto_functionst::entry_point());
-
-  return return_code;
-}
 
 std::unique_ptr<languaget> get_entry_point_language(
   const symbol_table_baset &symbol_table,
@@ -109,6 +68,3 @@ void remove_existing_entry_point(symbol_table_baset &symbol_table)
     symbol_table.remove(entry_point_symbol);
   }
 }
-
-template class rebuild_goto_start_function_baset<goto_modelt>;
-template class rebuild_goto_start_function_baset<lazy_goto_modelt>;

--- a/src/goto-programs/rebuild_goto_start_function.cpp
+++ b/src/goto-programs/rebuild_goto_start_function.cpp
@@ -47,13 +47,8 @@ rebuild_goto_start_function_baset<maybe_lazy_goto_modelt>::
 template<typename maybe_lazy_goto_modelt>
 bool rebuild_goto_start_function_baset<maybe_lazy_goto_modelt>::operator()()
 {
-  const irep_idt &mode = get_entry_point_mode(goto_model.symbol_table);
-
-  // Get the relevant languaget to generate the new entry point with
-  std::unique_ptr<languaget> language=get_language_from_mode(mode);
-  INVARIANT(language, "No language found for mode: "+id2string(mode));
-  language->set_message_handler(get_message_handler());
-  language->set_language_options(options);
+  std::unique_ptr<languaget> language = get_entry_point_language(
+    goto_model.symbol_table, options, get_message_handler());
 
   // To create a new entry point we must first remove the old one
   remove_existing_entry_point(goto_model.symbol_table);
@@ -67,6 +62,21 @@ bool rebuild_goto_start_function_baset<maybe_lazy_goto_modelt>::operator()()
     goto_model.unload(goto_functionst::entry_point());
 
   return return_code;
+}
+
+std::unique_ptr<languaget> get_entry_point_language(
+  const symbol_table_baset &symbol_table,
+  const optionst &options,
+  message_handlert &message_handler)
+{
+  const irep_idt &mode = get_entry_point_mode(symbol_table);
+
+  // Get the relevant languaget to generate the new entry point with
+  std::unique_ptr<languaget> language = get_language_from_mode(mode);
+  INVARIANT(language, "No language found for mode: " + id2string(mode));
+  language->set_message_handler(message_handler);
+  language->set_language_options(options);
+  return language;
 }
 
 const irep_idt &get_entry_point_mode(const symbol_table_baset &symbol_table)

--- a/src/goto-programs/rebuild_goto_start_function.cpp
+++ b/src/goto-programs/rebuild_goto_start_function.cpp
@@ -47,7 +47,7 @@ rebuild_goto_start_function_baset<maybe_lazy_goto_modelt>::
 template<typename maybe_lazy_goto_modelt>
 bool rebuild_goto_start_function_baset<maybe_lazy_goto_modelt>::operator()()
 {
-  const irep_idt &mode=get_entry_point_mode();
+  const irep_idt &mode = get_entry_point_mode(goto_model.symbol_table);
 
   // Get the relevant languaget to generate the new entry point with
   std::unique_ptr<languaget> language=get_language_from_mode(mode);
@@ -69,15 +69,10 @@ bool rebuild_goto_start_function_baset<maybe_lazy_goto_modelt>::operator()()
   return return_code;
 }
 
-/// Find out the mode of the current entry point to determine the mode of the
-/// replacement entry point
-/// \return A mode string saying which language to use
-template<typename maybe_lazy_goto_modelt>
-irep_idt rebuild_goto_start_function_baset<maybe_lazy_goto_modelt>::
-get_entry_point_mode() const
+const irep_idt &get_entry_point_mode(const symbol_table_baset &symbol_table)
 {
   const symbolt &current_entry_point =
-    goto_model.symbol_table.lookup_ref(goto_functionst::entry_point());
+    symbol_table.lookup_ref(goto_functionst::entry_point());
   return current_entry_point.mode;
 }
 

--- a/src/goto-programs/rebuild_goto_start_function.cpp
+++ b/src/goto-programs/rebuild_goto_start_function.cpp
@@ -30,8 +30,9 @@ std::unique_ptr<languaget> get_entry_point_language(
 {
   const irep_idt &mode = get_entry_point_mode(symbol_table);
 
-  // Get the relevant languaget to generate the new entry point with
+  // Get the relevant languaget to generate the new entry point with.
   std::unique_ptr<languaget> language = get_language_from_mode(mode);
+  // This might fail if the driver program hasn't registered that language.
   INVARIANT(language, "No language found for mode: " + id2string(mode));
   language->set_message_handler(message_handler);
   language->set_language_options(options);

--- a/src/goto-programs/rebuild_goto_start_function.cpp
+++ b/src/goto-programs/rebuild_goto_start_function.cpp
@@ -56,7 +56,7 @@ bool rebuild_goto_start_function_baset<maybe_lazy_goto_modelt>::operator()()
   language->set_language_options(options);
 
   // To create a new entry point we must first remove the old one
-  remove_existing_entry_point();
+  remove_existing_entry_point(goto_model.symbol_table);
 
   bool return_code=
     language->generate_support_functions(goto_model.symbol_table);
@@ -81,18 +81,14 @@ get_entry_point_mode() const
   return current_entry_point.mode;
 }
 
-/// Eliminate the existing entry point function symbol and any symbols created
-/// in that scope from the symbol table.
-template<typename maybe_lazy_goto_modelt>
-void rebuild_goto_start_function_baset<maybe_lazy_goto_modelt>::
-remove_existing_entry_point()
+void remove_existing_entry_point(symbol_table_baset &symbol_table)
 {
   // Remove the function itself
-  goto_model.symbol_table.remove(goto_functionst::entry_point());
+  symbol_table.remove(goto_functionst::entry_point());
 
   // And any symbols created in the scope of the entry point
   std::vector<irep_idt> entry_point_symbols;
-  for(const auto &symbol_entry : goto_model.symbol_table.symbols)
+  for(const auto &symbol_entry : symbol_table.symbols)
   {
     const bool is_entry_point_symbol=
       has_prefix(
@@ -105,7 +101,7 @@ remove_existing_entry_point()
 
   for(const irep_idt &entry_point_symbol : entry_point_symbols)
   {
-    goto_model.symbol_table.remove(entry_point_symbol);
+    symbol_table.remove(entry_point_symbol);
   }
 }
 

--- a/src/goto-programs/rebuild_goto_start_function.h
+++ b/src/goto-programs/rebuild_goto_start_function.h
@@ -54,6 +54,15 @@ void remove_existing_entry_point(symbol_table_baset &);
 /// \return A mode string saying which language to use
 const irep_idt &get_entry_point_mode(const symbol_table_baset &);
 
+/// Find the language corresponding to the __CPROVER_start function
+/// \param symbol_table: The symbol table of the goto model.
+/// \param options: Command-line options
+/// \param message_handler: The message handler to report any messages with
+std::unique_ptr<languaget> get_entry_point_language(
+  const symbol_table_baset &symbol_table,
+  const optionst &options,
+  message_handlert &message_handler);
+
 // NOLINTNEXTLINE(readability/namespace)  using required for templates
 using rebuild_goto_start_functiont =
   rebuild_goto_start_function_baset<goto_modelt>;

--- a/src/goto-programs/rebuild_goto_start_function.h
+++ b/src/goto-programs/rebuild_goto_start_function.h
@@ -49,6 +49,11 @@ private:
 /// in that scope from the \p symbol_table.
 void remove_existing_entry_point(symbol_table_baset &);
 
+/// Find out the mode of the current entry point to determine the mode of the
+/// replacement entry point
+/// \return A mode string saying which language to use
+const irep_idt &get_entry_point_mode(const symbol_table_baset &);
+
 // NOLINTNEXTLINE(readability/namespace)  using required for templates
 using rebuild_goto_start_functiont =
   rebuild_goto_start_function_baset<goto_modelt>;

--- a/src/goto-programs/rebuild_goto_start_function.h
+++ b/src/goto-programs/rebuild_goto_start_function.h
@@ -12,38 +12,20 @@ Author: Thomas Kiley, thomas@diffblue.com
 #ifndef CPROVER_GOTO_PROGRAMS_REBUILD_GOTO_START_FUNCTION_H
 #define CPROVER_GOTO_PROGRAMS_REBUILD_GOTO_START_FUNCTION_H
 
-#include <util/message.h>
+#include <memory>
+
+#include <util/irep.h>
+
+class languaget;
+class message_handlert;
 class optionst;
-
-#include "lazy_goto_model.h"
-
-
-class symbol_tablet;
-class goto_functionst;
+class symbol_table_baset;
 
 #define OPT_FUNCTIONS \
   "(function):"
 
 #define HELP_FUNCTIONS \
   " --function name              set main function name\n"
-
-template<typename maybe_lazy_goto_modelt>
-class rebuild_goto_start_function_baset: public messaget
-{
-public:
-  rebuild_goto_start_function_baset(
-    const optionst &options,
-    maybe_lazy_goto_modelt &goto_model,
-    message_handlert &message_handler);
-
-  bool operator()();
-
-private:
-  irep_idt get_entry_point_mode() const;
-
-  const optionst &options;
-  maybe_lazy_goto_modelt &goto_model;
-};
 
 /// Eliminate the existing entry point function symbol and any symbols created
 /// in that scope from the \p symbol_table.
@@ -62,13 +44,5 @@ std::unique_ptr<languaget> get_entry_point_language(
   const symbol_table_baset &symbol_table,
   const optionst &options,
   message_handlert &message_handler);
-
-// NOLINTNEXTLINE(readability/namespace)  using required for templates
-using rebuild_goto_start_functiont =
-  rebuild_goto_start_function_baset<goto_modelt>;
-
-// NOLINTNEXTLINE(readability/namespace)  using required for templates
-using rebuild_lazy_goto_start_functiont =
-  rebuild_goto_start_function_baset<lazy_goto_modelt>;
 
 #endif // CPROVER_GOTO_PROGRAMS_REBUILD_GOTO_START_FUNCTION_H

--- a/src/goto-programs/rebuild_goto_start_function.h
+++ b/src/goto-programs/rebuild_goto_start_function.h
@@ -41,11 +41,13 @@ public:
 private:
   irep_idt get_entry_point_mode() const;
 
-  void remove_existing_entry_point();
-
   const optionst &options;
   maybe_lazy_goto_modelt &goto_model;
 };
+
+/// Eliminate the existing entry point function symbol and any symbols created
+/// in that scope from the \p symbol_table.
+void remove_existing_entry_point(symbol_table_baset &);
 
 // NOLINTNEXTLINE(readability/namespace)  using required for templates
 using rebuild_goto_start_functiont =


### PR DESCRIPTION
Replaces the rebuild_goto_start_function class by free functions and removes the dependency on lazy_goto_model, which will allow me to move it away from goto-programs in a follow-up PR.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
