### PR TITLE
Correct nondet init of function pointer arguments

### DIFF
--- a/regression/cbmc/pointer-function-origin-argument/main.c
+++ b/regression/cbmc/pointer-function-origin-argument/main.c
@@ -1,0 +1,8 @@
+#include <assert.h>
+
+typedef int (*other_function_type)(int n);
+
+void foo(other_function_type other_function)
+{
+  assert(other_function(4) > 5);
+}

--- a/regression/cbmc/pointer-function-origin-argument/test.desc
+++ b/regression/cbmc/pointer-function-origin-argument/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--function foo
+^EXIT=10$
+^SIGNAL=0$
+^\[foo.assertion.\d+\] line \d+ assertion other_function\(4\) > 5: FAILURE$
+VERIFICATION FAILED
+--
+^warning: ignoring

--- a/src/ansi-c/c_nondet_symbol_factory.cpp
+++ b/src/ansi-c/c_nondet_symbol_factory.cpp
@@ -54,6 +54,13 @@ void symbol_factoryt::gen_nondet_init(
     const pointer_typet &pointer_type=to_pointer_type(type);
     const typet &subtype = pointer_type.subtype();
 
+    if(subtype.id() == ID_code)
+    {
+      assignments.add(
+        code_assignt{expr, side_effect_expr_nondett{pointer_type, loc}});
+      return;
+    }
+
     if(subtype.id() == ID_struct_tag)
     {
       const irep_idt struct_tag = to_struct_tag_type(subtype).get_identifier();

--- a/src/ansi-c/c_nondet_symbol_factory.cpp
+++ b/src/ansi-c/c_nondet_symbol_factory.cpp
@@ -54,10 +54,44 @@ void symbol_factoryt::gen_nondet_init(
     const pointer_typet &pointer_type=to_pointer_type(type);
     const typet &subtype = pointer_type.subtype();
 
+    //TODO check if really is not target candidate
     if(subtype.id() == ID_code)
     {
+      symbolt function_symbol;
+      code_typet function_type = to_code_type(subtype);
+
+      for(size_t index = 0; index < function_type.parameters().size(); index++)
+      {
+        auto &param = function_type.parameters().at(index);
+        symbolt param_symbol;
+        param_symbol.type = param.type();
+        param_symbol.name = "param" + std::to_string(index);
+        param_symbol.base_name = param_symbol.name;
+        param_symbol.pretty_name = param_symbol.name;
+        param_symbol.mode = "C";
+        param_symbol.is_parameter = true;
+        //TODO check if not present
+        symbol_table.add(param_symbol);
+        param.set_identifier(param_symbol.name);
+        //TODO flags
+      }
+      function_symbol.type = function_type;
+      code_blockt function_body;
+      function_body.add(
+        code_returnt{side_effect_expr_nondett{function_type.return_type()}});
+      function_symbol.value = function_body;
+      //      function_symbol.name = CPROVER_PREFIX "_generated_function";
+      function_symbol.name = "my_generated_function";
+      function_symbol.base_name = function_symbol.name;
+      function_symbol.pretty_name = function_symbol.name;
+      function_symbol.mode = "C";
+      //TODO set flags
+      symbol_table.add(function_symbol);
+
+      // assignments.add(
+      //   code_assignt{expr, side_effect_expr_nondett{pointer_type, loc}});
       assignments.add(
-        code_assignt{expr, side_effect_expr_nondett{pointer_type, loc}});
+        code_assignt{expr, address_of_exprt{function_symbol.symbol_expr()}});
       return;
     }
 

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -447,8 +447,8 @@ void remove_function_pointerst::remove_function_pointer(
   // entry point
   if(functions.empty() && calling_from_entry() && target_is_param())
     ;
-  else
-    new_code_gotos.add(goto_programt::make_assumption(false_exprt()));
+  //else
+  new_code_gotos.add(goto_programt::make_assumption(false_exprt()));
 
   goto_programt new_code;
 


### PR DESCRIPTION
At least until handling of function pointers is transferred to symex.

1. The nondet symbol factory only assigns nondet to function pointers, i.e. does
not build the `depth` deep pointer tree.
2. The function pointer removal checks if the pointer is an argument to the
entry point and if so, skips adding the `assume(false)` for cutting short the
execution in case on function target was found.

add 2: On the GOTO level, the function call is replaced with `return_value`
which is never assigned to.

Notes:
- this is an alternative/extension to #4940 which only changed the factory.
- both PRs try to fix #4937.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
