### PR TITLE
Sizeof should fail on incomplete types

### DIFF
--- a/regression/cbmc/incomplete-sizeof/array.c
+++ b/regression/cbmc/incomplete-sizeof/array.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int arr[];
+
+int main(int argc, char **argv)
+{
+  size_t s = sizeof(arr);
+  assert(s == 4);
+}

--- a/regression/cbmc/incomplete-sizeof/array.desc
+++ b/regression/cbmc/incomplete-sizeof/array.desc
@@ -1,0 +1,9 @@
+CORE
+array.c
+
+^EXIT=6$
+^SIGNAL=0$
+^file array.c line \d+ function main: invalid application of \'sizeof\' to an incomplete type$
+^CONVERSION ERROR$
+--
+^warning: ignoring

--- a/regression/cbmc/incomplete-sizeof/enum.c
+++ b/regression/cbmc/incomplete-sizeof/enum.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+#include <stdlib.h>
+
+enum foo;
+
+int main(int argc, char **argv)
+{
+  size_t s = sizeof(enum foo);
+  assert(s == 0);
+}

--- a/regression/cbmc/incomplete-sizeof/enum.desc
+++ b/regression/cbmc/incomplete-sizeof/enum.desc
@@ -1,0 +1,9 @@
+CORE
+enum.c
+
+^EXIT=6$
+^SIGNAL=0$
+^file enum.c line \d+ function main: invalid application of \'sizeof\' to an incomplete type$
+^CONVERSION ERROR$
+--
+^warning: ignoring

--- a/regression/cbmc/incomplete-sizeof/struct.c
+++ b/regression/cbmc/incomplete-sizeof/struct.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+#include <stdlib.h>
+
+struct foo;
+
+int main(int argc, char **argv)
+{
+  struct foo *thefoo = malloc(sizeof(struct foo));
+  size_t s = sizeof(struct foo);
+  assert(s == 0);
+}

--- a/regression/cbmc/incomplete-sizeof/struct.desc
+++ b/regression/cbmc/incomplete-sizeof/struct.desc
@@ -1,0 +1,9 @@
+CORE
+struct.c
+
+^EXIT=6$
+^SIGNAL=0$
+^file struct.c line \d+ function main: invalid application of \'sizeof\' to an incomplete type$
+^CONVERSION ERROR$
+--
+^warning: ignoring

--- a/regression/cbmc/incomplete-sizeof/union.c
+++ b/regression/cbmc/incomplete-sizeof/union.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+#include <stdlib.h>
+
+union foo;
+
+int main(int argc, char **argv)
+{
+  size_t s = sizeof(union foo);
+  assert(s == 0);
+}

--- a/regression/cbmc/incomplete-sizeof/union.desc
+++ b/regression/cbmc/incomplete-sizeof/union.desc
@@ -1,0 +1,9 @@
+CORE
+union.c
+
+^EXIT=6$
+^SIGNAL=0$
+^file union.c line \d+ function main: invalid application of \'sizeof\' to an incomplete type$
+^CONVERSION ERROR$
+--
+^warning: ignoring

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -951,6 +951,21 @@ void c_typecheck_baset::typecheck_expr_sizeof(exprt &expr)
   }
   else
   {
+    if(
+      (type.id() == ID_struct_tag &&
+       follow_tag(to_struct_tag_type(type)).is_incomplete()) ||
+      (type.id() == ID_union_tag &&
+       follow_tag(to_union_tag_type(type)).is_incomplete()) ||
+      (type.id() == ID_c_enum_tag &&
+       follow_tag(to_c_enum_tag_type(type)).is_incomplete()) ||
+      (type.id() == ID_array && to_array_type(type).is_incomplete()))
+    {
+      error().source_location = expr.source_location();
+      error() << "invalid application of \'sizeof\' to an incomplete type\n\t\'"
+              << to_string(type) << "\'" << eom;
+      throw 0;
+    }
+
     auto size_of_opt = size_of_expr(type, *this);
 
     if(!size_of_opt.has_value())


### PR DESCRIPTION
And so we check for it when type-checking the `sizeof` expression.

Note: previously, the `size-of-expr` function would return zero (sum of the struct components sizes).

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
