### PR TITLE
Feature/source location hint on symex failure

### DIFF
--- a/src/goto-checker/symex_bmc.cpp
+++ b/src/goto-checker/symex_bmc.cpp
@@ -44,10 +44,12 @@ void symex_bmct::symex_step(
   statet &state)
 {
   const source_locationt &source_location = state.source.pc->source_location;
-  // Turn on throwing invariants so we can safely log invariant failure during Symex
+  // Turn on throwing invariants so we can safely log invariant failure during
+  // Symex
   auto const invariants_should_throw_during_symex_step =
     cbmc_invariants_should_throwt{};
-  // If an exception is thrown during symex step, log the last relevant source location
+  // If an exception is thrown during symex step, log the last relevant
+  // source location
   auto const print_step_location_on_error =
     on_exit_scope_with_exception([source_location, this]() {
       auto const actual_source_location =

--- a/src/util/parse_options.cpp
+++ b/src/util/parse_options.cpp
@@ -118,6 +118,11 @@ int parse_options_baset::main()
     log.error() << e.what() << messaget::eom;
     return CPROVER_EXIT_EXCEPTION;
   }
+  catch(const invariant_failedt &invariant_failed)
+  {
+    log.error() << invariant_failed.what() << messaget::eom;
+    return CPROVER_EXIT_INTERNAL_ERROR;
+  }
   catch(...)
   {
     log.error() << "Unknown exception type!" << messaget::eom;

--- a/src/util/scope_guard.h
+++ b/src/util/scope_guard.h
@@ -67,4 +67,4 @@ on_exit_scope_with_exception(OnErrorHandler onErrorHandler)
     std::move(onErrorHandler)};
 }
 
-#endif //CPROVER_UTIL_SCOPE_GUARD_H
+#endif // CPROVER_UTIL_SCOPE_GUARD_H

--- a/src/util/scope_guard.h
+++ b/src/util/scope_guard.h
@@ -1,0 +1,68 @@
+/*******************************************************************\
+
+Module: Scope Guard
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_SCOPE_GUARD_H
+#define CPROVER_UTIL_SCOPE_GUARD_H
+
+#include <stdexcept>
+#include <utility>
+
+/// Execute some code if a scope is exited with an exception
+template <typename OnErrorHandler>
+class on_exit_scope_with_exceptiont
+{
+  OnErrorHandler handler;
+  int uncaught_exceptions_at_scope_start;
+  bool cancelled = false;
+
+public:
+  explicit on_exit_scope_with_exceptiont(OnErrorHandler handler)
+    : handler(std::move(handler)),
+      uncaught_exceptions_at_scope_start(std::uncaught_exceptions())
+  {
+  }
+
+  on_exit_scope_with_exceptiont(const on_exit_scope_with_exceptiont &) = delete;
+  on_exit_scope_with_exceptiont(on_exit_scope_with_exceptiont &&other) noexcept
+    : handler{std::move(other.handler)},
+      uncaught_exceptions_at_scope_start{
+        other.uncaught_exceptions_at_scope_start},
+      cancelled{false}
+  {
+    other.cancelled = true;
+  }
+  on_exit_scope_with_exceptiont &
+  operator=(const on_exit_scope_with_exceptiont &) = delete;
+  on_exit_scope_with_exceptiont &
+  operator=(on_exit_scope_with_exceptiont &&) = delete;
+
+  ~on_exit_scope_with_exceptiont()
+  {
+    // there was an uncaught exception in the scope of this guard if
+    // the number of uncaught exceptions has increased since its creation.
+    if(
+      !cancelled &&
+      std::uncaught_exceptions() > uncaught_exceptions_at_scope_start)
+    {
+      handler();
+    }
+  }
+};
+
+/// This is needed for usability with lambdas, as their types can’t be spelled
+/// in C++11
+/// \see on_exit_scope_with_exceptiont
+template <typename OnErrorHandler>
+on_exit_scope_with_exceptiont<OnErrorHandler>
+on_exit_scope_with_exception(OnErrorHandler onErrorHandler)
+{
+  return on_exit_scope_with_exceptiont<OnErrorHandler>{
+    std::move(onErrorHandler)};
+}
+
+#endif //CPROVER_UTIL_SCOPE_GUARD_H

--- a/src/util/scope_guard.h
+++ b/src/util/scope_guard.h
@@ -17,25 +17,26 @@ template <typename OnErrorHandler>
 class on_exit_scope_with_exceptiont
 {
   OnErrorHandler handler;
-  int uncaught_exceptions_at_scope_start;
+  std::exception_ptr uncaught_exception_at_scope_start;
   bool cancelled = false;
 
 public:
   explicit on_exit_scope_with_exceptiont(OnErrorHandler handler)
     : handler(std::move(handler)),
-      uncaught_exceptions_at_scope_start(std::uncaught_exceptions())
+      uncaught_exception_at_scope_start(std::current_exception())
   {
   }
 
   on_exit_scope_with_exceptiont(const on_exit_scope_with_exceptiont &) = delete;
   on_exit_scope_with_exceptiont(on_exit_scope_with_exceptiont &&other) noexcept
     : handler{std::move(other.handler)},
-      uncaught_exceptions_at_scope_start{
-        other.uncaught_exceptions_at_scope_start},
-      cancelled{false}
+      uncaught_exception_at_scope_start{
+        std::move(other.uncaught_exception_at_scope_start)},
+      cancelled{other.cancelled}
   {
     other.cancelled = true;
   }
+
   on_exit_scope_with_exceptiont &
   operator=(const on_exit_scope_with_exceptiont &) = delete;
   on_exit_scope_with_exceptiont &
@@ -44,10 +45,11 @@ public:
   ~on_exit_scope_with_exceptiont()
   {
     // there was an uncaught exception in the scope of this guard if
-    // the number of uncaught exceptions has increased since its creation.
+    // the current exception now is different than the current exception
+    // at the time of creating this object.
     if(
       !cancelled &&
-      std::uncaught_exceptions() > uncaught_exceptions_at_scope_start)
+      std::current_exception() != uncaught_exception_at_scope_start)
     {
       handler();
     }


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

Note that due to the nature of the change there aren’t any tests for the behaviour changes, though I’m going to add some unit tests for the new utility type.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
