### PR TITLE
Catch and log invariant errors when `cbmc_invariants_should_throwt` is enabled

### DIFF
--- a/src/util/parse_options.cpp
+++ b/src/util/parse_options.cpp
@@ -118,6 +118,11 @@ int parse_options_baset::main()
     log.error() << e.what() << messaget::eom;
     return CPROVER_EXIT_EXCEPTION;
   }
+  catch(const invariant_failedt &e)
+  {
+    log.error() << e.what() << messaget::eom;
+    return CPROVER_EXIT_EXCEPTION;
+  }
   catch(...)
   {
     log.error() << "Unknown exception type!" << messaget::eom;


### PR DESCRIPTION
If `cbmc_invariants_should_throwt` is enabled, then invariants become
exceptions, and we should log them instead of putting them into the catch
all with no information.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
