### PR TITLE
Make CMake generation of cprover_library.inc match with Makefile

### DIFF
--- a/src/ansi-c/CMakeLists.txt
+++ b/src/ansi-c/CMakeLists.txt
@@ -4,17 +4,10 @@ generic_flex(ansi_c)
 add_executable(converter library/converter.cpp)
 
 file(GLOB ansi_c_library_sources "library/*.c")
-set(converter_input_path "${CMAKE_CURRENT_SOURCE_DIR}/converter_input.txt")
-file(WRITE ${converter_input_path} "")
-foreach(source ${ansi_c_library_sources})
-    file(READ ${source} file_contents)
-    file(APPEND ${converter_input_path} "${file_contents}")
-endforeach()
 
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
-    COMMAND converter < ${converter_input_path} > "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
-    DEPENDS converter ${converter_input_path}
-)
+    COMMAND cat ${ansi_c_library_sources} | $<TARGET_FILE:converter> > "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
+    DEPENDS converter ${ansi_c_library_sources})
 
 add_executable(file_converter file_converter.cpp)
 


### PR DESCRIPTION
Before it appended the converter input at configure time, meaning if you changed
any of the model *.c files it’d actually not notice the change unless you ran
CMake again. This version will pick up such changes, and also matches what we
have in the current Makefile.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
