### PR TITLE
Add support for gccs __builtin_mul_overflow

### DIFF
--- a/regression/cbmc/gcc_builtin_mul_overflow/main.c
+++ b/regression/cbmc/gcc_builtin_mul_overflow/main.c
@@ -1,0 +1,116 @@
+#include <assert.h>
+#include <limits.h>
+#include <stdint.h>
+
+#define A_VALUE_X_SO_THAT_X_TIMES_X_DOES_NOT_OVERFLOW(T)                       \
+  (((T)(1)) << (sizeof(T) * CHAR_BIT) / 2 - 1)
+
+void check_int(void)
+{
+  int result;
+  assert(!__builtin_smul_overflow(1, 1, &result));
+  assert(result == 1);
+  int const lt_isqrt_of_int_max =
+    A_VALUE_X_SO_THAT_X_TIMES_X_DOES_NOT_OVERFLOW(int);
+  assert(!__builtin_smul_overflow(
+    lt_isqrt_of_int_max, lt_isqrt_of_int_max, &result));
+  assert(result == lt_isqrt_of_int_max * lt_isqrt_of_int_max);
+  assert(__builtin_smul_overflow(
+    lt_isqrt_of_int_max << 1, lt_isqrt_of_int_max << 1, &result));
+  assert(0 && "reachability");
+}
+
+void check_long(void)
+{
+  long result;
+  assert(!__builtin_smull_overflow(1l, 1l, &result));
+  assert(result == 1l);
+  long const lt_isqrt_of_long_max =
+    A_VALUE_X_SO_THAT_X_TIMES_X_DOES_NOT_OVERFLOW(long);
+  assert(!__builtin_smull_overflow(
+    lt_isqrt_of_long_max, lt_isqrt_of_long_max, &result));
+  assert(result == lt_isqrt_of_long_max * lt_isqrt_of_long_max);
+  assert(__builtin_smull_overflow(
+    lt_isqrt_of_long_max << 1, lt_isqrt_of_long_max << 1, &result));
+  assert(0 && "reachability");
+}
+
+void check_long_long(void)
+{
+  long long result;
+  assert(!__builtin_smulll_overflow(1ll, 1ll, &result));
+  assert(result == 1ll);
+  long long const lt_isqrt_of_long_long_max =
+    A_VALUE_X_SO_THAT_X_TIMES_X_DOES_NOT_OVERFLOW(long long);
+  assert(!__builtin_smulll_overflow(
+    lt_isqrt_of_long_long_max, lt_isqrt_of_long_long_max, &result));
+  assert(result == lt_isqrt_of_long_long_max * lt_isqrt_of_long_long_max);
+  assert(__builtin_smulll_overflow(
+    lt_isqrt_of_long_long_max << 1, lt_isqrt_of_long_long_max << 1, &result));
+  assert(0 && "reachability");
+}
+
+void check_unsigned(void)
+{
+  unsigned result;
+  assert(!__builtin_umul_overflow(1u, 1u, &result));
+  assert(result == 1u);
+  unsigned const lt_isqrt_of_unsigned_max =
+    A_VALUE_X_SO_THAT_X_TIMES_X_DOES_NOT_OVERFLOW(unsigned);
+  assert(!__builtin_umul_overflow(
+    lt_isqrt_of_unsigned_max, lt_isqrt_of_unsigned_max, &result));
+  assert(result == lt_isqrt_of_unsigned_max * lt_isqrt_of_unsigned_max);
+  assert(__builtin_umul_overflow(
+    lt_isqrt_of_unsigned_max << 1, lt_isqrt_of_unsigned_max << 1, &result));
+  assert(0 && "reachability");
+}
+
+void check_unsigned_long(void)
+{
+  unsigned long result;
+  assert(!__builtin_umull_overflow(1ul, 1ul, &result));
+  assert(result == 1ul);
+  unsigned long const lt_isqrt_of_unsigned_long_max =
+    A_VALUE_X_SO_THAT_X_TIMES_X_DOES_NOT_OVERFLOW(unsigned long);
+  assert(!__builtin_umull_overflow(
+    lt_isqrt_of_unsigned_long_max, lt_isqrt_of_unsigned_long_max, &result));
+  assert(
+    result == lt_isqrt_of_unsigned_long_max * lt_isqrt_of_unsigned_long_max);
+  assert(__builtin_umull_overflow(
+    lt_isqrt_of_unsigned_long_max << 1,
+    lt_isqrt_of_unsigned_long_max << 1,
+    &result));
+  assert(0 && "reachability");
+}
+
+void check_unsigned_long_long(void)
+{
+  unsigned long long result;
+  assert(!__builtin_umulll_overflow(1ull, 1ull, &result));
+  assert(result == 1ull);
+  unsigned long long const lt_isqrt_of_unsigned_long_long_max =
+    A_VALUE_X_SO_THAT_X_TIMES_X_DOES_NOT_OVERFLOW(unsigned long long);
+  assert(!__builtin_umulll_overflow(
+    lt_isqrt_of_unsigned_long_long_max,
+    lt_isqrt_of_unsigned_long_long_max,
+    &result));
+  assert(
+    result ==
+    lt_isqrt_of_unsigned_long_long_max * lt_isqrt_of_unsigned_long_long_max);
+  assert(__builtin_umulll_overflow(
+    lt_isqrt_of_unsigned_long_long_max << 1,
+    lt_isqrt_of_unsigned_long_long_max << 1,
+    &result));
+  assert(0 && "reachability");
+}
+
+int main(void)
+{
+  check_int();
+  check_long();
+  check_long_long();
+  check_unsigned();
+  check_unsigned_long();
+  check_unsigned_long_long();
+  return 0;
+}

--- a/regression/cbmc/gcc_builtin_mul_overflow/test.desc
+++ b/regression/cbmc/gcc_builtin_mul_overflow/test.desc
@@ -1,0 +1,41 @@
+CORE gcc-only
+main.c
+
+\[check_int.assertion.1\] line \d+ assertion !__builtin_smul_overflow\(1, 1, &result\): SUCCESS
+\[check_int.assertion.2\] line \d+ assertion result == 1: SUCCESS
+\[check_int.assertion.3\] line \d+ assertion !__builtin_smul_overflow\( lt_isqrt_of_int_max, lt_isqrt_of_int_max, &result\): SUCCESS
+\[check_int.assertion.4\] line \d+ assertion result == lt_isqrt_of_int_max \* lt_isqrt_of_int_max: SUCCESS
+\[check_int.assertion.5\] line \d+ assertion __builtin_smul_overflow\( lt_isqrt_of_int_max << 1, lt_isqrt_of_int_max << 1, &result\): SUCCESS
+\[check_int.assertion.6\] line \d+ assertion 0 && "reachability": FAILURE
+\[check_long.assertion.1\] line \d+ assertion !__builtin_smull_overflow\(1l, 1l, &result\): SUCCESS
+\[check_long.assertion.2\] line \d+ assertion result == 1l: SUCCESS
+\[check_long.assertion.3\] line \d+ assertion !__builtin_smull_overflow\( lt_isqrt_of_long_max, lt_isqrt_of_long_max, &result\): SUCCESS
+\[check_long.assertion.4\] line \d+ assertion result == lt_isqrt_of_long_max \* lt_isqrt_of_long_max: SUCCESS
+\[check_long.assertion.5\] line \d+ assertion __builtin_smull_overflow\( lt_isqrt_of_long_max << 1, lt_isqrt_of_long_max << 1, &result\): SUCCESS
+\[check_long.assertion.6\] line \d+ assertion 0 && "reachability": FAILURE
+\[check_long_long.assertion.1\] line \d+ assertion !__builtin_smulll_overflow\(1ll, 1ll, &result\): SUCCESS
+\[check_long_long.assertion.2\] line \d+ assertion result == 1ll: SUCCESS
+\[check_long_long.assertion.3\] line \d+ assertion !__builtin_smulll_overflow\( lt_isqrt_of_long_long_max, lt_isqrt_of_long_long_max, &result\): SUCCESS
+\[check_long_long.assertion.4\] line \d+ assertion result == lt_isqrt_of_long_long_max \* lt_isqrt_of_long_long_max: SUCCESS
+\[check_long_long.assertion.5\] line \d+ assertion __builtin_smulll_overflow\( lt_isqrt_of_long_long_max << 1, lt_isqrt_of_long_long_max << 1, &result\): SUCCESS
+\[check_long_long.assertion.6\] line \d+ assertion 0 && "reachability": FAILURE
+\[check_unsigned.assertion.1\] line \d+ assertion !__builtin_umul_overflow\(1u, 1u, &result\): SUCCESS
+\[check_unsigned.assertion.2\] line \d+ assertion result == 1u: SUCCESS
+\[check_unsigned.assertion.3\] line \d+ assertion !__builtin_umul_overflow\( lt_isqrt_of_unsigned_max, lt_isqrt_of_unsigned_max, &result\): SUCCESS
+\[check_unsigned.assertion.4\] line \d+ assertion result == lt_isqrt_of_unsigned_max \* lt_isqrt_of_unsigned_max: SUCCESS
+\[check_unsigned.assertion.5\] line \d+ assertion __builtin_umul_overflow\( lt_isqrt_of_unsigned_max << 1, lt_isqrt_of_unsigned_max << 1, &result\): SUCCESS
+\[check_unsigned.assertion.6\] line \d+ assertion 0 && "reachability": FAILURE
+\[check_unsigned_long.assertion.1\] line \d+ assertion !__builtin_umull_overflow\(1ul, 1ul, &result\): SUCCESS
+\[check_unsigned_long.assertion.2\] line \d+ assertion result == 1ul: SUCCESS
+\[check_unsigned_long.assertion.3\] line \d+ assertion !__builtin_umull_overflow\( lt_isqrt_of_unsigned_long_max, lt_isqrt_of_unsigned_long_max, &result\): SUCCESS
+\[check_unsigned_long.assertion.4\] line \d+ assertion result == lt_isqrt_of_unsigned_long_max \* lt_isqrt_of_unsigned_long_max: SUCCESS
+\[check_unsigned_long.assertion.5\] line \d+ assertion __builtin_umull_overflow\( lt_isqrt_of_unsigned_long_max << 1, lt_isqrt_of_unsigned_long_max << 1, &result\): SUCCESS
+\[check_unsigned_long.assertion.6\] line \d+ assertion 0 && "reachability": FAILURE
+\[check_unsigned_long_long.assertion.1\] line \d+ assertion !__builtin_umulll_overflow\(1ull, 1ull, &result\): SUCCESS
+\[check_unsigned_long_long.assertion.2\] line \d+ assertion result == 1ull: SUCCESS
+\[check_unsigned_long_long.assertion.3\] line \d+ assertion !__builtin_umulll_overflow\( lt_isqrt_of_unsigned_long_long_max, lt_isqrt_of_unsigned_long_long_max, &result\): SUCCESS
+\[check_unsigned_long_long.assertion.4\] line \d+ assertion result == lt_isqrt_of_unsigned_long_long_max \* lt_isqrt_of_unsigned_long_long_max: SUCCESS
+\[check_unsigned_long_long.assertion.5\] line \d+ assertion __builtin_umulll_overflow\( lt_isqrt_of_unsigned_long_long_max << 1, lt_isqrt_of_unsigned_long_long_max << 1, &result\): SUCCESS
+\[check_unsigned_long_long.assertion.6\] line \d+ assertion 0 && "reachability": FAILURE
+^EXIT=10$
+^SIGNAL=0$

--- a/src/ansi-c/library/math.c
+++ b/src/ansi-c/library/math.c
@@ -2406,3 +2406,57 @@ _Bool __builtin_usubll_overflow(
   *res = a - b;
   return __CPROVER_overflow_minus(a, b);
 }
+
+/* FUNCTION: __builtin_smul_overflow */
+
+_Bool __builtin_smul_overflow(int a, int b, int *res)
+{
+  *res = a * b;
+  return __CPROVER_overflow_mult(a, b);
+}
+
+/* FUNCTION: __builtin_smull_overflow */
+
+_Bool __builtin_smull_overflow(long a, long b, long *res)
+{
+  *res = a * b;
+  return __CPROVER_overflow_mult(a, b);
+}
+
+/* FUNCTION: __builtin_smulll_overflow */
+
+_Bool __builtin_smulll_overflow(long long a, long long b, long long *res)
+{
+  *res = a * b;
+  return __CPROVER_overflow_mult(a, b);
+}
+
+/* FUNCTION: __builtin_umul_overflow */
+
+_Bool __builtin_umul_overflow(unsigned a, unsigned b, unsigned *res)
+{
+  *res = a * b;
+  return __CPROVER_overflow_mult(a, b);
+}
+
+/* FUNCTION: __builtin_umull_overflow */
+
+_Bool __builtin_umull_overflow(
+  unsigned long a,
+  unsigned long b,
+  unsigned long *res)
+{
+  *res = a * b;
+  return __CPROVER_overflow_mult(a, b);
+}
+
+/* FUNCTION: __builtin_umulll_overflow */
+
+_Bool __builtin_umulll_overflow(
+  unsigned long long a,
+  unsigned long long b,
+  unsigned long long *res)
+{
+  *res = a * b;
+  return __CPROVER_overflow_mult(a, b);
+}


### PR DESCRIPTION
Not the generic version.

This is a continuation of https://github.com/diffblue/cbmc/pull/5235. Once this is merged we’ll support all the non-generic overflow builtins.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
