### PR TITLE
Refinement iteration printing

### DIFF
--- a/regression/cbmc-incr-oneloop/alarm2/test-json-output.desc
+++ b/regression/cbmc-incr-oneloop/alarm2/test-json-output.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--incremental-loop main.0 --unwind-min 5 --unwind-max 10 --json-ui
+^EXIT=10$
+^SIGNAL=0$
+"messageText": "VERIFICATION FAILED"
+"currentUnwinding": 1
+--
+^warning: ignoring

--- a/regression/cbmc-incr-oneloop/alarm2/test-xml-output.desc
+++ b/regression/cbmc-incr-oneloop/alarm2/test-xml-output.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--incremental-loop main.0 --unwind-min 5 --unwind-max 10 --xml-ui
+^EXIT=10$
+^SIGNAL=0$
+<text>VERIFICATION FAILED</text>
+<current-unwinding>1</current-unwinding>
+<refinement-iteration>1</refinement-iteration>
+--
+^warning: ignoring

--- a/regression/cbmc-incr-oneloop/alarm2/test.desc
+++ b/regression/cbmc-incr-oneloop/alarm2/test.desc
@@ -1,6 +1,7 @@
 CORE
 main.c
 --incremental-loop main.0 --unwind-min 5 --unwind-max 10
+Current unwinding: 1
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/src/goto-checker/single_loop_incremental_symex_checker.cpp
+++ b/src/goto-checker/single_loop_incremental_symex_checker.cpp
@@ -34,7 +34,8 @@ single_loop_incremental_symex_checkert::single_loop_incremental_symex_checkert(
       equation,
       options,
       path_storage,
-      guard_manager),
+      guard_manager,
+      ui_message_handler.get_ui()),
     property_decider(options, ui_message_handler, equation, ns)
 {
   setup_symex(symex, ns, options, ui_message_handler);

--- a/src/goto-checker/symex_bmc_incremental_one_loop.cpp
+++ b/src/goto-checker/symex_bmc_incremental_one_loop.cpp
@@ -88,14 +88,7 @@ bool symex_bmc_incremental_one_loopt::should_stop_unwind(
     abort_unwind_decision.is_known(), "unwind decision should be taken by now");
   bool abort = abort_unwind_decision.is_true();
 
-
-  if(output_ui == ui_message_handlert::uit::XML_UI)
-  {
-    xmlt xml("current-unwinding");
-    xml.data = std::to_string(unwind);
-    log.statistics() << xml;
-  }
-
+  log_unwinding(unwind);
   log.statistics() << (abort ? "Not unwinding" : "Unwinding") << " loop " << id
                    << " iteration " << unwind;
 
@@ -141,4 +134,30 @@ bool symex_bmc_incremental_one_loopt::resume(
   symex_with_state(*state, get_goto_function, state->symbol_table);
 
   return should_pause_symex;
+}
+void symex_bmc_incremental_one_loopt::log_unwinding(unsigned unwind)
+{
+  const std::string unwind_num = std::to_string(unwind);
+  switch(output_ui)
+  {
+  case ui_message_handlert::uit::PLAIN:
+  {
+    log.statistics() << "Current unwinding: " << unwind_num << messaget::eom;
+    break;
+  }
+  case ui_message_handlert::uit::XML_UI:
+  {
+    xmlt xml("current-unwinding");
+    xml.data = unwind_num;
+    log.statistics() << xml << messaget::eom;
+    break;
+  }
+  case ui_message_handlert::uit::JSON_UI:
+  {
+    json_objectt json;
+    json["currentUnwinding"] = json_numbert(unwind_num);
+    log.statistics() << json << messaget::eom;
+    break;
+  }
+  }
 }

--- a/src/goto-checker/symex_bmc_incremental_one_loop.cpp
+++ b/src/goto-checker/symex_bmc_incremental_one_loop.cpp
@@ -19,7 +19,8 @@ symex_bmc_incremental_one_loopt::symex_bmc_incremental_one_loopt(
   symex_target_equationt &target,
   const optionst &options,
   path_storaget &path_storage,
-  guard_managert &guard_manager)
+  guard_managert &guard_manager,
+  ui_message_handlert::uit output_ui)
   : symex_bmct(
       message_handler,
       outer_symbol_table,
@@ -33,7 +34,8 @@ symex_bmc_incremental_one_loopt::symex_bmc_incremental_one_loopt(
                                    : std::numeric_limits<unsigned>::max()),
     incr_min_unwind(
       options.is_set("unwind-min") ? options.get_signed_int_option("unwind-min")
-                                   : 0)
+                                   : 0),
+    output_ui(output_ui)
 {
   ignore_assertions =
     incr_min_unwind >= 1 &&
@@ -56,6 +58,7 @@ bool symex_bmc_incremental_one_loopt::should_stop_unwind(
     this_loop_limit = incr_max_unwind;
     if(unwind + 1 >= incr_min_unwind)
       ignore_assertions = false;
+
     abort_unwind_decision = tvt(unwind >= this_loop_limit);
   }
   else
@@ -84,6 +87,14 @@ bool symex_bmc_incremental_one_loopt::should_stop_unwind(
   INVARIANT(
     abort_unwind_decision.is_known(), "unwind decision should be taken by now");
   bool abort = abort_unwind_decision.is_true();
+
+
+  if(output_ui == ui_message_handlert::uit::XML_UI)
+  {
+    xmlt xml("current-unwinding");
+    xml.data = std::to_string(unwind);
+    log.statistics() << xml;
+  }
 
   log.statistics() << (abort ? "Not unwinding" : "Unwinding") << " loop " << id
                    << " iteration " << unwind;

--- a/src/goto-checker/symex_bmc_incremental_one_loop.h
+++ b/src/goto-checker/symex_bmc_incremental_one_loop.h
@@ -10,6 +10,7 @@
 #define CPROVER_GOTO_CHECKER_SYMEX_BMC_INCREMENTAL_ONE_LOOP_H
 
 #include "symex_bmc.h"
+#include <util/ui_message.h>
 
 class symex_bmc_incremental_one_loopt : public symex_bmct
 {
@@ -20,7 +21,8 @@ public:
     symex_target_equationt &,
     const optionst &,
     path_storaget &,
-    guard_managert &);
+    guard_managert &,
+    ui_message_handlert::uit output_ui);
 
   /// Return true if symex can be resumed
   bool from_entry_point_of(
@@ -44,6 +46,8 @@ protected:
     const symex_targett::sourcet &source,
     const call_stackt &context,
     unsigned unwind) override;
+
+  ui_message_handlert::uit output_ui;
 };
 
 #endif // CPROVER_GOTO_CHECKER_SYMEX_BMC_INCREMENTAL_ONE_LOOP_H

--- a/src/goto-checker/symex_bmc_incremental_one_loop.h
+++ b/src/goto-checker/symex_bmc_incremental_one_loop.h
@@ -47,6 +47,8 @@ protected:
     const call_stackt &context,
     unsigned unwind) override;
 
+  void log_unwinding(unsigned unwind);
+
   ui_message_handlert::uit output_ui;
 };
 


### PR DESCRIPTION
- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

~I'm not totally convinced by my approach for finding out whether XML is turned on. I'm not really clear on why you can't always just pipe some xml to the message handler, and let it figure out what to do with it. (Ideally, for example, if you send xml to json-ui, then it outputs equivalent json)~
Went for something much simpler, might raise a seperate PR to make the handling of this stuff less ad-hoc. 
