### PR TITLE
Logging structured data

### DIFF
--- a/src/goto-checker/symex_bmc_incremental_one_loop.cpp
+++ b/src/goto-checker/symex_bmc_incremental_one_loop.cpp
@@ -137,27 +137,8 @@ bool symex_bmc_incremental_one_loopt::resume(
 }
 void symex_bmc_incremental_one_loopt::log_unwinding(unsigned unwind)
 {
-  const std::string unwind_num = std::to_string(unwind);
-  switch(output_ui)
-  {
-  case ui_message_handlert::uit::PLAIN:
-  {
-    log.statistics() << "Current unwinding: " << unwind_num << messaget::eom;
-    break;
-  }
-  case ui_message_handlert::uit::XML_UI:
-  {
-    xmlt xml("current-unwinding");
-    xml.data = unwind_num;
-    log.statistics() << xml << messaget::eom;
-    break;
-  }
-  case ui_message_handlert::uit::JSON_UI:
-  {
-    json_objectt json;
-    json["currentUnwinding"] = json_numbert(unwind_num);
-    log.statistics() << json << messaget::eom;
-    break;
-  }
-  }
+  structured_datat data{{{labelt({"current", "unwinding"}),
+                          structured_data_entryt::data_node(
+                            json_numbert{std::to_string(unwind)})}}};
+  log.statistics() << data;
 }

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -87,6 +87,7 @@ SRC = allocate_objects.cpp \
       string_container.cpp \
       string_hash.cpp \
       string_utils.cpp \
+      structured_data.cpp \
       symbol.cpp \
       symbol_table_base.cpp \
       symbol_table.cpp \

--- a/src/util/json.cpp
+++ b/src/util/json.cpp
@@ -8,6 +8,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "json.h"
 
+#include "structured_data.h"
+
 #include <algorithm>
 #include <ostream>
 
@@ -203,4 +205,32 @@ bool operator==(const jsont &left, const jsont &right)
   }
   }
   UNREACHABLE;
+}
+
+jsont json_node(const structured_data_entryt &entry)
+{
+  if(entry.is_leaf())
+    return entry.leaf_object();
+  else
+  {
+    json_objectt result;
+    for(const auto sub_entry : entry.get_children())
+    {
+      result[sub_entry.first.camel_case()] = json_node(sub_entry.second);
+    }
+    return std::move(result);
+  }
+}
+
+jsont to_json(const structured_datat &data)
+{
+  if(data.data().size() == 0)
+    return jsont{};
+
+  json_objectt result;
+  for(const auto sub_entry : data.data())
+  {
+    result[sub_entry.first.camel_case()] = json_node(sub_entry.second);
+  }
+  return std::move(result);
 }

--- a/src/util/json.cpp
+++ b/src/util/json.cpp
@@ -214,7 +214,7 @@ jsont json_node(const structured_data_entryt &entry)
   else
   {
     json_objectt result;
-    for(const auto sub_entry : entry.get_children())
+    for(const auto sub_entry : entry.children())
     {
       result[sub_entry.first.camel_case()] = json_node(sub_entry.second);
     }

--- a/src/util/json.h
+++ b/src/util/json.h
@@ -467,6 +467,27 @@ inline const json_stringt &to_json_string(const jsont &json)
 
 bool operator==(const jsont &left, const jsont &right);
 
+/// Convert the structured_datat into an json object. For example, the
+/// structured data:
+/// structured_datat data{
+///   {{labelt{{"my", "data"}},
+///      structured_data_entryt::entry(
+///        {{labelt{{"my", "number"}},
+///           structured_data_entryt::data_node(json_numbert("10"))},
+///         {labelt{{"my", "string"}},
+///           structured_data_entryt::data_node(json_stringt("hi"))}})}}};
+///
+/// Will produce:
+/// ```json
+/// {
+///   "myData": {
+///      "myNumber": 10
+///      "myString": "hi"
+///    }
+///  }
+/// ```
+/// \param data: The structured data to convert.
+/// \return The json object as specified.
 jsont to_json(const structured_datat &data);
 
 #endif // CPROVER_UTIL_JSON_H

--- a/src/util/json.h
+++ b/src/util/json.h
@@ -18,6 +18,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "irep.h"
 #include "range.h"
 
+class structured_datat;
+
 class json_objectt;
 class json_arrayt;
 
@@ -464,5 +466,7 @@ inline const json_stringt &to_json_string(const jsont &json)
 }
 
 bool operator==(const jsont &left, const jsont &right);
+
+jsont to_json(const structured_datat &data);
 
 #endif // CPROVER_UTIL_JSON_H

--- a/src/util/message.cpp
+++ b/src/util/message.cpp
@@ -67,7 +67,7 @@ void message_handlert::print(
 void message_handlert::print(unsigned level, const structured_datat &data)
 {
   // default to just printing out the data in a format
-  print(level, data.to_pretty());
+  print(level, to_pretty(data));
 }
 
 messaget::~messaget()

--- a/src/util/message.cpp
+++ b/src/util/message.cpp
@@ -64,6 +64,11 @@ void message_handlert::print(
     message_count.resize(level+1, 0);
   ++message_count[level];
 }
+void message_handlert::print(unsigned level, const structured_datat &data)
+{
+  // default to just printing out the data in a format
+  print(level, data.to_pretty());
+}
 
 messaget::~messaget()
 {

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -18,6 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "deprecate.h"
 #include "invariant.h"
 #include "source_location.h"
+#include "structured_data.h"
 
 class json_objectt;
 class jsont;
@@ -35,6 +36,8 @@ public:
   virtual void print(unsigned level, const xmlt &xml) = 0;
 
   virtual void print(unsigned level, const jsont &json) = 0;
+
+  virtual void print(unsigned level, const structured_datat &data);
 
   virtual void print(
     unsigned level,
@@ -255,6 +258,17 @@ public:
     }
 
     mstreamt &operator<<(const json_objectt &data);
+
+    mstreamt &operator<<(const structured_datat &data)
+    {
+      if(this->tellp() > 0)
+        *this << eom; // force end of previous message
+      if(message.message_handler)
+      {
+        message.message_handler->print(message_level, data);
+      }
+      return *this;
+    }
 
     template <class T>
     mstreamt &operator << (const T &x)

--- a/src/util/string_utils.cpp
+++ b/src/util/string_utils.cpp
@@ -167,3 +167,11 @@ std::string escape_non_alnum(const std::string &to_escape)
   }
   return escaped.str();
 }
+std::string capitalize(const std::string &str)
+{
+  if(str.empty())
+    return str;
+  std::string capitalized = str;
+  capitalized[0] = toupper(capitalized[0]);
+  return capitalized;
+}

--- a/src/util/string_utils.h
+++ b/src/util/string_utils.h
@@ -18,6 +18,8 @@ Author: Daniel Poetzl
 
 std::string strip_string(const std::string &s);
 
+std::string capitalize(const std::string &str);
+
 /// Given a string s, split into a sequence of substrings when separated by
 /// specified delimiter.
 /// \param s: The string to split up

--- a/src/util/structured_data.cpp
+++ b/src/util/structured_data.cpp
@@ -17,9 +17,7 @@ labelt::labelt(std::vector<std::string> components) : components(components)
   PRECONDITION(std::all_of(
     components.begin(), components.end(), [](const std::string &component) {
       return !component.empty() &&
-             std::all_of(component.begin(), component.end(), [](const char &c) {
-               return !(::isalpha(c)) || ::islower(c);
-             });
+             std::none_of(component.begin(), component.end(), ::isupper);
     }));
 }
 

--- a/src/util/structured_data.cpp
+++ b/src/util/structured_data.cpp
@@ -1,0 +1,73 @@
+/*******************************************************************\
+
+Module: Classes for representing generic structured data
+
+Author: Thomas Kiley
+
+\*******************************************************************/
+
+#include "structured_data.h"
+#include "range.h"
+#include "string_utils.h"
+#include <algorithm>
+
+std::string capitalize(const std::string &str)
+{
+  std::string capitalized = str;
+  capitalized[0] = toupper(capitalized[0]);
+  return capitalized;
+}
+
+labelt::labelt(std::vector<std::string> components)
+{
+  auto to_lower_string = [](const std::string &s) -> std::string {
+    std::string lower_case = s;
+    std::for_each(
+      lower_case.begin(), lower_case.end(), [](char &c) { c = ::tolower(c); });
+    return lower_case;
+  };
+  this->components = make_range(components)
+                       .map(to_lower_string)
+                       .collect<std::vector<std::string>>();
+}
+std::string labelt::camel_case() const
+{
+  std::ostringstream output;
+  if(!components.empty())
+  {
+    output << *components.begin();
+    join_strings(
+      output, std::next(components.begin()), components.end(), "", capitalize);
+  }
+  return output.str();
+}
+std::string labelt::snake_case() const
+{
+  std::ostringstream output;
+  join_strings(output, components.begin(), components.end(), '_');
+  return output.str();
+}
+std::string labelt::kebab_case() const
+{
+  std::ostringstream output;
+  join_strings(output, components.begin(), components.end(), '-');
+  return output.str();
+}
+std::string labelt::pretty() const
+{
+  std::ostringstream output;
+  if(!components.empty())
+  {
+    const auto range =
+      make_range(components.begin(), std::next(components.begin()))
+        .map(capitalize)
+        .concat(make_range(std::next(components.begin()), components.end()));
+
+    join_strings(output, range.begin(), range.end(), ' ');
+  }
+  return output.str();
+}
+bool labelt::operator<(const labelt &other) const
+{
+  return camel_case() < other.camel_case();
+}

--- a/src/util/structured_data.cpp
+++ b/src/util/structured_data.cpp
@@ -80,21 +80,21 @@ structured_data_entryt::structured_data_entryt(const jsont &data) : data(data)
 }
 structured_data_entryt::structured_data_entryt(
   std::map<labelt, structured_data_entryt> children)
-  : children(std::move(children))
+  : _children(std::move(children))
 {
 }
 bool structured_data_entryt::is_leaf() const
 {
-  return children.empty();
+  return _children.empty();
 }
 std::string structured_data_entryt::leaf_data() const
 {
   return data.value;
 }
-std::map<labelt, structured_data_entryt>
-structured_data_entryt::get_children() const
+const std::map<labelt, structured_data_entryt> &
+structured_data_entryt::children() const
 {
-  return children;
+  return _children;
 }
 jsont structured_data_entryt::leaf_object() const
 {
@@ -121,7 +121,7 @@ pretty_node(const std::pair<labelt, structured_data_entryt> &entry)
   {
     const auto indent = [](const std::string line) { return "\t" + line; };
 
-    const auto &children = data.get_children();
+    const auto &children = data.children();
     std::vector<std::vector<std::string>> lines =
       make_range(children)
         .map(pretty_node)

--- a/src/util/structured_data.cpp
+++ b/src/util/structured_data.cpp
@@ -22,6 +22,7 @@ labelt::labelt(std::vector<std::string> components) : components(components)
              });
     }));
 }
+
 std::string labelt::camel_case() const
 {
   std::ostringstream output;
@@ -30,18 +31,21 @@ std::string labelt::camel_case() const
     output, std::next(components.begin()), components.end(), "", capitalize);
   return output.str();
 }
+
 std::string labelt::snake_case() const
 {
   std::ostringstream output;
   join_strings(output, components.begin(), components.end(), '_');
   return output.str();
 }
+
 std::string labelt::kebab_case() const
 {
   std::ostringstream output;
   join_strings(output, components.begin(), components.end(), '-');
   return output.str();
 }
+
 std::string labelt::pretty() const
 {
   std::ostringstream output;
@@ -53,33 +57,40 @@ std::string labelt::pretty() const
   join_strings(output, range.begin(), range.end(), ' ');
   return output.str();
 }
+
 bool labelt::operator<(const labelt &other) const
 {
   return components < other.components;
 }
+
 structured_data_entryt structured_data_entryt::data_node(const jsont &data)
 {
   // Structured data (e.g. arrays and objects) should use an entry
   PRECONDITION(!(data.is_array() || data.is_object()));
   return structured_data_entryt(data);
 }
+
 structured_data_entryt
 structured_data_entryt::entry(std::map<labelt, structured_data_entryt> children)
 {
   return structured_data_entryt(children);
 }
+
 structured_data_entryt::structured_data_entryt(const jsont &data) : data(data)
 {
 }
+
 structured_data_entryt::structured_data_entryt(
   std::map<labelt, structured_data_entryt> children)
   : _children(std::move(children))
 {
 }
+
 bool structured_data_entryt::is_leaf() const
 {
   return _children.empty();
 }
+
 std::string structured_data_entryt::leaf_data() const
 {
   return data.value;
@@ -89,10 +100,12 @@ structured_data_entryt::children() const
 {
   return _children;
 }
+
 jsont structured_data_entryt::leaf_object() const
 {
   return data;
 }
+
 structured_datat::structured_datat(
   std::map<labelt, structured_data_entryt> data)
   : _data(std::move(data))
@@ -153,6 +166,7 @@ std::string to_pretty(const structured_datat &data)
   join_strings(output, flattened_lines.begin(), flattened_lines.end(), "\n");
   return output.str();
 }
+
 const std::map<labelt, structured_data_entryt> &structured_datat::data() const
 {
   return _data;

--- a/src/util/structured_data.cpp
+++ b/src/util/structured_data.cpp
@@ -106,69 +106,6 @@ structured_datat::structured_datat(
 {
 }
 
-xmlt xml_node(const std::pair<labelt, structured_data_entryt> &entry)
-{
-  const labelt &label = entry.first;
-  const structured_data_entryt &data = entry.second;
-  xmlt output_data{label.kebab_case()};
-  if(data.is_leaf())
-  {
-    output_data.data = data.leaf_data();
-  }
-  else
-  {
-    const auto &children = data.get_children();
-    output_data.elements =
-      make_range(children).map(xml_node).collect<std::list<xmlt>>();
-  }
-  return output_data;
-}
-
-xmlt to_xml(const structured_datat &data)
-{
-  if(data.data().size() == 0)
-    return xmlt{};
-  if(data.data().size() == 1)
-  {
-    return xml_node(*data.data().begin());
-  }
-  else
-  {
-    xmlt root{"root"};
-    root.elements =
-      make_range(data.data()).map(xml_node).collect<std::list<xmlt>>();
-    return root;
-  }
-}
-
-jsont json_node(const structured_data_entryt &entry)
-{
-  if(entry.is_leaf())
-    return entry.leaf_object();
-  else
-  {
-    json_objectt result;
-    for(const auto sub_entry : entry.get_children())
-    {
-      result[sub_entry.first.camel_case()] = json_node(sub_entry.second);
-    }
-    return std::move(result);
-  }
-}
-
-jsont to_json(const structured_datat &data)
-{
-  if(data.data().size() == 0)
-    return jsont{};
-
-  json_objectt result;
-  for(const auto sub_entry : data.data())
-  {
-    result[sub_entry.first.camel_case()] = json_node(sub_entry.second);
-  }
-  return std::move(result);
-}
-
 std::vector<std::string>
 pretty_node(const std::pair<labelt, structured_data_entryt> &entry)
 {

--- a/src/util/structured_data.cpp
+++ b/src/util/structured_data.cpp
@@ -124,18 +124,19 @@ xmlt xml_node(const std::pair<labelt, structured_data_entryt> &entry)
   return output_data;
 }
 
-xmlt structured_datat::to_xml() const
+xmlt to_xml(const structured_datat &data)
 {
-  if(data().size() == 0)
+  if(data.data().size() == 0)
     return xmlt{};
-  if(data().size() == 1)
+  if(data.data().size() == 1)
   {
-    return xml_node(*data().begin());
+    return xml_node(*data.data().begin());
   }
   else
   {
     xmlt root{"root"};
-    root.elements = make_range(data()).map(xml_node).collect<std::list<xmlt>>();
+    root.elements =
+      make_range(data.data()).map(xml_node).collect<std::list<xmlt>>();
     return root;
   }
 }
@@ -155,13 +156,13 @@ jsont json_node(const structured_data_entryt &entry)
   }
 }
 
-jsont structured_datat::to_json() const
+jsont to_json(const structured_datat &data)
 {
-  if(data.size() == 0)
+  if(data.data().size() == 0)
     return jsont{};
 
   json_objectt result;
-  for(const auto sub_entry : data())
+  for(const auto sub_entry : data.data())
   {
     result[sub_entry.first.camel_case()] = json_node(sub_entry.second);
   }
@@ -203,13 +204,13 @@ pretty_node(const std::pair<labelt, structured_data_entryt> &entry)
   }
 }
 
-std::string structured_datat::to_pretty() const
+std::string to_pretty(const structured_datat &data)
 {
-  if(data().empty())
+  if(data.data().empty())
     return "";
 
   std::vector<std::vector<std::string>> lines =
-    make_range(data())
+    make_range(data.data())
       .map(pretty_node)
       .collect<std::vector<std::vector<std::string>>>();
   std::vector<std::string> flattened_lines;

--- a/src/util/structured_data.cpp
+++ b/src/util/structured_data.cpp
@@ -62,7 +62,7 @@ std::string labelt::pretty() const
 }
 bool labelt::operator<(const labelt &other) const
 {
-  return camel_case() < other.camel_case();
+  return components < other.components;
 }
 structured_data_entryt structured_data_entryt::data_node(const jsont &data)
 {

--- a/src/util/structured_data.cpp
+++ b/src/util/structured_data.cpp
@@ -11,13 +11,6 @@ Author: Thomas Kiley
 #include "string_utils.h"
 #include <algorithm>
 
-std::string capitalize(const std::string &str)
-{
-  std::string capitalized = str;
-  capitalized[0] = toupper(capitalized[0]);
-  return capitalized;
-}
-
 labelt::labelt(std::vector<std::string> components)
 {
   auto to_lower_string = [](const std::string &s) -> std::string {

--- a/src/util/structured_data.cpp
+++ b/src/util/structured_data.cpp
@@ -102,7 +102,7 @@ jsont structured_data_entryt::leaf_object() const
 }
 structured_datat::structured_datat(
   std::map<labelt, structured_data_entryt> data)
-  : data(std::move(data))
+  : _data(std::move(data))
 {
 }
 
@@ -126,16 +126,16 @@ xmlt xml_node(const std::pair<labelt, structured_data_entryt> &entry)
 
 xmlt structured_datat::to_xml() const
 {
-  if(data.size() == 0)
+  if(data().size() == 0)
     return xmlt{};
-  if(data.size() == 1)
+  if(data().size() == 1)
   {
-    return xml_node(*data.begin());
+    return xml_node(*data().begin());
   }
   else
   {
     xmlt root{"root"};
-    root.elements = make_range(data).map(xml_node).collect<std::list<xmlt>>();
+    root.elements = make_range(data()).map(xml_node).collect<std::list<xmlt>>();
     return root;
   }
 }
@@ -161,7 +161,7 @@ jsont structured_datat::to_json() const
     return jsont{};
 
   json_objectt result;
-  for(const auto sub_entry : data)
+  for(const auto sub_entry : data())
   {
     result[sub_entry.first.camel_case()] = json_node(sub_entry.second);
   }
@@ -205,11 +205,11 @@ pretty_node(const std::pair<labelt, structured_data_entryt> &entry)
 
 std::string structured_datat::to_pretty() const
 {
-  if(data.empty())
+  if(data().empty())
     return "";
 
   std::vector<std::vector<std::string>> lines =
-    make_range(data)
+    make_range(data())
       .map(pretty_node)
       .collect<std::vector<std::vector<std::string>>>();
   std::vector<std::string> flattened_lines;
@@ -221,4 +221,8 @@ std::string structured_datat::to_pretty() const
   std::ostringstream output;
   join_strings(output, flattened_lines.begin(), flattened_lines.end(), "\n");
   return output.str();
+}
+const std::map<labelt, structured_data_entryt> &structured_datat::data() const
+{
+  return _data;
 }

--- a/src/util/structured_data.cpp
+++ b/src/util/structured_data.cpp
@@ -71,10 +71,11 @@ structured_data_entryt structured_data_entryt::data_node(const jsont &data)
 structured_data_entryt
 structured_data_entryt::entry(std::map<labelt, structured_data_entryt> children)
 {
-  return structured_data_entryt(children);
+  return structured_data_entryt(std::move(children));
 }
 
-structured_data_entryt::structured_data_entryt(const jsont &data) : data(data)
+structured_data_entryt::structured_data_entryt(jsont data)
+  : data(std::move(data))
 {
 }
 
@@ -123,7 +124,7 @@ pretty_node(const std::pair<labelt, structured_data_entryt> &entry)
   }
   else
   {
-    const auto indent = [](const std::string line) { return "\t" + line; };
+    const auto indent = [](const std::string &line) { return "\t" + line; };
 
     const auto &children = data.children();
     std::vector<std::vector<std::string>> lines =

--- a/src/util/structured_data.cpp
+++ b/src/util/structured_data.cpp
@@ -11,27 +11,23 @@ Author: Thomas Kiley
 #include "string_utils.h"
 #include <algorithm>
 
-labelt::labelt(std::vector<std::string> components)
+labelt::labelt(std::vector<std::string> components) : components(components)
 {
-  auto to_lower_string = [](const std::string &s) -> std::string {
-    std::string lower_case = s;
-    std::for_each(
-      lower_case.begin(), lower_case.end(), [](char &c) { c = ::tolower(c); });
-    return lower_case;
-  };
-  this->components = make_range(components)
-                       .map(to_lower_string)
-                       .collect<std::vector<std::string>>();
+  PRECONDITION(!components.empty());
+  PRECONDITION(std::all_of(
+    components.begin(), components.end(), [](const std::string &component) {
+      return !component.empty() &&
+             std::all_of(component.begin(), component.end(), [](const char &c) {
+               return !(::isalpha(c)) || ::islower(c);
+             });
+    }));
 }
 std::string labelt::camel_case() const
 {
   std::ostringstream output;
-  if(!components.empty())
-  {
-    output << *components.begin();
-    join_strings(
-      output, std::next(components.begin()), components.end(), "", capitalize);
-  }
+  output << *components.begin();
+  join_strings(
+    output, std::next(components.begin()), components.end(), "", capitalize);
   return output.str();
 }
 std::string labelt::snake_case() const
@@ -49,15 +45,12 @@ std::string labelt::kebab_case() const
 std::string labelt::pretty() const
 {
   std::ostringstream output;
-  if(!components.empty())
-  {
-    const auto range =
-      make_range(components.begin(), std::next(components.begin()))
-        .map(capitalize)
-        .concat(make_range(std::next(components.begin()), components.end()));
+  const auto range =
+    make_range(components.begin(), std::next(components.begin()))
+      .map(capitalize)
+      .concat(make_range(std::next(components.begin()), components.end()));
 
-    join_strings(output, range.begin(), range.end(), ' ');
-  }
+  join_strings(output, range.begin(), range.end(), ' ');
   return output.str();
 }
 bool labelt::operator<(const labelt &other) const

--- a/src/util/structured_data.h
+++ b/src/util/structured_data.h
@@ -8,6 +8,8 @@ Author: Thomas Kiley
 #ifndef CPROVER_UTIL_STRUCTURED_DATA_H
 #define CPROVER_UTIL_STRUCTURED_DATA_H
 
+#include "json.h"
+#include "xml.h"
 #include <string>
 #include <vector>
 
@@ -27,5 +29,37 @@ private:
   std::vector<std::string> components;
 };
 
+struct structured_data_entryt
+{
+  static structured_data_entryt data_node(const jsont &data);
+  static structured_data_entryt
+  entry(std::map<labelt, structured_data_entryt> children);
+
+  bool is_leaf() const;
+  std::string leaf_data() const;
+  jsont leaf_object() const;
+  std::map<labelt, structured_data_entryt> get_children() const;
+
+private:
+  explicit structured_data_entryt(const jsont &data);
+  explicit structured_data_entryt(
+    std::map<labelt, structured_data_entryt> children);
+
+  jsont data;
+  std::map<labelt, structured_data_entryt> children;
+};
+
+class structured_datat
+{
+public:
+  explicit structured_datat(std::map<labelt, structured_data_entryt> data);
+
+  xmlt to_xml() const;
+  jsont to_json() const;
+  std::string to_pretty() const;
+
+private:
+  std::map<labelt, structured_data_entryt> data;
+};
 
 #endif // CPROVER_UTIL_STRUCTURED_DATA_H

--- a/src/util/structured_data.h
+++ b/src/util/structured_data.h
@@ -1,0 +1,31 @@
+/*******************************************************************\
+
+Module: Classes for representing generic structured data
+
+Author: Thomas Kiley
+
+\*******************************************************************/
+#ifndef CPROVER_UTIL_STRUCTURED_DATA_H
+#define CPROVER_UTIL_STRUCTURED_DATA_H
+
+#include <string>
+#include <vector>
+
+struct labelt
+{
+public:
+  explicit labelt(std::vector<std::string> components);
+
+  std::string camel_case() const;
+  std::string snake_case() const;
+  std::string kebab_case() const;
+  std::string pretty() const;
+
+  bool operator<(const labelt &other) const;
+
+private:
+  std::vector<std::string> components;
+};
+
+
+#endif // CPROVER_UTIL_STRUCTURED_DATA_H

--- a/src/util/structured_data.h
+++ b/src/util/structured_data.h
@@ -38,7 +38,7 @@ struct structured_data_entryt
   bool is_leaf() const;
   std::string leaf_data() const;
   jsont leaf_object() const;
-  std::map<labelt, structured_data_entryt> get_children() const;
+  const std::map<labelt, structured_data_entryt> &children() const;
 
 private:
   explicit structured_data_entryt(const jsont &data);
@@ -46,7 +46,7 @@ private:
     std::map<labelt, structured_data_entryt> children);
 
   jsont data;
-  std::map<labelt, structured_data_entryt> children;
+  std::map<labelt, structured_data_entryt> _children;
 };
 
 /// A way of representing nested key/value data. Used for logging on any
@@ -74,7 +74,7 @@ class structured_datat
 {
 public:
   explicit structured_datat(std::map<labelt, structured_data_entryt> data);
-  const std::map<labelt, structured_data_entryt> & data() const;
+  const std::map<labelt, structured_data_entryt> &data() const;
 
 private:
   std::map<labelt, structured_data_entryt> _data;

--- a/src/util/structured_data.h
+++ b/src/util/structured_data.h
@@ -98,8 +98,10 @@ public:
   jsont to_json() const;
   std::string to_pretty() const;
 
+  const std::map<labelt, structured_data_entryt> & data() const;
+
 private:
-  std::map<labelt, structured_data_entryt> data;
+  std::map<labelt, structured_data_entryt> _data;
 };
 
 #endif // CPROVER_UTIL_STRUCTURED_DATA_H

--- a/src/util/structured_data.h
+++ b/src/util/structured_data.h
@@ -63,32 +63,13 @@ private:
 /// message() << data << eom;
 /// ```
 /// Then if the output dependending on the UI of the message handler, you'll
-/// get appropriately formatted data:
+/// get appropriately formatted data.
 ///
-/// XML:
-/// ```xml
-/// <my-data>
-///   <my-number>10</my-number>
-///   <my-string>hi</my-string>
-/// </my-data>
-/// ```
-///
-/// JSON:
-/// ```json
-/// {
-///   "myData": {
-///      "myNumber": 10
-///      "myString": "hi"
-///    }
-///  }
-/// ```
-///
-/// Plain:
-/// ```
-/// My data:
-///    My number: 10
-///    My string: hi
-/// ```
+/// See
+/// \ref to_xml(const structured_datat &),
+/// \ref to_json(const structured_datat &),
+/// \ref to_pretty(const structured_datat &)
+/// for details of the format.
 class structured_datat
 {
 public:
@@ -99,6 +80,13 @@ private:
   std::map<labelt, structured_data_entryt> _data;
 };
 
+/// Convert the structured_data into plain text. For the example structured
+/// data, this will produce:
+/// ```
+/// My data:
+///    My number: 10
+///    My string: hi
+/// ```
 std::string to_pretty(const structured_datat &);
 
 #endif // CPROVER_UTIL_STRUCTURED_DATA_H

--- a/src/util/structured_data.h
+++ b/src/util/structured_data.h
@@ -41,7 +41,7 @@ struct structured_data_entryt
   const std::map<labelt, structured_data_entryt> &children() const;
 
 private:
-  explicit structured_data_entryt(const jsont &data);
+  explicit structured_data_entryt(jsont data);
   explicit structured_data_entryt(
     std::map<labelt, structured_data_entryt> children);
 

--- a/src/util/structured_data.h
+++ b/src/util/structured_data.h
@@ -99,8 +99,6 @@ private:
   std::map<labelt, structured_data_entryt> _data;
 };
 
-xmlt to_xml(const structured_datat &data);
-jsont to_json(const structured_datat &data);
 std::string to_pretty(const structured_datat &);
 
 #endif // CPROVER_UTIL_STRUCTURED_DATA_H

--- a/src/util/structured_data.h
+++ b/src/util/structured_data.h
@@ -93,15 +93,14 @@ class structured_datat
 {
 public:
   explicit structured_datat(std::map<labelt, structured_data_entryt> data);
-
-  xmlt to_xml() const;
-  jsont to_json() const;
-  std::string to_pretty() const;
-
   const std::map<labelt, structured_data_entryt> & data() const;
 
 private:
   std::map<labelt, structured_data_entryt> _data;
 };
+
+xmlt to_xml(const structured_datat &data);
+jsont to_json(const structured_datat &data);
+std::string to_pretty(const structured_datat &);
 
 #endif // CPROVER_UTIL_STRUCTURED_DATA_H

--- a/src/util/structured_data.h
+++ b/src/util/structured_data.h
@@ -49,6 +49,46 @@ private:
   std::map<labelt, structured_data_entryt> children;
 };
 
+/// A way of representing nested key/value data. Used for logging on any
+/// message handler.
+/// Usage:
+/// ```
+/// structured_datat data{
+///   {{labelt{{"my", "data"}},
+///      structured_data_entryt::entry(
+///        {{labelt{{"my", "number"}},
+///           structured_data_entryt::data_node(json_numbert("10"))},
+///         {labelt{{"my", "string"}},
+///           structured_data_entryt::data_node(json_stringt("hi"))}})}}};
+/// message() << data << eom;
+/// ```
+/// Then if the output dependending on the UI of the message handler, you'll
+/// get appropriately formatted data:
+///
+/// XML:
+/// ```xml
+/// <my-data>
+///   <my-number>10</my-number>
+///   <my-string>hi</my-string>
+/// </my-data>
+/// ```
+///
+/// JSON:
+/// ```json
+/// {
+///   "myData": {
+///      "myNumber": 10
+///      "myString": "hi"
+///    }
+///  }
+/// ```
+///
+/// Plain:
+/// ```
+/// My data:
+///    My number: 10
+///    My string: hi
+/// ```
 class structured_datat
 {
 public:

--- a/src/util/ui_message.cpp
+++ b/src/util/ui_message.cpp
@@ -315,13 +315,13 @@ void ui_message_handlert::print(unsigned level, const structured_datat &data)
   switch(get_ui())
   {
   case uit::PLAIN:
-    print(level, data.to_pretty());
+    print(level, to_pretty(data));
     break;
   case uit::XML_UI:
-    print(level, data.to_xml());
+    print(level, to_xml(data));
     break;
   case uit::JSON_UI:
-    print(level, data.to_json());
+    print(level, to_json(data));
     break;
   }
 }

--- a/src/util/ui_message.cpp
+++ b/src/util/ui_message.cpp
@@ -310,3 +310,18 @@ void ui_message_handlert::flush(unsigned level)
     break;
   }
 }
+void ui_message_handlert::print(unsigned level, const structured_datat &data)
+{
+  switch(get_ui())
+  {
+  case uit::PLAIN:
+    print(level, data.to_pretty());
+    break;
+  case uit::XML_UI:
+    print(level, data.to_xml());
+    break;
+  case uit::JSON_UI:
+    print(level, data.to_json());
+    break;
+  }
+}

--- a/src/util/ui_message.cpp
+++ b/src/util/ui_message.cpp
@@ -12,9 +12,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <iostream>
 
 #include "cmdline.h"
+#include "json.h"
 #include "json_irep.h"
 #include "json_stream.h"
 #include "make_unique.h"
+#include "xml.h"
 #include "xml_irep.h"
 
 ui_message_handlert::ui_message_handlert(

--- a/src/util/ui_message.h
+++ b/src/util/ui_message.h
@@ -40,6 +40,7 @@ public:
     PRECONDITION(json_stream!=nullptr);
     return *json_stream;
   }
+  void print(unsigned level, const structured_datat &data) override;
 
 protected:
   std::unique_ptr<console_message_handlert> console_message_handler;

--- a/src/util/xml.cpp
+++ b/src/util/xml.cpp
@@ -270,7 +270,7 @@ xmlt xml_node(const std::pair<labelt, structured_data_entryt> &entry)
   }
   else
   {
-    const auto &children = data.get_children();
+    const auto &children = data.children();
     output_data.elements =
       make_range(children).map(xml_node).collect<std::list<xmlt>>();
   }

--- a/src/util/xml.cpp
+++ b/src/util/xml.cpp
@@ -248,3 +248,12 @@ std::string xmlt::unescape(const std::string &str)
 
   return result;
 }
+bool operator==(const xmlt &a, const xmlt &b)
+{
+  return a.name == b.name && a.data == b.data && a.elements == b.elements &&
+         a.attributes == b.attributes;
+}
+bool operator!=(const xmlt &a, const xmlt &b)
+{
+  return !(a == b);
+}

--- a/src/util/xml.cpp
+++ b/src/util/xml.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "exception_utils.h"
 #include "string2int.h"
+#include "structured_data.h"
 
 void xmlt::clear()
 {
@@ -256,4 +257,39 @@ bool operator==(const xmlt &a, const xmlt &b)
 bool operator!=(const xmlt &a, const xmlt &b)
 {
   return !(a == b);
+}
+
+xmlt xml_node(const std::pair<labelt, structured_data_entryt> &entry)
+{
+  const labelt &label = entry.first;
+  const structured_data_entryt &data = entry.second;
+  xmlt output_data{label.kebab_case()};
+  if(data.is_leaf())
+  {
+    output_data.data = data.leaf_data();
+  }
+  else
+  {
+    const auto &children = data.get_children();
+    output_data.elements =
+      make_range(children).map(xml_node).collect<std::list<xmlt>>();
+  }
+  return output_data;
+}
+
+xmlt to_xml(const structured_datat &data)
+{
+  if(data.data().size() == 0)
+    return xmlt{};
+  if(data.data().size() == 1)
+  {
+    return xml_node(*data.data().begin());
+  }
+  else
+  {
+    xmlt root{"root"};
+    root.elements =
+      make_range(data.data()).map(xml_node).collect<std::list<xmlt>>();
+    return root;
+  }
 }

--- a/src/util/xml.h
+++ b/src/util/xml.h
@@ -15,6 +15,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <string>
 #include <iosfwd>
 
+class structured_datat;
+
 class xmlt
 {
 public:
@@ -138,4 +140,5 @@ inline std::ostream &operator<<(
 bool operator==(const xmlt &a, const xmlt &b);
 bool operator!=(const xmlt &a, const xmlt &b);
 
+xmlt to_xml(const structured_datat &data);
 #endif // CPROVER_UTIL_XML_H

--- a/src/util/xml.h
+++ b/src/util/xml.h
@@ -140,5 +140,26 @@ inline std::ostream &operator<<(
 bool operator==(const xmlt &a, const xmlt &b);
 bool operator!=(const xmlt &a, const xmlt &b);
 
+/// Convert the structured_datat into an xml object. For example, the
+/// structured data:
+/// structured_datat data{
+///   {{labelt{{"my", "data"}},
+///      structured_data_entryt::entry(
+///        {{labelt{{"my", "number"}},
+///           structured_data_entryt::data_node(json_numbert("10"))},
+///         {labelt{{"my", "string"}},
+///           structured_data_entryt::data_node(json_stringt("hi"))}})}}};
+///
+/// Will produce:
+/// ```xml
+/// <my-data>
+///   <my-number>10</my-number>
+///   <my-string>hi</my-string>
+/// </my-data>
+/// ```
+///
+/// \param data: The structured data to convert.
+/// \return The XML object as specified.
 xmlt to_xml(const structured_datat &data);
+
 #endif // CPROVER_UTIL_XML_H

--- a/src/util/xml.h
+++ b/src/util/xml.h
@@ -135,4 +135,7 @@ inline std::ostream &operator<<(
   return out;
 }
 
+bool operator==(const xmlt &a, const xmlt &b);
+bool operator!=(const xmlt &a, const xmlt &b);
+
 #endif // CPROVER_UTIL_XML_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -98,6 +98,7 @@ SRC += analyses/ai/ai.cpp \
        util/std_expr.cpp \
        util/string2int.cpp \
        util/structured_data.cpp \
+       util/string_utils/capitalize.cpp \
        util/string_utils/join_string.cpp \
        util/string_utils/split_string.cpp \
        util/string_utils/strip_string.cpp \

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -97,6 +97,7 @@ SRC += analyses/ai/ai.cpp \
        util/ssa_expr.cpp \
        util/std_expr.cpp \
        util/string2int.cpp \
+       util/structured_data.cpp \
        util/string_utils/join_string.cpp \
        util/string_utils/split_string.cpp \
        util/string_utils/strip_string.cpp \

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -103,6 +103,7 @@ SRC += analyses/ai/ai.cpp \
        util/symbol_table.cpp \
        util/symbol.cpp \
        util/unicode.cpp \
+       util/xml.cpp \
        # Empty last line
 
 ifeq ($(OS),Windows_NT)

--- a/unit/util/string_utils/capitalize.cpp
+++ b/unit/util/string_utils/capitalize.cpp
@@ -1,0 +1,20 @@
+/*******************************************************************\
+
+Module: Unit tests for string utilities
+
+Author: Thomas Kiley
+
+\*******************************************************************/
+
+#include <testing-utils/use_catch.h>
+#include <util/string_utils.h>
+
+TEST_CASE("capitalize", "[core][util][string_utils]")
+{
+  REQUIRE(capitalize("") == "");
+  REQUIRE(capitalize("abc") == "Abc");
+  REQUIRE(capitalize("aBc") == "ABc");
+  REQUIRE(capitalize("ABc") == "ABc");
+  REQUIRE(capitalize("abc def") == "Abc def");
+  REQUIRE(capitalize("1") == "1");
+}

--- a/unit/util/structured_data.cpp
+++ b/unit/util/structured_data.cpp
@@ -76,3 +76,122 @@ TEST_CASE("Label equality", "[core][util][structured_data][label]")
 
   REQUIRE(multi_label < multi_label2);
 }
+
+TEST_CASE("Convert structured_datat", "[core][util][structured_data]")
+{
+  GIVEN("Empty structured data")
+  {
+    structured_datat empty_data{{}};
+
+    THEN("Empty json object")
+    {
+      REQUIRE(empty_data.to_json() == json_nullt());
+    }
+
+    THEN("Empty xml object")
+    {
+      REQUIRE(empty_data.to_xml().elements.empty());
+      REQUIRE(empty_data.to_xml().data.empty());
+    }
+
+    THEN("Empty pretty object")
+    {
+      REQUIRE(empty_data.to_pretty() == "");
+    }
+  }
+  GIVEN("Single node XML")
+  {
+    const labelt label = labelt{{"node", "name"}};
+    const structured_data_entryt entry =
+      structured_data_entryt::data_node(json_stringt{"nodeValue"});
+    structured_datat single_node{{{label, entry}}};
+
+    THEN("Appropriate json object")
+    {
+      json_objectt expected;
+      expected["nodeName"] = json_stringt{"nodeValue"};
+      REQUIRE(single_node.to_json() == expected);
+    }
+
+    THEN("Appropriate xml object")
+    {
+      xmlt expected_xml{"node-name"};
+      expected_xml.data = "nodeValue";
+      auto result = single_node.to_xml();
+      REQUIRE(result == expected_xml);
+    }
+
+    THEN("Appropriate pretty object")
+    {
+      REQUIRE(single_node.to_pretty() == "Node name: nodeValue");
+    }
+  }
+  GIVEN("Nested nodes")
+  {
+    const labelt child1_label = labelt{{"child", "1"}};
+    const structured_data_entryt child1_value =
+      structured_data_entryt::data_node(json_stringt{"c1v"});
+    const labelt child2_label = labelt{{"child", "2"}};
+    const structured_data_entryt child2_value =
+      structured_data_entryt::data_node(json_stringt{"c2v"});
+    structured_datat single_node{
+      {{child1_label, child1_value}, {child2_label, child2_value}}};
+
+    THEN("Appropriate json object")
+    {
+      json_objectt expected;
+      expected["child1"] = json_stringt{"c1v"};
+      expected["child2"] = json_stringt{"c2v"};
+      REQUIRE(single_node.to_json() == expected);
+    }
+
+    THEN("Empty xml object")
+    {
+      xmlt expected_xml{"root"};
+      xmlt expected_child1 = xmlt{"child-1"};
+      expected_child1.data = "c1v";
+      xmlt expected_child2 = xmlt{"child-2"};
+      expected_child2.data = "c2v";
+      expected_xml.elements = {{expected_child1, expected_child2}};
+      auto result = single_node.to_xml();
+      REQUIRE(result == expected_xml);
+    }
+
+    THEN("Empty pretty object")
+    {
+      std::string expected =
+        "Child 1: c1v\n"
+        "Child 2: c2v";
+      REQUIRE(single_node.to_pretty() == expected);
+    }
+  }
+  SECTION("Non-string data")
+  {
+    const labelt child1_label = labelt{{"child", "1"}};
+    const structured_data_entryt child1_value =
+      structured_data_entryt::data_node(json_numbert{"10"});
+
+    structured_datat single_node{{{child1_label, child1_value}}};
+
+    THEN("Appropriate json object")
+    {
+      json_objectt expected;
+      expected["child1"] = json_numbert{"10"};
+      REQUIRE(single_node.to_json() == expected);
+    }
+
+    THEN("Empty xml object")
+    {
+      xmlt expected_xml = xmlt{"child-1"};
+      expected_xml.data = "10";
+      auto result = single_node.to_xml();
+      REQUIRE(result == expected_xml);
+    }
+
+    THEN("Empty pretty object")
+    {
+      std::string expected = "Child 1: 10";
+      REQUIRE(single_node.to_pretty() == expected);
+    }
+  }
+}

--- a/unit/util/structured_data.cpp
+++ b/unit/util/structured_data.cpp
@@ -11,14 +11,8 @@ Author: Thomas Kiley
 
 TEST_CASE("label", "[core][util][structured_data][label]")
 {
-  SECTION("Empty label")
-  {
-    labelt empty_label({});
-    REQUIRE(empty_label.camel_case() == "");
-    REQUIRE(empty_label.kebab_case() == "");
-    REQUIRE(empty_label.snake_case() == "");
-    REQUIRE(empty_label.pretty() == "");
-  }
+  const cbmc_invariants_should_throwt invariant_throw_during_tests{};
+
   SECTION("Single element")
   {
     labelt empty_label({"hello"});
@@ -35,41 +29,35 @@ TEST_CASE("label", "[core][util][structured_data][label]")
     REQUIRE(empty_label.snake_case() == "hello_goodbye");
     REQUIRE(empty_label.pretty() == "Hello goodbye");
   }
-  SECTION("Odd casing elements")
+  SECTION("Valid labels")
   {
-    labelt empty_label({"HelLo", "Goodbye"});
-    REQUIRE(empty_label.camel_case() == "helloGoodbye");
-    REQUIRE(empty_label.kebab_case() == "hello-goodbye");
-    REQUIRE(empty_label.snake_case() == "hello_goodbye");
-    REQUIRE(empty_label.pretty() == "Hello goodbye");
+    labelt numbered_label({"hello", "1"});
+    REQUIRE(numbered_label.camel_case() == "hello1");
+    REQUIRE(numbered_label.kebab_case() == "hello-1");
+    REQUIRE(numbered_label.snake_case() == "hello_1");
+    REQUIRE(numbered_label.pretty() == "Hello 1");
+  }
+  SECTION("Invalid components")
+  {
+    REQUIRE_THROWS_AS(labelt{{}}, invariant_failedt);
+    std::vector<std::string> starts_with_upper{"Hello"};
+    REQUIRE_THROWS_AS(labelt{starts_with_upper}, invariant_failedt);
+    std::vector<std::string> contains_upper{"Hello"};
+    REQUIRE_THROWS_AS(labelt{contains_upper}, invariant_failedt);
+    REQUIRE_THROWS_AS(labelt{{""}}, invariant_failedt);
   }
 }
 
 TEST_CASE("Label equality", "[core][util][structured_data][label]")
 {
-  labelt empty_label({});
   labelt single_label({"a"});
-  labelt capital_label({"A"});
   labelt b_label({"b"});
   labelt multi_label({"b", "c", "d"});
   labelt multi_label2({"b", "d", "d"});
 
-  REQUIRE(empty_label < single_label);
-  REQUIRE(empty_label < capital_label);
-  REQUIRE(empty_label < b_label);
-  REQUIRE(empty_label < multi_label);
-  REQUIRE(empty_label < multi_label2);
-
-  REQUIRE_FALSE(single_label < capital_label);
-  REQUIRE_FALSE(capital_label < single_label);
-
   REQUIRE(single_label < b_label);
   REQUIRE(single_label < multi_label);
   REQUIRE(single_label < multi_label2);
-
-  REQUIRE(capital_label < b_label);
-  REQUIRE(capital_label < multi_label);
-  REQUIRE(capital_label < multi_label2);
 
   REQUIRE(b_label < multi_label);
   REQUIRE(b_label < multi_label2);

--- a/unit/util/structured_data.cpp
+++ b/unit/util/structured_data.cpp
@@ -1,0 +1,78 @@
+/*******************************************************************\
+
+Module: Unit tests for the structed_datat related classes
+
+Author: Thomas Kiley
+
+\*******************************************************************/
+
+#include <testing-utils/use_catch.h>
+#include <util/structured_data.h>
+
+TEST_CASE("label", "[core][util][structured_data][label]")
+{
+  SECTION("Empty label")
+  {
+    labelt empty_label({});
+    REQUIRE(empty_label.camel_case() == "");
+    REQUIRE(empty_label.kebab_case() == "");
+    REQUIRE(empty_label.snake_case() == "");
+    REQUIRE(empty_label.pretty() == "");
+  }
+  SECTION("Single element")
+  {
+    labelt empty_label({"hello"});
+    REQUIRE(empty_label.camel_case() == "hello");
+    REQUIRE(empty_label.kebab_case() == "hello");
+    REQUIRE(empty_label.snake_case() == "hello");
+    REQUIRE(empty_label.pretty() == "Hello");
+  }
+  SECTION("Two elements")
+  {
+    labelt empty_label({"hello", "goodbye"});
+    REQUIRE(empty_label.camel_case() == "helloGoodbye");
+    REQUIRE(empty_label.kebab_case() == "hello-goodbye");
+    REQUIRE(empty_label.snake_case() == "hello_goodbye");
+    REQUIRE(empty_label.pretty() == "Hello goodbye");
+  }
+  SECTION("Odd casing elements")
+  {
+    labelt empty_label({"HelLo", "Goodbye"});
+    REQUIRE(empty_label.camel_case() == "helloGoodbye");
+    REQUIRE(empty_label.kebab_case() == "hello-goodbye");
+    REQUIRE(empty_label.snake_case() == "hello_goodbye");
+    REQUIRE(empty_label.pretty() == "Hello goodbye");
+  }
+}
+
+TEST_CASE("Label equality", "[core][util][structured_data][label]")
+{
+  labelt empty_label({});
+  labelt single_label({"a"});
+  labelt capital_label({"A"});
+  labelt b_label({"b"});
+  labelt multi_label({"b", "c", "d"});
+  labelt multi_label2({"b", "d", "d"});
+
+  REQUIRE(empty_label < single_label);
+  REQUIRE(empty_label < capital_label);
+  REQUIRE(empty_label < b_label);
+  REQUIRE(empty_label < multi_label);
+  REQUIRE(empty_label < multi_label2);
+
+  REQUIRE_FALSE(single_label < capital_label);
+  REQUIRE_FALSE(capital_label < single_label);
+
+  REQUIRE(single_label < b_label);
+  REQUIRE(single_label < multi_label);
+  REQUIRE(single_label < multi_label2);
+
+  REQUIRE(capital_label < b_label);
+  REQUIRE(capital_label < multi_label);
+  REQUIRE(capital_label < multi_label2);
+
+  REQUIRE(b_label < multi_label);
+  REQUIRE(b_label < multi_label2);
+
+  REQUIRE(multi_label < multi_label2);
+}

--- a/unit/util/structured_data.cpp
+++ b/unit/util/structured_data.cpp
@@ -85,18 +85,18 @@ TEST_CASE("Convert structured_datat", "[core][util][structured_data]")
 
     THEN("Empty json object")
     {
-      REQUIRE(empty_data.to_json() == json_nullt());
+      REQUIRE(to_json(empty_data) == json_nullt());
     }
 
     THEN("Empty xml object")
     {
-      REQUIRE(empty_data.to_xml().elements.empty());
-      REQUIRE(empty_data.to_xml().data.empty());
+      REQUIRE(to_xml(empty_data).elements.empty());
+      REQUIRE(to_xml(empty_data).data.empty());
     }
 
     THEN("Empty pretty object")
     {
-      REQUIRE(empty_data.to_pretty() == "");
+      REQUIRE(to_pretty(empty_data) == "");
     }
   }
   GIVEN("Single node XML")
@@ -110,20 +110,20 @@ TEST_CASE("Convert structured_datat", "[core][util][structured_data]")
     {
       json_objectt expected;
       expected["nodeName"] = json_stringt{"nodeValue"};
-      REQUIRE(single_node.to_json() == expected);
+      REQUIRE(to_json(single_node) == expected);
     }
 
     THEN("Appropriate xml object")
     {
       xmlt expected_xml{"node-name"};
       expected_xml.data = "nodeValue";
-      auto result = single_node.to_xml();
+      auto result = to_xml(single_node);
       REQUIRE(result == expected_xml);
     }
 
     THEN("Appropriate pretty object")
     {
-      REQUIRE(single_node.to_pretty() == "Node name: nodeValue");
+      REQUIRE(to_pretty(single_node) == "Node name: nodeValue");
     }
   }
   GIVEN("Nested nodes")
@@ -142,7 +142,7 @@ TEST_CASE("Convert structured_datat", "[core][util][structured_data]")
       json_objectt expected;
       expected["child1"] = json_stringt{"c1v"};
       expected["child2"] = json_stringt{"c2v"};
-      REQUIRE(single_node.to_json() == expected);
+      REQUIRE(to_json(single_node) == expected);
     }
 
     THEN("Empty xml object")
@@ -153,7 +153,7 @@ TEST_CASE("Convert structured_datat", "[core][util][structured_data]")
       xmlt expected_child2 = xmlt{"child-2"};
       expected_child2.data = "c2v";
       expected_xml.elements = {{expected_child1, expected_child2}};
-      auto result = single_node.to_xml();
+      auto result = to_xml(single_node);
       REQUIRE(result == expected_xml);
     }
 
@@ -162,7 +162,7 @@ TEST_CASE("Convert structured_datat", "[core][util][structured_data]")
       std::string expected =
         "Child 1: c1v\n"
         "Child 2: c2v";
-      REQUIRE(single_node.to_pretty() == expected);
+      REQUIRE(to_pretty(single_node) == expected);
     }
   }
   SECTION("Non-string data")
@@ -177,21 +177,21 @@ TEST_CASE("Convert structured_datat", "[core][util][structured_data]")
     {
       json_objectt expected;
       expected["child1"] = json_numbert{"10"};
-      REQUIRE(single_node.to_json() == expected);
+      REQUIRE(to_json(single_node) == expected);
     }
 
     THEN("Empty xml object")
     {
       xmlt expected_xml = xmlt{"child-1"};
       expected_xml.data = "10";
-      auto result = single_node.to_xml();
+      auto result = to_xml(single_node);
       REQUIRE(result == expected_xml);
     }
 
     THEN("Empty pretty object")
     {
       std::string expected = "Child 1: 10";
-      REQUIRE(single_node.to_pretty() == expected);
+      REQUIRE(to_pretty(single_node) == expected);
     }
   }
 }

--- a/unit/util/xml.cpp
+++ b/unit/util/xml.cpp
@@ -1,0 +1,99 @@
+/*******************************************************************\
+
+Module: Unit tests for xmlt
+
+Author: Thomas Kiley
+
+\*******************************************************************/
+
+#include <testing-utils/use_catch.h>
+#include <util/xml.h>
+
+TEST_CASE("xml_equal", "[core][util][xml]")
+{
+  SECTION("Empty xml")
+  {
+    xmlt a;
+    xmlt b;
+    REQUIRE(a == b);
+    REQUIRE_FALSE(a != b);
+  }
+  SECTION("Matching node")
+  {
+    xmlt a{"a"};
+    a.data = "hello";
+    a.attributes = {{"a", "b"}, {"b", "c"}};
+    xmlt b{"a"};
+    b.data = "hello";
+    b.attributes = {{"a", "b"}, {"b", "c"}};
+
+    REQUIRE(a == b);
+    REQUIRE_FALSE(a != b);
+  }
+  SECTION("non-matching node")
+  {
+    xmlt a{"a"};
+    a.data = "hello";
+    a.attributes = {{"a", "b"}, {"b", "c"}};
+    SECTION("Different name")
+    {
+      xmlt b{"b"};
+      b.data = "hello";
+      b.attributes = {{"a", "b"}, {"b", "c"}};
+
+      REQUIRE_FALSE(a == b);
+      REQUIRE(a != b);
+    }
+    SECTION("Different data")
+    {
+      xmlt b{"b"};
+      b.data = "world";
+      b.attributes = {{"a", "b"}, {"b", "c"}};
+
+      REQUIRE_FALSE(a == b);
+      REQUIRE(a != b);
+    }
+    SECTION("Different attributes")
+    {
+      xmlt b{"b"};
+      b.data = "world";
+      b.attributes = {{"a", "b"}, {"b", "d"}};
+
+      REQUIRE_FALSE(a == b);
+      REQUIRE(a != b);
+    }
+  }
+  SECTION("Matching children")
+  {
+    xmlt a{"a"};
+    a.elements = {xmlt{"b"}};
+    xmlt b{"a"};
+    b.elements = {xmlt{"b"}};
+
+    REQUIRE(a == b);
+    REQUIRE_FALSE(a != b);
+  }
+  SECTION("Non-matching children")
+  {
+    xmlt a{"a"};
+    a.elements = {xmlt{"b"}};
+    SECTION("Different child")
+    {
+      xmlt b{"a"};
+      a.elements = {xmlt{"c"}};
+
+      REQUIRE_FALSE(a == b);
+      REQUIRE(a != b);
+    }
+    SECTION("Different sub child")
+    {
+      xmlt b{"a"};
+      xmlt sub_child{"b"};
+      sub_child.elements = {xmlt{"d"}};
+      a.elements = {sub_child};
+
+      REQUIRE_FALSE(a == b);
+      REQUIRE(a != b);
+    }
+  }
+}


### PR DESCRIPTION
On #5237 it was pointed out it is a bit clunky to have to switch between message handler UIs. This PR attempts to simplify this by allowing sending XML to the message handler, and it will convert it to JSON or plain text if those UIs are in play. 

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

Thoughts?
