### PR TITLE
Fix over-writing library prologue

### DIFF
--- a/src/ansi-c/cprover_library.cpp
+++ b/src/ansi-c/cprover_library.cpp
@@ -45,7 +45,9 @@ std::string get_cprover_library_text(
   const struct cprover_library_entryt cprover_library[],
   const std::string &prologue)
 {
-  std::ostringstream library_text(prologue);
+  // the default mode is ios_base::out which means subsequent write to the
+  // stream will overwrite the original content
+  std::ostringstream library_text(prologue, std::ios_base::ate);
 
   std::size_t count=0;
 


### PR DESCRIPTION
when linking the cprover library. The default mode for this constructor of
stringstream is to over-write the string used in construction, which presumably
was not the intention here.

Note: until now there wasn't anything too interesting in the prologue except for
the string-abstraction define, which was ignored. But we might want more defines
in the future.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
