### PR TITLE
Refine-arrays: work with refine-strings

### DIFF
--- a/src/goto-checker/solver_factory.cpp
+++ b/src/goto-checker/solver_factory.cpp
@@ -131,8 +131,12 @@ std::unique_ptr<solver_factoryt::solvert> solver_factoryt::get_solver()
 {
   if(options.get_bool_option("dimacs"))
     return get_dimacs();
-  if(options.get_bool_option("refine"))
+  if(
+    options.get_bool_option("refine") &&
+    !options.get_bool_option("refine-strings"))
+  {
     return get_bv_refinement();
+  }
   else if(options.get_bool_option("refine-strings"))
     return get_string_refinement();
   if(options.get_bool_option("smt2"))


### PR DESCRIPTION
Trivial fix to allow running the string solver with `--refine-arrays`. Doesn't seem to help much when the index set is large, but at least this means we don't ignore `--refine-strings` when `--refine-arrays` is passed.