### PR TITLE
Don't run failed unit tests by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -355,9 +355,13 @@ script:
   - env PATH=$PATH:`pwd`/src/solvers UBSAN_OPTIONS=print_stacktrace=1 make -C regression/cbmc test-cprover-smt2
   - make -C unit "CXX=${COMPILER} ${EXTRA_CXXFLAGS}" -j2
   - make -C unit test
+  - echo "Running expected failure tests"
+  - make TAGS="[!shouldfail]" -C unit test
   - env UBSAN_OPTIONS=print_stacktrace=1 make -C jbmc/regression test-parallel "CXX=${COMPILER} ${EXTRA_CXXFLAGS}" -j2 JOBS=2
   - make -C jbmc/unit "CXX=${COMPILER} ${EXTRA_CXXFLAGS}" -j2
   - make -C jbmc/unit test
+  - echo "Running expected failure tests"
+  - make TAGS="[!shouldfail]" -C jbmc/unit test
 
 before_cache:
   - ccache -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -243,7 +243,7 @@ jobs:
         - cmake -S . -Bbuild '-DCMAKE_BUILD_TYPE=Release'  '-DCMAKE_CXX_COMPILER=/usr/bin/g++-7' '-DCMAKE_USE_CUDD=true' -DCMAKE_CXX_FLAGS="-DBDD_GUARDS" '-DWITH_MEMORY_ANALYZER=On'
         - git submodule update --init --recursive
         - cmake --build build -- -j4
-      script: (cd build; ctest -V -L CORE -j2)
+      script: (cd build; ctest -V -L CORE -j2; ctest -V -R unit-xfail -j2)
 
     # cmake build using clang++-6
     - stage: Test different OS/CXX/Flags
@@ -280,7 +280,7 @@ jobs:
         - cmake -S . -Bbuild '-DCMAKE_BUILD_TYPE=Release' '-DCMAKE_CXX_COMPILER=/usr/bin/clang++-7' '-DCMAKE_CXX_FLAGS=-Qunused-arguments' '-DWITH_MEMORY_ANALYZER=On'
         - git submodule update --init --recursive
         - cmake --build build -- -j4
-      script: (cd build; ctest -V -L CORE -j2)
+      script: (cd build; ctest -V -L CORE -j2; ctest -V -R unit-xfail -j2)
 
     # cmake build on OSX, using default clang
     - stage: Test different OS/CXX/Flags
@@ -300,7 +300,7 @@ jobs:
         - cmake -S . -Bbuild '-DCMAKE_BUILD_TYPE=Release' '-DCMAKE_OSX_ARCHITECTURES=x86_64'
         - git submodule update --init --recursive
         - cmake --build build -- -j4
-      script: (cd build; ctest -V -L CORE -j2)
+      script: (cd build; ctest -V -L CORE -j2; ctest -V -R unit-xfail -j2)
 
 
     # Run Coverity

--- a/buildspec-linux-clang.yml
+++ b/buildspec-linux-clang.yml
@@ -27,10 +27,14 @@ phases:
   post_build:
     commands:
       - make -C unit test
+      - echo "Running expected failure tests"
+      - make TAGS="[!shouldfail]" -C unit test
       - make -C regression test CXX='ccache /usr/bin/clang++-8' CXX_FLAGS='-Qunused-arguments'
       - make -C regression/cbmc test-paths-lifo
       - env PATH=$PATH:`pwd`/src/solvers make -C regression/cbmc test-cprover-smt2
       - make -C jbmc/unit test
+      - echo "Running expected failure tests"
+      - make TAGS="[!shouldfail]" -C jbmc/unit test
       - make -C jbmc/regression test
       - echo Build completed on `date`
 cache:

--- a/buildspec-linux-cmake-gcc.yml
+++ b/buildspec-linux-cmake-gcc.yml
@@ -22,6 +22,7 @@ phases:
   post_build:
     commands:
       - cd build; ctest -V -L CORE -j2
+      - cd build; ctest -V -R unit-xfail -j2
       - echo Build completed on `date`
 cache:
   paths:

--- a/buildspec-windows.yml
+++ b/buildspec-windows.yml
@@ -59,11 +59,19 @@ phases:
 
       - |
         $env:Path = "C:\tools\cygwin\bin;$env:Path"
+        cmd /c 'call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64 && bash -c "make TAGS=[!shouldfail] -C unit test BUILD_ENV=MSVC" '
+
+      - |
+        $env:Path = "C:\tools\cygwin\bin;$env:Path"
         cmd /c 'call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64 && bash -c "make -C jbmc/regression test BUILD_ENV=MSVC" '
 
       - |
         $env:Path = "C:\tools\cygwin\bin;$env:Path"
         cmd /c 'call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64 && bash -c "make -C jbmc/unit test BUILD_ENV=MSVC" '
+
+      - |
+        $env:Path = "C:\tools\cygwin\bin;$env:Path"
+        cmd /c 'call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64 && bash -c "make TAGS=[!shouldfail] -C jbmc/unit test BUILD_ENV=MSVC" '
 
 cache:
   paths:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -26,10 +26,14 @@ phases:
   post_build:
     commands:
       - make -C unit test
+      - echo "Running expected failure tests"
+      - make TAGS="[!shouldfail]" -C unit test
       - make -C regression test
       - make -C regression/cbmc test-paths-lifo
       - env PATH=$PATH:`pwd`/src/solvers make -C regression/cbmc test-cprover-smt2
       - make -C jbmc/unit test
+      - echo "Running expected failure tests"
+      - make TAGS="[!shouldfail]" -C jbmc/unit test
       - make -C jbmc/regression test
       - echo Build completed on `date`
 cache:

--- a/jbmc/unit/CMakeLists.txt
+++ b/jbmc/unit/CMakeLists.txt
@@ -36,4 +36,11 @@ add_test(
     COMMAND $<TARGET_FILE:java-unit>
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+add_test(
+    NAME java-unit-xfail
+    COMMAND $<TARGET_FILE:java-unit> "[!shouldfail]"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
 set_tests_properties(java-unit PROPERTIES LABELS "CORE;CBMC")

--- a/jbmc/unit/Makefile
+++ b/jbmc/unit/Makefile
@@ -144,8 +144,9 @@ all: $(CATCH_TEST)
 clean: java-testing-utils-clean
 
 test: $(CATCH_TEST)
-	if ! ./$(CATCH_TEST) -l | grep -q "^$(N_CATCH_TESTS) test cases" ; then \
-	  ./$(CATCH_TEST) -l ; fi
+	# Include hidden tests by specifying "*,[.]" for tests to count
+	if ! ./$(CATCH_TEST) "*,[.]" -l | grep -q "^$(N_CATCH_TESTS) matching test cases" ; then \
+	  ./$(CATCH_TEST) "*,[.]" -l ; fi
 	./$(CATCH_TEST) ${TAGS}
 
 

--- a/jbmc/unit/Makefile
+++ b/jbmc/unit/Makefile
@@ -146,7 +146,7 @@ clean: java-testing-utils-clean
 test: $(CATCH_TEST)
 	if ! ./$(CATCH_TEST) -l | grep -q "^$(N_CATCH_TESTS) test cases" ; then \
 	  ./$(CATCH_TEST) -l ; fi
-	./$(CATCH_TEST)
+	./$(CATCH_TEST) ${TAGS}
 
 
 ###############################################################################

--- a/jbmc/unit/java_bytecode/ci_lazy_methods/lazy_load_lambdas.cpp
+++ b/jbmc/unit/java_bytecode/ci_lazy_methods/lazy_load_lambdas.cpp
@@ -12,7 +12,7 @@ Author: Diffblue Limited.
 
 SCENARIO(
   "Lazy load lambda methods",
-  "[core][java_bytecode][ci_lazy_methods][lambdas][!mayfail]")
+  "[core][java_bytecode][ci_lazy_methods][lambdas]")
 {
   GIVEN("A class with some locally declared lambdas")
   {
@@ -192,7 +192,7 @@ SCENARIO(
 
 SCENARIO(
   "Lazy load lambda methods in seperate class",
-  "[core][java_bytecode][ci_lazy_methods][lambdas][!mayfail]")
+  "[core][java_bytecode][ci_lazy_methods][lambdas]")
 {
   const symbol_tablet symbol_table = load_java_class_lazy(
     "ExternalLambdaAccessor",

--- a/jbmc/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_convert_method/convert_invoke_dynamic.cpp
@@ -188,7 +188,7 @@ void validate_local_variable_lambda_assignment(
 SCENARIO(
   "Converting invokedynamic with a local lambda",
   "[core]"
-  "[lambdas][java_bytecode][java_bytecode_convert_method][!mayfail]")
+  "[lambdas][java_bytecode][java_bytecode_convert_method]" XFAIL)
 {
   // NOLINTNEXTLINE(whitespace/braces)
   run_test_with_compilers([](const std::string &compiler) {
@@ -380,7 +380,7 @@ void validate_member_variable_lambda_assignment(
 SCENARIO(
   "Converting invokedynamic with a member lambda",
   "[core]"
-  "[lamdba][java_bytecode][java_bytecode_convert_method][!mayfail]")
+  "[lamdba][java_bytecode][java_bytecode_convert_method]" XFAIL)
 {
   // NOLINTNEXTLINE(whitespace/braces)
   run_test_with_compilers([](const std::string &compiler) {
@@ -548,7 +548,7 @@ void validate_static_member_variable_lambda_assignment(
 SCENARIO(
   "Converting invokedynamic with a static member lambda",
   "[core]"
-  "[lamdba][java_bytecode][java_bytecode_convert_method][!mayfail]")
+  "[lamdba][java_bytecode][java_bytecode_convert_method]" XFAIL)
 {
   // NOLINTNEXTLINE(whitespace/braces)
   run_test_with_compilers([](const std::string &compiler) {

--- a/jbmc/unit/solvers/strings/string_constraint_instantiation/instantiate_not_contains.cpp
+++ b/jbmc/unit/solvers/strings/string_constraint_instantiation/instantiate_not_contains.cpp
@@ -172,10 +172,9 @@ decision_proceduret::resultt check_sat(const exprt &expr, const namespacet &ns)
   return solver();
 }
 
-// The [!mayfail] tag allows tests to fail while reporting the failure
 SCENARIO(
   "instantiate_not_contains",
-  "[!mayfail][core][solvers][refinement][string_constraint_instantiation]")
+  "[core][solvers][refinement][string_constraint_instantiation]" XFAIL)
 {
   // For printing expression
   register_language(new_java_bytecode_language);

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -65,4 +65,11 @@ add_test(
     COMMAND $<TARGET_FILE:unit>
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+add_test(
+    NAME unit-xfail
+    COMMAND $<TARGET_FILE:unit> "[!shouldfail]"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
 set_tests_properties(unit PROPERTIES LABELS "CORE;CBMC")

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -206,7 +206,7 @@ clean: testing-utils-clean
 test: $(CATCH_TEST)
 	if ! ./$(CATCH_TEST) -l | grep -q "^$(N_CATCH_TESTS) test cases" ; then \
 		./$(CATCH_TEST) -l ; fi
-	./$(CATCH_TEST)
+	./$(CATCH_TEST) ${TAGS}
 
 
 ###############################################################################

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -204,8 +204,9 @@ all: $(CATCH_TEST)
 clean: testing-utils-clean
 
 test: $(CATCH_TEST)
-	if ! ./$(CATCH_TEST) -l | grep -q "^$(N_CATCH_TESTS) test cases" ; then \
-		./$(CATCH_TEST) -l ; fi
+	# Include hidden tests by specifying "*,[.]" for tests to count
+	if ! ./$(CATCH_TEST) "*,[.]" -l | grep -q "^$(N_CATCH_TESTS) matching test cases" ; then \
+		./$(CATCH_TEST) "*,[.]" -l ; fi
 	./$(CATCH_TEST) ${TAGS}
 
 

--- a/unit/testing-utils/use_catch.h
+++ b/unit/testing-utils/use_catch.h
@@ -36,4 +36,7 @@ Author: Michael Tautschnig
 #include <util/pragma_pop.def>
 #endif
 
+/// Add to the end of test tags to mark a test that is expected to fail
+#define XFAIL "[.][!shouldfail]"
+
 #endif // CPROVER_TESTING_UTILS_USE_CATCH_H

--- a/unit/util/irep_sharing.cpp
+++ b/unit/util/irep_sharing.cpp
@@ -9,7 +9,7 @@
 
 #ifdef SHARING
 
-SCENARIO("irept_sharing_trade_offs", "[!mayfail][core][utils][irept]")
+SCENARIO("irept_sharing_trade_offs", "[core][utils][irept]" XFAIL)
 {
   GIVEN("An irept created with move_to_sub")
   {
@@ -116,7 +116,7 @@ SCENARIO("irept_sharing", "[core][utils][irept]")
 
 #include <util/expr.h>
 
-SCENARIO("exprt_sharing_trade_offs", "[!mayfail][core][utils][exprt]")
+SCENARIO("exprt_sharing_trade_offs", "[core][utils][exprt]" XFAIL)
 {
   GIVEN("An expression created with add_to_operands(std::move(...))")
   {


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [na] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

This replaces #2256. By using the tag `[.]`, the tests are not run by default, leading to no useless output when another unit test fails. By changing `[!mayfail]` to `[!shouldfail`] means that these tests fail if they pass. This stops tests inadvertently getting fixed without anyone noticing. I used @owen-mc-diffblue suggestion of `xfail` for an expected failure. Finally, I added a separate run of these failed tests to CI.
